### PR TITLE
RavenDB-8925 Server crashes when saving a SQL ETL Task with an *inval…

### DIFF
--- a/src/Raven.Client/ServerWide/ETL/EtlConfiguration.cs
+++ b/src/Raven.Client/ServerWide/ETL/EtlConfiguration.cs
@@ -73,11 +73,8 @@ namespace Raven.Client.ServerWide.ETL
 
         public ulong GetTaskKey()
         {
-            Debug.Assert(Name != null);
-            Debug.Assert(ConnectionStringName != null);
-
-            return _taskKey ?? (_taskKey = Hashing.XXHash64.Calculate(Name.ToLowerInvariant(), Encodings.Utf8) ^
-                                           Hashing.XXHash64.Calculate(ConnectionStringName.ToLowerInvariant(), Encodings.Utf8)).Value;
+            Debug.Assert(TaskId != 0);
+            return (ulong)TaskId;
         }
 
         public string GetMentorNode()


### PR DESCRIPTION
…id* SQL connection string - GetTaskKey Modified