### PR TITLE
RavenDB-6484

### DIFF
--- a/src/Raven.Client/Documents/Session/Operations/LoadOperation.cs
+++ b/src/Raven.Client/Documents/Session/Operations/LoadOperation.cs
@@ -124,15 +124,18 @@ namespace Raven.Client.Documents.Session.Operations
                 }
             }
 
-            foreach (BlittableJsonReaderObject document in result.Results)
+            if (result.Results != null)
             {
-                if (document == null)
-                    continue;
+                foreach (BlittableJsonReaderObject document in result.Results)
+                {
+                    if (document == null)
+                        continue;
 
-                var newDocumentInfo = DocumentInfo.GetNewDocumentInfo(document);
-                _session.DocumentsById.Add(newDocumentInfo);
+                    var newDocumentInfo = DocumentInfo.GetNewDocumentInfo(document);
+                    _session.DocumentsById.Add(newDocumentInfo);
+                }
             }
-
+            
             if (_includes != null && _includes.Length > 0)
             {
                 _session.RegisterMissingIncludes(result.Results, _includes);

--- a/src/Raven.Client/Http/RavenCommand.cs
+++ b/src/Raven.Client/Http/RavenCommand.cs
@@ -23,6 +23,8 @@ namespace Raven.Client.Http
         public abstract bool IsReadRequest { get; }
         public HttpStatusCode StatusCode;
 
+        public bool AvoidFailover;
+
         public RavenCommandResponseType ResponseType { get; protected set; } = RavenCommandResponseType.Object;
 
         public TimeSpan? Timeout { get; protected set; }

--- a/src/Raven.Client/Http/TopologyLocalCache.cs
+++ b/src/Raven.Client/Http/TopologyLocalCache.cs
@@ -92,6 +92,13 @@ namespace Raven.Client.Http
 
                     writer.WritePropertyName(context.GetLazyString(nameof(Topology.WriteBehavior)));
                     writer.WriteString(context.GetLazyString(topology.WriteBehavior.ToString()));
+
+                    writer.WritePropertyName(context.GetLazyString(nameof(Topology.SLA)));
+                    writer.WriteStartObject();
+                    writer.WritePropertyName(context.GetLazyString(nameof(topology.SLA.RequestTimeThresholdInMilliseconds)));
+                    writer.WriteInteger(topology.SLA.RequestTimeThresholdInMilliseconds);
+                    writer.WriteEndObject();
+
                     writer.WriteEndObject();
                 }
             }

--- a/src/Raven.Client/Json/Converters/JsonDeserializationClient.cs
+++ b/src/Raven.Client/Json/Converters/JsonDeserializationClient.cs
@@ -49,6 +49,8 @@ namespace Raven.Client.Json.Converters
 
         public static readonly Func<BlittableJsonReaderObject, CreateDatabaseResult> CreateDatabaseResult = GenerateJsonDeserializationRoutine<CreateDatabaseResult>();
 
+        public static readonly Func<BlittableJsonReaderObject, DisableResoureceToggleResult> DisableResoureceToggleResult = GenerateJsonDeserializationRoutine<DisableResoureceToggleResult>();
+
         public static readonly Func<BlittableJsonReaderObject, BlittableArrayResult> BlittableArrayResult = GenerateJsonDeserializationRoutine<BlittableArrayResult>();
 
         public static readonly Func<BlittableJsonReaderObject, PutTransformerResult> PutTransformerResult = GenerateJsonDeserializationRoutine<PutTransformerResult>();

--- a/src/Raven.Client/Server/Commands/GetTopologyCommand.cs
+++ b/src/Raven.Client/Server/Commands/GetTopologyCommand.cs
@@ -7,6 +7,11 @@ namespace Raven.Client.Server.Commands
 {
     public class GetTopologyCommand : RavenCommand<Topology>
     {
+        public GetTopologyCommand()
+        {
+            AvoidFailover = true;
+        }
+
         public override HttpRequestMessage CreateRequest(ServerNode node, out string url)
         {
             url = $"{node.Url}/databases/{node.Database}/topology?url={node.Url}";

--- a/src/Raven.Client/Server/Operations/DisableResourceToggleOperation.cs
+++ b/src/Raven.Client/Server/Operations/DisableResourceToggleOperation.cs
@@ -1,0 +1,78 @@
+﻿using System;
+using System.Net.Http;
+using Raven.Client.Documents.Conventions;
+using Raven.Client.Documents.Operations;
+using Raven.Client.Http;
+using Raven.Client.Json.Converters;
+using Sparrow.Json;
+
+namespace Raven.Client.Server.Operations
+{
+    public class DisableResourceToggleOperation : IServerOperation<DisableResoureceToggleResult>
+    {
+        private readonly string _databaseName;
+        private readonly bool _ifDisableRequest;
+
+        public DisableResourceToggleOperation(string databaseName, bool ifDisableRequest)
+        {
+            if(databaseName == null)
+                throw new ArgumentNullException(nameof(databaseName));
+
+            _databaseName = databaseName;
+            _ifDisableRequest = ifDisableRequest;
+        }
+
+        public RavenCommand<DisableResoureceToggleResult> GetCommand(DocumentConventions conventions,
+            JsonOperationContext context)
+        {
+            return new DisableResourceToggleCommand(_databaseName, _ifDisableRequest);
+        }
+
+        public class DisableResourceToggleCommand : RavenCommand<DisableResoureceToggleResult>
+        {
+
+            private readonly string _databaseName;
+            private readonly bool _ifDisableRequest;
+
+            public DisableResourceToggleCommand(string databaseName, bool ifDisableRequest)
+            {
+                _databaseName = databaseName;
+                _ifDisableRequest = ifDisableRequest;
+
+                ResponseType = RavenCommandResponseType.Array;
+            }
+
+            public override HttpRequestMessage CreateRequest(ServerNode node, out string url)
+            {
+                var toggle = _ifDisableRequest ? "disable" : "enable";
+                url = $"{node.Url}/admin/databases/{toggle}?name={_databaseName}";
+
+                var request = new HttpRequestMessage
+                {
+                    Method = HttpMethod.Post,
+                };
+
+                return request;
+            }
+        
+            public override void SetResponse(BlittableJsonReaderObject response, bool fromCache)
+            {
+                if (response == null)
+                    ThrowInvalidResponse();
+               
+            }
+
+            public override void SetResponse(BlittableJsonReaderArray response, bool fromCache)
+            {
+                if (response == null)
+                    ThrowInvalidResponse();
+
+                var resultObject = response[0] as BlittableJsonReaderObject;
+                Result = JsonDeserializationClient.DisableResoureceToggleResult(resultObject);
+
+            }
+
+            public override bool IsReadRequest => false;
+        }
+    }
+}

--- a/src/Raven.Client/Server/Operations/DisableResoureceToggleResult.cs
+++ b/src/Raven.Client/Server/Operations/DisableResoureceToggleResult.cs
@@ -1,0 +1,26 @@
+﻿using System;
+using System.Collections.Generic;
+using System.Linq;
+using System.Threading.Tasks;
+
+namespace Raven.Client.Server.Operations
+{
+    /// <summary>
+    /// The result of a disable or enable database
+    /// </summary>
+    public class DisableResoureceToggleResult
+    {
+        /// <summary>
+        ///  If database disabled.
+        /// </summary>
+        public bool Disabled;
+        /// <summary>
+        ///  Name of the database.
+        /// </summary>
+        public string Name;
+        /// <summary>
+        ///  If request succeed.
+        /// </summary>
+        public bool Success;
+    }
+}

--- a/src/Raven.Server/Documents/AbstractLandlord.cs
+++ b/src/Raven.Server/Documents/AbstractLandlord.cs
@@ -40,7 +40,7 @@ namespace Raven.Server.Documents
 
         public TimeSpan DatabaseLoadTimeout => ServerStore.Configuration.Server.MaxTimeForTaskToWaitForDatabaseToLoad.AsTimeSpan;
 
-        public abstract Task<TResource> TryGetOrCreateResourceStore(StringSegment resourceName);
+        public abstract Task<TResource> TryGetOrCreateResourceStore(StringSegment resourceName, bool ignoreDisabledDatabase = false);
 
         public void Dispose()
         {

--- a/src/Raven.Server/Documents/DatabasesLandlord.cs
+++ b/src/Raven.Server/Documents/DatabasesLandlord.cs
@@ -23,7 +23,7 @@ namespace Raven.Server.Documents
         public event Action<string> OnDatabaseLoaded = delegate { };
 
 
-        public override Task<DocumentDatabase> TryGetOrCreateResourceStore(StringSegment databaseName)
+        public override Task<DocumentDatabase> TryGetOrCreateResourceStore(StringSegment databaseName, bool ignoreDisabledDatabase = false)
         {
             if (HasLocks != 0)
             {
@@ -45,12 +45,12 @@ namespace Raven.Server.Documents
                 }
             }
 
-            return CreateDatabase(databaseName);
+            return CreateDatabase(databaseName, ignoreDisabledDatabase);
         }
 
-        private Task<DocumentDatabase> CreateDatabase(StringSegment databaseName)
+        private Task<DocumentDatabase> CreateDatabase(StringSegment databaseName, bool ignoreDisabledDatabase = false)
         {
-            var config = CreateDatabaseConfiguration(databaseName);
+            var config = CreateDatabaseConfiguration(databaseName, ignoreDisabledDatabase);
             if (config == null)
                 return null;
 

--- a/test/FastTests/Server/Replication/ReplicationWithFailover.cs
+++ b/test/FastTests/Server/Replication/ReplicationWithFailover.cs
@@ -1,0 +1,65 @@
+﻿using System.Diagnostics;
+using System.Threading.Tasks;
+using Raven.Client.Server.Operations;
+using Xunit;
+
+namespace FastTests.Server.Replication
+{
+    public class ReplicationWithFailover : ReplicationTestsBase
+    {
+        public class User
+        {
+            public string Name;
+        }
+
+        [Fact]
+        public async Task LoadDocumentsWithFailOver()
+        {
+            var master = GetDocumentStore(ignoreDisabledDatabase: true);
+            var slave = GetDocumentStore(ignoreDisabledDatabase: true);
+
+            try
+            {
+
+                SetupReplication(master, slave);
+                EnsureReplicating(master, slave);
+
+                var sp = Stopwatch.StartNew();
+                var requestExecutor = master.GetRequestExecuter();
+
+                while (await requestExecutor.UpdateTopology() == false)
+                {
+                    Assert.False(sp.Elapsed.Seconds > 30);
+                }
+
+                using (var session = master.OpenSession())
+                {
+                    session.Advanced.WaitForReplicationAfterSaveChanges();
+                    session.Store(new User { Name = "Idan" }, "users/1");
+                    session.Store(new User { Name = "Shalom" }, "users/2");
+                    session.SaveChanges();
+                }
+
+                var result = master.Admin.Server.Send(new DisableResourceToggleOperation("LoadDocumentsWithFailOver_1", true));
+                Assert.True(result.Disabled);
+                Assert.Equal("LoadDocumentsWithFailOver_1", result.Name);
+
+                using (var session = master.OpenSession())
+                {
+                    var user1 = session.Load<User>("users/1");
+                    Assert.NotNull(user1);
+                    Assert.Equal("Idan", user1.Name);
+                    var user2 = session.Load<User>("users/2");
+                    Assert.NotNull(user2);
+                    Assert.Equal("Shalom", user2.Name);
+                }
+
+            }
+            finally
+            {
+                master.Dispose();
+                slave.Dispose();
+            }
+        }
+    }
+}

--- a/test/Tests.Infrastructure/RavenTestBase.cs
+++ b/test/Tests.Infrastructure/RavenTestBase.cs
@@ -45,7 +45,8 @@ namespace FastTests
             string path = null,
             Action<DatabaseDocument> modifyDatabaseDocument = null,
             Func<string, string> modifyName = null,
-            string apiKey = null)
+            string apiKey = null,
+            bool ignoreDisabledDatabase = false)
         {
             lock (_getDocumentStoreSync)
             {
@@ -107,7 +108,7 @@ namespace FastTests
 
                     if (Server.Disposed == false)
                     {
-                        var databaseTask = Server.ServerStore.DatabasesLandlord.TryGetOrCreateResourceStore(name);
+                        var databaseTask = Server.ServerStore.DatabasesLandlord.TryGetOrCreateResourceStore(name, ignoreDisabledDatabase);
                         if (databaseTask != null && databaseTask.IsCompleted == false)
                             databaseTask.Wait();
                                 // if we are disposing store before database had chance to load then we need to wait


### PR DESCRIPTION
- Fix LoadOperation fail when getting null Result
- Getting RequestExecutor will check the cache for topology
- Write SLA parameter to topology local cache
- Add AvoidFailover parameter to RavenCommand
- Add failover test to the replication