### PR TITLE
RavenDB-6335 Prevent from using free space handling when we are split…

### DIFF
--- a/Raven.Voron/Voron.Tests/Trees/FreeSpaceTest.cs
+++ b/Raven.Voron/Voron.Tests/Trees/FreeSpaceTest.cs
@@ -3,6 +3,7 @@ using System.Collections.Generic;
 using System.IO;
 using Voron.Impl.FreeSpace;
 using Xunit;
+using Xunit.Extensions;
 
 namespace Voron.Tests.Trees
 {
@@ -121,12 +122,18 @@ namespace Voron.Tests.Trees
             }
         }
 
-        [PrefixesFact]
-        public void FreeSpaceHandlingShouldNotReturnPagesThatAreAlreadyAllocated()
+        [PrefixesTheory]
+        [InlineData(60, 2)]
+        [InlineData(60, 893)]
+        [InlineData(60, 6430)]
+        [InlineData(60, 7749)]
+        [InlineData(56, 893)]
+        [InlineDataWithRandomSeed(60)]
+        [InlineDataWithRandomSeed(-1)] // also random 'numberOfFreedPages'
+        public void FreeSpaceHandlingShouldNotReturnPagesThatAreAlreadyAllocated(int numberOfFreedPages, int seed)
         {
             const int maxPageNumber = 400000;
-            const int numberOfFreedPages = 60;
-            var random = new Random(2);
+            var random = new Random(seed);
             var freedPages = new HashSet<long>();
 
             using (var tx = Env.NewTransaction(TransactionFlags.ReadWrite))
@@ -134,6 +141,11 @@ namespace Voron.Tests.Trees
                 tx.State.NextPageNumber = maxPageNumber + 1;
 
                 tx.Commit();
+            }
+
+            if (numberOfFreedPages == -1)
+            {
+                numberOfFreedPages = random.Next(0, 10000);
             }
 
             for (int i = 0; i < numberOfFreedPages; i++)
@@ -153,7 +165,9 @@ namespace Voron.Tests.Trees
             }
 
             var alreadyReused = new List<long>();
+            var freedInternallyByFreeSpaceHandling = new HashSet<long>();
 
+            ((FreeSpaceHandling)Env.FreeSpaceHandling).PageFreed += pageNumber => freedInternallyByFreeSpaceHandling.Add(pageNumber); // need to take into account pages freed by free space handling itself
             do
             {
                 using (var tx = Env.NewTransaction(TransactionFlags.ReadWrite))
@@ -166,7 +180,7 @@ namespace Voron.Tests.Trees
                     }
 
                     Assert.False(alreadyReused.Contains(page.Value), "Free space handling returned a page number that has been already allocated. Page number: " + page);
-                    Assert.True(freedPages.Remove(page.Value));
+                    Assert.True(freedPages.Remove(page.Value) || freedInternallyByFreeSpaceHandling.Remove(page.Value));
 
                     alreadyReused.Add(page.Value);
 

--- a/Raven.Voron/Voron/Impl/Backup/IncrementalBackup.cs
+++ b/Raven.Voron/Voron/Impl/Backup/IncrementalBackup.cs
@@ -324,6 +324,7 @@ namespace Voron.Impl.Backup
                             var root = Tree.Open(txw, &lastTxHeader->Root);
                             var freeSpaceRoot = Tree.Open(txw, &lastTxHeader->FreeSpace);
                             freeSpaceRoot.Name = Constants.FreeSpaceTreeName;
+                            freeSpaceRoot.IsFreeSpaceTree = true;
                             root.Name = Constants.RootTreeName;
 
                             txw.UpdateRootsIfNeeded(root, freeSpaceRoot);

--- a/Raven.Voron/Voron/Impl/FreeSpace/FreeSpaceHandling.cs
+++ b/Raven.Voron/Voron/Impl/FreeSpace/FreeSpaceHandling.cs
@@ -1,3 +1,4 @@
+using System;
 using System.Collections.Generic;
 using Voron.Trees;
 using Voron.Util.Conversion;
@@ -8,6 +9,17 @@ namespace Voron.Impl.FreeSpace
     {
         internal const int NumberOfPagesInSection = 256 * 8; // 256 bytes, 8 bits per byte = 2,048 - each section 8 MB in size
 
+        private readonly FreeSpaceHandlingDisabler _disableStatus = new FreeSpaceHandlingDisabler();
+
+        private readonly FreeSpaceRecursiveCallGuard _guard;
+
+        public FreeSpaceHandling()
+        {
+            _guard = new FreeSpaceRecursiveCallGuard(this);
+        }
+
+        public event Action<long> PageFreed;
+
         public long? TryAllocateFromFreeSpace(Transaction tx, int num)
         {
             if (tx.State.FreeSpaceRoot == null)
@@ -16,16 +28,25 @@ namespace Voron.Impl.FreeSpace
             if (tx.FreeSpaceRoot.State.EntriesCount == 0)
                 return null;
 
-            using (var it = tx.FreeSpaceRoot.Iterate())
-            {
-                if (it.Seek(Slice.BeforeAllKeys) == false)
-                    return null;
+            if (_disableStatus.DisableCount > 0)
+                return null;
 
-                if (num < NumberOfPagesInSection)
+            if (_guard.IsEntered)
+                return null;
+
+            using (_guard.Enter(tx))
+            {
+                using (var it = tx.FreeSpaceRoot.Iterate())
                 {
-                    return TryFindSmallValue(tx, it, num);
+                    if (it.Seek(Slice.BeforeAllKeys) == false)
+                        return null;
+
+                    if (num < NumberOfPagesInSection)
+                    {
+                        return TryFindSmallValue(tx, it, num);
+                    }
+                    return TryFindLargeValue(tx, it, num);
                 }
-                return TryFindLargeValue(tx, it, num);
             }
         }
 
@@ -267,12 +288,32 @@ namespace Voron.Impl.FreeSpace
 
         public void FreePage(Transaction tx, long pageNumber)
         {
-            var section = pageNumber / NumberOfPagesInSection;
-            var sectionKey = new Slice(EndianBitConverter.Big.GetBytes(section));
-            var result = tx.FreeSpaceRoot.Read(sectionKey);
-            var sba = result == null ? new StreamBitArray() : new StreamBitArray(result.Reader);
-            sba.Set((int)(pageNumber % NumberOfPagesInSection), true);
-            tx.FreeSpaceRoot.Add(sectionKey, sba.ToStream());
+            if (_guard.IsEntered)
+            {
+                _guard.PagesFreed.Add(pageNumber);
+                return;
+            }
+
+            using (_guard.Enter(tx))
+            {
+                var section = pageNumber / NumberOfPagesInSection;
+                var sectionKey = new Slice(EndianBitConverter.Big.GetBytes(section));
+                var result = tx.FreeSpaceRoot.Read(sectionKey);
+                var sba = result == null ? new StreamBitArray() : new StreamBitArray(result.Reader);
+                sba.Set((int) (pageNumber % NumberOfPagesInSection), true);
+                tx.FreeSpaceRoot.Add(sectionKey, sba.ToStream());
+
+                var onPageFreed = PageFreed;
+
+                if (onPageFreed != null)
+                    onPageFreed.Invoke(pageNumber);
+            }
+        }
+
+        public FreeSpaceHandlingDisabler Disable()
+        {
+            _disableStatus.DisableCount++;
+            return _disableStatus;
         }
     }
 }

--- a/Raven.Voron/Voron/Impl/FreeSpace/FreeSpaceHandlingDisabler.cs
+++ b/Raven.Voron/Voron/Impl/FreeSpace/FreeSpaceHandlingDisabler.cs
@@ -1,0 +1,19 @@
+﻿// -----------------------------------------------------------------------
+//  <copyright file="FreeSpaceHandlingDisabler.cs" company="Hibernating Rhinos LTD">
+//      Copyright (c) Hibernating Rhinos LTD. All rights reserved.
+//  </copyright>
+// -----------------------------------------------------------------------
+using System;
+
+namespace Voron.Impl.FreeSpace
+{
+    public class FreeSpaceHandlingDisabler : IDisposable
+    {
+        public int DisableCount;
+
+        public void Dispose()
+        {
+            DisableCount--;
+        }
+    }
+}

--- a/Raven.Voron/Voron/Impl/FreeSpace/FreeSpaceRecursiveCallGuard.cs
+++ b/Raven.Voron/Voron/Impl/FreeSpace/FreeSpaceRecursiveCallGuard.cs
@@ -1,0 +1,51 @@
+﻿// -----------------------------------------------------------------------
+//  <copyright file="FreeSpaceRecursiveCallGuard.cs" company="Hibernating Rhinos LTD">
+//      Copyright (c) Hibernating Rhinos LTD. All rights reserved.
+//  </copyright>
+// -----------------------------------------------------------------------
+using System;
+using System.Collections.Generic;
+using System.Runtime.CompilerServices;
+
+namespace Voron.Impl.FreeSpace
+{
+    public class FreeSpaceRecursiveCallGuard : IDisposable
+    {
+        private readonly FreeSpaceHandling _freeSpaceHandling;
+        public bool IsEntered;
+        private Transaction _tx;
+        public List<long> PagesFreed = new List<long>();
+
+        public FreeSpaceRecursiveCallGuard(FreeSpaceHandling freeSpaceHandling)
+        {
+            _freeSpaceHandling = freeSpaceHandling;
+        }
+
+        [MethodImpl(MethodImplOptions.AggressiveInlining)]
+        public IDisposable Enter(Transaction tx)
+        {
+            if (IsEntered)
+                throw new InvalidOperationException("Free space handling cannot be called recursively");
+
+            IsEntered = true;
+            _tx = tx;
+            return this;
+        }
+
+        public void Dispose()
+        {
+            IsEntered = false;
+            if (PagesFreed == null)
+                return;
+            var copy = PagesFreed;
+            PagesFreed = null;
+            foreach (var page in copy)
+            {
+                _freeSpaceHandling.FreePage(_tx, page);
+            }
+            _tx = null;
+            copy.Clear();
+            PagesFreed = copy;
+        }
+    }
+}

--- a/Raven.Voron/Voron/Impl/FreeSpace/IFreeSpaceHandling.cs
+++ b/Raven.Voron/Voron/Impl/FreeSpace/IFreeSpaceHandling.cs
@@ -7,5 +7,6 @@ namespace Voron.Impl.FreeSpace
         long? TryAllocateFromFreeSpace(Transaction tx, int num);
         List<long> AllPages(Transaction tx);
         void FreePage(Transaction tx, long pageNumber);
+        FreeSpaceHandlingDisabler Disable();
     }
 }

--- a/Raven.Voron/Voron/Impl/FreeSpace/NoFreeSpaceHandling.cs
+++ b/Raven.Voron/Voron/Impl/FreeSpace/NoFreeSpaceHandling.cs
@@ -18,5 +18,10 @@ namespace Voron.Impl.FreeSpace
         {
             
         }
+
+        public FreeSpaceHandlingDisabler Disable()
+        {
+            return null;
+        }
     }
 }

--- a/Raven.Voron/Voron/Impl/Transaction.cs
+++ b/Raven.Voron/Voron/Impl/Transaction.cs
@@ -74,6 +74,7 @@ namespace Voron.Impl
         private PageFromScratchBuffer _transactionHeaderPage;
         private readonly HashSet<PageFromScratchBuffer> _transactionPages = new HashSet<PageFromScratchBuffer>();
         private readonly HashSet<long> _freedPages = new HashSet<long>();
+        private readonly Stack<long> _pagesToFreeOnCommit = new Stack<long>();
         private readonly List<PageFromScratchBuffer> _unusedScratchPages = new List<PageFromScratchBuffer>();
         private readonly Dictionary<string, Tree> _trees = new Dictionary<string, Tree>();
         private readonly Dictionary<int, PagerState> _scratchPagerStates;
@@ -144,7 +145,7 @@ namespace Voron.Impl
             if (_state.FreeSpaceRoot != null)
             {
                 _state.FreeSpaceRoot.InWriteTransaction = Flags == TransactionFlags.ReadWrite;
-                _freeSpace = new Tree(this, _state.FreeSpaceRoot) {Name = Constants.FreeSpaceTreeName};
+                _freeSpace = new Tree(this, _state.FreeSpaceRoot) {Name = Constants.FreeSpaceTreeName, IsFreeSpaceTree = true };
             }
         }
 
@@ -428,6 +429,11 @@ namespace Voron.Impl
 
             FlushAllMultiValues();
 
+            while (_pagesToFreeOnCommit.Count > 0)
+            {
+                FreePage(_pagesToFreeOnCommit.Pop());
+            }
+
             State.Root.InWriteTransaction = false;
             State.FreeSpaceRoot.InWriteTransaction = false;
 
@@ -548,6 +554,11 @@ namespace Voron.Impl
             }
         }
 
+        internal void FreePageOnCommit(long pageNumber)
+        {
+            _pagesToFreeOnCommit.Push(pageNumber);
+        }
+
         internal void FreePage(long pageNumber)
         {
             if (_disposed)
@@ -588,6 +599,8 @@ namespace Voron.Impl
 
         internal void UpdateRootsIfNeeded(Tree root, Tree freeSpace)
         {
+            Debug.Assert(freeSpace.IsFreeSpaceTree);
+
             //can only happen during initial transaction that creates Root and FreeSpaceRoot trees
             if (State.Root != null || State.FreeSpaceRoot != null) 
                 return;

--- a/Raven.Voron/Voron/StorageEnvironment.cs
+++ b/Raven.Voron/Voron/StorageEnvironment.cs
@@ -135,6 +135,7 @@ namespace Voron
             {
                 var root = Tree.Open(tx, header->TransactionId == 0 ? &entry.Root : &header->Root);
                 var freeSpace = Tree.Open(tx, header->TransactionId == 0 ? &entry.FreeSpace : &header->FreeSpace);
+                freeSpace.IsFreeSpaceTree = true;
 
                 tx.UpdateRootsIfNeeded(root, freeSpace);
                 tx.Commit();
@@ -153,6 +154,7 @@ namespace Voron
             {
                 var root = Tree.Create(tx, false);
                 var freeSpace = Tree.Create(tx, false);
+                freeSpace.IsFreeSpaceTree = true;
 
                 // important to first create the two trees, then set them on the env
                 tx.UpdateRootsIfNeeded(root, freeSpace);

--- a/Raven.Voron/Voron/Trees/PageSplitter.cs
+++ b/Raven.Voron/Voron/Trees/PageSplitter.cs
@@ -1,8 +1,8 @@
 using System;
 using System.Diagnostics;
-using System.Linq;
 using System.Text;
 using Voron.Impl;
+using Voron.Impl.FreeSpace;
 using Voron.Impl.Paging;
 
 namespace Voron.Trees
@@ -47,103 +47,84 @@ namespace Voron.Trees
 
         public byte* Execute()
         {
-            Page rightPage = _tree.NewPage(_page.Flags, 1);
-
-            if (_cursor.PageCount == 0) // we need to do a root split
+            using (_tree.IsFreeSpaceTree ? _tx.Environment.FreeSpaceHandling.Disable() : null)
             {
-                Page newRootPage = _tree.NewPage(_tree.KeysPrefixing ? PageFlags.Branch | PageFlags.KeysPrefixed : PageFlags.Branch, 1);
-                _cursor.Push(newRootPage);
-                _treeState.RootPageNumber = newRootPage.PageNumber;
-                _treeState.Depth++;
+                Page rightPage = _tree.NewPage(_page.Flags, 1);
 
-                // now add implicit left page
-                newRootPage.AddPageRefNode(0, _tree.KeysPrefixing ? (MemorySlice) PrefixedSlice.BeforeAllKeys : Slice.BeforeAllKeys, _page.PageNumber);
-                _parentPage = newRootPage;
-                _parentPage.LastSearchPosition++;
-            }
-            else
-            {
-                // we already popped the page, so the current one on the stack is the parent of the page
-
-                if (_tree.Name == Constants.FreeSpaceTreeName)
+                if (_cursor.PageCount == 0) // we need to do a root split
                 {
-                    // a special case for FreeSpaceTree because the allocation of a new page called above
-                    // can cause a delete of a free space section resulting in a run of the tree rebalancer
-                    // and here the parent page that exists in cursor can be outdated
+                    Page newRootPage = _tree.NewPage(_tree.KeysPrefixing ? PageFlags.Branch | PageFlags.KeysPrefixed : PageFlags.Branch, 1);
+                    _cursor.Push(newRootPage);
+                    _treeState.RootPageNumber = newRootPage.PageNumber;
+                    _treeState.Depth++;
 
-                    _parentPage = _tx.ModifyPage(_cursor.CurrentPage.PageNumber, _tree, null); // pass _null_ to make sure we'll get the most updated parent page
-                    _parentPage.LastSearchPosition = _cursor.CurrentPage.LastSearchPosition;
-                    _parentPage.LastMatch = _cursor.CurrentPage.LastMatch;
+                    // now add implicit left page
+                    newRootPage.AddPageRefNode(0, _tree.KeysPrefixing ? (MemorySlice) PrefixedSlice.BeforeAllKeys : Slice.BeforeAllKeys, _page.PageNumber);
+                    _parentPage = newRootPage;
+                    _parentPage.LastSearchPosition++;
                 }
                 else
                 {
+                    // we already popped the page, so the current one on the stack is the parent of the page
+
                     _parentPage = _tx.ModifyPage(_cursor.CurrentPage.PageNumber, _tree, _cursor.CurrentPage);
+
+                    _cursor.Update(_cursor.Pages.First, _parentPage);
                 }
 
-                _cursor.Update(_cursor.Pages.First, _parentPage);
-            }
-
-            if (_page.IsLeaf)
-            {
-                _tree.ClearRecentFoundPages();
-            }
-
-            if (_tree.Name == Constants.FreeSpaceTreeName)
-            {
-                // we need to refresh the LastSearchPosition of the split page which is used by the free space handling
-                // because the allocation of a new page called above could remove some sections
-                // from the page that is being split
-
-                _page.NodePositionFor(_newKey);
-            }
-
-            if (_page.LastSearchPosition >= _page.NumberOfEntries)
-            {
-                // when we get a split at the end of the page, we take that as a hint that the user is doing 
-                // sequential inserts, at that point, we are going to keep the current page as is and create a new 
-                // page, this will allow us to do minimal amount of work to get the best density
-
-                Page branchOfSeparator;
-
-                byte* pos;
-                if (_page.IsBranch)
+                if (_page.IsLeaf)
                 {
-                    if (_page.NumberOfEntries > 2)
+                    _tree.ClearRecentFoundPages();
+                }
+
+                if (_page.LastSearchPosition >= _page.NumberOfEntries)
+                {
+                    // when we get a split at the end of the page, we take that as a hint that the user is doing 
+                    // sequential inserts, at that point, we are going to keep the current page as is and create a new 
+                    // page, this will allow us to do minimal amount of work to get the best density
+
+                    Page branchOfSeparator;
+
+                    byte* pos;
+                    if (_page.IsBranch)
                     {
-                        // here we steal the last entry from the current page so we maintain the implicit null left entry
+                        if (_page.NumberOfEntries > 2)
+                        {
+                            // here we steal the last entry from the current page so we maintain the implicit null left entry
 
-                        NodeHeader* node = _page.GetNode(_page.NumberOfEntries - 1);
-                        Debug.Assert(node->Flags == NodeFlags.PageRef);
-                        rightPage.AddPageRefNode(0, _tree.KeysPrefixing ? (MemorySlice)PrefixedSlice.BeforeAllKeys : Slice.BeforeAllKeys, node->PageNumber);
-                        pos = AddNodeToPage(rightPage, 1);
+                            NodeHeader* node = _page.GetNode(_page.NumberOfEntries - 1);
+                            Debug.Assert(node->Flags == NodeFlags.PageRef);
+                            rightPage.AddPageRefNode(0, _tree.KeysPrefixing ? (MemorySlice) PrefixedSlice.BeforeAllKeys : Slice.BeforeAllKeys, node->PageNumber);
+                            pos = AddNodeToPage(rightPage, 1);
 
-                        var separatorKey = _page.GetNodeKey(node);
+                            var separatorKey = _page.GetNodeKey(node);
 
-                        AddSeparatorToParentPage(rightPage.PageNumber, separatorKey, out branchOfSeparator);
+                            AddSeparatorToParentPage(rightPage.PageNumber, separatorKey, out branchOfSeparator);
 
-                        _page.RemoveNode(_page.NumberOfEntries - 1);
+                            _page.RemoveNode(_page.NumberOfEntries - 1);
+                        }
+                        else
+                        {
+                            _tree.FreePage(rightPage); // return the unnecessary right page
+                            pos = AddSeparatorToParentPage(_pageNumber, _newKey, out branchOfSeparator);
+
+                            if (_cursor.CurrentPage.PageNumber != branchOfSeparator.PageNumber)
+                                _cursor.Push(branchOfSeparator);
+
+                            return pos;
+                        }
                     }
                     else
                     {
-                        _tree.FreePage(rightPage); // return the unnecessary right page
-                        pos = AddSeparatorToParentPage(_pageNumber, _newKey, out branchOfSeparator);
-
-                        if (_cursor.CurrentPage.PageNumber != branchOfSeparator.PageNumber)
-                            _cursor.Push(branchOfSeparator);
-
-                        return pos;
+                        AddSeparatorToParentPage(rightPage.PageNumber, _newKey, out branchOfSeparator);
+                        pos = AddNodeToPage(rightPage, 0);
                     }
+                    _cursor.Push(rightPage);
+                    return pos;
                 }
-                else
-                {
-                    AddSeparatorToParentPage(rightPage.PageNumber, _newKey, out branchOfSeparator);
-                    pos = AddNodeToPage(rightPage, 0);
-                }
-                _cursor.Push(rightPage);
-                return pos;
-            }
 
-            return SplitPageInHalf(rightPage);
+                return SplitPageInHalf(rightPage);
+            }
         }
 
         private byte* AddNodeToPage(Page page, int index, MemorySlice alreadyPreparedNewKey = null)

--- a/Raven.Voron/Voron/Trees/Tree.cs
+++ b/Raven.Voron/Voron/Trees/Tree.cs
@@ -30,6 +30,8 @@ namespace Voron.Trees
 
         public string Name { get; set; }
 
+        public bool IsFreeSpaceTree { get; set; }
+
         public TreeMutableState State
         {
             get { return _state; }
@@ -554,7 +556,11 @@ namespace Voron.Trees
 
         internal Page NewPage(PageFlags flags, int num)
         {
-            var page = _tx.AllocatePage(num, flags);
+            Page page;
+            using (IsFreeSpaceTree ? _tx.Environment.FreeSpaceHandling.Disable() : null)
+            {
+                page = _tx.AllocatePage(num, flags);
+            }
 
             State.RecordNewPage(page, num);
 
@@ -568,14 +574,20 @@ namespace Voron.Trees
                 var numberOfPages = _tx.DataPager.GetNumberOfOverflowPages(p.OverflowSize);
                 for (int i = 0; i < numberOfPages; i++)
                 {
-                    _tx.FreePage(p.PageNumber + i);
+                    if (IsFreeSpaceTree)
+                        _tx.FreePageOnCommit(p.PageNumber + i);
+                    else
+                        _tx.FreePage(p.PageNumber + i);
                 }
 
                 State.RecordFreedPage(p, numberOfPages);
             }
             else
             {
-                _tx.FreePage(p.PageNumber);
+                if (IsFreeSpaceTree)
+                    _tx.FreePageOnCommit(p.PageNumber);
+                else
+                    _tx.FreePage(p.PageNumber);
                 State.RecordFreedPage(p, 1);
             }
         }

--- a/Raven.Voron/Voron/Trees/TreeRebalancer.cs
+++ b/Raven.Voron/Voron/Trees/TreeRebalancer.cs
@@ -22,82 +22,85 @@ namespace Voron.Trees
 
         public Page Execute(Page page)
         {
-            _tree.ClearRecentFoundPages();
-            if (_cursor.PageCount <= 1) // the root page
+            using (_tree.IsFreeSpaceTree ? _tx.Environment.FreeSpaceHandling.Disable() : null)
             {
-                RebalanceRoot(page);
-                return null;
-            }
-            
-            _cursor.Pop();
-
-            var parentPage = _tx.ModifyPage(_cursor.CurrentPage.PageNumber, _tree, _cursor.CurrentPage);
-            _cursor.Update(_cursor.Pages.First, parentPage);
-
-            if (page.NumberOfEntries == 0) // empty page, just delete it and fixup parent
-            {
-                // need to change the implicit left page
-                if (parentPage.LastSearchPosition == 0 && parentPage.NumberOfEntries > 2)
+                _tree.ClearRecentFoundPages();
+                if (_cursor.PageCount <= 1) // the root page
                 {
-                    var newImplicit = parentPage.GetNode(1)->PageNumber;
-                    parentPage.RemoveNode(0);
-                    parentPage.ChangeImplicitRefPageNode(newImplicit);
-                }
-                else // will be set to rights by the next rebalance call
-                {
-                    parentPage.RemoveNode(parentPage.LastSearchPositionOrLastEntry);
+                    RebalanceRoot(page);
+                    return null;
                 }
 
-                _tree.FreePage(page);
+                _cursor.Pop();
 
-                return parentPage;
-            }
+                var parentPage = _tx.ModifyPage(_cursor.CurrentPage.PageNumber, _tree, _cursor.CurrentPage);
+                _cursor.Update(_cursor.Pages.First, parentPage);
 
-            if (page.IsBranch && page.NumberOfEntries == 1)
-            {
-                RemoveBranchWithOneEntry(page, parentPage);
+                if (page.NumberOfEntries == 0) // empty page, just delete it and fixup parent
+                {
+                    // need to change the implicit left page
+                    if (parentPage.LastSearchPosition == 0 && parentPage.NumberOfEntries > 2)
+                    {
+                        var newImplicit = parentPage.GetNode(1)->PageNumber;
+                        parentPage.RemoveNode(0);
+                        parentPage.ChangeImplicitRefPageNode(newImplicit);
+                    }
+                    else // will be set to rights by the next rebalance call
+                    {
+                        parentPage.RemoveNode(parentPage.LastSearchPositionOrLastEntry);
+                    }
 
-                return parentPage;
-            }
+                    _tree.FreePage(page);
 
-            var minKeys = page.IsBranch ? 2 : 1;
-            if (page.UseMoreSizeThan(_tx.DataPager.PageMinSpace) &&
-                page.NumberOfEntries >= minKeys)
-                return null; // above space/keys thresholds
+                    return parentPage;
+                }
 
-            Debug.Assert(parentPage.NumberOfEntries >= 2); // if we have less than 2 entries in the parent, the tree is invalid
+                if (page.IsBranch && page.NumberOfEntries == 1)
+                {
+                    RemoveBranchWithOneEntry(page, parentPage);
 
-            var sibling = SetupMoveOrMerge(page, parentPage);
-            Debug.Assert(sibling.PageNumber != page.PageNumber);
+                    return parentPage;
+                }
 
-            if (page.Flags != sibling.Flags)
-                return null;
+                var minKeys = page.IsBranch ? 2 : 1;
+                if (page.UseMoreSizeThan(_tx.DataPager.PageMinSpace) &&
+                    page.NumberOfEntries >= minKeys)
+                    return null; // above space/keys thresholds
 
-            minKeys = sibling.IsBranch ? 2 : 1; // branch must have at least 2 keys
-            if (sibling.UseMoreSizeThan(_tx.DataPager.PageMinSpace) &&
-                sibling.NumberOfEntries > minKeys)
-            {
-                // neighbor is over the min size and has enough key, can move just one key to  the current page
-                if (page.IsBranch)
-                    MoveBranchNode(parentPage, sibling, page);
-                else
-                    MoveLeafNode(parentPage, sibling, page);
+                Debug.Assert(parentPage.NumberOfEntries >= 2); // if we have less than 2 entries in the parent, the tree is invalid
 
-                return parentPage;
-            }
+                var sibling = SetupMoveOrMerge(page, parentPage);
+                Debug.Assert(sibling.PageNumber != page.PageNumber);
 
-            if (page.LastSearchPosition == 0) // this is the right page, merge left
-            {
-                if (TryMergePages(parentPage, sibling, page) == false)
+                if (page.Flags != sibling.Flags)
                     return null;
-            }
-            else // this is the left page, merge right
-            {
-                if (TryMergePages(parentPage, page, sibling) == false)
-                    return null;
-            }
 
-            return parentPage;
+                minKeys = sibling.IsBranch ? 2 : 1; // branch must have at least 2 keys
+                if (sibling.UseMoreSizeThan(_tx.DataPager.PageMinSpace) &&
+                    sibling.NumberOfEntries > minKeys)
+                {
+                    // neighbor is over the min size and has enough key, can move just one key to  the current page
+                    if (page.IsBranch)
+                        MoveBranchNode(parentPage, sibling, page);
+                    else
+                        MoveLeafNode(parentPage, sibling, page);
+
+                    return parentPage;
+                }
+
+                if (page.LastSearchPosition == 0) // this is the right page, merge left
+                {
+                    if (TryMergePages(parentPage, sibling, page) == false)
+                        return null;
+                }
+                else // this is the left page, merge right
+                {
+                    if (TryMergePages(parentPage, page, sibling) == false)
+                        return null;
+                }
+
+                return parentPage;
+            }
         }
 
         private void RemoveBranchWithOneEntry(Page page, Page parentPage)

--- a/Raven.Voron/Voron/Voron.csproj
+++ b/Raven.Voron/Voron/Voron.csproj
@@ -69,6 +69,8 @@
     <Compile Include="Exceptions\VoronUnrecoverableErrorException.cs" />
     <Compile Include="Impl\Backup\MinimalIncrementalBackup.cs" />
     <Compile Include="Impl\Compaction\StorageCompaction.cs" />
+    <Compile Include="Impl\FreeSpace\FreeSpaceHandlingDisabler.cs" />
+    <Compile Include="Impl\FreeSpace\FreeSpaceRecursiveCallGuard.cs" />
     <Compile Include="Impl\PagePosition.cs" />
     <Compile Include="Impl\Scratch\PageFromScratchBuffer.cs" />
     <Compile Include="Impl\Scratch\ScratchBufferFile.cs" />


### PR DESCRIPTION
…ting / rebalancing the free space tree. Also protect from recursive calls to ensure that bytes of a section that we are trying to write won't be changed underneath by internal allocations / frees of pages belonging to the free space tree. Exposing FreeSpaceHandling.PageFreed event in order to properly write a test where we need to take into account pages of the free space tree.