### PR TITLE
Fix bug on sql replication with ConnectionStringSettingName

### DIFF
--- a/Raven.Database/Bundles/SqlReplication/SqlReplicationTask.cs
+++ b/Raven.Database/Bundles/SqlReplication/SqlReplicationTask.cs
@@ -604,6 +604,7 @@ namespace Raven.Database.Bundles.SqlReplication
 								document.Key);
 							continue;
 						}
+						cfg.ConnectionString = setting;
 					}
 					sqlReplicationConfigs.Add(cfg);
 				}


### PR DESCRIPTION
Submitting as a PR mostly because it's easier to show where I think the bug is.