### PR TITLE
RavenDB-6748 In order to ensure that we won't override freed scratch …

### DIFF
--- a/src/Voron/Impl/Journal/JournalFile.cs
+++ b/src/Voron/Impl/Journal/JournalFile.cs
@@ -211,7 +211,7 @@ namespace Voron.Impl.Journal
 
         public bool DeleteOnClose { set { _journalWriter.DeleteOnClose = value; } }
 
-        public void FreeScratchPagesOlderThan(long lastSyncedTransactionId)
+        public void FreeScratchPagesOlderThan(LowLevelTransaction tx, long lastSyncedTransactionId)
         {
             var unusedPages = new List<PagePosition>();
 
@@ -230,7 +230,7 @@ namespace Voron.Impl.Journal
                 if (unusedScratchPage.IsFreedPageMarker)
                     continue;
 
-                _env.ScratchBufferPool.Free(unusedScratchPage.ScratchNumber, unusedScratchPage.ScratchPos, _env.PossibleOldestReadTransaction);
+                _env.ScratchBufferPool.Free(unusedScratchPage.ScratchNumber, unusedScratchPage.ScratchPos, tx.Id);
             }
 
             foreach (var page in unusedPages)
@@ -246,7 +246,7 @@ namespace Voron.Impl.Journal
                     continue;
                 }
 
-                _env.ScratchBufferPool.Free(page.ScratchNumber, page.ScratchPos, _env.PossibleOldestReadTransaction);
+                _env.ScratchBufferPool.Free(page.ScratchNumber, page.ScratchPos, tx.Id);
             }
         }
     }

--- a/src/Voron/Impl/Journal/WriteAheadJournal.cs
+++ b/src/Voron/Impl/Journal/WriteAheadJournal.cs
@@ -724,12 +724,12 @@ namespace Voron.Impl.Journal
 
                 foreach (var journalFile in unusedJournals.OrderBy(x => x.Number))
                 {
-                    journalFile.FreeScratchPagesOlderThan(lastSyncedTransactionId);
+                    journalFile.FreeScratchPagesOlderThan(txw, lastSyncedTransactionId);
                 }
 
                 foreach (var jrnl in _waj._files.OrderBy(x => x.Number))
                 {
-                    jrnl.FreeScratchPagesOlderThan(lastSyncedTransactionId);
+                    jrnl.FreeScratchPagesOlderThan(txw, lastSyncedTransactionId);
                 }
 
                 // by forcing a commit, we free the read transaction that held the lazy tx buffer (if existed)


### PR DESCRIPTION
…pages while read transactions can look at them we cannot mark them as available for allocation after PossibleOldestReadTransaction. We have to use the id of the current write transaction since the possible oldest read transaction can finish but there might be still other read transaction. Basically the condition commited in cd72151 was too weak, we need to get back to what we have in 3.x by reverting the change introduced in (d43c11ee).