### PR TITLE
Adding LongCount method support to LINQ provider

### DIFF
--- a/Raven.Client.Lightweight/Linq/RavenQueryProviderProcessor.cs
+++ b/Raven.Client.Lightweight/Linq/RavenQueryProviderProcessor.cs
@@ -899,6 +899,17 @@ The recommended method is to use full text search (mark the field as Analyzed an
 						VisitCount();
 						break;
 					}
+				case "LongCount":
+					{
+						VisitExpression(expression.Arguments[0]);
+						if (expression.Arguments.Count == 2)
+						{
+							VisitExpression(((UnaryExpression)expression.Arguments[1]).Operand);
+						}
+
+						VisitLongCount();
+						break;
+					}
 				case "Distinct":
 					luceneQuery.GroupBy(AggregationOperation.Distinct);
 					VisitExpression(expression.Arguments[0]);
@@ -1053,6 +1064,12 @@ The recommended method is to use full text search (mark the field as Analyzed an
 		{
 			luceneQuery.Take(1);
 			queryType = SpecialQueryType.Count;
+		}
+
+		private void VisitLongCount()
+		{
+			luceneQuery.Take(1);
+			queryType = SpecialQueryType.LongCount;
 		}
 
 		private void VisitSingle()
@@ -1341,8 +1358,17 @@ The recommended method is to use full text search (mark the field as Analyzed an
 						var queryResultAsync = finalQuery.QueryResult;
 						return queryResultAsync.TotalResults;
 					}
+				case SpecialQueryType.LongCount:
+					{
+						var queryResultAsync = finalQuery.QueryResult;
+						return (long)queryResultAsync.TotalResults;
+					}
 #else
 				case SpecialQueryType.Count:
+					{
+						throw new NotImplementedException("not done yet");
+					}
+				case SpecialQueryType.LongCount:
 					{
 						throw new NotImplementedException("not done yet");
 					}
@@ -1378,6 +1404,10 @@ The recommended method is to use full text search (mark the field as Analyzed an
 			/// </summary>
 			Count,
 			/// <summary>
+			/// Get count of items for the query as an Int64
+			/// </summary>
+			LongCount,
+			/// <summary>
 			/// Get only the first item
 			/// </summary>
 			First,
@@ -1392,7 +1422,7 @@ The recommended method is to use full text search (mark the field as Analyzed an
 			/// <summary>
 			/// Get only the first item (or throw if there are more than one) or null if empty
 			/// </summary>
-			SingleOrDefault
+			SingleOrDefault,
 		}
 
 		#endregion

--- a/Raven.Tests/Linq/LongCount.cs
+++ b/Raven.Tests/Linq/LongCount.cs
@@ -1,0 +1,40 @@
+﻿// -----------------------------------------------------------------------
+//  <copyright file="LongCount.cs" company="Hibernating Rhinos LTD">
+//      Copyright (c) Hibernating Rhinos LTD. All rights reserved.
+//  </copyright>
+// -----------------------------------------------------------------------
+namespace Raven.Tests.Linq
+{
+	using Raven.Abstractions;
+	using System;
+	using System.Linq;
+	using Xunit;
+
+	public class LongCount : LocalClientTest
+	{
+		private class TestDoc
+		{
+			public string Name { get; set; }
+		}
+
+		[Fact]
+		public void CanQueryLongCount()
+		{
+			using (var store = NewDocumentStore())
+			{
+				using (var session = store.OpenSession())
+				{
+					var doc = new TestDoc { Name = "foo" };
+					session.Store(doc);
+					session.SaveChanges();
+				}
+
+				using (var session = store.OpenSession())
+				{
+					long count = session.Query<TestDoc>().LongCount();
+					Assert.Equal(1, count);
+				}
+			}
+		}
+	}
+}

--- a/Raven.Tests/Raven.Tests.csproj
+++ b/Raven.Tests/Raven.Tests.csproj
@@ -552,6 +552,7 @@
     <Compile Include="Issues\RavenDB_301.cs" />
     <Compile Include="Issues\RavenDB_302.cs" />
     <Compile Include="Issues\Ravendb_334.cs" />
+    <Compile Include="Linq\LongCount.cs" />
     <Compile Include="MailingList\AccesscControlHeaders.cs" />
     <Compile Include="MailingList\Ben.cs" />
     <Compile Include="MailingList\BrianVallelunga.cs" />


### PR DESCRIPTION
Not that I have this many docs, but the default OData DataService implementation executes LongCount and not Count 
