### PR TITLE
Quick fix: Run debug server without going into directory.

### DIFF
--- a/Scripts/Start.cmd
+++ b/Scripts/Start.cmd
@@ -1,1 +1,1 @@
-start .\Server\Raven.Server.exe --debug --browser
+start %~dp0\Server\Raven.Server.exe --debug --browser


### PR DESCRIPTION
Batch file fails if working directory is different than Raven directory when using dot (.). %~dp0 works on Windows XP+.
