### PR TITLE
RavenDB-11979 Cluster wide transaction failed with NRE when the datab…

### DIFF
--- a/src/Raven.Server/Documents/DatabasesLandlord.cs
+++ b/src/Raven.Server/Documents/DatabasesLandlord.cs
@@ -133,11 +133,13 @@ namespace Raven.Server.Documents
                     case ClusterDatabaseChangeType.PendingClusterTransactions:
                         if (task.IsCompleted)
                         {
+                            task.Result.DatabaseGroupId = record.Topology.DatabaseTopologyIdBase64;
                             NotifyPendingClusterTransaction(databaseName, task);
                             return;
                         }
                         task.ContinueWith(done =>
                         {
+                            done.Result.DatabaseGroupId = record.Topology.DatabaseTopologyIdBase64;
                             NotifyPendingClusterTransaction(databaseName, done);
                         });
 

--- a/src/Raven.Server/Documents/Handlers/BatchHandler.cs
+++ b/src/Raven.Server/Documents/Handlers/BatchHandler.cs
@@ -136,7 +136,8 @@ namespace Raven.Server.Documents.Handlers
 
         private async Task HandleClusterTransaction(DocumentsOperationContext context, MergedBatchCommand command, ClusterTransactionCommand.ClusterTransactionOptions options)
         {
-            var clusterTransactionCommand = new ClusterTransactionCommand(Database.Name, command.ParsedCommands, options);
+            var record = ServerStore.LoadDatabaseRecord(Database.Name, out _);
+            var clusterTransactionCommand = new ClusterTransactionCommand(Database.Name, record.Topology.DatabaseTopologyIdBase64, command.ParsedCommands, options);
             var result = await ServerStore.SendToLeaderAsync(clusterTransactionCommand);
 
             if (result.Result is List<string> errors)


### PR DESCRIPTION
…ase was created in 4.0.x version

The In that case the fields `record.Topology.DatabaseTopologyIdBase64` and `Database.DatabaseGroupId` were missing.