### PR TITLE
[4.0] RavenDB-10720 - cannot parse the value of property @metadata.@last-modified

### DIFF
--- a/src/Raven.Server/Documents/BlittableMetadataModifier.cs
+++ b/src/Raven.Server/Documents/BlittableMetadataModifier.cs
@@ -443,20 +443,21 @@ namespace Raven.Server.Documents
                         *(short*)(state.StringBuffer + sizeof(long) + sizeof(long)) != 25961 ||
                         state.StringBuffer[18] != (byte)'d')
                     {
-                        if (reader.Read() == false)
-                        {
-                            _state = State.ReadingLastModified;
-                            {
-                                aboutToReadPropertyName = false;
-                                return true;
-                            }
-                        }
-                        if (state.CurrentTokenType != JsonParserToken.String)
-                            ThrowExpectedFieldTypeOfString(Constants.Documents.Metadata.LastModified, state, reader);
-                        LastModified = ReadDateTime(state, reader);
+                        aboutToReadPropertyName = true;
+                        return true;
                     }
 
-                    goto case -1;
+                    if (reader.Read() == false)
+                    {
+                        _state = State.ReadingLastModified;
+                        aboutToReadPropertyName = false;
+                        return true;
+                    }
+
+                    if (state.CurrentTokenType != JsonParserToken.String)
+                        ThrowExpectedFieldTypeOfString(Constants.Documents.Metadata.LastModified, state, reader);
+                    LastModified = ReadDateTime(state, reader);
+                    break;
                 case 21: //Raven-Expiration-Date
                     if (*(long*)state.StringBuffer != 8666383010116297042 ||
                         *(long*)(state.StringBuffer + sizeof(long)) != 7957695015158966640 ||

--- a/test/FastTests/Issues/RavenDB-10720.cs
+++ b/test/FastTests/Issues/RavenDB-10720.cs
@@ -1,0 +1,28 @@
+﻿using Xunit;
+
+namespace FastTests.Issues
+{
+    public class RavenDB_10720 : RavenTestBase
+    {
+        [Fact]
+        public void CanSaveDocumentWithMetadata()
+        {
+            using (var store = GetDocumentStore())
+            {
+                using (var session = store.OpenSession())
+                {
+                    var entity = new User();
+                    session.Store(entity);
+                    var metadata = session.Advanced.GetMetadataFor(entity);
+                    metadata.Add("property--length-19", true);
+                    session.SaveChanges();
+                }
+            }
+        }
+
+        public class User
+        {
+            public string Id { get; set; }
+        }
+    }
+}


### PR DESCRIPTION
http://issues.hibernatingrhinos.com/issue/RavenDB-10720