### PR TITLE
fix(indexes) use index name as was the case in Raven 2.5 + current docs

### DIFF
--- a/Raven.Database/Indexing/Index.cs
+++ b/Raven.Database/Indexing/Index.cs
@@ -969,7 +969,7 @@ namespace Raven.Database.Indexing
 																(currentAnalyzer, generator) =>
 																{
 																	Analyzer generateAnalyzer =
-																		generator.Value.GenerateAnalyzerForIndexing(indexId.ToString(), luceneDoc,
+																		generator.Value.GenerateAnalyzerForIndexing(PublicName, luceneDoc,
 																											currentAnalyzer);
 																	if (generateAnalyzer != currentAnalyzer &&
 																		currentAnalyzer != analyzer)
@@ -1598,7 +1598,7 @@ namespace Raven.Database.Indexing
 						searchAnalyzer = parent.CreateAnalyzer(new LowerCaseKeywordAnalyzer(), toDispose, true);
 						searchAnalyzer = parent.AnalyzerGenerators.Aggregate(searchAnalyzer, (currentAnalyzer, generator) =>
 						{
-							Analyzer newAnalyzer = generator.GenerateAnalyzerForQuerying(parent.indexId.ToString(), indexQuery.Query, currentAnalyzer);
+							Analyzer newAnalyzer = generator.GenerateAnalyzerForQuerying(parent.PublicName, indexQuery.Query, currentAnalyzer);
 							if (newAnalyzer != currentAnalyzer)
 							{
 								DisposeAnalyzerAndFriends(toDispose, currentAnalyzer);


### PR DESCRIPTION
Docs : http://ravendb.net/docs/article-page/3.0/csharp/server/plugins/analyzer-generators
Relevant section (note `indexName`): 

```cs
	public override Analyzer GenerateAnalyzerForIndexing(string indexName, Document document, Analyzer previousAnalyzer)
	{
		if (indexName == SpecificIndexName)
		{
			return new WhitespaceAnalyzer();
		}

		return previousAnalyzer;
	}

	public override Analyzer GenerateAnalyzerForQuerying(string indexName, string query, Analyzer previousAnalyzer)
	{
		if (indexName == SpecificIndexName)
		{
			return new WhitespaceAnalyzer();
		}

		return previousAnalyzer;
	}
```

More from Version 2.5 : https://github.com/ravendb/ravendb/blob/007a513ee0fb9ef11a9c2b11a801e070b466766d/Raven.Database/Indexing/Index.cs#L88 / https://github.com/ravendb/ravendb/blob/007a513ee0fb9ef11a9c2b11a801e070b466766d/Raven.Database/Indexing/Index.cs#L726-L727

Currently `AbstractAnalyzerGenerator` is broken in Raven 3 :rose: