### PR TITLE
[4.1] RavenDB-11552

### DIFF
--- a/test/Tryouts/Program.cs
+++ b/test/Tryouts/Program.cs
@@ -10,6 +10,7 @@ using SlowTests.Client.Attachments;
 using SlowTests.Issues;
 using SlowTests.MailingList;
 using Sparrow.Logging;
+using StressTests.Client.Attachments;
 
 namespace Tryouts
 {
@@ -19,9 +20,9 @@ namespace Tryouts
         {
             try
             {
-                using (var test = new Jordan())
+                using (var test = new AttachmentsSessionStress())
                 {
-                    await test.CanTranslateToRql();
+                    test.StressPutLotOfAttachments(10_000);
                 }
             }
             catch (Exception e)


### PR DESCRIPTION
- avoiding re-reading blittable all the time when we are putting a lot of attachments
- disposing old blittables when re-reading