### PR TITLE
RavenDB-5384 Creating multiple decompression files instead of a singl…

### DIFF
--- a/src/Voron/StorageEnvironment.cs
+++ b/src/Voron/StorageEnvironment.cs
@@ -847,6 +847,7 @@ namespace Voron
         {
             Journal.Cleanup();
             ScratchBufferPool.Cleanup();
+            DecompressionBuffers.Cleanup();
         }
 
         public override string ToString()

--- a/test/FastTests/Voron/LeafsCompression/RavenDB_5384.cs
+++ b/test/FastTests/Voron/LeafsCompression/RavenDB_5384.cs
@@ -1,8 +1,8 @@
 ﻿using System;
 using System.Collections.Generic;
-using System.Diagnostics;
 using System.IO;
 using System.Linq;
+using FastTests.Voron.FixedSize;
 using Sparrow;
 using Voron;
 using Voron.Data.BTrees;
@@ -13,16 +13,15 @@ namespace FastTests.Voron.LeafsCompression
 {
     public class RavenDB_5384 : StorageTest
     {
-        // TODO arek - slow test cases move to SlowTests
         [Theory]
         [InlineData(26, 256, true, 1)]
         [InlineData(1024, 256, false, 1)]
-        [InlineData(8192, 512, true, 1)]
-        [InlineData(16384, 512, false, 1)] 
         [InlineData(26, 333, true, 1)]
         [InlineData(1024, 555, false, 1)]
         [InlineData(777, 2048, false, 1)]
-        public void Can_compress_leaf_pages_and_read_directly_from_them_after_decompression(int iterationCount, int size, bool sequentialKeys, int seed)
+        [InlineDataWithRandomSeed(312, 345, true)]
+        [InlineDataWithRandomSeed(254, 713, false)]
+        public void Leafs_compressed_CRUD(int iterationCount, int size, bool sequentialKeys, int seed)
         {
             using (var tx = Env.WriteTransaction())
             {

--- a/test/FastTests/Voron/LeafsCompression/RavenDB_5384_DecompressionBuffersPoolTests.cs
+++ b/test/FastTests/Voron/LeafsCompression/RavenDB_5384_DecompressionBuffersPoolTests.cs
@@ -1,0 +1,51 @@
+﻿using Sparrow;
+using Voron;
+using Voron.Impl.Paging;
+using Xunit;
+using Assert = Xunit.Assert;
+
+namespace FastTests.Voron.LeafsCompression
+{
+    public class RavenDB_5384_DecompressionBuffersPoolTests : StorageTest
+    {
+        private const int _64KB = 64 * 1024;
+
+        protected override void Configure(StorageEnvironmentOptions options)
+        {
+            options.MaxScratchBufferSize = _64KB * 4;
+        }
+
+        [Fact]
+        public void Should_cleanup_scratch_files_which_are_no_longer_necessary()
+        {
+            using (var tx = Env.ReadTransaction())
+            {
+                var llt = tx.LowLevelTransaction;
+                
+                TemporaryPage temp;
+                TemporaryPage temp3;
+                var page1 = Env.DecompressionBuffers.GetTemporaryPage(llt, _64KB, out temp);
+
+                var page2 = Env.DecompressionBuffers.GetTemporaryPage(llt, _64KB, out temp);
+
+                var page3 = Env.DecompressionBuffers.GetTemporaryPage(llt, _64KB, out temp3);
+
+                var page4 = Env.DecompressionBuffers.GetTemporaryPage(llt, _64KB, out temp);
+
+                var page5 = Env.DecompressionBuffers.GetTemporaryPage(llt, _64KB, out temp);
+
+                Assert.Equal(2, Env.DecompressionBuffers.NumberOfScratchFiles);
+
+                page1.Dispose();
+                page2.Dispose();
+                
+                Env.DecompressionBuffers.Cleanup();
+
+                Assert.Equal(1, Env.DecompressionBuffers.NumberOfScratchFiles);
+
+                Env.DecompressionBuffers.GetTemporaryPage(llt, _64KB, out temp);
+            }
+            
+        }
+    }
+}

--- a/test/SlowTests/Voron/LeafsCompression/RavenDB_5384.cs
+++ b/test/SlowTests/Voron/LeafsCompression/RavenDB_5384.cs
@@ -1,0 +1,19 @@
+﻿using FastTests;
+using Xunit;
+
+namespace SlowTests.Voron.LeafsCompression
+{
+    public class RavenDB_5384 : NoDisposalNeeded
+    {
+        [Theory]
+        [InlineData(8192, 512, true, 1)]
+        [InlineData(16384, 512, false, 1)]
+        public void Leafs_compressed_CRUD(int iterationCount, int size, bool sequentialKeys, int seed)
+        {
+            using (var test = new FastTests.Voron.LeafsCompression.RavenDB_5384())
+            {
+                test.Leafs_compressed_CRUD(iterationCount, size, sequentialKeys, seed);
+            }
+        }
+    }
+}


### PR DESCRIPTION
…e, big one. Cleaning them up. Moving slow test cases to SlowTests.