### PR TITLE
[4.0] RavenDB-10997

### DIFF
--- a/src/Raven.Server/ServerWide/BackgroundTasks/LatestVersionCheck.cs
+++ b/src/Raven.Server/ServerWide/BackgroundTasks/LatestVersionCheck.cs
@@ -55,7 +55,7 @@ namespace Raven.Server.ServerWide.BackgroundTasks
                     return;
 
                 var stream = await ApiRavenDbClient.GetStreamAsync(
-                    $"/api/v2/versions/latest?channel=dev&build={buildNumber}");
+                    $"/api/v2/versions/latest?channel=patch&build={buildNumber}");
 
                 using (var context = JsonOperationContext.ShortTermSingleUse())
                 {


### PR DESCRIPTION
- on server start new version available notification will be removed when it concerns older build or when dev build is used
- switched to 'patch' channel