### PR TITLE
Fix HTTP header filtering

### DIFF
--- a/Raven.Abstractions/Extensions/MetadataExtensions.cs
+++ b/Raven.Abstractions/Extensions/MetadataExtensions.cs
@@ -118,11 +118,11 @@ namespace Raven.Abstractions.Extensions
             "X-SITE-DEPLOYMENT-ID",
         };
 
-        private static readonly HashSet<string> HeadersToIgnoreForClient = HeadersToIgnoreClient.Except(new[]
+        private static readonly HashSet<string> HeadersToIgnoreForClient = new HashSet<string>(HeadersToIgnoreClient.Except(new[]
         {
             Constants.LastModified,
             Constants.RavenLastModified
-        }).ToHashSet();
+        }), StringComparer.OrdinalIgnoreCase);
 
         private static readonly HashSet<string> PrefixesInHeadersToIgnoreClient = new HashSet<string>(StringComparer.OrdinalIgnoreCase)
                                                                                {

--- a/Raven.Tests/Bugs/ExcludesWebServerHttpHeadersWhenDeserializing.cs
+++ b/Raven.Tests/Bugs/ExcludesWebServerHttpHeadersWhenDeserializing.cs
@@ -1,0 +1,37 @@
+// -----------------------------------------------------------------------
+//  <copyright file="CanDeserializeWhenWeHaveLastModifiedTwiceInMetadata.cs" company="Hibernating Rhinos LTD">
+//      Copyright (c) Hibernating Rhinos LTD. All rights reserved.
+//  </copyright>
+// -----------------------------------------------------------------------
+using System;
+using System.Collections.Specialized;
+using System.Net;
+using Raven.Abstractions.Data;
+using Raven.Client.Connection;
+using Raven.Json.Linq;
+using Raven.Tests.Common;
+
+using Xunit;
+
+namespace Raven.Tests.Bugs
+{
+	public class ExcludesWebServerHttpHeadersWhenDeserializing : NoDisposalNeeded
+	{
+		[Fact]
+		public void CaseInsensitiveMatch()
+		{
+			var webHeaderCollection = new NameValueCollection
+			{
+				{Constants.LastModified, "2012-12-26T06:34:57.8189446Z"},
+				{"WWW-Authenticate", "Negotiate oYG3MIG0oAMKAQChCwYJKoZIgvcSAQICooGfBIGcYIGZBgkqhkiG9xIBAgICAG+BiT..."},
+				{"WWW-Authenticate".ToUpper(), "Negotiate oYG3MIG0oAMKAQChCwYJKoZIgvcSAQICooGfBIGcYIGZBgkqhkiG9xIBAgICAG+BiT..."},
+				{"WWW-Authenticate".ToLower(), "Negotiate oYG3MIG0oAMKAQChCwYJKoZIgvcSAQICooGfBIGcYIGZBgkqhkiG9xIBAgICAG+BiT..."},
+				{"ETag", Guid.NewGuid().ToString()},
+			};
+			JsonDocument document = SerializationHelper.DeserializeJsonDocument("products/ravendb", new RavenJObject(), webHeaderCollection, HttpStatusCode.OK);
+			
+			// The WWW-Authenticate header should have been excluded from the metadata no matter the case
+			Assert.DoesNotContain("www-authenticate", document.Metadata.Keys, StringComparer.OrdinalIgnoreCase);
+		}
+	}
+}

--- a/Raven.Tests/Raven.Tests.csproj
+++ b/Raven.Tests/Raven.Tests.csproj
@@ -1,4 +1,4 @@
-<?xml version="1.0" encoding="utf-8"?>
+﻿<?xml version="1.0" encoding="utf-8"?>
 <Project ToolsVersion="12.0" DefaultTargets="Build" xmlns="http://schemas.microsoft.com/developer/msbuild/2003">
   <PropertyGroup>
     <Configuration Condition=" '$(Configuration)' == '' ">Debug</Configuration>
@@ -252,6 +252,7 @@
     <Compile Include="Bugs\BatchPatching.cs" />
     <Compile Include="Bugs\Caching\CachingOfPostQueries.cs" />
     <Compile Include="Bugs\CanAggregateOnDecimal.cs" />
+    <Compile Include="Bugs\ExcludesWebServerHttpHeadersWhenDeserializing.cs" />
     <Compile Include="Bugs\CanDeserializeWhenWeHaveLastModifiedTwiceInMetadata.cs" />
     <Compile Include="Bugs\CannotChangeId.cs" />
     <Compile Include="Bugs\CanUseLuceneCodecDirectory.cs" />


### PR DESCRIPTION
This pull request fixes a regression that was introduced in RavenDB-4041.

The filtering of HTTP headers was case-insensitive before that, but RavenDB-4041 made it case-sensitive. This was probably not discovered as a problem because most of the items in the relevant HashSet already had the correct casing, except "Www-Authenticate" which only becomes a problem when using Windows Authentication, and when the server includes the "WWW-Authenticate" header in the response to a single document load request.

To avoid this problem in the future, it would probably be wise to put all the items in the HashSet in lower-case so that it breaks immediately if they are accidentally handled in a case-sensitive way.

The more significant problem that is _not_ addressed by this pull request is that if a document somehow makes it into the database with certain keys in the metadata, the server will not be able to return it from DocumentsController.DocsGet (/docs?id=). It fails with an exception "System.InvalidOperationException: Misused header name. Make sure request headers are used with HttpRequestMessage, response headers with HttpResponseMessage, and content headers with HttpContent objects"

The server really should either prevent a user from storing a document containing reserved names in its metadata, or should not attempt to set reserved HTTP response headers.

This pull request makes the HashSet case-insensitive again and includes one new test that specifically checks that the WWW-Authenticate header is ignored when deserializing.