### PR TITLE
RavenDB-7097 Renaming `pending-recycle` files to `reusable-journal`. …

### DIFF
--- a/test/FastTests/Voron/Compaction/StorageCompactionTests.cs
+++ b/test/FastTests/Voron/Compaction/StorageCompactionTests.cs
@@ -276,7 +276,7 @@ namespace FastTests.Voron.Compaction
         {
             var files = d.GetFiles();
             var size = files
-                .Where(x=>Path.GetFileNameWithoutExtension(x.Name) != StorageEnvironmentOptions.PendingRecycleFileNamePrefix)
+                .Where(x=>Path.GetFileNameWithoutExtension(x.Name) != StorageEnvironmentOptions.RecyclableJournalFileNamePrefix)
                 .Sum(x => x.Length);
 
             var directories = d.GetDirectories();

--- a/test/SlowTests/Voron/Issues/RavenDB_7097.cs
+++ b/test/SlowTests/Voron/Issues/RavenDB_7097.cs
@@ -1,7 +1,6 @@
 ﻿using System;
 using System.IO;
 using System.Threading;
-using SlowTests.Utils;
 using Voron;
 using Xunit;
 
@@ -15,7 +14,7 @@ namespace SlowTests.Voron.Issues
         }
 
         [Fact]
-        public void Pending_recycle_files_are_deleted_on_dispose()
+        public void Recyclable_journal_files_are_deleted_on_dispose()
         {
             RequireFileBasedPager();
 
@@ -38,12 +37,12 @@ namespace SlowTests.Voron.Issues
             Env.FlushLogToDataFile();
             Env.ForceSyncDataFile();
 
-            SpinWait.SpinUntil(() => new DirectoryInfo(DataDir).GetFiles($"{StorageEnvironmentOptions.PendingRecycleFileNamePrefix}*").Length == 6,
+            SpinWait.SpinUntil(() => new DirectoryInfo(DataDir).GetFiles($"{StorageEnvironmentOptions.RecyclableJournalFileNamePrefix}*").Length == 6,
                 TimeSpan.FromSeconds(30));
 
             Env.Dispose();
 
-            var journalsForReuse = new DirectoryInfo(DataDir).GetFiles($"{StorageEnvironmentOptions.PendingRecycleFileNamePrefix}*");
+            var journalsForReuse = new DirectoryInfo(DataDir).GetFiles($"{StorageEnvironmentOptions.RecyclableJournalFileNamePrefix}*");
 
             Assert.Equal(0, journalsForReuse.Length);
         }

--- a/test/SlowTests/Voron/Issues/RavenDB_7099.cs
+++ b/test/SlowTests/Voron/Issues/RavenDB_7099.cs
@@ -16,7 +16,7 @@ namespace SlowTests.Voron.Issues
 
         [Theory]
         [InlineDataWithRandomSeed()]
-        public void Do_not_create_pending_recycle_files_on_db_load(int seed)
+        public void Do_not_create_recyclable_journal_files_on_db_load(int seed)
         {
             RequireFileBasedPager();
 
@@ -36,20 +36,20 @@ namespace SlowTests.Voron.Issues
                 }
             }
 
-            var journalsForReuse = new DirectoryInfo(DataDir).GetFiles($"{StorageEnvironmentOptions.PendingRecycleFileNamePrefix}*");
+            var journalsForReuse = new DirectoryInfo(DataDir).GetFiles($"{StorageEnvironmentOptions.RecyclableJournalFileNamePrefix}*");
 
             Assert.Equal(0, journalsForReuse.Length);
 
             RestartDatabase();
 
-            journalsForReuse = new DirectoryInfo(DataDir).GetFiles($"{StorageEnvironmentOptions.PendingRecycleFileNamePrefix}*");
+            journalsForReuse = new DirectoryInfo(DataDir).GetFiles($"{StorageEnvironmentOptions.RecyclableJournalFileNamePrefix}*");
 
             Assert.Equal(0, journalsForReuse.Length);
         }
 
         [Theory]
         [InlineDataWithRandomSeed()]
-        public void Flushed_journals_should_become_pending_recycle_files_after_sync(int seed)
+        public void Flushed_journals_should_become_recyclable_files_after_sync(int seed)
         {
             RequireFileBasedPager();
 
@@ -72,7 +72,7 @@ namespace SlowTests.Voron.Issues
             Env.FlushLogToDataFile();
             Env.ForceSyncDataFile();
 
-            SpinWait.SpinUntil(() => new DirectoryInfo(DataDir).GetFiles($"{StorageEnvironmentOptions.PendingRecycleFileNamePrefix}*").Length > 0,
+            SpinWait.SpinUntil(() => new DirectoryInfo(DataDir).GetFiles($"{StorageEnvironmentOptions.RecyclableJournalFileNamePrefix}*").Length > 0,
                 TimeSpan.FromSeconds(30));
         }
     }


### PR DESCRIPTION
…Adding a comment explaining why we might still need to load such files on the db load while we delete them on the db disposal.