### PR TITLE
RavenDB-7322

### DIFF
--- a/test/FastTests/Server/Documents/Notifications/ChangesTests.cs
+++ b/test/FastTests/Server/Documents/Notifications/ChangesTests.cs
@@ -39,7 +39,6 @@ namespace FastTests.Server.Documents.Notifications
             }
         }
 
-        [Fact]
         public async Task CanGetAllNotificationAboutDocument_ALotOfDocuments()
         {
             using (var store = GetDocumentStore())

--- a/test/SlowTests/Issues/RavenDB-7275.cs
+++ b/test/SlowTests/Issues/RavenDB-7275.cs
@@ -1,7 +1,6 @@
 ﻿using System;
-using System.Collections.Generic;
-using System.Text;
 using System.Threading.Tasks;
+using FastTests;
 using FastTests.Client.Attachments;
 using FastTests.Server.Documents.Notifications;
 using Raven.Client.Documents.Subscriptions;
@@ -12,9 +11,9 @@ using Raven.Server.Config.Attributes;
 using Sparrow;
 using Xunit;
 
-namespace FastTests.Client.Subscriptions
+namespace SlowTests.Issues
 {
-    public class RavenDB_7275:RavenTestBase
+    public class RavenDB_7275 : RavenTestBase
     {
         private readonly ApiKeyDefinition _apiKey = new ApiKeyDefinition
         {

--- a/test/SlowTests/Issues/RavenDB_6285.cs
+++ b/test/SlowTests/Issues/RavenDB_6285.cs
@@ -11,6 +11,15 @@ namespace SlowTests.Issues
     public class RavenDB_6285 : RavenTestBase
     {
         [Fact]
+        public async Task CanGetAllNotificationAboutDocument_ALotOfDocuments()
+        {
+            using (var x = new ChangesTests())
+            {
+                await x.CanGetAllNotificationAboutDocument_ALotOfDocuments();
+            }
+        }
+
+        [Fact]
         public async Task BasicChangesApi()
         {
             using (var store = GetDocumentStore())

--- a/test/SlowTests/Issues/RavenDB_7253.cs
+++ b/test/SlowTests/Issues/RavenDB_7253.cs
@@ -1,23 +1,24 @@
 ﻿using System;
 using System.Threading.Tasks;
+using FastTests;
 using FastTests.Client.Attachments;
-using Raven.Client.Documents.Subscriptions;
-using Xunit;
 using FastTests.Server.Documents.Notifications;
+using Raven.Client.Documents.Subscriptions;
 using Raven.Client.Extensions;
 using Raven.Client.Server.Operations;
 using Sparrow;
+using Xunit;
 
-namespace FastTests.Client.Subscriptions
+namespace SlowTests.Issues
 {
-    public class RavenDB_7253:RavenTestBase
+    public class RavenDB_7253 : RavenTestBase
     {
         [Fact]
         public async Task SubscriptionShouldStopUponDatabaseDeletion()
         {
             using (var store = GetDocumentStore())
             {
-                    
+
                 var subscriptionId = await store.AsyncSubscriptions.CreateAsync(new SubscriptionCreationOptions<User>());
 
                 var subscription = store.AsyncSubscriptions.Open<User>(new SubscriptionConnectionOptions(subscriptionId)

--- a/test/StressTests/Client/Attachments/AttachmentsHugeFiles.cs
+++ b/test/StressTests/Client/Attachments/AttachmentsHugeFiles.cs
@@ -3,13 +3,14 @@ using System.IO;
 using FastTests;
 using FastTests.Client.Attachments;
 using Microsoft.AspNetCore.Http.Features;
+using Tests.Infrastructure;
 using Xunit;
 
 namespace StressTests.Client.Attachments
 {
     public class AttachmentsHugeFiles : NoDisposalNeeded
     {
-        [Theory]
+        [NightlyBuildTheory]
         [InlineData(FormOptions.DefaultMultipartBodyLengthLimit * 2, "vEbE0Uh02lIPx/cEFBagkmepLTP0nWWYX5+exkt9yoE=")] // 256 MB
         [InlineData(2.5 * 1024 * 1024 * 1024, "2ssXqJM7lbdDpDNkc2GsfDbmcQ6CXdgP6/LFmLtFCT4=")] // 2.5 GB
         public void BatchRequestWithLongMultiPartSections(long size, string hash)
@@ -29,7 +30,7 @@ namespace StressTests.Client.Attachments
             }
         }
 
-        [Theory]
+        [NightlyBuildTheory]
         [InlineData(2.5 * 1024 * 1024 * 1024, "2ssXqJM7lbdDpDNkc2GsfDbmcQ6CXdgP6/LFmLtFCT4=")] // 2.5 GB
         public void SupportHugeAttachment(long size, string hash)
         {

--- a/test/StressTests/Databases.cs
+++ b/test/StressTests/Databases.cs
@@ -18,7 +18,7 @@ namespace StressTests
 {
     public class Databases : RavenTestBase
     {
-        [Theory]
+        [NightlyBuildTheory]
         [InlineData(100)]
         public void CanHandleMultipleDatabasesOnWrite(int numberOfDatabases)
         {

--- a/test/Tests.Infrastructure/NightlyBuildTheory.cs
+++ b/test/Tests.Infrastructure/NightlyBuildTheory.cs
@@ -1,0 +1,21 @@
+﻿using System;
+using Raven.Client.Util;
+using Xunit;
+
+namespace Tests.Infrastructure
+{
+    public class NightlyBuildTheory : TheoryAttribute
+    {
+        public override string Skip
+        {
+            get
+            {
+                var now = SystemTime.UtcNow;
+                if (now.Hour >= 21 || now.Hour <= 6)
+                    return null;
+
+                return "Nightly build tests are only working between 21:00 and 6:00 UTC.";
+            }
+        }
+    }
+}


### PR DESCRIPTION
- moved longest tests from Fast to Slow,
- AttachmentsHugeFiles tests will only start in our nightly builds