### PR TITLE
RavenDB-11415 Perform a performance test on cluster-wide transactions

### DIFF
--- a/bench/BulkInsert.Benchmark/Program.cs
+++ b/bench/BulkInsert.Benchmark/Program.cs
@@ -5,9 +5,11 @@ using System.Globalization;
 using System.IO;
 using System.Linq;
 using System.Text;
+using System.Threading;
 using System.Threading.Tasks;
 using Raven.Client;
 using Raven.Client.Documents;
+using Raven.Client.Documents.Session;
 using Raven.Client.Extensions;
 using Raven.Client.ServerWide;
 using Raven.Client.ServerWide.Operations;
@@ -104,7 +106,140 @@ namespace BulkInsert.Benchmark
 //                .Select(s => s[_random.Next(s.Length)]).ToArray());
         }
 
+        private static string[] _randStr;
+        public void PerformSessionStore(string collection, long numberOfDocuments, int docsPerSession, int numberOfClients, int? sizeOfDocuments,
+            bool useSeqId = true)
+        {
+            int docSize = sizeOfDocuments == null ? _random.Next(5 * 1024 * 1024) : sizeOfDocuments.Value;
+            var sizeStr = sizeOfDocuments == null ? $"Random Size of {docSize:#,#}" : $"size of {sizeOfDocuments:#,#}";
+            Log($"About to perform Store for {numberOfDocuments:##,###} documents with {sizeStr} from {numberOfClients} clients.");
+            
+            var dummies = Math.Min(numberOfDocuments, 1024 * 1024 * 1024 / docSize + 1);
+            Console.WriteLine("dummies==" + dummies);
+            _randStr = new string[dummies];
+            for (int index = 0; index < _randStr.Length; index++)
+            {
+                _randStr[index] = RandomString(docSize);
+            }
+           
+            var threads = new Thread[numberOfClients];
+            for (int i = 0; i < numberOfClients; i++)
+            {
+                threads[i] = new Thread(() => PerfomStore(collection, numberOfDocuments, docsPerSession, dummies, docSize, sizeOfDocuments, useSeqId));
+            }
+            foreach (var thread in threads)
+            {
+                thread.Start();
+            }
+            foreach (var thread in threads)
+            {
+                thread.Join();
+            }
+        }
 
+        private void PerfomStore(string collection, long numberOfDocuments, int docsPerSession, long dummies, int docSize, int? sizeOfDocuments, bool useSeqId)
+        {
+            var entities = new DocEntity[3];
+            var ids = new long[] {-1, -1, -1};
+            var sp = Stopwatch.StartNew();
+
+            string[] tags = null;
+            long id = 1;
+
+            var numberOfSessions = numberOfDocuments / docsPerSession;
+            var i = 0;
+            for (int j = 0; j < numberOfSessions; j++)
+            {
+                using (var session = store.OpenSession(new SessionOptions
+                {
+                    TransactionMode = TransactionMode.ClusterWide
+                }))
+                {
+                    for (; i < docsPerSession * (j + 1); i++)
+                    {
+                        if (i % (numberOfDocuments / 5) == 0)
+                            Console.WriteLine($"{SystemTime.UtcNow:G} : Progress {i:##,###} out of {numberOfDocuments} ...");
+
+                        var entity = new DocEntity
+                        {
+                            SerialId = i,
+                            RandomId = _random.Next(),
+                            SomeRandomText = _randStr[i % dummies],
+                            Tags = tags
+                        };
+                        var idToUse = useSeqId ? _seqId++ : id++;
+                        session.Store(entity, $"{collection}/{idToUse}");
+
+                        if (i == 0)
+                        {
+                            ids[0] = idToUse;
+                            entities[0] = entity;
+                        }
+                        else if (i == numberOfDocuments / 2)
+                        {
+                            ids[1] = idToUse;
+                            entities[1] = entity;
+                        }
+                        else if (i == numberOfDocuments - 1)
+                        {
+                            ids[2] = idToUse;
+                            entities[2] = entity;
+                        }
+                    }
+
+                    session.SaveChanges();
+                }
+            }
+
+            if (ids[0] == -1 ||
+                ids[1] == -1 ||
+                ids[2] == -1)
+                throw new Exception("Internal Error");
+            long clientSideTime = sp.ElapsedMilliseconds;
+
+            var elapsed = sp.ElapsedMilliseconds;
+            Log($"Client Inserted {numberOfDocuments:#,#} documents of size {docSize:#,#} at " + clientSideTime.ToString("#,#") + " mSec");
+            Log($"Finished store {numberOfDocuments:#,#} documents of size {docSize:#,#} at " + elapsed.ToString("#,#") + " mSec");
+
+            if (sizeOfDocuments == null)
+            {
+                Log($"STATISTICS: N/A - Random Size");
+            }
+            else
+            {
+                long totalSize = numberOfDocuments * docSize;
+                var totalRate = (totalSize / elapsed) / 1000;
+                Log($"STATISTICS: Total Size {totalSize:#,#}, {totalRate:#,#} MB/Sec");
+            }
+
+
+            using (var session = store.OpenSession())
+            {
+                var first = session.Load<DocEntity>($"{collection}/{ids[0]}");
+                var middle = session.Load<DocEntity>($"{collection}/{ids[1]}");
+                var last = session.Load<DocEntity>($"{collection}/{ids[2]}");
+
+                if (first == null || middle == null || last == null)
+                {
+                    Log(
+                        $"Data Verification Failed : isNull :: first={first == null}, middle={middle == null}, last={last == null}",
+                        true);
+                }
+
+                if (first.SerialId == 0 &&
+                    middle.SerialId == numberOfDocuments / 2 &&
+                    last.SerialId == numberOfDocuments - 1)
+                {
+                    Log("Data Successfully Verified!");
+                }
+                else
+                {
+                    Log(
+                        $"Data Verification Failed : first={first.SerialId}, middle={middle.SerialId}, last={last.SerialId}",
+                        true);
+                }
+            }
+        }
 
         public void PerformBulkInsert(string collection, long numberOfDocuments, int? sizeOfDocuments,
             bool useSeqId = true)
@@ -243,7 +378,7 @@ namespace BulkInsert.Benchmark
         {
             public static void Main(string[] args)
             {
-                using (var massiveObj = new BulkInsertBench("http://localhost:8080", 1805861237))
+                using (var massiveObj = new BulkInsertBench("http://10.0.0.87:8080", 1805861237))
                 {
                     massiveObj.CreateDb();
 //                    var sp = Stopwatch.StartNew();
@@ -259,27 +394,49 @@ namespace BulkInsert.Benchmark
                     //Console.WriteLine("metoraf...");
                     //massiveObj.PerformBulkInsert("warmup", 1000 * k, 30 * kb * kb);
 
-//                    Console.WriteLine("bigSize...");
-//                    massiveObj.PerformBulkInsert("bigSize", 1 * k, 30 * kb * kb);
-                                    
+                    //                    Console.WriteLine("bigSize...");
+                    //                    massiveObj.PerformBulkInsert("bigSize", 1 * k, 30 * kb * kb);
 
-                                        Console.WriteLine("warmup...");
-                                        massiveObj.PerformBulkInsert("warmup", 10 * k, 2 * kb);
-                                        Console.WriteLine("smallSize...");
-                                        massiveObj.PerformBulkInsert("smallSize", 2 * k * k, 2 * kb);
-                                        Console.WriteLine("bigSize...");
-                                        massiveObj.PerformBulkInsert("bigSize", 1 * k, 30 * kb * kb);
-                                        Console.WriteLine("forOverrite...");
-                                        massiveObj.PerformBulkInsert("forOverrite", 500 * k, 5 * kb, false);
-                                        Console.WriteLine("forOverrite2...");
-                                        massiveObj.PerformBulkInsert("forOverrite", 1000 * k, 5 * kb, false);
-                                        for (int i = 1; i <= 5; i++)
-                                        {
-                                            Console.WriteLine($"random {i}...");
-                                            massiveObj.PerformBulkInsert("random", i * k * k, null);
-                                        }
-                    
-                                        Console.WriteLine("Ending tests...");
+
+                    //                                        Console.WriteLine("warmup...");
+                    //                                        massiveObj.PerformBulkInsert("warmup", 10 * k, 2 * kb);
+                    //                                        Console.WriteLine("smallSize...");
+                    //                                        massiveObj.PerformBulkInsert("smallSize", 2 * k * k, 2 * kb);
+                    //                                        Console.WriteLine("bigSize...");
+                    //                                        massiveObj.PerformBulkInsert("bigSize", 1 * k, 30 * kb * kb);
+                    //                                        Console.WriteLine("forOverrite...");
+                    //                                        massiveObj.PerformBulkInsert("forOverrite", 500 * k, 5 * kb, false);
+                    //                                        Console.WriteLine("forOverrite2...");
+                    //                                        massiveObj.PerformBulkInsert("forOverrite", 1000 * k, 5 * kb, false);
+                    //                                        for (int i = 1; i <= 5; i++)
+                    //                                        {
+                    //                                            Console.WriteLine($"random {i}...");
+                    //                                            massiveObj.PerformBulkInsert("random", i * k * k, null);
+                    //                                        }
+                    //                    
+                    //                                        Console.WriteLine("Ending tests...");
+
+                    var clients = 10;
+                    var docsPerSession = 2;
+
+                    Console.WriteLine("warmup...");
+                    massiveObj.PerformSessionStore("warmup", 10 * k, docsPerSession, clients, 2 * kb);
+                    Console.WriteLine("smallSize...");
+                    massiveObj.PerformSessionStore("smallSize", 2 * k * k, docsPerSession, clients, 2 * kb);
+                    Console.WriteLine("bigSize...");
+                    massiveObj.PerformSessionStore("bigSize", 1 * k, docsPerSession, clients, 30 * kb * kb);
+                    Console.WriteLine("forOverrite...");
+                    massiveObj.PerformSessionStore("forOverrite", 500 * k, docsPerSession, clients, 5 * kb, false);
+                    Console.WriteLine("forOverrite2...");
+                    massiveObj.PerformSessionStore("forOverrite", 1000 * k, docsPerSession, clients, 5 * kb, false);
+                    for (int i = 1; i <= 5; i++)
+                    {
+                        Console.WriteLine($"random {i}...");
+                        massiveObj.PerformSessionStore("random", docsPerSession, clients, i * k * k, null);
+                    }
+
+                    Console.WriteLine("Ending tests...");
+
                 }
             }
         }

--- a/src/Raven.Server/Documents/DatabasesLandlord.cs
+++ b/src/Raven.Server/Documents/DatabasesLandlord.cs
@@ -104,11 +104,19 @@ namespace Raven.Server.Documents
                         if (task.IsCompleted)
                         {
                             NotifyDatabaseAboutStateChange(databaseName, task, index);
+                            if (type == ClusterStateMachine.SnapshotInstalled)
+                            {
+                                NotifyPendingClusterTransaction(databaseName, task, index);
+                            }
                             return;
                         }
                         task.ContinueWith(done =>
                         {
                             NotifyDatabaseAboutStateChange(databaseName, done, index);
+                            if (type == ClusterStateMachine.SnapshotInstalled)
+                            {
+                                NotifyPendingClusterTransaction(databaseName, done, index);
+                            }
                         });
                         break;
                     case ClusterDatabaseChangeType.ValueChanged:

--- a/src/Raven.Server/Documents/DatabasesLandlord.cs
+++ b/src/Raven.Server/Documents/DatabasesLandlord.cs
@@ -2,6 +2,7 @@
 using System.Collections.Concurrent;
 using System.Collections.Generic;
 using System.Diagnostics;
+using System.Linq;
 using System.Runtime.CompilerServices;
 using System.Threading;
 using System.Threading.Tasks;
@@ -20,7 +21,6 @@ using Raven.Server.ServerWide.Context;
 using Raven.Server.Utils;
 using Raven.Server.Web.System;
 using Sparrow;
-using Sparrow.Json.Parsing;
 using Sparrow.Logging;
 using Sparrow.Utils;
 
@@ -172,19 +172,9 @@ namespace Raven.Server.Documents
                 return;
             }
 
-            RavenTransaction rtnCtx = null;
             try
             {
-                using (_serverStore.ContextPool.AllocateOperationContext(out TransactionOperationContext serverContext))
-                using (database.DocumentsStorage.ContextPool.AllocateOperationContext(out DocumentsOperationContext docContext))
-                using (docContext.OpenReadTransaction())
-                {
-                    rtnCtx = serverContext.OpenReadTransaction();
-                    var tasks = ExecutePendingClusterTransactions(database, index, docContext, serverContext);
-                    // ReSharper disable once AccessToDisposedClosure
-                    // we don't care about any exceptions in the continuation..
-                    Task.WhenAll(tasks).ContinueWith(t => { rtnCtx.Dispose(); });
-                }
+                ExecutePendingClusterTransactions(database, index);
             }
             catch (Exception e)
             {
@@ -193,71 +183,93 @@ namespace Raven.Server.Documents
                 {
                     _logger.Info($"Failed enqueue cluster transaction command for database: '{databaseName}'", e);
                 }
-                rtnCtx?.Dispose();
             }
         }
 
-        public List<Task> ExecutePendingClusterTransactions(
-            DocumentDatabase database, 
-            long index, 
-            DocumentsOperationContext docContext,
-            TransactionOperationContext serverContext)
+        public void ExecutePendingClusterTransactions(DocumentDatabase database, long index, Action<List<Task>> customWait = null)
         {
             var transactionsTasks = new List<Task>();
-            var global = DocumentsStorage.GetDatabaseChangeVector(docContext);
+            string global;
+
+            using (database.DocumentsStorage.ContextPool.AllocateOperationContext(out DocumentsOperationContext docContext))
+            using (docContext.OpenReadTransaction())
+            {
+                global = DocumentsStorage.GetDatabaseChangeVector(docContext);
+            }
+
             var dbGrpId = database.DatabaseGroupId;
-            var currentRaftIndex = ChangeVectorUtils.GetEtagById(global, dbGrpId);
-            var firstCommandIndex = ClusterTransactionCommand.ReadFirstIndex(serverContext, database.Name);
-            var first = Math.Max(firstCommandIndex, currentRaftIndex + 1);
+            var lastDocFromClusterTransaction = ChangeVectorUtils.GetEtagById(global, dbGrpId);
 
-            foreach (var command in ClusterTransactionCommand.ReadCommandsBatch(serverContext, database.Name, first))
+            using (database.ServerStore.ContextPool.AllocateOperationContext(out TransactionOperationContext serverContext))
+            using (serverContext.OpenReadTransaction())
             {
-                var mergedCommands = new BatchHandler.ClusterTransactionMergedCommand(database, command);
-                var task = database.TxMerger.Enqueue(mergedCommands);
-                transactionsTasks.Add(task);
-                task.ContinueWith(t =>
+                // TODO: There is a race between replication the transaction result from other node and executing the transaction on this one.
+                // If the above occur, the user will wait for ever for a result. 
+                // we need to correlate between the TaskId and the already executed cluster transactions (maybe use the Raft Index?).
+                // As a work around we pass 'fromCount: 0'
+                var commands = ClusterTransactionCommand.ReadCommandsBatch(serverContext, database.Name, fromCount: 0).ToList();
+
+                foreach (var command in commands)
                 {
-                    try
-                    {
-                        if (t.IsCompletedSuccessfully)
-                        {
-                            var options = mergedCommands.Options;
-                            Task indexTask = null;
-                            if (options?.WaitForIndexesTimeout != null)
-                            {
-                                indexTask = BatchHandler.WaitForIndexesAsync(database.DocumentsStorage.ContextPool, database, options.WaitForIndexesTimeout.Value,
-                                    options.SpecifiedIndexesQueryString, options.WaitForIndexThrow,
-                                    mergedCommands.LastChangeVector, mergedCommands.LastTombstoneEtag, mergedCommands.ModifiedCollections);
-                            }
+                    var mergedCommands = new BatchHandler.ClusterTransactionMergedCommand(database, command);
+                    var task = database.TxMerger.Enqueue(mergedCommands);
+                    transactionsTasks.Add(task);
+                    NotifyDatabaseAfterCompletion(database, index, task, mergedCommands);
+                }
 
-                            var result = new BatchHandler.ClusterTransactionCompletionResult
-                            {
-                                Array = mergedCommands.Reply,
-                                IndexTask = indexTask,
-                            };
-                            database.ClusterTransactionWaiter.SetResult(mergedCommands.Options.TaskId, index, result);
-                            return;
-                        }
+                if (transactionsTasks.Count == 0)
+                {
+                    database.RachisLogIndexNotifications.NotifyListenersAbout(index, null);
+                    return;
+                }
 
-                        database.ClusterTransactionWaiter.SetException(mergedCommands.Options.TaskId, index, t.Exception);
-                    }
-                    catch (Exception e)
-                    {
-                        // nothing we can do
-                        if (_logger.IsInfoEnabled)
-                        {
-                            _logger.Info($"Failed to notify about transaction completion for database '{database.Name}'.", e);
-                        }
-                    }
-                });
+                if (customWait != null)
+                {
+                    customWait(transactionsTasks);
+                    return;
+                }
+
+                Task.WaitAll(transactionsTasks.ToArray());
             }
+        }
 
-            if (transactionsTasks.Count == 0)
+        private void NotifyDatabaseAfterCompletion(DocumentDatabase database, long index, Task task, BatchHandler.ClusterTransactionMergedCommand mergedCommands)
+        {
+            task.ContinueWith(t =>
             {
-                database.RachisLogIndexNotifications.NotifyListenersAbout(index, null);
-            }
+                try
+                {
+                    if (t.IsCompletedSuccessfully)
+                    {
+                        var options = mergedCommands.Options;
+                        Task indexTask = null;
+                        if (options?.WaitForIndexesTimeout != null)
+                        {
+                            indexTask = BatchHandler.WaitForIndexesAsync(database.DocumentsStorage.ContextPool, database, options.WaitForIndexesTimeout.Value,
+                                options.SpecifiedIndexesQueryString, options.WaitForIndexThrow,
+                                mergedCommands.LastChangeVector, mergedCommands.LastTombstoneEtag, mergedCommands.ModifiedCollections);
+                        }
 
-            return transactionsTasks;
+                        var result = new BatchHandler.ClusterTransactionCompletionResult
+                        {
+                            Array = mergedCommands.Reply,
+                            IndexTask = indexTask,
+                        };
+                        database.ClusterTransactionWaiter.SetResult(mergedCommands.Options.TaskId, index, result);
+                        return;
+                    }
+
+                    database.ClusterTransactionWaiter.SetException(mergedCommands.Options.TaskId, index, t.Exception);
+                }
+                catch (Exception e)
+                {
+                    // nothing we can do
+                    if (_logger.IsInfoEnabled)
+                    {
+                        _logger.Info($"Failed to notify about transaction completion for database '{database.Name}'.", e);
+                    }
+                }
+            });
         }
 
         public bool ShouldDeleteDatabase(string dbName, DatabaseRecord record)

--- a/src/Raven.Server/Documents/DocumentDatabase.cs
+++ b/src/Raven.Server/Documents/DocumentDatabase.cs
@@ -57,7 +57,7 @@ namespace Raven.Server.Documents
         private readonly ServerStore _serverStore;
         private readonly Action<string> _addToInitLog;
         private readonly Logger _logger;
-        private DisposeOnce<SingleAttempt> _disposeOnce;
+        private readonly DisposeOnce<SingleAttempt> _disposeOnce;
 
         private readonly CancellationTokenSource _databaseShutdown = new CancellationTokenSource();
 

--- a/src/Raven.Server/ServerWide/ClusterStateMachine.cs
+++ b/src/Raven.Server/ServerWide/ClusterStateMachine.cs
@@ -61,7 +61,7 @@ namespace Raven.Server.ServerWide
         private static readonly TableSchema ItemsSchema;
         private static readonly TableSchema CompareExchangeSchema;
         public static readonly TableSchema TransactionCommandsSchema;
-        public static readonly Slice CommandByDatabaseAndIndex;
+        public static readonly Slice CommandByDatabaseAndCount;
 
         public enum UniqueItems
         {
@@ -84,7 +84,7 @@ namespace Raven.Server.ServerWide
                 Slice.From(ctx, "CmpXchg", out CompareExchange);
                 Slice.From(ctx, "Identities", out Identities);
                 Slice.From(ctx, "TransactionCommands", out TransactionCommands);
-                Slice.From(ctx, "CommandByDatabaseAndIndex", out CommandByDatabaseAndIndex);
+                Slice.From(ctx, "CommandByDatabaseAndCount", out CommandByDatabaseAndCount);
                 Slice.From(ctx, "TransactionCommandsIndex", out TransactionCommandsIndex);
             }
             ItemsSchema = new TableSchema();
@@ -107,9 +107,9 @@ namespace Raven.Server.ServerWide
             TransactionCommandsSchema = new TableSchema();
             TransactionCommandsSchema.DefineIndex(new TableSchema.SchemaIndexDef()
             {
-                Name = CommandByDatabaseAndIndex,
+                Name = CommandByDatabaseAndCount,
                 StartIndex = 0,
-                Count = 3, // Database, Separator, Index
+                Count = 3, // Database, Separator, Commands count
             });
         }
 
@@ -622,7 +622,7 @@ namespace Raven.Server.ServerWide
             var transactionsCommands = context.Transaction.InnerTransaction.OpenTable(TransactionCommandsSchema, TransactionCommands);
             using (ClusterTransactionCommand.GetPrefix(context, databaseName, out var prefixSlice))
             {
-                transactionsCommands.DeleteForwardFrom(TransactionCommandsSchema.Indexes[CommandByDatabaseAndIndex], prefixSlice, true, long.MaxValue);
+                transactionsCommands.DeleteForwardFrom(TransactionCommandsSchema.Indexes[CommandByDatabaseAndCount], prefixSlice, true, long.MaxValue);
             }
         }
 

--- a/src/Raven.Server/ServerWide/Commands/CleanUpClusterStateCommand.cs
+++ b/src/Raven.Server/ServerWide/Commands/CleanUpClusterStateCommand.cs
@@ -25,13 +25,13 @@ namespace Raven.Server.ServerWide.Commands
                 var items = context.Transaction.InnerTransaction.OpenTable(ClusterStateMachine.TransactionCommandsSchema, ClusterStateMachine.TransactionCommands);
                 using (ClusterTransactionCommand.GetPrefix(context, database, out var prefixSlice))
                 {
-                    var schemaIndexDef = ClusterStateMachine.TransactionCommandsSchema.Indexes[ClusterStateMachine.CommandByDatabaseAndIndex];
+                    var schemaIndexDef = ClusterStateMachine.TransactionCommandsSchema.Indexes[ClusterStateMachine.CommandByDatabaseAndCount];
                     var deleted = items.DeleteForwardFrom(schemaIndexDef, prefixSlice, 
                         startsWith: true, 
                         numberOfEntriesToDelete: long.MaxValue,
                         shouldAbort: (tvb) =>
                         {
-                            var value = *(long*)tvb.Reader.Read((int)ClusterTransactionCommand.TransactionCommandsColumn.RaftIndex, out var _);
+                            var value = *(long*)tvb.Reader.Read((int)ClusterTransactionCommand.TransactionCommandsColumn.PreviousCount, out var _);
                             var currentIndex = Bits.SwapBytes(value);
                             return currentIndex > upToIndex;
                         });


### PR DESCRIPTION
still WIP

- Fixing concurrent usage of context in the cluster transaction.
- Fixing confusion between the 'raft index' and the 'previous cluster command count'
- Adding Session bench-marking.