### PR TITLE
RavenDB-7491 VoronStream.ReadByte() throws System.AccessViolationExce…

### DIFF
--- a/src/Voron/Data/VoronStream.cs
+++ b/src/Voron/Data/VoronStream.cs
@@ -49,6 +49,7 @@ namespace Voron.Data
             if (tx != null)
             {
                 _llt = tx.LowLevelTransaction;
+                _lastPage = default(Page);
                 return;
             }
 


### PR DESCRIPTION
…ption

Problem was that when the transaction changes, we should not rely on _lastPage anymore, it is not valid.