### PR TITLE
RavenDB-6141 Removing Raven/WorkingDir setting - since Raven/DataDir …

### DIFF
--- a/src/Raven.Server/Config/Categories/CoreConfiguration.cs
+++ b/src/Raven.Server/Config/Categories/CoreConfiguration.cs
@@ -1,25 +1,11 @@
-using System;
 using System.ComponentModel;
-using System.IO;
-using System.Text.RegularExpressions;
 using Raven.Server.Config.Attributes;
 using Raven.Server.Config.Settings;
-using Raven.Server.Documents;
 
 namespace Raven.Server.Config.Categories
 {
     public class CoreConfiguration : ConfigurationCategory
     {
-        private string _workingDirectory;
-        private PathSetting _dataDirectory;
-
-        private readonly RavenConfiguration _root;
-
-        public CoreConfiguration(RavenConfiguration root)
-        {
-            _root = root;
-        }
-
         [Description("The maximum allowed page size for queries")]
         [DefaultValue(1024)]
         [MinValue(10)]
@@ -56,25 +42,10 @@ namespace Raven.Server.Config.Categories
         [ConfigurationEntry("Raven/RunInMemory")]
         public bool RunInMemory { get; set; }
 
-        [DefaultValue(@"~\")]
-        [ConfigurationEntry("Raven/WorkingDir")]
-        public string WorkingDirectory
-        {
-            get { return _workingDirectory; }
-            set { _workingDirectory = CalculateWorkingDirectory(value); }
-        }
-
         [Description("The directory for the RavenDB resource. You can use the ~/ prefix to refer to RavenDB's base directory.")]
         [DefaultValue(@"~/{pluralizedResourceType}/{name}")]
         [ConfigurationEntry("Raven/DataDir")]
-        public PathSetting DataDirectory
-        {
-            get { return _dataDirectory; }
-            set
-            {
-                _dataDirectory = value.ApplyWorkingDirectory(new PathSetting(WorkingDirectory));
-            }
-        }
+        public PathSetting DataDirectory { get; set; }
 
         [Description("The time to wait before canceling a database operation such as load (many) or query")]
         [DefaultValue(5)]
@@ -92,21 +63,5 @@ namespace Raven.Server.Config.Categories
         [DefaultValue(false)]
         [ConfigurationEntry("Raven/RunAsService")]
         public bool RunAsService { get; set; }
-
-        private static string CalculateWorkingDirectory(string workingDirectory)
-        {
-            if (string.IsNullOrEmpty(workingDirectory))
-                workingDirectory = @"~\";
-
-            if (workingDirectory.StartsWith("APPDRIVE:", StringComparison.OrdinalIgnoreCase))
-            {
-                var baseDirectory = AppContext.BaseDirectory;
-                var rootPath = Path.GetPathRoot(baseDirectory);
-                if (string.IsNullOrEmpty(rootPath) == false)
-                    workingDirectory = Regex.Replace(workingDirectory, "APPDRIVE:", rootPath.TrimEnd('\\'), RegexOptions.IgnoreCase);
-            }
-
-            return workingDirectory;
-        }
     }
 }

--- a/src/Raven.Server/Config/RavenConfiguration.cs
+++ b/src/Raven.Server/Config/RavenConfiguration.cs
@@ -78,7 +78,7 @@ namespace Raven.Server.Config
             AddJsonConfigurationVariables();
 
             Settings = _configBuilder.Build();
-            Core = new CoreConfiguration(this);
+            Core = new CoreConfiguration();
 
             Replication = new ReplicationConfiguration();
             SqlReplication = new SqlReplicationConfiguration();

--- a/src/Raven.Server/settings_windows.json
+++ b/src/Raven.Server/settings_windows.json
@@ -1,5 +1,5 @@
 ﻿{
   "Raven/ServerUrl": "http://0.0.0.0:8080",
-  "Raven/DataDir": "C:/Deployment",
+  "Raven/DataDir": "APPDRIVE:\Deployment",
   "Raven/RunInMemory": false
 }

--- a/test/FastTests/Issues/RavenDB_6141.cs
+++ b/test/FastTests/Issues/RavenDB_6141.cs
@@ -1,4 +1,6 @@
-﻿using Raven.Server.Config;
+﻿using System;
+using System.IO;
+using Raven.Server.Config;
 using Raven.Server.Config.Settings;
 using Raven.Server.ServerWide;
 using Xunit;
@@ -21,7 +23,115 @@ namespace FastTests.Issues
             Assert.Null(config.Indexing.JournalsStoragePath);
             Assert.Null(config.Indexing.AdditionalStoragePaths);
 
-            // TODO arek - add more tests, working directory etc..
+            Assert.Null(config.Storage.TempPath);
+            Assert.Null(config.Storage.JournalsStoragePath);
+
+            // actual configuration is created in the following manner
+
+            config = RavenConfiguration.CreateFrom(new RavenConfiguration(null, ResourceType.Server), "foo",
+                ResourceType.Database);
+
+            config.Initialize();
+
+            Assert.Equal(new PathSetting("Databases/foo").FullPath, config.Core.DataDirectory.FullPath);
+            Assert.Equal(new PathSetting("Databases/foo/Indexes").FullPath, config.Indexing.StoragePath.FullPath);
+
+            Assert.Null(config.Indexing.TempPath);
+            Assert.Null(config.Indexing.JournalsStoragePath);
+            Assert.Null(config.Indexing.AdditionalStoragePaths);
+
+            Assert.Null(config.Storage.TempPath);
+            Assert.Null(config.Storage.JournalsStoragePath);
+        }
+
+        [Fact]
+        public void Inherits_server_settings_and_appends_resource_specific_suffix_paths()
+        {
+            var server = new RavenConfiguration(null, ResourceType.Server);
+
+            server.SetSetting(RavenConfiguration.GetKey(x => x.Core.DataDirectory), @"C:\Deployment");
+            
+            server.SetSetting(RavenConfiguration.GetKey(x => x.Storage.TempPath), @"C:\temp");
+            server.SetSetting(RavenConfiguration.GetKey(x => x.Storage.JournalsStoragePath), @"F:\Journals");
+
+            server.SetSetting(RavenConfiguration.GetKey(x => x.Indexing.StoragePath), @"E:\Indexes");
+            server.SetSetting(RavenConfiguration.GetKey(x => x.Indexing.TempPath), @"C:\indexes-temp");
+            server.SetSetting(RavenConfiguration.GetKey(x => x.Indexing.JournalsStoragePath), @"F:\Indexes-Journals");
+
+            server.Initialize();
+
+            var database = RavenConfiguration.CreateFrom(server, "Foo", ResourceType.Database);
+
+            database.Initialize();
+
+            Assert.Equal(new PathSetting(@"C:\Deployment\Databases\Foo").FullPath, database.Core.DataDirectory.FullPath);
+
+            Assert.Equal(new PathSetting(@"C:\temp\Databases\Foo").FullPath, database.Storage.TempPath.FullPath);
+            Assert.Equal(new PathSetting(@"F:\Journals\Databases\Foo").FullPath, database.Storage.JournalsStoragePath.FullPath);
+
+            Assert.Equal(new PathSetting(@"E:\Indexes\Databases\Foo").FullPath, database.Indexing.StoragePath.FullPath);
+            Assert.Equal(new PathSetting(@"C:\indexes-temp\Databases\Foo").FullPath, database.Indexing.TempPath.FullPath);
+            Assert.Equal(new PathSetting(@"F:\Indexes-Journals\Databases\Foo").FullPath, database.Indexing.JournalsStoragePath.FullPath);
+        }
+
+        [Fact]
+        public void Resource_specific_paths_do_not_require_any_suffixes()
+        {
+            var server = new RavenConfiguration(null, ResourceType.Server);
+
+            server.SetSetting(RavenConfiguration.GetKey(x => x.Core.DataDirectory), @"C:\Deployment");
+
+            server.SetSetting(RavenConfiguration.GetKey(x => x.Storage.TempPath), @"C:\temp");
+            server.SetSetting(RavenConfiguration.GetKey(x => x.Storage.JournalsStoragePath), @"F:\Journals");
+
+            server.SetSetting(RavenConfiguration.GetKey(x => x.Indexing.StoragePath), @"E:\Indexes");
+            server.SetSetting(RavenConfiguration.GetKey(x => x.Indexing.TempPath), @"C:\indexes-temp");
+            server.SetSetting(RavenConfiguration.GetKey(x => x.Indexing.JournalsStoragePath), @"F:\Indexes-Journals");
+
+            server.Initialize();
+
+            var database = RavenConfiguration.CreateFrom(server, "Foo", ResourceType.Database);
+
+            database.SetSetting(RavenConfiguration.GetKey(x => x.Core.DataDirectory), @"C:\MyDatabase");
+
+            database.SetSetting(RavenConfiguration.GetKey(x => x.Storage.TempPath), @"C:\my-temp-path");
+            database.SetSetting(RavenConfiguration.GetKey(x => x.Storage.JournalsStoragePath), @"F:\MyJournals");
+
+            database.SetSetting(RavenConfiguration.GetKey(x => x.Indexing.StoragePath), @"E:\MyIndexes");
+            database.SetSetting(RavenConfiguration.GetKey(x => x.Indexing.TempPath), @"C:\my-indexes-temp");
+            database.SetSetting(RavenConfiguration.GetKey(x => x.Indexing.JournalsStoragePath), @"F:\My-Indexes-Journals");
+
+            database.Initialize();
+
+            Assert.Equal(new PathSetting(@"C:\MyDatabase").FullPath, database.Core.DataDirectory.FullPath);
+
+            Assert.Equal(new PathSetting(@"C:\my-temp-path").FullPath, database.Storage.TempPath.FullPath);
+            Assert.Equal(new PathSetting(@"F:\MyJournals").FullPath, database.Storage.JournalsStoragePath.FullPath);
+
+            Assert.Equal(new PathSetting(@"E:\MyIndexes").FullPath, database.Indexing.StoragePath.FullPath);
+            Assert.Equal(new PathSetting(@"C:\my-indexes-temp").FullPath, database.Indexing.TempPath.FullPath);
+            Assert.Equal(new PathSetting(@"F:\My-Indexes-Journals").FullPath, database.Indexing.JournalsStoragePath.FullPath);
+        }
+
+        [Fact]
+        public void Should_handle_APPDRIVE_properly_if_specified()
+        {
+            var server = new RavenConfiguration(null, ResourceType.Server);
+
+            server.SetSetting(RavenConfiguration.GetKey(x => x.Core.DataDirectory), @"APPDRIVE:\RavenData");
+
+            server.Initialize();
+            
+            var rootPath = Path.GetPathRoot(AppContext.BaseDirectory);
+
+            Assert.Equal(new PathSetting($@"{rootPath}RavenData").FullPath, server.Core.DataDirectory.FullPath);
+
+            var database = RavenConfiguration.CreateFrom(server, "Foo", ResourceType.Database);
+
+            database.Initialize();
+
+            Assert.Equal(new PathSetting($@"{rootPath}RavenData\Databases\Foo").FullPath, database.Core.DataDirectory.FullPath);
+            Assert.Equal(new PathSetting($@"{rootPath}RavenData\Databases\Foo\Indexes").FullPath, database.Indexing.StoragePath.FullPath);
         }
     }
 }

--- a/test/SlowTests/Issues/RavenDB_6131.cs
+++ b/test/SlowTests/Issues/RavenDB_6131.cs
@@ -1,4 +1,5 @@
-﻿using System.IO;
+﻿using System.Collections.Generic;
+using System.IO;
 using System.Linq;
 using System.Threading.Tasks;
 using FastTests;
@@ -6,7 +7,6 @@ using FastTests.Server.Basic.Entities;
 using Raven.NewClient.Client.Indexes;
 using Raven.NewClient.Operations.Databases.Indexes;
 using Raven.Server.Config;
-using Raven.Server.Documents;
 using Xunit;
 
 namespace SlowTests.Issues
@@ -26,7 +26,7 @@ namespace SlowTests.Issues
         }
 
         [Fact]
-        public async Task IndexPathsInheritance()
+        public async Task IndexPathsInheritance_DatabaseSpecificSettings()
         {
             var path1 = NewDataPath();
             var path2 = NewDataPath();
@@ -64,6 +64,53 @@ namespace SlowTests.Issues
                 Assert.False(Directory.Exists(storagePath));
                 Assert.False(Directory.Exists(tempPath));
                 Assert.False(Directory.Exists(journalsStoragePath));
+            }
+        }
+
+        [Fact]
+        public async Task IndexPathsInheritance_ServerWideSettings()
+        {
+            var path1 = NewDataPath();
+            var path2 = NewDataPath();
+            var path3 = NewDataPath();
+            var path4 = NewDataPath();
+
+            DoNotReuseServer(new Dictionary<string, string>
+            {
+                {RavenConfiguration.GetKey(x => x.Indexing.StoragePath), path2},
+                {RavenConfiguration.GetKey(x => x.Indexing.TempPath), path3},
+                {RavenConfiguration.GetKey(x => x.Indexing.JournalsStoragePath), path4}
+            });
+
+            using (var server = GetNewServer())
+            {
+                using (var store = GetDocumentStore(path: path1))
+                {
+                    var index = new SimpleIndex();
+                    index.Execute(store);
+
+                    var database = await GetDocumentDatabaseInstanceFor(store);
+                    Assert.Equal(path1, database.Configuration.Core.DataDirectory.FullPath);
+                    Assert.Equal(Path.Combine(path2, "Databases", store.DefaultDatabase), database.Configuration.Indexing.StoragePath.FullPath);
+                    Assert.Equal(Path.Combine(path3, "Databases", store.DefaultDatabase), database.Configuration.Indexing.TempPath.FullPath);
+                    Assert.Equal(Path.Combine(path4, "Databases", store.DefaultDatabase), database.Configuration.Indexing.JournalsStoragePath.FullPath);
+
+                    var indexInstance = database.IndexStore.GetIndex(index.IndexName);
+                    var safeName = indexInstance.GetIndexNameSafeForFileSystem();
+                    var storagePath = Path.Combine(path2, "Databases", store.DefaultDatabase, safeName);
+                    var tempPath = Path.Combine(path3, "Databases", store.DefaultDatabase, safeName);
+                    var journalsStoragePath = Path.Combine(path4, "Databases", store.DefaultDatabase, safeName);
+
+                    Assert.True(Directory.Exists(storagePath));
+                    Assert.True(Directory.Exists(tempPath));
+                    Assert.True(Directory.Exists(journalsStoragePath));
+
+                    await store.Admin.SendAsync(new DeleteIndexOperation(index.IndexName));
+
+                    Assert.False(Directory.Exists(storagePath));
+                    Assert.False(Directory.Exists(tempPath));
+                    Assert.False(Directory.Exists(journalsStoragePath));
+                }
             }
         }
     }


### PR DESCRIPTION
…applies to all types of resources then it can be used instead of Raven/WorkingDir. Adding more tests. Handling APPDRIVE specified in a path