### PR TITLE
Added generic overload of SetResultTransformer to IDocumentQuery

### DIFF
--- a/Raven.Client.Lightweight/Document/DocumentQuery.cs
+++ b/Raven.Client.Lightweight/Document/DocumentQuery.cs
@@ -1,4 +1,5 @@
-﻿#if !SILVERLIGHT && !NETFX_CORE
+﻿using Raven.Client.Indexes;
+#if !SILVERLIGHT && !NETFX_CORE
 using System;
 using System.Collections;
 using System.Collections.Generic;
@@ -69,7 +70,58 @@ namespace Raven.Client.Document
 	        base.SetResultTransformer(resultsTransformer);
 	        return this;
 	    }
-
+				public IDocumentQuery<TTransformerResult> SetResultTransformer<TTransformer, TTransformerResult>()
+			where TTransformer : AbstractTransformerCreationTask, new()
+		{
+		var documentQuery = new DocumentQuery<TTransformerResult>(theSession,
+#if !SILVERLIGHT
+ theDatabaseCommands,
+#endif
+ theAsyncDatabaseCommands,
+																 indexName,
+																 fieldsToFetch,
+																 projectionFields,
+																 queryListeners,
+																 isMapReduce)
+		{
+			pageSize = pageSize,
+			queryText = new StringBuilder(queryText.ToString()),
+			start = start,
+			timeout = timeout,
+			cutoff = cutoff,
+			cutoffEtag = cutoffEtag,
+			queryStats = queryStats,
+			theWaitForNonStaleResults = theWaitForNonStaleResults,
+			sortByHints = sortByHints,
+			orderByFields = orderByFields,
+			allowMultipleIndexEntriesForSameDocumentToResultTransformer = allowMultipleIndexEntriesForSameDocumentToResultTransformer,
+			groupByFields = groupByFields,
+			aggregationOp = aggregationOp,
+			negate = negate,
+			transformResultsFunc = transformResultsFunc,
+			includes = new HashSet<string>(includes),
+			isSpatialQuery = isSpatialQuery,
+			spatialFieldName = spatialFieldName,
+			queryShape = queryShape,
+			spatialRelation = spatialRelation,
+			spatialUnits = spatialUnits,
+			distanceErrorPct = distanceErrorPct,
+			rootTypes = { typeof(TTransformerResult) },
+			defaultField = defaultField,
+			beforeQueryExecutionAction = beforeQueryExecutionAction,
+			afterQueryExecutedCallback = afterQueryExecutedCallback,
+			highlightedFields = new List<HighlightedField>(highlightedFields),
+			highlighterPreTags = highlighterPreTags,
+			highlighterPostTags = highlighterPostTags,
+			resultsTransformer = new TTransformer().TransformerName,
+			queryInputs = queryInputs,
+			disableEntitiesTracking = disableEntitiesTracking,
+			disableCaching = disableCaching,
+			lastEquality = lastEquality,
+			defaultOperator = defaultOperator
+		};
+		return documentQuery;
+	}
         IDocumentQuery<T> IDocumentQueryBase<T, IDocumentQuery<T>>.SetAllowMultipleIndexEntriesForSameDocumentToResultTransformer(bool val)
         {
             base.SetAllowMultipleIndexEntriesForSameDocumentToResultTransformer(val);

--- a/Raven.Client.Lightweight/IDocumentQuery.cs
+++ b/Raven.Client.Lightweight/IDocumentQuery.cs
@@ -7,6 +7,7 @@ using System;
 using System.Collections.Generic;
 using System.Linq.Expressions;
 using Raven.Abstractions.Data;
+using Raven.Client.Indexes;
 using Raven.Client.Linq;
 using Raven.Client.Spatial;
 using Raven.Json.Linq;
@@ -86,5 +87,8 @@ namespace Raven.Client
 		/// Get the facets as per the specified facets with the given start and pageSize
 		/// </summary>
 		FacetResults GetFacets(List<Facet> facets, int facetStart, int? facetPageSize);
+
+		IDocumentQuery<TTransformerResult> SetResultTransformer<TTransformer, TTransformerResult>()
+			where TTransformer : AbstractTransformerCreationTask, new();
 	}
 }


### PR DESCRIPTION
...that will allow strong-typing of the transformed result separate from the type of the index entries.

Allows the following syntax:

```c#
List<XForm.Result> list = Session.Advanced.LuceneQuery<Idx.MapResult, Idx>()
.WhereEquals(m => m.MappedField, "value")
.SetResultTransformer<XForm, XForm.Result>()
.ToList();
```