### PR TITLE
RavenDB-7801 fix

### DIFF
--- a/Raven.Tests/Abstractions/Logging/LoggerExecutionWrapperTests.cs
+++ b/Raven.Tests/Abstractions/Logging/LoggerExecutionWrapperTests.cs
@@ -1,4 +1,5 @@
 using System;
+using System.Collections.Generic;
 using Raven.Abstractions.Logging;
 using Raven.Tests.Common;
 using Sparrow.Collections;
@@ -14,7 +15,7 @@ namespace Raven.Tests.Abstractions.Logging
         public LoggerExecutionWrapperTests()
         {
             fakeLogger = new FakeLogger();
-            sut = new LoggerExecutionWrapper(fakeLogger, "name", new ConcurrentSet<Target>());
+            sut = new LoggerExecutionWrapper(fakeLogger, "name", new List<Target>());
         }
 
         [Fact]


### PR DESCRIPTION
Avoid using synchronized properties of ConcurrentSet<T> by passing non-concurrent collection and atomically synchronizing when the parent "Targets" collection is changed.