### PR TITLE
RavenDB-10120 Allow to do CSV export using a query from document.

### DIFF
--- a/src/Raven.Server/Documents/Queries/IndexQueryServerSide.cs
+++ b/src/Raven.Server/Documents/Queries/IndexQueryServerSide.cs
@@ -54,14 +54,16 @@ namespace Raven.Server.Documents.Queries
             return result;
         }
 
-        public static IndexQueryServerSide Create(HttpContext httpContext, int start, int pageSize, JsonOperationContext context)
+        public static IndexQueryServerSide Create(HttpContext httpContext, int start, int pageSize, JsonOperationContext context, string overrideQuery = null)
         {
-            if (httpContext.Request.Query.TryGetValue("query", out var query) == false || query.Count == 0 || string.IsNullOrWhiteSpace(query[0]))
+            var isQueryOverwritten = !string.IsNullOrEmpty(overrideQuery);
+            if ((httpContext.Request.Query.TryGetValue("query", out var query) == false || query.Count == 0 || string.IsNullOrWhiteSpace(query[0])) && isQueryOverwritten == false)
                 throw new InvalidOperationException("Missing mandatory query string parameter 'query'.");
 
+            var actualQuery = isQueryOverwritten ? overrideQuery: query[0] ;
             var result = new IndexQueryServerSide
             {
-                Query = Uri.UnescapeDataString(query[0]),
+                Query = Uri.UnescapeDataString(actualQuery),
                 // all defaults which need to have custom value
                 Start = start,
                 PageSize = pageSize

--- a/test/FastTests/Issues/RavenDB_9519.cs
+++ b/test/FastTests/Issues/RavenDB_9519.cs
@@ -25,7 +25,48 @@ namespace FastTests.Issues
                 }
 
                 var client = new HttpClient();
-                var stream = await client.GetStreamAsync($"{store.Urls[0]}/databases/{store.Database}/streams/queries?query=From%20companies");
+                var stream = await client.GetStreamAsync($"{store.Urls[0]}/databases/{store.Database}/streams/queries?query=From%20companies&format=csv");
+
+                using (var commands = store.Commands())
+                {
+                    var getOperationIdCommand = new GetNextOperationIdCommand();
+                    await commands.RequestExecutor.ExecuteAsync(getOperationIdCommand, commands.Context);
+                    var operationId = getOperationIdCommand.Result;
+
+                    {
+                        var csvImportCommand = new CsvImportCommand(stream, null, operationId);
+
+                        await commands.ExecuteAsync(csvImportCommand);
+
+                        var operation = new Operation(commands.RequestExecutor, () => store.Changes(), store.Conventions, operationId);
+
+                        await operation.WaitForCompletionAsync();
+                    }
+                }
+
+                using (var session = store.OpenSession())
+                {
+                    var res = session.Query<Company>().ToList();
+                    Assert.Equal(2, res.Count);
+                    Assert.Equal(res[0], res[1]);
+                }
+            }
+        }
+
+        [Fact]
+        public async Task ExportingAndImportingCsvUsingQueryFromDocumentShouldWork()
+        {
+            using (var store = GetDocumentStore())
+            {
+                using (var session = store.OpenSession())
+                {
+                    session.Store(_testCompany, "companies/1");
+                    session.Store(new{Query= "From%20companies" },"queries/1");
+                    session.SaveChanges();
+                }
+
+                var client = new HttpClient();
+                var stream = await client.GetStreamAsync($"{store.Urls[0]}/databases/{store.Database}/streams/queries?fromDocument=queries%2F1&format=csv");
 
                 using (var commands = store.Commands())
                 {


### PR DESCRIPTION
The idea is that for excel we need to include the RQL in the GET request query and this easily exceeds the 256 chars limit for a GET request supported by excel.
So in order to bypass this issue we will allow the user to supply a document id that contains a 'Query' field with the escaped query and we will use it for querying.