### PR TITLE
RavenDB-10307 When loading to different collection we need to change …

### DIFF
--- a/src/Raven.Server/Documents/ETL/Providers/Raven/RavenEtlDocumentTransformer.cs
+++ b/src/Raven.Server/Documents/ETL/Providers/Raven/RavenEtlDocumentTransformer.cs
@@ -31,7 +31,9 @@ namespace Raven.Server.Documents.ETL.Providers.Raven
         {
             if (collectionName == null)
                 ThrowLoadParameterIsMandatory(nameof(collectionName));
+            
             string id;
+            var loadedToDifferentCollection = false;
 
             if (_script.IsLoadedToDefaultCollection(Current, collectionName))
             {
@@ -40,11 +42,12 @@ namespace Raven.Server.Documents.ETL.Providers.Raven
             else
             {
                 id = GetPrefixedId(Current.DocumentId, collectionName);
+                loadedToDifferentCollection = true;
             }
 
             var metadata = document.GetOrCreate(Constants.Documents.Metadata.Key);
             
-            if (metadata.HasProperty(Constants.Documents.Metadata.Collection) == false)
+            if (loadedToDifferentCollection || metadata.HasProperty(Constants.Documents.Metadata.Collection) == false)
                 metadata.Put(Constants.Documents.Metadata.Collection, collectionName, false);
 
             if (metadata.HasProperty(Constants.Documents.Metadata.Id) == false)

--- a/src/Raven.Server/Documents/Patch/BlittableObjectInstance.cs
+++ b/src/Raven.Server/Documents/Patch/BlittableObjectInstance.cs
@@ -43,7 +43,10 @@ namespace Raven.Server.Documents.Patch
                 value = new BlittableObjectProperty(this, key);
                 if (propertyIndex == -1)
                 {
-                    value.Value = new JsValue(new ObjectInstance(Engine));
+                    value.Value = new JsValue(new ObjectInstance(Engine)
+                    {
+                        Extensible = true
+                    });
                 }
                 OwnValues[key] = value;
                 Deletes?.Remove(key);


### PR DESCRIPTION
…@collection metadata. Allow to extend newly created JS object.