### PR TITLE
RavenDB-11409 Fixing race condition between allocating a context by s…

### DIFF
--- a/src/Sparrow/Json/JsonContextPoolBase.cs
+++ b/src/Sparrow/Json/JsonContextPoolBase.cs
@@ -94,9 +94,16 @@ namespace Sparrow.Json
                 return; // the context pool was already disposed
             }
 
-            while(current != null)
+            while (current != null)
             {
-                current.Value?.Dispose();
+                var value = current.Value;
+
+                if (value != null)
+                {
+                    if (value.InUse.Raise()) // it could be stolen by another thread - RavenDB-11409
+                        value.Dispose();
+                }
+
                 current = current.Next;
             }
         }


### PR DESCRIPTION
…tealing it from another thread and disposing the pool on thread local cleanup. Marking a context instance as in-use before disposing it.