### PR TITLE
allow caller to choose whether to include the index ID in the compari…

### DIFF
--- a/Raven.Abstractions/Indexing/IndexDefinition.cs
+++ b/Raven.Abstractions/Indexing/IndexDefinition.cs
@@ -153,31 +153,34 @@ namespace Raven.Abstractions.Indexing
 		/// </summary>
 		public int? MaxIndexOutputsPerDocument { get; set; }
 
-		/// <summary>
-		/// Equals the specified other.
-		/// </summary>
-		/// <param name="other">The other.</param>
-		/// <returns></returns>
-		public bool Equals(IndexDefinition other)
-		{
-			if (ReferenceEquals(null, other))
-				return false;
-			if (ReferenceEquals(this, other))
-				return true;
-			return Maps.SequenceEqual(other.Maps) &&
-					Equals(other.IndexId, IndexId) &&
-					Equals(other.Reduce, Reduce) &&
-					Equals(other.MaxIndexOutputsPerDocument, MaxIndexOutputsPerDocument) &&
-					DictionaryExtensions.ContentEquals(other.Stores, Stores) &&
-					DictionaryExtensions.ContentEquals(other.Indexes, Indexes) &&
-					DictionaryExtensions.ContentEquals(other.Analyzers, Analyzers) &&
-					DictionaryExtensions.ContentEquals(other.SortOptions, SortOptions) &&
-					DictionaryExtensions.ContentEquals(other.Suggestions, Suggestions) &&
-					DictionaryExtensions.ContentEquals(other.TermVectors, TermVectors) &&
-					DictionaryExtensions.ContentEquals(other.SpatialIndexes, SpatialIndexes);
-		}
+        /// <summary>
+        /// Equals the specified other.
+        /// </summary>
+        /// <param name="other">The other.</param>
+        /// <param name="compareIndexIds">allow caller to choose whether to include the index Id in the comparison</param>
+        /// <returns></returns>
+        public bool Equals(IndexDefinition other, bool compareIndexIds = true)
+        {
+            if (ReferenceEquals(null, other))
+                return false;
 
+            if (ReferenceEquals(this, other))
+                return true;
 
+            if (compareIndexIds && !Equals(other.IndexId, IndexId))
+                return false;
+
+            return Maps.SequenceEqual(other.Maps) &&
+                    Equals(other.Reduce, Reduce) &&
+                    Equals(other.MaxIndexOutputsPerDocument, MaxIndexOutputsPerDocument) &&
+                    DictionaryExtensions.ContentEquals(other.Stores, Stores) &&
+                    DictionaryExtensions.ContentEquals(other.Indexes, Indexes) &&
+                    DictionaryExtensions.ContentEquals(other.Analyzers, Analyzers) &&
+                    DictionaryExtensions.ContentEquals(other.SortOptions, SortOptions) &&
+                    DictionaryExtensions.ContentEquals(other.Suggestions, Suggestions) &&
+                    DictionaryExtensions.ContentEquals(other.TermVectors, TermVectors) &&
+                    DictionaryExtensions.ContentEquals(other.SpatialIndexes, SpatialIndexes);
+        }
 
 		private static int DictionaryHashCode<TKey, TValue>(IEnumerable<KeyValuePair<TKey, TValue>> x)
 		{

--- a/Raven.Client.Lightweight/Indexes/AbstractIndexCreationTask.cs
+++ b/Raven.Client.Lightweight/Indexes/AbstractIndexCreationTask.cs
@@ -275,12 +275,12 @@ namespace Raven.Client.Indexes
 
         private bool CurrentOrLegacyIndexDefinitionEquals(DocumentConvention documentConvention, IndexDefinition serverDef, IndexDefinition indexDefinition)
         {
-            if (serverDef.Equals(indexDefinition))
+            if (serverDef.Equals(indexDefinition, false))
                 return true;
 
             // now we need to check if this is a legacy index...
             var legacyIndexDefinition = GetLegacyIndexDefinition(documentConvention);
-            return serverDef.Equals(legacyIndexDefinition);
+            return serverDef.Equals(legacyIndexDefinition, false);
         }
 
         private void ReplicateIndexesIfNeeded(IDatabaseCommands databaseCommands)


### PR DESCRIPTION
…son when comparing 2 index definitions for equality + don't compare IndexId when performing index operations from AbstractIndexCreationTask

The problem here is side by side indexes get created every time SideBySideExecute is called from AbstractIndexCreationTask regardless of whether the index has actually changed as the comparison in the client was checking index IDs of the index definition which never matched