### PR TITLE
RavenDB-12148 Prevent from killing the process if we get any exceptio…

### DIFF
--- a/src/Raven.Server/Documents/Indexes/Index.cs
+++ b/src/Raven.Server/Documents/Indexes/Index.cs
@@ -1138,6 +1138,11 @@ namespace Raven.Server.Documents.Indexes
                         }
                     }
                 }
+                catch (Exception e)
+                {
+                    if (_logger.IsOperationsEnabled)
+                        _logger.Operations($"Unexpected error in '{Name}' index. This should never happen.", e);
+                }
                 finally
                 {
                     storageEnvironment.OnLogsApplied -= HandleLogsApplied;

--- a/src/Raven.Server/Documents/Indexes/Index.cs
+++ b/src/Raven.Server/Documents/Indexes/Index.cs
@@ -1142,6 +1142,19 @@ namespace Raven.Server.Documents.Indexes
                 {
                     if (_logger.IsOperationsEnabled)
                         _logger.Operations($"Unexpected error in '{Name}' index. This should never happen.", e);
+
+                    try
+                    {
+                        DocumentDatabase.NotificationCenter.Add(AlertRaised.Create(DocumentDatabase.Name, $"Unexpected error in '{Name}' index",
+                            "Unexpected error in indexing thread. See details.", AlertType.UnexpectedIndexingThreadError, NotificationSeverity.Error,
+                            details: new ExceptionDetails(e)));
+                    }
+                    catch (Exception)
+                    {
+                        // ignore if we can't create notification
+                    }
+
+                    State = IndexState.Error;
                 }
                 finally
                 {

--- a/src/Raven.Server/NotificationCenter/Notifications/AlertType.cs
+++ b/src/Raven.Server/NotificationCenter/Notifications/AlertType.cs
@@ -50,6 +50,8 @@ namespace Raven.Server.NotificationCenter.Notifications
 
         ClusterTransactionFailure,
 
-        OutOfMemoryException
+        OutOfMemoryException,
+
+        UnexpectedIndexingThreadError
     }
 }


### PR DESCRIPTION
…n in indexing thread. Let's ignore disk full and timeout exceptions when cleaning the scratch buffers pool.