### PR TITLE
[4.0] RavenDB-10938 Fix a leak in the Counting State Machine

### DIFF
--- a/test/RachisTests/TopologyChangesTests.cs
+++ b/test/RachisTests/TopologyChangesTests.cs
@@ -57,7 +57,7 @@ namespace RachisTests
             var leader = await CreateNetworkAndGetLeader(3);
             Assert.True(await leader.AddToClusterAsync(node4.Url).WaitAsync(TimeSpan.FromMilliseconds(leader.ElectionTimeout.TotalMilliseconds * 2)), "non existing node should be able to join the cluster");
             Assert.True(await leader.AddToClusterAsync(node5.Url).WaitAsync(TimeSpan.FromMilliseconds(leader.ElectionTimeout.TotalMilliseconds * 2)), "non existing node should be able to join the cluster");
-            var t = IssueCommandsAndWaitForCommit(leader, 3, "test", 1);
+            var t = IssueCommandsAndWaitForCommit(3, "test", 1);
             Assert.True(await t.WaitAsync(TimeSpan.FromMilliseconds(leader.ElectionTimeout.TotalMilliseconds * 2)), "Commands were not committed in time although there is a majority of active nodes in the cluster");
 
             ReconnectToNode(node4);

--- a/test/Tests.Infrastructure/ClusterTestBase.cs
+++ b/test/Tests.Infrastructure/ClusterTestBase.cs
@@ -36,7 +36,7 @@ namespace Tests.Infrastructure
                 Console.WriteLine($"\tTo attach debugger to test process ({(PlatformDetails.Is32Bits ? "x86" : "x64")}), use proc-id: {currentProcess.Id}.");
         }
 
-        private const int ElectionTimeoutInMs = 300;
+        private int _electionTimeoutInMs = 300;
 
         protected readonly ConcurrentBag<IDisposable> _toDispose = new ConcurrentBag<IDisposable>();
 
@@ -412,7 +412,7 @@ namespace Tests.Infrastructure
                 await follower.ServerStore.WaitForTopology(Leader.TopologyModification.Voter);
             }
             // ReSharper disable once PossibleNullReferenceException
-            Assert.True(await leader.ServerStore.WaitForState(RachisState.Leader, CancellationToken.None).WaitAsync(numberOfNodes * ElectionTimeoutInMs),
+            Assert.True(await leader.ServerStore.WaitForState(RachisState.Leader, CancellationToken.None).WaitAsync(numberOfNodes * _electionTimeoutInMs),
                 "The leader has changed while waiting for cluster to become stable. Status: " + leader.ServerStore.LastStateChangeReason());
             return leader;
         }
@@ -423,11 +423,13 @@ namespace Tests.Infrastructure
             RavenServer leader = null;
             var serversToPorts = new Dictionary<RavenServer, string>();
             var clustersServers = new List<RavenServer>();
+            _electionTimeoutInMs = Math.Max(300, numberOfNodes * 80);
             for (var i = 0; i < numberOfNodes; i++)
             {
                 customSettings = customSettings ?? new Dictionary<string, string>()
                 {
                     [RavenConfiguration.GetKey(x=>x.Cluster.MoveToRehabGraceTime)] = "1",
+                    [RavenConfiguration.GetKey(x=>x.Cluster.ElectionTimeout)] = _electionTimeoutInMs.ToString(),
                 };
                 string serverUrl;
 
@@ -468,7 +470,7 @@ namespace Tests.Infrastructure
                 await follower.ServerStore.WaitForTopology(Leader.TopologyModification.Voter);
             }
             // ReSharper disable once PossibleNullReferenceException
-            var condition = await leader.ServerStore.WaitForState(RachisState.Leader, CancellationToken.None).WaitAsync(numberOfNodes * ElectionTimeoutInMs * 5);
+            var condition = await leader.ServerStore.WaitForState(RachisState.Leader, CancellationToken.None).WaitAsync(numberOfNodes * _electionTimeoutInMs * 5);
             var states = string.Empty;
             if (condition == false)
             {
@@ -518,7 +520,7 @@ namespace Tests.Infrastructure
                 await follower.ServerStore.WaitForTopology(Leader.TopologyModification.Voter);
             }
             // ReSharper disable once PossibleNullReferenceException
-            var condition = await leader.ServerStore.WaitForState(RachisState.Leader, CancellationToken.None).WaitAsync(numberOfNodes * ElectionTimeoutInMs * 5);
+            var condition = await leader.ServerStore.WaitForState(RachisState.Leader, CancellationToken.None).WaitAsync(numberOfNodes * _electionTimeoutInMs * 5);
             var states = string.Empty;
             if (condition == false)
             {


### PR DESCRIPTION
- Make OnNetworkDisconnectionANewLeaderIsElectedAfterReconnectOldLeaderStepsDownAndRollBackHisLog more stable.
- Election timeout is now proportional to the number of nodes, since we are running multiple servers on the same machine.
- Dispose the server store on the disopse of the counting state machine, so we would not leak scratch buffers.