### PR TITLE
RavenDB-6328 - Limit the size of each ScratchBuffer to 256MB

### DIFF
--- a/Raven.Abstractions/Data/Constants.cs
+++ b/Raven.Abstractions/Data/Constants.cs
@@ -411,6 +411,8 @@ namespace Raven.Abstractions.Data
 
             public const string MaxScratchBufferSize = "Raven/Voron/MaxScratchBufferSize";
 
+            public const string MaxSizePerScratchBufferFile = "Raven/Voron/MaxSizePerScratchBufferFile";
+
             public const string AllowOn32Bits = "Raven/Voron/AllowOn32Bits";
 
             public const string ScratchBufferSizeNotificationThreshold = "Raven/Voron/ScratchBufferSizeNotificationThreshold";

--- a/Raven.Database/Config/InMemoryRavenConfiguration.cs
+++ b/Raven.Database/Config/InMemoryRavenConfiguration.cs
@@ -335,6 +335,7 @@ namespace Raven.Database.Config
             Storage.Voron.MaxBufferPoolSize = Math.Max(2, ravenSettings.Voron.MaxBufferPoolSize.Value);
             Storage.Voron.InitialFileSize = ravenSettings.Voron.InitialFileSize.Value;
             Storage.Voron.MaxScratchBufferSize = ravenSettings.Voron.MaxScratchBufferSize.Value;
+            Storage.Voron.MaxSizePerScratchBufferFile = ravenSettings.Voron.MaxSizePerScratchBufferFile.Value;
             Storage.Voron.ScratchBufferSizeNotificationThreshold = ravenSettings.Voron.ScratchBufferSizeNotificationThreshold.Value;
             Storage.Voron.AllowIncrementalBackups = ravenSettings.Voron.AllowIncrementalBackups.Value;
             Storage.Voron.TempPath = ravenSettings.Voron.TempPath.Value;
@@ -1511,6 +1512,12 @@ namespace Raven.Database.Config
                 /// Default: 6144.
                 /// </summary>
                 public int MaxScratchBufferSize { get; set; }
+
+                /// <summary>
+                /// The maximum per scratch buffer file size. The value is in megabytes. 
+                /// Default: 256.
+                /// </summary>
+                public int MaxSizePerScratchBufferFile { get; set; }
 
                 /// <summary>
                 /// The minimum number of megabytes after which each scratch buffer size increase will create a notification. Used for indexing batch size tuning.

--- a/Raven.Database/Config/StronglyTypedRavenSettings.cs
+++ b/Raven.Database/Config/StronglyTypedRavenSettings.cs
@@ -252,6 +252,7 @@ namespace Raven.Database.Config
             Voron.MaxBufferPoolSize = new IntegerSetting(settings[Constants.Voron.MaxBufferPoolSize], 4);
             Voron.InitialFileSize = new NullableIntegerSetting(settings[Constants.Voron.InitialFileSize], (int?)null);
             Voron.MaxScratchBufferSize = new IntegerSetting(settings[Constants.Voron.MaxScratchBufferSize], 6144);
+            Voron.MaxSizePerScratchBufferFile = new IntegerSetting(settings[Constants.Voron.MaxSizePerScratchBufferFile], 256);
 
             var maxScratchBufferSize = Voron.MaxScratchBufferSize.Value;
             var scratchBufferSizeNotificationThreshold = -1;
@@ -545,6 +546,8 @@ namespace Raven.Database.Config
             public NullableIntegerSetting InitialFileSize { get; set; }
 
             public IntegerSetting MaxScratchBufferSize { get; set; }
+
+            public IntegerSetting MaxSizePerScratchBufferFile { get; set; }
 
             public IntegerSetting ScratchBufferSizeNotificationThreshold { get; set; }
 

--- a/Raven.Database/Storage/Voron/TransactionalStorage.cs
+++ b/Raven.Database/Storage/Voron/TransactionalStorage.cs
@@ -458,6 +458,7 @@ namespace Raven.Storage.Voron
             var options = StorageEnvironmentOptions.CreateMemoryOnly(configuration.Storage.Voron.TempPath);
             options.InitialFileSize = configuration.Storage.Voron.InitialFileSize;
             options.MaxScratchBufferSize = configuration.Storage.Voron.MaxScratchBufferSize * 1024L * 1024L;
+            options.MaxSizePerScratchBufferFile = configuration.Storage.Voron.MaxSizePerScratchBufferFile * 1024L * 1024L;
 
             return options;
         }
@@ -482,6 +483,7 @@ namespace Raven.Storage.Voron
             options.IncrementalBackupEnabled = configuration.Storage.Voron.AllowIncrementalBackups;
             options.InitialFileSize = configuration.Storage.Voron.InitialFileSize;
             options.MaxScratchBufferSize = configuration.Storage.Voron.MaxScratchBufferSize * 1024L * 1024L;
+            options.MaxSizePerScratchBufferFile = configuration.Storage.Voron.MaxSizePerScratchBufferFile * 1024L * 1024L;
 
             return options;
         }

--- a/Raven.Voron/Voron/StorageEnvironmentOptions.cs
+++ b/Raven.Voron/Voron/StorageEnvironmentOptions.cs
@@ -63,6 +63,8 @@ namespace Voron
 
         public long MaxScratchBufferSize { get; set; }
 
+        public long MaxSizePerScratchBufferFile { get; set; }
+
         public long MaxNumberOfPagesInMergedTransaction { get; set; }
 
         public bool OwnsPagers { get; set; }
@@ -100,6 +102,8 @@ namespace Voron
             InitialLogFileSize = 64 * 1024;
 
             MaxScratchBufferSize = 512 * 1024 * 1024;
+
+            MaxSizePerScratchBufferFile = 256 * 1024 * 1024;
 
             ScratchBufferOverflowTimeout = 5000;
 


### PR DESCRIPTION
http://issues.hibernatingrhinos.com/issue/RavenDB-6328