### PR TITLE
Make unit test for RavenDB-2129 reliable

### DIFF
--- a/Raven.Tests.Issues/RavenDB_2129.cs
+++ b/Raven.Tests.Issues/RavenDB_2129.cs
@@ -34,12 +34,16 @@ namespace Raven.Tests.Issues
                 RunReplication(store1, store2, db: "SomeDB");
 
                 SystemTime.UtcDateTime = () => DateTime.UtcNow.AddMinutes(10); // this will force replication information update when session is opened
+                
+                await store1.GetReplicationInformerForDatabase("SomeDB")
+                    .UpdateReplicationInformationIfNeededAsync((AsyncServerClient)store1.AsyncDatabaseCommands.ForDatabase("SomeDB"),force:true);                    
 
                 using (var session = store1.OpenAsyncSession("SomeDB"))
                 {
                     await session.StoreAsync(new Person { Name = "Person1" });
                     await session.SaveChangesAsync();
                 }
+                
 
                 WaitForReplication(store2, "people/1", db: "SomeDB");
 


### PR DESCRIPTION
fix race condition in the test - if client doesn't have enough time to fetch topology, the test would fail