### PR TITLE
RavenDB-5935 Replication: should update all incoming replications abo…

### DIFF
--- a/src/Raven.Server/Documents/DocumentsTransaction.cs
+++ b/src/Raven.Server/Documents/DocumentsTransaction.cs
@@ -37,7 +37,7 @@ namespace Raven.Server.Documents
 
         public void AddAfterCommitNotification(DocumentChange change)
         {
-            change.TriggeredByReplicationThread = IncomingReplicationHandler.IsIncomingReplicationThread;
+            change.TriggeredByReplicationThread = IncomingReplicationHandler.IsIncomingReplication;
 
             if (change.IsSystemDocument)
             {

--- a/src/Raven.Server/Documents/Replication/OutgoingReplicationHandler.cs
+++ b/src/Raven.Server/Documents/Replication/OutgoingReplicationHandler.cs
@@ -83,7 +83,6 @@ namespace Raven.Server.Documents.Replication
             _log = LoggingSource.Instance.GetLogger<OutgoingReplicationHandler>(_database.Name);
             
             _database.Changes.OnDocumentChange += OnDocumentChange;
-            _database.Changes.OnTransformerChange += OnTransformerChange;
             _cts = CancellationTokenSource.CreateLinkedTokenSource(_database.DatabaseShutdown);
         }
 
@@ -561,22 +560,6 @@ namespace Raven.Server.Documents.Replication
             _waitForChanges.Set();
         }
       
-
-        private void OnTransformerChange(TransformerChange change)
-        {
-            if (change.Type != TransformerChangeTypes.TransformerAdded &&
-                change.Type != TransformerChangeTypes.TransformerRemoved)
-                return;
-
-            if (_log.IsInfoEnabled)
-                _log.Info(
-                    $"Received transformer {change.Type} event, transformer name = {change.Name}, etag = {change.Etag}");
-
-            if (IncomingReplicationHandler.IsIncomingReplicationThread)
-                return;
-            _waitForChanges.Set();
-        }
-
         private int _disposed;
         public void Dispose()
         {
@@ -587,7 +570,6 @@ namespace Raven.Server.Documents.Replication
                 _log.Info($"Disposing OutgoingReplicationHandler ({FromToString})");
 
             _database.Changes.OnDocumentChange -= OnDocumentChange;
-            _database.Changes.OnTransformerChange -= OnTransformerChange;
 
             _cts.Cancel();
 

--- a/test/Tests.Infrastructure/RavenTestBase.cs
+++ b/test/Tests.Infrastructure/RavenTestBase.cs
@@ -247,6 +247,37 @@ namespace FastTests
             } while (true);
         }
 
+        protected async Task<T> WaitForValueAsync<T>(Func<T> act, T expectedVal)
+        {
+            int timeout = 5000 * (Debugger.IsAttached ? 100 : 1);
+            
+            var sw = Stopwatch.StartNew();
+            do
+            {
+                try
+                {
+                    var currentVal = act();
+                    if (expectedVal.Equals(currentVal))
+                    {
+                        return currentVal;
+                    }
+                    if (sw.ElapsedMilliseconds > timeout)
+                    {
+                        return currentVal;
+                    }
+                }
+                catch
+                {
+                    if (sw.ElapsedMilliseconds > timeout)
+                    {
+                        throw;
+                    }
+                }
+                await Task.Delay(100);
+            } while (true);
+        }
+
+
         protected T WaitForValue<T>(Func<T> act, T expectedVal)
         {
             int timeout = 15000;
@@ -269,11 +300,12 @@ namespace FastTests
                 }
                 catch
                 {
-                    if (sw.ElapsedMilliseconds <= timeout)
+                    if (sw.ElapsedMilliseconds > timeout)
                     {
                         throw;
                     }
                 }
+
                 Thread.Sleep(16);
             } while (true);
         }


### PR DESCRIPTION
…ut CV when receiving a replication batch

The problem was, that after moving the replication to the transaction merger, we performed the PUT action always in the same thread.