### PR TITLE
RavenDB-9487: Better Low Memory Notifications Handling

### DIFF
--- a/src/Raven.Server/Documents/Indexes/Index.cs
+++ b/src/Raven.Server/Documents/Indexes/Index.cs
@@ -147,7 +147,9 @@ namespace Raven.Server.Documents.Indexes
         private bool _allocationCleanupNeeded;
         private readonly MultipleUseFlag _lowMemoryFlag = new MultipleUseFlag();
         private long _lastLowMemoryEventTicks = 0;
-        private readonly long _lowMemoryIntervalTicks = TimeSpan.FromMinutes(1).Ticks;
+
+        // delay a bit after low mem is over in order to let the flush(es) to finish (or at least do some major flushing writes)
+        private readonly long _lowMemoryIntervalTicks = TimeSpan.FromSeconds(1).Ticks; 
 
         private Size _currentMaximumAllowedMemory = DefaultMaximumMemoryAllocation;
         private NativeMemory.ThreadStats _threadAllocations;

--- a/src/Sparrow/Sparrow.csproj
+++ b/src/Sparrow/Sparrow.csproj
@@ -33,6 +33,7 @@
     <PackageReference Include="Microsoft.CSharp" Version="4.4.0" />
     <PackageReference Include="System.Runtime.CompilerServices.Unsafe" Version="4.4.0" />
     <PackageReference Include="System.Threading.Tasks.Extensions" Version="4.4.0" />
+    <PackageReference Include="System.Diagnostics.Process" Version="4.1.0" />
   </ItemGroup>
   <ItemGroup Condition="$(TargetFramework) == 'netstandard1.3'">
     <PackageReference Include="System.Diagnostics.Contracts" Version="4.3.0" />


### PR DESCRIPTION
* PrivateWorkingSet is not being calculated correctly - shared mem is calculated (approx)
* Misscalc of freeOrCheapToFree fixed

*Note : Sparrow->System.Diagnostic.Process will use 4.1.0 (and not 4.3.0) to be netstandard1.3 compliant