### PR TITLE
RavenDB-11196 if we are modifying original document inside a patch, we need to refresh it

### DIFF
--- a/src/Raven.Server/Documents/Patch/PatchDocumentCommand.cs
+++ b/src/Raven.Server/Documents/Patch/PatchDocumentCommand.cs
@@ -146,7 +146,7 @@ namespace Raven.Server.Documents.Patch
             // we will to acccess this value, and the original document data may be changed by
             // the actions of the script, so we translate (which will create a clone) then use
             // that clone later
-            using (var scriptResult = _run.Run(context, context, "execute", new[] { documentInstance, args }))
+            using (var scriptResult = _run.Run(context, context, "execute", _id, new[] { documentInstance, args }))
             {
                 var modifiedDocument = scriptResult.TranslateToObject(_externalContext ?? context, usageMode: BlittableJsonDocumentBuilder.UsageMode.ToDisk);
 
@@ -163,6 +163,21 @@ namespace Raven.Server.Documents.Patch
                     PatchResult = result;
 
                     return 1;
+                }
+
+                if (_run.RefreshOriginalDocument)
+                {
+                    originalDocument = _database.DocumentsStorage.Get(context, _id);
+                    originalDoc = null;
+
+                    if (originalDocument != null)
+                    {
+                        var translated = (BlittableObjectInstance)((JsValue)_run.Translate(context, originalDocument)).AsObject();
+                        // here we need to use the _cloned_ version of the document, since the patch may
+                        // change it
+                        originalDoc = translated.Blittable;
+                        originalDocument.Data = null; // prevent access to this by accident
+                    }
                 }
 
                 if (_run.UpdatedDocumentCounterIds != null)

--- a/src/Raven.Server/Documents/Patch/ScriptRunner.cs
+++ b/src/Raven.Server/Documents/Patch/ScriptRunner.cs
@@ -54,7 +54,7 @@ namespace Raven.Server.Documents.Patch
             _creationTime = DateTime.UtcNow;
         }
 
-        public DynamicJsonValue GetDebugInfo(bool detailed=false)
+        public DynamicJsonValue GetDebugInfo(bool detailed = false)
         {
             var djv = new DynamicJsonValue
             {
@@ -62,10 +62,10 @@ namespace Raven.Server.Documents.Patch
                 ["CreationTime"] = _creationTime,
                 ["LastRun"] = _lastRun,
                 ["Runs"] = Runs,
-                ["CachedScriptsCount"] = _cache.Count                
+                ["CachedScriptsCount"] = _cache.Count
             };
             if (detailed)
-                djv["ScriptsSource"] = ScriptsSource;                
+                djv["ScriptsSource"] = ScriptsSource;
 
             return djv;
         }
@@ -117,6 +117,8 @@ namespace Raven.Server.Documents.Patch
             public HashSet<string> Includes;
             private HashSet<string> _documentIds;
             public bool ReadOnly;
+            public string OriginalDocumentId;
+            public bool RefreshOriginalDocument;
             private readonly ConcurrentLruRegexCache _regexCache = new ConcurrentLruRegexCache(1024);
             public HashSet<string> UpdatedDocumentCounterIds;
 
@@ -141,7 +143,7 @@ namespace Raven.Server.Documents.Patch
                 });
                 ScriptEngine.SetValue("output", new ClrFunctionInstance(ScriptEngine, OutputDebug));
                 ObjectInstance consoleObject = new ObjectInstance(ScriptEngine);
-                consoleObject.FastAddProperty("log", new ClrFunctionInstance(ScriptEngine, OutputDebug),false,false,false);
+                consoleObject.FastAddProperty("log", new ClrFunctionInstance(ScriptEngine, OutputDebug), false, false, false);
                 ScriptEngine.SetValue("console", consoleObject);
                 ScriptEngine.SetValue("include", new ClrFunctionInstance(ScriptEngine, IncludeDoc));
                 ScriptEngine.SetValue("load", new ClrFunctionInstance(ScriptEngine, LoadDocument));
@@ -424,9 +426,9 @@ namespace Raven.Server.Documents.Patch
                     reader = JsBlittableBridge.Translate(_jsonCtx, ScriptEngine, args[1].AsObject(), usageMode: BlittableJsonDocumentBuilder.UsageMode.ToDisk);
 
                     var put = _database.DocumentsStorage.Put(
-                        _docsCtx, 
-                        id, 
-                        _docsCtx.GetLazyString(changeVector), 
+                        _docsCtx,
+                        id,
+                        _docsCtx.GetLazyString(changeVector),
                         reader,
                         //RavenDB-11391 Those flags were added to cause attachment/counter metadata table check & remove metadata properties if not necessary
                         nonPersistentFlags: NonPersistentDocumentFlags.ResolveAttachmentsConflict | NonPersistentDocumentFlags.ResolveCountersConflict
@@ -440,6 +442,9 @@ namespace Raven.Server.Documents.Patch
                             ["Data"] = reader
                         });
                     }
+
+                    if (RefreshOriginalDocument == false && string.Equals(put.Id, OriginalDocumentId, StringComparison.OrdinalIgnoreCase))
+                        RefreshOriginalDocument = true;
 
                     return put.Id;
                 }
@@ -475,6 +480,10 @@ namespace Raven.Server.Documents.Patch
                 if (DebugMode)
                     DebugActions.DeleteDocument.Add(id);
                 var result = _database.DocumentsStorage.Delete(_docsCtx, id, changeVector);
+
+                if (RefreshOriginalDocument == false && string.Equals(OriginalDocumentId, id, StringComparison.OrdinalIgnoreCase))
+                    RefreshOriginalDocument = true;
+
                 return result != null;
             }
 
@@ -894,8 +903,8 @@ namespace Raven.Server.Documents.Patch
                 if (args[0].IsDate())
                 {
                     var date = args[0].AsDate().ToDateTime();
-                    return format != null ? 
-                        date.ToString(format, cultureInfo) : 
+                    return format != null ?
+                        date.ToString(format, cultureInfo) :
                         date.ToString(cultureInfo);
 
                 }
@@ -1052,9 +1061,17 @@ namespace Raven.Server.Documents.Patch
 
             public ScriptRunnerResult Run(JsonOperationContext jsonCtx, DocumentsOperationContext docCtx, string method, object[] args)
             {
+                return Run(jsonCtx, docCtx, method, null, args);
+            }
+
+            public ScriptRunnerResult Run(JsonOperationContext jsonCtx, DocumentsOperationContext docCtx, string method, string documentId, object[] args)
+            {
                 _docsCtx = docCtx;
                 _jsonCtx = jsonCtx ?? ThrowArgumentNull();
+
                 Reset();
+                OriginalDocumentId = documentId;
+
                 if (_args.Length != args.Length)
                     _args = new JsValue[args.Length];
                 for (var i = 0; i < args.Length; i++)
@@ -1109,6 +1126,8 @@ namespace Raven.Server.Documents.Patch
                 }
                 Includes?.Clear();
                 PutOrDeleteCalled = false;
+                OriginalDocumentId = null;
+                RefreshOriginalDocument = false;
                 ScriptEngine.ResetCallStack();
                 ScriptEngine.ResetStatementsCount();
                 ScriptEngine.ResetTimeoutTicks();

--- a/test/SlowTests/Issues/RavenDB_10505.cs
+++ b/test/SlowTests/Issues/RavenDB_10505.cs
@@ -1,11 +1,8 @@
 ﻿using System;
-using System.Collections.Generic;
 using System.Linq;
 using FastTests;
-using Raven.Client.Documents.Commands.Batches;
 using Raven.Client.Documents.Operations;
 using Raven.Client.Documents.Operations.Indexes;
-using Raven.Client.Documents.Session;
 using Raven.Tests.Core.Utils.Entities;
 using Xunit;
 


### PR DESCRIPTION
fixes: `SlowTests.Issues.RavenDB_10505.ChangingCollectionNameByPutAndDeleteShouldNotDeleteTheOriginalTheTombstone`