### PR TITLE
RavenDB-6769 Removing unnecessary incremental of pager's state refere…

### DIFF
--- a/src/Voron/Impl/Scratch/ScratchBufferPool.cs
+++ b/src/Voron/Impl/Scratch/ScratchBufferPool.cs
@@ -172,7 +172,6 @@ namespace Voron.Impl.Scratch
 
             try
             {
-                current.File.PagerState.AddRef();
                 tx.EnsurePagerStateReference(current.File.PagerState);
 
                 return current.File.Allocate(tx, numberOfPages, size);


### PR DESCRIPTION
…nce.  We don't need to call it explicitly here because a reference it's added inside EnsurePagerStateReference.