### PR TITLE
 PR; Linq to RQL: ValueType .Parse() support

### DIFF
--- a/src/Raven.Client/Documents/Linq/RavenQueryProviderProcessor.cs
+++ b/src/Raven.Client/Documents/Linq/RavenQueryProviderProcessor.cs
@@ -1964,6 +1964,7 @@ The recommended method is to use full text search (mark the field as Analyzed an
                     new JavascriptConversionExtensions.ConstSupport(),
                     new JavascriptConversionExtensions.LoadSupport(),
                     new JavascriptConversionExtensions.MetadataSupport(),
+                    new JavascriptConversionExtensions.ValueTypeParseSupport(),
                     MemberInitAsJson.ForAllTypes));
 
             if (expression.Type == typeof(TimeSpan) && expression.NodeType != ExpressionType.MemberAccess)

--- a/src/Raven.Client/Util/JavascriptConversionExtensions.cs
+++ b/src/Raven.Client/Util/JavascriptConversionExtensions.cs
@@ -428,6 +428,27 @@ namespace Raven.Client.Util
             }
         }
 
+        public class ValueTypeParseSupport : JavascriptConversionExtension
+        {
+            private static readonly HashSet<Type> ValueTypes = new HashSet<Type>() {
+                typeof(int), typeof(uint), typeof(double), typeof(decimal),
+                typeof(bool), typeof(char), typeof(long), typeof(ulong),
+                typeof(sbyte),  typeof(short), typeof(ushort), typeof(byte)
+            };
+
+            public override void ConvertToJavascript(JavascriptConversionContext context)
+            {
+                var methodCallExpression = context.Node as MethodCallExpression;
+                var method = methodCallExpression?.Method;
+
+                if (method == null || method.Name != "Parse" || !ValueTypes.Contains(method.DeclaringType))
+                    return;
+
+                context.PreventDefault();
+                context.Visitor.Visit(methodCallExpression.Arguments[0]);
+            }
+        }
+
         public class DateTimeSupport : JavascriptConversionExtension
         {
             public override void ConvertToJavascript(JavascriptConversionContext context)

--- a/test/FastTests/Client/QueriesWithCustomFunctions.cs
+++ b/test/FastTests/Client/QueriesWithCustomFunctions.cs
@@ -1577,6 +1577,73 @@ FROM Users as u LOAD u.FriendId as _doc_0, u.DetailIds as _docs_1[] SELECT outpu
         }
 
         [Fact]
+        public void Custom_Functions_Parse_Support()
+        {
+            using (var store = GetDocumentStore())
+            {
+                using (var session = store.OpenSession())
+                {
+                    session.Store(new User { Name = "Jerry", LastName = "Garcia" }, "users/1");
+                    session.Store(new User { Name = "Phil", LastName = "" }, "users/2");
+                    session.Store(new User { Name = "Pigpen" }, "users/3");
+                    session.SaveChanges();
+                }
+
+                using (var session = store.OpenSession())
+                {
+                    var query = from u in session.Query<User>()
+                                select new
+                                {
+                                    IntParse = int.Parse("1234"),
+                                    DoubleParse = double.Parse("1234"),
+                                    DecimalParse = decimal.Parse("1234"),
+                                    BoolParse = bool.Parse("true"),
+                                    CharParse = char.Parse("s"),
+                                    ByteParse = byte.Parse("127"),
+                                    LongParse = long.Parse("1234"),
+                                    SByteParse = sbyte.Parse("127"),
+                                    ShortParse = short.Parse("1234"),
+                                    UintParse = uint.Parse("1234"),
+                                    UlongParse = ulong.Parse("1234"),
+                                    UshortParse = ushort.Parse("1234")
+                                };
+
+                    Assert.Equal("FROM Users as u SELECT { " +
+                        "IntParse : \"1234\", " +
+                        "DoubleParse : \"1234\", " +
+                        "DecimalParse : \"1234\", " +
+                        "BoolParse : \"true\", " +
+                        "CharParse : \"s\", " +
+                        "ByteParse : \"127\", " +
+                        "LongParse : \"1234\", " +
+                        "SByteParse : \"127\", " +
+                        "ShortParse : \"1234\", " +
+                        "UintParse : \"1234\", " +
+                        "UlongParse : \"1234\", " +
+                        "UshortParse : \"1234\" }", query.ToString());
+
+                    var queryResult = query.ToList();
+                    Assert.Equal(3, queryResult.Count);
+
+
+                    Assert.Equal(1234, queryResult[0].IntParse);
+                    Assert.Equal(1234, queryResult[0].DoubleParse);
+                    Assert.Equal(1234, queryResult[0].DecimalParse);
+                    Assert.Equal(true, queryResult[0].BoolParse);
+                    Assert.Equal('s', queryResult[0].CharParse);
+                    Assert.Equal(127, queryResult[0].ByteParse);
+                    Assert.Equal(1234, queryResult[0].LongParse);
+                    Assert.Equal(127, queryResult[0].SByteParse);
+                    Assert.Equal(1234, queryResult[0].ShortParse);
+                    Assert.Equal((uint)1234, queryResult[0].UintParse);
+                    Assert.Equal((ulong)1234, queryResult[0].UlongParse);
+                    Assert.Equal((ushort)1234, queryResult[0].UshortParse);
+
+                }
+            }
+        }
+
+        [Fact]
         public void Custom_Functions_Nested_Conditional_Support()
         {
             using (var store = GetDocumentStore())

--- a/test/FastTests/Client/QueriesWithCustomFunctions.cs
+++ b/test/FastTests/Client/QueriesWithCustomFunctions.cs
@@ -1584,8 +1584,6 @@ FROM Users as u LOAD u.FriendId as _doc_0, u.DetailIds as _docs_1[] SELECT outpu
                 using (var session = store.OpenSession())
                 {
                     session.Store(new User { Name = "Jerry", LastName = "Garcia" }, "users/1");
-                    session.Store(new User { Name = "Phil", LastName = "" }, "users/2");
-                    session.Store(new User { Name = "Pigpen" }, "users/3");
                     session.SaveChanges();
                 }
 
@@ -1594,9 +1592,9 @@ FROM Users as u LOAD u.FriendId as _doc_0, u.DetailIds as _docs_1[] SELECT outpu
                     var query = from u in session.Query<User>()
                                 select new
                                 {
-                                    IntParse = int.Parse("1234"),
+                                    IntParse = int.Parse("1234") + int.Parse("1234"),
                                     DoubleParse = double.Parse("1234"),
-                                    DecimalParse = decimal.Parse("1234"),
+                                    DecimalParse = decimal.Parse("12.34"),
                                     BoolParse = bool.Parse("true"),
                                     CharParse = char.Parse("s"),
                                     ByteParse = byte.Parse("127"),
@@ -1609,26 +1607,26 @@ FROM Users as u LOAD u.FriendId as _doc_0, u.DetailIds as _docs_1[] SELECT outpu
                                 };
 
                     Assert.Equal("FROM Users as u SELECT { " +
-                        "IntParse : \"1234\", " +
-                        "DoubleParse : \"1234\", " +
-                        "DecimalParse : \"1234\", " +
-                        "BoolParse : \"true\", " +
-                        "CharParse : \"s\", " +
-                        "ByteParse : \"127\", " +
-                        "LongParse : \"1234\", " +
-                        "SByteParse : \"127\", " +
-                        "ShortParse : \"1234\", " +
-                        "UintParse : \"1234\", " +
-                        "UlongParse : \"1234\", " +
-                        "UshortParse : \"1234\" }", query.ToString());
+                        "IntParse : parseInt(\"1234\")+parseInt(\"1234\"), " +
+                        "DoubleParse : parseFloat(\"1234\"), " +
+                        "DecimalParse : parseFloat(\"12.34\"), " +
+                        "BoolParse : \"true\" == (\"true\"), " +
+                        "CharParse : (\"s\"), " +
+                        "ByteParse : parseInt(\"127\"), " +
+                        "LongParse : parseInt(\"1234\"), " +
+                        "SByteParse : parseInt(\"127\"), " +
+                        "ShortParse : parseInt(\"1234\"), " +
+                        "UintParse : parseInt(\"1234\"), " +
+                        "UlongParse : parseInt(\"1234\"), " +
+                        "UshortParse : parseInt(\"1234\") }", query.ToString());
 
                     var queryResult = query.ToList();
-                    Assert.Equal(3, queryResult.Count);
+                    Assert.Equal(1, queryResult.Count);
 
 
-                    Assert.Equal(1234, queryResult[0].IntParse);
+                    Assert.Equal(int.Parse("1234") + int.Parse("1234"), queryResult[0].IntParse);
                     Assert.Equal(1234, queryResult[0].DoubleParse);
-                    Assert.Equal(1234, queryResult[0].DecimalParse);
+                    Assert.Equal(12.34M, queryResult[0].DecimalParse);
                     Assert.Equal(true, queryResult[0].BoolParse);
                     Assert.Equal('s', queryResult[0].CharParse);
                     Assert.Equal(127, queryResult[0].ByteParse);

--- a/test/FastTests/Client/QueriesWithCustomFunctions.cs
+++ b/test/FastTests/Client/QueriesWithCustomFunctions.cs
@@ -1577,7 +1577,7 @@ FROM Users as u LOAD u.FriendId as _doc_0, u.DetailIds as _docs_1[] SELECT outpu
         }
 
         [Fact]
-        public void Custom_Functions_Parse_Support()
+        public void Custom_Functions_ValueTypeParse_Support()
         {
             using (var store = GetDocumentStore())
             {


### PR DESCRIPTION
To support valueType.Parse() for any conversion needed in your projection.

Based on Visitor Pattern, only removes the int/double/....Parse(), since conversion is already done in BLIT to Object. Pretty straight forward. Added a HashSet containing the ValueTypes, since Type.IsValueType isn't supported in dotnetstandard 1.3.

UnitTest included.