### PR TITLE
RavenDB-5763 fix

### DIFF
--- a/test/FastTests/Server/Replication/ReplicationTombstoneTests.cs
+++ b/test/FastTests/Server/Replication/ReplicationTombstoneTests.cs
@@ -149,7 +149,8 @@ namespace FastTests.Server.Documents.Replication
                 Assert.Equal(1, tombstoneIDs.Count);
                 Assert.Contains("foo/bar", tombstoneIDs);
 
-                Assert.False(WaitForDocument(store1, "foo/bar", 1000));
+                var timeout = 1000 * Server.ServerStore.DatabasesLandlord.LastRecentlyUsed.Count;
+                Assert.False(WaitForDocument(store1, "foo/bar", timeout));
             }
         }
 
@@ -175,8 +176,9 @@ namespace FastTests.Server.Documents.Replication
                 SetupReplication(store1, store2);
                 SetupReplication(store2, store1);
 
-                Assert.True(WaitForDocument(store2, "foo/bar"));
-                Assert.True(WaitForDocument(store2, "foo/bar2"));
+                var timeout = 100 * Server.ServerStore.DatabasesLandlord.LastRecentlyUsed.Count;
+                Assert.True(WaitForDocument(store2, "foo/bar",timeout));
+                Assert.True(WaitForDocument(store2, "foo/bar2", timeout));
 
                 using (var s2 = store1.OpenSession())
                 {
@@ -189,7 +191,7 @@ namespace FastTests.Server.Documents.Replication
                 Assert.Equal(2, tombstoneIDs.Count);
                 Assert.Contains("foo/bar", tombstoneIDs);
 
-                Assert.False(WaitForDocument(store1, "foo/bar", 1000));
+                Assert.False(WaitForDocument(store1, "foo/bar", timeout));
             }
         }
 

--- a/test/SlowTests/Issues/RavenDB-5763.cs
+++ b/test/SlowTests/Issues/RavenDB-5763.cs
@@ -1,0 +1,26 @@
+﻿using System;
+using System.Collections.Generic;
+using System.Linq;
+using System.Threading;
+using System.Threading.Tasks;
+using FastTests;
+using Xunit;
+
+namespace SlowTests.Issues
+{
+    public class RavenDB_5763 : RavenTestBase
+    {
+        [Fact]
+        public void Should_not_throw_timeout_and_out_of_memory()
+        {
+            Parallel.For(0, 1000, i =>
+                {
+                    using (var store = new FastTests.Server.Documents.Replication.ReplicationTombstoneTests())
+                    {
+                        store.Two_tombstones_should_replicate_in_master_master().Wait();
+                    }
+                }
+            );
+        }
+    }
+}

--- a/test/Tryouts/Program.cs
+++ b/test/Tryouts/Program.cs
@@ -10,20 +10,17 @@ namespace Tryouts
 {
     public class Program
     {
-        static unsafe void Main(string[] args)
+        static void Main(string[] args)
         {
-            //LoggingSource.Instance.SetupLogMode(LogMode.Information, "E:\\Work");
-
-            //Parallel.For(0, 1000, i =>
-            for (int i = 0; i < 1000; i++)
-            {
-                Console.WriteLine(i); 
-                using (var store = new FastTests.Server.Documents.PeriodicExport.PeriodicExportTests())
+            Parallel.For(0, 1000, i =>
                 {
-                    store.CanExportToDirectory().Wait();
+                    Console.WriteLine(i);
+                    using (var store = new FastTests.Server.Documents.Replication.ReplicationTombstoneTests())
+                    {
+                        store.Two_tombstones_should_replicate_in_master_master().Wait();
+                    }
                 }
-            }
-            //); 
+            );
         }
     }
 


### PR DESCRIPTION
make timeout in the test dependent on concurrent test count - so if the test is run in Parallel.For and IO slows down, it won't fail on timeout assert