### PR TITLE
Fixed potential issue with double checked locking pattern

### DIFF
--- a/Raven.Client.Lightweight/Document/MultiTypeHiLoKeyGenerator.cs
+++ b/Raven.Client.Lightweight/Document/MultiTypeHiLoKeyGenerator.cs
@@ -15,7 +15,7 @@ namespace Raven.Client.Document
     {
         private readonly int capacity;
         private readonly object generatorLock = new object();
-        private IDictionary<string, HiLoKeyGenerator> keyGeneratorsByTag = new Dictionary<string, HiLoKeyGenerator>();
+        private volatile IDictionary<string, HiLoKeyGenerator> keyGeneratorsByTag = new Dictionary<string, HiLoKeyGenerator>();
 
 
         /// <summary>


### PR DESCRIPTION
On ARM and any other hardware with less strict memory model than on x86, double checked locking pattern requires volatile write.