### PR TITLE
RavenDB-10923: Linux Container under Windows Host with cifs Mount bec…

### DIFF
--- a/src/Sparrow/Platform/Posix/Syscall.cs
+++ b/src/Sparrow/Platform/Posix/Syscall.cs
@@ -304,6 +304,8 @@ namespace Sparrow.Platform.Posix
             {
                 case Errno.ENOMEM:
                     throw new OutOfMemoryException("ENOMEM on " + msg);
+                case Errno.ENOENT:
+                    throw new FileNotFoundException("ENOENT on " + msg);
                 default:
                     throw new InvalidOperationException(error + " " + msg);
             }

--- a/src/Voron/Impl/Journal/JournalFile.cs
+++ b/src/Voron/Impl/Journal/JournalFile.cs
@@ -15,6 +15,7 @@ using System.Threading;
 using Sparrow.Collections;
 using Voron.Global;
 using Voron.Util;
+using System.Buffers;
 
 namespace Voron.Impl.Journal
 {
@@ -23,6 +24,9 @@ namespace Voron.Impl.Journal
         private readonly StorageEnvironment _env;
         private IJournalWriter _journalWriter;
         private long _writePosIn4Kb;
+
+        private TransactionHeader[] _transactionHeaders;
+        private int _numberOfTransactionHeaders;
 
         private readonly PageTable _pageTranslationTable = new PageTable();
 
@@ -35,6 +39,7 @@ namespace Voron.Impl.Journal
         {
             Number = journalNumber;
             _env = env;
+            _transactionHeaders = ArrayPool<TransactionHeader>.Shared.Rent(journalWriter.NumberOfAllocated4Kb);
             _journalWriter = journalWriter;
             _writePosIn4Kb = 0;
             _unusedPages = new FastList<PagePosition>();
@@ -74,6 +79,9 @@ namespace Voron.Impl.Journal
 
         public void Dispose()
         {
+            if (_transactionHeaders != null)
+                ArrayPool<TransactionHeader>.Shared.Return(_transactionHeaders);
+            _transactionHeaders = null;
             _unusedPagesHashSetPool.Clear();
             _unusedPages.Clear();
             _pageTranslationTable.Clear();
@@ -95,9 +103,75 @@ namespace Voron.Impl.Journal
             };
         }
 
-        public bool ReadTransaction(long pos, TransactionHeader* txHeader)
+        public void SetLastReadTxHeader(long maxTransactionId, ref TransactionHeader lastReadTxHeader)
         {
-            return _journalWriter.Read((byte*)txHeader, sizeof(TransactionHeader), pos);
+            int low = 0;
+            int high = _numberOfTransactionHeaders-1;
+
+            while (low <= high)
+            {
+                int mid = (low + high) >> 1;
+                long midValTxId = _transactionHeaders[mid].TransactionId;
+
+                if (midValTxId < maxTransactionId)
+                    low = mid + 1;
+                else if (midValTxId > maxTransactionId)
+                    high = mid - 1;
+                else // found the max tx id
+                {
+                    lastReadTxHeader = _transactionHeaders[mid];
+                    return; 
+                }
+            }
+            if(low == 0)
+            {
+                lastReadTxHeader.TransactionId = -1; // not found
+                return;
+            }
+            if(high != _numberOfTransactionHeaders - 1)
+            {
+                throw new InvalidOperationException("Found a gap in the transaction headers held by this journal file in memory, shouldn't be possible");
+            }
+            lastReadTxHeader = _transactionHeaders[_numberOfTransactionHeaders - 1];
+        }
+
+        /// <summary>
+        /// Write a buffer of transactions (from lazy, usually) to the file
+        /// </summary>
+        public void Write(long posBy4Kb, byte* p, int numberOf4Kbs)
+        {
+            int posBy4Kbs = 0;
+            while (posBy4Kbs < numberOf4Kbs)
+            {
+                var readTxHeader = (TransactionHeader*)(p + (posBy4Kbs * 4 * Constants.Size.Kilobyte));
+                var totalSize = readTxHeader->CompressedSize != -1 ? readTxHeader->CompressedSize + 
+                    sizeof(TransactionHeader) : readTxHeader->UncompressedSize + sizeof(TransactionHeader);
+                var roundTo4Kb = (totalSize / (4 * Constants.Size.Kilobyte)) +
+                                   (totalSize % (4 * Constants.Size.Kilobyte) == 0 ? 0 : 1);
+                if (roundTo4Kb > int.MaxValue)
+                {
+                    MathFailure(numberOf4Kbs);
+                }
+
+                // We skip to the next transaction header.
+                posBy4Kbs += (int)roundTo4Kb ;
+                if(_transactionHeaders.Length == _numberOfTransactionHeaders)
+                {
+                    var temp = ArrayPool<TransactionHeader>.Shared.Rent(_transactionHeaders.Length * 2);
+                    Array.Copy(_transactionHeaders, temp, _transactionHeaders.Length);
+                    ArrayPool<TransactionHeader>.Shared.Return(_transactionHeaders);
+                    _transactionHeaders = temp;
+                }
+                Debug.Assert(readTxHeader->HeaderMarker == Constants.TransactionHeaderMarker);
+                _transactionHeaders[_numberOfTransactionHeaders++] = *readTxHeader;
+            }
+
+            JournalWriter.Write(posBy4Kb, p, numberOf4Kbs);
+        }
+
+        private static void MathFailure(int numberOf4Kbs)
+        {
+            throw new InvalidOperationException("Math failed, total size is larger than 2^31*4KB but we have just: " + numberOf4Kbs + " * 4KB");
         }
 
         /// <summary>
@@ -109,6 +183,10 @@ namespace Voron.Impl.Journal
             var cur4KbPos = _writePosIn4Kb;
 
             Debug.Assert(pages.NumberOf4Kbs > 0);
+
+            var readTxHeader = (TransactionHeader*)pages.Base;
+            Debug.Assert(readTxHeader->HeaderMarker == Constants.TransactionHeaderMarker);
+            _transactionHeaders[_numberOfTransactionHeaders++] = *readTxHeader;
 
             UpdatePageTranslationTable(tx, _unusedPagesHashSetPool, ptt);
 
@@ -125,7 +203,7 @@ namespace Voron.Impl.Journal
             {
                 try
                 {
-                    _journalWriter.Write(cur4KbPos, pages.Base, pages.NumberOf4Kbs);
+                    Write(cur4KbPos, pages.Base, pages.NumberOf4Kbs);
                 }
                 catch (Exception e)
                 {
@@ -179,6 +257,7 @@ namespace Voron.Impl.Journal
             }
         }
 
+       
         private void UpdatePageTranslationTable(LowLevelTransaction tx, HashSet<PagePosition> unused, Dictionary<long, PagePosition> ptt)
         {
             // REVIEW: This number do not grow easily. There is no way we can go higher than int.MaxValue

--- a/src/Voron/Impl/Journal/JournalFile.cs
+++ b/src/Voron/Impl/Journal/JournalFile.cs
@@ -184,10 +184,6 @@ namespace Voron.Impl.Journal
 
             Debug.Assert(pages.NumberOf4Kbs > 0);
 
-            var readTxHeader = (TransactionHeader*)pages.Base;
-            Debug.Assert(readTxHeader->HeaderMarker == Constants.TransactionHeaderMarker);
-            _transactionHeaders[_numberOfTransactionHeaders++] = *readTxHeader;
-
             UpdatePageTranslationTable(tx, _unusedPagesHashSetPool, ptt);
 
             using (_locker2.Lock())

--- a/src/Voron/Impl/Journal/LazyTransactionBuffer.cs
+++ b/src/Voron/Impl/Journal/LazyTransactionBuffer.cs
@@ -93,7 +93,7 @@ namespace Voron.Impl.Journal
                     _lazyTransactionPager.EnsureMapped(tempTx, 0, numberOfPages);
                     var src = _lazyTransactionPager.AcquirePagePointer(tempTx, 0);
                     var sp = Stopwatch.StartNew();
-                    journalFile.JournalWriter.Write(_firstPositionInJournalFile.Value, src, _lastUsed4Kbs);
+                    journalFile.Write(_firstPositionInJournalFile.Value, src, _lastUsed4Kbs);
                     if (_log.IsInfoEnabled)
                     {
                         _log.Info($"Writing lazy transaction buffer with {_lastUsed4Kbs / 4:#,#0} kb took {sp.Elapsed}");

--- a/test/Tryouts/Program.cs
+++ b/test/Tryouts/Program.cs
@@ -1,6 +1,7 @@
 using System;
 using System.Threading.Tasks;
 using FastTests.Server.Documents.Queries.Parser;
+using FastTests.Voron.Compaction;
 using SlowTests.Authentication;
 using SlowTests.Bugs.MapRedue;
 using SlowTests.Client;
@@ -18,9 +19,9 @@ namespace Tryouts
                 try
                 {
                     Console.WriteLine(i);
-                    using (var test = new SlowTests.Core.Commands.Documents())
+                    using (var test = new StorageCompactionTests())
                     {
-                        test.CanCancelPutDocument();
+                        test.ShouldDeleteCurrentJournalEvenThoughItHasAvailableSpace();
                     }
                 }
                 catch (Exception e)

--- a/test/Tryouts/Program.cs
+++ b/test/Tryouts/Program.cs
@@ -1,6 +1,7 @@
 using System;
 using System.Threading.Tasks;
 using FastTests.Server.Documents.Queries.Parser;
+using FastTests.Voron.Backups;
 using FastTests.Voron.Compaction;
 using SlowTests.Authentication;
 using SlowTests.Bugs.MapRedue;
@@ -19,9 +20,9 @@ namespace Tryouts
                 try
                 {
                     Console.WriteLine(i);
-                    using (var test = new StorageCompactionTests())
+                    using (var test = new RavenDB_3115())
                     {
-                        test.ShouldDeleteCurrentJournalEvenThoughItHasAvailableSpace();
+                        test.ShouldCorrectlyLoadAfterRestartIfIncrementalBackupWasDone();
                     }
                 }
                 catch (Exception e)


### PR DESCRIPTION
…ause of file system caching issues

- Instead of reading the transaction data from the journal file, we'll keep it in our own memory and use that for sync purposes.
  This allows us to avoid stale read after write when using CIFS system (such as Docker using Linux container on Windows with external volume).
  There is no impact to the safety guarantees since we not relying on the sync validating the status of the journal file and we are known to be okay WRT the state of writes ot the journal.
- Will properly handle FileNotFound errors when we create scratch files