### PR TITLE
Adding the posibility to run a PatchRequest on all the items in an array

### DIFF
--- a/Raven.Abstractions/Data/PatchRequest.cs
+++ b/Raven.Abstractions/Data/PatchRequest.cs
@@ -5,80 +5,85 @@ using System.Linq;
 namespace Raven.Database.Json
 {
     /// <summary>
-	/// A patch request for a specified document
-	/// </summary>
-	public class PatchRequest
-	{
-		/// <summary>
-		/// Gets or sets the type of the operation
-		/// </summary>
-		/// <value>The type.</value>
-		public PatchCommandType Type { get; set; }
-		/// <summary>
-		/// Gets or sets the previous val, which is compared against the current value to verify a
-		/// change isn't overwriting new values.
-		/// If the value is null, the operation is always successful
-		/// </summary>
-		/// <value>The previous val.</value>
-		public JToken PrevVal { get; set; }
-		/// <summary>
-		/// Gets or sets the value.
-		/// </summary>
-		/// <value>The value.</value>
-		public JToken Value { get; set; }
-		/// <summary>
-		/// Gets or sets the nested operations to perform. This is only valid when the <see cref="Type"/> is <see cref="PatchCommandType.Modify"/>.
-		/// </summary>
-		/// <value>The nested.</value>
-		public PatchRequest[] Nested { get; set; }
-		/// <summary>
-		/// Gets or sets the name.
-		/// </summary>
-		/// <value>The name.</value>
-		public string Name { get; set; }
-		/// <summary>
-		/// Gets or sets the position.
-		/// </summary>
-		/// <value>The position.</value>
-		public int? Position { get; set; }
+    /// A patch request for a specified document
+    /// </summary>
+    public class PatchRequest
+    {
+        /// <summary>
+        /// Gets or sets the type of the operation
+        /// </summary>
+        /// <value>The type.</value>
+        public PatchCommandType Type { get; set; }
+        /// <summary>
+        /// Gets or sets the previous val, which is compared against the current value to verify a
+        /// change isn't overwriting new values.
+        /// If the value is null, the operation is always successful
+        /// </summary>
+        /// <value>The previous val.</value>
+        public JToken PrevVal { get; set; }
+        /// <summary>
+        /// Gets or sets the value.
+        /// </summary>
+        /// <value>The value.</value>
+        public JToken Value { get; set; }
+        /// <summary>
+        /// Gets or sets the nested operations to perform. This is only valid when the <see cref="Type"/> is <see cref="PatchCommandType.Modify"/>.
+        /// </summary>
+        /// <value>The nested.</value>
+        public PatchRequest[] Nested { get; set; }
+        /// <summary>
+        /// Gets or sets the name.
+        /// </summary>
+        /// <value>The name.</value>
+        public string Name { get; set; }
+        /// <summary>
+        /// Gets or sets the position.
+        /// </summary>
+        /// <value>The position.</value>
+        public int? Position { get; set; }
 
-		/// <summary>
-		/// Translate this instance to json
-		/// </summary>
-		public JObject ToJson()
-		{
-			var jObject = new JObject(
-				new JProperty("Type", new JValue(Type.ToString())),
-				new JProperty("Value", Value),
-				new JProperty("Name", new JValue(Name)),
-				new JProperty("Position", Position == null ? null : new JValue(Position.Value)),
-				new JProperty("Nested", Nested == null ? null : new JArray(Nested.Select(x => x.ToJson())))
-				);
-			if (PrevVal != null)
-				jObject.Add(new JProperty("PrevVal", PrevVal));
-			return jObject;
-		}
+        public bool? AllPositions { get; set; }
 
-		/// <summary>
-		/// Create an instance from a json object
-		/// </summary>
-		/// <param name="patchRequestJson">The patch request json.</param>
-		public static PatchRequest FromJson(JObject patchRequestJson)
-		{
-			PatchRequest[] nested = null;
-			var nestedJson = patchRequestJson.Value<JToken>("Nested");
+        /// <summary>
+        /// Translate this instance to json
+        /// </summary>
+        public JObject ToJson()
+        {
+            var jObject = new JObject(
+                new JProperty("Type", new JValue(Type.ToString())),
+                new JProperty("Value", Value),
+                new JProperty("Name", new JValue(Name)),
+                new JProperty("Position", Position == null ? null : new JValue(Position.Value)),
+                new JProperty("Nested", Nested == null ? null : new JArray(Nested.Select(x => x.ToJson()))),
+                new JProperty("AllPositions", AllPositions == null ? null : new JValue(AllPositions.Value))
+                );
+            if (PrevVal != null)
+                jObject.Add(new JProperty("PrevVal", PrevVal));
+            return jObject;
+        }
+
+        /// <summary>
+        /// Create an instance from a json object
+        /// </summary>
+        /// <param name="patchRequestJson">The patch request json.</param>
+        public static PatchRequest FromJson(JObject patchRequestJson)
+        {
+            PatchRequest[] nested = null;
+            var nestedJson = patchRequestJson.Value<JToken>("Nested");
             if (nestedJson != null && nestedJson.Type != JTokenType.Null)
                 nested = patchRequestJson.Value<JArray>("Nested").Cast<JObject>().Select(FromJson).ToArray();
 
-			return new PatchRequest
-			{
-				Type = (PatchCommandType)Enum.Parse(typeof(PatchCommandType), patchRequestJson.Value<string>("Type"), true),
-				Name = patchRequestJson.Value<string>("Name"),
-				Nested = nested,
-				Position = patchRequestJson.Value<int?>("Position"),
-				PrevVal = patchRequestJson.Property("PrevVal") == null ? null : patchRequestJson.Property("PrevVal").Value,
-				Value = patchRequestJson.Property("Value") == null ? null : patchRequestJson.Property("Value").Value,
-			};
-		}
-	}
+            return new PatchRequest
+            {
+                Type = (PatchCommandType)Enum.Parse(typeof(PatchCommandType), patchRequestJson.Value<string>("Type"), true),
+                Name = patchRequestJson.Value<string>("Name"),
+                Nested = nested,
+                Position = patchRequestJson.Value<int?>("Position"),
+                AllPositions = patchRequestJson.Value<bool?>("AllPositions"),
+                PrevVal = patchRequestJson.Property("PrevVal") == null ? null : patchRequestJson.Property("PrevVal").Value,
+                Value = patchRequestJson.Property("Value") == null ? null : patchRequestJson.Property("Value").Value,
+
+            };
+        }
+    }
 }

--- a/Raven.Tests/Patching/NestedPatching.cs
+++ b/Raven.Tests/Patching/NestedPatching.cs
@@ -12,10 +12,54 @@ namespace Raven.Tests.Patching
         private readonly JObject doc = JObject.Parse(@"{ title: ""A Blog Post"", body: ""html markup"", comments: [{""author"":""ayende"",""text"":""good post 1""},{author: ""ayende"", text:""good post 2""}], ""user"": { ""name"": ""ayende"", ""id"": 13} }");
 
         [Fact]
+        public void RenameSecondItemInArray()
+        {
+            var patchedDoc = new JsonPatcher(doc).Apply(
+                new[]
+        		{
+        			new PatchRequest
+        			{
+        				Type = PatchCommandType.Modify,
+        				Name = "comments",
+						Position = 1,
+        				Nested = new[]
+        				{
+        					new PatchRequest {Type = PatchCommandType.Rename, Name = "author", Value = "authorname"},
+        				}
+        			},
+        		});
+
+            Assert.Equal(@"{""title"":""A Blog Post"",""body"":""html markup"",""comments"":[{""author"":""ayende"",""text"":""good post 1""},{""text"":""good post 2"",""authorname"":""ayende""}],""user"":{""name"":""ayende"",""id"":13}}",
+                patchedDoc.ToString(Formatting.None));
+        }
+        [Fact]
+        public void RenameAllItemsInArray()
+        {
+            var patchedDoc = new JsonPatcher(doc).Apply(
+                new[]
+                    {
+                        new PatchRequest
+                            {
+                                Type = PatchCommandType.Modify,
+                                Name = "comments",
+                                AllPositions = true,
+        				Nested = new[]
+        				{
+        					new PatchRequest {Type = PatchCommandType.Rename, Name = "author", Value = "authorname"},
+        				}
+        			},
+        		});
+
+            Assert.Equal(@"{""title"":""A Blog Post"",""body"":""html markup"",""comments"":[{""text"":""good post 1"",""authorname"":""ayende""},{""text"":""good post 2"",""authorname"":""ayende""}],""user"":{""name"":""ayende"",""id"":13}}",
+                patchedDoc.ToString(Formatting.None));
+        }
+
+
+        [Fact]
         public void SetValueInNestedElement()
         {
-        	var patchedDoc = new JsonPatcher(doc).Apply(
-        		new[]
+            var patchedDoc = new JsonPatcher(doc).Apply(
+                new[]
         		{
         			new PatchRequest
         			{
@@ -36,7 +80,7 @@ namespace Raven.Tests.Patching
         public void SetValueInNestedElement_WithConcurrency_Ok()
         {
             var patchedDoc = new JsonPatcher(doc).Apply(
-				new[]
+                new[]
         		{
         			new PatchRequest
         			{
@@ -57,8 +101,8 @@ namespace Raven.Tests.Patching
         [Fact]
         public void SetValueInNestedElement_WithConcurrency_Error()
         {
-        	Assert.Throws<ConcurrencyException>(() => new JsonPatcher(doc).Apply(
-        		new[]
+            Assert.Throws<ConcurrencyException>(() => new JsonPatcher(doc).Apply(
+                new[]
         		{
         			new PatchRequest
         			{
@@ -78,7 +122,7 @@ namespace Raven.Tests.Patching
         public void RemoveValueInNestedElement()
         {
             var patchedDoc = new JsonPatcher(doc).Apply(
-				new[]
+                new[]
         		{
         			new PatchRequest
         			{
@@ -100,7 +144,7 @@ namespace Raven.Tests.Patching
         public void SetValueNestedInArray()
         {
             var patchedDoc = new JsonPatcher(doc).Apply(
-				new[]
+                new[]
         		{
         			new PatchRequest
         			{


### PR DESCRIPTION
Hi,
I have added some changes that gives you the posibility to run a PatchRequest on all the items in an array without specifying the specific position.

An example can be a Customer document which has a "addresses[]" property and the address has a PostalCode property. My scenario is that I want to change the PostalCode property to ZipCode on all the addresses.
Instead of first finding out how many addresses every customer has and then add PatchRequst with Position correctly set, I can now do like this:

```
 new PatchRequest
                        {
                            Type = PatchCommandType.Modify,
                            Name = "addresses",
                            AllPositions = true,
                    Nested = new[]
                    {
                        new PatchRequest {Type = PatchCommandType.Rename, Name="PostalCode",Value="ZipCode"}, 
                    }
                }
```

As you may see I have added the property AllPositions to trigger my new code.

What do you think?
