### PR TITLE
RavenDB-6306 Reset the object json parser after reading / writing in …

### DIFF
--- a/src/Sparrow/Json/JsonOperationContext.cs
+++ b/src/Sparrow/Json/JsonOperationContext.cs
@@ -350,6 +350,9 @@ namespace Sparrow.Json
             if (_documentBuilder.Read() == false)
                 throw new InvalidOperationException("Partial content in object json parser shouldn't happen");
             _documentBuilder.FinalizeDocument();
+            
+            _objectJsonParser.Reset(null);
+
             var reader = _documentBuilder.CreateReader();
             return reader;
         }
@@ -597,6 +600,8 @@ namespace Sparrow.Json
             _objectJsonParser.Read();
 
             WriteObject(writer, _jsonParserState, _objectJsonParser);
+
+            _objectJsonParser.Reset(null);
         }
 
         public void Write(BlittableJsonTextWriter writer, DynamicJsonValue json)
@@ -612,6 +617,8 @@ namespace Sparrow.Json
             _objectJsonParser.Read();
 
             WriteArray(writer, _jsonParserState, _objectJsonParser);
+
+            _objectJsonParser.Reset(null);
         }
 
         public unsafe void WriteObject(BlittableJsonTextWriter writer, JsonParserState state, ObjectJsonParser parser)


### PR DESCRIPTION
…order free memory allocation kept by `_currentStateBuffer`. It used to be the last piece of allocated memory and prevented others from returning memory efficiently.