### PR TITLE
[4.1] RavenDB-11112 Fix EtlDestinationFailoverBetweenNodesWithinSameCluster

### DIFF
--- a/src/Raven.Client/Documents/Operations/ConnectionStrings/ConnectionString.cs
+++ b/src/Raven.Client/Documents/Operations/ConnectionStrings/ConnectionString.cs
@@ -31,6 +31,14 @@ namespace Raven.Client.Documents.Operations.ConnectionStrings
                 [nameof(Name)] = Name
             };
         }
+
+        public virtual bool IsEqual(ConnectionString connectionString)
+        {
+            if (connectionString == null)
+                return false;
+
+            return Name == connectionString.Name && Type == connectionString.Type;
+        }
     }
 
     public enum ConnectionStringType

--- a/src/Raven.Client/Documents/Operations/ETL/RavenConnectionString.cs
+++ b/src/Raven.Client/Documents/Operations/ETL/RavenConnectionString.cs
@@ -1,4 +1,5 @@
 ﻿using System.Collections.Generic;
+using System.Linq;
 using Raven.Client.Documents.Operations.ConnectionStrings;
 using Sparrow.Json.Parsing;
 
@@ -31,6 +32,28 @@ namespace Raven.Client.Documents.Operations.ETL
                 }
                 TopologyDiscoveryUrls[i] = TopologyDiscoveryUrls[i].Trim();
             }
+        }
+
+        public override bool IsEqual(ConnectionString connectionString)
+        {
+            if (connectionString is RavenConnectionString ravenConnection)
+            {
+                if (TopologyDiscoveryUrls.Length != ravenConnection.TopologyDiscoveryUrls.Length)
+                    return false;
+
+                foreach (var url in TopologyDiscoveryUrls)
+                {
+                    if (ravenConnection.TopologyDiscoveryUrls.Contains(url) == false)
+                        return false;
+                }
+
+                var isEqual = base.IsEqual(connectionString);
+                return isEqual &&
+                       Database == ravenConnection.Database &&
+                       TopologyDiscoveryUrls.SequenceEqual(ravenConnection.TopologyDiscoveryUrls);
+            }
+
+            return false;
         }
 
         public override DynamicJsonValue ToJson()

--- a/src/Raven.Client/Documents/Operations/ETL/SQL/SqlConnectionString.cs
+++ b/src/Raven.Client/Documents/Operations/ETL/SQL/SqlConnectionString.cs
@@ -16,6 +16,16 @@ namespace Raven.Client.Documents.Operations.ETL.SQL
                 errors.Add($"{nameof(ConnectionString)} cannot be empty");
         }
 
+        public override bool IsEqual(ConnectionString connectionString)
+        {
+            if (connectionString is SqlConnectionString sqlConnection)
+            {
+                return base.IsEqual(connectionString) && ConnectionString == sqlConnection.ConnectionString;
+            }
+
+            return false;
+        }
+
         public override DynamicJsonValue ToJson()
         {
             var json = base.ToJson();

--- a/src/Raven.Client/Documents/Operations/ETL/Transformation.cs
+++ b/src/Raven.Client/Documents/Operations/ETL/Transformation.cs
@@ -1,6 +1,7 @@
 ﻿using System;
 using System.Collections.Generic;
 using System.Text.RegularExpressions;
+using Sparrow.Json.Parsing;
 
 namespace Raven.Client.Documents.Operations.ETL
 {
@@ -86,6 +87,40 @@ namespace Raven.Client.Documents.Operations.ETL
             }
 
             return errors.Count == 0;
+        }
+
+        public DynamicJsonValue ToJson()
+        {
+            return new DynamicJsonValue
+            {
+                [nameof(Name)] = Name,
+                [nameof(Script)] = Script,
+                [nameof(Collections)] = new DynamicJsonArray(Collections),
+                [nameof(ApplyToAllDocuments)] = ApplyToAllDocuments,
+                [nameof(Disabled)] = Disabled
+            };
+        }
+
+        public bool IsEqual(Transformation transformation)
+        {
+            if (transformation == null)
+                return false;
+
+            if (transformation.Collections.Count != Collections.Count)
+                return false;
+
+            var collections = new List<string>(Collections);
+
+            foreach (var collection in transformation.Collections)
+            {
+                collections.Remove(collection);
+            }
+
+            return collections.Count == 0 &&
+                   transformation.Name == Name &&
+                   transformation.Script == Script &&
+                   transformation.ApplyToAllDocuments == ApplyToAllDocuments &&
+                   transformation.Disabled == Disabled;
         }
 
         public string[] GetCollectionsFromScript()

--- a/test/Tryouts/Program.cs
+++ b/test/Tryouts/Program.cs
@@ -16,9 +16,9 @@ namespace Tryouts
                 try
                 {
                     Console.WriteLine(i);
-                    using (var test = new RachisTests.DatabaseCluster.ClusterDatabaseMaintenance())
+                    using (var test = new RachisTests.DatabaseCluster.EtlFailover())
                     {
-                        await test.MoveToPassiveWhenRefusedConnectionFromAllNodes();
+                        await test.EtlDestinationFailoverBetweenNodesWithinSameCluster();
                     }
                 }
                 catch (Exception e)


### PR DESCRIPTION
The underlying issue was that on _any_ change of the database record we disposed and initilized _all_ of the ETLs processes.
Now we find only the relevent processes to dispose and to start.