### PR TITLE
RavenDB-6285

### DIFF
--- a/src/Raven.Client/Documents/Changes/ChangeNotification.cs
+++ b/src/Raven.Client/Documents/Changes/ChangeNotification.cs
@@ -12,13 +12,6 @@ namespace Raven.Client.Documents.Changes
 {
     public class DocumentChange : DatabaseChange
     {
-        private string _key;
-
-        [Newtonsoft.Json.JsonIgnore]
-        public Func<object, string> MaterializeKey;
-
-        public object MaterializeKeyState;
-
         /// <summary>
         /// Type of change that occurred on document.
         /// </summary>
@@ -27,20 +20,7 @@ namespace Raven.Client.Documents.Changes
         /// <summary>
         /// Identifier of document for which notification was created.
         /// </summary>
-        public string Key
-        {
-            get
-            {
-                if (_key == null && MaterializeKey != null)
-                {
-                    _key = MaterializeKey(MaterializeKeyState);
-                    MaterializeKey = null;
-                    MaterializeKeyState = null;
-                }
-                return _key;
-            }
-            set { _key = value; }
-        }
+        public string Key { get; set; }
 
         /// <summary>
         /// Document collection name.

--- a/src/Raven.Client/Documents/Changes/ConnectionStateBase.cs
+++ b/src/Raven.Client/Documents/Changes/ConnectionStateBase.cs
@@ -28,7 +28,7 @@ namespace Raven.Client.Documents.Changes
             lock (this)
             {
                 if (++_value == 1)
-                    _onConnect();
+                    AsyncHelpers.RunSync(() => _onConnect());
             }
         }
 

--- a/src/Raven.Client/Documents/Changes/IConnectableChanges.cs
+++ b/src/Raven.Client/Documents/Changes/IConnectableChanges.cs
@@ -1,10 +1,14 @@
 using System;
+using System.Threading.Tasks;
 
 namespace Raven.Client.Documents.Changes
 {
-    public interface IConnectableChanges : IDisposable
+    public interface IConnectableChanges<TChanges> : IDisposable
+        where TChanges : IDatabaseChanges
     {
         bool Connected { get; }
+
+        Task<TChanges> EnsureConnectedNow();
 
         event EventHandler ConnectionStatusChanged;
 

--- a/src/Raven.Client/Documents/Changes/IDatabaseChanges.cs
+++ b/src/Raven.Client/Documents/Changes/IDatabaseChanges.cs
@@ -3,7 +3,7 @@ using Raven.Client.Documents.Operations;
 
 namespace Raven.Client.Documents.Changes
 {
-    public interface IDatabaseChanges : IConnectableChanges
+    public interface IDatabaseChanges : IConnectableChanges<IDatabaseChanges>
     {
         /// <summary>
         /// Subscribe to changes for specified index only.

--- a/src/Raven.Client/Documents/Operations/Operation.cs
+++ b/src/Raven.Client/Documents/Operations/Operation.cs
@@ -38,7 +38,10 @@ namespace Raven.Client.Documents.Operations
         {
             try
             {
-                _subscription = _changes().ForOperationId(_id).Subscribe(this);
+                var changes = await _changes().EnsureConnectedNow();
+                _subscription = changes
+                    .ForOperationId(_id)
+                    .Subscribe(this);
                 await FetchOperationStatus().ConfigureAwait(false);
             }
             catch (Exception e)
@@ -85,7 +88,7 @@ namespace Raven.Client.Documents.Operations
                 case OperationStatus.Faulted:
                     _subscription?.Dispose();
                     var exceptionResult = (OperationExceptionResult)change.State.Result;
-                    Debug.Assert(exceptionResult!=null);
+                    Debug.Assert(exceptionResult != null);
                     _result.TrySetException(ExceptionDispatcher.Get(exceptionResult.Message, exceptionResult.Error, exceptionResult.Type, exceptionResult.StatusCode));
                     break;
                 case OperationStatus.Canceled:

--- a/test/FastTests/Server/Documents/Notifications/ChangesTests.cs
+++ b/test/FastTests/Server/Documents/Notifications/ChangesTests.cs
@@ -18,7 +18,7 @@ namespace FastTests.Server.Documents.Notifications
             {
                 var list = new BlockingCollection<DocumentChange>();
                 var taskObservable = store.Changes();
-                //await taskObservable.Task;
+                await taskObservable.EnsureConnectedNow();
                 var observableWithTask = taskObservable.ForDocument("users/1");
                 //await observableWithTask.Task;
                 observableWithTask.Subscribe(list.Add);
@@ -45,7 +45,7 @@ namespace FastTests.Server.Documents.Notifications
             {
                 var list = new BlockingCollection<DocumentChange>();
                 var taskObservable = store.Changes();
-                //await taskObservable.Task;
+                await taskObservable.EnsureConnectedNow();
                 var observableWithTask = taskObservable.ForAllDocuments();
                 //await observableWithTask.Task;
                 observableWithTask.Subscribe(list.Add);
@@ -78,7 +78,7 @@ namespace FastTests.Server.Documents.Notifications
             {
                 var list = new BlockingCollection<DocumentChange>();
                 var taskObservable = store.Changes();
-                //await taskObservable.Task;
+                await taskObservable.EnsureConnectedNow();
                 var observableWithTask = taskObservable.ForDocument("users/1");
                 //await observableWithTask.Task;
                 observableWithTask
@@ -113,7 +113,7 @@ namespace FastTests.Server.Documents.Notifications
             {
                 var list = new BlockingCollection<DocumentChange>();
                 var taskObservable = store.Changes();
-                //await taskObservable.Task;
+                await taskObservable.EnsureConnectedNow();
                 var observableWithTask = taskObservable.ForDocument("users/1");
                 //await observableWithTask.Task;
                 observableWithTask.Subscribe(list.Add);
@@ -125,7 +125,7 @@ namespace FastTests.Server.Documents.Notifications
                 }
 
                 DocumentChange documentChange;
-                Assert.True(list.TryTake(out documentChange, TimeSpan.FromSeconds(2)));
+                Assert.True(list.TryTake(out documentChange, TimeSpan.FromSeconds(15)));
 
                 observableWithTask = taskObservable.ForDocument("users/2");
                 //await observableWithTask.Task;
@@ -137,12 +137,12 @@ namespace FastTests.Server.Documents.Notifications
                     await session.SaveChangesAsync();
                 }
 
-                Assert.True(list.TryTake(out documentChange, TimeSpan.FromSeconds(2)));
+                Assert.True(list.TryTake(out documentChange, TimeSpan.FromSeconds(15)));
             }
         }
 
         [Fact]
-        public async Task NotificationOnWrongDatabase_ShouldNotCrashServer()
+        public void NotificationOnWrongDatabase_ShouldNotCrashServer()
         {
             using (var store = GetDocumentStore())
             {
@@ -151,7 +151,7 @@ namespace FastTests.Server.Documents.Notifications
                 var taskObservable = store.Changes("does-not-exists");
                 taskObservable.OnError += e => mre.Set();
 
-                Assert.True(mre.Wait(5000));
+                Assert.True(mre.Wait(TimeSpan.FromSeconds(15)));
 
                 // ensure the db still works
                 store.Admin.Send(new GetStatisticsOperation());


### PR DESCRIPTION
- removed MaterializeKey from DocumentChange (was not used)
- we do not want to send watch/unwatch command when we are disconnected
- need to ensure that we are connected before subscribing in Operations to avoid race condition