### PR TITLE
RavenDB-6440 PutAttachment and DeleteAttachment should call Put docum…

### DIFF
--- a/RavenDB-Dnx.sln.DotSettings
+++ b/RavenDB-Dnx.sln.DotSettings
@@ -1,5 +1,6 @@
 ﻿<wpf:ResourceDictionary xml:space="preserve" xmlns:x="http://schemas.microsoft.com/winfx/2006/xaml" xmlns:s="clr-namespace:System;assembly=mscorlib" xmlns:ss="urn:shemas-jetbrains-com:settings-storage-xaml" xmlns:wpf="http://schemas.microsoft.com/winfx/2006/xaml/presentation">
 	<s:Boolean x:Key="/Default/CodeStyle/CodeFormatting/CSharpFormat/SPACE_AFTER_TYPECAST_PARENTHESES/@EntryValue">False</s:Boolean>
+	<s:Int64 x:Key="/Default/CodeStyle/CodeFormatting/CSharpFormat/WRAP_LIMIT/@EntryValue">170</s:Int64>
 	<s:Boolean x:Key="/Default/Environment/InjectedLayers/FileInjectedLayer/=77534FD473DA1649945C7165031E1A9B/@KeyIndexDefined">True</s:Boolean>
 	<s:String x:Key="/Default/Environment/InjectedLayers/FileInjectedLayer/=77534FD473DA1649945C7165031E1A9B/AbsolutePath/@EntryValue">C:\work\ravendb\RavenDB-Dnx.sln.DotSettings</s:String>
 	<s:String x:Key="/Default/Environment/InjectedLayers/FileInjectedLayer/=77534FD473DA1649945C7165031E1A9B/RelativePath/@EntryValue"></s:String>

--- a/src/Raven.Server/Documents/DocumentFlags.cs
+++ b/src/Raven.Server/Documents/DocumentFlags.cs
@@ -9,12 +9,14 @@ namespace Raven.Server.Documents
 
         Artificial = 0x1,
         Versioned = 0x2,
-        SkipVersioning = 0x4,
-        ForceVersioning = 0x8,
+        Reserved1 = 0x4,
+        Reserved2 = 0x8,
 
         FromIndex = 0x10,
         FromVersionStorage = 0x20,
         FromReplication = 0x40,
-        HasAttachments = 0x80,
+        Reserved3 = 0x80,
+
+        HasAttachments = 0x100,
     }
 }

--- a/src/Raven.Server/Documents/Versioning/VersioningStorage.cs
+++ b/src/Raven.Server/Documents/Versioning/VersioningStorage.cs
@@ -147,7 +147,7 @@ namespace Raven.Server.Documents.Versioning
             return _emptyConfiguration;
         }
 
-        public DocumentFlags ShouldVersionDocument(CollectionName collectionName, BlittableJsonReaderObject document, out VersioningConfigurationCollection configuration)
+        public bool ShouldVersionDocument(CollectionName collectionName, BlittableJsonReaderObject document, out VersioningConfigurationCollection configuration)
         {
             configuration = null;
             BlittableJsonReaderObject metadata;
@@ -162,9 +162,7 @@ namespace Raven.Server.Documents.Versioning
                     metadata.Modifications = mutatedMetadata = new DynamicJsonValue(metadata);
                     mutatedMetadata.Remove(Constants.Documents.Versioning.DisableVersioning);
                     if (disableVersioning)
-                    {
-                        return DocumentFlags.SkipVersioning;
-                    }
+                        return false;
                 }
 
                 bool enableVersioning;
@@ -175,14 +173,12 @@ namespace Raven.Server.Documents.Versioning
                         metadata.Modifications = mutatedMetadata = new DynamicJsonValue(metadata);
                     mutatedMetadata.Remove(Constants.Documents.Versioning.EnableVersioning);
                     if (enableVersioning)
-                    {
-                        return DocumentFlags.ForceVersioning | DocumentFlags.Versioned;
-                    }
+                        return true;
                 }
             }
 
             configuration = GetVersioningConfiguration(collectionName);
-            return configuration.Active ? DocumentFlags.Versioned : DocumentFlags.None;
+            return configuration.Active;
         }
 
         public void PutFromDocument(DocumentsOperationContext context, string key,


### PR DESCRIPTION
…ent instead of updating the document using a dedicating code. This way we reuse put for versioning which should be updated to also revision attachments.

No need to have SkipVersioning and ForceVersioning flags. In attachment we check if a document is Versioned or not.