### PR TITLE
[4.1] RavenDB-11282 If the replacement index wasn't running then we shouldn…

### DIFF
--- a/test/FastTests/Client/Indexing/StaticIndexesFromClient.cs
+++ b/test/FastTests/Client/Indexing/StaticIndexesFromClient.cs
@@ -143,11 +143,11 @@ namespace FastTests.Client.Indexing
 
                     await store
                         .Maintenance
-                        .SendAsync(new PutIndexesOperation(input2), cts.Token);
+                        .SendAsync(new StopIndexingOperation(), cts.Token);
 
                     await store
                         .Maintenance
-                        .SendAsync(new StopIndexingOperation(), cts.Token);
+                        .SendAsync(new PutIndexesOperation(input2), cts.Token);
 
                     await store
                        .Maintenance


### PR DESCRIPTION
…'t start it after renaming it. Making sure nobody will start the index if we stop it during the replacement. Changing the order of stop indexing / put index operations to test what we actually want - we want to test that we can get back to the original index def if the replacement index still exists