### PR TITLE
RavenDB-3695 - ILoaderWithInclude should have Load with transformer

### DIFF
--- a/Raven.Client.Lightweight/Document/ILoaderWithInclude.cs
+++ b/Raven.Client.Lightweight/Document/ILoaderWithInclude.cs
@@ -6,6 +6,7 @@
 using System;
 using System.Collections.Generic;
 using System.Linq.Expressions;
+using Raven.Client.Indexes;
 
 namespace Raven.Client.Document
 {
@@ -162,5 +163,23 @@ namespace Raven.Client.Document
 		/// Or whatever your conventions specify.
 		/// </remarks>
 		TResult[] Load<TResult>(IEnumerable<ValueType> ids);
+
+        /// <summary>
+        /// Loads the specified id with a specific transformer.
+        /// </summary>
+        /// <typeparam name="TTransformer"></typeparam>
+        /// <typeparam name="TResult"></typeparam>
+        /// <param name="id">The id.</param>
+        /// <returns></returns>
+        TResult Load<TTransformer, TResult>(string id, Action<ILoadConfiguration> configure = null) where TTransformer : AbstractTransformerCreationTask, new();
+
+        /// <summary>
+        /// Loads the specified ids with a specific transformer.
+        /// </summary>
+        /// <typeparam name="TTransformer"></typeparam>
+        /// <typeparam name="TResult"></typeparam>
+        /// <param name="ids">The id.</param>
+        /// <returns></returns>
+        TResult[] Load<TTransformer, TResult>(IEnumerable<string> ids, Action<ILoadConfiguration> configure = null) where TTransformer : AbstractTransformerCreationTask, new();
 	}
 }

--- a/Raven.Client.Lightweight/Document/MultiLoaderWithInclude.cs
+++ b/Raven.Client.Lightweight/Document/MultiLoaderWithInclude.cs
@@ -8,6 +8,7 @@ using System.Collections.Generic;
 using System.Linq;
 using System.Linq.Expressions;
 using Raven.Abstractions.Extensions;
+using Raven.Client.Indexes;
 
 namespace Raven.Client.Document
 {
@@ -210,5 +211,27 @@ namespace Raven.Client.Document
 			var documentKeys = ids.Select(id => session.Conventions.FindFullDocumentKeyFromNonStringIdentifier(id, typeof(T), false));
 			return Load<TResult>(documentKeys);
 		}
+
+        public TResult Load<TTransformer, TResult>(string id, Action<ILoadConfiguration> configure = null) 
+            where TTransformer : AbstractTransformerCreationTask, new()
+        {
+            var transformer = new TTransformer().TransformerName;
+            var configuration = new RavenLoadConfiguration();
+            if (configure != null)
+                configure(configuration);
+
+            return session.LoadInternal<TResult>(new[] { id }, includes.ToArray(), transformer, configuration.TransformerParameters).FirstOrDefault();
+        }
+
+        public TResult[] Load<TTransformer, TResult>(IEnumerable<string> ids, Action<ILoadConfiguration> configure = null) 
+            where TTransformer : AbstractTransformerCreationTask, new()
+        {
+            var transformer = new TTransformer().TransformerName;
+            var configuration = new RavenLoadConfiguration();
+            if (configure != null)
+                configure(configuration);
+
+            return session.LoadInternal<TResult>(ids.ToArray(), includes.ToArray(), transformer, configuration.TransformerParameters);
+        }
 	}
 }

--- a/Raven.Client.Lightweight/IDocumentSessionImpl.cs
+++ b/Raven.Client.Lightweight/IDocumentSessionImpl.cs
@@ -7,6 +7,7 @@ using System;
 using System.Collections.Generic;
 using Raven.Client.Document;
 using Raven.Client.Document.Batches;
+using Raven.Json.Linq;
 
 namespace Raven.Client
 {
@@ -19,6 +20,8 @@ namespace Raven.Client
 
 		T[] LoadInternal<T>(string[] ids);
 		T[] LoadInternal<T>(string[] ids, KeyValuePair<string, Type>[] includes);
+        T[] LoadInternal<T>(string[] ids, string transformer, Dictionary<string, RavenJToken> transformerParameters = null);
+        T[] LoadInternal<T>(string[] ids, KeyValuePair<string, Type>[] includes, string transformer, Dictionary<string, RavenJToken> transformerParameters = null);
 		Lazy<T[]> LazyLoadInternal<T>(string[] ids, KeyValuePair<string, Type>[] includes, Action<T[]> onEval);
 	}
 }

--- a/Raven.Client.Lightweight/Shard/ShardedDocumentSession.cs
+++ b/Raven.Client.Lightweight/Shard/ShardedDocumentSession.cs
@@ -233,7 +233,12 @@ namespace Raven.Client.Shard
 			return LoadInternal<TResult>(ids.ToArray(), null, transformer, configuration.TransformerParameters);
 		}
 
-		private T[] LoadInternal<T>(string[] ids, KeyValuePair<string, Type>[] includes, string transformer, Dictionary<string, RavenJToken> transformerParameters = null)
+        public T[] LoadInternal<T>(string[] ids, string transformer, Dictionary<string, RavenJToken> transformerParameters = null)
+        {
+            return LoadInternal<T>(ids.ToArray(), null, transformer, transformerParameters);
+        }
+
+	    public T[] LoadInternal<T>(string[] ids, KeyValuePair<string, Type>[] includes, string transformer, Dictionary<string, RavenJToken> transformerParameters = null)
         {
 			var results = new T[ids.Length];
 			var includePaths = includes != null ? includes.Select(x => x.Key).ToArray() : null;


### PR DESCRIPTION
In order to share the *IDocumentSessionImpl* interface between *ShardedDocumentSession* and *DocumentSession* I had to rename the private method LoadUsingTransfomerInternal to LoadInternal (with new overloads).