### PR TITLE
RavenDB-6496 - fix Importing failure - "An item with the same key has already been added: 'Raven-Ignore-Versioning'"

### DIFF
--- a/Raven.Abstractions/Smuggler/SmugglerHelper.cs
+++ b/Raven.Abstractions/Smuggler/SmugglerHelper.cs
@@ -67,7 +67,9 @@ namespace Raven.Abstractions.Smuggler
         public static RavenJToken DisableVersioning(RavenJObject metadata)
         {
             if (metadata != null)
-                metadata.Add(Constants.RavenIgnoreVersioning, true);
+            {
+                metadata[Constants.RavenIgnoreVersioning] = true;
+            }
 
             return metadata;
         }

--- a/Raven.Database/FileSystem/Smuggler/SmugglerEmbeddedFilesOperations.cs
+++ b/Raven.Database/FileSystem/Smuggler/SmugglerEmbeddedFilesOperations.cs
@@ -169,7 +169,7 @@ namespace Raven.Database.FileSystem.Smuggler
         {
             if (metadata != null)
             {
-                metadata.Add(Constants.RavenIgnoreVersioning, true);
+                metadata[Constants.RavenIgnoreVersioning] = true;
             }
 
             return metadata;

--- a/Raven.Database/Smuggler/SmugglerDatabaseBetweenOperation.cs
+++ b/Raven.Database/Smuggler/SmugglerDatabaseBetweenOperation.cs
@@ -400,7 +400,10 @@ namespace Raven.Smuggler
 
         public RavenJToken DisableVersioning(RavenJObject metadata)
         {
-            metadata.Add(Constants.RavenIgnoreVersioning, true);
+            if (metadata != null)
+            {
+                metadata[Constants.RavenIgnoreVersioning] = true;
+            }
 
             return metadata;
         }

--- a/Raven.Database/Smuggler/SmugglerEmbeddedDatabaseOperations.cs
+++ b/Raven.Database/Smuggler/SmugglerEmbeddedDatabaseOperations.cs
@@ -353,7 +353,7 @@ namespace Raven.Database.Smuggler
         {
             if (metadata != null)
             {
-                metadata.Add(Constants.RavenIgnoreVersioning, true);
+                metadata[Constants.RavenIgnoreVersioning] = true;
             }
 
             return metadata;

--- a/Raven.Database/Smuggler/SmugglerRemoteFilesOperations.cs
+++ b/Raven.Database/Smuggler/SmugglerRemoteFilesOperations.cs
@@ -168,7 +168,7 @@ namespace Raven.Smuggler
         {
             if (metadata != null)
             {
-                metadata.Add(Constants.RavenIgnoreVersioning, true);
+                metadata[Constants.RavenIgnoreVersioning] = true;
             }
 
             return metadata;


### PR DESCRIPTION
http://issues.hibernatingrhinos.com/issue/RavenDB-6496