### PR TITLE
[4.1] RavenDB-11090 [FLAKY] Failed on Windows - RachisTests.AddNodeToCluste…

### DIFF
--- a/test/RachisTests/AddNodeToClusterTests.cs
+++ b/test/RachisTests/AddNodeToClusterTests.cs
@@ -101,9 +101,9 @@ namespace RachisTests
                     }
 
                     Assert.True(WaitForDocument<User>(watcherStore, "users/1", u => u.Name == "Karmel", 30_000));
-
+                    
                     // remove the node from the cluster that is responsible for the external replication
-                    Assert.True(await leader.ServerStore.RemoveFromClusterAsync(watcherRes.ResponsibleNode).WaitAsync(fromSeconds));
+                    await ActionWithLeader((l) => l.ServerStore.RemoveFromClusterAsync(watcherRes.ResponsibleNode).WaitAsync(fromSeconds));
                     Assert.True(await responsibleServer.ServerStore.WaitForState(RachisState.Passive, CancellationToken.None).WaitAsync(fromSeconds));
 
                     var dbInstance = await responsibleServer.ServerStore.DatabasesLandlord.TryGetOrCreateResourceStore("MainDB");


### PR DESCRIPTION
…rTests.RemoveNodeWithDb