### PR TITLE
RavenDB-7113 Fixing StackOverflowException. The problem is that this …

### DIFF
--- a/test/FastTests/Issues/RavenDB-6451.cs
+++ b/test/FastTests/Issues/RavenDB-6451.cs
@@ -54,6 +54,9 @@ namespace FastTests.Issues
             {
                 try
                 {
+                    if (t == typeof(Microsoft.Extensions.CommandLineUtils.CommandParsingException))
+                        continue;
+
                     Assert.False(HasInvalidProperties(t), $"The type {t.FullName} should not have pointer or BlittableXXX properties");
                 }
                 catch (Exception e)


### PR DESCRIPTION
…exception has a cycle in properties (one of prop is Parent). We don't need to check it anyway.