### PR TITLE
Revert "RavenDB-8692 Watch task works faster without running the test…

### DIFF
--- a/src/Raven.Studio/gulpfile.js
+++ b/src/Raven.Studio/gulpfile.js
@@ -234,7 +234,7 @@ gulp.task('z_mochaTests', function () {
 });
 
 gulp.task('test', [ 'z_compile:test' ], function (cb) {
-    return runSequence('z_generate-test-list', /*'z_mochaTests', */cb);
+    return runSequence('z_generate-test-list', 'z_mochaTests', cb);
 });
 
 gulp.task('z_watch:test', ['test'], function () {


### PR DESCRIPTION
…s. We might want to add here a throttling to run tests only if there is no changes for 30 seconds."

This reverts commit 74a51214d3f4a232c646b78f24887d62397bd5e5.