### PR TITLE
RavenDB-9904 

### DIFF
--- a/test/FastTests/Issues/RavenDB_9519.cs
+++ b/test/FastTests/Issues/RavenDB_9519.cs
@@ -6,7 +6,6 @@ using System.Threading.Tasks;
 using Raven.Client.Documents.Commands;
 using Raven.Client.Documents.Operations;
 using Raven.Client.Http;
-using Raven.Server.Utils;
 using Sparrow.Json;
 using Xunit;
 
@@ -49,7 +48,7 @@ namespace FastTests.Issues
                 {
                     var res = session.Query<Company>().ToList();
                     Assert.Equal(2, res.Count);
-                    Assert.Equal(res[0],res[1]);
+                    Assert.Equal(res[0], res[1]);
                 }
             }
         }
@@ -103,6 +102,11 @@ namespace FastTests.Issues
                        && Address?.Line1 == other.Address?.Line1 && Address?.Line2 == other.Address?.Line2 && Address?.PostalCode == other.Address?.PostalCode
                        && Address?.Region == other.Address?.Region && Address?.Location?.Latitude == other.Address?.Location?.Latitude
                        && Address?.Location?.Longitude == other.Address?.Location?.Longitude && Phone == other.Phone && Fax == other.Fax;
+            }
+
+            public override int GetHashCode()
+            {
+                return 1;
             }
         }
 

--- a/test/Tests.Infrastructure/TestBase.cs
+++ b/test/Tests.Infrastructure/TestBase.cs
@@ -90,8 +90,11 @@ namespace FastTests
                 using (var sr = new StreamReader(file))
                 {
                     var json = JObject.Parse(sr.ReadToEnd());
-                    if (json.TryGetValue("maxParallelThreads", out JToken token))
-                        maxNumberOfConcurrentTests = token.Value<int>();
+
+                    if (json.TryGetValue("maxRunningTests", out var testsToken))
+                        maxNumberOfConcurrentTests = testsToken.Value<int>();
+                    else if (json.TryGetValue("maxParallelThreads", out var threadsToken))
+                        maxNumberOfConcurrentTests = threadsToken.Value<int>();
                 }
             }
 

--- a/test/xunit.runner.CI.json
+++ b/test/xunit.runner.CI.json
@@ -1,5 +1,6 @@
 {
-	"diagnosticMessages": true,
-	"parallelizeTestCollections": false,
-	"maxParallelThreads": 1
+    "diagnosticMessages": true,
+    "parallelizeTestCollections": false,
+    "maxParallelThreads": 2,
+    "maxRunningTests": 1
 }

--- a/test/xunit.runner.json
+++ b/test/xunit.runner.json
@@ -1,5 +1,6 @@
 {
-	"diagnosticMessages": false,
-	"parallelizeTestCollections": true,
-	"maxParallelThreads": 2
+    "diagnosticMessages": false,
+    "parallelizeTestCollections": true,
+    "maxParallelThreads": 2,
+    "maxRunningTests": 2
 }


### PR DESCRIPTION
introduced 'maxRunningTests' to xunit.runner.json to allow xunit to schedule more processing threads with the ability to limit max number of running tests