### PR TITLE
RavenDB-6916 enforce that encrypted db must have a stored secret key,…

### DIFF
--- a/src/Raven.Server/Documents/DocumentDatabase.cs
+++ b/src/Raven.Server/Documents/DocumentDatabase.cs
@@ -178,6 +178,12 @@ namespace Raven.Server.Documents
                 using (ctx.OpenReadTransaction())
                 {
                     MasterKey = _serverStore.GetSecretKey(ctx, Name);
+
+                    var databaseRecord = _serverStore.Cluster.ReadDatabase(ctx, Name);
+                    if (databaseRecord.Encrypted && MasterKey == null)
+                        throw new InvalidOperationException($"Attempt to create encrypted db {Name} without supplying the secret key");
+                    if (databaseRecord.Encrypted == false && MasterKey != null)
+                        throw new InvalidOperationException($"Attempt to create a non-encrypted db {Name}, but a secret key exists for this db.");
                 }
                 DocumentsStorage.Initialize();
                 InitializeInternal();


### PR DESCRIPTION
… otherwise throw an error