### PR TITLE
RavenDB-5587

### DIFF
--- a/Raven.SlowTests/Issues/RavenDB_1594.cs
+++ b/Raven.SlowTests/Issues/RavenDB_1594.cs
@@ -35,6 +35,7 @@ namespace Raven.SlowTests.Issues
                             {
                                 Port = 8079,
                                 RunInUnreliableYetFastModeThatIsNotSuitableForProduction = true,
+                                MaxSecondsForTaskToWaitForDatabaseToLoad = 20,
                                 DataDirectory = path,
                                 Settings = { { "Raven/ActiveBundles", "PeriodicBackup" } },
                             };

--- a/Raven.Tests.Bundles/CompressionAndEncryption/CompressionAndEncryption.cs
+++ b/Raven.Tests.Bundles/CompressionAndEncryption/CompressionAndEncryption.cs
@@ -12,7 +12,7 @@ using Raven.Tests.Common.Util;
 
 namespace Raven.Tests.Bundles.CompressionAndEncryption
 {
-    public class CompressionAndEncryption : IDisposable
+    public abstract class CompressionAndEncryption : IDisposable
     {
         protected readonly string path;
         protected readonly DocumentStore documentStore;
@@ -20,7 +20,7 @@ namespace Raven.Tests.Bundles.CompressionAndEncryption
         private bool closed = false;
         private Raven.Database.Config.RavenConfiguration settings;
 
-        public CompressionAndEncryption()
+        protected CompressionAndEncryption()
         {
             path = Path.GetDirectoryName(Assembly.GetAssembly(typeof(Versioning.Versioning)).CodeBase);
             path = Path.Combine(path, "TestDb").Substring(6);
@@ -29,6 +29,7 @@ namespace Raven.Tests.Bundles.CompressionAndEncryption
             {
                 Port = 8079,
                 RunInUnreliableYetFastModeThatIsNotSuitableForProduction = true,
+                MaxSecondsForTaskToWaitForDatabaseToLoad = 20,
                 DataDirectory = path,
                 Settings =
                     {

--- a/Raven.Tests.Issues/RavenDB_1595.cs
+++ b/Raven.Tests.Issues/RavenDB_1595.cs
@@ -59,7 +59,8 @@ namespace Raven.Tests.Issues
                 RunInUnreliableYetFastModeThatIsNotSuitableForProduction = true,
                 RunInMemory = false,
                 Port = port,
-                DefaultStorageTypeName = "esent"
+                DefaultStorageTypeName = "esent",
+                MaxSecondsForTaskToWaitForDatabaseToLoad = 20
             };
 
             if (removeDataDirectory)

--- a/Raven.Tests.Server.Runner/Controllers/ServersController.cs
+++ b/Raven.Tests.Server.Runner/Controllers/ServersController.cs
@@ -107,6 +107,7 @@ namespace Raven.Tests.Server.Runner.Controllers
             configuration.DataDirectory = Path.Combine(Context.DataDir, port, "System");
             configuration.FileSystem.DataDirectory = Path.Combine(Context.DataDir, port, "FileSystem");
             configuration.AccessControlAllowOrigin = new HashSet<string> { "*" };
+            configuration.MaxSecondsForTaskToWaitForDatabaseToLoad = 20;
 
             if (configuration.RunInMemory == false && deleteData)
             {

--- a/Raven.Tests/Bugs/HiLoServerKeysNotExported.cs
+++ b/Raven.Tests/Bugs/HiLoServerKeysNotExported.cs
@@ -48,18 +48,7 @@ namespace Raven.Tests.Bugs
             if(server != null)
                 server.Dispose();
 
-            server = new RavenDbServer(new RavenConfiguration
-                                        {
-                                            Port = 8079,
-                                            DataDirectory = "HiLoData",
-                                            RunInUnreliableYetFastModeThatIsNotSuitableForProduction = true,
-                                            AnonymousUserAccessMode = AnonymousUserAccessMode.Admin
-                                        })
-            {
-                UseEmbeddedHttpServer = true
-            };
-            server.Initialize();
-
+            server = GetNewServer();
         }
 
         [Fact]

--- a/Raven.Tests/Bugs/MultiTenancy/Basic.cs
+++ b/Raven.Tests/Bugs/MultiTenancy/Basic.cs
@@ -23,26 +23,6 @@ namespace Raven.Tests.Bugs.MultiTenancy
 {
     public class Basic : RavenTest
     {
-        protected RavenDbServer GetNewServer(int port)
-        {
-            var dataDirectory = Path.Combine(NewDataPath(), "System");
-            var configuration = new RavenConfiguration
-                                {
-                                    Port = port,
-                                    DataDirectory = dataDirectory,
-                                    AnonymousUserAccessMode = AnonymousUserAccessMode.Admin
-                                };
-            configuration.RunInMemory = configuration.DefaultStorageTypeName == InMemoryRavenConfiguration.VoronTypeName;
-
-            var ravenDbServer = new RavenDbServer(configuration)
-            {
-                UseEmbeddedHttpServer = true
-            };
-
-            ravenDbServer.Initialize();
-            return ravenDbServer;
-        }
-
         [Fact]
         public void CanCreateDatabaseUsingExtensionMethod()
         {

--- a/Raven.Tests/Bugs/MultiTenancy/CreatingIndexes.cs
+++ b/Raven.Tests/Bugs/MultiTenancy/CreatingIndexes.cs
@@ -19,26 +19,8 @@ using Raven.Client.Extensions;
 
 namespace Raven.Tests.Bugs.MultiTenancy
 {
-    public class CreatingIndexes : RavenTest, IDisposable
+    public class CreatingIndexes : RavenTest
     {
-        protected RavenDbServer GetNewServer(int port)
-        {
-            RavenDbServer ravenDbServer = new RavenDbServer(new RavenConfiguration
-            {
-                Port = port,
-                RunInMemory = true,
-                DataDirectory = "Data",
-                AnonymousUserAccessMode = AnonymousUserAccessMode.Admin
-            })
-            {
-                UseEmbeddedHttpServer = true
-            };
-            ravenDbServer.Initialize();
-            return
-                ravenDbServer;
-        }
-
-
         [Fact]
         public void Multitenancy_Test()
         {

--- a/Raven.Tests/Embedded/EmbeddedTests.cs
+++ b/Raven.Tests/Embedded/EmbeddedTests.cs
@@ -106,9 +106,7 @@ namespace Raven.Tests.Embedded
         [Fact]
         public void CanInsertSeveralDocuments()
         {
-            var configuration = new RavenConfiguration();
-            configuration.RunInMemory = configuration.DefaultStorageTypeName == InMemoryRavenConfiguration.VoronTypeName;
-            using (var server = new RavenDbServer(configuration).Initialize())
+            using (var server = GetNewServer())
             {
                 var store = server.DocumentStore;
                 var bulkInsertOperation = new RemoteBulkInsertOperation(new BulkInsertOptions(), (AsyncServerClient)store.AsyncDatabaseCommands, store.Changes());


### PR DESCRIPTION
added MaxSecondsForTaskToWaitForDatabaseToLoad to all tests that create local instance of RavenDBServer or substituted with instance from RavenTestBase