### PR TITLE
fix support of OfType with Select

### DIFF
--- a/src/Raven.Client/Documents/Indexes/ExpressionStringBuilder.cs
+++ b/src/Raven.Client/Documents/Indexes/ExpressionStringBuilder.cs
@@ -1524,21 +1524,22 @@ namespace Raven.Client.Documents.Indexes
                     }
                     Visit(node.Arguments[num2]);
                     _avoidDuplicatedParameters = oldAvoidDuplicateParameters;
-                    // Convert OfType<Foo>() to Where(x => x["$type"] == typeof(Foo).AssemblyQualifiedName)
-                    if (node.Method.Name == "OfType")
-                    {
-                        var type = node.Method.GetGenericArguments()[0];
-                        var typeFullName = ReflectionUtil.GetFullNameWithoutVersionInformation(type);
-                        Out(", (Func<dynamic, bool>)(_itemRaven => string.Equals(_itemRaven[\"$type\"], \"");
-                        Out(typeFullName);
-                        Out("\", StringComparison.Ordinal))");
-                    }
                 }
                 finally
                 {
                     castLambdas = old;
                 }
                 num2++;
+            }
+
+            // Convert OfType<Foo>() to Where(x => x["$type"] == typeof(Foo).AssemblyQualifiedName)
+            if (node.Method.Name == "OfType")
+            {
+                var type = node.Method.GetGenericArguments()[0];
+                var typeFullName = ReflectionUtil.GetFullNameWithoutVersionInformation(type);
+                Out("_itemRaven => string.Equals(_itemRaven[\"$type\"], \"");
+                Out(typeFullName);
+                Out("\", StringComparison.Ordinal)");
             }
 
             if (node.Method.Name == nameof(AbstractIndexCreationTask.LoadDocument))
@@ -1650,6 +1651,7 @@ namespace Raven.Client.Documents.Indexes
                     case "Reverse":
                     case "Take":
                     case "Skip":
+                    case "OfType":
                         return true;
                 }
                 return false;

--- a/test/SlowTests/Tests/Linq/OfTypeSuppor3.cs
+++ b/test/SlowTests/Tests/Linq/OfTypeSuppor3.cs
@@ -1,0 +1,75 @@
+// -----------------------------------------------------------------------
+//  <copyright file="OfTypeSupport.cs" company="Hibernating Rhinos LTD">
+//      Copyright (c) Hibernating Rhinos LTD. All rights reserved.
+//  </copyright>
+// -----------------------------------------------------------------------
+
+using System.Linq;
+using System.Threading.Tasks;
+using FastTests;
+using Raven.Client.Documents;
+using Raven.Client.Documents.Indexes;
+using Xunit;
+
+namespace SlowTests.Tests.Linq
+{
+    public class OfTypeSupport3 : RavenTestBase
+    {
+        [Fact]
+        public void OfTypeSupportSelectAfterwards()
+        {
+            using (var store = GetDocumentStore())
+            {
+                using (var session = store.OpenSession())
+                {
+                    session.Store(new Foo { Values = new[] { new Bar() { Value = "str" } } });
+                    session.SaveChanges();
+                }
+
+                store.ExecuteIndex(new Index());
+
+                using (var session = store.OpenSession())
+                {
+                    var item = session.Query<Index.Result, Index>()
+                                      .Customize(c => c.WaitForNonStaleResults())
+                                      .ProjectFromIndexFieldsInto<Index.Result>()
+                                      .Single();
+
+                    Assert.NotNull(item.Strings);
+                }
+            }
+        }
+
+        private class Index : AbstractIndexCreationTask<Foo, Index.Result>
+        {
+            public class Result
+            {
+                public object[] Values { get; set; }
+                public string[] Strings { get; set; }
+            }
+
+            public Index()
+            {
+                Map = docs => docs.Select(doc => new Result
+                                                 {
+                                                     Values = doc.Values,
+                                                     Strings = doc.Values.OfType<Bar>().Select(x => x.Value).ToArray(),
+                                                 });
+
+                Store(result => result.Strings, FieldStorage.Yes);
+            }
+
+        }
+
+        private class Foo
+        {
+            public object[] Values { get; set; }
+
+        }
+
+        private class Bar
+        {
+            public string Value { get; set; }
+        }
+    }
+}


### PR DESCRIPTION
fix support of OfType with Select
`
Map = docs => docs.Select(doc => new Result
                                                 {
                                                     Values = doc.Values,
                                                     Strings = doc.Values.OfType<Bar>().Select(x => x.Value).ToArray(),
                                                 });
`
failed to run on 3.5 and 4.0.
