### PR TITLE
RavenDB-7496

### DIFF
--- a/test/FastTests/Issues/RavenDB-6250.cs
+++ b/test/FastTests/Issues/RavenDB-6250.cs
@@ -7,13 +7,12 @@
 using System;
 using System.Collections.Generic;
 using System.Linq;
-using FastTests;
 using Raven.Client.Extensions;
 using Raven.Server.Documents.Operations;
 using Raven.Server.NotificationCenter.Notifications;
 using Xunit;
 
-namespace SlowTests.Issues
+namespace FastTests.Issues
 {
 
     /**
@@ -48,7 +47,7 @@ namespace SlowTests.Issues
 
             var list = allKnownTypes.Except(unionSet.Select(x => x.ToString())).ToList();
 
-            Assert.True(list.Count == 0, "Probably unhandled details for operations: " + string.Join(", ", list) + 
+            Assert.True(list.Count == 0, "Probably unhandled details for operations: " + string.Join(", ", list) +
                 ". If those was already handled in notification center please add given type to 'alreadyHandledInStudio' set. " +
                                          "If operation doesn't provide details, please add this to 'operationWithoutDetails' set.");
         }

--- a/test/FastTests/Server/Documents/Versioning/VersioningReplication.cs
+++ b/test/FastTests/Server/Documents/Versioning/VersioningReplication.cs
@@ -240,7 +240,7 @@ namespace FastTests.Server.Documents.Versioning
             }
         }
 
-        [Fact(Skip = "RavenDB-7543")]
+        [Theory(Skip = "RavenDB-7543")]
         public async Task ReplicateExpiredAndDeletedRevisions(bool useSession)
         {
             // TODO

--- a/test/SlowTests/MailingList/IdComesBackLowerCase.cs
+++ b/test/SlowTests/MailingList/IdComesBackLowerCase.cs
@@ -11,13 +11,9 @@ namespace SlowTests.MailingList
 {
     public class IdComesBackLowerCase : RavenTestBase
     {
-        private readonly IDocumentStore _store;
-
-        public IdComesBackLowerCase()
+        private static void CreateData(IDocumentStore store)
         {
-            _store = GetDocumentStore();
-
-            new Product_AvailableForSale3().Execute(_store);
+            new Product_AvailableForSale3().Execute(store);
 
             var product1 = new Product("MyName1", "MyBrand1");
             product1.Id = "Products/100";
@@ -27,7 +23,7 @@ namespace SlowTests.MailingList
 
             var facetSetup = new FacetSetup { Id = "facets/ProductFacets", Facets = new List<Facet> { new Facet { Name = "Brand" } } };
 
-            using (var docSession = _store.OpenSession())
+            using (var docSession = store.OpenSession())
             {
                 foreach (var productDoc in docSession.Query<Product>().Customize(x => x.WaitForNonStaleResults()))
                 {
@@ -41,7 +37,7 @@ namespace SlowTests.MailingList
                 docSession.SaveChanges();
             }
 
-            using (var session = _store.OpenSession())
+            using (var session = store.OpenSession())
             {
                 var check = session.Query<Product>().ToList();
                 Assert.Equal(check.Count, 2);
@@ -51,29 +47,39 @@ namespace SlowTests.MailingList
         [Fact]
         public void ShouldReturnMatchingProductWithGivenIdWhenSelectingAllFields()
         {
-            using (var session = _store.OpenSession())
+            using (var store = GetDocumentStore())
             {
-                var products = session.Advanced.DocumentQuery<Product, Product_AvailableForSale3>()
-                    .WaitForNonStaleResults()
-                    .SelectFields<Product>()
-                    .UsingDefaultField("Any")
-                    .Where("MyName1").ToList();
+                CreateData(store);
 
-                Assert.Equal("Products/100", products.First().Id);
+                using (var session = store.OpenSession())
+                {
+                    var products = session.Advanced.DocumentQuery<Product, Product_AvailableForSale3>()
+                        .WaitForNonStaleResults()
+                        .SelectFields<Product>()
+                        .UsingDefaultField("Any")
+                        .Where("MyName1").ToList();
+
+                    Assert.Equal("Products/100", products.First().Id);
+                }
             }
         }
 
         [Fact]
         public void ShouldReturnMatchingProductWithGivenId()
         {
-            using (var session = _store.OpenSession())
+            using (var store = GetDocumentStore())
             {
-                var products = session.Advanced.DocumentQuery<Product, Product_AvailableForSale3>()
-                    .WaitForNonStaleResults()
-                    .UsingDefaultField("Any")
-                    .Where("MyName1").ToList();
+                CreateData(store);
 
-                Assert.Equal("Products/100", products.First().Id);
+                using (var session = store.OpenSession())
+                {
+                    var products = session.Advanced.DocumentQuery<Product, Product_AvailableForSale3>()
+                        .WaitForNonStaleResults()
+                        .UsingDefaultField("Any")
+                        .Where("MyName1").ToList();
+
+                    Assert.Equal("Products/100", products.First().Id);
+                }
             }
         }
 

--- a/test/SlowTests/MailingList/ProjectionTests.cs
+++ b/test/SlowTests/MailingList/ProjectionTests.cs
@@ -7,8 +7,6 @@
 using System.Collections.Generic;
 using System.Linq;
 using FastTests;
-using Raven.Client;
-using Raven.Client.Documents;
 using Raven.Client.Documents.Session;
 using Xunit;
 
@@ -16,18 +14,7 @@ namespace SlowTests.MailingList
 {
     public class ProjectionTests : RavenTestBase
     {
-        private readonly DocumentStore _store;
-        private readonly IDocumentSession _session;
-
-        public ProjectionTests()
-        {
-            _store = GetDocumentStore();
-            _session = _store.OpenSession();
-
-            Setup();
-        }
-
-        private void Setup()
+        private void CreateData(IDocumentSession session)
         {
             var list = new List<Foo>
             {
@@ -37,77 +24,101 @@ namespace SlowTests.MailingList
                 new Foo {Data = 4},
             };
 
-            list.ForEach(foo => _session.Store(foo));
-            _session.SaveChanges();
+            list.ForEach(foo => session.Store(foo));
+            session.SaveChanges();
         }
 
         //This works as expected
         [Fact]
         public void ActuallyGetData()
         {
-            var foos = _session.Query<Foo>()
-                .Customize(x => x.WaitForNonStaleResults())
-                .Where(foo => foo.Data > 1)
-                .Select(foo => new FooWithId
-                {
-                    Id = foo.Id,
-                    Data = foo.Data
-                })
-                .ToList();
+            using (var store = GetDocumentStore())
+            using (var session = store.OpenSession())
+            {
+                CreateData(session);
 
-            Assert.True(foos.Count == 3);
+                var foos = session.Query<Foo>()
+                    .Customize(x => x.WaitForNonStaleResults())
+                    .Where(foo => foo.Data > 1)
+                    .Select(foo => new FooWithId
+                    {
+                        Id = foo.Id,
+                        Data = foo.Data
+                    })
+                    .ToList();
+
+                Assert.True(foos.Count == 3);
+            }
         }
 
         //This works as expected
         [Fact]
         public void ShouldBeAbleToProjectIdOntoAnotherFieldCalledId()
         {
-            var foos = _session.Query<Foo>()
-                .Customize(x => x.WaitForNonStaleResults())
-                .Where(foo => foo.Data > 1)
-                .Select(foo => new FooWithId
-                {
-                    Id = foo.Id,
-                    Data = foo.Data
-                })
-                .ToList();
+            using (var store = GetDocumentStore())
+            using (var session = store.OpenSession())
+            {
+                CreateData(session);
 
-            Assert.NotNull(foos[0].Id);
+                var foos = session.Query<Foo>()
+                    .Customize(x => x.WaitForNonStaleResults())
+                    .Where(foo => foo.Data > 1)
+                    .Select(foo => new FooWithId
+                    {
+                        Id = foo.Id,
+                        Data = foo.Data
+                    })
+                    .ToList();
+
+                Assert.NotNull(foos[0].Id);
+            }
         }
 
         //Fails
         [Fact]
         public void ShouldBeAbleToProjectIdOntoAnotherName()
         {
-            var foos = _session.Query<Foo>()
-                              .Customize(x => x.WaitForNonStaleResults())
-                              .Where(foo => foo.Data > 1)
-                              .Select(foo => new FooWithFooId
-                              {
-                                  FooId = foo.Id,
-                                  Data = foo.Data
-                              })
-                              .ToList();
+            using (var store = GetDocumentStore())
+            using (var session = store.OpenSession())
+            {
+                CreateData(session);
 
-            Assert.NotNull(foos[0].FooId);
+                var foos = session.Query<Foo>()
+                    .Customize(x => x.WaitForNonStaleResults())
+                    .Where(foo => foo.Data > 1)
+                    .Select(foo => new FooWithFooId
+                    {
+                        FooId = foo.Id,
+                        Data = foo.Data
+                    })
+                    .ToList();
+
+                Assert.NotNull(foos[0].FooId);
+            }
         }
 
         [Fact]
         public void ShouldBeAbleToProjectIdOntoAnotherName_ButIdFieldWillBeFilledAnyway()
         {
-            var foos = _session.Query<Foo>()
-                              .Customize(x => x.WaitForNonStaleResults())
-                              .Where(foo => foo.Data > 1)
-                              .Select(foo => new FooWithFooIdAndId
-                              {
-                                  FooId = foo.Id,
-                                  Data2 = foo.Data
-                              })
-                              .ToList();
+            using (var store = GetDocumentStore())
+            using (var session = store.OpenSession())
+            {
+                CreateData(session);
 
-            Assert.NotNull(foos[0].Id);
-            Assert.NotNull(foos[0].FooId);
-            Assert.Equal(foos[0].Id, foos[0].FooId);
+                var foos = session.Query<Foo>()
+                    .Customize(x => x.WaitForNonStaleResults())
+                    .Where(foo => foo.Data > 1)
+                    .Select(foo => new FooWithFooIdAndId
+                    {
+                        FooId = foo.Id,
+                        Data2 = foo.Data
+                    })
+                    .ToList();
+
+                Assert.NotNull(foos[0].Id);
+                Assert.NotNull(foos[0].FooId);
+                Assert.Equal(foos[0].Id, foos[0].FooId);
+            }
         }
 
         private class Foo

--- a/test/SlowTests/MailingList/RavenDynamicTests.cs
+++ b/test/SlowTests/MailingList/RavenDynamicTests.cs
@@ -30,15 +30,11 @@ namespace SlowTests.MailingList
 
         public class WhenUsingIdCopy : RavenTestBase
         {
-            private readonly DocumentStore _store;
-
-            public WhenUsingIdCopy()
+            private void CreateData(IDocumentStore store)
             {
-                _store = GetDocumentStore();
+                new Person_IdCopy_Index().Execute(store);
 
-                new Person_IdCopy_Index().Execute(_store);
-
-                using (var session = _store.OpenSession())
+                using (var session = store.OpenSession())
                 {
                     session.Store(Sally);
                     session.Store(new Person { Name = "bob", UserId = Guid.NewGuid() });
@@ -48,27 +44,26 @@ namespace SlowTests.MailingList
                 }
             }
 
-            public override void Dispose()
-            {
-                _store.Dispose();
-                base.Dispose();
-            }
-
             [Fact]
             public void It_should_be_stored_in_index()
             {
-                using (var session = _store.OpenSession())
+                using (var store = GetDocumentStore())
                 {
-                    //WaitForUserToContinueTheTest(store);
+                    CreateData(store);
 
-                    var results2 = session.Advanced.DocumentQuery<Person, Person_IdCopy_Index>()
-                                          .WaitForNonStaleResultsAsOfNow()
-                                          .SelectFields<PersonIndexItem>()
-                                          .ToArray();
+                    using (var session = store.OpenSession())
+                    {
+                        //WaitForUserToContinueTheTest(store);
 
-                    var s = results2.Single(x => x.Id.Contains("sally"));
+                        var results2 = session.Advanced.DocumentQuery<Person, Person_IdCopy_Index>()
+                            .WaitForNonStaleResultsAsOfNow()
+                            .SelectFields<PersonIndexItem>()
+                            .ToArray();
 
-                    Assert.Equal(Sally.Family["Dad"].Id, s.Family_Dad_Id);
+                        var s = results2.Single(x => x.Id.Contains("sally"));
+
+                        Assert.Equal(Sally.Family["Dad"].Id, s.Family_Dad_Id);
+                    }
                 }
             }
 
@@ -76,18 +71,23 @@ namespace SlowTests.MailingList
             [Fact]
             public void It_should_be_stored_be_able_to_be_searched()
             {
-                using (var session = _store.OpenSession())
+                using (var store = GetDocumentStore())
                 {
-                    //WaitForUserToContinueTheTest(store);
+                    CreateData(store);
 
-                    var results = session.Advanced.DocumentQuery<Person, Person_IdCopy_Index>()
-                                         .WaitForNonStaleResultsAsOfNow()
-                                         .WhereEquals("Family_Dad_Id", "people/Dad")
-                                         .ToArray();
+                    using (var session = store.OpenSession())
+                    {
+                        //WaitForUserToContinueTheTest(store);
+
+                        var results = session.Advanced.DocumentQuery<Person, Person_IdCopy_Index>()
+                            .WaitForNonStaleResultsAsOfNow()
+                            .WhereEquals("Family_Dad_Id", "people/Dad")
+                            .ToArray();
 
 
-                    Assert.Equal(1, results.Count());
-                    Assert.Equal(Sally.Name, results.Single().Name);
+                        Assert.Equal(1, results.Count());
+                        Assert.Equal(Sally.Name, results.Single().Name);
+                    }
                 }
             }
 
@@ -109,15 +109,11 @@ namespace SlowTests.MailingList
 
         public class When_using_Id : RavenTestBase
         {
-            private readonly DocumentStore _store;
-
-            public When_using_Id()
+            private static void CreateData(IDocumentStore store)
             {
-                _store = GetDocumentStore();
+                new Person_Id_Index().Execute(store);
 
-                new Person_Id_Index().Execute(_store);
-
-                using (var session = _store.OpenSession())
+                using (var session = store.OpenSession())
                 {
                     session.Store(Sally);
                     session.Store(new Person { Name = "bob", UserId = Guid.NewGuid() });
@@ -127,27 +123,26 @@ namespace SlowTests.MailingList
                 }
             }
 
-            public override void Dispose()
-            {
-                _store.Dispose();
-                base.Dispose();
-            }
-
             [Fact]
             public void It_should_be_stored_in_index()
             {
-                using (var session = _store.OpenSession())
+                using (var store = GetDocumentStore())
                 {
-                    //WaitForUserToContinueTheTest(store);
+                    CreateData(store);
 
-                    var results2 = session.Advanced.DocumentQuery<Person, Person_Id_Index>()
-                                          .WaitForNonStaleResultsAsOfNow()
-                                          .SelectFields<PersonIndexItem>()
-                                          .ToArray();
+                    using (var session = store.OpenSession())
+                    {
+                        //WaitForUserToContinueTheTest(store);
 
-                    var s = results2.Single(x => x.Id.Contains("sally"));
+                        var results2 = session.Advanced.DocumentQuery<Person, Person_Id_Index>()
+                            .WaitForNonStaleResultsAsOfNow()
+                            .SelectFields<PersonIndexItem>()
+                            .ToArray();
 
-                    Assert.Equal(Sally.Family["Dad"].Id, s.Family_Dad_Id);
+                        var s = results2.Single(x => x.Id.Contains("sally"));
+
+                        Assert.Equal(Sally.Family["Dad"].Id, s.Family_Dad_Id);
+                    }
                 }
             }
 
@@ -155,18 +150,23 @@ namespace SlowTests.MailingList
             [Fact]
             public void It_should_be_stored_be_able_to_be_searched()
             {
-                using (var session = _store.OpenSession())
+                using (var store = GetDocumentStore())
                 {
-                    //WaitForUserToContinueTheTest(store);
+                    CreateData(store);
 
-                    var results = session.Advanced.DocumentQuery<Person, Person_Id_Index>()
-                                         .WaitForNonStaleResultsAsOfNow()
-                                         .WhereEquals("Family_Dad_Id", "people/Dad")
-                                         .ToArray();
+                    using (var session = store.OpenSession())
+                    {
+                        //WaitForUserToContinueTheTest(store);
+
+                        var results = session.Advanced.DocumentQuery<Person, Person_Id_Index>()
+                            .WaitForNonStaleResultsAsOfNow()
+                            .WhereEquals("Family_Dad_Id", "people/Dad")
+                            .ToArray();
 
 
-                    Assert.Equal(1, results.Count());
-                    Assert.Equal(Sally.Name, results.Single().Name);
+                        Assert.Equal(1, results.Count());
+                        Assert.Equal(Sally.Name, results.Single().Name);
+                    }
                 }
             }
 

--- a/test/SlowTests/MailingList/WhereInQueryTests.cs
+++ b/test/SlowTests/MailingList/WhereInQueryTests.cs
@@ -11,13 +11,9 @@ namespace SlowTests.MailingList
 {
     public class WhereInQueryTests : RavenTestBase
     {
-        private readonly DocumentStore documentStore;
-
-        public WhereInQueryTests()
+        private void CreateData(IDocumentStore store)
         {
-            documentStore = GetDocumentStore();
-
-            using (IDocumentSession session = documentStore.OpenSession())
+            using (IDocumentSession session = store.OpenSession())
             {
                 session.Store(new TestDocument
                 {
@@ -40,48 +36,52 @@ namespace SlowTests.MailingList
                 session.SaveChanges();
             }
 
-            new TestIndex().Execute(documentStore);
-        }
-
-        public override void Dispose()
-        {
-            documentStore.Dispose();
-            base.Dispose();
+            new TestIndex().Execute(store);
         }
 
         [Fact]
         public void Query_should_return_2_results()
         {
-            using (IDocumentSession session = documentStore.OpenSession())
+            using (var store = GetDocumentStore())
             {
-                List<TestDocument> results = session
-                    .Advanced
-                    .DocumentQuery<TestDocument, TestIndex>()
-                    .WhereEquals("FirstName", "FirstName1")
-                    .OrElse()
-                    .WhereEquals("LastName", "LastName2")
-                    .WaitForNonStaleResults()
-                    .ToList();
+                CreateData(store);
 
-                Assert.Equal(2, results.Count);
+                using (IDocumentSession session = store.OpenSession())
+                {
+                    List<TestDocument> results = session
+                        .Advanced
+                        .DocumentQuery<TestDocument, TestIndex>()
+                        .WhereEquals("FirstName", "FirstName1")
+                        .OrElse()
+                        .WhereEquals("LastName", "LastName2")
+                        .WaitForNonStaleResults()
+                        .ToList();
+
+                    Assert.Equal(2, results.Count);
+                }
             }
         }
 
         [Fact]
         public void Query_using_WhereIn_should_return_2_results()
         {
-            using (IDocumentSession session = documentStore.OpenSession())
+            using (var store = GetDocumentStore())
             {
-                List<TestDocument> results = session
-                    .Advanced
-                    .DocumentQuery<TestDocument, TestIndex>()
-                    .WhereIn("FirstName", new[] { "FirstName1" })
-                    .OrElse()
-                    .WhereIn("LastName", new[] { "LastName2" })
-                    .WaitForNonStaleResults()
-                    .ToList();
+                CreateData(store);
 
-                Assert.Equal(2, results.Count);
+                using (IDocumentSession session = store.OpenSession())
+                {
+                    List<TestDocument> results = session
+                        .Advanced
+                        .DocumentQuery<TestDocument, TestIndex>()
+                        .WhereIn("FirstName", new[] { "FirstName1" })
+                        .OrElse()
+                        .WhereIn("LastName", new[] { "LastName2" })
+                        .WaitForNonStaleResults()
+                        .ToList();
+
+                    Assert.Equal(2, results.Count);
+                }
             }
         }
 

--- a/test/SlowTests/MailingList/WhereStringEqualsInCollection.cs
+++ b/test/SlowTests/MailingList/WhereStringEqualsInCollection.cs
@@ -9,11 +9,8 @@ namespace SlowTests.MailingList
 {
     public class WhereStringEqualsInCollection : RavenTestBase
     {
-        private readonly DocumentStore store;
-
-        public WhereStringEqualsInCollection()
+        private void CreateData(IDocumentStore store)
         {
-            store = GetDocumentStore();
             using (var session = store.OpenSession())
             {
                 session.Store(new MyEntity { StringData = "Entity with collection", StringCollection = new List<string> { "CollectionItem1", "CollectionItem2" } });
@@ -24,45 +21,54 @@ namespace SlowTests.MailingList
         [Fact]
         public void AnyInCollectionEqualsConstant_ShouldWork()
         {
-            using (var session = store.OpenSession())
+            using (var store = GetDocumentStore())
             {
-                var count = session.Query<MyEntity>()
-                                   .Customize(customization => customization.WaitForNonStaleResultsAsOfNow())
-                                   .Count(o => o.StringCollection.Any(s => s.Equals("CollectionItem1")));
+                CreateData(store);
 
-                Assert.Equal(1, count);
+                using (var session = store.OpenSession())
+                {
+                    var count = session.Query<MyEntity>()
+                        .Customize(customization => customization.WaitForNonStaleResultsAsOfNow())
+                        .Count(o => o.StringCollection.Any(s => s.Equals("CollectionItem1")));
+
+                    Assert.Equal(1, count);
+                }
             }
         }
 
         [Fact]
         public void AnyInCollectionEqualsConstant_IgnoreCase_ShouldWork()
         {
-            using (var session = store.OpenSession())
+            using (var store = GetDocumentStore())
             {
-                var count = session.Query<MyEntity>()
-                                   .Customize(customization => customization.WaitForNonStaleResultsAsOfNow())
-                                   .Count(o => o.StringCollection.Any(s => s.Equals("CollectionItem1", StringComparison.OrdinalIgnoreCase)));
+                CreateData(store);
 
-                Assert.Equal(1, count);
+                using (var session = store.OpenSession())
+                {
+                    var count = session.Query<MyEntity>()
+                        .Customize(customization => customization.WaitForNonStaleResultsAsOfNow())
+                        .Count(o => o.StringCollection.Any(s => s.Equals("CollectionItem1", StringComparison.OrdinalIgnoreCase)));
+
+                    Assert.Equal(1, count);
+                }
             }
         }
 
         [Fact]
         public void AnyInCollectionEqualsConstant_CaseSensitive_ShouldWork()
         {
-            using (var session = store.OpenSession())
+            using (var store = GetDocumentStore())
             {
-                Assert.Throws<NotSupportedException>(() => session.Query<MyEntity>()
-                                                                  .Customize(customization => customization.WaitForNonStaleResultsAsOfNow())
-                                                                  .Count(o => o.StringCollection.Any(s => s.Equals("CollectionItem1", StringComparison.Ordinal))));
+                CreateData(store);
 
+                using (var session = store.OpenSession())
+                {
+                    Assert.Throws<NotSupportedException>(() => session.Query<MyEntity>()
+                        .Customize(customization => customization.WaitForNonStaleResultsAsOfNow())
+                        .Count(o => o.StringCollection.Any(s => s.Equals("CollectionItem1", StringComparison.Ordinal))));
+
+                }
             }
-        }
-
-        public override void Dispose()
-        {
-            store.Dispose();
-            base.Dispose();
         }
 
         private class MyEntity

--- a/test/Tests.Infrastructure/RavenTestBase.cs
+++ b/test/Tests.Infrastructure/RavenTestBase.cs
@@ -11,7 +11,6 @@ using Raven.Client.Documents;
 using Raven.Client.Documents.Indexes;
 using Raven.Client.Documents.Operations;
 using Raven.Client.Documents.Operations.Indexes;
-using Raven.Client.Exceptions;
 using Raven.Client.Exceptions.Cluster;
 using Raven.Client.Exceptions.Database;
 using Raven.Client.Server;
@@ -91,6 +90,9 @@ namespace FastTests
         {
             try
             {
+                if (caller != null && caller.Contains(".ctor"))
+                    throw new InvalidOperationException($"Usage of '{nameof(GetDocumentStore)}' without explicit '{nameof(caller)}' parameter is forbidden from inside constructor.");
+
                 lock (_getDocumentStoreSync)
                 {
                     defaultServer = defaultServer ?? Server;


### PR DESCRIPTION
- we cannot release semaphore when it was not taken, this can happen for tests that are executing tests from other classes
- forbidding to execute GetDocumentStore without explicit 'caller' parameter from constructors to avoid having N-number of '.ctorXXX' databases