### PR TITLE
[4.0] RavenDB-11423 Allow to reset index with 'Output reduce to the collect…

### DIFF
--- a/src/Raven.Server/Documents/Indexes/IndexStore.cs
+++ b/src/Raven.Server/Documents/Indexes/IndexStore.cs
@@ -822,7 +822,7 @@ namespace Raven.Server.Documents.Indexes
                             index = MapIndex.CreateNew(staticIndexDefinition, _documentDatabase);
                             break;
                         case IndexType.MapReduce:
-                            index = MapReduceIndex.CreateNew(staticIndexDefinition, _documentDatabase);
+                            index = MapReduceIndex.CreateNew(staticIndexDefinition, _documentDatabase, isIndexReset: true);
                             break;
                         default:
                             throw new NotSupportedException($"Cannot create {staticIndexDefinition.Type} index from IndexDefinition");
@@ -835,13 +835,11 @@ namespace Raven.Server.Documents.Indexes
             }
             catch (TimeoutException toe)
             {
-                throw new IndexCreationException($"Failed to reset index: {index.Name}, the cluster is probably down. " +
-                                                 $"Node {_serverStore.NodeTag} state is {_serverStore.LastStateChangeReason()}", toe);
+                throw new IndexCreationException($"Failed to reset index: {index.Name}", toe);
             }
             catch (Exception e)
             {
-                throw new IndexCreationException($"Failed to reset index: {index.Name}, unexpected error during index creation. " +
-                                                 $"Node {_serverStore.NodeTag} state is {_serverStore.LastStateChangeReason()}", e);
+                throw new IndexCreationException($"Failed to reset index: {index.Name}", e);
             }
         }
 

--- a/src/Raven.Server/Documents/Indexes/MapReduce/Static/MapReduceIndex.cs
+++ b/src/Raven.Server/Documents/Indexes/MapReduce/Static/MapReduceIndex.cs
@@ -65,10 +65,10 @@ namespace Raven.Server.Documents.Indexes.MapReduce.Static
             _mre.Set();
         }
 
-        public static MapReduceIndex CreateNew(IndexDefinition definition, DocumentDatabase documentDatabase)
+        public static MapReduceIndex CreateNew(IndexDefinition definition, DocumentDatabase documentDatabase, bool isIndexReset = false)
         {
             var instance = CreateIndexInstance(definition);
-            ValidateReduceResultsCollectionName(definition, instance._compiled, documentDatabase);
+            ValidateReduceResultsCollectionName(definition, instance._compiled, documentDatabase, isIndexReset);
 
             instance.Initialize(documentDatabase,
                 new SingleIndexConfiguration(definition.Configuration, documentDatabase.Configuration),
@@ -77,7 +77,7 @@ namespace Raven.Server.Documents.Indexes.MapReduce.Static
             return instance;
         }
 
-        public static void ValidateReduceResultsCollectionName(IndexDefinition definition, StaticIndexBase index, DocumentDatabase database)
+        public static void ValidateReduceResultsCollectionName(IndexDefinition definition, StaticIndexBase index, DocumentDatabase database, bool isIndexReset = false)
         {
             var outputReduceToCollection = definition.OutputReduceToCollection;
             if (string.IsNullOrWhiteSpace(outputReduceToCollection))
@@ -148,16 +148,19 @@ namespace Raven.Server.Documents.Indexes.MapReduce.Static
                 }
             }
 
-            using (database.DocumentsStorage.ContextPool.AllocateOperationContext(out DocumentsOperationContext context))
-            using (context.OpenReadTransaction())
+            if (isIndexReset == false)
             {
-                var stats = database.DocumentsStorage.GetCollection(outputReduceToCollection, context);
-                if (stats.Count > 0)
+                using (database.DocumentsStorage.ContextPool.AllocateOperationContext(out DocumentsOperationContext context))
+                using (context.OpenReadTransaction())
                 {
-                    throw new IndexInvalidException($"In order to create the '{definition.Name}' index " +
-                                                    $"which would output reduce results to documents in the '{outputReduceToCollection}' collection, " +
-                                                    $"you firstly need to delete all of the documents in the '{stats.Name}' collection " +
-                                                    $"(currently have {stats.Count} document{(stats.Count == 1 ? "" : "s")}).");
+                    var stats = database.DocumentsStorage.GetCollection(outputReduceToCollection, context);
+                    if (stats.Count > 0)
+                    {
+                        throw new IndexInvalidException($"In order to create the '{definition.Name}' index " +
+                                                        $"which would output reduce results to documents in the '{outputReduceToCollection}' collection, " +
+                                                        $"you firstly need to delete all of the documents in the '{stats.Name}' collection " +
+                                                        $"(currently have {stats.Count} document{(stats.Count == 1 ? "" : "s")}).");
+                    }
                 }
             }
         }


### PR DESCRIPTION
…ion' . Removing cluster status from index reset errors as it isn't cluster wide operation.