### PR TITLE
RavenDB-5941 Flushing needs to be scheduled _after_ we are no longer …

### DIFF
--- a/src/Voron/Impl/Journal/WriteAheadJournal.cs
+++ b/src/Voron/Impl/Journal/WriteAheadJournal.cs
@@ -564,8 +564,6 @@ namespace Voron.Impl.Journal
                         
                         using (var txw = _waj._env.NewLowLevelTransaction(transactionPersistentContext, TransactionFlags.ReadWrite, timeout: Infinity))
                         {
-                            txw.JournalApplicatorTransaction();
-
                             _lastFlushedJournalId = lastProcessedJournal;
                             _lastFlushedTransactionId = lastFlushedTransactionId;
                             _lastFlushedJournal = _waj._files.First(x => x.Number == lastProcessedJournal);
@@ -586,15 +584,12 @@ namespace Voron.Impl.Journal
 
                             FreeScratchPages(unusedJournals, txw);
 
-                            if (txw != null)
-                            {
-                                // by forcing a commit, we free the read transaction that held the lazy tx buffer (if existed)
-                                // and make those pages available in the scratch files
-                                txw.IsLazyTransaction = false;
-                                _waj.HasLazyTransactions = false;
+                            // by forcing a commit, we free the read transaction that held the lazy tx buffer (if existed)
+                            // and make those pages available in the scratch files
+                            txw.IsLazyTransaction = false;
+                            _waj.HasLazyTransactions = false;
 
-                                txw.Commit();
-                            }
+                            txw.Commit();
                         }
                     }
                     finally

--- a/src/Voron/Impl/Journal/WriteAheadJournal.cs
+++ b/src/Voron/Impl/Journal/WriteAheadJournal.cs
@@ -561,8 +561,15 @@ namespace Voron.Impl.Journal
                     try
                     {
                         var transactionPersistentContext = new TransactionPersistentContext(true);
-                        
-                        using (var txw = _waj._env.NewLowLevelTransaction(transactionPersistentContext, TransactionFlags.ReadWrite, timeout: Infinity))
+
+                        TimeSpan? timeout;
+
+                        if (pagesToWrite.Count < _waj._env.Options.MaxNumberOfPagesInJournalBeforeFlush)
+                            timeout = null;
+                        else
+                            timeout = Infinity;
+
+                        using (var txw = _waj._env.NewLowLevelTransaction(transactionPersistentContext, TransactionFlags.ReadWrite, timeout: timeout))
                         {
                             _lastFlushedJournalId = lastProcessedJournal;
                             _lastFlushedTransactionId = lastFlushedTransactionId;

--- a/src/Voron/Impl/LowLevelTransaction.cs
+++ b/src/Voron/Impl/LowLevelTransaction.cs
@@ -111,9 +111,6 @@ namespace Voron.Impl
             }
         }
 
-
-        internal bool CreatedByJournalApplicator;
-
         public StorageEnvironment Environment => _env;
 
         public long Id => _id;
@@ -693,13 +690,6 @@ namespace Voron.Impl
         public void RetrieveCommitStats(out CommitStats stats)
         {
             _requestedCommitStats = stats = new CommitStats();
-        }
-
-
-        internal LowLevelTransaction JournalApplicatorTransaction()
-        {
-            CreatedByJournalApplicator = true;
-            return this;
         }
 
         private PagerState _lastState;

--- a/src/Voron/Impl/Scratch/ScratchBufferFile.cs
+++ b/src/Voron/Impl/Scratch/ScratchBufferFile.cs
@@ -96,6 +96,8 @@ namespace Voron.Impl.Scratch
 
         public long AllocatedPagesCount => _allocatedPagesCount;
 
+        public long TxIdAfterWhichLatestFreePagesBecomeAvailable => _txIdAfterWhichLatestFreePagesBecomeAvailable;
+
         public long SizeAfterAllocation(long sizeToAllocate)
         {
             return (_lastUsedPage + sizeToAllocate) * _pageSize;

--- a/src/Voron/Impl/Scratch/ScratchBufferPool.cs
+++ b/src/Voron/Impl/Scratch/ScratchBufferPool.cs
@@ -4,7 +4,6 @@ using System;
 using System.Collections.Concurrent;
 using System.Collections.Generic;
 using System.Runtime.CompilerServices;
-using System.Runtime.InteropServices;
 using Voron.Impl.Paging;
 
 namespace Voron.Impl.Scratch
@@ -306,13 +305,54 @@ namespace Voron.Impl.Scratch
 
         public void Cleanup()
         {
-            if (_recycleArea.Count == 0)
+            if (_recycleArea.Count == 0 && _scratchBuffers.Count == 1)
                 return;
+
+            long txIdAllowingToReleaseOldScratches = -1;
+
+            // ReSharper disable once LoopCanBeConvertedToQuery
+            foreach (var scratchBufferItem in _scratchBuffers)
+            {
+                if (scratchBufferItem.Value == _current)
+                    continue;
+
+                txIdAllowingToReleaseOldScratches = Math.Max(txIdAllowingToReleaseOldScratches,
+                    scratchBufferItem.Value.File.TxIdAfterWhichLatestFreePagesBecomeAvailable);
+            }
+            
+            while (_env.CurrentReadTransactionId <= txIdAllowingToReleaseOldScratches)
+            {
+                // we've just flushed and had no more writes after that, let us bump id of next read transactions to ensure
+                // that nobody will attempt to read old scratches so we will be able to release more files
+
+                using (var tx = _env.WriteTransaction())
+                {
+                    tx.LowLevelTransaction.ModifyPage(0);
+                    tx.Commit();
+                }
+            }
 
             // we need to ensure that no access to _recycleArea will take place in the same time
             // and only methods that access this are used within write transaction
             using (_env.WriteTransaction())
             {
+                //check if we can put more files into recycle area
+
+                foreach (var scratchBufferItem in _scratchBuffers)
+                {
+                    var scratchItem = scratchBufferItem.Value;
+                    if (scratchItem == _current)
+                        continue;
+
+                    if (scratchItem.File.HasActivelyUsedBytes(_env.PossibleOldestReadTransaction))
+                        continue;
+
+                    RecyleScratchFile(scratchItem);
+                }
+
+                if (_recycleArea.Count == 0)
+                    return;
+
                 while (_recycleArea.First != null)
                 {
                     _recycleArea.First.Value.Item2.File.Dispose();


### PR DESCRIPTION
…seen as an active transaction (in particular we can be the oldest one). Now the journal applicator is able to flush what we've just committed. We had a mismatch between what we've reported in SizeOfUnflushedTransactionsInJournalFile and what the applicator could really flush.