### PR TITLE
RavenDB-7288 ETL : Prevent loads from multiple nodes to a single dest…

### DIFF
--- a/src/Raven.Client/ServerWide/DatabaseTopology.cs
+++ b/src/Raven.Client/ServerWide/DatabaseTopology.cs
@@ -95,7 +95,7 @@ namespace Raven.Client.ServerWide
                    Promotables.Contains(nodeTag);
         }
 
-        public List<ReplicationNode> GetDestinations(string nodeTag, string databaseName, ClusterTopology clusterTopology, bool isPassive)
+        public List<ReplicationNode> GetDestinations(string nodeTag, string databaseName, ClusterTopology clusterTopology, RachisState state)
         {
             var list = new List<string>();
             var destinations = new List<ReplicationNode>();
@@ -113,7 +113,7 @@ namespace Raven.Client.ServerWide
             {
                 var url = clusterTopology.GetUrlFromTag(promotable);
                 PredefinedMentors.TryGetValue(promotable, out var mentor);
-                if (WhoseTaskIsIt(new PromotableTask(promotable, url, databaseName, mentor), isPassive) == nodeTag)
+                if (WhoseTaskIsIt(new PromotableTask(promotable, url, databaseName, mentor), state) == nodeTag)
                 {
                     list.Add(url);
                 }
@@ -207,9 +207,9 @@ namespace Raven.Client.ServerWide
             Rehabs.RemoveAll(r => r == delDbFromNode);
         }
 
-        public string WhoseTaskIsIt(IDatabaseTask task, bool inPassiveState)
+        public string WhoseTaskIsIt(IDatabaseTask task, RachisState state)
         {
-            if (inPassiveState)
+            if (state == RachisState.Candidate || state == RachisState.Passive)
                 return null;
 
             var mentorNode = task.GetMentorNode();

--- a/src/Raven.Client/ServerWide/RachisEnum.cs
+++ b/src/Raven.Client/ServerWide/RachisEnum.cs
@@ -1,0 +1,11 @@
+﻿namespace Raven.Client.ServerWide
+{
+    public enum RachisState
+    {
+        Passive,
+        Candidate,
+        Follower,
+        LeaderElect,
+        Leader
+    }
+}

--- a/src/Raven.Server/Documents/ETL/EtlLoader.cs
+++ b/src/Raven.Server/Documents/ETL/EtlLoader.cs
@@ -128,7 +128,7 @@ namespace Raven.Server.Documents.ETL
                 if (config.Disabled)
                     continue;
 
-                if (_databaseRecord.Topology.WhoseTaskIsIt(config, _serverStore.IsPassive()) != _serverStore.NodeTag)
+                if (_databaseRecord.Topology.WhoseTaskIsIt(config, _serverStore.Engine.CurrentState) != _serverStore.NodeTag)
                     continue;
 
                 foreach (var transform in config.Transforms)

--- a/src/Raven.Server/Documents/Handlers/Admin/RachisAdminHandler.cs
+++ b/src/Raven.Server/Documents/Handlers/Admin/RachisAdminHandler.cs
@@ -209,7 +209,7 @@ namespace Raven.Server.Documents.Handlers.Admin
                     {
                         ["Topology"] = topology.ToSortedJson(),
                         ["Leader"] = ServerStore.LeaderTag,
-                        ["CurrentState"] = ServerStore.CurrentState,
+                        ["CurrentState"] = ServerStore.CurrentRachisState,
                         ["NodeTag"] = nodeTag,
                         ["CurrentTerm"] = ServerStore.Engine.CurrentTerm,
                         ["NodeLicenseDetails"] = nodeLicenseDetails,

--- a/src/Raven.Server/Documents/PeriodicBackup/PeriodicBackupRunner.cs
+++ b/src/Raven.Server/Documents/PeriodicBackup/PeriodicBackupRunner.cs
@@ -1012,7 +1012,7 @@ namespace Raven.Server.Documents.PeriodicBackup
                 return TaskStatus.Disabled;
             }
 
-            var whoseTaskIsIt = databaseRecord.Topology.WhoseTaskIsIt(configuration, _serverStore.IsPassive());
+            var whoseTaskIsIt = databaseRecord.Topology.WhoseTaskIsIt(configuration, _serverStore.Engine.CurrentState);
             if (whoseTaskIsIt == null)
                 return TaskStatus.Disabled;
 

--- a/src/Raven.Server/Documents/Replication/ReplicationLoader.cs
+++ b/src/Raven.Server/Documents/Replication/ReplicationLoader.cs
@@ -409,7 +409,7 @@ namespace Raven.Server.Documents.Replication
             var changes = ExternalReplication.FindChanges(_externalDestinations, newRecord.ExternalReplication);
 
             DropOutgoingConnections(changes.RemovedDestiantions, ref instancesToDispose);
-            var newDestinations = changes.AddedDestinations.Where(o => newRecord.Topology.WhoseTaskIsIt(o, false) == _server.NodeTag).ToList();
+            var newDestinations = changes.AddedDestinations.Where(o => newRecord.Topology.WhoseTaskIsIt(o, _server.Engine.CurrentState) == _server.NodeTag).ToList();
             foreach (var externalReplication in newDestinations.ToList())
             {
                 if (newRecord.RavenConnectionStrings.TryGetValue(externalReplication.ConnectionStringName, out var connectionString) == false)
@@ -433,7 +433,7 @@ namespace Raven.Server.Documents.Replication
         private void HandleInternalReplication(DatabaseRecord newRecord, ref List<OutgoingReplicationHandler> instancesToDispose)
         {
             var clusterTopology = GetClusterTopology();
-            var newInternalDestinations = newRecord.Topology?.GetDestinations(_server.NodeTag, Database.Name, clusterTopology, _server.IsPassive());
+            var newInternalDestinations = newRecord.Topology?.GetDestinations(_server.NodeTag, Database.Name, clusterTopology, _server.Engine.CurrentState);
             var internalConnections = DatabaseTopology.FindChanges(_internalDestinations, newInternalDestinations);
 
             if (internalConnections.RemovedDestiantions.Count > 0)

--- a/src/Raven.Server/Documents/Subscriptions/SubscriptionStorage.cs
+++ b/src/Raven.Server/Documents/Subscriptions/SubscriptionStorage.cs
@@ -136,7 +136,7 @@ namespace Raven.Server.Documents.Subscriptions
             {
                 var subscription = GetSubscriptionFromServerStore(serverStoreContext, name);
                 var dbRecord = _serverStore.Cluster.ReadDatabase(serverStoreContext, _db.Name, out var _);
-                var whoseTaskIsIt = dbRecord.Topology.WhoseTaskIsIt(subscription, _serverStore.IsPassive());
+                var whoseTaskIsIt = dbRecord.Topology.WhoseTaskIsIt(subscription, _serverStore.Engine.CurrentState);
                 if (whoseTaskIsIt != _serverStore.NodeTag)
                 {
                     throw new SubscriptionDoesNotBelongToNodeException($"Subscripition with id {id} can't be proccessed on current node ({_serverStore.NodeTag}), because it belongs to {whoseTaskIsIt}")
@@ -413,7 +413,7 @@ namespace Raven.Server.Documents.Subscriptions
                         DropSubscriptionConnection(subscriptionStateKvp.Key, new SubscriptionClosedException($"The subscription {subscriptionName} query has been modified, connection must be restarted"));
                     }
 
-                    if (databaseRecord.Topology.WhoseTaskIsIt(subscriptionState, _serverStore.IsPassive()) != _serverStore.NodeTag)
+                    if (databaseRecord.Topology.WhoseTaskIsIt(subscriptionState, _serverStore.Engine.CurrentState) != _serverStore.NodeTag)
                     {
                         if (_logger.IsInfoEnabled)
                             _logger.Info($"Disconnected subscription with id {subscriptionStateKvp.Key}, because it was is no longer managed by this node ({_serverStore.NodeTag})");

--- a/src/Raven.Server/Monitoring/Snmp/Objects/Cluster/3.1/ClusterNodeState.cs
+++ b/src/Raven.Server/Monitoring/Snmp/Objects/Cluster/3.1/ClusterNodeState.cs
@@ -19,7 +19,7 @@ namespace Raven.Server.Monitoring.Snmp.Objects.Cluster
             if (string.IsNullOrWhiteSpace(tag))
                 return null;
 
-            return new OctetString(_store.CurrentState.ToString());
+            return new OctetString(_store.CurrentRachisState.ToString());
         }
     }
 }

--- a/src/Raven.Server/Rachis/Candidate.cs
+++ b/src/Raven.Server/Rachis/Candidate.cs
@@ -6,6 +6,7 @@ using System.Threading.Tasks;
 using Raven.Server.ServerWide.Context;
 using Raven.Client.Exceptions;
 using Raven.Client.Http;
+using Raven.Client.ServerWide;
 using Sparrow.Threading;
 
 namespace Raven.Server.Rachis
@@ -130,7 +131,7 @@ namespace Raven.Server.Rachis
                                 _engine.Log.Info($"Candidate {_engine.Tag}: A leader node has indicated that I'm not in their topology, I was probably kicked out. Moving to passive mode");
                             }
                             var engineCurrentTerm = _engine.CurrentTerm;
-                            _engine.SetNewState(RachisConsensus.State.Passive, this, engineCurrentTerm,
+                            _engine.SetNewState(RachisState.Passive, this, engineCurrentTerm,
                                 "I just learned from the leader that I\'m not in their topology, moving to passive state");
                             break;
                         }

--- a/src/Raven.Server/Rachis/CandidateAmbassador.cs
+++ b/src/Raven.Server/Rachis/CandidateAmbassador.cs
@@ -3,8 +3,8 @@ using System.Diagnostics;
 using System.IO;
 using System.Security.Cryptography.X509Certificates;
 using System.Threading;
-using Raven.Client.Exceptions;
 using Raven.Client.Http;
+using Raven.Client.ServerWide;
 using Raven.Server.ServerWide.Context;
 
 namespace Raven.Server.Rachis
@@ -150,7 +150,7 @@ namespace Raven.Server.Rachis
                                     {
                                         var message = $"Candidate ambassador {_engine.Tag}: found election term {rvr.Term} that is higher than ours {currentElectionTerm}";
                                         // we need to abort the current elections
-                                        _engine.SetNewState(RachisConsensus.State.Follower, null, engineCurrentTerm, message);
+                                        _engine.SetNewState(RachisState.Follower, null, engineCurrentTerm, message);
                                         if (_engine.Log.IsInfoEnabled)
                                         {
                                             _engine.Log.Info($"CandidateAmbassador {_engine.Tag}: {message}");
@@ -196,7 +196,7 @@ namespace Raven.Server.Rachis
                                         _engine.Log.Info($"CandidateAmbassador {_engine.Tag}: {message}");
                                     }
                                     // we need to abort the current elections
-                                    _engine.SetNewState(RachisConsensus.State.Follower, null, engineCurrentTerm, message);
+                                    _engine.SetNewState(RachisState.Follower, null, engineCurrentTerm, message);
                                     _engine.FoundAboutHigherTerm(rvr.Term);
                                     throw new InvalidOperationException(message);
                                 }

--- a/src/Raven.Server/Rachis/Elector.cs
+++ b/src/Raven.Server/Rachis/Elector.cs
@@ -1,6 +1,7 @@
 using System;
 using System.Threading;
 using Raven.Client.Http;
+using Raven.Client.ServerWide;
 using Raven.Server.ServerWide.Context;
 
 namespace Raven.Server.Rachis
@@ -63,7 +64,7 @@ namespace Raven.Server.Rachis
                                 VoteGranted = false,
                                 // we only report to the node asking for our vote if we are the leader, this gives
                                 // the oust node a authorotative confirmation that they were removed from the cluster
-                                NotInTopology = _engine.CurrentState == RachisConsensus.State.Leader,
+                                NotInTopology = _engine.CurrentState == RachisState.Leader,
                                 Message = $"Node {rv.Source} is not in my topology, cannot vote for it"
                             });
                             _connection.Dispose();
@@ -98,8 +99,8 @@ namespace Raven.Server.Rachis
 
                         if (rv.IsForcedElection == false &&
                             (
-                                _engine.CurrentState == RachisConsensus.State.Leader ||
-                                _engine.CurrentState == RachisConsensus.State.LeaderElect
+                                _engine.CurrentState == RachisState.Leader ||
+                                _engine.CurrentState == RachisState.LeaderElect
                             )
                         )
                         {

--- a/src/Raven.Server/Rachis/Follower.cs
+++ b/src/Raven.Server/Rachis/Follower.cs
@@ -4,6 +4,7 @@ using System.Diagnostics;
 using System.Linq;
 using System.Threading;
 using Raven.Client.Http;
+using Raven.Client.ServerWide;
 using Raven.Server.ServerWide.Context;
 using Sparrow;
 using Voron;
@@ -156,7 +157,7 @@ namespace Raven.Server.Rachis
                             {
                                 _engine.Log.Info("Was notified that I was removed from the node topoloyg, will be moving to passive mode now.");
                             }
-                            _engine.SetNewState(RachisConsensus.State.Passive, null, appendEntries.Term,
+                            _engine.SetNewState(RachisState.Passive, null, appendEntries.Term,
                                                "I was kicked out of the cluster and moved to passive mode");
                             return;
                         }
@@ -624,7 +625,7 @@ namespace Raven.Server.Rachis
             }
             // if leader / candidate, this remove them from play and revert to follower mode
             var engineCurrentTerm = _engine.CurrentTerm;
-            _engine.SetNewState(RachisConsensus.State.Follower, this, engineCurrentTerm,
+            _engine.SetNewState(RachisState.Follower, this, engineCurrentTerm,
                 $"Accepted a new connection from {_connection.Source} in term {negotiation.Term}");
             _engine.LeaderTag = _connection.Source;
             _engine.Timeout.Start(_engine.SwitchToCandidateStateOnTimeout);

--- a/src/Raven.Server/Rachis/FollowerAmbassador.cs
+++ b/src/Raven.Server/Rachis/FollowerAmbassador.cs
@@ -8,6 +8,7 @@ using System.Text;
 using System.Threading;
 using Raven.Client.Exceptions;
 using Raven.Client.Http;
+using Raven.Client.ServerWide;
 using Raven.Server.ServerWide.Context;
 using Sparrow;
 using Sparrow.Binary;
@@ -600,7 +601,7 @@ namespace Raven.Server.Rachis
                     {
                         // we need to abort the current leadership
                         var msg = $"Follower ambassador {_engine.Tag}: found election term {llr.CurrentTerm} that is higher than ours {engineCurrentTerm}";
-                        _engine.SetNewState(RachisConsensus.State.Follower, null, engineCurrentTerm,
+                        _engine.SetNewState(RachisState.Follower, null, engineCurrentTerm,
                             msg);
                         _engine.FoundAboutHigherTerm(llr.CurrentTerm);
                         throw new InvalidOperationException(msg);

--- a/src/Raven.Server/Rachis/Leader.cs
+++ b/src/Raven.Server/Rachis/Leader.cs
@@ -1,12 +1,12 @@
 ﻿using System;
 using System.Collections.Generic;
 using System.Diagnostics;
-using System.IO;
 using System.Linq;
 using System.Text;
 using System.Threading;
 using System.Threading.Tasks;
 using Raven.Client.Http;
+using Raven.Client.ServerWide;
 using Raven.Server.NotificationCenter.Notifications;
 using Raven.Server.NotificationCenter.Notifications.Details;
 using Raven.Server.ServerWide.Commands;
@@ -400,7 +400,7 @@ namespace Raven.Server.Rachis
                 if (clusterTopology.Contains(_engine.LeaderTag) == false)
                 {
                     TaskExecutor.CompleteAndReplace(ref _newEntriesArrived);
-                    _engine.SetNewState(RachisConsensus.State.Passive, this, _engine.CurrentTerm,
+                    _engine.SetNewState(RachisState.Passive, this, _engine.CurrentTerm,
                         "I was kicked out of the cluster and moved to passive mode");
                     return;
                 }

--- a/src/Raven.Server/ServerWide/ClusterStateMachine.cs
+++ b/src/Raven.Server/ServerWide/ClusterStateMachine.cs
@@ -325,7 +325,7 @@ namespace Raven.Server.ServerWide
 
                 try
                 {
-                    updateCommand.Execute(context, items, index, record, _parent.CurrentState == RachisConsensus.State.Passive, out result);
+                    updateCommand.Execute(context, items, index, record, _parent.CurrentState, out result);
                 }
                 catch (Exception e)
                 {

--- a/src/Raven.Server/ServerWide/Commands/ETL/DeleteEtlProcessStateCommand.cs
+++ b/src/Raven.Server/ServerWide/Commands/ETL/DeleteEtlProcessStateCommand.cs
@@ -28,7 +28,7 @@ namespace Raven.Server.ServerWide.Commands.ETL
         }
 
         protected override BlittableJsonReaderObject GetUpdatedValue(long index, DatabaseRecord record, JsonOperationContext context,
-            BlittableJsonReaderObject existingValue, bool isPassive)
+            BlittableJsonReaderObject existingValue, RachisState state)
         {
             return null; // it's going to delete the value
         }

--- a/src/Raven.Server/ServerWide/Commands/ETL/UpdateEtlProcessStateCommand.cs
+++ b/src/Raven.Server/ServerWide/Commands/ETL/UpdateEtlProcessStateCommand.cs
@@ -38,26 +38,26 @@ namespace Raven.Server.ServerWide.Commands.ETL
             return EtlProcessState.GenerateItemName(DatabaseName, ConfigurationName, TransformationName);
         }
 
-        protected override BlittableJsonReaderObject GetUpdatedValue(long index, DatabaseRecord record, JsonOperationContext context, BlittableJsonReaderObject existingValue, bool isPassive)
+        protected override BlittableJsonReaderObject GetUpdatedValue(long index, DatabaseRecord record, JsonOperationContext context, BlittableJsonReaderObject existingValue, RachisState state)
         {
-            EtlProcessState state;
+            EtlProcessState etlState;
 
             if (existingValue != null)
-                state = JsonDeserializationClient.EtlProcessState(existingValue);
+                etlState = JsonDeserializationClient.EtlProcessState(existingValue);
             else
             {
-                state = new EtlProcessState
+                etlState = new EtlProcessState
                 {
                     ConfigurationName = ConfigurationName,
                     TransformationName = TransformationName
                 };
             }
 
-            state.LastProcessedEtagPerNode[NodeTag] = LastProcessedEtag;
-            state.ChangeVector = ChangeVector;
+            etlState.LastProcessedEtagPerNode[NodeTag] = LastProcessedEtag;
+            etlState.ChangeVector = ChangeVector;
 
 
-            return context.ReadObject(state.ToJson(), GetItemId());
+            return context.ReadObject(etlState.ToJson(), GetItemId());
         }
 
         public override void FillJson(DynamicJsonValue json)

--- a/src/Raven.Server/ServerWide/Commands/IncrementClusterIdentityCommand.cs
+++ b/src/Raven.Server/ServerWide/Commands/IncrementClusterIdentityCommand.cs
@@ -32,12 +32,12 @@ namespace Raven.Server.ServerWide.Commands
             return _itemId ?? (_itemId = GetStorageKey(DatabaseName, Prefix));
         }
 
-        protected override BlittableJsonReaderObject GetUpdatedValue(long index, DatabaseRecord record, JsonOperationContext context, BlittableJsonReaderObject existingValue, bool isPassive)
+        protected override BlittableJsonReaderObject GetUpdatedValue(long index, DatabaseRecord record, JsonOperationContext context, BlittableJsonReaderObject existingValue, RachisState state)
         {
             throw new NotImplementedException();
         }
 
-        public override void Execute(TransactionOperationContext context, Table items, long index, DatabaseRecord record, bool isPassive, out object result)
+        public override void Execute(TransactionOperationContext context, Table items, long index, DatabaseRecord record, RachisState state, out object result)
         {
             var identities = context.Transaction.InnerTransaction.ReadTree(ClusterStateMachine.Identities);
             var itemKey = GetItemId();

--- a/src/Raven.Server/ServerWide/Commands/Monitoring/Snmp/UpdateSnmpDatabaseIndexesMappingCommand.cs
+++ b/src/Raven.Server/ServerWide/Commands/Monitoring/Snmp/UpdateSnmpDatabaseIndexesMappingCommand.cs
@@ -41,7 +41,7 @@ namespace Raven.Server.ServerWide.Commands.Monitoring.Snmp
             json[nameof(Indexes)] = new DynamicJsonArray(Indexes);
         }
 
-        protected override BlittableJsonReaderObject GetUpdatedValue(long index, DatabaseRecord record, JsonOperationContext context, BlittableJsonReaderObject previousValue, bool isPassive)
+        protected override BlittableJsonReaderObject GetUpdatedValue(long index, DatabaseRecord record, JsonOperationContext context, BlittableJsonReaderObject previousValue, RachisState state)
         {
             if (previousValue != null)
             {

--- a/src/Raven.Server/ServerWide/Commands/PeriodicBackup/UpdatePeriodicBackupStatusCommand.cs
+++ b/src/Raven.Server/ServerWide/Commands/PeriodicBackup/UpdatePeriodicBackupStatusCommand.cs
@@ -23,7 +23,7 @@ namespace Raven.Server.ServerWide.Commands.PeriodicBackup
             return PeriodicBackupStatus.GenerateItemName(DatabaseName, PeriodicBackupStatus.TaskId);
         }
 
-        protected override BlittableJsonReaderObject GetUpdatedValue(long index, DatabaseRecord record, JsonOperationContext context, BlittableJsonReaderObject existingValue, bool isPassive)
+        protected override BlittableJsonReaderObject GetUpdatedValue(long index, DatabaseRecord record, JsonOperationContext context, BlittableJsonReaderObject existingValue, RachisState state)
         {
             return context.ReadObject(PeriodicBackupStatus.ToJson(), GetItemId());
         }

--- a/src/Raven.Server/ServerWide/Commands/Subscriptions/AcknowledgeSubscriptionBatchCommand.cs
+++ b/src/Raven.Server/ServerWide/Commands/Subscriptions/AcknowledgeSubscriptionBatchCommand.cs
@@ -27,7 +27,7 @@ namespace Raven.Server.ServerWide.Commands.Subscriptions
 
         public override string GetItemId() => SubscriptionState.GenerateSubscriptionItemKeyName(DatabaseName, SubscriptionName);
 
-        protected override BlittableJsonReaderObject GetUpdatedValue(long index, DatabaseRecord record, JsonOperationContext context, BlittableJsonReaderObject existingValue, bool isPassive)
+        protected override BlittableJsonReaderObject GetUpdatedValue(long index, DatabaseRecord record, JsonOperationContext context, BlittableJsonReaderObject existingValue, RachisState state)
         {
             var subscriptionName = SubscriptionName;
             if (string.IsNullOrEmpty(subscriptionName))
@@ -40,7 +40,7 @@ namespace Raven.Server.ServerWide.Commands.Subscriptions
 
             var subscription = JsonDeserializationCluster.SubscriptionState(existingValue);
 
-            if (record.Topology.WhoseTaskIsIt(subscription, isPassive) != NodeTag)
+            if (record.Topology.WhoseTaskIsIt(subscription, state) != NodeTag)
                 throw new InvalidOperationException($"Can't update subscription with name {subscriptionName} by node {NodeTag}, because it's not it's task to update this subscription");
 
             if (ChangeVector == nameof(Constants.Documents.SubscriptionChangeVectorSpecialStates.DoNotChange))

--- a/src/Raven.Server/ServerWide/Commands/Subscriptions/DeleteSubscriptionCommand.cs
+++ b/src/Raven.Server/ServerWide/Commands/Subscriptions/DeleteSubscriptionCommand.cs
@@ -30,12 +30,12 @@ namespace Raven.Server.ServerWide.Commands.Subscriptions
             throw new NotImplementedException();
         }
 
-        protected override BlittableJsonReaderObject GetUpdatedValue(long index, DatabaseRecord record, JsonOperationContext context, BlittableJsonReaderObject existingValue, bool isPassive)
+        protected override BlittableJsonReaderObject GetUpdatedValue(long index, DatabaseRecord record, JsonOperationContext context, BlittableJsonReaderObject existingValue, RachisState state)
         {
             throw new NotImplementedException();
         }
 
-        public override unsafe void Execute(TransactionOperationContext context, Table items, long index, DatabaseRecord record, bool isPassive, out object result)
+        public override unsafe void Execute(TransactionOperationContext context, Table items, long index, DatabaseRecord record, RachisState state, out object result)
         {
             result = null;
             var itemKey = SubscriptionState.GenerateSubscriptionItemKeyName(DatabaseName, SubscriptionName);

--- a/src/Raven.Server/ServerWide/Commands/Subscriptions/PutSubscriptionCommand.cs
+++ b/src/Raven.Server/ServerWide/Commands/Subscriptions/PutSubscriptionCommand.cs
@@ -33,13 +33,13 @@ namespace Raven.Server.ServerWide.Commands.Subscriptions
             SubscriptionConnection.ParseSubscriptionQuery(query);
         }
 
-        protected override BlittableJsonReaderObject GetUpdatedValue(long index, DatabaseRecord record, JsonOperationContext context, BlittableJsonReaderObject existingValue, bool isPassive)
+        protected override BlittableJsonReaderObject GetUpdatedValue(long index, DatabaseRecord record, JsonOperationContext context, BlittableJsonReaderObject existingValue, RachisState state)
         {
             throw new NotImplementedException();
         }
 
 
-        public override unsafe void Execute(TransactionOperationContext context, Table items, long index, DatabaseRecord record, bool isPassive, out object result)
+        public override unsafe void Execute(TransactionOperationContext context, Table items, long index, DatabaseRecord record, RachisState state, out object result)
         {
             result = null;
             var subscriptionId = SubscriptionId ?? index;

--- a/src/Raven.Server/ServerWide/Commands/Subscriptions/ToggleSubscriptionStateCommand.cs
+++ b/src/Raven.Server/ServerWide/Commands/Subscriptions/ToggleSubscriptionStateCommand.cs
@@ -34,12 +34,12 @@ namespace Raven.Server.ServerWide.Commands.Subscriptions
             throw new NotImplementedException();
         }
 
-        protected override BlittableJsonReaderObject GetUpdatedValue(long index, DatabaseRecord record, JsonOperationContext context, BlittableJsonReaderObject existingValue, bool isPassive)
+        protected override BlittableJsonReaderObject GetUpdatedValue(long index, DatabaseRecord record, JsonOperationContext context, BlittableJsonReaderObject existingValue, RachisState state)
         {
             throw new NotImplementedException();
         }
 
-        public override unsafe void Execute(TransactionOperationContext context, Table items, long index, DatabaseRecord record, bool isPassive, out object result)
+        public override unsafe void Execute(TransactionOperationContext context, Table items, long index, DatabaseRecord record, RachisState state, out object result)
         {
             result = null;
             var itemKey = SubscriptionState.GenerateSubscriptionItemKeyName(DatabaseName, SubscriptionName);

--- a/src/Raven.Server/ServerWide/Commands/Subscriptions/UpdateSubscriptionClientConnectionTime.cs
+++ b/src/Raven.Server/ServerWide/Commands/Subscriptions/UpdateSubscriptionClientConnectionTime.cs
@@ -19,7 +19,7 @@ namespace Raven.Server.ServerWide.Commands.Subscriptions
 
         public override string GetItemId() => SubscriptionState.GenerateSubscriptionItemKeyName(DatabaseName, SubscriptionName);
 
-        protected override BlittableJsonReaderObject GetUpdatedValue(long index, DatabaseRecord record, JsonOperationContext context, BlittableJsonReaderObject existingValue, bool isPassive)
+        protected override BlittableJsonReaderObject GetUpdatedValue(long index, DatabaseRecord record, JsonOperationContext context, BlittableJsonReaderObject existingValue, RachisState state)
         {
             var itemId = GetItemId();
             if (existingValue == null)
@@ -27,7 +27,7 @@ namespace Raven.Server.ServerWide.Commands.Subscriptions
 
             var subscription = JsonDeserializationCluster.SubscriptionState(existingValue);
 
-            if (record.Topology.WhoseTaskIsIt(subscription, isPassive) != NodeTag)
+            if (record.Topology.WhoseTaskIsIt(subscription, state) != NodeTag)
                 throw new InvalidOperationException($"Can't update subscription with name {itemId} by node {NodeTag}, because it's not it's task to update this subscription");
 
 

--- a/src/Raven.Server/ServerWide/Commands/UpdateClusterIdentityCommand.cs
+++ b/src/Raven.Server/ServerWide/Commands/UpdateClusterIdentityCommand.cs
@@ -30,12 +30,12 @@ namespace Raven.Server.ServerWide.Commands
             throw new NotSupportedException();
         }
 
-        protected override BlittableJsonReaderObject GetUpdatedValue(long index, DatabaseRecord record, JsonOperationContext context, BlittableJsonReaderObject existingValue, bool isPassive)
+        protected override BlittableJsonReaderObject GetUpdatedValue(long index, DatabaseRecord record, JsonOperationContext context, BlittableJsonReaderObject existingValue, RachisState state)
         {
             throw new NotSupportedException();
         }
 
-        public override void Execute(TransactionOperationContext context, Table items, long index, DatabaseRecord record, bool isPassive, out object result)
+        public override void Execute(TransactionOperationContext context, Table items, long index, DatabaseRecord record, RachisState state, out object result)
         {
             var resultDict = new Dictionary<string, long>();
             var identities = context.Transaction.InnerTransaction.ReadTree(ClusterStateMachine.Identities);

--- a/src/Raven.Server/ServerWide/Commands/UpdateValueForDatabaseCommand.cs
+++ b/src/Raven.Server/ServerWide/Commands/UpdateValueForDatabaseCommand.cs
@@ -17,14 +17,14 @@ namespace Raven.Server.ServerWide.Commands
         public abstract void FillJson(DynamicJsonValue json);
 
         protected abstract BlittableJsonReaderObject GetUpdatedValue(long index, DatabaseRecord record, JsonOperationContext context,
-            BlittableJsonReaderObject existingValue, bool isPassive);
+            BlittableJsonReaderObject existingValue, RachisState state);
 
         public static string GetStorageKey(string databaseName, string prefix)
         {
             return $"{Constants.Documents.Prefix}{databaseName.ToLowerInvariant()}/identities/{prefix?.ToLowerInvariant()}";
         }
 
-        public virtual unsafe void Execute(TransactionOperationContext context, Table items, long index, DatabaseRecord record, bool isPassive, out object result)
+        public virtual unsafe void Execute(TransactionOperationContext context, Table items, long index, DatabaseRecord record, RachisState state, out object result)
         {
             BlittableJsonReaderObject itemBlittable = null;
             var itemKey = GetItemId();
@@ -37,7 +37,7 @@ namespace Raven.Server.ServerWide.Commands
                     itemBlittable = new BlittableJsonReaderObject(ptr, size, context);
                 }
 
-                itemBlittable = GetUpdatedValue(index, record, context, itemBlittable, isPassive);
+                itemBlittable = GetUpdatedValue(index, record, context, itemBlittable, state);
 
                 // if returned null, means, there is nothing to update and we just wanted to delete the value
                 if (itemBlittable == null)

--- a/src/Raven.Server/ServerWide/Maintenance/ClusterObserver.cs
+++ b/src/Raven.Server/ServerWide/Maintenance/ClusterObserver.cs
@@ -529,7 +529,7 @@ namespace Raven.Server.ServerWide.Maintenance
             var url = clusterTopology.GetUrlFromTag(promotable);
             topology.PredefinedMentors.TryGetValue(promotable, out var mentor);
             var task = new PromotableTask(promotable, url, dbName, mentor);
-            mentorNode = topology.WhoseTaskIsIt(task, _server.IsPassive());
+            mentorNode = topology.WhoseTaskIsIt(task, _server.Engine.CurrentState);
 
             if (mentorNode == null)
             {

--- a/src/Raven.Server/ServerWide/ServerStore.cs
+++ b/src/Raven.Server/ServerWide/ServerStore.cs
@@ -146,7 +146,7 @@ namespace Raven.Server.ServerWide
 
         public ClusterStateMachine Cluster => _engine?.StateMachine;
         public string LeaderTag => _engine.LeaderTag;
-        public RachisConsensus.State CurrentState => _engine.CurrentState;
+        public RachisState CurrentRachisState => _engine.CurrentState;
         public string NodeTag => _engine.Tag;
 
         public bool Disposed => _disposed;
@@ -175,7 +175,7 @@ namespace Raven.Server.ServerWide
                 {
                     if (_engine.LeaderTag != NodeTag)
                     {
-                        await _engine.WaitForState(RachisConsensus.State.Leader)
+                        await _engine.WaitForState(RachisState.Leader)
                             .WithCancellation(_shutdownNotification.Token);
                         continue;
                     }
@@ -204,7 +204,7 @@ namespace Raven.Server.ServerWide
                                 ClusterMaintenanceSupervisor.AddToCluster(node.Key, clusterTopology.GetUrlFromTag(node.Key));
                             }
 
-                            var leaderChanged = _engine.WaitForLeaveState(RachisConsensus.State.Leader);
+                            var leaderChanged = _engine.WaitForLeaveState(RachisState.Leader);
                             if (await Task.WhenAny(topologyChangedTask, leaderChanged)
                                     .WithCancellation(_shutdownNotification.Token) == leaderChanged)
                                 break;
@@ -453,13 +453,14 @@ namespace Raven.Server.ServerWide
             {
                 OnTopologyChanged(null, GetClusterTopology(context));
 
-                // if we are in passive state, we prevent from tasks to be performed by this node.
-                if (state.From == RachisConsensus.State.Passive || state.To == RachisConsensus.State.Passive)
+                // if we are in passive/candidate state, we prevent from tasks to be performed by this node.
+                if (state.From == RachisState.Passive || state.To == RachisState.Passive || 
+                    state.From == RachisState.Candidate || state.To == RachisState.Candidate)
                 {
                     RefreshOutgoingTasks();
                 }
 
-                if (state.To == RachisConsensus.State.LeaderElect)
+                if (state.To == RachisState.LeaderElect)
                 {
                     _engine.CurrentLeader.OnNodeStatusChange += OnTopologyChanged;
                 }
@@ -507,17 +508,17 @@ namespace Raven.Server.ServerWide
         {
             Dictionary<string, NodeStatus> nodesStatuses = null;
 
-            switch (CurrentState)
+            switch (CurrentRachisState)
             {
-                case RachisConsensus.State.Leader:
+                case RachisState.Leader:
                     nodesStatuses = _engine.CurrentLeader?.GetStatus();
 
                     break;
-                case RachisConsensus.State.Candidate:
+                case RachisState.Candidate:
                     nodesStatuses = _engine.Candidate?.GetStatus();
 
                     break;
-                case RachisConsensus.State.Follower:
+                case RachisState.Follower:
                     var leaderTag = _engine.LeaderTag;
                     if (leaderTag != null)
                     {
@@ -1146,7 +1147,7 @@ namespace Raven.Server.ServerWide
 
         public void EnsureNotPassive()
         {
-            if (_engine.CurrentState != RachisConsensus.State.Passive)
+            if (_engine.CurrentState != RachisState.Passive)
                 return;
 
             _engine.Bootstrap(_server.ServerStore.NodeHttpServerUrl);
@@ -1188,12 +1189,12 @@ namespace Raven.Server.ServerWide
 
         public bool IsLeader()
         {
-            return _engine.CurrentState == RachisConsensus.State.Leader;
+            return _engine.CurrentState == RachisState.Leader;
         }
 
         public bool IsPassive()
         {
-            return _engine.CurrentState == RachisConsensus.State.Passive;
+            return _engine.CurrentState == RachisState.Passive;
         }
 
         public Task<(long Index, object Result)> SendToLeaderAsync(CommandBase cmd)
@@ -1345,11 +1346,11 @@ namespace Raven.Server.ServerWide
             {
                 ServerShutdown.ThrowIfCancellationRequested();
 
-                if (_engine.CurrentState == RachisConsensus.State.Leader)
+                if (_engine.CurrentState == RachisState.Leader)
                 {
                     return await _engine.PutAsync(cmd);
                 }
-                if (_engine.CurrentState == RachisConsensus.State.Passive)
+                if (_engine.CurrentState == RachisState.Passive)
                 {
                     ThrowInvalidEngineState(cmd);
                 }
@@ -1496,9 +1497,9 @@ namespace Raven.Server.ServerWide
             return _engine.WaitForTopology(state);
         }
 
-        public Task WaitForState(RachisConsensus.State state)
+        public Task WaitForState(RachisState rachisState)
         {
-            return _engine.WaitForState(state);
+            return _engine.WaitForState(rachisState);
         }
 
         public void ClusterAcceptNewConnection(Stream client)

--- a/src/Raven.Server/Web/System/DatabasesHandler.cs
+++ b/src/Raven.Server/Web/System/DatabasesHandler.cs
@@ -377,7 +377,7 @@ namespace Raven.Server.Web.System
                 {
                     topology.PredefinedMentors.TryGetValue(promotable, out var mentorCandidate);
                     var node = GetNode(databaseName, clusterTopology, promotable, mentorCandidate, out var promotableTask);
-                    var mentor = topology.WhoseTaskIsIt(promotableTask, ServerStore.IsPassive());
+                    var mentor = topology.WhoseTaskIsIt(promotableTask, ServerStore.Engine.CurrentState);
                     nodesTopology.Promotables.Add(GetNodeId(node, mentor));
                     SetNodeStatus(topology, promotable, nodesTopology);
                 }
@@ -385,7 +385,7 @@ namespace Raven.Server.Web.System
                 foreach (var rehab in topology.Rehabs)
                 {
                     var node = GetNode(databaseName, clusterTopology, rehab, null, out var promotableTask);
-                    var mentor = topology.WhoseTaskIsIt(promotableTask, ServerStore.IsPassive());
+                    var mentor = topology.WhoseTaskIsIt(promotableTask, ServerStore.Engine.CurrentState);
                     nodesTopology.Rehabs.Add(GetNodeId(node, mentor));
                     SetNodeStatus(topology, rehab, nodesTopology);
                 }

--- a/src/Raven.Server/Web/System/OngoingTasksHandler.cs
+++ b/src/Raven.Server/Web/System/OngoingTasksHandler.cs
@@ -86,7 +86,7 @@ namespace Raven.Server.Web.System
             foreach (var keyValue in ClusterStateMachine.ReadValuesStartingWith(context, SubscriptionState.SubscriptionPrefix(databaseRecord.DatabaseName)))
             {
                 var subscriptionState = JsonDeserializationClient.SubscriptionState(keyValue.Value);
-                var tag = databaseRecord.Topology.WhoseTaskIsIt(subscriptionState, ServerStore.IsPassive());
+                var tag = databaseRecord.Topology.WhoseTaskIsIt(subscriptionState, ServerStore.Engine.CurrentState);
 
                 yield return new OngoingTaskSubscription
                 {
@@ -121,7 +121,7 @@ namespace Raven.Server.Web.System
         {
             NodeId responsibale = null;
 
-            var tag = dbTopology.WhoseTaskIsIt(watcher, ServerStore.IsPassive());
+            var tag = dbTopology.WhoseTaskIsIt(watcher, ServerStore.Engine.CurrentState);
             if (tag != null)
             {
                 responsibale = new NodeId
@@ -171,7 +171,7 @@ namespace Raven.Server.Web.System
 
             foreach (var backupConfiguration in databaseRecord.PeriodicBackups)
             {
-                var tag = dbTopology.WhoseTaskIsIt(backupConfiguration, ServerStore.IsPassive());
+                var tag = dbTopology.WhoseTaskIsIt(backupConfiguration, ServerStore.Engine.CurrentState);
 
                 var backupDestinations = GetBackupDestinations(backupConfiguration);
 
@@ -224,7 +224,7 @@ namespace Raven.Server.Web.System
             {
                 foreach (var ravenEtl in databaseRecord.RavenEtls)
                 {
-                    var tag = dbTopology.WhoseTaskIsIt(ravenEtl, ServerStore.IsPassive());
+                    var tag = dbTopology.WhoseTaskIsIt(ravenEtl, ServerStore.Engine.CurrentState);
 
                     var taskState = GetEtlTaskState(ravenEtl);
 
@@ -283,7 +283,7 @@ namespace Raven.Server.Web.System
             {
                 foreach (var sqlEtl in databaseRecord.SqlEtls)
                 {
-                    var tag = dbTopology.WhoseTaskIsIt(sqlEtl, ServerStore.IsPassive());
+                    var tag = dbTopology.WhoseTaskIsIt(sqlEtl, ServerStore.Engine.CurrentState);
 
                     var taskState = GetEtlTaskState(sqlEtl);
 
@@ -361,7 +361,7 @@ namespace Raven.Server.Web.System
                                 break;
                             }
 
-                            tag = dbTopology?.WhoseTaskIsIt(backupConfiguration, ServerStore.IsPassive());
+                            tag = dbTopology?.WhoseTaskIsIt(backupConfiguration, ServerStore.Engine.CurrentState);
                             var backupDestinations = GetBackupDestinations(backupConfiguration);
                             var backupStatus = Database.PeriodicBackupRunner.GetBackupStatus(key);
                             var nextBackup = Database.PeriodicBackupRunner.GetNextBackupDetails(record, backupConfiguration, backupStatus);
@@ -434,7 +434,7 @@ namespace Raven.Server.Web.System
                             }
 
                             var subscriptionState = JsonDeserializationClient.SubscriptionState(doc);
-                            tag = dbTopology?.WhoseTaskIsIt(subscriptionState, ServerStore.IsPassive());
+                            tag = dbTopology?.WhoseTaskIsIt(subscriptionState, ServerStore.Engine.CurrentState);
 
                             var subscriptionStateInfo = new SubscriptionStateWithNodeDetails
                             {
@@ -564,7 +564,7 @@ namespace Raven.Server.Web.System
                 using (context.OpenReadTransaction())
                 {
                     var record = ServerStore.Cluster.ReadDatabase(context, Database.Name);
-                    responsibleNode = record.Topology.WhoseTaskIsIt(watcher, ServerStore.IsPassive());
+                    responsibleNode = record.Topology.WhoseTaskIsIt(watcher, ServerStore.Engine.CurrentState);
                 }
 
                 HttpContext.Response.StatusCode = (int)HttpStatusCode.Created;

--- a/test/RachisTests/AddNodeToClusterTests.cs
+++ b/test/RachisTests/AddNodeToClusterTests.cs
@@ -101,7 +101,7 @@ namespace RachisTests
 
             // remove the node from the cluster that is responsible for the external replication
             Assert.True(await leader.ServerStore.RemoveFromClusterAsync(watcherRes.ResponsibleNode).WaitAsync(fromSeconds));
-            Assert.True(await responsibleServer.ServerStore.WaitForState(RachisConsensus.State.Passive).WaitAsync(fromSeconds));
+            Assert.True(await responsibleServer.ServerStore.WaitForState(RachisState.Passive).WaitAsync(fromSeconds));
 
             var dbInstance = await responsibleServer.ServerStore.DatabasesLandlord.TryGetOrCreateResourceStore("MainDB");
             await WaitForValueAsync(() => dbInstance.ReplicationLoader.OutgoingConnections.Count(), 0);
@@ -140,7 +140,7 @@ namespace RachisTests
             // rejoin the node
             var newLeader = Servers.Single(s => s.ServerStore.IsLeader());
             Assert.True(await newLeader.ServerStore.AddNodeToClusterAsync(responsibleServer.WebUrl, watcherRes.ResponsibleNode).WaitAsync(fromSeconds));
-            Assert.True(await responsibleServer.ServerStore.WaitForState(RachisConsensus.State.Follower).WaitAsync(fromSeconds));
+            Assert.True(await responsibleServer.ServerStore.WaitForState(RachisState.Follower).WaitAsync(fromSeconds));
 
             using (var session = responsibleStore.OpenSession())
             {

--- a/test/RachisTests/BasicCluster.cs
+++ b/test/RachisTests/BasicCluster.cs
@@ -2,6 +2,7 @@
 using System.Collections.Generic;
 using System.Linq;
 using System.Threading.Tasks;
+using Raven.Client.ServerWide;
 using Raven.Server.Rachis;
 using Raven.Server.ServerWide.Context;
 using Sparrow.Json;
@@ -30,7 +31,7 @@ namespace RachisTests
                 await follower.WaitForTopology(Leader.TopologyModification.Voter);
             }
 
-            var leaderSelected = followers.Select(x => x.WaitForState(RachisConsensus.State.Leader).ContinueWith(_ => x)).ToArray();
+            var leaderSelected = followers.Select(x => x.WaitForState(RachisState.Leader).ContinueWith(_ => x)).ToArray();
 
             using (var ctx = JsonOperationContext.ShortTermSingleUse())
             {
@@ -60,7 +61,7 @@ namespace RachisTests
 
             followers = followers.Except(new[] { leader }).ToArray();
 
-            leaderSelected = followers.Select(x => x.WaitForState(RachisConsensus.State.Leader).ContinueWith(_ => x)).ToArray();
+            leaderSelected = followers.Select(x => x.WaitForState(RachisState.Leader).ContinueWith(_ => x)).ToArray();
 
             foreach (var follower in followers)
             {
@@ -107,8 +108,8 @@ namespace RachisTests
             await bUpgraded;
             await cUpgraded;
 
-            var bLeader = b.WaitForState(RachisConsensus.State.Leader);
-            var cLeader = c.WaitForState(RachisConsensus.State.Leader);
+            var bLeader = b.WaitForState(RachisState.Leader);
+            var cLeader = c.WaitForState(RachisState.Leader);
 
             using (var ctx = JsonOperationContext.ShortTermSingleUse())
             {

--- a/test/RachisTests/DatabaseCluster/ClusterDatabaseMaintenance.cs
+++ b/test/RachisTests/DatabaseCluster/ClusterDatabaseMaintenance.cs
@@ -213,12 +213,12 @@ namespace RachisTests.DatabaseCluster
                 }
                 // bring the node back to live and ensure that he moves to passive state
                 Servers[1] = GetNewServer(new Dictionary<string, string> { { RavenConfiguration.GetKey(x => x.Core.PublicServerUrl), urls[0] }, { RavenConfiguration.GetKey(x => x.Core.ServerUrl), urls[0] } }, runInMemory: false, deletePrevious: false, partialPath: dataDir);
-                await Servers[1].ServerStore.WaitForState(RachisConsensus.State.Passive).WaitAsync(TimeSpan.FromSeconds(30));
-                Assert.Equal(RachisConsensus.State.Passive, Servers[1].ServerStore.CurrentState);
+                await Servers[1].ServerStore.WaitForState(RachisState.Passive).WaitAsync(TimeSpan.FromSeconds(30));
+                Assert.Equal(RachisState.Passive, Servers[1].ServerStore.CurrentRachisState);
                 // rejoin the node to the cluster
                 await leader.ServerStore.AddNodeToClusterAsync(urls[0], nodeTag);
-                await Servers[1].ServerStore.WaitForState(RachisConsensus.State.Follower).WaitAsync(TimeSpan.FromSeconds(300));
-                Assert.Equal(RachisConsensus.State.Follower, Servers[1].ServerStore.CurrentState);
+                await Servers[1].ServerStore.WaitForState(RachisState.Follower).WaitAsync(TimeSpan.FromSeconds(300));
+                Assert.Equal(RachisState.Follower, Servers[1].ServerStore.CurrentRachisState);
             }
         }
 
@@ -464,7 +464,7 @@ namespace RachisTests.DatabaseCluster
                 // remove and rejoin to change the url
                 await leader.ServerStore.RemoveFromClusterAsync(nodeTag);
                 await leader.ServerStore.AddNodeToClusterAsync(Servers[1].ServerStore.NodeHttpServerUrl, nodeTag);
-                await Servers[1].ServerStore.WaitForState(RachisConsensus.State.Follower);
+                await Servers[1].ServerStore.WaitForState(RachisState.Follower);
                 await Task.Delay(TimeSpan.FromSeconds(5)); // wait for the observer to update the status
                 dbToplogy = (await leaderStore.Admin.Server.SendAsync(new GetDatabaseRecordOperation(databaseName))).Topology;
                 Assert.Equal(groupSize, dbToplogy.Members.Count);

--- a/test/RachisTests/SubscriptionsFailover.cs
+++ b/test/RachisTests/SubscriptionsFailover.cs
@@ -16,6 +16,7 @@ using Raven.Client.Documents.Session;
 using Raven.Client.Exceptions.Documents.Subscriptions;
 using Raven.Client.Extensions;
 using Raven.Client.Http;
+using Raven.Client.ServerWide;
 using Raven.Client.ServerWide.Operations;
 using Raven.Client.ServerWide.Revisions;
 using Raven.Client.Util;
@@ -508,7 +509,7 @@ namespace RachisTests
 
             if (mentor != null)
             {
-                Assert.Equal(mentor, record.Topology.WhoseTaskIsIt(subscripitonState, false));
+                Assert.Equal(mentor, record.Topology.WhoseTaskIsIt(subscripitonState, RachisState.Follower));
             }
 
             var task = subscription.Run(a =>
@@ -556,7 +557,7 @@ namespace RachisTests
                 var databaseRecord = someServer.ServerStore.Cluster.ReadDatabase(context, defaultDatabase);
                 var db = await someServer.ServerStore.DatabasesLandlord.TryGetOrCreateResourceStore(defaultDatabase).ConfigureAwait(false);
                 var subscriptionState = db.SubscriptionStorage.GetSubscriptionFromServerStore(subscriptionName);
-                tag = databaseRecord.Topology.WhoseTaskIsIt(subscriptionState, someServer.ServerStore.IsPassive());
+                tag = databaseRecord.Topology.WhoseTaskIsIt(subscriptionState, someServer.ServerStore.Engine.CurrentState);
             }
             Assert.NotNull(tag);
             DisposeServerAndWaitForFinishOfDisposal(Servers.First(x => x.ServerStore.NodeTag == tag));
@@ -615,7 +616,7 @@ namespace RachisTests
 
                 if (mentor != null)
                 {
-                    Assert.Equal(mentor, record.Topology.WhoseTaskIsIt(subscripitonState, false));
+                    Assert.Equal(mentor, record.Topology.WhoseTaskIsIt(subscripitonState, RachisState.Follower));
                 }
 
                 await DisposeServerAndWaitForFinishOfDisposalAsync(leader);
@@ -666,7 +667,7 @@ namespace RachisTests
 
                 if (mentor != null)
                 {
-                    Assert.Equal(mentor, record.Topology.WhoseTaskIsIt(subscripitonState, false));
+                    Assert.Equal(mentor, record.Topology.WhoseTaskIsIt(subscripitonState, RachisState.Follower));
                 }
 
                 using (var subscription = store.Subscriptions.Open<User>(new SubscriptionConnectionOptions(subscriptionName)
@@ -730,7 +731,7 @@ namespace RachisTests
 
                 if (mentor != null)
                 {
-                    Assert.Equal(mentor, record.Topology.WhoseTaskIsIt(subscripitonState, false));
+                    Assert.Equal(mentor, record.Topology.WhoseTaskIsIt(subscripitonState, RachisState.Follower));
                 }
 
                 using (var subscription = store.Subscriptions.Open<User>(new SubscriptionConnectionOptions(subscriptionName)

--- a/test/Tests.Infrastructure/ClusterTestBase.cs
+++ b/test/Tests.Infrastructure/ClusterTestBase.cs
@@ -377,7 +377,7 @@ namespace Tests.Infrastructure
                 await follower.ServerStore.WaitForTopology(Leader.TopologyModification.Voter);
             }
             // ReSharper disable once PossibleNullReferenceException
-            Assert.True(await leader.ServerStore.WaitForState(RachisConsensus.State.Leader).WaitAsync(numberOfNodes * ElectionTimeoutInMs),
+            Assert.True(await leader.ServerStore.WaitForState(RachisState.Leader).WaitAsync(numberOfNodes * ElectionTimeoutInMs),
                 "The leader has changed while waiting for cluster to become stable. Status: " + leader.ServerStore.LastStateChangeReason());
             return leader;
         }
@@ -427,7 +427,7 @@ namespace Tests.Infrastructure
                 await follower.ServerStore.WaitForTopology(Leader.TopologyModification.Voter);
             }
             // ReSharper disable once PossibleNullReferenceException
-            var condition = await leader.ServerStore.WaitForState(RachisConsensus.State.Leader).WaitAsync(numberOfNodes * ElectionTimeoutInMs * 5);
+            var condition = await leader.ServerStore.WaitForState(RachisState.Leader).WaitAsync(numberOfNodes * ElectionTimeoutInMs * 5);
             var states = string.Empty;
             if (condition == false)
             {
@@ -479,7 +479,7 @@ namespace Tests.Infrastructure
                 await follower.ServerStore.WaitForTopology(Leader.TopologyModification.Voter);
             }
             // ReSharper disable once PossibleNullReferenceException
-            var condition = await leader.ServerStore.WaitForState(RachisConsensus.State.Leader).WaitAsync(numberOfNodes * ElectionTimeoutInMs * 5);
+            var condition = await leader.ServerStore.WaitForState(RachisState.Leader).WaitAsync(numberOfNodes * ElectionTimeoutInMs * 5);
             var states = string.Empty;
             if (condition == false)
             {
@@ -511,7 +511,7 @@ namespace Tests.Infrastructure
         public async Task WaitForLeader(TimeSpan timeout)
         {
             var tasks = Servers
-                .Select(server => server.ServerStore.WaitForState(RachisConsensus.State.Leader))
+                .Select(server => server.ServerStore.WaitForState(RachisState.Leader))
                 .ToList();
 
             tasks.Add(Task.Delay(timeout));


### PR DESCRIPTION
…ination

- move the rachis state enum to the client namespace.
- WhoseTaskIsIt will return null if the server is in Passive or Candidate state.