### PR TITLE
RavenDB-10033 Better logging for the Rachis

### DIFF
--- a/src/Raven.Client/Documents/TcpUtils.cs
+++ b/src/Raven.Client/Documents/TcpUtils.cs
@@ -134,6 +134,9 @@ namespace Raven.Client.Documents
             {
                 tcpClient = new TcpClient();
             }
+            
+            tcpClient.NoDelay = true;            
+            tcpClient.LingerState = new LingerOption(true, 0);
 
             if (timeout.HasValue)
                 SetTimeouts(tcpClient, timeout.Value);

--- a/src/Raven.Client/ServerWide/Tcp/TcpConnectionHeader.cs
+++ b/src/Raven.Client/ServerWide/Tcp/TcpConnectionHeader.cs
@@ -11,7 +11,8 @@ namespace Raven.Client.ServerWide.Tcp
             Subscription,
             Replication,
             Cluster,
-            Heartbeats
+            Heartbeats,
+            Ping
         }
 
         public string DatabaseName { get; set; }
@@ -34,6 +35,7 @@ namespace Raven.Client.ServerWide.Tcp
         {
             switch (operationType)
             {
+                case OperationTypes.Ping:
                 case OperationTypes.None:
                     return -1;
                 case OperationTypes.Drop:

--- a/src/Raven.Server/Documents/Handlers/Admin/RachisAdminHandler.cs
+++ b/src/Raven.Server/Documents/Handlers/Admin/RachisAdminHandler.cs
@@ -219,6 +219,7 @@ namespace Raven.Server.Documents.Handlers.Admin
                     {
                         ["Topology"] = topology.ToSortedJson(),
                         ["Leader"] = ServerStore.LeaderTag,
+                        ["LeaderShipDuration"] = ServerStore.Engine.CurrentLeader?.LeaderShipDuration,
                         ["CurrentState"] = ServerStore.CurrentRachisState,
                         ["NodeTag"] = nodeTag,
                         ["CurrentTerm"] = ServerStore.Engine.CurrentTerm,

--- a/src/Raven.Server/Documents/Handlers/Debugging/NodeDebugHandler.cs
+++ b/src/Raven.Server/Documents/Handlers/Debugging/NodeDebugHandler.cs
@@ -1,8 +1,15 @@
 ﻿using System;
+using System.Collections.Generic;
+using System.Diagnostics;
 using System.Linq;
+using System.Text;
 using System.Threading.Tasks;
+using Raven.Client.Documents;
+using Raven.Client.ServerWide.Tcp;
+using Raven.Server.Json;
 using Raven.Server.Rachis;
 using Raven.Server.Routing;
+using Raven.Server.Utils;
 using Raven.Server.Web;
 using Sparrow.Json;
 using Sparrow.Json.Parsing;
@@ -34,6 +41,99 @@ namespace Raven.Server.Documents.Handlers.Debugging
                 write.Flush();
             }
             return Task.CompletedTask;
+        }
+
+        [RavenAction("/admin/debug/node/engine-logs", "GET", AuthorizationStatus.Operator, IsDebugInformationEndpoint = true)]
+        public Task ListRecentEngineLogs()
+        {
+            using (ServerStore.ContextPool.AllocateOperationContext(out JsonOperationContext context))
+            using (var write = new BlittableJsonTextWriter(context, ResponseBodyStream()))
+            {
+                context.Write(write,ServerStore.Engine.InMemoryDebug.ToJson());
+                write.Flush();
+            }
+            return Task.CompletedTask;
+        }
+        
+        [RavenAction("/admin/debug/node/ping", "GET", AuthorizationStatus.Operator, IsDebugInformationEndpoint = true)]
+        public async Task PingTest()
+        {
+            var dest = GetStringQueryString("url", false) ?? GetStringQueryString("node", false);
+            var topology = ServerStore.GetClusterTopology();
+            var tasks = new List<Task<(string url, string res)>>();
+            if (string.IsNullOrEmpty(dest))
+            {
+                foreach (var node in topology.AllNodes)
+                {
+                    tasks.Add(PingOnce(node.Value));
+                }
+            }
+            else
+            {
+                var url = topology.GetUrlFromTag(dest);
+                tasks.Add(PingOnce(url ?? dest));
+            }
+            
+            using (ServerStore.ContextPool.AllocateOperationContext(out JsonOperationContext context))
+            using (var write = new BlittableJsonTextWriter(context, ResponseBodyStream()))
+            {
+                write.WriteStartObject();
+                while (tasks.Count > 0)
+                {
+                    var task = await Task.WhenAny(tasks);
+                    tasks.Remove(task);
+                    var res = task.Result;
+                    write.WritePropertyName(res.url);
+                    write.WriteString(res.res);
+                    if (tasks.Count > 0)
+                    {
+                        write.WriteComma();
+                    }
+                    write.Flush();
+                }
+                write.WriteEndObject();
+                write.Flush();
+            }
+        }
+
+        private async Task<(string url, string res)> PingOnce(string url)
+        {
+            var sp = Stopwatch.StartNew();
+            try
+            {
+                var sb = new StringBuilder();
+                var info = await ReplicationUtils.GetTcpInfoAsync(url, null, "PingTest", ServerStore.Engine.ClusterCertificate);
+                sb.Append(sp.ElapsedMilliseconds); // Received tcp info
+                using (var tcpClient = await TcpUtils.ConnectAsync(info.Url, ServerStore.Engine.TcpConnectionTimeout).ConfigureAwait(false))
+                using (var stream = await TcpUtils
+                    .WrapStreamWithSslAsync(tcpClient, info, ServerStore.Engine.ClusterCertificate, ServerStore.Engine.TcpConnectionTimeout).ConfigureAwait(false))
+                using (ServerStore.ContextPool.AllocateOperationContext(out JsonOperationContext context))
+                {
+                    var msg = new DynamicJsonValue
+                    {
+                        [nameof(TcpConnectionHeaderMessage.DatabaseName)] = null,
+                        [nameof(TcpConnectionHeaderMessage.Operation)] = TcpConnectionHeaderMessage.OperationTypes.Ping,
+                        [nameof(TcpConnectionHeaderMessage.OperationVersion)] = -1
+                    };
+
+                    using (var writer = new BlittableJsonTextWriter(context, stream))
+                    using (var msgJson = context.ReadObject(msg, "message"))
+                    {
+                        sb.Append(", ").Append(sp.ElapsedMilliseconds); // Send ping
+                        context.Write(writer, msgJson);
+                    }
+                    using (var response = context.ReadForMemory(stream, "cluster-ConnectToPeer-header-response"))
+                    {
+                        var reply = JsonDeserializationServer.TcpConnectionHeaderResponse(response);
+                        sb.Append(", ").Append(sp.ElapsedMilliseconds); // got pong
+                    }
+                }
+                return (url, sb.ToString());
+            }
+            catch (Exception e)
+            {
+                return (url, e.ToString());
+            }
         }
     }
 }

--- a/src/Raven.Server/NotificationCenter/Notifications/Server/ClusterTopologyChanged.cs
+++ b/src/Raven.Server/NotificationCenter/Notifications/Server/ClusterTopologyChanged.cs
@@ -46,6 +46,8 @@ namespace Raven.Server.NotificationCenter.Notifications.Server
         {
             return new ClusterTopologyChanged
             {
+                Severity = NotificationSeverity.Info,
+                Title = "Cluster topology was changed",
                 Topology = clusterTopology,
                 Leader = leaderTag,
                 NodeTag = nodeTag,

--- a/src/Raven.Server/Rachis/Elector.cs
+++ b/src/Raven.Server/Rachis/Elector.cs
@@ -92,8 +92,11 @@ namespace Raven.Server.Rachis
                         if (rv.Term == _engine.CurrentTerm && rv.ElectionResult == ElectionResult.Won)
                         {
                             _electionWon = true;
-                            var follower = new Follower(_engine, _connection);
-                            follower.TryAcceptConnection();
+                            if (Follower.CheckIfValidLeader(_engine, _connection,out var negotiation))
+                            {
+                                var follower = new Follower(_engine, _connection);
+                                follower.AcceptConnection(negotiation);
+                            }
                             return;
                         }
 

--- a/src/Raven.Server/Rachis/FollowerAmbassador.cs
+++ b/src/Raven.Server/Rachis/FollowerAmbassador.cs
@@ -50,7 +50,6 @@ namespace Raven.Server.Rachis
                 if (_statusMessage == value)
                     return;
                 _statusMessage = value;
-                _leader?.NotifyAboutNodeStatusChange();
             }
         }
         public AmbassadorStatus Status;
@@ -243,7 +242,7 @@ namespace Raven.Server.Rachis
 #endif
                                     );
                                 }
-                                _debugRecorder.Record($"Start sending {entries.Count} entries");
+                                _debugRecorder.Record("Sending entries");
                                 _connection.Send(context, appendEntries, entries);
                                 _debugRecorder.Record("Waiting for response");
                                 var aer = _connection.Read<AppendEntriesResponse>(context);

--- a/src/Raven.Server/Rachis/Leader.cs
+++ b/src/Raven.Server/Rachis/Leader.cs
@@ -663,30 +663,6 @@ namespace Raven.Server.Rachis
             ErrorsList.Reduce(25);
         }
 
-        public void NotifyAboutNodeStatusChange()
-        {
-            ClusterTopology clusterTopology;
-            try
-            {
-                using (_engine.ContextPool.AllocateOperationContext(out TransactionOperationContext context))
-                using (context.OpenReadTransaction())
-                {
-                    clusterTopology = _engine.GetTopology(context);
-                }
-            }
-            catch (OperationCanceledException)
-            {
-                return;
-            }
-            catch (ObjectDisposedException)
-            {
-                return;
-            }
-            OnNodeStatusChange?.Invoke(this, clusterTopology);
-        }
-
-        public event EventHandler<ClusterTopology> OnNodeStatusChange;
-
         public void Dispose()
         {
             bool lockTaken = false;
@@ -853,7 +829,7 @@ namespace Raven.Server.Rachis
 
                 var topologyJson = _engine.SetTopology(context, clusterTopology);
                 var index = _engine.InsertToLeaderLog(context, topologyJson, RachisEntryFlags.Topology);
-
+ 
                 if (modification == TopologyModification.Remove)
                 {
                     _engine.GetStateMachine().EnsureNodeRemovalOnDeletion(context,nodeTag);

--- a/src/Raven.Server/Rachis/RemoteConnection.cs
+++ b/src/Raven.Server/Rachis/RemoteConnection.cs
@@ -177,8 +177,11 @@ namespace Raven.Server.Rachis
         {
             if (_log.IsInfoEnabled)
             {
-                _log.Info(
-                    $"AppendEntries ({ae.EntriesCount}) in {ae.Term}, commit: {ae.LeaderCommit}, leader for: {ae.TimeAsLeader}, ({ae.PrevLogIndex} / {ae.PrevLogTerm}), truncate: {ae.TruncateLogBefore}, force elections: {ae.ForceElections}.");
+                if (ae.EntriesCount > 0)
+                {
+                    _log.Info(
+                        $"AppendEntries ({ae.EntriesCount}) in {ae.Term}, commit: {ae.LeaderCommit}, leader for: {ae.TimeAsLeader}, ({ae.PrevLogIndex} / {ae.PrevLogTerm}), truncate: {ae.TruncateLogBefore}, force elections: {ae.ForceElections}.");
+                }
             }
 
             var msg = new DynamicJsonValue
@@ -375,7 +378,10 @@ namespace Raven.Server.Rachis
         {
             if (_log.IsInfoEnabled)
             {
-                _log.Info($"Replying with success {aer.Success}: {aer.Message ?? "(empty)"}");
+                if (aer.Message != null)
+                {
+                    _log.Info($"Replying with success {aer.Success}: {aer.Message }");
+                }
             }
             var msg = new DynamicJsonValue
             {

--- a/src/Raven.Server/RavenServer.cs
+++ b/src/Raven.Server/RavenServer.cs
@@ -1013,6 +1013,11 @@ namespace Raven.Server
                 return true;
             }
 
+            if (tcp.Operation == TcpConnectionHeaderMessage.OperationTypes.Ping)
+            {
+                return true;
+            }
+            
             if (tcp.Operation == TcpConnectionHeaderMessage.OperationTypes.Heartbeats)
             {
                 // check for the term          


### PR DESCRIPTION
WIP

- Currently only the follower and the follower candidate are recorded.
- And Tcp Ping endpoint.
- Set linger of the tcp client to zero, so it will close the socket immediatly on dispose without trying to send what it still have.