### PR TITLE
RavenDB-10550 WaitForIndexesAfterSaveChanges honors throwOnTimeout

### DIFF
--- a/src/Raven.Client/Documents/Commands/Batches/BatchCommand.cs
+++ b/src/Raven.Client/Documents/Commands/Batches/BatchCommand.cs
@@ -124,10 +124,7 @@ namespace Raven.Client.Documents.Commands.Batches
             if (_options.WaitForIndexes)
             {
                 sb.Append("&waitForIndexesTimeout=").Append(_options.WaitForIndexesTimeout);
-                if (_options.ThrowOnTimeoutInWaitForIndexes)
-                {
-                    sb.Append("&waitForIndexThrow=true");
-                }
+                sb.Append("&waitForIndexThrow=").Append(_options.ThrowOnTimeoutInWaitForIndexes ? "true" : "false");
                 if (_options.WaitForSpecificIndexes != null)
                 {
                     foreach (var specificIndex in _options.WaitForSpecificIndexes)


### PR DESCRIPTION
Previously it would honor this flag only if set to true. Now it honors the flag regardless of the value.