### PR TITLE
RavenDB-12025 High CPU usage in idle state

### DIFF
--- a/src/Raven.Client/ServerWide/Tcp/TcpConnectionHeader.cs
+++ b/src/Raven.Client/ServerWide/Tcp/TcpConnectionHeader.cs
@@ -13,7 +13,7 @@ namespace Raven.Client.ServerWide.Tcp
             Subscription,
             Replication,
             Cluster,
-            Heartbeats,
+            Maintenance,
             Ping,
             TestConnection
         }
@@ -32,7 +32,8 @@ namespace Raven.Client.ServerWide.Tcp
         public static readonly int NoneBaseLine = -1;
         public static readonly int DropBaseLine = -2;
         public static readonly int ClusterBaseLine = 10;
-        public static readonly int HeartbeatsBaseLine = 20;
+        public static readonly int MaintenanceBaseLine = 20;
+        public static readonly int Maintenance41200 = 41_200;
         public static readonly int ReplicationBaseLine = 31;
         public static readonly int ReplicationAttachmentMissing = 40_300;
         public static readonly int ReplicationAttachmentMissingVersion41 = 41_300;
@@ -40,7 +41,7 @@ namespace Raven.Client.ServerWide.Tcp
         public static readonly int TestConnectionBaseLine = 50;
 
         public static readonly int ClusterTcpVersion = ClusterBaseLine;
-        public static readonly int HeartbeatsTcpVersion = HeartbeatsBaseLine;
+        public static readonly int MaintenanceTcpVersion = Maintenance41200;
         public static readonly int ReplicationTcpVersion = ReplicationAttachmentMissingVersion41;
         public static readonly int SubscriptionTcpVersion = SubscriptionBaseLine;
         public static readonly int TestConnectionTcpVersion = TestConnectionBaseLine;
@@ -52,7 +53,7 @@ namespace Raven.Client.ServerWide.Tcp
             {
                 OperationTypes.Cluster,
                 OperationTypes.Drop,
-                OperationTypes.Heartbeats,
+                OperationTypes.Maintenance,
                 OperationTypes.None,
                 OperationTypes.Ping,
                 OperationTypes.Replication,
@@ -102,10 +103,10 @@ namespace Raven.Client.ServerWide.Tcp
                         if (features[ClusterTcpVersion] == null)
                             throw new ArgumentException();
                         break;
-                    case OperationTypes.Heartbeats:
-                        if (version != HeartbeatsTcpVersion)
+                    case OperationTypes.Maintenance:
+                        if (version != MaintenanceTcpVersion)
                             throw new ArgumentException();
-                        if (features[HeartbeatsTcpVersion] == null)
+                        if (features[MaintenanceTcpVersion] == null)
                             throw new ArgumentException();
                         break;
                     case OperationTypes.Ping:
@@ -140,7 +141,7 @@ namespace Raven.Client.ServerWide.Tcp
             public DropFeatures Drop { get; set; }
             public SubscriptionFeatures Subscription { get; set; }
             public ClusterFeatures Cluster { get; set; }
-            public HeartbeatsFeatures Heartbeats { get; set; }
+            public MaintenanceFeatures Maintenance { get; set; }
             public TestConnectionFeatures TestConnection { get; set; }
             public ReplicationFeatures Replication { get; set; }
 
@@ -164,9 +165,10 @@ namespace Raven.Client.ServerWide.Tcp
             {
                 public bool BaseLine = true;
             }
-            public class HeartbeatsFeatures
+            public class MaintenanceFeatures
             {
                 public bool BaseLine = true;
+                public bool SendChangesOnly;
             }
             public class TestConnectionFeatures
             {
@@ -210,9 +212,10 @@ namespace Raven.Client.ServerWide.Tcp
                 {
                     ClusterBaseLine
                 },
-                [OperationTypes.Heartbeats] = new List<int>
+                [OperationTypes.Maintenance] = new List<int>
                 {
-                    HeartbeatsBaseLine
+                    Maintenance41200,
+                    MaintenanceBaseLine
                 },
                 [OperationTypes.TestConnection] = new List<int>
                 {
@@ -282,11 +285,18 @@ namespace Raven.Client.ServerWide.Tcp
                         Cluster = new SupportedFeatures.ClusterFeatures()
                     }
                 },
-                [OperationTypes.Heartbeats] = new Dictionary<int, SupportedFeatures>
+                [OperationTypes.Maintenance] = new Dictionary<int, SupportedFeatures>
                 {
-                    [HeartbeatsBaseLine] = new SupportedFeatures(HeartbeatsBaseLine)
+                    [Maintenance41200] = new SupportedFeatures(Maintenance41200)
                     {
-                        Heartbeats = new SupportedFeatures.HeartbeatsFeatures()
+                        Maintenance = new SupportedFeatures.MaintenanceFeatures
+                        {
+                            SendChangesOnly = true
+                        }
+                    },
+                    [MaintenanceBaseLine] = new SupportedFeatures(MaintenanceBaseLine)
+                    {
+                        Maintenance = new SupportedFeatures.MaintenanceFeatures()
                     }
                 },
                 [OperationTypes.TestConnection] = new Dictionary<int, SupportedFeatures>
@@ -341,7 +351,7 @@ namespace Raven.Client.ServerWide.Tcp
                 case OperationTypes.Subscription:
                 case OperationTypes.Replication:
                 case OperationTypes.Cluster:
-                case OperationTypes.Heartbeats:
+                case OperationTypes.Maintenance:
                 case OperationTypes.TestConnection:
                     return OperationsToSupportedProtocolVersions[operationType][index];
                 default:

--- a/src/Raven.Client/ServerWide/Tcp/TcpConnectionHeader.cs
+++ b/src/Raven.Client/ServerWide/Tcp/TcpConnectionHeader.cs
@@ -13,7 +13,7 @@ namespace Raven.Client.ServerWide.Tcp
             Subscription,
             Replication,
             Cluster,
-            Maintenance,
+            Heartbeats,
             Ping,
             TestConnection
         }
@@ -32,8 +32,8 @@ namespace Raven.Client.ServerWide.Tcp
         public static readonly int NoneBaseLine = -1;
         public static readonly int DropBaseLine = -2;
         public static readonly int ClusterBaseLine = 10;
-        public static readonly int MaintenanceBaseLine = 20;
-        public static readonly int Maintenance41200 = 41_200;
+        public static readonly int HeartbeatsBaseLine = 20;
+        public static readonly int Heartbeats41200 = 41_200;
         public static readonly int ReplicationBaseLine = 31;
         public static readonly int ReplicationAttachmentMissing = 40_300;
         public static readonly int ReplicationAttachmentMissingVersion41 = 41_300;
@@ -41,7 +41,7 @@ namespace Raven.Client.ServerWide.Tcp
         public static readonly int TestConnectionBaseLine = 50;
 
         public static readonly int ClusterTcpVersion = ClusterBaseLine;
-        public static readonly int MaintenanceTcpVersion = Maintenance41200;
+        public static readonly int HeartbeatsTcpVersion = Heartbeats41200;
         public static readonly int ReplicationTcpVersion = ReplicationAttachmentMissingVersion41;
         public static readonly int SubscriptionTcpVersion = SubscriptionBaseLine;
         public static readonly int TestConnectionTcpVersion = TestConnectionBaseLine;
@@ -53,7 +53,7 @@ namespace Raven.Client.ServerWide.Tcp
             {
                 OperationTypes.Cluster,
                 OperationTypes.Drop,
-                OperationTypes.Maintenance,
+                OperationTypes.Heartbeats,
                 OperationTypes.None,
                 OperationTypes.Ping,
                 OperationTypes.Replication,
@@ -103,10 +103,10 @@ namespace Raven.Client.ServerWide.Tcp
                         if (features[ClusterTcpVersion] == null)
                             throw new ArgumentException();
                         break;
-                    case OperationTypes.Maintenance:
-                        if (version != MaintenanceTcpVersion)
+                    case OperationTypes.Heartbeats:
+                        if (version != HeartbeatsTcpVersion)
                             throw new ArgumentException();
-                        if (features[MaintenanceTcpVersion] == null)
+                        if (features[HeartbeatsTcpVersion] == null)
                             throw new ArgumentException();
                         break;
                     case OperationTypes.Ping:
@@ -141,7 +141,7 @@ namespace Raven.Client.ServerWide.Tcp
             public DropFeatures Drop { get; set; }
             public SubscriptionFeatures Subscription { get; set; }
             public ClusterFeatures Cluster { get; set; }
-            public MaintenanceFeatures Maintenance { get; set; }
+            public HeartbeatsFeatures Heartbeats { get; set; }
             public TestConnectionFeatures TestConnection { get; set; }
             public ReplicationFeatures Replication { get; set; }
 
@@ -165,7 +165,7 @@ namespace Raven.Client.ServerWide.Tcp
             {
                 public bool BaseLine = true;
             }
-            public class MaintenanceFeatures
+            public class HeartbeatsFeatures
             {
                 public bool BaseLine = true;
                 public bool SendChangesOnly;
@@ -212,10 +212,10 @@ namespace Raven.Client.ServerWide.Tcp
                 {
                     ClusterBaseLine
                 },
-                [OperationTypes.Maintenance] = new List<int>
+                [OperationTypes.Heartbeats] = new List<int>
                 {
-                    Maintenance41200,
-                    MaintenanceBaseLine
+                    Heartbeats41200,
+                    HeartbeatsBaseLine
                 },
                 [OperationTypes.TestConnection] = new List<int>
                 {
@@ -285,18 +285,18 @@ namespace Raven.Client.ServerWide.Tcp
                         Cluster = new SupportedFeatures.ClusterFeatures()
                     }
                 },
-                [OperationTypes.Maintenance] = new Dictionary<int, SupportedFeatures>
+                [OperationTypes.Heartbeats] = new Dictionary<int, SupportedFeatures>
                 {
-                    [Maintenance41200] = new SupportedFeatures(Maintenance41200)
+                    [Heartbeats41200] = new SupportedFeatures(Heartbeats41200)
                     {
-                        Maintenance = new SupportedFeatures.MaintenanceFeatures
+                        Heartbeats = new SupportedFeatures.HeartbeatsFeatures
                         {
                             SendChangesOnly = true
                         }
                     },
-                    [MaintenanceBaseLine] = new SupportedFeatures(MaintenanceBaseLine)
+                    [HeartbeatsBaseLine] = new SupportedFeatures(HeartbeatsBaseLine)
                     {
-                        Maintenance = new SupportedFeatures.MaintenanceFeatures()
+                        Heartbeats = new SupportedFeatures.HeartbeatsFeatures()
                     }
                 },
                 [OperationTypes.TestConnection] = new Dictionary<int, SupportedFeatures>
@@ -351,7 +351,7 @@ namespace Raven.Client.ServerWide.Tcp
                 case OperationTypes.Subscription:
                 case OperationTypes.Replication:
                 case OperationTypes.Cluster:
-                case OperationTypes.Maintenance:
+                case OperationTypes.Heartbeats:
                 case OperationTypes.TestConnection:
                     return OperationsToSupportedProtocolVersions[operationType][index];
                 default:

--- a/src/Raven.Server/Documents/Indexes/Index.cs
+++ b/src/Raven.Server/Documents/Indexes/Index.cs
@@ -187,6 +187,8 @@ namespace Raven.Server.Documents.Indexes
 
         private static readonly Size DefaultMaximumMemoryAllocation = new Size(32, SizeUnit.Megabytes);
 
+        public long LastTransactionId => _environment.CurrentReadTransactionId;
+
         protected Index(IndexType type, IndexDefinitionBase definition)
         {
             Type = type;

--- a/src/Raven.Server/Documents/Replication/OutgoingReplicationHandler.cs
+++ b/src/Raven.Server/Documents/Replication/OutgoingReplicationHandler.cs
@@ -465,17 +465,10 @@ namespace Raven.Server.Documents.Replication
 
         private void AddAlertOnFailureToReachOtherSide(string msg, Exception e)
         {
-            using (_database.ConfigurationStorage.ContextPool.AllocateOperationContext(out TransactionOperationContext configurationContext))
-            using (var txw = configurationContext.OpenWriteTransaction())
-            {
-                _database.NotificationCenter.AddAfterTransactionCommit(
-                    AlertRaised.Create(
-                        _database.Name, 
-                        AlertTitle, msg, AlertType.Replication, NotificationSeverity.Warning, key: FromToString, details: new ExceptionDetails(e)),
-                    txw);
-
-                txw.Commit();
-            }
+            _database.NotificationCenter.Add(
+                AlertRaised.Create(
+                    _database.Name,
+                    AlertTitle, msg, AlertType.Replication, NotificationSeverity.Warning, key: FromToString, details: new ExceptionDetails(e)));
         }
 
         private void WriteHeaderToRemotePeer()

--- a/src/Raven.Server/NotificationCenter/NotificationCenter.cs
+++ b/src/Raven.Server/NotificationCenter/NotificationCenter.cs
@@ -103,19 +103,6 @@ namespace Raven.Server.NotificationCenter
             }
         }
 
-        public void AddAfterTransactionCommit(Notification notification, RavenTransaction tx)
-        {
-            var llt = tx.InnerTransaction.LowLevelTransaction;
-
-            llt.OnDispose += _ =>
-            {
-                if (llt.Committed == false)
-                    return;
-
-                Add(notification);
-            };
-        }
-
         public IDisposable GetStored(out IEnumerable<NotificationTableValue> actions, bool postponed = true)
         {
             var scope = _notificationsStorage.ReadActionsOrderedByCreationDate(out actions);

--- a/src/Raven.Server/RavenServer.cs
+++ b/src/Raven.Server/RavenServer.cs
@@ -1396,7 +1396,7 @@ namespace Raven.Server
                 return true;
             }
 
-            if (tcp.Operation == TcpConnectionHeaderMessage.OperationTypes.Heartbeats)
+            if (tcp.Operation == TcpConnectionHeaderMessage.OperationTypes.Maintenance)
             {
                 // check for the term          
                 using (_tcpContextPool.AllocateOperationContext(out JsonOperationContext context))
@@ -1541,7 +1541,7 @@ namespace Raven.Server
                     switch (header.Operation)
                     {
                         case TcpConnectionHeaderMessage.OperationTypes.Cluster:
-                        case TcpConnectionHeaderMessage.OperationTypes.Heartbeats:
+                        case TcpConnectionHeaderMessage.OperationTypes.Maintenance:
                             msg = header.Operation + " is a server wide operation and the certificate " + certificate.FriendlyName + "is not ClusterAdmin/Operator";
                             return false;
                         case TcpConnectionHeaderMessage.OperationTypes.Subscription:

--- a/src/Raven.Server/RavenServer.cs
+++ b/src/Raven.Server/RavenServer.cs
@@ -1396,7 +1396,7 @@ namespace Raven.Server
                 return true;
             }
 
-            if (tcp.Operation == TcpConnectionHeaderMessage.OperationTypes.Maintenance)
+            if (tcp.Operation == TcpConnectionHeaderMessage.OperationTypes.Heartbeats)
             {
                 // check for the term          
                 using (_tcpContextPool.AllocateOperationContext(out JsonOperationContext context))
@@ -1541,7 +1541,7 @@ namespace Raven.Server
                     switch (header.Operation)
                     {
                         case TcpConnectionHeaderMessage.OperationTypes.Cluster:
-                        case TcpConnectionHeaderMessage.OperationTypes.Maintenance:
+                        case TcpConnectionHeaderMessage.OperationTypes.Heartbeats:
                             msg = header.Operation + " is a server wide operation and the certificate " + certificate.FriendlyName + "is not ClusterAdmin/Operator";
                             return false;
                         case TcpConnectionHeaderMessage.OperationTypes.Subscription:

--- a/src/Raven.Server/ServerWide/JsonDeserializationCluster.cs
+++ b/src/Raven.Server/ServerWide/JsonDeserializationCluster.cs
@@ -39,6 +39,8 @@ namespace Raven.Server.ServerWide
 
         public static readonly Func<BlittableJsonReaderObject, DatabaseRecord> DatabaseRecord = GenerateJsonDeserializationRoutine<DatabaseRecord>();
 
+        public static readonly Func<BlittableJsonReaderObject, DatabaseTopology> DatabaseTopology = GenerateJsonDeserializationRoutine<DatabaseTopology>();
+
         public static readonly Func<BlittableJsonReaderObject, RemoveNodeFromDatabaseCommand> RemoveNodeFromDatabaseCommand = GenerateJsonDeserializationRoutine<RemoveNodeFromDatabaseCommand>();
 
         public static readonly Func<BlittableJsonReaderObject, RemoveNodeFromClusterCommand> RemoveNodeFromClusterCommand = GenerateJsonDeserializationRoutine<RemoveNodeFromClusterCommand>();

--- a/src/Raven.Server/ServerWide/Maintenance/ClusterMaintenanceSupervisor.cs
+++ b/src/Raven.Server/ServerWide/Maintenance/ClusterMaintenanceSupervisor.cs
@@ -251,9 +251,9 @@ namespace Raven.Server.ServerWide.Maintenance
 
                                 var nodeReport = BuildReport(rawReport);
                                 timeoutEvent.Defer(_parent._leaderClusterTag);
-
-                                unchangedReports.Clear();
+                                
                                 UpdateNodeReportIfNeeded(nodeReport, unchangedReports);
+                                unchangedReports.Clear();
 
                                 ReceivedReport = _lastSuccessfulReceivedReport = nodeReport;
                             }
@@ -291,9 +291,16 @@ namespace Raven.Server.ServerWide.Maintenance
                 foreach (var dbReport in unchangedReports)
                 {
                     var dbName = dbReport.Name;
-                    nodeReport.Report[dbName] = _lastSuccessfulReceivedReport.Report[dbName];
-                    nodeReport.Report[dbName].LastSentEtag = dbReport.LastSentEtag;
-                    nodeReport.Report[dbName].UpTime = dbReport.UpTime;
+                    if(_lastSuccessfulReceivedReport.TryGetValue(name, out var previous) == false)
+                    {
+                        // new db, shouldn't really be the case, but not much we can do, we'll
+                        // show it to the user as is
+                        continue;
+                    }
+                    previous.LastSentEtag = dbReport.LastSentEtag;
+                    previous.UpTime = dbReport.UpTime;
+                    
+                    nodeReport.Report[dbName] = previous;
                 }
             }
 

--- a/src/Raven.Server/ServerWide/Maintenance/ClusterMaintenanceSupervisor.cs
+++ b/src/Raven.Server/ServerWide/Maintenance/ClusterMaintenanceSupervisor.cs
@@ -291,7 +291,7 @@ namespace Raven.Server.ServerWide.Maintenance
                 foreach (var dbReport in unchangedReports)
                 {
                     var dbName = dbReport.Name;
-                    if(_lastSuccessfulReceivedReport.TryGetValue(name, out var previous) == false)
+                    if(_lastSuccessfulReceivedReport.Report.TryGetValue(dbName, out var previous) == false)
                     {
                         // new db, shouldn't really be the case, but not much we can do, we'll
                         // show it to the user as is

--- a/src/Raven.Server/ServerWide/Maintenance/ClusterMaintenanceSupervisor.cs
+++ b/src/Raven.Server/ServerWide/Maintenance/ClusterMaintenanceSupervisor.cs
@@ -136,7 +136,7 @@ namespace Raven.Server.ServerWide.Maintenance
                 _cts = CancellationTokenSource.CreateLinkedTokenSource(token);
                 _token = _cts.Token;
                 _readStatusUpdateDebugString = $"ClusterMaintenanceServer/{ClusterTag}/UpdateState/Read-Response in term {term}";
-                _name = $"Maintenance supervisor from {_parent._server.NodeTag} to {ClusterTag} in term {term}";
+                _name = $"Heartbeats supervisor from {_parent._server.NodeTag} to {ClusterTag} in term {term}";
                 _log = LoggingSource.Instance.GetLogger<ClusterNode>(_name);
             }
 
@@ -365,8 +365,8 @@ namespace Raven.Server.ServerWide.Maintenance
                     var parameters = new TcpNegotiateParameters
                     {
                         Database = null,
-                        Operation = TcpConnectionHeaderMessage.OperationTypes.Maintenance,
-                        Version = TcpConnectionHeaderMessage.MaintenanceTcpVersion,
+                        Operation = TcpConnectionHeaderMessage.OperationTypes.Heartbeats,
+                        Version = TcpConnectionHeaderMessage.HeartbeatsTcpVersion,
                         ReadResponseAndGetVersionCallback = SupervisorReadResponseAndGetVersion,
                         DestinationUrl = tcpConnectionInfo.Url,
                         DestinationNodeTag = ClusterTag
@@ -413,14 +413,14 @@ namespace Raven.Server.ServerWide.Maintenance
 
             private void WriteOperationHeaderToRemote(BlittableJsonTextWriter writer, int remoteVersion = -1, bool drop = false)
             {
-                var operation = drop ? TcpConnectionHeaderMessage.OperationTypes.Drop : TcpConnectionHeaderMessage.OperationTypes.Maintenance;
+                var operation = drop ? TcpConnectionHeaderMessage.OperationTypes.Drop : TcpConnectionHeaderMessage.OperationTypes.Heartbeats;
                 writer.WriteStartObject();
                 {
                     writer.WritePropertyName(nameof(TcpConnectionHeaderMessage.Operation));
                     writer.WriteString(operation.ToString());
                     writer.WriteComma();
                     writer.WritePropertyName(nameof(TcpConnectionHeaderMessage.OperationVersion));
-                    writer.WriteInteger(TcpConnectionHeaderMessage.MaintenanceTcpVersion);
+                    writer.WriteInteger(TcpConnectionHeaderMessage.HeartbeatsTcpVersion);
                     writer.WriteComma();
                     writer.WritePropertyName(nameof(TcpConnectionHeaderMessage.DatabaseName));
                     writer.WriteString((string)null);
@@ -428,7 +428,7 @@ namespace Raven.Server.ServerWide.Maintenance
                     {
                         writer.WriteComma();
                         writer.WritePropertyName(nameof(TcpConnectionHeaderMessage.Info));
-                        writer.WriteString($"Couldn't agree on heartbeats tcp version ours:{TcpConnectionHeaderMessage.MaintenanceTcpVersion} theirs:{remoteVersion}");
+                        writer.WriteString($"Couldn't agree on heartbeats tcp version ours:{TcpConnectionHeaderMessage.HeartbeatsTcpVersion} theirs:{remoteVersion}");
                     }
                 }
                 writer.WriteEndObject();

--- a/src/Raven.Server/ServerWide/Maintenance/ClusterMaintenanceWorker.cs
+++ b/src/Raven.Server/ServerWide/Maintenance/ClusterMaintenanceWorker.cs
@@ -38,11 +38,11 @@ namespace Raven.Server.ServerWide.Maintenance
             _token = _cts.Token;
             _server = serverStore;
             _logger = LoggingSource.Instance.GetLogger<ClusterMaintenanceWorker>(serverStore.NodeTag);
-            _name = $"Maintenance worker connection to leader {leader} in term {term}";
+            _name = $"Heartbeats worker connection to leader {leader} in term {term}";
 
             WorkerSamplePeriod = _server.Configuration.Cluster.WorkerSamplePeriod.AsTimeSpan;
             CurrentTerm = term;
-            SupportedFeatures = TcpConnectionHeaderMessage.GetSupportedFeaturesFor(TcpConnectionHeaderMessage.OperationTypes.Maintenance, _tcp.ProtocolVersion);
+            SupportedFeatures = TcpConnectionHeaderMessage.GetSupportedFeaturesFor(TcpConnectionHeaderMessage.OperationTypes.Heartbeats, _tcp.ProtocolVersion);
         }
 
         public void Start()
@@ -204,7 +204,7 @@ namespace Raven.Server.ServerWide.Maintenance
                     FillReplicationInfo(dbInstance, report);
 
                     prevReport.TryGetValue(dbName, out var prevDatabaseReport);
-                    if (SupportedFeatures.Maintenance.SendChangesOnly && 
+                    if (SupportedFeatures.Heartbeats.SendChangesOnly && 
                         prevDatabaseReport != null && prevDatabaseReport.EnvironmentsHash == currentHash)
                     {
                         report.Status = DatabaseStatus.NoChange;

--- a/src/Raven.Server/ServerWide/Maintenance/ClusterMaintenanceWorker.cs
+++ b/src/Raven.Server/ServerWide/Maintenance/ClusterMaintenanceWorker.cs
@@ -87,13 +87,14 @@ namespace Raven.Server.ServerWide.Maintenance
                         {
                             nodeReport = CollectDatabaseInformation(ctx, lastNodeReport);
                         }
-                        lastNodeReport = nodeReport;
 
                         using (var writer = new BlittableJsonTextWriter(ctx, _tcp.Stream))
                         {
                             ctx.Write(writer, DynamicJsonValue.Convert(nodeReport));
-                         }
-                     }
+                        }
+
+                        lastNodeReport = nodeReport;
+                    }
                 }
                 catch (Exception e)
                 {
@@ -237,6 +238,7 @@ namespace Raven.Server.ServerWide.Maintenance
                 }
                 catch (Exception e)
                 {
+                    report.EnvironmentsHash = 0; // on error we should do the complete report collaction path
                     report.Error = e.ToString();
                 }
 

--- a/src/Raven.Server/ServerWide/Maintenance/ClusterNodeStatusReport.cs
+++ b/src/Raven.Server/ServerWide/Maintenance/ClusterNodeStatusReport.cs
@@ -129,13 +129,14 @@ namespace Raven.Server.ServerWide.Maintenance
                 var dbName = dbReport.Key;
                 var dbStatus = dbReport.Value.Status;
 
-                if (reportStatus != ReportStatus.Ok || dbStatus != DatabaseStatus.Loaded)
-                { 
-                    SetLastDbGoodTime(lastSuccessfulReport, dbName);
+                if (reportStatus == ReportStatus.Ok && 
+                    (dbStatus == DatabaseStatus.Loaded || dbStatus == DatabaseStatus.NoChange))
+                {
+                    LastGoodDatabaseStatus[dbName] = updateDateTime;
                 }
                 else
                 {
-                    LastGoodDatabaseStatus[dbName] = updateDateTime;
+                    SetLastDbGoodTime(lastSuccessfulReport, dbName);
                 }
             }
         }

--- a/src/Raven.Server/ServerWide/Maintenance/ClusterNodeStatusReport.cs
+++ b/src/Raven.Server/ServerWide/Maintenance/ClusterNodeStatusReport.cs
@@ -13,7 +13,8 @@ namespace Raven.Server.ServerWide.Maintenance
         Loading = 2,
         Faulted = 4,
         Unloaded = 8,
-        Shutdown = 16
+        Shutdown = 16,
+        NoChange = 32
     }
 
     public class DatabaseStatusReport : IDynamicJson
@@ -33,6 +34,7 @@ namespace Raven.Server.ServerWide.Maintenance
             public TimeSpan? LastQueried;
             public bool IsStale;
             public IndexState State;
+            public long LastTransactionId; // this is local, so we don't serialize it
         }
 
         public long LastEtag;
@@ -44,6 +46,9 @@ namespace Raven.Server.ServerWide.Maintenance
         public DatabaseStatus Status;
         public string Error;
         public TimeSpan? UpTime;
+
+        public long LastTransactionId; // this is local, so we don't serialize it
+        public long EnvironmentsHash; // this is local, so we don't serialize it
 
         public DynamicJsonValue ToJson()
         {

--- a/test/RachisTests/Cluster.cs
+++ b/test/RachisTests/Cluster.cs
@@ -65,7 +65,7 @@ namespace RachisTests
             var clusterSize = 3;
             var leader = await CreateRaftClusterAndGetLeader(clusterSize);
             var replicationFactor = 2;
-            var databaseName = "test";
+            var databaseName = GetDatabaseName();
             using (var store = new DocumentStore()
             {
                 Urls = new[] { leader.WebUrl },


### PR DESCRIPTION
This was usually the case when we had many indexes and/or databases (several hundreds in total).

- Reduce network traffic by sending an empty report to the supervisor if no changes were made to any of the database's envs.
- Reduce openning of read transactions and disk access when no change was made to a specific index or database.
- Reduce DatabaseRecord deserialization costs when the database is disabled by accessing the blittable directly.
- Bump the maintenance TCP protocol version and rename `Heartbeats` to `Maintenance`.