### PR TITLE
[4.0] RavenDB-11255

### DIFF
--- a/src/Raven.Server/Documents/Indexes/Index.cs
+++ b/src/Raven.Server/Documents/Indexes/Index.cs
@@ -165,6 +165,7 @@ namespace Raven.Server.Documents.Indexes
         private readonly ReaderWriterLockSlim _currentlyRunningQueriesLock = new ReaderWriterLockSlim();
         private readonly MultipleUseFlag _priorityChanged = new MultipleUseFlag();
         private readonly MultipleUseFlag _hadRealIndexingWorkToDo = new MultipleUseFlag();
+        private readonly MultipleUseFlag _definitionChanged = new MultipleUseFlag();
         private Func<bool> _indexValidationStalenessCheck = () => true;
 
         private readonly ConcurrentDictionary<string, SpatialField> _spatialFields = new ConcurrentDictionary<string, SpatialField>(StringComparer.OrdinalIgnoreCase);
@@ -897,14 +898,15 @@ namespace Raven.Server.Documents.Indexes
                             _mre.Reset();
                         }
                         
-                        // this is called on every iteration because index priorities can be changed at runtime
-                        ChangeIndexThreadPriorityIfNeeded();
+                        if (_priorityChanged)
+                            ChangeIndexThreadPriority();
+
+                        if (_definitionChanged)
+                            PersistIndexDefinition();
 
                         if (_logger.IsInfoEnabled)
                             _logger.Info($"Starting indexing for '{Name}'.");
-
                         
-
                         var stats = _lastStats = new IndexingStatsAggregator(DocumentDatabase.IndexStore.Identities.GetNextIndexingStatsId(), _lastStats);
                         LastIndexingTime = stats.StartTime;
 
@@ -1118,11 +1120,8 @@ namespace Raven.Server.Documents.Indexes
             return false;
         }
 
-        private void ChangeIndexThreadPriorityIfNeeded()
+        private void ChangeIndexThreadPriority()
         {
-            if (_priorityChanged == false)
-                return;
-
             _priorityChanged.Lower();
 
             ThreadPriority newPriority;
@@ -1147,6 +1146,21 @@ namespace Raven.Server.Documents.Indexes
                 return;
 
             Thread.CurrentThread.Priority = newPriority;
+        }
+
+        private void PersistIndexDefinition()
+        {
+            try
+            {
+                _indexStorage.WriteDefinition(Definition);
+
+                _definitionChanged.Lower();
+            }
+            catch (Exception e)
+            {
+                if (_logger.IsOperationsEnabled)
+                    _logger.Operations($"Failed to persist definition of '{Name}' index", e);
+            }
         }
 
         private void HandleLogsApplied()
@@ -1544,9 +1558,25 @@ namespace Raven.Server.Documents.Indexes
                 if (_logger.IsInfoEnabled)
                     _logger.Info($"Changing priority for '{Name}' from '{Definition.Priority}' to '{priority}'.");
 
-                _indexStorage.WritePriority(priority);
-
+                var oldPriority = Definition.Priority;
+                
                 Definition.Priority = priority;
+
+                try
+                {
+                    _indexStorage.WriteDefinition(Definition, timeout: TimeSpan.FromSeconds(5));
+                }
+                catch (TimeoutException)
+                {
+                    _definitionChanged.Raise();
+                    _mre.Set();
+                }
+                catch (Exception)
+                {
+                    Definition.Priority = oldPriority;
+                    throw;
+                }
+
                 _priorityChanged.Raise();
 
                 DocumentDatabase.Changes.RaiseNotifications(new IndexChange
@@ -1636,7 +1666,24 @@ namespace Raven.Server.Documents.Indexes
                     _logger.Info(
                         $"Changing lock mode for '{Name}' from '{Definition.LockMode}' to '{mode}'.");
 
-                _indexStorage.WriteLock(mode);
+                var oldLockMode = Definition.LockMode;
+                
+                Definition.LockMode = mode;
+
+                try
+                {
+                    _indexStorage.WriteDefinition(Definition, timeout: TimeSpan.FromSeconds(5));
+                }
+                catch (TimeoutException)
+                {
+                    _definitionChanged.Raise();
+                    _mre.Set();
+                }
+                catch (Exception)
+                {
+                    Definition.LockMode = oldLockMode;
+                    throw;
+                }
 
                 DocumentDatabase.Changes.RaiseNotifications(new IndexChange
                 {

--- a/src/Raven.Server/Documents/Indexes/IndexStore.cs
+++ b/src/Raven.Server/Documents/Indexes/IndexStore.cs
@@ -934,6 +934,30 @@ namespace Raven.Server.Documents.Indexes
             try
             {
                 index = Index.Open(indexPath, _documentDatabase);
+
+                var differences = IndexDefinitionCompareDifferences.None;
+
+                if (staticIndexDefinition != null)
+                {
+                    if (staticIndexDefinition.LockMode != null && index.Definition.LockMode != staticIndexDefinition.LockMode)
+                        differences |= IndexDefinitionCompareDifferences.LockMode;
+
+                    if (staticIndexDefinition.Priority != null && index.Definition.Priority != staticIndexDefinition.Priority)
+                        differences |= IndexDefinitionCompareDifferences.Priority;
+                }
+                else if (autoIndexDefinition != null)
+                {
+                    if (autoIndexDefinition.Priority != index.Definition.Priority)
+                        differences |= IndexDefinitionCompareDifferences.Priority;
+                }
+
+                if (differences != IndexDefinitionCompareDifferences.None)
+                {
+                    // database record has different lock mode / priority setting than persisted locally
+
+                    UpdateStaticIndexLockModeAndPriority(staticIndexDefinition, index, differences);
+                }
+
                 index.Start();
                 if (_logger.IsInfoEnabled)
                     _logger.Info($"Started {index.Name} from {indexPath}");

--- a/src/Raven.Server/Documents/Indexes/Workers/MapDocuments.cs
+++ b/src/Raven.Server/Documents/Indexes/Workers/MapDocuments.cs
@@ -96,7 +96,7 @@ namespace Raven.Server.Documents.Indexes.Workers
                                     collectionStats.RecordMapAttempt();
                                     stats.RecordDocumentSize(current.Data.Size);
                                     if (_logger.IsInfoEnabled && count % 8192 == 0)
-                                        _logger.Info($"Executing map for '{_index.Name}'. Proccessed count: {count:#,#;;0} etag: {lastEtag}.");
+                                        _logger.Info($"Executing map for '{_index.Name}'. Processed count: {count:#,#;;0} etag: {lastEtag}.");
 
                                     lastEtag = current.Etag;
                                     inMemoryStats.UpdateLastEtag(lastEtag, isTombsone: false);

--- a/src/Raven.Server/ServerWide/Context/DocumentsOperationContext.cs
+++ b/src/Raven.Server/ServerWide/Context/DocumentsOperationContext.cs
@@ -42,9 +42,9 @@ namespace Raven.Server.ServerWide.Context
             return new DocumentsTransaction(this, _documentDatabase.DocumentsStorage.Environment.ReadTransaction(PersistentContext, Allocator), _documentDatabase.Changes);
         }
 
-        protected override DocumentsTransaction CreateWriteTransaction()
+        protected override DocumentsTransaction CreateWriteTransaction(TimeSpan? timeout = null)
         {
-            var tx = new DocumentsTransaction(this, _documentDatabase.DocumentsStorage.Environment.WriteTransaction(PersistentContext, Allocator), _documentDatabase.Changes);
+            var tx = new DocumentsTransaction(this, _documentDatabase.DocumentsStorage.Environment.WriteTransaction(PersistentContext, Allocator, timeout), _documentDatabase.Changes);
 
             CurrentTxMarker = (short) tx.InnerTransaction.LowLevelTransaction.Id;
 

--- a/src/Raven.Server/ServerWide/Context/TransactionOperationContext.cs
+++ b/src/Raven.Server/ServerWide/Context/TransactionOperationContext.cs
@@ -21,9 +21,9 @@ namespace Raven.Server.ServerWide.Context
             return new RavenTransaction(_environment.ReadTransaction(PersistentContext, Allocator));
         }
 
-        protected override RavenTransaction CreateWriteTransaction()
+        protected override RavenTransaction CreateWriteTransaction(TimeSpan? timeout = null)
         {
-            return new RavenTransaction(_environment.WriteTransaction(PersistentContext, Allocator));
+            return new RavenTransaction(_environment.WriteTransaction(PersistentContext, Allocator, timeout));
         }
 
         public StorageEnvironment Environment => _environment;
@@ -81,16 +81,16 @@ namespace Raven.Server.ServerWide.Context
 
         protected abstract TTransaction CreateReadTransaction();
 
-        protected abstract TTransaction CreateWriteTransaction();
+        protected abstract TTransaction CreateWriteTransaction(TimeSpan? timeout = null);
 
-        public TTransaction OpenWriteTransaction()
+        public TTransaction OpenWriteTransaction(TimeSpan? timeout = null)
         {
             if (Transaction != null && Transaction.Disposed == false)
             {
                 ThrowTransactionAlreadyOpened();
             }
 
-            Transaction = CreateWriteTransaction();
+            Transaction = CreateWriteTransaction(timeout);
 
             return Transaction;
         }

--- a/src/Voron/StorageEnvironment.cs
+++ b/src/Voron/StorageEnvironment.cs
@@ -565,9 +565,9 @@ namespace Voron
             return new Transaction(newLowLevelTransaction);
         }
 
-        public Transaction WriteTransaction(TransactionPersistentContext transactionPersistentContext, ByteStringContext context = null)
+        public Transaction WriteTransaction(TransactionPersistentContext transactionPersistentContext, ByteStringContext context = null, TimeSpan? timeout = null)
         {
-            var writeTransaction = new Transaction(NewLowLevelTransaction(transactionPersistentContext, TransactionFlags.ReadWrite, context, null));
+            var writeTransaction = new Transaction(NewLowLevelTransaction(transactionPersistentContext, TransactionFlags.ReadWrite, context, timeout));
             return writeTransaction;
         }
 

--- a/test/SlowTests/Issues/RavenDB_11255.cs
+++ b/test/SlowTests/Issues/RavenDB_11255.cs
@@ -1,0 +1,60 @@
+﻿using System.Threading;
+using System.Threading.Tasks;
+using FastTests;
+using Raven.Client.Documents.Indexes;
+using Raven.Server.Documents.Indexes.Static;
+using Raven.Server.ServerWide.Context;
+using Xunit;
+
+namespace SlowTests.Issues
+{
+    public class RavenDB_11255 : RavenLowLevelTestBase
+    {
+        [Fact]
+        public void Can_update_lock_mode_and_priority_of_index_even_if_indexing_is_running()
+        {
+            using (var database = CreateDocumentDatabase())
+            {
+                using (var index = MapIndex.CreateNew(new IndexDefinition()
+                {
+                    Name = "Users_ByName",
+                    Maps =
+                    {
+                        "from user in docs.Users select new { user.Name }"
+                    },
+                    Type = IndexType.Map
+                }, database))
+                {
+                    using (index._indexStorage._contextPool.AllocateOperationContext(out TransactionOperationContext context))
+                    using (context.OpenWriteTransaction()) // open write tx to simulate running indexing batch
+                    {
+                        var task = Task.Factory.StartNew(() =>
+                        {
+                            index.SetLock(IndexLockMode.LockedIgnore);
+                            index.SetPriority(IndexPriority.High);
+                        }, TaskCreationOptions.LongRunning);
+
+                        task.Wait();
+                    }
+
+                    index.Start(); // will persist the introduced changes
+
+                    IndexDefinition persistedDef = null;
+
+                    for (int i = 0; i < 10; i++)
+                    {
+                        persistedDef = MapIndexDefinition.Load(index._indexStorage.Environment());
+
+                        if (persistedDef.Priority == IndexPriority.High)
+                            break;
+
+                        Thread.Sleep(1000);
+                    }
+
+                    Assert.Equal(IndexLockMode.LockedIgnore, persistedDef.LockMode);
+                    Assert.Equal(IndexPriority.High, persistedDef.Priority);
+                }
+            }
+        }
+    }
+}


### PR DESCRIPTION
- Changing lock mode or priority of an index can result in the timeout exception if we have a long running indexing batch. Then instead of failing the entire operation let's keep the in-memory state updated and persist the modified index definition on next indexing run.
- Decrease the timeout for write tx to 5 seconds
- If database record has different lock mode / priority setting than persisted locally then let's update it after opening an index