### PR TITLE
RavenDB-9324

### DIFF
--- a/src/Raven.Server/Config/Categories/PerformanceHintsConfiguration.cs
+++ b/src/Raven.Server/Config/Categories/PerformanceHintsConfiguration.cs
@@ -29,7 +29,7 @@ namespace Raven.Server.Config.Categories
         public int MaxNumberOfResults { get; set; }
 
         [Description("Request latency threshold before the server would issue a performance hint")]
-        [ConfigurationEntry("PerformanceHints.TooLongRequestThresholdInSec", ConfigurationEntryScope.ServerWideOnly)]
+        [ConfigurationEntry("PerformanceHints.TooLongRequestThresholdInSec", ConfigurationEntryScope.ServerWideOrPerDatabase)]
         [DefaultValue(30)]
         [TimeUnit(TimeUnit.Seconds)]
         public TimeSetting TooLongRequestThreshold { get; set; }

--- a/src/Raven.Server/Documents/DatabaseRequestHandler.cs
+++ b/src/Raven.Server/Documents/DatabaseRequestHandler.cs
@@ -1,10 +1,13 @@
 ﻿using System;
+using System.Diagnostics;
+using System.Threading.Tasks;
 using Raven.Server.Documents.Indexes;
 using Raven.Server.ServerWide;
 using Raven.Server.ServerWide.Context;
 using Raven.Server.Web;
 using Microsoft.AspNetCore.Http;
 using Raven.Client;
+using Raven.Client.Util;
 using Raven.Server.NotificationCenter.Notifications.Details;
 using Sparrow.Logging;
 
@@ -29,7 +32,7 @@ namespace Raven.Server.Documents
             var topologyEtag = GetLongFromHeaders(Constants.Headers.TopologyEtag);
             if (topologyEtag.HasValue && Database.HasTopologyChanged(topologyEtag.Value))
                 context.HttpContext.Response.Headers[Constants.Headers.RefreshTopology] = "true";
-             
+
             var clientConfigurationEtag = GetLongFromHeaders(Constants.Headers.ClientConfigurationEtag);
             if (clientConfigurationEtag.HasValue && Database.HasClientConfigurationChanged(clientConfigurationEtag.Value))
                 context.HttpContext.Response.Headers[Constants.Headers.RefreshClientConfiguration] = "true";
@@ -43,6 +46,44 @@ namespace Raven.Server.Documents
         protected OperationCancelToken CreateOperationToken()
         {
             return new OperationCancelToken(Database.DatabaseShutdown);
+        }
+
+        protected DisposableAction TrackRequestTime(string source, bool doPerformanceHintIfTooLong = true)
+        {
+            var sw = Stopwatch.StartNew();
+
+            HttpContext.Response.OnStarting(state =>
+            {
+                sw.Stop();
+                var httpContext = (HttpContext)state;
+                httpContext.Response.Headers.Add(Constants.Headers.RequestTime, sw.ElapsedMilliseconds.ToString());
+                return Task.CompletedTask;
+            }, HttpContext);
+
+            if (doPerformanceHintIfTooLong == false)
+                return null;
+
+            return new DisposableAction(() =>
+            {
+                if (sw.Elapsed <= Database.Configuration.PerformanceHints.TooLongRequestThreshold.AsTimeSpan)
+                    return;
+
+                try
+                {
+                    Database
+                        .NotificationCenter
+                        .RequestLatency
+                        .AddHint(HttpContext.Request.Path, sw.ElapsedMilliseconds, source);
+                }
+                catch (Exception e)
+                {
+                    //precaution - should never arrive here
+                    if (Logger.IsInfoEnabled)
+                        Logger.Info($"Failed to write request time in response headers. This is not supposed to happen and is probably a bug. The request path was: {HttpContext.Request.Path}", e);
+
+                    throw;
+                }
+            });
         }
 
         protected void AddPagingPerformanceHint(PagingOperationType operation, string action, HttpContext httpContext, int numberOfResults, int pageSize, TimeSpan duration)


### PR DESCRIPTION
- PerformanceHints.TooLongRequestThresholdInSec should be configurable per database also, not only per server
- performance hints should be persisted in database.NotificationCenter, not server.NotificationCenter
- fixed polarization