### PR TITLE
add options to setup for DataDir and IndexStoragePath

### DIFF
--- a/Raven.Setup/Components/IIS/Raven.Web.wxs
+++ b/Raven.Setup/Components/IIS/Raven.Web.wxs
@@ -40,7 +40,42 @@
                  Value="[RAVEN_LICENSE_FILE_PATH]"
                  SelectionLanguage="XSLPattern"
                  Sequence="4" />
-      </Component>
+		  <util:XmlFile Id="SetDataDirIIS"
+				   Action="setValue"
+				   Permanent="yes"
+				   ElementPath="/configuration/appSettings/add[\[]@key='Raven/DataDir'[\]]"
+				   Name="value"
+			       File="[#web.config]"
+				   Value="[RAVEN_DATA_DIR]"
+				   SelectionLanguage="XSLPattern"
+				   Sequence="5" />
+		  <util:XmlFile Id="AddEmptyIndexStoragePathSettingIIS"
+				   Action="createElement"
+				   Permanent="yes"
+				   ElementPath="/configuration/appSettings"
+				   Name="add"
+				File="[#web.config]"
+				   SelectionLanguage="XSLPattern"
+				   Sequence="6" />
+		  <util:XmlFile Id="AddIndexStoragePathIIS"
+				   Action="setValue"
+				   Permanent="yes"
+				   ElementPath="/configuration/appSettings/add[\[]not(@key)[\]] "
+				   Name="key"
+				   Value="Raven/IndexStoragePath"
+				   File="[#web.config]"
+				   SelectionLanguage="XSLPattern"
+				   Sequence="7" />
+		  <util:XmlFile Id="SetIndexStoragePathIIS"
+				   Action="setValue"
+				   Permanent="yes"
+				   ElementPath="/configuration/appSettings/add[\[]@key='Raven/IndexStoragePath'[\]]"
+				   Name="key"
+				   File="[#web.config]"
+				   Value="[RAVEN_INDEX_DIR]"
+				   SelectionLanguage="XSLPattern"
+				   Sequence="8" />
+	  </Component>
       <Component Id="Raven.Web.Config.IIS_6" Guid="{0D39076B-E488-44DD-9E07-57732A515601}">
         <Condition><![CDATA[IISMAJORVERSION < "#7"]]></Condition>
         <File Id='web_iis6.config' Name='web.config' DiskId='1' Source='$(var.SolutionDir)\DefaultConfigs\Web_IIS6.config'>
@@ -71,7 +106,42 @@
                  Value="[RAVEN_LICENSE_FILE_PATH]"
                  SelectionLanguage="XSLPattern"
                  Sequence="4" />
-      </Component>
+		  <util:XmlFile Id="SetDataDirIIS6"
+				   Action="setValue"
+				   Permanent="yes"
+				   ElementPath="/configuration/appSettings/add[\[]@key='Raven/DataDir'[\]]"
+				   Name="value"
+			   File="[#web_iis6.config]"
+				   Value="[RAVEN_DATA_DIR]"
+				   SelectionLanguage="XSLPattern"
+				   Sequence="5" />
+		  <util:XmlFile Id="AddEmptyIndexStoragePathSettingIIS6"
+				   Action="createElement"
+				   Permanent="yes"
+				   ElementPath="/configuration/appSettings"
+				   Name="add"
+			   File="[#web_iis6.config]"
+				   SelectionLanguage="XSLPattern"
+				   Sequence="6" />
+		  <util:XmlFile Id="AddIndexStoragePathIIS6"
+				   Action="setValue"
+				   Permanent="yes"
+				   ElementPath="/configuration/appSettings/add[\[]not(@key)[\]] "
+				   Name="key"
+				   Value="Raven/IndexStoragePath"
+				   File="[#web.config]"
+				   SelectionLanguage="XSLPattern"
+				   Sequence="7" />
+		  <util:XmlFile Id="SetIndexStoragePathIIS6"
+				   Action="setValue"
+				   Permanent="yes"
+				   ElementPath="/configuration/appSettings/add[\[]@key='Raven/IndexStoragePath'[\]]"
+				   Name="key"
+				   File="[#web.config]"
+				   Value="[RAVEN_INDEX_DIR]"
+				   SelectionLanguage="XSLPattern"
+				   Sequence="7" />
+	  </Component>
       <Component Id="PersistWebSiteValues" Guid="{BA5C1D27-7DD0-4521-BE13-4BC0A57D9D1D}">
         <RegistryKey Action="create" Root="HKLM"
                      Key="SOFTWARE\[Manufacturer]\[ProductName]">

--- a/Raven.Setup/Components/Service/Raven.Server.wxs
+++ b/Raven.Setup/Components/Service/Raven.Server.wxs
@@ -46,7 +46,42 @@
                  Value="[RAVEN_LICENSE_FILE_PATH]"
                  SelectionLanguage="XSLPattern"
                  Sequence="4" />
-      </Component>
+		  <util:XmlFile Id="SetDataDir"
+				   Action="setValue"
+				   Permanent="yes"
+				   ElementPath="/configuration/appSettings/add[\[]@key='Raven/DataDir'[\]]"
+				   Name="value"
+				   File="[#Raven.Server.exe.config]"
+				   Value="[RAVEN_DATA_DIR]"
+				   SelectionLanguage="XSLPattern"
+				   Sequence="5" />
+		  <util:XmlFile Id="AddEmptyIndexStoragePathSetting"
+				   Action="createElement"
+				   Permanent="yes"
+				   ElementPath="/configuration/appSettings"
+				   Name="add"
+				   File="[#Raven.Server.exe.config]"
+				   SelectionLanguage="XSLPattern"
+				   Sequence="6" />
+		  <util:XmlFile Id="AddIndexStoragePath"
+				   Action="setValue"
+				   Permanent="yes"
+				   ElementPath="/configuration/appSettings/add[\[]not(@key)[\]] "
+				   Name="key"
+				   Value="Raven/IndexStoragePath"
+				   File="[#Raven.Server.exe.config]"
+				   SelectionLanguage="XSLPattern"
+				   Sequence="7" />
+		  <util:XmlFile Id="SetIndexStoragePath"
+				   Action="setValue"
+				   Permanent="yes"
+				   ElementPath="/configuration/appSettings/add[\[]@key='Raven/IndexStoragePath'[\]]"
+				   Name="value"
+			       File="[#Raven.Server.exe.config]"
+				   Value="[RAVEN_INDEX_DIR]"
+				   SelectionLanguage="XSLPattern"
+				   Sequence="8" />
+	  </Component>
       <Component Id="PersistServiceValues" Guid="{54DE475A-D1B2-4536-9598-A77AA3BC0264}" >
         <RegistryKey Root="HKLM" Key="Software\[Manufacturer]\[ProductName]" >
           <RegistryValue Type="string" Name="SERVICE_NAME" Value="[SERVICE_NAME]"  />

--- a/Raven.Setup/Settings.wxi
+++ b/Raven.Setup/Settings.wxi
@@ -9,5 +9,7 @@
   <Property Id="RAVEN_TARGET_ENVIRONMENT" Value="PRODUCTION" /> <!-- default value is PRODUCTION [available options: PRODUCTION, DEVELOPMENT] -->
   <Property Id="RAVEN_LICENSE_FILE_PATH" />
   <Property Id="RAVEN_LICENSE_ERROR" />
-
+  <Property Id="RAVEN_DATA_DIR" Value="~\Data" />
+  <Property Id="RAVEN_INDEX_DIR" Value="~\Data\Indexes" />
+	
 </Include>


### PR DESCRIPTION
Added two new command line options to setup - RAVEN_DATA_DIR and RAVEN_INDEX_DIR - to allow setting of DataDir and IndexStoragePath config options. I did not add these options to the setup UI.
