### PR TITLE
RavenDB-9055 Fix AggressivelyCache when _firstTopologyUpdate is null

### DIFF
--- a/src/Raven.Client/Documents/Changes/ConnectionStateBase.cs
+++ b/src/Raven.Client/Documents/Changes/ConnectionStateBase.cs
@@ -14,6 +14,7 @@ namespace Raven.Client.Documents.Changes
         private readonly Func<Task<bool>> _onConnect;
         private int _value;
         private TaskCompletionSource<object> _tcs;
+        public Exception LastException;
 
         protected ConnectionStateBase(IDatabaseChanges changes, Func<Task<bool>> onConnect, Func<Task> onDisconnect)
         {
@@ -103,6 +104,7 @@ namespace Raven.Client.Documents.Changes
 
         public void Error(Exception e)
         {
+            LastException = e;
             OnError?.Invoke(e);
         }
 

--- a/src/Raven.Client/Documents/DocumentStore.cs
+++ b/src/Raven.Client/Documents/DocumentStore.cs
@@ -268,6 +268,16 @@ namespace Raven.Client.Documents
             return new DatabaseChanges(GetRequestExecutor(database), database, () => _databaseChanges.Remove(database));
         }
 
+        public Exception GetLastDatabaseChangesStateException(string database = null)
+        {
+            if (_databaseChanges.TryGetValue(database ?? Database, out IDatabaseChanges databaseChanges))
+            {
+                return ((DatabaseChanges)databaseChanges).GetLastConnectionStateException(database);
+            }
+
+            return null;
+        }
+
         /// <summary>
         /// Setup the context for aggressive caching.
         /// </summary>

--- a/src/Raven.Client/Http/RequestExecutor.cs
+++ b/src/Raven.Client/Http/RequestExecutor.cs
@@ -1200,7 +1200,7 @@ namespace Raven.Client.Http
 
         private async Task EnsureNodeSelector()
         {
-            if (_firstTopologyUpdate.Status != TaskStatus.RanToCompletion)
+            if (_firstTopologyUpdate != null && _firstTopologyUpdate.Status != TaskStatus.RanToCompletion)
                 await _firstTopologyUpdate.ConfigureAwait(false);
 
             if (_nodeSelector == null)

--- a/test/FastTests/Issues/RavenDB-9055.cs
+++ b/test/FastTests/Issues/RavenDB-9055.cs
@@ -1,0 +1,78 @@
+﻿using System;
+using System.Diagnostics;
+using System.Reflection.Metadata;
+using System.Threading;
+using Lucene.Net.Util;
+using Raven.Client.Documents.Session;
+using Raven.Tests.Core.Utils.Entities;
+using Xunit;
+using Constants = Raven.Client.Constants;
+
+namespace FastTests.Issues
+{
+
+    public class RavenDB_9055 : RavenTestBase
+    {
+        [Fact]
+        public void AggressivelyCacheWorksWhenTopologyUpdatesIsDisable()
+        {
+            using (var documentStore = GetDocumentStore(options: new Options
+            {
+                ModifyDocumentStore = store =>
+                {
+                    store.Conventions.UseOptimisticConcurrency = true;
+                    store.Conventions.DisableTopologyUpdates = true;
+                }
+            }))
+            {
+                using (documentStore.AggressivelyCache())
+                {
+                    using (var session = documentStore.OpenSession())
+                    {
+                        session.Store(new User
+                        {
+                            Name = "Idan"
+                        }, "users/1");
+                        session.SaveChanges();
+                    }
+                }
+
+                string changeVector;
+                using (documentStore.AggressivelyCache())
+                {
+                    using (var session = documentStore.OpenSession())
+                    {
+                        var user = session.Load<User>("users/1");
+                        user.Name = "Shalom";
+                        session.SaveChanges();
+                        changeVector = session.Advanced.GetMetadataFor(user)?.GetString(Constants.Documents.Metadata.ChangeVector);
+                    }
+                    Assert.NotNull(changeVector);
+                }
+                string updateChangeVector = null;
+                for (int i = 0; i < 15; i++)
+                {
+                    using (documentStore.AggressivelyCache())
+                    using (var session = documentStore.OpenSession())
+                    {
+                        var user = session.Load<User>("users/1");
+                        updateChangeVector = session.Advanced.GetMetadataFor(user)?
+                            .GetString(Constants.Documents.Metadata.ChangeVector);
+
+                        if (updateChangeVector != null && updateChangeVector.Equals(changeVector))
+                        {
+                            break;
+                        }
+                        Thread.Sleep(100);
+                    }
+                }
+                Assert.NotNull(updateChangeVector);
+                if (changeVector != updateChangeVector)
+                {
+                    Console.WriteLine(1);
+                }
+                Assert.Equal(changeVector, updateChangeVector);
+            }
+        }
+    }
+}


### PR DESCRIPTION
- Add GetLastDatabaseChangesStateException to be able to get the LastException that accord in DatabaseChanges