### PR TITLE
[4.1] RavenDB-8427

### DIFF
--- a/src/Sparrow/Json/BlittableJsonReaderObject.cs
+++ b/src/Sparrow/Json/BlittableJsonReaderObject.cs
@@ -575,7 +575,7 @@ namespace Sparrow.Json
             long metadataSize = currentOffsetSize + currentPropertyIdSize + sizeof(byte);
             byte* metadataPtr = _metadataPtr;
 
-            int mid = comparer.LastFoundAt ?? (min + max) / 2;
+            int mid = (min + max) / 2;
             if (mid > max)
                 mid = max;
 

--- a/src/Sparrow/Json/LazyStringValue.cs
+++ b/src/Sparrow/Json/LazyStringValue.cs
@@ -96,7 +96,6 @@ namespace Sparrow.Json
 
         public int[] EscapePositions;
         public AllocatedMemoryData AllocatedMemoryData;
-        public int? LastFoundAt;        
 
         [MethodImpl(MethodImplOptions.AggressiveInlining)]
         public LazyStringValue(string str, byte* buffer, int size, JsonOperationContext context)
@@ -929,6 +928,7 @@ namespace Sparrow.Json
             _buffer = buffer;
             _string = str;
             _length = -1;
+            EscapePositions = null;
             IsDisposed = false;
             AllocatedMemoryData = null;
         }


### PR DESCRIPTION
- when renewing LazyStringValue we need to set EscapePositions to null
- removed LastFoundAt - not used