### PR TITLE
[4.1] RavenDB-10493 Implementation of DateTime.MinValue and .MaxValue

### DIFF
--- a/src/Raven.Client/Util/JavascriptConversionExtensions.cs
+++ b/src/Raven.Client/Util/JavascriptConversionExtensions.cs
@@ -990,6 +990,12 @@ namespace Raven.Client.Util
                         //match DateTime.Now , DateTime.UtcNow, DateTime.Today
                         switch (node.Member.Name)
                         {
+                            case "MinValue":
+                                writer.Write("new Date(-62135596800000)");
+                                break;
+                            case "MaxValue":
+                                writer.Write("new Date(253402297199999)");
+                                break;
                             case "Now":
                                 writer.Write("Date.now()");
                                 break;

--- a/test/FastTests/Issues/RavenDB-10493.cs
+++ b/test/FastTests/Issues/RavenDB-10493.cs
@@ -1,0 +1,53 @@
+﻿using System;
+using System.Collections.Generic;
+using System.Linq;
+using Xunit;
+
+namespace FastTests.Issues
+{
+    public class RavenDB_10493: RavenTestBase
+    {        
+        private class Article
+        {
+            public DateTime? DateTime;
+        }
+                        
+        [Fact]
+        public void CanHaveArrayInMetadata()
+        {             
+            using (var store = GetDocumentStore())
+            {             
+                using (var session = store.OpenSession())
+                {
+                    session.Store(new Article
+                    {
+                        DateTime = null
+                    });
+                    session.SaveChanges();
+                }
+                                
+                using (var session = store.OpenSession())
+                {
+                    var query = from x in session.Query<Article>()
+                                let test = 1
+                                select new
+                                {
+                                    DateTime = x.DateTime,
+                                    DateTimeMinValue = DateTime.MinValue,
+                                    DateTimeMaxValue = DateTime.MaxValue
+                                };
+
+                    Assert.Equal("declare function output(x) {\r\n\tvar test = 1;\r\n\treturn { DateTime : x.DateTime, DateTimeMinValue : new Date(-62135596800000), DateTimeMaxValue : new Date(253402297199999) };\r\n}\r\nfrom Articles as x select output(x)", query.ToString());
+
+                    var result = query.ToList();
+                    
+                    Assert.Equal(DateTime.MinValue, result[0].DateTimeMinValue);
+                    // Only missing 0.0009999 sec... 
+                    //Assert.Equal(DateTime.MaxValue, result[0].DateTimeMaxValue);
+
+                }                              
+            }
+        }
+                        
+    }
+}

--- a/test/FastTests/Issues/RavenDB-10493.cs
+++ b/test/FastTests/Issues/RavenDB-10493.cs
@@ -13,7 +13,7 @@ namespace FastTests.Issues
         }
                         
         [Fact]
-        public void CanHaveArrayInMetadata()
+        public void CanTranslateDateTimeMinValueMaxValue()
         {             
             using (var store = GetDocumentStore())
             {             
@@ -42,8 +42,11 @@ namespace FastTests.Issues
                     var result = query.ToList();
                     
                     Assert.Equal(DateTime.MinValue, result[0].DateTimeMinValue);
-                    // Only missing 0.0009999 sec... 
-                    //Assert.Equal(DateTime.MaxValue, result[0].DateTimeMaxValue);
+
+                    // Only missing 0.9999 ms
+                    var epsilon = 1; // Lower than 1 ms
+                    Assert.True(
+                        Math.Abs((DateTime.MaxValue.ToUniversalTime() - result[0].DateTimeMaxValue).TotalSeconds) < epsilon);
 
                 }                              
             }


### PR DESCRIPTION
This seems the best approach without breaking or implementing lower level stuff. MaxValue is off by timezone + 0.9999ms, since the precision of JS Date implementation doesn't match .NET.

Other approach could be:
date.parse("9999-12-31T23:59:59.9999999") which is turned into a Int presentation of milliseconds since 1970-1-1 00:00:00UTC (unixtimestamp).

Though BlittableParser cannot handle this and returns: Cannot convert Int64 to DateTime.