### PR TITLE
[4.1] RavenDB-11027 / RavenDB-11038

### DIFF
--- a/src/Raven.Server/Documents/CatastrophicFailureHandler.cs
+++ b/src/Raven.Server/Documents/CatastrophicFailureHandler.cs
@@ -27,9 +27,12 @@ namespace Raven.Server.Documents
             _logger = LoggingSource.Instance.GetLogger<CatastrophicFailureHandler>("Raven/Server");
         }
 
-        public FailureStats GetStats(Guid environmentId)
+        public bool TryGetStats(Guid environmentId, out FailureStats stats)
         {
-            return _errorsPerEnvironment[environmentId];
+            if (_errorsPerEnvironment.TryGetValue(environmentId, out stats))
+                return true;
+
+            return false;
         }
 
         public void Execute(string databaseName, Exception e, Guid environmentId)

--- a/src/Raven.Server/Documents/Indexes/Index.cs
+++ b/src/Raven.Server/Documents/Indexes/Index.cs
@@ -24,6 +24,7 @@ using Raven.Server.Documents.Includes;
 using Raven.Server.Documents.Indexes.Auto;
 using Raven.Server.Documents.Indexes.MapReduce;
 using Raven.Server.Documents.Indexes.MapReduce.Auto;
+using Raven.Server.Documents.Indexes.MapReduce.Exceptions;
 using Raven.Server.Documents.Indexes.MapReduce.Static;
 using Raven.Server.Documents.Indexes.Persistence.Lucene;
 using Raven.Server.Documents.Indexes.Static;
@@ -982,6 +983,10 @@ namespace Raven.Server.Documents.Indexes
                                 {
                                     HandleCriticalErrors(scope, cie);
                                 }
+                                catch (ExcessiveNumberOfReduceErrorsException enre)
+                                {
+                                    HandleExcessiveNumberOfReduceErrors(scope, enre);
+                                }
                                 catch (OperationCanceledException)
                                 {
                                     // We are here only in the case of indexing process cancellation.
@@ -1243,6 +1248,20 @@ namespace Raven.Server.Documents.Indexes
             SetState(IndexState.Error);
         }
 
+        internal void HandleExcessiveNumberOfReduceErrors(IndexingStatsScope stats, ExcessiveNumberOfReduceErrorsException e)
+        {
+            if (_logger.IsOperationsEnabled)
+                _logger.Operations($"Erroring index due to excessive number of reduce errors '{Name}'.", e);
+
+            stats.AddExcessiveNumberOfReduceErrors(e);
+
+            if (State == IndexState.Error)
+                return;
+
+            _errorStateReason = e.Message;
+            SetState(IndexState.Error);
+        }
+
         private void HandleOutOfMemoryException(OutOfMemoryException oome, IndexingStatsScope scope)
         {
             try
@@ -1302,9 +1321,8 @@ namespace Raven.Server.Documents.Indexes
             if (_logger.IsOperationsEnabled)
                 _logger.Operations($"Data corruption occurred for '{Name}'.", e);
 
-            var corruptionStats = DocumentDatabase.ServerStore.DatabasesLandlord.CatastrophicFailureHandler.GetStats(_environment.DbId);
-
-            if (corruptionStats.WillUnloadDatabase)
+            if (DocumentDatabase.ServerStore.DatabasesLandlord.CatastrophicFailureHandler.TryGetStats(_environment.DbId, out var corruptionStats) &&
+                corruptionStats.WillUnloadDatabase)
             {
                 // it can be a transient error, we are going to unload the database and do not error the index yet
                 // let's stop the indexing thread

--- a/src/Raven.Server/Documents/Indexes/IndexingRunStats.cs
+++ b/src/Raven.Server/Documents/Indexes/IndexingRunStats.cs
@@ -2,6 +2,7 @@
 using System.Collections.Generic;
 using Raven.Client.Documents.Indexes;
 using Raven.Client.Util;
+using Raven.Server.Documents.Indexes.MapReduce.Exceptions;
 using Raven.Server.Exceptions;
 
 namespace Raven.Server.Documents.Indexes
@@ -30,6 +31,8 @@ namespace Raven.Server.Documents.Indexes
 
         public int MaxNumberOfOutputsPerDocument;
 
+        public int NumberOfKeptReduceErrors;
+
         public override string ToString()
         {
             return $"Map - attempts: {MapAttempts}, successes: {MapSuccesses}, errors: {MapErrors} / " +
@@ -44,6 +47,8 @@ namespace Raven.Server.Documents.Indexes
         public void AddReduceError(string message)
         {
             AddError(null, message, "Reduce");
+
+            NumberOfKeptReduceErrors++;
         }
 
         public void AddCorruptionError(Exception exception)
@@ -74,6 +79,11 @@ namespace Raven.Server.Documents.Indexes
         public void AddMemoryError(OutOfMemoryException oome)
         {
             AddError(null, $"Memory exception occurred: {oome}", "Memory");
+        }
+
+        public void AddExcessiveNumberOfReduceErrors(ExcessiveNumberOfReduceErrorsException e)
+        {
+            AddError(null, $"Excessive number of reduce errors: {e}", "Reduce");
         }
 
         private void AddError(string key, string message, string action)

--- a/src/Raven.Server/Documents/Indexes/IndexingStatsAggregator.cs
+++ b/src/Raven.Server/Documents/Indexes/IndexingStatsAggregator.cs
@@ -3,6 +3,7 @@ using System.Diagnostics;
 using System.Linq;
 using Raven.Client.Documents.Indexes;
 using Raven.Client.Util;
+using Raven.Server.Documents.Indexes.MapReduce.Exceptions;
 using Raven.Server.Exceptions;
 using Raven.Server.Utils.Stats;
 
@@ -104,7 +105,15 @@ namespace Raven.Server.Documents.Indexes
 
         public int MapAttempts => _stats.MapAttempts;
 
+        public int MapErrors => _stats.MapErrors;
+
+        public int ReduceAttempts => _stats.ReduceAttempts;
+
+        public int ReduceErrors => _stats.ReduceErrors;
+
         public int ErrorsCount => _stats.Errors?.Count ?? 0;
+
+        public int NumberOfKeptReduceErrors => _stats.NumberOfKeptReduceErrors;
 
         public void AddAllocatedBytes(long sizeInBytes)
         {
@@ -139,6 +148,11 @@ namespace Raven.Server.Documents.Indexes
         public void AddAnalyzerError(IndexAnalyzerException iae)
         {
             _stats.AddAnalyzerError(iae);
+        }
+
+        public void AddExcessiveNumberOfReduceErrors(ExcessiveNumberOfReduceErrorsException e)
+        {
+            _stats.AddExcessiveNumberOfReduceErrors(e);
         }
 
         public void AddMapError(string key, string message)
@@ -208,9 +222,9 @@ namespace Raven.Server.Documents.Indexes
             _stats.ReduceSuccesses += numberOfEntries;
         }
 
-        public int RecordReduceErrors(int numberOfEntries)
+        public void RecordReduceErrors(int numberOfEntries)
         {
-            return _stats.ReduceErrors += numberOfEntries;
+            _stats.ReduceErrors += numberOfEntries;
         }
 
         public IndexingPerformanceOperation ToIndexingPerformanceOperation(string name)

--- a/src/Raven.Server/Documents/Indexes/MapReduce/Exceptions/AggregationResultNotFoundException.cs
+++ b/src/Raven.Server/Documents/Indexes/MapReduce/Exceptions/AggregationResultNotFoundException.cs
@@ -1,0 +1,19 @@
+﻿using System;
+
+namespace Raven.Server.Documents.Indexes.MapReduce.Exceptions
+{
+    public class AggregationResultNotFoundException : Exception
+    {
+        public AggregationResultNotFoundException()
+        {
+        }
+
+        public AggregationResultNotFoundException(string message) : base(message)
+        {
+        }
+
+        public AggregationResultNotFoundException(string message, Exception inner) : base(message, inner)
+        {
+        }
+    }
+}

--- a/src/Raven.Server/Documents/Indexes/MapReduce/Exceptions/ExcessiveNumberOfReduceErrorsException.cs
+++ b/src/Raven.Server/Documents/Indexes/MapReduce/Exceptions/ExcessiveNumberOfReduceErrorsException.cs
@@ -1,0 +1,19 @@
+﻿using System;
+
+namespace Raven.Server.Documents.Indexes.MapReduce.Exceptions
+{
+    public class ExcessiveNumberOfReduceErrorsException : Exception
+    {
+        public ExcessiveNumberOfReduceErrorsException()
+        {
+        }
+
+        public ExcessiveNumberOfReduceErrorsException(string message) : base(message)
+        {
+        }
+
+        public ExcessiveNumberOfReduceErrorsException(string message, Exception inner) : base(message, inner)
+        {
+        }
+    }
+}

--- a/src/Raven.Server/Documents/Indexes/MapReduce/Exceptions/UnexpectedReduceTreePageException.cs
+++ b/src/Raven.Server/Documents/Indexes/MapReduce/Exceptions/UnexpectedReduceTreePageException.cs
@@ -1,6 +1,6 @@
 ﻿using System;
 
-namespace Raven.Server.Documents.Indexes.MapReduce
+namespace Raven.Server.Documents.Indexes.MapReduce.Exceptions
 {
     public class UnexpectedReduceTreePageException : Exception
     {

--- a/src/Raven.Server/Smuggler/Documents/Processors/BuildVersion.cs
+++ b/src/Raven.Server/Smuggler/Documents/Processors/BuildVersion.cs
@@ -4,7 +4,7 @@ namespace Raven.Server.Smuggler.Documents.Processors
     {
         public static BuildVersionType Type(long buildVersion)
         {
-            if (buildVersion >= 40 && buildVersion <= 49)
+            if (buildVersion >= 40 && buildVersion < 50)
                 return BuildVersionType.V4; // debug / dev version
             if (buildVersion < 40000)
                 return BuildVersionType.V3;

--- a/test/SlowTests/Issues/RavenDB_10744.cs
+++ b/test/SlowTests/Issues/RavenDB_10744.cs
@@ -33,7 +33,7 @@ namespace SlowTests.Issues
                 {
                     handler.Execute(db.Name, new Exception("Catastrophic"), environmentId);
 
-                    failureStats = handler.GetStats(environmentId);
+                    handler.TryGetStats(environmentId, out failureStats);
 
                     Assert.True(failureStats.WillUnloadDatabase);
 
@@ -45,7 +45,7 @@ namespace SlowTests.Issues
 
                 handler.Execute(db.Name, new Exception("Catastrophic"), Guid.Empty);
 
-                failureStats = handler.GetStats(environmentId);
+                handler.TryGetStats(environmentId, out failureStats);
 
                 Assert.False(failureStats.WillUnloadDatabase);
 
@@ -55,7 +55,7 @@ namespace SlowTests.Issues
 
                 handler.Execute(db.Name, new Exception("Catastrophic"), environmentId);
 
-                failureStats = handler.GetStats(environmentId);
+                handler.TryGetStats(environmentId, out failureStats);
 
                 Assert.True(failureStats.WillUnloadDatabase);
                 Assert.True(failureStats.DatabaseUnloadTask.Wait(TimeSpan.FromSeconds(30)));


### PR DESCRIPTION
- better message for "Couldn't find pre-computed results for existing page" error - we failed to aggregate a leaf page so we don't have the result stored in PageNumberToReduceResult table
- ensure we don't generate stack trace each time we get a reduce error as we keep only 500 errors anyway
- fixing possible KeyNotFoundException when getting stats for CatastrophicFailureHandler
- fixing build version detection so we can import 4.1 ravendump file