### PR TITLE
[4.1] RavenDB-11478 Check if we are not leaking servers or client tasks tha…

### DIFF
--- a/src/Raven.Client/Http/RequestExecutor.cs
+++ b/src/Raven.Client/Http/RequestExecutor.cs
@@ -328,14 +328,11 @@ namespace Raven.Client.Http
 
         protected void DisposeAllFailedNodesTimers()
         {
-            var oldFailedNodesTimers = _failedNodesTimers;
-            _failedNodesTimers.Clear();
-
-            foreach (var failedNodesTimers in oldFailedNodesTimers)
+            foreach (var failedNodesTimers in _failedNodesTimers)
             {
-                failedNodesTimers.Value.Dispose();
+                if (_failedNodesTimers.TryRemove(failedNodesTimers.Key, out var status))
+                    status.Dispose();
             }
-
         }
 
         public void Execute<TResult>(
@@ -1107,8 +1104,13 @@ namespace Raven.Client.Http
         private void SpawnHealthChecks(ServerNode chosenNode, int nodeIndex)
         {
             var nodeStatus = new NodeStatus(this, nodeIndex, chosenNode);
-            if (_failedNodesTimers.TryAdd(chosenNode, nodeStatus))
-                nodeStatus.StartTimer();
+
+            if (_failedNodesTimers.TryAdd(chosenNode, nodeStatus) == false)
+            {
+                nodeStatus.Dispose();
+            }
+
+            nodeStatus.StartTimer();
         }
 
         internal Task CheckNodeStatusNow(string tag)
@@ -1129,7 +1131,7 @@ namespace Raven.Client.Http
             }
 
             var nodeStatus = new NodeStatus(this, i, copy[i]);
-            return CheckNodeStatusCallback(nodeStatus);
+            return CheckNodeStatusCallback(nodeStatus).ContinueWith(t => nodeStatus.Dispose());
         }
 
         private async Task CheckNodeStatusCallback(NodeStatus nodeStatus)
@@ -1145,7 +1147,6 @@ namespace Raven.Client.Http
             {
                 using (ContextPool.AllocateOperationContext(out JsonOperationContext context))
                 {
-                    NodeStatus status;
                     try
                     {
                         await PerformHealthCheck(serverNode, nodeStatus.NodeIndex, context).ConfigureAwait(false);
@@ -1155,13 +1156,13 @@ namespace Raven.Client.Http
                         if (Logger.IsInfoEnabled)
                             Logger.Info($"{serverNode.ClusterTag} is still down", e);
 
-                        if (_failedNodesTimers.TryGetValue(nodeStatus.Node, out status))
+                        if (_failedNodesTimers.TryGetValue(nodeStatus.Node, out _))
                             nodeStatus.UpdateTimer();
 
                         return;// will wait for the next timer call
                     }
 
-                    if (_failedNodesTimers.TryRemove(nodeStatus.Node, out status))
+                    if (_failedNodesTimers.TryRemove(nodeStatus.Node, out var status))
                     {
                         status.Dispose();
                     }

--- a/test/SlowTests/Cluster/ClusterModesForRequestExecutorTest.cs
+++ b/test/SlowTests/Cluster/ClusterModesForRequestExecutorTest.cs
@@ -41,7 +41,7 @@ namespace SlowTests.Cluster
             {
                 Servers.Add(server);
 
-                var databaseName = "ProxyServer_should_work" + Guid.NewGuid();
+                var databaseName = GetDatabaseName();
                 using (var documentStore = new DocumentStore
                 {
                     Database = databaseName,
@@ -81,7 +81,7 @@ namespace SlowTests.Cluster
         public async Task Fastst_node_should_choose_the_node_without_delay()
         {
             NoTimeouts();
-            var databaseName = "Fastst_node_should_choose_the_node_without_delay" + Guid.NewGuid();
+            var databaseName = GetDatabaseName();
 
             var (leader, serversToProxies) = await CreateRaftClusterWithProxiesAndGetLeader(3);
             var followers = Servers.Where(x => x.ServerStore.IsLeader() == false).ToArray();
@@ -189,10 +189,10 @@ namespace SlowTests.Cluster
         [Fact]
         public async Task Round_robin_load_balancing_should_work()
         {
-            var databaseName = "Round_robin_load_balancing_should_work" + Guid.NewGuid();
+            var databaseName = GetDatabaseName();
             var leader = await CreateRaftClusterAndGetLeader(3);
             var followers = Servers.Where(x => x.ServerStore.IsLeader() == false).ToArray();
-
+            Console.WriteLine(leader.WebUrl);
             var conventionsForLoadBalancing = new DocumentConventions
             {
                 ReadBalanceBehavior = ReadBalanceBehavior.RoundRobin
@@ -232,7 +232,7 @@ namespace SlowTests.Cluster
                     ClusterTag = leader.ServerStore.NodeTag,
                     Database = databaseName,
                     Url = leader.WebUrl
-                },  5000);
+                },  5000, forceUpdate: true);
 
                 //wait until all nodes in database cluster are members (and not promotables)
                 //GetDatabaseTopologyCommand -> does not retrieve promotables
@@ -281,7 +281,7 @@ namespace SlowTests.Cluster
         [Fact]
         public async Task Round_robin_load_balancing_with_failing_node_should_work()
         {
-            var databaseName = "Round_robin_load_balancing_should_work" + Guid.NewGuid();
+            var databaseName = GetDatabaseName();
             var leader = await CreateRaftClusterAndGetLeader(3);
             var followers = Servers.Where(x => x.ServerStore.IsLeader() == false).ToArray();
 
@@ -289,7 +289,6 @@ namespace SlowTests.Cluster
             {
                 ReadBalanceBehavior = ReadBalanceBehavior.RoundRobin
             };
-
             using (var leaderStore = new DocumentStore
             {
                 Urls = new[] {leader.WebUrl},
@@ -345,26 +344,28 @@ namespace SlowTests.Cluster
                         leader.ServerStore.Configuration.Cluster.OperationTimeout.AsTimeSpan);
                 }
 
-                var requestExecutor = RequestExecutor.Create(follower1.Urls, databaseName, null, follower1.Conventions);
-                do //make sure there are three nodes in the topology
+                using (var requestExecutor = RequestExecutor.Create(follower1.Urls, databaseName, null, follower1.Conventions))
                 {
-                    await Task.Delay(100);
-                } while (requestExecutor.TopologyNodes == null);
-
-                DisposeServerAndWaitForFinishOfDisposal(leader);
-            
-                var failedRequests = new HashSet<(string, Exception)>();
-
-                requestExecutor.FailedRequest += (url, e) => failedRequests.Add((url, e));
-
-
-
-                using (var tmpContext = JsonOperationContext.ShortTermSingleUse())
-                {
-                    for (var sessionId = 0; sessionId < 5; sessionId++)
+                    do //make sure there are three nodes in the topology
                     {
-                        requestExecutor.Cache.Clear(); //make sure we do not use request cache
-                        await requestExecutor.ExecuteAsync(new GetStatisticsOperation().GetCommand(DocumentConventions.Default, tmpContext), tmpContext, new SessionInfo(sessionId, false));
+                        await Task.Delay(100);
+                    } while (requestExecutor.TopologyNodes == null);
+
+                    Console.WriteLine(requestExecutor.TopologyNodes.Count);
+
+                    DisposeServerAndWaitForFinishOfDisposal(leader);
+
+                    var failedRequests = new HashSet<(string, Exception)>();
+
+                    requestExecutor.FailedRequest += (url, e) => failedRequests.Add((url, e));
+
+                    using (var tmpContext = JsonOperationContext.ShortTermSingleUse())
+                    {
+                        for (var sessionId = 0; sessionId < 5; sessionId++)
+                        {
+                            requestExecutor.Cache.Clear(); //make sure we do not use request cache
+                            await requestExecutor.ExecuteAsync(new GetStatisticsOperation().GetCommand(DocumentConventions.Default, tmpContext), tmpContext, new SessionInfo(sessionId, false));
+                        }
                     }
                 }
             }
@@ -376,7 +377,7 @@ namespace SlowTests.Cluster
             //here we test that when choosing Fastest-Node as the ReadBalanceBehavior, 
             //we can execute commands that use a context, without it leading to a race condition 
 
-            var databaseName = "RavenDB_7992" + Guid.NewGuid();
+            var databaseName = GetDatabaseName();
             var leader = await CreateRaftClusterAndGetLeader(3);
 
             var conventionsForLoadBalancing = new DocumentConventions


### PR DESCRIPTION
…t are issuing request in a periodic manner

The issue was in Round_robin_load_balancing_with_failing_node_should_work (which had the same database name as the Round_robin_load_balancing_should_work test), that we haven't disposed the request executor.