### PR TITLE
[4.0] RavenDB-11444 Wake the database for backups

### DIFF
--- a/src/Raven.Server/Documents/DatabaseInfoCache.cs
+++ b/src/Raven.Server/Documents/DatabaseInfoCache.cs
@@ -50,7 +50,6 @@ namespace Raven.Server.Documents
             using (var tx = context.OpenWriteTransaction())
             {
                 var table = tx.InnerTransaction.OpenTable(_databaseInfoSchema, DatabaseInfoSchema.DatabaseInfoTree);
-
                 using (var id = context.GetLazyString(databaseName.ToLowerInvariant()))
                 using (var json = context.ReadObject(databaseInfo, "DatabaseInfo", BlittableJsonDocumentBuilder.UsageMode.ToDisk))
                 {
@@ -100,7 +99,7 @@ namespace Raven.Server.Documents
         }
 
         /// <summary>
-        /// This method deletes the database info from the cache when the databse is deleted.
+        /// This method deletes the database info from the cache when the database is deleted.
         /// It assumes that the ctx already opened a write transaction.
         /// </summary>
         /// <param name="ctx">A context allocated outside the method with an open write transaction</param>
@@ -108,7 +107,7 @@ namespace Raven.Server.Documents
         public void DeleteInternal(TransactionOperationContext ctx, Slice databaseName)
         {
             if (Logger.IsInfoEnabled)
-                Logger.Info($"Deleteing database info for '{databaseName}'.");
+                Logger.Info($"Deleting database info for '{databaseName}'.");
             var table = ctx.Transaction.InnerTransaction.OpenTable(_databaseInfoSchema, DatabaseInfoSchema.DatabaseInfoTree);
             table.DeleteByKey(databaseName);
         }

--- a/src/Raven.Server/Documents/DocumentDatabase.cs
+++ b/src/Raven.Server/Documents/DocumentDatabase.cs
@@ -57,7 +57,7 @@ namespace Raven.Server.Documents
         private readonly ServerStore _serverStore;
         private readonly Action<string> _addToInitLog;
         private readonly Logger _logger;
-        private DisposeOnce<SingleAttempt> _disposeOnce;
+        private readonly DisposeOnce<SingleAttempt> _disposeOnce;
 
         private readonly CancellationTokenSource _databaseShutdown = new CancellationTokenSource();
 
@@ -124,7 +124,7 @@ namespace Raven.Server.Documents
                 HugeDocuments = new HugeDocuments(configuration.PerformanceHints.HugeDocumentsCollectionSize,
                     configuration.PerformanceHints.HugeDocumentSize.GetValue(SizeUnit.Bytes));
                 ConfigurationStorage = new ConfigurationStorage(this);
-                NotificationCenter = new NotificationCenter.NotificationCenter(ConfigurationStorage.NotificationsStorage, Name, _databaseShutdown.Token);
+                NotificationCenter = new NotificationCenter.NotificationCenter(ConfigurationStorage.NotificationsStorage, Name, DatabaseShutdown);
                 Operations = new Operations.Operations(Name, ConfigurationStorage.OperationsStorage, NotificationCenter, Changes);
                 DatabaseInfoCache = serverStore.DatabaseInfoCache;
                 RachisLogIndexNotifications = new RachisLogIndexNotifications(DatabaseShutdown);
@@ -370,6 +370,7 @@ namespace Raven.Server.Documents
 
         private unsafe void DisposeInternal()
         {
+            _databaseShutdown.Cancel();
 
             //before we dispose of the database we take its latest info to be displayed in the studio
             try
@@ -385,8 +386,6 @@ namespace Raven.Server.Documents
                 if (_logger.IsInfoEnabled)
                     _logger.Info("Failed to generate and store database info", e);
             }
-
-            _databaseShutdown.Cancel();
 
             // we'll wait for 1 minute to drain all the requests
             // from the database
@@ -584,7 +583,6 @@ namespace Raven.Server.Documents
                 _lastIdleTicks = DateTime.UtcNow.Ticks;
                 IndexStore?.RunIdleOperations();
                 Operations?.CleanupOperations();
-                PeriodicBackupRunner?.RemoveInactiveCompletedTasks();
                 DocumentsStorage.Environment.ScratchBufferPool.Cleanup();
             }
             finally

--- a/src/Raven.Server/Documents/PeriodicBackup/BackupTask.cs
+++ b/src/Raven.Server/Documents/PeriodicBackup/BackupTask.cs
@@ -501,7 +501,7 @@ namespace Raven.Server.Documents.PeriodicBackup
             {
                 var smugglerSource = new DatabaseSource(_database, startDocumentEtag.Value);
                 var smugglerDestination = new StreamDestination(file, context, smugglerSource);
-                var smuggler = new Smuggler.Documents.DatabaseSmuggler(_database,
+                var smuggler = new DatabaseSmuggler(_database,
                     smugglerSource,
                     smugglerDestination,
                     _database.Time,

--- a/src/Raven.Server/ServerWide/ServerStore.cs
+++ b/src/Raven.Server/ServerWide/ServerStore.cs
@@ -1419,13 +1419,8 @@ namespace Raven.Server.ServerWide
                     foreach (var db in databasesToCleanup)
                     {
 
-                        if (DatabasesLandlord.DatabasesCache.TryGetValue(db, out Task<DocumentDatabase> resourceTask) &&
-                            resourceTask != null &&
-                            resourceTask.Status == TaskStatus.RanToCompletion &&
-                            resourceTask.Result.PeriodicBackupRunner != null &&
-                            resourceTask.Result.PeriodicBackupRunner.HasRunningBackups())
+                        if (DatabasesLandlord.DatabasesCache.TryGetValue(db, out Task<DocumentDatabase> resourceTask) == false)
                         {
-                            // there are running backups for this database
                             continue;
                         }
 
@@ -1454,7 +1449,7 @@ namespace Raven.Server.ServerWide
                         if (idleDbInstance.CanUnload == false)
                             continue;
 
-                        DatabasesLandlord.UnloadDirectly(db);
+                        DatabasesLandlord.UnloadDirectly(db, idleDbInstance.PeriodicBackupRunner.GetWakeDatabaseTime());
                     }
 
                 }

--- a/src/Raven.Server/Web/System/AdminDatabasesHandler.cs
+++ b/src/Raven.Server/Web/System/AdminDatabasesHandler.cs
@@ -1155,7 +1155,7 @@ namespace Raven.Server.Web.System
                         {
                             using (database.PreventFromUnloading())
                             {
-                                // send some initial progess so studio can open details 
+                                // send some initial progress so studio can open details 
                                 result.AddInfo("Starting migration");
                                 result.AddInfo($"Path of temporary export file: {tmpFile}");
                                 onProgress(overallProgress);


### PR DESCRIPTION
Always wake up the database for a full backup.
But for incremental, wake the database only if changes were made.

- Prevent the database to unload during the actual backup process.
- Unloading a database due to idleness will generate a wakeup timer, dependent on the nearest backup task.