### PR TITLE
RavenDB-6484 Refactor document storage:

### DIFF
--- a/RavenDB-Dnx.sln.DotSettings
+++ b/RavenDB-Dnx.sln.DotSettings
@@ -1,0 +1,7 @@
+﻿<wpf:ResourceDictionary xml:space="preserve" xmlns:x="http://schemas.microsoft.com/winfx/2006/xaml" xmlns:s="clr-namespace:System;assembly=mscorlib" xmlns:ss="urn:shemas-jetbrains-com:settings-storage-xaml" xmlns:wpf="http://schemas.microsoft.com/winfx/2006/xaml/presentation">
+	<s:Boolean x:Key="/Default/CodeStyle/CodeFormatting/CSharpFormat/SPACE_AFTER_TYPECAST_PARENTHESES/@EntryValue">False</s:Boolean>
+	<s:Boolean x:Key="/Default/Environment/InjectedLayers/FileInjectedLayer/=77534FD473DA1649945C7165031E1A9B/@KeyIndexDefined">True</s:Boolean>
+	<s:String x:Key="/Default/Environment/InjectedLayers/FileInjectedLayer/=77534FD473DA1649945C7165031E1A9B/AbsolutePath/@EntryValue">C:\work\ravendb\RavenDB-Dnx.sln.DotSettings</s:String>
+	<s:String x:Key="/Default/Environment/InjectedLayers/FileInjectedLayer/=77534FD473DA1649945C7165031E1A9B/RelativePath/@EntryValue"></s:String>
+	<s:Boolean x:Key="/Default/Environment/InjectedLayers/InjectedLayerCustomization/=File77534FD473DA1649945C7165031E1A9B/@KeyIndexDefined">True</s:Boolean>
+	<s:Double x:Key="/Default/Environment/InjectedLayers/InjectedLayerCustomization/=File77534FD473DA1649945C7165031E1A9B/RelativePriority/@EntryValue">1</s:Double></wpf:ResourceDictionary>

--- a/src/Raven.Server/Documents/DocumentsStorage.cs
+++ b/src/Raven.Server/Documents/DocumentsStorage.cs
@@ -1605,7 +1605,7 @@ namespace Raven.Server.Documents
             foreach (var tvr in conflictsTable.SeekForwardFrom(ConflictsSchema.Indexes[KeyAndChangeVectorSlice], loweredKey, 0, true))
             {
                 var conflict = TableValueToConflictDocument(context, ref tvr.Result.Reader);
-                if (loweredKey.Content.Match(conflict.LoweredKey))
+                if (loweredKey.Content.Match(conflict.LoweredKey) == false)
                     break;
 
                 items.Add(conflict);

--- a/src/Sparrow/ByteString.cs
+++ b/src/Sparrow/ByteString.cs
@@ -341,7 +341,15 @@ namespace Sparrow
         [MethodImpl(MethodImplOptions.AggressiveInlining)]
         public bool Match(ByteString other)
         {
-            return GetContentHash() == other.GetContentHash();
+            return Length == other.Length &&
+                   Memory.Compare(Ptr, other.Ptr, Length) == 0;
+        }
+
+        [MethodImpl(MethodImplOptions.AggressiveInlining)]
+        public bool Match(LazyStringValue other)
+        {
+            return Length == other.Length &&
+                   Memory.Compare(Ptr, other.Buffer, Length) == 0;
         }
     }
 


### PR DESCRIPTION
- Use slice instead of strings when possible
- Use DocumentTable enum for better readable code
- Extract TableValueToString for building a string from a reader
- Use Match method on the ByteString for doing memory compare