### PR TITLE
RavenDB-5475 When index is already disposed we don't have anything to…

### DIFF
--- a/Raven.Database/Config/MemoryStatistics.cs
+++ b/Raven.Database/Config/MemoryStatistics.cs
@@ -240,7 +240,8 @@ namespace Raven.Database.Config
                         Log.ErrorException("Failure to process low memory notification (low memory handler - " + handler + ")", e);
                     }
                 }
-
+                else
+                    inactiveHandlers.Add(lowMemoryHandler);
             }
             stats.Duration = sp.Elapsed;
             LowMemoryCallRecords.Enqueue(stats);

--- a/Raven.Database/Indexing/Index.cs
+++ b/Raven.Database/Indexing/Index.cs
@@ -2306,6 +2306,17 @@ namespace Raven.Database.Indexing
 
         public LowMemoryHandlerStatistics HandleLowMemory()
         {
+            if (disposed)
+            {
+                return new LowMemoryHandlerStatistics
+                {
+                    Name = $"Index: {PublicName}",
+                    DatabaseName = context.DatabaseName,
+                    Summary = "Index is already disposed. Nothing to free.",
+                    EstimatedUsedMemory = 0
+                };
+            }
+
             bool tryEnter = false;
             var res = new LowMemoryHandlerStatistics();
             try
@@ -2331,7 +2342,7 @@ namespace Raven.Database.Indexing
                 RecreateSearcher();
                 return new LowMemoryHandlerStatistics
                 {
-                    Name = $"CachedIndexedTerms:{PublicName}",
+                    Name = $"Index: {PublicName}",
                     DatabaseName = context.DatabaseName,
                     Summary = $"Writing in memory index {IndexId} to disk, recreating index readers and writers, freeing write and read cache"
                 };


### PR DESCRIPTION
… release while the attempt to recreated the searcher would result in throwing an exception. Added missing removal of inactive memory handlers. Fixed Name property in low memory stats handler called by an index.
