### PR TITLE
RavenDB-5919 code review

### DIFF
--- a/src/Raven.Server/Documents/Indexes/CollectionOfIndexes.cs
+++ b/src/Raven.Server/Documents/Indexes/CollectionOfIndexes.cs
@@ -31,16 +31,20 @@ namespace Raven.Server.Documents.Indexes
             }
         }
 
-        public void ReplaceIndexes(Index oldIndex, Index NewIndex)
+        public void ReplaceIndexes(Index oldIndex, Index newIndex)
         {
             //WIP
-            _indexesByName.AddOrUpdate(oldIndex.Name, oldIndex, (key, oldValue) => NewIndex);
-            _indexesByName.TryRemove(NewIndex.Name, out NewIndex);
+            _indexesByName.AddOrUpdate(oldIndex.Name, oldIndex, (key, oldValue) => newIndex);
+
+            Index _;
+            _indexesByName.TryRemove(newIndex.Name, out _);
             foreach (var collection in oldIndex.Definition.Collections)
             {
-                ConcurrentSet<Index> indexSet;
-                _indexesByCollection.TryGetValue(collection, out indexSet);
-                indexSet.TryRemove(oldIndex);
+                ConcurrentSet<Index> indexes;
+                if (_indexesByCollection.TryGetValue(collection, out indexes) == false)
+                    continue;
+
+                indexes.TryRemove(oldIndex);
             }
             _indexesById.TryRemove(oldIndex.IndexId, out oldIndex);
         }

--- a/src/Raven.Server/Documents/Indexes/IndexDefinitionBase.cs
+++ b/src/Raven.Server/Documents/Indexes/IndexDefinitionBase.cs
@@ -37,7 +37,7 @@ namespace Raven.Server.Documents.Indexes
             Slice.From(StorageEnvironment.LabelsContext, "Definition", ByteStringType.Immutable, out DefinitionSlice);
         }
 
-        public string Name { get; set; }
+        public string Name { get; private set; }
 
         public HashSet<string> Collections { get; }
 
@@ -153,6 +153,13 @@ namespace Raven.Server.Documents.Indexes
                 first = false;
             }
             writer.WriteEndArray();
+        }
+
+        public void Rename(string name, TransactionOperationContext context, StorageEnvironmentOptions options)
+        {
+            Name = name;
+
+            Persist(context, options);
         }
 
         public IndexDefinition ConvertToIndexDefinition(Index index)

--- a/src/Raven.Server/Documents/Indexes/Static/MapIndex.cs
+++ b/src/Raven.Server/Documents/Indexes/Static/MapIndex.cs
@@ -1,6 +1,7 @@
 ﻿using System;
 using System.Collections.Generic;
 using System.Linq;
+using Raven.Client;
 using Raven.Client.Documents.Changes;
 using Raven.Client.Documents.Indexes;
 using Raven.Client.Extensions;
@@ -8,7 +9,6 @@ using Raven.Server.Documents.Indexes.Configuration;
 using Raven.Server.Documents.Indexes.Persistence.Lucene;
 using Raven.Server.Documents.Indexes.Workers;
 using Raven.Server.ServerWide.Context;
-using Sparrow;
 using Voron;
 
 namespace Raven.Server.Documents.Indexes.Static
@@ -18,6 +18,7 @@ namespace Raven.Server.Documents.Indexes.Static
         private readonly HashSet<string> _referencedCollections = new HashSet<string>(StringComparer.OrdinalIgnoreCase);
 
         protected internal readonly StaticIndexBase _compiled;
+        private bool? _isSideBySide;
 
         private HandleReferences _handleReferences;
 
@@ -94,6 +95,31 @@ namespace Raven.Server.Documents.Indexes.Static
             var writePos = indexEtagBytes + minLength;
 
             return StaticIndexHelper.CalculateIndexEtag(this, length, indexEtagBytes, writePos, documentsContext, indexContext);
+        }
+
+        protected override bool ShouldReplace()
+        {
+            if (_isSideBySide.HasValue == false)
+                _isSideBySide = Name.StartsWith(Constants.Documents.Indexing.SideBySideIndexNamePrefix, StringComparison.OrdinalIgnoreCase);
+
+            if (_isSideBySide == false)
+                return false;
+
+            DocumentsOperationContext databaseContext;
+            TransactionOperationContext indexContext;
+            using (DocumentDatabase.DocumentsStorage.ContextPool.AllocateOperationContext(out databaseContext))
+            using (_contextPool.AllocateOperationContext(out indexContext))
+            {
+                using (indexContext.OpenReadTransaction())
+                using (databaseContext.OpenReadTransaction())
+                {
+                    var canReplace = StaticIndexHelper.CanReplace(this, IsStale(databaseContext, indexContext), DocumentDatabase, databaseContext, indexContext);
+                    if (canReplace)
+                        _isSideBySide = null;
+
+                    return canReplace;
+                }
+            }
         }
 
         public override Dictionary<string, HashSet<CollectionName>> GetReferencedCollections()

--- a/src/Raven.Server/Documents/Indexes/StaticIndexHelper.cs
+++ b/src/Raven.Server/Documents/Indexes/StaticIndexHelper.cs
@@ -1,6 +1,5 @@
 ﻿using System;
 using System.Collections.Generic;
-using System.Diagnostics;
 using System.Runtime.CompilerServices;
 using Raven.Server.Documents.Indexes.MapReduce.Static;
 using Raven.Server.Documents.Indexes.Static;
@@ -11,6 +10,37 @@ namespace Raven.Server.Documents.Indexes
 {
     public static class StaticIndexHelper
     {
+        public static bool CanReplace(MapIndex index, bool isStale, DocumentDatabase database, DocumentsOperationContext databaseContext, TransactionOperationContext indexContext)
+        {
+            return CanReplace(index, isStale, index.Definition.IndexDefinition.MinimumEtagBeforeReplace, database, databaseContext, indexContext);
+        }
+
+        public static bool CanReplace(MapReduceIndex index, bool isStale, DocumentDatabase database, DocumentsOperationContext databaseContext, TransactionOperationContext indexContext)
+        {
+            return CanReplace(index, isStale, index.Definition.IndexDefinition.MinimumEtagBeforeReplace, database, databaseContext, indexContext);
+        }
+
+        private static bool CanReplace(Index index, bool isStale, long? minimumEtagBeforeReplace, DocumentDatabase database, DocumentsOperationContext databaseContext, TransactionOperationContext indexContext)
+        {
+            if (minimumEtagBeforeReplace == null)
+                return isStale == false;
+
+            foreach (var collection in index.Collections)
+            {
+                var lastProcessedDocEtag = index._indexStorage.ReadLastIndexedEtag(indexContext.Transaction, collection);
+                if (lastProcessedDocEtag < minimumEtagBeforeReplace.Value)
+                {
+                    var maxCollectionEtag = database.DocumentsStorage.GetLastDocumentEtag(databaseContext, collection);
+                    if (maxCollectionEtag == lastProcessedDocEtag)
+                        continue;
+
+                    return false;
+                }
+            }
+
+            return true;
+        }
+
         [MethodImpl(MethodImplOptions.AggressiveInlining)]
         public static bool IsStale(MapIndex index, DocumentsOperationContext databaseContext, TransactionOperationContext indexContext, long? cutoff)
         {
@@ -48,7 +78,7 @@ namespace Raven.Server.Documents.Indexes
                 // we haven't handled references for that collection yet
                 // in theory we could check what is the last etag for that collection in documents store
                 // but this was checked earlier by the base index class
-                if (lastIndexedEtag == 0) 
+                if (lastIndexedEtag == 0)
                     continue;
 
                 foreach (var referencedCollection in referencedCollections)

--- a/src/Raven.Server/Extensions/JsonSerializationExtensions.cs
+++ b/src/Raven.Server/Extensions/JsonSerializationExtensions.cs
@@ -56,6 +56,7 @@ namespace Raven.Server.Extensions
                 settings[kvp.Key] = kvp.Value;
 
             result[nameof(IndexDefinition.Configuration)] = settings;
+            result[nameof(IndexDefinition.MinimumEtagBeforeReplace)] = definition.MinimumEtagBeforeReplace;
 
             return result;
         }

--- a/test/FastTests/Client/Indexing/StaticIndexesFromClient.cs
+++ b/test/FastTests/Client/Indexing/StaticIndexesFromClient.cs
@@ -1,6 +1,8 @@
-﻿using System.Threading.Tasks;
-using FastTests.Server.Basic.Entities;
+﻿using System;
+using System.Threading;
+using System.Threading.Tasks;
 using Raven.Client.Documents.Indexes;
+using Raven.Client.Documents.Operations;
 using Raven.Client.Documents.Operations.Indexes;
 using Raven.Tests.Core.Utils.Entities;
 using Xunit;
@@ -91,6 +93,7 @@ namespace FastTests.Client.Indexing
                     .SendAsync(new PutIndexesOperation(new[] { input2 }));
 
                 WaitForIndexing(store);
+
                 output = await store
                     .Admin
                     .SendAsync(new GetIndexOperation("Users_ByName"));
@@ -149,6 +152,7 @@ namespace FastTests.Client.Indexing
                    .SendAsync(new PutIndexesOperation(new[] { input }));
 
                 WaitForIndexing(store);
+
                 output = await store
                     .Admin
                     .SendAsync(new GetIndexOperation("Users_ByName"));


### PR DESCRIPTION
- etag replacement should take into account max collection etag,
- when replacing the index we should use DeleteIndex method,
- draining queries for old index after replacement,
- persisting MinimumEtagBeforeReplace from index definition,
- persisting index definition after rename