### PR TITLE
[4.1] RavenDB-11444 Wake the database for backups

### DIFF
--- a/src/Raven.Server/Documents/DatabaseInfoCache.cs
+++ b/src/Raven.Server/Documents/DatabaseInfoCache.cs
@@ -50,7 +50,6 @@ namespace Raven.Server.Documents
             using (var tx = context.OpenWriteTransaction())
             {
                 var table = tx.InnerTransaction.OpenTable(_databaseInfoSchema, DatabaseInfoSchema.DatabaseInfoTree);
-
                 using (var id = context.GetLazyString(databaseName.ToLowerInvariant()))
                 using (var json = context.ReadObject(databaseInfo, "DatabaseInfo", BlittableJsonDocumentBuilder.UsageMode.ToDisk))
                 {
@@ -100,7 +99,7 @@ namespace Raven.Server.Documents
         }
 
         /// <summary>
-        /// This method deletes the database info from the cache when the databse is deleted.
+        /// This method deletes the database info from the cache when the database is deleted.
         /// It assumes that the ctx already opened a write transaction.
         /// </summary>
         /// <param name="ctx">A context allocated outside the method with an open write transaction</param>
@@ -108,7 +107,7 @@ namespace Raven.Server.Documents
         public void DeleteInternal(TransactionOperationContext ctx, Slice databaseName)
         {
             if (Logger.IsInfoEnabled)
-                Logger.Info($"Deleteing database info for '{databaseName}'.");
+                Logger.Info($"Deleting database info for '{databaseName}'.");
             var table = ctx.Transaction.InnerTransaction.OpenTable(_databaseInfoSchema, DatabaseInfoSchema.DatabaseInfoTree);
             table.DeleteByKey(databaseName);
         }

--- a/src/Raven.Server/Documents/PeriodicBackup/BackupTask.cs
+++ b/src/Raven.Server/Documents/PeriodicBackup/BackupTask.cs
@@ -501,7 +501,7 @@ namespace Raven.Server.Documents.PeriodicBackup
             {
                 var smugglerSource = new DatabaseSource(_database, startDocumentEtag.Value);
                 var smugglerDestination = new StreamDestination(file, context, smugglerSource);
-                var smuggler = new Smuggler.Documents.DatabaseSmuggler(_database,
+                var smuggler = new DatabaseSmuggler(_database,
                     smugglerSource,
                     smugglerDestination,
                     _database.Time,

--- a/src/Raven.Server/Documents/PeriodicBackup/PeriodicBackupRunner.cs
+++ b/src/Raven.Server/Documents/PeriodicBackup/PeriodicBackupRunner.cs
@@ -39,8 +39,8 @@ namespace Raven.Server.Documents.PeriodicBackup
             = new ConcurrentDictionary<long, PeriodicBackup>();
 
         private static readonly Dictionary<string, long> EmptyDictionary = new Dictionary<string, long>();
-
         private readonly ConcurrentSet<Task> _inactiveRunningPeriodicBackupsTasks = new ConcurrentSet<Task>();
+
         private bool _disposed;
 
         // interval can be 2^32-2 milliseconds at most
@@ -97,6 +97,26 @@ namespace Raven.Server.Documents.PeriodicBackup
         {
             var taskStatus = GetTaskStatus(databaseRecord, configuration, skipErrorLog: true);
             return taskStatus == TaskStatus.Disabled ? null : GetNextBackupDetails(configuration, backupStatus, skipErrorLog: true);
+        }
+
+        private DateTime? GetNextWakeupTime(long lastEtag, PeriodicBackupConfiguration configuration, PeriodicBackupStatus backupStatus)
+        {
+            // we will always wake up the database for a full backup.
+            // but for incremental we will wake the database only if there were changes made.
+            
+            var now = SystemTime.UtcNow;
+            if (backupStatus.LastEtag != lastEtag)
+            {
+                var lastIncrementalBackup = backupStatus.LastIncrementalBackupInternal ?? backupStatus.LastFullBackupInternal ?? now;
+                var nextlastIncrementalBackup = GetNextBackupOccurrence(configuration.IncrementalBackupFrequency,
+                    lastIncrementalBackup, configuration, skipErrorLog: false);
+                if (nextlastIncrementalBackup != null)
+                    return nextlastIncrementalBackup;
+            }
+            
+            var lastFullBackup = backupStatus.LastFullBackupInternal ?? now;
+            return GetNextBackupOccurrence(configuration.FullBackupFrequency,
+                lastFullBackup, configuration, skipErrorLog: false);
         }
 
         private NextBackup GetNextBackupDetails(
@@ -297,6 +317,28 @@ namespace Raven.Server.Documents.PeriodicBackup
             return CreateBackupTask(periodicBackup, isFullBackup);
         }
 
+        public DateTime GetWakeDatabaseTime()
+        {
+            var wakeupDatabase = DateTime.MaxValue;
+            long lastEtag;
+
+            using (_database.DocumentsStorage.ContextPool.AllocateOperationContext(out DocumentsOperationContext context))
+            using (var tx = context.OpenReadTransaction())
+            {
+                lastEtag = DocumentsStorage.ReadLastEtag(tx.InnerTransaction);
+            }
+
+            foreach (var backup in _periodicBackups)
+            {
+                var nextBackup = GetNextWakeupTime(lastEtag, backup.Value.Configuration, backup.Value.BackupStatus);
+                if (nextBackup == null)
+                    continue;
+                if (nextBackup < wakeupDatabase)
+                    wakeupDatabase = nextBackup.Value;
+            }
+            return wakeupDatabase;
+        }
+
         private long CreateBackupTask(PeriodicBackup periodicBackup, bool isFullBackup)
         {
             if (periodicBackup.UpdateBackupTaskSemaphore.Wait(0) == false)
@@ -348,7 +390,10 @@ namespace Raven.Server.Documents.PeriodicBackup
                     {
                         try
                         {
-                            return await backupTask.RunPeriodicBackup(onProgress);
+                            using (_database.PreventFromUnloading())
+                            {
+                                return await backupTask.RunPeriodicBackup(onProgress);
+                            }
                         }
                         finally
                         {
@@ -495,10 +540,9 @@ namespace Raven.Server.Documents.PeriodicBackup
             {
                 foreach (var periodicBackup in _periodicBackups)
                 {
-                    periodicBackup.Value.DisableFutureBackups();
-
-                    TryAddInactiveRunningPeriodicBackups(periodicBackup.Value.RunningTask);
+                    periodicBackup.Value.Dispose();
                 }
+                _periodicBackups.Clear();
                 return;
             }
 
@@ -513,8 +557,6 @@ namespace Raven.Server.Documents.PeriodicBackup
                 UpdatePeriodicBackup(newBackupTaskId, periodicBackupConfiguration, taskState);
             }
 
-            RemoveInactiveCompletedTasks();
-
             var deletedBackupTaskIds = _periodicBackups.Keys.Except(allBackupTaskIds).ToList();
             foreach (var deletedBackupId in deletedBackupTaskIds)
             {
@@ -523,28 +565,7 @@ namespace Raven.Server.Documents.PeriodicBackup
 
                 // stopping any future backups
                 // currently running backups will continue to run
-                deletedBackup.DisableFutureBackups();
-                TryAddInactiveRunningPeriodicBackups(deletedBackup.RunningTask);
-            }
-        }
-
-        public void RemoveInactiveCompletedTasks()
-        {
-            if (_inactiveRunningPeriodicBackupsTasks.Count == 0)
-                return;
-
-            var tasksToRemove = new List<Task>();
-            foreach (var inactiveTask in _inactiveRunningPeriodicBackupsTasks)
-            {
-                if (inactiveTask.IsCompleted == false)
-                    continue;
-
-                tasksToRemove.Add(inactiveTask);
-            }
-
-            foreach (var taskToRemove in tasksToRemove)
-            {
-                _inactiveRunningPeriodicBackupsTasks.TryRemove(taskToRemove);
+                deletedBackup.Dispose();
             }
         }
 
@@ -553,19 +574,23 @@ namespace Raven.Server.Documents.PeriodicBackup
             TaskStatus taskState)
         {
             Debug.Assert(taskId == newConfiguration.TaskId);
-
+            
             var backupStatus = GetBackupStatus(taskId, inMemoryBackupStatus: null);
             if (_periodicBackups.TryGetValue(taskId, out var existingBackupState) == false)
             {
-                var newPeriodicBackup = new PeriodicBackup
+                var newPeriodicBackup = new PeriodicBackup(_inactiveRunningPeriodicBackupsTasks)
                 {
                     Configuration = newConfiguration
                 };
 
-                _periodicBackups.TryAdd(taskId, newPeriodicBackup);
+                var periodicBackup = _periodicBackups.GetOrAdd(taskId, newPeriodicBackup);
+                if (periodicBackup != newPeriodicBackup)
+                {
+                    newPeriodicBackup.Dispose();
+                }
 
                 if (taskState == TaskStatus.ActiveByCurrentNode)
-                    newPeriodicBackup.UpdateTimer(GetTimer(newConfiguration, backupStatus));
+                    periodicBackup.UpdateTimer(GetTimer(newConfiguration, backupStatus));
 
                 return;
             }
@@ -644,51 +669,6 @@ namespace Raven.Server.Documents.PeriodicBackup
             return TaskStatus.ActiveByOtherNode;
         }
 
-        private void TryAddInactiveRunningPeriodicBackups(Task runningTask)
-        {
-            if (runningTask == null ||
-                runningTask.IsCompleted)
-                return;
-
-            _inactiveRunningPeriodicBackupsTasks.Add(runningTask);
-        }
-
-        public void Dispose()
-        {
-            if (_disposed)
-                return;
-
-            lock (this)
-            {
-                if (_disposed)
-                    return;
-
-                _disposed = true;
-                _database.TombstoneCleaner.Unsubscribe(this);
-
-                using (_cancellationToken)
-                {
-                    _cancellationToken.Cancel();
-
-                    foreach (var periodicBackup in _periodicBackups)
-                    {
-                        periodicBackup.Value.DisableFutureBackups();
-
-                        var task = periodicBackup.Value.RunningTask;
-                        WaitForTaskCompletion(task);
-                    }
-
-                    foreach (var task in _inactiveRunningPeriodicBackupsTasks)
-                    {
-                        WaitForTaskCompletion(task);
-                    }
-                }
-
-                if (_tempBackupPath != null)
-                    IOExtensions.DeleteDirectory(_tempBackupPath.FullPath);
-            }
-        }
-
         private void WaitForTaskCompletion(Task task)
         {
             try
@@ -710,6 +690,39 @@ namespace Raven.Server.Documents.PeriodicBackup
             }
         }
 
+        public void Dispose()
+        {
+            if (_disposed)
+                return;
+
+            lock (this)
+            {
+                if (_disposed)
+                    return;
+
+                _disposed = true;
+                _database.TombstoneCleaner.Unsubscribe(this);
+
+                using (_cancellationToken)
+                {
+                    _cancellationToken.Cancel();
+
+                    foreach (var periodicBackup in _periodicBackups)
+                    {
+                        periodicBackup.Value.Dispose();
+                    }
+
+                    foreach (var inactiveTask in _inactiveRunningPeriodicBackupsTasks)
+                    {
+                        WaitForTaskCompletion(inactiveTask);
+                    }
+                }
+
+                if (_tempBackupPath != null)
+                    IOExtensions.DeleteDirectory(_tempBackupPath.FullPath);
+            }
+        }
+        
         public bool HasRunningBackups()
         {
             foreach (var periodicBackup in _periodicBackups)

--- a/src/Raven.Server/Documents/PeriodicBackup/PeriodicBackupRunner.cs
+++ b/src/Raven.Server/Documents/PeriodicBackup/PeriodicBackupRunner.cs
@@ -105,6 +105,12 @@ namespace Raven.Server.Documents.PeriodicBackup
             // but for incremental we will wake the database only if there were changes made.
             
             var now = SystemTime.UtcNow;
+
+            if (backupStatus == null)
+            {
+                return GetNextBackupOccurrence(configuration.FullBackupFrequency, now, configuration, skipErrorLog: false);
+            }
+
             if (backupStatus.LastEtag != lastEtag)
             {
                 var lastIncrementalBackup = backupStatus.LastIncrementalBackupInternal ?? backupStatus.LastFullBackupInternal ?? now;

--- a/src/Raven.Server/Web/System/AdminDatabasesHandler.cs
+++ b/src/Raven.Server/Web/System/AdminDatabasesHandler.cs
@@ -1157,7 +1157,7 @@ namespace Raven.Server.Web.System
                         {
                             using (database.PreventFromUnloading())
                             {
-                                // send some initial progess so studio can open details 
+                                // send some initial progress so studio can open details 
                                 result.AddInfo("Starting migration");
                                 result.AddInfo($"Path of temporary export file: {tmpFile}");
                                 onProgress(overallProgress);


### PR DESCRIPTION
Always wake up the database for a full backup.
But for incremental, wake the database only if changes were made.

- Prevent the database to unload during the actual backup process.
- Unloading a database due to idleness will generate a wakeup timer, dependent on the nearest backup task.