### PR TITLE
Etobi/query with static property

### DIFF
--- a/Raven.Client.Lightweight/Linq/RavenQueryProviderProcessor.cs
+++ b/Raven.Client.Lightweight/Linq/RavenQueryProviderProcessor.cs
@@ -744,15 +744,16 @@ namespace Raven.Client.Linq
 				throw new ArgumentNullException("memberExpression");
 
 			// Get object
-            if (memberExpression.Expression is ConstantExpression)
-                obj = ((ConstantExpression)memberExpression.Expression).Value;
-            else if (memberExpression.Expression is MemberExpression)
-                obj = GetMemberValue((MemberExpression)memberExpression.Expression);
-            //Fix for the issue here http://github.com/ravendb/ravendb/issues/#issue/145
-            //Needed to allow things like ".Where(x => x.TimeOfDay > DateTime.MinValue)", where Expression is null
-            //can just leave obj as it is because it's not used below (because Member is a FieldInfo), so won't cause a problem
-            else if ((memberExpression.Expression == null && memberExpression.Member is FieldInfo) == false)
-                throw new NotSupportedException("Expression type not supported: " + memberExpression.Expression.GetType().FullName);
+			if (memberExpression.Expression is ConstantExpression)
+				obj = ((ConstantExpression)memberExpression.Expression).Value;
+			else if (memberExpression.Expression is MemberExpression)
+				obj = GetMemberValue((MemberExpression)memberExpression.Expression);
+			//Fix for the issue here http://github.com/ravendb/ravendb/issues/#issue/145
+			//Needed to allow things like ".Where(x => x.TimeOfDay > DateTime.MinValue)", where Expression is null
+			//(applies to DateTime.Now as well, where "Now" is a property
+			//can just leave obj as it is because it's not used below (because Member is a MemberInfo), so won't cause a problem
+			else if (memberExpression.Expression != null)
+				throw new NotSupportedException("Expression type not supported: " + memberExpression.Expression.GetType().FullName);
 
 			// Get value
 			var memberInfo = memberExpression.Member;


### PR DESCRIPTION
This allows to e.g. use DateTime.Now in queries (where "Now" is a property unlike MinValue and MaxValue which are fields).

BTW: The spaces/tabs mixing in the sources really sucks!
