### PR TITLE
Can now use DateTimeOffsets to describe facet ranges.

### DIFF
--- a/src/Raven.Client/Documents/Queries/Facets/RangeFacet.cs
+++ b/src/Raven.Client/Documents/Queries/Facets/RangeFacet.cs
@@ -239,6 +239,8 @@ namespace Raven.Client.Documents.Queries.Facets
                 //The nullable stuff here it a bit weird, but it helps with trying to cast Value types
                 case "System.DateTime":
                     return $"'{((DateTime)value).GetDefaultRavenFormat()}'";
+                case "System.DateTimeOffset":
+                    return $"'{((DateTimeOffset)value).UtcDateTime.GetDefaultRavenFormat()}'";
                 case "System.Int32":
                     return NumberUtil.NumberToString((int)value);
                 case "System.Int64":

--- a/test/SlowTests/Tests/Faceted/FacetsOnDateTimeOffset.cs
+++ b/test/SlowTests/Tests/Faceted/FacetsOnDateTimeOffset.cs
@@ -1,0 +1,65 @@
+using System;
+using Raven.Client.Documents.Queries.Facets;
+using Xunit;
+
+namespace SlowTests.Tests.Faceted
+{
+    public class FacetsOnDateTimeOffset
+    {
+        private class ClassWithDateTimeOffset
+        {
+            public DateTime Date { get; set; }
+            public DateTimeOffset DateTimeOffset { get; set; }
+            public DateTimeOffset? NullableDateTimeOffset { get; set; }
+        }
+
+        [Fact]
+        public void FacetShouldWorkWithDateOffset()
+        {
+            var now = new DateTime(2017, 1, 2);
+            var min = DateTime.MinValue;
+            var actual = RangeFacet<ClassWithDateTimeOffset>.Parse(c => c.Date > min && c.Date < now);
+
+            Assert.Equal("Date > '0001-01-01T00:00:00.0000000' and Date < '2017-01-02T00:00:00.0000000'", actual);
+
+        }
+
+        [Fact]
+        public void FacetShouldWorkWithDateTimeOffset()
+        {
+            var now = new DateTimeOffset(2017, 1, 2, 0, 0, 0, TimeSpan.Zero);
+            var min = DateTimeOffset.MinValue;
+            var actual = RangeFacet<ClassWithDateTimeOffset>.Parse(c => c.DateTimeOffset > min && c.DateTimeOffset < now);
+
+            Assert.Equal("DateTimeOffset > '0001-01-01T00:00:00.0000000' and DateTimeOffset < '2017-01-02T00:00:00.0000000'", actual);
+        }
+
+        [Fact]
+        public void FacetShouldWorkWithNullableDateTimeOffset()
+        {
+            DateTimeOffset? now = new DateTimeOffset(2017, 1, 2, 0, 0, 0, TimeSpan.Zero);
+            DateTimeOffset? min = DateTimeOffset.MinValue;
+            var actual = RangeFacet<ClassWithDateTimeOffset>.Parse(c => c.NullableDateTimeOffset > min && c.NullableDateTimeOffset < now);
+
+            Assert.Equal("NullableDateTimeOffset > '0001-01-01T00:00:00.0000000' and NullableDateTimeOffset < '2017-01-02T00:00:00.0000000'", actual);
+        }
+
+        [Fact]
+        public void IdeallyTheVariableWouldNotNeedToBeANullable()
+        {
+            DateTimeOffset now = new DateTimeOffset(2017, 1, 2, 0, 0, 0, TimeSpan.Zero);
+            DateTimeOffset min = DateTimeOffset.MinValue;
+            var actual = RangeFacet<ClassWithDateTimeOffset>.Parse(c => c.NullableDateTimeOffset > min && c.NullableDateTimeOffset < now);
+
+            Assert.Equal("NullableDateTimeOffset > '0001-01-01T00:00:00.0000000' and NullableDateTimeOffset < '2017-01-02T00:00:00.0000000'", actual);
+        }
+
+        [Fact]
+        public void IdeallyIWouldNotNeedAVariable()
+        {
+            var actual = RangeFacet<ClassWithDateTimeOffset>.Parse(c => c.DateTimeOffset > DateTimeOffset.MinValue && c.DateTimeOffset < new DateTimeOffset(2017, 1, 2, 0, 0, 0, TimeSpan.Zero));
+
+            Assert.Equal("NullableDateTimeOffset > '0001-01-01T00:00:00.0000000' and NullableDateTimeOffset < '2017-01-02T00:00:00.0000000'", actual);
+        }
+    }
+}


### PR DESCRIPTION
Spotted this while moving some code over from 3.5. 
I think it's safe to expect client code to use DateTimeOffset to represent datetimes?

Still a bit limited, but at least doesn't crash out as soon as it hits the field. And there's tests for it.