### PR TITLE
RavenDB-8505 Change @document-type in smuggler file to be more readab…

### DIFF
--- a/src/Raven.Server/Smuggler/Documents/SmugglerDocumentType.cs
+++ b/src/Raven.Server/Smuggler/Documents/SmugglerDocumentType.cs
@@ -8,15 +8,15 @@ using Voron;
 
 namespace Raven.Server.Smuggler.Documents
 {
-    public enum DocumentType : byte
-    {
-        Document = 1,
-        Attachment = 2
-    }
-
     public class DocumentItem
     {
-        public const string Key = "@document-type";
+        public static class ExportDocumentType
+        {
+            public const string Key = "@export-type";
+
+            public const string Document = nameof(Document);
+            public const string Attachment = nameof(Attachment);
+        }
 
         public Document Document;
         public List<AttachmentStream> Attachments;

--- a/src/Raven.Server/Smuggler/Documents/StreamDestination.cs
+++ b/src/Raven.Server/Smuggler/Documents/StreamDestination.cs
@@ -225,8 +225,13 @@ namespace Raven.Server.Smuggler.Documents
 
                 Writer.WriteStartObject();
 
-                Writer.WritePropertyName(DocumentItem.Key);
-                Writer.WriteInteger((byte)DocumentType.Attachment);
+                Writer.WritePropertyName(Constants.Documents.Metadata.Key);
+                Writer.WriteStartObject();
+
+                Writer.WritePropertyName(DocumentItem.ExportDocumentType.Key);
+                Writer.WriteString(DocumentItem.ExportDocumentType.Attachment);
+
+                Writer.WriteEndObject();
                 Writer.WriteComma();
 
                 Writer.WritePropertyName(nameof(AttachmentName.Hash));

--- a/src/Raven.Server/Smuggler/Documents/StreamSource.cs
+++ b/src/Raven.Server/Smuggler/Documents/StreamSource.cs
@@ -1,6 +1,7 @@
 ﻿using System;
 using System.Collections.Generic;
 using System.IO;
+using Raven.Client;
 using Raven.Client.Documents.Indexes;
 using Raven.Client.Documents.Operations;
 using Raven.Client.Documents.Smuggler;
@@ -320,8 +321,9 @@ namespace Raven.Server.Smuggler.Documents
                     var data = builder.CreateReader();
                     builder.Reset();
 
-                    if (data.TryGet(DocumentItem.Key, out byte type) &&
-                        type == (byte)DocumentType.Attachment)
+                    if (data.TryGet(Constants.Documents.Metadata.Key, out BlittableJsonReaderObject metadata) &&
+                        metadata.TryGet(DocumentItem.ExportDocumentType.Key, out string type) &&
+                        type == DocumentItem.ExportDocumentType.Attachment)
                     {
                         if (attachments == null)
                             attachments = new List<DocumentItem.AttachmentStream>();

--- a/src/Sparrow/Json/BlittableJsonDocumentBuilder.cs
+++ b/src/Sparrow/Json/BlittableJsonDocumentBuilder.cs
@@ -342,8 +342,7 @@ namespace Sparrow.Json
                 BlittableJsonToken stringToken;
                 if (typeof(TWriteStrategy) == typeof(WriteNone))
                 {
-                    start = _writer.WriteValue(_state.StringBuffer, _state.StringSize, _state.EscapePositions);
-                    stringToken = BlittableJsonToken.String;
+                    start = _writer.WriteValue(_state.StringBuffer, _state.StringSize, _state.EscapePositions, out stringToken, _mode, _state.CompressedSize);
                 }
                 else // WriteFull
                 {

--- a/test/SlowTests/Issues/RavenDB_7136.cs
+++ b/test/SlowTests/Issues/RavenDB_7136.cs
@@ -66,13 +66,10 @@ namespace SlowTests.Issues
                 }
 
                 WaitForIndexing(store);
-
-                var errors = store.Admin.Send(new GetIndexErrorsOperation());
-                
-                Assert.Equal(1, errors.Length);
-
-                Assert.Equal(1, errors[0].Errors.Length);
-                Assert.Contains(nameof(DivideByZeroException), errors[0].Errors[0].Error);
+                var indexes = WaitForIndexingErrors(store);
+                var error = indexes.Single();
+                Assert.Equal(1, error.Errors.Length);
+                Assert.Contains(nameof(DivideByZeroException), error.Errors[0].Error);
             }
         }
     }

--- a/test/Tests.Infrastructure/RavenTestBase.cs
+++ b/test/Tests.Infrastructure/RavenTestBase.cs
@@ -319,6 +319,27 @@ namespace FastTests
             throw new TimeoutException("The indexes stayed stale for more than " + timeout.Value + ", stats at " + file);
         }
 
+        public static IndexErrors[] WaitForIndexingErrors(IDocumentStore store, TimeSpan? timeout = null)
+        {
+            timeout = timeout ?? (Debugger.IsAttached
+                          ? TimeSpan.FromMinutes(15)
+                          : TimeSpan.FromMinutes(1));
+
+            var sp = Stopwatch.StartNew();
+            while (sp.Elapsed < timeout.Value)
+            {
+                var indexes = store.Admin.Send(new GetIndexErrorsOperation());
+                foreach (var index in indexes)
+                {
+                    if (index.Errors.Any())
+                        return indexes;
+                }
+
+                Thread.Sleep(32);
+            }
+
+            throw new TimeoutException("Got no index error for more than " + timeout.Value);
+        }
 
         protected async Task<T> WaitForValueAsync<T>(Func<Task<T>> act, T expectedVal, int timeout = 15000)
         {

--- a/test/Tryouts/Program.cs
+++ b/test/Tryouts/Program.cs
@@ -1,5 +1,6 @@
 using System;
 using System.Threading.Tasks;
+using SlowTests.Issues;
 using SlowTests.Server.Documents.PeriodicBackup;
 
 namespace Tryouts
@@ -8,14 +9,14 @@ namespace Tryouts
     {
         public static void Main(string[] args)
         {
-            Parallel.For(0, 1000, i =>
+            for (int i = 0; i < 1000; i++)
             {
                 Console.WriteLine(i);
-                using (var test = new SlowTests.Client.Attachments.AttachmentFailover())
+                using (var test = new RavenDB_7136())
                 {
-                    test.PutAttachmentsWithFailover_Session().Wait();
+                    test.IfOneOfTheMultiMapFunctionsIsFailingWeNeedToResetTheEnumeratorToAvoidApplyingWrongFunctionOnPreviousDocument();
                 }
-            });
+            }
         }
     }
 }

--- a/tools/Voron.Recovery/Recovery.cs
+++ b/tools/Voron.Recovery/Recovery.cs
@@ -427,7 +427,7 @@ namespace Voron.Recovery
 
         private bool _firstAttachment = true;
         private long _attachmentNumber = 0;
-        private List<string> _attachmentsHashs = new List<string>();
+        private readonly List<string> _attachmentsHashs = new List<string>();
         private void WriteAttachment(BlittableJsonTextWriter attachmentWriter, long totalSize, string hash)
         {
             if (_firstAttachment == false)
@@ -438,8 +438,13 @@ namespace Voron.Recovery
 
             attachmentWriter.WriteStartObject();
 
-            attachmentWriter.WritePropertyName(DocumentItem.Key);
-            attachmentWriter.WriteInteger((byte)DocumentType.Attachment);
+            attachmentWriter.WritePropertyName(Raven.Client.Constants.Documents.Metadata.Key);
+            attachmentWriter.WriteStartObject();
+
+            attachmentWriter.WritePropertyName(DocumentItem.ExportDocumentType.Key);
+            attachmentWriter.WriteString(DocumentItem.ExportDocumentType.Attachment);
+
+            attachmentWriter.WriteEndObject();
             attachmentWriter.WriteComma();
 
             attachmentWriter.WritePropertyName(nameof(AttachmentName.Hash));


### PR DESCRIPTION
…le and maintained. It changed to this format:

{
   "Docs":[{
      "@metadata":{
         "@export-type":"Attachment"
      },
      "Hash":"Hash Value",
      "Size":12356
   }]
}