### PR TITLE
Adding a bit of :heart: to the unit testing & RavenTestBase

### DIFF
--- a/Raven.Tests.Helpers/RavenTestBase.cs
+++ b/Raven.Tests.Helpers/RavenTestBase.cs
@@ -163,7 +163,7 @@ namespace Raven.Tests.Helpers
 					DataDirectory = Path.Combine(dataDirectory, "System"),
 					RunInUnreliableYetFastModeThatIsNotSuitableForProduction = true,
 					RunInMemory = storageType.Equals("esent", StringComparison.OrdinalIgnoreCase) == false && runInMemory,
-					Port = port == null ? 8079 : port.Value,
+					Port = port ?? 8079,
 					AnonymousUserAccessMode = anonymousUserAccessMode,
 				}
 			};
@@ -176,14 +176,19 @@ namespace Raven.Tests.Helpers
 				documentStore.Configuration.Settings["Raven/ActiveBundles"] = activeBundles;
 			}
 
-			if (catalog != null)
-				documentStore.Configuration.Catalog.Catalogs.Add(catalog);
+		    if (catalog != null)
+		    {
+		        documentStore.Configuration.Catalog.Catalogs.Add(catalog);
+		    }
 
 			try
 			{
-				if (configureStore != null)
-					configureStore(documentStore);
-				ModifyStore(documentStore);
+			    if (configureStore != null)
+			    {
+			        configureStore(documentStore);
+			    }
+
+			    ModifyStore(documentStore);
 				ModifyConfiguration(documentStore.Configuration);
 				documentStore.Configuration.PostInit();
 				documentStore.Initialize();
@@ -220,7 +225,9 @@ namespace Raven.Tests.Helpers
 			database.StartupTasks.OfType<AuthenticationForCommercialUseOnly>().First().Execute(database);
 		}
 
-		public DocumentStore NewRemoteDocumentStore(bool fiddler = false, RavenDbServer ravenDbServer = null, [CallerMemberName] string databaseName = null,
+		public DocumentStore NewRemoteDocumentStore(bool fiddler = false, 
+            RavenDbServer ravenDbServer = null, 
+            [CallerMemberName] string databaseName = null,
 			bool runInMemory = true,
 			string dataDirectory = null,
 			string requestedStorage = null,

--- a/Raven.Tests.Helpers/RavenTestBase.cs
+++ b/Raven.Tests.Helpers/RavenTestBase.cs
@@ -261,6 +261,21 @@ namespace Raven.Tests.Helpers
 			database.StartupTasks.OfType<AuthenticationForCommercialUseOnly>().First().Execute(database);
 		}
 
+        /// <summary>
+        /// Creates a new document store connecting to a remote RavenDb server.
+        /// </summary>
+        /// <param name="fiddler">Are all requests to the remote RavenDb server passed through Fiddler? (NOTE: This is only* for a localhost RavenDb server).</param>
+        /// <param name="ravenDbServer">A RavenDb server.</param>
+        /// <param name="databaseName">Name of the server that will show up on /admin/stats endpoint.</param>
+        /// <param name="runInMemory">Whatever the database should run purely in memory. When running in memory, nothing is written to disk and if the server is restarted all data will be lost.<br/>Default: <b>true</b></param>
+        /// <param name="dataDirectory">The path for the database directory. Can use ~\ as the root, in which case the path will start from the server base directory. <br/>Default: <b>~\Data</b></param>
+        /// <param name="requestedStorage">What storage type to use (see: RavenDB Storage engines).<br/>Allowed values: <b>vornon</b>, <b>esent</b>.<br/>Default: <b>voron</b></param>
+        /// <param name="enableAuthentication"></param>
+        /// <param name="ensureDatabaseExists">For a multi-tenant RavenDb server, creates the database if it doesn't already exist.</param>
+        /// <param name="configureStore">An action delegate which allows you to configure the document store instance that is returned. eg. <code>configureStore: store => store.DefaultDatabase = "MasterDb"</code></param>
+        /// <param name="activeBundles">Semicolon separated list of bundles names, such as: 'Replication;Versioning'.<br/>Default: no bundles turned on.</param>
+        /// <param name="seedData">A collection of some fake data that will be automatically stored into the document store.</param>
+        /// <returns></returns>
 		public DocumentStore NewRemoteDocumentStore(bool fiddler = false, 
             RavenDbServer ravenDbServer = null, 
             [CallerMemberName] string databaseName = null,

--- a/Raven.Tests.Helpers/RavenTestBase.cs
+++ b/Raven.Tests.Helpers/RavenTestBase.cs
@@ -142,19 +142,19 @@ namespace Raven.Tests.Helpers
         /// Creates a new Embeddable document store.
         /// </summary>
         /// <param name="runInMemory">Whatever the database should run purely in memory. When running in memory, nothing is written to disk and if the server is restarted all data will be lost.<br/>Default: <b>true</b></param>
-        /// <param name="requestedStorage">What storage type to use (see: RavenDB Storage engines).<br/>Allowed values: <b>esent</b>, <b>munin</b>.<br/>Default: <b>esent</b></param>
-        /// <param name="catalog"></param>
+        /// <param name="requestedStorage">What storage type to use (see: RavenDB Storage engines).<br/>Allowed values: <b>vornon</b>, <b>esent</b>.<br/>Default: <b>voron</b></param>
+        /// <param name="catalog">Custom bundles that are not provided by RavenDb.</param>
         /// <param name="dataDir">The path for the database directory. Can use ~\ as the root, in which case the path will start from the server base directory. <br/>Default: <b>~\Data</b></param>
         /// <param name="enableAuthentication"></param>
-        /// <param name="activeBundles"></param>
+        /// <param name="activeBundles">Semicolon separated list of bundles names, such as: 'Replication;Versioning'.<br/>Default: no bundles turned on.</param>
         /// <param name="port">The port to use when creating the http listener. Allowed: 1 - 65,536 or * (find first available port from 8079 and upward).<br/>Default: <b>8079</b></param>
         /// <param name="anonymousUserAccessMode">Determines what actions an anonymous user can do. Get - read only, All - read & write, None - allows access to only authenticated users, Admin - all (including administrative actions).<br/>Default: <b>Get</b></param>
-        /// <param name="configureStore"></param>
+        /// <param name="configureStore">An action delegate which allows you to configure the document store instance that is returned. eg. <code>configureStore: store => store.DefaultDatabase = "MasterDb"</code></param>
         /// <param name="databaseName">Name of the server that will show up on /admin/stats endpoint.</param>
         /// <param name="indexes">A collection of indexes to execute.</param>
         /// <param name="transformers">A collection of transformers to execute.</param>
         /// <param name="seedData">A collection of some fake data that will be automatically stored into the document store.</param>
-        /// <remarks>Besides the document store being instansiated, it is also Initialized.<br/>Also, any indexes or transfomers that are provided, the process will not wait for them to be completed/not stale. You need to explicity call the <code>WaitForIndexing(..)</code> method.<br/>For further info, please goto: http://ravendb.net/docs/article-page/2.5/csharp/server/administration/configuration</remarks>
+        /// <remarks>Besides the document store being instantiated, it is also Initialized.<br/>Also, any indexes or transfomers that are provided, the process will not wait for them to be completed/not stale. You need to explicity call the <code>WaitForIndexing(..)</code> method.<br/>For further info, please goto: http://ravendb.net/docs/article-page/2.5/csharp/server/administration/configuration</remarks>
         /// <returns>A new instance of an EmbeddableDocumentStore.</returns>
         public EmbeddableDocumentStore NewDocumentStore(
             bool runInMemory = true,

--- a/Raven.Tests.Helpers/RavenTestBase.cs
+++ b/Raven.Tests.Helpers/RavenTestBase.cs
@@ -251,15 +251,15 @@ namespace Raven.Tests.Helpers
         }
 
         public static void EnableAuthentication(DocumentDatabase database)
-		{
-			var license = GetLicenseByReflection(database);
-			license.Error = false;
-			license.Status = "Commercial";
-		    license.Attributes["ravenfs"] = "true";
+        {
+            var license = GetLicenseByReflection(database);
+            license.Error = false;
+            license.Status = "Commercial";
+            license.Attributes["ravenfs"] = "true";
             license.Attributes["counters"] = "true";
-			// rerun this startup task
-			database.StartupTasks.OfType<AuthenticationForCommercialUseOnly>().First().Execute(database);
-		}
+            // rerun this startup task
+            database.StartupTasks.OfType<AuthenticationForCommercialUseOnly>().First().Execute(database);
+        }
 
         /// <summary>
         /// Creates a new document store connecting to a remote RavenDb server.
@@ -276,53 +276,53 @@ namespace Raven.Tests.Helpers
         /// <param name="activeBundles">Semicolon separated list of bundles names, such as: 'Replication;Versioning'.<br/>Default: no bundles turned on.</param>
         /// <param name="seedData">A collection of some fake data that will be automatically stored into the document store.</param>
         /// <returns></returns>
-		public DocumentStore NewRemoteDocumentStore(bool fiddler = false, 
-            RavenDbServer ravenDbServer = null, 
+        public DocumentStore NewRemoteDocumentStore(bool fiddler = false,
+            RavenDbServer ravenDbServer = null,
             [CallerMemberName] string databaseName = null,
-			bool runInMemory = true,
-			string dataDirectory = null,
-			string requestedStorage = null,
-			bool enableAuthentication = false,
-			bool ensureDatabaseExists = true,
-			Action<DocumentStore> configureStore = null,
-			string activeBundles = null,
+            bool runInMemory = true,
+            string dataDirectory = null,
+            string requestedStorage = null,
+            bool enableAuthentication = false,
+            bool ensureDatabaseExists = true,
+            Action<DocumentStore> configureStore = null,
+            string activeBundles = null,
             IEnumerable<IEnumerable> seedData = null)
-		{
-			databaseName = NormalizeDatabaseName(databaseName);
+        {
+            databaseName = NormalizeDatabaseName(databaseName);
 
-			checkPorts = true;
-		    ravenDbServer = ravenDbServer ?? GetNewServer(runInMemory: runInMemory,
-		        dataDirectory: dataDirectory,
-		        requestedStorage: requestedStorage,
-		        enableAuthentication: enableAuthentication,
-		        databaseName: databaseName,
-		        activeBundles: activeBundles);
-			ModifyServer(ravenDbServer);
-			var documentStore = new DocumentStore
-			{
-				Url = GetServerUrl(fiddler, ravenDbServer.SystemDatabase.ServerUrl),
-				DefaultDatabase = databaseName
-			};
-			pathsToDelete.Add(Path.Combine(ravenDbServer.SystemDatabase.Configuration.DataDirectory, @"..\Databases"));
-			stores.Add(documentStore);
-			documentStore.AfterDispose += (sender, args) => ravenDbServer.Dispose();
+            checkPorts = true;
+            ravenDbServer = ravenDbServer ?? GetNewServer(runInMemory: runInMemory,
+                dataDirectory: dataDirectory,
+                requestedStorage: requestedStorage,
+                enableAuthentication: enableAuthentication,
+                databaseName: databaseName,
+                activeBundles: activeBundles);
+            ModifyServer(ravenDbServer);
+            var documentStore = new DocumentStore
+            {
+                Url = GetServerUrl(fiddler, ravenDbServer.SystemDatabase.ServerUrl),
+                DefaultDatabase = databaseName
+            };
+            pathsToDelete.Add(Path.Combine(ravenDbServer.SystemDatabase.Configuration.DataDirectory, @"..\Databases"));
+            stores.Add(documentStore);
+            documentStore.AfterDispose += (sender, args) => ravenDbServer.Dispose();
 
-		    if (configureStore != null)
-		    {
-		        configureStore(documentStore);
-		    }
+            if (configureStore != null)
+            {
+                configureStore(documentStore);
+            }
 
-		    ModifyStore(documentStore);
+            ModifyStore(documentStore);
 
-			documentStore.Initialize(ensureDatabaseExists);
+            documentStore.Initialize(ensureDatabaseExists);
 
-		    if (seedData != null)
-		    {
-		        StoreSeedData(seedData, documentStore);
-		    }
+            if (seedData != null)
+            {
+                StoreSeedData(seedData, documentStore);
+            }
 
-			return documentStore;
-		}
+            return documentStore;
+        }
 
         protected RavenDbServer GetServer(int port = 8079)
         {
@@ -927,31 +927,31 @@ namespace Raven.Tests.Helpers
 			return (LicensingStatus)currentLicenseProp.GetValue(validateLicense, null);
 		}
 
-		protected string NormalizeDatabaseName(string databaseName)
-		{
-		    if (string.IsNullOrEmpty(databaseName))
-		    {
-		        return null;
-		    }
+        protected string NormalizeDatabaseName(string databaseName)
+        {
+            if (string.IsNullOrEmpty(databaseName))
+            {
+                return null;
+            }
 
-			if (databaseName.Length < 50)
-			{
-				DatabaseNames.Add(databaseName);
-				return databaseName;
-			}
+            if (databaseName.Length < 50)
+            {
+                DatabaseNames.Add(databaseName);
+                return databaseName;
+            }
 
-			var prefix = databaseName.Substring(0, 30);
-			var suffix = databaseName.Substring(databaseName.Length - 10, 10);
-			var hash = new Guid(Encryptor.Current.Hash.Compute16(Encoding.UTF8.GetBytes(databaseName))).ToString("N").Substring(0, 8);
+            var prefix = databaseName.Substring(0, 30);
+            var suffix = databaseName.Substring(databaseName.Length - 10, 10);
+            var hash = new Guid(Encryptor.Current.Hash.Compute16(Encoding.UTF8.GetBytes(databaseName))).ToString("N").Substring(0, 8);
 
-			var name = string.Format("{0}_{1}_{2}", prefix, hash, suffix);
+            var name = string.Format("{0}_{1}_{2}", prefix, hash, suffix);
 
-			DatabaseNames.Add(name);
+            DatabaseNames.Add(name);
 
-			return name;
-		}
+            return name;
+        }
 
-		protected static void DeployNorthwind(DocumentStore store, string databaseName = null)
+        protected static void DeployNorthwind(DocumentStore store, string databaseName = null)
 		{
 			if (string.IsNullOrEmpty(databaseName) == false)
 				store.DatabaseCommands.GlobalAdmin.EnsureDatabaseExists(databaseName);

--- a/Raven.Tests.Helpers/RavenTestBase.cs
+++ b/Raven.Tests.Helpers/RavenTestBase.cs
@@ -156,101 +156,101 @@ namespace Raven.Tests.Helpers
         /// <param name="seedData">A collection of some fake data that will be automatically stored into the document store.</param>
         /// <remarks>Besides the document store being instansiated, it is also Initialized.<br/>Also, any indexes or transfomers that are provided, the process will not wait for them to be completed/not stale. You need to explicity call the <code>WaitForIndexing(..)</code> method.<br/>For further info, please goto: http://ravendb.net/docs/article-page/2.5/csharp/server/administration/configuration</remarks>
         /// <returns>A new instance of an EmbeddableDocumentStore.</returns>
-		public EmbeddableDocumentStore NewDocumentStore(
-			bool runInMemory = true,
-			string requestedStorage = null,
-			ComposablePartCatalog catalog = null,
-			string dataDir = null,
-			bool enableAuthentication = false,
-			string activeBundles = null,
-			int? port = null,
-			AnonymousUserAccessMode anonymousUserAccessMode = AnonymousUserAccessMode.Admin,
-			Action<EmbeddableDocumentStore> configureStore = null,
-			[CallerMemberName] string databaseName = null,
+        public EmbeddableDocumentStore NewDocumentStore(
+            bool runInMemory = true,
+            string requestedStorage = null,
+            ComposablePartCatalog catalog = null,
+            string dataDir = null,
+            bool enableAuthentication = false,
+            string activeBundles = null,
+            int? port = null,
+            AnonymousUserAccessMode anonymousUserAccessMode = AnonymousUserAccessMode.Admin,
+            Action<EmbeddableDocumentStore> configureStore = null,
+            [CallerMemberName] string databaseName = null,
             IEnumerable<AbstractIndexCreationTask> indexes = null,
             IEnumerable<AbstractTransformerCreationTask> transformers = null,
             IEnumerable<IEnumerable> seedData = null)
-		{
-			databaseName = NormalizeDatabaseName(databaseName);
+        {
+            databaseName = NormalizeDatabaseName(databaseName);
 
-			var storageType = GetDefaultStorageType(requestedStorage);
-			var dataDirectory = dataDir ?? NewDataPath(databaseName);
-			var documentStore = new EmbeddableDocumentStore
-			{
-				UseEmbeddedHttpServer = port.HasValue,
-				Configuration =
-				{
-					DefaultStorageTypeName = storageType,
-					DataDirectory = Path.Combine(dataDirectory, "System"),
-					RunInUnreliableYetFastModeThatIsNotSuitableForProduction = true,
-					RunInMemory = storageType.Equals("esent", StringComparison.OrdinalIgnoreCase) == false && runInMemory,
-					Port = port ?? 8079,
-					AnonymousUserAccessMode = anonymousUserAccessMode,
-				}
-			};
+            var storageType = GetDefaultStorageType(requestedStorage);
+            var dataDirectory = dataDir ?? NewDataPath(databaseName);
+            var documentStore = new EmbeddableDocumentStore
+            {
+                UseEmbeddedHttpServer = port.HasValue,
+                Configuration =
+                {
+                    DefaultStorageTypeName = storageType,
+                    DataDirectory = Path.Combine(dataDirectory, "System"),
+                    RunInUnreliableYetFastModeThatIsNotSuitableForProduction = true,
+                    RunInMemory = storageType.Equals("esent", StringComparison.OrdinalIgnoreCase) == false && runInMemory,
+                    Port = port ?? 8079,
+                    AnonymousUserAccessMode = anonymousUserAccessMode,
+                }
+            };
 
-			documentStore.Configuration.FileSystem.DataDirectory = Path.Combine(dataDirectory, "FileSystem");
-			documentStore.Configuration.Encryption.UseFips = SettingsHelper.UseFipsEncryptionAlgorithms;
+            documentStore.Configuration.FileSystem.DataDirectory = Path.Combine(dataDirectory, "FileSystem");
+            documentStore.Configuration.Encryption.UseFips = SettingsHelper.UseFipsEncryptionAlgorithms;
 
-			if (activeBundles != null)
-			{
-				documentStore.Configuration.Settings["Raven/ActiveBundles"] = activeBundles;
-			}
+            if (activeBundles != null)
+            {
+                documentStore.Configuration.Settings["Raven/ActiveBundles"] = activeBundles;
+            }
 
-		    if (catalog != null)
-		    {
-		        documentStore.Configuration.Catalog.Catalogs.Add(catalog);
-		    }
+            if (catalog != null)
+            {
+                documentStore.Configuration.Catalog.Catalogs.Add(catalog);
+            }
 
-			try
-			{
-			    if (configureStore != null)
-			    {
-			        configureStore(documentStore);
-			    }
+            try
+            {
+                if (configureStore != null)
+                {
+                    configureStore(documentStore);
+                }
 
-			    ModifyStore(documentStore);
-				ModifyConfiguration(documentStore.Configuration);
-				documentStore.Configuration.PostInit();
-				documentStore.Initialize();
+                ModifyStore(documentStore);
+                ModifyConfiguration(documentStore.Configuration);
+                documentStore.Configuration.PostInit();
+                documentStore.Initialize();
 
-				if (enableAuthentication)
-				{
-					EnableAuthentication(documentStore.SystemDatabase);
-				}
+                if (enableAuthentication)
+                {
+                    EnableAuthentication(documentStore.SystemDatabase);
+                }
 
-				CreateDefaultIndexes(documentStore);
+                CreateDefaultIndexes(documentStore);
 
-			    if (indexes != null)
-			    {
-			        ExecuteIndexes(indexes, documentStore);
-			    }
+                if (indexes != null)
+                {
+                    ExecuteIndexes(indexes, documentStore);
+                }
 
                 if (transformers != null)
                 {
                     ExecuteTransformers(transformers, documentStore);
                 }
 
-			    if (seedData != null)
-			    {
-			        StoreSeedData(seedData, documentStore);
-			    }
+                if (seedData != null)
+                {
+                    StoreSeedData(seedData, documentStore);
+                }
 
-				return documentStore;
-			}
-			catch
-			{
-				// We must dispose of this object in exceptional cases, otherwise this test will break all the following tests.
-				documentStore.Dispose();
-				throw;
-			}
-			finally
-			{
-				stores.Add(documentStore);
-			}
-		}
+                return documentStore;
+            }
+            catch
+            {
+                // We must dispose of this object in exceptional cases, otherwise this test will break all the following tests.
+                documentStore.Dispose();
+                throw;
+            }
+            finally
+            {
+                stores.Add(documentStore);
+            }
+        }
 
-		public static void EnableAuthentication(DocumentDatabase database)
+        public static void EnableAuthentication(DocumentDatabase database)
 		{
 			var license = GetLicenseByReflection(database);
 			license.Error = false;

--- a/Raven.Tests.Helpers/RavenTestBase.cs
+++ b/Raven.Tests.Helpers/RavenTestBase.cs
@@ -141,20 +141,20 @@ namespace Raven.Tests.Helpers
         /// <summary>
         /// Creates a new Embeddable document store.
         /// </summary>
-        /// <param name="runInMemory">The document store is all stored in RAM. Nothing hits the file system. (Default is True).</param>
-        /// <param name="requestedStorage"></param>
+        /// <param name="runInMemory">Whatever the database should run purely in memory. When running in memory, nothing is written to disk and if the server is restarted all data will be lost.<br/>Default: <b>true</b></param>
+        /// <param name="requestedStorage">What storage type to use (see: RavenDB Storage engines).<br/>Allowed values: <b>esent</b>, <b>munin</b>.<br/>Default: <b>esent</b></param>
         /// <param name="catalog"></param>
-        /// <param name="dataDir"></param>
+        /// <param name="dataDir">The path for the database directory. Can use ~\ as the root, in which case the path will start from the server base directory. <br/>Default: <b>~\Data</b></param>
         /// <param name="enableAuthentication"></param>
         /// <param name="activeBundles"></param>
-        /// <param name="port"></param>
-        /// <param name="anonymousUserAccessMode"></param>
+        /// <param name="port">The port to use when creating the http listener. Allowed: 1 - 65,536 or * (find first available port from 8079 and upward).<br/>Default: <b>8079</b></param>
+        /// <param name="anonymousUserAccessMode">Determines what actions an anonymous user can do. Get - read only, All - read & write, None - allows access to only authenticated users, Admin - all (including administrative actions).<br/>Default: <b>Get</b></param>
         /// <param name="configureStore"></param>
-        /// <param name="databaseName"></param>
+        /// <param name="databaseName">Name of the server that will show up on /admin/stats endpoint.</param>
         /// <param name="indexes">A collection of indexes to execute.</param>
         /// <param name="transformers">A collection of transformers to execute.</param>
         /// <param name="seedData">A collection of some fake data that will be automatically stored into the document store.</param>
-        /// <remarks>Besides the document store being instansiated, it is also Initialized. Also, any indexes or transfomers that are provided, the process will not wait for them to be completed/not stale. You need to explicity call the WaitForIndexing(..) method.</remarks>
+        /// <remarks>Besides the document store being instansiated, it is also Initialized.<br/>Also, any indexes or transfomers that are provided, the process will not wait for them to be completed/not stale. You need to explicity call the <code>WaitForIndexing(..)</code> method.<br/>For further info, please goto: http://ravendb.net/docs/article-page/2.5/csharp/server/administration/configuration</remarks>
         /// <returns>A new instance of an EmbeddableDocumentStore.</returns>
 		public EmbeddableDocumentStore NewDocumentStore(
 			bool runInMemory = true,

--- a/Raven.Tests.Issues/RavenDB_2670.cs
+++ b/Raven.Tests.Issues/RavenDB_2670.cs
@@ -64,7 +64,7 @@ namespace Raven.Tests.Issues
 
 				new Products_ByName().Execute(store.DatabaseCommands.ForDatabase("Northwind"), store.Conventions);
 
-				WaitForIndexing(store, db: "Northwind");
+				WaitForIndexing(store, database: "Northwind");
 
 				using (var session = store.OpenSession("Northwind"))
 				{

--- a/Raven.Tests/Raven.Tests.csproj
+++ b/Raven.Tests/Raven.Tests.csproj
@@ -902,6 +902,10 @@
     <Compile Include="Suggestions\SuggestionsLazy.cs" />
     <Compile Include="Suggestions\Suggestions.cs" />
     <Compile Include="Suggestions\SuggestionsHelper.cs" />
+    <Compile Include="TestBase\Animal_Search.cs" />
+    <Compile Include="TestBase\FakeModelHelpers.cs" />
+    <Compile Include="TestBase\FakeModels.cs" />
+    <Compile Include="TestBase\RavenTestBaseTests.cs" />
     <Compile Include="Track\AsyncProjectionShouldWork.cs" />
     <Compile Include="Track\RavenDB053.cs" />
     <Compile Include="Track\RavenDB17.cs" />

--- a/Raven.Tests/TestBase/Animal_Search.cs
+++ b/Raven.Tests/TestBase/Animal_Search.cs
@@ -1,0 +1,14 @@
+﻿using System.Linq;
+using Raven.Client.Indexes;
+
+namespace Raven.Tests.TestBase
+{
+    public class Animal_Search : AbstractMultiMapIndexCreationTask
+    {
+        public Animal_Search()
+        {
+            AddMapForAll<Animal>(animals => from animal in animals
+                select new {animal.Name});
+        }
+    }
+}

--- a/Raven.Tests/TestBase/FakeModelHelpers.cs
+++ b/Raven.Tests/TestBase/FakeModelHelpers.cs
@@ -1,0 +1,48 @@
+﻿using System;
+using System.Collections.Generic;
+
+namespace Raven.Tests.TestBase
+{
+    public static class FakeModelHelpers
+    {
+        public static IEnumerable<Cat> CreateFakeCats(int numberOfCats = 20)
+        {
+            if (numberOfCats <= 0)
+            {
+                throw new ArgumentOutOfRangeException("numberOfCats");
+            }
+
+            var result = new List<Cat>();
+            for (var i = 1; i <= numberOfCats; i++)
+            {
+                result.Add(new Cat
+                {
+                    Name = "Some Cat " + i,
+                    PurringCount = i
+                });
+            }
+
+            return result;
+        }
+
+        public static IEnumerable<Dog> CreateFakeDogs(int numberOfDogs = 20)
+        {
+            if (numberOfDogs <= 0)
+            {
+                throw new ArgumentOutOfRangeException("numberOfDogs");
+            }
+
+            var result = new List<Dog>();
+            for (var i = 1; i <= numberOfDogs; i++)
+            {
+                result.Add(new Dog
+                {
+                    Name = "Some Dog " + i,
+                    BarkCount = i
+                });
+            }
+
+            return result;
+        }
+    }
+}

--- a/Raven.Tests/TestBase/FakeModels.cs
+++ b/Raven.Tests/TestBase/FakeModels.cs
@@ -1,0 +1,27 @@
+﻿namespace Raven.Tests.TestBase
+{
+    public abstract class AggregateRoot
+    {
+        public string Id { get; set; }
+    }
+
+    public abstract class Animal
+    {
+        public string Name { get; set; }
+    }
+
+    public class Cat : Animal
+    {
+        public int PurringCount { get; set; }
+    }
+
+    public class Dog : Animal
+    {
+        public int BarkCount { get; set; }
+    }
+
+    public class Home
+    {
+        public string Address { get; set; }
+    }
+}

--- a/Raven.Tests/TestBase/RavenTestBaseTests.cs
+++ b/Raven.Tests/TestBase/RavenTestBaseTests.cs
@@ -1,0 +1,57 @@
+﻿using System;
+using System.Collections;
+using System.Collections.Generic;
+using System.Linq;
+using System.Text;
+using System.Threading.Tasks;
+using Raven.Tests.Helpers;
+using Xunit;
+
+namespace Raven.Tests.TestBase
+{
+    public class RavenTestBaseTests : RavenTestBase
+    {
+        [Fact]
+        public void GivenACollectionOfSeedData_NewDocumentStore_StoresTheSeedData()
+        {
+            // Arrange.
+            var seedData = new IEnumerable[]
+            {
+                FakeModelHelpers.CreateFakeCats(),
+                FakeModelHelpers.CreateFakeDogs(10)
+            };
+            
+            // Act.
+            var documentStore = NewDocumentStore(seedData: seedData);
+            WaitForIndexing(documentStore);
+
+            // Assert.
+            IList<Cat> cats;
+            IList<Dog> dogs;
+            using (var session = documentStore.OpenSession())
+            {
+                cats = session.Query<Cat>().ToList();
+                dogs = session.Query<Dog>().ToList();
+            }
+
+            Assert.Equal(20, cats.Count);
+            Assert.Equal(10, dogs.Count);
+        }
+
+        [Fact]
+        public void GivenAnIndex_NewDocumentStore_StoresTheIndex()
+        {
+            // Arrange.
+            var indexes = new[] {new Animal_Search()};
+
+            // Act.
+            var documentStore = NewDocumentStore(indexes: indexes);
+
+            // Assert.
+            // Two indexes:
+            // 1 - Default : RavenDocumentsByEntityName
+            // 2 - Animal/Search
+            Assert.Equal(2, documentStore.DatabaseCommands.GetStatistics().CountOfIndexes);
+        }
+    }
+}


### PR DESCRIPTION
Helping keep unit testing a bit cleaner by adding the following optional overloads into `NewDocumentStore` method

- Seed data
- indexes (to execute)
- transformers (to execute)

Also, so minor code cleanup/formatting .. just to make it a bit easier to read the file.

I've included all my questions inline :+1: 

_NOTE: I've been referencing the [2.5 server configuration](http://ravendb.net/docs/article-page/2.5/csharp/server/administration/configuration) docs for reference/guide._