### PR TITLE
Fixed: Sharding, missing tagname on dynamic index query.

### DIFF
--- a/Raven.Client.Lightweight/Document/InMemoryDocumentSessionOperations.cs
+++ b/Raven.Client.Lightweight/Document/InMemoryDocumentSessionOperations.cs
@@ -35,7 +35,7 @@ namespace Raven.Client.Document
 	/// <summary>
 	/// Abstract implementation for in memory session operations
 	/// </summary>
-	public abstract class InMemoryDocumentSessionOperations : IDisposable
+    public abstract class InMemoryDocumentSessionOperations : IDisposable, IAdvancedDocumentSessionOperations
 	{
 		/// <summary>
 		/// The session id 

--- a/Raven.Client.Lightweight/Shard/ShardedDocumentSession.cs
+++ b/Raven.Client.Lightweight/Shard/ShardedDocumentSession.cs
@@ -159,13 +159,13 @@ namespace Raven.Client.Shard
 			return GetSingleShardSession(shardIds).Advanced.HasChanged(entity);
 		}
 
-		/// <summary>
-		/// Initializes a new instance of the <see cref="ShardedDocumentSession"/> class.
-		/// </summary>
-		/// <param name="shardStrategy">The shard strategy.</param>
-		/// <param name="shardSessions">The shard sessions.</param>
-		/// <param name="documentStore"></param>
-		public ShardedDocumentSession(IShardStrategy shardStrategy, IDocumentSession[] shardSessions, ShardedDocumentStore documentStore)
+	    /// <summary>
+	    /// Initializes a new instance of the <see cref="ShardedDocumentSession"/> class.
+	    /// </summary>
+	    /// <param name="shardStrategy">The shard strategy.</param>
+	    /// <param name="shardSessions">The shard sessions.</param>
+	    /// <param name="documentStore"></param>
+	    public ShardedDocumentSession(IShardStrategy shardStrategy, IDocumentSession[] shardSessions, ShardedDocumentStore documentStore)
 		{
 			this.shardStrategy = shardStrategy;
 			this.shardSessions = shardSessions;
@@ -176,7 +176,7 @@ namespace Raven.Client.Shard
 		private readonly IDocumentSession[] shardSessions;
 		private readonly ShardedDocumentStore documentStore;
 
-		/// <summary>
+	    /// <summary>
 		/// Gets the database commands.
 		/// </summary>
 		/// <value>The database commands.</value>
@@ -249,6 +249,14 @@ namespace Raven.Client.Shard
 		{
 			get { return documentStore; }
 		}
+
+        /// <summary>
+        /// The sharded document store associated with this session
+        /// </summary>
+        public ShardedDocumentStore ShardedDocumentStore
+        {
+            get { return documentStore; }
+        }
 
 		/// <summary>
 		/// Returns whatever a document with the specified id is loaded in the 
@@ -538,7 +546,7 @@ namespace Raven.Client.Shard
 			}
 		}
 
-		/// <summary>
+	    /// <summary>
 		/// Executes a dynamic query against the RavenDB store
 		/// </summary>
 		/// <typeparam name="T"></typeparam>
@@ -555,7 +563,20 @@ namespace Raven.Client.Shard
 		/// <returns></returns>
 		public IDocumentQuery<T> LuceneQuery<T>()
 		{
-			return new ShardedDocumentQuery<T>("dynamic",
+            string indexName = "dynamic";
+		    var shardId = shardStrategy
+                                    .ShardResolutionStrategy
+                                    .SelectShardIds(ShardResolutionStrategyData.BuildFrom(typeof (T), null))
+                                    .FirstOrDefault();
+
+		    var convention = ShardedDocumentStore.GetConvention(shardId);
+
+            if (typeof(T) != typeof(object))
+            {
+                indexName += "/" + convention.GetTypeTagName(typeof(T));
+            }
+
+            return new ShardedDocumentQuery<T>(indexName,
 											   GetAppropriateShardedSessions<T>(null));		
 		}
 	}

--- a/Raven.Client.Lightweight/Shard/ShardedDocumentStore.cs
+++ b/Raven.Client.Lightweight/Shard/ShardedDocumentStore.cs
@@ -184,7 +184,7 @@ namespace Raven.Client.Shard
 		/// </summary>
 		public IDocumentSession OpenSession(string database)
 		{
-			return new ShardedDocumentSession(shardStrategy, shards.Select(x => x.OpenSession(database)).ToArray(), this);
+            return new ShardedDocumentSession(shardStrategy, shards.Select(x => x.OpenSession(database)).ToArray(), this);
 		}
 
 		/// <summary>
@@ -192,7 +192,7 @@ namespace Raven.Client.Shard
 		/// </summary>
 		public IDocumentSession OpenSession(string database, ICredentials credentialsForSession)
 		{
-			return new ShardedDocumentSession(shardStrategy, shards.Select(x => x.OpenSession(database, credentialsForSession)).ToArray(), this);
+            return new ShardedDocumentSession(shardStrategy, shards.Select(x => x.OpenSession(database, credentialsForSession)).ToArray(), this);
 		}
 
 		/// <summary>
@@ -201,7 +201,7 @@ namespace Raven.Client.Shard
 		/// <param name="credentialsForSession">The credentials for session.</param>
 		public IDocumentSession OpenSession(ICredentials credentialsForSession)
 		{
-			return new ShardedDocumentSession(shardStrategy, shards.Select(x => x.OpenSession(credentialsForSession)).ToArray(), this);
+            return new ShardedDocumentSession(shardStrategy, shards.Select(x => x.OpenSession(credentialsForSession)).ToArray(), this);
 		}
 
 		/// <summary>
@@ -222,6 +222,16 @@ namespace Raven.Client.Shard
 		{
 			get { throw new NotSupportedException("Sharded document store doesn't have a database conventions. you need to explicitly use the shard instances to get access to the database commands"); }
 		}
+
+	    /// <summary>
+	    /// 
+	    /// </summary>
+	    /// <param name="shardId"></param>
+	    /// <returns></returns>
+	    public DocumentConvention GetConvention(string shardId)
+        {
+            return shards.Where(x => x.Identifier == shardId).FirstOrDefault().Conventions;
+        }
 
 		/// <summary>
 		/// Gets or sets the URL.

--- a/Samples/Raven.Sample.ComplexSharding/Program.cs
+++ b/Samples/Raven.Sample.ComplexSharding/Program.cs
@@ -102,10 +102,13 @@ namespace Raven.Sample.ComplexSharding
 			// queries
 			using (var session = documentStore.OpenSession())
 			{
-                session.Advanced.LuceneQuery<User>().WaitForNonStaleResults().ToArray();
-                session.Advanced.LuceneQuery<Blog>().WaitForNonStaleResults().ToArray();
-                session.Advanced.LuceneQuery<Post>().WaitForNonStaleResults().ToArray();
-			}
+                var users = session.Advanced.LuceneQuery<User>().WaitForNonStaleResults().ToArray();
+                var blogs = session.Advanced.LuceneQuery<Blog>().WaitForNonStaleResults().ToArray();
+                var posts = session.Advanced.LuceneQuery<Post>().WaitForNonStaleResults().ToArray();
+                Console.WriteLine("Users:" + users.Length);
+                Console.WriteLine("Blogs:" + blogs.Length);
+                Console.WriteLine("Posts:" + posts.Length);
+            }
 
 			// loading
 			using (var session = documentStore.OpenSession())
@@ -122,6 +125,9 @@ namespace Raven.Sample.ComplexSharding
 			{
 				server.Dispose();
 			}
+
+            Console.WriteLine("press any key to exit...");
+		    Console.ReadLine();
 		}
 
 		private static IEnumerable<RavenDbServer> StartServers()

--- a/Samples/Raven.Sample.ComplexSharding/Raven.Sample.ComplexSharding.csproj
+++ b/Samples/Raven.Sample.ComplexSharding/Raven.Sample.ComplexSharding.csproj
@@ -44,6 +44,9 @@
     <Reference Include="Newtonsoft.Json">
       <HintPath>..\..\SharedLibs\Newtonsoft.Json.dll</HintPath>
     </Reference>
+    <Reference Include="Raven.Storage.Esent">
+      <HintPath>..\..\Raven.Storage.Esent\bin\Debug\Raven.Storage.Esent.dll</HintPath>
+    </Reference>
     <Reference Include="System" />
     <Reference Include="System.Core" />
     <Reference Include="System.Xml.Linq" />

--- a/Samples/Raven.Samples.sln
+++ b/Samples/Raven.Samples.sln
@@ -44,6 +44,8 @@ Project("{FAE04EC0-301F-11D3-BF4B-00C04F79EFBC}") = "Raven.Sample.LiveProjection
 EndProject
 Project("{FAE04EC0-301F-11D3-BF4B-00C04F79EFBC}") = "Raven.Json", "..\Modules\Json\Raven.Json\Raven.Json.csproj", "{B9DD0239-3476-48CB-A541-1B3EC6679BB6}"
 EndProject
+Project("{FAE04EC0-301F-11D3-BF4B-00C04F79EFBC}") = "Raven.Sample.LeapCentralSharding", "Raven.Sample.LeapCentralSharding\Raven.Sample.LeapCentralSharding.csproj", "{2DBFB6BD-0831-4302-852C-9DFBCF433573}"
+EndProject
 Global
 	GlobalSection(SolutionConfigurationPlatforms) = preSolution
 		Debug|Any CPU = Debug|Any CPU
@@ -264,6 +266,16 @@ Global
 		{B9DD0239-3476-48CB-A541-1B3EC6679BB6}.Release|Mixed Platforms.ActiveCfg = Release|Any CPU
 		{B9DD0239-3476-48CB-A541-1B3EC6679BB6}.Release|Mixed Platforms.Build.0 = Release|Any CPU
 		{B9DD0239-3476-48CB-A541-1B3EC6679BB6}.Release|x86.ActiveCfg = Release|Any CPU
+		{2DBFB6BD-0831-4302-852C-9DFBCF433573}.Debug|Any CPU.ActiveCfg = Debug|x86
+		{2DBFB6BD-0831-4302-852C-9DFBCF433573}.Debug|Mixed Platforms.ActiveCfg = Debug|x86
+		{2DBFB6BD-0831-4302-852C-9DFBCF433573}.Debug|Mixed Platforms.Build.0 = Debug|x86
+		{2DBFB6BD-0831-4302-852C-9DFBCF433573}.Debug|x86.ActiveCfg = Debug|x86
+		{2DBFB6BD-0831-4302-852C-9DFBCF433573}.Debug|x86.Build.0 = Debug|x86
+		{2DBFB6BD-0831-4302-852C-9DFBCF433573}.Release|Any CPU.ActiveCfg = Release|x86
+		{2DBFB6BD-0831-4302-852C-9DFBCF433573}.Release|Mixed Platforms.ActiveCfg = Release|x86
+		{2DBFB6BD-0831-4302-852C-9DFBCF433573}.Release|Mixed Platforms.Build.0 = Release|x86
+		{2DBFB6BD-0831-4302-852C-9DFBCF433573}.Release|x86.ActiveCfg = Release|x86
+		{2DBFB6BD-0831-4302-852C-9DFBCF433573}.Release|x86.Build.0 = Release|x86
 	EndGlobalSection
 	GlobalSection(SolutionProperties) = preSolution
 		HideSolutionNode = FALSE


### PR DESCRIPTION
class ShardedDocument
  +DocumentConvention GetConvention(string shardId) 

Change method IDocumentQuery<T> LuceneQuery<T>()
