### PR TITLE
RavenDB-11364 RavenDB_6369.ShouldTimeout doesn't timeout

### DIFF
--- a/src/Raven.Client/Http/NodeSelector.cs
+++ b/src/Raven.Client/Http/NodeSelector.cs
@@ -126,7 +126,7 @@ namespace Raven.Client.Http
         public void RestoreNodeIndex(int nodeIndex)
         {
             var state = _state;
-            if (state.CurrentNodeIndex < nodeIndex)
+            if (state.CurrentNodeIndex <= nodeIndex)
                 return; // nothing to do
 
             var stateFailure = state.Failures[nodeIndex];

--- a/test/Tryouts/Program.cs
+++ b/test/Tryouts/Program.cs
@@ -18,9 +18,9 @@ namespace Tryouts
                 try
                 {
                     Console.WriteLine(i);
-                    using (var test = new SlowTests.Core.Commands.Documents())
+                    using (var test = new RavenDB_6369())
                     {
-                        test.CanCancelPutDocument();
+                        test.ShouldTimeout();
                     }
                 }
                 catch (Exception e)


### PR DESCRIPTION
Fixing out of bound write