### PR TITLE
Indexing of subclasses without maintaining index code.

### DIFF
--- a/Raven.Client.Lightweight/Indexes/AbstractMultiMapIndexCreationTask.cs
+++ b/Raven.Client.Lightweight/Indexes/AbstractMultiMapIndexCreationTask.cs
@@ -2,6 +2,7 @@
 using System.Collections;
 using System.Collections.Generic;
 using System.Linq.Expressions;
+using System.Reflection;
 using Raven.Abstractions.Indexing;
 using System.Linq;
 
@@ -23,7 +24,30 @@ namespace Raven.Client.Indexes
 			});
 		}
 
-		/// <summary>
+        /// <summary>
+        /// Uses reflection to call <see cref="AddMap{TSource}"/> for the base type and all available subclasses.
+        /// </summary>
+        /// <remarks>This is taken from Oren's code in this thread https://groups.google.com/d/msg/ravendb/eFUlQG-spzE/Ac0PrvsFyJYJ </remarks>
+        /// <typeparam name="TBase">The base class type whose descendant types are to be included in the index.</typeparam>
+        /// <param name="expr"></param>
+        protected void AddMapForAll<TBase>(Expression<Func<IEnumerable<TBase>, IEnumerable>> expr)
+        {
+            // Index the base class.
+            AddMap(expr);
+
+            // Index child classes.
+            var children = typeof(TBase).Assembly.GetTypes().Where(x => x.IsSubclassOf(typeof(TBase)));
+            var addMapGeneric = GetType().GetMethod("AddMap", BindingFlags.Instance | BindingFlags.NonPublic);
+            foreach (var child in children)
+            {
+                var genericEnumerable = typeof(IEnumerable<>).MakeGenericType(child);
+                var delegateType = typeof(Func<,>).MakeGenericType(genericEnumerable, typeof(IEnumerable));
+                var lambdaExpression = Expression.Lambda(delegateType, expr.Body, Expression.Parameter(genericEnumerable, expr.Parameters[0].Name));
+                addMapGeneric.MakeGenericMethod(child).Invoke(this, new[] { lambdaExpression });
+            }
+        }
+        
+        /// <summary>
 		/// Creates the index definition.
 		/// </summary>
 		/// <returns></returns>

--- a/Raven.Tests/MailingList/AddMapForAllTest.cs
+++ b/Raven.Tests/MailingList/AddMapForAllTest.cs
@@ -1,0 +1,83 @@
+﻿using System;
+using System.Linq;
+using System.Linq.Expressions;
+using Raven.Client;
+using Raven.Client.Indexes;
+using Xunit;
+
+namespace Raven.Tests.MailingList
+{
+    public class AddMapForAllTest : RavenTest
+    {
+        // Parent class whose children will be indexed.
+        public abstract class Animal
+        {
+            public string Name { get; set; }
+        }
+
+        public class Rhino : Animal
+        {
+        }
+
+        public class Tiger : Animal
+        {
+        }
+
+        public abstract class Equine : Animal
+        {
+        }
+
+        public class Horse : Equine
+        {
+        }
+
+        public class AnimalsByName : AbstractMultiMapIndexCreationTask<Animal>
+        {
+            public AnimalsByName()
+            {
+                AddMapForAll<Animal>(parents =>
+                                     from parent in parents
+                                     select new
+                                     {
+                                         parent.Name
+                                     });
+            }
+        }
+
+        protected override void CreateDefaultIndexes(IDocumentStore documentStore)
+        {
+            base.CreateDefaultIndexes(documentStore);
+            new AnimalsByName().Execute(documentStore);
+        }
+
+        [Fact]
+        public void IndexOnAbstractParentIndexesChildClasses()
+        {
+            using (var store = NewDocumentStore())
+            {
+                using (var session = store.OpenSession())
+                {
+                    session.Store(new Rhino { Name = "Ronald" });
+                    session.Store(new Rhino { Name = "Roger" });
+                    session.Store(new Tiger { Name = "Tina" });
+                    session.Store(new Horse { Name = "Mahoney" });
+                    session.SaveChanges();
+                }
+
+                using (var session = store.OpenSession())
+                {
+                    Assert.Equal(2, GetAnimals(session, x => x.Name.StartsWith("R")).Length);
+                    Assert.Equal(1, GetAnimals(session, x => x.Name == "Tina").Length);
+
+                    // Check that indexing applies to more than a single level of inheritance.
+                    Assert.IsType<Horse>(GetAnimals(session, x => x.Name == "Mahoney").Single());
+                }
+            }
+        }
+
+        private static Animal[] GetAnimals(IDocumentSession s, Expression<Func<Animal, bool>> e)
+        {
+            return s.Query<Animal, AnimalsByName>().Customize(x => x.WaitForNonStaleResults()).Where(e).ToArray();
+        }
+    }
+}

--- a/Raven.Tests/Raven.Tests.csproj
+++ b/Raven.Tests/Raven.Tests.csproj
@@ -559,6 +559,7 @@
     <Compile Include="Linq\User.cs" />
     <Compile Include="Linq\WhereClause.cs" />
     <Compile Include="LocalClientTest.cs" />
+    <Compile Include="MailingList\AddMapForAllTest.cs" />
     <Compile Include="MailingList\AttachmentContentType.cs" />
     <Compile Include="MailingList\BooleanCollection.cs" />
     <Compile Include="MailingList\CanUpdateInsideDtcWithOptimisticConcurrency.cs" />


### PR DESCRIPTION
This change allows AbstractMultiMapIndexCreationTask to index all subclasses and removes the need to maintain the index code when new subclasses are added.

As per this thread:  https://groups.google.com/forum/?fromgroups#!topic/ravendb/eFUlQG-spzE
