### PR TITLE
RavenDB-6692

### DIFF
--- a/src/Raven.Server/Documents/Indexes/Persistence/Lucene/Documents/Fields/FieldCacheKey.cs
+++ b/src/Raven.Server/Documents/Indexes/Persistence/Lucene/Documents/Fields/FieldCacheKey.cs
@@ -28,7 +28,7 @@ namespace Raven.Server.Documents.Indexes.Persistence.Lucene.Documents.Fields
                     {
                         int nameHash = name?.GetHashCode() ?? 0;
                         int fieldHash = (index != null ? (byte)index : -1) << 16 | ((byte)store << 8) | (byte)termVector;
-                        int hash = Hashing.CombineInline(nameHash, fieldHash);
+                        int hash = Hashing.Combine(nameHash, fieldHash);
 
                         if (multipleItemsSameField.Length > 0)
                         {

--- a/src/Raven.Server/ServerWide/Context/TransactionOperationContext.cs
+++ b/src/Raven.Server/ServerWide/Context/TransactionOperationContext.cs
@@ -59,25 +59,19 @@ namespace Raven.Server.ServerWide.Context
         public short GetTransactionMarker()
         {
             if (Transaction != null && Transaction.Disposed == false && Transaction.InnerTransaction.LowLevelTransaction.Flags != TransactionFlags.ReadWrite)
-                MustHaveWriteTransactionOpened();
+                ThrowWriteTransactionMustBeOpen();
 
             var value = (short)(CurrentTxMarker + TransactionMarkerOffset);
-            if (value <= 0)
-            {
-                switch (value)
-                {
-                    case short.MaxValue:
-                        return 1;
-                    case 0:
-                        return 2;
-                    default:
-                        return (short)-value;
-                }
-            }
+
+            if (value == 0)
+                return 2;
+            if (value < 0)
+                return (short)-value;
+            
             return value;
         }
 
-        private static void MustHaveWriteTransactionOpened()
+        private static void ThrowWriteTransactionMustBeOpen()
         {
             throw new InvalidOperationException("Write transaction must be opened");
         }

--- a/src/Sparrow/Collections/FastDictionary.cs
+++ b/src/Sparrow/Collections/FastDictionary.cs
@@ -213,48 +213,66 @@ namespace Sparrow.Collections
 
         public void Add(TKey key, TValue value)
         {
+            Contract.Requires(key != null);
             Contract.Ensures(this._numberOfUsed <= this._capacity);
-            Contract.EndContractBlock();
-
-            if (key == null)
-                ThrowWhenKeyIsNull(key);
 
             ResizeIfNeeded();
 
-            int hash = GetInternalHashCode(key);
+            int hash = GetInternalHashCode(key); // PERF: This goes first because it can consume lots of registers.
+            uint uhash = (uint)hash;
+
+            var entries = _entries;
+
+            int numProbes = 1;
+            int capacity = _capacity;
             int bucket = hash & _capacityMask;
 
-            uint uhash = (uint)hash;
-            int numProbes = 1;
+            Loop:
             do
             {
-                uint nHash = _entries[bucket].Hash;
+                uint nHash = entries[bucket].Hash;
                 if (nHash == KUnusedHash)
                 {
                     _numberOfUsed++;
                     _size++;
-
-                    goto SET;
+                    goto Set;
                 }
                 if (nHash == KDeletedHash)
                 {
                     _numberOfDeleted--;
                     _size++;
-
-                    goto SET;
+                    goto Set;
                 }
-                else
-                {
-                    if (nHash == uhash && _comparer.Equals(_entries[bucket].Key, key))
-                        ThrowWhenDuplicatedKey(key);                        
-                }
+                    
+                if (nHash == uhash)
+                    goto PartialHit;
 
                 bucket = (bucket + numProbes) & _capacityMask;
                 numProbes++;
+
+#if DEBUG
+                if ( numProbes >= 100 )
+                    throw new InvalidOperationException("The hash function used for this object is not good enough. The distribution is causing clusters and causing huge slowdowns.");
+#else
+                if (numProbes >= capacity)
+                    break;
+#endif
             }
             while (true);
 
-        SET:
+            // PERF: If it happens, it should be rare therefore outside of the critical path. 
+            PartialHit:
+            if (!_comparer.Equals(entries[bucket].Key, key))
+            {
+                // PERF: This can happen with a very^3 low probability (assuming your hash function is good enough)
+                bucket = (bucket + numProbes) & _capacityMask;
+                numProbes++;
+                goto Loop;
+            }
+            ThrowWhenDuplicatedKey(key); // We throw here. 
+
+            Set:
+
             this._entries[bucket].Hash = uhash;
             this._entries[bucket].Key = key;
             this._entries[bucket].Value = value;
@@ -334,9 +352,6 @@ namespace Sparrow.Collections
             Rehash(entries);
         }
 
-
-
-
         public TValue this[TKey key]
         {
             [MethodImpl(MethodImplOptions.AggressiveInlining)]
@@ -345,30 +360,51 @@ namespace Sparrow.Collections
                 Contract.Requires(key != null);
                 Contract.Ensures(this._numberOfUsed <= this._capacity);
 
-                int hash = GetInternalHashCode(key);
-                int bucket = hash & _capacityMask;
+                int hash = GetInternalHashCode(key); // PERF: This goes first because it can consume lots of registers.
 
                 var entries = _entries;
 
-                uint nHash;
                 int numProbes = 1;
+                int capacity = _capacity;
+                int bucket = hash & _capacityMask;
+
+                Loop:
                 do
                 {
-                    nHash = entries[bucket].Hash;
-                    if (nHash == hash && _comparer.Equals(entries[bucket].Key, key))
-                        return entries[bucket].Value;
+                    uint nHash = entries[bucket].Hash;
+                    if (nHash == KUnusedHash)
+                        goto ReturnFalse;
+                    if (nHash == hash)
+                        goto PartialHit;
 
                     bucket = (bucket + numProbes) & _capacityMask;
                     numProbes++;
 
-                    //Debug.Assert(numProbes < 100);
-                    if (numProbes >= _capacity)
+#if DEBUG
+                if ( numProbes >= 100 )
+                    throw new InvalidOperationException("The hash function used for this object is not good enough. The distribution is causing clusters and causing huge slowdowns.");
+#else
+                    if (numProbes >= capacity)
                         break;
+#endif
                 }
-                while (nHash != KUnusedHash);
+                while (true);
 
+                ReturnFalse:
                 return ThrowWhenKeyNotFound();
+
+                PartialHit:
+                if (!_comparer.Equals(entries[bucket].Key, key))
+                {
+                    // PERF: This can happen with a very^3 low probability (assuming your hash function is good enough)
+                    bucket = (bucket + numProbes) & _capacityMask;
+                    numProbes++;
+                    goto Loop;
+                }
+
+                return entries[bucket].Value;
             }
+
             [MethodImpl(MethodImplOptions.AggressiveInlining)]
             set
             {
@@ -377,44 +413,60 @@ namespace Sparrow.Collections
 
                 ResizeIfNeeded();
 
-                int hash = GetInternalHashCode(key);
+                int hash = GetInternalHashCode(key); // PERF: This goes first because it can consume lots of registers.
+                uint uhash = (uint)hash;
+
+                var entries = _entries;
+
+                int numProbes = 1;
+                int capacity = _capacity;
                 int bucket = hash & _capacityMask;
 
-                uint uhash = (uint)hash;
-                int numProbes = 1;
+                Loop:
                 do
                 {
-                    uint nHash = _entries[bucket].Hash;
+                    uint nHash = entries[bucket].Hash;
                     if (nHash == KUnusedHash)
                     {
                         _numberOfUsed++;
                         _size++;
-
-                        goto SET;
+                        goto Set;
                     }
                     if (nHash == KDeletedHash)
                     {
                         _numberOfDeleted--;
                         _size++;
+                        goto Set;
+                    }
 
-                        goto SET;
-                    }
-                    else
-                    {
-                        if (nHash == uhash && _comparer.Equals(_entries[bucket].Key, key))
-                            goto SET;
-                    }
+                    if (nHash == uhash)
+                        goto PartialHit;
 
                     bucket = (bucket + numProbes) & _capacityMask;
                     numProbes++;
 
-                    //Debug.Assert(numProbes < 100);
-                    if (numProbes >= _capacity)
+#if DEBUG
+                if ( numProbes >= 100 )
+                    throw new InvalidOperationException("The hash function used for this object is not good enough. The distribution is causing clusters and causing huge slowdowns.");
+#else
+                    if (numProbes >= capacity)
                         break;
+#endif
                 }
                 while (true);
 
-            SET:
+                // PERF: If it happens, it should be rare therefore outside of the critical path. 
+                PartialHit:
+                if (!_comparer.Equals(entries[bucket].Key, key))
+                {
+                    // PERF: This can happen with a very^3 low probability (assuming your hash function is good enough)
+                    bucket = (bucket + numProbes) & _capacityMask;
+                    numProbes++;
+                    goto Loop;
+                }
+
+                Set:
+
                 this._entries[bucket].Hash = uhash;
                 this._entries[bucket].Key = key;
                 this._entries[bucket].Value = value;
@@ -491,7 +543,7 @@ namespace Sparrow.Collections
 #endif                
             }
             while (true);
-            
+
             ReturnFalse:
             value = default(TValue);
             return false;
@@ -504,7 +556,7 @@ namespace Sparrow.Collections
                 numProbes++;
                 goto Loop;
             }
-                
+
             value = entries[bucket].Value;
             return true;
         }
@@ -517,31 +569,48 @@ namespace Sparrow.Collections
         [MethodImpl(MethodImplOptions.AggressiveInlining)]
         private int Lookup(TKey key)
         {
-            int hash = GetInternalHashCode(key);
-            int bucket = hash & _capacityMask;
+            int hash = GetInternalHashCode(key); // PERF: This goes first because it can consume lots of registers.
 
             var entries = _entries;
 
-            uint uhash = (uint)hash;
-            int numProbes = 1; // how many times we've probed
+            int numProbes = 1;
+            int capacity = _capacity;
+            int bucket = hash & _capacityMask;
 
-            uint nHash;
+            Loop:
             do
             {
-                nHash = entries[bucket].Hash;
-                if (nHash == uhash && _comparer.Equals(entries[bucket].Key, key))
-                    return bucket;
+                uint nHash = entries[bucket].Hash;
+                if (nHash == KUnusedHash)
+                    goto ReturnFalse;
+                if (nHash == hash)
+                    goto PartialHit;
 
-                bucket = ((bucket + numProbes) & _capacityMask);
+                bucket = (bucket + numProbes) & _capacityMask;
                 numProbes++;
 
-                //Debug.Assert(numProbes < 100);
-                if (numProbes >= _capacity)
+#if DEBUG       
+                if ( numProbes >= 100 )
+                    throw new InvalidOperationException("The hash function used for this object is not good enough. The distribution is causing clusters and causing huge slowdowns.");
+#else
+                if (numProbes >= capacity)
                     break;
+#endif                
             }
-            while (nHash != KUnusedHash);
+            while (true);
 
-            return InvalidNodePosition;
+            ReturnFalse: return InvalidNodePosition;
+
+            PartialHit:
+            if (!_comparer.Equals(entries[bucket].Key, key))
+            {
+                // PERF: This can happen with a very^3 low probability (assuming your hash function is good enough)
+                bucket = (bucket + numProbes) & _capacityMask;
+                numProbes++;
+                goto Loop;
+            }
+
+            return bucket;
         }
 
         [MethodImpl(MethodImplOptions.AggressiveInlining)]

--- a/src/Sparrow/Collections/ZFastNodesTable.cs
+++ b/src/Sparrow/Collections/ZFastNodesTable.cs
@@ -721,7 +721,7 @@ namespace Sparrow.Collections
                         uint hash = Hashing.Iterative.XXHash32.CalculateInline((byte*)bitsPtr, words * sizeof(ulong), state, lcp / BitVector.BitsPerByte);
 
                         remainingWord = ((remainingWord) >> shift) << shift;
-                        ulong intermediate = Hashing.CombineInline(remainingWord, ((ulong)remaining) << 32 | (ulong)hash);
+                        ulong intermediate = Hashing.Combine(remainingWord, ((ulong)remaining) << 32 | (ulong)hash);
 
                         hash = (uint)intermediate ^ (uint)(intermediate >> 32);
 

--- a/src/Sparrow/Comparers.cs
+++ b/src/Sparrow/Comparers.cs
@@ -17,7 +17,7 @@ namespace Sparrow
         [MethodImpl(MethodImplOptions.AggressiveInlining)]
         public int GetHashCode(long obj)
         {
-            return unchecked((int)obj ^ (int)(obj >> 32));
+            return Hashing.Combine((int)(obj >> 32), (int)obj);
         }
 
         [MethodImpl(MethodImplOptions.AggressiveInlining)]
@@ -41,7 +41,7 @@ namespace Sparrow
         [MethodImpl(MethodImplOptions.AggressiveInlining)]
         public int GetHashCode(ulong obj)
         {
-            return unchecked((int)obj ^ (int)(obj >> 32));
+            return Hashing.Combine((int)(obj >> 32), (int)obj);
         }
     }
 
@@ -56,7 +56,7 @@ namespace Sparrow
         [MethodImpl(MethodImplOptions.AggressiveInlining)]
         public int GetHashCode(long obj)
         {
-            return unchecked((int)obj ^ (int)(obj >> 32));
+            return Hashing.Mix(obj);
         }
 
         [MethodImpl(MethodImplOptions.AggressiveInlining)]
@@ -80,7 +80,7 @@ namespace Sparrow
         [MethodImpl(MethodImplOptions.AggressiveInlining)]
         public int GetHashCode(ulong obj)
         {
-            return unchecked((int)obj ^ (int)(obj >> 32));
+            return (int) Hashing.Mix(obj);
         }
     }
 

--- a/src/Sparrow/Hashing.cs
+++ b/src/Sparrow/Hashing.cs
@@ -478,40 +478,71 @@ namespace Sparrow
 
         #region Downsampling Hashing
 
-        public static int Combine(int x, int y)
+        public static class HashCombiner
         {
-            return CombineInline(x, y);
+            public static int Combine(int x, int y)
+            {
+                return CombineInline(x, y);
+            }
+
+            public static uint Combine(uint x, uint y)
+            {
+                return CombineInline(x, y);
+            }
+
+            public static long Combine(long x, long y)
+            {
+                return CombineInline(x, y);
+            }
+
+            public static ulong Combine(ulong x, ulong y)
+            {
+                return CombineInline(x, y);
+            }
+
+            [MethodImpl(MethodImplOptions.AggressiveInlining)]
+            public static int CombineInline(int x, int y)
+            {
+                // The jit optimizes this to use the ROL instruction on x86
+                // Related GitHub pull request: dotnet/coreclr#1830
+                uint shift5 = ((uint)x << 5) | ((uint)x >> 27);
+                return ((int)shift5 + x) ^ y;
+            }
+
+            [MethodImpl(MethodImplOptions.AggressiveInlining)]
+            public static uint CombineInline(uint x, uint y)
+            {
+                // The jit optimizes this to use the ROL instruction on x86
+                // Related GitHub pull request: dotnet/coreclr#1830
+                uint shift5 = (x << 5) | (x >> 27);
+                return (shift5 + x) ^ y;
+            }
+
+            [MethodImpl(MethodImplOptions.AggressiveInlining)]
+            public static long CombineInline(long x, long y)
+            {
+                // The jit optimizes this to use the ROL instruction on x86
+                // Related GitHub pull request: dotnet/coreclr#1830
+                ulong ux = (ulong)x;
+                ulong shift5 = (ux << 10) | (ux >> 54);
+                return (long) (shift5 + ux) ^ y;
+            }
+
+            [MethodImpl(MethodImplOptions.AggressiveInlining)]
+            public static ulong CombineInline(ulong x, ulong y)
+            {
+                // The jit optimizes this to use the ROL instruction on x86
+                // Related GitHub pull request: dotnet/coreclr#1830
+                ulong shift5 = (x << 10) | (x >> 54);
+                return (shift5 + x) ^ y;
+            }
         }
 
-        public static uint Combine(uint x, uint y)
-        {
-            return CombineInline(x, y);
-        }
-
-
-        public static long Combine(long x, long y)
-        {
-            return CombineInline(x, y);
-        }
-
-        public static ulong Combine(ulong x, ulong y)
-        {
-            return CombineInline(x, y);
-        }
-
-        [MethodImpl(MethodImplOptions.AggressiveInlining)]
-        public static int CombineInline(int x, int y)
-        {
-            // The jit optimizes this to use the ROL instruction on x86
-            // Related GitHub pull request: dotnet/coreclr#1830
-            uint shift5 = ((uint)x << 5) | ((uint)x >> 27);
-            return ((int)shift5 + x) ^ y;
-        }
 
         private static readonly ulong kMul = 0x9ddfea08eb382d69UL;
 
         [MethodImpl(MethodImplOptions.AggressiveInlining)]
-        public static ulong CombineInline(ulong x, ulong y)
+        public static ulong Combine(ulong x, ulong y)
         {
             // This is the Hash128to64 function from Google's CityHash (available
             // under the MIT License).  We use it to reduce multiple 64 bit hashes
@@ -528,7 +559,7 @@ namespace Sparrow
         }
 
         [MethodImpl(MethodImplOptions.AggressiveInlining)]
-        public static long CombineInline(long upper, long lower)
+        public static long Combine(long upper, long lower)
         {
             // This is the Hash128to64 function from Google's CityHash (available
             // under the MIT License).  We use it to reduce multiple 64 bit hashes
@@ -544,16 +575,60 @@ namespace Sparrow
             b ^= (b >> 47);
             b *= kMul;
 
-            return (long) b;
+            return (long)b;
         }
 
         [MethodImpl(MethodImplOptions.AggressiveInlining)]
-        public static uint CombineInline(uint x, uint y)
+        public static uint Mix(ulong key)
         {
-            // The jit optimizes this to use the ROL instruction on x86
-            // Related GitHub pull request: dotnet/coreclr#1830
-            uint shift5 = (x << 5) | (x >> 27);
-            return (shift5 + x) ^ y;
+            key = (~key) + (key << 18); // key = (key << 18) - key - 1;
+            key = key ^ (key >> 31);
+            key = key * 21; // key = (key + (key << 2)) + (key << 4);
+            key = key ^ (key >> 11);
+            key = key + (key << 6);
+            key = key ^ (key >> 22);
+            return (uint)key;
+        }
+
+        [MethodImpl(MethodImplOptions.AggressiveInlining)]
+        public static int Mix(long key)
+        {
+            key = (~key) + (key << 18); // key = (key << 18) - key - 1;
+            key = key ^ (key >> 31);
+            key = key * 21; // key = (key + (key << 2)) + (key << 4);
+            key = key ^ (key >> 11);
+            key = key + (key << 6);
+            key = key ^ (key >> 22);
+            return (int)key;
+        }
+
+        [MethodImpl(MethodImplOptions.AggressiveInlining)]
+        public static uint Combine(uint upper, uint lower)
+        {
+            ulong key = ((ulong)upper << 32) | lower;
+
+            key = (~key) + (key << 18); // key = (key << 18) - key - 1;
+            key = key ^ (key >> 31);
+            key = key * 21; // key = (key + (key << 2)) + (key << 4);
+            key = key ^ (key >> 11);
+            key = key + (key << 6);
+            key = key ^ (key >> 22);
+            return (uint)key;
+        }
+
+        [MethodImpl(MethodImplOptions.AggressiveInlining)]
+        public static int Combine(int upper, int lower)
+        {
+            ulong x = (uint)upper; // Ensure we do not mess up with the sign extend.
+            ulong key = (x << 32) | (uint)lower;
+
+            key = (~key) + (key << 18); // key = (key << 18) - key - 1;
+            key = key ^ (key >> 31);
+            key = key * 21; // key = (key + (key << 2)) + (key << 4);
+            key = key ^ (key >> 11);
+            key = key + (key << 6);
+            key = key ^ (key >> 22);
+            return (int)key;
         }
 
         #endregion

--- a/src/Sparrow/Json/CachedProperties.cs
+++ b/src/Sparrow/Json/CachedProperties.cs
@@ -223,7 +223,7 @@ namespace Sparrow.Json
             int hash = 0;
             for (int i = 0; i < count; i++)
             {
-                hash = Hashing.CombineInline(hash, properties[i].Property.HashCode);
+                hash = Hashing.HashCombiner.CombineInline(hash, properties[i].Property.HashCode);
             }
 
             Debug.Assert(_cachedSorts.Length == CachedSortsSize && Bits.NextPowerOf2(CachedSortsSize) == CachedSortsSize); 

--- a/src/Sparrow/StringSegment.cs
+++ b/src/Sparrow/StringSegment.cs
@@ -76,7 +76,7 @@ namespace Sparrow
             uint hash = 0;
             for (int i = 0; i < xSize; i++)
             {
-                hash = Hashing.CombineInline(hash, xStr[xStart + i]);
+                hash = Hashing.Combine(hash, xStr[xStart + i]);
             }
 
             return (int)hash;

--- a/src/Voron/SliceComparer.cs
+++ b/src/Voron/SliceComparer.cs
@@ -89,7 +89,13 @@ namespace Voron
         [MethodImpl(MethodImplOptions.AggressiveInlining)]
         int IEqualityComparer<Slice>.GetHashCode(Slice obj)
         {
-            return obj.GetHashCode();
+            unsafe
+            {
+                byte* ptr = obj.Content.Ptr;
+                int size = obj.Content.Length;
+
+                return (int)Hashing.Marvin32.CalculateInline(ptr, size);
+            }
         }
 
         public static unsafe bool StartWith(Slice value, Slice prefix)
@@ -153,7 +159,13 @@ namespace Voron
         [MethodImpl(MethodImplOptions.AggressiveInlining)]
         public int GetHashCode(Slice obj)
         {
-            return obj.GetHashCode();
+            unsafe
+            {
+                byte* ptr = obj.Content.Ptr;
+                int size = obj.Content.Length;
+
+                return (int)Hashing.Marvin32.CalculateInline(ptr, size);
+            }
         }
     }
 }

--- a/test/FastTests/Sparrow/Hashing.cs
+++ b/test/FastTests/Sparrow/Hashing.cs
@@ -292,8 +292,8 @@ namespace FastTests.Sparrow
         [Fact]
         public void Combine()
         {
-            int h1 = Hashing.CombineInline(1991, 13);
-            int h2 = Hashing.CombineInline(1991, 12);
+            int h1 = Hashing.HashCombiner.CombineInline(1991, 13);
+            int h2 = Hashing.HashCombiner.CombineInline(1991, 12);
             Assert.NotEqual(h1, h2);
         }
 


### PR DESCRIPTION
RavenDB-6692: Fixed Add can create duplicates using the same code as ```this[key] = value```.

Improved code for other lookup and set operations too.