### PR TITLE
RavenDB-9680 When deleting tombstones we need to store _lastEtag if i…

### DIFF
--- a/src/Raven.Server/Documents/DocumentsStorage.cs
+++ b/src/Raven.Server/Documents/DocumentsStorage.cs
@@ -1474,6 +1474,7 @@ namespace Raven.Server.Documents
             if (_logger.IsInfoEnabled && deleteCount > 0)
                 _logger.Info($"Deleted {deleteCount:#,#;;0} tombstones earlier than {etag} in {collection}");
 
+            EnsureLastEtagIsPersisted(context, etag);
         }
 
         public IEnumerable<string> GetTombstoneCollections(Transaction transaction)

--- a/test/SlowTests/Issues/RavenDB_9680.cs
+++ b/test/SlowTests/Issues/RavenDB_9680.cs
@@ -1,0 +1,73 @@
+﻿using System.Linq;
+using System.Threading.Tasks;
+using FastTests;
+using Raven.Client.Documents.Queries;
+using SlowTests.Core.Utils.Entities;
+using Xunit;
+
+namespace SlowTests.Issues
+{
+    public class RavenDB_9680 : RavenTestBase
+    {
+        [Fact]
+        public async Task Should_delete_index_entries_on_document_deletion_after_database_restart()
+        {
+            using (var store = GetDocumentStore(new Options() { Path = NewDataPath() }))
+            {
+                string indexName;
+
+                using (var session = store.OpenSession())
+                {
+                    session.Store(new User()
+                    {
+                        Name = "joe"
+                    }, "users/1");
+
+                    session.Store(new User()
+                    {
+                        Name = "doe"
+                    }, "users/2");
+
+                    session.SaveChanges();
+
+                    // to create an index
+                    session.Query<User>().Customize(x => x.WaitForNonStaleResults()).Statistics(out var stats).Where(x => x.Name != null).ToList();
+
+                    indexName = stats.IndexName;
+                }
+
+                using (var session = store.OpenSession())
+                {
+                    session.Delete("users/1");
+
+                    session.SaveChanges();
+                }
+
+                WaitForIndexing(store);
+
+                await (await GetDatabase(store.Database)).DocumentTombstoneCleaner.ExecuteCleanup(); // will delete users/1 tombstone
+
+                // the restart is necessary to expose the issue
+                // on db load we read last etag
+                // however next created tombstone will get _the same_ etag as tombstone of users/1
+                Server.ServerStore.DatabasesLandlord.UnloadDatabase(store.Database);
+
+                using (var session = store.OpenSession())
+                {
+                    session.Delete("users/2");
+
+                    session.SaveChanges();
+                }
+
+                WaitForIndexing(store);
+                
+                using (var commands = store.Commands())
+                {
+                    var result = commands.Query(new IndexQuery { Query = $"from index '{indexName}'" }, indexEntriesOnly: true);
+
+                    Assert.Equal(0, result.Results.Length);
+                }
+            }
+        }
+    }
+}


### PR DESCRIPTION
…t's the etag of the last deleted tombstone. We need that to ensure tombstones created after the db restart won't get the same etag as already deleted ones.