### PR TITLE
Fixing Voron race condition that can happen when a read transaction is started _while_ the flush is in progress.

### DIFF
--- a/Raven.Voron/Voron.Tests/Bugs/InvalidReleasesOfScratchPages.cs
+++ b/Raven.Voron/Voron.Tests/Bugs/InvalidReleasesOfScratchPages.cs
@@ -160,7 +160,7 @@ namespace Voron.Tests.Bugs
 
                 env.FlushLogToDataFile(); // non read nor write transactions, so it should flush and release everything from scratch
 
-                Assert.Equal(0, env.ScratchBufferPool.GetNumberOfAllocations(0));
+                Assert.Equal(2, env.ScratchBufferPool.GetNumberOfAllocations(0));
             }
         }
     }

--- a/Raven.Voron/Voron.Tests/ScratchBuffer/MutipleScratchBuffersUsage.cs
+++ b/Raven.Voron/Voron.Tests/ScratchBuffer/MutipleScratchBuffersUsage.cs
@@ -37,7 +37,7 @@ namespace Voron.Tests.ScratchBuffer
             // also in the meanwhile the free space handling is doing its job so it needs some pages too
             // and we allocate not the exact size but the nearest power of two e.g. we write 257 pages but in scratch we request 512 ones
             int i = 0;
-            while (size < 256 * AbstractPager.PageSize) 
+            while (size < 128 * AbstractPager.PageSize) 
             {
                 using (Env.NewTransaction(TransactionFlags.Read))
                 {

--- a/Raven.Voron/Voron/Impl/Journal/WriteAheadJournal.cs
+++ b/Raven.Voron/Voron/Impl/Journal/WriteAheadJournal.cs
@@ -684,17 +684,22 @@ namespace Voron.Impl.Journal
 
             private void FreeScratchPages(IEnumerable<JournalFile> unusedJournalFiles, Transaction txw)
             {
+                // we release up to the last read transaction, because there might be new read transactions that are currently
+                // running, that started after the flush
+                var lastSyncedTransactionId = Math.Min(_lastSyncedTransactionId, _waj._env.CurrentReadTransactionId - 1);
+
                 // we have to free pages of the unused journals before the remaining ones that are still in use
                 // to prevent reading from them by any read transaction (read transactions search journals from the newest
                 // to read the most updated version)
+
                 foreach (var journalFile in unusedJournalFiles.OrderBy(x => x.Number))
                 {
-                    journalFile.FreeScratchPagesOlderThan(txw, _lastSyncedTransactionId, forceToFreeAllPages: forcedFlushOfOldPages);
+                    journalFile.FreeScratchPagesOlderThan(txw, lastSyncedTransactionId, forceToFreeAllPages: forcedFlushOfOldPages);
                 }
 
                 foreach (var jrnl in _waj._files.OrderBy(x => x.Number))
                 {
-                    jrnl.FreeScratchPagesOlderThan(txw, _lastSyncedTransactionId, forceToFreeAllPages: forcedFlushOfOldPages);
+                    jrnl.FreeScratchPagesOlderThan(txw, lastSyncedTransactionId, forceToFreeAllPages: forcedFlushOfOldPages);
                 }
             }
 

--- a/Raven.Voron/Voron/StorageEnvironment.cs
+++ b/Raven.Voron/Voron/StorageEnvironment.cs
@@ -461,6 +461,11 @@ namespace Voron
             DebugJournal.RecordTransactionAction(tx, state);
         }
 
+        public long CurrentReadTransactionId
+        {
+            get { return Thread.VolatileRead(ref _transactionsCounter); }
+        }
+
         public long NextWriteTransactionId
         {
             get { return Thread.VolatileRead(ref _transactionsCounter) + 1; }


### PR DESCRIPTION
This can cause the read transaction to read data that started after it opened, so we need to prevent that.
