### PR TITLE
[4.1] RavenDB-11015 Removed node will truncate his log to the index of the …

### DIFF
--- a/src/Raven.Server/Rachis/Follower.cs
+++ b/src/Raven.Server/Rachis/Follower.cs
@@ -251,7 +251,8 @@ namespace Raven.Server.Rachis
 
                 if (entries.Count > 0)
                 {
-                    using (var lastTopology = _engine.AppendToLog(context, entries))
+                    var (lastTopology, lastTopologyIndex) = _engine.AppendToLog(context, entries);
+                    using (lastTopology)
                     {
                         if (lastTopology != null)
                         {
@@ -270,17 +271,17 @@ namespace Raven.Server.Rachis
                             else
                             {
                                 removedFromTopology = true;
+                                _engine.ClearAppendedEntriesAfter(context, lastTopologyIndex);
                             }
                         }
                     }
                 }
 
                 lastLogIndex = _engine.GetLastEntryIndex(context);
-
+               
                 var lastEntryIndexToCommit = Math.Min(
                     lastLogIndex,
                     appendEntries.LeaderCommit);
-
 
                 var lastAppliedIndex = _engine.GetLastCommitIndex(context);
 
@@ -291,6 +292,7 @@ namespace Raven.Server.Rachis
 
                 lastTruncate = Math.Min(appendEntries.TruncateLogBefore, lastAppliedIndex);
                 _engine.TruncateLogBefore(context, lastTruncate);
+
                 lastCommit = lastEntryIndexToCommit;
                 if (_engine.Log.IsInfoEnabled)
                 {
@@ -394,7 +396,7 @@ namespace Raven.Server.Rachis
                     LastLogIndex = negotiation.PrevLogIndex
                 });
             }
-            _debugRecorder.Record("Matching Negotiation is over, wating for snapshot");
+            _debugRecorder.Record("Matching Negotiation is over, waiting for snapshot");
             _engine.Timeout.Defer(_connection.Source);
 
             // at this point, the leader will send us a snapshot message
@@ -413,7 +415,7 @@ namespace Raven.Server.Rachis
                         _engine.Log.Info(
                             $"{ToString()}: Got installed snapshot with last index={snapshot.LastIncludedIndex} while our lastCommitIndex={lastCommitIndex}, will just ignore it");
                     }
-                    //This is okay to ignore because we will just get the commited entries again and skip them
+                    //This is okay to ignore because we will just get the committed entries again and skip them
                     ReadInstallSnapshotAndIgnoreContent(context);
                 }
                 else if (InstallSnapshot(context))

--- a/src/Raven.Server/Rachis/RachisConsensus.cs
+++ b/src/Raven.Server/Rachis/RachisConsensus.cs
@@ -1165,7 +1165,7 @@ namespace Raven.Server.Rachis
             }
         }
 
-        public unsafe BlittableJsonReaderObject AppendToLog(TransactionOperationContext context,
+        public unsafe (BlittableJsonReaderObject LastTopology, long LastTopologyIndex) AppendToLog(TransactionOperationContext context,
             List<RachisEntry> entries)
         {
             Debug.Assert(entries.Count > 0);
@@ -1173,7 +1173,7 @@ namespace Raven.Server.Rachis
             var table = context.Transaction.InnerTransaction.OpenTable(LogsTable, EntriesSlice);
 
             long reversedEntryIndex = -1;
-
+            long lastTopologyIndex = -1;
             BlittableJsonReaderObject lastTopology = null;
 
             using (
@@ -1202,8 +1202,9 @@ namespace Raven.Server.Rachis
 
                     firstIndexInEntriesThatWeHaveNotSeen++;
                 }
+
                 if (firstIndexInEntriesThatWeHaveNotSeen >= entries.Count)
-                    return null; // we have all of those entries in our log, so we can safely ignore them
+                    return (null, lastTopologyIndex); // we have all of those entries in our log, so we can safely ignore them
 
                 var firstEntry = entries[firstIndexInEntriesThatWeHaveNotSeen];
                 //While we do support the case where we get the same entries, we expect them to have the same index/term up to the commit index.
@@ -1257,6 +1258,7 @@ namespace Raven.Server.Rachis
                     {
                         lastTopology?.Dispose();
                         lastTopology = nested;
+                        lastTopologyIndex = entry.Index;
                     }
                     else
                     {
@@ -1264,7 +1266,7 @@ namespace Raven.Server.Rachis
                     }
                 }
             }
-            return lastTopology;
+            return (lastTopology, lastTopologyIndex);
         }
 
         private void ThrowFatalError(RachisEntry firstEntry, long lastCommitIndex, long lastCommitTerm)
@@ -1851,6 +1853,16 @@ namespace Raven.Server.Rachis
         public void LeaderElectToLeaderChanged()
         {
             LeaderElected?.Invoke(null, null);
+        }
+
+        public unsafe void ClearAppendedEntriesAfter(TransactionOperationContext context, long index)
+        {
+            var table = context.Transaction.InnerTransaction.OpenTable(LogsTable, EntriesSlice);
+            var reversedEntryIndex = Bits.SwapBytes(index);
+            using (Slice.External(context.Transaction.InnerTransaction.Allocator, (byte*)&reversedEntryIndex, sizeof(long), out Slice key))
+            {
+                table.DeleteByPrimaryKey(key, _ => true);
+            }
         }
     }
 

--- a/src/Raven.Server/ServerWide/Maintenance/ClusterMaintenanceSupervisor.cs
+++ b/src/Raven.Server/ServerWide/Maintenance/ClusterMaintenanceSupervisor.cs
@@ -140,7 +140,29 @@ namespace Raven.Server.ServerWide.Maintenance
 
             public void Start()
             {
-                _maintenanceTask = PoolOfThreads.GlobalRavenThreadPool.LongRunning(x => ListenToMaintenanceWorker(), null, _name);
+                _maintenanceTask = PoolOfThreads.GlobalRavenThreadPool.LongRunning(_ =>
+                {
+                    try
+                    {
+                        ListenToMaintenanceWorker();
+                    }
+                    catch (ObjectDisposedException)
+                    {
+                        // expected
+                    }
+                    catch (OperationCanceledException)
+                    {
+                        // expected
+                    }
+                    catch (Exception e)
+                    {
+                        if (_log.IsInfoEnabled)
+                        {
+                            _log.Info($"Exception occurred while collecting info from {ClusterTag}. Task is closed.", e);
+                        }
+                        // we don't want to crash the process so we don't propagate this exception.
+                    }
+                }, null, _name);
             }
 
             private void ListenToMaintenanceWorker()

--- a/test/RachisTests/DatabaseCluster/RemoveNodeFromCluster.cs
+++ b/test/RachisTests/DatabaseCluster/RemoveNodeFromCluster.cs
@@ -184,7 +184,7 @@ namespace RachisTests.DatabaseCluster
                     await session.SaveChangesAsync();
                 }
 
-                await firstLeader.ServerStore.RemoveFromClusterAsync(removed.ServerStore.NodeTag);
+                await ActionWithLeader(l => l.ServerStore.RemoveFromClusterAsync(removed.ServerStore.NodeTag));
                 Assert.True(await removed.ServerStore.WaitForState(RachisState.Passive, CancellationToken.None).WaitAsync(TimeSpan.FromSeconds(30)),
                     "Removed node wasn't move to passive state.");
 


### PR DESCRIPTION
…last topology.

- Also prevent from the process to crash on maintenance exception.