### PR TITLE
RavenDB-11680 (WIP) refactoring IntermediateResults so it won't run queries…

### DIFF
--- a/src/Raven.Server/Documents/Queries/GraphQueryRunner.IntermediateResults.cs
+++ b/src/Raven.Server/Documents/Queries/GraphQueryRunner.IntermediateResults.cs
@@ -1,14 +1,44 @@
-﻿using System.Collections.Generic;
+﻿using System;
+using System.Collections.Generic;
+using System.Threading.Tasks;
+using Raven.Client.Util;
+using Raven.Server.Documents.Queries.AST;
+using Raven.Server.ServerWide;
+using Raven.Server.ServerWide.Context;
 
 namespace Raven.Server.Documents.Queries
 {
     public partial class GraphQueryRunner
     {
-        public struct IntermediateResults// using struct because we have a single field 
+        public class IntermediateResults
         {
             private Dictionary<string, Dictionary<string, Match>> _matchesByAlias;
-            private Dictionary<string, Dictionary<string, Match>> MatchesByAlias => 
-                _matchesByAlias ??( _matchesByAlias = new Dictionary<string, Dictionary<string, Match>>());
+            private Dictionary<string, IndexQueryServerSide> _queryPerAlias;
+            private DocumentDatabase _database;
+            private DocumentsOperationContext _documentsContext;
+            private long? _existingResultEtag;
+            private OperationCancelToken _token;
+
+            public IntermediateResults(DocumentDatabase database, IndexQueryServerSide query, DocumentsOperationContext documentsContext, long? existingResultEtag,
+                OperationCancelToken token)
+            {
+                var q = query.Metadata.Query;
+                if (q.GraphQuery == null)
+                    throw new InvalidOperationException($"None graph queries can't run through the GraphQueryRunner, query = {q}.");
+                _database = database;
+                _documentsContext = documentsContext;
+                _existingResultEtag = existingResultEtag;
+                _token = token;
+                _matchesByAlias = new Dictionary<string, Dictionary<string, Match>>();
+                _queryPerAlias  = new Dictionary<string, IndexQueryServerSide>();
+
+                //Here we only populate the queries to be run but we might decide to not run them (in case of optimizations).
+                foreach (var documentQuery in q.GraphQuery.WithDocumentQueries)
+                {
+                    var queryMetadata = new QueryMetadata(documentQuery.Value, query.QueryParameters, 0);
+                    _queryPerAlias.Add(documentQuery.Key, new IndexQueryServerSide(queryMetadata));
+                }
+            }
 
             public void Add(Match match)
             {
@@ -21,19 +51,32 @@ namespace Raven.Server.Documents.Queries
             public void Add(string alias, Match match, Document instance)
             {
                 //TODO: need to handle map/reduce results?
-                MatchesByAlias[alias][instance.Id] = match;
+                _matchesByAlias[alias][instance.Id] = match;
             }
 
-            public bool TryGetByAlias(string alias, out Dictionary<string,Match> value)
+            public bool TryGetByAlias(string alias, out Dictionary<string, Match> value)
             {
-                return MatchesByAlias.TryGetValue(alias, out value);
+                if (_matchesByAlias.TryGetValue(alias, out value) == false)
+                {
+                    if (_queryPerAlias.TryGetValue(alias, out var query) == false)
+                        return false;
+
+                    _matchesByAlias[alias] = new Dictionary<string, Match>();
+                    //TODO: should we move everything to be async?
+                    var results = AsyncHelpers.RunSync( ()=>_database.QueryRunner.ExecuteQuery(query, _documentsContext, _existingResultEtag, _token));
+                    foreach (var result in results.Results)
+                    {
+                        var match = new Match();
+                        match.Set(alias, result);
+                        match.PopulateVertices(this);
+                    }
+
+                    return _matchesByAlias.TryGetValue(alias, out value);
+                }
+
+                return true;
             }
 
-            public void EnsureExists(string alias)
-            {
-                if (MatchesByAlias.TryGetValue(alias, out _) == false)
-                    MatchesByAlias[alias] =  new Dictionary<string, Match>();
-            }
         }
     }
 }

--- a/src/Raven.Server/Documents/Queries/GraphQueryRunner.Match.cs
+++ b/src/Raven.Server/Documents/Queries/GraphQueryRunner.Match.cs
@@ -80,7 +80,7 @@ namespace Raven.Server.Documents.Queries
                 }
             }
 
-            public void PopulateVertices(ref IntermediateResults i)
+            public void PopulateVertices(IntermediateResults i)
             {
                 if (_inner == null)
                     return;

--- a/src/Raven.Server/Documents/Queries/GraphQueryRunner.cs
+++ b/src/Raven.Server/Documents/Queries/GraphQueryRunner.cs
@@ -34,23 +34,7 @@ namespace Raven.Server.Documents.Queries
 
             using (var timingScope = new QueryTimingsScope())
             {
-                var ir = new IntermediateResults();
-
-                foreach (var documentQuery in q.GraphQuery.WithDocumentQueries)
-                {
-                    var queryMetadata = new QueryMetadata(documentQuery.Value, query.QueryParameters, 0);
-                    var results = await Database.QueryRunner.ExecuteQuery(new IndexQueryServerSide(queryMetadata),
-                        documentsContext, existingResultEtag, token);
-
-                    ir.EnsureExists(documentQuery.Key);
-
-                    foreach (var result in results.Results)
-                    {
-                        var match = new Match();
-                        match.Set(documentQuery.Key, result);
-                        match.PopulateVertices(ref ir);
-                    }
-                }
+                var ir = new IntermediateResults(Database, query, documentsContext,existingResultEtag, token);
 
                 var matchResults = ExecutePatternMatch(documentsContext, query, ir) ?? new List<Match>();
 


### PR DESCRIPTION
… until the result are actually requested.

We need this so if we decide to change the actual query during the MATCH phase we won't already pay the price at the WITH phase making any optimization futile.