### PR TITLE
Smuggler filter option for in/out

### DIFF
--- a/Raven.Smuggler/Raven.Smuggler.csproj
+++ b/Raven.Smuggler/Raven.Smuggler.csproj
@@ -55,6 +55,9 @@
     <Reference Include="System.Xml" />
   </ItemGroup>
   <ItemGroup>
+    <Compile Include="..\Raven.Server\FromMono\Options.cs">
+      <Link>Options.cs</Link>
+    </Compile>
     <Compile Include="Smuggler.cs" />
     <Compile Include="Properties\AssemblyInfo.cs" />
   </ItemGroup>


### PR DESCRIPTION
Hello,

As per email conversations with Ayende, this is my first ever attempt (on github) at contributing to a project, so be gentle :)

My coding probably needs work, things I can think of to improve (but I'm not smart enough):
- Better handle the filter splitting, feels dirty and not extensible.
- Ayende mentioned "SelectTokenWithRavenSyntaxReturningFlatStructure" but I really don't understand in what context he wanted to me use it.
- Messages probably need to be reworked to deal with filtering out documents, they currently work fine but wording/style might need tweaking.
- Just noticed I need a Environment.Exit(-1); after I output only metadata filters are supported (doh)
