### PR TITLE
[4.1] RavenDB-11415 Don't use SetResult on TaskCompletionSource

### DIFF
--- a/src/Raven.Server/Documents/ClusterTransactionWaiter.cs
+++ b/src/Raven.Server/Documents/ClusterTransactionWaiter.cs
@@ -34,7 +34,7 @@ namespace Raven.Server.Documents
             Database.RachisLogIndexNotifications.NotifyListenersAbout(index, null);
             if (_results.TryGetValue(id, out var task))
             {
-                task.SetResult(result);
+                task.TrySetResult(result);
             }
         }
 
@@ -43,7 +43,7 @@ namespace Raven.Server.Documents
             Database.RachisLogIndexNotifications.NotifyListenersAbout(index, e);
             if (_results.TryGetValue(id, out var task))
             {
-                task.SetException(e);
+                task.TrySetException(e);
             }
         }
 


### PR DESCRIPTION
It throws "System.InvalidOperationException: An attempt was made to transition a task to a final state when it had already completed."
When the SetResult called twice.