### PR TITLE
[4.1] RavenDB-11614

### DIFF
--- a/test/InterversionTests/MixedClusterTestBase.cs
+++ b/test/InterversionTests/MixedClusterTestBase.cs
@@ -24,6 +24,17 @@ namespace InterversionTests
             public string Url;
         }
 
+        protected override RavenServer GetNewServer(IDictionary<string, string> customSettings = null, bool deletePrevious = true, bool runInMemory = true, string partialPath = null,
+            string customConfigPath = null)
+        {
+            if (customSettings == null)
+                customSettings = new Dictionary<string, string>();
+            var key = RavenConfiguration.GetKey(x => x.Http.UseLibuv);
+            if (customSettings.ContainsKey(key) == false)
+                customSettings[key] = "true";
+            return base.GetNewServer(customSettings, deletePrevious, runInMemory, partialPath, customConfigPath);
+        }
+
         protected async Task<(RavenServer Leader, List<ProcessNode> Peers, List<RavenServer> LocalPeers)> CreateMixedCluster(
             string[] peers, int localPeers = 0, IDictionary<string, string> customSettings = null)
         {


### PR DESCRIPTION
- use 4.0.7-nightly instead of 4.0.6 (4.0.6 does not support UseLibuv config)
- minor changes in ClientFailover and SubscriptionFailover tests
- add DistributedRevisionsSubscription test