### PR TITLE
[4.0] Revert "RavenDB-11330 disable assembly version check using Assembly.L…

### DIFF
--- a/scripts/version.ps1
+++ b/scripts/version.ps1
@@ -267,12 +267,9 @@ function Validate-AssemblyVersion($assemblyPath, $versionInfo) {
     #     BuiltAtString = $builtAtString;
     #     BuildType = $buildType;
     # }
-
-    # TODO http://issues.hibernatingrhinos.com/issue/RavenDB-11330
-    # 
-    # Assert-AssemblyVersion `
-    #     -ExpectedVersion $versionInfo.VersionPrefix `
-    #     -AssemblyPath $assemblyPath
+    Assert-AssemblyVersion `
+        -ExpectedVersion $versionInfo.VersionPrefix `
+        -AssemblyPath $assemblyPath
     
     Assert-AssemblyFileVersion `
         -ExpectedFileVersion "$($versionInfo.VersionPrefix).$($versionInfo.BuildNumber)" `


### PR DESCRIPTION
…oadFrom() for the time being"

This reverts commit 6335387003a51ecca41471c8cb39701ad757c6ee.

It was an issue with CI build setup after all.