### PR TITLE
[4.0] RavenDB-11282 If the replacement index wasn't running then we shouldn…

### DIFF
--- a/src/Raven.Server/Documents/Indexes/IndexStore.cs
+++ b/src/Raven.Server/Documents/Indexes/IndexStore.cs
@@ -1178,23 +1178,26 @@ namespace Raven.Server.Documents.Indexes
 
             _indexes.ReplaceIndex(oldIndexName, oldIndex, newIndex);
 
-            var needToStop = PoolOfThreads.LongRunningWork.Current != newIndex._indexingThread;
+            using (newIndex.DrainRunningQueries()) // to ensure nobody will start index meanwhile if we stop it here
+            {
+                var needToStop = newIndex.Status == IndexRunningStatus.Running && PoolOfThreads.LongRunningWork.Current != newIndex._indexingThread;
 
-            if (needToStop)
-            {
-                // stop the indexing to allow renaming the index 
-                // the write tx required to rename it might be hold by indexing thread
-                ExecuteIndexAction(() => newIndex.Stop());
-            }
-
-            try
-            {
-                newIndex.Rename(oldIndexName);
-            }
-            finally
-            {
                 if (needToStop)
-                    ExecuteIndexAction(newIndex.Start);
+                {
+                    // stop the indexing to allow renaming the index 
+                    // the write tx required to rename it might be hold by indexing thread
+                    ExecuteIndexAction(() => newIndex.Stop());
+                }
+
+                try
+                {
+                    newIndex.Rename(oldIndexName);
+                }
+                finally
+                {
+                    if (needToStop)
+                        ExecuteIndexAction(newIndex.Start);
+                }
             }
 
             newIndex.ResetIsSideBySideAfterReplacement();

--- a/test/FastTests/Client/Indexing/StaticIndexesFromClient.cs
+++ b/test/FastTests/Client/Indexing/StaticIndexesFromClient.cs
@@ -143,11 +143,11 @@ namespace FastTests.Client.Indexing
 
                     await store
                         .Maintenance
-                        .SendAsync(new PutIndexesOperation(input2), cts.Token);
+                        .SendAsync(new StopIndexingOperation(), cts.Token);
 
                     await store
                         .Maintenance
-                        .SendAsync(new StopIndexingOperation(), cts.Token);
+                        .SendAsync(new PutIndexesOperation(input2), cts.Token);
 
                     await store
                        .Maintenance


### PR DESCRIPTION
…'t start it after renaming it. Making sure nobody will start the index if we stop it during the replacement. Changing the order of stop indexing / put index operations to test what we actually want - we want to test that we can get back to the original index def if the replacement index still exists