### PR TITLE
[4.1] RavenDB-11366 InvalidDataException Expected to get type of 'LogLength…

### DIFF
--- a/src/Raven.Server/Rachis/Follower.cs
+++ b/src/Raven.Server/Rachis/Follower.cs
@@ -19,6 +19,8 @@ namespace Raven.Server.Rachis
 {
     public class Follower : IDisposable
     {
+        private static int _uniqueId;
+
         private readonly RachisConsensus _engine;
         private readonly long _term;
         private readonly RemoteConnection _connection;
@@ -32,8 +34,10 @@ namespace Raven.Server.Rachis
             _engine = engine;
             _connection = remoteConnection;
             _term = term;
-            
-            _debugName = $"Follower in term {_term}";
+
+            // this will give us a unique identifier for this follower
+            var uniqueId = Interlocked.Increment(ref _uniqueId);
+            _debugName = $"Follower in term {_term} (id: {uniqueId})";
             _debugRecorder = _engine.InMemoryDebug.GetNewRecorder(_debugName);
             _debugRecorder.Start();
         }


### PR DESCRIPTION
…NegotiationResponse' message, but got 'Error' message.

The issue is probably due to a race between disposing a follower in term X, while creating a new one in the same term.
This could occur during a short period split-brain (network delay) so the follower went to elections but was immediately forced by the leader to becamce his follower again.