### PR TITLE
Convinced the backup tool to return meaningful exit codes

### DIFF
--- a/Raven.Backup/ExitCodes.cs
+++ b/Raven.Backup/ExitCodes.cs
@@ -1,0 +1,9 @@
+﻿namespace Raven.Backup
+{
+    public enum ExitCodes
+    {
+        Success = 0,
+        InvalidArguments = 1,
+        Error = 2
+    }
+}

--- a/Raven.Backup/Program.cs
+++ b/Raven.Backup/Program.cs
@@ -4,79 +4,116 @@ using Raven.Abstractions;
 
 namespace Raven.Backup
 {
-	class Program
-	{
-		static void Main(string[] args)
-		{
-			var doReadKeyOnExit = false;
-			var op = new BackupOperation { NoWait = false };
-			var incrementalBackup = false;
-			var optionSet = new OptionSet
+    class Program
+    {
+        private static bool doReadKeyOnExit;
+        private static BackupOperation op;
+        private static OptionSet optionSet;
+
+        static void Main(string[] args)
+        {
+            Initialize();
+
+            ParseArguments(args);
+
+            EnsureMinimalParameters();
+
+            var backupOperationSucceeded = PerformBackup();
+
+            if (doReadKeyOnExit) Console.ReadKey();
+
+            var exitCode = (int)(backupOperationSucceeded ? ExitCodes.Success : ExitCodes.Error);
+            Environment.Exit(exitCode);
+        }
+
+        private static void Initialize()
+        {
+            op = new BackupOperation
+                 {
+                     NoWait = false,
+                     Incremental = false
+                 };
+
+            optionSet = new OptionSet
 			                	{
 			                		{"url=", "RavenDB server {0:url}", url => op.ServerUrl = url},
 			                		{"dest=", "Full {0:path} to backup folder", path => op.BackupPath = path},
 			                		{"nowait", "Return immediately without waiting for a response from the server", _ => op.NoWait = true},
 			                		{"readkey", "Specifying this flag will make the utility wait for key press before exiting.", _ => doReadKeyOnExit = true},
-									{"incremental", "When specified, the backup process will be incremental when done to a folder where a previous backup lies. If dest is an empty folder, or it does not exist, a full backup will be created. For incremental backups to work, the configuration option Raven/Esent/CircularLog must be set to false.", s => incrementalBackup= true}
+									{"incremental", "When specified, the backup process will be incremental when done to a folder where a previous backup lies. If dest is an empty folder, or it does not exist, a full backup will be created. For incremental backups to work, the configuration option Raven/Esent/CircularLog must be set to false.", _ => op.Incremental = true}
 			                	};
+        }
 
-			try
-			{
-				if (args.Length == 0)
-					PrintUsage(optionSet);
+        private static void ParseArguments(string[] args)
+        {
+            try
+            {
+                if (args.Length == 0)
+                    PrintUsage();
 
-				optionSet.Parse(args);
-			}
-			catch (Exception e)
-			{
-				Console.WriteLine("Could not understand arguments");
-				Console.WriteLine(e.Message);
-				PrintUsage(optionSet);
-				return;
-			}
+                optionSet.Parse(args);
+            }
+            catch (Exception e)
+            {
+                Console.WriteLine("Could not understand arguments");
+                Console.WriteLine(e.Message);
+                PrintUsage();
 
-			op.Incremental = incrementalBackup;
-			if (string.IsNullOrWhiteSpace(op.ServerUrl))
-			{
-				Console.WriteLine("Enter RavenDB server URL:");
-				op.ServerUrl = Console.ReadLine();
-			}
+                Environment.Exit((int)ExitCodes.InvalidArguments);
+            }
+        }
 
-			if (string.IsNullOrWhiteSpace(op.BackupPath))
-			{
-				Console.WriteLine("Enter backup destination:");
-				op.BackupPath = Console.ReadLine();
-			}
+        private static void EnsureMinimalParameters()
+        {
+            if (string.IsNullOrWhiteSpace(op.ServerUrl))
+            {
+                Console.WriteLine("Enter RavenDB server URL:");
+                op.ServerUrl = Console.ReadLine();
+            }
 
-			if (string.IsNullOrWhiteSpace(op.BackupPath) || string.IsNullOrWhiteSpace(op.ServerUrl))
-				return;
+            if (string.IsNullOrWhiteSpace(op.BackupPath))
+            {
+                Console.WriteLine("Enter backup destination:");
+                op.BackupPath = Console.ReadLine();
+            }
 
-			try
-			{
-				if (op.InitBackup())
-					op.WaitForBackup();
-			}
-			catch (Exception ex)
-			{
-				Console.WriteLine(ex);
-			}
+            if (string.IsNullOrWhiteSpace(op.BackupPath) || string.IsNullOrWhiteSpace(op.ServerUrl))
+            {
+                Environment.Exit((int)ExitCodes.InvalidArguments);
+            }
+        }
 
-			if (doReadKeyOnExit) Console.ReadKey();
-		}
+        private static bool PerformBackup()
+        {
+            try
+            {
+                if (op.InitBackup())
+                {
+                    op.WaitForBackup();
+                    return true;
+                }
+            }
+            catch (Exception ex)
+            {
+                Console.WriteLine(ex);
+            }
 
-		private static void PrintUsage(OptionSet optionSet)
-		{
-			Console.WriteLine(
-				@"
+            return false;
+        }
+
+        private static void PrintUsage()
+        {
+            Console.WriteLine(
+                @"
 Backup utility for RavenDB
 ----------------------------------------
 Copyright (C) 2008 - {0} - Hibernating Rhinos
 ----------------------------------------
 Command line options:", SystemTime.UtcNow.Year);
 
-			optionSet.WriteOptionDescriptions(Console.Out);
+            optionSet.WriteOptionDescriptions(Console.Out);
 
-			Console.WriteLine();
-		}
-	}
+            Console.WriteLine();
+        }
+    }
 }

--- a/Raven.Backup/Raven.Backup.csproj
+++ b/Raven.Backup/Raven.Backup.csproj
@@ -53,6 +53,7 @@
       <Link>Options.cs</Link>
     </Compile>
     <Compile Include="BackupOperation.cs" />
+    <Compile Include="ExitCodes.cs" />
     <Compile Include="Program.cs" />
   </ItemGroup>
   <ItemGroup>


### PR DESCRIPTION
Hello,

The backup tool always returns 0 as exit code. This makes it hard to integrate with other tools (like deployment scripts, and so on).

I have not changed the functionality of the tool at all, just added some methods and set some non-zero exit codes for exceptional cases.

ps: i have a CLA with you.
