### PR TITLE
DateTime tests verify DateTime.Kind on roundtrip, UTC fails

### DIFF
--- a/Raven.Tests/Bugs/DateTimeInLocalTime.cs
+++ b/Raven.Tests/Bugs/DateTimeInLocalTime.cs
@@ -29,7 +29,7 @@ namespace Raven.Tests.Bugs
 				{
 					var log = session.Load<ServiceExecutionLog>("ServiceExecutionLogs/1");
 					Assert.Equal(new DateTime(2010, 2, 17, 19, 06, 06), log.LastDateChecked);
-					Assert.Equal(DateTimeKind.Local, log.LastDateChecked.ToLocalTime().Kind);
+					Assert.Equal(DateTimeKind.Local, log.LastDateChecked.Kind);
 				}
 			}
 		}


### PR DESCRIPTION
This seems like a bug.
