### PR TITLE
Changed the way the LINQ provider resolves field names for queries on sta

### DIFF
--- a/Raven.Client.Lightweight/Document/DocumentConvention.cs
+++ b/Raven.Client.Lightweight/Document/DocumentConvention.cs
@@ -61,7 +61,7 @@ namespace Raven.Client.Document
 			FindFullDocumentKeyFromNonStringIdentifier = DefaultFindFullDocumentKeyFromNonStringIdentifier;
 			FindIdentityPropertyNameFromEntityName = entityName => "Id";
 			FindTypeTagName = DefaultTypeTagName;
-			FindPropertyNameForIndex = (indexedType, indexedName, path, prop) => prop;
+			FindPropertyNameForIndex = (indexedType, indexedName, path, prop) => (path + prop).Replace(",", "_").Replace(".", "_");
 			FindPropertyNameForDynamicIndex = (indexedType, indexedName, path, prop) => path + prop;
 			IdentityPartsSeparator = "/";
 			JsonContractResolver = new DefaultRavenContractResolver(shareCache: true)

--- a/Raven.Client.Lightweight/Linq/RavenQueryProviderProcessor.cs
+++ b/Raven.Client.Lightweight/Linq/RavenQueryProviderProcessor.cs
@@ -313,32 +313,36 @@ namespace Raven.Client.Linq
 			return info.Type;
 		}
 
-		/// <summary>
-		/// Gets member info for the specified expression and the path to that expression
-		/// </summary>
-		/// <param name="expression"></param>
-		/// <returns></returns>
-		protected virtual ExpressionInfo GetMember(Expression expression)
-		{
-			var parameterExpression = expression as ParameterExpression;
-			if (parameterExpression != null)
-			{
-				return new ExpressionInfo(CurrentPath, parameterExpression.Type, false);
-			}
+        /// <summary>
+        /// Gets member info for the specified expression and the path to that expression
+        /// </summary>
+        /// <param name="expression"></param>
+        /// <returns></returns>
+        protected virtual ExpressionInfo GetMember(System.Linq.Expressions.Expression expression)
+        {
+            var parameterExpression = expression as ParameterExpression;
+            if (parameterExpression != null)
+            {
 
-			string fullPath;
-			Type memberType;
-			bool isNestedPath;
-			GetPath(expression, out fullPath, out memberType, out isNestedPath);
+                if (currentPath.EndsWith(","))
+                    currentPath = currentPath.Substring(0, currentPath.Length - 1);
+                return new ExpressionInfo(currentPath, parameterExpression.Type, false);
 
-			//for stnadard queries, we take just the last part. But for dynamic queries, we take the whole part
-			var prop = fullPath.Substring(fullPath.LastIndexOf('.') + 1);
-			var path = fullPath.Substring(fullPath.IndexOf('.') + 1);
+            }
 
-			return new ExpressionInfo(
-				queryGenerator.Conventions.FindPropertyNameForIndex(typeof(T), indexName, path, prop),
-				memberType, isNestedPath);
-		}
+            string path;
+            Type memberType;
+            bool isNestedPath;
+            GetPath(expression, out path, out memberType, out isNestedPath);
+
+            //for standard queries, we take just the last part. But for dynamic queries, we take the whole part
+            path = path.Substring(path.IndexOf('.') + 1);
+
+            return new ExpressionInfo(
+                queryGenerator.Conventions.FindPropertyNameForIndex(typeof(T), indexName, CurrentPath, path),
+                memberType,
+                isNestedPath);
+        }
 
 		/// <summary>
 		/// Get the path from the expression, including considering dictionary calls

--- a/Raven.Tests/Bugs/FindPropertyNameForIndex.cs
+++ b/Raven.Tests/Bugs/FindPropertyNameForIndex.cs
@@ -16,7 +16,6 @@ namespace Raven.Tests.Bugs
 		{
 			using (var store = NewDocumentStore())
 			{
-				store.Conventions.FindPropertyNameForIndex = (type, index, path, prop) => path.Replace(".", "");
 
 				using (var session = store.OpenSession())
 				{
@@ -69,7 +68,7 @@ namespace Raven.Tests.Bugs
 		{
 			public Accounts_FindPropertyNameForIndex()
 			{
-				Map = docs => docs.Select(x => new { DealerId = x.Dealer.Id });
+				Map = docs => docs.Select(x => new { Dealer_Id = x.Dealer.Id });
 			}
 		}
 	}

--- a/Raven.Tests/Bugs/IndexNestedFields.cs
+++ b/Raven.Tests/Bugs/IndexNestedFields.cs
@@ -37,9 +37,9 @@ namespace Raven.Tests.Bugs
 		{
 			UsingPrepoulatedDatabase(delegate(IDocumentSession session3)
 			{
-				var results1 = session3.Advanced.LuceneQuery<Outer>("matryoshka").Where("ID:" + ExpectedId).ToArray();
+                var results1 = session3.Advanced.LuceneQuery<Outer>("matryoshka").Where("middle_inner_ID:" + ExpectedId).ToArray();
 
-				Assert.Equal(ExpectedId, results1.Single().middle.inner.ID);
+                Assert.Equal(ExpectedId, results1.Single().middle.inner.ID);
 			});
 		}
 
@@ -58,15 +58,19 @@ namespace Raven.Tests.Bugs
 
 		void UsingPrepoulatedDatabase(Action<IDocumentSession> testOperation)
 		{
-			using (var store = base.NewDocumentStore())
+			using (var store = NewDocumentStore())
 			{
-				store.DatabaseCommands.PutIndex("matryoshka", new IndexDefinitionBuilder<Outer, Outer>()
-					{
-						Map = docs => from doc in docs
-									  select new { doc.middle.inner.ID},
-						Indexes = { {d => d.middle.inner.ID, FieldIndexing.NotAnalyzed  }}
-					});
 
+			    var indexedFields = new { middle_inner_ID = FieldIndexing.NotAnalyzed };
+
+				store.DatabaseCommands.PutIndex("matryoshka", new IndexDefinitionBuilder<Outer, Outer>()
+				{
+
+					Map = docs => from doc in docs select new { middle_inner_ID = doc.middle.inner.ID },
+                    Indexes = { { d => indexedFields.middle_inner_ID, indexedFields.middle_inner_ID } }
+
+                });
+			    
 				using(var session = store.OpenSession())
 				{
 					session.Store(new Outer
@@ -91,5 +95,7 @@ namespace Raven.Tests.Bugs
 				}
 			}
 		}
+
 	}
+
 }

--- a/Raven.Tests/Bugs/Vlko/RelationIdIndex.cs
+++ b/Raven.Tests/Bugs/Vlko/RelationIdIndex.cs
@@ -55,7 +55,7 @@ namespace Raven.Tests.Bugs.Vlko
 			public ThorIndex()
 			{
 				Map = thors => from doc in thors
-							   select new { doc.Name, doc.Rel.Id };
+							   select new { doc.Name, Rel_Id = doc.Rel.Id };
 			}
 		}
 

--- a/Raven.Tests/Linq/DynamicQueriesWithStaticIndexes.cs
+++ b/Raven.Tests/Linq/DynamicQueriesWithStaticIndexes.cs
@@ -1,0 +1,116 @@
+﻿using System.Collections.Generic;
+using Raven.Abstractions.Indexing;
+using Xunit;
+using Raven.Client.Linq;
+using System.Linq;
+
+namespace Raven.Tests.Linq
+{
+
+    public class DynamicQueriesWithStaticIndexes : LocalClientTest
+    {
+
+        [Fact]
+        public void DynamicQueryWillInterpretFieldNamesProperly()
+        {
+
+            using (var store = NewDocumentStore())
+            {
+
+                using (var session = store.OpenSession())
+                {
+
+                    var foo = new Foo()
+                    {
+
+                        SomeProperty = "Some Data",
+                        Bar = new Bar() { SomeDictionary = new Dictionary<string, string>() { { "KeyOne", "ValueOne" }, { "KeyTwo", "ValueTwo" } } }
+
+                    };
+
+                    session.Store(foo);
+
+                    foo = new Foo()
+                    {
+
+                        SomeProperty = "Some More Data",
+
+                    };
+
+                    session.Store(foo);
+
+                    foo = new Foo()
+                    {
+
+                        SomeProperty = "Some Even More Data",
+                        Bar = new Bar() { SomeDictionary = new Dictionary<string, string>() { { "KeyThree", "ValueThree" } } }
+
+                    };
+
+                    session.Store(foo);
+
+                    foo = new Foo()
+                    {
+
+                        SomeProperty = "Some Even More Data",
+                        Bar = new Bar() { SomeOtherDictionary = new Dictionary<string, string>() { { "KeyFour", "ValueFour" } } }
+
+                    };
+
+                    session.Store(foo);
+
+                    session.SaveChanges();
+
+                    store.DatabaseCommands.PutIndex("Foos/TestDynamicQueries", new IndexDefinition()
+                    {
+                        Map = @"from doc in docs.Foos
+                                from docBarSomeOtherDictionaryItem in ((IEnumerable<dynamic>)doc.Bar.SomeOtherDictionary).DefaultIfEmpty()
+                                from docBarSomeDictionaryItem in ((IEnumerable<dynamic>)doc.Bar.SomeDictionary).DefaultIfEmpty()
+                                select new
+                                {
+                                    Bar_SomeOtherDictionary_Value = docBarSomeOtherDictionaryItem.Value,
+                                    Bar_SomeOtherDictionary_Key = docBarSomeOtherDictionaryItem.Key,
+                                    Bar_SomeDictionary_Value = docBarSomeDictionaryItem.Value,
+                                    Bar_SomeDictionary_Key = docBarSomeDictionaryItem.Key,
+                                    Bar = doc.Bar
+                                }"
+                    }, true);
+
+                    RavenQueryStatistics stats;
+
+                    var result = session.Query<Foo>("Foos/TestDynamicQueries")
+                        .Where(x =>
+                            x.Bar.SomeDictionary.Any(y => y.Key == "KeyOne" && y.Value == "ValueOne") ||
+                                x.Bar.SomeOtherDictionary.Any(y => y.Key == "KeyFour" && y.Value == "ValueFour") ||
+                                    x.Bar == null)
+                                        .Customize(x => x.WaitForNonStaleResults())
+                                            .Statistics(out stats).ToList();
+
+                    Assert.Equal(result.Count, 3);
+
+                }
+
+            }
+
+        }
+
+    }
+
+    public class Foo
+    {
+
+        public string SomeProperty { get; set; }
+
+        public Bar Bar { get; set; }
+
+    }
+
+    public class Bar
+    {
+
+        public Dictionary<string, string> SomeDictionary { get; set; }
+        public Dictionary<string, string> SomeOtherDictionary { get; set; }
+
+    }
+
+}

--- a/Raven.Tests/Linq/WhereClause.cs
+++ b/Raven.Tests/Linq/WhereClause.cs
@@ -467,7 +467,7 @@ namespace Raven.Tests.Linq
 			var indexedUsers = GetRavenQueryInspector();
 			var q = indexedUsers
 				.Where(x => x.Properties.Any(y => y.Key == "first"));
-			Assert.Equal("Key:first", q.ToString());
+            Assert.Equal("Properties_Key:first", q.ToString());
 		}
 
 		public class IndexedUser

--- a/Raven.Tests/Raven.Tests.csproj
+++ b/Raven.Tests/Raven.Tests.csproj
@@ -541,6 +541,7 @@
     <Compile Include="Json\RavenJObjects.cs" />
     <Compile Include="Linq\Any.cs" />
     <Compile Include="Linq\CommitInfo.cs" />
+    <Compile Include="Linq\DynamicQueriesWithStaticIndexes.cs" />
     <Compile Include="Linq\SampleDynamicCompilationExtension.cs" />
     <Compile Include="Linq\SampleGeoLocation.cs" />
     <Compile Include="Linq\User.cs" />


### PR DESCRIPTION
Changed the way the LINQ provider resolves field names for queries on static indexes.

Will produce a complete member path (i.e.: x.Bar.SomeProperty resolves into Bar_SomeProperty) for a Lucene search field name.
