### PR TITLE
RavenDB-10094 Outgoing replication should always accept the destinati…

### DIFF
--- a/src/Raven.Server/Documents/Replication/OutgoingReplicationHandler.cs
+++ b/src/Raven.Server/Documents/Replication/OutgoingReplicationHandler.cs
@@ -624,7 +624,7 @@ namespace Raven.Server.Documents.Replication
 
         private void UpdateDestinationChangeVectorHeartbeat(ReplicationMessageReply replicationBatchReply)
         {
-            _lastSentDocumentEtag = Math.Max(_lastSentDocumentEtag, replicationBatchReply.LastEtagAccepted);
+            _lastSentDocumentEtag = replicationBatchReply.LastEtagAccepted;
 
             LastAcceptedChangeVector = replicationBatchReply.DatabaseChangeVector;
             if (_external == false)


### PR DESCRIPTION
…on last sent etag as the last sent etag even if we think we sent it a higher etag documents