### PR TITLE
RavenDB-11897 Fixing the regex used for parsing delete behavior funct…

### DIFF
--- a/src/Raven.Client/Documents/Operations/ETL/Transformation.cs
+++ b/src/Raven.Client/Documents/Operations/ETL/Transformation.cs
@@ -34,13 +34,15 @@ namespace Raven.Client.Documents.Operations.ETL
         private static readonly Regex LoadCounterMethodRegex = new Regex(LoadCounter, RegexOptions.Compiled);
         private static readonly Regex AddCounterMethodRegex = new Regex(AddCounter, RegexOptions.Compiled);
 
-        internal static readonly Regex LoadCountersBehaviorMethodRegex = new Regex(@"function\s+loadCountersOf(\w+)Behavior\s*\(.+?\}", RegexOptions.Singleline);
-        internal static readonly Regex LoadCountersBehaviorMethodNameRegex = new Regex(@"loadCountersOf(\w+)Behavior", RegexOptions.Singleline);
+        internal static readonly Regex LoadCountersBehaviorMethodRegex = new Regex(@"function\s+loadCountersOf(\w+)Behavior\s*\(.+\)", RegexOptions.Compiled);
+        internal static readonly Regex LoadCountersBehaviorMethodNameRegex = new Regex(@"loadCountersOf(\w+)Behavior", RegexOptions.Compiled);
 
-        internal static readonly Regex DeleteDocumentsBehaviorMethodRegex = new Regex(@"function\s+deleteDocumentsOf(\w+)Behavior\s*\(.+?\}", RegexOptions.Singleline);
-        internal static readonly Regex DeleteDocumentsBehaviorMethodNameRegex = new Regex(@"deleteDocumentsOf(\w+)Behavior", RegexOptions.Singleline);
+        private const string ParametersAndFunctionBodyRegex = @"\s*\((?:[^)(]+|\((?:[^)(]+|\([^)(]*\))*\))*\)\s*\{(?:[^}{]+|\{(?:[^}{]+|\{[^}{]*\})*\})*\}"; // https://stackoverflow.com/questions/4204136/does-anyone-have-regular-expression-match-javascript-function
 
-        internal static readonly Regex GenericDeleteDocumentsBehaviorMethodRegex = new Regex(@"function\s+" + GenericDeleteDocumentsBehaviorFunctionName + @"\(.+?\}", RegexOptions.Singleline);
+        internal static readonly Regex DeleteDocumentsBehaviorMethodRegex = new Regex(@"function\s+deleteDocumentsOf(\w+)Behavior" + ParametersAndFunctionBodyRegex, RegexOptions.Singleline);
+        internal static readonly Regex DeleteDocumentsBehaviorMethodNameRegex = new Regex(@"deleteDocumentsOf(\w+)Behavior", RegexOptions.Compiled);
+        
+        internal static readonly Regex GenericDeleteDocumentsBehaviorMethodRegex = new Regex(@"function\s+" + GenericDeleteDocumentsBehaviorFunctionName + ParametersAndFunctionBodyRegex, RegexOptions.Singleline);
 
         private static readonly Regex Legacy_ReplicateToMethodRegex = new Regex(@"replicateTo(\w+)", RegexOptions.Compiled);
 
@@ -126,10 +128,10 @@ namespace Raven.Client.Documents.Operations.ETL
                                     "loadCountersOf<CollectionName>Behavior(docId, counterName) and return 'true' if counter should be loaded to a destination");
                             }
 
-                            var function = counterBehaviorFunction.Groups[0].Value;
+                            var functionSignature = counterBehaviorFunction.Groups[0].Value;
                             var collection = counterBehaviorFunction.Groups[1].Value;
 
-                            var functionName = LoadCountersBehaviorMethodNameRegex.Match(function);
+                            var functionName = LoadCountersBehaviorMethodNameRegex.Match(functionSignature);
 
                             if (Collections.Contains(collection) == false)
                             {

--- a/test/SlowTests/Server/Documents/ETL/RavenDB_11891.cs
+++ b/test/SlowTests/Server/Documents/ETL/RavenDB_11891.cs
@@ -107,14 +107,8 @@ namespace SlowTests.Server.Documents.ETL
             }
         }
 
-        [Fact]
-        public void Should_choose_more_specific_delete_behavior_function()
-        {
-            using (var src = GetDocumentStore())
-            using (var dest = GetDocumentStore())
-            {
-                AddEtl(src, dest, collections: new[] { "Users", "Employees" }, script:
-                    @"
+        [Theory]
+        [InlineData(@"
     loadToUsers(this);
 
     function deleteDocumentsBehavior(docId, collection) {
@@ -125,7 +119,30 @@ namespace SlowTests.Server.Documents.ETL
     function deleteDocumentsOfEmployeesBehavior(docId) {
         return true;
     }
-");
+")]
+        [InlineData(@"
+    loadToUsers(this);
+
+    function deleteDocumentsBehavior(docId, collection) {
+        
+       if (true)
+       {   
+          return false;
+       }
+
+       return true;
+    }
+
+    function deleteDocumentsOfEmployeesBehavior(docId) {
+        return true;
+    }
+")]
+        public void Should_choose_more_specific_delete_behavior_function(string script)
+        {
+            using (var src = GetDocumentStore())
+            using (var dest = GetDocumentStore())
+            {
+                AddEtl(src, dest, collections: new[] { "Users", "Employees" }, script: script);
 
                 var etlDone = WaitForEtl(src, (n, s) => s.LoadSuccesses > 0);
 


### PR DESCRIPTION
…ions. Now we are able to properly detect that ETL transformation is actually empty and so we'll send docs without modifications.