### PR TITLE
RavenDB-9591

### DIFF
--- a/src/Raven.Client/Constants.cs
+++ b/src/Raven.Client/Constants.cs
@@ -136,6 +136,8 @@ namespace Raven.Client
 
                 public const string Attachments = "@attachments";
 
+                public const string LegacyAttachmentsMetadata = "@legacy-attachment-metadata";
+
                 public const string IndexScore = "@index-score";
 
                 public const string LastModified = "@last-modified";


### PR DESCRIPTION
* Renaming Attachments dummy file names to 'files/' from 'dummy/'
* Adding the Attachments Metadata to the dummy document metadata under @legacy-attachment-metadata
* will filter tombstones and downloading files