### PR TITLE
RavenDB-5627

### DIFF
--- a/src/Raven.Server/Documents/ResourceCache.cs
+++ b/src/Raven.Server/Documents/ResourceCache.cs
@@ -24,6 +24,8 @@ namespace Raven.Server.Documents
         /// </summary>
         public IEnumerable<Task<TResource>> Values => _caseSensitive.Values;
 
+        public int Count => _caseSensitive.Count;
+
         public void Clear()
         {
             _caseSensitive.Clear();

--- a/src/Raven.Server/Monitoring/Snmp/Objects/Database/5.1/DatabaseLoadedCount.cs
+++ b/src/Raven.Server/Monitoring/Snmp/Objects/Database/5.1/DatabaseLoadedCount.cs
@@ -1,4 +1,3 @@
-using System.Linq;
 using Lextm.SharpSnmpLib;
 using Raven.Server.Documents;
 
@@ -21,7 +20,7 @@ namespace Raven.Server.Monitoring.Snmp.Objects.Documents
 
         private static int GetCount(DatabasesLandlord landlord)
         {
-            return landlord.DatabasesCache.Values.Count();
+            return landlord.DatabasesCache.Count;
         }
     }
 }

--- a/src/Raven.Server/ServerWide/Commands/Monitoring/Snmp/AddDatabasesToSnmpMappingCommand.cs
+++ b/src/Raven.Server/ServerWide/Commands/Monitoring/Snmp/AddDatabasesToSnmpMappingCommand.cs
@@ -1,0 +1,63 @@
+﻿using System.Collections.Generic;
+using Raven.Client;
+using Sparrow.Json;
+using Sparrow.Json.Parsing;
+
+namespace Raven.Server.ServerWide.Commands.Monitoring.Snmp
+{
+    public class AddDatabasesToSnmpMappingCommand : UpdateValueCommand<List<string>>
+    {
+        public AddDatabasesToSnmpMappingCommand()
+        {
+            Name = Constants.Monitoring.Snmp.MappingKey;
+        }
+
+        public AddDatabasesToSnmpMappingCommand(List<string> databases)
+            : this()
+        {
+            Value = databases;
+        }
+
+        public override object ValueToJson()
+        {
+            if (Value == null)
+                return null;
+
+            return new DynamicJsonArray(Value);
+        }
+
+        public override BlittableJsonReaderObject OnUpdate(JsonOperationContext context, BlittableJsonReaderObject previousValue)
+        {
+            if (previousValue != null)
+            {
+                if (previousValue.Modifications == null)
+                    previousValue.Modifications = new DynamicJsonValue();
+
+                AddDatabasesIfNecessary(previousValue.Modifications, previousValue, Value);
+
+                if (previousValue.Modifications.Properties.Count == 0)
+                    return null;
+
+                return context.ReadObject(previousValue, Name);
+            }
+
+            var djv = new DynamicJsonValue();
+            if (Value != null)
+                AddDatabasesIfNecessary(djv, null, Value);
+
+            return context.ReadObject(djv, Name);
+        }
+
+        private static void AddDatabasesIfNecessary(DynamicJsonValue djv, BlittableJsonReaderObject previousValue, List<string> databases)
+        {
+            if (databases == null)
+                return;
+
+            foreach (var database in databases)
+            {
+                if (previousValue == null || previousValue.TryGet(database, out long _) == false)
+                    djv[database] = djv.Properties.Count + 1;
+            }
+        }
+    }
+}

--- a/src/Raven.Server/ServerWide/Commands/UpdateValueCommand.cs
+++ b/src/Raven.Server/ServerWide/Commands/UpdateValueCommand.cs
@@ -1,0 +1,25 @@
+﻿using Sparrow.Json;
+using Sparrow.Json.Parsing;
+
+namespace Raven.Server.ServerWide.Commands
+{
+    public abstract class UpdateValueCommand<T> : CommandBase
+    {
+        public string Name;
+
+        public T Value;
+
+        public override DynamicJsonValue ToJson(JsonOperationContext context)
+        {
+            var djv = base.ToJson(context);
+            djv[nameof(Name)] = Name;
+            djv[nameof(Value)] = ValueToJson();
+
+            return djv;
+        }
+
+        public abstract object ValueToJson();
+
+        public abstract BlittableJsonReaderObject OnUpdate(JsonOperationContext context, BlittableJsonReaderObject previousValue);
+    }
+}

--- a/src/Raven.Server/ServerWide/JsonDeserializationCluster.cs
+++ b/src/Raven.Server/ServerWide/JsonDeserializationCluster.cs
@@ -11,6 +11,7 @@ using Raven.Server.ServerWide.Commands;
 using Raven.Server.ServerWide.Commands.ConnectionStrings;
 using Raven.Server.ServerWide.Commands.ETL;
 using Raven.Server.ServerWide.Commands.Indexes;
+using Raven.Server.ServerWide.Commands.Monitoring.Snmp;
 using Raven.Server.ServerWide.Commands.PeriodicBackup;
 using Raven.Server.ServerWide.Commands.Subscriptions;
 using Sparrow.Json;
@@ -100,7 +101,8 @@ namespace Raven.Server.ServerWide
             [nameof(RemoveRavenConnectionString)] = GenerateJsonDeserializationRoutine<RemoveRavenConnectionString>(),
             [nameof(RemoveSqlConnectionString)] = GenerateJsonDeserializationRoutine<RemoveSqlConnectionString>(),
             [nameof(RemoveNodeFromClusterCommand)] = GenerateJsonDeserializationRoutine<RemoveNodeFromClusterCommand>(),
-            [nameof(UpdateSubscriptionClientConnectionTime)] = GenerateJsonDeserializationRoutine<UpdateSubscriptionClientConnectionTime>()
+            [nameof(UpdateSubscriptionClientConnectionTime)] = GenerateJsonDeserializationRoutine<UpdateSubscriptionClientConnectionTime>(),
+            [nameof(AddDatabasesToSnmpMappingCommand)] = GenerateJsonDeserializationRoutine<AddDatabasesToSnmpMappingCommand>()
         };
     }
 }


### PR DESCRIPTION
- monitoring/snmp/mapping is kept in cluster to get consistent database indexes
- using ConcurrentDictionry.Count instead of ConcurrentDictionary.Values.Count() in DatabaseLoadedCount