### PR TITLE
[4.1] RavenDB-11065 ObjectDisposedException: Cannot access a disposed object. Object name: 'RemoteConnection'.

### DIFF
--- a/src/Raven.Server/Rachis/Exceptions.cs
+++ b/src/Raven.Server/Rachis/Exceptions.cs
@@ -1,0 +1,59 @@
+﻿using System;
+
+namespace Raven.Server.Rachis
+{
+    public abstract class RachisException : Exception
+    {
+        protected RachisException()
+        {
+        }
+
+        protected RachisException(string message) : base(message)
+        {
+        }
+
+        protected RachisException(string message, Exception innerException) : base(message, innerException)
+        {
+        }
+    }
+
+    public class RachisInvalidOperationException : RachisException
+    {
+        public RachisInvalidOperationException()
+        {
+        }
+
+        public RachisInvalidOperationException(string message) : base(message)
+        {
+        }
+
+        public RachisInvalidOperationException(string message, Exception innerException) : base(message, innerException)
+        {
+        }
+
+        public static void Throw(string msg)
+        {
+            throw new RachisInvalidOperationException(msg);
+        }
+    }
+
+    public class RachisConcurrencyException : RachisException
+    {
+        public RachisConcurrencyException()
+        {
+        }
+
+        public RachisConcurrencyException(string message) : base(message)
+        {
+        }
+
+        public RachisConcurrencyException(string message, Exception innerException) : base(message, innerException)
+        {
+        }
+
+        public static void Throw(string msg)
+        {
+            throw new RachisConcurrencyException(msg);
+        }
+    }
+}

--- a/src/Raven.Server/ServerWide/Maintenance/ClusterObserver.cs
+++ b/src/Raven.Server/ServerWide/Maintenance/ClusterObserver.cs
@@ -93,6 +93,12 @@ namespace Raven.Server.ServerWide.Maintenance
                     if (Suspended == false)
                     {
                         _iteration++;
+                        if (_iteration == 1)
+                        {
+                            prevStats = _maintenance.GetStats();
+                            continue;
+                        }
+
                         var newStats = _maintenance.GetStats();
                         await AnalyzeLatestStats(newStats, prevStats);
                         prevStats = newStats;
@@ -392,6 +398,23 @@ namespace Raven.Server.ServerWide.Maintenance
             }
         }
 
+        private void RaiseNodeNotFoundAlert(string alertMsg, string node)
+        {
+            var alert = AlertRaised.Create(
+                null,
+                $"Node {node} not found.",
+                $"{alertMsg}",
+                AlertType.DatabaseTopologyWarning,
+                NotificationSeverity.Warning
+            );
+
+            NotificationCenter.Add(alert);
+            if (_logger.IsOperationsEnabled)
+            {
+                _logger.Operations(alertMsg);
+            }
+        }
+
         private string UpdateDatabaseTopology(string dbName, DatabaseRecord record, ClusterTopology clusterTopology,
             Dictionary<string, ClusterNodeStatusReport> current,
             Dictionary<string, ClusterNodeStatusReport> previous,
@@ -405,8 +428,27 @@ namespace Raven.Server.ServerWide.Maintenance
             foreach (var member in topology.Members)
             {
                 var status = None;
-                if (current.TryGetValue(member, out var nodeStats) &&
-                    nodeStats.Status == ClusterNodeStatusReport.ReportStatus.Ok &&
+                if(current.TryGetValue(member, out var nodeStats) == false)
+                {
+                    // there isn't much we can do here, except for log it.
+                    if (previous.TryGetValue(member, out _))
+                    {
+                        // if we found this node in the previous report, we will ingore it this time and wait for the next report.
+                        continue;
+                    }
+
+                    var msg =
+                        $"The member node {member} was not found in both current and previuos reports of the cluster observer. " +
+                        $"If this error continue to raise, check the latancy between the cluster nodes.";
+                    if (_logger.IsInfoEnabled)
+                    {
+                        _logger.Info(msg);
+                        
+                    }
+                    RaiseNodeNotFoundAlert(msg, member);
+                    continue;
+                }
+                if (nodeStats.Status == ClusterNodeStatusReport.ReportStatus.Ok &&
                     nodeStats.Report.TryGetValue(dbName, out var dbStats))
                 {
                     status = dbStats.Status;
@@ -694,7 +736,7 @@ namespace Raven.Server.ServerWide.Maintenance
 
             if (_logger.IsOperationsEnabled)
             {
-                _logger.Operations(reason);
+                _logger.Operations($"Node {member} of database '{dbName}': {reason}");
             }
 
             return true;

--- a/src/Sparrow/Utils/DisposeLock.cs
+++ b/src/Sparrow/Utils/DisposeLock.cs
@@ -76,12 +76,8 @@ namespace Sparrow.Utils
         }
     }
 
-    public class LockAlreadyDisposedException : Exception
+    public class LockAlreadyDisposedException : ObjectDisposedException
     {
-        public LockAlreadyDisposedException()
-        {
-        }
-
         public LockAlreadyDisposedException(string message) : base(message)
         {
         }


### PR DESCRIPTION
Some small fixes are also included:
RavenDB-11068 The connection with node A was suddenly broken.
RavenDB-10510 Failed to talk with A, message: Cannot access a disposed object. Object name: 'RemoteConnection'.

RavenDB-11319 Cluster observer logs do not indicate the node related
RavenDB-11023 KeyNotFoundException: current.Length == 0 but we try to access the 'A' node