### PR TITLE
RavenDB-11764 LoadStartingWith only returns first page when combined with matches parameter

### DIFF
--- a/Raven.Client.Lightweight/RavenPagingInformation.cs
+++ b/Raven.Client.Lightweight/RavenPagingInformation.cs
@@ -9,6 +9,8 @@ namespace Raven.Client
 {
     public class RavenPagingInformation
     {
+        private int previousNextPageStart;
+
         public int Start { get; private set; }
 
         public int PageSize { get; private set; }
@@ -25,6 +27,7 @@ namespace Raven.Client
 
             Start = start;
             PageSize = pageSize;
+            previousNextPageStart = NextPageStart;
             NextPageStart = nextPageStart;
         }
 
@@ -38,7 +41,7 @@ namespace Raven.Client
 
         public bool IsLastPage()
         {
-            return Start == NextPageStart;
+            return previousNextPageStart == NextPageStart;
         }
     }
 }

--- a/Raven.Database/Actions/DocumentActions.cs
+++ b/Raven.Database/Actions/DocumentActions.cs
@@ -145,6 +145,10 @@ namespace Raven.Database.Actions
                         {
                             token.ThrowIfCancellationRequested();
                             docCount++;
+                            if (doc == null)
+                            {
+                                continue;
+                            }
                             if (docCount - docCountOnLastAdd > 1000)
                             {
                                 addDoc(null); // heartbeat

--- a/Raven.Database/Actions/DocumentActions.cs
+++ b/Raven.Database/Actions/DocumentActions.cs
@@ -180,7 +180,7 @@ namespace Raven.Database.Actions
                                 break;
                         }
 
-                        actualStart += pageSize;
+                        actualStart += docCount;
                     } while (docCount > 0 && addedDocs < pageSize && actualStart > 0 && actualStart < int.MaxValue);
                 });
 

--- a/Raven.Database/Bundles/SqlReplication/SqlReplicationTask.cs
+++ b/Raven.Database/Bundles/SqlReplication/SqlReplicationTask.cs
@@ -833,6 +833,10 @@ namespace Raven.Database.Bundles.SqlReplication
 
                 foreach (var sqlReplicationConfigDocument in accessor.Documents.GetDocumentsWithIdStartingWith(Prefix, 0, int.MaxValue, null))
                 {
+                    if (sqlReplicationConfigDocument == null)
+                    {
+                        continue;
+                    }
                     var cfg = sqlReplicationConfigDocument.DataAsJson.JsonDeserialization<SqlReplicationConfig>();
                     var replicationStats = statistics.GetOrAdd(cfg.Name, name => new SqlReplicationStatistics(name));
                     if (!PrepareSqlReplicationConfig(cfg, sqlReplicationConfigDocument.Key, replicationStats, sqlReplicationConnections))

--- a/Raven.Database/DocumentConflictResolver.cs
+++ b/Raven.Database/DocumentConflictResolver.cs
@@ -30,7 +30,7 @@ namespace Raven.Database
             var conflicts = actions
                 .Documents
                 .GetDocumentsWithIdStartingWith(document.Key, 0, int.MaxValue, null)
-                .Where(x => x.Key.Contains("/conflicts/"))
+                .Where(x => x != null && x.Key.Contains("/conflicts/"))
                 .ToList();
 
             KeyValuePair<JsonDocument, DateTime> local;

--- a/Raven.Database/Raft/Storage/ClusterStateMachine.cs
+++ b/Raven.Database/Raft/Storage/ClusterStateMachine.cs
@@ -159,6 +159,10 @@ namespace Raven.Database.Raft.Storage
             var databaseDocuments = accessor.Documents.GetDocumentsWithIdStartingWith(Constants.Database.Prefix, 0, int.MaxValue, null);
             foreach (var dbDoc in databaseDocuments)
             {
+                if (dbDoc == null)
+                {
+                    continue;
+                }
                 jsonTextWriter.WritePropertyName(dbDoc.Key);
                 dbDoc.ToJson().WriteTo(jsonTextWriter);
             }

--- a/Raven.Database/Server/Controllers/StudioTasksController.cs
+++ b/Raven.Database/Server/Controllers/StudioTasksController.cs
@@ -438,6 +438,10 @@ for(var customFunction in customFunctions) {{
 
                     foreach (var document in documents)
                     {
+                        if (document == null)
+                        {
+                            continue;
+                        }
                         document.DataAsJson["Disabled"] = disable;
                         actions.Documents.AddDocument(document.Key, document.Etag, document.DataAsJson, document.Metadata);
                     }
@@ -800,7 +804,7 @@ for(var customFunction in customFunctions) {{
                             var conflicts = accessor
                                 .Documents
                                 .GetDocumentsWithIdStartingWith(documentId, 0, int.MaxValue, null)
-                                .Where(x => x.Key.Contains("/conflicts/"))
+                                .Where(x => x != null && x.Key.Contains("/conflicts/"))
                                 .ToList();
 
                             KeyValuePair<JsonDocument, DateTime> local;

--- a/Raven.Database/Storage/Esent/StorageActions/Documents.cs
+++ b/Raven.Database/Storage/Esent/StorageActions/Documents.cs
@@ -634,7 +634,7 @@ namespace Raven.Database.Storage.Esent.StorageActions
                 if (keyFromDb.StartsWith(idPrefix, StringComparison.OrdinalIgnoreCase) == false)
                 {
                     if (StartsWithIgnoreCaseAndSymbols(keyFromDb, idPrefix))
-                        continue;
+                        yield return null;
                     yield break;
                 }
 

--- a/Raven.SlowTests/Issues/RavenDB_11764.cs
+++ b/Raven.SlowTests/Issues/RavenDB_11764.cs
@@ -1,0 +1,81 @@
+﻿using System.Collections.Generic;
+using System.Linq;
+using System.Threading;
+using Raven.Client;
+using Raven.Client.Document;
+using Raven.Json.Linq;
+using Raven.Tests.Helpers;
+using Xunit;
+
+namespace Raven.Tests.Issues
+{
+    public class RavenDB_11764 : RavenTestBase
+    {
+        [Fact]
+        public void GetDocumentsWithIdStartingWith_WhenFilteringLeadThePageDocumentsCollectingToEndInTheMiddleOfUnfilteredPage_NextStartShouldBeOneAfterTheLastDocument()
+        {
+            const int pageSize = 5;
+            const int documentAmount = pageSize + 2;
+
+            using (var documentStore = NewDocumentStore())
+            {
+                for (var i = 0; i < documentAmount; i++)
+                {
+                    documentStore.SystemDatabase.Documents.Put("FooBar" + i, null, new RavenJObject(), new RavenJObject(), null);
+                }
+                
+                var nextStart = 0;
+                var documents = documentStore.SystemDatabase.Documents;
+                documents.GetDocumentsWithIdStartingWith("FooBar", string.Empty, "1*", 0, pageSize, CancellationToken.None, ref nextStart);
+
+                Assert.Equal(6, nextStart);
+            }
+        }
+
+        [Fact]
+        public void LoadStartingWithAndIsLastPage_WhenFilteringLeadThePageDocumentsCollectingToEndInTheMiddleOfUnfilteredPageAndRepeatUntilLastPage_ShouldLoadAllMatches()
+        {
+            const int pageSize = 5;
+            const int expected = pageSize + 1;
+
+            using (var store = NewDocumentStore())
+            using (var session = store.OpenSession())
+            {
+                session.Store(new Employee { Id = "Employee/" + "A", Name = "Bob" });
+                for (var i = 0; i < expected; i++)
+                {
+                    session.Store(new Employee { Id = "Employee/" + "B" + i, Name = "Bob" });
+                }
+                session.SaveChanges();
+
+                var start = 0;
+                var allDocuments = new List<Employee>();
+                var pagingInformation = new RavenPagingInformation();
+
+                do
+                {
+                    IEnumerable<Employee> documents = session.Advanced.LoadStartingWith<Employee>(
+                        keyPrefix: "Employee/",
+                        matches: "B*",
+                        start: start,
+                        pageSize: pageSize,
+                        pagingInformation: pagingInformation
+                    );
+
+                    allDocuments.AddRange(documents);
+                    start += pageSize;
+                }
+                while (pagingInformation.IsLastPage() == false);
+
+                Assert.Equal(expected, allDocuments.Count); 
+            }
+        }
+
+        private class Employee
+        {
+            public string Id { get; set; }
+
+            public string Name { get; set; }
+        }
+    }
+}

--- a/Raven.SlowTests/Raven.SlowTests.csproj
+++ b/Raven.SlowTests/Raven.SlowTests.csproj
@@ -120,6 +120,7 @@
     <Compile Include="Issues\RavenDB-5584.cs" />
     <Compile Include="Issues\RavenDB-6363.cs" />
     <Compile Include="Issues\RavenDB_1033.cs" />
+    <Compile Include="Issues\RavenDB_11764.cs" />
     <Compile Include="Issues\RavenDB_1280.cs" />
     <Compile Include="Issues\RavenDB_1280_ReOpen.cs" />
     <Compile Include="Issues\RavenDB_1359 .cs" />


### PR DESCRIPTION
http://issues.hibernatingrhinos.com/issue/RavenDB-11764

`GetDocumentsWithIdStartingWith` modified to return `nextStart` also in the middle of the unfiltered page if there is the last document of filtered page and client modified to recognize the last page according to it