### PR TITLE
RavenDB-5974: Subscription changes porting from 3.5

### DIFF
--- a/ToMigrate/Raven.Tests.Issues/RavenDB-3491.cs
+++ b/ToMigrate/Raven.Tests.Issues/RavenDB-3491.cs
@@ -42,9 +42,8 @@ namespace Raven.Tests.Issues
 
                     var users = new List<RavenJObject>();
 
-                    using (var subscription = store.Subscriptions.Open(id, new SubscriptionConnectionOptions()))
+                    using (var subscription = store.AsyncSubscriptions.Open(new SubscriptionConnectionOptions(id)))
                     {
-
                         var docs = new BlockingCollection<RavenJObject>();
                         var keys = new BlockingCollection<string>();
                         var ages = new BlockingCollection<int>();
@@ -117,7 +116,7 @@ namespace Raven.Tests.Issues
 
                     var users = new List<User>();
 
-                    using (var subscription = store.Subscriptions.Open<User>(id, new SubscriptionConnectionOptions()))
+                    using (var subscription = store.AsyncSubscriptions.Open<User>(new SubscriptionConnectionOptions(id)))
                     {
 
                         var docs = new BlockingCollection<User>();
@@ -193,7 +192,7 @@ namespace Raven.Tests.Issues
 
                     var users = new List<RavenJObject>();
 
-                    using (var subscription = store.Subscriptions.Open(subscriptionId, new SubscriptionConnectionOptions()))
+                    using (var subscription = store.AsyncSubscriptions.Open(new SubscriptionConnectionOptions(subscriptionId)))
                     {
 
                         var docs = new BlockingCollection<RavenJObject>();
@@ -237,9 +236,9 @@ namespace Raven.Tests.Issues
                         Assert.Equal(34, age);
                     }
                 }
-                using (var subscription = store.Subscriptions.Open(subscriptionId, new SubscriptionConnectionOptions()))
+                using (var subscription = store.AsyncSubscriptions.Open(new SubscriptionConnectionOptions(subscriptionId)))
                 {
-                    var docs = new BlockingCollection<RavenJObject>();
+                    var docs = new BlockingCollection<dynamic>();
 
                     subscription.Subscribe(o => docs.Add(o));
 

--- a/bench/Subscriptions.Benchmark/SingleSubscriptionBenchmark.cs
+++ b/bench/Subscriptions.Benchmark/SingleSubscriptionBenchmark.cs
@@ -112,9 +112,8 @@ namespace SubscriptionsBenchmark
                 }
 
 
-                using (var subscription = _store.AsyncSubscriptions.Open(new SubscriptionConnectionOptions()
+                using (var subscription = _store.AsyncSubscriptions.Open(new SubscriptionConnectionOptions(_subscriptionId.Value)
                 {
-                    SubscriptionId = _subscriptionId.Value,
                     Strategy = SubscriptionOpeningStrategy.WaitForFree
                 }))
                 {

--- a/src/Raven.Client/Documents/Subscriptions/AsyncDocumentSubscriptions.cs
+++ b/src/Raven.Client/Documents/Subscriptions/AsyncDocumentSubscriptions.cs
@@ -71,7 +71,11 @@ namespace Raven.Client.Documents.Subscriptions
                 throw new InvalidOperationException("Cannot open a subscription if options are null");
 
             var subscription = new Subscription<T>(options, _store, _store.Conventions, database);
-
+            subscription.SubscriptionConnectionInterrupted  += (exception, willReconnect) =>
+            {
+                if (willReconnect == false)
+                    _subscriptions.TryRemove(subscription);
+            };
             _subscriptions.Add(subscription);
 
             return subscription;

--- a/src/Raven.Client/Documents/Subscriptions/Subscription.cs
+++ b/src/Raven.Client/Documents/Subscriptions/Subscription.cs
@@ -34,6 +34,8 @@ namespace Raven.Client.Documents.Subscriptions
 
     public delegate void AfterAcknowledgment();
 
+    public delegate void SubscriptionConnectionInterrupted(Exception ex, bool willReconnect);
+
     public class Subscription<T> : IObservable<T>, IDisposableAsync, IDisposable where T : class
     {
         private readonly Logger _logger;
@@ -50,6 +52,49 @@ namespace Raven.Client.Documents.Subscriptions
         private Task _subscriptionTask;
         private Stream _stream;
         private readonly TaskCompletionSource<object> _disposedTask = new TaskCompletionSource<object>();
+        private TaskCompletionSource<bool> taskCompletionSource = new TaskCompletionSource<bool>();
+
+        /// <summary>
+        ///     It indicates if the subscription is in errored state because one of subscribers threw an exception.
+        /// </summary>
+        public bool IsErroredBecauseOfSubscriber { get; private set; }
+
+        /// <summary>
+        ///     The last exception thrown by one of subscribers.
+        /// </summary>
+        public Exception LastSubscriberException { get; private set; }
+
+        /// <summary>
+        /// Task that will be completed when the subscription connection will close and self dispose, or errorous if subscription connection is entirely interrupted
+        /// </summary>
+        public Task SubscriptionLifetimeTask { private set; get; }
+
+        /// <summary>
+        ///     It determines if the subscription connection is closed.
+        /// </summary>
+        public bool IsConnectionClosed { get; private set; }
+        
+        /// <summary>
+        /// Called before received batch starts to be proccessed by subscribers
+        /// </summary>
+        public event BeforeBatch BeforeBatch = delegate { };
+
+        /// <summary>
+        /// Called after received batch finished being proccessed by subscribers
+        /// </summary>
+        public event AfterBatch AfterBatch = delegate { };
+
+        /// <summary>
+        /// Called before subscription progress is being stored to the DB
+        /// </summary>
+        public event BeforeAcknowledgment BeforeAcknowledgment = delegate { };
+
+        /// <summary>
+        /// Called when subscription connection is interrupted. The error passed will describe the reason for the interruption. 
+        /// </summary>
+        public event SubscriptionConnectionInterrupted SubscriptionConnectionInterrupted = delegate { };
+        
+        
 
         internal Subscription(SubscriptionConnectionOptions options, IDocumentStore documentStore,
             DocumentConventions conventions, string dbName)
@@ -66,6 +111,8 @@ namespace Raven.Client.Documents.Subscriptions
 
             _generateEntityIdOnTheClient = new GenerateEntityIdOnTheClient(conventions,
                 entity => { throw new InvalidOperationException("Shouldn't be generating new ids here"); });
+
+            SubscriptionLifetimeTask = taskCompletionSource.Task;
         }
 
         ~Subscription()
@@ -82,20 +129,7 @@ namespace Raven.Client.Documents.Subscriptions
             }
         }
 
-        /// <summary>
-        ///     It indicates if the subscription is in errored state because one of subscribers threw an exception.
-        /// </summary>
-        public bool IsErroredBecauseOfSubscriber { get; private set; }
-
-        /// <summary>
-        ///     The last exception thrown by one of subscribers.
-        /// </summary>
-        public Exception LastSubscriberException { get; private set; }
-
-        /// <summary>
-        ///     It determines if the subscription connection is closed.
-        /// </summary>
-        public bool IsConnectionClosed { get; private set; }
+        
 
         public void Dispose()
         {
@@ -111,7 +145,7 @@ namespace Raven.Client.Documents.Subscriptions
             {
                 if (_disposed)
                     return;
-
+                
                 _disposed = true;
                 _proccessingCts.Cancel();
                 _disposedTask.TrySetResult(null); // notify the subscription task that we are done
@@ -131,6 +165,11 @@ namespace Raven.Client.Documents.Subscriptions
                 CloseTcpClient(); // we disconnect immediately, freeing the subscription task
 
                 OnCompletedNotification();
+
+                if (taskCompletionSource.Task.IsCanceled == false && taskCompletionSource.Task.IsCompleted == false && taskCompletionSource.Task.IsFaulted == false)
+                {
+                    taskCompletionSource.TrySetResult(true);
+                }
             }
             catch (Exception ex)
             {
@@ -153,11 +192,7 @@ namespace Raven.Client.Documents.Subscriptions
             // we cannot remove subscriptions dynamically, once we added, it is done
             return new DisposableAction(() => { });
         }
-
-        public event BeforeBatch BeforeBatch = delegate { };
-        public event AfterBatch AfterBatch = delegate { };
-        public event BeforeAcknowledgment BeforeAcknowledgment = delegate { };
-
+        
         /// <summary>
         /// allows the user to define stuff that happens after the confirm was recieved from the server (this way we know we won't
         /// get those documents again)
@@ -200,67 +235,50 @@ namespace Raven.Client.Documents.Subscriptions
 
             JsonOperationContext context;
             var requestExecuter = _store.GetRequestExecuter(_dbName ?? _store.DefaultDatabase);
-            requestExecuter.ContextPool.AllocateOperationContext(out context);
 
-            await requestExecuter.ExecuteAsync(command, context).ConfigureAwait(false);
-            var apiToken = await requestExecuter.GetAuthenticationToken(context, command.RequestedNode);
-            var uri = new Uri(command.Result.Url);
-
-            await _tcpClient.ConnectAsync(uri.Host, uri.Port).ConfigureAwait(false);
-
-            _tcpClient.NoDelay = true;
-            _tcpClient.SendBufferSize = 32 * 1024;
-            _tcpClient.ReceiveBufferSize = 4096;
-            _stream = _tcpClient.GetStream();
-            _stream = await TcpUtils.WrapStreamWithSslAsync(_tcpClient, command.Result);
-
-            var header = Encoding.UTF8.GetBytes(JsonConvert.SerializeObject(new TcpConnectionHeaderMessage
+            using (requestExecuter.ContextPool.AllocateOperationContext(out context))
             {
-                Operation = TcpConnectionHeaderMessage.OperationTypes.Subscription,
-                DatabaseName = _dbName ?? _store.DefaultDatabase,
-                AuthorizationToken = apiToken
-            }));
+                await requestExecuter.ExecuteAsync(command, context).ConfigureAwait(false);
+                var apiToken = await requestExecuter.GetAuthenticationToken(context, command.RequestedNode);
+                var uri = new Uri(command.Result.Url);
 
-            var options = Encoding.UTF8.GetBytes(JsonConvert.SerializeObject(_options));
+                await _tcpClient.ConnectAsync(uri.Host, uri.Port).ConfigureAwait(false);
 
-            await _stream.WriteAsync(header, 0, header.Length);
-            await _stream.FlushAsync();
-            //Reading reply from server
-            using (var response = context.ReadForMemory(_stream, "Subscription/tcp-header-response"))
-            {
-                var reply = JsonDeserializationClient.TcpConnectionHeaderResponse(response);
-                switch (reply.Status)
+                _tcpClient.NoDelay = true;
+                _tcpClient.SendBufferSize = 32 * 1024;
+                _tcpClient.ReceiveBufferSize = 4096;
+                _stream = _tcpClient.GetStream();
+                _stream = await TcpUtils.WrapStreamWithSslAsync(_tcpClient, command.Result);
+
+                var header = Encoding.UTF8.GetBytes(JsonConvert.SerializeObject(new TcpConnectionHeaderMessage
                 {
-                    case TcpConnectionHeaderResponse.AuthorizationStatus.Forbidden:
-                        throw AuthorizationException.Forbidden(_store.Url);
-                    case TcpConnectionHeaderResponse.AuthorizationStatus.Success:
-                        break;
-                    default:
-                        throw AuthorizationException.Unauthorized(reply.Status, _dbName);
-                }
-            }
-            await _stream.WriteAsync(options, 0, options.Length);
+                    Operation = TcpConnectionHeaderMessage.OperationTypes.Subscription,
+                    DatabaseName = _dbName ?? _store.DefaultDatabase,
+                    AuthorizationToken = apiToken
+                }));
 
-            await _stream.FlushAsync();
-            return _stream;
-        }
+                    var options = Encoding.UTF8.GetBytes(JsonConvert.SerializeObject(_options));
 
-        private void InformSubscribersOnError(Exception ex)
-        {
-            foreach (var subscriber in _subscribers)
-            {
-                try
+                await _stream.WriteAsync(header, 0, header.Length);
+                await _stream.FlushAsync();
+                //Reading reply from server
+                using (var response = context.ReadForMemory(_stream, "Subscription/tcp-header-response"))
                 {
-                    subscriber.OnError(ex);
-                }
-                catch (Exception)
-                {
-                    if (_logger.IsInfoEnabled)
+                    var reply = JsonDeserializationClient.TcpConnectionHeaderResponse(response);
+                    switch (reply.Status)
                     {
-                        _logger.Info(
-                            $"Subscription #{_options.SubscriptionId}. Subscriber threw an exception while proccessing OnError ", ex);
+                        case TcpConnectionHeaderResponse.AuthorizationStatus.Forbidden:
+                            throw AuthorizationException.Forbidden(_store.Url);
+                        case TcpConnectionHeaderResponse.AuthorizationStatus.Success:
+                            break;
+                        default:
+                            throw AuthorizationException.Unauthorized(reply.Status, _dbName);
                     }
                 }
+                await _stream.WriteAsync(options, 0, options.Length);
+
+                await _stream.FlushAsync();
+                return _stream;
             }
         }
 
@@ -368,8 +386,7 @@ namespace Raven.Client.Documents.Subscriptions
             }
             catch (Exception ex)
             {
-                if (_proccessingCts.Token.IsCancellationRequested == false)
-                    InformSubscribersOnError(ex);
+                SubscriptionConnectionInterrupted(ex, true);
                 throw;
             }
         }
@@ -502,6 +519,8 @@ namespace Raven.Client.Documents.Subscriptions
                     {
                         IsErroredBecauseOfSubscriber = true;
                         LastSubscriberException = ex;
+                        SubscriptionConnectionInterrupted(ex, false);
+                        taskCompletionSource.TrySetException(ex);
 
                         try
                         {
@@ -511,6 +530,7 @@ namespace Raven.Client.Documents.Subscriptions
                         {
                             // can happen if a subscriber doesn't have an onError handler - just ignore it
                         }
+
                         break;
                     }
                 }
@@ -565,6 +585,7 @@ namespace Raven.Client.Documents.Subscriptions
                 {
                     if (_proccessingCts.Token.IsCancellationRequested)
                     {
+                        SubscriptionConnectionInterrupted(ex, true);
                         return;
                     }
 #pragma warning disable CS4014 // Because this call is not awaited, execution of the current method continues before the call is completed
@@ -576,15 +597,16 @@ namespace Raven.Client.Documents.Subscriptions
                             $"Subscription #{_options.SubscriptionId}. Pulling task threw the following exception", ex);
                     }
 
-
-                    if (await TryHandleRejectedConnection(ex, false).ConfigureAwait(false))
+                    if (await TryHandleRejectedConnectionOrDispose(ex, false).ConfigureAwait(false))
                     {
                         if (_logger.IsInfoEnabled)
                             _logger.Info($"Subscription #{_options.SubscriptionId}");
                         return;
                     }
+                    
                     await Task.Delay(_options.TimeToWaitBeforeConnectionRetryMilliseconds);
                 }
+
             }
             if (_proccessingCts.Token.IsCancellationRequested)
                 return;
@@ -606,7 +628,7 @@ namespace Raven.Client.Documents.Subscriptions
             }
         }
 
-        private async Task<bool> TryHandleRejectedConnection(Exception ex, bool reopenTried)
+        private async Task<bool> TryHandleRejectedConnectionOrDispose(Exception ex, bool reopenTried)
         {
             if (ex is SubscriptionInUseException || // another client has connected to the subscription
                 ex is SubscriptionDoesNotExistException || // subscription has been deleted meanwhile
@@ -614,8 +636,8 @@ namespace Raven.Client.Documents.Subscriptions
             // someone forced us to drop the connection by calling Subscriptions.Release
             {
                 IsConnectionClosed = true;
-
-                InformSubscribersOnError(ex);
+                taskCompletionSource.TrySetException(ex);
+                SubscriptionConnectionInterrupted(ex, false);
 
                 await DisposeAsync().ConfigureAwait(false);
 
@@ -670,6 +692,11 @@ namespace Raven.Client.Documents.Subscriptions
                 {
                 }
             }
+        }
+
+        public void Start()
+        {
+            AsyncHelpers.RunSync(StartAsync);
         }
     }
 }

--- a/src/Raven.Client/Documents/Subscriptions/SubscriptionConnectionOptions.cs
+++ b/src/Raven.Client/Documents/Subscriptions/SubscriptionConnectionOptions.cs
@@ -59,20 +59,17 @@ namespace Raven.Client.Documents.Subscriptions
 
     public class SubscriptionConnectionOptions
     {
-        public long SubscriptionId { get; set; }
-
-        public SubscriptionConnectionOptions()
+        public SubscriptionConnectionOptions(long subscriptionId)
         {
             Strategy = SubscriptionOpeningStrategy.OpenIfFree;
             MaxDocsPerBatch = 4096;
+            SubscriptionId = subscriptionId;
         }
 
+        public readonly long SubscriptionId;
         public int TimeToWaitBeforeConnectionRetryMilliseconds { get; set; } = 5000;
         public bool IgnoreSubscribersErrors { get; set; }
         public SubscriptionOpeningStrategy Strategy { get; set; }
         public int MaxDocsPerBatch { get; set; }
-        public long ClientSubscriptionId { get; set; } = Interlocked.Increment(ref _counter);
-
-        private static long _counter;
     }
 }

--- a/src/Raven.Server/Documents/Handlers/SubscriptionsHandler.cs
+++ b/src/Raven.Server/Documents/Handlers/SubscriptionsHandler.cs
@@ -127,7 +127,7 @@ namespace Raven.Server.Documents.Handlers
         {
             var subscriptionId = GetLongQueryString("id").Value;
 
-            if (Database.SubscriptionStorage.DropSubscriptionConnection(subscriptionId) == false)
+            if (Database.SubscriptionStorage.DropSubscriptionConnection(subscriptionId, "Dropped by api request") == false)
             {
                 HttpContext.Response.StatusCode = (int)HttpStatusCode.NotFound;
                 return Task.CompletedTask;

--- a/src/Raven.Server/Documents/SubscriptionState.cs
+++ b/src/Raven.Server/Documents/SubscriptionState.cs
@@ -13,10 +13,12 @@ namespace Raven.Server.Documents
 {
     public class SubscriptionState:IDisposable
     {
+        private readonly SubscriptionStorage _storage;
         private readonly AsyncManualResetEvent _connectionInUse = new AsyncManualResetEvent();
 
-        public SubscriptionState()
+        public SubscriptionState(SubscriptionStorage storage)
         {
+            _storage = storage;
             _connectionInUse.Set();
         }
 
@@ -58,16 +60,17 @@ namespace Raven.Server.Documents
                                     $"Subscription {incomingConnection.SubscriptionId} is occupied by a ForceAndKeep connection, connectionId cannot be opened");
 
                             if (_currentConnection != null)
-                                _currentConnection.ConnectionException = new SubscriptionClosedException("Closed by Takeover");
+                                _storage.DropSubscriptionConnection(_currentConnection.SubscriptionId,
+                                    "Closed by TakeOver");
 
-                            _currentConnection?.CancellationTokenSource.Cancel();
-                        
                             throw new TimeoutException();
 
                         case SubscriptionOpeningStrategy.ForceAndKeep:
-                            _currentConnection.ConnectionException = new SubscriptionClosedException("Closed by ForceAndKeep");
-                            _currentConnection?.CancellationTokenSource.Cancel();
-                        
+
+                            if (_currentConnection != null)
+                                _storage.DropSubscriptionConnection(_currentConnection.SubscriptionId,
+                                    "Closed by ForceAndKeep");
+
                             throw new TimeoutException();
                         default:
                             throw new InvalidOperationException("Unknown subscription open strategy: " +

--- a/src/Raven.Server/Documents/SubscriptionStorage.cs
+++ b/src/Raven.Server/Documents/SubscriptionStorage.cs
@@ -118,7 +118,7 @@ namespace Raven.Server.Documents
         public SubscriptionState OpenSubscription(SubscriptionConnection connection)
         {
             var subscriptionState = _subscriptionStates.GetOrAdd(connection.SubscriptionId,
-                _ => new SubscriptionState());
+                _ => new SubscriptionState(this));
             return subscriptionState;
         }
 
@@ -196,27 +196,22 @@ namespace Raven.Server.Documents
 
         public unsafe void DeleteSubscription(long id)
         {
-            SubscriptionState subscriptionState;
-            if (_subscriptionStates.TryRemove(id, out subscriptionState))
-            {
-                subscriptionState.EndConnection();
-                subscriptionState.Dispose();
-            }
-
+            DropSubscriptionConnection(id, "Deleted");
             var transactionPersistentContext = new TransactionPersistentContext();
             using (var tx = _environment.WriteTransaction(transactionPersistentContext))
             {
                 var table = tx.OpenTable(_subscriptionsSchema, SubscriptionSchema.SubsTree);
 
-                long subscriptionId = id;
+                var subscriptionId = Bits.SwapBytes(id);
                 TableValueReader subscription;
                 Slice subsriptionSlice;
                 using (Slice.External(tx.Allocator, (byte*)&subscriptionId, sizeof(long), out subsriptionSlice))
                 {
                     if (table.ReadByKey(subsriptionSlice, out subscription) == false)
                         return;
+
+                    table.DeleteByKey(subsriptionSlice);
                 }
-                table.Delete(subscription.Id);
 
                 tx.Commit();
 
@@ -227,18 +222,18 @@ namespace Raven.Server.Documents
             }
         }
 
-        public bool DropSubscriptionConnection(long subscriptionId)
+        public bool DropSubscriptionConnection(long subscriptionId, string reason)
         {
             SubscriptionState subscriptionState;
             if (_subscriptionStates.TryGetValue(subscriptionId, out subscriptionState) == false)
                 return false;
 
-            subscriptionState.Connection.ConnectionException = new SubscriptionClosedException("Closed by request");
-            subscriptionState.RegisterRejectedConnection(subscriptionState.Connection, new SubscriptionClosedException("Closed by request"));
+            subscriptionState.Connection.ConnectionException = new SubscriptionClosedException(reason);
+            subscriptionState.RegisterRejectedConnection(subscriptionState.Connection, new SubscriptionClosedException(reason));
             subscriptionState.Connection.CancellationTokenSource.Cancel();
 
             if (_logger.IsInfoEnabled)
-                _logger.Info($"Subscription with id {subscriptionId} connection was dropped");
+                _logger.Info($"Subscription with id {subscriptionId} connection was dropped. Reason: {reason}");
 
             return true;
         }
@@ -300,8 +295,7 @@ namespace Raven.Server.Documents
                 [nameof(SubscriptionConnectionOptions.TimeToWaitBeforeConnectionRetryMilliseconds)] = options.TimeToWaitBeforeConnectionRetryMilliseconds,
                 [nameof(SubscriptionConnectionOptions.IgnoreSubscribersErrors)] = options.IgnoreSubscribersErrors,
                 [nameof(SubscriptionConnectionOptions.Strategy)] = options.Strategy,
-                [nameof(SubscriptionConnectionOptions.MaxDocsPerBatch)] = options.MaxDocsPerBatch,
-                [nameof(SubscriptionConnectionOptions.ClientSubscriptionId)] = options.ClientSubscriptionId
+                [nameof(SubscriptionConnectionOptions.MaxDocsPerBatch)] = options.MaxDocsPerBatch
             };
         }
 

--- a/src/Raven.Server/Documents/TcpHandlers/SubscriptionConnection.cs
+++ b/src/Raven.Server/Documents/TcpHandlers/SubscriptionConnection.cs
@@ -252,6 +252,7 @@ namespace Raven.Server.Documents.TcpHandlers
                                     ["Exception"] = connection.ConnectionException.ToString()
                                 });
 
+
                             }
                             catch
                             {

--- a/test/ClientFastTests/Subscriptions/SubscriptionOperationsSignaling.cs
+++ b/test/ClientFastTests/Subscriptions/SubscriptionOperationsSignaling.cs
@@ -1,0 +1,237 @@
+﻿using System;
+using System.Collections.Concurrent;
+using System.Collections.Generic;
+using System.Linq;
+using System.Threading;
+using System.Threading.Tasks;
+using FastTests;
+using FastTests.Subscriptions;
+using Raven.NewClient.Abstractions.Data;
+using Raven.NewClient.Client.Exceptions.Subscriptions;
+using Raven.Tests.Core.Utils.Entities;
+using Xunit;
+
+namespace NewClientTests.NewClient.Subscriptions
+{
+    public class SubscriptionOperationsSignaling : RavenNewTestBase
+    {
+        private readonly TimeSpan _reasonableWaitTime = TimeSpan.FromSeconds(20);// todo: reduce to 20
+
+        [Fact]
+        public void WaitOnSubscriptionTaskWhenSubscriptionIsOvertaken()
+        {
+            using (var store = GetDocumentStore())
+            {
+                var subscriptionId = store.Subscriptions.Create(new SubscriptionCriteria<User>());
+
+                var subscription = store.Subscriptions.Open<User>(new SubscriptionConnectionOptions(subscriptionId));
+                
+                var users = new BlockingCollection<User>();
+                
+                subscription.Subscribe(users.Add);
+                subscription.Start();
+
+                using (var session = store.OpenSession())
+                {
+                    session.Store(new User());
+                    session.SaveChanges();
+                }
+
+                User user;
+                Assert.True(users.TryTake(out user, _reasonableWaitTime));
+
+                var concurrentSubscription = store.Subscriptions.Open<User>(
+                    new SubscriptionConnectionOptions(subscriptionId) { 
+                    Strategy = SubscriptionOpeningStrategy.TakeOver
+                });
+
+                var thread = new Thread(() => {
+                    Thread.Sleep(300);
+                    concurrentSubscription.Subscribe(users.Add);
+                    concurrentSubscription.Start();
+                });
+                thread.Start();
+                Assert.Throws(typeof(AggregateException), () => subscription.SubscriptionLifetimeTask.Wait(_reasonableWaitTime));
+
+                Assert.True(subscription.SubscriptionLifetimeTask.IsFaulted);
+
+                Assert.Equal(typeof(SubscriptionInUseException), subscription.SubscriptionLifetimeTask.Exception.InnerException.GetType());
+
+            }
+        }
+
+        [Fact]
+        public void SubscriptionInterruptionEventIsFiredWhenSubscriptionIsOvertaken()
+        {
+            using (var store = GetDocumentStore())
+            {
+                var subscriptionId = store.Subscriptions.Create(new SubscriptionCriteria<User>());
+                var subscription = store.Subscriptions.Open<User>(new SubscriptionConnectionOptions(subscriptionId));
+                var users = new BlockingCollection<User>();
+                
+                var mre = new ManualResetEvent(false);
+                subscription.SubscriptionConnectionInterrupted += (exception, reconnect) =>
+                {
+                    if (exception is SubscriptionInUseException && reconnect == false)
+                        mre.Set();
+                };
+
+
+                subscription.Subscribe(users.Add);
+                subscription.Start();
+
+                using (var session = store.OpenSession())
+                {
+                    session.Store(new User());
+                    session.SaveChanges();
+                }
+
+                User User;
+                Assert.True(users.TryTake(out User, _reasonableWaitTime));
+
+                var concurrentSubscription = store.Subscriptions.Open<User>(
+                    new SubscriptionConnectionOptions(subscriptionId) { 
+                    Strategy = SubscriptionOpeningStrategy.TakeOver
+                });
+
+                concurrentSubscription.Subscribe(users.Add);
+                concurrentSubscription.Start();
+                Assert.True(mre.WaitOne(_reasonableWaitTime));
+            }
+        }
+
+        [Fact]
+        public void WaitOnSubscriptionTaskWhenSubscriptionIsDeleted()
+        {
+            using (var store = GetDocumentStore())
+            {
+                var subscriptionId = store.Subscriptions.Create(new SubscriptionCriteria<User>());
+                var subscription = store.Subscriptions.Open<User>(new SubscriptionConnectionOptions(subscriptionId));
+                
+                var beforeAckMre = new ManualResetEvent(false);
+                var users = new BlockingCollection<User>();
+                subscription.Subscribe(users.Add);
+                subscription.Start();
+                using (var session = store.OpenSession())
+                {
+                    session.Store(new User());
+                    session.SaveChanges();
+                }
+
+                User User;
+                Assert.True(users.TryTake(out User, _reasonableWaitTime));
+
+
+                subscription.BeforeAcknowledgment += () => beforeAckMre.WaitOne();
+
+                store.Subscriptions.Delete(subscriptionId);
+                beforeAckMre.Set();
+
+                Assert.Throws(typeof(AggregateException), () => subscription.SubscriptionLifetimeTask.Wait(_reasonableWaitTime));
+
+                Assert.True(subscription.SubscriptionLifetimeTask.IsFaulted);
+
+                Assert.Equal(typeof(SubscriptionDoesNotExistException), subscription.SubscriptionLifetimeTask.Exception.InnerException.GetType());
+            }
+        }
+
+        [Fact]
+        public void SubscriptionInterruptionEventIsFiredWhenSubscriptionIsDeleted()
+        {
+            using (var store = GetDocumentStore())
+            {
+                var subscriptionId = store.Subscriptions.Create(new SubscriptionCriteria<User>());
+                var subscription = store.Subscriptions.Open<User>(new SubscriptionConnectionOptions(subscriptionId));
+                var users = new BlockingCollection<User>();
+
+                var mre = new ManualResetEvent(false);
+                subscription.SubscriptionConnectionInterrupted += (exception, reconnect) =>
+                {
+                    if (exception is SubscriptionDoesNotExistException && reconnect == false)
+                        mre.Set();
+                };
+                subscription.Subscribe(users.Add);
+                subscription.Start();
+
+                using (var session = store.OpenSession())
+                {
+                    session.Store(new User());
+                    session.SaveChanges();
+                }
+
+                User User;
+                Assert.True(users.TryTake(out User, _reasonableWaitTime));
+
+                var thread = new Thread(() =>
+                {
+                    Thread.Sleep(400);
+                    store.Subscriptions.Delete(subscriptionId);
+                });
+                thread.Start();
+                
+                Assert.True(mre.WaitOne(_reasonableWaitTime));
+            }
+        }
+
+        [Fact]
+        public void WaitOnSubscriptionTaskWhenSubscriptionCompleted()
+        {
+            using (var store = GetDocumentStore())
+            {
+                var subscriptionId = store.Subscriptions.Create(new SubscriptionCriteria<User>());
+                var subscription = store.Subscriptions.Open<User>(new SubscriptionConnectionOptions(subscriptionId));
+                var users = new BlockingCollection<User>();
+                subscription.Subscribe(users.Add);
+                subscription.Start();
+                using (var session = store.OpenSession())
+                {
+                    session.Store(new User());
+                    session.SaveChanges();
+                }
+
+                User user;
+                Assert.True(users.TryTake(out user, _reasonableWaitTime));
+
+                subscription.Dispose();
+                subscription.SubscriptionLifetimeTask.Wait(_reasonableWaitTime);
+
+                Assert.True(subscription.SubscriptionLifetimeTask.IsCompleted);
+
+
+
+
+            }
+        }
+        
+        [Fact]
+        public void WaitOnSubscriptionStopDueToSubscriberError()
+        {
+            using (var store = GetDocumentStore())
+            {
+                var subscriptionId = store.Subscriptions.Create(new SubscriptionCriteria<User>());
+                var subscription = store.Subscriptions.Open<User>(new SubscriptionConnectionOptions(subscriptionId));
+                var exceptions = new BlockingCollection<Exception>();
+                
+                subscription.Subscribe(_ =>
+                {
+                    throw new InvalidCastException();
+                }, exceptions.Add);
+                subscription.Start();
+                using (var session = store.OpenSession())
+                {
+                    session.Store(new User());
+                    session.SaveChanges();
+                }
+
+                Exception exception;
+                Assert.True(exceptions.TryTake(out exception, _reasonableWaitTime));
+
+                Assert.Throws(typeof(AggregateException), () => subscription.SubscriptionLifetimeTask.Wait(_reasonableWaitTime));
+
+                Assert.True(subscription.SubscriptionLifetimeTask.IsFaulted);
+
+                Assert.Equal(typeof(InvalidCastException), subscription.SubscriptionLifetimeTask.Exception.InnerException.GetType());
+            }
+        }
+    }
+}

--- a/test/FastTests/Client/Subscriptions/CriteriaScript.cs
+++ b/test/FastTests/Client/Subscriptions/CriteriaScript.cs
@@ -32,10 +32,7 @@ namespace FastTests.Client.Subscriptions
                     FilterJavaScript = " return this.Name == 'ThingNo3'",
                 };
                 var subsId = subscriptionManager.Create(subscriptionCriteria, lastEtag);
-                using (var subscription = subscriptionManager.Open<Thing>(new SubscriptionConnectionOptions()
-                {
-                    SubscriptionId = subsId
-                }))
+                using (var subscription = subscriptionManager.Open<Thing>(new SubscriptionConnectionOptions(subsId)))
                 {
                     var list = new BlockingCollection<Thing>();
                     subscription.Subscribe(x =>

--- a/test/FastTests/Client/Subscriptions/RavenDB_3082.cs
+++ b/test/FastTests/Client/Subscriptions/RavenDB_3082.cs
@@ -60,12 +60,7 @@ namespace FastTests.Client.Subscriptions
 
                 var id = await store.AsyncSubscriptions.CreateAsync(criteria);
 
-                using (
-                    var subscription =
-                        store.AsyncSubscriptions.Open<PersonWithAddress>(new SubscriptionConnectionOptions
-                        {
-                            SubscriptionId = id
-                        }))
+                using (var subscription = store.AsyncSubscriptions.Open<PersonWithAddress>(new SubscriptionConnectionOptions(id)))
                 {
 
                     var users = new BlockingCollection<PersonWithAddress>();

--- a/test/FastTests/Client/Subscriptions/RavenDB_3491.cs
+++ b/test/FastTests/Client/Subscriptions/RavenDB_3491.cs
@@ -43,10 +43,7 @@ namespace FastTests.Client.Subscriptions
 
                     var users = new List<dynamic>();
 
-                    using (var subscription = store.AsyncSubscriptions.Open(new SubscriptionConnectionOptions
-                    {
-                        SubscriptionId = id
-                    }))
+                    using (var subscription = store.AsyncSubscriptions.Open(new SubscriptionConnectionOptions(id)))
                     {
 
                         var docs = new BlockingCollection<dynamic>();
@@ -121,10 +118,7 @@ namespace FastTests.Client.Subscriptions
 
                     var users = new List<User>();
 
-                    using (var subscription = store.AsyncSubscriptions.Open<User>(new SubscriptionConnectionOptions
-                    {
-                        SubscriptionId = id
-                    }))
+                    using (var subscription = store.AsyncSubscriptions.Open<User>(new SubscriptionConnectionOptions(id)))
                     {
 
                         var docs = new BlockingCollection<User>();
@@ -203,10 +197,7 @@ namespace FastTests.Client.Subscriptions
 
                     var users = new List<dynamic>();
 
-                    using (var subscription = store.AsyncSubscriptions.Open(new SubscriptionConnectionOptions
-                    {
-                        SubscriptionId = subscriptionId
-                    }))
+                    using (var subscription = store.AsyncSubscriptions.Open(new SubscriptionConnectionOptions(subscriptionId)))
                     {
                         var docs = new BlockingCollection<dynamic>();
                         var keys = new BlockingCollection<string>();
@@ -251,10 +242,7 @@ namespace FastTests.Client.Subscriptions
                     }
                 }
 
-                using (var subscription = store.AsyncSubscriptions.Open(new SubscriptionConnectionOptions
-                {
-                    SubscriptionId = subscriptionId
-                }))
+                using (var subscription = store.AsyncSubscriptions.Open(new SubscriptionConnectionOptions(subscriptionId)))
                 {
 
                     var docs = new BlockingCollection<dynamic>();

--- a/test/FastTests/Client/Subscriptions/Subscriptions.cs
+++ b/test/FastTests/Client/Subscriptions/Subscriptions.cs
@@ -49,10 +49,7 @@ namespace FastTests.Client.Subscriptions
                     Collection = "Things",
                 };
                 var subsId = await store.AsyncSubscriptions.CreateAsync(subscriptionCriteria, lastEtag);
-                using (var subscription = store.AsyncSubscriptions.Open<Thing>(new SubscriptionConnectionOptions()
-                {
-                    SubscriptionId = subsId
-                }))
+                using (var subscription = store.AsyncSubscriptions.Open<Thing>(new SubscriptionConnectionOptions(subsId)))
                 {
                     var list = new BlockingCollection<Thing>();
                     subscription.Subscribe<Thing>(x =>
@@ -86,12 +83,9 @@ namespace FastTests.Client.Subscriptions
                     Collection = "Things",
                 };
                 var subsId = await store.AsyncSubscriptions.CreateAsync(subscriptionCriteria, lastEtag);
-                using (
-                    var acceptedSubscription = store.AsyncSubscriptions.Open<Thing>(new SubscriptionConnectionOptions()
-                    {
-                        SubscriptionId = subsId,
-                        TimeToWaitBeforeConnectionRetryMilliseconds = 20000
-                    }))
+                using (var acceptedSubscription = store.AsyncSubscriptions.Open<Thing>(
+                    new SubscriptionConnectionOptions(subsId){
+                        TimeToWaitBeforeConnectionRetryMilliseconds = 20000}))
                 {
 
                     var acceptedSusbscriptionList = new BlockingCollection<Thing>();
@@ -112,14 +106,12 @@ namespace FastTests.Client.Subscriptions
                     Assert.False(acceptedSusbscriptionList.TryTake(out thing, 50));
 
                     // open second subscription
-                    using (
-                        var rejectedSusbscription =
-                            store.AsyncSubscriptions.Open<Thing>(new SubscriptionConnectionOptions()
-                            {
-                                SubscriptionId = subsId,
-                                Strategy = SubscriptionOpeningStrategy.OpenIfFree,
-                                TimeToWaitBeforeConnectionRetryMilliseconds = 2000
-                            }))
+                    using (var rejectedSusbscription = store.AsyncSubscriptions.Open<Thing>(
+                                new SubscriptionConnectionOptions(subsId)
+                                {
+                                    Strategy = SubscriptionOpeningStrategy.OpenIfFree,
+                                    TimeToWaitBeforeConnectionRetryMilliseconds = 2000
+                                }))
                     {
 
                         rejectedSusbscription.Subscribe(thing1 => { });
@@ -158,10 +150,7 @@ namespace FastTests.Client.Subscriptions
                 };
                 var subsId = await store.AsyncSubscriptions.CreateAsync(subscriptionCriteria, lastEtag);
                 using (
-                    var acceptedSubscription = store.AsyncSubscriptions.Open<Thing>(new SubscriptionConnectionOptions()
-                    {
-                        SubscriptionId = subsId
-                    }))
+                    var acceptedSubscription = store.AsyncSubscriptions.Open<Thing>(new SubscriptionConnectionOptions(subsId)))
                 {
 
                     var acceptedSusbscriptionList = new BlockingCollection<Thing>();
@@ -192,12 +181,12 @@ namespace FastTests.Client.Subscriptions
                     // open second subscription
                     using (
                         var waitingSubscription =
-                            store.AsyncSubscriptions.Open<Thing>(new SubscriptionConnectionOptions()
-                            {
-                                SubscriptionId = subsId,
-                                Strategy = SubscriptionOpeningStrategy.WaitForFree,
-                                TimeToWaitBeforeConnectionRetryMilliseconds = 250
-                            }))
+                            store.AsyncSubscriptions.Open<Thing>(
+                                new SubscriptionConnectionOptions(subsId)
+                                {
+                                    Strategy = SubscriptionOpeningStrategy.WaitForFree,
+                                    TimeToWaitBeforeConnectionRetryMilliseconds = 250
+                                }))
                     {
 
                         waitingSubscription.Subscribe(x =>
@@ -243,12 +232,9 @@ namespace FastTests.Client.Subscriptions
                     Collection = "Things",
                 };
                 var subsId = await store.AsyncSubscriptions.CreateAsync(subscriptionCriteria, lastEtag);
-                
+
                 using (
-                    var acceptedSubscription = store.AsyncSubscriptions.Open<Thing>(new SubscriptionConnectionOptions()
-                    {
-                        SubscriptionId = subsId
-                    }))
+                    var acceptedSubscription = store.AsyncSubscriptions.Open<Thing>(new SubscriptionConnectionOptions(subsId)))
                 {
                     var acceptedSusbscriptionList = new BlockingCollection<Thing>();
                     var takingOverSubscriptionList = new BlockingCollection<Thing>();
@@ -283,9 +269,10 @@ namespace FastTests.Client.Subscriptions
                     Assert.False(acceptedSusbscriptionList.TryTake(out thing));
 
                     // open second subscription
-                    using (var takingOverSubscription = store.AsyncSubscriptions.Open<Thing>(new SubscriptionConnectionOptions()
+                    using (var takingOverSubscription = store.AsyncSubscriptions.Open<Thing>(
+                        new SubscriptionConnectionOptions(subsId)
                     {
-                        SubscriptionId = subsId,
+                        
                         Strategy = SubscriptionOpeningStrategy.TakeOver
                     }))
                     {

--- a/test/SlowTests/Core/Subscriptions/RavenDB-3193.cs
+++ b/test/SlowTests/Core/Subscriptions/RavenDB-3193.cs
@@ -35,11 +35,10 @@ namespace SlowTests.Core.Subscriptions
                     Collection = "Users"                    
                 });
 
-                using (var subscription = store.AsyncSubscriptions.Open(new SubscriptionConnectionOptions
-                {
-                    MaxDocsPerBatch = 31,
-                    SubscriptionId = id
-                }))
+                using (var subscription = store.AsyncSubscriptions.Open(
+                    new SubscriptionConnectionOptions(id){
+                        MaxDocsPerBatch = 31
+                    }))
                 {
                     var docs = new List<dynamic>();
 

--- a/test/SlowTests/Tests/Subscriptions.cs
+++ b/test/SlowTests/Tests/Subscriptions.cs
@@ -27,10 +27,7 @@ namespace SlowTests.Tests
                 };
 
                 var subsId = await store.AsyncSubscriptions.CreateAsync(subscriptionCriteria, lastEtag);
-                using (var subscription = store.AsyncSubscriptions.Open<Thing>(new SubscriptionConnectionOptions
-                {
-                    SubscriptionId = subsId
-                }))
+                using (var subscription = store.AsyncSubscriptions.Open<Thing>(new SubscriptionConnectionOptions(subsId)))
                 {
 
                     var bc = new BlockingCollection<Thing>();


### PR DESCRIPTION
* Perform minor api fixes (that lead to a lot of tests fixes)
*Port recent 3.5 subscription changes to v4.0 we should address the following issues:
 ** RavenDB-5523: Added SubscriptionLifetimeTask task and SubscriptionConnectionInterrupted for better signaling of internal subscription state changes
 ** RavenDB-5947 - Closing subscription should remove it from the set
 ** Call InformSubscribersOnError only when there is a subscriber error, for all other exceptions, use the SubscriptionConnectionInterrupted event and the SubscriptionLifetimeTask task.