### PR TITLE
[4.0] RavenDB-10895 Node in rehabilitation due to last report status being …

### DIFF
--- a/src/Raven.Server/RavenServer.cs
+++ b/src/Raven.Server/RavenServer.cs
@@ -1349,7 +1349,7 @@ namespace Raven.Server
                     var old = _clusterMaintenanceWorker;
                     using (old)
                     {
-                        _clusterMaintenanceWorker = new ClusterMaintenanceWorker(tcp, ServerStore.ServerShutdown, ServerStore, maintenanceHeader.Term);
+                        _clusterMaintenanceWorker = new ClusterMaintenanceWorker(tcp, ServerStore.ServerShutdown, ServerStore, maintenanceHeader.LeaderClusterTag, maintenanceHeader.Term);
                         _clusterMaintenanceWorker.Start();
                     }
 


### PR DESCRIPTION
…'WaitingForResponse'

ClusterMaintenanceSupervisor and ClusterMaintenanceWorker running using the PoolOfThreads.
Since both are long running tasks.