### PR TITLE
RavenDB-11170 Fix ResolveInFavorOfLocalClusterTransaction

### DIFF
--- a/src/Raven.Server/Documents/Replication/IncomingReplicationHandler.cs
+++ b/src/Raven.Server/Documents/Replication/IncomingReplicationHandler.cs
@@ -1065,16 +1065,15 @@ namespace Raven.Server.Documents.Replication
 
                     var maxReceivedChangeVectorByDatabase = currentDatabaseChangeVector;
 
-                    var groupId = _incoming._parent.Database.DatabaseGroupId;
                     foreach (var item in _incoming._replicatedItems)
                     {
                         context.TransactionMarkerOffset = item.TransactionMarker;
                         ++operationsCount;
-                        using (var rcvdChangeVector = context.GetLazyString(item.ChangeVector))
                         using (item)
                         {
                             Debug.Assert(item.Flags.Contain(DocumentFlags.Artificial) == false);
 
+                            var rcvdChangeVector = item.ChangeVector;
                             maxReceivedChangeVectorByDatabase =
                                 ChangeVectorUtils.MergeVectors(item.ChangeVector, maxReceivedChangeVectorByDatabase);
 
@@ -1218,10 +1217,12 @@ namespace Raven.Server.Documents.Replication
                                                 flags = item.Flags.Strip(DocumentFlags.FromClusterTransaction);
                                                 if (local.Document != null)
                                                 {
+                                                    rcvdChangeVector = ChangeVectorUtils.MergeVectors(rcvdChangeVector, local.Document.ChangeVector);
                                                     resolvedDocument = local.Document.Data.Clone(context);
                                                 }
                                                 else if (local.Tombstone != null)
                                                 {
+                                                    rcvdChangeVector = ChangeVectorUtils.MergeVectors(rcvdChangeVector, local.Tombstone.ChangeVector);
                                                     resolvedDocument = null;
                                                 }
                                                 else

--- a/test/SlowTests/Cluster/ClusterTransactionTests.cs
+++ b/test/SlowTests/Cluster/ClusterTransactionTests.cs
@@ -15,6 +15,7 @@ using Raven.Client.Documents.Smuggler;
 using Raven.Client.Exceptions;
 using Raven.Client.ServerWide;
 using Raven.Server.Config;
+using Raven.Server.Documents.Replication;
 using Raven.Server.ServerWide.Commands;
 using Raven.Server.ServerWide.Context;
 using Raven.Tests.Core.Utils.Entities;
@@ -321,11 +322,11 @@ namespace SlowTests.Cluster
         {
             var user1 = new User()
             {
-                Name = "Karmel"
+                Name = "Source"
             };
             var user2 = new User()
             {
-                Name = "Indych"
+                Name = "Dest"
             };
             using (var store1 = GetDocumentStore())
             using (var store2 = GetDocumentStore())
@@ -348,7 +349,22 @@ namespace SlowTests.Cluster
                 await SetupReplicationAsync(store1, store2);
 
                 // 1. at first we will resolve to the local, since both are form cluster transaction
-                Assert.True(WaitForDocument<User>(store2, "users/1", (u) => u.Name == "Indych"));
+                var resolvedToLocal = await WaitForValueAsync(async () =>
+                {
+                    using (var session = store2.OpenAsyncSession())
+                    {
+                        var user = await session.LoadAsync<User>("users/1");
+                        if (user == null)
+                            return false;
+
+                        if (user.Name != "Dest")
+                            return false;
+                        var changeVector = session.Advanced.GetChangeVectorFor(user);
+                        var entries = changeVector.ToChangeVector();
+                        return entries.Length == 2;
+                    }
+                }, true);
+                Assert.True(resolvedToLocal);
 
                 // 2. after the resolution the document is stripped from the cluster transaction flag
                 using (var session = store1.OpenAsyncSession(new SessionOptions
@@ -356,12 +372,13 @@ namespace SlowTests.Cluster
                     TransactionMode = TransactionMode.ClusterWide
                 }))
                 {
+                    user1.Name = "Source 2";
                     await session.StoreAsync(user1, "users/1");
                     await session.SaveChangesAsync();
                 }
 
                 // 3. so in the next conflict we will be overwriting it.
-                Assert.True(WaitForDocument<User>(store2, "users/1", (u) => u.Name == "Karmel"));
+                Assert.True(WaitForDocument<User>(store2, "users/1", (u) => u.Name == "Source 2"));
             }
         }
 


### PR DESCRIPTION
We didn't really wait for the destination to resolved the conflict.