### PR TITLE
RavenDB-6783 Refactor Put method to a standalone class.

### DIFF
--- a/src/Raven.Server/Documents/AttachmentsStorage.cs
+++ b/src/Raven.Server/Documents/AttachmentsStorage.cs
@@ -124,10 +124,7 @@ namespace Raven.Server.Documents
             Stream stream)
         {
             if (context.Transaction == null)
-            {
-                DocumentsStorage.ThrowRequiresTransaction();
-                return default(AttachmentResult); // never reached
-            }
+                throw DocumentPutAction.ThrowRequiresTransaction();
 
             // Attachment etag should be generated before updating the document
             var attachmenEtag = _documentsStorage.GenerateNextEtag();

--- a/src/Raven.Server/Documents/DocumentPutAction.cs
+++ b/src/Raven.Server/Documents/DocumentPutAction.cs
@@ -1,0 +1,413 @@
+using System;
+using System.Diagnostics;
+using System.Globalization;
+using System.IO;
+using System.Runtime.CompilerServices;
+using System.Text;
+using Raven.Client;
+using Raven.Client.Documents.Changes;
+using Raven.Client.Documents.Replication.Messages;
+using Raven.Server.Documents.Versioning;
+using Raven.Server.ServerWide.Context;
+using Raven.Server.Utils;
+using Sparrow.Binary;
+using Sparrow.Json;
+using Sparrow.Json.Parsing;
+using Voron;
+using Voron.Data.Tables;
+using Voron.Exceptions;
+
+namespace Raven.Server.Documents
+{
+    public unsafe class DocumentPutAction
+    {
+        private readonly DocumentsStorage _documentsStorage;
+        private readonly DocumentDatabase _documentDatabase;
+
+        private readonly StringBuilder _keyBuilder = new StringBuilder();
+
+        public DocumentPutAction(DocumentsStorage documentsStorage, DocumentDatabase documentDatabase)
+        {
+            _documentsStorage = documentsStorage;
+            _documentDatabase = documentDatabase;
+        }
+
+        public DocumentsStorage.PutOperationResults PutDocument(DocumentsOperationContext context, string key, long? expectedEtag,
+            BlittableJsonReaderObject document,
+            long? lastModifiedTicks = null,
+            ChangeVectorEntry[] changeVector = null,
+            DocumentFlags flags = DocumentFlags.None,
+            NonPersistentDocumentFlags nonPersistentFlags = NonPersistentDocumentFlags.None)
+        {
+            if (context.Transaction == null)
+                throw ThrowRequiresTransaction();
+
+#if DEBUG
+            var documentDebugHash = document.DebugHash;
+            document.BlittableValidation();
+#endif
+
+            BlittableJsonReaderObject.AssertNoModifications(document, key, assertChildren: true);
+
+            var collectionName = _documentsStorage.ExtractCollectionName(context, key, document);
+            var newEtag = _documentsStorage.GenerateNextEtag();
+
+            var modifiedTicks = lastModifiedTicks ?? _documentDatabase.Time.GetUtcNow().Ticks;
+
+            var table = context.Transaction.InnerTransaction.OpenTable(DocumentsStorage.DocsSchema, collectionName.GetTableName(CollectionTableType.Documents));
+
+            bool knownNewKey = false;
+            if (string.IsNullOrWhiteSpace(key))
+            {
+                key = Guid.NewGuid().ToString();
+                knownNewKey = true;
+            }
+            else
+            {
+                switch (key[key.Length - 1])
+                {
+                    case '/':
+                        key = GetNextIdentityValueWithoutOverwritingOnExistingDocuments(key, table, context, out _);
+                        knownNewKey = true;
+                        break;
+                    case '|':
+                        key = AppendNumericValueToKey(key, newEtag);
+                        knownNewKey = true;
+                        break;
+                }
+            }
+
+            DocumentKeyWorker.GetLowerKeySliceAndStorageKey(context, key, out Slice lowerKey, out Slice keyPtr);
+
+            if (_documentsStorage.ConflictsStorage.ConflictsCount != 0)
+            {
+                // Since this document resolve the conflict we dont need to alter the change vector.
+                // This way we avoid another replication back to the source
+                if (expectedEtag.HasValue)
+                {
+                    _documentsStorage.ConflictsStorage.ThrowConcurrencyExceptionOnConflict(context, lowerKey.Content.Ptr, lowerKey.Size, expectedEtag);
+                }
+
+                if ((flags & DocumentFlags.FromReplication) == DocumentFlags.FromReplication)
+                {
+                    _documentsStorage.ConflictsStorage.DeleteConflictsFor(context, key);
+                }
+                else
+                {
+                    changeVector = _documentsStorage.ConflictsStorage.MergeConflictChangeVectorIfNeededAndDeleteConflicts(changeVector, context, key, newEtag);
+                }
+            }
+
+            var oldValue = default(TableValueReader);
+            if (knownNewKey == false)
+            {
+                // delete a tombstone if it exists, if it known that it is a new key, no need, so we can skip it
+                DeleteTombstoneIfNeeded(context, collectionName, lowerKey.Content.Ptr, lowerKey.Size);
+
+                table.ReadByKey(lowerKey, out oldValue);
+            }
+
+            BlittableJsonReaderObject oldDoc = null;
+            if (oldValue.Pointer == null)
+            {
+                if (expectedEtag != null && expectedEtag != 0)
+                {
+                    ThrowConcurrentExceptionOnMissingDoc(key, expectedEtag.Value);
+                }
+            }
+            else
+            {
+                if (expectedEtag != null)
+                {
+                    var oldEtag = DocumentsStorage.TableValueToEtag(1, ref oldValue);
+                    if (oldEtag != expectedEtag)
+                        ThrowConcurrentException(key, expectedEtag, oldEtag);
+                }
+
+                oldDoc = new BlittableJsonReaderObject(oldValue.Read((int)DocumentsStorage.DocumentsTable.Data, out int oldSize), oldSize, context);
+                var oldCollectionName = _documentsStorage.ExtractCollectionName(context, key, oldDoc);
+                if (oldCollectionName != collectionName)
+                    ThrowInvalidCollectionNameChange(key, oldCollectionName, collectionName);
+
+                var oldFlags = *(DocumentFlags*)oldValue.Read((int)DocumentsStorage.DocumentsTable.Flags, out int size);
+                if ((oldFlags & DocumentFlags.HasAttachments) == DocumentFlags.HasAttachments ||
+                    (nonPersistentFlags & NonPersistentDocumentFlags.ResolvedAttachmentConflict) == NonPersistentDocumentFlags.ResolvedAttachmentConflict)
+                {
+                    flags |= DocumentFlags.HasAttachments;
+                }
+            }
+
+            if (changeVector == null)
+            {
+                var oldChangeVector = oldValue.Pointer != null ? DocumentsStorage.GetChangeVectorEntriesFromTableValueReader(ref oldValue, (int)DocumentsStorage.DocumentsTable.ChangeVector) : null;
+                changeVector = SetDocumentChangeVectorForLocalChange(context, lowerKey, oldChangeVector, newEtag);
+            }
+
+
+            if (collectionName.IsSystem == false &&
+                (flags & DocumentFlags.Artificial) != DocumentFlags.Artificial)
+            {
+                if(ShouldRecreateAttachment(context, lowerKey, oldDoc, document, flags, nonPersistentFlags))
+                {
+#if DEBUG
+                    if (document.DebugHash != documentDebugHash)
+                    {
+                        throw new InvalidDataException("The incoming document " + key + " has changed _during_ the put process, " +
+                                                       "this is likely because you are trying to save a document that is already stored and was moved");
+                    }
+#endif
+                    document = context.ReadObject(document, key, BlittableJsonDocumentBuilder.UsageMode.ToDisk);
+#if DEBUG
+                    documentDebugHash = document.DebugHash;
+                    document.BlittableValidation();
+#endif
+                }
+
+                if (_documentDatabase.BundleLoader.VersioningStorage != null)
+                {
+                    VersioningConfigurationCollection configuration;
+                    if (_documentDatabase.BundleLoader.VersioningStorage.ShouldVersionDocument(collectionName, nonPersistentFlags, oldDoc, document, ref flags, out configuration, context, key))
+                    {
+                        _documentDatabase.BundleLoader.VersioningStorage.PutFromDocument(context, key, document, flags, changeVector, modifiedTicks, configuration);
+                    }
+                }
+            }
+
+            fixed (ChangeVectorEntry* pChangeVector = changeVector)
+            {
+                using (table.Allocate(out TableValueBuilder tbv))
+                {
+                    tbv.Add(lowerKey);
+                    tbv.Add(Bits.SwapBytes(newEtag));
+                    tbv.Add(keyPtr);
+                    tbv.Add(document.BasePointer, document.Size);
+                    tbv.Add((byte*)pChangeVector, sizeof(ChangeVectorEntry) * changeVector.Length);
+                    tbv.Add(modifiedTicks);
+                    tbv.Add((int)flags);
+                    tbv.Add(context.GetTransactionMarker());
+
+                    if (oldValue.Pointer == null)
+                    {
+                        table.Insert(tbv);
+                    }
+                    else
+                    {
+                        table.Update(oldValue.Id, tbv);
+                    }
+                }
+            }
+
+            if (collectionName.IsSystem == false)
+            {
+                _documentDatabase.BundleLoader.ExpiredDocumentsCleaner?.Put(context, lowerKey, document);
+            }
+
+            _documentDatabase.Metrics.DocPutsPerSecond.MarkSingleThreaded(1);
+            _documentDatabase.Metrics.BytesPutsPerSecond.MarkSingleThreaded(document.Size);
+
+
+            context.Transaction.AddAfterCommitNotification(new DocumentChange
+            {
+                Etag = newEtag,
+                CollectionName = collectionName.Name,
+                Key = key,
+                Type = DocumentChangeTypes.Put,
+                IsSystemDocument = collectionName.IsSystem,
+            });
+
+#if DEBUG
+            if (document.DebugHash != documentDebugHash)
+            {
+                throw new InvalidDataException("The incoming document " + key + " has changed _during_ the put process, " +
+                                               "this is likely because you are trying to save a document that is already stored and was moved");
+            }
+#endif
+
+            return new DocumentsStorage.PutOperationResults
+            {
+                Etag = newEtag,
+                Key = key,
+                Collection = collectionName,
+                ChangeVector = changeVector
+            };
+        }
+
+        private bool ShouldRecreateAttachment(DocumentsOperationContext context, Slice lowerKey, BlittableJsonReaderObject oldDoc, BlittableJsonReaderObject document, DocumentFlags flags, NonPersistentDocumentFlags nonPersistentFlags)
+        {
+            var shouldRecreateAttachment = false;
+            BlittableJsonReaderObject metadata = null;
+            if ((flags & DocumentFlags.HasAttachments) == DocumentFlags.HasAttachments &&
+                (nonPersistentFlags & NonPersistentDocumentFlags.ByAttachmentUpdate) != NonPersistentDocumentFlags.ByAttachmentUpdate &&
+                (nonPersistentFlags & NonPersistentDocumentFlags.FromReplication) != NonPersistentDocumentFlags.FromReplication)
+            {
+                Debug.Assert(oldDoc != null, "Can be null when it comes from replication, but we checked for this.");
+
+                if (oldDoc.TryGet(Constants.Documents.Metadata.Key, out BlittableJsonReaderObject oldMetadata) &&
+                    oldMetadata.TryGet(Constants.Documents.Metadata.Attachments, out BlittableJsonReaderArray oldAttachments))
+                {
+                    // Make sure the user did not changed the value of @attachments in the @metadata
+                    // In most cases it won't be changed so we can use this value 
+                    // instead of recreating the document's blitable from scratch
+                    if (document.TryGet(Constants.Documents.Metadata.Key, out metadata) == false ||
+                        metadata.TryGet(Constants.Documents.Metadata.Attachments, out BlittableJsonReaderArray attachments) == false ||
+                        attachments.Equals(oldAttachments) == false)
+                    {
+                        shouldRecreateAttachment = true;
+                    }
+                }
+            }
+
+            if (shouldRecreateAttachment == false && 
+                (nonPersistentFlags & NonPersistentDocumentFlags.ResolvedAttachmentConflict) != NonPersistentDocumentFlags.ResolvedAttachmentConflict)
+                return false;
+
+            if (shouldRecreateAttachment == false)
+                document.TryGet(Constants.Documents.Metadata.Key, out metadata);
+
+            var actualAttachments = _documentsStorage.AttachmentsStorage.GetAttachmentsMetadataForDocument(context, lowerKey);
+            if (metadata == null)
+            {
+                document.Modifications = new DynamicJsonValue(document)
+                {
+                    [Constants.Documents.Metadata.Key] = new DynamicJsonValue
+                    {
+                        [Constants.Documents.Metadata.Attachments] = actualAttachments
+                    }
+                };
+            }
+            else
+            {
+                metadata.Modifications = new DynamicJsonValue(metadata)
+                {
+                    [Constants.Documents.Metadata.Attachments] = actualAttachments
+                };
+                document.Modifications = new DynamicJsonValue(document)
+                {
+                    [Constants.Documents.Metadata.Key] = metadata
+                };
+            }
+
+            return true;
+        }
+
+        public static ArgumentException ThrowRequiresTransaction([CallerMemberName]string caller = null)
+        {
+            // ReSharper disable once NotResolvedInText
+            return new ArgumentException("Context must be set with a valid transaction before calling " + caller, "context");
+        }
+
+        private static void ThrowConcurrentExceptionOnMissingDoc(string key, long expectedEtag)
+        {
+            throw new ConcurrencyException(
+                $"Document {key} does not exist, but Put was called with etag {expectedEtag}. Optimistic concurrency violation, transaction will be aborted.")
+            {
+                ExpectedETag = expectedEtag
+            };
+        }
+
+        private static void ThrowInvalidCollectionNameChange(string key, CollectionName oldCollectionName, CollectionName collectionName)
+        {
+            throw new InvalidOperationException(
+                $"Changing '{key}' from '{oldCollectionName.Name}' to '{collectionName.Name}' via update is not supported.{System.Environment.NewLine}" +
+                $"Delete it and recreate the document {key}.");
+        }
+
+        private static void ThrowConcurrentException(string key, long? expectedEtag, long oldEtag)
+        {
+            throw new ConcurrencyException(
+                $"Document {key} has etag {oldEtag}, but Put was called with etag {expectedEtag}. Optimistic concurrency violation, transaction will be aborted.")
+            {
+                ActualETag = oldEtag,
+                ExpectedETag = expectedEtag ?? -1
+            };
+        }
+
+        public string GetNextIdentityValueWithoutOverwritingOnExistingDocuments(string key, Table table, DocumentsOperationContext context, out int tries)
+        {
+            var identities = context.Transaction.InnerTransaction.ReadTree(IdentitiesStorage.IdentitiesSlice);
+            var nextIdentityValue = identities.Increment(key, 1);
+            var finalKey = AppendIdentityValueToKey(key, nextIdentityValue);
+            Slice finalKeySlice;
+            tries = 1;
+
+            using (DocumentKeyWorker.GetSliceFromKey(context, finalKey, out finalKeySlice))
+            {
+                TableValueReader reader;
+                if (table.ReadByKey(finalKeySlice, out reader) == false)
+                {
+                    return finalKey;
+                }
+            }
+
+            /* We get here if the user inserted a document with a specified id.
+            e.g. your identity is 100
+            but you forced a put with 101
+            so you are trying to insert next document and it would overwrite the one with 101 */
+
+            var lastKnownBusy = nextIdentityValue;
+            var maybeFree = nextIdentityValue * 2;
+            var lastKnownFree = long.MaxValue;
+            while (true)
+            {
+                tries++;
+                finalKey = AppendIdentityValueToKey(key, maybeFree);
+                using (DocumentKeyWorker.GetSliceFromKey(context, finalKey, out finalKeySlice))
+                {
+                    TableValueReader reader;
+                    if (table.ReadByKey(finalKeySlice, out reader) == false)
+                    {
+                        if (lastKnownBusy + 1 == maybeFree)
+                        {
+                            nextIdentityValue = identities.Increment(key, lastKnownBusy);
+                            return key + nextIdentityValue;
+                        }
+                        lastKnownFree = maybeFree;
+                        maybeFree = Math.Max(maybeFree - (maybeFree - lastKnownBusy) / 2, lastKnownBusy + 1);
+                    }
+                    else
+                    {
+                        lastKnownBusy = maybeFree;
+                        maybeFree = Math.Min(lastKnownFree, maybeFree * 2);
+                    }
+                }
+            }
+        }
+
+        private string AppendIdentityValueToKey(string key, long val)
+        {
+            _keyBuilder.Length = 0;
+            _keyBuilder.Append(key);
+            _keyBuilder.Append(val);
+            return _keyBuilder.ToString();
+        }
+
+
+        private string AppendNumericValueToKey(string key, long val)
+        {
+            _keyBuilder.Length = 0;
+            _keyBuilder.Append(key);
+            _keyBuilder[_keyBuilder.Length - 1] = '/';
+            _keyBuilder.AppendFormat(CultureInfo.InvariantCulture, "{0:D19}", val);
+            return _keyBuilder.ToString();
+        }
+
+        private static void DeleteTombstoneIfNeeded(DocumentsOperationContext context, CollectionName collectionName, byte* lowerKey, int lowerSize)
+        {
+            var tombstoneTable = context.Transaction.InnerTransaction.OpenTable(DocumentsStorage.TombstonesSchema, collectionName.GetTableName(CollectionTableType.Tombstones));
+            using (Slice.From(context.Allocator, lowerKey, lowerSize, out Slice key))
+            {
+                tombstoneTable.DeleteByKey(key);
+            }
+        }
+
+        private ChangeVectorEntry[] SetDocumentChangeVectorForLocalChange(
+            DocumentsOperationContext context, Slice loweredKey,
+            ChangeVectorEntry[] oldChangeVector, long newEtag)
+        {
+            if (oldChangeVector != null)
+                return ReplicationUtils.UpdateChangeVectorWithNewEtag(_documentsStorage.Environment.DbId, newEtag, oldChangeVector);
+
+            return _documentsStorage.ConflictsStorage.GetMergedConflictChangeVectorsAndDeleteConflicts(context, loweredKey, newEtag);
+        }
+    }
+}

--- a/src/Raven.Server/Documents/IdentitiesStorage.cs
+++ b/src/Raven.Server/Documents/IdentitiesStorage.cs
@@ -1,0 +1,58 @@
+using System.Collections.Generic;
+using Raven.Server.ServerWide.Context;
+using Sparrow;
+using Voron;
+using Voron.Impl;
+
+namespace Raven.Server.Documents
+{
+    public class IdentitiesStorage
+    {
+        private readonly DocumentDatabase _documentDatabase;
+        public static readonly Slice IdentitiesSlice;
+
+        static IdentitiesStorage()
+        {
+            Slice.From(StorageEnvironment.LabelsContext, "Identities", ByteStringType.Immutable, out IdentitiesSlice);
+        }
+
+        public IdentitiesStorage(DocumentDatabase documentDatabase, Transaction tx)
+        {
+            _documentDatabase = documentDatabase;
+            tx.CreateTree(IdentitiesSlice);
+        }
+
+        public void Update(DocumentsOperationContext context, Dictionary<string, long> identities)
+        {
+            var readTree = context.Transaction.InnerTransaction.ReadTree(IdentitiesSlice);
+            foreach (var identity in identities)
+            {
+                readTree.AddMax(identity.Key, identity.Value);
+            }
+        }
+
+        public long IdentityFor(DocumentsOperationContext ctx, string key)
+        {
+            var identities = ctx.Transaction.InnerTransaction.ReadTree(IdentitiesSlice);
+            return identities.Increment(key, 1);
+        }
+
+        public IEnumerable<KeyValuePair<string, long>> GetIdentities(DocumentsOperationContext context)
+        {
+            var identities = context.Transaction.InnerTransaction.ReadTree(IdentitiesSlice);
+            using (var it = identities.Iterate(false))
+            {
+                if (it.Seek(Slices.BeforeAllKeys) == false)
+                    yield break;
+
+                do
+                {
+                    var name = it.CurrentKey.ToString();
+                    var value = it.CreateReaderForCurrent().ReadLittleEndianInt64();
+
+                    yield return new KeyValuePair<string, long>(name, value);
+                } while (it.MoveNext());
+            }
+        }
+    }
+}

--- a/src/Raven.Server/Documents/IndexesEtagsStorage.cs
+++ b/src/Raven.Server/Documents/IndexesEtagsStorage.cs
@@ -329,7 +329,7 @@ namespace Raven.Server.Documents
         {
             if (oldValue.Pointer != null)
             {
-                var changeVector = ReplicationUtils.GetChangeVectorEntriesFromTableValueReader(ref oldValue, (int)MetadataFields.ChangeVector);
+                var changeVector = DocumentsStorage.GetChangeVectorEntriesFromTableValueReader(ref oldValue, (int)MetadataFields.ChangeVector);
                 return ReplicationUtils.UpdateChangeVectorWithNewEtag(_environment.DbId, newEtag, changeVector);
             }
 
@@ -407,7 +407,7 @@ namespace Raven.Server.Documents
                 foreach (var tvr in table.SeekForwardFrom(ConflictsTableSchema.Indexes[NameAndEtagIndexName], name, 0, true))
                 {
                     more = true;
-                    list.Add(ReplicationUtils.GetChangeVectorEntriesFromTableValueReader(ref tvr.Result.Reader, (int)MetadataFields.ChangeVector));
+                    list.Add(DocumentsStorage.GetChangeVectorEntriesFromTableValueReader(ref tvr.Result.Reader, (int)MetadataFields.ChangeVector));
 
                     table.Delete(tvr.Result.Reader.Id);
                     break;
@@ -600,7 +600,7 @@ namespace Raven.Server.Documents
 
             metadata.Name = context.AllocateStringValue(null, tvr.Read((int)MetadataFields.Name, out size), size).ToString();
 
-            metadata.ChangeVector = ReplicationUtils.GetChangeVectorEntriesFromTableValueReader(ref tvr, (int)MetadataFields.ChangeVector);
+            metadata.ChangeVector = DocumentsStorage.GetChangeVectorEntriesFromTableValueReader(ref tvr, (int)MetadataFields.ChangeVector);
             metadata.Type = (IndexEntryType)(*tvr.Read((int)MetadataFields.Type, out size));
             metadata.Etag = Bits.SwapBytes(*(long*)tvr.Read((int)MetadataFields.Etag, out size));
             metadata.IsConflicted = *(bool*)tvr.Read((int)MetadataFields.IsConflicted, out size);
@@ -617,7 +617,7 @@ namespace Raven.Server.Documents
 
             data.Name = context.AllocateStringValue(null, tvr.Read((int)ConflictFields.Name, out size), size).ToString();
 
-            data.ChangeVector = ReplicationUtils.GetChangeVectorEntriesFromTableValueReader(ref tvr, (int)ConflictFields.ChangeVector);
+            data.ChangeVector = DocumentsStorage.GetChangeVectorEntriesFromTableValueReader(ref tvr, (int)ConflictFields.ChangeVector);
             data.Type = (IndexEntryType)(*tvr.Read((int)ConflictFields.Type, out size));
             data.Etag = Bits.SwapBytes(*(long*)tvr.Read((int)ConflictFields.Etag, out size));
 

--- a/src/Raven.Server/Documents/Replication/ConflictManager.cs
+++ b/src/Raven.Server/Documents/Replication/ConflictManager.cs
@@ -99,7 +99,7 @@ namespace Raven.Server.Documents.Replication
                     _conflictResolver.ResolveToLatest(documentsContext, conflicts);
                     break;
                 default:
-                    _database.DocumentsStorage.AddConflict(documentsContext, id, lastModifiedTicks, doc, changeVector, collection);
+                    _database.DocumentsStorage.ConflictsStorage.AddConflict(documentsContext, id, lastModifiedTicks, doc, changeVector, collection);
                     break;
             }
         }
@@ -260,7 +260,7 @@ namespace Raven.Server.Documents.Replication
                 Slice loweredKey;
                 using (Slice.External(context.Allocator, existingTombstone.LoweredKey, out loweredKey))
                 {
-                    _database.DocumentsStorage.DeleteConflicts(context, loweredKey, null, existingTombstone.ChangeVector);
+                    _database.DocumentsStorage.ConflictsStorage.DeleteConflicts(context, loweredKey, null, existingTombstone.ChangeVector);
                 }
                 return true;
             }

--- a/src/Raven.Server/Documents/Replication/IncomingReplicationHandler.cs
+++ b/src/Raven.Server/Documents/Replication/IncomingReplicationHandler.cs
@@ -335,12 +335,12 @@ namespace Raven.Server.Documents.Replication
             int itemsCount;
             if (!message.TryGet(nameof(ReplicationMessageHeader.ItemsCount), out itemsCount))
                 throw new InvalidDataException(
-                    "Expected the 'ItemsCount' field, but had no numeric field of this value, this is likely a bug");
+                    $"Expected the '{nameof(ReplicationMessageHeader.ItemsCount)}' field, but had no numeric field of this value, this is likely a bug");
 
             int attachmentStreamCount;
             if (!message.TryGet(nameof(ReplicationMessageHeader.AttachmentStreamsCount), out attachmentStreamCount))
                 throw new InvalidDataException(
-                    "Expected the 'AttachmentStreamsCount' field, but had no numeric field of this value, this is likely a bug");
+                    $"Expected the '{nameof(ReplicationMessageHeader.AttachmentStreamsCount)}' field, but had no numeric field of this value, this is likely a bug");
 
             string resovlerId;
             int? resolverVersion;

--- a/src/Raven.Server/Smuggler/Documents/DatabaseDestination.cs
+++ b/src/Raven.Server/Smuggler/Documents/DatabaseDestination.cs
@@ -232,7 +232,7 @@ namespace Raven.Server.Smuggler.Documents
 
                     using (var tx = _context.OpenWriteTransaction())
                     {
-                        _database.DocumentsStorage.UpdateIdentities(_context, _identities);
+                        _database.DocumentsStorage.Identities.Update(_context, _identities);
 
                         tx.Commit();
                     }

--- a/src/Raven.Server/Smuggler/Documents/DatabaseSource.cs
+++ b/src/Raven.Server/Smuggler/Documents/DatabaseSource.cs
@@ -118,7 +118,7 @@ namespace Raven.Server.Smuggler.Documents
 
         public IEnumerable<KeyValuePair<string, long>> GetIdentities()
         {
-            return _database.DocumentsStorage.GetIdentities(_context);
+            return _database.DocumentsStorage.Identities.GetIdentities(_context);
         }
 
         public long SkipType(DatabaseItemType type)

--- a/src/Raven.Server/Utils/ReplicationUtils.cs
+++ b/src/Raven.Server/Utils/ReplicationUtils.cs
@@ -308,18 +308,6 @@ namespace Raven.Server.Utils
             return (TEnum)Enum.ToObject(typeof(TEnum), storageTypeNum);
         }
 
-        public static unsafe ChangeVectorEntry[] GetChangeVectorEntriesFromTableValueReader(ref TableValueReader tvr, int index)
-        {
-            int size;
-            var pChangeVector = (ChangeVectorEntry*)tvr.Read(index, out size);
-            var changeVector = new ChangeVectorEntry[size / sizeof(ChangeVectorEntry)];
-            for (int i = 0; i < changeVector.Length; i++)
-            {
-                changeVector[i] = pChangeVector[i];
-            }
-            return changeVector;
-        }
-
         public static unsafe ChangeVectorEntry[] ReadChangeVectorFrom(Tree tree)
         {
             var changeVector = new ChangeVectorEntry[tree.State.NumberOfEntries];

--- a/test/FastTests/Client/Attachments/AttachmentsReplication.cs
+++ b/test/FastTests/Client/Attachments/AttachmentsReplication.cs
@@ -427,7 +427,7 @@ namespace FastTests.Client.Attachments
 
         [Fact(Skip = "WIP")]
         public async Task AttachmentsVersioningReplication()
-         {
+        {
             using (var store1 = GetDocumentStore())
             using (var store2 = GetDocumentStore())
             {

--- a/test/FastTests/Server/Documents/DocumentsCrud.cs
+++ b/test/FastTests/Server/Documents/DocumentsCrud.cs
@@ -556,8 +556,6 @@ namespace FastTests.Server.Documents
                 }
                 ctx.Transaction.Commit();
             }
-
-
         }
 
         public override void Dispose()

--- a/test/SlowTests/Issues/RavenDB_535.cs
+++ b/test/SlowTests/Issues/RavenDB_535.cs
@@ -29,10 +29,10 @@ namespace SlowTests.Issues
                 {
                     var table = context.Transaction.InnerTransaction.OpenTable(DocumentsStorage.DocsSchema, "Collection.Documents.users");
                     int tries;
-                    var val = documentDatabase.DocumentsStorage.GetNextIdentityValueWithoutOverwritingOnExistingDocuments("users/", table, context, out tries);
+                    var val = documentDatabase.DocumentsStorage.DocumentPut.GetNextIdentityValueWithoutOverwritingOnExistingDocuments("users/", table, context, out tries);
                     Assert.True(30 > tries);
                     Assert.Equal("users/1338", val);
-                    val = documentDatabase.DocumentsStorage.GetNextIdentityValueWithoutOverwritingOnExistingDocuments("users/", table, context, out tries);
+                    val = documentDatabase.DocumentsStorage.DocumentPut.GetNextIdentityValueWithoutOverwritingOnExistingDocuments("users/", table, context, out tries);
                     Assert.Equal(1, tries);
                     Assert.Equal("users/1339", val);
                 }


### PR DESCRIPTION
Refactor ShouldRecreateAttachment method out of the Put method.
Refactor identities related code to IdentitiesStorage.
Move AddConflict and DeleteConflicts to ConflictsStorage.
Remove duplicate GetChangeVectorEntriesFromTableValueReader method from ReplicationUtils.