### PR TITLE
Added failing test for WhereEqualsOrBetween on Spatial search

### DIFF
--- a/Raven.Tests/Spatial/Event.cs
+++ b/Raven.Tests/Spatial/Event.cs
@@ -27,9 +27,19 @@ namespace Raven.Tests.Spatial
 			Date = date;
 		}
 
+		public Event(string venue, double lat, double lng, DateTime date, int capacity)
+		{
+			this.Venue = venue;
+			this.Latitude = lat;
+			this.Longitude = lng;
+			Date = date;
+			this.Capacity = capacity;
+		}
+
 		public string Venue { get; set; }
 		public double Latitude { get; set; }
 		public double Longitude { get; set; }
 		public DateTime Date { get; set; }
+		public int Capacity { get; set; }
 	}
 }


### PR DESCRIPTION
Whole story here: https://groups.google.com/d/topic/ravendb/gQ3E375lVno/discussion

I'm also unable to get any of the WhereLess... WhereGreater than. Always returning 0 results.
Even if I exclude the spatial search on line 80: .WithinRadiusOf(6.0, 38.96939, -77.386398)
