### PR TITLE
Smuggler: Fix NPE with Username/Password Credentials

### DIFF
--- a/Raven.Smuggler/Program.cs
+++ b/Raven.Smuggler/Program.cs
@@ -132,12 +132,12 @@ namespace Raven.Smuggler
                 {"h|?|help", v => PrintUsageAndExit(0)},
                 {"timeout:", "The timeout to use for requests", s => databaseOptions.Timeout = TimeSpan.FromMilliseconds(int.Parse(s)) },
                 {"incremental", "States usage of incremental operations", _ => databaseOptions.Incremental = true },
-			    {"u|user|username:", "The username to use when the database requires the client to authenticate.", value => ((NetworkCredential)databaseOptions.Source.Credentials).UserName = value },
-			    {"u2|user2|username2:", "The username to use when the database requires the client to authenticate. This parameter is used only in the between operation.", value => ((NetworkCredential)databaseOptions.Destination.Credentials).UserName = value },
-			    {"p|pass|password:", "The password to use when the database requires the client to authenticate.", value => ((NetworkCredential) databaseOptions.Source.Credentials).Password = value },
-			    {"p2|pass2|password2:", "The password to use when the database requires the client to authenticate. This parameter is used only in the between operation.", value => ((NetworkCredential)databaseOptions.Destination.Credentials).Password = value },
-			    {"domain:", "The domain to use when the database requires the client to authenticate.", value => ((NetworkCredential)databaseOptions.Source.Credentials).Domain = value },
-			    {"domain2:", "The domain to use when the database requires the client to authenticate. This parameter is used only in the between operation.", value => ((NetworkCredential)databaseOptions.Destination.Credentials).Domain = value },
+			    {"u|user|username:", "The username to use when the database requires the client to authenticate.", value => GetOrCreateNetworkCredential(databaseOptions.Source).UserName = value },
+			    {"u2|user2|username2:", "The username to use when the database requires the client to authenticate. This parameter is used only in the between operation.", value => GetOrCreateNetworkCredential(databaseOptions.Destination).UserName = value },
+			    {"p|pass|password:", "The password to use when the database requires the client to authenticate.", value => GetOrCreateNetworkCredential(databaseOptions.Source).Password = value },
+			    {"p2|pass2|password2:", "The password to use when the database requires the client to authenticate. This parameter is used only in the between operation.", value => GetOrCreateNetworkCredential(databaseOptions.Destination).Password = value },
+			    {"domain:", "The domain to use when the database requires the client to authenticate.", value => GetOrCreateNetworkCredential(databaseOptions.Source).Domain = value },
+			    {"domain2:", "The domain to use when the database requires the client to authenticate. This parameter is used only in the between operation.", value => GetOrCreateNetworkCredential(databaseOptions.Destination).Domain = value },
 			    {"key|api-key|apikey:", "The API-key to use, when using OAuth.", value => databaseOptions.Source.ApiKey = value },
 			    {"key2|api-key2|apikey2:", "The API-key to use, when using OAuth. This parameter is used only in the between operation.", value => databaseOptions.Destination.ApiKey = value },
 		    };
@@ -148,12 +148,12 @@ namespace Raven.Smuggler
                 {"h|?|help", v => PrintUsageAndExit(0)},
                 {"timeout:", "The timeout to use for requests", s => filesOptions.Timeout = TimeSpan.FromMilliseconds(int.Parse(s)) },
                 {"incremental", "States usage of incremental operations", _ => filesOptions.Incremental = true },
-			    {"u|user|username:", "The username to use when the filesystem requires the client to authenticate.", value => ((NetworkCredential)filesOptions.Source.Credentials).UserName = value },
-			    {"u2|user2|username2:", "The username to use when the filesystem requires the client to authenticate. This parameter is used only in the between operation.", value => ((NetworkCredential)filesOptions.Destination.Credentials).UserName = value },
-			    {"p|pass|password:", "The password to use when the filesystem requires the client to authenticate.", value => ((NetworkCredential)filesOptions.Source.Credentials).Password = value },
-			    {"p2|pass2|password2:", "The password to use when the filesystem requires the client to authenticate. This parameter is used only in the between operation.", value => ((NetworkCredential)filesOptions.Destination.Credentials).Password = value },
-			    {"domain:", "The domain to use when the filesystem requires the client to authenticate.", value => ((NetworkCredential)filesOptions.Source.Credentials).Domain = value },
-			    {"domain2:", "The domain to use when the filesystem requires the client to authenticate. This parameter is used only in the between operation.", value => ((NetworkCredential)filesOptions.Destination.Credentials).Domain = value },
+			    {"u|user|username:", "The username to use when the filesystem requires the client to authenticate.", value => GetOrCreateNetworkCredential(filesOptions.Source).UserName = value },
+			    {"u2|user2|username2:", "The username to use when the filesystem requires the client to authenticate. This parameter is used only in the between operation.", value => GetOrCreateNetworkCredential(filesOptions.Destination).UserName = value },
+			    {"p|pass|password:", "The password to use when the filesystem requires the client to authenticate.", value => GetOrCreateNetworkCredential(filesOptions.Source).Password = value },
+			    {"p2|pass2|password2:", "The password to use when the filesystem requires the client to authenticate. This parameter is used only in the between operation.", value => GetOrCreateNetworkCredential(filesOptions.Destination).Password = value },
+			    {"domain:", "The domain to use when the filesystem requires the client to authenticate.", value => GetOrCreateNetworkCredential(filesOptions.Source).Domain = value },
+			    {"domain2:", "The domain to use when the filesystem requires the client to authenticate. This parameter is used only in the between operation.", value => GetOrCreateNetworkCredential(filesOptions.Destination).Domain = value },
 			    {"key|api-key|apikey:", "The API-key to use, when using OAuth.", value => filesOptions.Source.ApiKey = value },
 			    {"key2|api-key2|apikey2:", "The API-key to use, when using OAuth. This parameter is used only in the between operation.", value => filesOptions.Destination.ApiKey = value },
 
@@ -170,6 +170,14 @@ namespace Raven.Smuggler
 		}
 
         private SmugglerMode mode = SmugglerMode.Unknown;
+
+        private static NetworkCredential GetOrCreateNetworkCredential(ConnectionStringOptions connectionStringOptions) 
+        {
+            if (connectionStringOptions.Credentials == null)
+                connectionStringOptions.Credentials = new NetworkCredential();
+
+            return (NetworkCredential)connectionStringOptions.Credentials;
+        }
 
         private async Task Parse(string[] args)
 		{


### PR DESCRIPTION
Smuggler throws an NPE with NTLM username and password. Fixed and tested it.
