### PR TITLE
[4.1] RavenDB-11624 NRE in InstallSnapshot on 4.0 when 4.1 talks to 4.0

### DIFF
--- a/src/Raven.Server/Rachis/RachisConsensus.cs
+++ b/src/Raven.Server/Rachis/RachisConsensus.cs
@@ -763,7 +763,7 @@ namespace Raven.Server.Rachis
             var leader = new Leader(this, electionTerm);
             SetNewState(RachisState.LeaderElect, leader, electionTerm, reason, () =>
             {
-                ClusterCommandsVersionManager.CurrentClusterMinimalVersion = version;
+                ClusterCommandsVersionManager.SetClusterVersion(version);
                 _currentLeader = leader;
             });
             leader.Start(connections);

--- a/src/Raven.Server/ServerWide/ClusterCommandsVersionManager.cs
+++ b/src/Raven.Server/ServerWide/ClusterCommandsVersionManager.cs
@@ -1,7 +1,7 @@
 ﻿using System;
 using System.Collections.Generic;
 using System.Linq;
-using Microsoft.Extensions.Logging;
+using System.Threading;
 using Raven.Server.ServerWide.Commands;
 using Raven.Server.ServerWide.Commands.ConnectionStrings;
 using Raven.Server.ServerWide.Commands.ETL;
@@ -17,70 +17,71 @@ namespace Raven.Server.ServerWide
     {
         public static readonly int MyCommandsVersion;
 
-        public static int CurrentClusterMinimalVersion;
+        public static int CurrentClusterMinimalVersion => _currentClusterMinimalVersion;
+        private static int _currentClusterMinimalVersion;
 
-        private static readonly Logger _log = LoggingSource.Instance.GetLogger(typeof(ClusterCommandsVersionManager).FullName, typeof(ClusterCommandsVersionManager).FullName);
+        private static readonly Logger Log = LoggingSource.Instance.GetLogger(typeof(ClusterCommandsVersionManager).FullName, typeof(ClusterCommandsVersionManager).FullName);
 
         public static readonly IReadOnlyDictionary<string, int> ClusterCommandsVersions = new Dictionary<string, int>
         {
-            [nameof(AddDatabaseCommand)] = 400,
-            [nameof(RemoveCompareExchangeCommand)] = 400,
-            [nameof(AddOrUpdateCompareExchangeCommand)] = 400,
-            [nameof(DeleteCertificateCollectionFromClusterCommand)] = 400,
-            [nameof(DeleteCertificateFromClusterCommand)] = 400,
-            [nameof(DeleteDatabaseCommand)] = 400,
-            [nameof(DeleteMultipleValuesCommand)] = 400,
-            [nameof(DeleteOngoingTaskCommand)] = 400,
-            [nameof(DeleteValueCommand)] = 400,
-            [nameof(EditExpirationCommand)] = 400,
-            [nameof(EditRevisionsConfigurationCommand)] = 400,
-            [nameof(IncrementClusterIdentitiesBatchCommand)] = 400,
-            [nameof(IncrementClusterIdentityCommand)] = 400,
-            [nameof(InstallUpdatedServerCertificateCommand)] = 400,
-            [nameof(ConfirmReceiptServerCertificateCommand)] = 400,
-            [nameof(RecheckStatusOfServerCertificateCommand)] = 400,
-            [nameof(ModifyConflictSolverCommand)] = 400,
-            [nameof(PromoteDatabaseNodeCommand)] = 400,
-            [nameof(PutCertificateCommand)] = 400,
-            [nameof(PutClientConfigurationCommand)] = 400,
-            [nameof(PutLicenseCommand)] = 400,
-            [nameof(PutLicenseLimitsCommand)] = 400,
-            [nameof(RemoveNodeFromClusterCommand)] = 400,
-            [nameof(RemoveNodeFromDatabaseCommand)] = 400,
-            [nameof(ToggleTaskStateCommand)] = 400,
-            [nameof(UpdateClusterIdentityCommand)] = 400,
-            [nameof(UpdateExternalReplicationCommand)] = 400,
-            [nameof(UpdateExternalReplicationStateCommand)] = 400,
-            [nameof(UpdateTopologyCommand)] = 400,
-            [nameof(AcknowledgeSubscriptionBatchCommand)] = 400,
-            [nameof(DeleteSubscriptionCommand)] = 400,
-            [nameof(PutSubscriptionCommand)] = 400,
-            [nameof(ToggleSubscriptionStateCommand)] = 400,
-            [nameof(UpdateSubscriptionClientConnectionTime)] = 400,
-            [nameof(UpdatePeriodicBackupCommand)] = 400,
-            [nameof(UpdatePeriodicBackupStatusCommand)] = 400,
-            [nameof(UpdateSnmpDatabaseIndexesMappingCommand)] = 400,
-            [nameof(UpdateSnmpDatabasesMappingCommand)] = 400,
-            [nameof(DeleteIndexCommand)] = 400,
-            [nameof(PutAutoIndexCommand)] = 400,
-            [nameof(PutIndexCommand)] = 400,
-            [nameof(SetIndexLockCommand)] = 400,
-            [nameof(SetIndexPriorityCommand)] = 400,
-            [nameof(AddRavenEtlCommand)] = 400,
-            [nameof(AddSqlEtlCommand)] = 400,
-            [nameof(RemoveEtlProcessStateCommand)] = 400,
-            [nameof(UpdateRavenEtlCommand)] = 400,
-            [nameof(UpdateSqlEtlCommand)] = 400,
-            [nameof(UpdateEtlProcessStateCommand)] = 400,
-            [nameof(PutRavenConnectionStringCommand)] = 400,
-            [nameof(PutSqlConnectionStringCommand)] = 400,
-            [nameof(RemoveRavenConnectionStringCommand)] = 400,
-            [nameof(RemoveSqlConnectionStringCommand)] = 400,
-            [nameof(AddOrUpdateCompareExchangeBatchCommand)] = 400,
+            [nameof(AddDatabaseCommand)] = 400_000,
+            [nameof(RemoveCompareExchangeCommand)] = 400_000,
+            [nameof(AddOrUpdateCompareExchangeCommand)] = 400_000,
+            [nameof(DeleteCertificateCollectionFromClusterCommand)] = 400_000,
+            [nameof(DeleteCertificateFromClusterCommand)] = 400_000,
+            [nameof(DeleteDatabaseCommand)] = 400_000,
+            [nameof(DeleteMultipleValuesCommand)] = 400_000,
+            [nameof(DeleteOngoingTaskCommand)] = 400_000,
+            [nameof(DeleteValueCommand)] = 400_000,
+            [nameof(EditExpirationCommand)] = 400_000,
+            [nameof(EditRevisionsConfigurationCommand)] = 400_000,
+            [nameof(IncrementClusterIdentitiesBatchCommand)] = 400_000,
+            [nameof(IncrementClusterIdentityCommand)] = 400_000,
+            [nameof(InstallUpdatedServerCertificateCommand)] = 400_000,
+            [nameof(ConfirmReceiptServerCertificateCommand)] = 400_000,
+            [nameof(RecheckStatusOfServerCertificateCommand)] = 400_000,
+            [nameof(ModifyConflictSolverCommand)] = 400_000,
+            [nameof(PromoteDatabaseNodeCommand)] = 400_000,
+            [nameof(PutCertificateCommand)] = 400_000,
+            [nameof(PutClientConfigurationCommand)] = 400_000,
+            [nameof(PutLicenseCommand)] = 400_000,
+            [nameof(PutLicenseLimitsCommand)] = 400_000,
+            [nameof(RemoveNodeFromClusterCommand)] = 400_000,
+            [nameof(RemoveNodeFromDatabaseCommand)] = 400_000,
+            [nameof(ToggleTaskStateCommand)] = 400_000,
+            [nameof(UpdateClusterIdentityCommand)] = 400_000,
+            [nameof(UpdateExternalReplicationCommand)] = 400_000,
+            [nameof(UpdateExternalReplicationStateCommand)] = 400_000,
+            [nameof(UpdateTopologyCommand)] = 400_000,
+            [nameof(AcknowledgeSubscriptionBatchCommand)] = 400_000,
+            [nameof(DeleteSubscriptionCommand)] = 400_000,
+            [nameof(PutSubscriptionCommand)] = 400_000,
+            [nameof(ToggleSubscriptionStateCommand)] = 400_000,
+            [nameof(UpdateSubscriptionClientConnectionTime)] = 400_000,
+            [nameof(UpdatePeriodicBackupCommand)] = 400_000,
+            [nameof(UpdatePeriodicBackupStatusCommand)] = 400_000,
+            [nameof(UpdateSnmpDatabaseIndexesMappingCommand)] = 400_000,
+            [nameof(UpdateSnmpDatabasesMappingCommand)] = 400_000,
+            [nameof(DeleteIndexCommand)] = 400_000,
+            [nameof(PutAutoIndexCommand)] = 400_000,
+            [nameof(PutIndexCommand)] = 400_000,
+            [nameof(SetIndexLockCommand)] = 400_000,
+            [nameof(SetIndexPriorityCommand)] = 400_000,
+            [nameof(AddRavenEtlCommand)] = 400_000,
+            [nameof(AddSqlEtlCommand)] = 400_000,
+            [nameof(RemoveEtlProcessStateCommand)] = 400_000,
+            [nameof(UpdateRavenEtlCommand)] = 400_000,
+            [nameof(UpdateSqlEtlCommand)] = 400_000,
+            [nameof(UpdateEtlProcessStateCommand)] = 400_000,
+            [nameof(PutRavenConnectionStringCommand)] = 400_000,
+            [nameof(PutSqlConnectionStringCommand)] = 400_000,
+            [nameof(RemoveRavenConnectionStringCommand)] = 400_000,
+            [nameof(RemoveSqlConnectionStringCommand)] = 400_000,
+            [nameof(AddOrUpdateCompareExchangeBatchCommand)] = 400_000,
 
-            [nameof(CleanUpClusterStateCommand)] = 410,
-            [nameof(ClusterTransactionCommand)] = 410,
-            [nameof(SetIndexStateCommand)] = 410,
+            [nameof(CleanUpClusterStateCommand)] = 410_000,
+            [nameof(ClusterTransactionCommand)] = 410_000,
+            [nameof(SetIndexStateCommand)] = 410_000,
         };
 
         public static bool CanPutCommand(string command)
@@ -93,7 +94,43 @@ namespace Raven.Server.ServerWide
 
         static ClusterCommandsVersionManager()
         {
-            MyCommandsVersion = CurrentClusterMinimalVersion = Enumerable.Max(ClusterCommandsVersions.Values);
+            MyCommandsVersion = _currentClusterMinimalVersion = Enumerable.Max(ClusterCommandsVersions.Values);
+        }
+
+        public static void SetClusterVersion(int version)
+        {
+            int currentVersion;
+            while (true)
+            {
+                currentVersion = _currentClusterMinimalVersion;
+                if (currentVersion == version)
+                    break;
+                Interlocked.CompareExchange(ref _currentClusterMinimalVersion, version, currentVersion);
+            }
+
+            if (currentVersion != version && Log.IsInfoEnabled)
+            {
+                Log.Info($"Cluster version was changed from {currentVersion} to {version}");
+            }
+        }
+
+        public static void SetMinimalClusterVersion(int version)
+        {
+            var fromVersion = _currentClusterMinimalVersion;
+            int currentVersion;
+            while (true)
+            {
+                currentVersion = _currentClusterMinimalVersion;
+                var minimalVersion = Math.Min(currentVersion, version);
+                if (currentVersion <= minimalVersion)
+                    break;
+                Interlocked.CompareExchange(ref _currentClusterMinimalVersion, minimalVersion, currentVersion);
+            }
+
+            if (fromVersion != currentVersion && Log.IsInfoEnabled)
+            {
+                Log.Info($"Cluster version was changed from {fromVersion} to {currentVersion}");
+            }
         }
 
         public static int GetClusterMinimalVersion(List<int> versions, int? maximalVersion)
@@ -101,12 +138,16 @@ namespace Raven.Server.ServerWide
             var minVersion = versions.Min();
             if (maximalVersion < minVersion)
             {
-                if (_log.IsInfoEnabled)
+                if (Log.IsInfoEnabled)
                 {
-                    _log.Info($"Cluster version was clamped from {minVersion} to {maximalVersion.Value}");
+                    Log.Info($"Cluster version was clamped from {minVersion} to {maximalVersion.Value}");
                 }
                 return maximalVersion.Value;
             }
+
+            if (minVersion == 400)
+                return 400_000;
+
             return minVersion;
         }
     }

--- a/src/Raven.Server/ServerWide/ClusterStateMachine.cs
+++ b/src/Raven.Server/ServerWide/ClusterStateMachine.cs
@@ -964,11 +964,16 @@ namespace Raven.Server.ServerWide
 
         public override bool ShouldSnapshot(Slice slice, RootObjectType type)
         {
-            return slice.Content.Match(Items.Content)
-                    || slice.Content.Match(CompareExchange.Content)
-                    || slice.Content.Match(Identities.Content)
-                    || slice.Content.Match(TransactionCommands.Content) 
-                    || slice.Content.Match(TransactionCommandsIndex.Content);
+            var baseVersion = slice.Content.Match(Items.Content)
+                            || slice.Content.Match(CompareExchange.Content)
+                            || slice.Content.Match(Identities.Content);
+
+            if (ClusterCommandsVersionManager.CurrentClusterMinimalVersion >= 410_000)
+                return baseVersion
+                       || slice.Content.Match(TransactionCommands.Content)
+                       || slice.Content.Match(TransactionCommandsIndex.Content);
+
+            return baseVersion;
         }
 
         public override void Initialize(RachisConsensus parent, TransactionOperationContext context)


### PR DESCRIPTION
- Need to take the version into account when sending the snapshot.
- Connecting a follower (or adding a new node) can affect the version.
- Change the base version from 400 to 400,000 in order to be more flexible.