### PR TITLE
RavenDB-7070

### DIFF
--- a/src/Raven.Server/Documents/TcpHandlers/SubscriptionConnection.cs
+++ b/src/Raven.Server/Documents/TcpHandlers/SubscriptionConnection.cs
@@ -2,7 +2,6 @@
 using System.Diagnostics;
 using System.IO;
 using System.Linq;
-using System.Reflection.PortableExecutable;
 using System.Text;
 using System.Threading;
 using System.Threading.Tasks;
@@ -133,7 +132,7 @@ namespace Raven.Server.Documents.TcpHandlers
             _connectionState = TcpConnection.DocumentDatabase.SubscriptionStorage.OpenSubscription(this);
             var timeout = TimeSpan.FromMilliseconds(16);
 
-            var shouldRetry = false;
+            bool shouldRetry;
             do
             {
                 try
@@ -265,13 +264,13 @@ namespace Raven.Server.Documents.TcpHandlers
                         }
                     });
                 }
-                catch (Exception e)
+                catch (Exception)
                 {
                     connection?.Dispose();
                     throw;
                 }
             }
-            catch (Exception e)
+            catch (Exception)
             {
                 tcpConnectionDisposable?.Dispose();
 

--- a/src/Raven.Server/Utils/Cli/RavenCli.cs
+++ b/src/Raven.Server/Utils/Cli/RavenCli.cs
@@ -342,8 +342,7 @@ namespace Raven.Server.Utils.Cli
 
         private static bool CommandGc(List<string> args, RavenCli cli)
         {
-            int genNum;
-            genNum = args == null || args.Count == 0 ? 2 : Convert.ToInt32(args.First());
+            var genNum = args == null || args.Count == 0 ? 2 : Convert.ToInt32(args.First());
 
             WriteText("Before collecting, managed memory used: ", TextColor, cli, newLine: false);
             WriteText(new Size(GC.GetTotalMemory(false), SizeUnit.Bytes).ToString(), ConsoleColor.Cyan, cli);
@@ -1068,8 +1067,6 @@ namespace Raven.Server.Utils.Cli
             [Command.Print] = new SingleAction { NumOfArgs = 1, DelegateFync = CommandPrint, Experimental = true }, // test cli
             [Command.ReplaceClusterCert] = new SingleAction { NumOfArgs = 2, DelegateFync = CommandReplaceClusterCert, Experimental = true }
         };
-
-        private LogMode _previousLogMode;
 
         public bool Start(RavenServer server, TextWriter textWriter, TextReader textReader, bool consoleColoring)
         {

--- a/src/Sparrow/Utils/NativeMemoryCleaner.cs
+++ b/src/Sparrow/Utils/NativeMemoryCleaner.cs
@@ -11,7 +11,10 @@ namespace Sparrow.Utils
         private readonly SharedMultipleUseFlag _lowMemoryFlag;
         private readonly TimeSpan _idleTime;
         private readonly Timer _timer;
+
+#if NETSTANDARD1_3
         private bool _disposed;
+#endif
 
         public NativeMemoryCleaner(ThreadLocal<TStack> pool, SharedMultipleUseFlag lowMemoryFlag, TimeSpan period, TimeSpan idleTime)
         {
@@ -30,8 +33,10 @@ namespace Sparrow.Utils
                 if (lockTaken == false)
                     return;
 
+#if NETSTANDARD1_3
                 if (_disposed)
                     return;
+#endif
 
                 var now = DateTime.UtcNow;
                 foreach (var header in _pool.Values)
@@ -93,7 +98,7 @@ namespace Sparrow.Utils
                 }
             }
 #else
-            lock(_lock) // prevent from running the callback _after_ dispose
+            lock (_lock) // prevent from running the callback _after_ dispose
             {
                 _disposed = true;
                 _timer.Dispose();


### PR DESCRIPTION
- fixed: cannot change tuple element names when overriding inherited member 'RachisStateMachine.ConnectToPeer(string, X509Certificate2)'
- fixed few warnings