### PR TITLE
RavenDB-6629: Fixed degradation of dictionary performance 

### DIFF
--- a/src/Raven.Server/Smuggler/Documents/Handlers/SmugglerHandler.cs
+++ b/src/Raven.Server/Smuggler/Documents/Handlers/SmugglerHandler.cs
@@ -215,7 +215,7 @@ namespace Raven.Server.Smuggler.Documents.Handlers
                         }
                         using (ContextPool.AllocateOperationContext(out context))
                         using (var file = await getFile())
-                        using (var stream = new GZipStream(file, CompressionMode.Decompress))
+                        using (var stream = new GZipStream(new BufferedStream(file, 128 * Voron.Global.Constants.Size.Kilobyte), CompressionMode.Decompress))
                         {
                             var source = new StreamSource(stream, context);
                             var destination = new DatabaseDestination(Database);
@@ -298,7 +298,7 @@ namespace Raven.Server.Smuggler.Documents.Handlers
                 var options = DatabaseSmugglerOptionsServerSide.Create(HttpContext, context);
                 var token = CreateOperationToken();
 
-                using (var stream = new GZipStream(await GetImportStream(), CompressionMode.Decompress))
+                using (var stream = new GZipStream(new BufferedStream(await GetImportStream(), 128 * Voron.Global.Constants.Size.Kilobyte), CompressionMode.Decompress))
                 using (token)
                 {
                     var source = new StreamSource(stream, context);

--- a/src/Sparrow/Json/AllocatedMemoryData.cs
+++ b/src/Sparrow/Json/AllocatedMemoryData.cs
@@ -1,6 +1,0 @@
-﻿using System;
-
-namespace Sparrow.Json
-{
-    
-}

--- a/src/Sparrow/StringComparer.cs
+++ b/src/Sparrow/StringComparer.cs
@@ -1,12 +1,13 @@
 ﻿using System;
 using System.Collections.Generic;
-using System.Globalization;
 using System.Runtime.CompilerServices;
-using System.Text;
-using System.Xml.Linq;
 
 namespace Sparrow
 {
+    /// <summary>
+    /// The struct compared is optimized for small strings that come from the outside of the controlled fence, 
+    /// the hash function used is compact (making it suitable for inlining) and also flood resistant. 
+    /// </summary>
     public struct OrdinalStringStructComparer : IEqualityComparer<string>
     {
         public static readonly OrdinalStringStructComparer Instance = default(OrdinalStringStructComparer);
@@ -33,18 +34,14 @@ namespace Sparrow
         [MethodImpl(MethodImplOptions.AggressiveInlining)]
         public int GetHashCode(string x)
         {
-            int xSize = x.Length;
-            uint hash = 0;
-
-            for (int i = 0; i < xSize; i++)
-            {
-                hash = Hashing.CombineInline(hash, x[i]);
-            }
-
-            return (int)hash;
+            return (int)Hashing.Marvin32.CalculateInline<Hashing.OrdinalModifier>(x);
         }
     }
 
+    /// <summary>
+    /// The struct compared is optimized for small strings that come from the outside of the controlled fence, 
+    /// the hash function used is compact (making it suitable for inlining) and also flood resistant. 
+    /// </summary>
     public struct OrdinalIgnoreCaseStringStructComparer : IEqualityComparer<string>
     {        
         public static readonly OrdinalIgnoreCaseStringStructComparer Instance = default(OrdinalIgnoreCaseStringStructComparer);
@@ -79,19 +76,7 @@ namespace Sparrow
         [MethodImpl(MethodImplOptions.AggressiveInlining)]
         public int GetHashCode(string x)
         {
-            int xSize = x.Length;
-            uint hash = 0;
-
-            for (int i = 0; i < xSize; i++)
-            {
-                char ch = x[i];
-                if ((ch >= 65) && (ch <= 90))
-                    ch = (char)(ch | 0x0020);
-
-                hash = Hashing.CombineInline(hash, ch);
-            }
-
-            return (int)hash;
+            return (int)Hashing.Marvin32.CalculateInline<Hashing.OrdinalIgnoreCaseModifier>(x);
         }
     }
 }

--- a/test/FastTests/Sparrow/Hashing.cs
+++ b/test/FastTests/Sparrow/Hashing.cs
@@ -22,8 +22,33 @@ namespace FastTests.Sparrow
         {
             var r1 = Hashing.XXHash32.CalculateRaw("Public");
             var r2 = Hashing.XXHash32.CalculateRaw(new string("Public".ToCharArray()));
+            var r3 = Hashing.XXHash32.Calculate("Public");
 
             Assert.Equal(r1, r2);
+            Assert.Equal(r2, r3);
+        }
+
+        [Fact]
+        public void Marvin32_UseActualValues()
+        {
+            byte[] value = { (byte)'A', 0, (byte)'b', 0, (byte)'c', 0, (byte)'d', 0, (byte)'e', 0, (byte)'f', 0, (byte)'g', 0, }; /* "Abcdefg" in UTF-16-LE */
+
+            var r1 = Hashing.Marvin32.Calculate(value);
+            var r2 = Hashing.Marvin32.Calculate("Abcdefg");
+
+            Assert.Equal(r1, r2);
+        }
+
+
+        [Fact]
+        public void XXHash32_UseLongActualValues()
+        {
+            var r1 = Hashing.XXHash32.CalculateRaw("PublicPublicPublicPublic");
+            var r2 = Hashing.XXHash32.CalculateRaw(new string("PublicPublicPublicPublic".ToCharArray()));
+            var r3 = Hashing.XXHash32.Calculate("PublicPublicPublicPublic");
+
+            Assert.Equal(r1, r2);
+            Assert.Equal(r2, r3);
         }
 
 
@@ -74,6 +99,14 @@ namespace FastTests.Sparrow
 
             Assert.Equal(r1.H1, 0x9B9FEDA4BFE27CC7UL);
             Assert.Equal(r1.H2, 0x97A27450ACB24805UL);
+        }
+
+        [Fact]
+        public void Marvin32()
+        {
+            byte[] test = { (byte)'A', 0, (byte)'b', 0, (byte)'c', 0, (byte)'d', 0, (byte)'e', 0, (byte)'f', 0, (byte)'g', 0, }; /* "Abcdefg" in UTF-16-LE */
+            uint r = Hashing.Marvin32.Calculate(test);
+            Assert.Equal(r, 0xba627c81);
         }
 
 


### PR DESCRIPTION
RavenDB-6629: Fixed degradation of dictionary performance because of not good enough hashing function.

Implemented Marvin32 because we needed a compact function to allow inlining of key methods. xxHash while very fast has a big instructions footprint making it a very unsuitable hash function on hot-paths and small inputs. While we pondered other options like Dbj or FNV which are very fast for small inputs, the data we are going to be stores comes unfiltered from user land; so for a very small premium we decided to use a flood resistant one.

We also implemented improvements to the code layout for the FastDictionary insertion method.