### PR TITLE
RavenDB-11968 Fix CanPreformSeveralClusterTransactions test that thro…

### DIFF
--- a/src/Raven.Server/Rachis/Leader.cs
+++ b/src/Raven.Server/Rachis/Leader.cs
@@ -683,7 +683,7 @@ namespace Raven.Server.Rachis
         {
             var list = new List<TaskCompletionSource<Task<(long, object)>>>();
             var tasks = new List<Task<(long, object)>>();
-            var lostLeadershipException = new NotLeadingException("We no longer the leader, this leader is disposed");
+            var lostLeadershipException = new NotLeadingException("We are no longer the leader, this leader is disposed");
             try
             {
                 using (_engine.ContextPool.AllocateOperationContext(out TransactionOperationContext context))
@@ -741,7 +741,7 @@ namespace Raven.Server.Rachis
             {
                 if (_running.IsRaised() == false)
                 {
-                    e = lostLeadershipException;
+                    e = new NotLeadingException("We are no longer the leader, this leader is disposed", e);
                 }
                 foreach (var tcs in list)
                 {

--- a/test/SlowTests/Cluster/ClusterTransactionTests.cs
+++ b/test/SlowTests/Cluster/ClusterTransactionTests.cs
@@ -89,11 +89,9 @@ namespace SlowTests.Cluster
             {
                 for (int j = 0; j < numOfSessions; j++)
                 {
-
-                    bool retry;
+                    var trys = 5;
                     do
                     {
-                        retry = false;
                         try
                         {
                             using (var session = store.OpenAsyncSession(new SessionOptions
@@ -118,18 +116,20 @@ namespace SlowTests.Cluster
                                         return Task.CompletedTask;
                                     });
                                 await session.SaveChangesAsync();
+                                trys = 5;
                             }
                         }
                         catch (Exception e) when (e is ConcurrencyException)
                         {
-                            retry = true;
+                            trys--;
                         }
-                    } while (retry);
-                }
+                    } while (trys < 5 && trys > 0);
 
+                    Assert.True(trys > 0, $"Couldn't save a document after 5 retries.");
+                }
                 using (var session = store.OpenSession())
                 {
-                    var res = session.Query<User>().ToArray();
+                    var res = session.Query<User>().Customize(q => q.WaitForNonStaleResults()).ToArray();
                     Assert.Equal(numOfSessions * docsPerSession, res.Length);
                 }
             }


### PR DESCRIPTION
…ws NotLeadingException

The node could have been the leader while the rachis request arrived, but lost it afterwards.
In that case we need to throw an appropriate exception to the client (the executor that issued the request).
Moreover, this fix will cause for the raft command to be retried as long as we have any valid leader.