### PR TITLE
RavenDB-8226

### DIFF
--- a/src/Raven.Client/Constants.cs
+++ b/src/Raven.Client/Constants.cs
@@ -159,7 +159,7 @@ namespace Raven.Client
                     
                     public const string CustomSortFieldName = "__customSort";
 
-                    public const string DocumentIdFieldName = "__document_id";
+                    public const string DocumentIdFieldName = "id()";
 
                     public const string ReduceKeyFieldName = "__reduce_key";
 

--- a/src/Raven.Server/Documents/Indexes/Static/CurrentIndexingScope.cs
+++ b/src/Raven.Server/Documents/Indexes/Static/CurrentIndexingScope.cs
@@ -25,7 +25,7 @@ namespace Raven.Server.Documents.Indexes.Static
         [ThreadStatic]
         public static CurrentIndexingScope Current;
 
-        public dynamic Source;
+        public DynamicBlittableJson Source;
 
         public string SourceCollection;
 
@@ -60,7 +60,7 @@ namespace Raven.Server.Documents.Indexes.Static
                 if (source == null)
                     throw new ArgumentException("Cannot execute LoadDocument. Source is not set.");
 
-                var id = source.__document_id as LazyStringValue;
+                var id = source.GetId() as LazyStringValue;
                 if (id == null)
                     throw new ArgumentException("Cannot execute LoadDocument. Source does not have a key.");
 

--- a/src/Raven.Server/Documents/Indexes/Static/DynamicBlittableJson.cs
+++ b/src/Raven.Server/Documents/Indexes/Static/DynamicBlittableJson.cs
@@ -63,6 +63,14 @@ namespace Raven.Server.Documents.Indexes.Static
             BlittableJson = document.Data;
         }
 
+        public dynamic GetId()
+        {
+            if (_doc == null)
+                return DynamicNullObject.Null;
+
+            return _doc.Id;
+        }
+
         public bool ContainsKey(string key)
         {
             return BlittableJson.GetPropertyNames().Contains(key);

--- a/src/Raven.Server/Documents/Indexes/Static/StaticIndexBase.cs
+++ b/src/Raven.Server/Documents/Indexes/Static/StaticIndexBase.cs
@@ -57,6 +57,12 @@ namespace Raven.Server.Documents.Indexes.Static
             set.Add(referencedCollectionName);
         }
 
+        public dynamic Id(dynamic doc)
+        {
+            var json = (DynamicBlittableJson)doc;
+            return json.GetId();
+        }
+
         public IEnumerable<dynamic> Recurse(object item, Func<dynamic, dynamic> func)
         {
             return new RecursiveFunction(item, func).Execute();

--- a/src/Raven.Server/Documents/Queries/CollectionQueryEnumerable.cs
+++ b/src/Raven.Server/Documents/Queries/CollectionQueryEnumerable.cs
@@ -342,7 +342,27 @@ namespace Raven.Server.Documents.Queries
 
                 public override void VisitMethodTokens(QueryExpression expression, BlittableJsonReaderObject parameters)
                 {
-                    throw new NotSupportedException();
+                    expression = (QueryExpression)expression.Arguments[expression.Arguments.Count - 1];
+
+                    switch (expression.Type)
+                    {
+                        case OperatorType.Equal:
+                        case OperatorType.LessThan:
+                        case OperatorType.GreaterThan:
+                        case OperatorType.LessThanEqual:
+                        case OperatorType.GreaterThanEqual:
+                            VisitFieldToken(Constants.Documents.Indexing.Fields.DocumentIdFieldName, expression.Value, parameters);
+                            break;
+                        case OperatorType.Between:
+                            VisitFieldTokens(Constants.Documents.Indexing.Fields.DocumentIdFieldName, expression.First, expression.Second, parameters);
+                            break;
+                        case OperatorType.In:
+                        case OperatorType.AllIn:
+                            VisitFieldTokens(Constants.Documents.Indexing.Fields.DocumentIdFieldName, expression.Values, parameters);
+                            break;
+                        default:
+                            throw new ArgumentOutOfRangeException();
+                    }
                 }
 
                 private void AddId(string id)

--- a/src/Raven.Server/Documents/Queries/FieldsToFetch.cs
+++ b/src/Raven.Server/Documents/Queries/FieldsToFetch.cs
@@ -101,8 +101,7 @@ namespace Raven.Server.Documents.Queries
             {
                 return new FieldToFetch(selectFieldName, selectField, selectField.Alias, canExtractFromIndex: false, isDocumentId: false);
             }
-            if (selectFieldName.Length > 0 && 
-                selectFieldName[0] == '_')
+            if (selectFieldName.Length > 0)
             {
                 if (selectFieldName == Constants.Documents.Indexing.Fields.DocumentIdFieldName)
                 {
@@ -110,26 +109,29 @@ namespace Raven.Server.Documents.Queries
                     return new FieldToFetch(selectFieldName, selectField, selectField.Alias, canExtractFromIndex: false, isDocumentId: true);
                 }
 
-                if (selectFieldName == Constants.Documents.Indexing.Fields.AllStoredFields)
+                if (selectFieldName[0] == '_')
                 {
-                    if (results == null)
-                        ThrowInvalidFetchAllStoredDocuments();
-                    Debug.Assert(results != null);
-                    results.Clear(); // __all_stored_fields should only return stored fields so we are ensuring that no other fields will be returned
-
-                    extractAllStoredFields = true;
-
-                    foreach (var kvp in indexDefinition.MapFields)
+                    if (selectFieldName == Constants.Documents.Indexing.Fields.AllStoredFields)
                     {
-                        var stored = kvp.Value.Storage == FieldStorage.Yes;
-                        if (stored == false)
-                            continue;
+                        if (results == null)
+                            ThrowInvalidFetchAllStoredDocuments();
+                        Debug.Assert(results != null);
+                        results.Clear(); // __all_stored_fields should only return stored fields so we are ensuring that no other fields will be returned
 
-                        anyExtractableFromIndex = true;
-                        results[kvp.Key] = new FieldToFetch(kvp.Key, null, null, canExtractFromIndex: true, isDocumentId: false);
+                        extractAllStoredFields = true;
+
+                        foreach (var kvp in indexDefinition.MapFields)
+                        {
+                            var stored = kvp.Value.Storage == FieldStorage.Yes;
+                            if (stored == false)
+                                continue;
+
+                            anyExtractableFromIndex = true;
+                            results[kvp.Key] = new FieldToFetch(kvp.Key, null, null, canExtractFromIndex: true, isDocumentId: false);
+                        }
+
+                        return null;
                     }
-
-                    return null;
                 }
             }
 

--- a/src/Raven.Server/Documents/Queries/MethodType.cs
+++ b/src/Raven.Server/Documents/Queries/MethodType.cs
@@ -2,6 +2,7 @@
 {
     public enum MethodType
     {
+        Id,
         Search,
         Boost,
         StartsWith,

--- a/src/Raven.Server/Documents/Queries/QueryMethod.cs
+++ b/src/Raven.Server/Documents/Queries/QueryMethod.cs
@@ -8,6 +8,9 @@ namespace Raven.Server.Documents.Queries
     {
         public static MethodType GetMethodType(string methodName)
         {
+            if (string.Equals(methodName, "id", StringComparison.OrdinalIgnoreCase))
+                return MethodType.Id;
+
             if (string.Equals(methodName, "search", StringComparison.OrdinalIgnoreCase))
                 return MethodType.Search;
 

--- a/src/Raven.Server/Documents/Queries/Results/QueryResultRetrieverBase.cs
+++ b/src/Raven.Server/Documents/Queries/Results/QueryResultRetrieverBase.cs
@@ -71,7 +71,7 @@ namespace Raven.Server.Documents.Queries.Results
             var result = new DynamicJsonValue();
 
             if (FieldsToFetch.IsDistinct == false && string.IsNullOrEmpty(id) == false)
-                result[Constants.Documents.Indexing.Fields.DocumentIdFieldName] = id;
+                result[Constants.Documents.Metadata.Id] = id;
 
             Dictionary<string, FieldsToFetch.FieldToFetch> fields = null;
             if (FieldsToFetch.ExtractAllFromIndex)
@@ -159,7 +159,7 @@ namespace Raven.Server.Documents.Queries.Results
             }
 
             if (fieldsToFetch.IsDistinct == false && doc.Id != null)
-                result[Constants.Documents.Indexing.Fields.DocumentIdFieldName] = doc.Id;
+                result[Constants.Documents.Metadata.Id] = doc.Id;
 
             return ReturnProjection(result, doc, score, context);
         }

--- a/src/Raven.Server/Documents/Queries/SelectField.cs
+++ b/src/Raven.Server/Documents/Queries/SelectField.cs
@@ -35,11 +35,12 @@ namespace Raven.Server.Documents.Queries
             
         }
 
-        public static SelectField Create(string name)
+        public static SelectField Create(string name, string alias = null)
         {
             return new SelectField
             {
-                Name = name
+                Name = name,
+                Alias = alias
             };
         }
 

--- a/test/FastTests/Client/Lazy/Async/lazyAsync.cs
+++ b/test/FastTests/Client/Lazy/Async/lazyAsync.cs
@@ -168,7 +168,7 @@ namespace FastTests.Client.Lazy.Async
                     session.Advanced.AsyncDocumentQuery<ContactDto>()
                         .RawQuery(@"
 from Contacts as contact
-where contact.__document_id = $id
+where id(contact) = $id
 load contact.DetailIds as details[]
 select {
     ContactId: id(contact),
@@ -247,7 +247,7 @@ select {
                         .RawQuery(@"
 declare function triple(pos) { return pos *3; }
 from Items
-where __document_id in ($ids)
+where id() in ($ids)
 select triple(Position) as Position
 ")
                         .AddParameter("ids", new[] {"items/1", "items/2"})

--- a/test/FastTests/Server/Documents/Indexing/TranslatingLinqQueriesToIndexes.cs
+++ b/test/FastTests/Server/Documents/Indexing/TranslatingLinqQueriesToIndexes.cs
@@ -17,7 +17,7 @@ namespace FastTests.Server.Documents.Indexing
             Expression<Func<IEnumerable<Nestable>, IEnumerable>> map = nests => from nestable in nests
                 select new { nestable.Id };
             var code = IndexDefinitionHelper.PruneToFailureLinqQueryAsStringToWorkableCode<Nestable, Nestable>(map, new DocumentConventions(), "docs", true);
-            Assert.Contains("Id = nestable.__document_id", code);
+            Assert.Contains("Id = Id(nestable)", code);
         }
 
         [Fact]
@@ -38,7 +38,7 @@ namespace FastTests.Server.Documents.Indexing
                 select new { child.Id, Id2 = nestable.Id };
             var code = IndexDefinitionHelper.PruneToFailureLinqQueryAsStringToWorkableCode<Nestable, Nestable>(map, new DocumentConventions(), "docs", true);
             Assert.Contains("Id = child.Id", code);
-            Assert.Contains("Id2 = nestable.__document_id", code);
+            Assert.Contains("Id2 = Id(nestable)", code);
         }
 
         [Fact]

--- a/test/SlowTests/Bugs/Distinct.cs
+++ b/test/SlowTests/Bugs/Distinct.cs
@@ -1,6 +1,7 @@
 using System.Collections.Generic;
 using System.Linq;
 using FastTests;
+using Raven.Client;
 using Raven.Client.Documents.Indexes;
 using Raven.Client.Documents.Operations.Indexes;
 using Raven.Client.Documents.Session;
@@ -174,7 +175,7 @@ namespace SlowTests.Bugs
                         .Distinct()
                         .SelectFields<Customer>("CustomerId")
                         .Take(20)
-                        .Include("__document_id")
+                        .Include(Constants.Documents.Indexing.Fields.DocumentIdFieldName)
                         .ToList();
                     var cust = session.Load<Customer>("Customers/2");
                     Assert.Equal(1, session.Advanced.NumberOfRequests);

--- a/test/SlowTests/Bugs/Queries/Fetching.cs
+++ b/test/SlowTests/Bugs/Queries/Fetching.cs
@@ -2,6 +2,7 @@ using FastTests;
 using Newtonsoft.Json;
 using System.Linq;
 using Newtonsoft.Json.Linq;
+using Raven.Client;
 using Xunit;
 
 namespace SlowTests.Bugs.Queries
@@ -36,7 +37,7 @@ namespace SlowTests.Bugs.Queries
                     var objects = s.Advanced.DocumentQuery<dynamic>()
                         .WaitForNonStaleResults()
                         .SelectFields<JObject>("Tags[].Id", "Tags[].Id3")
-                        .OrderBy("__document_id")
+                        .OrderBy(Constants.Documents.Indexing.Fields.DocumentIdFieldName)
                         .ToArray();
                     Assert.Equal(3, objects.Length);
 

--- a/test/SlowTests/MailingList/Alexander.cs
+++ b/test/SlowTests/MailingList/Alexander.cs
@@ -22,7 +22,7 @@ namespace SlowTests.MailingList
                 {
                     Maps = { @"
 docs.Casinos
-    .SelectMany(casino => casino.Comments, (casino, comment) => new {CityId = casino.CityId, CasinoId = casino.__document_id, Id = comment.Id, DateTime = comment.DateTime, Author = comment.Author, Text = comment.Text})" },
+    .SelectMany(casino => casino.Comments, (casino, comment) => new {CityId = casino.CityId, CasinoId = Id(casino), Id = comment.Id, DateTime = comment.DateTime, Author = comment.Author, Text = comment.Text})" },
 
                     Fields = new Dictionary<string, IndexFieldOptions>
                     {

--- a/test/SlowTests/MailingList/Andrew.cs
+++ b/test/SlowTests/MailingList/Andrew.cs
@@ -23,8 +23,8 @@ namespace SlowTests.MailingList
             var indexDefinition = technologySummaryIndex.CreateIndexDefinition();
 
             Assert.Equal(
-                @"docs.Technologies.Where(technology => !technology.__document_id.EndsWith(""/published"")).Select(technology => new {
-    TechnologyId = technology.__document_id,
+                @"docs.Technologies.Where(technology => !Id(technology).EndsWith(""/published"")).Select(technology => new {
+    TechnologyId = Id(technology),
     DrugId = technology.Drug.Id
 })".Replace("\r\n", Environment.NewLine),
                 indexDefinition.Maps.First());

--- a/test/SlowTests/MailingList/CustomIdInIndexCreationTask.cs
+++ b/test/SlowTests/MailingList/CustomIdInIndexCreationTask.cs
@@ -53,7 +53,7 @@ namespace SlowTests.MailingList
                 Conventions = convention
             }.CreateIndexDefinition();
 
-            Assert.Contains("__document_id", indexDefinition.Maps.First());
+            Assert.Contains("Id(", indexDefinition.Maps.First());
         }
 
 
@@ -66,7 +66,7 @@ namespace SlowTests.MailingList
                 new Task_Index().Execute(store);
 
                 var indexDefinition = store.Admin.Send(new GetIndexOperation("Task/Index"));
-                Assert.Contains("__document_id", indexDefinition.Maps.First());
+                Assert.Contains("Id(", indexDefinition.Maps.First());
             }
         }
     }

--- a/test/SlowTests/MailingList/Everett616.cs
+++ b/test/SlowTests/MailingList/Everett616.cs
@@ -62,7 +62,7 @@ namespace SlowTests.MailingList
                                                     Name = "test",
                                                     Maps = {
                                                         LinuxTestUtils.Dos2Unix(@"docs.ClickAllocations
-    .Select(doc => new {AccountId = doc.AccountId, Date = doc.Date, Id = doc.__document_id, Key = doc.Key, LastSavedDate = doc.LastSavedDate, LastSavedUser = doc.LastSavedUser, OrderNumber = doc.OrderNumber, PurchaseDate = doc.PurchaseDate, PurchaseOrderNumber = doc.PurchaseOrderNumber, Quantity = doc.Quantity, ReorderQuantity = doc.ReorderQuantity, Type = doc.Type})
+    .Select(doc => new {AccountId = doc.AccountId, Date = doc.Date, Id = Id(doc), Key = doc.Key, LastSavedDate = doc.LastSavedDate, LastSavedUser = doc.LastSavedUser, OrderNumber = doc.OrderNumber, PurchaseDate = doc.PurchaseDate, PurchaseOrderNumber = doc.PurchaseOrderNumber, Quantity = doc.Quantity, ReorderQuantity = doc.ReorderQuantity, Type = doc.Type})
 ") },
                                                     Reduce =
                                                         LinuxTestUtils.Dos2Unix(@"results
@@ -126,7 +126,7 @@ namespace SlowTests.MailingList
                                                     Name = "test",
                                                     Maps = {
                                                         LinuxTestUtils.Dos2Unix(@"docs.ClickAllocations
-    .Select(doc => new {AccountId = doc.AccountId, Date = doc.Date, Id = doc.__document_id, Key = doc.Key, LastSavedDate = doc.LastSavedDate, LastSavedUser = doc.LastSavedUser, OrderNumber = doc.OrderNumber, PurchaseDate = doc.PurchaseDate, PurchaseOrderNumber = doc.PurchaseOrderNumber, Quantity = doc.Quantity, ReorderQuantity = doc.ReorderQuantity, Type = doc.Type})
+    .Select(doc => new {AccountId = doc.AccountId, Date = doc.Date, Id = Id(doc), Key = doc.Key, LastSavedDate = doc.LastSavedDate, LastSavedUser = doc.LastSavedUser, OrderNumber = doc.OrderNumber, PurchaseDate = doc.PurchaseDate, PurchaseOrderNumber = doc.PurchaseOrderNumber, Quantity = doc.Quantity, ReorderQuantity = doc.ReorderQuantity, Type = doc.Type})
 ") },
                                                     Reduce =
                                                         LinuxTestUtils.Dos2Unix(@"results

--- a/test/SlowTests/MailingList/ProjectionShouldNotLoadDocument.cs
+++ b/test/SlowTests/MailingList/ProjectionShouldNotLoadDocument.cs
@@ -53,7 +53,7 @@ namespace SlowTests.MailingList
                     // if this is upper case, then we loaded this from the db, because we used Auto-Index that is not storing fields
                     var json = (BlittableJsonReaderObject)result.Results[0];
                     string documentId;
-                    Assert.True(json.TryGet(Constants.Documents.Indexing.Fields.DocumentIdFieldName, out documentId));
+                    Assert.True(json.TryGet(Constants.Documents.Metadata.Id, out documentId));
                     Assert.Equal("FOO", documentId);
                     Assert.True(result.IndexName.StartsWith("Auto"));
 
@@ -64,7 +64,7 @@ namespace SlowTests.MailingList
 
                     // if this is lower case, then we loaded this from the index, not from the db, because w used Static-Index with stored field
                     json = (BlittableJsonReaderObject)result.Results[0];
-                    Assert.True(json.TryGet(Constants.Documents.Indexing.Fields.DocumentIdFieldName, out documentId));
+                    Assert.True(json.TryGet(Constants.Documents.Metadata.Id, out documentId));
                     Assert.Equal("foo", documentId);
                     Assert.True(result.IndexName.StartsWith("Index1"));
                 }

--- a/test/SlowTests/MailingList/Samina.cs
+++ b/test/SlowTests/MailingList/Samina.cs
@@ -1,6 +1,7 @@
 using System;
 using System.Linq;
 using FastTests;
+using Raven.Client;
 using Xunit;
 
 namespace SlowTests.MailingList
@@ -44,7 +45,7 @@ namespace SlowTests.MailingList
                 {
                     if (first == false)
                         properties.OrElse();
-                    properties.WhereEquals("__document_id", guid);
+                    properties.WhereEquals(Constants.Documents.Indexing.Fields.DocumentIdFieldName, guid);
                     first = false;
                 }
                 properties.CloseSubclause();

--- a/test/SlowTests/Tests/Bugs/Vlko/QueryWithMultipleWhere.cs
+++ b/test/SlowTests/Tests/Bugs/Vlko/QueryWithMultipleWhere.cs
@@ -21,7 +21,7 @@ namespace SlowTests.Tests.Bugs.Vlko
 
                     var iq = RavenTestHelper.GetIndexQuery(query);
 
-                    Assert.Equal("FROM Users WHERE ((__document_id = $p0 OR __document_id = $p1) OR __document_id = $p2) AND (Age = $p3)", iq.Query);
+                    Assert.Equal("FROM Users WHERE ((id() = $p0 OR id() = $p1) OR id() = $p2) AND (Age = $p3)", iq.Query);
                     Assert.Equal("1", iq.QueryParameters["p0"]);
                     Assert.Equal("2", iq.QueryParameters["p1"]);
                     Assert.Equal("3", iq.QueryParameters["p2"]);

--- a/test/SlowTests/Tests/Indexes/LinqIndexesFromClient.cs
+++ b/test/SlowTests/Tests/Indexes/LinqIndexesFromClient.cs
@@ -12,6 +12,7 @@ using System.Linq;
 using System.Linq.Expressions;
 using System.Text;
 using FastTests;
+using Raven.Client;
 using Raven.Client.Documents.Conventions;
 using Raven.Client.Documents.Indexes;
 using Raven.Server.Documents;
@@ -69,7 +70,7 @@ namespace SlowTests.Tests.Indexes
                     {
                         bool shouldSkip;
                         converter.SetDocument(lazyStringValue, result, context, out shouldSkip);
-                        Assert.Equal("docs/1", converter.Document.Get("__document_id", null));
+                        Assert.Equal("docs/1", converter.Document.Get(Constants.Documents.Indexing.Fields.DocumentIdFieldName, null));
                     }
                 }
             }
@@ -174,7 +175,7 @@ namespace SlowTests.Tests.Indexes
                 },
                 Maps = { @"docs.Users.Where(user => user.Location == ""Tel Aviv"").Select(user => new {
     Name = user.Name,
-    Id = user.__document_id
+    Id = Id(user)
 })".Replace("\r\n", Environment.NewLine) }
             };
 


### PR DESCRIPTION
- added 'id()' method to RQL,
- static index now contains Id(document) method
- projection returns '@id' instead of '__document_id' field