### PR TITLE
Mistype in Conventions.cs

### DIFF
--- a/Raven.Client.Lightweight/Convention.cs
+++ b/Raven.Client.Lightweight/Convention.cs
@@ -29,9 +29,9 @@ namespace Raven.Client
         }
 
         /// <summary>
-        /// Enable multipule async operations
+        /// Enable multiple async operations
         /// </summary>
-        public bool AllowMultipuleAsyncOperations { get; set; }
+        public bool AllowMultipleAsyncOperations { get; set; }
 
         /// <summary>
         /// Gets or sets the function to find the identity property.


### PR DESCRIPTION
This might be left here, because it would be a breaking change for all of the previous versions, but at least it should be renamed in the next major release