### PR TITLE
Add a failing test: Transforming a mapped array returns a single result

### DIFF
--- a/Raven.Tests.Issues/MappedArrayWithTransform.cs
+++ b/Raven.Tests.Issues/MappedArrayWithTransform.cs
@@ -1,0 +1,141 @@
+﻿using System.Linq;
+using Raven.Client;
+using Raven.Client.Indexes;
+using Raven.Tests.Common;
+using Xunit;
+
+namespace Raven.Tests.Issues
+{
+	public class MappedArrayWithTransform : RavenTest
+	{
+		private readonly IDocumentStore docStore;
+		private const string RandomUserId = "Users/1";
+		private static readonly string[] SampleWatchedProducts = { "Product/1", "Product/2", "Product/3" };
+
+		public MappedArrayWithTransform()
+		{
+			docStore = NewDocumentStore();
+
+			new UserWatchedProducts().Execute(docStore);
+			new UserWatchedProductsWithReduce().Execute(docStore);
+			new TestTransformer().Execute(docStore);
+
+			using (var session = docStore.OpenSession())
+			{
+				session.Store(new UserWatches
+				{
+					User = RandomUserId,
+					Products = SampleWatchedProducts
+				});
+				session.SaveChanges();
+			}
+		}
+
+		[Fact]
+		public void QueryIndexWithTransformReturnsResultForEachItemInArray()
+		{
+			using (var session = docStore.OpenSession())
+			{
+				var results = session.Query<UserWatchedProducts.ReduceResult, UserWatchedProducts>()
+					.Customize(x => x.WaitForNonStaleResults())
+					.TransformWith<TestTransformer, WatchedProduct>()
+					.ToList();
+
+				Assert.Equal(SampleWatchedProducts.Length, results.Count);
+			}
+		}
+
+		[Fact]
+		public void QueryIndexWithReduceAndTransformReturnsResultForEachItemInArray()
+		{
+			using (var session = docStore.OpenSession())
+			{
+				var results = session.Query<UserWatchedProductsWithReduce.ReduceResult, UserWatchedProductsWithReduce>()
+					.Customize(x => x.WaitForNonStaleResults())
+					.TransformWith<TestTransformer, WatchedProduct>()
+					.ToList();
+
+				Assert.Equal(SampleWatchedProducts.Length, results.Count);
+			}
+		}
+
+		public class UserWatches
+		{
+			public string User { get; set; }
+			public string[] Products { get; set; }
+		}
+
+		public class UserWatchedProducts : AbstractIndexCreationTask<UserWatches, UserWatchedProducts.ReduceResult>
+		{
+			public class ReduceResult
+			{
+				public string User { get; set; }
+				public string Product { get; set; }
+			}
+
+			public UserWatchedProducts()
+			{
+				Map = results =>
+					from x in results
+					from p in x.Products
+					select new
+					{
+						x.User,
+						Product = p
+					};
+			}
+		}
+
+		public class UserWatchedProductsWithReduce : AbstractIndexCreationTask<UserWatches, UserWatchedProductsWithReduce.ReduceResult>
+		{
+			public class ReduceResult
+			{
+				public string User { get; set; }
+				public string Product { get; set; }
+			}
+
+			public UserWatchedProductsWithReduce()
+			{
+				Map = results => from x in results
+								 from p in x.Products
+								 select new
+								 {
+									 x.User,
+									 Product = p
+								 };
+
+				Reduce = results => from result in results
+									group result by new { result.User, result.Product }
+										into g
+										select new
+										{
+											g.Key.User,
+											g.Key.Product
+										};
+			}
+		}
+
+		public class WatchedProduct
+		{
+			public string User { get; set; }
+			public string Description { get; set; }
+			public string Product { get; set; }
+		}
+
+		public class TestTransformer : AbstractTransformerCreationTask<UserWatchedProducts.ReduceResult>
+		{
+			public TestTransformer()
+			{
+				TransformResults = results =>
+					from result in results
+					select new
+					{
+						result.User,
+						result.Product,
+						Description = "Fake loaded product description"
+					};
+			}
+		}
+
+	}
+}

--- a/Raven.Tests.Issues/Raven.Tests.Issues.csproj
+++ b/Raven.Tests.Issues/Raven.Tests.Issues.csproj
@@ -116,6 +116,7 @@
     <Compile Include="BulkInsertClient.cs" />
     <Compile Include="BulkInsertDatabaseUrl.cs" />
     <Compile Include="BulkInsertTests.cs" />
+    <Compile Include="MappedArrayWithTransform.cs" />
     <Compile Include="RavenDB-3150.cs" />
     <Compile Include="RavenDB3075.cs" />
     <Compile Include="RavenDB_2627.cs" />


### PR DESCRIPTION
When querying and transforming an index that maps an array, only a single result is returned. This previously worked in v2.5

Document:
```javascript
{
    "User": "User/1",
    "Products": ["Product/1", "Product/2", "Product/3"]
}
````

Indexed entries
```
User/1  |  Product/1
User/1  |  Product/2
User/1  |  Product/3
```

**Expected query with transform result**
````
User/1  |  Product/1  | Other transformed values
User/1  |  Product/2  | Other transformed values
User/1  |  Product/3  | Other transformed values
````
**Actual query with transform result**
````
User/1  |  Product/1  | Other transformed values
````