### PR TITLE
RavenDB-8543: Environment.ProcessorCount() respects container limits …

### DIFF
--- a/src/Sparrow/Utils/ProcessorInfo.cs
+++ b/src/Sparrow/Utils/ProcessorInfo.cs
@@ -10,19 +10,7 @@ namespace Sparrow.Utils
 
         public static int GetProcessorCount()
         {
-            if (PlatformDetails.RunningOnPosix == false)
-                return Environment.ProcessorCount;
-
-            // on linux, if running in container, the number of cores might be set by either cpuset-cpus or cpus (cpus == cfs quota)
-            // if not in container Environment.ProcessorCount is the value to be considered. So we read all the three values and return the lowest
-            var cpussetCpusCores = KernelVirtualFileSystemUtils.ReadNumberOfCoresFromCgroupFile("/sys/fs/cgroup/cpuset/cpuset.cpus");
-            var quota = KernelVirtualFileSystemUtils.ReadNumberFromFile("/sys/fs/cgroup/cpu/cpu.cfs_quota_us");
-            var period = quota != long.MaxValue ? KernelVirtualFileSystemUtils.ReadNumberFromFile("/sys/fs/cgroup/cpu/cpu.cfs_period_us") : 0; // read from file only if quota read successful
-            var cpusCore = period != 0 ? quota / period : Environment.ProcessorCount; // note that we round down here ("2.5" processors quota will be read as "2")
-            if (cpusCore == 0) // i.e. "0.5" processors quota
-                cpusCore = 1;
-
-            return Math.Min(Environment.ProcessorCount, Math.Min((int)cpusCore, cpussetCpusCores));
+            return Environment.ProcessorCount;
         }
     }
 }


### PR DESCRIPTION
…starting at dotnet 2.0.0