### PR TITLE
RavenDB-8047 Stuck in election state

### DIFF
--- a/src/Raven.Server/Rachis/Elector.cs
+++ b/src/Raven.Server/Rachis/Elector.cs
@@ -183,9 +183,6 @@ namespace Raven.Server.Rachis
                         }
                         else
                         {
-                            _engine.SetNewState(RachisConsensus.State.Follower, this, rv.Term,
-                                $"I\'ve given my vote to {_connection.Source} in term {rv.Term} and therefor became follower");
-
                             _connection.Send(context, new RequestVoteResponse
                             {
                                 Term = _engine.CurrentTerm,


### PR DESCRIPTION
Switching to follower from the elctor has 2 flaws in this case:
1. We don't know if the one who we voted for is elected to leader.
2. We moved to follower state without timeout.