### PR TITLE
RavenDB-10166 RandomOrder: If no seed recieved, we use the same "dumm…

### DIFF
--- a/src/Raven.Server/Documents/Queries/Sorting/AlphaNumeric/RandomSortField.cs
+++ b/src/Raven.Server/Documents/Queries/Sorting/AlphaNumeric/RandomSortField.cs
@@ -5,9 +5,7 @@ namespace Raven.Server.Documents.Queries.Sorting.AlphaNumeric
 {
     public class RandomSortField : SortField
     {
-        private static readonly string DummyValue = "RandomValue-" + Guid.NewGuid();
-
-        public RandomSortField(string field) : base(field ?? DummyValue, INT)
+        public RandomSortField(string field) : base(field ?? "RandomValue-" + Guid.NewGuid(), INT)
         {
         }
 

--- a/test/FastTests/Issues/RavenDB_10166.cs
+++ b/test/FastTests/Issues/RavenDB_10166.cs
@@ -1,0 +1,82 @@
+﻿using System;
+using System.Collections.Generic;
+using System.Linq;
+using System.Text;
+using System.Threading.Tasks;
+using Raven.Tests.Core.Utils.Entities;
+using Xunit;
+
+namespace FastTests.Issues
+{
+    public class RavenDB_10166:RavenTestBase
+    {
+        [Fact]
+        public async Task RandomResultsShouldBeRecievedInDifferentOrderEachTime()
+        {
+            using (var store = GetDocumentStore())
+            {
+                using (var session = store.OpenAsyncSession())
+                {
+                    await session.StoreAsync(new User
+                    {
+                        Name = "Vasilii",
+                        Age = 1
+                    });
+                    await session.StoreAsync(new User
+                    {
+                        Name = "Ivan",
+                        Age = 1
+                    });
+                    await session.StoreAsync(new User
+                    {
+                        Name = "Michail",
+                        Age = 1
+                    });
+                    await session.StoreAsync(new User
+                    {
+                        Name = "Danil",
+                        Age = 2
+                    });
+                    await session.StoreAsync(new User
+                    {
+                        Name = "Lazar",
+                        Age = 3
+                    });
+
+                    await session.SaveChangesAsync();
+                }
+
+                List<User> firstOrder;
+                using (var session = store.OpenAsyncSession())
+                {
+                    firstOrder = await session.Advanced.AsyncDocumentQuery<User>()
+                        .WaitForNonStaleResults()
+                        .OrderBy(x => x.Age)
+                        .RandomOrdering().ToListAsync();
+                }
+
+                bool orderVaried = false;
+                for (var i=0; i< 10; i++)
+                {
+                    store.GetRequestExecutor().Cache.Clear();
+                    using (var session = store.OpenAsyncSession())
+                    {
+                        var curOrder = await session.Advanced.AsyncDocumentQuery<User>()
+                            .WaitForNonStaleResults()
+                            .OrderBy(x => x.Age)
+                            .RandomOrdering().ToListAsync();
+                        for (var docIndex=0; docIndex < curOrder.Count; docIndex++)
+                        {
+                            if (curOrder[docIndex].Name != firstOrder[docIndex].Name)
+                            {
+                                orderVaried = true;
+                                break;
+                            }
+                        }
+                    }
+                }
+                Assert.True(orderVaried);
+            }
+        }
+    }
+}


### PR DESCRIPTION
…y" seed for all queries