### PR TITLE
RavenDB-11901 - OS name is in quotes after parsing: /etc/os-release

### DIFF
--- a/src/Raven.Server/Commercial/OsInfoExtensions.cs
+++ b/src/Raven.Server/Commercial/OsInfoExtensions.cs
@@ -240,7 +240,7 @@ namespace Raven.Server.Commercial
                     (from line in File.ReadAllLines(path)
                      let splitted = line.Split("=")
                      where splitted.Length == 2
-                     select (Key: splitted[0], Value: splitted[1]))
+                     select (Key: splitted[0], Value: splitted[1]?.Replace("\"", string.Empty)))
                     .ToDictionary(x => x.Key, x => x.Value);
 
                 osReleaseProperties.TryGetValue("NAME", out var name);


### PR DESCRIPTION
http://issues.hibernatingrhinos.com/issue/RavenDB-11901