### PR TITLE
[v4.1] RavenDB-11276: request executor disposal deadlock

### DIFF
--- a/src/Raven.Client/Http/RequestExecutor.cs
+++ b/src/Raven.Client/Http/RequestExecutor.cs
@@ -315,6 +315,12 @@ namespace Raven.Client.Http
                     OnTopologyUpdated(topology);
                 }
             }
+            // we want to throw here only if we are not disposed yet
+            catch (Exception)
+            {
+                if (Disposed == false)
+                    throw;
+            }
             finally
             {
                 _updateDatabaseTopologySemaphore.Release();
@@ -1189,7 +1195,6 @@ namespace Raven.Client.Http
             if (_disposeOnceRunner.Disposed)
                 return;
 
-            _updateDatabaseTopologySemaphore.Wait();
             _disposeOnceRunner.Dispose();
         }
 


### PR DESCRIPTION
Do not wait for topology update semaphore on RequestExecutor disposal.
Do not throw exceptions on topology update if RequestExecutor was disposed.