### PR TITLE
[4.0] RavenDB-10887 Exposing MaxScratchBufferSize as Storage.MaxScratchBuff…

### DIFF
--- a/src/Raven.Server/Config/Categories/StorageConfiguration.cs
+++ b/src/Raven.Server/Config/Categories/StorageConfiguration.cs
@@ -44,5 +44,11 @@ namespace Raven.Server.Config.Categories
         [SizeUnit(SizeUnit.Kilobytes)]
         [ConfigurationEntry("Storage.CompressTxAboveSizeInKb", ConfigurationEntryScope.ServerWideOrPerDatabase)]
         public Size CompressTxAboveSize { get; set; }
+
+        [Description("Max size of .buffers files")]
+        [DefaultValue(null)]
+        [SizeUnit(SizeUnit.Megabytes)]
+        [ConfigurationEntry("Storage.MaxScratchBufferSizeInMb", ConfigurationEntryScope.ServerWideOrPerDatabase)]
+        public Size? MaxScratchBufferSize { get; set; }
     }
 }

--- a/src/Raven.Server/Documents/ConfigurationStorage.cs
+++ b/src/Raven.Server/Documents/ConfigurationStorage.cs
@@ -38,6 +38,8 @@ namespace Raven.Server.Documents
             options.NumOfConcurrentSyncsPerPhysDrive = db.Configuration.Storage.NumberOfConcurrentSyncsPerPhysicalDrive;
             options.MasterKey = db.MasterKey?.ToArray();
             options.DoNotConsiderMemoryLockFailureAsCatastrophicError = db.Configuration.Security.DoNotConsiderMemoryLockFailureAsCatastrophicError;
+            if (db.Configuration.Storage.MaxScratchBufferSize.HasValue)
+                options.MaxScratchBufferSize = db.Configuration.Storage.MaxScratchBufferSize.Value.GetValue(SizeUnit.Bytes);
 
             Environment = LayoutUpdater.OpenEnvironment(options);
 

--- a/src/Raven.Server/Documents/DocumentsStorage.cs
+++ b/src/Raven.Server/Documents/DocumentsStorage.cs
@@ -229,7 +229,8 @@ namespace Raven.Server.Documents
             options.AddToInitLog = _addToInitLog;
             options.MasterKey = DocumentDatabase.MasterKey?.ToArray();
             options.DoNotConsiderMemoryLockFailureAsCatastrophicError = DocumentDatabase.Configuration.Security.DoNotConsiderMemoryLockFailureAsCatastrophicError;
-
+            if (DocumentDatabase.Configuration.Storage.MaxScratchBufferSize.HasValue)
+                options.MaxScratchBufferSize = DocumentDatabase.Configuration.Storage.MaxScratchBufferSize.Value.GetValue(SizeUnit.Bytes);
             try
             {
                 Initialize(options);

--- a/src/Raven.Server/Documents/Indexes/Index.cs
+++ b/src/Raven.Server/Documents/Indexes/Index.cs
@@ -424,18 +424,24 @@ namespace Raven.Server.Documents.Indexes
             return options;
         }
 
-        private static void InitializeOptions(StorageEnvironmentOptions options, DocumentDatabase documentDatabase, string name)
+        private static void InitializeOptions(StorageEnvironmentOptions options, DocumentDatabase documentDatabase, string name, bool schemaUpgrader = true)
         {
             options.OnNonDurableFileSystemError += documentDatabase.HandleNonDurableFileSystemError;
             options.OnRecoveryError += (s, e) => documentDatabase.HandleOnIndexRecoveryError(name, s, e);
             options.CompressTxAboveSizeInBytes = documentDatabase.Configuration.Storage.CompressTxAboveSize.GetValue(SizeUnit.Bytes);
-            options.SchemaVersion = SchemaUpgrader.CurrentVersion.IndexVersion;
-            options.SchemaUpgrader = SchemaUpgrader.Upgrader(SchemaUpgrader.StorageType.Index, null, null);
             options.ForceUsing32BitsPager = documentDatabase.Configuration.Storage.ForceUsing32BitsPager;
             options.TimeToSyncAfterFlashInSec = (int)documentDatabase.Configuration.Storage.TimeToSyncAfterFlash.AsTimeSpan.TotalSeconds;
             options.NumOfConcurrentSyncsPerPhysDrive = documentDatabase.Configuration.Storage.NumberOfConcurrentSyncsPerPhysicalDrive;
             options.MasterKey = documentDatabase.MasterKey?.ToArray(); //clone
             options.DoNotConsiderMemoryLockFailureAsCatastrophicError = documentDatabase.Configuration.Security.DoNotConsiderMemoryLockFailureAsCatastrophicError;
+            if (documentDatabase.Configuration.Storage.MaxScratchBufferSize.HasValue)
+                options.MaxScratchBufferSize = documentDatabase.Configuration.Storage.MaxScratchBufferSize.Value.GetValue(SizeUnit.Bytes);
+
+            if (schemaUpgrader)
+            {
+                options.SchemaVersion = SchemaUpgrader.CurrentVersion.IndexVersion;
+                options.SchemaUpgrader = SchemaUpgrader.Upgrader(SchemaUpgrader.StorageType.Index, null, null);
+            }
         }
 
         internal ExitWriteLock DrainRunningQueries()
@@ -2801,29 +2807,16 @@ namespace Raven.Server.Documents.Indexes
                         (StorageEnvironmentOptions.DirectoryStorageEnvironmentOptions)storageEnvironmentOptions;
                     var srcOptions = StorageEnvironmentOptions.ForPath(environmentOptions.BasePath.FullPath, null, null, DocumentDatabase.IoChanges,
                         DocumentDatabase.CatastrophicFailureNotification);
-                    srcOptions.ForceUsing32BitsPager = DocumentDatabase.Configuration.Storage.ForceUsing32BitsPager;
-                    srcOptions.OnNonDurableFileSystemError += DocumentDatabase.HandleNonDurableFileSystemError;
-                    srcOptions.OnRecoveryError += (s, e) => DocumentDatabase.HandleOnIndexRecoveryError(Name, s, e);
-                    srcOptions.CompressTxAboveSizeInBytes = DocumentDatabase.Configuration.Storage.CompressTxAboveSize.GetValue(SizeUnit.Bytes);
-                    srcOptions.TimeToSyncAfterFlashInSec = (int)DocumentDatabase.Configuration.Storage.TimeToSyncAfterFlash.AsTimeSpan.TotalSeconds;
-                    srcOptions.NumOfConcurrentSyncsPerPhysDrive = DocumentDatabase.Configuration.Storage.NumberOfConcurrentSyncsPerPhysicalDrive;
-                    srcOptions.MasterKey = DocumentDatabase.MasterKey?.ToArray();//clone
-                    srcOptions.DoNotConsiderMemoryLockFailureAsCatastrophicError = DocumentDatabase.Configuration.Security.DoNotConsiderMemoryLockFailureAsCatastrophicError;
-                    compactPath = Configuration.StoragePath.Combine(IndexDefinitionBase.GetIndexNameSafeForFileSystem(Name) + "_Compact");
 
+                    InitializeOptions(srcOptions, DocumentDatabase, Name, schemaUpgrader: false);
+
+                    compactPath = Configuration.StoragePath.Combine(IndexDefinitionBase.GetIndexNameSafeForFileSystem(Name) + "_Compact");
 
                     using (var compactOptions = (StorageEnvironmentOptions.DirectoryStorageEnvironmentOptions)
                         StorageEnvironmentOptions.ForPath(compactPath.FullPath, null, null, DocumentDatabase.IoChanges,
                             DocumentDatabase.CatastrophicFailureNotification))
                     {
-                        compactOptions.OnNonDurableFileSystemError += DocumentDatabase.HandleNonDurableFileSystemError;
-                        compactOptions.OnRecoveryError += (s, e) => DocumentDatabase.HandleOnIndexRecoveryError(Name, s, e);
-                        compactOptions.CompressTxAboveSizeInBytes = DocumentDatabase.Configuration.Storage.CompressTxAboveSize.GetValue(SizeUnit.Bytes);
-                        compactOptions.ForceUsing32BitsPager = DocumentDatabase.Configuration.Storage.ForceUsing32BitsPager;
-                        compactOptions.TimeToSyncAfterFlashInSec = (int)DocumentDatabase.Configuration.Storage.TimeToSyncAfterFlash.AsTimeSpan.TotalSeconds;
-                        compactOptions.NumOfConcurrentSyncsPerPhysDrive = DocumentDatabase.Configuration.Storage.NumberOfConcurrentSyncsPerPhysicalDrive;
-                        compactOptions.MasterKey = DocumentDatabase.MasterKey?.ToArray();//clone
-                        compactOptions.DoNotConsiderMemoryLockFailureAsCatastrophicError = DocumentDatabase.Configuration.Security.DoNotConsiderMemoryLockFailureAsCatastrophicError;
+                        InitializeOptions(compactOptions, DocumentDatabase, Name, schemaUpgrader: false);
 
                         StorageCompaction.Execute(srcOptions, compactOptions, progressReport =>
                         {

--- a/src/Raven.Server/ServerWide/ServerStore.cs
+++ b/src/Raven.Server/ServerWide/ServerStore.cs
@@ -462,6 +462,8 @@ namespace Raven.Server.ServerWide
             options.SchemaVersion = SchemaUpgrader.CurrentVersion.ServerVersion;
             options.SchemaUpgrader = SchemaUpgrader.Upgrader(SchemaUpgrader.StorageType.Server, null, null);
             options.ForceUsing32BitsPager = Configuration.Storage.ForceUsing32BitsPager;
+            if (Configuration.Storage.MaxScratchBufferSize.HasValue)
+                options.MaxScratchBufferSize = Configuration.Storage.MaxScratchBufferSize.Value.GetValue(SizeUnit.Bytes);
             try
             {
                 StorageEnvironment.MaxConcurrentFlushes = Configuration.Storage.MaxConcurrentFlushes;

--- a/src/Voron/StorageEnvironmentOptions.cs
+++ b/src/Voron/StorageEnvironmentOptions.cs
@@ -127,7 +127,23 @@ namespace Voron
 
         public UpgraderDelegate SchemaUpgrader { get; set; }
 
-        public long MaxScratchBufferSize { get; set; }
+        public long MaxScratchBufferSize
+        {
+            get => _maxScratchBufferSize;
+            set
+            {
+                if (value < 0)
+                    throw new InvalidOperationException($"Cannot set {nameof(MaxScratchBufferSize)} to negative value: {value}");
+
+                if (_forceUsing32BitsPager && _maxScratchBufferSize > 0)
+                {
+                    _maxScratchBufferSize = Math.Min(value, _maxScratchBufferSize);
+                    return;
+                }
+
+                _maxScratchBufferSize = value;
+            }
+        }
 
         public bool OwnsPagers { get; set; }
 
@@ -1064,6 +1080,7 @@ namespace Voron
         private int _timeToSyncAfterFlashInSec;
         public long CompressTxAboveSizeInBytes;
         private Guid _environmentId;
+        private long _maxScratchBufferSize;
 
         public virtual void SetPosixOptions()
         {

--- a/test/SlowTests/Issues/RavenDB_10887.cs
+++ b/test/SlowTests/Issues/RavenDB_10887.cs
@@ -1,0 +1,63 @@
+﻿using System.Linq;
+using System.Threading.Tasks;
+using FastTests;
+using Raven.Server.Config;
+using Raven.Tests.Core.Utils.Entities;
+using Voron;
+using Voron.Global;
+using Xunit;
+
+namespace SlowTests.Issues
+{
+    public class RavenDB_10887 : RavenTestBase
+    {
+        [Fact]
+        public async Task CanSetMaxScratchBufferFileSize()
+        {
+            using (var store = GetDocumentStore(options: new Options()
+            {
+                ModifyDatabaseRecord = x => x.Settings[RavenConfiguration.GetKey(k => k.Storage.MaxScratchBufferSize)] = "4"
+            }))
+            {
+                var documentDatabase = await GetDatabase(store.Database);
+
+                Assert.Equal(4 * Constants.Size.Megabyte, documentDatabase.DocumentsStorage.Environment.Options.MaxScratchBufferSize);
+
+                using (var session = store.OpenSession())
+                {
+                    // create auto index
+                    session.Query<User>().Where(x => x.Name == "a").ToList();
+                }
+
+                var index = documentDatabase.IndexStore.GetIndexes().First();
+
+                Assert.Equal(4 * Constants.Size.Megabyte, index._indexStorage.Environment().Options.MaxScratchBufferSize);
+            }
+        }
+
+        [Fact]
+        public void SettingMaxScratchBufferSizeMustNotExceed32BitsLimit()
+        {
+            using (var options = StorageEnvironmentOptions.ForPath(NewDataPath()))
+            {
+                options.ForceUsing32BitsPager = true;
+                options.MaxScratchBufferSize = 512 * Constants.Size.Megabyte;
+
+                // 32 MB is the default on 32 bits
+                Assert.Equal(32 * Constants.Size.Megabyte, options.MaxScratchBufferSize);
+            }
+        }
+
+        [Fact]
+        public void SettingMaxScratchBufferSizeCanBeLimitedOn32Bits()
+        {
+            using (var options = StorageEnvironmentOptions.ForPath(NewDataPath()))
+            {
+                options.ForceUsing32BitsPager = true;
+                options.MaxScratchBufferSize = 4 * Constants.Size.Megabyte;
+
+                Assert.Equal(4 * Constants.Size.Megabyte, options.MaxScratchBufferSize);
+            }
+        }
+    }
+}


### PR DESCRIPTION
…erSizeInMb configuration option