### PR TITLE
[4.1] RavenDB-10812 introduced LastAccessTime that is bumped when database …

### DIFF
--- a/src/Raven.Server/Documents/DatabasesLandlord.cs
+++ b/src/Raven.Server/Documents/DatabasesLandlord.cs
@@ -402,6 +402,9 @@ namespace Raven.Server.Documents
                     }
                     else
                     {
+                        if (database.IsCompletedSuccessfully)
+                            database.Result.LastAccessTime = database.Result.Time.GetUtcNow();
+
                         return database;
                     }
                 }
@@ -641,7 +644,7 @@ namespace Raven.Server.Documents
             var envs = resource.GetAllStoragesEnvironment();
 
             long dbSize = 0;
-            var maxLastWork = DateTime.MinValue;
+            var maxLastWork = resource.LastAccessTime;
 
             foreach (var env in envs)
             {

--- a/src/Raven.Server/Documents/DocumentDatabase.cs
+++ b/src/Raven.Server/Documents/DocumentDatabase.cs
@@ -81,7 +81,8 @@ namespace Raven.Server.Documents
             _logger = LoggingSource.Instance.GetLogger<DocumentDatabase>(Name);
             _serverStore = serverStore;
             _addToInitLog = addToInitLog;
-            StartTime = SystemTime.UtcNow;
+            StartTime = Time.GetUtcNow();
+            LastAccessTime = Time.GetUtcNow();
             Configuration = configuration;
             Scripts = new ScriptRunnerCache(this, Configuration);
 
@@ -137,6 +138,8 @@ namespace Raven.Server.Documents
         public ServerStore ServerStore => _serverStore;
 
         public DateTime LastIdleTime => new DateTime(_lastIdleTicks);
+
+        public DateTime LastAccessTime;
 
         public DatabaseInfoCache DatabaseInfoCache { get; set; }
 

--- a/test/FastTests/Server/Basic/IdleOperations.cs
+++ b/test/FastTests/Server/Basic/IdleOperations.cs
@@ -84,6 +84,8 @@ namespace FastTests.Server.Basic
 
                         foreach (var env in documentDatabase.GetAllStoragesEnvironment())
                             env.Environment.ResetLastWorkTime();
+
+                        documentDatabase.LastAccessTime = DateTime.MinValue;
                     }
                 }
 
@@ -93,7 +95,7 @@ namespace FastTests.Server.Basic
                 {
                     var name = "IdleOperations_CleanupResources_DB_" + i;
 
-                    if (i%2==1)
+                    if (i % 2 == 1)
                         Assert.True(landlord.LastRecentlyUsed.TryGetValue(name, out outTime));
                     else
                         Assert.False(landlord.LastRecentlyUsed.TryGetValue(name, out outTime));


### PR DESCRIPTION
…is being accessed by DatabasesLandlord (e.g. on request)