### PR TITLE
RavenDB-7609

### DIFF
--- a/src/Raven.Client/Documents/Commands/QueryCommand.cs
+++ b/src/Raven.Client/Documents/Commands/QueryCommand.cs
@@ -98,7 +98,7 @@ namespace Raven.Client.Documents.Commands
             Result = JsonDeserializationClient.QueryResult(response);
 
             if (fromCache)
-                Result.DurationMilliseconds = -1;
+                Result.DurationInMs = -1;
         }
 
         public override bool IsReadRequest => true;

--- a/src/Raven.Client/Documents/Indexes/IndexingPerformanceOperation.cs
+++ b/src/Raven.Client/Documents/Indexes/IndexingPerformanceOperation.cs
@@ -11,13 +11,13 @@ namespace Raven.Client.Documents.Indexes
 
         public IndexingPerformanceOperation(TimeSpan duration)
         {
-            DurationInMilliseconds = Math.Round(duration.TotalMilliseconds, 2);
+            DurationInMs = Math.Round(duration.TotalMilliseconds, 2);
             Operations = new IndexingPerformanceOperation[0];
         }
 
         public string Name { get; set; }
 
-        public double DurationInMilliseconds { get; }
+        public double DurationInMs { get; }
 
         public ReduceRunDetails ReduceDetails { get; set; }
 

--- a/src/Raven.Client/Documents/Indexes/IndexingPerformanceStats.cs
+++ b/src/Raven.Client/Documents/Indexes/IndexingPerformanceStats.cs
@@ -30,7 +30,7 @@ namespace Raven.Client.Documents.Indexes
 
         public IndexingPerformanceBasicStats(TimeSpan duration)
         {
-            DurationInMilliseconds = Math.Round(duration.TotalMilliseconds, 2);
+            DurationInMs = Math.Round(duration.TotalMilliseconds, 2);
         }
 
         public int InputCount { get; set; }
@@ -43,6 +43,6 @@ namespace Raven.Client.Documents.Indexes
 
         public DateTime Started { get; set; }
 
-        public double DurationInMilliseconds { get; }
+        public double DurationInMs { get; }
     }
 }

--- a/src/Raven.Client/Documents/Queries/MoreLikeThis/MoreLikeThisQueryResult.cs
+++ b/src/Raven.Client/Documents/Queries/MoreLikeThis/MoreLikeThisQueryResult.cs
@@ -11,6 +11,6 @@ namespace Raven.Client.Documents.Queries.MoreLikeThis
         /// <summary>
         /// The duration of actually executing the query server side
         /// </summary>
-        public long DurationMilliseconds { get; set; }
+        public long DurationInMs { get; set; }
     }
 }

--- a/src/Raven.Client/Documents/Queries/QueryResult.cs
+++ b/src/Raven.Client/Documents/Queries/QueryResult.cs
@@ -33,7 +33,7 @@ namespace Raven.Client.Documents.Queries
         /// <summary>
         /// The duration of actually executing the query server side
         /// </summary>
-        public long DurationMilliseconds { get; set; }
+        public long DurationInMs { get; set; }
 
         /// <summary>
         /// Explanations of document scores (if requested).
@@ -43,7 +43,7 @@ namespace Raven.Client.Documents.Queries
         /// <summary>
         /// Detailed timings for various parts of a query (Lucene search, loading documents, transforming results) - if requested.
         /// </summary>
-        public Dictionary<string, double> TimingsInMilliseconds { get; set; }
+        public Dictionary<string, double> TimingsInMs { get; set; }
 
         /// <summary>
         /// The size of the request which were sent from the server.
@@ -87,9 +87,9 @@ namespace Raven.Client.Documents.Queries
                     pair => pair.Key,
                     x => new Dictionary<string, string[]>(x.Value)),
                 ScoreExplanations = ScoreExplanations?.ToDictionary(x => x.Key, x => x.Value),
-                TimingsInMilliseconds = TimingsInMilliseconds?.ToDictionary(x => x.Key, x => x.Value),
+                TimingsInMs = TimingsInMs?.ToDictionary(x => x.Key, x => x.Value),
                 LastQueryTime = LastQueryTime,
-                DurationMilliseconds = DurationMilliseconds,
+                DurationInMs = DurationInMs,
                 ResultEtag = ResultEtag
             };
         }

--- a/src/Raven.Client/Documents/Replication/OutgoingReplicationPerformanceStats.cs
+++ b/src/Raven.Client/Documents/Replication/OutgoingReplicationPerformanceStats.cs
@@ -55,14 +55,14 @@ namespace Raven.Client.Documents.Replication
 
         protected ReplicationPerformanceBase(TimeSpan duration)
         {
-            DurationInMilliseconds = Math.Round(duration.TotalMilliseconds, 2);
+            DurationInMs = Math.Round(duration.TotalMilliseconds, 2);
         }
 
         public int Id { get; set; }
 
         public DateTime Started { get; set; }
 
-        public double DurationInMilliseconds { get; set; }
+        public double DurationInMs { get; set; }
 
         public DateTime? Completed { get; set; }
 

--- a/src/Raven.Client/Documents/Replication/ReplicationPerformanceOperation.cs
+++ b/src/Raven.Client/Documents/Replication/ReplicationPerformanceOperation.cs
@@ -11,13 +11,13 @@ namespace Raven.Client.Documents.Replication
 
         public ReplicationPerformanceOperation(TimeSpan duration)
         {
-            DurationInMilliseconds = Math.Round(duration.TotalMilliseconds, 2);
+            DurationInMs = Math.Round(duration.TotalMilliseconds, 2);
             Operations = new ReplicationPerformanceOperation[0];
         }
 
         public string Name { get; set; }
 
-        public double DurationInMilliseconds { get; }
+        public double DurationInMs { get; }
 
         public ReplicationPerformanceOperation[] Operations { get; set; }
     }

--- a/src/Raven.Client/Documents/Session/QueryStatistics.cs
+++ b/src/Raven.Client/Documents/Session/QueryStatistics.cs
@@ -18,7 +18,7 @@ namespace Raven.Client.Documents.Session
     {
         public QueryStatistics()
         {
-            TimingsInMilliseconds = new Dictionary<string, double>();
+            TimingsInMs = new Dictionary<string, double>();
         }
 
         /// <summary>
@@ -29,7 +29,7 @@ namespace Raven.Client.Documents.Session
         /// <summary>
         /// The duration of the query _server side_
         /// </summary>
-        public long DurationMilliseconds { get; set; }
+        public long DurationInMs { get; set; }
 
         /// <summary>
         /// What was the total count of the results that matched the query
@@ -64,9 +64,7 @@ namespace Raven.Client.Documents.Session
         /// <summary>
         /// Detailed timings for various parts of a query (Lucene search, loading documents, transforming results)
         /// </summary>
-        public Dictionary<string, double> TimingsInMilliseconds { get; set; }
-
-
+        public Dictionary<string, double> TimingsInMs { get; set; }
 
         public long? ResultEtag { get; set; }
 
@@ -82,13 +80,13 @@ namespace Raven.Client.Documents.Session
         internal void UpdateQueryStats(QueryResult qr)
         {
             IsStale = qr.IsStale;
-            DurationMilliseconds = qr.DurationMilliseconds;
+            DurationInMs = qr.DurationInMs;
             TotalResults = qr.TotalResults;
             SkippedResults = qr.SkippedResults;
             Timestamp = qr.IndexTimestamp;
             IndexName = qr.IndexName;
             IndexTimestamp = qr.IndexTimestamp;
-            TimingsInMilliseconds = qr.TimingsInMilliseconds;
+            TimingsInMs = qr.TimingsInMs;
             LastQueryTime = qr.LastQueryTime;
             ResultSize = qr.ResultSize;
             ResultEtag = qr.ResultEtag;

--- a/src/Raven.Client/Http/TopologySla.cs
+++ b/src/Raven.Client/Http/TopologySla.cs
@@ -1,7 +1,0 @@
-namespace Raven.Client.Http
-{
-    public class TopologySla
-    {
-        public int RequestTimeThresholdInMilliseconds;
-    }
-}

--- a/src/Raven.Client/Server/Expiration/ExpirationConfiguration.cs
+++ b/src/Raven.Client/Server/Expiration/ExpirationConfiguration.cs
@@ -4,13 +4,13 @@ namespace Raven.Client.Server.Expiration
     {
         public bool Active { get; set; }
 
-        public long? DeleteFrequencySeconds { get; set; }
+        public long? DeleteFrequencyInSec { get; set; }
 
         public override int GetHashCode()
         {
             unchecked
             {
-                return (Active.GetHashCode() * 397) ^ DeleteFrequencySeconds.GetHashCode();
+                return (Active.GetHashCode() * 397) ^ DeleteFrequencyInSec.GetHashCode();
             }
         }
 
@@ -24,7 +24,7 @@ namespace Raven.Client.Server.Expiration
 
         protected bool Equals(ExpirationConfiguration other)
         {
-            return Active == other.Active && DeleteFrequencySeconds == other.DeleteFrequencySeconds;
+            return Active == other.Active && DeleteFrequencyInSec == other.DeleteFrequencyInSec;
         }
     }
 }

--- a/src/Raven.Client/Server/Operations/DatabasesInfo.cs
+++ b/src/Raven.Client/Server/Operations/DatabasesInfo.cs
@@ -15,14 +15,15 @@ namespace Raven.Client.Server.Operations
     public class BackupInfo : IDynamicJson
     {
         public DateTime? LastBackup { get; set; }
-        public int IntervalUntilNextBackupInSeconds { get; set; }
+
+        public int IntervalUntilNextBackupInSec { get; set; }
 
         public DynamicJsonValue ToJson()
         {
             return new DynamicJsonValue
             {
                 [nameof(LastBackup)] = LastBackup,
-                [nameof(IntervalUntilNextBackupInSeconds)] = IntervalUntilNextBackupInSeconds
+                [nameof(IntervalUntilNextBackupInSec)] = IntervalUntilNextBackupInSec
             };
         }
     }
@@ -34,7 +35,7 @@ namespace Raven.Client.Server.Operations
         public Size TotalSize { get; set; }
 
         public bool IsAdmin { get; set; }
-        public TimeSpan? UpTime { get; set; } 
+        public TimeSpan? UpTime { get; set; }
         public BackupInfo BackupInfo { get; set; }
 
         public long? Alerts { get; set; }

--- a/src/Raven.Server/Config/Categories/BulkInsertConfiguration.cs
+++ b/src/Raven.Server/Config/Categories/BulkInsertConfiguration.cs
@@ -1,15 +1,6 @@
-using System.ComponentModel;
-using Raven.Server.Config.Attributes;
-using Raven.Server.Config.Settings;
-
 namespace Raven.Server.Config.Categories
 {
     public class BulkInsertConfiguration : ConfigurationCategory
     {
-        [DefaultValue(60000)]
-        [TimeUnit(TimeUnit.Milliseconds)]
-        [ConfigurationEntry("Raven/BulkImport/BatchTimeoutInMs")]
-        [LegacyConfigurationEntry("Raven/BulkImport/BatchTimeout")]
-        public TimeSetting ImportBatchTimeout { get; set; }
     }
 }

--- a/src/Raven.Server/Config/Categories/DebugLoggingConfiguration.cs
+++ b/src/Raven.Server/Config/Categories/DebugLoggingConfiguration.cs
@@ -17,7 +17,7 @@ namespace Raven.Server.Config.Categories
 
         [DefaultValue(3)]
         [TimeUnit(TimeUnit.Days)]
-        [ConfigurationEntry("Raven/DebugLog/RetentionTime")]
+        [ConfigurationEntry("Raven/DebugLog/RetentionTimeInDays")]
         public TimeSetting RetentionTime { get; set; }
 
     }

--- a/src/Raven.Server/Config/Categories/ExpirationConfiguration.cs
+++ b/src/Raven.Server/Config/Categories/ExpirationConfiguration.cs
@@ -9,7 +9,6 @@ namespace Raven.Server.Config.Categories
         [DefaultValue(300)]
         [TimeUnit(TimeUnit.Seconds)]
         [ConfigurationEntry("Raven/Expiration/DeleteFrequencyInSec")]
-        [LegacyConfigurationEntry("Raven/Expiration/DeleteFrequencySeconds")]
         public TimeSetting DeleteFrequency { get; set; }
     }
 }

--- a/src/Raven.Server/Config/Categories/ReplicationConfiguration.cs
+++ b/src/Raven.Server/Config/Categories/ReplicationConfiguration.cs
@@ -9,7 +9,7 @@ namespace Raven.Server.Config.Categories
         [Description("Threshold under which an incoming replication connection is considered active. If an incoming connection receives messages within this time-span, new connection coming from the same source would be rejected (as the existing connection is considered active)")]
         [DefaultValue(30)]
         [TimeUnit(TimeUnit.Seconds)]
-        [ConfigurationEntry("Raven/Replication/ActiveConnectionTimeout")]
+        [ConfigurationEntry("Raven/Replication/ActiveConnectionTimeoutInSec")]
         public TimeSetting ActiveConnectionTimeout { get; set; }
         
         [Description("Number of seconds after which replication will stop reading documents from disk")]
@@ -17,7 +17,7 @@ namespace Raven.Server.Config.Categories
         [TimeUnit(TimeUnit.Seconds)]
         [ConfigurationEntry("Raven/Replication/FetchingFromDiskTimeoutInSec")]
         [LegacyConfigurationEntry("Raven/Replication/FetchingFromDiskTimeout")]
-        public TimeSetting FetchingFromDiskTimeoutInSeconds { get; set; }
+        public TimeSetting FetchingFromDiskTimeout { get; set; }
 
         [Description("Number of milliseconds before replication requests will timeout")]
         [DefaultValue(60 * 1000)]
@@ -27,9 +27,9 @@ namespace Raven.Server.Config.Categories
         public TimeSetting ReplicationRequestTimeout { get; set; }
 
         [Description("Minimal time in milliseconds before sending another heartbeat")]
-        [DefaultValue(15 * 1000)]
-        [TimeUnit(TimeUnit.Milliseconds)]
-        [ConfigurationEntry("Raven/Replication/ReplicationMinimalHeartbeat")]
+        [DefaultValue(15)]
+        [TimeUnit(TimeUnit.Seconds)]
+        [ConfigurationEntry("Raven/Replication/ReplicationMinimalHeartbeatInSec")]
         public TimeSetting ReplicationMinimalHeartbeat { get; set; }
 
         [Description("Number of seconds before replication topology discovery requests will timeout")]

--- a/src/Raven.Server/Config/Categories/StorageConfiguration.cs
+++ b/src/Raven.Server/Config/Categories/StorageConfiguration.cs
@@ -72,24 +72,24 @@ namespace Raven.Server.Config.Categories
         [Description("How long transaction mode (Danger/Lazy) last before returning to Safe mode. Value in Minutes. Default one day. Zero for infinite time")]
         [DefaultValue(1440)]
         [TimeUnit(TimeUnit.Minutes)]
-        [ConfigurationEntry("Raven/Storage/TransactionsModeDuration")]
-        [LegacyConfigurationEntry("Raven/TransactionsModeDuration")]
-        public int TransactionsModeDuration { get; set; }
+        [ConfigurationEntry("Raven/Storage/TransactionsModeDurationInMin")]
+        public TimeSetting TransactionsModeDuration { get; set; }
 
         [Description("Maximum concurrent flushes")]
         [DefaultValue(10)]
         [ConfigurationEntry("Raven/Storage/MaxConcurrentFlushes")]
         public int MaxConcurrentFlushes { get; set; }
 
-        [Description("Time To Sync After Flash In Seconds")]
+        [Description("Time to sync after flash in seconds")]
         [DefaultValue(30)]
-        [ConfigurationEntry("Raven/Storage/TimeToSyncAfterFlashInSeconds")]
-        public int TimeToSyncAfterFlashInSeconds { get; set; }
+        [TimeUnit(TimeUnit.Seconds)]
+        [ConfigurationEntry("Raven/Storage/TimeToSyncAfterFlashInSec")]
+        public TimeSetting TimeToSyncAfterFlash { get; set; }
 
-        [Description("Num Of Cocurrent Syncs Per Physical Drive")]
+        [Description("Number of concurrent syncs per physical drive")]
         [DefaultValue(3)]
         [ConfigurationEntry("Raven/Storage/NumOfConcurrentSyncsPerPhysicalDrive")]
-        public int NumOfCocurrentSyncsPerPhysDrive { get; set; }
+        public int NumOfConcurrentSyncsPerPhysDrive { get; set; }
 
         public override void Initialize(IConfigurationRoot settings, IConfigurationRoot serverWideSettings, ResourceType type, string resourceName)
         {

--- a/src/Raven.Server/Config/Categories/TombstoneConfiguration.cs
+++ b/src/Raven.Server/Config/Categories/TombstoneConfiguration.cs
@@ -9,8 +9,8 @@ namespace Raven.Server.Config.Categories
     {
         [DefaultValue(5)]
         [TimeUnit(TimeUnit.Minutes)]
-        [ConfigurationEntry("Raven/Tombstones/Interval")]
+        [ConfigurationEntry("Raven/Tombstones/CleanupIntervalInMin")]
         [Description("Time (in minutes) between tombstone cleanups.")]
-        public TimeSetting Interval { get; set; }
+        public TimeSetting CleanupInterval { get; set; }
     }
 }

--- a/src/Raven.Server/Documents/ConfigurationStorage.cs
+++ b/src/Raven.Server/Documents/ConfigurationStorage.cs
@@ -30,8 +30,8 @@ namespace Raven.Server.Documents
 
             options.SchemaVersion = 1;
             options.ForceUsing32BitsPager = db.Configuration.Storage.ForceUsing32BitsPager;
-            options.TimeToSyncAfterFlashInSeconds = db.Configuration.Storage.TimeToSyncAfterFlashInSeconds;
-            options.NumOfConcurrentSyncsPerPhysDrive = db.Configuration.Storage.NumOfCocurrentSyncsPerPhysDrive;
+            options.TimeToSyncAfterFlashInSec = (int)db.Configuration.Storage.TimeToSyncAfterFlash.AsTimeSpan.TotalSeconds;
+            options.NumOfConcurrentSyncsPerPhysDrive = db.Configuration.Storage.NumOfConcurrentSyncsPerPhysDrive;
             Sodium.CloneKey(out options.MasterKey, db.MasterKey);
 
             Environment = new StorageEnvironment(options);

--- a/src/Raven.Server/Documents/DocumentTombstoneCleaner.cs
+++ b/src/Raven.Server/Documents/DocumentTombstoneCleaner.cs
@@ -52,7 +52,7 @@ namespace Raven.Server.Documents
 
         protected override async Task DoWork()
         {
-            await WaitOrThrowOperationCanceled(_documentDatabase.Configuration.Tombstones.Interval.AsTimeSpan);
+            await WaitOrThrowOperationCanceled(_documentDatabase.Configuration.Tombstones.CleanupInterval.AsTimeSpan);
 
             await ExecuteCleanup();
         }

--- a/src/Raven.Server/Documents/DocumentsStorage.cs
+++ b/src/Raven.Server/Documents/DocumentsStorage.cs
@@ -217,8 +217,8 @@ namespace Raven.Server.Documents
 
             options.GenerateNewDatabaseId = generateNewDatabaseId;
             options.ForceUsing32BitsPager = _documentDatabase.Configuration.Storage.ForceUsing32BitsPager;
-            options.TimeToSyncAfterFlashInSeconds = _documentDatabase.Configuration.Storage.TimeToSyncAfterFlashInSeconds;
-            options.NumOfConcurrentSyncsPerPhysDrive = _documentDatabase.Configuration.Storage.NumOfCocurrentSyncsPerPhysDrive;
+            options.TimeToSyncAfterFlashInSec = (int)_documentDatabase.Configuration.Storage.TimeToSyncAfterFlash.AsTimeSpan.TotalSeconds;
+            options.NumOfConcurrentSyncsPerPhysDrive = _documentDatabase.Configuration.Storage.NumOfConcurrentSyncsPerPhysDrive;
             Sodium.CloneKey(out options.MasterKey, _documentDatabase.MasterKey);
 
             try

--- a/src/Raven.Server/Documents/ETL/Providers/SQL/EtlPerformanceStats.cs
+++ b/src/Raven.Server/Documents/ETL/Providers/SQL/EtlPerformanceStats.cs
@@ -8,7 +8,7 @@ namespace Raven.Server.Documents.ETL.Providers.SQL
         public TimeSpan Duration { get; set; }
         public DateTime Started { get; set; }
 
-        public double DurationMilliseconds => Math.Round(Duration.TotalMilliseconds, 2);
+        public double DurationInMs => Math.Round(Duration.TotalMilliseconds, 2);
 
         public override string ToString()
         {

--- a/src/Raven.Server/Documents/ETL/Providers/SQL/RelationalWriters/RelationalDatabaseWriter.cs
+++ b/src/Raven.Server/Documents/ETL/Providers/SQL/RelationalWriters/RelationalDatabaseWriter.cs
@@ -32,7 +32,7 @@ namespace Raven.Server.Documents.ETL.Providers.SQL.RelationalWriters
 
         private readonly List<Func<DbParameter, string, bool>> _stringParserList;
 
-        private const int LongStatementWarnThresholdInMilliseconds = 3000;
+        private const int LongStatementWarnThresholdInMs = 3000;
 
         public RelationalDatabaseWriter(SqlEtl etl, DocumentDatabase database)
             : base(etl.Configuration.FactoryName)
@@ -212,7 +212,7 @@ namespace Raven.Server.Documents.ETL.Providers.SQL.RelationalWriters
                         var tableMetrics = _etl.SqlMetrics.GetTableMetrics(tableName);
                         tableMetrics.InsertActionsMeter.Mark(1);
 
-                        if (elapsedMilliseconds > LongStatementWarnThresholdInMilliseconds)
+                        if (elapsedMilliseconds > LongStatementWarnThresholdInMs)
                         {
                             HandleSlowSql(elapsedMilliseconds, stmt);
                         }
@@ -324,7 +324,7 @@ namespace Raven.Server.Documents.ETL.Providers.SQL.RelationalWriters
                         var tableMetrics = _etl.SqlMetrics.GetTableMetrics(tableName);
                         tableMetrics.DeleteActionsMeter.Mark(1);
 
-                        if (elapsedMiliseconds > LongStatementWarnThresholdInMilliseconds)
+                        if (elapsedMiliseconds > LongStatementWarnThresholdInMs)
                         {
                             HandleSlowSql(elapsedMiliseconds, stmt);
                         }

--- a/src/Raven.Server/Documents/ETL/Stats/EtlPerformanceOperation.cs
+++ b/src/Raven.Server/Documents/ETL/Stats/EtlPerformanceOperation.cs
@@ -6,13 +6,13 @@ namespace Raven.Server.Documents.ETL.Stats
     {
         public EtlPerformanceOperation(TimeSpan duration)
         {
-            DurationInMilliseconds = Math.Round(duration.TotalMilliseconds, 2);
+            DurationInMs = Math.Round(duration.TotalMilliseconds, 2);
             Operations = new EtlPerformanceOperation[0];
         }
 
         public string Name { get; set; }
 
-        public double DurationInMilliseconds { get; }
+        public double DurationInMs { get; }
 
         public EtlPerformanceOperation[] Operations { get; set; }
     }

--- a/src/Raven.Server/Documents/ETL/Stats/EtlPerformanceStats.cs
+++ b/src/Raven.Server/Documents/ETL/Stats/EtlPerformanceStats.cs
@@ -6,7 +6,7 @@ namespace Raven.Server.Documents.ETL.Stats
     {
         public EtlPerformanceStats(TimeSpan duration)
         {
-            DurationInMilliseconds = Math.Round(duration.TotalMilliseconds, 2);
+            DurationInMs = Math.Round(duration.TotalMilliseconds, 2);
         }
 
         public int Id { get; set; }
@@ -15,7 +15,7 @@ namespace Raven.Server.Documents.ETL.Stats
 
         public DateTime? Completed { get; set; }
 
-        public double DurationInMilliseconds { get; }
+        public double DurationInMs { get; }
 
         public EtlPerformanceOperation Details { get; set; }
 

--- a/src/Raven.Server/Documents/Expiration/ExpiredDocumentsCleaner.cs
+++ b/src/Raven.Server/Documents/Expiration/ExpiredDocumentsCleaner.cs
@@ -36,7 +36,7 @@ namespace Raven.Server.Documents.Expiration
             Configuration = configuration;
             _database = database;
 
-            var deleteFrequencyInSeconds = configuration.DeleteFrequencySeconds ?? 60;
+            var deleteFrequencyInSeconds = configuration.DeleteFrequencyInSec ?? 60;
             if (Logger.IsInfoEnabled)
                 Logger.Info($"Initialized expired document cleaner, will check for expired documents every {deleteFrequencyInSeconds} seconds");
 

--- a/src/Raven.Server/Documents/Handlers/Admin/TransactionsModeHandler.cs
+++ b/src/Raven.Server/Documents/Handlers/Admin/TransactionsModeHandler.cs
@@ -17,7 +17,7 @@ namespace Raven.Server.Documents.Handlers.Admin
             if (Enum.TryParse(modeStr, true, out mode) == false)
                 throw new InvalidOperationException("Query string value 'mode' is not a valid mode: " + modeStr);
 
-            var configDuration = TimeSpan.FromMinutes(Database.Configuration.Storage.TransactionsModeDuration);
+            var configDuration = Database.Configuration.Storage.TransactionsModeDuration.AsTimeSpan;
             var duration = GetTimeSpanQueryString("duration", required: false) ?? configDuration;
             JsonOperationContext context;
             using (ContextPool.AllocateOperationContext(out context))

--- a/src/Raven.Server/Documents/Handlers/QueriesHandler.cs
+++ b/src/Raven.Server/Documents/Handlers/QueriesHandler.cs
@@ -174,7 +174,7 @@ namespace Raven.Server.Documents.Handlers
                 writer.WriteDocumentQueryResult(context, result, metadataOnly, out numberOfResults);
             }
 
-            AddPagingPerformanceHint(PagingOperationType.Queries, $"{nameof(Query)} ({indexName})", HttpContext, numberOfResults, indexQuery.PageSize, TimeSpan.FromMilliseconds(result.DurationMilliseconds));
+            AddPagingPerformanceHint(PagingOperationType.Queries, $"{nameof(Query)} ({indexName})", HttpContext, numberOfResults, indexQuery.PageSize, TimeSpan.FromMilliseconds(result.DurationInMs));
         }
 
         private IndexQueryServerSide GetIndexQuery(DocumentsOperationContext context, HttpMethod method)
@@ -215,7 +215,7 @@ namespace Raven.Server.Documents.Handlers
                 writer.WriteMoreLikeThisQueryResult(context, result, out numberOfResults);
             }
 
-            AddPagingPerformanceHint(PagingOperationType.Queries, $"{nameof(MoreLikeThis)} ({indexName})", HttpContext, numberOfResults, query.PageSize, TimeSpan.FromMilliseconds(result.DurationMilliseconds));
+            AddPagingPerformanceHint(PagingOperationType.Queries, $"{nameof(MoreLikeThis)} ({indexName})", HttpContext, numberOfResults, query.PageSize, TimeSpan.FromMilliseconds(result.DurationInMs));
         }
 
         private void Explain(DocumentsOperationContext context, string indexName)

--- a/src/Raven.Server/Documents/Indexes/Index.cs
+++ b/src/Raven.Server/Documents/Indexes/Index.cs
@@ -191,8 +191,8 @@ namespace Raven.Server.Documents.Indexes
                 options.OnRecoveryError += documentDatabase.HandleOnRecoveryError;
                 options.SchemaVersion = 1;
                 options.ForceUsing32BitsPager = documentDatabase.Configuration.Storage.ForceUsing32BitsPager;
-                options.TimeToSyncAfterFlashInSeconds = documentDatabase.Configuration.Storage.TimeToSyncAfterFlashInSeconds;
-                options.NumOfConcurrentSyncsPerPhysDrive = documentDatabase.Configuration.Storage.NumOfCocurrentSyncsPerPhysDrive;
+                options.TimeToSyncAfterFlashInSec = (int)documentDatabase.Configuration.Storage.TimeToSyncAfterFlash.AsTimeSpan.TotalSeconds;
+                options.NumOfConcurrentSyncsPerPhysDrive = documentDatabase.Configuration.Storage.NumOfConcurrentSyncsPerPhysDrive;
                 Sodium.CloneKey(out options.MasterKey, documentDatabase.MasterKey);
 
                 environment = new StorageEnvironment(options);
@@ -308,8 +308,8 @@ namespace Raven.Server.Documents.Indexes
 
                 options.SchemaVersion = 1;
                 options.ForceUsing32BitsPager = documentDatabase.Configuration.Storage.ForceUsing32BitsPager;
-                options.TimeToSyncAfterFlashInSeconds = documentDatabase.Configuration.Storage.TimeToSyncAfterFlashInSeconds;
-                options.NumOfConcurrentSyncsPerPhysDrive = documentDatabase.Configuration.Storage.NumOfCocurrentSyncsPerPhysDrive;
+                options.TimeToSyncAfterFlashInSec = (int)documentDatabase.Configuration.Storage.TimeToSyncAfterFlash.AsTimeSpan.TotalSeconds;
+                options.NumOfConcurrentSyncsPerPhysDrive = documentDatabase.Configuration.Storage.NumOfConcurrentSyncsPerPhysDrive;
                 Sodium.CloneKey(out options.MasterKey, documentDatabase.MasterKey);
 
                 try
@@ -449,7 +449,7 @@ namespace Raven.Server.Documents.Indexes
                 SetState(IndexState.Normal);
 
                 _cts = CancellationTokenSource.CreateLinkedTokenSource(DocumentDatabase.DatabaseShutdown);
-                
+
                 _indexingThread = new Thread(ExecuteIndexing)
                 {
                     Name = IndexingThreadName,
@@ -622,7 +622,7 @@ namespace Raven.Server.Documents.Indexes
                 long lastEtag = 0;
                 foreach (var collection in Collections)
                 {
-                    lastEtag  = Math.Max(lastEtag , _indexStorage.ReadLastIndexedEtag(indexContext.Transaction, collection));
+                    lastEtag = Math.Max(lastEtag, _indexStorage.ReadLastIndexedEtag(indexContext.Transaction, collection));
                 }
 
                 return (false, lastEtag);
@@ -1048,7 +1048,7 @@ namespace Raven.Server.Documents.Indexes
                 State = IndexState.Error; // just in case it didn't took from the SetState call
             }
         }
-        
+
         private void HandleIndexFailureInformation(IndexFailureInformation failureInformation)
         {
             if (failureInformation.IsInvalidIndex(_indexValidationStalenessCheck) == false)
@@ -2335,8 +2335,8 @@ namespace Raven.Server.Documents.Indexes
                     srcOptions.ForceUsing32BitsPager = DocumentDatabase.Configuration.Storage.ForceUsing32BitsPager;
                     srcOptions.OnNonDurableFileSystemError += DocumentDatabase.HandleNonDurableFileSystemError;
                     srcOptions.OnRecoveryError += DocumentDatabase.HandleOnRecoveryError;
-                    srcOptions.TimeToSyncAfterFlashInSeconds = DocumentDatabase.Configuration.Storage.TimeToSyncAfterFlashInSeconds;
-                    srcOptions.NumOfConcurrentSyncsPerPhysDrive = DocumentDatabase.Configuration.Storage.NumOfCocurrentSyncsPerPhysDrive;
+                    srcOptions.TimeToSyncAfterFlashInSec = (int)DocumentDatabase.Configuration.Storage.TimeToSyncAfterFlash.AsTimeSpan.TotalSeconds;
+                    srcOptions.NumOfConcurrentSyncsPerPhysDrive = DocumentDatabase.Configuration.Storage.NumOfConcurrentSyncsPerPhysDrive;
                     Sodium.CloneKey(out srcOptions.MasterKey, DocumentDatabase.MasterKey);
 
                     var wasRunning = _indexingThread != null;
@@ -2352,8 +2352,8 @@ namespace Raven.Server.Documents.Indexes
                         compactOptions.OnRecoveryError += DocumentDatabase.HandleOnRecoveryError;
 
                         compactOptions.ForceUsing32BitsPager = DocumentDatabase.Configuration.Storage.ForceUsing32BitsPager;
-                        compactOptions.TimeToSyncAfterFlashInSeconds = DocumentDatabase.Configuration.Storage.TimeToSyncAfterFlashInSeconds;
-                        compactOptions.NumOfConcurrentSyncsPerPhysDrive = DocumentDatabase.Configuration.Storage.NumOfCocurrentSyncsPerPhysDrive;
+                        compactOptions.TimeToSyncAfterFlashInSec = (int)DocumentDatabase.Configuration.Storage.TimeToSyncAfterFlash.AsTimeSpan.TotalSeconds;
+                        compactOptions.NumOfConcurrentSyncsPerPhysDrive = DocumentDatabase.Configuration.Storage.NumOfConcurrentSyncsPerPhysDrive;
                         Sodium.CloneKey(out srcOptions.MasterKey, DocumentDatabase.MasterKey);
 
                         StorageCompaction.Execute(srcOptions, compactOptions, progressReport =>
@@ -2510,7 +2510,7 @@ namespace Raven.Server.Documents.Indexes
 
                 _hasLock = true;
             }
-            
+
             private void ThrowLockTimeoutException()
             {
                 throw new TimeoutException($"Could not get the index read lock in a reasonable time, {_parent.Name} is probably undergoing maintenance now, try again later");

--- a/src/Raven.Server/Documents/PeriodicBackup/PeriodicBackupRunner.cs
+++ b/src/Raven.Server/Documents/PeriodicBackup/PeriodicBackupRunner.cs
@@ -1023,7 +1023,7 @@ namespace Raven.Server.Documents.PeriodicBackup
             return new BackupInfo
             {
                 LastBackup = allBackupTicks.Count == 0 ? (DateTime?)null : new DateTime(allBackupTicks.Max()),
-                IntervalUntilNextBackupInSeconds = allNextBackupTimeSpanSeconds.Count == 0 ?
+                IntervalUntilNextBackupInSec = allNextBackupTimeSpanSeconds.Count == 0 ?
                     0 : allNextBackupTimeSpanSeconds.Min()
             };
         }

--- a/src/Raven.Server/Documents/Queries/QueryRunner.cs
+++ b/src/Raven.Server/Documents/Queries/QueryRunner.cs
@@ -47,7 +47,7 @@ namespace Raven.Server.Documents.Queries
                 var runner = new DynamicQueryRunner(_database.IndexStore, _database.TransformerStore, _database.DocumentsStorage, _documentsContext, token);
 
                 result = await runner.Execute(indexName, query, existingResultEtag);
-                result.DurationMilliseconds = (long)sw.Elapsed.TotalMilliseconds;
+                result.DurationInMs = (long)sw.Elapsed.TotalMilliseconds;
                 return result;
             }
 
@@ -60,7 +60,7 @@ namespace Raven.Server.Documents.Queries
             }
 
             result = await index.Query(query, _documentsContext, token);
-            result.DurationMilliseconds = (long)sw.Elapsed.TotalMilliseconds;
+            result.DurationInMs = (long)sw.Elapsed.TotalMilliseconds;
             return result;
         }
 
@@ -151,7 +151,7 @@ namespace Raven.Server.Documents.Queries
             context.OpenReadTransaction();
 
             var result = index.MoreLikeThisQuery(query, context, token);
-            result.DurationMilliseconds = (int)sw.Elapsed.TotalMilliseconds;
+            result.DurationInMs = (int)sw.Elapsed.TotalMilliseconds;
             return result;
         }
 

--- a/src/Raven.Server/Json/BlittableJsonTextWriterExtensions.cs
+++ b/src/Raven.Server/Json/BlittableJsonTextWriterExtensions.cs
@@ -254,8 +254,8 @@ namespace Raven.Server.Json
             writer.WriteInteger(result.SkippedResults);
             writer.WriteComma();
 
-            writer.WritePropertyName(nameof(result.DurationMilliseconds));
-            writer.WriteInteger(result.DurationMilliseconds);
+            writer.WritePropertyName(nameof(result.DurationInMs));
+            writer.WriteInteger(result.DurationInMs);
             writer.WriteComma();
 
             writer.WriteQueryResult(context, result, metadataOnly: false, numberOfResults: out int _, partial: true);
@@ -275,8 +275,8 @@ namespace Raven.Server.Json
             writer.WriteInteger(result.SkippedResults);
             writer.WriteComma();
 
-            writer.WritePropertyName(nameof(result.DurationMilliseconds));
-            writer.WriteInteger(result.DurationMilliseconds);
+            writer.WritePropertyName(nameof(result.DurationInMs));
+            writer.WriteInteger(result.DurationInMs);
             writer.WriteComma();
 
             writer.WriteQueryResult(context, result, metadataOnly, out numberOfResults, partial: true);
@@ -288,8 +288,8 @@ namespace Raven.Server.Json
         {
             writer.WriteStartObject();
 
-            writer.WritePropertyName(nameof(result.DurationMilliseconds));
-            writer.WriteInteger(result.DurationMilliseconds);
+            writer.WritePropertyName(nameof(result.DurationInMs));
+            writer.WriteInteger(result.DurationInMs);
             writer.WriteComma();
 
             writer.WriteQueryResult(context, result, metadataOnly: false, numberOfResults: out numberOfResults, partial: true);

--- a/src/Raven.Server/ServerWide/Maintenance/ClusterConfiguration.cs
+++ b/src/Raven.Server/ServerWide/Maintenance/ClusterConfiguration.cs
@@ -10,31 +10,31 @@ namespace Raven.Server.ServerWide.Maintenance
         [Description("Timeout in which the node expects to receive a heartbeat from the leader")]
         [DefaultValue(300)]
         [TimeUnit(TimeUnit.Milliseconds)]
-        [ConfigurationEntry("Raven/Cluster/ElectionTimeout")]
+        [ConfigurationEntry("Raven/Cluster/ElectionTimeoutInMs")]
         public TimeSetting ElectionTimeout { get; set; }
 
         [Description("How frequently we sample the information about the databases and send it to the maintenance supervisor.")]
         [DefaultValue(250)]
         [TimeUnit(TimeUnit.Milliseconds)]
-        [ConfigurationEntry("Raven/Cluster/WorkerSamplePeriod")]
+        [ConfigurationEntry("Raven/Cluster/WorkerSamplePeriodInMs")]
         public TimeSetting WorkerSamplePeriod { get; set; }
 
         [Description("As the maintenance supervisor, how frequent we sample the information received from the nodes.")]
         [DefaultValue(500)]
         [TimeUnit(TimeUnit.Milliseconds)]
-        [ConfigurationEntry("Raven/Cluster/SupervisorSamplePeriod")]
+        [ConfigurationEntry("Raven/Cluster/SupervisorSamplePeriodInMs")]
         public TimeSetting SupervisorSamplePeriod { get; set; }
 
         [Description("As the maintenance supervisor, how long we wait to hear from a worker before it is time out.")]
         [DefaultValue(1000)]
         [TimeUnit(TimeUnit.Milliseconds)]
-        [ConfigurationEntry("Raven/Cluster/ReceiveFromWorkerTimeout")]
+        [ConfigurationEntry("Raven/Cluster/ReceiveFromWorkerTimeoutInMs")]
         public TimeSetting ReceiveFromWorkerTimeout { get; set; }
 
         [Description("As the maintenance supervisor, how long we wait after we received an exception from a worker. Before we retry.")]
         [DefaultValue(5000)]
         [TimeUnit(TimeUnit.Milliseconds)]
-        [ConfigurationEntry("Raven/Cluster/OnErrorDelayTime")]
+        [ConfigurationEntry("Raven/Cluster/OnErrorDelayTimeInMs")]
         public TimeSetting OnErrorDelayTime { get; set; }
 
         [Description("As a cluster node, how long it takes to timeout operation between two cluster nodes.")]
@@ -46,7 +46,7 @@ namespace Raven.Server.ServerWide.Maintenance
         [Description("The time we give to the cluster stats to stabilize after a database topology change.")]
         [DefaultValue(5)]
         [TimeUnit(TimeUnit.Seconds)]
-        [ConfigurationEntry("Raven/Cluster/StatsStabilizationTime")]
+        [ConfigurationEntry("Raven/Cluster/StatsStabilizationTimeInSec")]
         public TimeSetting StabilizationTime { get; set; }
 
     }

--- a/src/Raven.Studio/typescript/models/database/query/abstractQueryResult.ts
+++ b/src/Raven.Studio/typescript/models/database/query/abstractQueryResult.ts
@@ -24,7 +24,7 @@ class abstractQueryResult {
         this.resultEtag = dto.ResultEtag;
         this.highlightings = dto.Highlightings;
         this.lastQueryTime = new Date(dto.LastQueryTime);
-        this.durationMilliseconds = dto.DurationMilliseconds;
+        this.durationMilliseconds = dto.DurationInMs;
     }
 }
 

--- a/src/Raven.Studio/typescript/models/resources/info/databaseInfo.ts
+++ b/src/Raven.Studio/typescript/models/resources/info/databaseInfo.ts
@@ -84,7 +84,7 @@ class databaseInfo {
             return "text-danger";
         }
 
-        return dto.IntervalUntilNextBackupInSeconds === 0 ? "text-warning" : "text-success";
+        return dto.IntervalUntilNextBackupInSec === 0 ? "text-warning" : "text-success";
     }
 
     private initializeObservables() {

--- a/src/Raven.Studio/typescript/viewmodels/database/indexes/indexPerformance.ts
+++ b/src/Raven.Studio/typescript/viewmodels/database/indexes/indexPerformance.ts
@@ -768,7 +768,7 @@ class indexPerformance extends viewModelBase {
                 if (perfStat.Completed) {
                     end = perfStatsWithCache.CompletedAsDate;
                 } else {
-                    end = new Date(start.getTime() + perfStat.DurationInMilliseconds);
+                    end = new Date(start.getTime() + perfStat.DurationInMs);
                 }
                 result.push([start, end]);
             });
@@ -886,7 +886,7 @@ class indexPerformance extends viewModelBase {
 
                 const startDateAsInt = startDate.getTime();
 
-                const endDateAsInt = startDateAsInt + perf.DurationInMilliseconds;
+                const endDateAsInt = startDateAsInt + perf.DurationInMs;
                 if (endDateAsInt < visibleStartDateAsInt || visibleEndDateAsInt < startDateAsInt)
                     continue;
 
@@ -908,7 +908,7 @@ class indexPerformance extends viewModelBase {
             let currentX = xStart;
 
             perfs.forEach(op => {
-                const dx = extentFunc(op.DurationInMilliseconds);
+                const dx = extentFunc(op.DurationInMs);
 
                 this.inProgressAnimator.register([currentX, yStart, dx, indexPerformance.trackHeight]);
 
@@ -944,7 +944,7 @@ class indexPerformance extends viewModelBase {
             const op = operations[i];
             context.fillStyle = this.getColorForOperation(op.Name);
 
-            const dx = extentFunc(op.DurationInMilliseconds);
+            const dx = extentFunc(op.DurationInMs);
 
             context.fillRect(currentX, yStart, dx, indexPerformance.trackHeight);
 
@@ -1059,7 +1059,7 @@ class indexPerformance extends viewModelBase {
         const currentDatum = this.tooltip.datum();
 
         if (currentDatum !== element) {
-            let tooltipHtml = `${element.Name}<br/>Duration: ${generalUtils.formatMillis((element).DurationInMilliseconds)}`;
+            let tooltipHtml = `${element.Name}<br/>Duration: ${generalUtils.formatMillis((element).DurationInMs)}`;
 
             const opWithParent = element as IndexingPerformanceOperationWithParent;
 

--- a/src/Raven.Studio/typescript/viewmodels/database/status/replicationStats.ts
+++ b/src/Raven.Studio/typescript/viewmodels/database/status/replicationStats.ts
@@ -779,7 +779,7 @@ class replicationStats extends viewModelBase {
                 if (perfStat.Completed) {
                     end = perfStatsWithCache.CompletedAsDate;
                 } else {
-                    end = new Date(start.getTime() + perfStat.DurationInMilliseconds);
+                    end = new Date(start.getTime() + perfStat.DurationInMs);
                 }
                 result.push([start, end]);
             });
@@ -897,7 +897,7 @@ class replicationStats extends viewModelBase {
                 const x1 = xScale(startDate);
                 const startDateAsInt = startDate.getTime();
 
-                const endDateAsInt = startDateAsInt + perf.DurationInMilliseconds;
+                const endDateAsInt = startDateAsInt + perf.DurationInMs;
                 if (endDateAsInt < visibleStartDateAsInt || visibleEndDateAsInt < startDateAsInt)
                     continue;
 
@@ -945,7 +945,7 @@ class replicationStats extends viewModelBase {
         const length = operations.length;
         for (let i = 0; i < length; i++) {
             const op = operations[i];
-            const dx = extentFunc(op.DurationInMilliseconds);
+            const dx = extentFunc(op.DurationInMs);
 
             // 0. Draw item:
             context.fillStyle = this.getColorForOperation(op.Name);
@@ -1084,7 +1084,7 @@ class replicationStats extends viewModelBase {
         const baseElement = element as Raven.Client.Documents.Replication.ReplicationPerformanceBase;
 
         if (currentDatum !== element) {
-            const duration = (element.DurationInMilliseconds === 0) ? "0" : generalUtils.formatMillis(element.DurationInMilliseconds);
+            const duration = (element.DurationInMs === 0) ? "0" : generalUtils.formatMillis(element.DurationInMs);
             const direction = (element.Type === 'Outgoing') ? "Outgoing" : "Incoming";
 
             let tooltipHtml = `*** ${direction} Replication ***<br/>`;
@@ -1127,7 +1127,7 @@ class replicationStats extends viewModelBase {
 
         if (currentDatum !== element) {
             let tooltipHtml = `*** ${element.Name} ***<br/>`;
-            tooltipHtml += `Duration: ${generalUtils.formatMillis((element).DurationInMilliseconds)}<br/>`;
+            tooltipHtml += `Duration: ${generalUtils.formatMillis((element).DurationInMs)}<br/>`;
 
             this.handleTooltip(element, x, y, tooltipHtml); 
         }

--- a/src/Voron/GlobalFlushingBehavior.cs
+++ b/src/Voron/GlobalFlushingBehavior.cs
@@ -215,7 +215,7 @@ namespace Voron
 
                     // At the same time, we want to avoid excessive flushes, so we'll limit it to once in a while if we don't
                     // have a lot to flush
-                    if ((DateTime.UtcNow - envToFlush.LastFlushTime).TotalSeconds < StorageEnvironment.TimeToSyncAfterFlashInSeconds)
+                    if ((DateTime.UtcNow - envToFlush.LastFlushTime).TotalSeconds < StorageEnvironment.TimeToSyncAfterFlashInSec)
                         continue;
                 }
 

--- a/src/Voron/StorageEnvironment.cs
+++ b/src/Voron/StorageEnvironment.cs
@@ -91,7 +91,7 @@ namespace Voron
         private readonly Logger _log;
         public static int MaxConcurrentFlushes = 10; // RavenDB-5221
         public static int NumOfConcurrentSyncsPerPhysDrive;
-        public static int TimeToSyncAfterFlashInSeconds;
+        public static int TimeToSyncAfterFlashInSec;
 
         public Guid DbId { get; set; }
 
@@ -111,7 +111,7 @@ namespace Voron
                 _freeSpaceHandling = new FreeSpaceHandling();
                 _headerAccessor = new HeaderAccessor(this);
                 NumOfConcurrentSyncsPerPhysDrive = options.NumOfConcurrentSyncsPerPhysDrive;
-                TimeToSyncAfterFlashInSeconds = options.TimeToSyncAfterFlashInSeconds;
+                TimeToSyncAfterFlashInSec = options.TimeToSyncAfterFlashInSec;
 
                 Debug.Assert(_dataPager.NumberOfAllocatedPages != 0);
 

--- a/src/Voron/StorageEnvironmentOptions.cs
+++ b/src/Voron/StorageEnvironmentOptions.cs
@@ -952,15 +952,15 @@ namespace Voron
             set => _numOfConcurrentSyncsPerPhysDrive = value;
         }
 
-        public int TimeToSyncAfterFlashInSeconds
+        public int TimeToSyncAfterFlashInSec
         {
             get
             {
-                if (_timeToSyncAfterFlashInSeconds < 1)
-                    _timeToSyncAfterFlashInSeconds = 30;
-                return _timeToSyncAfterFlashInSeconds;
+                if (_timeToSyncAfterFlashInSec < 1)
+                    _timeToSyncAfterFlashInSec = 30;
+                return _timeToSyncAfterFlashInSec;
             }
-            set => _timeToSyncAfterFlashInSeconds = value;
+            set => _timeToSyncAfterFlashInSec = value;
         }
 
         public byte[] MasterKey;
@@ -974,7 +974,7 @@ namespace Voron
             new SortedList<long, string>();
 
         private int _numOfConcurrentSyncsPerPhysDrive;
-        private int _timeToSyncAfterFlashInSeconds;
+        private int _timeToSyncAfterFlashInSec;
 
         public virtual void SetPosixOptions()
         {

--- a/test/FastTests/Server/Documents/Expiration/ExpirationTests.cs
+++ b/test/FastTests/Server/Documents/Expiration/ExpirationTests.cs
@@ -26,7 +26,7 @@ namespace FastTests.Server.Documents.Expiration
             var config = new ExpirationConfiguration
             {
                 Active = true,
-                DeleteFrequencySeconds = 100,
+                DeleteFrequencyInSec = 100,
             };
             await store.Admin.Server.SendAsync(new ConfigureExpirationOperation(config, store.Database));
         }

--- a/test/FastTests/Server/Documents/Queries/NotModifiedQueryResults.cs
+++ b/test/FastTests/Server/Documents/Queries/NotModifiedQueryResults.cs
@@ -41,7 +41,7 @@ namespace FastTests.Server.Documents.Queries
                         WaitForNonStaleResultsTimeout = TimeSpan.FromMinutes(1)
                     });
 
-                    Assert.Equal(-1, users.DurationMilliseconds); // taken from cache
+                    Assert.Equal(-1, users.DurationInMs); // taken from cache
                     Assert.Equal(2, users.Results.Length);
                 }
             }

--- a/test/FastTests/Smuggler/SmugglerApiTests.cs
+++ b/test/FastTests/Smuggler/SmugglerApiTests.cs
@@ -289,7 +289,7 @@ namespace FastTests.Smuggler
                 var config = new ExpirationConfiguration
                 {
                     Active = true,
-                    DeleteFrequencySeconds = 100,
+                    DeleteFrequencyInSec = 100,
                 };
                 await store.Admin.Server.SendAsync(new ConfigureExpirationOperation(config, store.Database));
                 await session.SaveChangesAsync();

--- a/test/SlowTests/Issues/RDBQA_11.cs
+++ b/test/SlowTests/Issues/RDBQA_11.cs
@@ -169,7 +169,7 @@ namespace SlowTests.Issues
                 var config = new ExpirationConfiguration
                 {
                     Active = true,
-                    DeleteFrequencySeconds = 100,
+                    DeleteFrequencyInSec = 100,
                 };
                 store.Admin.Server.Send(new ConfigureExpirationOperation(config, store.Database));
                 session.SaveChanges();

--- a/test/StressTests/Databases.cs
+++ b/test/StressTests/Databases.cs
@@ -82,12 +82,12 @@ namespace StressTests
                             }
                             //Not sure if reported result is worth anything...
                             onePart = (double)1 / (_totalQueryCount - _totalQueryUsedCachedResults + 1);
-                            if (queryStat.DurationMilliseconds > 0)
+                            if (queryStat.DurationInMs > 0)
                             {
-                                _reportedAvarageQueryTime = onePart * (_totalQueryCount - _totalQueryUsedCachedResults) * _reportedAvarageQueryTime + queryStat.DurationMilliseconds * onePart;
-                                if (_reportedMaxQueryTime < queryStat.DurationMilliseconds)
+                                _reportedAvarageQueryTime = onePart * (_totalQueryCount - _totalQueryUsedCachedResults) * _reportedAvarageQueryTime + queryStat.DurationInMs * onePart;
+                                if (_reportedMaxQueryTime < queryStat.DurationInMs)
                                 {
-                                    _reportedMaxQueryTime = queryStat.DurationMilliseconds;
+                                    _reportedMaxQueryTime = queryStat.DurationInMs;
                                 }
                             }
                             else

--- a/tools/Voron.Recovery/VoronRecoveryConfiguration.cs
+++ b/tools/Voron.Recovery/VoronRecoveryConfiguration.cs
@@ -11,7 +11,7 @@ namespace Voron.Recovery
         public int NumberOfFieldsInDocumentTable { get; set; } = 5;
         public int InitialContextSizeInMB { get; set; } = 1;
         public int InitialContextLongLivedSizeInKB { get; set; } = 16;
-        public int ProgressIntervalInSeconds { get; set; } = 5;
+        public int ProgressIntervalInSec { get; set; } = 5;
         public bool DisableCopyOnWriteMode { get; set; }
 
         public static VoronRecoveryArgsProcessStatus ProcessArgs(string[] args, out VoronRecoveryConfiguration config)
@@ -78,7 +78,7 @@ namespace Voron.Recovery
                         int refreshRate;
                         if (int.TryParse(args[i + 1], out refreshRate) == false || refreshRate < 1)
                             return VoronRecoveryArgsProcessStatus.InvalidRefreshRate;
-                        config.ProgressIntervalInSeconds = refreshRate;
+                        config.ProgressIntervalInSec = refreshRate;
                         break;
                     case "-DisableCopyOnWriteMode":
                         bool disableCopyOnWriteMode;


### PR DESCRIPTION
- all long/int properties that refer to time should end with InMs/InSec/InMin/InHrs/InDays suffix
- all configuration options that refer to time should end also with InMs/InSec/InMin/InHrs/InDays
- removed 'Raven/BulkImport/BatchTimeout' configuration (not used)
- renamed Tombstone.Interval to Tombstone.CleanupInterval
- fixed typos