### PR TITLE
RavenDB-11043 Treating undefined as null in JintPropertyAccessor to a…

### DIFF
--- a/src/Raven.Server/Documents/Indexes/Persistence/Lucene/Documents/PropertyAccessor.cs
+++ b/src/Raven.Server/Documents/Indexes/Persistence/Lucene/Documents/PropertyAccessor.cs
@@ -215,7 +215,10 @@ namespace Raven.Server.Documents.Indexes.Persistence.Lucene.Documents
             {
                 return jsValue.AsObject();
             }
-
+            if (jsValue.IsUndefined())
+            {
+                return null;
+            }
 
             ThrowInvalidObject(jsValue);
             return null;


### PR DESCRIPTION
…lign our self with other Jint usages