### PR TITLE
RavenDB-9711 Undisposed requests in the client causing memory issues:

### DIFF
--- a/Raven.Client.Lightweight/FileSystem/Extensions/AsyncFilesServerClientExtension.cs
+++ b/Raven.Client.Lightweight/FileSystem/Extensions/AsyncFilesServerClientExtension.cs
@@ -60,9 +60,10 @@ namespace Raven.Client.FileSystem.Extensions
                     request.AddRange(@from.Value);
             }
 
+            HttpResponseMessage response = null;
             try
             {
-                var response = await request.ExecuteRawResponseAsync().ConfigureAwait(false);
+                response = await request.ExecuteRawResponseAsync().ConfigureAwait(false);
                 if (response.StatusCode == HttpStatusCode.NotFound)
                     throw new FileNotFoundException("The file requested does not exists on the file system.", baseUrl + path + filename);
 
@@ -80,6 +81,20 @@ namespace Raven.Client.FileSystem.Extensions
             }
             catch (Exception e)
             {
+                try
+                {
+                    request.Dispose();
+
+                    if (response != null)
+                    {
+                        response.Content.Dispose();
+                        response.Dispose();
+                    }
+                }
+                catch (Exception)
+                {
+                }
+
                 throw e.SimplifyException();
             }
         }

--- a/Raven.Client.Lightweight/Util/DisposableStream.cs
+++ b/Raven.Client.Lightweight/Util/DisposableStream.cs
@@ -114,6 +114,7 @@ namespace Raven.Client.Util
         public override void Close()
         {
             innerStream.Close();
+            base.Close();
         }
 #endif
 


### PR DESCRIPTION
- dispose the request when the exception is thrown
- fixing disposal of DisposableStream by calling base.Close() in order to ensure Dispose(bool disposing) will be called once the stream is disposed