### PR TITLE
RavenDB-10056 GetCompareExchangeValuesOperation would return a dictio…

### DIFF
--- a/src/Raven.Client/Documents/Operations/CompareExchangeValueResultParser.cs
+++ b/src/Raven.Client/Documents/Operations/CompareExchangeValueResultParser.cs
@@ -10,12 +10,12 @@ namespace Raven.Client.Documents.Operations
 {
     internal static class CompareExchangeValueResultParser<T>
     {
-        public static List<CompareExchangeValue<T>> GetValues(BlittableJsonReaderObject response, DocumentConventions conventions)
+        public static Dictionary<string, CompareExchangeValue<T>> GetValues(BlittableJsonReaderObject response, DocumentConventions conventions)
         {
             if (response.TryGet("Results", out BlittableJsonReaderArray items) == false)
                     throw new InvalidDataException("Response is invalid. Results is missing.");
 
-            var results = new List<CompareExchangeValue<T>>();
+            var results = new Dictionary<string, CompareExchangeValue<T>>();
             foreach (BlittableJsonReaderObject item in items)
             {
                 if (item == null)
@@ -33,7 +33,7 @@ namespace Raven.Client.Documents.Operations
                     // simple
                     T value = default(T);
                     raw?.TryGet("Object", out value);
-                    results.Add(new CompareExchangeValue<T>(key, index, value));
+                    results[key] = new CompareExchangeValue<T>(key, index, value);
                 }
                 else
                 {
@@ -41,12 +41,12 @@ namespace Raven.Client.Documents.Operations
                     raw?.TryGet("Object", out val);
                     if (val == null)
                     {
-                        results.Add(new CompareExchangeValue<T>(key, index, default(T)));
+                        results[key] = new CompareExchangeValue<T>(key, index, default(T));
                     }
                     else
                     {
                         var convereted = EntityToBlittable.ConvertToEntity(typeof(T), null, val, conventions);
-                        results.Add(new CompareExchangeValue<T>(key, index, (T)convereted));
+                        results[key] = new CompareExchangeValue<T>(key, index, (T)convereted);
                     }
                 }
             }
@@ -56,7 +56,8 @@ namespace Raven.Client.Documents.Operations
         
         public static CompareExchangeValue<T> GetValue(BlittableJsonReaderObject response, DocumentConventions conventions)
         {
-            return GetValues(response, conventions).FirstOrDefault();
+            var value = GetValues(response, conventions).FirstOrDefault();
+            return value.Value;
         }
     }
 }

--- a/src/Raven.Client/Documents/Operations/GetCompareExchangeValuesOperation.cs
+++ b/src/Raven.Client/Documents/Operations/GetCompareExchangeValuesOperation.cs
@@ -12,7 +12,7 @@ using Sparrow.Json;
 
 namespace Raven.Client.Documents.Operations
 {
-    public class GetCompareExchangeValuesOperation<T> : IOperation<List<CompareExchangeValue<T>>>
+    public class GetCompareExchangeValuesOperation<T> : IOperation<Dictionary<string, CompareExchangeValue<T>>>
     {
         private readonly string[] _keys;
 
@@ -35,12 +35,12 @@ namespace Raven.Client.Documents.Operations
             _pageSize = pageSize;
         }
 
-        public RavenCommand<List<CompareExchangeValue<T>>> GetCommand(IDocumentStore store, DocumentConventions conventions, JsonOperationContext context, HttpCache cache)
+        public RavenCommand<Dictionary<string, CompareExchangeValue<T>>> GetCommand(IDocumentStore store, DocumentConventions conventions, JsonOperationContext context, HttpCache cache)
         {
             return new GetCompareExchangeValuesCommand(this, conventions);
         }
 
-        private class GetCompareExchangeValuesCommand : RavenCommand<List<CompareExchangeValue<T>>>
+        private class GetCompareExchangeValuesCommand : RavenCommand<Dictionary<string, CompareExchangeValue<T>>>
         {
             private readonly GetCompareExchangeValuesOperation<T> _operation;
             private readonly DocumentConventions _conventions;

--- a/test/FastTests/Client/UniqueValues.cs
+++ b/test/FastTests/Client/UniqueValues.cs
@@ -112,10 +112,8 @@ namespace FastTests.Client
             
             var values = await store.Operations.SendAsync(new GetCompareExchangeValuesOperation<User>("test"));
             Assert.Equal(2, values.Count);
-            Assert.Equal("test", values[0].Key);
-            Assert.Equal("Karmel", values[0].Value.Name);
-            Assert.Equal("test2", values[1].Key);
-            Assert.Equal("Karmel", values[1].Value.Name);
+            Assert.Equal("Karmel", values["test"].Value.Name);
+            Assert.Equal("Karmel", values["test2"].Value.Name);
         }
         
         [Fact]


### PR DESCRIPTION
…nary so the client can tell fast if a value is there or not.

The value itself would also contain the key for easy iteration on the values.