### PR TITLE
[4.1] RavenDB-7070 better culture support

### DIFF
--- a/src/Raven.Client/Util/JavascriptConversionExtensions.cs
+++ b/src/Raven.Client/Util/JavascriptConversionExtensions.cs
@@ -1455,7 +1455,7 @@ namespace Raven.Client.Util
                     // if we have a number, write the value without quatation
                     if (_numericTypes.Contains(valueType) || _numericTypes.Contains(Nullable.GetUnderlyingType(valueType)))
                     {
-                        writer.Write(value);
+                        writer.Write(value.ToInvariantString());
                     }
                     else
                     {
@@ -1466,7 +1466,7 @@ namespace Raven.Client.Util
                 }
             }
 
-            private static HashSet<Type> _numericTypes = new HashSet<Type>
+            private static readonly HashSet<Type> _numericTypes = new HashSet<Type>
             {
                 typeof(Byte),
                 typeof(SByte),

--- a/src/Raven.Server/Documents/PeriodicBackup/Aws/RavenAwsClient.cs
+++ b/src/Raven.Server/Documents/PeriodicBackup/Aws/RavenAwsClient.cs
@@ -6,6 +6,7 @@
 
 using System;
 using System.Collections.Generic;
+using System.Globalization;
 using System.Linq;
 using System.Net.Http;
 using System.Net.Http.Headers;
@@ -51,13 +52,13 @@ namespace Raven.Server.Documents.PeriodicBackup.Aws
             using (var hash = new HMACSHA256(signingKey))
             {
                 var regionForRequest = IsRegionInvariantRequest ? DefaultRegion : AwsRegion;
-                var scope = $"{date:yyyyMMdd}/{regionForRequest}/{ServiceName}/aws4_request";
+                var scope = $"{date.ToString("yyyyMMdd", CultureInfo.InvariantCulture)}/{regionForRequest}/{ServiceName}/aws4_request";
                 var stringToHash = $"AWS4-HMAC-SHA256\n{RavenAwsHelper.ConvertToString(date)}\n{scope}\n{canonicalRequestHash}";
 
                 var hashedString = hash.ComputeHash(Encoding.UTF8.GetBytes(stringToHash));
                 var signature = RavenAwsHelper.ConvertToHex(hashedString);
 
-                var credentials = $"{_awsAccessKey}/{date:yyyyMMdd}/{regionForRequest}/{ServiceName}/aws4_request";
+                var credentials = $"{_awsAccessKey}/{date.ToString("yyyyMMdd", CultureInfo.InvariantCulture)}/{regionForRequest}/{ServiceName}/aws4_request";
 
                 return new AuthenticationHeaderValue("AWS4-HMAC-SHA256", $"Credential={credentials},SignedHeaders={signedHeaders},Signature={signature}");
             }
@@ -120,7 +121,7 @@ namespace Raven.Server.Documents.PeriodicBackup.Aws
         {
             byte[] key;
             using (var hash = new HMACSHA256(_awsSecretKey))
-                key = hash.ComputeHash(Encoding.UTF8.GetBytes(date.ToString("yyyyMMdd")));
+                key = hash.ComputeHash(Encoding.UTF8.GetBytes(date.ToString("yyyyMMdd", CultureInfo.InvariantCulture)));
 
             var regionForRequest = IsRegionInvariantRequest ? DefaultRegion : AwsRegion;
             using (var hash = new HMACSHA256(key))

--- a/src/Raven.Server/Documents/PeriodicBackup/Aws/RavenAwsHelper.cs
+++ b/src/Raven.Server/Documents/PeriodicBackup/Aws/RavenAwsHelper.cs
@@ -5,6 +5,7 @@
 // -----------------------------------------------------------------------
 
 using System;
+using System.Globalization;
 using System.IO;
 using System.Security.Cryptography;
 using System.Text;
@@ -17,7 +18,7 @@ namespace Raven.Server.Documents.PeriodicBackup.Aws
 
         public static string ConvertToString(DateTime date)
         {
-            return date.ToString("yyyyMMddTHHmmssZ");
+            return date.ToString("yyyyMMddTHHmmssZ", CultureInfo.InvariantCulture);
         }
 
         public static string ConvertToHex(byte[] array)

--- a/test/SlowTests/Core/AdminConsole/AdminJsConsoleTests.cs
+++ b/test/SlowTests/Core/AdminConsole/AdminJsConsoleTests.cs
@@ -13,6 +13,11 @@ namespace SlowTests.Core.AdminConsole
 {
     public class AdminJsConsoleTests : RavenTestBase
     {
+        public AdminJsConsoleTests()
+        {
+            DoNotReuseServer();
+        }
+
         [Fact]
         public async Task CanGetSettings()
         {

--- a/test/SlowTests/MailingList/DayOfWeekTest.cs
+++ b/test/SlowTests/MailingList/DayOfWeekTest.cs
@@ -5,6 +5,7 @@
 // -----------------------------------------------------------------------
 
 using System;
+using System.Globalization;
 using System.Linq;
 using System.Threading.Tasks;
 using FastTests;
@@ -19,7 +20,7 @@ namespace SlowTests.MailingList
         {
             using (var store = GetDocumentStore())
             {
-                var knownDay = DateTime.Parse("2014-03-31").Date; // This is a Monday
+                var knownDay = DateTime.Parse("2014-03-31", CultureInfo.InvariantCulture).Date; // This is a Monday
                 using (var session = store.OpenSession())
                 {
                     var monday = new SampleData { Date = knownDay };

--- a/test/SlowTests/Tests/Linq/WhereClause.cs
+++ b/test/SlowTests/Tests/Linq/WhereClause.cs
@@ -5,6 +5,7 @@
 //-----------------------------------------------------------------------
 
 using System;
+using System.Globalization;
 using System.Linq;
 using FastTests;
 using Newtonsoft.Json;
@@ -1027,7 +1028,7 @@ namespace SlowTests.Tests.Linq
                 {
                     var indexedUsers = GetRavenQueryInspector(session);
                     var q = from user in indexedUsers
-                            where user.Birthday >= DateTime.Parse("2010-05-15")
+                            where user.Birthday >= DateTime.Parse("2010-05-15", CultureInfo.InvariantCulture)
                             select new { user.Name, user.Age };
 
                     var iq = RavenTestHelper.GetIndexQuery(q);


### PR DESCRIPTION
- SubscriptionsWrappedConstantSupport should not be culture specific (fixes SubscriptionTypedCreationOptionsShouldSupportConstantValuesWithIndirectPath)
- AdminJsConsoleTests should not modify global server
- fixed various culture tests