### PR TITLE
Added a failing test to demonstrate failing ad hoc projection

### DIFF
--- a/Raven.Tests/Bugs/AdHocProjections.cs
+++ b/Raven.Tests/Bugs/AdHocProjections.cs
@@ -1,0 +1,69 @@
+﻿using System.Linq;
+using Xunit;
+
+namespace Raven.Tests.Bugs
+{
+	public class AdHocProjections : LocalClientTest
+	{
+		[Fact]
+		public void Query_can_project_to_a_different_model()
+		{
+			using (var documentStore = NewDocumentStore())
+			{
+				using (var session = documentStore.OpenSession())
+				{
+					session.Store(new Entity
+					              	{
+					              		Id = 1,
+					              		Category = new Category { Title = "Category Title" }
+					              	});
+
+					session.SaveChanges();
+				}
+
+				using (var session = documentStore.OpenSession())
+				{
+					var viewModel = (from entity in session.Query<Entity>()
+					                 select new EntityViewModel
+					                        	{
+					                        		Id = entity.Id,
+					                        		CategoryTitle = entity.Category.Title
+					                        	}).SingleOrDefault();
+
+					Assert.NotNull(viewModel);
+					Assert.Equal(1, viewModel.Id);
+					Assert.Equal("Category Title", viewModel.CategoryTitle);
+				}
+			}
+		}
+
+		#region Nested type: Category
+
+		public class Category
+		{
+			public string Title { get; set; }
+		}
+
+		#endregion
+
+		#region Nested type: Entity
+
+		public class Entity
+		{
+			public int Id { get; set; }
+			public Category Category { get; set; }
+		}
+
+		#endregion
+
+		#region Nested type: EntityViewModel
+
+		public class EntityViewModel
+		{
+			public int Id { get; set; }
+			public string CategoryTitle { get; set; }
+		}
+
+		#endregion
+	}
+}

--- a/Raven.Tests/Raven.Tests.csproj
+++ b/Raven.Tests/Raven.Tests.csproj
@@ -159,6 +159,7 @@
     </Compile>
     <Compile Include="Bugs\Account.cs" />
     <Compile Include="Bugs\AccurateCount.cs" />
+    <Compile Include="Bugs\AdHocProjections.cs" />
     <Compile Include="Bugs\AfterDeletingTheIndexStopsBeingStale.cs" />
     <Compile Include="Bugs\AggressiveCaching.cs" />
     <Compile Include="Bugs\AnalyzerPerField.cs" />


### PR DESCRIPTION
Given domain model...

``` c#
public class Entity
{
    public int Id { get; set; }
    public Category Category { get; set; }
}

public class Category
{
    public string Title { get; set; }
}
```

... I want to project results of a select query to this view model:

``` c#
public class EntityViewModel
{
    public int Id { get; set; }
    public string CategoryTitle { get; set; }
}
```

I have tried the following query:

``` c#
var viewModel = (from entity in _documentSession.Query<Entity>()
                select new EntityViewModel
                        {
                            Id = entity.Id,
                            CategoryTitle = entity.Category.Title
                        }.ToList();
```

The result of this is only partially correct: the Id is set, the CategoryTitle is not. 

Is this behaviour by design? Is there, perhaps, an API call I should use for this?

I posted a question on StackOverflow (http://stackoverflow.com/questions/8950182/how-to-handle-projections-in-ravendb), but no answers so far.
