### PR TITLE
RavenDB-10674 Once ETL process cannot proceed the load stage then ent…

### DIFF
--- a/src/Raven.Server/Config/Categories/EtlConfiguration.cs
+++ b/src/Raven.Server/Config/Categories/EtlConfiguration.cs
@@ -22,5 +22,12 @@ namespace Raven.Server.Config.Categories
         [DefaultValue(null)]
         [ConfigurationEntry("ETL.MaxNumberOfExtractedDocuments", ConfigurationEntryScope.ServerWideOrPerDatabase)]
         public int? MaxNumberOfExtractedDocuments { get; protected set; }
+
+        [Description("Maximum number of seconds ETL process will be in a fallback mode after a load connection failure to a destination. The fallback mode means suspending the process.")]
+        [DefaultValue(60 * 15)]
+        [TimeUnit(TimeUnit.Seconds)]
+        [ConfigurationEntry("ETL.MaxFallbackTimeInSec", ConfigurationEntryScope.ServerWideOrPerDatabase)]
+        public TimeSetting MaxFallbackTime { get; set; }
+
     }
 }

--- a/src/Raven.Server/Documents/ETL/EtlProcess.cs
+++ b/src/Raven.Server/Documents/ETL/EtlProcess.cs
@@ -1,6 +1,7 @@
 ﻿using System;
 using System.Collections.Concurrent;
 using System.Collections.Generic;
+using System.Diagnostics;
 using System.Linq;
 using System.Text;
 using System.Threading;
@@ -41,6 +42,8 @@ namespace Raven.Server.Documents.ETL
         public string ConfigurationName { get; protected set; }
 
         public string TransformationName { get; protected set; }
+
+        public TimeSpan? FallbackTime { get; protected set; }
 
         public abstract void Start();
 
@@ -92,7 +95,6 @@ namespace Raven.Server.Documents.ETL
         protected readonly Logger Logger;
         protected readonly DocumentDatabase Database;
         private readonly ServerStore _serverStore;
-        protected TimeSpan? FallbackTime;
 
         public readonly TConfiguration Configuration;        
 
@@ -264,15 +266,24 @@ namespace Raven.Server.Documents.ETL
                     if (Logger.IsOperationsEnabled)
                         Logger.Operations($"Failed to load transformed data for '{Name}'", e);
 
-                    HandleFallback();
+                    EnterFallbackMode();
 
                     Statistics.RecordLoadError(e.ToString(), documentId: null, count: stats.NumberOfExtractedItems);
                 }
             }
         }
 
-        protected virtual void HandleFallback()
+        private void EnterFallbackMode()
         {
+            if (Statistics.LastLoadErrorTime == null)
+                FallbackTime = TimeSpan.FromSeconds(5);
+            else
+            {
+                // double the fallback time (but don't cross Etl.MaxFallbackTime)
+                var secondsSinceLastError = (Database.Time.GetUtcNow() - Statistics.LastLoadErrorTime.Value).TotalSeconds;
+                
+                FallbackTime = TimeSpan.FromSeconds(Math.Min(Database.Configuration.Etl.MaxFallbackTime.AsTimeSpan.Seconds, Math.Max(5, secondsSinceLastError * 2)));
+            }
         }
 
         protected abstract void LoadInternal(IEnumerable<TTransformed> items, JsonOperationContext context);
@@ -415,11 +426,6 @@ namespace Raven.Server.Documents.ETL
 
                     var startTime = Database.Time.GetUtcNow();
 
-                    if (FallbackTime != null)
-                    {
-                        Thread.Sleep(FallbackTime.Value);
-                        FallbackTime = null;
-                    }
                     var didWork = false;
 
                     var state = GetProcessState(Database, Configuration.Name, Transformation.Name);
@@ -509,7 +515,29 @@ namespace Raven.Server.Documents.ETL
 
                     try
                     {
-                        _waitForChanges.Wait(CancellationToken);
+                        if (FallbackTime == null)
+                        {
+                            _waitForChanges.Wait(CancellationToken);
+                        }
+                        else
+                        {
+                            var sp = Stopwatch.StartNew();
+
+                            if (_waitForChanges.Wait(FallbackTime.Value, CancellationToken))
+                            {
+                                // we are in the fallback mode but got new docs to process
+                                // let's wait full time and retry the process then
+
+                                var timeLeftToWait = FallbackTime.Value - sp.Elapsed;
+
+                                if (timeLeftToWait > TimeSpan.Zero)
+                                {
+                                    Thread.Sleep(timeLeftToWait);
+                                }
+                            }
+
+                            FallbackTime = null;
+                        }
                     }
                     catch (ObjectDisposedException)
                     {

--- a/src/Raven.Server/Documents/ETL/EtlProcessStatistics.cs
+++ b/src/Raven.Server/Documents/ETL/EtlProcessStatistics.cs
@@ -32,7 +32,9 @@ namespace Raven.Server.Documents.ETL
 
         public long LastProcessedEtag { get; set; }
 
-        public DateTime? LastErrorTime { get; private set; }
+        public DateTime? LastTransformationErrorTime { get; private set; }
+
+        public DateTime? LastLoadErrorTime { get; private set; }
 
         private int TransformationErrors { get; set; }
 
@@ -64,7 +66,7 @@ namespace Raven.Server.Documents.ETL
         {
             TransformationErrors++;
 
-            LastErrorTime = SystemTime.UtcNow;
+            LastTransformationErrorTime = SystemTime.UtcNow;
 
             _transformationErrorsInCurrentBatch.Add(new EtlErrorInfo
             {
@@ -93,7 +95,7 @@ namespace Raven.Server.Documents.ETL
 
             LoadErrors += count;
 
-            LastErrorTime = SystemTime.UtcNow;
+            LastLoadErrorTime = SystemTime.UtcNow;
 
             _loadErrorsInCurrentBatch.Add(new EtlErrorInfo
             {
@@ -162,7 +164,8 @@ namespace Raven.Server.Documents.ETL
             var json = new DynamicJsonValue
             {
                 [nameof(LastAlert)] = LastAlert?.ToJson(),
-                [nameof(LastErrorTime)] = LastErrorTime,
+                [nameof(LastTransformationErrorTime)] = LastTransformationErrorTime,
+                [nameof(LastLoadErrorTime)] = LastLoadErrorTime,
                 [nameof(LastProcessedEtag)] = LastProcessedEtag,
                 [nameof(TransformationSuccesses)] = TransformationSuccesses,
                 [nameof(TransformationErrors)] = TransformationErrors,
@@ -175,7 +178,8 @@ namespace Raven.Server.Documents.ETL
         public override string ToString()
         {
             return $"{nameof(LastProcessedEtag)}: {LastProcessedEtag} " +
-                   $"{nameof(LastErrorTime)}: {LastErrorTime} " +
+                   $"{nameof(LastTransformationErrorTime)}: {LastTransformationErrorTime} " +
+                   $"{nameof(LastLoadErrorTime)}: {LastLoadErrorTime} " +
                    $"{nameof(TransformationSuccesses)}: {TransformationSuccesses} " +
                    $"{nameof(TransformationErrors)}: {TransformationErrors} " +
                    $"{nameof(LoadSuccesses)}: {LoadSuccesses} " +
@@ -185,7 +189,8 @@ namespace Raven.Server.Documents.ETL
         public void Reset()
         {
             LastProcessedEtag = 0;
-            LastErrorTime = null;
+            LastTransformationErrorTime = null;
+            LastLoadErrorTime = null;
             TransformationSuccesses = 0;
             TransformationErrors = 0;
             LoadSuccesses = 0;

--- a/src/Raven.Server/Documents/ETL/Providers/SQL/SqlEtl.cs
+++ b/src/Raven.Server/Documents/ETL/Providers/SQL/SqlEtl.cs
@@ -78,19 +78,6 @@ namespace Raven.Server.Documents.ETL.Providers.SQL
             }
         }
 
-        protected override void HandleFallback()
-        {
-            if (Statistics.LastErrorTime == null)
-                FallbackTime = TimeSpan.FromSeconds(5);
-            else
-            {
-                // double the fallback time (but don't cross 15 minutes)
-                var secondsSinceLastError = (Database.Time.GetUtcNow() - Statistics.LastErrorTime.Value).TotalSeconds;
-
-                FallbackTime = TimeSpan.FromSeconds(Math.Min(60 * 15, Math.Max(5, secondsSinceLastError * 2)));
-            }
-        }
-
         protected override bool ShouldFilterOutHiLoDocument()
         {
             return true;

--- a/src/Raven.Server/Web/System/OngoingTasksHandler.cs
+++ b/src/Raven.Server/Web/System/OngoingTasksHandler.cs
@@ -826,14 +826,17 @@ namespace Raven.Server.Web.System
                         if (etlProcess.ConfigurationName == ravenEtl.Name)
                         {
                             res.Url = etlProcess.Url;
-                            res.Status = OngoingTaskConnectionStatus.Active;
+                            res.Status = etlProcess.FallbackTime == null ? OngoingTaskConnectionStatus.Active : OngoingTaskConnectionStatus.Reconnect;
                             break;
                         }
                     }
                 }
                 if (res.Status == OngoingTaskConnectionStatus.None)
                 {
-                    error = $"The raven ETL process '{ravenEtl.Name}' was not found.";
+                    if (ravenEtl.Disabled)
+                        res.Status = OngoingTaskConnectionStatus.NotActive;
+                    else
+                        error = $"The raven ETL process '{ravenEtl.Name}' was not found.";
                 }
             }
             else

--- a/test/SlowTests/Server/Documents/ETL/RavenDB_10674.cs
+++ b/test/SlowTests/Server/Documents/ETL/RavenDB_10674.cs
@@ -1,0 +1,58 @@
+﻿using System;
+using System.Threading;
+using Raven.Client.Documents.Operations.ETL;
+using Raven.Tests.Core.Utils.Entities;
+using Xunit;
+
+namespace SlowTests.Server.Documents.ETL
+{
+    public class RavenDB_10674 : EtlTestBase
+    {
+        [Fact]
+        public void EntersFallbackModeIfCantConnectTheDestination()
+        {
+            using (var src = GetDocumentStore())
+            {
+                using (var store = src.OpenSession())
+                {
+                    store.Store(new User());
+
+                    store.SaveChanges();
+                }
+
+                var configuration = new RavenEtlConfiguration()
+                {
+                    ConnectionStringName = "test",
+                    Name = "aaa",
+                    Transforms =
+                    {
+                        new Transformation()
+                        {
+                            Collections = {"Users"},
+                            Name = "test"
+                        }
+                    }
+                };
+
+                AddEtl(src, configuration, new RavenConnectionString
+                {
+                    Name = "test",
+                    TopologyDiscoveryUrls = new []{ "http://abc.localhost:1234"},
+                    Database = "test",
+                });
+
+                var process = GetDatabase(src.Database).Result.EtlLoader.Processes[0];
+
+                Assert.True(SpinWait.SpinUntil(() =>
+                {
+                    if (process.FallbackTime != null)
+                        return true;
+
+                    Thread.Sleep(100);
+
+                    return false;
+                }, TimeSpan.FromMinutes(1)));
+            }
+        }
+    }
+}


### PR DESCRIPTION
…er the fallback mode and retry the process after some time (according to the last error time). Once the process is in the fallback mode then show 'Reconnect' state in the studio. Show 'NotActive' state if ETL task is disabled.