### PR TITLE
RavenDB-10265 Database deletion generate a lot of raft commands

### DIFF
--- a/src/Raven.Server/Documents/Replication/ReplicationDocumentSender.cs
+++ b/src/Raven.Server/Documents/Replication/ReplicationDocumentSender.cs
@@ -495,14 +495,19 @@ namespace Raven.Server.Documents.Replication
             fixed (byte* pTemp = _tempBuffer)
             {
                 var requiredSize = sizeof(byte) + // type
-                              sizeof(int) + //  size of change vector
-                              cv.Size +
-                              sizeof(short) + // transaction marker
-                              sizeof(long) + // Last modified ticks
-                              sizeof(DocumentFlags) +
-                              sizeof(int) + // size of document ID
-                              item.Id.Size +
-                              sizeof(int); // size of document
+                                   sizeof(int) + //  size of change vector
+                                   cv.Size +
+                                   sizeof(short) + // transaction marker
+                                   sizeof(long) + // Last modified ticks
+                                   sizeof(DocumentFlags) +
+                                   sizeof(int) + // size of document ID
+                                   item.Id.Size +
+                                   sizeof(int); // size of document
+                
+                if (item.Collection != null)
+                {
+                    requiredSize += item.Collection.Size + sizeof(int);
+                }
 
                 if (requiredSize > _tempBuffer.Length)
                     ThrowTooManyChangeVectorEntries(item);
@@ -570,7 +575,7 @@ namespace Raven.Server.Documents.Replication
                     Memory.Copy(pTemp + tempBufferPos, item.Collection.Buffer, item.Collection.Size);
                     tempBufferPos += item.Collection.Size;
                 }
-
+                
                 _stream.Write(_tempBuffer, 0, tempBufferPos);
             }
         }

--- a/src/Raven.Server/ServerWide/ClusterStateMachine.cs
+++ b/src/Raven.Server/ServerWide/ClusterStateMachine.cs
@@ -420,7 +420,7 @@ namespace Raven.Server.ServerWide
             // ReSharper disable once UseNullPropagation
             if (leader == null)
                 return;
-
+            
             leader.SetStateOf(index, tcs => { tcs.TrySetException(e); });
         }
 
@@ -498,6 +498,7 @@ namespace Raven.Server.ServerWide
                     NotifyDatabaseChanged(context, databaseName, index, nameof(RemoveNodeFromDatabaseCommand));
                     return;
                 }
+                
                 remove.UpdateDatabaseRecord(databaseRecord, index);
 
                 if (databaseRecord.DeletionInProgress.Count == 0 && databaseRecord.Topology.Count == 0)
@@ -509,8 +510,6 @@ namespace Raven.Server.ServerWide
                 var updated = EntityToBlittable.ConvertEntityToBlittable(databaseRecord, DocumentConventions.Default, context);
 
                 UpdateValue(index, items, lowerKey, key, updated);
-
-                NotifyDatabaseChanged(context, databaseName, index, nameof(RemoveNodeFromDatabaseCommand));
             }
         }
 

--- a/src/Sparrow/Platform/Posix/PosixMemoryQueryMethods.cs
+++ b/src/Sparrow/Platform/Posix/PosixMemoryQueryMethods.cs
@@ -16,6 +16,7 @@ namespace Sparrow.Platform.Posix
 
             var vecSize = (int)((length + Syscall.PageSize - 1) / Syscall.PageSize);
 
+            var p = stackalloc IntPtr[2];
             IntPtr vec = IntPtr.Zero;
             char* pVec;
             if (vecSize > 4)
@@ -25,7 +26,6 @@ namespace Sparrow.Platform.Posix
             }
             else
             {
-                void *p = stackalloc IntPtr[(int)length];
                 pVec = (char*)p;
             }
 

--- a/src/Sparrow/Platform/Win32/Win32MemoryQueryMethods.cs
+++ b/src/Sparrow/Platform/Win32/Win32MemoryQueryMethods.cs
@@ -36,6 +36,7 @@ namespace Sparrow.Platform.Win32
 
             IntPtr wsInfo = IntPtr.Zero;
             PPSAPI_WORKING_SET_EX_INFORMATION* pWsInfo;
+            var p = stackalloc PPSAPI_WORKING_SET_EX_INFORMATION[2];
             if (pages > 2)
             {
                 wsInfo = Marshal.AllocHGlobal((int)(sizeof(PPSAPI_WORKING_SET_EX_INFORMATION)*pages));
@@ -43,7 +44,6 @@ namespace Sparrow.Platform.Win32
             }
             else
             {
-                var p = stackalloc PPSAPI_WORKING_SET_EX_INFORMATION[(int)pages];
                 pWsInfo = p;
             }
 


### PR DESCRIPTION
- Don't notify the database about database removal confermation, since it could trigger the pyshical deletion again if we recieved the confermation from a different node.
- Set 'Reached-Leader' header first, then do the rest.