### PR TITLE
[4.0] RavenDB-10870 Calling AssertNoCatastrophicFailure() only for write tr…

### DIFF
--- a/src/Raven.Server/Documents/DocumentDatabase.cs
+++ b/src/Raven.Server/Documents/DocumentDatabase.cs
@@ -864,19 +864,16 @@ namespace Raven.Server.Documents
                 Transaction tx = null;
                 try
                 {
-                    using (environment.Environment.Options.SkipCatastrophicFailureAssertion())
+                    try
                     {
-                        try
-                        {
-                            tx = environment.Environment.ReadTransaction();
-                        }
-                        catch (OperationCanceledException)
-                        {
-                            continue;
-                        }
-
-                        sizeOnDiskInBytes += GetSizeOnDisk(environment, tx);
+                        tx = environment.Environment.ReadTransaction();
                     }
+                    catch (OperationCanceledException)
+                    {
+                        continue;
+                    }
+
+                    sizeOnDiskInBytes += GetSizeOnDisk(environment, tx);
                 }
                 finally
                 {

--- a/src/Raven.Server/Documents/Indexes/Index.cs
+++ b/src/Raven.Server/Documents/Indexes/Index.cs
@@ -683,7 +683,6 @@ namespace Raven.Server.Documents.Indexes
                 }
 
                 using (_contextPool.AllocateOperationContext(out TransactionOperationContext indexContext))
-                using (_environment.Options.SkipCatastrophicFailureAssertion())
                 using (indexContext.OpenReadTransaction())
                 {
                     return IsStale(databaseContext, indexContext, cutoff, stalenessReasons);
@@ -711,7 +710,6 @@ namespace Raven.Server.Documents.Indexes
                     return (true, (long)IndexProgressStatus.RunningStorageOperation);
 
                 using (_contextPool.AllocateOperationContext(out TransactionOperationContext indexContext))
-                using (_environment.Options.SkipCatastrophicFailureAssertion())
                 using (indexContext.OpenReadTransaction())
                 {
                     var isStale = IsStale(databaseContext, indexContext);
@@ -1759,7 +1757,6 @@ namespace Raven.Server.Documents.Indexes
                     throw new ObjectDisposedException("Index " + Name);
 
                 using (_contextPool.AllocateOperationContext(out TransactionOperationContext context))
-                using (_environment.Options.SkipCatastrophicFailureAssertion())
                 using (var tx = context.OpenReadTransaction())
                 using (var reader = IndexPersistence.OpenIndexReader(tx.InnerTransaction))
                 {

--- a/src/Raven.Server/Documents/Indexes/IndexStorage.cs
+++ b/src/Raven.Server/Documents/Indexes/IndexStorage.cs
@@ -180,7 +180,6 @@ namespace Raven.Server.Documents.Indexes
             var errors = new List<IndexingError>();
 
             using (_contextPool.AllocateOperationContext(out TransactionOperationContext context))
-            using (_environment.Options.SkipCatastrophicFailureAssertion())
             using (var tx = context.OpenReadTransaction())
             {
                 var table = tx.InnerTransaction.OpenTable(_errorsSchema, "Errors");
@@ -212,7 +211,6 @@ namespace Raven.Server.Documents.Indexes
         public long ReadErrorsCount()
         {
             using (_contextPool.AllocateOperationContext(out TransactionOperationContext context))
-            using (_environment.Options.SkipCatastrophicFailureAssertion())
             using (var tx = context.OpenReadTransaction())
             {
                 var table = tx.InnerTransaction.OpenTable(_errorsSchema, "Errors");

--- a/src/Voron/Impl/LowLevelTransaction.cs
+++ b/src/Voron/Impl/LowLevelTransaction.cs
@@ -226,7 +226,9 @@ namespace Voron.Impl
         public LowLevelTransaction(StorageEnvironment env, long id, TransactionPersistentContext transactionPersistentContext, TransactionFlags flags, IFreeSpaceHandling freeSpaceHandling, ByteStringContext context = null)
         {
             TxStartTime = DateTime.UtcNow;
-            env.Options.AssertNoCatastrophicFailure();
+
+            if (flags == TransactionFlags.ReadWrite)
+                env.Options.AssertNoCatastrophicFailure();
 
             DataPager = env.Options.DataPager;
             _env = env;

--- a/src/Voron/StorageEnvironment.cs
+++ b/src/Voron/StorageEnvironment.cs
@@ -961,7 +961,6 @@ namespace Voron
         public EnvironmentStats Stats()
         {
             var transactionPersistentContext = new TransactionPersistentContext();
-            using (_options.SkipCatastrophicFailureAssertion())
             using (var tx = NewLowLevelTransaction(transactionPersistentContext, TransactionFlags.Read))
             {
                 var numberOfAllocatedPages = Math.Max(_dataPager.NumberOfAllocatedPages, State.NextPageNumber - 1); // async apply to data file task


### PR DESCRIPTION
…ansactions. Removing no longer necessary calls which forced to skip this assertion for read tx.