### PR TITLE
Support Postgres arrays in sql replication

### DIFF
--- a/Raven.Tests.Bundles/Raven.Tests.Bundles.csproj
+++ b/Raven.Tests.Bundles/Raven.Tests.Bundles.csproj
@@ -198,6 +198,7 @@
     <Compile Include="ScriptedIndexResults\AnimalType.cs" />
     <Compile Include="ScriptedIndexResults\ScriptedIndexResultsTest.cs" />
     <Compile Include="SqlReplication\CanReplicate.cs" />
+    <Compile Include="SqlReplication\CanReplicateToArraysInPostgresSQL.cs" />
     <Compile Include="UniqueConstraints\Bugs\CaseInsensitive.cs" />
     <Compile Include="UniqueConstraints\Bugs\Concurrency.cs" />
     <Compile Include="UniqueConstraints\Bugs\EmptyValues.cs" />

--- a/Raven.Tests.Bundles/Raven.Tests.Bundles.csproj
+++ b/Raven.Tests.Bundles/Raven.Tests.Bundles.csproj
@@ -74,6 +74,10 @@
       <HintPath>..\packages\Newtonsoft.Json.6.0.8\lib\net45\Newtonsoft.Json.dll</HintPath>
       <Private>True</Private>
     </Reference>
+    <Reference Include="Npgsql, Version=3.1.4.0, Culture=neutral, PublicKeyToken=5d8b90d52f46fda7, processorArchitecture=MSIL">
+      <HintPath>..\packages\Npgsql.3.1.4\lib\net45\Npgsql.dll</HintPath>
+      <Private>True</Private>
+    </Reference>
     <Reference Include="Owin, Version=1.0.0.0, Culture=neutral, PublicKeyToken=f0ebd12fd5e55cc5, processorArchitecture=MSIL">
       <HintPath>..\packages\Owin.1.0\lib\net40\Owin.dll</HintPath>
       <Private>True</Private>

--- a/Raven.Tests.Bundles/SqlReplication/CanReplicate.cs
+++ b/Raven.Tests.Bundles/SqlReplication/CanReplicate.cs
@@ -56,10 +56,10 @@ for (var i = 0; i < this.OrderLines.length; i++) {
 
         private void CreateRdbmsSchema()
         {
-            var providerFactory = DbProviderFactories.GetFactory(MaybeSqlServerIsAvailable.ConnectionStringSettings.ProviderName);
+            var providerFactory = DbProviderFactories.GetFactory(MaybeSqlServerIsAvailable.SqlServerConnectionStringSettings.ProviderName);
             using (var con = providerFactory.CreateConnection())
             {
-                con.ConnectionString = MaybeSqlServerIsAvailable.ConnectionStringSettings.ConnectionString;
+                con.ConnectionString = MaybeSqlServerIsAvailable.SqlServerConnectionStringSettings.ConnectionString;
                 con.Open();
 
                 using (var dbCommand = con.CreateCommand())
@@ -126,10 +126,10 @@ CREATE TABLE [dbo].[Orders]
 
                 eventSlim.Wait(TimeSpan.FromMinutes(5));
 
-                var providerFactory = DbProviderFactories.GetFactory(MaybeSqlServerIsAvailable.ConnectionStringSettings.ProviderName);
+                var providerFactory = DbProviderFactories.GetFactory(MaybeSqlServerIsAvailable.SqlServerConnectionStringSettings.ProviderName);
                 using (var con = providerFactory.CreateConnection())
                 {
-                    con.ConnectionString = MaybeSqlServerIsAvailable.ConnectionStringSettings.ConnectionString;
+                    con.ConnectionString = MaybeSqlServerIsAvailable.SqlServerConnectionStringSettings.ConnectionString;
                     con.Open();
 
                     using (var dbCommand = con.CreateCommand())
@@ -180,10 +180,10 @@ replicateToOrders(orderData);");
 
                 eventSlim.Wait(TimeSpan.FromMinutes(5));
 
-                var providerFactory = DbProviderFactories.GetFactory(MaybeSqlServerIsAvailable.ConnectionStringSettings.ProviderName);
+                var providerFactory = DbProviderFactories.GetFactory(MaybeSqlServerIsAvailable.SqlServerConnectionStringSettings.ProviderName);
                 using (var con = providerFactory.CreateConnection())
                 {
-                    con.ConnectionString = MaybeSqlServerIsAvailable.ConnectionStringSettings.ConnectionString;
+                    con.ConnectionString = MaybeSqlServerIsAvailable.SqlServerConnectionStringSettings.ConnectionString;
                     con.Open();
 
                     using (var dbCommand = con.CreateCommand())
@@ -235,10 +235,10 @@ replicateToOrders(orderData);");
 
                 eventSlim.Wait(TimeSpan.FromMinutes(5));
 
-                var providerFactory = DbProviderFactories.GetFactory(MaybeSqlServerIsAvailable.ConnectionStringSettings.ProviderName);
+                var providerFactory = DbProviderFactories.GetFactory(MaybeSqlServerIsAvailable.SqlServerConnectionStringSettings.ProviderName);
                 using (var con = providerFactory.CreateConnection())
                 {
-                    con.ConnectionString = MaybeSqlServerIsAvailable.ConnectionStringSettings.ConnectionString;
+                    con.ConnectionString = MaybeSqlServerIsAvailable.SqlServerConnectionStringSettings.ConnectionString;
                     con.Open();
 
                     using (var dbCommand = con.CreateCommand())
@@ -341,10 +341,10 @@ replicateToOrders(orderData);");
         private static int GetOrdersCount()
         {
             var providerFactory =
-                    DbProviderFactories.GetFactory(MaybeSqlServerIsAvailable.ConnectionStringSettings.ProviderName);
+                    DbProviderFactories.GetFactory(MaybeSqlServerIsAvailable.SqlServerConnectionStringSettings.ProviderName);
             using (var con = providerFactory.CreateConnection())
             {
-                con.ConnectionString = MaybeSqlServerIsAvailable.ConnectionStringSettings.ConnectionString;
+                con.ConnectionString = MaybeSqlServerIsAvailable.SqlServerConnectionStringSettings.ConnectionString;
                 con.Open();
 
                 using (var dbCommand = con.CreateCommand())
@@ -643,10 +643,10 @@ var nameArr = this.StepName.split('.');");
 
         private static void AssertCounts(int ordersCount, int orderLineCounts)
         {
-            var providerFactory = DbProviderFactories.GetFactory(MaybeSqlServerIsAvailable.ConnectionStringSettings.ProviderName);
+            var providerFactory = DbProviderFactories.GetFactory(MaybeSqlServerIsAvailable.SqlServerConnectionStringSettings.ProviderName);
             using (var con = providerFactory.CreateConnection())
             {
-                con.ConnectionString = MaybeSqlServerIsAvailable.ConnectionStringSettings.ConnectionString;
+                con.ConnectionString = MaybeSqlServerIsAvailable.SqlServerConnectionStringSettings.ConnectionString;
                 con.Open();
 
                 using (var dbCommand = con.CreateCommand())
@@ -667,8 +667,8 @@ var nameArr = this.StepName.split('.');");
                 {
                     Id = "Raven/SqlReplication/Configuration/OrdersAndLines",
                     Name = "OrdersAndLines",
-                    ConnectionString = MaybeSqlServerIsAvailable.ConnectionStringSettings.ConnectionString,
-                    FactoryName = MaybeSqlServerIsAvailable.ConnectionStringSettings.ProviderName,
+                    ConnectionString = MaybeSqlServerIsAvailable.SqlServerConnectionStringSettings.ConnectionString,
+                    FactoryName = MaybeSqlServerIsAvailable.SqlServerConnectionStringSettings.ProviderName,
                     RavenEntityName = "Orders",
                     SqlReplicationTables =
                     {

--- a/Raven.Tests.Bundles/SqlReplication/CanReplicateToArraysInPostgresSQL.cs
+++ b/Raven.Tests.Bundles/SqlReplication/CanReplicateToArraysInPostgresSQL.cs
@@ -1,0 +1,231 @@
+﻿// -----------------------------------------------------------------------
+//  <copyright file="CanReplicateToArraysInPostgresSQL.cs" company="Hibernating Rhinos LTD">
+//      Copyright (c) Hibernating Rhinos LTD. All rights reserved.
+//  </copyright>
+// -----------------------------------------------------------------------
+using System;
+using System.Collections.Generic;
+using System.Configuration;
+using System.Data.Common;
+using System.Linq;
+using System.Threading;
+using Raven.Abstractions.Data;
+using Raven.Client.Embedded;
+using Raven.Database.Bundles.SqlReplication;
+using Raven.Tests.Common;
+using Raven.Tests.Common.Attributes;
+using Xunit;
+using Xunit.Sdk;
+
+namespace Raven.Tests.Bundles.SqlReplication
+{
+    public class CanReplicateToArraysInPostgresSQL : RavenTest
+    {
+        protected override void ModifyConfiguration(Database.Config.InMemoryRavenConfiguration configuration)
+        {
+            configuration.Settings["Raven/ActiveBundles"] = "sqlReplication";
+        }
+
+        private const string defaultScript = @"
+var orderData = {
+	Id: documentId,
+	OrderLinesCount: this.OrderLines.length,
+	TotalCost: 0,
+    Quantities: { 
+        EnumType : 'NpgsqlTypes.NpgsqlDbType, Npgsql',
+        EnumValue : 'Array | Double',
+        EnumProperty : 'NpgsqlDbType',
+        Values : this.OrderLines.map(function(l) {return l.Quantity;})
+    }
+};
+replicateToorders(orderData);
+
+for (var i = 0; i < this.OrderLines.length; i++) {
+	var line = this.OrderLines[i];
+	orderData.TotalCost += line.Cost;
+	replicateToorderlines({
+		OrderId: documentId,
+		Qty: line.Quantity,
+		Product: line.Product,
+		Cost: line.Cost
+	});
+}";
+
+        private void CreateRdbmsSchema()
+        {
+            var providerFactory = DbProviderFactories.GetFactory(MaybeSqlServerIsAvailable.PostgresConnectionStringSettings.ProviderName);
+            using (var con = providerFactory.CreateConnection())
+            {
+                con.ConnectionString = MaybeSqlServerIsAvailable.PostgresConnectionStringSettings.ConnectionString;
+                con.Open();
+
+                using (var dbCommand = con.CreateCommand())
+                {
+                    dbCommand.CommandText = @"
+
+DROP TABLE IF EXISTS orderlines;
+DROP TABLE IF EXISTS orders;
+";
+                    dbCommand.ExecuteNonQuery();
+
+                    dbCommand.CommandText = @"
+CREATE TABLE orderlines
+(
+	""Id"" serial primary key,
+	""OrderId"" text NOT NULL,
+	""Qty"" int NOT NULL,
+	""Product"" text NOT NULL,
+	""Cost"" int NOT NULL
+);
+
+CREATE TABLE orders
+(
+	""Id"" text NOT NULL,
+	""OrderLinesCount"" int  NULL,
+	""TotalCost"" int NOT NULL,
+    ""City"" text NULL,
+    ""Quantities"" int[] NULL
+);";
+                    dbCommand.ExecuteNonQuery();
+                }
+            }
+        }
+
+        [Fact]
+        public void CanReplicate()
+        {
+            CreateRdbmsSchema();
+            using (var store = NewDocumentStore())
+            {
+                var eventSlim = new ManualResetEventSlim(false);
+                var sqlReplicationTask = store.SystemDatabase.StartupTasks.OfType<SqlReplicationTask>().First();
+                sqlReplicationTask
+                     .AfterReplicationCompleted += successCount =>
+                     {
+                         if (successCount != 0)
+                             eventSlim.Set();
+                     };
+
+                using (var session = store.OpenSession())
+                {
+                    session.Store(new CanReplicate.Order
+                    {
+                        OrderLines = new List<CanReplicate.OrderLine>
+                        {
+                            new CanReplicate.OrderLine{Cost = 3, Product = "Milk", Quantity = 3},
+                            new CanReplicate.OrderLine{Cost = 4, Product = "Bear", Quantity = 2},
+                        }
+                    });
+                    session.SaveChanges();
+                }
+
+                SetupSqlReplication(store, defaultScript);
+                
+                eventSlim.Wait(TimeSpan.FromMinutes(1));
+
+                Alert lastAlert;
+                if (sqlReplicationTask.Statistics.ContainsKey("OrdersAndLines"))
+                {
+                    lastAlert = sqlReplicationTask.Statistics["OrdersAndLines"].LastAlert;
+                    if (lastAlert != null)
+                        throw new AssertActualExpectedException(null, lastAlert, lastAlert.Message + lastAlert.Exception);
+                }
+
+                AssertCounts(1, 2);
+            }
+        }
+
+        [Fact]
+        public void CanDelete()
+        {
+            CreateRdbmsSchema();
+            using (var store = NewDocumentStore())
+            {
+                var eventSlim = new ManualResetEventSlim(false);
+                var sqlReplicationTask = store.SystemDatabase.StartupTasks.OfType<SqlReplicationTask>().First();
+                sqlReplicationTask
+                     .AfterReplicationCompleted += successCount =>
+                     {
+                         if (successCount != 0)
+                             eventSlim.Set();
+                     };
+
+                using (var session = store.OpenSession())
+                {
+                    session.Store(new CanReplicate.Order
+                    {
+                        OrderLines = new List<CanReplicate.OrderLine>
+                        {
+                            new CanReplicate.OrderLine{Cost = 3, Product = "Milk", Quantity = 3},
+                            new CanReplicate.OrderLine{Cost = 4, Product = "Bear", Quantity = 2},
+                        }
+                    });
+                    session.SaveChanges();
+                }
+
+                SetupSqlReplication(store, defaultScript);
+
+                eventSlim.Wait(TimeSpan.FromMinutes(1));
+
+                Alert lastAlert;
+                if (sqlReplicationTask.Statistics.ContainsKey("OrdersAndLines"))
+                {
+                    lastAlert = sqlReplicationTask.Statistics["OrdersAndLines"].LastAlert;
+                    if (lastAlert != null)
+                        throw new AssertActualExpectedException(null, lastAlert, lastAlert.Message + lastAlert.Exception);
+                }
+
+                AssertCounts(1, 2);
+
+                eventSlim.Reset();
+
+                store.DatabaseCommands.Delete("orders/1", null);
+
+                eventSlim.Wait(TimeSpan.FromMinutes(1));
+
+                AssertCounts(0, 0);
+
+            }
+        }
+
+        private static void SetupSqlReplication(EmbeddableDocumentStore store, string script, bool insertOnly = false)
+        {
+            using (var session = store.OpenSession())
+            {
+                session.Store(new SqlReplicationConfig
+                {
+                    Id = "Raven/SqlReplication/Configuration/OrdersAndLines",
+                    Name = "OrdersAndLines",
+                    ConnectionString = MaybeSqlServerIsAvailable.PostgresConnectionStringSettings.ConnectionString,
+                    FactoryName = MaybeSqlServerIsAvailable.PostgresConnectionStringSettings.ProviderName,
+                    RavenEntityName = "Orders",
+                    SqlReplicationTables =
+                    {
+                        new SqlReplicationTable {TableName = "orders", DocumentKeyColumn = "Id", InsertOnlyMode = insertOnly},
+                        new SqlReplicationTable {TableName = "orderlines", DocumentKeyColumn = "OrderId", InsertOnlyMode = insertOnly},
+                    },
+                    Script = script
+                });
+                session.SaveChanges();
+            }
+        }
+
+        private static void AssertCounts(long ordersCount, long orderLineCounts)
+        {
+            var providerFactory = DbProviderFactories.GetFactory(MaybeSqlServerIsAvailable.PostgresConnectionStringSettings.ProviderName);
+            using (var con = providerFactory.CreateConnection())
+            {
+                con.ConnectionString = MaybeSqlServerIsAvailable.PostgresConnectionStringSettings.ConnectionString;
+                con.Open();
+
+                using (var dbCommand = con.CreateCommand())
+                {
+                    dbCommand.CommandText = "SELECT COUNT(*) FROM Orders";
+                    Assert.Equal(ordersCount, dbCommand.ExecuteScalar());
+                    dbCommand.CommandText = "SELECT COUNT(*) FROM OrderLines";
+                    Assert.Equal(orderLineCounts, dbCommand.ExecuteScalar());
+                }
+            }
+        }
+    }
+}

--- a/Raven.Tests.Bundles/app.config
+++ b/Raven.Tests.Bundles/app.config
@@ -13,10 +13,10 @@
         </DbProviderFactories>
     </system.data>
     <connectionStrings>
-      <add name="PostgreSQL" providerName="Npgsql" connectionString="Server=localhost;Port=5432;User Id=postgres;Password=postgres;Database=raven_tests" />
       <add name="SqlExpress" providerName="System.Data.SqlClient" connectionString="Data Source=.\sqlexpress;Initial Catalog=Raven.Tests;Integrated Security=SSPI;Connection Timeout=1" />
       <add name="LocalHost" providerName="System.Data.SqlClient" connectionString="Data Source=.;Initial Catalog=Raven.Tests;Integrated Security=SSPI;Connection Timeout=1" />
       <add name="CiHost" providerName="System.Data.SqlClient" connectionString="Data Source=ci1\sqlexpress;Initial Catalog=Raven.Tests;Integrated Security=SSPI;Connection Timeout=1" />
+      <add name="Postgres" providerName="Npgsql" connectionString="Server=localhost;Port=5432;User Id=postgres;Password=postgres;Database=raven_tests" />
     </connectionStrings>
     <runtime>
         <assemblyBinding xmlns="urn:schemas-microsoft-com:asm.v1">

--- a/Raven.Tests.Bundles/app.config
+++ b/Raven.Tests.Bundles/app.config
@@ -7,7 +7,13 @@
         <add key="Raven/Bundles/LiveTest/Quotas/Size/SoftLimitInKB" value="555555" />
         <add key="Raven/Bundles/LiveTest/Tenants/MaxIdleTimeForTenantResource" value="10" />
     </appSettings>
+    <system.data>
+        <DbProviderFactories>
+            <add name="Npgsql Data Provider" invariant="Npgsql" support="FF" description=".Net Framework Data Provider for Postgresql Server" type="Npgsql.NpgsqlFactory, Npgsql, Culture=neutral" />
+        </DbProviderFactories>
+    </system.data>
     <connectionStrings>
+      <add name="PostgreSQL" providerName="Npgsql" connectionString="Server=localhost;Port=5432;User Id=postgres;Password=postgres;Database=raven_tests" />
       <add name="SqlExpress" providerName="System.Data.SqlClient" connectionString="Data Source=.\sqlexpress;Initial Catalog=Raven.Tests;Integrated Security=SSPI;Connection Timeout=1" />
       <add name="LocalHost" providerName="System.Data.SqlClient" connectionString="Data Source=.;Initial Catalog=Raven.Tests;Integrated Security=SSPI;Connection Timeout=1" />
       <add name="CiHost" providerName="System.Data.SqlClient" connectionString="Data Source=ci1\sqlexpress;Initial Catalog=Raven.Tests;Integrated Security=SSPI;Connection Timeout=1" />

--- a/Raven.Tests.Bundles/packages.config
+++ b/Raven.Tests.Bundles/packages.config
@@ -6,5 +6,6 @@
   <package id="Microsoft.Owin.Host.HttpListener" version="3.0.1" targetFramework="net45" />
   <package id="Microsoft.Owin.Hosting" version="3.0.1" targetFramework="net45" />
   <package id="Newtonsoft.Json" version="6.0.8" targetFramework="net45" />
+  <package id="Npgsql" version="3.1.4" targetFramework="net45" />
   <package id="Owin" version="1.0" targetFramework="net45" />
 </packages>

--- a/Raven.Tests.Common/Attributes/FactIfSqlServerIsAvailable.cs
+++ b/Raven.Tests.Common/Attributes/FactIfSqlServerIsAvailable.cs
@@ -38,6 +38,7 @@ namespace Raven.Tests.Common.Attributes
         {
             foreach (var settings in new[]
             {
+                ConfigurationManager.ConnectionStrings["PostgreSQL"],
                 ConfigurationManager.ConnectionStrings["SqlExpress"],
                 ConfigurationManager.ConnectionStrings["LocalHost"],
                 ConfigurationManager.ConnectionStrings["CiHost"]


### PR DESCRIPTION
This is a first attempt at getting arrays to work with the latest npgsql version (3.0, tested with 3.1.4).
