### PR TITLE
[v4.1]RavenDB-11200: Fixing test: we had parallel usage of JsonOperationCon…

### DIFF
--- a/test/FastTests/Client/Subscriptions/SubscriptionTestBase.cs
+++ b/test/FastTests/Client/Subscriptions/SubscriptionTestBase.cs
@@ -9,6 +9,8 @@ namespace FastTests.Client.Subscriptions
         {
             public string Id { get; set; }
             public string Name { get; set; }
+            public Thing OtherDoc { get; set; }
+
         }
 
         protected async Task CreateDocuments(DocumentStore store, int amount)


### PR DESCRIPTION
…text, due to parallel blittable field access

# Conflicts:
#	test/SlowTests/Client/Subscriptions/CriteriaScript.cs