### PR TITLE
RavenDB-5861

### DIFF
--- a/src/Raven.Client/Json/BlittableOperation.cs
+++ b/src/Raven.Client/Json/BlittableOperation.cs
@@ -53,6 +53,8 @@ namespace Raven.Client.Json
                 newBlittable.GetPropertyByIndex(propId, ref newProp);
 
                 if (newProp.Name.Equals(Constants.Documents.Metadata.LastModified) ||
+                    newProp.Name.Equals(Constants.Documents.Metadata.Collection) ||
+                    newProp.Name.Equals(Constants.Documents.Metadata.ChangeVector) ||
                     newProp.Name.Equals(Constants.Documents.Metadata.Etag) ||
                     newProp.Name.Equals(Constants.Documents.Metadata.Id))
                     continue;

--- a/src/Raven.Server/Documents/DocumentsStorage.cs
+++ b/src/Raven.Server/Documents/DocumentsStorage.cs
@@ -881,7 +881,7 @@ namespace Raven.Server.Documents
                 return 0;
 
             int size;
-            var ptr = result.Reader.Read((int) DocumentsTable.Etag, out size);
+            var ptr = result.Reader.Read((int)DocumentsTable.Etag, out size);
             return IPAddress.NetworkToHostOrder(*(long*)ptr);
         }
 
@@ -981,7 +981,7 @@ namespace Raven.Server.Documents
             {
                 StorageId = tvr.Id
             };
-            
+
             result.LoweredKey = TableValueToString(context, (int)ConflictsTable.LoweredKey, ref tvr);
             result.Key = TableValueToKey(context, (int)ConflictsTable.OriginalKey, ref tvr);
             result.ChangeVector = GetChangeVectorEntriesFromTableValueReader(ref tvr, (int)ConflictsTable.ChangeVector);
@@ -1167,8 +1167,8 @@ namespace Raven.Server.Documents
                     var ptr = table.DirectRead(doc.StorageId, out size);
                     var tvr = new TableValueReader(ptr, size);
 
-                    lowerKey = tvr.Read((int) DocumentsTable.LoweredKey, out lowerSize);
-                    keyPtr = tvr.Read((int) DocumentsTable.Key, out keySize);
+                    lowerKey = tvr.Read((int)DocumentsTable.LoweredKey, out lowerSize);
+                    keyPtr = tvr.Read((int)DocumentsTable.Key, out keySize);
 
                     etag = CreateTombstone(context,
                         lowerKey,
@@ -1428,7 +1428,7 @@ namespace Raven.Server.Documents
             long maxEtag = 0L;
             foreach (var tvr in conflictsTable.SeekForwardFrom(ConflictsSchema.Indexes[KeyAndChangeVectorSlice], loweredKey, 0, startsWith: true))
             {
-                var etag = TableValueToEtag((int) ConflictsTable.Etag, ref tvr.Result.Reader);
+                var etag = TableValueToEtag((int)ConflictsTable.Etag, ref tvr.Result.Reader);
                 if (maxEtag < etag)
                     maxEtag = etag;
             }
@@ -1989,6 +1989,7 @@ namespace Raven.Server.Documents
             public string Key;
             public long Etag;
             public CollectionName Collection;
+            public ChangeVectorEntry[] ChangeVector;
         }
 
         public void DeleteWithoutCreatingTombstone(DocumentsOperationContext context, string collection, long storageId, bool isTombstone)
@@ -2159,7 +2160,7 @@ namespace Raven.Server.Documents
                             ThrowConcurrentException(key, expectedEtag, oldEtag);
 
                         int oldSize;
-                        var oldDoc = new BlittableJsonReaderObject(oldValue.Read((int) DocumentsTable.Data, out oldSize), oldSize, context);
+                        var oldDoc = new BlittableJsonReaderObject(oldValue.Read((int)DocumentsTable.Data, out oldSize), oldSize, context);
                         var oldCollectionName = ExtractCollectionName(context, key, oldDoc);
                         if (oldCollectionName != collectionName)
                             ThrowInvalidCollectionNameChange(key, oldCollectionName, collectionName);
@@ -2198,7 +2199,8 @@ namespace Raven.Server.Documents
             {
                 Etag = newEtag,
                 Key = key,
-                Collection = collectionName
+                Collection = collectionName,
+                ChangeVector = changeVector
             };
         }
 
@@ -2847,9 +2849,9 @@ namespace Raven.Server.Documents
         }
 
         private PutOperationResults UpdateDocumentForAttachmentChange(
-            DocumentsOperationContext context, 
-            string documentId, 
-            TableValueReader tvr, 
+            DocumentsOperationContext context,
+            string documentId,
+            TableValueReader tvr,
             long modifiedTicks)
         {
             // We can optimize this by copy just the document's data instead of the all tvr

--- a/src/Raven.Server/Documents/Handlers/HiLoHandler.cs
+++ b/src/Raven.Server/Documents/Handlers/HiLoHandler.cs
@@ -126,35 +126,35 @@ namespace Raven.Server.Documents.Handlers
 
                     if (hiloDocReader != null)
                     {
-                        hiloDocReader.TryGet("Max", out oldMax);
                         var prop = new BlittableJsonReaderObject.PropertyDetails();
-                        for (var i = 0; i < hiloDocReader.Count; i++)
+                        foreach (var propertyId in hiloDocReader.GetPropertiesByInsertionOrder())
                         {
-                            hiloDocReader.GetPropertyByIndex(0, ref prop);
+                            hiloDocReader.GetPropertyByIndex(propertyId, ref prop);
                             if (prop.Name == "Max")
+                            {
+                                oldMax = (long)prop.Value;
                                 continue;
+                            }
+
                             newDoc[prop.Name] = prop.Value;
                         }
                     }
-                }
 
+                    oldMax = Math.Max(oldMax, LastRangeMax);
+
+                    newDoc["Max"] = oldMax + Capacity;
+
+                    using (var freshHilo = context.ReadObject(newDoc, hiLoDocumentKey, BlittableJsonDocumentBuilder.UsageMode.ToDisk))
+                        Database.DocumentsStorage.Put(context, hiLoDocumentKey, null, freshHilo);
+
+                    OldMax = oldMax;
+                    Prefix = prefix;
+                }
                 finally
                 {
                     serverPrefixDocReader?.Dispose();
                     hiloDocReader?.Dispose();
                 }
-                oldMax = Math.Max(oldMax, LastRangeMax);
-
-                newDoc["Max"] = oldMax + Capacity;
-
-                using (var freshHilo = context.ReadObject(newDoc, hiLoDocumentKey,
-                        BlittableJsonDocumentBuilder.UsageMode.ToDisk))
-                {
-                    Database.DocumentsStorage.Put(context, hiLoDocumentKey, null, freshHilo);
-                }
-
-                OldMax = oldMax;
-                Prefix = prefix;
             }
         }
 

--- a/test/SlowTests/Bugs/AnonymousClasses.cs
+++ b/test/SlowTests/Bugs/AnonymousClasses.cs
@@ -6,6 +6,7 @@
 
 using FastTests;
 using Microsoft.Extensions.Primitives;
+using Raven.Client;
 using Xunit;
 
 namespace SlowTests.Bugs
@@ -39,12 +40,14 @@ namespace SlowTests.Bugs
                 {
                     var entity = new { a = 1 };
                     s.Store(entity);
-                    s.SaveChanges();
 
                     var metadata = s.Advanced.GetMetadataFor(entity);
-
-                    
                     Assert.False(metadata.ContainsKey("@collection"));
+
+                    s.SaveChanges();
+
+                    metadata = s.Advanced.GetMetadataFor(entity);
+                    Assert.Equal("@empty", metadata.GetString("@collection"));
                 }
             }
         }


### PR DESCRIPTION
- sending minimal amount of data back after batch put
- we cannot dispose reader in HiLo before converting DJV
- skipping @change-vector and @collection comparison in WhatChanged