### PR TITLE
RavenDB-12025 Improve low memory handler performance

### DIFF
--- a/src/Raven.Server/Dashboard/MachineResourcesNotificationSender.cs
+++ b/src/Raven.Server/Dashboard/MachineResourcesNotificationSender.cs
@@ -83,7 +83,7 @@ namespace Raven.Server.Dashboard
                 CommittedMemory = memInfo.CurrentCommitCharge.GetValue(SizeUnit.Bytes),
                 ProcessMemoryUsage = memInfo.WorkingSet.GetValue(SizeUnit.Bytes),
                 IsWindows = PlatformDetails.RunningOnPosix == false,
-                IsLowMemory = LowMemoryNotification.Instance.IsLowMemory(memInfo),
+                IsLowMemory = LowMemoryNotification.Instance.IsLowMemory(memInfo, smapsReader),
                 LowMemoryThreshold = LowMemoryNotification.Instance.LowMemoryThreshold.GetValue(SizeUnit.Bytes),
                 CommitChargeThreshold = LowMemoryNotification.Instance.GetCommitChargeThreshold(memInfo).GetValue(SizeUnit.Bytes),
                 MachineCpuUsage = cpuInfo.MachineCpuUsage,

--- a/src/Raven.Server/Utils/CpuUsage.cs
+++ b/src/Raven.Server/Utils/CpuUsage.cs
@@ -218,7 +218,7 @@ namespace Raven.Server.Utils
         private static char[] _separators = new[] { ' ', '\t' };
         private static LinuxInfo GetLinuxInfo()
         {
-            var lines = File.ReadAllLines("/proc/stat");
+            var lines = File.ReadLines("/proc/stat");
             foreach (var line in lines)
             {
                 if (line.StartsWith("cpu", StringComparison.OrdinalIgnoreCase) == false)


### PR DESCRIPTION
- Don't trigger `LowMemoryOver` on every wake-up.
- For Linux & Windows, first make a simple check for low memory by comparing `AvailableWithoutTotalCleanMemory < _lowMemoryThreshold` and if that expression true make the full one.