### PR TITLE
RavenDB-8606 Lower case the doc id given in the input since internall…

### DIFF
--- a/src/Raven.Server/Documents/Indexes/Debugging/IndexDebugExtensions.cs
+++ b/src/Raven.Server/Documents/Indexes/Debugging/IndexDebugExtensions.cs
@@ -182,7 +182,7 @@ namespace Raven.Server.Documents.Indexes.Debugging
                 foreach (var docId in docIds)
                 {
                     FixedSizeTree mapEntriesTree;
-                    scope.EnsureDispose(mapEntriesTree = mapPhaseTree.FixedTreeFor(docId, sizeof(long)));
+                    scope.EnsureDispose(mapEntriesTree = mapPhaseTree.FixedTreeFor(docId.ToLower(), sizeof(long)));
                     mapEntries.Add(mapEntriesTree);
                 }
 

--- a/src/Raven.Server/Documents/Indexes/Errors/FaultyInMemoryIndex.cs
+++ b/src/Raven.Server/Documents/Indexes/Errors/FaultyInMemoryIndex.cs
@@ -48,7 +48,7 @@ namespace Raven.Server.Documents.Indexes.Errors
             throw new NotSupportedException($"Index with etag {Etag} is in-memory implementation of a faulty index", _e);
         }
 
-        public override int HandleMap(LazyStringValue key, IEnumerable mapResults, IndexWriteOperation writer, TransactionOperationContext indexContext, IndexingStatsScope stats)
+        public override int HandleMap(LazyStringValue lowerId, IEnumerable mapResults, IndexWriteOperation writer, TransactionOperationContext indexContext, IndexingStatsScope stats)
         {
             throw new NotSupportedException($"Index with etag {Etag} is in-memory implementation of a faulty index", _e);
         }

--- a/src/Raven.Server/Documents/Indexes/Index.cs
+++ b/src/Raven.Server/Documents/Indexes/Index.cs
@@ -1264,7 +1264,7 @@ namespace Raven.Server.Documents.Indexes
         public abstract void HandleDelete(DocumentTombstone tombstone, string collection, IndexWriteOperation writer,
             TransactionOperationContext indexContext, IndexingStatsScope stats);
 
-        public abstract int HandleMap(LazyStringValue key, IEnumerable mapResults, IndexWriteOperation writer,
+        public abstract int HandleMap(LazyStringValue lowerId, IEnumerable mapResults, IndexWriteOperation writer,
             TransactionOperationContext indexContext, IndexingStatsScope stats);
 
         private void HandleIndexChange(IndexChange change)

--- a/src/Raven.Server/Documents/Indexes/MapIndexBase.cs
+++ b/src/Raven.Server/Documents/Indexes/MapIndexBase.cs
@@ -47,27 +47,27 @@ namespace Raven.Server.Documents.Indexes
             writer.Delete(tombstone.LowerId, stats);
         }
 
-        public override int HandleMap(LazyStringValue key, IEnumerable mapResults, IndexWriteOperation writer, TransactionOperationContext indexContext, IndexingStatsScope stats)
+        public override int HandleMap(LazyStringValue lowerId, IEnumerable mapResults, IndexWriteOperation writer, TransactionOperationContext indexContext, IndexingStatsScope stats)
         {
             EnsureValidStats(stats);
 
             bool mustDelete;
             using (_stats.BloomStats.Start())
             {
-                mustDelete = _filter.Add(key) == false;
+                mustDelete = _filter.Add(lowerId) == false;
             }
 
             if (mustDelete)
-                writer.Delete(key, stats);
+                writer.Delete(lowerId, stats);
 
             var numberOfOutputs = 0;
             foreach (var mapResult in mapResults)
             {
-                writer.IndexDocument(key, mapResult, stats, indexContext);
+                writer.IndexDocument(lowerId, mapResult, stats, indexContext);
                 numberOfOutputs++;
             }
 
-            HandleIndexOutputsPerDocument(key, numberOfOutputs, stats);
+            HandleIndexOutputsPerDocument(lowerId, numberOfOutputs, stats);
 
             DocumentDatabase.Metrics.IndexedPerSecond.Mark();
             return numberOfOutputs;

--- a/src/Raven.Server/Documents/Indexes/MapReduce/Auto/AutoMapReduceIndex.cs
+++ b/src/Raven.Server/Documents/Indexes/MapReduce/Auto/AutoMapReduceIndex.cs
@@ -79,7 +79,7 @@ namespace Raven.Server.Documents.Indexes.MapReduce.Auto
             SetPriority(definition.Priority);
         }
 
-        public override int HandleMap(LazyStringValue key, IEnumerable mapResults, IndexWriteOperation writer, TransactionOperationContext indexContext, IndexingStatsScope stats)
+        public override int HandleMap(LazyStringValue lowerId, IEnumerable mapResults, IndexWriteOperation writer, TransactionOperationContext indexContext, IndexingStatsScope stats)
         {
             EnsureValidStats(stats);
 
@@ -88,7 +88,7 @@ namespace Raven.Server.Documents.Indexes.MapReduce.Auto
             using (_stats.BlittableJsonAggregation.Start())
             {
                 var document = ((Document[])mapResults)[0];
-                Debug.Assert(key == document.LowerId);
+                Debug.Assert(lowerId == document.LowerId);
 
                 foreach (var field in Definition.MapFields.Values)
                 {
@@ -159,14 +159,14 @@ namespace Raven.Server.Documents.Indexes.MapReduce.Auto
 
             BlittableJsonReaderObject mr;
             using (_stats.CreateBlittableJson.Start())
-                mr = indexContext.ReadObject(mappedResult, key);
+                mr = indexContext.ReadObject(mappedResult, lowerId);
 
             var mapResult = _singleOutputList[0];
 
             mapResult.Data = mr;
             mapResult.ReduceKeyHash = _reduceKeyProcessor.Hash;
 
-            var resultsCount = PutMapResults(key, _singleOutputList, indexContext, stats);
+            var resultsCount = PutMapResults(lowerId, _singleOutputList, indexContext, stats);
 
             DocumentDatabase.Metrics.MapReduceMappedPerSecond.Mark(resultsCount);
 

--- a/src/Raven.Server/Documents/Indexes/MapReduce/MapReduceIndexBase.cs
+++ b/src/Raven.Server/Documents/Indexes/MapReduce/MapReduceIndexBase.cs
@@ -97,16 +97,16 @@ namespace Raven.Server.Documents.Indexes.MapReduce
             return tx.CreateTree(ReducePhaseTreeName);
         }
 
-        protected unsafe int PutMapResults(LazyStringValue documentKey, IEnumerable<MapResult> mappedResults, TransactionOperationContext indexContext, IndexingStatsScope stats)
+        protected unsafe int PutMapResults(LazyStringValue lowerId, IEnumerable<MapResult> mappedResults, TransactionOperationContext indexContext, IndexingStatsScope stats)
         {
             EnsureValidStats(stats);
 
-            using (Slice.External(indexContext.Allocator, documentKey.Buffer, documentKey.Length, out Slice docKeyAsSlice))
+            using (Slice.External(indexContext.Allocator, lowerId.Buffer, lowerId.Length, out Slice docIdAsSlice))
             {
                 Queue<MapEntry> existingEntries = null;
 
                 using (_stats.GetMapEntriesTree.Start())
-                    MapReduceWorkContext.DocumentMapEntries.RepurposeInstance(docKeyAsSlice, clone: false);
+                    MapReduceWorkContext.DocumentMapEntries.RepurposeInstance(docIdAsSlice, clone: false);
 
 
                 if (MapReduceWorkContext.DocumentMapEntries.NumberOfEntries > 0)
@@ -169,7 +169,7 @@ namespace Raven.Server.Documents.Indexes.MapReduce
                     }
                 }
 
-                HandleIndexOutputsPerDocument(documentKey, resultsCount, stats);
+                HandleIndexOutputsPerDocument(lowerId, resultsCount, stats);
 
                 DocumentDatabase.Metrics.MapReduceMappedPerSecond.Mark(resultsCount);
 

--- a/src/Raven.Server/Documents/Indexes/MapReduce/Static/MapReduceIndex.cs
+++ b/src/Raven.Server/Documents/Indexes/MapReduce/Static/MapReduceIndex.cs
@@ -200,7 +200,7 @@ namespace Raven.Server.Documents.Indexes.MapReduce.Static
             return new StaticIndexDocsEnumerator(documents, _compiled.Maps[collection], collection, stats);
         }
 
-        public override int HandleMap(LazyStringValue key, IEnumerable mapResults, IndexWriteOperation writer, TransactionOperationContext indexContext, IndexingStatsScope stats)
+        public override int HandleMap(LazyStringValue lowerId, IEnumerable mapResults, IndexWriteOperation writer, TransactionOperationContext indexContext, IndexingStatsScope stats)
         {
             if (_enumerationWrappers.TryGetValue(CurrentIndexingScope.Current.SourceCollection, out AnonymousObjectToBlittableMapResultsEnumerableWrapper wrapper) == false)
             {
@@ -209,7 +209,7 @@ namespace Raven.Server.Documents.Indexes.MapReduce.Static
 
             wrapper.InitializeForEnumeration(mapResults, indexContext, stats);
 
-            return PutMapResults(key, wrapper, indexContext, stats);
+            return PutMapResults(lowerId, wrapper, indexContext, stats);
         }
 
         protected override bool IsStale(DocumentsOperationContext databaseContext, TransactionOperationContext indexContext, long? cutoff = null, List<string> stalenessReasons = null)


### PR DESCRIPTION
…y we use lowered doc id for names of mapped results trees