### PR TITLE
RavenDB-7911 Promoting of a rehab member

### DIFF
--- a/src/Raven.Server/ServerWide/Maintenance/ClusterMaintenanceWorker.cs
+++ b/src/Raven.Server/ServerWide/Maintenance/ClusterMaintenanceWorker.cs
@@ -138,6 +138,7 @@ namespace Raven.Server.ServerWide.Maintenance
                         report.LastEtag = DocumentsStorage.ReadLastEtag(tx.InnerTransaction);
                         report.LastTombstoneEtag = DocumentsStorage.ReadLastTombstoneEtag(tx.InnerTransaction);
                         report.NumberOfConflicts = documentsStorage.ConflictsStorage.ConflictsCount;
+                        report.NumberOfDocuments = documentsStorage.GetNumberOfDocuments(context);
                         report.LastChangeVector = DocumentsStorage.GetDatabaseChangeVector(context);
 
                         if (indexStorage != null)

--- a/src/Raven.Server/ServerWide/Maintenance/ClusterNodeStatusReport.cs
+++ b/src/Raven.Server/ServerWide/Maintenance/ClusterNodeStatusReport.cs
@@ -33,6 +33,7 @@ namespace Raven.Server.ServerWide.Maintenance
         public long LastEtag;
         public long LastTombstoneEtag;
         public long NumberOfConflicts;
+        public long NumberOfDocuments;
 
         public DatabaseStatus Status;
         public string Error;
@@ -47,6 +48,7 @@ namespace Raven.Server.ServerWide.Maintenance
                 [nameof(LastEtag)] = LastEtag,
                 [nameof(LastTombstoneEtag)] = LastTombstoneEtag,
                 [nameof(NumberOfConflicts)] = NumberOfConflicts,
+                [nameof(NumberOfDocuments)] = NumberOfDocuments,
                 [nameof(LastChangeVector)] = LastChangeVector,
                 [nameof(Error)] = Error
             };

--- a/src/Raven.Server/Utils/ChangeVectorUtils.cs
+++ b/src/Raven.Server/Utils/ChangeVectorUtils.cs
@@ -110,14 +110,14 @@ namespace Raven.Server.Utils
             } while (etag != 0);
             }
             
-        private static long ParseToLong(string s, int count, int len)
+        private static long ParseToLong(string s, int start, int len)
             {
             int num;
-            num = s[count] - '0';
+            num = s[start] - '0';
             for (int i = 1; i < len; i++)
             {
                 num *= 10;
-                num += s[count+i] - '0';
+                num += s[start+i] - '0';
         }
             return num;
         }
@@ -234,7 +234,6 @@ namespace Raven.Server.Utils
             
             return _mergeVectorBuffer.SerializeVector();
         }
-
 
         public static unsafe string NewChangeVector(string nodeTag, long etag, Guid dbId)
         {


### PR DESCRIPTION
We select the most up-to-date node by the change vector, but if there is a conflict we pick the one with the most documents on it.