### PR TITLE
RavenDB-7383 implement

### DIFF
--- a/src/Raven.Client/ServerWide/Commands/GetRawStreamResultCommand.cs
+++ b/src/Raven.Client/ServerWide/Commands/GetRawStreamResultCommand.cs
@@ -51,10 +51,8 @@ namespace Raven.Client.ServerWide.Commands
 
         public override void SetResponseRaw(HttpResponseMessage response, Stream stream, JsonOperationContext context)
         {
-            var outputStream = new MemoryStream();
-            stream.CopyTo(outputStream);
-
-            Result = outputStream;
+            Result = new MemoryStream();
+            stream.CopyTo(Result);
         }
 
         public void Dispose()
@@ -63,6 +61,8 @@ namespace Raven.Client.ServerWide.Commands
             {
                 _headerStream?.Dispose();
             }
+
+            Result.Dispose();
         }
     }
 }

--- a/src/Raven.Server/Documents/Handlers/Debugging/DatabaseDebugInfoPackageHandler.cs
+++ b/src/Raven.Server/Documents/Handlers/Debugging/DatabaseDebugInfoPackageHandler.cs
@@ -16,7 +16,7 @@ namespace Raven.Server.Documents.Handlers.Debugging
         [RavenAction("/databases/*/debug/info-package", "GET", AuthorizationStatus.ValidUser, IsDebugInformationEndpoint = true)]
         public async Task GetInfoPackage()
         {
-            var contentDisposition = $"attachment; filename=debug-info of {Database.Name} {DateTime.UtcNow}.zip";
+            var contentDisposition = $"attachment; filename={DateTime.UtcNow:yyyy-MM-dd H:mm:ss}.zip";
             HttpContext.Response.Headers["Content-Disposition"] = contentDisposition;
             using (ServerStore.ContextPool.AllocateOperationContext(out JsonOperationContext context))
             {


### PR DESCRIPTION
* change file names of debug-info packages to more intuitive
* for cluster-wide, make local data also a zip file
* for cluster-wide, make sure that data from remote nodes is not an empty zip file
(RavenDB-7383)