### PR TITLE
[4.1] Revert "RavenDB-11330 disable assembly version check using Assembly.L…

### DIFF
--- a/scripts/version.ps1
+++ b/scripts/version.ps1
@@ -266,12 +266,9 @@ function Validate-AssemblyVersion($assemblyPath, $versionInfo) {
     #     BuiltAtString = $builtAtString;
     #     BuildType = $buildType;
     # }
-
-    # TODO http://issues.hibernatingrhinos.com/issue/RavenDB-11330
-    # 
-    # Assert-AssemblyVersion `
-    #     -ExpectedVersion $versionInfo.VersionPrefix `
-    #     -AssemblyPath $assemblyPath
+    Assert-AssemblyVersion `
+        -ExpectedVersion $versionInfo.VersionPrefix `
+        -AssemblyPath $assemblyPath
     
     Assert-AssemblyFileVersion `
         -ExpectedFileVersion "$($versionInfo.VersionPrefix).$($versionInfo.BuildNumber)" `


### PR DESCRIPTION
…oadFrom() for the time being"

This reverts commit add8b0272482e1cbc7f5483284bdd4b63cf7b5d7.

It was an issue with CI build setup after all.