### PR TITLE
RavenDB-9701: Seperate into the following timeouts:

### DIFF
--- a/src/Raven.Server/Config/Categories/DatabaseConfiguration.cs
+++ b/src/Raven.Server/Config/Categories/DatabaseConfiguration.cs
@@ -6,23 +6,41 @@ namespace Raven.Server.Config.Categories
 {
     public class DatabaseConfiguration : ConfigurationCategory
     {
-        [Description("The time in seconds to wait before canceling query operation")]
+        /// <summary>
+        /// The time in seconds to wait before canceling query
+        /// </summary>
+        [Description("The time in seconds to wait before canceling query")]
+        [DefaultValue(300)]
+        [TimeUnit(TimeUnit.Seconds)]
+        [ConfigurationEntry("Databases.QueryTimeoutInSec", ConfigurationEntryScope.ServerWideOrPerDatabase)]
+        public TimeSetting QueryTimeout { get; set; }
+
+        /// <summary>
+        /// The time in seconds to wait before canceling query related operation (patch/delete query)
+        /// </summary>
+        [Description("The time in seconds to wait before canceling query related operation (patch/delete query)")]
         [DefaultValue(300)]
         [TimeUnit(TimeUnit.Seconds)]
         [ConfigurationEntry("Databases.QueryOperationTimeoutInSec", ConfigurationEntryScope.ServerWideOrPerDatabase)]
         public TimeSetting QueryOperationTimeout { get; set; }
 
-        [Description("The time in seconds to wait before canceling terms indexing operation")]
+        /// <summary>
+        /// The time in seconds to wait before canceling specific operations (such as indexing terms)
+        /// </summary>
+        [Description("The time in seconds to wait before canceling specific operations (such as indexing terms)")]
         [DefaultValue(300)]
         [TimeUnit(TimeUnit.Seconds)]
-        [ConfigurationEntry("Databases.IndexTermsOperationTimeoutInSec", ConfigurationEntryScope.ServerWideOrPerDatabase)]
-        public TimeSetting IndexTermsOperationTimeout { get; set; }
+        [ConfigurationEntry("Databases.OperationTimeoutInSec", ConfigurationEntryScope.ServerWideOrPerDatabase)]
+        public TimeSetting OperationTimeout { get; set; }
 
-        [Description("The time in seconds to wait before canceling indexing terms operation")]
+        /// <summary>
+        /// The time in seconds to wait before canceling several collection operations (such as batch delete documents)
+        /// </summary>
+        [Description("The time in seconds to wait before canceling several collection operations (such as batch delete documents from studio)")]
         [DefaultValue(300)]
         [TimeUnit(TimeUnit.Seconds)]
-        [ConfigurationEntry("Databases.DeleteDocsOperationTimeoutInSec", ConfigurationEntryScope.ServerWideOrPerDatabase)]
-        public TimeSetting DeleteDocsOperationTimeout { get; set; }
+        [ConfigurationEntry("Databases.CollectionOperationTimeoutInSec", ConfigurationEntryScope.ServerWideOrPerDatabase)]
+        public TimeSetting CollectionOperationTimeout { get; set; }
 
         /// <summary>
         /// This much time has to wait for the database to become available when too much

--- a/src/Raven.Server/Documents/DatabaseRequestHandler.cs
+++ b/src/Raven.Server/Documents/DatabaseRequestHandler.cs
@@ -94,19 +94,24 @@ namespace Raven.Server.Documents
             }
         }
 
+        protected OperationCancelToken CreateTimeLimitedOperationToken()
+        {
+            return new OperationCancelToken(Database.Configuration.Databases.OperationTimeout.AsTimeSpan, Database.DatabaseShutdown);
+        }
+
+        protected OperationCancelToken CreateTimeLimitedQueryToken()
+        {
+            return new OperationCancelToken(Database.Configuration.Databases.QueryTimeout.AsTimeSpan, Database.DatabaseShutdown);
+        }
+
+        protected OperationCancelToken CreateTimeLimitedCollectionOperationToken()
+        {
+            return new OperationCancelToken(Database.Configuration.Databases.CollectionOperationTimeout.AsTimeSpan, Database.DatabaseShutdown);
+        }
+
         protected OperationCancelToken CreateTimeLimitedQueryOperationToken()
         {
             return new OperationCancelToken(Database.Configuration.Databases.QueryOperationTimeout.AsTimeSpan, Database.DatabaseShutdown);
-        }
-
-        protected OperationCancelToken CreateTimeLimitedDeleteDocsOperationToken()
-        {
-            return new OperationCancelToken(Database.Configuration.Databases.DeleteDocsOperationTimeout.AsTimeSpan, Database.DatabaseShutdown);
-        }
-
-        protected OperationCancelToken CreateTimeLimitedIndexTermsOperationToken()
-        {
-            return new OperationCancelToken(Database.Configuration.Databases.IndexTermsOperationTimeout.AsTimeSpan, Database.DatabaseShutdown);
         }
 
         protected OperationCancelToken CreateOperationToken()

--- a/src/Raven.Server/Documents/Handlers/IndexHandler.cs
+++ b/src/Raven.Server/Documents/Handlers/IndexHandler.cs
@@ -528,7 +528,7 @@ namespace Raven.Server.Documents.Handlers
             var field = GetQueryStringValueAndAssertIfSingleAndNotEmpty("field");
             var fromValue = GetStringQueryString("fromValue", required: false);
 
-            using (var token = CreateTimeLimitedIndexTermsOperationToken())
+            using (var token = CreateTimeLimitedOperationToken())
             using (Database.DocumentsStorage.ContextPool.AllocateOperationContext(out DocumentsOperationContext context))
             using (context.OpenReadTransaction())
             {

--- a/src/Raven.Server/Documents/Handlers/QueriesHandler.cs
+++ b/src/Raven.Server/Documents/Handlers/QueriesHandler.cs
@@ -29,7 +29,7 @@ namespace Raven.Server.Documents.Handlers
         public async Task Post()
         {
             using (var tracker = new RequestTimeTracker(HttpContext, Logger, Database, "Query"))
-            using (var token = CreateTimeLimitedQueryOperationToken())
+            using (var token = CreateTimeLimitedQueryToken())
             using (Database.DocumentsStorage.ContextPool.AllocateOperationContext(out DocumentsOperationContext context))
             {
                 var debug = GetStringQueryString("debug", required: false);
@@ -47,7 +47,7 @@ namespace Raven.Server.Documents.Handlers
         public async Task Get()
         {
             using (var tracker = new RequestTimeTracker(HttpContext, Logger, Database, "Query"))
-            using (var token = CreateTimeLimitedQueryOperationToken())
+            using (var token = CreateTimeLimitedQueryToken())
             using (Database.DocumentsStorage.ContextPool.AllocateOperationContext(out DocumentsOperationContext context))
             {
                 var debug = GetStringQueryString("debug", required: false);

--- a/src/Raven.Server/Documents/Handlers/StreamingHandler.cs
+++ b/src/Raven.Server/Documents/Handlers/StreamingHandler.cs
@@ -67,7 +67,7 @@ namespace Raven.Server.Documents.Handlers
         {
             // ReSharper disable once ArgumentsStyleLiteral
             using (var tracker = new RequestTimeTracker(HttpContext, Logger, Database, "StreamQuery", doPerformanceHintIfTooLong: false))
-            using (var token = CreateTimeLimitedQueryOperationToken())
+            using (var token = CreateTimeLimitedQueryToken())
             using (Database.DocumentsStorage.ContextPool.AllocateOperationContext(out DocumentsOperationContext context))
             {
                 var query = IndexQueryServerSide.Create(HttpContext, GetStart(), GetPageSize(), context);
@@ -95,7 +95,7 @@ namespace Raven.Server.Documents.Handlers
         {
             // ReSharper disable once ArgumentsStyleLiteral
             using (var tracker = new RequestTimeTracker(HttpContext, Logger, Database, "StreamQuery", doPerformanceHintIfTooLong: false))
-            using (var token = CreateTimeLimitedQueryOperationToken())
+            using (var token = CreateTimeLimitedQueryToken())
             using (Database.DocumentsStorage.ContextPool.AllocateOperationContext(out DocumentsOperationContext context))
             {
                 var stream = TryGetRequestFromStream("ExportOptions") ?? RequestBodyStream(); 

--- a/src/Raven.Server/Web/Studio/StudioCollectionsHandler.cs
+++ b/src/Raven.Server/Web/Studio/StudioCollectionsHandler.cs
@@ -316,7 +316,7 @@ namespace Raven.Server.Web.Studio
         {
             var collectionName = GetStringQueryString("name");
 
-            var token = CreateTimeLimitedDeleteDocsOperationToken();
+            var token = CreateTimeLimitedCollectionOperationToken();
 
             var collectionRunner = new StudioCollectionRunner(Database, context, excludeIds);
 


### PR DESCRIPTION
* QueryTimeout: canceling query
* QueryOperationTimeout: canceling patch/delete Query
* CollectionOperationTimeout: the studio delete docs timeout
* OperationTimeout: general cancelation with timeout (currently only "indexing terms")