### PR TITLE
RavenDB-7503 **Partial**

### DIFF
--- a/src/Raven.Client/Server/Operations/ApiKeys/ApiKeyDefinition.cs
+++ b/src/Raven.Client/Server/Operations/ApiKeys/ApiKeyDefinition.cs
@@ -11,7 +11,7 @@ namespace Raven.Client.Server.Operations.ApiKeys
         public bool ServerAdmin;
         public Dictionary<string, AccessModes> ResourcesAccessMode = new Dictionary<string, AccessModes>(StringComparer.OrdinalIgnoreCase);
 
-        internal virtual DynamicJsonValue ToJson()
+        public virtual DynamicJsonValue ToJson()
         {
             var ram = new DynamicJsonValue();
             foreach (var kvp in ResourcesAccessMode)
@@ -41,7 +41,7 @@ namespace Raven.Client.Server.Operations.ApiKeys
     {
         public string UserName;
 
-        internal override DynamicJsonValue ToJson()
+        public override DynamicJsonValue ToJson()
         {
             var djv = base.ToJson();
             djv[nameof(UserName)] = UserName;

--- a/src/Raven.Server/Documents/DocumentDatabase.cs
+++ b/src/Raven.Server/Documents/DocumentDatabase.cs
@@ -95,7 +95,7 @@ namespace Raven.Server.Documents
                 using (_serverStore.ContextPool.AllocateOperationContext(out TransactionOperationContext ctx))
                 using (ctx.OpenReadTransaction())
                 {
-                    MasterKey = _serverStore.GetSecretKey(ctx, Name);
+                    MasterKey = ServerStore.GetSecretKey(ctx, Name);
 
                     var databaseRecord = _serverStore.Cluster.ReadDatabase(ctx, Name);
                     if (databaseRecord != null)

--- a/src/Raven.Server/Routing/RequestRouter.cs
+++ b/src/Raven.Server/Routing/RequestRouter.cs
@@ -21,6 +21,7 @@ using Microsoft.Extensions.Primitives;
 using Raven.Client;
 using Raven.Client.Exceptions.Security;
 using Raven.Client.Server.Operations.ApiKeys;
+using Raven.Server.ServerWide;
 using Raven.Server.ServerWide.Context;
 using Raven.Server.Utils;
 using Raven.Server.Web;
@@ -270,7 +271,9 @@ namespace Raven.Server.Routing
                         {
                             try
                             {
-                                publicKey = ravenServer.ServerStore.GetSecretKey(txContext, $"Raven/Sign/Public/{tag}");
+                                //If we are not a part of a cluster we won't have our public key in the topology so we will try to validate agaist our own public key
+                                var key = (tag == ravenServer.ServerStore.NodeTag || ravenServer.ServerStore.NodeTag == "?") ? "Raven/Sign/Public" : $"Raven/Sign/Public/{tag}";
+                                publicKey = ServerStore.GetSecretKey(txContext, key);
                             }
                             catch
                             {

--- a/src/Raven.Server/ServerWide/ServerStore.cs
+++ b/src/Raven.Server/ServerWide/ServerStore.cs
@@ -462,7 +462,7 @@ namespace Raven.Server.ServerWide
 
         }
 
-        private bool TryLoadAuthenticationKeyPairs(TransactionOperationContext ctx)
+        private unsafe bool TryLoadAuthenticationKeyPairs(TransactionOperationContext ctx)
         {
             using (ctx.OpenReadTransaction())
             {
@@ -470,7 +470,7 @@ namespace Raven.Server.ServerWide
                 SignSecretKey = GetSecretKey(ctx, "Raven/Sign/Private");
             }
 
-            return BoxPublicKey != null && BoxSecretKey != null && SignPublicKey != null && SignSecretKey != null;
+            return SignPublicKey != null && SignSecretKey != null;
         }
 
         private void OnStateChanged(object sender, RachisConsensus.StateTransition state)
@@ -673,7 +673,7 @@ namespace Raven.Server.ServerWide
         }
 
 
-        public unsafe byte[] GetSecretKey(TransactionOperationContext context, string name)
+        public static unsafe byte[] GetSecretKey(TransactionOperationContext context, string name)
         {
             Debug.Assert(context.Transaction != null);
 

--- a/src/Raven.Server/Web/Authentication/SignedTokenGenerator.cs
+++ b/src/Raven.Server/Web/Authentication/SignedTokenGenerator.cs
@@ -20,11 +20,12 @@ namespace Raven.Server.Web.Authentication
             byte[] signSecretKey,
             string apiKeyName,
             string nodeTag,
-            out DateTime expires)
+            out DateTime expires,
+            bool longDuration = false)
         {
             if (_signatureBuffer == null)
                 _signatureBuffer = new byte[Sodium.crypto_sign_bytes()];
-            expires = DateTime.UtcNow.AddMinutes(30);
+            expires = longDuration? DateTime.UtcNow.AddDays(1): DateTime.UtcNow.AddMinutes(30);
 
             var ms = new MemoryStream();
             using (var writer = new BlittableJsonTextWriter(context, ms))


### PR DESCRIPTION
Fixed an issue where we generate new sign keys everytime we restart the Server/Operations/ApiKeys/ApiKeyDefinition.cs
Externalized some of the sodium keys method so RVN tool can use it.
Will try validating oauth tokens against our own public key in case our node tag is unknown ("?")

The work on RVN is not completed need to clean up the code.