### PR TITLE
[v4.0 only] RavenDB-11022 update SourceLink to v2.8.1

### DIFF
--- a/src/Directory.Build.props
+++ b/src/Directory.Build.props
@@ -25,6 +25,6 @@
 
   </PropertyGroup>
   <ItemGroup>
-    <PackageReference Include="SourceLink.Create.CommandLine" Version="2.8.0" PrivateAssets="All" /> 
+    <PackageReference Include="SourceLink.Create.CommandLine" Version="2.8.1" PrivateAssets="All" /> 
   </ItemGroup>
 </Project>

--- a/tools/Directory.Build.props
+++ b/tools/Directory.Build.props
@@ -17,6 +17,6 @@
     
   </PropertyGroup>
   <ItemGroup>
-    <PackageReference Include="SourceLink.Create.CommandLine" Version="2.8.0" PrivateAssets="All" /> 
+    <PackageReference Include="SourceLink.Create.CommandLine" Version="2.8.1" PrivateAssets="All" /> 
   </ItemGroup>
 </Project>


### PR DESCRIPTION
This change is required only in v4.0 branch. It was already included in v4.1 as part of aca5daff34.