### PR TITLE
RavenDB-5917 When Append entries request fail we now return the previ…

### DIFF
--- a/Rachis/Rachis/Behaviors/AbstractRaftStateBehavior.cs
+++ b/Rachis/Rachis/Behaviors/AbstractRaftStateBehavior.cs
@@ -473,7 +473,7 @@ namespace Rachis.Behaviors
                 {
                     Success = false,
                     CurrentTerm = Engine.PersistentState.CurrentTerm,
-                    LastLogIndex = Engine.PersistentState.LastLogEntry().Index,
+                    LastLogIndex = req.PrevLogIndex,
                     Message = msg,
                     LeaderId = Engine.CurrentLeader,
                     From = Engine.Name,

--- a/Rachis/Rachis/Behaviors/LeaderStateBehavior.cs
+++ b/Rachis/Rachis/Behaviors/LeaderStateBehavior.cs
@@ -367,20 +367,23 @@ namespace Rachis.Behaviors
             }
 
 
+            if (resp.Success == false)
+            {
+                _nextIndexes[resp.From] = resp.LastLogIndex - 1;
+                _matchIndexes[resp.From] = 0;
+
+                if (_log.IsDebugEnabled)
+                    _log.Debug("Received Success = false in AppendEntriesResponse from {1}. Now _nextIndexes[{1}] = {0}. Reason: {2}",
+                    _nextIndexes[resp.From], resp.From, resp.Message);
+                return;
+            }
+
             Debug.Assert(resp.From != null);
             _nextIndexes[resp.From] = resp.LastLogIndex + 1;
             _matchIndexes[resp.From] = resp.LastLogIndex;
             _lastContact[resp.From] = DateTime.UtcNow;
             if (_log.IsDebugEnabled)
                 _log.Debug("Follower ({0}) has LastLogIndex = {1}", resp.From, resp.LastLogIndex);
-
-            if (resp.Success == false)
-            {
-                if (_log.IsDebugEnabled)
-                    _log.Debug("Received Success = false in AppendEntriesResponse from {1}. Now _nextIndexes[{1}] = {0}. Reason: {2}",
-                    _nextIndexes[resp.From], resp.From, resp.Message);
-                return;
-            }
 
 
             if (Engine.CurrentTopology.IsPromotable(resp.From) &&

--- a/Rachis/Rachis/RaftEngine.cs
+++ b/Rachis/Rachis/RaftEngine.cs
@@ -54,7 +54,7 @@ namespace Rachis
                 if (_currentLeader == value)
                     return;
                 if (_log.IsDebugEnabled)
-                    _log.Debug("Setting CurrentLeader: {0}", value);
+                    _log.Debug("Setting CurrentLeader: {0} on term {1}", value, PersistentState.CurrentTerm);
                 _currentLeader = value;
 
 


### PR DESCRIPTION
…ous log entry and the leader will also rewind the sent entry index by one and so the leader will go back to the point in time where the two nodes agree on the state of the logs and send it from there.