### PR TITLE
Setting recovery windows service fails if service-name not equal to RavenDB

### DIFF
--- a/Raven.Server/Program.cs
+++ b/Raven.Server/Program.cs
@@ -435,7 +435,7 @@ Enjoy...
 			else
 			{
 				ManagedInstallerClass.InstallHelper(new[] { Assembly.GetExecutingAssembly().Location });
-				SetRecoveryOptions("RavenDB");
+				SetRecoveryOptions(ProjectInstaller.SERVICE_NAME);
 				var startController = new ServiceController(ProjectInstaller.SERVICE_NAME);
 				startController.Start();
 			}


### PR DESCRIPTION
Here is the error:

```
c:\Program Files\RavenDB>Raven.Server.exe -install --service-name=SuperRaven

Running a transacted installation.

Beginning the Install phase of the installation.
See the contents of the log file for the c:\Program Files\RavenDB\Raven.Server.e
xe assembly's progress.
The file is located at c:\Program Files\RavenDB\Raven.Server.InstallLog.
Installing assembly 'c:\Program Files\RavenDB\Raven.Server.exe'.
Affected parameters are:
   logtoconsole =
   assemblypath = c:\Program Files\RavenDB\Raven.Server.exe
   logfile = c:\Program Files\RavenDB\Raven.Server.InstallLog
Installing service SuperRaven...
Service SuperRaven has been successfully installed.
Creating EventLog source SuperRaven in log Application...

The Install phase completed successfully, and the Commit phase is beginning.
See the contents of the log file for the c:\Program Files\RavenDB\Raven.Server.e
xe assembly's progress.
The file is located at c:\Program Files\RavenDB\Raven.Server.InstallLog.
Committing assembly 'c:\Program Files\RavenDB\Raven.Server.exe'.
Affected parameters are:
   logtoconsole =
   assemblypath = c:\Program Files\RavenDB\Raven.Server.exe
   logfile = c:\Program Files\RavenDB\Raven.Server.InstallLog

The Commit phase completed successfully.

The transacted install has completed.
A critical error occurred while starting the server. Please see the exception de
tails bellow for more details:
System.InvalidOperationException: Failed to set the service recovery policy. Com
mand:
sc failure RavenDB reset= 500 actions= restart/60000
Exit code: 1060
   at Raven.Server.Program.SetRecoveryOptions(String serviceName)
   at Raven.Server.Program.InstallAndStart()
   at Raven.Server.Program.InteractiveRun(String[] args)
   at Raven.Server.Program.Main(String[] args)
Press any key to continue...
```
