### PR TITLE
RavenDB-8629 dealing with missing LoadDocument and other

### DIFF
--- a/src/Raven.Server/Documents/Patch/JintNullPropgationReferenceResolver.cs
+++ b/src/Raven.Server/Documents/Patch/JintNullPropgationReferenceResolver.cs
@@ -1,4 +1,5 @@
-﻿using Jint;
+﻿using System;
+using Jint;
 using Jint.Native;
 using Jint.Runtime.Interop;
 using Jint.Runtime.References;
@@ -20,6 +21,11 @@ namespace Raven.Server.Documents.Patch
 
         public bool TryGetCallable(Engine engine, object callee, out JsValue value)
         {
+            var @ref = callee as Reference;
+            if (@ref != null && @ref.IsUnresolvableReference())
+            {
+                throw new MissingMethodException($"Could not locate refrence to the method: {@ref.GetReferencedName()}");
+            }
             value = new JsValue(new ClrFunctionInstance(engine, (thisObj, values) => thisObj));
             return true;
         }

--- a/src/Raven.Server/Documents/Patch/ScriptRunner.cs
+++ b/src/Raven.Server/Documents/Patch/ScriptRunner.cs
@@ -105,13 +105,14 @@ namespace Raven.Server.Documents.Patch
                         .AddObjectConverter(new JintEnumConverter())
                         .AddObjectConverter(new JintDateTimeConverter())
                         .AddObjectConverter(new JintTimeSpanConverter())
-						.LocalTimeZone( TimeZoneInfo.Utc);
+                        .LocalTimeZone( TimeZoneInfo.Utc);
                     
                 });
                 ScriptEngine.SetValue("output", new ClrFunctionInstance(ScriptEngine, OutputDebug));
 
                 ScriptEngine.SetValue("include", new ClrFunctionInstance(ScriptEngine, IncludeDoc));
                 ScriptEngine.SetValue("load", new ClrFunctionInstance(ScriptEngine, LoadDocument));
+                ScriptEngine.SetValue("LoadDocument", new ClrFunctionInstance(ScriptEngine, ThrowLoadDocument));
                 ScriptEngine.SetValue("loadPath", new ClrFunctionInstance(ScriptEngine, LoadDocumentByPath));
                 ScriptEngine.SetValue("del", new ClrFunctionInstance(ScriptEngine, DeleteDocument));
                 ScriptEngine.SetValue("put", new ClrFunctionInstance(ScriptEngine, PutDocument));
@@ -451,6 +452,11 @@ namespace Raven.Server.Documents.Patch
                     throw new InvalidOperationException("load(id) must be called with a single string argument");
 
                 return LoadDocumentInternal(args[0].AsString());
+            }
+
+            private JsValue ThrowLoadDocument(JsValue self, JsValue[] args)
+            {
+                throw new MissingMethodException("The method LoadDocument was renamed to 'load'");
             }
 
             private static JsValue ConvertJsTimeToTimeSpanString(JsValue self, JsValue[] args)


### PR DESCRIPTION
* will throw a clear exception indicating LoadDocument was renamed load
* will not do null propagation for callables since it may yield unexpected (and un-wanted) results