### PR TITLE
RavenDB-11914 DeleteByQueryOperation<TEntity> throws when DocumentSto…

### DIFF
--- a/src/Raven.Client/Documents/Operations/DeleteByQueryOperation.cs
+++ b/src/Raven.Client/Documents/Operations/DeleteByQueryOperation.cs
@@ -40,7 +40,7 @@ namespace Raven.Client.Documents.Operations
         {
             if (_queryToDelete == DummyQuery)
             {
-                using (var session = store.OpenSession(store.Database ?? "DummyDatabase"))
+                using (var session = store.OpenSession(string.IsNullOrWhiteSpace(store.Database) ? "DummyDatabase" : store.Database))
                 {
                     var query = session
                         .Query<TEntity>(_indexName)

--- a/test/SlowTests/Issues/RavenDB_11914.cs
+++ b/test/SlowTests/Issues/RavenDB_11914.cs
@@ -1,0 +1,40 @@
+﻿using FastTests;
+using Raven.Client.Documents;
+using Raven.Client.Documents.Operations;
+using Raven.Tests.Core.Utils.Entities;
+using Xunit;
+
+namespace SlowTests.Issues
+{
+    public class RavenDB_11914 : RavenTestBase
+    {
+        [Fact]
+        public void CanSendOperationsWithSettingExplicitDbName()
+        {
+            using (var store = GetDocumentStore())
+            using (var other = new DocumentStore
+            {
+                Urls = store.Urls,
+            }.Initialize())
+            {
+                other.Operations.ForDatabase(store.Database).Send(
+                    new DeleteByQueryOperation<User>("test", x => x.Name == "arek"));
+            }
+        }
+
+        [Fact]
+        public void CanSendOperationsWithSettingExplicitDbName2()
+        {
+            using (var store = GetDocumentStore())
+            using (var other = new DocumentStore
+            {
+                Urls = store.Urls,
+                Database = string.Empty
+            }.Initialize())
+            {
+                other.Operations.ForDatabase(store.Database).Send(
+                    new DeleteByQueryOperation<User>("test", x => x.Name == "arek"));
+            }
+        }
+    }
+}


### PR DESCRIPTION
…re uses empty string as default database