### PR TITLE
RavenDB-8741

### DIFF
--- a/src/Raven.Server/Documents/Indexes/MapReduce/ReduceKeyProcessor.cs
+++ b/src/Raven.Server/Documents/Indexes/MapReduce/ReduceKeyProcessor.cs
@@ -1,4 +1,5 @@
 ﻿using System;
+using System.Collections;
 using System.Runtime.CompilerServices;
 using Raven.Server.Documents.Indexes.Static;
 using Raven.Server.ServerWide;
@@ -214,6 +215,12 @@ namespace Raven.Server.Documents.Indexes.MapReduce
                 return;
             }
 
+            if (value is LazyNumberValue lnv)
+            {
+                Process(context, lnv.Inner, true);
+                return;
+            }
+
             long? ticks = null;
             if (value is DateTime)
                 ticks = ((DateTime)value).Ticks;
@@ -238,9 +245,7 @@ namespace Raven.Server.Documents.Indexes.MapReduce
                 return;
             }
 
-            var json = value as BlittableJsonReaderObject;
-
-            if (json != null)
+            if (value is BlittableJsonReaderObject json)
             {
                 _mode = Mode.MultipleValues;
 
@@ -260,16 +265,14 @@ namespace Raven.Server.Documents.Indexes.MapReduce
                 return;
             }
 
-            var array = value as DynamicJsonArray;
-
-            if (array != null)
+            if (value is IEnumerable enumerable)
             {
                 _mode = Mode.MultipleValues;
 
                 if (_buffer == null)
                     _buffer = _buffersPool.Allocate(16);
 
-                foreach (var item in array)
+                foreach (var item in enumerable)
                 {
                     Process(context, item, true);
                 }

--- a/test/SlowTests/Issues/RavenDB_8741.cs
+++ b/test/SlowTests/Issues/RavenDB_8741.cs
@@ -1,0 +1,106 @@
+﻿using System.Linq;
+using FastTests;
+using Xunit;
+
+namespace SlowTests.Issues
+{
+    public class RavenDB_8741 : RavenTestBase
+    {
+        [Fact]
+        public void Can_group_by_array()
+        {
+            using (var store = GetDocumentStore())
+            {
+                using (var session = store.OpenSession())
+                {
+                    session.Store(new Item
+                    {
+                        Tags = new []{ "a", "c"}
+                    });
+
+                    session.Store(new Item
+                    {
+                        Tags = new[] { "a", "b" }
+                    });
+
+                    session.Store(new Item
+                    {
+                        Tags = new[] { "a", "b" }
+                    });
+
+                    session.SaveChanges();
+
+                    var results = session.Query<Item>().Customize(x => x.WaitForNonStaleResults())
+                        .GroupBy(x => x.Tags).Select(x =>
+                        new
+                        {
+                            Count = x.Count(),
+                            Tags = x.Key
+                        }).
+                        OrderBy(x => x.Count)
+                        .ToList();
+
+                    Assert.Equal(2, results.Count);
+
+                    Assert.Equal(new[] { "a", "c" }, results[0].Tags);
+                    Assert.Equal(1, results[0].Count);
+
+                    Assert.Equal(new[] { "a", "b" }, results[1].Tags);
+                    Assert.Equal(2, results[1].Count);
+                }
+            }
+        }
+
+        [Fact]
+        public void Can_group_by_lazy_double_value()
+        {
+            using (var store = GetDocumentStore())
+            {
+                using (var session = store.OpenSession())
+                {
+                    session.Store(new Item
+                    {
+                        DoubleVal = 1.1
+                    });
+
+                    session.Store(new Item
+                    {
+                        DoubleVal = 1.2
+                    });
+
+                    session.Store(new Item
+                    {
+                        DoubleVal = 1.2
+                    });
+
+                    session.SaveChanges();
+
+                    var results = session.Query<Item>().Customize(x => x.WaitForNonStaleResults())
+                        .GroupBy(x => x.DoubleVal).Select(x =>
+                            new
+                            {
+                                Count = x.Count(),
+                                Value = x.Key
+                            }).
+                        OrderBy(x => x.Count)
+                        .ToList();
+
+                    Assert.Equal(2, results.Count);
+
+                    Assert.Equal(1.1, results[0].Value);
+                    Assert.Equal(1, results[0].Count);
+
+                    Assert.Equal(1.2, results[1].Value);
+                    Assert.Equal(2, results[1].Count);
+                }
+            }
+        }
+
+        private class Item
+        {
+            public string[] Tags { get; set; }
+
+            public double DoubleVal { get; set; }
+        }
+    }
+}


### PR DESCRIPTION
- support grouping by arrays
- we cannot dispose a map result right after we put it into in-memory aggregation batch because we a valid pointer on write (the problem was that the parent of blittable array was already disposed so it's pointer was null while we needed to to retrieve array items)
- support grouping by doubles