### PR TITLE
RavenDB-12021 Fix a race between disposing a database and creating a …

### DIFF
--- a/src/Raven.Client/Extensions/WhoIsLocking.cs
+++ b/src/Raven.Client/Extensions/WhoIsLocking.cs
@@ -46,7 +46,7 @@ namespace Raven.Client.Extensions
                 return processes;
             }
             if (rv != 0)
-                throw new Win32Exception(Marshal.GetLastWin32Error(), "Failed to RmStartSession");
+                throw new Win32Exception(Marshal.GetLastWin32Error(), $"Failed to RmStartSession (error: {rv})");
             try
             {
                 // Let the restart manager know what files we’re interested in
@@ -55,7 +55,7 @@ namespace Raven.Client.Extensions
                                          (uint) pathStrings.Length, pathStrings,
                                          0, null, 0, null);
                 if (rv != 0)
-                    throw new Win32Exception(Marshal.GetLastWin32Error(), "Failed to RmRegisterResources (sessionHandle=" + sessionHandle + ")");
+                    throw new Win32Exception(Marshal.GetLastWin32Error(), $"Failed to RmRegisterResources for file '{filePath}' with error {rv} (sessionHandle={sessionHandle})");
 
                 // Ask the restart manager what other applications 
                 // are using those files
@@ -90,10 +90,10 @@ namespace Raven.Client.Extensions
                         }
                     }
                     else
-                        throw new Win32Exception(Marshal.GetLastWin32Error(), "Failed to RmGetList (sessionHandle=" + sessionHandle + ")");
+                        throw new Win32Exception(Marshal.GetLastWin32Error(), $"Failed to RmGetList for file '{filePath}' with error {rv} (sessionHandle={sessionHandle})");
                 }
                 else if (rv != 0)
-                    throw new Win32Exception(Marshal.GetLastWin32Error(), "Failed to RmGetList (sessionHandle=" + sessionHandle + ")");
+                    throw new Win32Exception(Marshal.GetLastWin32Error(), $"Failed to RmGetList for file '{filePath}' with error {rv} (sessionHandle={sessionHandle})");
             }
             finally
             {

--- a/src/Raven.Server/Documents/Indexes/Index.cs
+++ b/src/Raven.Server/Documents/Indexes/Index.cs
@@ -571,6 +571,12 @@ namespace Raven.Server.Documents.Indexes
             if (_initialized == false)
                 throw new InvalidOperationException($"Index '{Name}' was not initialized.");
 
+            if (DocumentDatabase.IndexStore.IsDisposed.IsRaised())
+            {
+                Dispose();
+                return;
+            }
+
             using (DrainRunningQueries())
             {
                 StartIndexingThread();

--- a/src/Raven.Server/Documents/Indexes/IndexStore.cs
+++ b/src/Raven.Server/Documents/Indexes/IndexStore.cs
@@ -31,6 +31,7 @@ using Raven.Server.ServerWide.Commands.Indexes;
 using Raven.Server.ServerWide.Context;
 using Raven.Server.Utils;
 using Sparrow.Logging;
+using Sparrow.Threading;
 
 namespace Raven.Server.Documents.Indexes
 {
@@ -353,7 +354,10 @@ namespace Raven.Server.Documents.Indexes
 
             _initialized = true;
 
-            return Task.Run(() => { OpenIndexes(record); });
+            return Task.Run(() =>
+            {
+                OpenIndexes(record);
+            });
         }
 
         public Index GetIndex(string name)
@@ -485,7 +489,6 @@ namespace Raven.Server.Documents.Indexes
         {
             Debug.Assert(index != null);
             Debug.Assert(string.IsNullOrEmpty(index.Name) == false);
-
             _indexes.Add(index);
 
             if (_documentDatabase.Configuration.Indexing.Disabled == false && _run)
@@ -843,8 +846,11 @@ namespace Raven.Server.Documents.Indexes
             }
         }
 
+        public SharedMultipleUseFlag IsDisposed = new SharedMultipleUseFlag(false);
+
         public void Dispose()
         {
+            IsDisposed.Raise();
             //FlushMapIndexes();
             //FlushReduceIndexes();
 


### PR DESCRIPTION
…new index on it

It might happened that when the two commands: `PutIndex` and `DeleteDatabase` are accpeted closly on to another,
that the `DeleteDatabase` will complete it's execution first and skip the disposing of the later index.