### PR TITLE
Per this discussion on the google group: https://groups.google.com/d/topic/ravendb/FrwYvsV_Kc0/discussion

### DIFF
--- a/Raven.Abstractions/Json/Linq/RavenJTokenWriter.cs
+++ b/Raven.Abstractions/Json/Linq/RavenJTokenWriter.cs
@@ -373,5 +373,29 @@ namespace Raven.Json.Linq
 		}
 		
 		#endregion
+
+		#region Unsupported Write methods
+
+		/// <summary>
+		/// Overrides the WriteRaw method of <see cref="JsonWriter"/> which is not supported.
+		/// </summary>
+		/// <param name="json">The json to write</param>
+		/// <exception cref="NotSupportedException">always</exception>
+		public override void WriteRaw(string json)
+		{
+			throw new NotSupportedException("Writing raw json is not supported.");
+		}
+
+		/// <summary>
+		/// Overrides the WriteRawValue method of <see cref="JsonWriter"/> which is not supported.
+		/// </summary>
+		/// <param name="json">The json to write</param>
+		/// <exception cref="NotSupportedException">always</exception>
+		public override void WriteRawValue(string json)
+		{
+			throw new NotSupportedException("Writing raw json is not supported.");
+		}
+
+		#endregion
 	}
 }


### PR DESCRIPTION
Overriding these methods of JsonWriter to throw NotSupportedException.
If a client implemented a custom JsonConverter using either their object
would fail to save from a later NullReferenceException. This makes it
clear that these methods are not supported.
