### PR TITLE
applied configureawait to eleminate the deadlock problem.

### DIFF
--- a/Raven.Client.Lightweight/Changes/RemoteDatabaseChanges.cs
+++ b/Raven.Client.Lightweight/Changes/RemoteDatabaseChanges.cs
@@ -98,7 +98,7 @@ namespace Raven.Client.Changes
             IObservable<string> serverEvents = null;
             try
             {
-                serverEvents = await jsonRequestFactory.CreateHttpJsonRequest(requestParams).ServerPullAsync();
+                serverEvents = await jsonRequestFactory.CreateHttpJsonRequest(requestParams).ServerPullAsync().ConfigureAwait(false);
             }
             catch (Exception e)
             {
@@ -123,8 +123,8 @@ namespace Raven.Client.Changes
 
             if (retry)
             {
-                await Time.Delay(TimeSpan.FromSeconds(15));
-                await EstablishConnection();
+                await Time.Delay(TimeSpan.FromSeconds(15)).ConfigureAwait(false);
+                await EstablishConnection().ConfigureAwait(false);
                 return;
             }
             if (disposed)
@@ -141,28 +141,28 @@ namespace Raven.Client.Changes
             clientSideHeartbeatTimer = new Timer(ClientSideHeartbeat, null, TimeSpan.FromSeconds(10), TimeSpan.FromSeconds(10));
 
             if (watchAllDocs)
-                await Send("watch-docs", null);
+                await Send("watch-docs", null).ConfigureAwait(false);
 
             if (watchAllIndexes)
-                await Send("watch-indexes", null);
+                await Send("watch-indexes", null).ConfigureAwait(false);
 
             foreach (var watchedDoc in watchedDocs)
             {
-                await Send("watch-doc", watchedDoc);
+                await Send("watch-doc", watchedDoc).ConfigureAwait(false);
             }
 
             foreach (var watchedPrefix in watchedPrefixes)
             {
-                await Send("watch-prefix", watchedPrefix);
+                await Send("watch-prefix", watchedPrefix).ConfigureAwait(false);
             }
             foreach (var watchedIndex in watchedIndexes)
             {
-                await Send("watch-indexes", watchedIndex);
+                await Send("watch-indexes", watchedIndex).ConfigureAwait(false);
             }
 
             foreach (var watchedBulkInsert in watchedBulkInserts)
             {
-                await Send("watch-bulk-operation", watchedBulkInsert);
+                await Send("watch-bulk-operation", watchedBulkInsert).ConfigureAwait(false);
             }
 
         }

--- a/Raven.Client.Lightweight/Connection/Async/AsyncServerClient.cs
+++ b/Raven.Client.Lightweight/Connection/Async/AsyncServerClient.cs
@@ -512,7 +512,7 @@ namespace Raven.Client.Connection.Async
 								Key = key,
 								Patches = patches,
 							}
-					});
+					}).ConfigureAwait(false);
 			if (!ignoreMissing && batchResults[0].PatchResult != null && batchResults[0].PatchResult == PatchResult.DocumentDoesNotExists)
 				throw new DocumentDoesNotExistsException("Document with key " + key + " does not exist.");
 			return batchResults[0].AdditionalData;
@@ -534,7 +534,7 @@ namespace Raven.Client.Connection.Async
 								Patches = patches,
 								Etag = etag
 							}
-					});
+					}).ConfigureAwait(false);
 			return batchResults[0].AdditionalData;
 		}
 
@@ -556,7 +556,7 @@ namespace Raven.Client.Connection.Async
 								PatchesIfMissing = patchesToDefault,
 								Metadata = defaultMetadata
 							}
-					});
+					}).ConfigureAwait(false);
 			return batchResults[0].AdditionalData;
 		}
 
@@ -575,7 +575,7 @@ namespace Raven.Client.Connection.Async
 					Key = key,
 					Patch = patch,
 				}
-			});
+			}).ConfigureAwait(false);
 			if (!ignoreMissing && batchResults[0].PatchResult != null && batchResults[0].PatchResult == PatchResult.DocumentDoesNotExists)
 				throw new DocumentDoesNotExistsException("Document with key " + key + " does not exist.");
 			return batchResults[0].AdditionalData;
@@ -597,7 +597,7 @@ namespace Raven.Client.Connection.Async
 					Patch = patch,
 					Etag = etag
 				}
-			});
+			}).ConfigureAwait(false);
 			return batchResults[0].AdditionalData;
 		}
 
@@ -619,7 +619,7 @@ namespace Raven.Client.Connection.Async
 					PatchIfMissing = patchDefault,
 					Metadata = defaultMetadata
 				}
-			});
+			}).ConfigureAwait(false);
 			return batchResults[0].AdditionalData;
 		}
 
@@ -1027,7 +1027,7 @@ namespace Raven.Client.Connection.Async
 				new CreateHttpJsonRequestParams(this, actualUrl, "GET", new RavenJObject(), credentials, convention)
 					.AddOperationHeaders(OperationsHeaders));
 
-			var result = await request.ReadResponseJsonAsync();
+            var result = await request.ReadResponseJsonAsync().ConfigureAwait(false);
 			return new LicensingStatus
 			{
 				Error = result.Value<bool>("Error"),
@@ -1043,7 +1043,7 @@ namespace Raven.Client.Connection.Async
 				new CreateHttpJsonRequestParams(this, actualUrl, "GET", new RavenJObject(), credentials, convention)
 					.AddOperationHeaders(OperationsHeaders));
 
-			RavenJToken result = await request.ReadResponseJsonAsync();
+            RavenJToken result = await request.ReadResponseJsonAsync().ConfigureAwait(false);
 			return new BuildNumber
 			{
 				BuildVersion = result.Value<string>("BuildVersion"),
@@ -1666,11 +1666,11 @@ namespace Raven.Client.Connection.Async
 
 			request.RemoveAuthorizationHeader();
 
-			var token = await GetSingleAuthToken();
+            var token = await GetSingleAuthToken().ConfigureAwait(false);
 
 			try
 			{
-				token = await ValidateThatWeCanUseAuthenticateTokens(token);
+                token = await ValidateThatWeCanUseAuthenticateTokens(token).ConfigureAwait(false);
 			}
 			catch (Exception e)
 			{
@@ -1681,7 +1681,7 @@ namespace Raven.Client.Connection.Async
 
 			request.AddOperationHeader("Single-Use-Auth-Token", token);
 
-			var webResponse = await request.RawExecuteRequestAsync();
+            var webResponse = await request.RawExecuteRequestAsync().ConfigureAwait(false);
 			queryHeaderInfo.Value = new QueryHeaderInformation
 			{
 				Index = webResponse.Headers["Raven-Index"],
@@ -1717,13 +1717,13 @@ namespace Raven.Client.Connection.Async
 
 			private async Task InitAsync()
 			{
-				if (await reader.ReadAsync() == false || reader.TokenType != JsonToken.StartObject)
+                if (await reader.ReadAsync().ConfigureAwait(false) == false || reader.TokenType != JsonToken.StartObject)
 					throw new InvalidOperationException("Unexpected data at start of stream");
 
-				if (await reader.ReadAsync() == false || reader.TokenType != JsonToken.PropertyName || Equals("Results", reader.Value) == false)
+                if (await reader.ReadAsync().ConfigureAwait(false) == false || reader.TokenType != JsonToken.PropertyName || Equals("Results", reader.Value) == false)
 					throw new InvalidOperationException("Unexpected data at stream 'Results' property name");
 
-				if (await reader.ReadAsync() == false || reader.TokenType != JsonToken.StartArray)
+                if (await reader.ReadAsync().ConfigureAwait(false) == false || reader.TokenType != JsonToken.StartArray)
 					throw new InvalidOperationException("Unexpected data at 'Results', could not find start results array");
 			}
 
@@ -1750,7 +1750,7 @@ namespace Raven.Client.Connection.Async
 					wasInitalized = true;
 				}
 
-				if (await reader.ReadAsync() == false)
+                if (await reader.ReadAsync().ConfigureAwait(false) == false)
 					throw new InvalidOperationException("Unexpected end of data");
 
 				if (reader.TokenType == JsonToken.EndArray)
@@ -1759,7 +1759,7 @@ namespace Raven.Client.Connection.Async
 					return false;
 				}
 
-				Current = (RavenJObject)await RavenJToken.ReadFromAsync(reader);
+                Current = (RavenJObject)await RavenJToken.ReadFromAsync(reader).ConfigureAwait(false);
 				return true;
 			}
 
@@ -1804,11 +1804,11 @@ namespace Raven.Client.Connection.Async
 				.AddReplicationStatusHeaders(Url, Url, replicationInformer, convention.FailoverBehavior, HandleReplicationStatusChanges);
 			request.RemoveAuthorizationHeader();
 
-			var token = await GetSingleAuthToken();
+            var token = await GetSingleAuthToken().ConfigureAwait(false);
 
 			try
 			{
-				token = await ValidateThatWeCanUseAuthenticateTokens(token);
+                token = await ValidateThatWeCanUseAuthenticateTokens(token).ConfigureAwait(false);
 			}
 			catch (Exception e)
 			{
@@ -1819,8 +1819,8 @@ namespace Raven.Client.Connection.Async
 
 			request.AddOperationHeader("Single-Use-Auth-Token", token);
 
-			
-			var webResponse = await request.RawExecuteRequestAsync();
+
+            var webResponse = await request.RawExecuteRequestAsync().ConfigureAwait(false);
 			return new YieldStreamResults(webResponse);
 		}
 #endif
@@ -1947,7 +1947,7 @@ namespace Raven.Client.Connection.Async
 			if (metadata.Value<int>("@Http-Status-Code") == 409)
 			{
 				var etag = HttpExtensions.EtagHeaderToEtag(metadata.Value<string>("@etag"));
-				var e = await TryResolveConflictOrCreateConcurrencyException(operationMetadata, metadata.Value<string>("@id"), docResult, etag);
+                var e = await TryResolveConflictOrCreateConcurrencyException(operationMetadata, metadata.Value<string>("@id"), docResult, etag).ConfigureAwait(false);
 				if (e != null)
 					throw e;
 				return true;
@@ -2029,7 +2029,7 @@ namespace Raven.Client.Connection.Async
 			bool requiresRetry = false;
 			foreach (var docResult in docResults)
 			{
-				requiresRetry |= await AssertNonConflictedDocumentAndCheckIfNeedToReload(operationMetadata, docResult);
+                requiresRetry |= await AssertNonConflictedDocumentAndCheckIfNeedToReload(operationMetadata, docResult).ConfigureAwait(false);
 			}
 			if (!requiresRetry)
 				return currentResult;
@@ -2040,7 +2040,7 @@ namespace Raven.Client.Connection.Async
 			resolvingConflictRetries = true;
 			try
 			{
-				return await nextTry();
+                return await nextTry().ConfigureAwait(false);
 			}
 			finally
 			{
@@ -2078,7 +2078,7 @@ namespace Raven.Client.Connection.Async
 		{
 			var tokenRequest = CreateRequest("/singleAuthToken", "GET", disableRequestCompression: true);
 
-			var response = await tokenRequest.ReadResponseJsonAsync();
+            var response = await tokenRequest.ReadResponseJsonAsync().ConfigureAwait(false);
 			return response.Value<string>("Token");
 		}
 
@@ -2089,7 +2089,7 @@ namespace Raven.Client.Connection.Async
 			request.DisableAuthentication();
 			request.webRequest.ContentLength = 0;
 			request.AddOperationHeader("Single-Use-Auth-Token", token);
-			var result = await request.ReadResponseJsonAsync();
+            var result = await request.ReadResponseJsonAsync().ConfigureAwait(false);
 			return result.Value<string>("Token");
 		}
 

--- a/Raven.Client.Lightweight/Connection/HttpJsonRequest.cs
+++ b/Raven.Client.Lightweight/Connection/HttpJsonRequest.cs
@@ -150,7 +150,7 @@ namespace Raven.Client.Connection
 				{
 					if (writeCalled == false)
 						webRequest.ContentLength = 0;
-					return await ReadJsonInternalAsync(webRequest.GetResponseAsync());
+                    return await ReadJsonInternalAsync(webRequest.GetResponseAsync()).ConfigureAwait(false);
 				}
 				catch (WebException e)
 				{
@@ -169,12 +169,12 @@ namespace Raven.Client.Connection
 
 				if (httpWebResponse.StatusCode == HttpStatusCode.Forbidden)
 				{
-					await HandleForbiddenResponseAsync(httpWebResponse);
-					await new CompletedTask(webException).Task; // Throws, preserving original stack
+                    await HandleForbiddenResponseAsync(httpWebResponse).ConfigureAwait(false);
+                    await new CompletedTask(webException).Task.ConfigureAwait(false); // Throws, preserving original stack
 				}
 
-				if (await HandleUnauthorizedResponseAsync(httpWebResponse) == false)
-					await new CompletedTask(webException).Task; // Throws, preserving original stack
+                if (await HandleUnauthorizedResponseAsync(httpWebResponse).ConfigureAwait(false) == false)
+                    await new CompletedTask(webException).Task.ConfigureAwait(false); // Throws, preserving original stack
 			}
 		}
 
@@ -182,11 +182,11 @@ namespace Raven.Client.Connection
 		{
 			if (writeCalled == false)
 				webRequest.ContentLength = 0;
-			using (var webResponse = await webRequest.GetResponseAsync())
+            using (var webResponse = await webRequest.GetResponseAsync().ConfigureAwait(false))
 			using (var stream = webResponse.GetResponseStreamWithHttpDecompression())
 			{
 				ResponseHeaders = new NameValueCollection(webResponse.Headers);
-				return await stream.ReadDataAsync();
+                return await stream.ReadDataAsync().ConfigureAwait(false);
 			}
 		}
 
@@ -292,7 +292,7 @@ namespace Raven.Client.Connection
 			if (unauthorizedResponseAsync == null)
 				return false;
 
-			RecreateWebRequest(await unauthorizedResponseAsync);
+            RecreateWebRequest(await unauthorizedResponseAsync.ConfigureAwait(false));
 			return true;
 		}
 
@@ -305,7 +305,7 @@ namespace Raven.Client.Connection
 			if (forbiddenResponseAsync == null)
 				return;
 
-			await forbiddenResponseAsync;
+            await forbiddenResponseAsync.ConfigureAwait(false);
 		}
 
 		private void RecreateWebRequest(Action<HttpWebRequest> action)
@@ -393,7 +393,7 @@ namespace Raven.Client.Connection
 			WebResponse response;
 			try
 			{
-				response = await responseTask;
+                response = await responseTask.ConfigureAwait(false);
 				sp.Stop();
 			}
 			catch (WebException e)
@@ -413,7 +413,7 @@ namespace Raven.Client.Connection
 			using (response)
 			using (var responseStream = response.GetResponseStreamWithHttpDecompression())
 			{
-				var data = await RavenJToken.TryLoadAsync(responseStream);
+                var data = await RavenJToken.TryLoadAsync(responseStream).ConfigureAwait(false);
 
 				if (Method == "GET" && ShouldCacheRequest)
 				{
@@ -817,7 +817,7 @@ namespace Raven.Client.Connection
 
 				try
 				{
-					var response = await webRequest.GetResponseAsync();
+                    var response = await webRequest.GetResponseAsync().ConfigureAwait(false);
 					var stream = response.GetResponseStreamWithHttpDecompression();
 					var observableLineStream = new ObservableLineStream(stream, () =>
 					{
@@ -844,12 +844,12 @@ namespace Raven.Client.Connection
 
 				if (httpWebResponse.StatusCode == HttpStatusCode.Forbidden)
 				{
-					await HandleForbiddenResponseAsync(httpWebResponse);
-					await new CompletedTask(webException).Task; // Throws, preserving original stack
+                    await HandleForbiddenResponseAsync(httpWebResponse).ConfigureAwait(false);
+                    await new CompletedTask(webException).Task.ConfigureAwait(false); // Throws, preserving original stack
 				}
 
-				if (await HandleUnauthorizedResponseAsync(httpWebResponse) == false)
-					await new CompletedTask(webException).Task; // Throws, preserving original stack
+                if (await HandleUnauthorizedResponseAsync(httpWebResponse).ConfigureAwait(false) == false)
+                    await new CompletedTask(webException).Task.ConfigureAwait(false); // Throws, preserving original stack
 			}
 		}
 
@@ -923,7 +923,7 @@ namespace Raven.Client.Connection
 		{
 			try
 			{
-				return await webRequest.GetResponseAsync();
+                return await webRequest.GetResponseAsync().ConfigureAwait(false);
 			}
 			catch (WebException we)
 			{

--- a/Raven.Client.Lightweight/Connection/ObservableLineStream.cs
+++ b/Raven.Client.Lightweight/Connection/ObservableLineStream.cs
@@ -141,7 +141,7 @@ namespace Raven.Client.Connection
 		    return await Task.Factory.FromAsync<int>(
 		        (callback, state) => stream.BeginRead(buffer, posInBuffer, buffer.Length - posInBuffer, callback, state),
 		        stream.EndRead,
-		        null);
+                null).ConfigureAwait(false);
 		}
 #endif
 

--- a/Raven.Client.Lightweight/Connection/Operation.cs
+++ b/Raven.Client.Lightweight/Connection/Operation.cs
@@ -41,16 +41,16 @@ namespace Raven.Client.Connection
 
 			while (true)
 			{
-				var status = await asyncServerClient.GetOperationStatusAsync(id);
+                var status = await asyncServerClient.GetOperationStatusAsync(id).ConfigureAwait(false);
 				if (status == null)
 					return null;
 				if (status.Value<bool>("Completed"))
 					return status.Value<RavenJToken>("State");
 
 #if NET45
-				await Task.Delay(500);
+				await Task.Delay(500).ConfigureAwait(false);
 #else
-				await TaskEx.Delay(500);
+                await TaskEx.Delay(500).ConfigureAwait(false);
 #endif
 
 			}

--- a/Raven.Client.Lightweight/Document/Async/AsyncDocumentSession.cs
+++ b/Raven.Client.Lightweight/Document/Async/AsyncDocumentSession.cs
@@ -73,14 +73,14 @@ namespace Raven.Client.Document.Async
 		{
 			var queryInspector = (IRavenQueryProvider)query.Provider;
 			var indexQuery = queryInspector.ToAsyncLuceneQuery<T>(query.Expression);
-			return await StreamAsync(indexQuery, queryHeaderInformation);
+            return await StreamAsync(indexQuery, queryHeaderInformation).ConfigureAwait(false);
 		}
 
 		public async Task<IAsyncEnumerator<StreamResult<T>>> StreamAsync<T>(IAsyncDocumentQuery<T> query, Reference<QueryHeaderInformation> queryHeaderInformation)
 		{
 			var ravenQueryInspector = ((IRavenQueryInspector)query);
 			var indexQuery = ravenQueryInspector.GetIndexQuery(true);
-			var enumerator = await AsyncDatabaseCommands.StreamQueryAsync(ravenQueryInspector.AsyncIndexQueried, indexQuery, queryHeaderInformation);
+            var enumerator = await AsyncDatabaseCommands.StreamQueryAsync(ravenQueryInspector.AsyncIndexQueried, indexQuery, queryHeaderInformation).ConfigureAwait(false);
 			var queryOperation = ((AsyncDocumentQuery<T>)query).InitializeQueryOperation(null);
 			queryOperation.DisableEntitiesTracking = true;
 
@@ -101,7 +101,7 @@ namespace Raven.Client.Document.Async
 
 		private async Task<IAsyncEnumerator<StreamResult<T>>> StreamAsync<T>(Etag fromEtag, string startsWith, string matches, int start, int pageSize)
 		{
-			var enumerator = await AsyncDatabaseCommands.StreamDocsAsync(fromEtag, startsWith, matches, start, pageSize);
+            var enumerator = await AsyncDatabaseCommands.StreamDocsAsync(fromEtag, startsWith, matches, start, pageSize).ConfigureAwait(false);
 			return new DocsYieldStream<T>(this, enumerator);
 		}
 
@@ -123,7 +123,7 @@ namespace Raven.Client.Document.Async
 
 			public async Task<bool> MoveNextAsync()
 			{
-				if (await enumerator.MoveNextAsync() == false)
+                if (await enumerator.MoveNextAsync().ConfigureAwait(false) == false)
 					return false;
 
 				SetCurrent();
@@ -383,13 +383,13 @@ namespace Raven.Client.Document.Async
 		public async Task<T> LoadAsync<TTransformer, T>(string id) where TTransformer : AbstractTransformerCreationTask, new()
 		{
 			var transformer = new TTransformer();
-			var result = await LoadAsyncInternal<T>(new[] { id }, null, transformer.TransformerName);
+            var result = await LoadAsyncInternal<T>(new[] { id }, null, transformer.TransformerName).ConfigureAwait(false);
 			return result.FirstOrDefault();
 		}
 
 		public async Task<T> LoadAsync<TTransformer, T>(string id, Action<ILoadConfiguration> configure) where TTransformer : AbstractTransformerCreationTask, new()
 		{
-			var result = await LoadAsync<TTransformer, T>(new[] { id }.AsEnumerable(), configure);
+            var result = await LoadAsync<TTransformer, T>(new[] { id }.AsEnumerable(), configure).ConfigureAwait(false);
 			return result.FirstOrDefault();
 		}
 
@@ -398,7 +398,7 @@ namespace Raven.Client.Document.Async
 			var transformer = new TTransformer();
 			var ravenLoadConfiguration = new RavenLoadConfiguration();
 			configure(ravenLoadConfiguration);
-			var result = await LoadAsyncInternal<TResult>(ids.ToArray(), null, transformer.TransformerName, ravenLoadConfiguration.QueryInputs);
+            var result = await LoadAsyncInternal<TResult>(ids.ToArray(), null, transformer.TransformerName, ravenLoadConfiguration.QueryInputs).ConfigureAwait(false);
 			return result;
 		}
 
@@ -421,7 +421,7 @@ namespace Raven.Client.Document.Async
 			{
 				// Returns array of arrays, public APIs don't surface that yet though as we only support Transform
 				// With a single Id
-				var arrayOfArrays = (await AsyncDatabaseCommands.GetAsync(ids, includePaths, transformer, queryInputs))
+                var arrayOfArrays = (await AsyncDatabaseCommands.GetAsync(ids, includePaths, transformer, queryInputs).ConfigureAwait(false))
 											.Results
 											.Select(x => x.Value<RavenJArray>("$values").Cast<RavenJObject>())
 											.Select(values =>
@@ -441,7 +441,7 @@ namespace Raven.Client.Document.Async
 				return arrayOfArrays;
 			}
 
-		    var getResponse = (await this.AsyncDatabaseCommands.GetAsync(ids, includePaths, transformer, queryInputs));
+            var getResponse = (await this.AsyncDatabaseCommands.GetAsync(ids, includePaths, transformer, queryInputs).ConfigureAwait(false));
 		    var items = new List<T>();
 		    foreach (var result in getResponse.Results)
 		    {
@@ -490,7 +490,7 @@ namespace Raven.Client.Document.Async
 				multiLoadOperation.LogOperation();
 				using (multiLoadOperation.EnterMultiLoadContext())
 				{
-					result = await AsyncDatabaseCommands.GetAsync(ids, includePaths);
+                    result = await AsyncDatabaseCommands.GetAsync(ids, includePaths).ConfigureAwait(false);
 				}
 			} while (multiLoadOperation.SetResult(result));
 			return multiLoadOperation.Complete<T>();

--- a/Raven.Client.Lightweight/Extensions/MultiTenancyExtensions.cs
+++ b/Raven.Client.Lightweight/Extensions/MultiTenancyExtensions.cs
@@ -148,7 +148,7 @@ namespace Raven.Client.Extensions
 
 			serverClient.ForceReadFromMaster();
 
-			var get = await serverClient.GetAsync(docId);
+            var get = await serverClient.GetAsync(docId).ConfigureAwait(false);
 			if (get != null)
 				return;
 
@@ -156,14 +156,14 @@ namespace Raven.Client.Extensions
 			req.Write(doc.ToString(Formatting.Indented));
 			try
 			{
-				await req.ExecuteRequestAsync();
+                await req.ExecuteRequestAsync().ConfigureAwait(false);
 			}
 			catch (Exception)
 			{
 				if (ignoreFailures)
 					return;
 			}
-			await new RavenDocumentsByEntityName().ExecuteAsync(serverClient.ForDatabase(name), new DocumentConvention());
+            await new RavenDocumentsByEntityName().ExecuteAsync(serverClient.ForDatabase(name), new DocumentConvention()).ConfigureAwait(false);
 		}
 
 		public static Task CreateDatabaseAsync(this IAsyncDatabaseCommands self, DatabaseDocument databaseDocument, bool ignoreFailures = false)

--- a/Raven.Client.Lightweight/PublicExtensions/LinqExtensions.cs
+++ b/Raven.Client.Lightweight/PublicExtensions/LinqExtensions.cs
@@ -450,7 +450,7 @@ namespace Raven.Client
 	        RavenQueryStatistics stats;
 	        query.Statistics(out stats);
 
-            await query.ToListAsync();
+            await query.ToListAsync().ConfigureAwait(false);
 
             return stats.TotalResults > 0;
         }
@@ -498,7 +498,7 @@ namespace Raven.Client
 			RavenQueryStatistics stats;
 			query.Statistics(out stats);
 
-			await query.ToListAsync();
+			await query.ToListAsync().ConfigureAwait(false);
 
 			return stats.TotalResults > 0;
         }
@@ -544,7 +544,7 @@ namespace Raven.Client
 			RavenQueryStatistics stats;
 			query.Statistics(out stats);
 
-			await query.ToListAsync();
+            await query.ToListAsync().ConfigureAwait(false);
 
 			return stats.TotalResults;
         }
@@ -595,7 +595,7 @@ namespace Raven.Client
 			RavenQueryStatistics stats;
 			query.Statistics(out stats);
 
-			await query.ToListAsync();
+            await query.ToListAsync().ConfigureAwait(false);
 
 			return stats.TotalResults;
         }
@@ -639,7 +639,7 @@ namespace Raven.Client
 
             provider.MoveAfterQueryExecuted(query);
 
-            var result = await query.ToListAsync();
+            var result = await query.ToListAsync().ConfigureAwait(false);
 
             return result.First();
         }
@@ -689,7 +689,7 @@ namespace Raven.Client
 
             provider.MoveAfterQueryExecuted(query);
 
-            var result = await query.ToListAsync();
+            var result = await query.ToListAsync().ConfigureAwait(false);
 
             return result.First();
         }
@@ -733,7 +733,7 @@ namespace Raven.Client
 
             provider.MoveAfterQueryExecuted(query);
 
-            var result = await query.ToListAsync();
+            var result = await query.ToListAsync().ConfigureAwait(false);
 
             return result.FirstOrDefault();
         }
@@ -785,7 +785,7 @@ namespace Raven.Client
 
             provider.MoveAfterQueryExecuted(query);
 
-            var result = await query.ToListAsync();
+            var result = await query.ToListAsync().ConfigureAwait(false);
 
             return result.FirstOrDefault();
         }
@@ -830,7 +830,7 @@ namespace Raven.Client
 
             provider.MoveAfterQueryExecuted(query);
 
-            var result = await query.ToListAsync();
+            var result = await query.ToListAsync().ConfigureAwait(false);
 
             return result.Single();
         }
@@ -881,7 +881,7 @@ namespace Raven.Client
 
             provider.MoveAfterQueryExecuted(query);
 
-            var result = await query.ToListAsync();
+            var result = await query.ToListAsync().ConfigureAwait(false);
 
             return result.Single();
         }
@@ -928,7 +928,7 @@ namespace Raven.Client
 
             provider.MoveAfterQueryExecuted(query);
 
-            var result = await query.ToListAsync();
+            var result = await query.ToListAsync().ConfigureAwait(false);
 
             return result.SingleOrDefault();
         }
@@ -980,7 +980,7 @@ namespace Raven.Client
 
             provider.MoveAfterQueryExecuted(query);
 
-            var result = await query.ToListAsync();
+            var result = await query.ToListAsync().ConfigureAwait(false);
 
             return result.SingleOrDefault();
         }

--- a/Raven.Client.Lightweight/Shard/AsyncShardedDocumentSession.cs
+++ b/Raven.Client.Lightweight/Shard/AsyncShardedDocumentSession.cs
@@ -146,7 +146,7 @@ namespace Raven.Client.Shard
 
 		public async Task<T> LoadAsync<TTransformer, T>(string id) where TTransformer : AbstractTransformerCreationTask, new()
 		{
-			var result = await LoadAsyncInternal<T>(new[] { id }, null, new TTransformer().TransformerName);
+            var result = await LoadAsyncInternal<T>(new[] { id }, null, new TTransformer().TransformerName).ConfigureAwait(false);
 			return result.FirstOrDefault();
 		}
 
@@ -154,7 +154,7 @@ namespace Raven.Client.Shard
 		{
 			var ravenLoadConfiguration = new RavenLoadConfiguration();
 			configure(ravenLoadConfiguration);
-			var result = await LoadAsyncInternal<T>(new[] { id }, null, new TTransformer().TransformerName, ravenLoadConfiguration.QueryInputs);
+            var result = await LoadAsyncInternal<T>(new[] { id }, null, new TTransformer().TransformerName, ravenLoadConfiguration.QueryInputs).ConfigureAwait(false);
 			return result.FirstOrDefault();
 		}
 
@@ -197,11 +197,11 @@ namespace Raven.Client.Shard
 						multiLoadOperation.LogOperation();
 						using (multiLoadOperation.EnterMultiLoadContext())
 						{
-							multiLoadResult = await dbCmd.GetAsync(currentShardIds, includePaths);
+                            multiLoadResult = await dbCmd.GetAsync(currentShardIds, includePaths).ConfigureAwait(false);
 						}
 					} while (multiLoadOperation.SetResult(multiLoadResult));
 					return multiLoadOperation;
-				});
+                }).ConfigureAwait(false);
 				foreach (var multiLoadOperation in multiLoadOperations)
 				{
 					var loadResults = multiLoadOperation.Complete<T>();
@@ -250,7 +250,7 @@ namespace Raven.Client.Shard
 							{
 								// Returns array of arrays, public APIs don't surface that yet though as we only support Transform
 								// With a single Id
-								var arrayOfArrays = (await dbCmd.GetAsync(currentShardIds, includePaths, transformer, queryInputs))
+                                var arrayOfArrays = (await dbCmd.GetAsync(currentShardIds, includePaths, transformer, queryInputs).ConfigureAwait(false))
 															.Results
 															.Select(x => x.Value<RavenJArray>("$values").Cast<RavenJObject>())
 															.Select(values =>
@@ -281,7 +281,7 @@ namespace Raven.Client.Shard
 						new ShardRequestData { EntityType = typeof(T), Keys = currentShardIds.ToList() },
 						async (dbCmd, i) =>
 						{
-							var items = (await dbCmd.GetAsync(currentShardIds, includePaths, transformer, queryInputs))
+                            var items = (await dbCmd.GetAsync(currentShardIds, includePaths, transformer, queryInputs).ConfigureAwait(false))
 								.Results
 								.SelectMany(x => x.Value<RavenJArray>("$values").ToArray())
 								.Select(JsonExtensions.ToJObject)
@@ -304,7 +304,7 @@ namespace Raven.Client.Shard
 							}
 
 							return items;
-						});
+                        }).ConfigureAwait(false);
 
 				foreach (var shardResult in shardResults)
 				{

--- a/Raven.Client.Lightweight/Shard/ShardedRavenQueryInspector.cs
+++ b/Raven.Client.Lightweight/Shard/ShardedRavenQueryInspector.cs
@@ -66,7 +66,7 @@ namespace Raven.Client.Shard
 				IndexName = IndexQueried,
 				EntityType = typeof(T),
 				Query = indexQuery
-			}, (commands, i) => commands.GetFacetsAsync(IndexQueried, indexQuery, facets, start, pageSize));
+            }, (commands, i) => commands.GetFacetsAsync(IndexQueried, indexQuery, facets, start, pageSize)).ConfigureAwait(false);
 
 			return MergeFacets(results);
 		}
@@ -79,7 +79,7 @@ namespace Raven.Client.Shard
 				IndexName = IndexQueried,
 				EntityType = typeof(T),
 				Query = indexQuery
-			}, (commands, i) => commands.GetFacetsAsync(IndexQueried, indexQuery, facetSetupDoc, start, pageSize));
+            }, (commands, i) => commands.GetFacetsAsync(IndexQueried, indexQuery, facetSetupDoc, start, pageSize)).ConfigureAwait(false);
 
 			return MergeFacets(results);
 		}

--- a/RavenDB.sln.DotSettings
+++ b/RavenDB.sln.DotSettings
@@ -2,7 +2,9 @@
 	<s:Boolean x:Key="/Default/CodeInspection/CodeAnnotations/NamespacesWithAnnotations/=Raven_002EStudio_002EAnnotations/@EntryIndexedValue">True</s:Boolean>
 	<s:String x:Key="/Default/CodeStyle/CodeFormatting/CSharpFormat/ANONYMOUS_METHOD_DECLARATION_BRACES/@EntryValue">NEXT_LINE</s:String>
 	<s:Int64 x:Key="/Default/CodeStyle/CodeFormatting/CSharpFormat/BLANK_LINES_AFTER_START_COMMENT/@EntryValue">0</s:Int64>
+	<s:Int64 x:Key="/Default/CodeStyle/CodeFormatting/CSharpFormat/BLANK_LINES_AROUND_AUTO_PROPERTY/@EntryValue">0</s:Int64>
 	<s:Int64 x:Key="/Default/CodeStyle/CodeFormatting/CSharpFormat/BLANK_LINES_AROUND_FIELD/@EntryValue">0</s:Int64>
+	<s:Int64 x:Key="/Default/CodeStyle/CodeFormatting/CSharpFormat/BLANK_LINES_AROUND_PROPERTY/@EntryValue">0</s:Int64>
 	<s:String x:Key="/Default/CodeStyle/CodeFormatting/CSharpFormat/CASE_BLOCK_BRACES/@EntryValue">NEXT_LINE</s:String>
 	<s:Boolean x:Key="/Default/CodeStyle/CodeFormatting/CSharpFormat/INDENT_ANONYMOUS_METHOD_BLOCK/@EntryValue">False</s:Boolean>
 	<s:Boolean x:Key="/Default/CodeStyle/CodeFormatting/CSharpFormat/INDENT_EMBRACED_INITIALIZER_BLOCK/@EntryValue">False</s:Boolean>
@@ -14,5 +16,6 @@
 -----------------------------------------------------------------------</s:String>
 	<s:String x:Key="/Default/CodeStyle/Naming/CSharpNaming/PredefinedNamingRules/=PrivateInstanceFields/@EntryIndexedValue">&lt;Policy Inspect="True" Prefix="" Suffix="" Style="aaBb" /&gt;</s:String>
 	<s:String x:Key="/Default/CodeStyle/Naming/CSharpNaming/PredefinedNamingRules/=PrivateStaticFields/@EntryIndexedValue">&lt;Policy Inspect="True" Prefix="" Suffix="" Style="aaBb" /&gt;</s:String>
+	<s:Boolean x:Key="/Default/Environment/SettingsMigration/IsMigratorApplied/=JetBrains_002EReSharper_002EPsi_002ECSharp_002ECodeStyle_002ESettingsUpgrade_002EMigrateBlankLinesAroundFieldToBlankLinesAroundProperty/@EntryIndexedValue">True</s:Boolean>
 	<s:String x:Key="/Default/FilterSettingsManager/AttributeFilterXml/@EntryValue">&lt;data /&gt;</s:String>
 	<s:String x:Key="/Default/FilterSettingsManager/CoverageFilterXml/@EntryValue">&lt;data&gt;&lt;IncludeFilters /&gt;&lt;ExcludeFilters /&gt;&lt;/data&gt;</s:String></wpf:ResourceDictionary>


### PR DESCRIPTION
I had to have the following query on the `IAsyncDocumentSession` as ASP.NET MVC child actions don't support async:

```
[ChildActionOnly]
public ActionResult List()
{
    IEnumerable<Tags_Count.ReduceResult> tags = _documentSession
        .Query<Tags_Count.ReduceResult, Tags_Count>()
        .ToListAsync()
        .Result;

    return View(tags.Select(tag => new TagModel
    {
        Name = tag.Name,
        Slug = tag.Slug,
        Count = tag.Count,
        LastSeenAt = tag.LastSeenAt
    }));
}
```

However, this call will causes deadlock because of the reasons explained in the following articles and questions:
- [The Perfect Recipe to Shoot Yourself in The Foot - Ending up with a Deadlock Using the C# 5.0 Asynchronous Language Features](http://www.tugberkugurlu.com/archive/the-perfect-recipe-to-shoot-yourself-in-the-foot-ending-up-with-a-deadlock-using-the-c-sharp-5-0-asynchronous-language-features)
- [Asynchronous .NET Client Libraries for Your HTTP API and Awareness of async/await's Bad Effects](http://www.tugberkugurlu.com/archive/asynchronousnet-client-libraries-for-your-http-api-and-awareness-of-async-await-s-bad-effects)
- [Best practice to call ConfigureAwait for all server-side code](http://stackoverflow.com/questions/13489065/best-practice-to-call-configureawait-for-all-server-side-code)

Hope this helps.

Not completely sure if this pull-request completely fixes this problem (as nearly every await needs to be made against `ConfigureAwait(false)` in a library which doesn't care about the sync. context) but I just wanted to raise the problem here with this pull request.
