### PR TITLE
RavenDB-9167 Publish Docker multi-arch images

### DIFF
--- a/docker/manifest/manifest.yml
+++ b/docker/manifest/manifest.yml
@@ -1,0 +1,12 @@
+image: ravendb/ravendb:latest
+manifests:
+  -
+    image: ravendb/ravendb:ubuntu-latest
+    platform:
+      architecture: amd64
+      os: linux
+  -
+    image: ravendb/ravendb:windows-nanoserver-latest
+    platform:
+      architecture: amd64
+      os: windows

--- a/docker/manifest/tag.ps1
+++ b/docker/manifest/tag.ps1
@@ -1,0 +1,7 @@
+param([string]$DockerUser, [string]$DockerPass)
+
+if($DockerUser -ne $null -and $DockerPass -ne $null) {
+    ./manifest-tool.exe --username $DockerUser --password $DockerPass push from-spec .\manifest.yml;
+} else {
+    ./manifest-tool.exe push from-spec .\manifest.yml;
+}


### PR DESCRIPTION
[RavenDB-9167](http://issues.hibernatingrhinos.com/issue/RavenDB-9167)

Uses manifest-tool from https://github.com/estesp/manifest-tool to create a `ravendb/ravendb:latest` tag that aliases the windows-nanoserver-latest or ubuntu-latest tags.

Download latest release of manifest-tool from linked repository, CD to the docker/manifest folder, run `./tag.ps1` after the windows and ubuntu images have been built/pushed.

This will publish a manifest to `ravendb/ravendb:latest` that refers to both `ubuntu-latest` and `windows-nanoserver-latest` tags.  For the users, they then only need to know to run `docker pull ravendb/ravendb` and it will pull the correct image for their platform/architecture.