### PR TITLE
[4.0] RavenDB-10744 Adjust handling of catastrophic failures:

### DIFF
--- a/src/Raven.Server/Documents/CatastrophicFailureHandler.cs
+++ b/src/Raven.Server/Documents/CatastrophicFailureHandler.cs
@@ -1,0 +1,111 @@
+﻿using System;
+using System.Threading.Tasks;
+using Raven.Server.NotificationCenter.Notifications;
+using Raven.Server.NotificationCenter.Notifications.Details;
+using Raven.Server.ServerWide;
+using Sparrow.Collections.LockFree;
+using Sparrow.Logging;
+
+namespace Raven.Server.Documents
+{
+    public class CatastrophicFailureHandler
+    {
+        internal TimeSpan TimeToWaitBeforeUnloadingDatabase = TimeSpan.FromSeconds(2);
+        internal int MaxDatabaseUnloads = 3;
+        internal TimeSpan NoFailurePeriod = TimeSpan.FromMinutes(15);
+
+        private readonly ConcurrentDictionary<Guid, FailureStats> _errorsPerEnvironment = new ConcurrentDictionary<Guid, FailureStats>();
+
+        private readonly DatabasesLandlord _databasesLandlord;
+        private readonly ServerStore _serverStore;
+        private readonly Logger _logger;
+        
+        public CatastrophicFailureHandler(DatabasesLandlord databasesLandlord, ServerStore serverStore)
+        {
+            _databasesLandlord = databasesLandlord;
+            _serverStore = serverStore;
+            _logger = LoggingSource.Instance.GetLogger<CatastrophicFailureHandler>("Raven/Server");
+        }
+
+        public FailureStats GetStats(Guid environmentId)
+        {
+            return _errorsPerEnvironment[environmentId];
+        }
+
+        public void Execute(string databaseName, Exception e, Guid environmentId)
+        {
+            var stats = _errorsPerEnvironment.GetOrAdd(environmentId, x => FailureStats.Create(MaxDatabaseUnloads));
+
+            if (stats.WillUnloadDatabase == false)
+            {
+                if (DateTime.UtcNow - stats.LastUnloadTime > NoFailurePeriod)
+                {
+                    // let it unload again after it was working fine for a given time with no failure
+
+                    stats.NumberOfUnloads = 0;
+                    stats.LastUnloadTime = DateTime.MinValue;
+                }
+                else
+                {
+                    return;
+                }
+            }
+
+            stats.DatabaseUnloadTask = Task.Run(async () =>
+            {
+                var title = $"Critical error in '{databaseName}'";
+                const string message = "Database is about to be unloaded due to an encountered error";
+
+                try
+                {
+                    _serverStore.NotificationCenter.Add(AlertRaised.Create(
+                        databaseName,
+                        title,
+                        message,
+                        AlertType.CatastrophicDatabaseFailure,
+                        NotificationSeverity.Error,
+                        key: databaseName,
+                        details: new ExceptionDetails(e)));
+                }
+                catch (Exception)
+                {
+                    // exception in raising an alert can't prevent us from unloading a database
+                }
+
+                if (_logger.IsOperationsEnabled)
+                    _logger.Operations($"{title}. {message}", e);
+
+                // let it propagate the exception to the client first and do
+                // the internal failure handling e.g. Index.HandleIndexCorruption
+                await Task.Delay(TimeToWaitBeforeUnloadingDatabase); 
+
+                stats.NumberOfUnloads++;
+                stats.LastUnloadTime = DateTime.UtcNow;
+                (await _databasesLandlord.UnloadAndLockDatabase(databaseName, "CatastrophicFailure"))?.Dispose();
+                
+                stats.DatabaseUnloadTask = null;
+            });
+        }
+
+        public class FailureStats
+        {
+            private readonly int _maxDatabaseUnloads;
+
+            public FailureStats(int maxDatabaseUnloads)
+            {
+                _maxDatabaseUnloads = maxDatabaseUnloads;
+            }
+
+            public int NumberOfUnloads;
+            public DateTime? LastUnloadTime;
+            public Task DatabaseUnloadTask;
+
+            public bool WillUnloadDatabase => NumberOfUnloads < _maxDatabaseUnloads;
+
+            public static FailureStats Create(int maxDatabaseUnloads)
+            {
+                return new FailureStats(maxDatabaseUnloads);
+            }
+        }
+    }
+}

--- a/src/Raven.Server/Documents/CompactDatabaseTask.cs
+++ b/src/Raven.Server/Documents/CompactDatabaseTask.cs
@@ -42,7 +42,7 @@ namespace Raven.Server.Documents
 
             using (await _serverStore.DatabasesLandlord.UnloadAndLockDatabase(_database, "it is being compacted"))
             using (var src = DocumentsStorage.GetStorageEnvironmentOptionsFromConfiguration(configuration, new IoChangesNotifications(),
-                new CatastrophicFailureNotification(exception => throw new InvalidOperationException($"Failed to compact database {_database}", exception))))
+                new CatastrophicFailureNotification((endId, exception) => throw new InvalidOperationException($"Failed to compact database {_database}", exception))))
             {
                 src.ForceUsing32BitsPager = configuration.Storage.ForceUsing32BitsPager;
                 src.OnNonDurableFileSystemError += documentDatabase.HandleNonDurableFileSystemError;
@@ -60,7 +60,7 @@ namespace Raven.Server.Documents
                 {
                     configuration.Core.DataDirectory = new PathSetting(basePath + "-Compacting");
                     using (var dst = DocumentsStorage.GetStorageEnvironmentOptionsFromConfiguration(configuration, new IoChangesNotifications(),
-                        new CatastrophicFailureNotification(exception => throw new InvalidOperationException($"Failed to compact database {_database}", exception))))
+                        new CatastrophicFailureNotification((envId, exception) => throw new InvalidOperationException($"Failed to compact database {_database}", exception))))
                     {
                         dst.OnNonDurableFileSystemError += documentDatabase.HandleNonDurableFileSystemError;
                         dst.OnRecoveryError += documentDatabase.HandleOnDatabaseRecoveryError;

--- a/src/Raven.Server/Documents/Indexes/CollectionOfBloomFilters.cs
+++ b/src/Raven.Server/Documents/Indexes/CollectionOfBloomFilters.cs
@@ -426,6 +426,9 @@ namespace Raven.Server.Documents.Indexes
                 if (Count == _initialCount)
                     return;
 
+                if (_tree.Llt.Environment.Options.IsCatastrophicFailureSet)
+                    return; // avoid re-throwing it
+
                 _tree.Increment(_keySlice, Count - _initialCount);
             }
 

--- a/src/Raven.Server/Documents/Indexes/Index.cs
+++ b/src/Raven.Server/Documents/Indexes/Index.cs
@@ -683,6 +683,7 @@ namespace Raven.Server.Documents.Indexes
                 }
 
                 using (_contextPool.AllocateOperationContext(out TransactionOperationContext indexContext))
+                using (_environment.Options.SkipCatastrophicFailureAssertion())
                 using (indexContext.OpenReadTransaction())
                 {
                     return IsStale(databaseContext, indexContext, cutoff, stalenessReasons);
@@ -710,6 +711,7 @@ namespace Raven.Server.Documents.Indexes
                     return (true, (long)IndexProgressStatus.RunningStorageOperation);
 
                 using (_contextPool.AllocateOperationContext(out TransactionOperationContext indexContext))
+                using (_environment.Options.SkipCatastrophicFailureAssertion())
                 using (indexContext.OpenReadTransaction())
                 {
                     var isStale = IsStale(databaseContext, indexContext);
@@ -1282,7 +1284,20 @@ namespace Raven.Server.Documents.Indexes
             if (_logger.IsOperationsEnabled)
                 _logger.Operations($"Data corruption occurred for '{Name}'.", e);
 
+            var corruptionStats = DocumentDatabase.ServerStore.DatabasesLandlord.CatastrophicFailureHandler.GetStats(_environment.DbId);
+
+            if (corruptionStats.WillUnloadDatabase)
+            {
+                // it can be a transient error, we are going to unload the database and do not error the index yet
+                // let's stop the indexing thread
+                _indexDisabled = true;  
+                return;
+            }
+
+            // we exceeded the number of db unloads due to corruption error, let's error the index
+            
             _errorStateReason = $"State was changed due to data corruption with message '{e.Message}'";
+
             try
             {
                 using (_environment.Options.SkipCatastrophicFailureAssertion()) // we really want to store Error state
@@ -1744,6 +1759,7 @@ namespace Raven.Server.Documents.Indexes
                     throw new ObjectDisposedException("Index " + Name);
 
                 using (_contextPool.AllocateOperationContext(out TransactionOperationContext context))
+                using (_environment.Options.SkipCatastrophicFailureAssertion())
                 using (var tx = context.OpenReadTransaction())
                 using (var reader = IndexPersistence.OpenIndexReader(tx.InnerTransaction))
                 {

--- a/src/Voron/Exceptions/CatastrophicFailureNotification.cs
+++ b/src/Voron/Exceptions/CatastrophicFailureNotification.cs
@@ -5,22 +5,22 @@ namespace Voron.Exceptions
 {
     public class CatastrophicFailureNotification
     {
-        private readonly Action<Exception> _catastrophicFailure;
+        private readonly Action<Guid, Exception> _catastrophicFailure;
         private bool _raised;
 
-        public CatastrophicFailureNotification(Action<Exception> catastrophicFailureHandler)
+        public CatastrophicFailureNotification(Action<Guid, Exception> catastrophicFailureHandler)
         {
             Debug.Assert(catastrophicFailureHandler != null);
 
             _catastrophicFailure = catastrophicFailureHandler;
         }
 
-        public void RaiseNotificationOnce(Exception e)
+        public void RaiseNotificationOnce(Guid environmentId, Exception e)
         {
             if (_raised)
                 return;
 
-            _catastrophicFailure.Invoke(e);
+            _catastrophicFailure.Invoke(environmentId, e);
 
             _raised = true;
         }

--- a/src/Voron/StorageEnvironment.cs
+++ b/src/Voron/StorageEnvironment.cs
@@ -402,6 +402,8 @@ namespace Voron
                 var result = Base64.ConvertToBase64ArrayUnpadded(pChars, (byte*)&databseGuidId, 0, 16);
                 Debug.Assert(result == 22);
             }
+
+            _options.SetEnvironmentId(databseGuidId);
         }
 
         public string Base64Id { get; } = new string(' ', 22);
@@ -959,6 +961,7 @@ namespace Voron
         public EnvironmentStats Stats()
         {
             var transactionPersistentContext = new TransactionPersistentContext();
+            using (_options.SkipCatastrophicFailureAssertion())
             using (var tx = NewLowLevelTransaction(transactionPersistentContext, TransactionFlags.Read))
             {
                 var numberOfAllocatedPages = Math.Max(_dataPager.NumberOfAllocatedPages, State.NextPageNumber - 1); // async apply to data file task

--- a/src/Voron/StorageEnvironmentOptions.cs
+++ b/src/Voron/StorageEnvironmentOptions.cs
@@ -189,9 +189,9 @@ namespace Voron
 
             IoMetrics = new IoMetrics(256, 256, ioChangesNotifications);
 
-            _log = LoggingSource.Instance.GetLogger<StorageEnvironment>(tempPath.FullPath);
+            _log = LoggingSource.Instance.GetLogger<StorageEnvironmentOptions>(tempPath.FullPath);
 
-            _catastrophicFailureNotification = catastrophicFailureNotification ?? new CatastrophicFailureNotification((e) =>
+            _catastrophicFailureNotification = catastrophicFailureNotification ?? new CatastrophicFailureNotification((id, e) =>
             {
                 if (_log.IsOperationsEnabled)
                     _log.Operations($"Catastrophic failure in {this}", e);
@@ -207,7 +207,7 @@ namespace Voron
         public void SetCatastrophicFailure(ExceptionDispatchInfo exception)
         {
             _catastrophicFailure = exception;
-            _catastrophicFailureNotification.RaiseNotificationOnce(exception.SourceException);
+            _catastrophicFailureNotification.RaiseNotificationOnce(_environmentId, exception.SourceException);
         }
 
         public bool IsCatastrophicFailureSet => _catastrophicFailure != null;
@@ -1063,6 +1063,7 @@ namespace Voron
         private int _numOfConcurrentSyncsPerPhysDrive;
         private int _timeToSyncAfterFlashInSec;
         public long CompressTxAboveSizeInBytes;
+        private Guid _environmentId;
 
         public virtual void SetPosixOptions()
         {
@@ -1126,6 +1127,11 @@ namespace Voron
                     // nothing we can do about it
                 }
             }
+        }
+
+        public void SetEnvironmentId(Guid environmentId)
+        {
+            _environmentId = environmentId;
         }
     }
 }

--- a/test/SlowTests/Issues/RavenDB_10744.cs
+++ b/test/SlowTests/Issues/RavenDB_10744.cs
@@ -1,0 +1,168 @@
+﻿using System;
+using System.Linq;
+using System.Threading;
+using FastTests;
+using Raven.Client;
+using Raven.Client.Documents.Changes;
+using Raven.Client.Documents.Indexes;
+using Raven.Server.Documents;
+using Raven.Server.Documents.Indexes.Static;
+using Raven.Server.ServerWide.Context;
+using Sparrow.Json.Parsing;
+using Xunit;
+
+namespace SlowTests.Issues
+{
+    public class RavenDB_10744 : RavenLowLevelTestBase
+    {
+        [Fact]
+        public void Shold_stop_unloading_database_after_consecutive_corruptions_in_given_time()
+        {
+            UseNewLocalServer();
+
+            using (var db = CreateDocumentDatabase())
+            {
+                var handler = db.ServerStore.DatabasesLandlord.CatastrophicFailureHandler;
+
+                handler.TimeToWaitBeforeUnloadingDatabase = TimeSpan.Zero;
+                var environmentId = Guid.NewGuid();
+
+                CatastrophicFailureHandler.FailureStats failureStats;
+
+                for (int i = 0; i < handler.MaxDatabaseUnloads; i++)
+                {
+                    handler.Execute(db.Name, new Exception("Catastrophic"), environmentId);
+
+                    failureStats = handler.GetStats(environmentId);
+
+                    Assert.True(failureStats.WillUnloadDatabase);
+                    Assert.True(failureStats.DatabaseUnloadTask.Wait(TimeSpan.FromSeconds(30)));
+                }
+
+                handler.Execute(db.Name, new Exception("Catastrophic"), Guid.Empty);
+
+                failureStats = handler.GetStats(environmentId);
+
+                Assert.False(failureStats.WillUnloadDatabase);
+
+                // but it should let it unload after it exceeds the given time
+
+                handler.NoFailurePeriod = TimeSpan.Zero;
+
+                handler.Execute(db.Name, new Exception("Catastrophic"), environmentId);
+
+                failureStats = handler.GetStats(environmentId);
+
+                Assert.True(failureStats.WillUnloadDatabase);
+                Assert.True(failureStats.DatabaseUnloadTask.Wait(TimeSpan.FromSeconds(30)));
+            }
+        }
+
+        [Fact]
+        public void First_index_corruption_should_not_error_it_immediately()
+        {
+            UseNewLocalServer();
+
+            using (var db = CreateDocumentDatabase())
+            {
+                using (var index = MapIndex.CreateNew(new IndexDefinition()
+                {
+                    Name = "Users_ByName",
+                    Maps =
+                    {
+                        "from user in docs.Users select new { user.Name }"
+                    },
+                    Type = IndexType.Map
+                }, db))
+                {
+                    PutUser(db);
+
+                    index._indexStorage.SimulateCorruption = true;
+
+                    index.Start();
+
+                    // should unload db but not error the index
+                    Assert.True(SpinWait.SpinUntil(() => db.ServerStore.DatabasesLandlord.DatabasesCache.Any() == false, TimeSpan.FromMinutes(1)));
+                    Assert.Equal(IndexState.Normal, index.State);
+                }
+            }
+        }
+
+        [Fact]
+        public void Should_be_able_to_read_index_stats_even_if_corruption_happened()
+        {
+            UseNewLocalServer();
+
+            using (var db = CreateDocumentDatabase())
+            {
+                using (var index = MapIndex.CreateNew(new IndexDefinition()
+                {
+                    Name = "Users_ByName",
+                    Maps =
+                    {
+                        "from user in docs.Users select new { user.Name }"
+                    },
+                    Type = IndexType.Map
+                }, db))
+                {
+                    PutUser(db);
+
+                    index._indexStorage.SimulateCorruption = true;
+
+                    db.ServerStore.DatabasesLandlord.CatastrophicFailureHandler.MaxDatabaseUnloads = 0;
+
+                    index.Start();
+
+                    var mre = new ManualResetEventSlim();
+
+                    db.Changes.OnIndexChange += change =>
+                    {
+                        if (change.Type == IndexChangeTypes.IndexMarkedAsErrored)
+                            mre.Set();
+                    };
+
+                    Assert.True(mre.Wait(TimeSpan.FromMinutes(1)));
+                    Assert.Equal(IndexState.Error, index.State);
+
+                    var errorCount = index.GetErrorCount();
+                    Assert.Equal(1, errorCount);
+
+                    using (var context = DocumentsOperationContext.ShortTermSingleUse(db))
+                    {
+                        using (var tx = context.OpenWriteTransaction())
+                        {
+                            var indexStats = index.GetIndexStats(context);
+
+                            Assert.True(indexStats.IsStale);
+                        }
+                    }
+
+                    var indexingErrors = index.GetErrors();
+
+                    Assert.Equal(1, indexingErrors.Count);
+                }
+            }
+        }
+
+        private static void PutUser(DocumentDatabase db)
+        {
+            using (var context = DocumentsOperationContext.ShortTermSingleUse(db))
+            {
+                using (var tx = context.OpenWriteTransaction())
+                {
+                    using (var doc = CreateDocument(context, "users/1", new DynamicJsonValue
+                    {
+                        ["Name"] = "John",
+                        [Constants.Documents.Metadata.Key] = new DynamicJsonValue
+                            {[Constants.Documents.Metadata.Collection] = "Users"}
+                    }))
+                    {
+                        db.DocumentsStorage.Put(context, "users/1", null, doc);
+                    }
+
+                    tx.Commit();
+                }
+            }
+        }
+    }
+}

--- a/test/SlowTests/Issues/RavenDB_5489.cs
+++ b/test/SlowTests/Issues/RavenDB_5489.cs
@@ -17,6 +17,8 @@ namespace SlowTests.Issues
         [Fact]
         public async Task IfIndexEncountersCorruptionItShouldBeMarkedAsErrored()
         {
+            UseNewLocalServer();
+
             using (var store = GetDocumentStore())
             {
                 new Users_ByName().Execute(store);
@@ -38,6 +40,9 @@ namespace SlowTests.Issues
                 var database = await GetDatabase(store.Database);
                 var index = database.IndexStore.GetIndex("Users/ByName");
                 index._indexStorage.SimulateCorruption = true;
+
+                // force erroring the index immediately
+                database.ServerStore.DatabasesLandlord.CatastrophicFailureHandler.MaxDatabaseUnloads = 0;
 
                 using (var session = store.OpenSession())
                 {


### PR DESCRIPTION
- don't error the index immediately once the corruption happens there, let's do it after 3rd error
- stop unloading database if after 3rd unload we still get an error
- allow to read index stats once the catastrophic failure is set (to prevent crashing the studio, we are going to unload the db anyway but it's it should be still possible to get the stats and errors)