### PR TITLE
RavenDB-5798

### DIFF
--- a/src/Raven.Server/Documents/Indexes/IndexStore.cs
+++ b/src/Raven.Server/Documents/Indexes/IndexStore.cs
@@ -1,11 +1,9 @@
 ﻿using System;
 using System.Collections.Generic;
-using System.Data.SqlTypes;
 using System.Diagnostics;
 using System.IO;
 using System.Linq;
 using System.Threading.Tasks;
-
 using Raven.Abstractions.Data;
 using Raven.Abstractions.Exceptions;
 using Raven.Abstractions.Indexing;
@@ -18,13 +16,9 @@ using Raven.Server.Documents.Indexes.MapReduce.Auto;
 using Raven.Server.Documents.Indexes.MapReduce.Static;
 using Raven.Server.Documents.Indexes.Static;
 using Raven.Server.Documents.Queries.Dynamic;
-using Raven.Server.Documents.SqlReplication;
-using Raven.Server.ServerWide.Context;
 using Raven.Server.Utils;
 
 using Voron.Platform.Posix;
-
-using Sparrow;
 using Sparrow.Logging;
 using Sparrow.Platform;
 

--- a/src/Raven.Server/Web/System/AdminResourcesStudioTasksHandler.cs
+++ b/src/Raven.Server/Web/System/AdminResourcesStudioTasksHandler.cs
@@ -91,11 +91,6 @@ namespace Raven.Server.Web.System
                         continue;
                     }
 
-                    dbDoc.Modifications = new DynamicJsonValue(dbDoc)
-                    {
-                        ["Disabled"] = disableRequested
-                    };
-
                     var newDoc2 = context.ReadObject(dbDoc, dbId, BlittableJsonDocumentBuilder.UsageMode.ToDisk);
 
                     ServerStore.Write(context, dbId, newDoc2);

--- a/src/Raven.Studio/mockups/src/partials/resources/resource.html
+++ b/src/Raven.Studio/mockups/src/partials/resources/resource.html
@@ -97,7 +97,7 @@
                     <div class="properties-value value-only text-warning">
                         <div class="set-size">
                             <i class="icon-pause"></i>
-                            <span>Indexing disabled</span>
+                            <span>Indexing paused</span>
                         </div>
                     </div>
                 </div>

--- a/src/Raven.Studio/typescript/models/resources/info/databaseInfo.ts
+++ b/src/Raven.Studio/typescript/models/resources/info/databaseInfo.ts
@@ -8,7 +8,8 @@ class databaseInfo extends resourceInfo {
 
     rejectClients = ko.observable<boolean>();
     indexingStatus = ko.observable<Raven.Client.Data.Indexes.IndexRunningStatus>();
-    indexingEnabled = ko.observable<boolean>();
+    indexingNotPaused = ko.observable<boolean>();
+    indexingEnable = ko.observable<boolean>();
     documentsCount = ko.observable<number>();
     indexesCount = ko.observable<number>();
 
@@ -38,7 +39,8 @@ class databaseInfo extends resourceInfo {
         super.update(databaseInfo);
         this.rejectClients(databaseInfo.RejectClients);
         this.indexingStatus(databaseInfo.IndexingStatus);
-        this.indexingEnabled(databaseInfo.IndexingStatus === "Running");
+        this.indexingNotPaused(databaseInfo.IndexingStatus === "Running");
+        this.indexingEnable(databaseInfo.IndexingStatus === "Running");
         this.documentsCount(databaseInfo.DocumentsCount);
         this.indexesCount(databaseInfo.IndexesCount);
     }

--- a/src/Raven.Studio/typescript/viewmodels/database/indexes/indexes.ts
+++ b/src/Raven.Studio/typescript/viewmodels/database/indexes/indexes.ts
@@ -42,7 +42,8 @@ class indexes extends viewModelBase {
         localState: ko.observableArray<string>([])
     }
 
-    indexingEnabled = ko.observable<boolean>(true);
+    indexingNotPaused = ko.observable<boolean>(true);
+    indexingEnable = ko.observable<boolean>(true);
 
     resetsInProgress = new Set<string>();
 
@@ -135,7 +136,7 @@ class indexes extends viewModelBase {
     private processData(stats: Array<Raven.Client.Data.Indexes.IndexStats>, replacements: indexReplaceDocument[], statuses: Raven.Client.Data.Indexes.IndexingStatus) {
         //TODO: handle replacements
 
-        this.indexingEnabled(statuses.Status !== "Paused");
+        this.indexingNotPaused(statuses.Status !== "Paused");
 
         stats
             .map(i => new index(i))
@@ -439,7 +440,7 @@ class indexes extends viewModelBase {
                     this.spinners.globalStartStop(true);
                     new toggleIndexingCommand(true, this.activeDatabase())
                         .execute()
-                        .done(() => this.indexingEnabled(true))
+                        .done(() => this.indexingNotPaused(true))
                         .always(() => {
                             this.spinners.globalStartStop(false);
                             this.fetchIndexes();
@@ -456,7 +457,7 @@ class indexes extends viewModelBase {
                     this.spinners.globalStartStop(true);
                     new toggleIndexingCommand(false, this.activeDatabase())
                         .execute()
-                        .done(() => this.indexingEnabled(false))
+                        .done(() => this.indexingNotPaused(false))
                         .always(() => {
                             this.spinners.globalStartStop(false);
                             this.fetchIndexes();

--- a/src/Raven.Studio/typescript/viewmodels/resources/resources.ts
+++ b/src/Raven.Studio/typescript/viewmodels/resources/resources.ts
@@ -301,17 +301,17 @@ class resources extends viewModelBase {
     }
 
     toggleDatabaseIndexing(db: databaseInfo) {
-        const enableIndexing = !db.indexingEnabled();
-        const message = enableIndexing ? "Enable" : "Disable";
+        const enableIndexing = !db.indexingNotPaused();
+        const message = enableIndexing ? "Enable" : "Pause";
 
         this.confirmationMessage("Are you sure?", message + " indexing?")
             .done(result => {
                 if (result.can) {
                     this.spinners.disableIndexing.push(db.qualifiedName);
 
-                    new toggleIndexingCommand(true, db.asResource())
+                    new toggleIndexingCommand(enableIndexing, db.asResource())
                         .execute()
-                        .done(() => db.indexingEnabled(enableIndexing))
+                        .done(() => db.indexingNotPaused(enableIndexing))
                         .always(() => this.spinners.disableIndexing.remove(db.qualifiedName));
                 }
             });

--- a/src/Raven.Studio/wwwroot/App/views/database/indexes/indexes.html
+++ b/src/Raven.Studio/wwwroot/App/views/database/indexes/indexes.html
@@ -65,14 +65,14 @@
         </div>
         <div class="pull-right" id="toggleIndexing">
             <button class="btn btn-default btn-toggle disable-indexing" title="Pause indexing process for ALL indexes until restart"
-                    data-bind="click: stopIndexing, visible: indexingEnabled(), enable: !spinners.globalStartStop(), css: { 'btn-spinner': spinners.globalStartStop() }">
+                    data-bind="click: stopIndexing, visible: indexingNotPaused(), enable: !spinners.globalStartStop(), css: { 'btn-spinner': spinners.globalStartStop() }">
                 <i class="icon-pause"></i>
                 <span>Pause indexing until restart</span>
             </button>
             <button class="btn btn-success btn-toggle enable-indexing" title="Enable indexing process"
-                    data-bind="click: startIndexing, visible: !indexingEnabled(), enable: !spinners.globalStartStop(), css: { 'btn-spinner': spinners.globalStartStop() }">
+                    data-bind="click: startIndexing, visible: !indexingNotPaused(), enable: !spinners.globalStartStop(), css: { 'btn-spinner': spinners.globalStartStop() }">
                 <i class="icon-play"></i>
-                <span>Enable indexing</span>
+                <span>Resume indexing</span>
             </button>
         </div>
     </div>
@@ -156,7 +156,7 @@
     <span class="properties-label">Priority:</span>
     <div class="btn-group properties-value">
         <button type="button" class="btn set-size dropdown-toggle" data-toggle="dropdown"
-                data-bind="css: { 'btn-spinner': _.includes($root.spinners.localPriority(), name) }, enable: $root.indexingEnabled() && !_.includes($root.spinners.localPriority(), name)">
+                data-bind="css: { 'btn-spinner': _.includes($root.spinners.localPriority(), name) }, enable: $root.indexingNotPaused() && !_.includes($root.spinners.localPriority(), name)">
             <span data-bind="visible: isNormalPriority()">
                 <i class="icon-check"></i>
                 <span>Normal</span>
@@ -195,7 +195,7 @@
     <span class="properties-label">State:</span>
     <div class="btn-group properties-value">
         <button type="button" class="btn set-size dropdown-toggle" data-toggle="dropdown"
-                data-bind="css: { 'btn-spinner': _.includes($root.spinners.localState(), name) }, enable: $root.indexingEnabled() && !_.includes($root.spinners.localState(), name)">
+                data-bind="css: { 'btn-spinner': _.includes($root.spinners.localState(), name) }, enable: $root.indexingNotPaused() && !_.includes($root.spinners.localState(), name)">
             <span class="text-warning" data-bind="visible: pausedUntilRestart()">
                 <i class="icon-cancel"></i>
                 <span>Paused until restart</span>

--- a/src/Raven.Studio/wwwroot/App/views/resources/resources.html
+++ b/src/Raven.Studio/wwwroot/App/views/resources/resources.html
@@ -117,13 +117,23 @@
                                         <span class="sr-only">Toggle Dropdown</span>
                                     </button>
                                     <ul class="dropdown-menu">
-                                        <li data-bind="visible: online() && indexingEnabled()">
+                                        <li data-bind="visible: online() && (indexingNotPaused() && indexingEnable())">
                                             <a href="#" data-bind="click: $root.toggleDatabaseIndexing">
-                                                <i class="icon-pause"></i> Disable indexing
+                                                <i class="icon-pause"></i> Pause indexing
                                             </a>
                                         </li>
-                                        <li data-bind="visible: online() && !indexingEnabled()">
+                                        <li data-bind="visible: online() && !indexingNotPaused()">
                                             <a href="#" data-bind="click: $root.toggleDatabaseIndexing">
+                                                <i class="icon-play"></i> Resume indexing
+                                            </a>
+                                        </li>
+                                        <li data-bind="visible: online() && (indexingEnable() && indexingNotPaused())">
+                                            <a href="#" data-bind="click:">
+                                                <i class="icon-lock"></i> Disable indexing (coming soon)
+                                            </a>
+                                        </li>
+                                        <li data-bind="visible: online() && !indexingEnable()">
+                                            <a href="#" data-bind="click:">
                                                 <i class="icon-play"></i> Enable indexing
                                             </a>
                                         </li>
@@ -221,11 +231,19 @@
         </div>
     </div>
 
-    <div class="properties-item" data-bind="visible: !indexingEnabled()">
+    <div class="properties-item" data-bind="visible: !indexingNotPaused()">
         <div class="properties-value value-only text-warning">
             <div class="set-size">
                 <i class="icon-pause"></i>
-                <span>Indexing disabled</span>
+                <span>Indexing paused</span>
+            </div>
+        </div>
+    </div>
+    <div class="properties-item" data-bind="visible: !indexingEnable()">
+        <div class="properties-value value-only text-warning">
+            <div class="set-size">
+                <i class="icon-pause"></i>
+                <span>Indexing disable</span>
             </div>
         </div>
     </div>

--- a/src/Sparrow/Json/JsonDeserializationBase.cs
+++ b/src/Sparrow/Json/JsonDeserializationBase.cs
@@ -285,10 +285,10 @@ namespace Sparrow.Json
 
             foreach (var propertyName in obj.GetPropertyNames())
             {
-                string val;
+                object val;
                 if (obj.TryGet(propertyName, out val))
                 {
-                    dic[propertyName] = val;
+                    dic[propertyName] = val?.ToString();
                 }
             }
             return dic;


### PR DESCRIPTION
- update the disable and enable index admin endpoint to be able to disable/enable all the indexes in database/indexes/indexes.html
- Fix the databaseConfigure to be able to parse bool fields
- separate between pause indexes and disable them
- add disable indexing button in studio

**  look here http://issues.hibernatingrhinos.com/issue/RavenDB-6088