### PR TITLE
[4.0] - RavenDB-11710 - Cannot create database on macOS

### DIFF
--- a/src/Raven.Server/Documents/DocumentDatabase.cs
+++ b/src/Raven.Server/Documents/DocumentDatabase.cs
@@ -308,6 +308,11 @@ namespace Raven.Server.Documents
                 _writeLockFile.SetLength(1);
                 _writeLockFile.Lock(0, 1);
             }
+            catch (PlatformNotSupportedException)
+            {
+                // locking part of the file isn't supported on macOS
+                // new FileStream will lock the file on this platform
+            }
             catch (Exception e)
             {
                 throw new InvalidOperationException("Cannot open database because RavenDB was unable create file lock on: " + _lockFile, e);
@@ -503,8 +508,17 @@ namespace Raven.Server.Documents
             {
                 if (_writeLockFile != null)
                 {
-                    _writeLockFile.Unlock(0, 1);
+                    try
+                    {
+                        _writeLockFile.Unlock(0, 1);
+                    }
+                    catch (PlatformNotSupportedException)
+                    {
+                        // Unlock isn't supported on macOS
+                    }
+                    
                     _writeLockFile.Dispose();
+                    
                     try
                     {
                         if (File.Exists(_lockFile))


### PR DESCRIPTION
http://issues.hibernatingrhinos.com/issue/RavenDB-11710