### PR TITLE
Make sure to dispose HttpResponseMessage and it's Content property for streaming requests

### DIFF
--- a/Raven.Client.Lightweight/Connection/Implementation/HttpJsonRequest.cs
+++ b/Raven.Client.Lightweight/Connection/Implementation/HttpJsonRequest.cs
@@ -578,9 +578,9 @@ namespace Raven.Client.Connection.Implementation
                 {
                     factory.CacheResponse(Url, data, ResponseHeaders);
                 }
+
                 if (factory.CanLogRequest)
                 {
-
                     factory.OnLogRequest(owner, new RequestResultArgs
                     {
                         DurationMilliseconds = CalculateDuration(),
@@ -862,6 +862,7 @@ namespace Raven.Client.Connection.Implementation
                 CopyHeadersToHttpRequestMessage(rawRequestMessage);
 
                 Response = await httpClient.SendAsync(rawRequestMessage, HttpCompletionOption.ResponseHeadersRead).ConfigureAwait(false);
+                
                 ResponseStatusCode = Response.StatusCode;
                 if (Response.IsSuccessStatusCode == false &&
                     (ResponseStatusCode == HttpStatusCode.PreconditionFailed ||

--- a/Raven.Client.Lightweight/FileSystem/Extensions/AsyncFilesServerClientExtension.cs
+++ b/Raven.Client.Lightweight/FileSystem/Extensions/AsyncFilesServerClientExtension.cs
@@ -71,7 +71,12 @@ namespace Raven.Client.FileSystem.Extensions
                 if (metadataRef != null)
                     metadataRef.Value = response.HeadersToObject();
 
-                return new DisposableStream(await response.GetResponseStreamWithHttpDecompression().ConfigureAwait(false), request.Dispose);
+                return new DisposableStream(await response.GetResponseStreamWithHttpDecompression().ConfigureAwait(false),() =>
+                {
+                    request.Dispose();
+                    response.Content.Dispose();
+                    response.Dispose();
+                });
             }
             catch (Exception e)
             {

--- a/Raven.Client.Lightweight/Indexes/AbstractResultsTransformer.cs
+++ b/Raven.Client.Lightweight/Indexes/AbstractResultsTransformer.cs
@@ -179,7 +179,11 @@ namespace Raven.Client.Indexes
             {
                 try
                 {
-                    replicateTransformerRequest.ExecuteRawResponseAsync().Wait();
+                    replicateTransformerRequest.ExecuteRawResponseAsync().ContinueWith(t =>
+                    {
+                        t.Result.Content.Dispose();
+                        t.Result.Dispose();
+                    }).Wait();
                 }
                 catch (Exception)
                 {
@@ -199,7 +203,11 @@ namespace Raven.Client.Indexes
             {
                 try
                 {
-                    await replicateTransformerRequest.ExecuteRawResponseAsync().ConfigureAwait(false);
+                    await replicateTransformerRequest.ExecuteRawResponseAsync().ContinueWith(t =>
+                    {
+                        t.Result.Content.Dispose();
+                        t.Result.Dispose();
+                    }).ConfigureAwait(false);
                 }
                 catch (Exception)
                 {

--- a/Raven.Database/Smuggler/SmugglerRemoteFilesOperations.cs
+++ b/Raven.Database/Smuggler/SmugglerRemoteFilesOperations.cs
@@ -202,7 +202,12 @@ namespace Raven.Smuggler
                     
                 var response = await request.ExecuteRawResponseAsync(fileNamesJson).ConfigureAwait(false);
 
-                return new DisposableStream(await response.GetResponseStreamWithHttpDecompression().ConfigureAwait(false), request.Dispose);
+                return new DisposableStream(await response.GetResponseStreamWithHttpDecompression().ConfigureAwait(false), () =>
+                {
+                    request.Dispose();
+                    response.Content.Dispose();
+                    response.Dispose();
+                });
                 
             }
             catch (Exception e)


### PR DESCRIPTION
This is to make sure we do not leak connections in case of raw http requests. (streaming)