### PR TITLE
Evict constraint doc in CheckForUniqueConstraints

### DIFF
--- a/Bundles/Raven.Client.UniqueConstraints/UniqueConstraintExtensions.cs
+++ b/Bundles/Raven.Client.UniqueConstraints/UniqueConstraintExtensions.cs
@@ -193,6 +193,8 @@ namespace Raven.Client.UniqueConstraints
 				if (constraintDoc == null)
 					continue;
 
+				session.Advanced.Evict(constraintDoc);
+
 				var constraintId = constraintsIds[i];
 				var relatedId = constraintDoc.GetRelatedIdFor(constraintId.Key);
 
@@ -231,6 +233,8 @@ namespace Raven.Client.UniqueConstraints
 
 			if (constraintDoc == null)
 				return default(T);
+
+			session.Advanced.Evict(constraintDoc);
 
 			return await session.LoadAsync<T>(constraintDoc.GetRelatedIdFor(escapedValue));
 		}


### PR DESCRIPTION
Because constraint docs are created by a trigger they do not have a Raven-Entity-Name.  Hence if you check for unique constraints the constraint doc is loaded into your session then when you SaveChanges() the constraint doc is saved because the client has added a Raven-Entity-Name.

Then there is a conflict at the server because the client doc is updated but also the trigger writes in its own doc.

Easy fix is to just evict the constraint doc in the extension method.