### PR TITLE
RavenDB-11957 Fix record tx PR comments

### DIFF
--- a/src/Raven.Client/Documents/Conventions/DefaultRavenContractResolver.cs
+++ b/src/Raven.Client/Documents/Conventions/DefaultRavenContractResolver.cs
@@ -131,14 +131,9 @@ namespace Raven.Client.Documents.Conventions
         {
             if (info is EventInfo)
                 return true;
-            if (info is FieldInfo fieldInfo)
-            {
-                if (false == fieldInfo.IsPublic &&
-                    false == fieldInfo.CustomAttributes.Any(a => a.AttributeType == typeof(JsonPropertyAttribute)))
-                {
-                    return true;
-                }
-            }
+            var fieldInfo = info as FieldInfo;
+            if (fieldInfo != null && !fieldInfo.IsPublic)
+                return true;
             return info.GetCustomAttributes(typeof(CompilerGeneratedAttribute), true).Any();
         }
     }

--- a/src/Raven.Server/Documents/Handlers/BatchHandler.cs
+++ b/src/Raven.Server/Documents/Handlers/BatchHandler.cs
@@ -1000,16 +1000,17 @@ namespace Raven.Server.Documents.Handlers
                     continue;
                 }
 
-                ParsedCommands[i].PatchCommand = new PatchDocumentCommand(context, 
-                    ParsedCommands[i].Id, 
-                    ParsedCommands[i].ChangeVector,
-                    false,
-                    (ParsedCommands[i].Patch, ParsedCommands[i].PatchArgs),
-                    (ParsedCommands[i].PatchIfMissing, ParsedCommands[i].PatchIfMissingArgs),
-                    database,
-                    false,
-                    false,
-                    true
+                ParsedCommands[i].PatchCommand = new PatchDocumentCommand(
+                    context: context, 
+                    id: ParsedCommands[i].Id, 
+                    expectedChangeVector: ParsedCommands[i].ChangeVector,
+                    skipPatchIfChangeVectorMismatch: false,
+                    patch: (ParsedCommands[i].Patch, ParsedCommands[i].PatchArgs),
+                    patchIfMissing: (ParsedCommands[i].PatchIfMissing, ParsedCommands[i].PatchIfMissingArgs),
+                    database: database,
+                    isTest: false,
+                    debugMode: false,
+                    collectResultsNeeded: true
                 );
             }
 

--- a/src/Raven.Server/Documents/Handlers/TransactionsRecordingHandler.cs
+++ b/src/Raven.Server/Documents/Handlers/TransactionsRecordingHandler.cs
@@ -118,6 +118,7 @@ namespace Raven.Server.Documents.Handlers
             );
 
             await Database.TxMerger.Enqueue(command);
+            NoContentStatus();
         }
     }
 

--- a/src/Raven.Server/Json/Converters/BlittableJsonConverter.cs
+++ b/src/Raven.Server/Json/Converters/BlittableJsonConverter.cs
@@ -1,9 +1,9 @@
-﻿using System;
-using System.Runtime.Serialization;
+﻿using System.Runtime.Serialization;
 using Newtonsoft.Json;
+using Raven.Client.Json;
 using Sparrow.Json;
 
-namespace Raven.Client.Json.Converters
+namespace Raven.Server.Json.Converters
 {
 
     internal sealed class BlittableJsonConverter : RavenTypeJsonConverter<BlittableJsonReaderObject>
@@ -22,13 +22,13 @@ namespace Raven.Client.Json.Converters
             if (!(blittableReader.Value is BlittableJsonReaderObject blittableValue))
             {
                 throw new SerializationException(
-                    $"Can't convert {blittableReader.Value.GetType()} type to {nameof(BlittableJsonReaderObject)}. The value must to be a complex object");
+                    $"Can't convert {blittableReader.Value?.GetType()} type to {nameof(BlittableJsonReaderObject)}. The value must to be a complex object");
             }
 
             if (blittableReader.TokenType == JsonToken.StartObject)
             {
-                //Skip in order to prevent unnecessary movement inside the blittable
-                //when field\property type is BlittableJsonReaderObject
+                //Because the value that return is the blittable as a whole
+                //we skip the reading inside this blittable
                 blittableReader.SkipBlittableInside();
             }
 

--- a/src/Raven.Server/Json/Converters/BlittableJsonReaderArrayConverter.cs
+++ b/src/Raven.Server/Json/Converters/BlittableJsonReaderArrayConverter.cs
@@ -1,9 +1,9 @@
-﻿using System;
-using System.Runtime.Serialization;
+﻿using System.Runtime.Serialization;
 using Newtonsoft.Json;
+using Raven.Client.Json;
 using Sparrow.Json;
 
-namespace Raven.Client.Json.Converters
+namespace Raven.Server.Json.Converters
 {
     internal sealed class BlittableJsonReaderArrayConverter : RavenTypeJsonConverter<BlittableJsonReaderArray>
     {
@@ -26,10 +26,11 @@ namespace Raven.Client.Json.Converters
             if (!(blittableReader.Value is BlittableJsonReaderArray blittableArrayValue))
             {
                 throw new SerializationException(
-                    $"Can't convert {blittableReader.Value.GetType()} type to {nameof(BlittableJsonReaderArray)}. The value must to be an array");
+                    $"Can't convert {blittableReader.Value?.GetType()} type to {nameof(BlittableJsonReaderArray)}. The value must to be an array");
             }
-            
-            //Skip in order to prevent unnecessary movement inside the blittable array
+
+            //Because the value that return is the blittable array as a whole
+            //we skip the reading inside this blittable array
             blittableReader.SkipBlittableArrayInside();
 
             return

--- a/src/Raven.Server/Json/Converters/LazyStringValueJsonConverter.cs
+++ b/src/Raven.Server/Json/Converters/LazyStringValueJsonConverter.cs
@@ -1,9 +1,9 @@
-﻿using System;
-using System.Runtime.Serialization;
+﻿using System.Runtime.Serialization;
 using Newtonsoft.Json;
+using Raven.Client.Json;
 using Sparrow.Json;
 
-namespace Raven.Client.Json.Converters
+namespace Raven.Server.Json.Converters
 {
     internal sealed class LazyStringValueJsonConverter : RavenTypeJsonConverter<LazyStringValue>
     {
@@ -21,7 +21,7 @@ namespace Raven.Client.Json.Converters
             //Todo It will be better to change the reader to set the value as LazyStringValue 
             if (!(reader.Value is string strValue))
             {
-                throw new SerializationException($"Try to read {nameof(LazyStringValue)} from {reader.Value.GetType()}. Should be string here");
+                throw new SerializationException($"Try to read {nameof(LazyStringValue)} from {reader.Value?.GetType()}. Should be string here");
             }
 
             return reader.Context.GetLazyString(strValue);

--- a/src/Raven.Server/Json/Converters/RavenTypeJsonConverter.cs
+++ b/src/Raven.Server/Json/Converters/RavenTypeJsonConverter.cs
@@ -1,8 +1,10 @@
 ﻿using System;
 using System.Runtime.Serialization;
 using Newtonsoft.Json;
+using Raven.Client.Json;
+using Raven.Client.Json.Converters;
 
-namespace Raven.Client.Json.Converters
+namespace Raven.Server.Json.Converters
 {
     internal abstract class RavenTypeJsonConverter<T> : RavenJsonConverter
     {
@@ -16,7 +18,7 @@ namespace Raven.Client.Json.Converters
 
             if (!(value is T tValue))
             {
-                throw new SerializationException($"Try to write {value.GetType()} with {GetType().Name}. The converter should be used only for {nameof(T)}");
+                throw new SerializationException($"Try to write {value?.GetType()} with {GetType().Name}. The converter should be used only for {nameof(T)}");
             }
 
             WriteJson(blittableJsonWriter, tValue, serializer);

--- a/src/Raven.Server/Json/Converters/SliceJsonConverter.cs
+++ b/src/Raven.Server/Json/Converters/SliceJsonConverter.cs
@@ -31,7 +31,7 @@ namespace Raven.Server.Json.Converters
         {
             if (!(reader.Value is string strValue))
             {
-                throw new SerializationException($"Try to read {nameof(Slice)} from {reader.Value.GetType()}. Should be string here");
+                throw new SerializationException($"Try to read {nameof(Slice)} from {reader.Value?.GetType()}. Should be string here");
             }
 
             if (!(reader.Context is DocumentsOperationContext context))

--- a/src/Raven.Server/Json/Converters/StreamConverter.cs
+++ b/src/Raven.Server/Json/Converters/StreamConverter.cs
@@ -1,12 +1,11 @@
 ﻿using System;
 using System.IO;
-using System.Reflection;
 using System.Runtime.Serialization;
 using Newtonsoft.Json;
 using Raven.Client.Extensions.Streams;
-using Sparrow.Json;
+using Raven.Client.Json;
 
-namespace Raven.Client.Json.Converters
+namespace Raven.Server.Json.Converters
 {
     internal sealed class StreamConverter : RavenTypeJsonConverter<Stream>
     {
@@ -32,7 +31,7 @@ namespace Raven.Client.Json.Converters
         {
             if (!(blittableReader.Value is string strValue))
             {
-                throw new SerializationException($"Try to read {nameof(Stream)} from {blittableReader.Value.GetType()}. Should be string here");
+                throw new SerializationException($"Try to read {nameof(Stream)} from {blittableReader.Value?.GetType()}. Should be string here");
             }
 
             var buffer = Convert.FromBase64String(strValue);

--- a/src/Raven.Server/Smuggler/Documents/DatabaseDestination.cs
+++ b/src/Raven.Server/Smuggler/Documents/DatabaseDestination.cs
@@ -665,7 +665,10 @@ namespace Raven.Server.Smuggler.Documents
                 {
                     IsRevision = IsRevision
                 };
-                Documents.ForEach(d => command.Add(d));
+                foreach (var document in Documents)
+                {
+                    command.Add(document);
+                }
 
                 return command;
             }

--- a/test/SlowTests/Blittable/JsonSerializerTests.cs
+++ b/test/SlowTests/Blittable/JsonSerializerTests.cs
@@ -7,8 +7,7 @@ using Newtonsoft.Json;
 using Raven.Client.Documents.Conventions;
 using Raven.Client.Documents.Session;
 using Raven.Client.Json;
-using Raven.Client.Json.Converters;
-using Raven.Server.Documents.Handlers;
+using Raven.Server.Json.Converters;
 using Sparrow;
 using Sparrow.Json;
 using Sparrow.Json.Parsing;
@@ -173,37 +172,6 @@ namespace SlowTests.Blittable
                 }
 
                 Assert.Equal(expected, actual);
-            }
-        }
-
-        [Fact]
-        public void JsonDeserialize_WhenHasPrivateReadOnlyField_ShouldResultInCommandWithTheField()
-        {
-            using (Server.ServerStore.ContextPool.AllocateOperationContext(out JsonOperationContext context))
-            {
-                Command actual;
-                const int expected = 32;
-                using (var writer = new BlittableJsonWriter(context))
-                {
-                    var jsonSerializer = new JsonSerializer
-                    {
-                        ContractResolver = new DefaultRavenContractResolver(),
-                    };
-
-                    var command = new Command(id: expected);
-                    jsonSerializer.Serialize(writer, command);
-                    writer.FinalizeDocument();
-
-                    var toDeseialize = writer.CreateReader();
-
-                    using (var reader = new BlittableJsonReader(context))
-                    {
-                        reader.Init(toDeseialize);
-                        actual = jsonSerializer.Deserialize<Command>(reader);
-                    }
-                }
-
-                Assert.Equal(expected, actual.GetId());
             }
         }
 

--- a/test/SlowTests/Blittable/SerializeAndDeserializeMergedTransactionCommandTests.cs
+++ b/test/SlowTests/Blittable/SerializeAndDeserializeMergedTransactionCommandTests.cs
@@ -8,7 +8,7 @@ using FastTests.Voron.Util;
 using Raven.Client.Documents.Conventions;
 using Raven.Client.Documents.Session;
 using Raven.Client.Json;
-using Raven.Client.Json.Converters;
+using Raven.Server.Json.Converters;
 using Raven.Server.Documents;
 using Raven.Server.Documents.Handlers;
 using Raven.Server.Documents.Patch;


### PR DESCRIPTION
Issue: http://issues.hibernatingrhinos.com/issue/RavenDB-11957
Comments from: https://github.com/ravendb/ravendb/pull/7495

* Unnecessary modification to DefaultRavenContractResolver filtering removed
* Names added to unclear constructor arguments
* NoContentStatus added to the endpoint without content to return
* Server converters moved to the server project
* Null checks added to the error messages in converters
* Clearer comment in blittable & blittable array converters
* Lambda `foreach` converted to regular