### PR TITLE
[4.0] RavenDB-11171 do not create attachment revision on revision put only when inserting a revision because it is handled manually outside

### DIFF
--- a/src/Raven.Server/Documents/DocumentFlags.cs
+++ b/src/Raven.Server/Documents/DocumentFlags.cs
@@ -1,4 +1,5 @@
 ﻿using System;
+using System.Runtime.CompilerServices;
 
 namespace Raven.Server.Documents
 {
@@ -40,11 +41,13 @@ namespace Raven.Server.Documents
 
     public static class EnumExtensions
     {
+        [MethodImpl(MethodImplOptions.AggressiveInlining)]
         public static bool Contain(this DocumentFlags current, DocumentFlags flag)
         {
             return (current & flag) == flag;
         }
 
+        [MethodImpl(MethodImplOptions.AggressiveInlining)]
         public static bool Contain(this NonPersistentDocumentFlags current, NonPersistentDocumentFlags flag)
         {
             return (current & flag) == flag;

--- a/src/Raven.Server/Documents/Revisions/RevisionsStorage.cs
+++ b/src/Raven.Server/Documents/Revisions/RevisionsStorage.cs
@@ -287,20 +287,21 @@ namespace Raven.Server.Documents.Revisions
 
             using (DocumentIdWorker.GetLowerIdSliceAndStorageKey(context, id, out Slice lowerId, out Slice idPtr))
             {
-                var fromSmuggler = (nonPersistentFlags & NonPersistentDocumentFlags.FromSmuggler) == NonPersistentDocumentFlags.FromSmuggler;
                 var fromReplication = (nonPersistentFlags & NonPersistentDocumentFlags.FromReplication) == NonPersistentDocumentFlags.FromReplication;
 
                 var table = EnsureRevisionTableCreated(context.Transaction.InnerTransaction, collectionName);
 
                 // We want the revision's attachments to have a lower etag than the revision itself
-                if ((flags & DocumentFlags.HasAttachments) == DocumentFlags.HasAttachments &&
-                    fromSmuggler == false)
+                if ((flags & DocumentFlags.HasAttachments) == DocumentFlags.HasAttachments)
                 {
-                    using (Slice.From(context.Allocator, changeVector, out Slice changeVectorSlice))
+                    if (flags.Contain(DocumentFlags.Revision) == false)
                     {
-                        if (table.VerifyKeyExists(changeVectorSlice) == false)
+                        using (Slice.From(context.Allocator, changeVector, out Slice changeVectorSlice))
                         {
-                            _documentsStorage.AttachmentsStorage.RevisionAttachments(context, lowerId, changeVectorSlice);
+                            if (table.VerifyKeyExists(changeVectorSlice) == false)
+                            {
+                                _documentsStorage.AttachmentsStorage.RevisionAttachments(context, lowerId, changeVectorSlice);
+                            }
                         }
                     }
                 }

--- a/test/SlowTests/Client/Attachments/AttachmentsSmuggler.cs
+++ b/test/SlowTests/Client/Attachments/AttachmentsSmuggler.cs
@@ -352,7 +352,7 @@ namespace SlowTests.Client.Attachments
                     var stats = await store2.Maintenance.SendAsync(new GetStatisticsOperation());
                     Assert.Equal(1, stats.CountOfDocuments);
                     Assert.Equal(3, stats.CountOfRevisionDocuments);
-                    Assert.Equal(2, stats.CountOfAttachments);
+                    Assert.Equal(2 + 1, stats.CountOfAttachments); // the imported document will create 1 additional revision with 1 attachment
                     Assert.Equal(1, stats.CountOfUniqueAttachments);
 
                     using (var session = store2.OpenSession())
@@ -421,7 +421,7 @@ namespace SlowTests.Client.Attachments
                         var stats = await store2.Maintenance.SendAsync(new GetStatisticsOperation());
                         Assert.Equal(1, stats.CountOfDocuments);
                         Assert.Equal(5, stats.CountOfRevisionDocuments);
-                        Assert.Equal(14, stats.CountOfAttachments);
+                        Assert.Equal(14 + 4, stats.CountOfAttachments); // the imported document will create 1 additional revision with 4 attachments
                         Assert.Equal(4, stats.CountOfUniqueAttachments);
 
                         using (var session = store2.OpenSession())
@@ -431,7 +431,6 @@ namespace SlowTests.Client.Attachments
                             using (var attachment = session.Advanced.Attachments.Get("users/1", "big-file"))
                             {
                                 attachment.Stream.CopyTo(attachmentStream);
-                                Assert.Contains("A:" + (2 + 20 * i), attachment.Details.ChangeVector);
                                 Assert.Equal("big-file", attachment.Details.Name);
                                 Assert.Equal("zKHiLyLNRBZti9DYbzuqZ/EDWAFMgOXB+SwKvjPAINk=", attachment.Details.Hash);
                                 Assert.Equal(999 * 1024, attachmentStream.Position);

--- a/test/SlowTests/Issues/RavenDB_11171.cs
+++ b/test/SlowTests/Issues/RavenDB_11171.cs
@@ -1,0 +1,124 @@
+﻿using System.IO;
+using System.Text;
+using System.Threading.Tasks;
+using FastTests;
+using Orders;
+using Raven.Client.Documents;
+using Raven.Client.Documents.Operations.Revisions;
+using Raven.Client.Documents.Smuggler;
+using Xunit;
+
+namespace SlowTests.Issues
+{
+    public class RavenDB_11171 : RavenTestBase
+    {
+        [Fact]
+        public async Task ShouldWork()
+        {
+            using (var store = GetDocumentStore())
+            {
+                using (var session = store.OpenAsyncSession())
+                {
+                    var company = new Company
+                    {
+                        Name = "HR"
+                    };
+
+                    await session.StoreAsync(company, "companies/1");
+
+                    var stream = new MemoryStream(Encoding.UTF8.GetBytes("123"));
+                    session.Advanced.Attachments.Store(company, "photo.jpg", stream);
+
+                    await session.SaveChangesAsync();
+                }
+
+                await AssertAttachment(store);
+
+                using (var store2 = GetDocumentStore())
+                {
+                    await store2.Maintenance.SendAsync(new ConfigureRevisionsOperation(new RevisionsConfiguration
+                    {
+                        Default = new RevisionsCollectionConfiguration()
+                    }));
+
+                    await store.Smuggler.ExportAsync(new DatabaseSmugglerExportOptions(), store2.Smuggler);
+
+                    await AssertAttachment(store2);
+
+                    await AssertRevision(store2, 1);
+
+                    using (var store3 = GetDocumentStore())
+                    {
+                        await store3.Maintenance.SendAsync(new ConfigureRevisionsOperation(new RevisionsConfiguration
+                        {
+                            Default = new RevisionsCollectionConfiguration()
+                        }));
+
+                        await store2.Smuggler.ExportAsync(new DatabaseSmugglerExportOptions(), store3.Smuggler);
+
+                        await AssertAttachment(store3);
+
+                        await AssertRevision(store3, 2);
+                    }
+                }
+            }
+        }
+
+        private static async Task AssertRevision(IDocumentStore store, int expectedNumberOfRevisions)
+        {
+            using (var session = store.OpenAsyncSession())
+            {
+                var revisions = await session.Advanced.Revisions.GetForAsync<Company>("companies/1");
+
+                Assert.NotNull(revisions);
+                Assert.Equal(expectedNumberOfRevisions, revisions.Count);
+
+                foreach (var revision in revisions)
+                {
+                    var attachmentNames = session.Advanced.Attachments.GetNames(revision);
+                    Assert.NotNull(attachmentNames);
+                    Assert.Equal(1, attachmentNames.Length);
+
+                    foreach (var attachmentName in attachmentNames)
+                    {
+                        var attachment = await session.Advanced.Attachments.GetRevisionAsync(revision.Id, attachmentName.Name, session.Advanced.GetChangeVectorFor(revision));
+                        Assert.NotNull(attachment);
+                        Assert.NotNull(attachment.Stream);
+
+                        using (var sr = new StreamReader(attachment.Stream))
+                        {
+                            var value = sr.ReadToEnd();
+                            Assert.Equal("123", value);
+                        }
+                    }
+                }
+            }
+        }
+
+        private static async Task AssertAttachment(IDocumentStore store)
+        {
+            using (var session = store.OpenAsyncSession())
+            {
+                var company = await session.LoadAsync<Company>("companies/1");
+                Assert.NotNull(company);
+
+                var attachmentNames = session.Advanced.Attachments.GetNames(company);
+                Assert.NotNull(attachmentNames);
+                Assert.Equal(1, attachmentNames.Length);
+
+                foreach (var attachmentName in attachmentNames)
+                {
+                    var attachment = await session.Advanced.Attachments.GetAsync(company, attachmentName.Name);
+                    Assert.NotNull(attachment);
+                    Assert.NotNull(attachment.Stream);
+
+                    using (var sr = new StreamReader(attachment.Stream))
+                    {
+                        var value = sr.ReadToEnd();
+                        Assert.Equal("123", value);
+                    }
+                }
+            }
+        }
+    }
+}


### PR DESCRIPTION
@maximburyak @fitzchak @ayende Can you validate my logic here?

We do not want to create attachment revisions for a revision document, because for all of those situations this is handled outside?

This also fixes a case when we are importing document with attachments but created document revision does not create revision attachments.