### PR TITLE
RavenDB-6292

### DIFF
--- a/src/Raven.Client/Documents/Queries/IndexQuery.cs
+++ b/src/Raven.Client/Documents/Queries/IndexQuery.cs
@@ -79,11 +79,6 @@ namespace Raven.Client.Documents.Queries
         public bool ShowTimings { get; set; }
 
         /// <summary>
-        /// Indicates if it's intersect query
-        /// </summary>
-        public bool IsIntersect { get; set; }
-
-        /// <summary>
         /// Gets the custom query string variables.
         /// </summary>
         /// <returns></returns>

--- a/src/Raven.Client/Documents/Queries/IndexQuery.cs
+++ b/src/Raven.Client/Documents/Queries/IndexQuery.cs
@@ -26,7 +26,6 @@ namespace Raven.Client.Documents.Queries
                 hasher.Write(Query);
                 hasher.Write(WaitForNonStaleResults);
                 hasher.Write(WaitForNonStaleResultsAsOfNow);
-                hasher.Write(WaitForNonStaleResultsAsOfNow);
                 hasher.Write(SkipDuplicateChecking);
                 hasher.Write(ShowTimings);
                 hasher.Write(ExplainScores);

--- a/src/Raven.Client/Documents/Session/AbstractDocumentQuery.cs
+++ b/src/Raven.Client/Documents/Session/AbstractDocumentQuery.cs
@@ -934,8 +934,7 @@ If you really want to do in memory filtering on the data returned from the query
                 QueryParameters = QueryParameters,
                 DisableCaching = DisableCaching,
                 ShowTimings = ShowQueryTimings,
-                ExplainScores = ShouldExplainScores,
-                IsIntersect = IsIntersect
+                ExplainScores = ShouldExplainScores
             };
 
             if (PageSize != null)

--- a/src/Raven.Client/Extensions/BlittableJsonTextWriterExtensions.cs
+++ b/src/Raven.Client/Extensions/BlittableJsonTextWriterExtensions.cs
@@ -252,13 +252,6 @@ namespace Raven.Client.Extensions
                 writer.WriteComma();
             }
 
-            if (query.IsIntersect)
-            {
-                writer.WritePropertyName(nameof(query.IsIntersect));
-                writer.WriteBool(true);
-                writer.WriteComma();
-            }
-
             writer.WritePropertyName(nameof(query.QueryParameters));
             if (query.QueryParameters != null)
                 writer.WriteObject(EntityToBlittable.ConvertEntityToBlittable(query.QueryParameters, conventions, context));

--- a/src/Raven.Server/Documents/AttachmentsStorage.cs
+++ b/src/Raven.Server/Documents/AttachmentsStorage.cs
@@ -341,7 +341,7 @@ namespace Raven.Server.Documents
         {
             using (DocumentIdWorker.GetSliceFromId(context, documentId, out Slice lowerDocumentId))
             {
-                var exists = _documentsStorage.GetTableValueReaderForDocument(context, lowerDocumentId, out TableValueReader tvr);
+                var exists = _documentsStorage.GetTableValueReaderForDocument(context, lowerDocumentId, throwOnConflict: true, tvr: out TableValueReader tvr);
                 if (exists == false)
                     return null;
                 return UpdateDocumentAfterAttachmentChange(context, lowerDocumentId, documentId, tvr, null);
@@ -426,7 +426,7 @@ namespace Raven.Server.Documents
             bool hasDoc;
             try
             {
-                hasDoc = _documentsStorage.GetTableValueReaderForDocument(context, lowerDocumentId, out tvr);
+                hasDoc = _documentsStorage.GetTableValueReaderForDocument(context, lowerDocumentId, throwOnConflict: true, tvr: out tvr);
             }
             catch (DocumentConflictException e)
             {
@@ -808,8 +808,8 @@ namespace Raven.Server.Documents
             var currentChangeVector = TableValueToChangeVector(context, (int)AttachmentsTable.ChangeVector, ref tvr);
             var etag = TableValueToEtag((int)AttachmentsTable.Etag, ref tvr);
 
-            using (isPartialKey ? 
-                TableValueToSlice(context, (int)AttachmentsTable.LowerDocumentIdAndLowerNameAndTypeAndHashAndContentType, ref tvr, out key) 
+            using (isPartialKey ?
+                TableValueToSlice(context, (int)AttachmentsTable.LowerDocumentIdAndLowerNameAndTypeAndHashAndContentType, ref tvr, out key)
               : default(ByteStringContext.InternalScope))
             using (TableValueToSlice(context, (int)AttachmentsTable.Hash, ref tvr, out Slice hash))
             {

--- a/src/Raven.Server/Documents/Indexes/Index.cs
+++ b/src/Raven.Server/Documents/Indexes/Index.cs
@@ -1723,7 +1723,7 @@ namespace Raven.Server.Documents.Indexes
 
                             var retriever = GetQueryResultRetriever(query, documentsContext, fieldsToFetch, includeDocumentsCommand);
 
-                            if (query.IsIntersect == false)
+                            if (query.Metadata.IsIntersect == false)
                             {
                                 documents = reader.Query(query, fieldsToFetch, totalResults, skippedResults,
                                     retriever, documentsContext, GetOrAddSpatialField, token.Token);

--- a/src/Raven.Server/Documents/Indexes/Static/CurrentIndexingScope.cs
+++ b/src/Raven.Server/Documents/Indexes/Static/CurrentIndexingScope.cs
@@ -99,15 +99,8 @@ namespace Raven.Server.Documents.Indexes.Static
 
                 references.Add(keySlice);
 
-                Document document = null;
-                try
-                {
-                    document = _documentsStorage.Get(_documentsContext, keySlice);
-                }
-                catch (DocumentConflictException)
-                {
-                    // when there is conflict, we need to apply same behavior as if the document would not exist
-                }
+                // when there is conflict, we need to apply same behavior as if the document would not exist
+                var document = _documentsStorage.Get(_documentsContext, keySlice, throwOnConflict: false);
 
                 if (document == null)
                 {
@@ -121,7 +114,7 @@ namespace Raven.Server.Documents.Indexes.Static
                 return new DynamicBlittableJson(document);
             }
         }
-        
+
         public SpatialField GetOrCreateSpatialField(string name)
         {
             return _getSpatialField(name);

--- a/src/Raven.Server/Documents/Indexes/Workers/HandleReferences.cs
+++ b/src/Raven.Server/Documents/Indexes/Workers/HandleReferences.cs
@@ -176,15 +176,8 @@ namespace Raven.Server.Documents.Indexes.Workers
                                     {
                                         using (DocumentIdWorker.GetLower(databaseContext.Allocator, key.Content.Ptr, key.Size, out var loweredKey))
                                         {
-                                            Document doc = null;
-                                            try
-                                            {
-                                                doc = _documentsStorage.Get(databaseContext, loweredKey);
-                                            }
-                                            catch (DocumentConflictException)
-                                            {
-                                                // when there is conflict, we need to apply same behavior as if the document would not exist
-                                            }
+                                            // when there is conflict, we need to apply same behavior as if the document would not exist
+                                            var doc = _documentsStorage.Get(databaseContext, loweredKey, throwOnConflict: false);
 
                                             if (doc != null && doc.Etag <= lastIndexedEtag)
                                                 documents.Add(doc);

--- a/src/Raven.Server/Documents/Queries/QueryMetadata.cs
+++ b/src/Raven.Server/Documents/Queries/QueryMetadata.cs
@@ -53,6 +53,8 @@ namespace Raven.Server.Documents.Queries
 
         public readonly bool IsGroupBy;
 
+        public bool IsIntersect { get; private set; }
+
         public readonly string CollectionName;
 
         public readonly string IndexName;
@@ -799,6 +801,8 @@ namespace Raven.Server.Documents.Queries
                         Visit(firstArg, parameters);
                         break;
                     case MethodType.Intersect:
+                        _metadata.IsIntersect = true;
+                        goto case MethodType.Exact;
                     case MethodType.Exact:
                         for (var i = 0; i < arguments.Count; i++)
                         {

--- a/src/Raven.Server/Documents/Replication/ResolveConflictOnReplicationConfigurationChange.cs
+++ b/src/Raven.Server/Documents/Replication/ResolveConflictOnReplicationConfigurationChange.cs
@@ -307,15 +307,8 @@ namespace Raven.Server.Documents.Replication
 
         private void DeleteDocumentFromDifferentCollectionIfNeeded(DocumentsOperationContext ctx, DocumentConflict conflict)
         {
-            Document oldVersion;
-            try
-            {
-                oldVersion = _database.DocumentsStorage.Get(ctx, conflict.LowerId);
-            }
-            catch (DocumentConflictException)
-            {
-                return; // if already conflicted, don't need to do anything
-            }
+            // if already conflicted, don't need to do anything
+            var oldVersion = _database.DocumentsStorage.Get(ctx, conflict.LowerId, throwOnConflict: false);
 
             if (oldVersion == null)
                 return;

--- a/src/Raven.Server/Documents/Revisions/RevisionsStorage.cs
+++ b/src/Raven.Server/Documents/Revisions/RevisionsStorage.cs
@@ -259,7 +259,7 @@ namespace Raven.Server.Documents.Revisions
                         TableValueReader tvr;
                         try
                         {
-                            hasDoc = _documentsStorage.GetTableValueReaderForDocument(context, lowerId, out tvr);
+                            hasDoc = _documentsStorage.GetTableValueReaderForDocument(context, lowerId, throwOnConflict: true, tvr: out tvr);
                         }
                         catch (DocumentConflictException)
                         {
@@ -551,7 +551,7 @@ namespace Raven.Server.Documents.Revisions
                     TableValueReader tvr;
                     try
                     {
-                        var hasDoc = _documentsStorage.GetTableValueReaderForDocument(context, lowerId, out tvr);
+                        var hasDoc = _documentsStorage.GetTableValueReaderForDocument(context, lowerId, throwOnConflict: true, tvr: out tvr);
                         if (hasDoc == false)
                             return;
                     }


### PR DESCRIPTION
- ExpiredDocumentsCleaner will now handle conflicts (if all conflicts are expired then it will clean then up)
- ExpiredDocumentsCleaner should break the loop, not end method execution when exceeded entry is encountered, this will allow us to remove all previous expired documents
- removed duplicates from IndexQuery.GetQueryHash