### PR TITLE
RavenDB-11207: SlowTest - can_get_in_progress_operation_when_deleting…

### DIFF
--- a/test/SlowTests/Issues/RavenDB_4091.cs
+++ b/test/SlowTests/Issues/RavenDB_4091.cs
@@ -50,7 +50,7 @@ namespace SlowTests.Issues
                     progresses.Add(progress);
                 };
 
-                operation.WaitForCompletion(TimeSpan.FromSeconds(15));
+                operation.WaitForCompletion(TimeSpan.FromSeconds(60));
 
                 Assert.NotEmpty(progresses);
 


### PR DESCRIPTION
…_by_index : from 15 secs to 60 secs