### PR TITLE
Solution for Unwanted Duplication of Trace/Debug Output During Testing

### DIFF
--- a/Raven.Database/Embedded/OwinEmbeddedHost.cs
+++ b/Raven.Database/Embedded/OwinEmbeddedHost.cs
@@ -8,11 +8,13 @@ using System.Diagnostics.CodeAnalysis;
 using System.IO;
 using System.Threading;
 using System.Threading.Tasks;
+using System.Web.WebSockets;
 using Microsoft.Owin;
 using Microsoft.Owin.Hosting;
 using Microsoft.Owin.Hosting.Engine;
 using Microsoft.Owin.Hosting.ServerFactory;
 using Microsoft.Owin.Hosting.Services;
+using Microsoft.Owin.Hosting.Tracing;
 using Owin;
 
 namespace Raven.Database.Embedded
@@ -55,7 +57,9 @@ namespace Raven.Database.Embedded
             }
 
             var testServerFactory = new OwinEmbeddedServerFactory();
-            IServiceProvider services = ServicesFactory.Create();
+            IServiceProvider services = ServicesFactory.Create(
+                serviceProvider => serviceProvider.AddInstance<ITraceOutputFactory>(new NullTraceOutputFactory())
+                );
             var engine = services.GetService<IHostingEngine>();
             var context = new StartContext(options)
             {
@@ -105,6 +109,14 @@ namespace Raven.Database.Embedded
                 public void Dispose()
                 {
                 }
+            }
+        }
+
+        private class NullTraceOutputFactory : ITraceOutputFactory
+        {
+            public TextWriter Create(string outputFile)
+            {
+                return StreamWriter.Null;
             }
         }
     }


### PR DESCRIPTION
While building an integration test, I needed to send some trace/debug text to the Debug Output window in Visual Studio. This included multiple lines of IoC container mappings.  I immediately saw that all my “Debug.WriteLine” text was being displayed twice. This made reading those mappings difficult.

After chasing my tail for a little bit, I narrowed the problem down. Whenever I’d insert an EmbeddableDocumentStore into my test arrangement, the duplication occurred. Whenever I’d remove the EmbeddableDocumentStore, my debug output went back to normal.

With some research I figured out the source of the problem. Others have encountered this (outside the context of RavenDB usage). Apparently, Microsoft’s Owin self-host component, used internally by Raven, creates a default trace/debug listener and adds it to the ambient Trace.Listeners collection. This collection already includes a default trace listener that writes to the debug output window. This is why I was seeing duplicate output.

The solution in my pull request is similar to several that I've seen others use. (I don’t believe there is a more elegant way to solve this.)

The Owin AppBuilder pipeline allows you to create “Service Providers” using an IServiceProvider interface. One of the types can be an ITraceOutputFactory. An implementation of this interface can be given to the AppBuilder pipline. This factory will be used to create a tracewriter that will replace the default Microsoft.Owin.Host.Tracing.DualWriter that is normally used by Owin.

I inquired of RavenDB support whether this was left enabled on purpose. Oren replied that it wasn’t.

My pull request properly replaces the default tracewriter with one that writes to a null stream.

This may seem to be a minor issue, but if left uncorrected, can be a real hassle for developers during testing. (In my own case, it cost me many hours of work.)

I submitted a CLA to the support address a few hours ago.

Please review this and contact me if you have any questions.

Thank you
