### PR TITLE
RavenDB-12067 Fix ThrowTransactionAlreadyOpened if there is few number of retries in executeQuery

### DIFF
--- a/src/Raven.Server/Documents/Queries/QueryRunner.cs
+++ b/src/Raven.Server/Documents/Queries/QueryRunner.cs
@@ -58,6 +58,8 @@ namespace Raven.Server.Documents.Queries
             {
                 try
                 {
+                    documentsContext.CloseTransaction();
+
                     Stopwatch sw = null;
                     QueryTimingsScope scope;
                     DocumentQueryResult result;

--- a/src/Raven.Server/Documents/Queries/QueryRunner.cs
+++ b/src/Raven.Server/Documents/Queries/QueryRunner.cs
@@ -59,7 +59,6 @@ namespace Raven.Server.Documents.Queries
                 try
                 {
                     documentsContext.CloseTransaction();
-
                     Stopwatch sw = null;
                     QueryTimingsScope scope;
                     DocumentQueryResult result;
@@ -94,6 +93,7 @@ namespace Raven.Server.Documents.Queries
             {
                 try
                 {
+                    documentsContext.CloseTransaction();
                     await GetRunner(query).ExecuteStreamQuery(query, documentsContext, response, writer, token);
                     return;
                 }
@@ -119,6 +119,7 @@ namespace Raven.Server.Documents.Queries
             {
                 try
                 {
+                    documentsContext.CloseTransaction();
                     var sw = Stopwatch.StartNew();
 
                     var result = await _static.ExecuteFacetedQuery(query, existingResultEtag, documentsContext, token);
@@ -147,6 +148,7 @@ namespace Raven.Server.Documents.Queries
 
                 try
                 {
+                    context.CloseTransaction();
                     index = GetIndex(indexName);
 
                     var etag = index.GetIndexEtag(null);
@@ -177,6 +179,7 @@ namespace Raven.Server.Documents.Queries
             {
                 try
                 {
+                    context.CloseTransaction();
                     var sw = Stopwatch.StartNew();
 
                     if (query.Metadata.SelectFields.Length != 1 || query.Metadata.SelectFields[0].IsSuggest == false)
@@ -227,6 +230,7 @@ namespace Raven.Server.Documents.Queries
             {
                 try
                 {
+                    context.CloseTransaction();
                     return await GetRunner(query).ExecuteIndexEntriesQuery(query, context, existingResultEtag, token);
                 }
                 catch (ObjectDisposedException e)
@@ -248,6 +252,7 @@ namespace Raven.Server.Documents.Queries
             {
                 try
                 {
+                    context.CloseTransaction();
                     return await GetRunner(query).ExecuteDeleteQuery(query, options, context, onProgress, token);
                 }
                 catch (ObjectDisposedException e)
@@ -269,6 +274,7 @@ namespace Raven.Server.Documents.Queries
             {
                 try
                 {
+                    context.CloseTransaction();
                     return await GetRunner(query).ExecutePatchQuery(query, options, patch, patchArgs, context, onProgress, token);
                 }
                 catch (ObjectDisposedException e)

--- a/src/Raven.Server/Documents/Queries/QueryRunner.cs
+++ b/src/Raven.Server/Documents/Queries/QueryRunner.cs
@@ -148,7 +148,6 @@ namespace Raven.Server.Documents.Queries
 
                 try
                 {
-                    context.CloseTransaction();
                     index = GetIndex(indexName);
 
                     var etag = index.GetIndexEtag(null);


### PR DESCRIPTION
If there is are few NumberOfRetries to execute a query (happens on 32bit) we are getting a TransactionAlreadyOpened exception and if we are using CmpXchangeInternal we are getting fail to read a disposed object exception..