### PR TITLE
RavenDB-6487: Smuggler timeout when skipping large number of attachme…

### DIFF
--- a/Raven.Abstractions/Smuggler/ISmugglerDatabaseOperations.cs
+++ b/Raven.Abstractions/Smuggler/ISmugglerDatabaseOperations.cs
@@ -81,5 +81,7 @@ namespace Raven.Abstractions.Smuggler
         Task<List<KeyValuePair<string, long>>> GetIdentities();
 
         Task SeedIdentities(List<KeyValuePair<string, long>> identities);
+
+        Task WaitForLastBulkInsertTaskToFinish();
     }
 }

--- a/Raven.Abstractions/Smuggler/SmugglerDatabaseApiBase.cs
+++ b/Raven.Abstractions/Smuggler/SmugglerDatabaseApiBase.cs
@@ -1642,7 +1642,7 @@ namespace Raven.Abstractions.Smuggler
             await Operations.DeleteDocument(Constants.BulkImportHeartbeatDocKey).ConfigureAwait(false);
 
             await Operations.PutDocument(null, -1).ConfigureAwait(false); // force flush    
-
+            await Operations.WaitForLastBulkInsertTaskToFinish().ConfigureAwait(false);
             return count;
         }
 

--- a/Raven.Client.Lightweight/Document/BulkInsertOperation.cs
+++ b/Raven.Client.Lightweight/Document/BulkInsertOperation.cs
@@ -73,6 +73,11 @@ namespace Raven.Client.Document
             return Operation.DisposeAsync();
         }
 
+        public async Task WaitForLastTaskToFinish()
+        {
+            await Operation.WaitForLastTaskToFinish().ConfigureAwait(false);
+        }
+
         public void Dispose()
         {
             Operation.Dispose();

--- a/Raven.Client.Lightweight/Document/ChunkedRemoteBulkInsertOperation.cs
+++ b/Raven.Client.Lightweight/Document/ChunkedRemoteBulkInsertOperation.cs
@@ -59,6 +59,16 @@ namespace Raven.Client.Document
             processedItemsInCurrentOperation++;
         }
 
+        public async Task WaitForLastTaskToFinish()
+        {
+            if (disposed == false && current != null)
+            {
+                await current.DisposeAsync().ConfigureAwait(false);
+                current = null;
+            }
+                
+        }
+
         private RemoteBulkInsertOperation GetBulkInsertOperation()
         {
             if (current == null)

--- a/Raven.Client.Lightweight/Document/RemoteBulkInsertOperation.cs
+++ b/Raven.Client.Lightweight/Document/RemoteBulkInsertOperation.cs
@@ -40,6 +40,8 @@ namespace Raven.Client.Document
 
         void Write(string id, RavenJObject metadata, RavenJObject data, int? dataSize = null);
 
+        Task WaitForLastTaskToFinish();
+
         Task<int> DisposeAsync();
 
         /// <summary>
@@ -331,6 +333,11 @@ namespace Raven.Client.Document
                 operationTask.Wait(); //error early if we have any error
 
             throw new TimeoutException("Could not flush in the specified timeout, server probably not responding or responding too slowly.\r\nAre you writing very big documents?");
+        }
+
+        public async Task WaitForLastTaskToFinish()
+        {
+            throw new NotImplementedException("WaitForLastTaskToFinish not implemented for RemoteBulkInsertOperation, see ChunkedRemoteBulkInsertOperation");
         }
 
         private async Task<bool> IsOperationCompleted(long operationId)

--- a/Raven.Database/Smuggler/SmugglerEmbeddedDatabaseOperations.cs
+++ b/Raven.Database/Smuggler/SmugglerEmbeddedDatabaseOperations.cs
@@ -338,6 +338,11 @@ namespace Raven.Database.Smuggler
             return new CompletedTask();
         }
 
+        public async Task WaitForLastBulkInsertTaskToFinish()
+        {
+            //noop
+        }
+
         public Task<IAsyncEnumerator<RavenJObject>> ExportItems(ItemType types, OperationState state)
         {
             var exporter = new SmugglerExporter(database, ExportOptions.Create(state, types, Options.ExportDeletions, Options.Limit));

--- a/Raven.Database/Smuggler/SmugglerRemoteDatabaseOperations.cs
+++ b/Raven.Database/Smuggler/SmugglerRemoteDatabaseOperations.cs
@@ -376,6 +376,11 @@ namespace Raven.Smuggler
             return client.SeedIdentitiesAsync(itemsToInsert);
         }
 
+        public async Task WaitForLastBulkInsertTaskToFinish()
+        {
+            await Operation.WaitForLastTaskToFinish().ConfigureAwait(false);
+        }
+
         public Task<IAsyncEnumerator<RavenJObject>> ExportItems(ItemType types, OperationState state)
         {
             var options = ExportOptions.Create(state, types, Options.ExportDeletions, Options.Limit);


### PR DESCRIPTION
…nts. Now we dispose of the last chunk of the bulkinsert operation when we know we've finished proccessing the documents.