### PR TITLE
[4.1] RavenDB-10666

### DIFF
--- a/src/Raven.Client/Documents/Session/DocumentSessionAttachments.cs
+++ b/src/Raven.Client/Documents/Session/DocumentSessionAttachments.cs
@@ -29,7 +29,7 @@ namespace Raven.Client.Documents.Session
         public AttachmentResult Get(string documentId, string name)
         {
             var operation = new GetAttachmentOperation(documentId, name, AttachmentType.Document, null);
-            return Session.OperationExecutor.Send(operation, SessionInfo);
+            return Session.Operations.Send(operation, SessionInfo);
         }
 
         public AttachmentResult Get(object entity, string name)
@@ -38,13 +38,13 @@ namespace Raven.Client.Documents.Session
                 ThrowEntityNotInSession(entity);
 
             var operation = new GetAttachmentOperation(document.Id, name, AttachmentType.Document, null);
-            return Session.OperationExecutor.Send(operation, SessionInfo);
+            return Session.Operations.Send(operation, SessionInfo);
         }
 
         public AttachmentResult GetRevision(string documentId, string name, string changeVector)
         {
             var operation = new GetAttachmentOperation(documentId, name, AttachmentType.Revision, changeVector);
-            return Session.OperationExecutor.Send(operation, SessionInfo);
+            return Session.Operations.Send(operation, SessionInfo);
         }
     }
 }

--- a/src/Raven.Client/Documents/Session/DocumentSessionAttachmentsAsync.cs
+++ b/src/Raven.Client/Documents/Session/DocumentSessionAttachmentsAsync.cs
@@ -27,25 +27,25 @@ namespace Raven.Client.Documents.Session
             return command.Result != null;
         }
 
-        public async Task<AttachmentResult> GetAsync(string documentId, string name)
+        public Task<AttachmentResult> GetAsync(string documentId, string name)
         {
             var operation = new GetAttachmentOperation(documentId, name, AttachmentType.Document, null);
-            return await Session.OperationExecutor.SendAsync(operation, sessionInfo: SessionInfo).ConfigureAwait(false);
+            return Session.Operations.SendAsync(operation, sessionInfo: SessionInfo);
         }
 
-        public async Task<AttachmentResult> GetAsync(object entity, string name)
+        public Task<AttachmentResult> GetAsync(object entity, string name)
         {
             if (DocumentsByEntity.TryGetValue(entity, out DocumentInfo document) == false)
                 ThrowEntityNotInSession(entity);
 
             var operation = new GetAttachmentOperation(document.Id, name, AttachmentType.Document, null);
-            return await Session.OperationExecutor.SendAsync(operation, sessionInfo: SessionInfo).ConfigureAwait(false);
+            return Session.Operations.SendAsync(operation, sessionInfo: SessionInfo);
         }
 
-        public async Task<AttachmentResult> GetRevisionAsync(string documentId, string name, string changeVector)
+        public Task<AttachmentResult> GetRevisionAsync(string documentId, string name, string changeVector)
         {
             var operation = new GetAttachmentOperation(documentId, name, AttachmentType.Revision, changeVector);
-            return await Session.OperationExecutor.SendAsync(operation, sessionInfo: SessionInfo).ConfigureAwait(false);
+            return Session.Operations.SendAsync(operation, sessionInfo: SessionInfo);
         }
     }
 }

--- a/src/Raven.Client/Documents/Session/InMemoryDocumentSessionOperations.cs
+++ b/src/Raven.Client/Documents/Session/InMemoryDocumentSessionOperations.cs
@@ -127,7 +127,7 @@ namespace Raven.Client.Documents.Session
 
         public RequestExecutor RequestExecutor => _requestExecutor;
 
-        public OperationExecutor OperationExecutor => _operationExecutor ?? (_operationExecutor = DocumentStore.Operations.ForDatabase(DatabaseName));
+        internal OperationExecutor Operations => _operationExecutor ?? (_operationExecutor = DocumentStore.Operations.ForDatabase(DatabaseName));
 
         public JsonOperationContext Context => _context;
 


### PR DESCRIPTION
- renamed OperationExecuter -> Operations (consistent with DocumentStore)
- internalized Operations property
- simplified async calls in DocumentSessionAttachmentsAsync