### PR TITLE
RavenDB-8872 Remove redundant remark about windows service in daemon param data

### DIFF
--- a/docker/ravendb-nanoserver/Dockerfile
+++ b/docker/ravendb-nanoserver/Dockerfile
@@ -5,12 +5,15 @@ HEALTHCHECK --start-period=60s CMD powershell -c 'c:\healthcheck.ps1'
 ENV DATA_DIR=APPDRIVE:/databases CUSTOM_CONFIG_FILE='' PUBLIC_SERVER_URL='' PUBLIC_TCP_SERVER_URL='' UNSECURED_ACCESS_ALLOWED='' LOGS_MODE='' CERTIFICATE_PATH='' CERTIFICATE_PASSWORD='' CERTIFICATE_PASSWORD_FILE=''
 
 VOLUME c:/databases c:/ravendb/cert c:/ravendb/secrets c:/ravendb/config
+
 EXPOSE 8080 38888
 
 COPY RavenDB.zip install-raven.ps1 run-raven.ps1 healthcheck.ps1 c:/
 
 RUN powershell -c 'c:\install-raven.ps1'
+
 WORKDIR C:/ravendb/Server
 
 ADD https://ravendb-docker.s3.amazonaws.com/vcruntime140.dll c:/ravendb/server
+
 CMD powershell -c 'c:\run-raven.ps1'

--- a/docker/ravendb-nanoserver/healthcheck.ps1
+++ b/docker/ravendb-nanoserver/healthcheck.ps1
@@ -6,23 +6,4 @@ if ($p.HasExited) {
     exit 1
 }
 
-$serverUrlScheme = if ([string]::IsNullOrEmpty($env:CERTIFICATE_PATH)) { "http" } else { "https" }
-
-# Since we're bound to 0.0.0.0 we can check studio on localhost
-$uri = "$($serverUrlScheme)://localhost:8080/studio/index.html"
-
-# If public server URL is specified, use that
-if ([string]::IsNullOrEmpty($env:PUBLIC_SERVER_URL) -eq $False) {
-    $uri = $env:PUBLIC_SERVER_URL
-}
-
-write-host "Trying to access studio under $uri"
-$studioIndexResponse = Invoke-WebRequest -Uri $uri  -Method Get
-
-if ($studioIndexResponse.StatusCode -ne 400) {
-    Write-Host "Server responsed with HTTP $($studioIndexResponse.StatusCode) $($studioIndexResponse.StatusDescription)"
-    Write-Host "$($studioIndexReponse.Content)"
-    exit 1
-}
-
 exit 0

--- a/docker/ravendb-nanoserver/healthcheck.ps1
+++ b/docker/ravendb-nanoserver/healthcheck.ps1
@@ -1,6 +1,28 @@
-$serviceStatus = (Get-Service -Name "RavenDB").Status
-if (($serviceStatus -eq "Running") -or ($serviceStatus -eq "StartPending")) {
-    exit 0;
-} else {
-    exit 1;
+$ErrorActionPreference = 'Stop'
+
+$p = Get-Process -Name "Raven.Server"
+if ($p.HasExited) {
+    Write-Host "Server exited with code $($p.ExitCode)."
+    exit 1
 }
+
+$serverUrlScheme = if ([string]::IsNullOrEmpty($env:CERTIFICATE_PATH)) { "http" } else { "https" }
+
+# Since we're bound to 0.0.0.0 we can check studio on localhost
+$uri = "$($serverUrlScheme)://localhost:8080/studio/index.html"
+
+# If public server URL is specified, use that
+if ([string]::IsNullOrEmpty($env:PUBLIC_SERVER_URL) -eq $False) {
+    $uri = $env:PUBLIC_SERVER_URL
+}
+
+write-host "Trying to access studio under $uri"
+$studioIndexResponse = Invoke-WebRequest -Uri $uri  -Method Get
+
+if ($studioIndexResponse.StatusCode -ne 400) {
+    Write-Host "Server responsed with HTTP $($studioIndexResponse.StatusCode) $($studioIndexResponse.StatusDescription)"
+    Write-Host "$($studioIndexReponse.Content)"
+    exit 1
+}
+
+exit 0

--- a/docker/ravendb-nanoserver/install-raven.ps1
+++ b/docker/ravendb-nanoserver/install-raven.ps1
@@ -1,3 +1,3 @@
-New-Item -Type Directory -Force -Path c:/ravendb
+New-Item -Type Directory -Force -Path c:/ravendb | Out-Null
 Expand-Archive c:/ravendb.zip -DestinationPath c:/ravendb -Force
 Remove-Item c:\ravendb.zip

--- a/docker/ravendb-nanoserver/run-raven.ps1
+++ b/docker/ravendb-nanoserver/run-raven.ps1
@@ -1,5 +1,5 @@
 function CheckLastExitCode {
-    param ([int[]]$SuccessCodes = @(0), [scriptblock]$CleanupScript=$null)
+    param ([int[]]$SuccessCodes = @(0), [scriptblock]$CleanupScript = $null)
 
     if ($SuccessCodes -notcontains $LastExitCode) {
         if ($CleanupScript) {
@@ -16,72 +16,63 @@ CALLSTACK:$(Get-PSCallStack | Out-String)
 
 $ErrorActionPreference = 'Stop'
 
-$command = './rvn.exe'
-$commandArgs = @( 'windows-service' )
+$command = './Raven.Server.exe'
+$commandArgs = @( '--non-interactive', '--log-to-console' )
 
-$service = Get-Service | Where-Object { $_.Name -eq "RavenDB" } | Select-Object -First 1
-if ($service -eq $null) {
-    $commandArgs += 'register'
+$serverUrlScheme = if ([string]::IsNullOrEmpty($env:CERTIFICATE_PATH)) { "http" } else { "https" }
 
-    $serverUrlScheme = if ([string]::IsNullOrEmpty($env:CERTIFICATE_PATH)) { "http" } else { "https" }
-
-    if ([string]::IsNullOrEmpty($env:CUSTOM_CONFIG_FILE) -eq $False) {
-        $commandArgs += "--config-path"
-        $commandArgs += "`"$($env:CUSTOM_CONFIG_FILE)`""
-    }
-
-    $commandArgs += "--ServerUrl=$($serverUrlScheme)://0.0.0.0:8080"
-    $commandArgs += "--ServerUrl.Tcp=tcp://0.0.0.0:38888"
-    $commandArgs += "--DataDir=`"$($env:DATA_DIR)`""
-
-    if ([string]::IsNullOrEmpty($env:UNSECURED_ACCESS_ALLOWED) -eq $False) {
-        $commandArgs += "--Security.UnsecuredAccessAllowed=$($env:UNSECURED_ACCESS_ALLOWED)"
-    }
-
-    if ([string]::IsNullOrEmpty($env:PUBLIC_SERVER_URL) -eq $False) {
-        $commandArgs += "--PublicServerUrl=$($env:PUBLIC_SERVER_URL)"
-    }
-
-    if ([string]::IsNullOrEmpty($env:PUBLIC_TCP_SERVER_URL) -eq $False) {
-        $commandArgs += "--PublicServerUrl.Tcp=$($env:PUBLIC_TCP_SERVER_URL)"
-    }
-
-    if ([string]::IsNullOrEmpty($env:LOGS_MODE) -eq $False) {
-        $commandArgs += "--Logs.Mode=$($env:LOGS_MODE)"
-    }
-
-    if ([string]::IsNullOrEmpty($env:CERTIFICATE_PATH) -eq $False) {
-        $certificatePath = $env:CERTIFICATE_PATH;
-        $commandArgs += "--Security.Certificate.Path=`"$certificatePath`""
-    }
-
-    if (([string]::IsNullOrEmpty($env:CERTIFICATE_PASSWORD) -eq $False) -and ([string]::IsNullOrEmpty($env:CERTIFICATE_PASSWORD_FILE) -eq $False)) {
-        throw "CERTIFICATE_PASSWORD and CERTIFICATE_PASSWORD_FILE were both specified. Please use only one of those environment variables to configure your certificate's password.";
-    }
-
-    $certificatePassword = $null
-    if ([string]::IsNullOrEmpty($env:CERTIFICATE_PASSWORD) -eq $False) {
-        $certificatePassword = "$env:CERTIFICATE_PASSWORD";
-    }
-
-    if ([string]::IsNullOrEmpty($env:CERTIFICATE_PASSWORD_FILE) -eq $False) {
-        $certificatePassword = $(Get-Content "$env:CERTIFICATE_PASSWORD_FILE").Trim();
-    }
-
-    if ([string]::IsNullOrEmpty($certificatePassword) -eq $False) {
-        $commandArgs += "--Security.Certificate.Password=`"$certificatePassword`""
-    }
-
-    $commandDesc = "Registering Windows Service: $command $commandArgs" -replace "$certificatePassword","********"
-    write-host $commandDesc
-} else {
-    $commandArgs += "start"
-    write-host "Starting existing Windows Service $command $commandArgs"
+if ([string]::IsNullOrEmpty($env:CUSTOM_CONFIG_FILE) -eq $False) {
+    $commandArgs += "--config-path"
+    $commandArgs += "`"$($env:CUSTOM_CONFIG_FILE)`""
 }
 
+$commandArgs += "--ServerUrl=$($serverUrlScheme)://0.0.0.0:8080"
+$commandArgs += "--ServerUrl.Tcp=tcp://0.0.0.0:38888"
+$commandArgs += "--DataDir=`"$($env:DATA_DIR)`""
+
+if ([string]::IsNullOrEmpty($env:UNSECURED_ACCESS_ALLOWED) -eq $False) {
+    $commandArgs += "--Security.UnsecuredAccessAllowed=$($env:UNSECURED_ACCESS_ALLOWED)"
+}
+
+if ([string]::IsNullOrEmpty($env:PUBLIC_SERVER_URL) -eq $False) {
+    $commandArgs += "--PublicServerUrl=$($env:PUBLIC_SERVER_URL)"
+}
+
+if ([string]::IsNullOrEmpty($env:PUBLIC_TCP_SERVER_URL) -eq $False) {
+    $commandArgs += "--PublicServerUrl.Tcp=$($env:PUBLIC_TCP_SERVER_URL)"
+}
+
+if ([string]::IsNullOrEmpty($env:LOGS_MODE) -eq $False) {
+    $commandArgs += "--Logs.Mode=$($env:LOGS_MODE)"
+}
+
+if ([string]::IsNullOrEmpty($env:CERTIFICATE_PATH) -eq $False) {
+    $certificatePath = $env:CERTIFICATE_PATH;
+    $commandArgs += "--Security.Certificate.Path=`"$certificatePath`""
+}
+
+if (([string]::IsNullOrEmpty($env:CERTIFICATE_PASSWORD) -eq $False) -and ([string]::IsNullOrEmpty($env:CERTIFICATE_PASSWORD_FILE) -eq $False)) {
+    throw "CERTIFICATE_PASSWORD and CERTIFICATE_PASSWORD_FILE were both specified. Please use only one of those environment variables to configure your certificate's password.";
+}
+
+$certificatePassword = $null
+if ([string]::IsNullOrEmpty($env:CERTIFICATE_PASSWORD) -eq $False) {
+    $certificatePassword = "$env:CERTIFICATE_PASSWORD";
+}
+
+if ([string]::IsNullOrEmpty($env:CERTIFICATE_PASSWORD_FILE) -eq $False) {
+    $certificatePassword = $(Get-Content "$env:CERTIFICATE_PASSWORD_FILE").Trim();
+}
+
+if ([string]::IsNullOrEmpty($certificatePassword) -eq $False) {
+    $commandArgs += "--Security.Certificate.Password=`"$certificatePassword`""
+}
+
+$commandDesc = "Starting RavenDB server: $command $commandArgs" 
+if ([string]::IsNullOrEmpty($certificatePassword) -eq $False) {
+    $commandDesc = $commandDesc -replace "$certificatePassword", "********"
+}
+
+write-host $commandDesc
+
 Invoke-Expression -Command "$command $commandArgs"
-CheckLastExitCode
-
-Start-Sleep -Seconds 5
-
-.\rvn.exe logstream

--- a/docker/ravendb-ubuntu1604/Dockerfile
+++ b/docker/ravendb-ubuntu1604/Dockerfile
@@ -4,7 +4,7 @@ COPY RavenDB-4.0.*-*-*-ubuntu.16.04-x64.tar.bz2 /opt/RavenDB.tar.bz2
 
 RUN apt-get update \
     && apt-get install -y \
-    && apt-get install --no-install-recommends bzip2 libunwind8 libicu55 libcurl3 ca-certificates -y \
+    && apt-get install --no-install-recommends curl bzip2 libunwind8 libicu55 libcurl3 ca-certificates -y \
     && cd /opt \
     && tar xjvf RavenDB.tar.bz2 \
     && rm RavenDB.tar.bz2 \

--- a/docker/ravendb-ubuntu1604/healthcheck.sh
+++ b/docker/ravendb-ubuntu1604/healthcheck.sh
@@ -4,22 +4,4 @@ if [ $? -ne 0 ]; then
     exit 1
 fi
 
-if [ ! -z "$CERTIFICATE_PATH" ]; then
-    SERVER_URL_SCHEME="https"
-else
-    SERVER_URL_SCHEME="http"
-fi
-
-SERVER_URL="${SERVER_URL_SCHEME}://localhost:8080/studio/index.html"
-
-if [ ! -z "$PUBLIC_SERVER_URL" ]; then
-    SERVER_URL="$PUBLIC_SERVER_URL"
-fi
-
-curl -f -X GET "$SERVER_URL" > /dev/null
-if [ $? -ne 0 ]; then
-    echo "Could not access studio index.html with curl: $?"
-    exit 1
-fi
-
 exit 0

--- a/docker/ravendb-ubuntu1604/healthcheck.sh
+++ b/docker/ravendb-ubuntu1604/healthcheck.sh
@@ -1,1 +1,25 @@
-pgrep Raven.Server
+pgrep Raven.Server > /dev/null
+if [ $? -ne 0 ]; then
+    echo "pgrep Raven.Server failed: $?"
+    exit 1
+fi
+
+if [ ! -z "$CERTIFICATE_PATH" ]; then
+    SERVER_URL_SCHEME="https"
+else
+    SERVER_URL_SCHEME="http"
+fi
+
+SERVER_URL="${SERVER_URL_SCHEME}://localhost:8080/studio/index.html"
+
+if [ ! -z "$PUBLIC_SERVER_URL" ]; then
+    SERVER_URL="$PUBLIC_SERVER_URL"
+fi
+
+curl -f -X GET "$SERVER_URL" > /dev/null
+if [ $? -ne 0 ]; then
+    echo "Could not access studio index.html with curl: $?"
+    exit 1
+fi
+
+exit 0

--- a/docker/ravendb-ubuntu1604/run-raven.sh
+++ b/docker/ravendb-ubuntu1604/run-raven.sh
@@ -88,14 +88,12 @@ if [ ! -z "$CERT_PASSWORD" ]; then
 fi
 
 COMMAND="$COMMAND --print-id"
-COMMAND="$COMMAND --daemon"
+COMMAND="$COMMAND --non-interactive"
+COMMAND="$COMMAND --log-to-console"
 
 if [ -f "$CUSTOM_CONFIG_FILE" ]; then
     COMMAND="$COMMAND --config-path=\"$CUSTOM_CONFIG_FILE\""
 fi
 
 echo "Starting RavenDB server: ${COMMAND/"$CERT_PASSWORD"/"*******"}"
-
-eval $COMMAND &
-sleep 5
-./rvn logstream
+eval $COMMAND 

--- a/src/Raven.Server/Program.cs
+++ b/src/Raven.Server/Program.cs
@@ -131,8 +131,8 @@ namespace Raven.Server
                             Console.WriteLine("TIP: type 'help' to list the available commands.");
                             Console.ForegroundColor = prevColor;
 
-                            IsRunningAsService = false;
-                            rerun = CommandLineSwitches.Daemon ? RunAsService() : RunInteractive(server);
+                            IsRunningNonInteractive = false;
+                            rerun = CommandLineSwitches.NonInteractive ? RunAsNonInteractive() : RunInteractive(server);
 
                             Console.WriteLine("Starting shut down...");
                             if (Logger.IsInfoEnabled)
@@ -173,18 +173,23 @@ namespace Raven.Server
         public static ManualResetEvent ShutdownServerMre = new ManualResetEvent(false);
         public static ManualResetEvent ResetServerMre = new ManualResetEvent(false);
 
-        public static bool IsRunningAsService;
+        public static bool IsRunningNonInteractive;
 
-        public static bool RunAsService()
+        public static bool RunAsNonInteractive()
         {
-            IsRunningAsService = true;
+            IsRunningNonInteractive = true;
 
             if (Logger.IsInfoEnabled)
-                Logger.Info("Server is running as a service");
-            Console.WriteLine("Running as Service");
+                Logger.Info("Server is running as non-interactive.");
+
+            Console.WriteLine("Running non-interactive.");
+
+            if (CommandLineSwitches.LogToConsole)
+                LoggingSource.Instance.EnableConsoleLogging();
 
             AssemblyLoadContext.Default.Unloading += s =>
             {
+                LoggingSource.Instance.DisableConsoleLogging();
                 if (ShutdownServerMre.WaitOne(0))
                     return; // already done
                 Console.WriteLine("Received graceful exit request...");

--- a/src/Raven.Server/Utils/Cli/CommandLineSwitches.cs
+++ b/src/Raven.Server/Utils/Cli/CommandLineSwitches.cs
@@ -15,7 +15,7 @@ namespace Raven.Server.Utils.Cli
 
         public static bool PrintVersionAndExit => ParseSwitchOption(_versionOption);
 
-        public static bool Daemon => ParseSwitchOption(_daemonOption);
+        public static bool NonInteractive => ParseSwitchOption(_nonInteractiveOption);
 
         public const string DefaultServiceName = "RavenDB";
 
@@ -27,7 +27,11 @@ namespace Raven.Server.Utils.Cli
 
         public static bool ShouldShowHelp => ParseSwitchOption(_helpOption);
 
+        public static bool LogToConsole => ParseSwitchOption(_logToConsole);
+
         private static CommandLineApplication _app;
+
+        private static CommandOption _logToConsole;
 
         private static CommandOption _printIdOption;
 
@@ -35,7 +39,7 @@ namespace Raven.Server.Utils.Cli
 
         private static CommandOption _versionOption;
 
-        private static CommandOption _daemonOption;
+        private static CommandOption _nonInteractiveOption;
 
         private static CommandOption _serviceNameOption;
 
@@ -77,9 +81,9 @@ namespace Raven.Server.Utils.Cli
                 "--print-id",
                 "Prints server ID upon server start",
                 CommandOptionType.NoValue);
-            _daemonOption = _app.Option(
-                "-d | --daemon",
-                "Runs as daemon (available only for Linux). Windows users should use --register-service and services.msc for service management",
+            _nonInteractiveOption = _app.Option(
+                "-n | --non-interactive",
+                "Run in non-interactive mode",
                 CommandOptionType.NoValue);
             _serviceNameOption = _app.Option(
                 "--service-name",
@@ -93,6 +97,10 @@ namespace Raven.Server.Utils.Cli
                 "--browser",
                 "Attempts to open RavenDB Studio in the browser",
                 CommandOptionType.NoValue);
+            _logToConsole = _app.Option(
+                "-l | --log-to-console",
+                "Print logs to console (when run in non-interactive mode)",
+                CommandOptionType.NoValue);
 
             _app.Execute(nonConfigurationSwitches.ToArray());
 
@@ -105,10 +113,6 @@ namespace Raven.Server.Utils.Cli
         {
             if (ServiceName.Length > 256)
                 throw new CommandParsingException(_app, "Service name must have maximum length of 256 characters.");
-
-            if (PlatformDetails.RunningOnPosix == false && Daemon)
-                throw new CommandParsingException(_app,
-                    "Switch \"--daemon\" is not supported on Windows. Use --register-service switch to register the service and services.msc for service management.");
         }
 
         private static bool ParseSwitchOption(CommandOption opt)

--- a/src/Raven.Server/Utils/Cli/RavenCli.cs
+++ b/src/Raven.Server/Utils/Cli/RavenCli.cs
@@ -870,7 +870,7 @@ namespace Raven.Server.Utils.Cli
                             break;
                         WriteText("End of standard input detected, switching to server mode...", WarningColor, this);
 
-                        Program.RunAsService();
+                        Program.RunAsNonInteractive();
                         return false;
                     }
                 }
@@ -950,7 +950,7 @@ namespace Raven.Server.Utils.Cli
                     {
                         if (parsedCommand.Command == Command.ResetServer)
                         {
-                            if (Program.IsRunningAsService || _writer == Console.Out)
+                            if (Program.IsRunningNonInteractive || _writer == Console.Out)
                             {
                                 if (_consoleColoring == false)
                                 {
@@ -965,7 +965,7 @@ namespace Raven.Server.Utils.Cli
                         }
                         if (parsedCommand.Command == Command.Shutdown)
                         {
-                            if (Program.IsRunningAsService || _writer == Console.Out)
+                            if (Program.IsRunningNonInteractive || _writer == Console.Out)
                             {
                                 if (_consoleColoring == false)
                                 {


### PR DESCRIPTION
RavenDB-8580 Restarting windows-nanoserver docker container shows weird message full of asterisks in logs

obsoletes RavenDB-8529 RAVEN. environment variables set for docker windows nanoserver container don't affect RavenConfiguration
obsoletes RavenDB-8601 Only exit container if server exits - retry logic for logstream connection
obsoletes RavenDB-8620 Intermitent pipes connection timeout on docker.