### PR TITLE
RavenDB-7781

### DIFF
--- a/Rachis/Rachis/RaftEngine.cs
+++ b/Rachis/Rachis/RaftEngine.cs
@@ -71,12 +71,7 @@ namespace Rachis
             }
         }
 
-    
-        public long CommitIndex
-        {
-            get { return StateMachine.LastAppliedIndex; }
-            
-        }
+        public long CommitIndex => StateMachine.LastAppliedIndex;
 
         public RaftEngineState State
         {
@@ -107,7 +102,6 @@ namespace Rachis
 
         private readonly Task _eventLoopTask;
 
-        private long _commitIndex;
         private string _currentLeader;
 
         private Task _snapshottingTask;
@@ -173,8 +167,7 @@ namespace Rachis
             {
                 SetState(RaftEngineState.Follower);
             }
-
-            _commitIndex = StateMachine.LastAppliedIndex;            
+        
             _eventLoopTask = Task.Factory.StartNew(EventLoop, TaskCreationOptions.LongRunning);
         }
 
@@ -527,13 +520,13 @@ namespace Rachis
             var leaderStateBehavior = StateBehavior as LeaderStateBehavior;
             if (leaderStateBehavior == null || leaderStateBehavior.State != RaftEngineState.Leader)
                 throw new NotLeadingException("Command can be appended only on leader node. This node behavior type is " +
-                                                    StateBehavior.GetType().Name)
+                                              StateBehavior.GetType().Name)
                 {
                     CurrentLeader = CurrentLeader
                 };
+        
 
-
-            leaderStateBehavior.AppendCommand(command);
+        leaderStateBehavior.AppendCommand(command);
         }
 
         public void ApplyCommits(long from, long to)

--- a/Raven.Database/Raft/ClusterManager.cs
+++ b/Raven.Database/Raft/ClusterManager.cs
@@ -223,7 +223,7 @@ namespace Raven.Database.Raft
             Engine.PersistentState.SetCurrentTopology(tcc.Requested, 0);
             Engine.StartTopologyChange(tcc);
             Engine.CommitTopologyChange(tcc);
-
+            
             if (isPartOfExistingCluster || forceCandidateState)
                 Engine.ForceCandidateState();
             else

--- a/Raven.Database/Raft/ClusterManagerFactory.cs
+++ b/Raven.Database/Raft/ClusterManagerFactory.cs
@@ -4,19 +4,10 @@
 //  </copyright>
 // -----------------------------------------------------------------------
 using System;
-using System.Collections.Generic;
 using System.IO;
-using System.Linq;
-
 using Rachis;
-using Rachis.Commands;
-using Rachis.Storage;
 using Rachis.Transport;
-
-using Raven.Abstractions.Logging;
-using Raven.Database.Raft.Commands;
 using Raven.Database.Raft.Storage;
-using Raven.Database.Raft.Storage.Handlers;
 using Raven.Database.Raft.Util;
 using Raven.Database.Server.Tenancy;
 using Raven.Database.Util;
@@ -42,7 +33,7 @@ namespace Raven.Database.Raft
             };
         }
 
-        public static ClusterManager Create(DocumentDatabase systemDatabase, DatabasesLandlord databasesLandlord)
+        public static ClusterManager Create(DocumentDatabase systemDatabase, DatabasesLandlord databasesLandlord, bool nullifyLastAppliedIndex = false)
         {
             if (systemDatabase == null)
                 throw new ArgumentNullException("systemDatabase");
@@ -71,7 +62,7 @@ namespace Raven.Database.Raft
 
             var shortOperationsTimeout = TimeSpan.FromMilliseconds(1.5 * Math.Max(configuration.Cluster.ElectionTimeout, configuration.Cluster.HeartbeatTimeout));
             var transport = new HttpTransport(nodeConnectionInfo.Name, shortOperationsTimeout, systemDatabase.WorkContext.CancellationToken);
-            var stateMachine = new ClusterStateMachine(systemDatabase, databasesLandlord);
+            var stateMachine = new ClusterStateMachine(systemDatabase, databasesLandlord, nullifyLastAppliedIndex: nullifyLastAppliedIndex);
             var raftEngineOptions = new RaftEngineOptions(nodeConnectionInfo, options, transport, stateMachine)
             {
                 ElectionTimeout = configuration.Cluster.ElectionTimeout,

--- a/Raven.Database/Raft/Controllers/ClusterAdminController.cs
+++ b/Raven.Database/Raft/Controllers/ClusterAdminController.cs
@@ -150,7 +150,7 @@ namespace Raven.Database.Raft.Controllers
             }
             oldClusterManager?.Dispose();
 
-            var newClusterManager = ClusterManagerFactory.Create(SystemDatabase, DatabasesLandlord);
+            var newClusterManager = ClusterManagerFactory.Create(SystemDatabase, DatabasesLandlord, nullifyLastAppliedIndex: true);
 
             if (string.IsNullOrEmpty(id))
                 newClusterManager.InitializeTopology(isPartOfExistingCluster: true);
@@ -159,7 +159,7 @@ namespace Raven.Database.Raft.Controllers
                 newClusterManager.InitializeEmptyTopologyWithId(Guid.Parse(id));
             }
 
-            ((Reference<ClusterManager>)Configuration.Properties[typeof(ClusterManager)]).Value = newClusterManager;
+            ((Reference<ClusterManager>) Configuration.Properties[typeof(ClusterManager)]).Value = newClusterManager;
             return GetEmptyMessage(HttpStatusCode.NoContent);
         }
 
@@ -167,7 +167,7 @@ namespace Raven.Database.Raft.Controllers
         {
             //making sure nobody contact us while we change the persistent state.
             ClusterManager oldClusterManager = ((Reference<ClusterManager>) Configuration.Properties[typeof(ClusterManager)]).Value;
-            Configuration.Properties[typeof(ClusterManager)] = new Reference<ClusterManager>();
+            ((Reference<ClusterManager>) Configuration.Properties[typeof(ClusterManager)]).Value = null;
             return oldClusterManager;
         }
 

--- a/Raven.Database/Raft/Storage/ClusterStateMachine.cs
+++ b/Raven.Database/Raft/Storage/ClusterStateMachine.cs
@@ -42,7 +42,7 @@ namespace Raven.Database.Raft.Storage
 
         internal RaftEngine RaftEngine { get; set; }
 
-        public ClusterStateMachine(DocumentDatabase systemDatabase, DatabasesLandlord databasesLandlord)
+        public ClusterStateMachine(DocumentDatabase systemDatabase, DatabasesLandlord databasesLandlord, bool nullifyLastAppliedIndex = false)
         {
             if (systemDatabase == null)
                 throw new ArgumentNullException("systemDatabase");
@@ -51,7 +51,7 @@ namespace Raven.Database.Raft.Storage
 
             database = systemDatabase;
 
-            LastAppliedIndex = ReadLastAppliedIndex();
+            LastAppliedIndex = nullifyLastAppliedIndex == false ? ReadLastAppliedIndex() : 0;
 
             handlers.Add(typeof(ClusterConfigurationUpdateCommand), new ClusterConfigurationUpdateCommandHandler(systemDatabase, databasesLandlord));
             handlers.Add(typeof(DatabaseDeletedCommand), new DatabaseDeletedCommandHandler(systemDatabase, databasesLandlord));

--- a/Raven.Tests.Raft/ClusterBasic.cs
+++ b/Raven.Tests.Raft/ClusterBasic.cs
@@ -151,25 +151,23 @@ namespace Raven.Tests.Raft
         public void CanInitializeNewClusterOnNodeBeingPartOfExistingClusterAndTakeOverNodeFromIt()
         {
             var nodes = CreateRaftCluster(3);
-
-            var selectedNode = 0;
+            var selectedNode = 2;
 
             var nodeClient = nodes[selectedNode];
             var nodeServer = servers[selectedNode];
-            var nodeRaftEngine = nodeServer.Options.ClusterManager.Value.Engine;
+            var nodeRaftEngine = nodeServer.Options.ClusterManager;
 
-            var oldClusterId = nodeRaftEngine.CurrentTopology.TopologyId;
-
+            var oldClusterId = nodeRaftEngine.Value.Engine.CurrentTopology.TopologyId;
             // initialize new single node cluster
             nodeClient.DatabaseCommands.ForSystemDatabase().CreateRequest("/admin/cluster/initialize-new-cluster", new HttpMethod("PATCH")).ExecuteRequest();
+         
+            Assert.True(nodeRaftEngine.Value.Engine.WaitForLeader());
 
-            Assert.True(nodeRaftEngine.WaitForLeader());
-
-            var newClusterId = nodeRaftEngine.CurrentTopology.TopologyId;
+            var newClusterId = nodeRaftEngine.Value.Engine.CurrentTopology.TopologyId;
 
             Assert.NotEqual(oldClusterId, newClusterId);
-            Assert.Equal(1, nodeRaftEngine.CurrentTopology.AllNodes.Count());
-            Assert.Contains(nodeRaftEngine.Name, nodeRaftEngine.CurrentTopology.AllNodeNames);
+            Assert.Equal(1, nodeRaftEngine.Value.Engine.CurrentTopology.AllNodes.Count());
+            Assert.Contains(nodeRaftEngine.Value.Engine.Name, nodeRaftEngine.Value.Engine.CurrentTopology.AllNodeNames);
 
             var nextNodeInNewCluster = 1;
             var nextNodeClient = nodes[nextNodeInNewCluster];
@@ -180,8 +178,8 @@ namespace Raven.Tests.Raft
                 .WriteWithObjectAsync(newNodeRaftEngine.Options.SelfConnection).Wait();
 
             // ensure that cluster contains two nodes
-            Assert.True(SpinWait.SpinUntil(() => nodeRaftEngine.CurrentTopology.Contains(newNodeRaftEngine.Name), TimeSpan.FromSeconds(30)));
-            Assert.True(SpinWait.SpinUntil(() => newNodeRaftEngine.CurrentTopology.Contains(nodeRaftEngine.Name), TimeSpan.FromSeconds(30)));
+            Assert.True(SpinWait.SpinUntil(() => nodeRaftEngine.Value.Engine.CurrentTopology.Contains(newNodeRaftEngine.Name), TimeSpan.FromSeconds(30)));
+            Assert.True(SpinWait.SpinUntil(() => newNodeRaftEngine.CurrentTopology.Contains(nodeRaftEngine.Value.Engine.Name), TimeSpan.FromSeconds(30)));
 
             // verify that database is 
             nodeClient.DatabaseCommands.GlobalAdmin.CreateDatabase(new DatabaseDocument

--- a/Raven.Tests.Raft/RaftTestBase.cs
+++ b/Raven.Tests.Raft/RaftTestBase.cs
@@ -26,7 +26,9 @@ using System.Collections.Generic;
 using System.Diagnostics;
 using System.Linq;
 using System.Runtime.CompilerServices;
+using System.Runtime.Remoting.Channels;
 using System.Threading;
+using Rachis;
 using Raven.Client.Connection.Async;
 using Raven.Client.Connection.Request;
 using Raven.Tests.Common;
@@ -52,9 +54,9 @@ namespace Raven.Tests.Raft
             {
                 return new[]
                 {
-                    new object[] { 1 },
-                    new object[] { 3 },
-                    new object[] { 5 }
+                    new object[] {1},
+                    new object[] {3},
+                    new object[] {5}
                 };
             }
         }
@@ -81,17 +83,18 @@ namespace Raven.Tests.Raft
         }
 
         private Action<DocumentStore> defaultConfigureStore = store => store.Conventions.FailoverBehavior = FailoverBehavior.ReadFromLeaderWriteToLeader;
+
         public List<DocumentStore> CreateRaftCluster(int numberOfNodes, string activeBundles = null, Action<DocumentStore> configureStore = null, [CallerMemberName] string databaseName = null, bool inMemory = true, bool fiddler = false)
         {
             if (configureStore == null)
                 configureStore = defaultConfigureStore;
             var nodes = Enumerable.Range(0, numberOfNodes)
-                .Select(x => GetNewServer(GetPort(), activeBundles: activeBundles, databaseName: databaseName, runInMemory:inMemory, 
-                configureConfig: configuration =>
-                {
-                    configuration.Cluster.ElectionTimeout *= 10;
-                    configuration.Cluster.HeartbeatTimeout *= 10;
-                }))
+                .Select(x => GetNewServer(GetPort(), activeBundles: activeBundles, databaseName: databaseName, runInMemory: inMemory,
+                    configureConfig: configuration =>
+                    {
+                        configuration.Cluster.ElectionTimeout *= 10;
+                        configuration.Cluster.HeartbeatTimeout *= 10;
+                    }))
                 .ToList();
 
             var allNodesFinishedJoining = new ManualResetEventSlim();
@@ -99,9 +102,9 @@ namespace Raven.Tests.Raft
             var random = new Random();
             var leader = nodes[random.Next(0, numberOfNodes - 1)];
 
-            leader.Options.ClusterManager.Value.InitializeTopology(forceCandidateState:true);
+            leader.Options.ClusterManager.Value.InitializeTopology(forceCandidateState: true);
 
-            Assert.True(leader.Options.ClusterManager.Value.Engine.WaitForLeader(),"Leader was not elected by himself in time");
+            Assert.True(leader.Options.ClusterManager.Value.Engine.WaitForLeader(), "Leader was not elected by himself in time");
 
             leader.Options.ClusterManager.Value.Engine.TopologyChanged += command =>
             {
@@ -119,17 +122,17 @@ namespace Raven.Tests.Raft
                     continue;
 
                 Assert.True(leader.Options.ClusterManager.Value.Engine.AddToClusterAsync(new NodeConnectionInfo
-                                                                        {
-                                                                            Name = RaftHelper.GetNodeName(n.SystemDatabase.TransactionalStorage.Id),
-                                                                            Uri = RaftHelper.GetNodeUrl(n.SystemDatabase.Configuration.ServerUrl)
-                                                                        }).Wait(3000),"Failed to add node to cluster");
+                {
+                    Name = RaftHelper.GetNodeName(n.SystemDatabase.TransactionalStorage.Id),
+                    Uri = RaftHelper.GetNodeUrl(n.SystemDatabase.Configuration.ServerUrl)
+                }).Wait(3000), "Failed to add node to cluster");
             }
 
             if (numberOfNodes == 1)
                 allNodesFinishedJoining.Set();
 
             Assert.True(allNodesFinishedJoining.Wait(10000 * numberOfNodes), "Not all nodes become voters. " + leader.Options.ClusterManager.Value.Engine.CurrentTopology);
-            Assert.True(leader.Options.ClusterManager.Value.Engine.WaitForLeader(),"Wait for leader timedout");
+            Assert.True(leader.Options.ClusterManager.Value.Engine.WaitForLeader(), "Wait for leader timeout");
 
             WaitForClusterToBecomeNonStale(nodes);
 
@@ -141,17 +144,17 @@ namespace Raven.Tests.Raft
             }
 
             var documentStores = nodes
-                .Select(node => NewRemoteDocumentStore(ravenDbServer: node, fiddler: fiddler,activeBundles: activeBundles, configureStore: configureStore, databaseName: databaseName))
+                .Select(node => NewRemoteDocumentStore(ravenDbServer: node, fiddler: fiddler, activeBundles: activeBundles, configureStore: configureStore, databaseName: databaseName))
                 .ToList();
 
             foreach (var documentStore in documentStores)
             {
-                ((ClusterAwareRequestExecuter)((ServerClient)documentStore.DatabaseCommands).RequestExecuter).WaitForLeaderTimeout = TimeSpan.FromSeconds(30);
+                ((ClusterAwareRequestExecuter) ((ServerClient) documentStore.DatabaseCommands).RequestExecuter).WaitForLeaderTimeout = TimeSpan.FromSeconds(30);
             }
             return documentStores;
         }
 
-        public List<DocumentStore> ExtendRaftCluster(int numberOfExtraNodes,Guid topologyId, string activeBundles = null, Action<DocumentStore> configureStore = null, [CallerMemberName] string databaseName = null, bool inMemory = true)
+        public List<DocumentStore> ExtendRaftCluster(int numberOfExtraNodes, Guid topologyId, string activeBundles = null, Action<DocumentStore> configureStore = null, [CallerMemberName] string databaseName = null, bool inMemory = true)
         {
             if (configureStore == null)
                 configureStore = defaultConfigureStore;
@@ -159,12 +162,12 @@ namespace Raven.Tests.Raft
             Assert.NotNull(leader);
 
             var nodes = Enumerable.Range(0, numberOfExtraNodes)
-                .Select(x => GetNewServer(GetPort(), activeBundles: activeBundles, databaseName: databaseName, runInMemory:inMemory,
-                configureConfig: configuration =>
-                {
-                    configuration.Cluster.ElectionTimeout *= 10;
-                    configuration.Cluster.HeartbeatTimeout *= 10;
-                }))
+                .Select(x => GetNewServer(GetPort(), activeBundles: activeBundles, databaseName: databaseName, runInMemory: inMemory,
+                    configureConfig: configuration =>
+                    {
+                        configuration.Cluster.ElectionTimeout *= 10;
+                        configuration.Cluster.HeartbeatTimeout *= 10;
+                    }))
                 .ToList();
 
             var allNodesFinishedJoining = new ManualResetEventSlim();
@@ -188,7 +191,7 @@ namespace Raven.Tests.Raft
                     Name = RaftHelper.GetNodeName(n.SystemDatabase.TransactionalStorage.Id),
                     Uri = RaftHelper.GetNodeUrl(n.SystemDatabase.Configuration.ServerUrl)
                 }).Wait(10000));
-                Assert.True(allNodesFinishedJoining.Wait(10000),"Not all nodes finished joining");
+                Assert.True(allNodesFinishedJoining.Wait(10000), "Not all nodes finished joining");
                 allNodesFinishedJoining.Reset();
             }
 
@@ -206,7 +209,7 @@ namespace Raven.Tests.Raft
             if (leader == null)
                 throw new InvalidOperationException("Leader is currently not present, thus can't remove node from cluster");
             if (leader == serverToRemove)
-            {                
+            {
                 leader.Options.ClusterManager.Value.Engine.StepDownAsync().Wait();
                 leader.Server.Options.ClusterManager.Value.Engine.WaitForLeader();
                 leader = ChooseTheRealLeader(topologyId);
@@ -214,7 +217,7 @@ namespace Raven.Tests.Raft
                 //this is because a leader chosen event is placed wrongly
                 //SpinWait.SpinUntil(()=>leader.Options.ClusterManager.Value.Engine.PersistentState.GetLogEntry(leader.Options.ClusterManager.Value.Engine.CommitIndex).Term
                 //                 == leader.Options.ClusterManager.Value.Engine.PersistentState.CurrentTerm,TimeSpan.FromSeconds(10));
-            }         
+            }
             leader.Options.ClusterManager.Value.Engine.RemoveFromClusterAsync(serverToRemove.Options.ClusterManager.Value.Engine.Options.SelfConnection).Wait(10000);
         }
 
@@ -223,7 +226,7 @@ namespace Raven.Tests.Raft
             return servers.OrderByDescending(server => server.Options.ClusterManager.Value.Engine.PersistentState.LastLogEntry().Term)
                 .ThenByDescending(server => server.Options.ClusterManager.Value.Engine.PersistentState.LastLogEntry().Index)
                 .FirstOrDefault(server => server.Options.ClusterManager.Value.IsLeader()
-                && topologyId == server.Options.ClusterManager.Value.Engine.CurrentTopology.TopologyId);
+                                          && topologyId == server.Options.ClusterManager.Value.Engine.CurrentTopology.TopologyId);
         }
 
         private void WaitForClusterToBecomeNonStale(IReadOnlyCollection<RavenDbServer> nodes)
@@ -289,6 +292,7 @@ namespace Raven.Tests.Raft
 
         protected void SetupClusterConfiguration(List<DocumentStore> clusterStores, bool enableReplication = true, Dictionary<string, string> databaseSettings = null)
         {
+      
             var clusterStore = clusterStores[0];
             var requestFactory = new HttpRavenRequestFactory();
             var replicationRequestUrl = string.Format("{0}/admin/cluster/commands/configuration", clusterStore.Url);
@@ -323,7 +327,7 @@ namespace Raven.Tests.Raft
 
         protected void UpdateTopologyForAllClients(IEnumerable<DocumentStore> clusterStores)
         {
-            clusterStores.ForEach(store => ((ServerClient)store.DatabaseCommands).RequestExecuter.UpdateReplicationInformationIfNeededAsync((AsyncServerClient)store.AsyncDatabaseCommands, force: true));
+            clusterStores.ForEach(store => ((ServerClient) store.DatabaseCommands).RequestExecuter.UpdateReplicationInformationIfNeededAsync((AsyncServerClient) store.AsyncDatabaseCommands, force: true));
         }
     }
 }


### PR DESCRIPTION
- Fix CanInitializeNewClusterOnNodeBeingPartOfExistingClusterAndTakeOverNodeFromIt test
- SetClusterManagerToNullAndGetOldValue no longer change the reference to ClusterManager