### PR TITLE
Add test for Load/Include<T, TInclude> referring via Id property

### DIFF
--- a/Raven.Tests/Queries/Includes.cs
+++ b/Raven.Tests/Queries/Includes.cs
@@ -174,6 +174,30 @@ namespace Raven.Tests.Queries
 		}
 
 		[Fact]
+		public void can_include_by_primary_valuetype_id()
+		{
+			using (var session = store.OpenSession())
+			{
+				session.Store(new Customer2 { Id = 1 });
+				session.Store(new Order2 { Id = 1 });
+
+				session.SaveChanges();
+			}
+
+			using (var session = store.OpenSession())
+			{
+				var order = session.Include<Order2, Customer2>(x => x.Id)
+					.Load("order2s/1");
+
+				// this will not require querying the server!
+				var cust = session.Load<Customer2>(order.Id);
+
+				Assert.NotNull(cust);
+				Assert.Equal(1, session.Advanced.NumberOfRequests);
+			}
+		}
+
+		[Fact]
 		public void can_include_by_primary_list_of_strings()
 		{
 			using (var session = store.OpenSession())
@@ -383,6 +407,7 @@ namespace Raven.Tests.Queries
 
 		public class Order2
 		{
+			public int Id { get; set; }
 			public int Customer2Id { get; set; }
 			public Guid[] Supplier2Ids { get; set; }
 			public Referral2 Refferal2 { get; set; }


### PR DESCRIPTION
We found in our project that Including other documents via a loaded document's Id property fails silently on the server. Let's say we have the following types:

```
class Customer {
    public int Id { get; set; }
```

   } 

```
class Order {
    public int Id { get; set; }
}
```

If we load an Order as follows:

```
session.Include<Order, Customer>(x => x.Id).Load(1);
```

Then customers/1 will not be included in the response from the server, for reasons unknown. No error is raised, the Include simply has no effect.

I've added a test to check this scenario; it fails, which corresponds to our findings. Regardless of how Raven is supposed to behave in this scenario, I think it'd be good to define it via a test. Personally I'd prefer that this scenario either works or fails with an exception so the client (e.g. our project) isn't left in the dark.
