### PR TITLE
RavenDB-5936 Bitness detection in StorageEnvironmentOptions

### DIFF
--- a/src/Raven.Server/Config/Categories/StorageConfiguration.cs
+++ b/src/Raven.Server/Config/Categories/StorageConfiguration.cs
@@ -63,12 +63,10 @@ namespace Raven.Server.Config.Categories
         [LegacyConfigurationEntry("Raven/TransactionJournalsPath")]
         public PathSetting JournalsStoragePath { get; set; }
 
-        // TODO: We always uses voron
-        [Description("Whether to allow Voron to run in 32 bits process.")]
+        [Description("Use the 32 bits memory mapped pager, even when running in 64 bits")]
         [DefaultValue(false)]
-        [ConfigurationEntry("Raven/Storage/AllowOn32Bits")]
-        [LegacyConfigurationEntry("Raven/Voron/AllowOn32Bits")]
-        public bool AllowOn32Bits { get; set; }
+        [ConfigurationEntry("Raven/Storage/ForceUsing32BitPager")]
+        public bool ForceUsing32BitPager { get; set; }
 
         [Description("How long transaction mode (Danger/Lazy) last before returning to Safe mode. Value in Minutes. Default one day. Zero for infinite time")]
         [DefaultValue(1440)]

--- a/src/Raven.Server/Config/RavenConfiguration.cs
+++ b/src/Raven.Server/Config/RavenConfiguration.cs
@@ -170,7 +170,7 @@ namespace Raven.Server.Config
             Encryption.UseSsl = serverConfiguration.Encryption.UseSsl;
             Encryption.UseFips = serverConfiguration.Encryption.UseFips;
 
-            Storage.AllowOn32Bits = serverConfiguration.Storage.AllowOn32Bits;
+            Storage.ForceUsing32BitPager = serverConfiguration.Storage.ForceUsing32BitPager;
         }
 
         public void SetSetting(string key, string value)

--- a/src/Raven.Server/Documents/ConfigurationStorage.cs
+++ b/src/Raven.Server/Documents/ConfigurationStorage.cs
@@ -32,6 +32,7 @@ namespace Raven.Server.Documents
                 : StorageEnvironmentOptions.ForPath(path.FullPath);
 
             options.SchemaVersion = 1;
+            options.ForceUsing32BitPager = db.Configuration.Storage.ForceUsing32BitPager;
 
             Environment = new StorageEnvironment(options);
             

--- a/src/Raven.Server/Documents/DocumentsStorage.cs
+++ b/src/Raven.Server/Documents/DocumentsStorage.cs
@@ -257,6 +257,8 @@ namespace Raven.Server.Documents
                     _documentDatabase.Configuration.Storage.JournalsStoragePath?.FullPath
                     );
 
+            options.ForceUsing32BitPager = _documentDatabase.Configuration.Storage.ForceUsing32BitPager;
+
             try
             {
                 Initialize(options);

--- a/src/Raven.Server/Documents/Indexes/Index.cs
+++ b/src/Raven.Server/Documents/Indexes/Index.cs
@@ -179,6 +179,7 @@ namespace Raven.Server.Documents.Indexes
             try
             {
                 options.SchemaVersion = 1;
+                options.ForceUsing32BitPager = documentDatabase.Configuration.Storage.ForceUsing32BitPager;
 
                 environment = new StorageEnvironment(options);
 
@@ -289,6 +290,8 @@ namespace Raven.Server.Documents.Indexes
                     : StorageEnvironmentOptions.ForPath(indexPath.FullPath, indexTempPath?.FullPath, journalPath?.FullPath);
 
                 options.SchemaVersion = 1;
+                options.ForceUsing32BitPager = documentDatabase.Configuration.Storage.ForceUsing32BitPager;
+
                 try
                 {
                     Initialize(new StorageEnvironment(options), documentDatabase, configuration, performanceHints);
@@ -2081,6 +2084,7 @@ namespace Raven.Server.Documents.Indexes
                     var environmentOptions =
                         (StorageEnvironmentOptions.DirectoryStorageEnvironmentOptions)_environment.Options;
                     var srcOptions = StorageEnvironmentOptions.ForPath(environmentOptions.BasePath);
+                    srcOptions.ForceUsing32BitPager = DocumentDatabase.Configuration.Storage.ForceUsing32BitPager;
 
                     var wasRunning = _indexingThread != null;
 
@@ -2090,6 +2094,8 @@ namespace Raven.Server.Documents.Indexes
 
                     using (var compactOptions = (StorageEnvironmentOptions.DirectoryStorageEnvironmentOptions)StorageEnvironmentOptions.ForPath(compactPath.FullPath))
                     {
+                        compactOptions.ForceUsing32BitPager = DocumentDatabase.Configuration.Storage.ForceUsing32BitPager;
+
                         StorageCompaction.Execute(srcOptions, compactOptions, progressReport =>
                         {
                             progress.Processed = progressReport.GlobalProgress;

--- a/src/Raven.Server/Documents/SubscriptionStorage.cs
+++ b/src/Raven.Server/Documents/SubscriptionStorage.cs
@@ -46,6 +46,8 @@ namespace Raven.Server.Documents
 
             options.SchemaVersion = 1;
             options.TransactionsMode = TransactionsMode.Lazy;
+            options.ForceUsing32BitPager = db.Configuration.Storage.ForceUsing32BitPager;
+
             _environment = new StorageEnvironment(options);
             var databaseName = db.Name;
             _unmanagedBuffersPool = new UnmanagedBuffersPoolWithLowMemoryHandling("Subscriptions", databaseName);

--- a/src/Raven.Server/ServerWide/ServerStore.cs
+++ b/src/Raven.Server/ServerWide/ServerStore.cs
@@ -117,7 +117,7 @@ namespace Raven.Server.ServerWide
                 : StorageEnvironmentOptions.ForPath(path.FullPath);
 
             options.SchemaVersion = 2;
-
+            options.ForceUsing32BitPager = Configuration.Storage.ForceUsing32BitPager;
             try
             {
                 StorageEnvironment.MaxConcurrentFlushes = Configuration.Storage.MaxConcurrentFlushes;

--- a/src/Voron/Impl/Backup/IncrementalBackup.cs
+++ b/src/Voron/Impl/Backup/IncrementalBackup.cs
@@ -11,6 +11,9 @@ using System.Diagnostics;
 using System.IO;
 using System.IO.Compression;
 using System.Linq;
+using System.Threading;
+using Sparrow.Json;
+using Sparrow.Utils;
 using Voron.Data.BTrees;
 using Voron.Impl.Journal;
 using Voron.Impl.Paging;
@@ -271,7 +274,7 @@ namespace Voron.Impl.Backup
             }
         }
 
-        public void Restore(string outPath, IEnumerable<string> backupPaths)
+        public void Restore(string outPath, IEnumerable<string> backupPaths, Action<StorageEnvironmentOptions> configure = null)
         {
             foreach (var backupPath in backupPaths)
             {
@@ -284,6 +287,7 @@ namespace Voron.Impl.Backup
                         using (var options = StorageEnvironmentOptions.ForPath(Path.Combine(outPath, dir.Key)))
                         {
                             options.ManualFlushing = true;
+                            configure?.Invoke(options);
                             using (var env = new StorageEnvironment(options))
                             {
                                 Restore(env, dir);

--- a/src/Voron/Impl/Journal/JournalReader.cs
+++ b/src/Voron/Impl/Journal/JournalReader.cs
@@ -301,8 +301,8 @@ namespace Voron.Impl.Journal
             return checked((int)(size / Constants.Storage.PageSize) + (size % Constants.Storage.PageSize == 0 ? 0 : 1));
         }
 
-        Dictionary<AbstractPager, SparseMemoryMappedPager.TransactionState> IPagerLevelTransactionState.
-            SparsePagerTransactionState
+        Dictionary<AbstractPager, Windows32BitMemoryMapPager.TransactionState> IPagerLevelTransactionState.
+            Windows32BitPagerTransactionState
         { get; set; }
 
         public event Action<IPagerLevelTransactionState> OnDispose;

--- a/src/Voron/Impl/LowLevelTransaction.cs
+++ b/src/Voron/Impl/LowLevelTransaction.cs
@@ -22,7 +22,7 @@ namespace Voron.Impl
 {
     public interface IPagerLevelTransactionState : IDisposable
     {
-        Dictionary<AbstractPager, SparseMemoryMappedPager.TransactionState> SparsePagerTransactionState { get; set; }
+        Dictionary<AbstractPager, Windows32BitMemoryMapPager.TransactionState> Windows32BitPagerTransactionState { get; set; }
         event Action<IPagerLevelTransactionState> OnDispose;
         void EnsurePagerStateReference(PagerState state);
         StorageEnvironment Environment { get; }
@@ -46,7 +46,7 @@ namespace Voron.Impl
         private readonly WriteAheadJournal _journal;
         internal readonly List<JournalSnapshot> JournalSnapshots = new List<JournalSnapshot>();
 
-        Dictionary<AbstractPager, SparseMemoryMappedPager.TransactionState> IPagerLevelTransactionState.SparsePagerTransactionState
+        Dictionary<AbstractPager, Windows32BitMemoryMapPager.TransactionState> IPagerLevelTransactionState.Windows32BitPagerTransactionState
         {
             get;
             set;

--- a/src/Voron/Impl/Paging/TempPagerTransaction.cs
+++ b/src/Voron/Impl/Paging/TempPagerTransaction.cs
@@ -10,7 +10,7 @@ namespace Voron.Impl.Paging
             OnDispose?.Invoke(this);
         }
 
-        public Dictionary<AbstractPager, SparseMemoryMappedPager.TransactionState> SparsePagerTransactionState
+        public Dictionary<AbstractPager, Windows32BitMemoryMapPager.TransactionState> Windows32BitPagerTransactionState
         {
             get; set;
         }

--- a/src/Voron/Platform/Win32/Win32JournalWriter.cs
+++ b/src/Voron/Platform/Win32/Win32JournalWriter.cs
@@ -137,8 +137,10 @@ namespace Voron.Platform.Win32
 
         public AbstractPager CreatePager()
         {
-            return new Win32MemoryMapPager(_options, _filename);
-            //return new SparseMemoryMappedPager(_options,_filename);
+            if (_options.RunningOn32Bits)
+                return new Windows32BitMemoryMapPager(_options, _filename);
+
+            return new WindowsMemoryMapPager(_options, _filename);
         }
 
         public bool Read(byte* buffer, long numOfBytes, long offsetInFile)

--- a/src/Voron/Platform/Win32/WindowsMemoryMapPager.cs
+++ b/src/Voron/Platform/Win32/WindowsMemoryMapPager.cs
@@ -22,7 +22,7 @@ using static Voron.Platform.Win32.Win32NativeMethods;
 
 namespace Voron.Platform.Win32
 {
-    public unsafe class Win32MemoryMapPager : AbstractPager
+    public unsafe class WindowsMemoryMapPager : AbstractPager
     {
         public readonly long AllocationGranularity;
         private long _totalAllocationSize;
@@ -48,7 +48,7 @@ namespace Voron.Platform.Win32
             public uint High;
         }
 
-        public Win32MemoryMapPager(StorageEnvironmentOptions options,string file,
+        public WindowsMemoryMapPager(StorageEnvironmentOptions options,string file,
             long? initialFileSize = null,
             Win32NativeFileAttributes fileAttributes = Win32NativeFileAttributes.Normal,
             Win32NativeFileAccess access = Win32NativeFileAccess.GenericRead | Win32NativeFileAccess.GenericWrite,

--- a/test/FastTests/Voron/Backups/BackupToOneZipFile.cs
+++ b/test/FastTests/Voron/Backups/BackupToOneZipFile.cs
@@ -207,11 +207,12 @@ namespace FastTests.Voron.Backups
                     database.IncrementalBackupTo(Path.Combine(tempFileName,
                         string.Format("voron-test.{0}-incremental-backup.zip", 1)));
 
+                    var forceUsing32BitPager = database.Configuration.Storage.ForceUsing32BitPager;
                     BackupMethods.Incremental.Restore(Path.Combine(tempFileName, "backup-test.data"), new[]
                     {
                         Path.Combine(tempFileName, "voron-test.0-incremental-backup.zip"),
                         Path.Combine(tempFileName, "voron-test.1-incremental-backup.zip")
-                    });
+                    }, options => options.ForceUsing32BitPager = forceUsing32BitPager);
                 }
             }
             using (var database = CreateDocumentDatabase(runInMemory: false, dataDirectory: Path.Combine(tempFileName, "backup-test.data")))

--- a/test/Tests.Infrastructure/TestBase.cs
+++ b/test/Tests.Infrastructure/TestBase.cs
@@ -95,7 +95,6 @@ namespace FastTests
             configuration.Core.RunInMemory = true;
             configuration.Core.DataDirectory = configuration.Core.DataDirectory.Combine($"Tests{Interlocked.Increment(ref _serverCounter)}");
             configuration.Server.MaxTimeForTaskToWaitForDatabaseToLoad = new TimeSetting(60, TimeUnit.Seconds);
-            configuration.Storage.AllowOn32Bits = true;
 
             IOExtensions.DeleteDirectory(configuration.Core.DataDirectory.FullPath);
 


### PR DESCRIPTION
- Allow to pass configuration "ForceUsing32BitPager"
- Rename SparseMemoryMapPager to Windows32BitMemoryMapPager
- Rename Win32MemoryMapPager to WindowsMemoryMapPager
- Unit Tests _NOT_ handled yet - still running only in 64 bit mode