### PR TITLE
RavenDB-8460 Fix a bug where we created corrupted revisions because w…

### DIFF
--- a/src/Raven.Server/Smuggler/Documents/SmugglerDocumentType.cs
+++ b/src/Raven.Server/Smuggler/Documents/SmugglerDocumentType.cs
@@ -8,15 +8,15 @@ using Voron;
 
 namespace Raven.Server.Smuggler.Documents
 {
-    public enum DocumentType : byte
-    {
-        Document = 1,
-        Attachment = 2
-    }
-
     public class DocumentItem
     {
-        public const string Key = "@document-type";
+        public static class ExportDocumentType
+        {
+            public const string Key = "@export-type";
+
+            public const string Document = nameof(Document);
+            public const string Attachment = nameof(Attachment);
+        }
 
         public Document Document;
         public List<AttachmentStream> Attachments;

--- a/src/Raven.Server/Smuggler/Documents/StreamDestination.cs
+++ b/src/Raven.Server/Smuggler/Documents/StreamDestination.cs
@@ -225,8 +225,8 @@ namespace Raven.Server.Smuggler.Documents
 
                 Writer.WriteStartObject();
 
-                Writer.WritePropertyName(DocumentItem.Key);
-                Writer.WriteInteger((byte)DocumentType.Attachment);
+                Writer.WritePropertyName(DocumentItem.ExportDocumentType.Key);
+                Writer.WriteString(DocumentItem.ExportDocumentType.Attachment);
                 Writer.WriteComma();
 
                 Writer.WritePropertyName(nameof(AttachmentName.Hash));

--- a/src/Raven.Server/Smuggler/Documents/StreamSource.cs
+++ b/src/Raven.Server/Smuggler/Documents/StreamSource.cs
@@ -1,6 +1,7 @@
 ﻿using System;
 using System.Collections.Generic;
 using System.IO;
+using Raven.Client;
 using Raven.Client.Documents.Indexes;
 using Raven.Client.Documents.Operations;
 using Raven.Client.Documents.Smuggler;
@@ -320,8 +321,9 @@ namespace Raven.Server.Smuggler.Documents
                     var data = builder.CreateReader();
                     builder.Reset();
 
-                    if (data.TryGet(DocumentItem.Key, out byte type) &&
-                        type == (byte)DocumentType.Attachment)
+                    if (data.TryGet(Constants.Documents.Metadata.Key, out BlittableJsonReaderObject metadata) &&
+                        metadata.TryGet(DocumentItem.ExportDocumentType.Key, out string type) &&
+                        type == DocumentItem.ExportDocumentType.Attachment)
                     {
                         if (attachments == null)
                             attachments = new List<DocumentItem.AttachmentStream>();

--- a/tools/Voron.Recovery/Recovery.cs
+++ b/tools/Voron.Recovery/Recovery.cs
@@ -427,7 +427,7 @@ namespace Voron.Recovery
 
         private bool _firstAttachment = true;
         private long _attachmentNumber = 0;
-        private List<string> _attachmentsHashs = new List<string>();
+        private readonly List<string> _attachmentsHashs = new List<string>();
         private void WriteAttachment(BlittableJsonTextWriter attachmentWriter, long totalSize, string hash)
         {
             if (_firstAttachment == false)
@@ -438,8 +438,8 @@ namespace Voron.Recovery
 
             attachmentWriter.WriteStartObject();
 
-            attachmentWriter.WritePropertyName(DocumentItem.Key);
-            attachmentWriter.WriteInteger((byte)DocumentType.Attachment);
+            attachmentWriter.WritePropertyName(DocumentItem.ExportDocumentType.Key);
+            attachmentWriter.WriteString(DocumentItem.ExportDocumentType.Attachment);
             attachmentWriter.WriteComma();
 
             attachmentWriter.WritePropertyName(nameof(AttachmentName.Hash));


### PR DESCRIPTION
…e called context.ReadObject without the UsageMode.ToDisk parameter which caused us to not write the compressed string correctly.

I fixed it by removing the context.ReadObject call as it seems redundant to copy the document, we can use the original.