### PR TITLE
RavenDB-8521 Delayed external replication

### DIFF
--- a/src/Raven.Client/ServerWide/ExternalReplication.cs
+++ b/src/Raven.Client/ServerWide/ExternalReplication.cs
@@ -13,7 +13,7 @@ namespace Raven.Client.ServerWide
         public string Name;
         public string ConnectionStringName;
         public string MentorNode;
-        public long DelayReplicationFor; 
+        public TimeSpan DelayReplicationFor; 
 
         [JsonDeserializationIgnore]
         public RavenConnectionString ConnectionString; // this is in memory only

--- a/src/Raven.Server/Commercial/LicenseManager.cs
+++ b/src/Raven.Server/Commercial/LicenseManager.cs
@@ -1339,6 +1339,20 @@ namespace Raven.Server.Commercial
             return false;
         }
 
+        public bool CanDelayReplication(out LicenseLimit licenseLimit)
+        {
+            if (IsValid(out licenseLimit) == false)
+                return false;
+
+            if (_licenseStatus.HasDelayedExternalReplication)
+                return true;
+
+            const string details = "Your current license doesn't include " +
+                                   "the delayed replication feature";
+            licenseLimit = GenerateLicenseLimit(LimitType.DelayedReplication, details, addNotification: true);
+            return false;
+        }
+
         public bool CanDynamicallyDistributeNodes(out LicenseLimit licenseLimit)
         {
             if (IsValid(out licenseLimit) == false)

--- a/src/Raven.Server/Commercial/LimitType.cs
+++ b/src/Raven.Server/Commercial/LimitType.cs
@@ -16,6 +16,7 @@
         Cores,
         Memory,
         Downgrade,
-        Snmp
+        Snmp,
+        DelayedReplication
     }
 }

--- a/src/Raven.Server/Utils/Stats/StatsScope.cs
+++ b/src/Raven.Server/Utils/Stats/StatsScope.cs
@@ -22,6 +22,8 @@ namespace Raven.Server.Utils.Stats
 
         public TimeSpan Duration => _sw.Elapsed;
 
+        public T CurrentStats => _stats;
+
         public TStatsScope Start()
         {
             _sw.Start();

--- a/test/SlowTests/Server/Replication/ExternalReplicationTests.cs
+++ b/test/SlowTests/Server/Replication/ExternalReplicationTests.cs
@@ -46,7 +46,7 @@ namespace SlowTests.Server.Replication
             using (var store1 = GetDocumentStore())
             using (var store2 = GetDocumentStore())
             {
-                var delay = TimeSpan.FromSeconds(5).Ticks;
+                var delay = TimeSpan.FromSeconds(5);
                 var externalTask = new ExternalReplication(store2.Database, "DelayedExternalReplication")
                 {
                     DelayReplicationFor = delay
@@ -62,7 +62,7 @@ namespace SlowTests.Server.Replication
                 }
 
                 Assert.True(WaitForDocument(store2, "foo/bar"));
-                var elapsed = (DateTime.UtcNow - date).Ticks;
+                var elapsed = DateTime.UtcNow - date;
                 Assert.True(elapsed >= delay,$" only {elapsed}/{delay} ticks elapsed");
 
             }


### PR DESCRIPTION
- Fixes after PR
- Check was added to send a heartbeat if we spend too much time in preparing a batch to send.