### PR TITLE
RavenDB-10192 BREAKING CHANGE! This commit change the format of repli…

### DIFF
--- a/src/Raven.Server/Documents/ConflictsStorage.cs
+++ b/src/Raven.Server/Documents/ConflictsStorage.cs
@@ -338,7 +338,8 @@ namespace Raven.Server.Documents
                     {
                         using (Slice.External(context.Allocator, conflicted.LowerId, out Slice key))
                         {
-                            _documentsStorage.RevisionsStorage.DeleteRevision(context, key, conflicted.Collection, conflicted.ChangeVector);
+                            var lastModifiedTicks = _documentDatabase.Time.GetUtcNow().Ticks;
+                            _documentsStorage.RevisionsStorage.DeleteRevision(context, key, conflicted.Collection, conflicted.ChangeVector, lastModifiedTicks);
                         }
                     }
                     _documentsStorage.EnsureLastEtagIsPersisted(context, conflicted.Etag);

--- a/src/Raven.Server/Documents/DocumentPutAction.cs
+++ b/src/Raven.Server/Documents/DocumentPutAction.cs
@@ -54,10 +54,7 @@ namespace Raven.Server.Documents
 #endif
 
             var newEtag = _documentsStorage.GenerateNextEtag();
-            
-            Debug.Assert(lastModifiedTicks.HasValue == false || 
-                         lastModifiedTicks.Value != DateTime.MinValue.Ticks);
-            var modifiedTicks = lastModifiedTicks ?? _documentDatabase.Time.GetUtcNow().Ticks;
+            var modifiedTicks = _documentsStorage.GetOrCreateLastModifiedTicks(lastModifiedTicks);
 
             id = BuildDocumentId(id, newEtag, out bool knownNewId);
             using (DocumentIdWorker.GetLowerIdSliceAndStorageKey(context, id, out Slice lowerId, out Slice idPtr))

--- a/src/Raven.Server/Documents/Replication/IncomingReplicationHandler.cs
+++ b/src/Raven.Server/Documents/Replication/IncomingReplicationHandler.cs
@@ -704,6 +704,8 @@ namespace Raven.Server.Documents.Replication
 
                     using (tombstoneRead.Start())
                     {
+                        item.LastModifiedTicks = *(long*)ReadExactly(sizeof(long));
+
                         var keySize = *(int*)ReadExactly(sizeof(int));
                         item.KeyDispose = Slice.From(context.Allocator, ReadExactly(keySize), keySize, out item.Key);
                     }
@@ -714,6 +716,8 @@ namespace Raven.Server.Documents.Replication
 
                     using (tombstoneRead.Start())
                     {
+                        item.LastModifiedTicks = *(long*)ReadExactly(sizeof(long));
+                        
                         var keySize = *(int*)ReadExactly(sizeof(int));
                         item.KeyDispose = Slice.From(context.Allocator, ReadExactly(keySize), keySize, out item.Key);
 
@@ -976,11 +980,11 @@ namespace Raven.Server.Documents.Replication
                             }
                             else if (item.Type == ReplicationBatchItem.ReplicationItemType.AttachmentTombstone)
                             {
-                                database.DocumentsStorage.AttachmentsStorage.DeleteAttachmentDirect(context, item.Key, false, "$fromReplication", null, rcvdChangeVector);
+                                database.DocumentsStorage.AttachmentsStorage.DeleteAttachmentDirect(context, item.Key, false, "$fromReplication", null, rcvdChangeVector, item.LastModifiedTicks);
                             }
                             else if (item.Type == ReplicationBatchItem.ReplicationItemType.RevisionTombstone)
                             {
-                                database.DocumentsStorage.RevisionsStorage.DeleteRevision(context, item.Key, item.Collection, rcvdChangeVector);
+                                database.DocumentsStorage.RevisionsStorage.DeleteRevision(context, item.Key, item.Collection, rcvdChangeVector, item.LastModifiedTicks);
                             }
                             else
                             {

--- a/src/Raven.Server/Documents/Replication/ReplicationDocumentSender.cs
+++ b/src/Raven.Server/Documents/Replication/ReplicationDocumentSender.cs
@@ -636,11 +636,12 @@ namespace Raven.Server.Documents.Replication
             fixed (byte* pTemp = _tempBuffer)
             {
                 var requiredSize = sizeof(byte) + // type
-                             sizeof(int) + // # of change vectors
-                             cv.Size +
-                             sizeof(short) + // transaction marker
-                             sizeof(int) + // size of key
-                             item.Id.Size;
+                                   sizeof(int) + // # of change vectors
+                                   cv.Size +
+                                   sizeof(short) + // transaction marker
+                                   sizeof(long) + // last modified
+                                   sizeof(int) + // size of key
+                                   item.Id.Size;
 
                 if (requiredSize > _tempBuffer.Length)
                     ThrowTooManyChangeVectorEntries(item);
@@ -656,6 +657,9 @@ namespace Raven.Server.Documents.Replication
 
                 *(short*)(pTemp + tempBufferPos) = item.TransactionMarker;
                 tempBufferPos += sizeof(short);
+                
+                *(long*)(pTemp + tempBufferPos) = item.LastModifiedTicks;
+                tempBufferPos += sizeof(long);
 
                 *(int*)(pTemp + tempBufferPos) = item.Id.Size;
                 tempBufferPos += sizeof(int);
@@ -673,13 +677,14 @@ namespace Raven.Server.Documents.Replication
             fixed (byte* pTemp = _tempBuffer)
             {
                 var requiredSize = sizeof(byte) + // type
-                               sizeof(int) + // # of change vectors
-                               cv.Size +
-                               sizeof(short) + // transaction marker
-                               sizeof(int) + // size of key
-                               item.Id.Size +
-                               sizeof(int) + // size of collection
-                               item.Collection.Size;
+                                   sizeof(int) + // # of change vectors
+                                   cv.Size +
+                                   sizeof(short) + // transaction marker
+                                   sizeof(long) + // last modified
+                                   sizeof(int) + // size of key
+                                   item.Id.Size +
+                                   sizeof(int) + // size of collection
+                                   item.Collection.Size;
 
                 if (requiredSize > _tempBuffer.Length)
                     ThrowTooManyChangeVectorEntries(item);
@@ -695,6 +700,9 @@ namespace Raven.Server.Documents.Replication
 
                 *(short*)(pTemp + tempBufferPos) = item.TransactionMarker;
                 tempBufferPos += sizeof(short);
+
+                *(long*)(pTemp + tempBufferPos) = item.LastModifiedTicks;
+                tempBufferPos += sizeof(long);
 
                 *(int*)(pTemp + tempBufferPos) = item.Id.Size;
                 tempBufferPos += sizeof(int);

--- a/src/Raven.Server/Smuggler/Documents/DatabaseDestination.cs
+++ b/src/Raven.Server/Smuggler/Documents/DatabaseDestination.cs
@@ -458,7 +458,7 @@ namespace Raven.Server.Smuggler.Documents
                             switch (tombstone.Type)
                             {
                                 case DocumentTombstone.TombstoneType.Document:
-                                    _database.DocumentsStorage.Delete(context, key, tombstone.LowerId, null, null, changeVector, new CollectionName(tombstone.Collection));
+                                    _database.DocumentsStorage.Delete(context, key, tombstone.LowerId, null, tombstone.LastModified.Ticks, changeVector, new CollectionName(tombstone.Collection));
                                     break;
                                 case DocumentTombstone.TombstoneType.Attachment:
                                     var idEnd = key.Content.IndexOf(SpecialChars.RecordSeparator);
@@ -467,10 +467,10 @@ namespace Raven.Server.Smuggler.Documents
                                     var id = key.Content.Substring(idEnd);
                                     idsOfDocumentsToUpdateAfterAttachmentDeletion.Add(id);
 
-                                    _database.DocumentsStorage.AttachmentsStorage.DeleteAttachmentDirect(context, key, false, "$fromReplication", null, changeVector);
+                                    _database.DocumentsStorage.AttachmentsStorage.DeleteAttachmentDirect(context, key, false, "$fromReplication", null, changeVector, tombstone.LastModified.Ticks);
                                     break;
                                 case DocumentTombstone.TombstoneType.Revision:
-                                    _database.DocumentsStorage.RevisionsStorage.DeleteRevision(context, key, tombstone.Collection, changeVector);
+                                    _database.DocumentsStorage.RevisionsStorage.DeleteRevision(context, key, tombstone.Collection, changeVector, tombstone.LastModified.Ticks);
                                     break;
                             }
                         }

--- a/src/Raven.Server/Smuggler/Documents/DatabaseSmuggler.cs
+++ b/src/Raven.Server/Smuggler/Documents/DatabaseSmuggler.cs
@@ -11,7 +11,6 @@ using Raven.Server.Documents;
 using Raven.Server.Documents.Expiration;
 using Raven.Server.Documents.Indexes.Auto;
 using Raven.Server.Documents.Indexes.MapReduce.Auto;
-using Raven.Server.Routing;
 using Raven.Server.Smuggler.Documents.Data;
 using Raven.Server.Smuggler.Documents.Processors;
 using Sparrow.Json;

--- a/src/Raven.Server/Smuggler/Documents/StreamSource.cs
+++ b/src/Raven.Server/Smuggler/Documents/StreamSource.cs
@@ -766,7 +766,8 @@ namespace Raven.Server.Smuggler.Documents
                     var tombstone = new DocumentTombstone();
                     if (data.TryGet("Key", out tombstone.LowerId) &&
                         data.TryGet(nameof(DocumentTombstone.Type), out string type) &&
-                        data.TryGet(nameof(DocumentTombstone.Collection), out tombstone.Collection))
+                        data.TryGet(nameof(DocumentTombstone.Collection), out tombstone.Collection) &&
+                        data.TryGet(nameof(DocumentTombstone.LastModified), out tombstone.LastModified))
                     {
                         tombstone.Type = Enum.Parse<DocumentTombstone.TombstoneType>(type);
                         yield return tombstone;


### PR DESCRIPTION
…cation data between nodes.

Make sure to preserve the original last modified date of tombstones of documents, revisions and attachments when importing from smuggler and when getting them from replication.