### PR TITLE
Removing redundant condition _log.IsDebugEnabled

### DIFF
--- a/Rachis/Rachis/Behaviors/AbstractRaftStateBehavior.cs
+++ b/Rachis/Rachis/Behaviors/AbstractRaftStateBehavior.cs
@@ -486,11 +486,10 @@ namespace Rachis.Behaviors
             if (req.Entries.Length > 0)
             {
                 if (_log.IsDebugEnabled)
+                {
                     _log.Debug("Appending log (persistant state), entries count: {0} (node state = {1})", req.Entries.Length,
                     Engine.State);
 
-                if (_log.IsDebugEnabled)
-                {
                     foreach (var logEntry in req.Entries)
                     {
                         _log.Debug("Entry {0} (term {1})", logEntry.Index, logEntry.Term);

--- a/Raven.Database/Storage/Voron/StorageActions/DocumentsStorageActions.cs
+++ b/Raven.Database/Storage/Voron/StorageActions/DocumentsStorageActions.cs
@@ -439,7 +439,7 @@ namespace Raven.Database.Storage.Voron.StorageActions
                           .Delete(writeBatch.Value, deletedETag);
 
             documentCacher.RemoveCachedDocument(normalizedKey, existingEtag);
-            if (logger.IsDebugEnabled)
+
             if (logger.IsDebugEnabled) { logger.Debug("Deleted document with key = '{0}'", key); }
 
             return true;
@@ -456,7 +456,7 @@ namespace Raven.Database.Storage.Voron.StorageActions
             DateTime savedAt;
             var normalizedKey = CreateKey(key);
             var isUpdate = WriteDocumentData(key, normalizedKey, etag, data, metadata, out newEtag, out existingEtag, out savedAt);
-            if (logger.IsDebugEnabled)
+
             if (logger.IsDebugEnabled) { logger.Debug("AddDocument() - {0} document with key = '{1}'", isUpdate ? "Updated" : "Added", key); }
 
             if (existingEtag != null)
@@ -534,7 +534,7 @@ namespace Raven.Database.Storage.Voron.StorageActions
 
             documentCacher.RemoveCachedDocument(normalizedKey, preTouchEtag);
             etagTouches.Add(preTouchEtag, afterTouchEtag);
-            if (logger.IsDebugEnabled)
+
             if (logger.IsDebugEnabled) { logger.Debug("TouchDocument() - document with key = '{0}'", key); }
         }
 


### PR DESCRIPTION
Removing redundant condition _log.IsDebugEnabled
