### PR TITLE
RavenDB-7756

### DIFF
--- a/Rachis/Rachis/Behaviors/AbstractRaftStateBehavior.cs
+++ b/Rachis/Rachis/Behaviors/AbstractRaftStateBehavior.cs
@@ -32,14 +32,14 @@ namespace Rachis.Behaviors
         private DateTime lastHeartbeatTime;
         private readonly Dictionary<Type, Action<MessageContext>> _actionDispatch;
 
-        protected bool FromOurTopology(BaseMessage msg)
+        protected bool FromOurTopology(BaseMessage msg, bool acceptWhenTopologyIsEmpty = true)
         {
             if (msg.ClusterTopologyId == Engine.CurrentTopology.TopologyId)
                 return true;
 
             // if we don't have the same topology id, maybe we have _no_ topology, if that is the case,
             // we are accepting the new topology id immediately
-            if (Engine.CurrentTopology.TopologyId == Guid.Empty && 
+            if (acceptWhenTopologyIsEmpty && Engine.CurrentTopology.TopologyId == Guid.Empty && 
                 Engine.CurrentTopology.HasVoters == false)
             {
                 var tcc = new TopologyChangeCommand
@@ -203,7 +203,8 @@ namespace Rachis.Behaviors
 
         public RequestVoteResponse Handle(RequestVoteRequest req)
         {
-            if (FromOurTopology(req) == false)
+            //We don't vote for nodes when we have no topology!
+            if (FromOurTopology(req, acceptWhenTopologyIsEmpty:false) == false)
             {
                 _log.Info("Got a request vote message outside my cluster topology (id: {0}), ignoring", req.ClusterTopologyId);
                 return new RequestVoteResponse


### PR DESCRIPTION
* Fixing an issue where we would vote for anyone after we cleared our cluster information making it impossible to leave the cluster mode
* Fixing an issue where while we initialize a new cluster the old cluster member can talk to us and change our persistent state making it impossible to leave the old cluster (while leader is active).