### PR TITLE
RavenDB-6487: Smuggler timeout when skipping large number of attachme…

### DIFF
--- a/Raven.Abstractions/Smuggler/ISmugglerDatabaseOperations.cs
+++ b/Raven.Abstractions/Smuggler/ISmugglerDatabaseOperations.cs
@@ -81,5 +81,7 @@ namespace Raven.Abstractions.Smuggler
         Task<List<KeyValuePair<string, long>>> GetIdentities();
 
         Task SeedIdentities(List<KeyValuePair<string, long>> identities);
+
+        Task FinishBulkInsertOperation();
     }
 }

--- a/Raven.Abstractions/Smuggler/SmugglerDatabaseApiBase.cs
+++ b/Raven.Abstractions/Smuggler/SmugglerDatabaseApiBase.cs
@@ -1642,7 +1642,7 @@ namespace Raven.Abstractions.Smuggler
             await Operations.DeleteDocument(Constants.BulkImportHeartbeatDocKey).ConfigureAwait(false);
 
             await Operations.PutDocument(null, -1).ConfigureAwait(false); // force flush    
-
+            await Operations.FinishBulkInsertOperation().ConfigureAwait(false);
             return count;
         }
 

--- a/Raven.Database/Smuggler/SmugglerEmbeddedDatabaseOperations.cs
+++ b/Raven.Database/Smuggler/SmugglerEmbeddedDatabaseOperations.cs
@@ -338,6 +338,11 @@ namespace Raven.Database.Smuggler
             return new CompletedTask();
         }
 
+        public async Task FinishBulkInsertOperation()
+        {
+            //noop
+        }
+
         public Task<IAsyncEnumerator<RavenJObject>> ExportItems(ItemType types, OperationState state)
         {
             var exporter = new SmugglerExporter(database, ExportOptions.Create(state, types, Options.ExportDeletions, Options.Limit));

--- a/Raven.Database/Smuggler/SmugglerRemoteDatabaseOperations.cs
+++ b/Raven.Database/Smuggler/SmugglerRemoteDatabaseOperations.cs
@@ -376,6 +376,11 @@ namespace Raven.Smuggler
             return client.SeedIdentitiesAsync(itemsToInsert);
         }
 
+        public async Task FinishBulkInsertOperation()
+        {
+            await Operation.DisposeAsync().ConfigureAwait(false);
+        }
+
         public Task<IAsyncEnumerator<RavenJObject>> ExportItems(ItemType types, OperationState state)
         {
             var options = ExportOptions.Create(state, types, Options.ExportDeletions, Options.Limit);


### PR DESCRIPTION
…nts. Now we close the bulkinsert operation when we know we've finished proccessing the documents.