### PR TITLE
Checking numericfield in IndexReplication bundle

### DIFF
--- a/Bundles/Raven.Bundles.IndexReplication/IndexReplicationIndexUpdateTrigger.cs
+++ b/Bundles/Raven.Bundles.IndexReplication/IndexReplicationIndexUpdateTrigger.cs
@@ -101,6 +101,11 @@ namespace Raven.Bundles.IndexReplication
 						var parameter = cmd.CreateParameter();
 						parameter.ParameterName = GetParameterName(mapping.Key);
 						var field = document.GetFieldable(mapping.Key);
+
+						var numericfield = document.GetFieldable(String.Concat(mapping.Key, "_Range"));
+						if (numericfield != null)
+							field = numericfield;
+						
 						if (field == null)
 							parameter.Value = DBNull.Value;
 						else if(field is NumericField)


### PR DESCRIPTION
To check if a field index document is Numeric we must use the field´s
name, plus the '_Range' suffix. If not, this code (field is
NumericField) is always false.
