### PR TITLE
RavenDB-6934 Allow authentication token to be used across all nodes o…

### DIFF
--- a/src/Raven.Client/Http/ClusterTopology.cs
+++ b/src/Raven.Client/Http/ClusterTopology.cs
@@ -1,17 +1,19 @@
-﻿using System.Collections.Generic;
+﻿using System;
+using System.Collections.Generic;
 using Sparrow.Json.Parsing;
 
 namespace Raven.Client.Http
 {
     public class ClusterTopology
     {
-        public ClusterTopology(string topologyId, string apiKey, Dictionary<string, string> members, Dictionary<string, string> promotables, Dictionary<string, string> watchers, string lastNodeId)
+        public ClusterTopology(string topologyId, string apiKey, Dictionary<string, string> members, Dictionary<string, string> promotables, Dictionary<string, string> watchers, Dictionary<string, string> authPublicKeys, string lastNodeId)
         {
             TopologyId = topologyId;
             ApiKey = apiKey;
             Members = members;
             Promotables = promotables;
             Watchers = watchers;
+            AuthPublicKeys = authPublicKeys;
             LastNodeId = lastNodeId;
         }
 
@@ -61,6 +63,7 @@ namespace Raven.Client.Http
                 [nameof(Members)] = DynamicJsonValue.Convert(Members),
                 [nameof(Promotables)] = DynamicJsonValue.Convert(Promotables),
                 [nameof(Watchers)] = DynamicJsonValue.Convert(Watchers),
+                [nameof(AuthPublicKeys)] = DynamicJsonValue.Convert(AuthPublicKeys),
                 [nameof(LastNodeId)] = LastNodeId
             };
         }
@@ -80,6 +83,13 @@ namespace Raven.Client.Http
             {
                 return url;
             }
+            return null;
+        }
+
+        public byte[] GetPublicKeyFromTag(string tag)
+        {
+            if (AuthPublicKeys.TryGetValue(tag, out string key))
+                return Convert.FromBase64String(key);
             return null;
         }
 
@@ -142,5 +152,6 @@ namespace Raven.Client.Http
         public Dictionary<string,string> Members { get; protected set; }
         public Dictionary<string,string> Promotables { get; protected set; }
         public Dictionary<string,string> Watchers { get; protected set; }
+        public Dictionary<string,string> AuthPublicKeys  { get; protected set; }
     }
 }

--- a/src/Raven.Client/Http/RequestExecutor.cs
+++ b/src/Raven.Client/Http/RequestExecutor.cs
@@ -578,7 +578,7 @@ namespace Raven.Client.Http
 
         public async Task<string> GetAuthenticationToken(JsonOperationContext context, ServerNode node)
         {
-            return await _authenticator.GetAuthenticationTokenAsync(_apiKey, node.Url, context).ConfigureAwait(false);
+            return node.ClusterToken = await _authenticator.GetAuthenticationTokenAsync(_apiKey, node.Url, context).ConfigureAwait(false);          
         }
 
         private async Task HandleUnauthorized(ServerNode node, JsonOperationContext context, bool shouldThrow = true)

--- a/src/Raven.Client/Server/Commands/GetNodeInfoCommand.cs
+++ b/src/Raven.Client/Server/Commands/GetNodeInfoCommand.cs
@@ -9,6 +9,7 @@ namespace Raven.Client.Server.Commands
     {
         public string NodeTag;
         public string TopologyId;
+        public string AuthPublicKey;
     }
 
     class GetNodeInfoCommand : RavenCommand<NodeInfo>

--- a/src/Raven.Server/Documents/ConfigurationStorage.cs
+++ b/src/Raven.Server/Documents/ConfigurationStorage.cs
@@ -32,7 +32,7 @@ namespace Raven.Server.Documents
             options.ForceUsing32BitsPager = db.Configuration.Storage.ForceUsing32BitsPager;
             options.TimeToSyncAfterFlashInSeconds = db.Configuration.Storage.TimeToSyncAfterFlashInSeconds;
             options.NumOfConcurrentSyncsPerPhysDrive = db.Configuration.Storage.NumOfCocurrentSyncsPerPhysDrive;
-            Sodium.CopyMasterKey(out options.MasterKey, db.MasterKey);
+            Sodium.CloneKey(out options.MasterKey, db.MasterKey);
 
             Environment = new StorageEnvironment(options);
             

--- a/src/Raven.Server/Documents/DocumentsStorage.cs
+++ b/src/Raven.Server/Documents/DocumentsStorage.cs
@@ -219,7 +219,7 @@ namespace Raven.Server.Documents
             options.ForceUsing32BitsPager = _documentDatabase.Configuration.Storage.ForceUsing32BitsPager;
             options.TimeToSyncAfterFlashInSeconds = _documentDatabase.Configuration.Storage.TimeToSyncAfterFlashInSeconds;
             options.NumOfConcurrentSyncsPerPhysDrive = _documentDatabase.Configuration.Storage.NumOfCocurrentSyncsPerPhysDrive;
-            Sodium.CopyMasterKey(out options.MasterKey, _documentDatabase.MasterKey);
+            Sodium.CloneKey(out options.MasterKey, _documentDatabase.MasterKey);
 
             try
             {

--- a/src/Raven.Server/Documents/Handlers/Admin/RachisAdminHandler.cs
+++ b/src/Raven.Server/Documents/Handlers/Admin/RachisAdminHandler.cs
@@ -1,4 +1,5 @@
-﻿using System.Collections.Generic;
+﻿using System;
+using System.Collections.Generic;
 using System.Net;
 using System.Threading.Tasks;
 using Jint.Native;
@@ -67,6 +68,7 @@ namespace Raven.Server.Documents.Handlers.Admin
                 {
                     json[nameof(NodeInfo.NodeTag)] = ServerStore.NodeTag;
                     json[nameof(NodeInfo.TopologyId)] = ServerStore.GetClusterTopology(context).TopologyId;
+                    json[nameof(NodeInfo.AuthPublicKey)] = Convert.ToBase64String(ServerStore.AuthPublicKey);
                 }
                 context.Write(writer, json);
                 writer.Flush();
@@ -89,6 +91,7 @@ namespace Raven.Server.Documents.Handlers.Admin
                 {
                     var tag = ServerStore.NodeTag ?? "A";
                     var serverUrl = ServerStore.NodeHttpServerUrl;
+                    var authPublicKey = ServerStore.AuthPublicKey;
 
                     topology = new ClusterTopology(
                         "dummy",
@@ -99,6 +102,10 @@ namespace Raven.Server.Documents.Handlers.Admin
                         },
                         new Dictionary<string, string>(),
                         new Dictionary<string, string>(),
+                        new Dictionary<string, string>
+                        {
+                            [tag] = Convert.ToBase64String(authPublicKey)
+                        },
                         tag
                     );
                     nodeTag = tag;
@@ -196,7 +203,7 @@ namespace Raven.Server.Documents.Handlers.Admin
 
                         var nodeTag = nodeInfo.NodeTag == "?" 
                             ? null : nodeInfo.NodeTag;
-                        await ServerStore.AddNodeToClusterAsync(serverUrl, nodeTag, validateNotInTopology:false);
+                        await ServerStore.AddNodeToClusterAsync(serverUrl, Convert.FromBase64String(nodeInfo.AuthPublicKey), nodeTag, validateNotInTopology:false);
                         NoContentStatus();
                         return;
                     }

--- a/src/Raven.Server/Documents/Handlers/SecretKeyHandler.cs
+++ b/src/Raven.Server/Documents/Handlers/SecretKeyHandler.cs
@@ -182,7 +182,7 @@ namespace Raven.Server.Documents.Handlers
             {
                 using (var tx = ctx.OpenWriteTransaction())
                 {
-                    Server.ServerStore.PutSecretKey(ctx, name, key, false);
+                    Server.ServerStore.PutSecretKey(ctx, name, key);
                     tx.Commit();
                 }
             }

--- a/src/Raven.Server/Documents/Indexes/Index.cs
+++ b/src/Raven.Server/Documents/Indexes/Index.cs
@@ -193,7 +193,7 @@ namespace Raven.Server.Documents.Indexes
                 options.ForceUsing32BitsPager = documentDatabase.Configuration.Storage.ForceUsing32BitsPager;
                 options.TimeToSyncAfterFlashInSeconds = documentDatabase.Configuration.Storage.TimeToSyncAfterFlashInSeconds;
                 options.NumOfConcurrentSyncsPerPhysDrive = documentDatabase.Configuration.Storage.NumOfCocurrentSyncsPerPhysDrive;
-                Sodium.CopyMasterKey(out options.MasterKey, documentDatabase.MasterKey);
+                Sodium.CloneKey(out options.MasterKey, documentDatabase.MasterKey);
 
                 environment = new StorageEnvironment(options);
 
@@ -310,7 +310,7 @@ namespace Raven.Server.Documents.Indexes
                 options.ForceUsing32BitsPager = documentDatabase.Configuration.Storage.ForceUsing32BitsPager;
                 options.TimeToSyncAfterFlashInSeconds = documentDatabase.Configuration.Storage.TimeToSyncAfterFlashInSeconds;
                 options.NumOfConcurrentSyncsPerPhysDrive = documentDatabase.Configuration.Storage.NumOfCocurrentSyncsPerPhysDrive;
-                Sodium.CopyMasterKey(out options.MasterKey, documentDatabase.MasterKey);
+                Sodium.CloneKey(out options.MasterKey, documentDatabase.MasterKey);
 
                 try
                 {
@@ -2330,7 +2330,7 @@ namespace Raven.Server.Documents.Indexes
                     srcOptions.OnRecoveryError += DocumentDatabase.HandleOnRecoveryError;
                     srcOptions.TimeToSyncAfterFlashInSeconds = DocumentDatabase.Configuration.Storage.TimeToSyncAfterFlashInSeconds;
                     srcOptions.NumOfConcurrentSyncsPerPhysDrive = DocumentDatabase.Configuration.Storage.NumOfCocurrentSyncsPerPhysDrive;
-                    Sodium.CopyMasterKey(out srcOptions.MasterKey, DocumentDatabase.MasterKey);
+                    Sodium.CloneKey(out srcOptions.MasterKey, DocumentDatabase.MasterKey);
 
                     var wasRunning = _indexingThread != null;
 
@@ -2347,7 +2347,7 @@ namespace Raven.Server.Documents.Indexes
                         compactOptions.ForceUsing32BitsPager = DocumentDatabase.Configuration.Storage.ForceUsing32BitsPager;
                         compactOptions.TimeToSyncAfterFlashInSeconds = DocumentDatabase.Configuration.Storage.TimeToSyncAfterFlashInSeconds;
                         compactOptions.NumOfConcurrentSyncsPerPhysDrive = DocumentDatabase.Configuration.Storage.NumOfCocurrentSyncsPerPhysDrive;
-                        Sodium.CopyMasterKey(out srcOptions.MasterKey, DocumentDatabase.MasterKey);
+                        Sodium.CloneKey(out srcOptions.MasterKey, DocumentDatabase.MasterKey);
 
                         StorageCompaction.Execute(srcOptions, compactOptions, progressReport =>
                         {

--- a/src/Raven.Server/Web/Authentication/AccessToken.cs
+++ b/src/Raven.Server/Web/Authentication/AccessToken.cs
@@ -1,26 +1,18 @@
+using System;
 using System.Collections.Generic;
-using System.Diagnostics;
 using Raven.Client.Server.Operations.ApiKeys;
 
 namespace Raven.Server.Web.Authentication
 {
     public class AccessToken
     {
-        public string Token { get; set; }
         public string Name { get; set; }
+        public string NodeTag { get; set; }
+        public string Token { get; set; }
+        public DateTime Expires { get; set; }
+
         public Dictionary<string, AccessModes> AuthorizedDatabases { get; set; }
-        public long Issued { get; set; }
-        public bool IsServerAdminAuthorized { get; set; }
 
-        public static readonly long MaxAge = Stopwatch.Frequency * 60 * 30;// 30 minutes
-
-        public bool IsExpired
-        {
-            get
-            {
-                var ticks = Stopwatch.GetTimestamp() - Issued;
-                return ticks > MaxAge;
-            }
-        }
+        public bool IsExpired => Expires.CompareTo(DateTime.UtcNow) <= 0;
     }
 }

--- a/src/Raven.Server/Web/Authentication/AdminApiKeysHandler.cs
+++ b/src/Raven.Server/Web/Authentication/AdminApiKeysHandler.cs
@@ -38,11 +38,7 @@ namespace Raven.Server.Web.Authentication
                 var apiKey = JsonDeserializationServer.ApiKeyDefinition(apiKeyJson);
                 await ServerStore.PutValueInClusterAsync(new PutApiKeyCommand(Constants.ApiKeys.Prefix + name, apiKey));
 
-                AccessToken value;
-                if (Server.AccessTokensByName.TryRemove(name, out value))
-                {
-                    Server.AccessTokensById.TryRemove(value.Token, out value);
-                }
+                Server.AccessTokenCache.Clear();
 
                 HttpContext.Response.StatusCode = (int)HttpStatusCode.Created;
             }
@@ -58,11 +54,7 @@ namespace Raven.Server.Web.Authentication
             {
                 await ServerStore.DeleteValueInClusterAsync(Constants.ApiKeys.Prefix + name);
 
-                AccessToken value;
-                if (Server.AccessTokensByName.TryRemove(name, out value))
-                {
-                    Server.AccessTokensById.TryRemove(value.Token, out value);
-                }
+                Server.AccessTokenCache.Clear();
 
                 HttpContext.Response.StatusCode = (int)HttpStatusCode.NoContent;
             }

--- a/src/Sparrow/Json/JsonOperationContext.cs
+++ b/src/Sparrow/Json/JsonOperationContext.cs
@@ -579,6 +579,31 @@ namespace Sparrow.Json
             }
         }
 
+        public unsafe BlittableJsonReaderObject ParseBuffer(byte* buffer, int length, string debugTag,
+            BlittableJsonDocumentBuilder.UsageMode mode, IBlittableDocumentModifier modifier = null)
+        {
+
+            if (_disposed)
+                ThrowObjectDisposed();
+
+            _jsonParserState.Reset();
+            using (var parser = new UnmanagedJsonParser(this, _jsonParserState, debugTag))
+            using (var builder = new BlittableJsonDocumentBuilder(this, mode, debugTag, parser, _jsonParserState, modifier: modifier))
+            {
+                CachedProperties.NewDocument();
+                builder.ReadObjectDocument();
+                parser.SetBuffer(buffer, length);
+
+                if (builder.Read() == false)
+                    throw new EndOfStreamException("Buffer ended without reaching end of json content");
+
+                builder.FinalizeDocument();
+
+                var reader = builder.CreateReader();
+                return reader;
+            }
+        }
+
         public async Task<BlittableJsonReaderObject> ParseToMemoryAsync(WebSocket webSocket, string debugTag,
            BlittableJsonDocumentBuilder.UsageMode mode,
            ManagedPinnedBuffer bytes,

--- a/src/Sparrow/Platform/Posix/PosixSodium.cs
+++ b/src/Sparrow/Platform/Posix/PosixSodium.cs
@@ -251,5 +251,34 @@ namespace Sparrow.Platform.Posix
             byte* n,
             byte* pk,
             byte* sk);
+
+        [DllImport(LIB_SODIUM)]
+        public static extern int crypto_sign_detached(
+            byte* sig,
+            ulong* siglen,
+            byte* m,
+            ulong mlen,
+            byte* sk);
+
+        [DllImport(LIB_SODIUM)]
+        public static extern int crypto_sign_verify_detached(
+            byte* sig,
+            byte* m,
+            ulong mlen,
+            byte* pk);
+
+        [DllImport(LIB_SODIUM)]
+        public static extern UIntPtr crypto_sign_publickeybytes();
+
+        [DllImport(LIB_SODIUM)]
+        public static extern UIntPtr crypto_sign_secretkeybytes();
+
+        [DllImport(LIB_SODIUM)]
+        public static extern UIntPtr crypto_sign_bytes();
+
+        [DllImport(LIB_SODIUM)]
+        public static extern int crypto_sign_keypair(
+            byte* pk,
+            byte* sk);
     }
 }

--- a/src/Sparrow/Platform/Win32/WinSodium.cs
+++ b/src/Sparrow/Platform/Win32/WinSodium.cs
@@ -247,6 +247,35 @@ namespace Sparrow.Platform.Win32
             byte* sk);
 
         [DllImport(LIB_SODIUM)]
+        public static extern int crypto_sign_detached(
+            byte* sig,
+            ulong* siglen,
+            byte* m,
+            ulong mlen,
+            byte* sk);
+
+        [DllImport(LIB_SODIUM)]
+        public static extern int crypto_sign_verify_detached(
+            byte* sig,
+            byte* m,
+            ulong mlen,
+            byte* pk);
+
+        [DllImport(LIB_SODIUM)]
+        public static extern UIntPtr crypto_sign_publickeybytes();
+
+        [DllImport(LIB_SODIUM)]
+        public static extern UIntPtr crypto_sign_secretkeybytes();
+
+        [DllImport(LIB_SODIUM)]
+        public static extern UIntPtr crypto_sign_bytes();
+        
+        [DllImport(LIB_SODIUM)]
+        public static extern int crypto_sign_keypair(
+            byte* pk,
+            byte* sk);
+
+        [DllImport(LIB_SODIUM)]
         public static extern void sodium_memzero(
             byte* pnt,
             UIntPtr len);

--- a/src/Sparrow/Sodium.cs
+++ b/src/Sparrow/Sodium.cs
@@ -275,14 +275,11 @@ namespace Sparrow
             return buffer;
         }
 
-        public static void crypto_box_keypair(byte* pk, byte* sk)
+        public static int crypto_box_keypair(byte* pk, byte* sk)
         {
-            if (Platform.PlatformDetails.RunningOnPosix)
-            {
-                Platform.Posix.PosixSodium.crypto_box_keypair(pk, sk);
-                return;
-            }
-            Platform.Win32.WinSodium.crypto_box_keypair(pk, sk);
+            return Platform.PlatformDetails.RunningOnPosix 
+                ? Platform.Posix.PosixSodium.crypto_box_keypair(pk, sk) 
+                : Platform.Win32.WinSodium.crypto_box_keypair(pk, sk);
         }
 
         public static int crypto_generichash(byte* @out, UIntPtr outlen, byte* @in,
@@ -373,6 +370,57 @@ namespace Sparrow
                 : Platform.Win32.WinSodium.crypto_box_open_easy(m, c, clen, n, pk, sk);
         }
 
+        public static int crypto_sign_detached(
+            byte* sig,
+            ulong* siglen,
+            byte* m,
+            ulong mlen,
+            byte* sk)
+        {
+            return Platform.PlatformDetails.RunningOnPosix
+                ? Platform.Posix.PosixSodium.crypto_sign_detached(sig, siglen, m, mlen, sk)
+                : Platform.Win32.WinSodium.crypto_sign_detached(sig, siglen, m, mlen, sk);
+        }
+
+        public static int crypto_sign_verify_detached(
+            byte* sig,
+            byte* m,
+            ulong mlen,
+            byte* pk)
+        {
+            return Platform.PlatformDetails.RunningOnPosix
+                ? Platform.Posix.PosixSodium.crypto_sign_verify_detached(sig, m, mlen, pk)
+                : Platform.Win32.WinSodium.crypto_sign_verify_detached(sig, m, mlen, pk);
+        }
+
+        public static int crypto_sign_bytes()
+        {
+            return (int)(Platform.PlatformDetails.RunningOnPosix
+                ? Platform.Posix.PosixSodium.crypto_sign_bytes()
+                : Platform.Win32.WinSodium.crypto_sign_bytes());
+        }
+
+        public static int crypto_sign_keypair(byte* pk, byte* sk)
+        {
+            return Platform.PlatformDetails.RunningOnPosix 
+                ? Platform.Posix.PosixSodium.crypto_sign_keypair(pk, sk) 
+                : Platform.Win32.WinSodium.crypto_sign_keypair(pk, sk);
+        }
+
+        public static int crypto_sign_publickeybytes()
+        {
+            return (int)(Platform.PlatformDetails.RunningOnPosix
+                ? Platform.Posix.PosixSodium.crypto_sign_publickeybytes()
+                : Platform.Win32.WinSodium.crypto_sign_publickeybytes());
+        }
+
+        public static int crypto_sign_secretkeybytes()
+        {
+            return (int)(Platform.PlatformDetails.RunningOnPosix
+                ? Platform.Posix.PosixSodium.crypto_sign_secretkeybytes()
+                : Platform.Win32.WinSodium.crypto_sign_secretkeybytes());
+        }
+
         public static void ZeroMemory(byte* ptr, long size)
         {
             if (Platform.PlatformDetails.RunningOnPosix)
@@ -393,7 +441,7 @@ namespace Sparrow
             }
         }
 
-        public static void CopyMasterKey(out byte[] dst, byte[] src)
+        public static void CloneKey(out byte[] dst, byte[] src)
         {
             if (src == null)
             {

--- a/src/Sparrow/Utils/Base64.cs
+++ b/src/Sparrow/Utils/Base64.cs
@@ -1,0 +1,82 @@
+﻿using System;
+
+namespace Sparrow.Utils
+{
+    public class Base64
+    {
+        // This code was taken from: https://github.com/dotnet/coreclr/blob/master/src/mscorlib/shared/System/Convert.cs
+
+
+        internal static readonly char[] base64Table =
+        {
+            'A', 'B', 'C', 'D', 'E', 'F', 'G', 'H', 'I', 'J', 'K', 'L', 'M', 'N', 'O',
+            'P', 'Q', 'R', 'S', 'T', 'U', 'V', 'W', 'X', 'Y', 'Z', 'a', 'b', 'c', 'd',
+            'e', 'f', 'g', 'h', 'i', 'j', 'k', 'l', 'm', 'n', 'o', 'p', 'q', 'r', 's',
+            't', 'u', 'v', 'w', 'x', 'y', 'z', '0', '1', '2', '3', '4', '5', '6', '7',
+            '8', '9', '+', '/', '='
+        };
+
+
+        public static int CalculateAndValidateOutputLength(int inputLength)
+        {
+            long outlen = ((long)inputLength) / 3 * 4;          // the base length - we want integer division here. 
+            outlen += ((inputLength % 3) != 0) ? 4 : 0;         // at most 4 more chars for the remainder
+
+            if (outlen == 0)
+                return 0;
+
+            // If we overflow an int then we cannot allocate enough
+            // memory to output the value so throw
+            if (outlen > int.MaxValue)
+                throw new OutOfMemoryException();
+
+            return (int)outlen;
+        }
+
+        public static unsafe int ConvertToBase64Array(byte* outChars, byte* inData, int offset, int length)
+        {
+            int lengthmod3 = length % 3;
+            int calcLength = offset + (length - lengthmod3);
+            int j = 0;
+            int charcount = 0;
+            //Convert three bytes at a time to base64 notation.  This will consume 4 chars.
+            int i;
+
+            // get a pointer to the base64Table to avoid unnecessary range checking
+            fixed (char* base64 = &base64Table[0])
+            {
+                for (i = offset; i < calcLength; i += 3)
+                {
+                    outChars[j] = (byte)base64[(inData[i] & 0xfc) >> 2];
+                    outChars[j + 1] = (byte)base64[((inData[i] & 0x03) << 4) | ((inData[i + 1] & 0xf0) >> 4)];
+                    outChars[j + 2] = (byte)base64[((inData[i + 1] & 0x0f) << 2) | ((inData[i + 2] & 0xc0) >> 6)];
+                    outChars[j + 3] = (byte)base64[(inData[i + 2] & 0x3f)];
+                    j += 4;
+                }
+
+                //Where we left off before
+                i = calcLength;
+
+                switch (lengthmod3)
+                {
+                    case 2: //One character padding needed
+                        outChars[j] = (byte)base64[(inData[i] & 0xfc) >> 2];
+                        outChars[j + 1] = (byte)base64[((inData[i] & 0x03) << 4) | ((inData[i + 1] & 0xf0) >> 4)];
+                        outChars[j + 2] = (byte)base64[(inData[i + 1] & 0x0f) << 2];
+                        outChars[j + 3] = (byte)base64[64]; //Pad
+                        j += 4;
+                        break;
+                    case 1: // Two character padding needed
+                        outChars[j] = (byte)base64[(inData[i] & 0xfc) >> 2];
+                        outChars[j + 1] = (byte)base64[(inData[i] & 0x03) << 4];
+                        outChars[j + 2] = (byte)base64[64]; //Pad
+                        outChars[j + 3] = (byte)base64[64]; //Pad
+                        j += 4;
+                        break;
+                }
+            }
+
+            return j;
+        }
+    }
+}

--- a/test/RachisTests/AddNodeToClusterTests.cs
+++ b/test/RachisTests/AddNodeToClusterTests.cs
@@ -24,7 +24,8 @@ namespace RachisTests
             var raft2 = await CreateRaftClusterAndGetLeader(1);
             
             var url = raft2.WebUrls[0];
-            await raft1.ServerStore.AddNodeToClusterAsync(url);
+            var publicKey = raft2.ServerStore.AuthPublicKey;
+            await raft1.ServerStore.AddNodeToClusterAsync(url, publicKey);
             Assert.True(await WaitForValueAsync(() => raft1.ServerStore.GetClusterErrors().Count > 0,true));
         }
 
@@ -133,7 +134,7 @@ namespace RachisTests
 
             // rejoin the node
             var newLeader = Servers.Single(s => s.ServerStore.IsLeader());
-            Assert.True(await newLeader.ServerStore.AddNodeToClusterAsync(responsibleServer.WebUrls[0], watcherRes.ResponsibleNode).WaitAsync(fromSeconds));
+            Assert.True(await newLeader.ServerStore.AddNodeToClusterAsync(responsibleServer.WebUrls[0], responsibleServer.ServerStore.AuthPublicKey, watcherRes.ResponsibleNode).WaitAsync(fromSeconds));
             Assert.True(await responsibleServer.ServerStore.WaitForState(RachisConsensus.State.Follower).WaitAsync(fromSeconds));
 
             using (var session = responsibleStore.OpenSession())

--- a/test/RachisTests/BasicCluster.cs
+++ b/test/RachisTests/BasicCluster.cs
@@ -26,7 +26,7 @@ namespace RachisTests
 
             foreach (var follower in followers)
             {
-                await a.AddToClusterAsync(follower.Url);
+                await a.AddToClusterAsync(follower.Url, DummyPublicKey);
                 await follower.WaitForTopology(Leader.TopologyModification.Voter);
             }
 
@@ -99,9 +99,9 @@ namespace RachisTests
             var bUpgraded = b.WaitForTopology(Leader.TopologyModification.Voter);
             var cUpgraded = c.WaitForTopology(Leader.TopologyModification.Voter);
 
-            await a.AddToClusterAsync(b.Url);
+            await a.AddToClusterAsync(b.Url, DummyPublicKey);
             await b.WaitForTopology(Leader.TopologyModification.Voter);
-            await a.AddToClusterAsync(c.Url);
+            await a.AddToClusterAsync(c.Url, DummyPublicKey);
             await c.WaitForTopology(Leader.TopologyModification.Voter);
 
             await bUpgraded;
@@ -141,7 +141,7 @@ namespace RachisTests
 
             var b = SetupServer();
 
-            await a.AddToClusterAsync(b.Url);
+            await a.AddToClusterAsync(b.Url, DummyPublicKey);
             await b.WaitForTopology(Leader.TopologyModification.Voter);
             long lastIndex = 0;
             using (var ctx = JsonOperationContext.ShortTermSingleUse())
@@ -169,7 +169,7 @@ namespace RachisTests
             var a = SetupServer(true);
             var b = SetupServer();
 
-            await a.AddToClusterAsync(b.Url);
+            await a.AddToClusterAsync(b.Url, DummyPublicKey);
             await b.WaitForTopology(Leader.TopologyModification.Voter);
 
             using (var ctx = JsonOperationContext.ShortTermSingleUse())

--- a/test/Tests.Infrastructure/ClusterTestBase.cs
+++ b/test/Tests.Infrastructure/ClusterTestBase.cs
@@ -336,11 +336,13 @@ namespace Tests.Infrastructure
             RavenServer leader = null;
             var numberOfNodes = servers.Length;
             var serversToPorts = new Dictionary<RavenServer, string>();
+            var serversToPublicKeys = new Dictionary<RavenServer, byte[]>();
             var leaderIndex = _random.Next(0, numberOfNodes);
             for (var i = 0; i < numberOfNodes; i++)
             {
                 var server = servers[i];
                 serversToPorts.Add(server, server.WebUrls[0]);
+                serversToPublicKeys.Add(server, server.ServerStore.AuthPublicKey);
                 if (i == leaderIndex)
                 {
                     server.ServerStore.EnsureNotPassive();
@@ -357,7 +359,7 @@ namespace Tests.Infrastructure
                 }
                 var follower = Servers[i];
                 // ReSharper disable once PossibleNullReferenceException
-                await leader.ServerStore.AddNodeToClusterAsync(serversToPorts[follower]);
+                await leader.ServerStore.AddNodeToClusterAsync(serversToPorts[follower], serversToPublicKeys[follower]);
                 await follower.ServerStore.WaitForTopology(Leader.TopologyModification.Voter);
             }
             // ReSharper disable once PossibleNullReferenceException
@@ -371,6 +373,7 @@ namespace Tests.Infrastructure
             leaderIndex = leaderIndex ?? _random.Next(0, numberOfNodes);
             RavenServer leader = null;
             var serversToPorts = new Dictionary<RavenServer, string>();
+            var serversToPublicKeys = new Dictionary<RavenServer, byte[]>();
             for (var i = 0; i < numberOfNodes; i++)
             {
                 var serverUrl = UseFiddler($"http://127.0.0.1:{GetPort()}");
@@ -390,6 +393,7 @@ namespace Tests.Infrastructure
                 Servers.Add(server);
 
                 serversToPorts.Add(server, serverUrl);
+                serversToPublicKeys.Add(server, server.ServerStore.AuthPublicKey);
                 if (i == leaderIndex)
                 {
                     server.ServerStore.EnsureNotPassive();
@@ -404,7 +408,7 @@ namespace Tests.Infrastructure
                 }
                 var follower = Servers[i];
                 // ReSharper disable once PossibleNullReferenceException
-                await leader.ServerStore.AddNodeToClusterAsync(serversToPorts[follower]);
+                await leader.ServerStore.AddNodeToClusterAsync(serversToPorts[follower], serversToPublicKeys[follower]);
                 await follower.ServerStore.WaitForTopology(Leader.TopologyModification.Voter);
             }
             // ReSharper disable once PossibleNullReferenceException


### PR DESCRIPTION
…f a cluster

- Each server has it's own signature key pair and can sign access tokens.
- Signed access tokens are also accepted by other members of the cluster.
- ClusterTopology contains dictionary of public keys by node tag.
- Nodes can verify that a token was signed by a member of the cluster by verifying a token's signature with the public key from the topology.
- Server holds cache of active access tokens.