### PR TITLE
RavenDB-4636

### DIFF
--- a/src/Raven.Client/Constants.cs
+++ b/src/Raven.Client/Constants.cs
@@ -32,6 +32,14 @@ namespace Raven.Client
 
             public const string RequestTime = "Raven-Request-Time";
 
+            public const string RefreshTopology = "Refresh-Topology";
+
+            public const string TopologyEtag = "Topology-Etag";
+
+            public const string ClientConfigurationEtag = "Client-Configuration-Etag";
+
+            public const string RefreshClientConfiguration = "Refresh-Client-Configuration";
+
             public const string Etag = "ETag";
         }
 
@@ -72,6 +80,15 @@ namespace Raven.Client
 
             public const string Prefix = "apikeys/";
             public const string ClusterApiKeyName = "Raven/Cluster";
+        }
+
+        public class Configuration
+        {
+            private Configuration()
+            {
+            }
+
+            public const string ClientId = "Configuration/Client";
         }
 
         public class Documents
@@ -115,15 +132,6 @@ namespace Raven.Client
                 public const string ChangeVector = "@change-vector";
 
                 public const string HasValue = "HasValue";
-            }
-
-            public class BulkInsert
-            {
-                private BulkInsert()
-                {
-                }
-
-                public const string Content = "Content";
             }
 
             public class Collections

--- a/src/Raven.Client/Documents/Conventions/DocumentConventions.cs
+++ b/src/Raven.Client/Documents/Conventions/DocumentConventions.cs
@@ -510,11 +510,15 @@ namespace Raven.Client.Documents.Conventions
                 {
                     _originalConfiguration = new ClientConfiguration
                     {
-                        MaxNumberOfRequestsPerSession = MaxNumberOfRequestsPerSession
+                        MaxNumberOfRequestsPerSession = MaxNumberOfRequestsPerSession,
+                        MaxLengthOfQueryUsingGetUrl = MaxLengthOfQueryUsingGetUrl,
+                        PrettifyGeneratedLinqExpressions = PrettifyGeneratedLinqExpressions
                     };
                 }
 
                 MaxNumberOfRequestsPerSession = configuration.MaxNumberOfRequestsPerSession ?? _originalConfiguration.MaxNumberOfRequestsPerSession.Value;
+                MaxLengthOfQueryUsingGetUrl = configuration.MaxLengthOfQueryUsingGetUrl ?? _originalConfiguration.MaxLengthOfQueryUsingGetUrl.Value;
+                PrettifyGeneratedLinqExpressions = configuration.PrettifyGeneratedLinqExpressions ?? _originalConfiguration.PrettifyGeneratedLinqExpressions.Value;
             }
         }
 

--- a/src/Raven.Client/Documents/Conventions/DocumentConventions.cs
+++ b/src/Raven.Client/Documents/Conventions/DocumentConventions.cs
@@ -514,8 +514,7 @@ namespace Raven.Client.Documents.Conventions
                     };
                 }
 
-                if (configuration.MaxNumberOfRequestsPerSession.HasValue)
-                    MaxNumberOfRequestsPerSession = configuration.MaxNumberOfRequestsPerSession.Value;
+                MaxNumberOfRequestsPerSession = configuration.MaxNumberOfRequestsPerSession ?? _originalConfiguration.MaxNumberOfRequestsPerSession.Value;
             }
         }
 

--- a/src/Raven.Client/Extensions/HttpExtensions.cs
+++ b/src/Raven.Client/Extensions/HttpExtensions.cs
@@ -15,7 +15,7 @@ namespace Raven.Client.Extensions
     {
         public static long GetRequiredEtagHeader(this HttpResponseMessage response)
         {
-            if (response.Headers.TryGetValues(Constants.Headers.Etag, out IEnumerable<string> values) == false || 
+            if (response.Headers.TryGetValues(Constants.Headers.Etag, out IEnumerable<string> values) == false ||
                 values == null)
                 throw new InvalidOperationException("Response didn't had an ETag header");
 
@@ -28,7 +28,7 @@ namespace Raven.Client.Extensions
 
         public static long? GetEtagHeader(this HttpResponseMessage response)
         {
-            if (response.Headers.TryGetValues(Constants.Headers.Etag, out IEnumerable<string> values) == false || 
+            if (response.Headers.TryGetValues(Constants.Headers.Etag, out IEnumerable<string> values) == false ||
                 values == null)
                 return null;
 
@@ -48,7 +48,19 @@ namespace Raven.Client.Extensions
             return EtagHeaderToEtag(value);
         }
 
-        internal static long EtagHeaderToEtag(string responseHeader)
+        public static bool? GetBoolHeader(this HttpResponseMessage response, string header)
+        {
+            if (response.Headers.TryGetValues(header, out IEnumerable<string> values) == false || values == null)
+                return null;
+
+            var value = values.FirstOrDefault();
+            if (value == null)
+                return null;
+
+            return bool.Parse(value);
+        }
+
+        private static long EtagHeaderToEtag(string responseHeader)
         {
             if (string.IsNullOrEmpty(responseHeader))
                 throw new InvalidOperationException("Response didn't had an ETag header");

--- a/src/Raven.Client/Http/AggressiveCacheOptions.cs
+++ b/src/Raven.Client/Http/AggressiveCacheOptions.cs
@@ -1,0 +1,9 @@
+﻿using System;
+
+namespace Raven.Client.Http
+{
+    public class AggressiveCacheOptions
+    {
+        public TimeSpan? Duration;
+    }
+}

--- a/src/Raven.Client/Http/RequestExecutor.cs
+++ b/src/Raven.Client/Http/RequestExecutor.cs
@@ -95,7 +95,6 @@ namespace Raven.Client.Http
         {
             _databaseName = databaseName;
             _apiKey = apiKey;
-            TopologyEtag = 0;
 
             _lastReturnedResponse = DateTime.UtcNow;
 

--- a/src/Raven.Client/Json/Converters/JsonDeserializationClient.cs
+++ b/src/Raven.Client/Json/Converters/JsonDeserializationClient.cs
@@ -16,6 +16,7 @@ using Raven.Client.Server;
 using Raven.Client.Server.Commands;
 using Raven.Client.Server.ETL;
 using Raven.Client.Server.Operations;
+using Raven.Client.Server.Operations.Configuration;
 using Raven.Client.Server.Operations.ConnectionStrings;
 using Raven.Client.Server.Operations.ETL;
 using Raven.Client.Server.PeriodicBackup;
@@ -140,5 +141,6 @@ namespace Raven.Client.Json.Converters
 
         internal static readonly Func<BlittableJsonReaderObject, AddConnectionStringResult> AddConnectionStringResult = GenerateJsonDeserializationRoutine<AddConnectionStringResult>();
 
+        internal static readonly Func<BlittableJsonReaderObject, GetClientConfigurationOperation.Result> ClientConfigurationResult = GenerateJsonDeserializationRoutine<GetClientConfigurationOperation.Result>();
     }
 }

--- a/src/Raven.Client/Raven.Client.csproj
+++ b/src/Raven.Client/Raven.Client.csproj
@@ -37,7 +37,7 @@
       <PackagePath>lib/netstandard1.3/</PackagePath>
       <Pack>true</Pack>
     </Content>
-    <Content Include="..\..\libs\libsodium\x64\libsodium.dll" >
+    <Content Include="..\..\libs\libsodium\x64\libsodium.dll">
       <PackagePath>runtimes/win/native/libsodium.x64.dll</PackagePath>
       <Pack>true</Pack>
     </Content>
@@ -53,7 +53,7 @@
       <PackagePath>runtimes/linux/native/libsodium.x86.so</PackagePath>
       <Pack>true</Pack>
     </Content>
-    <Content Include="..\..\libs\libsodium\x86\libsodium.arm.so" >
+    <Content Include="..\..\libs\libsodium\x86\libsodium.arm.so">
       <PackagePath>runtimes/linux/native/libsodium.arm.so</PackagePath>
       <Pack>true</Pack>
     </Content>

--- a/src/Raven.Client/Server/DatabaseRecord.cs
+++ b/src/Raven.Client/Server/DatabaseRecord.cs
@@ -32,7 +32,7 @@ namespace Raven.Client.Server
         public Dictionary<string, DeletionInProgressStatus> DeletionInProgress;
 
         public string DataDirectory;
-        
+
         public DatabaseTopology Topology;
 
         // public OnGoingTasks tasks;  tasks for this node..
@@ -44,13 +44,13 @@ namespace Raven.Client.Server
 
         public Dictionary<string, AutoIndexDefinition> AutoIndexes;
 
-        //todo: see how we can protect this
         public Dictionary<string, TransformerDefinition> Transformers;
 
         public Dictionary<string, long> Identities;
 
         public Dictionary<string, string> Settings;
 
+        //todo: see how we can protect this
         public Dictionary<string, string> SecuredSettings { get; set; }
 
         public VersioningConfiguration Versioning { get; set; }
@@ -118,13 +118,8 @@ namespace Raven.Client.Server
                 throw new IndexOrTransformerAlreadyExistException($"Tried to create an index with a name of {definition.Name}, but a transformer under the same name exists");
             }
 
-            var lockMode = IndexLockMode.Unlock;
-
             if (AutoIndexes.TryGetValue(definition.Name, out AutoIndexDefinition existingDefinition))
             {
-                if (existingDefinition.LockMode != null)
-                    lockMode = existingDefinition.LockMode.Value;
-
                 var result = existingDefinition.Compare(definition);
                 result &= ~IndexDefinitionCompareDifferences.Etag;
 

--- a/src/Raven.Client/Server/Operations/Configuration/ClientConfiguration.cs
+++ b/src/Raven.Client/Server/Operations/Configuration/ClientConfiguration.cs
@@ -8,12 +8,18 @@ namespace Raven.Client.Server.Operations.Configuration
 
         public int? MaxNumberOfRequestsPerSession { get; set; }
 
+        public int? MaxLengthOfQueryUsingGetUrl { get; set; }
+
+        public bool? PrettifyGeneratedLinqExpressions { get; set; }
+
         public DynamicJsonValue ToJson()
         {
             return new DynamicJsonValue
             {
                 [nameof(Disabled)] = Disabled,
-                [nameof(MaxNumberOfRequestsPerSession)] = MaxNumberOfRequestsPerSession
+                [nameof(MaxNumberOfRequestsPerSession)] = MaxNumberOfRequestsPerSession,
+                [nameof(MaxLengthOfQueryUsingGetUrl)] = MaxLengthOfQueryUsingGetUrl,
+                [nameof(PrettifyGeneratedLinqExpressions)] = PrettifyGeneratedLinqExpressions
             };
         }
     }

--- a/src/Raven.Client/Server/Operations/Configuration/ClientConfiguration.cs
+++ b/src/Raven.Client/Server/Operations/Configuration/ClientConfiguration.cs
@@ -1,0 +1,20 @@
+﻿using Sparrow.Json.Parsing;
+
+namespace Raven.Client.Server.Operations.Configuration
+{
+    public class ClientConfiguration
+    {
+        public bool Disabled { get; set; }
+
+        public int? MaxNumberOfRequestsPerSession { get; set; }
+
+        public DynamicJsonValue ToJson()
+        {
+            return new DynamicJsonValue
+            {
+                [nameof(Disabled)] = Disabled,
+                [nameof(MaxNumberOfRequestsPerSession)] = MaxNumberOfRequestsPerSession
+            };
+        }
+    }
+}

--- a/src/Raven.Client/Server/Operations/Configuration/GetClientConfigurationOperation.cs
+++ b/src/Raven.Client/Server/Operations/Configuration/GetClientConfigurationOperation.cs
@@ -1,0 +1,48 @@
+﻿using System.Net.Http;
+using Raven.Client.Documents.Conventions;
+using Raven.Client.Http;
+using Raven.Client.Json.Converters;
+using Sparrow.Json;
+
+namespace Raven.Client.Server.Operations.Configuration
+{
+    public class GetClientConfigurationOperation : IServerOperation<GetClientConfigurationOperation.Result>
+    {
+        public RavenCommand<Result> GetCommand(DocumentConventions conventions, JsonOperationContext context)
+        {
+            return new GetClientConfigurationCommand();
+        }
+
+        internal class GetClientConfigurationCommand : RavenCommand<Result>
+        {
+            public override bool IsReadRequest => false;
+
+            public override HttpRequestMessage CreateRequest(ServerNode node, out string url)
+            {
+                url = $"{node.Url}/configuration/client";
+
+                var request = new HttpRequestMessage
+                {
+                    Method = HttpMethod.Get
+                };
+
+                return request;
+            }
+
+            public override void SetResponse(BlittableJsonReaderObject response, bool fromCache)
+            {
+                if (response == null)
+                    return;
+
+                Result = JsonDeserializationClient.ClientConfigurationResult(response);
+            }
+        }
+
+        public class Result
+        {
+            public long RaftCommandIndex { get; set; }
+
+            public ClientConfiguration Configuration { get; set; }
+        }
+    }
+}

--- a/src/Raven.Client/Server/Operations/Configuration/PutClientConfigurationOperation.cs
+++ b/src/Raven.Client/Server/Operations/Configuration/PutClientConfigurationOperation.cs
@@ -1,0 +1,56 @@
+﻿using System;
+using System.Net.Http;
+using Raven.Client.Documents.Conventions;
+using Raven.Client.Documents.Session;
+using Raven.Client.Http;
+using Raven.Client.Json;
+using Sparrow.Json;
+
+namespace Raven.Client.Server.Operations.Configuration
+{
+    public class PutClientConfigurationOperation : IServerOperation
+    {
+        private readonly ClientConfiguration _configuration;
+
+        public PutClientConfigurationOperation(ClientConfiguration configuration)
+        {
+            _configuration = configuration ?? throw new ArgumentNullException(nameof(configuration));
+        }
+
+        public RavenCommand GetCommand(DocumentConventions conventions, JsonOperationContext context)
+        {
+            return new PutClientConfigurationCommand(conventions, context, _configuration);
+        }
+
+        private class PutClientConfigurationCommand : RavenCommand
+        {
+            private readonly JsonOperationContext _context;
+            private readonly BlittableJsonReaderObject _configuration;
+
+            public PutClientConfigurationCommand(DocumentConventions conventions, JsonOperationContext context, ClientConfiguration configuration)
+            {
+                if (conventions == null)
+                    throw new ArgumentNullException(nameof(conventions));
+                if (configuration == null)
+                    throw new ArgumentNullException(nameof(configuration));
+
+                _context = context ?? throw new ArgumentNullException(nameof(context));
+                _configuration = EntityToBlittable.ConvertEntityToBlittable(configuration, conventions, context);
+            }
+
+            public override HttpRequestMessage CreateRequest(ServerNode node, out string url)
+            {
+                url = $"{node.Url}/admin/configuration/client";
+
+                return new HttpRequestMessage
+                {
+                    Method = HttpMethod.Put,
+                    Content = new BlittableJsonContent(stream =>
+                    {
+                        _context.Write(stream, _configuration);
+                    })
+                };
+            }
+        }
+    }
+}

--- a/src/Raven.Server/Documents/Handlers/Admin/RachisAdminHandler.cs
+++ b/src/Raven.Server/Documents/Handlers/Admin/RachisAdminHandler.cs
@@ -191,11 +191,11 @@ namespace Raven.Server.Documents.Handlers.Admin
                         apiKey = clusterTopology.ApiKey;
                         topologyId = clusterTopology.TopologyId;
                     }
-                    using (var requestExecuter = ClusterRequestExecutor.CreateForSingleNode(serverUrl, apiKey))
+                    using (var requestExecutor = ClusterRequestExecutor.CreateForSingleNode(serverUrl, apiKey))
                     {
-                        requestExecuter.ClusterToken = ServerStore.GetClusterTokenForNode(ctx);
+                        requestExecutor.ClusterToken = ServerStore.GetClusterTokenForNode(ctx);
                         var infoCmd = new GetNodeInfoCommand();
-                        await requestExecuter.ExecuteAsync(infoCmd, ctx);
+                        await requestExecutor.ExecuteAsync(infoCmd, ctx);
                         var nodeInfo = infoCmd.Result;
 
                         if (nodeInfo.TopologyId != null && topologyId != nodeInfo.TopologyId)

--- a/src/Raven.Server/Documents/Handlers/Debugging/ServerWideDebugInfoPackageHandler.cs
+++ b/src/Raven.Server/Documents/Handlers/Debugging/ServerWideDebugInfoPackageHandler.cs
@@ -210,13 +210,13 @@ namespace Raven.Server.Documents.Handlers.Debugging
                 writer.Flush();
                 ms.Flush();
 
-                var requestExecuter = ClusterRequestExecutor.CreateForSingleNode(url, apiKey);
-                requestExecuter.ClusterToken = token;
-                requestExecuter.DefaultTimeout = ServerStore.Configuration.Cluster.ClusterOperationTimeout.AsTimeSpan;
+                var requestExecutor = ClusterRequestExecutor.CreateForSingleNode(url, apiKey);
+                requestExecutor.ClusterToken = token;
+                requestExecutor.DefaultTimeout = ServerStore.Configuration.Cluster.ClusterOperationTimeout.AsTimeSpan;
 
                 var rawStreamCommand = new GetRawStreamResultCommand("/debug/remote-cluster-info-package", ms);
 
-                await requestExecuter.ExecuteAsync(rawStreamCommand, jsonOperationContext);
+                await requestExecutor.ExecuteAsync(rawStreamCommand, jsonOperationContext);
                 return rawStreamCommand.Result;
             }
         }

--- a/src/Raven.Server/Json/JsonDeserializationServer.cs
+++ b/src/Raven.Server/Json/JsonDeserializationServer.cs
@@ -9,6 +9,7 @@ using Raven.Client.Server.Commands;
 using Raven.Client.Server.ETL;
 using Raven.Client.Server.Expiration;
 using Raven.Client.Server.Operations.ApiKeys;
+using Raven.Client.Server.Operations.Configuration;
 using Raven.Client.Server.PeriodicBackup;
 using Raven.Client.Server.Tcp;
 using Raven.Client.Server.Versioning;
@@ -88,5 +89,7 @@ namespace Raven.Server.Json
         public static readonly Func<BlittableJsonReaderObject, ApiKeyDefinition> ApiKeyDefinition = GenerateJsonDeserializationRoutine<ApiKeyDefinition>();
 
         public static readonly Func<BlittableJsonReaderObject, RestoreSettings> RestoreSettings = GenerateJsonDeserializationRoutine<RestoreSettings>();
+
+        public static readonly Func<BlittableJsonReaderObject, ClientConfiguration> ClientConfiguration = GenerateJsonDeserializationRoutine<ClientConfiguration>();
     }
 }

--- a/src/Raven.Server/ServerWide/Commands/CommandBase.cs
+++ b/src/Raven.Server/ServerWide/Commands/CommandBase.cs
@@ -1,0 +1,33 @@
+using System;
+using Sparrow.Json;
+using Sparrow.Json.Parsing;
+
+namespace Raven.Server.ServerWide.Commands
+{
+    public abstract class CommandBase
+    {
+        public virtual DynamicJsonValue ToJson(JsonOperationContext context)
+        {
+            return new DynamicJsonValue
+            {
+                ["Type"] = GetType().Name
+            };
+        }
+
+        public long? RaftCommandIndex;
+
+        public static CommandBase CreateFrom(BlittableJsonReaderObject json)
+        {
+            if (json.TryGet("Type", out string type) == false)
+            {
+                // TODO: maybe add further validation?
+                throw new ArgumentException("Command must contain 'Type' field.");
+            }
+
+            if (JsonDeserializationCluster.Commands.TryGetValue(type, out Func<BlittableJsonReaderObject, CommandBase> deserializer) == false)
+                throw new InvalidOperationException($"There is not deserializer for '{type}' command.");
+
+            return deserializer(json);
+        }
+    }
+}

--- a/src/Raven.Server/ServerWide/Commands/PutClientConfigurationCommand.cs
+++ b/src/Raven.Server/ServerWide/Commands/PutClientConfigurationCommand.cs
@@ -1,0 +1,26 @@
+﻿using Raven.Client;
+using Raven.Client.Server;
+using Raven.Client.Server.Operations.Configuration;
+using Sparrow.Json.Parsing;
+
+namespace Raven.Server.ServerWide.Commands
+{
+    public class PutClientConfigurationCommand : PutValueCommand<ClientConfiguration>
+    {
+        public PutClientConfigurationCommand()
+        {
+            // for deserialization
+        }
+
+        public PutClientConfigurationCommand(ClientConfiguration value)
+        {
+            Name = Constants.Configuration.ClientId;
+            Value = value;
+        }
+
+        public override DynamicJsonValue ValueToJson()
+        {
+            return Value?.ToJson();
+        }
+    }
+}

--- a/src/Raven.Server/ServerWide/Commands/UpdateDatabaseCommand.cs
+++ b/src/Raven.Server/ServerWide/Commands/UpdateDatabaseCommand.cs
@@ -1,4 +1,3 @@
-using System;
 using Raven.Client.Server;
 using Sparrow.Json;
 using Sparrow.Json.Parsing;
@@ -27,33 +26,6 @@ namespace Raven.Server.ServerWide.Commands
             FillJson(djv);
 
             return djv;
-        }
-    }
-
-    public abstract class CommandBase
-    {
-        public virtual DynamicJsonValue ToJson(JsonOperationContext context)
-        {
-            return new DynamicJsonValue
-            {
-                ["Type"] = GetType().Name
-            };
-        }
-
-        public long? RaftCommandIndex;
-
-        public static CommandBase CreateFrom(BlittableJsonReaderObject json)
-        {
-            if (json.TryGet("Type", out string type) == false)
-            {
-                // TODO: maybe add further validation?
-                throw new ArgumentException("Command must contain 'Type' field.");
-            }
-
-            if (JsonDeserializationCluster.Commands.TryGetValue(type, out Func<BlittableJsonReaderObject, CommandBase> deserializer) == false)
-                throw new InvalidOperationException($"There is not deserializer for '{type}' command.");
-
-            return deserializer(json);
         }
     }
 }

--- a/src/Raven.Server/ServerWide/JsonDeserializationCluster.cs
+++ b/src/Raven.Server/ServerWide/JsonDeserializationCluster.cs
@@ -76,6 +76,7 @@ namespace Raven.Server.ServerWide
             [nameof(AddDatabaseCommand)] = GenerateJsonDeserializationRoutine<AddDatabaseCommand>(),
             [nameof(DeleteValueCommand)] = GenerateJsonDeserializationRoutine<DeleteValueCommand>(),
             [nameof(PutApiKeyCommand)] = GenerateJsonDeserializationRoutine<PutApiKeyCommand>(),
+            [nameof(PutClientConfigurationCommand)] = GenerateJsonDeserializationRoutine<PutClientConfigurationCommand>(),
             [nameof(RemoveNodeFromDatabaseCommand)] = GenerateJsonDeserializationRoutine<RemoveNodeFromDatabaseCommand>(),
             [nameof(AcknowledgeSubscriptionBatchCommand)] = GenerateJsonDeserializationRoutine<AcknowledgeSubscriptionBatchCommand>(),
             [nameof(PutSubscriptionCommand)] = GenerateJsonDeserializationRoutine<PutSubscriptionCommand>(),

--- a/src/Raven.Server/Web/RequestHandler.cs
+++ b/src/Raven.Server/Web/RequestHandler.cs
@@ -303,7 +303,7 @@ namespace Raven.Server.Web
                 return result;
 
             ThrowInvalidDateTime(name, dataAsString);
-            return null; //unreacahble
+            return null; //unreachable
         }
 
         private static void ThrowInvalidDateTime(string name, string dataAsString)

--- a/src/Raven.Server/Web/System/AdminConfigurationHandler.cs
+++ b/src/Raven.Server/Web/System/AdminConfigurationHandler.cs
@@ -1,0 +1,31 @@
+﻿using System.Net;
+using System.Threading.Tasks;
+using Raven.Client;
+using Raven.Server.Documents.Handlers.Admin;
+using Raven.Server.Json;
+using Raven.Server.Routing;
+using Raven.Server.ServerWide.Commands;
+using Raven.Server.ServerWide.Context;
+
+namespace Raven.Server.Web.System
+{
+    public class AdminConfigurationHandler : AdminRequestHandler
+    {
+        [RavenAction("/admin/configuration/client", "PUT")]
+        public async Task PutClientConfiguration()
+        {
+            ServerStore.EnsureNotPassive();
+
+            using (ServerStore.ContextPool.AllocateOperationContext(out TransactionOperationContext ctx))
+            {
+                var clientConfigurationJson = ctx.ReadForDisk(RequestBodyStream(), Constants.Configuration.ClientId);
+
+                var clientConfiguration = JsonDeserializationServer.ClientConfiguration(clientConfigurationJson);
+                var res = await ServerStore.PutValueInClusterAsync(new PutClientConfigurationCommand(clientConfiguration));
+                await ServerStore.Cluster.WaitForIndexNotification(res.Etag);
+                
+                HttpContext.Response.StatusCode = (int)HttpStatusCode.Created;
+            }
+        }
+    }
+}

--- a/src/Raven.Server/Web/System/ConfigurationHandler.cs
+++ b/src/Raven.Server/Web/System/ConfigurationHandler.cs
@@ -1,0 +1,48 @@
+﻿using System.Net;
+using System.Threading.Tasks;
+using Raven.Client;
+using Raven.Client.Server.Operations.Configuration;
+using Raven.Server.Json;
+using Raven.Server.Routing;
+using Raven.Server.ServerWide.Commands;
+using Raven.Server.ServerWide.Context;
+using Sparrow.Json;
+
+namespace Raven.Server.Web.System
+{
+    public class ConfigurationHandler : RequestHandler
+    {
+        [RavenAction("/configuration/client", "GET")]
+        public Task GetClientConfiguration()
+        {
+            using (ServerStore.ContextPool.AllocateOperationContext(out TransactionOperationContext context))
+            {
+                using (context.OpenReadTransaction())
+                {
+                    var clientConfigurationJson = ServerStore.Cluster.Read(context, Constants.Configuration.ClientId, out long index);
+                    if (clientConfigurationJson == null)
+                    {
+                        HttpContext.Response.StatusCode = (int)HttpStatusCode.NotFound;
+                        return Task.CompletedTask;
+                    }
+
+                    using (var writer = new BlittableJsonTextWriter(context, ResponseBodyStream()))
+                    {
+                        writer.WriteStartObject();
+
+                        writer.WritePropertyName(nameof(GetClientConfigurationOperation.Result.RaftCommandIndex));
+                        writer.WriteInteger(index);
+                        writer.WriteComma();
+
+                        writer.WritePropertyName(nameof(GetClientConfigurationOperation.Result.Configuration));
+                        writer.WriteObject(clientConfigurationJson);
+
+                        writer.WriteEndObject();
+                    }
+                }
+            }
+
+            return Task.CompletedTask;
+        }
+    }
+}

--- a/src/Raven.Server/Web/System/DatabasesHandler.cs
+++ b/src/Raven.Server/Web/System/DatabasesHandler.cs
@@ -4,21 +4,18 @@ using System.Net;
 using System.Threading.Tasks;
 using Raven.Client;
 using Raven.Client.Documents.Indexes;
-using Raven.Client.Documents.Replication;
 using Raven.Client.Http;
 using Raven.Client.Server;
 using Raven.Client.Server.Operations;
 using Raven.Client.Util;
 using Raven.Server.Config;
 using Raven.Server.Documents;
-using Raven.Server.Documents.Expiration;
 using Raven.Server.Extensions;
 using Raven.Server.Routing;
 using Raven.Server.ServerWide;
 using Raven.Server.ServerWide.Context;
 using Sparrow.Json;
 using Sparrow.Json.Parsing;
-using DatabaseInfo = Raven.Client.Server.Operations.DatabaseInfo;
 
 namespace Raven.Server.Web.System
 {
@@ -139,16 +136,16 @@ namespace Raven.Server.Web.System
                         }
                         WriteDatabaseInfo(dbName, dbRecord, context, writer);
                     }
-                        return Task.CompletedTask;
-                    }
+                    return Task.CompletedTask;
                 }
             }
+        }
 
         private void WriteDatabaseInfo(string databaseName, BlittableJsonReaderObject dbRecordBlittable,
             TransactionOperationContext context, BlittableJsonTextWriter writer)
         {
             var online = ServerStore.DatabasesLandlord.DatabasesCache.TryGetValue(databaseName, out Task<DocumentDatabase> dbTask) &&
-                         dbTask != null && 
+                         dbTask != null &&
                          dbTask.IsCompleted;
 
             // Check for exceptions
@@ -157,15 +154,15 @@ namespace Raven.Server.Web.System
                 WriteFaultedDatabaseInfo(context, writer, dbTask, databaseName);
                 return;
             }
-           
+
             var dbRecord = JsonDeserializationCluster.DatabaseRecord(dbRecordBlittable);
             var db = online ? dbTask.Result : null;
 
             var indexingStatus = db?.IndexStore.Status ?? IndexRunningStatus.Running;
             // Looking for disabled indexing flag inside the database settings for offline database status
-            if (dbRecord.Settings.TryGetValue(RavenConfiguration.GetKey(x => x.Indexing.Disabled),out var val) && val == "true")
+            if (dbRecord.Settings.TryGetValue(RavenConfiguration.GetKey(x => x.Indexing.Disabled), out var val) && val == "true")
             {
-                 indexingStatus = IndexRunningStatus.Disabled;
+                indexingStatus = IndexRunningStatus.Disabled;
             }
             var disabled = dbRecord.Disabled;
             var topology = dbRecord.Topology;
@@ -195,8 +192,8 @@ namespace Raven.Server.Web.System
                         NodeTag = promotable,
                         Url = url
                     };
-                    var promotableTask = new PromotableTask(promotable,url,databaseName);
-                    nodesTopology.Promotables.Add(GetNodeId(node, topology.WhoseTaskIsIt(promotableTask,ServerStore.IsPassive())));
+                    var promotableTask = new PromotableTask(promotable, url, databaseName);
+                    nodesTopology.Promotables.Add(GetNodeId(node, topology.WhoseTaskIsIt(promotableTask, ServerStore.IsPassive())));
                 }
             }
 
@@ -253,7 +250,7 @@ namespace Raven.Server.Web.System
 
             context.Write(writer, doc);
         }
-        
+
         private static BackupInfo GetBackupInfo(DocumentDatabase db)
         {
             var periodicBackupRunner = db?.PeriodicBackupRunner;
@@ -274,7 +271,7 @@ namespace Raven.Server.Web.System
                 db.GetAllStoragesEnvironment().Sum(env => env.Environment.Stats().AllocatedDataFileSizeInBytes);
         }
 
-        private NodeId GetNodeId(InternalReplication node,string responsible = null)
+        private NodeId GetNodeId(InternalReplication node, string responsible = null)
         {
             var nodeId = new NodeId
             {

--- a/test/SlowTests/Issues/RavenDB_4636.cs
+++ b/test/SlowTests/Issues/RavenDB_4636.cs
@@ -1,0 +1,51 @@
+﻿using FastTests;
+using Raven.Client.Server.Operations.Configuration;
+using Xunit;
+
+namespace SlowTests.Issues
+{
+    public class RavenDB_4636 : RavenTestBase
+    {
+        [Fact]
+        public void CanInjectConfigurationFromServer()
+        {
+            using (var store = GetDocumentStore())
+            {
+                Assert.Equal(30, store.Conventions.MaxNumberOfRequestsPerSession);
+
+                var result = store.Admin.Server.Send(new GetClientConfigurationOperation());
+                Assert.Null(result);
+
+                store.Admin.Server.Send(new PutClientConfigurationOperation(new ClientConfiguration { MaxNumberOfRequestsPerSession = 10 }));
+
+                result = store.Admin.Server.Send(new GetClientConfigurationOperation());
+                Assert.NotNull(result);
+                Assert.True(result.RaftCommandIndex > 0);
+                Assert.Equal(10, result.Configuration.MaxNumberOfRequestsPerSession.Value);
+
+                using (var session = store.OpenSession())
+                {
+                    session.Load<dynamic>("users/1"); // forcing client configuration update
+                }
+
+                Assert.Equal(10, store.Conventions.MaxNumberOfRequestsPerSession);
+                Assert.Equal(result.RaftCommandIndex, store.GetRequestExecutor().ClientConfigurationEtag);
+
+                var differentRequestExecutor = store.GetRequestExecutor("DoNotExist");
+                Assert.Equal(result.RaftCommandIndex, differentRequestExecutor.ClientConfigurationEtag);
+
+                store.Admin.Server.Send(new PutClientConfigurationOperation(new ClientConfiguration { MaxNumberOfRequestsPerSession = 10, Disabled = true }));
+                result = store.Admin.Server.Send(new GetClientConfigurationOperation());
+
+                using (var session = store.OpenSession())
+                {
+                    session.Load<dynamic>("users/1"); // forcing client configuration update
+                }
+
+                Assert.Equal(30, store.Conventions.MaxNumberOfRequestsPerSession);
+                Assert.Equal(result.RaftCommandIndex, store.GetRequestExecutor().ClientConfigurationEtag);
+                Assert.Equal(result.RaftCommandIndex, differentRequestExecutor.ClientConfigurationEtag);
+            }
+        }
+    }
+}

--- a/test/Tests.Infrastructure/RavenTestBase.cs
+++ b/test/Tests.Infrastructure/RavenTestBase.cs
@@ -63,10 +63,10 @@ namespace FastTests
                 message += $"{Environment.NewLine}Url: {Servers[i].WebUrls[0]}. Applied: {tasks[i].IsCompleted}.";
                 if (tasks[i].IsCompleted == false)
                 {
-                    using (Servers[i].ServerStore.ContextPool.AllocateOperationContext(out TransactionOperationContext context))                    
+                    using (Servers[i].ServerStore.ContextPool.AllocateOperationContext(out TransactionOperationContext context))
                     {
                         context.OpenReadTransaction();
-                        message += $"{Environment.NewLine}Log state for non responsing server:{Environment.NewLine}{context.ReadObject(Servers[i].ServerStore.GetLogDetails(context),"LogSummary/"+i)}";
+                        message += $"{Environment.NewLine}Log state for non responsing server:{Environment.NewLine}{context.ReadObject(Servers[i].ServerStore.GetLogDetails(context), "LogSummary/" + i)}";
                     }
                 }
             }
@@ -135,9 +135,9 @@ namespace FastTests
                         Database = name,
                         ApiKey = apiKey
                     };
-                    ModifyStore(store);                    
+                    ModifyStore(store);
                     store.Initialize();
-                    
+
                     if (createDatabase)
                     {
                         foreach (var server in Servers)
@@ -229,10 +229,9 @@ namespace FastTests
 
         protected virtual void ModifyStore(DocumentStore store)
         {
-            store.CustomizeRequestExecutor += re =>
+            store.RequestExecutorCreated += (sender, executor) =>
             {
-                re.AdditionalErrorInformation += sb => sb.AppendLine().Append(GetLastStatesFromAllServersOrderedByTime());
-                return re;
+                executor.AdditionalErrorInformation += sb => sb.AppendLine().Append(GetLastStatesFromAllServersOrderedByTime());
             };
         }
 
@@ -329,7 +328,7 @@ namespace FastTests
         protected async Task<T> WaitForValueAsync<T>(Func<T> act, T expectedVal)
         {
             int timeout = 5000;// * (Debugger.IsAttached ? 100 : 1);
-            
+
             var sw = Stopwatch.StartNew();
             do
             {


### PR DESCRIPTION
- introduced ClientConfiguration that is persisted inside state machine
- ClientConfiguration will override DocumentConventions from any client connected to the server/cluster
- if ClientConfiguration will be Disabled then original configuration from conventions will be applied
- all created RequestExecutors in DocumentStore will update the ClientConfigurationEtag value automatically to avoid unnecessary requests to get the same configuration
- fixed condition for HasTopologyChanged in DocumentDatabase

Note: other configuration options will be added tomorrow or on Monday