### PR TITLE
RavenDB-8282 Fixing managed memory leak caused by retaining ClusterNo…

### DIFF
--- a/src/Raven.Server/ServerWide/Maintenance/ClusterNodeStatusReport.cs
+++ b/src/Raven.Server/ServerWide/Maintenance/ClusterNodeStatusReport.cs
@@ -90,9 +90,8 @@ namespace Raven.Server.ServerWide.Maintenance
         public readonly Exception Error;
 
         public readonly DateTime UpdateDateTime;
-        private readonly ClusterNodeStatusReport _lastSuccessfulReport;
 
-        public DateTime LastSuccessfulUpdateDateTime => _lastSuccessfulReport?.UpdateDateTime ?? DateTime.MinValue;
+        public readonly DateTime LastSuccessfulUpdateDateTime;
 
         public ClusterNodeStatusReport(
             Dictionary<string, DatabaseStatusReport> report, 
@@ -105,7 +104,9 @@ namespace Raven.Server.ServerWide.Maintenance
             Status = reportStatus;
             Error = error;
             UpdateDateTime = updateDateTime;
-            _lastSuccessfulReport = lastSuccessfulReport;
+
+            LastSuccessfulUpdateDateTime = lastSuccessfulReport?.UpdateDateTime ?? DateTime.MinValue;
+            
             LastGoodDatabaseStatus = new Dictionary<string, DateTime>();
             foreach (var dbReport in report)
             {


### PR DESCRIPTION
…deStatusReport instances forever in _lastSuccessfulReport field. We don't need nothing but UpdateDateTime from the previous report.