### PR TITLE
RavenDB-6369 adjusted http client timeout behavior

### DIFF
--- a/src/Raven.Client/Documents/Commands/QueryCommand.cs
+++ b/src/Raven.Client/Documents/Commands/QueryCommand.cs
@@ -40,6 +40,9 @@ namespace Raven.Client.Documents.Commands
             _includes = includes;
             _metadataOnly = metadataOnly;
             _indexEntriesOnly = indexEntriesOnly;
+
+            if (_indexQuery.WaitForNonStaleResultsTimeout.HasValue)
+                Timeout = _indexQuery.WaitForNonStaleResultsTimeout.Value.Add(TimeSpan.FromSeconds(10)); // giving the server an opportunity to finish the response
         }
 
         public override HttpRequestMessage CreateRequest(ServerNode node, out string url)

--- a/src/Raven.Client/Http/RavenCommand.cs
+++ b/src/Raven.Client/Http/RavenCommand.cs
@@ -24,6 +24,8 @@ namespace Raven.Client.Http
 
         public RavenCommandResponseType ResponseType { get; protected set; } = RavenCommandResponseType.Object;
 
+        public TimeSpan? Timeout { get; protected set; }
+
         public abstract HttpRequestMessage CreateRequest(ServerNode node, out string url);
         public abstract void SetResponse(BlittableJsonReaderObject response, bool fromCache);
 

--- a/test/SlowTests/Issues/RavenDB_6369.cs
+++ b/test/SlowTests/Issues/RavenDB_6369.cs
@@ -1,0 +1,57 @@
+﻿using System;
+using System.Collections.Generic;
+using System.Diagnostics;
+using System.Threading.Tasks;
+using FastTests;
+using Raven.Client.Documents.Commands;
+using Raven.Client.Documents.Conventions;
+using Raven.Client.Documents.Operations.Indexes;
+using Raven.Client.Documents.Queries;
+using SlowTests.Core.Utils.Entities;
+using SlowTests.Core.Utils.Indexes;
+using Sparrow.Json;
+using Xunit;
+
+namespace SlowTests.Issues
+{
+    public class RavenDB_6369 : RavenTestBase
+    {
+        [Fact]
+        public void ShouldTimeout()
+        {
+            using (var store = GetDocumentStore())
+            {
+                new Users_ByName().Execute(store);
+
+                store.Admin.Send(new StopIndexingOperation());
+
+                using (var session = store.OpenSession())
+                {
+                    session.Store(new User { Name = "John" });
+                    session.SaveChanges();
+                }
+
+                JsonOperationContext context;
+                var requestExecuter = store.GetRequestExecuter();
+                using (requestExecuter.ContextPool.AllocateOperationContext(out context))
+                {
+                    var command = new TestQueryCommand(store.Conventions, context, new Users_ByName().IndexName, new IndexQuery(store.Conventions) { WaitForNonStaleResultsTimeout = TimeSpan.FromSeconds(5), WaitForNonStaleResults = true });
+
+                    var sw = Stopwatch.StartNew();
+                    Assert.Throws<TaskCanceledException>(() => requestExecuter.Execute(command, context));
+                    sw.Stop();
+
+                    Assert.True(sw.Elapsed < TimeSpan.FromSeconds(1));
+                }
+            }
+        }
+
+        private class TestQueryCommand : QueryCommand
+        {
+            public TestQueryCommand(DocumentConventions conventions, JsonOperationContext context, string indexName, IndexQuery indexQuery, HashSet<string> includes = null, bool metadataOnly = false, bool indexEntriesOnly = false) : base(conventions, context, indexName, indexQuery, includes, metadataOnly, indexEntriesOnly)
+            {
+                Timeout = TimeSpan.FromMilliseconds(100);
+            }
+        }
+    }
+}


### PR DESCRIPTION
- we should rely on server when it comes to timeout (increased client timeout to 12h)
- when WaitForNonStaleResultsTimeout is used in QueryCommand then adding 10s to give server a chance to respond