### PR TITLE
[4.0] RavenDB-10878 Prevent deadlock during indexing stopping. We need to s…

### DIFF
--- a/src/Raven.Server/Documents/Indexes/Index.cs
+++ b/src/Raven.Server/Documents/Indexes/Index.cs
@@ -114,6 +114,7 @@ namespace Raven.Server.Documents.Indexes
         internal TransactionContextPool _contextPool;
 
         protected readonly ManualResetEventSlim _mre = new ManualResetEventSlim();
+        private readonly object _disablingIndexLock = new object();
 
         private readonly ManualResetEventSlim _logsAppliedEvent = new ManualResetEventSlim();
 
@@ -614,8 +615,11 @@ namespace Raven.Server.Documents.Indexes
 
             if (disableIndex)
             {
-                _indexDisabled = true;
-                _mre.Set();
+                lock (_disablingIndexLock)
+                {
+                    _indexDisabled = true;
+                    _mre.Set();
+                }
             }
             else
             {
@@ -877,16 +881,21 @@ namespace Raven.Server.Documents.Indexes
 
                     while (true)
                     {
-                        if (_indexDisabled)
-                            return;
+                        lock (_disablingIndexLock)
+                        {
+                            if (_indexDisabled)
+                                return;
 
+                            _mre.Reset();
+                        }
+                        
                         // this is called on every iteration because index priorities can be changed at runtime
                         ChangeIndexThreadPriorityIfNeeded();
 
                         if (_logger.IsInfoEnabled)
                             _logger.Info($"Starting indexing for '{Name}'.");
 
-                        _mre.Reset();
+                        
 
                         var stats = _lastStats = new IndexingStatsAggregator(DocumentDatabase.IndexStore.Identities.GetNextIndexingStatsId(), _lastStats);
                         LastIndexingTime = stats.StartTime;
@@ -1288,7 +1297,9 @@ namespace Raven.Server.Documents.Indexes
             {
                 // it can be a transient error, we are going to unload the database and do not error the index yet
                 // let's stop the indexing thread
-                _indexDisabled = true;  
+                _indexDisabled = true;
+                _mre.Set();
+
                 return;
             }
 


### PR DESCRIPTION
…ynchronize the code responsible for disabling the indexing thread.

Added missing _mre.Set() in HandleIndexCorruption (lock isn't needed, we are in the index thread)