### PR TITLE
RavenDB-6141 Path like "~/" should take into account Raven/DataDir de…

### DIFF
--- a/src/Raven.Server/Config/RavenConfiguration.cs
+++ b/src/Raven.Server/Config/RavenConfiguration.cs
@@ -12,8 +12,6 @@ using Raven.Server.Config.Categories;
 using Raven.Server.Config.Settings;
 using Raven.Server.ServerWide;
 using ExpressionExtensions = Raven.Server.Extensions.ExpressionExtensions;
-using Sparrow;
-using Sparrow.Logging;
 using Sparrow.Platform;
 
 namespace Raven.Server.Config
@@ -157,6 +155,9 @@ namespace Raven.Server.Config
             PostInit();
 
             Initialized = true;
+
+            if (ResourceType == ResourceType.Server && Settings[GetKey(x => x.Core.DataDirectory)] != null)
+                PathSetting.BaseDataDir = Core.DataDirectory;
 
             return this;
         }

--- a/src/Raven.Server/Config/Settings/PathSetting.cs
+++ b/src/Raven.Server/Config/Settings/PathSetting.cs
@@ -9,6 +9,8 @@ namespace Raven.Server.Config.Settings
 {
     public class PathSetting
     {
+        public static PathSetting BaseDataDir { get; set; }
+
         private readonly string _path;
 
         private string _fullPath;
@@ -45,9 +47,11 @@ namespace Raven.Server.Config.Settings
             path = Environment.ExpandEnvironmentVariables(path);
 
             if (path.StartsWith(@"~\") || path.StartsWith(@"~/"))
-                path = Path.Combine(AppContext.BaseDirectory, path.Substring(2));
+                path = Path.Combine(BaseDataDir?.FullPath ?? AppContext.BaseDirectory, path.Substring(2));
 
-            var result = Path.IsPathRooted(path) ? path : Path.Combine(AppContext.BaseDirectory, path);
+            var result = Path.IsPathRooted(path)
+                ? path
+                : Path.Combine(BaseDataDir?.FullPath ?? AppContext.BaseDirectory, path);
 
             if (PlatformDetails.RunningOnPosix)
                 return PosixHelper.FixLinuxPath(result);

--- a/test/FastTests/Issues/RavenDB_6141.cs
+++ b/test/FastTests/Issues/RavenDB_6141.cs
@@ -133,5 +133,25 @@ namespace FastTests.Issues
             Assert.Equal(new PathSetting($@"{rootPath}RavenData\Databases\Foo").FullPath, database.Core.DataDirectory.FullPath);
             Assert.Equal(new PathSetting($@"{rootPath}RavenData\Databases\Foo\Indexes").FullPath, database.Indexing.StoragePath.FullPath);
         }
+
+        [Fact]
+        public void Should_create_data_in_directory_specified_at_server_level()
+        {
+            var server = new RavenConfiguration(null, ResourceType.Server);
+
+            server.SetSetting(RavenConfiguration.GetKey(x => x.Core.DataDirectory), @"C:\RavenData");
+
+            server.Initialize();
+
+            var database = RavenConfiguration.CreateFrom(server, "Foo", ResourceType.Database);
+
+            database.SetSetting(RavenConfiguration.GetKey(x => x.Core.DataDirectory), @"~/Items");
+            database.SetSetting(RavenConfiguration.GetKey(x => x.Indexing.StoragePath), @"~/Items/Indexes");
+
+            database.Initialize();
+
+            Assert.Equal(new PathSetting(@"C:\RavenData\Items").FullPath, database.Core.DataDirectory.FullPath);
+            Assert.Equal(new PathSetting($@"C:\RavenData\Items\Indexes").FullPath, database.Indexing.StoragePath.FullPath);
+        }
     }
 }


### PR DESCRIPTION
…fined globally in settings.json file