### PR TITLE
RavenDB-7353 :

### DIFF
--- a/src/Raven.Server/ServerWide/ServerStore.cs
+++ b/src/Raven.Server/ServerWide/ServerStore.cs
@@ -488,7 +488,7 @@ namespace Raven.Server.ServerWide
                 {
                     RefreshOutgoingTasks();
                 }
-                if (state.To == RachisConsensus.State.Leader)
+                if (state.To == RachisConsensus.State.LeaderElect)
                 {
                     _engine.CurrentLeader.OnNodeStatusChange += OnTopologyChanged;
                 }


### PR DESCRIPTION
 - set Leader.OnNodeStatusChange when state changes to LeaderElect (instead of Leader)
 - set the new _currentLeader before invoking StateChanged