### PR TITLE
fix for RavenDB-5617

### DIFF
--- a/Raven.Database/Indexing/Index.cs
+++ b/Raven.Database/Indexing/Index.cs
@@ -721,7 +721,10 @@ namespace Raven.Database.Indexing
             {
                 var old = indexindDone;
                 Interlocked.Exchange(ref indexindDone, new TaskCompletionSource<object>());
-                Task.Factory.StartNew(() => old.TrySetResult(null));
+                Task.Factory.StartNew(() =>
+                {
+                    old.TrySetResult(null);
+                });
             }
 
             if (writePerformanceStats != null)

--- a/Raven.Tests.Issues/Raven.Tests.Issues.csproj
+++ b/Raven.Tests.Issues/Raven.Tests.Issues.csproj
@@ -575,6 +575,7 @@
     <Compile Include="RavenDB_554.cs" />
     <Compile Include="RavenDB_556.cs" />
     <Compile Include="RavenDB_4453.cs" />
+    <Compile Include="RavenDB_5617.cs" />
     <Compile Include="RavenDB_576.cs" />
     <Compile Include="RavenDB_578.cs" />
     <Compile Include="RavenDB_579.cs" />

--- a/Raven.Tests.Issues/RavenDB_5617.cs
+++ b/Raven.Tests.Issues/RavenDB_5617.cs
@@ -1,0 +1,36 @@
+﻿using System;
+using System.Linq;
+using Raven.Tests.Helpers;
+using Xunit;
+
+namespace Raven.Tests.Issues
+{
+    public class RavenDB_5617 : RavenTestBase
+    {
+        [Fact]
+        public void CanAutomaticallyWaitForIndexes_ForSpecificIndex()
+        {
+            using (var store = NewDocumentStore())
+            {
+                var userByReverseName = new RavenDB_4903.UserByReverseName();
+                userByReverseName.Execute(store);
+                using (var s = store.OpenSession())
+                {
+                    s.Advanced.WaitForIndexesAfterSaveChanges(
+                        timeout: TimeSpan.FromSeconds(30),
+                        indexes: new[] { userByReverseName.IndexName },
+                        throwOnTimeout: true);
+
+                    s.Store(new RavenDB_4903.User { Name = "Oren" });
+
+                    s.SaveChanges();
+                }
+
+                using (var s = store.OpenSession())
+                {
+                    Assert.NotEmpty(s.Query<RavenDB_4903.User, RavenDB_4903.UserByReverseName>().Where(x => x.Name == "nerO").ToList());
+                }
+            }
+        }
+    }
+}

--- a/Raven.Tryouts/Program.cs
+++ b/Raven.Tryouts/Program.cs
@@ -23,12 +23,12 @@ namespace Raven.Tryouts
     {
         public static void Main(string[] args)
         {
-            for (int i = 0; i < 100; i++)
+            for (int i = 0; i < 2000; i++)
             {
                 Console.WriteLine(i);
-                using (var x = new RavenDB_3612())
+                using (var x = new RavenDB_5617())
                 {
-                    x.BeforeAcknowledgment_Can_Prevent_Batch_Acknowledgment();
+                    x.CanAutomaticallyWaitForIndexes_ForSpecificIndex();
                 }
             }
         }

--- a/Raven.Tryouts/Raven.Tryouts.csproj
+++ b/Raven.Tryouts/Raven.Tryouts.csproj
@@ -167,7 +167,6 @@
       <SubType>Designer</SubType>
       <CopyToOutputDirectory>Always</CopyToOutputDirectory>
     </None>
-    <Content Include="Raven.Tryouts.project.json" />
     <None Include="packages.config" />
   </ItemGroup>
   <ItemGroup>


### PR DESCRIPTION
fix race condition in WaitForIndexesAsync() between waiting TaskCompletionSource CompareExchange in the index and waiting for completion in WaitForIndexesAsync()