### PR TITLE
RavenDB-10309

### DIFF
--- a/src/Raven.Server/Documents/Replication/ReplicationDocumentSender.cs
+++ b/src/Raven.Server/Documents/Replication/ReplicationDocumentSender.cs
@@ -230,8 +230,8 @@ namespace Raven.Server.Documents.Replication
                             else if (item.Type == ReplicationBatchItem.ReplicationItemType.Attachment)
                                 size += item.Stream.Length;
 
-                            if (AddReplicationItemToBatch(item, _stats.Storage, skippedReplicationItemsInfo))
-                                numberOfItemsSent++;
+                            if (AddReplicationItemToBatch(item, _stats.Storage, skippedReplicationItemsInfo) == false)
+                                continue;
 
                             numberOfItemsSent++;
                         }


### PR DESCRIPTION
* Now properly set the destination CV when starting outgoing replication
* Will break outgoing replication if canceled during idle time
* Will send an heartbeat if we had no modifications outside the replication and only send documents if our prev CV was not already merged by the current CV of the destination
* Will correctly update number of items sent