### PR TITLE
RavenDB-6296 Configuration file not being parsed

### DIFF
--- a/src/Raven.Server/Config/RavenConfiguration.cs
+++ b/src/Raven.Server/Config/RavenConfiguration.cs
@@ -2,6 +2,7 @@
 using System.Collections;
 using System.Collections.Generic;
 using System.ComponentModel;
+using System.IO;
 using System.Linq;
 using System.Linq.Expressions;
 using System.Reflection;
@@ -108,6 +109,7 @@ namespace Raven.Server.Config
             if (PlatformDetails.RunningOnPosix)
                 platformPostfix = "posix";
 
+            _configBuilder.SetBasePath(Directory.GetCurrentDirectory());
             _configBuilder.AddJsonFile($"settings_{platformPostfix}.json", optional: true);
         }
 

--- a/src/Raven.Server/settings_windows.json
+++ b/src/Raven.Server/settings_windows.json
@@ -1,5 +1,5 @@
 ﻿{
   "Raven/ServerUrl": "http://0.0.0.0:8080",
-  "Raven/DataDir": "APPDRIVE:\Deployment",
+  "Raven/DataDir": "APPDRIVE:\\Deployment",
   "Raven/RunInMemory": false
 }


### PR DESCRIPTION
- Make sure it's being parsed from its current location
- Double escape Raven/DataDir's path