### PR TITLE
RavenDB-6511

### DIFF
--- a/src/Raven.Client/Documents/Operations/GetAttachmentOperation.cs
+++ b/src/Raven.Client/Documents/Operations/GetAttachmentOperation.cs
@@ -135,7 +135,7 @@ namespace Raven.Client.Documents.Operations
                 var etag = response.GetRequiredEtagHeader();
                 IEnumerable<string> hashVal;
                 var hash = response.Headers.TryGetValues("Content-Hash", out hashVal) ? hashVal.First() : null;
-                var size = response.Content.Headers.ContentLength ?? 0;
+                var size = stream.Length;
           
                 Result = new AttachmentResult
                 {

--- a/src/Raven.Server/Documents/PeriodicExport/PeriodicExportRunner.cs
+++ b/src/Raven.Server/Documents/PeriodicExport/PeriodicExportRunner.cs
@@ -309,8 +309,7 @@ namespace Raven.Server.Documents.PeriodicExport
                         using (var file = File.Open(exportFilePath, FileMode.CreateNew))
                         {
                             var smugglerSource = new DatabaseSource(_database, startDocsEtag ?? 0, 0);
-
-                            var smugglerDestination = new StreamDestination(file, context);
+                            var smugglerDestination = new StreamDestination(file, context, smugglerSource);
                             var smuggler = new DatabaseSmuggler(
                                 smugglerSource,
                                 smugglerDestination,

--- a/src/Raven.Server/Smuggler/Documents/Data/ISmugglerDestination.cs
+++ b/src/Raven.Server/Smuggler/Documents/Data/ISmugglerDestination.cs
@@ -2,7 +2,6 @@
 using Raven.Client.Documents.Indexes;
 using Raven.Client.Documents.Smuggler;
 using Raven.Client.Documents.Transformers;
-using Raven.Server.Documents;
 using Raven.Server.Documents.Indexes;
 using Raven.Server.ServerWide.Context;
 

--- a/src/Raven.Server/Smuggler/Documents/Data/ISmugglerDestination.cs
+++ b/src/Raven.Server/Smuggler/Documents/Data/ISmugglerDestination.cs
@@ -20,7 +20,7 @@ namespace Raven.Server.Smuggler.Documents.Data
 
     public interface IDocumentActions : INewDocumentActions, IDisposable
     {
-        void WriteDocument(Document document);
+        void WriteDocument(DocumentItem item);
     }
 
     public interface INewDocumentActions

--- a/src/Raven.Server/Smuggler/Documents/Data/ISmugglerDestination.cs
+++ b/src/Raven.Server/Smuggler/Documents/Data/ISmugglerDestination.cs
@@ -19,7 +19,7 @@ namespace Raven.Server.Smuggler.Documents.Data
 
     public interface IDocumentActions : INewDocumentActions, IDisposable
     {
-        void WriteDocument(DocumentItem item);
+        void WriteDocument(DocumentItem item, SmugglerProgressBase.CountsWithLastEtag progress);
     }
 
     public interface INewDocumentActions

--- a/src/Raven.Server/Smuggler/Documents/Data/ISmugglerSource.cs
+++ b/src/Raven.Server/Smuggler/Documents/Data/ISmugglerSource.cs
@@ -11,8 +11,8 @@ namespace Raven.Server.Smuggler.Documents.Data
     {
         IDisposable Initialize(DatabaseSmugglerOptions options, SmugglerResult result, out long buildVersion);
         DatabaseItemType GetNextType();
-        IEnumerable<Document> GetDocuments(List<string> collectionsToExport, INewDocumentActions actions);
-        IEnumerable<Document> GetRevisionDocuments(List<string> collectionsToExport, INewDocumentActions actions, int limit);
+        IEnumerable<DocumentItem> GetDocuments(List<string> collectionsToExport, INewDocumentActions actions);
+        IEnumerable<DocumentItem> GetRevisionDocuments(List<string> collectionsToExport, INewDocumentActions actions, int limit);
         IEnumerable<IndexDefinitionAndType> GetIndexes();
         IEnumerable<TransformerDefinition> GetTransformers();
         IEnumerable<KeyValuePair<string, long>> GetIdentities();

--- a/src/Raven.Server/Smuggler/Documents/Data/SmugglerResult.cs
+++ b/src/Raven.Server/Smuggler/Documents/Data/SmugglerResult.cs
@@ -95,7 +95,6 @@ namespace Raven.Server.Smuggler.Documents.Data
             {
                 var json = base.ToJson();
                 json[nameof(Message)] = Message;
-
                 return json;
             }
         }
@@ -118,9 +117,9 @@ namespace Raven.Server.Smuggler.Documents.Data
             return new DynamicJsonValue(GetType())
             {
                 [nameof(Documents)] = Documents.ToJson(),
+                [nameof(RevisionDocuments)] = RevisionDocuments.ToJson(),
                 [nameof(Identities)] = Identities.ToJson(),
                 [nameof(Indexes)] = Indexes.ToJson(),
-                [nameof(RevisionDocuments)] = RevisionDocuments.ToJson(),
                 [nameof(Transformers)] = Transformers.ToJson()
             };
         }
@@ -156,12 +155,19 @@ namespace Raven.Server.Smuggler.Documents.Data
         {
             public long LastEtag { get; set; }
 
+            public Counts Attachemnts { get; set; } = new Counts();
+
             public override DynamicJsonValue ToJson()
             {
                 var json = base.ToJson();
                 json[nameof(LastEtag)] = LastEtag;
-
+                json[nameof(Attachemnts)] = Attachemnts.ToJson();
                 return json;
+            }
+
+            public override string ToString()
+            {
+                return $"{base.ToString()} Attachments: {Attachemnts}";
             }
         }
 
@@ -173,13 +179,12 @@ namespace Raven.Server.Smuggler.Documents.Data
             {
                 var json = base.ToJson();
                 json[nameof(SkippedCount)] = SkippedCount;
-
                 return json;
             }
 
             public override string ToString()
             {
-                return $"Read: {ReadCount}. Skipped: {SkippedCount}. Errored: {ErroredCount}.";
+                return $"Skipped: {SkippedCount}. {base.ToString()}";
             }
         }
     }

--- a/src/Raven.Server/Smuggler/Documents/DatabaseDestination.cs
+++ b/src/Raven.Server/Smuggler/Documents/DatabaseDestination.cs
@@ -137,8 +137,10 @@ namespace Raven.Server.Smuggler.Documents
                 };
             }
 
-            public void WriteDocument(DocumentItem item)
+            public void WriteDocument(DocumentItem item, SmugglerProgressBase.CountsWithLastEtag progress)
             {
+                if (item.Attachments != null)
+                    progress.Attachemnts.ReadCount += item.Attachments.Count;
                 _command.Add(item);
                 HandleBatchOfDocumentsIfNecessary();
             }

--- a/src/Raven.Server/Smuggler/Documents/DatabaseDestination.cs
+++ b/src/Raven.Server/Smuggler/Documents/DatabaseDestination.cs
@@ -137,31 +137,10 @@ namespace Raven.Server.Smuggler.Documents
                 };
             }
 
-            public void WriteDocument(Document document)
+            public void WriteDocument(DocumentItem item)
             {
-                _command.Add(new DocumentItem
-                {
-                    Type = DocumentType.Document,
-                    Document = document,
-                });
-
+                _command.Add(item);
                 HandleBatchOfDocumentsIfNecessary();
-            }
-
-            public void WriteAttachment(StreamSource.AttachmentStream attachment)
-            {
-                _command.Add(new DocumentItem
-                {
-                    Type = DocumentType.Attachment,
-                    Attachment = attachment,
-                });
-            }
-
-            public StreamSource.AttachmentStream CreateAttachment()
-            {
-                var attachment = new StreamSource.AttachmentStream();
-                attachment.FileDispose = _database.DocumentsStorage.AttachmentsStorage.GetTempFile(out attachment.File, "smuggler-");
-                return attachment;
             }
 
             public DocumentsOperationContext GetContextForNewDocument()
@@ -299,14 +278,16 @@ namespace Raven.Server.Smuggler.Documents
 
                 foreach (var documentType in Documents)
                 {
-                    if (documentType.Type == DocumentType.Attachment)
+                    if (documentType.Attachments != null)
                     {
-                        using (var attachment = documentType.Attachment)
-                        using (Slice.From(context.Allocator, "Smuggler", out Slice tag)) // TODO: Export the tag also
+                        foreach (var attachment in documentType.Attachments)
                         {
-                            _database.DocumentsStorage.AttachmentsStorage.PutAttachmentStream(context, tag, attachment.Base64Hash, attachment.File);
+                            using (attachment)
+                            using (Slice.From(context.Allocator, "Smuggler", out Slice tag)) // TODO: Export the tag also
+                            {
+                                _database.DocumentsStorage.AttachmentsStorage.PutAttachmentStream(context, tag, attachment.Base64Hash, attachment.File);
+                            }
                         }
-                        continue;
                     }
 
                     var document = documentType.Document;

--- a/src/Raven.Server/Smuggler/Documents/DatabaseSmuggler.cs
+++ b/src/Raven.Server/Smuggler/Documents/DatabaseSmuggler.cs
@@ -331,18 +331,17 @@ namespace Raven.Server.Smuggler.Documents
                         _onProgress.Invoke(result.Progress);
                     }
 
-                    var document = item.Document;
-                    if (document == null)
+                    if (item.Document == null)
                     {
                         result.RevisionDocuments.ErroredCount++;
                         continue;
                     }
 
-                    Debug.Assert(document.Key != null);
+                    Debug.Assert(item.Document.Key != null);
 
-                    WriteUniqueAttachmentStreams(document, actions, result.RevisionDocuments);
+                    WriteUniqueAttachmentStreams(item.Document, actions, result.RevisionDocuments);
 
-                    document.NonPersistentFlags |= NonPersistentDocumentFlags.FromSmuggler;
+                    item.Document.NonPersistentFlags |= NonPersistentDocumentFlags.FromSmuggler;
 
                     if (item.Attachments != null)
                     {
@@ -351,7 +350,7 @@ namespace Raven.Server.Smuggler.Documents
 
                     actions.WriteDocument(item);
 
-                    result.RevisionDocuments.LastEtag = document.Etag;
+                    result.RevisionDocuments.LastEtag = item.Document.Etag;
                 }
             }
 
@@ -376,34 +375,33 @@ namespace Raven.Server.Smuggler.Documents
                         _onProgress.Invoke(result.Progress);
                     }
 
-                    var document = item.Document;
-                    if (document == null)
+                    if (item.Document == null)
                     {
                         result.Documents.ErroredCount++;
                         continue;
                     }
 
-                    if (document.Key == null)
+                    if (item.Document.Key == null)
                         ThrowInvalidData();
 
-                    if (CanSkipDocument(document, buildType))
+                    if (CanSkipDocument(item.Document, buildType))
                     {
                         SkipDocument(item, result);
                         continue;
                     }
 
-                    if (_options.IncludeExpired == false && document.Expired(_time.GetUtcNow()))
+                    if (_options.IncludeExpired == false && item.Document.Expired(_time.GetUtcNow()))
                     {
                         SkipDocument(item, result);
                         continue;
                     }
 
-                    WriteUniqueAttachmentStreams(document, actions, result.Documents);
+                    WriteUniqueAttachmentStreams(item.Document, actions, result.Documents);
 
                     if (_patcher != null)
                     {
-                        document = _patcher.Transform(document, actions.GetContextForNewDocument());
-                        if (document == null)
+                        item.Document = _patcher.Transform(item.Document, actions.GetContextForNewDocument());
+                        if (item.Document == null)
                         {
                             result.Documents.SkippedCount++;
                             continue;
@@ -412,7 +410,7 @@ namespace Raven.Server.Smuggler.Documents
 
                     // TODO: RavenDB-6931 - Make sure that patching cannot change the @attachments and @collectoin in metadata
 
-                    document.NonPersistentFlags |= NonPersistentDocumentFlags.FromSmuggler;
+                    item.Document.NonPersistentFlags |= NonPersistentDocumentFlags.FromSmuggler;
 
                     if (item.Attachments != null)
                     {
@@ -421,7 +419,7 @@ namespace Raven.Server.Smuggler.Documents
 
                     actions.WriteDocument(item);
 
-                    result.Documents.LastEtag = document.Etag;
+                    result.Documents.LastEtag = item.Document.Etag;
                 }
             }
 

--- a/src/Raven.Server/Smuggler/Documents/DatabaseSmuggler.cs
+++ b/src/Raven.Server/Smuggler/Documents/DatabaseSmuggler.cs
@@ -29,7 +29,7 @@ namespace Raven.Server.Smuggler.Documents
         private readonly Action<IOperationProgress> _onProgress;
         private readonly SmugglerPatcher _patcher;
         private CancellationToken _token;
-        private HashSet<LazyStringValue> _attachmentStreamsAlreadyExported;
+        private HashSet<string> _attachmentStreamsAlreadyExported;
 
         public DatabaseSmuggler(
             ISmugglerSource source,
@@ -459,7 +459,7 @@ namespace Raven.Server.Smuggler.Documents
                 return;
 
             if (_attachmentStreamsAlreadyExported == null)
-                _attachmentStreamsAlreadyExported = new HashSet<LazyStringValue>();
+                _attachmentStreamsAlreadyExported = new HashSet<string>();
 
             foreach (BlittableJsonReaderObject attachment in attachments)
             {

--- a/src/Raven.Server/Smuggler/Documents/DatabaseSource.cs
+++ b/src/Raven.Server/Smuggler/Documents/DatabaseSource.cs
@@ -69,20 +69,35 @@ namespace Raven.Server.Smuggler.Documents
             return _types[_currentTypeIndex++];
         }
 
-        public IEnumerable<Document> GetDocuments(List<string> collectionsToExport, INewDocumentActions actions)
+        public IEnumerable<DocumentItem> GetDocuments(List<string> collectionsToExport, INewDocumentActions actions)
         {
-            return collectionsToExport.Count != 0
+            var documents = collectionsToExport.Count != 0
                 ? _database.DocumentsStorage.GetDocumentsFrom(_context, collectionsToExport, _startDocsEtag, int.MaxValue)
                 : _database.DocumentsStorage.GetDocumentsFrom(_context, _startDocsEtag, 0, int.MaxValue);
+
+            foreach (var document in documents)
+            {
+                yield return new DocumentItem
+                {
+                    Document = document,
+                };
+            }
         }
 
-        public IEnumerable<Document> GetRevisionDocuments(List<string> collectionsToExport, INewDocumentActions actions, int limit)
+        public IEnumerable<DocumentItem> GetRevisionDocuments(List<string> collectionsToExport, INewDocumentActions actions, int limit)
         {
             var versioningStorage = _database.BundleLoader.VersioningStorage;
             if (versioningStorage == null)
-                return Enumerable.Empty<Document>();
+                yield break;
 
-            return versioningStorage.GetRevisionsFrom(_context, _startRevisionDocumentsEtag, limit);
+            var documents = versioningStorage.GetRevisionsFrom(_context, _startRevisionDocumentsEtag, limit);
+            foreach (var document in documents)
+            {
+                yield return new DocumentItem
+                {
+                    Document = document,
+                };
+            }
         }
 
         public Stream GetAttachmentStream(LazyStringValue hash)

--- a/src/Raven.Server/Smuggler/Documents/Handlers/SmugglerHandler.cs
+++ b/src/Raven.Server/Smuggler/Documents/Handlers/SmugglerHandler.cs
@@ -122,7 +122,11 @@ namespace Raven.Server.Smuggler.Documents.Handlers
                 }
                 else
                 {
-                    ExportDatabaseInternal(options, null, context, token);
+                    var result = (SmugglerResult)ExportDatabaseInternal(options, null, context, token);
+                    using (var writer = new BlittableJsonTextWriter(context, ResponseBodyStream()))
+                    {
+                        context.Write(writer, result.ToJson());
+                    }
                 }
             }
         }
@@ -201,7 +205,7 @@ namespace Raven.Server.Smuggler.Documents.Handlers
                         using (var file = await getFile())
                         using (var stream = new GZipStream(new BufferedStream(file, 128 * Voron.Global.Constants.Size.Kilobyte), CompressionMode.Decompress))
                         {
-                            var source = new StreamSource(stream, context);
+                            var source = new StreamSource(stream, context, Database);
                             var destination = new DatabaseDestination(Database);
 
                             var smuggler = new DatabaseSmuggler(source, destination, Database.Time);
@@ -222,10 +226,12 @@ namespace Raven.Server.Smuggler.Documents.Handlers
                 finalResult.Documents.ReadCount += importResult.Documents.ReadCount;
                 finalResult.Documents.ErroredCount += importResult.Documents.ErroredCount;
                 finalResult.Documents.LastEtag = Math.Max(finalResult.Documents.LastEtag, importResult.Documents.LastEtag);
+                finalResult.Documents.Attachemnts = importResult.Documents.Attachemnts;
 
                 finalResult.RevisionDocuments.ReadCount += importResult.RevisionDocuments.ReadCount;
                 finalResult.RevisionDocuments.ErroredCount += importResult.RevisionDocuments.ErroredCount;
                 finalResult.RevisionDocuments.LastEtag = Math.Max(finalResult.RevisionDocuments.LastEtag, importResult.RevisionDocuments.LastEtag);
+                finalResult.RevisionDocuments.Attachemnts = importResult.RevisionDocuments.Attachemnts;
 
                 finalResult.Identities.ReadCount += importResult.Identities.ReadCount;
                 finalResult.Identities.ErroredCount += importResult.Identities.ErroredCount;
@@ -285,7 +291,7 @@ namespace Raven.Server.Smuggler.Documents.Handlers
                 using (var stream = new GZipStream(new BufferedStream(await GetImportStream(), 128 * Voron.Global.Constants.Size.Kilobyte), CompressionMode.Decompress))
                 using (token)
                 {
-                    var source = new StreamSource(stream, context);
+                    var source = new StreamSource(stream, context, Database);
                     var destination = new DatabaseDestination(Database);
 
                     var smuggler = new DatabaseSmuggler(source, destination, Database.Time, options, token: token.Token);
@@ -385,7 +391,7 @@ namespace Raven.Server.Smuggler.Documents.Handlers
             using (stream)
             using (token)
             {
-                var source = new StreamSource(stream, context);
+                var source = new StreamSource(stream, context, Database);
                 var destination = new DatabaseDestination(Database);
                 var smuggler = new DatabaseSmuggler(source, destination, Database.Time, options, result, onProgress, token.Token);
 

--- a/src/Raven.Server/Smuggler/Documents/Handlers/SmugglerHandler.cs
+++ b/src/Raven.Server/Smuggler/Documents/Handlers/SmugglerHandler.cs
@@ -136,7 +136,7 @@ namespace Raven.Server.Smuggler.Documents.Handlers
             using (token)
             {
                 var source = new DatabaseSource(Database, 0, 0);
-                var destination = new StreamDestination(ResponseBodyStream(), context);
+                var destination = new StreamDestination(ResponseBodyStream(), context, source);
                 var smuggler = new DatabaseSmuggler(source, destination, Database.Time, options, onProgress: onProgress, token: token.Token);
                 return smuggler.Execute();
             }

--- a/src/Raven.Server/Smuggler/Documents/SmugglerDocumentType.cs
+++ b/src/Raven.Server/Smuggler/Documents/SmugglerDocumentType.cs
@@ -1,4 +1,10 @@
-﻿using Raven.Server.Documents;
+﻿using System;
+using System.Collections.Generic;
+using System.IO;
+using Raven.Server.Documents;
+using Sparrow;
+using Sparrow.Json;
+using Voron;
 
 namespace Raven.Server.Smuggler.Documents
 {
@@ -12,8 +18,25 @@ namespace Raven.Server.Smuggler.Documents
     {
         public const string Key = "@document-type";
 
-        public DocumentType Type;
         public Document Document;
-        public StreamSource.AttachmentStream Attachment;
+        public List<AttachmentStream> Attachments;
+
+        public struct AttachmentStream : IDisposable
+        {
+            public Slice Base64Hash;
+            public ByteStringContext<ByteStringMemoryCache>.ExternalScope Base64HashDispose;
+
+            public FileStream File;
+            public AttachmentsStorage.ReleaseTempFile FileDispose;
+
+            public BlittableJsonReaderObject Data;
+
+            public void Dispose()
+            {
+                Base64HashDispose.Dispose();
+                FileDispose.Dispose();
+                Data.Dispose();
+            }
+        }
     }
 }

--- a/src/Raven.Server/Smuggler/Documents/SmugglerDocumentType.cs
+++ b/src/Raven.Server/Smuggler/Documents/SmugglerDocumentType.cs
@@ -14,7 +14,7 @@ namespace Raven.Server.Smuggler.Documents
         Attachment = 2,
     }
 
-    public struct DocumentItem
+    public class DocumentItem
     {
         public const string Key = "@document-type";
 

--- a/src/Raven.Server/Smuggler/Documents/StreamDestination.cs
+++ b/src/Raven.Server/Smuggler/Documents/StreamDestination.cs
@@ -6,7 +6,6 @@ using Raven.Client.Documents.Operations;
 using Raven.Client.Documents.Smuggler;
 using Raven.Client.Documents.Transformers;
 using Raven.Client.Util;
-using Raven.Server.Documents;
 using Raven.Server.Documents.Indexes;
 using Raven.Server.Json;
 using Raven.Server.ServerWide.Context;
@@ -148,8 +147,12 @@ namespace Raven.Server.Smuggler.Documents
                 _context = context;
             }
 
-            public void WriteDocument(Document document)
+            public void WriteDocument(DocumentItem item)
             {
+                if (item.Attachments != null)
+                    throw new NotSupportedException();
+
+                var document = item.Document;
                 using (document.Data)
                 {
                     if (First == false)

--- a/src/Raven.Server/Smuggler/Documents/StreamDestination.cs
+++ b/src/Raven.Server/Smuggler/Documents/StreamDestination.cs
@@ -1,11 +1,14 @@
 ﻿using System;
+using System.Collections.Generic;
 using System.IO;
 using System.IO.Compression;
+using Raven.Client;
 using Raven.Client.Documents.Indexes;
 using Raven.Client.Documents.Operations;
 using Raven.Client.Documents.Smuggler;
 using Raven.Client.Documents.Transformers;
 using Raven.Client.Util;
+using Raven.Server.Documents;
 using Raven.Server.Documents.Indexes;
 using Raven.Server.Json;
 using Raven.Server.ServerWide.Context;
@@ -19,12 +22,14 @@ namespace Raven.Server.Smuggler.Documents
         private readonly Stream _stream;
         private GZipStream _gzipStream;
         private readonly DocumentsOperationContext _context;
+        private readonly DatabaseSource _source;
         private BlittableJsonTextWriter _writer;
 
-        public StreamDestination(Stream stream, DocumentsOperationContext context)
+        public StreamDestination(Stream stream, DocumentsOperationContext context, DatabaseSource source)
         {
             _stream = stream;
             _context = context;
+            _source = source;
         }
 
         public IDisposable Initialize(DatabaseSmugglerOptions options, SmugglerResult result, long buildVersion)
@@ -47,12 +52,12 @@ namespace Raven.Server.Smuggler.Documents
 
         public IDocumentActions Documents()
         {
-            return new StreamDocumentActions(_writer, _context, isRevision: false);
+            return new StreamDocumentActions(_writer, _context, _source, isRevision: false);
         }
 
         public IDocumentActions RevisionDocuments()
         {
-            return new StreamDocumentActions(_writer, _context, isRevision: true);
+            return new StreamDocumentActions(_writer, _context, _source, isRevision: true);
         }
 
         public IIdentityActions Identities()
@@ -137,17 +142,20 @@ namespace Raven.Server.Smuggler.Documents
             }
         }
 
-        public class StreamDocumentActions : StreamActionsBase, IDocumentActions
+        private class StreamDocumentActions : StreamActionsBase, IDocumentActions
         {
             private readonly DocumentsOperationContext _context;
+            private readonly DatabaseSource _source;
+            private HashSet<string> _attachmentStreamsAlreadyExported;
 
-            public StreamDocumentActions(BlittableJsonTextWriter writer, DocumentsOperationContext context, bool isRevision)
+            public StreamDocumentActions(BlittableJsonTextWriter writer, DocumentsOperationContext context, DatabaseSource source, bool isRevision)
                 : base(writer, isRevision ? "RevisionDocuments" : "Docs")
             {
                 _context = context;
+                _source = source;
             }
 
-            public void WriteDocument(DocumentItem item)
+            public void WriteDocument(DocumentItem item, SmugglerProgressBase.CountsWithLastEtag progress)
             {
                 if (item.Attachments != null)
                     throw new NotSupportedException();
@@ -155,6 +163,8 @@ namespace Raven.Server.Smuggler.Documents
                 var document = item.Document;
                 using (document.Data)
                 {
+                    WriteUniqueAttachmentStreams(document, progress);
+
                     if (First == false)
                         Writer.WriteComma();
                     First = false;
@@ -164,13 +174,45 @@ namespace Raven.Server.Smuggler.Documents
                 }
             }
 
+            private void WriteUniqueAttachmentStreams(Document document, SmugglerProgressBase.CountsWithLastEtag progress)
+            {
+                if ((document.Flags & DocumentFlags.HasAttachments) != DocumentFlags.HasAttachments ||
+                    document.Data.TryGet(Constants.Documents.Metadata.Key, out BlittableJsonReaderObject metadata) == false ||
+                    metadata.TryGet(Constants.Documents.Metadata.Attachments, out BlittableJsonReaderArray attachments) == false)
+                    return;
+
+                if (_attachmentStreamsAlreadyExported == null)
+                    _attachmentStreamsAlreadyExported = new HashSet<string>();
+
+                foreach (BlittableJsonReaderObject attachment in attachments)
+                {
+                    if (attachment.TryGet(nameof(AttachmentResult.Hash), out LazyStringValue hash) == false)
+                    {
+                        progress.Attachemnts.ErroredCount++;
+
+                        // TODO: How should we handle errors here?
+                        throw new ArgumentException($"Hash field is mandatory in attachment's metadata: {attachment}");
+                    }
+
+                    progress.Attachemnts.ReadCount++;
+
+                    if (_attachmentStreamsAlreadyExported.Add(hash))
+                    {
+                        using (var stream = _source.GetAttachmentStream(hash))
+                        {
+                            WriteAttachmentStream(hash, stream);
+                        }
+                    }
+                }
+            }
+
             public DocumentsOperationContext GetContextForNewDocument()
             {
                 _context.CachedProperties.NewDocument();
                 return _context;
             }
 
-            public void WriteAttachmentStream(LazyStringValue hash, Stream stream)
+            private void WriteAttachmentStream(LazyStringValue hash, Stream stream)
             {
                 if (First == false)
                     Writer.WriteComma();
@@ -218,7 +260,7 @@ namespace Raven.Server.Smuggler.Documents
             }
         }
 
-        public abstract class StreamActionsBase : IDisposable
+        private abstract class StreamActionsBase : IDisposable
         {
             protected readonly BlittableJsonTextWriter Writer;
 

--- a/src/Raven.Server/Web/Studio/SampleDataHandler.cs
+++ b/src/Raven.Server/Web/Studio/SampleDataHandler.cs
@@ -34,7 +34,7 @@ namespace Raven.Server.Web.Studio
                 {
                     using (var stream = new GZipStream(sampleData, CompressionMode.Decompress))
                     {
-                        var source = new StreamSource(stream, context);
+                        var source = new StreamSource(stream, context, Database);
                         var destination = new DatabaseDestination(Database);
 
                         var smuggler = new DatabaseSmuggler(source, destination, Database.Time);

--- a/test/FastTests/Client/Attachments/AttachmentsSmuggler.cs
+++ b/test/FastTests/Client/Attachments/AttachmentsSmuggler.cs
@@ -25,7 +25,8 @@ namespace FastTests.Client.Attachments
                     using (var bigStream = new MemoryStream(Enumerable.Range(1, 999 * 1024).Select(x => (byte)x).ToArray()))
                         store1.Operations.Send(new PutAttachmentOperation("users/1", "big-file", bigStream, "image/png"));
 
-                    await store1.Smuggler.ExportAsync(new DatabaseSmugglerOptions(), file);
+                    /*var result = */await store1.Smuggler.ExportAsync(new DatabaseSmugglerOptions(), file);
+                    // TODO: RavenDB-6936 store.Smuggler.Export and Import method should return the SmugglerResult
 
                     var stats = await store1.Admin.SendAsync(new GetStatisticsOperation());
                     Assert.Equal(1, stats.CountOfDocuments);

--- a/test/SlowTests/Issues/RavenDB_5998.cs
+++ b/test/SlowTests/Issues/RavenDB_5998.cs
@@ -25,7 +25,7 @@ namespace SlowTests.Issues
                 using (var database = CreateDocumentDatabase())
                 using (database.DocumentsStorage.ContextPool.AllocateOperationContext(out context))
                 {
-                    var source = new StreamSource(stream, context);
+                    var source = new StreamSource(stream, context, database);
                     var destination = new DatabaseDestination(database);
 
                     var smuggler = new DatabaseSmuggler(source, destination, database.Time, new DatabaseSmugglerOptions


### PR DESCRIPTION
We now import attachments only if the document itself is imported. So if the document is Skipped, we won't put its attachments.