### PR TITLE
RavenDB-6589 Raft: Need to handle the case where a node was removed f…

### DIFF
--- a/src/Raven.Server/Documents/DocumentDatabase.cs
+++ b/src/Raven.Server/Documents/DocumentDatabase.cs
@@ -715,7 +715,8 @@ namespace Raven.Server.Documents
                 Debug.Assert(string.Equals(Name, record.DatabaseName, StringComparison.OrdinalIgnoreCase),
                     $"{Name} != {record.DatabaseName}");
 
-                if (LastDatabaseRecordIndex >= index)
+                // index and LastDatabaseRecordIndex could have equal values when we transit from/to passive and want to update the tasks. 
+                if (LastDatabaseRecordIndex > index)
                 {
                     if (_logger.IsInfoEnabled)
                         _logger.Info($"Skipping record {index} (current {RachisLogIndexNotifications.LastModifiedIndex}) for {record.DatabaseName} because it was already precessed.");
@@ -725,7 +726,7 @@ namespace Raven.Server.Documents
                 if (_logger.IsInfoEnabled)
                     _logger.Info($"Starting to process record {index} (current {RachisLogIndexNotifications.LastModifiedIndex}) for {record.DatabaseName}.");
 
-                Debug.Assert(index > RachisLogIndexNotifications.LastModifiedIndex, "Should never happen");
+                Debug.Assert(index >= RachisLogIndexNotifications.LastModifiedIndex, $"Should never happen");
 
                 try
                 {

--- a/src/Raven.Server/Documents/Handlers/Admin/RachisAdminHandler.cs
+++ b/src/Raven.Server/Documents/Handlers/Admin/RachisAdminHandler.cs
@@ -290,7 +290,7 @@ namespace Raven.Server.Documents.Handlers.Admin
                             $"Adding a new node to cluster failed. The new node is already in another cluster. Expected topology id: {topologyId}, but we get {nodeInfo.TopologyId}");
                     }
 
-                    var nodeTag = nodeInfo.NodeTag == "?" 
+                    var nodeTag = nodeInfo.NodeTag == RachisConsensus.InitialTag
                         ? null : nodeInfo.NodeTag;
 
                     if (remoteIsHttps)

--- a/src/Raven.Server/Documents/Replication/ReplicationLoader.cs
+++ b/src/Raven.Server/Documents/Replication/ReplicationLoader.cs
@@ -366,6 +366,7 @@ namespace Raven.Server.Documents.Replication
                 _internalDestinations.Clear();
                 _externalDestinations.Clear();
                 _destinations.Clear();
+                DisposeConnections(instancesToDispose);
                 return;
             }
 
@@ -376,6 +377,11 @@ namespace Raven.Server.Documents.Replication
             destinations.AddRange(_externalDestinations);
             _destinations = destinations;
 
+            DisposeConnections(instancesToDispose);
+        }
+
+        private void DisposeConnections(List<OutgoingReplicationHandler> instancesToDispose)
+        {
             foreach (var instance in instancesToDispose)
             {
                 try

--- a/src/Raven.Server/Utils/ChangeVectorUtils.cs
+++ b/src/Raven.Server/Utils/ChangeVectorUtils.cs
@@ -22,6 +22,9 @@ namespace Raven.Server.Utils
             if (remoteAsString == localAsString)
                 return ConflictStatus.AlreadyMerged;
 
+            if(string.IsNullOrEmpty(remoteAsString))
+                return ConflictStatus.AlreadyMerged;
+
             if (string.IsNullOrEmpty(remoteAsString) || string.IsNullOrEmpty(localAsString))
                 return ConflictStatus.Update;
 


### PR DESCRIPTION
…rom raft cluster

- Even if node distribution is off, we move bad nodes to rehab and try to recover them.
- Allow refresh the database record features for the last index. Needed if we transit to/from passive.
- Dispose replication connection to to all nodes if we are in passive state.