### PR TITLE
[4.1] RavenDB-10575 Fixing race condition in test. We need to check if the …

### DIFF
--- a/src/Raven.Server/Documents/Indexes/Index.cs
+++ b/src/Raven.Server/Documents/Indexes/Index.cs
@@ -1009,6 +1009,9 @@ namespace Raven.Server.Documents.Indexes
                                 _didWork = true;
                                 _firstBatchTimeout = null;
                             }
+                            
+                            var batchCompletedAction = DocumentDatabase.IndexStore.IndexBatchCompleted;
+                            batchCompletedAction?.Invoke((Name, didWork));
                         }
 
                         try

--- a/src/Raven.Server/Documents/Indexes/IndexStore.cs
+++ b/src/Raven.Server/Documents/Indexes/IndexStore.cs
@@ -51,6 +51,8 @@ namespace Raven.Server.Documents.Indexes
 
         public SemaphoreSlim StoppedConcurrentIndexBatches { get; }
 
+        internal Action<(string IndexName, bool DidWork)> IndexBatchCompleted;
+
         public IndexStore(DocumentDatabase documentDatabase, ServerStore serverStore)
         {
             _documentDatabase = documentDatabase;

--- a/test/SlowTests/Issues/RavenDB_8847.cs
+++ b/test/SlowTests/Issues/RavenDB_8847.cs
@@ -1,4 +1,5 @@
-﻿using System.Linq;
+﻿using System;
+using System.Linq;
 using FastTests;
 using Raven.Client.Documents.Indexes;
 using Raven.Client.Documents.Operations.Indexes;
@@ -42,11 +43,14 @@ namespace SlowTests.Issues
 
                     session.Query<User>().Customize(x => x.WaitForNonStaleResults()).Where(x => x.Name != "ema").ToList();
 
+                    WaitForIndexBatchCompleted(store, x => x.DidWork).Wait(TimeSpan.FromSeconds(2));
+
+                    // ensure the timeout was reset after the run completed
                     Assert.False(index._firstBatchTimeout.HasValue);
                 }
             }
         }
-
+        
         [Fact]
         public void Should_set_first_batch_timeout_of_newly_created_static_index()
         {
@@ -89,6 +93,9 @@ namespace SlowTests.Issues
 
                     session.Query<User>(usersByname).Customize(x => x.WaitForNonStaleResults()).Where(x => x.Name != "ema").ToList();
 
+                    WaitForIndexBatchCompleted(store, x => x.DidWork).Wait(TimeSpan.FromSeconds(2));
+
+                    // ensure the timeout was reset after the run completed
                     Assert.False(index._firstBatchTimeout.HasValue);
                 }
             }

--- a/test/Tests.Infrastructure/RavenTestBase.cs
+++ b/test/Tests.Infrastructure/RavenTestBase.cs
@@ -483,6 +483,21 @@ namespace FastTests
             } while (documentStore.Commands().Head("Debug/Done") == null && (debug == false || Debugger.IsAttached));
         }
 
+        protected ManualResetEventSlim WaitForIndexBatchCompleted(IDocumentStore store, Func<(string IndexName, bool DidWork), bool> predicate)
+        {
+            var database = GetDatabase(store.Database).Result;
+
+            var mre = new ManualResetEventSlim();
+
+            database.IndexStore.IndexBatchCompleted += x =>
+            {
+                if (predicate(x))
+                    mre.Set();
+            };
+
+            return mre;
+        }
+
         protected override void Dispose(ExceptionAggregator exceptionAggregator)
         {
             foreach (var store in CreatedStores)


### PR DESCRIPTION
…_firstBatchTimeout was reset _after_ the indexing batch completed (the query might return earlier)