### PR TITLE
RavenDB-7533 related changes after code review

### DIFF
--- a/src/Raven.Client/Documents/Operations/OperationExecutor.Operations.cs
+++ b/src/Raven.Client/Documents/Operations/OperationExecutor.Operations.cs
@@ -9,13 +9,12 @@ namespace Raven.Client.Documents.Operations
     {
         public Operation Send(IOperation<OperationIdResult> operation)
         {
-            return AsyncHelpers.RunSync(() => SendAsync(operation));
+            return AsyncHelpers.RunSync(() => SendAsyncAndFetchOperation(operation));
         }
 
-        public async Task<Operation> SendAsync(IOperation<OperationIdResult> operation, CancellationToken token = default(CancellationToken))
+        public async Task<Operation> SendAsyncAndFetchOperation(IOperation<OperationIdResult> operation, CancellationToken token = default(CancellationToken))
         {
-            JsonOperationContext context;
-            using (GetContext(out context))
+            using (GetContext(out JsonOperationContext context))
             {
                 var command = operation.GetCommand(_store, _requestExecutor.Conventions, context, _requestExecutor.Cache);
 

--- a/src/Raven.Client/Documents/Operations/OperationExecutor.cs
+++ b/src/Raven.Client/Documents/Operations/OperationExecutor.cs
@@ -28,33 +28,33 @@ namespace Raven.Client.Documents.Operations
             return new OperationExecutor(_store, databaseName);
         }
 
-        public void Send(IOperation operation)
+        public void Send(IOperation operation, long? sessionId = null)
         {
-            AsyncHelpers.RunSync(() => SendAsync(operation));
+            AsyncHelpers.RunSync(() => SendAsync(operation, sessionId: sessionId));
         }
 
-        public TResult Send<TResult>(IOperation<TResult> operation)
+        public TResult Send<TResult>(IOperation<TResult> operation, long? sessionId = null)
         {
-            return AsyncHelpers.RunSync(() => SendAsync(operation));
+            return AsyncHelpers.RunSync(() => SendAsync(operation, sessionId:sessionId));
         }
 
-        public Task SendAsync(IOperation operation, CancellationToken token = default(CancellationToken))
+        public Task SendAsync(IOperation operation, CancellationToken token = default(CancellationToken), long? sessionId = null)
         {
             using (GetContext(out JsonOperationContext context))
             {
                 var command = operation.GetCommand(_store, _requestExecutor.Conventions, context, _requestExecutor.Cache);
 
-                return _requestExecutor.ExecuteAsync(command, context, token);
+                return _requestExecutor.ExecuteAsync(command, context, token, sessionId);
             }
         }
 
-        public async Task<TResult> SendAsync<TResult>(IOperation<TResult> operation, CancellationToken token = default(CancellationToken))
+        public async Task<TResult> SendAsync<TResult>(IOperation<TResult> operation, CancellationToken token = default(CancellationToken), long? sessionId = null)
         {
             using (GetContext(out JsonOperationContext context))
             {
                 var command = operation.GetCommand(_store, _requestExecutor.Conventions, context, _requestExecutor.Cache);
 
-                await _requestExecutor.ExecuteAsync(command, context, token).ConfigureAwait(false);
+                await _requestExecutor.ExecuteAsync(command, context, token, sessionId).ConfigureAwait(false);
 
                 return command.Result;
             }

--- a/src/Raven.Client/Documents/Session/AsyncDocumentSession.Attachments.cs
+++ b/src/Raven.Client/Documents/Session/AsyncDocumentSession.Attachments.cs
@@ -19,14 +19,14 @@ namespace Raven.Client.Documents.Session
         public async Task<bool> AttachmentExistsAsync(string documentId, string name)
         {
             var command = new HeadAttachmentCommand(documentId, name, null);
-            await RequestExecutor.ExecuteAsync(command, Context).ConfigureAwait(false);
+            await RequestExecutor.ExecuteAsync(command, Context, sessionId: _clientSessionId).ConfigureAwait(false);
             return command.Result != null;
         }
 
         public async Task<AttachmentResult> GetAttachmentAsync(string documentId, string name)
         {
             var operation = new GetAttachmentOperation(documentId, name, AttachmentType.Document, null);
-            return await DocumentStore.Operations.SendAsync(operation).ConfigureAwait(false);
+            return await DocumentStore.Operations.SendAsync(operation, sessionId: _clientSessionId).ConfigureAwait(false);
         }
 
         public async Task<AttachmentResult> GetAttachmentAsync(object entity, string name)
@@ -35,13 +35,13 @@ namespace Raven.Client.Documents.Session
                 ThrowEntityNotInSession(entity);
 
             var operation = new GetAttachmentOperation(document.Id, name, AttachmentType.Document, null);
-            return await DocumentStore.Operations.SendAsync(operation).ConfigureAwait(false);
+            return await DocumentStore.Operations.SendAsync(operation, sessionId: _clientSessionId).ConfigureAwait(false);
         }
 
         public async Task<AttachmentResult> GetRevisionAttachmentAsync(string documentId, string name, ChangeVectorEntry[] changeVector)
         {
             var operation = new GetAttachmentOperation(documentId, name, AttachmentType.Revision, changeVector);
-            return await DocumentStore.Operations.SendAsync(operation).ConfigureAwait(false);
+            return await DocumentStore.Operations.SendAsync(operation, sessionId: _clientSessionId).ConfigureAwait(false);
         }
     }
 }

--- a/src/Raven.Client/Documents/Session/AsyncDocumentSession.Lazy.cs
+++ b/src/Raven.Client/Documents/Session/AsyncDocumentSession.Lazy.cs
@@ -100,7 +100,7 @@ namespace Raven.Client.Documents.Session
             var requests = PendingLazyOperations.Select(x => x.CreateRequest()).ToList();
             var multiGetOperation = new MultiGetOperation(this);
             var multiGetCommand = multiGetOperation.CreateRequest(requests);
-            await RequestExecutor.ExecuteAsync(multiGetCommand, Context).ConfigureAwait(false);
+            await RequestExecutor.ExecuteAsync(multiGetCommand, Context, sessionId: _clientSessionId).ConfigureAwait(false);
             var responses = multiGetCommand.Result;
 
             for (var i = 0; i < PendingLazyOperations.Count; i++)

--- a/src/Raven.Client/Documents/Session/AsyncDocumentSession.Load.cs
+++ b/src/Raven.Client/Documents/Session/AsyncDocumentSession.Load.cs
@@ -110,7 +110,7 @@ namespace Raven.Client.Documents.Session
             var command = loadOperation.CreateRequest();
             if (command != null)
             {
-                await RequestExecutor.ExecuteAsync(command, Context, token).ConfigureAwait(false);
+                await RequestExecutor.ExecuteAsync(command, Context, token, sessionId: _clientSessionId).ConfigureAwait(false);
                 loadOperation.SetResult(command.Result);
             }
 
@@ -136,7 +136,7 @@ namespace Raven.Client.Documents.Session
             var command = loadOperation.CreateRequest();
             if (command != null)
             {
-                await RequestExecutor.ExecuteAsync(command, Context, token).ConfigureAwait(false);
+                await RequestExecutor.ExecuteAsync(command, Context, token, sessionId: _clientSessionId).ConfigureAwait(false);
                 loadOperation.SetResult(command.Result);
             }
 
@@ -160,7 +160,7 @@ namespace Raven.Client.Documents.Session
             var command = operation.CreateRequest();
             if (command != null)
             {
-                await RequestExecutor.ExecuteAsync(command, Context, token).ConfigureAwait(false);
+                await RequestExecutor.ExecuteAsync(command, Context, token, sessionId: _clientSessionId).ConfigureAwait(false);
                 if(stream != null)
                     Context.Write(stream, command.Result.Results.Parent);
                 else
@@ -225,7 +225,7 @@ namespace Raven.Client.Documents.Session
             var command = operation.CreateRequest();
             if (command != null)
             {
-                await RequestExecutor.ExecuteAsync(command, Context, token).ConfigureAwait(false);
+                await RequestExecutor.ExecuteAsync(command, Context, token, sessionId: _clientSessionId).ConfigureAwait(false);
 
                 if (stream != null)
                     Context.Write(stream, command.Result.Results.Parent);
@@ -244,7 +244,7 @@ namespace Raven.Client.Documents.Session
             var command = operation.CreateRequest();
             if (command != null)
             {
-                await RequestExecutor.ExecuteAsync(command, Context, token).ConfigureAwait(false);
+                await RequestExecutor.ExecuteAsync(command, Context, token, sessionId: _clientSessionId).ConfigureAwait(false);
 
                 if (stream != null)
                     Context.Write(stream, command.Result.Results.Parent);

--- a/src/Raven.Client/Documents/Session/AsyncDocumentSession.MoreLikeThis.cs
+++ b/src/Raven.Client/Documents/Session/AsyncDocumentSession.MoreLikeThis.cs
@@ -87,7 +87,7 @@ namespace Raven.Client.Documents.Session
             var operation = new MoreLikeThisOperation(this, query);
 
             var command = operation.CreateRequest();
-            await RequestExecutor.ExecuteAsync(command, Context).ConfigureAwait(false);
+            await RequestExecutor.ExecuteAsync(command, Context, sessionId: _clientSessionId).ConfigureAwait(false);
 
             var result = command.Result;
             operation.SetResult(result);

--- a/src/Raven.Client/Documents/Session/AsyncDocumentSession.Stream.cs
+++ b/src/Raven.Client/Documents/Session/AsyncDocumentSession.Stream.cs
@@ -137,7 +137,7 @@ namespace Raven.Client.Documents.Session
 
             var streamOperation = new StreamOperation(this);
             var command = streamOperation.CreateRequest(query.IndexName, indexQuery);
-            await RequestExecutor.ExecuteAsync(command, Context, token).ConfigureAwait(false);
+            await RequestExecutor.ExecuteAsync(command, Context, token, sessionId: _clientSessionId).ConfigureAwait(false);
             var result = streamOperation.SetResultAsync(command.Result);
 
             var queryOperation = ((AsyncDocumentQuery<T>)query).InitializeQueryOperation();
@@ -171,7 +171,7 @@ namespace Raven.Client.Documents.Session
             var streamOperation = new StreamOperation(this);
             var command = streamOperation.CreateRequest(fromEtag, startsWith, matches, start, pageSize, null, startAfter, transformer,
                 transformerParameters);
-            await RequestExecutor.ExecuteAsync(command, Context, token).ConfigureAwait(false);
+            await RequestExecutor.ExecuteAsync(command, Context, token, sessionId: _clientSessionId).ConfigureAwait(false);
             var result = streamOperation.SetResultAsync(command.Result);
             return new YieldStream<T>(this, null, null, command.UsedTransformer, result, token);
         }
@@ -181,7 +181,7 @@ namespace Raven.Client.Documents.Session
             var streamOperation = new StreamOperation(this);
             var command = streamOperation.CreateRequest(query.IndexName, query.GetIndexQuery());
 
-            await RequestExecutor.ExecuteAsync(command, Context, token).ConfigureAwait(false);
+            await RequestExecutor.ExecuteAsync(command, Context, token, sessionId: _clientSessionId).ConfigureAwait(false);
 
             using (command.Result.Response)
             using (command.Result.Stream)

--- a/src/Raven.Client/Documents/Session/AsyncDocumentSession.Versioning.cs
+++ b/src/Raven.Client/Documents/Session/AsyncDocumentSession.Versioning.cs
@@ -20,7 +20,7 @@ namespace Raven.Client.Documents.Session
             var operation = new GetRevisionOperation(this, id, start, pageSize);
 
             var command = operation.CreateRequest();
-            await RequestExecutor.ExecuteAsync(command, Context).ConfigureAwait(false);
+            await RequestExecutor.ExecuteAsync(command, Context, sessionId: _clientSessionId).ConfigureAwait(false);
             operation.SetResult(command.Result);
             return operation.Complete<T>();
         }

--- a/src/Raven.Client/Documents/Session/AsyncDocumentSession.cs
+++ b/src/Raven.Client/Documents/Session/AsyncDocumentSession.cs
@@ -42,7 +42,7 @@ namespace Raven.Client.Documents.Session
                 return true;
 
             var command = new HeadDocumentCommand(id, null);
-            await RequestExecutor.ExecuteAsync(command, Context).ConfigureAwait(false);
+            await RequestExecutor.ExecuteAsync(command, Context, sessionId: _clientSessionId).ConfigureAwait(false);
 
             return command.Result != null;
         }
@@ -55,7 +55,7 @@ namespace Raven.Client.Documents.Session
             IncrementRequestCount();
 
             var command = new GetDocumentCommand(new[] { documentInfo.Id }, includes: null, transformer: null, transformerParameters: null, metadataOnly: false, context: Context);
-            await RequestExecutor.ExecuteAsync(command, Context, token).ConfigureAwait(false);
+            await RequestExecutor.ExecuteAsync(command, Context, token, sessionId: _clientSessionId).ConfigureAwait(false);
 
             RefreshInternal(entity, command, documentInfo);
         }
@@ -113,7 +113,7 @@ namespace Raven.Client.Documents.Session
                 if (command == null)
                     return;
 
-                await RequestExecutor.ExecuteAsync(command, Context, token).ConfigureAwait(false);
+                await RequestExecutor.ExecuteAsync(command, Context, token, sessionId: _clientSessionId).ConfigureAwait(false);
                 saveChangesOperation.SetResult(command.Result);
             }
         }

--- a/src/Raven.Client/Documents/Session/DocumentSession.Attachments.cs
+++ b/src/Raven.Client/Documents/Session/DocumentSession.Attachments.cs
@@ -18,14 +18,14 @@ namespace Raven.Client.Documents.Session
         public bool AttachmentExists(string documentId, string name)
         {
             var command = new HeadAttachmentCommand(documentId, name, null);
-            RequestExecutor.Execute(command, Context);
+            RequestExecutor.Execute(command, Context, sessionId:_clientSessionId);
             return command.Result != null;
         }
 
         public AttachmentResult GetAttachment(string documentId, string name)
         {
             var operation = new GetAttachmentOperation(documentId, name, AttachmentType.Document, null);
-            return DocumentStore.Operations.Send(operation);
+            return DocumentStore.Operations.Send(operation, sessionId:_clientSessionId);
         }
 
         public AttachmentResult GetAttachment(object entity, string name)
@@ -34,13 +34,13 @@ namespace Raven.Client.Documents.Session
                 ThrowEntityNotInSession(entity);
 
             var operation = new GetAttachmentOperation(document.Id, name, AttachmentType.Document, null);
-            return DocumentStore.Operations.Send(operation);
+            return DocumentStore.Operations.Send(operation, sessionId: _clientSessionId);
         }
 
         public AttachmentResult GetRevisionAttachment(string documentId, string name, ChangeVectorEntry[] changeVector)
         {
             var operation = new GetAttachmentOperation(documentId, name, AttachmentType.Revision, changeVector);
-            return DocumentStore.Operations.Send(operation);
+            return DocumentStore.Operations.Send(operation, sessionId: _clientSessionId);
         }
     }
 }

--- a/src/Raven.Client/Documents/Session/DocumentSession.Load.cs
+++ b/src/Raven.Client/Documents/Session/DocumentSession.Load.cs
@@ -37,7 +37,7 @@ namespace Raven.Client.Documents.Session
 
             if (command != null)
             {
-                RequestExecutor.Execute(command, Context);
+                RequestExecutor.Execute(command, Context, sessionId: _clientSessionId);
                 loadOperation.SetResult(command.Result);
             }
 
@@ -121,7 +121,7 @@ namespace Raven.Client.Documents.Session
             var command = operation.CreateRequest();
             if (command != null)
             {
-                RequestExecutor.Execute(command, Context);
+                RequestExecutor.Execute(command, Context, sessionId: _clientSessionId);
                 if(stream!=null)
                     Context.Write(stream, command.Result.Results.Parent);
                 else
@@ -138,7 +138,7 @@ namespace Raven.Client.Documents.Session
             var command = loadOperation.CreateRequest();
             if (command != null)
             {
-                RequestExecutor.Execute(command, Context);
+                RequestExecutor.Execute(command, Context, sessionId: _clientSessionId);
                 loadOperation.SetResult(command.Result);
             }
 
@@ -161,7 +161,7 @@ namespace Raven.Client.Documents.Session
             var command = operation.CreateRequest();
             if (command != null)
             {
-                RequestExecutor.Execute(command, Context);
+                RequestExecutor.Execute(command, Context, sessionId: _clientSessionId);
 
                 if(stream != null)
                     Context.Write(stream, command.Result.Results.Parent);
@@ -187,7 +187,7 @@ namespace Raven.Client.Documents.Session
             var command = loadTransformerOperation.CreateRequest();
             if (command != null)
             {
-                RequestExecutor.Execute(command, Context);
+                RequestExecutor.Execute(command, Context, sessionId: _clientSessionId);
                 loadTransformerOperation.SetResult(command.Result);
             }
 
@@ -241,7 +241,7 @@ namespace Raven.Client.Documents.Session
             var command = operation.CreateRequest();
             if (command != null)
             {
-                RequestExecutor.Execute(command, Context);
+                RequestExecutor.Execute(command, Context, sessionId: _clientSessionId);
 
                 if (stream != null)
                     Context.Write(stream, command.Result.Results.Parent);

--- a/src/Raven.Client/Documents/Session/DocumentSession.MoreLikeThis.cs
+++ b/src/Raven.Client/Documents/Session/DocumentSession.MoreLikeThis.cs
@@ -86,7 +86,7 @@ namespace Raven.Client.Documents.Session
             var operation = new MoreLikeThisOperation(this, query);
 
             var command = operation.CreateRequest();
-            RequestExecutor.Execute(command, Context);
+            RequestExecutor.Execute(command, Context, sessionId: _clientSessionId);
 
             var result = command.Result;
             operation.SetResult(result);

--- a/src/Raven.Client/Documents/Session/DocumentSession.Stream.cs
+++ b/src/Raven.Client/Documents/Session/DocumentSession.Stream.cs
@@ -33,7 +33,7 @@ namespace Raven.Client.Documents.Session
             var streamOperation = new StreamOperation(this);
             var command = streamOperation.CreateRequest(query.IndexName, query.GetIndexQuery());
 
-            RequestExecutor.Execute(command, Context);
+            RequestExecutor.Execute(command, Context, sessionId: _clientSessionId);
             using (var result = streamOperation.SetResult(command.Result))
             {
                 return YieldResults(query, result, command.UsedTransformer);
@@ -46,7 +46,7 @@ namespace Raven.Client.Documents.Session
             var streamOperation = new StreamOperation(this, stats);
             var command = streamOperation.CreateRequest(query.IndexName, query.GetIndexQuery());
 
-            RequestExecutor.Execute(command, Context);
+            RequestExecutor.Execute(command, Context, sessionId: _clientSessionId);
             using (var result = streamOperation.SetResult(command.Result))
             {
                 streamQueryStats = stats;
@@ -81,7 +81,7 @@ namespace Raven.Client.Documents.Session
             var streamOperation = new StreamOperation(this);
             var command = streamOperation.CreateRequest(query.IndexName, query.GetIndexQuery());
 
-            RequestExecutor.Execute(command, Context);
+            RequestExecutor.Execute(command, Context, sessionId: _clientSessionId);
 
             using (command.Result.Response)
             using (command.Result.Stream)
@@ -154,7 +154,7 @@ namespace Raven.Client.Documents.Session
             var streamOperation = new StreamOperation(this);
             var command = streamOperation.CreateRequest(fromEtag, startsWith, matches, start, pageSize, null, startAfter, transformer,
                 transformerParameters);
-            RequestExecutor.Execute(command, Context);
+            RequestExecutor.Execute(command, Context, sessionId: _clientSessionId);
             using (var result = streamOperation.SetResult(command.Result))
             {
                 while (result.MoveNext())

--- a/src/Raven.Client/Documents/Session/DocumentSession.Versioning.cs
+++ b/src/Raven.Client/Documents/Session/DocumentSession.Versioning.cs
@@ -19,7 +19,7 @@ namespace Raven.Client.Documents.Session
             var operation = new GetRevisionOperation(this, id, start, pageSize);
 
             var command = operation.CreateRequest();
-            RequestExecutor.Execute(command, Context);
+            RequestExecutor.Execute(command, Context, sessionId: _clientSessionId);
             operation.SetResult(command.Result);
             return operation.Complete<T>();
         }

--- a/src/Raven.Client/Documents/Session/DocumentSession.cs
+++ b/src/Raven.Client/Documents/Session/DocumentSession.cs
@@ -61,7 +61,7 @@ namespace Raven.Client.Documents.Session
                 if (command == null)
                     return;
 
-                RequestExecutor.Execute(command, Context);
+                RequestExecutor.Execute(command, Context, sessionId:_clientSessionId);
                 saveChangesOperation.SetResult(command.Result);
             }
         }
@@ -80,7 +80,7 @@ namespace Raven.Client.Documents.Session
                 return true;
 
             var command = new HeadDocumentCommand(id, null);
-            RequestExecutor.Execute(command, Context);
+            RequestExecutor.Execute(command, Context, sessionId:_clientSessionId);
 
             return command.Result != null;
         }
@@ -98,7 +98,7 @@ namespace Raven.Client.Documents.Session
             IncrementRequestCount();
 
             var command = new GetDocumentCommand(new[] { documentInfo.Id }, includes: null, transformer: null, transformerParameters: null, metadataOnly: false, context: Context);
-            RequestExecutor.Execute(command, Context);
+            RequestExecutor.Execute(command, Context, sessionId: _clientSessionId);
 
             RefreshInternal(entity, command, documentInfo);
         }
@@ -165,7 +165,7 @@ namespace Raven.Client.Documents.Session
             var requests = PendingLazyOperations.Select(x => x.CreateRequest()).ToList();
             var multiGetOperation = new MultiGetOperation(this);
             var multiGetCommand = multiGetOperation.CreateRequest(requests);
-            RequestExecutor.Execute(multiGetCommand, Context);
+            RequestExecutor.Execute(multiGetCommand, Context, sessionId: _clientSessionId);
             var responses = multiGetCommand.Result;
 
             for (var i = 0; i < PendingLazyOperations.Count; i++)

--- a/src/Raven.Client/Documents/Session/InMemoryDocumentSessionOperations.cs
+++ b/src/Raven.Client/Documents/Session/InMemoryDocumentSessionOperations.cs
@@ -34,6 +34,9 @@ namespace Raven.Client.Documents.Session
     /// </summary>
     public abstract partial class InMemoryDocumentSessionOperations : IDisposable
     {
+        private static long _clientSessionIdCounter;
+        protected readonly long _clientSessionId = Interlocked.Increment(ref _clientSessionIdCounter);
+
         protected readonly RequestExecutor _requestExecutor;
         private readonly IDisposable _releaseOperationContext;
         private readonly JsonOperationContext _context;
@@ -997,6 +1000,8 @@ more responsive application.
             {
                 Context.Dispose();
             }
+
+			RequestExecutor.RetireSession(_clientSessionId);
         }
 
         /// <summary>
@@ -1017,7 +1022,6 @@ more responsive application.
             {
                 // nothing can be done here
             }
-
 #if DEBUG
             Debug.WriteLine("Disposing a session for finalizer! It should be disposed by calling session.Dispose()!");
 #endif

--- a/src/Raven.Client/Http/INodeSelector.cs
+++ b/src/Raven.Client/Http/INodeSelector.cs
@@ -6,11 +6,14 @@ namespace Raven.Client.Http
     {
         Topology Topology { get; }
         int GetCurrentNodeIndex();
-        void OnSucceededRequest();
+        INodeSelector HandleRequestWithoutSessionId();
+        INodeSelector AdvanceToNextNodeAndFetchInstance();
         void OnFailedRequest(int nodeIndex);
         bool OnUpdateTopology(Topology topology, bool forceUpdate = false);
         ServerNode GetCurrentNode();
         void RestoreNodeIndex(int nodeIndex);
+
+        INodeSelector CloneForNewSession();
 
         event Action<int> NodeSwitch;
     }

--- a/src/Raven.Client/Http/RequestExecutor.cs
+++ b/src/Raven.Client/Http/RequestExecutor.cs
@@ -507,7 +507,7 @@ namespace Raven.Client.Http
                 {
                     sp.Stop();
                     if (await HandleServerDown(url, chosenNode, nodeIndex, context, command, request, response, e).ConfigureAwait(false) == false)
-                        throw new AllTopologyNodesDownException($"Tried to send {command.GetType().Name} request to all configured nodes in the topology, all of them seem to be down or not responding.", _nodeSelector.Topology, e);
+                        throw new AllTopologyNodesDownException($"Tried to send {command.GetType().Name} request to all configured nodes in the topology, all of them seem to be down or not responding.", _nodeSelector?.Topology, e);
 
                     return;
                 }
@@ -619,7 +619,7 @@ namespace Raven.Client.Http
             switch (response.StatusCode)
             {
                 case HttpStatusCode.NotFound:
-                    _nodeSelector.OnFailedRequest(nodeIndex);
+                    _nodeSelector?.OnFailedRequest(nodeIndex);
                     if (command.ResponseType == RavenCommandResponseType.Empty)
                         return true;
                     else if (command.ResponseType == RavenCommandResponseType.Object)
@@ -747,7 +747,7 @@ namespace Raven.Client.Http
                     {
                         status.Dispose();
                     }
-                    _nodeSelector.RestoreNodeIndex(nodeStatus.NodeIndex);
+                    _nodeSelector?.RestoreNodeIndex(nodeStatus.NodeIndex);
                 }
             }
             catch (Exception e)
@@ -833,12 +833,16 @@ namespace Raven.Client.Http
             JsonOperationContext context;
             using (ContextPool.AllocateOperationContext(out context))
             {
-                var topology = _nodeSelector.Topology;
-                foreach (var node in topology.Nodes)
+                var topology = _nodeSelector?.Topology;
+
+                if (topology != null)
                 {
+                    foreach (var node in topology.Nodes)
+                    {
 #pragma warning disable 4014
-                    HandleUnauthorized(node, context, shouldThrow: false);
+                        HandleUnauthorized(node, context, shouldThrow: false);
 #pragma warning restore 4014
+                    }
                 }
             }
         }

--- a/src/Raven.Client/Http/RequestExecutor.cs
+++ b/src/Raven.Client/Http/RequestExecutor.cs
@@ -67,13 +67,15 @@ namespace Raven.Client.Http
 
         protected INodeSelector _nodeSelector;
 
+        protected ConcurrentDictionary<long, INodeSelector> _nodeSelectorBySessionId = new ConcurrentDictionary<long, INodeSelector>();
+
         private TimeSpan? _defaultTimeout;
 
         //note: the condition for non empty nodes is precaution, should never happen..
         public string Url => _nodeSelector?.GetCurrentNode()?.Url;
 
         public string ClusterToken;
-
+        
         public long TopologyEtag { get; protected set; }
 
         public long ClientConfigurationEtag { get; internal set; }
@@ -216,6 +218,11 @@ namespace Raven.Client.Http
             }
         }
 
+        public void RetireSession(long sessionId)
+        {
+            _nodeSelectorBySessionId.TryRemove(sessionId, out _);
+        }
+
         public virtual async Task<bool> UpdateTopologyAsync(ServerNode node, int timeout)
         {
             if (_disposed)
@@ -269,22 +276,34 @@ namespace Raven.Client.Http
 
         }
 
-        public void Execute<TResult>(RavenCommand<TResult> command, JsonOperationContext context, CancellationToken token = default(CancellationToken))
+        public void Execute<TResult>(RavenCommand<TResult> command, 
+            JsonOperationContext context, 
+            CancellationToken token = default(CancellationToken),
+            long? sessionId = null)
         {
-            AsyncHelpers.RunSync(() => ExecuteAsync(command, context, token));
+            AsyncHelpers.RunSync(() => ExecuteAsync(command, context, token, sessionId));
         }
 
-        public Task ExecuteAsync<TResult>(RavenCommand<TResult> command, JsonOperationContext context, CancellationToken token = default(CancellationToken))
+        public Task ExecuteAsync<TResult>(
+            RavenCommand<TResult> command, 
+            JsonOperationContext context, 
+            CancellationToken token = default(CancellationToken),
+            long? sessionId = null)
         {
             var topologyUpdate = _firstTopologyUpdate;
 
             if (topologyUpdate != null && topologyUpdate.Status == TaskStatus.RanToCompletion || _disableTopologyUpdates)
-                return ExecuteAsync(_nodeSelector.GetCurrentNode(), context, command, token);
+                return ExecuteAsync(_nodeSelector.GetCurrentNode(), context, command, token, sessionId:sessionId);
 
-            return UnlikelyExecuteAsync(command, context, token, topologyUpdate);
+            return UnlikelyExecuteAsync(command, context, token, topologyUpdate, sessionId);
         }
 
-        private async Task UnlikelyExecuteAsync<TResult>(RavenCommand<TResult> command, JsonOperationContext context, CancellationToken token, Task topologyUpdate)
+        private async Task UnlikelyExecuteAsync<TResult>(
+            RavenCommand<TResult> command, 
+            JsonOperationContext context, 
+            CancellationToken token, 
+            Task topologyUpdate,
+            long? sessionId = null)
         {
             try
             {
@@ -313,7 +332,7 @@ namespace Raven.Client.Http
                 throw;
             }
 
-            await ExecuteAsync(_nodeSelector.GetCurrentNode(), context, command, token).ConfigureAwait(false);
+            await ExecuteAsync(_nodeSelector.GetCurrentNode(), context, command, token, true, sessionId).ConfigureAwait(false);
         }
 
         private void UpdateTopologyCallback(object _)
@@ -417,11 +436,22 @@ namespace Raven.Client.Http
             return true;
         }
 
-        public async Task ExecuteAsync<TResult>(ServerNode chosenNode, JsonOperationContext context, RavenCommand<TResult> command, CancellationToken token = default(CancellationToken), bool shouldRetry = true)
+        public async Task ExecuteAsync<TResult>(
+            ServerNode chosenNode, 
+            JsonOperationContext context, 
+            RavenCommand<TResult> command, 
+            CancellationToken token = default(CancellationToken), 
+            bool shouldRetry = true,
+            long? sessionId = null)
         {
             var request = CreateRequest(chosenNode, command, out string url);
 
-            var nodeIndex = _nodeSelector?.GetCurrentNodeIndex() ?? 0;
+            var nodeSelector = _nodeSelector == null ? null : 
+                    (sessionId.HasValue ? 
+                        _nodeSelectorBySessionId.GetOrAdd(sessionId.Value, _ => _nodeSelector.CloneForNewSession()) : 
+                        _nodeSelector.HandleRequestWithoutSessionId());
+
+            var nodeIndex = nodeSelector?.GetCurrentNodeIndex() ?? 0;
 
             using (var cachedItem = GetFromCache(context, command, request, url, out long cachedEtag, out BlittableJsonReaderObject cachedValue))
             {
@@ -518,7 +548,6 @@ namespace Raven.Client.Http
                         return; // we either handled this already in the unsuccessful response or we are throwing
                     }
 
-                    _nodeSelector?.OnSucceededRequest();
                     OnSucceededRequest(url);
 
                     responseDispose = await command.ProcessResponse(context, Cache, response, url).ConfigureAwait(false);
@@ -590,6 +619,7 @@ namespace Raven.Client.Http
             switch (response.StatusCode)
             {
                 case HttpStatusCode.NotFound:
+                    _nodeSelector.OnFailedRequest(nodeIndex);
                     if (command.ResponseType == RavenCommandResponseType.Empty)
                         return true;
                     else if (command.ResponseType == RavenCommandResponseType.Object)
@@ -937,6 +967,13 @@ namespace Raven.Client.Http
             }
 
             return _nodeSelector.GetCurrentNode();
+        }
+
+        ~RequestExecutor()
+        {
+#if DEBUG
+            Debug.WriteLine("_nodeSelectorBySessionId is not empty when finalizer is called! Perhaps you somewhere missed calling session.Dipose()?");
+#endif
         }
     }
 }

--- a/src/Raven.Client/Http/Topology.cs
+++ b/src/Raven.Client/Http/Topology.cs
@@ -1,4 +1,5 @@
 using System.Collections.Generic;
+using System.Linq;
 
 namespace Raven.Client.Http
 {
@@ -6,5 +7,14 @@ namespace Raven.Client.Http
     {
         public long Etag;
         public List<ServerNode> Nodes;
+
+        public Topology Clone()
+        {
+            return new Topology
+            {
+                Etag = this.Etag,
+                Nodes = Nodes.ToList()
+            };
+        }
     }
 }

--- a/test/FastTests/Server/Documents/Patching/AdvancedPatching.cs
+++ b/test/FastTests/Server/Documents/Patching/AdvancedPatching.cs
@@ -821,7 +821,7 @@ this.Value = another.Value;
                         .ToListAsync();
                 }
 
-                var operation = await store.Operations.SendAsync(new PatchByIndexOperation("TestIndex",
+                var operation = await store.Operations.SendAsyncAndFetchOperation(new PatchByIndexOperation("TestIndex",
                     new IndexQuery() { Query = "Value:1" },
                     new PatchRequest { Script = @"PutDocument('NewItem/3', {'CopiedValue': this.Value });" }));
                 await operation.WaitForCompletionAsync(TimeSpan.FromSeconds(15));

--- a/test/SlowTests/Client/DeleteByIndexTests.cs
+++ b/test/SlowTests/Client/DeleteByIndexTests.cs
@@ -71,7 +71,7 @@ namespace SlowTests.Client
                     indexName = stats.IndexName;
                 }
 
-                var operation = await store.Operations.SendAsync(new DeleteByIndexOperation(indexName, new IndexQuery(), new QueryOperationOptions { AllowStale = false }));
+                var operation = await store.Operations.SendAsyncAndFetchOperation(new DeleteByIndexOperation(indexName, new IndexQuery(), new QueryOperationOptions { AllowStale = false }));
 
                 await operation.WaitForCompletionAsync(TimeSpan.FromSeconds(60));
 

--- a/test/SlowTests/Client/Indexing/IndexesFromClient.cs
+++ b/test/SlowTests/Client/Indexing/IndexesFromClient.cs
@@ -42,7 +42,7 @@ namespace SlowTests.Client.Indexing
 
                 var operation = await store
                     .Operations
-                    .SendAsync(new DeleteByIndexOperation(indexName, new IndexQuery(), new QueryOperationOptions { AllowStale = false }));
+                    .SendAsyncAndFetchOperation(new DeleteByIndexOperation(indexName, new IndexQuery(), new QueryOperationOptions { AllowStale = false }));
 
                 var deleteResult = await operation
                     .WaitForCompletionAsync(TimeSpan.FromSeconds(15)).ConfigureAwait(false) as BulkOperationResult;
@@ -76,7 +76,7 @@ namespace SlowTests.Client.Indexing
 
                 operation = await store
                     .Operations
-                    .SendAsync(new DeleteByIndexOperation(indexName, new IndexQuery(), new QueryOperationOptions { AllowStale = false }));
+                    .SendAsyncAndFetchOperation(new DeleteByIndexOperation(indexName, new IndexQuery(), new QueryOperationOptions { AllowStale = false }));
 
                 var e = Assert.Throws<RavenException>(() =>
                 {
@@ -115,11 +115,10 @@ namespace SlowTests.Client.Indexing
 
                 var operation = await store
                     .Operations
-                    .SendAsync(new PatchByIndexOperation(indexName, new IndexQuery(), new PatchRequest { Script = "this.LastName = 'Test';" }, new QueryOperationOptions { AllowStale = false }));
+                    .SendAsyncAndFetchOperation(new PatchByIndexOperation(indexName, new IndexQuery(), new PatchRequest { Script = "this.LastName = 'Test';" }, new QueryOperationOptions { AllowStale = false }));
 
                 await operation
-                    .WaitForCompletionAsync(TimeSpan.FromSeconds(15))
-                    ;
+                    .WaitForCompletionAsync(TimeSpan.FromSeconds(15));
 
                 using (var session = store.OpenSession())
                 {

--- a/test/SlowTests/Issues/RavenDB-3987.cs
+++ b/test/SlowTests/Issues/RavenDB-3987.cs
@@ -107,12 +107,12 @@ namespace SlowTests.Issues
 
                 WaitForIndexing(store);
 
-                var operation1 = await store.Operations.SendAsync(new DeleteByIndexOperation<Person>("Person/ByName", x => x.Name == "Bob"));
+                var operation1 = await store.Operations.SendAsyncAndFetchOperation(new DeleteByIndexOperation<Person>("Person/ByName", x => x.Name == "Bob"));
                 await operation1.WaitForCompletionAsync();
 
                 WaitForIndexing(store);
 
-                var operation2 = await store.Operations.SendAsync(new DeleteByIndexOperation<Person, Person_ByAge>(x => x.Age < 35));
+                var operation2 = await store.Operations.SendAsyncAndFetchOperation(new DeleteByIndexOperation<Person, Person_ByAge>(x => x.Age < 35));
                 await operation2.WaitForCompletionAsync();
 
                 using (var session = store.OpenAsyncSession())

--- a/test/SlowTests/Server/Basic/CollectionTests.cs
+++ b/test/SlowTests/Server/Basic/CollectionTests.cs
@@ -23,7 +23,7 @@ namespace SlowTests.Server.Basic
                     await session.SaveChangesAsync();
                 }
 
-                var operation = await store.Operations.SendAsync(new DeleteCollectionOperation("Users"));
+                var operation = await store.Operations.SendAsyncAndFetchOperation(new DeleteCollectionOperation("Users"));
                 await operation.WaitForCompletionAsync();
 
                 var stats = await store.Admin.SendAsync(new GetStatisticsOperation());

--- a/test/SlowTests/Server/Documents/Indexing/MapReduce/RavenDB_4323_Replication.cs
+++ b/test/SlowTests/Server/Documents/Indexing/MapReduce/RavenDB_4323_Replication.cs
@@ -57,7 +57,7 @@ namespace SlowTests.Server.Documents.Indexing.MapReduce
                 database.DocumentTombstoneCleaner.Subscribe(this);
                 database2.DocumentTombstoneCleaner.Subscribe(this);
 
-                var operation = await store1.Operations.SendAsync(new DeleteCollectionOperation("Invoices"));
+                var operation = await store1.Operations.SendAsyncAndFetchOperation(new DeleteCollectionOperation("Invoices"));
                 await operation.WaitForCompletionAsync();
                 using (var session = store1.OpenAsyncSession())
                 {

--- a/test/SlowTests/SlowTests/Bugs/AsyncSetBasedOps.cs
+++ b/test/SlowTests/SlowTests/Bugs/AsyncSetBasedOps.cs
@@ -60,7 +60,7 @@ namespace SlowTests.SlowTests.Bugs
 
                 WaitForIndexing(store, timeout: TimeSpan.FromMinutes(5));
 
-                await (await store.Operations.SendAsync(new PatchByIndexOperation(
+                await (await store.Operations.SendAsyncAndFetchOperation(new PatchByIndexOperation(
                     stats.IndexName,
                     new IndexQuery() { Query = string.Empty },
                     new PatchRequest


### PR DESCRIPTION
Now the behavior for load balancing RequestExecutor behavior will be:
* inside session
  ** when session starts, node selector will advance to next node
  ** all requests inside particular session will be sent to the same node
  ** each session will have independent node selector for handling failures
* outside of session : each operation will send requests to different node.