### PR TITLE
Fix LocalDirectoryTransactionRecoveryStorage not finding recovery info when using relative path

### DIFF
--- a/Raven.Client.Lightweight/Document/DTC/LocalDirectoryTransactionRecoveryStorage.cs
+++ b/Raven.Client.Lightweight/Document/DTC/LocalDirectoryTransactionRecoveryStorage.cs
@@ -30,7 +30,6 @@ namespace Raven.Client.Document.DTC
 
         public void DeleteFile(string name)
         {
-            name = Path.Combine(path, name);
             if (File.Exists(name) == false)
                 return;
             File.Delete(name);
@@ -43,7 +42,7 @@ namespace Raven.Client.Document.DTC
 
         public Stream OpenRead(string name)
         {
-            return File.Open(Path.Combine(path, name), FileMode.Open, FileAccess.Read, FileShare.ReadWrite);
+            return File.Open(name, FileMode.Open, FileAccess.Read, FileShare.ReadWrite);
         }
 
         public byte[] GetRecoveryInformation(PreparingEnlistment preparingEnlistment)


### PR DESCRIPTION
Currently, if you use a relative path for transaction recovery storage...

    string path = @".\TxRecovery";
    var store = new DocumentStore
    {
        TransactionRecoveryStorage = new LocalDirectoryTransactionRecoveryStorage(path)
    }

... you will get a nasty surprise if you actually need to recover anything.

LocalDirectoryTransactionRecoveryStorage.GetFileNames(filter) will return Directory.GetFiles(path, filter), which will take the form:

    `.\TxRecovery\<GUID>.recovery-information

Then the OpenRead and DeleteFile will both try to do Path.Combine(path, name) resulting in a file path value like:

    .\TxRecovery\.\TxRecovery\<GUID>.recovery-information

When you try to open that, you'll get:

    System.IO.DirectoryNotFoundException: Could not find a part of the path '<WorkingDirectory>\TxRecovery\TxRecovery\<GUID>.recovery-information'.

Path.Combine() should not be called from the OpenRead and DeleteFile methods.

On the other hand, when you use a fully qualified path (say `C:\ProgramData\TxRecovery`), GetFileNames returns:

    C:\ProgramData\TxRecovery\5a165c50-e345-4d19-94a9-87d5f6a3d4f3.recovery-information

Which is already fully qualified. Once Path.Combine() is applied, the value is unchanged. Path.Combine(rootedPath1, rootedPath2) returns rootedPath2.