### PR TITLE
RavenDB-12043 fix

### DIFF
--- a/Raven.Client.Lightweight/Document/BulkInsertOperation.cs
+++ b/Raven.Client.Lightweight/Document/BulkInsertOperation.cs
@@ -21,7 +21,7 @@ namespace Raven.Client.Document
 
         private readonly IDocumentStore documentStore;
         private readonly GenerateEntityIdOnTheClient generateEntityIdOnTheClient;
-        protected ILowLevelBulkInsertOperation Operation { get; set; }
+        public ILowLevelBulkInsertOperation Operation { get; set; }
         public IAsyncDatabaseCommands DatabaseCommands { get; private set; }
         private readonly EntityToJson entityToJson;
 

--- a/Raven.Client.Lightweight/Document/BulkInsertOperation.cs
+++ b/Raven.Client.Lightweight/Document/BulkInsertOperation.cs
@@ -21,7 +21,7 @@ namespace Raven.Client.Document
 
         private readonly IDocumentStore documentStore;
         private readonly GenerateEntityIdOnTheClient generateEntityIdOnTheClient;
-        public ILowLevelBulkInsertOperation Operation { get; set; }
+        protected internal ILowLevelBulkInsertOperation Operation { get; set; }
         public IAsyncDatabaseCommands DatabaseCommands { get; private set; }
         private readonly EntityToJson entityToJson;
 
@@ -92,7 +92,7 @@ namespace Raven.Client.Document
 
         public void Store(object entity, string id)
         {
-            if(Operation.IsAborted)
+            if (Operation.IsAborted)
                 throw new InvalidOperationException("Bulk insert has been aborted or the operation was timed out");
 
             var metadata = new RavenJObject();

--- a/Raven.Client.Lightweight/Document/ChunkedRemoteBulkInsertOperation.cs
+++ b/Raven.Client.Lightweight/Document/ChunkedRemoteBulkInsertOperation.cs
@@ -19,12 +19,12 @@ namespace Raven.Client.Document
         private readonly AsyncServerClient client;
 
         private readonly IDatabaseChanges changes;
-                
+
         private int processedItemsInCurrentOperation;
 
         private RemoteBulkInsertOperation current;
 
-        public int RemoteBulkInsertOperationSwitches { get; private set; }
+        internal int RemoteBulkInsertOperationSwitches { get; private set; }
 
         private long currentChunkSize;
 
@@ -36,7 +36,7 @@ namespace Raven.Client.Document
         {
             this.options = options;
             this.client = client;
-            this.changes = changes;			
+            this.changes = changes;
             currentChunkSize = 0;
             RemoteBulkInsertOperationSwitches = 0;
             current = GetBulkInsertOperation();
@@ -69,7 +69,7 @@ namespace Raven.Client.Document
                 await current.DisposeAsync().ConfigureAwait(false);
                 current = null;
             }
-                
+
         }
 
         private RemoteBulkInsertOperation GetBulkInsertOperation()
@@ -82,9 +82,9 @@ namespace Raven.Client.Document
                 {
                     return current;
                 }
-        // if we haven't flushed the previous one yet, we will force 
-        // a disposal of both the previous one and the one before, to avoid 
-        // consuming a lot of memory, and to have _too_ much concurrency.
+            // if we haven't flushed the previous one yet, we will force 
+            // a disposal of both the previous one and the one before, to avoid 
+            // consuming a lot of memory, and to have _too_ much concurrency.
             if (previousTask != null)
             {
                 previousTask.ConfigureAwait(false).GetAwaiter().GetResult();
@@ -143,7 +143,7 @@ namespace Raven.Client.Document
                 disposeAsync.GetAwaiter().GetResult();
             }
         }
-        
+
         public bool IsAborted
         {
             get { return current != null && current.IsAborted; }

--- a/Raven.Tests.Core/BulkInsert/ChunkedBulkInsert.cs
+++ b/Raven.Tests.Core/BulkInsert/ChunkedBulkInsert.cs
@@ -1,12 +1,9 @@
 using Raven.Abstractions.Data;
 using System;
-using System.Collections.Concurrent;
 using System.Collections.Generic;
-using System.Diagnostics;
 using System.Linq;
 using System.Threading;
 using Raven.Client.Document;
-using Raven.Tests.Core.ChangesApi;
 using Xunit;
 
 namespace Raven.Tests.Core.BulkInsert
@@ -49,14 +46,14 @@ namespace Raven.Tests.Core.BulkInsert
                             Children = Enumerable.Range(0, 5).Select(x => new Node { Name = "Child" + x }).ToArray()
                         });
                     }
-                    bulkInsertStartsCounter = ((ChunkedRemoteBulkInsertOperation) bulkInsert.Operation).RemoteBulkInsertOperationSwitches;
+                    bulkInsertStartsCounter = ((ChunkedRemoteBulkInsertOperation)bulkInsert.Operation).RemoteBulkInsertOperationSwitches;
                 }
 
                 Assert.Equal(20, bulkInsertStartsCounter);
                 using (var session = store.OpenSession())
                 {
                     var count = session.Query<Node>().Customize(x => x.WaitForNonStaleResults()).Count();
-                    if(20 != count)
+                    if (20 != count)
                         WaitForUserToContinueTheTest(store);
                 }
             }
@@ -85,7 +82,7 @@ namespace Raven.Tests.Core.BulkInsert
                             Children = Enumerable.Range(0, 5).Select(x => new Node { Name = "Child" + x }).ToArray()
                         });
                     }
-                    bulkInsertStartsCounter = ((ChunkedRemoteBulkInsertOperation) bulkInsert.Operation).RemoteBulkInsertOperationSwitches;
+                    bulkInsertStartsCounter = ((ChunkedRemoteBulkInsertOperation)bulkInsert.Operation).RemoteBulkInsertOperationSwitches;
                 }
 
                 Assert.Equal(1, bulkInsertStartsCounter);
@@ -120,7 +117,7 @@ namespace Raven.Tests.Core.BulkInsert
                         });
                     }
 
-                    remoteBulkInsertOperationSwitches = ((ChunkedRemoteBulkInsertOperation) bulkInsert.Operation).RemoteBulkInsertOperationSwitches;
+                    remoteBulkInsertOperationSwitches = ((ChunkedRemoteBulkInsertOperation)bulkInsert.Operation).RemoteBulkInsertOperationSwitches;
                 }
 
                 Assert.Equal(20, remoteBulkInsertOperationSwitches);
@@ -128,7 +125,7 @@ namespace Raven.Tests.Core.BulkInsert
                 using (var session = store.OpenSession())
                 {
                     var count = session.Query<Node>().Customize(x => x.WaitForNonStaleResults()).Count();
-                    Assert.Equal(20,count);
+                    Assert.Equal(20, count);
                 }
             }
         }
@@ -156,7 +153,7 @@ namespace Raven.Tests.Core.BulkInsert
                         });
                     }
 
-                    bulkInsertStartsCounter = ((ChunkedRemoteBulkInsertOperation) bulkInsert.Operation).RemoteBulkInsertOperationSwitches;
+                    bulkInsertStartsCounter = ((ChunkedRemoteBulkInsertOperation)bulkInsert.Operation).RemoteBulkInsertOperationSwitches;
                 }
                 mre.Wait(1000);
                 Assert.Equal(1, bulkInsertStartsCounter);


### PR DESCRIPTION
Avoid race condition in tests - when chunked bulk insert switches RemoteBulkInsertOperation, it may dispose the event changes API faster than it receives the event from the server