### PR TITLE
Fixes to autoincremented "id" columns schema updates:

### DIFF
--- a/Raven.Database/FileSystem/Synchronization/SynchronizationTask.cs
+++ b/Raven.Database/FileSystem/Synchronization/SynchronizationTask.cs
@@ -473,6 +473,9 @@ namespace Raven.Database.FileSystem.Synchronization
                     // let's do it _only_ if we saw the same etag multiple times
 
                     forceIncrementingEtag = true;
+
+                    if (Log.IsDebugEnabled)
+                        Log.Debug("Going to force incrementing last synchronized etag as last source file etag: " + lastReplicatedEtagRecord.Etag + " was already seen " + lastReplicatedEtagRecord.Seen + " times. This should prevent from getting stuck.");
                 }
             }
  


### PR DESCRIPTION
- let's create "by_page_id" index in the first migration phase so we'll feed the index when inserting the records
- taking into account that 'usages' table can contain multiple records pointing to the same 'page_id'