### PR TITLE
RavenDB-12122 Don't use size of blittable when calculating the hash c…

### DIFF
--- a/src/Sparrow/Json/BlittableJsonReaderObject.cs
+++ b/src/Sparrow/Json/BlittableJsonReaderObject.cs
@@ -1153,7 +1153,7 @@ NotFound:
 
         public override int GetHashCode()
         {
-            return _isRoot ? _size ^ _propCount : _propCount;
+            return _propCount;
         }
 
         private bool HasSamePropertyNames(BlittableJsonReaderObject other)

--- a/test/FastTests/Blittable/BlittableJsonEqualityTests.cs
+++ b/test/FastTests/Blittable/BlittableJsonEqualityTests.cs
@@ -345,6 +345,7 @@ namespace FastTests.Blittable
                     using (var blittable2 = ctx.ReadObject(json2, "foo"))
                     {
                         Assert.Equal(blittable1, blittable2);
+                        Assert.Equal(blittable1.GetHashCode(), blittable2.GetHashCode());
 
                         blittable1.TryGet("Company", out BlittableJsonReaderObject ob1);
                         blittable2.TryGet("Company", out BlittableJsonReaderObject ob2);
@@ -414,6 +415,7 @@ namespace FastTests.Blittable
                 using (var blittable2 = CreateBlittable())
                 {
                     Assert.Equal(blittable1, blittable2);
+                    Assert.Equal(blittable1.GetHashCode(), blittable2.GetHashCode());
                     
                     blittable1.TryGet("Office", out BlittableJsonReaderObject ob1);
                     blittable2.TryGet("Office", out BlittableJsonReaderObject ob2);


### PR DESCRIPTION
…ode. Blittables created manually can have different size but they can be the same in terms of properties and values.