### PR TITLE
RavenDB-6335 Prevent from using free space handling when we are split…

### DIFF
--- a/Raven.Voron/Voron.Tests/Trees/FreeSpaceTest.cs
+++ b/Raven.Voron/Voron.Tests/Trees/FreeSpaceTest.cs
@@ -4,6 +4,7 @@ using System.IO;
 using System.Linq;
 using Voron.Impl.FreeSpace;
 using Xunit;
+using Xunit.Extensions;
 
 namespace Voron.Tests.Trees
 {
@@ -122,12 +123,18 @@ namespace Voron.Tests.Trees
             }
         }
 
-        [PrefixesFact]
-        public void FreeSpaceHandlingShouldNotReturnPagesThatAreAlreadyAllocated()
+        [PrefixesTheory]
+        [InlineData(60, 2)]
+        [InlineData(60, 893)]
+        [InlineData(60, 6430)]
+        [InlineData(60, 7749)]
+        [InlineData(56, 893)]
+        [InlineDataWithRandomSeed(60)]
+        [InlineDataWithRandomSeed(-1)] // also random 'numberOfFreedPages'
+        public void FreeSpaceHandlingShouldNotReturnPagesThatAreAlreadyAllocated(int numberOfFreedPages, int seed)
         {
             const int maxPageNumber = 400000;
-            const int numberOfFreedPages = 60;
-            var random = new Random(2);
+            var random = new Random(seed);
             var freedPages = new HashSet<long>();
 
             using (var tx = Env.NewTransaction(TransactionFlags.ReadWrite))
@@ -135,6 +142,11 @@ namespace Voron.Tests.Trees
                 tx.State.NextPageNumber = maxPageNumber + 1;
 
                 tx.Commit();
+            }
+
+            if (numberOfFreedPages == -1)
+            {
+                numberOfFreedPages = random.Next(0, 10000);
             }
 
             for (int i = 0; i < numberOfFreedPages; i++)
@@ -154,7 +166,9 @@ namespace Voron.Tests.Trees
             }
 
             var alreadyReused = new List<long>();
+            var freedInternallyByFreeSpaceHandling = new HashSet<long>();
 
+            ((FreeSpaceHandling)Env.FreeSpaceHandling).PageFreed += pageNumber => freedInternallyByFreeSpaceHandling.Add(pageNumber); // need to take into account pages freed by free space handling itself
             do
             {
                 using (var tx = Env.NewTransaction(TransactionFlags.ReadWrite))
@@ -167,7 +181,7 @@ namespace Voron.Tests.Trees
                     }
 
                     Assert.False(alreadyReused.Contains(page.Value), "Free space handling returned a page number that has been already allocated. Page number: " + page);
-                    Assert.True(freedPages.Remove(page.Value));
+                    Assert.True(freedPages.Remove(page.Value) || freedInternallyByFreeSpaceHandling.Remove(page.Value));
 
                     alreadyReused.Add(page.Value);
 

--- a/Raven.Voron/Voron/Impl/Backup/IncrementalBackup.cs
+++ b/Raven.Voron/Voron/Impl/Backup/IncrementalBackup.cs
@@ -329,6 +329,7 @@ namespace Voron.Impl.Backup
                             var root = Tree.Open(txw, &lastTxHeader->Root);
                             var freeSpaceRoot = Tree.Open(txw, &lastTxHeader->FreeSpace);
                             freeSpaceRoot.Name = Constants.FreeSpaceTreeName;
+                            freeSpaceRoot.IsFreeSpaceTree = true;
                             root.Name = Constants.RootTreeName;
 
                             txw.UpdateRootsIfNeeded(root, freeSpaceRoot);

--- a/Raven.Voron/Voron/Impl/FreeSpace/FreeSpaceHandlingDisabler.cs
+++ b/Raven.Voron/Voron/Impl/FreeSpace/FreeSpaceHandlingDisabler.cs
@@ -1,0 +1,19 @@
+﻿// -----------------------------------------------------------------------
+//  <copyright file="FreeSpaceHandlingDisabler.cs" company="Hibernating Rhinos LTD">
+//      Copyright (c) Hibernating Rhinos LTD. All rights reserved.
+//  </copyright>
+// -----------------------------------------------------------------------
+using System;
+
+namespace Voron.Impl.FreeSpace
+{
+    public class FreeSpaceHandlingDisabler : IDisposable
+    {
+        public int DisableCount;
+
+        public void Dispose()
+        {
+            DisableCount--;
+        }
+    }
+}

--- a/Raven.Voron/Voron/Impl/FreeSpace/FreeSpaceRecursiveCallGuard.cs
+++ b/Raven.Voron/Voron/Impl/FreeSpace/FreeSpaceRecursiveCallGuard.cs
@@ -1,0 +1,51 @@
+﻿// -----------------------------------------------------------------------
+//  <copyright file="FreeSpaceRecursiveCallGuard.cs" company="Hibernating Rhinos LTD">
+//      Copyright (c) Hibernating Rhinos LTD. All rights reserved.
+//  </copyright>
+// -----------------------------------------------------------------------
+using System;
+using System.Collections.Generic;
+using System.Runtime.CompilerServices;
+
+namespace Voron.Impl.FreeSpace
+{
+    public class FreeSpaceRecursiveCallGuard : IDisposable
+    {
+        private readonly FreeSpaceHandling _freeSpaceHandling;
+        public bool IsEntered;
+        private Transaction _tx;
+        public List<long> PagesFreed = new List<long>();
+
+        public FreeSpaceRecursiveCallGuard(FreeSpaceHandling freeSpaceHandling)
+        {
+            _freeSpaceHandling = freeSpaceHandling;
+        }
+
+        [MethodImpl(MethodImplOptions.AggressiveInlining)]
+        public IDisposable Enter(Transaction tx)
+        {
+            if (IsEntered)
+                throw new InvalidOperationException("Free space handling cannot be called recursively");
+
+            IsEntered = true;
+            _tx = tx;
+            return this;
+        }
+
+        public void Dispose()
+        {
+            IsEntered = false;
+            if (PagesFreed == null)
+                return;
+            var copy = PagesFreed;
+            PagesFreed = null;
+            foreach (var page in copy)
+            {
+                _freeSpaceHandling.FreePage(_tx, page);
+            }
+            _tx = null;
+            copy.Clear();
+            PagesFreed = copy;
+        }
+    }
+}

--- a/Raven.Voron/Voron/Impl/FreeSpace/IFreeSpaceHandling.cs
+++ b/Raven.Voron/Voron/Impl/FreeSpace/IFreeSpaceHandling.cs
@@ -7,5 +7,6 @@ namespace Voron.Impl.FreeSpace
         long? TryAllocateFromFreeSpace(Transaction tx, int num);
         List<long> AllPages(Transaction tx);
         void FreePage(Transaction tx, long pageNumber);
+        FreeSpaceHandlingDisabler Disable();
     }
 }

--- a/Raven.Voron/Voron/Impl/FreeSpace/NoFreeSpaceHandling.cs
+++ b/Raven.Voron/Voron/Impl/FreeSpace/NoFreeSpaceHandling.cs
@@ -18,5 +18,10 @@ namespace Voron.Impl.FreeSpace
         {
             
         }
+
+        public FreeSpaceHandlingDisabler Disable()
+        {
+            return null;
+        }
     }
 }

--- a/Raven.Voron/Voron/StorageEnvironment.cs
+++ b/Raven.Voron/Voron/StorageEnvironment.cs
@@ -135,6 +135,7 @@ namespace Voron
             {
                 var root = Tree.Open(tx, header->TransactionId == 0 ? &entry.Root : &header->Root);
                 var freeSpace = Tree.Open(tx, header->TransactionId == 0 ? &entry.FreeSpace : &header->FreeSpace);
+                freeSpace.IsFreeSpaceTree = true;
 
                 tx.UpdateRootsIfNeeded(root, freeSpace);
                 tx.Commit();
@@ -153,6 +154,7 @@ namespace Voron
             {
                 var root = Tree.Create(tx, false);
                 var freeSpace = Tree.Create(tx, false);
+                freeSpace.IsFreeSpaceTree = true;
 
                 // important to first create the two trees, then set them on the env
                 tx.UpdateRootsIfNeeded(root, freeSpace);

--- a/Raven.Voron/Voron/Trees/TreeRebalancer.cs
+++ b/Raven.Voron/Voron/Trees/TreeRebalancer.cs
@@ -22,82 +22,85 @@ namespace Voron.Trees
 
         public Page Execute(Page page)
         {
-            _tree.ClearRecentFoundPages();
-            if (_cursor.PageCount <= 1) // the root page
+            using (_tree.IsFreeSpaceTree ? _tx.Environment.FreeSpaceHandling.Disable() : null)
             {
-                RebalanceRoot(page);
-                return null;
-            }
-            
-            _cursor.Pop();
-
-            var parentPage = _tx.ModifyPage(_cursor.CurrentPage.PageNumber, _tree, _cursor.CurrentPage);
-            _cursor.Update(_cursor.Pages.First, parentPage);
-
-            if (page.NumberOfEntries == 0) // empty page, just delete it and fixup parent
-            {
-                // need to change the implicit left page
-                if (parentPage.LastSearchPosition == 0 && parentPage.NumberOfEntries > 2)
+                _tree.ClearRecentFoundPages();
+                if (_cursor.PageCount <= 1) // the root page
                 {
-                    var newImplicit = parentPage.GetNode(1)->PageNumber;
-                    parentPage.RemoveNode(0);
-                    parentPage.ChangeImplicitRefPageNode(newImplicit);
+                    RebalanceRoot(page);
+                    return null;
                 }
-                else // will be set to rights by the next rebalance call
+
+                _cursor.Pop();
+
+                var parentPage = _tx.ModifyPage(_cursor.CurrentPage.PageNumber, _tree, _cursor.CurrentPage);
+                _cursor.Update(_cursor.Pages.First, parentPage);
+
+                if (page.NumberOfEntries == 0) // empty page, just delete it and fixup parent
                 {
-                    parentPage.RemoveNode(parentPage.LastSearchPositionOrLastEntry);
+                    // need to change the implicit left page
+                    if (parentPage.LastSearchPosition == 0 && parentPage.NumberOfEntries > 2)
+                    {
+                        var newImplicit = parentPage.GetNode(1)->PageNumber;
+                        parentPage.RemoveNode(0);
+                        parentPage.ChangeImplicitRefPageNode(newImplicit);
+                    }
+                    else // will be set to rights by the next rebalance call
+                    {
+                        parentPage.RemoveNode(parentPage.LastSearchPositionOrLastEntry);
+                    }
+
+                    _tree.FreePage(page);
+
+                    return parentPage;
+                }
+
+                if (page.IsBranch && page.NumberOfEntries == 1)
+                {
+                    RemoveBranchWithOneEntry(page, parentPage);
+
+                    return parentPage;
                 }
                 
-                _tree.FreePage(page);
+                var minKeys = page.IsBranch ? 2 : 1;
+                if (page.UseMoreSizeThan(_tx.DataPager.PageMinSpace) &&
+                    page.NumberOfEntries >= minKeys)
+                    return null; // above space/keys thresholds
 
-                return parentPage;
-            }
+                Debug.Assert(parentPage.NumberOfEntries >= 2); // if we have less than 2 entries in the parent, the tree is invalid
 
-            if (page.IsBranch && page.NumberOfEntries == 1)
-            {
-                RemoveBranchWithOneEntry(page, parentPage);
+                var sibling = SetupMoveOrMerge(page, parentPage);
+                Debug.Assert(sibling.PageNumber != page.PageNumber);
 
-                return parentPage;
-            }
-
-            var minKeys = page.IsBranch ? 2 : 1;
-            if (page.UseMoreSizeThan(_tx.DataPager.PageMinSpace) &&
-                page.NumberOfEntries >= minKeys)
-                return null; // above space/keys thresholds
-            
-            Debug.Assert(parentPage.NumberOfEntries >= 2); // if we have less than 2 entries in the parent, the tree is invalid
-            
-            var sibling = SetupMoveOrMerge(page, parentPage);
-            Debug.Assert(sibling.PageNumber != page.PageNumber);
-
-            if (page.Flags != sibling.Flags)
-                return null;
-
-            minKeys = sibling.IsBranch ? 2 : 1; // branch must have at least 2 keys
-            if (sibling.UseMoreSizeThan(_tx.DataPager.PageMinSpace) &&
-                sibling.NumberOfEntries > minKeys)
-            {
-                // neighbor is over the min size and has enough key, can move just one key to  the current page
-                if (page.IsBranch)
-                    MoveBranchNode(parentPage, sibling, page);
-                else
-                    MoveLeafNode(parentPage, sibling, page);
-
-                return parentPage;
-            }
-
-            if (page.LastSearchPosition == 0) // this is the right page, merge left
-            {
-                if (TryMergePages(parentPage, sibling, page) == false)
+                if (page.Flags != sibling.Flags)
                     return null;
-            }
-            else // this is the left page, merge right
-            {
-                if (TryMergePages(parentPage, page, sibling) == false)
-                    return null;
-            }
 
-            return parentPage;
+                minKeys = sibling.IsBranch ? 2 : 1; // branch must have at least 2 keys
+                if (sibling.UseMoreSizeThan(_tx.DataPager.PageMinSpace) &&
+                    sibling.NumberOfEntries > minKeys)
+                {
+                    // neighbor is over the min size and has enough key, can move just one key to  the current page
+                    if (page.IsBranch)
+                        MoveBranchNode(parentPage, sibling, page);
+                    else
+                        MoveLeafNode(parentPage, sibling, page);
+            
+                    return parentPage;
+                }
+            
+                if (page.LastSearchPosition == 0) // this is the right page, merge left
+                {
+                    if (TryMergePages(parentPage, sibling, page) == false)
+                        return null;
+                }
+                else // this is the left page, merge right
+                {
+                    if (TryMergePages(parentPage, page, sibling) == false)
+                        return null;
+                }
+
+                return parentPage;
+            }
         }
 
         private void RemoveBranchWithOneEntry(Page page, Page parentPage)

--- a/Raven.Voron/Voron/Voron.csproj
+++ b/Raven.Voron/Voron/Voron.csproj
@@ -76,6 +76,8 @@
     <Compile Include="Trees\Fixed\Iterators.cs" />
     <Compile Include="Impl\Backup\MinimalIncrementalBackup.cs" />
     <Compile Include="Impl\Compaction\StorageCompaction.cs" />
+    <Compile Include="Impl\FreeSpace\FreeSpaceHandlingDisabler.cs" />
+    <Compile Include="Impl\FreeSpace\FreeSpaceRecursiveCallGuard.cs" />
     <Compile Include="Impl\PagePosition.cs" />
     <Compile Include="Impl\Scratch\PageFromScratchBuffer.cs" />
     <Compile Include="Impl\Scratch\ScratchBufferFile.cs" />


### PR DESCRIPTION
…ting / rebalancing the free space tree. Also protect from recursive calls to ensure that bytes of a section that we are trying to write won't be changed underneath by internal allocations / frees of pages belonging to the free space tree. Exposing FreeSpaceHandling.PageFreed event in order to properly write a test where we need to take into account pages of the free space tree.