### PR TITLE
fix for RavenDB-10635

### DIFF
--- a/Raven.Database/Storage/BaseRestoreOperation.cs
+++ b/Raven.Database/Storage/BaseRestoreOperation.cs
@@ -19,7 +19,8 @@ namespace Raven.Database.Storage
 
         protected readonly DatabaseRestoreRequest _restoreRequest;
         protected readonly InMemoryRavenConfiguration Configuration;
-        protected readonly string databaseLocation, indexLocation, indexDefinitionLocation, journalLocation;
+        protected readonly string databaseLocation, indexLocation, indexDefinitionLocation;
+        protected string journalLocation;
 
         protected BaseRestoreOperation(DatabaseRestoreRequest restoreRequest, InMemoryRavenConfiguration configuration, InMemoryRavenConfiguration globalConfiguration, Action<string> output)
         {
@@ -29,13 +30,13 @@ namespace Raven.Database.Storage
             indexLocation = GenerateIndexLocation(_restoreRequest, configuration, globalConfiguration).ToFullPath();
             journalLocation = (_restoreRequest.JournalsLocation ?? _restoreRequest.DatabaseLocation).ToFullPath();
             Configuration = configuration;
-            this.output = output;			
+            this.output = output;
         }
         
         private string GenerateIndexLocation(DatabaseRestoreRequest databaseRestoreRequest, InMemoryRavenConfiguration configuration, InMemoryRavenConfiguration globalConfiguration)
         {
             //If we got the index location in the request use that.
-            if (databaseRestoreRequest.IndexesLocation != null)
+            if (!string.IsNullOrWhiteSpace(databaseRestoreRequest.IndexesLocation))
                 return databaseRestoreRequest.IndexesLocation;
 
             if (globalConfiguration != null)

--- a/Raven.Database/Storage/Voron/Backup/RestoreOperation.cs
+++ b/Raven.Database/Storage/Voron/Backup/RestoreOperation.cs
@@ -4,6 +4,7 @@ using Raven.Abstractions.Logging;
 using Raven.Database.Config;
 using System;
 using System.IO;
+using Raven.Database.Extensions;
 using Voron;
 using Voron.Impl.Backup;
 
@@ -14,6 +15,15 @@ namespace Raven.Database.Storage.Voron.Backup
         public RestoreOperation(DatabaseRestoreRequest restoreRequest, InMemoryRavenConfiguration configuration, InMemoryRavenConfiguration globalConfiguration, Action<string> operationOutputCallback)
             : base(restoreRequest, configuration, globalConfiguration, operationOutputCallback)
         {
+            journalLocation = GenerateJournalLocation(_restoreRequest, configuration).ToFullPath();
+        }
+
+        private string GenerateJournalLocation(DatabaseRestoreRequest databaseRestoreRequest, InMemoryRavenConfiguration configuration)
+        {
+            if (!string.IsNullOrWhiteSpace(databaseRestoreRequest.JournalsLocation))
+                return databaseRestoreRequest.JournalsLocation;
+
+            return configuration != null ? configuration.DataDirectory : databaseRestoreRequest.DatabaseLocation;
         }
 
         protected override bool IsValidBackup(string backupFilename)

--- a/Raven.Database/Storage/Voron/TransactionalStorage.cs
+++ b/Raven.Database/Storage/Voron/TransactionalStorage.cs
@@ -488,7 +488,7 @@ namespace Raven.Storage.Voron
             }
 
             var tempPath = configuration.Storage.Voron.TempPath;
-            var journalPath = configuration.Storage.Voron.JournalsStoragePath;
+            var journalPath = configuration.Storage.Voron.JournalsStoragePath ?? configuration.Settings[Abstractions.Data.Constants.RavenTxJournalPath];
             var options = StorageEnvironmentOptions.ForPath(directoryPath, tempPath, journalPath);
             options.IncrementalBackupEnabled = configuration.Storage.Voron.AllowIncrementalBackups;
             options.InitialFileSize = configuration.Storage.Voron.InitialFileSize;

--- a/Raven.Tests.Issues/Raven.Tests.Issues.csproj
+++ b/Raven.Tests.Issues/Raven.Tests.Issues.csproj
@@ -141,6 +141,7 @@
     <Compile Include="Backup_restore_backup.cs" />
     <Compile Include="FullAndIncrementalBackups.cs" />
     <Compile Include="NtpServers.cs" />
+    <Compile Include="RavenDB-10635.cs" />
     <Compile Include="RavenDB-7972.cs" />
     <Compile Include="RavenDB_7873.cs" />
     <Compile Include="RavenDB-7406.cs" />

--- a/Raven.Tests.Issues/RavenDB-10635.cs
+++ b/Raven.Tests.Issues/RavenDB-10635.cs
@@ -1,0 +1,99 @@
+﻿using System.IO;
+using Raven.Abstractions.Data;
+using Raven.Client.Indexes;
+using Raven.Database;
+using Raven.Database.Actions;
+using Raven.Database.Config;
+using Raven.Database.Extensions;
+using Raven.Json.Linq;
+using Raven.Tests.Helpers;
+using Xunit;
+using Xunit.Extensions;
+
+namespace Raven.Tests.Issues
+{
+    public class RavenDB_10635 : RavenTestBase
+    {
+        private readonly string DataDir;
+        private readonly string BackupDir;
+
+        private DocumentDatabase db;
+
+        public RavenDB_10635()
+        {
+            BackupDir = NewDataPath("BackupDatabase");
+            DataDir = NewDataPath("DataDirectory");
+        }
+
+        public override void Dispose()
+        {
+            db.Dispose();
+            base.Dispose();
+        }
+
+        [Theory]
+        [PropertyData("Storages")]
+        public void Full_backup_then_restore_should_work_with_custom_journal_folder(string storageName)
+        {
+            InitializeDocumentDatabase(storageName);
+            IOExtensions.DeleteDirectory(BackupDir);
+
+            //generate some journal entries
+            db.Documents.Put("Foo", null, RavenJObject.Parse("{'email':'foo@bar.com'}"), new RavenJObject(), null);
+            db.Documents.Put("Foo", null, RavenJObject.Parse("{'email':'foo@bar2.com'}"), new RavenJObject(), null);
+            db.Documents.Put("Foo", null, RavenJObject.Parse("{'email':'foo@bar3.com'}"), new RavenJObject(), null);
+
+            db.Maintenance.StartBackup(BackupDir, false, new DatabaseDocument(), new ResourceBackupState());
+            WaitForBackup(db, true);
+
+            db.Dispose();
+            IOExtensions.DeleteDirectory(DataDir);
+
+            var journalsCustomPath = Path.Combine(DataDir,"Journals");
+            MaintenanceActions.Restore(new RavenConfiguration
+            {
+                DefaultStorageTypeName = storageName,
+                DataDirectory = DataDir,
+                RunInMemory = false          
+            }, new DatabaseRestoreRequest
+            {
+                BackupLocation = BackupDir,
+                DatabaseLocation = DataDir,
+                JournalsLocation = journalsCustomPath,
+                Defrag = true
+            }, s => { });
+
+            db = new DocumentDatabase(new RavenConfiguration
+            {
+                DataDirectory = DataDir,
+                RunInMemory = false,
+                Settings =
+                {
+                    {"Raven/TransactionJournalsPath", journalsCustomPath }
+                }
+            }, null);
+
+            var fetchedData = db.Documents.Get("Foo", null);
+            Assert.NotNull(fetchedData);
+
+            var jObject = fetchedData.ToJson();
+            Assert.NotNull(jObject);
+            Assert.Equal("foo@bar3.com", jObject.Value<string>("email"));
+
+            db.Dispose();
+        }
+
+        private void InitializeDocumentDatabase(string storageName)
+        {
+            db = new DocumentDatabase(new RavenConfiguration
+            {
+                DefaultStorageTypeName = storageName,
+                DataDirectory = DataDir,
+                RunInMemory = false,
+                RunInUnreliableYetFastModeThatIsNotSuitableForProduction = false              
+            }, null);
+            db.Indexes.PutIndex(new RavenDocumentsByEntityName().IndexName, new RavenDocumentsByEntityName().CreateIndexDefinition());
+        }
+
+    }
+}


### PR DESCRIPTION
Properly handle custom journal path in Voron
* Make sure the journals custom folder is properly taken into account during full restore
* Make sure that the journals custom folder is properly taken into account when creating a database in the Land Lord (I mean the settings entry for custom journal path)
