### PR TITLE
RavenDB-6430 RavenDB-6439 Fixed overloads of GetCollectionName to be …

### DIFF
--- a/src/Raven.Server/Documents/CollectionName.cs
+++ b/src/Raven.Server/Documents/CollectionName.cs
@@ -141,7 +141,7 @@ namespace Raven.Server.Documents
 
         public static string GetCollectionName(string key, BlittableJsonReaderObject document)
         {
-            if (key != null && key.StartsWith("Raven/", StringComparison.OrdinalIgnoreCase))
+            if (key != null && key.StartsWith("Raven/", StringComparison.OrdinalIgnoreCase) && key.StartsWith("Raven/HiLo/", StringComparison.OrdinalIgnoreCase) == false)
                 return SystemCollection;
 
             return GetCollectionName(document);
@@ -152,7 +152,7 @@ namespace Raven.Server.Documents
             dynamic dynamicDocument = document;
             string key = dynamicDocument.Id;
 
-            if (key != null && key.StartsWith("Raven/", StringComparison.OrdinalIgnoreCase))
+            if (key != null && key.StartsWith("Raven/", StringComparison.OrdinalIgnoreCase) && key.StartsWith("Raven/HiLo/", StringComparison.OrdinalIgnoreCase) == false)
                 return SystemCollection;
 
             return GetCollectionName(document.BlittableJson);


### PR DESCRIPTION
…consistent with 25800adfc06bba84 - HiLo documents aren't considered to be system documents.