### PR TITLE
RavenDB-7658

### DIFF
--- a/Rachis/Rachis/Behaviors/LeaderStateBehavior.cs
+++ b/Rachis/Rachis/Behaviors/LeaderStateBehavior.cs
@@ -534,6 +534,13 @@ namespace Rachis.Behaviors
         /// </summary>
         protected long GetMaxIndexOnQuorum()
         {
+            //this was moved to internal method so we could extract statistics about the followers
+            return GetMaxIndexOnQuorumInternal().MaxQuorumIndex;
+        }
+
+        public FollowerLastSentEntries GetMaxIndexOnQuorumInternal()
+        {
+            FollowerLastSentEntries fs = new FollowerLastSentEntries(_matchIndexes);
             var topology = Engine.CurrentTopology;
             var dic = new Dictionary<long, int>();
             foreach (var index in _matchIndexes)
@@ -552,10 +559,13 @@ namespace Rachis.Behaviors
                 var confirmationsForThisIndex = source.Value + boost;
                 boost += source.Value;
                 if (confirmationsForThisIndex >= topology.QuorumSize)
-                    return source.Key;
+                {
+                    fs.MaxQuorumIndex = source.Key;
+                    return fs;
+                }
             }
-
-            return -1;
+            fs.MaxQuorumIndex = -1;
+            return fs;
         }
 
         public void AppendCommand(Command command)

--- a/Rachis/Rachis/RaftEngine.cs
+++ b/Rachis/Rachis/RaftEngine.cs
@@ -496,11 +496,9 @@ namespace Rachis
             }
         }
 
-        public Topology CurrentTopology
-        {
-            get { return _currentTopology; }
-        }
+        public Topology CurrentTopology => _currentTopology;
 
+        public Topology PersistentStateCurrentTopology => PersistentState.GetCurrentTopology();
 
         internal bool LogIsUpToDate(long lastLogTerm, long lastLogIndex)
         {
@@ -998,6 +996,11 @@ namespace Rachis
             steppingDownCompletionSource.TrySetResult(null);
         }
 
+        public FollowerLastSentEntries GetFollowerStatistics()
+        {
+            var leader = StateBehavior as LeaderStateBehavior;
+            return leader?.GetMaxIndexOnQuorumInternal();
+        }
     }
 
     public class ProposingCandidacyResult : EventArgs

--- a/Rachis/Rachis/RaftEngineStatistics.cs
+++ b/Rachis/Rachis/RaftEngineStatistics.cs
@@ -30,8 +30,11 @@ namespace Rachis
             Messages = new ConcurrentQueue<MessageWithTimingInformation>();
             Elections = new ConcurrentQueue<ElectionInformation>();
             CommitTimes = new ConcurrentQueue<CommitInformation>();
-            CurrenTopology = engine.CurrentTopology;
         }
+
+        public LogEntry LastLogEntry { get; set; }
+
+        public long CommitIndex { get; set; }
         private ConcurrentDictionary<long, DateTime> IndexesToAppendTimes = new ConcurrentDictionary<long, DateTime>(); 
         public ConcurrentQueue<TimeoutInformation> TimeOuts { get; }
         public ConcurrentQueue<ElectionInformation> Elections { get; } 
@@ -40,7 +43,7 @@ namespace Rachis
         public ElectionInformation LastElectionInformation => Elections.LastOrDefault();
         public ConcurrentQueue<CommitInformation> CommitTimes { get; } 
 
-        public Topology CurrenTopology { get; private set; }
+        public Topology CurrenTopology { get; set; }
 
         public string Name { get; set; }
 
@@ -51,7 +54,9 @@ namespace Rachis
         public int HeartbeatTimeout { get; set; }
 
         public int ElectionTimeout { get; set; }
-
+        public string CurrentLeader { get; set; }
+        public long CurrentTerm { get; set; }
+        public FollowerLastSentEntries FollowersStatistics = null;
         public void ReportIndexAppend(long index)
         {
             IndexesToAppendTimes[index] = DateTime.UtcNow;
@@ -66,6 +71,16 @@ namespace Rachis
                 ,NumberOfCommitsToTrack);
             }            
         }
+    }
+
+    public class FollowerLastSentEntries
+    {
+        public FollowerLastSentEntries(ConcurrentDictionary<string, long> f2e)
+        {
+            FollowersToLastSent = f2e;
+        }
+        public readonly ConcurrentDictionary<string,long> FollowersToLastSent;
+        public long MaxQuorumIndex { get; set; }
     }
 
     public class TimeoutInformation

--- a/Raven.Database/Raft/Controllers/ClusterAdminController.cs
+++ b/Raven.Database/Raft/Controllers/ClusterAdminController.cs
@@ -135,7 +135,7 @@ namespace Raven.Database.Raft.Controllers
             nodeConnectionInfo.Name = ClusterManager.Engine.Name;
 
             ClusterManager.InitializeTopology(nodeConnectionInfo);
-
+            ClusterManager.Engine.WaitForLeader();
             return GetEmptyMessage(HttpStatusCode.Created);
         }
 

--- a/Raven.Database/Server/Controllers/Admin/AdminController.cs
+++ b/Raven.Database/Server/Controllers/Admin/AdminController.cs
@@ -24,7 +24,7 @@ using Raven.Database.Config;
 using System.Net.Http;
 using System.Security.Cryptography;
 using System.Text;
-
+using Rachis;
 using Raven.Abstractions.Smuggler;
 using Raven.Client.Document;
 using Raven.Database.DiskIO;
@@ -82,6 +82,13 @@ namespace Raven.Database.Server.Controllers.Admin
         [RavenRoute("admin/cluster-statistics")]
         public HttpResponseMessage GetClusterStatistics()
         {
+            var statistics = ClusterManager.Engine.EngineStatistics;
+            statistics.CurrenTopology = ClusterManager.Engine.PersistentStateCurrentTopology;
+            statistics.CommitIndex = ClusterManager.Engine.CommitIndex;
+            statistics.CurrentTerm = ClusterManager.Engine.PersistentState.CurrentTerm;
+            statistics.LastLogEntry = ClusterManager.Engine.PersistentState.LastLogEntry();
+            statistics.CurrentLeader = ClusterManager.Engine.CurrentLeader;
+            statistics.FollowersStatistics = ClusterManager.Engine.GetFollowerStatistics();
             return GetMessageWithObject(ClusterManager.Engine.EngineStatistics);
         }
 


### PR DESCRIPTION
GetMaxIndexOnQuorum is now calling GetMaxIndexOnQuorumInternal that exposes the last entries to the statistics
Added Engine.PersistentStateCurrentTopology to force fetch the topology from the PersistentState since it always shows as null in the statistics
Added Last log entry and last commit index to the statistics
Added follower statistics so we know what was sent to each follower
Now waiting to become a leader when creating a cluster (i think this is the annoying race condition that will cause us not to have a leader when creating cluster from the studio)