### PR TITLE
RavenDB-5738 Failing test: MapIndexRecoveryTests.ShouldRecoverDeletes

### DIFF
--- a/Raven.Database/Indexing/Index.cs
+++ b/Raven.Database/Indexing/Index.cs
@@ -373,7 +373,7 @@ namespace Raven.Database.Indexing
             }
         }
 
-        public void Flush(Etag highestETag, bool considerLastCommitedTime = false)
+        public void Flush(Etag highestETag, bool forceFlush = false, bool considerLastCommitedTime = false)
         {
             try
             {
@@ -391,7 +391,9 @@ namespace Raven.Database.Indexing
                     {
                         try
                         {
-                            indexWriter.Commit(highestETag, considerLastCommitedTime: considerLastCommitedTime);
+                            indexWriter.Commit(highestETag, 
+                                forceCommit: forceFlush, 
+                                considerLastCommitedTime: considerLastCommitedTime);
                         }
                         catch (Exception e)
                         {
@@ -661,7 +663,7 @@ namespace Raven.Database.Indexing
 
                                 if (indexWriter != null && indexWriter.RamSizeInBytes() >= flushSize)
                                 {
-                                    Flush(itemsInfo.HighestETag); // just make sure changes are flushed to disk
+                                    Flush(itemsInfo.HighestETag, forceFlush: true); // just make sure changes are flushed to disk
                                     flushed = true;
                                 }
                             }

--- a/Raven.Database/Indexing/IndexingExecuter.cs
+++ b/Raven.Database/Indexing/IndexingExecuter.cs
@@ -915,11 +915,11 @@ namespace Raven.Database.Indexing
                                     // (if we discover that the last indexed etag is different from the last commited one)
                                     // we already flush the last indexed etag when we pass a certain size in ram,
                                     // however we don't do that if we only have a few of them
-                                    // it's also limited to flushing for every 10 minutes if don't have any results
+                                    // it's also limited to flushing for every 10 minutes if we don't have any results
                                     actions.BeforeStorageCommit += () =>
                                     {
                                         batchForIndex.Index.EnsureIndexWriter();
-                                        // we don't to flush to disk too often
+                                        // we don't want to flush to disk too often
                                         batchForIndex.Index.Flush(lastEtag, considerLastCommitedTime: true);
                                     };
                                 });


### PR DESCRIPTION
1) delete the index data if we have a faulty index to prevent loading it again (forcing its recreation)
2) don't commit too often

http://issues.hibernatingrhinos.com/issue/RavenDB-5738