### PR TITLE
RavenDB-5213 csv import

### DIFF
--- a/src/Raven.Server/Smuggler/Documents/Handlers/SmugglerHandler.cs
+++ b/src/Raven.Server/Smuggler/Documents/Handlers/SmugglerHandler.cs
@@ -420,8 +420,8 @@ namespace Raven.Server.Smuggler.Documents.Handlers
                 }
                 var token = new OperationCancelToken(Database.DatabaseShutdown);
                 var result = new SmugglerResult();
-                var operationId = Database.Operations.GetNextOperationId();
-                await Database.Operations.AddOperation(Database, $"Import to: {Database.Name} from csv file", Raven.Server.Documents.Operations.Operations.OperationType.DatabaseImportFromCsv,
+                var operationId = GetLongQueryString("operationId");
+                await Database.Operations.AddOperation(Database, "Import from csv file", Raven.Server.Documents.Operations.Operations.OperationType.DatabaseImportFromCsv,
                     onProgress =>
                     {
                         return Task.Run(async () =>

--- a/src/Sparrow/Json/BlittableJsonDocumentBuilder.cs
+++ b/src/Sparrow/Json/BlittableJsonDocumentBuilder.cs
@@ -572,8 +572,7 @@ namespace Sparrow.Json
         {
             var reader = CreateReader();
             reader.NoCache = noCache;
-            BlittableJsonReaderArray array;
-            if (reader.TryGet("_", out array))
+            if (reader.TryGet("_", out BlittableJsonReaderArray array))
                 return array;
             throw new InvalidOperationException("Couldn't find array");
         }

--- a/src/Sparrow/Json/BlittableJsonReaderArray.cs
+++ b/src/Sparrow/Json/BlittableJsonReaderArray.cs
@@ -9,7 +9,7 @@ using Sparrow.Json.Parsing;
 
 namespace Sparrow.Json
 {
-    public unsafe class BlittableJsonReaderArray : BlittableJsonReaderBase, IEnumerable<object>
+    public unsafe class BlittableJsonReaderArray : BlittableJsonReaderBase, IEnumerable<object>, IDisposable
     {
         private readonly int _count;
         private readonly byte* _metadataPtr;
@@ -50,6 +50,11 @@ namespace Sparrow.Json
 
                 return new StreamReader(memoryStream).ReadToEnd();
             }
+        }
+
+        public void Dispose()
+        {
+            _parent?.Dispose();
         }
 
         public BlittableJsonToken GetArrayType()


### PR DESCRIPTION
* now disposing of memory allocated from parsing ArraySegment
* Will consider @metadata.@collection as my collection along side @collection
* Will consider escaped dots like  A.'Foo.Bar'.B and generate "A","Foo.Bar","B" segments
* Will expect operation id from the query string
* BlittableJsonReaderArray is now disposable
* Can Parse large arrays (larger than the un-managed buffer)