### PR TITLE
RavenDB-5390 Fixing infinite indexing loop problem by removing the op…

### DIFF
--- a/Raven.Tests.Issues/Raven.Tests.Issues.csproj
+++ b/Raven.Tests.Issues/Raven.Tests.Issues.csproj
@@ -567,6 +567,7 @@
     <Compile Include="RavenDB_505.cs" />
     <Compile Include="RavenDB_514.cs" />
     <Compile Include="RavenDB_535.cs" />
+    <Compile Include="RavenDB_5390.cs" />
     <Compile Include="RavenDB_5395.cs" />
     <Compile Include="RavenDB_542 .cs" />
     <Compile Include="RavenDB_554.cs" />

--- a/Raven.Tests.Issues/RavenDB_5390.cs
+++ b/Raven.Tests.Issues/RavenDB_5390.cs
@@ -1,0 +1,46 @@
+﻿using Raven.Abstractions.Data;
+using Raven.Tests.Issues.Prefetcher;
+using System;
+using System.Threading;
+using System.Threading.Tasks;
+using Xunit;
+
+namespace Raven.Tests.Issues
+{
+    public class RavenDB_5390 : PrefetcherTestBase
+    {
+        [Fact]
+        public void Frequent_updates_of_document_should_not_cause_deadlock_in_prefetcher()
+        {
+            // this test does not guarantee to fail on very run however 9/10 runs is failed
+
+            var prefetcher = CreatePrefetcher();
+
+            var task = Task.Factory.StartNew(() =>
+            {
+                for (int i = 0; i < 1000; i++)
+                {
+                    AddDocumentsToTransactionalStorage(prefetcher.TransactionalStorage, 1);
+
+                    if (prefetcher.PrefetchingBehavior.InMemoryFutureIndexBatchesSize > 0)
+                        break;
+                }
+            });
+
+            Assert.True(SpinWait.SpinUntil(() =>
+            {
+                prefetcher.PrefetchingBehavior.GetDocumentsBatchFrom(Etag.Empty, 1); // get docs to ensure a future batch will be added
+
+                return prefetcher.PrefetchingBehavior.InMemoryFutureIndexBatchesSize > 0;
+            }, TimeSpan.FromSeconds(10)));
+            
+            task.Wait();
+
+            AddDocumentsToTransactionalStorage(prefetcher.TransactionalStorage, 1);
+
+            var docs = prefetcher.PrefetchingBehavior.GetDocumentsBatchFrom(Etag.Empty, 1);
+
+            Assert.Equal(1, docs.Count);
+        }
+    }
+}


### PR DESCRIPTION
…timization in PrefetchingBehavior (commits: 47079f85 and 0675e13f). The problem was that during frequent updates future batches can contain etags which no longer exist (docs already updated). We limited ourselves on loading docs from a disk (untilEtag param) however there were no documents to load within a such range of etags. In result we had stale indexes but the prefetcher didn't return any docs.
