### PR TITLE
RavenDB-7411 - Raven.Backup.exe fails on esent when using a UNC path

### DIFF
--- a/Raven.Backup/DatabaseBackupOperation.cs
+++ b/Raven.Backup/DatabaseBackupOperation.cs
@@ -53,7 +53,7 @@ namespace Raven.Backup
 
             var backupRequest = new
             {
-                BackupLocation = parameters.BackupPath.Replace("\\", "\\\\"),
+               BackupLocation = parameters.BackupPath
             };
 
            


### PR DESCRIPTION
http://issues.hibernatingrhinos.com/issue/RavenDB-7411