### PR TITLE
Use fixed "dummy id" rather than generating a new one each time

### DIFF
--- a/Bundles/Raven.Client.UniqueConstraints/UniqueConstraintExtensions.cs
+++ b/Bundles/Raven.Client.UniqueConstraints/UniqueConstraintExtensions.cs
@@ -68,8 +68,8 @@ namespace Raven.Client.UniqueConstraints
 				var constraintDocs = session.Include("RelatedId").Load<RavenJObject>(uniqueIds);
 				if (constraintDocs != null)
 				{
-					string nullId = Guid.NewGuid().ToString(); // simple way to maintain parallel results array - this ID should never exist in the DB
-					var ids = constraintDocs.Select(d => d == null ? nullId : d.Value<string>("RelatedId")).ToArray();
+					// simple way to maintain parallel results array - DummyId should never exist in the DB
+					var ids = constraintDocs.Select(d => d == null ? DummyId : d.Value<string>("RelatedId")).ToArray();
 					return session.Load<T>(ids);
 				}
 			}
@@ -77,7 +77,7 @@ namespace Raven.Client.UniqueConstraints
 			return values.Select(v => default(T)).ToArray();
 		}
 
-
+	    public const string DummyId = "E1972AA7-148D-4035-9779-0EDFB3A7DBFF";
 
 		private static string GetPropropertyNameForKeySelector<T>(Expression<Func<T, object>> keySelector)
 		{


### PR DESCRIPTION
If you do 

```
LoadByUniqueConstraint<Foo>(arrayOfIds);

foreach(var id in arrayOfIds) {
    LoadByUniqueConstraint<Foo>(id);
}
```

You get a request for every Foo that does not exist.  Using a Guid as the "id" in this case is a useful hack that avoids having to line up 2 arrays, but there is no need to generate a new Guid each time.  Instead I've just hardcoded a fixed Guid and we'll use this every time.
