### PR TITLE
RavenDB-7349 WIP

### DIFF
--- a/src/Raven.Client/Http/RequestExecutor.cs
+++ b/src/Raven.Client/Http/RequestExecutor.cs
@@ -172,7 +172,7 @@ namespace Raven.Client.Http
         {
             var topologyUpdate = _firstTopologyUpdate;
 
-            if ((topologyUpdate != null && topologyUpdate.Status == TaskStatus.RanToCompletion) || _withoutTopology)
+            if (topologyUpdate != null && topologyUpdate.Status == TaskStatus.RanToCompletion || _withoutTopology)
             {
                 await ExecuteAsync(_nodeSelector.CurrentNode, context, command, token).ConfigureAwait(false);
                 return;

--- a/src/Raven.Server/Documents/Indexes/IndexStore.cs
+++ b/src/Raven.Server/Documents/Indexes/IndexStore.cs
@@ -421,7 +421,7 @@ namespace Raven.Server.Documents.Indexes
             if (definition is MapIndexDefinition)
                 return await CreateIndex(((MapIndexDefinition)definition).IndexDefinition);
 
-            await _indexAndTransformerLocker.WaitAsync();
+            await _indexAndTransformerLocker.WaitAsync(_documentDatabase.DatabaseShutdown);
 
             try
             {

--- a/src/Raven.Server/Documents/Replication/OutgoingReplicationHandler.cs
+++ b/src/Raven.Server/Documents/Replication/OutgoingReplicationHandler.cs
@@ -163,7 +163,7 @@ namespace Raven.Server.Documents.Replication
                             if (response.Item1 == ReplicationMessageReply.ReplyType.Error)
                             {
                                 if (response.Item2.Exception.Contains(nameof(DatabaseDoesNotExistException)))
-                                    throw new DatabaseDoesNotExistException(response.Item2.Message, 
+                                    throw new DatabaseDoesNotExistException(response.Item2.Message,
                                         new InvalidOperationException(response.Item2.Exception));
                                 throw new InvalidOperationException(response.Item2.Exception);
                             }
@@ -180,6 +180,12 @@ namespace Raven.Server.Documents.Replication
 
                             AddAlertOnFailureToReachOtherSide(msg, e);
 
+                            throw;
+                        }
+                        catch (OperationCanceledException e)
+                        {
+                            if (_log.IsInfoEnabled)
+                                _log.Info("Got operation canceled notification while opening outgoing replication channel. Aborting and closing the channel.", e);
                             throw;
                         }
                         catch (Exception e)
@@ -219,6 +225,12 @@ namespace Raven.Server.Documents.Replication
                                                 _waitForChanges.Set();
                                                 break;
                                             }
+                                        }
+                                        catch (OperationCanceledException)
+                                        {
+                                            //cancelation is not an actual error,
+                                            //it is a "notification" that we need to cancel current operation
+                                            throw;
                                         }
                                         catch (Exception e)
                                         {
@@ -465,6 +477,12 @@ namespace Raven.Server.Documents.Replication
                 {
                     HandleServerResponse();
                 }
+                catch (OperationCanceledException)
+                {
+                    if (_log.IsInfoEnabled)
+                        _log.Info($"Got cancelation notification while parsing heartbeat response. Closing replication channel. ({FromToString})");
+                    throw;
+                }
                 catch (Exception e)
                 {
                     if (_log.IsInfoEnabled)
@@ -478,7 +496,7 @@ namespace Raven.Server.Documents.Replication
         {
             while (true)
             {
-                var timeout = 2 * 60 * 1000;// TODO: configurable
+                var timeout = 2 * 60 * 1000; // TODO: configurable
                 if (Debugger.IsAttached)
                     timeout *= 10;
                 using (var replicationBatchReplyMessage = _interruptableRead.ParseToMemory(

--- a/src/Raven.Server/Documents/Replication/ReplicationDocumentSender.cs
+++ b/src/Raven.Server/Documents/Replication/ReplicationDocumentSender.cs
@@ -231,6 +231,12 @@ namespace Raven.Server.Documents.Replication
                             SendDocumentsBatch(documentsContext, _stats.Network);
                         }
                     }
+                    catch (OperationCanceledException)
+                    {
+                        if (_log.IsInfoEnabled)
+                            _log.Info("Received cancelation notification while sending document replication batch.");
+                        throw;
+                    }
                     catch (Exception e)
                     {
                         if (_log.IsInfoEnabled)
@@ -349,8 +355,8 @@ namespace Raven.Server.Documents.Replication
                 _log.Info($"Finished sending replication batch. Sent {_orderedReplicaItems.Count:#,#;;0} documents and {_replicaAttachmentStreams.Count:#,#;;0} attachment streams in {sw.ElapsedMilliseconds:#,#;;0} ms. Last sent etag = {_lastEtag}");
 
             _parent._lastDocumentSentTime = DateTime.UtcNow;
-            _parent.HandleServerResponse();
 
+            _parent.HandleServerResponse();
         }
 
         private void WriteItemToServer(ReplicationBatchItem item, OutgoingReplicationStatsScope stats)

--- a/src/Raven.Server/Rachis/CandidateAmbassador.cs
+++ b/src/Raven.Server/Rachis/CandidateAmbassador.cs
@@ -139,6 +139,12 @@ namespace Raven.Server.Rachis
                                         });
 
                                         rvr = connection.Read<RequestVoteResponse>(context);
+                                        if (rvr == null)
+                                        {
+                                            HandleUnexpectedRemoteConnectionClosed();
+                                            return;
+                                        }
+
                                         if (rvr.Term > currentElectionTerm)
                                         {
                                             var message = "Found election term " + rvr.Term + " that is higher than ours " + currentElectionTerm;
@@ -180,6 +186,12 @@ namespace Raven.Server.Rachis
                                     });
 
                                     rvr = connection.Read<RequestVoteResponse>(context);
+                                    if (rvr == null)
+                                    {
+                                        HandleUnexpectedRemoteConnectionClosed();
+                                        return;
+                                    }
+
                                     if (rvr.Term > currentElectionTerm)
                                     {
                                         var message = "Found election term " + rvr.Term + " that is higher than ours " + currentElectionTerm;
@@ -248,6 +260,16 @@ namespace Raven.Server.Rachis
                     _engine.Log.Info("Failed to talk to remote peer: " + _url, e);
                 }
             }
+        }
+
+        private void HandleUnexpectedRemoteConnectionClosed()
+        {
+            if (_engine.Log.IsInfoEnabled)
+            {
+                _engine.Log.Info(
+                    $"CandidateAmbassador {_engine.Tag}: remote follower closed the connection while reading RequestVoteResponse message, so I am closing it on this side.");
+            }
+            _candidate.Dispose();
         }
 
         public bool NotInTopology { get; private set; }

--- a/src/Raven.Server/Rachis/Elector.cs
+++ b/src/Raven.Server/Rachis/Elector.cs
@@ -28,6 +28,16 @@ namespace Raven.Server.Rachis
                     using (_engine.ContextPool.AllocateOperationContext(out context))
                     {
                         var rv = _connection.Read<RequestVote>(context);
+                        if(rv == null)
+                        {
+                            if (_engine.Log.IsInfoEnabled)
+                            {
+                                _engine.Log.Info("Failed to read the RequestVote, IOException was thrown. Most likely the remote node went down while sending the RequestVote. Aborting the vote processing.");
+                            }
+                            _connection.Dispose();
+                            return;
+                        }
+
                         if (rv.Term <= _engine.CurrentTerm)
                         {
                             _connection.Send(context, new RequestVoteResponse

--- a/src/Raven.Server/Rachis/Leader.cs
+++ b/src/Raven.Server/Rachis/Leader.cs
@@ -274,6 +274,7 @@ namespace Raven.Server.Rachis
                             return;
                     }
                     EnsureThatWeHaveLeadership(VotersMajority);
+                    _engine.ReportLeaderTime(LeaderShipDuration);
 
                     _engine.ReportLeaderTime(LeaderShipDuration);
                     

--- a/src/Raven.Server/Rachis/RemoteConnection.cs
+++ b/src/Raven.Server/Rachis/RemoteConnection.cs
@@ -261,14 +261,24 @@ namespace Raven.Server.Rachis
         }
 
         public T Read<T>(JsonOperationContext context)
+            where T : class
         {
-            using (
-                var json = context.ParseToMemory(_stream, "rachis-item",
-                    BlittableJsonDocumentBuilder.UsageMode.None, _buffer))
+            try
             {
-                json.BlittableValidation();
-                ValidateMessage(typeof(T).Name, json);
-                return JsonDeserializationRachis<T>.Deserialize(json);
+                using (
+                    var json = context.ParseToMemory(_stream, "rachis-item",
+                        BlittableJsonDocumentBuilder.UsageMode.None, _buffer))
+                {
+                    json.BlittableValidation();
+                    ValidateMessage(typeof(T).Name, json);
+                    return JsonDeserializationRachis<T>.Deserialize(json);
+                }
+            }
+            catch (IOException e)
+            {
+                if(_log.IsInfoEnabled)
+                    _log.Info($"Failed to read from connection. If this error happens during state change of a node, it is expected. (source : [{_src}] -> destination : [{_destTag}])",e);
+                return null;
             }
         }
 

--- a/src/Raven.Server/Utils/MiscUtils.cs
+++ b/src/Raven.Server/Utils/MiscUtils.cs
@@ -16,7 +16,7 @@ namespace Raven.Server.Utils
             if(DisableLongTimespan)
                 return;
 
-            timespan = Debugger.IsAttached ? TimeSpan.FromHours(1) : timespan;
+            timespan = Debugger.IsAttached ? TimeSpan.FromMinutes(1) : timespan;
 
         }
     }

--- a/src/Sparrow/AsyncManualResetEvent.cs
+++ b/src/Sparrow/AsyncManualResetEvent.cs
@@ -1,5 +1,4 @@
 using System;
-using System.Diagnostics;
 using System.Diagnostics.Contracts;
 using System.Runtime.CompilerServices;
 using System.Threading;
@@ -107,15 +106,8 @@ namespace Sparrow
         [MethodImpl(MethodImplOptions.AggressiveInlining)]
         private static void SetInAsyncManner(TaskCompletionSource<bool> tcs)
         {
-            // run the completion asynchronously to ensure that continuations (await WaitAsync()) won't happen as part of a call to TrySetResult
-            // http://blogs.msdn.com/b/pfxteam/archive/2012/02/11/10266920.aspx
-
             var currentTcs = tcs;
-
-            Task.Factory.StartNew(s => ((TaskCompletionSource<bool>)s).TrySetResult(true),
-                currentTcs, CancellationToken.None, TaskCreationOptions.PreferFairness | TaskCreationOptions.RunContinuationsAsynchronously, TaskScheduler.Default);
-
-            currentTcs.Task.Wait();
+            currentTcs.TrySetResult(true);
         }
 
         public void SetInAsyncMannerFireAndForget()

--- a/src/Sparrow/Json/JsonDeserializationBase.cs
+++ b/src/Sparrow/Json/JsonDeserializationBase.cs
@@ -459,7 +459,9 @@ namespace Sparrow.Json
 
         private static T GetPrimitiveProperty<T>(BlittableJsonReaderObject json, string prop)
         {
-            return !json.TryGet(prop, out T val) ? default(T) : val;
+            return !json.TryGet(prop, out T val) ? 
+                throw new InvalidCastException($"Failed to fetch property name = {prop} of type {typeof(T).Name} from json with value : [{json}]") : 
+                val;
         }
 
         private static T ToObject<T>(BlittableJsonReaderObject json, string name, Func<BlittableJsonReaderObject, T> converter) where T : new()

--- a/test/Tryouts/Program.cs
+++ b/test/Tryouts/Program.cs
@@ -1,6 +1,8 @@
 ﻿using System;
 using System.Diagnostics;
+using System.Threading.Tasks;
 using FastTests.Client.Attachments;
+using FastTests.Tasks;
 using RachisTests.DatabaseCluster;
 using Sparrow.Logging;
 using System.Threading.Tasks;
@@ -18,13 +20,18 @@ namespace Tryouts
             Console.WriteLine(Process.GetCurrentProcess().Id);
             Console.WriteLine();
 
-            for (int i = 0; i < 100; i++)
+            for (int i = 0; i < 1000; i++)
             {
                 Console.WriteLine(i);
-                using (var a = new AttachmentFailover())
-                {
-                    a.PutAttachmentsWithFailover(false, 512 * 1024, "BfKA8g/BJuHOTHYJ+A6sOt9jmFSVEDzCM3EcLLKCRMU=").Wait();
-                }
+                //Parallel.For(0, 10, _ =>
+                //{
+                    using (var a = new RavenDB_6886())
+                    {
+                        Console.Write(".");
+                        a.Cluster_identity_for_single_document_in_parallel_on_different_nodes_should_work().Wait();
+                    }
+                //});
+                Console.WriteLine();
             }
         }
     }


### PR DESCRIPTION
Not finished, there are still timeouts, they happen at lower probability
(doing PR so this branch won't lag too much behind)

* Better exception handling and more logging in Raft -> IOExceptions when reading from a connection between cluster nodes will not cause unhandled exceptions
* better Set() at AsyncManualResetEvent
* JsonDeserializationBase::GetPrimitiveProperty() should not fail silently if failing to fetch property of type T
* additional test for RavenDB-6886