### PR TITLE
Attribution bundle

### DIFF
--- a/Bundles/Raven.Bundles.Attribution/Constants.cs
+++ b/Bundles/Raven.Bundles.Attribution/Constants.cs
@@ -1,0 +1,8 @@
+﻿namespace Raven.Bundles.Attribution
+{
+    class Constants
+    {
+        public const string RavenAttributionUser = "Raven-Attribution-User";
+        public const string RavenDocumentAuthor = "Raven-Document-Author";
+    }
+}

--- a/Bundles/Raven.Bundles.Attribution/Data/AttributionConfiguration.cs
+++ b/Bundles/Raven.Bundles.Attribution/Data/AttributionConfiguration.cs
@@ -1,0 +1,9 @@
+﻿namespace Raven.Bundles.Attribution.Data
+{
+    public class AttributionConfiguration
+    {
+        public bool Exclude { get; set; }
+
+        public string Id { get; set; }
+    }
+}

--- a/Bundles/Raven.Bundles.Attribution/Properties/AssemblyInfo.cs
+++ b/Bundles/Raven.Bundles.Attribution/Properties/AssemblyInfo.cs
@@ -1,0 +1,36 @@
+﻿using System.Reflection;
+using System.Runtime.CompilerServices;
+using System.Runtime.InteropServices;
+
+// General Information about an assembly is controlled through the following 
+// set of attributes. Change these attribute values to modify the information
+// associated with an assembly.
+[assembly: AssemblyTitle("Raven.Bundles.Attribution")]
+[assembly: AssemblyDescription("")]
+[assembly: AssemblyConfiguration("")]
+[assembly: AssemblyCompany("")]
+[assembly: AssemblyProduct("Raven.Bundles.Attribution")]
+[assembly: AssemblyCopyright("Copyright ©  2011")]
+[assembly: AssemblyTrademark("")]
+[assembly: AssemblyCulture("")]
+
+// Setting ComVisible to false makes the types in this assembly not visible 
+// to COM components.  If you need to access a type in this assembly from 
+// COM, set the ComVisible attribute to true on that type.
+[assembly: ComVisible(false)]
+
+// The following GUID is for the ID of the typelib if this project is exposed to COM
+[assembly: Guid("c7a8e3e9-1875-4a34-bf6a-24f152a51cb6")]
+
+// Version information for an assembly consists of the following four values:
+//
+//      Major Version
+//      Minor Version 
+//      Build Number
+//      Revision
+//
+// You can specify all the values or you can default the Build and Revision Numbers 
+// by using the '*' as shown below:
+// [assembly: AssemblyVersion("1.0.*")]
+[assembly: AssemblyVersion("1.0.0.0")]
+[assembly: AssemblyFileVersion("1.0.0.0")]

--- a/Bundles/Raven.Bundles.Attribution/Raven.Bundles.Attribution.csproj
+++ b/Bundles/Raven.Bundles.Attribution/Raven.Bundles.Attribution.csproj
@@ -1,0 +1,74 @@
+﻿<?xml version="1.0" encoding="utf-8"?>
+<Project ToolsVersion="4.0" DefaultTargets="Build" xmlns="http://schemas.microsoft.com/developer/msbuild/2003">
+  <PropertyGroup>
+    <Configuration Condition=" '$(Configuration)' == '' ">Debug</Configuration>
+    <Platform Condition=" '$(Platform)' == '' ">AnyCPU</Platform>
+    <ProductVersion>8.0.30703</ProductVersion>
+    <SchemaVersion>2.0</SchemaVersion>
+    <ProjectGuid>{586D59D9-1D29-403C-8C45-B8A454CD2C90}</ProjectGuid>
+    <OutputType>Library</OutputType>
+    <AppDesignerFolder>Properties</AppDesignerFolder>
+    <RootNamespace>Raven.Bundles.Attribution</RootNamespace>
+    <AssemblyName>Raven.Bundles.Attribution</AssemblyName>
+    <TargetFrameworkVersion>v4.0</TargetFrameworkVersion>
+    <FileAlignment>512</FileAlignment>
+  </PropertyGroup>
+  <PropertyGroup Condition=" '$(Configuration)|$(Platform)' == 'Debug|AnyCPU' ">
+    <DebugSymbols>true</DebugSymbols>
+    <DebugType>full</DebugType>
+    <Optimize>false</Optimize>
+    <OutputPath>bin\Debug\</OutputPath>
+    <DefineConstants>DEBUG;TRACE</DefineConstants>
+    <ErrorReport>prompt</ErrorReport>
+    <WarningLevel>4</WarningLevel>
+  </PropertyGroup>
+  <PropertyGroup Condition=" '$(Configuration)|$(Platform)' == 'Release|AnyCPU' ">
+    <DebugType>pdbonly</DebugType>
+    <Optimize>true</Optimize>
+    <OutputPath>bin\Release\</OutputPath>
+    <DefineConstants>TRACE</DefineConstants>
+    <ErrorReport>prompt</ErrorReport>
+    <WarningLevel>4</WarningLevel>
+  </PropertyGroup>
+  <ItemGroup>
+    <Reference Include="System" />
+    <Reference Include="System.Core" />
+    <Reference Include="System.Xml.Linq" />
+    <Reference Include="System.Data.DataSetExtensions" />
+    <Reference Include="Microsoft.CSharp" />
+    <Reference Include="System.Data" />
+    <Reference Include="System.Xml" />
+  </ItemGroup>
+  <ItemGroup>
+    <Compile Include="Constants.cs" />
+    <Compile Include="Data\AttributionConfiguration.cs" />
+    <Compile Include="Triggers\AttributionPutTrigger.cs" />
+    <Compile Include="Properties\AssemblyInfo.cs" />
+  </ItemGroup>
+  <ItemGroup>
+    <ProjectReference Include="..\..\Modules\Json\Raven.Json\Raven.Json.csproj">
+      <Project>{B9DD0239-3476-48CB-A541-1B3EC6679BB6}</Project>
+      <Name>Raven.Json</Name>
+    </ProjectReference>
+    <ProjectReference Include="..\..\Raven.Abstractions\Raven.Abstractions.csproj">
+      <Project>{41AC479E-1EB2-4D23-AAF2-E4C8DF1BC2BA}</Project>
+      <Name>Raven.Abstractions</Name>
+    </ProjectReference>
+    <ProjectReference Include="..\..\Raven.Database\Raven.Database.csproj">
+      <Project>{212823CD-25E1-41AC-92D1-D6DF4D53FC85}</Project>
+      <Name>Raven.Database</Name>
+    </ProjectReference>
+    <ProjectReference Include="..\..\Raven.Http\Raven.Http.csproj">
+      <Project>{508E5F54-A8F3-47F4-9297-CB96F91D4DF8}</Project>
+      <Name>Raven.Http</Name>
+    </ProjectReference>
+  </ItemGroup>
+  <Import Project="$(MSBuildToolsPath)\Microsoft.CSharp.targets" />
+  <!-- To modify your build process, add your task inside one of the targets below and uncomment it. 
+       Other similar extension points exist, see Microsoft.Common.targets.
+  <Target Name="BeforeBuild">
+  </Target>
+  <Target Name="AfterBuild">
+  </Target>
+  -->
+</Project>

--- a/Bundles/Raven.Bundles.Attribution/Triggers/AttributionPutTrigger.cs
+++ b/Bundles/Raven.Bundles.Attribution/Triggers/AttributionPutTrigger.cs
@@ -1,0 +1,53 @@
+﻿using System;
+using Raven.Abstractions.Extensions;
+using Raven.Bundles.Attribution.Data;
+using Raven.Database.Plugins;
+using Raven.Http;
+using Raven.Json.Linq;
+
+namespace Raven.Bundles.Attribution.Triggers
+{
+    public class AttributionPutTrigger : AbstractPutTrigger
+    {
+        public override void OnPut(string key, RavenJObject document, RavenJObject metadata, Abstractions.Data.TransactionInformation transactionInformation)
+        {
+            // Exclude RavenDB internal documents.
+            if (key.StartsWith("Raven/", StringComparison.InvariantCultureIgnoreCase))
+                return;
+
+            // Check the attribution bundle configuration document to determine if this document type is excluded.
+            var attributionConfiguration = GetDocumentAttributionConfiguration(metadata);
+            if (attributionConfiguration.Exclude)
+                return;
+
+            // Add author metadata to the document.
+            using (Database.DisableAllTriggersForCurrentThread())
+            {
+                var user = CurrentOperationContext.Headers.Value[Constants.RavenAttributionUser];
+                if (user != null)
+                    metadata[Constants.RavenDocumentAuthor] = RavenJToken.FromObject(user);
+            }
+        }
+
+        private AttributionConfiguration GetDocumentAttributionConfiguration(RavenJObject metadata)
+        {
+            var attributionConfiguration = new AttributionConfiguration
+            {
+                Exclude = false
+            };
+
+            var entityName = metadata.Value<string>("Raven-Entity-Name");
+            if (entityName != null)
+            {
+                var doc = Database.Get("Raven/Attribution/" + entityName, null) ??
+                          Database.Get("Raven/Attribution/DefaultConfiguration", null);
+                if (doc != null)
+                {
+                    attributionConfiguration = doc.DataAsJson.JsonDeserialization<AttributionConfiguration>();
+                }
+            }
+
+            return attributionConfiguration;
+        }
+    }
+}

--- a/Bundles/Raven.Bundles.Tests/Attribution/Attribution.cs
+++ b/Bundles/Raven.Bundles.Tests/Attribution/Attribution.cs
@@ -1,0 +1,173 @@
+//-----------------------------------------------------------------------
+// <copyright file="Attribution.cs" company="Hibernating Rhinos LTD">
+//     Copyright (c) Hibernating Rhinos LTD. All rights reserved.
+// </copyright>
+//-----------------------------------------------------------------------
+extern alias database;
+using System;
+using System.ComponentModel.Composition.Hosting;
+using System.IO;
+using System.Reflection;
+using Raven.Bundles.Attribution.Data;
+using Raven.Bundles.Attribution.Triggers;
+using Raven.Client.Attribution;
+using Raven.Client.Document;
+using Raven.Server;
+using Xunit;
+
+namespace Raven.Bundles.Tests.Attribution
+{
+    public class Attribution : IDisposable
+    {
+        private readonly DocumentStore documentStore;
+        private readonly string path;
+        private readonly RavenDbServer ravenDbServer;
+
+        public Attribution()
+        {
+            path = Path.GetDirectoryName(Assembly.GetAssembly(typeof(Attribution)).CodeBase);
+            path = Path.Combine(path, "TestDb").Substring(6);
+            database::Raven.Database.Extensions.IOExtensions.DeleteDirectory(path);
+            ravenDbServer = new RavenDbServer(
+                new database::Raven.Database.Config.RavenConfiguration
+                {
+                    Port = 58080,
+                    DataDirectory = path,
+                    RunInUnreliableYetFastModeThatIsNotSuitableForProduction = true,
+                    Catalog =
+                    {
+                        Catalogs =
+                        {
+                            new AssemblyCatalog(typeof(AttributionPutTrigger).Assembly)
+                        }
+                    },
+                });
+            documentStore = new DocumentStore
+            {
+                Url = "http://localhost:58080"
+            };
+            documentStore.Initialize();
+            using (var s = documentStore.OpenSession())
+            {
+                s.Store(new AttributionConfiguration
+                {
+                    Exclude = true,
+                    Id = "Raven/Attribution/Users",
+                });
+                s.Store(new AttributionConfiguration
+                {
+                    Exclude = true,
+                    Id = "Raven/Attribution/Comments",
+                });
+                s.Store(new AttributionConfiguration
+                {
+                    Exclude = false,
+                    Id = "Raven/Attribution/DefaultConfiguration",
+                });
+                s.SaveChanges();
+            }
+        }
+
+        #region IDisposable Members
+
+        public void Dispose()
+        {
+            documentStore.Dispose();
+            ravenDbServer.Dispose();
+            database::Raven.Database.Extensions.IOExtensions.DeleteDirectory(path);
+        }
+
+        #endregion
+
+        [Fact]
+        public void Will_automatically_set_metadata()
+        {
+            var company = new Company { Name = "Company Name" };
+            using (var session = documentStore.OpenSession())
+            {
+                session.AttributeTo("users/1");
+                session.Store(company);
+                session.SaveChanges();
+            }
+
+            using (var session = documentStore.OpenSession())
+            {
+                var company2 = session.Load<Company>(company.Id);
+                var metadata = session.Advanced.GetMetadataFor(company2);
+                Assert.Equal("users/1", metadata.Value<string>("Raven-Document-Author"));
+            }
+        }
+
+        [Fact]
+        public void Can_exclude_entities_from_attribution()
+        {
+            var user = new User { Name = "User Name" };
+            var comment = new Comment { Name = "foo" };
+            using (var session = documentStore.OpenSession())
+            {
+                session.AttributeTo("users/1");
+                session.Store(user);
+                session.Store(comment);
+                session.SaveChanges();
+            }
+
+            using (var sesion = documentStore.OpenSession())
+            {
+                var metadata = sesion.Advanced.GetMetadataFor(sesion.Load<User>(user.Id));
+                Assert.Null(metadata.Value<string>("Raven-Document-Author"));
+
+                metadata = sesion.Advanced.GetMetadataFor(sesion.Load<Comment>(comment.Id));
+                Assert.Null(metadata.Value<string>("Raven-Document-Author"));
+            }
+        }
+
+        [Fact]
+        public void Will_automatically_overwrite_metadata_on_next_insert()
+        {
+            var company = new Company { Name = "Company Name" };
+            using (var session = documentStore.OpenSession())
+            {
+                session.AttributeTo("users/1");
+                session.Store(company);
+                session.SaveChanges();
+                session.AttributeTo("users/2");
+                company.Name = "Hibernating Rhinos";
+                session.SaveChanges();
+            }
+
+            using (var session = documentStore.OpenSession())
+            {
+                var company2 = session.Load<Company>(company.Id);
+                var metadata = session.Advanced.GetMetadataFor(company2);
+                Assert.Equal("users/2", metadata.Value<string>("Raven-Document-Author"));
+            }
+        }
+
+        #region Nested type: Comment
+
+        public class Comment
+        {
+            public string Id { get; set; }
+            public string Name { get; set; }
+        }
+
+        #endregion
+
+        #region Nested type: User
+
+        public class User
+        {
+            public string Id { get; set; }
+            public string Name { get; set; }
+        }
+
+        #endregion
+    }
+
+    public class Company
+    {
+        public string Name { get; set; }
+
+        public string Id { get; set; }
+    }
+}

--- a/Bundles/Raven.Bundles.Tests/Raven.Bundles.Tests.csproj
+++ b/Bundles/Raven.Bundles.Tests/Raven.Bundles.Tests.csproj
@@ -52,6 +52,7 @@
     </Reference>
   </ItemGroup>
   <ItemGroup>
+    <Compile Include="Attribution\Attribution.cs" />
     <Compile Include="Authorization\AuthorizationTest.cs" />
     <Compile Include="Authorization\Bugs\Jalchr.cs" />
     <Compile Include="Authorization\Bugs\Kwal.cs" />
@@ -112,6 +113,10 @@
       <Project>{DA99A419-E137-40DB-9495-0C363B479D4B}</Project>
       <Name>Raven.Storage.Managed</Name>
     </ProjectReference>
+    <ProjectReference Include="..\Raven.Bundles.Attribution\Raven.Bundles.Attribution.csproj">
+      <Project>{586D59D9-1D29-403C-8C45-B8A454CD2C90}</Project>
+      <Name>Raven.Bundles.Attribution</Name>
+    </ProjectReference>
     <ProjectReference Include="..\Raven.Bundles.Authorization\Raven.Bundles.Authorization.csproj">
       <Project>{034FFD8F-F917-4A45-B920-9C460CD66BAF}</Project>
       <Name>Raven.Bundles.Authorization</Name>
@@ -136,6 +141,10 @@
     <ProjectReference Include="..\Raven.Bundles.Versioning\Raven.Bundles.Versioning.csproj">
       <Project>{22BCC20F-FC1F-4523-A717-77CDF8519C1D}</Project>
       <Name>Raven.Bundles.Versioning</Name>
+    </ProjectReference>
+    <ProjectReference Include="..\Raven.Client.Attribution\Raven.Client.Attribution.csproj">
+      <Project>{F98397AC-6E80-4A67-BE30-826BA9500594}</Project>
+      <Name>Raven.Client.Attribution</Name>
     </ProjectReference>
     <ProjectReference Include="..\Raven.Client.Authorization\Raven.Client.Authorization.csproj">
       <Project>{3A852FD2-E0F9-449C-8F66-0C6A180D030A}</Project>

--- a/Bundles/Raven.Bundles.sln
+++ b/Bundles/Raven.Bundles.sln
@@ -44,6 +44,10 @@ Project("{FAE04EC0-301F-11D3-BF4B-00C04F79EFBC}") = "Raven.Bundles.Quotas", "Rav
 EndProject
 Project("{FAE04EC0-301F-11D3-BF4B-00C04F79EFBC}") = "Raven.Client.Embedded", "..\Raven.Client.Embedded\Raven.Client.Embedded.csproj", "{0F5287AD-37B3-4375-BA3E-3CED64B1FC5B}"
 EndProject
+Project("{FAE04EC0-301F-11D3-BF4B-00C04F79EFBC}") = "Raven.Bundles.Attribution", "Raven.Bundles.Attribution\Raven.Bundles.Attribution.csproj", "{586D59D9-1D29-403C-8C45-B8A454CD2C90}"
+EndProject
+Project("{FAE04EC0-301F-11D3-BF4B-00C04F79EFBC}") = "Raven.Client.Attribution", "Raven.Client.Attribution\Raven.Client.Attribution.csproj", "{F98397AC-6E80-4A67-BE30-826BA9500594}"
+EndProject
 Global
 	GlobalSection(SolutionConfigurationPlatforms) = preSolution
 		Debug|Any CPU = Debug|Any CPU
@@ -264,6 +268,26 @@ Global
 		{0F5287AD-37B3-4375-BA3E-3CED64B1FC5B}.Release|Mixed Platforms.ActiveCfg = Release|Any CPU
 		{0F5287AD-37B3-4375-BA3E-3CED64B1FC5B}.Release|Mixed Platforms.Build.0 = Release|Any CPU
 		{0F5287AD-37B3-4375-BA3E-3CED64B1FC5B}.Release|x86.ActiveCfg = Release|Any CPU
+		{586D59D9-1D29-403C-8C45-B8A454CD2C90}.Debug|Any CPU.ActiveCfg = Debug|Any CPU
+		{586D59D9-1D29-403C-8C45-B8A454CD2C90}.Debug|Any CPU.Build.0 = Debug|Any CPU
+		{586D59D9-1D29-403C-8C45-B8A454CD2C90}.Debug|Mixed Platforms.ActiveCfg = Debug|Any CPU
+		{586D59D9-1D29-403C-8C45-B8A454CD2C90}.Debug|Mixed Platforms.Build.0 = Debug|Any CPU
+		{586D59D9-1D29-403C-8C45-B8A454CD2C90}.Debug|x86.ActiveCfg = Debug|Any CPU
+		{586D59D9-1D29-403C-8C45-B8A454CD2C90}.Release|Any CPU.ActiveCfg = Release|Any CPU
+		{586D59D9-1D29-403C-8C45-B8A454CD2C90}.Release|Any CPU.Build.0 = Release|Any CPU
+		{586D59D9-1D29-403C-8C45-B8A454CD2C90}.Release|Mixed Platforms.ActiveCfg = Release|Any CPU
+		{586D59D9-1D29-403C-8C45-B8A454CD2C90}.Release|Mixed Platforms.Build.0 = Release|Any CPU
+		{586D59D9-1D29-403C-8C45-B8A454CD2C90}.Release|x86.ActiveCfg = Release|Any CPU
+		{F98397AC-6E80-4A67-BE30-826BA9500594}.Debug|Any CPU.ActiveCfg = Debug|Any CPU
+		{F98397AC-6E80-4A67-BE30-826BA9500594}.Debug|Any CPU.Build.0 = Debug|Any CPU
+		{F98397AC-6E80-4A67-BE30-826BA9500594}.Debug|Mixed Platforms.ActiveCfg = Debug|Any CPU
+		{F98397AC-6E80-4A67-BE30-826BA9500594}.Debug|Mixed Platforms.Build.0 = Debug|Any CPU
+		{F98397AC-6E80-4A67-BE30-826BA9500594}.Debug|x86.ActiveCfg = Debug|Any CPU
+		{F98397AC-6E80-4A67-BE30-826BA9500594}.Release|Any CPU.ActiveCfg = Release|Any CPU
+		{F98397AC-6E80-4A67-BE30-826BA9500594}.Release|Any CPU.Build.0 = Release|Any CPU
+		{F98397AC-6E80-4A67-BE30-826BA9500594}.Release|Mixed Platforms.ActiveCfg = Release|Any CPU
+		{F98397AC-6E80-4A67-BE30-826BA9500594}.Release|Mixed Platforms.Build.0 = Release|Any CPU
+		{F98397AC-6E80-4A67-BE30-826BA9500594}.Release|x86.ActiveCfg = Release|Any CPU
 	EndGlobalSection
 	GlobalSection(SolutionProperties) = preSolution
 		HideSolutionNode = FALSE

--- a/Bundles/Raven.Client.Attribution/AttributionClientExtensions.cs
+++ b/Bundles/Raven.Client.Attribution/AttributionClientExtensions.cs
@@ -1,0 +1,12 @@
+﻿using Raven.Bundles.Attribution;
+
+namespace Raven.Client.Attribution
+{
+    public static class AttributionClientExtensions
+    {
+        public static void AttributeTo(this IDocumentSession session, string userId)
+        {
+            session.Advanced.DatabaseCommands.OperationsHeaders[Constants.RavenAttributionUser] = userId;
+        }
+    }
+}

--- a/Bundles/Raven.Client.Attribution/Properties/AssemblyInfo.cs
+++ b/Bundles/Raven.Client.Attribution/Properties/AssemblyInfo.cs
@@ -1,0 +1,36 @@
+﻿using System.Reflection;
+using System.Runtime.CompilerServices;
+using System.Runtime.InteropServices;
+
+// General Information about an assembly is controlled through the following 
+// set of attributes. Change these attribute values to modify the information
+// associated with an assembly.
+[assembly: AssemblyTitle("Raven.Client.Attribution")]
+[assembly: AssemblyDescription("")]
+[assembly: AssemblyConfiguration("")]
+[assembly: AssemblyCompany("")]
+[assembly: AssemblyProduct("Raven.Client.Attribution")]
+[assembly: AssemblyCopyright("Copyright ©  2011")]
+[assembly: AssemblyTrademark("")]
+[assembly: AssemblyCulture("")]
+
+// Setting ComVisible to false makes the types in this assembly not visible 
+// to COM components.  If you need to access a type in this assembly from 
+// COM, set the ComVisible attribute to true on that type.
+[assembly: ComVisible(false)]
+
+// The following GUID is for the ID of the typelib if this project is exposed to COM
+[assembly: Guid("0b6ef850-04ee-42bd-9764-00f7512dc5b9")]
+
+// Version information for an assembly consists of the following four values:
+//
+//      Major Version
+//      Minor Version 
+//      Build Number
+//      Revision
+//
+// You can specify all the values or you can default the Build and Revision Numbers 
+// by using the '*' as shown below:
+// [assembly: AssemblyVersion("1.0.*")]
+[assembly: AssemblyVersion("1.0.0.0")]
+[assembly: AssemblyFileVersion("1.0.0.0")]

--- a/Bundles/Raven.Client.Attribution/Raven.Client.Attribution.csproj
+++ b/Bundles/Raven.Client.Attribution/Raven.Client.Attribution.csproj
@@ -1,0 +1,63 @@
+﻿<?xml version="1.0" encoding="utf-8"?>
+<Project ToolsVersion="4.0" DefaultTargets="Build" xmlns="http://schemas.microsoft.com/developer/msbuild/2003">
+  <PropertyGroup>
+    <Configuration Condition=" '$(Configuration)' == '' ">Debug</Configuration>
+    <Platform Condition=" '$(Platform)' == '' ">AnyCPU</Platform>
+    <ProductVersion>8.0.30703</ProductVersion>
+    <SchemaVersion>2.0</SchemaVersion>
+    <ProjectGuid>{F98397AC-6E80-4A67-BE30-826BA9500594}</ProjectGuid>
+    <OutputType>Library</OutputType>
+    <AppDesignerFolder>Properties</AppDesignerFolder>
+    <RootNamespace>Raven.Client.Attribution</RootNamespace>
+    <AssemblyName>Raven.Client.Attribution</AssemblyName>
+    <TargetFrameworkVersion>v4.0</TargetFrameworkVersion>
+    <FileAlignment>512</FileAlignment>
+  </PropertyGroup>
+  <PropertyGroup Condition=" '$(Configuration)|$(Platform)' == 'Debug|AnyCPU' ">
+    <DebugSymbols>true</DebugSymbols>
+    <DebugType>full</DebugType>
+    <Optimize>false</Optimize>
+    <OutputPath>bin\Debug\</OutputPath>
+    <DefineConstants>DEBUG;TRACE</DefineConstants>
+    <ErrorReport>prompt</ErrorReport>
+    <WarningLevel>4</WarningLevel>
+  </PropertyGroup>
+  <PropertyGroup Condition=" '$(Configuration)|$(Platform)' == 'Release|AnyCPU' ">
+    <DebugType>pdbonly</DebugType>
+    <Optimize>true</Optimize>
+    <OutputPath>bin\Release\</OutputPath>
+    <DefineConstants>TRACE</DefineConstants>
+    <ErrorReport>prompt</ErrorReport>
+    <WarningLevel>4</WarningLevel>
+  </PropertyGroup>
+  <ItemGroup>
+    <Reference Include="System" />
+    <Reference Include="System.Core" />
+    <Reference Include="System.Xml.Linq" />
+    <Reference Include="System.Data.DataSetExtensions" />
+    <Reference Include="Microsoft.CSharp" />
+    <Reference Include="System.Data" />
+    <Reference Include="System.Xml" />
+  </ItemGroup>
+  <ItemGroup>
+    <Compile Include="..\Raven.Bundles.Attribution\Constants.cs">
+      <Link>Constants.cs</Link>
+    </Compile>
+    <Compile Include="AttributionClientExtensions.cs" />
+    <Compile Include="Properties\AssemblyInfo.cs" />
+  </ItemGroup>
+  <ItemGroup>
+    <ProjectReference Include="..\..\Raven.Client.Lightweight\Raven.Client.Lightweight.csproj">
+      <Project>{4E087ECB-E7CA-4891-AC3C-3C76702715B6}</Project>
+      <Name>Raven.Client.Lightweight</Name>
+    </ProjectReference>
+  </ItemGroup>
+  <Import Project="$(MSBuildToolsPath)\Microsoft.CSharp.targets" />
+  <!-- To modify your build process, add your task inside one of the targets below and uncomment it. 
+       Other similar extension points exist, see Microsoft.Common.targets.
+  <Target Name="BeforeBuild">
+  </Target>
+  <Target Name="AfterBuild">
+  </Target>
+  -->
+</Project>


### PR DESCRIPTION
This plug-in saves the author of a document in metadata (Raven-Document-Author). When used with the versioning bundle, this metadata serves as a useful audit trail for edits to a document.

The author of a document is set by calling the extension method:

``` csharp
session.AttributeTo("users/1");
```
