### PR TITLE
Added unique sufix to enable parallel testing scenarios for embedded …

### DIFF
--- a/Raven.Tests.Helpers/RavenTestBase.cs
+++ b/Raven.Tests.Helpers/RavenTestBase.cs
@@ -133,7 +133,9 @@ namespace Raven.Tests.Helpers
             if (prefix != null)
                 prefix = prefix.Replace("<", "").Replace(">", "");
 
-            var newDataDir = Path.GetFullPath(string.Format(@".\{1}-{0}-{2}\", DateTime.Now.ToString("yyyy-MM-dd,HH-mm-ss"), prefix ?? "TestDatabase", Interlocked.Increment(ref pathCount)));
+            string suffix = Guid.NewGuid().ToString("N").Substring(0, 8);
+
+            var newDataDir = Path.GetFullPath(string.Format(@".\{1}-{0}-{2}-{3}\", DateTime.Now.ToString("yyyy-MM-dd,HH-mm-ss"), prefix ?? "TestDatabase", suffix, Interlocked.Increment(ref pathCount)));
             if (forceCreateDir && Directory.Exists(newDataDir) == false)
                 Directory.CreateDirectory(newDataDir);
             pathsToDelete.Add(newDataDir);


### PR DESCRIPTION
When running unit test in parallel, at times several tests try to create a new document store on the same second and then the data directory will not be available. By adding a Guid suffix like in raven fs tests we can get a new directory for each test.