### PR TITLE
RavenDB-10371 Minor: We need the directory name as the index name (no…

### DIFF
--- a/src/Raven.Server/Documents/Indexes/Index.cs
+++ b/src/Raven.Server/Documents/Indexes/Index.cs
@@ -252,7 +252,7 @@ namespace Raven.Server.Documents.Indexes
         {
             StorageEnvironment environment = null;
 
-            var name = Path.GetDirectoryName(path);
+            var name = new DirectoryInfo(path).Name;
             var indexPath = path;
 
             var indexTempPath =


### PR DESCRIPTION
…t the full directory path of parent dir). It's used only for logging