### PR TITLE
RavenDB-6475

### DIFF
--- a/Raven.Tests.Raft/RaftWithAuth.cs
+++ b/Raven.Tests.Raft/RaftWithAuth.cs
@@ -40,11 +40,6 @@ namespace Raven.Tests.Raft
             NodeConnectionInfo secondConnectionInfo;
             CreateServerWithOAuth(8078, "Marcin/cba", out secondConnectionInfo);
 
-            var mre = new AsyncManualResetEvent();
-            leader.Options.ClusterManager.Value.Engine.TopologyChanged += command =>
-            {
-                mre.Set();
-            };
             Assert.True(leader.Options.ClusterManager.Value.Engine.AddToClusterAsync(secondConnectionInfo).Wait(3000));
             Assert.True(leader.Options.ClusterManager.Value.Engine.WaitForLeader());
             //If we don't wait here we can cause two topology changes to happen at the same time and fail.
@@ -52,7 +47,6 @@ namespace Raven.Tests.Raft
             WaitForClusterToBecomeNonStale(2);
             NodeConnectionInfo thirdConnectionInfo;
             CreateServerWithOAuth(8077, "User3/pass", out thirdConnectionInfo);
-            await mre.WaitAsync();
             Assert.True(leader.Options.ClusterManager.Value.Engine.AddToClusterAsync(thirdConnectionInfo).Wait(3000));
 
             Assert.True(servers[0].Options.ClusterManager.Value.IsLeader());
@@ -128,9 +122,9 @@ namespace Raven.Tests.Raft
             Assert.True(leader.Options.ClusterManager.Value.Engine.AddToClusterAsync(secondConnectionInfo).Wait(3000));
             //If we don't wait here we can cause two topology changes to happen at the same time and fail.
             WaitForClusterToBecomeNonStale(2);
+
             NodeConnectionInfo thirdConnectionInfo;
             CreateServerWithOAuth(8077, "User3/pass", out thirdConnectionInfo);
-            Assert.True(leader.Options.ClusterManager.Value.Engine.AddToClusterAsync(thirdConnectionInfo).Wait(3000));
             Assert.True(leader.Options.ClusterManager.Value.Engine.AddToClusterAsync(thirdConnectionInfo).Wait(3000));
 
             WaitForClusterToBecomeNonStale(3);

--- a/Raven.Tests.Raft/Snapshotting.cs
+++ b/Raven.Tests.Raft/Snapshotting.cs
@@ -34,8 +34,6 @@ namespace Raven.Tests.Raft
                 client.SendClusterConfigurationAsync(new ClusterConfiguration {EnableReplication = false}).Wait(3000);
             }
 
-            WaitForClusterToBecomeNonStale(3);
-
             var leader = servers.FirstOrDefault(server => server.Options.ClusterManager.Value.IsLeader());
             Assert.NotNull(leader);
 


### PR DESCRIPTION
*fixing failing test CanCreateClusterWithApiKeyAndSendCommandToNonLeader
* removing workaround from CanCreateClusterWithApiKeyAndSendCommandToLeader
* fixing bad implementation of WaitForClusterToBecomeNonStale (the current topology was set before the task completion source result is set)
* removing un-needed use of WaitForClusterToBecomeNonStale from CanInstallSnapshot, if this test will fail because i removed the delay than there is something else wrong with it (seems to pass without it for me).