### PR TITLE
Missing AdditionalSources on IndexDefinition for AbstractMultiMapIndexCreationTask

### DIFF
--- a/src/Raven.Client/Documents/Indexes/AbstractMultiMapIndexCreationTask.cs
+++ b/src/Raven.Client/Documents/Indexes/AbstractMultiMapIndexCreationTask.cs
@@ -72,7 +72,8 @@ namespace Raven.Client.Documents.Indexes
                 StoresStrings = StoresStrings,
                 TermVectorsStrings = TermVectorsStrings,
                 SpatialIndexesStrings = SpatialIndexesStrings,
-                OutputReduceToCollection = OutputReduceToCollection
+                OutputReduceToCollection = OutputReduceToCollection,
+                AdditionalSources = AdditionalSources
             }.ToIndexDefinition(Conventions, validateMap: false);
             foreach (var map in _maps.Select(generateMap => generateMap()))
             {


### PR DESCRIPTION
Noticed that it seemed like AdditionalSources was missing on a AbstractMultiMapIndexCreationTask