### PR TITLE
RavenDB-4458 Support Voron on large databases using 32 bits

### DIFF
--- a/src/Raven.Server/Documents/Handlers/Debugging/MemoryStatsHandler.cs
+++ b/src/Raven.Server/Documents/Handlers/Debugging/MemoryStatsHandler.cs
@@ -85,13 +85,20 @@ namespace Raven.Server.Documents.Handlers.Debugging
                     {
                         long totalMapped = 0;
                         var dja = new DynamicJsonArray();
+                        var dic = new Dictionary<long, long>();
                         foreach (var mapping in file.Value)
                         {
                             totalMapped += mapping.Value;
+                            long prev;
+                            dic.TryGetValue(mapping.Value, out prev);
+                            dic[mapping.Value] = prev + 1;
+                        }
+                        foreach (var maps in dic)
+                        {
                             dja.Add(new DynamicJsonValue
                             {
-                                ["Address"] = "0x" + mapping.Key.ToString("x"),
-                                ["Size"] = mapping.Value
+                                ["Size"] = maps.Key,
+                                ["Count"] = maps.Value
                             });
                         }
                         dir[Path.GetFileName(file.Key)] = new DynamicJsonValue

--- a/src/Raven.Server/Documents/Indexes/MapReduce/MapReduceResultsStore.cs
+++ b/src/Raven.Server/Documents/Indexes/MapReduce/MapReduceResultsStore.cs
@@ -56,7 +56,8 @@ namespace Raven.Server.Documents.Indexes.MapReduce
         private void InitializeTree(bool create)
         {
             var treeName = ReduceTreePrefix + _reduceKeyHash;
-            Tree = create ? _tx.CreateTree(treeName, flags: TreeFlags.LeafsCompressed, pageLocator: _pageLocator) : _tx.ReadTree(treeName, pageLocator: _pageLocator);
+            var options = _tx.LowLevelTransaction.Environment.Options.RunningOn32Bits ? TreeFlags.None : TreeFlags.LeafsCompressed;
+            Tree = create ? _tx.CreateTree(treeName, flags: options, pageLocator: _pageLocator) : _tx.ReadTree(treeName, pageLocator: _pageLocator);
 
             ModifiedPages = new HashSet<long>();
             FreedPages = new HashSet<long>();

--- a/src/Raven.Server/Documents/Indexes/MapReduce/ReduceMapResultsBase.cs
+++ b/src/Raven.Server/Documents/Indexes/MapReduce/ReduceMapResultsBase.cs
@@ -121,7 +121,7 @@ namespace Raven.Server.Documents.Indexes.MapReduce
             return false;
         }
 
-        public bool CanContinueBatch(IndexingStatsScope stats, long currentEtag, long maxEtag)
+        public bool CanContinueBatch(DocumentsOperationContext documentsContext, TransactionOperationContext indexingContext, IndexingStatsScope stats, long currentEtag, long maxEtag)
         {
             throw new NotSupportedException();
         }

--- a/src/Raven.Server/Documents/Indexes/Workers/CleanupDeletedDocuments.cs
+++ b/src/Raven.Server/Documents/Indexes/Workers/CleanupDeletedDocuments.cs
@@ -100,7 +100,7 @@ namespace Raven.Server.Documents.Indexes.Workers
 
                                 _index.HandleDelete(tombstone, collection, indexWriter, indexContext, collectionStats);
 
-                                if (CanContinueBatch(collectionStats, lastEtag, lastCollectionEtag) == false)
+                                if (CanContinueBatch(databaseContext, indexContext, collectionStats, lastEtag, lastCollectionEtag) == false)
                                 {
                                     keepRunning = false;
                                     break;
@@ -137,7 +137,12 @@ namespace Raven.Server.Documents.Indexes.Workers
             return moreWorkFound;
         }
 
-        public bool CanContinueBatch(IndexingStatsScope stats, long currentEtag, long maxEtag)
+        public bool CanContinueBatch(
+            DocumentsOperationContext documentsContext, 
+            TransactionOperationContext indexingContext, 
+            IndexingStatsScope stats, 
+            long currentEtag, 
+            long maxEtag)
         {
             if (stats.Duration >= _configuration.MapTimeout.AsTimeSpan)
                 return false;
@@ -145,7 +150,7 @@ namespace Raven.Server.Documents.Indexes.Workers
             if (currentEtag >= maxEtag && stats.Duration >= _configuration.MapTimeoutAfterEtagReached.AsTimeSpan)
                 return false;
 
-            if (_index.CanContinueBatch(stats) == false)
+            if (_index.CanContinueBatch(stats, documentsContext, indexingContext) == false)
                 return false;
 
             return true;

--- a/src/Raven.Server/Documents/Indexes/Workers/HandleReferences.cs
+++ b/src/Raven.Server/Documents/Indexes/Workers/HandleReferences.cs
@@ -52,7 +52,7 @@ namespace Raven.Server.Documents.Indexes.Workers
             return moreWorkFound;
         }
 
-        public bool CanContinueBatch(IndexingStatsScope stats, long currentEtag, long maxEtag)
+        public bool CanContinueBatch(DocumentsOperationContext documentsContext, TransactionOperationContext indexingContext, IndexingStatsScope stats, long currentEtag, long maxEtag)
         {
             if (stats.Duration >= _configuration.MapTimeout.AsTimeSpan)
                 return false;
@@ -60,7 +60,7 @@ namespace Raven.Server.Documents.Indexes.Workers
             if (currentEtag >= maxEtag && stats.Duration >= _configuration.MapTimeoutAfterEtagReached.AsTimeSpan)
                 return false;
 
-            if (_index.CanContinueBatch(stats) == false)
+            if (_index.CanContinueBatch(stats,documentsContext, indexingContext) == false)
                 return false;
 
             return true;
@@ -206,7 +206,7 @@ namespace Raven.Server.Documents.Indexes.Workers
                                                     _logger.Info($"Failed to execute mapping function on '{current.Key}' for '{_index.Name} ({_index.IndexId})'.", e);
                                             }
 
-                                            if (CanContinueBatch(collectionStats, lastEtag, lastCollectionEtag) == false)
+                                            if (CanContinueBatch(databaseContext, indexContext, collectionStats, lastEtag, lastCollectionEtag) == false)
                                             {
                                                 keepRunning = false;
                                                 break;

--- a/src/Raven.Server/Documents/Indexes/Workers/IIndexingWork.cs
+++ b/src/Raven.Server/Documents/Indexes/Workers/IIndexingWork.cs
@@ -12,6 +12,6 @@ namespace Raven.Server.Documents.Indexes.Workers
         bool Execute(DocumentsOperationContext databaseContext, TransactionOperationContext indexContext,
                      Lazy<IndexWriteOperation> writeOperation, IndexingStatsScope stats, CancellationToken token);
 
-        bool CanContinueBatch(IndexingStatsScope stats, long currentEtag, long maxEtag);
+        bool CanContinueBatch(DocumentsOperationContext documentsContext, TransactionOperationContext indexingContext, IndexingStatsScope stats, long currentEtag, long maxEtag);
     }
 }

--- a/src/Raven.Server/Documents/Indexes/Workers/MapDocuments.cs
+++ b/src/Raven.Server/Documents/Indexes/Workers/MapDocuments.cs
@@ -126,7 +126,7 @@ namespace Raven.Server.Documents.Indexes.Workers
                                             $"Failed to execute mapping function on {current.Key}. Exception: {e}");
                                     }
 
-                                    if (CanContinueBatch(collectionStats, lastEtag, lastCollectionEtag) == false)
+                                    if (CanContinueBatch(databaseContext, indexContext, collectionStats, lastEtag, lastCollectionEtag) == false)
                                     {
                                         keepRunning = false;
                                         break;
@@ -217,7 +217,7 @@ namespace Raven.Server.Documents.Indexes.Workers
             return false;
         }
 
-        public bool CanContinueBatch(IndexingStatsScope stats, long currentEtag, long maxEtag)
+        public bool CanContinueBatch(DocumentsOperationContext documentsContext, TransactionOperationContext indexingContext, IndexingStatsScope stats, long currentEtag, long maxEtag)
         {
             if (stats.Duration >= _configuration.MapTimeout.AsTimeSpan)
             {
@@ -234,7 +234,7 @@ namespace Raven.Server.Documents.Indexes.Workers
             if (ShouldReleaseTransactionBecauseFlushIsWaiting(stats))
                 return false;
            
-            if (_index.CanContinueBatch(stats) == false)
+            if (_index.CanContinueBatch(stats,documentsContext, indexingContext) == false)
                 return false;
 
             return true;

--- a/src/Sparrow/Platform/Win32/Win32ThreadsMethods.cs
+++ b/src/Sparrow/Platform/Win32/Win32ThreadsMethods.cs
@@ -5,19 +5,19 @@ namespace Sparrow
 {
     public static class Win32ThreadsMethods
     {
-        [DllImport("kernel32.dll", CallingConvention = CallingConvention.Cdecl, SetLastError = true)]
+        [DllImport("kernel32.dll", CallingConvention = CallingConvention.Winapi, SetLastError = true)]
         public static extern int SetThreadPriority(IntPtr hThread, int nPriority);
 
-        [DllImport("kernel32.dll", CallingConvention = CallingConvention.Cdecl, SetLastError = true)]
+        [DllImport("kernel32.dll", CallingConvention = CallingConvention.Winapi, SetLastError = true)]
         public static extern ThreadPriority GetThreadPriority(IntPtr hThread);
 
-        [DllImport("kernel32.dll", CallingConvention = CallingConvention.Cdecl, SetLastError = true)]
+        [DllImport("kernel32.dll", CallingConvention = CallingConvention.Winapi, SetLastError = true)]
         public static extern uint GetCurrentThreadId();
 
-        [DllImport("kernel32.dll", CallingConvention = CallingConvention.Cdecl, SetLastError = true)]
+        [DllImport("kernel32.dll", CallingConvention = CallingConvention.Winapi, SetLastError = true)]
         public static extern IntPtr OpenThread(ThreadAccess desiredAccess, bool inheritHandle, uint threadId);
 
-        [DllImport("kernel32.dll", CallingConvention = CallingConvention.Cdecl, SetLastError = true)]
+        [DllImport("kernel32.dll", CallingConvention = CallingConvention.Winapi, SetLastError = true)]
         public static extern bool CloseHandle(IntPtr handle);
 
         [DllImport("kernel32.dll")]

--- a/src/Voron/Impl/IPagerLevelTransactionState.cs
+++ b/src/Voron/Impl/IPagerLevelTransactionState.cs
@@ -1,0 +1,31 @@
+using System;
+using System.Collections.Generic;
+using Voron.Impl.Paging;
+
+namespace Voron.Impl
+{
+    public interface IPagerLevelTransactionState : IDisposable
+    {
+        Dictionary<AbstractPager, TransactionState> PagerTransactionState32Bits { get; set; }
+        event Action<IPagerLevelTransactionState> OnDispose;
+        void EnsurePagerStateReference(PagerState state);
+        StorageEnvironment Environment { get; }
+    }
+
+    public static class PagerLevelTransacionState
+    {
+        public static long GetTotal32BitsMappedSize(this IPagerLevelTransactionState self)
+        {
+            var dic = self?.PagerTransactionState32Bits;
+            if (dic == null)
+                return 0;
+            var result = 0L;
+            // ReSharper disable once LoopCanBeConvertedToQuery
+            foreach (var state in dic)
+            {
+                result += state.Value.TotalLoadedSize;
+            }
+            return result;
+        }
+    }
+}

--- a/src/Voron/Impl/Journal/JournalReader.cs
+++ b/src/Voron/Impl/Journal/JournalReader.cs
@@ -302,7 +302,7 @@ namespace Voron.Impl.Journal
         }
 
         Dictionary<AbstractPager, TransactionState> IPagerLevelTransactionState.
-            Windows32BitsPagerTransactionState
+            PagerTransactionState32Bits
         { get; set; }
 
         public event Action<IPagerLevelTransactionState> OnDispose;

--- a/src/Voron/Impl/Journal/WriteAheadJournal.cs
+++ b/src/Voron/Impl/Journal/WriteAheadJournal.cs
@@ -1125,7 +1125,7 @@ namespace Voron.Impl.Journal
 
             foreach (var txPage in txPages)
             {
-                var scratchPage = tx.Environment.ScratchBufferPool.AcquirePagePointer(tx, txPage.ScratchFileNumber, txPage.PositionInScratchBuffer);
+                var scratchPage = tx.Environment.ScratchBufferPool.AcquirePagePointerWithOverflowHandling(tx, txPage.ScratchFileNumber, txPage.PositionInScratchBuffer);
 
                 pagesInfo[pageSequencialNumber].PageNumber = ((PageHeader*)scratchPage)->PageNumber;
 

--- a/src/Voron/Impl/LowLevelTransaction.cs
+++ b/src/Voron/Impl/LowLevelTransaction.cs
@@ -21,14 +21,6 @@ using Voron.Util;
 
 namespace Voron.Impl
 {
-    public interface IPagerLevelTransactionState : IDisposable
-    {
-        Dictionary<AbstractPager, TransactionState> Windows32BitsPagerTransactionState { get; set; }
-        event Action<IPagerLevelTransactionState> OnDispose;
-        void EnsurePagerStateReference(PagerState state);
-        StorageEnvironment Environment { get; }
-    }
-
     public unsafe class LowLevelTransaction : IPagerLevelTransactionState
     {
         private const int PagesTakenByHeader = 1;
@@ -51,7 +43,7 @@ namespace Voron.Impl
         private readonly WriteAheadJournal _journal;
         internal readonly List<JournalSnapshot> JournalSnapshots = new List<JournalSnapshot>();
 
-        Dictionary<AbstractPager, TransactionState> IPagerLevelTransactionState.Windows32BitsPagerTransactionState
+        Dictionary<AbstractPager, TransactionState> IPagerLevelTransactionState.PagerTransactionState32Bits
         {
             get;
             set;

--- a/src/Voron/Impl/Paging/TempPagerTransaction.cs
+++ b/src/Voron/Impl/Paging/TempPagerTransaction.cs
@@ -10,7 +10,7 @@ namespace Voron.Impl.Paging
             OnDispose?.Invoke(this);
         }
 
-        public Dictionary<AbstractPager, TransactionState> Windows32BitsPagerTransactionState
+        public Dictionary<AbstractPager, TransactionState> PagerTransactionState32Bits
         {
             get; set;
         }

--- a/src/Voron/Impl/Scratch/ScratchBufferFile.cs
+++ b/src/Voron/Impl/Scratch/ScratchBufferFile.cs
@@ -264,10 +264,16 @@ namespace Voron.Impl.Scratch
             return new Page(_scratchPager.AcquirePagePointerWithOverflowHandling(tx, p, pagerState));
         }
 
-        public byte* AcquirePagePointer(LowLevelTransaction tx, long p)
+        public byte* AcquirePagePointerWithOverflowHandling(LowLevelTransaction tx, long p)
         {
             return _scratchPager.AcquirePagePointerWithOverflowHandling(tx, p);
         }
+
+        public byte* AcquirePagePointer(LowLevelTransaction tx, long p)
+        {
+            return _scratchPager.AcquirePagePointer(tx, p);
+        }
+
 
         internal Dictionary<long, long> GetMostAvailableFreePagesBySize()
         {

--- a/src/Voron/Impl/Scratch/ScratchBufferPool.cs
+++ b/src/Voron/Impl/Scratch/ScratchBufferPool.cs
@@ -300,6 +300,15 @@ namespace Voron.Impl.Scratch
         }
 
         [MethodImpl(MethodImplOptions.AggressiveInlining)]
+        public byte* AcquirePagePointerWithOverflowHandling(LowLevelTransaction tx, int scratchNumber, long p)
+        {
+            var item = GetScratchBufferFile(scratchNumber);
+
+            ScratchBufferFile bufferFile = item.File;
+            return bufferFile.AcquirePagePointerWithOverflowHandling(tx, p);
+        }
+
+        [MethodImpl(MethodImplOptions.AggressiveInlining)]
         private ScratchBufferItem GetScratchBufferFile(int scratchNumber)
         {
             var currentScratchFile = _current;

--- a/src/Voron/Platform/Win32/WindowsMemoryMapPager.cs
+++ b/src/Voron/Platform/Win32/WindowsMemoryMapPager.cs
@@ -24,7 +24,7 @@ namespace Voron.Platform.Win32
 {
     public unsafe class WindowsMemoryMapPager : AbstractPager
     {
-        public readonly long AllocationGranularity;
+        public const int AllocationGranularity = 64 * Constants.Size.Kilobyte;
         private long _totalAllocationSize;
         private readonly FileInfo _fileInfo;
         private readonly FileStream _fileStream;
@@ -59,7 +59,7 @@ namespace Voron.Platform.Win32
             GetSystemInfo(out systemInfo);
             FileName = file;
             _logger = LoggingSource.Instance.GetLogger<StorageEnvironment>($"Pager-{file}");
-            AllocationGranularity = systemInfo.allocationGranularity;
+
             _access = access;
             _copyOnWriteMode = Options.CopyOnWriteMode && FileName.EndsWith(Constants.DatabaseFilename);
             if (_copyOnWriteMode)


### PR DESCRIPTION
- Allow transactions to cleanup mappings that overlap with other transactions
- Limit mapped size of indexing batch to 8MB
- Disable compression for map reduce in 32 bits
- When allocating new pages don't call AcquirePagePointerWithOverflowHandling
- Fix name of Windows32BitsPagerTransactionState
- Fix calling convention for WinApi calls