### PR TITLE
RavenDB-6476

### DIFF
--- a/Raven.Database/JsConsole/AdminJsConsole.cs
+++ b/Raven.Database/JsConsole/AdminJsConsole.cs
@@ -4,14 +4,21 @@
 //  </copyright>
 // -----------------------------------------------------------------------
 using System;
+using System.Linq;
 using Jint;
 using Jint.Native;
 using Jint.Parser;
 using Jint.Runtime;
+using Lucene.Net.Analysis;
+using Lucene.Net.Index;
+using Lucene.Net.Search;
+using Rachis;
+using Raven.Abstractions;
 using Raven.Abstractions.Logging;
 using Raven.Database.Extensions;
 using Raven.Database.Json;
 using Raven.Json.Linq;
+using Voron;
 
 namespace Raven.Database.JsConsole
 {
@@ -66,7 +73,12 @@ namespace Raven.Database.JsConsole
 #else
                 cfg.AllowDebuggerStatement(false);
 #endif                
-                cfg.AllowClr(AppDomain.CurrentDomain.GetAssemblies());
+                cfg.AllowClr(typeof(DocumentDatabase).Assembly/*Raven.Database*/, typeof(RavenJObject).Assembly/*Raven.Abstractions*/
+                    ,typeof(Slice).Assembly/*Voron*/,typeof(Sparrow.Memory).Assembly/*Sparrow*/,typeof(RaftEngine).Assembly/*Rachis*/
+                    ,typeof(Analyzer).Assembly/*Lucene*/, typeof(Term).Assembly/*Lucene*/, typeof(BooleanQuery).Assembly/*Lucene*/);
+                /*bundles are dynamically loaded so we can't reference them unless they are loaded by MEF*/
+                var bundles = AppDomain.CurrentDomain.GetAssemblies().Where(a=>a.FullName.StartsWith("Raven.Bundles."));
+                cfg.AllowClr(bundles.ToArray());
                 cfg.LimitRecursion(1024);
                 cfg.MaxStatements(int.MaxValue);
             });

--- a/Raven.Tests.Issues/RavenDB_3390.cs
+++ b/Raven.Tests.Issues/RavenDB_3390.cs
@@ -143,7 +143,7 @@ namespace Raven.Tests.Issues
                     Script = @"
                                 var doc = Raven.Json.Linq.RavenJObject.Parse('{ ""Name"" : ""Raven"" }');
                                 var metadata = Raven.Json.Linq.RavenJObject.Parse('{ ""Raven-Entity-Name"" : ""Docs"" }');
-                                database.Documents.Put('doc/1', null, doc, metadata, null, null);
+                                database.Documents.Put('doc/1', null, doc, metadata, null, null,Raven.Database.Storage.InvokeSource.Default);
                              "
                 });
 


### PR DESCRIPTION
* Fixing an issue where allowing CLR types for all dll in the AppDoamin may cause problem when executing scripts in the AdminJsConsole
* Fixing a test that is failing because Jint can't handle invocation of methods without explicitly specifying the default parameters (this is a regression introduced by https://github.com/ravendb/ravendb/commit/633720547790c909d0cdf34d508e694e31afa426)