### PR TITLE
RavenDB-7472

### DIFF
--- a/src/Raven.Client/Exceptions/Commercial/LicenseLimitException.cs
+++ b/src/Raven.Client/Exceptions/Commercial/LicenseLimitException.cs
@@ -1,0 +1,29 @@
+﻿using System;
+
+namespace Raven.Client.Exceptions.Commercial
+{
+    public class LicenseLimitException : RavenException
+    {
+        public LimitType Type { get; }
+
+        public LicenseLimitException()
+        {
+        }
+
+        public LicenseLimitException(string message)
+            : base(message)
+        {
+        }
+
+        public LicenseLimitException(LimitType type, string message)
+            : base(message)
+        {
+            Type = type;
+        }
+
+        public LicenseLimitException(string message, Exception e)
+            : base(message, e)
+        {
+        }
+    }
+}

--- a/src/Raven.Client/Exceptions/Commercial/LimitType.cs
+++ b/src/Raven.Client/Exceptions/Commercial/LimitType.cs
@@ -1,4 +1,4 @@
-﻿namespace Raven.Server.Commercial
+﻿namespace Raven.Client.Exceptions.Commercial
 {
     public enum LimitType
     {

--- a/src/Raven.Server/Commercial/LicenseLimit.cs
+++ b/src/Raven.Server/Commercial/LicenseLimit.cs
@@ -1,9 +1,0 @@
-﻿namespace Raven.Server.Commercial
-{
-    public class LicenseLimit
-    {
-        public LimitType Type { get; set; }
-
-        public string Message { get; set; }
-    }
-}

--- a/src/Raven.Server/Commercial/SetupManager.cs
+++ b/src/Raven.Server/Commercial/SetupManager.cs
@@ -1011,7 +1011,8 @@ namespace Raven.Server.Commercial
 
                             try
                             {
-                                serverStore.Engine.SetNewState(RachisState.Passive, null, serverStore.Engine.CurrentTerm, "During setup wizard, making sure there is no cluster from previous installation.");
+                                serverStore.Engine.SetNewState(RachisState.Passive, null, serverStore.Engine.CurrentTerm, "During setup wizard, " +
+                                                                                                                          "making sure there is no cluster from previous installation.");
                             }
                             catch (Exception e)
                             {

--- a/src/Raven.Server/Documents/DatabaseRequestHandler.cs
+++ b/src/Raven.Server/Documents/DatabaseRequestHandler.cs
@@ -47,7 +47,7 @@ namespace Raven.Server.Documents
         protected async Task DatabaseConfigurations(Func<TransactionOperationContext, string,
            BlittableJsonReaderObject, Task<(long, object)>> setupConfigurationFunc,
            string debug,
-           Func<string, BlittableJsonReaderObject, bool> beforeSetupConfiguration = null,
+           Action<string, BlittableJsonReaderObject> beforeSetupConfiguration = null,
            Action<DynamicJsonValue, BlittableJsonReaderObject, long> fillJson = null,
            HttpStatusCode statusCode = HttpStatusCode.OK)
         {
@@ -62,8 +62,7 @@ namespace Raven.Server.Documents
             using (ServerStore.ContextPool.AllocateOperationContext(out TransactionOperationContext context))
             {
                 var configurationJson = await context.ReadForMemoryAsync(RequestBodyStream(), debug);
-                if (beforeSetupConfiguration?.Invoke(Database.Name, configurationJson) == false)
-                    return;
+                beforeSetupConfiguration?.Invoke(Database.Name, configurationJson);
 
                 var (index, _) = await setupConfigurationFunc(context, Database.Name, configurationJson);
                 DatabaseRecord dbRecord;

--- a/src/Raven.Server/Documents/Handlers/Admin/RachisAdminHandler.cs
+++ b/src/Raven.Server/Documents/Handlers/Admin/RachisAdminHandler.cs
@@ -329,11 +329,7 @@ namespace Raven.Server.Documents.Handlers.Admin
 
             Debug.Assert(assignedCores <= nodeInfo.NumberOfCores);
 
-            if (ServerStore.LicenseManager.CanAddNode(nodeUrl, assignedCores.Value, out var licenseLimit) == false)
-            {
-                SetLicenseLimitResponse(licenseLimit);
-                return;
-            }
+            ServerStore.LicenseManager.AssertCanAddNode(nodeUrl, assignedCores.Value);
 
             if (ServerStore.IsLeader())
             {
@@ -500,15 +496,7 @@ namespace Raven.Server.Documents.Handlers.Admin
 
             if (ServerStore.IsLeader())
             {
-                var licenseLimit = await ServerStore
-                    .LicenseManager
-                    .ChangeLicenseLimits(nodeTag, newAssignedCores.Value);
-
-                if (licenseLimit != null)
-                {
-                    SetLicenseLimitResponse(licenseLimit);
-                    return;
-                }
+                await ServerStore.LicenseManager.ChangeLicenseLimits(nodeTag, newAssignedCores.Value);
 
                 NoContentStatus();
                 return;

--- a/src/Raven.Server/Documents/Handlers/MultiGetHandler.cs
+++ b/src/Raven.Server/Documents/Handlers/MultiGetHandler.cs
@@ -153,11 +153,9 @@ namespace Raven.Server.Documents.Handlers
                             {
                                 [nameof(ExceptionDispatcher.ExceptionSchema.Url)] = $"{url}{query}",
                                 [nameof(ExceptionDispatcher.ExceptionSchema.Type)] = e.GetType().FullName,
-                                [nameof(ExceptionDispatcher.ExceptionSchema.Message)] = e.Message
+                                [nameof(ExceptionDispatcher.ExceptionSchema.Message)] = e.Message,
+                                [nameof(ExceptionDispatcher.ExceptionSchema.Error)] = e.ToString()
                             };
-
-
-                            djv[nameof(ExceptionDispatcher.ExceptionSchema.Error)] = e.ToString();
 
                             using (var json = context.ReadObject(djv, "exception"))
                                 writer.WriteObject(json);

--- a/src/Raven.Server/Documents/Replication/ReplicationDocumentSender.cs
+++ b/src/Raven.Server/Documents/Replication/ReplicationDocumentSender.cs
@@ -305,10 +305,8 @@ namespace Raven.Server.Documents.Replication
             {
                 delayReplicationFor = external.DelayReplicationFor;
 
-                if (delayReplicationFor.Ticks > 0 && _parent._parent._server.LicenseManager.CanDelayReplication(out var limit) == false)
-                {
-                    throw new OperationCanceledException($"External replication was canceled, because : {limit.Message}");
-                }
+                if (delayReplicationFor.Ticks > 0)
+                    _parent._parent._server.LicenseManager.AssertCanDelayReplication();
             }
             return delayReplicationFor;
         }

--- a/src/Raven.Server/NotificationCenter/Notifications/Details/LicenseLimitWarning.cs
+++ b/src/Raven.Server/NotificationCenter/Notifications/Details/LicenseLimitWarning.cs
@@ -1,4 +1,5 @@
-﻿using Raven.Server.Commercial;
+﻿using Raven.Client.Exceptions.Commercial;
+using Raven.Server.Commercial;
 using Raven.Server.ServerWide;
 using Sparrow.Json.Parsing;
 
@@ -11,7 +12,7 @@ namespace Raven.Server.NotificationCenter.Notifications.Details
             
         }
 
-        private LicenseLimitWarning(LicenseLimit licenseLimit)
+        private LicenseLimitWarning(LicenseLimitException licenseLimit)
         {
             Type = licenseLimit.Type;
             Message = licenseLimit.Message;
@@ -30,7 +31,7 @@ namespace Raven.Server.NotificationCenter.Notifications.Details
             };
         }
 
-        public static void AddLicenseLimitNotification(ServerStore serverStore, LicenseLimit licenseLimit)
+        public static void AddLicenseLimitNotification(ServerStore serverStore, LicenseLimitException licenseLimit)
         {
             var alert = AlertRaised.Create(
                 null,

--- a/src/Raven.Server/ServerWide/Maintenance/ClusterObserver.cs
+++ b/src/Raven.Server/ServerWide/Maintenance/ClusterObserver.cs
@@ -229,6 +229,7 @@ namespace Raven.Server.ServerWide.Maintenance
                 _logger.Operations(alertMsg);
             }
         }
+        
         private string UpdateDatabaseTopology(string dbName, DatabaseRecord record, ClusterTopology clusterTopology,
             Dictionary<string, ClusterNodeStatusReport> current,
             Dictionary<string, ClusterNodeStatusReport> previous,
@@ -331,7 +332,7 @@ namespace Raven.Server.ServerWide.Maintenance
                         continue;
                     }
 
-                    if (_server.LicenseManager.CanDynamicallyDistributeNodes(out var _) == false)
+                    if (_server.LicenseManager.CanDynamicallyDistributeNodes(out _) == false)
                         continue;
 
                     // replace the bad promotable otherwise we will continue to add more and more nodes.
@@ -386,7 +387,7 @@ namespace Raven.Server.ServerWide.Maintenance
                         if (goodMembers < topology.ReplicationFactor &&
                             TryFindFitNode(rehab, dbName, topology, clusterTopology, current, out var node))
                         {
-                            if (_server.LicenseManager.CanDynamicallyDistributeNodes(out var _) == false)
+                            if (_server.LicenseManager.CanDynamicallyDistributeNodes(out _) == false)
                                 continue;
 
                             topology.Promotables.Add(node);

--- a/src/Raven.Server/Web/RequestHandler.cs
+++ b/src/Raven.Server/Web/RequestHandler.cs
@@ -15,6 +15,7 @@ using Raven.Client;
 using Raven.Client.Documents.Conventions;
 using Raven.Client.Documents.Session;
 using Raven.Client.Exceptions;
+using Raven.Client.Exceptions.Commercial;
 using Raven.Client.ServerWide;
 using Raven.Client.ServerWide.Operations.Certificates;
 using Raven.Server.Commercial;
@@ -478,21 +479,6 @@ namespace Raven.Server.Web
         protected void SetupCORSHeaders()
         {
             SetupCORSHeaders(HttpContext);
-        }
-
-        protected void SetLicenseLimitResponse(LicenseLimit licenseLimit)
-        {
-            if (licenseLimit == null)
-                throw new ArgumentNullException(nameof(licenseLimit));
-
-            HttpContext.Response.StatusCode = (int)HttpStatusCode.PaymentRequired;
-            using (ServerStore.ContextPool.AllocateOperationContext(out TransactionOperationContext context))
-            using (var writer = new BlittableJsonTextWriter(context, ResponseBodyStream()))
-            {
-                var blittable = EntityToBlittable.ConvertEntityToBlittable(licenseLimit, DocumentConventions.Default, context);
-                context.Write(writer, blittable);
-                writer.Flush();
-            }
         }
     }
 }

--- a/src/Raven.Server/Web/Studio/LicenseHandler.cs
+++ b/src/Raven.Server/Web/Studio/LicenseHandler.cs
@@ -32,12 +32,7 @@ namespace Raven.Server.Web.Studio
                 license = JsonDeserializationServer.License(json);
             }
 
-            var licenseLimit = await ServerStore.LicenseManager.Activate(license, skipLeaseLicense: false);
-            if (licenseLimit != null)
-            {
-                SetLicenseLimitResponse(licenseLimit);
-                return;
-            }
+            await ServerStore.LicenseManager.Activate(license, skipLeaseLicense: false);
 
             NoContentStatus();
         }

--- a/src/Raven.Server/Web/System/AdminDatabasesHandler.cs
+++ b/src/Raven.Server/Web/System/AdminDatabasesHandler.cs
@@ -120,12 +120,8 @@ namespace Raven.Server.Web.System
                 var databaseRecord = ServerStore.Cluster.ReadDatabase(context, name, out var index);
                 var clusterTopology = ServerStore.GetClusterTopology(context);
 
-                if (databaseRecord.Encrypted &&
-                    ServerStore.LicenseManager.CanCreateEncryptedDatabase(out var licenseLimit) == false)
-                {
-                    SetLicenseLimitResponse(licenseLimit);
-                    return;
-                }
+                if (databaseRecord.Encrypted)
+                    ServerStore.LicenseManager.AssertCanCreateEncryptedDatabase();
 
                 // the case where an explicit node was requested 
                 if (string.IsNullOrEmpty(node) == false)
@@ -222,8 +218,7 @@ namespace Raven.Server.Web.System
                 if ((databaseRecord.Topology?.DynamicNodesDistribution ?? false) &&
                     Server.ServerStore.LicenseManager.CanDynamicallyDistributeNodes(out var licenseLimit) == false)
                 {
-                    SetLicenseLimitResponse(licenseLimit);
-                    return;
+                    throw licenseLimit;
                 }
 
                 if (ServerStore.DatabasesLandlord.IsDatabaseLoaded(name) == false)
@@ -743,8 +738,7 @@ namespace Raven.Server.Web.System
                 if (enable &&
                     Server.ServerStore.LicenseManager.CanDynamicallyDistributeNodes(out var licenseLimit) == false)
                 {
-                    SetLicenseLimitResponse(licenseLimit);
-                    return;
+                    throw licenseLimit;
                 }
 
                 databaseRecord.Topology.DynamicNodesDistribution = enable;

--- a/src/Raven.Studio/typescript/common/notifications/models/recentLicenseLimitError.ts
+++ b/src/Raven.Studio/typescript/common/notifications/models/recentLicenseLimitError.ts
@@ -5,9 +5,9 @@ import generalUtils = require("common/generalUtils");
 
 class recentLicenseLimitError extends recentError {
 
-    licenseLimitType = ko.observable<Raven.Server.Commercial.LimitType>();
+    licenseLimitType = ko.observable<Raven.Client.Exceptions.Commercial.LimitType>();
     
-    constructor(dto: recentErrorDto, limitType: Raven.Server.Commercial.LimitType) {
+    constructor(dto: recentErrorDto, limitType: Raven.Client.Exceptions.Commercial.LimitType) {
         super(dto);
 
         this.hasDetails = ko.pureComputed(() => true); // it always has details
@@ -15,7 +15,7 @@ class recentLicenseLimitError extends recentError {
         this.licenseLimitType(limitType);
     }
 
-    static tryExtractLicenseLimitType(details: string): Raven.Server.Commercial.LimitType {
+    static tryExtractLicenseLimitType(details: string): Raven.Client.Exceptions.Commercial.LimitType {
         try {
             const parsedDetails = JSON.parse(details);
 

--- a/src/Raven.Studio/typescript/models/auth/licenseModel.ts
+++ b/src/Raven.Studio/typescript/models/auth/licenseModel.ts
@@ -9,7 +9,7 @@ class licenseModel {
 
     private static baseUrl = "https://ravendb.net/license/request";
 
-    static generateLicenseRequestUrl(limitType: Raven.Server.Commercial.LimitType = null): string {
+    static generateLicenseRequestUrl(limitType: Raven.Client.Exceptions.Commercial.LimitType = null): string {
         let url = `${licenseModel.baseUrl}?`;
 
         const build = buildInfo.serverBuildVersion();

--- a/test/Tryouts/Program.cs
+++ b/test/Tryouts/Program.cs
@@ -6,6 +6,7 @@ using System.Diagnostics;
 using System.Linq;
 using System.Threading.Tasks;
 using Raven.Server.Utils;
+using SlowTests.Server.Replication;
 
 /*
     Code reference - please DO NOT REMOVE:
@@ -29,13 +30,17 @@ namespace Tryouts
             Console.WriteLine(Process.GetCurrentProcess().Id);
             Console.WriteLine();
            
-            for (int i = 0; i < 100; i++)
+            for (var i = 0; i < 10000; i++)
             {
                 Console.WriteLine(i);
-                using (var a = new ClusterDatabaseMaintenance())
+
+                Parallel.For(1, 10, (x) =>
                 {
-                    a.DontRemoveNodeWhileItHasNotReplicatedDocs().Wait();
-                }
+                    using (var test = new ReplicationSpecialCases())
+                    {
+                        test.IdenticalContentConflictResolution().Wait();
+                    }
+                });
             }
         }
 

--- a/tools/TypingsGenerator/Program.cs
+++ b/tools/TypingsGenerator/Program.cs
@@ -14,6 +14,7 @@ using Raven.Client.Documents.Operations.Indexes;
 using Raven.Client.Documents.Queries;
 using Raven.Client.Documents.Smuggler;
 using Raven.Client.Documents.Subscriptions;
+using Raven.Client.Exceptions.Commercial;
 using Raven.Client.Http;
 using Raven.Client.ServerWide;
 using Raven.Client.ServerWide.ETL;
@@ -319,7 +320,7 @@ namespace TypingsGenerator
             scripter.AddType(typeof(AdminRevisionsHandler.Parameters));
             scripter.AddType(typeof(ReorderDatabaseMembersOperation.Parameters));
             
-            scripter.AddType(typeof(LicenseLimit));
+            scripter.AddType(typeof(LicenseLimitException));
             
             scripter.AddType(typeof(CompactSettings));
             scripter.AddType(typeof(CompactionResult));


### PR DESCRIPTION
- Make sure to throw LicenseLimitException which can be parsed by the client, instead of returning an error message with "Error" property.
- Handle 5 places or so where we didn't throw an license limit exception but reported the license was used successfully.
- Remove custom SetLicenseLimitResponse method as use the MaybeSetExceptionStatusCode method to convert exception to HTTP code.