### PR TITLE
Facet bug, query bug, loadstartingwith case bug

### DIFF
--- a/Bundles/Raven.Bundles.Tests/Authorization/Bugs/Preston.cs
+++ b/Bundles/Raven.Bundles.Tests/Authorization/Bugs/Preston.cs
@@ -1,0 +1,79 @@
+﻿extern alias client;
+using System.Linq;
+using client::Raven.Client.Authorization;
+using client::Raven.Bundles.Authorization.Model;
+using Raven.Client.Exceptions;
+using Raven.Client;
+using Raven.Client.Linq;
+using Raven.Client.Indexes;
+using Xunit;
+using Raven.Abstractions.Data;
+using System.Collections.Generic;
+using Raven.Abstractions.Data;
+
+namespace Raven.Bundles.Tests.Authorization.Bugs
+{
+	public class Preston : AuthorizationTest
+	{
+        [Fact]
+        public void CannotReadDocumentWhenTransformIsAppliedWithoutPermissionToIt()
+        {
+            new CompanyTransformer().Execute(store);
+            var company = new Company
+            {
+                Name = "Hibernating Rhinos"
+            };
+            using (var s = store.OpenSession())
+            {
+
+                s.Store(new AuthorizationUser
+                {
+                    Id = UserId,
+                    Name = "Ayende Rahien",
+                });
+
+                s.Store(company);
+
+                s.SetAuthorizationFor(company, new DocumentAuthorization());// deny everyone
+
+                s.SaveChanges();
+            }
+
+            using (var s = store.OpenSession())
+            {
+                s.SecureFor(UserId, "Company/Bid");
+
+                var companyListTransform = s.Query<Company>().Where(c => c.Name.StartsWith("Hibernating")).TransformWith<CompanyTransformer, CompanyTransformer.TransformedCompany>().ToList();
+                var companyListNoTransform = s.Query<Company>().Where(c => c.Name.StartsWith("Hibernating")).ToList();
+
+                Assert.Equal(companyListNoTransform.Count, companyListTransform.Count);
+
+                var readVetoException = Assert.Throws<ReadVetoException>(() => s.Load<CompanyTransformer, CompanyTransformer.TransformedCompany>(company.Id));
+
+                Assert.Equal(@"Document could not be read because of a read veto.
+The read was vetoed by: Raven.Bundles.Authorization.Triggers.AuthorizationReadTrigger
+Veto reason: Could not find any permissions for operation: Company/Bid on companies/1 for user Authorization/Users/Ayende.
+No one may perform operation Company/Bid on companies/1
+", readVetoException.Message);
+            }
+        }
+
+    }
+    public class CompanyTransformer : AbstractTransformerCreationTask<Company>
+    {
+        public class TransformedCompany
+        {
+            public string CompanyId { get; set; }
+        }
+        public CompanyTransformer()
+        {
+            TransformResults = companies =>
+                from company in companies
+                select new TransformedCompany
+                {
+                    CompanyId = company.Id
+                };
+        }
+    }
+
+}

--- a/Bundles/Raven.Bundles.Tests/Raven.Bundles.Tests.csproj
+++ b/Bundles/Raven.Bundles.Tests/Raven.Bundles.Tests.csproj
@@ -77,6 +77,7 @@
     <Compile Include="Authorization\Bugs\Kwal.cs" />
     <Compile Include="Authorization\Bugs\LoadingSavedInfo.cs" />
     <Compile Include="Authorization\Bugs\Matthew.cs" />
+    <Compile Include="Authorization\Bugs\Preston.cs" />
     <Compile Include="Authorization\Bugs\WhenUsingMultiTenancy.cs" />
     <Compile Include="Authorization\Bugs\WithChangingOfUser.cs" />
     <Compile Include="Authorization\CanAskAuthQuestions.cs" />
@@ -168,7 +169,9 @@
     <None Include="App.config" />
     <None Include="packages.config" />
   </ItemGroup>
-  <ItemGroup />
+  <ItemGroup>
+    <Service Include="{82A7F48D-3B50-4B1E-B82E-3ADA8210C358}" />
+  </ItemGroup>
   <Import Project="$(MSBuildToolsPath)\Microsoft.CSharp.targets" />
   <Import Project="$(MSBuildProjectDirectory)\..\..\Tools\StyleCop\StyleCop.Targets" />
   <Import Project="$(SolutionDir)\.nuget\nuget.targets" />

--- a/Raven.Abstractions/Data/Facet.cs
+++ b/Raven.Abstractions/Data/Facet.cs
@@ -158,11 +158,10 @@ namespace Raven.Abstractions.Data
 				}
 			}
 
-			//i.e. new DateTime(10, 4, 2001)
-			if (operation.Right is NewExpression)
+			//i.e. new DateTime(10, 4, 2001) || dateTimeVar.AddDays(2) || val +100
+			if (operation.Right is NewExpression || operation.Right is MethodCallExpression || operation.Right is BinaryExpression)
 			{
-				var right = (NewExpression)operation.Right;
-				var invoke = Expression.Lambda(right).Compile();
+                var invoke = Expression.Lambda(operation.Right).Compile();
 				var result = invoke.DynamicInvoke();
 				return result;
 			}
@@ -209,8 +208,9 @@ namespace Raven.Abstractions.Data
 			{
 				//The nullable stuff here it a bit weird, but it helps with trying to cast Value types
 				case "System.DateTime":
-					return RavenQuery.Escape(((DateTime)value).ToString(Default.DateTimeFormatsToWrite, CultureInfo.InvariantCulture));
-				case "System.Int32":
+                    return ((DateTime)value).ToString(Default.DateTimeFormatsToWrite, CultureInfo.InvariantCulture);
+                    return RavenQuery.Escape(((DateTime)value).ToString(Default.DateTimeFormatsToWrite, CultureInfo.InvariantCulture));
+                case "System.Int32":
 					return NumberUtil.NumberToString(((int)value));
 				case "System.Int64":
 					return NumberUtil.NumberToString((long)value);

--- a/Raven.Tests/Bugs/Errors/QueryIssues.cs
+++ b/Raven.Tests/Bugs/Errors/QueryIssues.cs
@@ -1,0 +1,94 @@
+﻿using Raven.Abstractions.Indexing;
+using Raven.Client.Indexes;
+using System;
+using System.Collections.Generic;
+using System.Linq;
+using System.Text;
+using System.Threading.Tasks;
+using Xunit;
+using Raven.Client;
+
+
+namespace Raven.Tests.Bugs.Errors
+{
+    public class QueryIssues : RavenTest
+    {
+        [Fact]
+        public void PrestonThinksThatOrShouldBeValidInQueries()
+        {
+            using (var store = NewDocumentStore())
+            {
+                new CompanyIndex().Execute(store);
+                using (var session = store.OpenSession())
+                {
+                    session.Store(new Company { Name = "This Company", HasParentCompany = false });
+                    session.Store(new Company { Name = "That Company", HasParentCompany = true });
+                    session.Store(new Company { Name = "The Other Company", HasParentCompany = false });
+                    session.SaveChanges();
+                }
+                using (var session = store.OpenSession())
+                {
+                    var compCompany = new Company { Name = "The Other Company", HasParentCompany = true };
+                    var results = session
+                        .Query<Company>()
+                        .Customize(x => x.WaitForNonStaleResultsAsOfNow())
+                        .Where(c => c.Name == compCompany.Name
+                            || (c.HasParentCompany && compCompany.HasParentCompany))
+                        .ToList();
+                    Assert.Equal(results.Count, 2);
+                }
+            }
+
+        }
+        
+        [Fact]
+        public void PrestonThinksLoadStartingWithShouldBeCaseInsensitive()
+        {
+            using (var store = NewDocumentStore())
+            {
+                new CompanyIndex().Execute(store);
+                using (var session = store.OpenSession())
+                {
+                    session.Store(new Company { Id = "CoMpAnY/1", Name = "This Company", HasParentCompany = false });
+                    session.Store(new Company { Id = "CoMpAnY/2", Name = "That Company", HasParentCompany = true });
+                    session.Store(new Company { Id = "CoMpAnY/3", Name = "The Other Company", HasParentCompany = false });
+                    session.SaveChanges();
+
+                }
+                using (var session = store.OpenSession())
+                {
+                    //first query to make sure we aren't stale.
+                    session.Query<Company>().Customize(x => x.WaitForNonStaleResultsAsOfNow()).ToList();
+
+                    var loadResult = session.Load<Company>("cOmPaNy/1");
+                    var loadStartResults = session.Advanced.LoadStartingWith<Company>("cOmPaNy/1").ToList();
+                    Assert.Contains(loadResult, loadStartResults);
+                    Assert.Equal(1, loadStartResults.Count);
+                }
+            }
+        }
+
+        public class Company
+        {
+            public string Id { get; set; }
+            public string Name { get; set; }
+            public bool HasParentCompany { get; set; }
+        }
+
+        public class CompanyIndex : AbstractIndexCreationTask<Company>
+        {
+            public CompanyIndex()
+            {
+                Map = companies =>
+                    from company in companies
+                    select new
+                    {
+                        company.Id,
+                        company.Name,
+                        company.HasParentCompany
+                    };
+            }
+        }
+
+    }
+}

--- a/Raven.Tests/Bugs/Facets/DateTimeFacets.cs
+++ b/Raven.Tests/Bugs/Facets/DateTimeFacets.cs
@@ -1,0 +1,159 @@
+﻿using Raven.Abstractions.Data;
+using Raven.Client;
+using Raven.Client.Linq;
+using Raven.Tests.Faceted;
+using System;
+using System.Collections.Generic;
+using System.Linq;
+using System.Linq.Expressions;
+using Xunit;
+
+namespace Raven.Tests.Bugs.Facets
+{
+
+    public class DateTimeFacets : FacetTestBase
+    {
+        [Fact]
+        public void PrestonThinksDateRangeQueryShouldProduceCorrectResultsWhenBuiltWithClient()
+        {
+            var cameras = GetCameras(30);
+            var now = DateTime.Now;
+
+            //putting some in the past and some in the future
+            for (int x = 0; x < cameras.Count; x++)
+            {
+                cameras[x].DateOfListing = now.AddDays(x - 15);
+            }
+
+
+            var dates = new List<DateTime>{
+                now.AddDays(-10),
+                now.AddDays(-7),
+                now.AddDays(0),
+                now.AddDays(7)
+            };
+
+            using (var store = NewDocumentStore())
+            {
+                CreateCameraCostIndex(store);
+
+                InsertCameraDataAndWaitForNonStaleResults(store, cameras);
+
+                var facetsNewWay = new List<Facet>
+			    {
+				    new Facet<Camera>
+				    {
+					    Name = x => x.DateOfListing,
+                        Ranges =
+                            {
+                                x => x.DateOfListing <= dates[0],
+                                x => x.DateOfListing > dates[0] && x.DateOfListing < dates[1],
+                                x => x.DateOfListing > dates[1] && x.DateOfListing < dates[2],
+                                x => x.DateOfListing > dates[2] && x.DateOfListing < dates[3],
+                                x => x.DateOfListing >= dates[3]
+                            }
+
+                        //throws exception if i have the .AddDays call in the definition, should it?
+                        //Ranges =
+                        //    {
+                        //        x => x.DateOfListing <= now.AddDays(-10),
+                        //        x => x.DateOfListing > now.AddDays(-10) && x.DateOfListing < now.AddDays(-7),
+                        //        x => x.DateOfListing > now.AddDays(-7) && x.DateOfListing < now.AddDays(0),
+                        //        x => x.DateOfListing > now.AddDays(0) && x.DateOfListing < now.AddDays(7),
+                        //        x => x.DateOfListing >= now.AddDays(7)
+                        //    }
+				    }
+                };
+                var facetOldSchool = new List<Facet>{
+                    new Facet
+                                     {
+                                         Name = "DateOfListing",
+                                         Mode = FacetMode.Ranges,
+                                         Ranges = new List<string>{
+                                             string.Format("[NULL TO {0:yyyy-MM-ddTHH-mm-ss.fffffff}]", dates[0]),
+                                             string.Format("[{0:yyyy-MM-ddTHH-mm-ss.fffffff} TO {1:yyyy-MM-ddTHH-mm-ss.fffffff}]", dates[0], dates[1]),
+                                             string.Format("[{0:yyyy-MM-ddTHH-mm-ss.fffffff} TO {1:yyyy-MM-ddTHH-mm-ss.fffffff}]", dates[1], dates[2]),
+                                             string.Format("[{0:yyyy-MM-ddTHH-mm-ss.fffffff} TO {1:yyyy-MM-ddTHH-mm-ss.fffffff}]", dates[2], dates[3]),
+                                             string.Format("[{0:yyyy-MM-ddTHH-mm-ss.fffffff} TO NULL]", dates[3])
+                                         }
+                                     }
+                };
+
+                using (var s = store.OpenSession())
+                {
+                    var expressions = new Expression<Func<Camera, bool>>[]
+                    {
+                        x => x.Cost >= 100 && x.Cost <= 300,
+                        x => x.DateOfListing > new DateTime(2000, 1, 1),
+                        x => x.Megapixels > 5.0m && x.Cost < 500,
+                        x => x.Manufacturer == "abc&edf"
+                    };
+
+                    foreach (var exp in expressions)
+                    {
+                        var facetResultsNew = s.Query<Camera, CameraCostIndex>()
+                            .Where(exp)
+                            .ToFacets(facetsNewWay);
+
+                         var facetResultsOldSchool = s.Query<Camera, CameraCostIndex>()
+                            .Where(exp)
+                            .ToFacets(facetOldSchool);
+
+
+                         Assert.True(AreFacetsEquiv(facetResultsNew, facetResultsOldSchool));
+                    }
+                }
+            }
+
+        }
+
+        private void CheckFacetResultsMatchInMemoryData(FacetResults facetResults, List<Camera> filteredData, IList<DateTime> dates)
+        {
+            //Test the Megapixels_Range facets using the same method
+            var dateOfListingFacets = facetResults.Results["DateOfListing_Range"].Values;
+            CheckFacetCount(filteredData.Count(x => x.DateOfListing <= dates.First()), dateOfListingFacets.FirstOrDefault(x => x.Range.Contains("NULL TO")));
+            CheckFacetCount(filteredData.Count(x => x.DateOfListing >= dates.Last()), dateOfListingFacets.FirstOrDefault(x => x.Range.Contains("TO NULL")));
+
+        }
+
+        private void CheckFacetCount(int expectedCount, FacetValue facets)
+        {
+            if (expectedCount > 0)
+            {
+                Assert.NotNull(facets);
+                Assert.Equal(expectedCount, facets.Hits);
+            }
+        }
+
+        private bool AreFacetsEquiv(FacetResults left, FacetResults right)
+        {
+            //check if same number of ranges.
+            if(left.Results.Count != right.Results.Count 
+               // || left.Results.Select(r=> r.Key).Intersect(right.Results.Select(r=> r.Key)).Count() != left.Results.Count
+                ){
+                return false;
+            }
+            //deeper check onthe ranges.
+            if(left.Results.Sum(r=> r.Value.Values.Sum(var=> var.Hits)) != right.Results.Sum(r=> r.Value.Values.Sum(var=> var.Hits))){
+                return false;
+            }
+
+            //all the way down...
+            foreach (var lfr in left.Results)
+            {
+                var leftFacetResult = lfr.Value;
+                var rightFacetResult = right.Results.First(r => r.Key.Contains(lfr.Key) || lfr.Key.Contains(r.Key)).Value;
+                for (int i = 0; i < leftFacetResult.Values.Count; i++)
+                {
+                    if (leftFacetResult.Values[i].Hits != rightFacetResult.Values[i].Hits)
+                    {
+                        return false;
+                    }
+                }
+
+            }
+            return true;
+        }
+
+    }
+}

--- a/Raven.Tests/Bugs/Facets/FacetErrors.cs
+++ b/Raven.Tests/Bugs/Facets/FacetErrors.cs
@@ -1,0 +1,63 @@
+﻿using Raven.Abstractions.Data;
+using Raven.Client;
+using Raven.Client.Linq;
+using Raven.Tests.Faceted;
+using System;
+using System.Collections.Generic;
+using System.Linq;
+using Xunit;
+
+namespace Raven.Tests.Bugs.Facets
+{
+    public class FacetErrors : FacetTestBase
+    {
+        [Fact]
+        public void PrestonThinksFacetsShouldNotHideOtherErrors()
+        {
+            var cameras = GetCameras(30);
+            var now = DateTime.Now;
+
+            //putting some in the past and some in the future
+            for (int x = 0; x < cameras.Count; x++)
+            {
+                cameras[x].DateOfListing = now.AddDays(x - 15);
+            }
+
+
+            var dates = new List<DateTime>{
+                now.AddDays(-10),
+                now.AddDays(-7),
+                now.AddDays(0),
+                now.AddDays(7)
+            };
+
+            using (var store = NewDocumentStore())
+            {
+                CreateCameraCostIndex(store);
+
+                InsertCameraDataAndWaitForNonStaleResults(store, cameras);
+
+                var facets = new List<Facet>{
+                    new Facet
+                    {
+                        Name = "DateOfListing",
+                        Mode = FacetMode.Ranges,
+                        Ranges = new List<string>{
+                            string.Format("[NULL TO {0:yyyy-MM-ddTHH-mm-ss.fffffff}]", dates[0]),
+                            string.Format("[{0:yyyy-MM-ddTHH-mm-ss.fffffff} TO {1:yyyy-MM-ddTHH-mm-ss.fffffff}]", dates[0], dates[1]),
+                            string.Format("[{0:yyyy-MM-ddTHH-mm-ss.fffffff} TO {1:yyyy-MM-ddTHH-mm-ss.fffffff}]", dates[1], dates[2]),
+                            string.Format("[{0:yyyy-MM-ddTHH-mm-ss.fffffff} TO {1:yyyy-MM-ddTHH-mm-ss.fffffff}]", dates[2], dates[3]),
+                            string.Format("[{0:yyyy-MM-ddTHH-mm-ss.fffffff} TO NULL]", dates[3])
+                        }
+                    }
+                };
+
+                var session = store.OpenSession();
+                //CameraCostIndex does not include zoom, bad index specified.
+                var query = session.Query<Camera, CameraCostIndex>().Where(x => x.Zoom > 3);
+                Assert.Throws<System.ArgumentException>(()=>query.ToList());
+                Assert.Throws<System.ArgumentException>(()=>query.ToFacets(facets));
+            }
+        }
+    }
+}

--- a/Raven.Tests/Bugs/Facets/FacetsCreationTest.cs
+++ b/Raven.Tests/Bugs/Facets/FacetsCreationTest.cs
@@ -1,0 +1,69 @@
+﻿using Raven.Abstractions.Data;
+using Raven.Client;
+using Raven.Client.Linq;
+using Raven.Tests.Faceted;
+using System;
+using System.Collections.Generic;
+using System.Linq;
+using System.Linq.Expressions;
+using Xunit;
+
+namespace Raven.Tests.Bugs.Facets
+{
+
+    public class FacetsCreationTest : FacetTestBase
+    {
+        [Fact]
+        public void PrestonThinksFacetsShouldAllowSimpleExpressionsDuringCreation()
+        {
+            var now = DateTime.Now;
+
+            var dates = new List<DateTime>{
+                now.AddDays(-10),
+                now.AddDays(-7),
+                now.AddDays(0),
+                now.AddDays(7)
+            };
+
+            var exceptionThrown = false;
+            try
+            {
+				var facet =new List<Facet>{ new Facet<Camera>
+				{
+					Name = x => x.DateOfListing,
+                    Ranges =
+                        {
+                            x => x.DateOfListing <= dates[0],
+                            x => x.DateOfListing > dates[0] && x.DateOfListing < dates[1],
+                            x => x.DateOfListing > dates[1] && x.DateOfListing < dates[2],
+                            x => x.DateOfListing > dates[2] && x.DateOfListing < dates[3],
+                            x => x.DateOfListing >= dates[3]
+                        }
+                }};
+                facet = new List<Facet>{new Facet<Camera>{
+					Name = x => x.DateOfListing,
+                    Ranges =
+                        {
+                            x => x.DateOfListing <= now.AddDays(-10),
+                            x => x.DateOfListing > now.AddDays(-10) && x.DateOfListing < now.AddDays(-7),
+                            x => x.DateOfListing > now.AddDays(-7) && x.DateOfListing < now.AddDays(0),
+                            x => x.DateOfListing > now.AddDays(0) && x.DateOfListing < now.AddDays(7),
+                            x => x.DateOfListing >= now.AddDays(7)
+                        }
+				}};
+                facet = new List<Facet>{new Facet<Camera>{
+                    Name = x => x.Cost,
+                    Ranges = {
+                        x=> x.Cost < Math.Ceiling(100.99m),
+                        x=> x.Cost > Math.Ceiling(100.99m) && x.Cost < Math.Ceiling(100.99m) + 50,
+                        x=> x.Cost > Math.Ceiling(100.99m) + 50 && x.Cost < Math.Ceiling(100.99m) + 100,
+                        x=> x.Cost > Math.Ceiling(100.99m) + 100,
+                    }
+                }};
+
+            }
+            catch{exceptionThrown = true;}
+            Assert.False(exceptionThrown);
+        }
+    }
+}

--- a/Raven.Tests/Raven.Tests.csproj
+++ b/Raven.Tests/Raven.Tests.csproj
@@ -221,6 +221,10 @@
     <Compile Include="Bugs\CaseSensitiveDeletes.cs" />
     <Compile Include="Bugs\Chripede\IndexOnList.cs" />
     <Compile Include="Bugs\AccessingMetadataInTransformer.cs" />
+    <Compile Include="Bugs\Errors\OrQueries.cs" />
+    <Compile Include="Bugs\Facets\FacetErrors.cs" />
+    <Compile Include="Bugs\Facets\FacetsCreationTest.cs" />
+    <Compile Include="Bugs\Facets\DateTimeFacets.cs" />
     <Compile Include="Bugs\WhenStoringADocumentWithAsyncSessionAndZipCompressionOn.cs" />
     <Compile Include="Issues\RavenDB_1435.cs" />
     <Compile Include="LicenseValidatorTest.cs" />
@@ -1531,9 +1535,7 @@
   <ItemGroup>
     <EmbeddedResource Include="MailingList\Everett\DocumentWithBytes.txt" />
   </ItemGroup>
-  <ItemGroup>
-    <Folder Include="Bugs\Facets\" />
-  </ItemGroup>
+  <ItemGroup />
   <ItemGroup>
     <Service Include="{82A7F48D-3B50-4B1E-B82E-3ADA8210C358}" />
   </ItemGroup>


### PR DESCRIPTION
Raven changes:

TEST: creating a facet hides other errors.

TEST: facet doesn’t work with datetimes and the advanced api

TEST: authorization doesn't work with transformers

TEST/Patch: allowing for expressions when creating facet ranges with advanced api

TEST: || in where blows chunks.

TEST: When we specify our own Id with mixed case, we can't find it with all lowercase prefix request nor with the matching mixed-case request. LoadStartingWith is partially case-sensitive.. And Load is not?
