### PR TITLE
RavenDB-12019_v4.1: Using 'group by' when querying on an Index throws exception now.

### DIFF
--- a/src/Raven.Server/Documents/Queries/IndexQueryServerSide.cs
+++ b/src/Raven.Server/Documents/Queries/IndexQueryServerSide.cs
@@ -112,8 +112,6 @@ namespace Raven.Server.Documents.Queries
             }
 
             result.Metadata = new QueryMetadata(result.Query, null, 0);
-            if (result.Metadata.IndexName != null && result.Metadata.IsGroupBy)
-                throw new ArgumentException("Can't use 'group by' when querying on an Index. 'group by' can be used only when querying on collections.");
 
             if (result.Metadata.HasTimings)
                 result.Timings = new QueryTimingsScope(start: false);

--- a/src/Raven.Server/Documents/Queries/IndexQueryServerSide.cs
+++ b/src/Raven.Server/Documents/Queries/IndexQueryServerSide.cs
@@ -112,6 +112,9 @@ namespace Raven.Server.Documents.Queries
             }
 
             result.Metadata = new QueryMetadata(result.Query, null, 0);
+            if (result.Metadata.IndexName != null && result.Metadata.IsGroupBy)
+                throw new ArgumentException("Can't use 'group by' when querying on an Index. 'group by' can be used only when querying on collections.");
+
             if (result.Metadata.HasTimings)
                 result.Timings = new QueryTimingsScope(start: false);
             return result;

--- a/src/Raven.Server/Documents/Queries/QueryMetadata.cs
+++ b/src/Raven.Server/Documents/Queries/QueryMetadata.cs
@@ -56,7 +56,7 @@ namespace Raven.Server.Documents.Queries
             if (IsDynamic == false || IsGroupBy)
                 IsCollectionQuery = false;
 
-            if (IsGroupBy && IsCollectionQuery == false)
+            if (IsGroupBy && IsDynamic == false)
                 throw new ArgumentException("Can't use 'group by' when querying on an Index. 'group by' can be used only when querying on collections.");
 
             DeclaredFunctions = Query.DeclaredFunctions;

--- a/src/Raven.Server/Documents/Queries/QueryMetadata.cs
+++ b/src/Raven.Server/Documents/Queries/QueryMetadata.cs
@@ -56,6 +56,9 @@ namespace Raven.Server.Documents.Queries
             if (IsDynamic == false || IsGroupBy)
                 IsCollectionQuery = false;
 
+            if (IsGroupBy && IsCollectionQuery == false)
+                throw new ArgumentException("Can't use 'group by' when querying on an Index. 'group by' can be used only when querying on collections.");
+
             DeclaredFunctions = Query.DeclaredFunctions;
 
             Build(parameters);


### PR DESCRIPTION
WIP DONT MERGE