### PR TITLE
[4.1] RavenDB-11696 various cluster fixes

### DIFF
--- a/src/Raven.Server/Documents/ClusterTransactionWaiter.cs
+++ b/src/Raven.Server/Documents/ClusterTransactionWaiter.cs
@@ -1,8 +1,8 @@
 ﻿using System;
+using System.Collections.Concurrent;
 using System.Threading;
 using System.Threading.Tasks;
 using Raven.Client.Extensions;
-using Sparrow.Collections.LockFree;
 
 namespace Raven.Server.Documents
 {

--- a/src/Raven.Server/Documents/DocumentDatabase.cs
+++ b/src/Raven.Server/Documents/DocumentDatabase.cs
@@ -385,10 +385,13 @@ namespace Raven.Server.Documents
                         try
                         {
                             TxMerger.Enqueue(mergedCommands).Wait(DatabaseShutdown);
-                           
                         }
-                        catch
+                        catch(Exception e)
                         {
+                            if (_logger.IsInfoEnabled)
+                            {
+                                _logger.Info($"Failed to execute cluster transaction batch (count: {batch.Count}), will retry them one-by-one.", e);
+                            }
                             ExecuteClusterTransactionOneByOne(batch);
                             return;
                         }

--- a/src/Raven.Server/Rachis/Leader.cs
+++ b/src/Raven.Server/Rachis/Leader.cs
@@ -31,7 +31,7 @@ namespace Raven.Server.Rachis
     /// </summary>
     public class Leader : IDisposable
     {
-        private Task _topologyModification;
+        private TaskCompletionSource<object> _topologyModification;
         private readonly RachisConsensus _engine;
 
         public delegate object ConvertResultFromLeader(JsonOperationContext ctx, object result);
@@ -635,30 +635,21 @@ namespace Raven.Server.Rachis
                 Command = command,
                 Tcs = new TaskCompletionSource<Task<(long, object)>>(TaskCreationOptions.RunContinuationsAsynchronously)
             };
-
             _commandsQueue.Enqueue(rachisMergedCommand);
+
             while (rachisMergedCommand.Tcs.Task.IsCompleted == false)
             {
                 var lockTaken = false;
                 try
                 {
-                    var task = _waitForCommit.WaitAsync(timeout);
                     Monitor.TryEnter(_commandsQueue, ref lockTaken);
-
                     if (lockTaken)
                     {
-                        try
-                        {
-                            EmptyQueue();
-                        }
-                        finally
-                        {
-                            _waitForCommit.SetAndResetAtomically();
-                        }
+                        EmptyQueue();
                     }
                     else
                     {
-                        if (await task == false)
+                        if (await _waitForCommit.WaitAsync(timeout) == false)
                         {
                             if (rachisMergedCommand.Consumed.Raise())
                             {
@@ -673,7 +664,10 @@ namespace Raven.Server.Rachis
                 finally
                 {
                     if (lockTaken)
+                    {
                         Monitor.Exit(_commandsQueue);
+                        _waitForCommit.SetAndResetAtomically();
+                    }
                 }
             }
 
@@ -696,7 +690,8 @@ namespace Raven.Server.Rachis
                 using (_engine.ContextPool.AllocateOperationContext(out TransactionOperationContext context))
                 using (context.OpenWriteTransaction())
                 {
-                    while (_commandsQueue.TryDequeue(out var cmd))
+                    var cmdsCount = 0;
+                    while (_commandsQueue.TryDequeue(out var cmd) && cmdsCount++ < 128)
                     {
                         if (cmd.Consumed.Raise() == false)
                         {
@@ -886,19 +881,21 @@ namespace Raven.Server.Rachis
             {
                 throw new ArgumentException("Can't set the node tag to 'RAFT'. It is a reserved tag.");
             }
-
+            
             using (_disposerLock.EnsureNotDisposed())
             {
+                var topologyModification = new TaskCompletionSource<object>(TaskCreationOptions.RunContinuationsAsynchronously);
+                var existing = Interlocked.CompareExchange(ref _topologyModification, topologyModification, null);
+                if (existing != null)
+                {
+                    task = existing.Task;
+                    return false;
+                }
+                task = topologyModification.Task;
+
                 using (_engine.ContextPool.AllocateOperationContext(out TransactionOperationContext context))
                 using (context.OpenWriteTransaction())
                 {
-                    var existing = Interlocked.CompareExchange(ref _topologyModification, null, null);
-                    if (existing != null)
-                    {
-                        task = existing;
-                        return false;
-                    }
-
                     var clusterTopology = _engine.GetTopology(context);
 
                     //We need to validate that the node doesn't exists before we generate the nodeTag
@@ -976,9 +973,9 @@ namespace Raven.Server.Rachis
                         CommandIndex = index
                     };
 
-                    _topologyModification = task = tcs.Task.ContinueWith(_ =>
+                    tcs.Task.ContinueWith(_ =>
                     {
-                        Interlocked.Exchange(ref _topologyModification, null);
+                        Interlocked.Exchange(ref _topologyModification, null).TrySetResult(null);
                     });
                 }
                 _hasNewTopology.Raise();

--- a/src/Raven.Server/Routing/RequestRouter.cs
+++ b/src/Raven.Server/Routing/RequestRouter.cs
@@ -113,16 +113,17 @@ namespace Raven.Server.Routing
                 if (reqCtx.Database != null)
                 {
                     using (reqCtx.Database.DatabaseInUse(tryMatch.Value.SkipUsagesCount))
-                {
-                    if (reqCtx.HttpContext.Response.Headers.TryGetValue(Constants.Headers.LastKnownClusterTransactionIndex, out var value) 
-                        && long.TryParse(value, out var index) 
-                        && index < reqCtx.Database.RachisLogIndexNotifications.LastModifiedIndex)
                     {
-                        await reqCtx.Database.RachisLogIndexNotifications.WaitForIndexNotification(index, reqCtx.HttpContext.RequestAborted);
-                    }
+                        if (reqCtx.HttpContext.Response.Headers.TryGetValue(Constants.Headers.LastKnownClusterTransactionIndex, out var value)
+                            && long.TryParse(value, out var index)
+                            && index < reqCtx.Database.RachisLogIndexNotifications.LastModifiedIndex)
+                        {
+                            await reqCtx.Database.RachisLogIndexNotifications.WaitForIndexNotification(index, reqCtx.HttpContext.RequestAborted);
+                        }
+
                         await handler(reqCtx);
+                    }
                 }
-            }
                 else
                 {
                     await handler(reqCtx);

--- a/src/Raven.Server/ServerWide/Commands/CleanUpClusterStateCommand.cs
+++ b/src/Raven.Server/ServerWide/Commands/CleanUpClusterStateCommand.cs
@@ -28,13 +28,13 @@ namespace Raven.Server.ServerWide.Commands
                     var deleted = items.DeleteByPrimaryKeyPrefix(prefixSlice, shouldAbort: (tvb) =>
                     {
                         var value = tvb.Reader.Read((int)ClusterTransactionCommand.TransactionCommandsColumn.Key, out var size);
-                        var commandCount = Bits.SwapBytes(*(long*)(value + size - sizeof(long)));
-                        return commandCount > upToCommandCount;
+                        var prevCommandsCount = Bits.SwapBytes(*(long*)(value + size - sizeof(long)));
+                        return prevCommandsCount > upToCommandCount;
                     });
                    
                     if (deleted)
                     {
-                        affectedDatabases.Add(database, upToCommandCount);
+                        affectedDatabases.Add(database, tuple.Value);
                     }
                 }
             }


### PR DESCRIPTION
- Fix concurrency issue in TryModify, we could have changed the topology without waiting for the previous change to be completed.
- Use the BCL ConcurrentDictionary for the cluster transaction waiter.
- Limit the execution of batched raft commands to 128.