### PR TITLE
Enabling transactional sessions with DTC under AsyncDocumentSession

### DIFF
--- a/Raven.Client.Lightweight/Document/Async/AsyncDocumentSession.cs
+++ b/Raven.Client.Lightweight/Document/Async/AsyncDocumentSession.cs
@@ -28,7 +28,7 @@ namespace Raven.Client.Document.Async
 	/// <summary>
 	/// Implementation for async document session 
 	/// </summary>
-	public class AsyncDocumentSession : InMemoryDocumentSessionOperations, IAsyncDocumentSessionImpl, IAsyncAdvancedSessionOperations, IDocumentQueryGenerator
+	public class AsyncDocumentSession : InMemoryDocumentSessionOperations, IAsyncDocumentSessionImpl, IAsyncAdvancedSessionOperations, IDocumentQueryGenerator, ITransactionalDocumentSession
 	{
 		private readonly AsyncDocumentKeyGeneration asyncDocumentKeyGeneration;
 
@@ -931,18 +931,26 @@ namespace Raven.Client.Document.Async
 		/// Commits the specified tx id.
 		/// </summary>
 		/// <param name="txId">The tx id.</param>
-		public override void Commit(string txId)
+		public override async Task Commit(string txId)
 		{
-			throw new NotImplementedException();
+			await AsyncDatabaseCommands.CommitAsync(txId).ConfigureAwait(false);
+			ClearEnlistment();
 		}
 
 		/// <summary>
 		/// Rollbacks the specified tx id.
 		/// </summary>
 		/// <param name="txId">The tx id.</param>
-		public override void Rollback(string txId)
+		public override async Task Rollback(string txId)
 		{
-			throw new NotImplementedException();
+			await AsyncDatabaseCommands.RollbackAsync(txId).ConfigureAwait(false);
+			ClearEnlistment();
+		}
+
+		public async Task PrepareTransaction(string txId, Guid? resourceManagerId = null, byte[] recoveryInformation = null)
+		{
+			await AsyncDatabaseCommands.PrepareTransactionAsync(txId, resourceManagerId, recoveryInformation).ConfigureAwait(false);
+			ClearEnlistment();
 		}
 
 		/// <summary>

--- a/Raven.Client.Lightweight/Document/AsyncPump.cs
+++ b/Raven.Client.Lightweight/Document/AsyncPump.cs
@@ -1,0 +1,88 @@
+using System;
+using System.Collections.Concurrent;
+using System.Collections.Generic;
+using System.Threading;
+using System.Threading.Tasks;
+
+namespace Raven.Client.Document
+{
+	/// <summary>Provides a pump that supports running asynchronous methods on the current thread.</summary>
+	/// http://blogs.msdn.com/b/pfxteam/archive/2012/01/20/10259049.aspx
+	internal static class AsyncPump
+	{
+		/// <summary>Runs the specified asynchronous function.</summary>
+		/// <param name="func">The asynchronous function to execute.</param>
+		public static void Run(Func<Task> func)
+		{
+			if (func == null) throw new ArgumentNullException("func");
+
+			var prevCtx = SynchronizationContext.Current;
+			try
+			{
+				// Establish the new context
+				var syncCtx = new SingleThreadSynchronizationContext();
+				SynchronizationContext.SetSynchronizationContext(syncCtx);
+
+				// Invoke the function and alert the context to when it completes
+				var t = func();
+				if (t == null) throw new InvalidOperationException("No tasks provided.");
+				t.ContinueWith(delegate { syncCtx.Complete(); }, TaskScheduler.Default);
+
+				// Pump continuations and propagate any exceptions
+				syncCtx.RunOnCurrentThread();
+				t.GetAwaiter().GetResult();
+			}
+			finally { SynchronizationContext.SetSynchronizationContext(prevCtx); }
+		}
+
+		/// <summary>Provides a SynchronizationContext that's single-threaded.</summary>
+		private sealed class SingleThreadSynchronizationContext : SynchronizationContext
+		{
+			/// <summary>The queue of work items.</summary>
+			private readonly BlockingCollection<KeyValuePair<SendOrPostCallback, object>> m_queue;
+			/// <summary>The processing thread.</summary>
+			private readonly Thread m_thread;
+
+			public SingleThreadSynchronizationContext()
+				: this(new BlockingCollection<KeyValuePair<SendOrPostCallback, object>>(), Thread.CurrentThread)
+			{
+			}
+
+			public SingleThreadSynchronizationContext(BlockingCollection<KeyValuePair<SendOrPostCallback, object>> queue, Thread currentThread)
+			{
+				m_queue = queue;
+				m_thread = currentThread;
+			}
+
+			/// <summary>Dispatches an asynchronous message to the synchronization context.</summary>
+			/// <param name="d">The System.Threading.SendOrPostCallback delegate to call.</param>
+			/// <param name="state">The object passed to the delegate.</param>
+			public override void Post(SendOrPostCallback d, object state)
+			{
+				if (d == null) throw new ArgumentNullException("d");
+				this.m_queue.Add(new KeyValuePair<SendOrPostCallback, object>(d, state));
+			}
+
+			/// <summary>Not supported.</summary>
+			public override void Send(SendOrPostCallback d, object state)
+			{
+				throw new NotSupportedException("Synchronously sending is not supported.");
+			}
+
+			public override SynchronizationContext CreateCopy()
+			{
+				return new SingleThreadSynchronizationContext(this.m_queue, this.m_thread);
+			}
+
+			/// <summary>Runs an loop to process all queued work items.</summary>
+			public void RunOnCurrentThread()
+			{
+				foreach (var workItem in this.m_queue.GetConsumingEnumerable())
+					workItem.Key(workItem.Value);
+			}
+
+			/// <summary>Notifies the context that no more work will arrive.</summary>
+			public void Complete() { this.m_queue.CompleteAdding(); }
+		}
+	}
+}

--- a/Raven.Client.Lightweight/Document/DocumentSession.cs
+++ b/Raven.Client.Lightweight/Document/DocumentSession.cs
@@ -785,27 +785,30 @@ namespace Raven.Client.Document
         /// Commits the specified tx id.
         /// </summary>
         /// <param name="txId">The tx id.</param>
-        public override void Commit(string txId)
+        public override Task Commit(string txId)
         {
             DatabaseCommands.Commit(txId);
             ClearEnlistment();
-        }
+			return Task.FromResult(0);
+		}
 
         /// <summary>
         /// Rollbacks the specified tx id.
         /// </summary>
         /// <param name="txId">The tx id.</param>
-        public override void Rollback(string txId)
+        public override Task Rollback(string txId)
         {
             DatabaseCommands.Rollback(txId);
             ClearEnlistment();
+	        return Task.FromResult(0);
         }
 
-        public void PrepareTransaction(string txId, Guid? resourceManagerId = null, byte[] recoveryInformation = null)
+        public Task PrepareTransaction(string txId, Guid? resourceManagerId = null, byte[] recoveryInformation = null)
         {
             DatabaseCommands.PrepareTransaction(txId, resourceManagerId, recoveryInformation);
             ClearEnlistment();
-        }
+			return Task.FromResult(0);
+		}
 
         /// <summary>
         /// Query RavenDB dynamically using LINQ

--- a/Raven.Client.Lightweight/Document/InMemoryDocumentSessionOperations.cs
+++ b/Raven.Client.Lightweight/Document/InMemoryDocumentSessionOperations.cs
@@ -1239,12 +1239,12 @@ more responsive application.
 		/// Commits the specified tx id.
 		/// </summary>
 		/// <param name="txId">The tx id.</param>
-		public abstract void Commit(string txId);
+		public abstract Task Commit(string txId);
 		/// <summary>
 		/// Rollbacks the specified tx id.
 		/// </summary>
 		/// <param name="txId">The tx id.</param>
-		public abstract void Rollback(string txId);
+		public abstract Task Rollback(string txId);
 
 		/// <summary>
 		/// Clears the enlistment.

--- a/Raven.Client.Lightweight/Document/RavenClientEnlistment.cs
+++ b/Raven.Client.Lightweight/Document/RavenClientEnlistment.cs
@@ -6,7 +6,6 @@
 using System;
 using System.IO;
 using System.IO.IsolatedStorage;
-using System.Threading;
 using System.Transactions;
 using Raven.Abstractions.Logging;
 using Raven.Client.Document.DTC;
@@ -30,7 +29,7 @@ namespace Raven.Client.Document
 		/// <summary>
 		/// Initializes a new instance of the <see cref="RavenClientEnlistment"/> class.
 		/// </summary>
-		public RavenClientEnlistment(DocumentStoreBase documentStore,ITransactionalDocumentSession session, Action onTxComplete)
+		public RavenClientEnlistment(DocumentStoreBase documentStore, ITransactionalDocumentSession session, Action onTxComplete)
 		{
 			transaction = Transaction.Current.TransactionInformation;
 			this.documentStore = documentStore;
@@ -63,13 +62,13 @@ namespace Raven.Client.Document
 
 			    if (recoveryInformation == null)
 			    {
-			        session.PrepareTransaction(transaction.LocalIdentifier);
+					AsyncPump.Run(() => session.PrepareTransaction(transaction.LocalIdentifier));
 			    }
 			    else
 			    {
-                    session.PrepareTransaction(transaction.LocalIdentifier,
+					AsyncPump.Run(() => session.PrepareTransaction(transaction.LocalIdentifier,
                         session.ResourceManagerId,
-                        recoveryInformation);    
+                        recoveryInformation));    
 			    }
 			}
 			catch (Exception e)
@@ -77,7 +76,7 @@ namespace Raven.Client.Document
 				logger.ErrorException("Could not prepare distributed transaction", e);
 			    try
 			    {
-                    session.Rollback(transaction.LocalIdentifier);
+					AsyncPump.Run(() => session.Rollback(transaction.LocalIdentifier));
                     DeleteFile();
 			    }
 			    catch (Exception e2)
@@ -102,7 +101,7 @@ namespace Raven.Client.Document
 			try
 			{
 				onTxComplete();
-                session.Commit(transaction.LocalIdentifier);
+				AsyncPump.Run(() => session.Commit(transaction.LocalIdentifier));
 
 				DeleteFile();
 			}
@@ -124,7 +123,7 @@ namespace Raven.Client.Document
 			try
 			{
 				onTxComplete();
-                session.Rollback(transaction.LocalIdentifier);
+				AsyncPump.Run(() => session.Rollback(transaction.LocalIdentifier));
 
 				DeleteFile();
 			}
@@ -150,7 +149,7 @@ namespace Raven.Client.Document
 			try
 			{
 				onTxComplete();
-                session.Rollback(transaction.LocalIdentifier);
+				AsyncPump.Run(() => session.Rollback(transaction.LocalIdentifier));
 
 				DeleteFile();
 			}
@@ -178,7 +177,7 @@ namespace Raven.Client.Document
 			onTxComplete();
 			try
 			{
-                session.Rollback(transaction.LocalIdentifier);
+				AsyncPump.Run(() => session.Rollback(transaction.LocalIdentifier));
 
 				DeleteFile();
 			}

--- a/Raven.Client.Lightweight/ITransactionalDocumentSession.cs
+++ b/Raven.Client.Lightweight/ITransactionalDocumentSession.cs
@@ -4,6 +4,7 @@
 // </copyright>
 //-----------------------------------------------------------------------
 using System;
+using System.Threading.Tasks;
 
 namespace Raven.Client
 {
@@ -26,17 +27,17 @@ namespace Raven.Client
 		///     Commits the specified tx id
 		/// </summary>
 		/// <param name="txId">transaction identifier</param>
-		void Commit(string txId);
+		Task Commit(string txId);
 
 		/// <summary>
 		///     Prepares the transaction on the server.
 		/// </summary>
-		void PrepareTransaction(string txId, Guid? resourceManagerId = null, byte[] recoveryInformation = null);
+		Task PrepareTransaction(string txId, Guid? resourceManagerId = null, byte[] recoveryInformation = null);
 
 		/// <summary>
 		///     Rollbacks the specified tx id
 		/// </summary>
 		/// <param name="txId">transaction identifier</param>
-		void Rollback(string txId);
+		Task Rollback(string txId);
 	}
 }

--- a/Raven.Client.Lightweight/Raven.Client.Lightweight.csproj
+++ b/Raven.Client.Lightweight/Raven.Client.Lightweight.csproj
@@ -112,6 +112,7 @@
     <Compile Include="Counters\Connections\CounterConvention.cs" />
     <Compile Include="Counters\RavenCountersClient.cs" />
     <Compile Include="Document\AsyncDocumentSubscriptions.cs" />
+    <Compile Include="Document\AsyncPump.cs" />
     <Compile Include="Document\Batches\LazyMoreLikeThisOperation.cs" />
     <Compile Include="Document\Batches\LazyTransformerLoadOperation.cs" />
     <Compile Include="Document\ChunkedRemoteBulkInsertOperation.cs" />

--- a/Raven.Client.Lightweight/Shard/BaseShardedDocumentSession.cs
+++ b/Raven.Client.Lightweight/Shard/BaseShardedDocumentSession.cs
@@ -1,6 +1,7 @@
 ﻿using System;
 using System.Collections.Generic;
 using System.Linq;
+using System.Threading.Tasks;
 using Raven.Abstractions.Commands;
 using Raven.Abstractions.Data;
 using Raven.Abstractions.Extensions;
@@ -195,17 +196,17 @@ namespace Raven.Client.Shard
 
 		#region Transaction methods (not supported)
 
-		public override void Commit(string txId)
+		public override Task Commit(string txId)
 		{
 			throw new NotSupportedException("DTC support is handled via the internal document stores");
 		}
 
-		public override void Rollback(string txId)
+		public override Task Rollback(string txId)
 		{
 			throw new NotSupportedException("DTC support is handled via the internal document stores");
 		}
 
-		public void PrepareTransaction(string txId, Guid? resourceManagerId = null, byte[] recoveryInformation = null)
+		public Task PrepareTransaction(string txId, Guid? resourceManagerId = null, byte[] recoveryInformation = null)
 		{
 			throw new NotSupportedException("DTC support is handled via the internal document stores");
 		}

--- a/Raven.DtcTests/Raven.DtcTests.csproj
+++ b/Raven.DtcTests/Raven.DtcTests.csproj
@@ -9,7 +9,7 @@
     <AppDesignerFolder>Properties</AppDesignerFolder>
     <RootNamespace>Raven.DtcTests</RootNamespace>
     <AssemblyName>Raven.DtcTests</AssemblyName>
-    <TargetFrameworkVersion>v4.5</TargetFrameworkVersion>
+    <TargetFrameworkVersion>v4.5.1</TargetFrameworkVersion>
     <FileAlignment>512</FileAlignment>
     <TargetFrameworkProfile />
     <SolutionDir Condition="$(SolutionDir) == '' Or $(SolutionDir) == '*Undefined*'">..\</SolutionDir>
@@ -100,6 +100,7 @@
     <Compile Include="RavenDB_1562.cs" />
     <Compile Include="RavenDB_2613.cs" />
     <Compile Include="RavenDB_551.cs" />
+    <Compile Include="SaveChangesAsync.cs" />
     <Compile Include="tjbsb.cs" />
     <Compile Include="Transactions\Deletes.cs" />
     <Compile Include="Transactions\Etags.cs" />

--- a/Raven.DtcTests/SaveChangesAsync.cs
+++ b/Raven.DtcTests/SaveChangesAsync.cs
@@ -1,0 +1,47 @@
+﻿// -----------------------------------------------------------------------
+//  <copyright file="SaveChangesAsync.cs" company="Hibernating Rhinos LTD">
+//      Copyright (c) Hibernating Rhinos LTD. All rights reserved.
+//  </copyright>
+// -----------------------------------------------------------------------
+using System.Threading.Tasks;
+using System.Transactions;
+using Raven.Tests.Bugs;
+using Raven.Tests.Common;
+using Xunit;
+
+namespace Raven.DtcTests
+{
+	public class SaveChangesAsync : RavenTest
+	{
+		[Fact]
+		public async Task Should_just_work()
+		{
+			using (var documentStore = NewDocumentStore(requestedStorage: "esent"))
+			{
+				EnsureDtcIsSupported(documentStore);
+
+				using (var s = documentStore.OpenAsyncSession())
+				{
+					await s.StoreAsync(new AccurateCount.User { Name = "Ayende" });
+					await s.SaveChangesAsync();
+				}
+
+				using (var s = documentStore.OpenAsyncSession())
+				using (var scope = new TransactionScope(TransactionScopeAsyncFlowOption.Enabled))
+				{
+					var user = await s.LoadAsync<AccurateCount.User>("users/1");
+					user.Name = "Rahien";
+					await s.SaveChangesAsync();
+					scope.Complete();
+				}
+
+				using (var s = documentStore.OpenAsyncSession())
+				{
+					s.Advanced.AllowNonAuthoritativeInformation = false;
+					var user = await s.LoadAsync<AccurateCount.User>("users/1");
+					Assert.Equal("Rahien", user.Name);
+				}
+			}
+		}
+	}
+}

--- a/Raven.DtcTests/app.config
+++ b/Raven.DtcTests/app.config
@@ -1,41 +1,41 @@
-﻿<?xml version="1.0" encoding="utf-8"?>
+<?xml version="1.0" encoding="utf-8"?>
 <configuration>
 	<appSettings>
-		<add key="Raven/Licensing/AllowAdminAnonymousAccessForCommercialUse" value="true" />
+		<add key="Raven/Licensing/AllowAdminAnonymousAccessForCommercialUse" value="true"/>
 	</appSettings>
 	<runtime>
 		<assemblyBinding xmlns="urn:schemas-microsoft-com:asm.v1">
 			<dependentAssembly>
-				<assemblyIdentity name="System.Net.Http.Formatting" publicKeyToken="31bf3856ad364e35" culture="neutral" />
-				<bindingRedirect oldVersion="0.0.0.0-5.2.2.0" newVersion="5.2.2.0" />
+				<assemblyIdentity name="System.Net.Http.Formatting" publicKeyToken="31bf3856ad364e35" culture="neutral"/>
+				<bindingRedirect oldVersion="0.0.0.0-5.2.2.0" newVersion="5.2.2.0"/>
 			</dependentAssembly>
 			<dependentAssembly>
-				<assemblyIdentity name="System.Web.Http" publicKeyToken="31bf3856ad364e35" culture="neutral" />
-				<bindingRedirect oldVersion="0.0.0.0-5.1.0.0" newVersion="5.1.0.0" />
+				<assemblyIdentity name="System.Web.Http" publicKeyToken="31bf3856ad364e35" culture="neutral"/>
+				<bindingRedirect oldVersion="0.0.0.0-5.1.0.0" newVersion="5.1.0.0"/>
 			</dependentAssembly>
 			<dependentAssembly>
-				<assemblyIdentity name="Microsoft.Owin" publicKeyToken="31bf3856ad364e35" culture="neutral" />
-				<bindingRedirect oldVersion="0.0.0.0-3.0.0.0" newVersion="3.0.0.0" />
+				<assemblyIdentity name="Microsoft.Owin" publicKeyToken="31bf3856ad364e35" culture="neutral"/>
+				<bindingRedirect oldVersion="0.0.0.0-3.0.0.0" newVersion="3.0.0.0"/>
 			</dependentAssembly>
 			<dependentAssembly>
-				<assemblyIdentity name="System.Reactive.Interfaces" publicKeyToken="31bf3856ad364e35" culture="neutral" />
-				<bindingRedirect oldVersion="0.0.0.0-2.2.5.0" newVersion="2.2.5.0" />
+				<assemblyIdentity name="System.Reactive.Interfaces" publicKeyToken="31bf3856ad364e35" culture="neutral"/>
+				<bindingRedirect oldVersion="0.0.0.0-2.2.5.0" newVersion="2.2.5.0"/>
 			</dependentAssembly>
 			<dependentAssembly>
-				<assemblyIdentity name="System.Reactive.Core" publicKeyToken="31bf3856ad364e35" culture="neutral" />
-				<bindingRedirect oldVersion="0.0.0.0-2.2.5.0" newVersion="2.2.5.0" />
+				<assemblyIdentity name="System.Reactive.Core" publicKeyToken="31bf3856ad364e35" culture="neutral"/>
+				<bindingRedirect oldVersion="0.0.0.0-2.2.5.0" newVersion="2.2.5.0"/>
 			</dependentAssembly>
 			<dependentAssembly>
-				<assemblyIdentity name="System.Reactive.Linq" publicKeyToken="31bf3856ad364e35" culture="neutral" />
-				<bindingRedirect oldVersion="0.0.0.0-2.2.5.0" newVersion="2.2.5.0" />
+				<assemblyIdentity name="System.Reactive.Linq" publicKeyToken="31bf3856ad364e35" culture="neutral"/>
+				<bindingRedirect oldVersion="0.0.0.0-2.2.5.0" newVersion="2.2.5.0"/>
 			</dependentAssembly>
 			<dependentAssembly>
-				<assemblyIdentity name="Newtonsoft.Json" publicKeyToken="30ad4fe6b2a6aeed" culture="neutral" />
-				<bindingRedirect oldVersion="0.0.0.0-6.0.0.0" newVersion="6.0.0.0" />
+				<assemblyIdentity name="Newtonsoft.Json" publicKeyToken="30ad4fe6b2a6aeed" culture="neutral"/>
+				<bindingRedirect oldVersion="0.0.0.0-6.0.0.0" newVersion="6.0.0.0"/>
 			</dependentAssembly>
 		</assemblyBinding>
 	</runtime>
 	<startup>
-		<supportedRuntime version="v4.0" sku=".NETFramework,Version=v4.5" />
+		<supportedRuntime version="v4.0" sku=".NETFramework,Version=v4.5.1"/>
 	</startup>
 </configuration>


### PR DESCRIPTION
This PR enables the client API to be used under a `TransactionScope`. I tried to keep the breaking changes as minimal as possible. The following changes are contained in this PR:

- Raven.DtcTests project upgrade to 4.5.1 to enable `TransactionScopeAsyncFlowOption.Enabled`
- Introduced [`AsyncPump`](http://blogs.msdn.com/b/pfxteam/archive/2012/01/20/10259049.aspx) which allows to shim in and execute async operations inside the client enlistment
- `RavenClientEnlistment` uses `AsyncPump` to execute the `Commit`, `Rollback` or `PrepareTransaction`

## Who is affected

All users of the client using `SaveChangesAsync` under a `TransactionScope` will get an `InvalidCastException` during runtime.

Relates to http://issues.hibernatingrhinos.com/issue/RavenDB-1405

## Steps to reproduce
```
	public class SaveChangesAsync : RavenTest
	{
		[Fact]
		public async Task Should_just_work()
		{
			using (var documentStore = NewDocumentStore(requestedStorage: "esent"))
			{
				EnsureDtcIsSupported(documentStore);

				using (var s = documentStore.OpenAsyncSession())
				{
					await s.StoreAsync(new AccurateCount.User { Name = "Ayende" });
					await s.SaveChangesAsync();
				}

				using (var s = documentStore.OpenAsyncSession())
				using (var scope = new TransactionScope(TransactionScopeAsyncFlowOption.Enabled))
				{
					var user = await s.LoadAsync<AccurateCount.User>("users/1");
					user.Name = "Rahien";
					await s.SaveChangesAsync();
					scope.Complete();
				}

				using (var s = documentStore.OpenAsyncSession())
				{
					s.Advanced.AllowNonAuthoritativeInformation = false;
					var user = await s.LoadAsync<AccurateCount.User>("users/1");
					Assert.Equal("Rahien", user.Name);
				}
			}
		}
	}
```

leads to

```
System.InvalidCastExceptionUnable to cast object of type 'Raven.Client.Document.Async.AsyncDocumentSession' to type 'Raven.Client.ITransactionalDocumentSession'.
   at Raven.Client.Document.InMemoryDocumentSessionOperations.TryEnlistInAmbientTransaction() in InMemoryDocumentSessionOperations.cs: line 1103
   at Raven.Client.Document.InMemoryDocumentSessionOperations.PrepareForSaveChanges() in InMemoryDocumentSessionOperations.cs: line 960
   at Raven.Client.Document.Async.AsyncDocumentSession.<SaveChangesAsync>d__72.MoveNext() in AsyncDocumentSession.cs: line 911
--- End of stack trace from previous location where exception was thrown ---
   at System.Runtime.CompilerServices.TaskAwaiter.ThrowForNonSuccess(Task task)
   at System.Runtime.CompilerServices.TaskAwaiter.HandleNonSuccessAndDebuggerNotification(Task task)
   at System.Runtime.CompilerServices.TaskAwaiter.GetResult()
   at Raven.Tests.Bugs.SaveChangesAsync.<Should_just_work>d__0.MoveNext() in SaveChangesAsync.cs: line 28
```

Result of this PR

![pasted image at 2015_09_24 16_45](https://cloud.githubusercontent.com/assets/174258/10078220/02a00c96-62e4-11e5-8beb-0e0cec86cca9.png)


## Random things

I have a spike branch where I also touched the transactional recovery storage. 

https://github.com/danielmarbach/ravendb/tree/AsyncDtcSupportSpike