### PR TITLE
[4.1] RavenDB-11452

### DIFF
--- a/src/Raven.Client/Documents/Session/AsyncDocumentSession.Load.cs
+++ b/src/Raven.Client/Documents/Session/AsyncDocumentSession.Load.cs
@@ -4,7 +4,6 @@ using System.IO;
 using System.Linq;
 using System.Threading;
 using System.Threading.Tasks;
-using Raven.Client.Documents.Commands;
 using Raven.Client.Documents.Session.Loaders;
 using Raven.Client.Documents.Session.Operations;
 
@@ -13,8 +12,11 @@ namespace Raven.Client.Documents.Session
     public partial class AsyncDocumentSession
     {
         /// <inheritdoc />
-        public async Task<T> LoadAsync<T>(string id, CancellationToken token = default(CancellationToken))
+        public async Task<T> LoadAsync<T>(string id, CancellationToken token = default)
         {
+            if (id == null)
+                return default;
+
             var loadOperation = new LoadOperation(this);
             loadOperation.ById(id);
 
@@ -28,25 +30,38 @@ namespace Raven.Client.Documents.Session
             return loadOperation.GetDocument<T>();
         }
 
-        public async Task<Dictionary<string, T>> LoadAsync<T>(IEnumerable<string> ids,
-            CancellationToken token = default(CancellationToken))
+        /// <inheritdoc />
+        public async Task<Dictionary<string, T>> LoadAsync<T>(IEnumerable<string> ids, CancellationToken token = default)
         {
+            if (ids == null)
+                throw new ArgumentNullException(nameof(ids));
+
             var loadOperation = new LoadOperation(this);
             await LoadAsyncInternal(ids.ToArray(), null, loadOperation, token).ConfigureAwait(false);
 
             return loadOperation.GetDocuments<T>();
         }
 
-        public async Task<T> LoadAsync<T>(string id, Action<IIncludeBuilder<T>> includes, CancellationToken token = default(CancellationToken))
+        /// <inheritdoc />
+        public async Task<T> LoadAsync<T>(string id, Action<IIncludeBuilder<T>> includes, CancellationToken token = default)
         {
-            var result = await LoadAsync(new[] {id}, includes, token).ConfigureAwait(false);
+            if (id == null)
+                return default;
+
+            var result = await LoadAsync(new[] { id }, includes, token).ConfigureAwait(false);
+
             return result.Values.FirstOrDefault();
         }
 
-        public Task<Dictionary<string, T>> LoadAsync<T>(IEnumerable<string> ids, Action<IIncludeBuilder<T>> includes, CancellationToken token = default(CancellationToken))
+        /// <inheritdoc />
+        public Task<Dictionary<string, T>> LoadAsync<T>(IEnumerable<string> ids, Action<IIncludeBuilder<T>> includes, CancellationToken token = default)
         {
+            if (ids == null)
+                throw new ArgumentNullException(nameof(ids));
+
             if (includes == null)
                 return LoadAsync<T>(ids, token);
+
             var includeBuilder = new IncludeBuilder<T>(Conventions);
             includes.Invoke(includeBuilder);
 
@@ -58,29 +73,16 @@ namespace Raven.Client.Documents.Session
                 token);
         }
 
-        public async Task<Dictionary<string, T>> LoadAsyncInternal<T>(string[] ids, string[] includes,
-            CancellationToken token = new CancellationToken())
+        /// <inheritdoc />
+        public async Task<Dictionary<string, T>> LoadAsyncInternal<T>(string[] ids, string[] includes, string[] counters = null, bool includeAllCounters = false, CancellationToken token = new CancellationToken())
         {
+            if (ids == null)
+                throw new ArgumentNullException(nameof(ids));
+
             var loadOperation = new LoadOperation(this);
             loadOperation.ByIds(ids);
-            loadOperation.WithIncludes(includes?.ToArray());
+            loadOperation.WithIncludes(includes);
 
-            var command = loadOperation.CreateRequest();
-            if (command != null)
-            {
-                await RequestExecutor.ExecuteAsync(command, Context, SessionInfo, token).ConfigureAwait(false);
-                loadOperation.SetResult(command.Result);
-            }
-
-            return loadOperation.GetDocuments<T>();
-        }
-
-        public async Task<Dictionary<string, T>> LoadAsyncInternal<T>(string[] ids, string[] includes,
-            string[] counters, bool includeAllCounters, CancellationToken token = new CancellationToken())
-        {
-            var loadOperation = new LoadOperation(this);
-            loadOperation.ByIds(ids);
-            loadOperation.WithIncludes(includes?.ToArray());
             if (includeAllCounters)
             {
                 loadOperation.WithAllCounters();
@@ -93,16 +95,22 @@ namespace Raven.Client.Documents.Session
             var command = loadOperation.CreateRequest();
             if (command != null)
             {
-                await RequestExecutor.ExecuteAsync(command, Context, SessionInfo, token).ConfigureAwait(false);
+                await RequestExecutor.ExecuteAsync(command, Context, sessionInfo: SessionInfo, token: token).ConfigureAwait(false);
                 loadOperation.SetResult(command.Result);
             }
 
             return loadOperation.GetDocuments<T>();
         }
 
-        public async Task<IEnumerable<T>> LoadStartingWithAsync<T>(string idPrefix, string matches = null, int start = 0,
-            int pageSize = 25, string exclude = null,
-            string startAfter = null, CancellationToken token = default(CancellationToken))
+        /// <inheritdoc />
+        public async Task<IEnumerable<T>> LoadStartingWithAsync<T>(
+            string idPrefix,
+            string matches = null,
+            int start = 0,
+            int pageSize = 25,
+            string exclude = null,
+            string startAfter = null,
+            CancellationToken token = default)
         {
             var operation = new LoadStartingWithOperation(this);
             await LoadStartingWithInternal(idPrefix, operation, null, matches, start,
@@ -111,18 +119,48 @@ namespace Raven.Client.Documents.Session
             return operation.GetDocuments<T>();
         }
 
-        public async Task LoadStartingWithIntoStreamAsync(string idPrefix, Stream output, string matches = null, int start = 0,
-            int pageSize = 25, string exclude = null, string startAfter = null, CancellationToken token = default(CancellationToken))
+        /// <inheritdoc />
+        public async Task LoadStartingWithIntoStreamAsync(
+            string idPrefix,
+            Stream output,
+            string matches = null,
+            int start = 0,
+            int pageSize = 25,
+            string exclude = null,
+            string startAfter = null,
+            CancellationToken token = default)
         {
-            await LoadStartingWithInternal(idPrefix, new LoadStartingWithOperation(this), output, matches, start,
-                pageSize, exclude,  startAfter, token).ConfigureAwait(false);
+            if (output == null)
+                throw new ArgumentNullException(nameof(output));
+
+            await LoadStartingWithInternal(idPrefix, new LoadStartingWithOperation(this), output, matches, start, pageSize, exclude, startAfter, token).ConfigureAwait(false);
         }
 
-
-        private async Task<GetDocumentsCommand> LoadStartingWithInternal(string idPrefix, LoadStartingWithOperation operation, Stream stream = null, string matches = null,
-            int start = 0, int pageSize = 25, string exclude = null, 
-            string startAfter = null, CancellationToken token = default(CancellationToken))
+        /// <inheritdoc />
+        public async Task LoadIntoStreamAsync(IEnumerable<string> ids, Stream output, CancellationToken token = default)
         {
+            if (ids == null)
+                throw new ArgumentNullException(nameof(ids));
+            if (output == null)
+                throw new ArgumentNullException(nameof(output));
+
+            await LoadAsyncInternal(ids.ToArray(), output, new LoadOperation(this), token).ConfigureAwait(false);
+        }
+
+        private async Task LoadStartingWithInternal(
+            string idPrefix,
+            LoadStartingWithOperation operation,
+            Stream stream = null,
+            string matches = null,
+            int start = 0,
+            int pageSize = 25,
+            string exclude = null,
+            string startAfter = null,
+            CancellationToken token = default)
+        {
+            if (idPrefix == null)
+                throw new ArgumentNullException(nameof(idPrefix));
+
             operation.WithStartWith(idPrefix, matches, start, pageSize, exclude, startAfter);
 
             var command = operation.CreateRequest();
@@ -135,13 +173,13 @@ namespace Raven.Client.Documents.Session
                 else
                     operation.SetResult(command.Result);
             }
-
-            return command;
         }
 
-        private async Task LoadAsyncInternal(string[] ids, Stream stream, LoadOperation operation,
-            CancellationToken token = default(CancellationToken))
+        private async Task LoadAsyncInternal(string[] ids, Stream stream, LoadOperation operation, CancellationToken token = default)
         {
+            if (ids == null)
+                throw new ArgumentNullException(nameof(ids));
+
             operation.ByIds(ids);
 
             var command = operation.CreateRequest();
@@ -154,11 +192,6 @@ namespace Raven.Client.Documents.Session
                 else
                     operation.SetResult(command.Result);
             }
-        }
-
-        public async Task LoadIntoStreamAsync(IEnumerable<string> ids, Stream output ,CancellationToken token = default(CancellationToken))
-        {
-            await LoadAsyncInternal(ids.ToArray(), output, new LoadOperation(this), token).ConfigureAwait(false);
         }
     }
 }

--- a/src/Raven.Client/Documents/Session/IAsyncDocumentSessionImpl.cs
+++ b/src/Raven.Client/Documents/Session/IAsyncDocumentSessionImpl.cs
@@ -20,9 +20,9 @@ namespace Raven.Client.Documents.Session
     {
         DocumentConventions Conventions { get; }
 
-        Task<Dictionary<string, T>> LoadAsyncInternal<T>(string[] ids, string[] includes, CancellationToken token = default (CancellationToken));
+        Task<Dictionary<string, T>> LoadAsyncInternal<T>(string[] ids, string[] includes, string[] counters = null, bool includeAllCounters = false, CancellationToken token = default);
 
-        Lazy<Task<Dictionary<string, T>>> LazyAsyncLoadInternal<T>(string[] ids, string[] includes, Action<Dictionary<string, T>> onEval, CancellationToken token = default (CancellationToken));
+        Lazy<Task<Dictionary<string, T>>> LazyAsyncLoadInternal<T>(string[] ids, string[] includes, Action<Dictionary<string, T>> onEval, CancellationToken token = default);
 
     }
 }

--- a/src/Raven.Client/Documents/Session/IDocumentSessionImpl.cs
+++ b/src/Raven.Client/Documents/Session/IDocumentSessionImpl.cs
@@ -17,7 +17,9 @@ namespace Raven.Client.Documents.Session
     internal interface IDocumentSessionImpl : IDocumentSession, ILazySessionOperations, IEagerSessionOperations
     {
         DocumentConventions Conventions { get; }
+
         Dictionary<string, T> LoadInternal<T>(string[] ids, string[] includes, string[] counters = null, bool includeAllCounters = false);
+
         Lazy<Dictionary<string, T>> LazyLoadInternal<T>(string[] ids, string[] includes, Action<Dictionary<string, T>> onEval);
     }
 }

--- a/src/Raven.Client/Documents/Session/Loaders/AsyncMultiLoaderWithInclude.cs
+++ b/src/Raven.Client/Documents/Session/Loaders/AsyncMultiLoaderWithInclude.cs
@@ -88,7 +88,7 @@ namespace Raven.Client.Documents.Session.Loaders
         /// <returns></returns>
         public Task<Dictionary<string, T>> LoadAsync(IEnumerable<string> ids, CancellationToken token = default)
         {
-            return _session.LoadAsyncInternal<T>(ids.ToArray(), _includes.ToArray(), token);
+            return _session.LoadAsyncInternal<T>(ids.ToArray(), _includes.ToArray(), token: token);
         }
 
         /// <summary>
@@ -98,7 +98,7 @@ namespace Raven.Client.Documents.Session.Loaders
         /// <returns></returns>
         public Task<T> LoadAsync(string id, CancellationToken token = default)
         {
-            return _session.LoadAsyncInternal<T>(new[] { id }, _includes.ToArray(), token).ContinueWith(x => x.Result.Values.FirstOrDefault(), token);
+            return _session.LoadAsyncInternal<T>(new[] { id }, _includes.ToArray(), token: token).ContinueWith(x => x.Result.Values.FirstOrDefault(), token);
         }
 
         /// <summary>
@@ -127,7 +127,7 @@ namespace Raven.Client.Documents.Session.Loaders
         /// <returns></returns>
         public Task<Dictionary<string, TResult>> LoadAsync<TResult>(IEnumerable<string> ids, CancellationToken token = default)
         {
-            return _session.LoadAsyncInternal<TResult>(ids.ToArray(), _includes.ToArray(), token);
+            return _session.LoadAsyncInternal<TResult>(ids.ToArray(), _includes.ToArray(), token: token);
         }
 
         /// <summary>

--- a/test/SlowTests/Issues/RavenDB_11452.cs
+++ b/test/SlowTests/Issues/RavenDB_11452.cs
@@ -1,0 +1,21 @@
+﻿using System.Threading.Tasks;
+using FastTests;
+using Xunit;
+
+namespace SlowTests.Issues
+{
+    public class RavenDB_11452 : RavenTestBase
+    {
+        [Fact]
+        public async Task ShouldNotThrow()
+        {
+            using (var store = GetDocumentStore())
+            {
+                using (var session = store.OpenAsyncSession())
+                {
+                    await session.LoadAsync<object>((string)null);
+                }
+            }
+        }
+    }
+}


### PR DESCRIPTION
- AsyncDocumentSession.LoadAsync should return default(T) when id is null to match sync session behavior
- added various null argument checks
- synchronized AsyncDocumentSession.Load and DocumentSession.Load implementations