### PR TITLE
[4.0] RavenDB-7919 Properly handling CompleteButIdle match - we want to us…

### DIFF
--- a/src/Raven.Server/Documents/Queries/Dynamic/DynamicQueryRunner.cs
+++ b/src/Raven.Server/Documents/Queries/Dynamic/DynamicQueryRunner.cs
@@ -229,6 +229,7 @@ namespace Raven.Server.Documents.Queries.Dynamic
             switch (matchResult.MatchType)
             {
                 case DynamicQueryMatchType.Complete:
+                case DynamicQueryMatchType.CompleteButIdle:
                     index = _indexStore.GetIndex(matchResult.IndexName);
                     return true;
                 case DynamicQueryMatchType.Partial:

--- a/test/SlowTests/Issues/RavenDB_7919.cs
+++ b/test/SlowTests/Issues/RavenDB_7919.cs
@@ -39,6 +39,11 @@ namespace SlowTests.Issues
                     await database.QueryRunner.ExecuteQuery(new IndexQueryServerSide("from Users where LastName = 'Arek'"), context, null,
                         OperationCancelToken.None);
                 }
+
+                var sameIndex = database.IndexStore.GetIndex(autoIndex.Name);
+
+                Assert.Same(autoIndex, sameIndex);
+                Assert.Equal(IndexState.Normal, sameIndex.State);
             }
         }
 


### PR DESCRIPTION
…e the idle index to satisfy the query when it's best match