### PR TITLE
[4.1] RavenDB-11354 High CPU after hitting leader stepdown several times

### DIFF
--- a/src/Raven.Server/NotificationCenter/Notifications/Server/ClusterTopologyChanged.cs
+++ b/src/Raven.Server/NotificationCenter/Notifications/Server/ClusterTopologyChanged.cs
@@ -53,7 +53,8 @@ namespace Raven.Server.NotificationCenter.Notifications.Server
                 NodeTag = nodeTag,
                 Status = status,
                 CurrentTerm = term,
-                NodeLicenseDetails = nodeLicenseDetails
+                NodeLicenseDetails = nodeLicenseDetails,
+                IsPersistent = true
             };
         }
     }

--- a/src/Raven.Server/NotificationCenter/NotificationsBase.cs
+++ b/src/Raven.Server/NotificationCenter/NotificationsBase.cs
@@ -17,18 +17,30 @@ namespace Raven.Server.NotificationCenter
         private TaskCompletionSource<object> _newWebSocket = new TaskCompletionSource<object>(TaskCreationOptions.RunContinuationsAsynchronously);
         private TaskCompletionSource<object> _allWebSocketsRemoved = new TaskCompletionSource<object>(TaskCreationOptions.RunContinuationsAsynchronously);
 
-        public Task WaitForAllRemoved => _allWebSocketsRemoved.Task;
+        public Task WaitForRemoveAllWebSocketClients
+        {
+            get
+            {
+                lock (_watchersLock)
+                {
+                    return _websocketClients == 0 ? Task.CompletedTask : _allWebSocketsRemoved.Task;
+                }
+            }
+        }
 
         protected ConcurrentSet<ConnectedWatcher> Watchers { get; }
         protected List<BackgroundWorkBase> BackgroundWorkers { get; }
 
-        private int _websocketClients;
+        private volatile int _websocketClients;
 
-        public Task WaitForNew()
+        public Task WaitForAnyWebSocketClient
         {
-            lock (_watchersLock)
+            get
             {
-                return _websocketClients > 0 ? Task.CompletedTask : _newWebSocket.Task;
+                lock (_watchersLock)
+                {
+                    return _websocketClients > 0 ? Task.CompletedTask : _newWebSocket.Task;
+                }
             }
         }
 

--- a/src/Raven.Server/NotificationCenter/NotificationsBase.cs
+++ b/src/Raven.Server/NotificationCenter/NotificationsBase.cs
@@ -15,22 +15,27 @@ namespace Raven.Server.NotificationCenter
     {
         private readonly object _watchersLock = new object();
 
-        private TaskCompletionSource<object> _newWebSocket = new TaskCompletionSource<object>(TaskCreationOptions.RunContinuationsAsynchronously);
-        private TaskCompletionSource<object> _allWebSocketsRemoved = new TaskCompletionSource<object>(TaskCreationOptions.RunContinuationsAsynchronously);
+
+        private class State
+        {
+            public TaskCompletionSource<object> NewWebSocket = new TaskCompletionSource<object>(TaskCreationOptions.RunContinuationsAsynchronously);
+            public TaskCompletionSource<object> AllWebSocketsRemoved = new TaskCompletionSource<object>(TaskCreationOptions.RunContinuationsAsynchronously);
+            public int NumberOfClients;
+        }
 
         protected ConcurrentSet<ConnectedWatcher> Watchers { get; }
         protected List<BackgroundWorkBase> BackgroundWorkers { get; }
 
-        private volatile int _websocketClients;
-
-        private long _haveClients;
+        private State _state = new State();
 
         public Task WaitForAnyWebSocketClient
         {
             get
             {
-                var task = _newWebSocket.Task;
-                return Interlocked.Read(ref _haveClients) == 1 ? Task.CompletedTask : task;
+                var copy = _state;
+                if (copy.NumberOfClients == 0)
+                    return copy.NewWebSocket.Task;
+                return Task.CompletedTask;
             }
         }
 
@@ -38,8 +43,10 @@ namespace Raven.Server.NotificationCenter
         {
             get
             {
-                var task = _allWebSocketsRemoved.Task;
-                return Interlocked.Read(ref _haveClients) == 0 ? Task.CompletedTask : task;
+                var copy = _state;
+                if (copy.NumberOfClients == 0)
+                    return Task.CompletedTask;
+                return copy.AllWebSocketsRemoved.Task;
             }
         }
 
@@ -68,11 +75,21 @@ namespace Raven.Server.NotificationCenter
 
                 if (watcher.Writer is NotificationCenterWebSocketWriter)
                 {
-                    if (Interlocked.CompareExchange(ref _haveClients, 1, 0) == 0)
+                    if(_state.NumberOfClients == 0)
                     {
-                        TaskExecutor.CompleteAndReplace(ref _newWebSocket);
+                        var copy = _state;
+                        // we use interlocked here to make sure that other threads
+                        // are immediately exposed to this
+                        Interlocked.Exchange(ref _state, new State
+                        {
+                            NumberOfClients = 1
+                        });
+                        copy.NewWebSocket.TrySetResult(null);
                     }
-                    _websocketClients++;
+                    else
+                    {
+                        Interlocked.Increment(ref _state.NumberOfClients);
+                    }
                 }
             }
 
@@ -89,11 +106,11 @@ namespace Raven.Server.NotificationCenter
 
                     if (watcher.Writer is NotificationCenterWebSocketWriter)
                     {
-                        _websocketClients--;
-                        if (_websocketClients == 0)
+                        var copy = _state;
+                        if(Interlocked.Decrement(ref copy.NumberOfClients) == 0)
                         {
-                            Interlocked.Exchange(ref _haveClients, 0);
-                            TaskExecutor.CompleteAndReplace(ref _allWebSocketsRemoved);
+                            Interlocked.Exchange(ref _state, new State());
+                            copy.AllWebSocketsRemoved.TrySetResult(null);
                         }
                     }
                 }

--- a/src/Raven.Server/NotificationCenter/NotificationsBase.cs
+++ b/src/Raven.Server/NotificationCenter/NotificationsBase.cs
@@ -1,6 +1,7 @@
 ﻿using System;
 using System.Collections.Generic;
 using System.Linq;
+using System.Threading;
 using System.Threading.Tasks;
 using Raven.Client.Util;
 using Raven.Server.Background;
@@ -17,30 +18,28 @@ namespace Raven.Server.NotificationCenter
         private TaskCompletionSource<object> _newWebSocket = new TaskCompletionSource<object>(TaskCreationOptions.RunContinuationsAsynchronously);
         private TaskCompletionSource<object> _allWebSocketsRemoved = new TaskCompletionSource<object>(TaskCreationOptions.RunContinuationsAsynchronously);
 
-        public Task WaitForRemoveAllWebSocketClients
-        {
-            get
-            {
-                lock (_watchersLock)
-                {
-                    return _websocketClients == 0 ? Task.CompletedTask : _allWebSocketsRemoved.Task;
-                }
-            }
-        }
-
         protected ConcurrentSet<ConnectedWatcher> Watchers { get; }
         protected List<BackgroundWorkBase> BackgroundWorkers { get; }
 
         private volatile int _websocketClients;
 
+        private long _haveClients;
+
         public Task WaitForAnyWebSocketClient
         {
             get
             {
-                lock (_watchersLock)
-                {
-                    return _websocketClients > 0 ? Task.CompletedTask : _newWebSocket.Task;
-                }
+                var task = _newWebSocket.Task;
+                return Interlocked.Read(ref _haveClients) == 1 ? Task.CompletedTask : task;
+            }
+        }
+
+        public Task WaitForRemoveAllWebSocketClients
+        {
+            get
+            {
+                var task = _allWebSocketsRemoved.Task;
+                return Interlocked.Read(ref _haveClients) == 0 ? Task.CompletedTask : task;
             }
         }
 
@@ -69,7 +68,7 @@ namespace Raven.Server.NotificationCenter
 
                 if (watcher.Writer is NotificationCenterWebSocketWriter)
                 {
-                    if (_websocketClients == 0)
+                    if (Interlocked.CompareExchange(ref _haveClients, 1, 0) == 0)
                     {
                         TaskExecutor.CompleteAndReplace(ref _newWebSocket);
                     }
@@ -93,6 +92,7 @@ namespace Raven.Server.NotificationCenter
                         _websocketClients--;
                         if (_websocketClients == 0)
                         {
+                            Interlocked.Exchange(ref _haveClients, 0);
                             TaskExecutor.CompleteAndReplace(ref _allWebSocketsRemoved);
                         }
                     }

--- a/src/Raven.Server/Rachis/RachisConsensus.cs
+++ b/src/Raven.Server/Rachis/RachisConsensus.cs
@@ -255,7 +255,7 @@ namespace Raven.Server.Rachis
 
         public event EventHandler LeaderElected;
 
-        private string _tag;
+        private volatile string _tag;
         private string _clusterId;
 
         public TransactionContextPool ContextPool { get; private set; }
@@ -481,6 +481,21 @@ namespace Raven.Server.Rachis
                 var task = _stateChanged.Task;
 
                 if (CurrentState == rachisState)
+                    return;
+
+                await task;
+            }
+        }
+
+        public async Task WaitForLeaderChange(CancellationToken cts)
+        {
+            var currentLeader = LeaderTag;
+            while (cts.IsCancellationRequested == false)
+            {
+                // we setup the wait _before_ checking the state
+                var task = _stateChanged.Task;
+
+                if (currentLeader != LeaderTag)
                     return;
 
                 await task;
@@ -1744,10 +1759,7 @@ namespace Raven.Server.Rachis
                         throw new ArgumentOutOfRangeException();
                 }
             }
-            internal set
-            {
-                _leaderTag = value;
-            }
+            internal set => _leaderTag = value;
         }
 
         public bool IsEncrypted => _persistentState.Options.EncryptionEnabled;

--- a/src/Raven.Server/Rachis/RachisConsensus.cs
+++ b/src/Raven.Server/Rachis/RachisConsensus.cs
@@ -255,7 +255,7 @@ namespace Raven.Server.Rachis
 
         public event EventHandler LeaderElected;
 
-        private volatile string _tag;
+        private string _tag;
         private string _clusterId;
 
         public TransactionContextPool ContextPool { get; private set; }
@@ -1758,7 +1758,7 @@ namespace Raven.Server.Rachis
                     return safe ? Volatile.Read(ref _leaderTag) : _leaderTag;
                 case RachisState.LeaderElect:
                 case RachisState.Leader:
-                    return _tag; // this is already mark as volatile
+                    return safe ? Volatile.Read(ref _tag) : _tag; 
                 default:
                     throw new ArgumentOutOfRangeException();
             }

--- a/src/Raven.Server/Rachis/RachisConsensus.cs
+++ b/src/Raven.Server/Rachis/RachisConsensus.cs
@@ -495,7 +495,7 @@ namespace Raven.Server.Rachis
                 // we setup the wait _before_ checking the state
                 var task = _stateChanged.Task;
 
-                if (currentLeader != LeaderTag)
+                if (currentLeader != GetLeaderTag(safe: true))
                     return;
 
                 await task;
@@ -1740,26 +1740,28 @@ namespace Raven.Server.Rachis
           
         }
 
-        private volatile string _leaderTag;
+        private string _leaderTag;
         public string LeaderTag
         {
-            get
-            {
-                switch (CurrentState)
-                {
-                    case RachisState.Passive:
-                    case RachisState.Candidate:
-                        return null;
-                    case RachisState.Follower:
-                        return _leaderTag;
-                    case RachisState.LeaderElect:
-                    case RachisState.Leader:
-                        return _tag;
-                    default:
-                        throw new ArgumentOutOfRangeException();
-                }
-            }
+            get => GetLeaderTag();
             internal set => _leaderTag = value;
+        }
+
+        public string GetLeaderTag(bool safe = false)
+        {
+            switch (CurrentState)
+            {
+                case RachisState.Passive:
+                case RachisState.Candidate:
+                    return null;
+                case RachisState.Follower:
+                    return safe ? Volatile.Read(ref _leaderTag) : _leaderTag;
+                case RachisState.LeaderElect:
+                case RachisState.Leader:
+                    return _tag; // this is already mark as volatile
+                default:
+                    throw new ArgumentOutOfRangeException();
+            }
         }
 
         public bool IsEncrypted => _persistentState.Options.EncryptionEnabled;

--- a/src/Raven.Server/ServerWide/ServerStore.cs
+++ b/src/Raven.Server/ServerWide/ServerStore.cs
@@ -181,17 +181,18 @@ namespace Raven.Server.ServerWide
                 {
                     using (var cts = CancellationTokenSource.CreateLinkedTokenSource(ServerShutdown))
                     {
-                        var leaveTask = _engine.WaitForLeaveState(RachisState.Follower, cts.Token);
-                        if (await Task.WhenAny(NotificationCenter.WaitForNew(), leaveTask).WithCancellation(ServerShutdown) == leaveTask)
+                        var leaderChangedTask = _engine.WaitForLeaderChange(cts.Token);
+                        if (await Task.WhenAny(NotificationCenter.WaitForAnyWebSocketClient, leaderChangedTask).WithCancellation(ServerShutdown) == leaderChangedTask)
                         {
                             continue;
                         }
 
-                        var cancelTask = Task.WhenAny(NotificationCenter.WaitForAllRemoved, leaveTask)
+                        var cancelTask = Task.WhenAny(NotificationCenter.WaitForRemoveAllWebSocketClients, leaderChangedTask)
                             .ContinueWith(state =>
                             {
                                 try
                                 {
+                                    // ReSharper disable once AccessToDisposedClosure
                                     cts.Cancel();
                                 }
                                 catch
@@ -206,6 +207,10 @@ namespace Raven.Server.ServerWide
                             var leaderUrl = topology.GetUrlFromTag(_engine.LeaderTag);
                             if (leaderUrl == null)
                                 break; // will continue from the top of the loop
+
+                            if (IsLeader())
+                                break;
+
                             using (var ws = new ClientWebSocket())
                             using (ContextPool.AllocateOperationContext(out JsonOperationContext context))
                             {
@@ -230,6 +235,9 @@ namespace Raven.Server.ServerWide
                                         var topologyNotification = JsonDeserializationServer.ClusterTopologyChanged(notification);
                                         if (topologyNotification == null)
                                             continue;
+
+                                        if (_engine.LeaderTag != topologyNotification.Leader)
+                                            break;
 
                                         topologyNotification.NodeTag = _engine.Tag;
                                         NotificationCenter.Add(topologyNotification);
@@ -679,6 +687,9 @@ namespace Raven.Server.ServerWide
 
         public void OnTopologyChanged(object sender, ClusterTopology topologyJson)
         {
+            if (_engine.CurrentState == RachisState.Follower)
+                return;
+
             NotificationCenter.Add(ClusterTopologyChanged.Create(topologyJson, LeaderTag,
                 NodeTag, _engine.CurrentTerm, GetNodesStatuses(), LoadLicenseLimits()?.NodeLicenseDetails));
         }

--- a/src/Raven.Studio/typescript/models/database/cluster/clusterNode.ts
+++ b/src/Raven.Studio/typescript/models/database/cluster/clusterNode.ts
@@ -109,7 +109,6 @@ class clusterNode {
     createStateObservable(topologyProvider: KnockoutObservable<clusterTopology>) {
         return ko.pureComputed(() => {
             const topology = topologyProvider();
-
             if (!topology.leader()) {
                 if (this.type() === "Watcher") {
                     return "Waiting";
@@ -120,16 +119,13 @@ class clusterNode {
                 }
             }
 
-            if (topology.nodeTag() !== topology.leader()) {
-                return "";
-            }
-
             return this.connected() ? "Active" : "Error";
         });
     }
 
     createStateClassObservable(topologyProvider: KnockoutObservable<clusterTopology>) {
         return ko.pureComputed(() => {
+            
             const topology = topologyProvider();
             if (!topology.leader()) {
                 if (this.type() === "Watcher") {
@@ -137,10 +133,6 @@ class clusterNode {
                 }
                 
                 return this.connected() ? "state-info" : "state-danger";
-            }
-
-            if (topology.nodeTag() !== topology.leader()) {
-                return "state-unknown";
             }
 
             return this.connected() ? "state-success" : "state-danger";

--- a/src/Sparrow/Json/JsonOperationContext.cs
+++ b/src/Sparrow/Json/JsonOperationContext.cs
@@ -577,7 +577,7 @@ namespace Sparrow.Json
         public async Task<BlittableJsonReaderObject> ReadFromWebSocket(
             WebSocket webSocket,
             string debugTag,
-            CancellationToken cancellationToken)
+            CancellationToken token)
         {
 
             if (Disposed)
@@ -598,8 +598,9 @@ namespace Sparrow.Json
                 try
                 {
                     builder.ReadObjectDocument();
-                    var result = await webSocket.ReceiveAsync(bytes.Buffer, cancellationToken).ConfigureAwait(false);
+                    var result = await webSocket.ReceiveAsync(bytes.Buffer, token).ConfigureAwait(false);
 
+                    token.ThrowIfCancellationRequested();
                     EnsureNotDisposed();
 
                     if (result.MessageType == WebSocketMessageType.Close)
@@ -614,7 +615,9 @@ namespace Sparrow.Json
                         bytes.Used += parser.BufferOffset;
                         if (read)
                             break;
-                        result = await webSocket.ReceiveAsync(bytes.Buffer, cancellationToken).ConfigureAwait(false);
+                        result = await webSocket.ReceiveAsync(bytes.Buffer, token).ConfigureAwait(false);
+                        token.ThrowIfCancellationRequested();
+                        EnsureNotDisposed();
                         bytes.Valid = result.Count;
                         bytes.Used = 0;
                         parser.SetBuffer(bytes);


### PR DESCRIPTION
The issue is related to code for sending topology change notification from the leader.
We waited to leave 'Follower' state in order to reconnect to a new leader, but it could happened that the leader was changed without us leaving the follower state, and so we were connected to the wrong node.
This could caused a circular connection between the nodes which sent the same notification again and again.