### PR TITLE
[4.1] RavenDB-11178

### DIFF
--- a/test/Tryouts/Program.cs
+++ b/test/Tryouts/Program.cs
@@ -16,9 +16,9 @@ namespace Tryouts
                 try
                 {
                     Console.WriteLine(i);
-                    using (var test = new RachisTests.DatabaseCluster.ClusterDatabaseMaintenance())
+                    using (var test = new RachisTests.SubscriptionsFailover())
                     {
-                        await test.MoveToPassiveWhenRefusedConnectionFromAllNodes();
+                        await test.DistributedRevisionsSubscription(5);
                     }
                 }
                 catch (Exception e)


### PR DESCRIPTION
fixing DistributedRevisionsSubscription test:
1. Creating a subscribtion will try to wait its creation on the alledged responsible node.
2. Defer the timeout exception on every incoming document.