### PR TITLE
RavenDB-9951

### DIFF
--- a/src/Raven.Client/ServerWide/DatabaseTopology.cs
+++ b/src/Raven.Client/ServerWide/DatabaseTopology.cs
@@ -93,8 +93,12 @@ namespace Raven.Client.ServerWide
 
         public override bool IsEqualTo(ReplicationNode other)
         {
-            return base.IsEqualTo(other) && 
-                   string.Equals(Url, other.Url, StringComparison.OrdinalIgnoreCase);
+            if (other is InternalReplication internalNode)
+            {
+                return base.IsEqualTo(internalNode) &&
+                       string.Equals(Url, internalNode.Url, StringComparison.OrdinalIgnoreCase);
+            }
+            return false;
         }
         
         public override int GetHashCode()

--- a/src/Raven.Client/ServerWide/ExternalReplication.cs
+++ b/src/Raven.Client/ServerWide/ExternalReplication.cs
@@ -78,10 +78,12 @@ namespace Raven.Client.ServerWide
 
         public override bool IsEqualTo(ReplicationNode other)
         {
-            var externalReplication = (ExternalReplication)other;
-            
-            return string.Equals(ConnectionStringName, externalReplication.ConnectionStringName, StringComparison.OrdinalIgnoreCase) &&
-                   TaskId == externalReplication.TaskId; 
+            if (other is ExternalReplication externalReplication)
+            {
+                return string.Equals(ConnectionStringName, externalReplication.ConnectionStringName, StringComparison.OrdinalIgnoreCase) &&
+                       TaskId == externalReplication.TaskId;
+            }
+            return false;
         }
 
         public string GetMentorNode()

--- a/src/Raven.Server/Documents/Handlers/Debugging/NodeDebugHandler.cs
+++ b/src/Raven.Server/Documents/Handlers/Debugging/NodeDebugHandler.cs
@@ -20,10 +20,11 @@ namespace Raven.Server.Documents.Handlers.Debugging
                 context.Write(write,
                     new DynamicJsonValue
                     {
-                        ["Remote-Connections"] = new DynamicJsonArray(RemoteConnection.RemoteConnectionsList.ToList()
+                        ["Remote-Connections"] = new DynamicJsonArray(RemoteConnection.RemoteConnectionsList
                             .Select(connection => new DynamicJsonValue
                             {
                                 [nameof(RemoteConnection.RemoteConnectionInfo.Caller)] = connection.Caller,
+                                [nameof(RemoteConnection.RemoteConnectionInfo.Term)] = connection.Term,
                                 [nameof(RemoteConnection.RemoteConnectionInfo.Destination)] = connection.Destination,
                                 [nameof(RemoteConnection.RemoteConnectionInfo.StartAt)] = connection.StartAt,
                                 ["Duration"] = DateTime.UtcNow - connection.StartAt,

--- a/src/Raven.Server/Rachis/AppendEntries.cs
+++ b/src/Raven.Server/Rachis/AppendEntries.cs
@@ -12,6 +12,7 @@ namespace Raven.Server.Rachis
         public int EntriesCount { get; set; }
         public bool ForceElections { get; set; }
         public long TimeAsLeader { get; set; }
+        public int SendingThread { get; set; }
     }
 
     public class RachisEntry

--- a/src/Raven.Server/Rachis/CandidateAmbassador.cs
+++ b/src/Raven.Server/Rachis/CandidateAmbassador.cs
@@ -166,7 +166,6 @@ namespace Raven.Server.Rachis
                                     if (_engine.Log.IsInfoEnabled)
                                         _engine.Log.Info($"Candidate RequestVote trial vote req/res took {sp.ElapsedMilliseconds:#,#;;0} ms");
 
-                                    // TODO: What if the elector on the other side casted his vote for some else, but that node _lost_ the elections ??? We can't simply became a follower.
                                     if (rvr.Term > currentElectionTerm)
                                     {
                                         var message = $"Candidate ambassador for {_tag}: found election term {rvr.Term} that is higher than ours {currentElectionTerm}";

--- a/src/Raven.Server/Rachis/CandidateAmbassador.cs
+++ b/src/Raven.Server/Rachis/CandidateAmbassador.cs
@@ -51,30 +51,36 @@ namespace Raven.Server.Rachis
         public void Dispose()
         {
             _running.Lower();
+            DisposeConnectionIfNeeded();
+            if (_thread != null && _thread.ManagedThreadId != Thread.CurrentThread.ManagedThreadId)
+            {
+                while (_thread.Join(TimeSpan.FromSeconds(1)) == false)
+                {
+                    // the thread may have create a new connection, so need
+                    // to dispose that as well
+                    if (_engine.Log.IsInfoEnabled)
+                    {
+                        _engine.Log.Info(
+                            $"CandidateAmbassador for {_tag}: Waited for a full second for thread {_thread.ManagedThreadId} ({_thread.ThreadState}) to finish, after the elections were {_candidate.ElectionResult}");
+                    }
+                    DisposeConnectionIfNeeded();
+                }
+            }
+
+            if (_engine.Log.IsInfoEnabled)
+            {
+                _engine.Log.Info($"Dispose CandidateAmbassador for {_tag} after the elections were {_candidate.ElectionResult}");
+            }
+        }
+
+        private void DisposeConnectionIfNeeded()
+        {
             if (_candidate.ElectionResult != ElectionResult.Won)
             {
                 Volatile.Read(ref Connection)?.Dispose();
-
-                if (_thread != null && _thread.ManagedThreadId != Thread.CurrentThread.ManagedThreadId)
-                {
-                    while (_thread.Join(TimeSpan.FromSeconds(1)) == false)
-                    {
-                        // the thread may have create a new connection, so need
-                        // to dispose that as well
-                        if (_engine.Log.IsInfoEnabled)
-                        {
-                            _engine.Log.Info($"CandidateAmbassador {_engine.Tag}: Waited for a full second for thread {_thread.ManagedThreadId} ({_thread.ThreadState}) to close, disposing connection and trying");
-                        }
-                        Volatile.Read(ref Connection)?.Dispose();
-                    }
-                }
-            }
-            if (_engine.Log.IsInfoEnabled)
-            {
-                _engine.Log.Info($"CandidateAmbassador {_tag}: Dispose after the elections were {_candidate.ElectionResult}");
             }
         }
-        
+
         /// <summary>
         /// This method may run for a long while, as we are trying to get agreement 
         /// from a majority of the cluster
@@ -85,6 +91,7 @@ namespace Raven.Server.Rachis
             {
                 while (_candidate.Running && _running)
                 {
+                    long currentElectionTerm = -1;
                     try
                     {
                         Stream stream;
@@ -104,7 +111,7 @@ namespace Raven.Server.Rachis
                             StatusMessage = $"Failed to connect with {_tag}.{Environment.NewLine} " + e.Message;
                             if (_engine.Log.IsInfoEnabled)
                             {
-                                _engine.Log.Info($"CandidateAmbassador {_engine.Tag}: Failed to connect to remote peer: " + _url, e);
+                                _engine.Log.Info($"CandidateAmbassador for {_tag}: Failed to connect to remote peer: " + _url, e);
                             }
                             // wait a bit
                             _candidate.WaitForChangeInState();
@@ -114,7 +121,7 @@ namespace Raven.Server.Rachis
                         StatusMessage = $"Connected to {_tag}";
 
                         Stopwatch sp;
-                        var connection = new RemoteConnection(_tag, _engine.Tag, stream);
+                        var connection = new RemoteConnection(_tag, _engine.Tag, _engine.CurrentTerm, stream);
                         Interlocked.Exchange(ref Connection, connection);//publish the new connection
                         using (_engine.ContextPool.AllocateOperationContext(out TransactionOperationContext context))
                         {
@@ -139,8 +146,7 @@ namespace Raven.Server.Rachis
                             while (_candidate.Running)
                             {
                                 RequestVoteResponse rvr;
-                                var currentElectionTerm = _candidate.ElectionTerm;
-                                var engineCurrentTerm = _engine.CurrentTerm;
+                                currentElectionTerm = _candidate.ElectionTerm;
                                 if (_candidate.IsForcedElection == false ||
                                     _candidate.RunRealElectionAtTerm != currentElectionTerm)
                                 {
@@ -160,14 +166,15 @@ namespace Raven.Server.Rachis
                                     if (_engine.Log.IsInfoEnabled)
                                         _engine.Log.Info($"Candidate RequestVote trial vote req/res took {sp.ElapsedMilliseconds:#,#;;0} ms");
 
+                                    // TODO: What if the elector on the other side casted his vote for some else, but that node _lost_ the elections ??? We can't simply became a follower.
                                     if (rvr.Term > currentElectionTerm)
                                     {
-                                        var message = $"Candidate ambassador {_engine.Tag}: found election term {rvr.Term} that is higher than ours {currentElectionTerm}";
+                                        var message = $"Candidate ambassador for {_tag}: found election term {rvr.Term} that is higher than ours {currentElectionTerm}";
                                         // we need to abort the current elections
-                                        _engine.SetNewState(RachisState.Follower, null, engineCurrentTerm, message);
+                                        _engine.SetNewState(RachisState.Follower, null, _engine.CurrentTerm, message);
                                         if (_engine.Log.IsInfoEnabled)
                                         {
-                                            _engine.Log.Info($"CandidateAmbassador {_engine.Tag}: {message}");
+                                            _engine.Log.Info($"CandidateAmbassador for {_tag}: {message}");
                                         }
                                         _engine.FoundAboutHigherTerm(rvr.Term, "Higher term found from node " + Tag);
                                         throw new InvalidOperationException(message);
@@ -177,7 +184,7 @@ namespace Raven.Server.Rachis
                                     {
                                         if (_engine.Log.IsInfoEnabled)
                                         {
-                                            _engine.Log.Info($"CandidateAmbassador {_engine.Tag}: Got a negative response from {_tag}  in {rvr.Term} reason: {rvr.Message}");
+                                            _engine.Log.Info($"CandidateAmbassador for {_tag}: Got a negative response from {_tag} in {rvr.Term} reason: {rvr.Message}");
                                         }
                                         // we go a negative response here, so we can't proceed
                                         // we'll need to wait until the candidate has done something, like
@@ -185,8 +192,11 @@ namespace Raven.Server.Rachis
                                         _candidate.WaitForChangeInState();
                                         continue;
                                     }
+                                    if (_engine.Log.IsInfoEnabled)
+                                    {
+                                        _engine.Log.Info($"CandidateAmbassador for {_tag}: Got a positive response for trial elections from {_tag} in {rvr.Term}: {rvr.Message}");
+                                    }
                                     TrialElectionWonAtTerm = rvr.Term;
-
                                     _candidate.WaitForChangeInState();
                                 }
                                 sp = Stopwatch.StartNew();
@@ -206,13 +216,13 @@ namespace Raven.Server.Rachis
 
                                 if (rvr.Term > currentElectionTerm)
                                 {
-                                    var message = $"Candidate ambassador {_engine.Tag}: found election term {rvr.Term} that is higher than ours {currentElectionTerm}";
+                                    var message = $"CandidateAmbassador for {_tag}: found election term {rvr.Term} that is higher than ours {currentElectionTerm}";
                                     if (_engine.Log.IsInfoEnabled)
                                     {
-                                        _engine.Log.Info($"CandidateAmbassador {_engine.Tag}: {message}");
+                                        _engine.Log.Info($"CandidateAmbassador for {_tag}: {message}");
                                     }
                                     // we need to abort the current elections
-                                    _engine.SetNewState(RachisState.Follower, null, engineCurrentTerm, message);
+                                    _engine.SetNewState(RachisState.Follower, null, _engine.CurrentTerm, message);
                                     _engine.FoundAboutHigherTerm(rvr.Term, "Got higher term from node: " + Tag);
                                     throw new InvalidOperationException(message);
                                 }
@@ -221,7 +231,7 @@ namespace Raven.Server.Rachis
                                 {
                                     if (_engine.Log.IsInfoEnabled)
                                     {
-                                        _engine.Log.Info($"CandidateAmbassador {_engine.Tag}: Got a negative response from {_tag} in {rvr.Term} reason: {rvr.Message}");
+                                        _engine.Log.Info($"CandidateAmbassador for {_tag}: Got a negative response from {_tag} in {rvr.Term} reason: {rvr.Message}");
                                     }
                                     // we go a negative response here, so we can't proceed
                                     // we'll need to wait until the candidate has done something, like
@@ -231,26 +241,26 @@ namespace Raven.Server.Rachis
                                 }
                                 if (_engine.Log.IsInfoEnabled)
                                 {
-                                    _engine.Log.Info($"CandidateAmbassador {_engine.Tag}: Got a positive response from {_tag} in {rvr.Term}: {rvr.Message}");
+                                    _engine.Log.Info($"CandidateAmbassador for {_tag}: Got a positive response from {_tag} in {rvr.Term}: {rvr.Message}");
                                 }
                                 RealElectionWonAtTerm = rvr.Term;
                                 _candidate.WaitForChangeInState();
                             }
-                            SendElectionResult();
+                            SendElectionResult(currentElectionTerm);
                         }
                     }
                     catch (OperationCanceledException)
                     {
                         Status = AmbassadorStatus.Closed;
                         StatusMessage = "Closed";
-                        SendElectionResult();
+                        SendElectionResult(currentElectionTerm);
                         break;
                     }
                     catch (ObjectDisposedException)
                     {
                         Status = AmbassadorStatus.Closed;
                         StatusMessage = "Closed";
-                        SendElectionResult();
+                        SendElectionResult(currentElectionTerm);
                         break;
                     }
                     catch (AggregateException ae)
@@ -258,7 +268,7 @@ namespace Raven.Server.Rachis
                     {
                         Status = AmbassadorStatus.Closed;
                         StatusMessage = "Closed";
-                        SendElectionResult();
+                        SendElectionResult(currentElectionTerm);
                         break;
                     }
                     catch (Exception e)
@@ -267,12 +277,11 @@ namespace Raven.Server.Rachis
                         StatusMessage = $"Failed to get vote from {_tag}.{Environment.NewLine}" + e.Message;
                         if (_engine.Log.IsInfoEnabled)
                         {
-                            _engine.Log.Info($"CandidateAmbassador {_engine.Tag}: Failed to get vote from remote peer url={_url} tag={_tag}", e);
+                            _engine.Log.Info($"CandidateAmbassador for {_tag}: Failed to get vote from remote peer url={_url} tag={_tag}", e);
                         }
                         Connection?.Dispose();
                         _candidate.WaitForChangeInState();
                     }
-
                 }
             }
             catch (Exception e)
@@ -293,18 +302,18 @@ namespace Raven.Server.Rachis
             }
         }
 
-        private void SendElectionResult()
+        private void SendElectionResult(long currentElectionTerm)
         {
             using (_engine.ContextPool.AllocateOperationContext(out TransactionOperationContext context))
             {
                 if (_engine.Log.IsInfoEnabled)
                 {
-                    _engine.Log.Info($"CandidateAmbassador {_engine.Tag}: Send election result message to {_tag} : {_candidate.ElectionResult}");
+                    _engine.Log.Info($"CandidateAmbassador for {_tag}: Send election result '{_candidate.ElectionResult}' at term {RealElectionWonAtTerm}");
                 }
                 Connection.Send(context, new RequestVote
                 {
                     Source = _engine.Tag,
-                    Term = _engine.CurrentTerm,
+                    Term = currentElectionTerm,
                     ElectionResult = _candidate.ElectionResult
                 });
             }

--- a/src/Raven.Server/Rachis/Negotiation.cs
+++ b/src/Raven.Server/Rachis/Negotiation.cs
@@ -6,6 +6,7 @@
         public long PrevLogTerm { get; set; }
         public long Term { get; set; }
         public bool Truncated { get; set; }
+        public int SendingThread { get; set; }
     }
 
     public class LogLengthNegotiationResponse

--- a/src/Raven.Server/Rachis/RachisHello.cs
+++ b/src/Raven.Server/Rachis/RachisHello.cs
@@ -22,5 +22,7 @@
         /// </summary>
         public InitialMessageType InitialMessageType;
 
+        public int SendingThread;
+
     }
 }

--- a/src/Raven.Server/Rachis/RemoteConnection.cs
+++ b/src/Raven.Server/Rachis/RemoteConnection.cs
@@ -408,13 +408,8 @@ namespace Raven.Server.Rachis
                 _src = rachisHello.DebugSourceIdentifier ?? "unknown";
                 _destTag = rachisHello.DebugDestinationIdentifier ?? _destTag;
                 _log = LoggingSource.Instance.GetLogger<RemoteConnection>($"{_src} > {_destTag}");
+                _info.Destination = _destTag;
 
-                if (RemoteConnectionsList.TryRemove(_info))
-                {
-                    _info.Destination = _destTag;
-                    RemoteConnectionsList.Add(_info);
-                }
-                
                 return rachisHello;
             }
         }

--- a/src/Raven.Server/Rachis/RequestVote.cs
+++ b/src/Raven.Server/Rachis/RequestVote.cs
@@ -9,7 +9,7 @@
 
     public class RequestVote
     {
-    
+        public int SendingThread { get; set; }
         public long Term { get; set; }
         public long LastLogIndex { get; set; }
         public long LastLogTerm { get; set; }

--- a/src/Raven.Server/ServerWide/ServerStore.cs
+++ b/src/Raven.Server/ServerWide/ServerStore.cs
@@ -480,7 +480,7 @@ namespace Raven.Server.ServerWide
                     }, null);
                 }
 
-                if (state.To == RachisState.LeaderElect)
+                if (state.To == RachisState.LeaderElect  || state.To == RachisState.Leader)
                 {
                     _engine.CurrentLeader.OnNodeStatusChange += OnTopologyChanged;
                 } else if (state.From == RachisState.LeaderElect || state.From == RachisState.Leader)

--- a/test/RachisTests/DatabaseCluster/ReplicationTests.cs
+++ b/test/RachisTests/DatabaseCluster/ReplicationTests.cs
@@ -25,7 +25,6 @@ namespace RachisTests.DatabaseCluster
 {
     public class ReplicationTests : ReplicationTestBase
     {
-
         [NightlyBuildFact]
         public async Task WaitForCommandToApply()
         {
@@ -220,7 +219,7 @@ namespace RachisTests.DatabaseCluster
             Assert.Equal(5, count);
         }
                 
-        [Fact]        
+        [NightlyBuildFact]        
         public async Task WaitForReplicaitonShouldWaitOnlyForInternalNodes()
         {
             var clusterSize = 5;

--- a/test/RachisTests/SubscriptionsFailover.cs
+++ b/test/RachisTests/SubscriptionsFailover.cs
@@ -198,7 +198,7 @@ namespace RachisTests
             }
         }
 
-        [Fact]
+        [NightlyBuildFact]
         public async Task SetMentorToSubscriptionWithFailover()
         {
             const int nodesAmount = 5;


### PR DESCRIPTION
The underlaying issue was that on state change we refresh all of our on-going-tasks by calling an async method, which in some cases executed in _sync_ manner (when there is no need to wait for a task to complete).

- Dispose replication connection in parallel and async manner
- In many places keep a copy of the current term, since it could be overwriten from different thread.
- more and better logs