### PR TITLE
RavenDB-9531 We need to remove the index from collection of indexes f…

### DIFF
--- a/src/Raven.Server/Documents/Indexes/IndexStore.cs
+++ b/src/Raven.Server/Documents/Indexes/IndexStore.cs
@@ -637,6 +637,8 @@ namespace Raven.Server.Documents.Indexes
         {
             lock (_locker)
             {
+                _indexes.TryRemoveByName(index.Name, index);
+
                 try
                 {
                     index.Dispose();
@@ -646,8 +648,6 @@ namespace Raven.Server.Documents.Indexes
                     if (_logger.IsInfoEnabled)
                         _logger.Info($"Could not dispose index '{index.Name}'.", e);
                 }
-
-                _indexes.TryRemoveByName(index.Name, index);
 
                 _documentDatabase.Changes.RaiseNotifications(new IndexChange
                 {


### PR DESCRIPTION
…irst to ensure someone won't get an index instance that is going to be disposed in a bit (this commit reverts the change introduced in 61e388ab8b)

CC @fitzchak 