### PR TITLE
[4.0] RavenDB-10925

### DIFF
--- a/src/Raven.Server/Documents/Indexes/AutoIndexNameFinder.cs
+++ b/src/Raven.Server/Documents/Indexes/AutoIndexNameFinder.cs
@@ -35,8 +35,8 @@ namespace Raven.Server.Documents.Indexes
             if (fields == null)
                 throw new ArgumentNullException(nameof(fields));
 
-            collection = 
-                string.Equals(collection, Constants.Documents.Collections.AllDocumentsCollection, StringComparison.OrdinalIgnoreCase) 
+            collection =
+                string.Equals(collection, Constants.Documents.Collections.AllDocumentsCollection, StringComparison.OrdinalIgnoreCase)
                     ? "AllDocs" : collection;
 
             if (fields.Count == 0)
@@ -48,7 +48,7 @@ namespace Raven.Server.Documents.Indexes
 
                 return collectionOnly;
             }
-            
+
             var combinedFields = string.Join("And", fields.Select(GetName).OrderBy(x => x));
 
             string formattableString = $"Auto/{collection}/By{combinedFields}";
@@ -68,6 +68,9 @@ namespace Raven.Server.Documents.Indexes
 
             if (x.HasQuotedName)
                 name = $"'{name}'";
+
+            if (x.GroupByArrayBehavior == GroupByArrayBehavior.ByContent)
+                name = AutoIndexField.GetGroupByArrayContentAutoIndexFieldName(name);
 
             if (x.Indexing == AutoFieldIndexing.Default || x.Indexing == AutoFieldIndexing.No)
             {

--- a/src/Raven.Server/Documents/Indexes/IndexField.cs
+++ b/src/Raven.Server/Documents/Indexes/IndexField.cs
@@ -159,6 +159,9 @@ namespace Raven.Server.Documents.Indexes
             if (options.Spatial != null)
                 field.Spatial = new AutoSpatialOptions(options.Spatial);
 
+            field.Aggregation = options.Aggregation;
+            field.GroupByArrayBehavior = options.GroupByArrayBehavior;
+
             return field;
         }
 
@@ -266,6 +269,11 @@ namespace Raven.Server.Documents.Indexes
         public static string GetExactAutoIndexFieldName(string name)
         {
             return $"exact({name})";
+        }
+
+        public static string GetGroupByArrayContentAutoIndexFieldName(string name)
+        {
+            return $"array({name})";
         }
     }
 }

--- a/src/Raven.Server/Documents/Indexes/IndexStore.cs
+++ b/src/Raven.Server/Documents/Indexes/IndexStore.cs
@@ -144,7 +144,6 @@ namespace Raven.Server.Documents.Indexes
                 .Select(x =>
                 {
                     var field = AutoIndexField.Create(x.Key, x.Value);
-                    field.Aggregation = x.Value.Aggregation;
 
                     Debug.Assert(x.Value.GroupByArrayBehavior == GroupByArrayBehavior.NotApplicable);
 
@@ -172,8 +171,6 @@ namespace Raven.Server.Documents.Indexes
                     .Select(x =>
                     {
                         var field = AutoIndexField.Create(x.Key, x.Value);
-                        field.Aggregation = x.Value.Aggregation;
-                        field.GroupByArrayBehavior = x.Value.GroupByArrayBehavior;
 
                         return field;
                     })

--- a/src/Raven.Server/Documents/Queries/Dynamic/DynamicQueryToIndexMatcher.cs
+++ b/src/Raven.Server/Documents/Queries/Dynamic/DynamicQueryToIndexMatcher.cs
@@ -243,6 +243,14 @@ namespace Raven.Server.Documents.Queries.Dynamic
             {
                 if (definition.GroupByFields.TryGetValue(groupByField.Name, out var indexField))
                 {
+                    if (groupByField.GroupByArrayBehavior != indexField.GroupByArrayBehavior)
+                    {
+                        explanations?.Add(new Explanation(indexName,
+                            $"The following group by field {indexField.Name} is grouping by '{indexField.GroupByArrayBehavior}', while the query needs to perform '{groupByField.GroupByArrayBehavior}' grouping"));
+
+                        return DynamicQueryMatchType.Failure;
+                    }
+
                     if (groupByField.IsSpecifiedInWhere == false)
                         continue;
 

--- a/test/SlowTests/Issues/RavenDB_10925.cs
+++ b/test/SlowTests/Issues/RavenDB_10925.cs
@@ -1,0 +1,63 @@
+﻿using System.Linq;
+using System.Threading.Tasks;
+using FastTests;
+using Raven.Client.Documents.Indexes;
+using Raven.Server.Documents.Indexes;
+using Raven.Server.Documents.Indexes.MapReduce.Auto;
+using Xunit;
+
+namespace SlowTests.Issues
+{
+    public class RavenDB_10925 : RavenTestBase
+    {
+        [Fact]
+        public async Task CanCreateTwoSimilarMapReduceIndexesThatAreGroupingArrayUsingDifferentBehavior()
+        {
+            using (var store = GetDocumentStore())
+            {
+                var database = await GetDatabase(store.Database);
+
+                var i0 = await database.IndexStore.CreateIndex(new AutoMapReduceIndexDefinition(
+                    "Companies",
+                    new[]
+                    {
+                        AutoIndexField.Create("Count", new AutoIndexDefinition.AutoIndexFieldOptions()),
+                        AutoIndexField.Create("City", new AutoIndexDefinition.AutoIndexFieldOptions())
+                    },
+                    new[]
+                    {
+                        AutoIndexField.Create("Name", new AutoIndexDefinition.AutoIndexFieldOptions
+                        {
+                            GroupByArrayBehavior = GroupByArrayBehavior.ByIndividualValues
+                        })
+                    }));
+
+                var i1 = await database.IndexStore.CreateIndex(new AutoMapReduceIndexDefinition(
+                    "Companies",
+                    new[]
+                    {
+                        AutoIndexField.Create("Count", new AutoIndexDefinition.AutoIndexFieldOptions()),
+                        AutoIndexField.Create("City", new AutoIndexDefinition.AutoIndexFieldOptions())
+                    },
+                    new[]
+                    {
+                        AutoIndexField.Create("Name", new AutoIndexDefinition.AutoIndexFieldOptions
+                        {
+                            GroupByArrayBehavior = GroupByArrayBehavior.ByContent
+                        })
+                    }));
+
+                database.IndexStore.RunIdleOperations();
+
+                var indexes = database
+                    .IndexStore
+                    .GetIndexes()
+                    .ToList();
+
+                Assert.Equal(2, indexes.Count);
+                Assert.Contains(i0, indexes);
+                Assert.Contains(i1, indexes);
+            }
+        }
+    }
+}


### PR DESCRIPTION
- fixing issue where two similar auto map-reduce indexes with different array grouping strategies could not be created because name was not unique
- query matcher should return match failure if the group by array behavior does not match