### PR TITLE
RavenDB-10382 / RavenDB-10371 Handle the case that after decompressio…

### DIFF
--- a/src/Voron/Data/BTrees/TreeRebalancer.cs
+++ b/src/Voron/Data/BTrees/TreeRebalancer.cs
@@ -386,7 +386,15 @@ namespace Voron.Data.BTrees
                     decompressedLeafPage?.Dispose();
                     decompressedLeafPage = _tree.DecompressPage(page, skipCache: true);
 
-                    node = decompressedLeafPage.GetNode(0);
+                    if (decompressedLeafPage.NumberOfEntries > 0)
+                        node = decompressedLeafPage.GetNode(0);
+                    else
+                    {
+                        // we have empty page after decompression (each compressed entry has a corresponding CompressionTombstone)
+                        // we can safely use the node key of first tombstone (they have proper order)
+
+                        node = page.GetNode(0);
+                    }
                 }
 
                 scope.Dispose();


### PR DESCRIPTION
…n we might get an empty page. Let's use first key of compressed entry then. (Removal of empty compressed pages is called by the reducer explicitly using Tree.RemoveEmptyDecompressedPage)