### PR TITLE
RavenDB-5552 implementation

### DIFF
--- a/src/Raven.Server/Documents/ConfigurationStorage.cs
+++ b/src/Raven.Server/Documents/ConfigurationStorage.cs
@@ -1,5 +1,7 @@
 ﻿using System;
 using System.IO;
+using Raven.Server.Documents.Indexes;
+using Raven.Server.Documents.Transformers;
 using Raven.Server.ServerWide;
 using Raven.Server.ServerWide.Context;
 using Voron;
@@ -30,11 +32,11 @@ namespace Raven.Server.Documents
             IndexesEtagsStorage = new IndexesEtagsStorage(db.Name);
         }
 
-        public void Initialize()
+        public void Initialize(IndexStore indexStore, TransformerStore transformerStore)
         {
             _contextPool = new TransactionContextPool(Environment);
             AlertsStorage.Initialize(Environment, _contextPool);
-            IndexesEtagsStorage.Initialize(Environment, _contextPool);
+            IndexesEtagsStorage.Initialize(Environment, _contextPool,indexStore, transformerStore);
         }
 
         public void Dispose()

--- a/src/Raven.Server/Documents/DocumentDatabase.cs
+++ b/src/Raven.Server/Documents/DocumentDatabase.cs
@@ -185,7 +185,7 @@ namespace Raven.Server.Documents
             }
 
             SubscriptionStorage.Initialize();
-            ConfigurationStorage.Initialize();
+            ConfigurationStorage.Initialize(IndexStore,TransformerStore);
         }
 
         public void Dispose()


### PR DESCRIPTION
scan for manually removed indexes and transformers when database is offline and if there were such indexes/transformers, remove metadata