### PR TITLE
Fixing Voron race condition that can happen when a read transaction i…

### DIFF
--- a/Raven.Voron/Voron.Tests/Bugs/InvalidReleasesOfScratchPages.cs
+++ b/Raven.Voron/Voron.Tests/Bugs/InvalidReleasesOfScratchPages.cs
@@ -160,7 +160,9 @@ namespace Voron.Tests.Bugs
 
                 env.FlushLogToDataFile(); // non read nor write transactions, so it should flush and release everything from scratch
 
-                Assert.Equal(0, env.ScratchBufferPool.GetNumberOfAllocations(0));
+                // we keep track of the pages in scratch for one additional transaction, to avoid race
+                // condition with FlushLogToDataFile concurrently with new read transactions
+                Assert.Equal(2, env.ScratchBufferPool.GetNumberOfAllocations(0));
             }
         }
     }

--- a/Raven.Voron/Voron.Tests/ScratchBuffer/MutipleScratchBuffersUsage.cs
+++ b/Raven.Voron/Voron.Tests/ScratchBuffer/MutipleScratchBuffersUsage.cs
@@ -37,7 +37,7 @@ namespace Voron.Tests.ScratchBuffer
             // also in the meanwhile the free space handling is doing its job so it needs some pages too
             // and we allocate not the exact size but the nearest power of two e.g. we write 257 pages but in scratch we request 512 ones
             int i = 0;
-            while (size < 256 * AbstractPager.PageSize) 
+            while (size < 128 * AbstractPager.PageSize) 
             {
                 using (Env.NewTransaction(TransactionFlags.Read))
                 {

--- a/Raven.Voron/Voron/Impl/Compaction/StorageCompaction.cs
+++ b/Raven.Voron/Voron/Impl/Compaction/StorageCompaction.cs
@@ -42,7 +42,7 @@ namespace Voron.Impl.Compaction
 
                 compactedEnv.FlushLogToDataFile(allowToFlushOverwrittenPages: true);
 
-                compactedEnv.Journal.Applicator.SyncDataFile(compactedEnv.OldestTransaction);
+                compactedEnv.Journal.Applicator.SyncDataFile();
                 compactedEnv.Journal.Applicator.DeleteCurrentAlreadyFlushedJournal();
 
                 minimalCompactedDataFileSize = compactedEnv.NextPageNumber*AbstractPager.PageSize;

--- a/Raven.Voron/Voron/StorageEnvironment.cs
+++ b/Raven.Voron/Voron/StorageEnvironment.cs
@@ -432,13 +432,14 @@ namespace Voron
                         RecordTransactionState(tx, DebugActionType.TransactionStart);
                         tx.RecordTransactionState = RecordTransactionState;
                     }
+
+                    _activeTransactions.Add(tx);
                 }
                 finally
                 {
                     _txCommit.ExitReadLock();
                 }
-
-                _activeTransactions.Add(tx);
+                
                 tx.EnsurePagerStateReference(_dataPager.PagerState);
 
                 if (flags == TransactionFlags.ReadWrite)
@@ -461,6 +462,32 @@ namespace Voron
             DebugJournal.RecordTransactionAction(tx, state);
         }
 
+        public long CurrentReadTransactionId
+        {
+            get { return Thread.VolatileRead(ref _transactionsCounter); }
+        }
+
+        internal ExitWriteLock PreventNewReadTransactions()
+        {
+            _txCommit.EnterWriteLock();
+            return new ExitWriteLock(_txCommit);
+        }
+
+        public struct ExitWriteLock : IDisposable
+        {
+            readonly ReaderWriterLockSlim _rwls;
+
+            public ExitWriteLock(ReaderWriterLockSlim rwls)
+            {
+                _rwls = rwls;
+            }
+
+            public void Dispose()
+            {
+                _rwls.ExitWriteLock();
+            }
+        }
+
         public long NextWriteTransactionId
         {
             get { return Thread.VolatileRead(ref _transactionsCounter) + 1; }
@@ -470,18 +497,13 @@ namespace Voron
         {
             if (_activeTransactions.Contains(tx) == false)
                 return;
-            
-            _txCommit.EnterWriteLock();
-            try
+
+            using (PreventNewReadTransactions())
             {
                 if (tx.Committed && tx.FlushedToJournal)
                     _transactionsCounter = tx.Id;
 
                 State = tx.State;
-            }
-            finally
-            {
-                _txCommit.ExitWriteLock();
             }
 
             if (tx.FlushedToJournal == false)
@@ -616,7 +638,7 @@ namespace Voron
 
                             try
                             {
-                                _journal.Applicator.ApplyLogsToDataFile(OldestTransaction, _cancellationTokenSource.Token);
+                                _journal.Applicator.ApplyLogsToDataFile(_cancellationTokenSource.Token);
                             }
                             catch (TimeoutException)
                             {
@@ -650,7 +672,7 @@ namespace Voron
                 _debugJournal.RecordFlushAction(DebugActionType.FlushStart, tx);
             }
 
-            _journal.Applicator.ApplyLogsToDataFile(OldestTransaction, _cancellationTokenSource.Token, tx, allowToFlushOverwrittenPages);
+            _journal.Applicator.ApplyLogsToDataFile(_cancellationTokenSource.Token, tx, allowToFlushOverwrittenPages);
 
             if (IsDebugRecording)
             {


### PR DESCRIPTION
…s started _while_ the flush is in progress.

This can cause the read transaction to read data that started after it opened, so we need to prevent that.
