### PR TITLE
RavenDB-10147

### DIFF
--- a/src/Raven.Client/Documents/Conventions/DocumentConventions.cs
+++ b/src/Raven.Client/Documents/Conventions/DocumentConventions.cs
@@ -41,9 +41,11 @@ namespace Raven.Client.Documents.Conventions
 
         private readonly Dictionary<MemberInfo, CustomQueryTranslator> _customQueryTranslators = new Dictionary<MemberInfo, CustomQueryTranslator>();
 
-        private readonly List<(Type Type, TryConvertValueForQueryDelegate<object> Convert)> _listOfQueryValueConverters = new List<(Type, TryConvertValueForQueryDelegate<object>)>();
+        private readonly List<(Type Type, TryConvertValueForQueryDelegate<object> Convert)> _listOfQueryValueConverters =
+            new List<(Type, TryConvertValueForQueryDelegate<object>)>();
 
-        private readonly List<Tuple<Type, Func<string, object, Task<string>>>> _listOfRegisteredIdConventionsAsync = new List<Tuple<Type, Func<string, object, Task<string>>>>();
+        private readonly List<Tuple<Type, Func<string, object, Task<string>>>> _listOfRegisteredIdConventionsAsync =
+            new List<Tuple<Type, Func<string, object, Task<string>>>>();
 
         private readonly List<Tuple<Type, Func<ValueType, string>>> _listOfRegisteredIdLoadConventions = new List<Tuple<Type, Func<ValueType, string>>>();
 
@@ -54,6 +56,7 @@ namespace Raven.Client.Documents.Conventions
             private readonly DocumentConventions _conventions;
             private Func<object, StreamWriter, bool> _trySerializeEntityToJsonStream;
             private Func<object, StreamWriter, bool> _trySerializeMetadataToJsonStream;
+
             public Func<object, StreamWriter, bool> TrySerializeMetadataToJsonStream
             {
                 get => _trySerializeMetadataToJsonStream;
@@ -95,7 +98,8 @@ namespace Raven.Client.Documents.Conventions
 
             FindClrType = (id, doc) =>
             {
-                if (doc.TryGet(Constants.Documents.Metadata.Key, out BlittableJsonReaderObject metadata) && metadata.TryGet(Constants.Documents.Metadata.RavenClrType, out string clrType))
+                if (doc.TryGet(Constants.Documents.Metadata.Key, out BlittableJsonReaderObject metadata) &&
+                    metadata.TryGet(Constants.Documents.Metadata.RavenClrType, out string clrType))
                     return clrType;
 
                 return null;
@@ -113,7 +117,7 @@ namespace Raven.Client.Documents.Conventions
             PrettifyGeneratedLinqExpressions = true;
 
             JsonContractResolver = new DefaultRavenContractResolver();
-            CustomizeJsonSerializer = serializer => { }; 
+            CustomizeJsonSerializer = serializer => { };
 
             BulkInsert = new BulkInsertConventions(this);
 
@@ -135,7 +139,7 @@ namespace Raven.Client.Documents.Conventions
                 else
                     httpCacheSizeInMb = 512; // We have enough memory to be aggresive.
             }
-        
+
             MaxHttpCacheSize = new Size(httpCacheSizeInMb, SizeUnit.Megabytes);
         }
 
@@ -491,15 +495,17 @@ namespace Raven.Client.Documents.Conventions
 
             if (t.Name.Contains("<>"))
                 return null;
-            
+
             // we want to reject queries and other operations on abstract types, because you usually
             // want to use them for polymorphic queries, and that require the conventions to be 
             // applied properly, so we reject the behavior and hint to the user explicitly
-            if(t.GetTypeInfo().IsInterface)
-                throw new InvalidOperationException("Cannot find collection name for interface " + t.FullName + ", only concrete classes are supported. Did you forget to customize Conventions.FindCollectionName?");
-            if(t.GetTypeInfo().IsAbstract)
-                throw new InvalidOperationException("Cannot find collection name for abstract class " + t.FullName + ", only concrete class are supported. Did you forget to customize Conventions.FindCollectionName?");
-            
+            if (t.GetTypeInfo().IsInterface)
+                throw new InvalidOperationException("Cannot find collection name for interface " + t.FullName +
+                                                    ", only concrete classes are supported. Did you forget to customize Conventions.FindCollectionName?");
+            if (t.GetTypeInfo().IsAbstract)
+                throw new InvalidOperationException("Cannot find collection name for abstract class " + t.FullName +
+                                                    ", only concrete class are supported. Did you forget to customize Conventions.FindCollectionName?");
+
             if (t.GetTypeInfo().IsGenericType)
             {
                 var name = t.GetGenericTypeDefinition().Name;
@@ -519,6 +525,7 @@ namespace Raven.Client.Documents.Conventions
             {
                 result = Inflector.Pluralize(t.Name);
             }
+
             var temp = new Dictionary<Type, string>(_cachedDefaultTypeCollectionNames)
             {
                 [t] = result
@@ -654,7 +661,7 @@ namespace Raven.Client.Documents.Conventions
             };
 
             CustomizeJsonSerializer(jsonSerializer);
-			
+
             if (SaveEnumsAsIntegers == false)
                 jsonSerializer.Converters.Add(new StringEnumConverter());
 
@@ -665,7 +672,7 @@ namespace Raven.Client.Documents.Conventions
             jsonSerializer.Converters.Add(ParametersConverter.Instance);
             jsonSerializer.Converters.Add(JsonLinqEnumerableConverter.Instance);
             jsonSerializer.Converters.Add(JsonIMetadataDictionaryConverter.Instance);
-            
+
             return jsonSerializer;
         }
 
@@ -787,8 +794,8 @@ namespace Raven.Client.Documents.Conventions
                 yield return propertyInfo;
 
             foreach (var @interface in type.GetInterfaces())
-                foreach (var propertyInfo in GetPropertiesForType(@interface))
-                    yield return propertyInfo;
+            foreach (var propertyInfo in GetPropertiesForType(@interface))
+                yield return propertyInfo;
         }
 
         public void RegisterQueryValueConverter<T>(TryConvertValueForQueryDelegate<T> converter)
@@ -859,7 +866,8 @@ namespace Raven.Client.Documents.Conventions
         internal void AssertNotFrozen()
         {
             if (_frozen)
-                throw new InvalidOperationException($"Conventions has frozen after '{nameof(DocumentStore)}.{nameof(DocumentStore.Initialize)}()' and no changes can be applied to them.");
+                throw new InvalidOperationException(
+                    $"Conventions has frozen after '{nameof(DocumentStore)}.{nameof(DocumentStore.Initialize)}()' and no changes can be applied to them.");
         }
     }
 }

--- a/src/Raven.Client/Documents/Session/InMemoryDocumentSessionOperations.cs
+++ b/src/Raven.Client/Documents/Session/InMemoryDocumentSessionOperations.cs
@@ -559,10 +559,10 @@ more responsive application.
             // to detect if they generate duplicates.
             AssertNoNonUniqueInstance(entity, id);
 
-            var tag = _requestExecutor.Conventions.GetCollectionName(entity);
+            var collectionName = _requestExecutor.Conventions.GetCollectionName(entity);
             var metadata = new DynamicJsonValue();
-            if (tag != null)
-                metadata[Constants.Documents.Metadata.Collection] = tag;
+            if (collectionName != null)
+                metadata[Constants.Documents.Metadata.Collection] = collectionName;
 
             var clrType = _requestExecutor.Conventions.GetClrTypeName(entity.GetType());
             if (clrType != null)

--- a/test/FastTests/Client/BulkInserts.cs
+++ b/test/FastTests/Client/BulkInserts.cs
@@ -43,7 +43,10 @@ namespace FastTests.Client
                 {
                     for (int i = 0; i < 1000; i++)
                     {
-                        await bulkInsert.StoreAsync(new FooBar() { Name = "foobar/" + i }, "FooBars/" + i);
+                        await bulkInsert.StoreAsync(new FooBar()
+                            {
+                                Name = "foobar/" + i
+                            }, "FooBars/" + i);
                     }
                 }
 
@@ -60,10 +63,22 @@ namespace FastTests.Client
         {
             var fooBars = new[]
             {
-                new FooBar { Name = "John Doe" },
-                new FooBar { Name = "Jane Doe" },
-                new FooBar { Name = "Mega John" },
-                new FooBar { Name = "Mega Jane" }
+                new FooBar
+                {
+                    Name = "John Doe"
+                },
+                new FooBar
+                {
+                    Name = "Jane Doe"
+                },
+                new FooBar
+                {
+                    Name = "Mega John"
+                },
+                new FooBar
+                {
+                    Name = "Mega Jane"
+                }
             };
             using (var store = GetDocumentStore())
             {
@@ -77,7 +92,7 @@ namespace FastTests.Client
 
                 store.GetRequestExecutor(store.Database).ContextPool.AllocateOperationContext(out JsonOperationContext context);
 
-                var getDocumentCommand = new GetDocumentsCommand(new[] { "FooBars/1-A", "FooBars/2-A", "FooBars/3-A", "FooBars/4-A" }, includes: null, metadataOnly: false);
+                var getDocumentCommand = new GetDocumentsCommand(new[] {"FooBars/1-A", "FooBars/2-A", "FooBars/3-A", "FooBars/4-A"}, includes: null, metadataOnly: false);
 
                 store.GetRequestExecutor(store.Database).Execute(getDocumentCommand, context);
 
@@ -123,20 +138,14 @@ namespace FastTests.Client
                     }
 
 
-                    var ae = Assert.Throws<AggregateException>(() =>
-                    {
-                        Parallel.ForEach(localList, element =>
-                        {
-                            bulkInsert.StoreAsync(element).Wait();
-                        });
-                    });
+                    var ae = Assert.Throws<AggregateException>(() => { Parallel.ForEach(localList, element => { bulkInsert.StoreAsync(element).Wait(); }); });
 
 
                     var msg = ae.InnerExceptions
                         .OfType<AggregateException>()
-                        .SelectMany(x=>x.InnerExceptions)
-                        .OfType<ConcurrencyException>().First().Message;
-                    Assert.Contains("Store/StoreAsync in bulkInsert concurrently is forbidden", msg);
+                        .SelectMany(x => x.InnerExceptions)
+                        .OfType<InvalidOperationException>().First().Message;
+                    Assert.Contains("Bulk Insert store methods cannot be executed concurrently", msg);
                 }
             }
         }
@@ -145,7 +154,10 @@ namespace FastTests.Client
         {
             public FooBarIndex()
             {
-                Map = foos => foos.Select(x => new { x.Name });
+                Map = foos => foos.Select(x => new
+                {
+                    x.Name
+                });
             }
         }
 

--- a/test/SlowTests/Issues/RavenDB_10147.cs
+++ b/test/SlowTests/Issues/RavenDB_10147.cs
@@ -1,0 +1,73 @@
+﻿using System.Collections.Generic;
+using FastTests;
+using Raven.Client;
+using Raven.Client.Documents.Session;
+using Raven.Client.Json;
+using Sparrow.Collections.LockFree;
+using Sparrow.Json;
+using Xunit;
+
+namespace SlowTests.Issues
+{
+    public class RavenDB_10147 : RavenTestBase
+    {
+        private class Entity
+        {
+            public string Id { get; set; }
+            public string Name { get; set; }
+            public IEnumerable<string> Tags { get; set; } = new string[0];
+        }
+
+        [Fact]
+        public void ShouldWork()
+        {
+            using (var store = GetDocumentStore())
+            {
+                using (var session = store.OpenSession())
+                {
+                    session.Store(new Entity
+                    {
+                        Id = "transactions/248738",
+                        Name = "Whatever",
+                        Tags = new string[] {"files/178996"}
+                    }, "items/1");
+
+                    session.SaveChanges();
+                }
+
+                using (var bulkInsert = store.BulkInsert())
+                {
+                    bulkInsert.Store(new Entity
+                    {
+                        Id = "transactions/248738",
+                        Name = "Whatever",
+                        Tags = new string[] {"files/178996"}
+                    }, "items/2");
+                }
+
+                using (var commands = store.Commands())
+                {
+                    var item1 = commands.Get("items/1");
+                    var item2 = commands.Get("items/2");
+
+                    var changes = new ConcurrentDictionary<string, DocumentsChanges[]>();
+                    var changed = BlittableOperation.EntityChanged(item1.BlittableJson, new DocumentInfo
+                    {
+                        IsNewDocument = false,
+                        Document = item2.BlittableJson
+                    }, changes);
+                    
+                    Assert.False(changed); // EntityChanged is not comparing @metadata
+                    Assert.Equal(0, changes.Count);
+
+                    var metadata1 = (BlittableJsonReaderObject)item1.BlittableJson[Constants.Documents.Metadata.Key];
+                    var metadata2 = (BlittableJsonReaderObject)item2.BlittableJson[Constants.Documents.Metadata.Key];
+                    
+                    Assert.Equal(metadata1.Count, metadata2.Count);
+                    Assert.Equal(metadata1[Constants.Documents.Metadata.Collection], metadata2[Constants.Documents.Metadata.Collection]);
+                    Assert.Equal(metadata1[Constants.Documents.Metadata.RavenClrType], metadata2[Constants.Documents.Metadata.RavenClrType]);
+                }
+            }
+        }
+    }
+}

--- a/test/SlowTests/MailingList/DocumentQueryIncludeAndStreamTest.cs
+++ b/test/SlowTests/MailingList/DocumentQueryIncludeAndStreamTest.cs
@@ -5,10 +5,9 @@ using FastTests;
 using Raven.Client.Documents;
 using Raven.Client.Documents.Indexes;
 using Raven.Client.Exceptions;
-using Raven.TestDriver;
 using Xunit;
 
-namespace RavenIndexErrorTest
+namespace SlowTests.MailingList
 {
     public class DocumentQueryIncludeAndStreamTest : RavenTestBase
     {


### PR DESCRIPTION
- BulkInsert should use the same serialization technique as session
- BulkInsert should guard concurrent execution for all Store methods
- BulkInsert should add also Raven-Clr-Type to the metadata