### PR TITLE
Create the CompiledIndexCacheDirectory if it does not exist.

### DIFF
--- a/Raven.Database/Linq/QueryParsingUtils.cs
+++ b/Raven.Database/Linq/QueryParsingUtils.cs
@@ -353,12 +353,9 @@ namespace Raven.Database.Linq
 			//    previously created and deleted, affecting both production and test environments.
 			//
 			// For more info, see http://ayende.com/blog/161218/robs-sprint-idly-indexing?key=f37cf4dc-0e5c-43be-9b27-632f61ba044f#comments-form-location
-			var indexCacheDir = GetIndexCacheDir(configuration);
 
 			try
 			{
-				if (Directory.Exists(indexCacheDir) == false)
-					Directory.CreateDirectory(indexCacheDir);
 				type = TryGetIndexFromDisk(indexFilePath, name);
 			}
 			catch (UnauthorizedAccessException)
@@ -417,8 +414,8 @@ namespace Raven.Database.Linq
 				// we know we can write there
 				try
 				{
-					if (Directory.Exists(indexCacheDir) == false)
-						Directory.CreateDirectory(indexCacheDir);
+                    EnsureDirectoryExists(indexCacheDir);
+
 					var touchFile = Path.Combine(indexCacheDir, Guid.NewGuid() + ".temp");
 					File.WriteAllText(touchFile, "test that we can write to this path");
 					File.Delete(touchFile);
@@ -428,9 +425,10 @@ namespace Raven.Database.Linq
 				{
 				}
 
-				return Path.Combine(configuration.IndexStoragePath, "Raven", "CompiledIndexCache");
+				indexCacheDir = Path.Combine(configuration.IndexStoragePath, "Raven", "CompiledIndexCache");
 			}
 
+            EnsureDirectoryExists(indexCacheDir);
 			return indexCacheDir;
 		}
 
@@ -536,5 +534,11 @@ namespace Raven.Database.Linq
 
 			return null;
 		}
+
+        private static void EnsureDirectoryExists(string directoryPath)
+        {
+            if (Directory.Exists(directoryPath) == false)
+                Directory.CreateDirectory(directoryPath);
+        }
 	}
 }

--- a/Raven.Tests/Bugs/CompilingIndexesCreatesCacheDirectory.cs
+++ b/Raven.Tests/Bugs/CompilingIndexesCreatesCacheDirectory.cs
@@ -1,0 +1,65 @@
+﻿using System.IO;
+using System.Linq;
+using Raven.Client.Indexes;
+using Xunit;
+
+namespace Raven.Tests.Bugs
+{
+    public class CompilingIndexesCreatesCacheDirectory : RavenTest
+    {
+        private readonly string compiledIndexCacheDirectory;
+
+        public CompilingIndexesCreatesCacheDirectory()
+        {
+            compiledIndexCacheDirectory = Path.Combine(Path.GetTempPath(), "TempIndexCacheDirectory");
+        }
+
+        [Fact]
+        public void CanDealWithMissingCacheDirectory()
+        {
+            using (var store = NewDocumentStore())
+            {
+                store.Configuration.CompiledIndexCacheDirectory = compiledIndexCacheDirectory;
+
+                DeleteDirectory(store.Configuration.CompiledIndexCacheDirectory);
+
+                var index = new Index();
+
+                Assert.DoesNotThrow(() => index.Execute(store));
+                Assert.True(Directory.Exists(compiledIndexCacheDirectory));
+            }
+        }
+
+        public override void Dispose()
+        {
+            base.Dispose();
+
+            DeleteDirectory(compiledIndexCacheDirectory);
+        }
+
+        private static void DeleteDirectory(string directoryPath)
+        {
+            if (Directory.Exists(directoryPath))
+            {
+                Directory.Delete(directoryPath, true);
+            }
+        }
+
+        class Entity
+        {
+            public string Id { get; set; }
+        }
+
+        class Index : AbstractIndexCreationTask<Entity>
+        {
+            public Index()
+            {
+                Map = entities => from entity in entities
+                                  select new
+                                  {
+                                      entity.Id
+                                  };
+            }
+        }
+    }
+}

--- a/Raven.Tests/Raven.Tests.csproj
+++ b/Raven.Tests/Raven.Tests.csproj
@@ -217,6 +217,7 @@
     <Compile Include="Bugs\Chripede\IndexOnList.cs" />
     <Compile Include="Bugs\AccessingMetadataInTransformer.cs" />
     <Compile Include="Bugs\CanPatchADocumentThatContainsBytes.cs" />
+    <Compile Include="Bugs\CompilingIndexesCreatesCacheDirectory.cs" />
     <Compile Include="Bugs\DefaultOperatorTest.cs" />
     <Compile Include="Bugs\DyanmicId.cs" />
     <Compile Include="Bugs\DynamicId.cs" />


### PR DESCRIPTION
Fix of: http://issues.hibernatingrhinos.com/issue/RavenDB-2240

Notes:
- GetIndexCacheDir - will always make sure the returned directory always exists (even when it falls back to IndexStoragePath)
- Because of the above TryGetDiskCacheResult no longer needs to verify and create the directory if it doesn't exist
