### PR TITLE
RavenDB-6913

### DIFF
--- a/src/Raven.Server/Documents/Replication/OutgoingReplicationHandler.cs
+++ b/src/Raven.Server/Documents/Replication/OutgoingReplicationHandler.cs
@@ -572,8 +572,12 @@ namespace Raven.Server.Documents.Replication
             _waitForChanges.Set();
         }
 
+        private int _disposed;
         public void Dispose()
         {
+            //There are multiple invokations of dispose, this happens sometimes during tests, causing failures.
+            if (Interlocked.CompareExchange(ref _disposed, 1, 0) == 1)
+                return;
             if (_log.IsInfoEnabled)
                 _log.Info($"Disposing OutgoingReplicationHandler ({FromToString})");
 

--- a/test/RachisTests/IndexesAndTranformers.cs
+++ b/test/RachisTests/IndexesAndTranformers.cs
@@ -5,7 +5,6 @@ using System.Linq;
 using System.Linq.Expressions;
 using System.Threading;
 using System.Threading.Tasks;
-using Raven.Client;
 using Raven.Client.Documents;
 using Raven.Client.Documents.Conventions;
 using Raven.Client.Documents.Indexes;
@@ -109,6 +108,7 @@ namespace SlowTests.Server.Rachis
                         foreach (var serverToCheckAt in relevantServers)
                         {
                             var db = await serverToCheckAt.ServerStore.DatabasesLandlord.TryGetOrCreateResourceStore(store.DefaultDatabase);
+
                             Assert.True(await db.WaitForIndexNotification(putTransformerResult.Etag).WaitAsync(WaitInterval));
                             using (var currentServerStore = new DocumentStore
                             {
@@ -116,15 +116,13 @@ namespace SlowTests.Server.Rachis
                                 DefaultDatabase = store.DefaultDatabase
                             })
                             {
-                                var getTransformerOperation = new GetTransformerOperation(curTransformerDefinition.Name);
-                                var transformerDefinition = await currentServerStore.Admin.SendAsync(getTransformerOperation);
+                                var transformerDefinition = db.TransformerStore.GetTransformer(curTransformerDefinition.Name);
                                 Assert.Equal(curTransformerDefinition.Name, transformerDefinition.Name);
                             }
                         }
                     }
                 }
             }
-            await Task.Delay(1000); //remove this
         }
     }
 }


### PR DESCRIPTION
* Fixing transformer test that was checking the existence of a transformer on the wrong server (flaky)
* Fixing a flaky case where outgoing replication Dispose is invoked multiple times causing ObjectDisposeException when trying to cancel an already disposed cancellation token.