### PR TITLE
Add failing test for Map/Reduce + transform with included decimal value

### DIFF
--- a/Raven.Tests/Bugs/TransformResults/AnswerViewItem.cs
+++ b/Raven.Tests/Bugs/TransformResults/AnswerViewItem.cs
@@ -8,5 +8,6 @@
 		public string UserId { get; set; }
 		public string UserDisplayName { get; set; }
 		public int VoteTotal { get; set; }
+	    public decimal DecimalTotal { get; set; }
 	}
 }

--- a/Raven.Tests/Bugs/TransformResults/AnswerVote.cs
+++ b/Raven.Tests/Bugs/TransformResults/AnswerVote.cs
@@ -7,6 +7,7 @@ namespace Raven.Tests.Bugs.TransformResults
 		public string QuestionId { get; set; }
 		public string AnswerId { get; set; }
 		public int Delta { get; set; }
+	    public decimal DecimalValue { get; set; }
 	}
 	public class AnswerVote2
 	{
@@ -14,6 +15,6 @@ namespace Raven.Tests.Bugs.TransformResults
 		public Guid QuestionId { get; set; }
 		public Guid AnswerId { get; set; }
 		public int Delta { get; set; }
-	}
+    }
 
 }

--- a/Raven.Tests/Bugs/TransformResults/Answers_ByQuestion.cs
+++ b/Raven.Tests/Bugs/TransformResults/Answers_ByQuestion.cs
@@ -12,7 +12,8 @@ namespace Raven.Tests.Bugs.TransformResults
 						  {
 							  AnswerId = doc.AnswerId,
 							  QuestionId = doc.QuestionId,
-							  VoteTotal = doc.Delta
+							  VoteTotal = doc.Delta,
+                              DecimalTotal = doc.DecimalValue
 						  };
 
 			Reduce = mapped => from map in mapped
@@ -25,7 +26,8 @@ namespace Raven.Tests.Bugs.TransformResults
 							   {
 								   AnswerId = g.Key.AnswerId,
 								   QuestionId = g.Key.QuestionId,
-								   VoteTotal = g.Sum(x => x.VoteTotal)
+								   VoteTotal = g.Sum(x => x.VoteTotal),
+                                   DecimalTotal = g.Sum(x => x.DecimalTotal)
 							   };
 
 			TransformResults = (database, results) =>
@@ -39,7 +41,8 @@ namespace Raven.Tests.Bugs.TransformResults
 					Content = answer.Content,
 					UserId = answer.UserId,
 					UserDisplayName = user.DisplayName,
-					VoteTotal = result.VoteTotal
+					VoteTotal = result.VoteTotal,
+                    result.DecimalTotal
 				};
 			this.IndexSortOptions.Add(x => x.VoteTotal, Raven.Abstractions.Indexing.SortOptions.Int);
 		}


### PR DESCRIPTION
If I have a Map/Reduce index with a transform and the result contains a decimal value, then I get the following exception:

```
System.InvalidOperationException: The transform results function failed.
Doc '', Error: Cannot convert type 'string' to 'decimal'
```

```
at Raven.Database.DocumentDatabase.<>c__DisplayClass72.<Query>b__6a(IStorageActionsAccessor actions) in DocumentDatabase.cs: line 769
at Raven.Storage.Managed.TransactionalStorage.Batch(Action`1 action) in TransactionalStorage.cs: line 118
at Raven.Database.DocumentDatabase.Query(String index, IndexQuery query) in DocumentDatabase.cs: line 707
at Raven.Client.Embedded.EmbeddedDatabaseCommands.Query(String index, IndexQuery query, String[] includes) in EmbeddedDatabaseCommands.cs: line 310
at Raven.Client.Document.AbstractDocumentQuery`2.ExecuteActualQuery() in AbstractDocumentQuery.cs: line 434
at Raven.Client.Document.AbstractDocumentQuery`2.InitSync() in AbstractDocumentQuery.cs: line 423
at Raven.Client.Document.AbstractDocumentQuery`2.GetEnumerator() in AbstractDocumentQuery.cs: line 553
at System.Linq.Enumerable.SingleOrDefault(IEnumerable`1 source)
at Raven.Client.Linq.RavenQueryProviderProcessor`1.GetQueryResult(IDocumentQuery`1 finalQuery) in RavenQueryProviderProcessor.cs: line 1206
at Raven.Client.Linq.RavenQueryProviderProcessor`1.ExecuteQuery() in RavenQueryProviderProcessor.cs: line 1148
at Raven.Client.Linq.RavenQueryProviderProcessor`1.Execute(Expression expression) in RavenQueryProviderProcessor.cs: line 1131
at Raven.Client.Linq.RavenQueryProvider`1.Execute(Expression expression) in RavenQueryProvider.cs: line 130
at Raven.Client.Linq.RavenQueryProvider`1.System.Linq.IQueryProvider.Execute(Expression expression) in RavenQueryProvider.cs: line 176
at System.Linq.Queryable.SingleOrDefault(IQueryable`1 source)
at Raven.Tests.Bugs.TransformResults.ComplexValuesFromTransformResults.DecimalValues() in ComplexValuesFromTransformResults.cs: line 133 
```
