### PR TITLE
[4.1] RavenDB-11644 Fix TCP versioning negotiation

### DIFF
--- a/src/Raven.Client/Documents/Subscriptions/SubscriptionWorker.cs
+++ b/src/Raven.Client/Documents/Subscriptions/SubscriptionWorker.cs
@@ -192,7 +192,7 @@ namespace Raven.Client.Documents.Subscriptions
                     Database = databaseName,
                     Operation = TcpConnectionHeaderMessage.OperationTypes.Subscription,
                     Version = TcpConnectionHeaderMessage.SubscriptionTcpVersion,
-                    ReadResponseAndGetVersion = ReadServerResponseAndGetVersion
+                    ReadResponseAndGetVersionCallback = ReadServerResponseAndGetVersion
                 };
                 _supportedFeatures = TcpNegotiation.NegotiateProtocolVersion(context, _stream, parameters);
 
@@ -233,18 +233,24 @@ namespace Raven.Client.Documents.Subscriptions
                             return reply.Version;
                         }
                         //Kindly request the server to drop the connection
-                        context.Write(writer, new DynamicJsonValue
-                        {
-                            [nameof(TcpConnectionHeaderMessage.DatabaseName)] = _dbName,
-                            [nameof(TcpConnectionHeaderMessage.Operation)] = TcpConnectionHeaderMessage.OperationTypes.Drop.ToString(),
-                            [nameof(TcpConnectionHeaderMessage.OperationVersion)] = TcpConnectionHeaderMessage.GetOperationTcpVersion(TcpConnectionHeaderMessage.OperationTypes.Drop),
-                            [nameof(TcpConnectionHeaderMessage.Info)] = $"Couldn't agree on subscription tcp version ours:{TcpConnectionHeaderMessage.SubscriptionTcpVersion} theirs:{reply.Version}"
-                        });
-                        writer.Flush();
+                        SendDropMessage(context, writer, reply);
                         throw new InvalidOperationException($"Can't connect to database {_dbName} because: {reply.Message}");
                 }
                 return reply.Version;
             }
+        }
+
+        private void SendDropMessage(JsonOperationContext context, BlittableJsonTextWriter writer, TcpConnectionHeaderResponse reply)
+        {
+            context.Write(writer, new DynamicJsonValue
+            {
+                [nameof(TcpConnectionHeaderMessage.DatabaseName)] = _dbName,
+                [nameof(TcpConnectionHeaderMessage.Operation)] = TcpConnectionHeaderMessage.OperationTypes.Drop.ToString(),
+                [nameof(TcpConnectionHeaderMessage.OperationVersion)] = TcpConnectionHeaderMessage.GetOperationTcpVersion(TcpConnectionHeaderMessage.OperationTypes.Drop),
+                [nameof(TcpConnectionHeaderMessage.Info)] =
+                    $"Couldn't agree on subscription TCP version ours:{TcpConnectionHeaderMessage.SubscriptionTcpVersion} theirs:{reply.Version}"
+            });
+            writer.Flush();
         }
 
         private void AssertConnectionState(SubscriptionConnectionServerMessage connectionStatus)

--- a/src/Raven.Client/ServerWide/Tcp/TcpConnectionHeader.cs
+++ b/src/Raven.Client/ServerWide/Tcp/TcpConnectionHeader.cs
@@ -1,5 +1,6 @@
 ﻿using System;
 using System.Collections.Generic;
+using System.Linq;
 
 namespace Raven.Client.ServerWide.Tcp
 {
@@ -27,22 +28,103 @@ namespace Raven.Client.ServerWide.Tcp
 
         public string Info { get; set; }
 
-        public static readonly int PingBaseLine40000 = -1;
-        public static readonly int NoneBaseLine40000 = -1;
-        public static readonly int DropBaseLine40000 = -2;
-        public static readonly int ClusterBaseLine40100 = 10;
-        public static readonly int HeartbeatsBaseLine40200 = 20;
-        public static readonly int ReplicationBaseLine40301 = 31;    
-        public static readonly int ReplicationAttachmentMissing = 40300;
-        public static readonly int ReplicationAttachmentMissingVersion41 = 41300;
-        public static readonly int SubscriptionBaseLine40400 = 40;
-        public static readonly int TestConnectionBaseLine40500 = 50;
+        public static readonly int PingBaseLine = -1;
+        public static readonly int NoneBaseLine = -1;
+        public static readonly int DropBaseLine = -2;
+        public static readonly int ClusterBaseLine = 10;
+        public static readonly int HeartbeatsBaseLine = 20;
+        public static readonly int ReplicationBaseLine = 31;
+        public static readonly int ReplicationAttachmentMissing = 40_300;
+        public static readonly int ReplicationAttachmentMissingVersion41 = 41_300;
+        public static readonly int SubscriptionBaseLine = 40;
+        public static readonly int TestConnectionBaseLine = 50;
 
-        public static readonly int ClusterTcpVersion = ClusterBaseLine40100;
-        public static readonly int HeartbeatsTcpVersion = HeartbeatsBaseLine40200;
+        public static readonly int ClusterTcpVersion = ClusterBaseLine;
+        public static readonly int HeartbeatsTcpVersion = HeartbeatsBaseLine;
         public static readonly int ReplicationTcpVersion = ReplicationAttachmentMissingVersion41;
-        public static readonly int SubscriptionTcpVersion = SubscriptionBaseLine40400;
-        public static readonly int TestConnectionTcpVersion = TestConnectionBaseLine40500;
+        public static readonly int SubscriptionTcpVersion = SubscriptionBaseLine;
+        public static readonly int TestConnectionTcpVersion = TestConnectionBaseLine;
+
+        static TcpConnectionHeaderMessage()
+        {
+            // validate
+            var operations = new []
+            {
+                OperationTypes.Cluster,
+                OperationTypes.Drop,
+                OperationTypes.Heartbeats,
+                OperationTypes.None,
+                OperationTypes.Ping,
+                OperationTypes.Replication,
+                OperationTypes.Subscription,
+                OperationTypes.TestConnection
+            };
+            foreach (var operation in operations)
+            {
+                var versions = OperationsToSupportedProtocolVersions[operation];
+                var features = SupportedFeaturesByProtocol[operation];
+                if (features.Keys.SequenceEqual(versions) == false)
+                {
+                    throw new ArgumentException();
+                }
+
+                var version = versions[0];
+
+                switch (operation)
+                {
+                    case OperationTypes.None:
+                        if (version != NoneBaseLine)
+                            throw new ArgumentException();
+                        if (features[NoneBaseLine] == null)
+                            throw new ArgumentException();
+                        break;
+                    case OperationTypes.Drop:
+                        if (version != DropBaseLine)
+                            throw new ArgumentException();
+                        if (features[DropBaseLine] == null)
+                            throw new ArgumentException();
+                        break;
+                    case OperationTypes.Subscription:
+                        if (version != SubscriptionTcpVersion)
+                            throw new ArgumentException();
+                        if (features[SubscriptionTcpVersion] == null)
+                            throw new ArgumentException();
+                        break;
+                    case OperationTypes.Replication:
+                        if (version != ReplicationTcpVersion)
+                            throw new ArgumentException();
+                        if (features[ReplicationTcpVersion] == null)
+                            throw new ArgumentException();
+                        break;
+                    case OperationTypes.Cluster:
+                        if (version != ClusterTcpVersion)
+                            throw new ArgumentException();
+                        if (features[ClusterTcpVersion] == null)
+                            throw new ArgumentException();
+                        break;
+                    case OperationTypes.Heartbeats:
+                        if (version != HeartbeatsTcpVersion)
+                            throw new ArgumentException();
+                        if (features[HeartbeatsTcpVersion] == null)
+                            throw new ArgumentException();
+                        break;
+                    case OperationTypes.Ping:
+                        if (version != PingBaseLine)
+                            throw new ArgumentException();
+                        if (features[PingBaseLine] == null)
+                            throw new ArgumentException();
+                        break;
+                    case OperationTypes.TestConnection:
+                        if (version != TestConnectionTcpVersion)
+                            throw new ArgumentException();
+                        if (features[TestConnectionTcpVersion] == null)
+                            throw new ArgumentException();
+                        break;
+                    default:
+                        throw new ArgumentOutOfRangeException();
+                }
+            }
+        }
 
         public class SupportedFeatures
         {
@@ -60,138 +142,195 @@ namespace Raven.Client.ServerWide.Tcp
             public ClusterFeatures Cluster { get; set; }
             public HeartbeatsFeatures Heartbeats { get; set; }
             public TestConnectionFeatures TestConnection { get; set; }
-
             public ReplicationFeatures Replication { get; set; }
 
             public class PingFeatures
             {
-                public bool BaseLine4000 = true;
+                public bool BaseLine = true;
             }
             public class NoneFeatures
             {
-                public bool BaseLine4000 = true;
+                public bool BaseLine = true;
             }
             public class DropFeatures
             {
-                public bool BaseLine4000 = true;
+                public bool BaseLine = true;
             }
             public class SubscriptionFeatures
             {
-                public bool BaseLine4000 = true;
+                public bool BaseLine = true;
             }
             public class ClusterFeatures
             {
-                public bool BaseLine4000 = true;
+                public bool BaseLine = true;
             }
-
             public class HeartbeatsFeatures
             {
-                public bool BaseLine4000 = true;
+                public bool BaseLine = true;
             }
             public class TestConnectionFeatures
             {
-                public bool BaseLine4000 = true;
+                public bool BaseLine = true;
             }
             public class ReplicationFeatures
             {
-                public bool BaseLine4000 = true, MissingAttachments, Counters, ClusterTransaction;
+                public bool BaseLine = true;
+                public bool MissingAttachments;
+                public bool Counters;
+                public bool ClusterTransaction;
             }
         }
 
-        /// <summary>
-        /// This dictionary maps (operation type, protocol version) to a list of supported features, supported features comes with a protocol versions
-        /// and the list of supported features is sorted by the most up to date protocol meaning OperationsToSupportedProtocolVersions[(type,version)][0]
-        /// will have the same version as the key.version and it is the most up to date version that is supported for key.version.
-        /// This dictionary has dual purpose:
-        /// 1. map available features for given protocol type and version.
-        /// 2. allow to find a prev version that the current version support and map its features.
-        ///
-        /// * When inserting new entries to this dictionary you must place them as the first item in the list of supported features
-        /// Lets say we had
-        /// OperationsToSupportedProtocolVersions[('Foo',5)] = new List<SupportedFeatures> {SupportedFeatures5}
-        /// and we want to add a new protocol '6' it should look like this:
-        /// OperationsToSupportedProtocolVersions[('Foo',6)] = new List<SupportedFeatures> {SupportedFeatures6, SupportedFeatures5}
-        /// </summary>
-        private static readonly Dictionary<(OperationTypes, int), List<SupportedFeatures>> OperationsToSupportedProtocolVersions
-            = new Dictionary<(OperationTypes, int), List<SupportedFeatures>>
+        private static readonly Dictionary<OperationTypes, List<int>> OperationsToSupportedProtocolVersions
+            = new Dictionary<OperationTypes, List<int>>
             {
-                [(OperationTypes.Ping, PingBaseLine40000)] =
-                    new List<SupportedFeatures>
-                    {
-                        new SupportedFeatures(PingBaseLine40000){Ping = new SupportedFeatures.PingFeatures()}
-                    },
-                [(OperationTypes.None, NoneBaseLine40000)] =
-                    new List<SupportedFeatures>
-                    {
-                        new SupportedFeatures(NoneBaseLine40000){None = new SupportedFeatures.NoneFeatures()}
-                    },
-                [(OperationTypes.Drop, DropBaseLine40000)] =
-                    new List<SupportedFeatures>
-                    {
-                        new SupportedFeatures(DropBaseLine40000) { Drop = new SupportedFeatures.DropFeatures() }
-                    },
-                [(OperationTypes.Subscription, SubscriptionBaseLine40400)] =
-                    new List<SupportedFeatures>
-                    {
-                        new SupportedFeatures(SubscriptionBaseLine40400){Subscription = new SupportedFeatures.SubscriptionFeatures()}
-                    },
-                [(OperationTypes.Replication, ReplicationAttachmentMissingVersion41)] =
-                    new List<SupportedFeatures>
-                    {
-                        new SupportedFeatures(ReplicationAttachmentMissingVersion41){Replication = new SupportedFeatures.ReplicationFeatures{Counters= true, ClusterTransaction = true, MissingAttachments = true}},
-                        /*While counter is a newer feature 'ReplicationAttachmentMissing' is a newer release and we must check the version by the order of the release*/
-                        new SupportedFeatures(ReplicationAttachmentMissing){Replication = new SupportedFeatures.ReplicationFeatures{MissingAttachments = true}},
-                        new SupportedFeatures(ReplicationBaseLine40301){Replication = new SupportedFeatures.ReplicationFeatures()}
-                    },
-                [(OperationTypes.Replication, ReplicationAttachmentMissing)] =
-                    new List<SupportedFeatures>
-                    {
-                        new SupportedFeatures(ReplicationAttachmentMissing){Replication = new SupportedFeatures.ReplicationFeatures{MissingAttachments = true}},
-                        new SupportedFeatures(ReplicationBaseLine40301){Replication = new SupportedFeatures.ReplicationFeatures()}
-                    },
-                [(OperationTypes.Replication, ReplicationBaseLine40301)] =
-                    new List<SupportedFeatures>
-                    {
-                        new SupportedFeatures(ReplicationBaseLine40301){Replication = new SupportedFeatures.ReplicationFeatures()}
-                    },
-                [(OperationTypes.Cluster, ClusterBaseLine40100)] =
-                    new List<SupportedFeatures>
-                    {
-                        new SupportedFeatures(ClusterBaseLine40100) {Cluster = new SupportedFeatures.ClusterFeatures()}
-                    },
-                [(OperationTypes.Heartbeats, HeartbeatsBaseLine40200)] =
-                    new List<SupportedFeatures>
-                    {
-                        new SupportedFeatures(HeartbeatsBaseLine40200) { Cluster = new SupportedFeatures.ClusterFeatures()}
-                    },
-                [(OperationTypes.TestConnection, TestConnectionBaseLine40500)] =
-                    new List<SupportedFeatures>
-                    {
-                        new SupportedFeatures(TestConnectionBaseLine40500) { TestConnection = new SupportedFeatures.TestConnectionFeatures()}
-                    },
+                [OperationTypes.Ping] = new List<int>
+                {
+                    PingBaseLine
+                },
+                [OperationTypes.None] = new List<int>
+                {
+                    NoneBaseLine
+                },
+                [OperationTypes.Drop] = new List<int>
+                {
+                    DropBaseLine
+                },
+                [OperationTypes.Subscription] = new List<int>
+                {
+                    SubscriptionBaseLine
+                },
+                [OperationTypes.Replication] = new List<int>
+                {
+                    ReplicationAttachmentMissingVersion41,
+                    ReplicationAttachmentMissing,
+                    ReplicationBaseLine
+                },
+                [OperationTypes.Cluster] = new List<int>
+                {
+                    ClusterBaseLine
+                },
+                [OperationTypes.Heartbeats] = new List<int>
+                {
+                    HeartbeatsBaseLine
+                },
+                [OperationTypes.TestConnection] = new List<int>
+                {
+                    TestConnectionBaseLine
+                }
             };
 
-        public static (bool Supported, int PrevSupported) OperationVersionSupported(OperationTypes operationType, int version)
-        {
-            var prev = -1;
-            if (OperationsToSupportedProtocolVersions.TryGetValue((operationType, version), out var supportedProtocols) == false)
-                return (false, prev);
-
-            for (var i = 0; i < supportedProtocols.Count; prev = supportedProtocols[i].ProtocolVersion, i++)
+        private static readonly Dictionary<OperationTypes, Dictionary<int, SupportedFeatures>> SupportedFeaturesByProtocol
+            = new Dictionary<OperationTypes, Dictionary<int, SupportedFeatures>>
             {
-                var current = supportedProtocols[i].ProtocolVersion;
-                if (current == version)
-                    return (true, prev);
+                [OperationTypes.Ping] = new Dictionary<int, SupportedFeatures>
+                {
+                    [PingBaseLine] = new SupportedFeatures(PingBaseLine)
+                    {
+                        Ping = new SupportedFeatures.PingFeatures()
+                    }
+                },
+                [OperationTypes.None] = new Dictionary<int, SupportedFeatures>
+                {
+                    [NoneBaseLine] = new SupportedFeatures(NoneBaseLine)
+                    {
+                        None = new SupportedFeatures.NoneFeatures()
+                    }
+                },
+                [OperationTypes.Drop] = new Dictionary<int, SupportedFeatures>
+                {
+                    [DropBaseLine] = new SupportedFeatures(DropBaseLine)
+                    {
+                        Drop = new SupportedFeatures.DropFeatures()
+                    }
+                },
+                [OperationTypes.Subscription] = new Dictionary<int, SupportedFeatures>
+                {
+                    [SubscriptionBaseLine] = new SupportedFeatures(SubscriptionBaseLine)
+                    {
+                        Subscription = new SupportedFeatures.SubscriptionFeatures()
+                    }
+                },
+                [OperationTypes.Replication] = new Dictionary<int, SupportedFeatures>
+                {
+                    [ReplicationAttachmentMissingVersion41] = new SupportedFeatures(ReplicationAttachmentMissingVersion41)
+                    {
+                        Replication = new SupportedFeatures.ReplicationFeatures
+                        {
+                            Counters = true,
+                            ClusterTransaction = true,
+                            MissingAttachments = true
+                        }
+                    },
+                    /*While counter is a newer feature 'ReplicationAttachmentMissing' is a newer release and we must check the version by the order of the release*/
+                    [ReplicationAttachmentMissing] = new SupportedFeatures(ReplicationAttachmentMissing)
+                    {
+                        Replication = new SupportedFeatures.ReplicationFeatures
+                        {
+                            MissingAttachments = true
+                        }
+                    },
+                    [ReplicationBaseLine] = new SupportedFeatures(ReplicationBaseLine)
+                    {
+                        Replication = new SupportedFeatures.ReplicationFeatures()
+                    }
+                },
+                [OperationTypes.Cluster] = new Dictionary<int, SupportedFeatures>
+                {
+                    [ClusterBaseLine] = new SupportedFeatures(ClusterBaseLine)
+                    {
+                        Cluster = new SupportedFeatures.ClusterFeatures()
+                    }
+                },
+                [OperationTypes.Heartbeats] = new Dictionary<int, SupportedFeatures>
+                {
+                    [HeartbeatsBaseLine] = new SupportedFeatures(HeartbeatsBaseLine)
+                    {
+                        Heartbeats = new SupportedFeatures.HeartbeatsFeatures()
+                    }
+                },
+                [OperationTypes.TestConnection] = new Dictionary<int, SupportedFeatures>
+                {
+                    [TestConnectionBaseLine] = new SupportedFeatures(TestConnectionBaseLine)
+                    {
+                        TestConnection = new SupportedFeatures.TestConnectionFeatures()
+                    }
+                }
+            };
 
-                if (current > version)
-                    return (false, prev);
-            }
 
-            return (false, prev);
+        public enum SupportedStatus
+        {
+            OutOfRange,
+            NotSupported,
+            Supported
         }
 
-        public static int GetOperationTcpVersion(OperationTypes operationType)
+        public static SupportedStatus OperationVersionSupported(OperationTypes operationType, int version, out int current)
         {
+            current = -1;
+            if (OperationsToSupportedProtocolVersions.TryGetValue(operationType, out var supportedProtocols) == false)
+            {
+                throw new ArgumentException($"This is a bug. Probably you forgot to add '{operationType}' operation " +
+                                            $"to the '{nameof(OperationsToSupportedProtocolVersions)}' dictionary.");
+            }
+
+            for (var i = 0; i < supportedProtocols.Count; i++)
+            {
+                current = supportedProtocols[i];
+                if (current == version)
+                    return SupportedStatus.Supported;
+
+                if (current < version)
+                    return SupportedStatus.NotSupported;
+            }
+
+            return SupportedStatus.OutOfRange;
+        }
+
+        public static int GetOperationTcpVersion(OperationTypes operationType, int index = 0)
+        {
+            // we don't check the if the index go out of range, since this is expected and means that we don't have 
             switch (operationType)
             {
                 case OperationTypes.Ping:
@@ -200,23 +339,21 @@ namespace Raven.Client.ServerWide.Tcp
                 case OperationTypes.Drop:
                     return -2;
                 case OperationTypes.Subscription:
-                    return SubscriptionTcpVersion;
                 case OperationTypes.Replication:
-                    return ReplicationTcpVersion;
                 case OperationTypes.Cluster:
-                    return ClusterTcpVersion;
                 case OperationTypes.Heartbeats:
-                    return HeartbeatsTcpVersion;
                 case OperationTypes.TestConnection:
-                    return TestConnectionTcpVersion;
+                    return OperationsToSupportedProtocolVersions[operationType][index];
                 default:
                     throw new ArgumentOutOfRangeException(nameof(operationType), operationType, null);
             }
         }
 
-        public static SupportedFeatures GetSupportedFeaturesFor(OperationTypes type, int optionsProtocolVersion)
+        public static SupportedFeatures GetSupportedFeaturesFor(OperationTypes type, int protocolVersion)
         {
-            return OperationsToSupportedProtocolVersions[(type, optionsProtocolVersion)][0];
+            if(SupportedFeaturesByProtocol[type].TryGetValue(protocolVersion, out var features) == false)
+                throw new ArgumentException($"{type} in protocol {protocolVersion} was not found in the features set.");
+            return features;
         }
     }
 }

--- a/src/Raven.Client/ServerWide/Tcp/TcpNegotiation.cs
+++ b/src/Raven.Client/ServerWide/Tcp/TcpNegotiation.cs
@@ -1,7 +1,6 @@
 ﻿using System;
 using System.IO;
 using System.Threading;
-using System.Threading.Tasks;
 using Sparrow.Json;
 using Sparrow.Json.Parsing;
 
@@ -9,95 +8,54 @@ namespace Raven.Client.ServerWide.Tcp
 {
     public class TcpNegotiation
     {
-        public static TcpConnectionHeaderMessage.SupportedFeatures NegotiateProtocolVersion(JsonOperationContext documentsContext, Stream stream, TcpNegotiateParamaters parameters)
+        public static TcpConnectionHeaderMessage.SupportedFeatures NegotiateProtocolVersion(JsonOperationContext context, Stream stream, TcpNegotiateParamaters parameters)
         {
-            using (var writer = new BlittableJsonTextWriter(documentsContext, stream))
-            {
-                var currentVersion = parameters.Version;
-                while (true)
-                {
-                    documentsContext.Write(writer, new DynamicJsonValue
-                    {
-                        [nameof(TcpConnectionHeaderMessage.DatabaseName)] = parameters.Database, // _parent.Database.Name,
-                        [nameof(TcpConnectionHeaderMessage.Operation)] = parameters.Operation.ToString(),
-                        [nameof(TcpConnectionHeaderMessage.SourceNodeTag)] = parameters.NodeTag,
-                        [nameof(TcpConnectionHeaderMessage.OperationVersion)] = currentVersion
-                    });
-                    writer.Flush();
-                    var version = parameters.ReadResponseAndGetVersion(documentsContext, writer, stream, parameters.Url);
-                    //In this case we usally throw internaly but for completeness we better handle it
-                    if (version == -2)
-                    {
-                        return TcpConnectionHeaderMessage.GetSupportedFeaturesFor(TcpConnectionHeaderMessage.OperationTypes.Drop, TcpConnectionHeaderMessage.DropBaseLine40000);
-                    }
-                    var (supported, prevSupported) = TcpConnectionHeaderMessage.OperationVersionSupported(parameters.Operation, version);
-                    if (supported)
-                    {
-                        //We are done
-                        if (currentVersion == version)
-                        {
-                            return TcpConnectionHeaderMessage.GetSupportedFeaturesFor(parameters.Operation, version);
-                        }
-                        //Here we support the requested version but need to inform the otherside we agree
-                        currentVersion = version;
-                        continue;
-                    }
-                    if (prevSupported == -1)
-                        return TcpConnectionHeaderMessage.GetSupportedFeaturesFor(TcpConnectionHeaderMessage.OperationTypes.None, TcpConnectionHeaderMessage.NoneBaseLine40000);
-                    currentVersion = prevSupported;
-                }
-            }
-        }
-
-        public static async Task<TcpConnectionHeaderMessage.SupportedFeatures> NegotiateProtocolVersionAsync(JsonOperationContext documentsContext, Stream stream, TcpNegotiateParamaters parameters)
-        {
-            using (var writer = new BlittableJsonTextWriter(documentsContext, stream))
+            using (var writer = new BlittableJsonTextWriter(context, stream))
             {
                 var currentVersion = parameters.Version;
                 while (true)
                 {
                     if (parameters.CancellationToken.IsCancellationRequested)
-                        throw new OperationCanceledException($"Stoped Tcp negotiation for {parameters.Operation} because of cancelation request");
+                        throw new OperationCanceledException($"Stopped TCP negotiation for {parameters.Operation} because of cancellation request");
 
-                    documentsContext.Write(writer, new DynamicJsonValue
-                    {
-                        [nameof(TcpConnectionHeaderMessage.DatabaseName)] = parameters.Database, // _parent.Database.Name,
-                        [nameof(TcpConnectionHeaderMessage.Operation)] = parameters.Operation.ToString(),
-                        [nameof(TcpConnectionHeaderMessage.SourceNodeTag)] = parameters.NodeTag,
-                        [nameof(TcpConnectionHeaderMessage.OperationVersion)] = currentVersion
-                    });
-                    writer.Flush();
-                    int version;
-                    if (parameters.ReadResponseAndGetVersionAsync == null)
-                    {
-                        version = parameters.ReadResponseAndGetVersion(documentsContext, writer, stream, parameters.Url);
-                    }
-                    else
-                    {
-                        version = await parameters.ReadResponseAndGetVersionAsync(documentsContext, writer, stream, parameters.Url, parameters.CancellationToken).ConfigureAwait(false);
-                    }
-                    //In this case we usally throw internaly but for completeness we better handle it
+                    SendTcpVersionInfo(context, writer, parameters, currentVersion);
+                    var version = parameters.ReadResponseAndGetVersionCallback(context, writer, stream, parameters.Url);
+                    //In this case we usually throw internally but for completeness we better handle it
                     if (version == -2)
                     {
-                        return TcpConnectionHeaderMessage.GetSupportedFeaturesFor(TcpConnectionHeaderMessage.OperationTypes.Drop, TcpConnectionHeaderMessage.DropBaseLine40000);
+                        return TcpConnectionHeaderMessage.GetSupportedFeaturesFor(TcpConnectionHeaderMessage.OperationTypes.Drop, TcpConnectionHeaderMessage.DropBaseLine);
                     }
-                    var (supported, prevSupported) = TcpConnectionHeaderMessage.OperationVersionSupported(parameters.Operation, version);
-                    if (supported)
+                    var status = TcpConnectionHeaderMessage.OperationVersionSupported(parameters.Operation, version, out var prevSupported);
+                    if (status == TcpConnectionHeaderMessage.SupportedStatus.OutOfRange)
                     {
-                        //We are done
-                        if (currentVersion == version)
-                        {
-                            return TcpConnectionHeaderMessage.GetSupportedFeaturesFor(parameters.Operation, version);
-                        }
-                        //Here we support the requested version but need to inform the otherside we agree
-                        currentVersion = version;
-                        continue;
+                        throw new ArgumentException($"The {parameters.Operation} version {parameters.Version} is out of range, our lowest version is {prevSupported}");
                     }
-                    if (prevSupported == -1)
-                        return TcpConnectionHeaderMessage.GetSupportedFeaturesFor(TcpConnectionHeaderMessage.OperationTypes.None, TcpConnectionHeaderMessage.NoneBaseLine40000);
+
+                    if (status == TcpConnectionHeaderMessage.SupportedStatus.Supported)
+                    {
+                        // if we had a negotiation we need to notify the other side about the current supported version.
+                        if (currentVersion != version)
+                        {
+                            SendTcpVersionInfo(context, writer, parameters, currentVersion);
+                        }
+                        return TcpConnectionHeaderMessage.GetSupportedFeaturesFor(parameters.Operation, version);
+                    }
+
                     currentVersion = prevSupported;
                 }
             }
+        }
+
+        private static void SendTcpVersionInfo(JsonOperationContext context, BlittableJsonTextWriter writer, TcpNegotiateParamaters parameters, int currentVersion)
+        {
+            context.Write(writer, new DynamicJsonValue
+            {
+                [nameof(TcpConnectionHeaderMessage.DatabaseName)] = parameters.Database,
+                [nameof(TcpConnectionHeaderMessage.Operation)] = parameters.Operation.ToString(),
+                [nameof(TcpConnectionHeaderMessage.SourceNodeTag)] = parameters.NodeTag,
+                [nameof(TcpConnectionHeaderMessage.OperationVersion)] = currentVersion
+            });
+            writer.Flush();
         }
     }
 
@@ -107,9 +65,7 @@ namespace Raven.Client.ServerWide.Tcp
         public int Version { get; set; }
         public string Database { get; set; }
         public string NodeTag { get; set; }
-
         public string Url { get; set; }
-
         public CancellationToken CancellationToken { get; set; }
 
         /// <summary>
@@ -120,7 +76,6 @@ namespace Raven.Client.ServerWide.Tcp
         /// If the respond is 'None' the function should throw.
         /// If the respond is 'TcpMissMatch' the function should return the read version.
         /// </summary>
-        public Func<JsonOperationContext, BlittableJsonTextWriter, Stream, string, int> ReadResponseAndGetVersion { get; set; }
-        public Func<JsonOperationContext, BlittableJsonTextWriter, Stream, string, CancellationToken, Task<int>> ReadResponseAndGetVersionAsync { get; set; }
+        public Func<JsonOperationContext, BlittableJsonTextWriter, Stream, string, int> ReadResponseAndGetVersionCallback { get; set; }
     }
 }

--- a/src/Raven.Server/Documents/Replication/OutgoingReplicationHandler.cs
+++ b/src/Raven.Server/Documents/Replication/OutgoingReplicationHandler.cs
@@ -486,7 +486,7 @@ namespace Raven.Server.Documents.Replication
                     Database = Destination.Database,
                     Operation = TcpConnectionHeaderMessage.OperationTypes.Replication,
                     NodeTag = _parent._server.NodeTag,
-                    ReadResponseAndGetVersion = ReadHeaderResponseAndThrowIfUnAuthorized,
+                    ReadResponseAndGetVersionCallback = ReadHeaderResponseAndThrowIfUnAuthorized,
                     Version = TcpConnectionHeaderMessage.ReplicationTcpVersion
                 };
 
@@ -515,9 +515,10 @@ namespace Raven.Server.Documents.Replication
             }
         }
 
-        private int ReadHeaderResponseAndThrowIfUnAuthorized(JsonOperationContext jsonContext, BlittableJsonTextWriter writer, Stream stream, string url)
+        private int ReadHeaderResponseAndThrowIfUnAuthorized(JsonOperationContext context, BlittableJsonTextWriter writer, Stream stream, string url)
         {
             const int timeout = 2 * 60 * 1000;
+
             using (var replicationTcpConnectReplyMessage = _interruptibleRead.ParseToMemory(
                 _connectionDisposed,
                 "replication acknowledge response",
@@ -546,21 +547,28 @@ namespace Raven.Server.Documents.Replication
                             return headerResponse.Version;
                         }
                         //Kindly request the server to drop the connection
-                        jsonContext.Write(writer, new DynamicJsonValue
-                        {
-                            [nameof(TcpConnectionHeaderMessage.DatabaseName)] = Destination.Database,
-                            [nameof(TcpConnectionHeaderMessage.Operation)] = TcpConnectionHeaderMessage.OperationTypes.Drop.ToString(),
-                            [nameof(TcpConnectionHeaderMessage.SourceNodeTag)] = _parent._server.NodeTag,
-                            [nameof(TcpConnectionHeaderMessage.OperationVersion)] = TcpConnectionHeaderMessage.GetOperationTcpVersion(TcpConnectionHeaderMessage.OperationTypes.Drop),
-                            [nameof(TcpConnectionHeaderMessage.Info)] = $"Couldn't agree on replication tcp version ours:{TcpConnectionHeaderMessage.ReplicationTcpVersion} theirs:{headerResponse.Version}"
-                        });
-                        writer.Flush();
+                        SendDropMessage(context, writer, headerResponse);
                         throw new InvalidOperationException($"{Destination.FromString()} replied with failure {headerResponse.Message}");
                     default:
                         throw new InvalidOperationException($"{Destination.FromString()} replied with unknown status {headerResponse.Status}, message:{headerResponse.Message}");
                 }
             }
         }
+
+        private void SendDropMessage(JsonOperationContext context, BlittableJsonTextWriter writer, TcpConnectionHeaderResponse headerResponse)
+        {
+            context.Write(writer, new DynamicJsonValue
+            {
+                [nameof(TcpConnectionHeaderMessage.DatabaseName)] = Destination.Database,
+                [nameof(TcpConnectionHeaderMessage.Operation)] = TcpConnectionHeaderMessage.OperationTypes.Drop.ToString(),
+                [nameof(TcpConnectionHeaderMessage.SourceNodeTag)] = _parent._server.NodeTag,
+                [nameof(TcpConnectionHeaderMessage.OperationVersion)] = TcpConnectionHeaderMessage.GetOperationTcpVersion(TcpConnectionHeaderMessage.OperationTypes.Drop),
+                [nameof(TcpConnectionHeaderMessage.Info)] =
+                    $"Couldn't agree on replication TCP version ours:{TcpConnectionHeaderMessage.ReplicationTcpVersion} theirs:{headerResponse.Version}"
+            });
+            writer.Flush();
+        }
+
         private bool WaitForChanges(int timeout, CancellationToken token)
         {
             while (true)

--- a/src/Raven.Server/ServerWide/ClusterStateMachine.cs
+++ b/src/Raven.Server/ServerWide/ClusterStateMachine.cs
@@ -1542,7 +1542,7 @@ namespace Raven.Server.ServerWide
                     Database = null,
                     Operation = TcpConnectionHeaderMessage.OperationTypes.Cluster,
                     Version = TcpConnectionHeaderMessage.ClusterTcpVersion,
-                    ReadResponseAndGetVersion = ClusterReadResponseAndGetVersion,
+                    ReadResponseAndGetVersionCallback = ClusterReadResponseAndGetVersion,
                     Url = info.Url
                 };
 

--- a/src/Raven.Server/ServerWide/Maintenance/ClusterMaintenanceSupervisor.cs
+++ b/src/Raven.Server/ServerWide/Maintenance/ClusterMaintenanceSupervisor.cs
@@ -313,7 +313,6 @@ namespace Raven.Server.ServerWide.Maintenance
                 }
             }
 
-
             private ClusterMaintenanceConnection ConnectToClientNode(TcpConnectionInfo tcpConnectionInfo, TimeSpan timeout)
             {
                 return AsyncHelpers.RunSync(() => ConnectToClientNodeAsync(tcpConnectionInfo, timeout));
@@ -332,10 +331,10 @@ namespace Raven.Server.ServerWide.Maintenance
                         Database = null,
                         Operation = TcpConnectionHeaderMessage.OperationTypes.Heartbeats,
                         Version = TcpConnectionHeaderMessage.HeartbeatsTcpVersion,
-                        ReadResponseAndGetVersionAsync = SupervisorReadResponseAndGetVersionAsync,
+                        ReadResponseAndGetVersionCallback = SupervisorReadResponseAndGetVersion,
                         Url = tcpConnectionInfo.Url
                     };
-                    supportedFeatures = await TcpNegotiation.NegotiateProtocolVersionAsync(ctx, connection, paramaters).ConfigureAwait(false);
+                    supportedFeatures = TcpNegotiation.NegotiateProtocolVersion(ctx, connection, paramaters);
 
                     WriteClusterMaintenanceConnectionHeader(writer);
                 }
@@ -348,9 +347,9 @@ namespace Raven.Server.ServerWide.Maintenance
                 };
             }
 
-            private async Task<int> SupervisorReadResponseAndGetVersionAsync(JsonOperationContext ctx, BlittableJsonTextWriter writer, Stream stream, string url, CancellationToken ct)
+            private int SupervisorReadResponseAndGetVersion(JsonOperationContext ctx, BlittableJsonTextWriter writer, Stream stream, string url)
             {
-                using (var responseJson = await ctx.ReadForMemoryAsync(stream, _readStatusUpdateDebugString + "/Read-Handshake-Response"))
+                using (var responseJson = ctx.ReadForMemory(stream, _readStatusUpdateDebugString + "/Read-Handshake-Response"))
                 {
                     var headerResponse = JsonDeserializationServer.TcpConnectionHeaderResponse(responseJson);
                     switch (headerResponse.Status)

--- a/test/Tests.Infrastructure/RachisConsensusTestBase.cs
+++ b/test/Tests.Infrastructure/RachisConsensusTestBase.cs
@@ -379,7 +379,7 @@ namespace Tests.Infrastructure
                 {
                     Stream = tcpClient.GetStream(),
 
-                    SupportedFeatures = new TcpConnectionHeaderMessage.SupportedFeatures(TcpConnectionHeaderMessage.NoneBaseLine40000),
+                    SupportedFeatures = new TcpConnectionHeaderMessage.SupportedFeatures(TcpConnectionHeaderMessage.NoneBaseLine),
                     Disconnect = () => tcpClient.Client.Disconnect(false)
                 };
             }


### PR DESCRIPTION
- If the version wasn't exist we would drop the connection, instead of keep searching.
- Some code refactoring, make it all just sync.