### PR TITLE
String comparisons should not be culture sensitive

### DIFF
--- a/src/Raven.Server/Documents/Document.cs
+++ b/src/Raven.Server/Documents/Document.cs
@@ -138,7 +138,7 @@ namespace Raven.Server.Documents
             foreach (var property in properties)
             {
                 if (isMetadata && property[0] == '@' && 
-                    property.Equals(Constants.Metadata.Collection, StringComparison.CurrentCultureIgnoreCase) == false)
+                    property.Equals(Constants.Metadata.Collection, StringComparison.OrdinalIgnoreCase) == false)
                     continue;
 
                 object myProperty;

--- a/src/Raven.Server/Documents/DocumentsStorage.cs
+++ b/src/Raven.Server/Documents/DocumentsStorage.cs
@@ -418,7 +418,7 @@ namespace Raven.Server.Documents
                     docCount++;
                     var document = TableValueToDocument(context, ref result.Reader);
                     string documentKey = document.Key;
-                    if (documentKey.StartsWith(prefix, StringComparison.CurrentCultureIgnoreCase) == false)
+                    if (documentKey.StartsWith(prefix, StringComparison.OrdinalIgnoreCase) == false)
                         break;
 
                     var keyTest = documentKey.Substring(prefix.Length);

--- a/src/Raven.Server/Documents/Replication/IncomingConnectionInfo.cs
+++ b/src/Raven.Server/Documents/Replication/IncomingConnectionInfo.cs
@@ -32,7 +32,7 @@ namespace Raven.Server.Documents.Replication
         {
             if (ReferenceEquals(null, other)) return false;
             if (ReferenceEquals(this, other)) return true;
-            return string.Equals(SourceDatabaseName, other.SourceDatabaseName, StringComparison.CurrentCultureIgnoreCase) && string.Equals(SourceUrl, other.SourceUrl, StringComparison.CurrentCultureIgnoreCase) && string.Equals(SourceMachineName, other.SourceMachineName, StringComparison.CurrentCultureIgnoreCase);
+            return string.Equals(SourceDatabaseName, other.SourceDatabaseName, StringComparison.OrdinalIgnoreCase) && string.Equals(SourceUrl, other.SourceUrl, StringComparison.OrdinalIgnoreCase) && string.Equals(SourceMachineName, other.SourceMachineName, StringComparison.CurrentCultureIgnoreCase);
         }
 
         public override bool Equals(object obj)


### PR DESCRIPTION
After rebasing to latest v4.0 failing tests are passing