### PR TITLE
RavenDB-7727 When sending a revision of a document that is newer then…

### DIFF
--- a/src/Raven.Server/Documents/DocumentFlags.cs
+++ b/src/Raven.Server/Documents/DocumentFlags.cs
@@ -30,6 +30,7 @@ namespace Raven.Server.Documents
         FromSmuggler = 0x4,
         FromReplication = 0x8,
         ByAttachmentUpdate = 0x10,
-        ResolveAttachmentsConflict = 0x20
+        ResolveAttachmentsConflict = 0x20,
+        FromRevision = 0x40,
     }
 }

--- a/src/Raven.Server/Documents/DocumentPutAction.cs
+++ b/src/Raven.Server/Documents/DocumentPutAction.cs
@@ -134,7 +134,8 @@ namespace Raven.Server.Documents
                         if (_documentDatabase.DocumentsStorage.RevisionsStorage.ShouldVersionDocument(collectionName, nonPersistentFlags, oldDoc, document,
                             ref flags, out RevisionsCollectionConfiguration configuration))
                         {
-                            _documentDatabase.DocumentsStorage.RevisionsStorage.Put(context, id, document, flags, nonPersistentFlags, changeVector, modifiedTicks, configuration);
+                            _documentDatabase.DocumentsStorage.RevisionsStorage.Put(context, id, document, flags, nonPersistentFlags, 
+                                changeVector, modifiedTicks, configuration, collectionName);
                         }
                     }
                 }

--- a/src/Raven.Server/Documents/Replication/IncomingReplicationHandler.cs
+++ b/src/Raven.Server/Documents/Replication/IncomingReplicationHandler.cs
@@ -923,7 +923,8 @@ namespace Raven.Server.Documents.Replication
                                                         context, keySlice, item.Id, null,
                                                         item.LastModifiedTicks,
                                                         _changeVector,
-                                                        context.GetLazyString(item.Collection));
+                                                        new CollectionName(item.Collection),
+                                                        NonPersistentDocumentFlags.FromReplication);
                                                 }
                                             }
                                             break;

--- a/src/Raven.Server/Documents/Replication/LiveReplicationPerformanceCollector.cs
+++ b/src/Raven.Server/Documents/Replication/LiveReplicationPerformanceCollector.cs
@@ -151,8 +151,7 @@ namespace Raven.Server.Documents.Replication
 
         private void OutgoingHandlerRemoved(OutgoingReplicationHandler handler)
         {
-            ReplicationHandlerAndPerformanceStatsList<OutgoingReplicationHandler, OutgoingReplicationStatsAggregator> stats;
-            if (_outgoing.TryRemove(handler, out stats))
+            if (_outgoing.TryRemove(handler, out ReplicationHandlerAndPerformanceStatsList<OutgoingReplicationHandler, OutgoingReplicationStatsAggregator> stats))
                 stats.Handler.DocumentsSend -= OutgoingDocumentsSend;
         }
 
@@ -168,8 +167,7 @@ namespace Raven.Server.Documents.Replication
 
         private void OutgoingDocumentsSend(OutgoingReplicationHandler handler)
         {
-            ReplicationHandlerAndPerformanceStatsList<OutgoingReplicationHandler, OutgoingReplicationStatsAggregator> stats;
-            if (_outgoing.TryGetValue(handler, out stats) == false)
+            if (_outgoing.TryGetValue(handler, out ReplicationHandlerAndPerformanceStatsList<OutgoingReplicationHandler, OutgoingReplicationStatsAggregator> stats) == false)
             {
                 // possible?
                 return;

--- a/src/Raven.Server/Documents/Replication/OutgoingReplicationHandler.cs
+++ b/src/Raven.Server/Documents/Replication/OutgoingReplicationHandler.cs
@@ -122,6 +122,7 @@ namespace Raven.Server.Documents.Replication
             var node = Destination as InternalReplication;
             return node?.NodeTag;
         }
+
         private void ReplicateToDestination()
         {
             NativeMemory.EnsureRegistered();
@@ -207,6 +208,11 @@ namespace Raven.Server.Documents.Replication
                         {
                             while (true)
                             {
+#if DEBUG
+                                _parent.WaitFormTest.WaitAsync().Wait(_cts.Token);
+                                _parent.WaitFormTest.Reset();
+#endif
+
                                 var sp = Stopwatch.StartNew();
                                 var stats = _lastStats = new OutgoingReplicationStatsAggregator(_parent.GetNextReplicationStatsId(), _lastStats);
                                 AddReplicationPerformance(stats);
@@ -231,7 +237,7 @@ namespace Raven.Server.Documents.Replication
                                         }
                                         catch (OperationCanceledException)
                                         {
-                                            //cancelation is not an actual error,
+                                            //cancellation is not an actual error,
                                             //it is a "notification" that we need to cancel current operation
                                             throw;
                                         }

--- a/src/Raven.Server/Documents/Replication/OutgoingReplicationHandler.cs
+++ b/src/Raven.Server/Documents/Replication/OutgoingReplicationHandler.cs
@@ -209,8 +209,11 @@ namespace Raven.Server.Documents.Replication
                             while (true)
                             {
 #if DEBUG
-                                _parent.WaitFormTest.WaitAsync().Wait(_cts.Token);
-                                _parent.WaitFormTest.Reset();
+                                if (_parent.WaitFormTest != null)
+                                {
+                                    _parent.WaitFormTest.WaitAsync().Wait(_cts.Token);
+                                    _parent.WaitFormTest.Reset();
+                                }
 #endif
 
                                 var sp = Stopwatch.StartNew();

--- a/src/Raven.Server/Documents/Replication/ReplicationLoader.cs
+++ b/src/Raven.Server/Documents/Replication/ReplicationLoader.cs
@@ -24,6 +24,7 @@ using Sparrow.Json;
 using Sparrow.Json.Parsing;
 using Sparrow.Logging;
 using Raven.Server.Utils;
+using Sparrow;
 using Sparrow.Utils;
 
 namespace Raven.Server.Documents.Replication
@@ -37,6 +38,10 @@ namespace Raven.Server.Documents.Replication
 
         public event Action<OutgoingReplicationHandler> OutgoingReplicationAdded;
         public event Action<OutgoingReplicationHandler> OutgoingReplicationRemoved;
+
+#if DEBUG
+        public AsyncManualResetEvent WaitFormTest;
+#endif
 
         public readonly DocumentDatabase Database;
         private volatile bool _isInitialized;

--- a/src/Raven.Server/Documents/Replication/ResolveConflictOnReplicationConfigurationChange.cs
+++ b/src/Raven.Server/Documents/Replication/ResolveConflictOnReplicationConfigurationChange.cs
@@ -287,7 +287,7 @@ namespace Raven.Server.Documents.Replication
                 using (Slice.External(context.Allocator, conflict.LowerId, out Slice lowerId))
                 {
                     _database.DocumentsStorage.Delete(context, lowerId, conflict.Id, null,
-                        _database.Time.GetUtcNow().Ticks, conflict.ChangeVector, conflict.Collection);
+                        _database.Time.GetUtcNow().Ticks, conflict.ChangeVector, new CollectionName(conflict.Collection));
                     return;
                 }
             }

--- a/src/Raven.Server/Documents/Revisions/RevisionsStorage.cs
+++ b/src/Raven.Server/Documents/Revisions/RevisionsStorage.cs
@@ -4,7 +4,9 @@ using System.Diagnostics;
 using System.Linq;
 using System.Runtime.CompilerServices;
 using Raven.Client;
+using Raven.Client.Documents.Exceptions;
 using Raven.Client.Documents.Replication.Messages;
+using Raven.Client.Extensions;
 using Raven.Client.Server;
 using Raven.Client.Server.Revisions;
 using Raven.Server.NotificationCenter.Notifications;
@@ -54,6 +56,7 @@ namespace Raven.Server.Documents.Revisions
             Flags = 6,
             Etag2 = 7, // Needed to get the revisions bin entries with a consistent order
             LastModified = 8,
+            TransactionMarker = 9
         }
 
         private readonly RevisionsCollectionConfiguration _emptyConfiguration = new RevisionsCollectionConfiguration();
@@ -214,17 +217,19 @@ namespace Raven.Server.Documents.Revisions
 
         public void Put(DocumentsOperationContext context, string id, BlittableJsonReaderObject document,
             DocumentFlags flags, NonPersistentDocumentFlags nonPersistentFlags, ChangeVectorEntry[] changeVector, long lastModifiedTicks,
-            RevisionsCollectionConfiguration configuration = null)
+            RevisionsCollectionConfiguration configuration = null, CollectionName collectionName = null)
         {
             Debug.Assert(changeVector != null, "Change vector must be set");
 
             BlittableJsonReaderObject.AssertNoModifications(document, id, assertChildren: true);
 
-            var collectionName = _database.DocumentsStorage.ExtractCollectionName(context, id, document);
+            if (collectionName == null)
+                collectionName = _database.DocumentsStorage.ExtractCollectionName(context, id, document);
 
             using (DocumentIdWorker.GetLowerIdSliceAndStorageKey(context, id, out Slice lowerId, out Slice idPtr))
             {
-                var notFromSmuggler = (nonPersistentFlags & NonPersistentDocumentFlags.FromSmuggler) != NonPersistentDocumentFlags.FromSmuggler;
+                var fromSmuggler = (nonPersistentFlags & NonPersistentDocumentFlags.FromSmuggler) == NonPersistentDocumentFlags.FromSmuggler;
+                var fromReplication = (nonPersistentFlags & NonPersistentDocumentFlags.FromReplication) == NonPersistentDocumentFlags.FromReplication;
 
                 var table = EnsureRevisionTableCreated(context.Transaction.InnerTransaction, collectionName);
 
@@ -235,7 +240,7 @@ namespace Raven.Server.Documents.Revisions
 
                     // We want the revision's attachments to have a lower etag than the revision itself
                     if ((flags & DocumentFlags.HasAttachments) == DocumentFlags.HasAttachments &&
-                        notFromSmuggler)
+                        fromSmuggler == false)
                     {
                         using (Slice.External(context.Allocator, changeVectorPtr, changeVectorSize, out Slice changeVectorSlice))
                         {
@@ -243,6 +248,33 @@ namespace Raven.Server.Documents.Revisions
                             {
                                 _documentsStorage.AttachmentsStorage.RevisionAttachments(context, lowerId, changeVector);
                             }
+                        }
+                    }
+
+                    if (fromReplication)
+                    {
+                        void PutFromRevision() => _documentsStorage.Put(context, id, null, document, lastModifiedTicks, changeVector, 
+                            flags & ~DocumentFlags.Revision, nonPersistentFlags | NonPersistentDocumentFlags.FromRevision);
+
+                        try
+                        {
+                            var hasDoc = _documentsStorage.GetTableValueReaderForDocument(context, lowerId, out TableValueReader tvr);
+                            if (hasDoc == false)
+                            {
+                                PutFromRevision();
+                            }
+                            else
+                            {
+                                var docChangeVector = TableValueToChangeVector(ref tvr, (int)DocumentsTable.ChangeVector);
+                                if (changeVector.GreaterThan(docChangeVector))
+                                {
+                                    PutFromRevision();
+                                }
+                            }
+                        }
+                        catch (DocumentConflictException)
+                        {
+                            // Do not modify the document.
                         }
                     }
 
@@ -262,6 +294,7 @@ namespace Raven.Server.Documents.Revisions
                         tvb.Add((int)flags);
                         tvb.Add(newEtagSwapBytes);
                         tvb.Add(lastModifiedTicks);
+                        tvb.Add(context.GetTransactionMarker());
                         var isNew = table.Set(tvb);
                         if (isNew == false)
                             // It might be just an update from replication as we call this twice, both for the doc delete and for deleteRevision.
@@ -471,6 +504,7 @@ namespace Raven.Server.Documents.Revisions
                     tvb.Add((int)DocumentFlags.DeleteRevision);
                     tvb.Add(newEtagSwapBytes);
                     tvb.Add(lastModifiedTicks);
+                    tvb.Add(context.GetTransactionMarker());
                     var isNew = table.Set(tvb);
                     if (isNew == false)
                         // It might be just an update from replication as we call this twice, both for the doc delete and for deleteRevision.
@@ -665,10 +699,11 @@ namespace Raven.Server.Documents.Revisions
                 Id = TableValueToId(context, (int)Columns.Id, ref tvr),
                 Etag = TableValueToEtag((int)Columns.Etag, ref tvr),
                 LastModified = TableValueToDateTime((int)Columns.LastModified, ref tvr),
-                Flags = TableValueToFlags((int)Columns.Flags, ref tvr)
+                Flags = TableValueToFlags((int)Columns.Flags, ref tvr),
+                TransactionMarker = *(short*)tvr.Read((int)Columns.TransactionMarker, out int size),
             };
 
-            var ptr = tvr.Read((int)Columns.Document, out int size);
+            var ptr = tvr.Read((int)Columns.Document, out size);
             result.Data = new BlittableJsonReaderObject(ptr, size, context);
 
             ptr = tvr.Read((int)Columns.ChangeVector, out size);

--- a/test/SlowTests/Server/Documents/Revisions/RevisionsReplicationTransactionMarker.cs
+++ b/test/SlowTests/Server/Documents/Revisions/RevisionsReplicationTransactionMarker.cs
@@ -1,0 +1,97 @@
+//-----------------------------------------------------------------------
+// <copyright file="Revisions.cs" company="Hibernating Rhinos LTD">
+//     Copyright (c) Hibernating Rhinos LTD. All rights reserved.
+// </copyright>
+//-----------------------------------------------------------------------
+
+using System.Threading.Tasks;
+using FastTests.Server.Documents.Revisions;
+using FastTests.Server.Replication;
+using Sparrow;
+using Xunit;
+
+namespace SlowTests.Server.Documents.Revisions
+{
+    public class RevisionsReplicationTransactionMarker : ReplicationTestsBase
+    {
+        [Fact]
+        public async Task RealSupportForTransactionMarkerAcrossMultiUpdates()
+        {
+            using (var store1 = GetDocumentStore())
+            using (var store2 = GetDocumentStore())
+            {
+                var database1 = await GetDocumentDatabaseInstanceFor(store1);
+                database1.Configuration.Replication.MaxItemsCount = 1;
+                database1.ReplicationLoader.WaitFormTest = new AsyncManualResetEvent();
+
+                await RevisionsHelper.SetupRevisions(Server.ServerStore, store1.Database);
+                await RevisionsHelper.SetupRevisions(Server.ServerStore, store2.Database);
+
+                using (var session = store1.OpenAsyncSession())
+                {
+                    await session.StoreAsync(new User {Id = "users/oren", Name = "Oren", Balance = 10});
+                    await session.StoreAsync(new User {Id = "users/fitzchak", Name = "Fitzchak", Balance = 10});
+                    await session.StoreAsync(new User {Id = "users/michael", Name = "Michael", Balance = 10});
+                    await session.SaveChangesAsync();
+                }
+
+                using (var session = store1.OpenAsyncSession())
+                {
+                    var fitzchak = await session.LoadAsync<User>("users/fitzchak");
+                    var michael = await session.LoadAsync<User>("users/michael");
+                    michael.Balance -= 10;
+                    fitzchak.Balance += 10;
+                    await session.SaveChangesAsync();
+                }
+
+                using (var session = store1.OpenAsyncSession())
+                {
+                    var fitzchak = await session.LoadAsync<User>("users/fitzchak");
+                    var oren = await session.LoadAsync<User>("users/oren");
+                    fitzchak.Balance -= 5;
+                    oren.Balance += 5;
+                    await session.SaveChangesAsync();
+                }
+
+                await SetupReplicationAsync(store1, store2);
+
+                database1.ReplicationLoader.WaitFormTest.Set();
+                using (var session = store2.OpenAsyncSession())
+                {
+                    Assert.True(WaitForDocument<User>(store2, "users/michael", u => u.Balance == 10));
+                    var fitzchak = await session.LoadAsync<User>("users/fitzchak");
+                    var oren = await session.LoadAsync<User>("users/oren");
+                    Assert.Equal(10, fitzchak.Balance);
+                    Assert.Equal(10, oren.Balance);
+                }
+
+                database1.ReplicationLoader.WaitFormTest.Set();
+                using (var session = store2.OpenAsyncSession())
+                {
+                    Assert.True(WaitForDocument<User>(store2, "users/michael", u => u.Balance == 0));
+                    var fitzchak = await session.LoadAsync<User>("users/fitzchak");
+                    var oren = await session.LoadAsync<User>("users/oren");
+                    Assert.Equal(20, fitzchak.Balance);
+                    Assert.Equal(10, oren.Balance);
+                }
+
+                database1.ReplicationLoader.WaitFormTest.Set();
+                using (var session = store2.OpenAsyncSession())
+                {
+                    Assert.True(WaitForDocument<User>(store2, "users/oren", u => u.Balance == 15));
+                    var fitzchak = await session.LoadAsync<User>("users/fitzchak");
+                    var michael = await session.LoadAsync<User>("users/michael");
+                    Assert.Equal(15, fitzchak.Balance);
+                    Assert.Equal(0, michael.Balance);
+                }
+            }
+        }
+
+        private class User
+        {
+            public string Id { get; set; }
+            public string Name { get; set; }
+            public decimal Balance { get; set; }
+        }
+    }
+}


### PR DESCRIPTION
… the current document, replace document. This will add real support for transaction marker across multi updates.