### PR TITLE
initialize CompositionContainer with CompositionOptions.IsThreadSafe

### DIFF
--- a/Raven.Database/Config/ConfigOptionDocs.cs
+++ b/Raven.Database/Config/ConfigOptionDocs.cs
@@ -86,6 +86,7 @@ namespace Raven.Database.Config
             {"Raven/MemoryCacheLimitCheckInterval", "TimeSpan", "HH:MM:SS", "The internal for checking that the internal document cache inside RavenDB server will be cleaned."},
             {"Raven/MemoryCacheExpiration", "int", null, "The expiration value for documents in the internal document cache. Value is in seconds. Default: 60 minutes"},
             {"Raven/MemoryLimitForProcessing", "int", null, "Maximum number of megabytes that can be used by database to control the maximum size of the processing batches. Default: 1024 or 75% percent of available memory if 1GB is not available."},
+            {"Raven/MemoryCacher", "string", "assembly qualified type name", "The MemoryCacher type to use for caching database documents."},
 
             // Esent
             {"Raven/Esent/CacheSizeMax", "int", null, "The size in MB of the Esent page cache, which is the default storage engine. Default: 25% of RAM on 64 bits, 256 MB on 32 bits."},

--- a/Raven.Database/Config/InMemoryRavenConfiguration.cs
+++ b/Raven.Database/Config/InMemoryRavenConfiguration.cs
@@ -1048,7 +1048,7 @@ namespace Raven.Database.Config
         [JsonIgnore]
         public CompositionContainer Container
         {
-            get { return container ?? (container = new CompositionContainer(Catalog)); }
+            get { return container ?? (container = new CompositionContainer(Catalog, CompositionOptions.IsThreadSafe)); }
             set
             {
                 containerExternallySet = true;

--- a/Raven.Database/Config/MemoryStatistics.cs
+++ b/Raven.Database/Config/MemoryStatistics.cs
@@ -19,13 +19,13 @@ using ThreadState = System.Threading.ThreadState;
 
 namespace Raven.Database.Config
 {
-    internal interface ILowMemoryHandler
+    public interface ILowMemoryHandler
     {
         LowMemoryHandlerStatistics HandleLowMemory();
         LowMemoryHandlerStatistics GetStats();
     }
 
-    internal static class MemoryStatistics
+    public static class MemoryStatistics
     {
         private static readonly ILog Log = LogManager.GetCurrentClassLogger();
 

--- a/Raven.Database/Config/StronglyTypedRavenSettings.cs
+++ b/Raven.Database/Config/StronglyTypedRavenSettings.cs
@@ -123,6 +123,8 @@ namespace Raven.Database.Config
                 new TimeSpanSetting(settings["Raven/MemoryCacheLimitCheckInterval"], MemoryCache.Default.PollingInterval,
                                     TimeSpanArgumentType.FromParse);
 
+            MemoryCacher = new StringSetting(settings["Raven/MemoryCacher"], (string)null);
+
             PrewarmFacetsSyncronousWaitTime =
                 new TimeSpanSetting(settings["Raven/PrewarmFacetsSyncronousWaitTime"], TimeSpan.FromSeconds(3),
                                     TimeSpanArgumentType.FromParse);
@@ -422,6 +424,8 @@ namespace Raven.Database.Config
         public IntegerSetting MemoryCacheLimitPercentage { get; private set; }
 
         public TimeSpanSetting MemoryCacheLimitCheckInterval { get; private set; }
+
+        public StringSetting MemoryCacher { get; private set; }
 
         public TimeSpanSetting MaxProcessingRunLatency { get; private set; }
 

--- a/Raven.Database/Storage/Esent/TransactionalStorage.cs
+++ b/Raven.Database/Storage/Esent/TransactionalStorage.cs
@@ -88,10 +88,18 @@ namespace Raven.Storage.Esent
             configuration.Container.SatisfyImportsOnce(this);
 
             if (configuration.CacheDocumentsInMemory == false)
+            {
                 documentCacher = new NullDocumentCacher();
+            }
+            else if (configuration.CustomMemoryCacher != null)
+            {
+                documentCacher = configuration.CustomMemoryCacher(configuration);
+            }
             else
-                documentCacher = new DocumentCacher(configuration);    
-            
+            {
+                documentCacher = new DocumentCacher(configuration);
+            }
+
             database = configuration.DataDirectory;
             this.configuration = configuration;
             this.onCommit = onCommit;

--- a/Raven.Database/Storage/Voron/TransactionalStorage.cs
+++ b/Raven.Database/Storage/Voron/TransactionalStorage.cs
@@ -852,9 +852,19 @@ namespace Raven.Storage.Voron
         private IDocumentCacher CreateDocumentCacher(InMemoryRavenConfiguration configuration)
         {
             if (configuration.CacheDocumentsInMemory == false)
-                return new NullDocumentCacher();
+            {
+                documentCacher = new NullDocumentCacher();
+            }
+            else if (configuration.CustomMemoryCacher != null)
+            {
+                documentCacher = configuration.CustomMemoryCacher(configuration);
+            }
+            else
+            {
+                documentCacher = new DocumentCacher(configuration);
+            }
 
-            return new DocumentCacher(configuration);
+            return documentCacher;
         }
     }
 }


### PR DESCRIPTION
To avoid NRE & InvalidOperationException when calling configuration.Container.SatisfyImportsOnce(index) in parallel