### PR TITLE
RavenDB-12025 Reduce the deserialization costs in the cluster observer

### DIFF
--- a/src/Raven.Server/Config/RavenConfiguration.cs
+++ b/src/Raven.Server/Config/RavenConfiguration.cs
@@ -259,7 +259,7 @@ namespace Raven.Server.Config
             return prop.GetCustomAttributes<DefaultValueAttribute>().FirstOrDefault()?.Value;
         }
 
-        public static object GetValue<T>(Expression<Func<RavenConfiguration, T>> getKey, RavenConfiguration serverConfiguration, DatabaseRecord record)
+        public static object GetValue<T>(Expression<Func<RavenConfiguration, T>> getKey, RavenConfiguration serverConfiguration, Dictionary<string, string> settings)
         {
             TimeUnitAttribute timeUnit = null;
 
@@ -276,7 +276,7 @@ namespace Raven.Server.Config
                 .GetCustomAttributes<ConfigurationEntryAttribute>()
                 .OrderBy(x => x.Order))
             {
-                if (record.Settings.TryGetValue(entry.Key, out var valueAsString) == false)
+                if (settings.TryGetValue(entry.Key, out var valueAsString) == false)
                     value = serverConfiguration.GetSetting(entry.Key);
 
                 if (valueAsString != null)

--- a/src/Raven.Server/Json/JsonDeserializationServer.cs
+++ b/src/Raven.Server/Json/JsonDeserializationServer.cs
@@ -91,6 +91,8 @@ namespace Raven.Server.Json
 
         public static readonly Func<BlittableJsonReaderObject, IndexDefinition> IndexDefinition = GenerateJsonDeserializationRoutine<IndexDefinition>();
 
+        public static readonly Func<BlittableJsonReaderObject, AutoIndexDefinition> AutoIndexDefinition = GenerateJsonDeserializationRoutine<AutoIndexDefinition>();
+
         internal static readonly Func<BlittableJsonReaderObject, LegacyIndexDefinition> LegacyIndexDefinition = GenerateJsonDeserializationRoutine<LegacyIndexDefinition>();
 
         public static readonly Func<BlittableJsonReaderObject, FacetSetup> FacetSetup = GenerateJsonDeserializationRoutine<FacetSetup>();

--- a/src/Raven.Server/ServerWide/ClusterStateMachine.cs
+++ b/src/Raven.Server/ServerWide/ClusterStateMachine.cs
@@ -1414,11 +1414,23 @@ namespace Raven.Server.ServerWide
         public DatabaseRecord ReadDatabase<T>(TransactionOperationContext<T> context, string name, out long etag)
             where T : RavenTransaction
         {
-            var doc = Read(context, "db/" + name.ToLowerInvariant(), out etag);
+            var doc = ReadRawDatabase(context, name, out etag);
             if (doc == null)
                 return null;
 
             return JsonDeserializationCluster.DatabaseRecord(doc);
+        }
+
+        public BlittableJsonReaderObject ReadRawDatabase<T>(TransactionOperationContext<T> context, string name, out long etag)
+            where T : RavenTransaction
+        {
+            return Read(context, "db/" + name.ToLowerInvariant(), out etag);
+        }
+
+        public DatabaseTopology ReadDatabaseTopology(BlittableJsonReaderObject rawDatabaseRecord)
+        {
+            rawDatabaseRecord.TryGet(nameof(DatabaseRecord.Topology), out BlittableJsonReaderObject topology);
+            return JsonDeserializationCluster.DatabaseTopology(topology);
         }
 
         public IEnumerable<(string Prefix, long Value)> ReadIdentities<T>(TransactionOperationContext<T> context, string databaseName, int start, long take)

--- a/src/Raven.Server/ServerWide/Maintenance/ClusterMaintenanceWorker.cs
+++ b/src/Raven.Server/ServerWide/Maintenance/ClusterMaintenanceWorker.cs
@@ -140,7 +140,8 @@ namespace Raven.Server.ServerWide.Maintenance
                         continue; // Database does not exists in this server
                     }
 
-                    if (record.TryGet(nameof(DatabaseRecord.Topology), out DatabaseTopology topology) == false || topology == null)
+                    var topology = _server.Cluster.ReadDatabaseTopology(record);
+                    if (topology == null)
                     {
                         continue;
                     }


### PR DESCRIPTION
- Most of the time we need only the database topology and no need to deserialize the whole database record (which can be big when there are many indexes).
- Run the cluster observer on a dedicated thread.