### PR TITLE
RavenDB-11797 Moving Streaming logic into a single thread to avoid "E…

### DIFF
--- a/Raven.Abstractions/Extensions/TaskExtensions.cs
+++ b/Raven.Abstractions/Extensions/TaskExtensions.cs
@@ -1,5 +1,6 @@
 using System;
 using System.Net;
+using System.Runtime.CompilerServices;
 using System.Security;
 using System.Threading;
 using System.Threading.Tasks;
@@ -92,6 +93,18 @@ namespace Raven.Abstractions.Extensions
             if (task == await Task.WhenAny(task, Task.Delay(timeout.Value)).ConfigureAwait(false))
                 return true;
             return false;
+        }
+
+        public static async Task<T> WaitWithTimeout<T>(this Task<T> task, TimeSpan? timeout, [CallerMemberName]string caller = null)
+        {
+            if (timeout == null)
+            {
+                return await task.ConfigureAwait(false);
+            }
+
+            if (task == await Task.WhenAny(task, Task.Delay(timeout.Value)).ConfigureAwait(false))
+                return await task.ConfigureAwait(false);
+            throw new TimeoutException("Failed to wait for task: " + caller);
         }
     }
 }

--- a/Raven.Database/Server/Controllers/StreamsController.cs
+++ b/Raven.Database/Server/Controllers/StreamsController.cs
@@ -365,8 +365,11 @@ namespace Raven.Database.Server.Controllers
 
             private void ActuallyStreamResults(InitParameters parameters)
             {
-                using (var accessor = parameters.Database.TransactionalStorage.CreateAccessor())
+                IStorageActionsAccessor accessor = null;
+                try
                 {
+
+                    accessor = parameters.Database.TransactionalStorage.CreateAccessor();
                     QueryOp = new QueryActions.DatabaseQueryOperation(parameters.Database, parameters.IndexName, parameters.Query, accessor, parameters.Cts);
                     QueryOp.Init();
                     _headerReady.TrySetResult(QueryOp.Header);
@@ -376,6 +379,14 @@ namespace Raven.Database.Server.Controllers
                     }
 
                     SerializeToStream(_streamReady.Task.Result, QueryOp.Header.TotalResults);
+                } 
+                catch( Exception e)
+                {
+                    _headerReady.TrySetException(e);
+                }
+                finally
+                {
+                    accessor?.Dispose();
                 }
             }
 


### PR DESCRIPTION
…sent transaction been accessed from multiple threads" errors.