### PR TITLE
RavenDB-11947 Fix NREs

### DIFF
--- a/src/Raven.Server/Rachis/FollowerAmbassador.cs
+++ b/src/Raven.Server/Rachis/FollowerAmbassador.cs
@@ -729,8 +729,8 @@ namespace Raven.Server.Rachis
                 var llr = _connection.Read<LogLengthNegotiationResponse>(context);
 
                 FollowerCommandsVersion = GetFollowerVersion(llr);
-                _engine.CurrentLeader.PeersVersion[_tag] = FollowerCommandsVersion;
-                var minimalVersion = ClusterCommandsVersionManager.GetClusterMinimalVersion(_engine.CurrentLeader.PeersVersion.Values.ToList(), _engine.MaximalVersion);
+                _leader.PeersVersion[_tag] = FollowerCommandsVersion;
+                var minimalVersion = ClusterCommandsVersionManager.GetClusterMinimalVersion(_leader.PeersVersion.Values.ToList(), _engine.MaximalVersion);
                 ClusterCommandsVersionManager.SetClusterVersion(minimalVersion);
 
                 if (_engine.Log.IsInfoEnabled)

--- a/src/Raven.Server/RavenServer.cs
+++ b/src/Raven.Server/RavenServer.cs
@@ -1381,7 +1381,7 @@ namespace Raven.Server
             if (tcp.Operation == TcpConnectionHeaderMessage.OperationTypes.Cluster)
             {
                 var tcpClient = tcp.TcpClient.Client;
-                ServerStore.ClusterAcceptNewConnection(tcp.Stream, () => tcpClient.Disconnect(false), tcpClient.RemoteEndPoint);
+                ServerStore.ClusterAcceptNewConnection(tcp, header,() => tcpClient.Disconnect(false), tcpClient.RemoteEndPoint);
                 return true;
             }
 

--- a/src/Raven.Server/ServerWide/ClusterStateMachine.cs
+++ b/src/Raven.Server/ServerWide/ClusterStateMachine.cs
@@ -1634,7 +1634,8 @@ namespace Raven.Server.ServerWide
                     Version = TcpConnectionHeaderMessage.ClusterTcpVersion,
                     ReadResponseAndGetVersionCallback = ClusterReadResponseAndGetVersion,
                     DestinationUrl = info.Url,
-                    DestinationNodeTag = tag
+                    DestinationNodeTag = tag,
+                    SourceNodeTag = _parent.Tag
                 };
 
                 TcpConnectionHeaderMessage.SupportedFeatures supportedFeatures;


### PR DESCRIPTION
- Race on startup, between tcp listeners init and the engine init.
- On leader change, the current leader of the engine could be null.
- Better error handling on raft network failures.