### PR TITLE
RavenDB-6514 Tests failing in 32 bits

### DIFF
--- a/test/SlowTests/Voron/Checksum.cs
+++ b/test/SlowTests/Voron/Checksum.cs
@@ -20,6 +20,7 @@ using Voron.Platform.Win32;
 using Xunit;
 using Sparrow;
 using Voron.Data;
+using Voron.Impl.Paging;
 
 namespace SlowTests.Voron
 {
@@ -79,8 +80,9 @@ namespace SlowTests.Voron
             // Lets corrupt something
             using (var options = StorageEnvironmentOptions.ForPath(DataDir))
             using (var pager = new WindowsMemoryMapPager(options, Path.Combine(DataDir, "Raven.Voron")))
+            using (var tempTX = new TempPagerTransaction())
             {
-                var writePtr = pager.AcquirePagePointer(null, 2) + PageHeader.SizeOf + 43; // just some random place on page #2
+                var writePtr = pager.AcquirePagePointer(tempTX, 2) + PageHeader.SizeOf + 43; // just some random place on page #2
                 for (byte i = 0; i < 8; i++)
                 {
                     writePtr[i] = i;

--- a/test/SlowTests/Voron/StorageTest.cs
+++ b/test/SlowTests/Voron/StorageTest.cs
@@ -10,6 +10,7 @@ using Voron.Impl;
 using Voron.Global;
 using Sparrow;
 using Sparrow.Logging;
+using Xunit;
 
 namespace SlowTests.Voron
 {
@@ -190,6 +191,20 @@ namespace SlowTests.Voron
             Slice item2;
             Slice.External(txh.Allocator, (byte*)node + node->KeySize + Constants.Tree.NodeHeaderSize, (ushort) node->DataSize, ByteStringType.Immutable, out item2);
             return Tuple.Create(item1, item2);
+        }
+
+        public class SkipWhen32BitsEnvironment : FactAttribute
+        {
+            public SkipWhen32BitsEnvironment()
+            {
+                var shouldForceEnvVar = Environment.GetEnvironmentVariable("VORON_INTERNAL_ForceUsing32BitsPager");
+
+                bool result;
+                if (bool.TryParse(shouldForceEnvVar, out result))
+                    if (result || IntPtr.Size == sizeof(int))
+                        Skip = "Not supported for 32 bits";
+                    
+            }
         }
     }
 }

--- a/test/StressTests/Voron/HugeTransactions.cs
+++ b/test/StressTests/Voron/HugeTransactions.cs
@@ -27,6 +27,7 @@ namespace StressTests.Voron
         [Theory]
         [InlineData(2)]
         [InlineData(6, Skip = "Too large to run on scratch machines. For manual run only")]
+        [SkipWhen32BitsEnvironment]
         public void CanWriteBigTransactions(long transactionSizeInGb)
         {
             var tmpFile = Path.Combine(Path.GetTempPath(), "TestBigTx" + transactionSizeInGb);
@@ -132,6 +133,7 @@ namespace StressTests.Voron
         [InlineData(2)] // in = 3GB, out ~= 1.5GB
         [InlineData(1)] // in = 3GB, out > 3GB (rare case)
         [InlineData(0)] // special case : in = Exactly 1GB, out > 1GB
+        [SkipWhen32BitsEnvironment]
         public unsafe void LZ4TestAbove2GB(long devider)
         {
             var options = StorageEnvironmentOptions.ForPath(Path.Combine(DataDir, $"bigLz4-test-{devider}.data"));


### PR DESCRIPTION
- Don't allow using pager without a transaction, fixing NRE
- Allow to map less than AllocationGranularity if we are at the end of a file.
- Skip tests not supported in 32 bits