### PR TITLE
[4.1] RavenDB-11426 fixing several cluster issues

### DIFF
--- a/src/Raven.Server/Rachis/Candidate.cs
+++ b/src/Raven.Server/Rachis/Candidate.cs
@@ -171,7 +171,7 @@ namespace Raven.Server.Rachis
                             StateChange();
 
                             var minimalVersion = ClusterCommandsVersionManager.GetClusterMinimalVersion(versions, _engine.MaximalVersion);
-                            string msg = $"Was elected by {realElectionsCount} nodes to leadership in {ElectionTerm} with cluster version of {minimalVersion}";
+                            string msg = $"Was elected by {realElectionsCount} nodes for leadership in term {ElectionTerm} with cluster version of {minimalVersion}";
                             _engine.SwitchToLeaderState(ElectionTerm, minimalVersion, msg, connections);
                             break;
                         }

--- a/src/Raven.Server/ServerWide/Commands/AddDatabaseCommand.cs
+++ b/src/Raven.Server/ServerWide/Commands/AddDatabaseCommand.cs
@@ -28,7 +28,7 @@ namespace Raven.Server.ServerWide.Commands
 
             foreach (var o in obj)
             {
-                rc.Add((string)o);
+                rc.Add(o.ToString());
             }
             return rc;
         }

--- a/test/RachisTests/AddNodeToClusterTests.cs
+++ b/test/RachisTests/AddNodeToClusterTests.cs
@@ -49,16 +49,19 @@ namespace RachisTests
         [Fact]
         public async Task RemoveNodeWithDb()
         {
+            var dbMain = GetDatabaseName();
+            var dbWatcher = GetDatabaseName();
+
             var fromSeconds = Debugger.IsAttached ? TimeSpan.FromSeconds(15) : TimeSpan.FromSeconds(5);
             var leader = await CreateRaftClusterAndGetLeader(5);
             Assert.True(leader.ServerStore.LicenseManager.HasHighlyAvailableTasks());
 
-            var db = await CreateDatabaseInCluster("MainDB", 5, leader.WebUrl);
-            var watcherDb = await CreateDatabaseInCluster("WatcherDB", 1, leader.WebUrl);
+            var db = await CreateDatabaseInCluster(dbMain, 5, leader.WebUrl);
+            var watcherDb = await CreateDatabaseInCluster(dbWatcher, 1, leader.WebUrl);
             var serverNodes = db.Servers.Select(s => new ServerNode
             {
                 ClusterTag = s.ServerStore.NodeTag,
-                Database = "MainDB",
+                Database = dbMain,
                 Url = s.WebUrl
             }).ToList();
 
@@ -69,18 +72,18 @@ namespace RachisTests
 
             using (var watcherStore = new DocumentStore
             {
-                Database = "WatcherDB",
+                Database = dbWatcher,
                 Urls = new[] { watcherDb.Item2.Single().WebUrl },
                 Conventions = conventions
             }.Initialize())
             using (var leaderStore = new DocumentStore
             {
-                Database = "MainDB",
+                Database = dbMain,
                 Urls = new[] { leader.WebUrl },
                 Conventions = conventions
             }.Initialize())
             {
-                var watcher = new ExternalReplication("WatcherDB", "Connection")
+                var watcher = new ExternalReplication(dbWatcher, "Connection")
                 {
                     MentorNode = Servers.First(s => s.ServerStore.NodeTag != watcherDb.Servers[0].ServerStore.NodeTag).ServerStore.NodeTag
                 };
@@ -99,7 +102,7 @@ namespace RachisTests
                 var responsibleServer = Servers.Single(s => s.ServerStore.NodeTag == watcherRes.ResponsibleNode);
                 using (var responsibleStore = new DocumentStore
                 {
-                    Database = "MainDB",
+                    Database = dbMain,
                     Urls = new[] { responsibleServer.WebUrl },
                     Conventions = conventions
                 }.Initialize())
@@ -121,7 +124,7 @@ namespace RachisTests
                     await ActionWithLeader((l) => l.ServerStore.RemoveFromClusterAsync(watcherRes.ResponsibleNode).WaitAsync(fromSeconds));
                     Assert.True(await responsibleServer.ServerStore.WaitForState(RachisState.Passive, CancellationToken.None).WaitAsync(fromSeconds));
 
-                    var dbInstance = await responsibleServer.ServerStore.DatabasesLandlord.TryGetOrCreateResourceStore("MainDB");
+                    var dbInstance = await responsibleServer.ServerStore.DatabasesLandlord.TryGetOrCreateResourceStore(dbMain);
                     await WaitForValueAsync(() => dbInstance.ReplicationLoader.OutgoingConnections.Count(), 0);
 
                     // replication from the removed node should be suspended
@@ -141,7 +144,7 @@ namespace RachisTests
                 var nodeInCluster = serverNodes.First(s => s.ClusterTag != responsibleServer.ServerStore.NodeTag);
                 using (var nodeInClusterStore = new DocumentStore
                 {
-                    Database = "MainDB",
+                    Database = dbMain,
                     Urls = new[] { nodeInCluster.Url },
                     Conventions = conventions
                 }.Initialize())
@@ -167,7 +170,7 @@ namespace RachisTests
 
                 using (var newLeaderStore = new DocumentStore
                 {
-                    Database = "MainDB",
+                    Database = dbMain,
                     Urls = new[] { newLeader.WebUrl },
                 }.Initialize())
                 using (var session = newLeaderStore.OpenAsyncSession())

--- a/test/RachisTests/DatabaseCluster/ClusterDatabaseMaintenance.cs
+++ b/test/RachisTests/DatabaseCluster/ClusterDatabaseMaintenance.cs
@@ -609,7 +609,7 @@ namespace RachisTests.DatabaseCluster
         {
             var fromSeconds = TimeSpan.FromSeconds(8);
 
-            var databaseName = "ChangeUrlOfMultiNodeCluster" + Guid.NewGuid();
+            var databaseName = GetDatabaseName();
             var groupSize = 3;
             var newUrl = "http://" + Environment.MachineName + ":8080";
             string nodeTag;
@@ -658,8 +658,10 @@ namespace RachisTests.DatabaseCluster
             Assert.True(await leader.ServerStore.AddNodeToClusterAsync(Servers[1].ServerStore.GetNodeHttpServerUrl(), nodeTag).WaitAsync(fromSeconds));
             Assert.True(await Servers[1].ServerStore.WaitForState(RachisState.Follower, CancellationToken.None).WaitAsync(fromSeconds));
 
-            // create a new database and verify that it resids on the server with the new url
-            var (_, dbGroupNodes) = await CreateDatabaseInCluster("new" + databaseName, groupSize, leader.WebUrl);
+            Assert.Equal(3, WaitForValue(() => leader.ServerStore.GetClusterTopology().Members.Count, 3));
+
+            // create a new database and verify that it resides on the server with the new url
+            var (_, dbGroupNodes) = await CreateDatabaseInCluster(GetDatabaseName(), groupSize, leader.WebUrl);
             Assert.True(dbGroupNodes.Select(s => s.WebUrl).Contains(newUrl));
             
         }


### PR DESCRIPTION
- Create database from non-leader node resulted in an error.
- Fixing race on putting new _debugRecorder in the Follower Ambassador.
- Fixing tests.