### PR TITLE
Fix client check for UniqueConstraint on an enumerable property

### DIFF
--- a/Bundles/Raven.Bundles.Tests/UniqueConstraints/CreateTests.cs
+++ b/Bundles/Raven.Bundles.Tests/UniqueConstraints/CreateTests.cs
@@ -28,7 +28,7 @@ namespace Raven.Bundles.Tests.UniqueConstraints
 				var userMetadata = session.Advanced.GetMetadataFor(loadedUser);
 				var constraintsMeta = userMetadata.Value<RavenJArray>("Ensure-Unique-Constraints");
 				Assert.NotNull(constraintsMeta);
-				Assert.Equal(1, constraintsMeta.Length);
+				Assert.Equal(2, constraintsMeta.Length);
 			}
 		}
 

--- a/Bundles/Raven.Bundles.Tests/UniqueConstraints/ExtensionCheckTests.cs
+++ b/Bundles/Raven.Bundles.Tests/UniqueConstraints/ExtensionCheckTests.cs
@@ -68,6 +68,28 @@ namespace Raven.Bundles.Tests.UniqueConstraints
 			}
 		}
 
+        [Fact]
+        public void Check_works_on_enumerable_property()
+        {
+            var user1 = new User { Id = "users/1", Email = "user1@bar.com", Name = "James", TaskIds = new []{"TaskA", "TaskB"}};
+            var checkUser1 = new User { Id = "users/2", Email = "user2@bar.com", Name = "Watson", TaskIds = new[] { "TaskA"} };
+            var checkUser2 = new User { Id = "users/3", Email = "user3@bar.com", Name = "Sherlock", TaskIds = new[] { "TaskB", "TaskC" } };
+            var checkUser3 = new User { Id = "users/3", Email = "user3@bar.com", Name = "Sherlock", TaskIds = new[] { "TaskC", "TaskD" } };
+
+            using (var session = DocumentStore.OpenSession())
+            {
+                session.Store(user1);
+                session.SaveChanges();
+            }
+
+            using (var session = DocumentStore.OpenSession())
+            {
+                Assert.False(session.CheckForUniqueConstraints(checkUser1).ConstraintsAreFree());
+                Assert.False(session.CheckForUniqueConstraints(checkUser2).ConstraintsAreFree());
+                Assert.True(session.CheckForUniqueConstraints(checkUser3).ConstraintsAreFree());;
+            }
+        }
+
 		/* 
 		 * Can't use OperationVetoedException here for some reason I don't understand 
 		 * The code won't compile.

--- a/Bundles/Raven.Bundles.Tests/UniqueConstraints/UniqueConstraintsTest.cs
+++ b/Bundles/Raven.Bundles.Tests/UniqueConstraints/UniqueConstraintsTest.cs
@@ -1,4 +1,5 @@
-﻿using System.ComponentModel.Composition.Hosting;
+﻿using System.Collections.Generic;
+using System.ComponentModel.Composition.Hosting;
 
 namespace Raven.Bundles.Tests.UniqueConstraints
 {
@@ -44,7 +45,16 @@ namespace Raven.Bundles.Tests.UniqueConstraints
 		public string Email { get; set; }
 
 		public string Name { get; set; }
+
+        [UniqueConstraint]
+        public string[] TaskIds { get; set; }
 	}
+
+    public class Foo
+    {
+        [UniqueConstraint]
+        public List<string> UniqueStrings { get; set; } 
+    }
 
     public class GenericNamedValue<T>
     {

--- a/Bundles/Raven.Client.UniqueConstraints/UniqueConstraintExtensions.cs
+++ b/Bundles/Raven.Client.UniqueConstraints/UniqueConstraintExtensions.cs
@@ -1,4 +1,5 @@
 ﻿using System;
+using System.Collections;
 using System.Collections.Generic;
 using System.Linq;
 using System.Linq.Expressions;
@@ -61,9 +62,10 @@ namespace Raven.Client.UniqueConstraints
 			                     let propertyValue = property.GetValue(entity, null)
                                  let att = (UniqueConstraintAttribute)Attribute.GetCustomAttribute(property, typeof(UniqueConstraintAttribute))
 			                     where propertyValue != null
-			                     select
+                                 from item in typeof(IEnumerable).IsAssignableFrom(property.PropertyType) && property.PropertyType != typeof(string) ? ((IEnumerable)propertyValue).Cast<object>().Where(i => i != null) : new []{propertyValue}
+			                     select 
 				                     "UniqueConstraints/" + typeName.ToLowerInvariant() + "/" + property.Name.ToLowerInvariant() +
-				                     "/" + Raven.Bundles.UniqueConstraints.Util.EscapeUniqueValue(propertyValue.ToString(),att.CaseInsensitive);
+				                     "/" + Raven.Bundles.UniqueConstraints.Util.EscapeUniqueValue(item.ToString(),att.CaseInsensitive);
 
 			var constraintDocs = session.Include<ConstraintDocument>(x => x.RelatedId).Load(constraintsIds.ToArray());
 


### PR DESCRIPTION
Ensure UniqueConstraints client check checks each member of an IEnumerable separately, to follow same logic as in trigger.

Assuming any IEnumerable except a string should be dealt with in this way.
