### PR TITLE
RavenDB-6061 fix

### DIFF
--- a/Raven.Database/Actions/DocumentActions.cs
+++ b/Raven.Database/Actions/DocumentActions.cs
@@ -716,7 +716,7 @@ namespace Raven.Database.Actions
         }
 
 
-        public PutResult Put(string key, Etag etag, RavenJObject document, RavenJObject metadata, TransactionInformation transactionInformation, string[] participatingIds = null)
+        public PutResult Put(string key, Etag etag, RavenJObject document, RavenJObject metadata, TransactionInformation transactionInformation, HashSet<string> participatingIds = null)
         {
             WorkContext.MetricsCounters.DocsPerSecond.Mark();
             key = string.IsNullOrWhiteSpace(key) ? Guid.NewGuid().ToString() : key.Trim();
@@ -809,13 +809,13 @@ namespace Raven.Database.Actions
             }
         }
 
-        public bool Delete(string key, Etag etag, TransactionInformation transactionInformation, string[] participatingIds = null)
+        public bool Delete(string key, Etag etag, TransactionInformation transactionInformation, HashSet<string> participatingIds = null)
         {
             RavenJObject metadata;
             return Delete(key, etag, transactionInformation, out metadata, participatingIds);
         }
 
-        public bool Delete(string key, Etag etag, TransactionInformation transactionInformation, out RavenJObject metadata, string[] participatingIds = null)
+        public bool Delete(string key, Etag etag, TransactionInformation transactionInformation, out RavenJObject metadata, HashSet<string> participatingIds = null)
         {
             if (key == null)
                 throw new ArgumentNullException("key");

--- a/Raven.Database/Actions/IndexActions.cs
+++ b/Raven.Database/Actions/IndexActions.cs
@@ -119,7 +119,7 @@ namespace Raven.Database.Actions
             return indexEtag;
         }
 
-        internal void CheckReferenceBecauseOfDocumentUpdate(string key, IStorageActionsAccessor actions, string[] participatingIds = null)
+        internal void CheckReferenceBecauseOfDocumentUpdate(string key, IStorageActionsAccessor actions, HashSet<string> participatingIds = null)
         {
             TouchedDocumentInfo touch;
             RecentTouches.TryRemove(key, out touch);
@@ -132,11 +132,12 @@ namespace Raven.Database.Actions
                 Database.TransactionalStorage.Batch(externalActions =>
                 {
                     var referencingKeys = externalActions.Indexing.GetDocumentsReferencing(key);
-                    if (participatingIds != null)
-                        referencingKeys = referencingKeys.Except(participatingIds);
 
                     foreach (var referencing in referencingKeys)
                     {
+                        if (participatingIds != null && participatingIds.Contains(referencing))
+                                continue;
+
                         Etag preTouchEtag = null;
                         Etag afterTouchEtag = null;
                         try

--- a/Raven.Database/Actions/PatchActions.cs
+++ b/Raven.Database/Actions/PatchActions.cs
@@ -27,7 +27,7 @@ namespace Raven.Database.Actions
         }
 
         public PatchResultData ApplyPatch(string docId, Etag etag, PatchRequest[] patchDoc,
-                                  TransactionInformation transactionInformation, bool debugMode = false, string[] participatingIds = null)
+                                  TransactionInformation transactionInformation, bool debugMode = false, HashSet<string> participatingIds = null)
         {
             if (docId == null)
                 throw new ArgumentNullException("docId");
@@ -38,7 +38,8 @@ namespace Raven.Database.Actions
 
         public PatchResultData ApplyPatch(string docId, Etag etag,
                                           PatchRequest[] patchExistingDoc, PatchRequest[] patchDefaultDoc, RavenJObject defaultMetadata,
-                                          TransactionInformation transactionInformation, bool debugMode = false, bool skipPatchIfEtagMismatch = false, string[] participatingIds = null)
+                                          TransactionInformation transactionInformation, bool debugMode = false, bool skipPatchIfEtagMismatch = false,
+                                          HashSet<string> participatingIds = null)
         {
             if (docId == null)
                 throw new ArgumentNullException("docId");
@@ -68,7 +69,7 @@ namespace Raven.Database.Actions
                                        Func<RavenJObject> getDebugActions,
                                        bool debugMode,
                                        bool skipPatchIfEtagMismatch = false,
-                                       string[] participatingIds = null)
+                                       HashSet<string> participatingIds = null)
         {
             if (docId == null) throw new ArgumentNullException("docId");
             docId = docId.Trim();
@@ -227,7 +228,7 @@ namespace Raven.Database.Actions
 
         public Tuple<PatchResultData, List<string>> ApplyPatch(string docId, Etag etag,
                                                                ScriptedPatchRequest patchExisting, ScriptedPatchRequest patchDefault, RavenJObject defaultMetadata,
-                                                               TransactionInformation transactionInformation, bool debugMode = false, string[] participatingIds = null)
+                                                               TransactionInformation transactionInformation, bool debugMode = false, HashSet<string> participatingIds = null)
         {
             ScriptedJsonPatcher scriptedJsonPatcher = null;
             DefaultScriptedJsonPatcherOperationScope scope = null;

--- a/Raven.Database/DocumentDatabase.cs
+++ b/Raven.Database/DocumentDatabase.cs
@@ -1316,7 +1316,11 @@ namespace Raven.Database
         private BatchResult[] ProcessBatch(IList<ICommandData> commands, CancellationToken token)
         {
             var results = new BatchResult[commands.Count];
-            var participatingIds = commands.Select(x => x.Key).ToArray();
+            var participatingIds = new HashSet<string>(StringComparer.OrdinalIgnoreCase);
+            foreach (var command in commands)
+            {
+                participatingIds.Add(command.Key);
+            }
 
             for (int index = 0; index < commands.Count; index++)
             {

--- a/Raven.Database/Extensions/CommandExtensions.cs
+++ b/Raven.Database/Extensions/CommandExtensions.cs
@@ -3,6 +3,7 @@
 //     Copyright (c) Hibernating Rhinos LTD. All rights reserved.
 // </copyright>
 //-----------------------------------------------------------------------
+using System.Collections.Generic;
 using System.Linq;
 using Newtonsoft.Json;
 using Raven.Abstractions.Commands;
@@ -18,7 +19,7 @@ namespace Raven.Database.Extensions
             Execute(self, database, null);
         }
 
-        public static BatchResult ExecuteBatch(this ICommandData self, DocumentDatabase database, string[] participatingIds = null)
+        public static BatchResult ExecuteBatch(this ICommandData self, DocumentDatabase database, HashSet<string> participatingIds = null)
         {
             var batchResult = new BatchResult();
 
@@ -33,7 +34,7 @@ namespace Raven.Database.Extensions
             return batchResult;
         }
 
-        private static void Execute(ICommandData self, DocumentDatabase database, BatchResult batchResult, string[] participatingIds = null)
+        private static void Execute(ICommandData self, DocumentDatabase database, BatchResult batchResult, HashSet<string> participatingIds = null)
         {
             var deleteCommandData = self as DeleteCommandData;
             if (deleteCommandData != null)


### PR DESCRIPTION
* Refactoring participating IDs to be stored in hashset (instead of array) in document related methods
* Refactoring slow code in IndexActions::CheckReferenceBecauseOfDocumentUpdate() to be more effective
 (RavenDB-6061)