### PR TITLE
RavenDB-8900 Error combining ShardedBulkInsert and EmeddableDocumentStores

### DIFF
--- a/Raven.Client.Lightweight/Document/ShardedBulkInsertOperation.cs
+++ b/Raven.Client.Lightweight/Document/ShardedBulkInsertOperation.cs
@@ -56,7 +56,7 @@ namespace Raven.Client.Document
             BulkInsertOperation bulkInsertOperation;
             if (Bulks.TryGetValue(shardId, out bulkInsertOperation) == false)
             {
-                var actualDatabaseName = database ?? ((DocumentStore)shard).DefaultDatabase ?? MultiDatabase.GetDatabaseName(shard.Url);
+                var actualDatabaseName = database ?? ((dynamic)shard).DefaultDatabase ?? MultiDatabase.GetDatabaseName(shard.Url);
                 bulkInsertOperation = new BulkInsertOperation(actualDatabaseName, shard, shard.Listeners, options, shard.Changes());
                 Bulks.Add(shardId, bulkInsertOperation);
             }


### PR DESCRIPTION
When using ShardedBulkInsert in UnitTests where the Shards is EmbeddableDocumentStores exception is thrown:
Unable to cast object of type 'Raven.Client.Embedded.EmbeddableDocumentStore' to type 'Raven.Client.Document.DocumentStore'.