### PR TITLE
support comparing relative uris

### DIFF
--- a/Raven.Abstractions/Json/Linq/RavenJValue.cs
+++ b/Raven.Abstractions/Json/Linq/RavenJValue.cs
@@ -543,7 +543,7 @@ namespace Raven.Json.Linq
 					return guid1.CompareTo(guid2);
 				case JTokenType.Uri:
 					if (objB is string)
-						objB = new Uri((string)objB);
+						objB = new Uri((string)objB, UriKind.RelativeOrAbsolute);
 
 					if (!(objB is Uri))
 						throw new ArgumentException("Object must be of type Uri.");


### PR DESCRIPTION
Passing in the UriKind enum will stop an unhandled UriFormatException getting thrown if the Uri is relative since the Uri ctor assumes UriKind.Absolute.
