### PR TITLE
RavenDB-11917 Fix failing test DisableExternalReplication

### DIFF
--- a/src/Raven.Server/Documents/Replication/OutgoingReplicationHandler.cs
+++ b/src/Raven.Server/Documents/Replication/OutgoingReplicationHandler.cs
@@ -56,6 +56,7 @@ namespace Raven.Server.Documents.Replication
         private TcpClient _tcpClient;
 
         private readonly AsyncManualResetEvent _connectionDisposed = new AsyncManualResetEvent();
+        public bool IsConnectionDisposed => _connectionDisposed.IsSet;
         private JsonOperationContext.ManagedPinnedBuffer _buffer;
 
         internal CancellationToken CancellationToken => _cts.Token;


### PR DESCRIPTION
There could be a race between disabling the external replication and the actual dropping of the conneciton.