### PR TITLE
Allow IndexedProperties Bundle to update complex properties as objects instead of incorrectly as a string

### DIFF
--- a/Raven.Database/Bundles/IndexedProperties/IndexedPropertiesTrigger.cs
+++ b/Raven.Database/Bundles/IndexedProperties/IndexedPropertiesTrigger.cs
@@ -129,7 +129,15 @@ namespace Raven.Bundles.IndexedProperties
 					}
 					else if(field.IsBinary == false)
 					{
-						resultDoc.DataAsJson[mapping.Value] = GetStringValue(field);
+						string stringValue = GetStringValue(field);
+						try
+						{
+							resultDoc.DataAsJson[mapping.Value] = RavenJToken.Parse(stringValue);
+						}
+						catch
+						{
+							resultDoc.DataAsJson[mapping.Value] = stringValue;
+						}
 					}
 					changesMade = true;
 				}


### PR DESCRIPTION
Current implementation updates complex properties as a string instead of
an object. For example: if I have an index which creates a Rating for
each Article (an aggregate of Votes).  When this is updated by the
IndexedProperty Bundle what I get is:

"Rating": "{\"Score\"::40754086, \"Count\":111, \"VoteTotal\":1839,
\"WeightTotal\":598, \"VoteCounts\":[22,19,24,18,28]}"

When it should be

"Rating": {"Score"::40754086, "Count":111, "VoteTotal":1839,
"WeightTotal":598, "VoteCounts":[22,19,24,18,28]}
