### PR TITLE
RavenDB-9917 Object name: 'blittable object has been disposed'

### DIFF
--- a/src/Raven.Server/Documents/TransactionOperationsMerger.cs
+++ b/src/Raven.Server/Documents/TransactionOperationsMerger.cs
@@ -379,10 +379,9 @@ namespace Raven.Server.Documents
                                 {
                                     throw;
                                 }
-                                NotifyTransactionFailureAndRerunIndependently(currentPendingOps, e);
-                                return;
                             }
-                          
+                            NotifyTransactionFailureAndRerunIndependently(currentPendingOps, e);
+                            return;
                         }
                         previous.Dispose();
 


### PR DESCRIPTION
Dispose the failed merged transaction before trying to run them again independently.