### PR TITLE
RavenDB-7873

### DIFF
--- a/Raven.Tests.Issues/Raven.Tests.Issues.csproj
+++ b/Raven.Tests.Issues/Raven.Tests.Issues.csproj
@@ -139,6 +139,7 @@
     <Compile Include="1379\RavenDB_1379_Client_Remote.cs" />
     <Compile Include="ActualValueInJsonReaderException.cs" />
     <Compile Include="NtpServers.cs" />
+    <Compile Include="RavenDB_7873.cs" />
     <Compile Include="RavenDB-7406.cs" />
     <Compile Include="RavenDB-7277.cs" />
     <Compile Include="RavenDB-6755.cs" />

--- a/Raven.Tests.Issues/RavenDB_7873.cs
+++ b/Raven.Tests.Issues/RavenDB_7873.cs
@@ -1,0 +1,43 @@
+﻿using System.Linq;
+using Raven.Client.Indexes;
+using Raven.Tests.Common;
+using Xunit;
+
+namespace Raven.Tests.Issues
+{
+    public class RavenDB_7873 : RavenTest
+    {
+        [Fact]
+        public void QueryingTermsWithDashesShouldWork()
+        {
+            using (var store = NewDocumentStore())
+            {
+                store.ExecuteIndex(new DogsByName());
+                using (var session = store.OpenSession())
+                {
+                    session.Store(new Dog { Name = "-woof woof", Age = 5 });
+                    session.SaveChanges();
+                    WaitForIndexing(store);
+                    var res = session.Query<Dog>().Where(m => m.Name.StartsWith("-woof ")).ToList();
+                    Assert.Equal(res.Count, 1);
+                }
+            }
+        }
+
+        public class DogsByName : AbstractIndexCreationTask<Dog>
+        {
+            public DogsByName()
+            {
+                Map = dogs => from dog in dogs select new { dog.Name };
+            }
+        }
+
+        public class Dog
+        {
+            public string Name { get; set; }
+            public int Age { get; set; }
+        }
+    }
+
+    
+}

--- a/Raven.Tests.MailingList/Kamran.cs
+++ b/Raven.Tests.MailingList/Kamran.cs
@@ -28,7 +28,7 @@ namespace Raven.Tests.MailingList
                 {
                     Assert.Equal("Name:(\\\"Foo\\\"\\: Test)", s.Query<Foo>()
                         .Search(x => x.Name , "\"Foo\": Test").ToString());
-                    Assert.Equal("Name:\"\\\"Foo\\\"\\: Test\"", s.Query<Foo>()
+                    Assert.Equal("Name:\"\\\"Foo\\\": Test\"", s.Query<Foo>()
                         .Where(x => x.Name == "\"Foo\": Test").ToString());
                 }
             }


### PR DESCRIPTION
When escaping qouted query we should not escaped Lucene special chars
Fixing wrong test assertion in Kamran.cs
Adding a new test to check for the case where we have both whitespace and special Lucene chars in the same query