### PR TITLE
ShowTiming was not properly used in queries with dynamic indexes (fixes ravendb/bootcamp#39)

### DIFF
--- a/Raven.Database/Queries/DynamicQueryRunner.cs
+++ b/Raven.Database/Queries/DynamicQueryRunner.cs
@@ -99,6 +99,7 @@ namespace Raven.Database.Queries
                 ResultsTransformer = query.ResultsTransformer,
                 TransformerParameters = query.TransformerParameters,
                 ExplainScores = query.ExplainScores,
+                ShowTimings = query.ShowTimings,
                 SortHints = query.SortHints
             };
             if (indexQuery.SortedFields == null)


### PR DESCRIPTION
The following code was not working properly. The reason was the "ShowTimings" property was not being considered when doing queries with dynamic indexes.

```csharp
//var query = session.Query<Order, Orders_ByOrderedAt>()
var query = session.Query<Order>()
    .Statistics(out stats)
    .Customize(q => q.ShowTimings());

var orders = (
        from order in query
        orderby order.OrderedAt
        select order
    )
    .ToList();
```