### PR TITLE
Optimizations for the regression

### DIFF
--- a/src/Raven.Server/Documents/Queries/Results/QueryResultRetrieverBase.cs
+++ b/src/Raven.Server/Documents/Queries/Results/QueryResultRetrieverBase.cs
@@ -204,7 +204,7 @@ namespace Raven.Server.Documents.Queries.Results
             if (fieldType.IsJson == false)
                 return stringValue;
 
-            var bytes = _context.Encoding.GetBytes(stringValue);
+            var bytes = JsonOperationContext.Encoding.GetBytes(stringValue);
             var ms = new MemoryStream(bytes);
             return _context.ReadForMemory(ms, field.Name);
         }

--- a/src/Sparrow/Json/LazyCompressedStringValue.cs
+++ b/src/Sparrow/Json/LazyCompressedStringValue.cs
@@ -44,11 +44,11 @@ namespace Sparrow.Json
 
             try
             {
-                var charCount = self._context.Encoding.GetCharCount(tempBuffer, self.UncompressedSize);
+                var charCount = JsonOperationContext.Encoding.GetCharCount(tempBuffer, self.UncompressedSize);
                 var str = new string(' ', charCount);
                 fixed (char* pStr = str)
                 {
-                    self._context.Encoding.GetChars(tempBuffer, self.UncompressedSize, pStr, charCount);
+                    JsonOperationContext.Encoding.GetChars(tempBuffer, self.UncompressedSize, pStr, charCount);
                     self.String = str;
                     return str;
                 }


### PR DESCRIPTION
Several improvements to JSON based operations which regressed write sustained speed caused by the memory consumption optimizations.

I am watching on Kaby Lake architecture a sustained average 100Mb/sec write speed for 3 parallel files importing; which is better than what I started with. Since the IO pattern is still spiky, it means that I still have  room for improvement, but I believe that we are now in a good place to run an SO benchmark.  