### PR TITLE
RavenDB-8713 Fixing case sensitivity of QueryMetadata.WhereFields (te…

### DIFF
--- a/src/Raven.Server/Documents/Queries/Dynamic/DynamicQueryMapping.cs
+++ b/src/Raven.Server/Documents/Queries/Dynamic/DynamicQueryMapping.cs
@@ -133,7 +133,7 @@ namespace Raven.Server.Documents.Queries.Dynamic
                 ForCollection = query.Metadata.CollectionName
             };
 
-            var mapFields = new Dictionary<string, DynamicQueryMappingItem>();
+            var mapFields = new Dictionary<string, DynamicQueryMappingItem>(StringComparer.Ordinal);
 
             foreach (var field in query.Metadata.IndexFieldNames)
             {
@@ -220,7 +220,7 @@ namespace Raven.Server.Documents.Queries.Dynamic
                 }
             }
 
-            var result = new Dictionary<string, DynamicQueryMappingItem>(groupByFields.Length);
+            var result = new Dictionary<string, DynamicQueryMappingItem>(groupByFields.Length, StringComparer.Ordinal);
 
             for (int i = 0; i < groupByFields.Length; i++)
             {

--- a/src/Raven.Server/Documents/Queries/FieldsToFetch.cs
+++ b/src/Raven.Server/Documents/Queries/FieldsToFetch.cs
@@ -161,7 +161,7 @@ namespace Raven.Server.Documents.Queries
             if (selectFields == null || selectFields.Length == 0)
                 return null;
 
-            var result = new Dictionary<string, FieldToFetch>();
+            var result = new Dictionary<string, FieldToFetch>(StringComparer.Ordinal);
             singleFieldNoAlias = selectFields.Length == 1 &&
                                  selectFields[0].Alias == null &&
                                  selectFields[0].Function != null;

--- a/src/Raven.Server/Documents/Queries/QueryMetadata.cs
+++ b/src/Raven.Server/Documents/Queries/QueryMetadata.cs
@@ -72,9 +72,9 @@ namespace Raven.Server.Documents.Queries
 
         public readonly string QueryText;
 
-        public readonly HashSet<string> IndexFieldNames = new HashSet<string>();
+        public readonly HashSet<string> IndexFieldNames = new HashSet<string>(StringComparer.Ordinal);
 
-        public readonly Dictionary<string, WhereField> WhereFields = new Dictionary<string, WhereField>(StringComparer.OrdinalIgnoreCase);
+        public readonly Dictionary<string, WhereField> WhereFields = new Dictionary<string, WhereField>(StringComparer.Ordinal);
 
         public string[] GroupBy;
 

--- a/src/Sparrow/Json/JsonDeserializationBase.cs
+++ b/src/Sparrow/Json/JsonDeserializationBase.cs
@@ -282,7 +282,7 @@ namespace Sparrow.Json
         private static Dictionary<TK, TV> ToDictionary<TK, TV>(BlittableJsonReaderObject json, string name, Func<BlittableJsonReaderObject, TV> converter)
         {
             var isStringKey = typeof(TK) == typeof(string);
-            var dictionary = new Dictionary<TK, TV>();
+            var dictionary = new Dictionary<TK, TV>((IEqualityComparer<TK>)StringComparer.Ordinal); // we need to deserialize it as we got it, keys could be case sensitive - RavenDB-8713
 
             BlittableJsonReaderObject obj;
             if (json.TryGet(name, out obj) == false || obj == null)


### PR DESCRIPTION
…st added). In indexing / querying code setting explicitly that dicts keeping field names are case sensitive.