### PR TITLE
[4.1] RavenDB-7070

### DIFF
--- a/install_build_prerequisites.sh
+++ b/install_build_prerequisites.sh
@@ -23,7 +23,7 @@ fi
 
 eval 
 
-echo "Installing .NET Core SDK 2.1.105..."
+echo "Installing .NET Core SDK 2.1"
 
 if [ -z "$CURL_CMD" ]; then
     sudo apt-get install -y curl 
@@ -40,7 +40,7 @@ elif [ "$UBUNTU_VERSION" = "18.04" ] ; then
 fi
 
 sudo apt-get update
-sudo apt-get install -y dotnet-sdk-2.1.105
+sudo apt-get install -y dotnet-sdk-2.1
 
 mkdir ./dotnet_tmp
 cd ./dotnet_tmp

--- a/src/Raven.TestDriver/Raven.TestDriver.csproj
+++ b/src/Raven.TestDriver/Raven.TestDriver.csproj
@@ -11,6 +11,13 @@
     <PackageTags>ravendb;client;database;nosql;doc db</PackageTags>
     <CodeAnalysisRuleSet>..\..\RavenDB.ruleset</CodeAnalysisRuleSet>
   </PropertyGroup>
+  
+  <PropertyGroup Condition="'$(OS)' == 'Windows_NT'">
+    <TargetFrameworks>netstandard1.3;netstandard2.0;net461</TargetFrameworks>
+  </PropertyGroup>
+  <PropertyGroup Condition="'$(OS)' != 'Windows_NT'">
+    <TargetFrameworks>netstandard1.3;netstandard2.0</TargetFrameworks>
+  </PropertyGroup>
 
   <ItemGroup Condition="'$(OS)' == 'Windows_NT'">
     <Compile Include="..\CommonAssemblyInfo.Windows.cs" Link="Properties\CommonAssemblyInfo.Windows.cs" />


### PR DESCRIPTION
- we cannot build a net461 target on linux
- fixed install_build_prerequisites.sh