### PR TITLE
Implemented the "AssembliesDirectory" configuration option to specify where the internal assemblies will be extracted to.

### DIFF
--- a/Raven.Abstractions/Data/Constants.cs
+++ b/Raven.Abstractions/Data/Constants.cs
@@ -154,9 +154,7 @@ namespace Raven.Abstractions.Data
 		/// if no encoding information in headers of incoming request, this encoding is assumed
 		/// </summary>
 		public const string DefaultRequestEncoding = "UTF-8";
-
-	    public const string AssembliesDirectoryName = "Assemblies";
-
+        
 		public const string DocumentsByEntityNameIndex = "Raven/DocumentsByEntityName";
 		
 		//Counters

--- a/Raven.Abstractions/Util/AssemblyHelper.cs
+++ b/Raven.Abstractions/Util/AssemblyHelper.cs
@@ -34,16 +34,5 @@ namespace Raven.Abstractions.Util
 
             return location;
         }
-
-        public static string GetExtractedAssemblyLocationFor(Type type, Assembly executingAssembly)
-        {
-            if (File.Exists(type.Assembly.Location))
-                return type.Assembly.Location;
-
-            var path = Path.GetDirectoryName(executingAssembly.Location);
-            var name = type.Assembly.GetName().Name;
-
-            return Path.Combine(path, Constants.AssembliesDirectoryName, name + ".dll");
-        }
     }
 }

--- a/Raven.Database/Config/InMemoryRavenConfiguration.cs
+++ b/Raven.Database/Config/InMemoryRavenConfiguration.cs
@@ -246,6 +246,8 @@ namespace Raven.Database.Config
 
 		    AssembliesDirectory = ravenSettings.AssembliesDirectory.Value.ToFullPath();
 
+		    EmbeddedFilesDirectory = ravenSettings.EmbeddedFilesDirectory.Value.ToFullPath();
+
 			CompiledIndexCacheDirectory = ravenSettings.CompiledIndexCacheDirectory.Value.ToFullPath();
 
 			var taskSchedulerType = ravenSettings.TaskScheduler.Value;
@@ -796,6 +798,12 @@ namespace Raven.Database.Config
         /// Default: ~\Assemblies
         /// </summary>
         public string AssembliesDirectory { get; set; }
+
+        /// <summary>
+        /// Where we search for embedded files.
+        /// Default: null
+        /// </summary>
+        public string EmbeddedFilesDirectory { get; set; }
 
 		public bool CreatePluginsDirectoryIfNotExisting { get; set; }
 		public bool CreateAnalyzersDirectoryIfNotExisting { get; set; }

--- a/Raven.Database/Config/InMemoryRavenConfiguration.cs
+++ b/Raven.Database/Config/InMemoryRavenConfiguration.cs
@@ -1145,6 +1145,8 @@ namespace Raven.Database.Config
 
 		    Encryption.UseSsl = defaultConfiguration.Encryption.UseSsl;
 		    Encryption.UseFips = defaultConfiguration.Encryption.UseFips;
+
+		    AssembliesDirectory = defaultConfiguration.AssembliesDirectory;
 		}
 
 		public IEnumerable<string> GetConfigOptionsDocs()

--- a/Raven.Database/Config/InMemoryRavenConfiguration.cs
+++ b/Raven.Database/Config/InMemoryRavenConfiguration.cs
@@ -244,6 +244,8 @@ namespace Raven.Database.Config
 
 			PluginsDirectory = ravenSettings.PluginsDirectory.Value.ToFullPath();
 
+		    AssembliesDirectory = ravenSettings.AssembliesDirectory.Value.ToFullPath();
+
 			CompiledIndexCacheDirectory = ravenSettings.CompiledIndexCacheDirectory.Value.ToFullPath();
 
 			var taskSchedulerType = ravenSettings.TaskScheduler.Value;
@@ -788,6 +790,12 @@ namespace Raven.Database.Config
 				}
 			}
 		}
+
+        /// <summary>
+        /// Where the internal assemblies will be extracted to.
+        /// Default: ~\Assemblies
+        /// </summary>
+        public string AssembliesDirectory { get; set; }
 
 		public bool CreatePluginsDirectoryIfNotExisting { get; set; }
 		public bool CreateAnalyzersDirectoryIfNotExisting { get; set; }

--- a/Raven.Database/Config/StronglyTypedRavenSettings.cs
+++ b/Raven.Database/Config/StronglyTypedRavenSettings.cs
@@ -141,6 +141,8 @@ namespace Raven.Database.Config
 				new StringSetting(settings["Raven/WebDir"], GetDefaultWebDir);
 			PluginsDirectory =
 				new StringSetting(settings["Raven/PluginsDirectory"], @"~\Plugins");
+            AssembliesDirectory =
+                new StringSetting(settings["Raven/AssembliesDirectory"], @"~\Assemblies");
 			CompiledIndexCacheDirectory =
 				new StringSetting(settings["Raven/CompiledIndexCacheDirectory"], @"~\Raven\CompiledIndexCache");
 			TaskScheduler =
@@ -308,6 +310,8 @@ namespace Raven.Database.Config
 		public StringSetting PluginsDirectory { get; private set; }
 
 		public StringSetting CompiledIndexCacheDirectory { get; private set; }
+
+        public StringSetting AssembliesDirectory { get; private set; }
 
 		public StringSetting TaskScheduler { get; private set; }
 

--- a/Raven.Database/Config/StronglyTypedRavenSettings.cs
+++ b/Raven.Database/Config/StronglyTypedRavenSettings.cs
@@ -143,6 +143,8 @@ namespace Raven.Database.Config
 				new StringSetting(settings["Raven/PluginsDirectory"], @"~\Plugins");
             AssembliesDirectory =
                 new StringSetting(settings["Raven/AssembliesDirectory"], @"~\Assemblies");
+            EmbeddedFilesDirectory =
+                new StringSetting(settings["Raven/EmbeddedFilesDirectory"], (string)null);
 			CompiledIndexCacheDirectory =
 				new StringSetting(settings["Raven/CompiledIndexCacheDirectory"], @"~\Raven\CompiledIndexCache");
 			TaskScheduler =
@@ -312,6 +314,8 @@ namespace Raven.Database.Config
 		public StringSetting CompiledIndexCacheDirectory { get; private set; }
 
         public StringSetting AssembliesDirectory { get; private set; }
+
+        public StringSetting EmbeddedFilesDirectory { get; private set; }
 
 		public StringSetting TaskScheduler { get; private set; }
 

--- a/Raven.Database/Linq/QueryParsingUtils.cs
+++ b/Raven.Database/Linq/QueryParsingUtils.cs
@@ -33,6 +33,7 @@ using Raven.Database.Indexing;
 using Raven.Database.Linq.Ast;
 using Raven.Database.Linq.PrivateExtensions;
 using Raven.Database.Plugins;
+using Raven.Database.Server;
 using Raven.Database.Storage;
 using Binder = Microsoft.CSharp.RuntimeBinder.Binder;
 
@@ -312,7 +313,7 @@ namespace Raven.Database.Linq
 					return type;
 			}
 
-			var result = DoActualCompilation(source, name, queryText, extensions, basePath, indexFilePath);
+			var result = DoActualCompilation(source, name, queryText, extensions, basePath, indexFilePath, configuration);
 
 			// ReSharper disable once RedundantArgumentName
 			AddResultToCache(source, result, shouldUpdateIfExists: shouldCachedIndexBeRecompiled);
@@ -447,10 +448,9 @@ namespace Raven.Database.Linq
 		}
 
 		private static Type DoActualCompilation(string source, string name, string queryText, OrderedPartCollection<AbstractDynamicCompilationExtension> extensions,
-												string basePath, string indexFilePath)
+												string basePath, string indexFilePath, InMemoryRavenConfiguration configuration)
 		{
 			var provider = new CSharpCodeProvider(new Dictionary<string, string> { { "CompilerVersion", "v4.0" } });
-			var currentAssembly = typeof(QueryParsingUtils).Assembly;
 
 			var assemblies = new HashSet<string>
 			{
@@ -459,7 +459,7 @@ namespace Raven.Database.Linq
 				typeof (NameValueCollection).Assembly.Location,
 				typeof (Enumerable).Assembly.Location,
 				typeof (Binder).Assembly.Location,
-				AssemblyHelper.GetExtractedAssemblyLocationFor(typeof(Field), currentAssembly),
+                AssemblyExtractor.GetExtractedAssemblyLocationFor(typeof(Field), configuration),
 			};
 			foreach (var extension in extensions)
 			{

--- a/Raven.Database/Server/AppBuilderExtensions.cs
+++ b/Raven.Database/Server/AppBuilderExtensions.cs
@@ -67,7 +67,7 @@ namespace Owin
 				}
 			}
 
-            AssemblyExtractor.ExtractEmbeddedAssemblies();
+            AssemblyExtractor.ExtractEmbeddedAssemblies(options.SystemDatabase.Configuration);
 
 #if DEBUG
 			app.UseInterceptor();

--- a/Raven.Database/Server/AssemblyExtractor.cs
+++ b/Raven.Database/Server/AssemblyExtractor.cs
@@ -14,6 +14,7 @@ using Lucene.Net.Documents;
 
 using Raven.Abstractions;
 using Raven.Abstractions.Data;
+using Raven.Database.Config;
 
 namespace Raven.Database.Server
 {
@@ -22,15 +23,26 @@ namespace Raven.Database.Server
         private const string AssemblySuffix = ".dll";
 
         private const string CompressedAssemblySuffix = AssemblySuffix + ".zip";
+        
+        public static string GetExtractedAssemblyLocationFor(Type type, InMemoryRavenConfiguration configuration)
+        {
+            if (File.Exists(type.Assembly.Location))
+                return type.Assembly.Location;
 
-        public static void ExtractEmbeddedAssemblies()
+            var name = type.Assembly.GetName().Name;
+
+            return Path.Combine(configuration.AssembliesDirectory, name + AssemblySuffix);
+        }
+
+        public static void ExtractEmbeddedAssemblies(InMemoryRavenConfiguration configuration)
         {
             var assemblies = new HashSet<string> { 
                 typeof(Field).Assembly.GetName().Name 
             };
 
+            var assemblyLocation = configuration.AssembliesDirectory;
+
             var assembly = Assembly.GetExecutingAssembly();
-            var assemblyLocation = Path.Combine(Path.GetDirectoryName(assembly.Location), Constants.AssembliesDirectoryName + "\\");
             var assembliesToExtract = FindAssembliesToExtract(assembly, assemblies);
 
           

--- a/Raven.Database/Server/Controllers/RavenBaseApiController.cs
+++ b/Raven.Database/Server/Controllers/RavenBaseApiController.cs
@@ -485,20 +485,28 @@ namespace Raven.Database.Server.Controllers
 			var filePath = Path.Combine(ravenPath, docPath);
 			if (File.Exists(filePath))
 				return WriteFile(filePath);
-			filePath = Path.Combine(AppDomain.CurrentDomain.BaseDirectory, "../Raven.Studio.Html5/", docPath);
+			
+            filePath = Path.Combine(AppDomain.CurrentDomain.BaseDirectory, "../Raven.Studio.Html5/", docPath);
 			if (File.Exists(filePath))
 				return WriteFile(filePath);
+
+		    filePath = Path.Combine(this.SystemConfiguration.EmbeddedFilesDirectory, docPath);
+		    if (File.Exists(filePath))
+		        return WriteFile(filePath);
 
             filePath = Path.Combine("~/../../../../Raven.Studio.Html5", docPath);
             if (File.Exists(filePath))
                 return WriteFile(filePath);
 
-
 			if (string.IsNullOrEmpty(zipPath) == false)
 			{
 			    var fullZipPath = Path.Combine(AppDomain.CurrentDomain.BaseDirectory, zipPath + ".zip");
+
 				if (File.Exists(fullZipPath) == false)
 					fullZipPath = Path.Combine(AppDomain.CurrentDomain.BaseDirectory, "bin", zipPath + ".zip");
+
+			    if (File.Exists(fullZipPath) == false)
+			        fullZipPath = Path.Combine(this.SystemConfiguration.EmbeddedFilesDirectory, zipPath + ".zip");
 
 				if (File.Exists(fullZipPath))
 				{

--- a/Raven.Tests.Core/Configuration/ConfigurationTests.cs
+++ b/Raven.Tests.Core/Configuration/ConfigurationTests.cs
@@ -127,6 +127,7 @@ namespace Raven.Tests.Core.Configuration
 			configurationComparer.Assert(expected => FilePathTools.MakeSureEndsWithSlash(expected.DataDir.Value.ToFullPath(null)), actual => actual.DataDirectory);
 			configurationComparer.Assert(expected => FilePathTools.MakeSureEndsWithSlash(expected.CountersDataDir.Value.ToFullPath(null)), actual => actual.CountersDataDirectory);
 			configurationComparer.Assert(expected => expected.PluginsDirectory.Value.ToFullPath(null), actual => actual.PluginsDirectory);
+            configurationComparer.Assert(expected => expected.AssembliesDirectory.Value.ToFullPath(null), actual => actual.AssembliesDirectory);
 			configurationComparer.Assert(expected => FilePathTools.MakeSureEndsWithSlash(expected.FileSystem.DataDir.Value.ToFullPath(null)), actual => actual.FileSystem.DataDirectory);
 			configurationComparer.Assert(expected => FilePathTools.MakeSureEndsWithSlash(expected.FileSystem.DataDir.Value.ToFullPath(null)) + @"Indexes", actual => actual.FileSystem.IndexStoragePath);
 			configurationComparer.Assert(expected => expected.FileSystem.DefaultStorageTypeName.Value, actual => actual.FileSystem.DefaultStorageTypeName);

--- a/Raven.Tests.Core/Configuration/ConfigurationTests.cs
+++ b/Raven.Tests.Core/Configuration/ConfigurationTests.cs
@@ -128,6 +128,7 @@ namespace Raven.Tests.Core.Configuration
 			configurationComparer.Assert(expected => FilePathTools.MakeSureEndsWithSlash(expected.CountersDataDir.Value.ToFullPath(null)), actual => actual.CountersDataDirectory);
 			configurationComparer.Assert(expected => expected.PluginsDirectory.Value.ToFullPath(null), actual => actual.PluginsDirectory);
             configurationComparer.Assert(expected => expected.AssembliesDirectory.Value.ToFullPath(null), actual => actual.AssembliesDirectory);
+            configurationComparer.Assert(expected => expected.EmbeddedFilesDirectory.Value.ToFullPath(null), actual => actual.EmbeddedFilesDirectory);
 			configurationComparer.Assert(expected => FilePathTools.MakeSureEndsWithSlash(expected.FileSystem.DataDir.Value.ToFullPath(null)), actual => actual.FileSystem.DataDirectory);
 			configurationComparer.Assert(expected => FilePathTools.MakeSureEndsWithSlash(expected.FileSystem.DataDir.Value.ToFullPath(null)) + @"Indexes", actual => actual.FileSystem.IndexStoragePath);
 			configurationComparer.Assert(expected => expected.FileSystem.DefaultStorageTypeName.Value, actual => actual.FileSystem.DefaultStorageTypeName);


### PR DESCRIPTION
This was previously not possible, so I thought, yeah, let me just do it by myself.
There's now a new setting *Raven/AssembliesDirectory*.
I also ran the tests, and they all seemed fine, although I'm not really familiar with the way costura works, so you propably should try it by yourself.

**Note**
I needed to move the *GetExtractedAssemblyLocationFor* method from the *AssemblyHelper* class to place where I have access to the *InMemoryRavenConfiguration*.
So I moved this method to the *AssemblyExtractor* class.

I will propably send you the copyright assignment agreement tomorrow.

Relevant mailing list thread:
https://groups.google.com/forum/#!topic/ravendb/d_lGhyCfRMA