### PR TITLE
RavenDB-9171

### DIFF
--- a/src/Raven.Client/ServerWide/ExternalReplication.cs
+++ b/src/Raven.Client/ServerWide/ExternalReplication.cs
@@ -82,8 +82,6 @@ namespace Raven.Client.ServerWide
             unchecked
             {
                 var hashCode = (ulong)base.GetHashCode();
-                hashCode = (hashCode * 397) ^ CalculateStringHash(Name);
-                hashCode = (hashCode * 397) ^ CalculateStringHash(MentorNode);
                 hashCode = (hashCode * 397) ^ CalculateStringHash(ConnectionStringName);
                 return (int)hashCode;
             }
@@ -93,8 +91,6 @@ namespace Raven.Client.ServerWide
         {
             var externalReplication = (ExternalReplication)other;
             return base.IsEqualTo(other) && 
-                   string.Equals(Name, externalReplication.Name, StringComparison.OrdinalIgnoreCase) &&
-                   string.Equals(MentorNode, externalReplication.MentorNode, StringComparison.OrdinalIgnoreCase) &&
                    string.Equals(ConnectionStringName, externalReplication.ConnectionStringName, StringComparison.OrdinalIgnoreCase);
         }
 

--- a/src/Raven.Server/Documents/DatabasesLandlord.cs
+++ b/src/Raven.Server/Documents/DatabasesLandlord.cs
@@ -106,7 +106,7 @@ namespace Raven.Server.Documents
                                 "This node was recently recovered from rehabilitation and should be deleted to maintain the replication factor, " +
                                 "but it may contain documents that are not existing in the rest of the database-group.\n" +
                                 $"The current change-vector is {dbChangeVector}, while issued change-vector for the deletion is {mentorsChangeVector}",
-                                AlertType.DatabaseTopologyWarning,
+                                AlertType.DeletionError,
                                 NotificationSeverity.Error
                             ));
                             return;
@@ -171,8 +171,10 @@ namespace Raven.Server.Documents
             }
             catch (Exception e)
             {
+                var title = $"Failed to digest change of type '{changeType}' for database '{t.DatabaseName}'";
                 if (_logger.IsInfoEnabled)
-                    _logger.Info($"Could not react to a cluster database change of type {changeType} for db {t.DatabaseName}", e);
+                    _logger.Info(title, e);
+                _serverStore.NotificationCenter.Add(AlertRaised.Create(title, e.Message, AlertType.DeletionError, NotificationSeverity.Error));
             }
             finally
             {

--- a/src/Raven.Server/Documents/Revisions/RevisionsStorage.cs
+++ b/src/Raven.Server/Documents/Revisions/RevisionsStorage.cs
@@ -568,6 +568,11 @@ namespace Raven.Server.Documents.Revisions
         {
             Debug.Assert(changeVector != null, "Change vector must be set");
 
+            if (flags.Contain(DocumentFlags.HasAttachments))
+            {
+                flags &= ~DocumentFlags.HasAttachments;
+            }
+
             var configuration = GetRevisionsConfiguration(collectionName.Name, flags);
             if (configuration.Active == false)
                 return;

--- a/src/Raven.Server/NotificationCenter/Notifications/AlertType.cs
+++ b/src/Raven.Server/NotificationCenter/Notifications/AlertType.cs
@@ -29,6 +29,8 @@ namespace Raven.Server.NotificationCenter.Notifications
         NonDurableFileSystem,
         RecoveryError,
         RestoreError,
+        DeletionError,
+
         ClusterTopologyWarning,
         DatabaseTopologyWarning,
         SwappingHddInsteadOfSsd,

--- a/src/Raven.Server/ServerWide/Maintenance/ClusterObserver.cs
+++ b/src/Raven.Server/ServerWide/Maintenance/ClusterObserver.cs
@@ -232,6 +232,9 @@ namespace Raven.Server.ServerWide.Maintenance
             Dictionary<string, ClusterNodeStatusReport> previous,
             ref List<DeleteDatabaseCommand> deletions)
         {
+            if (record.Disabled)
+                return null;
+
             var topology = record.Topology;
             var hasLivingNodes = false;
             foreach (var member in topology.Members)

--- a/test/FastTests/Server/Replication/ReplicationTestBase.cs
+++ b/test/FastTests/Server/Replication/ReplicationTestBase.cs
@@ -212,7 +212,7 @@ namespace FastTests.Server.Replication
             var resList = new List<ModifyOngoingTaskResult>();
             foreach (var store in toStores)
             {
-                var databaseWatcher = new ExternalReplication(store.Database, "ConnectionString");
+                var databaseWatcher = new ExternalReplication(store.Database, $"ConnectionString-{store.Identifier}");
                 ModifyReplicationDestination(databaseWatcher);
                 tasks.Add(AddWatcherToReplicationTopology(fromStore, databaseWatcher));
             }

--- a/test/SlowTests/Client/Attachments/AttachmentsReplication.cs
+++ b/test/SlowTests/Client/Attachments/AttachmentsReplication.cs
@@ -615,7 +615,7 @@ namespace SlowTests.Client.Attachments
             var metadata = session.Advanced.GetMetadataFor(revision);
             var flags = DocumentFlags.HasRevisions | DocumentFlags.Revision | DocumentFlags.FromReplication;
             if (isDeleteRevision)
-                flags = DocumentFlags.DeleteRevision | flags;
+                flags = DocumentFlags.HasRevisions | DocumentFlags.DeleteRevision | DocumentFlags.FromReplication;
             Assert.Equal(flags.ToString(), metadata[Constants.Documents.Metadata.Flags]);
             Assert.False(metadata.ContainsKey(Constants.Documents.Metadata.Attachments));
         }

--- a/test/SlowTests/Client/Attachments/AttachmentsRevisions.cs
+++ b/test/SlowTests/Client/Attachments/AttachmentsRevisions.cs
@@ -167,7 +167,7 @@ namespace SlowTests.Client.Attachments
             var metadata = session.Advanced.GetMetadataFor(revision);
             var flags = DocumentFlags.HasRevisions | DocumentFlags.Revision;
             if (isDeleteRevision)
-                flags = DocumentFlags.DeleteRevision | flags;
+                flags = DocumentFlags.DeleteRevision | DocumentFlags.HasRevisions;
             Assert.Equal(flags.ToString(), metadata[Constants.Documents.Metadata.Flags]);
             Assert.False(metadata.ContainsKey(Constants.Documents.Metadata.Attachments));
         }


### PR DESCRIPTION
RavenDB-9178, Fixing failing tests

RavenDB-9154, Cluster observer will skip disabled databases
 
RavenDB-9101, Showing error when we fail to delete a database

RavenDB-9171, The equality of the external replication will be determined by the connection string name and the destination database. 