### PR TITLE
[4.0] RavenDB-10676

### DIFF
--- a/src/Raven.Server/Documents/Indexes/MapReduce/MapReduceIndexingContext.cs
+++ b/src/Raven.Server/Documents/Indexes/MapReduce/MapReduceIndexingContext.cs
@@ -42,6 +42,9 @@ namespace Raven.Server.Documents.Indexes.MapReduce
 
         public unsafe void StoreNextMapResultId()
         {
+            if (MapPhaseTree.Llt.Environment.Options.IsCatastrophicFailureSet)
+                return; // avoid re-throwing it
+
             using (MapPhaseTree.DirectAdd(LastMapResultIdKey, sizeof(long), out byte* ptr))
                 *(long*)ptr = NextMapResultId;
         }


### PR DESCRIPTION
- When an index encounters corruption we really need to mark it as errored
- Do not start an errored index on database startup
- Ensure the original stacktrace of voron curruption in map-reduce index will be stored as indexing error