### PR TITLE
[4.0] RavenDB-7070

### DIFF
--- a/test/StressTests/Client/Attachments/AttachmentsSessionStress.cs
+++ b/test/StressTests/Client/Attachments/AttachmentsSessionStress.cs
@@ -20,6 +20,7 @@ namespace StressTests.Client.Attachments
         }
 
         [Theory]
+        [InlineData(1000)]
         [InlineData(10_000)]
         public async Task PutLotOfAttachmentsAsync(int count)
         {
@@ -30,10 +31,8 @@ namespace StressTests.Client.Attachments
         }
 
         [NightlyBuildTheory]
-        [InlineData(1000)]
         [InlineData(10_000)]
         [InlineData(100_000)]
-        [InlineData(1_000_000)]
         public void StressPutLotOfAttachments(int count)
         {
             using (var stress = new AttachmentsSession())
@@ -45,7 +44,6 @@ namespace StressTests.Client.Attachments
         [NightlyBuildTheory]
         [InlineData(10_000)]
         [InlineData(100_000)]
-        [InlineData(1_000_000)]
         public async Task StressPutLotOfAttachmentsAsync(int count)
         {
             using (var stress = new AttachmentsSessionAsync())


### PR DESCRIPTION
- using ArrayPool in AttachmentStreamContent to avoid situation where we are holding n * 4k buffers where n is the number of attachments stored in session
- removed 1M of attachments test, it takes 10M on a very good machine and over 1h on slow one