### PR TITLE
[4.1] RavenDB-11330 disable assembly version check using Assembly.LoadFrom(…

### DIFF
--- a/scripts/version.ps1
+++ b/scripts/version.ps1
@@ -266,9 +266,12 @@ function Validate-AssemblyVersion($assemblyPath, $versionInfo) {
     #     BuiltAtString = $builtAtString;
     #     BuildType = $buildType;
     # }
-    Assert-AssemblyVersion `
-        -ExpectedVersion $versionInfo.VersionPrefix `
-        -AssemblyPath $assemblyPath
+
+    # TODO http://issues.hibernatingrhinos.com/issue/RavenDB-11330
+    # 
+    # Assert-AssemblyVersion `
+    #     -ExpectedVersion $versionInfo.VersionPrefix `
+    #     -AssemblyPath $assemblyPath
     
     Assert-AssemblyFileVersion `
         -ExpectedFileVersion "$($versionInfo.VersionPrefix).$($versionInfo.BuildNumber)" `


### PR DESCRIPTION
…) for the time being