### PR TITLE
RavenDB-7466

### DIFF
--- a/src/Raven.Server/RavenServer.cs
+++ b/src/Raven.Server/RavenServer.cs
@@ -563,7 +563,8 @@ namespace Raven.Server
         {
             using (var writer = new BlittableJsonTextWriter(context, stream))
             {
-                if (configuration.Server.AnonymousUserAccessMode == AnonymousUserAccessModeValues.Admin)
+                if (configuration.Server.AnonymousUserAccessMode == AnonymousUserAccessModeValues.Admin
+                    && header.AuthorizationToken == null)
                 {
                     ReplyStatus(writer, nameof(TcpConnectionHeaderResponse.AuthorizationStatus.Success));
                     return true;
@@ -577,7 +578,7 @@ namespace Raven.Server
                 }
 
                 AccessToken accessToken;
-                if (!RequestRouter.TryGetAccessToken(this, header.AuthorizationToken, sigBase64Size, out accessToken))
+                if (RequestRouter.TryGetAccessToken(this, header.AuthorizationToken, sigBase64Size, out accessToken) == false)
                 {
                     if (accessToken.IsExpired)
                     {

--- a/src/Raven.Server/Routing/RequestRouter.cs
+++ b/src/Raven.Server/Routing/RequestRouter.cs
@@ -131,10 +131,7 @@ namespace Raven.Server.Routing
 
         private unsafe bool TryAuthorize(HttpContext context, RavenConfiguration configuration,
             DocumentDatabase database)
-        {
-            if (configuration.Server.AnonymousUserAccessMode == AnonymousUserAccessModeValues.Admin)
-                return true;
-
+        {            
             var authHeaderValues = context.Request.Headers["Raven-Authorization"];
             var token = authHeaderValues.Count == 0 ? null : authHeaderValues[0];
 
@@ -142,7 +139,9 @@ namespace Raven.Server.Routing
             {
                 token = context.Request.Cookies["Raven-Authorization"];
             }
-
+            if (configuration.Server.AnonymousUserAccessMode == AnonymousUserAccessModeValues.Admin
+                && token == null)
+                return true;
             var sigBase64Size = Sparrow.Utils.Base64.CalculateAndValidateOutputLength(Sodium.crypto_sign_bytes());
             if (token == null || token.Length < sigBase64Size + 8 /* sig length + prefix */)
             {


### PR DESCRIPTION
Making sure we don't authorize AnonymousUserAccessModeValues.Admin when accessed with authorization token
Waiting for raft index notification when inserting and deleting api keys (because they might not be created locally after we create them and the client might try to use them and fail)