### PR TITLE
RavenDB-6437:

### DIFF
--- a/src/Sparrow/Platform/Posix/OpenFlags.cs
+++ b/src/Sparrow/Platform/Posix/OpenFlags.cs
@@ -37,7 +37,7 @@ namespace Voron.Platform.Posix
 
         O_NOFOLLOW = 0x00020000,
         O_ASYNC = 0x00002000,
-        O_LARGEFILE = 0x00008000,
+        // O_LARGEFILE = 0x00008000,
         O_CLOEXEC = 0x00080000,
         O_PATH = 0x00200000
     }

--- a/src/Sparrow/Platform/Posix/PerPlatformValues.cs
+++ b/src/Sparrow/Platform/Posix/PerPlatformValues.cs
@@ -26,6 +26,12 @@ namespace Voron.Platform.Posix
              RuntimeInformation.OSArchitecture == Architecture.Arm64)
                 ? 16384 // value directly from printf("%d", O_DIRECTORY)
                 : 65536); // value directly from printf("%d", O_DIRECTORY) on the pi
+
+            public static Posix.OpenFlags O_LARGEFILE = (Posix.OpenFlags)(
+           (RuntimeInformation.OSArchitecture == Architecture.Arm ||
+            RuntimeInformation.OSArchitecture == Architecture.Arm64)
+               ? 131072 // value directly from printf("%d", O_DIRECT) on the pi
+               : 32768); // value directly from printf("%d", O_DIRECT)
         }
     }
 }

--- a/src/Sparrow/Platform/Posix/PosixElectricFencedMemory.cs
+++ b/src/Sparrow/Platform/Posix/PosixElectricFencedMemory.cs
@@ -19,8 +19,8 @@ namespace Sparrow.Platform
             var allocatedSize = ((sizeInPages + 2) * 4096); 
 
 
-            var virtualAlloc = (byte*)Syscall.mmap(IntPtr.Zero, (UIntPtr)allocatedSize, MmapProts.PROT_NONE,
-                MmapFlags.MAP_PRIVATE | MmapFlags.MAP_ANONYMOUS, -1, IntPtr.Zero);
+            var virtualAlloc = (byte*)Syscall.mmap64(IntPtr.Zero, (UIntPtr)allocatedSize, MmapProts.PROT_NONE,
+                MmapFlags.MAP_PRIVATE | MmapFlags.MAP_ANONYMOUS, -1, 0L);
 
             if (virtualAlloc == (byte*)-1)
             {
@@ -34,9 +34,9 @@ namespace Sparrow.Platform
                 throw new InvalidOperationException("Failed to free call msync " + (IntPtr)virtualAlloc + ". Err=" + Marshal.GetLastWin32Error());
             }
 
-            virtualAlloc = (byte*)Syscall.mmap((IntPtr)virtualAlloc, (UIntPtr)allocatedSize, 
+            virtualAlloc = (byte*)Syscall.mmap64((IntPtr)virtualAlloc, (UIntPtr)allocatedSize, 
                 MmapProts.PROT_READ | MmapProts.PROT_WRITE,
-                MmapFlags.MAP_FIXED | MmapFlags.MAP_SHARED | MmapFlags.MAP_ANONYMOUS, -1, IntPtr.Zero);
+                MmapFlags.MAP_FIXED | MmapFlags.MAP_SHARED | MmapFlags.MAP_ANONYMOUS, -1, 0L);
 
             if (virtualAlloc == (byte*)-1)
             {

--- a/src/Voron/Platform/Posix/Posix32BitsMemoryMapPager.cs
+++ b/src/Voron/Platform/Posix/Posix32BitsMemoryMapPager.cs
@@ -48,7 +48,7 @@ namespace Voron.Platform.Posix
 
             PosixHelper.EnsurePathExists(FileName);
 
-            _fd = Syscall.open(file, OpenFlags.O_RDWR | OpenFlags.O_CREAT,
+            _fd = Syscall.open(file, OpenFlags.O_RDWR | OpenFlags.O_CREAT | PerPlatformValues.OpenFlags.O_LARGEFILE,
                               FilePermissions.S_IWUSR | FilePermissions.S_IRUSR);
             if (_fd == -1)
             {
@@ -66,7 +66,7 @@ namespace Voron.Platform.Posix
                 _totalAllocationSize != GetFileSize())
             {
                 _totalAllocationSize = NearestSizeToAllocationGranularity(_totalAllocationSize);
-                PosixHelper.AllocateFileSpace(_options, _fd, (ulong)_totalAllocationSize, file);
+                PosixHelper.AllocateFileSpace(_options, _fd, _totalAllocationSize, file);
             }
 
             if (_isSyncDirAllowed && PosixHelper.SyncDirectory(file) == -1)
@@ -137,9 +137,9 @@ namespace Voron.Platform.Posix
             var offset = allocationStartPosition * Constants.Storage.PageSize;
             var mmflags = _copyOnWriteMode ? MmapFlags.MAP_PRIVATE : MmapFlags.MAP_SHARED;
 
-            var result = Syscall.mmap(IntPtr.Zero, (UIntPtr)sizeToMap,
+            var result = Syscall.mmap64(IntPtr.Zero, (UIntPtr)sizeToMap,
                                                       MmapProts.PROT_READ | MmapProts.PROT_WRITE,
-                                                      mmflags, _fd, new IntPtr(offset));
+                                                      mmflags, _fd, offset);
             try
             {
                 if (result.ToInt64() == -1) //system didn't succeed in mapping the address where we wanted
@@ -164,8 +164,8 @@ namespace Voron.Platform.Posix
                     result = new IntPtr(-1);
                     sizeToMap =NearestSizeToAllocationGranularity((numberOfPages + distanceFromStart)*
                                                            Constants.Storage.PageSize);
-                    result = Syscall.mmap(IntPtr.Zero, (UIntPtr) sizeToMap, MmapProts.PROT_READ | MmapProts.PROT_WRITE,
-                        mmflags, _fd, new IntPtr(offset));
+                    result = Syscall.mmap64(IntPtr.Zero, (UIntPtr) sizeToMap, MmapProts.PROT_READ | MmapProts.PROT_WRITE,
+                        mmflags, _fd, offset);
 
                     if (result.ToInt64() == -1)
                     {
@@ -243,9 +243,9 @@ namespace Voron.Platform.Posix
                 }
                 var mmflags = _copyOnWriteMode ? MmapFlags.MAP_PRIVATE : MmapFlags.MAP_SHARED;
 
-                var startingBaseAddressPtr = Syscall.mmap(IntPtr.Zero, (UIntPtr) size,
+                var startingBaseAddressPtr = Syscall.mmap64(IntPtr.Zero, (UIntPtr) size,
                     MmapProts.PROT_READ | MmapProts.PROT_WRITE,
-                    mmflags, _fd, new IntPtr(offset));
+                    mmflags, _fd, offset);
 
                 if (startingBaseAddressPtr.ToInt64() == -1)
                     //system didn't succeed in mapping the address where we wanted
@@ -485,7 +485,7 @@ namespace Voron.Platform.Posix
 
             var allocationSize = newLengthAfterAdjustment - _totalAllocationSize;
 
-            PosixHelper.AllocateFileSpace(_options, _fd, (ulong)(_totalAllocationSize + allocationSize), FileName);
+            PosixHelper.AllocateFileSpace(_options, _fd, _totalAllocationSize + allocationSize, FileName);
 
             if (_isSyncDirAllowed && PosixHelper.SyncDirectory(FileName) == -1)
             {

--- a/src/Voron/Platform/Posix/PosixJournalWriter.cs
+++ b/src/Voron/Platform/Posix/PosixJournalWriter.cs
@@ -63,7 +63,7 @@ namespace Voron.Platform.Posix
                 length = journalSize;
                 try
                 {
-                    PosixHelper.AllocateFileSpace(options, _fd, (ulong) journalSize,filename);
+                    PosixHelper.AllocateFileSpace(options, _fd, journalSize,filename);
                 }
                 catch (Exception)
                 {

--- a/src/Voron/Platform/Posix/PosixMemoryMapPager.cs
+++ b/src/Voron/Platform/Posix/PosixMemoryMapPager.cs
@@ -49,7 +49,7 @@ namespace Voron.Platform.Posix
                 _totalAllocationSize != GetFileSize())
             {
                 _totalAllocationSize = NearestSizeToPageSize(_totalAllocationSize);
-                PosixHelper.AllocateFileSpace(_options, _fd, (ulong) _totalAllocationSize, file);
+                PosixHelper.AllocateFileSpace(_options, _fd, _totalAllocationSize, file);
             }
 
             if (_isSyncDirAllowed && PosixHelper.SyncDirectory(file) == -1)
@@ -101,7 +101,7 @@ namespace Voron.Platform.Posix
 
             var allocationSize = newLengthAfterAdjustment - _totalAllocationSize;
 
-            PosixHelper.AllocateFileSpace(_options, _fd, (ulong) (_totalAllocationSize + allocationSize), FileName);
+            PosixHelper.AllocateFileSpace(_options, _fd, _totalAllocationSize + allocationSize, FileName);
 
             if (_isSyncDirAllowed && PosixHelper.SyncDirectory(FileName) == -1)
             {
@@ -134,9 +134,9 @@ namespace Voron.Platform.Posix
         {
             var fileSize = GetFileSize();
             var mmflags = _copyOnWriteMode ? MmapFlags.MAP_PRIVATE : MmapFlags.MAP_SHARED;
-            var startingBaseAddressPtr = Syscall.mmap(IntPtr.Zero, (UIntPtr)fileSize,
+            var startingBaseAddressPtr = Syscall.mmap64(IntPtr.Zero, (UIntPtr)fileSize,
                                                       MmapProts.PROT_READ | MmapProts.PROT_WRITE,
-                                                      mmflags, _fd, IntPtr.Zero);
+                                                      mmflags, _fd, 0L);
 
             if (startingBaseAddressPtr.ToInt64() == -1) //system didn't succeed in mapping the address where we wanted
             {

--- a/src/Voron/Platform/Posix/PosixTempMemoryMapPager.cs
+++ b/src/Voron/Platform/Posix/PosixTempMemoryMapPager.cs
@@ -48,7 +48,7 @@ namespace Voron.Platform.Posix
             SysPageSize = Syscall.sysconf(SysconfName._SC_PAGESIZE);
 
             _totalAllocationSize = NearestSizeToPageSize(initialFileSize ?? _totalAllocationSize);
-            PosixHelper.AllocateFileSpace(_options, _fd, (ulong)_totalAllocationSize, FileName);
+            PosixHelper.AllocateFileSpace(_options, _fd, _totalAllocationSize, FileName);
 
             NumberOfAllocatedPages = _totalAllocationSize / Constants.Storage.PageSize;
             SetPagerState(CreatePagerState());
@@ -84,7 +84,7 @@ namespace Voron.Platform.Posix
 
             var allocationSize = newLengthAfterAdjustment - _totalAllocationSize;
 
-            PosixHelper.AllocateFileSpace(_options, _fd, (ulong)(_totalAllocationSize + allocationSize), FileName);
+            PosixHelper.AllocateFileSpace(_options, _fd, _totalAllocationSize + allocationSize, FileName);
 
             _totalAllocationSize += allocationSize;
 
@@ -109,9 +109,9 @@ namespace Voron.Platform.Posix
 
         private PagerState CreatePagerState()
         {
-            var startingBaseAddressPtr = Syscall.mmap(IntPtr.Zero, (UIntPtr)_totalAllocationSize,
+            var startingBaseAddressPtr = Syscall.mmap64(IntPtr.Zero, (UIntPtr)_totalAllocationSize,
                                                       MmapProts.PROT_READ | MmapProts.PROT_WRITE,
-                                                      MmapFlags.MAP_SHARED, _fd, IntPtr.Zero);
+                                                      MmapFlags.MAP_SHARED, _fd, 0L);
 
             if (startingBaseAddressPtr.ToInt64() == -1) //system didn't succeed in mapping the address where we wanted
             {

--- a/src/Voron/StorageEnvironmentOptions.cs
+++ b/src/Voron/StorageEnvironmentOptions.cs
@@ -143,6 +143,8 @@ namespace Voron
 
         protected StorageEnvironmentOptions(string tempPath)
         {
+            SafePosixOpenFlags = SafePosixOpenFlags | DefaultPosixFlags;
+
             TempPath = tempPath;
 
             ShouldUseKeyPrefix = name => false;
@@ -608,7 +610,7 @@ namespace Voron
 
             public override void SetPosixOptions()
             {
-                PosixOpenFlags = 0;
+                PosixOpenFlags = DefaultPosixFlags;
             }
 
             public PureMemoryStorageEnvironmentOptions(string name, string tempPath) : base(tempPath)
@@ -821,6 +823,7 @@ namespace Voron
 
 
         public const Win32NativeFileAttributes SafeWin32OpenFlags = Win32NativeFileAttributes.Write_Through | Win32NativeFileAttributes.NoBuffering;
+        public OpenFlags DefaultPosixFlags = PlatformDetails.Is32Bits ? PerPlatformValues.OpenFlags.O_LARGEFILE : 0;
         public OpenFlags SafePosixOpenFlags = OpenFlags.O_DSYNC | PerPlatformValues.OpenFlags.O_DIRECT;
         private readonly Logger _log;
 

--- a/test/FastTests/Voron/Storage/MemoryMapWithoutBackingPagerTest.cs
+++ b/test/FastTests/Voron/Storage/MemoryMapWithoutBackingPagerTest.cs
@@ -87,8 +87,8 @@ namespace FastTests.Voron.Storage
         {
             if (StorageEnvironmentOptions.RunningOnPosix)
             {
-                var p = Syscall.mmap(new IntPtr(Env.Options.DataPager.PagerState.MapBase + totalAllocationSize), (UIntPtr)16,
-                    MmapProts.PROT_READ | MmapProts.PROT_WRITE, MmapFlags.MAP_ANONYMOUS, -1, IntPtr.Zero);
+                var p = Syscall.mmap64(new IntPtr(Env.Options.DataPager.PagerState.MapBase + totalAllocationSize), (UIntPtr)16,
+                    MmapProts.PROT_READ | MmapProts.PROT_WRITE, MmapFlags.MAP_ANONYMOUS, -1, 0L);
                 if (p.ToInt64() == -1)
                 {
                     return null;


### PR DESCRIPTION
* Support O_LARGEFILE (and PerPlatformValues adjust to the arm32)
* Use lseek as a fallback to fallocate
* Fix lseek usage / err handling
* Handle unknown mount type