### PR TITLE
Creating the index Raven/DocumentsByEntityName when executing EnsureDatabaseExist. Fixing bug with the EnsureDatabaseExistAsync and CreateDatabaseAsync the parameters of the AsyncServerClient.CreateRequest were in the wrong order

### DIFF
--- a/Raven.Tests/Bugs/MultiTenancy/Basic.cs
+++ b/Raven.Tests/Bugs/MultiTenancy/Basic.cs
@@ -15,6 +15,7 @@ using Raven.Server;
 using Xunit;
 using Raven.Client.Extensions;
 using System.Linq;
+using System.Threading.Tasks;
 
 namespace Raven.Tests.Bugs.MultiTenancy
 {
@@ -205,6 +206,41 @@ namespace Raven.Tests.Bugs.MultiTenancy
 				{
 					Assert.NotNull(s.Load<User>(userId));
 				}
+			}
+		}
+
+		[Fact]
+		public void RavenDocumentsByEntityNameIndexCreated()
+		{
+			using (GetNewServer(8079))
+			using (var store = new DocumentStore
+			{
+				Url = "http://localhost:8079"
+			}.Initialize())
+			{
+				store.DatabaseCommands.EnsureDatabaseExists("Northwind");
+				var index = store.DatabaseCommands.ForDatabase("Northwind").GetIndex("Raven/DocumentsByEntityName");
+				Assert.NotNull(index);
+			}
+		}
+
+		[Fact]
+		public void RavenDocumentsByEntityNameIndexCreatedAsync()
+		{
+			using (GetNewServer(8079))
+			using (var store = new DocumentStore
+			{
+				Url = "http://localhost:8079"
+			}.Initialize())
+			{
+				 Task task = store.AsyncDatabaseCommands.EnsureDatabaseExistsAsync("Northwind").ContinueWith(x =>
+ 				{
+					var index = store.DatabaseCommands.ForDatabase("Northwind").GetIndex("Raven/DocumentsByEntityName");
+					Assert.NotNull(index);
+ 				});
+ 
+ 				task.Wait();
+
 			}
 		}
 


### PR DESCRIPTION
When executing EnsureDatabaseExist the index Raven/DocumentsByEntityName
were not created. And that caused and error in the studio. I had to stop
and start the server and the index will be created automatically. So I
added the index in the EnsureDatabaseExist extension method.

Another thing
ServerClient and AsyncServerClient have the method CreateRequest but the
signature are different in the order of the parameters
(requestUrl,method)

So the EnsureDatabaseExistsAsync and CreateDatabaseAsync methods in
MultiTenancyExtensions just didn't work just changed the order of the
parameters
