### PR TITLE
RavenDB-9433: Remove unneeded meta property "etag" (which was change …

### DIFF
--- a/src/Raven.Server/Documents/Handlers/BatchRequestParser.cs
+++ b/src/Raven.Server/Documents/Handlers/BatchRequestParser.cs
@@ -521,8 +521,6 @@ namespace Raven.Server.Documents.Handlers
                 case 4:
                     if (*(int*)state.StringBuffer == 1701869908)
                         return CommandPropertyName.Type;
-                    if (*(int*)state.StringBuffer == 1734440005)
-                        return CommandPropertyName.ChangeVector;
                     if (*(int*)state.StringBuffer == 1701667150)
                         return CommandPropertyName.Name;
                     return CommandPropertyName.NoSuchProperty;


### PR DESCRIPTION
…wrongly to ChangeVector)