### PR TITLE
RavenDB-8343 Fixing race condition. We need to add index first before…

### DIFF
--- a/src/Raven.Server/Documents/Indexes/IndexStore.cs
+++ b/src/Raven.Server/Documents/Indexes/IndexStore.cs
@@ -463,11 +463,11 @@ namespace Raven.Server.Documents.Indexes
         {
             Debug.Assert(index != null);
             Debug.Assert(index.Etag > 0);
+            
+            _indexes.Add(index);
 
             if (_documentDatabase.Configuration.Indexing.Disabled == false && _run)
                 index.Start();
-
-            _indexes.Add(index);
 
             _documentDatabase.Changes.RaiseNotifications(
                 new IndexChange


### PR DESCRIPTION
… we start it. The issue was that the replacement index was not replaced because it didn't find itself on the list of indexes

https://github.com/ravendb/ravendb/blob/73d5c0684036a48c5d4cc70d1d4e2b4dedf0b09f/src/Raven.Server/Documents/Indexes/IndexStore.cs#L1088