### PR TITLE
[4.1] RavenDB-10547 Avoid clearing fields that other callers might use dur…

### DIFF
--- a/src/Raven.Server/Documents/DocumentsStorage.cs
+++ b/src/Raven.Server/Documents/DocumentsStorage.cs
@@ -194,13 +194,11 @@ namespace Raven.Server.Documents
             exceptionAggregator.Execute(() =>
             {
                 ContextPool?.Dispose();
-                ContextPool = null;
             });
 
             exceptionAggregator.Execute(() =>
             {
                 Environment?.Dispose();
-                Environment = null;
             });
 
             exceptionAggregator.ThrowIfNeeded();


### PR DESCRIPTION
…ing the db shutdown. ContextPool is going to throw OperationCancelledException if someone tries to allocate a context from the already disposed pool. Environment will also throw OperationCancelledException on attempt to create a transaction if is is already disposed.