### PR TITLE
[4.0] RavenDB-11015 The leader can't remove himself from the cluster

### DIFF
--- a/src/Raven.Server/Rachis/Exceptions.cs
+++ b/src/Raven.Server/Rachis/Exceptions.cs
@@ -37,6 +37,26 @@ namespace Raven.Server.Rachis
         }
     }
 
+    public class RachisTopologyChangeException : RachisException
+    {
+        protected RachisTopologyChangeException()
+        {
+        }
+
+        protected RachisTopologyChangeException(string message) : base(message)
+        {
+        }
+
+        protected RachisTopologyChangeException(string message, Exception innerException) : base(message, innerException)
+        {
+        }
+
+        public static void Throw(string msg)
+        {
+            throw new RachisTopologyChangeException(msg);
+        }
+    }
+
     public class RachisConcurrencyException : RachisException
     {
         public RachisConcurrencyException()

--- a/src/Raven.Server/Rachis/Leader.cs
+++ b/src/Raven.Server/Rachis/Leader.cs
@@ -823,6 +823,9 @@ namespace Raven.Server.Rachis
 
                     var highestNodeId = newVotes.Keys.Concat(newPromotables.Keys).Concat(newNonVotes.Keys).Concat(new[] {nodeTag}).Max();
 
+                    if (nodeTag == _engine.Tag)
+                        RachisTopologyChangeException.Throw("Cannot modify the topology of the leader node.");
+
                     switch (modification)
                     {
                         case TopologyModification.Voter:

--- a/src/Raven.Server/ServerWide/ClusterStateMachine.cs
+++ b/src/Raven.Server/ServerWide/ClusterStateMachine.cs
@@ -793,14 +793,7 @@ namespace Raven.Server.ServerWide
                 RemovedNode = nodeTag
             }.ToJson(context);
 
-            var index = _parent.InsertToLeaderLog(context, term, context.ReadObject(djv, "remove"), RachisEntryFlags.StateMachineCommand);
-            context.Transaction.InnerTransaction.LowLevelTransaction.OnDispose += tx =>
-            {
-                if (tx is LowLevelTransaction llt && llt.Committed)
-                {
-                    _parent.CurrentLeader.AddToEntries(index, null);
-                }
-            };
+            _parent.InsertToLeaderLog(context, term, context.ReadObject(djv, "remove"), RachisEntryFlags.StateMachineCommand);
         }
 
         private void NotifyValueChanged(TransactionOperationContext context, string type, long index)


### PR DESCRIPTION
If we try to remove it form the endpoint, we will stepdown first and let the new leader to remove that node.