### PR TITLE
RavenDB-10110 Key not found exception on map reduce indexes which hav…

### DIFF
--- a/test/FastTests/Server/Documents/Indexing/MapReduce/OutputReduceToCollectionTests.cs
+++ b/test/FastTests/Server/Documents/Indexing/MapReduce/OutputReduceToCollectionTests.cs
@@ -79,7 +79,7 @@ namespace FastTests.Server.Documents.Indexing.MapReduce
                                 "which would output reduce results to documents in the 'Invoices' collection, " +
                                 "as 'Invoices' collection is consumed by other index in a way that would lead to an infinite loop." +
                                 $"{Environment.NewLine}" +
-                                $"DailyInvoicesIndexLoadDocument: InvoiceHolders,Invoices => DailyInvoices{Environment.NewLine}" +
+                                $"DailyInvoicesIndexLoadDocument: InvoiceHolders (referenced: Invoices) => DailyInvoices{Environment.NewLine}" +
                                 $"MonthlyInvoicesIndex: DailyInvoices => MonthlyInvoices{Environment.NewLine}" +
                                 $"--> YearlyToDailyInfiniteLoopIndex: MonthlyInvoices => *Invoices*", exception.Message);
             }

--- a/test/SlowTests/Issues/RavenDB_10110.cs
+++ b/test/SlowTests/Issues/RavenDB_10110.cs
@@ -1,0 +1,118 @@
+﻿using System.Linq;
+using FastTests;
+using Raven.Client.Documents.Indexes;
+using Raven.Client.Documents.Operations.Indexes;
+using Xunit;
+
+namespace SlowTests.Issues
+{
+    public class RavenDB_10110 : RavenTestBase
+    {
+        [Fact]
+        public void InvalidOutputReduceToCollectionValidation()
+        {
+            using (var store = GetDocumentStore())
+            {
+                store.ExecuteIndex(new Invoices_CountByWarehouse());
+                store.ExecuteIndex(new Invoices_CountByWarehouse2());
+                
+                using (var session = store.OpenSession())
+                {
+                    session.Store(new Warehouse()
+                    {
+                        Id = "warehouses/1",
+                        WarehouseName = "ABC"
+                    });
+
+                    session.Store(new Invoice()
+                    {
+                        WarehouseId = "warehouses/1",
+                    });
+
+                    session.SaveChanges();
+                }
+
+                WaitForIndexing(store);
+
+                var indexStats = store.Maintenance.Send(new GetIndexesStatisticsOperation());
+
+                foreach (var stats in indexStats)
+                {
+                    Assert.Equal(0, stats.ErrorsCount);
+                }
+            }
+        }
+    }
+
+    public class Invoice
+    {
+        public string Id { get; set; }
+        public string WarehouseId { get; set; }
+    }
+
+    public class Warehouse
+    {
+        public string Id { get; set; }
+        public string WarehouseName { get; set; }
+    }
+
+    public class Invoices_CountByWarehouse : AbstractIndexCreationTask<Invoice, Invoices_CountByWarehouse.Result>
+    {
+        public class Result
+        {
+            public string WarehouseName { get; set; }
+            public int Count { get; set; }
+        }
+
+        public Invoices_CountByWarehouse()
+        {
+            Map = invoices => from invoice in invoices
+                select new
+                {
+                    WarehouseName = LoadDocument<Warehouse>(invoice.WarehouseId).WarehouseName,
+                    Count = 1
+                };
+
+            Reduce = results => from result in results
+                group result by result.WarehouseName
+                into g
+                select new Result
+                {
+                    WarehouseName = g.Key,
+                    Count = g.Sum(x => x.Count)
+                };
+
+            OutputReduceToCollection = "Results";
+        }
+    }
+
+    public class Invoices_CountByWarehouse2 : AbstractIndexCreationTask<Invoice, Invoices_CountByWarehouse2.Result>
+    {
+        public class Result
+        {
+            public string WarehouseName { get; set; }
+            public int Count { get; set; }
+        }
+
+        public Invoices_CountByWarehouse2()
+        {
+            Map = invoices => from invoice in invoices
+                select new
+                {
+                    WarehouseName = LoadDocument<Warehouse>(invoice.WarehouseId).WarehouseName,
+                    Count = 1
+                };
+
+            Reduce = results => from result in results
+                group result by result.WarehouseName
+                into g
+                select new Result
+                {
+                    WarehouseName = g.Key,
+                    Count = g.Sum(x => x.Count)
+                };
+
+            OutputReduceToCollection = "Results2";
+        }
+    }
+}


### PR DESCRIPTION
…e OutputReduceToCollection defined and use LoadDocument

- fixing OutputReduceToCollection validation - we must not add collections directly to Index.Collections when validating
- the above change broke OutputReduceToCollectionTests.ForbidOutputReduceDocumentsInAInfiniteLoopCausedByLoadDocument - fixing it and enhancing the exception message a bit