### PR TITLE
Update CommandDataFactory.cs

### DIFF
--- a/Raven.Database/Data/CommandDataFactory.cs
+++ b/Raven.Database/Data/CommandDataFactory.cs
@@ -16,7 +16,10 @@ namespace Raven.Database.Data
 	{
 		public static ICommandData CreateCommand(RavenJObject jsonCommand, TransactionInformation transactionInformation)
 		{
-			var key = jsonCommand["Key"].Value<string>();
+			string key = String.Empty;
+			if (jsonCommand.ContainsKey("Key"))
+			    key = jsonCommand["Key"].Value<string>();
+			    
 			switch (jsonCommand.Value<string>("Method"))
 			{
 				case "PUT":


### PR DESCRIPTION
You need to check if "Key" exists before trying to cast its value to a string. Key was not required in older versions.

I just upgrade from 4ab4776 to 6dce79a and I could no longer use the PUT command without a Key explicitly set to null.
