### PR TITLE
RavenDB-8861 Allow getting certificates from the cluster

### DIFF
--- a/scripts/certificates/powershell/dev-create-authenticated-cluster-with-subdomains.ps1
+++ b/scripts/certificates/powershell/dev-create-authenticated-cluster-with-subdomains.ps1
@@ -23,7 +23,7 @@ $ErrorActionPreference = "Stop"
 $SecurePassword = ConvertTo-SecureString $CertificatePassword -asplaintext -force
 
 # generate server certificate
-pushd "$serverDir\scripts\certificates\"
+pushd "$serverDir\scripts\certificates\powershell\"
 ./generate-server-cert.ps1 -CN *.hrhinos.local -CertificatePassword $SecurePassword
 popd
 
@@ -47,7 +47,7 @@ popd
 pushd $serverDir
 $commonArgs = "--Cluster.TimeBeforeAddingReplicaInSec=15"
 
-$authArgs = "--Security.Certificate.Path=$serverDir\scripts\certificates\server.pfx --Security.Certificate.Password=$CertificatePassword"
+$authArgs = "--Security.Certificate.Path=$serverDir\scripts\certificates\powershell\server.pfx --Security.Certificate.Password=$CertificatePassword"
 
 for($i=1; $i -le $nodeCount; $i++){
     start powershell "-NoExit -NoProfile dotnet run -p .\src\Raven.Server\Raven.Server.csproj --ServerUrl=https://rvn$i.hrhinos.local:8080 DataDir=$serverDir\src\Raven.Server\bin\$conf\netcoreapp2.0\$i --Logs.Path=$serverDir\src\Raven.Server\bin\$conf\netcoreapp2.0\$i --License.Path=$licensePath $commonArgs $authArgs"
@@ -58,7 +58,7 @@ write-host "Before you continue, make sure that server https://rvn1.hrhinos.loca
 sleep 3
 
 # obtain client cert using server cert
-pushd "$serverDir\scripts\certificates\"
+pushd "$serverDir\scripts\certificates\powershell\"
 ./obtain-cluster-admin-client-cert.ps1 -ServerUrl https://rvn1.hrhinos.local:8080 -ClientCertPassword $CertificatePassword
 
 

--- a/scripts/certificates/powershell/dev-create-authenticated-cluster.ps1
+++ b/scripts/certificates/powershell/dev-create-authenticated-cluster.ps1
@@ -12,7 +12,7 @@ $ErrorActionPreference = "Stop"
 $SecurePassword = ConvertTo-SecureString $CertificatePassword -asplaintext -force
 
 # generate server certificate 
-pushd "$serverDir\scripts\certificates\" 
+pushd "$serverDir\scripts\certificates\powershell\" 
 ./generate-server-cert.ps1 -CN localhost -CertificatePassword $SecurePassword
 popd 
 
@@ -37,10 +37,11 @@ pushd $serverDir
 
 $commonArgs = "--Cluster.TimeBeforeAddingReplicaInSec=15" 
 
-$authArgs = "--Security.Certificate.Path=$serverDir\scripts\certificates\server.pfx --Security.Certificate.Password=$CertificatePassword" 
+$authArgs = "--Security.Certificate.Path=$serverDir\scripts\certificates\powershell\server.pfx --Security.Certificate.Password=$CertificatePassword" 
 
 for($i=1; $i -le $nodeCount; $i++){    
     start powershell "-NoExit -NoProfile dotnet run -p .\src\Raven.Server\Raven.Server.csproj --ServerUrl=https://localhost:808$i --DataDir=$serverDir\src\Raven.Server\bin\$conf\netcoreapp2.0\$i --Logs.Path=$serverDir\src\Raven.Server\bin\$conf\netcoreapp2.0\$i --License.Path=$licensePath $commonArgs $authArgs" 
+    sleep -Milliseconds 500
 } 
 popd 
 
@@ -48,7 +49,7 @@ write-host "Before you continue, make sure that server https://localhost:8081 ha
 sleep 3
 
 # obtain client cert using server cert 
-pushd "$serverDir\scripts\certificates\" 
+pushd "$serverDir\scripts\certificates\powershell\" 
 ./obtain-cluster-admin-client-cert.ps1 -ServerUrl https://localhost:8081 -ClientCertPassword $CertificatePassword
 
 # add client cert to trusted root (for chrome)

--- a/src/Raven.Client/ServerWide/Operations/Certificates/CertificateDefinition.cs
+++ b/src/Raven.Client/ServerWide/Operations/Certificates/CertificateDefinition.cs
@@ -1,4 +1,5 @@
 ﻿using System;
+using System.Collections;
 using System.Collections.Generic;
 using Sparrow.Json.Parsing;
 
@@ -12,6 +13,8 @@ namespace Raven.Client.ServerWide.Operations.Certificates
         public SecurityClearance SecurityClearance;
         public string Thumbprint;
         public Dictionary<string, DatabaseAccess> Permissions = new Dictionary<string, DatabaseAccess>(StringComparer.OrdinalIgnoreCase);
+        public string CollectionPrimaryKey = string.Empty;
+        public List<string> CollectionSecondaryKeys = new List<string>();
 
         public DynamicJsonValue ToJson()
         {
@@ -27,7 +30,9 @@ namespace Raven.Client.ServerWide.Operations.Certificates
                 [nameof(Certificate)] = Certificate,
                 [nameof(Thumbprint)] = Thumbprint,
                 [nameof(SecurityClearance)] = SecurityClearance,
-                [nameof(Permissions)] = permissions
+                [nameof(Permissions)] = permissions,
+                [nameof(CollectionPrimaryKey)] = CollectionPrimaryKey,
+                [nameof(CollectionSecondaryKeys)] = CollectionSecondaryKeys
             };
         }
     }
@@ -42,6 +47,7 @@ namespace Raven.Client.ServerWide.Operations.Certificates
     {
         UnauthenticatedClients, //Default value
         ClusterAdmin,
+        ClusterNode,
         Operator,
         ValidUser
     }

--- a/src/Raven.Server/Documents/Handlers/AttachmentHandler.cs
+++ b/src/Raven.Server/Documents/Handlers/AttachmentHandler.cs
@@ -77,7 +77,7 @@ namespace Raven.Server.Documents.Handlers
                 ByteStringContext.InternalScope disposeCv = default(ByteStringContext.InternalScope);
                 if (isDocument == false)
                 {
-                    var stream = TryGetRequestFormStream("ChangeVectorAndType") ?? RequestBodyStream();
+                    var stream = TryGetRequestFromStream("ChangeVectorAndType") ?? RequestBodyStream();
                     var request = context.Read(stream, "GetAttachment");
 
                     if (request.TryGet("Type", out string typeString) == false ||

--- a/src/Raven.Server/Documents/Handlers/StreamingHandler.cs
+++ b/src/Raven.Server/Documents/Handlers/StreamingHandler.cs
@@ -102,7 +102,7 @@ namespace Raven.Server.Documents.Handlers
             using (var token = CreateTimeLimitedOperationToken())
             using (Database.DocumentsStorage.ContextPool.AllocateOperationContext(out DocumentsOperationContext context))
             {
-                var stream = TryGetRequestFormStream("ExportOptions") ?? RequestBodyStream(); 
+                var stream = TryGetRequestFromStream("ExportOptions") ?? RequestBodyStream(); 
                 var queryJson = await context.ReadForMemoryAsync(stream, "index/query");
                 var query = IndexQueryServerSide.Create(queryJson, context, Database.QueryMetadataCache);
                 var format = GetStringQueryString("format", false);

--- a/src/Raven.Server/RavenServer.cs
+++ b/src/Raven.Server/RavenServer.cs
@@ -439,6 +439,10 @@ namespace Raven.Server
                         {
                             authenticationStatus.Status = AuthenticationStatus.ClusterAdmin;
                         }
+                        else if (definition.SecurityClearance == SecurityClearance.ClusterNode)
+                        {
+                            authenticationStatus.Status = AuthenticationStatus.ClusterAdmin;
+                        }
                         else if (definition.SecurityClearance == SecurityClearance.Operator)
                         {
                             authenticationStatus.Status = AuthenticationStatus.Operator;

--- a/src/Raven.Server/ServerWide/Commands/DeleteCertificateFromClusterCommand.cs
+++ b/src/Raven.Server/ServerWide/Commands/DeleteCertificateFromClusterCommand.cs
@@ -14,7 +14,7 @@ namespace Raven.Server.ServerWide.Commands
                 if (read == null)
                     return;
                 var definition = JsonDeserializationServer.CertificateDefinition(read);
-                if (definition.SecurityClearance != SecurityClearance.ClusterAdmin)
+                if (definition.SecurityClearance != SecurityClearance.ClusterAdmin || definition.SecurityClearance != SecurityClearance.ClusterNode)
                     return;
             }
 

--- a/src/Raven.Server/ServerWide/Commands/PutCertificateCommand.cs
+++ b/src/Raven.Server/ServerWide/Commands/PutCertificateCommand.cs
@@ -24,7 +24,7 @@ namespace Raven.Server.ServerWide.Commands
 
         public override void VerifyCanExecuteCommand(ServerStore store, TransactionOperationContext context, bool isClusterAdmin)
         {
-            if (Value.SecurityClearance == SecurityClearance.ClusterAdmin)
+            if (Value.SecurityClearance == SecurityClearance.ClusterAdmin || Value.SecurityClearance != SecurityClearance.ClusterNode)
                 AssertClusterAdmin(isClusterAdmin);
         }
     }

--- a/src/Raven.Server/Smuggler/Documents/Handlers/SmugglerHandler.cs
+++ b/src/Raven.Server/Smuggler/Documents/Handlers/SmugglerHandler.cs
@@ -81,7 +81,7 @@ namespace Raven.Server.Smuggler.Documents.Handlers
                 var operationId = GetLongQueryString("operationId", true);
                 var startDocumentEtag = GetLongQueryString("startEtag", false) ?? 0;
 
-                var stream = TryGetRequestFormStream("DownloadOptions") ?? RequestBodyStream();
+                var stream = TryGetRequestFromStream("DownloadOptions") ?? RequestBodyStream();
 
                 var blittableJson = await context.ReadForMemoryAsync(stream, "DownloadOptions");
                 var options = JsonDeserializationServer.DatabaseSmugglerOptions(blittableJson);

--- a/src/Raven.Server/Utils/Cli/RavenCli.cs
+++ b/src/Raven.Server/Utils/Cli/RavenCli.cs
@@ -491,8 +491,8 @@ namespace Raven.Server.Utils.Cli
                 {
                     // this does not include the private key, that is only for the client
                     Certificate = Convert.ToBase64String(cert.Export(X509ContentType.Cert)),
-                    Permissions = null,
-                    SecurityClearance = SecurityClearance.ClusterAdmin,
+                    Permissions = new Dictionary<string, DatabaseAccess>(),
+                    SecurityClearance = SecurityClearance.ClusterNode,
                     Thumbprint = cert.Thumbprint
                 }.ToJson();
 

--- a/src/Raven.Server/Web/RequestHandler.cs
+++ b/src/Raven.Server/Web/RequestHandler.cs
@@ -59,7 +59,7 @@ namespace Raven.Server.Web
             _context = context;
         }
 
-        protected Stream TryGetRequestFormStream(string itemName)
+        protected Stream TryGetRequestFromStream(string itemName)
         {
             if (HttpContext.Request.HasFormContentType == false)
                 return null;

--- a/src/Raven.Studio/typescript/models/auth/certificateModel.ts
+++ b/src/Raven.Studio/typescript/models/auth/certificateModel.ts
@@ -9,6 +9,9 @@ class certificateModel {
             label: "Cluster Administator",
             value: "ClusterAdmin"
         }, {
+            label: "Cluster Node",
+            value: "ClusterNode"
+        }, {
             label: "Operator", 
             value: "Operator"
         }, {


### PR DESCRIPTION
- RavenDB-8973 Fix NRE in RachisAdminHandler
- Add ClusterNode SecurityClearance for server certificates
- Allow to export ClusterNode certificates to .pfx file
- Fix bug, register server's own certificate in cluster
- Fix paths in cluster scripts
- Better errors in certificates handlers