### PR TITLE
RavenDB-11746 Failed to properly close RavenServer (Delegate to an in…

### DIFF
--- a/src/Raven.Server/ServerWide/ServerStore.cs
+++ b/src/Raven.Server/ServerWide/ServerStore.cs
@@ -1484,7 +1484,7 @@ namespace Raven.Server.ServerWide
 
                     exceptionAggregator.Execute(_shutdownNotification.Dispose);
 
-                    exceptionAggregator.Execute(_timer.Dispose);
+                    exceptionAggregator.Execute(()=> _timer?.Dispose());
 
                     exceptionAggregator.ThrowIfNeeded();
                 }


### PR DESCRIPTION
…stance method cannot have null 'this'.) when server configuration is broken