### PR TITLE
Updated start script to work on paths with blanks

### DIFF
--- a/Scripts/Start.cmd
+++ b/Scripts/Start.cmd
@@ -11,7 +11,7 @@ IF NOT EXIST version.txt (
 )
 
 :START-RAVENDB
-start %~dp0\Server\Raven.Server.exe --debug --browser
+start "Raven DB" "%~dp0\Server\Raven.Server.exe" --debug --browser
 GOTO END
 
 :FIRST-RUN-START


### PR DESCRIPTION
Currently when starting RavenDB from a path (e.g. "RavenDB 3") nothing happens. This is an unpleasent experience, especially for first time users.
Fixed this by wrapping the entire path in quotes.

This fix also sets the title of the new window to RavenDb.