### PR TITLE
RavenDB-10767: Prevent using the same scratch file name in test (in c…

### DIFF
--- a/test/StressTests/Voron/HugeTransactions.cs
+++ b/test/StressTests/Voron/HugeTransactions.cs
@@ -143,9 +143,10 @@ namespace StressTests.Voron
                 long Gb = 1024 * 1024 * 1024;
                 long inputSize = 3L * Gb;
                 byte* outputBuffer, inputBuffer, checkedBuffer;
-                var outputPager = CreateScratchFile($"output-{devider}", env, inputSize, out outputBuffer);
-                var inputPager = CreateScratchFile($"input-{devider}", env, inputSize, out inputBuffer);
-                var checkedPager = CreateScratchFile($"checked-{devider}", env, inputSize, out checkedBuffer);
+                var rnd = new Random().Next(int.MaxValue);
+                var outputPager = CreateScratchFile($"output-{devider}-{rnd}", env, inputSize, out outputBuffer);
+                var inputPager = CreateScratchFile($"input-{devider}-{rnd}", env, inputSize, out inputBuffer);
+                var checkedPager = CreateScratchFile($"checked-{devider}-{rnd}", env, inputSize, out checkedBuffer);
 
                 var random = new Random(123);
 


### PR DESCRIPTION
…ase previous tests did not delete it)