### PR TITLE
RavenDB-5791

### DIFF
--- a/src/Raven.Client/Server/Operations/ServerOperationExecuter.cs
+++ b/src/Raven.Client/Server/Operations/ServerOperationExecuter.cs
@@ -16,7 +16,7 @@ namespace Raven.Client.Server.Operations
         public ServerOperationExecuter(DocumentStoreBase store)
         {
             _store = store;
-            _requestExecuter = RequestExecuter.ShortTermSingleUse(store.Url, null,store.ApiKey);
+            _requestExecuter = store.GetRequestExecuter();
         }
 
         public void Send(IServerOperation operation)


### PR DESCRIPTION
- we should dispose request executors on DocumentStore dispose
- server operation executor might be long living, it should use default request executor
- cleanup in request executor usages