### PR TITLE
RavenDB-6378 fixing an issue where !(condition) will fail to generate…

### DIFF
--- a/src/Raven.Client/Documents/Linq/RavenQueryProviderProcessor.cs
+++ b/src/Raven.Client/Documents/Linq/RavenQueryProviderProcessor.cs
@@ -133,7 +133,14 @@ namespace Raven.Client.Documents.Linq
                                 _documentQuery.CloseSubclause();
                                 break;
                             default:
-                                throw new ArgumentOutOfRangeException(unaryExpressionOp.NodeType.ToString());
+                                //probably the case of !(complex condition)
+                                _documentQuery.OpenSubclause();
+                                _documentQuery.Where("*:*");
+                                _documentQuery.AndAlso();
+                                _documentQuery.NegateNext();
+                                VisitExpression(unaryExpressionOp);
+                                _documentQuery.CloseSubclause();
+                                break;
                         }
                         break;
                     case ExpressionType.Convert:

--- a/test/FastTests/Issues/RavenDB_6345.cs
+++ b/test/FastTests/Issues/RavenDB_6345.cs
@@ -20,8 +20,8 @@ namespace FastTests.Issues
                     session.Store(new SomeClass { Culture = "EU", CatalogId = "Catalog/Test", ModelId = 4 });
                     session.SaveChanges();
                     WaitForIndexing(store);
-                    var query = session.Advanced.DocumentQuery<SomeClass>("SomeClassIndex").WhereEquals("Culture", "EU").AndAlso().Not.WhereEquals("ModelId", 4).AndAlso().WhereEquals("CatalogId", "Catalog/Test");
-                    Assert.Empty(query.ToList());
+                    var query = session.Query<SomeClass>("SomeClassIndex").Where(x => x.Culture.Equals("EU") && !(x.ModelId == 5) || x.CatalogId == "Catalog/Test");
+                    Assert.Single(query.ToList());
                 }
             }
         }


### PR DESCRIPTION
… query. the RavenDB_6345 test already covers this.