### PR TITLE
RavenDB-11923 Smuggler.LegacySmugglerTests.CanImportIndexesAndTransfo…

### DIFF
--- a/src/Raven.Server/Documents/Indexes/Configuration/SingleIndexConfiguration.cs
+++ b/src/Raven.Server/Documents/Indexes/Configuration/SingleIndexConfiguration.cs
@@ -29,7 +29,7 @@ namespace Raven.Server.Documents.Indexes.Configuration
 
         public override bool RunInMemory => _databaseConfiguration.Indexing.RunInMemory;
 
-        public override PathSetting TempPath => _databaseConfiguration.Indexing.TempPath ?? _databaseConfiguration.Indexing.StoragePath;
+        public override PathSetting TempPath => _databaseConfiguration.Indexing.TempPath ?? _databaseConfiguration.Indexing.StoragePath.Combine("Temp");
 
         public IndexUpdateType CalculateUpdateType(SingleIndexConfiguration newConfiguration)
         {

--- a/src/Raven.Server/Documents/Indexes/Configuration/SingleIndexConfiguration.cs
+++ b/src/Raven.Server/Documents/Indexes/Configuration/SingleIndexConfiguration.cs
@@ -29,7 +29,7 @@ namespace Raven.Server.Documents.Indexes.Configuration
 
         public override bool RunInMemory => _databaseConfiguration.Indexing.RunInMemory;
 
-        public override PathSetting TempPath => _databaseConfiguration.Indexing.TempPath;
+        public override PathSetting TempPath => _databaseConfiguration.Indexing.TempPath ?? _databaseConfiguration.Indexing.StoragePath;
 
         public IndexUpdateType CalculateUpdateType(SingleIndexConfiguration newConfiguration)
         {

--- a/test/SlowTests/Issues/RavenDB-6989.cs
+++ b/test/SlowTests/Issues/RavenDB-6989.cs
@@ -13,22 +13,19 @@ namespace SlowTests.Issues
         public void multi_map_index_with_load_document_to_same_collection()
         {
             using (var database = CreateDocumentDatabase())
+            using (var index = MapIndex.CreateNew(new IndexDefinition
             {
-                var index = MapIndex.CreateNew(new IndexDefinition
+                Name = "Index",
+                Maps =
                 {
-                    Name = "Index",
-                    Maps =
-                    {
-                        @"from user in docs.Users select new { Name = LoadDocument(""shippers/1"", ""Shippers"").Name }",
-                        @"from product in docs.Products select new { Name = LoadDocument(""shippers/1"", ""Shippers"").Name }"
-                    },
-                    Type = IndexType.Map
-                }, database);
-
-                using (var contextPool = new TransactionContextPool(database.DocumentsStorage.Environment))
-                {
-                    new IndexStorage(index, contextPool, database);
-                }
+                    @"from user in docs.Users select new { Name = LoadDocument(""shippers/1"", ""Shippers"").Name }",
+                    @"from product in docs.Products select new { Name = LoadDocument(""shippers/1"", ""Shippers"").Name }"
+                },
+                Type = IndexType.Map
+            }, database))
+            using (var contextPool = new TransactionContextPool(database.DocumentsStorage.Environment))
+            {
+                new IndexStorage(index, contextPool, database);
             }
         }
     }

--- a/test/SlowTests/Issues/RavenDB_3864.cs
+++ b/test/SlowTests/Issues/RavenDB_3864.cs
@@ -81,7 +81,7 @@ namespace SlowTests.Issues
         }
 
         [Fact]
-        public void can_use_conventions_with_create_side_by_side_indexes_async()
+        public async Task can_use_conventions_with_create_side_by_side_indexes_async()
         {
             using (var store = CreateDocumentStore())
             {
@@ -91,7 +91,7 @@ namespace SlowTests.Issues
                     new CustomIdWithNameInIndexCreationTask()
                 };
 
-                store.ExecuteIndexesAsync(list);
+                await store.ExecuteIndexesAsync(list);
                 Assert.True(TestFailed.Value == false);
             }
         }

--- a/test/SlowTests/Issues/RavenDB_3864.cs
+++ b/test/SlowTests/Issues/RavenDB_3864.cs
@@ -49,7 +49,7 @@ namespace SlowTests.Issues
         }
 
         [Fact]
-        public void can_use_conventions_with_create_indexes_async()
+        public async Task can_use_conventions_with_create_indexes_async()
         {
             using (var store = CreateDocumentStore())
             {
@@ -59,7 +59,7 @@ namespace SlowTests.Issues
                     new CustomIdWithNameInIndexCreationTask()
                 };
 
-                store.ExecuteIndexesAsync(list);
+                await store.ExecuteIndexesAsync(list);
                 Assert.True(TestFailed.Value == false);
             }
         }

--- a/test/SlowTests/Server/Documents/Indexing/Static/CollisionsOfReduceKeyHashes.cs
+++ b/test/SlowTests/Server/Documents/Indexing/Static/CollisionsOfReduceKeyHashes.cs
@@ -16,6 +16,7 @@ using Raven.Server.ServerWide;
 using Raven.Server.ServerWide.Context;
 using Raven.Server.Utils;
 using Sparrow.Json.Parsing;
+using Sparrow.Utils;
 using Xunit;
 
 namespace SlowTests.Server.Documents.Indexing.Static
@@ -28,24 +29,23 @@ namespace SlowTests.Server.Documents.Indexing.Static
         public async Task Auto_index_should_produce_multiple_outputs(int numberOfUsers, string[] locations)
         {
             using (var database = CreateDocumentDatabase())
+            using (var index = AutoMapReduceIndex.CreateNew(new AutoMapReduceIndexDefinition("Users", new[]
             {
-                var index = AutoMapReduceIndex.CreateNew(new AutoMapReduceIndexDefinition("Users", new[]
+                new AutoIndexField
                 {
-                    new AutoIndexField
-                    {
-                        Name = "Count",
-                        Aggregation = AggregationOperation.Count,
-                        Storage = FieldStorage.Yes
-                    }
-                }, new[]
+                    Name = "Count",
+                    Aggregation = AggregationOperation.Count,
+                    Storage = FieldStorage.Yes
+                }
+            }, new[]
+            {
+                new AutoIndexField
                 {
-                    new AutoIndexField
-                    {
-                        Name = "Location",
-                        Storage = FieldStorage.Yes
-                    },
-                }), database);
-
+                    Name = "Location",
+                    Storage = FieldStorage.Yes
+                },
+            }), database))
+            {
                 var mapReduceContext = new MapReduceIndexingContext();
                 using (var contextPool = new TransactionContextPool(database.DocumentsStorage.Environment))
                 {
@@ -65,21 +65,20 @@ namespace SlowTests.Server.Documents.Indexing.Static
         public async Task Static_index_should_produce_multiple_outputs(int numberOfUsers, string[] locations)
         {
             using (var database = CreateDocumentDatabase())
+            using (var index = MapReduceIndex.CreateNew(new IndexDefinition()
             {
-                var index = MapReduceIndex.CreateNew(new IndexDefinition()
+                Name = "Users_ByCount_GroupByLocation",
+                Maps = { "from user in docs.Users select new { user.Location, Count = 1 }" },
+                Reduce =
+                    "from result in results group result by result.Location into g select new { Location = g.Key, Count = g.Sum(x => x.Count) }",
+                Type = IndexType.MapReduce,
+                Fields =
                 {
-                    Name = "Users_ByCount_GroupByLocation",
-                    Maps = { "from user in docs.Users select new { user.Location, Count = 1 }" },
-                    Reduce =
-                        "from result in results group result by result.Location into g select new { Location = g.Key, Count = g.Sum(x => x.Count) }",
-                    Type = IndexType.MapReduce,
-                    Fields =
-                    {
-                        {"Location", new IndexFieldOptions {Storage = FieldStorage.Yes}},
-                        {"Count", new IndexFieldOptions {Storage = FieldStorage.Yes}}
-                    }
-                }, database);
-
+                    {"Location", new IndexFieldOptions {Storage = FieldStorage.Yes}},
+                    {"Count", new IndexFieldOptions {Storage = FieldStorage.Yes}}
+                }
+            }, database))
+            {
                 var mapReduceContext = new MapReduceIndexingContext();
                 using (var contextPool = new TransactionContextPool(database.DocumentsStorage.Environment))
                 {
@@ -204,7 +203,7 @@ namespace SlowTests.Server.Documents.Indexing.Static
                     }
                     finally
                     {
-                        if (writeOperation.IsValueCreated)
+                        if(writeOperation.IsValueCreated)
                             writeOperation.Value.Dispose();
                     }
 
@@ -267,7 +266,7 @@ namespace SlowTests.Server.Documents.Indexing.Static
                     }
                     finally
                     {
-                        if (writeOperation.IsValueCreated)
+                        if(writeOperation.IsValueCreated)
                             writeOperation.Value.Dispose();
                     }
                 }

--- a/test/Tests.Infrastructure/RavenLowLevelTestBase.cs
+++ b/test/Tests.Infrastructure/RavenLowLevelTestBase.cs
@@ -12,7 +12,6 @@ using Raven.Client.Util;
 using Raven.Server.Config;
 using Raven.Server.Documents;
 using Raven.Server.Documents.Indexes;
-using Raven.Server.ServerWide;
 using Raven.Server.ServerWide.Context;
 using Raven.Server.Utils;
 using Sparrow.Json;
@@ -134,7 +133,8 @@ namespace FastTests
                         {
                             try
                             {
-                                await Server.ServerStore.DeleteDatabaseAsync(database, hardDelete: true, fromNodes: new[] { Server.ServerStore.NodeTag });
+                                var (index, _) = await Server.ServerStore.DeleteDatabaseAsync(database, hardDelete: true, fromNodes: new[] { Server.ServerStore.NodeTag });
+                                await Server.ServerStore.Cluster.WaitForIndexNotification(index);
                             }
                             catch (DatabaseDoesNotExistException)
                             {


### PR DESCRIPTION
…rmers

When running in-memory all of the indexes were created in the same temp folder, which in this case genreated over 1,500 files in a single folder.
This crippled the database deletion, since it had to enumerate so many files (`Directory.GetFiles(tempPath.FullPath, "*.buffers")`).

So the fix is to create each index in a seperate folder.