### PR TITLE
RavenDB-7059 implementation

### DIFF
--- a/src/Raven.Client/Documents/Smuggler/DatabaseItemType.cs
+++ b/src/Raven.Client/Documents/Smuggler/DatabaseItemType.cs
@@ -11,6 +11,7 @@ namespace Raven.Client.Documents.Smuggler
         RevisionDocuments = 1 << 1,
         Indexes = 1 << 2,
         Transformers = 1 << 3,
-        Identities = 1 << 4,
+        LocalIdentities = 1 << 4,
+        ClusterIdentities = 1 << 5,
     }
 }

--- a/src/Raven.Client/Documents/Smuggler/DatabaseSmugglerOptions.cs
+++ b/src/Raven.Client/Documents/Smuggler/DatabaseSmugglerOptions.cs
@@ -7,7 +7,7 @@ namespace Raven.Client.Documents.Smuggler
 {
     public class DatabaseSmugglerOptions
     {
-        private const DatabaseItemType DefaultOperateOnTypes = DatabaseItemType.Indexes | DatabaseItemType.Transformers | DatabaseItemType.Documents | DatabaseItemType.RevisionDocuments | DatabaseItemType.Identities;
+        private const DatabaseItemType DefaultOperateOnTypes = DatabaseItemType.Indexes | DatabaseItemType.Transformers | DatabaseItemType.Documents | DatabaseItemType.RevisionDocuments | DatabaseItemType.LocalIdentities | DatabaseItemType.ClusterIdentities;
 
         private const int DefaultMaxStepsForTransformScript = 10 * 1000;
 

--- a/src/Raven.Server/Documents/Handlers/BatchRequestParser.cs
+++ b/src/Raven.Server/Documents/Handlers/BatchRequestParser.cs
@@ -8,6 +8,7 @@ using System.Threading.Tasks;
 using Raven.Client.Documents.Commands.Batches;
 using Raven.Client.Extensions;
 using Raven.Server.Documents.Patch;
+using Raven.Server.Rachis;
 using Raven.Server.ServerWide;
 using Sparrow.Json;
 using Sparrow.Json.Parsing;
@@ -87,6 +88,7 @@ namespace Raven.Server.Documents.Handlers
                 if (state.CurrentTokenType != JsonParserToken.StartArray)
                     ThrowUnexpectedToken(JsonParserToken.StartArray, state);
 
+                long maxClusterIdentityEtag = -1;
                 while (true)
                 {
                     while (parser.Read() == false)
@@ -112,11 +114,17 @@ namespace Raven.Server.Documents.Handlers
 
                     if (commandData.Type == CommandType.PUT && string.IsNullOrEmpty(commandData.Id) == false && commandData.Id[commandData.Id.Length - 1] == '/')
                     {
-                        commandData.Id = await serverStore.GenerateClusterIdentityAsync(commandData.Id, database.Name);
+                        var (id,etag) = await serverStore.GenerateClusterIdentityAsync(commandData.Id, database.Name);
+                        commandData.Id = id;
+                        maxClusterIdentityEtag = Math.Max(maxClusterIdentityEtag, etag);
                     }
                     
                     cmds[index] = commandData;
                 }
+
+                //if we have some documents with cluster identities, make sure to wait for cluster confirmation before proceeding
+                if (maxClusterIdentityEtag != -1)
+                    await serverStore.WaitForCommitIndexChange(RachisConsensus.CommitIndexModification.GreaterOrEqual, maxClusterIdentityEtag);
             }
             return new ArraySegment<CommandData>(cmds, 0, index + 1);
         }

--- a/src/Raven.Server/ServerWide/Commands/UpdateClusterIdentityCommand.cs
+++ b/src/Raven.Server/ServerWide/Commands/UpdateClusterIdentityCommand.cs
@@ -1,0 +1,47 @@
+﻿using System;
+using System.Collections.Generic;
+using Raven.Client.Extensions;
+using Raven.Client.Server;
+using Sparrow.Json.Parsing;
+
+namespace Raven.Server.ServerWide.Commands
+{
+    public class UpdateClusterIdentityCommand : UpdateDatabaseCommand
+    {
+        public Dictionary<string,long> Identities { get; set; }
+
+        public UpdateClusterIdentityCommand() : base(null)
+        {            
+        }
+
+        public UpdateClusterIdentityCommand(string databaseName, IDictionary<string, long> identities) : base(databaseName)
+        {
+            Identities = new Dictionary<string, long>(identities);
+        }
+
+        public override string UpdateDatabaseRecord(DatabaseRecord record, long etag)
+        {
+            
+            foreach (var kvp in Identities)
+            {
+                if (record.Identities.TryGetValue(kvp.Key, out long existingValue))
+                {
+                    record.Identities[kvp.Key] = Math.Max(existingValue, kvp.Value);
+                }
+                else
+                {
+                    record.Identities.Add(kvp.Key, kvp.Value);
+                }
+            }
+            return null;
+        }
+
+        public override void FillJson(DynamicJsonValue json)
+        {
+            if(Identities == null)
+                Identities = new Dictionary<string, long>();
+
+            json[nameof(Identities)] = Identities.ToJson();
+        }
+    }
+}

--- a/src/Raven.Server/ServerWide/JsonDeserializationCluster.cs
+++ b/src/Raven.Server/ServerWide/JsonDeserializationCluster.cs
@@ -52,6 +52,7 @@ namespace Raven.Server.ServerWide
             [nameof(RenameTransformerCommand)] = GenerateJsonDeserializationRoutine<RenameTransformerCommand>(),
             [nameof(DeleteDatabaseCommand)] = GenerateJsonDeserializationRoutine<DeleteDatabaseCommand>(),
             [nameof(IncrementClusterIdentityCommand)] = GenerateJsonDeserializationRoutine<IncrementClusterIdentityCommand>(),
+            [nameof(UpdateClusterIdentityCommand)] = GenerateJsonDeserializationRoutine<UpdateClusterIdentityCommand>(),
             [nameof(ModifyCustomFunctionsCommand)] = GenerateJsonDeserializationRoutine<ModifyCustomFunctionsCommand>(),
             [nameof(PutIndexCommand)] = GenerateJsonDeserializationRoutine<PutIndexCommand>(),
             [nameof(PutAutoIndexCommand)] = GenerateJsonDeserializationRoutine<PutAutoIndexCommand>(),

--- a/src/Raven.Server/ServerWide/ServerStore.cs
+++ b/src/Raven.Server/ServerWide/ServerStore.cs
@@ -919,9 +919,9 @@ namespace Raven.Server.ServerWide
             return _engine.GetClusterErrorsFromLeader();
         }
 
-        public async Task<string> GenerateClusterIdentityAsync(string id, string databaseName)
+        public async Task<(string,long)> GenerateClusterIdentityAsync(string id, string databaseName)
         {
-            var (_, result) = await SendToLeaderAsync(new IncrementClusterIdentityCommand(databaseName)
+            var (etag, result) = await SendToLeaderAsync(new IncrementClusterIdentityCommand(databaseName)
             {
                 Prefix = id.ToLower()
             });
@@ -933,7 +933,7 @@ namespace Raven.Server.ServerWide
                     $"Expected to get result from raft command that should generate a cluster-wide identity, but didn't. Leader is {LeaderTag}, Current node tag is {NodeTag}.");
             }
 
-            return id + result;
+            return (id + result,etag);
         }
 
         public DatabaseRecord LoadDatabaseRecord(string databaseName, out long etag)

--- a/src/Raven.Server/Smuggler/Documents/Data/ISmugglerDestination.cs
+++ b/src/Raven.Server/Smuggler/Documents/Data/ISmugglerDestination.cs
@@ -14,7 +14,8 @@ namespace Raven.Server.Smuggler.Documents.Data
         IDocumentActions RevisionDocuments();
         IIndexActions Indexes();
         ITransformerActions Transformers();
-        IIdentityActions Identities();
+        IIdentityActions LocalIdentities();
+        IIdentityActions ClusterIdentities();
     }
 
     public interface IDocumentActions : INewDocumentActions, IDisposable
@@ -40,6 +41,7 @@ namespace Raven.Server.Smuggler.Documents.Data
 
     public interface IIdentityActions : IDisposable
     {
+        IdentityType Type { get; }
         void WriteIdentity(string key, long value);
     }
 }

--- a/src/Raven.Server/Smuggler/Documents/Data/ISmugglerSource.cs
+++ b/src/Raven.Server/Smuggler/Documents/Data/ISmugglerSource.cs
@@ -15,7 +15,8 @@ namespace Raven.Server.Smuggler.Documents.Data
         IEnumerable<DocumentItem> GetRevisionDocuments(List<string> collectionsToExport, INewDocumentActions actions);
         IEnumerable<IndexDefinitionAndType> GetIndexes();
         IEnumerable<TransformerDefinition> GetTransformers();
-        IEnumerable<KeyValuePair<string, long>> GetIdentities();
+        IEnumerable<KeyValuePair<string, long>> GetLocalIdentities();
+        IEnumerable<KeyValuePair<string, long>> GetClusterIdentities();
         long SkipType(DatabaseItemType type);
     }
 

--- a/src/Raven.Server/Smuggler/Documents/Data/SmugglerResult.cs
+++ b/src/Raven.Server/Smuggler/Documents/Data/SmugglerResult.cs
@@ -21,7 +21,8 @@ namespace Raven.Server.Smuggler.Documents.Data
 
             Documents = new CountsWithSkippedCountAndLastEtag();
             RevisionDocuments = new CountsWithLastEtag();
-            Identities = new Counts();
+            LocalIdentities = new Counts();
+            ClusterIdentities = new Counts();
             Indexes = new Counts();
             Transformers = new Counts();
         }
@@ -87,7 +88,8 @@ namespace Raven.Server.Smuggler.Documents.Data
 
             public override CountsWithSkippedCountAndLastEtag Documents => _result.Documents;
             public override CountsWithLastEtag RevisionDocuments => _result.RevisionDocuments;
-            public override Counts Identities => _result.Identities;
+            public override Counts ClusterIdentities => _result.ClusterIdentities;
+            public override Counts LocalIdentities => _result.LocalIdentities;
             public override Counts Indexes => _result.Indexes;
             public override Counts Transformers => _result.Transformers;
 
@@ -118,7 +120,9 @@ namespace Raven.Server.Smuggler.Documents.Data
 
         public virtual CountsWithLastEtag RevisionDocuments { get; set; }
 
-        public virtual Counts Identities { get; set; }
+        public virtual Counts LocalIdentities { get; set; }
+
+        public virtual Counts ClusterIdentities { get; set; }
 
         public virtual Counts Indexes { get; set; }
 
@@ -130,7 +134,8 @@ namespace Raven.Server.Smuggler.Documents.Data
             {
                 [nameof(Documents)] = Documents.ToJson(),
                 [nameof(RevisionDocuments)] = RevisionDocuments.ToJson(),
-                [nameof(Identities)] = Identities.ToJson(),
+                [nameof(LocalIdentities)] = LocalIdentities.ToJson(),
+                [nameof(ClusterIdentities)] = ClusterIdentities.ToJson(),
                 [nameof(Indexes)] = Indexes.ToJson(),
                 [nameof(Transformers)] = Transformers.ToJson()
             };

--- a/src/Raven.Server/Smuggler/Documents/DatabaseSmuggler.cs
+++ b/src/Raven.Server/Smuggler/Documents/DatabaseSmuggler.cs
@@ -72,7 +72,8 @@ namespace Raven.Server.Smuggler.Documents
                 EnsureStepProcessed(result.RevisionDocuments.Attachments);
                 EnsureStepProcessed(result.Indexes);
                 EnsureStepProcessed(result.Transformers);
-                EnsureStepProcessed(result.Identities);
+                EnsureStepProcessed(result.LocalIdentities);
+                EnsureStepProcessed(result.ClusterIdentities);
 
                 return result;
             }
@@ -113,8 +114,11 @@ namespace Raven.Server.Smuggler.Documents
                 case DatabaseItemType.Transformers:
                     counts = ProcessTransformers(result);
                     break;
-                case DatabaseItemType.Identities:
-                    counts = ProcessIdentities(result);
+                case DatabaseItemType.LocalIdentities:
+                    counts = ProcessIdentities(result, IdentityType.Local);
+                    break;
+                case DatabaseItemType.ClusterIdentities:
+                    counts = ProcessIdentities(result, IdentityType.Cluster);
                     break;
                 default:
                     throw new ArgumentOutOfRangeException(nameof(type), type, null);
@@ -152,8 +156,11 @@ namespace Raven.Server.Smuggler.Documents
                 case DatabaseItemType.Transformers:
                     counts = result.Transformers;
                     break;
-                case DatabaseItemType.Identities:
-                    counts = result.Identities;
+                case DatabaseItemType.LocalIdentities:
+                    counts = result.LocalIdentities;
+                    break;
+                case DatabaseItemType.ClusterIdentities:
+                    counts = result.ClusterIdentities;
                     break;
                 default:
                     throw new ArgumentOutOfRangeException(nameof(type), type, null);
@@ -173,34 +180,63 @@ namespace Raven.Server.Smuggler.Documents
             _onProgress.Invoke(result.Progress);
         }
 
-        private SmugglerProgressBase.Counts ProcessIdentities(SmugglerResult result)
+        private SmugglerProgressBase.Counts ProcessIdentities(SmugglerResult result, IdentityType type)
         {
-            using (var actions = _destination.Identities())
+            switch (type)
             {
-                foreach (var kvp in _source.GetIdentities())
-                {
-                    _token.ThrowIfCancellationRequested();
-                    result.Identities.ReadCount++;
-
-                    if (kvp.Equals(default(KeyValuePair<string, long>)))
+                case IdentityType.Local:
+                    using (var localIdentityActions = _destination.LocalIdentities())
                     {
-                        result.Identities.ErroredCount++;
-                        continue;
+                        var sourceIdentities = _source.GetLocalIdentities();
+                        WriteIdentities(result, sourceIdentities, localIdentityActions,
+                            () => result.LocalIdentities.ReadCount++,
+                            () => result.LocalIdentities.ErroredCount++);
                     }
-
-                    try
+                    break;
+                case IdentityType.Cluster:
+                    using (var clusterIdentityActions = _destination.ClusterIdentities())
                     {
-                        actions.WriteIdentity(kvp.Key, kvp.Value);
+                        var sourceIdentities = _source.GetClusterIdentities();
+                        WriteIdentities(result, sourceIdentities, clusterIdentityActions,
+                                () => result.ClusterIdentities.ReadCount++,
+                                () => result.ClusterIdentities.ErroredCount++
+                            );
                     }
-                    catch (Exception e)
-                    {
-                        result.Identities.ErroredCount++;
-                        result.AddError($"Could not write identity '{kvp.Key} {kvp.Value}': {e.Message}");
-                    }
-                }
+                    break;
+                default:
+                    throw new ArgumentOutOfRangeException(nameof(type), type, null);
             }
 
-            return result.Identities;
+            return type == IdentityType.Local ? result.LocalIdentities : result.ClusterIdentities;
+        }
+
+        private void WriteIdentities(SmugglerResult result, 
+            IEnumerable<KeyValuePair<string, long>> sourceIdentities, 
+            IIdentityActions destinationIdentityActions,
+            Action incrementReadCount,
+            Action incrementErrorCount)
+        {
+            foreach (var kvp in sourceIdentities)
+            {
+                _token.ThrowIfCancellationRequested();
+                incrementReadCount();
+
+                if (kvp.Equals(default(KeyValuePair<string, long>)))
+                {
+                    incrementErrorCount();
+                    continue;
+                }
+
+                try
+                {
+                    destinationIdentityActions.WriteIdentity(kvp.Key, kvp.Value);
+                }
+                catch (Exception e)
+                {
+                    incrementErrorCount();
+                    result.AddError($"Could not write identity (of type {destinationIdentityActions.Type}) '{kvp.Key} {kvp.Value}': {e.Message}");
+                }
+            }
         }
 
         private SmugglerProgressBase.Counts ProcessTransformers(SmugglerResult result)

--- a/src/Raven.Server/Smuggler/Documents/DatabaseSource.cs
+++ b/src/Raven.Server/Smuggler/Documents/DatabaseSource.cs
@@ -36,7 +36,8 @@ namespace Raven.Server.Smuggler.Documents
             DatabaseItemType.RevisionDocuments,
             DatabaseItemType.Indexes,
             DatabaseItemType.Transformers,
-            DatabaseItemType.Identities,
+            DatabaseItemType.LocalIdentities,
+            DatabaseItemType.ClusterIdentities,
             DatabaseItemType.None
         };
 
@@ -140,10 +141,17 @@ namespace Raven.Server.Smuggler.Documents
             }
         }
 
-        public IEnumerable<KeyValuePair<string, long>> GetIdentities()
+        public IEnumerable<KeyValuePair<string, long>> GetLocalIdentities()
         {
             return _database.DocumentsStorage.Identities.GetIdentities(_context);
         }
+
+        public IEnumerable<KeyValuePair<string, long>> GetClusterIdentities()
+        {
+            var dr = _database.ServerStore.LoadDatabaseRecord(_database.Name, out long _);
+            return dr.Identities;
+        }
+
 
         public long SkipType(DatabaseItemType type)
         {

--- a/src/Raven.Server/Smuggler/Documents/Handlers/SmugglerHandler.cs
+++ b/src/Raven.Server/Smuggler/Documents/Handlers/SmugglerHandler.cs
@@ -193,16 +193,17 @@ namespace Raven.Server.Smuggler.Documents.Handlers
                     while (files.IsCompleted == false)
                     {
                         Func<Task<Stream>> getFile;
-                        DocumentsOperationContext context;
                         try
                         {
                             getFile = files.Take();
                         }
                         catch (Exception)
                         {
+                            //TODO : add logging, _silently_ skipping is a bad idea
                             continue;
                         }
-                        using (ContextPool.AllocateOperationContext(out context))
+
+                        using (ContextPool.AllocateOperationContext(out DocumentsOperationContext context))
                         using (var file = await getFile())
                         using (var stream = new GZipStream(new BufferedStream(file, 128 * Voron.Global.Constants.Size.Kilobyte), CompressionMode.Decompress))
                         {
@@ -234,8 +235,11 @@ namespace Raven.Server.Smuggler.Documents.Handlers
                 finalResult.RevisionDocuments.LastEtag = Math.Max(finalResult.RevisionDocuments.LastEtag, importResult.RevisionDocuments.LastEtag);
                 finalResult.RevisionDocuments.Attachments = importResult.RevisionDocuments.Attachments;
 
-                finalResult.Identities.ReadCount += importResult.Identities.ReadCount;
-                finalResult.Identities.ErroredCount += importResult.Identities.ErroredCount;
+                finalResult.LocalIdentities.ReadCount += importResult.LocalIdentities.ReadCount;
+                finalResult.LocalIdentities.ErroredCount += importResult.LocalIdentities.ErroredCount;
+
+                finalResult.ClusterIdentities.ReadCount += importResult.ClusterIdentities.ReadCount;
+                finalResult.ClusterIdentities.ErroredCount += importResult.ClusterIdentities.ErroredCount;
 
                 finalResult.Transformers.ReadCount += importResult.Transformers.ReadCount;
                 finalResult.Transformers.ErroredCount += importResult.Transformers.ErroredCount;

--- a/src/Raven.Server/Smuggler/Documents/IdentityType.cs
+++ b/src/Raven.Server/Smuggler/Documents/IdentityType.cs
@@ -1,0 +1,8 @@
+namespace Raven.Server.Smuggler.Documents
+{
+    public enum IdentityType
+    {
+        Local,
+        Cluster
+    }
+}

--- a/src/Raven.Server/Smuggler/Documents/StreamDestination.cs
+++ b/src/Raven.Server/Smuggler/Documents/StreamDestination.cs
@@ -60,10 +60,16 @@ namespace Raven.Server.Smuggler.Documents
             return new StreamDocumentActions(_writer, _context, _source, isRevision: true);
         }
 
-        public IIdentityActions Identities()
+        public IIdentityActions LocalIdentities()
         {
-            return new StreamIdentityActions(_writer);
+            return new StreamIdentityActions(_writer,IdentityType.Local);
         }
+
+        public IIdentityActions ClusterIdentities()
+        {
+            return new StreamIdentityActions(_writer, IdentityType.Cluster);
+        }
+
 
         public IIndexActions Indexes()
         {
@@ -235,14 +241,17 @@ namespace Raven.Server.Smuggler.Documents
 
                 Writer.WriteStream(stream);
             }
-        }
-
+        }        
+        
         private class StreamIdentityActions : StreamActionsBase, IIdentityActions
         {
-            public StreamIdentityActions(BlittableJsonTextWriter writer)
-                : base(writer, "Identities")
+            public StreamIdentityActions(BlittableJsonTextWriter writer, IdentityType type)
+                : base(writer, $"{type}Identities")
             {
+                Type = type;
             }
+
+            public IdentityType Type { get; }
 
             public void WriteIdentity(string key, long value)
             {

--- a/test/FastTests/Tasks/RavenDB-7059.cs
+++ b/test/FastTests/Tasks/RavenDB-7059.cs
@@ -1,0 +1,107 @@
+using System;
+using System.IO;
+using System.Linq;
+using System.Threading.Tasks;
+using Raven.Client.Documents;
+using Raven.Client.Documents.Smuggler;
+using Raven.Client.Server;
+using Raven.Client.Server.Operations;
+using Raven.Server.Utils;
+using Tests.Infrastructure;
+using Xunit;
+
+namespace FastTests.Tasks
+{
+    public class RavenDB_7059 : ClusterTestBase
+    {
+        private readonly string _fileName = Path.Combine(Path.GetTempPath(), $"{Guid.NewGuid()}.ravendump");
+
+        public class User
+        {
+            public string Id { get; set; }
+            public string Name { get; set; }
+        }
+        
+        [Fact]
+        public async Task Cluster_identity_should_work_with_smuggler()
+        {
+            const int clusterSize = 3;
+            const string databaseName = "Cluster_identity_for_single_document_should_work";
+            var leaderServer = await CreateRaftClusterAndGetLeader(clusterSize);
+            using (var leaderStore = new DocumentStore
+            {
+                Urls = leaderServer.WebUrls,
+                Database = databaseName
+            })
+            {
+                leaderStore.Initialize();
+                
+                await CreateDatabasesInCluster(clusterSize, databaseName, leaderStore);
+                using (var session = leaderStore.OpenSession())
+                {
+                    session.Store(new User { Name = "John Dow" }, "users/");
+                    session.Store(new User { Name = "Jake Dow" }, "users/");
+                    session.SaveChanges();                   
+                }
+                
+                await leaderStore.Smuggler.ExportAsync(new DatabaseSmugglerOptions
+                {
+                    Database = databaseName,
+                    FileName = _fileName
+                }, _fileName);
+            }
+
+            foreach (var server in Servers)
+            {
+                server.Dispose();
+            }
+            Servers.Clear();
+
+            leaderServer = await CreateRaftClusterAndGetLeader(clusterSize);
+            using (var leaderStore = new DocumentStore
+            {
+                Urls = leaderServer.WebUrls,
+                Database = databaseName
+            })
+            {
+                leaderStore.Initialize();
+                
+                await CreateDatabasesInCluster(clusterSize, databaseName, leaderStore);
+                await leaderStore.Smuggler.ImportAsync(new DatabaseSmugglerOptions
+                {
+                    Database = databaseName,
+                    FileName = _fileName
+                }, _fileName);
+                
+                using (var session = leaderStore.OpenSession())
+                {
+                    session.Store(new User { Name = "Julie Dow" }, "users/");
+                    session.SaveChanges();                   
+                }
+
+                using (var session = leaderStore.OpenSession())
+                {
+                    var julieDow = session.Query<User>().First(u => u.Name.StartsWith("Julie"));
+                    Assert.Equal("users/3",julieDow.Id);
+
+                }
+            }                        
+        }
+        
+        private async Task CreateDatabasesInCluster(int clusterSize, string databaseName, IDocumentStore store)
+        {
+            var databaseResult = await store.Admin.Server.SendAsync(new CreateDatabaseOperation(MultiDatabase.CreateDatabaseDocument(databaseName), clusterSize));
+            Assert.Equal(clusterSize, databaseResult.Topology.AllReplicationNodes().Count());
+            foreach (var server in Servers)
+            {
+                await server.ServerStore.Cluster.WaitForIndexNotification(databaseResult.ETag);
+            }
+        }
+
+        public override void Dispose()
+        {
+            base.Dispose();
+            IOExtensions.DeleteFile(_fileName);
+        }
+    }
+}

--- a/test/SlowTests/Issues/RavenDB_5998.cs
+++ b/test/SlowTests/Issues/RavenDB_5998.cs
@@ -45,8 +45,8 @@ namespace SlowTests.Issues
                     Assert.Equal(1, result.Transformers.ReadCount);
                     Assert.Equal(0, result.Transformers.ErroredCount);
 
-                    Assert.Equal(1, result.Identities.ReadCount);
-                    Assert.Equal(0, result.Identities.ErroredCount);
+                    Assert.Equal(1, result.LocalIdentities.ReadCount);
+                    Assert.Equal(0, result.LocalIdentities.ErroredCount);
 
                     Assert.Equal(0, result.RevisionDocuments.ReadCount);
                     Assert.Equal(0, result.RevisionDocuments.ErroredCount);

--- a/test/Tests.Infrastructure/ClusterTestBase.cs
+++ b/test/Tests.Infrastructure/ClusterTestBase.cs
@@ -476,8 +476,8 @@ namespace Tests.Infrastructure
                     continue; // must not dispose the global server
                 server?.Dispose();
             }
-
-            base.Dispose();
+            
+            base.Dispose();            
         }
     }
 }

--- a/test/Tryouts/Program.cs
+++ b/test/Tryouts/Program.cs
@@ -1,15 +1,20 @@
 ﻿using System;
+using System.Collections.Generic;
 using System.Diagnostics;
+using System.Linq;
 using FastTests.Client.Attachments;
 using RachisTests.DatabaseCluster;
 using Sparrow.Logging;
-using System.Threading.Tasks;
 using FastTests.Server.Documents.Notifications;
+using FastTests.Tasks;
 using Raven.Server.Utils;
 using Raven.Client.Documents;
 using RachisTests;
+using Raven.Client.Documents.Indexes;
+using Raven.Client.Documents.Linq;
+using Raven.Client.Documents.Transformers;
 using Raven.Client.Util;
-
+using Raven.Client.Documents.Linq;
 namespace Tryouts
 {
     public class Program
@@ -19,16 +24,235 @@ namespace Tryouts
             public string Name;
         }
 
+        public class BeerReviewComment
+        {
+            public string UserId { get; set; }
+            public string Comment { get; set; }
+            public DateTime Date { get; set; }
+            public List<BeerReviewComment> Replies { get; set; }
+        }
+
+        public class BeerReview
+        {
+            public string AuthorId { get; set; }
+            public string ReviewText { get; set; }
+            public string ReviewedBeerId { get; set; }
+            public DateTime PublishDate { get; set; }
+            public List<BeerReviewComment> Comments { get; set; }
+        }
+
+        public class ReviewTextWithAllCommentTextIndex : AbstractIndexCreationTask<BeerReview>
+        {
+            public class Result
+            {
+                public string ReviewText { get; set; }
+                public string[] Comments { get; set; }
+            }
+
+            public ReviewTextWithAllCommentTextIndex()
+            {
+                Map = reviews => from review in reviews
+                    select new
+                    {
+                        review.ReviewText,
+                        Comments = Recurse(review, x => x.Comments).Select(x => x.Comment)
+                    };
+            }
+        }
+
+        public class AllUsersWhoCommentedAReview : AbstractTransformerCreationTask<BeerReview>
+        {
+            public class Result
+            {
+                public string ReviewedBeerId { get; set; }
+                public string[] UserIDs { get; set; }
+            }
+
+            public AllUsersWhoCommentedAReview()
+            {
+                TransformResults = reviews => from review in reviews
+                    select new
+                    {
+                        review.ReviewedBeerId,
+                        UserId = Recurse(review, x => x.Comments).Select(x => x.UserId)
+                    };
+            }
+        }
+
+        public class BeerType
+        {
+            public string Name { get; set; }
+            public string BreweryId { get; set; }
+        }
+
+        public class BrewerType
+        {
+            public string Id { get; set; }
+            public string Name { get; set; }
+            public string Address { get; set; }
+        }
+
+        public class BeerAndBreweryTransformer : AbstractTransformerCreationTask<BeerType>
+        {
+            public class Result
+            {
+                public string Name { get; set; }
+                public string BreweryName { get; set; }
+                public string BreweryAddress { get; set; }
+            }
+
+            public BeerAndBreweryTransformer()
+            {
+                TransformResults = results => from result in results
+                    let brewery = LoadDocument<BrewerType>(result.BreweryId)
+                    select new
+                    {
+                        result.Name,
+                        BreweryName = brewery.Name,
+                        BreweryAddress = brewery.Address
+                    };
+            }
+        }
+
+        public class BeerByNameAndByBreweryNameIndex : AbstractIndexCreationTask<BeerType>
+        {
+            public class Result
+            {
+                public string Name { get; set; }
+                public string BreweryName { get; set; }
+            }
+
+            public BeerByNameAndByBreweryNameIndex()
+            {
+                Map = beers => from beer in beers
+                    let brewery = LoadDocument<BrewerType>(beer.BreweryId)
+                    select new
+                    {
+                        beer.Name,
+                        BreweryName = brewery.Name
+                    };
+            }
+        }
+
+        public class DocumentStoreHolder
+        {
+            private static readonly Lazy<IDocumentStore> store = 
+                new Lazy<IDocumentStore>(CreateStore);
+
+            public static IDocumentStore Store => store.Value;
+            private static IDocumentStore CreateStore()
+            {
+
+                return new DocumentStore
+                {
+                    Urls = new[] { "http://localhost:8080" },
+                    Database = "Northwind"
+                }.Initialize();
+            }
+        }
+
         public static void Main(string[] args)
         {
-           for (var i=0; i<1000; i++)
+            //using (var session = DocumentStoreHolder.Store.OpenSession())
+            //{
+            //    session.Store(new User {Name = "John Doe"});
+            //    session.SaveChanges();
+            //}
+
+
+            //using (var session = DocumentStoreHolder.Store.OpenSession())
+            //{
+            //    var users = Queryable.Where(session.Query<User>(), u => u.Name.StartsWith("Jo"))
+            //        .ToList();
+
+            //    #region Actually Use Query Results here
+            //    foreach (var user in users)
+            //    {
+            //        Console.WriteLine(user.Name);    
+            //    }
+            //    #endregion
+            //}
+
+            //new BeerAndBreweryTransformer().Execute(DocumentStoreHolder.Store);
+
+            //using (var session = DocumentStoreHolder.Store.OpenSession())
+            //{
+            //    var beers = Queryable.Where(session.Query<BeerType>()
+            //            .TransformWith<BeerAndBreweryTransformer, BeerAndBreweryTransformer.Result>(), b => b.Name.StartsWith("M"))
+            //        .ToList();
+
+            //    #region Actually Use Query Results here
+            //    foreach (var user in beers)
+            //    {
+            //        Console.WriteLine(user.Name);
+            //    }
+            //    #endregion
+            //}
+
+            //using (var session = DocumentStoreHolder.Store.OpenSession())
+            //{
+            //    var beers = Queryable.Where(session.Query<BeerType>()
+            //            .Include(b => b.BreweryId), b => b.Name.StartsWith("M"))
+            //        .ToList();
+
+            //    var brewery = session.Load<BrewerType>(beers[0].BreweryId);
+
+            //    #region Actually Use Query Results here
+
+            //    Console.WriteLine(brewery);
+            //    foreach (var b in beers)
+            //    {
+            //        Console.WriteLine(b.Name);
+            //    }
+            //    #endregion
+            //}
+
+            //new BeerByNameAndByBreweryNameIndex().Execute(DocumentStoreHolder.Store);
+            //using (var session = DocumentStoreHolder.Store.OpenSession())
+            //{
+            //    var beers = Queryable.Where(session.Query<BeerByNameAndByBreweryNameIndex.Result, BeerByNameAndByBreweryNameIndex>(), b => b.Name.StartsWith("M") &&
+            //                    b.BreweryName.EndsWith("R"))
+            //        .ToList();
+
+            //    #region Actually Use Query Results here
+
+            //    foreach (var b in beers)
+            //    {
+            //        Console.WriteLine(b.Name);
+            //    }
+            //    #endregion
+            //}
+
+
+            //using (var session = DocumentStoreHolder.Store.OpenSession())
+            //{
+            //    var reviews = session.Query<ReviewTextWithAllCommentTextIndex.Result, ReviewTextWithAllCommentTextIndex>()
+            //                         .Where(review => review.ReviewText.Contains("Pilsner") &&
+            //                                          review.Comments.ContainsAny(new []{ "Awesome", "Tasty", "Nice" }))
+            //                         .ToList();
+
+            //    #region Actually Use Query Results here
+
+
+            //    foreach (var b in reviews)
+            //    {
+            //        Console.WriteLine(b.ReviewText);
+            //    }
+            //    #endregion
+
+            //}
+
+
+            for (var i = 0; i < 100; i++)
             {
                 Console.WriteLine(i);
-                using (var test = new FastTests.Client.Subscriptions.VersionedSubscriptions())
+                using (var test = new RavenDB_7059())
                 {
-                    test.PlainVersionedSubscriptionsCompareDocs().Wait();
+                    test.Cluster_identity_should_work_with_smuggler().Wait();
                 }
             }
         }
     }
+
+
 }


### PR DESCRIPTION
* During Smuggler import that contains cluster identities information, the cluster will get properly updated with max cluster identity
* make sure that BulkImport endpoint (the endpoint that handles SaveChanges) will wait properly for all cluster identity commands
(RavenDB-7059)