### PR TITLE
Fixing a race conditions when moving from Passive state to Follower s…

### DIFF
--- a/src/Raven.Server/Rachis/Follower.cs
+++ b/src/Raven.Server/Rachis/Follower.cs
@@ -467,8 +467,33 @@ namespace Raven.Server.Rachis
 
                 context.Transaction.Commit();
             }
+
+            _engine.Timeout.Defer(_connection.Source);
+            _debugRecorder.Record("Invoking StateMachine.SnapshotInstalled");
+
+            // notify the state machine, we do this in an async manner, and start
+            // the operator in a separate thread to avoid timeouts while this is
+            // going on
+
+            var task = Task.Run(() => _engine.SnapshotInstalledAsync(snapshot.LastIncludedIndex));
+
+            var sp = Stopwatch.StartNew();
+
+            var timeToWait = (int)(_engine.ElectionTimeout.TotalMilliseconds / 4);
+
+            while (task.Wait(timeToWait) == false)
+            {
+                // this may take a while, so we let the other side know that
+                // we are still processing, and we reset our own timer while
+                // this is happening
+                MaybeNotifyLeaderThatWeAreStillAlive(context, sp);
+            }
+
+            _debugRecorder.Record("Done with StateMachine.SnapshotInstalled");
+
             // we might have moved from passive node, so we need to start the timeout clock
             _engine.Timeout.Start(_engine.SwitchToCandidateStateOnTimeout);
+
             _debugRecorder.Record("Snapshot installed");
             //Here we send the LastIncludedIndex as our matched index even for the case where our lastCommitIndex is greater
             //So we could validate that the entries sent by the leader are indeed the same as the ones we have.
@@ -478,11 +503,6 @@ namespace Raven.Server.Rachis
                 CurrentTerm = _term,
                 LastLogIndex = snapshot.LastIncludedIndex
             });
-
-            _engine.Timeout.Defer(_connection.Source);
-
-            // notify the state machine
-            _engine.SnapshotInstalled(context, snapshot.LastIncludedIndex);
 
             _engine.Timeout.Defer(_connection.Source);
         }

--- a/src/Raven.Server/Rachis/RachisConsensus.cs
+++ b/src/Raven.Server/Rachis/RachisConsensus.cs
@@ -86,9 +86,9 @@ namespace Raven.Server.Rachis
             return StateMachine.ShouldSnapshot(slice, type);
         }
 
-        public override void SnapshotInstalled(TransactionOperationContext context, long lastIncludedIndex)
+        public override Task SnapshotInstalledAsync(long lastIncludedIndex)
         {
-            StateMachine.OnSnapshotInstalled(context, lastIncludedIndex, _serverStore);
+            return StateMachine.OnSnapshotInstalledAsync(lastIncludedIndex, _serverStore);
         }
 
         public override Task<RachisConnection> ConnectToPeer(string url, X509Certificate2 certificate, TransactionOperationContext context = null)
@@ -1778,7 +1778,7 @@ namespace Raven.Server.Rachis
 
         public abstract long Apply(TransactionOperationContext context, long uptoInclusive, Leader leader, Stopwatch duration);
 
-        public abstract void SnapshotInstalled(TransactionOperationContext context, long lastIncludedIndex);
+        public abstract Task SnapshotInstalledAsync(long lastIncludedIndex);
 
         private readonly AsyncManualResetEvent _leadershipTimeChanged = new AsyncManualResetEvent();
         private int _heartbeatWaitersCounter;

--- a/src/Raven.Server/Rachis/RachisConsensus.cs
+++ b/src/Raven.Server/Rachis/RachisConsensus.cs
@@ -792,15 +792,24 @@ namespace Raven.Server.Rachis
                 {
                     var clusterTopology = GetTopology(context);
                     if (clusterTopology.TopologyId == null ||
-                        clusterTopology.Members.ContainsKey(_tag) == false)
+                        clusterTopology.AllNodes.ContainsKey(_tag) == false)
                     {
                         if (Log.IsInfoEnabled)
                         {
-                            Log.Info("We are not a part of the cluster so moving to passive");
+                            Log.Info($"We are not a part of the cluster so moving to passive (candidate because: {reason})");
                         }
 
                         SetNewStateInTx(context, RachisState.Passive, null, currentTerm, "We are not a part of the cluster so moving to passive" );
                         ctx.Commit();
+                        return;
+                    }
+                    if (clusterTopology.Members.ContainsKey(_tag) == false)
+                    {
+                        if (Log.IsInfoEnabled)
+                        {
+                            Log.Info($"Candidate because: {reason}, but while we are part of the cluster, we aren't a member, so we can't be a candidate.");
+                        }
+                        // we aren't a member, nothing that we can do here
                         return;
                     }
                     if (clusterTopology.Members.Count == 1)
@@ -1053,6 +1062,8 @@ namespace Raven.Server.Rachis
 
         private void ValidateElectionTimeout(RachisHello initialMessage)
         {
+            if (Debugger.IsAttached)
+                return; // don't check here
             var max = ElectionTimeout.TotalMilliseconds * 1.1;
             var min = ElectionTimeout.TotalMilliseconds * 0.9;
             var rcvdTimeout = initialMessage.ElectionTimeout;

--- a/src/Raven.Server/Rachis/RachisStateMachine.cs
+++ b/src/Raven.Server/Rachis/RachisStateMachine.cs
@@ -75,9 +75,9 @@ namespace Raven.Server.Rachis
 
         public abstract Task<RachisConnection> ConnectToPeer(string url, X509Certificate2 certificate);
 
-        public virtual void OnSnapshotInstalled(TransactionOperationContext context, long lastIncludedIndex, ServerStore serverStore)
+        public virtual Task OnSnapshotInstalledAsync(long lastIncludedIndex, ServerStore serverStore)
         {
-            
+            return Task.CompletedTask;
         }
     }
 }

--- a/src/Raven.Server/ServerWide/ClusterStateMachine.cs
+++ b/src/Raven.Server/ServerWide/ClusterStateMachine.cs
@@ -1477,8 +1477,9 @@ namespace Raven.Server.ServerWide
         }
 
 
-        public override void OnSnapshotInstalled(TransactionOperationContext context, long lastIncludedIndex, ServerStore serverStore)
+        public override async Task OnSnapshotInstalledAsync(long lastIncludedIndex, ServerStore serverStore)
         {
+            using(serverStore.ContextPool.AllocateOperationContext(out TransactionOperationContext context))
             using (context.OpenWriteTransaction())
             {
                 // lets read all the certificate keys from the cluster, and delete the matching ones from the local state
@@ -1517,7 +1518,7 @@ namespace Raven.Server.ServerWide
 
             // reload license can send a notification which will open a write tx
             serverStore.LicenseManager.ReloadLicense();
-            AsyncHelpers.RunSync(() => serverStore.LicenseManager.CalculateLicenseLimits());
+            await serverStore.LicenseManager.CalculateLicenseLimits();
 
             _rachisLogIndexNotifications.NotifyListenersAbout(lastIncludedIndex, null);
         }


### PR DESCRIPTION
…tate when adding new node to the cluster

We'll not start the timer clock until _after_ the leader pushed the snapshot to us if we are already passive.