### PR TITLE
Make SmugglerRemoteDatabaseOperations.ShowProgress virtual

### DIFF
--- a/Raven.Smuggler/SmugglerRemoteDatabaseOperations.cs
+++ b/Raven.Smuggler/SmugglerRemoteDatabaseOperations.cs
@@ -248,7 +248,7 @@ namespace Raven.Smuggler
             }
         }
 
-        public void ShowProgress(string format, params object[] args)
+        public virtual void ShowProgress(string format, params object[] args)
         {
             try
             {


### PR DESCRIPTION
… ravendb 2.5. We used this to monitor the progress in our application's Import feature which wrapped up the smuggler. This was changed in the SmugglerRemoteDatabaseOperations refactor and as such, we currently have no way to hook into the smuggler progress in 3.0+
