### PR TITLE
Add test for Load/Include<T, TInclude> with string type referring proper...

### DIFF
--- a/Raven.Tests/Queries/Includes.cs
+++ b/Raven.Tests/Queries/Includes.cs
@@ -104,6 +104,30 @@ namespace Raven.Tests.Queries
 		}
 
 		[Fact]
+		public void can_include_by_primary_valuetype_string_property()
+		{
+			using (var session = store.OpenSession())
+			{
+				session.Store(new Customer2 { Id = 1 });
+				session.Store(new Order2 { Customer2Id = 1 }, "orders/1234");
+
+				session.SaveChanges();
+			}
+
+			using (var session = store.OpenSession())
+			{
+				var order = session.Include<Order2, Customer2>(x => x.Customer2IdString)
+					.Load("orders/1234");
+
+				// this will not require querying the server!
+				var cust = session.Load<Customer2>(order.Customer2Id);
+
+				Assert.NotNull(cust);
+				Assert.Equal(1, session.Advanced.NumberOfRequests);
+			}
+		}
+
+		[Fact]
 		public void can_query_with_include_by_primary_string_property()
 		{
 			using (var session = store.OpenSession())
@@ -384,6 +408,7 @@ namespace Raven.Tests.Queries
 		public class Order2
 		{
 			public int Customer2Id { get; set; }
+			public string Customer2IdString { get { return Customer2Id.ToString(); } }
 			public Guid[] Supplier2Ids { get; set; }
 			public Referral2 Refferal2 { get; set; }
 			public LineItem2[] LineItem2s { get; set; }


### PR DESCRIPTION
I've added a test for using Include<T, TInclude> with Load where the property referred to by Include is a string. Include<T, TInclude> currently fails to take TInclude into account when generating the REST include parameter.
