### PR TITLE
[4.0] RavenDB-10824

### DIFF
--- a/src/Raven.Client/Documents/Smuggler/DatabaseSmuggler.cs
+++ b/src/Raven.Client/Documents/Smuggler/DatabaseSmuggler.cs
@@ -99,7 +99,9 @@ namespace Raven.Client.Documents.Smuggler
                         Constants.Documents.PeriodicBackup.IncrementalBackupExtension.Equals(extension, StringComparison.OrdinalIgnoreCase) ||
                         Constants.Documents.PeriodicBackup.FullBackupExtension.Equals(extension, StringComparison.OrdinalIgnoreCase);
                 })
-                .OrderBy(File.GetLastWriteTimeUtc)
+                .OrderBy(Path.GetFileNameWithoutExtension)
+                .ThenBy(Path.GetExtension, PeriodicBackupFileExtensionComparer.Instance)
+                .ThenBy(File.GetLastWriteTimeUtc)
                 .ToArray();
 
             if (files.Length == 0)

--- a/src/Raven.Client/Documents/Smuggler/PeriodicBackupFileExtensionComparer.cs
+++ b/src/Raven.Client/Documents/Smuggler/PeriodicBackupFileExtensionComparer.cs
@@ -1,0 +1,29 @@
+using System;
+using System.Collections.Generic;
+
+namespace Raven.Client.Documents.Smuggler
+{
+    internal class PeriodicBackupFileExtensionComparer : IComparer<string>
+    {
+        public static PeriodicBackupFileExtensionComparer Instance = new PeriodicBackupFileExtensionComparer();
+
+        private PeriodicBackupFileExtensionComparer()
+        {
+                
+        }
+
+        public int Compare(string x, string y)
+        {
+            if (string.Equals(x, y))
+                return 0;
+
+            if (string.Equals(x, Constants.Documents.PeriodicBackup.SnapshotExtension, StringComparison.OrdinalIgnoreCase))
+                return -1;
+
+            if (string.Equals(x, Constants.Documents.PeriodicBackup.FullBackupExtension, StringComparison.OrdinalIgnoreCase))
+                return -1;
+
+            return 1;
+        }
+    }
+}

--- a/src/Raven.Server/Documents/PeriodicBackup/PeriodicBackupRunner.cs
+++ b/src/Raven.Server/Documents/PeriodicBackup/PeriodicBackupRunner.cs
@@ -133,7 +133,7 @@ namespace Raven.Server.Documents.PeriodicBackup
                     message += $", backup name: {configuration.Name}";
 
                 _database.NotificationCenter.Add(AlertRaised.Create(
-                    _database.Name, 
+                    _database.Name,
                     "Couldn't schedule next backup, this shouldn't happen",
                     message,
                     AlertType.PeriodicBackup,
@@ -156,7 +156,7 @@ namespace Raven.Server.Documents.PeriodicBackup
                 IsFull = isFullBackup
             };
         }
-        
+
         private bool IsFullBackup(PeriodicBackupStatus backupStatus,
             PeriodicBackupConfiguration configuration,
             DateTime? nextFullBackup, DateTime? nextIncrementalBackup)
@@ -222,7 +222,7 @@ namespace Raven.Server.Documents.PeriodicBackup
                         previousBackupStatus.BackupType != configuration.BackupType || // backup type has changed
                         previousBackupStatus.LastEtag == null || // last document etag wasn't updated
                         backupToLocalFolder && DirectoryContainsFullBackupOrSnapshot(previousBackupStatus.LocalBackup.BackupDirectory, configuration.BackupType) == false)
-                        // the local folder has a missing full backup
+                    // the local folder has a missing full backup
                     {
                         isFullBackup = true;
 
@@ -323,7 +323,7 @@ namespace Raven.Server.Documents.PeriodicBackup
                     _logger.Operations(message, e);
 
                 _database.NotificationCenter.Add(AlertRaised.Create(
-                    _database.Name, 
+                    _database.Name,
                     "Periodic Backup",
                     message,
                     AlertType.PeriodicBackup,
@@ -389,7 +389,7 @@ namespace Raven.Server.Documents.PeriodicBackup
                 var counter = 1;
                 while (true)
                 {
-                    fileName = $"{now}-{counter}${getBackupExtension()}";
+                    fileName = $"{now}-{counter:D2}${getBackupExtension()}";
                     backupFilePath = Path.Combine(backupFolder, fileName);
 
                     if (File.Exists(backupFilePath) == false)
@@ -853,7 +853,7 @@ namespace Raven.Server.Documents.PeriodicBackup
 
                         await RunPeriodicBackup(periodicBackup, isFullBackup);
                     }
-                    catch(Exception e)
+                    catch (Exception e)
                     {
                         _logger.Operations("Error during create backup task", e);
                     }

--- a/src/Raven.Server/Documents/PeriodicBackup/RestoreBackupTask.cs
+++ b/src/Raven.Server/Documents/PeriodicBackup/RestoreBackupTask.cs
@@ -337,6 +337,7 @@ namespace Raven.Server.Documents.PeriodicBackup
                         Constants.Documents.PeriodicBackup.SnapshotExtension.Equals(extension, StringComparison.OrdinalIgnoreCase);
                 })
                 .OrderBy(Path.GetFileNameWithoutExtension)
+                .ThenBy(Path.GetExtension, PeriodicBackupFileExtensionComparer.Instance)
                 .ThenBy(File.GetLastWriteTimeUtc);
 
             if (string.IsNullOrWhiteSpace(_restoreConfiguration.LastFileNameToRestore))

--- a/test/SlowTests/Server/Documents/PeriodicBackup/PeriodicBackupSlowTests.cs
+++ b/test/SlowTests/Server/Documents/PeriodicBackup/PeriodicBackupSlowTests.cs
@@ -299,11 +299,11 @@ namespace SlowTests.Server.Documents.PeriodicBackup
                 var backupTaskId = (await store.Maintenance.SendAsync(new UpdatePeriodicBackupOperation(config))).TaskId;
                 await store.Maintenance.SendAsync(new StartBackupOperation(true, backupTaskId));
                 var operation = new GetPeriodicBackupStatusOperation(backupTaskId);
-                SpinWait.SpinUntil(() =>
+                Assert.True(SpinWait.SpinUntil(() =>
                 {
                     var getPeriodicBackupResult = store.Maintenance.Send(operation);
                     return getPeriodicBackupResult.Status?.LastEtag > 0;
-                }, TimeSpan.FromSeconds(15));
+                }, TimeSpan.FromSeconds(15)));
 
                 var etagForBackups = store.Maintenance.Send(operation).Status.LastEtag;
                 using (var session = store.OpenAsyncSession())
@@ -313,11 +313,11 @@ namespace SlowTests.Server.Documents.PeriodicBackup
                 }
 
                 await store.Maintenance.SendAsync(new StartBackupOperation(false, backupTaskId));
-                SpinWait.SpinUntil(() =>
+                Assert.True(SpinWait.SpinUntil(() =>
                 {
                     var newLastEtag = store.Maintenance.Send(operation).Status.LastEtag;
                     return newLastEtag != etagForBackups;
-                }, TimeSpan.FromSeconds(15));
+                }, TimeSpan.FromSeconds(15)));
             }
 
             using (var store = GetDocumentStore(new Options


### PR DESCRIPTION
- RestoreBackupTask and DatabaseSmuggler should take into account the file extension also when sorting files (on Linux the last write time can be exactly the same when done quickly)
- support for doing more than 9 backups of the same database a minute by changing the counter format to D2 (gives appropriate lexicographical ordering)