### PR TITLE
RavenDB-12009 SQL ETL: Open the connection to SQL db only if we have …

### DIFF
--- a/src/Raven.Server/Documents/ETL/EtlProcess.cs
+++ b/src/Raven.Server/Documents/ETL/EtlProcess.cs
@@ -576,7 +576,9 @@ namespace Raven.Server.Documents.ETL
                                             transformations.AddRange(transformed);
                                     }
 
-                                    Load(transformations, context, stats);
+                                    if (transformations.Count > 0)
+                                        Load(transformations, context, stats);
+
                                     var lastProcessed = Math.Max(stats.LastLoadedEtag, stats.LastFilteredOutEtags.Values.Max());
 
                                     if (lastProcessed > Statistics.LastProcessedEtag)

--- a/src/Raven.Server/Documents/ETL/Providers/SQL/SqlDocumentTransformer.cs
+++ b/src/Raven.Server/Documents/ETL/Providers/SQL/SqlDocumentTransformer.cs
@@ -142,11 +142,21 @@ namespace Raven.Server.Documents.ETL.Providers.SQL
         {
             if (_tables.TryGetValue(tableName, out SqlTableWithRecords table) == false)
             {
+                var sqlEtlTable = _config.SqlTables.Find(x => x.TableName.Equals(tableName, StringComparison.OrdinalIgnoreCase));
+
+                if (sqlEtlTable == null)
+                    ThrowTableNotDefinedInConfig(tableName);
+
                 _tables[tableName] =
-                    table = new SqlTableWithRecords(_config.SqlTables.Find(x => x.TableName.Equals(tableName, StringComparison.OrdinalIgnoreCase)));
+                    table = new SqlTableWithRecords(sqlEtlTable);
             }
 
             return table;
+        }
+
+        private static void ThrowTableNotDefinedInConfig(string tableName)
+        {
+            throw new InvalidOperationException($"Table '{tableName}' was not defined in the configuration of SQL ETL task");
         }
 
         public override List<SqlTableWithRecords> GetTransformedResults()


### PR DESCRIPTION
…items to replicate. Actually don't even try to initiate the load phase if we didn't transform anything. Better error message when using table in the script which was not defined in the configuration.