### PR TITLE
RavenDB-11292: pwrite64 with long argument as offset for 32bits, to s…

### DIFF
--- a/src/Sparrow/Platform/Posix/Syscall.cs
+++ b/src/Sparrow/Platform/Posix/Syscall.cs
@@ -200,7 +200,7 @@ namespace Sparrow.Platform.Posix
         {
             if (PlatformDetails.Is32Bits)
             {
-                var rc = (long)pwrite(fd, (IntPtr)buf, (UIntPtr)count, (long)offset);
+                var rc = (long)pwrite64(fd, (IntPtr)buf, (UIntPtr)count, (long)offset);
                 return rc;
             }
 


### PR DESCRIPTION
…upport above 4GB writes