### PR TITLE
Pull request for bugfix on PatchRequest

### DIFF
--- a/Raven.Client.Tests/Bugs/Patching.cs
+++ b/Raven.Client.Tests/Bugs/Patching.cs
@@ -18,6 +18,72 @@ namespace Raven.Client.Tests.Bugs
 			public string AuthorId { get; set; }
 		}
 
+        [Fact]
+        public void CanConvertToAndFromJsonWithNestedPatchRequests()
+        {
+            var patch = new PatchRequest
+                            {
+                                Name = "Comments",
+                                Type = PatchCommandType.Modify,
+                                Position = 0,
+                                Nested = new[]
+                                             {
+                                                 new PatchRequest
+                                                     {
+                                                         Name = "AuthorId",
+                                                         Type = PatchCommandType.Set,
+                                                         Value = "authors/456"
+                                                     },
+                                                    new PatchRequest
+                                                     {
+                                                         Name = "AuthorName",
+                                                         Type = PatchCommandType.Set,
+                                                         Value = "Tolkien"
+                                                     },
+                                             }
+                            };
+
+            var jsonPatch = patch.ToJson();
+            var backToPatch = PatchRequest.FromJson(jsonPatch);
+            Assert.Equal(patch.Name, backToPatch.Name);
+            Assert.Equal(patch.Nested.Length, backToPatch.Nested.Length);
+
+        }
+        
+        
+        [Fact]
+        public void CanConvertToAndFromJsonWithoutNestedPatchRequests()
+        {
+            var patch = new PatchRequest
+                            {
+                                Name = "Comments",
+                                Type = PatchCommandType.Modify,
+                                Position = 0,
+                                Nested = null
+                            };
+
+            var jsonPatch = patch.ToJson();
+            var backToPatch = PatchRequest.FromJson(jsonPatch);
+            Assert.Equal(patch.Name, backToPatch.Name);
+            Assert.Equal(patch.Nested, backToPatch.Nested);
+        }
+        
+        [Fact]
+        public void CanConvertToAndFromJsonWithEmptyNestedPatchRequests()
+        {
+            var patch = new PatchRequest
+                            {
+                                Name = "Comments",
+                                Type = PatchCommandType.Modify,
+                                Position = 0,
+                                Nested = new PatchRequest[] { }
+                            };
+
+            var jsonPatch = patch.ToJson();
+            var backToPatch = PatchRequest.FromJson(jsonPatch);
+            Assert.Equal(patch.Name, backToPatch.Name);
+            Assert.Equal(patch.Nested.Length, backToPatch.Nested.Length);
+        }
 		[Fact]
 		public void CanModifyValue()
 		{

--- a/Raven.Database/Json/PatchRequest.cs
+++ b/Raven.Database/Json/PatchRequest.cs
@@ -109,16 +109,16 @@ namespace Raven.Database.Json
 		public static PatchRequest FromJson(JObject patchRequestJson)
 		{
 			PatchRequest[] nested = null;
-			var nestedJson = patchRequestJson.Value<JValue>("Nested");
-			if (nestedJson != null && nestedJson.Value != null)
-				nested = nestedJson.Value<JArray>().Cast<JObject>().Select(FromJson).ToArray();
+			var nestedJson = patchRequestJson.Value<JToken>("Nested");
+            if (nestedJson != null && nestedJson.Type != JTokenType.Null)
+                nested = patchRequestJson.Value<JArray>("Nested").Cast<JObject>().Select(FromJson).ToArray();
 
 			return new PatchRequest
 			{
 				Type = (PatchCommandType)Enum.Parse(typeof(PatchCommandType), patchRequestJson.Value<string>("Type"), true),
 				Name = patchRequestJson.Value<string>("Name"),
 				Nested = nested,
-				Position = (int?)patchRequestJson.Value<object>("Position"),
+				Position = patchRequestJson.Value<int?>("Position"),
 				PrevVal = patchRequestJson.Property("PrevVal") == null ? null : patchRequestJson.Property("PrevVal").Value,
 				Value = patchRequestJson.Property("Value") == null ? null : patchRequestJson.Property("Value").Value,
 			};


### PR DESCRIPTION
It seems like there was a problem with the FromJson method on PatchRequest.
I wasn't able to do a patch from the client api.

This commit includes 3 unit tests that create a PatchRequest with and without Nested properties, and the fix itself.
All three tests failed before the fix and now pass.
