### PR TITLE
RavenDB-5390 Fixing infinite indexing loop problem by removing the op…

### DIFF
--- a/Raven.Database/Prefetching/PrefetchingBehavior.cs
+++ b/Raven.Database/Prefetching/PrefetchingBehavior.cs
@@ -375,13 +375,7 @@ namespace Raven.Database.Prefetching
                         if (log.IsDebugEnabled)
                             log.Debug("Didn't load any documents from previous batches. Loading documents directly from disk.");
 
-                        if (firstEtagInQueue == null || firstEtagInQueue.CompareTo(etag) <= 0)
-                        {
-                            //if the first etag in queue is smaller than the already requested one,
-                            //we can look for the next etag in the future batches
-                            firstEtagInQueue = GetMinimumEtagFromFutureBatches(Abstractions.Util.EtagUtil.Increment(etag, 1));
-                        }
-                        // if there has been no results, AND no future batch that we can wait for, then we just load directly from disk
+                        //if there has been no results, AND no future batch that we can wait for, then we just load directly from disk
                         LoadDocumentsFromDisk(etag, firstEtagInQueue); // here we _intentionally_ use the current etag, not the next one
                     }
                 }
@@ -438,7 +432,7 @@ namespace Raven.Database.Prefetching
             var jsonDocs = GetJsonDocsFromDisk(context.CancellationToken, etag, untilEtag);
             if (log.IsDebugEnabled)
             {
-                log.Debug("Loaded {0} documents ({3:#,#;;0} kb) from disk, starting from etag {1}, took {2}ms", jsonDocs.Count, etag, sp.ElapsedMilliseconds,
+                log.Debug("Loaded {0} documents ({4:#,#;;0} kb) from disk, starting from etag {1} (until {2}), took {3}ms", jsonDocs.Count, etag, untilEtag, sp.ElapsedMilliseconds,
                     jsonDocs.Sum(x => x.SerializedSizeOnDisk) / 1024);
             }
 
@@ -1015,30 +1009,6 @@ namespace Raven.Database.Prefetching
                     nextEtag = accessor.Documents.GetBestNextDocumentEtag(lastEtagInBatch);
                 }
             });
-        }
-
-        /// <summary>
-        /// Gets the minimum etag from the future batches that is bigger than the startEtag
-        /// </summary>
-        /// <param name="startEtag">The minimum etag we start to look from</param>
-        /// <returns></returns>
-        private Etag GetMinimumEtagFromFutureBatches(Etag startEtag)
-        {
-            Etag minEtag = null;
-
-            foreach (var futureIndexBatch in futureIndexBatches.Values)
-            {
-                if (startEtag.CompareTo(futureIndexBatch.StartingEtag) < 0 &&
-                    (minEtag == null || futureIndexBatch.StartingEtag.CompareTo(minEtag) < 0))
-                {
-                    minEtag = futureIndexBatch.StartingEtag;
-                }
-            }
-
-            if (minEtag != null && minEtag != Etag.Empty)
-                minEtag = Abstractions.Util.EtagUtil.Increment(minEtag, -1);
-
-            return minEtag;
         }
 
         private FutureIndexBatch GetCompletedFutureBatchWithMaxStartingEtag()

--- a/Raven.Tests.Issues/Raven.Tests.Issues.csproj
+++ b/Raven.Tests.Issues/Raven.Tests.Issues.csproj
@@ -517,6 +517,7 @@
     <Compile Include="RavenDB_505.cs" />
     <Compile Include="RavenDB_514.cs" />
     <Compile Include="RavenDB_535.cs" />
+    <Compile Include="RavenDB_5390.cs" />
     <Compile Include="RavenDB_5395.cs" />
     <Compile Include="RavenDB_542 .cs" />
     <Compile Include="RavenDB_554.cs" />

--- a/Raven.Tests.Issues/RavenDB_5390.cs
+++ b/Raven.Tests.Issues/RavenDB_5390.cs
@@ -1,0 +1,46 @@
+﻿using Raven.Abstractions.Data;
+using Raven.Tests.Issues.Prefetcher;
+using System;
+using System.Threading;
+using System.Threading.Tasks;
+using Xunit;
+
+namespace Raven.Tests.Issues
+{
+    public class RavenDB_5390 : PrefetcherTestBase
+    {
+        [Fact]
+        public void Frequent_updates_of_document_should_not_cause_deadlock_in_prefetcher()
+        {
+            // this test does not guarantee to fail on very run however 9/10 runs is failed
+
+            var prefetcher = CreatePrefetcher();
+
+            var task = Task.Factory.StartNew(() =>
+            {
+                for (int i = 0; i < 1000; i++)
+                {
+                    AddDocumentsToTransactionalStorage(prefetcher.TransactionalStorage, 1);
+
+                    if (prefetcher.PrefetchingBehavior.InMemoryFutureIndexBatchesSize > 0)
+                        break;
+                }
+            });
+
+            Assert.True(SpinWait.SpinUntil(() =>
+            {
+                prefetcher.PrefetchingBehavior.GetDocumentsBatchFrom(Etag.Empty, 1); // get docs to ensure a future batch will be added
+
+                return prefetcher.PrefetchingBehavior.InMemoryFutureIndexBatchesSize > 0;
+            }, TimeSpan.FromSeconds(10)));
+            
+            task.Wait();
+
+            AddDocumentsToTransactionalStorage(prefetcher.TransactionalStorage, 1);
+
+            var docs = prefetcher.PrefetchingBehavior.GetDocumentsBatchFrom(Etag.Empty, 1);
+
+            Assert.Equal(1, docs.Count);
+        }
+    }
+}


### PR DESCRIPTION
…timization in PrefetchingBehavior (commits: 47079f85 and 0675e13f). The problem was that during frequent updates future batches can contain etags which no longer exist (docs already updated). We limited ourselves on loading docs from a disk (untilEtag param) however there were no documents to load within a such range of etags. In result we had stale indexes but the prefetcher didn't return any docs.
