### PR TITLE
QueryStatistics property for IRavenQueryable and IDocumentQueryBase

### DIFF
--- a/Raven.Client.Lightweight/Document/AsyncDocumentQuery.cs
+++ b/Raven.Client.Lightweight/Document/AsyncDocumentQuery.cs
@@ -551,6 +551,19 @@ namespace Raven.Client.Document
 			return this;
 		}
 
+	    /// <summary>
+        /// Statistics about the query, such as total count of matching records, after the query executed
+	    /// </summary>
+	    public RavenQueryStatistics QueryStatistics
+	    {
+	        get 
+            { 
+                RavenQueryStatistics queryStatistics;
+                Statistics(out queryStatistics);
+                return queryStatistics;
+            }
+	    }
+
 		/// <summary>
 		/// Filter matches to be inside the specified radius
 		/// </summary>

--- a/Raven.Client.Lightweight/Document/DocumentQuery.cs
+++ b/Raven.Client.Lightweight/Document/DocumentQuery.cs
@@ -176,6 +176,19 @@ namespace Raven.Client.Document
 			return this;
 		}
 
+        /// <summary>
+        /// Statistics about the query, such as total count of matching records, after the query executed
+        /// </summary>
+        public RavenQueryStatistics QueryStatistics
+	    {
+	        get 
+            { 
+                RavenQueryStatistics queryStatistics;
+                Statistics(out queryStatistics);
+                return queryStatistics;
+            }
+	    }
+
 
 		/// <summary>
 		/// Includes the specified path in the query, loading the document specified in that path

--- a/Raven.Client.Lightweight/Document/ShardedDocumentQuery.cs
+++ b/Raven.Client.Lightweight/Document/ShardedDocumentQuery.cs
@@ -726,6 +726,17 @@ If you really want to do in memory filtering on the data returned from the query
 			throw new NotImplementedException();
 		}
 
+        /// <summary>
+        /// Statistics about the query, such as total count of matching records, after the query executed
+        /// </summary>
+        public RavenQueryStatistics QueryStatistics
+        {
+            get
+            {
+                throw new NotImplementedException();
+            }
+        }
+
 		/// <summary>
 		/// Simplified method for closing a clause within the query
 		/// </summary>

--- a/Raven.Client.Lightweight/IDocumentQueryBase.cs
+++ b/Raven.Client.Lightweight/IDocumentQueryBase.cs
@@ -370,5 +370,10 @@ If you really want to do in memory filtering on the data returned from the query
 		/// Provide statistics about the query, such as total count of matching records
 		/// </summary>
 		TSelf Statistics(out RavenQueryStatistics stats);
+
+	    /// <summary>
+	    /// Provide statistics about the query, such as total count of matching records, after the query executed
+	    /// </summary>
+	    RavenQueryStatistics QueryStatistics { get; }
 	}
 }

--- a/Raven.Client.Lightweight/Linq/IRavenQueryable.cs
+++ b/Raven.Client.Lightweight/Linq/IRavenQueryable.cs
@@ -18,6 +18,11 @@ namespace Raven.Client.Linq
 		/// </summary>
 		IRavenQueryable<T> Statistics(out RavenQueryStatistics stats);
 
+	    /// <summary>
+	    /// Provide statistics about the query, such as total count of matching records, after the query executed
+	    /// </summary>
+        RavenQueryStatistics QueryStatistics { get; }
+
 		/// <summary>
 		/// Customizes the query using the specified action
 		/// </summary>

--- a/Raven.Client.Lightweight/Linq/RavenQueryInspector.cs
+++ b/Raven.Client.Lightweight/Linq/RavenQueryInspector.cs
@@ -110,7 +110,15 @@ namespace Raven.Client.Linq
 			return this;
 		}
 
-		/// <summary>
+	    /// <summary>
+        /// Statistics about the query, such as total count of matching records, after the query executed
+	    /// </summary>
+	    public RavenQueryStatistics QueryStatistics 
+        { 
+            get { return queryStats; }
+        }
+
+	    /// <summary>
 		/// Customizes the query using the specified action
 		/// </summary>
 		/// <param name="action">The action.</param>

--- a/Raven.Tests/Bugs/Queries/StatsOnDynamicQueries.cs
+++ b/Raven.Tests/Bugs/Queries/StatsOnDynamicQueries.cs
@@ -62,5 +62,58 @@ namespace Raven.Tests.Bugs.Queries
 				}
 			}
 		}
+
+        [Fact]
+        public void WillGiveStatsAfterExecution()
+        {
+            using (var store = NewDocumentStore())
+            {
+                using (var session = store.OpenSession())
+                {
+                    session.Store(new User
+                    {
+                        Age = 15,
+                        Email = "ayende"
+                    });
+                    session.SaveChanges();
+                }
+
+                using (var session = store.OpenSession())
+                {
+                    var query = session.Query<User>()
+                        .Where(x => x.Email == "ayende");
+                    var result = query.ToArray();
+
+                    Assert.NotEqual(0, query.QueryStatistics.TotalResults);
+                }
+            }
+        }
+
+        [Fact]
+        public void WillGiveStatsForLuceneQueryAfterExecution()
+        {
+            using (var store = NewDocumentStore())
+            {
+                using (var session = store.OpenSession())
+                {
+                    session.Store(new User
+                    {
+                        Age = 15,
+                        Email = "ayende"
+                    });
+                    session.SaveChanges();
+                }
+
+                using (var session = store.OpenSession())
+                {
+                    var query = session.Advanced.LuceneQuery<User>()
+                        .Where("Email:ayende");
+                    var result = query.ToArray();
+
+                    Assert.NotEqual(0, query.QueryStatistics.TotalResults);
+                    Assert.Equal(query.QueryStatistics.TotalResults, query.QueryResult.TotalResults);
+                }
+            }
+        }
 	}
 }


### PR DESCRIPTION
as discussed here: https://groups.google.com/d/topic/ravendb/JCjnyP4AgOA/discussion

I would have wanted to name the property "Statistics" instead of "QueryStatistics" but this does not compile or would require the existing "Statistics" method to be renamed, thus being a breaking change.
