### PR TITLE
RavenDB-10005

### DIFF
--- a/src/Raven.Server/ServerWide/Maintenance/ClusterNodeStatusReport.cs
+++ b/src/Raven.Server/ServerWide/Maintenance/ClusterNodeStatusReport.cs
@@ -7,6 +7,7 @@ namespace Raven.Server.ServerWide.Maintenance
     [Flags]
     public enum DatabaseStatus
     {
+        None = 0,
         Loaded = 1,
         Loading = 2,
         Faulted = 4,


### PR DESCRIPTION
- Don't move node to rehab it the database is idle and was unloaded
- Avoid deadlock when disposing the database and its tcp connections.