### PR TITLE
[4.1] RavenDB-11597 if we do not want to reuse server and we do not have a …

### DIFF
--- a/test/Tests.Infrastructure/TestBase.cs
+++ b/test/Tests.Infrastructure/TestBase.cs
@@ -13,7 +13,6 @@ using System.Threading;
 using System.Threading.Tasks;
 using Newtonsoft.Json.Linq;
 using Raven.Client;
-using Raven.Client.Documents.Changes;
 using Raven.Client.Http;
 using Raven.Server;
 using Raven.Server.Config;
@@ -216,9 +215,6 @@ namespace FastTests
                     Servers.Add(_localServer);
                     _doNotReuseServer = false;
 
-                    if (_globalServer == null)
-                        _globalServer = _localServer;
-
                     return _localServer;
                 }
 
@@ -252,7 +248,7 @@ namespace FastTests
             }
         }
 
-        private void UnloadServer(AssemblyLoadContext obj)
+        private static void UnloadServer(AssemblyLoadContext obj)
         {
             try
             {


### PR DESCRIPTION
…global server yet, then we should never assign that local server as a global one