### PR TITLE
RavenDB-6184

### DIFF
--- a/src/Raven.Studio/typescript/viewmodels/database/documents/editDocument.ts
+++ b/src/Raven.Studio/typescript/viewmodels/database/documents/editDocument.ts
@@ -175,7 +175,7 @@ class editDocument extends viewModelBase {
           
         this.isSaveEnabled = ko.pureComputed(() => {            
             const isSaving = this.isSaving();
-            const isDirty = this.dirtyFlag().isDirty();           
+            const isDirty = this.dirtyFlag().isDirty();
             const etag = this.metadata().etag();
 
             if (isSaving || (!isDirty && etag)) {
@@ -484,8 +484,6 @@ class editDocument extends viewModelBase {
         this.canContinueIfNotDirty("Refresh", "You have unsaved data. Are you sure you want to continue?")
         .done(() => {
             const docId = this.editedDocId();
-            this.document(null);
-            this.documentText(null);
             this.userSpecifiedId("");
             this.loadDocument(docId);
 


### PR DESCRIPTION
- refresh document after change in another scope no longer try to create null document. now the client just load it again