### PR TITLE
RavenDB-9096 fixed long.MinValue parsing

### DIFF
--- a/test/SlowTests/Issues/RavenDB_9096.cs
+++ b/test/SlowTests/Issues/RavenDB_9096.cs
@@ -1,0 +1,45 @@
+﻿using System.Globalization;
+using System.IO;
+using System.Linq;
+using System.Text;
+using System.Threading.Tasks;
+using FastTests;
+using Raven.Client.Documents;
+using Raven.Client.Documents.Indexes;
+using Sparrow.Json;
+using Sparrow.Json.Parsing;
+using Xunit;
+
+namespace SlowTests.Issues
+{
+    public class RavenDB_9096 : RavenTestBase
+    {
+        [Fact]
+        public void LongMinShouldBeParsedCorrectly()
+        {
+            using (var context = JsonOperationContext.ShortTermSingleUse())
+            {
+                var djv = new DynamicJsonValue
+                {
+                    ["Value"] = long.MinValue
+                };
+
+                var json = context.ReadObject(djv, "json");
+
+                Assert.True(json.TryGetMember("Value", out var value));
+                Assert.Equal(long.MinValue, value);
+
+                var s = json.ToString();
+
+                using (var stream = new MemoryStream(Encoding.UTF8.GetBytes(s)))
+                {
+                    json = context.ReadForMemory(stream, "json");
+
+                    Assert.True(json.TryGet("Value", out LazyNumberValue lnv));
+
+                    Assert.Equal(long.MinValue, lnv.ToInt64(CultureInfo.InvariantCulture));
+                }
+            }
+        }
+    }
+}


### PR DESCRIPTION
@redknightlois Please review this PR,

there is also a potential issue with re-parsing, where we are no longer geting Int64, but LazyNumberValue. It should not affect anything, but it could be handled as Int64 directly.

The issue is here: https://github.com/ravendb/ravendb/blob/v4.0/src/Sparrow/Json/Parsing/UnmanagedJsonParser.cs#L572-L573
Wondering if we can write there:
```
_isDouble = next != long.MinValue
```

Would appreciate if someone with better knowledge of Blittable could look at this.