### PR TITLE
RavenDB-9030 removing check for number of ids in query

### DIFF
--- a/src/Raven.Server/Documents/Queries/CollectionQueryEnumerable.cs
+++ b/src/Raven.Server/Documents/Queries/CollectionQueryEnumerable.cs
@@ -94,9 +94,6 @@ namespace Raven.Server.Documents.Queries
 
                 _ids = ExtractIdsFromQuery(query);
 
-                if (_ids != null && _ids.Count > BooleanQuery.MaxClauseCount)
-                    throw new BooleanQuery.TooManyClauses();
-
                 _sort = ExtractSortFromQuery(query);
 
                 _resultsRetriever = new MapQueryResultRetriever(database, query, documents, context, fieldsToFetch, includeDocumentsCommand);

--- a/test/FastTests/Issues/RavenDB-9030.cs
+++ b/test/FastTests/Issues/RavenDB-9030.cs
@@ -1,0 +1,45 @@
+﻿using System;
+using System.Collections.Generic;
+using System.Linq;
+using System.Text;
+using Raven.Client.Documents.Linq;
+using Xunit;
+
+namespace FastTests.Issues
+{
+    public class RavenDB_9030: RavenTestBase
+    {
+        [Fact]
+        public void InQueryOnMultipleIdsShouldNotThrowTooManyBooleanClauses()
+        {
+            var numOfIds = 10_000;
+            var ids = Enumerable.Range(0, numOfIds).Select(x => x.ToString()).ToArray();
+            using (var store = GetDocumentStore())
+            {
+                using (var session = store.OpenSession())
+                {
+                    foreach (var id in ids)
+                    {
+                        session.Store(new Document { Id = id });
+                    }  
+                    session.SaveChanges();
+                }
+
+                using (var session = store.OpenSession())
+                {
+                    Assert.Equal(numOfIds, session.Query<Document>()
+                        .Where(x => x.Id.In(ids))
+                        .Select(x => new
+                        {
+                            x.Id
+                        }).Count());
+                }
+            }
+        }
+
+        public class Document
+        {
+            public string Id { get; set; }
+        }
+    }
+}


### PR DESCRIPTION
Please note that we should not constraint ourselves at this point since we don't know what are those ids used for.
In the test added they are used in an In method that doesn't generate boolean clauses at all