### PR TITLE
[4.1] RavenDB-10698 When there isn't any connection string defined (in ETL …

### DIFF
--- a/src/Raven.Studio/typescript/viewmodels/database/tasks/editExternalReplicationTask.ts
+++ b/src/Raven.Studio/typescript/viewmodels/database/tasks/editExternalReplicationTask.ts
@@ -112,6 +112,9 @@ class editExternalReplicationTask extends viewModelBase {
 
         this.newConnectionString(connectionStringRavenEtlModel.empty());
 
+        // Open the 'Create new conn. str.' area if no connection strings are yet defined 
+        this.ravenEtlConnectionStringsDetails.subscribe((value) => { this.createNewConnectionString(!value.length) }); 
+        
         // Discard test connection result when needed
         this.createNewConnectionString.subscribe(() => this.testConnectionResult(null));
         this.newConnectionString().inputUrl().discoveryUrlName.subscribe(() => this.testConnectionResult(null));

--- a/src/Raven.Studio/typescript/viewmodels/database/tasks/editRavenEtlTask.ts
+++ b/src/Raven.Studio/typescript/viewmodels/database/tasks/editRavenEtlTask.ts
@@ -121,6 +121,9 @@ class editRavenEtlTask extends viewModelBase {
         
         this.newConnectionString(connectionStringRavenEtlModel.empty());
         
+        // Open the 'Create new conn. str.' area if no connection strings are yet defined 
+        this.ravenEtlConnectionStringsDetails.subscribe((value) => { this.createNewConnectionString(!value.length) });
+
         // Discard test connection result when needed
         this.createNewConnectionString.subscribe(() => this.testConnectionResult(null));
         this.newConnectionString().inputUrl().discoveryUrlName.subscribe(() => this.testConnectionResult(null));        

--- a/src/Raven.Studio/typescript/viewmodels/database/tasks/editSqlEtlTask.ts
+++ b/src/Raven.Studio/typescript/viewmodels/database/tasks/editSqlEtlTask.ts
@@ -154,6 +154,9 @@ class editSqlEtlTask extends viewModelBase {
         this.initDirtyFlag();
 
         this.newConnectionString(connectionStringSqlEtlModel.empty());
+
+        // Open the 'Create new conn. str.' area if no connection strings are yet defined 
+        this.sqlEtlConnectionStringsNames.subscribe((value) => { this.createNewConnectionString(!value.length) });
     }
     
     private initDirtyFlag() {

--- a/src/Raven.Studio/wwwroot/App/views/database/tasks/editExternalReplicationTask.html
+++ b/src/Raven.Studio/wwwroot/App/views/database/tasks/editExternalReplicationTask.html
@@ -120,7 +120,7 @@
                                     </div>
                                     <div class="padding bg-info">
                                         <h2>About this error</h2>
-                                        <div>Each RavenDB server has both HTTP and TCP endpoints. While the first one is used for system management and client-server rest request, the second is used for inter-server and advanced clien-server communicaitons.</div>
+                                        <div>Each RavenDB server has both HTTP and TCP endpoints. While the first one is used for system management and client-server rest request, the second is used for inter-server and advanced clien-server communications.</div>
                                         <div>The connection tests the TCP endpoint only after a successful HTTP connection.</div>
                                         <div data-bind="visible: HTTPSuccess">It appears that the current server was able to connect to the desired server through HTTP, but failed connecting to it using TCP.</div>
                                         <div data-bind="visible: !HTTPSuccess">It appears that the current server could not connect to the desired node through HTTP.</div>

--- a/src/Raven.Studio/wwwroot/App/views/database/tasks/editRavenEtlTask.html
+++ b/src/Raven.Studio/wwwroot/App/views/database/tasks/editRavenEtlTask.html
@@ -112,7 +112,7 @@
                                     </div>
                                     <div class="padding bg-info">
                                         <h2>About this error</h2>
-                                        <div>Each RavenDB server has both HTTP and TCP endpoints. While the first one is used for system management and client-server rest request, the second is used for inter-server and advanced clien-server communicaitons.</div>
+                                        <div>Each RavenDB server has both HTTP and TCP endpoints. While the first one is used for system management and client-server rest request, the second is used for inter-server and advanced clien-server communications.</div>
                                         <div>The connection tests the TCP endpoint only after a successful HTTP connection.</div>
                                         <div data-bind="visible: HTTPSuccess">It appears that the current server was able to connect to the desired server through HTTP, but failed connecting to it using TCP.</div>
                                         <div data-bind="visible: !HTTPSuccess">It appears that the current server could not connect to the desired node through HTTP.</div>


### PR DESCRIPTION
…or SQL) set 'create new by default'