### PR TITLE
RavenDB-8694 Fixing edge condition what adding a stream - once we nee…

### DIFF
--- a/src/Voron/Data/BTrees/Tree.Stream.cs
+++ b/src/Voron/Data/BTrees/Tree.Stream.cs
@@ -117,7 +117,8 @@ namespace Voron.Data.BTrees
                     if (remaining < infoSize)
                     {
                         AllocateNextPage();
-                        RecordChunkPage(_currentPage.PageNumber, 0);
+                        chunkSize = 0;
+                        RecordChunkPage(_currentPage.PageNumber, chunkSize);
                     }
 
                     RecordStreamInfo();

--- a/test/FastTests/Voron/Storage/StorageReportGenerationTests.cs
+++ b/test/FastTests/Voron/Storage/StorageReportGenerationTests.cs
@@ -307,6 +307,7 @@ namespace FastTests.Voron.Storage
         [InlineDataWithRandomSeed(1)]
         [InlineDataWithRandomSeed(5)]
         [InlineDataWithRandomSeed(15)]
+        [InlineData(5, 1390075326)] // RavenDB-8694
         public void TreeReportContainsInfoAboutStreams(int numberOfStreams, int seed)
         {
             var r = new Random(seed);


### PR DESCRIPTION
…d to allocate additional page just for storing the stream info we need to zero `chunkSize` since we use it in `ShrinkOverflowPage` call a few lines below