### PR TITLE
No need to create string instance since LazyStringValue exposes Start…

### DIFF
--- a/src/Raven.Server/Documents/DocumentsStorage.cs
+++ b/src/Raven.Server/Documents/DocumentsStorage.cs
@@ -416,11 +416,11 @@ namespace Raven.Server.Documents
                     }
                     docCount++;
                     var document = TableValueToDocument(context, ref result.Reader);
-                    string documentKey = document.Key;
-                    if (documentKey.StartsWith(prefix, StringComparison.CurrentCultureIgnoreCase) == false)
+                    
+                    if (document.Key.StartsWith(prefix) == false)
                         break;
 
-                    var keyTest = documentKey.Substring(prefix.Length);
+                    var keyTest = document.Key.Substring(prefix.Length);
                     if (!WildcardMatcher.Matches(matches, keyTest) ||
                         WildcardMatcher.MatchesExclusion(exclude, keyTest))
                         continue;


### PR DESCRIPTION
…sWith and Substring methods