### PR TITLE
RavenDB-11640 Bug fixed + test - - lazy string escape characters

### DIFF
--- a/src/Raven.Server/Documents/BlittableMetadataModifier.cs
+++ b/src/Raven.Server/Documents/BlittableMetadataModifier.cs
@@ -86,6 +86,11 @@ namespace Raven.Server.Documents
             {
                 lazyStringValueFromParserState.EscapePositions = state.EscapePositions.ToArray();
             }
+            else
+            {
+                lazyStringValueFromParserState.EscapePositions = Array.Empty<int>();
+            }
+
             return lazyStringValueFromParserState;
         }
 

--- a/test/FastTests/Blittable/BlittableJsonWriterTests/BlittableMetadataModifierTest.cs
+++ b/test/FastTests/Blittable/BlittableJsonWriterTests/BlittableMetadataModifierTest.cs
@@ -1,0 +1,44 @@
+﻿using System.Text;
+using Raven.Client.Documents.Conventions;
+using Raven.Client.Json;
+using Raven.Server.Documents;
+using Sparrow.Json;
+using Sparrow.Json.Parsing;
+using Sparrow.Threading;
+using Xunit;
+
+namespace FastTests.Blittable.BlittableJsonWriterTests
+{
+    public unsafe class BlittableMetadataModifierTest : NoDisposalNeeded
+    {
+        [Fact]
+        public void BlittableMetadataModifier_WhileIdContainsNoEscapeCharacters_ResultInLazyStringWithoutEscapeInformation()
+        {
+            const string json = "{\"@metadata\": { \"@id\": \"u1\"}}";
+
+            using (var ctx = JsonOperationContext.ShortTermSingleUse())
+            {
+                var buffer = Encoding.UTF8.GetBytes(json);
+                var state = new JsonParserState();
+
+                var modifier = new BlittableMetadataModifier(ctx);
+                using (var parser = new UnmanagedJsonParser(ctx, state, "test"))
+                    fixed (byte* pBuffer = buffer)
+                    {
+                        parser.SetBuffer(pBuffer, buffer.Length);
+
+                        using (
+                            var builder = new BlittableJsonDocumentBuilder(ctx,
+                                BlittableJsonDocumentBuilder.UsageMode.None, "test", parser, state, null, modifier))
+                        {
+                            builder.ReadObjectDocument();
+                            builder.Read();
+                            builder.FinalizeDocument();
+                        }
+                    }
+
+                Assert.NotNull(modifier.Id.EscapePositions);
+            }
+        }
+    }
+}


### PR DESCRIPTION
BlittableMetadataModifier changed to add information about escape characters of id when there is none