### PR TITLE
RavenDB-8260: Remove volatile usages

### DIFF
--- a/src/Raven.Server/ServerWide/ClusterStateMachine.cs
+++ b/src/Raven.Server/ServerWide/ClusterStateMachine.cs
@@ -1204,12 +1204,12 @@ namespace Raven.Server.ServerWide
                     _notifiedListeners.WaitAsync() :
                     _notifiedListeners.WaitAsync(timeout.Value);
 
-                if (index <= Volatile.Read(ref LastModifiedIndex))
+                if (index <= Interlocked.Read(ref LastModifiedIndex))
                     break;
 
                 if (await waitAsync == false)
                 {
-                    var copy = Volatile.Read(ref LastModifiedIndex);
+                    var copy = Interlocked.Read(ref LastModifiedIndex);
                     if (index <= copy)
                         break;
                     ThrowTimeoutException(timeout ?? TimeSpan.MaxValue, index, copy);

--- a/src/Voron/GlobalFlushingBehavior.cs
+++ b/src/Voron/GlobalFlushingBehavior.cs
@@ -154,7 +154,7 @@ namespace Voron
 
                 // we have mutliple threads racing for this value, no a concern, the last one wins is probably
                 // going to be the latest, or close enough that we don't care
-                Volatile.Write(ref req.Env.LastSyncTimeInTicks, DateTime.UtcNow.Ticks);
+                Interlocked.Exchange(ref req.Env.LastSyncTimeInTicks, DateTime.UtcNow.Ticks);
             }
         }
 
@@ -199,7 +199,7 @@ namespace Voron
                 if (envToFlush.Disposed || envToFlush.Options.ManualFlushing)
                     continue;
 
-                var sizeOfUnflushedTransactionsInJournalFile = Volatile.Read(ref envToFlush.SizeOfUnflushedTransactionsInJournalFile);
+                var sizeOfUnflushedTransactionsInJournalFile = envToFlush.SizeOfUnflushedTransactionsInJournalFile;
 
                 if (sizeOfUnflushedTransactionsInJournalFile == 0)
                     continue; // nothing to do

--- a/src/Voron/Impl/Journal/JournalFile.cs
+++ b/src/Voron/Impl/Journal/JournalFile.cs
@@ -47,7 +47,7 @@ namespace Voron.Impl.Journal
         }
 
 
-        internal long WritePosIn4KbPosition => Volatile.Read(ref _writePosIn4Kb);
+        internal long WritePosIn4KbPosition => Interlocked.Read(ref _writePosIn4Kb);
 
         public long Number { get; }
 

--- a/src/Voron/Util/ActiveTransactions.cs
+++ b/src/Voron/Util/ActiveTransactions.cs
@@ -154,7 +154,7 @@ namespace Voron.Util
 
         public bool Contains(LowLevelTransaction tx)
         {
-            return Volatile.Read(ref tx.ActiveTransactionNode.Transaction) == tx;
+            return tx.ActiveTransactionNode.Transaction == tx;
         }
 
         public bool TryRemove(LowLevelTransaction tx)

--- a/src/Voron/Util/PageTable.cs
+++ b/src/Voron/Util/PageTable.cs
@@ -184,7 +184,7 @@ namespace Voron.Util
 
         public long GetLastSeenTransactionId()
         {
-            return Volatile.Read(ref _maxSeenTransaction);
+            return Interlocked.Read(ref _maxSeenTransaction);
         }
 
         public List<Dictionary<long, PagePosition>> GetModifiedPagesForTransactionRange(long minTxInclusive, long maxTxInclusive)


### PR DESCRIPTION
I have left some intentionally inside of data structures; I assume these are intentional.