### PR TITLE
RavenDB-7566 - prevent replication of attachments during ETL replication

### DIFF
--- a/Raven.Database/Bundles/Replication/Tasks/ReplicationTask.cs
+++ b/Raven.Database/Bundles/Replication/Tasks/ReplicationTask.cs
@@ -858,16 +858,19 @@ namespace Raven.Bundles.Replication.Tasks
 
                     using (var scope = stats.StartRecording("Attachments"))
                     {
-                        switch (ReplicateAttachments(destination,
-                            destinationsReplicationInformationForSource,
-                            scope,
-                            out lastAttachmentEtag))
+                        if (destination.IsETL == false)
                         {
-                            case true:
-                                replicated = true;
-                                break;
-                            case false:
-                                return false;
+                            switch (ReplicateAttachments(destination,
+                                destinationsReplicationInformationForSource,
+                                scope,
+                                out lastAttachmentEtag))
+                            {
+                                case true:
+                                    replicated = true;
+                                    break;
+                                case false:
+                                    return false;
+                            }
                         }
                     }
 


### PR DESCRIPTION
http://issues.hibernatingrhinos.com/issue/RavenDB-7566