### PR TITLE
RavenDB-7560 Catching ObjectDisposedExceptions in finalizers of objec…

### DIFF
--- a/src/Raven.Client/Documents/Session/InMemoryDocumentSessionOperations.cs
+++ b/src/Raven.Client/Documents/Session/InMemoryDocumentSessionOperations.cs
@@ -1004,7 +1004,13 @@ more responsive application.
 
         ~InMemoryDocumentSessionOperations()
         {
-            Dispose(false);
+            try
+            {
+                Dispose(false);
+            }
+            catch (ObjectDisposedException)
+            {
+            }
 
 #if DEBUG
             Debug.WriteLine("Disposing a session for finalizer! It should be disposed by calling session.Dispose()!");

--- a/src/Raven.Client/Http/HttpCache.cs
+++ b/src/Raven.Client/Http/HttpCache.cs
@@ -70,7 +70,13 @@ namespace Raven.Client.Http
 
             ~HttpCacheItem()
             {
-                Release();
+                try
+                {
+                    Release();
+                }
+                catch (ObjectDisposedException)
+                {
+                }
             }
 
         }

--- a/src/Sparrow/ByteString.cs
+++ b/src/Sparrow/ByteString.cs
@@ -390,7 +390,13 @@ namespace Sparrow
 
         ~UnmanagedGlobalSegment()
         {
-            Dispose();
+            try
+            {
+                Dispose();
+            }
+            catch (ObjectDisposedException)
+            {
+            }
         }
 
         public override void Dispose()
@@ -1460,7 +1466,13 @@ namespace Sparrow
         ~ByteStringContext()
         {
             _isFinalizerThread = true;
-            Dispose();
+            try
+            {
+                Dispose();
+            }
+            catch (ObjectDisposedException)
+            {
+            }
         }
 
         public void Dispose()

--- a/src/Sparrow/Json/ArenaMemoryAllocator.cs
+++ b/src/Sparrow/Json/ArenaMemoryAllocator.cs
@@ -251,7 +251,13 @@ namespace Sparrow.Json
 
         ~ArenaMemoryAllocator()
         {
-            Dispose();
+            try
+            {
+                Dispose();
+            }
+            catch (ObjectDisposedException)
+            {
+            }
         }
 
         public override string ToString()

--- a/src/Sparrow/Json/JsonContextPoolBase.cs
+++ b/src/Sparrow/Json/JsonContextPoolBase.cs
@@ -24,7 +24,13 @@ namespace Sparrow.Json
         {
             ~ContextStack()
             {
-                Dispose();
+                try
+                {
+                    Dispose();
+                }
+                catch (ObjectDisposedException)
+                {
+                }
             }
 
             public void Dispose()

--- a/src/Sparrow/Json/UnmanagedBuffersPool.cs
+++ b/src/Sparrow/Json/UnmanagedBuffersPool.cs
@@ -90,7 +90,13 @@ namespace Sparrow.Json
                     _log.Operations($"UnmanagedBuffersPool for {_debugTag} wasn't properly disposed");
             }
 
-            Dispose();
+            try
+            {
+                Dispose();
+            }
+            catch (ObjectDisposedException)
+            {
+            }
         }
 
         public void Dispose()

--- a/src/Voron/Impl/EncryptionBuffersPool.cs
+++ b/src/Voron/Impl/EncryptionBuffersPool.cs
@@ -98,7 +98,13 @@ namespace Voron.Impl
 
         ~EncryptionBuffersPool()
         {
-            Dispose();
+            try
+            {
+                Dispose();
+            }
+            catch (ObjectDisposedException)
+            {
+            }
         }
     }
 }

--- a/src/Voron/Platform/Win32/Win32JournalWriter.cs
+++ b/src/Voron/Platform/Win32/Win32JournalWriter.cs
@@ -233,7 +233,13 @@ namespace Voron.Platform.Win32
 
         ~Win32FileJournalWriter()
         {
-            Dispose();
+            try
+            {
+                Dispose();
+            }
+            catch (ObjectDisposedException)
+            {
+            }
 
 #if DEBUG
             Debug.WriteLine(


### PR DESCRIPTION
…ts which might free native memory - that can happen only during a shutdown when the static instance NativeMemory.ThreadAllocations gets finalized