### PR TITLE
RavenDB-5491 When deleting an index that couldn't be compiled we also…

### DIFF
--- a/Raven.Database/Actions/MaintenanceActions.cs
+++ b/Raven.Database/Actions/MaintenanceActions.cs
@@ -212,6 +212,7 @@ namespace Raven.Database.Actions
                             // Even though technically we are running into a situation that is considered to be corrupt data
                             // we can safely recover from it by removing the other parts of the index.
                             Database.IndexStorage.DeleteIndex(indexId);
+                            actions.Indexing.PrepareIndexForDeletion(indexId);
                             actions.Indexing.DeleteIndex(indexId, WorkContext.CancellationToken);
 
                             string indexName;


### PR DESCRIPTION
… need to delete its stats (PrepareIndexForDeletion) so we won't retry the deletion after server restart.
