### PR TITLE
RavenDB-8539 - Starting a server with License.Path argument does not activate the license

### DIFF
--- a/src/Raven.Server/Documents/Handlers/Admin/RachisAdminHandler.cs
+++ b/src/Raven.Server/Documents/Handlers/Admin/RachisAdminHandler.cs
@@ -315,13 +315,14 @@ namespace Raven.Server.Documents.Handlers.Admin
                                             $"than the available cores on that machine: {nodeInfo.NumberOfCores}");
             }
 
+            ServerStore.EnsureNotPassive();
+
             if (ServerStore.LicenseManager.CanAddNode(nodeUrl, assignedCores, out var licenseLimit) == false)
             {
                 SetLicenseLimitResponse(licenseLimit);
                 return;
             }
-
-            ServerStore.EnsureNotPassive();
+            
             if (ServerStore.IsLeader())
             {
                 using (ServerStore.ContextPool.AllocateOperationContext(out TransactionOperationContext ctx))


### PR DESCRIPTION
- cannot add license when we have an empty database (external replication error)