### PR TITLE
RavenDB-5698

### DIFF
--- a/Rachis/Rachis/RaftEngine.cs
+++ b/Rachis/Rachis/RaftEngine.cs
@@ -382,6 +382,9 @@ namespace Rachis
 
         public Task UpdateNodeAsync(NodeConnectionInfo node)
         {
+            if (State == RaftEngineState.Leader && node.IsNoneVoter)
+                throw new InvalidOperationException("Can't change leader voting mode to none voter");
+
             var currentTopology = CurrentTopology;
 
             var allVotingNodes = currentTopology.AllVotingNodes.Select(n => n.Uri.AbsoluteUri == node.Uri.AbsoluteUri ? node : n).ToList();

--- a/Rachis/Rachis/RaftEngineStatistics.cs
+++ b/Rachis/Rachis/RaftEngineStatistics.cs
@@ -3,6 +3,7 @@ using System.Collections.Concurrent;
 using System.Collections.Generic;
 using System.Linq;
 using Rachis.Messages;
+using Rachis.Storage;
 using Rachis.Transport;
 using Raven.Abstractions.Extensions;
 using Raven.Abstractions.Util;
@@ -29,6 +30,7 @@ namespace Rachis
             Messages = new ConcurrentQueue<MessageWithTimingInformation>();
             Elections = new ConcurrentQueue<ElectionInformation>();
             CommitTimes = new ConcurrentQueue<CommitInformation>();
+            CurrenTopology = engine.CurrentTopology;
         }
         private ConcurrentDictionary<long, DateTime> IndexesToAppendTimes = new ConcurrentDictionary<long, DateTime>(); 
         public ConcurrentQueue<TimeoutInformation> TimeOuts { get; }
@@ -37,6 +39,9 @@ namespace Rachis
         public ConcurrentQueue<MessageWithTimingInformation> Messages { get; }
         public ElectionInformation LastElectionInformation => Elections.LastOrDefault();
         public ConcurrentQueue<CommitInformation> CommitTimes { get; } 
+
+        public Topology CurrenTopology { get; private set; }
+
         public string Name { get; set; }
 
         public int MaxLogLengthBeforeCompaction { get; set; }

--- a/Raven.Studio.Html5/App/viewmodels/manage/cluster.ts
+++ b/Raven.Studio.Html5/App/viewmodels/manage/cluster.ts
@@ -199,7 +199,7 @@ class cluster extends viewModelBase {
                 new updateRaftClusterCommand(appUrl.getSystemDatabase(), nci.toDto())
                     .execute()
                     .done(() => setTimeout(() => this.refresh(), 500));
-            });
+            }).always(()=>this.refresh());
 
         app.showDialog(dialog);
     }

--- a/Raven.Studio.Html5/App/views/manage/editNodeConnectionInfoDialog.html
+++ b/Raven.Studio.Html5/App/views/manage/editNodeConnectionInfoDialog.html
@@ -66,8 +66,9 @@
             <div class="form-group">
                 <div class="col-sm-7 col-sm-offset-4">
                     <div class="checkbox">
-                        <input type="checkbox" id="votingNode" class="form-control" data-bind="checked: isVoting" />
+                        <input type="checkbox" id="votingNode" class="form-control" data-bind="checked: isVoting" />                        
                         <label for="votingNode">Voting node</label>
+                        <h3 class="text-danger" data-bind="visible: !isVoting()">Careful removing voting mode from a node may lead to losing the cluster quorum.</h3>
                     </div>
                 </div>
             </div>


### PR DESCRIPTION
* Now preventing removing voting mode from update node connection
* Added Node topology to the cluster statistics
* admin/cluster/changeVotingMode will now redirect to leader node (this logic behaves differently than other ClusterManager.Client method because of edge cases in the HotSpare code )
* Now always refreshing the clustering view after editing a node
* Added danger text for when the user tries to remove voting mode from a node