### PR TITLE
Update HttpJsonRequestFactory.cs - Fixed issue with RequestTimeout being overridden

### DIFF
--- a/Raven.Client.Lightweight/Connection/HttpJsonRequestFactory.cs
+++ b/Raven.Client.Lightweight/Connection/HttpJsonRequestFactory.cs
@@ -73,10 +73,11 @@ namespace Raven.Client.Connection
 				request.SkipServerCheck = cachedRequestDetails.SkipServerCheck;
 			}
 
+			ConfigureRequest(createHttpJsonRequestParams.Owner, new WebRequestEventArgs {Request = request.webRequest, Credentials = createHttpJsonRequestParams.Credentials});
+			
 			if (RequestTimeout != null)
 				request.Timeout = RequestTimeout.Value;
 
-			ConfigureRequest(createHttpJsonRequestParams.Owner, new WebRequestEventArgs {Request = request.webRequest, Credentials = createHttpJsonRequestParams.Credentials});
 			return request;
 		}
 


### PR DESCRIPTION
Swapped the ConfigureRequest and where the RequestTimeout.Value is Set.
Otherwise the timeout value is overridden
