### PR TITLE
RavenDB-8052: Make client retry connection, if it received a "null" i…

### DIFF
--- a/src/Raven.Client/Documents/Subscriptions/Subscription.cs
+++ b/src/Raven.Client/Documents/Subscriptions/Subscription.cs
@@ -659,6 +659,10 @@ namespace Raven.Client.Documents.Subscriptions
             {
                 case SubscriptionDoesNotBelongToNodeException se:
                     var requestExecutor = _store.GetRequestExecutor(_dbName);
+
+                    if (se.AppropriateNode == null)
+                        return true;
+
                     var nodeToRedirectTo = requestExecutor.TopologyNodes
                         .FirstOrDefault(x => x.ClusterTag == se.AppropriateNode);
                     _redirectNode = nodeToRedirectTo ?? throw new AggregateException(ex,


### PR DESCRIPTION
…n the responsible node, meaning that the database is up, but the topology is not updated yet for some reason