### PR TITLE
RavenDB-11923 Reverting recent change which caused that temp files of…

### DIFF
--- a/src/Raven.Server/Documents/Indexes/Configuration/SingleIndexConfiguration.cs
+++ b/src/Raven.Server/Documents/Indexes/Configuration/SingleIndexConfiguration.cs
@@ -29,7 +29,7 @@ namespace Raven.Server.Documents.Indexes.Configuration
 
         public override bool RunInMemory => _databaseConfiguration.Indexing.RunInMemory;
 
-        public override PathSetting TempPath => _databaseConfiguration.Indexing.TempPath ?? _databaseConfiguration.Indexing.StoragePath.Combine("Temp");
+        public override PathSetting TempPath => _databaseConfiguration.Indexing.TempPath;
 
         public IndexUpdateType CalculateUpdateType(SingleIndexConfiguration newConfiguration)
         {

--- a/src/Raven.Server/Documents/Indexes/Index.cs
+++ b/src/Raven.Server/Documents/Indexes/Index.cs
@@ -425,7 +425,7 @@ namespace Raven.Server.Documents.Indexes
             var indexTempPath = configuration.TempPath?.Combine(name);
 
             var options = configuration.RunInMemory
-                ? StorageEnvironmentOptions.CreateMemoryOnly(indexPath.FullPath, indexTempPath?.FullPath,
+                ? StorageEnvironmentOptions.CreateMemoryOnly(indexPath.FullPath, indexTempPath?.FullPath ?? Path.Combine(indexPath.FullPath, "Temp"),
                     documentDatabase.IoChanges, documentDatabase.CatastrophicFailureNotification)
                 : StorageEnvironmentOptions.ForPath(indexPath.FullPath, indexTempPath?.FullPath, null,
                     documentDatabase.IoChanges, documentDatabase.CatastrophicFailureNotification);

--- a/test/FastTests/Server/Documents/Indexing/Auto/BasicAutoMapIndexing.cs
+++ b/test/FastTests/Server/Documents/Indexing/Auto/BasicAutoMapIndexing.cs
@@ -172,7 +172,8 @@ namespace FastTests.Server.Documents.Indexing.Auto
 
             await database.IndexStore.DeleteIndex(index1.Name);
 
-            Assert.True(SpinWait.SpinUntil(() => Directory.Exists(path1) == false, TimeSpan.FromSeconds(5)));
+            if (index1.Configuration.RunInMemory == false)
+                Assert.True(SpinWait.SpinUntil(() => Directory.Exists(path1) == false, TimeSpan.FromSeconds(5)));
 
             var indexes = database.IndexStore.GetIndexesForCollection("Users").ToList();
 
@@ -180,7 +181,8 @@ namespace FastTests.Server.Documents.Indexing.Auto
 
             await database.IndexStore.DeleteIndex(index2.Name);
 
-            Assert.True(SpinWait.SpinUntil(() => Directory.Exists(path2) == false, TimeSpan.FromSeconds(5)));
+            if (index1.Configuration.RunInMemory == false)
+                Assert.True(SpinWait.SpinUntil(() => Directory.Exists(path2) == false, TimeSpan.FromSeconds(5)));
 
             indexes = database.IndexStore.GetIndexesForCollection("Users").ToList();
 


### PR DESCRIPTION
… indexes were put in Indexes\Temp\{index-name} instead of Indexes\{index-name}\Temp