### PR TITLE
RavenDB-4762: Improvements into page diffing.

### DIFF
--- a/src/Voron/Impl/Journal/WriteAheadJournal.cs
+++ b/src/Voron/Impl/Journal/WriteAheadJournal.cs
@@ -1090,26 +1090,28 @@ namespace Voron.Impl.Journal
 
             foreach (var txPage in txPages)
             {
-                var scratchPage = tx.Environment.ScratchBufferPool.AcquirePagePointer(tx, txPage.ScratchFileNumber,
-                    txPage.PositionInScratchBuffer);
+                var scratchPage = tx.Environment.ScratchBufferPool.AcquirePagePointer(tx, txPage.ScratchFileNumber, txPage.PositionInScratchBuffer);
+
                 pagesInfo[pageSequencialNumber].PageNumber = ((PageHeader*)scratchPage)->PageNumber;
+
                 *(long*)write = ((PageHeader*)scratchPage)->PageNumber;
                 write += sizeof(long);
+
                 _diffPage.Output = write;
-                _diffPage.Modified = scratchPage;
-                _diffPage.Size = txPage.NumberOfPages * pageSize;
+
+                int diffPageSize = txPage.NumberOfPages * pageSize;
+
                 if (txPage.PreviousVersion != null)
                 {
-                    _diffPage.Original = txPage.PreviousVersion.Value.Pointer;
-                    _diffPage.ComputeDiff();
+                    _diffPage.ComputeDiff(txPage.PreviousVersion.Value.Pointer, scratchPage, diffPageSize);
                 }
                 else
                 {
-                    _diffPage.Original = null;
-                    _diffPage.ComputeNew();
+                    _diffPage.ComputeNew(scratchPage, diffPageSize);
                 }
+
                 write += _diffPage.OutputSize;
-                pagesInfo[pageSequencialNumber].Size = _diffPage.OutputSize == 0 ? 0 : _diffPage.Size;
+                pagesInfo[pageSequencialNumber].Size = _diffPage.OutputSize == 0 ? 0 : diffPageSize;
                 pagesInfo[pageSequencialNumber].DiffSize = _diffPage.IsDiff ? _diffPage.OutputSize : 0;
 
 

--- a/test/FastTests/Sparrow/DiffPagesTests.cs
+++ b/test/FastTests/Sparrow/DiffPagesTests.cs
@@ -23,13 +23,10 @@ namespace FastTests.Sparrow
             {
                 var diffPages = new DiffPages
                 {
-                    Size = 4096,
-                    Original = one,
-                    Modified = two,
                     Output = tmp,
                 };
 
-                diffPages.ComputeDiff();
+                diffPages.ComputeDiff(one, two, 4096);
 
                 Assert.Equal(0, diffPages.OutputSize);
             }
@@ -53,13 +50,10 @@ namespace FastTests.Sparrow
             {
                 var diffPages = new DiffPages
                 {
-                    Size = 4096,
-                    Original = one,
-                    Modified = two,
                     Output = tmp,
                 };
 
-                diffPages.ComputeDiff();
+                diffPages.ComputeDiff(one, two, 4096);
 
                 Assert.Equal(96, diffPages.OutputSize);
             }
@@ -79,12 +73,10 @@ namespace FastTests.Sparrow
             {
                 var diffPages = new DiffPages
                 {
-                    Size = 4096,
-                    Modified = one,
                     Output = tmp,
                 };
 
-                diffPages.ComputeNew();
+                diffPages.ComputeNew(one, 4096);
 
                 Assert.Equal(96, diffPages.OutputSize);
             }
@@ -110,13 +102,10 @@ namespace FastTests.Sparrow
             {
                 var diffPages = new DiffPages
                 {
-                    Size = 4096,
-                    Original = one,
-                    Modified = two,
                     Output = tmp,
                 };
 
-                diffPages.ComputeDiff();
+                diffPages.ComputeDiff(one, two, 4096);
 
                 Memory.Copy(tri, one, 4096);
                 new DiffApplier
@@ -146,13 +135,10 @@ namespace FastTests.Sparrow
             {
                 var diffPages = new DiffPages
                 {
-                    Size = 4096,
-                    Original = one,
-                    Modified = two,
                     Output = tmp,
                 };
 
-                diffPages.ComputeDiff();
+                diffPages.ComputeDiff(one, two, 4096);
 
                 Assert.False(diffPages.IsDiff);
             }


### PR DESCRIPTION
- Using function parameters instead of diff properties to handle buffers.
- Avoid executing comparisons when we already know that the page has been modified.
- Better code layout to ensure instructions follow a least resistant path.
- Diminished the instructions retired by roughly 12%
- Still couldn't diminish the LD_BLOCKS_PARTIAL.ADDRESS_ALIAS instances.