### PR TITLE
Access FieldHighlightings from Projection Query and from Map/Reduce

### DIFF
--- a/Raven.Abstractions/Data/IndexQuery.cs
+++ b/Raven.Abstractions/Data/IndexQuery.cs
@@ -175,6 +175,11 @@ namespace Raven.Abstractions.Data
 	    public string[] HighlighterPostTags { get; set; }
 
         /// <summary>
+        /// Gets or sets the highlighter key
+        /// </summary>
+	    public string HighlighterKeyName { get; set; }
+
+        /// <summary>
         /// Gets or sets the results transformer
         /// </summary>
 	    public string ResultsTransformer { get; set; }
@@ -290,6 +295,11 @@ namespace Raven.Abstractions.Data
             HighlighterPreTags.ApplyIfNotNull(tag=>path.Append("&preTags=").Append(tag));
             HighlighterPostTags.ApplyIfNotNull(tag=>path.Append("&postTags=").Append(tag));
 
+			if (string.IsNullOrEmpty(HighlighterKeyName) == false)
+			{
+				path.AppendFormat("&highlighterKeyName={0}", Uri.EscapeDataString(HighlighterKeyName));
+			}
+
 			if(DebugOptionGetIndexEntries)
 				path.Append("&debug=entries");
 
@@ -359,7 +369,8 @@ namespace Raven.Abstractions.Data
                    DebugOptionGetIndexEntries.Equals(other.DebugOptionGetIndexEntries) && 
                    Equals(HighlightedFields, other.HighlightedFields) && 
                    Equals(HighlighterPreTags, other.HighlighterPreTags) && 
-                   Equals(HighlighterPostTags, other.HighlighterPostTags) && 
+                   Equals(HighlighterPostTags, other.HighlighterPostTags) &&
+				   Equals(HighlighterKeyName, other.HighlighterKeyName) && 
                    String.Equals(ResultsTransformer, other.ResultsTransformer) && 
 				   ShowTimings == other.ShowTimings &&
                    DisableCaching.Equals(other.DisableCaching);
@@ -394,6 +405,7 @@ namespace Raven.Abstractions.Data
                 hashCode = (hashCode * 397) ^ (HighlightedFields != null ? HighlightedFields.GetHashCode() : 0);
                 hashCode = (hashCode * 397) ^ (HighlighterPreTags != null ? HighlighterPreTags.GetHashCode() : 0);
                 hashCode = (hashCode * 397) ^ (HighlighterPostTags != null ? HighlighterPostTags.GetHashCode() : 0);
+				hashCode = (hashCode * 397) ^ (HighlighterKeyName != null ? HighlighterKeyName.GetHashCode() : 0);
                 hashCode = (hashCode * 397) ^ (ResultsTransformer != null ? ResultsTransformer.GetHashCode() : 0);
 				hashCode = (hashCode * 397) ^ (ShowTimings ? 1 : 0);
                 hashCode = (hashCode * 397) ^ DisableCaching.GetHashCode();

--- a/Raven.Abstractions/Data/SpatialIndexQuery.cs
+++ b/Raven.Abstractions/Data/SpatialIndexQuery.cs
@@ -56,6 +56,7 @@ namespace Raven.Abstractions.Data
 		    HighlighterPreTags = query.HighlighterPreTags;
 		    HighlighterPostTags = query.HighlighterPostTags;
 		    HighlightedFields = query.HighlightedFields;
+			HighlighterKeyName = query.HighlighterKeyName;
 	        TransformerParameters = query.TransformerParameters;
 		    ResultsTransformer = query.ResultsTransformer;
 		    DefaultOperator = query.DefaultOperator;

--- a/Raven.Client.Lightweight/Document/AbstractDocumentQuery.cs
+++ b/Raven.Client.Lightweight/Document/AbstractDocumentQuery.cs
@@ -133,6 +133,11 @@ namespace Raven.Client.Document
 		protected string[] highlighterPostTags = new string[0];
 
 		/// <summary>
+		///   Highlighter key
+		/// </summary>
+		protected string highlighterKeyName;
+
+		/// <summary>
 		///   The types to sort the fields by (NULL if not specified)
 		/// </summary>
 		protected HashSet<KeyValuePair<string, Type>> sortByHints = new HashSet<KeyValuePair<string, Type>>();
@@ -831,6 +836,13 @@ namespace Raven.Client.Document
 			return this;
 		}
 
+		IDocumentQueryCustomization IDocumentQueryCustomization.Highlight(
+			string fieldName, string fieldKeyName, int fragmentLength, int fragmentCount, out FieldHighlightings fieldHighlightings)
+		{
+			this.Highlight(fieldName, fieldKeyName, fragmentLength, fragmentCount, out fieldHighlightings);
+			return this;
+		}
+
 	    IDocumentQueryCustomization IDocumentQueryCustomization.SetAllowMultipleIndexEntriesForSameDocumentToResultTransformer(bool val)
 	    {
 	        this.SetAllowMultipleIndexEntriesForSameDocumentToResultTransformer(val);
@@ -906,6 +918,13 @@ namespace Raven.Client.Document
 
 		public void Highlight(string fieldName, int fragmentLength, int fragmentCount, out FieldHighlightings fieldHighlightings)
 		{
+			highlightedFields.Add(new HighlightedField(fieldName, fragmentLength, fragmentCount, null));
+			fieldHighlightings = highlightings.AddField(fieldName);
+		}
+
+		public void Highlight(string fieldName, string fieldKeyName, int fragmentLength, int fragmentCount, out FieldHighlightings fieldHighlightings)
+		{
+			highlighterKeyName = fieldKeyName;
 			highlightedFields.Add(new HighlightedField(fieldName, fragmentLength, fragmentCount, null));
 			fieldHighlightings = highlightings.AddField(fieldName);
 		}
@@ -1839,6 +1858,7 @@ If you really want to do in memory filtering on the data returned from the query
 					HighlightedFields = highlightedFields.Select(x => x.Clone()).ToArray(),
 					HighlighterPreTags = highlighterPreTags.ToArray(),
 					HighlighterPostTags = highlighterPostTags.ToArray(),
+					HighlighterKeyName = highlighterKeyName,
                     ResultsTransformer = resultsTransformer,
                     AllowMultipleIndexEntriesForSameDocumentToResultTransformer = allowMultipleIndexEntriesForSameDocumentToResultTransformer,
                     TransformerParameters  = transformerParameters,
@@ -1864,6 +1884,7 @@ If you really want to do in memory filtering on the data returned from the query
 				HighlightedFields = highlightedFields.Select(x => x.Clone()).ToArray(),
 				HighlighterPreTags = highlighterPreTags.ToArray(),
 				HighlighterPostTags = highlighterPostTags.ToArray(),
+				HighlighterKeyName = highlighterKeyName,
                 ResultsTransformer = this.resultsTransformer,
                 TransformerParameters = transformerParameters,
                 AllowMultipleIndexEntriesForSameDocumentToResultTransformer = allowMultipleIndexEntriesForSameDocumentToResultTransformer,

--- a/Raven.Client.Lightweight/Document/AsyncDocumentQuery.cs
+++ b/Raven.Client.Lightweight/Document/AsyncDocumentQuery.cs
@@ -518,6 +518,13 @@ namespace Raven.Client.Document
 			return this;
 		}
 
+		IAsyncDocumentQuery<T> IDocumentQueryBase<T, IAsyncDocumentQuery<T>>.Highlight(string fieldName, string fieldKeyName, int fragmentLength, int fragmentCount,
+			out FieldHighlightings fieldHighlightings)
+		{
+			this.Highlight(fieldName, fieldKeyName, fragmentLength, fragmentCount, out fieldHighlightings);
+			return this;
+		}
+
 		IAsyncDocumentQuery<T> IDocumentQueryBase<T, IAsyncDocumentQuery<T>>.Highlight<TValue>(
 			Expression<Func<T, TValue>> propertySelector, 
 			int fragmentLength, 
@@ -535,6 +542,14 @@ namespace Raven.Client.Document
 			out FieldHighlightings fieldHighlightings)
 		{
 			this.Highlight(this.GetMemberQueryPath(propertySelector), fragmentLength, fragmentCount, out fieldHighlightings);
+			return this;
+		}
+
+		IAsyncDocumentQuery<T> IDocumentQueryBase<T, IAsyncDocumentQuery<T>>.Highlight<TValue>(
+			Expression<Func<T, TValue>> propertySelector, Expression<Func<T, TValue>> keyPropertySelector, int fragmentLength, int fragmentCount,
+			out FieldHighlightings fieldHighlightings)
+		{
+			this.Highlight(this.GetMemberQueryPath(propertySelector), this.GetMemberQueryPath(keyPropertySelector), fragmentLength, fragmentCount, out fieldHighlightings);
 			return this;
 		}
 

--- a/Raven.Client.Lightweight/Document/DocumentQuery.cs
+++ b/Raven.Client.Lightweight/Document/DocumentQuery.cs
@@ -850,6 +850,17 @@ namespace Raven.Client.Document
 			return this;
 		}
 
+		IDocumentQuery<T> IDocumentQueryBase<T, IDocumentQuery<T>>.Highlight(
+			string fieldName,
+			string fieldKeyName, 
+			int fragmentLength, 
+			int fragmentCount, 
+			out FieldHighlightings highlightings)
+		{
+			this.Highlight(fieldName, fieldKeyName, fragmentLength, fragmentCount, out highlightings);
+			return this;
+		}
+
 		IDocumentQuery<T> IDocumentQueryBase<T, IDocumentQuery<T>>.Highlight<TValue>(
 			Expression<Func<T, TValue>> propertySelector, 
 			int fragmentLength, 
@@ -869,6 +880,17 @@ namespace Raven.Client.Document
 			out FieldHighlightings fieldHighlightings)
 		{
 			this.Highlight(this.GetMemberQueryPath(propertySelector), fragmentLength, fragmentCount, out fieldHighlightings);
+			return this;
+		}
+
+		IDocumentQuery<T> IDocumentQueryBase<T, IDocumentQuery<T>>.Highlight<TValue>(
+			Expression<Func<T, TValue>> propertySelector,
+			Expression<Func<T, TValue>> keyPropertySelector, 
+			int fragmentLength, 
+			int fragmentCount,
+			out FieldHighlightings fieldHighlightings)
+		{
+			this.Highlight(this.GetMemberQueryPath(propertySelector), this.GetMemberQueryPath(keyPropertySelector), fragmentLength, fragmentCount, out fieldHighlightings);
 			return this;
 		}
 

--- a/Raven.Client.Lightweight/Document/IAbstractDocumentQuery.cs
+++ b/Raven.Client.Lightweight/Document/IAbstractDocumentQuery.cs
@@ -271,6 +271,21 @@ namespace Raven.Client.Document
 		void Highlight(string fieldName, int fragmentLength, int fragmentCount, out FieldHighlightings highlightings);
 
 		/// <summary>
+		///   Adds matches highlighting for the specified field on a Map/Reduce Index.
+		/// </summary>
+		/// <remarks>
+		///   This is only valid for Map/Reduce Index querys.
+		///   The specified field and key should be analysed and stored for highlighter to work.
+		///   For each match it creates a fragment that contains matched text surrounded by highlighter tags.
+		/// </remarks>
+		/// <param name="fieldName">The field name to highlight.</param>
+		/// <param name="fieldKeyName">The field key to associate highlights with.</param>
+		/// <param name="fragmentLength">The fragment length.</param>
+		/// <param name="fragmentCount">The maximum number of fragments for the field.</param>
+		/// <param name="highlightings">Field highlightings for all results.</param>
+		void Highlight(string fieldName, string fieldKeyName, int fragmentLength, int fragmentCount, out FieldHighlightings highlightings);
+
+		/// <summary>
 		///   Sets the tags to highlight matches with.
 		/// </summary>
 		/// <param name="preTag">Prefix tag.</param>

--- a/Raven.Client.Lightweight/FieldHighlightings.cs
+++ b/Raven.Client.Lightweight/FieldHighlightings.cs
@@ -30,13 +30,13 @@ namespace Raven.Client
 		/// <summary>
 		///     Returns the list of document's field highlighting fragments.
 		/// </summary>
-		/// <param name="documentId">The document id.</param>
+		/// <param name="key">The document id, or the map/reduce key field.</param>
 		/// <returns></returns>
-		public string[] GetFragments(string documentId)
+		public string[] GetFragments(string key)
 		{
 			string[] result;
 
-			if (!this.highlightings.TryGetValue(documentId, out result))
+			if (!this.highlightings.TryGetValue(key, out result))
 				return new string[0];
 
 			return result;

--- a/Raven.Client.Lightweight/IDocumentQueryBase.cs
+++ b/Raven.Client.Lightweight/IDocumentQueryBase.cs
@@ -421,7 +421,23 @@ If you really want to do in memory filtering on the data returned from the query
 		/// <param name="fieldName">The field name to highlight.</param>
 		/// <param name="fragmentLength">The fragment length.</param>
 		/// <param name="fragmentCount">The maximum number of fragments for the field.</param>
+		/// <param name="highlightings">Field highlightings for all results.</param>
 		TSelf Highlight(string fieldName, int fragmentLength, int fragmentCount, out FieldHighlightings highlightings);
+
+		/// <summary>
+		///   Adds matches highlighting for the specified field on a Map/Reduce Index.
+		/// </summary>
+		/// <remarks>
+		///   This is only valid for Map/Reduce Index querys.
+		///   The specified field and key should be analysed and stored for highlighter to work.
+		///   For each match it creates a fragment that contains matched text surrounded by highlighter tags.
+		/// </remarks>
+		/// <param name="fieldName">The field name to highlight.</param>
+		/// <param name="fieldKeyName">The field key name to associate highlights with.</param>
+		/// <param name="fragmentLength">The fragment length.</param>
+		/// <param name="fragmentCount">The maximum number of fragments for the field.</param>
+		/// <param name="highlightings">Field highlightings for all results.</param>
+		TSelf Highlight(string fieldName, string fieldKeyName, int fragmentLength, int fragmentCount, out FieldHighlightings highlightings);
 
 		/// <summary>
 		///   Adds matches highlighting for the specified field.
@@ -450,8 +466,29 @@ If you really want to do in memory filtering on the data returned from the query
 		/// <param name="propertySelector">The property to highlight.</param>
 		/// <param name="fragmentLength">The fragment length.</param>
 		/// <param name="fragmentCount">The maximum number of fragments for the field.</param>
+		/// <param name="highlightings">Field highlightings for all results.</param>
 		TSelf Highlight<TValue>(
 			Expression<Func<T, TValue>> propertySelector, 
+			int fragmentLength, 
+			int fragmentCount,
+			out FieldHighlightings highlightings);
+
+		/// <summary>
+		///   Adds matches highlighting for the specified field on a Map/Reduce Index.
+		/// </summary>
+		/// <remarks>
+		///   This is only valid for Map/Reduce Index querys.
+		///   The specified fields should be analysed and stored for highlighter to work.
+		///   For each match it creates a fragment that contains matched text surrounded by highlighter tags.
+		/// </remarks>
+		/// <param name="propertySelector">The property to highlight.</param>
+		/// <param name="keyPropertySelector">The key property to associate highlights with.</param>
+		/// <param name="fragmentLength">The fragment length.</param>
+		/// <param name="fragmentCount">The maximum number of fragments for the field.</param>
+		/// <param name="highlightings">Field highlightings for all results.</param>
+		TSelf Highlight<TValue>(
+			Expression<Func<T, TValue>> propertySelector,
+			Expression<Func<T, TValue>> keyPropertySelector, 
 			int fragmentLength, 
 			int fragmentCount,
 			out FieldHighlightings highlightings);

--- a/Raven.Client.Lightweight/IDocumentQueryCustomization.cs
+++ b/Raven.Client.Lightweight/IDocumentQueryCustomization.cs
@@ -194,6 +194,21 @@ namespace Raven.Client
 		IDocumentQueryCustomization Highlight(string fieldName, int fragmentLength, int fragmentCount, out FieldHighlightings highlightings);
 
 		/// <summary>
+		///   Adds matches highlighting for the specified field on a Map/Reduce Index.
+		/// </summary>
+		/// <remarks>
+		///   This is only valid for Map/Reduce Index querys.
+		///   The specified field and key should be analysed and stored for highlighter to work.
+		///   For each match it creates a fragment that contains matched text surrounded by highlighter tags.
+		/// </remarks>
+		/// <param name="fieldName">The field name to highlight.</param>
+		/// <param name="fieldKeyName">The field key to associate highlights with.</param>
+		/// <param name="fragmentLength">The fragment length.</param>
+		/// <param name="fragmentCount">The maximum number of fragments for the field.</param>
+		/// <param name="highlightings">Field highlightings for all results.</param>
+		IDocumentQueryCustomization Highlight(string fieldName, string fieldKeyName, int fragmentLength, int fragmentCount, out FieldHighlightings highlightings);
+
+		/// <summary>
 		///   Sets the tags to highlight matches with.
 		/// </summary>
 		/// <param name="preTag">Prefix tag.</param>

--- a/Raven.Database/Actions/QueryActions.cs
+++ b/Raven.Database/Actions/QueryActions.cs
@@ -174,11 +174,9 @@ namespace Raven.Database.Actions
                 scoreExplanations = new Dictionary<string, string>();
                 Func<IndexQueryResult, object> tryRecordHighlightingAndScoreExplanation = queryResult =>
                 {
-                    if (queryResult.Key == null)
-                        return null;
-                    if (queryResult.Highligtings != null)
-                        highlightings.Add(queryResult.Key, queryResult.Highligtings);
-                    if (queryResult.ScoreExplanation != null)
+                    if (queryResult.Highligtings != null && (queryResult.Key != null || queryResult.HighlighterKey != null))
+						highlightings.Add(queryResult.Key ?? queryResult.HighlighterKey, queryResult.Highligtings);
+                    if (queryResult.Key != null && queryResult.ScoreExplanation != null)
                         scoreExplanations.Add(queryResult.Key, queryResult.ScoreExplanation);
                     return null;
                 };

--- a/Raven.Database/Data/IndexQueryResult.cs
+++ b/Raven.Database/Data/IndexQueryResult.cs
@@ -16,6 +16,7 @@ namespace Raven.Database.Data
 
 		public float Score { get; set; }
 	    public Dictionary<string, string[]> Highligtings { get; set; }
+		public string HighlighterKey { get; set; }
 		public string ScoreExplanation { get; set; }
 
 		public bool Equals(IndexQueryResult other)

--- a/Raven.Database/Impl/DatabaseBulkOperations.cs
+++ b/Raven.Database/Impl/DatabaseBulkOperations.cs
@@ -78,6 +78,7 @@ namespace Raven.Database.Impl
 				HighlighterPreTags = indexQuery.HighlighterPreTags,
 				HighlighterPostTags = indexQuery.HighlighterPostTags,
 				HighlightedFields = indexQuery.HighlightedFields,
+				HighlighterKeyName = indexQuery.HighlighterKeyName,
 				SortHints = indexQuery.SortHints
 			};
 

--- a/Raven.Database/Indexing/Index.cs
+++ b/Raven.Database/Indexing/Index.cs
@@ -1142,6 +1142,10 @@ namespace Raven.Database.Indexing
 								var scoreDoc = search.ScoreDocs[position];
 								var document = indexSearcher.Doc(scoreDoc.Doc);
 								var indexQueryResult = parent.RetrieveDocument(document, fieldsToFetch, scoreDoc);
+								if (indexQueryResult.Key == null && !string.IsNullOrEmpty(indexQuery.HighlighterKeyName))
+								{
+									indexQueryResult.HighlighterKey = document.Get(indexQuery.HighlighterKeyName);
+								}
 								
 								if (ShouldIncludeInResults(indexQueryResult) == false)
 								{
@@ -1271,10 +1275,7 @@ namespace Raven.Database.Indexing
 					}
 				}
 
-				if (!parent.IsMapReduce)
-				{
-					indexQueryResult.Highligtings = highlightings.ToDictionary(x => x.Field, x => x.Fragments);
-				}
+				indexQueryResult.Highligtings = highlightings.ToDictionary(x => x.Field, x => x.Fragments);
 			}
 
 			private void SetupHighlighter(Query documentQuery)

--- a/Raven.Database/Queries/DynamicQueryRunner.cs
+++ b/Raven.Database/Queries/DynamicQueryRunner.cs
@@ -95,6 +95,7 @@ namespace Raven.Database.Queries
 				HighlighterPreTags = query.HighlighterPreTags,
 				HighlighterPostTags = query.HighlighterPostTags,
 				HighlightedFields = query.HighlightedFields,
+				HighlighterKeyName = query.HighlighterKeyName,
 				ResultsTransformer = query.ResultsTransformer,
 				TransformerParameters = query.TransformerParameters,
 				ExplainScores = query.ExplainScores,

--- a/Raven.Database/Server/Controllers/RavenDbApiController.cs
+++ b/Raven.Database/Server/Controllers/RavenDbApiController.cs
@@ -242,6 +242,7 @@ namespace Raven.Database.Server.Controllers
 				HighlightedFields = GetHighlightedFields().ToArray(),
 				HighlighterPreTags = GetQueryStringValues("preTags"),
 				HighlighterPostTags = GetQueryStringValues("postTags"),
+				HighlighterKeyName = GetQueryStringValue("highlighterKeyName"),
 				ResultsTransformer = GetQueryStringValue("resultsTransformer"),
 				TransformerParameters = ExtractTransformerParameters(),
 				ExplainScores = GetExplainScores(),

--- a/Raven.Tests/Indexes/HighlightTesting.cs
+++ b/Raven.Tests/Indexes/HighlightTesting.cs
@@ -298,7 +298,7 @@ So, the greedy dog looked at his reflection and growled. The reflection growled 
 				FieldHighlightings nameHighlighting;
 				var results = session.Advanced.DocumentQuery<SearchItemWithTypeResult>("ContentSearchMapReduceIndex")
 									 .WaitForNonStaleResults()
-									 .Highlight("AllText", 128, 1, out nameHighlighting)
+									 .Highlight("AllText", "Type", 128, 1, out nameHighlighting)
 									 .Search("AllText", searchFor)
 									 .ToArray();
 


### PR DESCRIPTION
This includes tests and updates to allow for .Highlight(..., out fieldHighlightings) syntax when querying with a projection or a map-reduce.

Previously this was only possible for querying directly on a document, and the fieldHighlightings were associated with the document by id.
Previously you could only get fieldHighlightings when querying with a projection or a map-reduce by storing the field on the projected object - which is sometimes undesirable.

Now .Highlight(..., out fieldHighlightings) works with projections by associating the fieldHighlightings with the original document.
Additionally, the same now works with map-reduce by providing the field name of a field on the reduce object of which the value is always unique - this can easily be the reduce key.

Related topic on mailing list - https://groups.google.com/forum/#!topic/ravendb/pShFMqb-6Y8
