### PR TITLE
RavenDB-7976 change target runtime for windows build from win10-x** to win7-x**

### DIFF
--- a/scripts/target.ps1
+++ b/scripts/target.ps1
@@ -1,14 +1,14 @@
 $TARGET_SPECS = (
     @{
         "Name"      = "windows-x64";
-        "Runtime"   = "win10-x64";
+        "Runtime"   = "win7-x64";
         "PkgType"   = "zip";
         "IsUnix"    = $False;
         "TargetId" = "win-x64";
     },
     @{
         "Name"      = "windows-x86";
-        "Runtime"   = "win10-x86";
+        "Runtime"   = "win7-x86";
         "Arch"      = "x86";
         "PkgType"   = "zip";
         "IsUnix"    = $False;


### PR DESCRIPTION
By the recommendation from dotnet/corefx#22915