### PR TITLE
Increased count of indexes copied when using the "Copy All Indexes An…

### DIFF
--- a/Raven.Studio.Html5/App/commands/getIndexesDefinitionsCommand.ts
+++ b/Raven.Studio.Html5/App/commands/getIndexesDefinitionsCommand.ts
@@ -2,12 +2,16 @@
 import database = require("models/database");
 
 class getIndexesDefinitionsCommand extends commandBase {
-    constructor(private db: database) {
+    constructor(private db: database, private skip = 0, private take = 256) {
         super();
     }
 
     execute(): JQueryPromise<indexDefinitionListItemDto[]> {
-        var url = "/indexes";
+        var args = {
+          start: this.skip,
+          pageSize: this.take
+        };
+        var url = "/indexes" + this.urlEncodeArgs(args);
         return this.query(url, null, this.db);
     }
 }


### PR DESCRIPTION
I noticed that not all of the indexes in the database were being copied. Compared it to the copy of all transformers and noticed that they were being limited due to missing limit argument. Increased count of indexes copied when using the "Copy All Indexes And Transformers" feature, based changes on the logic from the getTransformersCommands.ts
