### PR TITLE
RavenDB-11983 When collecting processes to remove in ETL loader we ne…

### DIFF
--- a/src/Raven.Server/Documents/ETL/EtlLoader.cs
+++ b/src/Raven.Server/Documents/ETL/EtlLoader.cs
@@ -1,5 +1,7 @@
 ﻿using System;
 using System.Collections.Generic;
+using System.Diagnostics;
+using System.Linq;
 using System.Threading.Tasks;
 using Raven.Client.Documents.Changes;
 using Raven.Client.Documents.Operations.ConnectionStrings;
@@ -308,12 +310,16 @@ namespace Raven.Server.Documents.ETL
                     mySqlEtl.Add(config);
                 }
             }
+            
+            var toRemove = _processes.GroupBy(x => x.ConfigurationName).ToDictionary(x => x.Key, x => x.ToList());
 
-            var toRemove = new List<EtlProcess>(_processes);
-
-            foreach (var etlProcess in _processes)
+            foreach (var processesPerConfig in _processes.GroupBy(x => x.ConfigurationName))
             {
-                if (etlProcess is RavenEtl ravenEtl)
+                var process = processesPerConfig.First();
+
+                Debug.Assert(processesPerConfig.All(x => x.GetType() == process.GetType()));
+
+                if (process is RavenEtl ravenEtl)
                 {
                     RavenEtlConfiguration existing = null;
                     foreach (var config in myRavenEtl)
@@ -326,12 +332,11 @@ namespace Raven.Server.Documents.ETL
                     }
                     if (existing != null)
                     {
-                        toRemove.Remove(etlProcess);
+                        toRemove.Remove(processesPerConfig.Key);
                         myRavenEtl.Remove(existing);
                     }
                 }
-
-                if (etlProcess is SqlEtl sqlEtl)
+                else if (process is SqlEtl sqlEtl)
                 {
                     SqlEtlConfiguration existing = null;
                     foreach (var config in mySqlEtl)
@@ -344,43 +349,55 @@ namespace Raven.Server.Documents.ETL
                     }
                     if (existing != null)
                     {
-                        toRemove.Remove(etlProcess);
+                        toRemove.Remove(processesPerConfig.Key);
                         mySqlEtl.Remove(existing);
                     }
+                }
+                else
+                {
+                    throw new InvalidOperationException($"Unknown ETL process type: {process.GetType()}");
                 }
             }
 
             Parallel.ForEach(toRemove, x =>
             {
-                try
+                foreach (var process in x.Value)
                 {
-                    x.Stop();
-                }
-                catch (Exception e)
-                {
-                    if (Logger.IsInfoEnabled)
-                        Logger.Info($"Failed to stop ETL process {x.Name} on the database record change", e);
+                    try
+                    {
+
+                        process.Stop();
+                    }
+                    catch (Exception e)
+                    {
+                        if (Logger.IsInfoEnabled)
+                            Logger.Info($"Failed to stop ETL process {process.Name} on the database record change", e);
+                    }
                 }
             });
 
-            LoadProcesses(record, myRavenEtl, mySqlEtl, toRemove);
+            LoadProcesses(record, myRavenEtl, mySqlEtl, toRemove.SelectMany(x => x.Value).ToList());
 
             // unsubscribe old etls _after_ we start new processes to ensure the tombstone cleaner 
             // constantly keeps track of tombstones processed by ETLs so it won't delete them during etl processes reloading
 
-            foreach (var process in toRemove)
+            foreach (var processesPerConfig in toRemove)
+            foreach (var process in processesPerConfig.Value)
                 _database.TombstoneCleaner.Unsubscribe(process);
 
             Parallel.ForEach(toRemove, x =>
             {
-                try
+                foreach (var process in x.Value)
                 {
-                    x.Dispose();
-                }
-                catch (Exception e)
-                {
-                    if (Logger.IsInfoEnabled)
-                        Logger.Info($"Failed to dispose ETL process {x.Name} on the database record change", e);
+                    try
+                    {
+                        process.Dispose();
+                    }
+                    catch (Exception e)
+                    {
+                        if (Logger.IsInfoEnabled)
+                            Logger.Info($"Failed to dispose ETL process {process.Name} on the database record change", e);
+                    }
                 }
             });
         }

--- a/test/SlowTests/Server/Documents/ETL/RavenDB_11983.cs
+++ b/test/SlowTests/Server/Documents/ETL/RavenDB_11983.cs
@@ -1,0 +1,80 @@
+﻿using System.Threading.Tasks;
+using Raven.Client.Documents.Operations.ETL;
+using Sparrow.Collections;
+using Sparrow.Json.Parsing;
+using Xunit;
+
+namespace SlowTests.Server.Documents.ETL
+{
+    public class RavenDB_11983 : EtlTestBase
+    {
+        [Fact]
+        public async Task Should_have_process_per_transformation_script()
+        {
+            using (var store = GetDocumentStore())
+            {
+                var database = await GetDatabase(store.Database);
+
+                var notifications = new AsyncQueue<DynamicJsonValue>();
+                using (database.NotificationCenter.TrackActions(notifications, null))
+                {
+                    AddEtl(store, new RavenEtlConfiguration()
+                    {
+                        ConnectionStringName = "test",
+                        Name = "myFirstEtl",
+                        Transforms =
+                        {
+                            new Transformation()
+                            {
+                                Collections = {"Users"},
+                                Script = "loadToUsers(this)",
+                                Name = "a"
+                            },
+                            new Transformation()
+                            {
+                                Collections = {"Addresses"},
+                                Script = "loadToAddresses(this)",
+                                Name = "b"
+                            }
+                        }
+                    }, new RavenConnectionString()
+                    {
+                        Name = "test",
+                        TopologyDiscoveryUrls = new[] { "http://127.0.0.1:8080" },
+                        Database = "Northwind",
+                    });
+
+                    Assert.Equal(2, database.EtlLoader.Processes.Length);
+
+                    AddEtl(store, new RavenEtlConfiguration()
+                    {
+                        ConnectionStringName = "test",
+                        Name = "mySecondEtl",
+                        Transforms =
+                        {
+                            new Transformation()
+                            {
+                                Collections = {"Users"},
+                                Script = "loadToUsers(this)",
+                                Name = "a"
+                            },
+                            new Transformation()
+                            {
+                                Collections = {"Addresses"},
+                                Script = "loadToAddresses(this)",
+                                Name = "b"
+                            }
+                        }
+                    }, new RavenConnectionString()
+                    {
+                        Name = "test",
+                        TopologyDiscoveryUrls = new[] { "http://127.0.0.1:8080" },
+                        Database = "Northwind",
+                    });
+
+                    Assert.Equal(4, database.EtlLoader.Processes.Length);
+                }
+            }
+        }
+    }
+}


### PR DESCRIPTION
…ed to take into account that single configuration can have multiple scripts what will result in multiple processes. We need to group by configuration when detecting if the task configuration has changed.