### PR TITLE
RavenDB-8783 add ubuntu docker image with openssh for remote debugging

### DIFF
--- a/build.ps1
+++ b/build.ps1
@@ -9,6 +9,7 @@ param(
     [switch]$DontBuildStudio,
     [switch]$JustStudio,
     [switch]$JustNuget,
+    [switch]$Debug,
     [switch]$Help)
 
 $ErrorActionPreference = "Stop"
@@ -136,8 +137,8 @@ Foreach ($spec in $targets) {
     $specOutDir = [io.path]::combine($OUT_DIR, $spec.Name)
     CleanDir $specOutDir
 
-    BuildServer $SERVER_SRC_DIR $specOutDir $spec
-    BuildRvn $RVN_SRC_DIR $specOutDir $spec
+    BuildServer $SERVER_SRC_DIR $specOutDir $spec $Debug
+    BuildRvn $RVN_SRC_DIR $specOutDir $spec $Debug
     
     $specOutDirs = @{
         "Main" = $specOutDir;

--- a/docker/debug/build-ubuntu-1604-debug.ps1
+++ b/docker/debug/build-ubuntu-1604-debug.ps1
@@ -1,0 +1,76 @@
+$ErrorActionPreference = 'Stop'
+
+function Get-ScriptDirectory {
+    $Invocation = (Get-Variable MyInvocation -Scope 1).Value
+    Split-Path $Invocation.MyCommand.Path
+}
+
+function CheckLastExitCode {
+    param ([int[]]$SuccessCodes = @(0), [scriptblock]$CleanupScript = $null)
+
+    if ($SuccessCodes -notcontains $LastExitCode) {
+        if ($CleanupScript) {
+            "Executing cleanup script: $CleanupScript"
+            &$CleanupScript
+        }
+        $msg = @"
+EXE RETURNED EXIT CODE $LastExitCode
+CALLSTACK:$(Get-PSCallStack | Out-String)
+"@
+        throw $msg
+    }
+}
+
+$scriptDir = Get-ScriptDirectory
+
+$projectDir = [io.path]::combine($scriptDir, "../..")
+$dockerDir = [io.path]::combine($projectDir, "docker")
+$debugDockerDir = [io.path]::combine($projectDir, "docker", "debug")
+$debugDockerfileDir = [io.path]::combine($projectDir, "docker", "debug", "ravendb-ubuntu1604-debug")
+
+$pkgFile = [io.path]::combine($projectDir, "artifacts", "RavenDB-4.0.0-custom-40-ubuntu.16.04-x64.tar.bz2")
+
+if ($(Test-Path $pkgFile) -eq $False) {
+
+    Push-Location .
+
+    try {
+        Set-Location $projectDir
+        .\build.ps1 -Ubuntu16 -Debug
+        CheckLastExitCode
+        write-host "Built RavenDB in Debug"
+    }
+    finally {
+        Pop-Location
+    }
+
+} else {
+    write-host "Found RavenDB server in artifacts. Building image with whatever is in $pkgFile."
+}
+
+Push-Location .
+try {
+    Set-Location $dockerDir
+    .\build-ubuntu1604.ps1
+    CheckLastExitCode
+    write-host "Built RavenDB Ubuntu 16.04 docker image."
+}
+finally {
+    Pop-Location 
+}
+
+Push-Location .
+
+$dockerDebugTag = "ravendb/ravendb:ubuntu1604-debug"
+
+try {
+    Set-Location $debugDockerDir
+    docker build -t "$dockerDebugTag" "$debugDockerfileDir"
+    CheckLastExitCode
+}
+finally {
+    Pop-Location 
+}
+
+write-host "Built docker debug image $dockerDebugTag"
+

--- a/docker/debug/ravendb-ubuntu1604-debug/Dockerfile
+++ b/docker/debug/ravendb-ubuntu1604-debug/Dockerfile
@@ -1,0 +1,12 @@
+FROM ravendb/ravendb:ubuntu-latest
+
+EXPOSE 22 8080 38888
+
+# install SSH server and set root password to 'debug'
+RUN apt-get update && \
+    apt-get install -y openssh-server unzip curl && \
+    sh -c "echo 'root:debug' | chpasswd" && \
+    sed -i '/PermitRootLogin/c\PermitRootLogin yes' /etc/ssh/sshd_config
+
+CMD service ssh start && \
+    /opt/RavenDB/run-raven.sh

--- a/scripts/buildProjects.ps1
+++ b/scripts/buildProjects.ps1
@@ -1,4 +1,4 @@
-function BuildServer ( $srcDir, $outDir, $spec ) {
+function BuildServer ( $srcDir, $outDir, $spec, $debug ) {
     write-host "Building Server for $($spec.Name)..."
     $command = "dotnet" 
     $commandArgs = @( "publish" )
@@ -6,7 +6,10 @@ function BuildServer ( $srcDir, $outDir, $spec ) {
     $output = [io.path]::combine($outDir, "Server");
     $quotedOutput = '"' + $output + '"'
     $commandArgs += @( "--output", $quotedOutput )
-    $commandArgs += @( "--configuration", "Release" )
+
+    $configuration = if ($debug) { 'Debug' } else { 'Release' }
+    $commandArgs += @( "--configuration", $configuration )
+    
     $commandArgs += $( "--runtime", "$($spec.Runtime)" )
     $commandArgs += "$srcDir"
 
@@ -88,7 +91,8 @@ function BuildRvn ( $srcDir, $outDir, $spec ) {
     $output = [io.path]::combine($outDir, "rvn");
     $quotedOutput = '"' + $output + '"'
     $commandArgs += @( "--output", $quotedOutput )
-    $commandArgs += @( "--configuration", "Release" )
+    $configuration = if ($debug) { 'Debug' } else { 'Release' }
+    $commandArgs += @( "--configuration", $configuration )
     $commandArgs += $( "--runtime", "$($spec.Runtime)" )
     $commandArgs += "$srcDir"
 

--- a/scripts/certificates/obtain-cluster-admin-client-cert.ps1
+++ b/scripts/certificates/obtain-cluster-admin-client-cert.ps1
@@ -37,6 +37,18 @@ write-host "POST $url"
 write-host 
 write-host $payload
 
+[Net.ServicePointManager]::ServerCertificateValidationCallback = [System.Net.Security.RemoteCertificateValidationCallback] {
+        param($sender, $certificate, $chain, $sslPolicyErrors)
+    
+        # validate whether server cert is used for obtaining client cert
+        $result = $certificate.Thumbprint -eq $serverCert.Thumbprint
+        if ($result -eq $False) {
+            throw "Certificate used for obtaining client certificate must be same as server certificate."
+        }
+    
+        return $result
+    }
+
 Invoke-WebRequest `
     -Method POST `
     -Certificate $serverCert `


### PR DESCRIPTION
Steps:

0. Make sure your `artifacts` dir is either empty OR it contains `RavenDB-4.0.0-custom-40-ubuntu.16.04-x64.tar.bz2` file built originated from `.\build.ps1 -Debug` (don't worry if you don't have that, step 1 will build it for you)

1. Build RavenDB for Ubuntu in debug, create regular docker image, create another image based on the first one with `sshd` running with:
```
.\docker\debug\build-ubuntu-1604-debug.ps1
```

2. Run your container. Basic run command would look like this:
`docker run -p 40022:22 -p 8080:8080 -p 38888:38888 ravendb/ravendb:ubuntu1604-debug`

Add any additional options you need (cert info etc.). Make sure port 22 is exposed like in the above command (`-p 40022:22`)

3. [Debug](https://blogs.msdn.microsoft.com/devops/2017/01/26/debugging-net-core-on-unix-over-ssh/)

Connection Type: SSH
Connection Target: 10.0.75.2
Port: 40022 (if using above mapping)

Note about SSH access - user: root, password: debug