### PR TITLE
RavenDB-10375 We need to use the commit charge, rather than the memor…

### DIFF
--- a/src/Raven.Server/Dashboard/MachineResourcesNotificationSender.cs
+++ b/src/Raven.Server/Dashboard/MachineResourcesNotificationSender.cs
@@ -67,6 +67,7 @@ namespace Raven.Server.Dashboard
                         ? currentProcess.WorkingSet64
                         : MemoryInformation.GetRssMemoryUsage(currentProcess.Id);
                 var memoryInfoResult = MemoryInformation.GetMemoryInfo(useFreeInsteadOfAvailable: true); // useFreeInsteadOfAvailable for presentation only (for low mem we still use "available mem")
+                var committedMemory = memoryInfoResult.CurrentCommitCharge.GetValue(SizeUnit.Bytes);
                 var installedMemory = memoryInfoResult.InstalledMemory.GetValue(SizeUnit.Bytes);
                 var availableMemory = memoryInfoResult.AvailableMemory.GetValue(SizeUnit.Bytes);
                 var mappedSharedMem = LowMemoryNotification.GetCurrentProcessMemoryMappedShared();
@@ -78,7 +79,7 @@ namespace Raven.Server.Dashboard
                 {
                     TotalMemory = installedMemory,
                     MachineMemoryUsage = installedMemory - availableMemory,
-                    ProcessMemoryUsage = workingSet,
+                    ProcessMemoryUsage = committedMemory < installedMemory - availableMemory ? committedMemory : workingSet,
                     ProcessMemoryExcludingSharedUsage = Math.Max(workingSet - shared, 0),
                     MachineCpuUsage = cpuInfo.MachineCpuUsage,
                     ProcessCpuUsage = Math.Min(cpuInfo.MachineCpuUsage, cpuInfo.ProcessCpuUsage) // min as sometimes +-1% due to time sampling


### PR DESCRIPTION
…y utilization, for low memory

We consider low memory only if we don't have enough free pyhsical memory *AND* the commited memory size if larger than our pyhsical memory.
This is to ensure that from one hand we don't hit the disk to do page faults and from the other hand
we don't want to stay in low memory due to retained memory.