### PR TITLE
RavenDB-6900 For encrypted databases, replication must use SSL

### DIFF
--- a/src/Raven.Client/Properties/VersionInfo.cs
+++ b/src/Raven.Client/Properties/VersionInfo.cs
@@ -3,7 +3,7 @@ using System.Linq;
 using System.Reflection;
 using Raven.Client.Properties;
 
-[assembly: RavenVersion(Build = "40", CommitHash = "005256c", Version = "4.0", FullVersion = "4.0.0-custom-40")]
+[assembly: RavenVersion(Build = "40", CommitHash = "7f2651b", Version = "4.0", FullVersion = "4.0.0-custom-40")]
 
 namespace Raven.Client.Properties
 {

--- a/src/Raven.Client/Server/ETL/EtlDestination.cs
+++ b/src/Raven.Client/Server/ETL/EtlDestination.cs
@@ -8,6 +8,8 @@ namespace Raven.Client.Server.ETL
 
         public abstract string Name { get; }
 
+        public abstract bool UsingEncryptedCommunicationChannel();
+
         public override string ToString()
         {
             return Name;

--- a/src/Raven.Client/Server/ETL/RavenDestination.cs
+++ b/src/Raven.Client/Server/ETL/RavenDestination.cs
@@ -1,4 +1,5 @@
-﻿using System.Collections.Generic;
+﻿using System;
+using System.Collections.Generic;
 
 namespace Raven.Client.Server.ETL
 {
@@ -31,5 +32,10 @@ namespace Raven.Client.Server.ETL
         }
 
         public override string Name => _name ?? (_name = $"{Database}@{Url}");
+
+        public override bool UsingEncryptedCommunicationChannel()
+        {
+            return Url?.StartsWith("https:", StringComparison.OrdinalIgnoreCase) == true;
+        }
     }
 }

--- a/src/Raven.Client/Server/ETL/SqlDestination.cs
+++ b/src/Raven.Client/Server/ETL/SqlDestination.cs
@@ -51,6 +51,11 @@ namespace Raven.Client.Server.ETL
                 return _name = $"{database}@{server} [{string.Join(" ", SqlTables.Select(x => x.TableName))}]";
             }
         }
+
+        public override bool UsingEncryptedCommunicationChannel()
+        {
+            return true; //TODO: Figure out how we can tell
+        }
     }
 
     public class SqlEtlTable

--- a/src/Raven.Server/Config/Categories/StorageConfiguration.cs
+++ b/src/Raven.Server/Config/Categories/StorageConfiguration.cs
@@ -66,7 +66,7 @@ namespace Raven.Server.Config.Categories
 
         [Description("Use the 32 bits memory mapped pager, even when running in 64 bits")]
         [DefaultValue(false)]
-        [ConfigurationEntry("Raven/Storage/ForceUsing32BitsPager")]
+        [ConfigurationEntry("Raven/Storage/ForceUsing32BitsPager", isServerWideOnly: true)]
         public bool ForceUsing32BitsPager { get; set; }
 
         [Description("How long transaction mode (Danger/Lazy) last before returning to Safe mode. Value in Minutes. Default one day. Zero for infinite time")]

--- a/src/Raven.Server/Config/RavenConfiguration.cs
+++ b/src/Raven.Server/Config/RavenConfiguration.cs
@@ -181,9 +181,6 @@ namespace Raven.Server.Config
 
         public void CopyParentSettings(RavenConfiguration serverConfiguration)
         {
-            Security.CertificatePassword = serverConfiguration.Security.CertificatePassword;
-            Security.CertificateFilePath = serverConfiguration.Security.CertificateFilePath;
-
             Storage.ForceUsing32BitsPager = serverConfiguration.Storage.ForceUsing32BitsPager;
 
             Queries.MaxClauseCount = serverConfiguration.Queries.MaxClauseCount;

--- a/src/Raven.Server/Documents/DatabasesLandlord.cs
+++ b/src/Raven.Server/Documents/DatabasesLandlord.cs
@@ -475,6 +475,20 @@ namespace Raven.Server.Documents
                     return null;
 
                 var databaseRecord = JsonDeserializationCluster.DatabaseRecord(doc);
+
+                if (databaseRecord.Encrypted)
+                {
+                    if (_serverStore.RavenServer.WebUrls != null && _serverStore.RavenServer.WebUrls.Length > 0)
+                    {
+                        var ravenServerWebUrl = _serverStore.RavenServer.WebUrls[0];
+                        if (ravenServerWebUrl?.StartsWith("https:", StringComparison.OrdinalIgnoreCase) == false)
+                        {
+                            throw new DatabaseDisabledException(
+                                $"The database {databaseName.Value} is encrypted, and must be accessed only via HTTPS, but the web url used is {ravenServerWebUrl}");       
+                        }
+                    }
+                }
+
                 return CreateDatabaseConfiguration(databaseName, ignoreDisabledDatabase, ignoreBeenDeleted, databaseRecord);
 
             }

--- a/src/Raven.Server/Documents/Replication/ReplicationLoader.cs
+++ b/src/Raven.Server/Documents/Replication/ReplicationLoader.cs
@@ -12,6 +12,7 @@ using Raven.Client.Documents.Changes;
 using Raven.Client.Documents.Replication;
 using Raven.Client.Documents.Replication.Messages;
 using Raven.Client.Server;
+using Raven.Server.Config;
 using Raven.Server.Documents.TcpHandlers;
 using Raven.Server.Json;
 using Raven.Server.NotificationCenter.Notifications;
@@ -491,6 +492,16 @@ namespace Raven.Server.Documents.Replication
 
             _numberOfSiblings = 0;
             StartOutgoingConnections(Destinations);
+        }
+
+        public DatabaseRecord LoadDatabaseRecord()
+        {
+            TransactionOperationContext context;
+            using (_server.ContextPool.AllocateOperationContext(out context))
+            using (context.OpenReadTransaction())
+            {
+                return _server.Cluster.ReadDatabase(context, Database.Name);
+            }
         }
 
         private void AddAndStartOutgoingReplication(ReplicationNode node)

--- a/src/Raven.Server/ServerWide/ClusterStateMachine.cs
+++ b/src/Raven.Server/ServerWide/ClusterStateMachine.cs
@@ -635,6 +635,10 @@ namespace Raven.Server.ServerWide
 
         public override async Task<Stream> ConnectToPeer(string url, string apiKey)
         {
+            // TODO: This causes the tests to freeze, fix it...
+            //if (_parent.Url.StartsWith("https:", StringComparison.OrdinalIgnoreCase) != url.StartsWith("https:", StringComparison.OrdinalIgnoreCase))
+            //    throw new InvalidOperationException($"Failed to connect from node {_parent.Url} to node {url}. If HTTPS is used on one node, the other node must also use it");
+            
             var info = await ReplicationUtils.GetTcpInfoAsync(url, "Rachis.Server", apiKey, "Cluster");
             var authenticator = new ApiKeyAuthenticator();
 

--- a/src/Raven.Server/ServerWide/ClusterStateMachine.cs
+++ b/src/Raven.Server/ServerWide/ClusterStateMachine.cs
@@ -635,9 +635,9 @@ namespace Raven.Server.ServerWide
 
         public override async Task<Stream> ConnectToPeer(string url, string apiKey)
         {
-            // TODO: This causes the tests to freeze, fix it...
-            //if (_parent.Url.StartsWith("https:", StringComparison.OrdinalIgnoreCase) != url.StartsWith("https:", StringComparison.OrdinalIgnoreCase))
-            //    throw new InvalidOperationException($"Failed to connect from node {_parent.Url} to node {url}. If HTTPS is used on one node, the other node must also use it");
+            if (_parent?.Url != null && url != null)
+                if (_parent.Url.StartsWith("https:", StringComparison.OrdinalIgnoreCase) != url.StartsWith("https:", StringComparison.OrdinalIgnoreCase))
+                    throw new InvalidOperationException($"Failed to connect from node {_parent.Url} to node {url}. If HTTPS is used on one node, the other node must also use it");
             
             var info = await ReplicationUtils.GetTcpInfoAsync(url, "Rachis.Server", apiKey, "Cluster");
             var authenticator = new ApiKeyAuthenticator();

--- a/src/Raven.Server/ServerWide/ServerStore.cs
+++ b/src/Raven.Server/ServerWide/ServerStore.cs
@@ -89,6 +89,8 @@ namespace Raven.Server.ServerWide
 
         }
 
+        public RavenServer RavenServer => _ravenServer;
+
         public DatabaseInfoCache DatabaseInfoCache { get; set; }
 
         public TransactionContextPool ContextPool;

--- a/test/Tests.Infrastructure/RachisConsensusTestBase.cs
+++ b/test/Tests.Infrastructure/RachisConsensusTestBase.cs
@@ -8,6 +8,7 @@ using System.Net.Sockets;
 using System.Runtime.CompilerServices;
 using System.Runtime.InteropServices;
 using System.Threading.Tasks;
+using Raven.Client.Documents;
 using Raven.Server.Config;
 using Raven.Server.Config.Categories;
 using Raven.Server.Config.Settings;
@@ -16,6 +17,7 @@ using Raven.Server.ServerWide;
 using Raven.Server.ServerWide.Commands;
 using Raven.Server.ServerWide.Context;
 using Raven.Server.ServerWide.Maintenance;
+using Raven.Server.Utils;
 using Sparrow.Collections;
 using Sparrow.Json;
 using Sparrow.Json.Parsing;
@@ -304,13 +306,17 @@ namespace Tests.Infrastructure
 
             public override async Task<Stream> ConnectToPeer(string url, string apiKey)
             {
+                if (_parent.Url.StartsWith("https:", StringComparison.OrdinalIgnoreCase) != url.StartsWith("https:", StringComparison.OrdinalIgnoreCase))
+                    throw new InvalidOperationException($"Failed to connect from node {_parent.Url} to node {url}. If HTTPS is used on one node, the other node must also use it");
+
+                var info = await ReplicationUtils.GetTcpInfoAsync(url, "Rachis.Server", apiKey, "Cluster");
                 var tcpInfo = new Uri(url);
                 var tcpClient = new TcpClient();
                 await tcpClient.ConnectAsync(tcpInfo.Host, tcpInfo.Port);
-                return tcpClient.GetStream();
+                return await TcpUtils.WrapStreamWithSslAsync(tcpClient, info);
             }
         }
-
+        
         public class TestCommand : CommandBase
         {
             public string Name;


### PR DESCRIPTION
- Fix previous PR comments
- Cannot create encrypted database without using https
- Replication & ETL for encrypted databases must go through https
- Don't allow putting and distributing secret keys without https
- In raft (ConnectToPeer), if one node uses https, the other must too (commented, need to fix)