### PR TITLE
LoadByUniqueConstraint now also accepts UnaryExpression as keySelector parameter

### DIFF
--- a/Bundles/Raven.Client.UniqueConstraints/UniqueConstraintExtensions.cs
+++ b/Bundles/Raven.Client.UniqueConstraints/UniqueConstraintExtensions.cs
@@ -18,7 +18,16 @@
 		public static T LoadByUniqueConstraint<T>(this IDocumentSession session, Expression<Func<T, object>> keySelector, object value)
 		{
 			var typeName = session.Advanced.DocumentStore.Conventions.GetTypeTagName(typeof(T));
-			var body = (MemberExpression)keySelector.Body;
+			MemberExpression body;
+			if (keySelector.Body is MemberExpression)
+			{
+				body = ((MemberExpression)keySelector.Body);
+			}
+			else
+			{
+				var op = ((UnaryExpression)keySelector.Body).Operand;
+				body = ((MemberExpression)op);
+			}
 			var propertyName = body.Member.Name;
 
 			var constraintDoc = session.Include("Id").Load<ConstraintDocument>("UniqueConstraints/" + typeName.ToLowerInvariant() + "/" + propertyName.ToLowerInvariant() + "/" + value);


### PR DESCRIPTION
If you use the LoadByUniqueConstraint ExtensionMethod as described in
the documentation:

var existingUser = session.LoadByUniqueConstraint<User>(x => x.Email, "john@gmail.com");

The keySelector.Body will evaluate to a UnaryExpression resulting in an exception. 

This change introduces a check for this so that either a MemberExpression or UnaryExpression will work
