### PR TITLE
RavenDB-6482 GetReplicationConfig should load using ConfigurationRetr…

### DIFF
--- a/Raven.Database/Config/Retriever/ConfigurationRetriever.cs
+++ b/Raven.Database/Config/Retriever/ConfigurationRetriever.cs
@@ -25,22 +25,22 @@ namespace Raven.Database.Config.Retriever
         private readonly DocumentDatabase database;
 
         private readonly Dictionary<string, DocumentType> documentTypes = new Dictionary<string, DocumentType>(StringComparer.OrdinalIgnoreCase)
-                                                                          {
-                                                                              {Constants.RavenReplicationDestinations, DocumentType.ReplicationDestinations},
-                                                                              {Constants.Versioning.RavenVersioningDefaultConfiguration, DocumentType.VersioningConfiguration},
-                                                                              {PeriodicExportSetup.RavenDocumentKey, DocumentType.PeriodicExportConfiguration},
-                                                                              {Constants.DocsHardLimit, DocumentType.QuotasConfiguration},
-                                                                              {Constants.DocsSoftLimit, DocumentType.QuotasConfiguration},
-                                                                              {Constants.SizeHardLimitInKB, DocumentType.QuotasConfiguration},
-                                                                              {Constants.SizeSoftLimitInKB, DocumentType.QuotasConfiguration},
-                                                                              {Constants.PeriodicExport.AwsAccessKey, DocumentType.PeriodicExportSettingsConfiguration},
-                                                                              {Constants.PeriodicExport.AwsSecretKey, DocumentType.PeriodicExportSettingsConfiguration},
-                                                                              {Constants.PeriodicExport.AzureStorageAccount, DocumentType.PeriodicExportSettingsConfiguration},
-                                                                              {Constants.PeriodicExport.AzureStorageKey, DocumentType.PeriodicExportSettingsConfiguration},
-                                                                              {Constants.SqlReplication.SqlReplicationConnectionsDocumentName, DocumentType.SqlReplicationConnections},
-                                                                              {Constants.RavenJavascriptFunctions, DocumentType.JavascriptFunctions},
-                                                                              {Constants.RavenReplicationConfig, DocumentType.ReplicationConflictResolutionConfiguration}
-                                                                          };
+        {
+            {Constants.RavenReplicationDestinations, DocumentType.ReplicationDestinations},
+            {Constants.Versioning.RavenVersioningDefaultConfiguration, DocumentType.VersioningConfiguration},
+            {PeriodicExportSetup.RavenDocumentKey, DocumentType.PeriodicExportConfiguration},
+            {Constants.DocsHardLimit, DocumentType.QuotasConfiguration},
+            {Constants.DocsSoftLimit, DocumentType.QuotasConfiguration},
+            {Constants.SizeHardLimitInKB, DocumentType.QuotasConfiguration},
+            {Constants.SizeSoftLimitInKB, DocumentType.QuotasConfiguration},
+            {Constants.PeriodicExport.AwsAccessKey, DocumentType.PeriodicExportSettingsConfiguration},
+            {Constants.PeriodicExport.AwsSecretKey, DocumentType.PeriodicExportSettingsConfiguration},
+            {Constants.PeriodicExport.AzureStorageAccount, DocumentType.PeriodicExportSettingsConfiguration},
+            {Constants.PeriodicExport.AzureStorageKey, DocumentType.PeriodicExportSettingsConfiguration},
+            {Constants.SqlReplication.SqlReplicationConnectionsDocumentName, DocumentType.SqlReplicationConnections},
+            {Constants.RavenJavascriptFunctions, DocumentType.JavascriptFunctions},
+            {Constants.RavenReplicationConfig, DocumentType.ReplicationConflictResolutionConfiguration}
+        };
 
         private readonly ReplicationConflictResolutionConfigurationRetriever replicationConflictResolutionConfigurationRetriever;
 

--- a/Raven.Tests.Raft/RavenDB_4845.cs
+++ b/Raven.Tests.Raft/RavenDB_4845.cs
@@ -54,7 +54,7 @@ namespace Raven.Tests.Raft
                     {
                         using (var session = clusterStores[i].OpenSession())
                         {
-                            session.Store(new ReplicationConfig()
+                            session.Store(new ReplicationConfig
                             {
                                 DocumentConflictResolution = StraightforwardConflictResolution.ResolveToLatest
                             }, Constants.RavenReplicationConfig);


### PR DESCRIPTION
…iever. This will fix Raven/Global/Replication/Config is not honored and this is why users have conflicts