### PR TITLE
RavenDB-11747 => make sure ByteStringMemoryCache properly uses NativeMemoryCleaner

### DIFF
--- a/src/Raven.Server/Extensions/MemoryExtensions.cs
+++ b/src/Raven.Server/Extensions/MemoryExtensions.cs
@@ -116,7 +116,7 @@ namespace Raven.Server.Extensions
                 var result = SetProcessWorkingSetSizeEx(process.Handle, -1, -1, flags);
                 if (result == false)
                 {
-                    logger.Info($"Failed to empty working set, error code: {Marshal.GetLastWin32Error()}");
+                    logger?.Info($"Failed to empty working set, error code: {Marshal.GetLastWin32Error()}");
                 }
             }
         }

--- a/src/Raven.Server/Rachis/RachisConsensus.cs
+++ b/src/Raven.Server/Rachis/RachisConsensus.cs
@@ -1616,7 +1616,7 @@ namespace Raven.Server.Rachis
         public virtual void Dispose()
         {
             _disposeEvent.Set();
-            Timeout.Dispose();
+            Timeout?.Dispose(); //prevent NRE if an exception is thrown in Initialize()
             OnDispose?.Invoke(this, EventArgs.Empty);
             _topologyChanged.TrySetCanceled();
             _stateChanged.TrySetCanceled();

--- a/src/Raven.Server/ServerWide/ServerStore.cs
+++ b/src/Raven.Server/ServerWide/ServerStore.cs
@@ -364,6 +364,8 @@ namespace Raven.Server.ServerWide
             await _engine.RemoveFromClusterAsync(nodeTag).WithCancellation(_shutdownNotification.Token);
         }
 
+        public LowMemoryNotification LowMemoryNotification => LowMemoryNotification.Instance;
+
         public void Initialize()
         {
             Configuration.CheckDirectoryPermissions();

--- a/src/Raven.Server/Utils/PoolOfThreads.cs
+++ b/src/Raven.Server/Utils/PoolOfThreads.cs
@@ -30,6 +30,9 @@ namespace Raven.Server.Utils
         });
 
         public static PoolOfThreads GlobalRavenThreadPool => _globalRavenThreadPool.Value;
+
+        public ConcurrentQueue<PooledThread> Pool => _pool;
+
         private static Logger _log = LoggingSource.Instance.GetLogger<PoolOfThreads>("Server");
         private float _minimumFreeCommittedMemory = 0.05f;
 
@@ -101,7 +104,7 @@ namespace Raven.Server.Utils
             return pooled.SetWorkForThread(action, state, name);
         }
 
-        internal class PooledThread
+        public class PooledThread
         {
             private static readonly FieldInfo RuntimeThreadField;
             private static readonly FieldInfo ThreadFieldName;
@@ -117,6 +120,10 @@ namespace Raven.Server.Utils
             private Process _currentProcess;
 
             public DateTime StartedAt { get; internal set; }
+
+            public ulong CurrentUnmangedThreadId => _currentUnmangedThreadId;
+
+            public string Name => _name;
 
             static PooledThread()
             {

--- a/src/Sparrow/LowMemory/LowMemoryNotification.cs
+++ b/src/Sparrow/LowMemory/LowMemoryNotification.cs
@@ -42,6 +42,8 @@ namespace Sparrow.LowMemory
             public long LowMemThreshold { get; set; }
         }
 
+        public event Action LowMemoryEvent;
+
         public LowMemEventDetails[] LowMemEventDetailsStack = new LowMemEventDetails[256];
         private int _lowMemEventDetailsIndex;
         private int _clearInactiveHandlersCounter;
@@ -92,6 +94,7 @@ namespace Sparrow.LowMemory
             finally
             {
                 _inactiveHandlers.Clear();
+                OnLowMemoryEvent();
             }
         }
 
@@ -383,6 +386,11 @@ namespace Sparrow.LowMemory
         public void SimulateLowMemoryNotification()
         {
             _simulatedLowMemory.Set();
+        }
+
+        protected void OnLowMemoryEvent()
+        {
+            LowMemoryEvent?.Invoke();
         }
     }
 }

--- a/src/Sparrow/Utils/NativeMemory.cs
+++ b/src/Sparrow/Utils/NativeMemory.cs
@@ -3,6 +3,7 @@ using System.Collections.Concurrent;
 using System.Collections.Generic;
 using System.ComponentModel;
 using System.Diagnostics;
+using System.IO;
 using System.Linq;
 using System.Runtime.CompilerServices;
 using System.Runtime.InteropServices;
@@ -23,7 +24,7 @@ namespace Sparrow.Utils
 
         public static void NotifyCurrentThreadAboutToClose()
         {
-            ThreadAllocations.Value = null;
+            ThreadAllocations.Value = null;            
         }
 
         public static ThreadStats CurrentThreadStats => ThreadAllocations.Value;

--- a/test/RachisTests/TopologyChangesTests.cs
+++ b/test/RachisTests/TopologyChangesTests.cs
@@ -114,18 +114,23 @@ namespace RachisTests
 
             var oldTag = follower.Tag;
             var url = follower.Url;
-            Assert.True(await leader.RemoveFromClusterAsync(oldTag).WaitAsync(TimeSpan.FromMilliseconds(leader.ElectionTimeout.TotalMilliseconds * 10)), "Was unable to remove node from cluster in time");
+            Assert.True(await leader.RemoveFromClusterAsync(oldTag).WaitAsync(TimeSpan.FromMilliseconds(leader.ElectionTimeout.TotalMilliseconds * 10)),
+                "Was unable to remove node from cluster in time");
             foreach (var node in RachisConsensuses)
             {
                 if (node.Url == url)
                     continue;
-                Assert.True(await node.WaitForTopology(Leader.TopologyModification.Remove, follower.Tag).WaitAsync(TimeSpan.FromMilliseconds(node.ElectionTimeout.TotalMilliseconds * 10)), "Node was not removed from topology in time");
+                Assert.True(
+                    await node.WaitForTopology(Leader.TopologyModification.Remove, follower.Tag)
+                        .WaitAsync(TimeSpan.FromMilliseconds(node.ElectionTimeout.TotalMilliseconds * 10)), "Node was not removed from topology in time");
             }
 
             follower.Url = url;
-            var isAddedSuccessfully = await leader.AddToClusterAsync(follower.Url, follower.Tag).WaitAsync(TimeSpan.FromMilliseconds(leader.ElectionTimeout.TotalMilliseconds * 5));
+            var isAddedSuccessfully = await leader.AddToClusterAsync(follower.Url, follower.Tag)
+                .WaitAsync(TimeSpan.FromMilliseconds(leader.ElectionTimeout.TotalMilliseconds * 5));
             Assert.True(isAddedSuccessfully);
-            var waitForTopologySuccessful = await follower.WaitForTopology(Leader.TopologyModification.Voter).WaitAsync(TimeSpan.FromMilliseconds(leader.ElectionTimeout.TotalMilliseconds * 5));
+            var waitForTopologySuccessful = await follower.WaitForTopology(Leader.TopologyModification.Voter)
+                .WaitAsync(TimeSpan.FromMilliseconds(leader.ElectionTimeout.TotalMilliseconds * 5));
             Assert.True(waitForTopologySuccessful);
 
             using (leader.ContextPool.AllocateOperationContext(out TransactionOperationContext ctx))

--- a/test/Tests.Infrastructure/RavenTestBase.cs
+++ b/test/Tests.Infrastructure/RavenTestBase.cs
@@ -146,7 +146,7 @@ namespace FastTests
 
                     if (options.CreateDatabase)
                     {
-                        foreach (var server in Servers)
+                        foreach (var server in Servers.Union(new []{ Server }))
                         {
                             using (server.ServerStore.ContextPool.AllocateOperationContext(out TransactionOperationContext context))
                             {

--- a/test/Tests.Infrastructure/TestBase.cs
+++ b/test/Tests.Infrastructure/TestBase.cs
@@ -58,7 +58,7 @@ namespace FastTests
 
         private RavenServer _localServer;
 
-        protected List<RavenServer> Servers = new List<RavenServer>();
+        public List<RavenServer> Servers = new List<RavenServer>();
 
         private static readonly object ServerLocker = new object();
 
@@ -85,7 +85,8 @@ namespace FastTests
             };
 #endif
 
-            System.Threading.ThreadPool.SetMinThreads(250, 250);
+            if(Environment.Is64BitProcess)
+                System.Threading.ThreadPool.SetMinThreads(250, 250);
 
             var maxNumberOfConcurrentTests = Math.Max(ProcessorInfo.ProcessorCount / 2, 2);
 
@@ -251,6 +252,8 @@ namespace FastTests
             }
         }
 
+        public static RavenServer GlobalServer => _globalServer;
+
         private static void UnloadServer(AssemblyLoadContext obj)
         {
             try
@@ -394,7 +397,6 @@ namespace FastTests
                             retries--;
                             GC.Collect();
                             GC.WaitForFullGCComplete(3000);
-                            Thread.Sleep(1000);
                             lastException = e;
                             continue;
                         }                     

--- a/test/Tests.Infrastructure/TestBase.cs
+++ b/test/Tests.Infrastructure/TestBase.cs
@@ -1,5 +1,6 @@
 ﻿using System;
 using System.Collections.Generic;
+using System.ComponentModel;
 using System.Diagnostics;
 using System.IO;
 using System.Linq;
@@ -14,6 +15,7 @@ using System.Threading.Tasks;
 using Newtonsoft.Json.Linq;
 using Raven.Client;
 using Raven.Client.Http;
+using Raven.Client.ServerWide.Operations;
 using Raven.Server;
 using Raven.Server.Config;
 using Raven.Server.Config.Categories;
@@ -357,10 +359,51 @@ namespace FastTests
                 if (deletePrevious)
                     IOExtensions.DeleteDirectory(configuration.Core.DataDirectory.FullPath);
 
-                var server = new RavenServer(configuration);
-                server.Initialize();
+                if (PlatformDetails.Is32Bits == false)
+                {                    
+                    var server = new RavenServer(configuration);
+                    server.Initialize();
 
-                return server;
+                    return server;
+                }
+                else
+                {
+                    RavenServer server;
+                    var retries = 5;
+                    Win32Exception lastException = null;
+                    while (true)
+                    {
+                        if (retries == 0)
+                        {
+                            if (lastException != null)
+                                throw new OutOfMemoryException("Failed to allocate needed memory map, perhaps out of 32-bit memory space?", lastException);
+                            
+                            throw new OutOfMemoryException("Failed to allocate needed memory map, perhaps out of 32-bit memory space?");
+                        }
+
+                        try
+                        {
+                            server = new RavenServer(configuration);
+                            server.Initialize();
+                        }
+                        catch (Win32Exception e)
+                        {
+                            Console.WriteLine("------------------------------");
+                            Console.WriteLine(e);
+                            Console.WriteLine("------------------------------");
+                            retries--;
+                            GC.Collect();
+                            GC.WaitForFullGCComplete(3000);
+                            Thread.Sleep(1000);
+                            lastException = e;
+                            continue;
+                        }                     
+
+                        break;
+                    }
+
+                    return server;
+                }
             }
         }
 

--- a/test/Tryouts/Program.cs
+++ b/test/Tryouts/Program.cs
@@ -1,12 +1,23 @@
 using System;
+using System.Collections.Generic;
+using System.ComponentModel;
+using System.Diagnostics;
+using System.IO;
+using System.Linq;
+using System.Runtime.InteropServices;
+using System.Threading;
 using System.Threading.Tasks;
 using FastTests;
 using FastTests.Server.Documents.Queries.Parser;
+using FastTests.Server.Replication;
 using FastTests.Voron.Backups;
 using FastTests.Voron.Compaction;
+using Microsoft.Win32.SafeHandles;
 using RachisTests;
 using RachisTests.DatabaseCluster;
 using Raven.Client.Documents.Queries;
+using Raven.Server;
+using Raven.Server.ServerWide.Context;
 using Raven.Tests.Core.Utils.Entities;
 using SlowTests.Authentication;
 using SlowTests.Bugs.MapRedue;
@@ -14,35 +25,160 @@ using SlowTests.Client;
 using SlowTests.Client.Attachments;
 using SlowTests.Issues;
 using SlowTests.MailingList;
+using Sparrow.Json;
 using Sparrow.Logging;
+using Sparrow.LowMemory;
 using Sparrow.Platform;
+using Sparrow.Utils;
 using StressTests.Client.Attachments;
 using Xunit;
 
 namespace Tryouts
 {
-
     public static class Program
     {
+        private static ManualResetEventSlim _isRunningEvent;
+
         public static void Main(string[] args)
-        {
-            for (int i = 0; i < 500; i++)
+        {            
+            _isRunningEvent = new ManualResetEventSlim();
+            HashSet<ulong> threadIds = null;
+            long lowMemoryCount = 0;
+            using(_isRunningEvent)
             {
-                Console.WriteLine(i);
                 try
                 {
                     using (var test = new ReplicationTests())
                     {
-                        test.EnsureReplicationToWatchers(false).Wait();
+                        test.VerySimpleTest();
+                    }
+
+                    var sw = Stopwatch.StartNew();
+                    double lowMemoryPerSec = 0;
+                    TestBase.GlobalServer.ServerStore.LowMemoryNotification.LowMemoryEvent += () =>
+                    {
+                        lowMemoryCount++;
+                        lowMemoryPerSec = lowMemoryCount / sw.Elapsed.TotalSeconds;
+                    };
+                    for (int i = 0; i < 1000; i++)
+                    {                     
+                        try
+                        {
+                            using (var test = new ReplicationTests())
+                            {
+                                //test.EnsureReplicationToWatchers(false).Wait();
+                                test.VerySimpleTest();
+
+                                var createdServersCount = test.Servers.Count;
+                                Console.Clear();
+                                Console.WriteLine("Iteration: " + i);                                
+                                Console.WriteLine($"Low memory handlers activated {lowMemoryCount} times. (averaging on {lowMemoryPerSec:F} activations/sec)");
+                                Console.WriteLine($"Server instances in test fixture : {createdServersCount}");
+                                
+                                var allocationsPerThread = Raven.Server.Program.WriteServerStatsOnce(test.Server).AllocationsPerThread;
+                                if (threadIds != null)
+                                {
+                                    threadIds.IntersectWith(allocationsPerThread.Select(x => x.ThreadId));
+                                    var newThreads = new HashSet<ulong>(allocationsPerThread.Select(x => x.ThreadId));
+                                    newThreads.ExceptWith(threadIds);
+
+                                    Console.WriteLine($"There are {allocationsPerThread.Count - threadIds.Count} new threads out of total {allocationsPerThread.Count} threads in this iteration.");
+
+                                    Console.WriteLine("New threads:");
+                                    foreach (var id in newThreads)
+                                    {
+                                        Console.WriteLine(allocationsPerThread.FirstOrDefault(x => x.ThreadId == id).ThreadName);
+                                    }
+                                }
+                                threadIds = new HashSet<ulong>(allocationsPerThread.Select(x => x.ThreadId));
+                            }
+                        }
+                        catch (Exception e)
+                        {
+                            Console.WriteLine(e);
+                            break;
+                        }
+
+                        LowMemoryNotification.Instance.SimulateLowMemoryNotification();
+//                        GC.Collect(2);
                     }
                 }
-                catch (Exception e)
+                finally
                 {
-                    Console.WriteLine(e);
-                    break;
+                    _isRunningEvent.Set();
                 }
             }
+        }
+    }
 
+   public static class DumpHelper
+    {
+        public enum DumpType
+        {
+            MiniDumpNormal = 0,
+            MiniDumpWithDataSegs = 1,
+            MiniDumpWithFullMemory = 2,
+            MiniDumpWithHandleData = 4,
+            MiniDumpFilterMemory = 8,
+            MiniDumpScanMemory = 16,
+            MiniDumpWithUnloadedModules = 32,
+            MiniDumpWithIndirectlyReferencedMemory = 64,
+            MiniDumpFilterModulePaths = 128,
+            MiniDumpWithProcessThreadData = 256,
+            MiniDumpWithPrivateReadWriteMemory = 512,
+            MiniDumpWithoutOptionalData = 1024,
+            MiniDumpWithFullMemoryInfo = 2048,
+            MiniDumpWithThreadInfo = 4096,
+            MiniDumpWithCodeSegs = 8192,
+        }
+
+        [DllImportAttribute("dbghelp.dll")]
+        [return: MarshalAsAttribute(UnmanagedType.Bool)]
+        private static extern bool MiniDumpWriteDump(
+            [In] IntPtr hProcess,
+            uint ProcessId,
+            SafeFileHandle hFile,
+            DumpType DumpType,
+            [In] IntPtr ExceptionParam,
+            [In] IntPtr UserStreamParam,
+            [In] IntPtr CallbackParam);
+
+        public static void WriteTinyDumpForThisProcess(string fileName)
+        {
+            WriteDumpForThisProcess(fileName, DumpType.MiniDumpNormal);
+        }
+
+        public static void WriteFullDumpForThisProcess(string fileName)
+        {
+            WriteDumpForThisProcess(fileName, DumpType.MiniDumpWithFullMemory);
+        }
+
+        public static void WriteDumpForThisProcess(string fileName, DumpType dumpType)
+        {
+            WriteDumpForProcess(Process.GetCurrentProcess(), fileName, dumpType);
+        }
+
+        public static void WriteTinyDumpForProcess(Process process, string fileName)
+        {
+            WriteDumpForProcess(process, fileName, DumpType.MiniDumpNormal);
+        }
+
+        public static void WriteFullDumpForProcess(Process process, string fileName)
+        {
+            WriteDumpForProcess(process, fileName, DumpType.MiniDumpWithFullMemory);
+        }
+
+        public static void WriteDumpForProcess(Process process, string fileName, DumpType dumpType)
+        {
+            using (FileStream fs = File.Create(fileName))
+            {
+                if (!MiniDumpWriteDump(Process.GetCurrentProcess().Handle,
+                    (uint)process.Id, fs.SafeFileHandle, dumpType,
+                    IntPtr.Zero, IntPtr.Zero, IntPtr.Zero))
+                {
+                    throw new Win32Exception(Marshal.GetLastWin32Error(), "Error calling MiniDumpWriteDump.");
+                }
+            }
         }
     }
 }


### PR DESCRIPTION
Because the ByteStringMemoryCache was a struct, it passed the wrong reference to RegisterLowMemoryHandler(), thus not executing the low memory event when needed.