### PR TITLE
Fixing Voron race condition that can happen when a read transaction is started _while_ the flush is in progress

### DIFF
--- a/Raven.Voron/Voron.Tests/Bugs/InvalidReleasesOfScratchPages.cs
+++ b/Raven.Voron/Voron.Tests/Bugs/InvalidReleasesOfScratchPages.cs
@@ -160,7 +160,9 @@ namespace Voron.Tests.Bugs
 
                 env.FlushLogToDataFile(); // non read nor write transactions, so it should flush and release everything from scratch
 
-                Assert.Equal(0, env.ScratchBufferPool.GetNumberOfAllocations(0));
+                // we keep track of the pages in scratch for one additional transaction, to avoid race
+                // condition with FlushLogToDataFile concurrently with new read transactions
+                Assert.Equal(2, env.ScratchBufferPool.GetNumberOfAllocations(0));
             }
         }
     }

--- a/Raven.Voron/Voron.Tests/ScratchBuffer/MutipleScratchBuffersUsage.cs
+++ b/Raven.Voron/Voron.Tests/ScratchBuffer/MutipleScratchBuffersUsage.cs
@@ -37,7 +37,7 @@ namespace Voron.Tests.ScratchBuffer
             // also in the meanwhile the free space handling is doing its job so it needs some pages too
             // and we allocate not the exact size but the nearest power of two e.g. we write 257 pages but in scratch we request 512 ones
             int i = 0;
-            while (size < 256 * AbstractPager.PageSize) 
+            while (size < 128 * AbstractPager.PageSize) 
             {
                 using (Env.NewTransaction(TransactionFlags.Read))
                 {

--- a/Raven.Voron/Voron/Impl/Compaction/StorageCompaction.cs
+++ b/Raven.Voron/Voron/Impl/Compaction/StorageCompaction.cs
@@ -42,7 +42,7 @@ namespace Voron.Impl.Compaction
 
                 compactedEnv.FlushLogToDataFile(allowToFlushOverwrittenPages: true);
 
-                compactedEnv.Journal.Applicator.SyncDataFile(compactedEnv.OldestTransaction);
+                compactedEnv.Journal.Applicator.SyncDataFile();
                 compactedEnv.Journal.Applicator.DeleteCurrentAlreadyFlushedJournal();
 
                 minimalCompactedDataFileSize = compactedEnv.NextPageNumber*AbstractPager.PageSize;


### PR DESCRIPTION
This can cause the read transaction to read data that started after it opened, so we need to prevent that.

@arekpalinski reviewed this.
