### PR TITLE
Fixed bug in IsAllowed() and IsAllowedAsync()

### DIFF
--- a/Bundles/Raven.Client.Authorization/AuthorizationClientAsyncExtensions.cs
+++ b/Bundles/Raven.Client.Authorization/AuthorizationClientAsyncExtensions.cs
@@ -97,7 +97,7 @@ namespace Raven.Client.Authorization
 
         private static bool OperationMatches(string op1, string op2)
         {
-            return op2.StartsWith(op1);
+            return op1 == op2 || op2.StartsWith(op1+"/");
         }
 
         public static void SecureFor(this IAsyncDocumentSession session, string userId, string operation)

--- a/Bundles/Raven.Client.Authorization/AuthorizationClientExtensions.cs
+++ b/Bundles/Raven.Client.Authorization/AuthorizationClientExtensions.cs
@@ -104,7 +104,7 @@ namespace Raven.Client.Authorization
 
         private static bool OperationMatches(string op1, string op2)
         {
-            return op2.StartsWith(op1);
+			return op1 == op2 || op2.StartsWith(op1+"/");
         }
 
         public static void SecureFor(this IDocumentSession session, string userId, string operation)


### PR DESCRIPTION
Fixed bug when IsAllowed() and IsAllowedAsync() wrongly considered an operation as sub-operation.

Example: "Operation1" was considered as a sub item of "Operation"