### PR TITLE
RavenDB-5603

### DIFF
--- a/Raven.Database/Impl/BackgroundTaskExecuter/RavenThreadPool.cs
+++ b/Raven.Database/Impl/BackgroundTaskExecuter/RavenThreadPool.cs
@@ -300,9 +300,14 @@ namespace Raven.Database.Impl.BackgroundTaskExecuter
             try
             {
                 threadTask.Duration = Stopwatch.StartNew();
-
+              
                 try
                 {
+                    if (threadTask.Database.Disposed)
+                    {
+                        logger.Warn("Ignoring request to run threadTask because the database is been disposed.");
+                        return;
+                    }
                     _runningTasks.TryAdd(threadTask, null);
                     threadTask.Action();
                 }
@@ -503,6 +508,11 @@ namespace Raven.Database.Impl.BackgroundTaskExecuter
                 try
                 {
                     _runningTasks.TryAdd(threadTask, null);
+                    if (database.Disposed)
+                    {
+                        logger.Warn("Ignoring request to run a single batch because the database is been disposed.");
+                        return;
+                    }
                     threadTask.Action();
                     threadTask.BatchStats.Completed++;
                 }
@@ -655,6 +665,11 @@ namespace Raven.Database.Impl.BackgroundTaskExecuter
             try
             {
                 _runningTasks.TryAdd(threadTask, null);
+                if (database.Disposed)
+                {
+                    logger.Warn("Ignoring request to run a single batch because the database is been disposed.");
+                    return;
+                }
                 threadTask.Action();
                 threadTask.BatchStats.Completed++;
             }

--- a/Raven.Database/Impl/BackgroundTaskExecuter/RavenThreadPool.cs
+++ b/Raven.Database/Impl/BackgroundTaskExecuter/RavenThreadPool.cs
@@ -305,7 +305,7 @@ namespace Raven.Database.Impl.BackgroundTaskExecuter
                 {
                     if (threadTask.Database.Disposed)
                     {
-                        logger.Warn("Ignoring request to run threadTask because the database is been disposed.");
+                        logger.Warn($"Ignoring request to run threadTask because the database ({threadTask.Database.Name}) is been disposed.");
                         return;
                     }
                     _runningTasks.TryAdd(threadTask, null);
@@ -510,7 +510,7 @@ namespace Raven.Database.Impl.BackgroundTaskExecuter
                     _runningTasks.TryAdd(threadTask, null);
                     if (database.Disposed)
                     {
-                        logger.Warn("Ignoring request to run a single batch because the database is been disposed.");
+                        logger.Warn($"Ignoring request to run a single batch because the database ({database.Name}) is been disposed.");
                         return;
                     }
                     threadTask.Action();
@@ -667,7 +667,7 @@ namespace Raven.Database.Impl.BackgroundTaskExecuter
                 _runningTasks.TryAdd(threadTask, null);
                 if (database.Disposed)
                 {
-                    logger.Warn("Ignoring request to run a single batch because the database is been disposed.");
+                    logger.Warn($"Ignoring request to run a single batch because the database ({database.Name}) is been disposed.");
                     return;
                 }
                 threadTask.Action();

--- a/Raven.Database/Indexing/IndexingExecuter.cs
+++ b/Raven.Database/Indexing/IndexingExecuter.cs
@@ -883,6 +883,9 @@ namespace Raven.Database.Indexing
                     }
 
                     var keepTrying = true;
+                    //Here we make sure that the database isn't been disposed so we won't advance the indexing etags on 
+                    //aborted batches (see RavenDB-5603 related changes)
+                    if (context.Database.Disposed == false)
                     for (var i = 0; i < 10 && keepTrying; i++)
                     {
                         keepTrying = false;

--- a/Raven.Database/Storage/IndexDefinitionStorage.cs
+++ b/Raven.Database/Storage/IndexDefinitionStorage.cs
@@ -436,8 +436,9 @@ namespace Raven.Database.Storage
         public AbstractViewGenerator GetViewGenerator(string name)
         {
             int id = 0;
-            if (indexNameToId.TryGetValue(name, out id))
-                return indexCache[id];
+            AbstractViewGenerator viewGenerator;
+            if (indexNameToId.TryGetValue(name, out id) && indexCache.TryGetValue(id, out viewGenerator))
+                return viewGenerator;
             return null;
         }
 
@@ -641,7 +642,11 @@ namespace Raven.Database.Storage
         {
             int id = 0;
             if (transformNameToId.TryGetValue(name, out id))
-                return transformCache[id];
+            {
+                AbstractTransformer value;
+                if (transformCache.TryGetValue(id, out value))
+                    return value;
+            }
             return null;
         }
 


### PR DESCRIPTION
* Will check for Database disposed flag before executing batches
* Will not advance the etags of index batches if database is been disposed because we don't throw now and the code used to assume we would
* Index/Transformer caches were been used in an unsafe manner causing key not found exceptions.