### PR TITLE
RavenDB-11892 Memory leak in ByteStringContext

### DIFF
--- a/src/Sparrow/ByteString.cs
+++ b/src/Sparrow/ByteString.cs
@@ -747,8 +747,17 @@ namespace Sparrow
             _externalFastPoolCount = 0;
             _externalCurrentLeft = (int)(_externalCurrent.End - _externalCurrent.Start) / _externalAlignedSize;
 
+            Debug.Assert(_wholeSegments.Count >= 2);
+            // We need to make ensure that the _internalCurrent is linked to an unmanaged segment
+            var index = _wholeSegments.Count - 1;
+            if (_wholeSegments[index] == _externalCurrent)
+            {
+                index = _wholeSegments.Count - 2;
+            }
+            _internalCurrent = _wholeSegments[index];
+
             _internalCurrent.Current = _internalCurrent.Start;
-            _externalCurrent.Current = _externalCurrent.Start;
+            _externalCurrent.Current = _externalCurrent.Start; // no need to reset it, always whole section
 
             _currentlyAllocated = 0;
 
@@ -757,10 +766,11 @@ namespace Sparrow
 
             for (int i = 0; i < _wholeSegments.Count; i++)
             {
-                if (_wholeSegments[i] == _internalCurrent || _wholeSegments[i] == _externalCurrent)
+                var segment = _wholeSegments[i];
+                if (segment == _internalCurrent || segment == _externalCurrent)
                     continue;
 
-                ReleaseSegment(_wholeSegments[i]);
+                ReleaseSegment(segment);
                 _wholeSegments.RemoveAt(i);
                 i--;
             }

--- a/src/Sparrow/ByteString.cs
+++ b/src/Sparrow/ByteString.cs
@@ -626,7 +626,7 @@ namespace Sparrow
 
     public sealed class ByteStringContext : ByteStringContext<ByteStringMemoryCache>
     {
-        public const int MinBlockSizeInBytes = 64 * 1024; // If this is changed, we need to change also LogMinBlockSize.
+        public const int MinBlockSizeInBytes = 4 * 1024; // If this is changed, we need to change also LogMinBlockSize.
         public const int MaxAllocationBlockSizeInBytes = 256 * MinBlockSizeInBytes;
         public const int DefaultAllocationBlockSizeInBytes = 1 * MinBlockSizeInBytes;
         public const int MinReusableBlockSizeInBytes = 8;
@@ -735,9 +735,6 @@ namespace Sparrow
             if (_disposed)
                 ThrowObjectDisposed();
 
-            if (_wholeSegments.Count == 2)
-                return; // nothing to do
-
             Array.Clear(_internalReusableStringPoolCount, 0, _internalReusableStringPoolCount.Length);
             foreach (var stack in _internalReusableStringPool)
             {
@@ -749,7 +746,13 @@ namespace Sparrow
             _externalFastPoolCount = 0;
             _externalCurrentLeft = (int)(_externalCurrent.End - _externalCurrent.Start) / _externalAlignedSize;
 
+            _internalCurrent.Current = _internalCurrent.Start;
+            _externalCurrent.Current = _externalCurrent.Start;
+
             _currentlyAllocated = 0;
+
+            if (_wholeSegments.Count == 2)
+                return;
 
             for (int i = 0; i < _wholeSegments.Count; i++)
             {
@@ -760,9 +763,6 @@ namespace Sparrow
                 _wholeSegments.RemoveAt(i);
                 i--;
             }
-            _internalCurrent.Current = _internalCurrent.Start;
-            _externalCurrent.Current = _externalCurrent.Start;
-
         }
 
         [MethodImpl(MethodImplOptions.AggressiveInlining)]
@@ -809,7 +809,7 @@ namespace Sparrow
             {
                 if (_externalCurrentLeft == 0)
                 {
-                    var tmp = Math.Min(16 * Constants.Size.Megabyte, _allocationBlockSize * 2);
+                    var tmp = Math.Min(2 * Constants.Size.Megabyte, _allocationBlockSize * 2);
                     AllocateExternalSegment(tmp);
                     _allocationBlockSize = tmp;
                 }
@@ -939,7 +939,7 @@ namespace Sparrow
             }
             else
             {
-                _allocationBlockSize = Math.Min(16 * Constants.Size.Megabyte, _allocationBlockSize * 2);
+                _allocationBlockSize = Math.Min(2 * Constants.Size.Megabyte, _allocationBlockSize * 2);
                 _internalCurrent = AllocateSegment(_allocationBlockSize);
             }
 
@@ -1013,6 +1013,7 @@ namespace Sparrow
 
             var byteString = Create(segment.Current, length, segment.Size, type);
             segment.Current += byteString._pointer->Size;
+            _currentlyAllocated += size;
 
             return byteString;
         }

--- a/src/Sparrow/ByteString.cs
+++ b/src/Sparrow/ByteString.cs
@@ -680,7 +680,8 @@ namespace Sparrow
             }
         }
 
-        private const int LogMinBlockSize = 16;
+        // Log₂(MinBlockSizeInBytes)
+        private const int LogMinBlockSize = 12;
 
         /// <summary>
         /// This list keeps all the segments already instantiated in order to release them after context finalization. 
@@ -1013,7 +1014,7 @@ namespace Sparrow
 
             var byteString = Create(segment.Current, length, segment.Size, type);
             segment.Current += byteString._pointer->Size;
-            _currentlyAllocated += size;
+            _currentlyAllocated += byteString._pointer->Size;
 
             return byteString;
         }


### PR DESCRIPTION
Resetting the context doesn't free the memory as long as we had only 2 segments.

So with many small allocation, this caused to the hot segments to grow to their maximal value of 16 MB.
And in presence of many contexts we ended up in a high memory usage.

Since ByteStringContext is mostly used for converting from string to slice document ids and different keys for voron tress/indexes, we do not expect to have large segments.

Therefor we changed the default size of minimum block from 64k to 4k and the maximal segment size to 2MB.