### PR TITLE
RavenDB-5911 fix

### DIFF
--- a/src/Raven.Server/Documents/Replication/DocumentReplicationLoader.cs
+++ b/src/Raven.Server/Documents/Replication/DocumentReplicationLoader.cs
@@ -186,11 +186,17 @@ namespace Raven.Server.Documents.Replication
 
         private void AssertValidConnection(IncomingConnectionInfo connectionInfo)
         {
-
-            if (Guid.Parse(connectionInfo.SourceDatabaseId) == _database.DbId)
+            Guid sourceDbId;
+            //precaution, should never happen..
+            if (string.IsNullOrWhiteSpace(connectionInfo.SourceDatabaseId) ||
+                !Guid.TryParse(connectionInfo.SourceDatabaseId, out sourceDbId))
             {
-                throw new InvalidOperationException(
-                    "Cannot have have replication with source and destination being the same database. They share the same db id ({connectionInfo} - {_database.DbId})");
+                throw new InvalidOperationException($"Failed to parse source database Id. What I got is {(string.IsNullOrWhiteSpace(connectionInfo.SourceDatabaseId) ? "<empty string>" : _database.DbId.ToString())}. This is not supposed to happen and is likely a bug.");
+            }
+
+            if (sourceDbId == _database.DbId)
+            {
+                throw new InvalidOperationException($"Cannot have have replication with source and destination being the same database. They share the same db id ({connectionInfo} - {_database.DbId})");
             }
 
             foreach (var relevantActivityEntry in _incomingLastActivityTime)

--- a/src/Raven.Server/Documents/Replication/IncomingReplicationHandler.cs
+++ b/src/Raven.Server/Documents/Replication/IncomingReplicationHandler.cs
@@ -172,12 +172,11 @@ namespace Raven.Server.Documents.Replication
                                             [nameof(ReplicationMessageReply.MessageType)] = messageType,
                                             [nameof(ReplicationMessageReply.LastEtagAccepted)] = -1,
                                             [nameof(ReplicationMessageReply.LastIndexTransformerEtagAccepted)] = -1,
-                                            [nameof(ReplicationMessageReply.Exception)] = e.SimplifyError()
-                                        };
+                                            [nameof(ReplicationMessageReply.Exception)] = e.ToString()
+                                        };                                   
 
                                         _documentsContext.Write(writer, returnValue);
                                         writer.Flush();
-
                                         exceptionLogged = true;
 
                                         if (_log.IsInfoEnabled)

--- a/src/Raven.Server/Documents/Replication/OutgoingReplicationHandler.cs
+++ b/src/Raven.Server/Documents/Replication/OutgoingReplicationHandler.cs
@@ -22,6 +22,7 @@ using Raven.Json.Linq;
 using Raven.Server.Alerts;
 using Raven.Server.Exceptions;
 using Raven.Server.Extensions;
+using Sparrow;
 
 namespace Raven.Server.Documents.Replication
 {
@@ -209,7 +210,7 @@ namespace Raven.Server.Documents.Replication
 
                             while (_cts.IsCancellationRequested == false)
                             {
-                                _documentsContext.ResetAndRenew();
+                                _documentsContext.ResetAndRenew();                                
                                 long currentEtag;
 
                                 Debug.Assert(_database.IndexMetadataPersistence.IsInitialized);

--- a/src/Raven.Server/Extensions/StringExtensions.cs
+++ b/src/Raven.Server/Extensions/StringExtensions.cs
@@ -3,11 +3,20 @@ using System.Collections.Generic;
 using System.IO;
 using System.Linq;
 using System.Text;
+using System.Text.RegularExpressions;
 
 namespace Raven.Server.Extensions
 {
     public static class StringExtensions
     {
+        /// <summary>
+        /// note: for debugging and testing, do not use in production!
+        /// </summary>
+        public static string RemoveControlChars(this string s)
+        {
+            return Regex.Replace(s, @"[^\x20-\x7F]", string.Empty);
+        }
+
         public static List<string> GetSemicolonSeparatedValues(this string self)
         {
             return self.Split(new[] { ';' }, StringSplitOptions.RemoveEmptyEntries)

--- a/src/Sparrow/Json/BlittableJsonReaderObject.cs
+++ b/src/Sparrow/Json/BlittableJsonReaderObject.cs
@@ -251,7 +251,15 @@ namespace Sparrow.Json
                     }
                     else
                     {
-                        obj = (T)Convert.ChangeType(result, type);
+                        var lazyStringValue = result as LazyStringValue;
+                        if (lazyStringValue != null)
+                        {
+                            obj = (T)Convert.ChangeType(lazyStringValue.String, type);
+                        }
+                        else
+                        {
+                            obj = (T)Convert.ChangeType(result, type);
+                        }
                     }
                 }
                 catch (Exception e)
@@ -673,12 +681,12 @@ namespace Sparrow.Json
             var escCount = ReadVariableSizeInt(stringOffset + lenOffset + stringLength, out escOffset);
             if (escCount != 0)
             {
-                var prevEscChar = 0;
+                var prevEscCharOffset = 0;
                 for (var i = 0; i < escCount; i++)
                 {
                     byte escCharOffsetLen;
                     var escCharOffset = ReadVariableSizeInt(str + stringLength + escOffset + totalEscCharLen, out escCharOffsetLen);
-                    escCharOffset += prevEscChar ;
+                    escCharOffset += prevEscCharOffset;
                     var escChar = (char)ReadNumber(_mem + str + escCharOffset, 1);
                     switch (escChar)
                     {
@@ -695,7 +703,7 @@ namespace Sparrow.Json
                             throw new InvalidDataException("String not valid, invalid escape character: " + escChar);
                     }
                     totalEscCharLen += escCharOffsetLen;
-                    prevEscChar = escCharOffset + 1;
+                    prevEscCharOffset = escCharOffset + 1;
                 }
             }
             return stringLength + escOffset + totalEscCharLen + lenOffset;

--- a/src/Sparrow/Json/BlittableJsonTextWriter.cs
+++ b/src/Sparrow/Json/BlittableJsonTextWriter.cs
@@ -4,6 +4,7 @@ using System.IO;
 using System.Runtime.CompilerServices;
 using System.Runtime.InteropServices.ComTypes;
 using System.Text;
+using System.Threading;
 
 namespace Sparrow.Json
 {
@@ -337,7 +338,7 @@ namespace Sparrow.Json
             _stream.Write(_pinnedBuffer.Buffer.Array, _pinnedBuffer.Buffer.Offset, _pos);
             _pos = 0;
         }
-
+      
         [MethodImpl(MethodImplOptions.AggressiveInlining)]
         public void WriteNull()
         {


### PR DESCRIPTION
Refresh buffer used in UnmanagedJsonParser when parent context buffers are refershed - so it points to a valid buffer (RavenDB-5911)