### PR TITLE
RavenDB-10424 - A write transaction is already opened by another thread with the same id

### DIFF
--- a/src/Raven.Server/Documents/CollectionRunner.cs
+++ b/src/Raven.Server/Documents/CollectionRunner.cs
@@ -5,6 +5,7 @@ using System.Threading.Tasks;
 using Raven.Client;
 using Raven.Client.Documents.Operations;
 using Raven.Client.Util.RateLimiting;
+using Raven.Server.Documents.Handlers;
 using Raven.Server.Documents.Patch;
 using Raven.Server.Documents.Queries;
 using Raven.Server.Documents.TransactionCommands;
@@ -86,7 +87,7 @@ namespace Raven.Server.Documents
 
                             token.Delay();
 
-                            if (isAllDocs && IsHiLoDocument(document))
+                            if (isAllDocs && document.Id.StartsWith(HiLoHandler.RavenHiloIdPrefix, StringComparison.OrdinalIgnoreCase))
                                 continue;
 
                             if (document.Etag > lastEtag) // we don't want to go over the documents that we have patched
@@ -130,12 +131,6 @@ namespace Raven.Server.Documents
             {
                 Total = progress.Processed
             };
-        }
-
-        private static bool IsHiLoDocument(Document document)
-        {
-            var collection = CollectionName.GetCollectionName(document.Data);
-            return CollectionName.IsHiLoCollection(collection);
         }
 
         protected virtual IEnumerable<Document> GetDocuments(DocumentsOperationContext context, string collectionName, long startEtag, int batchSize, bool isAllDocs)

--- a/src/Raven.Server/Documents/Replication/ConflictManager.cs
+++ b/src/Raven.Server/Documents/Replication/ConflictManager.cs
@@ -3,6 +3,7 @@ using System.Collections.Generic;
 using System.IO;
 using System.Linq;
 using Raven.Client.ServerWide;
+using Raven.Server.Documents.Handlers;
 using Raven.Server.ServerWide.Context;
 using Raven.Server.Utils;
 using Sparrow.Json;
@@ -35,7 +36,7 @@ namespace Raven.Server.Documents.Replication
             string conflictedChangeVector,
             DocumentFlags flags)
         {
-            if (id.StartsWith("Raven/Hilo/", StringComparison.OrdinalIgnoreCase))
+            if (id.StartsWith(HiLoHandler.RavenHiloIdPrefix, StringComparison.OrdinalIgnoreCase))
             {
                 HandleHiloConflict(documentsContext, id, doc, changeVector);
                 return;

--- a/src/Raven.Server/Documents/TransactionOperationsMerger.cs
+++ b/src/Raven.Server/Documents/TransactionOperationsMerger.cs
@@ -314,22 +314,18 @@ namespace Raven.Server.Documents
                     }
                     catch (Exception e)
                     {
-                        try
+                        if (_log.IsInfoEnabled)
                         {
-                            if (_log.IsInfoEnabled)
-                            {
-                                _log.Info(
-                                    $"Failed to run merged transaction with {pendingOps.Count:#,#0}, will retry independently",
-                                    e);
-                            }
+                            _log.Info(
+                                $"Failed to run merged transaction with {pendingOps.Count:#,#0}, will retry independently",
+                                e);
+                        }
 
-                            NotifyTransactionFailureAndRerunIndependently(pendingOps, e);
-                            return;
-                        }
-                        finally
-                        {
-                            tx?.Dispose();
-                        }
+                        // need to dispose here since we are going to open new tx for each operation
+                        tx?.Dispose();
+
+                        NotifyTransactionFailureAndRerunIndependently(pendingOps, e);
+                        return;
                     }
 
                     switch (result)


### PR DESCRIPTION
http://issues.hibernatingrhinos.com/issue/RavenDB-10424