### PR TITLE
Duplicate assignment

### DIFF
--- a/Raven.Database/Server/RavenDbServer.cs
+++ b/Raven.Database/Server/RavenDbServer.cs
@@ -106,8 +106,6 @@ namespace Raven.Server
             }
             BooleanQuery.MaxClauseCount = configuration.MaxClauseCount;
 
-            BooleanQuery.MaxClauseCount = configuration.MaxClauseCount;
-
             owinHttpServer = new OwinHttpServer(configuration, useHttpServer: UseEmbeddedHttpServer, configure: configure);
             options = owinHttpServer.Options;
             


### PR DESCRIPTION
`BooleanQuery.MaxClauseCount` is assigned the same value twice.
