### PR TITLE
Raven db 10953 v4.0

### DIFF
--- a/src/Raven.Client/Documents/Subscriptions/SubscriptionWorker.cs
+++ b/src/Raven.Client/Documents/Subscriptions/SubscriptionWorker.cs
@@ -210,7 +210,7 @@ namespace Raven.Client.Documents.Subscriptions
             }
         }
 
-        private int ReadServerRespondAndGetVersion(JsonOperationContext context, BlittableJsonTextWriter writer)
+        private int ReadServerRespondAndGetVersion(JsonOperationContext context, BlittableJsonTextWriter writer, Stream stream, string url)
         {
             //Reading reply from server
             using (var response = context.ReadForMemory(_stream, "Subscription/tcp-header-response"))
@@ -219,7 +219,7 @@ namespace Raven.Client.Documents.Subscriptions
                 switch (reply.Status)
                 {
                     case TcpConnectionStatus.Ok:
-                        break;
+                        return reply.Version;
                     case TcpConnectionStatus.AuthorizationFailed:
                         throw new AuthorizationException($"Cannot access database {_dbName} because " + reply.Message);
                     case TcpConnectionStatus.TcpVersionMismatch:

--- a/src/Raven.Client/Documents/Subscriptions/SubscriptionWorker.cs
+++ b/src/Raven.Client/Documents/Subscriptions/SubscriptionWorker.cs
@@ -550,7 +550,7 @@ namespace Raven.Client.Documents.Subscriptions
         }
 
         private DateTime? LastConnectionFailure;
-        private TcpFeaturesSupported _supportedFeatures;
+        private TcpConnectionHeaderMessage.SupportedFeatures _supportedFeatures;
 
         private void AssertLastConnectionFailure()
         {

--- a/src/Raven.Client/Documents/Subscriptions/SubscriptionWorker.cs
+++ b/src/Raven.Client/Documents/Subscriptions/SubscriptionWorker.cs
@@ -195,7 +195,7 @@ namespace Raven.Client.Documents.Subscriptions
                     Version = TcpConnectionHeaderMessage.SubscriptionTcpVersion,
                     ReadRespondAndGetVersion = ReadServerRespondAndGetVersion
                 };
-                _protocolVersion = TcpNegotiation.NegotiateProtocolVersion(context, _stream, parameters);
+                _supportedFeatures = TcpNegotiation.NegotiateProtocolVersion(context, _stream, parameters);
 
                 var options = Encodings.Utf8.GetBytes(JsonConvert.SerializeObject(_options));
                
@@ -550,7 +550,7 @@ namespace Raven.Client.Documents.Subscriptions
         }
 
         private DateTime? LastConnectionFailure;
-        private int _protocolVersion;
+        private TcpFeaturesSupported _supportedFeatures;
 
         private void AssertLastConnectionFailure()
         {

--- a/src/Raven.Client/ServerWide/Tcp/TcpConnectionHeader.cs
+++ b/src/Raven.Client/ServerWide/Tcp/TcpConnectionHeader.cs
@@ -27,21 +27,21 @@ namespace Raven.Client.ServerWide.Tcp
 
         public string Info { get; set; }
         
-        public static readonly int PingBaseLine4000 = -1;
-        public static readonly int NoneBaseLine4000 = -1;
-        public static readonly int DropBaseLine4000 = -2;
-        public static readonly int ClusterBaseLine4000 = 10;
-        public static readonly int HeartbeatsBaseLine4000 = 20;
-        public static readonly int ReplicationBaseLine4000 = 31;
-        public static readonly int ReplicationAttachmentMissing = 33;
-        public static readonly int SubscriptionBaseLine4000 = 40;
-        public static readonly int TestConnectionBaseLine4000 = 50;
+        public static readonly int PingBaseLine40000 = -1;
+        public static readonly int NoneBaseLine40000 = -1;
+        public static readonly int DropBaseLine40000 = -2;
+        public static readonly int ClusterBaseLine40100 = 10;
+        public static readonly int HeartbeatsBaseLine40200 = 20;
+        public static readonly int ReplicationBaseLine40301 = 31;
+        public static readonly int ReplicationAttachmentMissing = 40303;
+        public static readonly int SubscriptionBaseLine40400 = 40;
+        public static readonly int TestConnectionBaseLine40500 = 50;
 
-        public static readonly int ClusterTcpVersion = ClusterBaseLine4000;
-        public static readonly int HeartbeatsTcpVersion = HeartbeatsBaseLine4000;
+        public static readonly int ClusterTcpVersion = ClusterBaseLine40100;
+        public static readonly int HeartbeatsTcpVersion = HeartbeatsBaseLine40200;
         public static readonly int ReplicationTcpVersion = ReplicationAttachmentMissing;
-        public static readonly int SubscriptionTcpVersion = SubscriptionBaseLine4000;
-        public static readonly int TestConnectionTcpVersion = TestConnectionBaseLine4000;
+        public static readonly int SubscriptionTcpVersion = SubscriptionBaseLine40400;
+        public static readonly int TestConnectionTcpVersion = TestConnectionBaseLine40500;
 
         public class SupportedFeatures
         {            
@@ -114,51 +114,51 @@ namespace Raven.Client.ServerWide.Tcp
         private static readonly Dictionary<(OperationTypes,int), List<SupportedFeatures>> OperationsToSupportedProtocolVersions
             = new Dictionary<(OperationTypes, int), List<SupportedFeatures>>
             {
-                [(OperationTypes.Ping, PingBaseLine4000)] = 
+                [(OperationTypes.Ping, PingBaseLine40000)] = 
                     new List<SupportedFeatures>
                     {
-                        new SupportedFeatures(PingBaseLine4000){Ping = new SupportedFeatures.PingFeatures()}
+                        new SupportedFeatures(PingBaseLine40000){Ping = new SupportedFeatures.PingFeatures()}
                     },
-                [(OperationTypes.None, NoneBaseLine4000)] = 
+                [(OperationTypes.None, NoneBaseLine40000)] = 
                     new List<SupportedFeatures>
                     {
-                        new SupportedFeatures(NoneBaseLine4000){None = new SupportedFeatures.NoneFeatures()}
+                        new SupportedFeatures(NoneBaseLine40000){None = new SupportedFeatures.NoneFeatures()}
                     },
-                [(OperationTypes.Drop, DropBaseLine4000)] = 
+                [(OperationTypes.Drop, DropBaseLine40000)] = 
                     new List<SupportedFeatures>
                     {
-                        new SupportedFeatures(DropBaseLine4000) { Drop = new SupportedFeatures.DropFeatures() }
+                        new SupportedFeatures(DropBaseLine40000) { Drop = new SupportedFeatures.DropFeatures() }
                     },
-                [(OperationTypes.Subscription, SubscriptionBaseLine4000)] = 
+                [(OperationTypes.Subscription, SubscriptionBaseLine40400)] = 
                     new List<SupportedFeatures>
                     {
-                        new SupportedFeatures(SubscriptionBaseLine4000){Subscription = new SupportedFeatures.SubscriptionFeatures()}
+                        new SupportedFeatures(SubscriptionBaseLine40400){Subscription = new SupportedFeatures.SubscriptionFeatures()}
                     },
                 [(OperationTypes.Replication, ReplicationAttachmentMissing)] = 
                     new List<SupportedFeatures>
                     {
                         new SupportedFeatures(ReplicationAttachmentMissing){Replication = new SupportedFeatures.ReplicationFeatures{MissingAttachments = true}},
-                        new SupportedFeatures(ReplicationBaseLine4000){Replication = new SupportedFeatures.ReplicationFeatures()}
+                        new SupportedFeatures(ReplicationBaseLine40301){Replication = new SupportedFeatures.ReplicationFeatures()}
                     },
-                [(OperationTypes.Replication, ReplicationBaseLine4000)] =
+                [(OperationTypes.Replication, ReplicationBaseLine40301)] =
                     new List<SupportedFeatures>
                     {
-                        new SupportedFeatures(ReplicationBaseLine4000){Replication = new SupportedFeatures.ReplicationFeatures()}
+                        new SupportedFeatures(ReplicationBaseLine40301){Replication = new SupportedFeatures.ReplicationFeatures()}
                     },
-                [(OperationTypes.Cluster, ClusterBaseLine4000)] =
+                [(OperationTypes.Cluster, ClusterBaseLine40100)] =
                     new List<SupportedFeatures>
                     {
-                        new SupportedFeatures(ClusterBaseLine4000) {Cluster = new SupportedFeatures.ClusterFeatures()}
+                        new SupportedFeatures(ClusterBaseLine40100) {Cluster = new SupportedFeatures.ClusterFeatures()}
                     },
-                [(OperationTypes.Heartbeats, HeartbeatsBaseLine4000)] =
+                [(OperationTypes.Heartbeats, HeartbeatsBaseLine40200)] =
                     new List<SupportedFeatures>
                     {
-                        new SupportedFeatures(HeartbeatsBaseLine4000) { Cluster = new SupportedFeatures.ClusterFeatures()}
+                        new SupportedFeatures(HeartbeatsBaseLine40200) { Cluster = new SupportedFeatures.ClusterFeatures()}
                     },
-                [(OperationTypes.TestConnection, TestConnectionBaseLine4000)] =
+                [(OperationTypes.TestConnection, TestConnectionBaseLine40500)] =
                     new List<SupportedFeatures>
                     {
-                        new SupportedFeatures(TestConnectionBaseLine4000) { TestConnection = new SupportedFeatures.TestConnectionFeatures()}
+                        new SupportedFeatures(TestConnectionBaseLine40500) { TestConnection = new SupportedFeatures.TestConnectionFeatures()}
                     },
             };
         public static (bool Supported, int PrevSupported) OperationVersionSupported(OperationTypes operationType, int version)

--- a/src/Raven.Client/ServerWide/Tcp/TcpConnectionHeader.cs
+++ b/src/Raven.Client/ServerWide/Tcp/TcpConnectionHeader.cs
@@ -27,30 +27,149 @@ namespace Raven.Client.ServerWide.Tcp
 
         public string Info { get; set; }
         
-        public static readonly int PingBaseLine40 = -1;
-        public static readonly int NoneBaseLine40 = -1;
-        public static readonly int DropBaseLine40 = -2;
-        public static readonly int ClusterBaseLine40 = 10;
-        public static readonly int HeartbeatsBaseLine40 = 20;
-        public static readonly int ReplicationBaseLine40 = 31;
+        public static readonly int PingBaseLine4000 = -1;
+        public static readonly int NoneBaseLine4000 = -1;
+        public static readonly int DropBaseLine4000 = -2;
+        public static readonly int ClusterBaseLine4000 = 10;
+        public static readonly int HeartbeatsBaseLine4000 = 20;
+        public static readonly int ReplicationBaseLine4000 = 31;
         public static readonly int ReplicationAttachmentMissing = 33;
-        public static readonly int SubscriptionBaseLine40 = 40;
-        public static readonly int TestConnectionBaseLine40 = 50;
+        public static readonly int SubscriptionBaseLine4000 = 40;
+        public static readonly int TestConnectionBaseLine4000 = 50;
 
-        public static readonly int ClusterTcpVersion = ClusterBaseLine40;
-        public static readonly int HeartbeatsTcpVersion = HeartbeatsBaseLine40;
+        public static readonly int ClusterTcpVersion = ClusterBaseLine4000;
+        public static readonly int HeartbeatsTcpVersion = HeartbeatsBaseLine4000;
         public static readonly int ReplicationTcpVersion = ReplicationAttachmentMissing;
-        public static readonly int SubscriptionTcpVersion = SubscriptionBaseLine40;
-        public static readonly int TestConnectionTcpVersion = TestConnectionBaseLine40;
+        public static readonly int SubscriptionTcpVersion = SubscriptionBaseLine4000;
+        public static readonly int TestConnectionTcpVersion = TestConnectionBaseLine4000;
+
+        public class SupportedFeatures
+        {            
+            public readonly int ProtocolVersion;
+
+            public SupportedFeatures(int version)
+            {
+                ProtocolVersion = version;
+            }
+
+            public PingFeatures Ping { get; set; }           
+            public NoneFeatures None { get; set; }
+            public DropFeatures Drop { get; set; }
+            public SubscriptionFeatures Subscription { get; set; }
+            public ClusterFeatures Cluster { get; set; }
+            public HeartbeatsFeatures Heartbeats { get; set; }
+            public TestConnectionFeatures TestConnection { get; set; }
+
+            public ReplicationFeatures Replication { get; set; }
+
+            public class PingFeatures
+            {
+                public bool BaseLine4000 = true;
+            }
+            public class NoneFeatures
+            {
+                public bool BaseLine4000 = true;
+            }
+            public class DropFeatures
+            {
+                public bool BaseLine4000 = true;
+            }
+            public class SubscriptionFeatures
+            {
+                public bool BaseLine4000 = true;
+            }
+            public class ClusterFeatures
+            {
+                public bool BaseLine4000 = true;
+            }
+
+            public class HeartbeatsFeatures
+            {
+                public bool BaseLine4000 = true;
+            }
+            public class TestConnectionFeatures
+            {
+                public bool BaseLine4000 = true;
+            }
+            public class ReplicationFeatures
+            {
+                public bool BaseLine4000 = true, MissingAttachments;
+            }
+        }
+
+        /// <summary>
+        /// This dictionary maps (operation type, protocol version) to a list of supported features, supported features comes with a protocol versions
+        /// and the list of supported features is sorted by the most up to date protocol meaning OperationsToSupportedProtocolVersions[(type,version)][0]
+        /// will have the same version as the key.version and it is the most up to date version that is supported for key.version.
+        /// This dictionary has dual purpose:
+        /// 1. map available features for given protocol type and version.
+        /// 2. allow to find a prev version that the current version support and map its features.
+        ///
+        /// * When inserting new entries to this dictionary you must place them as the first item in the list of supported features
+        /// Lets say we had
+        /// OperationsToSupportedProtocolVersions[('Foo',5)] = new List<SupportedFeatures> {SupportedFeatures5}
+        /// and we want to add a new protocol '6' it should look like this:
+        /// OperationsToSupportedProtocolVersions[('Foo',6)] = new List<SupportedFeatures> {SupportedFeatures6, SupportedFeatures5}
+        /// </summary>
+        private static readonly Dictionary<(OperationTypes,int), List<SupportedFeatures>> OperationsToSupportedProtocolVersions
+            = new Dictionary<(OperationTypes, int), List<SupportedFeatures>>
+            {
+                [(OperationTypes.Ping, PingBaseLine4000)] = 
+                    new List<SupportedFeatures>
+                    {
+                        new SupportedFeatures(PingBaseLine4000){Ping = new SupportedFeatures.PingFeatures()}
+                    },
+                [(OperationTypes.None, NoneBaseLine4000)] = 
+                    new List<SupportedFeatures>
+                    {
+                        new SupportedFeatures(NoneBaseLine4000){None = new SupportedFeatures.NoneFeatures()}
+                    },
+                [(OperationTypes.Drop, DropBaseLine4000)] = 
+                    new List<SupportedFeatures>
+                    {
+                        new SupportedFeatures(DropBaseLine4000) { Drop = new SupportedFeatures.DropFeatures() }
+                    },
+                [(OperationTypes.Subscription, SubscriptionBaseLine4000)] = 
+                    new List<SupportedFeatures>
+                    {
+                        new SupportedFeatures(SubscriptionBaseLine4000){Subscription = new SupportedFeatures.SubscriptionFeatures()}
+                    },
+                [(OperationTypes.Replication, ReplicationAttachmentMissing)] = 
+                    new List<SupportedFeatures>
+                    {
+                        new SupportedFeatures(ReplicationAttachmentMissing){Replication = new SupportedFeatures.ReplicationFeatures{MissingAttachments = true}},
+                        new SupportedFeatures(ReplicationBaseLine4000){Replication = new SupportedFeatures.ReplicationFeatures()}
+                    },
+                [(OperationTypes.Replication, ReplicationBaseLine4000)] =
+                    new List<SupportedFeatures>
+                    {
+                        new SupportedFeatures(ReplicationBaseLine4000){Replication = new SupportedFeatures.ReplicationFeatures()}
+                    },
+                [(OperationTypes.Cluster, ClusterBaseLine4000)] =
+                    new List<SupportedFeatures>
+                    {
+                        new SupportedFeatures(ClusterBaseLine4000) {Cluster = new SupportedFeatures.ClusterFeatures()}
+                    },
+                [(OperationTypes.Heartbeats, HeartbeatsBaseLine4000)] =
+                    new List<SupportedFeatures>
+                    {
+                        new SupportedFeatures(HeartbeatsBaseLine4000) { Cluster = new SupportedFeatures.ClusterFeatures()}
+                    },
+                [(OperationTypes.TestConnection, TestConnectionBaseLine4000)] =
+                    new List<SupportedFeatures>
+                    {
+                        new SupportedFeatures(TestConnectionBaseLine4000) { TestConnection = new SupportedFeatures.TestConnectionFeatures()}
+                    },
+            };
         public static (bool Supported, int PrevSupported) OperationVersionSupported(OperationTypes operationType, int version)
         {
             var prev = -1;
-            if (OperationsToSupportedProtocolVersions.TryGetValue(operationType, out var supportedProtocols) == false)
+            if (OperationsToSupportedProtocolVersions.TryGetValue((operationType, version), out var supportedProtocols) == false)
                 return (false, prev);
             
-            for (var i =0; i< supportedProtocols.Count; prev = supportedProtocols[i], i++)
+            for (var i =0; i< supportedProtocols.Count; prev = supportedProtocols[i].ProtocolVersion, i++)
             {
-                var current = supportedProtocols[i];
+                var current = supportedProtocols[i].ProtocolVersion;
                 if (current == version)
                     return (true, prev);
 
@@ -61,18 +180,7 @@ namespace Raven.Client.ServerWide.Tcp
             return (false, prev);
         }
 
-        private static readonly Dictionary<OperationTypes, List<int>> OperationsToSupportedProtocolVersions
-        = new Dictionary<OperationTypes, List<int>>
-            {
-                [OperationTypes.Ping] = new List<int> { PingBaseLine40 },
-                [OperationTypes.None] = new List<int> { NoneBaseLine40 },
-                [OperationTypes.Drop] = new List<int> { DropBaseLine40 },
-                [OperationTypes.Subscription] = new List<int> { SubscriptionBaseLine40 },
-                [OperationTypes.Replication] = new List<int> { ReplicationAttachmentMissing, ReplicationBaseLine40 },
-                [OperationTypes.Cluster] = new List<int> { ClusterBaseLine40 },
-                [OperationTypes.Heartbeats] = new List<int> { HeartbeatsBaseLine40 },
-                [OperationTypes.TestConnection] = new List<int> { TestConnectionBaseLine40 },
-        };
+
         public static int GetOperationTcpVersion(OperationTypes operationType)
         {
             switch (operationType)
@@ -95,6 +203,11 @@ namespace Raven.Client.ServerWide.Tcp
                 default:
                     throw new ArgumentOutOfRangeException(nameof(operationType), operationType, null);
             }
+        }
+
+        public static SupportedFeatures GetSupportedFeaturesFor(OperationTypes type, int optionsProtocolVersion)
+        {
+            return OperationsToSupportedProtocolVersions[(type, optionsProtocolVersion)][0];
         }
     }
 }

--- a/src/Raven.Client/ServerWide/Tcp/TcpConnectionHeader.cs
+++ b/src/Raven.Client/ServerWide/Tcp/TcpConnectionHeader.cs
@@ -1,4 +1,5 @@
 ﻿using System;
+using System.Collections.Generic;
 
 namespace Raven.Client.ServerWide.Tcp
 {
@@ -29,10 +30,29 @@ namespace Raven.Client.ServerWide.Tcp
         public static readonly int NumberOfRetriesForSendingTcpHeader = 2;
         public static readonly int ClusterTcpVersion = 10;
         public static readonly int HeartbeatsTcpVersion = 20;
-        public static readonly int ReplicationTcpVersion = 31;
+        public static readonly int ReplicationTcpVersion = 33;
         public static readonly int SubscriptionTcpVersion = 40;
         public static readonly int TestConnectionTcpVersion = 50;
 
+        public static bool OperationVersionSupported(OperationTypes operationType, int version)
+        {
+            if (_operationsToSupportedProtocolVersions.TryGetValue(operationType, out var supportedProtocols) == false)
+                return false;
+            return supportedProtocols.Contains(version);
+        }
+
+        private static readonly Dictionary<OperationTypes,HashSet<int>> _operationsToSupportedProtocolVersions
+        = new Dictionary<OperationTypes, HashSet<int>>
+            {
+                [OperationTypes.Ping] = new HashSet<int> { -1},
+                [OperationTypes.None] = new HashSet<int> { -1 },
+                [OperationTypes.Drop] = new HashSet<int> { -2 },
+                [OperationTypes.Subscription] = new HashSet<int> { 40 },
+                [OperationTypes.Replication] = new HashSet<int> { 31, 33 },
+                [OperationTypes.Cluster] = new HashSet<int> { 10 },
+                [OperationTypes.Heartbeats] = new HashSet<int> { 20 },
+                [OperationTypes.TestConnection] = new HashSet<int> { 50 },
+        };
         public static int GetOperationTcpVersion(OperationTypes operationType)
         {
             switch (operationType)

--- a/src/Raven.Client/ServerWide/Tcp/TcpConnectionHeader.cs
+++ b/src/Raven.Client/ServerWide/Tcp/TcpConnectionHeader.cs
@@ -26,17 +26,26 @@ namespace Raven.Client.ServerWide.Tcp
         public int OperationVersion { get; set; }
 
         public string Info { get; set; }
-      
-        public static readonly int ClusterTcpVersion = 10;
-        public static readonly int HeartbeatsTcpVersion = 20;
-        public static readonly int ReplicationTcpVersion = 33;
-        public static readonly int SubscriptionTcpVersion = 40;
-        public static readonly int TestConnectionTcpVersion = 50;
+        
+        public static readonly int PingBaseLine40 = -1;
+        public static readonly int NoneBaseLine40 = -1;
+        public static readonly int DropBaseLine40 = -2;
+        public static readonly int ClusterBaseLine40 = 10;
+        public static readonly int HeartbeatsBaseLine40 = 20;
+        public static readonly int ReplicationBaseLine40 = 31;
+        public static readonly int ReplicationAttachmentMissing = 33;
+        public static readonly int SubscriptionBaseLine40 = 40;
+        public static readonly int TestConnectionBaseLine40 = 50;
 
+        public static readonly int ClusterTcpVersion = ClusterBaseLine40;
+        public static readonly int HeartbeatsTcpVersion = HeartbeatsBaseLine40;
+        public static readonly int ReplicationTcpVersion = ReplicationAttachmentMissing;
+        public static readonly int SubscriptionTcpVersion = SubscriptionBaseLine40;
+        public static readonly int TestConnectionTcpVersion = TestConnectionBaseLine40;
         public static (bool Supported, int PrevSupported) OperationVersionSupported(OperationTypes operationType, int version)
         {
             var prev = -1;
-            if (_operationsToSupportedProtocolVersions.TryGetValue(operationType, out var supportedProtocols) == false)
+            if (OperationsToSupportedProtocolVersions.TryGetValue(operationType, out var supportedProtocols) == false)
                 return (false, prev);
             
             for (var i =0; i< supportedProtocols.Count; prev = supportedProtocols[i], i++)
@@ -52,17 +61,17 @@ namespace Raven.Client.ServerWide.Tcp
             return (false, prev);
         }
 
-        private static readonly Dictionary<OperationTypes, List<int>> _operationsToSupportedProtocolVersions
+        private static readonly Dictionary<OperationTypes, List<int>> OperationsToSupportedProtocolVersions
         = new Dictionary<OperationTypes, List<int>>
             {
-                [OperationTypes.Ping] = new List<int> { -1},
-                [OperationTypes.None] = new List<int> { -1 },
-                [OperationTypes.Drop] = new List<int> { -2 },
-                [OperationTypes.Subscription] = new List<int> { 40 },
-                [OperationTypes.Replication] = new List<int> { 33, 31 },
-                [OperationTypes.Cluster] = new List<int> { 10 },
-                [OperationTypes.Heartbeats] = new List<int> { 20 },
-                [OperationTypes.TestConnection] = new List<int> { 50 },
+                [OperationTypes.Ping] = new List<int> { PingBaseLine40 },
+                [OperationTypes.None] = new List<int> { NoneBaseLine40 },
+                [OperationTypes.Drop] = new List<int> { DropBaseLine40 },
+                [OperationTypes.Subscription] = new List<int> { SubscriptionBaseLine40 },
+                [OperationTypes.Replication] = new List<int> { ReplicationAttachmentMissing, ReplicationBaseLine40 },
+                [OperationTypes.Cluster] = new List<int> { ClusterBaseLine40 },
+                [OperationTypes.Heartbeats] = new List<int> { HeartbeatsBaseLine40 },
+                [OperationTypes.TestConnection] = new List<int> { TestConnectionBaseLine40 },
         };
         public static int GetOperationTcpVersion(OperationTypes operationType)
         {

--- a/src/Raven.Client/ServerWide/Tcp/TcpNegotiation.cs
+++ b/src/Raven.Client/ServerWide/Tcp/TcpNegotiation.cs
@@ -1,0 +1,47 @@
+﻿using System;
+using System.Collections.Generic;
+using System.IO;
+using System.Text;
+using Sparrow.Json;
+using Sparrow.Json.Parsing;
+
+namespace Raven.Client.ServerWide.Tcp
+{
+    public class TcpNegotiation
+    {
+        public static int NegotiateProtocolVersion(JsonOperationContext documentsContext, Stream stream, TcpNegotiateParamaters parameters)
+        {
+            using (var writer = new BlittableJsonTextWriter(documentsContext, stream))
+            {
+                var currentVersion = parameters.Version;
+                while (true)
+                {
+                    documentsContext.Write(writer, new DynamicJsonValue
+                    {
+                        [nameof(TcpConnectionHeaderMessage.DatabaseName)] = parameters.Database, // _parent.Database.Name,
+                        [nameof(TcpConnectionHeaderMessage.Operation)] = parameters.Operation.ToString(),
+                        [nameof(TcpConnectionHeaderMessage.SourceNodeTag)] = parameters.NodeTag,
+                        [nameof(TcpConnectionHeaderMessage.OperationVersion)] = currentVersion
+                    });
+                    writer.Flush();
+                    var version = parameters.ReadRespondAndGetVersion(documentsContext, writer);
+                    var (supported, prevSupported) = TcpConnectionHeaderMessage.OperationVersionSupported(parameters.Operation, version);
+                    if (supported)
+                        return version;
+                    if (prevSupported == -1)
+                        return -1;
+                    currentVersion = prevSupported;
+                }
+            }
+        }
+    }
+    public class TcpNegotiateParamaters
+    {
+        public TcpConnectionHeaderMessage.OperationTypes Operation { get; set; }
+        public int Version { get; set; }
+        public string Database { get; set; }
+        public string NodeTag { get; set; }
+
+        public Func<JsonOperationContext, BlittableJsonTextWriter, int> ReadRespondAndGetVersion { get; set; }
+    }
+}

--- a/src/Raven.Client/ServerWide/Tcp/TcpNegotiation.cs
+++ b/src/Raven.Client/ServerWide/Tcp/TcpNegotiation.cs
@@ -30,13 +30,13 @@ namespace Raven.Client.ServerWide.Tcp
                     //In this case we usally throw internaly but for completeness we better handle it
                     if (version == -2)
                     {
-                        return TcpConnectionHeaderMessage.GetSupportedFeaturesFor(TcpConnectionHeaderMessage.OperationTypes.Drop, TcpConnectionHeaderMessage.DropBaseLine4000);
+                        return TcpConnectionHeaderMessage.GetSupportedFeaturesFor(TcpConnectionHeaderMessage.OperationTypes.Drop, TcpConnectionHeaderMessage.DropBaseLine40000);
                     }
                     var (supported, prevSupported) = TcpConnectionHeaderMessage.OperationVersionSupported(parameters.Operation, version);
                     if (supported)
                         return TcpConnectionHeaderMessage.GetSupportedFeaturesFor(parameters.Operation, version);
                     if (prevSupported == -1)
-                        return TcpConnectionHeaderMessage.GetSupportedFeaturesFor(TcpConnectionHeaderMessage.OperationTypes.None, TcpConnectionHeaderMessage.NoneBaseLine4000);
+                        return TcpConnectionHeaderMessage.GetSupportedFeaturesFor(TcpConnectionHeaderMessage.OperationTypes.None, TcpConnectionHeaderMessage.NoneBaseLine40000);
                     currentVersion = prevSupported;
                 }
             }
@@ -72,13 +72,13 @@ namespace Raven.Client.ServerWide.Tcp
                     //In this case we usally throw internaly but for completeness we better handle it
                     if (version == -2)
                     {
-                        return TcpConnectionHeaderMessage.GetSupportedFeaturesFor(TcpConnectionHeaderMessage.OperationTypes.Drop, TcpConnectionHeaderMessage.DropBaseLine4000);
+                        return TcpConnectionHeaderMessage.GetSupportedFeaturesFor(TcpConnectionHeaderMessage.OperationTypes.Drop, TcpConnectionHeaderMessage.DropBaseLine40000);
                     }
                     var (supported, prevSupported) = TcpConnectionHeaderMessage.OperationVersionSupported(parameters.Operation, version);
                     if (supported)
                         return TcpConnectionHeaderMessage.GetSupportedFeaturesFor(parameters.Operation, version);
                     if (prevSupported == -1)
-                        return TcpConnectionHeaderMessage.GetSupportedFeaturesFor(TcpConnectionHeaderMessage.OperationTypes.None, TcpConnectionHeaderMessage.NoneBaseLine4000);
+                        return TcpConnectionHeaderMessage.GetSupportedFeaturesFor(TcpConnectionHeaderMessage.OperationTypes.None, TcpConnectionHeaderMessage.NoneBaseLine40000);
                     currentVersion = prevSupported;
                 }
             }

--- a/src/Raven.Client/ServerWide/Tcp/TcpNegotiation.cs
+++ b/src/Raven.Client/ServerWide/Tcp/TcpNegotiation.cs
@@ -2,6 +2,8 @@
 using System.Collections.Generic;
 using System.IO;
 using System.Text;
+using System.Threading;
+using System.Threading.Tasks;
 using Sparrow.Json;
 using Sparrow.Json.Parsing;
 
@@ -24,7 +26,49 @@ namespace Raven.Client.ServerWide.Tcp
                         [nameof(TcpConnectionHeaderMessage.OperationVersion)] = currentVersion
                     });
                     writer.Flush();
-                    var version = parameters.ReadRespondAndGetVersion(documentsContext, writer);
+                    var version = parameters.ReadRespondAndGetVersion(documentsContext, writer, stream, parameters.Url);
+                    //In this case we usally throw internaly but for completeness we better handle it
+                    if (version == -2)
+                    {
+                        return TcpConnectionHeaderMessage.GetSupportedFeaturesFor(TcpConnectionHeaderMessage.OperationTypes.Drop, TcpConnectionHeaderMessage.DropBaseLine4000);
+                    }
+                    var (supported, prevSupported) = TcpConnectionHeaderMessage.OperationVersionSupported(parameters.Operation, version);
+                    if (supported)
+                        return TcpConnectionHeaderMessage.GetSupportedFeaturesFor(parameters.Operation, version);
+                    if (prevSupported == -1)
+                        return TcpConnectionHeaderMessage.GetSupportedFeaturesFor(TcpConnectionHeaderMessage.OperationTypes.None, TcpConnectionHeaderMessage.NoneBaseLine4000);
+                    currentVersion = prevSupported;
+                }
+            }
+        }
+
+        public static async Task<TcpConnectionHeaderMessage.SupportedFeatures> NegotiateProtocolVersionAsync(JsonOperationContext documentsContext, Stream stream, TcpNegotiateParamaters parameters)
+        {            
+            using (var writer = new BlittableJsonTextWriter(documentsContext, stream))
+            {
+                var currentVersion = parameters.Version;
+                while (true)
+                {
+                    if(parameters.CancellationToken.IsCancellationRequested)
+                        throw new OperationCanceledException($"Stoped Tcp negotiation for {parameters.Operation} because of cancelation request");
+
+                    documentsContext.Write(writer, new DynamicJsonValue
+                    {
+                        [nameof(TcpConnectionHeaderMessage.DatabaseName)] = parameters.Database, // _parent.Database.Name,
+                        [nameof(TcpConnectionHeaderMessage.Operation)] = parameters.Operation.ToString(),
+                        [nameof(TcpConnectionHeaderMessage.SourceNodeTag)] = parameters.NodeTag,
+                        [nameof(TcpConnectionHeaderMessage.OperationVersion)] = currentVersion
+                    });
+                    writer.Flush();
+                    int version;
+                    if (parameters.ReadRespondAndGetVersionAsync == null)
+                    {
+                        version = parameters.ReadRespondAndGetVersion(documentsContext, writer, stream, parameters.Url);
+                    }
+                    else
+                    {
+                        version = await parameters.ReadRespondAndGetVersionAsync(documentsContext, writer, stream, parameters.Url, parameters.CancellationToken).ConfigureAwait(false);                        
+                    }
                     //In this case we usally throw internaly but for completeness we better handle it
                     if (version == -2)
                     {
@@ -47,6 +91,11 @@ namespace Raven.Client.ServerWide.Tcp
         public string Database { get; set; }
         public string NodeTag { get; set; }
 
-        public Func<JsonOperationContext, BlittableJsonTextWriter, int> ReadRespondAndGetVersion { get; set; }
+        public string Url { get; set; }
+
+        public CancellationToken CancellationToken { get; set; }
+
+        public Func<JsonOperationContext, BlittableJsonTextWriter,Stream,string, int> ReadRespondAndGetVersion { get; set; }
+        public Func<JsonOperationContext, BlittableJsonTextWriter, Stream, string, CancellationToken, Task<int>> ReadRespondAndGetVersionAsync { get; set; }
     }
 }

--- a/src/Raven.Client/ServerWide/Tcp/TcpNegotiation.cs
+++ b/src/Raven.Client/ServerWide/Tcp/TcpNegotiation.cs
@@ -9,7 +9,7 @@ namespace Raven.Client.ServerWide.Tcp
 {
     public class TcpNegotiation
     {
-        public static int NegotiateProtocolVersion(JsonOperationContext documentsContext, Stream stream, TcpNegotiateParamaters parameters)
+        public static TcpFeaturesSupported NegotiateProtocolVersion(JsonOperationContext documentsContext, Stream stream, TcpNegotiateParamaters parameters)
         {
             using (var writer = new BlittableJsonTextWriter(documentsContext, stream))
             {
@@ -25,16 +25,50 @@ namespace Raven.Client.ServerWide.Tcp
                     });
                     writer.Flush();
                     var version = parameters.ReadRespondAndGetVersion(documentsContext, writer);
+                    //In this case we usally throw internaly but for completeness we better handle it
+                    if (version == -2)
+                    {
+                        return new TcpFeaturesSupported(parameters.Operation, -2);
+                    }
                     var (supported, prevSupported) = TcpConnectionHeaderMessage.OperationVersionSupported(parameters.Operation, version);
                     if (supported)
-                        return version;
+                        return new TcpFeaturesSupported(parameters.Operation, version);
                     if (prevSupported == -1)
-                        return -1;
+                        return new TcpFeaturesSupported(parameters.Operation, -1);
                     currentVersion = prevSupported;
                 }
             }
         }
     }
+
+    public class TcpFeaturesSupported
+    {
+        private int _version;
+        private TcpConnectionHeaderMessage.OperationTypes _type;
+
+        public TcpFeaturesSupported(TcpConnectionHeaderMessage.OperationTypes type, int protocolVersion)
+        {
+            _version = protocolVersion;
+            _type = type;
+        }
+
+        public bool IsMissingAttachmentSupported {
+            get
+            {
+                if (_type != TcpConnectionHeaderMessage.OperationTypes.Replication)
+                    throw new InvalidOperationException($"Was asked about IsAttachmentSupported while this object represents {_type} operation and attachments" +
+                                                        $" are only relevant to {TcpConnectionHeaderMessage.OperationTypes.Replication} protocols");
+                switch (_version)
+                {
+                    case 33:
+                        return true;
+                    default:
+                        return false;
+                }
+            }
+        }
+}
+
     public class TcpNegotiateParamaters
     {
         public TcpConnectionHeaderMessage.OperationTypes Operation { get; set; }

--- a/src/Raven.Server/Documents/Replication/IncomingReplicationHandler.cs
+++ b/src/Raven.Server/Documents/Replication/IncomingReplicationHandler.cs
@@ -62,7 +62,7 @@ namespace Raven.Server.Documents.Replication
             _database = options.DocumentDatabase;
             _tcpClient = options.TcpClient;
             _stream = options.Stream;
-            SupportedFeatures = new TcpFeaturesSupported(TcpConnectionHeaderMessage.OperationTypes.Replication, options.ProtocolVersion);
+            SupportedFeatures = TcpConnectionHeaderMessage.GetSupportedFeaturesFor(TcpConnectionHeaderMessage.OperationTypes.Replication, options.ProtocolVersion);
             ConnectionInfo.RemoteIp = ((IPEndPoint)_tcpClient.Client.RemoteEndPoint).Address.ToString();
             _parent = parent;
 
@@ -644,7 +644,7 @@ namespace Raven.Server.Documents.Replication
         private readonly ConflictManager _conflictManager;
         private IDisposable _connectionOptionsDisposable;
         private (IDisposable ReleaseBuffer, JsonOperationContext.ManagedPinnedBuffer Buffer) _copiedBuffer;
-        public TcpFeaturesSupported SupportedFeatures { get; private set; }
+        public TcpConnectionHeaderMessage.SupportedFeatures SupportedFeatures { get; set; }
 
         private struct ReplicationItem : IDisposable
         {
@@ -1083,7 +1083,7 @@ namespace Raven.Server.Documents.Replication
                                         }
                                         catch (MissingAttachmentException mae)
                                         {
-                                            if (_incoming.SupportedFeatures.IsMissingAttachmentSupported)
+                                            if (_incoming.SupportedFeatures.Replication.MissingAttachments)
                                             {
                                                 throw;
                                             }

--- a/src/Raven.Server/Documents/Replication/OutgoingReplicationHandler.cs
+++ b/src/Raven.Server/Documents/Replication/OutgoingReplicationHandler.cs
@@ -543,12 +543,6 @@ namespace Raven.Server.Documents.Replication
             }
         }
 
-        [MethodImpl(MethodImplOptions.AggressiveInlining)]
-        private bool CanCommunicateWithReplicationProtocol(int headerResponseVersion)
-        {
-            return _supportedProtocolVersions.Contains(headerResponseVersion);
-        }
-        
         private static HashSet<int> _supportedProtocolVersions = new HashSet<int>(){31,33};
         private bool WaitForChanges(int timeout, CancellationToken token)
         {

--- a/src/Raven.Server/Documents/Replication/OutgoingReplicationHandler.cs
+++ b/src/Raven.Server/Documents/Replication/OutgoingReplicationHandler.cs
@@ -477,7 +477,10 @@ namespace Raven.Server.Documents.Replication
                 };
                 //This will either throw or return acceptable protocol version.
                 SupportedFeatures = TcpNegotiation.NegotiateProtocolVersion(documentsContext, _stream, parameters);
-
+#if DEBUG
+                Debug.Assert(SupportedFeatures.ProtocolVersion != -1);
+                Debug.Assert(SupportedFeatures.ProtocolVersion != -2);
+#endif
                 //start request/response for fetching last etag
                 var request = new DynamicJsonValue
                 {
@@ -863,7 +866,7 @@ namespace Raven.Server.Documents.Replication
 
         private readonly SingleUseFlag _disposed = new SingleUseFlag();
         private readonly DateTime _startedAt = DateTime.UtcNow;
-        public TcpFeaturesSupported SupportedFeatures { get; private set; }
+        public TcpConnectionHeaderMessage.SupportedFeatures SupportedFeatures { get; private set; }
 
         public void Dispose()
         {

--- a/src/Raven.Server/Documents/Replication/OutgoingReplicationHandler.cs
+++ b/src/Raven.Server/Documents/Replication/OutgoingReplicationHandler.cs
@@ -86,7 +86,6 @@ namespace Raven.Server.Documents.Replication
             _connectionInfo = connectionInfo;
             _database.Changes.OnDocumentChange += OnDocumentChange;
             _cts = CancellationTokenSource.CreateLinkedTokenSource(_database.DatabaseShutdown);
-            _protocolVersion = TcpConnectionHeaderMessage.ReplicationTcpVersion;
         }
 
         public OutgoingReplicationPerformanceStats[] GetReplicationPerformance()
@@ -477,7 +476,7 @@ namespace Raven.Server.Documents.Replication
                     Version = TcpConnectionHeaderMessage.ReplicationTcpVersion
                 };
                 //This will either throw or return acceptable protocol version.
-                _protocolVersion = TcpNegotiation.NegotiateProtocolVersion(documentsContext, _stream, parameters);
+                SupportedFeatures = TcpNegotiation.NegotiateProtocolVersion(documentsContext, _stream, parameters);
 
                 //start request/response for fetching last etag
                 var request = new DynamicJsonValue
@@ -864,7 +863,7 @@ namespace Raven.Server.Documents.Replication
 
         private readonly SingleUseFlag _disposed = new SingleUseFlag();
         private readonly DateTime _startedAt = DateTime.UtcNow;
-        private int _protocolVersion;
+        public TcpFeaturesSupported SupportedFeatures { get; private set; }
 
         public void Dispose()
         {

--- a/src/Raven.Server/Documents/Replication/OutgoingReplicationHandler.cs
+++ b/src/Raven.Server/Documents/Replication/OutgoingReplicationHandler.cs
@@ -496,7 +496,7 @@ namespace Raven.Server.Documents.Replication
                 writer.Flush();
             }
         }
-        private int ReadHeaderResponseAndThrowIfUnAuthorized(JsonOperationContext jsonContext, BlittableJsonTextWriter writer)
+        private int ReadHeaderResponseAndThrowIfUnAuthorized(JsonOperationContext jsonContext, BlittableJsonTextWriter writer, Stream stream, string url)
         {
             const int timeout = 2 * 60 * 1000; 
             using (var replicationTcpConnectReplyMessage = _interruptibleRead.ParseToMemory(
@@ -518,7 +518,7 @@ namespace Raven.Server.Documents.Replication
                 switch (headerResponse.Status)
                 {
                     case TcpConnectionStatus.Ok:
-                        break;
+                        return headerResponse.Version;
                     case TcpConnectionStatus.AuthorizationFailed:
                         throw new AuthorizationException($"{Destination.FromString()} replied with failure {headerResponse.Message}");
                     case TcpConnectionStatus.TcpVersionMismatch:
@@ -541,8 +541,6 @@ namespace Raven.Server.Documents.Replication
                         throw new InvalidOperationException($"{Destination.FromString()} replied with unknown status {headerResponse.Status}, message:{headerResponse.Message}");
                 }
             }
-
-            return TcpConnectionHeaderMessage.ReplicationTcpVersion;
         }
 
         [MethodImpl(MethodImplOptions.AggressiveInlining)]

--- a/src/Raven.Server/Documents/Replication/ReplicationDocumentSender.cs
+++ b/src/Raven.Server/Documents/Replication/ReplicationDocumentSender.cs
@@ -5,6 +5,7 @@ using System.Diagnostics;
 using System.IO;
 using System.Linq;
 using System.Runtime.CompilerServices;
+using Raven.Client.Documents.Attachments;
 using Raven.Client.Documents.Operations.Replication;
 using Raven.Client.Documents.Replication.Messages;
 using Sparrow;
@@ -28,6 +29,7 @@ namespace Raven.Server.Documents.Replication
         private readonly OutgoingReplicationHandler _parent;
         private OutgoingReplicationStatsScope _statsInstance;
         private readonly ReplicationStats _stats = new ReplicationStats();
+        public bool MissingAttachmentsInLastBatch { get; private set; }
 
         public ReplicationDocumentSender(Stream stream, OutgoingReplicationHandler parent, Logger log)
         {
@@ -181,6 +183,8 @@ namespace Raven.Server.Documents.Replication
                     var numberOfItemsSent = 0;
                     var skippedReplicationItemsInfo = new SkippedReplicationItemsInfo();
                     short lastTransactionMarker = -1;
+                    long prevLastEtag = _lastEtag;
+
                     using (_stats.Storage.Start())
                     {
                         foreach (var item in GetDocsConflictsTombstonesRevisionsAndAttachmentsAfter(documentsContext, _lastEtag, _stats))
@@ -222,6 +226,25 @@ namespace Raven.Server.Documents.Replication
                             }
 
                             _stats.Storage.RecordInputAttempt();
+
+                            //Here we add missing attachments in the same batch as the document that contains them without modifying the last etag or transaction boundry
+                            if (MissingAttachmentsInLastBatch &&
+                                item.Type == ReplicationBatchItem.ReplicationItemType.Document &&
+                                (item.Flags & DocumentFlags.HasAttachments) == DocumentFlags.HasAttachments)
+                            {
+                                var type = (item.Flags & DocumentFlags.Revision) == DocumentFlags.Revision ? AttachmentType.Revision : AttachmentType.Document;
+                                foreach (var attachment in _parent._database.DocumentsStorage.AttachmentsStorage.GetAttachmentsForDocument(documentsContext, type, item.Id))
+                                {
+                                    //We need to filter attachments that are been sent in the same batch as the document
+                                    if (attachment.Etag >= prevLastEtag)
+                                        continue;
+                                    var stream = _parent._database.DocumentsStorage.AttachmentsStorage.GetAttachmentStream(documentsContext, attachment.Base64Hash);
+                                    attachment.Stream = stream;
+                                    AddReplicationItemToBatch(ReplicationBatchItem.From(attachment), _stats.Storage, skippedReplicationItemsInfo);
+                                    size += attachment.Stream.Length;
+                                }
+
+                            }
 
                             _lastEtag = item.Etag;
 
@@ -269,6 +292,8 @@ namespace Raven.Server.Documents.Replication
                         using (_stats.Network.Start())
                         {
                             SendDocumentsBatch(documentsContext, _stats.Network);
+                            if (MissingAttachmentsInLastBatch)
+                                return false;
                         }
                     }
                     catch (OperationCanceledException)
@@ -283,6 +308,9 @@ namespace Raven.Server.Documents.Replication
                             _log.Info("Failed to send document replication batch", e);
                         throw;
                     }
+
+                    MissingAttachmentsInLastBatch = false;
+
                     return true;
                 }
                 finally
@@ -383,7 +411,8 @@ namespace Raven.Server.Documents.Replication
             }
 
             // destination already has it
-            if (ChangeVectorUtils.GetConflictStatus(item.ChangeVector, _parent.LastAcceptedChangeVector) == ConflictStatus.AlreadyMerged)
+            if ((MissingAttachmentsInLastBatch == false || item.Type != ReplicationBatchItem.ReplicationItemType.Attachment) &&
+                ChangeVectorUtils.GetConflictStatus(item.ChangeVector, _parent.LastAcceptedChangeVector) == ConflictStatus.AlreadyMerged)
             {
                 stats.RecordChangeVectorSkip();
                 skippedReplicationItemsInfo.Update(item);
@@ -448,8 +477,12 @@ namespace Raven.Server.Documents.Replication
             if (_log.IsInfoEnabled && _orderedReplicaItems.Count > 0)
                 _log.Info($"Finished sending replication batch. Sent {_orderedReplicaItems.Count:#,#;;0} documents and {_replicaAttachmentStreams.Count:#,#;;0} attachment streams in {sw.ElapsedMilliseconds:#,#;;0} ms. Last sent etag = {_lastEtag}");
 
-            _parent.HandleServerResponse();
-
+            var (type, _) = _parent.HandleServerResponse();
+            if (type == ReplicationMessageReply.ReplyType.MissingAttachments)
+            {
+                MissingAttachmentsInLastBatch = true;
+                return;
+            }
             _parent._lastSentDocumentEtag = _lastEtag;
 
             _parent._lastDocumentSentTime = DateTime.UtcNow;

--- a/src/Raven.Server/Documents/Replication/ReplicationMessageReply.cs
+++ b/src/Raven.Server/Documents/Replication/ReplicationMessageReply.cs
@@ -6,7 +6,8 @@
         {
             None,
             Ok,
-            Error
+            Error,
+            MissingAttachments
         }
 
         public ReplyType Type { get; set; }

--- a/src/Raven.Server/Documents/TcpHandlers/TcpConnectionOptions.cs
+++ b/src/Raven.Server/Documents/TcpHandlers/TcpConnectionOptions.cs
@@ -29,6 +29,7 @@ namespace Raven.Server.Documents.TcpHandlers
 
         public TcpClient TcpClient;
 
+        public int ProtocolVersion;
         public TcpConnectionOptions()
         {
             _bytesReceivedMetric = new MeterMetric();

--- a/src/Raven.Server/Exceptions/MissingAttachmentException.cs
+++ b/src/Raven.Server/Exceptions/MissingAttachmentException.cs
@@ -1,0 +1,25 @@
+﻿using System;
+using System.Runtime.Serialization;
+
+namespace Raven.Server.Exceptions
+{
+    [Serializable]
+    internal class MissingAttachmentException : Exception
+    {
+        public MissingAttachmentException()
+        {
+        }
+
+        public MissingAttachmentException(string message) : base(message)
+        {
+        }
+
+        public MissingAttachmentException(string message, Exception innerException) : base(message, innerException)
+        {
+        }
+
+        protected MissingAttachmentException(SerializationInfo info, StreamingContext context) : base(info, context)
+        {
+        }
+    }
+}

--- a/src/Raven.Server/Extensions/ExceptionExtensions.cs
+++ b/src/Raven.Server/Extensions/ExceptionExtensions.cs
@@ -30,5 +30,15 @@ namespace Raven.Server.Extensions
 
             return e.InnerExceptions[0];
         }
+
+        public static Exception ExtractSingleInnerException(this Exception e)
+        {
+            if (e is AggregateException ae)
+            {
+                return ae.ExtractSingleInnerException();
+            }
+
+            return e;
+        }
     }
 }

--- a/src/Raven.Server/NotificationCenter/Notifications/AlertType.cs
+++ b/src/Raven.Server/NotificationCenter/Notifications/AlertType.cs
@@ -45,6 +45,8 @@ namespace Raven.Server.NotificationCenter.Notifications
 
         RevisionsConfigurationNotValid,
 
+        ReplicationMissingAttachments,
+
         OutOfMemoryException
     }
 }

--- a/src/Raven.Server/Rachis/CandidateAmbassador.cs
+++ b/src/Raven.Server/Rachis/CandidateAmbassador.cs
@@ -113,7 +113,9 @@ namespace Raven.Server.Rachis
                         {
                             using (_engine.ContextPool.AllocateOperationContext(out TransactionOperationContext context))
                             {
-                                (stream, disconnect) = _engine.ConnectToPeer(_url, _certificate, context).Result;
+                                var connection = _engine.ConnectToPeer(_url, _certificate, context).Result;
+                                stream = connection.Stream;
+                                disconnect = connection.Disconnect;
                             }
 
                             if (_candidate.Running == false)

--- a/src/Raven.Server/Rachis/FollowerAmbassador.cs
+++ b/src/Raven.Server/Rachis/FollowerAmbassador.cs
@@ -177,7 +177,9 @@ namespace Raven.Server.Rachis
                                 using (_engine.ContextPool.AllocateOperationContext(out TransactionOperationContext context))
                                 {
                                     _engine.RemoveAndDispose(_leader, _connection);
-                                    var (stream, disconnect) = _engine.ConnectToPeer(_url, _certificate, context).Result;
+                                    var connection = _engine.ConnectToPeer(_url, _certificate, context).Result;
+                                    var stream = connection.Stream;
+                                    var disconnect = connection.Disconnect;
                                     var con = new RemoteConnection(_tag, _engine.Tag, _term, stream, disconnect);
                                     Interlocked.Exchange(ref _connection, con);
                                     ClusterTopology topology;

--- a/src/Raven.Server/Rachis/RachisConnection.cs
+++ b/src/Raven.Server/Rachis/RachisConnection.cs
@@ -1,0 +1,15 @@
+﻿using System;
+using System.Collections.Generic;
+using System.IO;
+using System.Text;
+using Raven.Client.ServerWide.Tcp;
+
+namespace Raven.Server.Rachis
+{
+    public class RachisConnection
+    {
+        public Stream Stream { get; set; }
+        public Action Disconnect { get; set; }
+        public TcpConnectionHeaderMessage.SupportedFeatures SupportedFeatures { get; set; }
+    }
+}

--- a/src/Raven.Server/Rachis/RachisConsensus.cs
+++ b/src/Raven.Server/Rachis/RachisConsensus.cs
@@ -91,7 +91,7 @@ namespace Raven.Server.Rachis
             StateMachine.OnSnapshotInstalled(context, lastIncludedIndex, _serverStore);
         }
 
-        public override Task<(Stream Stream, Action Disconnect)> ConnectToPeer(string url, X509Certificate2 certificate, TransactionOperationContext context = null)
+        public override Task<RachisConnection> ConnectToPeer(string url, X509Certificate2 certificate, TransactionOperationContext context = null)
         {
             return StateMachine.ConnectToPeer(url, certificate);
         }
@@ -1611,7 +1611,7 @@ namespace Raven.Server.Rachis
             ContextPool?.Dispose();
         }
 
-        public abstract Task<(Stream Stream, Action Disconnect)> ConnectToPeer(string url, X509Certificate2 certificate, TransactionOperationContext context = null);
+        public abstract Task<RachisConnection> ConnectToPeer(string url, X509Certificate2 certificate, TransactionOperationContext context = null);
 
         public class BootstrapOptions
         {

--- a/src/Raven.Server/Rachis/RachisStateMachine.cs
+++ b/src/Raven.Server/Rachis/RachisStateMachine.cs
@@ -73,7 +73,7 @@ namespace Raven.Server.Rachis
 
         public abstract bool ShouldSnapshot(Slice slice, RootObjectType type);
 
-        public abstract Task<(Stream Stream, Action Disconnect)> ConnectToPeer(string url, X509Certificate2 certificate);
+        public abstract Task<RachisConnection> ConnectToPeer(string url, X509Certificate2 certificate);
 
         public virtual void OnSnapshotInstalled(TransactionOperationContext context, long lastIncludedIndex, ServerStore serverStore)
         {

--- a/src/Raven.Server/RavenServer.cs
+++ b/src/Raven.Server/RavenServer.cs
@@ -1136,6 +1136,9 @@ namespace Raven.Server
                                             return;
                                         }
 
+                                        if (header.Operation == TcpConnectionHeaderMessage.OperationTypes.Ping)
+                                            break;
+
                                     }                                    
 
                                     var (isSupported, prevSupported) = TcpConnectionHeaderMessage.OperationVersionSupported(header.Operation, header.OperationVersion);

--- a/src/Raven.Server/ServerWide/ClusterStateMachine.cs
+++ b/src/Raven.Server/ServerWide/ClusterStateMachine.cs
@@ -1380,8 +1380,37 @@ namespace Raven.Server.ServerWide
             Debug.Assert(size == sizeof(long));
             return size;
         }
+        private int ClusterReadRespondAndGetVersion(JsonOperationContext ctx, BlittableJsonTextWriter writer, Stream stream, string url)
+        {            
+            using (var response = ctx.ReadForMemory(stream, "cluster-ConnectToPeer-header-response"))
+            {
+                var reply = JsonDeserializationServer.TcpConnectionHeaderResponse(response);
+                switch (reply.Status)
+                {
+                    case TcpConnectionStatus.Ok:
+                        return reply.Version;
+                    case TcpConnectionStatus.AuthorizationFailed:
+                        throw new AuthorizationException($"Unable to access  {url} because {reply.Message}");
+                    case TcpConnectionStatus.TcpVersionMismatch:
+                        if (reply.Version != -1)
+                        {
+                            return reply.Version;
+                        }
+                        //Kindly request the server to drop the connection
+                        ctx.Write( writer , new DynamicJsonValue
+                        {
+                            [nameof(TcpConnectionHeaderMessage.DatabaseName)] = null,
+                            [nameof(TcpConnectionHeaderMessage.Operation)] = TcpConnectionHeaderMessage.OperationTypes.Drop,
+                            [nameof(TcpConnectionHeaderMessage.OperationVersion)] = TcpConnectionHeaderMessage.ClusterTcpVersion,
+                            [nameof(TcpConnectionHeaderMessage.Info)] = $"Couldn't agree on cluster tcp version ours:{TcpConnectionHeaderMessage.ClusterTcpVersion} theirs:{reply.Version}"
+                        });
+                        throw new InvalidOperationException($"Unable to access  {url} because {reply.Message}");
+                }
+            }
 
-        public override async Task<(Stream Stream, Action Disconnect)> ConnectToPeer(string url, X509Certificate2 certificate)
+            return TcpConnectionHeaderMessage.ClusterTcpVersion;
+        }
+        public override async Task<RachisConnection> ConnectToPeer(string url, X509Certificate2 certificate)
         {
             if (url == null)
                 throw new ArgumentNullException(nameof(url));
@@ -1403,60 +1432,40 @@ namespace Raven.Server.ServerWide
                 tcpClient = await TcpUtils.ConnectAsync(info.Url, _parent.TcpConnectionTimeout).ConfigureAwait(false);
                 stream = await TcpUtils.WrapStreamWithSslAsync(tcpClient, info, _parent.ClusterCertificate, _parent.TcpConnectionTimeout);
 
+                var paramaters = new TcpNegotiateParamaters
+                {
+                    Database = null,
+                    Operation = TcpConnectionHeaderMessage.OperationTypes.Cluster,
+                    Version = TcpConnectionHeaderMessage.ClusterTcpVersion,
+                    ReadRespondAndGetVersion = ClusterReadRespondAndGetVersion,
+                    Url = info.Url
+                };
+
+                TcpConnectionHeaderMessage.SupportedFeatures supportedFeatures;
                 using (ContextPoolForReadOnlyOperations.AllocateOperationContext(out JsonOperationContext context))
                 {
-                    var msg = new DynamicJsonValue
-                    {
-                        [nameof(TcpConnectionHeaderMessage.DatabaseName)] = null,
-                        [nameof(TcpConnectionHeaderMessage.Operation)] = TcpConnectionHeaderMessage.OperationTypes.Cluster,
-                        [nameof(TcpConnectionHeaderMessage.OperationVersion)] = TcpConnectionHeaderMessage.ClusterTcpVersion
-                    };
-                    using (var writer = new BlittableJsonTextWriter(context, stream))
-                    using (var msgJson = context.ReadObject(msg, "message"))
-                    {
-                        context.Write(writer, msgJson);
-                    }
-                    using (var response = context.ReadForMemory(stream, "cluster-ConnectToPeer-header-response"))
-                    {
-                        var reply = JsonDeserializationServer.TcpConnectionHeaderResponse(response);
-                        switch (reply.Status)
-                        {
-                            case TcpConnectionStatus.Ok:
-                                break;
-                            case TcpConnectionStatus.AuthorizationFailed:
-                                throw new AuthorizationException($"Unable to access  {url} because {reply.Message}");
-                            case TcpConnectionStatus.TcpVersionMismatch:
-                                //Kindly request the server to drop the connection
-                                msg = new DynamicJsonValue
-                                {
-                                    [nameof(TcpConnectionHeaderMessage.DatabaseName)] = null,
-                                    [nameof(TcpConnectionHeaderMessage.Operation)] = TcpConnectionHeaderMessage.OperationTypes.Drop,
-                                    [nameof(TcpConnectionHeaderMessage.OperationVersion)] = TcpConnectionHeaderMessage.ClusterTcpVersion,
-                                    [nameof(TcpConnectionHeaderMessage.Info)] = $"Couldn't agree on cluster tcp version ours:{TcpConnectionHeaderMessage.ClusterTcpVersion} theirs:{reply.Version}"
-                                };
-                                using (var writer = new BlittableJsonTextWriter(context, stream))
-                                using (var msgJson = context.ReadObject(msg, "message"))
-                                {
-                                    context.Write(writer, msgJson);
-                                }
-                                throw new InvalidOperationException($"Unable to access  {url} because {reply.Message}");
-                        }
-                    }
+                    supportedFeatures = TcpNegotiation.NegotiateProtocolVersion(context, stream, paramaters);
                 }
-                return (stream, () =>
+
+                return new RachisConnection
                 {
+                    Stream = stream,
+                    SupportedFeatures = supportedFeatures,
+                    Disconnect = () =>
                     {
-                        try
                         {
-                            tcpClient.Client.Disconnect(false);
-                        }
-                        catch (ObjectDisposedException)
-                        {
-                            //Happens, we don't really care at this point
+                            try
+                            {
+                                tcpClient.Client.Disconnect(false);
+                            }
+                            catch (ObjectDisposedException)
+                            {
+                                //Happens, we don't really care at this point
+                            }
                         }
                     }
-                }
-                );
+                };
+
             }
             catch (Exception)
             {
@@ -1465,6 +1474,7 @@ namespace Raven.Server.ServerWide
                 throw;
             }
         }
+
 
         public override void OnSnapshotInstalled(TransactionOperationContext context, long lastIncludedIndex, ServerStore serverStore)
         {

--- a/src/Raven.Server/ServerWide/Maintenance/ClusterMaintenanceConnection.cs
+++ b/src/Raven.Server/ServerWide/Maintenance/ClusterMaintenanceConnection.cs
@@ -1,0 +1,16 @@
+﻿using System;
+using System.Collections.Generic;
+using System.IO;
+using System.Net.Sockets;
+using System.Text;
+using Raven.Client.ServerWide.Tcp;
+
+namespace Raven.Server.ServerWide.Maintenance
+{
+    public class ClusterMaintenanceConnection
+    {
+        public Stream Stream { get; set; }
+        public TcpClient TcpClient { get; set; }
+        public TcpConnectionHeaderMessage.SupportedFeatures SupportedFeatures { get; set; }
+    }
+}

--- a/src/Voron/Data/BTrees/Tree.Stream.cs
+++ b/src/Voron/Data/BTrees/Tree.Stream.cs
@@ -257,7 +257,13 @@ namespace Voron.Data.BTrees
             return new VoronStream(tree.Name, chunksDetails, _llt);
         }
 
-        public int TouchStream(Slice key)
+        public bool StreamExist(Slice key)
+        {
+            var tree = FixedTreeFor(key, ChunkDetails.SizeOf);
+            return tree.NumberOfEntries > 0;
+        }
+
+    public int TouchStream(Slice key)
         {
             var info = GetStreamInfo(key, writable: true);
 

--- a/src/Voron/Slice.cs
+++ b/src/Voron/Slice.cs
@@ -127,6 +127,12 @@ namespace Voron
         }
 
         [MethodImpl(MethodImplOptions.AggressiveInlining)]
+        public static ByteStringContext.InternalScope From(ByteStringContext context, LazyStringValue value, out Slice str)
+        {
+            return From(context, value.Buffer, value.Size, ByteStringType.Immutable, out str);
+        }
+
+        [MethodImpl(MethodImplOptions.AggressiveInlining)]
         public static ByteStringContext.InternalScope From(ByteStringContext context, byte* value, int size, ByteStringType type, out Slice str)
         {
             var scope = context.From(value, size, type, out ByteString byteString);

--- a/test/FastTests/Server/Replication/ReplicationTestBase.cs
+++ b/test/FastTests/Server/Replication/ReplicationTestBase.cs
@@ -160,6 +160,23 @@ namespace FastTests.Server.Replication
             return null;
         }
 
+        protected T WaitForDocumentWithAttachmentToReplicate<T>(IDocumentStore store, string id, string attachmentName, int timeout)
+            where T : class
+        {
+            var sw = Stopwatch.StartNew();
+            while (sw.ElapsedMilliseconds <= timeout)
+            {
+                using (var session = store.OpenSession(store.Database))
+                {
+                    var doc = session.Load<T>(id);
+                    if (doc != null && session.Advanced.Attachments.Exists(id, attachmentName))
+                        return doc;
+                }
+                Thread.Sleep(100);
+            }
+
+            return null;
+        }
         public class SetupResult : IDisposable
         {
             public IReadOnlyList<ServerNode> Nodes;

--- a/test/Tests.Infrastructure/RachisConsensusTestBase.cs
+++ b/test/Tests.Infrastructure/RachisConsensusTestBase.cs
@@ -378,7 +378,7 @@ namespace Tests.Infrastructure
                 {
                     Stream = tcpClient.GetStream(),
 
-                    SupportedFeatures = new TcpConnectionHeaderMessage.SupportedFeatures(TcpConnectionHeaderMessage.NoneBaseLine4000),
+                    SupportedFeatures = new TcpConnectionHeaderMessage.SupportedFeatures(TcpConnectionHeaderMessage.NoneBaseLine40000),
                     Disconnect = () => tcpClient.Client.Disconnect(false)
                 };                
             }


### PR DESCRIPTION
+++++++++++
| DON'T MERGE |
+++++++++++
This PR includes the port of the missing attachment fix.
It also includes the start of trying to correct the handling of TCP operation versioning.
I think that the TCP versioning is something that is going to grow in complexity and we need to handle now before we go live with v4.1 since it will put constraints we will find hard to break later on.
In my simple approach, I'm planning to state for each server which protocol version he supports for each operation.
What I'm still missing (WIP) is the destination handling of an unmatching operation version.
It is possible that the destination is able to work with a lower protocol version but the source isn't able to handle the destination version E.G. replication from 4.0 to 4.1, there is no way 4.0 could talk with a 4.1 protocol but 4.1 could respond as if it was 4.0.
I have started to modify the accept TCP connection and the idea is that if I support your version I'll accept the connection and pass the accepted protocol version down the line to be handled by the "bundles".
This means that each "bundle" will have to deal with the protocol giving to it with the TCP stream, for incoming replication that means not responding with missing attachment to a v4.0 server but raising a flag instead. for outgoing replication that may mean not sending counters to a v4.0 server.
This is not a complete solution nor is this set in stone, your feedback is appreciated.