### PR TITLE
RavenDB-10948 Fixing handling of OnBeforeStore and metadata modifications

### DIFF
--- a/src/Raven.Client/Documents/Session/InMemoryDocumentSessionOperations.cs
+++ b/src/Raven.Client/Documents/Session/InMemoryDocumentSessionOperations.cs
@@ -807,9 +807,12 @@ more responsive application.
         {
             foreach (var entity in DocumentsByEntity)
             {
+                if (entity.Value.IgnoreChanges)
+                    continue;
+
                 var metadataUpdated = UpdateMetadataModifications(entity.Value);
                 var document = EntityToBlittable.ConvertEntityToBlittable(entity.Key, entity.Value);
-                if (entity.Value.IgnoreChanges || EntityChanged(document, entity.Value, null) == false)
+                if (EntityChanged(document, entity.Value, null) == false)
                     continue;
 
                 if (result.DeferredCommandsDictionary.TryGetValue((entity.Value.Id, CommandType.ClientNotAttachment, null), out ICommandData command))
@@ -820,7 +823,7 @@ more responsive application.
                 {
                     var beforeStoreEventArgs = new BeforeStoreEventArgs(this, entity.Value.Id, entity.Key);
                     onOnBeforeStore(this, beforeStoreEventArgs);
-                    if (beforeStoreEventArgs.MetadataAccessed)
+                    if (metadataUpdated || beforeStoreEventArgs.MetadataAccessed)
                         metadataUpdated |= UpdateMetadataModifications(entity.Value);
                     if (beforeStoreEventArgs.MetadataAccessed ||
                         EntityChanged(document, entity.Value, null))

--- a/src/Raven.Client/Json/BlittableJsonWriter.cs
+++ b/src/Raven.Client/Json/BlittableJsonWriter.cs
@@ -63,6 +63,7 @@ namespace Raven.Client.Json
                 }
 
                 _manualBlittableJsonDocumentBuilder.WriteObjectEnd();
+                _documentInfo.Metadata.Modifications = null;
             }
             else if (_documentInfo.Metadata != null)
             {


### PR DESCRIPTION
- Reverting previous RavenDB-10931 fix because its scope was too large
- If OnBeforeStore is called, always update metadata if that is needed.