### PR TITLE
Add the project ref. of Raven.Client.Debug to Raven.Bundles solution

### DIFF
--- a/Bundles/Raven.Bundles.sln
+++ b/Bundles/Raven.Bundles.sln
@@ -65,6 +65,8 @@ Project("{FAE04EC0-301F-11D3-BF4B-00C04F79EFBC}") = "Raven.Tests", "..\Raven.Tes
 EndProject
 Project("{FAE04EC0-301F-11D3-BF4B-00C04F79EFBC}") = "Raven.Client.IndexedProperties", "Raven.Client.IndexedProperties\Raven.Client.IndexedProperties.csproj", "{F41C7F7E-A287-449A-A545-E7152937EF77}"
 EndProject
+Project("{FAE04EC0-301F-11D3-BF4B-00C04F79EFBC}") = "Raven.Client.Debug", "..\Raven.Client.Debug\Raven.Client.Debug.csproj", "{27153214-4630-4E2D-9807-0D5352687DD5}"
+EndProject
 Global
 	GlobalSection(SolutionConfigurationPlatforms) = preSolution
 		Debug|Any CPU = Debug|Any CPU
@@ -365,6 +367,16 @@ Global
 		{F41C7F7E-A287-449A-A545-E7152937EF77}.Release|Mixed Platforms.ActiveCfg = Release|Any CPU
 		{F41C7F7E-A287-449A-A545-E7152937EF77}.Release|Mixed Platforms.Build.0 = Release|Any CPU
 		{F41C7F7E-A287-449A-A545-E7152937EF77}.Release|x86.ActiveCfg = Release|Any CPU
+		{27153214-4630-4E2D-9807-0D5352687DD5}.Debug|Any CPU.ActiveCfg = Debug|Any CPU
+		{27153214-4630-4E2D-9807-0D5352687DD5}.Debug|Any CPU.Build.0 = Debug|Any CPU
+		{27153214-4630-4E2D-9807-0D5352687DD5}.Debug|Mixed Platforms.ActiveCfg = Debug|Any CPU
+		{27153214-4630-4E2D-9807-0D5352687DD5}.Debug|Mixed Platforms.Build.0 = Debug|Any CPU
+		{27153214-4630-4E2D-9807-0D5352687DD5}.Debug|x86.ActiveCfg = Debug|Any CPU
+		{27153214-4630-4E2D-9807-0D5352687DD5}.Release|Any CPU.ActiveCfg = Release|Any CPU
+		{27153214-4630-4E2D-9807-0D5352687DD5}.Release|Any CPU.Build.0 = Release|Any CPU
+		{27153214-4630-4E2D-9807-0D5352687DD5}.Release|Mixed Platforms.ActiveCfg = Release|Any CPU
+		{27153214-4630-4E2D-9807-0D5352687DD5}.Release|Mixed Platforms.Build.0 = Release|Any CPU
+		{27153214-4630-4E2D-9807-0D5352687DD5}.Release|x86.ActiveCfg = Release|Any CPU
 	EndGlobalSection
 	GlobalSection(SolutionProperties) = preSolution
 		HideSolutionNode = FALSE
@@ -380,5 +392,6 @@ Global
 		{486537C2-EDF7-404F-9CFB-EEE25996DF5F} = {86C266B7-8898-452C-AA95-4CCB81C382B7}
 		{3E6401AC-3E33-4B61-A460-49953654A207} = {86C266B7-8898-452C-AA95-4CCB81C382B7}
 		{267AC60C-751E-42E9-AA18-66035DEFF63A} = {86C266B7-8898-452C-AA95-4CCB81C382B7}
+		{27153214-4630-4E2D-9807-0D5352687DD5} = {86C266B7-8898-452C-AA95-4CCB81C382B7}
 	EndGlobalSection
 EndGlobal


### PR DESCRIPTION
To allow correct compilation of Ranven.Bundles solution we must add the
project Raven.Client.Debug. If not, Raven.Tests fails on compilation.
