### PR TITLE
RavenDB-6725 Introducing SetRequiredPrefix method so we won't need to…

### DIFF
--- a/src/Raven.Server/Documents/DocumentsStorage.cs
+++ b/src/Raven.Server/Documents/DocumentsStorage.cs
@@ -1929,7 +1929,7 @@ namespace Raven.Server.Documents
 
             using (var it = transaction.LowLevelTransaction.RootObjects.Iterate(false))
             {
-                it.RequiredPrefix = TombstonesPrefix.Clone(transaction.Allocator);
+                it.SetRequiredPrefix(TombstonesPrefix);
 
                 if (it.Seek(TombstonesPrefix) == false)
                     yield break;

--- a/src/Raven.Server/Documents/Indexes/Debugging/IndexDebugExtensions.cs
+++ b/src/Raven.Server/Documents/Indexes/Debugging/IndexDebugExtensions.cs
@@ -107,7 +107,7 @@ namespace Raven.Server.Documents.Indexes.Debugging
             Slice prefixSlice;
             scope = Slice.From(context.Transaction.InnerTransaction.Allocator, prefix, out prefixSlice);
 
-            it.RequiredPrefix = prefixSlice;
+            it.SetRequiredPrefix(prefixSlice);
 
             if (it.Seek(prefixSlice))
                 return true;
@@ -115,7 +115,7 @@ namespace Raven.Server.Documents.Indexes.Debugging
             scope.Value.Dispose();
             scope = null;
 
-            it.RequiredPrefix = default(Slice);
+            it.SetRequiredPrefix(Slices.Empty);
 
             if (it.Seek(Slices.BeforeAllKeys) == false)
                 return false;
@@ -146,7 +146,7 @@ namespace Raven.Server.Documents.Indexes.Debugging
 
             scope = Slice.From(context.Transaction.InnerTransaction.Allocator, prefix, out prefixSlice);
 
-            it.RequiredPrefix = prefixSlice;
+            it.SetRequiredPrefix(prefixSlice);
 
             if (it.Seek(prefixSlice) == false)
             {

--- a/src/Voron/Data/BTrees/TreeIterator.cs
+++ b/src/Voron/Data/BTrees/TreeIterator.cs
@@ -249,14 +249,16 @@ namespace Voron.Data.BTrees
         }
 
         private Slice _requiredPrefix;
+
         public Slice RequiredPrefix
         {
             get { return _requiredPrefix; }
-            set
-            {
-                _requiredPrefix = value;
-                _requireValidation = _maxKey.HasValue || _requiredPrefix.HasValue;
-            }
+        }
+
+        public void SetRequiredPrefix(Slice prefix)
+        {
+            _requiredPrefix = prefix.Clone(_tx.Allocator); // make sure the prefix slice won't become invalid during iterator usage
+            _requireValidation = _maxKey.HasValue || _requiredPrefix.HasValue;
         }
 
         private Slice _maxKey;

--- a/src/Voron/Data/BTrees/TreePageIterator.cs
+++ b/src/Voron/Data/BTrees/TreePageIterator.cs
@@ -31,6 +31,10 @@ namespace Voron.Data.BTrees
         {
             _disposed = true;
             _prevScopeDispose.Dispose();
+
+            if (RequiredPrefix.HasValue)
+                RequiredPrefix.Release(_tx.Allocator);
+
             OnDisposal?.Invoke(this);
         }
 
@@ -96,11 +100,13 @@ namespace Voron.Data.BTrees
         public Slice RequiredPrefix
         {
             get { return _requiredPrefix; }
-            set
-            {
-                _requiredPrefix = value;
-                _requireValidation = _maxKey.HasValue || _requiredPrefix.HasValue;
-            }
+            
+        }
+
+        public void SetRequiredPrefix(Slice prefix)
+        {
+            _requiredPrefix = prefix.Clone(_tx.Allocator); // make sure the prefix slice won't become invalid during iterator usage
+            _requireValidation = _maxKey.HasValue || _requiredPrefix.HasValue;
         }
 
         private Slice _maxKey;

--- a/src/Voron/Data/EmptyIterator.cs
+++ b/src/Voron/Data/EmptyIterator.cs
@@ -57,7 +57,10 @@ namespace Voron.Data
         public Slice RequiredPrefix
         {
             get;
-            set;
+        }
+
+        public void SetRequiredPrefix(Slice prefix)
+        {
         }
 
         public bool MoveNext()

--- a/src/Voron/Data/IIterator.cs
+++ b/src/Voron/Data/IIterator.cs
@@ -7,13 +7,14 @@ namespace Voron.Data
         bool DoRequireValidation { get; }
 
         Slice CurrentKey { get; }
-        Slice RequiredPrefix { get; set; }
+        Slice RequiredPrefix { get; }
         Slice MaxKey { get; set; }
 
         bool Seek(Slice key);
         bool MoveNext();
         bool MovePrev();
         bool Skip(int count);
+        void SetRequiredPrefix(Slice prefix);
 
         ValueReader CreateReaderForCurrent();
         int GetCurrentDataSize();

--- a/src/Voron/Data/Tables/Table.cs
+++ b/src/Voron/Data/Tables/Table.cs
@@ -761,7 +761,7 @@ namespace Voron.Data.Tables
             using (var it = tree.Iterate(false))
             {
                 if (startsWith)
-                    it.RequiredPrefix = value.Clone(_tx.Allocator);
+                    it.SetRequiredPrefix(value);
 
                 if (it.Seek(value) == false)
                     yield break;
@@ -797,7 +797,7 @@ namespace Voron.Data.Tables
                 if (it.Seek(last) == false && it.Seek(Slices.AfterAllKeys) == false)
                     yield break;
 
-                it.RequiredPrefix = prefix.Clone(_tx.Allocator);
+                it.SetRequiredPrefix(prefix);
                 if (SliceComparer.StartWith(it.CurrentKey, it.RequiredPrefix) == false)
                 {
                     if (it.MovePrev() == false)
@@ -858,7 +858,7 @@ namespace Voron.Data.Tables
             var tree = GetTree(pk);
             using (var it = tree.Iterate(false))
             {
-                it.RequiredPrefix = requiredPrefix.Clone(_tx.Allocator);
+                it.SetRequiredPrefix(requiredPrefix);
 
                 var seekValue = isStartAfter ? startAfter : requiredPrefix;
                 if (it.Seek(seekValue) == false)
@@ -929,7 +929,7 @@ namespace Voron.Data.Tables
             var tree = GetTree(pk);
             using (var it = tree.Iterate(false))
             {
-                it.RequiredPrefix = slice.Clone(_tx.Allocator);
+                it.SetRequiredPrefix(slice);
 
                 if (it.Seek(slice) == false)
                 {
@@ -1108,7 +1108,7 @@ namespace Voron.Data.Tables
             {
                 using (var it = tree.Iterate(false))
                 {
-                    it.RequiredPrefix = startSlice.Clone(_tx.Allocator);
+                    it.SetRequiredPrefix(startSlice);
                     if (it.Seek(it.RequiredPrefix) == false)
                         return;
 
@@ -1145,7 +1145,7 @@ namespace Voron.Data.Tables
                 using (var it = tree.Iterate(false))
                 {
                     if (startsWith)
-                        it.RequiredPrefix = value.Clone(_tx.Allocator);
+                        it.SetRequiredPrefix(value);
                     if (it.Seek(value) == false)
                         return deleted;
 


### PR DESCRIPTION
… remeber that the prefix requires to be clonned (the prefix slice passed here can become invalid during iteration because of page defrag for instance). The clonned instance is released in the iterator's dispose method.