### PR TITLE
RavenDB-7571 If the session is disposed from the finalizer then we ha…

### DIFF
--- a/src/Raven.Client/Documents/Session/InMemoryDocumentSessionOperations.cs
+++ b/src/Raven.Client/Documents/Session/InMemoryDocumentSessionOperations.cs
@@ -989,8 +989,14 @@ more responsive application.
         private void Dispose(bool isDisposing)
         {
             if (isDisposing)
+            {
                 GC.SuppressFinalize(this);
-            _releaseOperationContext.Dispose();
+                _releaseOperationContext.Dispose();
+            }
+            else
+            {
+                Context.Dispose();
+            }
         }
 
         /// <summary>


### PR DESCRIPTION
…ve to dispose the context immediately instead of returning it to the pool - the finalizer of ArenaMemoryAllocator could be already called so we cannot return such a context to the pool