### PR TITLE
[4.1] RavenDB-10644: Added support for Math.Round() with 2 arguments

### DIFF
--- a/src/Raven.Client/Util/JavascriptConversionExtensions.cs
+++ b/src/Raven.Client/Util/JavascriptConversionExtensions.cs
@@ -657,14 +657,25 @@ namespace Raven.Client.Util
 
                     writer.Write("(");
 
-                    for (var i = 0; i < methodCallExpression.Arguments.Count; i++)
+                    if (method.Name == "Round" && methodCallExpression.Arguments.Count > 1)
                     {
-                        if (i != 0)
+                        context.Visitor.Visit(methodCallExpression.Arguments[0]);
+                        writer.Write(" * Math.pow(10, ");
+                        context.Visitor.Visit(methodCallExpression.Arguments[1]);
+                        writer.Write(")) / Math.pow(10, ");
+                        context.Visitor.Visit(methodCallExpression.Arguments[1]);
+                    }
+                    else
+                    {
+                        for (var i = 0; i < methodCallExpression.Arguments.Count; i++)
                         {
-                            writer.Write(", ");
-                        }
+                            if (i != 0)
+                            {
+                                writer.Write(", ");
+                            }
 
-                        context.Visitor.Visit(methodCallExpression.Arguments[i]);
+                            context.Visitor.Visit(methodCallExpression.Arguments[i]);
+                        }
                     }
 
                     writer.Write(")");

--- a/test/FastTests/Issues/RavenDB_10644.cs
+++ b/test/FastTests/Issues/RavenDB_10644.cs
@@ -1,0 +1,54 @@
+﻿using System;
+using System.Collections.Generic;
+using System.Linq;
+using Xunit;
+
+namespace FastTests.Issues
+{
+    public class RavenDB_10644 : RavenTestBase
+    {
+        private class Article
+        {
+            public decimal Value { get; set; }
+        }
+
+        [Fact]
+        public void TranslateMathRound()
+        {
+            using (var store = GetDocumentStore(new Options()
+            {
+                ModifyDocumentStore = a => a.Conventions.SaveEnumsAsIntegers = false
+            }))
+            {
+                using (var session = store.OpenSession())
+                {
+                    session.Store(new Article
+                    {
+                        Value = 2.5555555M
+                    });
+                    session.SaveChanges();
+                }
+
+                using (var session = store.OpenSession())
+                {
+                    var query = from x in session.Query<Article>()
+                                select new
+                                {
+                                    Round = Math.Round(x.Value),
+                                    Round2 = Math.Round(x.Value, 2),
+                                    Round4 = Math.Round(x.Value, 4)
+                                };
+
+                    Assert.Equal("from Articles as x select { Round : Math.round(x.Value), Round2 : Math.round(x.Value * Math.pow(10, 2)) / Math.pow(10, 2), Round4 : Math.round(x.Value * Math.Pow(10, 4)) / Math.Pow(10, 4) }", query.ToString());
+
+                    var result = query.ToList();
+                    Assert.Equal(3, result[0].Round);
+                    Assert.Equal(2.56M, result[0].Round2);
+                    Assert.Equal(2.5556M, result[0].Round4);
+
+                }
+            }
+        }
+
+    }
+}

--- a/test/FastTests/Issues/RavenDB_10644.cs
+++ b/test/FastTests/Issues/RavenDB_10644.cs
@@ -15,10 +15,7 @@ namespace FastTests.Issues
         [Fact]
         public void TranslateMathRound()
         {
-            using (var store = GetDocumentStore(new Options()
-            {
-                ModifyDocumentStore = a => a.Conventions.SaveEnumsAsIntegers = false
-            }))
+            using (var store = GetDocumentStore())
             {
                 using (var session = store.OpenSession())
                 {


### PR DESCRIPTION
Didn't saw a better way to implement this, besides splitting the current MathSupport with 2 code paths (splitted on method.Name and argument size)