### PR TITLE
RavenDB-11477 Fixing tests

### DIFF
--- a/src/Raven.Server/Documents/Handlers/Admin/RachisAdminHandler.cs
+++ b/src/Raven.Server/Documents/Handlers/Admin/RachisAdminHandler.cs
@@ -58,13 +58,6 @@ namespace Raven.Server.Documents.Handlers.Admin
 
                 switch (command)
                 {
-                    case AddDatabaseCommand addDatabase:
-                        if (addDatabase.Record.Topology.Count == 0)
-                        {
-                            ServerStore.AssignNodesToDatabase(ServerStore.GetClusterTopology(), addDatabase.Record);
-                        }
-                        Debug.Assert(addDatabase.Record.Topology.Count != 0, "Empty topology after AssignNodesToDatabase");
-                        break;
                     case AddOrUpdateCompareExchangeBatchCommand batchCmpExchange:
                         batchCmpExchange.ContextToWriteResult = context;
                         break;

--- a/src/Raven.Server/Rachis/Leader.cs
+++ b/src/Raven.Server/Rachis/Leader.cs
@@ -608,6 +608,8 @@ namespace Raven.Server.Rachis
 
         public async Task<(long Index, object Result)> PutAsync(CommandBase cmd, TimeSpan timeout)
         {
+            _engine.InvokeBeforeAppendToRaftLog(cmd);
+
             Task<(long Index, object Result)> task;
             long index;
             using (_engine.ContextPool.AllocateOperationContext(out TransactionOperationContext context))

--- a/src/Raven.Server/Rachis/Leader.cs
+++ b/src/Raven.Server/Rachis/Leader.cs
@@ -608,13 +608,14 @@ namespace Raven.Server.Rachis
 
         public async Task<(long Index, object Result)> PutAsync(CommandBase cmd, TimeSpan timeout)
         {
-            _engine.InvokeBeforeAppendToRaftLog(cmd);
 
             Task<(long Index, object Result)> task;
             long index;
             using (_engine.ContextPool.AllocateOperationContext(out TransactionOperationContext context))
             using (context.OpenWriteTransaction()) // this line prevents concurrency issues on the PutAsync
             {
+                _engine.InvokeBeforeAppendToRaftLog(context, cmd);
+
                 var djv = cmd.ToJson(context);
                 var cmdJson = context.ReadObject(djv, "raft/command");
 

--- a/src/Raven.Server/Rachis/RachisConsensus.cs
+++ b/src/Raven.Server/Rachis/RachisConsensus.cs
@@ -253,7 +253,7 @@ namespace Raven.Server.Rachis
 
         public event EventHandler<StateTransition> StateChanged;
 
-        public event EventHandler<CommandBase> BeforeAppendToRaftLog;
+        public event Action<TransactionOperationContext, CommandBase> BeforeAppendToRaftLog;
 
         public event EventHandler LeaderElected;
 
@@ -1780,9 +1780,9 @@ namespace Raven.Server.Rachis
         private readonly AsyncManualResetEvent _leadershipTimeChanged = new AsyncManualResetEvent();
         private int _heartbeatWaitersCounter;
 
-        public void InvokeBeforeAppendToRaftLog(CommandBase cmd)
+        public void InvokeBeforeAppendToRaftLog(TransactionOperationContext context,CommandBase cmd)
         {
-            BeforeAppendToRaftLog?.Invoke(this, cmd);
+            BeforeAppendToRaftLog?.Invoke(context, cmd);
         }
 
         public async Task WaitForHeartbeat()

--- a/src/Raven.Server/Rachis/RachisConsensus.cs
+++ b/src/Raven.Server/Rachis/RachisConsensus.cs
@@ -226,7 +226,7 @@ namespace Raven.Server.Rachis
     }
     
     public abstract class RachisConsensus : IDisposable
-    {        
+    {
         internal abstract RachisStateMachine GetStateMachine();
 
         internal abstract RachisVersionValidation Validator { get; }
@@ -252,6 +252,8 @@ namespace Raven.Server.Rachis
         public event EventHandler<ClusterTopology> TopologyChanged;
 
         public event EventHandler<StateTransition> StateChanged;
+
+        public event EventHandler<CommandBase> BeforeAppendToRaftLog;
 
         public event EventHandler LeaderElected;
 
@@ -1777,6 +1779,11 @@ namespace Raven.Server.Rachis
 
         private readonly AsyncManualResetEvent _leadershipTimeChanged = new AsyncManualResetEvent();
         private int _heartbeatWaitersCounter;
+
+        public void InvokeBeforeAppendToRaftLog(CommandBase cmd)
+        {
+            BeforeAppendToRaftLog?.Invoke(this, cmd);
+        }
 
         public async Task WaitForHeartbeat()
         {

--- a/src/Raven.Server/ServerWide/ServerStore.cs
+++ b/src/Raven.Server/ServerWide/ServerStore.cs
@@ -539,14 +539,14 @@ namespace Raven.Server.ServerWide
         }
 
 
-        private void BeforeAppendToRaftLog(object sender, CommandBase cmd)
+        private void BeforeAppendToRaftLog(TransactionOperationContext ctx, CommandBase cmd)
         {
             switch (cmd)
             {
                 case AddDatabaseCommand addDatabase:
                     if (addDatabase.Record.Topology.Count == 0)
                     {
-                        AssignNodesToDatabase(GetClusterTopology(), addDatabase.Record);
+                        AssignNodesToDatabase(GetClusterTopology(ctx), addDatabase.Record);
                     }
                     Debug.Assert(addDatabase.Record.Topology.Count != 0, "Empty topology after AssignNodesToDatabase");
                     break;

--- a/src/Raven.Server/Web/System/AdminDatabasesHandler.cs
+++ b/src/Raven.Server/Web/System/AdminDatabasesHandler.cs
@@ -368,11 +368,6 @@ namespace Raven.Server.Web.System
                     databaseRecord.Topology = new DatabaseTopology();
 
                 databaseRecord.Topology.ReplicationFactor = Math.Min(replicationFactor, clusterTopology.AllNodes.Count);
-
-                if (ServerStore.IsLeader())
-                {
-                    ServerStore.AssignNodesToDatabase(clusterTopology, databaseRecord);
-                }
             }
 
             var (newIndex, result) = await ServerStore.WriteDatabaseRecordAsync(name, databaseRecord, index);
@@ -659,6 +654,13 @@ namespace Raven.Server.Web.System
                             if (record.Topology.Count == 0)
                                 waitOnRecordDeletion.Add(databaseName);
                         }
+                    }
+                }
+                else
+                {
+                    foreach (var databaseName in parameters.DatabaseNames)
+                    {
+                        waitOnRecordDeletion.Add(databaseName);
                     }
                 }
 

--- a/test/FastTests/Server/Documents/DocumentsCrud.cs
+++ b/test/FastTests/Server/Documents/DocumentsCrud.cs
@@ -17,7 +17,7 @@ namespace FastTests.Server.Documents
 
         public DocumentsCrud()
         {
-            _disposeDatabase = CreatePersistentDocumentDatabase(NewDataPath(), out _documentDatabase);
+            _disposeDatabase = CreatePersistentDocumentDatabase(NewDataPath(prefix: "DocumentsCrud"), out _documentDatabase);
         }
 
         [Theory]
@@ -568,8 +568,8 @@ namespace FastTests.Server.Documents
 
         public override void Dispose()
         {
-            base.Dispose();
             _disposeDatabase.Dispose();
+            base.Dispose();
         }
     }
 }

--- a/test/FastTests/Server/Documents/Operations/BasicOperationsTests.cs
+++ b/test/FastTests/Server/Documents/Operations/BasicOperationsTests.cs
@@ -105,7 +105,7 @@ namespace FastTests.Server.Documents.Operations
 
                 OperationStatusChange change;
 
-                Assert.True(notifications.TryTake(out change, TimeSpan.FromSeconds(1)));
+                Assert.True(notifications.TryTake(out change, TimeSpan.FromSeconds(30)));
                 Assert.NotNull(change.OperationId);
                 Assert.Equal(OperationStatus.Faulted, change.State.Status);
                 Assert.NotNull(change.State.Result);

--- a/test/Tests.Infrastructure/RavenLowLevelTestBase.cs
+++ b/test/Tests.Infrastructure/RavenLowLevelTestBase.cs
@@ -101,7 +101,7 @@ namespace FastTests
             {
                 store.Initialize();
 
-                store.Maintenance.Server.Send(new DeleteDatabasesOperation(dbName, true));
+                store.Maintenance.Server.Send(new DeleteDatabasesOperation(dbName, true, timeToWaitForConfirmation: TimeSpan.FromSeconds(30)));
             }
         }
 


### PR DESCRIPTION
Move all pre-processing of commands on the leader to an event to avoid race conditions during elections

- Fix proper dispose order
- Ensure we can wait properly for database deletion even if we aren't deleting just specific nodes
- Better name for data path in test
- Increase timeout undre stress test