### PR TITLE
[v4.0] RavenDB-11465: Preventing race condition between one subscription finishing work and the other starting it...

### DIFF
--- a/src/Raven.Server/Documents/TcpHandlers/SubscriptionConnection.cs
+++ b/src/Raven.Server/Documents/TcpHandlers/SubscriptionConnection.cs
@@ -121,18 +121,17 @@ namespace Raven.Server.Documents.TcpHandlers
             _connectionState = TcpConnection.DocumentDatabase.SubscriptionStorage.OpenSubscription(this);
             var timeout = TimeSpan.FromMilliseconds(16);
             
-            bool shouldRetry;
-            bool waitedAnyTime = false;
+            bool shouldRetry = false;
+            
             do
             {
                 try
                 {
                     DisposeOnDisconnect = await _connectionState.RegisterSubscriptionConnection(this, timeout);
-                    shouldRetry = false;
+                    shouldRetry = false;                    
                 }
                 catch (TimeoutException)
-                {
-                    waitedAnyTime = true;
+                {                    
                     if (timeout == TimeSpan.Zero && _logger.IsInfoEnabled)
                     {
                         _logger.Info(
@@ -144,10 +143,11 @@ namespace Raven.Server.Documents.TcpHandlers
                 }
             } while (shouldRetry);
 
-            // if waited, refresh subscription data (change vector may have been updated)
-            if (waitedAnyTime)
-                SubscriptionState = await TcpConnection.DocumentDatabase.SubscriptionStorage.AssertSubscriptionConnectionDetails(SubscriptionId, _options.SubscriptionName);
+           
 
+            // refresh subscription data (change vector may have been updated, because in the meanwhile, another subscription could have just completed a batch)            
+            SubscriptionState = await TcpConnection.DocumentDatabase.SubscriptionStorage.AssertSubscriptionConnectionDetails(SubscriptionId, _options.SubscriptionName);
+            
             (Collection, (Script, Functions), Revisions) = ParseSubscriptionQuery(SubscriptionState.Query);
 
             try
@@ -454,7 +454,7 @@ namespace Raven.Server.Documents.TcpHandlers
         private (IDisposable ReleaseBuffer, JsonOperationContext.ManagedPinnedBuffer Buffer) _copiedBuffer;
 
         private async Task ProcessSubscriptionAsync()
-        {
+        {            
             if (_logger.IsInfoEnabled)
             {
                 _logger.Info(

--- a/test/SlowTests/Client/Subscriptions/RavenDB_3484.cs
+++ b/test/SlowTests/Client/Subscriptions/RavenDB_3484.cs
@@ -241,9 +241,9 @@ namespace SlowTests.Client.Subscriptions
                     User user;
 
                     Assert.True(items.TryTake(out user, _reasonableWaitTime));
-                    Assert.Equal("users/" + (userId - 4), user.Id);
+                    Assert.Equal("users/" + (userId - 2), user.Id);
                     Assert.True(items.TryTake(out user, _reasonableWaitTime));
-                    Assert.Equal("users/" + (userId - 3), user.Id);
+                    Assert.Equal("users/" + (userId - 1), user.Id);
 
                     Assert.True(await pendingBatchAcknowledgedMre.WaitAsync(_reasonableWaitTime)); // let it acknowledge the processed batch before we open another subscription
 


### PR DESCRIPTION
Fixed RavenDB_3484 test.