### PR TITLE
RavenDB-11816 - Replace legacy properties when migrating indexes from a v3.x dump

### DIFF
--- a/src/Raven.Server/Smuggler/Documents/Processors/IndexProcessor.cs
+++ b/src/Raven.Server/Smuggler/Documents/Processors/IndexProcessor.cs
@@ -236,7 +236,7 @@ namespace Raven.Server.Smuggler.Documents.Processors
             if (string.IsNullOrWhiteSpace(str))
                 return str;
 
-            str = str.Replace("new Raven.Abstractions.Linq.DynamicList", string.Empty);
+            str = str.Replace("new Raven.Abstractions.Linq.DynamicList", "DynamicArray");
             var regex = new Regex(@"([\w_.]+)\.__document_id");
             return regex.Replace(str, "Id($1)");
         }

--- a/src/Raven.Server/Smuggler/Documents/Processors/IndexProcessor.cs
+++ b/src/Raven.Server/Smuggler/Documents/Processors/IndexProcessor.cs
@@ -236,7 +236,7 @@ namespace Raven.Server.Smuggler.Documents.Processors
             if (string.IsNullOrWhiteSpace(str))
                 return str;
 
-            str = str.Replace("new Raven.Abstractions.Linq.DynamicList", "DynamicArray");
+            str = str.Replace("new Raven.Abstractions.Linq.DynamicList", "new DynamicArray");
             var regex = new Regex(@"([\w_.]+)\.__document_id");
             return regex.Replace(str, "Id($1)");
         }


### PR DESCRIPTION
http://issues.hibernatingrhinos.com/issue/RavenDB-11816