### PR TITLE
RavenDB-6517

### DIFF
--- a/src/Raven.Client/Documents/Session/Operations/LoadOperation.cs
+++ b/src/Raven.Client/Documents/Session/Operations/LoadOperation.cs
@@ -124,16 +124,13 @@ namespace Raven.Client.Documents.Session.Operations
                 }
             }
 
-            if (result.Results != null)
+            foreach (BlittableJsonReaderObject document in result.Results)
             {
-                foreach (BlittableJsonReaderObject document in result.Results)
-                {
-                    if (document == null)
-                        continue;
+                if (document == null)
+                    continue;
 
-                    var newDocumentInfo = DocumentInfo.GetNewDocumentInfo(document);
-                    _session.DocumentsById.Add(newDocumentInfo);
-                }
+                var newDocumentInfo = DocumentInfo.GetNewDocumentInfo(document);
+                _session.DocumentsById.Add(newDocumentInfo);
             }
             
             if (_includes != null && _includes.Length > 0)

--- a/src/Raven.Client/Http/RequestExecutor.cs
+++ b/src/Raven.Client/Http/RequestExecutor.cs
@@ -227,16 +227,6 @@ namespace Raven.Client.Http
                     }
 
                     sp.Stop();
-               
-                    switch (response.StatusCode)
-                    {
-                        case HttpStatusCode.GatewayTimeout:
-                        case HttpStatusCode.RequestTimeout:
-                        case HttpStatusCode.BadGateway:
-                        case HttpStatusCode.ServiceUnavailable:
-                            await HandleServerDown(choosenNode, context, command, null);
-                            return;
-                    }
                 }
                 catch (HttpRequestException e) // server down, network down
                 {
@@ -342,6 +332,8 @@ namespace Raven.Client.Http
                     return true;
                 case HttpStatusCode.Forbidden:
                     throw AuthorizationException.Forbidden(url);
+                case HttpStatusCode.GatewayTimeout:
+                case HttpStatusCode.RequestTimeout:
                 case HttpStatusCode.BadGateway:
                 case HttpStatusCode.ServiceUnavailable:
                     await HandleServerDown(choosenNode, context, command, null).ConfigureAwait(false);


### PR DESCRIPTION
- LoadOperation.SetResult will raise null exception if result.Results is null
- HandleServerDown in RequestExecutor will be called only in HandleUnsuccessfulResponse and in the exception