### PR TITLE
RavenDB-8460 Fix a bug where we created corrupted revisions because w…

### DIFF
--- a/src/Raven.Server/Documents/Revisions/RevisionsStorage.cs
+++ b/src/Raven.Server/Documents/Revisions/RevisionsStorage.cs
@@ -293,7 +293,6 @@ namespace Raven.Server.Documents.Revisions
                 }
 
                 flags |= DocumentFlags.Revision;
-                var data = context.ReadObject(document, id);
                 var newEtag = _database.DocumentsStorage.GenerateNextEtag();
                 var newEtagSwapBytes = Bits.SwapBytes(newEtag);
 
@@ -305,7 +304,7 @@ namespace Raven.Server.Documents.Revisions
                     tvb.Add(SpecialChars.RecordSeparator);
                     tvb.Add(newEtagSwapBytes);
                     tvb.Add(idPtr);
-                    tvb.Add(data.BasePointer, data.Size);
+                    tvb.Add(document.BasePointer, document.Size);
                     tvb.Add((int)flags);
                     tvb.Add(newEtagSwapBytes);
                     tvb.Add(lastModifiedTicks);


### PR DESCRIPTION
…e called context.ReadObject without the UsageMode.ToDisk parameter which caused us to not write the compressed string correctly.

I fixed it by removing the context.ReadObject call as it seems redundant to copy the document, we can use the original.