### PR TITLE
[3.0] Revert "RavenDB-6588 Very old active read transaction is left open. I…

### DIFF
--- a/Raven.Database/Storage/Esent/StorageActions/General.cs
+++ b/Raven.Database/Storage/Esent/StorageActions/General.cs
@@ -21,7 +21,7 @@ using Raven.Storage.Esent;
 namespace Raven.Database.Storage.Esent.StorageActions
 {
     [CLSCompliant(false)]
-    public partial class DocumentStorageActions : IGeneralStorageActions
+    public partial class DocumentStorageActions : IDisposable, IGeneralStorageActions
     {
         public event Action OnStorageCommit = delegate { };
         public event Action BeforeStorageCommit;

--- a/Raven.Database/Storage/IGeneralStorageActions.cs
+++ b/Raven.Database/Storage/IGeneralStorageActions.cs
@@ -8,7 +8,7 @@ using System.Collections.Generic;
 
 namespace Raven.Database.Storage
 {
-    public interface IGeneralStorageActions : IDisposable
+    public interface IGeneralStorageActions
     {
         long GetNextIdentityValue(string name, int val = 1);
         void SetIdentityValue(string name, long value);

--- a/Raven.Database/Storage/Voron/StorageActions/GeneralStorageActions.cs
+++ b/Raven.Database/Storage/Voron/StorageActions/GeneralStorageActions.cs
@@ -154,11 +154,5 @@ namespace Raven.Database.Storage.Voron.StorageActions
         {
             return MaybePulseTransaction(null, addToPulseCount, beforePulseTransaction);
         }
-
-        public void Dispose()
-        {
-            if (snapshot.Value != null)
-                snapshot.Value.Dispose();
-        }
     }
 }

--- a/Raven.Database/Storage/Voron/StorageActionsAccessor.cs
+++ b/Raven.Database/Storage/Voron/StorageActionsAccessor.cs
@@ -44,7 +44,6 @@ namespace Raven.Database.Storage.Voron
 
         public void Dispose()
         {
-            General.Dispose();
             var onDispose = OnDispose;
             if (onDispose != null)
                 onDispose();


### PR DESCRIPTION
… found only when case when it might be possible. We create a snapshot which have read tx and we dispose the tx only when calling MaybePulseTransaction which might not be called. So I made sure to always dispose the current snapshot in the Dispose method."

This reverts commit 9035487fdfa5fcb63c18851b4d03a52f8831f27a.

No need as we do dispose the snapshotReference.