### PR TITLE
RavenDB-9982 Fixing Rachis Tests

### DIFF
--- a/src/Raven.Client/Http/RequestExecutor.cs
+++ b/src/Raven.Client/Http/RequestExecutor.cs
@@ -671,10 +671,12 @@ namespace Raven.Client.Http
                     if (sessionInfo != null)
                         sessionInfo.AsyncCommandRunning = false;
 
-                    ThrowIfClientException(response, e);
 
                     if (await HandleServerDown(url, chosenNode, nodeIndex, context, command, request, response, e, sessionInfo).ConfigureAwait(false) == false)
+                    {
+                        ThrowIfClientException(response, e);
                         ThrowFailedToContactAllNodes(command, request, e, null);
+                    }
 
                     return;
                 }

--- a/src/Raven.Server/Documents/DatabasesLandlord.cs
+++ b/src/Raven.Server/Documents/DatabasesLandlord.cs
@@ -534,6 +534,7 @@ namespace Raven.Server.Documents
                 var sp = Stopwatch.StartNew();
                 var documentDatabase = new DocumentDatabase(config.ResourceName, config, _serverStore, AddToInitLog);
                 documentDatabase.Initialize();
+                AddToInitLog("Finish database initialization");
                 DeleteDatabaseCachedInfo(documentDatabase, _serverStore);
                 if (_logger.IsInfoEnabled)
                     _logger.Info($"Started database {config.ResourceName} in {sp.ElapsedMilliseconds:#,#;;0}ms");

--- a/src/Raven.Server/Documents/Replication/ResolveConflictOnReplicationConfigurationChange.cs
+++ b/src/Raven.Server/Documents/Replication/ResolveConflictOnReplicationConfigurationChange.cs
@@ -43,7 +43,7 @@ namespace Raven.Server.Documents.Replication
             {
                 try
                 {
-                    ResolveConflictsTask.Wait();
+                    ResolveConflictsTask.Wait(TimeSpan.FromSeconds(60));
                 }
                 catch (Exception e)
                 {

--- a/src/Raven.Server/Rachis/TimeoutEvent.cs
+++ b/src/Raven.Server/Rachis/TimeoutEvent.cs
@@ -131,7 +131,7 @@ namespace Raven.Server.Rachis
 
         public void Dispose()
         {
-            _timeoutHappened = null;
+            DisableTimeout();
             _timer.Dispose();
         }
     }

--- a/test/RachisTests/DatabaseCluster/ClusterDatabaseMaintenance.cs
+++ b/test/RachisTests/DatabaseCluster/ClusterDatabaseMaintenance.cs
@@ -562,9 +562,8 @@ namespace RachisTests.DatabaseCluster
                 await leader.ServerStore.RemoveFromClusterAsync(nodeTag);
                 await leader.ServerStore.AddNodeToClusterAsync(Servers[1].ServerStore.GetNodeHttpServerUrl(), nodeTag);
                 await Servers[1].ServerStore.WaitForState(RachisState.Follower);
-                await Task.Delay(TimeSpan.FromSeconds(5)); // wait for the observer to update the status
-                dbToplogy = (await leaderStore.Maintenance.Server.SendAsync(new GetDatabaseRecordOperation(databaseName))).Topology;
-                Assert.Equal(groupSize, dbToplogy.Members.Count);
+                Assert.Equal(groupSize,
+                    (WaitForValue(() => leaderStore.Maintenance.Server.Send(new GetDatabaseRecordOperation(databaseName)).Topology.Members.Count, groupSize)));
             }
         }
 


### PR DESCRIPTION
- fixing race on the timeout event, Dispose was called during timer change.
- on database initialize, execute the features in different thread.