### PR TITLE
RavenDB-10060

### DIFF
--- a/src/Raven.Server/Documents/Indexes/Errors/FaultyAutoIndexDefinition.cs
+++ b/src/Raven.Server/Documents/Indexes/Errors/FaultyAutoIndexDefinition.cs
@@ -1,34 +1,35 @@
 using System;
 using System.Collections.Generic;
 using Raven.Client.Documents.Indexes;
+using Raven.Server.Documents.Indexes.Auto;
 using Sparrow.Json;
 
 namespace Raven.Server.Documents.Indexes.Errors
 {
-    public class FaultyIndexDefinition : IndexDefinitionBase<IndexField>
+    public class FaultyAutoIndexDefinition : IndexDefinitionBase<IndexField>
     {
-        private readonly IndexDefinition _definition;
+        public readonly AutoIndexDefinitionBase Definition;
 
-        public FaultyIndexDefinition(string name, HashSet<string> collections, IndexLockMode lockMode, IndexPriority priority,
-            IndexField[] mapFields, IndexDefinition definition)
+        public FaultyAutoIndexDefinition(string name, HashSet<string> collections, IndexLockMode lockMode, IndexPriority priority,
+            IndexField[] mapFields, AutoIndexDefinitionBase definition)
             : base(name, collections, lockMode, priority, mapFields)
         {
-            _definition = definition;
+            Definition = definition;
         }
 
         protected override void PersistMapFields(JsonOperationContext context, BlittableJsonTextWriter writer)
         {
-            throw new NotSupportedException($"Definition of a faulty '{Name}' index does not support that");
+            throw new NotSupportedException($"Definition of a faulty '{Name}' auto index does not support that");
         }
 
         protected override void PersistFields(JsonOperationContext context, BlittableJsonTextWriter writer)
         {
-            throw new NotSupportedException($"Definition of a faulty '{Name}' index does not support that");
+            throw new NotSupportedException($"Definition of a faulty '{Name}' auto index does not support that");
         }
 
         protected internal override IndexDefinition GetOrCreateIndexDefinitionInternal()
         {
-            var definition = _definition.Clone();
+            var definition = Definition.GetOrCreateIndexDefinitionInternal();
             definition.Name = Name;
             definition.LockMode = LockMode;
             definition.Priority = Priority;
@@ -42,12 +43,12 @@ namespace Raven.Server.Documents.Indexes.Errors
 
         public override IndexDefinitionCompareDifferences Compare(IndexDefinitionBase indexDefinition)
         {
-            return IndexDefinitionCompareDifferences.All;
+            return Definition.Compare(indexDefinition);
         }
 
         public override IndexDefinitionCompareDifferences Compare(IndexDefinition indexDefinition)
         {
-            return _definition.Compare(indexDefinition);
+            return Definition.Compare(indexDefinition);
         }
     }
 }

--- a/src/Raven.Server/Documents/Indexes/Errors/FaultyInMemoryIndex.cs
+++ b/src/Raven.Server/Documents/Indexes/Errors/FaultyInMemoryIndex.cs
@@ -6,6 +6,7 @@ using Microsoft.AspNetCore.Http;
 using Raven.Client.Documents.Indexes;
 using Raven.Server.Config.Categories;
 using Raven.Server.Documents.Includes;
+using Raven.Server.Documents.Indexes.Auto;
 using Raven.Server.Documents.Indexes.Persistence.Lucene;
 using Raven.Server.Documents.Indexes.Workers;
 using Raven.Server.Documents.Queries;
@@ -23,9 +24,18 @@ namespace Raven.Server.Documents.Indexes.Errors
     {
         private readonly Exception _e;
 
+        public FaultyInMemoryIndex(Exception e, string name, IndexingConfiguration configuration, AutoIndexDefinitionBase definition)
+            : this(e, configuration, new FaultyAutoIndexDefinition(name, new HashSet<string> { "@FaultyIndexes" }, IndexLockMode.Unlock, IndexPriority.Normal, new IndexField[0], definition))
+        {
+        }
+
         public FaultyInMemoryIndex(Exception e, string name, IndexingConfiguration configuration, IndexDefinition definition)
-            : base(IndexType.Faulty, new FaultyIndexDefinition(name, new HashSet<string> { "@FaultyIndexes" },
-                   IndexLockMode.Unlock, IndexPriority.Normal, new IndexField[0], definition))
+            : this(e, configuration, new FaultyIndexDefinition(name, new HashSet<string> { "@FaultyIndexes" }, IndexLockMode.Unlock, IndexPriority.Normal, new IndexField[0], definition))
+        {
+        }
+
+        private FaultyInMemoryIndex(Exception e, IndexingConfiguration configuration, IndexDefinitionBase definition)
+            : base(IndexType.Faulty, definition)
         {
             _e = e;
             State = IndexState.Error;


### PR DESCRIPTION
- if we have a faulty index then we need to compare the definition correctly to avoid unnecessary operations that are throwing 'faulty index exceptions' (even when different index is edited)
- faulty auto indexes can now be reset properly