### PR TITLE
[3.0] RavenDB-7736 Infinite synchronization due to invalid handling of sync…

### DIFF
--- a/Raven.Database/FileSystem/Actions/FileActions.cs
+++ b/Raven.Database/FileSystem/Actions/FileActions.cs
@@ -271,12 +271,15 @@ namespace Raven.Database.FileSystem.Actions
                 // copy renaming file metadata and set special markers
                 var tombstoneMetadata = new RavenJObject(operation.MetadataAfterOperation).WithRenameMarkers(operation.Rename);
 
-                var putResult = accessor.PutFile(operation.Name, 0, tombstoneMetadata, true); // put rename tombstone
+                accessor.PutFile(operation.Name, 0, tombstoneMetadata, true); // put rename tombstone
+
+                // let's bump renamed doc etag so it'll be greater than tombstone
+                var touchResult = accessor.TouchFile(operation.Rename, null);
 
                 accessor.DeleteConfig(configName);
 
                 Search.Delete(operation.Name);
-                Search.Index(operation.Rename, operation.MetadataAfterOperation, putResult.Etag);
+                Search.Index(operation.Rename, operation.MetadataAfterOperation, touchResult.Etag);
             });
 
             Publisher.Publish(new ConfigurationChangeNotification { Name = configName, Action = ConfigurationChangeAction.Set });

--- a/Raven.Database/FileSystem/Storage/IStorageActionsAccessor.cs
+++ b/Raven.Database/FileSystem/Storage/IStorageActionsAccessor.cs
@@ -48,6 +48,8 @@ namespace Raven.Database.FileSystem.Storage
 
         void RenameFile(string filename, string rename, bool commitPeriodically = false);
 
+        FileUpdateResult TouchFile(string filename, Etag etag);
+
         RavenJObject GetConfig(string name);
 
         void SetConfig(string name, RavenJObject metadata);

--- a/Raven.Tests.FileSystem/Bugs/FileRenaming.cs
+++ b/Raven.Tests.FileSystem/Bugs/FileRenaming.cs
@@ -1,15 +1,20 @@
 using Raven.Json.Linq;
+using Raven.Tests.FileSystem.Storage;
 using System.Linq;
 using Xunit;
+using Xunit.Extensions;
 
 namespace Raven.Tests.FileSystem.Bugs
 {
-    public class FileRenaming : StorageTest
+    public class FileRenaming : StorageAccessorTestBase
     {
-        [Fact]
-        public void Should_rename_file_and_content()
+        [Theory]
+        [PropertyData("Storages")]
+        public void Should_rename_file_and_content(string requestedStorage)
         {
-            transactionalStorage.Batch(
+            using (var transactionalStorage = NewTransactionalStorage(requestedStorage))
+            {
+                transactionalStorage.Batch(
                 accessor =>
                 {
                     accessor.PutFile("test.bin", 3, new RavenJObject());
@@ -18,25 +23,28 @@ namespace Raven.Tests.FileSystem.Bugs
                     accessor.CompleteFileUpload("test.bin");
                 });
 
-            transactionalStorage.Batch(
-                accessor => accessor.RenameFile("test.bin", "test.result.bin"));
+                transactionalStorage.Batch(
+                    accessor => accessor.RenameFile("test.bin", "test.result.bin"));
 
-            transactionalStorage.Batch(
-                accessor =>
-                {
-                    var pages = accessor.GetFile("test.result.bin", 0, 1);
-                    var buffer = new byte[3];
-                    accessor.ReadPage(pages.Pages.First().Id, buffer);
-                    Assert.Equal(1, buffer[0]);
-                });
-
+                transactionalStorage.Batch(
+                    accessor =>
+                    {
+                        var pages = accessor.GetFile("test.result.bin", 0, 1);
+                        var buffer = new byte[3];
+                        accessor.ReadPage(pages.Pages.First().Id, buffer);
+                        Assert.Equal(1, buffer[0]);
+                    });
+            }
         }
 
-        [Fact]
-        public void Should_rename_file_and_content_after_deleting_some_other_file()
+        [Theory]
+        [PropertyData("Storages")]
+        public void Should_rename_file_and_content_after_deleting_some_other_file(string requestedStorage)
         {
-            // create 1st file
-            transactionalStorage.Batch(
+            using (var transactionalStorage = NewTransactionalStorage(requestedStorage))
+            {
+                // create 1st file
+                transactionalStorage.Batch(
                 accessor =>
                     {
                         accessor.PutFile("test0.bin", 3, new RavenJObject());
@@ -44,34 +52,64 @@ namespace Raven.Tests.FileSystem.Bugs
                         accessor.AssociatePage("test0.bin", pageId, 0, 3);
                         accessor.CompleteFileUpload("test0.bin");
                     });
-            // create 2nd file
-            transactionalStorage.Batch(
-                accessor =>
-                    {
-                        accessor.PutFile("test1.bin", 3, new RavenJObject());
-                        var pageId = accessor.InsertPage(new byte[] { 4, 5, 6 }, 3);
-                        accessor.AssociatePage("test1.bin", pageId, 0, 3);
-                        accessor.CompleteFileUpload("test1.bin");
-                    });
-            // remove 1st file
-            transactionalStorage.Batch(
-                accessor =>
-                    {
+                // create 2nd file
+                transactionalStorage.Batch(
+                    accessor =>
+                        {
+                            accessor.PutFile("test1.bin", 3, new RavenJObject());
+                            var pageId = accessor.InsertPage(new byte[] { 4, 5, 6 }, 3);
+                            accessor.AssociatePage("test1.bin", pageId, 0, 3);
+                            accessor.CompleteFileUpload("test1.bin");
+                        });
+                // remove 1st file
+                transactionalStorage.Batch(
+                    accessor =>
+                        {
                         // WARN Test passes if you comment out the following line.
-                       accessor.Delete("test0.bin");
+                        accessor.Delete("test0.bin");
+                        });
+                // rename the 2nd file
+                transactionalStorage.Batch(
+                    accessor => accessor.RenameFile("test1.bin", "test.result.bin"));
+                // check the renamed file
+                transactionalStorage.Batch(
+                    accessor =>
+                    {
+                        var pages = accessor.GetFile("test.result.bin", 0, 1);
+                        var buffer = new byte[3];
+                        accessor.ReadPage(pages.Pages.First().Id, buffer);
+                        Assert.Equal(4, buffer[0]);
                     });
-            // rename the 2nd file
-            transactionalStorage.Batch(
-                accessor => accessor.RenameFile("test1.bin", "test.result.bin"));
-            // check the renamed file
-            transactionalStorage.Batch(
+            }
+        }
+
+        [Theory]
+        [PropertyData("Storages")]
+        public void Should_rename_file_and_content_2(string requestedStorage)
+        {
+            using (var transactionalStorage = NewTransactionalStorage(requestedStorage))
+            {
+                transactionalStorage.Batch(
                 accessor =>
                 {
-                    var pages = accessor.GetFile("test.result.bin", 0, 1);
-                    var buffer = new byte[3];
-                    accessor.ReadPage(pages.Pages.First().Id, buffer);
-                    Assert.Equal(4, buffer[0]);
+                    accessor.PutFile("1", 3, new RavenJObject());
+                    var pageId = accessor.InsertPage(new byte[] { 1, 2, 3 }, 3);
+                    accessor.AssociatePage("1", pageId, 0, 3);
+                    accessor.CompleteFileUpload("1");
                 });
+
+                transactionalStorage.Batch(
+                    accessor => accessor.RenameFile("1", "0"));
+
+                transactionalStorage.Batch(
+                    accessor =>
+                    {
+                        var pages = accessor.GetFile("0", 0, 1);
+                        var buffer = new byte[3];
+                        accessor.ReadPage(pages.Pages.First().Id, buffer);
+                        Assert.Equal(1, buffer[0]);
+                    });
+            }
         }
     }
 }


### PR DESCRIPTION
… configurations and file renames:

- removing syncing configuration if it's no longer relevant
- ensuring that the etag of the renamed file is greater that its related rename tombstone

Port of https://github.com/ravendb/ravendb/pull/2978 to 3.0