### PR TITLE
[4.1] RavenDB-11379

### DIFF
--- a/src/Raven.Client/Documents/Operations/ETL/Transformation.cs
+++ b/src/Raven.Client/Documents/Operations/ETL/Transformation.cs
@@ -22,8 +22,6 @@ namespace Raven.Client.Documents.Operations.ETL
 
         internal const string CounterMarker = "$counter/";
 
-        internal const string NullMarkerSuffix = "/$null";
-
         private static readonly Regex LoadToMethodRegex = new Regex($@"{LoadTo}(\w+)", RegexOptions.Compiled);
 
         private static readonly Regex LoadAttachmentMethodRegex = new Regex(LoadAttachment, RegexOptions.Compiled);
@@ -52,6 +50,8 @@ namespace Raven.Client.Documents.Operations.ETL
         internal Dictionary<string, string> CollectionToLoadCounterBehaviorFunction { get; private set; }
 
         internal bool IsAddingAttachments { get; private set; }
+
+        internal bool IsLoadingAttachments { get; private set; }
 
         internal bool IsAddingCounters { get; private set; }
 
@@ -103,9 +103,10 @@ namespace Raven.Client.Documents.Operations.ETL
                                "If you are using the SQL replication script from RavenDB 3.x version then please use `loadTo<TableName>()` instead.");
                 }
 
-                IsAddingAttachments = LoadAttachmentMethodRegex.Matches(Script).Count > 0 || AddAttachmentMethodRegex.Matches(Script).Count > 0;
+                IsAddingAttachments = AddAttachmentMethodRegex.Matches(Script).Count > 0;
+                IsLoadingAttachments = LoadAttachmentMethodRegex.Matches(Script).Count > 0;
 
-                IsAddingCounters = LoadCounterMethodRegex.Matches(Script).Count > 0 || AddCounterMethodRegex.Matches(Script).Count > 0;
+                IsAddingCounters = AddCounterMethodRegex.Matches(Script).Count > 0;
 
                 var counterBehaviors = LoadCountersBehaviorMethodRegex.Matches(Script);
 

--- a/src/Raven.Server/Documents/ETL/EtlTransformer.cs
+++ b/src/Raven.Server/Documents/ETL/EtlTransformer.cs
@@ -116,13 +116,13 @@ namespace Raven.Server.Documents.ETL
                 var attachment = Database.DocumentsStorage.AttachmentsStorage.GetAttachment(Context, Current.DocumentId, attachmentName, AttachmentType.Document, null);
 
                 if (attachment == null)
-                    return loadAttachmentReference + Transformation.NullMarkerSuffix;
+                    return JsValue.Null;
 
                 AddLoadedAttachment(loadAttachmentReference, attachmentName, attachment);
             }
             else
             {
-                return loadAttachmentReference + Transformation.NullMarkerSuffix;
+                return JsValue.Null;
             }
 
             return loadAttachmentReference;
@@ -141,13 +141,13 @@ namespace Raven.Server.Documents.ETL
                 var value = Database.DocumentsStorage.CountersStorage.GetCounterValue(Context, Current.DocumentId, counterName);
 
                 if (value == null)
-                    return loadCounterReference + Transformation.NullMarkerSuffix;
+                    return JsValue.Null;
 
                 AddLoadedCounter(loadCounterReference, counterName, value.Value);
             }
             else
             {
-                return loadCounterReference + Transformation.NullMarkerSuffix;
+                return JsValue.Null;
             }
 
             return loadCounterReference;

--- a/src/Raven.Server/Documents/ETL/Providers/Raven/RavenEtl.cs
+++ b/src/Raven.Server/Documents/ETL/Providers/Raven/RavenEtl.cs
@@ -49,8 +49,7 @@ namespace Raven.Server.Documents.ETL.Providers.Raven
 
         protected override bool ShouldTrackAttachmentTombstones()
         {
-            // if script isn't empty we relay on addAttachment() calls and detect that attachments needs be deleted
-            // when this call gets an attachment reference marked as null ($attachment/{attachment-name}/$null)
+            // if script isn't empty and we have addAttachment() calls there we send DELETE doc command before sending transformation results (docs and attachments)
 
             return string.IsNullOrEmpty(Transformation.Script);
         }

--- a/src/Raven.Server/Documents/ETL/Providers/Raven/RavenEtlScriptRun.cs
+++ b/src/Raven.Server/Documents/ETL/Providers/Raven/RavenEtlScriptRun.cs
@@ -16,8 +16,6 @@ namespace Raven.Server.Documents.ETL.Providers.Raven
         
         private Dictionary<JsValue, List<(string Name, Attachment Attachment)>> _addAttachments;
 
-        private Dictionary<JsValue, List<string>> _deleteAttachments;
-
         private Dictionary<JsValue, Attachment> _loadedAttachments;
 
         private Dictionary<JsValue, List<CounterOperation>> _countersByJsReference;
@@ -110,20 +108,6 @@ namespace Raven.Server.Documents.ETL.Providers.Raven
             attachments.Add((name ?? attachment.Name, attachment));
         }
 
-        public void DeleteAttachment(JsValue instance, string name)
-        {
-            if (_deleteAttachments == null)
-                _deleteAttachments = new Dictionary<JsValue, List<string>>(ReferenceEqualityComparer<JsValue>.Default);
-
-            if (_deleteAttachments.TryGetValue(instance, out var attachmentsToDelete) == false)
-            {
-                attachmentsToDelete = new List<string>();
-                _deleteAttachments.Add(instance, attachmentsToDelete);
-            }
-
-            attachmentsToDelete.Add(name);
-        }
-
         public void DeleteAttachment(string documentId, string name)
         {
             _deletes.Add(new DeleteAttachmentCommandData(documentId, name, null));
@@ -166,24 +150,6 @@ namespace Raven.Server.Documents.ETL.Providers.Raven
                 CounterName = counterName,
                 Delta = value,
                 Type = CounterOperationType.Put
-            });
-        }
-
-        public void DeleteCounter(JsValue instance, string counterName)
-        {
-            if (_countersByJsReference == null)
-                _countersByJsReference = new Dictionary<JsValue, List<CounterOperation>>(ReferenceEqualityComparer<JsValue>.Default);
-
-            if (_countersByJsReference.TryGetValue(instance, out var operations) == false)
-            {
-                operations = new List<CounterOperation>();
-                _countersByJsReference.Add(instance, operations);
-            }
-
-            operations.Add(new CounterOperation
-            {
-                CounterName = counterName,
-                Type = CounterOperationType.Delete
             });
         }
 
@@ -230,14 +196,6 @@ namespace Raven.Server.Documents.ETL.Providers.Raven
                         {
                             commands.Add(new PutAttachmentCommandData(put.Value.Id, addAttachment.Name, addAttachment.Attachment.Stream, addAttachment.Attachment.ContentType,
                                 null));
-                        }
-                    }
-
-                    if (_deleteAttachments != null && _deleteAttachments.TryGetValue(put.Key, out var deleteAttachments))
-                    {
-                        foreach (var deleteAttachment in deleteAttachments)
-                        {
-                            commands.Add(new DeleteAttachmentCommandData(put.Value.Id, deleteAttachment, null));
                         }
                     }
 

--- a/src/Raven.Server/Documents/ETL/Providers/SQL/SqlDocumentTransformer.cs
+++ b/src/Raven.Server/Documents/ETL/Providers/SQL/SqlDocumentTransformer.cs
@@ -38,7 +38,7 @@ namespace Raven.Server.Documents.ETL.Providers.SQL
 
             LoadToDestinations = tables;
 
-            if (_transformation.IsAddingAttachments)
+            if (_transformation.IsLoadingAttachments)
                _loadedAttachments = new Dictionary<string, Queue<Attachment>>(StringComparer.OrdinalIgnoreCase);
         }
 
@@ -75,7 +75,7 @@ namespace Raven.Server.Documents.ETL.Providers.SQL
                     Type = prop.Token
                 };
 
-                if (_transformation.IsAddingAttachments && 
+                if (_transformation.IsLoadingAttachments && 
                     prop.Token == BlittableJsonToken.String && IsLoadAttachment(prop.Value as LazyStringValue, out var attachmentName))
                 {
                     var attachment = _loadedAttachments[attachmentName].Dequeue();

--- a/test/SlowTests/Server/Documents/ETL/Raven/RavenDB_11379.cs
+++ b/test/SlowTests/Server/Documents/ETL/Raven/RavenDB_11379.cs
@@ -24,6 +24,17 @@ var doc = loadToUsers(this);
 doc.addAttachment('image', loadAttachment('photo'));
 
 ", false, "photo", "image")]
+        [InlineData(@"
+
+var doc = loadToUsers(this);
+
+var attachments = this['@metadata']['@attachments'];
+
+for (var i = 0; i < attachments.length; i++) {
+    if (attachments[i].Name.endsWith('.png'))
+        doc.addAttachment(loadAttachment(attachments[i].Name));
+}
+", false, "photo.png", "photo.png")]
         public void Should_remove_attachment(string script, bool applyToAllDocuments, string attachmentSourceName, string attachmentDestinationName)
         {
             using (var src = GetDocumentStore())


### PR DESCRIPTION
- If the script has `addAttachment` calls then let's send DELETE document command before sending a document and its attachments
- This way we won't overlook any attachment deletions
- Removing previous implementation that assumed that addAttachment(null) means deletion - no longer need for that