### PR TITLE
RavenDB-7503

### DIFF
--- a/src/Raven.Client/Http/OAuth/ApiKeyAuthenticator.cs
+++ b/src/Raven.Client/Http/OAuth/ApiKeyAuthenticator.cs
@@ -176,13 +176,7 @@ namespace Raven.Client.Http.OAuth
             var apiKeyParts = apiKey.Split(new[] { '/' }, StringSplitOptions.None);
             if (apiKeyParts.Length > 2)
             {
-                var secretIndex = 1;
-                if (apiKeyParts[0] == "Raven" && apiKeyParts.Length > 3)
-                {
-                    apiKeyParts[0] = $"{apiKeyParts[0]}/{apiKeyParts[1]}";
-                    secretIndex = 2;
-                }
-                apiKeyParts[1] = string.Join("/", apiKeyParts.Skip(secretIndex));
+                apiKeyParts[1] = string.Join("/", apiKeyParts.Skip(1));
             }
 
             if (apiKeyParts.Length < 2)

--- a/src/Raven.Client/Http/OAuth/ApiKeyAuthenticator.cs
+++ b/src/Raven.Client/Http/OAuth/ApiKeyAuthenticator.cs
@@ -176,7 +176,13 @@ namespace Raven.Client.Http.OAuth
             var apiKeyParts = apiKey.Split(new[] { '/' }, StringSplitOptions.None);
             if (apiKeyParts.Length > 2)
             {
-                apiKeyParts[1] = string.Join("/", apiKeyParts.Skip(1));
+                var secretIndex = 1;
+                if (apiKeyParts[0] == "Raven" && apiKeyParts.Length > 3)
+                {
+                    apiKeyParts[0] = $"{apiKeyParts[0]}/{apiKeyParts[1]}";
+                    secretIndex = 2;
+                }
+                apiKeyParts[1] = string.Join("/", apiKeyParts.Skip(secretIndex));
             }
 
             if (apiKeyParts.Length < 2)

--- a/src/Raven.Server/Program.cs
+++ b/src/Raven.Server/Program.cs
@@ -1,6 +1,7 @@
 using System;
 using System.IO;
 using System.Diagnostics;
+using System.IO.Pipes;
 using System.Linq;
 using System.Runtime.Loader;
 using System.Threading;
@@ -76,7 +77,7 @@ namespace Raven.Server
             LoggingSource.Instance.SetupLogMode(mode, Path.Combine(AppContext.BaseDirectory, configuration.Core.LogsDirectory));
 
             if (RavenWindowsServiceController.ShouldRunAsWindowsService(configuration))
-            {
+            {                
                 RavenWindowsServiceController.Run(configuration);
                 return 0;
             }
@@ -96,8 +97,9 @@ namespace Raven.Server
                     {
                         try
                         {
+                            server.OpenPipe();
                             server.Initialize();
-
+                            
                             if (CommandLineSwitches.PrintServerId)
                                 Console.WriteLine($"Server ID is {server.ServerStore.GetServerId()}.");
                             
@@ -118,8 +120,7 @@ namespace Raven.Server
                                         Console.Error.WriteLine($"Tcp listen failure (see {server.ServerStore.NodeHttpServerUrl}/info/tcp for details) {tcp.Exception.Message}");
                                     }
                                 });
-                            Console.WriteLine("Server started, listening to requests...");
-
+                            Console.WriteLine("Server started, listening to requests...");                            
                             if (CommandLineSwitches.Daemon)
                             {
                                 RunAsService();

--- a/src/Raven.Server/Raven.Server.csproj
+++ b/src/Raven.Server/Raven.Server.csproj
@@ -81,6 +81,7 @@
     <PackageReference Include="Portable.BouncyCastle" Version="1.8.1.2" />
     <PackageReference Include="System.ComponentModel" Version="4.3.0" />
     <PackageReference Include="System.Data.SqlClient" Version="4.3.1" />
+    <PackageReference Include="System.IO.Pipes" Version="4.3.0" />
     <PackageReference Include="System.Reflection.Emit.Lightweight" Version="4.3.0" />
     <PackageReference Include="System.Runtime.Loader" Version="4.3.0" />
     <PackageReference Include="System.Security.Cryptography.Csp" Version="4.3.0" />

--- a/src/Raven.Server/RavenServer.cs
+++ b/src/Raven.Server/RavenServer.cs
@@ -3,6 +3,7 @@ using System.Collections.Concurrent;
 using System.Collections.Generic;
 using System.Diagnostics;
 using System.IO;
+using System.IO.Pipes;
 using System.Linq;
 using System.Net;
 using System.Net.Security;
@@ -39,6 +40,7 @@ using AccessToken = Raven.Server.Web.Authentication.AccessToken;
 using System.Reflection;
 using Raven.Server.ServerWide.Commands;
 using Raven.Server.ServerWide.Context;
+using Sparrow.Platform;
 
 namespace Raven.Server
 {
@@ -119,7 +121,10 @@ namespace Raven.Server
                 _logger.Info(string.Format("Server store started took {0:#,#;;0} ms", sp.ElapsedMilliseconds));
 
             sp.Restart();
-
+            if (Pipe != null)
+            {
+                Task.Factory.StartNew(ListenToPipe);
+            }
             Router = new RequestRouter(RouteScanner.Scan(), this);
 
             try
@@ -181,6 +186,95 @@ namespace Raven.Server
                 if (_logger.IsOperationsEnabled)
                     _logger.Operations("Could not start server", e);
                 throw;
+            }
+        }
+
+        private async Task ListenToPipe()
+        {
+            while (true)
+            {
+                try
+                {
+                    await Pipe.WaitForConnectionAsync();                    
+                    using (var reader = new StreamReader(Pipe))
+                    using (var writer = new StreamWriter(Pipe))
+                    {
+                        try
+                        {
+                            var msg = reader.ReadLine();
+                            var tokens = msg.Split(new[] { ' ' }, StringSplitOptions.RemoveEmptyEntries);
+
+                            if (tokens.Length < 1)
+                            {
+                                var reply = "Expected 'trust' or 'init' but got nothing";
+                                PipeLogAndReply(writer, reply);
+                                continue;
+                            }
+
+                            switch (tokens[0])
+                            {
+                                case "trust":
+                                    if (tokens.Length < 3)
+                                    {
+                                        msg = $"Expected 'trust' followed by public key and tag but didn't get both of them";
+                                        PipeLogAndReply(writer, msg);
+                                        continue;
+                                    }                                    
+                                    var k = $"Raven/Sign/Public/{tokens[2]}";
+                                    ServerStore.PutSecretKey(tokens[1], k, true);                                    
+                                    writer.WriteLine($"Server {tokens[2]} public key {tokens[1]} was installed successfully");
+                                    writer.Flush();
+                                    break;
+                                case "init":                                    
+                                    var (api_key, pub_key) = await ServerStore.GetApiKeyAndPublicKey();
+                                    writer.WriteLine($"{api_key} public key={pub_key}");
+                                    writer.Flush();                                    
+                                    break;
+                                default:
+                                    var reply = $"Provided command {tokens[0]} isn't supported";
+                                    PipeLogAndReply(writer, reply);
+                                    continue;
+
+                            }
+                        }
+                        catch (Exception e)
+                        {
+                            var msg = "Got an exception trying to communicate through the pipe";
+                            if (_logger.IsInfoEnabled)
+                            {
+                                _logger.Info(msg, e);
+                            }
+                            PipeLogAndReply(writer,$"{msg}{Environment.NewLine}{e}");
+                            continue;
+                        }
+                    }
+                    
+                }
+                catch (ObjectDisposedException)
+                {
+                    //Server shutting down
+                    return;
+                }
+                catch (Exception e)
+                {
+                    if (_logger.IsInfoEnabled)
+                    {
+                        _logger.Info("Got an exception trying to connect to server pipe", e);
+                    }
+                }
+                //From what i read we should not re-use a pipe.
+                Pipe.Dispose();
+                OpenPipe();
+            }
+        }
+
+        private static void PipeLogAndReply(StreamWriter writer, string reply)
+        {
+            writer.Write(reply);
+            writer.Flush();
+            if (_logger.IsInfoEnabled)
+            {
+                _logger.Info(reply);
             }
         }
 
@@ -658,6 +752,7 @@ namespace Raven.Server
         public MetricsCountersManager Metrics { get; private set; }
 
         public bool Disposed { get; private set; }
+        internal NamedPipeServerStream Pipe { get; set; }
 
         public void Dispose()
         {
@@ -669,6 +764,7 @@ namespace Raven.Server
                     return;
 
                 Disposed = true;
+                Pipe?.Dispose();
                 Metrics?.Dispose();
                 _webHost?.Dispose();
                 if (_tcpListenerTask != null)
@@ -716,6 +812,15 @@ namespace Raven.Server
                 }
             }
 
+        }
+
+        public const string PipePrefix = "raven-control-pipe-";
+        public void OpenPipe()
+        {
+            var pipeName = PipePrefix + Process.GetCurrentProcess().Id;
+
+            Pipe = new NamedPipeServerStream(pipeName, PipeDirection.InOut, 1, PipeTransmissionMode.Byte,
+                PipeOptions.None, 1024, 1024);
         }
     }
 }

--- a/src/Raven.Server/ServerWide/ServerStore.cs
+++ b/src/Raven.Server/ServerWide/ServerStore.cs
@@ -5,6 +5,7 @@ using System.IO;
 using System.Linq;
 using System.Net.Http;
 using System.Security.Cryptography;
+using System.ServiceModel;
 using System.Text;
 using System.Threading;
 using System.Threading.Tasks;
@@ -18,10 +19,12 @@ using Raven.Client.Json;
 using Raven.Client.Server;
 using Raven.Client.Server.ETL;
 using Raven.Client.Server.Operations;
+using Raven.Client.Server.Operations.ApiKeys;
 using Raven.Server.Commercial;
 using Raven.Server.Config;
 using Raven.Server.Documents;
 using Raven.Server.Documents.Operations;
+using Raven.Server.Json;
 using Raven.Server.NotificationCenter;
 using Raven.Server.Rachis;
 using Raven.Server.NotificationCenter.Notifications;
@@ -1395,12 +1398,78 @@ namespace Raven.Server.ServerWide
 
         }
 
+        private const string SystemApiKey = "Raven/System";
+        public async Task<(string api_key, string public_key)> GetApiKeyAndPublicKey()
+        {
+            TransactionOperationContext context;
+            using (ContextPool.AllocateOperationContext(out context))
+            using (context.OpenReadTransaction())
+            {
+                var key = Cluster.Read(context, SystemApiKey);
+                string keyFullName;
+                if (key == null)
+                {
+                    EnsureNotPassive();
+                    //making sure we are leaders, we might be followers and fail but that is okay.                    
+                    if (await Engine.WaitForState(RachisConsensus.State.Leader).WaitWithTimeout(TimeSpan.FromSeconds(5)) == false)
+                    {
+                        var msg = "Was requested to get api key and public key but i haven't became leader after 5 seconds";
+                        if (Logger.IsInfoEnabled)
+                        {
+                            Logger.Info(msg);
+                        }
+                        throw new TimeoutException(msg);
+                    }
+                    var secret = GenerateRandomSecret();
+                    var defintions = new ApiKeyDefinition
+                    {
+                        Enabled = true,
+                        ResourcesAccessMode = new Dictionary<string, AccessModes> { { "*",AccessModes.Admin} },
+                        Secret = secret,
+                        ServerAdmin = true
+                    };
+                    var createApiKey = new PutApiKeyCommand(SystemApiKey, defintions);
+                    var index = (await Engine.PutAsync(createApiKey)).Etag;
+                    if (await Engine.WaitForCommitIndexChange(RachisConsensus.CommitIndexModification.GreaterOrEqual, index).WaitWithTimeout(TimeSpan.FromSeconds(5)) == false)
+                    {
+                        var msg = "Waited for 5 seconds for Raven/System to be commited but it wasn't";
+                        if (Logger.IsInfoEnabled)
+                        {
+                            Logger.Info(msg);
+                        }
+                        throw new TimeoutException(msg);
+                    }
+                    keyFullName = $"Key={SystemApiKey}/{secret}";
+                }
+                else
+                {
+                    var desKey = JsonDeserializationServer.ApiKeyDefinition(key);
+                    keyFullName = $"Key={SystemApiKey}/{desKey.Secret}";
+                }
+                return (keyFullName, Convert.ToBase64String(SignPublicKey));
+            }            
+        }
+
+        private const string secretCharacters = "0123456789abcdefghijklmnopqrstuvwxyzABCDEFGHIJKLMNOPQRSTUVWXYZ";
+        private string GenerateRandomSecret()
+        {
+            var rand = new Random();
+            var secretLength = (int)(22 * rand.NextDouble()) + 10;
+            var sb = new StringBuilder();
+            for (int i = 0; i < secretLength; i++)
+            {
+                sb.Append(secretCharacters[rand.Next(secretCharacters.Length)]);
+            }
+            return sb.ToString();
+        }
+		
         public bool HasClientConfigurationChanged(long index)
         {
             if (index < 0)
                 return false;
 
             return _lastClientConfigurationIndex > index;
-        }
+        }		
+
     }
 }

--- a/src/Raven.Server/ServerWide/ServerStore.cs
+++ b/src/Raven.Server/ServerWide/ServerStore.cs
@@ -1398,8 +1398,8 @@ namespace Raven.Server.ServerWide
 
         }
 
-        private const string SystemApiKey = "Raven/System";
-        public async Task<(string api_key, string public_key)> GetApiKeyAndPublicKey()
+        private const string SystemApiKey = "Raven:System";
+        public async Task<(string apiKey, string publicKey)> GetApiKeyAndPublicKey()
         {
             TransactionOperationContext context;
             using (ContextPool.AllocateOperationContext(out context))

--- a/src/Raven.Server/Web/Authentication/AdminApiKeysHandler.cs
+++ b/src/Raven.Server/Web/Authentication/AdminApiKeysHandler.cs
@@ -23,8 +23,8 @@ namespace Raven.Server.Web.Authentication
         public async Task Put()
         {
             var name = GetQueryStringValueAndAssertIfSingleAndNotEmpty("name");
-            if (name.StartsWith("Raven/", StringComparison.OrdinalIgnoreCase))
-                throw new InvalidOperationException($"Can't create api key named {name}, api keys starting with 'Raven/' are reserved");
+            if (name.StartsWith("Raven:", StringComparison.OrdinalIgnoreCase))
+                throw new InvalidOperationException($"Can't create api key named {name}, api keys starting with 'Raven:' are reserved");
 
             // one of the first admin action is to create an API key, so let
             // us also use that to indicate that we are the seed node
@@ -55,8 +55,8 @@ namespace Raven.Server.Web.Authentication
         public async Task Delete()
         {
             var name = GetQueryStringValueAndAssertIfSingleAndNotEmpty("name");
-            if (name.StartsWith("Raven/", StringComparison.OrdinalIgnoreCase))
-                throw new InvalidOperationException($"Can't delete api key named {name}, api keys starting with 'Raven/' are protected");
+            if (name.StartsWith("Raven:", StringComparison.OrdinalIgnoreCase))
+                throw new InvalidOperationException($"Can't delete api key named {name}, api keys starting with 'Raven:' are protected");
             TransactionOperationContext ctx;
             using (ServerStore.ContextPool.AllocateOperationContext(out ctx))
             {
@@ -68,6 +68,13 @@ namespace Raven.Server.Web.Authentication
             }
         }
 
+        [RavenAction("/admin/server/reset-pipe", "GET", "/admin/server/reset-pipe")]
+        public async Task ResetServerPipe()
+        {
+            Server.Pipe?.Dispose();
+            Server.OpenPipe();
+            await Server.ListenToPipe();
+        }
 
         [RavenAction("/admin/api-keys", "GET", "/admin/api-keys")]
         public Task GetAll()

--- a/tools/rvn/rvn.csproj
+++ b/tools/rvn/rvn.csproj
@@ -28,6 +28,9 @@
     </None>
   </ItemGroup>
   <ItemGroup>
+    <PackageReference Include="System.IO.Pipes" Version="4.3.0" />
+  </ItemGroup>
+  <ItemGroup>
     <ProjectReference Include="..\..\src\Raven.Server\Raven.Server.csproj" />
     <ProjectReference Include="..\..\src\Sparrow\Sparrow.csproj" />
   </ItemGroup>


### PR DESCRIPTION
* Now allowing api keys with '/' as long as they are starting with Raven/ and properly split their secret.
* Opening an async task listening to a named pipe constructed as raven-control-pipe-<raven server pid>
* Added a method to create a system api key named Raven/System to be used by the admin in harden environment
* Added trust/init methods to RVN tool, still need TLC will open another issue to have better error handling and validation in RVN