### PR TITLE
Include attachments when exporting database (optional).

### DIFF
--- a/Raven.Studio/Commands/BackupCommand.cs
+++ b/Raven.Studio/Commands/BackupCommand.cs
@@ -35,7 +35,7 @@ namespace Raven.Studio.Commands
 					var databaseDocument = ApplicationModel.Current.Server.Value.DocumentStore.Conventions.CreateSerializer()
 						.Deserialize<DatabaseDocument>(new RavenJTokenReader(doc));
 
-					DatabaseCommands.StartBackupAsync(location.Value, databaseDocument)
+					DatabaseCommands.StartBackupAsync(location.Value.ToString(), databaseDocument)
 						.ContinueWith(task =>
 						{
 							task.Wait(); // throws

--- a/Raven.Studio/Commands/ExportDatabaseCommand.cs
+++ b/Raven.Studio/Commands/ExportDatabaseCommand.cs
@@ -24,6 +24,7 @@ namespace Raven.Studio.Commands
 		private StreamWriter streamWriter;
 		private JsonTextWriter jsonWriter;
 		private TaskModel taskModel;
+	    private bool includeAttachments;
 
 		public ExportDatabaseCommand(TaskModel taskModel, Action<string> output)
 		{
@@ -33,6 +34,9 @@ namespace Raven.Studio.Commands
 
 		public override void Execute(object parameter)
 		{
+            TaskCheckBox attachmentUI = taskModel.TaskInputs.FirstOrDefault(x => x.Name == "Include Attachments") as TaskCheckBox;
+            includeAttachments = attachmentUI != null && attachmentUI.Value;
+
 			var saveFile = new SaveFileDialog
 			{
 				DefaultExt = ".ravendump",
@@ -61,89 +65,158 @@ namespace Raven.Studio.Commands
 				Formatting = Formatting.Indented
 			};
 			taskModel.TaskStatus = TaskStatus.Started;
+
 			output(String.Format("Exporting to {0}", saveFile.SafeFileName));
-
-			output("Begin reading indexes");
-
 			jsonWriter.WriteStartObject();
-			jsonWriter.WritePropertyName("Indexes");
-			jsonWriter.WriteStartArray();
 
-			ReadIndexes(0)
-				.Catch(exception =>
-				{
-					taskModel.ReportError(exception);
-					Infrastructure.Execute.OnTheUI(() => Finish(exception));
-				});
+		    Action finalized = () => 
+            {
+                jsonWriter.WriteEndObject();
+                Infrastructure.Execute.OnTheUI(() => Finish(null));
+		    };
+
+		    Action readAttachments = () => ReadAttachments(Guid.Empty, 0, callback: finalized);
+		    Action readDocuments = () => ReadDocuments(Guid.Empty, 0, callback: includeAttachments ? readAttachments : finalized);
+
+            try
+            {
+                ReadIndexes(0, callback: readDocuments);
+            }
+            catch (Exception ex)
+            {
+                taskModel.ReportError(ex);
+				Infrastructure.Execute.OnTheUI(() => Finish(ex));
+            }
 		}
 
-		private Task ReadIndexes(int totalCount)
+		private void ReadIndexes(int totalCount, Action callback)
 		{
+            if (totalCount == 0)
+            {
+                output("Begin reading indexes");
+                jsonWriter.WritePropertyName("Indexes");
+                jsonWriter.WriteStartArray();    
+            }
+            
 			var url = ("/indexes/?start=" + totalCount + "&pageSize=" + BatchSize).NoCache();
 			var request = DatabaseCommands.CreateRequest(url, "GET");
-			return request.ReadResponseJsonAsync()
-			              .ContinueOnSuccess(documents =>
-			              {
-				              var array = ((RavenJArray) documents);
-				              if (array.Length == 0)
-				              {
-					              output(String.Format("Done with reading indexes, total: {0}", totalCount));
-					              output(String.Format("Begin reading documents"));
+		    request.ReadResponseJsonAsync()
+		           .ContinueOnSuccess(documents =>
+		           {
+		               var array = ((RavenJArray) documents);
+		               if (array.Length == 0)
+		               {
+		                   output(String.Format("Done with reading indexes, total: {0}", totalCount));
+		                   jsonWriter.WriteEndArray();
 
-					              jsonWriter.WriteEndArray();
-					              jsonWriter.WritePropertyName("Docs");
-					              jsonWriter.WriteStartArray();
+		                   callback();
+		               }
+		               else
+		               {
+		                   totalCount += array.Length;
+		                   output(String.Format("Reading batch of {0,3} indexes, read so far: {1,10:#,#;;0}", array.Length,
+		                                        totalCount));
+		                   foreach (RavenJToken item in array)
+		                   {
+		                       item.WriteTo(jsonWriter);
+		                   }
 
-					              return ReadDocuments(Guid.Empty, 0);
-				              }
-				              else
-				              {
-					              totalCount += array.Length;
-					              output(String.Format("Reading batch of {0,3} indexes, read so far: {1,10:#,#;;0}", array.Length,
-					                                   totalCount));
-					              foreach (RavenJToken item in array)
-					              {
-						              item.WriteTo(jsonWriter);
-					              }
-
-					              return ReadIndexes(totalCount);
-				              }
-			              })
-			              .Catch(exception => taskModel.ReportError(exception));
+		                   ReadIndexes(totalCount, callback);
+		               }
+		           });
 		}
 
-		private Task ReadDocuments(Guid lastEtag, int totalCount)
+		private void ReadDocuments(Guid lastEtag, int totalCount, Action callback)
 		{
+            if (totalCount == 0)
+            {
+                output("Begin reading documents");
+
+                jsonWriter.WritePropertyName("Docs");
+                jsonWriter.WriteStartArray();
+            }
+
 			var url = ("/docs/?pageSize=" + BatchSize + "&etag=" + lastEtag).NoCache();
 			var request = DatabaseCommands.CreateRequest(url, "GET");
-			return request.ReadResponseJsonAsync()
-			              .ContinueOnSuccess(docs =>
-			              {
-				              var array = ((RavenJArray) docs);
-				              if (array.Length == 0)
-				              {
-					              output(String.Format("Done with reading documents, total: {0}", totalCount));
-					              jsonWriter.WriteEndArray();
-					              jsonWriter.WriteEndObject();
+		    request.ReadResponseJsonAsync()
+		           .ContinueOnSuccess(docs =>
+		           {
+		               var array = ((RavenJArray) docs);
+		               if (array.Length == 0)
+		               {
+		                   output(String.Format("Done with reading documents, total: {0}", totalCount));
+                           jsonWriter.WriteEndArray();
 
-					              return Infrastructure.Execute.OnTheUI(() => Finish(null));
-				              }
-				              else
-				              {
-					              totalCount += array.Length;
-					              output(String.Format("Reading batch of {0,3} documents, read so far: {1,10:#,#;;0}", array.Length,
-					                                   totalCount));
-					              foreach (RavenJToken item in array)
-					              {
-						              item.WriteTo(jsonWriter);
-					              }
-					              lastEtag = new Guid(array.Last().Value<RavenJObject>("@metadata").Value<string>("@etag"));
+		                   callback();
+		               }
+		               else
+		               {
+		                   totalCount += array.Length;
+		                   output(String.Format("Reading batch of {0,3} documents, read so far: {1,10:#,#;;0}", array.Length,
+		                                        totalCount));
+		                   foreach (RavenJToken item in array)
+		                   {
+		                       item.WriteTo(jsonWriter);
+		                   }
+		                   lastEtag = new Guid(array.Last().Value<RavenJObject>("@metadata").Value<string>("@etag"));
 
-					              return ReadDocuments(lastEtag, totalCount);
-				              }
-			              })
-			              .Catch(exception => taskModel.ReportError(exception));
+                           ReadDocuments(lastEtag, totalCount, callback);
+		               }
+		           });
 		}
+
+        private void ReadAttachments(Guid lastEtag, int totalCount, Action callback) {
+            if (totalCount == 0)
+            {
+                output("Begin reading attachments");
+
+                jsonWriter.WritePropertyName("Attachments");
+                jsonWriter.WriteStartArray();
+            }
+
+            var url = ("/static/?pageSize=" + BatchSize + "&etag=" + lastEtag).NoCache();
+            var request = DatabaseCommands.CreateRequest(url, "GET");
+            request.ReadResponseJsonAsync()
+                   .ContinueOnSuccess(attachments =>
+                   {
+                       var array = ((RavenJArray) attachments);
+                       if (array.Length == 0)
+                       {
+                           output(String.Format("Done with reading attachments, total: {0}", totalCount));
+                           jsonWriter.WriteEndArray();
+
+                           callback();
+                       }
+                       else
+                       {
+                           totalCount += array.Length;
+                           output(String.Format(
+                               "Reading batch of {0,3} attachments, read so far: {1,10:#,#;;0}", array.Length,
+                               totalCount));
+
+                           foreach (var item in array)
+                           {
+                               output(String.Format("Downloading attachment: {0}", item.Value<string>("Key")));
+
+                               var requestData = DatabaseCommands.CreateRequest("/static/" + item.Value<string>("Key"),
+                                                                                "GET");
+                               requestData.ReadResponseBytesAsync()
+                                          .ContinueOnSuccess(attachmentData =>
+                                          {
+                                              new RavenJObject
+                                              {
+                                                  {"Data", attachmentData},
+                                                  {"Metadata", item.Value<RavenJObject>("Metadata")},
+                                                  {"Key", item.Value<string>("Key")}
+                                              }.WriteTo(jsonWriter);
+                                          });
+                           }
+                       }
+
+                       lastEtag = new Guid(array.Last().Value<string>("Etag"));
+                       ReadAttachments(lastEtag, totalCount, callback);
+                   });
+        }
 
 		private void Finish(Exception exception)
 		{

--- a/Raven.Studio/Commands/RestoreCommand.cs
+++ b/Raven.Studio/Commands/RestoreCommand.cs
@@ -30,7 +30,7 @@ namespace Raven.Studio.Commands
 			DatabaseCommands.ForSystemDatabase().DeleteDocumentAsync("Raven/Restore/Status")
 			                .ContinueOnSuccessInTheUIThread(() =>
 			                {
-				                DatabaseCommands.StartRestoreAsync(backupLocation.Value, databaseLocation.Value, name.Value).Catch();
+				                DatabaseCommands.StartRestoreAsync(backupLocation.Value.ToString(), databaseLocation.Value.ToString(), name.Value.ToString()).Catch();
 				                failCount = 0;
 				                UpdateStatus();
 			                });

--- a/Raven.Studio/Features/Tasks/ExportTask.cs
+++ b/Raven.Studio/Features/Tasks/ExportTask.cs
@@ -12,6 +12,8 @@ namespace Raven.Studio.Features.Tasks
 			Name = "Export Database";
 		    IconResource = "Image_Export_Tiny";
 			Description = "Export your database to a dump file. Both indexes and documents are exported.";
+
+            TaskInputs.Add(new TaskCheckBox("Include Attachments", false));
 		}
 
 		public override ICommand Action

--- a/Raven.Studio/Features/Tasks/TaskView.xaml
+++ b/Raven.Studio/Features/Tasks/TaskView.xaml
@@ -5,6 +5,9 @@
                          xmlns:mc="http://schemas.openxmlformats.org/markup-compatibility/2006"
                          mc:Ignorable="d" d:DesignWidth="640" d:DesignHeight="480"
                          xmlns:Infrastructure="clr-namespace:Raven.Studio.Infrastructure"
+                         xmlns:models="clr-namespace:Raven.Studio.Models"
+                         xmlns:system="clr-namespace:System;assembly=mscorlib"
+                         xmlns:local="clr-namespace:Raven.Studio.Infrastructure.TemplateSelectors"
                          Title="TaskView Page"
                          DataContext="{Binding Path=SelectedTask.Value}">
 
@@ -23,22 +26,43 @@
 		<StackPanel Grid.Row="1">
 			<ItemsControl ItemsSource="{Binding TaskInputs}">
 				<ItemsControl.ItemTemplate>
-					<DataTemplate>
-						<Grid>
-							<Grid.ColumnDefinitions>
-								<ColumnDefinition Width="Auto"/>
-								<ColumnDefinition Width="Auto"/>
-							</Grid.ColumnDefinitions>
-							<TextBlock Grid.Column="0" Text="{Binding Name}"
+                    <DataTemplate>
+                        <local:TaskUITemplateSelector Content="{Binding}">
+                            <local:TaskUITemplateSelector.Input>
+                                <DataTemplate>
+                                    <Grid>
+                                        <Grid.ColumnDefinitions>
+                                            <ColumnDefinition Width="Auto"/>
+                                            <ColumnDefinition Width="Auto"/>
+                                        </Grid.ColumnDefinitions>
+                                        <TextBlock Grid.Column="0" Text="{Binding Name}"
 									   Width="{Binding DataContext.LongestInput, RelativeSource={RelativeSource AncestorType=Infrastructure:PageView}}"
 									   Padding="5"
 									   VerticalAlignment="Center" />
-							<TextBox Grid.Column="1" Text="{Binding Value, Mode=TwoWay}"
+                                        <TextBox Grid.Column="1" Text="{Binding Value, Mode=TwoWay}"
 									 VerticalAlignment="Center"
 									 Margin="5"
 									 MinWidth="150" />
-						</Grid>
-					</DataTemplate>
+                                    </Grid>
+                                </DataTemplate>
+                            </local:TaskUITemplateSelector.Input>
+                            <local:TaskUITemplateSelector.CheckBox>
+                                <DataTemplate>
+                                    <Grid>
+                                        <Grid.ColumnDefinitions>
+                                            <ColumnDefinition Width="Auto"/>
+                                            <ColumnDefinition Width="Auto"/>
+                                        </Grid.ColumnDefinitions>
+                                        <CheckBox Grid.Column="0" IsChecked="{Binding Value, Mode=TwoWay}" VerticalAlignment="Center" Margin="5"></CheckBox>
+                                        <TextBlock Grid.Column="1" Text="{Binding Name}"
+									   Width="{Binding DataContext.LongestInput, RelativeSource={RelativeSource AncestorType=Infrastructure:PageView}}"
+									   Padding="5"
+									   VerticalAlignment="Center" />
+                                    </Grid>
+                                </DataTemplate>
+                            </local:TaskUITemplateSelector.CheckBox>
+                        </local:TaskUITemplateSelector>
+                    </DataTemplate>
 				</ItemsControl.ItemTemplate>
 			</ItemsControl>
 

--- a/Raven.Studio/Infrastructure/TemplateSelectors/DataTemplateSelector.cs
+++ b/Raven.Studio/Infrastructure/TemplateSelectors/DataTemplateSelector.cs
@@ -1,0 +1,28 @@
+﻿using System;
+using System.Net;
+using System.Windows;
+using System.Windows.Controls;
+using System.Windows.Documents;
+using System.Windows.Ink;
+using System.Windows.Input;
+using System.Windows.Media;
+using System.Windows.Media.Animation;
+using System.Windows.Shapes;
+
+namespace Raven.Studio.Infrastructure.TemplateSelectors 
+{
+    public abstract class DataTemplateSelector : ContentControl
+    {
+        public virtual DataTemplate SelectTemplate(object item, DependencyObject container)
+        {
+            return null;
+        }
+
+        protected override void OnContentChanged(object oldContent, object newContent)
+        {
+            base.OnContentChanged(oldContent, newContent);
+
+            ContentTemplate = SelectTemplate(newContent, this);
+        }
+    }
+}

--- a/Raven.Studio/Infrastructure/TemplateSelectors/TaskUITemplateSelector.cs
+++ b/Raven.Studio/Infrastructure/TemplateSelectors/TaskUITemplateSelector.cs
@@ -1,0 +1,28 @@
+﻿using System;
+using System.Net;
+using System.Windows;
+using System.Windows.Controls;
+using System.Windows.Documents;
+using System.Windows.Ink;
+using System.Windows.Input;
+using System.Windows.Media;
+using System.Windows.Media.Animation;
+using System.Windows.Shapes;
+using Raven.Studio.Models;
+
+namespace Raven.Studio.Infrastructure.TemplateSelectors 
+{
+    public class TaskUITemplateSelector : DataTemplateSelector
+    {
+        public DataTemplate Input { get; set; }
+        public DataTemplate CheckBox { get; set; }
+
+        public override DataTemplate SelectTemplate(object item, DependencyObject container)
+        {
+            if (item as TaskInput != null) return Input;
+            if (item as TaskCheckBox != null) return CheckBox;
+
+            return base.SelectTemplate(item, container);
+        }
+    }
+}

--- a/Raven.Studio/Models/TaskModel.cs
+++ b/Raven.Studio/Models/TaskModel.cs
@@ -34,7 +34,7 @@ namespace Raven.Studio.Models
 				Value = true
 			};
 
-			TaskInputs = new BindableCollection<TaskInput>(x => x.Name);
+			TaskInputs = new BindableCollection<TaskUIObject>(x => x.Name);
 			TaskDatas = new BindableCollection<TaskData>(x => x.Name);
 			TaskStatus = TaskStatus.DidNotStart;
 		}
@@ -117,33 +117,61 @@ namespace Raven.Studio.Models
 		}
 
 		public BindableCollection<string> Output { get; set; }
-		public BindableCollection<TaskInput> TaskInputs { get; set; }
+		public BindableCollection<TaskUIObject> TaskInputs { get; set; }
 		public BindableCollection<TaskData> TaskDatas { get; set; }
 
 		public abstract ICommand Action { get; }
 	}
 
-	public class TaskInput : NotifyPropertyChangedBase
+    public abstract class TaskUIObject : NotifyPropertyChangedBase
+    {
+        public TaskUIObject(string name, object value)
+        {
+            Name = name;
+            Value = value;
+        }
+
+        public string name;
+        public string Name
+        {
+            get { return name; }
+            set { name = value; OnPropertyChanged(() => Name); }
+        }
+
+        private object value;
+        public object Value
+        {
+            get { return Value; }
+            set { this.value = value; OnPropertyChanged(() => Value); }
+        }
+    }
+
+    public class TaskCheckBox : TaskUIObject
+    {
+        public TaskCheckBox(string name, bool value) : base(name, value)
+        {
+            Name = name;
+            Value = value;
+        }
+
+        private bool value;
+        public new bool Value
+        {
+            get { return value; }
+            set { this.value = value; OnPropertyChanged(() => Value); }
+        }
+    }
+
+    public class TaskInput : TaskUIObject
 	{
-		public TaskInput(string name, string value)
+		public TaskInput(string name, string value) : base(name, value)
 		{
 			Name = name;
 			Value = value;
 		}
 
-		private string name;
-		public string Name
-		{
-			get { return name; }
-			set
-			{
-				name = value;
-				OnPropertyChanged(() => Name);
-			}
-		}
-
 		private string value;
-		public string Value
+		public new string Value
 		{
 			get { return value; }
 			set { this.value = value; OnPropertyChanged(() => Value); }

--- a/Raven.Studio/Raven.Studio.csproj
+++ b/Raven.Studio/Raven.Studio.csproj
@@ -254,6 +254,8 @@
     <Compile Include="Infrastructure\Converters\GetFullConnectionStringConverter.cs" />
     <Compile Include="Infrastructure\Converters\MillisecondsToMinutesConverter.cs" />
     <Compile Include="Infrastructure\Converters\VisibilityByParamInEqualityConverter.cs" />
+    <Compile Include="Infrastructure\TemplateSelectors\DataTemplateSelector.cs" />
+    <Compile Include="Infrastructure\TemplateSelectors\TaskUITemplateSelector.cs" />
     <Compile Include="Models\PeriodicBackupSettingsSectionModel.cs" />
     <Compile Include="Models\QueueModel.cs" />
     <Compile Include="Models\SqlReplicationSettingsSectionModel.cs" />


### PR DESCRIPTION
Ability to include attachments when exporting a database.

Includes ability to show a checkbox vs textbox now within the
taskinputs, using a datatemplate selector. Can be easily extended to
show drop downs etc.. in future releases.
![attachments](https://f.cloud.github.com/assets/957896/140936/f94ed09e-7233-11e2-8001-3a0d82a81326.png)
