### PR TITLE
RavenDB-9455 - Dashboard displays incorrect value of used memory on MacOS

### DIFF
--- a/src/Sparrow/LowMemory/MemoryInformation.cs
+++ b/src/Sparrow/LowMemory/MemoryInformation.cs
@@ -248,7 +248,7 @@ namespace Sparrow.LowMemory
                         return FailedResult;
                     }
 
-                    availableRamInBytes = vmStats.FreePagesCount * (ulong)pageSize;
+                    availableRamInBytes = (vmStats.FreePagesCount + vmStats.InactivePagesCount) * (ulong)pageSize;
                 }
 
                 Size availableRam, totalPhysicalMemory;


### PR DESCRIPTION
http://issues.hibernatingrhinos.com/issue/RavenDB-9455