### PR TITLE
RavenDB-6040 - Allow to run the Raven.Server directly from the Debug/Release folder (without running through VS)

### DIFF
--- a/src/Raven.Server/Web/System/StudioHandler.cs
+++ b/src/Raven.Server/Web/System/StudioHandler.cs
@@ -36,6 +36,7 @@ namespace Raven.Server.Web.System
              "wwwroot",
             "../Raven.Studio/wwwroot",
             "../src/Raven.Studio/wwwroot",
+            "../../../../../Raven.Studio/wwwroot"
         };
 
         public static Dictionary<string, string> FileExtensionToContentTypeMapping = new Dictionary<string, string>(StringComparer.OrdinalIgnoreCase)


### PR DESCRIPTION
http://issues.hibernatingrhinos.com/issue/RavenDB-6040