### PR TITLE
[4.0] RavenDB-11178

### DIFF
--- a/src/Sparrow/AsyncManualResetEvent.cs
+++ b/src/Sparrow/AsyncManualResetEvent.cs
@@ -10,6 +10,7 @@ namespace Sparrow
     {
         private volatile TaskCompletionSource<bool> _tcs = new TaskCompletionSource<bool>(TaskCreationOptions.RunContinuationsAsynchronously);
         private CancellationToken _token;
+        private int _defer = 0;
 
         public AsyncManualResetEvent()
         {
@@ -39,6 +40,11 @@ namespace Sparrow
             return new FrozenAwaiter(_tcs, this);
         }
 
+        public void Defer()
+        {
+            Interlocked.Exchange(ref _defer, 1);
+        }
+
         public struct FrozenAwaiter
         {
             private readonly TaskCompletionSource<bool> _tcs;
@@ -55,18 +61,39 @@ namespace Sparrow
             {
                 return _tcs.Task;
             }
-
-
+            
             [Pure]
             public async Task<bool> WaitAsync(TimeSpan timeout)
             {
                 var waitAsync = _tcs.Task;
-                _parent._token.ThrowIfCancellationRequested();
-                var result = await Task.WhenAny(waitAsync, TimeoutManager.WaitFor(timeout, _parent._token)).ConfigureAwait(false);
-                if (_parent._token != CancellationToken.None)
-                    return result == waitAsync && !_parent._token.IsCancellationRequested;
+                while (true)
+                {
+                    _parent._token.ThrowIfCancellationRequested();
+                    var result = await Task.WhenAny(waitAsync, TimeoutManager.WaitFor(timeout, _parent._token)).ConfigureAwait(false);
 
-                return result == waitAsync;
+                    if (Interlocked.Exchange(ref _parent._defer, 0) == 1)
+                    {
+                        if (result == waitAsync)
+                        {
+                            if (_parent._token != CancellationToken.None)
+                            {
+                                return _parent._token.IsCancellationRequested == false;
+                            }
+
+                            return true;
+                        }
+
+                        continue;
+                    }
+
+                    if (_parent._token != CancellationToken.None)
+                    {
+                        return result == waitAsync && _parent._token.IsCancellationRequested == false;
+                    }
+
+                    return result == waitAsync;
+                }
+                
             }
         }
 
@@ -85,6 +112,9 @@ namespace Sparrow
                 if ((tcs.Task.IsCompleted == false && force == false) ||
 #pragma warning disable 420
                     Interlocked.CompareExchange(ref _tcs, new TaskCompletionSource<bool>(TaskCreationOptions.RunContinuationsAsynchronously), tcs) == tcs)
+                {
+                    _defer = 0; // don't care about concurrency here.
+                }
 #pragma warning restore 420
                     return;
             }

--- a/test/Tryouts/Program.cs
+++ b/test/Tryouts/Program.cs
@@ -16,9 +16,9 @@ namespace Tryouts
                 try
                 {
                     Console.WriteLine(i);
-                    using (var test = new RachisTests.DatabaseCluster.ClusterDatabaseMaintenance())
+                    using (var test = new RachisTests.SubscriptionsFailover())
                     {
-                        await test.MoveToPassiveWhenRefusedConnectionFromAllNodes();
+                        await test.DistributedRevisionsSubscription(5);
                     }
                 }
                 catch (Exception e)


### PR DESCRIPTION
fixing DistributedRevisionsSubscription test:
1. Creating a subscribtion will try to wait its creation on the alledged responsible node.
2. Defer the timeout exception on every incoming document.