### PR TITLE
RavenDB-7708 Fix Racing test: ReplicationResolveToDatabase.ResovleToD…

### DIFF
--- a/src/Raven.Server/Documents/Replication/ResolveConflictOnReplicationConfigurationChange.cs
+++ b/src/Raven.Server/Documents/Replication/ResolveConflictOnReplicationConfigurationChange.cs
@@ -59,8 +59,7 @@ namespace Raven.Server.Documents.Replication
         {
             try
             {
-                DocumentsOperationContext context;
-                using (_database.DocumentsStorage.ContextPool.AllocateOperationContext(out context))
+                using (_database.DocumentsStorage.ContextPool.AllocateOperationContext(out DocumentsOperationContext context))
                 {
                     using (context.OpenReadTransaction())
                     {
@@ -124,7 +123,7 @@ namespace Raven.Server.Documents.Replication
                         {
                             var cmd = new PutResolvedConflictsCommand(_database.DocumentsStorage.ConflictsStorage, resolvedConflicts, this);
                             await _database.TxMerger.Enqueue(cmd);
-                            if(cmd.RequiresRetry)
+                            if (cmd.RequiresRetry)
                                 RunConflictResolversOnce();
                         }
                     }
@@ -162,7 +161,7 @@ namespace Raven.Server.Documents.Replication
                     using (Slice.External(context.Allocator, item.ResolvedConflict.LowerId, out var slice))
                     {
                         // let's check if nothing has changed since we resolved the conflict in the read tx
-                        // in particulal the conflict could be resolved externally before the tx merger opened this write tx
+                        // in particular the conflict could be resolved externally before the tx merger opened this write tx
 
                         if (_conflictsStorage.ShouldThrowConcurrencyExceptionOnConflict(context, slice, item.MaxConflictEtag, out var _))
                             continue;

--- a/src/Raven.Server/Web/System/AdminDatabasesHandler.cs
+++ b/src/Raven.Server/Web/System/AdminDatabasesHandler.cs
@@ -545,7 +545,7 @@ namespace Raven.Server.Web.System
         }
 
         [RavenAction("/admin/update-resolver", "POST", "/admin/update-resolver?name={databaseName:string}")]
-        public async Task ChangeConflictResolver()
+        public async Task UpdateConflictResolver()
         {
             var name = GetQueryStringValueAndAssertIfSingleAndNotEmpty("name");
             if (ResourceNameValidator.IsValidResourceName(name, ServerStore.Configuration.Core.DataDirectory.FullPath, out string errorMessage) == false)

--- a/test/FastTests/Server/Basic/MaxSecondsForTaskToWaitForDatabaseToLoad.cs
+++ b/test/FastTests/Server/Basic/MaxSecondsForTaskToWaitForDatabaseToLoad.cs
@@ -66,11 +66,11 @@ namespace FastTests.Server.Basic
                 Assert.Throws<DatabaseLoadTimeoutException>(() =>
                 {
                     using (var ctx = JsonOperationContext.ShortTermSingleUse())
-                    using (var reqExecuter = RequestExecutor.CreateForSingleNode(url, name, null))
+                    using (var requestExecutor = RequestExecutor.CreateForSingleNode(url, name, null))
                     {
-                        reqExecuter.Execute(
+                        requestExecutor.Execute(
                             new CreateDatabaseOperation(doc).GetCommand(new DocumentConventions(), ctx), ctx);
-                        reqExecuter.Execute(new GetDocumentCommand("Raven/HiloPrefix", includes: null, transformer: null, transformerParameters: null, metadataOnly: false), ctx);
+                        requestExecutor.Execute(new GetDocumentCommand("Raven/HiloPrefix", includes: null, transformer: null, transformerParameters: null, metadataOnly: false), ctx);
                     }
                 });
             }
@@ -84,7 +84,7 @@ namespace FastTests.Server.Basic
         private static DatabaseRecord GenerateDatabaseDoc(string name)
         {
             var doc = MultiDatabase.CreateDatabaseDocument(name);
-            doc.Settings[RavenConfiguration.GetKey(x => x.Replication.ReplicationMinimalHeartbeat)] = "10";
+            doc.Settings[RavenConfiguration.GetKey(x => x.Replication.ReplicationMinimalHeartbeat)] = "1";
             doc.Settings[RavenConfiguration.GetKey(x => x.Core.RunInMemory)] = "true";
             doc.Settings[RavenConfiguration.GetKey(x => x.Core.ThrowIfAnyIndexOrTransformerCouldNotBeOpened)] = "true";
             doc.Settings[RavenConfiguration.GetKey(x => x.Indexing.MinNumberOfMapAttemptsAfterWhichBatchWillBeCanceledIfRunningLowOnMemory)] = int.MaxValue.ToString();

--- a/test/SlowTests/Server/Replication/ReplicationResolveToLeader.cs
+++ b/test/SlowTests/Server/Replication/ReplicationResolveToLeader.cs
@@ -11,7 +11,7 @@ namespace SlowTests.Server.Replication
     public class ReplicationResolveToDatabase : ReplicationTestsBase, IDocumentTombstoneAware
     {
         [Fact]
-        public async Task ResovleToDatabase()
+        public async Task ResolveToDatabase()
         {
             using (var store1 = GetDocumentStore())
             using (var store2 = GetDocumentStore())
@@ -42,7 +42,7 @@ namespace SlowTests.Server.Replication
         }
 
         [Fact]
-        public async Task ResovleToDatabaseComplex()
+        public async Task ResolveToDatabaseComplex()
         {
             // store2 <--> store1 --> store3
             using (var store1 = GetDocumentStore())
@@ -75,8 +75,7 @@ namespace SlowTests.Server.Replication
                 // store2 <--> store1 <--> store3*               
                 var documentDatabase = Server.ServerStore.DatabasesLandlord.TryGetOrCreateResourceStore(store3.Database).Result;
                 //this waits for the information to propagate in the cluster
-                await UpdateConflictResolver(store3,
-                    resovlerDbId: documentDatabase.DbId.ToString());
+                await UpdateConflictResolver(store3, resovlerDbId: documentDatabase.DbId.ToString());
                 await SetupReplicationAsync(store3, store1);
 
                 Assert.True(WaitForDocument<User>(store1, "foo/bar", u => u.Name == "Leader"));
@@ -140,8 +139,8 @@ namespace SlowTests.Server.Replication
 
 
                 // store2 <--> store1 --> store3*
-                var databaseResovlerId = GetDocumentDatabaseInstanceFor(store3).Result.DbId.ToString();
-                await UpdateConflictResolver(store3, databaseResovlerId);
+                var databaseResolverId = GetDocumentDatabaseInstanceFor(store3).Result.DbId.ToString();
+                await UpdateConflictResolver(store3, databaseResolverId);
 
                 using (var session = store3.OpenSession())
                 {
@@ -156,8 +155,8 @@ namespace SlowTests.Server.Replication
                 }
 
                 // store2 <--> store1 --> store3*
-                databaseResovlerId = GetDocumentDatabaseInstanceFor(store3).Result.DbId.ToString();
-                await UpdateConflictResolver(store3, databaseResovlerId);
+                databaseResolverId = GetDocumentDatabaseInstanceFor(store3).Result.DbId.ToString();
+                await UpdateConflictResolver(store3, databaseResolverId);
 
                 Assert.True(WaitForDocument<User>(store1, "foo/bar", u => u.Name == "Leader"));
                 Assert.True(WaitForDocument<User>(store2, "foo/bar", u => u.Name == "Leader"));
@@ -184,8 +183,8 @@ namespace SlowTests.Server.Replication
 
                 // store1* --> store2
                 var documentDatabase = Server.ServerStore.DatabasesLandlord.TryGetOrCreateResourceStore(store1.Database).Result;
-                var databaseResovlerId = documentDatabase.DbId.ToString();
-                await UpdateConflictResolver(store2, databaseResovlerId);
+                var databaseResolverId = documentDatabase.DbId.ToString();
+                await UpdateConflictResolver(store2, databaseResolverId);
                 await SetupReplicationAsync(store1, store2);
 
                 Assert.True(WaitForDocument<User>(store2, "foo/bar", u => u.Name == "Karmel"));
@@ -254,7 +253,6 @@ namespace SlowTests.Server.Replication
             {
                 ["Users"] = 0
             };
-
         }
     }
 }

--- a/test/Tests.Infrastructure/ClusterTestBase.cs
+++ b/test/Tests.Infrastructure/ClusterTestBase.cs
@@ -421,8 +421,7 @@ namespace Tests.Infrastructure
             {
                 states = GetLastStatesFromAllServersOrderedByTime();
             }
-            Assert.True(condition,
-                "The leader has changed while waiting for cluster to become stable. All nodes status: " + states);
+            Assert.True(condition, "The leader has changed while waiting for cluster to become stable. All nodes status: " + states);
             return leader;
         }
 

--- a/test/Tests.Infrastructure/RavenTestBase.cs
+++ b/test/Tests.Infrastructure/RavenTestBase.cs
@@ -118,7 +118,7 @@ namespace FastTests
                     }
 
                     var doc = MultiDatabase.CreateDatabaseDocument(name);
-                    doc.Settings[RavenConfiguration.GetKey(x => x.Replication.ReplicationMinimalHeartbeat)] = "100";
+                    doc.Settings[RavenConfiguration.GetKey(x => x.Replication.ReplicationMinimalHeartbeat)] = "1";
                     doc.Settings[RavenConfiguration.GetKey(x => x.Core.RunInMemory)] = runInMemory.ToString();
                     doc.Settings[RavenConfiguration.GetKey(x => x.Core.DataDirectory)] = path;
                     doc.Settings[RavenConfiguration.GetKey(x => x.Core.ThrowIfAnyIndexOrTransformerCouldNotBeOpened)] = "true";


### PR DESCRIPTION
…atabaseComplex which failed because of ReplicationMinimalHeartbeat is now in seconds and not in milliseconds.