### PR TITLE
RavenDB-9317

### DIFF
--- a/src/Raven.Studio/typescript/viewmodels/wizard/certificate.ts
+++ b/src/Raven.Studio/typescript/viewmodels/wizard/certificate.ts
@@ -19,7 +19,9 @@ class certificate extends setupStep {
 
     canActivate(): JQueryPromise<canActivateResultDto> {
         const mode = this.model.mode();
-
+        
+        this.model.domain().reusingConfiguration(false);
+        
         if (mode && mode === "Secured") {
             return $.when({ can: true });
         }

--- a/src/Raven.Studio/typescript/viewmodels/wizard/nodes.ts
+++ b/src/Raven.Studio/typescript/viewmodels/wizard/nodes.ts
@@ -63,7 +63,7 @@ class nodes extends setupStep {
     
     activate(args: any) {
         super.activate(args);
-
+        
         switch (this.model.mode()) {
             case "LetsEncrypt":
                 this.currentStep = 4;
@@ -100,16 +100,28 @@ class nodes extends setupStep {
             }
         }
         
+        let focusedOnInvalidNode = false;
+        
         nodes.forEach(node => {
+            let validNodeConfig = true;
+            
             if (!this.isValid(node.validationGroup)) {
-                isValid = false;
+                validNodeConfig = false;
             }
             
             node.ips().forEach(entry => {
                 if (!this.isValid(entry.validationGroup)) {
-                    isValid = false;
+                    validNodeConfig = false;
                 }
             });
+            
+            if (!validNodeConfig) {
+                isValid = false;
+                if (!focusedOnInvalidNode) {
+                    this.editedNode(node);
+                    focusedOnInvalidNode = true;
+                }
+            }
         });
         
         if (!this.isValid(this.model.nodesValidationGroup)) {


### PR DESCRIPTION
- focus on first invalid node configuration
-  revert 'reusingConfiguration' field when going though secured flow