### PR TITLE
RavenDB-9362 Subscription subscriptionChangeVectorBeforeCurrentBatch …

### DIFF
--- a/src/Raven.Server/Documents/TcpHandlers/SubscriptionConnection.cs
+++ b/src/Raven.Server/Documents/TcpHandlers/SubscriptionConnection.cs
@@ -451,7 +451,7 @@ namespace Raven.Server.Documents.TcpHandlers
                                 _lastChangeVector ?? 
                                     nameof(Client.Constants.Documents.SubscriptionChangeVectorSpecialStates.DoNotChange),
                                 subscriptionChangeVectorBeforeCurrentBatch);
-                            subscriptionChangeVectorBeforeCurrentBatch = _lastChangeVector;
+                            subscriptionChangeVectorBeforeCurrentBatch = _lastChangeVector?? SubscriptionState.ChangeVectorForNextBatchStartingPoint;
 
                             if (sendingCurrentBatchStopwatch.ElapsedMilliseconds > 1000)
                                 await SendHeartBeat();


### PR DESCRIPTION
…sent as null in fresh connection when there are no documents to send