### PR TITLE
[v4.1] RavenDB-11341 Fixed typo on certificateModel

### DIFF
--- a/src/Raven.Studio/typescript/models/auth/certificateModel.ts
+++ b/src/Raven.Studio/typescript/models/auth/certificateModel.ts
@@ -6,7 +6,7 @@ class certificateModel {
 
     static securityClearanceTypes: valueAndLabelItem<Raven.Client.ServerWide.Operations.Certificates.SecurityClearance, string>[] = [
         {
-            label: "Cluster Administator",
+            label: "Cluster Administrator",
             value: "ClusterAdmin"
         }, {
             label: "Operator", 


### PR DESCRIPTION
Fixed a typo on certificateModel (missing 'r'): Administator => Administrator