### PR TITLE
[4.1] RavenDB-10625: Incorrect translation of grouped null-coalescing

### DIFF
--- a/src/Raven.Client/Util/JavascriptConversionExtensions.cs
+++ b/src/Raven.Client/Util/JavascriptConversionExtensions.cs
@@ -1078,16 +1078,17 @@ namespace Raven.Client.Util
                     return;
 
                 context.PreventDefault();
-                var writer = context.GetWriter();
 
-                using (writer.Operation(binaryExpression))
-                {
-                    context.Visitor.Visit(binaryExpression.Left);
-                    writer.Write(" != null ? ");
-                    context.Visitor.Visit(binaryExpression.Left);
-                    writer.Write(" : ");
-                    context.Visitor.Visit(binaryExpression.Right);
-                }
+                var test = Expression.NotEqual(
+                        binaryExpression.Left,
+                        Expression.Constant(null, binaryExpression.Left.Type)
+                    );
+
+                var condition = Expression.Condition(test, 
+                    binaryExpression.Left, 
+                    Expression.Convert(binaryExpression.Right, binaryExpression.Left.Type));
+
+                context.Visitor.Visit(condition);
             }
         }
 

--- a/test/FastTests/Issues/RavenDB-10625.cs
+++ b/test/FastTests/Issues/RavenDB-10625.cs
@@ -40,11 +40,17 @@ namespace SlowTests.Issues
                                     CheckGroup5 = x.Quantity != null ? x.Quantity : 0,
                                 }; 
                     
-                    //Assert.Equal("from Articles as x select { HasProperties : x.Properties.length > 0 }", query.ToString());
+                    Assert.Equal("declare function output(x) {\r\n\tvar test = 1;\r\n\treturn { CheckGroup : ((x.Quantity!=null?x.Quantity:0)!==0?2:3)===2?1:0, CheckGroup1 : (x.Quantity==null?1:2)===1?1:2, CheckGroup2 : x.Quantity!=null?x.Quantity:0, CheckGroup3 : x.Quantity!=null?x.Quantity:0, CheckGroup4 : (x.Quantity!=null?x.Quantity:0)!==0?2:3, CheckGroup5 : x.Quantity!=null?x.Quantity:0 };\r\n}\r\nfrom Articles as x select output(x)", query.ToString());
 
                     var result = query.ToList();
                     
                     Assert.Equal(1, result.Count);
+                    Assert.Equal(0, result[0].CheckGroup);
+                    Assert.Equal(1, result[0].CheckGroup1);
+                    Assert.Equal(0, result[0].CheckGroup2);
+                    Assert.Equal(0, result[0].CheckGroup3);
+                    Assert.Equal(3, result[0].CheckGroup4);
+                    Assert.Equal(0, result[0].CheckGroup5);
 
                 }                              
             }

--- a/test/FastTests/Issues/RavenDB-10625.cs
+++ b/test/FastTests/Issues/RavenDB-10625.cs
@@ -1,0 +1,54 @@
+﻿using System.Collections.Generic;
+using System.Linq;
+using FastTests;
+using Xunit;
+
+namespace SlowTests.Issues
+{
+    public class RavenDB_10625: RavenTestBase
+    {        
+        private class Article
+        {
+            public int? Quantity { get; set; }
+        }
+                        
+        [Fact]
+        public void CanTranslateGroupsCorrectly()
+        {             
+            using (var store = GetDocumentStore())
+            {             
+                using (var session = store.OpenSession())
+                {
+                    session.Store(new Article
+                    {
+                        
+                    });
+                    session.SaveChanges();
+                }
+                                
+                using (var session = store.OpenSession())
+                {
+                    var query = from x in session.Query<Article>()
+                                let test = 1
+                                select new
+                                {
+                                    CheckGroup = ((x.Quantity ?? 0) != 0 ? 2 : 3) == 2 ? 1 : 0,
+                                    CheckGroup1 = (x.Quantity == null ? 1 : 2) == 1 ? 1 : 2,
+                                    CheckGroup2 = (x.Quantity ?? 0),
+                                    CheckGroup3 = x.Quantity ?? 0,
+                                    CheckGroup4 = ((x.Quantity ?? 0)) != 0 ? 2 : 3,
+                                    CheckGroup5 = x.Quantity != null ? x.Quantity : 0,
+                                }; 
+                    
+                    //Assert.Equal("from Articles as x select { HasProperties : x.Properties.length > 0 }", query.ToString());
+
+                    var result = query.ToList();
+                    
+                    Assert.Equal(1, result.Count);
+
+                }                              
+            }
+        }
+                        
+    }
+}


### PR DESCRIPTION
Rewritten to use ConditionalExpression, (since this is being done normally by this function), which has Nested support. Since the outcome is the same, I think this method better, since it uses the code already there instead of creating it once again.