### PR TITLE
RavenDB-6066 WIP (not automatically mergeable)

### DIFF
--- a/src/Raven.Server/Documents/SubscriptionStorage.cs
+++ b/src/Raven.Server/Documents/SubscriptionStorage.cs
@@ -386,6 +386,17 @@ namespace Raven.Server.Documents
             Memory.Copy(data.Address, ptr, size);
             var criteria = new BlittableJsonReaderObject(data.Address, size, context);
 
+            //registering 'criteria' is not enough for disposal since it 
+            //is constructed using the Address field (which is only a pointer),
+            //thus when disposed, BlittableJsonReaderObject won't return to context 
+            //the allocated memory
+            context.RegisterForReturnMemory(data);
+
+            //we still need to dispose 'criteria' because of the
+            //UnamangedWriteBuffer (that is used in BlittableJsonReaderObject)
+            //that needs to be disposed
+            context.RegisterForDispose(criteria); 
+
             return new DynamicJsonValue
             {
                 ["SubscriptionId"] = id,

--- a/test/FastTests/Blittable/BlittableJsonWriterTests/ManualBuilderTests.cs
+++ b/test/FastTests/Blittable/BlittableJsonWriterTests/ManualBuilderTests.cs
@@ -665,8 +665,10 @@ namespace FastTests.Blittable.BlittableJsonWriterTests
 
         [Theory]
         [InlineData(byte.MaxValue)]
+#if !MEM_GUARD
         [InlineData(short.MaxValue)]
         [InlineData(short.MaxValue + 1)]
+#endif
         public void BigAmountOfPreperties(int propertiesAmount)
         {
             using (var context = new JsonOperationContext(1024, 1024 * 4))
@@ -703,8 +705,10 @@ namespace FastTests.Blittable.BlittableJsonWriterTests
 
         [Theory]
         [InlineData(byte.MaxValue)]
+#if !MEM_GUARD
         [InlineData(short.MaxValue)]
         [InlineData(short.MaxValue + 1)]
+#endif
         public void BigDepthTest(int propertiesAmount)
         {
             using (var context = new JsonOperationContext(1024, 1024 * 4))

--- a/test/Tryouts/Program.cs
+++ b/test/Tryouts/Program.cs
@@ -9,8 +9,10 @@ using Sparrow.Platform;
 using System.Linq;
 using FastTests.Blittable;
 using FastTests.Issues;
+using FastTests.Server.Basic;
 using FastTests.Server.Documents;
 using FastTests.Server.Documents.Queries;
+using FastTests.Server.Replication;
 using FastTests.Voron.FixedSize;
 using FastTests.Voron.RawData;
 using SlowTests.Tests;
@@ -22,21 +24,13 @@ namespace Tryouts
     {
         public static void Main(string[] args)
         {
-            using (var a = new RecoveryMultipleJournals())
-                a.CorruptingOneTransactionWillThrow();
+            for (int i = 0; i < 100; i++)
+            {
+                using (var a = new ReplicationIndexesAndTransformers())
+                    a.Manually_removed_indexes_would_remove_metadata_on_startup().Wait();
 
-            using (var a = new RecoveryMultipleJournals())
-                a.CorruptingAllLastTransactionsConsideredAsEndOfJournal();
-
-            using (var a = new DocumentsCrud())
-                a.EtagsArePersistedWithDeletes();
-
-            using (var a = new LargeFixedSizeTreeBugs())
-                a.DeleteRangeShouldModifyPage();
-
-            using (var a = new RecoveryMultipleJournals())
-                a.CorruptingLastTransactionsInNotLastJournalShouldThrow();
-
+                Console.Write(".");
+            }
         }
     }
 }


### PR DESCRIPTION
* prevent leak at SubscriptionStorage::ExtractSubscriptionConfigValue()
* prevent usage of ManagedPinnedBuffer after disposal
* some minor refactorings for easier checks for memory leaks/issues
(RavenDB-6066)