### PR TITLE
RavenDB-6440

### DIFF
--- a/src/Raven.Server/Documents/DocumentFlags.cs
+++ b/src/Raven.Server/Documents/DocumentFlags.cs
@@ -6,11 +6,15 @@ namespace Raven.Server.Documents
     public enum DocumentFlags
     {
         None = 0,
-        Versioned = 0x1,
-        Artificial = 0x2,
-        FromIndex = 0x4,
-        FromVersionStorage = 0x8,
-        FromReplication = 0x10,
-        HasAttachments = 0x20,
+
+        Artificial = 0x1,
+        Versioned = 0x2,
+        SkipVersioning = 0x4,
+        ForceVersioning = 0x8,
+
+        FromIndex = 0x10,
+        FromVersionStorage = 0x20,
+        FromReplication = 0x40,
+        HasAttachments = 0x80,
     }
 }


### PR DESCRIPTION
- When getting an incoming version document in replication we should store it even if versioning bundle is not active for this node. This should not be possible in the future, so I also added a log operation if this is the case.
- Store SkipVersioning and ForceVersioning in DocumentFlags. We need this to also decide whether to version attachments for this document.