### PR TITLE
Only increment read stripe once when creating a session. Previously this...

### DIFF
--- a/Raven.Client.Lightweight/Connection/Async/AsyncServerClient.cs
+++ b/Raven.Client.Lightweight/Connection/Async/AsyncServerClient.cs
@@ -84,7 +84,7 @@ namespace Raven.Client.Connection.Async
 		public AsyncServerClient(string url, DocumentConvention convention, OperationCredentials credentials,
 								 HttpJsonRequestFactory jsonRequestFactory, Guid? sessionId,
 								 Func<string, IDocumentStoreReplicationInformer> replicationInformerGetter, string databaseName,
-								 IDocumentConflictListener[] conflictListeners)
+								 IDocumentConflictListener[] conflictListeners, bool incrementReadStripe)
 		{
 			profilingInformation = ProfilingInformation.CreateProfilingInformation(sessionId);
 			this.url = url;
@@ -104,7 +104,7 @@ namespace Raven.Client.Connection.Async
 			this.conflictListeners = conflictListeners;
 			this.replicationInformerGetter = replicationInformerGetter;
 			this.replicationInformer = replicationInformerGetter(databaseName);
-			this.readStripingBase = replicationInformer.GetReadStripingBase();
+            this.readStripingBase = replicationInformer.GetReadStripingBase(incrementReadStripe);
 
 			this.replicationInformer.UpdateReplicationInformationIfNeeded(this);
 		}
@@ -598,7 +598,7 @@ namespace Raven.Client.Connection.Async
 			if (databaseUrl == url)
 				return this;
 			return new AsyncServerClient(databaseUrl, convention, credentialsThatShouldBeUsedOnlyInOperationsWithoutReplication, jsonRequestFactory, sessionId,
-										 replicationInformerGetter, database, conflictListeners)
+										 replicationInformerGetter, database, conflictListeners, false)
 			{
 				operationsHeaders = operationsHeaders
 			};
@@ -614,7 +614,7 @@ namespace Raven.Client.Connection.Async
 			if (databaseUrl == url)
 				return this;
 			return new AsyncServerClient(databaseUrl, convention, credentialsThatShouldBeUsedOnlyInOperationsWithoutReplication, jsonRequestFactory, sessionId,
-										 replicationInformerGetter, databaseName, conflictListeners)
+										 replicationInformerGetter, databaseName, conflictListeners, false)
 			{
 				operationsHeaders = operationsHeaders
 			};
@@ -2403,7 +2403,7 @@ namespace Raven.Client.Connection.Async
 		public IAsyncDatabaseCommands With(ICredentials credentialsForSession)
 		{
 			return new AsyncServerClient(url, convention, new OperationCredentials(credentialsThatShouldBeUsedOnlyInOperationsWithoutReplication.ApiKey, credentialsForSession), jsonRequestFactory, sessionId,
-										 replicationInformerGetter, databaseName, conflictListeners);
+										 replicationInformerGetter, databaseName, conflictListeners, false);
 		}
 
 		internal async Task<ReplicationDocument> DirectGetReplicationDestinationsAsync(OperationMetadata operationMetadata)

--- a/Raven.Client.Lightweight/Connection/Async/AsyncServerClientBase.cs
+++ b/Raven.Client.Lightweight/Connection/Async/AsyncServerClientBase.cs
@@ -30,7 +30,7 @@ namespace Raven.Client.Connection.Async
                 this.OperationsHeaders = new NameValueCollection();
 
             this._replicationInformer = new Lazy<TReplicationInformer>(GetReplicationInformer, true);
-            this.readStrippingBase = new Lazy<int>(() => this.ReplicationInformer.GetReadStripingBase(), true);
+            this.readStrippingBase = new Lazy<int>(() => this.ReplicationInformer.GetReadStripingBase(true), true);
 
             this.MaxQuerySizeForGetRequest = 8 * 1024;
         }

--- a/Raven.Client.Lightweight/Connection/IReplicationInformerBase.cs
+++ b/Raven.Client.Lightweight/Connection/IReplicationInformerBase.cs
@@ -40,7 +40,7 @@ namespace Raven.Client.Connection
         /// </summary>
         DateTime GetFailureLastCheck(string operationUrl);
 
-        int GetReadStripingBase();
+        int GetReadStripingBase(bool increment);
 
         Task<T> ExecuteWithReplicationAsync<T>(string method, string primaryUrl, OperationCredentials primaryCredentials, int currentRequest, int currentReadStripingBase, Func<OperationMetadata, Task<T>> operation);
 

--- a/Raven.Client.Lightweight/Connection/ReplicationInformerBase.cs
+++ b/Raven.Client.Lightweight/Connection/ReplicationInformerBase.cs
@@ -272,9 +272,9 @@ namespace Raven.Client.Connection
 			}
 		}
 
-		public virtual int GetReadStripingBase()
+		public virtual int GetReadStripingBase(bool increment)
 		{
-			return Interlocked.Increment(ref readStripingBase);
+            return increment ? Interlocked.Increment(ref readStripingBase) : readStripingBase;
 		}
 		
         public async Task<T> ExecuteWithReplicationAsync<T>(string method, string primaryUrl, OperationCredentials primaryCredentials, int currentRequest, int currentReadStripingBase, Func<OperationMetadata, Task<T>> operation)

--- a/Raven.Client.Lightweight/Document/DocumentStore.cs
+++ b/Raven.Client.Lightweight/Document/DocumentStore.cs
@@ -612,12 +612,12 @@ namespace Raven.Client.Document
 				}
 				return new ServerClient(new AsyncServerClient(databaseUrl, Conventions, new OperationCredentials(ApiKey, Credentials), jsonRequestFactory,
 					currentSessionId, GetReplicationInformerForDatabase, null,
-					Listeners.ConflictListeners));
+					Listeners.ConflictListeners, true));
 			};
 
 			asyncDatabaseCommandsGenerator = () =>
 			{
-				var asyncServerClient = new AsyncServerClient(Url, Conventions, new OperationCredentials(ApiKey, Credentials), jsonRequestFactory, currentSessionId, GetReplicationInformerForDatabase, null, Listeners.ConflictListeners);
+				var asyncServerClient = new AsyncServerClient(Url, Conventions, new OperationCredentials(ApiKey, Credentials), jsonRequestFactory, currentSessionId, GetReplicationInformerForDatabase, null, Listeners.ConflictListeners, true);
 
 				if (string.IsNullOrEmpty(DefaultDatabase))
 					return asyncServerClient;

--- a/Raven.Tests.Core/ChangesApi/ImplementingChangesClient.cs
+++ b/Raven.Tests.Core/ChangesApi/ImplementingChangesClient.cs
@@ -176,7 +176,7 @@ namespace Raven.Tests.Core.ChangesApi
                 throw new NotImplementedException();
             }
 
-            public int GetReadStripingBase()
+            public int GetReadStripingBase(bool increment)
             {
                 throw new NotImplementedException();
             }


### PR DESCRIPTION
... was being called twice per session creation which breaks the round robin reads from all servers

I noticed when read from all servers was enabled and I had just 2 servers in my cluster that no reads were going to the secondary, this was because the readStripingBase field of ReplicationInformerBase was being incremented twice each time a session was created.

So the change I have made only increments readStripingBase when instantiating the AsyncServerClient via the databaseCommandsGenerator and asyncDatabaseCommandsGenerator.

I left the AsyncServerClientBase (only used by AsyncFilesServerClient) incrementing the readStripingBase field whenever its instantiated, I am unsure whether you need to change the behaviour here or not.
