### PR TITLE
[4.1] RavenDB-11203 Fixing race condition in the logging. If we start new l…

### DIFF
--- a/src/Sparrow/Logging/LoggingSource.cs
+++ b/src/Sparrow/Logging/LoggingSource.cs
@@ -293,7 +293,7 @@ namespace Sparrow.Logging
             var state = _localState.Value;
             if (state.Generation != _generation)
             {
-                _localState.Value = GenerateThreadWriterState();
+                state = _localState.Value = GenerateThreadWriterState();
             }
 
             if (state.Free.Dequeue(out var item))


### PR DESCRIPTION
…ogging thread (e.g. by enabling admin logs) then we increment the generation. In result we need to create new LocalThreadWriterState then we _need_ to use this new instance.