### PR TITLE
RavenDB-7332 & RavenDB-7333

### DIFF
--- a/Raven.Abstractions/Data/Constants.cs
+++ b/Raven.Abstractions/Data/Constants.cs
@@ -220,6 +220,9 @@ namespace Raven.Abstractions.Data
         public const string RavenReplicationIndexesTombstones = "Raven/Replication/Indexes/Tombstones";
         public const string RavenReplicationTransformerTombstones = "Raven/Replication/Transformers/Tombstones";
 
+        public const string RavenDeletedIndexesVersions = "Raven/Deleted/Indexes/Versions";
+        public const string RavenDeletedTransformersVersions = "Raven/Deleted/Transformers/Versions";
+
         public const string RavenSqlReplicationConnectionsDocumentName = "Raven/SqlReplication/Connections";
         public const string ReplicationPropagationDelayInSeconds = "Raven/Replication/ReplicationPropagationDelayInSeconds";
 

--- a/Raven.Abstractions/Data/Constants.cs
+++ b/Raven.Abstractions/Data/Constants.cs
@@ -14,6 +14,9 @@ namespace Raven.Abstractions.Data
         public const string ParticipatingIDsPropertyName = "Participating-IDs-Property-Name";
 
         public const string IsReplicatedUrlParamName = "is-replicated";
+        public const string IndexVersion = "index-version";
+        public const string TransformerVersion = "transformer-version";
+
         public const string RavenClientPrimaryServerUrl = "Raven-Client-Primary-Server-Url";
 
         public const string RavenClientPrimaryServerLastCheck = "Raven-Client-Primary-Server-LastCheck";

--- a/Raven.Database/Actions/IndexActions.cs
+++ b/Raven.Database/Actions/IndexActions.cs
@@ -232,6 +232,16 @@ namespace Raven.Database.Actions
             name = name.Trim();
             IsIndexNameValid(name);
 
+            var deletedIndexVersion = IndexDefinitionStorage.GetDeletedIndexVersion(definition.Name, definition.IndexId);
+            if (isReplication && definition.IndexVersion != null &&
+                deletedIndexVersion > definition.IndexVersion)
+            {
+                // we got a new index definition from replication
+                // where its version is smaller then the deleted one
+                // probably from an outdated node
+                return null;
+            }
+
             var existingIndex = IndexDefinitionStorage.GetIndexDefinition(name);
             if (existingIndex != null)
             {
@@ -265,6 +275,7 @@ namespace Raven.Database.Actions
 
             AssertAnalyzersValid(definition);
 
+            var existingIndexVersion = existingIndex?.IndexVersion;
             switch (creationOptions ?? FindIndexCreationOptions(definition, ref name))
             {
                 case IndexCreationOptions.Noop:
@@ -274,26 +285,28 @@ namespace Raven.Database.Actions
                     new DynamicViewCompiler(definition.Name, definition, Database.Extensions, IndexDefinitionStorage.IndexDefinitionsPath, Database.Configuration).GenerateInstance();
                     IndexDefinitionStorage.UpdateIndexDefinitionWithoutUpdatingCompiledIndex(definition);
                     if (isReplication == false)
-                        definition.IndexVersion = (definition.IndexVersion ?? 0) + 1;
+                        definition.IndexVersion = Math.Max(definition.IndexVersion ?? 0, existingIndexVersion ?? 0) + 1;
                     return null;
                 case IndexCreationOptions.Update:
                     // ensure that the code can compile
                     new DynamicViewCompiler(definition.Name, definition, Database.Extensions, IndexDefinitionStorage.IndexDefinitionsPath, Database.Configuration).GenerateInstance();
                     DeleteIndex(name);
                     if (isReplication == false)
-                        definition.IndexVersion = (definition.IndexVersion ?? 0) + 1;
+                        definition.IndexVersion = Math.Max(definition.IndexVersion ?? 0, existingIndexVersion ?? 0) + 1;
                     break;
                 case IndexCreationOptions.Create:
+
+
                     if (isReplication == false)
                     {
                         // we create a new index,
                         // we need to restore its previous IndexVersion (if it was deleted before)
-                        var deletedIndexVersion = IndexDefinitionStorage.GetDeletedIndexVersion(definition.Name, definition.IndexId);
+
                         var replacingIndexVersion = GetOriginalIndexVersion(definition.Name);
                         definition.IndexVersion = Math.Max(deletedIndexVersion, replacingIndexVersion);
                         definition.IndexVersion++;
                     }
-                        
+
                     break;
             }
 
@@ -924,23 +937,34 @@ namespace Raven.Database.Actions
         }
 
         [MethodImpl(MethodImplOptions.Synchronized)]
-        public bool DeleteIndex(string name)
+        public bool DeleteIndex(string name, int? deletedIndexVersion = null)
         {
             var instance = IndexDefinitionStorage.GetIndexDefinition(name);
             if (instance == null)
                 return false;
 
-            DeleteIndex(instance);
+            DeleteIndex(instance, deletedIndexVersion: deletedIndexVersion);
             return true;
         }
 
         internal void DeleteIndex(IndexDefinition instance, bool removeByNameMapping = true, 
-            bool clearErrors = true, bool removeIndexReplaceDocument = true, bool isSideBySideReplacement = false)
+            bool clearErrors = true, bool removeIndexReplaceDocument = true, 
+            bool isSideBySideReplacement = false, int? deletedIndexVersion = null)
         {
             using (IndexDefinitionStorage.TryRemoveIndexContext())
             {
                 if (instance == null)
                     return;
+
+                var currentIndexVersion = instance.IndexVersion;
+                if (deletedIndexVersion != null &&
+                    currentIndexVersion != null &&
+                    currentIndexVersion > deletedIndexVersion)
+                {
+                    // the index version is larger than the deleted one
+                    // got an old delete from an outdated node
+                    return;
+                }
 
                 // Set up a flag to signal that this is something we're doing
                 TransactionalStorage.Batch(actions =>
@@ -954,15 +978,6 @@ namespace Raven.Database.Actions
                             IndexName = instance.Name,
                             instance.IndexVersion
                         }), UuidType.Tasks);
-
-                    if (instance.Name.StartsWith(Constants.SideBySideIndexNamePrefix))
-                        return;
-
-                    var metadata = new RavenJObject
-                    {
-                        {IndexDefinitionStorage.IndexVersionKey, instance.IndexVersion ?? 0 }
-                    };
-                    actions.Lists.Set(Constants.RavenDeletedIndexesVersions, instance.Name, metadata, UuidType.Indexing);
                 });
 
                 // Delete the main record synchronously
@@ -987,6 +1002,22 @@ namespace Raven.Database.Actions
                 Database.Maintenance.StartDeletingIndexDataAsync(instance.IndexId, instance.Name);
 
                 var indexChangeType = isSideBySideReplacement ? IndexChangeTypes.SideBySideReplace : IndexChangeTypes.IndexRemoved;
+
+                var version = currentIndexVersion ?? 0;
+                if (deletedIndexVersion != null)
+                    version = Math.Max(version, deletedIndexVersion.Value);
+
+                TransactionalStorage.Batch(actions =>
+                {
+                    if (instance.Name.StartsWith(Constants.SideBySideIndexNamePrefix))
+                        return;
+
+                    var metadata = new RavenJObject
+                    {
+                        {IndexDefinitionStorage.IndexVersionKey, version }
+                    };
+                    actions.Lists.Set(Constants.RavenDeletedIndexesVersions, instance.Name, metadata, UuidType.Indexing);
+                });
 
                 // We raise the notification now because as far as we're concerned it is done *now*
                 TransactionalStorage.ExecuteImmediatelyOrRegisterForSynchronization(() =>

--- a/Raven.Database/Bundles/Replication/Controllers/ReplicationController.cs
+++ b/Raven.Database/Bundles/Replication/Controllers/ReplicationController.cs
@@ -937,7 +937,9 @@ namespace Raven.Database.Bundles.Replication.Controllers
 
             if (string.Equals(op, "replicate-all-to-destination", StringComparison.InvariantCultureIgnoreCase))
             {
-                replicationTask.IndexReplication.Execute(dest => dest.IsEqualTo(replicationDestination) && dest.SkipIndexReplication == false);
+                replicationTask.IndexReplication.Execute(
+                    dest => dest.IsEqualTo(replicationDestination) && dest.SkipIndexReplication == false,
+                    forceTombstoneReplication: true);
 
                 return GetEmptyMessage();
             }
@@ -950,7 +952,7 @@ namespace Raven.Database.Bundles.Replication.Controllers
                 return GetEmptyMessage();
             }
 
-            replicationTask.IndexReplication.Execute();
+            replicationTask.IndexReplication.Execute(forceTombstoneReplication: true);
             return GetEmptyMessage();
         }
 
@@ -967,7 +969,9 @@ namespace Raven.Database.Bundles.Replication.Controllers
 
             if (string.Equals(op, "replicate-all-to-destination", StringComparison.InvariantCultureIgnoreCase))
             {
-                replicationTask.TransformerReplication.Execute(dest => dest.IsEqualTo(replicationDestination) && dest.SkipIndexReplication == false);
+                replicationTask.TransformerReplication.Execute(
+                    dest => dest.IsEqualTo(replicationDestination) && dest.SkipIndexReplication == false,
+                    forceTombstoneReplication: true);
                 return GetEmptyMessage();
             }
 
@@ -979,7 +983,7 @@ namespace Raven.Database.Bundles.Replication.Controllers
                 return GetEmptyMessage();
             }
 
-            replicationTask.TransformerReplication.Execute();
+            replicationTask.TransformerReplication.Execute(forceTombstoneReplication: true);
             return GetEmptyMessage();
         }
 

--- a/Raven.Database/Bundles/Replication/Tasks/IndexReplicationTask.cs
+++ b/Raven.Database/Bundles/Replication/Tasks/IndexReplicationTask.cs
@@ -519,7 +519,11 @@ namespace Raven.Database.Bundles.Replication.Tasks
                         continue;
                     }
 
-                    var url = string.Format("{0}/indexes/{1}?{2}", destination.ConnectionStringOptions.Url, Uri.EscapeUriString(tombstone.Key), GetDebugInformation());
+                    var url = string.Format("{0}/indexes/{1}?{2}&{3}", 
+                        destination.ConnectionStringOptions.Url, 
+                        Uri.EscapeUriString(tombstone.Key), 
+                        GetTombstoneVersion(tombstone, IndexDefinitionStorage.IndexVersionKey, Constants.IndexVersion),
+                        GetDebugInformation());
                     var replicationRequest = HttpRavenRequestFactory.Create(url, HttpMethods.Delete, destination.ConnectionStringOptions, Replication.GetRequestBuffering(destination));
                     replicationRequest.Write(RavenJObject.FromObject(EmptyRequestBody));
                     replicationRequest.ExecuteRequest();

--- a/Raven.Database/Bundles/Replication/Tasks/ReplicationTaskBase.cs
+++ b/Raven.Database/Bundles/Replication/Tasks/ReplicationTaskBase.cs
@@ -29,6 +29,12 @@ namespace Raven.Database.Bundles.Replication.Tasks
             Replication = replication;
         }
 
+        protected string GetTombstoneVersion(JsonDocument tombstone, string tombstoneKey, string key)
+        {
+            var version = tombstone.Metadata.Value<int?>(tombstoneKey) ?? 0;
+            return key + "=" + version;
+        }
+
         protected string GetDebugInformation()
         {
             return Constants.IsReplicatedUrlParamName + "=true&from=" + Uri.EscapeDataString(Database.ServerUrl);

--- a/Raven.Database/Bundles/Replication/Tasks/TransformerReplicationTask.cs
+++ b/Raven.Database/Bundles/Replication/Tasks/TransformerReplicationTask.cs
@@ -199,7 +199,11 @@ namespace Raven.Database.Bundles.Replication.Tasks
                         continue;
                     }
 
-                    var url = string.Format("{0}/transformers/{1}?{2}", destination.ConnectionStringOptions.Url, Uri.EscapeUriString(tombstone.Key), GetDebugInformation());
+                    var url = string.Format("{0}/transformers/{1}?{2}&{3}", 
+                        destination.ConnectionStringOptions.Url, 
+                        Uri.EscapeUriString(tombstone.Key),
+                        GetTombstoneVersion(tombstone, IndexDefinitionStorage.TransformerVersionKey, Constants.TransformerVersion),
+                        GetDebugInformation());
                     var replicationRequest = HttpRavenRequestFactory.Create(url, HttpMethods.Delete, destination.ConnectionStringOptions, Replication.GetRequestBuffering(destination));
                     replicationRequest.Write(RavenJObject.FromObject(EmptyRequestBody));
                     replicationRequest.ExecuteRequest();

--- a/Raven.Database/Bundles/Replication/Tasks/TransformerReplicationTask.cs
+++ b/Raven.Database/Bundles/Replication/Tasks/TransformerReplicationTask.cs
@@ -16,6 +16,7 @@ using Raven.Abstractions.Replication;
 using Raven.Abstractions.Util;
 using Raven.Bundles.Replication.Impl;
 using Raven.Bundles.Replication.Tasks;
+using Raven.Database.Storage;
 using Raven.Database.Util;
 using Raven.Json.Linq;
 
@@ -68,7 +69,7 @@ namespace Raven.Database.Bundles.Replication.Tasks
                         {Constants.RavenTransformerDeleteMarker, true},
                         {Constants.RavenReplicationSource, Database.TransactionalStorage.Id.ToString()},
                         {Constants.RavenReplicationVersion, ReplicationHiLo.NextId(Database)},
-                        {"TransformerVersion", notification.Version }
+                        {IndexDefinitionStorage.TransformerVersionKey, notification.Version }
                     };
 
                     Database.TransactionalStorage.Batch(accessor => 
@@ -77,7 +78,8 @@ namespace Raven.Database.Bundles.Replication.Tasks
             }
         }
 
-        public bool Execute(Func<ReplicationDestination, bool> shouldSkipDestinationPredicate = null)
+        public bool Execute(Func<ReplicationDestination, bool> shouldSkipDestinationPredicate = null,
+            bool forceTombstoneReplication = false)
         {
             if (Database.Disposed)
                 return false;
@@ -91,6 +93,7 @@ namespace Raven.Database.Bundles.Replication.Tasks
                 {
                     shouldSkipDestinationPredicate = shouldSkipDestinationPredicate ?? (x => x.SkipIndexReplication == false);
                     var replicationDestinations = GetReplicationDestinations(x => shouldSkipDestinationPredicate(x));
+                    var replicatedTransformerTombstones = new Dictionary<string, int>();
 
                     foreach (var destination in replicationDestinations)
                     {
@@ -100,8 +103,7 @@ namespace Raven.Database.Bundles.Replication.Tasks
                             // we don't send out deletions immediately, we wait for a bit
                             // to make sure that the user didn't reset the index or delete / create
                             // things manually
-                            x => (now - x.CreatedAt) >= TimeToWaitBeforeSendingDeletesOfTransformersToSiblings);
-                        var replicatedTransformerTombstones = new Dictionary<string, int>();
+                            x => forceTombstoneReplication || (now - x.CreatedAt) >= TimeToWaitBeforeSendingDeletesOfTransformersToSiblings);
 
                         try
                         {
@@ -117,20 +119,21 @@ namespace Raven.Database.Bundles.Replication.Tasks
                         {
                             Log.ErrorException("Failed to replicate transformers to " + destination, e);
                         }
-
-                        Database.TransactionalStorage.Batch(actions =>
-                        {
-                            foreach (var transformerTombstone in replicatedTransformerTombstones)
-                            {
-                                var transformerExists = Database.Transformers.GetTransformerDefinition(transformerTombstone.Key) != null;
-                                if (transformerTombstone.Value != replicationDestinations.Count &&
-                                    transformerExists == false)
-                                    continue;
-
-                                actions.Lists.Remove(Constants.RavenReplicationTransformerTombstones, transformerTombstone.Key);
-                            }
-                        });
                     }
+
+                    Database.TransactionalStorage.Batch(actions =>
+                    {
+                        foreach (var transformerTombstone in replicatedTransformerTombstones)
+                        {
+                            var transformerExists = Database.Transformers.GetTransformerDefinition(transformerTombstone.Key) != null;
+                            if (transformerTombstone.Value != replicationDestinations.Count &&
+                                transformerExists == false)
+                                continue;
+
+                            actions.Lists.Remove(Constants.RavenReplicationTransformerTombstones, transformerTombstone.Key);
+                        }
+                    });
+
                     return true;
                 }
             }

--- a/Raven.Database/Server/Controllers/IndexController.cs
+++ b/Raven.Database/Server/Controllers/IndexController.cs
@@ -382,7 +382,15 @@ namespace Raven.Database.Server.Controllers
             var index = id;
 
             var isReplication = GetQueryStringValue(Constants.IsReplicatedUrlParamName);
-            if (Database.Indexes.DeleteIndex(index) &&
+            var indexVersionAsString = GetQueryStringValue(Constants.IndexVersion);
+            int? indexVersionAsInt = null;
+            int indexVersion;
+            if (int.TryParse(indexVersionAsString, out indexVersion))
+            {
+                indexVersionAsInt = indexVersion;
+            }
+
+            if (Database.Indexes.DeleteIndex(index, deletedIndexVersion: indexVersionAsInt) &&
                 !string.IsNullOrWhiteSpace(isReplication) && isReplication.Equals("true", StringComparison.InvariantCultureIgnoreCase))
             {
                 const string emptyFrom = "<no hostname>";

--- a/Raven.Database/Server/Controllers/TransformersController.cs
+++ b/Raven.Database/Server/Controllers/TransformersController.cs
@@ -107,9 +107,16 @@ namespace Raven.Database.Server.Controllers
         [RavenRoute("databases/{databaseName}/transformers/{*id}")]
         public HttpResponseMessage TransformersDelete(string id)
         {
-            var isReplication = GetQueryStringValue("is-replication");
+            var isReplication = GetQueryStringValue(Constants.IsReplicatedUrlParamName);
+            var transformerVersionAsString = GetQueryStringValue(Constants.TransformerVersion);
+            int? transformerVersionAsInt = null;
+            int transformerVersion;
+            if (int.TryParse(transformerVersionAsString, out transformerVersion))
+            {
+                transformerVersionAsInt = transformerVersion;
+            }
 
-            if (Database.Transformers.DeleteTransform(id) &&
+            if (Database.Transformers.DeleteTransform(id, transformerVersionAsInt) &&
                 !String.IsNullOrWhiteSpace(isReplication) && isReplication.Equals("true", StringComparison.InvariantCultureIgnoreCase))
             {
                 const string emptyFrom = "<no hostname>";

--- a/Raven.Database/Storage/IndexDefinitionStorage.cs
+++ b/Raven.Database/Storage/IndexDefinitionStorage.cs
@@ -23,11 +23,15 @@ using Raven.Abstractions.MEF;
 using Raven.Database.Config;
 using Raven.Database.Linq;
 using Raven.Database.Plugins;
+using Raven.Json.Linq;
 
 namespace Raven.Database.Storage
 {
     public class IndexDefinitionStorage
     {
+        public const string IndexVersionKey = "IndexVersion";
+        public const string TransformerVersionKey = "TransformerVersion";
+
         private const string IndexDefDir = "IndexDefinitions";
 
         private readonly ReaderWriterLockSlim currentlyIndexingLock = new ReaderWriterLockSlim(LockRecursionPolicy.SupportsRecursion);
@@ -532,20 +536,25 @@ namespace Raven.Database.Storage
             return res;
         }
 
-        public int GetDeletedIndexVersion(IndexDefinition definition)
+        public int GetDeletedIndexVersion(string indexName, int indexId)
         {
             // we only need the deleted index version if exists
             // no need to log an error
             int indexVersionFromTombstones;
-            CheckIfIndexVersionIsEqualOrSmaller(Constants.RavenReplicationIndexesTombstones, 
-                definition.Name, int.MaxValue, definition.Name, out indexVersionFromTombstones);
+            CheckIfIndexVersionIsEqualOrSmaller(Constants.RavenReplicationIndexesTombstones,
+                indexName, int.MaxValue, indexName, out indexVersionFromTombstones);
 
             int indexVersionFromPendingDeletions;
-            CheckIfIndexVersionIsEqualOrSmaller("Raven/Indexes/PendingDeletion", 
-                definition.IndexId.ToString(CultureInfo.InvariantCulture), 
-                int.MaxValue, definition.Name, out indexVersionFromPendingDeletions);
+            CheckIfIndexVersionIsEqualOrSmaller("Raven/Indexes/PendingDeletion",
+                indexId.ToString(CultureInfo.InvariantCulture), 
+                int.MaxValue, indexName, out indexVersionFromPendingDeletions);
 
-            return Math.Max(indexVersionFromTombstones, indexVersionFromPendingDeletions);
+            var result = Math.Max(indexVersionFromTombstones, indexVersionFromPendingDeletions);
+
+            int deletedIndexVersion;
+            CheckIfIndexVersionIsEqualOrSmaller(Constants.RavenDeletedIndexesVersions,
+                indexName, int.MaxValue, indexName, out deletedIndexVersion);
+            return Math.Max(result, deletedIndexVersion);
         }
 
         public bool Contains(string indexName)
@@ -601,7 +610,17 @@ namespace Raven.Database.Storage
             var transformer = GetTransformerDefinition(name);
             if (transformer == null)
                 return false;
+
             RemoveTransformer(transformer.TransfomerId);
+
+            transactionalStorage.Batch(actions =>
+            {
+                var metadata = new RavenJObject
+                {
+                    {TransformerVersionKey, transformer.TransformerVersion ?? 0 }
+                };
+                actions.Lists.Set(Constants.RavenDeletedTransformersVersions, name, metadata, UuidType.Transformers);
+            });
 
             return true;
         }
@@ -688,12 +707,8 @@ namespace Raven.Database.Storage
             else
             {
                 index.Name = indexToSwapName;
-
-                int indexVersionFromTombstones;
-                CheckIfIndexVersionIsEqualOrSmaller(Constants.RavenReplicationIndexesTombstones,
-                    indexToSwapName, 0, indexToSwapName, out indexVersionFromTombstones);
-
-                index.IndexVersion = indexVersionFromTombstones + 1;
+                var deletedIndexVersion = GetDeletedIndexVersion(indexToSwapName, indexId: 0);
+                index.IndexVersion = deletedIndexVersion + 1;
             }
 
             index.Name = indexToReplace != null ? indexToReplace.Name : indexToSwapName;

--- a/Raven.Database/Storage/IndexDefinitionStorage.cs
+++ b/Raven.Database/Storage/IndexDefinitionStorage.cs
@@ -538,6 +538,9 @@ namespace Raven.Database.Storage
 
         public int GetDeletedIndexVersion(string indexName, int indexId)
         {
+            if (indexName == null)
+                return 0;
+
             // we only need the deleted index version if exists
             // no need to log an error
             int indexVersionFromTombstones;
@@ -612,15 +615,6 @@ namespace Raven.Database.Storage
                 return false;
 
             RemoveTransformer(transformer.TransfomerId);
-
-            transactionalStorage.Batch(actions =>
-            {
-                var metadata = new RavenJObject
-                {
-                    {TransformerVersionKey, transformer.TransformerVersion ?? 0 }
-                };
-                actions.Lists.Set(Constants.RavenDeletedTransformersVersions, name, metadata, UuidType.Transformers);
-            });
 
             return true;
         }

--- a/Raven.Tests/Replication/IndexReplication.cs
+++ b/Raven.Tests/Replication/IndexReplication.cs
@@ -1,6 +1,7 @@
 using System;
 using System.Collections.Generic;
 using System.Linq;
+using System.Net.Http;
 using System.Threading;
 using System.Threading.Tasks;
 using Raven.Abstractions.Connection;
@@ -893,6 +894,138 @@ namespace Raven.Tests.Replication
 
                 //the new index should be replicated
                 Assert.Equal(3, destination.DatabaseCommands.ForDatabase("testDB").GetStatistics().Indexes.Length);
+            }
+        }
+
+        [Fact]
+        public void should_ignore_outdated_index_delete()
+        {
+            var requestFactory = new HttpRavenRequestFactory();
+            using (var sourceServer = GetNewServer(8077))
+            using (var source = NewRemoteDocumentStore(ravenDbServer: sourceServer, fiddler: true))
+            using (var destinationServer = GetNewServer(8078))
+            using (var destination = NewRemoteDocumentStore(ravenDbServer: destinationServer, fiddler: true))
+            {
+                CreateDatabaseWithReplication(source, "testDB");
+                CreateDatabaseWithReplication(destination, "testDB");
+
+                source.Conventions.IndexAndTransformerReplicationMode = IndexAndTransformerReplicationMode.None;
+                destination.Conventions.IndexAndTransformerReplicationMode = IndexAndTransformerReplicationMode.None;
+
+                SetupReplication(source, "testDB", store => false, destination);
+                SetupReplication(destination, "testDB", store => false, source);
+
+                for (var i = 0; i < 30; i++)
+                {
+                    //just for starting the initial index and transformer replication
+                    source.DatabaseCommands.ForDatabase("testDB").Put("test" + i, Etag.Empty, new RavenJObject(), new RavenJObject());
+                    destination.DatabaseCommands.ForDatabase("testDB").Put("test" + (i + 50), Etag.Empty, new RavenJObject(), new RavenJObject());
+                }
+
+                WaitForDocument(destination.DatabaseCommands.ForDatabase("testDB"), "test29");
+                WaitForDocument(source.DatabaseCommands.ForDatabase("testDB"), "test79");
+
+                var userIndex = new UserIndex();
+                source.DatabaseCommands.ForDatabase("testDB").PutIndex(userIndex.IndexName, userIndex.CreateIndexDefinition());
+                destination.DatabaseCommands.ForDatabase("testDB").PutIndex(userIndex.IndexName, userIndex.CreateIndexDefinition());
+                // index version = 1 on both servers
+
+                var extendedUserIndex = new UserIndex_Extended();
+                source.DatabaseCommands.ForDatabase("testDB").PutIndex(extendedUserIndex.IndexName, extendedUserIndex.CreateIndexDefinition(), true);
+                // index version = 2 on 'source server'
+
+                destination.DatabaseCommands.ForDatabase("testDB").DeleteIndex(userIndex.IndexName);
+                // deleted index version = 1
+
+                // replicating indexes from the destination
+                var replicationRequestUrl = string.Format("{0}/databases/testDB/replication/replicate-indexes?op=replicate-all", destination.Url);
+                var replicationRequest = requestFactory.Create(replicationRequestUrl, HttpMethod.Post, new RavenConnectionStringOptions
+                {
+                    Url = destination.Url
+                });
+                replicationRequest.ExecuteRequest();
+
+                // the index shouldn't be deleted
+                var index = source.DatabaseCommands.ForDatabase("testDB").GetIndex(userIndex.IndexName);
+                Assert.NotNull(index);
+                Assert.True(extendedUserIndex.CreateIndexDefinition().Map.Equals(index.Map));
+
+                // replicating indexes from the source
+                replicationRequestUrl = string.Format("{0}/databases/testDB/replication/replicate-indexes?op=replicate-all", source.Url);
+                replicationRequest = requestFactory.Create(replicationRequestUrl, HttpMethod.Post, new RavenConnectionStringOptions
+                {
+                    Url = source.Url
+                });
+                replicationRequest.ExecuteRequest();
+
+                index = destination.DatabaseCommands.ForDatabase("testDB").GetIndex(userIndex.IndexName);
+                Assert.NotNull(index);
+                Assert.True(extendedUserIndex.CreateIndexDefinition().Map.Equals(index.Map));
+            }
+        }
+
+        [Fact]
+        public void should_accept_updated_index_delete()
+        {
+            var requestFactory = new HttpRavenRequestFactory();
+            using (var sourceServer = GetNewServer(8077))
+            using (var source = NewRemoteDocumentStore(ravenDbServer: sourceServer, fiddler: true))
+            using (var destinationServer = GetNewServer(8078))
+            using (var destination = NewRemoteDocumentStore(ravenDbServer: destinationServer, fiddler: true))
+            {
+                CreateDatabaseWithReplication(source, "testDB");
+                CreateDatabaseWithReplication(destination, "testDB");
+
+                source.Conventions.IndexAndTransformerReplicationMode = IndexAndTransformerReplicationMode.None;
+                destination.Conventions.IndexAndTransformerReplicationMode = IndexAndTransformerReplicationMode.None;
+
+                SetupReplication(source, "testDB", store => false, destination);
+                SetupReplication(destination, "testDB", store => false, source);
+
+                for (var i = 0; i < 30; i++)
+                {
+                    //just for starting the initial index and transformer replication
+                    source.DatabaseCommands.ForDatabase("testDB").Put("test" + i, Etag.Empty, new RavenJObject(), new RavenJObject());
+                    destination.DatabaseCommands.ForDatabase("testDB").Put("test" + (i + 50), Etag.Empty, new RavenJObject(), new RavenJObject());
+                }
+
+                WaitForDocument(destination.DatabaseCommands.ForDatabase("testDB"), "test29");
+                WaitForDocument(source.DatabaseCommands.ForDatabase("testDB"), "test79");
+
+                var userIndex = new UserIndex();
+                source.DatabaseCommands.ForDatabase("testDB").PutIndex(userIndex.IndexName, userIndex.CreateIndexDefinition());
+                destination.DatabaseCommands.ForDatabase("testDB").PutIndex(userIndex.IndexName, userIndex.CreateIndexDefinition());
+                // index version = 1 on both servers
+
+                var extendedUserIndex = new UserIndex_Extended();
+                source.DatabaseCommands.ForDatabase("testDB").PutIndex(extendedUserIndex.IndexName, extendedUserIndex.CreateIndexDefinition(), true);
+                // index version = 2 on 'source server'
+
+                source.DatabaseCommands.ForDatabase("testDB").DeleteIndex(userIndex.IndexName);
+                // deleted index version = 2 on 'source server'
+
+                // replicating indexes from the source
+                var replicationRequestUrl = string.Format("{0}/databases/testDB/replication/replicate-indexes?op=replicate-all", source.Url);
+                var replicationRequest = requestFactory.Create(replicationRequestUrl, HttpMethod.Post, new RavenConnectionStringOptions
+                {
+                    Url = source.Url
+                });
+                replicationRequest.ExecuteRequest();
+
+                // the index should be deleted
+                var index = destination.DatabaseCommands.ForDatabase("testDB").GetIndex(userIndex.IndexName);
+                Assert.Null(index);
+
+                // replicating indexes from the destination
+                replicationRequestUrl = string.Format("{0}/databases/testDB/replication/replicate-indexes?op=replicate-all", destination.Url);
+                replicationRequest = requestFactory.Create(replicationRequestUrl, HttpMethod.Post, new RavenConnectionStringOptions
+                {
+                    Url = destination.Url
+                });
+                replicationRequest.ExecuteRequest();
+
+                index = source.DatabaseCommands.ForDatabase("testDB").GetIndex(userIndex.IndexName);
+                Assert.Null(index);
             }
         }
 


### PR DESCRIPTION
Index delete replication should send IndexVersion to the destination server
Replicate all indexes and transformers doesn't always replicate deletes