### PR TITLE
RavenDB-10131 [Replication] In cluster of 5 nodes, with random create…

### DIFF
--- a/src/Raven.Server/Documents/Replication/ReplicationDocumentSender.cs
+++ b/src/Raven.Server/Documents/Replication/ReplicationDocumentSender.cs
@@ -445,14 +445,15 @@ namespace Raven.Server.Documents.Replication
             _stream.Flush();
             sw.Stop();
 
-            _parent._lastSentDocumentEtag = _lastEtag;
-
             if (_log.IsInfoEnabled && _orderedReplicaItems.Count > 0)
                 _log.Info($"Finished sending replication batch. Sent {_orderedReplicaItems.Count:#,#;;0} documents and {_replicaAttachmentStreams.Count:#,#;;0} attachment streams in {sw.ElapsedMilliseconds:#,#;;0} ms. Last sent etag = {_lastEtag}");
 
+            _parent.HandleServerResponse();
+
+            _parent._lastSentDocumentEtag = _lastEtag;
+
             _parent._lastDocumentSentTime = DateTime.UtcNow;
 
-            _parent.HandleServerResponse();
         }
 
         private void WriteItemToServer(DocumentsOperationContext context, ReplicationBatchItem item, OutgoingReplicationStatsScope stats)


### PR DESCRIPTION
…/query/delete, after disconnect/reconnect a node - docs count mismatch

- Subscribe the replication loader to the tombstone cleaner.
- Update the last sent etag only after a successful response from the other side.