### PR TITLE
RavenDB-9620: Adding paths validation, so they will not start with "a…

### DIFF
--- a/src/Raven.Client/ServerWide/DatabaseRecord.cs
+++ b/src/Raven.Client/ServerWide/DatabaseRecord.cs
@@ -31,9 +31,7 @@ namespace Raven.Client.ServerWide
         public Dictionary<string, DeletionInProgressStatus> DeletionInProgress;
 
         public Dictionary<string, string> DeletionInProgressChangeVector;
-
-        public string DataDirectory;
-
+        
         public DatabaseTopology Topology;
 
         // public OnGoingTasks tasks;  tasks for this node..

--- a/src/Raven.Server/Config/RavenConfiguration.cs
+++ b/src/Raven.Server/Config/RavenConfiguration.cs
@@ -18,6 +18,7 @@ using Raven.Server.Config.Settings;
 using Raven.Server.Extensions;
 using Raven.Server.ServerWide;
 using Raven.Server.Utils.Cli;
+using Voron.Util.Settings;
 
 namespace Raven.Server.Config
 {
@@ -84,6 +85,7 @@ namespace Raven.Server.Config
             ResourceName = resourceName;
             ResourceType = resourceType;
             _customConfigPath = customConfigPath;
+            PathSettingBase<string>.ValidatePath(_customConfigPath);
             _configBuilder = new ConfigurationBuilder();
             AddEnvironmentVariables();
             AddJsonConfigurationVariables(customConfigPath);

--- a/src/Voron/Util/Settings/PathSettingBase.cs
+++ b/src/Voron/Util/Settings/PathSettingBase.cs
@@ -15,8 +15,20 @@ namespace Voron.Util.Settings
 
         protected PathSettingBase(string path, PathSettingBase<T> baseDataDir = null)
         {
+            ValidatePath(path);
             _baseDataDir = baseDataDir;
             _path = path;
+        }
+
+        public static void ValidatePath(string path)
+        {
+            if (path!= null && 
+                (path.StartsWith("appdrive:", StringComparison.InvariantCultureIgnoreCase) || 
+                path.StartsWith("~") || 
+                path.StartsWith("$home", StringComparison.InvariantCultureIgnoreCase)))
+            {
+                throw new ArgumentException($"The path '{path}' is illegal! Paths in RavenDB can't start with 'appdrive:', '~' or '$home'");
+            }
         }
 
         public string FullPath => _fullPath ?? (_fullPath = ToFullPath());

--- a/test/FastTests/Issues/RavenDB_9620.cs
+++ b/test/FastTests/Issues/RavenDB_9620.cs
@@ -1,0 +1,26 @@
+﻿using System;
+using System.Collections.Generic;
+using System.Text;
+using Raven.Server.Config;
+using Xunit;
+
+namespace FastTests.Issues
+{
+    public class RavenDB_9620:RavenTestBase
+    {
+        [Fact]
+        public void CreateServerWithIllegalAppdrivePath()
+        {
+            Assert.IsType(typeof(InvalidOperationException),                
+                Assert.Throws<Raven.Client.Exceptions.RavenException>(() => 
+                GetDocumentStore(new Options
+                {
+                    ModifyDatabaseRecord = x =>
+                    {
+                        x.Settings[
+                            RavenConfiguration.GetKey(config => config.Core.DataDirectory)] = "APPDRIVE:";
+                    }
+                })).InnerException);            
+        }
+    }
+}


### PR DESCRIPTION
…ppdata:", "~" and "$home"