### PR TITLE
RavenDB-10914

### DIFF
--- a/Raven.Database/Bundles/Replication/Impl/Historian.cs
+++ b/Raven.Database/Bundles/Replication/Impl/Historian.cs
@@ -19,11 +19,7 @@ namespace Raven.Database.Bundles.Replication.Impl
             if (existingMetadata == null || existingMetadata.Type == JTokenType.Null || incomingMetadata == null || incomingMetadata.Type == JTokenType.Null)
                 return false;
 
-            var existingMetadataInConflict = existingMetadata[Constants.RavenReplicationConflict]?.Value<bool>() ?? false;
-            existingMetadataInConflict |= existingMetadata[Constants.RavenReplicationConflictDocument]?.Value<bool>() ?? false;
-
-            //The existing document is a conflict document
-            if (existingMetadataInConflict)
+            if (existingMetadata[Constants.RavenReplicationSource] == null || existingMetadata[Constants.RavenReplicationVersion] == null)
                 return false;
 
             var history = incomingMetadata[Constants.RavenReplicationHistory];

--- a/Raven.Database/Bundles/Replication/Tasks/ReplicationTask.cs
+++ b/Raven.Database/Bundles/Replication/Tasks/ReplicationTask.cs
@@ -1413,12 +1413,12 @@ namespace Raven.Bundles.Replication.Tasks
             {
                 var destinationId = destinationsReplicationInformationForSource.ServerInstanceId.ToString();
                 var maxNumberOfItemsToReceiveInSingleBatch = destinationsReplicationInformationForSource.MaxNumberOfItemsToReceiveInSingleBatch;
-                var lastEtag = destinationsReplicationInformationForSource.LastDocumentEtag;
+                var lastEtag = destinationsReplicationInformationForSource.LastDocumentEtag??Etag.Empty;
 
                 int docsSinceLastReplEtag = 0;
                 List<JsonDocument> fetchedDocs;
                 List<JsonDocument> docsToReplicate;
-                result.LastEtag = lastEtag;
+                result.LastEtag = lastEtag??Etag.Empty;
                 var isEtl = destination.IsETL;
 
                 var collections = isEtl == false ? null :


### PR DESCRIPTION
* fixing Historian issue where there appears to be cases where conflicts do have replication versions and assumed to be parents of other documents
* fixing NRE in replication task (probably those are handled but are noisy when debugging )