### PR TITLE
RavenDB-6626 fix

### DIFF
--- a/Raven.Client.Lightweight/Document/SessionOperations/LoadOperation.cs
+++ b/Raven.Client.Lightweight/Document/SessionOperations/LoadOperation.cs
@@ -49,6 +49,7 @@ namespace Raven.Client.Document.SessionOperations
             documentFound = document;
             if (documentFound == null)
                 return false;
+
             return
                 documentFound.NonAuthoritativeInformation.HasValue &&
                 documentFound.NonAuthoritativeInformation.Value &&

--- a/Raven.Tests.Issues/Raven.Tests.Issues.csproj
+++ b/Raven.Tests.Issues/Raven.Tests.Issues.csproj
@@ -145,6 +145,7 @@
     <Compile Include="RavenDB-6259.cs" />
     <Compile Include="RavenDB-6345.cs" />
     <Compile Include="RavenDB-6400.cs" />
+    <Compile Include="RavenDB-6626.cs" />
     <Compile Include="RavenDB_5857.cs" />
     <Compile Include="RavenDB_5669.cs" />
     <Compile Include="NewIndexOptimizationIssue.cs" />

--- a/Raven.Tests.Issues/RavenDB-6626.cs
+++ b/Raven.Tests.Issues/RavenDB-6626.cs
@@ -1,0 +1,66 @@
+﻿using System;
+using System.Collections.Generic;
+using System.Linq;
+using System.Text;
+using System.Threading;
+using System.Threading.Tasks;
+using System.Transactions;
+using Raven.Abstractions.Data;
+using Raven.Client.Document.DTC;
+using Raven.Client.Exceptions;
+using Raven.Database.FileSystem.Infrastructure;
+using Raven.Database.Impl;
+using Raven.Database.Util;
+using Raven.Json.Linq;
+using Raven.Tests.Helpers;
+using Xunit;
+
+namespace Raven.Tests.Issues
+{
+    public class RavenDB_6626 : RavenTestBase
+    {
+        public class User
+        {
+            public string Name { get; set; }
+        }
+
+        [Fact]
+        public async Task LoadOperation_should_not_throw()
+        {
+            using (var server = GetNewServer(requestedStorage:"esent"))
+            using (var store = NewRemoteDocumentStore(ravenDbServer: server,requestedStorage:"esent"))
+            {
+                store.TransactionRecoveryStorage = new VolatileOnlyTransactionRecoveryStorage();
+                var database = await server.Server.GetDatabaseInternal(store.DefaultDatabase);
+
+                database.PrepareTransaction("1");
+                using (var session = store.OpenSession())
+                {
+                    var entity = new User {Name = "John Doe"};
+                    session.Store(entity, "users/1");
+                   
+                    session.SaveChanges();
+                    database.InFlightTransactionalState.AddDocumentInTransaction("users/1",
+                        Etag.Empty,
+                        RavenJObject.FromObject(entity),
+                        new RavenJObject(),
+                        new Raven.Abstractions.Data.TransactionInformation { Id = "1" },
+                        Etag.Empty,
+                        new DummyUuidGenerator());
+                }
+
+                using (var session = store.OpenAsyncSession())
+                {
+                    session.Advanced.AllowNonAuthoritativeInformation = false;
+
+                    //note: the issue was that LoadAsync in this use-case was throwing StackOverflow
+                    var ae = Assert.Throws<AggregateException>(() => session.LoadAsync<User>("users/1").Wait());
+
+                    Assert.NotNull(ae.InnerException);
+                    Assert.IsType<NonAuthoritativeInformationException>(ae.InnerException);
+                }
+            }
+
+        }
+    }
+}

--- a/Raven.Tryouts/Program.cs
+++ b/Raven.Tryouts/Program.cs
@@ -32,6 +32,10 @@ namespace Raven.Tryouts
     {
         public static void Main(string[] args)
         {
+            using (var test = new RavenDB_6626())
+            {
+                test.LoadOperation_should_not_throw().Wait();
+            }
         }
 
         public static async Task AsyncMain()


### PR DESCRIPTION
Prevent LoadAsync() from throwing StackOverflow when there are frequent DTC transactions, which cause document to return marked as non-authoritative information, which in turn causes "retry" logic to fire.
