### PR TITLE
RavenDB-11118 Fixing build "Feature 'digit separators' is not availab…

### DIFF
--- a/Raven.Database/Prefetching/PrefetchingBehavior.cs
+++ b/Raven.Database/Prefetching/PrefetchingBehavior.cs
@@ -34,7 +34,7 @@ namespace Raven.Database.Prefetching
             public DateTime AddedAt;
         }
 
-        private static readonly int MaxDeletedDocumentsToTrack = 64_000;
+        private static readonly int MaxDeletedDocumentsToTrack = 64000;
         private static readonly ILog log = LogManager.GetCurrentClassLogger();
         private readonly BaseBatchSizeAutoTuner autoTuner;
         private readonly WorkContext context;


### PR DESCRIPTION
…le in C# 6. Please use language version 7.0 or greater"