### PR TITLE
Failing test of handling of string and value type Ids 

### DIFF
--- a/Raven.Tests/Bugs/Queries/Includes.cs
+++ b/Raven.Tests/Bugs/Queries/Includes.cs
@@ -3,6 +3,7 @@
 //     Copyright (c) Hibernating Rhinos LTD. All rights reserved.
 // </copyright>
 //-----------------------------------------------------------------------
+using System;
 using Raven.Client.Document;
 using Xunit;
 
@@ -13,12 +14,12 @@ namespace Raven.Tests.Bugs.Queries
 		[Fact]
 		public void CanIncludeViaNestedPath()
 		{
-			using(GetNewServer())
-			using(var store = new DocumentStore{Url = "http://localhost:8079"}.Initialize())
+			using (GetNewServer())
+			using (var store = new DocumentStore { Url = "http://localhost:8079" }.Initialize())
 			{
-				using(var s = store.OpenSession())
+				using (var s = store.OpenSession())
 				{
-					s.Store(new User{Name = "Ayende"});
+					s.Store(new User { Name = "Ayende" });
 					s.Store(new User
 					{
 						Name = "Rahien",
@@ -45,17 +46,111 @@ namespace Raven.Tests.Bugs.Queries
 			}
 		}
 
+		[Fact]
+		public void CanIncludeViaLinq()
+		{
+			using (GetNewServer())
+			using (var store = new DocumentStore { Url = "http://localhost:8079" }.Initialize())
+			{
+				using (var s = store.OpenSession())
+				{
+					s.Store(new Person { Name = "Stuart", PhoneNumber = "55567453" });
+					s.Store(new User
+					{
+						Name = "Piers",
+						EmergencyPerson = new EmergencyContact { PersonId = "1", Relationship = "Father" }
+					});
+
+					s.SaveChanges();
+				}
+
+				using (var s = store.OpenSession())
+				{
+					var user = s.Include<User, Person>(u => u.EmergencyPerson.PersonId).Load<User>("users/1");
+					Assert.NotNull(user.EmergencyPerson);
+
+					// Should be loaded from cache
+					var emergencyContact = s.Load<Person>(user.EmergencyPerson.PersonId);
+					Assert.NotNull(emergencyContact);
+
+					Assert.Equal(1, s.Advanced.NumberOfRequests);
+				}
+			}
+		}
+
+		[Fact]
+		public void CanIncludeViaLinqWithValueTypeId()
+		{
+			using (GetNewServer())
+			using (var store = new DocumentStore { Url = "http://localhost:8079" }.Initialize())
+			{
+				using (var s = store.OpenSession())
+				{
+					var personId = Guid.NewGuid();
+
+					s.Store(new PersonGuid { Id = personId, Name = "Stuart", PhoneNumber = "55567453" });
+					s.Store(new User
+					{
+						Name = "Piers",
+						EmergencyPersonByGuid = new EmergencyContactGuid { PersonId = personId, Relationship = "Father" }
+					});
+
+					s.SaveChanges();
+				}
+
+				using (var s = store.OpenSession())
+				{
+					var user = s.Include<User, PersonGuid>(u => u.EmergencyPersonByGuid.PersonId).Load<User>("users/1");
+					Assert.NotNull(user.EmergencyPersonByGuid);
+
+					// Should be loaded from cache
+					var emergencyContact = s.Load<PersonGuid>(user.EmergencyPersonByGuid.PersonId);
+					Assert.NotNull(emergencyContact);
+
+					Assert.Equal(1, s.Advanced.NumberOfRequests);
+				}
+			}
+		}
+
 		public class User
 		{
 			public string Id { get; set; }
 			public string Name { get; set; }
 			public DenormalizedReference[] Friends { get; set; }
+			public EmergencyContact EmergencyPerson { get; set; }
+			public EmergencyContactGuid EmergencyPersonByGuid { get; set; }
 		}
 
 		public class DenormalizedReference
 		{
 			public string Id { get; set; }
 			public string Name { get; set; }
+		}
+
+		public class Person
+		{
+			public string Id { get; set; }
+			public string Name { get; set; }
+			public string PhoneNumber { get; set; }
+		}
+
+		public class EmergencyContact
+		{
+			public string PersonId { get; set; }
+			public string Relationship { get; set; }
+		}
+
+		public class PersonGuid
+		{
+			public Guid Id { get; set; }
+			public string Name { get; set; }
+			public string PhoneNumber { get; set; }
+		}
+
+		public class EmergencyContactGuid
+		{
+			public Guid PersonId { get; set; }
+			public string Relationship { get; set; }
 		}
 	}
 }


### PR DESCRIPTION
In this [thread](https://groups.google.com/forum/?fromgroups#!topic/ravendb/1gNqNW26bhk) I describe how I thought how the Include via Linq and Load via Linq operations seemed contradictory in how they treated a string based Id.

On further investigation I convinced myself I had just misunderstood how to use string based Ids. Oren thought it might be a bug and asked me to reproduce it in a failing test. I have added one test that passes
becuase it is using value type Ids and one that fails because it is using string based Ids.

I'm still fairly sure thsi must be how it has to be, and if it was to change, wouldn't that be a big breaking change?
