### PR TITLE
RavenDB-6827 For docker to discover server address scan the range of IPs and...

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -112,3 +112,4 @@ release
 
 !scripts/assets/bin
 /.idea
+.vscode

--- a/docker/ravendb-nanoserver/run-raven.ps1
+++ b/docker/ravendb-nanoserver/run-raven.ps1
@@ -7,11 +7,14 @@ if ([string]::IsNullOrEmpty($env:CustomConfigFilename) -eq $False) {
         /Raven/RunAsService=true `
         /Raven/ServerUrl/Tcp=38888 `
         /Raven/Config="$CUSTOM_SETTINGS_PATH" `
-        /Raven/DataDir=$($env:DataDir)
+        /Raven/DataDir=$($env:DataDir) `
+        --print-id
 }
 else {
     ./Raven.Server.exe `
         /Raven/RunAsService=true `
         /Raven/ServerUrl/Tcp=38888 `
-        /Raven/AllowEverybodyToAccessTheServerAsAdmin=$($env:AllowEverybodyToAccessTheServerAsAdmin) ` /Raven/DataDir=$($env:DataDir)
+        /Raven/AllowEverybodyToAccessTheServerAsAdmin=$($env:AllowEverybodyToAccessTheServerAsAdmin) `
+        /Raven/DataDir=$($env:DataDir) `
+        --print-id
 }

--- a/docker/ravendb-ubuntu1604/run-raven.sh
+++ b/docker/ravendb-ubuntu1604/run-raven.sh
@@ -10,11 +10,13 @@ then
         /Raven/RunAsService=true \
         /Raven/ServerUrl/Tcp=38888 \
         /Raven/AllowEverybodyToAccessTheServerAsAdmin=${AllowEverybodyToAccessTheServerAsAdmin} \
-        /Raven/DataDir=${DataDir} 
+        /Raven/DataDir=${DataDir} \
+        --print-id
 else
     ./Raven.Server \
         /Raven/RunAsService=true \
         /Raven/ServerUrl/Tcp=38888 \
         /Raven/Config=${CUSTOM_SETTINGS_PATH} \
-        /Raven/DataDir=${DataDir}
+        /Raven/DataDir=${DataDir} \
+        --print-id
 fi

--- a/src/Raven.Server/Documents/Handlers/Admin/AdminStatsHandler.cs
+++ b/src/Raven.Server/Documents/Handlers/Admin/AdminStatsHandler.cs
@@ -1,0 +1,28 @@
+using System.Threading.Tasks;
+using Raven.Server.Routing;
+using Sparrow.Json;
+using Sparrow.Json.Parsing;
+using Raven.Server.Web;
+
+namespace Raven.Server.Documents.Handlers.Admin
+{
+    public class AdminStatsHandler : RequestHandler
+    {
+        [RavenAction("/admin/stats/server-id", "GET", "/admin/stats/server-id", NoAuthorizationRequired = true)]
+        public Task ServerId()
+        {
+            JsonOperationContext context;
+
+            using (ServerStore.ContextPool.AllocateOperationContext(out context))
+            using (var writer = new BlittableJsonTextWriter(context, ResponseBodyStream()))
+            {
+                context.Write(writer, new DynamicJsonValue
+                {
+                    ["ServerId"] = ServerStore.GetServerId().ToString(),
+                });
+            }
+
+            return Task.CompletedTask;
+        }
+    }
+}

--- a/src/Raven.Server/Program.cs
+++ b/src/Raven.Server/Program.cs
@@ -24,8 +24,13 @@ namespace Raven.Server
 
             var customConfigPath = ParseCustomConfigPath(args);
             var configuration = new RavenConfiguration(null, ResourceType.Server, customConfigPath);
+            bool printServerId = false;
             if (args != null)
             {
+                var list = args.ToList();
+                printServerId = list.Remove("--print-id");
+                args = list.ToArray();
+
                 configuration.AddCommandLine(args);
             }
 
@@ -45,6 +50,10 @@ namespace Raven.Server
                     try
                     {
                         server.Initialize();
+
+                        if (printServerId)
+                            Console.WriteLine($"Server ID is {server.ServerStore.GetServerId()}.");
+
                         Console.WriteLine($"Listening to: {string.Join(", ", server.WebUrls)}");
 
                         var serverWebUrl = server.WebUrls[0];

--- a/src/Raven.Server/RavenServerStartup.cs
+++ b/src/Raven.Server/RavenServerStartup.cs
@@ -1,4 +1,5 @@
 using System;
+using System.Collections.Generic;
 using System.Diagnostics;
 using System.Net;
 using System.Threading;
@@ -67,8 +68,17 @@ namespace Raven.Server
 
         public static bool SkipHttpLogging;
 
+        private static readonly HashSet<string> RoutesAllowedInUnsafeMode = new HashSet<string> {
+            "/admin/stats/server-id"
+        };
+
         private Task UnsafeRequestHandler(HttpContext context)
         {
+            if (RoutesAllowedInUnsafeMode.Contains(context.Request.Path.Value))
+            {
+                return RequestHandler(context);
+            }
+
             context.Response.StatusCode = (int) HttpStatusCode.ServiceUnavailable;
             context.Response.Headers["Content-Type"] = "application/json; charset=utf-8";
             JsonOperationContext ctx;

--- a/src/Raven.Server/ServerWide/ServerStore.cs
+++ b/src/Raven.Server/ServerWide/ServerStore.cs
@@ -337,6 +337,11 @@ namespace Raven.Server.ServerWide
             }
         }
 
+        public Guid GetServerId()
+        {
+            return _env.DbId;
+        }
+
         public void Dispose()
         {
             if (_shutdownNotification.IsCancellationRequested || _disposed)


### PR DESCRIPTION
...compare with server ID from `docker logs` output.

To avoid the need of escalated privileges (for running HyperV commands to get VM IP) for running this script we workaround this problem by scanning small IP range to find the server. This is going to help people having customized DockerNAT network address. When using defaults - 10.0.75.2 then only 1 call is going to be made to the server and this covers the most of the users. In other cases we're scanning up to 253 addresses. Added `-DontScanVmSubnet` flag which might be used to skip the scan altogether and fallback to displaying 10.0.75.2.

In the previous version we just displayed where we guess it's listening.

Script is backwards-compatible and works with existing images not having serverId endpoint implemented.