### PR TITLE
RavenDB-6835 Splitting the conflict resolution work so the tx merger …

### DIFF
--- a/src/Raven.Server/Documents/Replication/ResolveConflictOnReplicationConfigurationChange.cs
+++ b/src/Raven.Server/Documents/Replication/ResolveConflictOnReplicationConfigurationChange.cs
@@ -1,11 +1,9 @@
 ﻿using System;
 using System.Collections.Generic;
-using System.Diagnostics;
 using System.Linq;
 using System.Threading.Tasks;
 using Raven.Client.Documents;
 using Raven.Client.Documents.Exceptions;
-using Raven.Client.Documents.Replication;
 using Raven.Server.Documents.Patch;
 using Raven.Server.NotificationCenter.Notifications;
 using Raven.Server.ServerWide.Context;
@@ -30,7 +28,7 @@ namespace Raven.Server.Documents.Replication
         public ResolveConflictOnReplicationConfigurationChange(ReplicationLoader replicationLoader, Logger log)
         {
             _replicationLoader = replicationLoader ?? 
-                throw new ArgumentNullException($"ResolveConflictOnReplicationConfigurationChange must have replicationLoader instance");
+                throw new ArgumentNullException($"{nameof(ResolveConflictOnReplicationConfigurationChange)} must have replicationLoader instance");
             _database = _replicationLoader.Database;
             _log = log;
         }
@@ -63,39 +61,64 @@ namespace Raven.Server.Documents.Replication
                 DocumentsOperationContext context;
                 using (_database.DocumentsStorage.ContextPool.AllocateOperationContext(out context))
                 {
-                    Slice lastKey;
-                    Slice.From(context.Allocator, string.Empty, out lastKey);
-                    try
+                    using (context.OpenReadTransaction())
                     {
-                        while (_database.DatabaseShutdown.IsCancellationRequested == false)
+                        var resolvedConflicts = new List<DocumentConflict>();
+
+                        var hadConflicts = false;
+
+                        foreach (var conflicts in _database.DocumentsStorage.ConflictsStorage.GetAllConflictsBySameKey(context))
                         {
-                            try
+                            if (_database.DatabaseShutdown.IsCancellationRequested)
+                                break;
+
+                            hadConflicts = true;
+
+                            var collection = conflicts[0].Collection;
+
+                            DocumentConflict resolved;
+                            if (ScriptConflictResolversCache.TryGetValue(collection, out var scriptResolver) && scriptResolver != null)
                             {
-                                using (context.OpenReadTransaction())
+                                if (TryResolveConflictByScriptInternal(
+                                    context,
+                                    scriptResolver,
+                                    conflicts,
+                                    collection,
+                                    hasLocalTombstone: false,
+                                    resolvedConflict: out resolved))
                                 {
-                                    var conflicts = _database.DocumentsStorage.ConflictsStorage.GetAllConflictsBySameKeyAfter(context, ref lastKey);
-                                    if (conflicts.Count == 0)
-                                        break;
+                                    resolvedConflicts.Add(resolved);
 
-                                    // TODO arek: tx merger should just get and put all of the result docs (output of resolution)
-                                    // instead of dealing with the resolving the conflicts
-
-                                    await _database.TxMerger.Enqueue(new ResolveConflictsCommand(conflicts, this));
+                                    //stats.AddResolvedBy(collection + " Script", conflictList.Count);
+                                    continue;
                                 }
                             }
-                            finally
-                            {
-                                if (lastKey.HasValue)
-                                    lastKey.Release(context.Allocator);
 
-                                Slice.From(context.Allocator, string.Empty, out lastKey);
+                            if (TryResolveUsingDefaultResolverInternal(
+                                context,
+                                ConflictSolver?.DatabaseResolverId,
+                                conflicts,
+                                out resolved))
+                            {
+                                resolvedConflicts.Add(resolved);
+
+                                //stats.AddResolvedBy("DatabaseResolver", conflictList.Count);
+                                continue;
+                            }
+
+                            if (ConflictSolver?.ResolveToLatest == true)
+                            {
+                                resolvedConflicts.Add(ResolveToLatest(context, conflicts));
+
+                                //stats.AddResolvedBy("ResolveToLatest", conflictList.Count);
                             }
                         }
-                    }
-                    finally
-                    {
-                        if (lastKey.HasValue)
-                            lastKey.Release(context.Allocator);
+
+                        if (hadConflicts == false || _database.DatabaseShutdown.IsCancellationRequested)
+                            return;
+
+                        if (resolvedConflicts.Count > 0)
+                            await _database.TxMerger.Enqueue(new PutResolvedConflictsCommand(resolvedConflicts, this));
                     }
                 }
             }
@@ -105,56 +128,29 @@ namespace Raven.Server.Documents.Replication
                     _log.Info("Failed to run automatic conflict resolution", e);
             }
         }
-
-
-        private class ResolveConflictsCommand : TransactionOperationsMerger.MergedTransactionCommand
+        
+        private class PutResolvedConflictsCommand : TransactionOperationsMerger.MergedTransactionCommand
         {
-            private readonly List<DocumentConflict> _conflicts;
+            private readonly List<DocumentConflict> _resolvedConflicts;
             private readonly ResolveConflictOnReplicationConfigurationChange _resolver;
 
-            public ResolveConflictsCommand(List<DocumentConflict> conflicts, ResolveConflictOnReplicationConfigurationChange resolver)
+            public PutResolvedConflictsCommand(List<DocumentConflict> resolvedConflicts, ResolveConflictOnReplicationConfigurationChange resolver)
             {
-                _conflicts = conflicts;
+                _resolvedConflicts = resolvedConflicts;
                 _resolver = resolver;
             }
 
             public override int Execute(DocumentsOperationContext context)
             {
-                var collection = _conflicts[0].Collection;
+                var count = 0;
 
-                ScriptResolver scriptResovler;
-                if (_resolver.ScriptConflictResolversCache.TryGetValue(collection, out scriptResovler) &&
-                    scriptResovler != null)
+                foreach (var resolved in _resolvedConflicts)
                 {
-                    if (_resolver.TryResolveConflictByScriptInternal(
-                        context,
-                        scriptResovler,
-                        _conflicts,
-                        collection,
-                        hasLocalTombstone: false))
-                    {
-                        //stats.AddResolvedBy(collection + " Script", conflictList.Count);
-                        return _conflicts.Count;
-                    }
+                    _resolver.PutResolvedDocument(context, resolved);
+                    count++;
                 }
 
-                if (_resolver.TryResolveUsingDefaultResolverInternal(
-                    context,
-                    _resolver.ConflictSolver?.DatabaseResolverId,
-                    _conflicts))
-                {
-                    //stats.AddResolvedBy("DatabaseResolver", conflictList.Count);
-                    return _conflicts.Count;
-                }
-
-                if (_resolver.ConflictSolver?.ResolveToLatest ?? false)
-                {
-                    _resolver.ResolveToLatest(context, _conflicts);
-                    //stats.AddResolvedBy("ResolveToLatest", conflictList.Count);
-                    return _conflicts.Count;
-                }
-
-                return 0;
+                return count;
             }
         }
 
@@ -185,14 +181,14 @@ namespace Raven.Server.Documents.Replication
         public bool TryResolveUsingDefaultResolverInternal(
             DocumentsOperationContext context,
             string resolver,
-            IReadOnlyList<DocumentConflict> conflicts)
+            IReadOnlyList<DocumentConflict> conflicts,
+            out DocumentConflict resolved)
         {
-            if (resolver == null)
-            {
-                return false;
-            }
+            resolved = null;
 
-            DocumentConflict resolved = null;
+            if (resolver == null)
+                return false;
+
             long maxEtag = -1;
             foreach (var documentConflict in conflicts)
             {
@@ -220,7 +216,6 @@ namespace Raven.Server.Documents.Replication
                 return false;
 
             resolved.ChangeVector = ChangeVectorUtils.MergeVectors(conflicts.Select(c => c.ChangeVector).ToList());
-            PutResolvedDocumentBackToStorage(context, resolved);
             return true;
         }
 
@@ -258,7 +253,7 @@ namespace Raven.Server.Documents.Replication
             return true;
         }
 
-        public void PutResolvedDocumentBackToStorage(
+        public void PutResolvedDocument(
            DocumentsOperationContext context,
            DocumentConflict conflict)
         {
@@ -316,10 +311,12 @@ namespace Raven.Server.Documents.Replication
             ScriptResolver scriptResolver,
             IReadOnlyList<DocumentConflict> conflicts,
             LazyStringValue collection,
-            bool hasLocalTombstone)
+            bool hasLocalTombstone, 
+            out DocumentConflict resolvedConflict)
         {
             if (ValidatedResolveByScriptInput(scriptResolver, conflicts, collection) == false)
             {
+                resolvedConflict = null;
                 return false;
             }
 
@@ -329,20 +326,25 @@ namespace Raven.Server.Documents.Replication
             {
                 Script = scriptResolver.Script
             };
+
             BlittableJsonReaderObject resolved;
             if (patch.TryResolveConflict(context, patchRequest, out resolved) == false)
             {
+                resolvedConflict = null;
                 return false;
             }
 
             updatedConflict.Doc = resolved;
             updatedConflict.Collection = collection;
             updatedConflict.ChangeVector = ChangeVectorUtils.MergeVectors(conflicts.Select(c => c.ChangeVector).ToList());
-            PutResolvedDocumentBackToStorage(context, updatedConflict);
+
+            resolvedConflict = updatedConflict;
+
+            
             return true;
         }
 
-        public void ResolveToLatest(
+        public DocumentConflict ResolveToLatest(
             DocumentsOperationContext context,
             IReadOnlyList<DocumentConflict> conflicts)
         {
@@ -359,7 +361,8 @@ namespace Raven.Server.Documents.Replication
             }
 
             latestDoc.ChangeVector = ChangeVectorUtils.MergeVectors(conflicts.Select(c => c.ChangeVector).ToList());
-            PutResolvedDocumentBackToStorage(context, latestDoc);
+
+            return latestDoc;
         }
     }
 }


### PR DESCRIPTION
…just puts the resolutions (the conflicts are resolved earlier). Simplifying the code responsible for dealing with conflicts in the background.