### PR TITLE
RavenDB-7168 Cluster erroneously demote node

### DIFF
--- a/src/Raven.Server/ServerWide/Maintance/ClusterObserver.cs
+++ b/src/Raven.Server/ServerWide/Maintance/ClusterObserver.cs
@@ -65,7 +65,7 @@ namespace Raven.Server.ServerWide.Maintance
                 {
                     if (_logger.IsInfoEnabled)
                     {
-                        _logger.Info($"Closing observer on {_nodeTag}, caused by an interrupt.", e);
+                        _logger.Info($"An error occured while analyzing maintainance stats on node {_nodeTag}.", e);
                     }
                 }
                 finally

--- a/test/FastTests/Server/Documents/Indexing/Auto/BasicAutoMapIndexing.cs
+++ b/test/FastTests/Server/Documents/Indexing/Auto/BasicAutoMapIndexing.cs
@@ -115,9 +115,11 @@ namespace FastTests.Server.Documents.Indexing.Auto
                 Assert.True(etag2 > 0);
 
                 var index2 = database.IndexStore.GetIndex(etag2);
-                index2.SetLock(IndexLockMode.LockedError);
-                index2.SetPriority(IndexPriority.Low);
+
+                var task =  Task.WhenAll(database.IndexStore.SetLock(index2.Name, IndexLockMode.LockedError), 
+                    database.IndexStore.SetPriority(index2.Name, IndexPriority.Low));
                 index2.SetState(IndexState.Disabled);
+                await task;
 
                 Server.ServerStore.DatabasesLandlord.UnloadDatabase(dbName);
 

--- a/test/FastTests/Server/Documents/Indexing/Auto/BasicAutoMapReduceIndexing.cs
+++ b/test/FastTests/Server/Documents/Indexing/Auto/BasicAutoMapReduceIndexing.cs
@@ -265,9 +265,10 @@ namespace FastTests.Server.Documents.Indexing.Auto
                 Assert.True(etag > 0);
 
                 var index2 = database.IndexStore.GetIndex(etag);
-                index2.SetLock(IndexLockMode.LockedError);
-                index2.SetPriority(IndexPriority.High);
+                var task = Task.WhenAll(database.IndexStore.SetLock(index2.Name, IndexLockMode.LockedError),
+                    database.IndexStore.SetPriority(index2.Name, IndexPriority.High));
                 index2.SetState(IndexState.Disabled);
+                await task;
 
                 Server.ServerStore.DatabasesLandlord.UnloadDatabase(dbName);
 

--- a/test/RachisTests/AddNodeToClusterTests.cs
+++ b/test/RachisTests/AddNodeToClusterTests.cs
@@ -15,7 +15,6 @@ namespace RachisTests
         [Fact]
         public async Task FailOnAddingNonPassiveNode()
         {
-            NoTimeouts();
             var raft1 = await CreateRaftClusterAndGetLeader(1);
             var raft2 = await CreateRaftClusterAndGetLeader(1);
             

--- a/test/RachisTests/DatabaseCluster/ReplicationTests.cs
+++ b/test/RachisTests/DatabaseCluster/ReplicationTests.cs
@@ -21,10 +21,10 @@ namespace RachisTests.DatabaseCluster
         [Fact]
         public async Task EnsureDocumentsReplication()
         {
-            NoTimeouts();
             var clusterSize = 5;
             var databaseName = "ReplicationTestDB";
             var leader = await CreateRaftClusterAndGetLeader(clusterSize,false);
+            WaitForUserToContinueTheTest(leader.WebUrls[0]);
             CreateDatabaseResult databaseResult;
             using (var store = new DocumentStore()
             {


### PR DESCRIPTION
On initialize, the indexes are loaded only of the folder exists.