### PR TITLE
[4.0] RavenDB-11639 added Http.UseLibuv configuration option

### DIFF
--- a/src/Raven.Server/Commercial/SetupManager.cs
+++ b/src/Raven.Server/Commercial/SetupManager.cs
@@ -1783,7 +1783,7 @@ namespace Raven.Server.Commercial
                 {
                     var responder = new UniqueResponseResponder(guid);
 
-                    webHost = new WebHostBuilder()
+                    var webHostBuilder = new WebHostBuilder()
                         .CaptureStartupErrors(captureStartupErrors: true)
                         .UseKestrel(options =>
                         {
@@ -1803,12 +1803,13 @@ namespace Raven.Server.Commercial
                             }
                         })
                         .UseSetting(WebHostDefaults.ApplicationKey, "Setup simulation")
-                        .ConfigureServices(collection =>
-                        {
-                            collection.AddSingleton(typeof(IStartup), responder);
-                        })
-                        .UseShutdownTimeout(TimeSpan.FromMilliseconds(150))
-                        .Build();
+                        .ConfigureServices(collection => { collection.AddSingleton(typeof(IStartup), responder); })
+                        .UseShutdownTimeout(TimeSpan.FromMilliseconds(150));
+
+                    if (configuration.Http.UseLibuv)
+                        webHostBuilder = webHostBuilder.UseLibuv();
+
+                    webHost = webHostBuilder.Build();
 
                     await webHost.StartAsync(token);
                 }

--- a/src/Raven.Server/Config/Categories/HttpConfiguration.cs
+++ b/src/Raven.Server/Config/Categories/HttpConfiguration.cs
@@ -56,5 +56,10 @@ namespace Raven.Server.Config.Categories
         [DefaultValue(CompressionLevel.Optimal)]
         [ConfigurationEntry("Http.StaticFilesResponseCompressionLevel", ConfigurationEntryScope.ServerWideOnly)]
         public CompressionLevel StaticFilesResponseCompressionLevel { get; set; }
+
+        [Description("EXPERT. Switches Kestrel to use Libuv")]
+        [DefaultValue(false)]
+        [ConfigurationEntry("Http.UseLibuv", ConfigurationEntryScope.ServerWideOnly)]
+        public bool UseLibuv { get; set; }
     }
 }

--- a/src/Raven.Server/Raven.Server.csproj
+++ b/src/Raven.Server/Raven.Server.csproj
@@ -68,6 +68,7 @@
     <PackageReference Include="Lucene.Net.Contrib.Spatial.NTS" Version="3.0.12" />
     <PackageReference Include="Microsoft.AspNetCore.ResponseCompression" Version="2.1.1" />
     <PackageReference Include="Microsoft.AspNetCore.Server.Kestrel" Version="2.1.2" />
+    <PackageReference Include="Microsoft.AspNetCore.Server.Kestrel.Transport.Libuv" Version="2.1.2" />
     <PackageReference Include="Microsoft.AspNetCore.WebSockets" Version="2.1.1" />
     <PackageReference Include="Microsoft.CodeAnalysis.CSharp" Version="2.8.2" />
     <PackageReference Include="Microsoft.CodeAnalysis.CSharp.Workspaces" Version="2.8.2" />

--- a/src/Raven.Server/RavenServer.cs
+++ b/src/Raven.Server/RavenServer.cs
@@ -175,7 +175,7 @@ namespace Raven.Server
                     }
                 }
 
-                _webHost = new WebHostBuilder()
+                var webHostBuilder = new WebHostBuilder()
                     .CaptureStartupErrors(captureStartupErrors: true)
                     .UseKestrel(ConfigureKestrel)
                     .UseUrls(Configuration.Core.ServerUrls)
@@ -202,9 +202,12 @@ namespace Raven.Server
                         services.AddSingleton(Router);
                         services.AddSingleton(this);
                         services.Configure<FormOptions>(options => { options.MultipartBodyLengthLimit = long.MaxValue; });
-                    })
-                    // ReSharper disable once AccessToDisposedClosure
-                    .Build();
+                    });
+
+                if (Configuration.Http.UseLibuv)
+                    webHostBuilder = webHostBuilder.UseLibuv();
+
+                _webHost = webHostBuilder.Build();
             }
             catch (Exception e)
             {
@@ -304,12 +307,16 @@ namespace Raven.Server
                 if (Logger.IsOperationsEnabled)
                     Logger.Operations($"HTTPS is on. Setting up a new web host to redirect incoming HTTP traffic on port 80 to HTTPS on port 443. The new web host is listening to { string.Join(", ", serverUrlsToRedirect) }");
 
-                _redirectingWebHost = new WebHostBuilder()
+                var webHostBuilder = new WebHostBuilder()
                     .UseKestrel()
                     .UseUrls(serverUrlsToRedirect)
                     .UseStartup<RedirectServerStartup>()
-                    .UseShutdownTimeout(TimeSpan.FromSeconds(1))
-                    .Build();
+                    .UseShutdownTimeout(TimeSpan.FromSeconds(1));
+
+                if (Configuration.Http.UseLibuv)
+                    webHostBuilder = webHostBuilder.UseLibuv();
+
+                _redirectingWebHost = webHostBuilder.Build();
 
                 _redirectingWebHost.Start();
             }
@@ -486,7 +493,7 @@ namespace Raven.Server
                 if (ServerStore.IsLeader() == false)
                     return;
 
-                if(ClusterCommandsVersionManager.ClusterCommandsVersions.TryGetValue(nameof(ConfirmServerCertificateReplacedCommand), out var commandVersion) == false)
+                if (ClusterCommandsVersionManager.ClusterCommandsVersions.TryGetValue(nameof(ConfirmServerCertificateReplacedCommand), out var commandVersion) == false)
                     throw new InvalidOperationException($"Failed to get the command version of '{nameof(ConfirmServerCertificateReplacedCommand)}'.");
 
                 if (ClusterCommandsVersionManager.CurrentClusterMinimalVersion < commandVersion)
@@ -1223,7 +1230,7 @@ namespace Raven.Server
 
                                         throw new ArgumentException(msg);
                                     }
-                                    
+
                                     if (Logger.IsInfoEnabled)
                                     {
                                         Logger.Info(
@@ -1307,7 +1314,7 @@ namespace Raven.Server
 
             using (var writer = new BlittableJsonTextWriter(context, stream))
             {
-                context.Write(writer,message);
+                context.Write(writer, message);
                 writer.Flush();
             }
         }

--- a/test/InterversionTests/MixedClusterTestBase.cs
+++ b/test/InterversionTests/MixedClusterTestBase.cs
@@ -24,6 +24,19 @@ namespace InterversionTests
             public string Url;
         }
 
+        protected override RavenServer GetNewServer(IDictionary<string, string> customSettings = null, bool deletePrevious = true, bool runInMemory = true, string partialPath = null,
+            string customConfigPath = null)
+        {
+            if (customSettings == null)
+                customSettings = new Dictionary<string, string>();
+
+            var key = RavenConfiguration.GetKey(x => x.Http.UseLibuv);
+            if (customSettings.ContainsKey(key) == false)
+                customSettings[key] = "true";
+
+            return base.GetNewServer(customSettings, deletePrevious, runInMemory, partialPath, customConfigPath);
+        }
+
         protected async Task<(RavenServer Leader, List<ProcessNode> Peers, List<RavenServer> LocalPeers)> CreateMixedCluster(string[] peers, int localPeers = 0)
         {
             var leaderServer = GetNewServer();

--- a/test/Tests.Infrastructure/InterversionTest/ConfigurableRavenServerLocator.cs
+++ b/test/Tests.Infrastructure/InterversionTest/ConfigurableRavenServerLocator.cs
@@ -13,6 +13,8 @@ namespace Tests.Infrastructure.InterversionTest
             _serverDirPath = serverDirPath;
         }
 
+        public override string CommandArguments => "--Http.UseLibuv=true";
+
         public override string ServerPath => Path.Combine(
             _serverDirPath,
             "Server",

--- a/test/Tests.Infrastructure/InterversionTestBase.cs
+++ b/test/Tests.Infrastructure/InterversionTestBase.cs
@@ -65,9 +65,9 @@ namespace Tests.Infrastructure
 
             options.ModifyDatabaseRecord?.Invoke(doc);
 
-            var store = new DocumentStore()
+            var store = new DocumentStore
             {
-                Urls = new[] { serverUrl.ToString() },
+                Urls = new[] { serverUrl },
                 Database = name
             };
 
@@ -91,10 +91,10 @@ namespace Tests.Infrastructure
             string serverVersion,
             InterversionTestOptions options = null,
             [CallerMemberName] string database = null,
-            CancellationToken token = default(CancellationToken))
+            CancellationToken token = default)
         {
             var serverBuildInfo = ServerBuildDownloadInfo.Create(serverVersion);
-            var serverPath = await _serverBuildRetriever.GetServerPath(serverBuildInfo);
+            var serverPath = await _serverBuildRetriever.GetServerPath(serverBuildInfo, token);
             var testServerPath = NewDataPath(prefix: serverVersion);
             CopyFilesRecursively(new DirectoryInfo(serverPath), new DirectoryInfo(testServerPath));
 

--- a/test/Tests.Infrastructure/TestBase.cs
+++ b/test/Tests.Infrastructure/TestBase.cs
@@ -316,7 +316,7 @@ namespace FastTests
 
         private readonly object _getNewServerSync = new object();
 
-        protected RavenServer GetNewServer(IDictionary<string, string> customSettings = null, bool deletePrevious = true, bool runInMemory = true, string partialPath = null, string customConfigPath = null)
+        protected virtual RavenServer GetNewServer(IDictionary<string, string> customSettings = null, bool deletePrevious = true, bool runInMemory = true, string partialPath = null, string customConfigPath = null)
         {
             lock (_getNewServerSync)
             {


### PR DESCRIPTION
This is a temporary option so we can proceed with interversion tests till MS fixes the issue