### PR TITLE
change related to RavenDB-11708

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -117,3 +117,4 @@ temp
 .vscode
 /test/Tryouts/Databases/*
 bench/Micro.Benchmark/BenchmarkDotNet.Artifacts/
+/src/Raven.Server/*.DotSettings

--- a/test/SlowTests/Server/Replication/ReplicationBasicTestsSlow.cs
+++ b/test/SlowTests/Server/Replication/ReplicationBasicTestsSlow.cs
@@ -121,7 +121,13 @@ namespace SlowTests.Server.Replication
                     TaskId = externalList.First().TaskId,
                     Disabled = true
                 };
+                var db1 = await GetDocumentDatabaseInstanceFor(store1);
+                var db2 = await GetDocumentDatabaseInstanceFor(store2);
                 var res = await store1.Maintenance.SendAsync(new UpdateExternalReplicationOperation(external));
+
+                //make sure the command is processed
+                await db1.ServerStore.Cluster.WaitForIndexNotification(res.RaftCommandIndex);
+                await db2.ServerStore.Cluster.WaitForIndexNotification(res.RaftCommandIndex);
 
                 Assert.Equal(externalList.First().TaskId, res.TaskId);
                 


### PR DESCRIPTION
Not a fix - because I wasn't able to repro the test failure. The change should make the test be less dependent on timing.