### PR TITLE
RavenDB-6370 Applying PR comments (#1702):

### DIFF
--- a/src/Voron/Data/BTrees/Tree.MultiTree.cs
+++ b/src/Voron/Data/BTrees/Tree.MultiTree.cs
@@ -123,7 +123,7 @@ namespace Voron.Data.BTrees
             EnsureNestedPagePointer(page, item, ref nestedPage, ref nestedPagePtr);
 
             // we now have to convert this into a tree instance, instead of just a nested page
-            var tree = Create(_llt, _tx, TreeFlags.MultiValue);
+            var tree = Create(_llt, _tx, key, TreeFlags.MultiValue);
             for (int i = 0; i < nestedPage.NumberOfEntries; i++)
             {
                 Slice existingValue;
@@ -186,7 +186,7 @@ namespace Voron.Data.BTrees
                 // no choice, very big value, we might as well just put it in its own tree from the get go...
                 // otherwise, we would have to put this in overflow page, and that won't save us any space anyway
 
-                var tree = Create(_llt, _tx, TreeFlags.MultiValue);
+                var tree = Create(_llt, _tx, key, TreeFlags.MultiValue);
                 tree.DirectAdd(value, 0).Dispose();
                 _tx.AddMultiValueTree(this, key, tree);
 
@@ -343,8 +343,7 @@ namespace Voron.Data.BTrees
             Debug.Assert(childTreeHeader->RootPageNumber < _llt.State.NextPageNumber);
             Debug.Assert(childTreeHeader->Flags == TreeFlags.MultiValue);
 
-            tree = Open(_llt, _tx, childTreeHeader);
-            tree.Name = key;
+            tree = Open(_llt, _tx, key, childTreeHeader);
             _tx.AddMultiValueTree(this, key, tree);
             return tree;
         }

--- a/src/Voron/Data/BTrees/Tree.cs
+++ b/src/Voron/Data/BTrees/Tree.cs
@@ -54,7 +54,7 @@ namespace Voron.Data.BTrees
                 RootPageNumber = root
             };
 
-            _addScope = new DirectAddScope(Name.ToString());
+            _addScope = new DirectAddScope(this);
         }
 
         public Tree(LowLevelTransaction llt, Transaction tx, Slice name, TreeMutableState state)
@@ -68,7 +68,7 @@ namespace Voron.Data.BTrees
             _state = new TreeMutableState(llt);
             _state = state;
 
-            _addScope = new DirectAddScope(Name.ToString());
+            _addScope = new DirectAddScope(this);
         }
 
         public bool IsLeafCompressionSupported

--- a/src/Voron/Data/DirectAddScope.cs
+++ b/src/Voron/Data/DirectAddScope.cs
@@ -7,7 +7,7 @@ namespace Voron.Data
     {
         private readonly object _tree;
         private uint _usage;
-#if DEBUG
+#if VALIDATE_DIRECT_ADD_STACKTRACE
         private string _allocationStacktrace = null;
 #endif
         public byte* Ptr;
@@ -30,7 +30,7 @@ namespace Voron.Data
             }
             else
             {
-#if DEBUG
+#if VALIDATE_DIRECT_ADD_STACKTRACE
                 ThrowScopeAlreadyOpen(_tree, _allocationStacktrace);
 #else
                 ThrowScopeAlreadyOpen(_tree, null);

--- a/src/Voron/Data/DirectAddScope.cs
+++ b/src/Voron/Data/DirectAddScope.cs
@@ -5,35 +5,45 @@ namespace Voron.Data
 {
     public unsafe class DirectAddScope : IDisposable
     {
-        private readonly ITree _tree;
+        private readonly string _treeName;
         private uint _usage;
+#if DEBUG
         private string _allocationStacktrace = null;
-
+#endif
         public byte* Ptr;
 
-        public DirectAddScope(ITree tree)
+        public DirectAddScope(string treeName)
         {
             _usage = 0;
-            _tree = tree;
+            _treeName = treeName;
             Ptr = null;
         }
 
         public DirectAddScope Open(byte* writePos)
         {
-            if (_usage++ > 0)
-                ThrowScopeAlreadyOpen(_tree, _allocationStacktrace);
-
-            Ptr = writePos;
+            if (_usage++ <= 0)
+            {
+                Ptr = writePos;
 #if DEBUG
-            // uncomment for debugging purposes only
-            //_allocationStacktrace = Environment.StackTrace;
+                // uncomment for debugging purposes only
+                //_allocationStacktrace = Environment.StackTrace;
 #endif
+            }
+            else
+            {
+#if DEBUG
+                ThrowScopeAlreadyOpen(_treeName, _allocationStacktrace);
+#else
+                ThrowScopeAlreadyOpen(_treeName, null);
+#endif
+            }
+
             return this;
         }
 
-        private static void ThrowScopeAlreadyOpen(ITree tree, string previousOpenStacktrace)
+        private static void ThrowScopeAlreadyOpen(string treeName, string previousOpenStacktrace)
         {
-            var message = $"Write operation already requested on a tree name: {tree.Name}. " +
+            var message = $"Write operation already requested on a tree name: {treeName}. " +
                           $"{nameof(Tree.DirectAdd)} method cannot be called recursively while the scope is already opened.";
 
             if (previousOpenStacktrace != null)
@@ -49,6 +59,14 @@ namespace Voron.Data
         {
             _usage--;
             Ptr = null;
+        }
+
+        public void Reset()
+        {
+            if (_usage <= 0)
+                return;
+
+            ThrowScopeAlreadyOpen(_treeName, null);
         }
     }
 }

--- a/src/Voron/Data/Fixed/FixedSizeTree.cs
+++ b/src/Voron/Data/Fixed/FixedSizeTree.cs
@@ -17,7 +17,7 @@ using Voron.Impl.Paging;
 
 namespace Voron.Data.Fixed
 {
-    public unsafe partial class FixedSizeTree : IDisposable, ITree
+    public unsafe partial class FixedSizeTree : IDisposable
     {
         internal const int BranchEntrySize = sizeof(long) + sizeof(long);
         private readonly LowLevelTransaction _tx;
@@ -34,7 +34,7 @@ namespace Voron.Data.Fixed
         private RootObjectType? _type;
         private Stack<FixedSizeTreePage> _cursor;
         private int _changes;
-        private DirectAddScope _addScope;
+        private readonly DirectAddScope _addScope;
 
         public LowLevelTransaction Llt => _tx;
 
@@ -58,7 +58,7 @@ namespace Voron.Data.Fixed
 
         public void RepurposeInstance(Slice treeName, bool clone)
         {
-            _addScope = new DirectAddScope(this);
+            _addScope.Reset();
 
             if (clone)
             {
@@ -120,6 +120,8 @@ namespace Voron.Data.Fixed
             _maxEmbeddedEntries = (Constants.Storage.PageSize / 8) / _entrySize;
             if (_maxEmbeddedEntries == 0)
                 ThrowInvalidFixedTreeValueSize();
+
+            _addScope = new DirectAddScope(null);
 
             RepurposeInstance(treeName, clone);
         }
@@ -1490,7 +1492,7 @@ namespace Voron.Data.Fixed
             }
         }
 
-        private IDisposable ModifyLargeHeader(out FixedSizeTreeHeader.Large* largeHeader)
+        private DirectAddScope ModifyLargeHeader(out FixedSizeTreeHeader.Large* largeHeader)
         {
             var largeHeaderScope = _parent.DirectAdd(_treeName, sizeof(FixedSizeTreeHeader.Large));
 

--- a/src/Voron/Data/Fixed/FixedSizeTree.cs
+++ b/src/Voron/Data/Fixed/FixedSizeTree.cs
@@ -121,7 +121,7 @@ namespace Voron.Data.Fixed
             if (_maxEmbeddedEntries == 0)
                 ThrowInvalidFixedTreeValueSize();
 
-            _addScope = new DirectAddScope(null);
+            _addScope = new DirectAddScope(this);
 
             RepurposeInstance(treeName, clone);
         }
@@ -1499,6 +1499,11 @@ namespace Voron.Data.Fixed
             largeHeader = (FixedSizeTreeHeader.Large*)largeHeaderScope.Ptr;
 
             return largeHeaderScope;
+        }
+
+        public override string ToString()
+        {
+            return Name.ToString();
         }
     }
 }

--- a/src/Voron/Data/ITree.cs
+++ b/src/Voron/Data/ITree.cs
@@ -1,7 +1,0 @@
-﻿namespace Voron.Data
-{
-    public interface ITree
-    {
-        Slice Name { get; }
-    }
-}

--- a/src/Voron/Data/Tables/Table.cs
+++ b/src/Voron/Data/Tables/Table.cs
@@ -639,9 +639,9 @@ namespace Voron.Data.Tables
             if (treeHeader == null)
                 throw new InvalidOperationException($"Cannot find tree {name} in table {Name}");
 
-            tree = Tree.Open(_tx.LowLevelTransaction, _tx, (TreeRootHeader*)treeHeader, newPageAllocator: _tablePageAllocator);
+            tree = Tree.Open(_tx.LowLevelTransaction, _tx, name, (TreeRootHeader*)treeHeader, newPageAllocator: _tablePageAllocator);
             _treesBySliceCache[name] = tree;
-            tree.Name = name;
+
             return tree;
         }
 

--- a/src/Voron/Data/Tables/TableSchema.cs
+++ b/src/Voron/Data/Tables/TableSchema.cs
@@ -400,7 +400,7 @@ namespace Voron.Data.Tables
                     if (_primaryKey.IsGlobal == false)
                     {
                         
-                        using (var indexTree = Tree.Create(tx.LowLevelTransaction, tx, newPageAllocator: tablePageAllocator))
+                        using (var indexTree = Tree.Create(tx.LowLevelTransaction, tx, _primaryKey.Name, newPageAllocator: tablePageAllocator))
                         {
                             using (var add = tableTree.DirectAdd(_primaryKey.Name, sizeof(TreeRootHeader)))
                             {
@@ -418,7 +418,7 @@ namespace Voron.Data.Tables
                 {
                     if (indexDef.IsGlobal == false)
                     {
-                        using (var indexTree = Tree.Create(tx.LowLevelTransaction, tx, newPageAllocator: tablePageAllocator))
+                        using (var indexTree = Tree.Create(tx.LowLevelTransaction, tx, indexDef.Name, newPageAllocator: tablePageAllocator))
                         {
                             using (var add = tableTree.DirectAdd(indexDef.Name, sizeof(TreeRootHeader)))
                             {

--- a/src/Voron/Impl/Backup/IncrementalBackup.cs
+++ b/src/Voron/Impl/Backup/IncrementalBackup.cs
@@ -401,8 +401,7 @@ namespace Voron.Impl.Backup
                 env.Options.DataPager.Sync(0);
 
 
-                var root = Tree.Open(txw, null, &lastTxHeader->Root);
-                root.Name = Constants.RootTreeNameSlice;
+                var root = Tree.Open(txw, null, Constants.RootTreeNameSlice, & lastTxHeader->Root);
 
                 txw.UpdateRootsIfNeeded(root);
 

--- a/src/Voron/Impl/LowLevelTransaction.cs
+++ b/src/Voron/Impl/LowLevelTransaction.cs
@@ -281,7 +281,7 @@ namespace Voron.Impl
         {
             if (_state.Root != null)
             {
-                _root = new Tree(this, null, _state.Root) { Name = Constants.RootTreeNameSlice };
+                _root = new Tree(this, null, Constants.RootTreeNameSlice, _state.Root);
             }
         }
 

--- a/src/Voron/Impl/Transaction.cs
+++ b/src/Voron/Impl/Transaction.cs
@@ -69,8 +69,7 @@ namespace Voron.Impl
                 if (header->RootObjectType != type)
                     ThrowInvalidTreeType(treeName, type, header);
 
-                tree = Tree.Open(_lowLevelTransaction, this, header, type, newPageAllocator, pageLocator);
-                tree.Name = treeName;
+                tree = Tree.Open(_lowLevelTransaction, this, treeName, header, type, newPageAllocator, pageLocator);
 
                 if ((tree.State.Flags & TreeFlags.LeafsCompressed) == TreeFlags.LeafsCompressed)
                     tree.InitializeCompression();
@@ -312,7 +311,7 @@ namespace Voron.Impl
             using (var add = _lowLevelTransaction.RootObjects.DirectAdd(toName, sizeof(TreeRootHeader)))
                 fromTree.State.CopyTo((TreeRootHeader*)add.Ptr);
 
-            fromTree.Name = toName;
+            fromTree.Rename(toName);
             fromTree.State.IsModified = true;
 
             // _trees already ensrued already created in ReadTree
@@ -340,8 +339,7 @@ namespace Voron.Impl
                 throw new InvalidOperationException("No such tree: '" + name +
                                                     "' and cannot create trees in read transactions");
 
-            tree = Tree.Create(_lowLevelTransaction, this, flags,  pageLocator: pageLocator);
-            tree.Name = name;
+            tree = Tree.Create(_lowLevelTransaction, this, name, flags, pageLocator: pageLocator);
             tree.State.RootObjectType = type;
 
             using (var space = _lowLevelTransaction.RootObjects.DirectAdd(name, sizeof(TreeRootHeader)))

--- a/src/Voron/StorageEnvironment.cs
+++ b/src/Voron/StorageEnvironment.cs
@@ -252,10 +252,8 @@ namespace Voron
             var transactionPersistentContext = new TransactionPersistentContext(true);
             using (var tx = NewLowLevelTransaction(transactionPersistentContext, TransactionFlags.ReadWrite))
             {
-                using (var root = Tree.Open(tx, null, header->TransactionId == 0 ? &entry.Root : &header->Root))
+                using (var root = Tree.Open(tx, null, Constants.RootTreeNameSlice, header->TransactionId == 0 ? &entry.Root : &header->Root))
                 {
-                    root.Name = Constants.RootTreeNameSlice;
-
                     tx.UpdateRootsIfNeeded(root);
 
                     using (var treesTx = new Transaction(tx))
@@ -310,7 +308,7 @@ namespace Voron
 
             var transactionPersistentContext = new TransactionPersistentContext();
             using (var tx = NewLowLevelTransaction(transactionPersistentContext, TransactionFlags.ReadWrite))
-            using (var root = Tree.Create(tx, null))
+            using (var root = Tree.Create(tx, null, Constants.RootTreeNameSlice))
             {
 
                 // important to first create the root trees, then set them on the env

--- a/src/Voron/project.json
+++ b/src/Voron/project.json
@@ -25,7 +25,7 @@
     "Validate": {
       "buildOptions": {
         "optimize": true,
-        "define": [ "VALIDATE", "VALIDATE_PAGES" ]
+        "define": [ "VALIDATE", "VALIDATE_PAGES", "VALIDATE_DIRECT_ADD_STACKTRACE" ]
       }
     }
   },


### PR DESCRIPTION
- wrapping unnecessary allocation into #if DEBUG
- getting rid of ITree - using ToString() to have a tree name
- returning DirectAddScope instead of IDisposable in ModifyLargeHeader
- reusing the existing scope to avoid extra allocations when FixedSizeTree.RepurposeInstance is called