### PR TITLE
Authorization bundle update to support multi-tag permissions

### DIFF
--- a/Bundles/Raven.Bundles.Authorization/AuthorizationDecisions.cs
+++ b/Bundles/Raven.Bundles.Authorization/AuthorizationDecisions.cs
@@ -55,9 +55,8 @@ namespace Raven.Bundles.Authorization
 				select permission;
 
 			permissions = permissions.Concat( // permissions on user matching the document's tags
-				from tag in documentAuthorization.Tags
 				from permission in user.Permissions
-				where TagMatches(permission.Tag, tag)
+                where TagsMatch(permission.Tags, documentAuthorization.Tags)
 				select permission
 				);
 
@@ -67,8 +66,7 @@ namespace Raven.Bundles.Authorization
 				where role != null
 				from permission in role.Permissions
 				where OperationMatches(permission.Operation, operation)
-				from tag in documentAuthorization.Tags
-				where TagMatches(permission.Tag, tag)
+                where TagsMatch(permission.Tags, documentAuthorization.Tags)
 				select permission
 				);
 
@@ -179,9 +177,9 @@ namespace Raven.Bundles.Authorization
 			return op2.StartsWith(op1);
 		}
 
-		private static bool TagMatches(string tag1, string tag2)
+		private static bool TagsMatch(IEnumerable<string> permissionTags, IEnumerable<string> documentTags)
 		{
-			return tag2.StartsWith(tag1);
+            return permissionTags.All(p => documentTags.Any(d => d.StartsWith(p)));
 		}
 
 		private T GetDocumentAsEntity<T>(string documentId) where T : class

--- a/Bundles/Raven.Bundles.Authorization/Model/OperationPermission.cs
+++ b/Bundles/Raven.Bundles.Authorization/Model/OperationPermission.cs
@@ -3,22 +3,27 @@
 //     Copyright (c) Hibernating Rhinos LTD. All rights reserved.
 // </copyright>
 //-----------------------------------------------------------------------
-using System;
+using System.Collections.Generic;
 
 namespace Raven.Bundles.Authorization.Model
 {
 	public class OperationPermission : IPermission
 	{
 		public string Operation { get; set; }
-		public string Tag { get; set; }
+        public List<string> Tags { get; set; }
 		public bool Allow { get; set; }
 		public int Priority { get; set; }
+
+        public OperationPermission()
+		{
+            Tags = new List<string>();
+		}
 
 		public string Explain
 		{
 			get
 			{
-				return string.Format("Operation: {0}, Tag: {1}, Allow: {2}, Priority: {3}", Operation, Tag, Allow, Priority);
+				return string.Format("Operation: {0}, Tags: {1}, Allow: {2}, Priority: {3}", Operation, string.Join(", ", Tags ?? new List<string>()), Allow, Priority);
 			}
 		}
 	}

--- a/Bundles/Raven.Bundles.Tests/Authorization/CanHandleAuthQuestions.cs
+++ b/Bundles/Raven.Bundles.Tests/Authorization/CanHandleAuthQuestions.cs
@@ -87,7 +87,7 @@ namespace Raven.Bundles.Tests.Authorization
 							{
 								Allow = true,
 								Operation = operation,
-								Tag = "Fortune 500"
+								Tags = { "Fortune 500" }
 							}
 						}
                 });
@@ -107,6 +107,140 @@ namespace Raven.Bundles.Tests.Authorization
             Assert.True(isAllowed);
         }
 
+        [Fact]
+        public void GivingPermissionToRoleOnMultiTagsAssociatedWithRoleWithMultiTagsOnDocumentWillAllow()
+        {
+            var company = new Company
+            {
+                Name = "Hibernating Rhinos"
+            };
+            using (var s = store.OpenSession())
+            {
+                s.Store(new AuthorizationUser
+                {
+                    Id = userId,
+                    Name = "Ayende Rahien",
+                    Roles = { "Authorization/Roles/Managers" }
+                });
+
+                s.Store(new AuthorizationRole
+                {
+                    Id = "Authorization/Roles/Managers",
+                    Permissions =
+						{
+							new OperationPermission
+							{
+								Allow = true,
+								Operation = operation,
+								Tags = { "Fortune 500", "Technology" }
+							}
+						}
+                });
+
+                s.Store(company);
+
+                s.SetAuthorizationFor(company, new DocumentAuthorization
+                {
+                    Tags = { "Fortune 500", "Technology/Application Software" }
+                });
+
+                s.SaveChanges();
+            }
+
+            var jsonDocument = server.Database.Get(company.Id, null);
+            var isAllowed = authorizationDecisions.IsAllowed(userId, operation, company.Id, jsonDocument.Metadata, null);
+            Assert.True(isAllowed);
+        }
+
+        [Fact]
+        public void GivingPermissionToRoleOnMultiTagsAssociatedWithRoleWithoutMultiTagsOnDocumentWillDeny()
+        {
+            var company = new Company
+            {
+                Name = "Hibernating Rhinos"
+            };
+            using (var s = store.OpenSession())
+            {
+                s.Store(new AuthorizationUser
+                {
+                    Id = userId,
+                    Name = "Ayende Rahien",
+                    Roles = { "Authorization/Roles/Managers" }
+                });
+
+                s.Store(new AuthorizationRole
+                {
+                    Id = "Authorization/Roles/Managers",
+                    Permissions =
+						{
+							new OperationPermission
+							{
+								Allow = true,
+								Operation = operation,
+								Tags = { "Fortune 500", "Technology" }
+							}
+						}
+                });
+
+                s.Store(company);
+
+                s.SetAuthorizationFor(company, new DocumentAuthorization
+                {
+                    Tags = { "Fortune 500" }
+                });
+
+                s.SaveChanges();
+            }
+
+            var jsonDocument = server.Database.Get(company.Id, null);
+            var isAllowed = authorizationDecisions.IsAllowed(userId, operation, company.Id, jsonDocument.Metadata, null);
+            Assert.False(isAllowed);
+        }
+
+        [Fact]
+        public void GivingPermissionToRoleOnMultiTagsAssociatedWithRoleWithMoreGeneralTagsOnDocumentWillDeny()
+        {
+            var company = new Company
+            {
+                Name = "Hibernating Rhinos"
+            };
+            using (var s = store.OpenSession())
+            {
+                s.Store(new AuthorizationUser
+                {
+                    Id = userId,
+                    Name = "Ayende Rahien",
+                    Roles = { "Authorization/Roles/Managers" }
+                });
+
+                s.Store(new AuthorizationRole
+                {
+                    Id = "Authorization/Roles/Managers",
+                    Permissions =
+						{
+							new OperationPermission
+							{
+								Allow = true,
+								Operation = operation,
+								Tags = { "Fortune 500", "Technology/Application Sofware" }
+							}
+						}
+                });
+
+                s.Store(company);
+
+                s.SetAuthorizationFor(company, new DocumentAuthorization
+                {
+                    Tags = { "Fortune 500", "Technology" }
+                });
+
+                s.SaveChanges();
+            }
+
+            var jsonDocument = server.Database.Get(company.Id, null);
+            var isAllowed = authorizationDecisions.IsAllowed(userId, operation, company.Id, jsonDocument.Metadata, null);
+            Assert.False(isAllowed);
+        }
 
         [Fact]
         public void GivingPermissionToRoleOnTagAssociatedWithRoleWillAllow_OnClient()
@@ -133,7 +267,7 @@ namespace Raven.Bundles.Tests.Authorization
 							{
 								Allow = true,
 								Operation = operation,
-								Tag = "Fortune 500"
+								Tags = { "Fortune 500" }
 							}
 						}
                 });
@@ -172,7 +306,7 @@ namespace Raven.Bundles.Tests.Authorization
 							{
 								Allow = false,
 								Operation = operation,
-								Tag = "Important"
+								Tags = { "Important" }
 							}
 						}
                 });
@@ -207,7 +341,7 @@ namespace Raven.Bundles.Tests.Authorization
 							{
 								Allow = true,
 								Operation = operation,
-								Tag = "/Important"
+								Tags = { "/Important" }
 							}
 						}
                 });
@@ -241,7 +375,7 @@ namespace Raven.Bundles.Tests.Authorization
 							{
 								Allow = false,
 								Operation = operation,
-								Tag = "Important"
+								Tags = { "Important" }
 							}
 						}
                 });
@@ -328,7 +462,7 @@ namespace Raven.Bundles.Tests.Authorization
 							{
 								Allow = true,
 								Operation = operation,
-								Tag = "Companies/Important"
+								Tags = { "Companies/Important" }
 							}
 						}
                 });
@@ -367,7 +501,7 @@ namespace Raven.Bundles.Tests.Authorization
 							{
 								Allow = true,
 								Operation = operation,
-								Tag = "Companies"
+								Tags = { "Companies" }
 							}
 						}
                 });


### PR DESCRIPTION
Updated authorization bundle to allow users to have permissions that require multiple tags to be present in a document for access to be allowed.
