### PR TITLE
Fix to make Load<T>(ValueType id) work on sharded sessions

### DIFF
--- a/Raven.Client.Lightweight/Shard/ShardStrategy/ShardResolution/ShardResolutionStrategyData.cs
+++ b/Raven.Client.Lightweight/Shard/ShardStrategy/ShardResolution/ShardResolutionStrategyData.cs
@@ -3,54 +3,113 @@
 //     Copyright (c) Hibernating Rhinos LTD. All rights reserved.
 // </copyright>
 //-----------------------------------------------------------------------
+
 using System;
 
 namespace Raven.Client.Shard.ShardStrategy.ShardResolution
 {
-	/// <summary>
-	/// Information required to resolve the appropriate shard for an entity / entity and key
-	/// </summary>
-	public class ShardResolutionStrategyData
-	{
-		/// <summary>
-		/// Builds an instance of <see cref="ShardResolutionStrategyData"/> from the given type
-		/// </summary>
-		public static ShardResolutionStrategyData BuildFrom(Type type) 
-		{
-			return BuildFrom(type, null);
-		}
+    /// <summary>
+    /// Information required to resolve the appropriate shard for an entity / entity and key
+    /// </summary>
+    public class ShardResolutionStrategyData
+    {
+        private string key;
 
-		/// <summary>
-		/// Builds an instance of <see cref="ShardResolutionStrategyData"/> from the given type
-		/// and key
-		/// </summary>
-		public static ShardResolutionStrategyData BuildFrom(Type type, string key)
-		{
-			if (type == null)
-				throw new ArgumentNullException("type");
+        private ValueType valueTypeKey;
 
-			return new ShardResolutionStrategyData
-			{
-				EntityType = type,
-				Key = key
-			};
-		}
+        private ShardResolutionStrategyData()
+        {
+        }
 
-		private ShardResolutionStrategyData()
-		{
-			
-		}
+        /// <summary>
+        /// Gets or sets the key.
+        /// </summary>
+        /// <value>The key.</value>
+        public string Key
+        {
+            get
+            {
+                if (HasValueTypeKey)
+                    throw new InvalidOperationException("You did not check HasStringTypeKey. These data might contain a ValueType key. Check and use that property instead.");
 
-		/// <summary>
-		/// Gets or sets the key.
-		/// </summary>
-		/// <value>The key.</value>
-		public string Key { get; set; }
+                return key;
+            }
+            private set { key = value; }
+        }
 
-		/// <summary>
-		/// Gets or sets the type of the entity.
-		/// </summary>
-		/// <value>The type of the entity.</value>
-		public Type EntityType { get; set; }
-	}
+        /// <summary>
+        /// Gets the key.
+        /// </summary>
+        public ValueType ValueTypeKey
+        {
+            get
+            {
+                if (HasStringTypeKey)
+                    throw new InvalidOperationException("You did not check HasValueTypeKey. These data might contain a string key. Check and use that property instead.");
+
+                return valueTypeKey;
+            }
+            private set { valueTypeKey = value; }
+        }
+
+        /// <summary>
+        /// Gets or sets the type of the entity.
+        /// </summary>
+        /// <value>The type of the entity.</value>
+        public Type EntityType { get; private set; }
+
+        /// <summary>
+        /// Indicates that <see cref="Key"/> has to be used for shard selection logic.
+        /// </summary>
+        public bool HasStringTypeKey { get; private set; }
+
+        /// <summary>
+        /// Indicates that <see cref="ValueTypeKey"/> has to be used for shard selection logic.
+        /// </summary>
+        public bool HasValueTypeKey { get; private set; }
+
+        /// <summary>
+        /// Builds an instance of <see cref="ShardResolutionStrategyData"/> from the given type
+        /// </summary>
+        public static ShardResolutionStrategyData BuildFrom(Type type)
+        {
+            return BuildFrom(type, (string) null);
+        }
+
+        /// <summary>
+        /// Builds an instance of <see cref="ShardResolutionStrategyData"/> from the given type
+        /// and key
+        /// </summary>
+        public static ShardResolutionStrategyData BuildFrom(Type type, string key)
+        {
+            if (type == null)
+                throw new ArgumentNullException("type");
+
+            return new ShardResolutionStrategyData
+                       {
+                           HasStringTypeKey = true,
+                           HasValueTypeKey = false,
+                           EntityType = type,
+                           Key = key
+                       };
+        }
+
+        /// <summary>
+        /// Builds an instance of <see cref="ShardResolutionStrategyData"/> from the given type
+        /// and key
+        /// </summary>
+        public static ShardResolutionStrategyData BuildFrom(Type type, ValueType key)
+        {
+            if (type == null)
+                throw new ArgumentNullException("type");
+
+            return new ShardResolutionStrategyData
+                       {
+                           HasStringTypeKey = false,
+                           HasValueTypeKey = true,
+                           EntityType = type,
+                           ValueTypeKey = key
+                       };
+        }
+    }
 }

--- a/Raven.Tests/Raven.Tests.csproj
+++ b/Raven.Tests/Raven.Tests.csproj
@@ -597,6 +597,7 @@
     <Compile Include="Security\OAuth\CertHelper.cs" />
     <Compile Include="Security\OAuth\GrantAccessTokenClientCredentialsFlow.cs" />
     <Compile Include="Security\OAuth\HttpWebRequestExtensions.cs" />
+    <Compile Include="Shard\When_Using_Entities_With_ValueType_Ids.cs" />
     <Compile Include="Shard\When_Using_Parallel_Access_Strategy.cs" />
     <Compile Include="Shard\When_Using_Sharded_Servers.cs" />
     <Compile Include="Some.cs" />

--- a/Raven.Tests/Shard/When_Using_Entities_With_ValueType_Ids.cs
+++ b/Raven.Tests/Shard/When_Using_Entities_With_ValueType_Ids.cs
@@ -1,0 +1,201 @@
+﻿using System;
+using System.Collections.Generic;
+using System.Threading;
+using Raven.Client;
+using Raven.Client.Document;
+using Raven.Client.Shard;
+using Raven.Client.Shard.ShardStrategy;
+using Raven.Client.Shard.ShardStrategy.ShardAccess;
+using Raven.Client.Shard.ShardStrategy.ShardResolution;
+using Raven.Client.Shard.ShardStrategy.ShardSelection;
+using Raven.Database.Extensions;
+using Raven.Database.Server;
+using Raven.Server;
+using Xunit;
+
+namespace Raven.Tests.Shard
+{
+    public class When_Using_Entities_With_ValueType_Ids : RemoteClientTest, IDisposable
+    {
+        private readonly string path1;
+        private readonly string path2;
+        private readonly int port1;
+        private readonly int port2;
+        private readonly string server;
+        private readonly RavenDbServer server1;
+        private readonly RavenDbServer server2;
+        private readonly ShardStrategy shardStrategy;
+        private Shards shards;
+
+        public When_Using_Entities_With_ValueType_Ids()
+        {
+            server = "localhost";
+
+            port1 = 8080;
+            port2 = 8081;
+
+            path1 = GetPath("TestShardedDb1");
+            path2 = GetPath("TestShardedDb2");
+
+            NonAdminHttp.EnsureCanListenToWhenInNonAdminContext(port1);
+            NonAdminHttp.EnsureCanListenToWhenInNonAdminContext(port2);
+
+            server1 = GetNewServer(port1, path1);
+            server2 = GetNewServer(port2, path2);
+
+            RefreshShards();
+
+            shardStrategy = new ShardStrategy
+                                {
+                                    ShardAccessStrategy = new ParallelShardAccessStrategy(),
+                                    ShardResolutionStrategy = new ByModulusResolutionStrategy("Shard", serverCount: 2),
+                                    ShardSelectionStrategy = new ByModulusSelectionStrategy("Shard", serverCount: 2)
+                                };
+
+            using (IDocumentStore store = new ShardedDocumentStore(shardStrategy, shards).Initialize())
+            {
+                var car1 = new Car {Id = 1, Name = "Car 1"};
+                var car2 = new Car {Id = 2, Name = "Car 2"};
+                var car3 = new Car {Id = 3, Name = "Car 3"};
+
+                using (IDocumentSession session = store.OpenSession())
+                {
+                    session.Store(car1);
+                    session.Store(car2);
+                    session.Store(car3);
+                    session.SaveChanges();
+                }
+            }
+        }
+
+        private void RefreshShards()
+        {
+            shards = new Shards
+                         {
+                             new DocumentStore {Identifier = "Shard1", Url = "http://" + server + ":" + port1},
+                             new DocumentStore {Identifier = "Shard2", Url = "http://" + server + ":" + port2}
+                         };
+        }
+
+        #region IDisposable Members
+
+        public void Dispose()
+        {
+            server1.Dispose();
+            server2.Dispose();
+
+            Thread.Sleep(100);
+
+            foreach (string path in new[] {path1, path2})
+            {
+                try
+                {
+                    IOExtensions.DeleteDirectory(path);
+                }
+                catch (Exception)
+                {
+                }
+            }
+        }
+
+        #endregion
+
+        [Fact]
+        public void Can_load_an_entity_by_id_instead_of_database_string_key()
+        {
+            RefreshShards();
+
+            using (IDocumentStore store = new ShardedDocumentStore(shardStrategy, shards).Initialize())
+            using (IDocumentSession session = store.OpenSession())
+            {
+                var car = session.Load<Car>(3);
+                Assert.NotNull(car);
+                Assert.Equal("Car 3", car.Name);
+            }
+        }
+    }
+
+    public class ByModulusSelectionStrategy : IShardSelectionStrategy
+    {
+        private readonly uint serverCount;
+        private readonly string shardPrefix;
+
+        public ByModulusSelectionStrategy(string shardPrefix, uint serverCount)
+        {
+            this.serverCount = serverCount;
+            this.shardPrefix = shardPrefix;
+        }
+
+        #region IShardSelectionStrategy Members
+
+        string IShardSelectionStrategy.ShardIdForNewObject(object obj)
+        {
+            var car = obj as Car;
+
+            if (car != null)
+                return GetShardId(car);
+
+            throw new NotImplementedException();
+        }
+
+        string IShardSelectionStrategy.ShardIdForExistingObject(object obj)
+        {
+            var car = obj as Car;
+
+            if (car != null)
+                return GetShardId(car);
+
+            throw new NotImplementedException();
+        }
+
+        #endregion
+
+        private string GetShardId(Car car)
+        {
+            return shardPrefix + ModulusHelper.GetPositiveGroupNumber(car.Id, serverCount);
+        }
+    }
+
+    public class ByModulusResolutionStrategy : IShardResolutionStrategy
+    {
+        private readonly uint serverCount;
+        private readonly string shardPrefix;
+
+        public ByModulusResolutionStrategy(string shardPrefix, uint serverCount)
+        {
+            this.shardPrefix = shardPrefix;
+            this.serverCount = serverCount;
+        }
+
+        #region IShardResolutionStrategy Members
+
+        IList<string> IShardResolutionStrategy.SelectShardIds(ShardResolutionStrategyData srsd)
+        {
+            if (srsd.HasValueTypeKey)
+            {
+                var key = (int) srsd.ValueTypeKey;
+                return new[] {shardPrefix + ModulusHelper.GetPositiveGroupNumber(key, serverCount)};
+            }
+
+            throw new NotImplementedException();
+        }
+
+        #endregion
+    }
+
+    internal class ModulusHelper
+    {
+        public static int GetPositiveGroupNumber(int x, uint numberOfGroups)
+        {
+            long remainder = x%numberOfGroups;
+            remainder = remainder < 0 ? remainder + numberOfGroups : remainder;
+            return (int) (remainder + 1);
+        }
+    }
+
+    internal class Car
+    {
+        public int Id { get; set; }
+        public string Name { get; set; }
+    }
+}


### PR DESCRIPTION
When using entities with non-string ids, I was not able to use Load<T>(ValueType id) on a sharded session. The reason was that the ShardResolutionStrategyData only transferred string type keys, so the method used above could not use that.
ShardResolutionStrategyData was updated to transfer OR a string key OR a ValueType key. Two properties (HasStringKey & HasValueTypeKey) helping to check which key to use in the ShardResolutionStrategy were added to ShardResolutionStrategyData. If someone has a nicer solution, feel free, but this solution was backwards compatible.
ShardedDocumentSession.Load<T>(string key) and ShardedDocumentSession.Load<T>(ValueType id) now basically use the same logic.
