### PR TITLE
RavenDB-7412 Fixing synchronization of a file deletion when the file …

### DIFF
--- a/Raven.Database/FileSystem/Controllers/SearchController.cs
+++ b/Raven.Database/FileSystem/Controllers/SearchController.cs
@@ -136,7 +136,8 @@ namespace Raven.Database.FileSystem.Controllers
                     var metadata = file.Metadata;
                     if (metadata == null || metadata.Keys.Contains(SynchronizationConstants.RavenDeleteMarker))
                         continue;
-
+                    
+                    Historian.Update(fileName, metadata);
                     Files.IndicateFileToDelete(fileName, null);
 
                     // don't create a tombstone for .downloading file


### PR DESCRIPTION
…was deleted by a query - we need to update file history before we delete it to make sure it won't be filtered out by the synchronization task