### PR TITLE
RavenDB-6776 Rachis is not logged by default when enabling debug logs…

### DIFF
--- a/DefaultConfigs/NLog.Ignored.config
+++ b/DefaultConfigs/NLog.Ignored.config
@@ -50,6 +50,7 @@
     </targets>
     <rules>
         <!--<logger name="Raven.Bundles.Replication.Plugins.*" writeTo="AsyncConflictLog" minlevel="Debug"/>-->
-        <logger name="Raven.*" writeTo="AsyncLog" minlevel="Warn"/>
+        <logger name="Raven.*" writeTo="AsyncLog" minlevel="Debug"/>
+        <logger name="Rachis.*" writeTo="AsyncLog" minlevel="Debug"/>
     </rules>
 </nlog>


### PR DESCRIPTION
… as it is not in the Raven.* namespace.

Also lower the default minlevel to Debug