### PR TITLE
RavenDB-8495 Promotable or rehab node which is in conflict with his r…

### DIFF
--- a/src/Raven.Server/ServerWide/Maintenance/ClusterMaintenanceWorker.cs
+++ b/src/Raven.Server/ServerWide/Maintenance/ClusterMaintenanceWorker.cs
@@ -139,7 +139,11 @@ namespace Raven.Server.ServerWide.Maintenance
                         report.LastTombstoneEtag = DocumentsStorage.ReadLastTombstoneEtag(tx.InnerTransaction);
                         report.NumberOfConflicts = documentsStorage.ConflictsStorage.ConflictsCount;
                         report.NumberOfDocuments = documentsStorage.GetNumberOfDocuments(context);
-                        report.LastChangeVector = DocumentsStorage.GetDatabaseChangeVector(context);
+                        report.DatabaseChangeVector = DocumentsStorage.GetDatabaseChangeVector(context);
+                        foreach (var collection in documentsStorage.GetCollections(context))
+                        {
+                            report.LastChangeVectorByCollection.Add(collection.Name, documentsStorage.GetLastDocumentChangeVector(context, collection.Name));
+                        }
 
                         if (indexStorage != null)
                         {

--- a/src/Raven.Server/ServerWide/Maintenance/ClusterNodeStatusReport.cs
+++ b/src/Raven.Server/ServerWide/Maintenance/ClusterNodeStatusReport.cs
@@ -19,9 +19,10 @@ namespace Raven.Server.ServerWide.Maintenance
         public string Name;
         public string NodeName;
 
-        public string LastChangeVector;
+        public string DatabaseChangeVector;
 
         public Dictionary<string, ObservedIndexStatus> LastIndexStats = new Dictionary<string, ObservedIndexStatus>();
+        public Dictionary<string, string> LastChangeVectorByCollection = new Dictionary<string, string>();
 
         public class ObservedIndexStatus
         {
@@ -49,11 +50,11 @@ namespace Raven.Server.ServerWide.Maintenance
                 [nameof(LastTombstoneEtag)] = LastTombstoneEtag,
                 [nameof(NumberOfConflicts)] = NumberOfConflicts,
                 [nameof(NumberOfDocuments)] = NumberOfDocuments,
-                [nameof(LastChangeVector)] = LastChangeVector,
+                [nameof(DatabaseChangeVector)] = DatabaseChangeVector,
+                [nameof(LastChangeVectorByCollection)] = DynamicJsonValue.Convert(LastChangeVectorByCollection),
                 [nameof(Error)] = Error
             };
             var indexStats = new DynamicJsonValue();
-
             foreach (var stat in LastIndexStats)
             {
                 indexStats[stat.Key] = new DynamicJsonValue
@@ -63,8 +64,8 @@ namespace Raven.Server.ServerWide.Maintenance
                     [nameof(stat.Value.IsStale)] = stat.Value.IsStale
                 };
             }
-
             dynamicJsonValue[nameof(LastIndexStats)] = indexStats;
+
             return dynamicJsonValue;
         }
     }

--- a/src/Raven.Server/ServerWide/Maintenance/ClusterObserverLogEntry.cs
+++ b/src/Raven.Server/ServerWide/Maintenance/ClusterObserverLogEntry.cs
@@ -9,6 +9,7 @@ namespace Raven.Server.ServerWide.Maintenance
         public long Iteration { get ; set; }
         public string Database { get; set; }
         public string Message { get; set; }
+        public bool HasTopologyChanged { get; set; }
 
         public DynamicJsonValue ToJson()
         {
@@ -17,7 +18,8 @@ namespace Raven.Server.ServerWide.Maintenance
                     [nameof(Date)] = Date,
                     [nameof(Iteration)] = Iteration,
                     [nameof(Database)] = Database,
-                    [nameof(Message)] = Message
+                    [nameof(Message)] = Message,
+                    [nameof(HasTopologyChanged)] = HasTopologyChanged
                 };
         }
     }


### PR DESCRIPTION
…esponsible node, will be never promoted to memeber

- Promoting a node to member is not based on the *global* change vector, but on the change vector of the last document in each collection.
- Rehabs are not deleted, but once they recovered they promoted to members and only then we delete the least updated node.