### PR TITLE
[4.1] RavenDB-11627 Moving an instance of the lucene doc converter used by …

### DIFF
--- a/src/Raven.Server/Documents/Indexes/Static/CurrentIndexingScope.cs
+++ b/src/Raven.Server/Documents/Indexes/Static/CurrentIndexingScope.cs
@@ -1,6 +1,7 @@
 ﻿using System;
 using System.Collections.Generic;
 using Raven.Client.Documents.Indexes;
+using Raven.Server.Documents.Indexes.Persistence.Lucene.Documents;
 using Raven.Server.Documents.Indexes.Static.Spatial;
 using Raven.Server.ServerWide;
 using Raven.Server.ServerWide.Context;
@@ -42,6 +43,8 @@ namespace Raven.Server.Documents.Indexes.Static
         public readonly TransactionOperationContext IndexContext;
 
         public readonly IndexDefinitionBase IndexDefinition;
+
+        public LuceneDocumentConverter CreateFieldConverter;
 
         public CurrentIndexingScope(DocumentsStorage documentsStorage, DocumentsOperationContext documentsContext, IndexDefinitionBase indexDefinition, TransactionOperationContext indexContext, Func<string, SpatialField> getSpatialField, UnmanagedBuffersPoolWithLowMemoryHandling _unmanagedBuffersPool)
         {

--- a/src/Raven.Server/Documents/Indexes/Static/StaticIndexBase.cs
+++ b/src/Raven.Server/Documents/Indexes/Static/StaticIndexBase.cs
@@ -18,8 +18,6 @@ namespace Raven.Server.Documents.Indexes.Static
 
     public abstract class StaticIndexBase
     {
-        private LuceneDocumentConverter _createFieldsConverter;
-
         private readonly Dictionary<string, CollectionName> _collectionsCache = new Dictionary<string, CollectionName>(StringComparer.OrdinalIgnoreCase);
 
         public readonly Dictionary<string, List<IndexingFunc>> Maps = new Dictionary<string, List<IndexingFunc>>(StringComparer.OrdinalIgnoreCase);
@@ -135,11 +133,11 @@ namespace Raven.Server.Documents.Indexes.Static
                 Indexing = index
             }, null);
 
-            if (_createFieldsConverter == null)
-                _createFieldsConverter = new LuceneDocumentConverter(new IndexField[] { });
+            if (CurrentIndexingScope.Current.CreateFieldConverter == null)
+                CurrentIndexingScope.Current.CreateFieldConverter = new LuceneDocumentConverter(new IndexField[] { });
 
             var result = new List<AbstractField>();
-            _createFieldsConverter.GetRegularFields(new StaticIndexLuceneDocumentWrapper(result), field, value, CurrentIndexingScope.Current.IndexContext);
+            CurrentIndexingScope.Current.CreateFieldConverter.GetRegularFields(new StaticIndexLuceneDocumentWrapper(result), field, value, CurrentIndexingScope.Current.IndexContext);
             return result;
         }
 


### PR DESCRIPTION
…CreateField() calls into the indexing scope which is thread specific. We must not have it in StaticIndexBase as this can be shared between indexes if the definition is the same while the lucene converter has _fieldsCache.