### PR TITLE
RavenDB-9617 fix typo, reuse exception message

### DIFF
--- a/src/Raven.Server/Documents/Queries/InvalidQueryRunner.cs
+++ b/src/Raven.Server/Documents/Queries/InvalidQueryRunner.cs
@@ -3,6 +3,7 @@ using System.Threading.Tasks;
 using Microsoft.AspNetCore.Http;
 using Raven.Client.Documents.Operations;
 using Raven.Client.Documents.Queries;
+using Raven.Server.Config.Categories;
 using Raven.Server.ServerWide;
 using Raven.Server.ServerWide.Context;
 using Sparrow.Json;
@@ -12,35 +13,37 @@ namespace Raven.Server.Documents.Queries
 {
     public class InvalidQueryRunner : AbstractQueryRunner
     {
+        internal const string ErrorMessage = "Dynamic queries are not supported by this database because the configuration '" + nameof(IndexingConfiguration.DisableQueryOptimizerGeneratedIndexes) + "' is set to true and the query optimizer needs an index for this query";
+
         public InvalidQueryRunner(DocumentDatabase database) : base(database)
         {
         }
 
         public override Task<DocumentQueryResult> ExecuteQuery(IndexQueryServerSide query, DocumentsOperationContext documentsContext, long? existingResultEtag, OperationCancelToken token)
         {
-            throw new NotSupportedException("Dynamic queries are not supported by this database because the configuration 'Indexing.DisableQueryOptimizerGeneratedIndexes' is set to ture and the query optimizer needs an index for this query");
+            throw new NotSupportedException(ErrorMessage);
         }
 
         public override Task ExecuteStreamQuery(IndexQueryServerSide query, DocumentsOperationContext documentsContext, HttpResponse response, IStreamDocumentQueryResultWriter writer,
             OperationCancelToken token)
         {
-            throw new NotSupportedException("Dynamic queries are not supported by this database because the configuration 'Indexing.DisableQueryOptimizerGeneratedIndexes' is set to ture and the query optimizer needs an index for this query");
+            throw new NotSupportedException(ErrorMessage);
         }
 
         public override Task<IndexEntriesQueryResult> ExecuteIndexEntriesQuery(IndexQueryServerSide query, DocumentsOperationContext context, long? existingResultEtag, OperationCancelToken token)
         {
-            throw new NotSupportedException("Dynamic queries are not supported by this database because the configuration 'Indexing.DisableQueryOptimizerGeneratedIndexes' is set to ture and the query optimizer needs an index for this query");
+            throw new NotSupportedException(ErrorMessage);
         }
 
         public override Task<IOperationResult> ExecuteDeleteQuery(IndexQueryServerSide query, QueryOperationOptions options, DocumentsOperationContext context, Action<IOperationProgress> onProgress, OperationCancelToken token)
         {
-            throw new NotSupportedException("Dynamic queries are not supported by this database because the configuration 'Indexing.DisableQueryOptimizerGeneratedIndexes' is set to ture and the query optimizer needs an index for this query");
+            throw new NotSupportedException(ErrorMessage);
         }
 
         public override Task<IOperationResult> ExecutePatchQuery(IndexQueryServerSide query, QueryOperationOptions options, PatchRequest patch, BlittableJsonReaderObject patchArgs,
             DocumentsOperationContext context, Action<IOperationProgress> onProgress, OperationCancelToken token)
         {
-            throw new NotSupportedException("Dynamic queries are not supported by this database because the configuration 'Indexing.DisableQueryOptimizerGeneratedIndexes' is set to ture and the query optimizer needs an index for this query");
+            throw new NotSupportedException(ErrorMessage);
         }
     }
 }

--- a/src/Raven.Server/Documents/Queries/QueryRunner.cs
+++ b/src/Raven.Server/Documents/Queries/QueryRunner.cs
@@ -141,14 +141,13 @@ namespace Raven.Server.Documents.Queries
 
         public List<DynamicQueryToIndexMatcher.Explanation> ExplainDynamicIndexSelection(IndexQueryServerSide query)
         {
-            if (query.Metadata.IsDynamic == false )
+            if (query.Metadata.IsDynamic == false)
                 throw new InvalidOperationException("Explain can only work on dynamic indexes");
 
             if (_dynamic is DynamicQueryRunner d)
                 return d.ExplainIndexSelection(query);
-            
-            throw new NotSupportedException("Dynamic queries are not supported by this database because the configuration 'Indexing.DisableQueryOptimizerGeneratedIndexes' is set to ture and the query optimizer needs an index for this query");
-        }
 
+            throw new NotSupportedException(InvalidQueryRunner.ErrorMessage);
+        }
     }
 }


### PR DESCRIPTION
There was a small typo in error message, "ture" instead of "true". Made the message constant and shared between usages.