### PR TITLE
Fix for RavenDB-12041

### DIFF
--- a/Raven.Database/Smuggler/DatabaseDataDumper.cs
+++ b/Raven.Database/Smuggler/DatabaseDataDumper.cs
@@ -64,7 +64,7 @@ namespace Raven.Database.Smuggler
                     From = Operations,
                     To = importOperations,
                     IncrementalKey = betweenOptions.IncrementalKey
-                }, Options, null)
+                }, Options)
                 .ConfigureAwait(false);
             }
         }

--- a/Raven.Database/Smuggler/SmugglerDatabaseApi.cs
+++ b/Raven.Database/Smuggler/SmugglerDatabaseApi.cs
@@ -67,7 +67,7 @@ namespace Raven.Smuggler
                         From = exportOperations,
                         To = importOperations,
                         IncrementalKey = betweenOptions.IncrementalKey
-                    }, Options, null)
+                    }, Options)
                     .ConfigureAwait(false);
                 }
             }

--- a/Raven.Database/Smuggler/SmugglerDatabaseBetweenOperation.cs
+++ b/Raven.Database/Smuggler/SmugglerDatabaseBetweenOperation.cs
@@ -30,7 +30,9 @@ namespace Raven.Smuggler
     {
         public Action<string> OnShowProgress { get; set; } 
 
-        public async Task Between(SmugglerBetweenOperations betweenOperations, SmugglerDatabaseOptions databaseOptions, IDisposable exportOperationDisposer)
+        public async Task Between(
+            SmugglerBetweenOperations betweenOperations, 
+            SmugglerDatabaseOptions databaseOptions)
         {
             var exportOperations = betweenOperations.From;
             var importOperations = betweenOperations.To;
@@ -84,7 +86,7 @@ namespace Raven.Smuggler
                 incremental.LastAttachmentsEtag = await ExportAttachments(exportOperations, importOperations, databaseOptions).ConfigureAwait(false);
             }
 
-            await ExportIdentities(exportOperations, importOperations, databaseOptions.OperateOnTypes, exportOperationDisposer).ConfigureAwait(false);
+            await ExportIdentities(exportOperations, importOperations, databaseOptions.OperateOnTypes).ConfigureAwait(false);
 
             if (databaseOptions.Incremental)
             {
@@ -108,12 +110,13 @@ namespace Raven.Smuggler
             }
         }
 
-        private async Task ExportIdentities(ISmugglerDatabaseOperations exportOperations, ISmugglerDatabaseOperations importOperations, ItemType operateOnTypes, IDisposable exportOperationDisposer)
+        private async Task ExportIdentities(ISmugglerDatabaseOperations exportOperations, 
+            ISmugglerDatabaseOperations importOperations, 
+            ItemType operateOnTypes)
         {
             ShowProgress("Exporting Identities");
 
             var identities = await exportOperations.GetIdentities().ConfigureAwait(false);
-            exportOperationDisposer?.Dispose(); //we don't need it anymore, so let us get rid of it
 
             ShowProgress("Got {0} following identities: {1}", identities.Count, string.Join(", ", identities.Select(x => x.Key)));
 


### PR DESCRIPTION
Make sure not to create during Smuggler "between" operations, Bulk Insert connection for the export side - so it won't time out and crash Smuggler process 