### PR TITLE
RavenDB-7672 Access violation when trying to open ongoing tasks in st…

### DIFF
--- a/src/Raven.Server/Documents/DocumentsTransaction.cs
+++ b/src/Raven.Server/Documents/DocumentsTransaction.cs
@@ -69,9 +69,11 @@ namespace Raven.Server.Documents
                 _context.Transaction = null;
             }
 
+            var committed = InnerTransaction.LowLevelTransaction.Committed;
+
             base.Dispose();
 
-            if (InnerTransaction.LowLevelTransaction.Committed)
+            if (committed)
                 AfterCommit();
         }
 

--- a/src/Raven.Server/RavenServer.cs
+++ b/src/Raven.Server/RavenServer.cs
@@ -534,6 +534,11 @@ namespace Raven.Server
             }
 
             tcp.DocumentDatabase = await databaseLoadingTask;
+            if(tcp.DocumentDatabase == null)
+                DatabaseDoesNotExistException.Throw(header.DatabaseName);
+
+            Debug.Assert(tcp.DocumentDatabase != null);
+
             if (tcp.DocumentDatabase.DatabaseShutdown.IsCancellationRequested)
                 ThrowDatabaseShutdown(tcp.DocumentDatabase);
 

--- a/src/Raven.Server/ServerWide/RavenTransaction.cs
+++ b/src/Raven.Server/ServerWide/RavenTransaction.cs
@@ -5,7 +5,7 @@ namespace Raven.Server.ServerWide
 {
     public class RavenTransaction : IDisposable
     {
-        public readonly Transaction InnerTransaction;
+        public Transaction InnerTransaction;
 
         public RavenTransaction(Transaction transaction)
         {
@@ -31,6 +31,7 @@ namespace Raven.Server.ServerWide
             Disposed = true;
 
             InnerTransaction?.Dispose();
+            InnerTransaction = null;
         }
     }
 }


### PR DESCRIPTION
…udio

- Fix use of transaction after Dispose
- When transaction disposes, set it to null
- From now on, these kind of errors will be caught as NullReferenceException instead of access violation
- Fix another NRE when loading unknown db in databaseLoadingTask