### PR TITLE
PR; StringSupport for: Contains, Split, Trim, ToUpper, ToLower & Replace

### DIFF
--- a/src/Raven.Client/Util/JavascriptConversionExtensions.cs
+++ b/src/Raven.Client/Util/JavascriptConversionExtensions.cs
@@ -736,46 +736,32 @@ namespace Raven.Client.Util
 
                         if (newName == "split")
                         {
-                            writer.Write("/");
+                            writer.Write("new RegExp(");
                             if (mce.Arguments[0] is NewArrayExpression arrayExpression)
                             {
                                 for (var i = 0; i < arrayExpression.Expressions.Count; i++)
                                 {
                                     if (i != 0)
                                     {
-                                        writer.Write("|");
+                                        writer.Write("+\"|\"+");
                                     }
 
-                                    writer.Write(
-                                        Regex.Escape(
-                                            ((ConstantExpression)arrayExpression.Expressions[i]).Value
-                                                .ToString()
-                                        ).Replace("/", "\\/")
-                                    );
+                                    context.Visitor.Visit(arrayExpression.Expressions[i]);
                                 }
                             }
                             else
                             {
-                                writer.Write(
-                                    Regex.Escape(
-                                        ((ConstantExpression)mce.Arguments[0]).Value
-                                            .ToString()
-                                    ).Replace("/", "\\/")
-                                );
+                                context.Visitor.Visit(mce.Arguments[0]);
                             }
 
-                            writer.Write("/g");
+                            writer.Write(", \"g\")");
                         }
                         else if (newName == "replace")
                         {
-                            writer.Write("/");
-                            writer.Write(
-                                Regex.Escape(
-                                    ((ConstantExpression)mce.Arguments[0]).Value
-                                        .ToString()
-                                ).Replace("/", "\\/")
-                            );
-                            writer.Write("/g, ");
+                            writer.Write("new RegExp(");
+                            context.Visitor.Visit(mce.Arguments[0]);
+                            writer.Write(", \"g\"), ");
+
                             context.Visitor.Visit(mce.Arguments[1]);
                         }
                         else


### PR DESCRIPTION
Added:
Contains -> .indexOf("???") !== -1
ToUpper -> .toUpperCase()
ToLower -> .toLowerCase()
Trim -> .trim()
Replace -> .replace(/regex/g, target) to mimic replace all
Split -> .split(/regex/g) to mimic splitAll + multi string split: /regex|regex/g)

Moved .join around, to better fit with multiple functions, tried to keep "for loops" for looping, where possible used context.Visitor.

Used if(mce.Method.Name =="Contains") since IndexOf could also be added, which will duplicate the newName (both indexOf in that case). Also added the apropriate tests to FastTests.

One remark on SplitEscape and ReplaceEscape, they both escape the regex fine, though your parser isn't happy about some characters (server side), if I try the regex on regex101.com, it's valid and escaped correctly.

Since used Regex.Escape().Replace() 3 times, maybe add it as a function in StringUtils (or something) couldn't find a class to add this function to. Purpose, to escape regex AND escape /, used to translate both split and replace.