### PR TITLE
RavenDB-7263: Do not assume facets aggregate results are sorted (in l…

### DIFF
--- a/test/SlowTests/Issues/RavenDB-3136.cs
+++ b/test/SlowTests/Issues/RavenDB-3136.cs
@@ -36,11 +36,16 @@ namespace SlowTests.Issues
 
                     Assert.Equal(resultInteger.Results.Count, 1);
                     Assert.Equal(resultInteger.Results.First().Value.Values.Count(), 2);
-                    var sorted = resultInteger.Results.First().Value.Values.Select(valueValue => valueValue.Range).ToList();
-                    sorted.Sort();
-                    Assert.Equal(sorted.First(), "2");
+                    Assert.Equal(GetFirstSortedRangeString(resultInteger), "2");
                 }
             }
+        }
+
+        private static string GetFirstSortedRangeString(Raven.Client.Documents.Commands.FacetedQueryResult resultInteger)
+        {
+            var sorted = resultInteger.Results.First().Value.Values.Select(valueValue => valueValue.Range).ToList();
+            sorted.Sort();
+            return sorted.First();
         }
 
         [Fact]
@@ -68,7 +73,7 @@ namespace SlowTests.Issues
 
                     Assert.Equal(resultInteger.Results.Count, 1);
                     Assert.Equal(resultInteger.Results.First().Value.Values.Count(), 2);
-                    Assert.Equal(resultInteger.Results.First().Value.Values.First().Range, "2");
+                    Assert.Equal(GetFirstSortedRangeString(resultInteger), "2");
                 }
             }
         }
@@ -100,7 +105,7 @@ namespace SlowTests.Issues
 
                     Assert.Equal(resultString.Results.Count, 1);
                     Assert.Equal(resultString.Results.First().Value.Values.Count(), 2);
-                    Assert.Equal(resultString.Results.First().Value.Values.First().Range, "2");
+                    Assert.Equal(GetFirstSortedRangeString(resultString), "2");
                 }
             }
         }

--- a/test/SlowTests/Issues/RavenDB-3136.cs
+++ b/test/SlowTests/Issues/RavenDB-3136.cs
@@ -1,3 +1,6 @@
+using System;
+using System.Collections;
+using System.Collections.Generic;
 using System.Linq;
 using FastTests;
 using Raven.Client.Documents;
@@ -33,7 +36,9 @@ namespace SlowTests.Issues
 
                     Assert.Equal(resultInteger.Results.Count, 1);
                     Assert.Equal(resultInteger.Results.First().Value.Values.Count(), 2);
-                    Assert.Equal(resultInteger.Results.First().Value.Values.First().Range, "2");
+                    var sorted = resultInteger.Results.First().Value.Values.Select(valueValue => valueValue.Range).ToList();
+                    sorted.Sort();
+                    Assert.Equal(sorted.First(), "2");
                 }
             }
         }


### PR DESCRIPTION
…inux 3 before 2 at this test)