### PR TITLE
[4.1] RavenDB-11734

### DIFF
--- a/src/Raven.Server/Documents/DocumentsStorage.cs
+++ b/src/Raven.Server/Documents/DocumentsStorage.cs
@@ -962,7 +962,7 @@ namespace Raven.Server.Documents
             return TableValueToEtag(1, ref result.Reader);
         }
 
-        public bool HasTombstonesWithDocumentEtagBetween(DocumentsOperationContext context, string collection,
+        public bool HasTombstonesWithEtagBetween(DocumentsOperationContext context, string collection,
             long start,
             long end)
         {
@@ -979,7 +979,7 @@ namespace Raven.Server.Documents
             if (table == null)
                 return false;
 
-            return table.HasEntriesBetween(TombstonesSchema.FixedSizeIndexes[DeletedEtagsSlice], start, end);
+            return table.HasEntriesBetween(TombstonesSchema.FixedSizeIndexes[CollectionEtagsSlice], start, end, inclusive: true);
         }
 
         [MethodImpl(MethodImplOptions.AggressiveInlining)]

--- a/src/Raven.Server/Documents/Indexes/Index.cs
+++ b/src/Raven.Server/Documents/Indexes/Index.cs
@@ -825,7 +825,7 @@ namespace Raven.Server.Documents.Indexes
                         stalenessReasons.Add(message);
                     }
 
-                    var hasTombstones = DocumentDatabase.DocumentsStorage.HasTombstonesWithDocumentEtagBetween(databaseContext,
+                    var hasTombstones = DocumentDatabase.DocumentsStorage.HasTombstonesWithEtagBetween(databaseContext,
                         collection,
                         lastProcessedTombstoneEtag,
                         cutoff.Value);

--- a/src/Raven.Server/Documents/Indexes/StaticIndexHelper.cs
+++ b/src/Raven.Server/Documents/Indexes/StaticIndexHelper.cs
@@ -106,7 +106,7 @@ namespace Raven.Server.Documents.Indexes
                                                  $"but last processed document etag for that collection is '{lastProcessedReferenceEtag:#,#;;0}'.");
                         }
 
-                        var hasTombstones = databaseContext.DocumentDatabase.DocumentsStorage.HasTombstonesWithDocumentEtagBetween(databaseContext, referencedCollection.Name,
+                        var hasTombstones = databaseContext.DocumentDatabase.DocumentsStorage.HasTombstonesWithEtagBetween(databaseContext, referencedCollection.Name,
                             lastProcessedTombstoneEtag,
                             referenceCutoff.Value);
                         if (hasTombstones)

--- a/src/Voron/Data/Tables/Table.cs
+++ b/src/Voron/Data/Tables/Table.cs
@@ -30,7 +30,7 @@ namespace Voron.Data.Tables
 
         public readonly Slice Name;
         private readonly byte _tableType;
-        
+
         public long NumberOfEntries { get; private set; }
 
         private long _overflowPageCount;
@@ -233,7 +233,7 @@ namespace Voron.Data.Tables
                     var tvr = new TableValueReader(oldData, oldDataSize);
                     UpdateValuesFromIndex(id,
                         ref tvr,
-                        builder, 
+                        builder,
                         forceUpdate);
 
                     builder.CopyTo(pos);
@@ -465,7 +465,7 @@ namespace Voron.Data.Tables
 
             if (size + sizeof(RawDataSection.RawDataEntrySizes) < RawDataSection.MaxItemSize)
             {
-                id = AllocateFromSmallActiveSection(builder,size);
+                id = AllocateFromSmallActiveSection(builder, size);
 
                 if (ActiveDataSmallSection.TryWriteDirect(id, size, out pos) == false)
                     throw new VoronErrorException(
@@ -670,7 +670,7 @@ namespace Voron.Data.Tables
 
         public FixedSizeTree GetFixedSizeTree(TableSchema.FixedSizeSchemaIndexDef indexDef)
         {
-            
+
             if (indexDef.IsGlobal)
                 return _tx.GetGlobalFixedSizeTree(indexDef.Name, sizeof(long), isIndexTree: true, newPageAllocator: _globalPageAllocator);
 
@@ -826,7 +826,7 @@ namespace Voron.Data.Tables
                     {
                         it.Seek(long.MaxValue);
                     }
-                    
+
                     var result = new TableValueHolder();
                     while (it.MovePrev())
                     {
@@ -1009,7 +1009,7 @@ namespace Voron.Data.Tables
                 } while (it.MovePrev());
             }
         }
-        
+
         public TableValueHolder SeekOneBackwardFrom(TableSchema.SchemaIndexDef index, Slice prefix, Slice last)
         {
             var tree = GetTree(index);
@@ -1025,7 +1025,7 @@ namespace Voron.Data.Tables
                 if (SliceComparer.StartWith(it.CurrentKey, it.RequiredPrefix) == false)
                 {
                     if (it.MovePrev() == false)
-                    return null;
+                        return null;
                 }
 
                 do
@@ -1142,7 +1142,7 @@ namespace Voron.Data.Tables
                     }
                 }
             }
-            finally 
+            finally
             {
                 value.Release(_tx.Allocator);
             }
@@ -1232,8 +1232,8 @@ namespace Voron.Data.Tables
             {
                 if (it.SeekToLast() == false)
                     yield break;
-                
-                if(it.Skip(-skip) == false)
+
+                if (it.Skip(-skip) == false)
                     yield break;
 
                 var result = new TableValueHolder();
@@ -1264,7 +1264,7 @@ namespace Voron.Data.Tables
             }
         }
 
-        public bool HasEntriesBetween(TableSchema.FixedSizeSchemaIndexDef index, long start, long end)
+        public bool HasEntriesBetween(TableSchema.FixedSizeSchemaIndexDef index, long start, long end, bool inclusive)
         {
             var fst = GetFixedSizeTree(index);
 
@@ -1273,6 +1273,8 @@ namespace Voron.Data.Tables
                 if (it.Seek(start) == false)
                     return false;
 
+                if (inclusive)
+                    return it.CurrentKey <= end;
 
                 return it.CurrentKey < end;
             }
@@ -1552,7 +1554,7 @@ namespace Voron.Data.Tables
                 {
                     if (NumberOfEntries != indexNumberOfEntries)
                         ThrowInconsistentItemsCountInIndexes(fsi.Key.ToString(), NumberOfEntries, indexNumberOfEntries);
-                        
+
                 }
                 else
                 {
@@ -1562,7 +1564,7 @@ namespace Voron.Data.Tables
                         ThrowInconsistentItemsCountInIndexes(fsi.Key.ToString(), NumberOfEntries, indexNumberOfEntries);
                 }
             }
-           
+
             if (_schema.Key == null)
                 return;
 

--- a/test/SlowTests/Issues/RavenDB_11734.cs
+++ b/test/SlowTests/Issues/RavenDB_11734.cs
@@ -1,0 +1,88 @@
+﻿using System.Collections.Generic;
+using System.Linq;
+using System.Threading.Tasks;
+using FastTests;
+using Raven.Client.Documents;
+using Raven.Client.Documents.Indexes;
+using Xunit;
+
+namespace SlowTests.Issues
+{
+    public class RavenDB_11734 : RavenTestBase
+    {
+        private const int USER_COUNT = 500;
+
+        [Fact]
+        public async Task Index_Queries_Should_Not_Return_Deleted_Documents()
+        {
+            using (var store = GetDocumentStore())
+            {
+                await new UserIndex().ExecuteAsync(store);
+
+                var userIds = new List<string>();
+                using (var session = store.OpenAsyncSession())
+                {
+                    for (var i = 0; i < USER_COUNT; i++)
+                    {
+                        var user = new User { Name = "Test User" };
+                        await session.StoreAsync(user);
+                        userIds.Add(user.Id);
+                    }
+
+                    await session.SaveChangesAsync();
+                }
+
+                for (var i = 0; i < USER_COUNT; i++)
+                {
+                    using (var session = store.OpenAsyncSession())
+                    {
+                        session.Delete(userIds[i]);
+                        await session.SaveChangesAsync();
+                    }
+
+                    using (var session = store.OpenAsyncSession())
+                    {
+                        var users = await session.Query<UserIndex.ReduceResult, UserIndex>()
+                            .Statistics(out var stats)
+                            .Customize(x => x.WaitForNonStaleResults())
+                            .OfType<User>()
+                            .Select(x => new { x.Id, x.Name })
+                            .ToListAsync();
+
+                        Assert.NotEqual(-1, stats.DurationInMs);
+                        Assert.Equal(USER_COUNT - i - 1, users.Count);
+                    }
+                }
+            }
+        }
+
+        private class UserIndex : AbstractIndexCreationTask<User, UserIndex.ReduceResult>
+        {
+            public UserIndex()
+            {
+                Map = users => from user in users
+                               select new
+                               {
+                                   Query = new[] { user.Name },
+                                   user.Name,
+                                   user.Id
+                               };
+
+                Index(x => x.Query, FieldIndexing.Search);
+            }
+
+            public class ReduceResult
+            {
+                public string Query { get; set; }
+                public string Name { get; set; }
+                public string Id { get; set; }
+            }
+        }
+
+        private class User
+        {
+            public string Id { get; set; }
+            public string Name { get; set; }
+        }
+    }
+}

--- a/test/Tryouts/Program.cs
+++ b/test/Tryouts/Program.cs
@@ -20,9 +20,9 @@ namespace Tryouts
         {
             try
             {
-                using (var test = new RavenDB_11705())
+                using (var test = new RavenDB_11734())
                 {
-                    await test.CanHandleRevisionOperationBeingRolledBack();
+                    await test.Index_Queries_Should_Not_Return_Deleted_Documents();
                 }
             }
             catch (Exception e)


### PR DESCRIPTION
- renamed HasTombstonesWithDocumentEtagBetween to HasTombstonesWithEtagBetween to avoid confusion because this method should check tombstone etags, not tombstone document etags
- switched HasTombstonesWithEtagBetween from using deleted document etags to deleted tomstone etags
- HasEntriesBetween should check inclusively