### PR TITLE
RavenDB-4458 Support Voron on large databases using 32 bits

### DIFF
--- a/src/Raven.Server/Config/Categories/StorageConfiguration.cs
+++ b/src/Raven.Server/Config/Categories/StorageConfiguration.cs
@@ -65,8 +65,8 @@ namespace Raven.Server.Config.Categories
 
         [Description("Use the 32 bits memory mapped pager, even when running in 64 bits")]
         [DefaultValue(false)]
-        [ConfigurationEntry("Raven/Storage/ForceUsing32BitPager")]
-        public bool ForceUsing32BitPager { get; set; }
+        [ConfigurationEntry("Raven/Storage/ForceUsing32BitsPager")]
+        public bool ForceUsing32BitsPager { get; set; }
 
         [Description("How long transaction mode (Danger/Lazy) last before returning to Safe mode. Value in Minutes. Default one day. Zero for infinite time")]
         [DefaultValue(1440)]

--- a/src/Raven.Server/Config/RavenConfiguration.cs
+++ b/src/Raven.Server/Config/RavenConfiguration.cs
@@ -168,7 +168,7 @@ namespace Raven.Server.Config
             Encryption.UseSsl = serverConfiguration.Encryption.UseSsl;
             Encryption.UseFips = serverConfiguration.Encryption.UseFips;
 
-            Storage.ForceUsing32BitPager = serverConfiguration.Storage.ForceUsing32BitPager;
+            Storage.ForceUsing32BitsPager = serverConfiguration.Storage.ForceUsing32BitsPager;
         }
 
         public void SetSetting(string key, string value)

--- a/src/Raven.Server/Documents/ConfigurationStorage.cs
+++ b/src/Raven.Server/Documents/ConfigurationStorage.cs
@@ -32,7 +32,7 @@ namespace Raven.Server.Documents
                 : StorageEnvironmentOptions.ForPath(path.FullPath);
 
             options.SchemaVersion = 1;
-            options.ForceUsing32BitPager = db.Configuration.Storage.ForceUsing32BitPager;
+            options.ForceUsing32BitsPager = db.Configuration.Storage.ForceUsing32BitsPager;
 
             Environment = new StorageEnvironment(options);
             

--- a/src/Raven.Server/Documents/DocumentsStorage.cs
+++ b/src/Raven.Server/Documents/DocumentsStorage.cs
@@ -262,7 +262,7 @@ namespace Raven.Server.Documents
                     _documentDatabase.Configuration.Storage.JournalsStoragePath?.FullPath
                     );
 
-            options.ForceUsing32BitPager = _documentDatabase.Configuration.Storage.ForceUsing32BitPager;
+            options.ForceUsing32BitsPager = _documentDatabase.Configuration.Storage.ForceUsing32BitsPager;
 
             try
             {

--- a/src/Raven.Server/Documents/Indexes/Index.cs
+++ b/src/Raven.Server/Documents/Indexes/Index.cs
@@ -183,7 +183,7 @@ namespace Raven.Server.Documents.Indexes
             try
             {
                 options.SchemaVersion = 1;
-                options.ForceUsing32BitPager = documentDatabase.Configuration.Storage.ForceUsing32BitPager;
+                options.ForceUsing32BitsPager = documentDatabase.Configuration.Storage.ForceUsing32BitsPager;
 
                 environment = new StorageEnvironment(options);
 
@@ -292,7 +292,7 @@ namespace Raven.Server.Documents.Indexes
                     : StorageEnvironmentOptions.ForPath(indexPath.FullPath, indexTempPath?.FullPath, journalPath?.FullPath);
 
                 options.SchemaVersion = 1;
-                options.ForceUsing32BitPager = documentDatabase.Configuration.Storage.ForceUsing32BitPager;
+                options.ForceUsing32BitsPager = documentDatabase.Configuration.Storage.ForceUsing32BitsPager;
 
                 try
                 {
@@ -2099,7 +2099,7 @@ namespace Raven.Server.Documents.Indexes
                     var environmentOptions =
                         (StorageEnvironmentOptions.DirectoryStorageEnvironmentOptions)_environment.Options;
                     var srcOptions = StorageEnvironmentOptions.ForPath(environmentOptions.BasePath);
-                    srcOptions.ForceUsing32BitPager = DocumentDatabase.Configuration.Storage.ForceUsing32BitPager;
+                    srcOptions.ForceUsing32BitsPager = DocumentDatabase.Configuration.Storage.ForceUsing32BitsPager;
 
                     var wasRunning = _indexingThread != null;
 
@@ -2109,7 +2109,7 @@ namespace Raven.Server.Documents.Indexes
 
                     using (var compactOptions = (StorageEnvironmentOptions.DirectoryStorageEnvironmentOptions)StorageEnvironmentOptions.ForPath(compactPath.FullPath))
                     {
-                        compactOptions.ForceUsing32BitPager = DocumentDatabase.Configuration.Storage.ForceUsing32BitPager;
+                        compactOptions.ForceUsing32BitsPager = DocumentDatabase.Configuration.Storage.ForceUsing32BitsPager;
 
                         StorageCompaction.Execute(srcOptions, compactOptions, progressReport =>
                         {

--- a/src/Raven.Server/Documents/SubscriptionStorage.cs
+++ b/src/Raven.Server/Documents/SubscriptionStorage.cs
@@ -45,7 +45,7 @@ namespace Raven.Server.Documents
 
             options.SchemaVersion = 1;
             options.TransactionsMode = TransactionsMode.Lazy;
-            options.ForceUsing32BitPager = db.Configuration.Storage.ForceUsing32BitPager;
+            options.ForceUsing32BitsPager = db.Configuration.Storage.ForceUsing32BitsPager;
 
             _environment = new StorageEnvironment(options);
             var databaseName = db.Name;

--- a/src/Raven.Server/ServerWide/Context/DocumentsContextPool.cs
+++ b/src/Raven.Server/ServerWide/Context/DocumentsContextPool.cs
@@ -22,7 +22,7 @@ namespace Raven.Server.ServerWide.Context
 
         protected override DocumentsOperationContext CreateContext()
         {
-            if (sizeof(int) == IntPtr.Size || _database.Configuration.Storage.ForceUsing32BitPager)
+            if (sizeof(int) == IntPtr.Size || _database.Configuration.Storage.ForceUsing32BitsPager)
                 return new DocumentsOperationContext(_database, 32 * 1024, 4 * 1024);
             return new DocumentsOperationContext(_database, 1024 * 1024, 16 * 1024);
         }

--- a/src/Raven.Server/ServerWide/ServerStore.cs
+++ b/src/Raven.Server/ServerWide/ServerStore.cs
@@ -118,7 +118,7 @@ namespace Raven.Server.ServerWide
                 : StorageEnvironmentOptions.ForPath(path.FullPath);
 
             options.SchemaVersion = 2;
-            options.ForceUsing32BitPager = Configuration.Storage.ForceUsing32BitPager;
+            options.ForceUsing32BitsPager = Configuration.Storage.ForceUsing32BitsPager;
             try
             {
                 StorageEnvironment.MaxConcurrentFlushes = Configuration.Storage.MaxConcurrentFlushes;

--- a/src/Voron/Impl/Journal/JournalReader.cs
+++ b/src/Voron/Impl/Journal/JournalReader.cs
@@ -301,8 +301,8 @@ namespace Voron.Impl.Journal
             return checked((int)(size / Constants.Storage.PageSize) + (size % Constants.Storage.PageSize == 0 ? 0 : 1));
         }
 
-        Dictionary<AbstractPager, Windows32BitMemoryMapPager.TransactionState> IPagerLevelTransactionState.
-            Windows32BitPagerTransactionState
+        Dictionary<AbstractPager, TransactionState> IPagerLevelTransactionState.
+            Windows32BitsPagerTransactionState
         { get; set; }
 
         public event Action<IPagerLevelTransactionState> OnDispose;

--- a/src/Voron/Impl/Paging/AbstractPager.cs
+++ b/src/Voron/Impl/Paging/AbstractPager.cs
@@ -283,12 +283,15 @@ namespace Voron.Impl.Paging
         public abstract void TryPrefetchingWholeFile();
         public abstract void MaybePrefetchMemory(List<long> pagesToPrefetch);
 
-        public virtual void EnsureMapped(IPagerLevelTransactionState tx, long page, int numberOfPages)
+        public virtual bool EnsureMapped(IPagerLevelTransactionState tx, long page, int numberOfPages)
         {
             // nothing to do
+            return false;
         }
 
-        public virtual int CopyPage(I4KbBatchWrites destwI4KbBatchWrites, long p, PagerState pagerState)
+        public abstract int CopyPage(I4KbBatchWrites destwI4KbBatchWrites, long p, PagerState pagerState);
+
+        protected int CopyPageImpl(I4KbBatchWrites destwI4KbBatchWrites, long p, PagerState pagerState)
         {
             var src = AcquirePagePointer(null, p, pagerState);
             var pageHeader = (PageHeader*)src;

--- a/src/Voron/Impl/Paging/AbstractPagerExtensions.cs
+++ b/src/Voron/Impl/Paging/AbstractPagerExtensions.cs
@@ -3,6 +3,7 @@ using System.Collections.Generic;
 using System.Diagnostics;
 using System.IO;
 using Sparrow;
+using Voron.Data;
 using Voron.Global;
 using Voron.Data.BTrees;
 using Voron.Platform.Win32;
@@ -13,12 +14,27 @@ namespace Voron.Impl.Paging
     {
         public static Page ReadPage(this AbstractPager pager, IPagerLevelTransactionState tx, long pageNumber, PagerState pagerState = null)
         {
-            return new Page(pager.AcquirePagePointer(tx, pageNumber, pagerState));
+            return new Page(AcquirePagePointerWithOverflowHandling(pager, tx, pageNumber, pagerState));
         }
 
         public static TreePage Read(this AbstractPager pager, IPagerLevelTransactionState tx, long pageNumber, PagerState pagerState = null)
         {
-            return new TreePage(pager.AcquirePagePointer(tx, pageNumber, pagerState), Constants.Storage.PageSize);
+            return new TreePage(AcquirePagePointerWithOverflowHandling(pager, tx, pageNumber, pagerState), Constants.Storage.PageSize);
+        }
+        
+        public static byte* AcquirePagePointerWithOverflowHandling(this AbstractPager pager, IPagerLevelTransactionState tx, long pageNumber, PagerState pagerState = null)
+        {
+            // Case 1: Page is not overflow ==> no problem, returning a pointer to existing mapping
+            var pageHeader = (PageHeader*)pager.AcquirePagePointer(tx, pageNumber, pagerState);
+            if ((pageHeader->Flags & PageFlags.Overflow) != PageFlags.Overflow)
+                return (byte*)pageHeader;
+
+            // Case 2: Page is overflow and already mapped large enough ==> no problem, returning a pointer to existing mapping
+            if (pager.EnsureMapped(tx, pageNumber, pager.GetNumberOfOverflowPages(pageHeader->OverflowSize)) == false)
+                return (byte*) pageHeader;
+
+            // Case 3: Page is overflow and was ensuredMapped above, view was re-mapped so we need to acquire a pointer to the new mapping.
+            return pager.AcquirePagePointer(tx, pageNumber, pagerState);
         }
 
         public static bool WillRequireExtension(this AbstractPager pager, long requestedPageNumber, int numberOfPages)

--- a/src/Voron/Impl/Paging/TempPagerTransaction.cs
+++ b/src/Voron/Impl/Paging/TempPagerTransaction.cs
@@ -10,7 +10,7 @@ namespace Voron.Impl.Paging
             OnDispose?.Invoke(this);
         }
 
-        public Dictionary<AbstractPager, Windows32BitMemoryMapPager.TransactionState> Windows32BitPagerTransactionState
+        public Dictionary<AbstractPager, TransactionState> Windows32BitsPagerTransactionState
         {
             get; set;
         }

--- a/src/Voron/Impl/Scratch/ScratchBufferFile.cs
+++ b/src/Voron/Impl/Scratch/ScratchBufferFile.cs
@@ -261,12 +261,12 @@ namespace Voron.Impl.Scratch
                 pagerRef.Pager = _scratchPager;
                 pagerRef.PagerPageNumber = p;
             }
-            return new Page(_scratchPager.AcquirePagePointer(tx, p, pagerState));
+            return new Page(_scratchPager.AcquirePagePointerWithOverflowHandling(tx, p, pagerState));
         }
 
         public byte* AcquirePagePointer(LowLevelTransaction tx, long p)
         {
-            return _scratchPager.AcquirePagePointer(tx, p);
+            return _scratchPager.AcquirePagePointerWithOverflowHandling(tx, p);
         }
 
         internal Dictionary<long, long> GetMostAvailableFreePagesBySize()

--- a/src/Voron/Platform/Posix/Posix32BitsMemoryMapPager.cs
+++ b/src/Voron/Platform/Posix/Posix32BitsMemoryMapPager.cs
@@ -19,9 +19,9 @@ using Voron.Platform.Win32;
 
 namespace Voron.Platform.Posix
 {
-    public unsafe class Posix32BitMemoryMapPager : PosixAbstractPager
+    public unsafe class Posix32BitsMemoryMapPager : PosixAbstractPager
     {
-        public Posix32BitMemoryMapPager(StorageEnvironmentOptions options, string file, long? initialFileSize = null,
+        public Posix32BitsMemoryMapPager(StorageEnvironmentOptions options, string file, long? initialFileSize = null,
                     bool usePageProtection = false) : base(options, usePageProtection)
         {
         }

--- a/src/Voron/Platform/Posix/PosixAbstractPager.cs
+++ b/src/Voron/Platform/Posix/PosixAbstractPager.cs
@@ -4,6 +4,7 @@ using Sparrow.Platform;
 using Sparrow.Platform.Posix;
 using Voron.Data.BTrees;
 using Voron.Global;
+using Voron.Impl;
 using Voron.Impl.Paging;
 using Voron.Platform.Win32;
 
@@ -11,6 +12,10 @@ namespace Voron.Platform.Posix
 {
     public abstract class PosixAbstractPager : AbstractPager
     {
+        public override int CopyPage(I4KbBatchWrites destwI4KbBatchWrites, long p, PagerState pagerState)
+        {
+            return CopyPageImpl(destwI4KbBatchWrites, p, pagerState);
+        }
 
         private unsafe void PrefetchRanges(List<Win32MemoryMapNativeMethods.WIN32_MEMORY_RANGE_ENTRY> ranges)
         {

--- a/src/Voron/Platform/Posix/PosixJournalWriter.cs
+++ b/src/Voron/Platform/Posix/PosixJournalWriter.cs
@@ -190,7 +190,7 @@ namespace Voron.Platform.Posix
         public AbstractPager CreatePager()
         {
             if (_options.RunningOn32Bits)
-                return new Posix32BitMemoryMapPager(_options, _filename);
+                return new Posix32BitsMemoryMapPager(_options, _filename);
 
             return new PosixMemoryMapPager(_options, _filename);
         }

--- a/src/Voron/Platform/Win32/Win32JournalWriter.cs
+++ b/src/Voron/Platform/Win32/Win32JournalWriter.cs
@@ -138,7 +138,7 @@ namespace Voron.Platform.Win32
         public AbstractPager CreatePager()
         {
             if (_options.RunningOn32Bits)
-                return new Windows32BitMemoryMapPager(_options, _filename);
+                return new Windows32BitsMemoryMapPager(_options, _filename);
 
             return new WindowsMemoryMapPager(_options, _filename);
         }

--- a/src/Voron/Platform/Win32/WindowsMemoryMapPager.cs
+++ b/src/Voron/Platform/Win32/WindowsMemoryMapPager.cs
@@ -32,7 +32,7 @@ namespace Voron.Platform.Win32
         private readonly Win32NativeFileAttributes _fileAttributes;
         private readonly Win32NativeFileAccess _access;
         private readonly MemoryMappedFileAccess _memoryMappedFileAccess;
-        private bool _copyOnWriteMode;
+        private readonly bool _copyOnWriteMode;
         private readonly Logger _logger;
         public override long TotalAllocationSize => _totalAllocationSize;
         [StructLayout(LayoutKind.Explicit)]
@@ -425,6 +425,11 @@ namespace Voron.Platform.Win32
                 Win32MemoryMapNativeMethods.PrefetchVirtualMemory(Win32Helper.CurrentProcess,
                     (UIntPtr)PagerState.AllocationInfos.Length, entriesPtr, 0);
             }
+        }
+
+        public override int CopyPage(I4KbBatchWrites destwI4KbBatchWrites, long p, PagerState pagerState)
+        {
+            return CopyPageImpl(destwI4KbBatchWrites, p, pagerState);
         }
 
         public override void TryPrefetchingWholeFile()

--- a/src/Voron/StorageEnvironmentOptions.cs
+++ b/src/Voron/StorageEnvironmentOptions.cs
@@ -29,7 +29,7 @@ namespace Voron
         public event EventHandler<NonDurabalitySupportEventArgs> OnNonDurabaleFileSystemError;
         private long _reuseCounter;
         public abstract override string ToString();
-        public bool ForceUsing32BitPager { get; set; }
+        public bool ForceUsing32BitsPager { get; set; }
 
         public void InvokeRecoveryError(object sender, string message, Exception e)
         {
@@ -151,11 +151,11 @@ namespace Voron
 
             _log = LoggingSource.Instance.GetLogger<StorageEnvironment>(tempPath);
 
-            var shouldForceEnvVar = Environment.GetEnvironmentVariable("VORON_INTERNAL_ForceUsing32BitPager");
+            var shouldForceEnvVar = Environment.GetEnvironmentVariable("VORON_INTERNAL_ForceUsing32BitsPager");
 
             bool result;
             if (bool.TryParse(shouldForceEnvVar, out result))
-                ForceUsing32BitPager = result;
+                ForceUsing32BitsPager = result;
         }
 
 
@@ -479,7 +479,7 @@ namespace Voron
                 {
                     if (RunningOn32Bits)
                     {
-                        return new Posix32BitMemoryMapPager(options, file, initialSize,
+                        return new Posix32BitsMemoryMapPager(options, file, initialSize,
                             usePageProtection: usePageProtection)
                         {
                             DeleteOnClose = deleteOnClose
@@ -496,7 +496,7 @@ namespace Voron
                     : Win32NativeFileAttributes.Normal;
 
                 if (RunningOn32Bits)
-                    return new Windows32BitMemoryMapPager(options, file, initialSize, attributes, usePageProtection: usePageProtection);
+                    return new Windows32BitsMemoryMapPager(options, file, initialSize, attributes, usePageProtection: usePageProtection);
 
                 return new WindowsMemoryMapPager(options, file, initialSize, attributes, usePageProtection: usePageProtection);
             }
@@ -517,12 +517,12 @@ namespace Voron
                 if (RunningOnPosix)
                 {
                     if (RunningOn32Bits)
-                        return new Posix32BitMemoryMapPager(this, path);
+                        return new Posix32BitsMemoryMapPager(this, path);
                     return new PosixMemoryMapPager(this, path);
                 }
 
                 if (RunningOn32Bits)
-                    return new Windows32BitMemoryMapPager(this, path, access: Win32NativeFileAccess.GenericRead,
+                    return new Windows32BitsMemoryMapPager(this, path, access: Win32NativeFileAccess.GenericRead,
                         fileAttributes: Win32NativeFileAttributes.SequentialScan);
                 
                 var windowsMemoryMapPager = new WindowsMemoryMapPager(this, path, access: Win32NativeFileAccess.GenericRead,
@@ -683,7 +683,7 @@ namespace Voron
                     return new PosixTempMemoryMapPager(options, path, intialSize);
                 }
                 if (RunningOn32Bits)
-                    return new Windows32BitMemoryMapPager(options, path, intialSize,
+                    return new Windows32BitsMemoryMapPager(options, path, intialSize,
                         Win32NativeFileAttributes.RandomAccess | Win32NativeFileAttributes.DeleteOnClose | Win32NativeFileAttributes.Temporary);
 
                 return new WindowsMemoryMapPager(options, path, intialSize,
@@ -703,12 +703,12 @@ namespace Voron
                 if (RunningOnPosix)
                 {
                     if (RunningOn32Bits)
-                        return new Posix32BitMemoryMapPager(this, filename);
+                        return new Posix32BitsMemoryMapPager(this, filename);
                     return new PosixMemoryMapPager(this, filename);
                 }
 
                 if (RunningOn32Bits)
-                    return new Windows32BitMemoryMapPager(this, filename);
+                    return new Windows32BitsMemoryMapPager(this, filename);
 
                 return new WindowsMemoryMapPager(this, filename);
             }
@@ -761,7 +761,7 @@ namespace Voron
             => RuntimeInformation.IsOSPlatform(OSPlatform.Linux) ||
                RuntimeInformation.IsOSPlatform(OSPlatform.OSX);
 
-        public bool RunningOn32Bits => IntPtr.Size == sizeof(int) || ForceUsing32BitPager;
+        public bool RunningOn32Bits => IntPtr.Size == sizeof(int) || ForceUsing32BitsPager;
 
 
         public TransactionsMode TransactionsMode { get; set; }

--- a/test/FastTests/Voron/Backups/BackupToOneZipFile.cs
+++ b/test/FastTests/Voron/Backups/BackupToOneZipFile.cs
@@ -205,12 +205,12 @@ namespace FastTests.Voron.Backups
                     database.IncrementalBackupTo(Path.Combine(tempFileName,
                         string.Format("voron-test.{0}-incremental-backup.zip", 1)));
 
-                    var forceUsing32BitPager = database.Configuration.Storage.ForceUsing32BitPager;
+                    var forceUsing32BitsPager = database.Configuration.Storage.ForceUsing32BitsPager;
                     BackupMethods.Incremental.Restore(Path.Combine(tempFileName, "backup-test.data"), new[]
                     {
                         Path.Combine(tempFileName, "voron-test.0-incremental-backup.zip"),
                         Path.Combine(tempFileName, "voron-test.1-incremental-backup.zip")
-                    }, options => options.ForceUsing32BitPager = forceUsing32BitPager);
+                    }, options => options.ForceUsing32BitsPager = forceUsing32BitsPager);
                 }
             }
             using (var database = CreateDocumentDatabase(runInMemory: false, dataDirectory: Path.Combine(tempFileName, "backup-test.data")))


### PR DESCRIPTION
- Fix case where we read a page with garbage header and rely on the (wrong) overflow size
- Fix which page we use as key in LoadedPages in EnsureMapped
- Fix spelling 32Bit -> 32Bits