### PR TITLE
RavenDB-6285

### DIFF
--- a/src/Raven.Client/Documents/Changes/ChangeNotification.cs
+++ b/src/Raven.Client/Documents/Changes/ChangeNotification.cs
@@ -12,13 +12,6 @@ namespace Raven.Client.Documents.Changes
 {
     public class DocumentChange : DatabaseChange
     {
-        private string _key;
-
-        [Newtonsoft.Json.JsonIgnore]
-        public Func<object, string> MaterializeKey;
-
-        public object MaterializeKeyState;
-
         /// <summary>
         /// Type of change that occurred on document.
         /// </summary>
@@ -27,20 +20,7 @@ namespace Raven.Client.Documents.Changes
         /// <summary>
         /// Identifier of document for which notification was created.
         /// </summary>
-        public string Key
-        {
-            get
-            {
-                if (_key == null && MaterializeKey != null)
-                {
-                    _key = MaterializeKey(MaterializeKeyState);
-                    MaterializeKey = null;
-                    MaterializeKeyState = null;
-                }
-                return _key;
-            }
-            set { _key = value; }
-        }
+        public string Key { get; set; }
 
         /// <summary>
         /// Document collection name.

--- a/src/Raven.Client/Documents/Changes/ConnectionStateBase.cs
+++ b/src/Raven.Client/Documents/Changes/ConnectionStateBase.cs
@@ -37,7 +37,7 @@ namespace Raven.Client.Documents.Changes
             lock (this)
             {
                 if (--_value == 0)
-                    AsyncHelpers.RunSync(() => _onDisconnect());
+                    _onDisconnect();
             }
         }
 

--- a/test/FastTests/Server/Documents/Notifications/ChangesTests.cs
+++ b/test/FastTests/Server/Documents/Notifications/ChangesTests.cs
@@ -125,7 +125,7 @@ namespace FastTests.Server.Documents.Notifications
                 }
 
                 DocumentChange documentChange;
-                Assert.True(list.TryTake(out documentChange, TimeSpan.FromSeconds(2)));
+                Assert.True(list.TryTake(out documentChange, TimeSpan.FromSeconds(15)));
 
                 observableWithTask = taskObservable.ForDocument("users/2");
                 //await observableWithTask.Task;
@@ -137,12 +137,12 @@ namespace FastTests.Server.Documents.Notifications
                     await session.SaveChangesAsync();
                 }
 
-                Assert.True(list.TryTake(out documentChange, TimeSpan.FromSeconds(2)));
+                Assert.True(list.TryTake(out documentChange, TimeSpan.FromSeconds(15)));
             }
         }
 
         [Fact]
-        public async Task NotificationOnWrongDatabase_ShouldNotCrashServer()
+        public void NotificationOnWrongDatabase_ShouldNotCrashServer()
         {
             using (var store = GetDocumentStore())
             {
@@ -151,7 +151,7 @@ namespace FastTests.Server.Documents.Notifications
                 var taskObservable = store.Changes("does-not-exists");
                 taskObservable.OnError += e => mre.Set();
 
-                Assert.True(mre.Wait(5000));
+                Assert.True(mre.Wait(TimeSpan.FromSeconds(15)));
 
                 // ensure the db still works
                 store.Admin.Send(new GetStatisticsOperation());


### PR DESCRIPTION
- removed MaterializeKey from DocumentChange (was not used)
- we do not need to disconnect in synchronous manner after unsubscribing
- we do not want to send watch/unwatch command when we are disconnected