### PR TITLE
RavenDB-6886 implementation

### DIFF
--- a/src/Raven.Client/Server/DatabaseRecord.cs
+++ b/src/Raven.Client/Server/DatabaseRecord.cs
@@ -45,6 +45,8 @@ namespace Raven.Client.Server
         //todo: see how we can protect this
         public Dictionary<string, TransformerDefinition> Transformers;
 
+        public Dictionary<string, long> Identities;
+
         public Dictionary<string, string> Settings;
 
         public Dictionary<string, string> SecuredSettings { get; set; }

--- a/src/Raven.Server/Documents/DocumentDatabase.cs
+++ b/src/Raven.Server/Documents/DocumentDatabase.cs
@@ -175,6 +175,11 @@ namespace Raven.Server.Documents
 
         public DateTime StartTime { get; }
 
+        public ServerStore ServerStore
+        {
+            get { return _serverStore; }
+        }
+
         public void Initialize()
         {
             try

--- a/src/Raven.Server/Documents/DocumentPutAction.cs
+++ b/src/Raven.Server/Documents/DocumentPutAction.cs
@@ -246,10 +246,10 @@ namespace Raven.Server.Documents
                 var lastChar = id[id.Length - 1];
                 if (lastChar == '/')
                 {
-                    knownNewId = true;
-                    id = _documentsStorage.Identities.GetNextIdentityValueWithoutOverwritingOnExistingDocuments(id, table, context, out _);
+                    ThrowInvalidDocumentId(id);
                 }
-                else if (lastChar == '|')
+
+                if (lastChar == '|')
                 {
                     knownNewId = true;
                     id = _documentsStorage.Identities.AppendNumericValueToId(id, newEtag);
@@ -262,6 +262,12 @@ namespace Raven.Server.Documents
 
             // Intentionally have just one return statement here for better inlining
             return id;
+        }
+
+        private static void ThrowInvalidDocumentId(string id)
+        {
+            throw new NotSupportedException("Document ids cannot end with '/', but was called with " + id +
+                                            ". Identities are only generated for external requests, not calls to PutDocument and such.");
         }
 
         private bool ShouldRecreateAttachment(DocumentsOperationContext context, Slice lowerId, BlittableJsonReaderObject oldDoc, BlittableJsonReaderObject document, DocumentFlags flags, NonPersistentDocumentFlags nonPersistentFlags)

--- a/src/Raven.Server/Documents/DocumentsStorage.cs
+++ b/src/Raven.Server/Documents/DocumentsStorage.cs
@@ -1387,6 +1387,12 @@ namespace Raven.Server.Documents
             if (_collectionsCache.TryGetValue(collectionName, out name))
                 return name;
 
+            if (context.Transaction == null)
+            {
+                ThrowNoActiveTransactionException(); //this throws, return null in the next row is there so intellisense will be happy
+                return null;
+            }
+
             var collections = context.Transaction.InnerTransaction.OpenTable(CollectionsSchema, CollectionsSlice);
 
             name = new CollectionName(collectionName);
@@ -1419,6 +1425,11 @@ namespace Raven.Server.Documents
                 };
             }
             return name;
+        }
+
+        private static void ThrowNoActiveTransactionException()
+        {
+            throw new InvalidOperationException("This method requires active transaction, and no active transactions in the current context...");
         }
 
         private FastDictionary<string, CollectionName, OrdinalIgnoreCaseStringStructComparer> ReadCollections(Transaction tx)

--- a/src/Raven.Server/Documents/Handlers/DocumentHandler.cs
+++ b/src/Raven.Server/Documents/Handlers/DocumentHandler.cs
@@ -381,6 +381,11 @@ namespace Raven.Server.Documents.Handlers
 
                 var doc = await context.ReadForDiskAsync(RequestBodyStream(), id);
 
+                if (id.EndsWith("/"))
+                {
+                    id = await ServerStore.GenerateClusterIdentityAsync(id, Database.Name);
+                }
+
                 var etag = GetLongFromHeaders("If-Match");
 
                 var cmd = new MergedPutCommand(doc, id, etag, Database);

--- a/src/Raven.Server/ServerWide/ClusterStateMachine.cs
+++ b/src/Raven.Server/ServerWide/ClusterStateMachine.cs
@@ -86,6 +86,17 @@ namespace Raven.Server.ServerWide
                 case nameof(DeleteValueCommand):
                     DeleteValue(context, cmd, index, leader);
                     break;
+                case nameof(IncrementClusterIdentityCommand):
+                    var updatedDatabaseRecord = UpdateDatabase(context, type, cmd, index, leader);
+                    if (!cmd.TryGet(nameof(IncrementClusterIdentityCommand.Prefix), out string prefix))
+                    {
+                        NotifyLeaderAboutError(index, leader, 
+                            new InvalidDataException($"Expected to find {nameof(IncrementClusterIdentityCommand)}.{nameof(IncrementClusterIdentityCommand.Prefix)} property in the Raft command but didn't find it..."));
+                        return;
+                    }
+
+                    leader?.SetStateOf(index,updatedDatabaseRecord.Identities[prefix]);
+                    break;
                 case nameof(PutIndexCommand):
                 case nameof(PutAutoIndexCommand):
                 case nameof(DeleteIndexCommand):
@@ -428,11 +439,12 @@ namespace Raven.Server.ServerWide
 
         private static readonly StringSegment DatabaseName = new StringSegment("DatabaseName");
 
-        private void UpdateDatabase(TransactionOperationContext context, string type, BlittableJsonReaderObject cmd, long index, Leader leader)
+        private DatabaseRecord UpdateDatabase(TransactionOperationContext context, string type, BlittableJsonReaderObject cmd, long index, Leader leader)
         {
             if (cmd.TryGet(DatabaseName, out string databaseName) == false)
                 throw new ArgumentException("Update database command must contain a DatabaseName property");
 
+            DatabaseRecord databaseRecord;
             try
             {
                 var items = context.Transaction.InnerTransaction.OpenTable(ItemsSchema, Items);
@@ -446,17 +458,17 @@ namespace Raven.Server.ServerWide
                     if (doc == null)
                     {
                         NotifyLeaderAboutError(index, leader, new DatabaseDoesNotExistException($"Cannot execute update command of type {type} for {databaseName} because it does not exists"));
-                        return;
+                        return null;
                     }
 
-                    var databaseRecord = JsonDeserializationCluster.DatabaseRecord(doc);
+                    databaseRecord = JsonDeserializationCluster.DatabaseRecord(doc);
                     var updateCommand = JsonDeserializationCluster.UpdateDatabaseCommands[type](cmd);
 
                     if (updateCommand.Etag != null && etag != updateCommand.Etag.Value)
                     {
                         NotifyLeaderAboutError(index, leader,
                             new ConcurrencyException($"Concurrency violation at executing {type} command, the database {databaseRecord.DatabaseName} has etag {etag} but was expecting {updateCommand.Etag}"));
-                        return;
+                        return null;
                     }
 
                     try
@@ -466,7 +478,7 @@ namespace Raven.Server.ServerWide
                     catch (Exception e)
                     {
                         NotifyLeaderAboutError(index, leader, new CommandExecutionException($"Cannot execute command of type {type} for database {databaseName}", e));
-                        return;
+                        return null;
                     }
 
                     var updatedDatabaseBlittable = EntityToBlittable.ConvertEntityToBlittable(databaseRecord, DocumentConventions.Default, context);
@@ -478,6 +490,8 @@ namespace Raven.Server.ServerWide
             {
                 NotifyDatabaseChanged(context, databaseName, index, type);
             }
+
+            return databaseRecord;
         }
 
         private static void NotifyLeaderAboutError(long index, Leader leader, Exception e)

--- a/src/Raven.Server/ServerWide/Commands/IncrementClusterIdentityCommand.cs
+++ b/src/Raven.Server/ServerWide/Commands/IncrementClusterIdentityCommand.cs
@@ -1,0 +1,45 @@
+﻿using System.Collections.Generic;
+using Raven.Client.Server;
+using Sparrow.Json.Parsing;
+
+namespace Raven.Server.ServerWide.Commands
+{
+    public class IncrementClusterIdentityCommand : UpdateDatabaseCommand
+    {
+        public string Prefix { get; set; }
+
+        public IncrementClusterIdentityCommand() : base(null)
+        {            
+        }
+
+        public IncrementClusterIdentityCommand(string databaseName) : base(databaseName)
+        {
+        }
+
+        public override void UpdateDatabaseRecord(DatabaseRecord record, long etag)
+        {
+            if(record.Identities == null)
+                record.Identities = new Dictionary<string, long>();
+
+            record.Identities.TryGetValue(Prefix, out var prev);
+            record.Identities[Prefix] = prev + 1;
+        }
+
+        public override void FillJson(DynamicJsonValue json)
+        {
+            json[nameof(Prefix)] = Prefix;
+            json["Type"] = nameof(IncrementClusterIdentityCommand);
+            json[nameof(DatabaseName)] = DatabaseName;
+        }
+
+        public override DynamicJsonValue ToJson()
+        {
+            return new DynamicJsonValue
+            {
+                ["Type"] = nameof(IncrementClusterIdentityCommand),
+                [nameof(DatabaseName)] = DatabaseName,
+                [nameof(Prefix)] = Prefix
+            };
+        }
+    }
+}

--- a/src/Raven.Server/ServerWide/Commands/UpdateTopologyCommand.cs
+++ b/src/Raven.Server/ServerWide/Commands/UpdateTopologyCommand.cs
@@ -1,8 +1,4 @@
-﻿using System;
-using System.Collections.Generic;
-using System.Text;
-using Raven.Client.Documents;
-using Raven.Client.Server;
+﻿using Raven.Client.Server;
 using Sparrow.Json.Parsing;
 
 namespace Raven.Server.ServerWide.Commands

--- a/src/Raven.Server/ServerWide/JsonDeserializationCluster.cs
+++ b/src/Raven.Server/ServerWide/JsonDeserializationCluster.cs
@@ -47,7 +47,7 @@ namespace Raven.Server.ServerWide
             [nameof(SetTransformerLockCommand)] = GenerateJsonDeserializationRoutine<SetTransformerLockCommand>(),
             [nameof(RenameTransformerCommand)] = GenerateJsonDeserializationRoutine<RenameTransformerCommand>(),
             [nameof(DeleteDatabaseCommand)] = GenerateJsonDeserializationRoutine<DeleteDatabaseCommand>(),
-
+            [nameof(IncrementClusterIdentityCommand)] = GenerateJsonDeserializationRoutine<IncrementClusterIdentityCommand>(),
             [nameof(PutIndexCommand)] = GenerateJsonDeserializationRoutine<PutIndexCommand>(),
             [nameof(PutAutoIndexCommand)] = GenerateJsonDeserializationRoutine<PutAutoIndexCommand>(),
             [nameof(DeleteIndexCommand)] = GenerateJsonDeserializationRoutine<DeleteIndexCommand>(),

--- a/src/Raven.Server/ServerWide/Maintenance/ClusterObserver.cs
+++ b/src/Raven.Server/ServerWide/Maintenance/ClusterObserver.cs
@@ -274,7 +274,7 @@ namespace Raven.Server.ServerWide.Maintenance
             return true;
         }
 
-        private Task<(long, BlittableJsonReaderObject)> UpdateTopology(BlittableJsonReaderObject cmd)
+        private Task<(long, object)> UpdateTopology(BlittableJsonReaderObject cmd)
         {
             
             if (_engine.LeaderTag != _server.NodeTag)

--- a/src/Raven.Server/Utils/MiscUtils.cs
+++ b/src/Raven.Server/Utils/MiscUtils.cs
@@ -1,0 +1,17 @@
+﻿using System;
+using System.Diagnostics;
+
+namespace Raven.Server.Utils
+{
+    public static class MiscUtils
+    {
+        /// <summary>
+        /// set longer timespan if debugging, so stuff won't timeout on breakpoints
+        /// </summary>
+        [Conditional("DEBUG")]
+        public static void LongTimespanIfDebugging(ref TimeSpan timespan)
+        {
+            timespan = Debugger.IsAttached ? TimeSpan.FromHours(1) : timespan;
+        }
+    }
+}

--- a/src/Raven.Server/Web/System/AdminDatabasesHandler.cs
+++ b/src/Raven.Server/Web/System/AdminDatabasesHandler.cs
@@ -331,7 +331,7 @@ namespace Raven.Server.Web.System
             await DatabaseConfigurations(ServerStore.ModifyDatabasePeriodicBackup, "read-periodic-backup-config").ThrowOnTimeout();
         }
 
-        private async Task DatabaseConfigurations(Func<TransactionOperationContext, string, BlittableJsonReaderObject, Task<(long, BlittableJsonReaderObject)>> setupConfigurationFunc, string debug)
+        private async Task DatabaseConfigurations(Func<TransactionOperationContext, string, BlittableJsonReaderObject, Task<(long, object)>> setupConfigurationFunc, string debug)
         {
             var name = GetQueryStringValueAndAssertIfSingleAndNotEmpty("name");
             string errorMessage;

--- a/src/Sparrow/Exceptions/StreamDisposedException.cs
+++ b/src/Sparrow/Exceptions/StreamDisposedException.cs
@@ -1,0 +1,11 @@
+﻿using System;
+
+namespace Sparrow.Exceptions
+{
+    public class StreamDisposedException : Exception
+    {
+        public StreamDisposedException(string message) : base(message)
+        {
+        }
+    }
+}

--- a/src/Sparrow/Json/BlittableJsonReaderObject.cs
+++ b/src/Sparrow/Json/BlittableJsonReaderObject.cs
@@ -246,6 +246,7 @@ namespace Sparrow.Json
                 obj = default(T);
                 return false;
             }
+
             ConvertType(result, out obj);
             return true;
         }

--- a/test/FastTests/Server/Documents/Transformers/BasicTransformers.cs
+++ b/test/FastTests/Server/Documents/Transformers/BasicTransformers.cs
@@ -83,8 +83,9 @@ namespace FastTests.Server.Documents.Transformers
 
                     var blittableJsonReaderObject = EntityToBlittable.ConvertEntityToBlittable(databaseRecord, DocumentConventions.Default, context);
 
-                    var (index, _) = await Server.ServerStore.WriteDbAsync(store.Database, blittableJsonReaderObject, null);
+                    var (index,_) = await Server.ServerStore.WriteDbAsync(store.Database, blittableJsonReaderObject, null);
                     await Server.ServerStore.Cluster.WaitForIndexNotification(index);
+
                 }
 
                 var database = await GetDocumentDatabaseInstanceFor(store);

--- a/test/FastTests/Tasks/RavenDB-6886.cs
+++ b/test/FastTests/Tasks/RavenDB-6886.cs
@@ -1,0 +1,295 @@
+﻿using System;
+using System.Collections.Generic;
+using System.Linq;
+using System.Text;
+using System.Threading.Tasks;
+using Raven.Client.Documents;
+using Raven.Client.Server;
+using Raven.Client.Server.Operations;
+using Tests.Infrastructure;
+using Xunit;
+
+namespace FastTests.Tasks
+{
+    // ReSharper disable once InconsistentNaming
+    public class RavenDB_6886 : ClusterTestBase
+    {
+        public class User
+        {
+            public string Id { get; set; }
+            public string Name { get; set; }
+        }
+
+        [Fact]
+        public async Task Cluster_identity_for_single_document_should_work()
+        {
+            const int clusterSize = 3;
+            const string databaseName = "Cluster_identity_for_single_document_should_work";
+            var leaderServer = await CreateRaftClusterAndGetLeader(clusterSize);
+            using (var leaderStore = new DocumentStore()
+            {
+                Url = leaderServer.WebUrls[0],
+                Database = databaseName
+            }.Initialize())
+            {
+                await CreateDatabasesInCluster(clusterSize, databaseName, leaderStore);
+                using (var session = leaderStore.OpenSession())
+                {
+                    //id ending with "/" should trigger cluster identity id so
+                    //after tx commit, the id would be "users/1"
+                    session.Store(new User { Name = "John Dow" }, "users/");
+                    session.SaveChanges();
+                }
+
+                using (var session = leaderStore.OpenSession())
+                {
+                    var users = session.Query<User>().Where(x => x.Name.StartsWith("John")).ToList();
+
+                    Assert.Equal(1, users.Count);
+                    Assert.NotNull(users[0].Id);
+                    Assert.Equal("users/1", users[0].Id);
+                }
+            }
+        }
+
+        [Fact]
+        public async Task Cluster_identity_for_multiple_documents_on_different_nodes_should_work()
+        {
+            const int clusterSize = 3;
+            const int docsInEachNode = 10;
+            const string databaseName = "Cluster_identity_for_multiple_documents_on_different_nodes_should_work";
+            var leaderServer = await CreateRaftClusterAndGetLeader(clusterSize);
+            var followers = Servers.Where(s => s != leaderServer).ToList();
+            using (var leaderStore = new DocumentStore
+            {
+                Url = leaderServer.WebUrls[0],
+                Database = databaseName
+            }.Initialize())
+            using (var followerA = new DocumentStore
+            {
+                Url = followers[0].WebUrls[0],
+                Database = databaseName
+            }.Initialize())
+            using (var followerB = new DocumentStore
+            {
+                Url = followers[1].WebUrls[0],
+                Database = databaseName
+            }.Initialize())
+            {
+                await CreateDatabasesInCluster(clusterSize, databaseName, leaderStore);
+
+#pragma warning disable 4014
+                var leaderInput = Task.Run(() =>
+#pragma warning restore 4014
+                {
+                    using (var session = leaderStore.OpenSession())
+                    {
+                        //id ending with "/" should trigger cluster identity id so
+                        //after tx commit, the id would be "users/1"
+                        for (int i = 0; i < docsInEachNode; i++)
+                        {
+                            session.Store(new User {Name = "John Dow"}, "users/");
+                        }
+                        session.SaveChanges();
+                    }
+                });
+
+#pragma warning disable 4014
+                var followerAInput = Task.Run(() =>
+#pragma warning restore 4014
+                {
+                    using (var session = followerA.OpenSession())
+                    {
+                        for (int i = 0; i < docsInEachNode; i++)
+                        {
+                            session.Store(new User {Name = "Jane Dow"}, "users/");
+                        }
+                        session.SaveChanges();
+                    }
+                });
+
+#pragma warning disable 4014
+                var followerBInput = Task.Run(() =>
+#pragma warning restore 4014
+                {
+                    using (var session = followerB.OpenSession())
+                    {
+                        for (int i = 0; i < docsInEachNode; i++)
+                        {
+                            session.Store(new User {Name = "Jake Dow"}, "users/");
+                        }
+                        session.SaveChanges();
+                    }
+                });
+
+                Task.WaitAll(leaderInput, followerAInput, followerBInput);
+
+                //now add markers to test when the replication finishes..
+                using (var session = followerA.OpenSession())
+                {
+                    session.Store(new User { Name = "foobar1" }, "marker A");
+                    session.SaveChanges();
+                }
+                using (var session = followerB.OpenSession())
+                {
+                    session.Store(new User { Name = "foobar2" }, "marker B");
+                    session.SaveChanges();
+                }
+
+                //make sure all replications that need to be done is done...
+                Assert.True(WaitForDocument<User>(leaderStore, "marker A", doc => true));
+                Assert.True(WaitForDocument<User>(leaderStore, "marker B", doc => true));
+
+                using (var session = leaderStore.OpenSession())
+                {
+                    var users = session.Query<User>()
+                        .Customize(x => x.WaitForNonStaleResults())
+                        .Where(x => x.Name.StartsWith("J"))
+                        .ToList();
+
+                    Assert.Equal(docsInEachNode * 3, users.Count);
+                    for (var i = 1; i <= docsInEachNode * 3; i++)
+                    {
+                        Assert.True(users.Any(u => u.Id == "users/" + i));                            
+                    }
+                }
+            }
+        }
+
+        [Fact]
+        public async Task Cluster_identity_for_single_document_on_different_nodes_should_work()
+        {
+            const int clusterSize = 3;
+            const string databaseName = "Cluster_identity_for_multiple_documents_on_different_nodes_should_work";
+            var leaderServer = await CreateRaftClusterAndGetLeader(clusterSize);
+            var followers = Servers.Where(s => s != leaderServer).ToList();
+            using (var leaderStore = new DocumentStore
+            {
+                Url = leaderServer.WebUrls[0],
+                Database = databaseName
+            }.Initialize())
+            using (var followerA = new DocumentStore
+            {
+                Url = followers[0].WebUrls[0],
+                Database = databaseName
+            }.Initialize())
+            using (var followerB = new DocumentStore
+            {
+                Url = followers[1].WebUrls[0],
+                Database = databaseName
+            }.Initialize())
+            {
+                await CreateDatabasesInCluster(clusterSize, databaseName, leaderStore);
+                using (var session = leaderStore.OpenSession())
+                {
+                    //id ending with "/" should trigger cluster identity id so
+                    //after tx commit, the id would be "users/1"
+                    session.Store(new User { Name = "John Dow" }, "users/");
+                    session.SaveChanges();
+                }
+
+                using (var session = followerA.OpenSession())
+                {
+                    session.Store(new User { Name = "Jane Dow" }, "users/");
+                    session.SaveChanges();
+                }
+
+                using (var session = followerB.OpenSession())
+                {
+                    session.Store(new User { Name = "Jake Dow" }, "users/");
+                    session.SaveChanges();
+                }
+
+                using (var session = followerA.OpenSession())
+                {
+                    session.Store(new User { Name = "foobar1" }, "marker A");
+                    session.SaveChanges();
+                }
+
+                using (var session = followerB.OpenSession())
+                {
+                    session.Store(new User { Name = "foobar2" }, "marker B");
+                    session.SaveChanges();
+                }
+
+                //make sure all replications that need to be done are done...
+                Assert.True(WaitForDocument<User>(leaderStore, "marker A", doc => true, timeout: 5000));
+                Assert.True(WaitForDocument<User>(leaderStore, "marker B", doc => true, timeout: 5000));
+
+                using (var session = leaderStore.OpenSession())
+                {
+                    var users = session.Query<User>()
+                        .Customize(x => x.WaitForNonStaleResults())
+                        .Where(x => x.Name.StartsWith("J"))
+                        .OrderBy(x => x.Id)
+                        .ToList();
+
+                    Assert.Equal(3, users.Count);
+                    Assert.Equal("users/1", users[0].Id);
+                    Assert.Equal("users/2", users[1].Id);
+                    Assert.Equal("users/3", users[2].Id);
+                }
+            }
+        }
+
+
+
+
+        [Fact]
+        public async Task Cluster_identity_for_multiple_documents_on_leader_should_work()
+        {
+            const int clusterSize = 3;
+            const string databaseName = "Cluster_identity_for_multiple_documents_on_leader_should_work";
+            var leaderServer = await CreateRaftClusterAndGetLeader(clusterSize);
+            using (var leaderStore = new DocumentStore()
+            {
+                Url = leaderServer.WebUrls[0],
+                Database = databaseName
+            }.Initialize())
+            {
+                await CreateDatabasesInCluster(clusterSize, databaseName, leaderStore);
+                using (var session = leaderStore.OpenSession())
+                {
+                    //id ending with "/" should trigger cluster identity id so
+                    //after tx commit, the id would be "users/1"
+                    session.Store(new User { Name = "John Dow" }, "users/");
+                    session.SaveChanges();
+                }
+                using (var session = leaderStore.OpenSession())
+                {
+                    session.Store(new User { Name = "Jane Dow" }, "users/");
+                    session.SaveChanges();
+                }
+                using (var session = leaderStore.OpenSession())
+                {
+                    session.Store(new User { Name = "Jake Dow" }, "users/");
+                    session.SaveChanges();
+                }
+
+                using (var session = leaderStore.OpenSession())
+                {
+                    var users = session.Query<User>()
+                        .Customize(x => x.WaitForNonStaleResults())
+                        .Where(x => x.Name.StartsWith("J"))
+                        .OrderBy(x=>x.Id)
+                        .ToList();
+
+                    Assert.Equal(3, users.Count);
+                    Assert.Equal("users/1", users[0].Id);
+                    Assert.Equal("users/2", users[1].Id);
+                    Assert.Equal("users/3", users[2].Id);
+                }
+            }
+        }
+
+        private async Task CreateDatabasesInCluster(int clusterSize, string databaseName, IDocumentStore store)
+        {
+            var databaseResult = await store.Admin.Server.SendAsync(new CreateDatabaseOperation(MultiDatabase.CreateDatabaseDocument(databaseName), clusterSize));
+            Assert.Equal(clusterSize, databaseResult.Topology.AllReplicationNodes().Count());
+            foreach (var server in Servers)
+            {
+                await server.ServerStore.Cluster.WaitForIndexNotification(databaseResult.ETag ?? -1);
+            }
+        }
+    }
+}

--- a/test/Tests.Infrastructure/ClusterTestBase.cs
+++ b/test/Tests.Infrastructure/ClusterTestBase.cs
@@ -174,7 +174,7 @@ namespace Tests.Infrastructure
             return stores;
         }
 
-        protected bool WaitForDocument<T>(DocumentStore store,
+        protected bool WaitForDocument<T>(IDocumentStore store,
             string docId,
             Func<T, bool> predicate,
             int timeout = 10000)


### PR DESCRIPTION
* new Raft command IncrementClusterIdentityCommand that will increment identity on Apply() on the leader (quorum)
* generate cluster identity in relevant endoints in BatchHandler and DocumentHandler
* refactor result of Raft command from BlittableJsonReaderObject to object
* if no active transaction in DocumentStorage::ExtractCollectionName() -> throw appropriate exception (prevent NRE)
* make sure that identities are only generated for external requests  …
* because BatchHandler parsed command is a struct, change the way it is updated with identity value
* some relevant unit tests
(RavenDB-6886)