### PR TITLE
Added PreInitialize method to override in RavenTestDriver

### DIFF
--- a/src/Raven.TestDriver/RavenTestDriver.cs
+++ b/src/Raven.TestDriver/RavenTestDriver.cs
@@ -64,6 +64,8 @@ namespace Raven.TestDriver
                 Database = name
             };
 
+            PreInitialize(store);
+
             store.Initialize();
 
             store.AfterDispose += (sender, args) =>
@@ -93,6 +95,10 @@ namespace Raven.TestDriver
             _documentStores[store] = null;
 
             return store;
+        }
+
+        protected virtual void PreInitialize(IDocumentStore documentStore)
+        {
         }
 
         protected virtual void SetupDatabase(IDocumentStore documentStore)


### PR DESCRIPTION
In order to setup Conventions and other actions prior to the DocumentStore being initialized inside the RavenTestDriver there need to be a way to access the store before `documentStore.Inititalize()` is called.