### PR TITLE
RavenDB-8837 Large scratch buffer allocation broken into separate pag…

### DIFF
--- a/src/Voron/Impl/Scratch/ScratchBufferFile.cs
+++ b/src/Voron/Impl/Scratch/ScratchBufferFile.cs
@@ -217,8 +217,7 @@ namespace Voron.Impl.Scratch
             _allocatedPagesCount -= value.NumberOfPages;
             _allocatedPages.Remove(page);
 
-            if (value.Size == 0)
-                return;// this value was broken up to smaller sections, only the first page there is valid for space allocations
+            Debug.Assert(value.Size > 0);
 
             if (asOfTxId == -1)
             {
@@ -306,12 +305,12 @@ namespace Voron.Impl.Scratch
                 InvalidAttemptToBreakupPageThatWasntAllocated(value);
 
             _allocatedPages.Add(value.PositionInScratchBuffer,
-                       new PageFromScratchBuffer(value.ScratchFileNumber, value.PositionInScratchBuffer, value.Size, 1));
+                       new PageFromScratchBuffer(value.ScratchFileNumber, value.PositionInScratchBuffer, 1, 1));
 
             for (int i = 1; i < value.NumberOfPages; i++)
             {
                 _allocatedPages.Add(value.PositionInScratchBuffer + i,
-                    new PageFromScratchBuffer(value.ScratchFileNumber, value.PositionInScratchBuffer + i, 0, 1));
+                    new PageFromScratchBuffer(value.ScratchFileNumber, value.PositionInScratchBuffer + i, 1, 1));
             }
 
             _scratchPager.BreakLargeAllocationToSeparatePages(tx, value.PositionInScratchBuffer);

--- a/test/FastTests/Voron/Bugs/RavenDB_8837.cs
+++ b/test/FastTests/Voron/Bugs/RavenDB_8837.cs
@@ -1,0 +1,76 @@
+﻿using Raven.Server.Documents;
+using Voron;
+using Voron.Data.RawData;
+using Xunit;
+
+namespace FastTests.Voron.Bugs
+{
+    public class RavenDB_8837 : StorageTest
+    {
+        protected override void Configure(StorageEnvironmentOptions options)
+        {
+            options.ManualFlushing = true;
+        }
+
+        [Fact]
+        public void Braking_large_allocation_in_scratch_file_has_to_really_create_separate_pages_of_size_one()
+        {
+            long pageNumber;
+            using (var tx = Env.WriteTransaction())
+            {
+                var section = ActiveRawDataSmallSection.Create(tx.LowLevelTransaction, "test", (byte)TableType.None);
+                pageNumber = section.PageNumber;
+
+                tx.Commit();
+            }
+
+            using (var tx = Env.WriteTransaction())
+            {
+                // just to increment transaction id
+                tx.LowLevelTransaction.ModifyPage(0);
+                tx.Commit();
+            }
+
+            using (var tx = Env.WriteTransaction())
+            {
+                var section = new ActiveRawDataSmallSection(tx.LowLevelTransaction, pageNumber);
+
+                section.DeleteSection(pageNumber);
+
+                var allocatePage = tx.LowLevelTransaction.AllocatePage(1);
+
+                // the case is that the free space handling will return same page number as we just freed by deleting raw data section
+                // if the below assertion fails it means we have changed voron internals and this test might require adjustments
+
+                Assert.Equal(allocatePage.PageNumber, pageNumber); 
+
+                tx.Commit();
+            }
+
+            Env.FlushLogToDataFile();
+
+            using (var tx = Env.WriteTransaction())
+            {
+                // just to increment transaction id
+                tx.LowLevelTransaction.ModifyPage(0);
+                tx.Commit();
+            }
+
+            using (var tx = Env.WriteTransaction())
+            {
+                // just to increment transaction id
+                tx.LowLevelTransaction.ModifyPage(0);
+                tx.Commit();
+            }
+
+            using (var tx = Env.WriteTransaction())
+            {
+                // ensure below call won't throw 'An item with the same key has already been added'
+                // from ScratchBufferFile.BreakLargeAllocationToSeparatePages
+
+                ActiveRawDataSmallSection.Create(tx.LowLevelTransaction, "test", (byte)TableType.None); 
+                tx.Commit();
+            }
+        }
+    }
+}


### PR DESCRIPTION
…es has to create pages of size 1. They can be freed separately during the flush so we cannot assume they we'll be available at the same time as a single unit when we want to reuse them for next allocations.