### PR TITLE
Only clear console when stdin / stdout are not redirected

### DIFF
--- a/Raven.Server/ConsoleEx.cs
+++ b/Raven.Server/ConsoleEx.cs
@@ -1,0 +1,67 @@
+﻿using System;
+using System.Runtime.InteropServices;
+
+namespace Raven.Server
+{
+
+	/// <summary>
+	/// Checks for redirected output before clearing
+	/// </summary>
+	/// <remarks>
+	/// Original Source: http://stackoverflow.com/a/3453272/837001
+	/// </remarks>
+	public static class ConsoleEx
+	{
+		private static bool IsOutputRedirected
+		{
+			get
+			{
+				return FileType.Char != GetFileType(GetStdHandle(StdHandle.Stdout));
+			}
+		}
+		private static bool IsInputRedirected
+		{
+			get
+			{
+				return FileType.Char != GetFileType(GetStdHandle(StdHandle.Stdin));
+			}
+		}
+		private static bool IsErrorRedirected
+		{
+			get
+			{
+				return FileType.Char != GetFileType(GetStdHandle(StdHandle.Stderr));
+			}
+		}
+
+		public static void ClearIfNotRedirected()
+		{
+			if (!IsOutputRedirected && !IsInputRedirected && !IsErrorRedirected)
+				Console.Clear();
+		}
+
+		// P/Invoke:
+		private enum FileType
+		{
+			Unknown,
+			Disk,
+			Char,
+			Pipe
+		};
+
+		private enum StdHandle
+		{
+			Stdin = -10,
+			Stdout = -11,
+			Stderr = -12
+		};
+
+		[DllImport("kernel32.dll")]
+		private static extern FileType GetFileType(IntPtr hdl);
+
+		[DllImport("kernel32.dll")]
+		private static extern IntPtr GetStdHandle(StdHandle std);
+
+	}
+
+}

--- a/Raven.Server/Program.cs
+++ b/Raven.Server/Program.cs
@@ -302,11 +302,11 @@ Configuration options:
 			bool? done = null;
 			var actions = new Dictionary<string,Action>
 			{
-				{"cls", () => Console.Clear()},
+				{"cls", () => ConsoleEx.ClearIfNotRedirected()},
 				{
 					"reset", () =>
 					{
-						Console.Clear();
+						ConsoleEx.ClearIfNotRedirected();
 						done = true;
 					}
 					},

--- a/Raven.Server/Raven.Server.csproj
+++ b/Raven.Server/Raven.Server.csproj
@@ -110,6 +110,7 @@
     <Compile Include="..\Raven.Smuggler\SmugglerApi.cs">
       <Link>Smuggler\SmugglerApi.cs</Link>
     </Compile>
+    <Compile Include="ConsoleEx.cs" />
     <Compile Include="FromMono\Options.cs" />
     <Compile Include="RavenDbServer.cs" />
     <Compile Include="Program.cs" />


### PR DESCRIPTION
Fixes "Handle is invalid" when calling Console.Clear while stdin / stdout are redirected. 

_Relies on call to Kernel32. This won't make the Mono crowd happy. Sorry._
