### PR TITLE
Feature/custom default order

### DIFF
--- a/src/Raven.Client/Documents/Conventions/DocumentConventions.cs
+++ b/src/Raven.Client/Documents/Conventions/DocumentConventions.cs
@@ -35,6 +35,7 @@ namespace Raven.Client.Documents.Conventions
         public delegate LinqPathProvider.Result CustomQueryTranslator(LinqPathProvider provider, Expression expression);
 
         public delegate bool TryConvertValueForQueryDelegate<in T>(string fieldName, T value, bool forRange, out string strValue);
+        public delegate bool TryConvertValueToObjectForQueryDelegate<in T>(string fieldName, T value, bool forRange, out object objValue);
 
         internal static readonly DocumentConventions Default = new DocumentConventions();
 
@@ -44,6 +45,11 @@ namespace Raven.Client.Documents.Conventions
 
         private readonly List<(Type Type, TryConvertValueForQueryDelegate<object> Convert)> _listOfQueryValueConverters =
             new List<(Type, TryConvertValueForQueryDelegate<object>)>();
+
+        private readonly List<(Type Type, TryConvertValueToObjectForQueryDelegate<object> Convert)> _listOfQueryValueToObjectConverters =
+            new List<(Type, TryConvertValueToObjectForQueryDelegate<object>)>();
+
+        private readonly Dictionary<Type, RangeType> _customRangeTypes = new Dictionary<Type, RangeType>();
 
         private readonly List<Tuple<Type, Func<string, object, Task<string>>>> _listOfRegisteredIdConventionsAsync =
             new List<Tuple<Type, Func<string, object, Task<string>>>>();
@@ -839,6 +845,51 @@ namespace Raven.Client.Documents.Conventions
             }
 
             strValue = null;
+            return false;
+        }
+
+        private void RegisterQueryValueConverter<T>(TryConvertValueToObjectForQueryDelegate<T> converter)
+        {
+            AssertNotFrozen();
+
+            int index;
+            for (index = 0; index < _listOfQueryValueToObjectConverters.Count; index++)
+            {
+                var entry = _listOfQueryValueToObjectConverters[index];
+                if (entry.Type.IsAssignableFrom(typeof(T)))
+                    break;
+            }
+
+            _listOfQueryValueToObjectConverters.Insert(index, (typeof(T), Actual));
+
+            bool Actual(string name, object value, bool forRange, out object objValue)
+            {
+                if (value is T)
+                    return converter(name, (T)value, forRange, out objValue);
+                objValue = null;
+                return false;
+            }
+        }
+
+        public void RegisterQueryValueConverter<T>(TryConvertValueToObjectForQueryDelegate<T> converter, RangeType rangeType)
+        {
+            RegisterQueryValueConverter(converter);
+
+            if (_customRangeTypes.ContainsKey(typeof(T)) == false)
+                _customRangeTypes.Add(typeof(T), rangeType);
+        }
+
+        internal bool TryConvertValueToObjectForQuery(string fieldName, object value, bool forRange, out object objValue)
+        {
+            foreach (var queryValueConverter in _listOfQueryValueToObjectConverters)
+            {
+                if (queryValueConverter.Type.IsInstanceOfType(value) == false)
+                    continue;
+
+                return queryValueConverter.Convert(fieldName, value, forRange, out objValue);
+            }
+
+            objValue = null;
             return false;
         }
 

--- a/src/Raven.Client/Documents/Conventions/DocumentConventions.cs
+++ b/src/Raven.Client/Documents/Conventions/DocumentConventions.cs
@@ -827,8 +827,8 @@ namespace Raven.Client.Documents.Conventions
 
             bool Actual(string name, object value, bool forRange, out string strValue)
             {
-                if (value is T)
-                    return converter(name, (T)value, forRange, out strValue);
+                if (value is T t)
+                    return converter(name, t, forRange, out strValue);
                 strValue = null;
                 return false;
             }
@@ -864,8 +864,8 @@ namespace Raven.Client.Documents.Conventions
 
             bool Actual(string name, object value, bool forRange, out object objValue)
             {
-                if (value is T)
-                    return converter(name, (T)value, forRange, out objValue);
+                if (value is T t)
+                    return converter(name, t, forRange, out objValue);
                 objValue = null;
                 return false;
             }

--- a/src/Raven.Client/Documents/Conventions/DocumentConventions.cs
+++ b/src/Raven.Client/Documents/Conventions/DocumentConventions.cs
@@ -702,7 +702,7 @@ namespace Raven.Client.Documents.Conventions
             return (DocumentConventions)MemberwiseClone();
         }
 
-        public static RangeType GetRangeType(Type type)
+        public RangeType GetRangeType(Type type)
         {
             var nonNullable = Nullable.GetUnderlyingType(type);
             if (nonNullable != null)
@@ -713,6 +713,11 @@ namespace Raven.Client.Documents.Conventions
 
             if (type == typeof(double) || type == typeof(float) || type == typeof(decimal))
                 return RangeType.Double;
+
+            if (_customRangeTypes.TryGetValue(type, out var rangeType))
+            {
+                return rangeType;
+            }
 
             return RangeType.None;
         }

--- a/src/Raven.Client/Documents/Indexes/FieldUtil.cs
+++ b/src/Raven.Client/Documents/Indexes/FieldUtil.cs
@@ -30,12 +30,6 @@ namespace Raven.Client.Documents.Indexes
             return RangeType.None;
         }
 
-        public static string ApplyRangeSuffixIfNecessary(string fieldName, Type type)
-        {
-            var rangeType = DocumentConventions.GetRangeType(type);
-            return ApplyRangeSuffixIfNecessary(fieldName, rangeType);
-        }
-
         public static string ApplyRangeSuffixIfNecessary(string fieldName, RangeType rangeType)
         {
             if (rangeType == RangeType.None)

--- a/src/Raven.Client/Documents/Linq/RavenQueryProviderProcessor.cs
+++ b/src/Raven.Client/Documents/Linq/RavenQueryProviderProcessor.cs
@@ -1815,7 +1815,9 @@ The recommended method is to use full text search (mark the field as Analyzed an
                 fieldType = typeof(string);
             }
 
-            var ordering = OrderingUtil.GetOrderingOfType(fieldType);
+            var rangeType = QueryGenerator.Conventions.GetRangeType(fieldType);
+
+            var ordering = OrderingUtil.GetOrderingFromRangeType(rangeType);
             if (descending)
                 _documentQuery.OrderByDescending(fieldName, ordering);
             else

--- a/src/Raven.Client/Documents/Session/AbstractDocumentQuery.cs
+++ b/src/Raven.Client/Documents/Session/AbstractDocumentQuery.cs
@@ -1546,6 +1546,9 @@ Use session.Query<T>() instead of session.Advanced.DocumentQuery<T>. The session
             if (_conventions.TryConvertValueForQuery(whereParams.FieldName, whereParams.Value, forRange, out var strVal))
                 return strVal;
 
+            if (_conventions.TryConvertValueToObjectForQuery(whereParams.FieldName, whereParams.Value, forRange, out var objValue))
+                return objValue;
+
             if (type == typeof(DateTime) || type == typeof(DateTimeOffset))
                 return whereParams.Value;
             if (type == typeof(string))

--- a/src/Raven.Client/Documents/Session/AsyncDocumentQuery.cs
+++ b/src/Raven.Client/Documents/Session/AsyncDocumentQuery.cs
@@ -391,7 +391,8 @@ namespace Raven.Client.Documents.Session
         /// <inheritdoc />
         IAsyncDocumentQuery<T> IDocumentQueryBase<T, IAsyncDocumentQuery<T>>.OrderBy<TValue>(Expression<Func<T, TValue>> propertySelector)
         {
-            OrderBy(GetMemberQueryPathForOrderBy(propertySelector), OrderingUtil.GetOrderingOfType(propertySelector.ReturnType));
+            var rangeType = Conventions.GetRangeType(propertySelector.ReturnType);
+            OrderBy(GetMemberQueryPathForOrderBy(propertySelector), OrderingUtil.GetOrderingFromRangeType(rangeType));
             return this;
         }
 
@@ -407,7 +408,8 @@ namespace Raven.Client.Documents.Session
         {
             foreach (var item in propertySelectors)
             {
-                OrderBy(GetMemberQueryPathForOrderBy(item), OrderingUtil.GetOrderingOfType(item.ReturnType));
+                var rangeType = Conventions.GetRangeType(item.ReturnType);
+                OrderBy(GetMemberQueryPathForOrderBy(item), OrderingUtil.GetOrderingFromRangeType(rangeType));
             }
 
             return this;
@@ -423,7 +425,8 @@ namespace Raven.Client.Documents.Session
         /// <inheritdoc />
         IAsyncDocumentQuery<T> IDocumentQueryBase<T, IAsyncDocumentQuery<T>>.OrderByDescending<TValue>(Expression<Func<T, TValue>> propertySelector)
         {
-            OrderByDescending(GetMemberQueryPathForOrderBy(propertySelector), OrderingUtil.GetOrderingOfType(propertySelector.ReturnType));
+            var rangeType = Conventions.GetRangeType(propertySelector.ReturnType);
+            OrderByDescending(GetMemberQueryPathForOrderBy(propertySelector), OrderingUtil.GetOrderingFromRangeType(rangeType));
             return this;
         }
 
@@ -439,7 +442,8 @@ namespace Raven.Client.Documents.Session
         {
             foreach (var item in propertySelectors)
             {
-                OrderByDescending(GetMemberQueryPathForOrderBy(item), OrderingUtil.GetOrderingOfType(item.ReturnType));
+                var rangeType = Conventions.GetRangeType(item.ReturnType);
+                OrderByDescending(GetMemberQueryPathForOrderBy(item), OrderingUtil.GetOrderingFromRangeType(rangeType));
             }
 
             return this;

--- a/src/Raven.Client/Documents/Session/DocumentQuery.cs
+++ b/src/Raven.Client/Documents/Session/DocumentQuery.cs
@@ -654,7 +654,8 @@ namespace Raven.Client.Documents.Session
         /// <inheritdoc />
         IDocumentQuery<T> IDocumentQueryBase<T, IDocumentQuery<T>>.OrderBy<TValue>(Expression<Func<T, TValue>> propertySelector)
         {
-            OrderBy(GetMemberQueryPathForOrderBy(propertySelector), OrderingUtil.GetOrderingOfType(propertySelector.ReturnType));
+            var rangeType = Conventions.GetRangeType(propertySelector.ReturnType);
+            OrderBy(GetMemberQueryPathForOrderBy(propertySelector), OrderingUtil.GetOrderingFromRangeType(rangeType));
             return this;
         }
 
@@ -670,7 +671,8 @@ namespace Raven.Client.Documents.Session
         {
             foreach (var item in propertySelectors)
             {
-                OrderBy(GetMemberQueryPathForOrderBy(item), OrderingUtil.GetOrderingOfType(item.ReturnType));
+                var rangeType = Conventions.GetRangeType(item.ReturnType);
+                OrderBy(GetMemberQueryPathForOrderBy(item), OrderingUtil.GetOrderingFromRangeType(rangeType));
             }
             return this;
         }
@@ -685,7 +687,8 @@ namespace Raven.Client.Documents.Session
         /// <inheritdoc />
         IDocumentQuery<T> IDocumentQueryBase<T, IDocumentQuery<T>>.OrderByDescending<TValue>(Expression<Func<T, TValue>> propertySelector)
         {
-            OrderByDescending(GetMemberQueryPathForOrderBy(propertySelector), OrderingUtil.GetOrderingOfType(propertySelector.ReturnType));
+            var rangeType = Conventions.GetRangeType(propertySelector.ReturnType);
+            OrderByDescending(GetMemberQueryPathForOrderBy(propertySelector), OrderingUtil.GetOrderingFromRangeType(rangeType));
             return this;
         }
 
@@ -701,7 +704,8 @@ namespace Raven.Client.Documents.Session
         {
             foreach (var item in propertySelectors)
             {
-                OrderByDescending(GetMemberQueryPathForOrderBy(item), OrderingUtil.GetOrderingOfType(item.ReturnType));
+                var rangeType = Conventions.GetRangeType(item.ReturnType);
+                OrderByDescending(GetMemberQueryPathForOrderBy(item), OrderingUtil.GetOrderingFromRangeType(rangeType));
             }
 
             return this;

--- a/src/Raven.Client/Documents/Session/Ordering.cs
+++ b/src/Raven.Client/Documents/Session/Ordering.cs
@@ -1,6 +1,4 @@
-﻿using System;
-using Raven.Client.Documents.Conventions;
-using Raven.Client.Documents.Indexes;
+﻿using Raven.Client.Documents.Indexes;
 
 namespace Raven.Client.Documents.Session
 {
@@ -14,10 +12,8 @@ namespace Raven.Client.Documents.Session
 
     internal static class OrderingUtil
     {
-        public static OrderingType GetOrderingOfType(Type fieldType)
+        public static OrderingType GetOrderingFromRangeType(RangeType rangeType)
         {
-            var rangeType = DocumentConventions.GetRangeType(fieldType);
-
             var ordering = OrderingType.String;
 
             switch (rangeType)

--- a/test/SlowTests/Issues/RavenDB_1251_1.cs
+++ b/test/SlowTests/Issues/RavenDB_1251_1.cs
@@ -47,6 +47,54 @@ namespace SlowTests.Issues
 
                 using (var session = documentStore.OpenSession())
                 {
+                    var q = session.Query<Foo>()
+                        .Customize(x => x.WaitForNonStaleResults())
+                        .OrderByDescending(x => x.Bar);
+                    Debug.WriteLine(q);
+                    var result = q.ToList();
+
+                    Assert.Equal(5, result.Count);
+                    Assert.True(result[0].Bar > result[1].Bar);
+                    Assert.True(result[1].Bar > result[2].Bar);
+                    Assert.True(result[2].Bar > result[3].Bar);
+                    Assert.True(result[3].Bar > result[4].Bar);
+                }
+            }
+        }
+
+        [Fact]
+        public void TimeSpan_Can_Filter_By_Value()
+        {
+            using (var documentStore = GetDocumentStore())
+            {
+                using (var session = documentStore.OpenSession())
+                {
+                    session.Store(new Foo
+                    {
+                        Bar = TimeSpan.FromHours(-2)
+                    });
+                    session.Store(new Foo
+                    {
+                        Bar = TimeSpan.FromHours(-1)
+                    });
+                    session.Store(new Foo
+                    {
+                        Bar = TimeSpan.FromHours(0)
+                    });
+                    session.Store(new Foo
+                    {
+                        Bar = TimeSpan.FromHours(1)
+                    });
+                    session.Store(new Foo
+                    {
+                        Bar = TimeSpan.FromHours(2)
+                    });
+
+                    session.SaveChanges();
+                }
+
+                using (var session = documentStore.OpenSession())
+                {
                     var t = TimeSpan.FromHours(-1.5);
 
                     var q = session.Query<Foo>()
@@ -60,6 +108,7 @@ namespace SlowTests.Issues
                     Assert.True(result[0].Bar > result[1].Bar);
                     Assert.True(result[1].Bar > result[2].Bar);
                     Assert.True(result[2].Bar > result[3].Bar);
+                    Assert.Equal(TimeSpan.FromHours(-1), result[3].Bar);
                 }
             }
         }


### PR DESCRIPTION
As discussed at https://groups.google.com/forum/#!topic/ravendb/Pq_U9Ch-d3E
I have implemented a way to be able to have the same order and filter semantics a timespan has 
but now for a custom type.

I needed to have a QueryConverter that could convert to string but also to long type.
So I ended up with a converter to object, we probably need a better API here ...

// Ryan