### PR TITLE
RavenDB-6872 Remove duplicated GetConflictsCommand

### DIFF
--- a/src/Raven.Client/Documents/Commands/GetConflictsCommand.cs
+++ b/src/Raven.Client/Documents/Commands/GetConflictsCommand.cs
@@ -5,8 +5,6 @@ using Sparrow.Json;
 
 namespace Raven.Client.Documents.Commands
 {
-    //not sure if this should be done for multiple doc IDs
-    //for now it will work for single conflicted document id
     public class GetConflictsCommand : RavenCommand<GetConflictsResult>
     {
         private readonly string _id;
@@ -28,6 +26,8 @@ namespace Raven.Client.Documents.Commands
 
         public override void SetResponse(BlittableJsonReaderObject response, bool fromCache)
         {
+            if (response == null)
+                ThrowInvalidResponse();
             Result = JsonDeserializationClient.GetConflictsResult(response);
         }
     }

--- a/src/Raven.Server/Smuggler/Documents/DatabaseDestination.cs
+++ b/src/Raven.Server/Smuggler/Documents/DatabaseDestination.cs
@@ -305,7 +305,6 @@ namespace Raven.Server.Smuggler.Documents
                             var endIndex = id.IndexOf(PreV4RevisionsDocumentId, StringComparison.OrdinalIgnoreCase);
                             var newId = id.Substring(0, endIndex);
 
-                            // ReSharper disable once PossibleNullReferenceException
                             _database.DocumentsStorage.VersioningStorage.Put(context, newId, document.Data, document.Flags, document.NonPersistentFlags, document.ChangeVector, document.LastModified.Ticks);
                             continue;
                         }

--- a/test/SlowTests/Client/Attachments/AttachmentsReplication.cs
+++ b/test/SlowTests/Client/Attachments/AttachmentsReplication.cs
@@ -894,14 +894,16 @@ namespace SlowTests.Client.Attachments
                 await SetupReplicationAsync(store2, store1);
 
                 var conflicts = WaitUntilHasConflict(store1, "users/1");
-                Assert.Equal(2, conflicts.Results.Length);
-                AssertConflict(conflicts.Results[0], "a1", "EcDnm3HDl2zNDALRMQ4lFsCO3J2Lb1fM1oDWOk2Octo=", "a1/png", 3);
-                AssertConflict(conflicts.Results[1], "a1", "EcDnm3HDl2zNDALRMQ4lFsCO3J2Lb1fM1oDWOk2Octo=", "a2/jpeg", 3);
+                Assert.Equal(2, conflicts.Length);
+                AssertConflict(conflicts[0], "a1", "EcDnm3HDl2zNDALRMQ4lFsCO3J2Lb1fM1oDWOk2Octo=", "a1/png", 3);
+                AssertConflict(conflicts[1], "a1", "EcDnm3HDl2zNDALRMQ4lFsCO3J2Lb1fM1oDWOk2Octo=", "a2/jpeg", 3);
 
                 conflicts = WaitUntilHasConflict(store2, "users/1");
-                Assert.Equal(2, conflicts.Results.Length);
-                AssertConflict(conflicts.Results[0], "a1", "EcDnm3HDl2zNDALRMQ4lFsCO3J2Lb1fM1oDWOk2Octo=", "a1/png", 3);
-                AssertConflict(conflicts.Results[1], "a1", "EcDnm3HDl2zNDALRMQ4lFsCO3J2Lb1fM1oDWOk2Octo=", "a2/jpeg", 3);
+                Assert.Equal(2, conflicts.Length);
+                AssertConflict(conflicts[0], "a1", "EcDnm3HDl2zNDALRMQ4lFsCO3J2Lb1fM1oDWOk2Octo=", "a1/png", 3);
+                AssertConflict(conflicts[1], "a1", "EcDnm3HDl2zNDALRMQ4lFsCO3J2Lb1fM1oDWOk2Octo=", "a2/jpeg", 3);
+
+                WaitForUserToContinueTheTest(store1);
             }
         }
 
@@ -942,14 +944,14 @@ namespace SlowTests.Client.Attachments
                 var hash2 = "Arg5SgIJzdjSTeY6LYtQHlyNiTPmvBLHbr/Cypggeco=";
 
                 var conflicts = WaitUntilHasConflict(store1, "users/1");
-                Assert.Equal(2, conflicts.Results.Length);
-                AssertConflict(conflicts.Results[0], "a1", hash1, "a1/png", 3);
-                AssertConflict(conflicts.Results[1], "a1", hash2, "a1/png", 5);
+                Assert.Equal(2, conflicts.Length);
+                AssertConflict(conflicts[0], "a1", hash1, "a1/png", 3);
+                AssertConflict(conflicts[1], "a1", hash2, "a1/png", 5);
 
                 conflicts = WaitUntilHasConflict(store2, "users/1");
-                Assert.Equal(2, conflicts.Results.Length);
-                AssertConflict(conflicts.Results[0], "a1", hash1, "a1/png", 3);
-                AssertConflict(conflicts.Results[1], "a1", hash2, "a1/png", 5);
+                Assert.Equal(2, conflicts.Length);
+                AssertConflict(conflicts[0], "a1", hash1, "a1/png", 3);
+                AssertConflict(conflicts[1], "a1", hash2, "a1/png", 5);
             }
         }
 

--- a/test/SlowTests/Issues/RavenDB-4997.cs
+++ b/test/SlowTests/Issues/RavenDB-4997.cs
@@ -1,8 +1,7 @@
-﻿using System.Linq;
-using System.Threading.Tasks;
+﻿using System.Threading.Tasks;
+using FastTests;
 using FastTests.Server.Replication;
 using Raven.Client.Documents.Exceptions;
-using Raven.Client.Exceptions;
 using Xunit;
 
 namespace SlowTests.Issues
@@ -117,8 +116,8 @@ namespace SlowTests.Issues
                     session.SaveChanges();
                 }
 
-                var conflicts = GetConflicts(storeA, "users/1");
-                Assert.Equal(0,conflicts.Results.Length);
+                var conflicts = storeA.Commands().GetConflictsFor("users/1");
+                Assert.Equal(0,conflicts.Length);
             }
         }
 

--- a/test/SlowTests/Issues/RavenDB_578.cs
+++ b/test/SlowTests/Issues/RavenDB_578.cs
@@ -39,12 +39,12 @@ namespace SlowTests.Issues
             await SetupReplicationAsync(store1, store2);
 
             var conflicts = WaitUntilHasConflict(store2, "people/1");
-            Assert.Equal(2, conflicts.Results.Length);
+            Assert.Equal(2, conflicts.Length);
 
             await SetupReplicationAsync(store2, store1);
 
             conflicts = WaitUntilHasConflict(store1, "people/1");
-            Assert.Equal(2, conflicts.Results.Length);
+            Assert.Equal(2, conflicts.Length);
 
             using (var commands = store2.Commands())
             {

--- a/test/SlowTests/Server/Replication/ReplicationAutomaticConflictResolution.cs
+++ b/test/SlowTests/Server/Replication/ReplicationAutomaticConflictResolution.cs
@@ -152,7 +152,7 @@ return out;
                     session.SaveChanges();
                 }
 
-                Assert.Equal(2, WaitUntilHasConflict(slave, "users/1").Results.Length);
+                Assert.Equal(2, WaitUntilHasConflict(slave, "users/1").Length);
             }
         }
 

--- a/test/SlowTests/Server/Replication/ReplicationConflictsTests.cs
+++ b/test/SlowTests/Server/Replication/ReplicationConflictsTests.cs
@@ -2,6 +2,7 @@
 using System.Collections.Generic;
 using System.Linq;
 using System.Threading.Tasks;
+using FastTests;
 using FastTests.Server.Replication;
 using Raven.Client.Documents.Exceptions;
 using Raven.Client.Documents.Indexes;
@@ -225,7 +226,7 @@ namespace SlowTests.Server.Replication
                 await SetupReplicationAsync(store1, store2);
 
                 var conflicts = WaitUntilHasConflict(store2, "foo/bar");
-                Assert.Equal(2, conflicts.Results.Length);
+                Assert.Equal(2, conflicts.Length);
             }
         }
 
@@ -257,8 +258,8 @@ namespace SlowTests.Server.Replication
 
                 await SetupReplicationAsync(store1, store2);
 
-                Assert.Equal(2, WaitUntilHasConflict(store2, "users/3").Results.Length);
-                Assert.Equal(2, WaitUntilHasConflict(store2, "users/2").Results.Length);
+                Assert.Equal(2, WaitUntilHasConflict(store2, "users/3").Length);
+                Assert.Equal(2, WaitUntilHasConflict(store2, "users/2").Length);
                 // conflict between two tombstones, resolved automaticlly to tombstone.
                 var tombstones = WaitUntilHasTombstones(store2);
                 Assert.Equal("users/1", tombstones.Single());
@@ -464,7 +465,7 @@ namespace SlowTests.Server.Replication
                 await SetupReplicationAsync(store1, store3);
                 await SetupReplicationAsync(store2, store3);
 
-                Assert.Equal(3, WaitUntilHasConflict(store3, "foo/bar", 3).Results.Length);
+                Assert.Equal(3, WaitUntilHasConflict(store3, "foo/bar", 3).Length);
             }
         }
 
@@ -489,7 +490,7 @@ namespace SlowTests.Server.Replication
 
                 await SetupReplicationAsync(store1, store2);
 
-                Assert.Equal(2, WaitUntilHasConflict(store2, "foo/bar").Results.Length);
+                Assert.Equal(2, WaitUntilHasConflict(store2, "foo/bar").Length);
             }
         }
 
@@ -556,7 +557,7 @@ namespace SlowTests.Server.Replication
 
                 await SetReplicationConflictResolutionAsync(store2, StraightforwardConflictResolution.ResolveToLatest);
 
-                var count = WaitForValue(() => GetConflicts(store2, "foo/bar").Results.Length, 0);
+                var count = WaitForValue(() => store2.Commands().GetConflictsFor("foo/bar").Length, 0);
                 Assert.Equal(count, 0);
 
                 var newCollection = WaitForValue(() =>
@@ -603,7 +604,7 @@ namespace SlowTests.Server.Replication
                     s2.SaveChanges();
                 }
 
-                var count = WaitForValue(() => GetConflicts(store2, "foo/bar").Results.Length, 0);
+                var count = WaitForValue(() => store2.Commands().GetConflictsFor("foo/bar").Length, 0);
                 Assert.Equal(count, 0);
 
                 New_User2 newDoc = null;

--- a/test/SlowTests/Server/Replication/ReplicationOfConflicts.cs
+++ b/test/SlowTests/Server/Replication/ReplicationOfConflicts.cs
@@ -31,11 +31,11 @@ namespace SlowTests.Server.Replication
 
                 await SetupReplicationAsync(store1, store2);
 
-                Assert.Equal(2, WaitUntilHasConflict(store2, "foo/bar").Results.Length);
+                Assert.Equal(2, WaitUntilHasConflict(store2, "foo/bar").Length);
 
                 await SetupReplicationAsync(store2, store1);
 
-                Assert.Equal(2, WaitUntilHasConflict(store1, "foo/bar").Results.Length);
+                Assert.Equal(2, WaitUntilHasConflict(store1, "foo/bar").Length);
 
                 // adding new document, resolve the conflict
                 using (var session = store2.OpenSession())
@@ -46,8 +46,8 @@ namespace SlowTests.Server.Replication
 
                 Assert.True(WaitForDocument(store1, "foo/bar"));
 
-                Assert.Empty(GetConflicts(store1, "foo/bar").Results);
-                Assert.Empty(GetConflicts(store2, "foo/bar").Results);
+                Assert.Empty(store1.Commands().GetConflictsFor("foo/bar"));
+                Assert.Empty(store2.Commands().GetConflictsFor("foo/bar"));
             }
         }  
 
@@ -129,12 +129,12 @@ namespace SlowTests.Server.Replication
 
                 await SetupReplicationAsync(store1, store2, store3);
 
-                Assert.Equal(2, WaitUntilHasConflict(store2, "foo/bar").Results.Length);
+                Assert.Equal(2, WaitUntilHasConflict(store2, "foo/bar").Length);
 
                 await SetupReplicationAsync(store2, store1);
 
-                Assert.Equal(2, WaitUntilHasConflict(store1, "foo/bar").Results.Length);
-                Assert.Equal(2, WaitUntilHasConflict(store3, "foo/bar").Results.Length);
+                Assert.Equal(2, WaitUntilHasConflict(store1, "foo/bar").Length);
+                Assert.Equal(2, WaitUntilHasConflict(store3, "foo/bar").Length);
 
                 using (var session = store2.OpenSession())
                 {
@@ -175,11 +175,11 @@ namespace SlowTests.Server.Replication
                     session.SaveChanges();
                 }
 
-                Assert.Equal(2, WaitUntilHasConflict(store2, "foo/bar").Results.Length);
+                Assert.Equal(2, WaitUntilHasConflict(store2, "foo/bar").Length);
 
                 await SetupReplicationAsync(store2, store1);
 
-                Assert.Equal(2, WaitUntilHasConflict(store1, "foo/bar").Results.Length);
+                Assert.Equal(2, WaitUntilHasConflict(store1, "foo/bar").Length);
             }
         }
 
@@ -202,8 +202,8 @@ namespace SlowTests.Server.Replication
                 await SetupReplicationAsync(store1, store2);
                 await SetupReplicationAsync(store2, store1);
 
-                Assert.Equal(2,WaitUntilHasConflict(store1, "users/1-A").Results.Length);
-                Assert.Equal(2,WaitUntilHasConflict(store2, "users/1-A").Results.Length);
+                Assert.Equal(2,WaitUntilHasConflict(store1, "users/1-A").Length);
+                Assert.Equal(2,WaitUntilHasConflict(store2, "users/1-A").Length);
 
                 var db = await GetDocumentDatabaseInstanceFor(store1);
                 using (db.DocumentsStorage.ContextPool.AllocateOperationContext(out DocumentsOperationContext ctx))

--- a/test/SlowTests/Server/Replication/ReplicationResolveConflictsOnConfigurationChange.cs
+++ b/test/SlowTests/Server/Replication/ReplicationResolveConflictsOnConfigurationChange.cs
@@ -34,8 +34,8 @@ namespace SlowTests.Server.Replication
             var list = await SetupReplicationAsync(store1,store2);
             list.AddRange(await SetupReplicationAsync(store2,store1));
 
-            Assert.Equal(2, WaitUntilHasConflict(store1, id).Results.Length);
-            Assert.Equal(2, WaitUntilHasConflict(store2, id).Results.Length);
+            Assert.Equal(2, WaitUntilHasConflict(store1, id).Length);
+            Assert.Equal(2, WaitUntilHasConflict(store2, id).Length);
             return list;
         }
 

--- a/test/SlowTests/Server/Replication/ReplicationResolveToLeader.cs
+++ b/test/SlowTests/Server/Replication/ReplicationResolveToLeader.cs
@@ -28,7 +28,7 @@ namespace SlowTests.Server.Replication
                 }
                 await SetupReplicationAsync(store1, store2);
                
-                Assert.Equal(2, WaitUntilHasConflict(store2, "foo/bar").Results.Length);
+                Assert.Equal(2, WaitUntilHasConflict(store2, "foo/bar").Length);
 
                 var documentDatabase = Server.ServerStore.DatabasesLandlord.TryGetOrCreateResourceStore(store2.Database).Result;
 
@@ -68,9 +68,9 @@ namespace SlowTests.Server.Replication
                 await SetupReplicationAsync(store1, store2, store3);
                 await SetupReplicationAsync(store2, store1);
 
-                Assert.Equal(2, WaitUntilHasConflict(store1, "foo/bar").Results.Length);
-                Assert.Equal(2, WaitUntilHasConflict(store2, "foo/bar").Results.Length);
-                Assert.Equal(3, WaitUntilHasConflict(store3, "foo/bar", 3).Results.Length);
+                Assert.Equal(2, WaitUntilHasConflict(store1, "foo/bar").Length);
+                Assert.Equal(2, WaitUntilHasConflict(store2, "foo/bar").Length);
+                Assert.Equal(3, WaitUntilHasConflict(store3, "foo/bar", 3).Length);
 
                 // store2 <--> store1 <--> store3*               
                 var documentDatabase = Server.ServerStore.DatabasesLandlord.TryGetOrCreateResourceStore(store3.Database).Result;
@@ -125,8 +125,8 @@ namespace SlowTests.Server.Replication
                     session.SaveChanges();
                 }
                 // store2 <-- store1 --> store3
-                Assert.Equal(2, WaitUntilHasConflict(store3, "foo/bar").Results.Length);
-                Assert.Equal(2, WaitUntilHasConflict(store2, "foo/bar").Results.Length);
+                Assert.Equal(2, WaitUntilHasConflict(store3, "foo/bar").Length);
+                Assert.Equal(2, WaitUntilHasConflict(store2, "foo/bar").Length);
 
                 // store2* <--> store1 --> store3
                 var documentDatabase = await GetDocumentDatabaseInstanceFor(store2);
@@ -201,7 +201,7 @@ namespace SlowTests.Server.Replication
                     session.Store(new User {Name = "NewOren"}, "foo/bar");
                     session.SaveChanges();
                 }
-                Assert.Equal(2, WaitUntilHasConflict(store2, "foo/bar").Results.Length);
+                Assert.Equal(2, WaitUntilHasConflict(store2, "foo/bar").Length);
             }
         }       
 
@@ -231,8 +231,8 @@ namespace SlowTests.Server.Replication
                 await SetupReplicationAsync(store1,store2);
                 await SetupReplicationAsync(store2,store1);
 
-                Assert.Equal(2, WaitUntilHasConflict(store1, "foo/bar").Results.Length);
-                Assert.Equal(2, WaitUntilHasConflict(store2, "foo/bar").Results.Length);
+                Assert.Equal(2, WaitUntilHasConflict(store1, "foo/bar").Length);
+                Assert.Equal(2, WaitUntilHasConflict(store2, "foo/bar").Length);
                 
                 using (var session = store2.OpenSession())
                 {

--- a/test/SlowTests/Server/Replication/ReplicationSpecialCases.cs
+++ b/test/SlowTests/Server/Replication/ReplicationSpecialCases.cs
@@ -37,7 +37,7 @@ namespace SlowTests.Server.Replication
                     session.SaveChanges();
                 }
 
-                Assert.Equal(2, WaitUntilHasConflict(slave, "users/1", 1).Results.Length);
+                Assert.Equal(2, WaitUntilHasConflict(slave, "users/1", 1).Length);
             }
         }
 
@@ -77,7 +77,7 @@ namespace SlowTests.Server.Replication
                     session.SaveChanges();
                 }
 
-                Assert.Equal(2, WaitUntilHasConflict(slave, "users/1", 1).Results.Length);
+                Assert.Equal(2, WaitUntilHasConflict(slave, "users/1", 1).Length);
             }
         }
 
@@ -107,7 +107,7 @@ namespace SlowTests.Server.Replication
                     }, "users/1");
                     session.SaveChanges();
                 }
-                Assert.Equal(2, WaitUntilHasConflict(slave, "users/1", 1).Results.Length);
+                Assert.Equal(2, WaitUntilHasConflict(slave, "users/1", 1).Length);
 
                 using (var session = master.OpenSession())
                 {
@@ -118,7 +118,7 @@ namespace SlowTests.Server.Replication
                     session.SaveChanges();
                 }
 
-                Assert.Equal(2, WaitUntilHasConflict(slave, "users/1", 1).Results.Length);
+                Assert.Equal(2, WaitUntilHasConflict(slave, "users/1", 1).Length);
             }
         }
 

--- a/test/SlowTests/Server/Replication/ReplicationTombstoneTests.cs
+++ b/test/SlowTests/Server/Replication/ReplicationTombstoneTests.cs
@@ -204,28 +204,28 @@ namespace SlowTests.Server.Replication
             using (var store2 = GetDocumentStore())
             {
 
-                using (var sessoin = store1.OpenSession())
+                using (var session = store1.OpenSession())
                 {
-                    sessoin.Store(new User { Name = "foo" }, "foo/bar");
-                    sessoin.SaveChanges();
+                    session.Store(new User { Name = "foo" }, "foo/bar");
+                    session.SaveChanges();
                 }
 
-                using (var sessoin = store2.OpenSession())
+                using (var session = store2.OpenSession())
                 {
-                    sessoin.Store(new User { Name = "bar" }, "foo/bar");
-                    sessoin.SaveChanges();
+                    session.Store(new User { Name = "bar" }, "foo/bar");
+                    session.SaveChanges();
                 }
 
                 await SetupReplicationAsync(store1, store2);
                 await SetupReplicationAsync(store2, store1);
 
-                Assert.Equal(2, WaitUntilHasConflict(store1, "foo/bar").Results.Length);
-                Assert.Equal(2, WaitUntilHasConflict(store2, "foo/bar").Results.Length);
+                Assert.Equal(2, WaitUntilHasConflict(store1, "foo/bar").Length);
+                Assert.Equal(2, WaitUntilHasConflict(store2, "foo/bar").Length);
 
-                using (var sessoin = store1.OpenSession())
+                using (var session = store1.OpenSession())
                 {
-                    sessoin.Delete("foo/bar");
-                    sessoin.SaveChanges();
+                    session.Delete("foo/bar");
+                    session.SaveChanges();
                 }
 
                 Assert.Equal(1, WaitUntilHasTombstones(store1).Count);

--- a/test/SlowTests/Server/Replication/ReplicationWithVersioning.cs
+++ b/test/SlowTests/Server/Replication/ReplicationWithVersioning.cs
@@ -94,8 +94,8 @@ namespace SlowTests.Server.Replication
             {
                 await GenerateConflict(storeA, storeB);
 
-                Assert.Equal(2, WaitUntilHasConflict(storeA, "foo/bar").Results.Length);
-                Assert.Equal(2, WaitUntilHasConflict(storeB, "foo/bar").Results.Length);
+                Assert.Equal(2, WaitUntilHasConflict(storeA, "foo/bar").Length);
+                Assert.Equal(2, WaitUntilHasConflict(storeB, "foo/bar").Length);
 
                 Assert.Equal(2, WaitForValue(() => storeA.Commands().GetRevisionsFor("foo/bar").Count, 2));
                 Assert.Equal(2, WaitForValue(() => storeB.Commands().GetRevisionsFor("foo/bar").Count, 2));
@@ -110,8 +110,8 @@ namespace SlowTests.Server.Replication
             {
                 await GenerateConflict(storeA, storeB);
 
-                Assert.Equal(2, WaitUntilHasConflict(storeA, "foo/bar").Results.Length);
-                Assert.Equal(2, WaitUntilHasConflict(storeB, "foo/bar").Results.Length);
+                Assert.Equal(2, WaitUntilHasConflict(storeA, "foo/bar").Length);
+                Assert.Equal(2, WaitUntilHasConflict(storeB, "foo/bar").Length);
 
                 Assert.Equal(2, WaitForValue(() => storeA.Commands().GetRevisionsFor("foo/bar").Count, 2));
                 Assert.Equal(2, WaitForValue(() => storeB.Commands().GetRevisionsFor("foo/bar").Count, 2));

--- a/test/Tests.Infrastructure/DocumentStoreExtensions.cs
+++ b/test/Tests.Infrastructure/DocumentStoreExtensions.cs
@@ -151,7 +151,13 @@ namespace FastTests
             {
                 var getConflictsCommand = new GetConflictsCommand(id);
                 RequestExecutor.Execute(getConflictsCommand, Context);
+                return getConflictsCommand.Result.Results;
+            }
 
+            public async Task<GetConflictsResult.Conflict[]> GetConflictsForAsync(string id)
+            {
+                var getConflictsCommand = new GetConflictsCommand(id);
+                await RequestExecutor.ExecuteAsync(getConflictsCommand, Context);
                 return getConflictsCommand.Result.Results;
             }
 


### PR DESCRIPTION
There is two failing tests, I don't think they are related to my work, but I didn't checked yet:

FastTests.Issues.RavenDB_6250.All_operations_has_details_providers [FAIL]
      Probably unhandled details for operations: DatabaseRestore. If those was already handled in notification center please add given type to 'alreadyHandledInStudio' set. If operation doesn't provide details, please add this to 'operationWithoutDetails' set.
      Expected: True
      Actual:   False
      Stack Trace:
        C:\work\ravendb\test\FastTests\Issues\RavenDB-6250.cs(50,0): at FastTests.Issues.RavenDB_6250.All_operations_has_details_providers()
    FastTests.Voron.Backups.BackupToOneZipFile.FullBackupToOneZipFile [SKIP]
      Should add database record to backup and restore
    FastTests.Voron.Backups.BackupToOneZipFile.IncrementalBackupToOneZipFile [SKIP]
      Should add database record to backup and restore
    FastTests.Client.Hilo.HiLoKeyGenerator_async_hangs_when_aggressive_caching_enabled_on_other_documentstore [SKIP]
      RavenDB-6312 AggressivelyCache Not Implemented yet
    FastTests.Server.ServerStore.Server_store_write_should_throw_concurrency_exception_if_relevant [SKIP]
      Should be restored
    FastTests.Client.Hilo.HiLoKeyGenerator_async_hangs_when_aggressive_caching_enabled [SKIP]
      RavenDB-6312 AggressivelyCache Not Implemented yet
    FastTests.Client.Queries.FullTextSearchOnTags.BoostingSearches [FAIL]
      Raven.Client.Exceptions.RavenException : System.InvalidOperationException: Failed to create index test
         at async Raven.Server.Documents.Indexes.IndexStore.CreateIndex(?) in C:\work\ravendb\src\Raven.Server\Documents\Indexes\IndexStore.cs:line 402
         at async Raven.Server.Documents.Handlers.IndexHandler.Put(?) in C:\work\ravendb\src\Raven.Server\Documents\Handlers\IndexHandler.cs:line 45
         at async Raven.Server.Routing.RequestRouter.HandlePath(?) in C:\work\ravendb\src\Raven.Server\Routing\RequestRouter.cs:line 115
         at async Raven.Server.RavenServerStartup.RequestHandler(?) in C:\work\ravendb\src\Raven.Server\RavenServerStartup.cs:line 160
      ---- System.InvalidOperationException : System.InvalidOperationException: Failed to create index test
         at async Raven.Server.Documents.Indexes.IndexStore.CreateIndex(?) in C:\work\ravendb\src\Raven.Server\Documents\Indexes\IndexStore.cs:line 402
         at async Raven.Server.Documents.Handlers.IndexHandler.Put(?) in C:\work\ravendb\src\Raven.Server\Documents\Handlers\IndexHandler.cs:line 45
         at async Raven.Server.Routing.RequestRouter.HandlePath(?) in C:\work\ravendb\src\Raven.Server\Routing\RequestRouter.cs:line 115
         at async Raven.Server.RavenServerStartup.RequestHandler(?) in C:\work\ravendb\src\Raven.Server\RavenServerStartup.cs:line 160
      State for A-term1:
      Passive=>LeaderElect at 2017-06-21T14:04:52.0724469Z
      because I'm the only one in the cluster, so I'm the leader
      Stack Trace:
        C:\work\ravendb\src\Raven.Client\Exceptions\ExceptionDispatcher.cs(103,0): at Raven.Client.Exceptions.ExceptionDispatcher.<Throw>d__2.MoveNext()
        --- End of stack trace from previous location where exception was thrown ---
           at System.Runtime.ExceptionServices.ExceptionDispatchInfo.Throw()
           at System.Runtime.CompilerServices.TaskAwaiter.HandleNonSuccessAndDebuggerNotification(Task task)
           at System.Runtime.CompilerServices.ConfiguredTaskAwaitable.ConfiguredTaskAwaiter.GetResult()
        C:\work\ravendb\src\Raven.Client\Http\RequestExecutor.cs(511,0): at Raven.Client.Http.RequestExecutor.<HandleUnsuccessfulResponse>d__47`1.MoveNext()
        --- End of stack trace from previous location where exception was thrown ---
           at System.Runtime.ExceptionServices.ExceptionDispatchInfo.Throw()
           at System.Runtime.CompilerServices.TaskAwaiter.HandleNonSuccessAndDebuggerNotification(Task task)
           at System.Runtime.CompilerServices.ConfiguredTaskAwaitable`1.ConfiguredTaskAwaiter.GetResult()
        C:\work\ravendb\src\Raven.Client\Http\RequestExecutor.cs(409,0): at Raven.Client.Http.RequestExecutor.<ExecuteAsync>d__40`1.MoveNext()
        --- End of stack trace from previous location where exception was thrown ---
           at System.Runtime.ExceptionServices.ExceptionDispatchInfo.Throw()
           at System.Runtime.CompilerServices.TaskAwaiter.HandleNonSuccessAndDebuggerNotification(Task task)
           at System.Runtime.CompilerServices.ConfiguredTaskAwaitable.ConfiguredTaskAwaiter.GetResult()
        C:\work\ravendb\src\Raven.Client\Http\RequestExecutor.cs(233,0): at Raven.Client.Http.RequestExecutor.<UnlikelyExecuteAsync>d__35`1.MoveNext()
        --- End of stack trace from previous location where exception was thrown ---
           at System.Runtime.ExceptionServices.ExceptionDispatchInfo.Throw()
           at System.Runtime.CompilerServices.TaskAwaiter.HandleNonSuccessAndDebuggerNotification(Task task)
           at System.Runtime.CompilerServices.ConfiguredTaskAwaitable.ConfiguredTaskAwaiter.GetResult()
        C:\work\ravendb\src\Raven.Client\Http\RequestExecutor.cs(201,0): at Raven.Client.Http.RequestExecutor.<ExecuteAsync>d__34`1.MoveNext()
        --- End of stack trace from previous location where exception was thrown ---
           at System.Runtime.ExceptionServices.ExceptionDispatchInfo.Throw()
           at System.Runtime.CompilerServices.TaskAwaiter.HandleNonSuccessAndDebuggerNotification(Task task)
           at System.Runtime.CompilerServices.ConfiguredTaskAwaitable.ConfiguredTaskAwaiter.GetResult()
        C:\work\ravendb\src\Raven.Client\Documents\Operations\AdminOperationExecutor.cs(63,0): at Raven.Client.Documents.Operations.AdminOperationExecutor.<SendAsync>d__13`1.MoveNext()
        --- End of stack trace from previous location where exception was thrown ---
           at System.Runtime.ExceptionServices.ExceptionDispatchInfo.Throw()
           at System.Runtime.CompilerServices.TaskAwaiter.HandleNonSuccessAndDebuggerNotification(Task task)
           at System.Runtime.CompilerServices.ConfiguredTaskAwaitable`1.ConfiguredTaskAwaiter.GetResult()
        C:\work\ravendb\src\Raven.Client\Util\AsyncHelpers.cs(74,0): at Raven.Client.Util.AsyncHelpers.<>c__DisplayClass1_1`1.<<RunSync>b__0>d.MoveNext()
        --- End of stack trace from previous location where exception was thrown ---
           at System.Runtime.ExceptionServices.ExceptionDispatchInfo.Throw()
        C:\work\ravendb\src\Raven.Client\Util\AsyncHelpers.cs(89,0): at Raven.Client.Util.AsyncHelpers.RunSync[T](Func`1 task)
        C:\work\ravendb\src\Raven.Client\Documents\Operations\AdminOperationExecutor.cs(43,0): at Raven.Client.Documents.Operations.AdminOperationExecutor.Send[TResult](IAdminOperation`1 operation)
        C:\work\ravendb\test\FastTests\Client\Queries\FullTextSearch.cs(298,0): at FastTests.Client.Queries.FullTextSearchOnTags.BoostingSearches()
        ----- Inner Stack Trace -----