### PR TITLE
RavenDB-4823 implementation

### DIFF
--- a/src/Raven.Client/Http/RavenCommand.cs
+++ b/src/Raven.Client/Http/RavenCommand.cs
@@ -1,5 +1,6 @@
 ﻿using System;
 using System.Collections.Generic;
+using System.Diagnostics;
 using System.IO;
 using System.Linq;
 using System.Net;
@@ -87,7 +88,7 @@ namespace Raven.Client.Http
         public virtual async Task ProcessResponse(JsonOperationContext context, HttpCache cache, HttpResponseMessage response, string url)
         {
             using (response)
-            {
+            {               
                 if (ResponseType == RavenCommandResponseType.Empty || response.StatusCode == HttpStatusCode.NoContent)
                     return;
 
@@ -106,7 +107,7 @@ namespace Raven.Client.Http
                         var contentLength = response.Content.Headers.ContentLength;
                         if (contentLength.HasValue && contentLength == 0)
                             return;
-
+                        
                         // we intentionally don't dispose the reader here, we'll be using it
                         // in the command, any associated memory will be released on context reset
                         var json = await context.ReadForMemoryAsync(stream, "response/object").ConfigureAwait(false);

--- a/src/Raven.Server/Documents/Handlers/Debugging/AdminDebugInfoPackageHandler.cs
+++ b/src/Raven.Server/Documents/Handlers/Debugging/AdminDebugInfoPackageHandler.cs
@@ -1,0 +1,84 @@
+﻿using System;
+using System.Collections.Generic;
+using System.IO;
+using System.IO.Compression;
+using System.Linq;
+using System.Text;
+using System.Threading.Tasks;
+using Raven.Server.Documents.Handlers.Admin;
+using Raven.Server.Routing;
+using Raven.Server.ServerWide.DebugInfo;
+using Raven.Server.Web;
+using Sparrow.Json;
+using Sparrow.Json.Parsing;
+
+namespace Raven.Server.Documents.Handlers.Debugging
+{
+    public class AdminDebugInfoPackageHandler : AdminRequestHandler
+    {
+        private static readonly IReadOnlyList<RouteInformation> _debugInformationRoutes = 
+            RouteScanner.Scan(attr => attr.IsDebugInformationEndpoint && 
+                                      attr.Path.Contains("info-package") == false).Values.ToList();
+
+        [RavenAction("/debug/info-package", "GET", IsDebugInformationEndpoint = true)]
+        public async Task GetInfoPackage()
+        {            
+            var contentDisposition = $"attachment; filename={DateTime.UtcNow}.debug-info-package.zip";
+            HttpContext.Response.Headers["Content-Disposition"] = contentDisposition;
+            using (ServerStore.ContextPool.AllocateOperationContext(out JsonOperationContext context))
+            {
+                using (var ms = new MemoryStream())
+                {
+                    using (var archive = new ZipArchive(ms, ZipArchiveMode.Create, true))
+                    {
+                        await WriteServerWide(archive, context);
+                    }
+
+                    ms.Position = 0;
+                    await ms.CopyToAsync(ResponseBodyStream());
+                }
+            }
+        }
+
+        private async Task WriteServerWide(ZipArchive archive, JsonOperationContext context)
+        {
+            var serverwideDataSources = GetServerwideDataSources();
+            try
+            {
+                //theoretically this could be parallelized,
+                //however ZipArchive allows only one archive entry to be open concurrently
+                foreach (var dataSource in serverwideDataSources)
+                {
+                    var entry = archive.CreateEntry(dataSource.FullPath);
+                    using (var entryStream = entry.Open())
+                    using (var writer = new BlittableJsonTextWriter(context, entryStream))
+                    using (var endpointOutput = await dataSource.GetData(context))
+                    {
+                        context.Write(writer, endpointOutput);
+                        writer.Flush();
+                        await entryStream.FlushAsync();
+                    }
+                }
+            }
+            finally
+            {
+                foreach (var dataSource in serverwideDataSources)
+                {
+                    dataSource.Dispose();
+                }
+            }
+        }
+
+        public IReadOnlyList<IDebugInfoDataSource> GetServerwideDataSources()
+        {
+            var dataSources = new List<IDebugInfoDataSource>();
+
+            foreach (var route in _debugInformationRoutes.Where(x => x.TypeOfRoute == RouteInformation.RouteType.None))
+            {
+                dataSources.Add(new ServerEndpointDebugInfoDataSource(ServerStore.NodeHttpServerUrl, route, ServerStore.ServerShutdown));
+            }
+
+            return dataSources;
+        }
+    }
+}

--- a/src/Raven.Server/Documents/Handlers/Debugging/DocumentDebugHandler.cs
+++ b/src/Raven.Server/Documents/Handlers/Debugging/DocumentDebugHandler.cs
@@ -9,7 +9,7 @@ namespace Raven.Server.Documents.Handlers.Debugging
 {
     public class DocumentDebugHandler : DatabaseRequestHandler
     {       
-        [RavenAction("/databases/*/debug/documents/huge", "GET")]
+        [RavenAction("/databases/*/debug/documents/huge", "GET", IsDebugInformationEndpoint = true)]
         public Task HugeDocuments()
         {
             using (ContextPool.AllocateOperationContext(out DocumentsOperationContext context))

--- a/src/Raven.Server/Documents/Handlers/Debugging/IdentityDebugHandler.cs
+++ b/src/Raven.Server/Documents/Handlers/Debugging/IdentityDebugHandler.cs
@@ -8,7 +8,7 @@ namespace Raven.Server.Documents.Handlers.Debugging
 {
     public class IdentityDebugHandler : DatabaseRequestHandler
     {
-        [RavenAction("/databases/*/debug/identities", "GET")]
+        [RavenAction("/databases/*/debug/identities", "GET", IsDebugInformationEndpoint = true)]
         public Task GetIdentities()
         {
             using (Database.ServerStore.ContextPool.AllocateOperationContext(out TransactionOperationContext context))

--- a/src/Raven.Server/Documents/Handlers/Debugging/MemoryStatsHandler.cs
+++ b/src/Raven.Server/Documents/Handlers/Debugging/MemoryStatsHandler.cs
@@ -16,7 +16,7 @@ namespace Raven.Server.Documents.Handlers.Debugging
 {
     public class MemoryStatsHandler : RequestHandler
     {
-        [RavenAction("/debug/memory/stats", "GET")]
+        [RavenAction("/debug/memory/stats", "GET", IsDebugInformationEndpoint = true)]
         public Task MemoryStats()
         {
             JsonOperationContext context;

--- a/src/Raven.Server/Documents/Handlers/Debugging/QueriesDebugHandler.cs
+++ b/src/Raven.Server/Documents/Handlers/Debugging/QueriesDebugHandler.cs
@@ -36,7 +36,7 @@ namespace Raven.Server.Documents.Handlers.Debugging
             return NoContent();
         }
 
-        [RavenAction("/databases/*/debug/queries/running", "GET")]
+        [RavenAction("/databases/*/debug/queries/running", "GET", IsDebugInformationEndpoint = true)]
         public Task RunningQueries()
         {
             var indexes = Database

--- a/src/Raven.Server/Documents/Handlers/Debugging/ServerInfoHandler.cs
+++ b/src/Raven.Server/Documents/Handlers/Debugging/ServerInfoHandler.cs
@@ -8,7 +8,7 @@ namespace Raven.Server.Documents.Handlers.Debugging
 {
     public class ServerInfoHandler : RequestHandler
     {
-        [RavenAction("/debug/server-id", "GET", "/debug/server-id", NoAuthorizationRequired = true)]
+        [RavenAction("/debug/server-id", "GET", "/debug/server-id", NoAuthorizationRequired = true, IsDebugInformationEndpoint = true)]
         public Task ServerId()
         {
             JsonOperationContext context;

--- a/src/Raven.Server/Documents/Handlers/Debugging/StorageHandler.cs
+++ b/src/Raven.Server/Documents/Handlers/Debugging/StorageHandler.cs
@@ -13,7 +13,7 @@ namespace Raven.Server.Documents.Handlers.Debugging
 {
     public class StorageHandler : DatabaseRequestHandler
     {
-        [RavenAction("/databases/*/debug/storage/report", "GET")]
+        [RavenAction("/databases/*/debug/storage/report", "GET", IsDebugInformationEndpoint = true)]
         public Task Report()
         {
             DocumentsOperationContext context;
@@ -59,7 +59,7 @@ namespace Raven.Server.Documents.Handlers.Debugging
             return Task.CompletedTask;
         }
 
-        [RavenAction("/databases/*/debug/storage/environment/report", "GET")]
+        [RavenAction("/databases/*/debug/storage/environment/report", "GET", IsDebugInformationEndpoint = true)]
         public Task EnvironmentReport()
         {
             var name = GetStringQueryString("name");

--- a/src/Raven.Server/Documents/Handlers/Debugging/TransactionDebugHandler.cs
+++ b/src/Raven.Server/Documents/Handlers/Debugging/TransactionDebugHandler.cs
@@ -19,7 +19,7 @@ namespace Raven.Server.Documents.Handlers.Debugging
             public List<LowLevelTransaction> Information;
         }
 
-        [RavenAction("/databases/*/debug/txinfo", "GET")]
+        [RavenAction("/databases/*/debug/txinfo", "GET", IsDebugInformationEndpoint = true)]
         public Task TxInfo()
         {
             

--- a/src/Raven.Server/Documents/Handlers/IoMetricsHandler.cs
+++ b/src/Raven.Server/Documents/Handlers/IoMetricsHandler.cs
@@ -18,7 +18,7 @@ namespace Raven.Server.Documents.Handlers
 {
     public class IoMetricsHandler : DatabaseRequestHandler
     {
-        [RavenAction("/databases/*/debug/io-metrics", "GET")]
+        [RavenAction("/databases/*/debug/io-metrics", "GET", IsDebugInformationEndpoint = true)]
         public Task IoMetrics()
         {
             JsonOperationContext context;

--- a/src/Raven.Server/Documents/Handlers/PerformanceMetricsHandler.cs
+++ b/src/Raven.Server/Documents/Handlers/PerformanceMetricsHandler.cs
@@ -28,7 +28,7 @@ namespace Raven.Server.Documents.Handlers
             }
         }
 
-        [RavenAction("/databases/*/debug/perf-metrics", "GET")]
+        [RavenAction("/databases/*/debug/perf-metrics", "GET", IsDebugInformationEndpoint = true)]
         public Task IoMetrics()
         {
             JsonOperationContext context;

--- a/src/Raven.Server/Documents/Handlers/ReplicationHandler.cs
+++ b/src/Raven.Server/Documents/Handlers/ReplicationHandler.cs
@@ -288,7 +288,7 @@ namespace Raven.Server.Documents.Handlers
             return Task.CompletedTask;
         }
 
-        [RavenAction("/databases/*/replication/debug/outgoing-failures", "GET")]
+        [RavenAction("/databases/*/replication/debug/outgoing-failures", "GET", IsDebugInformationEndpoint = true)]
         public Task GetReplicationOugoingFailureStats()
         {
             DocumentsOperationContext context;
@@ -321,7 +321,7 @@ namespace Raven.Server.Documents.Handlers
             return Task.CompletedTask;
         }
 
-        [RavenAction("/databases/*/replication/debug/incoming-last-activity-time", "GET")]
+        [RavenAction("/databases/*/replication/debug/incoming-last-activity-time", "GET", IsDebugInformationEndpoint = true)]
         public Task GetReplicationIncomingActivityTimes()
         {
             DocumentsOperationContext context;
@@ -349,7 +349,7 @@ namespace Raven.Server.Documents.Handlers
             return Task.CompletedTask;
         }
 
-        [RavenAction("/databases/*/replication/debug/incoming-rejection-info", "GET")]
+        [RavenAction("/databases/*/replication/debug/incoming-rejection-info", "GET", IsDebugInformationEndpoint = true)]
         public Task GetReplicationIncomingRejectionInfo()
         {
             using (ContextPool.AllocateOperationContext(out DocumentsOperationContext context))
@@ -384,7 +384,7 @@ namespace Raven.Server.Documents.Handlers
             return Task.CompletedTask;
         }
 
-        [RavenAction("/databases/*/replication/debug/outgoing-reconnect-queue", "GET")]
+        [RavenAction("/databases/*/replication/debug/outgoing-reconnect-queue", "GET", IsDebugInformationEndpoint = true)]
         public Task GetReplicationReconnectionQueue()
         {
             DocumentsOperationContext context;

--- a/src/Raven.Server/Documents/Handlers/TopologyHandler.cs
+++ b/src/Raven.Server/Documents/Handlers/TopologyHandler.cs
@@ -11,7 +11,7 @@ namespace Raven.Server.Documents.Handlers
 {
     public class TopologyHandler : DatabaseRequestHandler
     {
-        [RavenAction("/databases/*/debug/live-topology", "GET")]
+        [RavenAction("/databases/*/debug/live-topology", "GET", IsDebugInformationEndpoint = true)]
         public async Task GetLiveTopology()
         {
             var sp = Stopwatch.StartNew();

--- a/src/Raven.Server/Routing/RavenActionAttribute.cs
+++ b/src/Raven.Server/Routing/RavenActionAttribute.cs
@@ -7,6 +7,8 @@ namespace Raven.Server.Routing
     [MeansImplicitUse]
     public class RavenActionAttribute : Attribute
     {
+        public bool IsDebugInformationEndpoint { get; set; }
+
         public string Path { get; }
 
         public string Method { get; }
@@ -17,11 +19,12 @@ namespace Raven.Server.Routing
 
         public bool SkipUsagesCount { get; set; }
 
-        public RavenActionAttribute(string path, string method, string description = null)
+        public RavenActionAttribute(string path, string method, string description = null, bool isDebugInformationEndpoint = false)
         {
             Path = path;
             Method = method;
             Description = description;
+            IsDebugInformationEndpoint = isDebugInformationEndpoint;
         }
     }
 }

--- a/src/Raven.Server/Routing/RouteInformation.cs
+++ b/src/Raven.Server/Routing/RouteInformation.cs
@@ -22,19 +22,24 @@ namespace Raven.Server.Routing
         private HandleRequest _request;
         private RouteType _typeOfRoute;
 
-        private enum RouteType
+        public bool IsDebugInformationEndpoint;
+
+        public enum RouteType
         {
             None,
             Databases
         }
 
-        public RouteInformation(string method, string path, bool noAuthorizationRequired, bool skipUsagesCount)
+        public RouteInformation(string method, string path, bool noAuthorizationRequired, bool skipUsagesCount, bool isDebugInformationEndpoint = false)
         {
+            IsDebugInformationEndpoint = isDebugInformationEndpoint;
             Method = method;
             Path = path;
             NoAuthorizationRequired = noAuthorizationRequired;
             SkipUsagesCount = skipUsagesCount;
         }
+
+        public RouteType TypeOfRoute => _typeOfRoute;
 
         public void Build(MethodInfo action)
         {

--- a/src/Raven.Server/ServerWide/DebugInfo/DatabaseDebugInfoProvider.cs
+++ b/src/Raven.Server/ServerWide/DebugInfo/DatabaseDebugInfoProvider.cs
@@ -1,0 +1,31 @@
+﻿using System.Collections.Generic;
+using System.Linq;
+using System.Threading.Tasks;
+using Org.BouncyCastle.X509;
+using Raven.Client.Server;
+using Raven.Server.Documents;
+
+namespace Raven.Server.ServerWide.DebugInfo
+{
+    public class DatabaseDebugInfoProvider
+    {
+        private readonly DatabaseRecord _databaseRecord;
+        private readonly string _databaseName;
+
+        public DatabaseDebugInfoProvider(DocumentDatabase database)
+        {            
+            _databaseRecord = database.ServerStore.LoadDatabaseRecord(database.Name, out _);
+            _databaseName = database.Name;
+        }
+
+        public IEnumerable<IDebugInfoDataSource> GetDebugPackage()
+        {
+            foreach (var node in _databaseRecord.Topology.AllReplicationNodes())
+            {
+
+            }
+
+            return Enumerable.Empty<IDebugInfoDataSource>();
+        }       
+    }
+}

--- a/src/Raven.Server/ServerWide/DebugInfo/DatabaseEndpointDebugInfoDataSource.cs
+++ b/src/Raven.Server/ServerWide/DebugInfo/DatabaseEndpointDebugInfoDataSource.cs
@@ -1,0 +1,35 @@
+﻿using System;
+using System.Collections.Generic;
+using System.Text;
+using System.Threading.Tasks;
+using Raven.Client.Http;
+using Sparrow.Json;
+using Sparrow.Json.Parsing;
+
+namespace Raven.Server.ServerWide.DebugInfo
+{
+    public class DatabaseEndpointDebugInfoDataSource : IDebugInfoDataSource
+    {
+        private readonly string _databaseName;
+        private readonly string _url;
+        
+        public string FullPath { get; }
+
+        public DatabaseEndpointDebugInfoDataSource(string databaseName, string url, string fullPath)
+        {
+            _databaseName = databaseName;
+            _url = url;
+            FullPath = fullPath;
+        }
+
+        public async Task<BlittableJsonReaderObject> GetData(JsonOperationContext context)
+        {
+            await Task.Delay(100);
+            throw new NotImplementedException();
+        }
+
+        public void Dispose()
+        {            
+        }
+    }
+}

--- a/src/Raven.Server/ServerWide/DebugInfo/GetRawResponseCommand.cs
+++ b/src/Raven.Server/ServerWide/DebugInfo/GetRawResponseCommand.cs
@@ -1,0 +1,48 @@
+﻿using System;
+using System.Diagnostics;
+using System.Net.Http;
+using Raven.Client.Http;
+using Sparrow.Json;
+
+namespace Raven.Server.ServerWide.DebugInfo
+{
+    public class GetRawResponseCommand : RavenCommand<BlittableJsonReaderObject>
+    {
+        public override bool IsReadRequest => true;
+
+        private readonly string _method;
+        private readonly string _path;
+
+        public GetRawResponseCommand(string method, string path)
+        {
+            _method = method;
+            _path = path;
+        }
+
+        public override HttpRequestMessage CreateRequest(ServerNode node, out string url)
+        {
+            url = $"{node.Url}{_path}";
+
+            switch (_method.Trim().ToLowerInvariant())
+            {
+                case "get":
+                    return new HttpRequestMessage
+                    {
+                        Method = HttpMethod.Get,
+                    };
+                case "head":
+                    return new HttpRequestMessage
+                    {
+                        Method = HttpMethod.Head,
+                    };
+                default:
+                    throw new InvalidOperationException($"Expected to find either GET or HEAD debug endpoint, but found {_method}");
+            }
+        }
+
+        public override void SetResponse(BlittableJsonReaderObject response, bool fromCache)
+        {            
+            Result = response;
+        }
+    }
+}

--- a/src/Raven.Server/ServerWide/DebugInfo/IDebugInfoDataSource.cs
+++ b/src/Raven.Server/ServerWide/DebugInfo/IDebugInfoDataSource.cs
@@ -1,0 +1,13 @@
+﻿using System;
+using System.Threading.Tasks;
+using Sparrow.Json;
+using Sparrow.Json.Parsing;
+
+namespace Raven.Server.ServerWide.DebugInfo
+{
+    public interface IDebugInfoDataSource : IDisposable
+    {
+        string FullPath { get; }
+        Task<BlittableJsonReaderObject> GetData(JsonOperationContext context);
+    }
+}

--- a/src/Raven.Server/ServerWide/DebugInfo/ServerEndpointDebugInfoDataSource.cs
+++ b/src/Raven.Server/ServerWide/DebugInfo/ServerEndpointDebugInfoDataSource.cs
@@ -1,0 +1,54 @@
+﻿using System;
+using System.Collections.Generic;
+using System.Diagnostics;
+using System.Text;
+using System.Threading;
+using System.Threading.Tasks;
+using Raven.Client.Http;
+using Raven.Server.Routing;
+using Sparrow.Json;
+using Sparrow.Json.Parsing;
+
+namespace Raven.Server.ServerWide.DebugInfo
+{
+    public class ServerEndpointDebugInfoDataSource : IDebugInfoDataSource
+    {
+        private readonly RouteInformation _routeInformation;
+        private readonly RequestExecutor _requestExecutor;
+        private readonly CancellationToken _token;
+
+        public ServerEndpointDebugInfoDataSource(string url, RouteInformation routeInformation, CancellationToken token)
+        {
+            _requestExecutor = RequestExecutor.CreateForSingleNode(url, null, null);        
+            _routeInformation = routeInformation;
+            _token = token;
+        }
+
+        public string FullPath
+        {
+            get
+            {
+                var filename = _routeInformation.Path;
+                if (filename.StartsWith("debug/", StringComparison.OrdinalIgnoreCase))
+                    filename = filename.Replace("debug/", string.Empty);
+                if (filename.StartsWith("/debug/", StringComparison.OrdinalIgnoreCase))
+                    filename = filename.Replace("/debug/", string.Empty);
+                filename = filename.Replace("/", ".");
+
+                return $"Server-wide\\{filename}.json";
+            }
+        }
+
+        public async Task<BlittableJsonReaderObject> GetData(JsonOperationContext context)
+        {
+            var cmd = new GetRawResponseCommand(_routeInformation.Method, _routeInformation.Path);           
+            await _requestExecutor.ExecuteAsync(cmd, context, _token);
+            return cmd.Result;
+        }
+
+        public void Dispose()
+        {
+            _requestExecutor.Dispose();
+        }
+    }
+}


### PR DESCRIPTION
/debug/info-package WIP
 * minor refactoring for RouteScanner::Scan() so it accepts optional predicate for routes
* minor refactor -> modify output of /debug/threads/runaway so it outputs an object and not an array - so it can be reached by RequestExecuter (which currently expects to have blittable objects when parsing response results)
 * adding to RavenActionAttribute new property -> IsDebugInformationEndpoint. It will indicate which endpoints need to be included in debug-info package.
 * for now, endpoint will output zip file with output of server-wide debug endpoints

note: seen Raft timeouts in fast tests