### PR TITLE
[v4.0] RavenDB-11276:

### DIFF
--- a/src/Raven.Client/Http/ClusterRequestExecutor.cs
+++ b/src/Raven.Client/Http/ClusterRequestExecutor.cs
@@ -130,6 +130,11 @@ namespace Raven.Client.Http
                     OnTopologyUpdated(newTopology);
                 }
             }
+            catch(Exception)
+            {
+                if (Disposed == false)
+                    throw;
+            }
             finally
             {
                 _clusterTopologySemaphore.Release();
@@ -148,12 +153,6 @@ namespace Raven.Client.Http
             throw new AggregateException("Failed to retrieve cluster topology from all known nodes" + Environment.NewLine +
                                          string.Join(Environment.NewLine, list.Select(x => x.Item1 + " -> " + x.Item2?.Message))
                 , list.Select(x => x.Item2));
-        }
-
-        public override void Dispose()
-        {
-            _clusterTopologySemaphore.Wait();
-            base.Dispose();
         }
 
         protected override bool TryLoadFromCache(JsonOperationContext context)


### PR DESCRIPTION
We don't wait on the ClusterRequestExecutor cluster topology update sempahore upon disposal anymore.
Removed Dispose implementation in ClusterRequestExecutor