### PR TITLE
RavenDB-7735

### DIFF
--- a/src/Raven.Server/Documents/DocumentPutAction.cs
+++ b/src/Raven.Server/Documents/DocumentPutAction.cs
@@ -78,7 +78,7 @@ namespace Raven.Server.Documents
                 }
                 else
                 {
-                    if (expectedChangeVector != null)
+                    if (string.IsNullOrEmpty(expectedChangeVector) == false)
                     {
                         var oldChangeVector = TableValueToChangeVector(context, (int)DocumentsTable.ChangeVector, ref oldValue);
                         if (string.Compare(expectedChangeVector, oldChangeVector, StringComparison.Ordinal) != 0)
@@ -231,14 +231,14 @@ namespace Raven.Server.Documents
                 }
             }
 
-            if (changeVector != null)
+            if (string.IsNullOrEmpty(changeVector) == false)
                return (changeVector, nonPersistentFlags);
 
             string oldChangeVector;
             if (fromReplication == false)
             {
                 if(context.LastDatabaseChangeVector == null)
-                    context.LastDatabaseChangeVector = DocumentsStorage.GetDatabaseChangeVector(context);
+                    context.LastDatabaseChangeVector = GetDatabaseChangeVector(context);
                 oldChangeVector = context.LastDatabaseChangeVector;
             }
             else
@@ -408,9 +408,9 @@ namespace Raven.Server.Documents
 
         private string SetDocumentChangeVectorForLocalChange(DocumentsOperationContext context, Slice lowerId, string oldChangeVector, long newEtag)
         {
-            if (oldChangeVector != null)
+            if (string.IsNullOrEmpty(oldChangeVector) == false)
             {
-                ChangeVectorUtils.TryUpdateChangeVector(_documentsStorage.Environment.DbId, newEtag, ref oldChangeVector);
+                ChangeVectorUtils.TryUpdateChangeVector(_documentDatabase.ServerStore.NodeTag, _documentsStorage.Environment.DbId, newEtag, ref oldChangeVector);
                 return oldChangeVector;
             }
 

--- a/src/Raven.Server/Documents/DocumentsStorage.cs
+++ b/src/Raven.Server/Documents/DocumentsStorage.cs
@@ -296,15 +296,14 @@ namespace Raven.Server.Documents
             return context.GetLazyString(Encodings.Utf8.GetString(val.Reader.Base, val.Reader.Length));
         }
 
-        public LazyStringValue GetNewChangeVector(DocumentsOperationContext context, long newEtag)
+        public string GetNewChangeVector(DocumentsOperationContext context, long newEtag)
         {
             var changeVector = GetDatabaseChangeVector(context);
-            if (changeVector == null)
-                return context.GetLazyString(ChangeVectorUtils.NewChangeVector(_documentDatabase.ServerStore.NodeTag, newEtag, _documentDatabase.DbId)); ;
+            if (string.IsNullOrEmpty(changeVector))
+                return ChangeVectorUtils.NewChangeVector(_documentDatabase.ServerStore.NodeTag, newEtag, _documentDatabase.DbId);
 
-            var str = changeVector.ToString();
-            ChangeVectorUtils.TryUpdateChangeVector(Environment.DbId, newEtag, ref str);
-            return context.GetLazyString(str);
+            ChangeVectorUtils.TryUpdateChangeVector(_documentDatabase.ServerStore.NodeTag, Environment.DbId, newEtag, ref changeVector);
+            return changeVector;
         }
 
         public void SetDatabaseChangeVector(DocumentsOperationContext context, string changeVector)
@@ -899,7 +898,7 @@ namespace Raven.Server.Documents
 
             if (local.Tombstone != null)
             {
-                if (expectedChangeVector != null && expectedChangeVector.Length != 0)
+                if (string.IsNullOrEmpty(expectedChangeVector) == false)
                     throw new ConcurrencyException($"Document {local.Tombstone.LowerId} does not exist, but delete was called with change vector '{expectedChangeVector}'. " +
                                                    "Optimistic concurrency violation, transaction will be aborted.");
 
@@ -1013,7 +1012,7 @@ namespace Raven.Server.Documents
             {
                 // we adding a tombstone without having any previous document, it could happened if this was called
                 // from the incoming replication or if we delete document that wasn't exist at the first place.
-                if (expectedChangeVector != null && expectedChangeVector.Length != 0)
+                if (string.IsNullOrEmpty(expectedChangeVector) == false)
                     throw new ConcurrencyException($"Document {lowerId} does not exist, but delete was called with change vector '{expectedChangeVector}'. " +
                                                    $"Optimistic concurrency violation, transaction will be aborted.");
 
@@ -1109,7 +1108,7 @@ namespace Raven.Server.Documents
         {
             var newEtag = GenerateNextEtag();
 
-            if (changeVector == null)
+            if (string.IsNullOrEmpty(changeVector))
             {
                 changeVector = ConflictsStorage.GetMergedConflictChangeVectorsAndDeleteConflicts(
                     context,

--- a/src/Raven.Server/Documents/Replication/OutgoingReplicationHandler.cs
+++ b/src/Raven.Server/Documents/Replication/OutgoingReplicationHandler.cs
@@ -428,7 +428,7 @@ namespace Raven.Server.Documents.Replication
 
             public override int Execute(DocumentsOperationContext context)
             {
-                if (context.LastDatabaseChangeVector == null)
+                if (string.IsNullOrEmpty(context.LastDatabaseChangeVector))
                     context.LastDatabaseChangeVector = DocumentsStorage.GetDatabaseChangeVector(context);
 
                 var status = ChangeVectorUtils.GetConflictStatus(_replicationBatchReply.DatabaseChangeVector,
@@ -437,10 +437,7 @@ namespace Raven.Server.Documents.Replication
                 if (status != ConflictStatus.AlreadyMerged)
                     return 0;
 
-                var str = context.LastDatabaseChangeVector;
-                var res = ChangeVectorUtils.TryUpdateChangeVector(_dbId, _replicationBatchReply.CurrentEtag, ref str);
-                context.LastDatabaseChangeVector = context.GetLazyString(str);
-                return res ? 1 : 0;
+                return ChangeVectorUtils.TryUpdateChangeVector(_database.ServerStore.NodeTag, _dbId, _replicationBatchReply.CurrentEtag, ref context.LastDatabaseChangeVector) ? 1 : 0;
             }
         }
         

--- a/src/Raven.Server/Documents/Replication/ResolveConflictOnReplicationConfigurationChange.cs
+++ b/src/Raven.Server/Documents/Replication/ResolveConflictOnReplicationConfigurationChange.cs
@@ -241,7 +241,7 @@ namespace Raven.Server.Documents.Replication
             if (resolved == null || duplicateResolverEtagAt == maxEtag)
                 return false;
 
-            resolved.ChangeVector = context.GetLazyString(ChangeVectorUtils.MergeVectors(conflicts.Select(c => c.ChangeVector).ToList()));
+            resolved.ChangeVector = ChangeVectorUtils.MergeVectors(conflicts.Select(c => c.ChangeVector).ToList());
             return true;
         }
 
@@ -356,7 +356,7 @@ namespace Raven.Server.Documents.Replication
 
             updatedConflict.Doc = resolved;
             updatedConflict.Collection = collection;
-            updatedConflict.ChangeVector = context.GetLazyString(ChangeVectorUtils.MergeVectors(conflicts.Select(c => c.ChangeVector).ToList()));
+            updatedConflict.ChangeVector = ChangeVectorUtils.MergeVectors(conflicts.Select(c => c.ChangeVector).ToList());
 
             resolvedConflict = updatedConflict;
 
@@ -381,7 +381,7 @@ namespace Raven.Server.Documents.Replication
                 }
             }
 
-            latestDoc.ChangeVector = context.GetLazyString(ChangeVectorUtils.MergeVectors(conflicts.Select(c => c.ChangeVector).ToList()));
+            latestDoc.ChangeVector = ChangeVectorUtils.MergeVectors(conflicts.Select(c => c.ChangeVector).ToList());
 
             return latestDoc;
         }

--- a/src/Raven.Server/Documents/TcpHandlers/SubscriptionConnection.cs
+++ b/src/Raven.Server/Documents/TcpHandlers/SubscriptionConnection.cs
@@ -382,9 +382,9 @@ namespace Raven.Server.Documents.TcpHandlers
                             foreach (var result in fetcher.GetDataToSend(docsContext, subscription, patch, startEtag))
                             {
                                 startEtag = result.Doc.Etag;
-                                lastChangeVector = subscription.ChangeVector == null ? 
-                                    result.Doc.ChangeVector : 
-                                    context.GetLazyString(ChangeVectorUtils.MergeVectors(result.Doc.ChangeVector, context.GetLazyString(subscription.ChangeVector)));
+                                lastChangeVector = string.IsNullOrEmpty(subscription.ChangeVector) ? 
+                                    result.Doc.ChangeVector :
+                                    ChangeVectorUtils.MergeVectors(result.Doc.ChangeVector, subscription.ChangeVector);
                                 
                                 if (result.Doc.Data == null)
                                 {
@@ -534,7 +534,7 @@ namespace Raven.Server.Documents.TcpHandlers
                     return startEtag;
                 }
 
-                if (subscription.ChangeVector == null || subscription.ChangeVector.Length == 0)
+                if (string.IsNullOrEmpty(subscription.ChangeVector))
                 {
                     return startEtag;
                 }

--- a/src/Raven.Server/Documents/TransactionOperationsMerger.cs
+++ b/src/Raven.Server/Documents/TransactionOperationsMerger.cs
@@ -288,7 +288,7 @@ namespace Raven.Server.Documents
 
         private static void UpdateGlobalReplicationInfoBeforeCommit(DocumentsOperationContext context)
         {
-            if (context.LastDatabaseChangeVector != null)
+            if (string.IsNullOrEmpty(context.LastDatabaseChangeVector) == false)
             {
                 context.DocumentDatabase.DocumentsStorage.SetDatabaseChangeVector(context, context.LastDatabaseChangeVector);
             }

--- a/src/Sparrow/Utils/Base64.cs
+++ b/src/Sparrow/Utils/Base64.cs
@@ -77,5 +77,47 @@ namespace Sparrow.Utils
 
             return j;
         }
+
+        public static unsafe int ConvertToBase64ArrayUnpadded(char* outChars, byte* inData, int offset, int length)
+        {
+            int lengthmod3 = length % 3;
+            int calcLength = offset + (length - lengthmod3);
+            int j = 0;
+            //Convert three bytes at a time to base64 notation.  This will consume 4 chars.
+            int i;
+
+            // get a pointer to the base64Table to avoid unnecessary range checking
+            fixed (char* base64 = &base64Table[0])
+            {
+                for (i = offset; i < calcLength; i += 3)
+                {
+                    outChars[j] = base64[(inData[i] & 0xfc) >> 2];
+                    outChars[j + 1] = base64[((inData[i] & 0x03) << 4) | ((inData[i + 1] & 0xf0) >> 4)];
+                    outChars[j + 2] = base64[((inData[i + 1] & 0x0f) << 2) | ((inData[i + 2] & 0xc0) >> 6)];
+                    outChars[j + 3] = base64[(inData[i + 2] & 0x3f)];
+                    j += 4;
+                }
+
+                //Where we left off before
+                i = calcLength;
+
+                switch (lengthmod3)
+                {
+                    case 2: //One character padding needed
+                        outChars[j] = base64[(inData[i] & 0xfc) >> 2];
+                        outChars[j + 1] = base64[((inData[i] & 0x03) << 4) | ((inData[i + 1] & 0xf0) >> 4)];
+                        outChars[j + 2] = base64[(inData[i + 1] & 0x0f) << 2];
+                        j += 3;
+                        break;
+                    case 1: // Two character padding needed
+                        outChars[j] = base64[(inData[i] & 0xfc) >> 2];
+                        outChars[j + 1] = base64[(inData[i] & 0x03) << 4];
+                        j += 2;
+                        break;
+                }
+            }
+
+            return j;
+        }
     }
 }

--- a/test/FastTests/Server/Documents/DocumentsCrud.cs
+++ b/test/FastTests/Server/Documents/DocumentsCrud.cs
@@ -488,8 +488,7 @@ namespace FastTests.Server.Documents
                 }, "users/1", BlittableJsonDocumentBuilder.UsageMode.ToDisk))
                 {
                     _documentDatabase.DocumentsStorage.Put(ctx, "users/1", null, doc);
-                    var changeVector = ctx.GetLazyString("");
-                    Assert.Throws<ConcurrencyException>(() => _documentDatabase.DocumentsStorage.Put(ctx, "users/1", changeVector, doc));
+                    Assert.Throws<ConcurrencyException>(() => _documentDatabase.DocumentsStorage.Put(ctx, "users/1", "A:1-abc", doc));
                 }
 
                 ctx.Transaction.Commit();


### PR DESCRIPTION
- clean up the code.
- remove using change vector as LazyStringValue and replace it a simple string.
- optimizing update & merge of change vectors.