### PR TITLE
[4.1] RavenDB-11489 Make sure tests use a unique temp path for the server c…

### DIFF
--- a/test/Tests.Infrastructure/TestBase.cs
+++ b/test/Tests.Infrastructure/TestBase.cs
@@ -122,15 +122,23 @@ namespace FastTests
         }
 
         protected static volatile string _selfSignedCertFileName;
+
         protected static string GenerateAndSaveSelfSignedCertificate()
         {
-            if (_selfSignedCertFileName != null)
-                return _selfSignedCertFileName;
+            if (_selfSignedCertFileName == null)
+                GenerateSelfSignedCertFileName();
 
+            var tmp = Path.GetTempFileName();
+            File.Copy(_selfSignedCertFileName, tmp, true);
+            return tmp;
+        }
+
+        private static void GenerateSelfSignedCertFileName()
+        {
             lock (typeof(TestBase))
             {
                 if (_selfSignedCertFileName != null)
-                    return _selfSignedCertFileName;
+                    return ;
 
                 var log = new StringBuilder();
                 byte[] certBytes;
@@ -171,7 +179,6 @@ namespace FastTests
                 }
 
                 _selfSignedCertFileName = tempFileName;
-                return tempFileName;
             }
         }
 


### PR DESCRIPTION
…ert so it cannot be overwritten by other parallel tests.