### PR TITLE
RavenDB-11196 if we are modifying original document inside a patch, we need to refresh it

### DIFF
--- a/src/Raven.Server/Documents/Patch/PatchDocumentCommand.cs
+++ b/src/Raven.Server/Documents/Patch/PatchDocumentCommand.cs
@@ -59,7 +59,7 @@ namespace Raven.Server.Documents.Patch
             _isTest = isTest;
             _debugMode = debugMode;
 
-            if(string.IsNullOrEmpty(id) || id.EndsWith('/') || id.EndsWith('|'))
+            if (string.IsNullOrEmpty(id) || id.EndsWith('/') || id.EndsWith('|'))
             {
                 throw new ArgumentException("The id argument has invalid value: '" + id + "'", "id");
             }
@@ -131,12 +131,7 @@ namespace Raven.Server.Documents.Patch
             }
             else
             {
-                var translated = (BlittableObjectInstance)((JsValue)_run.Translate(context, originalDocument)).AsObject();
-                // here we need to use the _cloned_ version of the document, since the patch may
-                // change it
-                originalDoc = translated.Blittable;
-                originalDocument.Data = null; // prevent access to this by accident
-                documentInstance = translated;
+                documentInstance = UpdateOriginalDocument();
             }
 
             // we will to access this value, and the original document data may be changed by
@@ -164,16 +159,7 @@ namespace Raven.Server.Documents.Patch
                 if (_run.RefreshOriginalDocument)
                 {
                     originalDocument = _database.DocumentsStorage.Get(context, _id);
-                    originalDoc = null;
-
-                    if (originalDocument != null)
-                    {
-                        var translated = (BlittableObjectInstance)((JsValue)_run.Translate(context, originalDocument)).AsObject();
-                        // here we need to use the _cloned_ version of the document, since the patch may
-                        // change it
-                        originalDoc = translated.Blittable;
-                        originalDocument.Data = null; // prevent access to this by accident
-                    }
+                    documentInstance = UpdateOriginalDocument();
                 }
 
                 DocumentsStorage.PutOperationResults? putResult = null;
@@ -204,6 +190,24 @@ namespace Raven.Server.Documents.Patch
 
                 PatchResult = result;
                 return 1;
+            }
+
+            BlittableObjectInstance UpdateOriginalDocument()
+            {
+                originalDoc = null;
+
+                if (originalDocument != null)
+                {
+                    var translated = (BlittableObjectInstance)((JsValue)_run.Translate(context, originalDocument)).AsObject();
+                    // here we need to use the _cloned_ version of the document, since the patch may
+                    // change it
+                    originalDoc = translated.Blittable;
+                    originalDocument.Data = null; // prevent access to this by accident
+
+                    return translated;
+                }
+
+                return null;
             }
         }
 

--- a/test/SlowTests/Issues/RavenDB_10505.cs
+++ b/test/SlowTests/Issues/RavenDB_10505.cs
@@ -1,11 +1,8 @@
 ﻿using System;
-using System.Collections.Generic;
 using System.Linq;
 using FastTests;
-using Raven.Client.Documents.Commands.Batches;
 using Raven.Client.Documents.Operations;
 using Raven.Client.Documents.Operations.Indexes;
-using Raven.Client.Documents.Session;
 using Raven.Tests.Core.Utils.Entities;
 using Xunit;
 


### PR DESCRIPTION
fixes: `SlowTests.Issues.RavenDB_10505.ChangingCollectionNameByPutAndDeleteShouldNotDeleteTheOriginalTheTombstone`
