### PR TITLE
[4.1] RavenDB-10743

### DIFF
--- a/src/Raven.Server/Documents/Indexes/Static/Roslyn/MapFunctionProcessor.cs
+++ b/src/Raven.Server/Documents/Indexes/Static/Roslyn/MapFunctionProcessor.cs
@@ -36,7 +36,8 @@ namespace Raven.Server.Documents.Indexes.Static.Roslyn
                 RecurseRewriter.Instance,
                 SpatialFieldRewriter.Instance,
                 CoalesceRewriter.Instance,
-                InitializerExpressionRewriter.Instance
+                InitializerExpressionRewriter.Instance,
+                NullRewriter.Instance
             })
             {
                 node = rewriter.Visit(node);

--- a/src/Raven.Server/Documents/Indexes/Static/Roslyn/Rewriters/NullRewriter.cs
+++ b/src/Raven.Server/Documents/Indexes/Static/Roslyn/Rewriters/NullRewriter.cs
@@ -1,0 +1,48 @@
+﻿using Microsoft.CodeAnalysis;
+using Microsoft.CodeAnalysis.CSharp;
+using Microsoft.CodeAnalysis.CSharp.Syntax;
+
+namespace Raven.Server.Documents.Indexes.Static.Roslyn.Rewriters
+{
+    public class NullRewriter : CSharpSyntaxRewriter
+    {
+        public static readonly NullRewriter Instance = new NullRewriter();
+
+        private static readonly SyntaxNode Null = SyntaxFactory.ParseExpression($"{nameof(DynamicNullObject)}.{nameof(DynamicNullObject.ExplicitNull)}");
+
+        private NullRewriter()
+        {
+        }
+
+        public override SyntaxNode VisitLiteralExpression(LiteralExpressionSyntax node)
+        {
+            if (node.IsKind(SyntaxKind.NullLiteralExpression))
+            {
+                if (ShouldApply(node))
+                    return Null;
+            }
+
+            return base.VisitLiteralExpression(node);
+        }
+
+        private static bool ShouldApply(LiteralExpressionSyntax node)
+        {
+            var parent = node.Parent;
+            if (parent == null)
+                return false;
+
+            if (parent.IsKind(SyntaxKind.ConditionalExpression))
+            {
+                var conditionalExpressionSyntax = (ConditionalExpressionSyntax)parent;
+                var toCheck = conditionalExpressionSyntax.WhenFalse == node
+                    ? conditionalExpressionSyntax.WhenTrue
+                    : conditionalExpressionSyntax.WhenFalse;
+
+                if (toCheck.IsKind(SyntaxKind.CastExpression) == false)
+                    return true;
+            }
+
+            return false;
+        }
+    }
+}

--- a/src/Raven.Server/Documents/Indexes/Static/Roslyn/Rewriters/ReduceIndex/ReduceFunctionProcessor.cs
+++ b/src/Raven.Server/Documents/Indexes/Static/Roslyn/Rewriters/ReduceIndex/ReduceFunctionProcessor.cs
@@ -29,7 +29,8 @@ namespace Raven.Server.Documents.Indexes.Static.Roslyn.Rewriters.ReduceIndex
                 _selectManyRewriter,
                 SpatialFieldRewriter.Instance,
                 CoalesceRewriter.Instance,
-                InitializerExpressionRewriter.Instance
+                InitializerExpressionRewriter.Instance,
+                NullRewriter.Instance
             })
             {
                 node = rewriter.Visit(node);

--- a/src/Raven.Server/Smuggler/Documents/DatabaseSmuggler.cs
+++ b/src/Raven.Server/Smuggler/Documents/DatabaseSmuggler.cs
@@ -217,6 +217,9 @@ namespace Raven.Server.Smuggler.Documents
 
             void OnSkipped(long skipped)
             {
+                if (type == DatabaseItemType.Documents)
+                    result.Documents.SkippedCount = skipped;
+
                 if (skipped % 10000 != 0)
                     return;
 

--- a/src/Raven.Studio/typescript/viewmodels/common/notificationCenter/detailViewer/operations/smugglerDatabaseDetails.ts
+++ b/src/Raven.Studio/typescript/viewmodels/common/notificationCenter/detailViewer/operations/smugglerDatabaseDetails.ts
@@ -99,7 +99,7 @@ class smugglerDatabaseDetails extends abstractOperationDetails {
                     item.hasSkippedCount = false;
                     item.readCount = "-";
                     item.erroredCount = "-";
-                    item.skippedCount = "-";
+                    item.skippedCount = item.skippedCount || "-";
 
                     if (item.hasAttachments) {
                         const attachments = item.attachments;


### PR DESCRIPTION
- converting nulls in IndexDefinition to DynamicNullObject.ExplicitNull to enable null propagation,
- passing skippedCount when skipping documents and displaying that number in the UI to give user some feedback that we are actually doing something