### PR TITLE
RavenDB-7493 Avoid declaring readonly fields in classes for which we …

### DIFF
--- a/src/Raven.Client/Http/ClusterTopology.cs
+++ b/src/Raven.Client/Http/ClusterTopology.cs
@@ -136,11 +136,11 @@ namespace Raven.Client.Http
             }
         }
 
-        public readonly string LastNodeId;
-        public readonly string TopologyId;
-        public readonly string ApiKey;
-        public readonly Dictionary<string,string> Members;
-        public readonly Dictionary<string,string> Promotables;
-        public readonly Dictionary<string,string> Watchers;
+        public string LastNodeId { get; protected set; }
+        public string TopologyId { get; protected set; }
+        public string ApiKey { get; protected set; }
+        public Dictionary<string,string> Members { get; protected set; }
+        public Dictionary<string,string> Promotables { get; protected set; }
+        public Dictionary<string,string> Watchers { get; protected set; }
     }
 }

--- a/src/Raven.Server/Json/JsonDeserializationServer.cs
+++ b/src/Raven.Server/Json/JsonDeserializationServer.cs
@@ -13,7 +13,6 @@ using Raven.Client.Server.PeriodicBackup;
 using Raven.Client.Server.Tcp;
 using Raven.Client.Server.Versioning;
 using Raven.Server.Commercial;
-using Raven.Server.Documents.ETL;
 using Raven.Server.Documents.ETL.Providers.SQL.RelationalWriters;
 using Raven.Server.Documents.Indexes;
 using Raven.Server.Documents.PeriodicBackup;

--- a/src/Raven.Server/ServerWide/Commands/ETL/AddEtlCommand.cs
+++ b/src/Raven.Server/ServerWide/Commands/ETL/AddEtlCommand.cs
@@ -8,7 +8,7 @@ namespace Raven.Server.ServerWide.Commands.ETL
 {
     public abstract class AddEtlCommand<T> : UpdateDatabaseCommand where T : EtlDestination
     {
-        public readonly EtlConfiguration<T> Configuration;
+        public EtlConfiguration<T> Configuration { get; protected set; }
 
         protected AddEtlCommand() : base(null)
         {

--- a/src/Raven.Server/ServerWide/Commands/ETL/UpdateEtlCommand.cs
+++ b/src/Raven.Server/ServerWide/Commands/ETL/UpdateEtlCommand.cs
@@ -8,11 +8,11 @@ namespace Raven.Server.ServerWide.Commands.ETL
 {
     public abstract class UpdateEtlCommand<T> : UpdateDatabaseCommand where T : EtlDestination
     {
-        public readonly long TaskId;
+        public long TaskId { get; protected set; }
 
-        public readonly EtlConfiguration<T> Configuration;
+        public EtlConfiguration<T> Configuration { get; protected set; }
 
-        public readonly EtlType EtlType;
+        public EtlType EtlType { get; protected set; }
 
         protected UpdateEtlCommand() : base(null)
         {

--- a/src/Raven.Server/ServerWide/Commands/EditVersioningCommand.cs
+++ b/src/Raven.Server/ServerWide/Commands/EditVersioningCommand.cs
@@ -7,7 +7,7 @@ namespace Raven.Server.ServerWide.Commands
 {
     public class EditVersioningCommand : UpdateDatabaseCommand
     {
-        public readonly VersioningConfiguration Configuration;
+        public VersioningConfiguration Configuration { get; protected set; }
 
         public void UpdateDatabaseRecord(DatabaseRecord databaseRecord)
         {

--- a/src/Raven.Server/ServerWide/Maintenance/ClusterNodeStatusReport.cs
+++ b/src/Raven.Server/ServerWide/Maintenance/ClusterNodeStatusReport.cs
@@ -21,7 +21,7 @@ namespace Raven.Server.ServerWide.Maintenance
 
         public ChangeVectorEntry[] LastDocumentChangeVector;
 
-        public readonly Dictionary<string, ObservedIndexStatus> LastIndexStats = new Dictionary<string, ObservedIndexStatus>();
+        public Dictionary<string, ObservedIndexStatus> LastIndexStats = new Dictionary<string, ObservedIndexStatus>();
 
         public class ObservedIndexStatus
         {

--- a/src/Sparrow/Json/JsonDeserializationBase.cs
+++ b/src/Sparrow/Json/JsonDeserializationBase.cs
@@ -56,12 +56,18 @@ namespace Sparrow.Json
                 {
                     if (fieldInfo.IsStatic || fieldInfo.IsDefined(typeof(JsonIgnoreAttribute)))
                         continue;
+
+                    if (fieldInfo.IsPublic && fieldInfo.IsInitOnly)
+                        throw new InvalidOperationException($"Cannot create deserialization routine for '{type.FullName}' because '{fieldInfo.Name}' is readonly field");
+
                     propInit.Add(Expression.Bind(fieldInfo, GetValue(fieldInfo.Name, fieldInfo.FieldType, json, vars)));
                 }
+
                 foreach (var propertyInfo in typeof(T).GetProperties())
                 {
                     if (propertyInfo.CanWrite == false || propertyInfo.IsDefined(typeof(JsonIgnoreAttribute)))
                         continue;
+
                     propInit.Add(Expression.Bind(propertyInfo, GetValue(propertyInfo.Name, propertyInfo.PropertyType, json, vars)));
                 }
 

--- a/test/FastTests/Issues/RavenDB_7493.cs
+++ b/test/FastTests/Issues/RavenDB_7493.cs
@@ -1,0 +1,69 @@
+﻿using System;
+using System.Linq;
+using System.Reflection;
+using Raven.Client.Json.Converters;
+using Raven.Server.Json;
+using Raven.Server.ServerWide;
+using Raven.Server.Utils;
+using Sparrow.Json;
+using Sparrow.Json.Parsing;
+using Xunit;
+
+namespace FastTests.Issues
+{
+    public class RavenDB_7493 : NoDisposalNeeded
+    {
+        [Fact]
+        public void Ensure_deserialization_routines_are_properly_created()
+        {
+            using (var context = JsonOperationContext.ShortTermSingleUse())
+            {
+                var djv = new DynamicJsonValue();
+
+                var emptyBlittable = context.ReadObject(djv, "goo");
+
+                var ea = new ExceptionAggregator("Could not create deserialization routines");
+
+                foreach (var type in new []{ typeof(JsonDeserializationClient), typeof(JsonDeserializationCluster), typeof(JsonDeserializationServer) })
+                {
+                    foreach (var field in type.GetFields().Where(x => x.IsStatic))
+                    {
+                        var value = field.GetValue(null);
+
+                        var func = value as Func<BlittableJsonReaderObject, object>;
+
+                        if (func == null)
+                            continue;
+
+                        ea.Execute(() =>
+                        {
+                            try
+                            {
+                                func(emptyBlittable);
+                            }
+                            catch (Exception e) when (e.ToString().Contains("Failed to fetch property name")) // due to empty json we pass here, let's ignore it
+                            {
+                            }
+                        });
+                    }
+                }
+
+                foreach (var command in JsonDeserializationCluster.Commands.Values)
+                {
+                    ea.Execute(() =>
+                    {
+                        try
+                        {
+                            command(emptyBlittable);
+                        }
+                        catch (Exception e) when (e.ToString().Contains("Failed to fetch property name")) // due to empty json we pass here, let's ignore it
+                        {
+                        }
+                    });
+                }
+
+                ea.ThrowIfNeeded();
+            }
+        }
+    }
+}


### PR DESCRIPTION
…generate json deserialization routine since it results in throwing System.Security.VerificationException when running on .net 4.6 because such fields cannot be assigned (surprisingly it works seamlessly on .net core). Let us create protected setters instead of private once to avoid r# suggestions that it can be removed - then we skip such property during deserialization.