### PR TITLE
RavenDB-7663

### DIFF
--- a/Rachis/Rachis.Tests/DictionaryStateMachine.cs
+++ b/Rachis/Rachis.Tests/DictionaryStateMachine.cs
@@ -91,6 +91,11 @@ namespace Rachis.Tests
             };
         }
 
+        public void Danger__SetLastApplied(long postion)
+        {
+            LastAppliedIndex = postion;
+        }
+
         public void Dispose()
         {
             //nothing to do

--- a/Rachis/Rachis/Interfaces/IRaftStateMachine.cs
+++ b/Rachis/Rachis/Interfaces/IRaftStateMachine.cs
@@ -34,5 +34,11 @@ namespace Rachis.Interfaces
         /// Nothing else may access the state machine when this is running, this is guranteed by Raft.
         /// </summary>
         void ApplySnapshot(long term, long index, Stream stream);
+
+        /// <summary>
+        /// this method is intended to be use for emergency fixes of the cluster state using the JS admin console
+        /// it will set the last applied index to the given posion so we can replay the log 
+        /// </summary>
+        void Danger__SetLastApplied(long postion);
     }
 }

--- a/Rachis/Rachis/RaftEngine.cs
+++ b/Rachis/Rachis/RaftEngine.cs
@@ -1001,6 +1001,15 @@ namespace Rachis
             var leader = StateBehavior as LeaderStateBehavior;
             return leader?.GetMaxIndexOnQuorumInternal();
         }
+
+        public void Danger__CutLogAtPosition(long postion)
+        {
+            PersistentState.AppendToLog(this, new List<LogEntry>(), postion);
+            if (postion < StateMachine.LastAppliedIndex)
+            {
+                StateMachine.Danger__SetLastApplied(postion);
+            }
+        }
     }
 
     public class ProposingCandidacyResult : EventArgs

--- a/Rachis/Rachis/RaftEngineStatistics.cs
+++ b/Rachis/Rachis/RaftEngineStatistics.cs
@@ -33,7 +33,7 @@ namespace Rachis
         }
 
         public LogEntry LastLogEntry { get; set; }
-
+        public List<LogEntry> LastLogsEntries { get; set; }
         public long CommitIndex { get; set; }
         private ConcurrentDictionary<long, DateTime> IndexesToAppendTimes = new ConcurrentDictionary<long, DateTime>(); 
         public ConcurrentQueue<TimeoutInformation> TimeOuts { get; }

--- a/Raven.Database/Raft/Storage/ClusterStateMachine.cs
+++ b/Raven.Database/Raft/Storage/ClusterStateMachine.cs
@@ -267,6 +267,11 @@ namespace Raven.Database.Raft.Storage
 
         }
 
+        public void Danger__SetLastApplied(long postion)
+        {
+            LastAppliedIndex = postion;
+        }
+
         private void UpdateLastAppliedIndex(long index, IStorageActionsAccessor accessor)
         {
             accessor.Lists.Set("Raven/Cluster", "Status", new RavenJObject

--- a/Raven.Database/Server/Controllers/Admin/AdminController.cs
+++ b/Raven.Database/Server/Controllers/Admin/AdminController.cs
@@ -87,6 +87,7 @@ namespace Raven.Database.Server.Controllers.Admin
             statistics.CommitIndex = ClusterManager.Engine.CommitIndex;
             statistics.CurrentTerm = ClusterManager.Engine.PersistentState.CurrentTerm;
             statistics.LastLogEntry = ClusterManager.Engine.PersistentState.LastLogEntry();
+            statistics.LastLogsEntries = ClusterManager.Engine.PersistentState.LastLogsEntries().ToList();
             statistics.CurrentLeader = ClusterManager.Engine.CurrentLeader;
             statistics.FollowersStatistics = ClusterManager.Engine.GetFollowerStatistics();
             return GetMessageWithObject(ClusterManager.Engine.EngineStatistics);

--- a/Raven.Database/TimeSeries/KeyValueStateMachine.cs
+++ b/Raven.Database/TimeSeries/KeyValueStateMachine.cs
@@ -343,6 +343,11 @@ namespace Raven.Database.TimeSeries
             }
         }
 
+        public void Danger__SetLastApplied(long postion)
+        {
+            LastAppliedIndex = postion;
+        }
+
         private void Apply(IEnumerable<KeyValueOperation> ops, long commandIndex)
         {
             using (var tx = _storageEnvironment.NewTransaction(TransactionFlags.ReadWrite))


### PR DESCRIPTION
Added state machine Danger__SetLastApplied so we can change the last applied index in the JS console
Added RaftEngine Danger__CutLogAtPosition to cut the log at specified position for use in the JS console
Added last 100 log entries to the cluster statistics so we will know what is in the logs this is a must have!!!
Added Danger__InjectN00pAtPosition and Danger__InjectCommandAtPosition to inject commands into the logs to fix the log state (tested and working :) both the noop and json version)