### PR TITLE
RavenDB-8031

### DIFF
--- a/src/Raven.Client/Http/RequestExecutor.cs
+++ b/src/Raven.Client/Http/RequestExecutor.cs
@@ -242,6 +242,9 @@ namespace Raven.Client.Http
 
                     await ExecuteAsync(node, null, context, command, shouldRetry: false).ConfigureAwait(false);
 
+                    if (command.Result.Etag == -1)
+                        throw new InvalidOperationException($"Uninitialized topology ({nameof(Topology.Etag)}: -1)");
+
                     var serverHash = ServerHash.GetServerHash(node.Url, _databaseName);
 
                     TopologyLocalCache.TrySavingTopologyToLocalCache(serverHash, command.Result, context);

--- a/src/Raven.Server/ServerWide/Maintenance/ClusterObserver.cs
+++ b/src/Raven.Server/ServerWide/Maintenance/ClusterObserver.cs
@@ -275,6 +275,10 @@ namespace Raven.Server.ServerWide.Maintenance
             }
 
             RemoveOtherNodesIfNeeded(dbName, topology, ref deletions);
+
+            if (topology.Stamp.Index == -1)
+                return true;
+
             return false;
         }
 

--- a/test/SlowTests/Issues/RavenDB_8031.cs
+++ b/test/SlowTests/Issues/RavenDB_8031.cs
@@ -1,0 +1,59 @@
+﻿using System;
+using System.Threading;
+using System.Threading.Tasks;
+using FastTests;
+using Raven.Client.Documents;
+using Raven.Client.Documents.Operations;
+using Raven.Client.Server;
+using Raven.Client.Server.Operations;
+using Xunit;
+
+namespace SlowTests.Issues
+{
+    public class RavenDB_8031 : RavenTestBase
+    {
+        [Fact]
+        public async Task Can_talk_to_db_if_it_was_created_after_document_store_initialization()
+        {
+            using (var store = GetDocumentStore())
+            {
+                var dbName = store.Database + Guid.NewGuid();
+
+                using (var store2 = new DocumentStore()
+                {
+                    Urls = store.Urls,
+                    Database = dbName
+                }.Initialize())
+                {
+                    Assert.Throws<InvalidOperationException>(() => store2.Admin.Send(new GetStatisticsOperation()));
+
+                    store.Admin.Server.Send(new CreateDatabaseOperation(new DatabaseRecord(dbName)));
+
+                    try
+                    {
+                        for (int i = 0; i < 20; i++)
+                        {
+                            await Task.Delay(500);
+
+                            try
+                            {
+                                await store2.Admin.SendAsync(new GetStatisticsOperation());
+
+                                return;
+                            }
+                            catch (Exception)
+                            {
+                            }
+                        }
+
+                        Assert.True(false, "All attempts to get stats failed");
+                    }
+                    finally
+                    {
+                        store.Admin.Server.Send(new DeleteDatabaseOperation(dbName, hardDelete: true));
+                    }
+                }
+            }
+        }
+    }
+}


### PR DESCRIPTION
- throwing exception if the client gets topology with etag == -1
- make sure we call UpdateTopologyCommand if the db topology Stamp.Index is -1 (first time)