### PR TITLE
Remove identical sub-expression

### DIFF
--- a/Raven.Database/Linq/CodeVerifier.cs
+++ b/Raven.Database/Linq/CodeVerifier.cs
@@ -62,7 +62,7 @@ namespace Raven.Database.Linq
                         continue;
                     foreach (var instruction in methodInfo.GetInstructions())
                     {
-                        if (instruction.OpCode != OpCodes.Call && instruction.OpCode != OpCodes.Call &&
+                        if (instruction.OpCode != OpCodes.Call &&
                             instruction.OpCode != OpCodes.Callvirt && instruction.OpCode != OpCodes.Newobj)
                             continue;
 


### PR DESCRIPTION
`instruction.OpCode != OpCodes.Call` is checked twice, which seems a bit redundant.
