### PR TITLE
[4.0] RavenDB-11015 Verify cluster behavior on node removal

### DIFF
--- a/src/Raven.Server/ServerWide/ClusterStateMachine.cs
+++ b/src/Raven.Server/ServerWide/ClusterStateMachine.cs
@@ -412,8 +412,9 @@ namespace Raven.Server.ServerWide
                 {
                     if (record.DeletionInProgress != null)
                     {
-                        record.DeletionInProgress.Remove(removed);
-                        if (record.DeletionInProgress.Count == 0 && record.Topology.Count == 0)
+                        // delete immediately if this node was removed.
+                        var deleteNow = record.DeletionInProgress.Remove(removed) && _parent.Tag == removed;
+                        if (record.DeletionInProgress.Count == 0 && record.Topology.Count == 0 || deleteNow) 
                         {
                             DeleteDatabaseRecord(context, index, items, lowerKey, record.DatabaseName);
                             NotifyDatabaseChanged(context, record.DatabaseName, index, nameof(RemoveNodeFromCluster));
@@ -421,11 +422,22 @@ namespace Raven.Server.ServerWide
                         }
                     }
 
+                    if (_parent.Tag == removed)
+                    {
+                        //If no deletion was issued, then the removed node will keep all his data until either he will be bootstrapped or rejoined with the cluster.
+                        continue;
+                    }
+
                     if (record.Topology.RelevantFor(removed))
                     {
                         record.Topology.RemoveFromTopology(removed);
-                        // Explict removing of the node means that we modify the replication factor
+                        // Explicit removing of the node means that we modify the replication factor
                         record.Topology.ReplicationFactor = record.Topology.Count;
+                        if (record.Topology.Count == 0)
+                        {
+                            DeleteDatabaseRecord(context, index, items, lowerKey, record.DatabaseName);
+                            continue;
+                        }
                     }
                     var updated = EntityToBlittable.ConvertCommandToBlittable(record, context);
 
@@ -935,6 +947,65 @@ namespace Raven.Server.ServerWide
             CompareExchangeSchema.Create(context.Transaction.InnerTransaction, CompareExchange, 32);
             context.Transaction.InnerTransaction.CreateTree(LocalNodeStateTreeName);
             context.Transaction.InnerTransaction.CreateTree(Identities);
+            parent.StateChanged += OnStateChange;
+        }
+
+        private void OnStateChange(object sender, RachisConsensus.StateTransition transition)
+        {
+            if (transition.From == RachisState.Passive && transition.To == RachisState.LeaderElect)
+            {
+                // moving from 'passive'->'leader elect', means that we were bootstrapped!  
+                using (_parent.ContextPool.AllocateOperationContext(out TransactionOperationContext context))
+                {
+                    var toDelete = new List<string>();
+                    var toShrink = new List<DatabaseRecord>();
+                    using (context.OpenReadTransaction())
+                    {
+                        foreach (var record in ReadAllDatabases(context))
+                        {
+                            if (record.Topology.RelevantFor(_parent.Tag) == false)
+                            {
+                                toDelete.Add(record.DatabaseName);
+                            }
+                            else
+                            {
+                                record.Topology = new DatabaseTopology();
+                                record.Topology.Members.Add(_parent.Tag);
+                                toShrink.Add(record);
+                            }
+                        }
+                    }
+
+                    if (toShrink.Count == 0 && toDelete.Count == 0)
+                        return;
+
+                    using (context.OpenWriteTransaction())
+                    {
+                        var items = context.Transaction.InnerTransaction.OpenTable(ItemsSchema, Items);
+                        var index = _parent.GetLastCommitIndex(context);
+
+                        foreach (var databaseName in toDelete)
+                        {
+                            var dbKey = "db/" + databaseName;
+                            using (Slice.From(context.Allocator, dbKey.ToLowerInvariant(), out Slice valueNameLowered))
+                            {
+                                DeleteDatabaseRecord(context, index, items, valueNameLowered, databaseName);
+                            }
+                        }
+                        foreach (var record in toShrink)
+                        {
+                            var dbKey = "db/" + record.DatabaseName;
+                            using (Slice.From(context.Allocator, dbKey, out Slice valueName))
+                            using (Slice.From(context.Allocator, dbKey.ToLowerInvariant(), out Slice valueNameLowered))
+                            {
+                                var updatedDatabaseBlittable = EntityToBlittable.ConvertCommandToBlittable(record, context);
+                                UpdateValue(index, items, valueNameLowered, valueName, updatedDatabaseBlittable);
+                            }
+                        }
+                        context.Transaction.Commit();
+                    }
+                }
+            }
         }
 
         public unsafe void PutLocalState(TransactionOperationContext context, string key, BlittableJsonReaderObject value)

--- a/src/Raven.Server/Web/System/DatabasesHandler.cs
+++ b/src/Raven.Server/Web/System/DatabasesHandler.cs
@@ -137,7 +137,7 @@ namespace Raven.Server.Web.System
                                 })
                                 )
                             ),
-                            [nameof(Topology.Etag)] = dbRecord.Topology.Stamp.Index
+                            [nameof(Topology.Etag)] = dbRecord.Topology.Stamp?.Index ?? -1
                         });
                     }
                 }

--- a/test/RachisTests/DatabaseCluster/RemoveNodeFromCluster.cs
+++ b/test/RachisTests/DatabaseCluster/RemoveNodeFromCluster.cs
@@ -3,6 +3,7 @@ using System.Linq;
 using System.Threading;
 using System.Threading.Tasks;
 using Raven.Client.Documents;
+using Raven.Client.Documents.Conventions;
 using Raven.Client.ServerWide;
 using Raven.Client.ServerWide.Operations;
 using Raven.Server;
@@ -169,11 +170,16 @@ namespace RachisTests.DatabaseCluster
             {
                 Urls = new[] { firstLeader.WebUrl },
                 Database = dbName,
+                Conventions = new DocumentConventions
+                {
+                    DisableTopologyUpdates = true
+                }
             }.Initialize())
             {
 
                 using (var session = store.OpenAsyncSession())
                 {
+                    session.Advanced.WaitForReplicationAfterSaveChanges(TimeSpan.FromSeconds(30), replicas: replicationFactor - 1);
                     await session.StoreAsync(new User { Name = "Karmel" }, "foo/bar");
                     await session.SaveChangesAsync();
                 }

--- a/test/RachisTests/DatabaseCluster/RemoveNodeFromCluster.cs
+++ b/test/RachisTests/DatabaseCluster/RemoveNodeFromCluster.cs
@@ -1,0 +1,197 @@
+﻿using System;
+using System.Linq;
+using System.Threading;
+using System.Threading.Tasks;
+using Raven.Client.Documents;
+using Raven.Client.ServerWide;
+using Raven.Client.ServerWide.Operations;
+using Raven.Server;
+using Raven.Server.Rachis;
+using Raven.Tests.Core.Utils.Entities;
+using Tests.Infrastructure;
+using Xunit;
+
+namespace RachisTests.DatabaseCluster
+{
+    public class RemoveNodeFromCluster : ClusterTestBase
+    {
+        [Fact]
+        public async Task RemovedNodeChangeReplicationFactor()
+        {
+            var dbName = GetDatabaseName();
+            await RemoveNodeWithDatabase(dbName, 5, 5);
+        }
+
+        [Fact]
+        public async Task ReconnectRemovedNodeWithDatabases()
+        {
+            var dbName = GetDatabaseName();
+            var removed = await RemoveNodeWithDatabase(dbName, 5, 5);
+
+            RavenServer leaderNode;
+            using (var store = new DocumentStore
+            {
+                Urls = new[] { removed.WebUrl },
+                Database = dbName,
+            }.Initialize())
+            {
+                var record = await store.Maintenance.Server.SendAsync(new GetDatabaseRecordOperation(dbName));
+                Assert.Equal(5, record.Topology.Count);
+                Assert.Equal(5, record.Topology.ReplicationFactor);
+
+                //reconnect the removed node to the original cluster
+                leaderNode = await ActionWithLeader(leader => leader.ServerStore.AddNodeToClusterAsync(removed.WebUrl, removed.ServerStore.NodeTag));
+                Assert.True(await removed.ServerStore.WaitForState(RachisState.Follower, CancellationToken.None).WaitAsync(TimeSpan.FromSeconds(30)),
+                    "Removed node wasn't reconnected with the cluster.");
+                await removed.ServerStore.WaitForCommitIndexChange(RachisConsensus.CommitIndexModification.GreaterOrEqual, leaderNode.ServerStore.LastRaftCommitIndex);
+                record = await store.Maintenance.Server.SendAsync(new GetDatabaseRecordOperation(dbName));
+                
+                Assert.Equal(4, record.Topology.Count);
+                Assert.Equal(4, record.Topology.ReplicationFactor);
+            }
+
+            using (var store = new DocumentStore
+            {
+                Urls = new[] { leaderNode.WebUrl },
+                Database = dbName,
+            }.Initialize())
+            {
+                var record = await store.Maintenance.Server.SendAsync(new GetDatabaseRecordOperation(dbName));
+                Assert.Equal(4, record.Topology.Count);
+                Assert.Equal(4, record.Topology.ReplicationFactor);
+            }
+        }
+
+        [Fact]
+        public async Task BootstrapRemovedNode()
+        {
+            var dbName = GetDatabaseName();
+            var removed = await RemoveNodeWithDatabase(dbName, 5, 5);
+
+            using (var store = new DocumentStore
+            {
+                Urls = new[] { removed.WebUrl },
+                Database = dbName,
+            }.Initialize())
+            {
+                var record = await store.Maintenance.Server.SendAsync(new GetDatabaseRecordOperation(dbName));
+                Assert.Equal(5, record.Topology.Count);
+                Assert.Equal(5, record.Topology.ReplicationFactor);
+
+                //bootstrap the removed node to a single-node cluster
+                removed.ServerStore.EnsureNotPassive();
+                record = await store.Maintenance.Server.SendAsync(new GetDatabaseRecordOperation(dbName));
+                Assert.Equal(1, record.Topology.Count);
+                Assert.Equal(1, record.Topology.ReplicationFactor);
+
+                Assert.True(WaitForDocument(store, "foo/bar"));
+            }
+        }
+
+        [Fact]
+        public async Task ReconnectRemovedNodeWithOneDatabase()
+        {
+            // BAD IDEA - we lose the database!
+            var dbName = GetDatabaseName();
+            var removed = await RemoveNodeWithDatabase(dbName, 5, 1);
+
+            using (var store = new DocumentStore
+            {
+                Urls = new[] { removed.WebUrl },
+                Database = dbName,
+            }.Initialize())
+            {
+                var record = await store.Maintenance.Server.SendAsync(new GetDatabaseRecordOperation(dbName));
+                Assert.Equal(1, record.Topology.Count);
+                Assert.Equal(1, record.Topology.ReplicationFactor);
+
+                //reconnect the removed node to the original cluster
+                var leaderNode = await ActionWithLeader(leader => leader.ServerStore.AddNodeToClusterAsync(removed.WebUrl, removed.ServerStore.NodeTag));
+                Assert.True(await removed.ServerStore.WaitForState(RachisState.Follower, CancellationToken.None).WaitAsync(TimeSpan.FromSeconds(30)),
+                    "Removed node wasn't reconnected with the cluster.");
+                await removed.ServerStore.WaitForCommitIndexChange(RachisConsensus.CommitIndexModification.GreaterOrEqual, leaderNode.ServerStore.LastRaftCommitIndex);
+                record = await store.Maintenance.Server.SendAsync(new GetDatabaseRecordOperation(dbName));
+                Assert.Null(record);
+            }
+        }
+
+        [Fact]
+        public async Task BootstrapRemovedNodeWithOneDatabase()
+        {
+            var dbName = GetDatabaseName();
+            var removed = await RemoveNodeWithDatabase(dbName, 5, 1);
+
+            using (var store = new DocumentStore
+            {
+                Urls = new[] { removed.WebUrl },
+                Database = dbName,
+            }.Initialize())
+            {
+                var record = await store.Maintenance.Server.SendAsync(new GetDatabaseRecordOperation(dbName));
+                Assert.Equal(1, record.Topology.Count);
+                Assert.Equal(1, record.Topology.ReplicationFactor);
+
+                //bootstrap the removed node to a single-node cluster
+                removed.ServerStore.EnsureNotPassive();
+                record = await store.Maintenance.Server.SendAsync(new GetDatabaseRecordOperation(dbName));
+                Assert.Equal(1, record.Topology.Count);
+                Assert.Equal(1, record.Topology.ReplicationFactor);
+
+                Assert.True(WaitForDocument(store, "foo/bar"));
+            }
+        }
+
+        [InlineData(3)]
+        [InlineData(5)]
+        [Theory]
+        public async Task RemovedLeaderCauseReelection(int numberOfNodes)
+        {
+            var leader = await CreateRaftClusterAndGetLeader(numberOfNodes);
+            CancellationTokenSource cts = new CancellationTokenSource();
+            try
+            {
+                var followerTasks = Servers.Where(s => s != leader).Select(s => s.ServerStore.WaitForState(RachisState.Leader, cts.Token));
+                await leader.ServerStore.RemoveFromClusterAsync(leader.ServerStore.NodeTag);
+                Assert.True(await Task.WhenAny(followerTasks).WaitAsync(TimeSpan.FromSeconds(30)));
+            }
+            finally
+            {
+                cts.Cancel();
+            }
+        }
+
+        private async Task<RavenServer> RemoveNodeWithDatabase(string dbName, int nodesAmount, int replicationFactor)
+        {
+            var firstLeader = await CreateRaftClusterAndGetLeader(nodesAmount, leaderIndex: 0);
+            var (_, servers) = await CreateDatabaseInCluster(dbName, replicationFactor, firstLeader.WebUrl);
+            var removed = servers.Last();
+            using (var store = new DocumentStore
+            {
+                Urls = new[] { firstLeader.WebUrl },
+                Database = dbName,
+            }.Initialize())
+            {
+
+                using (var session = store.OpenAsyncSession())
+                {
+                    await session.StoreAsync(new User { Name = "Karmel" }, "foo/bar");
+                    await session.SaveChangesAsync();
+                }
+
+                await firstLeader.ServerStore.RemoveFromClusterAsync(removed.ServerStore.NodeTag);
+                Assert.True(await removed.ServerStore.WaitForState(RachisState.Passive, CancellationToken.None).WaitAsync(TimeSpan.FromSeconds(30)),
+                    "Removed node wasn't move to passive state.");
+
+                var record = await store.Maintenance.Server.SendAsync(new GetDatabaseRecordOperation(dbName));
+                if (replicationFactor == 1 && removed.WebUrl != firstLeader.WebUrl)
+                {
+                    Assert.Null(record);
+                    return removed;
+                }
+                Assert.Equal(replicationFactor - 1, record.Topology.Count);
+                Assert.Equal(replicationFactor - 1, record.Topology.ReplicationFactor);
+            }
+            return removed;
+        }
+    }
+}

--- a/test/Tests.Infrastructure/RavenTestBase.cs
+++ b/test/Tests.Infrastructure/RavenTestBase.cs
@@ -59,7 +59,7 @@ namespace FastTests
             if (Servers.Count == 0)
                 return;
 
-            var tasks = Servers
+            var tasks = Servers.Where(s => s.ServerStore.Engine.CurrentState != RachisState.Passive)
                 .Select(server => server.ServerStore.Cluster.WaitForIndexNotification(index))
                 .ToList();
 


### PR DESCRIPTION
In the original issue it was stated that a rejoined node to the cluster should automatically rejoined to the relevant database groups (bullet 4).

This implementation will not automatically add the node to his former database groups, but leave this for the admin to handle.
