### PR TITLE
* RavenDB-6347 Handle IO-metrics in 32 bits pagers

### DIFF
--- a/src/Raven.Server/Documents/Handlers/Debugging/MemoryStatsHandler.cs
+++ b/src/Raven.Server/Documents/Handlers/Debugging/MemoryStatsHandler.cs
@@ -39,8 +39,6 @@ namespace Raven.Server.Documents.Handlers.Debugging
         {
             var currentProcess = Process.GetCurrentProcess();
             var workingSet = currentProcess.WorkingSet64;
-            if (Sparrow.Platform.PlatformDetails.RunningOnPosix)
-                workingSet *= 4096; // TODO: bug in the framework, reports pages instead of bytes
             long totalUnmanagedAllocations = 0;
             long totalMapping = 0;
             var fileMappingByDir = new Dictionary<string, Dictionary<string, ConcurrentDictionary<IntPtr, long>>>();


### PR DESCRIPTION
- Call fsync instead of msync in POSIX pager's Sync()
- Fix working set size in POSIX memory stats