### PR TITLE
Don't compress Raven.Studio.xap

### DIFF
--- a/Raven.Database/Server/HttpServer.cs
+++ b/Raven.Database/Server/HttpServer.cs
@@ -727,6 +727,11 @@ namespace Raven.Database.Server
 			if (string.IsNullOrEmpty(acceptEncoding))
 				return;
 
+			// The Studio xap is already a compressed file, it's a waste of time to try to compress it further.
+			var requestUrl = ctx.GetRequestUrl();
+			if (String.Equals(requestUrl, "/silverlight/Raven.Studio.xap", StringComparison.InvariantCultureIgnoreCase))
+				return;
+
 			// gzip must be first, because chrome has an issue accepting deflate data
 			// when sending it json text
 			if ((acceptEncoding.IndexOf("gzip", StringComparison.OrdinalIgnoreCase) != -1))


### PR DESCRIPTION
The Studio xap file is already compressed, so it's a waste of time to try to gzip compress it further. In fact, it can drastically slow down the Studio load time from remote networks.
