### PR TITLE
RavenDB-12125

### DIFF
--- a/src/Raven.Server/Documents/DocumentDatabase.cs
+++ b/src/Raven.Server/Documents/DocumentDatabase.cs
@@ -57,13 +57,13 @@ namespace Raven.Server.Documents
         private readonly ServerStore _serverStore;
         private readonly Action<string> _addToInitLog;
         private readonly Logger _logger;
-        private DisposeOnce<SingleAttempt> _disposeOnce;
+        private readonly DisposeOnce<SingleAttempt> _disposeOnce;
 
         private readonly CancellationTokenSource _databaseShutdown = new CancellationTokenSource();
 
         private readonly object _idleLocker = new object();
 
-        private readonly object _locker = new object();
+        private readonly object _clusterLocker = new object();
         /// <summary>
         /// The current lock, used to make sure indexes have a unique names
         /// </summary>
@@ -418,132 +418,137 @@ namespace Raven.Server.Documents
             var exceptionAggregator = new ExceptionAggregator(_logger, $"Could not dispose {nameof(DocumentDatabase)} {Name}");
 
             var lockTaken = false;
-            Monitor.TryEnter(_locker, TimeSpan.FromSeconds(5), ref lockTaken);
-            if (lockTaken == false && _logger.IsOperationsEnabled)
-                _logger.Operations("Failed to acquire lock during database dispose for cluster notifications. Will dispose rudely...");
+            Monitor.TryEnter(_clusterLocker, TimeSpan.FromSeconds(5), ref lockTaken);
 
-            foreach (var connection in RunningTcpConnections)
+            try
             {
+                if (lockTaken == false && _logger.IsOperationsEnabled)
+                    _logger.Operations("Failed to acquire lock during database dispose for cluster notifications. Will dispose rudely...");
+
+                foreach (var connection in RunningTcpConnections)
+                {
+                    exceptionAggregator.Execute(() =>
+                    {
+                        connection.Dispose();
+                    });
+                }
+
                 exceptionAggregator.Execute(() =>
                 {
-                    connection.Dispose();
+                    TxMerger?.Dispose();
                 });
-            }
 
-            exceptionAggregator.Execute(() =>
-            {
-                TxMerger?.Dispose();
-            });
+                if (_indexStoreTask != null)
+                {
+                    exceptionAggregator.Execute(() =>
+                    {
+                        _indexStoreTask.Wait(DatabaseShutdown);
+                    });
+                }
 
-            if (_indexStoreTask != null)
-            {
                 exceptionAggregator.Execute(() =>
                 {
-                    _indexStoreTask.Wait(DatabaseShutdown);
+                    IndexStore?.Dispose();
                 });
+
+                exceptionAggregator.Execute(() =>
+                {
+                    ExpiredDocumentsCleaner?.Dispose();
+                });
+
+                exceptionAggregator.Execute(() =>
+                {
+                    PeriodicBackupRunner?.Dispose();
+                });
+
+                exceptionAggregator.Execute(() =>
+                {
+                    TombstoneCleaner?.Dispose();
+                });
+
+                exceptionAggregator.Execute(() =>
+                {
+                    ReplicationLoader?.Dispose();
+                });
+
+                exceptionAggregator.Execute(() =>
+                {
+                    EtlLoader?.Dispose();
+                });
+
+                exceptionAggregator.Execute(() =>
+                {
+                    Operations?.Dispose(exceptionAggregator);
+                });
+
+                exceptionAggregator.Execute(() =>
+                {
+                    NotificationCenter?.Dispose();
+                });
+
+                exceptionAggregator.Execute(() =>
+                {
+                    SubscriptionStorage?.Dispose();
+                });
+
+                exceptionAggregator.Execute(() =>
+                {
+                    ConfigurationStorage?.Dispose();
+                });
+
+                exceptionAggregator.Execute(() =>
+                {
+                    DocumentsStorage?.Dispose();
+                });
+
+                exceptionAggregator.Execute(() =>
+                {
+                    _databaseShutdown.Dispose();
+                });
+
+                exceptionAggregator.Execute(() =>
+                {
+                    if (MasterKey == null)
+                        return;
+                    fixed (byte* pKey = MasterKey)
+                    {
+                        Sodium.sodium_memzero(pKey, (UIntPtr)MasterKey.Length);
+                    }
+                });
+
+                exceptionAggregator.Execute(() =>
+                {
+                    if (_writeLockFile != null)
+                    {
+                        try
+                        {
+                            _writeLockFile.Unlock(0, 1);
+                        }
+                        catch (PlatformNotSupportedException)
+                        {
+                            // Unlock isn't supported on macOS
+                        }
+
+                        _writeLockFile.Dispose();
+
+                        try
+                        {
+                            if (File.Exists(_lockFile))
+                                File.Delete(_lockFile);
+                        }
+                        catch (IOException)
+                        {
+                        }
+                    }
+                });
+
+                exceptionAggregator.ThrowIfNeeded();
             }
-
-            exceptionAggregator.Execute(() =>
+            finally
             {
-                IndexStore?.Dispose();
-            });
-
-            exceptionAggregator.Execute(() =>
-            {
-                ExpiredDocumentsCleaner?.Dispose();
-            });
-
-            exceptionAggregator.Execute(() =>
-            {
-                PeriodicBackupRunner?.Dispose();
-            });
-
-            exceptionAggregator.Execute(() =>
-            {
-                TombstoneCleaner?.Dispose();
-            });
-
-            exceptionAggregator.Execute(() =>
-            {
-                ReplicationLoader?.Dispose();
-            });
-
-            exceptionAggregator.Execute(() =>
-            {
-                EtlLoader?.Dispose();
-            });
-
-            exceptionAggregator.Execute(() =>
-            {
-                Operations?.Dispose(exceptionAggregator);
-            });
-
-            exceptionAggregator.Execute(() =>
-            {
-                NotificationCenter?.Dispose();
-            });
-
-            exceptionAggregator.Execute(() =>
-            {
-                SubscriptionStorage?.Dispose();
-            });
-
-            exceptionAggregator.Execute(() =>
-            {
-                ConfigurationStorage?.Dispose();
-            });
-
-            exceptionAggregator.Execute(() =>
-            {
-                DocumentsStorage?.Dispose();
-            });
-
-            exceptionAggregator.Execute(() =>
-            {
-                _databaseShutdown.Dispose();
-            });
-
-            exceptionAggregator.Execute(() =>
-            {
-                if (MasterKey == null)
-                    return;
-                fixed (byte* pKey = MasterKey)
-                {
-                    Sodium.sodium_memzero(pKey, (UIntPtr)MasterKey.Length);
-                }
-            });
-
-            exceptionAggregator.Execute(() =>
-            {
-                if (_writeLockFile != null)
-                {
-                    try
-                    {
-                        _writeLockFile.Unlock(0, 1);
-                    }
-                    catch (PlatformNotSupportedException)
-                    {
-                        // Unlock isn't supported on macOS
-                    }
-
-                    _writeLockFile.Dispose();
-
-                    try
-                    {
-                        if (File.Exists(_lockFile))
-                            File.Delete(_lockFile);
-                    }
-                    catch (IOException)
-                    {
-                    }
-                }
-            });
-
-            if (lockTaken)
-                Monitor.Exit(_locker);
-
-            exceptionAggregator.ThrowIfNeeded();
-
+                if (lockTaken)
+                    Monitor.Exit(_clusterLocker);
+            }
         }
 
         public DynamicJsonValue GenerateDatabaseInfo()
@@ -857,7 +862,7 @@ namespace Raven.Server.Documents
 
         private void NotifyFeaturesAboutStateChange(DatabaseRecord record, long index)
         {
-            lock (_locker)
+            lock (_clusterLocker)
             {
                 DatabaseShutdown.ThrowIfCancellationRequested();
 
@@ -899,7 +904,7 @@ namespace Raven.Server.Documents
 
         private void NotifyFeaturesAboutValueChange(DatabaseRecord record)
         {
-            lock (_locker)
+            lock (_clusterLocker)
             {
                 DatabaseShutdown.ThrowIfCancellationRequested();
 

--- a/src/Raven.Server/Documents/Indexes/IndexStore.cs
+++ b/src/Raven.Server/Documents/Indexes/IndexStore.cs
@@ -77,6 +77,8 @@ namespace Raven.Server.Documents.Indexes
         {
             foreach (var kvp in record.AutoIndexes)
             {
+                _documentDatabase.DatabaseShutdown.ThrowIfCancellationRequested();
+
                 var name = kvp.Key;
                 try
                 {
@@ -190,6 +192,8 @@ namespace Raven.Server.Documents.Indexes
         {
             foreach (var kvp in record.Indexes)
             {
+                _documentDatabase.DatabaseShutdown.ThrowIfCancellationRequested();
+
                 var name = kvp.Key;
                 var definition = kvp.Value;
 
@@ -302,6 +306,8 @@ namespace Raven.Server.Documents.Indexes
         {
             foreach (var index in _indexes)
             {
+                _documentDatabase.DatabaseShutdown.ThrowIfCancellationRequested();
+
                 var indexNormalizedName = index.Name;
                 if (indexNormalizedName.StartsWith(Constants.Documents.Indexing.SideBySideIndexNamePrefix))
                 {

--- a/src/Raven.Server/Documents/Subscriptions/SubscriptionStorage.cs
+++ b/src/Raven.Server/Documents/Subscriptions/SubscriptionStorage.cs
@@ -389,7 +389,7 @@ namespace Raven.Server.Documents.Subscriptions
             }
         }
 
-        public void HandleDatabaseValueChange(DatabaseRecord databaseRecord)
+        public void HandleDatabaseRecordChange(DatabaseRecord databaseRecord)
         {
             using (_serverStore.ContextPool.AllocateOperationContext(out TransactionOperationContext context))
             using (context.OpenReadTransaction())

--- a/src/Raven.Server/Documents/Subscriptions/SubscriptionStorage.cs
+++ b/src/Raven.Server/Documents/Subscriptions/SubscriptionStorage.cs
@@ -80,7 +80,7 @@ namespace Raven.Server.Documents.Subscriptions
             return subscriptionState;
         }
 
-		public async Task AcknowledgeBatchProcessed(long id, string name, string changeVector, string previousChangeVector)
+        public async Task AcknowledgeBatchProcessed(long id, string name, string changeVector, string previousChangeVector)
         {           
             var command = new AcknowledgeSubscriptionBatchCommand(_db.Name)
             {


### PR DESCRIPTION
- during database dispose we should prevent handling of any new state changed notifications and wait for a short period of time for current notification to finish processing
- early exiting IndexStore RecordChanged process when shutdown is requested