### PR TITLE
RavenDB-9540 properly set file version

### DIFF
--- a/scripts/updateSourceWithBuildInfo.ps1
+++ b/scripts/updateSourceWithBuildInfo.ps1
@@ -47,16 +47,13 @@ function UpdateCommonAssemblyInfo ( $projectDir, $buildNumber, $version, $commit
 
     $fileVersion = "$($version.Split("-")[0]).$buildNumber"
 
-    $inputText = [System.IO.File]::ReadAllText($assemblyInfoFile)
-
-    $commitPattern = [regex]'{commit}'
-    $result = $commitPattern.Replace($inputText, $commit)
+    $result = [System.IO.File]::ReadAllText($assemblyInfoFile)
 
     $assemblyFileVersionPattern = [regex]'\[assembly: AssemblyFileVersion\(".*"\)\]';
-    $result = $assemblyFileVersionPattern.Replace($inputText, "[assembly: AssemblyFileVersion(""$fileVersion"")]"); 
+    $result = $assemblyFileVersionPattern.Replace($result, "[assembly: AssemblyFileVersion(""$fileVersion"")]"); 
 
     $assemblyInfoVersionPattern = [regex]'\[assembly: AssemblyInformationalVersion\(".*"\)\]';
-    $result = $assemblyInfoVersionPattern.Replace($inputText, "[assembly: AssemblyInformationalVersion(""$version"")]")
+    $result = $assemblyInfoVersionPattern.Replace($result, "[assembly: AssemblyInformationalVersion(""$version"")]")
 
     [System.IO.File]::WriteAllText($assemblyInfoFile, $result, [System.Text.Encoding]::UTF8)
 }


### PR DESCRIPTION
```powershell
PS C:\work\ravendb4> . '.\scripts\updateSourceWithBuildInfo.ps1'
PS C:\work\ravendb4> UpdateCommonAssemblyInfo "." "99999" "4.0.5" "zzzzzz"; Get-Content .\src\CommonAssemblyInfo.cs | write-host
Set version in .\src\CommonAssemblyInfo.cs...
using System.Reflection;
using System.Resources;

[assembly: AssemblyCopyright("© Hibernating Rhinos 2004 - 2016 All rights reserved.")]

[assembly: AssemblyVersion("4.0.5")]
[assembly: AssemblyFileVersion("4.0.5.99999")]
[assembly: AssemblyInformationalVersion("4.0.5")]

#if DEBUG
[assembly: AssemblyConfiguration("Debug")]
#else
[assembly: AssemblyConfiguration("Release")]
#endif

[assembly: AssemblyDelaySign(false)]
[assembly: NeutralResourcesLanguage("en-US")]
PS C:\work\ravendb4>
```