### PR TITLE
[4.0] RavenDB-10637

### DIFF
--- a/src/Raven.Client/Documents/Linq/IRavenQueryProvider.cs
+++ b/src/Raven.Client/Documents/Linq/IRavenQueryProvider.cs
@@ -79,11 +79,6 @@ namespace Raven.Client.Documents.Linq
         Lazy<Task<int>> CountLazilyAsync<T>(Expression expression, CancellationToken token = default(CancellationToken));
 
         /// <summary>
-        /// Move the registered after query actions
-        /// </summary>
-        void MoveAfterQueryExecuted<T>(IAsyncDocumentQuery<T> documentQuery);
-
-        /// <summary>
         /// Set the fields to fetch
         /// </summary>
         HashSet<FieldToFetch> FieldsToFetch { get; }

--- a/src/Raven.Client/Documents/Linq/RavenQueryProvider.cs
+++ b/src/Raven.Client/Documents/Linq/RavenQueryProvider.cs
@@ -222,15 +222,6 @@ namespace Raven.Client.Documents.Linq
         }
 
         /// <summary>
-        /// Move the registered after query actions
-        /// </summary>
-        public void MoveAfterQueryExecuted<TK>(IAsyncDocumentQuery<TK> documentQuery)
-        {
-            if (_afterQueryExecuted != null)
-                documentQuery.AfterQueryExecuted(_afterQueryExecuted);
-        }
-
-        /// <summary>
         /// Convert the expression to a Lucene query
         /// </summary>
         public IAsyncDocumentQuery<TResult> ToAsyncDocumentQuery<TResult>(Expression expression)
@@ -250,9 +241,6 @@ namespace Raven.Client.Documents.Linq
             var processor = GetQueryProviderProcessor<TS>();
             var query = processor.GetDocumentQueryFor(expression);
 
-            if (_afterQueryExecuted != null)
-                query.AfterQueryExecuted(_afterQueryExecuted);
-
             if (FieldsToFetch.Count > 0)
             {
                 var (fields, projections) = processor.GetProjections();
@@ -271,9 +259,6 @@ namespace Raven.Client.Documents.Linq
             var processor = GetQueryProviderProcessor<TS>();
             var query = processor.GetAsyncDocumentQueryFor(expression);
 
-            if (_afterQueryExecuted != null)
-                query.AfterQueryExecuted(_afterQueryExecuted);
-
             if (FieldsToFetch.Count > 0)
             {
                 var (fields, projections) = processor.GetProjections();
@@ -291,6 +276,7 @@ namespace Raven.Client.Documents.Linq
         {
             var processor = GetQueryProviderProcessor<TS>();
             var query = processor.GetDocumentQueryFor(expression);
+
             return query.CountLazily();
         }
 
@@ -302,6 +288,7 @@ namespace Raven.Client.Documents.Linq
         {
             var processor = GetQueryProviderProcessor<TS>();
             var query = processor.GetAsyncDocumentQueryFor(expression);
+
             return query.CountLazilyAsync(token);
         }
 

--- a/src/Raven.Client/Documents/Linq/RavenQueryProviderProcessor.cs
+++ b/src/Raven.Client/Documents/Linq/RavenQueryProviderProcessor.cs
@@ -2588,6 +2588,9 @@ The recommended method is to use full text search (mark the field as Analyzed an
         public IDocumentQuery<T> GetDocumentQueryFor(Expression expression)
         {
             var documentQuery = QueryGenerator.Query<T>(IndexName, _collectionName, _isMapReduce);
+            if (_afterQueryExecuted != null)
+                documentQuery.AfterQueryExecuted(_afterQueryExecuted);
+
             _documentQuery = (IAbstractDocumentQuery<T>)documentQuery;
 
             try
@@ -2624,6 +2627,9 @@ The recommended method is to use full text search (mark the field as Analyzed an
         public IAsyncDocumentQuery<T> GetAsyncDocumentQueryFor(Expression expression)
         {
             var asyncDocumentQuery = QueryGenerator.AsyncQuery<T>(IndexName, _collectionName, _isMapReduce);
+            if (_afterQueryExecuted != null)
+                asyncDocumentQuery.AfterQueryExecuted(_afterQueryExecuted);
+
             _documentQuery = (IAbstractDocumentQuery<T>)asyncDocumentQuery;
             try
             {
@@ -2693,8 +2699,6 @@ The recommended method is to use full text search (mark the field as Analyzed an
 
             var executeQuery = GetQueryResult(finalQuery);
 
-            var queryResult = finalQuery.GetQueryResult();
-            _afterQueryExecuted?.Invoke(queryResult);
             return executeQuery;
         }
 

--- a/src/Raven.Client/Documents/LinqExtensions.cs
+++ b/src/Raven.Client/Documents/LinqExtensions.cs
@@ -287,12 +287,11 @@ namespace Raven.Client.Documents
             return provider.CountLazily<T>(source.Expression);
         }
 
-
         /// <summary>
         /// Register the query as a lazy-count query in the session and return a lazy
         /// instance that will evaluate the query only when needed
         /// </summary>
-        public static Lazy<Task<int>> CountLazilyAsync<T>(this IQueryable<T> source, CancellationToken token = default(CancellationToken))
+        public static Lazy<Task<int>> CountLazilyAsync<T>(this IQueryable<T> source, CancellationToken token = default)
         {
             if (source == null)
                 throw new ArgumentNullException(nameof(source));
@@ -308,14 +307,13 @@ namespace Raven.Client.Documents
         /// <summary>
         /// Returns a list of results for a query asynchronously. 
         /// </summary>
-        public static Task<List<T>> ToListAsync<T>(this IQueryable<T> source, CancellationToken token = default(CancellationToken))
+        public static Task<List<T>> ToListAsync<T>(this IQueryable<T> source, CancellationToken token = default)
         {
             var provider = source.Provider as IRavenQueryProvider;
             if (provider == null)
                 throw new ArgumentException("You can only use Raven Queryable with ToListAsync");
 
             var documentQuery = provider.ToAsyncDocumentQuery<T>(source.Expression);
-            provider.MoveAfterQueryExecuted(documentQuery);
             return documentQuery.ToListAsync(token);
         }
 
@@ -339,7 +337,7 @@ namespace Raven.Client.Documents
         /// <exception cref="ArgumentNullException">
         /// source is null.
         /// </exception>
-        public static async Task<bool> AnyAsync<TSource>(this IQueryable<TSource> source, CancellationToken token = default(CancellationToken))
+        public static Task<bool> AnyAsync<TSource>(this IQueryable<TSource> source, CancellationToken token = default)
         {
             if (source == null)
                 throw new ArgumentNullException(nameof(source));
@@ -349,15 +347,9 @@ namespace Raven.Client.Documents
             if (provider == null)
                 throw new InvalidOperationException("AnyAsync only be used with IRavenQueryable");
 
-            var query = provider.ToAsyncDocumentQuery<TSource>(source.Expression)
-                                .Take(0);
+            var query = provider.ToAsyncDocumentQuery<TSource>(source.Expression);
 
-            provider.MoveAfterQueryExecuted(query);
-            query.Statistics(out var stats);
-
-            await query.ToListAsync(token).ConfigureAwait(false);
-
-            return stats.TotalResults > 0;
+            return query.AnyAsync(token);
         }
 
         /// <summary>
@@ -386,7 +378,7 @@ namespace Raven.Client.Documents
         /// <exception cref="ArgumentNullException">
         /// source or predicate is null.
         /// </exception>
-        public static async Task<bool> AnyAsync<TSource>(this IQueryable<TSource> source, Expression<Func<TSource, bool>> predicate, CancellationToken token = default(CancellationToken))
+        public static Task<bool> AnyAsync<TSource>(this IQueryable<TSource> source, Expression<Func<TSource, bool>> predicate, CancellationToken token = default)
         {
             if (source == null)
                 throw new ArgumentNullException(nameof(source));
@@ -397,16 +389,9 @@ namespace Raven.Client.Documents
             if (provider == null)
                 throw new InvalidOperationException("AnyAsync only be used with IRavenQueryable");
 
-            var query = provider.ToAsyncDocumentQuery<TSource>(filtered.Expression)
-                                .Take(0);
+            var query = provider.ToAsyncDocumentQuery<TSource>(filtered.Expression);
 
-            provider.MoveAfterQueryExecuted(query);
-
-            query.Statistics(out var stats);
-
-            await query.ToListAsync(token).ConfigureAwait(false);
-
-            return stats.TotalResults > 0;
+            return query.AnyAsync(token);
         }
 
         /// <summary>
@@ -433,7 +418,7 @@ namespace Raven.Client.Documents
         /// <exception cref="OverflowException">
         /// The number of elements in source is larger than <see cref="Int32.MaxValue"/>.
         /// </exception>
-        public static async Task<int> CountAsync<TSource>(this IQueryable<TSource> source, CancellationToken token = default(CancellationToken))
+        public static Task<int> CountAsync<TSource>(this IQueryable<TSource> source, CancellationToken token = default)
         {
             if (source == null)
                 throw new ArgumentNullException(nameof(source));
@@ -443,16 +428,9 @@ namespace Raven.Client.Documents
             if (provider == null)
                 throw new InvalidOperationException("CountAsync only be used with IRavenQueryable");
 
-            var query = provider.ToAsyncDocumentQuery<TSource>(source.Expression)
-                                .Take(0);
+            var query = provider.ToAsyncDocumentQuery<TSource>(source.Expression);
 
-            provider.MoveAfterQueryExecuted(query);
-
-            query.Statistics(out var stats);
-
-            await query.ToListAsync(token).ConfigureAwait(false);
-
-            return stats.TotalResults;
+            return query.CountAsync(token);
         }
 
         /// <summary>
@@ -485,7 +463,7 @@ namespace Raven.Client.Documents
         /// <exception cref="OverflowException">
         /// The number of elements in source is larger than <see cref="Int32.MaxValue"/>.
         /// </exception>
-        public static async Task<int> CountAsync<TSource>(this IQueryable<TSource> source, Expression<Func<TSource, bool>> predicate, CancellationToken token = default(CancellationToken))
+        public static Task<int> CountAsync<TSource>(this IQueryable<TSource> source, Expression<Func<TSource, bool>> predicate, CancellationToken token = default)
         {
             if (source == null)
                 throw new ArgumentNullException(nameof(source));
@@ -496,15 +474,9 @@ namespace Raven.Client.Documents
             if (provider == null)
                 throw new InvalidOperationException("CountAsync only be used with IRavenQueryable");
 
-            var query = provider.ToAsyncDocumentQuery<TSource>(filtered.Expression)
-                                .Take(0);
+            var query = provider.ToAsyncDocumentQuery<TSource>(filtered.Expression);
 
-            provider.MoveAfterQueryExecuted(query);
-            query.Statistics(out var stats);
-
-            await query.ToListAsync(token).ConfigureAwait(false);
-
-            return stats.TotalResults;
+            return query.CountAsync(token);
         }
 
         /// <summary>
@@ -532,7 +504,7 @@ namespace Raven.Client.Documents
         /// The source sequence is empty or source
         /// is not of type <see cref="IRavenQueryable{T}"/>.
         /// </exception>
-        public static async Task<TSource> FirstAsync<TSource>(this IQueryable<TSource> source, CancellationToken token = default(CancellationToken))
+        public static Task<TSource> FirstAsync<TSource>(this IQueryable<TSource> source, CancellationToken token = default)
         {
             if (source == null)
                 throw new ArgumentNullException(nameof(source));
@@ -542,14 +514,9 @@ namespace Raven.Client.Documents
             if (provider == null)
                 throw new InvalidOperationException("FirstAsync only be used with IRavenQueryable");
 
-            var query = provider.ToAsyncDocumentQuery<TSource>(source.Expression)
-                                .Take(1);
+            var query = provider.ToAsyncDocumentQuery<TSource>(source.Expression);
 
-            provider.MoveAfterQueryExecuted(query);
-
-            var result = await query.ToListAsync(token).ConfigureAwait(false);
-
-            return result.First();
+            return query.FirstAsync(token);
         }
 
         /// <summary>
@@ -582,7 +549,7 @@ namespace Raven.Client.Documents
         /// the source sequence is empty or source
         /// is not of type <see cref="IRavenQueryable{T}"/>.
         /// </exception>
-        public static async Task<TSource> FirstAsync<TSource>(this IQueryable<TSource> source, Expression<Func<TSource, bool>> predicate, CancellationToken token = default(CancellationToken))
+        public static Task<TSource> FirstAsync<TSource>(this IQueryable<TSource> source, Expression<Func<TSource, bool>> predicate, CancellationToken token = default)
         {
             if (source == null)
                 throw new ArgumentNullException(nameof(source));
@@ -593,14 +560,9 @@ namespace Raven.Client.Documents
             if (provider == null)
                 throw new InvalidOperationException("FirstAsync only be used with IRavenQueryable");
 
-            var query = provider.ToAsyncDocumentQuery<TSource>(filtered.Expression)
-                                .Take(1);
+            var query = provider.ToAsyncDocumentQuery<TSource>(filtered.Expression);
 
-            provider.MoveAfterQueryExecuted(query);
-
-            var result = await query.ToListAsync(token).ConfigureAwait(false);
-
-            return result.First();
+            return query.FirstAsync(token);
         }
 
         /// <summary>
@@ -628,7 +590,7 @@ namespace Raven.Client.Documents
         /// <exception cref="InvalidOperationException">
         /// source is not of type <see cref="IRavenQueryable{T}"/>.
         /// </exception>
-        public static async Task<TSource> FirstOrDefaultAsync<TSource>(this IQueryable<TSource> source, CancellationToken token = default(CancellationToken))
+        public static Task<TSource> FirstOrDefaultAsync<TSource>(this IQueryable<TSource> source, CancellationToken token = default)
         {
             if (source == null)
                 throw new ArgumentNullException(nameof(source));
@@ -638,14 +600,9 @@ namespace Raven.Client.Documents
             if (provider == null)
                 throw new InvalidOperationException("FirstOrDefaultAsync only be used with IRavenQueryable");
 
-            var query = provider.ToAsyncDocumentQuery<TSource>(source.Expression)
-                                .Take(1);
+            var query = provider.ToAsyncDocumentQuery<TSource>(source.Expression);
 
-            provider.MoveAfterQueryExecuted(query);
-
-            var result = await query.ToListAsync(token).ConfigureAwait(false);
-
-            return result.FirstOrDefault();
+            return query.FirstOrDefaultAsync(token);
         }
 
         /// <summary>
@@ -680,7 +637,7 @@ namespace Raven.Client.Documents
         /// <exception cref="InvalidOperationException">
         /// source is not of type <see cref="IRavenQueryable{T}"/>.
         /// </exception>
-        public static async Task<TSource> FirstOrDefaultAsync<TSource>(this IQueryable<TSource> source, Expression<Func<TSource, bool>> predicate, CancellationToken token = default(CancellationToken))
+        public static Task<TSource> FirstOrDefaultAsync<TSource>(this IQueryable<TSource> source, Expression<Func<TSource, bool>> predicate, CancellationToken token = default)
         {
             if (source == null)
                 throw new ArgumentNullException(nameof(source));
@@ -691,14 +648,9 @@ namespace Raven.Client.Documents
             if (provider == null)
                 throw new InvalidOperationException("FirstOrDefaultAsync only be used with IRavenQueryable");
 
-            var query = provider.ToAsyncDocumentQuery<TSource>(filtered.Expression)
-                                .Take(1);
+            var query = provider.ToAsyncDocumentQuery<TSource>(filtered.Expression);
 
-            provider.MoveAfterQueryExecuted(query);
-
-            var result = await query.ToListAsync(token).ConfigureAwait(false);
-
-            return result.FirstOrDefault();
+            return query.FirstOrDefaultAsync(token);
         }
 
         /// <summary>
@@ -727,7 +679,7 @@ namespace Raven.Client.Documents
         /// The source sequence is empty, has more than one element or
         /// is not of type <see cref="IRavenQueryable{T}"/>.
         /// </exception>
-        public static async Task<TSource> SingleAsync<TSource>(this IQueryable<TSource> source, CancellationToken token = default(CancellationToken))
+        public static Task<TSource> SingleAsync<TSource>(this IQueryable<TSource> source, CancellationToken token = default)
         {
             if (source == null)
                 throw new ArgumentNullException(nameof(source));
@@ -737,14 +689,9 @@ namespace Raven.Client.Documents
             if (provider == null)
                 throw new InvalidOperationException("SingleAsync only be used with IRavenQueryable");
 
-            var query = provider.ToAsyncDocumentQuery<TSource>(source.Expression)
-                                .Take(2);
+            var query = provider.ToAsyncDocumentQuery<TSource>(source.Expression);
 
-            provider.MoveAfterQueryExecuted(query);
-
-            var result = await query.ToListAsync(token).ConfigureAwait(false);
-
-            return result.Single();
+            return query.SingleAsync(token);
         }
 
         /// <summary>
@@ -778,7 +725,7 @@ namespace Raven.Client.Documents
         /// one element satisfies the condition, the source sequence is empty or
         /// source is not of type <see cref="IRavenQueryable{T}"/>.
         /// </exception>
-        public static async Task<TSource> SingleAsync<TSource>(this IQueryable<TSource> source, Expression<Func<TSource, bool>> predicate, CancellationToken token = default(CancellationToken))
+        public static Task<TSource> SingleAsync<TSource>(this IQueryable<TSource> source, Expression<Func<TSource, bool>> predicate, CancellationToken token = default)
         {
             if (source == null)
                 throw new ArgumentNullException(nameof(source));
@@ -789,14 +736,9 @@ namespace Raven.Client.Documents
             if (provider == null)
                 throw new InvalidOperationException("SingleAsync only be used with IRavenQueryable");
 
-            var query = provider.ToAsyncDocumentQuery<TSource>(filtered.Expression)
-                                .Take(2);
+            var query = provider.ToAsyncDocumentQuery<TSource>(filtered.Expression);
 
-            provider.MoveAfterQueryExecuted(query);
-
-            var result = await query.ToListAsync(token).ConfigureAwait(false);
-
-            return result.Single();
+            return query.SingleAsync(token);
         }
 
         /// <summary>
@@ -827,7 +769,7 @@ namespace Raven.Client.Documents
         /// source has more than one element or
         /// is not of type <see cref="IRavenQueryable{T}"/>.
         /// </exception>
-        public static async Task<TSource> SingleOrDefaultAsync<TSource>(this IQueryable<TSource> source, CancellationToken token = default(CancellationToken))
+        public static Task<TSource> SingleOrDefaultAsync<TSource>(this IQueryable<TSource> source, CancellationToken token = default)
         {
             if (source == null)
                 throw new ArgumentNullException(nameof(source));
@@ -837,14 +779,9 @@ namespace Raven.Client.Documents
             if (provider == null)
                 throw new InvalidOperationException("SingleOrDefaultAsync only be used with IRavenQueryable");
 
-            var query = provider.ToAsyncDocumentQuery<TSource>(source.Expression)
-                                .Take(2);
+            var query = provider.ToAsyncDocumentQuery<TSource>(source.Expression);
 
-            provider.MoveAfterQueryExecuted(query);
-
-            var result = await query.ToListAsync(token).ConfigureAwait(false);
-
-            return result.SingleOrDefault();
+            return query.SingleOrDefaultAsync(token);
         }
 
         /// <summary>
@@ -880,7 +817,7 @@ namespace Raven.Client.Documents
         /// More than one element satisfies the condition in predicate
         /// or source is not of type <see cref="IRavenQueryable{T}"/>.
         /// </exception>
-        public static async Task<TSource> SingleOrDefaultAsync<TSource>(this IQueryable<TSource> source, Expression<Func<TSource, bool>> predicate, CancellationToken token = default(CancellationToken))
+        public static Task<TSource> SingleOrDefaultAsync<TSource>(this IQueryable<TSource> source, Expression<Func<TSource, bool>> predicate, CancellationToken token = default)
         {
             if (source == null)
                 throw new ArgumentNullException(nameof(source));
@@ -891,14 +828,9 @@ namespace Raven.Client.Documents
             if (provider == null)
                 throw new InvalidOperationException("SingleOrDefaultAsync only be used with IRavenQueryable");
 
-            var query = provider.ToAsyncDocumentQuery<TSource>(filtered.Expression)
-                                .Take(2);
+            var query = provider.ToAsyncDocumentQuery<TSource>(filtered.Expression);
 
-            provider.MoveAfterQueryExecuted(query);
-
-            var result = await query.ToListAsync(token).ConfigureAwait(false);
-
-            return result.SingleOrDefault();
+            return query.SingleOrDefaultAsync(token);
         }
 
         /// <summary>
@@ -972,16 +904,17 @@ namespace Raven.Client.Documents
         /// <summary>
         /// Returns the query results as a stream
         /// </summary>
-        public static async Task ToStreamAsync<T>(this IQueryable<T> self, Stream stream, CancellationToken token = default(CancellationToken))
+        public static async Task ToStreamAsync<T>(this IQueryable<T> self, Stream stream, CancellationToken token = default)
         {
             var queryProvider = (IRavenQueryProvider)self.Provider;
             var docQuery = queryProvider.ToAsyncDocumentQuery<T>(self.Expression);
             await ToStreamAsync(docQuery, stream, token).ConfigureAwait(false);
         }
+
         /// <summary>
         /// Returns the query results as a stream
         /// </summary>
-        public static async Task ToStreamAsync<T>(this IAsyncDocumentQuery<T> self, Stream stream, CancellationToken token = default(CancellationToken))
+        public static async Task ToStreamAsync<T>(this IAsyncDocumentQuery<T> self, Stream stream, CancellationToken token = default)
         {
             var documentQuery = (AbstractDocumentQuery<T, AsyncDocumentQuery<T>>)self;
             var session = documentQuery.AsyncSession;

--- a/src/Raven.Client/Documents/Session/AsyncDocumentQuery.cs
+++ b/src/Raven.Client/Documents/Session/AsyncDocumentQuery.cs
@@ -761,6 +761,13 @@ namespace Raven.Client.Documents.Session
         /// <inheritdoc />
         async Task<bool> IAsyncDocumentQueryBase<T>.AnyAsync(CancellationToken token)
         {
+            if (IsDistinct)
+            {
+                // for distinct it is cheaper to do count 1
+                var operation = await ExecuteQueryOperation(1, token).ConfigureAwait(false);
+                return operation.Any();
+            }
+
             Take(0);
             var result = await GetQueryResultAsync(token).ConfigureAwait(false);
             return result.TotalResults > 0;
@@ -768,7 +775,7 @@ namespace Raven.Client.Documents.Session
 
         private async Task<List<T>> ExecuteQueryOperation(int? take, CancellationToken token)
         {
-            if (take.HasValue && (PageSize.HasValue == false || PageSize > take)) 
+            if (take.HasValue && (PageSize.HasValue == false || PageSize > take))
                 Take(take.Value);
 
             await InitAsync(token).ConfigureAwait(false);

--- a/src/Raven.Client/Documents/Session/AsyncDocumentQuery.cs
+++ b/src/Raven.Client/Documents/Session/AsyncDocumentQuery.cs
@@ -761,8 +761,9 @@ namespace Raven.Client.Documents.Session
         /// <inheritdoc />
         async Task<bool> IAsyncDocumentQueryBase<T>.AnyAsync(CancellationToken token)
         {
-            var operation = await ExecuteQueryOperation(1, token).ConfigureAwait(false);
-            return operation.Any();
+            Take(0);
+            var result = await GetQueryResultAsync(token).ConfigureAwait(false);
+            return result.TotalResults > 0;
         }
 
         private async Task<List<T>> ExecuteQueryOperation(int? take, CancellationToken token)

--- a/src/Raven.Client/Documents/Session/DocumentQuery.cs
+++ b/src/Raven.Client/Documents/Session/DocumentQuery.cs
@@ -753,7 +753,9 @@ namespace Raven.Client.Documents.Session
         /// <inheritdoc />
         bool IDocumentQueryBase<T>.Any()
         {
-            return ExecuteQueryOperation(1).Any();
+            Take(0);
+            var queryResult = GetQueryResult();
+            return queryResult.TotalResults > 0;
         }
 
         private List<T> ExecuteQueryOperation(int? take)
@@ -782,7 +784,6 @@ namespace Raven.Client.Documents.Session
                 Take(0);
                 QueryOperation = InitializeQueryOperation();
             }
-
 
             var lazyQueryOperation = new LazyQueryOperation<T>(TheSession.Conventions, QueryOperation, AfterQueryExecutedCallback);
 

--- a/src/Raven.Client/Documents/Session/DocumentQuery.cs
+++ b/src/Raven.Client/Documents/Session/DocumentQuery.cs
@@ -753,6 +753,12 @@ namespace Raven.Client.Documents.Session
         /// <inheritdoc />
         bool IDocumentQueryBase<T>.Any()
         {
+            if (IsDistinct)
+            {
+                // for distinct it is cheaper to do count 1
+                return ExecuteQueryOperation(1).Any();
+            }
+
             Take(0);
             var queryResult = GetQueryResult();
             return queryResult.TotalResults > 0;
@@ -760,7 +766,7 @@ namespace Raven.Client.Documents.Session
 
         private List<T> ExecuteQueryOperation(int? take)
         {
-            if (take.HasValue && (PageSize.HasValue == false || PageSize > take)) 
+            if (take.HasValue && (PageSize.HasValue == false || PageSize > take))
                 Take(take.Value);
 
             InitSync();

--- a/test/SlowTests/Issues/RavenDB_10637.cs
+++ b/test/SlowTests/Issues/RavenDB_10637.cs
@@ -1,0 +1,60 @@
+﻿using System;
+using System.Linq;
+using System.Threading.Tasks;
+using FastTests;
+using Raven.Client.Documents;
+using Raven.Client.Documents.Indexes;
+using Xunit;
+
+namespace SlowTests.Issues
+{
+    public class RavenDB_10637 : RavenTestBase
+    {
+        [Fact]
+        public async Task TestLazyQueryStatsTest()
+        {
+            using (var store = GetDocumentStore())
+            {
+                new DocsIndex().Execute(store);
+
+                using (var session = store.OpenAsyncSession())
+                {
+                    var query = session.Query<Doc, DocsIndex>();
+
+                    var lazyCount = await query.Statistics(out var stats).CountLazilyAsync().Value;
+                    Assert.NotEqual(default(string), stats.IndexName);
+                    Assert.NotEqual(default(DateTime), stats.Timestamp);
+                }
+
+                using (var session = store.OpenSession())
+                {
+                    var query = session.Query<Doc, DocsIndex>();
+
+                    var lazyCount = query.Statistics(out var stats).CountLazily().Value;
+                    Assert.NotEqual(default(string), stats.IndexName);
+                    Assert.NotEqual(default(DateTime), stats.Timestamp);
+                }
+            }
+        }
+
+        private class Doc
+        {
+            public string Id { get; set; }
+            public int IntVal { get; set; }
+        }
+
+        private class DocsIndex : AbstractIndexCreationTask<Doc>
+        {
+            public DocsIndex()
+            {
+                Map = docs =>
+                    from doc in docs
+                    select new
+                    {
+                        doc.Id,
+                        doc.IntVal,
+                    };
+            }
+        }
+    }
+}


### PR DESCRIPTION
- Lazy count query doesn't populate QueryStatistics
- better approach for Any and AnyAsync
- using built-in DocumentQuery and AsyncDocumentQuery methods in LinqExtensions