### PR TITLE
RavenDB-9193 - Remove duplicate LogQuery call

### DIFF
--- a/src/Raven.Client/Documents/Session/AsyncDocumentQuery.cs
+++ b/src/Raven.Client/Documents/Session/AsyncDocumentQuery.cs
@@ -775,7 +775,6 @@ namespace Raven.Client.Documents.Session
         {
             using (QueryOperation.EnterQueryContext())
             {
-                QueryOperation.LogQuery();
                 var command = QueryOperation.CreateRequest();
                 await TheSession.RequestExecutor.ExecuteAsync(command, TheSession.Context, token).ConfigureAwait(false);
                 QueryOperation.SetResult(command.Result);


### PR DESCRIPTION
See http://issues.hibernatingrhinos.com/issue/RavenDB-9193

Since `QueryOperation.CreateRequest()` already calls  `LogQuery` I'm seeing duplicate messages in my console.