### PR TITLE
Replicate static indexes to the correct target database

### DIFF
--- a/Raven.Client.Lightweight/Indexes/AbstractIndexCreationTask.cs
+++ b/Raven.Client.Lightweight/Indexes/AbstractIndexCreationTask.cs
@@ -296,7 +296,7 @@ namespace Raven.Client.Indexes
 			{
 				try
 				{
-					serverClient.DirectPutIndex(IndexName, replicationDestination.Url, true, indexDefinition);
+                    serverClient.DirectPutIndex(IndexName, GetReplicationUrl(replicationDestination), true, indexDefinition);
 				}
 				catch (Exception e)
 				{
@@ -339,7 +339,7 @@ namespace Raven.Client.Indexes
 				var tasks = new List<Task>();
 				foreach (var replicationDestination in replicationDocument.Destinations)
 				{
-					tasks.Add(asyncServerClient.DirectPutIndexAsync(IndexName, indexDefinition, true, replicationDestination.Url));
+                    tasks.Add(asyncServerClient.DirectPutIndexAsync(IndexName, indexDefinition, true, GetReplicationUrl(replicationDestination)));
 				}
 				return Task.Factory.ContinueWhenAll(tasks.ToArray(), indexingTask =>
 				{
@@ -353,6 +353,13 @@ namespace Raven.Client.Indexes
 				});
 			}).Unwrap();
 		}
+
+        private string GetReplicationUrl(ReplicationDestination replicationDestination)
+        {
+            return string.IsNullOrWhiteSpace(replicationDestination.Database)
+                ? replicationDestination.Url
+                : replicationDestination.Url + "/databases/" + replicationDestination.Database;
+        }
 	}
 
 	/// <summary>

--- a/Raven.Tests/Bundles/Replication/ReplicationBase.cs
+++ b/Raven.Tests/Bundles/Replication/ReplicationBase.cs
@@ -206,17 +206,20 @@ namespace Raven.Tests.Bundles.Replication
 		protected void SetupReplication(IDatabaseCommands source, params string[] urls)
 		{
 			Assert.NotEmpty(urls);
-			source.Put(Constants.RavenReplicationDestinations,
-					   null, new RavenJObject
-			           {
-			           	{
-			           		"Destinations", new RavenJArray(urls.Select(url => new RavenJObject
-			           		{
-			           			{"Url", url}
-			           		}))
-			           		}
-			           }, new RavenJObject());
+            SetupReplication(source, urls.Select(url => new RavenJObject { { "Url", url } }));
 		}
+
+        protected void SetupReplication(IDatabaseCommands source, IEnumerable<RavenJObject> destinations)
+        {
+            Assert.NotEmpty(destinations);
+            source.Put(Constants.RavenReplicationDestinations,
+                       null, new RavenJObject
+                       {
+                           {
+                               "Destinations", new RavenJArray(destinations)
+                           }
+                       }, new RavenJObject());
+        }
 
 		protected void RemoveReplication(IDatabaseCommands source)
 		{

--- a/Raven.Tests/Bundles/Replication/StoreIndex.cs
+++ b/Raven.Tests/Bundles/Replication/StoreIndex.cs
@@ -2,12 +2,13 @@
 using Raven.Client.Connection;
 using Raven.Client.Document;
 using Raven.Client.Indexes;
+using Raven.Json.Linq;
 using Xunit;
 using System.Linq;
 
 namespace Raven.Tests.Bundles.Replication
 {
-	class StoreIndex : ReplicationBase
+	public class StoreIndex : ReplicationBase
 	{
 		[Fact]
 		public void When_storing_index_replicate_to_all_stores()
@@ -41,6 +42,47 @@ namespace Raven.Tests.Bundles.Replication
 				Assert.True(store3.DatabaseCommands.GetIndexNames(0, 10).ToList().Contains(index.IndexName));
 			}).Wait();
 		}
+
+        [Fact]
+        public void When_storing_index_replicate_to_all_stores_in_respective_databases()
+        {
+            var store1 = CreateStore(configureStore: store => store.DefaultDatabase = "MasterDb");
+            var store2 = CreateStore(configureStore: store => store.DefaultDatabase = "Slave1Db");
+            var store3 = CreateStore(configureStore: store => store.DefaultDatabase = "Slave2Db");
+
+            SetupReplication(store1.DatabaseCommands, new[]
+            {
+                new RavenJObject { { "Url", store2.Url }, { "Database", "Slave1Db" } }, 
+                new RavenJObject { { "Url", store3.Url }, { "Database", "Slave2Db" } } 
+            });
+
+            var index = new IndexSample();
+            index.Execute(store1.DatabaseCommands, new DocumentConvention());
+
+            Assert.True(store2.DatabaseCommands.GetIndexNames(0, 10).ToList().Contains(index.IndexName));
+            Assert.True(store3.DatabaseCommands.GetIndexNames(0, 10).ToList().Contains(index.IndexName));
+        }
+
+        [Fact]
+        public void When_storing_index_replicate_to_all_stores_in_respective_databases_async()
+        {
+            var store1 = CreateStore(configureStore: store => store.DefaultDatabase = "MasterDb");
+            var store2 = CreateStore(configureStore: store => store.DefaultDatabase = "Slave1Db");
+            var store3 = CreateStore(configureStore: store => store.DefaultDatabase = "Slave2Db");
+
+            SetupReplication(store1.DatabaseCommands, new[]
+            {
+                new RavenJObject { { "Url", store2.Url }, { "Database", "Slave1Db" } }, 
+                new RavenJObject { { "Url", store3.Url }, { "Database", "Slave2Db" } } 
+            });
+
+            var index = new IndexSample();
+            index.ExecuteAsync(store1.AsyncDatabaseCommands, new DocumentConvention()).ContinueWith(task =>
+            {
+                Assert.True(store2.DatabaseCommands.GetIndexNames(0, 10).ToList().Contains(index.IndexName));
+                Assert.True(store3.DatabaseCommands.GetIndexNames(0, 10).ToList().Contains(index.IndexName));
+            }).Wait();
+        }
 	}
 
 	class IndexSample : AbstractIndexCreationTask


### PR DESCRIPTION
This fix ensures static indexes replicate to the correct target database
based on the replication destinations document.

CLA has been sent.
