### PR TITLE
RavenDB-5475 When index is already disposed we don't have anything to…

### DIFF
--- a/Raven.Database/Indexing/Index.cs
+++ b/Raven.Database/Indexing/Index.cs
@@ -2022,6 +2022,9 @@ namespace Raven.Database.Indexing
 
         public void HandleLowMemory()
         {
+            if (disposed)
+                return;
+
             bool tryEnter = false;
             try
             {


### PR DESCRIPTION
… release while the attempt to recreated the searcher would result in throwing an exception.
