### PR TITLE
[4.1] RavenDB-11415 Cluster transaction fixes

### DIFF
--- a/bench/BulkInsert.Benchmark/Program.cs
+++ b/bench/BulkInsert.Benchmark/Program.cs
@@ -11,6 +11,7 @@ using Raven.Client;
 using Raven.Client.Documents;
 using Raven.Client.Documents.Conventions;
 using Raven.Client.Documents.Session;
+using Raven.Client.Exceptions;
 using Raven.Client.Extensions;
 using Raven.Client.ServerWide;
 using Raven.Client.ServerWide.Operations;
@@ -198,8 +199,12 @@ namespace BulkInsert.Benchmark
                         }
                         break;
                     }
-                    catch (TimeoutException)
+                    catch (RavenException e)
                     {
+                        Console.WriteLine(e.GetType());
+                        Console.WriteLine(e.GetBaseException());
+
+                        Console.WriteLine("-------- Retry ------------");
                         // retry
                     }
                     catch (Exception e)
@@ -397,7 +402,7 @@ namespace BulkInsert.Benchmark
         {
             public static void Main(string[] args)
             {
-                using (var massiveObj = new BulkInsertBench("http://localhost:8090", 1805861237))
+                using (var massiveObj = new BulkInsertBench("http://10.0.0.87:8080", 1805861237))
                 {
                     massiveObj.CreateDb();
                     //                    var sp = Stopwatch.StartNew();

--- a/src/Raven.Server/ServerWide/Commands/ClusterTransactionCommand.cs
+++ b/src/Raven.Server/ServerWide/Commands/ClusterTransactionCommand.cs
@@ -104,6 +104,7 @@ namespace Raven.Server.ServerWide.Commands
             foreach (var commandData in commandParsedCommands)
             {
                 var command = ClusterTransactionDataCommand.FromCommandData(commandData);
+                ClusterCommandValidation(command);
                 switch (commandData.Type)
                 {
                     case CommandType.PUT:
@@ -120,6 +121,15 @@ namespace Raven.Server.ServerWide.Commands
             }
 
             DatabaseCommandsCount = DatabaseCommands.Count;
+        }
+
+        private static void ClusterCommandValidation(ClusterTransactionDataCommand command)
+        {
+            var lastChar = command.Id[command.Id.Length - 1];
+            if (lastChar == '/' || lastChar == '|')
+            {
+                throw new NotSupportedException($"Document id {command.Id} cannot end with '|' or '/' as part of cluster transaction");
+            }
         }
 
         public List<string> ExecuteCompareExchangeCommands(TransactionOperationContext context, long index, Table items)

--- a/src/Raven.Server/ServerWide/ServerStore.cs
+++ b/src/Raven.Server/ServerWide/ServerStore.cs
@@ -1920,7 +1920,7 @@ namespace Raven.Server.ServerWide
                 catch (Exception ex)
                 {
                     if (Logger.IsInfoEnabled)
-                        Logger.Info("Tried to send message to leader, retrying", ex);
+                        Logger.Info($"Tried to send message to leader (reached: {reachedLeader.Value}), retrying", ex);
 
                     if (reachedLeader.Value)
                         throw;


### PR DESCRIPTION
- Do backoff on cluster transction failure.
- Delete on PUT document to avoid exception if we put new document in a different collection.