### PR TITLE
[4.0] RavenDB-11661 Connections abuse due to repeated websocket reconnaction

### DIFF
--- a/src/Raven.Server/NotificationCenter/NotificationCenter.cs
+++ b/src/Raven.Server/NotificationCenter/NotificationCenter.cs
@@ -53,7 +53,7 @@ namespace Raven.Server.NotificationCenter
 
         public readonly NotificationCenterOptions Options;
 
-        public void Add(Notification notification)
+        public void Add(Notification notification, DateTime? postponeUntil = null)
         {
             try
             {
@@ -61,7 +61,7 @@ namespace Raven.Server.NotificationCenter
                 {
                     try
                     {
-                        if (_notificationsStorage.Store(notification) == false)
+                        if (_notificationsStorage.Store(notification, postponeUntil) == false)
                             return;
                     }
                     catch (Exception e)

--- a/src/Raven.Server/ServerWide/ServerStore.cs
+++ b/src/Raven.Server/ServerWide/ServerStore.cs
@@ -246,6 +246,7 @@ namespace Raven.Server.ServerWide
                                         NotificationCenter.Add(topologyNotification);
                                     }
                                 }
+                                delay = await ReconnactionBackoff(delay);
                             }
                         }
                     }
@@ -259,11 +260,15 @@ namespace Raven.Server.ServerWide
                     {
                         Logger.Info($"Error during receiving topology updates from the leader. Waiting {delay} [ms] before trying again.", e);
                     }
-
-                    await TimeoutManager.WaitFor(TimeSpan.FromMilliseconds(delay), ServerShutdown);
-                    delay = Math.Min(15_000, delay * 2);
+                    delay = await ReconnactionBackoff(delay);
                 }
             }
+        }
+
+        private async Task<int> ReconnactionBackoff(int delay)
+        {
+            await TimeoutManager.WaitFor(TimeSpan.FromMilliseconds(delay), ServerShutdown);
+            return Math.Min(15_000, delay * 2);
         }
 
         internal ClusterObserver Observer { get; set; }
@@ -716,7 +721,9 @@ namespace Raven.Server.ServerWide
                 return;
 
             NotificationCenter.Add(ClusterTopologyChanged.Create(topologyJson, LeaderTag,
-                NodeTag, _engine.CurrentTerm, GetNodesStatuses(), LoadLicenseLimits()?.NodeLicenseDetails));
+                NodeTag, _engine.CurrentTerm, GetNodesStatuses(), LoadLicenseLimits()?.NodeLicenseDetails), 
+                DateTime.MinValue); 
+            // we set the postpone time to the minimum in order to overwrite it and to send this notification every time when a new client connects. 
         }
 
         private void OnDatabaseChanged(object sender, (string DatabaseName, long Index, string Type) t)


### PR DESCRIPTION
The issue was that we kept an old cluster topology that was sent to the follower, but the follower recognized it and tried to reconnect.