### PR TITLE
RavenDB-6444 Do not filter out HiLo documents during replication

### DIFF
--- a/src/Raven.Server/Documents/CollectionName.cs
+++ b/src/Raven.Server/Documents/CollectionName.cs
@@ -101,7 +101,8 @@ namespace Raven.Server.Documents
 
         public static unsafe string GetCollectionName(Slice key, BlittableJsonReaderObject document)
         {
-            if (IsSystemDocument(key.Content.Ptr,key.Size))
+            bool _;
+            if (IsSystemDocument(key.Content.Ptr,key.Size, out _))
             {
                 return SystemCollection;
             }
@@ -109,8 +110,10 @@ namespace Raven.Server.Documents
             return GetCollectionName(document);
         }
 
-        public static unsafe bool IsSystemDocument(byte* buffer, int length)
+        public static unsafe bool IsSystemDocument(byte* buffer, int length, out bool isHiLo)
         {
+            isHiLo = false;
+
             if (length < 6)
                 return false;
 
@@ -133,12 +136,13 @@ namespace Raven.Server.Documents
                 (buffer[8] == (byte)'L' || buffer[8] == (byte)'l') &&
                 (buffer[9] == (byte)'O' || buffer[9] == (byte)'o') &&
                 buffer[10] == (byte)'/')
-                return false;
+            {
+                isHiLo = true;
+            }
 
             return true;
         }
-
-
+        
         public static string GetCollectionName(string key, BlittableJsonReaderObject document)
         {
             if (key != null && key.StartsWith("Raven/", StringComparison.OrdinalIgnoreCase))

--- a/src/Raven.Server/Documents/Replication/ReplicationDocumentSender.cs
+++ b/src/Raven.Server/Documents/Replication/ReplicationDocumentSender.cs
@@ -206,7 +206,8 @@ namespace Raven.Server.Documents.Replication
                 }
                 return;
             }
-            if (CollectionName.IsSystemDocument(item.Key.Buffer, item.Key.Size))
+            bool isHiLo;
+            if (CollectionName.IsSystemDocument(item.Key.Buffer, item.Key.Size, out isHiLo) && isHiLo == false)
             {
                 if (_log.IsInfoEnabled)
                 {

--- a/src/Raven.Server/Web/Studio/StudioCollectionRunner.cs
+++ b/src/Raven.Server/Web/Studio/StudioCollectionRunner.cs
@@ -23,12 +23,13 @@ namespace Raven.Server.Web.Studio
         {
             if (collectionName == Constants.Documents.Indexing.AllDocumentsCollection)
             {
+                bool _;
                 if (_excludeIds.Count == 0)
                 {
                     // all documents w/o exclusions -> filter system documents
                     return ExecuteOperation(collectionName, options, _context, onProgress, key =>
                     {
-                        if (!CollectionName.IsSystemDocument(key.Buffer, key.Length))
+                        if (CollectionName.IsSystemDocument(key.Buffer, key.Length, out _) == false)
                         {
                             _database.DocumentsStorage.Delete(_context, key, null);
                         }
@@ -37,7 +38,7 @@ namespace Raven.Server.Web.Studio
                 // all documents w/ exluclusions -> delete only not excluded and not system
                 return ExecuteOperation(collectionName, options, _context, onProgress, key =>
                 {
-                    if (_excludeIds.Contains(key) == false && !CollectionName.IsSystemDocument(key.Buffer, key.Length))
+                    if (_excludeIds.Contains(key) == false && CollectionName.IsSystemDocument(key.Buffer, key.Length, out _) == false)
                     {
                         _database.DocumentsStorage.Delete(_context, key, null);
                     }


### PR DESCRIPTION
Instead of introducing `@hilo` collection I'm just properly excluding HiLo docs from being filtered out during the replication.