### PR TITLE
RavenDB-11503 fix (4.0)

### DIFF
--- a/test/SlowTests/Server/Replication/ReplicationBasicTestsSlow.cs
+++ b/test/SlowTests/Server/Replication/ReplicationBasicTestsSlow.cs
@@ -8,6 +8,7 @@ using Raven.Client.Documents.Operations.Replication;
 using Raven.Client.ServerWide;
 using Raven.Client.ServerWide.Operations;
 using Raven.Client.ServerWide.Operations.Certificates;
+using Raven.Server.Commercial;
 using Raven.Tests.Core.Utils.Entities;
 using Xunit;
 
@@ -96,10 +97,15 @@ namespace SlowTests.Server.Replication
         [Fact]
         public async Task DisableExternalReplication()
         {
-
-            using (var store1 = GetDocumentStore())
-            using (var store2 = GetDocumentStore())
+            using (var store1 = GetDocumentStore(new Options
             {
+                ExternalReplicationEnabledForTests = true
+            }))
+            using (var store2 = GetDocumentStore(new Options
+            {
+                ExternalReplicationEnabledForTests = true
+            }))
+            {    
                 var externalList = await SetupReplicationAsync(store1, store2);
                 using (var session = store1.OpenSession())
                 {

--- a/test/Tests.Infrastructure/ClusterTestBase.cs
+++ b/test/Tests.Infrastructure/ClusterTestBase.cs
@@ -571,27 +571,41 @@ namespace Tests.Infrastructure
 
         public async Task<(long, List<RavenServer>)> CreateDatabaseInCluster(DatabaseRecord record, int replicationFactor, string leadersUrl)
         {
+            var serverCount = Servers.Count(s => s.Disposed == false);
+            if(serverCount < replicationFactor)
+            {
+                throw new InvalidOperationException($"Cannot create database with replication factor = {replicationFactor} when there is only {serverCount} servers in the cluster.");
+            }
+
             DatabasePutResult databaseResult;
+            string[] urls;
             using (var store = new DocumentStore()
             {
                 Urls = new[] { leadersUrl },
                 Database = record.DatabaseName
-            }.Initialize())
+            }.Initialize())            
             {
                 databaseResult = store.Maintenance.Server.Send(new CreateDatabaseOperation(record, replicationFactor));
+                var requestExecutor = store.GetRequestExecutor();
+                var preferred = await requestExecutor.GetPreferredNode();
+                await requestExecutor.UpdateTopologyAsync(preferred.Item2, 10000, true);
+                urls = requestExecutor.Topology.Nodes.Select(x => x.Url).ToArray();
             }
-            var currentServers = Servers.Where(s => s.Disposed == false && s.ServerStore.GetClusterTopology().TryGetNodeTagByUrl(leadersUrl).HasUrl).ToArray();
+
+            var currentServers = Servers.Where(s => s.Disposed == false && 
+                                                    urls.Contains(s.WebUrl)).ToArray();
             int numberOfInstances = 0;
             foreach (var server in currentServers)
             {
                 await server.ServerStore.Cluster.WaitForIndexNotification(databaseResult.RaftCommandIndex);
             }
-
+            
             foreach (var server in currentServers.Where(s => databaseResult.Topology.RelevantFor(s.ServerStore.NodeTag)))
             {
                 await server.ServerStore.DatabasesLandlord.TryGetOrCreateResourceStore(record.DatabaseName);
                 numberOfInstances++;
             }
+
             if (numberOfInstances != replicationFactor)
                 throw new InvalidOperationException("Couldn't create the db on all nodes, just on " + numberOfInstances + " out of " + replicationFactor);
             return (databaseResult.RaftCommandIndex,

--- a/test/Tests.Infrastructure/RavenTestBase.cs
+++ b/test/Tests.Infrastructure/RavenTestBase.cs
@@ -5,6 +5,7 @@ using System.Diagnostics;
 using System.IO;
 using System.IO.Compression;
 using System.Linq;
+using System.Reflection;
 using System.Runtime.CompilerServices;
 using System.Security.Cryptography;
 using System.Security.Cryptography.X509Certificates;
@@ -18,6 +19,7 @@ using Raven.Client.Documents.Operations.Backups;
 using Raven.Client.Documents.Operations.Indexes;
 using Raven.Client.Exceptions.Cluster;
 using Raven.Client.Exceptions.Database;
+using Raven.Client.Extensions;
 using Raven.Client.ServerWide;
 using Raven.Client.ServerWide.Operations;
 using Raven.Client.ServerWide.Operations.Certificates;
@@ -93,6 +95,11 @@ namespace FastTests
                 {
                     options = options ?? Options.Default;
                     var serverToUse = options.Server ?? Server;
+
+                    if (options.ExternalReplicationEnabledForTests)
+                    {
+                        SetExternalReplicationToLicenseToTrue(serverToUse);
+                    }
 
                     var name = GetDatabaseName(caller);
 
@@ -253,6 +260,29 @@ namespace FastTests
             {
                 throw new TimeoutException($"{te.Message} {Environment.NewLine} {te.StackTrace}{Environment.NewLine}Servers states:{Environment.NewLine}{GetLastStatesFromAllServersOrderedByTime()}");
             }
+        }
+
+        private static void SetExternalReplicationToLicenseToTrue(RavenServer serverToUse)
+        {
+            var licenseManagerType = serverToUse.ServerStore.LicenseManager.GetType();
+            var licenseStatusField = licenseManagerType.GetField("_licenseStatus", BindingFlags.Instance | BindingFlags.NonPublic);
+            var licenseStatus = licenseStatusField.GetValue(serverToUse.ServerStore.LicenseManager);
+
+            var licenseStatusType = licenseStatus.GetType();
+            var attributesProp = licenseStatusType.GetProperty("Attributes", BindingFlags.Instance | BindingFlags.Public);
+
+            var getAttributesMethod = attributesProp.GetGetMethod();
+            var attributes = getAttributesMethod.Invoke(licenseStatus, new object[0]);
+            if (attributes == null)
+            {
+                var setAttributesMethod = attributesProp.GetSetMethod();
+                setAttributesMethod.Invoke(licenseStatus, new object[] {new Dictionary<string, object>()});
+                attributes = getAttributesMethod.Invoke(licenseStatus, new object[0]);
+            }
+
+            var attributesType = attributes.GetType();
+            var indexerSet = attributesType.GetMethod("set_Item");
+            indexerSet.Invoke(attributes, new object[] {"externalReplication", true});
         }
 
         protected string GetLastStatesFromAllServersOrderedByTime()
@@ -607,6 +637,7 @@ namespace FastTests
             private Action<DatabaseRecord> _modifyDatabaseRecord;
             private Func<string, string> _modifyDatabaseName;
             private string _path;
+            private bool _isExternalReplicationEnabledForTests;
 
             public static readonly Options Default = new Options(true);
 
@@ -730,6 +761,16 @@ namespace FastTests
                 {
                     AssertNotFrozen();
                     _clientCertificate = value;
+                }
+            }
+
+            public bool ExternalReplicationEnabledForTests
+            {
+                get => _isExternalReplicationEnabledForTests;
+                set
+                {
+                    AssertNotFrozen();                   
+                    _isExternalReplicationEnabledForTests = value;
                 }
             }
 

--- a/test/Tryouts/Program.cs
+++ b/test/Tryouts/Program.cs
@@ -1,36 +1,28 @@
 using System;
-using System.Threading.Tasks;
-using FastTests.Server.Documents.Queries.Parser;
-using FastTests.Voron.Backups;
-using FastTests.Voron.Compaction;
-using SlowTests.Authentication;
-using SlowTests.Bugs.MapRedue;
-using SlowTests.Client;
-using SlowTests.Client.Attachments;
-using SlowTests.Issues;
-using SlowTests.MailingList;
-using Sparrow.Logging;
-using StressTests.Client.Attachments;
+using RachisTests;
 
 namespace Tryouts
 {
     public static class Program
     {
-        public static async Task Main(string[] args)
+        public static void Main(string[] args)
         {
             try
             {
-                using (var test = new RavenDB_11705())
+                for (int i = 0; i < 500; i++)
                 {
-                    await test.CanHandleRevisionOperationBeingRolledBack();
+                    Console.WriteLine(i);
+
+                    using (var test = new AddNodeToClusterTests())
+                    {
+                        test.PutDatabaseOnHealthyNodes().Wait();
+                    }
                 }
             }
             catch (Exception e)
             {
                 Console.WriteLine(e);
             }
-
-            
         }
     }
 }


### PR DESCRIPTION
Make the test deterministic. The issue was that ClusterTestBase::CreateDatabaseInCluster() relied on ServerStore::GetClusterTopology() that was async 

cherry pick of the fix for 4.1 (sha 6dd70b2ca842fde86e3129588d5c61897db6968b)