### PR TITLE
RavenDB-11020 - Allow to retrieve the attachments count through the /stats endpoint

### DIFF
--- a/Raven.Abstractions/Data/DatabaseStatistics.cs
+++ b/Raven.Abstractions/Data/DatabaseStatistics.cs
@@ -17,6 +17,7 @@ namespace Raven.Abstractions.Data
 		public long ApproximateTaskCount { get; set; }
 
 		public long CountOfDocuments { get; set; }
+		public long CountOfAttachments { get; set; }
 
 		public string[] StaleIndexes { get; set; }
 

--- a/Raven.Database/DocumentDatabase.cs
+++ b/Raven.Database/DocumentDatabase.cs
@@ -400,6 +400,7 @@ namespace Raven.Database
 
                     result.ApproximateTaskCount = actions.Tasks.ApproximateTaskCount;
                     result.CountOfDocuments = actions.Documents.GetDocumentsCount();
+                    result.CountOfAttachments = actions.Attachments.GetAttachmentsCount();
                     result.StaleIndexes = IndexStorage.Indexes
                         .Where(s =>
                         {

--- a/Raven.Database/Storage/Esent/StorageActions/DocumentStorageActions.cs
+++ b/Raven.Database/Storage/Esent/StorageActions/DocumentStorageActions.cs
@@ -111,7 +111,14 @@ namespace Raven.Storage.Esent.StorageActions
 			logger.Debug("Attachment with key '{0}' was deleted", key);
 		}
 
-		public IEnumerable<AttachmentInformation> GetAttachmentsByReverseUpdateOrder(int start)
+	    public long GetAttachmentsCount()
+	    {
+	        if (Api.TryMoveFirst(session, Details))
+	            return Api.RetrieveColumnAsInt32(session, Details, tableColumnsCache.DetailsColumns["attachment_count"]).Value;
+	        return 0;
+	    }
+
+        public IEnumerable<AttachmentInformation> GetAttachmentsByReverseUpdateOrder(int start)
 		{
 			Api.JetSetCurrentIndex(session, Files, "by_etag");
 			Api.MoveAfterLast(session, Files);

--- a/Raven.Database/Storage/IAttachmentsStorageActions.cs
+++ b/Raven.Database/Storage/IAttachmentsStorageActions.cs
@@ -17,7 +17,8 @@ namespace Raven.Database.Storage
 		Etag AddAttachment(string key, Etag etag, Stream data, RavenJObject headers);
 		void DeleteAttachment(string key, Etag etag);
 		Attachment GetAttachment(string key);
-		IEnumerable<AttachmentInformation> GetAttachmentsByReverseUpdateOrder(int start);
+	    long GetAttachmentsCount();
+        IEnumerable<AttachmentInformation> GetAttachmentsByReverseUpdateOrder(int start);
 		IEnumerable<AttachmentInformation> GetAttachmentsAfter(Etag value, int take, long maxTotalSize);
 		IEnumerable<AttachmentInformation> GetAttachmentsStartingWith(string idPrefix, int start, int pageSize);
 	}

--- a/Raven.Database/Storage/Managed/AttachmentsStorageActions.cs
+++ b/Raven.Database/Storage/Managed/AttachmentsStorageActions.cs
@@ -89,7 +89,12 @@ namespace Raven.Storage.Managed
 			logger.Debug("Attachment with key '{0}' was deleted", key);
 		}
 
-		public Attachment GetAttachment(string key)
+	    public long GetAttachmentsCount()
+	    {
+	        return storage.Attachments.Count;
+	    }
+
+        public Attachment GetAttachment(string key)
 		{
 			var readResult = storage.Attachments.Read(new RavenJObject { { "key", key } });
 			if (readResult == null)


### PR DESCRIPTION
http://issues.hibernatingrhinos.com/issue/RavenDB-11020