### PR TITLE
improve ability to mock loading with includes

### DIFF
--- a/Raven.Client.Lightweight/Document/ILoaderWithInclude.cs
+++ b/Raven.Client.Lightweight/Document/ILoaderWithInclude.cs
@@ -21,21 +21,21 @@ namespace Raven.Client.Document
 		/// </summary>
 		/// <param name="path">The path.</param>
 		/// <returns></returns>
-		MultiLoaderWithInclude<T> Include(string path);
+		ILoaderWithInclude<T> Include(string path);
 
 		/// <summary>
 		/// Includes the specified path.
 		/// </summary>
 		/// <param name="path">The path.</param>
 		/// <returns></returns>
-		MultiLoaderWithInclude<T> Include(Expression<Func<T, object>> path);
+		ILoaderWithInclude<T> Include(Expression<Func<T, object>> path);
 
 		/// <summary>
 		/// Includes the specified path.
 		/// </summary>
 		/// <param name="path">The path.</param>
 		/// <returns></returns>
-		MultiLoaderWithInclude<T> Include<TInclude>(Expression<Func<T, object>> path);
+		ILoaderWithInclude<T> Include<TInclude>(Expression<Func<T, object>> path);
 
 		/// <summary>
 		/// Loads the specified ids.

--- a/Raven.Client.Lightweight/Document/MultiLoaderWithInclude.cs
+++ b/Raven.Client.Lightweight/Document/MultiLoaderWithInclude.cs
@@ -25,12 +25,12 @@ namespace Raven.Client.Document
 		/// Includes the specified path.
 		/// </summary>
 		/// <param name="path">The path.</param>
-		public MultiLoaderWithInclude<T> Include(string path)
+        public ILoaderWithInclude<T> Include(string path)
 		{
 			return Include(path, typeof(object));
 		}
 
-		MultiLoaderWithInclude<T> Include(string path, Type type)
+        ILoaderWithInclude<T> Include(string path, Type type)
 		{
 			includes.Add(new KeyValuePair<string, Type>(path, type));
 			return this;
@@ -40,7 +40,7 @@ namespace Raven.Client.Document
 		/// Includes the specified path.
 		/// </summary>
 		/// <param name="path">The path.</param>
-		public MultiLoaderWithInclude<T> Include(Expression<Func<T, object>> path)
+        public ILoaderWithInclude<T> Include(Expression<Func<T, object>> path)
 		{
 			return Include(path.ToPropertyPath());
 		}
@@ -49,7 +49,7 @@ namespace Raven.Client.Document
 		/// Includes the specified path.
 		/// </summary>
 		/// <param name="path">The path.</param>
-		public MultiLoaderWithInclude<T> Include<TInclude>(Expression<Func<T, object>> path)
+        public ILoaderWithInclude<T> Include<TInclude>(Expression<Func<T, object>> path)
 		{
 			var fullId = session.Conventions.FindFullDocumentKeyFromNonStringIdentifier(-1, typeof (TInclude), false);
 			var id = path.ToPropertyPath();


### PR DESCRIPTION
It is difficult to mock ILoaderWithInclude because it has methods with concrete type MultiLoaderWithInclude that has an internal constructor.  Updating to use the interface allows for unit testing with mocks.
