### PR TITLE
RavenDB-5384 Ensure insert of map reduce entries is sequential

### DIFF
--- a/src/Raven.Server/Documents/Indexes/MapReduce/MapReduceIndexBase.cs
+++ b/src/Raven.Server/Documents/Indexes/MapReduce/MapReduceIndexBase.cs
@@ -12,6 +12,7 @@ using Voron.Data.BTrees;
 using Voron.Data.Fixed;
 using Voron.Impl;
 using Sparrow;
+using Sparrow.Binary;
 using Voron.Debugging;
 using Voron.Util;
 
@@ -163,7 +164,7 @@ namespace Raven.Server.Documents.Indexes.MapReduce
                         {
                             if (id == -1)
                             {
-                                id = MapReduceWorkContext.GetNextIdentifier();
+                                id = Bits.SwapBytes(MapReduceWorkContext.GetNextIdentifier());
 
                                 Slice val;
                                 using (Slice.External(indexContext.Allocator, (byte*)&reduceKeyHash, sizeof(ulong), out val))

--- a/src/Raven.Server/Documents/Indexes/MapReduce/MapReduceResultsStore.cs
+++ b/src/Raven.Server/Documents/Indexes/MapReduce/MapReduceResultsStore.cs
@@ -78,13 +78,11 @@ namespace Raven.Server.Documents.Indexes.MapReduce
 
         public void Delete(long id)
         {
-            var entryId = id;
-
             switch (Type)
             {
                 case MapResultsStorageType.Tree:
                     Slice entrySlice;
-                    using (Slice.External(_indexContext.Allocator, (byte*) &entryId, sizeof(long), out entrySlice))
+                    using (Slice.External(_indexContext.Allocator, (byte*) &id, sizeof(long), out entrySlice))
                         Tree.Delete(entrySlice);
                     break;
                 case MapResultsStorageType.Nested:


### PR DESCRIPTION
This fix is even better than the previous one which I did during compression work because it also guarantees inserts to fixed size trees are sequential as well.