### PR TITLE
RavenDB-7411 Raven.Backup.exe fails on esent when using a UNC path

### DIFF
--- a/Raven.Backup/BackupOperation.cs
+++ b/Raven.Backup/BackupOperation.cs
@@ -65,7 +65,7 @@ namespace Raven.Backup
 
 			var backupRequest = new
 								{
-									BackupLocation = BackupPath.Replace("\\", "\\\\")
+									BackupLocation = BackupPath
 								};
 
 			var json = RavenJObject.FromObject(backupRequest).ToString();


### PR DESCRIPTION
http://issues.hibernatingrhinos.com/issue/RavenDB-7411