### PR TITLE
RavenDB-5727

### DIFF
--- a/src/Raven.Server/Documents/Queries/Parse/LuceneAST.cs
+++ b/src/Raven.Server/Documents/Queries/Parse/LuceneAST.cs
@@ -4,6 +4,7 @@ using System.Diagnostics;
 using System.Globalization;
 using System.IO;
 using System.Linq;
+using System.Runtime.CompilerServices;
 using System.Text;
 using Lucene.Net.Analysis;
 using Lucene.Net.Analysis.Tokenattributes;
@@ -664,13 +665,15 @@ This edge-case has a very slim chance of happening, but still we should not igno
             var query = new BooleanQuery();
             //Here the Occur.MUST is ignored we will use the default occur in children nodes
             Node.AddQueryToBooleanQuery(query, configuration, Occur.MUST, true);
-            query.Boost = Boost == null ? 1 : float.Parse(Boost);
+            query.Boost = GetBoost();
             return query;
         }
 
         public override Query ToGroupFieldQuery(LuceneASTQueryConfiguration configuration)
         {
-            return Node.ToQuery(configuration);
+            var query = Node.ToQuery(configuration);
+            query.Boost = GetBoost();
+            return query;
         }
         public LuceneASTNodeBase Node { get; set; }
         public string Boost { get; set; }
@@ -680,7 +683,13 @@ This edge-case has a very slim chance of happening, but still we should not igno
             sb.Append('(').Append(Node).Append(')').Append(string.IsNullOrEmpty(Boost)?string.Empty:string.Format("^{0}",Boost));
             return sb.ToString();
         }
-    }
+
+        [MethodImpl(MethodImplOptions.AggressiveInlining)]
+        public float GetBoost()
+        {
+            return  Boost == null ? 1 : float.Parse(Boost);
+        }
+}
     public class PostfixModifiers
     {
         public string Boost { get; set; }

--- a/test/FastTests/Client/Queries/FullTextSearch.cs
+++ b/test/FastTests/Client/Queries/FullTextSearch.cs
@@ -1,0 +1,519 @@
+﻿using System.Collections.Generic;
+using System.Linq;
+using Raven.Abstractions.Indexing;
+using Raven.Client;
+using Raven.Client.Indexing;
+using Xunit;
+
+namespace FastTests.Client.Queries
+{
+    public class FullTextSearchOnTags : RavenTestBase
+    {
+        public class Image
+        {
+            public string Id { get; set; }
+            public string Name { get; set; }
+            public ICollection<string> Users { get; set; }
+            public ICollection<string> Tags { get; set; }
+        }
+
+        [Fact]
+        public void CanSearchUsingPhrase()
+        {
+            using (var store = GetDocumentStore())
+            {
+                using (var session = store.OpenSession())
+                {
+                    session.Store(new Image
+                    {
+                        Tags = new[] { "cats", "animal", "feline" }
+                    });
+                    session.SaveChanges();
+                }
+
+                store.DatabaseCommands.PutIndex("test", new IndexDefinition
+                {
+                    Maps = { "from doc in docs.Images select new { doc.Tags }"},
+                });
+
+                using (var session = store.OpenSession())
+                {
+                    var images = session.Query<Image>("test")
+                        .Customize(x => x.WaitForNonStaleResults())
+                        .Search(x => x.Tags, "i love cats")
+                        .ToList();
+                    Assert.NotEmpty(images);
+                }
+            }
+        }
+
+        [Fact]
+        public void CanSearchUsingPhraseAndOrderBy()
+        {
+            using (var store = GetDocumentStore())
+            {
+                using (var session = store.OpenSession())
+                {
+                    session.Store(new Image
+                    {
+                        Name = "B",
+                        Tags = new[] { "cats", "animal", "feline" }
+                    });
+                    session.Store(new Image
+                    {
+                        Name = "A",
+                        Tags = new[] { "cats", "animal", "feline" }
+                    });
+                    session.SaveChanges();
+                }
+
+                store.DatabaseCommands.PutIndex("test", new IndexDefinition
+                {
+                    Maps = { "from doc in docs.Images select new { doc.Tags,doc.Name }"},
+                });
+
+                using (var session = store.OpenSession())
+                {
+                    var images = session.Query<Image>("test")
+                        .Customize(x => x.WaitForNonStaleResults())
+                        .OrderBy(x => x.Name)
+                        .Search(x => x.Tags, "i love cats")
+                        .ToList();
+                    Assert.NotEmpty(images);
+
+                    Assert.Equal("images/2", images[0].Id);
+                    Assert.Equal("images/1", images[1].Id);
+                }
+            }
+        }
+
+        [Fact]
+        public void CanSearchUsingPhrase_MultipleSearches()
+        {
+            using (var store = GetDocumentStore())
+            {
+                using (var session = store.OpenSession())
+                {
+                    session.Store(new Image
+                    {
+                        Tags = new[] { "cats", "animal", "feline" }
+                    });
+
+                    session.Store(new Image
+                    {
+                        Tags = new[] { "dogs", "animal", "canine" }
+                    });
+                    session.SaveChanges();
+                }
+
+                store.DatabaseCommands.PutIndex("test", new IndexDefinition
+                {
+                    Maps = { "from doc in docs.Images select new { doc.Tags }"},
+                });
+
+                using (var session = store.OpenSession())
+                {
+                    var images = session.Query<Image>("test")
+                        .Customize(x => x.WaitForNonStaleResults())
+                        .Search(x => x.Tags, "i love cats")
+                        .Search(x => x.Tags, "canine love")
+                        .ToList();
+                    Assert.Equal(2, images.Count);
+                }
+            }
+        }
+
+        [Fact]
+        public void StandardSearchWillProduceExpectedResult()
+        {
+            using (var store = GetDocumentStore())
+            {
+                using (var session = store.OpenSession())
+                {
+                    var ravenQueryable = session.Query<Image>("test")
+                        .Customize(x => x.WaitForNonStaleResults())
+                        .Search(x => x.Tags, "i love cats")
+                        .Where(x => x.Name == "User");
+
+
+                    Assert.Equal("Tags:(i love cats) AND (Name:User)", ravenQueryable.ToString());
+                }
+            }
+        }
+
+        [Fact]
+        public void SearchCanUseAnd2()
+        {
+            using (var store = GetDocumentStore())
+            {
+                using (var session = store.OpenSession())
+                {
+                    var ravenQueryable = session.Query<Image>("test")
+                        .Customize(x => x.WaitForNonStaleResults())
+                        .Where(x => x.Name == "User")
+                        .Search(x => x.Tags, "i love cats", options: SearchOptions.And);
+
+
+                    Assert.Equal("Name:User AND Tags:(i love cats)", ravenQueryable.ToString());
+                }
+            }
+        }
+
+        [Fact]
+        public void SearchCanUseAnd()
+        {
+            using (var store = GetDocumentStore())
+            {
+                using (var session = store.OpenSession())
+                {
+                    var ravenQueryable = session.Query<Image>("test")
+                        .Customize(x => x.WaitForNonStaleResults())
+                        .Search(x => x.Tags, "i love cats", options: SearchOptions.And)
+                        .Where(x => x.Name == "User");
+
+
+                    Assert.Equal("Tags:(i love cats) AND (Name:User)", ravenQueryable.ToString());
+                }
+            }
+        }
+
+        [Fact]
+        public void SearchCanUseOr()
+        {
+            using (var store = GetDocumentStore())
+            {
+                using (var session = store.OpenSession())
+                {
+                    var ravenQueryable = session.Query<Image>("test")
+                        .Customize(x => x.WaitForNonStaleResults())
+                        .Search(x => x.Tags, "i love cats", options: SearchOptions.Or)
+                        .Where(x => x.Name == "User");
+
+
+                    Assert.Equal("Tags:(i love cats) Name:User", ravenQueryable.ToString());
+                }
+            }
+        }
+
+        [Fact]
+        public void SearchWillUseGuessByDefault()
+        {
+            using (var store = GetDocumentStore())
+            {
+                using (var session = store.OpenSession())
+                {
+                    var ravenQueryable = session.Query<Image>("test")
+                        .Customize(x => x.WaitForNonStaleResults())
+                        .Search(x => x.Tags, "i love cats")
+                        .Search(x => x.Users, "i love cats")
+                        .Where(x => x.Name == "User");
+
+
+                    Assert.Equal("( Tags:(i love cats) Users:(i love cats)) AND (Name:User)", ravenQueryable.ToString());
+                }
+            }
+        }
+
+
+        [Fact]
+        public void ActuallySearchWithAndAndNot()
+        {
+            using (var store = GetDocumentStore())
+            {
+                using (var session = store.OpenSession())
+                {
+                    session.Store(new Image
+                    {
+                        Tags = new string[] { "cats" },
+                        Name = "User"
+                    });
+
+                    session.Store(new Image
+                    {
+                        Tags = new string[] { "dogs" },
+                        Name = "User"
+                    });
+                    session.SaveChanges();
+                }
+
+                using (var session = store.OpenSession())
+                {
+                    var ravenQueryable = session.Query<Image>()
+                        .Customize(x => x.WaitForNonStaleResults())
+                        .Search(x => x.Tags, "i love cats", options: SearchOptions.And | SearchOptions.Not)
+                        .Where(x => x.Name == "User");
+
+
+                    Assert.Equal("( -Tags:(i love cats) AND Tags:(*)) AND (Name:User)", ravenQueryable.ToString());
+
+                    Assert.Equal(1, ravenQueryable.Count());
+                }
+            }
+        }
+
+        [Fact]
+        public void SearchCanUseNot()
+        {
+            using (var store = GetDocumentStore())
+            {
+                using (var session = store.OpenSession())
+                {
+                    var ravenQueryable = session.Query<Image>("test")
+                        .Customize(x => x.WaitForNonStaleResults())
+                        .Search(x => x.Tags, "i love cats", options: SearchOptions.Not)
+                        .Where(x => x.Name == "User");
+
+
+                    Assert.Equal("( -Tags:(i love cats) AND Tags:(*)) Name:User", ravenQueryable.ToString());
+                }
+            }
+        }
+
+        [Fact]
+        public void SearchCanUseNotAndAnd()
+        {
+            using (var store = GetDocumentStore())
+            {
+                using (var session = store.OpenSession())
+                {
+                    var ravenQueryable = session.Query<Image>("test")
+                        .Customize(x => x.WaitForNonStaleResults())
+                        .Search(x => x.Tags, "i love cats", options: SearchOptions.Not | SearchOptions.And)
+                        .Where(x => x.Name == "User");
+
+
+                    Assert.Equal("( -Tags:(i love cats) AND Tags:(*)) AND (Name:User)", ravenQueryable.ToString());
+                }
+            }
+        }
+
+        [Fact]
+        public void BoostingSearches()
+        {
+            using (var store = GetDocumentStore())
+            {
+
+                store.DatabaseCommands.PutIndex("test", new IndexDefinition
+                {
+                    Maps = { "from doc in docs.Images select new { doc.Tags }"},
+                });
+
+                using (var session = store.OpenSession())
+                {
+                    session.Store(new Image
+                    {
+                        Tags = new[] { "cats", "animal", "feline" }
+                    });
+
+                    session.Store(new Image
+                    {
+                        Tags = new[] { "dogs", "animal", "canine" }
+                    });
+                    session.Store(new Image
+                    {
+                        Tags = new[] { "bugs", "resolving", "tricky" }
+                    });
+                    session.SaveChanges();
+                }
+
+                using (var session = store.OpenSession())
+                {
+                    var ravenQueryable = session.Query<Image>("test")
+                        .Customize(x => x.WaitForNonStaleResults())
+                        .Search(x => x.Tags, "i love cats", boost: 3)
+                        .Search(x => x.Tags, "i love bugs", boost: 20)
+                        .Search(x => x.Tags, "canine love", boost: 13);
+                    var s = ravenQueryable
+                        .ToString();
+                    Assert.Equal("( Tags:(i love cats)^3 Tags:(i love bugs)^20 Tags:(canine love)^13)", s);
+
+                    var images = ravenQueryable.ToList();
+
+                    Assert.Equal(3, images.Count);
+                    Assert.Equal("images/2", images[1].Id);
+                    Assert.Equal("images/1", images[2].Id);
+                    Assert.Equal("images/3", images[0].Id);
+                }
+            }
+        }
+
+        [Fact]
+        public void MultipleSearches()
+        {
+            using (var store = GetDocumentStore())
+            {
+                using (var session = store.OpenSession())
+                {
+                    session.Store(new Image
+                    {
+                        Tags = new[] { "cats", "animal", "feline" },
+                        Users = new[] { "oren", "ayende" }
+                    });
+                    session.SaveChanges();
+                }
+
+                store.DatabaseCommands.PutIndex("test", new IndexDefinition
+                {
+                    Maps = { "from doc in docs.Images select new { doc.Tags, doc.Users }"},
+                });
+
+                using (var session = store.OpenSession())
+                {
+                    var query = session.Query<Image>("test")
+                        .Customize(x => x.WaitForNonStaleResults())
+                        .Search(x => x.Tags, "i love cats")
+                        .Search(x => x.Users, "oren")
+                        .ToString();
+                    Assert.Equal("( Tags:(i love cats) Users:(oren))", query.Trim());
+                }
+            }
+        }
+
+        [Fact(Skip = "Missing feature: Suggestions")]
+        public void UsingSuggest()
+        {
+            using (var store = GetDocumentStore())
+            {
+                using (var session = store.OpenSession())
+                {
+                    session.Store(new Image
+                    {
+                        Tags = new[] { "cats", "animal", "feline" },
+                        Users = new[] { "oren", "ayende" }
+                    });
+                    session.SaveChanges();
+                }
+
+                store.DatabaseCommands.PutIndex("test", new IndexDefinition
+                {
+                    Maps = { "from doc in docs.Images select new { doc.Tags, doc.Users }"},
+                    Fields = new Dictionary<string, IndexFieldOptions>
+                    {
+                        { "Tags", new IndexFieldOptions { Indexing = FieldIndexing.Analyzed,Suggestions = true} }
+                    }
+                });
+
+                using (var session = store.OpenSession())
+                {
+                    session.Query<Image>("test")
+                        .Customize(x => x.WaitForNonStaleResults())
+                        .ToList();
+
+                    var query = session.Query<Image>("test")
+                        .Search(x => x.Tags, "animal lover")
+                        .Suggest();
+                    Assert.NotEmpty(query.Suggestions);
+                    Assert.Equal("animal", query.Suggestions[0]);
+                }
+            }
+        }
+
+        [Fact]
+        public void Can_search_inner_words()
+        {
+            using (var store = GetDocumentStore())
+            {
+                using (var session = store.OpenSession())
+                {
+                    session.Store(new Image { Id = "1", Name = "Great Photo buddy" });
+                    session.Store(new Image { Id = "2", Name = "Nice Photo of the sky" });
+                    session.SaveChanges();
+                }
+
+                store.DatabaseCommands.PutIndex("test", new IndexDefinition
+                {
+                    Maps = { "from doc in docs.Images select new { doc.Name }"},
+                    Fields = new Dictionary<string, IndexFieldOptions>
+                    {
+                        { "Name", new IndexFieldOptions { Indexing = FieldIndexing.Analyzed } }
+                    }
+
+                });
+
+                using (var session = store.OpenSession())
+                {
+                    var images = session.Query<Image>("test")
+                        .Customize(x => x.WaitForNonStaleResults())
+                        .OrderBy(x => x.Name)
+                        .Search(x => x.Name, "Photo")
+                        .ToList();
+                    Assert.NotEmpty(images);
+                }
+            }
+        }
+
+
+        [Fact]
+        public void Can_search_inner_words_with_extra_condition()
+        {
+            using (var store = GetDocumentStore())
+            {
+                using (var session = store.OpenSession())
+                {
+                    session.Store(new Image { Id = "1", Name = "Great Photo buddy" });
+                    session.Store(new Image { Id = "2", Name = "Nice Photo of the sky" });
+                    session.SaveChanges();
+                }
+
+                store.DatabaseCommands.PutIndex("test", new IndexDefinition
+                {
+                    Maps = { "from doc in docs.Images select new { doc.Name }"},
+                    Fields = new Dictionary<string, IndexFieldOptions>
+                    {
+                        { "Name", new IndexFieldOptions { Indexing = FieldIndexing.Analyzed } }
+                    },
+
+                });
+
+                using (var session = store.OpenSession())
+                {
+                    var images = session.Query<Image>("test")
+                        .Customize(x => x.WaitForNonStaleResults())
+                        .OrderBy(x => x.Name)
+                        .Search(x => x.Name, "Photo", options: SearchOptions.And)
+                        .Where(x => x.Id == "1")
+                        .ToList();
+                    WaitForUserToContinueTheTest(store);
+                    Assert.NotEmpty(images);
+                    Assert.True(images.Count == 1);
+                }
+            }
+        }
+
+        [Fact]
+        public void Can_have_special_characters_in_search_text()
+        {
+            const string specialCharacters = "+-!(){}:[]^\"~*";
+            using (var store = GetDocumentStore())
+            {
+                using (var session = store.OpenSession())
+                {
+                    foreach (var specialCharacter in specialCharacters)
+                    {
+                        var qry = session.Query<Image>()
+                            .Customize(x => x.WaitForNonStaleResults())
+                            .Search(x => x.Name, specialCharacter.ToString());
+                        Assert.Equal(string.Format("Name:(\\{0})", specialCharacter), qry.ToString());
+                        qry.ToList();
+                    }
+                }
+            }
+        }
+
+        [Fact]
+        public void Can_have_special_characters_in_search_text_string()
+        {
+            using (var store = GetDocumentStore())
+            {
+                using (var session = store.OpenSession())
+                {
+                    var qry = session.Query<Image>()
+                        .Customize(x => x.WaitForNonStaleResults())
+                        .Search(x => x.Name, "He said: hello there");
+                    Assert.Equal("Name:(He said\\: hello there)", qry.ToString());
+                    qry.ToList();
+                }
+            }
+        }
+    }
+}


### PR DESCRIPTION
* Parenthesis query should respect Boost
* Also ported a bunch of fullTextSearch tests from v3.5