### PR TITLE
RavenDB-9711 Undisposed requests in the client causing memory issues:

### DIFF
--- a/Raven.Client.Lightweight/Util/DisposableStream.cs
+++ b/Raven.Client.Lightweight/Util/DisposableStream.cs
@@ -111,6 +111,7 @@ namespace Raven.Client.Util
         public override void Close()
         {
             innerStream.Close();
+            base.Close();
         }
 
         public override Task CopyToAsync(Stream destination, int bufferSize, CancellationToken cancellationToken)


### PR DESCRIPTION
- dispose the request when the exception is thrown
- fixing disposal of DisposableStream by calling base.Close() in order to ensure Dispose(bool disposing) will be called once the stream is disposed