### PR TITLE
RavenDB-5523:

### DIFF
--- a/Raven.Tests/Raven.Tests.csproj
+++ b/Raven.Tests/Raven.Tests.csproj
@@ -844,6 +844,7 @@
     <Compile Include="Storage\TasksStorageActionsTests.cs" />
     <Compile Include="Storage\Voron\DocumentsStorageActionsTests.cs" />
     <Compile Include="Subscriptions\SubscriptionInitialEtagGap.cs" />
+    <Compile Include="Subscriptions\SubscriptionOperationsSignaling.cs" />
     <Compile Include="Suggestions\LegacySuggestionsHandling.cs" />
     <Compile Include="Subscriptions\SubscriptionsBasic.cs" />
     <Compile Include="Subscriptions\SubscriptionsPaths.cs" />

--- a/Raven.Tests/Subscriptions/SubscriptionOperationsSignaling.cs
+++ b/Raven.Tests/Subscriptions/SubscriptionOperationsSignaling.cs
@@ -1,0 +1,318 @@
+﻿using System;
+using System.Collections.Concurrent;
+using System.Collections.Generic;
+using System.Linq;
+using System.Text;
+using System.Threading;
+using System.Threading.Tasks;
+using Raven.Abstractions.Data;
+using Raven.Abstractions.Exceptions.Subscriptions;
+using Raven.Client.Document;
+using Raven.Tests.Helpers;
+using Raven.Tests.Common.Dto;
+using Xunit;
+
+namespace Raven.Tests.Subscriptions
+{
+    public class SubscriptionOperationsSignaling:RavenTestBase
+    {
+        private TimeSpan reasonableWaitTime = TimeSpan.FromSeconds(20);
+
+        [Fact]
+        public void WaitOnSubscriptionTaskWhenSubscriptionIsOvertaken()
+        {
+            using (var store = NewDocumentStore())
+            {
+                var subscriptionId = store.Subscriptions.Create(new SubscriptionCriteria<User>());
+                var subscription = store.Subscriptions.Open<User>(subscriptionId, new SubscriptionConnectionOptions()
+                {
+                    ClientAliveNotificationInterval = TimeSpan.FromSeconds(1),
+                    BatchOptions = new SubscriptionBatchOptions
+                    {
+                        
+                    }
+                });
+                var users = new BlockingCollection<User>();
+
+                subscription.Subscribe(users.Add);
+
+                using (var session = store.OpenSession())
+                {
+                    session.Store(new User());
+                    session.SaveChanges();
+                }
+
+                User User;
+                Assert.True(users.TryTake(out User, reasonableWaitTime));
+
+                  var concurrentSubscription = store.Subscriptions.Open<User>(subscriptionId, new SubscriptionConnectionOptions()
+                {
+                      ClientAliveNotificationInterval = TimeSpan.FromSeconds(1),
+                      Strategy = SubscriptionOpeningStrategy.TakeOver
+                });
+
+                var thread = new Thread(() => {
+                    Thread.Sleep(300);
+                    concurrentSubscription.Subscribe(users.Add); });
+                thread.Start();
+                Assert.Throws(typeof(AggregateException), ()=>subscription.SubscriptionLifetimeTask.Wait(reasonableWaitTime));
+
+                Assert.True(subscription.SubscriptionLifetimeTask.IsFaulted);
+
+                Assert.Equal(typeof(SubscriptionInUseException), subscription.SubscriptionLifetimeTask.Exception.InnerException.GetType());
+            
+            }
+        }
+
+        [Fact]
+        public void SubscriptionInterruptionEventIsFiredWhenSubscriptionIsOvertaken()
+        {
+            using (var store = NewDocumentStore())
+            {
+                var subscriptionId = store.Subscriptions.Create(new SubscriptionCriteria<User>());
+                var subscription = store.Subscriptions.Open<User>(subscriptionId, new SubscriptionConnectionOptions()
+                {
+                    ClientAliveNotificationInterval = TimeSpan.FromSeconds(1),
+                    BatchOptions = new SubscriptionBatchOptions
+                    {
+
+                    }
+                });
+                var users = new BlockingCollection<User>();
+
+                var mre = new ManualResetEvent(false);
+                subscription.SubscriptionConnectionInterrupted += (exception, reconnect) =>
+                {
+                    if (exception is SubscriptionInUseException && reconnect == false)
+                        mre.Set();
+                };
+
+
+                subscription.Subscribe(users.Add);
+
+                using (var session = store.OpenSession())
+                {
+                    session.Store(new User());
+                    session.SaveChanges();
+                }
+
+                User User;
+                Assert.True(users.TryTake(out User, reasonableWaitTime));
+
+                var concurrentSubscription = store.Subscriptions.Open<User>(subscriptionId, new SubscriptionConnectionOptions()
+                {
+                    ClientAliveNotificationInterval = TimeSpan.FromSeconds(1),
+                    Strategy = SubscriptionOpeningStrategy.TakeOver
+                });
+
+                concurrentSubscription.Subscribe(users.Add);
+
+                Assert.True(mre.WaitOne(reasonableWaitTime));
+            }
+        }
+
+        [Fact]
+        public void WaitOnSubscriptionTaskWhenSubscriptionIsDeleted()
+        {
+            using (var store = NewDocumentStore())
+            {
+                var subscriptionId = store.Subscriptions.Create(new SubscriptionCriteria<User>());
+                var subscription = store.Subscriptions.Open<User>(subscriptionId, new SubscriptionConnectionOptions()
+                {
+                    ClientAliveNotificationInterval = TimeSpan.FromSeconds(1),
+                    BatchOptions = new SubscriptionBatchOptions
+                    {
+                        
+                    }
+                });
+
+                var beforeAckMre = new ManualResetEvent(false);
+                var users = new BlockingCollection<User>();
+                subscription.Subscribe(users.Add);
+
+                using (var session = store.OpenSession())
+                {
+                    session.Store(new User());
+                    session.SaveChanges();
+                }
+
+                User User;
+                Assert.True(users.TryTake(out User, reasonableWaitTime));
+
+
+                subscription.BeforeAcknowledgment += () => beforeAckMre.WaitOne();
+
+                store.Subscriptions.Delete(subscriptionId);
+                beforeAckMre.Set();
+
+                Assert.Throws(typeof(AggregateException), () => subscription.SubscriptionLifetimeTask.Wait(reasonableWaitTime));
+
+                Assert.True(subscription.SubscriptionLifetimeTask.IsFaulted);
+
+                Assert.Equal(typeof(SubscriptionDoesNotExistException), subscription.SubscriptionLifetimeTask.Exception.InnerException.GetType());
+            }
+        }
+
+        [Fact]
+        public void SubscriptionInterruptionEventIsFiredWhenSubscriptionIsDeleted()
+        {
+            using (var store = NewDocumentStore())
+            {
+                var subscriptionId = store.Subscriptions.Create(new SubscriptionCriteria<User>());
+                var subscription = store.Subscriptions.Open<User>(subscriptionId, new SubscriptionConnectionOptions()
+                {
+                    ClientAliveNotificationInterval = TimeSpan.FromSeconds(1),
+                    BatchOptions = new SubscriptionBatchOptions
+                    {
+                        
+                    }
+                });
+                var users = new BlockingCollection<User>();
+
+                var mre = new ManualResetEvent(false);
+                subscription.SubscriptionConnectionInterrupted += (exception, reconnect) =>
+                {
+                    if (exception is SubscriptionDoesNotExistException && reconnect == false)
+                        mre.Set();
+                };
+                subscription.Subscribe(users.Add);
+
+                using (var session = store.OpenSession())
+                {
+                    session.Store(new User());
+                    session.SaveChanges();
+                }
+
+                User User;
+                Assert.True(users.TryTake(out User, reasonableWaitTime));
+
+                var thread = new Thread(() =>
+                {
+                    Thread.Sleep(400);
+                    store.Subscriptions.Delete(subscriptionId);
+                });
+                thread.Start();
+                Assert.True(mre.WaitOne(reasonableWaitTime));
+            }
+        }
+
+        [Fact]
+        public void WaitOnSubscriptionTaskWhenSubscriptionCompleted()
+        {
+            using (var store = NewDocumentStore())
+            {
+                var subscriptionId = store.Subscriptions.Create(new SubscriptionCriteria<User>()
+                {
+                    
+                });
+                var subscription = store.Subscriptions.Open<User>(subscriptionId, new SubscriptionConnectionOptions()
+                {
+                    ClientAliveNotificationInterval = TimeSpan.FromSeconds(1),
+                    BatchOptions = new SubscriptionBatchOptions
+                    {
+                        
+                    }
+                });
+                var users = new BlockingCollection<User>();
+                subscription.Subscribe(users.Add);
+
+                using (var session = store.OpenSession())
+                {
+                    session.Store(new User());
+                    session.SaveChanges();
+                }
+
+                User User;
+                Assert.True(users.TryTake(out User, reasonableWaitTime));
+
+                subscription.Dispose();
+
+                Assert.DoesNotThrow(() => subscription.SubscriptionLifetimeTask.Wait(reasonableWaitTime));
+
+                Assert.True(subscription.SubscriptionLifetimeTask.IsCompleted);
+
+
+              
+
+            }
+        }
+
+        [Fact]
+        public void TrackSubscriptionResartDueToAckTimespan()
+        {
+            using (var store = NewDocumentStore())
+            {
+                var subscriptionId = store.Subscriptions.Create(new SubscriptionCriteria<User>()
+                {
+
+                });
+                var subscription = store.Subscriptions.Open<User>(subscriptionId, new SubscriptionConnectionOptions()
+                {
+                    ClientAliveNotificationInterval = TimeSpan.FromSeconds(1),
+                    BatchOptions = new SubscriptionBatchOptions
+                    {
+                        AcknowledgmentTimeout = TimeSpan.FromDays(-1)
+                    }
+                });
+                var users = new BlockingCollection<User>();
+                var mre = new ManualResetEvent(false);
+                subscription.SubscriptionConnectionInterrupted += (exception, reconnect) =>
+                {
+                    if (reconnect == true && exception is SubscriptionAckTimeoutException)
+                        mre.Set();
+
+                };
+                subscription.Subscribe(users.Add);
+
+                using (var session = store.OpenSession())
+                {
+                    session.Store(new User());
+                    session.SaveChanges();
+                }
+
+                User User;
+
+                Assert.True(users.TryTake(out User, reasonableWaitTime));
+                Assert.True(mre.WaitOne(reasonableWaitTime));
+            }
+        }
+
+        [Fact]
+        public void WaitOnSubscriptionStopDueToSubscriberError()
+        {
+            using (var store = NewDocumentStore())
+            {
+                var subscriptionId = store.Subscriptions.Create(new SubscriptionCriteria<User>());
+                var subscription = store.Subscriptions.Open<User>(subscriptionId, new SubscriptionConnectionOptions()
+                {
+                    ClientAliveNotificationInterval = TimeSpan.FromSeconds(1),
+                    BatchOptions = new SubscriptionBatchOptions
+                    {
+
+                    }
+                });
+                var exceptions = new BlockingCollection<Exception>();
+                subscription.Subscribe(_ =>
+                {
+                    throw new InvalidCastException();
+                }, exceptions.Add
+                );
+
+                using (var session = store.OpenSession())
+                {
+                    session.Store(new User());
+                    session.SaveChanges();
+                }
+
+                Exception exception;
+                Assert.True(exceptions.TryTake(out exception, reasonableWaitTime));
+                
+                Assert.Throws(typeof(AggregateException), () => subscription.SubscriptionLifetimeTask.Wait(reasonableWaitTime));
+
+                Assert.True(subscription.SubscriptionLifetimeTask.IsFaulted);
+
+                Assert.Equal(typeof(InvalidCastException), subscription.SubscriptionLifetimeTask.Exception.InnerException.GetType());
+            }
+        }
+    }
+}

--- a/Raven.Tests/Subscriptions/SubscriptionsBasic.cs
+++ b/Raven.Tests/Subscriptions/SubscriptionsBasic.cs
@@ -1316,8 +1316,10 @@ namespace Raven.Tests.Subscriptions
                 store.Changes().WaitForAllPendingSubscriptions();
                 var mre = new ManualResetEvent(false);
                 var docs = new BlockingCollection<RavenJObject>();
-                subscriptionZeroTimeout.AckTimedOut += () =>
+                subscriptionZeroTimeout.SubscriptionConnectionInterrupted += (ex,willReconnect) =>
                 {
+                    Assert.True(ex is SubscriptionAckTimeoutException);
+                    Assert.True(willReconnect);
                     mre.Set();
                 };
                 subscriptionZeroTimeout.Subscribe(docs.Add);

--- a/Raven.Tryouts/Program.cs
+++ b/Raven.Tryouts/Program.cs
@@ -2,6 +2,7 @@ using System;
 using System.Diagnostics;
 using Raven.Tests.Raft.Client;
 using Raven.Tests.Smuggler;
+using Raven.Tests.Subscriptions;
 #if !DNXCORE50
 using Raven.Tests.Sorting;
 using Raven.SlowTests.RavenThreadPool;
@@ -27,9 +28,24 @@ namespace Raven.Tryouts
                 //{
                 //    x.Frequent_updates_of_document_should_not_cause_deadlock_in_prefetcher();
                 //}
-                using (var x = new SmugglerExecutionTests())
+                using (var x = new SubscriptionsBasic())
                 {
-                    x.CanExportImportIncrementalSmugglerMaxSplitExportFileSize().Wait();
+                    try
+                    {
+                        x.ShouldNotOverrideSubscriptionAckEtag("voron");
+                    }
+                    catch (Exception ex)
+                    {
+                        Console.WriteLine(ex);
+                    }
+                    try
+                    {
+                        x.ShouldNotOverrideSubscriptionAckEtag("esent");
+                    }
+                    catch (Exception ex)
+                    {
+                        Console.WriteLine(ex);
+                    }
                 }                
             }
 


### PR DESCRIPTION
Undo subscription ack timeout logic that was raising subscribers OnError exceptions.
Add AclTimedOut event

* disregard the ShouldStopPullingDocsAndCloseSubscriptionOnSubscriberErrorByDefault test, it's being fixed in Tal's PR