### PR TITLE
RavenDB-8956 fixed invalid order by

### DIFF
--- a/src/Raven.Server/Documents/Indexes/Persistence/Lucene/IndexReadOperation.cs
+++ b/src/Raven.Server/Documents/Indexes/Persistence/Lucene/IndexReadOperation.cs
@@ -183,14 +183,14 @@ namespace Raven.Server.Documents.Indexes.Persistence.Lucene
 
         private IEnumerable<(Document Result, Dictionary<string, Dictionary<string, string[]>> Highlightings, ExplanationResult Explanation)> QuerySortOnly(IndexQueryServerSide query, IQueryResultRetriever retriever, int start, int pageSize)
         {
-            int FindDocument(bool isAcdending, int i, (int Index, StringIndex Item, IndexReader IndexReader)[] items)
+            int FindDocument(bool isAsc, int i, (int Index, StringIndex Item, IndexReader IndexReader)[] items)
             {
                 var innerDoc = -1;
                 var tpl = items[i];
                 var index = tpl.Index;
                 while (index < tpl.Item.reverseOrder.Length)
                 {
-                    if (isAcdending == false)
+                    if (isAsc == false)
                         index = tpl.Item.reverseOrder.Length - index - 1;
 
                     innerDoc = tpl.Item.reverseOrder[index];

--- a/src/Raven.Server/Documents/Queries/QueryMetadata.cs
+++ b/src/Raven.Server/Documents/Queries/QueryMetadata.cs
@@ -67,8 +67,7 @@ namespace Raven.Server.Documents.Queries
                                   && (OrderBy[0].OrderingType == OrderByFieldType.Implicit || OrderBy[0].OrderingType == OrderByFieldType.String)
                                   && HasExplanations == false
                                   && HasHighlightings == false
-                                  && IsDistinct == false
-                                  && IsGroupBy == false;
+                                  && IsDistinct == false;
         }
 
         public readonly bool IsOptimizedSortOnly;

--- a/test/SlowTests/Server/Documents/Indexing/Auto/RavenDB_8761.cs
+++ b/test/SlowTests/Server/Documents/Indexing/Auto/RavenDB_8761.cs
@@ -250,7 +250,7 @@ namespace SlowTests.Server.Documents.Indexing.Auto
                                 @"
                             from Orders 
                             group by array(Lines[].Product), array(Lines[].Quantity) 
-                            order by Lines[].Quantity
+                            order by count()
                             select Lines[].Product as Products, Lines[].Quantity as Quantities, count()")
                             .WaitForNonStaleResults(),
 


### PR DESCRIPTION
I will create separate issue to detect (and throw) when we are trying to order by group by field that is grouping by array content