### PR TITLE
RavenDB-7459

### DIFF
--- a/src/Raven.Server/Documents/Handlers/Admin/RachisAdminHandler.cs
+++ b/src/Raven.Server/Documents/Handlers/Admin/RachisAdminHandler.cs
@@ -226,13 +226,6 @@ namespace Raven.Server.Documents.Handlers.Admin
             RedirectToLeader();
         }
 
-        [RavenAction("/admin/cluster/secede", "GET", "/admin/cluster/secede")]
-        public Task SecedeFromCluster()
-        {
-            ServerStore.SecedeFromCluster();
-            return Task.CompletedTask;
-        }
-
         [RavenAction("/admin/cluster/reelect", "POST", "/admin/cluster/reelect")]
         public Task EnforceReelection()
         {

--- a/src/Raven.Server/Documents/Patch/AdminJsConsole.cs
+++ b/src/Raven.Server/Documents/Patch/AdminJsConsole.cs
@@ -47,9 +47,6 @@ namespace Raven.Server.Documents.Patch
         {
             var jintEngine = GetEngine(script, ServerExeceutionStr);
 
-            jintEngine.Global.Delete("SecedeFromCluster", false);
-            jintEngine.SetValue("SecedeFromCluster", (Action)(() => _server.ServerStore.SecedeFromCluster()));
-
             var jsVal = jintEngine.Invoke("ExecuteAdminScript", _server);
 
             return ConvertResultsToJson(jsVal);

--- a/src/Raven.Server/Rachis/RachisConsensus.cs
+++ b/src/Raven.Server/Rachis/RachisConsensus.cs
@@ -1268,7 +1268,7 @@ namespace Raven.Server.Rachis
 
         public abstract Task<Stream> ConnectToPeer(string url, string apiKey, TransactionOperationContext context = null);
 
-        public void Bootstrap(string selfUrl, byte[] publicKey)
+        public void Bootstrap(string selfUrl, byte[] publicKey, bool forNewCluster = false)
         {
             if (selfUrl == null)
                 throw new ArgumentNullException(nameof(selfUrl));
@@ -1278,10 +1278,13 @@ namespace Raven.Server.Rachis
             using (ContextPool.AllocateOperationContext(out TransactionOperationContext ctx))
             using (var tx = ctx.OpenWriteTransaction())
             {
-                if (CurrentState != State.Passive)
+                if (CurrentState != State.Passive && forNewCluster == false)
                     return;
 
-                UpdateNodeTag(ctx, "A");
+                if (forNewCluster == false)
+                {
+                    UpdateNodeTag(ctx, "A");
+                }
 
                 var topology = new ClusterTopology(
                     Guid.NewGuid().ToString(),

--- a/src/Raven.Server/ServerWide/ServerStore.cs
+++ b/src/Raven.Server/ServerWide/ServerStore.cs
@@ -947,7 +947,7 @@ namespace Raven.Server.ServerWide
             {
                 GenerateAuthenticationKeyPairs(ctx);
             }
-            Engine.Bootstrap(NodeHttpServerUrl, SignPublicKey);
+            Engine.Bootstrap(NodeHttpServerUrl, SignPublicKey, forNewCluster:true);
         }
 
         public Task<(long Etag, object Result)> WriteDatabaseRecordAsync(

--- a/test/RachisTests/EmergencyOperations.cs
+++ b/test/RachisTests/EmergencyOperations.cs
@@ -1,0 +1,73 @@
+﻿using System;
+using System.Collections.Generic;
+using System.Linq;
+using System.Text;
+using System.Threading;
+using System.Threading.Tasks;
+using Lucene.Net.Support;
+using Raven.Client.Http;
+using Raven.Server;
+using Raven.Server.Documents.Patch;
+using Raven.Server.Rachis;
+using Raven.Server.ServerWide.Context;
+using Tests.Infrastructure;
+using Xunit;
+
+namespace RachisTests
+{
+    public class EmergencyOperations : ClusterTestBase
+    {
+        [Fact]
+        public async Task LeaderCanCecedeFromClusterAndNewLeaderWillBeElected()
+        {
+            var clusterSize = 3;
+            var leader = await CreateRaftClusterAndGetLeader(clusterSize);
+            ClusterTopology old, @new;
+            old = GetServerTopology(leader);
+            new AdminJsConsole(leader).ApplyServerScript(new AdminJsScript
+            {
+                Script = @"server.ServerStore.SecedeFromCluster();"
+            });
+            await leader.ServerStore.WaitForState(RachisConsensus.State.Leader);
+            @new = GetServerTopology(leader);
+            Assert.NotEqual(old.TopologyId,@new.TopologyId);
+            List<Task<RavenServer>> leaderSelectedTasks = new List<Task<RavenServer>>();
+            foreach (var server in Servers)
+            {
+                if(server == leader)
+                    continue;
+                leaderSelectedTasks.Add(server.ServerStore.WaitForState(RachisConsensus.State.Leader).ContinueWith(_=>server));
+            }
+            Assert.True(await Task.WhenAny(leaderSelectedTasks).WaitAsync(TimeSpan.FromSeconds(2)),"New leader was not elected after old leader left the cluster.");            
+        }
+
+        [Fact]
+        public async Task FollowerCanCecedeFromCluster()
+        {
+            var clusterSize = 3;
+            await CreateRaftClusterAndGetLeader(clusterSize);
+            var follower = Servers.First(x => x.ServerStore.CurrentState == RachisConsensus.State.Follower);
+            ClusterTopology old, @new;
+            old = GetServerTopology(follower);
+            new AdminJsConsole(follower).ApplyServerScript(new AdminJsScript
+            {
+                Script = @"server.ServerStore.SecedeFromCluster();"
+            });
+            await follower.ServerStore.WaitForState(RachisConsensus.State.Leader);
+            @new = GetServerTopology(follower);
+            Assert.NotEqual(old.TopologyId, @new.TopologyId);            
+        }
+
+        private static ClusterTopology GetServerTopology(RavenServer leader)
+        {
+            ClusterTopology old;
+            using (leader.ServerStore.ContextPool.AllocateOperationContext(out TransactionOperationContext ctx))
+            using(ctx.OpenReadTransaction())
+            {
+                old = leader.ServerStore.GetClusterTopology(ctx);
+            }
+
+            return old;
+        }
+    }
+}


### PR DESCRIPTION
Removed secede from cluster endpoint
Removed SecedeFromCluster jint method
Added a flag for bootstrap to bootstrap a node that already is a part of a topology (leaving his Tag the same as it was and ignoring not passive state)