### PR TITLE
[v4.1]RavenDB-11001:

### DIFF
--- a/src/Raven.Server/Documents/Patch/JsBlittableBridge.cs
+++ b/src/Raven.Server/Documents/Patch/JsBlittableBridge.cs
@@ -124,7 +124,11 @@ namespace Raven.Server.Documents.Patch
             {
                 if (property.Key == "length")
                     continue;
-                WriteJsonValue(arrayInstance, false, property.Key, SafelyGetJsValue(property.Value));
+
+                JsValue propertyValue = SafelyGetJsValue(property.Value);
+                                
+                WriteJsonValue(arrayInstance, false, property.Key, propertyValue);
+                
             }
             _writer.WriteArrayEnd();
         }
@@ -326,9 +330,7 @@ namespace Raven.Server.Documents.Patch
                 var value = property.Value;
                 if (value == null)
                     continue;
-                JsValue safeValue = SafelyGetJsValue(value);
-                if (safeValue.IsUndefined())
-                    continue;
+                JsValue safeValue = SafelyGetJsValue(value);                
 
                 _writer.WritePropertyName(propertyName);
                 

--- a/src/Raven.Server/Json/BlittableJsonTraverser.cs
+++ b/src/Raven.Server/Json/BlittableJsonTraverser.cs
@@ -259,6 +259,10 @@ namespace Raven.Server.Json
                             yield return result;
                         }
                     }
+                    else
+                    {
+                        yield return null;
+                    }
                 }
                 else
                 {

--- a/src/Raven.Server/Utils/IncludeUtil.cs
+++ b/src/Raven.Server/Utils/IncludeUtil.cs
@@ -77,6 +77,8 @@ namespace Raven.Server.Utils
             {
                 foreach (var item in collectionOfIds)
                 {
+                    if (item == null)
+                        continue;
                     if (addition != null)
                     {
                         var includedId = _valueHandler(item, addition.Value);

--- a/test/SlowTests/Issues/RavenDB-11001.cs
+++ b/test/SlowTests/Issues/RavenDB-11001.cs
@@ -1,0 +1,145 @@
+﻿using System;
+using System.Collections.Generic;
+using System.Text;
+using FastTests;
+using Raven.Client.Documents.Commands;
+using Xunit;
+using Sparrow.Json.Parsing;
+using Raven.Client.Documents.Queries;
+using Raven.Client.Documents.Session;
+using Sparrow.Json;
+
+namespace SlowTests.Issues
+{
+    public class RavenDB_11001:RavenTestBase
+    {
+        [Fact]
+        public void JavascriptProjectionOfMapOfArrayWithNonexistingFieldShouldReturnArrayOfNulls()
+        {
+            using (var store = GetDocumentStore())                
+            {
+                var executer = store.GetRequestExecutor();
+
+                using (executer.ContextPool.AllocateOperationContext(out var context))
+                {
+                    var docBlit = context.ReadObject(new DynamicJsonValue
+                    {
+                        ["InnerArray"] = new[]
+                        {
+                            new DynamicJsonValue(),
+                            new DynamicJsonValue()
+                        },
+                        [Raven.Client.Constants.Documents.Metadata.Key] = new DynamicJsonValue
+                        {
+                            [Raven.Client.Constants.Documents.Metadata.Collection] = "docs"
+                        }
+                    }, "newDoc");
+                    store.Commands().Execute(new PutDocumentCommand("docs/1", null, docBlit));
+
+                    using (var session = store.OpenSession())
+                    {
+                        QueryCommand queryCommand = new QueryCommand(session as InMemoryDocumentSessionOperations, new IndexQuery()
+                        {
+                            Query = "from docs as d select { inner:d.InnerArray.map(x=>x.f)}"
+                        });
+                        store.Commands().Execute(queryCommand);
+                        var resBlittable = queryCommand.Result.Results[0] as BlittableJsonReaderObject;
+                        var inner = resBlittable["inner"] as BlittableJsonReaderArray;
+                        Assert.Equal(2, inner.Length);
+                        for (var i=0; i< 2; i++)
+                        {
+                            Assert.Equal(null, inner[i]);
+                        }
+                    }                
+                }
+            }
+        }
+
+
+        [Fact]
+        public void JavascriptProjectionOfMapOfArrayWithNonexistingFieldWrappedWithObjectShouldReturnArrayOfObjectsWithNulls()
+        {
+            using (var store = GetDocumentStore())
+            {
+                var executer = store.GetRequestExecutor();
+
+                using (executer.ContextPool.AllocateOperationContext(out var context))
+                {
+                    var docBlit = context.ReadObject(new DynamicJsonValue
+                    {
+                        ["InnerArray"] = new[]
+                        {
+                            new DynamicJsonValue(),
+                            new DynamicJsonValue()
+                        },
+                        [Raven.Client.Constants.Documents.Metadata.Key] = new DynamicJsonValue
+                        {
+                            [Raven.Client.Constants.Documents.Metadata.Collection] = "docs"
+                        }
+                    }, "newDoc");
+                    store.Commands().Execute(new PutDocumentCommand("docs/1", null, docBlit));
+
+                    using (var session = store.OpenSession())
+                    {
+                        QueryCommand queryCommand = new QueryCommand(session as InMemoryDocumentSessionOperations, new IndexQuery()
+                        {
+                            Query = "from docs as d select { inner:d.InnerArray.map(x=>({f:x.f}))}"
+                        });
+                        store.Commands().Execute(queryCommand);
+                        var resBlittable = queryCommand.Result.Results[0] as BlittableJsonReaderObject;
+                        var inner = resBlittable["inner"] as BlittableJsonReaderArray;
+                        Assert.Equal(2, inner.Length);
+                        for (var i = 0; i < 2; i++)
+                        {
+                            var innerObject = inner[i] as BlittableJsonReaderObject;
+                            Assert.Equal(null, innerObject["f"]);
+                        }
+                    }
+                }
+            }
+        }
+
+
+        [Fact]
+        public void RQLProjectionOfMapOfArrayWithNonexistingFieldShouldReturnArrayOfNulls()
+        {
+            using (var store = GetDocumentStore())
+            {
+                var executer = store.GetRequestExecutor();
+
+                using (executer.ContextPool.AllocateOperationContext(out var context))
+                {
+                    var docBlit = context.ReadObject(new DynamicJsonValue
+                    {
+                        ["InnerArray"] = new[]
+                        {
+                            new DynamicJsonValue(),
+                            new DynamicJsonValue()
+                        },
+                        [Raven.Client.Constants.Documents.Metadata.Key] = new DynamicJsonValue
+                        {
+                            [Raven.Client.Constants.Documents.Metadata.Collection] = "docs"
+                        }
+                    }, "newDoc");
+                    store.Commands().Execute(new PutDocumentCommand("docs/1", null, docBlit));
+
+                    using (var session = store.OpenSession())
+                    {
+                        QueryCommand queryCommand = new QueryCommand(session as InMemoryDocumentSessionOperations, new IndexQuery()
+                        {
+                            Query = "from docs select InnerArray[].f"
+                        });
+                        store.Commands().Execute(queryCommand);
+                        var resBlittable = queryCommand.Result.Results[0] as BlittableJsonReaderObject;
+                        var inner = resBlittable["InnerArray[].f"] as BlittableJsonReaderArray;
+                        Assert.Equal(2, inner.Length);
+                        for (var i = 0; i < 2; i++)
+                        {
+                            Assert.Equal(null, inner[i]);
+                        }
+                    }
+                }
+            }
+        }
+    }
+}

--- a/test/SlowTests/Issues/RavenDB_10992.cs
+++ b/test/SlowTests/Issues/RavenDB_10992.cs
@@ -45,8 +45,11 @@ namespace SlowTests.Issues
         public void CanGetDefaultNonSerializedEnumValue()
         {
             DateTimeOffset date = DateTimeOffset.UtcNow.Date;
-            using (var store = GetDocumentStore())
+            using (var store = GetDocumentStore(options: new Options
             {
+                ModifyDocumentStore = x => x.Conventions.CustomizeJsonSerializer = c => c.NullValueHandling = NullValueHandling.Ignore
+            }))
+            {                
                 using (var session = store.OpenSession())
                 {
                     var doc = new Document
@@ -80,6 +83,7 @@ namespace SlowTests.Issues
                                 .ToList()
                         };
 
+                    var projQuery = projection.ToString();
                     var projectionResult = projection.ToList();
 
                     var result = Assert.Single(projectionResult);


### PR DESCRIPTION
Reverting RavenDB-10992 changes, meaning that Jint undefined will be translated to null.
For RQL projections of the type doc.someArray[].nonExistingField the result will be an array of nulls
AddTest