### PR TITLE
RavenDB-6578 fixing an issue where if querying a string with unicode …

### DIFF
--- a/Raven.Database/Server/Controllers/RavenBaseApiController.cs
+++ b/Raven.Database/Server/Controllers/RavenBaseApiController.cs
@@ -271,7 +271,7 @@ namespace Raven.Database.Server.Controllers
                 if (originalQuery != null)
                     nvc["query"] = originalQuery.Replace("+", "%2B");
                 foreach (var queryKey in nvc.AllKeys)
-                    nvc[queryKey] = UnescapeStringIfNeeded(nvc[queryKey]);
+                    nvc[queryKey] = UnescapeStringIfNeeded(nvc[queryKey], true, queryKey == "query");
             }
 
             req.Properties["Raven.QueryString"] = nvc;
@@ -413,12 +413,15 @@ namespace Raven.Database.Server.Controllers
             return obj.ToString();
         }
 
-        private static string UnescapeStringIfNeeded(string str, bool shouldDecodeUrl = true)
+        private static string UnescapeStringIfNeeded(string str, bool shouldDecodeUrl = true, bool isQueryKey = false)
         {
             if (str.StartsWith("\"") && str.EndsWith("\""))
                 str = Regex.Unescape(str.Substring(1, str.Length - 2));
             if (str.Any(ch => ch > 127))
             {
+                //We can't do any escaping, unicode chars with special chars like '+' wouldn't work in the studio
+                if (isQueryKey)
+                    return str;
                 // contains non ASCII chars, needs encoding
                 return Uri.EscapeDataString(str);
             }


### PR DESCRIPTION
…chars we would generate the wrong query due to Uri.EscapeDataString changing the query string

The fix is not to do Uri.EscapeDataString for query parameter.
note that this affects v2.5 clients on v3.0 server as well as the studio (not only the studio!)