### PR TITLE
RavenDB-7890 External replication need to support destination failover

### DIFF
--- a/src/Raven.Client/Documents/Replication/ReplicationNode.cs
+++ b/src/Raven.Client/Documents/Replication/ReplicationNode.cs
@@ -10,27 +10,22 @@ using Sparrow.Json.Parsing;
 
 namespace Raven.Client.Documents.Replication
 {
+    /// <inheritdoc />
     /// <summary>
     /// Data class for replication destination
     /// </summary>
     public abstract class ReplicationNode : IEquatable<ReplicationNode>
     {
-        /// <summary>
-        /// The name of the connection string specified in the 
-        /// server configuration file. 
-        /// Override all other properties of the destination
-        /// </summary>
-
-        private string _url;
+        protected string LastKnownUrl;
 
         /// <summary>
         /// Gets or sets the URL of the replication destination
         /// </summary>
         /// <value>The URL.</value>
-        public string Url
+        public virtual string Url
         {
-            get => _url;
-            set => _url = value?.TrimEnd('/');
+            get => LastKnownUrl;
+            set => LastKnownUrl = value?.TrimEnd('/');
         }
 
         /// <summary>

--- a/src/Raven.Client/ServerWide/Commands/GetTopologyCommand.cs
+++ b/src/Raven.Client/ServerWide/Commands/GetTopologyCommand.cs
@@ -8,15 +8,17 @@ namespace Raven.Client.ServerWide.Commands
     public class GetTopologyCommand : RavenCommand<Topology>
     {
         private readonly string _forcedUrl;
+        private readonly string _database;
 
-        public GetTopologyCommand(string forcedUrl = null)
+        public GetTopologyCommand(string forcedUrl = null, string database = null)
         {
             _forcedUrl = forcedUrl;
+            _database = database;
         }
 
         public override HttpRequestMessage CreateRequest(JsonOperationContext ctx, ServerNode node, out string url)
         {
-            url = $"{node.Url}/topology?name={node.Database}";
+            url = $"{node.Url}/topology?name={_database ?? node.Database}";
             if (string.IsNullOrEmpty(_forcedUrl) == false)
             {
                 url += $"&url={_forcedUrl}";

--- a/src/Raven.Client/ServerWide/ExternalReplication.cs
+++ b/src/Raven.Client/ServerWide/ExternalReplication.cs
@@ -1,4 +1,5 @@
-﻿using System.Collections.Generic;
+﻿using System;
+using System.Collections.Generic;
 using System.Linq;
 using Raven.Client.Documents.Replication;
 using Sparrow.Json;
@@ -10,7 +11,18 @@ namespace Raven.Client.ServerWide
     {
         public long TaskId;
         public string Name;
+        public string[] TopologyDiscoveryUrls;
         public string MentorNode;
+
+        public ExternalReplication() { }
+
+        public ExternalReplication(string[] urls)
+        {
+            if(urls == null || urls.Length == 0)
+                throw new ArgumentNullException(nameof(TopologyDiscoveryUrls));
+
+            TopologyDiscoveryUrls = urls;
+        }
 
         public static void RemoveWatcher(ref List<ExternalReplication> watchers, long taskId)
         {
@@ -22,7 +34,7 @@ namespace Raven.Client.ServerWide
                 return;
             }
         }
-
+        
         public static void EnsureUniqueDbAndUrl(List<ExternalReplication> watchers, ExternalReplication watcher)
         {
             var dbName = watcher.Database;
@@ -66,13 +78,14 @@ namespace Raven.Client.ServerWide
             return (addDestinations, removeDestinations);
         }
 
-
         public override DynamicJsonValue ToJson()
         {
             var json = base.ToJson();
             json[nameof(TaskId)] = TaskId;
             json[nameof(Name)] = Name;
+            json[nameof(LastKnownUrl)] = LastKnownUrl;
             json[nameof(MentorNode)] = MentorNode;
+            json[nameof(TopologyDiscoveryUrls)] = new DynamicJsonArray(TopologyDiscoveryUrls);
             return json;
         }
 

--- a/src/Raven.Server/Documents/Replication/OutgoingReplicationHandler.cs
+++ b/src/Raven.Server/Documents/Replication/OutgoingReplicationHandler.cs
@@ -1,5 +1,6 @@
 ﻿using System;
 using System.Collections.Concurrent;
+using System.Collections.Generic;
 using System.Diagnostics;
 using System.IO;
 using System.Linq;
@@ -12,6 +13,7 @@ using Raven.Client.Documents.Replication.Messages;
 using Raven.Client.Exceptions.Database;
 using Raven.Client.Extensions;
 using Raven.Client.ServerWide;
+using Raven.Client.ServerWide.Commands;
 using Raven.Client.ServerWide.Tcp;
 using Raven.Client.Util;
 using Raven.Server.Json;
@@ -21,6 +23,7 @@ using Sparrow.Json.Parsing;
 using Sparrow.Logging;
 using Raven.Server.NotificationCenter.Notifications;
 using Raven.Server.NotificationCenter.Notifications.Details;
+using Raven.Server.ServerWide.Commands;
 using Raven.Server.Utils;
 using Sparrow;
 using Sparrow.Threading;
@@ -70,6 +73,7 @@ namespace Raven.Server.Documents.Replication
 
         private readonly ConcurrentQueue<OutgoingReplicationStatsAggregator> _lastReplicationStats = new ConcurrentQueue<OutgoingReplicationStatsAggregator>();
         private OutgoingReplicationStatsAggregator _lastStats;
+        public TcpConnectionInfo ConnectionInfo;
 
         public OutgoingReplicationHandler(ReplicationLoader parent, DocumentDatabase database, ReplicationNode node, bool external)
         {
@@ -115,18 +119,29 @@ namespace Raven.Server.Documents.Replication
             return node?.NodeTag;
         }
 
+        private void UpdateLastExternalDestination(ExternalReplication node)
+        {
+            _parent._server.SendToLeaderAsync(new UpdateExternalReplicationCommandSilently(_database.Name, node.TaskId, node.Url));
+        }
+
+
         private void ReplicateToDestination()
         {
             AddReplicationPulse(ReplicationPulseDirection.OutgoingInitiate);
-
             NativeMemory.EnsureRegistered();
             try
             {
-                var connectionInfo = ReplicationUtils.GetTcpInfo(Destination.Url, GetNode(), "Replication",
-                    _parent._server.Server.ClusterCertificateHolder.Certificate);
+                if (ConnectionInfo == null)
+                {
+                    ConnectionInfo = ReplicationUtils.GetTcpInfo(Destination.Url, GetNode(), "Replication",
+                        _parent._server.Server.ClusterCertificateHolder.Certificate);
+                }
+
+                if(Destination is ExternalReplication exNode)
+                    UpdateLastExternalDestination(exNode);
 
                 if (_log.IsInfoEnabled)
-                    _log.Info($"Will replicate to {Destination.FromString()} via {connectionInfo.Url}");
+                    _log.Info($"Will replicate to {Destination.FromString()} via {ConnectionInfo.Url}");
 
                 using (_parent._server.ContextPool.AllocateOperationContext(out TransactionOperationContext context))
                 using (context.OpenReadTransaction())
@@ -140,11 +155,11 @@ namespace Raven.Server.Documents.Replication
                             $"{record.DatabaseName} is encrypted, and require HTTPS for replication, but had endpoint with url {Destination.Url} to database {Destination.Database}");
                 }
 
-                var task = TcpUtils.ConnectSocketAsync(connectionInfo, _parent._server.Engine.TcpConnectionTimeout, _log);
+                var task = TcpUtils.ConnectSocketAsync(ConnectionInfo, _parent._server.Engine.TcpConnectionTimeout, _log);
                 task.Wait(CancellationToken);
                 using (_tcpClient = task.Result)
                 {
-                    var wrapSsl = TcpUtils.WrapStreamWithSslAsync(_tcpClient, connectionInfo, _parent._server.Server.ClusterCertificateHolder.Certificate);
+                    var wrapSsl = TcpUtils.WrapStreamWithSslAsync(_tcpClient, ConnectionInfo, _parent._server.Server.ClusterCertificateHolder.Certificate);
 
                     wrapSsl.Wait(CancellationToken);
 
@@ -727,7 +742,7 @@ namespace Raven.Server.Documents.Replication
             _waitForChanges.Set();
         }
 
-        private SingleUseFlag _disposed = new SingleUseFlag();
+        private readonly SingleUseFlag _disposed = new SingleUseFlag();
         private readonly DateTime _startedAt = DateTime.UtcNow;
 
         public void Dispose()

--- a/src/Raven.Server/ServerWide/JsonDeserializationCluster.cs
+++ b/src/Raven.Server/ServerWide/JsonDeserializationCluster.cs
@@ -73,6 +73,7 @@ namespace Raven.Server.ServerWide
             [nameof(ModifyConflictSolverCommand)] = GenerateJsonDeserializationRoutine<ModifyConflictSolverCommand>(),
             [nameof(UpdateTopologyCommand)] = GenerateJsonDeserializationRoutine<UpdateTopologyCommand>(),
             [nameof(UpdateExternalReplicationCommand)] = GenerateJsonDeserializationRoutine<UpdateExternalReplicationCommand>(),
+            [nameof(UpdateExternalReplicationCommandSilently)] = GenerateJsonDeserializationRoutine<UpdateExternalReplicationCommandSilently>(),
             [nameof(PromoteDatabaseNodeCommand)] = GenerateJsonDeserializationRoutine<PromoteDatabaseNodeCommand>(),
             [nameof(ToggleTaskStateCommand)] = GenerateJsonDeserializationRoutine<ToggleTaskStateCommand>(),
             [nameof(AddDatabaseCommand)] = GenerateJsonDeserializationRoutine<AddDatabaseCommand>(),

--- a/test/FastTests/Server/Replication/ReplicationTestBase.cs
+++ b/test/FastTests/Server/Replication/ReplicationTestBase.cs
@@ -203,10 +203,9 @@ namespace FastTests.Server.Replication
             var resList = new List<ModifyOngoingTaskResult>();
             foreach (var store in toStores)
             {
-                var databaseWatcher = new ExternalReplication
+                var databaseWatcher = new ExternalReplication(store.Urls)
                 {
-                    Database = store.Database,
-                    Url = store.Urls[0]
+                    Database = store.Database
                 };
                 ModifyReplicationDestination(databaseWatcher);
                 tasks.Add(AddWatcherToReplicationTopology(fromStore, databaseWatcher));
@@ -252,10 +251,9 @@ namespace FastTests.Server.Replication
         {
             foreach (var node in toNodes)
             {
-                var databaseWatcher = new ExternalReplication
+                var databaseWatcher = new ExternalReplication(new []{node.Url})
                 {
-                    Database = node.Database,
-                    Url = node.Url,
+                    Database = node.Database
                 };
                 await AddWatcherToReplicationTopology(fromStore, databaseWatcher);
             }

--- a/test/RachisTests/AddNodeToClusterTests.cs
+++ b/test/RachisTests/AddNodeToClusterTests.cs
@@ -61,10 +61,9 @@ namespace RachisTests
                 Conventions = conventions
             }.Initialize();
 
-            var watcher = new ExternalReplication
+            var watcher = new ExternalReplication(new string[]{ watcherDb.Item2.Single().WebUrl })
             {
                 Database = "WatcherDB",
-                Url = watcherDb.Item2.Single().WebUrl
             };
 
             var watcherRes = await AddWatcherToReplicationTopology((DocumentStore)leaderStore, watcher);

--- a/test/RachisTests/DatabaseCluster/OngoingTasks.cs
+++ b/test/RachisTests/DatabaseCluster/OngoingTasks.cs
@@ -59,10 +59,9 @@ loadToOrders(orderData);
                     await server.ServerStore.DatabasesLandlord.TryGetOrCreateResourceStore(databaseName);
                 }
 
-                watcher = new ExternalReplication
+                watcher = new ExternalReplication(new []{ "http://127.0.0.1:9090" })
                 {
                     Database = "Watcher1",
-                    Url = "http://127.0.0.1:9090",
                     Name = "MyExternalReplication"
                 };
 
@@ -216,10 +215,9 @@ loadToOrders(orderData);
                     await server.ServerStore.DatabasesLandlord.TryGetOrCreateResourceStore(databaseName);
                 }
 
-                var watcher = new ExternalReplication
+                var watcher = new ExternalReplication(new []{ "http://127.0.0.1:9090" })
                 {
                     Database = "Watcher1",
-                    Url = "http://127.0.0.1:9090"
                 };
 
                 addWatcherRes = await AddWatcherToReplicationTopology((DocumentStore)store, watcher);

--- a/test/SlowTests/Issues/RavenDB-5730.cs
+++ b/test/SlowTests/Issues/RavenDB-5730.cs
@@ -48,10 +48,9 @@ namespace SlowTests.Issues
 
         private void DoReplicationTest(DocumentStore storeA, DocumentStore storeB, string url)
         {
-            var watcher = new ExternalReplication
+            var watcher = new ExternalReplication(new []{url})
             {                
                 Database = storeB.Database,
-                Url = url,               
             };
 
             AddWatcherToReplicationTopology(storeA, watcher).ConfigureAwait(false);


### PR DESCRIPTION
- External replication recives now an array of urls to work with.
The inital urls refer to external cluster nodes, where we fetch the database group topology.
Then we replicate to the first responsive node in that group,
once this node is down we repeat this prcocess until we have a responsive node to replicate to.