### PR TITLE
Upgrade xunit: 2.4.0-beta1-build3909 -> 2.4.0-beta.1.build3958

### DIFF
--- a/bench/Micro.Benchmark/Micro.Benchmark.csproj
+++ b/bench/Micro.Benchmark/Micro.Benchmark.csproj
@@ -14,7 +14,7 @@
   </ItemGroup>
   <ItemGroup>
     <PackageReference Include="BenchmarkDotNet" Version="0.10.12" />
-    <PackageReference Include="xunit" Version="2.4.0-beta1-build3909" />
+    <PackageReference Include="xunit" Version="2.4.0-beta.1.build3958" />
   </ItemGroup>
   <ItemGroup>
     <ProjectReference Include="..\..\src\Voron\Voron.csproj" />

--- a/bench/Regression.Benchmark/Regression.Benchmark.csproj
+++ b/bench/Regression.Benchmark/Regression.Benchmark.csproj
@@ -16,10 +16,10 @@
   </ItemGroup>
   <ItemGroup>
     <PackageReference Include="Microsoft.NET.Test.Sdk" Version="15.5.0" />
-    <PackageReference Include="xunit.runner.visualstudio" Version="2.4.0-beta1-build3909" />
+    <PackageReference Include="xunit.runner.visualstudio" Version="2.4.0-beta.1.build3958" />
     <PackageReference Include="Microsoft.DotNet.xunit.performance" Version="1.0.0-alpha-build0041" />
     <PackageReference Include="Microsoft.DotNet.xunit.performance.runner.cli" Version="1.0.0-alpha-build0041" />
-    <PackageReference Include="xunit" Version="2.4.0-beta1-build3909" />
+    <PackageReference Include="xunit" Version="2.4.0-beta.1.build3958" />
   </ItemGroup>
   <ItemGroup>
     <ProjectReference Include="..\..\src\Raven.Client\Raven.Client.csproj" />

--- a/test/FastTests/FastTests.csproj
+++ b/test/FastTests/FastTests.csproj
@@ -39,9 +39,9 @@
   <ItemGroup>
     <PackageReference Include="Microsoft.NET.Test.Sdk" Version="15.5.0" />
     <PackageReference Include="NodaTime" Version="2.2.4" />
-    <PackageReference Include="xunit.runner.visualstudio" Version="2.4.0-beta1-build3909" />
-    <PackageReference Include="xunit" Version="2.4.0-beta1-build3909" />
-    <DotNetCliToolReference Include="dotnet-xunit" Version="2.4.0-beta1-build3909" />
+    <PackageReference Include="xunit.runner.visualstudio" Version="2.4.0-beta.1.build3958" />
+    <PackageReference Include="xunit" Version="2.4.0-beta.1.build3958" />
+    <DotNetCliToolReference Include="dotnet-xunit" Version="2.4.0-beta.1.build3958" />
   </ItemGroup>
   <ItemGroup>
     <Service Include="{82a7f48d-3b50-4b1e-b82e-3ada8210c358}" />

--- a/test/RachisTests/RachisTests.csproj
+++ b/test/RachisTests/RachisTests.csproj
@@ -32,9 +32,9 @@
   </ItemGroup>
   <ItemGroup>
     <PackageReference Include="Microsoft.NET.Test.Sdk" Version="15.5.0" />
-    <PackageReference Include="xunit" Version="2.4.0-beta1-build3909" />
-    <PackageReference Include="xunit.runner.visualstudio" Version="2.4.0-beta1-build3909" />
-    <DotNetCliToolReference Include="dotnet-xunit" Version="2.4.0-beta1-build3909" />
+    <PackageReference Include="xunit" Version="2.4.0-beta.1.build3958" />
+    <PackageReference Include="xunit.runner.visualstudio" Version="2.4.0-beta.1.build3958" />
+    <DotNetCliToolReference Include="dotnet-xunit" Version="2.4.0-beta.1.build3958" />
   </ItemGroup>
   <ItemGroup>
     <Service Include="{82a7f48d-3b50-4b1e-b82e-3ada8210c358}" />

--- a/test/SlowTests/SlowTests.csproj
+++ b/test/SlowTests/SlowTests.csproj
@@ -48,9 +48,9 @@
   </ItemGroup>
   <ItemGroup>
     <PackageReference Include="Microsoft.NET.Test.Sdk" Version="15.5.0" />
-    <PackageReference Include="xunit.runner.visualstudio" Version="2.4.0-beta1-build3909" />
-    <PackageReference Include="xunit" Version="2.4.0-beta1-build3909" />
-    <DotNetCliToolReference Include="dotnet-xunit" Version="2.4.0-beta1-build3909" />
+    <PackageReference Include="xunit.runner.visualstudio" Version="2.4.0-beta.1.build3958" />
+    <PackageReference Include="xunit" Version="2.4.0-beta.1.build3958" />
+    <DotNetCliToolReference Include="dotnet-xunit" Version="2.4.0-beta.1.build3958" />
   </ItemGroup>
   <ItemGroup>
     <Service Include="{82a7f48d-3b50-4b1e-b82e-3ada8210c358}" />

--- a/test/StressTests/StressTests.csproj
+++ b/test/StressTests/StressTests.csproj
@@ -33,9 +33,9 @@
   </ItemGroup>
   <ItemGroup>
     <PackageReference Include="Microsoft.NET.Test.Sdk" Version="15.5.0" />
-    <PackageReference Include="xunit.runner.visualstudio" Version="2.4.0-beta1-build3909" />
-    <PackageReference Include="xunit" Version="2.4.0-beta1-build3909" />
-    <DotNetCliToolReference Include="dotnet-xunit" Version="2.4.0-beta1-build3909" />
+    <PackageReference Include="xunit.runner.visualstudio" Version="2.4.0-beta.1.build3958" />
+    <PackageReference Include="xunit" Version="2.4.0-beta.1.build3958" />
+    <DotNetCliToolReference Include="dotnet-xunit" Version="2.4.0-beta.1.build3958" />
   </ItemGroup>
   <ItemGroup>
     <Service Include="{82a7f48d-3b50-4b1e-b82e-3ada8210c358}" />

--- a/test/Tests.Infrastructure/Tests.Infrastructure.csproj
+++ b/test/Tests.Infrastructure/Tests.Infrastructure.csproj
@@ -16,7 +16,7 @@
     <Compile Include="..\..\src\CommonAssemblyInfo.cs" Link="Properties\CommonAssemblyInfo.cs" />
   </ItemGroup>
   <ItemGroup>
-    <PackageReference Include="xunit" Version="2.4.0-beta1-build3909" />
+    <PackageReference Include="xunit" Version="2.4.0-beta.1.build3958" />
   </ItemGroup>
   <ItemGroup>
     <ProjectReference Include="..\..\src\Raven.Client\Raven.Client.csproj" />


### PR DESCRIPTION
`xunit 2.4.0-beta1-build3909` is no longer available on MyGet, so it's impossible to restore packages locally (if you don't have them in NuGet cache).
`xunit 2.4.0-beta.1.build3958` is the official release of xunit 2.4-beta1 which is available on both nuget.org and myget.org

See also:
* https://xunit.github.io/releases/2.4-beta1
* https://www.nuget.org/packages/xunit/2.4.0-beta.1.build3958
* https://myget.org/feed/xunit/package/nuget/xunit/2.4.0-beta.1.build3958