### PR TITLE
Fixed issue where JQuery migrate would cause null-exception in ProfilerData.handleResponse

### DIFF
--- a/Raven.Client.MvcIntegration/js/profiler.js
+++ b/Raven.Client.MvcIntegration/js/profiler.js
@@ -18,7 +18,7 @@
 				.append(new ProfilerButton({ model: profilerData }).render().el);
 
 			if (typeof window.jQuery === 'function') { // bind to original jQuery ajaxComplete
-				window.jQuery('body').on('ajaxComplete', _.bind(profilerData.handleResponse, profilerData));
+			    $(document).on('ajaxComplete', _.bind(profilerData.handleResponse, profilerData));
 			}
 		};
 	}


### PR DESCRIPTION
This was caused because the ajaxComplete event (in profiler.js, MvcIntegration project) was bound to the window object. JQuery-migrate would route this to the document object (this was changed in JQuery 1.8). The routing didn't do a good job though because it would lose the xhrRequest object along the way causing a null reference exception.

Since you're bundling Jquery 1.8.3 with the project I though it would be OK to bind it to the document instead.
