### PR TITLE
[4.1] RavenDB-10887 Exposing MaxScratchBufferSize as Storage.MaxScratchBuff…

### DIFF
--- a/src/Raven.Server/Config/Categories/StorageConfiguration.cs
+++ b/src/Raven.Server/Config/Categories/StorageConfiguration.cs
@@ -44,5 +44,11 @@ namespace Raven.Server.Config.Categories
         [SizeUnit(SizeUnit.Kilobytes)]
         [ConfigurationEntry("Storage.CompressTxAboveSizeInKb", ConfigurationEntryScope.ServerWideOrPerDatabase)]
         public Size CompressTxAboveSize { get; set; }
+
+        [Description("Max size of .buffers files")]
+        [DefaultValue(null)]
+        [SizeUnit(SizeUnit.Megabytes)]
+        [ConfigurationEntry("Storage.MaxScratchBufferSizeInMb", ConfigurationEntryScope.ServerWideOrPerDatabase)]
+        public Size? MaxScratchBufferSize { get; set; }
     }
 }

--- a/src/Raven.Server/Documents/ConfigurationStorage.cs
+++ b/src/Raven.Server/Documents/ConfigurationStorage.cs
@@ -38,6 +38,8 @@ namespace Raven.Server.Documents
             options.NumOfConcurrentSyncsPerPhysDrive = db.Configuration.Storage.NumberOfConcurrentSyncsPerPhysicalDrive;
             options.MasterKey = db.MasterKey?.ToArray();
             options.DoNotConsiderMemoryLockFailureAsCatastrophicError = db.Configuration.Security.DoNotConsiderMemoryLockFailureAsCatastrophicError;
+            if (db.Configuration.Storage.MaxScratchBufferSize.HasValue)
+                options.MaxScratchBufferSize = db.Configuration.Storage.MaxScratchBufferSize.Value.GetValue(SizeUnit.Bytes);
 
             Environment = LayoutUpdater.OpenEnvironment(options);
 

--- a/src/Raven.Server/Documents/DocumentsStorage.cs
+++ b/src/Raven.Server/Documents/DocumentsStorage.cs
@@ -229,7 +229,8 @@ namespace Raven.Server.Documents
             options.AddToInitLog = _addToInitLog;
             options.MasterKey = DocumentDatabase.MasterKey?.ToArray();
             options.DoNotConsiderMemoryLockFailureAsCatastrophicError = DocumentDatabase.Configuration.Security.DoNotConsiderMemoryLockFailureAsCatastrophicError;
-
+            if (DocumentDatabase.Configuration.Storage.MaxScratchBufferSize.HasValue)
+                options.MaxScratchBufferSize = DocumentDatabase.Configuration.Storage.MaxScratchBufferSize.Value.GetValue(SizeUnit.Bytes);
             try
             {
                 Initialize(options);

--- a/src/Raven.Server/ServerWide/ServerStore.cs
+++ b/src/Raven.Server/ServerWide/ServerStore.cs
@@ -462,6 +462,8 @@ namespace Raven.Server.ServerWide
             options.SchemaVersion = SchemaUpgrader.CurrentVersion.ServerVersion;
             options.SchemaUpgrader = SchemaUpgrader.Upgrader(SchemaUpgrader.StorageType.Server, null, null);
             options.ForceUsing32BitsPager = Configuration.Storage.ForceUsing32BitsPager;
+            if (Configuration.Storage.MaxScratchBufferSize.HasValue)
+                options.MaxScratchBufferSize = Configuration.Storage.MaxScratchBufferSize.Value.GetValue(SizeUnit.Bytes);
             try
             {
                 StorageEnvironment.MaxConcurrentFlushes = Configuration.Storage.MaxConcurrentFlushes;

--- a/src/Voron/StorageEnvironmentOptions.cs
+++ b/src/Voron/StorageEnvironmentOptions.cs
@@ -127,7 +127,23 @@ namespace Voron
 
         public UpgraderDelegate SchemaUpgrader { get; set; }
 
-        public long MaxScratchBufferSize { get; set; }
+        public long MaxScratchBufferSize
+        {
+            get => _maxScratchBufferSize;
+            set
+            {
+                if (value < 0)
+                    throw new InvalidOperationException($"Cannot set {nameof(MaxScratchBufferSize)} to negative value: {value}");
+
+                if (_forceUsing32BitsPager && _maxScratchBufferSize > 0)
+                {
+                    _maxScratchBufferSize = Math.Min(value, _maxScratchBufferSize);
+                    return;
+                }
+
+                _maxScratchBufferSize = value;
+            }
+        }
 
         public bool OwnsPagers { get; set; }
 
@@ -1064,6 +1080,7 @@ namespace Voron
         private int _timeToSyncAfterFlashInSec;
         public long CompressTxAboveSizeInBytes;
         private Guid _environmentId;
+        private long _maxScratchBufferSize;
 
         public virtual void SetPosixOptions()
         {

--- a/test/SlowTests/Issues/RavenDB_10887.cs
+++ b/test/SlowTests/Issues/RavenDB_10887.cs
@@ -1,0 +1,63 @@
+﻿using System.Linq;
+using System.Threading.Tasks;
+using FastTests;
+using Raven.Server.Config;
+using Raven.Tests.Core.Utils.Entities;
+using Voron;
+using Voron.Global;
+using Xunit;
+
+namespace SlowTests.Issues
+{
+    public class RavenDB_10887 : RavenTestBase
+    {
+        [Fact]
+        public async Task CanSetMaxScratchBufferFileSize()
+        {
+            using (var store = GetDocumentStore(options: new Options()
+            {
+                ModifyDatabaseRecord = x => x.Settings[RavenConfiguration.GetKey(k => k.Storage.MaxScratchBufferSize)] = "4"
+            }))
+            {
+                var documentDatabase = await GetDatabase(store.Database);
+
+                Assert.Equal(4 * Constants.Size.Megabyte, documentDatabase.DocumentsStorage.Environment.Options.MaxScratchBufferSize);
+
+                using (var session = store.OpenSession())
+                {
+                    // create auto index
+                    session.Query<User>().Where(x => x.Name == "a").ToList();
+                }
+
+                var index = documentDatabase.IndexStore.GetIndexes().First();
+
+                Assert.Equal(4 * Constants.Size.Megabyte, index._indexStorage.Environment().Options.MaxScratchBufferSize);
+            }
+        }
+
+        [Fact]
+        public void SettingMaxScratchBufferSizeMustNotExceed32BitsLimit()
+        {
+            using (var options = StorageEnvironmentOptions.ForPath(NewDataPath()))
+            {
+                options.ForceUsing32BitsPager = true;
+                options.MaxScratchBufferSize = 512 * Constants.Size.Megabyte;
+
+                // 32 MB is the default on 32 bits
+                Assert.Equal(32 * Constants.Size.Megabyte, options.MaxScratchBufferSize);
+            }
+        }
+
+        [Fact]
+        public void SettingMaxScratchBufferSizeCanBeLimitedOn32Bits()
+        {
+            using (var options = StorageEnvironmentOptions.ForPath(NewDataPath()))
+            {
+                options.ForceUsing32BitsPager = true;
+                options.MaxScratchBufferSize = 4 * Constants.Size.Megabyte;
+
+                Assert.Equal(4 * Constants.Size.Megabyte, options.MaxScratchBufferSize);
+            }
+        }
+    }
+}


### PR DESCRIPTION
…erSizeInMb configuration option