### PR TITLE
[4.0] RavenDB-10848

### DIFF
--- a/test/RachisTests/DatabaseCluster/ClusterDatabaseMaintenance.cs
+++ b/test/RachisTests/DatabaseCluster/ClusterDatabaseMaintenance.cs
@@ -194,7 +194,10 @@ namespace RachisTests.DatabaseCluster
         {
             var clusterSize = 3;
             var databaseName = "PromoteDatabaseNodeBackAfterReconnection";
-            var leader = await CreateRaftClusterAndGetLeader(clusterSize, false, 0);
+            var leader = await CreateRaftClusterAndGetLeader(clusterSize, false, 0, customSettings: new Dictionary<string, string>
+            {
+                [RavenConfiguration.GetKey(x => x.Cluster.MoveToRehabGraceTime)] = "4"
+            });
             using (var store = new DocumentStore
             {
                 Urls = new[] { leader.WebUrl },


### PR DESCRIPTION
fix failing test PromoteDatabaseNodeBackAfterReconnection
already merged to 4.1