### PR TITLE
[3.0] RavenDB-7411 - Raven.Backup.exe fails on esent when using a UNC path for RavenFS

### DIFF
--- a/Raven.Backup/FilesystemBackupOperation.cs
+++ b/Raven.Backup/FilesystemBackupOperation.cs
@@ -45,7 +45,7 @@ namespace Raven.Backup
 
             var backupRequest = new
             {
-                BackupLocation = parameters.BackupPath.Replace("\\", "\\\\"),
+                BackupLocation = parameters,
             };
 
 


### PR DESCRIPTION
http://issues.hibernatingrhinos.com/issue/RavenDB-7411