### PR TITLE
[4.0] RavenDB-11065 ObjectDisposedException: Cannot access a disposed object. Object name: 'RemoteConnection'.

### DIFF
--- a/src/Raven.Server/Rachis/Exceptions.cs
+++ b/src/Raven.Server/Rachis/Exceptions.cs
@@ -1,0 +1,59 @@
+﻿using System;
+
+namespace Raven.Server.Rachis
+{
+    public abstract class RachisException : Exception
+    {
+        protected RachisException()
+        {
+        }
+
+        protected RachisException(string message) : base(message)
+        {
+        }
+
+        protected RachisException(string message, Exception innerException) : base(message, innerException)
+        {
+        }
+    }
+
+    public class RachisInvalidOperationException : RachisException
+    {
+        public RachisInvalidOperationException()
+        {
+        }
+
+        public RachisInvalidOperationException(string message) : base(message)
+        {
+        }
+
+        public RachisInvalidOperationException(string message, Exception innerException) : base(message, innerException)
+        {
+        }
+
+        public static void Throw(string msg)
+        {
+            throw new RachisInvalidOperationException(msg);
+        }
+    }
+
+    public class RachisConcurrencyException : RachisException
+    {
+        public RachisConcurrencyException()
+        {
+        }
+
+        public RachisConcurrencyException(string message) : base(message)
+        {
+        }
+
+        public RachisConcurrencyException(string message, Exception innerException) : base(message, innerException)
+        {
+        }
+
+        public static void Throw(string msg)
+        {
+            throw new RachisConcurrencyException(msg);
+        }
+    }
+}

--- a/src/Sparrow/Utils/DisposeLock.cs
+++ b/src/Sparrow/Utils/DisposeLock.cs
@@ -76,12 +76,8 @@ namespace Sparrow.Utils
         }
     }
 
-    public class LockAlreadyDisposedException : Exception
+    public class LockAlreadyDisposedException : ObjectDisposedException
     {
-        public LockAlreadyDisposedException()
-        {
-        }
-
         public LockAlreadyDisposedException(string message) : base(message)
         {
         }


### PR DESCRIPTION
Some small fixes are also included:
RavenDB-11068 The connection with node A was suddenly broken.
RavenDB-10510 Failed to talk with A, message: Cannot access a disposed object. Object name: 'RemoteConnection'.

RavenDB-11319 Cluster observer logs do not indicate the node related
RavenDB-11023 KeyNotFoundException: current.Length == 0 but we try to access the 'A' node