### PR TITLE
[4.1] RavenDB-11415 Fix cluster transaction race

### DIFF
--- a/src/Raven.Server/Documents/Handlers/Debugging/TransactionDebugHandler.cs
+++ b/src/Raven.Server/Documents/Handlers/Debugging/TransactionDebugHandler.cs
@@ -47,7 +47,7 @@ namespace Raven.Server.Documents.Handlers.Debugging
             return Task.CompletedTask;
         }
 
-        [RavenAction("/databases/*/admin/debug/clustertxinfo", "GET", AuthorizationStatus.DatabaseAdmin, IsDebugInformationEndpoint = true)]
+        [RavenAction("/databases/*/admin/debug/cluster/txinfo", "GET", AuthorizationStatus.DatabaseAdmin, IsDebugInformationEndpoint = true)]
         public Task ClusterTxInfo()
         {
             var from = GetLongQueryString("from", false);
@@ -57,7 +57,10 @@ namespace Raven.Server.Documents.Handlers.Debugging
             using (context.OpenReadTransaction())
             using (var writer = new BlittableJsonTextWriter(context, ResponseBodyStream()))
             {
-                context.Write(writer, new DynamicJsonArray(ClusterTransactionCommand.ReadCommandsBatch(context, Database.Name, from, take)));
+                context.Write(writer, new DynamicJsonValue
+                {
+                    ["Results"] = new DynamicJsonArray(ClusterTransactionCommand.ReadCommandsBatch(context, Database.Name, from, take))
+                });
             }
 
             return Task.CompletedTask;

--- a/src/Raven.Server/ServerWide/Commands/ClusterTransactionCommand.cs
+++ b/src/Raven.Server/ServerWide/Commands/ClusterTransactionCommand.cs
@@ -271,13 +271,25 @@ namespace Raven.Server.ServerWide.Commands
             }
         }
 
-        public class SingleClusterDatabaseCommand
+        public class SingleClusterDatabaseCommand : IDynamicJson
         {
             public ClusterTransactionOptions Options;
             public BlittableJsonReaderArray Commands;
             public long Index;
             public long PreviousCount;
             public string Database;
+
+            public DynamicJsonValue ToJson()
+            {
+                return new DynamicJsonValue
+                {
+                    [nameof(Database)] = Database,
+                    [nameof(PreviousCount)] = PreviousCount,
+                    [nameof(Index)] = Index,
+                    [nameof(Options)] = Options.ToJson(),
+                    [nameof(Index)] = new DynamicJsonArray(Commands)
+                };
+            }
         }
 
         public static SingleClusterDatabaseCommand ReadSingleCommand(TransactionOperationContext context, string database, long? fromCount)

--- a/src/Raven.Server/ServerWide/Maintenance/ClusterMaintenanceWorker.cs
+++ b/src/Raven.Server/ServerWide/Maintenance/ClusterMaintenanceWorker.cs
@@ -190,6 +190,7 @@ namespace Raven.Server.ServerWide.Maintenance
                         report.NumberOfConflicts = documentsStorage.ConflictsStorage.ConflictsCount;
                         report.NumberOfDocuments = documentsStorage.GetNumberOfDocuments(context);
                         report.DatabaseChangeVector = DocumentsStorage.GetDatabaseChangeVector(context);
+                        report.LastCompletedClusterTransaction = dbInstance.LastCompletedClusterTransaction;
                         report.UpTime = now - dbInstance.StartTime;
 
                         foreach (var outgoing in dbInstance.ReplicationLoader.OutgoingHandlers)

--- a/src/Raven.Server/ServerWide/Maintenance/ClusterNodeStatusReport.cs
+++ b/src/Raven.Server/ServerWide/Maintenance/ClusterNodeStatusReport.cs
@@ -39,6 +39,7 @@ namespace Raven.Server.ServerWide.Maintenance
         public long LastTombstoneEtag;
         public long NumberOfConflicts;
         public long NumberOfDocuments;
+        public long LastCompletedClusterTransaction;
 
         public DatabaseStatus Status;
         public string Error;
@@ -56,6 +57,7 @@ namespace Raven.Server.ServerWide.Maintenance
                 [nameof(NumberOfConflicts)] = NumberOfConflicts,
                 [nameof(NumberOfDocuments)] = NumberOfDocuments,
                 [nameof(DatabaseChangeVector)] = DatabaseChangeVector,
+                [nameof(LastCompletedClusterTransaction)] = LastCompletedClusterTransaction,
                 [nameof(LastSentEtag)] = DynamicJsonValue.Convert(LastSentEtag),
                 [nameof(Error)] = Error,
                 [nameof(UpTime)] = UpTime

--- a/src/Raven.Server/ServerWide/Maintenance/ClusterObserver.cs
+++ b/src/Raven.Server/ServerWide/Maintenance/ClusterObserver.cs
@@ -360,8 +360,7 @@ namespace Raven.Server.ServerWide.Maintenance
                 if (nodeReport.Report.TryGetValue(database, out var report) == false)
                     return null;
 
-                var last = ChangeVectorUtils.GetEtagById(report.DatabaseChangeVector, record.Topology.DatabaseTopologyIdBase64);
-                commandCount = Math.Min(commandCount, last);
+                commandCount = Math.Min(commandCount, report.LastCompletedClusterTransaction);
             }
 
             if (commandCount <= record.TruncatedClusterTransactionCommandsCount)


### PR DESCRIPTION
Fixing the following Race:
1. Request for clsuter tx on node A
2. Execute the transaction first on node B
3. Replicate the documents back to node A
4. The cluster observer issue a clean up command for this transaction, since it resides already on nodes A & B
5. Node A lost that cluster id before the execution and can't notify that it was completed.