### PR TITLE
RavenDB-9440 Making sure we don't cache 'server not relevant for node'

### DIFF
--- a/src/Raven.Server/RavenServerStartup.cs
+++ b/src/Raven.Server/RavenServerStartup.cs
@@ -10,6 +10,7 @@ using Microsoft.AspNetCore.Http.Extensions;
 using Microsoft.AspNetCore.ResponseCompression;
 using Microsoft.Extensions.DependencyInjection;
 using Microsoft.Extensions.Logging;
+using Microsoft.Extensions.Primitives;
 using Raven.Client.Documents.Changes;
 using Raven.Client.Exceptions;
 using Raven.Client.Exceptions.Database;
@@ -317,6 +318,7 @@ namespace Raven.Server
             if (exception is DatabaseNotRelevantException)
             {
                 response.StatusCode = (int)HttpStatusCode.Gone;
+                response.Headers.Add("Cache-Control",new StringValues(new []{ "must-revalidate", "no-cache" }));
                 return;
             }
 


### PR DESCRIPTION
Tested by creating a database on A,B deleting it from A accessing it from the studio getting the 'Database a is not relevant  for node A' error, recreating the database on node A using node B studio and then accessing the database back from node A studio, everything seems to be working no caching issues.