### PR TITLE
RavenDB-7790

### DIFF
--- a/Raven.Client.Lightweight/Connection/Async/AsyncServerClient.cs
+++ b/Raven.Client.Lightweight/Connection/Async/AsyncServerClient.cs
@@ -129,7 +129,7 @@ namespace Raven.Client.Connection.Async
             this.requestExecuterGetter = requestExecuterGetter;
             this.requestTimeMetricGetter = requestTimeMetricGetter;
             requestExecuterSelector = new RequestExecuterSelector(() =>
-                requestExecuterGetter(this, databaseName, incrementReadStripe), convention);
+                requestExecuterGetter(this, databaseName, incrementReadStripe), convention, AvoidCluster);
 
             Lazy<Tuple<DateTime, Task>> val;
             try
@@ -189,7 +189,7 @@ namespace Raven.Client.Connection.Async
                 convention.UpdateFrom(topology.ClientConfiguration);
 
             executor = requestExecuterSelector.Select();
-            if (topology.ClusterInformation.IsInCluster)
+            if (AvoidCluster == false && topology.ClusterInformation.IsInCluster)
             {
                 var clusterAwareRequestExecuter = executor as ClusterAwareRequestExecuter;
                 //This should never happen.
@@ -2891,6 +2891,7 @@ namespace Raven.Client.Connection.Async
         private bool resolvingConflict;
         private bool resolvingConflictRetries;
 
+        public bool AvoidCluster { get; set; } = false;
         internal async Task<T> ExecuteWithReplication<T>(HttpMethod method, Func<OperationMetadata, IRequestTimeMetric, Task<T>> operation, CancellationToken token = default(CancellationToken))
         {
             var currentRequest = Interlocked.Increment(ref requestCount);

--- a/Raven.Database/Server/Controllers/ClusterAwareRavenDbApiController.cs
+++ b/Raven.Database/Server/Controllers/ClusterAwareRavenDbApiController.cs
@@ -89,7 +89,7 @@ namespace Raven.Database.Server.Controllers
             
             for (var leaderSeekRetries = 0; leaderSeekRetries <= NUMBER_OF_REDIRECT_FIND_LEADER_RETRIES && leaderNode==null; leaderSeekRetries++)
             {
-                var waitTimeToLeader = leaderSeekRetries * 75;
+                var waitTimeToLeader = leaderSeekRetries * ClusterManager.Engine.Options.ElectionTimeout;
 
                 if (leaderSeekRetries > 0 && Log.IsDebugEnabled)
                     Log.Debug("Redirect To Leader: leader not found, retrying {0} times out of {1}. This time will wait for {2} miliseconds", leaderSeekRetries, NUMBER_OF_REDIRECT_FIND_LEADER_RETRIES, waitTimeToLeader);

--- a/Raven.Database/Smuggler/DatabaseDataDumper.cs
+++ b/Raven.Database/Smuggler/DatabaseDataDumper.cs
@@ -83,7 +83,8 @@ namespace Raven.Database.Smuggler
             {
                 Url = connectionStringOptions.Url,
                 ApiKey = connectionStringOptions.ApiKey,
-                Credentials = credentials ?? CredentialCache.DefaultNetworkCredentials
+                Credentials = credentials ?? CredentialCache.DefaultNetworkCredentials,
+                AvoidCluster = true
             };
 
             s.Initialize();

--- a/Raven.Database/Smuggler/SmugglerDatabaseApi.cs
+++ b/Raven.Database/Smuggler/SmugglerDatabaseApi.cs
@@ -141,7 +141,8 @@ namespace Raven.Smuggler
             {
                 Url = connectionStringOptions.Url,
                 ApiKey = connectionStringOptions.ApiKey,
-                Credentials = credentials ?? CredentialCache.DefaultNetworkCredentials
+                Credentials = credentials ?? CredentialCache.DefaultNetworkCredentials,
+                AvoidCluster = true
             };
 
             s.Initialize();


### PR DESCRIPTION
* Adding avoid cluster mode to document store/ async server client/ request executor selector
* Smuggler will use avoid clustering
* removing paths that may cause stack over flow exception in the client in cluster scenarios (it will fail but with a catchable exception)