### PR TITLE
[4.0] RavenDB-11157 Reduce default time of extract and transform stages by …

### DIFF
--- a/src/Raven.Server/Config/Categories/EtlConfiguration.cs
+++ b/src/Raven.Server/Config/Categories/EtlConfiguration.cs
@@ -13,7 +13,7 @@ namespace Raven.Server.Config.Categories
         public TimeSetting? SqlCommandTimeout { get; set; }
 
         [Description("Number of seconds after which extraction and transformation will end and loading will start.")]
-        [DefaultValue(60 * 5)]
+        [DefaultValue(60)]
         [TimeUnit(TimeUnit.Seconds)]
         [ConfigurationEntry("ETL.ExtractAndTransformTimeoutInSec", ConfigurationEntryScope.ServerWideOrPerDatabase)]
         public TimeSetting ExtractAndTransformTimeout { get; protected set; }


### PR DESCRIPTION
…ETL process from 5 minutes to 60 seconds. It could result in huge batch to send and high memory usage.