### PR TITLE
[4.0] RavenDB-11015 Verify cluster behavior on node removal

### DIFF
--- a/src/Raven.Server/ServerWide/ClusterStateMachine.cs
+++ b/src/Raven.Server/ServerWide/ClusterStateMachine.cs
@@ -427,12 +427,6 @@ namespace Raven.Server.ServerWide
                         }
                     }
 
-                    if (_parent.Tag == removed)
-                    {
-                        //If no deletion was issued, then the removed node will keep all his data until either he will be bootstrapped or rejoined with the cluster.
-                        continue;
-                    }
-
                     if (record.Topology.RelevantFor(removed))
                     {
                         record.Topology.RemoveFromTopology(removed);

--- a/test/RachisTests/AddNodeToClusterTests.cs
+++ b/test/RachisTests/AddNodeToClusterTests.cs
@@ -164,8 +164,7 @@ namespace RachisTests
                 Assert.True(WaitForDocument<User>(watcherStore, "users/3", u => u.Name == "Karmel3", 30_000));
 
                 // rejoin the node
-                var newLeader = Servers.Single(s => s.ServerStore.IsLeader());
-                Assert.True(await newLeader.ServerStore.AddNodeToClusterAsync(responsibleServer.WebUrl, watcherRes.ResponsibleNode).WaitAsync(fromSeconds));
+                var newLeader = await ActionWithLeader(l => l.ServerStore.AddNodeToClusterAsync(responsibleServer.WebUrl, watcherRes.ResponsibleNode));
                 Assert.True(await responsibleServer.ServerStore.WaitForState(RachisState.Follower, CancellationToken.None).WaitAsync(fromSeconds));
 
                 using (var newLeaderStore = new DocumentStore


### PR DESCRIPTION
Addressing a race when rejoining a removed node.
In case that the cluster hasn't truncated its log, rejoinig the node would result in a different state on the nodes.
Since the leader wouldn't send 'install snapshot' to override the existing state.
But instead it would send the missing entries to the node.