### PR TITLE
unit test to verify that ChangesAPI works with whitespaces in database name

### DIFF
--- a/test/SlowTests/Server/Documents/Notifications/ChangesTests.cs
+++ b/test/SlowTests/Server/Documents/Notifications/ChangesTests.cs
@@ -1,19 +1,85 @@
 using System;
 using System.Collections.Concurrent;
+using System.Diagnostics;
 using System.Linq;
+using System.Net.Http;
 using System.Threading;
 using System.Threading.Tasks;
 using FastTests;
+using Org.BouncyCastle.Asn1.Cms;
+using Raven.Client.Documents;
 using Raven.Client.Documents.Changes;
+using Raven.Client.Documents.Conventions;
 using Raven.Client.Documents.Indexes;
 using Raven.Client.Documents.Operations;
+using Raven.Client.Documents.Session;
+using Raven.Client.Http;
+using Raven.Client.Json;
+using Raven.Client.Json.Converters;
+using Raven.Client.ServerWide;
+using Raven.Client.ServerWide.Operations;
+using Raven.Server.Config;
 using Raven.Tests.Core.Utils.Entities;
+using RavenDB_8118;
+using Sparrow.Json;
 using Xunit;
 
 namespace SlowTests.Server.Documents.Notifications
 {
     public class ChangesTests : RavenTestBase
     {
+        [Fact]
+        public async Task ChangesAPIWithDatabaseNameThatHasWhitespace()
+        {
+            var name = "Foo Bar";
+            var doc = new DatabaseRecord(name)
+            {
+                Settings =
+                {
+                    [RavenConfiguration.GetKey(x => x.Replication.ReplicationMinimalHeartbeat)] = "1",
+                    [RavenConfiguration.GetKey(x => x.Core.RunInMemory)] = false.ToString(),
+                    [RavenConfiguration.GetKey(x => x.Core.DataDirectory)] = NewDataPath(name),
+                    [RavenConfiguration.GetKey(x => x.Core.ThrowIfAnyIndexOrTransformerCouldNotBeOpened)] = "true",
+                    [RavenConfiguration.GetKey(x => x.Indexing.MinNumberOfMapAttemptsAfterWhichBatchWillBeCanceledIfRunningLowOnMemory)] = int.MaxValue.ToString()
+                }
+            };
+
+            using (var server = GetNewServer())
+            using (var store = new DocumentStore
+            {
+                Urls = UseFiddler(server.WebUrls),
+                Database = name,
+                Certificate = null
+            }.Initialize())
+            {
+                var result = store.Admin.Server.Send(new CreateDatabaseOperationWithoutNameValidation(doc));
+                var timeout = TimeSpan.FromMinutes(Debugger.IsAttached ? 5 : 1);
+                await WaitForRaftIndexToBeAppliedInCluster(result.RaftCommandIndex, timeout);
+
+                var list = new BlockingCollection<DocumentChange>();
+                var taskObservable = store.Changes();
+                await taskObservable.EnsureConnectedNow();
+                var observableWithTask = taskObservable.ForDocument("users/1");
+
+                observableWithTask.Subscribe(list.Add);
+                await observableWithTask.EnsureSubscribedNow();
+
+                using (var session = store.OpenAsyncSession())
+                {
+                    await session.StoreAsync(new User(), "users/1");
+                    await session.SaveChangesAsync();
+                }
+
+                DocumentChange documentChange;
+                Assert.True(list.TryTake(out documentChange, TimeSpan.FromSeconds(1)));
+
+                Assert.Equal("users/1", documentChange.Id);
+                Assert.Equal(documentChange.Type, DocumentChangeTypes.Put);
+                Assert.NotNull(documentChange.ChangeVector);
+            }
+
+        }
+
         [Fact]
         public async Task CanGetNotificationAboutDocumentPut()
         {
@@ -218,6 +284,71 @@ namespace SlowTests.Server.Documents.Notifications
                     select new { user.Name, user.LastName, user.Age, user.AddressId, user.Id };
 
 
+            }
+        }
+
+        public class CreateDatabaseOperationWithoutNameValidation : IServerOperation<DatabasePutResult>
+        {
+            private readonly DatabaseRecord _databaseRecord;
+            private readonly int _replicationFactor;
+
+            public CreateDatabaseOperationWithoutNameValidation(DatabaseRecord databaseRecord, int replicationFactor = 1)
+            {
+                _databaseRecord = databaseRecord;
+                _replicationFactor = replicationFactor;
+            }
+
+            public RavenCommand<DatabasePutResult> GetCommand(DocumentConventions conventions, JsonOperationContext context)
+            {
+                return new CreateDatabaseCommand(conventions, context, _databaseRecord, this);
+            }
+
+            private class CreateDatabaseCommand : RavenCommand<DatabasePutResult>
+            {
+                private readonly JsonOperationContext _context;
+                private readonly CreateDatabaseOperationWithoutNameValidation _createDatabaseOperation;
+                private readonly BlittableJsonReaderObject _databaseDocument;
+                private readonly string _databaseName;
+
+                public CreateDatabaseCommand(DocumentConventions conventions, JsonOperationContext context, DatabaseRecord databaseRecord,
+                    CreateDatabaseOperationWithoutNameValidation createDatabaseOperation)
+                {
+                    if (conventions == null)
+                        throw new ArgumentNullException(nameof(conventions));
+
+                    _context = context ?? throw new ArgumentNullException(nameof(context));
+                    _createDatabaseOperation = createDatabaseOperation;
+                    _databaseName = databaseRecord?.DatabaseName ?? throw new ArgumentNullException(nameof(databaseRecord));
+                    _databaseDocument = EntityToBlittable.ConvertEntityToBlittable(databaseRecord, conventions, context);
+                }
+
+                public override HttpRequestMessage CreateRequest(ServerNode node, out string url)
+                {
+                    url = $"{node.Url}/admin/databases?name={_databaseName}";
+
+                    url += "&replication-factor=" + _createDatabaseOperation._replicationFactor;
+
+                    var request = new HttpRequestMessage
+                    {
+                        Method = HttpMethod.Put,
+                        Content = new BlittableJsonContent(stream =>
+                        {
+                            _context.Write(stream, _databaseDocument);
+                        })
+                    };
+
+                    return request;
+                }
+
+                public override void SetResponse(BlittableJsonReaderObject response, bool fromCache)
+                {
+                    if (response == null)
+                        ThrowInvalidResponse();
+
+                    Result = JsonDeserializationClient.DatabasePutResult(response);
+                }
+
+                public override bool IsReadRequest => false;
             }
         }
     }


### PR DESCRIPTION
whitespaces in database names are invalid and shouldn't happen, but in case they _do_ happen