### PR TITLE
RavenDB-9678 Remove WaitForNonStaleResultsAsOf as it requires cutOffE…

### DIFF
--- a/src/Raven.Client/Documents/Queries/IndexQuery.cs
+++ b/src/Raven.Client/Documents/Queries/IndexQuery.cs
@@ -31,7 +31,6 @@ namespace Raven.Client.Documents.Queries
 #endif
                 hasher.Write(ExplainScores);
                 hasher.Write(WaitForNonStaleResultsTimeout?.Ticks);
-                hasher.Write(CutoffEtag);
                 hasher.Write(Start);
                 hasher.Write(PageSize);
                 hasher.Write(QueryParameters);
@@ -179,22 +178,6 @@ namespace Raven.Client.Documents.Queries
 
         public TimeSpan? WaitForNonStaleResultsTimeout { get; set; }
 
-        /// <summary>
-        /// Gets or sets the cutoff etag.
-        /// <para>Cutoff etag is used to check if the index has already process a document with the given</para>
-        /// <para>etag. Unlike Cutoff, which uses dates and is susceptible to clock synchronization issues between</para>
-        /// <para>machines, cutoff etag doesn't rely on both the server and client having a synchronized clock and </para>
-        /// <para>can work without it.</para>
-        /// <para>However, when used to query map/reduce indexes, it does NOT guarantee that the document that this</para>
-        /// <para>etag belong to is actually considered for the results. </para>
-        /// <para>What it does it guarantee that the document has been mapped, but not that the mapped values has been reduced. </para>
-        /// <para>Since map/reduce queries, by their nature, tend to be far less susceptible to issues with staleness, this is </para>
-        /// <para>considered to be an acceptable trade-off.</para>
-        /// <para>If you need absolute no staleness with a map/reduce index, you will need to ensure synchronized clocks and </para>
-        /// <para>use the Cutoff date option, instead.</para>
-        /// </summary>
-        public long? CutoffEtag { get; set; }
-
         public override string ToString()
         {
             return Query;
@@ -212,8 +195,7 @@ namespace Raven.Client.Documents.Queries
                    string.Equals(Query, other.Query) &&
                    Start == other.Start &&
                    WaitForNonStaleResultsTimeout == other.WaitForNonStaleResultsTimeout &&
-                   WaitForNonStaleResults.Equals(other.WaitForNonStaleResults) &&
-                   Equals(CutoffEtag, other.CutoffEtag);
+                   WaitForNonStaleResults.Equals(other.WaitForNonStaleResults);
         }
 
         public override bool Equals(object obj)
@@ -234,7 +216,6 @@ namespace Raven.Client.Documents.Queries
                 hashCode = (hashCode * 397) ^ (Query?.GetHashCode() ?? 0);
                 hashCode = (hashCode * 397) ^ Start;
                 hashCode = (hashCode * 397) ^ (WaitForNonStaleResultsTimeout != null ? WaitForNonStaleResultsTimeout.GetHashCode() : 0);
-                hashCode = (hashCode * 397) ^ (CutoffEtag != null ? CutoffEtag.GetHashCode() : 0);
                 return hashCode;
             }
         }

--- a/src/Raven.Client/Documents/Session/AbstractDocumentQuery.Customize.cs
+++ b/src/Raven.Client/Documents/Session/AbstractDocumentQuery.Customize.cs
@@ -105,19 +105,5 @@ namespace Raven.Client.Documents.Session
             WaitForNonStaleResults();
             return this;
         }
-
-        /// <inheritdoc />
-        IDocumentQueryCustomization IDocumentQueryCustomization.WaitForNonStaleResultsAsOf(long cutOffEtag)
-        {
-            WaitForNonStaleResultsAsOf(cutOffEtag);
-            return this;
-        }
-
-        /// <inheritdoc />
-        IDocumentQueryCustomization IDocumentQueryCustomization.WaitForNonStaleResultsAsOf(long cutOffEtag, TimeSpan waitTimeout)
-        {
-            WaitForNonStaleResultsAsOf(cutOffEtag, waitTimeout);
-            return this;
-        }
     }
 }

--- a/src/Raven.Client/Documents/Session/AbstractDocumentQuery.cs
+++ b/src/Raven.Client/Documents/Session/AbstractDocumentQuery.cs
@@ -152,8 +152,6 @@ namespace Raven.Client.Documents.Session
 
         public bool IsDynamicMapReduce => GroupByTokens.Count > 0;
 
-        protected long? CutoffEtag;
-
         private bool _isInMoreLikeThis;
 
         private static TimeSpan DefaultTimeout
@@ -213,7 +211,6 @@ namespace Raven.Client.Documents.Session
         public void WaitForNonStaleResults(TimeSpan waitTimeout)
         {
             TheWaitForNonStaleResults = true;
-            CutoffEtag = null;
             Timeout = waitTimeout;
         }
 
@@ -968,24 +965,6 @@ Use session.Query<T>() instead of session.Advanced.DocumentQuery<T>. The session
         }
 
         /// <summary>
-        /// Instructs the query to wait for non stale results as of the cutoff etag.
-        /// </summary>
-        public void WaitForNonStaleResultsAsOf(long cutOffEtag)
-        {
-            WaitForNonStaleResultsAsOf(cutOffEtag, DefaultTimeout);
-        }
-
-        /// <summary>
-        /// Instructs the query to wait for non stale results as of the cutoff etag.
-        /// </summary>
-        public void WaitForNonStaleResultsAsOf(long cutOffEtag, TimeSpan waitTimeout)
-        {
-            TheWaitForNonStaleResults = true;
-            Timeout = waitTimeout;
-            CutoffEtag = cutOffEtag;
-        }
-
-        /// <summary>
         ///   EXPERT ONLY: Instructs the query to wait for non stale results.
         ///   This shouldn't be used outside of unit tests unless you are well aware of the implications
         /// </summary>
@@ -1031,7 +1010,6 @@ Use session.Query<T>() instead of session.Advanced.DocumentQuery<T>. The session
             {
                 Query = query,
                 Start = Start,
-                CutoffEtag = CutoffEtag,
                 WaitForNonStaleResults = TheWaitForNonStaleResults,
                 WaitForNonStaleResultsTimeout = Timeout,
                 QueryParameters = QueryParameters,

--- a/src/Raven.Client/Documents/Session/AsyncDocumentQuery.cs
+++ b/src/Raven.Client/Documents/Session/AsyncDocumentQuery.cs
@@ -420,34 +420,6 @@ namespace Raven.Client.Documents.Session
         }
 
         /// <inheritdoc />
-        IAsyncDocumentQuery<T> IQueryBase<T, IAsyncDocumentQuery<T>>.WaitForNonStaleResultsAsOf(long cutOffEtag)
-        {
-            WaitForNonStaleResultsAsOf(cutOffEtag);
-            return this;
-        }
-
-        /// <inheritdoc />
-        IAsyncRawDocumentQuery<T> IQueryBase<T, IAsyncRawDocumentQuery<T>>.WaitForNonStaleResultsAsOf(long cutOffEtag)
-        {
-            WaitForNonStaleResultsAsOf(cutOffEtag);
-            return this;
-        }
-
-        /// <inheritdoc />
-        IAsyncDocumentQuery<T> IQueryBase<T, IAsyncDocumentQuery<T>>.WaitForNonStaleResultsAsOf(long cutOffEtag, TimeSpan waitTimeout)
-        {
-            WaitForNonStaleResultsAsOf(cutOffEtag, waitTimeout);
-            return this;
-        }
-
-        /// <inheritdoc />
-        IAsyncRawDocumentQuery<T> IQueryBase<T, IAsyncRawDocumentQuery<T>>.WaitForNonStaleResultsAsOf(long cutOffEtag, TimeSpan waitTimeout)
-        {
-            WaitForNonStaleResultsAsOf(cutOffEtag, waitTimeout);
-            return this;
-        }
-
-        /// <inheritdoc />
         IAsyncDocumentQuery<T> IQueryBase<T, IAsyncDocumentQuery<T>>.WaitForNonStaleResults()
         {
             WaitForNonStaleResults();
@@ -863,7 +835,6 @@ namespace Raven.Client.Documents.Session
                 QueryParameters = QueryParameters,
                 Start = Start,
                 Timeout = Timeout,
-                CutoffEtag = CutoffEtag,
                 QueryStats = QueryStats,
                 TheWaitForNonStaleResults = TheWaitForNonStaleResults,
                 Negate = Negate,

--- a/src/Raven.Client/Documents/Session/DocumentQuery.cs
+++ b/src/Raven.Client/Documents/Session/DocumentQuery.cs
@@ -672,34 +672,6 @@ namespace Raven.Client.Documents.Session
         }
 
         /// <inheritdoc />
-        IDocumentQuery<T> IQueryBase<T, IDocumentQuery<T>>.WaitForNonStaleResultsAsOf(long cutOffEtag)
-        {
-            WaitForNonStaleResultsAsOf(cutOffEtag);
-            return this;
-        }
-
-        /// <inheritdoc />
-        IRawDocumentQuery<T> IQueryBase<T, IRawDocumentQuery<T>>.WaitForNonStaleResultsAsOf(long cutOffEtag)
-        {
-            WaitForNonStaleResultsAsOf(cutOffEtag);
-            return this;
-        }
-
-        /// <inheritdoc />
-        IDocumentQuery<T> IQueryBase<T, IDocumentQuery<T>>.WaitForNonStaleResultsAsOf(long cutOffEtag, TimeSpan waitTimeout)
-        {
-            WaitForNonStaleResultsAsOf(cutOffEtag, waitTimeout);
-            return this;
-        }
-
-        /// <inheritdoc />
-        IRawDocumentQuery<T> IQueryBase<T, IRawDocumentQuery<T>>.WaitForNonStaleResultsAsOf(long cutOffEtag, TimeSpan waitTimeout)
-        {
-            WaitForNonStaleResultsAsOf(cutOffEtag, waitTimeout);
-            return this;
-        }
-
-        /// <inheritdoc />
         IDocumentQuery<T> IQueryBase<T, IDocumentQuery<T>>.WaitForNonStaleResults()
         {
             WaitForNonStaleResults();
@@ -867,7 +839,6 @@ namespace Raven.Client.Documents.Session
                 QueryParameters = QueryParameters,
                 Start = Start,
                 Timeout = Timeout,
-                CutoffEtag = CutoffEtag,
                 QueryStats = QueryStats,
                 TheWaitForNonStaleResults = TheWaitForNonStaleResults,
                 Negate = Negate,

--- a/src/Raven.Client/Documents/Session/IDocumentQueryBase.cs
+++ b/src/Raven.Client/Documents/Session/IDocumentQueryBase.cs
@@ -98,43 +98,6 @@ namespace Raven.Client.Documents.Session
         TSelf WaitForNonStaleResults(TimeSpan waitTimeout);
 
         /// <summary>
-        ///     Instructs the query to wait for non stale results as of the cutoff etag.
-        /// </summary>
-        /// <param name="cutOffEtag">
-        ///     <para>Cutoff etag is used to check if the index has already process a document with the given</para>
-        ///     <para>etag. Unlike Cutoff, which uses dates and is susceptible to clock synchronization issues between</para>
-        ///     <para>machines, cutoff etag doesn't rely on both the server and client having a synchronized clock and </para>
-        ///     <para>can work without it.</para>
-        ///     <para>However, when used to query map/reduce indexes, it does NOT guarantee that the document that this</para>
-        ///     <para>etag belong to is actually considered for the results. </para>
-        ///     <para>What it does it guarantee that the document has been mapped, but not that the mapped values has been reduced. </para>
-        ///     <para>Since map/reduce queries, by their nature, tend to be far less susceptible to issues with staleness, this is </para>
-        ///     <para>considered to be an acceptable trade-off.</para>
-        ///     <para>If you need absolute no staleness with a map/reduce index, you will need to ensure synchronized clocks and </para>
-        ///     <para>use the Cutoff date option, instead.</para>
-        /// </param>
-        TSelf WaitForNonStaleResultsAsOf(long cutOffEtag);
-
-        /// <summary>
-        ///     Instructs the query to wait for non stale results as of the cutoff etag for the specified timeout.
-        /// </summary>
-        /// <param name="cutOffEtag">
-        ///     <para>Cutoff etag is used to check if the index has already process a document with the given</para>
-        ///     <para>etag. Unlike Cutoff, which uses dates and is susceptible to clock synchronization issues between</para>
-        ///     <para>machines, cutoff etag doesn't rely on both the server and client having a synchronized clock and </para>
-        ///     <para>can work without it.</para>
-        ///     <para>However, when used to query map/reduce indexes, it does NOT guarantee that the document that this</para>
-        ///     <para>etag belong to is actually considered for the results. </para>
-        ///     <para>What it does it guarantee that the document has been mapped, but not that the mapped values has been reduced. </para>
-        ///     <para>Since map/reduce queries, by their nature, tend to be far less susceptible to issues with staleness, this is </para>
-        ///     <para>considered to be an acceptable trade-off.</para>
-        ///     <para>If you need absolute no staleness with a map/reduce index, you will need to ensure synchronized clocks and </para>
-        ///     <para>use the Cutoff date option, instead.</para>
-        /// </param>
-        /// <param name="waitTimeout">Maximum time to wait for index query results to become non-stale before exception is thrown.</param>
-        TSelf WaitForNonStaleResultsAsOf(long cutOffEtag, TimeSpan waitTimeout);
-
-        /// <summary>
         ///     Create the index query object for this query
         /// </summary>
         IndexQuery GetIndexQuery();

--- a/src/Raven.Client/Documents/Session/IDocumentQueryCustomization.cs
+++ b/src/Raven.Client/Documents/Session/IDocumentQueryCustomization.cs
@@ -88,42 +88,5 @@ namespace Raven.Client.Documents.Session
         /// </summary>
         /// <param name="waitTimeout">Maximum time to wait for index query results to become non-stale before exception is thrown.</param>
         IDocumentQueryCustomization WaitForNonStaleResults(TimeSpan waitTimeout);
-
-        /// <summary>
-        ///     Instructs the query to wait for non stale results as of the cutoff etag.
-        /// </summary>
-        /// <param name="cutOffEtag">
-        ///     <para>Cutoff etag is used to check if the index has already process a document with the given</para>
-        ///     <para>etag. Unlike Cutoff, which uses dates and is susceptible to clock synchronization issues between</para>
-        ///     <para>machines, cutoff etag doesn't rely on both the server and client having a synchronized clock and </para>
-        ///     <para>can work without it.</para>
-        ///     <para>However, when used to query map/reduce indexes, it does NOT guarantee that the document that this</para>
-        ///     <para>etag belong to is actually considered for the results. </para>
-        ///     <para>What it does it guarantee that the document has been mapped, but not that the mapped values has been reduced. </para>
-        ///     <para>Since map/reduce queries, by their nature, tend to be far less susceptible to issues with staleness, this is </para>
-        ///     <para>considered to be an acceptable trade-off.</para>
-        ///     <para>If you need absolute no staleness with a map/reduce index, you will need to ensure synchronized clocks and </para>
-        ///     <para>use the Cutoff date option, instead.</para>
-        /// </param>
-        IDocumentQueryCustomization WaitForNonStaleResultsAsOf(long cutOffEtag);
-
-        /// <summary>
-        ///     Instructs the query to wait for non stale results as of the cutoff etag for the specified timeout.
-        /// </summary>
-        /// <param name="cutOffEtag">
-        ///     <para>Cutoff etag is used to check if the index has already process a document with the given</para>
-        ///     <para>etag. Unlike Cutoff, which uses dates and is susceptible to clock synchronization issues between</para>
-        ///     <para>machines, cutoff etag doesn't rely on both the server and client having a synchronized clock and </para>
-        ///     <para>can work without it.</para>
-        ///     <para>However, when used to query map/reduce indexes, it does NOT guarantee that the document that this</para>
-        ///     <para>etag belong to is actually considered for the results. </para>
-        ///     <para>What it does it guarantee that the document has been mapped, but not that the mapped values has been reduced. </para>
-        ///     <para>Since map/reduce queries, by their nature, tend to be far less susceptible to issues with staleness, this is </para>
-        ///     <para>considered to be an acceptable trade-off.</para>
-        ///     <para>If you need absolute no staleness with a map/reduce index, you will need to ensure synchronized clocks and </para>
-        ///     <para>use the Cutoff date option, instead.</para>
-        /// </param>
-        /// <param name="waitTimeout">Maximum time to wait for index query results to become non-stale before exception is thrown.</param>
-        IDocumentQueryCustomization WaitForNonStaleResultsAsOf(long cutOffEtag, TimeSpan waitTimeout);
     }
 }

--- a/src/Raven.Client/Extensions/BlittableJsonTextWriterExtensions.cs
+++ b/src/Raven.Client/Extensions/BlittableJsonTextWriterExtensions.cs
@@ -29,13 +29,6 @@ namespace Raven.Client.Extensions
                 writer.WriteComma();
             }
 
-            if (query.CutoffEtag.HasValue)
-            {
-                writer.WritePropertyName(nameof(query.CutoffEtag));
-                writer.WriteInteger(query.CutoffEtag.Value);
-                writer.WriteComma();
-            }
-
             if (query.Start > 0)
             {
                 writer.WritePropertyName(nameof(query.Start));

--- a/src/Raven.Server/Documents/Indexes/Index.cs
+++ b/src/Raven.Server/Documents/Indexes/Index.cs
@@ -1902,9 +1902,7 @@ namespace Raven.Server.Documents.Indexes
                             // we have to open read tx for mapResults _after_ we open index tx
 
                             if (query.WaitForNonStaleResults && query.CutoffEtag == null)
-                                query.CutoffEtag =
-                                    Collections.Max(
-                                        x => DocumentDatabase.DocumentsStorage.GetLastDocumentEtag(documentsContext, x));
+                                query.CutoffEtag = Collections.Max(x => DocumentDatabase.DocumentsStorage.GetLastDocumentEtag(documentsContext, x));
 
                             var isStale = IsStale(documentsContext, indexContext, query.CutoffEtag);
 

--- a/src/Raven.Server/Documents/Queries/IndexQueryServerSide.cs
+++ b/src/Raven.Server/Documents/Queries/IndexQueryServerSide.cs
@@ -14,6 +14,16 @@ namespace Raven.Server.Documents.Queries
         [JsonDeserializationIgnore]
         public QueryMetadata Metadata { get; private set; }
 
+        /// <summary>
+        /// Gets or sets the cutoff etag.
+        /// <para>Cutoff etag is used to check if the index has already process a document with the given</para>
+        /// <para>etag. Unlike Cutoff, which uses dates and is susceptible to clock synchronization issues between</para>
+        /// <para>machines, cutoff etag doesn't rely on both the server and client having a synchronized clock and </para>
+        /// <para>can work without it.</para>
+        /// </summary>
+        [JsonDeserializationIgnore]
+        public long? CutoffEtag { get; set; }
+        
         private IndexQueryServerSide()
         {
             // for deserialization

--- a/test/FastTests/Client/Indexing/DebugIndexing.cs
+++ b/test/FastTests/Client/Indexing/DebugIndexing.cs
@@ -46,7 +46,6 @@ namespace FastTests.Client.Indexing
                     }, "query/parameters"))
                     {
                         Start = q.Start,
-                        CutoffEtag = q.CutoffEtag,
                         ExplainScores = q.ExplainScores,
                         PageSize = q.PageSize,
 #if FEATURE_SHOW_TIMINGS

--- a/test/FastTests/Server/Documents/Queries/WaitingForNonStaleResults.cs
+++ b/test/FastTests/Server/Documents/Queries/WaitingForNonStaleResults.cs
@@ -17,8 +17,6 @@ namespace FastTests.Server.Documents.Queries
         [Fact]
         public async Task Cutoff_etag_usage()
         {
-            long lastEtagOfUser;
-
             using (var store = GetDocumentStore())
             {
                 using (var session = store.OpenAsyncSession())
@@ -31,13 +29,11 @@ namespace FastTests.Server.Documents.Queries
                     await session.StoreAsync(new Address());
 
                     await session.SaveChangesAsync();
-
-                    lastEtagOfUser = session.Advanced.GetChangeVectorFor(entity).ToChangeVector()[0].Etag;
                 }
 
                 using (var session = store.OpenSession())
                 {
-                    var users = session.Query<User>().Customize(x => x.WaitForNonStaleResultsAsOf(lastEtagOfUser)).OrderBy(x => x.Name).ToList();
+                    var users = session.Query<User>().Customize(x => x.WaitForNonStaleResults()).OrderBy(x => x.Name).ToList();
 
                     Assert.Equal(2, users.Count);
                 }

--- a/test/SlowTests/Bugs/Caching/CachingOfDocumentInclude.cs
+++ b/test/SlowTests/Bugs/Caching/CachingOfDocumentInclude.cs
@@ -233,12 +233,10 @@ namespace SlowTests.Bugs.Caching
                     s.SaveChanges();
                 }
 
-                var latestEtag1 = store.Maintenance.Send(new GetStatisticsOperation()).LastDocEtag ?? 0;
-
                 using (var s = store.OpenSession())
                 {
                     var results = s.Query<User>("index")
-                        .Customize(q => q.WaitForNonStaleResultsAsOf(latestEtag1))
+                        .Customize(q => q.WaitForNonStaleResults())
                         .Where(u => u.Email == "same.email@example.com")
                         .ToArray();
                     // Cache is done by url, so including a cutoff date invalidates the cache.
@@ -254,8 +252,6 @@ namespace SlowTests.Bugs.Caching
                     s.SaveChanges();
                 }
 
-                var latestEtag2 = store.Maintenance.Send(new GetStatisticsOperation()).LastDocEtag ?? 0;
-
                 using (var s = store.OpenSession())
                 {
                     s.Store(new User { Name = "Other", Email = "same.email@example.com" });
@@ -265,7 +261,7 @@ namespace SlowTests.Bugs.Caching
                 using (var s = store.OpenSession())
                 {
                     var results = s.Query<User>("index")
-                        .Customize(q => q.WaitForNonStaleResultsAsOf(latestEtag2))
+                        .Customize(q => q.WaitForNonStaleResults())
                         .Where(u => u.Email == "same.email@example.com")
                         .ToArray();
                     // this works, since we don't hit the cache


### PR DESCRIPTION
…tag parameter which is not be available in the client