### PR TITLE
RavenDB-6771 Use index.GetErrorCount to avoid string allocations when…

### DIFF
--- a/src/Raven.Server/Documents/DocumentDatabase.cs
+++ b/src/Raven.Server/Documents/DocumentDatabase.cs
@@ -417,7 +417,7 @@ namespace Raven.Server.Documents
                     [nameof(Size.HumaneSize)] = size.HumaneSize,
                     [nameof(Size.SizeInBytes)] = size.SizeInBytes
                 },
-                [nameof(DatabaseInfo.IndexingErrors)] = IndexStore.GetIndexes().Sum(index => index.GetErrors().Count),
+                [nameof(DatabaseInfo.IndexingErrors)] = IndexStore.GetIndexes().Sum(index => index.GetErrorCount()),
                 [nameof(DatabaseInfo.Alerts)] = NotificationCenter.GetAlertCount(),
                 [nameof(DatabaseInfo.UpTime)] = null, //it is shutting down
                 [nameof(DatabaseInfo.BackupInfo)] = BundleLoader.GetBackupInfo(),

--- a/src/Raven.Server/Documents/Indexes/Index.cs
+++ b/src/Raven.Server/Documents/Indexes/Index.cs
@@ -1096,6 +1096,14 @@ namespace Raven.Server.Documents.Indexes
             return _indexStorage.ReadErrors();
         }
 
+        public long GetErrorCount()
+        {
+            if (_isCompactionInProgress)
+                return 0;
+
+            return _indexStorage.ReadErrorsCount();
+        }
+
         public virtual void SetPriority(IndexPriority priority)
         {
             if (Definition.Priority == priority)

--- a/src/Raven.Server/Documents/Indexes/IndexStorage.cs
+++ b/src/Raven.Server/Documents/Indexes/IndexStorage.cs
@@ -213,6 +213,17 @@ namespace Raven.Server.Documents.Indexes
             return errors;
         }
 
+        public long ReadErrorsCount()
+        {
+            TransactionOperationContext context;
+            using (_contextPool.AllocateOperationContext(out context))
+            using (var tx = context.OpenReadTransaction())
+            {
+                var table = tx.InnerTransaction.OpenTable(_errorsSchema, "Errors");
+                return table.NumberOfEntries;
+            }
+        }
+
         public DateTime? ReadLastIndexingTime(RavenTransaction tx)
         {
             var statsTree = tx.InnerTransaction.ReadTree(IndexSchema.StatsTree);

--- a/src/Raven.Server/NotificationCenter/BackgroundWork/DatabaseStatsSender.cs
+++ b/src/Raven.Server/NotificationCenter/BackgroundWork/DatabaseStatsSender.cs
@@ -43,7 +43,7 @@ namespace Raven.Server.NotificationCenter.BackgroundWork
                     {
                         var indexes = _database.IndexStore.GetIndexes().ToList();
                         var staleIndexes = 0;
-                        var countOfIndexingErrors = 0;
+                        var countOfIndexingErrors = 0L;
 
                         // ReSharper disable once LoopCanBeConvertedToQuery
                         foreach (var index in indexes)
@@ -51,7 +51,7 @@ namespace Raven.Server.NotificationCenter.BackgroundWork
                             if (index.IsStale(context))
                                 staleIndexes++;
 
-                            countOfIndexingErrors += index.GetErrors().Count;
+                            countOfIndexingErrors += index.GetErrorCount();
                         }
 
                         current = new Stats

--- a/src/Raven.Server/Web/Studio/StudioStatsHandler.cs
+++ b/src/Raven.Server/Web/Studio/StudioStatsHandler.cs
@@ -36,7 +36,7 @@ namespace Raven.Server.Web.Studio
                 writer.WriteComma();
 
                 writer.WritePropertyName(nameof(FooterStatistics.CountOfIndexingErrors));
-                writer.WriteInteger(indexes.Sum(index => index.GetErrors().Count));
+                writer.WriteInteger(indexes.Sum(index => index.GetErrorCount()));
 
                 writer.WriteEndObject();
             }

--- a/src/Raven.Server/Web/System/DatabasesHandler.cs
+++ b/src/Raven.Server/Web/System/DatabasesHandler.cs
@@ -135,7 +135,7 @@ namespace Raven.Server.Web.System
                     [nameof(Size.SizeInBytes)] = size.SizeInBytes
                 },
                 [nameof(DatabaseInfo.IndexingErrors)] = online
-                    ? db.IndexStore.GetIndexes().Sum(index => index.GetErrors().Count)
+                    ? db.IndexStore.GetIndexes().Sum(index => index.GetErrorCount())
                     : 0,
                 [nameof(DatabaseInfo.Alerts)] = online ? db.NotificationCenter.GetAlertCount() : 0,
                 [nameof(DatabaseInfo.UpTime)] = online ? GetUptime(db).ToString() : null,

--- a/test/FastTests/Server/Documents/Indexing/Auto/BasicAutoMapIndexing.cs
+++ b/test/FastTests/Server/Documents/Indexing/Auto/BasicAutoMapIndexing.cs
@@ -921,6 +921,7 @@ namespace FastTests.Server.Documents.Indexing.Auto
                     index._indexStorage.UpdateStats(SystemTime.UtcNow, stats);
 
                     Assert.Equal(0, index.GetErrors().Count);
+                    Assert.Equal(0, index.GetErrorCount());
 
                     stats.AddWriteError(new IndexWriteException());
                     stats.AddAnalyzerError(new IndexAnalyzerException());
@@ -942,6 +943,7 @@ namespace FastTests.Server.Documents.Indexing.Auto
 
                     errors = index.GetErrors();
                     Assert.Equal(IndexStorage.MaxNumberOfKeptErrors, errors.Count);
+                    Assert.Equal(index.GetErrorCount(), errors.Count);
                 }
             }
         }

--- a/test/SlowTests/Bugs/AccessingHostPropertyOnUri.cs
+++ b/test/SlowTests/Bugs/AccessingHostPropertyOnUri.cs
@@ -90,7 +90,7 @@ namespace SlowTests.Bugs
                 WaitForIndexing(store);
 
                 var db = GetDocumentDatabaseInstanceFor(store).Result;
-                var errorsCount = db.IndexStore.GetIndexes().Sum(index => index.GetErrors().Count);
+                var errorsCount = db.IndexStore.GetIndexes().Sum(index => index.GetErrorCount());
 
                 Assert.Equal(errorsCount, 0);
             }

--- a/test/SlowTests/Bugs/ArrayOfMaybeNull.cs
+++ b/test/SlowTests/Bugs/ArrayOfMaybeNull.cs
@@ -75,7 +75,7 @@ namespace SlowTests.Bugs
                         .ToList();
 
                     var db = GetDocumentDatabaseInstanceFor(store).Result;
-                    var errorsCount = db.IndexStore.GetIndexes().Sum(index => index.GetErrors().Count);
+                    var errorsCount = db.IndexStore.GetIndexes().Sum(index => index.GetErrorCount());
 
                     Assert.Equal(errorsCount, 0);
 

--- a/test/SlowTests/Bugs/Errors/CanIndexOnNull.cs
+++ b/test/SlowTests/Bugs/Errors/CanIndexOnNull.cs
@@ -38,7 +38,7 @@ namespace SlowTests.Bugs.Errors
                 }
 
                 var db = GetDocumentDatabaseInstanceFor(store).Result;
-                var errorsCount = db.IndexStore.GetIndexes().Sum(index => index.GetErrors().Count);
+                var errorsCount = db.IndexStore.GetIndexes().Sum(index => index.GetErrorCount());
 
                 Assert.Equal(errorsCount, 0);
             }

--- a/test/SlowTests/Bugs/Indexing/CanMultiMapIndexNullableValueTypes.cs
+++ b/test/SlowTests/Bugs/Indexing/CanMultiMapIndexNullableValueTypes.cs
@@ -49,7 +49,7 @@ namespace SlowTests.Bugs.Indexing
                 }
 
                 var db = GetDocumentDatabaseInstanceFor(store).Result;
-                var errorsCount = db.IndexStore.GetIndexes().Sum(index => index.GetErrors().Count);
+                var errorsCount = db.IndexStore.GetIndexes().Sum(index => index.GetErrorCount());
 
                 Assert.Equal(errorsCount, 0);
             }

--- a/test/SlowTests/Bugs/Indexing/FilterOnMissingProperty.cs
+++ b/test/SlowTests/Bugs/Indexing/FilterOnMissingProperty.cs
@@ -35,7 +35,7 @@ namespace SlowTests.Bugs.Indexing
                 }
 
                 var db = GetDocumentDatabaseInstanceFor(store).Result;
-                var errorsCount = db.IndexStore.GetIndexes().Sum(index => index.GetErrors().Count);
+                var errorsCount = db.IndexStore.GetIndexes().Sum(index => index.GetErrorCount());
 
                 Assert.Equal(errorsCount, 0);
             }

--- a/test/SlowTests/Bugs/Indexing/ThrowingAnalyzer.cs
+++ b/test/SlowTests/Bugs/Indexing/ThrowingAnalyzer.cs
@@ -62,7 +62,7 @@ namespace SlowTests.Bugs.Indexing
                 }
 
                 var db = GetDocumentDatabaseInstanceFor(store).Result;
-                var errorsCount = db.IndexStore.GetIndexes().Sum(index => index.GetErrors().Count);
+                var errorsCount = db.IndexStore.GetIndexes().Sum(index => index.GetErrorCount());
 
                 Assert.NotEqual(errorsCount, 0);
             }
@@ -99,7 +99,7 @@ namespace SlowTests.Bugs.Indexing
                 Assert.True(fooIndex.State == IndexState.Error);
 
                 var db = GetDocumentDatabaseInstanceFor(store).Result;
-                var errorsCount = db.IndexStore.GetIndexes().Sum(index => index.GetErrors().Count);
+                var errorsCount = db.IndexStore.GetIndexes().Sum(index => index.GetErrorCount());
 
                 Assert.NotEqual(errorsCount, 0);
 

--- a/test/SlowTests/Bugs/Indexing/WithStringReverse.cs
+++ b/test/SlowTests/Bugs/Indexing/WithStringReverse.cs
@@ -58,7 +58,7 @@ namespace SlowTests.Bugs.Indexing
                         .ToList();
 
                     var db = GetDocumentDatabaseInstanceFor(store).Result;
-                    var errorsCount = db.IndexStore.GetIndexes().Sum(index => index.GetErrors().Count);
+                    var errorsCount = db.IndexStore.GetIndexes().Sum(index => index.GetErrorCount());
 
                     Assert.Equal(errorsCount, 0);
 
@@ -101,7 +101,7 @@ namespace SlowTests.Bugs.Indexing
                         .ToList();
 
                     var db = GetDocumentDatabaseInstanceFor(store).Result;
-                    var errorsCount = db.IndexStore.GetIndexes().Sum(index => index.GetErrors().Count);
+                    var errorsCount = db.IndexStore.GetIndexes().Sum(index => index.GetErrorCount());
 
                     Assert.Equal(errorsCount, 0);
 

--- a/test/SlowTests/Bugs/MapRedue/LargeKeysInVoron.cs
+++ b/test/SlowTests/Bugs/MapRedue/LargeKeysInVoron.cs
@@ -105,7 +105,7 @@ namespace SlowTests.Bugs.MapRedue
 
                 var db = GetDocumentDatabaseInstanceFor(store).Result;
                 var indexes = db.IndexStore.GetIndexes();
-                var errorsCount = indexes.Sum(index => index.GetErrors().Count);
+                var errorsCount = indexes.Sum(index => index.GetErrorCount());
 
                 Assert.Equal(errorsCount, 0);
             }

--- a/test/SlowTests/Bugs/MapRedue/LetInReduceFunction.cs
+++ b/test/SlowTests/Bugs/MapRedue/LetInReduceFunction.cs
@@ -59,7 +59,7 @@ namespace SlowTests.Bugs.MapRedue
                 WaitForIndexing(store);
 
                 var db = GetDocumentDatabaseInstanceFor(store).Result;
-                var errorsCount = db.IndexStore.GetIndexes().Sum(index => index.GetErrors().Count);
+                var errorsCount = db.IndexStore.GetIndexes().Sum(index => index.GetErrorCount());
 
                 Assert.Equal(errorsCount, 0);
             }

--- a/test/SlowTests/Bugs/MapRedue/MinMax.cs
+++ b/test/SlowTests/Bugs/MapRedue/MinMax.cs
@@ -80,7 +80,7 @@ namespace SlowTests.Bugs.MapRedue
                         .ToList();
 
                     var db = GetDocumentDatabaseInstanceFor(store).Result;
-                    var errorsCount = db.IndexStore.GetIndexes().Sum(index => index.GetErrors().Count);
+                    var errorsCount = db.IndexStore.GetIndexes().Sum(index => index.GetErrorCount());
 
                     Assert.Equal(0, errorsCount);
 

--- a/test/SlowTests/Bugs/MultiMap/MultiMapWithCustomProperties.cs
+++ b/test/SlowTests/Bugs/MultiMap/MultiMapWithCustomProperties.cs
@@ -25,7 +25,7 @@ namespace SlowTests.Bugs.MultiMap
                 WaitForIndexing(store);
 
                 var db = GetDocumentDatabaseInstanceFor(store).Result;
-                var errorsCount = db.IndexStore.GetIndexes().Sum(index => index.GetErrors().Count);
+                var errorsCount = db.IndexStore.GetIndexes().Sum(index => index.GetErrorCount());
 
                 Assert.Equal(errorsCount, 0);
 

--- a/test/SlowTests/Bugs/MultiMap/MultiMapWithNullableEnum.cs
+++ b/test/SlowTests/Bugs/MultiMap/MultiMapWithNullableEnum.cs
@@ -26,7 +26,7 @@ namespace SlowTests.Bugs.MultiMap
                 WaitForIndexing(store);
 
                 var db = GetDocumentDatabaseInstanceFor(store).Result;
-                var errorsCount = db.IndexStore.GetIndexes().Sum(index => index.GetErrors().Count);
+                var errorsCount = db.IndexStore.GetIndexes().Sum(index => index.GetErrorCount());
 
                 Assert.Equal(errorsCount, 0);
 

--- a/test/SlowTests/Bugs/MultiMap/MultiMapWithNullableEnumAndCoalescingOperator.cs
+++ b/test/SlowTests/Bugs/MultiMap/MultiMapWithNullableEnumAndCoalescingOperator.cs
@@ -26,7 +26,7 @@ namespace SlowTests.Bugs.MultiMap
                 WaitForIndexing(store);
 
                 var db = GetDocumentDatabaseInstanceFor(store).Result;
-                var errorsCount = db.IndexStore.GetIndexes().Sum(index => index.GetErrors().Count);
+                var errorsCount = db.IndexStore.GetIndexes().Sum(index => index.GetErrorCount());
 
                 Assert.Equal(errorsCount, 0);
 


### PR DESCRIPTION
… only number of errors is needed