### PR TITLE
RavenDB-8400 fix

### DIFF
--- a/Raven.Database/Prefetching/PrefetchingBehavior.cs
+++ b/Raven.Database/Prefetching/PrefetchingBehavior.cs
@@ -168,6 +168,13 @@ namespace Raven.Database.Prefetching
             return UpdateCurrentlyUsedBatches(documents);
         }
 
+        public IDisposable DocumentBatchFrom(Etag etag, int take, out List<JsonDocument> documents)
+        {
+            LastTimeUsed = DateTime.UtcNow;
+            documents = GetDocumentsBatchFrom(etag, take);
+            return UpdateCurrentlyUsedBatches(documents);
+        }
+
         public List<JsonDocument> GetDocumentsBatchFrom(Etag etag, int? take = null)
         {
             Debug.Assert(ForEntityNames == null || ForEntityNames.Comparer.Equals(EqualityComparer<string>.Default) == false);


### PR DESCRIPTION
If SQL replication batch fails, limit batch size to 1, then gradually increase batch size if the batch successfully completes.

This is important for use-cases when there is an invalid sql transformation script for long periods of time - this will conserve CPU and memory (the queue will have an upper limit in case of repeating errors)