### PR TITLE
RavenDB-10845 implementation (v4.1)

### DIFF
--- a/src/Raven.Client/Documents/Conventions/DocumentConventions.cs
+++ b/src/Raven.Client/Documents/Conventions/DocumentConventions.cs
@@ -164,6 +164,7 @@ namespace Raven.Client.Documents.Conventions
         private Func<Type, BlittableJsonReaderObject, object> _deserializeEntityFromBlittable;
         private bool _preserveDocumentPropertiesNotFoundOnModel;
         private Size _maxHttpCacheSize;
+        private bool _useCompression = true;
 
         public TimeSpan? RequestTimeout
         {
@@ -172,6 +173,19 @@ namespace Raven.Client.Documents.Conventions
             {
                 AssertNotFrozen();
                 _requestTimeout = value;
+            }
+        }
+
+        /// <summary>
+        /// Should accept gzip/deflate headers be added to all requests?
+        /// </summary>
+        public bool UseCompression
+        {
+            get => _useCompression;
+            set
+            {
+                AssertNotFrozen();
+                _useCompression = value;
             }
         }
 

--- a/src/Raven.Client/Documents/Conventions/DocumentConventions.cs
+++ b/src/Raven.Client/Documents/Conventions/DocumentConventions.cs
@@ -164,7 +164,7 @@ namespace Raven.Client.Documents.Conventions
         private Func<Type, BlittableJsonReaderObject, object> _deserializeEntityFromBlittable;
         private bool _preserveDocumentPropertiesNotFoundOnModel;
         private Size _maxHttpCacheSize;
-        private bool _useCompression = true;
+        private bool? _useCompression;
 
         public TimeSpan? RequestTimeout
         {
@@ -176,12 +176,14 @@ namespace Raven.Client.Documents.Conventions
             }
         }
 
+        internal bool HasExplicitlySetCompressionUsage => _useCompression.HasValue;
+
         /// <summary>
         /// Should accept gzip/deflate headers be added to all requests?
         /// </summary>
         public bool UseCompression
         {
-            get => _useCompression;
+            get => _useCompression ?? true;
             set
             {
                 AssertNotFrozen();

--- a/src/Raven.Client/Documents/DocumentStore.cs
+++ b/src/Raven.Client/Documents/DocumentStore.cs
@@ -163,14 +163,14 @@ namespace Raven.Client.Documents
 
             RequestExecutor CreateRequestExecutor()
             {
-                var requestExecutor = RequestExecutor.Create(Urls, database, Certificate, Conventions, Conventions.UseCompression);
+                var requestExecutor = RequestExecutor.Create(Urls, database, Certificate, Conventions, Conventions.UseCompression ?? true);
                 RequestExecutorCreated?.Invoke(this, requestExecutor);
                 return requestExecutor;
             }
 
             RequestExecutor CreateRequestExecutorForSingleNode()
             {
-                var forSingleNode = RequestExecutor.CreateForSingleNodeWithConfigurationUpdates(Urls[0], database, Certificate, Conventions, Conventions.UseCompression);
+                var forSingleNode = RequestExecutor.CreateForSingleNodeWithConfigurationUpdates(Urls[0], database, Certificate, Conventions, Conventions.UseCompression ?? true);
                 RequestExecutorCreated?.Invoke(this, forSingleNode);
                 return forSingleNode;
             }

--- a/src/Raven.Client/Documents/Subscriptions/SubscriptionWorker.cs
+++ b/src/Raven.Client/Documents/Subscriptions/SubscriptionWorker.cs
@@ -229,7 +229,7 @@ namespace Raven.Client.Documents.Subscriptions
                 await _stream.FlushAsync().ConfigureAwait(false);
 
                 _subscriptionLocalRequestExecutor?.Dispose();
-                _subscriptionLocalRequestExecutor = RequestExecutor.CreateForSingleNodeWithoutConfigurationUpdates(command.RequestedNode.Url, _dbName, requestExecutor.Certificate, _store.Conventions);
+                _subscriptionLocalRequestExecutor = RequestExecutor.CreateForSingleNodeWithoutConfigurationUpdates(command.RequestedNode.Url, _dbName, requestExecutor.Certificate, _store.Conventions,true);
 
                 return _stream;
             }

--- a/src/Raven.Client/Http/ClusterRequestExecutor.cs
+++ b/src/Raven.Client/Http/ClusterRequestExecutor.cs
@@ -14,7 +14,7 @@ namespace Raven.Client.Http
     {
         private readonly SemaphoreSlim _clusterTopologySemaphore = new SemaphoreSlim(1, 1);
 
-        protected ClusterRequestExecutor(X509Certificate2 certificate, DocumentConventions conventions, string[] initialUrls, bool useCompression) : base(null, certificate, conventions, initialUrls, useCompression)
+        protected ClusterRequestExecutor(X509Certificate2 certificate, DocumentConventions conventions, string[] initialUrls, bool useCompression) : base(null, certificate, conventions, initialUrls)
         {
            
         }

--- a/src/Raven.Client/Http/ClusterRequestExecutor.cs
+++ b/src/Raven.Client/Http/ClusterRequestExecutor.cs
@@ -14,36 +14,36 @@ namespace Raven.Client.Http
     {
         private readonly SemaphoreSlim _clusterTopologySemaphore = new SemaphoreSlim(1, 1);
 
-        protected ClusterRequestExecutor(X509Certificate2 certificate, DocumentConventions conventions, string[] initialUrls) : base(null, certificate, conventions, initialUrls)
+        protected ClusterRequestExecutor(X509Certificate2 certificate, DocumentConventions conventions, string[] initialUrls, bool useCompression) : base(null, certificate, conventions, initialUrls, useCompression)
         {
            
         }
 
         [Obsolete("Not supported", error: true)]
-        public new static ClusterRequestExecutor Create(string[] urls, string databaseName, X509Certificate2 certificate, DocumentConventions conventions)
+        public new static ClusterRequestExecutor Create(string[] urls, string databaseName, X509Certificate2 certificate, DocumentConventions conventions, bool useCompression = true)
         {
             throw new NotSupportedException();
         }
 
         [Obsolete("Not supported", error: true)]
         public new static ClusterRequestExecutor CreateForSingleNodeWithConfigurationUpdates(string url, string databaseName, X509Certificate2 certificate,
-            DocumentConventions conventions)
+            DocumentConventions conventions, bool useCompression = true)
         {
             throw new NotSupportedException();
         }
 
         [Obsolete("Not supported", error: true)]
         public new static ClusterRequestExecutor CreateForSingleNodeWithoutConfigurationUpdates(string url, string databaseName, X509Certificate2 certificate,
-            DocumentConventions conventions)
+            DocumentConventions conventions, bool useCompression = true)
         {
             throw new NotSupportedException();
         }
 
-        public static ClusterRequestExecutor CreateForSingleNode(string url, X509Certificate2 certificate, DocumentConventions conventions = null)
+        public static ClusterRequestExecutor CreateForSingleNode(string url, X509Certificate2 certificate, DocumentConventions conventions = null,bool useCompression = true)
         {
             var initialUrls = new[] {url};
             url = ValidateUrls(initialUrls, certificate)[0];
-            var executor = new ClusterRequestExecutor(certificate, conventions ?? DocumentConventions.Default, initialUrls)
+            var executor = new ClusterRequestExecutor(certificate, conventions ?? DocumentConventions.Default, initialUrls,useCompression)
             {
                 _nodeSelector = new NodeSelector(new Topology
                 {
@@ -63,9 +63,9 @@ namespace Raven.Client.Http
             return executor;
         }
 
-        public static ClusterRequestExecutor Create(string[] initialUrls, X509Certificate2 certificate, DocumentConventions conventions = null)
+        public static ClusterRequestExecutor Create(string[] initialUrls, X509Certificate2 certificate, DocumentConventions conventions = null,bool useCompression = true)
         {
-            var executor = new ClusterRequestExecutor(certificate, conventions ?? DocumentConventions.Default, initialUrls)
+            var executor = new ClusterRequestExecutor(certificate, conventions ?? DocumentConventions.Default, initialUrls, useCompression)
             {
                 _disableClientConfigurationUpdates = true
             };

--- a/src/Raven.Client/ServerWide/Operations/ServerOperationExecutor.cs
+++ b/src/Raven.Client/ServerWide/Operations/ServerOperationExecutor.cs
@@ -10,15 +10,13 @@ namespace Raven.Client.ServerWide.Operations
 {
     public class ServerOperationExecutor : IDisposable
     {
-        private readonly DocumentStoreBase _store;
         private readonly ClusterRequestExecutor _requestExecutor;
 
         public ServerOperationExecutor(DocumentStoreBase store)
-        {
-            _store = store;
+        {            
             _requestExecutor = store.Conventions.DisableTopologyUpdates
-                ? ClusterRequestExecutor.CreateForSingleNode(store.Urls[0], store.Certificate)
-                : ClusterRequestExecutor.Create(store.Urls, store.Certificate);
+                ? ClusterRequestExecutor.CreateForSingleNode(store.Urls[0], store.Certificate, null, store.Conventions.UseCompression)
+                : ClusterRequestExecutor.Create(store.Urls, store.Certificate, null, store.Conventions.UseCompression);
 
             store.AfterDispose += (sender, args) => _requestExecutor.Dispose();
         }

--- a/src/Raven.Server/Documents/Replication/ReplicationLoader.cs
+++ b/src/Raven.Server/Documents/Replication/ReplicationLoader.cs
@@ -714,7 +714,7 @@ namespace Raven.Server.Documents.Replication
                 {
                     using (var requestExecutor = RequestExecutor.Create(exNode.ConnectionString.TopologyDiscoveryUrls, exNode.ConnectionString.Database,
                         _server.Server.Certificate.Certificate,
-                        DocumentConventions.Default))
+                        DocumentConventions.Default,true))
                     using (_server.ContextPool.AllocateOperationContext(out TransactionOperationContext ctx))
                     {
                         var database = exNode.ConnectionString.Database;

--- a/src/Raven.Server/Smuggler/Migration/Migrator.cs
+++ b/src/Raven.Server/Smuggler/Migration/Migrator.cs
@@ -38,7 +38,8 @@ namespace Raven.Server.Smuggler.Migration
             _buildMajorVersion = configuration.BuildMajorVersion;
             _buildVersion = configuration.BuildVersion;
 
-            var httpClientHandler = RequestExecutor.CreateHttpMessageHandler(_serverStore.Server.Certificate.Certificate, setSslProtocols: false);
+            //because of backward compatibility useCompression == false here
+            var httpClientHandler = RequestExecutor.CreateHttpMessageHandler(_serverStore.Server.Certificate.Certificate, setSslProtocols: false, useCompression:false);
             httpClientHandler.UseDefaultCredentials = false;
 
             if (string.IsNullOrWhiteSpace(configuration.ApiKey) == false)


### PR DESCRIPTION
Adding flag to DocumentStore to disable/enable compression usage by the client.
note: if any requests are in progress at the moment of changing the flag, the requests will be canceled. 