### PR TITLE
RavenDB-4366 Change defaults query limits

### DIFF
--- a/bench/Indexing.Benchmark/IndexingBenchmark.cs
+++ b/bench/Indexing.Benchmark/IndexingBenchmark.cs
@@ -53,7 +53,7 @@ namespace Indexing.Benchmark
                 //    } while ((result != null && result.IsStale == false) || sw.Elapsed > stalenessTimeout);
                 //}, TaskCreationOptions.LongRunning);
 
-                result = _store.DatabaseCommands.Query(test.Index.IndexName, new IndexQuery()
+                result = _store.DatabaseCommands.Query(test.Index.IndexName, new IndexQuery(_store.Conventions)
                 {
                     WaitForNonStaleResultsTimeout = stalenessTimeout,
                     PageSize = 0,

--- a/src/Raven.Client/Bundles/MoreLikeThis/MoreLikeThisExtensions.cs
+++ b/src/Raven.Client/Bundles/MoreLikeThis/MoreLikeThisExtensions.cs
@@ -15,7 +15,7 @@ namespace Raven.Client.Bundles.MoreLikeThis
         public static T[] MoreLikeThis<T, TIndexCreator>(this ISyncAdvancedSessionOperation advancedSession, string documentId) where TIndexCreator : AbstractIndexCreationTask, new()
         {
             var indexCreator = new TIndexCreator();
-            return MoreLikeThis<T>(advancedSession, indexCreator.IndexName, null, new MoreLikeThisQuery
+            return MoreLikeThis<T>(advancedSession, indexCreator.IndexName, null, new MoreLikeThisQuery(advancedSession.Conventions)
             {
                 DocumentId = documentId
             });
@@ -29,7 +29,7 @@ namespace Raven.Client.Bundles.MoreLikeThis
 
         public static T[] MoreLikeThis<T>(this ISyncAdvancedSessionOperation advancedSession, string index, string documentId)
         {
-            return MoreLikeThis<T>(advancedSession, index, null, new MoreLikeThisQuery
+            return MoreLikeThis<T>(advancedSession, index, null, new MoreLikeThisQuery(advancedSession.Conventions)
             {
                 DocumentId = documentId
             });
@@ -41,7 +41,7 @@ namespace Raven.Client.Bundles.MoreLikeThis
         {
             var indexCreator = new TIndexCreator();
             var transformer = new TTransformer();
-            return MoreLikeThis<T>(advancedSession, indexCreator.IndexName, transformer.TransformerName, new MoreLikeThisQuery
+            return MoreLikeThis<T>(advancedSession, indexCreator.IndexName, transformer.TransformerName, new MoreLikeThisQuery(advancedSession.Conventions)
             {
                 DocumentId = documentId
             });
@@ -58,7 +58,7 @@ namespace Raven.Client.Bundles.MoreLikeThis
 
         public static T[] MoreLikeThis<T>(this ISyncAdvancedSessionOperation advancedSession, string index, string transformer, string documentId)
         {
-            return MoreLikeThis<T>(advancedSession, index, transformer, new MoreLikeThisQuery
+            return MoreLikeThis<T>(advancedSession, index, transformer, new MoreLikeThisQuery(advancedSession.Conventions)
             {
                 DocumentId = documentId
             });
@@ -100,7 +100,7 @@ namespace Raven.Client.Bundles.MoreLikeThis
         public static Task<T[]> MoreLikeThisAsync<T, TIndexCreator>(this IAsyncAdvancedSessionOperations advancedSession, string documentId) where TIndexCreator : AbstractIndexCreationTask, new()
         {
             var indexCreator = new TIndexCreator();
-            return MoreLikeThisAsync<T>(advancedSession, indexCreator.IndexName, null, new MoreLikeThisQuery
+            return MoreLikeThisAsync<T>(advancedSession, indexCreator.IndexName, null, new MoreLikeThisQuery(advancedSession.Conventions)
             {
                 DocumentId = documentId
             });
@@ -114,7 +114,7 @@ namespace Raven.Client.Bundles.MoreLikeThis
 
         public static Task<T[]> MoreLikeThisAsync<T>(this IAsyncAdvancedSessionOperations advancedSession, string index, string documentId)
         {
-            return MoreLikeThisAsync<T>(advancedSession, index, null, new MoreLikeThisQuery
+            return MoreLikeThisAsync<T>(advancedSession, index, null, new MoreLikeThisQuery(advancedSession.Conventions)
             {
                 DocumentId = documentId
             });
@@ -126,7 +126,7 @@ namespace Raven.Client.Bundles.MoreLikeThis
         {
             var indexCreator = new TIndexCreator();
             var transformer = new TTransformer();
-            return MoreLikeThisAsync<T>(advancedSession, indexCreator.IndexName, transformer.TransformerName, new MoreLikeThisQuery
+            return MoreLikeThisAsync<T>(advancedSession, indexCreator.IndexName, transformer.TransformerName, new MoreLikeThisQuery(advancedSession.Conventions)
             {
                 DocumentId = documentId
             });
@@ -143,7 +143,7 @@ namespace Raven.Client.Bundles.MoreLikeThis
 
         public static Task<T[]> MoreLikeThisAsync<T>(this IAsyncAdvancedSessionOperations advancedSession, string index, string transformer, string documentId)
         {
-            return MoreLikeThisAsync<T>(advancedSession, index, transformer, new MoreLikeThisQuery
+            return MoreLikeThisAsync<T>(advancedSession, index, transformer, new MoreLikeThisQuery(advancedSession.Conventions)
             {
                 DocumentId = documentId
             });

--- a/src/Raven.Client/Connection/Async/AsyncDatabaseCommandsExtensions.cs
+++ b/src/Raven.Client/Connection/Async/AsyncDatabaseCommandsExtensions.cs
@@ -17,7 +17,7 @@ namespace Raven.Client.Connection.Async
                 .ContinueWith(task =>
                 {
                     terms = task.Result;
-                    var termRequests = terms.Select(term => new IndexQuery
+                    var termRequests = terms.Select(term => new IndexQuery(cmds.Conventions)
                     {
                         Query = field + ":" + RavenQuery.Escape(term),
                         PageSize = 0,

--- a/src/Raven.Client/Connection/Async/AsyncServerClient.cs
+++ b/src/Raven.Client/Connection/Async/AsyncServerClient.cs
@@ -2289,5 +2289,7 @@ namespace Raven.Client.Connection.Async
                 }
             }
         }
+
+        public DocumentConvention Conventions => convention;
     }
 }

--- a/src/Raven.Client/Connection/Async/IAsyncDatabaseCommands.cs
+++ b/src/Raven.Client/Connection/Async/IAsyncDatabaseCommands.cs
@@ -52,6 +52,8 @@ namespace Raven.Client.Connection.Async
         /// </summary>
         IAsyncInfoDatabaseCommands Info { get; }
 
+        DocumentConvention Conventions { get; }
+
         /// <summary>
         ///     Gets or sets the operations headers
         /// </summary>

--- a/src/Raven.Client/Connection/IRavenQueryInspector.cs
+++ b/src/Raven.Client/Connection/IRavenQueryInspector.cs
@@ -43,6 +43,8 @@ namespace Raven.Client.Connection
         /// </summary>
         InMemoryDocumentSessionOperations Session { get; }
 
+        DocumentConvention Conventions { get; }
+
         /// <summary>
         /// The last term that we asked the query to use equals on
         /// </summary>

--- a/src/Raven.Client/Data/FacetQuery.cs
+++ b/src/Raven.Client/Data/FacetQuery.cs
@@ -13,6 +13,7 @@ using Microsoft.AspNetCore.Http;
 using Microsoft.Extensions.Primitives;
 using Raven.Abstractions.Data;
 using Raven.Abstractions.Util;
+using Raven.Client.Document;
 using Raven.Imports.Newtonsoft.Json;
 using Raven.Json.Linq;
 
@@ -22,6 +23,10 @@ namespace Raven.Client.Data
     {
         private IReadOnlyList<Facet> _facets;
         private string _facetsAsJson;
+
+        public FacetQuery(DocumentConvention conventions) : base(conventions)
+        {
+        }
 
         /// <summary>
         /// Index name to run facet query on.
@@ -106,9 +111,9 @@ namespace Raven.Client.Data
             return path.ToString();
         }
 
-        public static FacetQuery Parse(IQueryCollection query, int start, int pageSize)
+        public static FacetQuery Parse(IQueryCollection query, int start, int pageSize, DocumentConvention conventions)
         {
-            var result = new FacetQuery
+            var result = new FacetQuery(conventions)
             {
                 Start = start,
                 PageSize = pageSize
@@ -145,9 +150,9 @@ namespace Raven.Client.Data
             return result;
         }
 
-        public static FacetQuery Create(string indexName, IndexQueryBase query, string facetSetupDoc, List<Facet> facets,  int start, int? pageSize)
+        public static FacetQuery Create(string indexName, IndexQueryBase query, string facetSetupDoc, List<Facet> facets,  int start, int? pageSize, DocumentConvention conventions)
         {
-            var result = new FacetQuery
+            var result = new FacetQuery(conventions)
             {
                 IndexName = indexName,
                 CutoffEtag = query.CutoffEtag,

--- a/src/Raven.Client/Data/IndexQuery.cs
+++ b/src/Raven.Client/Data/IndexQuery.cs
@@ -7,10 +7,10 @@
 using System;
 using System.Collections.Generic;
 using System.Text;
-
 using Raven.Abstractions.Data;
 using Raven.Abstractions.Extensions;
 using Raven.Abstractions.Util;
+using Raven.Client.Document;
 using Raven.Client.Indexing;
 using Raven.Json.Linq;
 
@@ -21,7 +21,9 @@ namespace Raven.Client.Data
     /// </summary>
     public class IndexQuery : IndexQuery<Dictionary<string, RavenJToken>>
     {
-        public static int DefaultPageSize = 128;
+        public IndexQuery(DocumentConvention conventions) : base(conventions)
+        {
+        }
 
         public override bool Equals(IndexQuery<Dictionary<string, RavenJToken>> other)
         {
@@ -184,6 +186,10 @@ namespace Raven.Client.Data
 
     public abstract class IndexQuery<T> : IndexQueryBase, IEquatable<IndexQuery<T>>
     {
+        protected IndexQuery(DocumentConvention conventions) : base(conventions)
+        {
+        }
+
         /// <summary>
         /// Parameters that will be passed to transformer (if specified).
         /// </summary>
@@ -332,13 +338,13 @@ namespace Raven.Client.Data
     {
         private int _pageSize;
 
-        /// <summary>
-        /// Initializes a new instance of the <see cref="IndexQueryBase"/> class.
-        /// </summary>
-        protected IndexQueryBase()
+        protected IndexQueryBase(DocumentConvention conventions)
         {
-            _pageSize = IndexQuery.DefaultPageSize;
+            Conventions = conventions;
+            _pageSize = Conventions?.ImplicitTakeAmount ?? 25;
         }
+
+        protected internal DocumentConvention Conventions { get; }
 
         /// <summary>
         /// Whatever the page size was explicitly set or still at its default value
@@ -365,10 +371,7 @@ namespace Raven.Client.Data
         /// </summary>
         public int PageSize
         {
-            get
-            {
-                return _pageSize;
-            }
+            get { return _pageSize; }
             set
             {
                 _pageSize = value;
@@ -489,6 +492,7 @@ namespace Raven.Client.Data
 
     public interface IIndexQuery
     {
+        int PageSize { set; get; }
     }
 
     public enum QueryOperator

--- a/src/Raven.Client/Data/Queries/MoreLikeThisQuery.cs
+++ b/src/Raven.Client/Data/Queries/MoreLikeThisQuery.cs
@@ -3,12 +3,17 @@ using System.Collections.Generic;
 using System.Text;
 
 using Raven.Abstractions.Data;
+using Raven.Client.Document;
 using Raven.Json.Linq;
 
 namespace Raven.Client.Data.Queries
 {
     public class MoreLikeThisQuery : MoreLikeThisQuery<Dictionary<string, RavenJToken>>
     {
+        public MoreLikeThisQuery(DocumentConvention conventions) : base(conventions)
+        {
+        }
+
         protected override void CreateRequestUri(StringBuilder uri)
         {
             base.CreateRequestUri(uri);
@@ -20,15 +25,15 @@ namespace Raven.Client.Data.Queries
     public abstract class MoreLikeThisQuery<T> : IIndexQuery
         where T : class
     {
+        public DocumentConvention Conventions { get; }
         private int _pageSize;
 
         private bool _pageSizeSet;
 
-        protected MoreLikeThisQuery()
+        protected MoreLikeThisQuery(DocumentConvention conventions)
         {
-            _pageSize = IndexQuery.DefaultPageSize;
-            _pageSizeSet = false;
-
+            Conventions = conventions;
+            _pageSize = Conventions?.ImplicitTakeAmount ?? 25;
             MapGroupFields = new Dictionary<string, string>(StringComparer.OrdinalIgnoreCase);
         }
 

--- a/src/Raven.Client/Data/SpatialIndexQuery.cs
+++ b/src/Raven.Client/Data/SpatialIndexQuery.cs
@@ -7,6 +7,7 @@ using System;
 using System.Globalization;
 using Raven.Abstractions.Indexing;
 using Raven.Client.Data;
+using Raven.Client.Document;
 
 namespace Raven.Abstractions.Data
 {
@@ -57,7 +58,7 @@ namespace Raven.Abstractions.Data
         /// Initializes a new instance of the <see cref="SpatialIndexQuery"/> class.
         /// </summary>
         /// <param name="query">The query.</param>
-        public SpatialIndexQuery(IndexQuery query) : this()
+        public SpatialIndexQuery(IndexQuery query) : this(query.Conventions)
         {
             Query = query.Query;
             Start = query.Start;
@@ -85,7 +86,7 @@ namespace Raven.Abstractions.Data
         /// <summary>
         /// Initializes a new instance of the <see cref="SpatialIndexQuery"/> class.
         /// </summary>
-        public SpatialIndexQuery()
+        public SpatialIndexQuery(DocumentConvention conventions) : base(conventions)
         {
             DistanceErrorPercentage = Constants.DefaultSpatialDistanceErrorPct;
         }

--- a/src/Raven.Client/Document/AbstractDocumentQuery.cs
+++ b/src/Raven.Client/Document/AbstractDocumentQuery.cs
@@ -265,6 +265,11 @@ namespace Raven.Client.Document
             get { return theSession; }
         }
 
+        public DocumentConvention Conventions
+        {
+            get { return conventions; }
+        }
+
         public bool IsDynamicMapReduce => dynamicMapReduceFields.Length > 0;
 
         protected Action<QueryResult> afterQueryExecutedCallback;
@@ -624,7 +629,7 @@ namespace Raven.Client.Document
         public FacetedQueryResult GetFacets(string facetSetupDoc, int facetStart, int? facetPageSize)
         {
             var q = GetIndexQuery(false);
-            var query = FacetQuery.Create(indexName, q, facetSetupDoc, null, facetStart, facetPageSize);
+            var query = FacetQuery.Create(indexName, q, facetSetupDoc, null, facetStart, facetPageSize, conventions);
 
             return DatabaseCommands.GetFacets(query);
         }
@@ -632,7 +637,7 @@ namespace Raven.Client.Document
         public FacetedQueryResult GetFacets(List<Facet> facets, int facetStart, int? facetPageSize)
         {
             var q = GetIndexQuery(false);
-            var query = FacetQuery.Create(indexName, q, null, facets, facetStart, facetPageSize);
+            var query = FacetQuery.Create(indexName, q, null, facets, facetStart, facetPageSize, conventions);
 
             return DatabaseCommands.GetFacets(query);
         }
@@ -640,7 +645,7 @@ namespace Raven.Client.Document
         public Task<FacetedQueryResult> GetFacetsAsync(string facetSetupDoc, int facetStart, int? facetPageSize, CancellationToken token = default(CancellationToken))
         {
             var q = GetIndexQuery(true);
-            var query = FacetQuery.Create(indexName, q, facetSetupDoc, null, facetStart, facetPageSize);
+            var query = FacetQuery.Create(indexName, q, facetSetupDoc, null, facetStart, facetPageSize, conventions);
 
             return AsyncDatabaseCommands.GetFacetsAsync(query, token);
         }
@@ -648,7 +653,7 @@ namespace Raven.Client.Document
         public Task<FacetedQueryResult> GetFacetsAsync(List<Facet> facets, int facetStart, int? facetPageSize, CancellationToken token = default(CancellationToken))
         {
             var q = GetIndexQuery(true);
-            var query = FacetQuery.Create(indexName, q, null, facets, facetStart, facetPageSize);
+            var query = FacetQuery.Create(indexName, q, null, facets, facetStart, facetPageSize, conventions);
 
             return AsyncDatabaseCommands.GetFacetsAsync(query, token);
         }
@@ -1857,7 +1862,7 @@ If you really want to do in memory filtering on the data returned from the query
                 if (indexName == "dynamic" || indexName.StartsWith("dynamic/"))
                     throw new NotSupportedException("Dynamic indexes do not support spatial queries. A static index, with spatial field(s), must be defined.");
 
-                var spatialQuery = new SpatialIndexQuery
+                var spatialQuery = new SpatialIndexQuery(conventions)
                 {
                     IsDistinct = isDistinct,
                     Query = query,
@@ -1895,7 +1900,7 @@ If you really want to do in memory filtering on the data returned from the query
                 return spatialQuery;
             }
 
-            var indexQuery = new IndexQuery
+            var indexQuery = new IndexQuery(conventions)
             {
                 IsDistinct = isDistinct,
                 Query = query,

--- a/src/Raven.Client/Document/Async/AsyncDocumentSession.cs
+++ b/src/Raven.Client/Document/Async/AsyncDocumentSession.cs
@@ -1081,7 +1081,7 @@ namespace Raven.Client.Document.Async
         public async Task<Operation> DeleteByIndexAsync<T>(string indexName, Expression<Func<T, bool>> expression)
         {
             var query = Query<T>(indexName).Where(expression);
-            var indexQuery = new IndexQuery()
+            var indexQuery = new IndexQuery(Conventions)
             {
                 Query = query.ToString()
             };

--- a/src/Raven.Client/Document/DocumentConvention.cs
+++ b/src/Raven.Client/Document/DocumentConvention.cs
@@ -268,6 +268,12 @@ namespace Raven.Client.Document
         public int MaxNumberOfRequestsPerSession { get; set; }
 
         /// <summary>
+        /// Gets or sets the implicit take amount (page size) that will be used for .Queries() without explicit .Take().
+        /// </summary>
+        /// <value>The max number of requests per session.</value>
+        public int ImplicitTakeAmount { get; set; } = 25;
+
+        /// <summary>
         /// Gets or sets the default max length of a query using the GET method against a server.
         /// </summary>
         public int MaxLengthOfQueryUsingGetUrl { get; set; }

--- a/src/Raven.Client/Document/DocumentSession.cs
+++ b/src/Raven.Client/Document/DocumentSession.cs
@@ -714,7 +714,7 @@ namespace Raven.Client.Document
         public Operation DeleteByIndex<T>(string indexName, Expression<Func<T, bool>> expression)
         {
             var query = Query<T>(indexName).Where(expression);
-            var indexQuery = new IndexQuery()
+            var indexQuery = new IndexQuery(Conventions)
             {
                 Query = query.ToString()
             };

--- a/src/Raven.Client/Document/SessionOperations/QueryOperation.cs
+++ b/src/Raven.Client/Document/SessionOperations/QueryOperation.cs
@@ -48,10 +48,13 @@ namespace Raven.Client.Document.SessionOperations
 
         private Stopwatch sp;
 
-        public QueryOperation(InMemoryDocumentSessionOperations sessionOperations, string indexName, IndexQuery indexQuery,
-                              string[] projectionFields, bool waitForNonStaleResults, TimeSpan? timeout,
-                              Func<IndexQuery, IEnumerable<object>, IEnumerable<object>> transformResults,
-                              bool disableEntitiesTracking)
+        public QueryOperation(InMemoryDocumentSessionOperations sessionOperations,
+            string indexName,
+            IndexQuery indexQuery,
+            string[] projectionFields, bool waitForNonStaleResults,
+            TimeSpan? timeout,
+            Func<IndexQuery, IEnumerable<object>, IEnumerable<object>> transformResults,
+            bool disableEntitiesTracking)
         {
             this.indexQuery = indexQuery;
             this.waitForNonStaleResults = waitForNonStaleResults;

--- a/src/Raven.Client/IAsyncAdvancedSessionOperations.cs
+++ b/src/Raven.Client/IAsyncAdvancedSessionOperations.cs
@@ -17,6 +17,7 @@ using Raven.Abstractions.Util;
 using Raven.Client.Connection;
 using Raven.Client.Data;
 using Raven.Client.Data.Queries;
+using Raven.Client.Document;
 using Raven.Client.Document.Batches;
 using Raven.Client.Indexes;
 using Raven.Json.Linq;
@@ -37,6 +38,8 @@ namespace Raven.Client
         ///     Access the lazy operations
         /// </summary>
         IAsyncLazySessionOperations Lazily { get; }
+
+        DocumentConvention Conventions { get; }
 
         /// <summary>
         ///     Queries the index specified by <typeparamref name="TIndexCreator" /> using lucene syntax.

--- a/src/Raven.Client/ISyncAdvancedSessionOperation.cs
+++ b/src/Raven.Client/ISyncAdvancedSessionOperation.cs
@@ -12,6 +12,7 @@ using Raven.Abstractions.Data;
 using Raven.Client.Connection;
 using Raven.Client.Data;
 using Raven.Client.Data.Queries;
+using Raven.Client.Document;
 using Raven.Client.Document.Batches;
 using Raven.Client.Indexes;
 using Raven.Json.Linq;
@@ -32,6 +33,8 @@ namespace Raven.Client
         ///     Access the lazy operations
         /// </summary>
         ILazySessionOperations Lazily { get; }
+
+        DocumentConvention Conventions { get; }
 
         /// <summary>
         ///     Queries the index specified by <typeparamref name="TIndexCreator" /> using lucene syntax.

--- a/src/Raven.Client/Linq/IRavenQueryProvider.cs
+++ b/src/Raven.Client/Linq/IRavenQueryProvider.cs
@@ -11,6 +11,7 @@ using System.Threading.Tasks;
 using Raven.Abstractions.Data;
 using Raven.Client.Data;
 using Raven.Client.Data.Queries;
+using Raven.Client.Document;
 using Raven.Json.Linq;
 
 namespace Raven.Client.Linq

--- a/src/Raven.Client/Linq/RavenQueryInspector.cs
+++ b/src/Raven.Client/Linq/RavenQueryInspector.cs
@@ -223,7 +223,7 @@ namespace Raven.Client.Linq
         public virtual FacetedQueryResult GetFacets(string facetSetupDoc, int start, int? pageSize)
         {
             var q = GetIndexQuery(false);
-            var query = FacetQuery.Create(indexName, q, facetSetupDoc, null, start, pageSize);
+            var query = FacetQuery.Create(indexName, q, facetSetupDoc, null, start, pageSize, q.Conventions);
 
             return databaseCommands.GetFacets(query);
         }
@@ -231,7 +231,7 @@ namespace Raven.Client.Linq
         public virtual FacetedQueryResult GetFacets(List<Facet> facets, int start, int? pageSize)
         {
             var q = GetIndexQuery(false);
-            var query = FacetQuery.Create(indexName, q, null, facets, start, pageSize);
+            var query = FacetQuery.Create(indexName, q, null, facets, start, pageSize, q.Conventions);
 
             return databaseCommands.GetFacets(query);
         }
@@ -239,7 +239,7 @@ namespace Raven.Client.Linq
         public virtual Task<FacetedQueryResult> GetFacetsAsync(string facetSetupDoc, int start, int? pageSize, CancellationToken token = default (CancellationToken))
         {
             var q = GetIndexQuery();
-            var query = FacetQuery.Create(indexName, q, facetSetupDoc, null, start, pageSize);
+            var query = FacetQuery.Create(indexName, q, facetSetupDoc, null, start, pageSize, q.Conventions);
 
             return asyncDatabaseCommands.GetFacetsAsync(query, token);
         }
@@ -247,7 +247,7 @@ namespace Raven.Client.Linq
         public virtual Task<FacetedQueryResult> GetFacetsAsync(List<Facet> facets, int start, int? pageSize, CancellationToken token = default (CancellationToken))
         {
             var q = GetIndexQuery();
-            var query = FacetQuery.Create(indexName, q, null, facets, start, pageSize);
+            var query = FacetQuery.Create(indexName, q, null, facets, start, pageSize, q.Conventions);
 
             return asyncDatabaseCommands.GetFacetsAsync(query, token);
         }
@@ -320,6 +320,8 @@ namespace Raven.Client.Linq
                 return session;
             }
         }
+
+        public DocumentConvention Conventions => session.Conventions;
 
         ///<summary>
         /// Get the last equality term for the query

--- a/src/Raven.Client/Linq/RavenQueryProvider.cs
+++ b/src/Raven.Client/Linq/RavenQueryProvider.cs
@@ -117,7 +117,6 @@ namespace Raven.Client.Linq
 
         public Type OriginalQueryType { get; set; }
 
-
         /// <summary>
         /// Set the fields to rename
         /// </summary>

--- a/src/Raven.Client/PublicExtensions/LinqExtensions.cs
+++ b/src/Raven.Client/PublicExtensions/LinqExtensions.cs
@@ -100,7 +100,7 @@ namespace Raven.Client
         {
             var ravenQueryInspector = (IRavenQueryInspector)queryable;
             var q = ravenQueryInspector.GetIndexQuery(false);
-            var query = FacetQuery.Create(ravenQueryInspector.IndexQueried, q, facetSetupDoc, null, start, pageSize);
+            var query = FacetQuery.Create(ravenQueryInspector.IndexQueried, q, facetSetupDoc, null, start, pageSize, ravenQueryInspector.Conventions);
 
             return query;
         }
@@ -140,7 +140,7 @@ namespace Raven.Client
 
             var ravenQueryInspector = (IRavenQueryInspector)queryable;
             var q = ravenQueryInspector.GetIndexQuery(false);
-            var query = FacetQuery.Create(ravenQueryInspector.IndexQueried, q, null, facetsList, start, pageSize);
+            var query = FacetQuery.Create(ravenQueryInspector.IndexQueried, q, null, facetsList, start, pageSize, ravenQueryInspector.Conventions);
 
             return query;
         }
@@ -188,7 +188,7 @@ namespace Raven.Client
         {
             var ravenQueryInspector = ((IRavenQueryInspector)queryable);
             var q = ravenQueryInspector.GetIndexQuery(isAsync: false);
-            var query = FacetQuery.Create(ravenQueryInspector.IndexQueried, q, facetSetupDoc, null, start, pageSize);
+            var query = FacetQuery.Create(ravenQueryInspector.IndexQueried, q, facetSetupDoc, null, start, pageSize, ravenQueryInspector.Conventions);
             var lazyOperation = new LazyFacetsOperation(query);
 
             var documentSession = ((DocumentSession)ravenQueryInspector.Session);
@@ -208,7 +208,7 @@ namespace Raven.Client
         {
             var ravenQueryInspector = ((IRavenQueryInspector)queryable);
             var q = ravenQueryInspector.GetIndexQuery(true);
-            var query = FacetQuery.Create(ravenQueryInspector.AsyncIndexQueried, q, facetSetupDoc, null, start, pageSize);
+            var query = FacetQuery.Create(ravenQueryInspector.AsyncIndexQueried, q, facetSetupDoc, null, start, pageSize, ravenQueryInspector.Conventions);
             var lazyOperation = new LazyFacetsOperation(query);
 
             var documentSession = ((AsyncDocumentSession)ravenQueryInspector.Session);
@@ -227,7 +227,7 @@ namespace Raven.Client
 
             var ravenQueryInspector = ((IRavenQueryInspector)queryable);
             var q = ravenQueryInspector.GetIndexQuery(isAsync: false);
-            var query = FacetQuery.Create(ravenQueryInspector.IndexQueried, q, null, facetsList, start, pageSize);
+            var query = FacetQuery.Create(ravenQueryInspector.IndexQueried, q, null, facetsList, start, pageSize, ravenQueryInspector.Conventions);
             var lazyOperation = new LazyFacetsOperation(query);
 
             var documentSession = ((DocumentSession)ravenQueryInspector.Session);
@@ -245,7 +245,7 @@ namespace Raven.Client
         {
             var indexQuery = query.GetIndexQuery(isAsync: false);
             var documentQuery = ((DocumentQuery<T>)query);
-            var facetQuery = FacetQuery.Create(documentQuery.IndexQueried, indexQuery, facetSetupDoc, null, start, pageSize);
+            var facetQuery = FacetQuery.Create(documentQuery.IndexQueried, indexQuery, facetSetupDoc, null, start, pageSize, documentQuery.Conventions);
             var lazyOperation = new LazyFacetsOperation(facetQuery);
 
             var documentSession = ((DocumentSession)documentQuery.Session);
@@ -268,7 +268,7 @@ namespace Raven.Client
 
             var indexQuery = query.GetIndexQuery(isAsync: false);
             var documentQuery = (DocumentQuery<T>)query;
-            var facetQuery = FacetQuery.Create(documentQuery.IndexQueried, indexQuery, null, facetsList, start, pageSize);
+            var facetQuery = FacetQuery.Create(documentQuery.IndexQueried, indexQuery, null, facetsList, start, pageSize, documentQuery.Conventions);
             var lazyOperation = new LazyFacetsOperation(facetQuery);
 
             var documentSession = ((DocumentSession)documentQuery.Session);

--- a/src/Raven.Client/Shard/AsyncShardedDocumentSession.cs
+++ b/src/Raven.Client/Shard/AsyncShardedDocumentSession.cs
@@ -845,7 +845,7 @@ namespace Raven.Client.Shard
             }, (dbCmd, i) =>
             {
                 var query = QueryInternal<T>(dbCmd, indexName).Where(expression);
-                var indexQuery = new IndexQuery()
+                var indexQuery = new IndexQuery(Conventions)
                 {
                     Query = query.ToString()
                 };

--- a/src/Raven.Client/Shard/ShardedDocumentSession.cs
+++ b/src/Raven.Client/Shard/ShardedDocumentSession.cs
@@ -975,7 +975,7 @@ namespace Raven.Client.Shard
         public Operation DeleteByIndex<T>(string indexName, Expression<Func<T, bool>> expression)
         {
             var query = Query<T>(indexName).Where(expression);
-            var indexQuery = new IndexQuery()
+            var indexQuery = new IndexQuery(Conventions)
             {
                 Query = query.ToString()
             };

--- a/src/Raven.Client/Shard/ShardedRavenQueryInspector.cs
+++ b/src/Raven.Client/Shard/ShardedRavenQueryInspector.cs
@@ -37,7 +37,7 @@ namespace Raven.Client.Shard
                 Query = indexQuery
             }, (commands, i) =>
             {
-                var query = FacetQuery.Create(IndexQueried, indexQuery, facetSetupDoc, null, start, pageSize);
+                var query = FacetQuery.Create(IndexQueried, indexQuery, facetSetupDoc, null, start, pageSize, shardStrategy.Conventions);
                 return commands.GetFacets(query);
             });
 
@@ -54,7 +54,7 @@ namespace Raven.Client.Shard
                 Query = indexQuery
             }, (commands, i) =>
             {
-                var query = FacetQuery.Create(IndexQueried, indexQuery, null, facets, start, pageSize);
+                var query = FacetQuery.Create(IndexQueried, indexQuery, null, facets, start, pageSize, shardStrategy.Conventions);
                 return commands.GetFacets(query);
             });
 
@@ -71,7 +71,7 @@ namespace Raven.Client.Shard
                 Query = indexQuery
             }, (commands, i) =>
             {
-                var query = FacetQuery.Create(AsyncIndexQueried, indexQuery, null, facets, start, pageSize);
+                var query = FacetQuery.Create(AsyncIndexQueried, indexQuery, null, facets, start, pageSize, shardStrategy.Conventions);
                 return commands.GetFacetsAsync(query, token);
             }).ConfigureAwait(false);
         
@@ -88,7 +88,7 @@ namespace Raven.Client.Shard
                 Query = indexQuery
             }, (commands, i) =>
             {
-                var query = FacetQuery.Create(AsyncIndexQueried, indexQuery, facetSetupDoc, null, start, pageSize);
+                var query = FacetQuery.Create(AsyncIndexQueried, indexQuery, facetSetupDoc, null, start, pageSize, shardStrategy.Conventions);
                 return commands.GetFacetsAsync(query, token);
             }).ConfigureAwait(false);
 

--- a/src/Raven.NewClient/Data/FacetQuery.cs
+++ b/src/Raven.NewClient/Data/FacetQuery.cs
@@ -15,6 +15,7 @@ using Microsoft.Extensions.Primitives;
 #endif
 using Raven.NewClient.Abstractions.Data;
 using Raven.NewClient.Abstractions.Util;
+using Raven.NewClient.Client.Document;
 using Sparrow.Json.Parsing;
 
 
@@ -24,6 +25,10 @@ namespace Raven.NewClient.Client.Data
     {
         private IReadOnlyList<Facet> _facets;
         private DynamicJsonArray _facetsAsDynamicJsonArray;
+
+        public FacetQuery(DocumentConvention conventions) : base(conventions)
+        {
+        }
 
         /// <summary>
         /// Index name to run facet query on.
@@ -71,8 +76,7 @@ namespace Raven.NewClient.Client.Data
             if (Start != 0)
                 path.Append("&start=").Append(Start);
 
-            if (PageSizeSet)
-                path.Append("&pageSize=").Append(PageSize);
+            path.Append("&pageSize=").Append(PageSize);
 
             if (string.IsNullOrEmpty(Query) == false)
                 path.Append("&query=").Append(EscapingHelper.EscapeLongDataString(Query));
@@ -109,9 +113,9 @@ namespace Raven.NewClient.Client.Data
         }
 
 #if !NET46
-        public static FacetQuery Parse(IQueryCollection query, int start, int pageSize)
+        public static FacetQuery Parse(IQueryCollection query, int start, int pageSize, DocumentConvention conventions)
         {
-            var result = new FacetQuery
+            var result = new FacetQuery(conventions)
             {
                 Start = start,
                 PageSize = pageSize
@@ -149,9 +153,9 @@ namespace Raven.NewClient.Client.Data
         }
 #endif
 
-        public static FacetQuery Create(string indexName, IndexQueryBase query, string facetSetupDoc, List<Facet> facets,  int start, int? pageSize)
+        public static FacetQuery Create(string indexName, IndexQueryBase query, string facetSetupDoc, List<Facet> facets,  int start, int? pageSize, DocumentConvention conventions)
         {
-            var result = new FacetQuery
+            var result = new FacetQuery(conventions)
             {
                 IndexName = indexName,
                 CutoffEtag = query.CutoffEtag,

--- a/src/Raven.NewClient/Data/SpatialIndexQuery.cs
+++ b/src/Raven.NewClient/Data/SpatialIndexQuery.cs
@@ -8,6 +8,7 @@ using System.Globalization;
 using Raven.NewClient.Abstractions.Data;
 using Raven.NewClient.Abstractions.Indexing;
 using Raven.NewClient.Client.Data;
+using Raven.NewClient.Client.Document;
 
 namespace Raven.NewClient.Abstractions.Data
 {
@@ -58,7 +59,7 @@ namespace Raven.NewClient.Abstractions.Data
         /// Initializes a new instance of the <see cref="SpatialIndexQuery"/> class.
         /// </summary>
         /// <param name="query">The query.</param>
-        public SpatialIndexQuery(IndexQuery query) : this()
+        public SpatialIndexQuery(IndexQuery query) : this(query.Conventions)
         {
             Query = query.Query;
             Start = query.Start;
@@ -86,7 +87,7 @@ namespace Raven.NewClient.Abstractions.Data
         /// <summary>
         /// Initializes a new instance of the <see cref="SpatialIndexQuery"/> class.
         /// </summary>
-        public SpatialIndexQuery()
+        public SpatialIndexQuery(DocumentConvention conventions) : base(conventions)
         {
             DistanceErrorPercentage = Constants.DefaultSpatialDistanceErrorPct;
         }

--- a/src/Raven.NewClient/Document/AbstractDocumentQuery.cs
+++ b/src/Raven.NewClient/Document/AbstractDocumentQuery.cs
@@ -229,6 +229,8 @@ namespace Raven.NewClient.Client.Document
             get { return theSession; }
         }
 
+        public DocumentConvention Conventions => conventions;
+
         public bool IsDynamicMapReduce => dynamicMapReduceFields.Length > 0;
 
         protected Action<QueryResult> afterQueryExecutedCallback;
@@ -569,7 +571,7 @@ namespace Raven.NewClient.Client.Document
         public FacetedQueryResult GetFacets(string facetSetupDoc, int facetStart, int? facetPageSize)
         {
             var q = GetIndexQuery(false);
-            var query = FacetQuery.Create(indexName, q, facetSetupDoc, null, facetStart, facetPageSize);
+            var query = FacetQuery.Create(indexName, q, facetSetupDoc, null, facetStart, facetPageSize, q.Conventions);
 
             var command = new GetFacetsCommand()
             {
@@ -583,7 +585,7 @@ namespace Raven.NewClient.Client.Document
         public FacetedQueryResult GetFacets(List<Facet> facets, int facetStart, int? facetPageSize)
         {
             var q = GetIndexQuery(false);
-            var query = FacetQuery.Create(indexName, q, null, facets, facetStart, facetPageSize);
+            var query = FacetQuery.Create(indexName, q, null, facets, facetStart, facetPageSize, q.Conventions);
 
             var command = new GetFacetsCommand()
             {
@@ -597,7 +599,7 @@ namespace Raven.NewClient.Client.Document
         public async Task<FacetedQueryResult> GetFacetsAsync(string facetSetupDoc, int facetStart, int? facetPageSize, CancellationToken token = default(CancellationToken))
         {
             var q = GetIndexQuery(true);
-            var query = FacetQuery.Create(indexName, q, facetSetupDoc, null, facetStart, facetPageSize);
+            var query = FacetQuery.Create(indexName, q, facetSetupDoc, null, facetStart, facetPageSize, q.Conventions);
 
             var command = new GetFacetsCommand()
             {
@@ -611,7 +613,7 @@ namespace Raven.NewClient.Client.Document
         public async Task<FacetedQueryResult> GetFacetsAsync(List<Facet> facets, int facetStart, int? facetPageSize, CancellationToken token = default(CancellationToken))
         {
             var q = GetIndexQuery(true);
-            var query = FacetQuery.Create(indexName, q, null, facets, facetStart, facetPageSize);
+            var query = FacetQuery.Create(indexName, q, null, facets, facetStart, facetPageSize, q.Conventions);
 
             var command = new GetFacetsCommand()
             {
@@ -1752,7 +1754,7 @@ If you really want to do in memory filtering on the data returned from the query
                 if (indexName == "dynamic" || indexName.StartsWith("dynamic/"))
                     throw new NotSupportedException("Dynamic indexes do not support spatial queries. A static index, with spatial field(s), must be defined.");
 
-                var spatialQuery = new SpatialIndexQuery
+                var spatialQuery = new SpatialIndexQuery(conventions)
                 {
                     IsDistinct = isDistinct,
                     Query = query,
@@ -1790,7 +1792,7 @@ If you really want to do in memory filtering on the data returned from the query
                 return spatialQuery;
             }
 
-            var indexQuery = new IndexQuery
+            var indexQuery = new IndexQuery(conventions)
             {
                 IsDistinct = isDistinct,
                 Query = query,

--- a/src/Raven.NewClient/Document/Async/AsyncDocumentSession.MoreLikeThis.cs
+++ b/src/Raven.NewClient/Document/Async/AsyncDocumentSession.MoreLikeThis.cs
@@ -23,7 +23,7 @@ namespace Raven.NewClient.Client.Document.Async
                 throw new ArgumentNullException(nameof(documentId));
 
             var index = new TIndexCreator();
-            return MoreLikeThisAsync<T>(new MoreLikeThisQuery { IndexName = index.IndexName, DocumentId = documentId });
+            return MoreLikeThisAsync<T>(new MoreLikeThisQuery(Conventions) {IndexName = index.IndexName, DocumentId = documentId});
         }
 
         public Task<List<T>> MoreLikeThisAsync<T, TIndexCreator>(MoreLikeThisQuery query) where TIndexCreator : AbstractIndexCreationTask, new()
@@ -44,7 +44,7 @@ namespace Raven.NewClient.Client.Document.Async
             var index = new TIndexCreator();
             var transformer = new TTransformer();
 
-            return MoreLikeThisAsync<T>(new MoreLikeThisQuery
+            return MoreLikeThisAsync<T>(new MoreLikeThisQuery(Conventions)
             {
                 IndexName = index.IndexName,
                 Transformer = transformer.TransformerName,
@@ -68,7 +68,7 @@ namespace Raven.NewClient.Client.Document.Async
 
         public Task<List<T>> MoreLikeThisAsync<T>(string index, string documentId, string transformer = null, Dictionary<string, object> transformerParameters = null)
         {
-            return MoreLikeThisAsync<T>(new MoreLikeThisQuery
+            return MoreLikeThisAsync<T>(new MoreLikeThisQuery(Conventions)
             {
                 IndexName = index,
                 DocumentId = documentId,

--- a/src/Raven.NewClient/Document/Async/AsyncDocumentSession.cs
+++ b/src/Raven.NewClient/Document/Async/AsyncDocumentSession.cs
@@ -100,7 +100,7 @@ namespace Raven.NewClient.Client.Document.Async
         public async Task<Operation> DeleteByIndexAsync<T>(string indexName, Expression<Func<T, bool>> expression)
         {
             var query = Query<T>(indexName).Where(expression);
-            var indexQuery = new IndexQuery
+            var indexQuery = new IndexQuery(Conventions)
             {
                 Query = query.ToString()
             };

--- a/src/Raven.NewClient/Document/AsyncDocumentQuery.cs
+++ b/src/Raven.NewClient/Document/AsyncDocumentQuery.cs
@@ -796,7 +796,7 @@ namespace Raven.NewClient.Client.Document
         {
             if (queryOperation == null)
             {
-               Take(0);
+                Take(0);
                 queryOperation = InitializeQueryOperation();
             }
 

--- a/src/Raven.NewClient/Document/Batches/ILazyOperation.cs
+++ b/src/Raven.NewClient/Document/Batches/ILazyOperation.cs
@@ -1,9 +1,5 @@
-using System;
-using Raven.NewClient.Abstractions.Data;
 using Raven.NewClient.Client.Data;
 using Raven.NewClient.Client.Data.Queries;
-using Raven.NewClient.Client.Shard;
-using Sparrow.Json;
 
 namespace Raven.NewClient.Client.Document.Batches
 {

--- a/src/Raven.NewClient/Document/Batches/LazyMoreLikeThisOperation.cs
+++ b/src/Raven.NewClient/Document/Batches/LazyMoreLikeThisOperation.cs
@@ -27,7 +27,7 @@ namespace Raven.NewClient.Client.Document.Batches
         {
             var uri = _query.GetRequestUri();
             var separator = uri.IndexOf('?');
-            return new GetRequest()
+            return new GetRequest
             {
                 Url = uri.Substring(0, separator),
                 Query = uri.Substring(separator, uri.Length - separator - 1)

--- a/src/Raven.NewClient/Document/DocumentConvention.cs
+++ b/src/Raven.NewClient/Document/DocumentConvention.cs
@@ -105,7 +105,7 @@ namespace Raven.NewClient.Client.Document
             {
                 serializer.Binder = new ClientSerializationBinder();
             };
-            FindIdValuePartForValueTypeConversion = (entity, id) => id.Split(new[] { IdentityPartsSeparator }, StringSplitOptions.RemoveEmptyEntries).Last();
+            FindIdValuePartForValueTypeConversion = (entity, id) => id.Split(new[] {IdentityPartsSeparator}, StringSplitOptions.RemoveEmptyEntries).Last();
             ShouldAggressiveCacheTrackChanges = true;
             ShouldSaveChangesForceAggressiveCacheCheck = true;
             IndexAndTransformerReplicationMode = IndexAndTransformerReplicationMode.Indexes | IndexAndTransformerReplicationMode.Transformers;
@@ -113,11 +113,11 @@ namespace Raven.NewClient.Client.Document
             RequestTimeThresholdInMilliseconds = 100;
 
             SerializeEntityToJsonStream = (entity, streamWriter) =>
-           {
-               var jsonSerializer = CreateSerializer();
-               jsonSerializer.Serialize(streamWriter, entity);
-               streamWriter.Flush();
-           };
+            {
+                var jsonSerializer = CreateSerializer();
+                jsonSerializer.Serialize(streamWriter, entity);
+                streamWriter.Flush();
+            };
 
             DeserializeEntityFromBlittable = new JsonNetBlittableEntitySerializer(this).EntityFromJsonStream;
         }
@@ -266,6 +266,12 @@ namespace Raven.NewClient.Client.Document
         /// </summary>
         /// <value>The max number of requests per session.</value>
         public int MaxNumberOfRequestsPerSession { get; set; }
+
+        /// <summary>
+        /// Gets or sets the implicit take amount (page size) that will be used for .Queries() without explicit .Take().
+        /// </summary>
+        /// <value>The max number of requests per session.</value>
+        public int ImplicitTakeAmount { get; set; } = 25;
 
         /// <summary>
         /// Gets or sets the default max length of a query using the GET method against a server.

--- a/src/Raven.NewClient/Document/DocumentSession.MoreLikeThis.cs
+++ b/src/Raven.NewClient/Document/DocumentSession.MoreLikeThis.cs
@@ -23,7 +23,7 @@ namespace Raven.NewClient.Client.Document
                 throw new ArgumentNullException(nameof(documentId));
 
             var index = new TIndexCreator();
-            return MoreLikeThis<T>(new MoreLikeThisQuery { IndexName = index.IndexName, DocumentId = documentId });
+            return MoreLikeThis<T>(new MoreLikeThisQuery(Conventions) { IndexName = index.IndexName, DocumentId = documentId });
         }
 
         public List<T> MoreLikeThis<T, TIndexCreator>(MoreLikeThisQuery query) where TIndexCreator : AbstractIndexCreationTask, new()
@@ -44,7 +44,7 @@ namespace Raven.NewClient.Client.Document
             var index = new TIndexCreator();
             var transformer = new TTransformer();
 
-            return MoreLikeThis<T>(new MoreLikeThisQuery
+            return MoreLikeThis<T>(new MoreLikeThisQuery(Conventions)
             {
                 IndexName = index.IndexName,
                 Transformer = transformer.TransformerName,
@@ -68,7 +68,7 @@ namespace Raven.NewClient.Client.Document
 
         public List<T> MoreLikeThis<T>(string index, string documentId, string transformer = null, Dictionary<string, object> transformerParameters = null)
         {
-            return MoreLikeThis<T>(new MoreLikeThisQuery
+            return MoreLikeThis<T>(new MoreLikeThisQuery(Conventions)
             {
                 IndexName = index,
                 DocumentId = documentId,

--- a/src/Raven.NewClient/Document/DocumentSession.cs
+++ b/src/Raven.NewClient/Document/DocumentSession.cs
@@ -72,7 +72,7 @@ namespace Raven.NewClient.Client.Document
         public Operation DeleteByIndex<T>(string indexName, Expression<Func<T, bool>> expression)
         {
             var query = Query<T>(indexName).Where(expression);
-            var indexQuery = new IndexQuery
+            var indexQuery = new IndexQuery(Conventions)
             {
                 Query = query.ToString()
             };

--- a/src/Raven.NewClient/Linq/RavenQueryInspector.cs
+++ b/src/Raven.NewClient/Linq/RavenQueryInspector.cs
@@ -220,7 +220,7 @@ namespace Raven.NewClient.Client.Linq
         public virtual FacetedQueryResult GetFacets(string facetSetupDoc, int start, int? pageSize)
         {
             var q = GetIndexQuery(false);
-            var query = FacetQuery.Create(indexName, q, facetSetupDoc, null, start, pageSize);
+            var query = FacetQuery.Create(indexName, q, facetSetupDoc, null, start, pageSize, q.Conventions);
 
             var command = new GetFacetsCommand()
             {
@@ -233,7 +233,7 @@ namespace Raven.NewClient.Client.Linq
         public virtual FacetedQueryResult GetFacets(List<Facet> facets, int start, int? pageSize)
         {
             var q = GetIndexQuery(false);
-            var query = FacetQuery.Create(indexName, q, null, facets, start, pageSize);
+            var query = FacetQuery.Create(indexName, q, null, facets, start, pageSize, q.Conventions);
             var command = new GetFacetsCommand()
             {
                 Query = query,
@@ -246,7 +246,7 @@ namespace Raven.NewClient.Client.Linq
         public virtual async Task<FacetedQueryResult> GetFacetsAsync(string facetSetupDoc, int start, int? pageSize, CancellationToken token = default (CancellationToken))
         {
             var q = GetIndexQuery();
-            var query = FacetQuery.Create(indexName, q, facetSetupDoc, null, start, pageSize);
+            var query = FacetQuery.Create(indexName, q, facetSetupDoc, null, start, pageSize, q.Conventions);
 
             var command = new GetFacetsCommand()
             {
@@ -260,7 +260,7 @@ namespace Raven.NewClient.Client.Linq
         public virtual async Task<FacetedQueryResult> GetFacetsAsync(List<Facet> facets, int start, int? pageSize, CancellationToken token = default (CancellationToken))
         {
             var q = GetIndexQuery();
-            var query = FacetQuery.Create(indexName, q, null, facets, start, pageSize);
+            var query = FacetQuery.Create(indexName, q, null, facets, start, pageSize, q.Conventions);
 
             var command = new GetFacetsCommand()
             {

--- a/src/Raven.NewClient/PublicExtensions/LinqExtensions.cs
+++ b/src/Raven.NewClient/PublicExtensions/LinqExtensions.cs
@@ -101,7 +101,7 @@ namespace Raven.NewClient.Client
         {
             var ravenQueryInspector = (IRavenQueryInspector)queryable;
             var q = ravenQueryInspector.GetIndexQuery(false);
-            var query = FacetQuery.Create(ravenQueryInspector.IndexQueried, q, facetSetupDoc, null, start, pageSize);
+            var query = FacetQuery.Create(ravenQueryInspector.IndexQueried, q, facetSetupDoc, null, start, pageSize, q.Conventions);
 
             return query;
         }
@@ -120,7 +120,7 @@ namespace Raven.NewClient.Client
             if (!facetsList.Any())
                 throw new ArgumentException("Facets must contain at least one entry", "facets");
 
-            var ravenQueryInspector = ((IRavenQueryInspector)queryable);
+            var ravenQueryInspector = (IRavenQueryInspector)queryable;
 
             return ravenQueryInspector.GetFacets(facetsList, start, pageSize);
         }
@@ -141,7 +141,7 @@ namespace Raven.NewClient.Client
 
             var ravenQueryInspector = (IRavenQueryInspector)queryable;
             var q = ravenQueryInspector.GetIndexQuery(false);
-            var query = FacetQuery.Create(ravenQueryInspector.IndexQueried, q, null, facetsList, start, pageSize);
+            var query = FacetQuery.Create(ravenQueryInspector.IndexQueried, q, null, facetsList, start, pageSize, q.Conventions);
 
             return query;
         }
@@ -189,7 +189,7 @@ namespace Raven.NewClient.Client
         {
             var ravenQueryInspector = ((IRavenQueryInspector)queryable);
             var q = ravenQueryInspector.GetIndexQuery(isAsync: false);
-            var query = FacetQuery.Create(ravenQueryInspector.IndexQueried, q, facetSetupDoc, null, start, pageSize);
+            var query = FacetQuery.Create(ravenQueryInspector.IndexQueried, q, facetSetupDoc, null, start, pageSize, q.Conventions);
             var lazyOperation = new LazyFacetsOperation(query);
 
             var documentSession = ((DocumentSession)ravenQueryInspector.Session);
@@ -209,7 +209,7 @@ namespace Raven.NewClient.Client
         {
             var ravenQueryInspector = ((IRavenQueryInspector)queryable);
             var q = ravenQueryInspector.GetIndexQuery(true);
-            var query = FacetQuery.Create(ravenQueryInspector.AsyncIndexQueried, q, facetSetupDoc, null, start, pageSize);
+            var query = FacetQuery.Create(ravenQueryInspector.AsyncIndexQueried, q, facetSetupDoc, null, start, pageSize, q.Conventions);
             var lazyOperation = new LazyFacetsOperation(query);
 
             var documentSession = ((AsyncDocumentSession)ravenQueryInspector.Session);
@@ -228,7 +228,7 @@ namespace Raven.NewClient.Client
 
             var ravenQueryInspector = ((IRavenQueryInspector)queryable);
             var q = ravenQueryInspector.GetIndexQuery(isAsync: false);
-            var query = FacetQuery.Create(ravenQueryInspector.IndexQueried, q, null, facetsList, start, pageSize);
+            var query = FacetQuery.Create(ravenQueryInspector.IndexQueried, q, null, facetsList, start, pageSize, q.Conventions);
             var lazyOperation = new LazyFacetsOperation(query);
 
             var documentSession = ((DocumentSession)ravenQueryInspector.Session);
@@ -246,7 +246,7 @@ namespace Raven.NewClient.Client
         {
             var indexQuery = query.GetIndexQuery(isAsync: false);
             var documentQuery = ((DocumentQuery<T>)query);
-            var facetQuery = FacetQuery.Create(documentQuery.IndexQueried, indexQuery, facetSetupDoc, null, start, pageSize);
+            var facetQuery = FacetQuery.Create(documentQuery.IndexQueried, indexQuery, facetSetupDoc, null, start, pageSize, documentQuery.Conventions);
             var lazyOperation = new LazyFacetsOperation(facetQuery);
 
             var documentSession = ((DocumentSession)documentQuery.Session);
@@ -269,7 +269,7 @@ namespace Raven.NewClient.Client
 
             var indexQuery = query.GetIndexQuery(isAsync: false);
             var documentQuery = (DocumentQuery<T>)query;
-            var facetQuery = FacetQuery.Create(documentQuery.IndexQueried, indexQuery, null, facetsList, start, pageSize);
+            var facetQuery = FacetQuery.Create(documentQuery.IndexQueried, indexQuery, null, facetsList, start, pageSize, documentQuery.Conventions);
             var lazyOperation = new LazyFacetsOperation(facetQuery);
 
             var documentSession = ((DocumentSession)documentQuery.Session);

--- a/src/Raven.Server/Documents/Handlers/QueriesHandler.cs
+++ b/src/Raven.Server/Documents/Handlers/QueriesHandler.cs
@@ -91,7 +91,7 @@ namespace Raven.Server.Documents.Handlers
 
         private async Task FacetedQuery(DocumentsOperationContext context, string indexName, OperationCancelToken token)
         {
-            var query = FacetQuery.Parse(HttpContext.Request.Query, GetStart(), GetPageSize(Database.Configuration.Core.MaxPageSize));
+            var query = FacetQuery.Parse(HttpContext.Request.Query, GetStart(), GetPageSize(Database.Configuration.Core.MaxPageSize), null);
 
             var existingResultEtag = GetLongFromHeaders("If-None-Match");
             long? facetsEtag = null;

--- a/src/Raven.Server/Documents/Queries/IndexQueryServerSide.cs
+++ b/src/Raven.Server/Documents/Queries/IndexQueryServerSide.cs
@@ -7,6 +7,7 @@ using Raven.Abstractions.Data;
 using Raven.Abstractions.Indexing;
 using Raven.Abstractions.Util;
 using Raven.Client.Data;
+using Raven.Client.Document;
 using Raven.Client.Indexing;
 using Raven.Server.Web;
 using Sparrow.Json;
@@ -18,6 +19,10 @@ namespace Raven.Server.Documents.Queries
 {
     public class IndexQueryServerSide : IndexQuery<BlittableJsonReaderObject>
     {
+        public IndexQueryServerSide() : base(null)
+        {
+        }
+
         public static IndexQueryServerSide Create(HttpContext httpContext, int start, int pageSize, JsonOperationContext context)
         {
             var result = new IndexQueryServerSide

--- a/src/Raven.Server/Documents/Queries/MoreLikeThis/MoreLikeThisQueryServerSide.cs
+++ b/src/Raven.Server/Documents/Queries/MoreLikeThis/MoreLikeThisQueryServerSide.cs
@@ -11,6 +11,10 @@ namespace Raven.Server.Documents.Queries.MoreLikeThis
 {
     public class MoreLikeThisQueryServerSide : MoreLikeThisQuery<BlittableJsonReaderObject>
     {
+        public MoreLikeThisQueryServerSide() : base(null)
+        {
+        }
+
         public static MoreLikeThisQueryServerSide Create(HttpContext httpContext, int pageSize, JsonOperationContext context)
         {
             var result = new MoreLikeThisQueryServerSide

--- a/src/Raven.Server/Web/RequestHandler.cs
+++ b/src/Raven.Server/Web/RequestHandler.cs
@@ -127,9 +127,24 @@ namespace Raven.Server.Web
             return GetIntValueQueryString(StartParameter, required: false) ?? defaultValue;
         }
 
-        protected int GetPageSize(int defaultValue = 25)
+        protected int GetPageSize(int maxPageSize)
         {
-            return GetIntValueQueryString(PageSizeParameter, required: false) ?? defaultValue;
+            var pageSize = GetIntValueQueryString(PageSizeParameter, required: false);
+            if (pageSize.HasValue == false)
+                return maxPageSize;
+
+            if (pageSize.Value > maxPageSize)
+            {
+                var message = $"Your page size ({pageSize}) is more than the max page size which is {maxPageSize}.";
+                if (RouteMatch.Url.StartsWith("/admin/", StringComparison.OrdinalIgnoreCase) == false)
+                {
+                    message += $"{Environment.NewLine}You can use the streaming feature in order to get all of the results of a query in a performant way. " +
+                               $"See the use of session.Advanced.Stream(query) in the client API for more details.";
+                }
+                throw new InvalidOperationException(message);
+            }
+
+            return pageSize.Value;
         }
 
         protected int? GetIntValueQueryString(string name, bool required = true)

--- a/src/Raven.Server/project.json
+++ b/src/Raven.Server/project.json
@@ -82,5 +82,5 @@
     "ubuntu.16.04-x64": {}
   },
 
-  "userSecretsId": "aspnet5-Raven.Server-20160308043041",
+  "userSecretsId": "aspnet5-Raven.Server-20160308043041"
 }

--- a/src/Voron/Impl/PagePosition.cs
+++ b/src/Voron/Impl/PagePosition.cs
@@ -20,7 +20,7 @@ namespace Voron.Impl
             if (x == y) return true;
             if (x == null || y == null) return false;
 
-            return x.ScratchPos == y.ScratchPos && x.TransactionId == y.TransactionId && x.JournalNumber == y.JournalNumber && x.IsFreedPageMarker == y.IsFreedPageMarker && x.ScratchNumber == y.ScratchNumber; ;
+            return x.ScratchPos == y.ScratchPos && x.TransactionId == y.TransactionId && x.JournalNumber == y.JournalNumber && x.IsFreedPageMarker == y.IsFreedPageMarker && x.ScratchNumber == y.ScratchNumber;
         }
 
         [MethodImpl(MethodImplOptions.AggressiveInlining)]

--- a/test/ClientFastTests/DeleteByIndexTests.cs
+++ b/test/ClientFastTests/DeleteByIndexTests.cs
@@ -43,7 +43,7 @@ namespace NewClientTests.NewClient.Client.Indexing
                 JsonOperationContext context;
                 store.GetRequestExecuter(store.DefaultDatabase).ContextPool.AllocateOperationContext(out context);
 
-                var operation = store.Operations.Send(new DeleteByIndexOperation(indexName, new IndexQuery(), new QueryOperationOptions { AllowStale = false }));
+                var operation = store.Operations.Send(new DeleteByIndexOperation(indexName, new IndexQuery(store.Conventions), new QueryOperationOptions { AllowStale = false }));
 
                 operation.WaitForCompletion(TimeSpan.FromSeconds(60));
 
@@ -81,7 +81,7 @@ namespace NewClientTests.NewClient.Client.Indexing
                 JsonOperationContext context;
                 store.GetRequestExecuter(store.DefaultDatabase).ContextPool.AllocateOperationContext(out context);
 
-                var operation = await store.Operations.SendAsync(new DeleteByIndexOperation(indexName, new IndexQuery(), new QueryOperationOptions { AllowStale = false }));
+                var operation = await store.Operations.SendAsync(new DeleteByIndexOperation(indexName, new IndexQuery(store.Conventions), new QueryOperationOptions { AllowStale = false }));
 
                 await operation.WaitForCompletionAsync(TimeSpan.FromSeconds(60));
 

--- a/test/ClientFastTests/MoreLikeThis/MoreLikeThisTests.cs
+++ b/test/ClientFastTests/MoreLikeThis/MoreLikeThisTests.cs
@@ -115,7 +115,7 @@ namespace NewClientTests.NewClient
 
             using (var session = _store.OpenSession())
             {
-                var list = session.Advanced.MoreLikeThis<Transformer1, Transformer1.Result, DataIndex>(new MoreLikeThisQuery
+                var list = session.Advanced.MoreLikeThis<Transformer1, Transformer1.Result, DataIndex>(new MoreLikeThisQuery(_store.Conventions)
                 {
                     DocumentId = id,
                     Fields = new[] { "Body" }
@@ -152,7 +152,7 @@ namespace NewClientTests.NewClient
 
             using (var session = _store.OpenSession())
             {
-                var list = session.Advanced.MoreLikeThis<Transformer2, Transformer2.Result, DataIndex>(new MoreLikeThisQuery
+                var list = session.Advanced.MoreLikeThis<Transformer2, Transformer2.Result, DataIndex>(new MoreLikeThisQuery(_store.Conventions)
                 {
                     DocumentId = id,
                     Fields = new[] { "Body" }
@@ -196,7 +196,7 @@ namespace NewClientTests.NewClient
 
             using (var session = _store.OpenSession())
             {
-                var list = session.Advanced.MoreLikeThis<Data, DataIndex>(new MoreLikeThisQuery
+                var list = session.Advanced.MoreLikeThis<Data, DataIndex>(new MoreLikeThisQuery(_store.Conventions)
                 {
                     DocumentId = id,
                     Fields = new[] { "Body" },
@@ -362,7 +362,7 @@ namespace NewClientTests.NewClient
 
             using (var session = _store.OpenSession())
             {
-                var list = session.Advanced.MoreLikeThis<Data, DataIndex>(new MoreLikeThisQuery
+                var list = session.Advanced.MoreLikeThis<Data, DataIndex>(new MoreLikeThisQuery(_store.Conventions)
                 {
                     DocumentId = key,
                     Fields = new[] { "Body" }
@@ -493,7 +493,7 @@ namespace NewClientTests.NewClient
 
             using (var session = _store.OpenSession())
             {
-                var list = session.Advanced.MoreLikeThis<Data, DataIndex>(new MoreLikeThisQuery
+                var list = session.Advanced.MoreLikeThis<Data, DataIndex>(new MoreLikeThisQuery(_store.Conventions)
                 {
                     DocumentId = key,
                     Fields = new[] { "Body" },
@@ -529,7 +529,7 @@ namespace NewClientTests.NewClient
             using (var session = _store.OpenSession())
             {
                 var list = session.Advanced.MoreLikeThis<Data, DataIndex>(
-                    new MoreLikeThisQuery
+                    new MoreLikeThisQuery(_store.Conventions)
                     {
                         DocumentId = key,
                         Fields = new[] { "Body" },
@@ -574,7 +574,7 @@ namespace NewClientTests.NewClient
 
             using (var session = _store.OpenSession())
             {
-                var list = session.Advanced.MoreLikeThis<Data, DataIndex>(new MoreLikeThisQuery
+                var list = session.Advanced.MoreLikeThis<Data, DataIndex>(new MoreLikeThisQuery(_store.Conventions)
                 {
                     DocumentId = key,
                     StopWordsDocumentId = "Config/Stopwords",
@@ -652,7 +652,7 @@ namespace NewClientTests.NewClient
         {
             using (var session = _store.OpenSession())
             {
-                var list = session.Advanced.MoreLikeThis<T, TIndex>(new MoreLikeThisQuery
+                var list = session.Advanced.MoreLikeThis<T, TIndex>(new MoreLikeThisQuery(_store.Conventions)
                 {
                     DocumentId = documentKey,
                     Fields = new[] { "Body" }
@@ -666,7 +666,7 @@ namespace NewClientTests.NewClient
         {
             using (var session = _store.OpenAsyncSession())
             {
-                var list = await session.Advanced.MoreLikeThisAsync<T, TIndex>(new MoreLikeThisQuery
+                var list = await session.Advanced.MoreLikeThisAsync<T, TIndex>(new MoreLikeThisQuery(_store.Conventions)
                 {
                     DocumentId = documentKey,
                     Fields = new[] { "Body" }

--- a/test/ClientSlowTests/Lazy/RavenDB_1443.cs
+++ b/test/ClientSlowTests/Lazy/RavenDB_1443.cs
@@ -81,7 +81,7 @@ namespace NewClientTests.NewClient
             {
                 var oldRequests = session.Advanced.NumberOfRequests;
 
-                var moreLikeThisLazy = session.Advanced.Lazily.MoreLikeThis<Article>(new MoreLikeThisQuery()
+                var moreLikeThisLazy = session.Advanced.Lazily.MoreLikeThis<Article>(new MoreLikeThisQuery(store.Conventions)
                 {
                     IndexName = index.IndexName,
                     DocumentId = "articles/0",

--- a/test/ClientSlowTests/PatchByIndexTests.cs
+++ b/test/ClientSlowTests/PatchByIndexTests.cs
@@ -97,7 +97,7 @@ namespace NewClientTests.NewClient.FastTests.Patching
 
                     var operation = await store
                         .Operations
-                        .SendAsync(new PatchByIndexOperation("TestIndex", new IndexQuery { Query = "Owner:bob" }, new PatchRequest { Script = sampleScript }));
+                        .SendAsync(new PatchByIndexOperation("TestIndex", new IndexQuery(store.Conventions) { Query = "Owner:bob" }, new PatchRequest { Script = sampleScript }));
 
                     await operation.WaitForCompletionAsync(TimeSpan.FromSeconds(60));
 
@@ -179,7 +179,7 @@ namespace NewClientTests.NewClient.FastTests.Patching
 
                     var operation = await store
                         .Operations
-                        .SendAsync(new PatchByIndexOperation("TestIndex", new IndexQuery { Query = "Value:1" }, new PatchRequest { Script = @"PutDocument('NewItem/3', {'CopiedValue': this.Value });" }));
+                        .SendAsync(new PatchByIndexOperation("TestIndex", new IndexQuery(store.Conventions) { Query = "Value:1" }, new PatchRequest { Script = @"PutDocument('NewItem/3', {'CopiedValue': this.Value });" }));
 
                     await operation.WaitForCompletionAsync(TimeSpan.FromSeconds(60));
 
@@ -244,7 +244,7 @@ namespace NewClientTests.NewClient.FastTests.Patching
 
                 var operation = await store
                     .Operations
-                    .SendAsync(new PatchByIndexOperation(stats.IndexName, new IndexQuery { Query = string.Empty }, new PatchRequest { Script = "this.FullName = this.FirstName + ' ' + this.LastName;" }));
+                    .SendAsync(new PatchByIndexOperation(stats.IndexName, new IndexQuery(store.Conventions) { Query = string.Empty }, new PatchRequest { Script = "this.FullName = this.FirstName + ' ' + this.LastName;" }));
 
                 await operation.WaitForCompletionAsync(TimeSpan.FromSeconds(60));
 

--- a/test/FastTests/Client/Indexing/DebugIndexing.cs
+++ b/test/FastTests/Client/Indexing/DebugIndexing.cs
@@ -78,7 +78,7 @@ namespace FastTests.Client.Indexing
                     DocumentId = "docs/1"
                 };
 
-                var query3 = new FacetQuery
+                var query3 = new FacetQuery(store.Conventions)
                 {
                     FacetSetupDoc = "setup/1"
                 };

--- a/test/FastTests/Client/Indexing/IndexesFromClient.cs
+++ b/test/FastTests/Client/Indexing/IndexesFromClient.cs
@@ -481,7 +481,7 @@ namespace FastTests.Client.Indexing
 
                 var operation = await store
                     .Operations
-                    .SendAsync(new DeleteByIndexOperation(indexName, new IndexQuery(), new QueryOperationOptions { AllowStale = false }));
+                    .SendAsync(new DeleteByIndexOperation(indexName, new IndexQuery(store.Conventions), new QueryOperationOptions { AllowStale = false }));
 
                 var deleteResult = await operation
                     .WaitForCompletionAsync(TimeSpan.FromSeconds(15)).ConfigureAwait(false) as BulkOperationResult;
@@ -515,7 +515,7 @@ namespace FastTests.Client.Indexing
 
                 operation = await store
                     .Operations
-                    .SendAsync(new DeleteByIndexOperation(indexName, new IndexQuery(), new QueryOperationOptions { AllowStale = false }));
+                    .SendAsync(new DeleteByIndexOperation(indexName, new IndexQuery(store.Conventions), new QueryOperationOptions { AllowStale = false }));
 
                 var e = Assert.Throws<RavenException>(() =>
                 {
@@ -554,7 +554,7 @@ namespace FastTests.Client.Indexing
 
                 var operation = await store
                     .Operations
-                    .SendAsync(new PatchByIndexOperation(indexName, new IndexQuery(), new PatchRequest { Script = "this.LastName = 'Test';" }, new QueryOperationOptions { AllowStale = false }));
+                    .SendAsync(new PatchByIndexOperation(indexName, new IndexQuery(store.Conventions), new PatchRequest { Script = "this.LastName = 'Test';" }, new QueryOperationOptions { AllowStale = false }));
 
                 await operation
                     .WaitForCompletionAsync(TimeSpan.FromSeconds(15))
@@ -632,7 +632,7 @@ namespace FastTests.Client.Indexing
 
                 using (var commands = store.Commands())
                 {
-                    var command = new ExplainQueryCommand(store.Conventions, commands.Context, "dynamic/Users", new IndexQuery());
+                    var command = new ExplainQueryCommand(store.Conventions, commands.Context, "dynamic/Users", new IndexQuery(store.Conventions));
 
                     await commands.RequestExecuter.ExecuteAsync(command, commands.Context);
 
@@ -686,7 +686,7 @@ namespace FastTests.Client.Indexing
 
                     WaitForIndexing(store);
 
-                    var list = session.Advanced.MoreLikeThis<Post>(new MoreLikeThisQuery
+                    var list = session.Advanced.MoreLikeThis<Post>(new MoreLikeThisQuery(store.Conventions)
                     {
                         IndexName = index.Name,
                         DocumentId = "posts/1",

--- a/test/FastTests/Client/Queries/Take.cs
+++ b/test/FastTests/Client/Queries/Take.cs
@@ -1,0 +1,44 @@
+﻿using System.Linq;
+using System.Threading.Tasks;
+using Raven.NewClient.Client;
+using Raven.NewClient.Client.Exceptions;
+using Raven.NewClient.Operations.Databases.ApiKeys;
+using Xunit;
+
+namespace FastTests.Client.Queries
+{
+    public class Take : RavenNewTestBase
+    {
+        [Fact]
+        public async Task ExplictTakeWhichIsGreaterThanMaxPageSizeShouldThrow()
+        {
+            using (var store = GetDocumentStore())
+            using (var session = store.OpenAsyncSession())
+            {
+                var exception = await Assert.ThrowsAsync<RavenException>(async () =>
+                {
+                    await session.Query<Item>()
+                        .Customize(customization => customization.WaitForNonStaleResults())
+                        .Take(2048)
+                        .ToListAsync();
+                });
+                Assert.Contains("Your page size (2048) is more than the max page size which is 1024.", exception.Message);
+                Assert.Contains("session.Advanced.Stream(query)", exception.Message);
+
+                exception = await Assert.ThrowsAsync<RavenException>(async () =>
+                {
+                    await store.Admin.SendAsync(new GetApiKeysOperation(0, 2048));
+                });
+                Assert.Contains("Your page size (2048) is more than the max page size which is 1024.", exception.Message);
+                Assert.DoesNotContain("Stream", exception.Message);
+            }
+        }
+
+        private class Item
+        {
+            public string Id { get; set; }
+
+            public int Index { get; set; }
+        }
+    }
+}

--- a/test/FastTests/Client/Queries/Take.cs
+++ b/test/FastTests/Client/Queries/Take.cs
@@ -34,6 +34,43 @@ namespace FastTests.Client.Queries
             }
         }
 
+        [Fact]
+        public async Task ImplicitTakeWillBeConfigurableAndByDefault25()
+        {
+            using (var store = GetDocumentStore())
+            using (var session = store.OpenAsyncSession())
+            {
+                for (int i = 1; i <= 30; i++)
+                {
+                    await session.StoreAsync(new Item { Index = i });
+                }
+                await session.SaveChangesAsync();
+
+                var items = await session.Query<Item>()
+                        .Customize(customization => customization.WaitForNonStaleResults())
+                        .ToListAsync();
+                Assert.Equal(25, items.Count);
+
+                store.Conventions.ImplicitTakeAmount = 15;
+                items = await session.Query<Item>()
+                        .Customize(customization => customization.WaitForNonStaleResults())
+                        .ToListAsync();
+                Assert.Equal(15, items.Count);
+
+                store.Conventions.ImplicitTakeAmount = 29;
+                items = await session.Query<Item>()
+                        .Customize(customization => customization.WaitForNonStaleResults())
+                        .ToListAsync();
+                Assert.Equal(29, items.Count);
+
+                items = await session.Query<Item>()
+                        .Customize(customization => customization.WaitForNonStaleResults())
+                        .Take(28)
+                        .ToListAsync();
+                Assert.Equal(28, items.Count);
+            }
+        }
+
         private class Item
         {
             public string Id { get; set; }

--- a/test/FastTests/Issues/RavenDB-5297.cs
+++ b/test/FastTests/Issues/RavenDB-5297.cs
@@ -61,7 +61,7 @@ namespace FastTests.Issues
                 JsonOperationContext context;
                 using (requestExecuter.ContextPool.AllocateOperationContext(out context))
                 {
-                    var command = new QueryCommand(store.Conventions, context, "Users/ByName", new IndexQuery { Query = "Name:* -First" });
+                    var command = new QueryCommand(store.Conventions, context, "Users/ByName", new IndexQuery(store.Conventions) { Query = "Name:* -First" });
 
                     requestExecuter.Execute(command, context);
 
@@ -101,7 +101,7 @@ namespace FastTests.Issues
                 JsonOperationContext context;
                 using (requestExecuter.ContextPool.AllocateOperationContext(out context))
                 {
-                    var command = new QueryCommand(store.Conventions, context, "Users/ByName", new IndexQuery { Query = "Name:* NOT Second" });
+                    var command = new QueryCommand(store.Conventions, context, "Users/ByName", new IndexQuery(store.Conventions) { Query = "Name:* NOT Second" });
 
                     requestExecuter.Execute(command, context);
 

--- a/test/FastTests/Server/Documents/Patching/AdvancedPatching.cs
+++ b/test/FastTests/Server/Documents/Patching/AdvancedPatching.cs
@@ -822,7 +822,7 @@ this.Value = another.Value;
                 }
 
                 var operation = await store.Operations.SendAsync(new PatchByIndexOperation("TestIndex",
-                    new IndexQuery { Query = "Value:1" },
+                    new IndexQuery(store.Conventions) { Query = "Value:1" },
                     new PatchRequest { Script = @"PutDocument('NewItem/3', {'CopiedValue': this.Value });" }));
                 await operation.WaitForCompletionAsync(TimeSpan.FromSeconds(15));
 
@@ -940,7 +940,7 @@ this.Value = another.Value;
                 WaitForIndexing(store);
 
                 var operation = store.Operations.Send(new PatchByIndexOperation("TestIndex",
-                    new IndexQuery { Query = "Owner:Bob" },
+                    new IndexQuery(store.Conventions) { Query = "Owner:Bob" },
                     new PatchRequest { Script = SampleScript }));
 
                 operation.WaitForCompletion(TimeSpan.FromSeconds(15));

--- a/test/FastTests/Server/Documents/Queries/Dynamic/MapReduce/BasicDynamicMapReduceQueries.cs
+++ b/test/FastTests/Server/Documents/Queries/Dynamic/MapReduce/BasicDynamicMapReduceQueries.cs
@@ -295,7 +295,7 @@ namespace FastTests.Server.Documents.Queries.Dynamic.MapReduce
 
                 using (var commands = store.Commands())
                 {
-                    var command = new QueryCommand(store.Conventions, commands.Context, "dynamic/Addresses", new IndexQuery
+                    var command = new QueryCommand(store.Conventions, commands.Context, "dynamic/Addresses", new IndexQuery(store.Conventions)
                     {
                         DynamicMapReduceFields = new[]
                         {

--- a/test/FastTests/Server/Documents/Queries/NotModifiedQueryResults.cs
+++ b/test/FastTests/Server/Documents/Queries/NotModifiedQueryResults.cs
@@ -26,7 +26,7 @@ namespace FastTests.Server.Documents.Queries
 
                 using (var commands = store.Commands())
                 {
-                    var users = commands.Query("dynamic/Users", new IndexQuery()
+                    var users = commands.Query("dynamic/Users", new IndexQuery(store.Conventions)
                     {
                         Query = "Name:Arek",
                         WaitForNonStaleResultsTimeout = TimeSpan.FromMinutes(1)
@@ -34,7 +34,7 @@ namespace FastTests.Server.Documents.Queries
 
                     Assert.Equal(2, users.Results.Length);
 
-                    users = commands.Query("dynamic/Users", new IndexQuery()
+                    users = commands.Query("dynamic/Users", new IndexQuery(store.Conventions)
                     {
                         Query = "Name:Arek",
                         WaitForNonStaleResultsTimeout = TimeSpan.FromMinutes(1)

--- a/test/FastTests/Server/Replication/ReplicationConflictsTests.cs
+++ b/test/FastTests/Server/Replication/ReplicationConflictsTests.cs
@@ -280,7 +280,7 @@ namespace FastTests.Server.Replication
 
                 WaitUntilHasConflict(store2, "foo/bar");
 
-                var operation = store2.Operations.Send(new DeleteByIndexOperation(userIndex.IndexName, new IndexQuery { Query = string.Empty }));
+                var operation = store2.Operations.Send(new DeleteByIndexOperation(userIndex.IndexName, new IndexQuery(store1.Conventions) { Query = string.Empty }));
 
                 Assert.Throws<DocumentConflictException>(() => operation.WaitForCompletion(TimeSpan.FromSeconds(15)));
             }
@@ -312,7 +312,7 @@ namespace FastTests.Server.Replication
                 WaitUntilHasConflict(store2, "foo/bar");
 
                 // /indexes/Raven/DocumentsByEntityName
-                var operation = store2.Operations.Send(new PatchByIndexOperation(userIndex.IndexName, new IndexQuery
+                var operation = store2.Operations.Send(new PatchByIndexOperation(userIndex.IndexName, new IndexQuery(store1.Conventions)
                 {
                     Query = string.Empty
                 }, new Raven.NewClient.Client.Data.PatchRequest

--- a/test/SlowTests/Bugs/Caching/CachingOfPostQueries.cs
+++ b/test/SlowTests/Bugs/Caching/CachingOfPostQueries.cs
@@ -144,7 +144,7 @@ namespace SlowTests.Bugs.Caching
             {
                 using (var session = store.OpenAsyncSession())
                 {
-                    await session.Advanced.MultiFacetedSearchAsync(new FacetQuery
+                    await session.Advanced.MultiFacetedSearchAsync(new FacetQuery(store.Conventions)
                     {
                         Query = "Name:Johnny",
                         IndexName = "PersonsIndex",
@@ -161,7 +161,7 @@ namespace SlowTests.Bugs.Caching
 
                     Assert.Equal(1, session.Advanced.RequestExecuter.Cache.NumberOfItems);
 
-                    await session.Advanced.MultiFacetedSearchAsync(new FacetQuery
+                    await session.Advanced.MultiFacetedSearchAsync(new FacetQuery(store.Conventions)
                     {
                         Query = "Name:Johnny",
                         IndexName = "PersonsIndex",

--- a/test/SlowTests/Core/Bundles/MoreLikeThis.cs
+++ b/test/SlowTests/Core/Bundles/MoreLikeThis.cs
@@ -33,7 +33,7 @@ namespace SlowTests.Core.Bundles
 
                     WaitForIndexing(store);
 
-                    var list = session.Advanced.MoreLikeThis<Post, Posts_ByTitleAndContent>(new MoreLikeThisQuery
+                    var list = session.Advanced.MoreLikeThis<Post, Posts_ByTitleAndContent>(new MoreLikeThisQuery(store.Conventions)
                     {
                         DocumentId = "posts/1",
                         MinimumDocumentFrequency = 1,
@@ -79,7 +79,7 @@ namespace SlowTests.Core.Bundles
 
                     WaitForIndexing(store);
 
-                    var list = session.Advanced.MoreLikeThis<PostWithContentTransformer.Result>(new MoreLikeThisQuery
+                    var list = session.Advanced.MoreLikeThis<PostWithContentTransformer.Result>(new MoreLikeThisQuery(store.Conventions)
                     {
                         IndexName = index.IndexName,
                         Transformer = transformer.TransformerName,
@@ -120,7 +120,7 @@ namespace SlowTests.Core.Bundles
 
                     WaitForIndexing(store);
 
-                    var list = session.Advanced.MoreLikeThis<User, Users_ByName>(new MoreLikeThisQuery
+                    var list = session.Advanced.MoreLikeThis<User, Users_ByName>(new MoreLikeThisQuery(store.Conventions)
                     {
                         DocumentId = "users/1",
                         Includes = new[] { "AddressId" },

--- a/test/SlowTests/Core/Commands/Documents.cs
+++ b/test/SlowTests/Core/Commands/Documents.cs
@@ -112,12 +112,12 @@ namespace SlowTests.Core.Commands
                 });
                 WaitForIndexing(store);
 
-                store.DatabaseCommands.UpdateByIndex("MyIndex", new IndexQuery { Query = "" }, new PatchRequest { Script = "this.NewName = 'NewValue';" }, null).WaitForCompletion(TimeSpan.FromSeconds(15));
+                store.DatabaseCommands.UpdateByIndex("MyIndex", new IndexQuery(store.Conventions) { Query = "" }, new PatchRequest { Script = "this.NewName = 'NewValue';" }, null).WaitForCompletion(TimeSpan.FromSeconds(15));
 
                 var document = await store.AsyncDatabaseCommands.GetAsync("items/1");
                 Assert.Equal("NewValue", document.DataAsJson.Value<string>("NewName"));
                 WaitForIndexing(store);
-                store.DatabaseCommands.DeleteByIndex("MyIndex", new IndexQuery { Query = "" }, null).WaitForCompletion(TimeSpan.FromSeconds(15));
+                store.DatabaseCommands.DeleteByIndex("MyIndex", new IndexQuery(store.Conventions) { Query = "" }, null).WaitForCompletion(TimeSpan.FromSeconds(15));
                 var documents = store.DatabaseCommands.GetDocuments(0, 25);
                 Assert.Equal(0, documents.Length);
             }

--- a/test/SlowTests/Core/Commands/Indexes.cs
+++ b/test/SlowTests/Core/Commands/Indexes.cs
@@ -151,7 +151,7 @@ namespace SlowTests.Core.Commands
 
                 using (var commands = store.Commands())
                 {
-                    var metadataOnly = commands.Query("test", new IndexQuery(), metadataOnly: true).Results;
+                    var metadataOnly = commands.Query("test", new IndexQuery(store.Conventions), metadataOnly: true).Results;
 
                     foreach (BlittableJsonReaderObject item in metadataOnly)
                     {
@@ -160,7 +160,7 @@ namespace SlowTests.Core.Commands
                         Assert.True(item.TryGet(Constants.Metadata.Key, out _));
                     }
 
-                    var entriesOnly = commands.Query("test", new IndexQuery
+                    var entriesOnly = commands.Query("test", new IndexQuery(store.Conventions)
                     {
                         SortedFields = new[] { new SortedField("Name") }
                     }, indexEntriesOnly: true).Results;

--- a/test/SlowTests/Core/Commands/Querying.cs
+++ b/test/SlowTests/Core/Commands/Querying.cs
@@ -43,7 +43,7 @@ namespace SlowTests.Core.Commands
 
                     WaitForIndexing(store);
 
-                    var companies = commands.Query(indexName, new IndexQuery { Query = "" });
+                    var companies = commands.Query(indexName, new IndexQuery(store.Conventions) { Query = "" });
                     Assert.Equal(3, companies.TotalResults);
 
                     var company = (BlittableJsonReaderObject)companies.Results[0];
@@ -94,7 +94,7 @@ namespace SlowTests.Core.Commands
                 //const string queryString = @"(((TagID: ""6ba9d9d1\-6b33\-40df\-b0fe\-5091790d9519"") AND (AssociatedTagID: ""0f7e407f\-46c8\-4dcc\-bcae\-512934732af5"")) OR (((TagID: ""bd7ad8b4\-f9df\-4aa0\-9a18\-9517bfd4bd83"") AND (AssociatedTagID: ""0f7e407f\-46c8\-4dcc\-bcae\-512934732af5"")) OR (((TagID: ""d278241e\-d6b2\-4d53\-bf42\-ae2786bb8307"") AND (AssociatedTagID: ""0f7e407f\-46c8\-4dcc\-bcae\-512934732af5"")) OR (((TagID: ""4e470c6a\-b2cc\-47ba\-a8c6\-0e84cc3c2f98"") AND (AssociatedTagID: ""0f7e407f\-46c8\-4dcc\-bcae\-512934732af5"")) OR (((TagID: ""ba59490f\-7003\-463b\-bb3d\-7ffd3f016af9"") AND (AssociatedTagID: ""0f7e407f\-46c8\-4dcc\-bcae\-512934732af5"")) OR (((TagID: ""bd7ad8b4\-f9df\-4aa0\-9a18\-9517bfd4bd83"") AND (AssociatedTagID: ""53cd8b83\-8793\-4328\-a6f3\-d45755275766"")) OR (((TagID: ""bd7ad8b4\-f9df\-4aa0\-9a18\-9517bfd4bd83"") AND (AssociatedTagID: ""6ba9d9d1\-6b33\-40df\-b0fe\-5091790d9519"")) OR (((TagID: ""7227bfa3\-1da2\-48d5\-aefb\-5716fe538173"") AND (AssociatedTagID: ""6ba9d9d1\-6b33\-40df\-b0fe\-5091790d9519"")) OR (((TagID: ""66010435\-60bd\-4cb2\-bbba\-ef262c6f3b40"") AND (AssociatedTagID: ""6ba9d9d1\-6b33\-40df\-b0fe\-5091790d9519"")) OR (((TagID: ""95cda7f6\-181c\-49f7\-809b\-9436011c7f29"") AND (AssociatedTagID: ""6ba9d9d1\-6b33\-40df\-b0fe\-5091790d9519"")) OR (((TagID: ""6ce4f353\-93fa\-452c\-be97\-5c91c5a2a6bb"") AND (AssociatedTagID: ""6ba9d9d1\-6b33\-40df\-b0fe\-5091790d9519"")) OR (((TagID: ""6ba9d9d1\-6b33\-40df\-b0fe\-5091790d9519"") AND (AssociatedTagID: ""4e470c6a\-b2cc\-47ba\-a8c6\-0e84cc3c2f98"")) OR (((TagID: ""bd7ad8b4\-f9df\-4aa0\-9a18\-9517bfd4bd83"") AND (AssociatedTagID: ""4e470c6a\-b2cc\-47ba\-a8c6\-0e84cc3c2f98"")) OR (((TagID: ""d278241e\-d6b2\-4d53\-bf42\-ae2786bb8307"") AND (AssociatedTagID: ""4e470c6a\-b2cc\-47ba\-a8c6\-0e84cc3c2f98"")) OR (((TagID: ""ba59490f\-7003\-463b\-bb3d\-7ffd3f016af9"") AND (AssociatedTagID: ""4e470c6a\-b2cc\-47ba\-a8c6\-0e84cc3c2f98"")) OR (((TagID: ""fb638f78\-686d\-4d81\-b9f6\-332a1c936a36"") AND (AssociatedTagID: ""ba59490f\-7003\-463b\-bb3d\-7ffd3f016af9"")) OR ((TagID: ""bd7ad8b4\-f9df\-4aa0\-9a18\-9517bfd4bd83"") AND (AssociatedTagID: ""ba59490f\-7003\-463b\-bb3d\-7ffd3f016af9""))))))))))))))))))";
 
                 Assert.NotInRange(stringBuilder.Length, 0, store.Conventions.MaxLengthOfQueryUsingGetUrl);
-                var indexQuery = new IndexQuery { Start = 0, PageSize = 50, Query = stringBuilder.ToString() };
+                var indexQuery = new IndexQuery(store.Conventions) { Start = 0, PageSize = 50, Query = stringBuilder.ToString() };
 
                 using (var commands = store.Commands())
                 {
@@ -244,12 +244,12 @@ namespace SlowTests.Core.Commands
 
                     using (var session = store.OpenSession())
                     {
-                        var multiFacetResults = session.Advanced.MultiFacetedSearch(new FacetQuery
+                        var multiFacetResults = session.Advanced.MultiFacetedSearch(new FacetQuery(store.Conventions)
                         {
                             IndexName = index.IndexName,
                             Query = "Cost:{NULL TO 200}",
                             FacetSetupDoc = "facets/CameraFacets"
-                        }, new FacetQuery
+                        }, new FacetQuery(store.Conventions)
                         {
                             IndexName = index.IndexName,
                             Query = "Megapixels:{NULL TO 3}",

--- a/test/SlowTests/Issues/RDoc_56.cs
+++ b/test/SlowTests/Issues/RDoc_56.cs
@@ -224,7 +224,7 @@ namespace SlowTests.Issues
                         .Customize(x => x.WaitForNonStaleResults())
                         .ToList();
 
-                var arrayResult = store.DatabaseCommands.Query(indexName, new IndexQuery(), metadataOnly: false, indexEntriesOnly: true);
+                var arrayResult = store.DatabaseCommands.Query(indexName, new IndexQuery(store.Conventions), metadataOnly: false, indexEntriesOnly: true);
 
                 Assert.Equal(expectedNumberOfResults, arrayResult.Results.Count);
             }

--- a/test/SlowTests/Issues/RavenDB-3818.cs
+++ b/test/SlowTests/Issues/RavenDB-3818.cs
@@ -12,11 +12,10 @@ namespace SlowTests.Issues
         [Fact(Skip = "RavenDB-5988")]
         public void SparialSearchWithDistanceErrorPercent()
         {
-            using (var documentStore = GetDocumentStore())
+            using (var store = GetDocumentStore())
             {
-                using (var session = documentStore.OpenSession())
+                using (var session = store.OpenSession())
                 {
-
                     //Point(12.556675672531128 55.675285554217), corner of the bounding rectangle below
                     var nearbyPoints1 = (RavenQueryInspector<Entity>)session.Query<Entity, EntitySpatialIndex>()
                         .Customize(x =>

--- a/test/SlowTests/Issues/RavenDB_302.cs
+++ b/test/SlowTests/Issues/RavenDB_302.cs
@@ -132,8 +132,8 @@ namespace SlowTests.Issues
 
                     GC.KeepAlive(x.ToList());// wait for the index to complete
 
-                    var indexQuery = new IndexQuery {Query = x.ToString(), DefaultField = "Query"};
-                    var facet = FacetQuery.Create("Index", indexQuery,"Raven/Facets/LastName",null,0,null);
+                    var indexQuery = new IndexQuery(s.Conventions) {Query = x.ToString(), DefaultField = "Query"};
+                    var facet = FacetQuery.Create("Index", indexQuery, "Raven/Facets/LastName", null, 0, null, s.Conventions);
 
                     var ravenfacets = s.DatabaseCommands.GetFacets(facet);
 

--- a/test/SlowTests/Issues/RavenDB_5489.cs
+++ b/test/SlowTests/Issues/RavenDB_5489.cs
@@ -52,7 +52,7 @@ namespace SlowTests.Issues
                 var result = SpinWait.SpinUntil(() => store.DatabaseCommands.GetStatistics().Indexes[0].State == IndexState.Error, TimeSpan.FromSeconds(5));
                 Assert.True(result);
 
-                var e = Assert.Throws<InvalidOperationException>(() => store.DatabaseCommands.Query(new Users_ByName().IndexName, new IndexQuery()));
+                var e = Assert.Throws<InvalidOperationException>(() => store.DatabaseCommands.Query(new Users_ByName().IndexName, new IndexQuery(store.Conventions)));
                 Assert.Contains("Simulated corruption", e.InnerException.Message);
 
                 var errors = store.DatabaseCommands.GetIndexErrors(new Users_ByName().IndexName);

--- a/test/SlowTests/Issues/RavenDB_554.cs
+++ b/test/SlowTests/Issues/RavenDB_554.cs
@@ -48,7 +48,7 @@ namespace SlowTests.Issues
                         .Customize(x => x.WaitForNonStaleResults())
                         .ToList();
 
-                    var queryResult = docStore.DatabaseCommands.Query(IndexName, new IndexQuery(), false, true);
+                    var queryResult = docStore.DatabaseCommands.Query(IndexName, new IndexQuery(docStore.Conventions), false, true);
                     foreach (var result in queryResult.Results)
                     {
                         RavenJToken q;

--- a/test/SlowTests/Issues/RavenDB_556.cs
+++ b/test/SlowTests/Issues/RavenDB_556.cs
@@ -60,7 +60,7 @@ namespace SlowTests.Issues
                             .Advanced
                             .DocumentStore
                             .DatabaseCommands
-                            .Query(newIndex, new IndexQuery(), false, true);
+                            .Query(newIndex, new IndexQuery(docStore.Conventions), false, true);
 
                         foreach (var result in queryResult.Results)
                         {

--- a/test/SlowTests/MailingList/ChrisMarisic.cs
+++ b/test/SlowTests/MailingList/ChrisMarisic.cs
@@ -75,7 +75,7 @@ namespace SlowTests.MailingList
                         .Take(1024);
 
                     var deserializer = session.Advanced.DocumentStore.Conventions.CreateSerializer();
-                    var indexQuery = new IndexQuery { Query = query.ToString(), PageSize = 1024, };
+                    var indexQuery = new IndexQuery(documentStore.Conventions) { Query = query.ToString(), PageSize = 1024, };
 
                     var queryResult = session.Advanced.DocumentStore.DatabaseCommands.Query(typeof(CarIndex).Name, indexQuery);
 

--- a/test/SlowTests/MailingList/DynamicFieldSorting.cs
+++ b/test/SlowTests/MailingList/DynamicFieldSorting.cs
@@ -105,6 +105,7 @@ namespace SlowTests.MailingList
                         .WaitForNonStaleResults()
                         .OrderBy("+TixP|N1_Range")
                         .SelectFields<WithDynamicIndex.ProjectionItem>("SongId", "NumericAttributes")
+                        .Take(128)
                         .ToList();
                     Assert.Equal(50, items.Count);
                     var counter = 1;
@@ -147,6 +148,7 @@ namespace SlowTests.MailingList
                         .WaitForNonStaleResults()
                         .AddOrder("N1_Range", true, typeof(double))
                         .SelectFields<WithDynamicIndex.ProjectionItem>("SongId", "NumericAttributes")
+                        .Take(128)
                         .ToList();
                     Assert.Equal(50, items.Count);
                     Assert.Equal("songs/50", items.First().SongId);

--- a/test/SlowTests/MailingList/FacetCountTest.cs
+++ b/test/SlowTests/MailingList/FacetCountTest.cs
@@ -130,7 +130,7 @@ namespace SlowTests.MailingList
 
                         var wods = query.ToList();
 
-                        var facets = session.Advanced.DocumentStore.DatabaseCommands.GetFacets(new FacetQuery
+                        var facets = session.Advanced.DocumentStore.DatabaseCommands.GetFacets(new FacetQuery(store.Conventions)
                         {
                             IndexName = "Wod/Search",
                             Query = query.ToString(),

--- a/test/SlowTests/MailingList/FacetQueryNotCorrectWithDefaultFieldSpecified.cs
+++ b/test/SlowTests/MailingList/FacetQueryNotCorrectWithDefaultFieldSpecified.cs
@@ -69,7 +69,7 @@ namespace SlowTests.MailingList
 
         private static FacetedQueryResult ExecuteTest(IDocumentStore store)
         {
-            FacetedQueryResult result = store.DatabaseCommands.GetFacets(new FacetQuery
+            FacetedQueryResult result = store.DatabaseCommands.GetFacets(new FacetQuery(store.Conventions)
             {
                 IndexName = "Product/AvailableForSale2",
                 Query = "MyName1",

--- a/test/SlowTests/MailingList/InQueries.cs
+++ b/test/SlowTests/MailingList/InQueries.cs
@@ -82,7 +82,7 @@ namespace SlowTests.MailingList
         }
 
         [Fact]
-        public void WhenElementcontainsCommasInMiddleOfList()
+        public void WhenElementContainsCommasInMiddleOfList()
         {
             using (var store = GetDocumentStore())
             {

--- a/test/SlowTests/MailingList/Kushnir.cs
+++ b/test/SlowTests/MailingList/Kushnir.cs
@@ -43,14 +43,16 @@ namespace SlowTests.MailingList
                 using (var session = store.OpenSession())
                 {
                     var ascending = session.Query<Foo, Foos_ByNameDateCreated>()
-                           .Where(a => a.Name.StartsWith(string.Empty))
-                           .OrderBy(a => a.DateCreated)
-                           .ToList();
-                    var descending = session.Query<Foo, Foos_ByNameDateCreated>()
-                           .Where(a => a.Name.StartsWith(string.Empty))
-                           .OrderByDescending(a => a.DateCreated)
-                           .ToList();
+                        .Where(a => a.Name.StartsWith(string.Empty))
+                        .OrderBy(a => a.DateCreated)
+                        .Take(128)
 
+                        .ToList();
+                    var descending = session.Query<Foo, Foos_ByNameDateCreated>()
+                        .Where(a => a.Name.StartsWith(string.Empty))
+                        .OrderByDescending(a => a.DateCreated)
+                        .Take(128)
+                        .ToList();
 
                     Assert.Equal(Alphabet, ascending.Select(a => a.Name).Aggregate((a, b) => a + b));
                     Assert.Equal(new string(Alphabet.Reverse().ToArray()), @descending.Select(a => a.Name).Aggregate((a, b) => a + b));

--- a/test/SlowTests/MailingList/Micha.cs
+++ b/test/SlowTests/MailingList/Micha.cs
@@ -32,7 +32,7 @@ namespace SlowTests.MailingList
                 WaitForIndexing(store);
 
                 store.DatabaseCommands.UpdateByIndex("EntityEntityIdPatch",
-                    new IndexQuery(),
+                    new IndexQuery(store.Conventions),
                     new PatchRequest
                     {
                         Script = @"

--- a/test/SlowTests/MailingList/MoreLikeThisEvaluation.cs
+++ b/test/SlowTests/MailingList/MoreLikeThisEvaluation.cs
@@ -34,7 +34,7 @@ namespace SlowTests.MailingList
                 {
                     var list = session
                         .Advanced
-                        .MoreLikeThis<Movie, MovieIndex>(new MoreLikeThisQuery
+                        .MoreLikeThis<Movie, MovieIndex>(new MoreLikeThisQuery(store.Conventions)
                         {
                             DocumentId = id,
                             Fields = new[] { "Cast" },

--- a/test/SlowTests/MailingList/MultiMapIndexWithDynamicFieldsTests.cs
+++ b/test/SlowTests/MailingList/MultiMapIndexWithDynamicFieldsTests.cs
@@ -46,15 +46,16 @@ namespace SlowTests.MailingList
                 using (var session = store.OpenSession())
                 {
                     var result = session.Advanced.DocumentQuery<DynamicMultiMapDataSetIndex.Result, DynamicMultiMapDataSetIndex>()
-                          .WaitForNonStaleResults()
-                          .AddOrder("N1_Range", true, typeof(double))
-                          .ToList();
+                        .WaitForNonStaleResults()
+                        .AddOrder("N1_Range", true, typeof(double))
+                        .Take(128)
+                        .ToList();
                     Assert.Equal(50, result.Count); //FAIL(:
                     Assert.Equal(49.50m, result.First().Attributes.First(x => x.Name == "N1").Value);
-
                 }
             }
         }
+
         private class Song
         {
             public string Id { get; set; }

--- a/test/SlowTests/MailingList/NimaHa.cs
+++ b/test/SlowTests/MailingList/NimaHa.cs
@@ -53,7 +53,7 @@ namespace SlowTests.MailingList
                     Assert.Equal(3, list.Count);
                 }
 
-                var query = store.DatabaseCommands.Query("HouseByRent", new IndexQuery { Query = "*:* AND -Rent:[[NULL_VALUE]]" });
+                var query = store.DatabaseCommands.Query("HouseByRent", new IndexQuery(store.Conventions) { Query = "*:* AND -Rent:[[NULL_VALUE]]" });
 
                 Assert.Equal(1, query.TotalResults);
             }

--- a/test/SlowTests/MailingList/ProjectionShouldNotLoadDocument.cs
+++ b/test/SlowTests/MailingList/ProjectionShouldNotLoadDocument.cs
@@ -48,7 +48,7 @@ namespace SlowTests.MailingList
             {
                 store.DatabaseCommands.Put("FOO", null, new RavenJObject { { "Name", "Ayende" } }, new RavenJObject { { Constants.Metadata.Collection, "Foos" } });
 
-                var result = store.DatabaseCommands.Query("dynamic", new IndexQuery
+                var result = store.DatabaseCommands.Query("dynamic", new IndexQuery(store.Conventions)
                 {
                     FieldsToFetch = new[] { "Name" },
                     Query = "Name:Ayende"
@@ -61,7 +61,7 @@ namespace SlowTests.MailingList
                 new Index1().Execute(store);
                 WaitForIndexing(store);
 
-                result = store.DatabaseCommands.Query("Index1", new IndexQuery
+                result = store.DatabaseCommands.Query("Index1", new IndexQuery(store.Conventions)
                 {
                     FieldsToFetch = new[] { "Name" },
                     Query = "Name:Ayende"

--- a/test/SlowTests/MailingList/Samina3.cs
+++ b/test/SlowTests/MailingList/Samina3.cs
@@ -64,7 +64,7 @@ namespace SlowTests.MailingList
 
                     var result = query.ToList();
 
-                    var facetResults = store.DatabaseCommands.GetFacets(new FacetQuery
+                    var facetResults = store.DatabaseCommands.GetFacets(new FacetQuery(store.Conventions)
                     {
                         IndexName = "PropertiesSearchIndex",
                         Query = query.ToString(),

--- a/test/SlowTests/MailingList/ScriptedPathBug.cs
+++ b/test/SlowTests/MailingList/ScriptedPathBug.cs
@@ -51,7 +51,7 @@ namespace SlowTests.MailingList
 
                 var operation = store.DatabaseCommands.UpdateByIndex(
                     new Index1().IndexName,
-                    new IndexQuery { Query = string.Empty },
+                    new IndexQuery(store.Conventions) { Query = string.Empty },
                     new PatchRequest { Script = script },
                     new QueryOperationOptions { AllowStale = false, StaleTimeout = TimeSpan.MaxValue, RetrieveDetails = true });
 

--- a/test/SlowTests/MailingList/SeanBuchanan.cs
+++ b/test/SlowTests/MailingList/SeanBuchanan.cs
@@ -129,7 +129,7 @@ namespace SlowTests.MailingList
                 WaitForIndexing(store);
                 //I use this patch to update the consultant name to "Subha" in the Proficiencies collection.
                 store.DatabaseCommands.UpdateByIndex("Proficiencies/ConsultantId",
-                    new IndexQuery
+                    new IndexQuery(store.Conventions)
                     {
                         Query = "Consultant_Id:1"
                     },

--- a/test/SlowTests/MailingList/SetBased.cs
+++ b/test/SlowTests/MailingList/SetBased.cs
@@ -68,7 +68,7 @@ namespace SlowTests.MailingList
                     .DatabaseCommands
                     .UpdateByIndex(
                         new Index1().IndexName,
-                        new IndexQuery { Query = string.Empty },
+                        new IndexQuery(store.Conventions) { Query = string.Empty },
                         new PatchRequest
                         {
                             Script = "this.Privilege[0].Level = 'Gold'"

--- a/test/SlowTests/MailingList/TomCabanski.cs
+++ b/test/SlowTests/MailingList/TomCabanski.cs
@@ -36,7 +36,7 @@ namespace SlowTests.MailingList
                     s.SaveChanges();
                 }
 
-                store.DatabaseCommands.GetFacets(new FacetQuery
+                store.DatabaseCommands.GetFacets(new FacetQuery(store.Conventions)
                 {
                     IndexName = "test",
                     Query = "(IsActive:true)  AND (BookVendor:\"stroheim & romann\")",

--- a/test/SlowTests/MailingList/WildCardQuery.cs
+++ b/test/SlowTests/MailingList/WildCardQuery.cs
@@ -11,7 +11,7 @@ namespace SlowTests.MailingList
          {
              using(var store = GetDocumentStore())
              {
-                 store.DatabaseCommands.Query("dynamic", new IndexQuery
+                 store.DatabaseCommands.Query("dynamic", new IndexQuery(store.Conventions)
                  {
                      Query = "PortalId:0 AND Query:(*) QueryBoosted:(*)"
                  });

--- a/test/SlowTests/SlowTests/Bugs/AsyncSetBasedOps.cs
+++ b/test/SlowTests/SlowTests/Bugs/AsyncSetBasedOps.cs
@@ -60,7 +60,7 @@ namespace SlowTests.SlowTests.Bugs
 
                 await (await store.AsyncDatabaseCommands.UpdateByIndexAsync(
                     stats.IndexName,
-                    new IndexQuery { Query = string.Empty },
+                    new IndexQuery(store.Conventions) { Query = string.Empty },
                     new PatchRequest
                     {
                         Script = "this.FullName = this.FirstName + ' ' + this.LastName;"

--- a/test/SlowTests/SlowTests/Issues/RavenDB_2134.cs
+++ b/test/SlowTests/SlowTests/Issues/RavenDB_2134.cs
@@ -40,7 +40,7 @@ namespace SlowTests.SlowTests.Issues
                 }
 
                 WaitForIndexing(store,timeout: TimeSpan.FromMinutes(1));
-                var queryToDelete = new IndexQuery
+                var queryToDelete = new IndexQuery(store.Conventions)
                 {
                     Query = string.Empty
                 };

--- a/test/SlowTests/SlowTests/Queries/IntersectionWithLargeDataset.cs
+++ b/test/SlowTests/SlowTests/Queries/IntersectionWithLargeDataset.cs
@@ -43,6 +43,7 @@ namespace SlowTests.SlowTests.Queries
                                     .OrderBy(o => o.Id)
                                     .Intersect()
                                     .Where(o => o.Attributes.Any(t => t.Key == "Nullam" && t.Value == N))
+                                    .Take(128)
                                     .ToList();
 
                         Assert.Equal(100, result.Count);

--- a/test/SlowTests/Tests/Bugs/QueryOptimizer/QueryOptimizeTests.cs
+++ b/test/SlowTests/Tests/Bugs/QueryOptimizer/QueryOptimizeTests.cs
@@ -50,7 +50,7 @@ namespace SlowTests.Tests.Bugs.QueryOptimizer
             using (var store = GetDocumentStore())
             {
                 var queryResult = store.DatabaseCommands.Query("dynamic",
-                                                               new IndexQuery
+                                                               new IndexQuery(store.Conventions)
                                                                {
                                                                    Query = "Name:Ayende AND Age:3"
                                                                });
@@ -58,7 +58,7 @@ namespace SlowTests.Tests.Bugs.QueryOptimizer
                 Assert.Equal("Auto/AllDocs/ByAgeAndName", queryResult.IndexName);
 
                 queryResult = store.DatabaseCommands.Query("dynamic",
-                                                               new IndexQuery
+                                                               new IndexQuery(store.Conventions)
                                                                {
                                                                    Query = "Name:Ayende"
                                                                });
@@ -79,7 +79,7 @@ namespace SlowTests.Tests.Bugs.QueryOptimizer
                                                 });
 
                 var queryResult = store.DatabaseCommands.Query("dynamic",
-                                                               new IndexQuery
+                                                               new IndexQuery(store.Conventions)
                                                                {
                                                                    Query = "Name:Ayende AND Age:3"
                                                                });
@@ -87,7 +87,7 @@ namespace SlowTests.Tests.Bugs.QueryOptimizer
                 Assert.Equal("test", queryResult.IndexName);
 
                 queryResult = store.DatabaseCommands.Query("dynamic",
-                                                               new IndexQuery
+                                                               new IndexQuery(store.Conventions)
                                                                {
                                                                    Query = "Name:Ayende"
                                                                });
@@ -102,7 +102,7 @@ namespace SlowTests.Tests.Bugs.QueryOptimizer
             using (var store = GetDocumentStore())
             {
                 var queryResult = store.DatabaseCommands.Query("dynamic",
-                                                               new IndexQuery
+                                                               new IndexQuery(store.Conventions)
                                                                {
                                                                    Query = "Name:3"
                                                                });
@@ -110,7 +110,7 @@ namespace SlowTests.Tests.Bugs.QueryOptimizer
                 Assert.Equal("Auto/AllDocs/ByName", queryResult.IndexName);
 
                 queryResult = store.DatabaseCommands.Query("dynamic",
-                                                               new IndexQuery
+                                                               new IndexQuery(store.Conventions)
                                                                {
                                                                    Query = "Age:3"
                                                                });
@@ -118,7 +118,7 @@ namespace SlowTests.Tests.Bugs.QueryOptimizer
                 Assert.Equal("Auto/AllDocs/ByAgeAndName", queryResult.IndexName);
 
                 queryResult = store.DatabaseCommands.Query("dynamic",
-                                                               new IndexQuery
+                                                               new IndexQuery(store.Conventions)
                                                                {
                                                                    Query = "Name:Ayende"
                                                                });
@@ -133,7 +133,7 @@ namespace SlowTests.Tests.Bugs.QueryOptimizer
             using (var store = GetDocumentStore())
             {
                 var queryResult = store.DatabaseCommands.Query("dynamic/Users",
-                                                               new IndexQuery
+                                                               new IndexQuery(store.Conventions)
                                                                {
                                                                    Query = "Name:3"
                                                                });
@@ -141,7 +141,7 @@ namespace SlowTests.Tests.Bugs.QueryOptimizer
                 Assert.Equal("Auto/Users/ByName", queryResult.IndexName);
 
                 queryResult = store.DatabaseCommands.Query("dynamic/Users",
-                                                               new IndexQuery
+                                                               new IndexQuery(store.Conventions)
                                                                {
                                                                    Query = "Age:3"
                                                                });
@@ -149,7 +149,7 @@ namespace SlowTests.Tests.Bugs.QueryOptimizer
                 Assert.Equal("Auto/Users/ByAgeAndName", queryResult.IndexName);
 
                 queryResult = store.DatabaseCommands.Query("dynamic/Users",
-                                                               new IndexQuery
+                                                               new IndexQuery(store.Conventions)
                                                                {
                                                                    Query = "Name:Ayende"
                                                                });
@@ -163,7 +163,7 @@ namespace SlowTests.Tests.Bugs.QueryOptimizer
             using (var store = GetDocumentStore())
             {
                 var queryResult = store.DatabaseCommands.Query("dynamic/Users",
-                                                               new IndexQuery
+                                                               new IndexQuery(store.Conventions)
                                                                {
                                                                    Query = "Name:3"
                                                                });
@@ -171,7 +171,7 @@ namespace SlowTests.Tests.Bugs.QueryOptimizer
                 Assert.Equal("Auto/Users/ByName", queryResult.IndexName);
 
                 queryResult = store.DatabaseCommands.Query("dynamic/Cars",
-                                                               new IndexQuery
+                                                               new IndexQuery(store.Conventions)
                                                                {
                                                                    Query = "Age:3"
                                                                });
@@ -179,7 +179,7 @@ namespace SlowTests.Tests.Bugs.QueryOptimizer
                 Assert.Equal("Auto/Cars/ByAge", queryResult.IndexName);
 
                 queryResult = store.DatabaseCommands.Query("dynamic/Users",
-                                                               new IndexQuery
+                                                               new IndexQuery(store.Conventions)
                                                                {
                                                                    Query = "Name:Ayende"
                                                                });
@@ -205,7 +205,7 @@ namespace SlowTests.Tests.Bugs.QueryOptimizer
                                                     Maps = { "from doc in docs select new { doc.Name }" }
                                                 });
                 var queryResult = store.DatabaseCommands.Query("dynamic",
-                                                               new IndexQuery
+                                                               new IndexQuery(store.Conventions)
                                                                {
                                                                    Query = "Name:Ayende AND Age:3"
                                                                });
@@ -213,7 +213,7 @@ namespace SlowTests.Tests.Bugs.QueryOptimizer
                 Assert.Equal("test", queryResult.IndexName);
 
                 queryResult = store.DatabaseCommands.Query("dynamic",
-                                                               new IndexQuery
+                                                               new IndexQuery(store.Conventions)
                                                                {
                                                                    Query = "Name:Ayende"
                                                                });
@@ -240,7 +240,7 @@ namespace SlowTests.Tests.Bugs.QueryOptimizer
                                                     Maps = { "from doc in docs select new { doc.Name }" }
                                                 });
                 var queryResult = store.DatabaseCommands.Query("dynamic",
-                                                               new IndexQuery
+                                                               new IndexQuery(store.Conventions)
                                                                {
                                                                    Query = "Name:Ayende AND Age:3"
                                                                });
@@ -248,7 +248,7 @@ namespace SlowTests.Tests.Bugs.QueryOptimizer
                 Assert.Equal("test", queryResult.IndexName);
 
                 queryResult = store.DatabaseCommands.Query("test2",
-                                                               new IndexQuery
+                                                               new IndexQuery(store.Conventions)
                                                                {
                                                                    Query = "Name:Ayende"
                                                                });
@@ -274,7 +274,7 @@ namespace SlowTests.Tests.Bugs.QueryOptimizer
                                                 });
 
                 var queryResult = store.DatabaseCommands.Query("dynamic",
-                                                               new IndexQuery
+                                                               new IndexQuery(store.Conventions)
                                                                {
                                                                    Query = "Title:Matt"
                                                                });
@@ -284,7 +284,7 @@ namespace SlowTests.Tests.Bugs.QueryOptimizer
                 Assert.NotEqual("test", queryResult.IndexName);
 
                 queryResult = store.DatabaseCommands.Query("dynamic",
-                                                               new IndexQuery
+                                                               new IndexQuery(store.Conventions)
                                                                {
                                                                    Query = "BodyText:Matt"
                                                                });

--- a/test/SlowTests/Tests/Bugs/QueryOptimizer/QueryOptimizeTests_ExplicitCollections.cs
+++ b/test/SlowTests/Tests/Bugs/QueryOptimizer/QueryOptimizeTests_ExplicitCollections.cs
@@ -49,7 +49,7 @@ namespace SlowTests.Tests.Bugs.QueryOptimizer
             using (var store = GetDocumentStore())
             {
                 var queryResult = store.DatabaseCommands.Query("dynamic/Users",
-                                                               new IndexQuery
+                                                               new IndexQuery(store.Conventions)
                                                                {
                                                                    Query = "Name:Ayende AND Age:3"
                                                                });
@@ -57,7 +57,7 @@ namespace SlowTests.Tests.Bugs.QueryOptimizer
                 Assert.Equal("Auto/Users/ByAgeAndName", queryResult.IndexName);
 
                 queryResult = store.DatabaseCommands.Query("dynamic/Users",
-                                                               new IndexQuery
+                                                               new IndexQuery(store.Conventions)
                                                                {
                                                                    Query = "Name:Ayende"
                                                                });
@@ -78,7 +78,7 @@ namespace SlowTests.Tests.Bugs.QueryOptimizer
                                                 });
 
                 var queryResult = store.DatabaseCommands.Query("dynamic/Users",
-                                                               new IndexQuery
+                                                               new IndexQuery(store.Conventions)
                                                                {
                                                                    Query = "Name:Ayende AND Age:3"
                                                                });
@@ -86,7 +86,7 @@ namespace SlowTests.Tests.Bugs.QueryOptimizer
                 Assert.Equal("test", queryResult.IndexName);
 
                 queryResult = store.DatabaseCommands.Query("dynamic/Users",
-                                                               new IndexQuery
+                                                               new IndexQuery(store.Conventions)
                                                                {
                                                                    Query = "Name:Ayende"
                                                                });
@@ -101,7 +101,7 @@ namespace SlowTests.Tests.Bugs.QueryOptimizer
             using (var store = GetDocumentStore())
             {
                 var queryResult = store.DatabaseCommands.Query("dynamic/Users",
-                                                               new IndexQuery
+                                                               new IndexQuery(store.Conventions)
                                                                {
                                                                    Query = "Name:3"
                                                                });
@@ -109,7 +109,7 @@ namespace SlowTests.Tests.Bugs.QueryOptimizer
                 Assert.Equal("Auto/Users/ByName", queryResult.IndexName);
 
                 queryResult = store.DatabaseCommands.Query("dynamic/Users",
-                                                               new IndexQuery
+                                                               new IndexQuery(store.Conventions)
                                                                {
                                                                    Query = "Age:3"
                                                                });
@@ -117,7 +117,7 @@ namespace SlowTests.Tests.Bugs.QueryOptimizer
                 Assert.Equal("Auto/Users/ByAgeAndName", queryResult.IndexName);
 
                 queryResult = store.DatabaseCommands.Query("dynamic/Users",
-                                                               new IndexQuery
+                                                               new IndexQuery(store.Conventions)
                                                                {
                                                                    Query = "Name:Ayende"
                                                                });
@@ -132,7 +132,7 @@ namespace SlowTests.Tests.Bugs.QueryOptimizer
             using (var store = GetDocumentStore())
             {
                 var queryResult = store.DatabaseCommands.Query("dynamic/Users",
-                                                               new IndexQuery
+                                                               new IndexQuery(store.Conventions)
                                                                {
                                                                    Query = "Name:3"
                                                                });
@@ -140,7 +140,7 @@ namespace SlowTests.Tests.Bugs.QueryOptimizer
                 Assert.Equal("Auto/Users/ByName", queryResult.IndexName);
 
                 queryResult = store.DatabaseCommands.Query("dynamic/Users",
-                                                               new IndexQuery
+                                                               new IndexQuery(store.Conventions)
                                                                {
                                                                    Query = "Age:3"
                                                                });
@@ -148,7 +148,7 @@ namespace SlowTests.Tests.Bugs.QueryOptimizer
                 Assert.Equal("Auto/Users/ByAgeAndName", queryResult.IndexName);
 
                 queryResult = store.DatabaseCommands.Query("dynamic/Users",
-                                                               new IndexQuery
+                                                               new IndexQuery(store.Conventions)
                                                                {
                                                                    Query = "Name:Ayende"
                                                                });
@@ -162,7 +162,7 @@ namespace SlowTests.Tests.Bugs.QueryOptimizer
             using (var store = GetDocumentStore())
             {
                 var queryResult = store.DatabaseCommands.Query("dynamic/Users",
-                                                               new IndexQuery
+                                                               new IndexQuery(store.Conventions)
                                                                {
                                                                    Query = "Name:3"
                                                                });
@@ -170,7 +170,7 @@ namespace SlowTests.Tests.Bugs.QueryOptimizer
                 Assert.Equal("Auto/Users/ByName", queryResult.IndexName);
 
                 queryResult = store.DatabaseCommands.Query("dynamic/Cars",
-                                                               new IndexQuery
+                                                               new IndexQuery(store.Conventions)
                                                                {
                                                                    Query = "Age:3"
                                                                });
@@ -178,7 +178,7 @@ namespace SlowTests.Tests.Bugs.QueryOptimizer
                 Assert.Equal("Auto/Cars/ByAge", queryResult.IndexName);
 
                 queryResult = store.DatabaseCommands.Query("dynamic/Users",
-                                                               new IndexQuery
+                                                               new IndexQuery(store.Conventions)
                                                                {
                                                                    Query = "Name:Ayende"
                                                                });
@@ -204,7 +204,7 @@ namespace SlowTests.Tests.Bugs.QueryOptimizer
                                                     Maps = { "from doc in docs.Users select new { doc.Name }" }
                                                 });
                 var queryResult = store.DatabaseCommands.Query("dynamic/Users",
-                                                               new IndexQuery
+                                                               new IndexQuery(store.Conventions)
                                                                {
                                                                    Query = "Name:Ayende AND Age:3"
                                                                });
@@ -212,7 +212,7 @@ namespace SlowTests.Tests.Bugs.QueryOptimizer
                 Assert.Equal("test", queryResult.IndexName);
 
                 queryResult = store.DatabaseCommands.Query("dynamic/Users",
-                                                               new IndexQuery
+                                                               new IndexQuery(store.Conventions)
                                                                {
                                                                    Query = "Name:Ayende"
                                                                });
@@ -239,7 +239,7 @@ namespace SlowTests.Tests.Bugs.QueryOptimizer
                                                     Maps = { "from doc in docs.Users select new { doc.Name }" }
                                                 });
                 var queryResult = store.DatabaseCommands.Query("dynamic/Users",
-                                                               new IndexQuery
+                                                               new IndexQuery(store.Conventions)
                                                                {
                                                                    Query = "Name:Ayende AND Age:3"
                                                                });
@@ -247,7 +247,7 @@ namespace SlowTests.Tests.Bugs.QueryOptimizer
                 Assert.Equal("test", queryResult.IndexName);
 
                 queryResult = store.DatabaseCommands.Query("test2",
-                                                               new IndexQuery
+                                                               new IndexQuery(store.Conventions)
                                                                {
                                                                    Query = "Name:Ayende"
                                                                });
@@ -273,7 +273,7 @@ namespace SlowTests.Tests.Bugs.QueryOptimizer
                                                 });
 
                 var queryResult = store.DatabaseCommands.Query("dynamic/Users",
-                                                               new IndexQuery
+                                                               new IndexQuery(store.Conventions)
                                                                {
                                                                    Query = "Title:Matt"
                                                                });
@@ -283,7 +283,7 @@ namespace SlowTests.Tests.Bugs.QueryOptimizer
                 Assert.NotEqual("test", queryResult.IndexName);
 
                 queryResult = store.DatabaseCommands.Query("dynamic/Users",
-                                                               new IndexQuery
+                                                               new IndexQuery(store.Conventions)
                                                                {
                                                                    Query = "BodyText:Matt"
                                                                });

--- a/test/SlowTests/Tests/Indexes/ComplexIndexOnNotAnalyzedField.cs
+++ b/test/SlowTests/Tests/Indexes/ComplexIndexOnNotAnalyzedField.cs
@@ -34,7 +34,7 @@ namespace SlowTests.Tests.Indexes
                 QueryResult queryResult;
                 do
                 {
-                    queryResult = store.DatabaseCommands.Query("CompaniesByPartners", new IndexQuery
+                    queryResult = store.DatabaseCommands.Query("CompaniesByPartners", new IndexQuery(store.Conventions)
                     {
                         Query = "Partner:companies/49",
                         PageSize = 10

--- a/test/SlowTests/Tests/Indexes/QueryingOnStaleIndexes.cs
+++ b/test/SlowTests/Tests/Indexes/QueryingOnStaleIndexes.cs
@@ -44,7 +44,7 @@ namespace SlowTests.Tests.Indexes
                     session.SaveChanges();
                 }
 
-                Assert.True(store.DatabaseCommands.Query(index.IndexName, new IndexQuery
+                Assert.True(store.DatabaseCommands.Query(index.IndexName, new IndexQuery(store.Conventions)
                 {
                     PageSize = 2,
                     Start = 0,

--- a/test/SlowTests/Tests/Querying/SkipDuplicates.cs
+++ b/test/SlowTests/Tests/Querying/SkipDuplicates.cs
@@ -63,7 +63,7 @@ namespace SlowTests.Tests.Querying
 
                     WaitForIndexing(store);
 
-                    var result = store.DatabaseCommands.Query("BlogPosts/PostsCountByTag", new IndexQuery { SkipDuplicateChecking = true });
+                    var result = store.DatabaseCommands.Query("BlogPosts/PostsCountByTag", new IndexQuery(store.Conventions) { SkipDuplicateChecking = true });
                     Assert.Equal(2, result.Results.Count);
                 }
             }

--- a/test/SlowTests/Tests/Views/MapReduce.cs
+++ b/test/SlowTests/Tests/Views/MapReduce.cs
@@ -109,7 +109,7 @@ select new {
         private QueryResult GetUnstableQueryResult(IDocumentStore store, string query)
         {
             WaitForIndexing(store);
-            var q = store.DatabaseCommands.Query("CommentsCountPerBlog", new IndexQuery
+            var q = store.DatabaseCommands.Query("CommentsCountPerBlog", new IndexQuery(store.Conventions)
             {
                 Query = query,
                 Start = 0,

--- a/test/SlowTests/Tests/Views/MapReduce_IndependentSteps.cs
+++ b/test/SlowTests/Tests/Views/MapReduce_IndependentSteps.cs
@@ -78,7 +78,7 @@ select new {
 
                 WaitForIndexing(store);
 
-                QueryResult q = store.DatabaseCommands.Query("CommentsCountPerBlog", new IndexQuery
+                QueryResult q = store.DatabaseCommands.Query("CommentsCountPerBlog", new IndexQuery(store.Conventions)
                 {
                     Query = "blog_id:3",
                     Start = 0,


### PR DESCRIPTION
1.
If you ask for more than the max page size, you get an error, with a pointer to streams.
But if you ask for /admin/api-keys with more than the max page size, you'll get an error without a pointer to streams, as it isn't relevant here.

2. 
Implicit take size will be 25 and allow to modify this default using the conventions.