### PR TITLE
RavenDB-9531

### DIFF
--- a/src/Raven.Client/Exceptions/Documents/Indexes/IndexCreationException.cs
+++ b/src/Raven.Client/Exceptions/Documents/Indexes/IndexCreationException.cs
@@ -16,6 +16,5 @@ namespace Raven.Client.Exceptions.Documents.Indexes
             : base(message, innerException)
         {
         }
-
     }
 }

--- a/src/Raven.Client/Exceptions/Documents/Indexes/IndexDeletionException.cs
+++ b/src/Raven.Client/Exceptions/Documents/Indexes/IndexDeletionException.cs
@@ -1,0 +1,20 @@
+﻿using System;
+
+namespace Raven.Client.Exceptions.Documents.Indexes
+{
+    public class IndexDeletionException : RavenException
+    {
+        public IndexDeletionException()
+        {            
+        }
+
+        public IndexDeletionException(string message) : base(message)
+        {
+        }
+
+        public IndexDeletionException(string message, Exception innerException)
+            : base(message, innerException)
+        {
+        }
+    }
+}


### PR DESCRIPTION
Add missing locker in ResetIndexInternal as it calls CreateNew concurrently which is throwing. (All other calls to DeleteIndexInternal are under a locker.)
Dispose the index before calling removing it from the indexes dictionary using TryRemoveByName.
Make sure to throw IndexDeletionException when the actual error is in delete.

@arekpalinski Thanks for the co-investigation 👍 