### PR TITLE
[4.1] RavenDB-10867

### DIFF
--- a/src/Raven.Client/Exceptions/Cluster/NodeIsPassiveException.cs
+++ b/src/Raven.Client/Exceptions/Cluster/NodeIsPassiveException.cs
@@ -1,0 +1,19 @@
+﻿using System;
+
+namespace Raven.Client.Exceptions.Cluster
+{
+    public class NodeIsPassiveException : RavenException
+    {
+        public NodeIsPassiveException()
+        {
+        }
+
+        public NodeIsPassiveException(string message) : base(message)
+        {
+        }
+
+        public NodeIsPassiveException(string message, Exception inner) : base(message, inner)
+        {
+        }
+    }
+}

--- a/src/Raven.Client/Http/RequestExecutor.cs
+++ b/src/Raven.Client/Http/RequestExecutor.cs
@@ -976,8 +976,7 @@ namespace Raven.Client.Http
                 case HttpStatusCode.RequestTimeout:
                 case HttpStatusCode.BadGateway:
                 case HttpStatusCode.ServiceUnavailable:
-                    await HandleServerDown(url, chosenNode, nodeIndex, context, command, request, response, null, sessionInfo).ConfigureAwait(false);
-                    break;
+                    return await HandleServerDown(url, chosenNode, nodeIndex, context, command, request, response, null, sessionInfo).ConfigureAwait(false);
                 case HttpStatusCode.Conflict:
                     await HandleConflict(context, response).ConfigureAwait(false);
                     break;

--- a/src/Raven.Server/Documents/DocumentDatabase.cs
+++ b/src/Raven.Server/Documents/DocumentDatabase.cs
@@ -263,7 +263,14 @@ namespace Raven.Server.Documents
 
                 TaskExecutor.Execute((state) =>
                 {
-                    NotifyFeaturesAboutStateChange(record, index);
+                    try
+                    {
+                        NotifyFeaturesAboutStateChange(record, index);
+                    }
+                    catch
+                    {
+                        // We ignore the exception since it was caught in the function itself
+                    }
                 }, null);
             }
             catch (Exception)

--- a/src/Raven.Server/RavenServerStartup.cs
+++ b/src/Raven.Server/RavenServerStartup.cs
@@ -12,6 +12,7 @@ using Microsoft.Extensions.Logging;
 using Microsoft.Extensions.Primitives;
 using Raven.Client.Documents.Changes;
 using Raven.Client.Exceptions;
+using Raven.Client.Exceptions.Cluster;
 using Raven.Client.Exceptions.Commercial;
 using Raven.Client.Exceptions.Database;
 using Raven.Client.Exceptions.Documents;
@@ -280,7 +281,8 @@ namespace Raven.Server
             if (exception is DatabaseDisabledException ||
                 exception is DatabaseLoadFailureException ||
                 exception is DatabaseLoadTimeoutException ||
-                exception is DatabaseConcurrentLoadTimeoutException)
+                exception is DatabaseConcurrentLoadTimeoutException ||
+                exception is NodeIsPassiveException)
             {
                 response.StatusCode = (int)HttpStatusCode.ServiceUnavailable;
                 return;

--- a/src/Raven.Server/Routing/RouteInformation.cs
+++ b/src/Raven.Server/Routing/RouteInformation.cs
@@ -3,6 +3,7 @@ using System.Linq.Expressions;
 using System.Reflection;
 using System.Text;
 using System.Threading.Tasks;
+using Raven.Client.Exceptions.Cluster;
 using Raven.Client.Exceptions.Database;
 using Raven.Server.Documents;
 using Raven.Server.Web;
@@ -71,6 +72,11 @@ namespace Raven.Server.Routing
         public Task CreateDatabase(RequestHandlerContext context)
         {
             var databaseName = context.RouteMatch.GetCapture();
+            if (context.RavenServer.ServerStore.IsPassive())
+            {
+                throw new NodeIsPassiveException($"Can't perform actions on the database '{databaseName}' while the node is passive.");
+            }
+
             var databasesLandlord = context.RavenServer.ServerStore.DatabasesLandlord;
             var database = databasesLandlord.TryGetOrCreateResourceStore(databaseName);
 

--- a/src/Raven.Server/ServerWide/BackgroundTasks/LatestVersionCheck.cs
+++ b/src/Raven.Server/ServerWide/BackgroundTasks/LatestVersionCheck.cs
@@ -1,6 +1,7 @@
 ﻿using System;
 using System.Net.Http;
 using System.Threading;
+using System.Threading.Tasks;
 using Sparrow.Logging;
 using Raven.Server.Json;
 using Raven.Server.NotificationCenter.Notifications;
@@ -31,7 +32,7 @@ namespace Raven.Server.ServerWide.BackgroundTasks
 
         static LatestVersionCheck()
         {
-            _timer = new Timer(state => PerformAsync(), null, (int)TimeSpan.FromMinutes(5).TotalMilliseconds, (int)TimeSpan.FromHours(12).TotalMilliseconds);
+            _timer = new Timer(async state => await PerformAsync(), null, (int)TimeSpan.FromMinutes(5).TotalMilliseconds, (int)TimeSpan.FromHours(12).TotalMilliseconds);
         }
 
         public static void Check(ServerStore serverStore)
@@ -45,7 +46,7 @@ namespace Raven.Server.ServerWide.BackgroundTasks
             serverStore.NotificationCenter.Add(_alert);
         }
 
-        private static async void PerformAsync()
+        private static async Task PerformAsync()
         {
             try
             {

--- a/src/Raven.Server/ServerWide/ClusterStateMachine.cs
+++ b/src/Raven.Server/ServerWide/ClusterStateMachine.cs
@@ -6,6 +6,7 @@ using System.Dynamic;
 using System.IO;
 using System.Linq;
 using System.Net.Sockets;
+using System.Runtime.CompilerServices;
 using System.Runtime.ExceptionServices;
 using System.Security.Cryptography.X509Certificates;
 using System.Text;
@@ -530,6 +531,7 @@ namespace Raven.Server.ServerWide
                 if (databaseRecord.DeletionInProgress.Count == 0 && databaseRecord.Topology.Count == 0)
                 {
                     DeleteDatabaseRecord(context, index, items, lowerKey, databaseName);
+                    NotifyDatabaseChanged(context, databaseName, index, nameof(RemoveNodeFromDatabaseCommand));
                     return;
                 }
 
@@ -537,6 +539,8 @@ namespace Raven.Server.ServerWide
 
                 UpdateValue(index, items, lowerKey, key, updated);
             }
+
+            NotifyDatabaseChanged(context, databaseName, index, nameof(RemoveNodeFromDatabaseCommand));
         }
 
         private void DeleteDatabaseRecord(TransactionOperationContext context, long index, Table items, Slice lowerKey, string databaseName)

--- a/src/Raven.Server/ServerWide/ServerStore.cs
+++ b/src/Raven.Server/ServerWide/ServerStore.cs
@@ -1529,7 +1529,7 @@ namespace Raven.Server.ServerWide
                 return;
 
             // Also need to register my own certificate in the cluster, for other nodes to trust me
-            RegisterServerCertificateInCluster(Server.Certificate.Certificate, name).Wait(ServerShutdown);
+            AsyncHelpers.RunSync(() => RegisterServerCertificateInCluster(Server.Certificate.Certificate, name));
         }
 
         public Task RegisterServerCertificateInCluster(X509Certificate2 certificateCertificate, string name)

--- a/src/Sparrow/Utils/TaskExecutor.cs
+++ b/src/Sparrow/Utils/TaskExecutor.cs
@@ -73,12 +73,10 @@ namespace Sparrow.Utils
             }
         }
 
-        private static void TaskCompletionCallback(object state) => ((TaskCompletionSource<object>)state).TrySetResult(null);
-
         public static void CompleteAndReplace(ref TaskCompletionSource<object> task)
         {
             var task2 = Interlocked.Exchange(ref task, new TaskCompletionSource<object>(TaskCreationOptions.RunContinuationsAsynchronously));
-            Execute(TaskCompletionCallback, task2);
+            task2.TrySetResult(null);
         }
 
         public static void CompleteReplaceAndExecute(ref TaskCompletionSource<object> task, Action act)
@@ -94,7 +92,7 @@ namespace Sparrow.Utils
 
         public static void Complete(TaskCompletionSource<object> task)
         {
-            Execute(TaskCompletionCallback, task);
+            task.TrySetResult(null);
         }
 
         private class RunOnce

--- a/test/RachisTests/AddNodeToClusterTests.cs
+++ b/test/RachisTests/AddNodeToClusterTests.cs
@@ -8,9 +8,9 @@ using FastTests.Server.Replication;
 using Raven.Client.Documents;
 using Raven.Client.Documents.Conventions;
 using Raven.Client.Documents.Operations.Replication;
+using Raven.Client.Exceptions.Cluster;
 using Raven.Client.Http;
 using Raven.Client.ServerWide;
-using Raven.Server.Utils;
 using Raven.Tests.Core.Utils.Entities;
 using Tests.Infrastructure;
 using Xunit;
@@ -34,9 +34,7 @@ namespace RachisTests
         [NightlyBuildFact]
         public async Task RemoveNodeWithDb()
         {
-            DebuggerAttachedTimeout.DisableLongTimespan = true;
             var fromSeconds = Debugger.IsAttached ? TimeSpan.FromSeconds(15) : TimeSpan.FromSeconds(5);
-
             var leader = await CreateRaftClusterAndGetLeader(5);
             Assert.True(leader.ServerStore.LicenseManager.HasHighlyAvailableTasks());
 
@@ -94,6 +92,7 @@ namespace RachisTests
                     // check that replication works.
                     using (var session = leaderStore.OpenSession())
                     {
+                        session.Advanced.WaitForReplicationAfterSaveChanges(timeout: fromSeconds, replicas: 4);
                         session.Store(new User
                         {
                             Name = "Karmel"
@@ -101,7 +100,6 @@ namespace RachisTests
                         session.SaveChanges();
                     }
 
-                    Assert.True(await WaitForDocumentInClusterAsync<User>(serverNodes, "users/1", u => u.Name == "Karmel", fromSeconds));
                     Assert.True(WaitForDocument<User>(watcherStore, "users/1", u => u.Name == "Karmel", 30_000));
 
                     // remove the node from the cluster that is responsible for the external replication
@@ -112,14 +110,17 @@ namespace RachisTests
                     await WaitForValueAsync(() => dbInstance.ReplicationLoader.OutgoingConnections.Count(), 0);
 
                     // replication from the removed node should be suspended
-                    using (var session = responsibleStore.OpenAsyncSession())
+                    await Assert.ThrowsAsync<NodeIsPassiveException>(async () =>
                     {
-                        await session.StoreAsync(new User
+                        using (var session = responsibleStore.OpenAsyncSession())
                         {
-                            Name = "Karmel2"
-                        }, "users/2");
-                        await session.SaveChangesAsync();
-                    }
+                            await session.StoreAsync(new User
+                            {
+                                Name = "Karmel2"
+                            }, "users/2");
+                            await session.SaveChangesAsync();
+                        }
+                    });
                 }
                 
                 var nodeInCluster = serverNodes.First(s => s.ClusterTag != responsibleServer.ServerStore.NodeTag);
@@ -130,29 +131,33 @@ namespace RachisTests
                     Conventions = conventions
                 }.Initialize())
                 {
-                    Assert.False(WaitForDocument<User>(nodeInClusterStore, "users/2", u => u.Name == "Karmel2"));
-                    Assert.False(WaitForDocument<User>(watcherStore, "users/2", u => u.Name == "Karmel2"));
-
                     // the task should be reassinged within to another node
                     using (var session = nodeInClusterStore.OpenSession())
                     {
+                        session.Advanced.WaitForReplicationAfterSaveChanges(timeout: TimeSpan.FromSeconds(30), replicas: 3);
                         session.Store(new User
                         {
-                            Name = "Karmel2"
+                            Name = "Karmel3"
                         }, "users/3");
                         session.SaveChanges();
                     }
                 }
 
-                Assert.True(WaitForDocument<User>(watcherStore, "users/3", u => u.Name == "Karmel2", 30_000));
+                Assert.True(WaitForDocument<User>(watcherStore, "users/3", u => u.Name == "Karmel3", 30_000));
 
                 // rejoin the node
                 var newLeader = Servers.Single(s => s.ServerStore.IsLeader());
                 Assert.True(await newLeader.ServerStore.AddNodeToClusterAsync(responsibleServer.WebUrl, watcherRes.ResponsibleNode).WaitAsync(fromSeconds));
                 Assert.True(await responsibleServer.ServerStore.WaitForState(RachisState.Follower, CancellationToken.None).WaitAsync(fromSeconds));
 
-                using (var session = leaderStore.OpenAsyncSession())
+                using (var newLeaderStore = new DocumentStore
                 {
+                    Database = "MainDB",
+                    Urls = new[] { newLeader.WebUrl },
+                }.Initialize())
+                using (var session = newLeaderStore.OpenAsyncSession())
+                {
+                    session.Advanced.WaitForReplicationAfterSaveChanges(timeout: TimeSpan.FromSeconds(30), replicas: 3);
                     await session.StoreAsync(new User
                     {
                         Name = "Karmel4"
@@ -160,25 +165,7 @@ namespace RachisTests
                     await session.SaveChangesAsync();
                 }
                 
-                foreach (var node in serverNodes)
-                {
-                    // after we removed watcherRes.ResponsibleNode from the cluster, it is no longer 
-                    // a part of the Database-Group (even after re-adding it to the cluster)
-                    if (node.ClusterTag == watcherRes.ResponsibleNode)
-                        continue;
-
-                    using (var store = new DocumentStore
-                    {
-                        Database = "MainDB",
-                        Urls = new[] { node.Url },
-                        Conventions = conventions
-                    }.Initialize())
-                    {
-                        Assert.True(WaitForDocument<User>(store, "users/4", u => u.Name == "Karmel4", 30_000));
-                    }
-                }
-                
-                Assert.True(WaitForDocument<User>(watcherStore, "users/4", u => u.Name == "Karmel4", 30_000));
+                Assert.True(WaitForDocument<User>(watcherStore, "users/4", u => u.Name == "Karmel4", 30_000), $"The watcher doesn't have the document");
             }
         }
     }

--- a/test/RachisTests/CommandsTests.cs
+++ b/test/RachisTests/CommandsTests.cs
@@ -66,12 +66,12 @@ namespace RachisTests
                 try
                 {
                     var task = leader.PutAsync(new TestCommand { Name = "test", Value = commandCount });
-                    Assert.True(await task.WaitAsync(TimeSpan.FromMilliseconds(leader.ElectionTimeout.TotalMilliseconds * 5)));
+                    Assert.True(await task.WaitAsync((int)leader.ElectionTimeout.TotalMilliseconds * 10));
                     await task;
                     Assert.True(false, "We should have gotten an error");
                 }
                 // expecting either one of those
-                catch (TimeoutException)
+                catch (Exception e) when (e.InnerException is TimeoutException)
                 {
                 }
                 catch (NotLeadingException)

--- a/test/RachisTests/DatabaseCluster/ClusterDatabaseMaintenance.cs
+++ b/test/RachisTests/DatabaseCluster/ClusterDatabaseMaintenance.cs
@@ -284,7 +284,7 @@ namespace RachisTests.DatabaseCluster
                 Assert.True(await Servers[1].ServerStore.WaitForState(RachisState.Passive, CancellationToken.None).WaitAsync(TimeSpan.FromSeconds(30)));
                 // rejoin the node to the cluster
                 await leader.ServerStore.AddNodeToClusterAsync(urls[0], nodeTag);
-                Assert.True(await Servers[1].ServerStore.WaitForState(RachisState.Follower, CancellationToken.None).WaitAsync(TimeSpan.FromSeconds(300)));
+                Assert.True(await Servers[1].ServerStore.WaitForState(RachisState.Follower, CancellationToken.None).WaitAsync(TimeSpan.FromSeconds(30)));
             }
         }
 

--- a/test/RachisTests/DatabaseCluster/EtlFailover.cs
+++ b/test/RachisTests/DatabaseCluster/EtlFailover.cs
@@ -9,6 +9,8 @@ using Raven.Client.Documents.Conventions;
 using Raven.Client.Documents.Operations.ConnectionStrings;
 using Raven.Client.Documents.Operations.ETL;
 using Raven.Client.Documents.Operations.OngoingTasks;
+using Raven.Client.Exceptions.Cluster;
+using Raven.Client.Exceptions.Database;
 using Raven.Client.ServerWide;
 using Raven.Client.ServerWide.Operations;
 using Raven.Tests.Core.Utils.Entities;
@@ -57,7 +59,7 @@ namespace RachisTests.DatabaseCluster
                             Disabled = false
                         }
                     },
-                    LoadRequestTimeoutInSec = 10,
+                    LoadRequestTimeoutInSec = 30,
                     MentorNode = "B"
                 };
                 var connectionString = new RavenConnectionString
@@ -80,6 +82,7 @@ namespace RachisTests.DatabaseCluster
 
                     session.SaveChanges();
                 }
+                
                 Assert.True(WaitForDocument<User>(dest, "users/1", u => u.Name == "Joe Doe", 30_000));
                 await srcRaft.ServerStore.RemoveFromClusterAsync("B");
                 await originalTaskNode.ServerStore.WaitForState(RachisState.Passive, CancellationToken.None);
@@ -95,28 +98,29 @@ namespace RachisTests.DatabaseCluster
                 }
 
                 Assert.True(WaitForDocument<User>(dest, "users/2", u => u.Name == "Joe Doe2", 30_000));
-
-                using (var originalSrc = new DocumentStore
+                Assert.Throws<NodeIsPassiveException>(() =>
                 {
-                    Urls = new[] {originalTaskNode.WebUrl},
-                    Database = srcDb,
-                    Conventions = new DocumentConventions
+                    using (var originalSrc = new DocumentStore
                     {
-                        DisableTopologyUpdates = true
-                    }
-                }.Initialize())
-                {
-                    using (var session = originalSrc.OpenSession())
-                    {
-                        session.Store(new User()
+                        Urls = new[] { originalTaskNode.WebUrl },
+                        Database = srcDb,
+                        Conventions = new DocumentConventions
                         {
-                            Name = "Joe Doe3"
-                        }, "users/3");
+                            DisableTopologyUpdates = true
+                        }
+                    }.Initialize())
+                    {
+                        using (var session = originalSrc.OpenSession())
+                        {
+                            session.Store(new User()
+                            {
+                                Name = "Joe Doe3"
+                            }, "users/3");
 
-                        session.SaveChanges();
+                            session.SaveChanges();
+                        }
                     }
-                    Assert.False(WaitForDocument<User>(dest, "users/3", u => u.Name == "Joe Doe3", 30_000));
-                }
+                });
             }
         }
 

--- a/test/RachisTests/DatabaseCluster/ReplicationTests.cs
+++ b/test/RachisTests/DatabaseCluster/ReplicationTests.cs
@@ -807,16 +807,12 @@ namespace RachisTests.DatabaseCluster
             {
                 using (var session = srcStore.OpenSession())
                 {
+                    session.Advanced.WaitForReplicationAfterSaveChanges(timeout: TimeSpan.FromSeconds(30), replicas: clusterSize - 1);
                     session.Store(new User
                     {
                         Name = "Karmel"
                     }, "users/1");
                     session.SaveChanges();
-                    Assert.True(await WaitForDocumentInClusterAsync<User>(
-                        session as DocumentSession,
-                        "users/1",
-                        u => u.Name.Equals("Karmel"),
-                        TimeSpan.FromSeconds(clusterSize + 5)));
                 }
 
                 // add watcher with invalid url to test the failover on database topology discovery
@@ -858,19 +854,14 @@ namespace RachisTests.DatabaseCluster
 
                     using (var session = srcStore.OpenSession())
                     {
+                        session.Advanced.WaitForReplicationAfterSaveChanges(timeout: TimeSpan.FromSeconds(30), replicas: clusterSize - 1);
                         session.Store(new User
                         {
                             Name = "Karmel2"
                         }, "users/2");
                         session.SaveChanges();
-                        Assert.True(await WaitForDocumentInClusterAsync<User>(
-                            session as DocumentSession,
-                            "users/2",
-                            u => u.Name.Equals("Karmel2"),
-                            TimeSpan.FromSeconds(clusterSize + 5)));
                     }
 
-                    WaitForUserToContinueTheTest(dstStore as DocumentStore);
                     Assert.True(WaitForDocument(dstStore, "users/2", 30_000));
                 }
             }

--- a/test/RachisTests/ElectionTests.cs
+++ b/test/RachisTests/ElectionTests.cs
@@ -20,8 +20,8 @@ namespace RachisTests
             Assert.True(nodeCurrentState == RachisState.LeaderElect ||
                         nodeCurrentState == RachisState.Leader);
             var waitForState = node.WaitForState(RachisState.Leader, CancellationToken.None);
-            var condition = await waitForState.WaitAsync(node.ElectionTimeout);
-            
+
+            var condition = await waitForState.WaitAsync(10 * node.ElectionTimeout);
             Assert.True(condition, $"Node is in state {node.CurrentState} and didn't become leader although he is alone in his cluster.");
         }
 
@@ -85,6 +85,10 @@ namespace RachisTests
             var leaderUrl = new HashSet<string>();
             foreach (var consensus in RachisConsensuses)
             {
+                if (consensus.Tag != consensus.LeaderTag)
+                {
+                    Assert.True(await consensus.WaitForState(RachisState.Follower, CancellationToken.None).WaitAsync(1000));
+                }
                 leaderUrl.Add(consensus.LeaderTag);
             }
             Assert.True(leaderUrl.Count == 1, "Not all nodes agree on the leader");

--- a/test/RachisTests/SubscriptionsFailover.cs
+++ b/test/RachisTests/SubscriptionsFailover.cs
@@ -355,9 +355,8 @@ namespace RachisTests
 
                 expectedRevisionsCount = nodesAmount + 2;
                 continueMre.Set();
-                //Assert.True(await task.WaitAsync(_reasonableWaitTime).ConfigureAwait(false), $"Doc count is {docsCount} with revesions {revisionsCount}/{expectedRevisionsCount}");
 
-                Assert.True(await ackSent.WaitAsync(_reasonableWaitTime).ConfigureAwait(false), $"Doc count is {docsCount} with revesions {revisionsCount}/{expectedRevisionsCount}");
+                Assert.True(await ackSent.WaitAsync(_reasonableWaitTime).ConfigureAwait(false), $"Doc count is {docsCount} with revisions {revisionsCount}/{expectedRevisionsCount}");
                 ackSent.Reset(true);
 
                 await KillServerWhereSubscriptionWorks(defaultDatabase, subscription.SubscriptionName).ConfigureAwait(false);
@@ -365,7 +364,7 @@ namespace RachisTests
                 expectedRevisionsCount += 2;
 
 
-                Assert.True(await ackSent.WaitAsync(_reasonableWaitTime).ConfigureAwait(false), $"Doc count is {docsCount} with revesions {revisionsCount}/{expectedRevisionsCount}");
+                Assert.True(await ackSent.WaitAsync(_reasonableWaitTime).ConfigureAwait(false), $"Doc count is {docsCount} with revisions {revisionsCount}/{expectedRevisionsCount}");
                 ackSent.Reset(true);
                 continueMre.Set();
 
@@ -629,7 +628,7 @@ namespace RachisTests
                 }))
                 {
                     var task = subscription.Run(a => { });
-                    Assert.True(await ThrowsAsync<SubscriptionInvalidStateException>(task).WaitWithTimeout(TimeSpan.FromSeconds(120)).ConfigureAwait(false));
+                    Assert.True(await ThrowsAsync<SubscriptionInvalidStateException>(task).WaitWithTimeout(TimeSpan.FromSeconds(60)).ConfigureAwait(false));
                 }
             }
         }
@@ -756,16 +755,15 @@ namespace RachisTests
                     {
                         if (disposedOnce == false)
                         {
+                            disposedOnce = true;
                             subscription.OnSubscriptionConnectionRetry += x =>
                             {
                                 subscriptionRetryBegins.SetAndResetAtomically();
                             };
                             await DisposeServerAndWaitForFinishOfDisposalAsync(leader);
-                            disposedOnce = true;
                         }
                         batchProccessed.SetAndResetAtomically();
                     });
-
                     await GenerateDocuments(store);
 
                     Assert.True(await batchProccessed.WaitAsync(_reasonableWaitTime));
@@ -783,8 +781,8 @@ namespace RachisTests
                             deletePrevious: false,
                             partialPath: leaderDataDir);
                     
-                    Assert.True(await batchProccessed.WaitAsync(TimeSpan.FromSeconds(120)));
-                    Assert.True(await batchedAcked.WaitAsync(TimeSpan.FromSeconds(120)));
+                    Assert.True(await batchProccessed.WaitAsync(TimeSpan.FromSeconds(60)));
+                    Assert.True(await batchedAcked.WaitAsync(TimeSpan.FromSeconds(60)));
 
                 }
             }

--- a/test/RachisTests/TopologyChangesTests.cs
+++ b/test/RachisTests/TopologyChangesTests.cs
@@ -16,13 +16,14 @@ namespace RachisTests
         {
             var leader = await CreateNetworkAndGetLeader(3);
             var followers = GetFollowers();
-            DisconnectFromNode(leader);
             var newServer = SetupServer();
+            DisconnectFromNode(leader);
             await leader.AddToClusterAsync(newServer.Url);
-            await newServer.WaitForTopology(Leader.TopologyModification.Promotable);
             var newLeader = WaitForAnyToBecomeLeader(followers);
+
             Assert.NotNull(newLeader);
             ReconnectToNode(leader);
+
             Assert.True(await leader.WaitForTopology(Leader.TopologyModification.Remove, newServer.Url).WaitAsync(TimeSpan.FromMilliseconds(leader.ElectionTimeout.TotalMilliseconds * 6))); // was 'TotalMilliseconds * 3', changed to *6 for low end machines RavenDB-7263
         }
         /// <summary>

--- a/test/Tests.Infrastructure/RavenTestBase.cs
+++ b/test/Tests.Infrastructure/RavenTestBase.cs
@@ -178,8 +178,10 @@ namespace FastTests
                         Assert.True(result.RaftCommandIndex > 0); //sanity check             
                         store.Urls = result.NodesAddedTo.SelectMany(UseFiddler).ToArray();
                         var timeout = TimeSpan.FromMinutes(Debugger.IsAttached ? 5 : 1);
-                        var task = WaitForRaftIndexToBeAppliedInCluster(result.RaftCommandIndex, timeout);
-                        task.ConfigureAwait(false).GetAwaiter().GetResult();
+                        AsyncHelpers.RunSync(async () =>
+                        {
+                            await WaitForRaftIndexToBeAppliedInCluster(result.RaftCommandIndex, timeout); 
+                        });
                     }
 
                     store.BeforeDispose += (sender, args) =>
@@ -242,7 +244,7 @@ namespace FastTests
                                     continue;
                                 }
 
-                                server.ServerStore.Cluster.WaitForIndexNotification(result.RaftCommandIndex).ConfigureAwait(false).GetAwaiter().GetResult();
+                                AsyncHelpers.RunSync(async () => await server.ServerStore.Cluster.WaitForIndexNotification(result.RaftCommandIndex));
                             }
                         }
                     };

--- a/test/Tests.Infrastructure/TestExtensions.cs
+++ b/test/Tests.Infrastructure/TestExtensions.cs
@@ -7,16 +7,20 @@ namespace Tests.Infrastructure
     {
         public static async Task<bool> WaitAsync(this Task task, TimeSpan timeout)
         {
-            var delay = Task.Delay(timeout);
-            await Task.WhenAny(delay, task);
-            return task.IsCompleted;
+            return await WaitAsync(task, (int)timeout.TotalMilliseconds).ConfigureAwait(false);
         }
 
         public static async Task<bool> WaitAsync(this Task task, int timeout)
         {
-            var delay = Task.Delay(timeout);
-            await Task.WhenAny(delay, task);
-            return task.IsCompleted;
+            var delay = Task.Delay(Math.Max(timeout, 1000));
+            var result = await Task.WhenAny(task, delay).ConfigureAwait(false);
+            if (result == delay && task.IsCompleted == false)
+                return false;
+            if (task.IsCompletedSuccessfully)
+                return true;
+            if (task.Exception != null)
+                throw task.Exception;
+            throw new Exception($"Should never reach this code path. {task.Status}, timeout: {timeout}");
         }
     }
 }


### PR DESCRIPTION
- Fixing an endless wait in the CanEnforceTopologyOnOldLeader test.
- Throw exception if occurs in WaitAsync.
- Fixing async void in LatestVersionCheck.
- Reduce pressure on the ThreadPool if we need to complete a TaskCompletionSource.
- Various time adjustments in rachis tests.
- Passive node will block accessing the databases.
- In the tests don't use Wait or Result on async or Task, instead use the AsyncHelper. Otherwise the xunit will deadlocked.