### PR TITLE
RavenDB-11477

### DIFF
--- a/src/Raven.Server/Config/RavenConfiguration.cs
+++ b/src/Raven.Server/Config/RavenConfiguration.cs
@@ -186,8 +186,6 @@ namespace Raven.Server.Config
 
         public void PostInit()
         {
-            CheckDirectoryPermissions();
-
             if (ResourceType != ResourceType.Server)
                 return;
 
@@ -339,7 +337,7 @@ namespace Raven.Server.Config
         
         private static int _pathCounter = 0;
 
-        private void CheckDirectoryPermissions()
+        public void CheckDirectoryPermissions()
         {
             if (Core.RunInMemory)
                 return;
@@ -391,7 +389,7 @@ namespace Raven.Server.Config
                             var curPathCounterVal = Interlocked.Increment(ref _pathCounter);
                             // test that we can create the directory, but
                             // not actually create it
-                            createdDirectory = path + curPathCounterVal.ToString();
+                            createdDirectory = path + "$" + curPathCounterVal.ToString();
                             Directory.CreateDirectory(createdDirectory);
                             var createdFile = Path.Combine(createdDirectory, "test.file");
                             File.WriteAllText(createdFile, string.Empty);

--- a/src/Raven.Server/Documents/DocumentDatabase.cs
+++ b/src/Raven.Server/Documents/DocumentDatabase.cs
@@ -225,6 +225,8 @@ namespace Raven.Server.Documents
         {
             try
             {
+                Configuration.CheckDirectoryPermissions();
+
                 _addToInitLog("Initializing NotificationCenter");
                 NotificationCenter.Initialize(this);
 

--- a/src/Raven.Server/Documents/Handlers/Admin/RachisAdminHandler.cs
+++ b/src/Raven.Server/Documents/Handlers/Admin/RachisAdminHandler.cs
@@ -63,6 +63,7 @@ namespace Raven.Server.Documents.Handlers.Admin
                         {
                             ServerStore.AssignNodesToDatabase(ServerStore.GetClusterTopology(), addDatabase.Record);
                         }
+                        Debug.Assert(addDatabase.Record.Topology.Count != 0, "Empty topology after AssignNodesToDatabase");
                         break;
                     case AddOrUpdateCompareExchangeBatchCommand batchCmpExchange:
                         batchCmpExchange.ContextToWriteResult = context;

--- a/src/Raven.Server/Rachis/RachisConsensus.cs
+++ b/src/Raven.Server/Rachis/RachisConsensus.cs
@@ -634,7 +634,6 @@ namespace Raven.Server.Rachis
             
             PrevStates.LimitedSizeEnqueue(transition, 5);
 
-            CurrentState = rachisState;
 
             context.Transaction.InnerTransaction.LowLevelTransaction.OnDispose += tx =>
             {
@@ -651,6 +650,8 @@ namespace Raven.Server.Rachis
                             Log.Info("Before state change invocation function failed.", e);
                         }
                     }
+
+                    CurrentState = rachisState;
 
                     try
                     {

--- a/src/Raven.Server/ServerWide/ClusterStateMachine.cs
+++ b/src/Raven.Server/ServerWide/ClusterStateMachine.cs
@@ -660,6 +660,7 @@ namespace Raven.Server.ServerWide
             var addDatabaseCommand = JsonDeserializationCluster.AddDatabaseCommand(cmd);
             try
             {
+                Debug.Assert(addDatabaseCommand.Record.Topology.Count != 0, "Attempt to add database with no nodes");
                 var items = context.Transaction.InnerTransaction.OpenTable(ItemsSchema, Items);
                 using (Slice.From(context.Allocator, "db/" + addDatabaseCommand.Name, out Slice valueName))
                 using (Slice.From(context.Allocator, "db/" + addDatabaseCommand.Name.ToLowerInvariant(), out Slice valueNameLowered))

--- a/test/FastTests/Blittable/PeepingTomTest.cs
+++ b/test/FastTests/Blittable/PeepingTomTest.cs
@@ -97,10 +97,17 @@ namespace FastTests.Blittable
 
                     for (var i = 0; i < peepWindow.Length; i++)
                     {
-                        var expectedByte = (byte)(((originalSize - peepWindow.Length + i) % 26) + 'a');
-                        if (expectedByte != peepWindow[i])
+                        try
                         {
-                            Assert.Equal(expectedByte, peepWindow[i]);
+                            var expectedByte = (byte)(((originalSize - peepWindow.Length + i) % 26) + 'a');
+                            if (expectedByte != peepWindow[i])
+                            {
+                                Assert.Equal(expectedByte, peepWindow[i]);
+                            }
+                        }
+                        catch (Exception e)
+                        {
+                            throw new InvalidOperationException("Failure at index: " + i, e);
                         }
                     }
                 }

--- a/test/FastTests/Client/Subscriptions/SubscriptionsBasic.cs
+++ b/test/FastTests/Client/Subscriptions/SubscriptionsBasic.cs
@@ -506,7 +506,8 @@ namespace FastTests.Client.Subscriptions
 
                 notThrowingSubscriptionWorker = store.Subscriptions.GetSubscriptionWorker(new SubscriptionWorkerOptions(id)
                 {
-                    TimeToWaitBeforeConnectionRetry = TimeSpan.FromSeconds(5)
+                    TimeToWaitBeforeConnectionRetry = TimeSpan.FromSeconds(5),
+                    Strategy = SubscriptionOpeningStrategy.WaitForFree
                 });
 
                 t = notThrowingSubscriptionWorker.Run(x =>

--- a/test/SlowTests/Server/Documents/ETL/SQL/SqlEtlTests.cs
+++ b/test/SlowTests/Server/Documents/ETL/SQL/SqlEtlTests.cs
@@ -576,7 +576,10 @@ var nameArr = this.StepName.split('.'); loadToOrders({});");
                 {
                     var msg = "Could not process SQL Replication script for OrdersAndLines, skipping document: orders/1";
                     var tempFileName = Path.GetTempFileName();
-                    File.WriteAllText(tempFileName, sb.ToString());
+                    lock (sb)
+                    {
+                        File.WriteAllText(tempFileName, sb.ToString());
+                    }
                     throw new InvalidOperationException($"{msg}. Full log is: \r\n{tempFileName}");
                 }
             }

--- a/test/Tests.Infrastructure/RavenTestHelper.cs
+++ b/test/Tests.Infrastructure/RavenTestHelper.cs
@@ -37,7 +37,7 @@ namespace FastTests
         {
             testName = testName?.Replace("<", "").Replace(">", "");
 
-            var newDataDir = Path.GetFullPath($".\\Databases\\{testName ?? "TestDatabase"}_{serverPort}-{DateTime.Now:yyyy-MM-dd-HH-mm-ss-fff}-{Interlocked.Increment(ref _pathCount)}");
+            var newDataDir = Path.GetFullPath($".\\Databases\\{testName ?? "TestDatabase"}@{serverPort}-{Interlocked.Increment(ref _pathCount)}");
 
             if (PlatformDetails.RunningOnPosix)
                 newDataDir = PosixHelper.FixLinuxPath(newDataDir);


### PR DESCRIPTION
 - Better error if test fails
 - Avoid checking directory permissions outside a lock
 - Simplify database path names in tests
 - Fixes an issue where there was a race condition when updating the non passive state of the cluster node before the cluster transaction has been committed

RavenDB-11403
 - Fixing bad subscription mode causing the test to fail because it assumed drop connection is synchronous
 - Avoid race condition in the test