### PR TITLE
More test helpers :heart:

### DIFF
--- a/Raven.Tests.Helpers/NoStaleQueriesListener.cs
+++ b/Raven.Tests.Helpers/NoStaleQueriesListener.cs
@@ -1,0 +1,26 @@
+﻿using Raven.Client;
+using Raven.Client.Listeners;
+
+namespace Raven.Tests.Helpers
+{
+    /// <summary>
+    /// Forces all document session queryies to wait for non stale results.
+    /// WARNING: This should not be used in production - it's designed for
+    /// use with unit/integration tests.
+    /// </summary>
+    internal class NoStaleQueriesListener : IDocumentQueryListener
+    {
+        #region IDocumentQueryListener Members
+
+        /// <summary>
+        /// Allow to customize a query globally.
+        /// </summary>
+        /// <param name="queryCustomization">Customize the document query.</param>
+        public void BeforeQueryExecuted(IDocumentQueryCustomization queryCustomization)
+        {
+            queryCustomization.WaitForNonStaleResults();
+        }
+
+        #endregion
+    }
+}

--- a/Raven.Tests.Helpers/Raven.Tests.Helpers.csproj
+++ b/Raven.Tests.Helpers/Raven.Tests.Helpers.csproj
@@ -58,6 +58,7 @@
     <Compile Include="..\CommonAssemblyInfo.cs">
       <Link>Properties\CommonAssemblyInfo.cs</Link>
     </Compile>
+    <Compile Include="NoStaleQueriesListener.cs" />
     <Compile Include="RavenFilesTestBase.cs" />
     <Compile Include="Util\CommonInitializationUtil.cs" />
     <Compile Include="RavenTestBase.cs" />

--- a/Raven.Tests.Helpers/RavenTestBase.cs
+++ b/Raven.Tests.Helpers/RavenTestBase.cs
@@ -154,7 +154,8 @@ namespace Raven.Tests.Helpers
         /// <param name="indexes">A collection of indexes to execute.</param>
         /// <param name="transformers">A collection of transformers to execute.</param>
         /// <param name="seedData">A collection of some fake data that will be automatically stored into the document store.</param>
-        /// <remarks>Besides the document store being instantiated, it is also Initialized.<br/>Also, any indexes or transfomers that are provided, the process will not wait for them to be completed/not stale. You need to explicity call the <code>WaitForIndexing(..)</code> method.<br/>For further info, please goto: http://ravendb.net/docs/article-page/2.5/csharp/server/administration/configuration</remarks>
+        /// <param name="waitForAllIndexesToBeNotStale">When you query an index, the query will wait for the index to complete it's indexing and not be stale -before- the query is executred.</param>
+        /// <remarks>Besides the document store being instantiated, it is also Initialized.<br/>Also, if you provide some indexes to be used, make sure you understand that they might be stale when you query them. To make sure you're querying against indexes that have completed their indexing (ie. index is not stale), use the <code>waitForAllIndexesToBeNotStale</code> parameter to determine if you wish to query against a stale or not-stale query.</remarks>
         /// <returns>A new instance of an EmbeddableDocumentStore.</returns>
         public EmbeddableDocumentStore NewDocumentStore(
             bool runInMemory = true,
@@ -169,7 +170,8 @@ namespace Raven.Tests.Helpers
             [CallerMemberName] string databaseName = null,
             IEnumerable<AbstractIndexCreationTask> indexes = null,
             IEnumerable<AbstractTransformerCreationTask> transformers = null,
-            IEnumerable<IEnumerable> seedData = null)
+            IEnumerable<IEnumerable> seedData = null,
+            bool waitForAllIndexesToBeNotStale = true)
         {
             databaseName = NormalizeDatabaseName(databaseName);
 
@@ -224,6 +226,16 @@ namespace Raven.Tests.Helpers
                 if (indexes != null)
                 {
                     ExecuteIndexes(indexes, documentStore);
+                }
+
+                if (waitForAllIndexesToBeNotStale)
+                {
+                    documentStore.Conventions.DefaultQueryingConsistency =
+                        ConsistencyOptions.AlwaysWaitForNonStaleResultsAsOfLastWrite;
+
+                    // When querying any map/reduce indexes, we'll wait until
+                    // the index has stopped being stale.
+                    documentStore.Listeners.RegisterListener(new NoStaleQueriesListener());
                 }
 
                 if (transformers != null)

--- a/Raven.Tests/Raven.Tests.csproj
+++ b/Raven.Tests/Raven.Tests.csproj
@@ -906,7 +906,8 @@
     <Compile Include="Suggestions\SuggestionsLazy.cs" />
     <Compile Include="Suggestions\Suggestions.cs" />
     <Compile Include="Suggestions\SuggestionsHelper.cs" />
-    <Compile Include="TestBase\Animal_Search.cs" />
+    <Compile Include="TestBase\Animals_Count.cs" />
+    <Compile Include="TestBase\Animals_Search.cs" />
     <Compile Include="TestBase\FakeModelHelpers.cs" />
     <Compile Include="TestBase\FakeModels.cs" />
     <Compile Include="TestBase\RavenTestBaseTests.cs" />

--- a/Raven.Tests/TestBase/Animals_Count.cs
+++ b/Raven.Tests/TestBase/Animals_Count.cs
@@ -1,0 +1,33 @@
+﻿using System.Linq;
+using Raven.Client.Indexes;
+
+namespace Raven.Tests.TestBase
+{
+    public class Animals_Count : AbstractMultiMapIndexCreationTask<Animals_Count.AnimalCountResult>
+    {
+        public Animals_Count()
+        {
+            AddMapForAll<Animal>(animals => from animal in animals
+                select new
+                {
+                    Type = MetadataFor(animal)["Raven-Entity-Name"],
+                    Total = 1
+                });
+
+            Reduce = results => from result in results
+                group result by result.Type
+                into g
+                select new
+                {
+                    Type = g.Key,
+                    Total = g.Sum(x => x.Total)
+                };
+        }
+
+        public class AnimalCountResult
+        {
+            public string Type { get; set; }
+            public int Total { get; set; }
+        }
+    }
+}

--- a/Raven.Tests/TestBase/Animals_Search.cs
+++ b/Raven.Tests/TestBase/Animals_Search.cs
@@ -3,9 +3,9 @@ using Raven.Client.Indexes;
 
 namespace Raven.Tests.TestBase
 {
-    public class Animal_Search : AbstractMultiMapIndexCreationTask
+    public class Animals_Search : AbstractMultiMapIndexCreationTask
     {
-        public Animal_Search()
+        public Animals_Search()
         {
             AddMapForAll<Animal>(animals => from animal in animals
                 select new {animal.Name});

--- a/Raven.Tests/TestBase/RavenTestBaseTests.cs
+++ b/Raven.Tests/TestBase/RavenTestBaseTests.cs
@@ -4,6 +4,7 @@ using System.Collections.Generic;
 using System.Linq;
 using System.Text;
 using System.Threading.Tasks;
+using Raven.Client;
 using Raven.Tests.Helpers;
 using Xunit;
 
@@ -42,7 +43,7 @@ namespace Raven.Tests.TestBase
         public void GivenAnIndex_NewDocumentStore_StoresTheIndex()
         {
             // Arrange.
-            var indexes = new[] {new Animal_Search()};
+            var indexes = new[] {new Animals_Search()};
 
             // Act.
             var documentStore = NewDocumentStore(indexes: indexes);
@@ -52,6 +53,36 @@ namespace Raven.Tests.TestBase
             // 1 - Default : RavenDocumentsByEntityName
             // 2 - Animal/Search
             Assert.Equal(2, documentStore.DatabaseCommands.GetStatistics().CountOfIndexes);
+        }
+
+        [Fact]
+        public async Task GivenSomeSeedDataAndAMapReduceIndex_Query_ReturnsAllTheIndexData()
+        {
+            // Arrange.
+            var indexes = new[] { new Animals_Count() };
+            const int numberOfCats = 1000;
+            const int numberOfDogs = 888;
+            var seedData = new IEnumerable[]
+            {
+                FakeModelHelpers.CreateFakeCats(numberOfCats),
+                FakeModelHelpers.CreateFakeDogs(numberOfDogs)
+            };
+
+            var documentStore = NewDocumentStore(seedData: seedData, 
+                indexes: indexes,
+                waitForAllIndexesToBeNotStale: true);
+
+            // Act.
+            IList<Animals_Count.AnimalCountResult> results;
+            using (var session = documentStore.OpenAsyncSession())
+            {
+                results = await session.Query<Animals_Count.AnimalCountResult, Animals_Count>()
+                    .ToListAsync();
+            }
+
+            // Assert.
+            Assert.Equal(numberOfCats, results.Single(x => x.Type == "Cats").Total);
+            Assert.Equal(numberOfDogs, results.Single(x => x.Type == "Dogs").Total);
         }
     }
 }


### PR DESCRIPTION
- Can now optionally wait for all indexes to finishing indexing. Great for getting accurate Asserts, especially map/reduce or _expensive_ indexes.
- Added more ctor options for the `NewRemoveDocumentStore` so it's now on-par with the `NewEmbeddableDocumentStore`.