### PR TITLE
 RavenDB-5592 Added missing removal of a recycled scratch from the sc…

### DIFF
--- a/src/Voron/Impl/Scratch/ScratchBufferPool.cs
+++ b/src/Voron/Impl/Scratch/ScratchBufferPool.cs
@@ -409,7 +409,11 @@ namespace Voron.Impl.Scratch
 
                 while (_recycleArea.First != null)
                 {
-                    _recycleArea.First.Value.File.Dispose();
+                    var recycledScratch = _recycleArea.First.Value;
+
+                    ScratchBufferItem _;
+                    _scratchBuffers.TryRemove(recycledScratch.Number, out _);
+                    recycledScratch.File.Dispose();
                     _recycleArea.RemoveFirst();
                 }
             }


### PR DESCRIPTION
…ratch buffers dictionary during the cleanup (that caused ObjectDisposedException thrown in UpdateCacheForPagerStatesOfAllScratches)