### PR TITLE
[4.1] RavenDB-10938 Fix a leak in the Counting State Machine

### DIFF
--- a/test/RachisTests/TopologyChangesTests.cs
+++ b/test/RachisTests/TopologyChangesTests.cs
@@ -57,7 +57,7 @@ namespace RachisTests
             var leader = await CreateNetworkAndGetLeader(3);
             Assert.True(await leader.AddToClusterAsync(node4.Url).WaitAsync(TimeSpan.FromMilliseconds(leader.ElectionTimeout.TotalMilliseconds * 2)), "non existing node should be able to join the cluster");
             Assert.True(await leader.AddToClusterAsync(node5.Url).WaitAsync(TimeSpan.FromMilliseconds(leader.ElectionTimeout.TotalMilliseconds * 2)), "non existing node should be able to join the cluster");
-            var t = IssueCommandsAndWaitForCommit(leader, 3, "test", 1);
+            var t = IssueCommandsAndWaitForCommit(3, "test", 1);
             Assert.True(await t.WaitAsync(TimeSpan.FromMilliseconds(leader.ElectionTimeout.TotalMilliseconds * 2)), "Commands were not committed in time although there is a majority of active nodes in the cluster");
 
             ReconnectToNode(node4);


### PR DESCRIPTION
- Make OnNetworkDisconnectionANewLeaderIsElectedAfterReconnectOldLeaderStepsDownAndRollBackHisLog more stable.
- Election timeout is now proportional to the number of nodes, since we are running multiple servers on the same machine.
- Dispose the server store on the disopse of the counting state machine, so we would not leak scratch buffers.