### PR TITLE
RavenDB-6581 - fix failing test ShouldNotRetrieveOperationDetails

### DIFF
--- a/Raven.Database/Server/Controllers/DocumentsBatchController.cs
+++ b/Raven.Database/Server/Controllers/DocumentsBatchController.cs
@@ -389,10 +389,15 @@ namespace Raven.Database.Server.Controllers
             {
                 using (DocumentCacher.SkipSetDocumentsInDocumentCache())
                 {
-                    status.State["Batch"] = batchOperation(index, indexQuery, option, x =>
+                    var batchResult = batchOperation(index, indexQuery, option, x =>
                     {
                         status.MarkProgress(x);
                     });
+
+                    lock (status.State)
+                    {
+                        status.State["Batch"] = batchResult;
+                    }
                 }
 
             }).ContinueWith(t =>


### PR DESCRIPTION
http://issues.hibernatingrhinos.com/issue/RavenDB-6581