### PR TITLE
RavenDB-5244 V4.0 new client : Remove temp DatabaseCommands

### DIFF
--- a/src/Raven.Client/Documents/Async/AsyncDocumentSession.cs
+++ b/src/Raven.Client/Documents/Async/AsyncDocumentSession.cs
@@ -5,32 +5,18 @@
 //-----------------------------------------------------------------------
 using System;
 using System.Collections.Generic;
-using System.Linq;
 using System.Linq.Expressions;
 using System.Threading;
 using System.Threading.Tasks;
-using Raven.Abstractions.Data;
 using Raven.Abstractions.Extensions;
-using Raven.Abstractions.Util;
 using Raven.Client.Connection;
 using Raven.Client.Connection.Async;
-using Raven.Client.Document.SessionOperations;
-using Raven.Client.Linq;
 using Raven.Client.Indexes;
-using Raven.Json.Linq;
-using Raven.Client.Document.Batches;
-using System.Diagnostics;
-using System.Dynamic;
-using Raven.Abstractions.Commands;
 using Raven.Client.Data;
-using Raven.Client.Data.Queries;
 using Raven.Client.Document;
 using Raven.Client.Documents.Commands;
 using Raven.Client.Documents.SessionOperations;
 using Raven.Client.Http;
-using Sparrow.Json;
-using LoadOperation = Raven.Client.Documents.SessionOperations.LoadOperation;
-using Sparrow.Json.Parsing;
 
 namespace Raven.Client.Documents.Async
 {
@@ -65,11 +51,7 @@ namespace Raven.Client.Documents.Async
 
         public string GetDocumentUrl(object entity)
         {
-            DocumentInfo value;
-            if (DocumentsByEntity.TryGetValue(entity, out value) == false)
-                throw new InvalidOperationException("Could not figure out identifier for transient instance");
-
-            return AsyncDatabaseCommands.UrlFor(value.Id);
+            throw new NotImplementedException();
         }
 
         public async Task RefreshAsync<T>(T entity, CancellationToken token = default(CancellationToken))
@@ -79,10 +61,18 @@ namespace Raven.Client.Documents.Async
                 throw new InvalidOperationException("Cannot refresh a transient instance");
             IncrementRequestCount();
 
-            //TODO - Efrat - Change when we have new DatabaseCommands.Get
-            var document = await TempAsyncDatabaseCommandGet(documentInfo);
+            var command = new GetDocumentCommand
+            {
+                Ids = new[] { documentInfo.Id }
+            };
+            await RequestExecuter.ExecuteAsync(command, Context, token);
 
-            RefreshInternal(entity, document, documentInfo);
+            RefreshInternal(entity, command, documentInfo);
+        }
+
+        public IDictionary<string, string> GetMetadataForAsync<T>(T instance)
+        {
+            return GetMetadataFor(instance);
         }
 
         public Task<Operation> DeleteByIndexAsync<T, TIndexCreator>(Expression<Func<T, bool>> expression) where TIndexCreator : AbstractIndexCreationTask, new()
@@ -104,14 +94,6 @@ namespace Raven.Client.Documents.Async
         /// </remarks>
         public IAsyncAdvancedSessionOperations Advanced => this;
 
-        /// <summary>
-        /// Get the json document by key from the store
-        /// </summary>
-        protected override DocumentInfo GetDocumentInfo(string documentId)
-        {
-            throw new NotSupportedException("Cannot get a document in a synchronous manner using async document session");
-        }
-
         protected override string GenerateKey(object entity)
         {
             throw new NotSupportedException("Async session cannot generate keys synchronously");
@@ -125,69 +107,6 @@ namespace Raven.Client.Documents.Async
         protected override Task<string> GenerateKeyAsync(object entity)
         {
             return Conventions.GenerateDocumentKeyAsync(DatabaseName, AsyncDatabaseCommands, entity);
-        }
-
-        public async Task<IDictionary<string, string>> GetMetadataForAsync<T>(T instance)
-        {
-            var documentInfo = await GetDocumentInfo(instance).ConfigureAwait(false);
-
-            if (documentInfo.MetadataInstance != null)
-                return documentInfo.MetadataInstance;
-
-            var metadataAsBlittable = documentInfo.Metadata;
-            var metadata = new MetadataAsDictionary(metadataAsBlittable);
-            documentInfo.MetadataInstance = metadata;
-            return metadata;
-        }
-
-        private async Task<DocumentInfo> GetDocumentInfo<T>(T instance)
-        {
-            DocumentInfo value;
-            string id;
-
-            if (DocumentsByEntity.TryGetValue(instance, out value)) return value;
-
-            if (!GenerateEntityIdOnTheClient.TryGetIdFromInstance(instance, out id) &&
-                (!(instance is IDynamicMetaObjectProvider) ||
-                 !GenerateEntityIdOnTheClient.TryGetIdFromDynamic(instance, out id)))
-                throw new InvalidOperationException("Could not find the document key for " + instance);
-
-            AssertNoNonUniqueInstance(instance, id);
-
-            var documentInfo = new DocumentInfo
-            {
-                Id = id,
-                Entity = instance
-            };
-
-            //TODO - Efrat - Change when we have new DatabaseCommands.Get
-            await TempAsyncDatabaseCommandGet(documentInfo);
-
-            return documentInfo;
-        }
-
-        private async Task<BlittableJsonReaderObject> TempAsyncDatabaseCommandGet(DocumentInfo documentInfo, CancellationToken token = default(CancellationToken))
-        {
-            var command = new GetDocumentCommand
-            {
-                Ids = new[] { documentInfo.Id }
-            };
-            await RequestExecuter.ExecuteAsync(command, Context, token);
-            var document = (BlittableJsonReaderObject)command.Result.Results[0];
-            if (document == null)
-                throw new InvalidOperationException("Document '" + documentInfo.Id +
-                                                    "' no longer exists and was probably deleted");
-
-            object metadata;
-            document.TryGetMember(Constants.Metadata.Key, out metadata);
-            documentInfo.Metadata = metadata as BlittableJsonReaderObject;
-
-            object etag;
-            document.TryGetMember(Constants.Metadata.Etag, out etag);
-            documentInfo.ETag = etag as long?;
-
-            documentInfo.Document = document;
-            return document;
         }
 
         public IAsyncEagerSessionOperations Eagerly { get; }

--- a/src/Raven.Client/Documents/DocumentSession/DocumentSession.cs
+++ b/src/Raven.Client/Documents/DocumentSession/DocumentSession.cs
@@ -6,20 +6,14 @@
 
 using Raven.Client.Connection;
 using System;
-using System.Collections.Generic;
-using System.Linq;
 using System.Linq.Expressions;
 using System.Threading.Tasks;
-using Raven.Abstractions.Data;
 using Raven.Client.Data;
-using Raven.Client.Data.Queries;
 using Raven.Client.Document;
 using Raven.Client.Documents.Commands;
 using Raven.Client.Documents.SessionOperations;
 using Raven.Client.Http;
 using Raven.Client.Indexes;
-using Raven.Json.Linq;
-using Sparrow.Json;
 
 namespace Raven.Client.Documents
 {
@@ -108,34 +102,13 @@ namespace Raven.Client.Documents
                 throw new InvalidOperationException("Cannot refresh a transient instance");
             IncrementRequestCount();
 
-            //TODO - Change when we have new DatabaseCommands.Get
-            var document = TempDatabaseCommandGet(documentInfo);
-
-            RefreshInternal(entity, document, documentInfo);
-        }
-        
-        private BlittableJsonReaderObject TempDatabaseCommandGet(DocumentInfo documentInfo)
-        {
             var command = new GetDocumentCommand
             {
-                Ids = new[] {documentInfo.Id}
+                Ids = new[] { documentInfo.Id }
             };
             RequestExecuter.Execute(command, Context);
-            var document = (BlittableJsonReaderObject) command.Result.Results[0];
-            if (document == null)
-                throw new InvalidOperationException("Document '" + documentInfo.Id +
-                                                    "' no longer exists and was probably deleted");
 
-            object value;
-            document.TryGetMember(Constants.Metadata.Key, out value);
-            documentInfo.Metadata = value as BlittableJsonReaderObject;
-
-            object etag;
-            document.TryGetMember(Constants.Metadata.Etag, out etag);
-            documentInfo.ETag = etag as long?;
-
-            documentInfo.Document = document;
-            return document;
+            RefreshInternal(entity, command, documentInfo);
         }
 
         /// <summary>
@@ -151,20 +124,6 @@ namespace Raven.Client.Documents
         public FacetedQueryResult[] MultiFacetedSearch(params FacetQuery[] queries)
         {
             throw new NotImplementedException();
-        }
-
-        /// <summary>
-        /// Gets the document info for the specified document id.
-        /// </summary>
-        /// <param name="documentId">Document Id</param>
-        /// <returns></returns>
-        protected override DocumentInfo GetDocumentInfo(string documentId)
-        {
-            var documentInfo = new DocumentInfo {Id = documentId};
-            DocumentsById.Add(documentId, documentInfo);
-            //TODO - Change when we have new DatabaseCommands.Get
-            TempDatabaseCommandGet(documentInfo);
-            return documentInfo;
         }
 
         /// <summary>

--- a/src/Raven.Client/Documents/IAsyncAdvancedSessionOperations.cs
+++ b/src/Raven.Client/Documents/IAsyncAdvancedSessionOperations.cs
@@ -10,17 +10,14 @@ using System.Linq;
 using System.Linq.Expressions;
 using System.Threading;
 using System.Threading.Tasks;
-
 using Raven.Abstractions.Data;
 using Raven.Abstractions.Extensions;
 using Raven.Abstractions.Util;
 using Raven.Client.Connection;
 using Raven.Client.Data;
 using Raven.Client.Data.Queries;
-using Raven.Client.Document.Batches;
 using Raven.Client.Indexes;
 using Raven.Json.Linq;
-using Sparrow.Json;
 
 namespace Raven.Client.Documents
 {
@@ -244,11 +241,9 @@ namespace Raven.Client.Documents
 
         /// <summary>
         ///     Gets the metadata for the specified entity.
-        ///     If the entity is transient, it will load the metadata from the store
-        ///     and associate the current state of the entity with the metadata from the server.
         /// </summary>
         /// <param name="instance">The instance.</param>
-        Task<IDictionary<string, string>> GetMetadataForAsync<T>(T instance);
+        IDictionary<string, string> GetMetadataForAsync<T>(T instance);
 
         /// <summary>
         ///     DeleteByIndexAsync using linq expression

--- a/src/Raven.Client/Documents/InMemoryDocumentSessionOperations.cs
+++ b/src/Raven.Client/Documents/InMemoryDocumentSessionOperations.cs
@@ -8,7 +8,6 @@ using System;
 using System.Collections.Generic;
 using System.Diagnostics;
 using System.Dynamic;
-using System.IO;
 using System.Linq;
 using System.Reflection;
 using Raven.Client.Document.Batches;
@@ -18,15 +17,13 @@ using Raven.Abstractions.Extensions;
 using Raven.Abstractions.Util;
 using Raven.Abstractions.Data;
 using Raven.Abstractions.Logging;
-using Raven.Client.Data;
 using Raven.Client.Document;
+using Raven.Client.Documents.Commands;
 using Raven.Client.Documents.Options;
 using Raven.Client.Exceptions;
 using Raven.Client.Http;
 using Raven.Client.Util;
-using Raven.Imports.Newtonsoft.Json.Linq;
 using Raven.Imports.Newtonsoft.Json.Utilities;
-using Raven.Json.Linq;
 using Sparrow.Json;
 using Sparrow.Json.Parsing;
 
@@ -213,25 +210,18 @@ namespace Raven.Client.Documents
 
         private DocumentInfo GetDocumentInfo<T>(T instance)
         {
-            DocumentInfo value;
+            DocumentInfo documentInfo;
             string id;
 
-            if (DocumentsByEntity.TryGetValue(instance, out value)) return value;
+            if (DocumentsByEntity.TryGetValue(instance, out documentInfo)) return documentInfo;
 
             if (!GenerateEntityIdOnTheClient.TryGetIdFromInstance(instance, out id) &&
                 (!(instance is IDynamicMetaObjectProvider) ||
                  !GenerateEntityIdOnTheClient.TryGetIdFromDynamic(instance, out id)))
-                throw new InvalidOperationException("Could not find the document key for " + instance);
+                 throw new InvalidOperationException("Could not find the document key for " + instance);
 
-            AssertNoNonUniqueInstance(instance, id);
-
-            return GetDocumentInfo(id);
+            throw new ArgumentException("Document " + id + " doesn't exist in the session");
         }
-
-        /// <summary>
-        /// Get the documentInfo by key (Load document from server)
-        /// </summary>
-        protected abstract DocumentInfo GetDocumentInfo(string documentId);
 
         /// <summary>
         /// Returns whatever a document with the specified id is loaded in the 
@@ -1179,8 +1169,23 @@ more responsive application.
             return true;
         }
 
-        protected void RefreshInternal<T>(T entity, BlittableJsonReaderObject document, DocumentInfo documentInfo)
+        protected void RefreshInternal<T>(T entity, RavenCommand<GetDocumentResult> cmd, DocumentInfo documentInfo)
         {
+            var document = (BlittableJsonReaderObject)cmd.Result.Results[0];
+            if (document == null)
+                throw new InvalidOperationException("Document '" + documentInfo.Id +
+                                                    "' no longer exists and was probably deleted");
+
+            object value;
+            document.TryGetMember(Constants.Metadata.Key, out value);
+            documentInfo.Metadata = value as BlittableJsonReaderObject;
+
+            object etag;
+            document.TryGetMember(Constants.Metadata.Etag, out etag);
+            documentInfo.ETag = etag as long?;
+
+            documentInfo.Document = document;
+
             documentInfo.Entity = ConvertToEntity(typeof(T), documentInfo.Id, document);
 
             var type = entity.GetType();


### PR DESCRIPTION
Also:
* GetDocumentInfo works only for document already in the session
* GetMetadataForAsync and GetMetadataFor are the same
* Removed unnecessary  using