### PR TITLE
RavenDB-12024-2_v4.0: Using buffer.copy for overlapped blocks

### DIFF
--- a/src/Sparrow/Json/Parsing/JsonParserState.cs
+++ b/src/Sparrow/Json/Parsing/JsonParserState.cs
@@ -1,6 +1,7 @@
 using System;
 using System.Runtime.CompilerServices;
 using Sparrow.Collections;
+using Sparrow.Platform.Win32;
 
 namespace Sparrow.Json.Parsing
 {
@@ -62,8 +63,8 @@ namespace Sparrow.Json.Parsing
                 // 12 => '\f' => 0000 1100
                 // 13 => '\r' => 0000 1101
 
-                // 34 => '\\' => 0010 0010
-                // 92 =>  '"' => 0101 1100
+                // 34 => '"'  => 0010 0010
+                // 92 => '\\' => 0101 1100
 
                 if (value == 92 || value == 34 || (value >= 8 && value <= 13 && value != 11))
                 {
@@ -113,8 +114,8 @@ namespace Sparrow.Json.Parsing
                 // 13 => '\r' => 0000 1101
                 // 10 => '\n' => 0000 1010
                 // 12 => '\f' => 0000 1100
-                // 34 => '\\' => 0010 0010
-                // 92 =>  '"' => 0101 1100
+                // 34 => '"'  => 0010 0010
+                // 92 => '\\' => 0101 1100
 
                 if (value == 92 || value == 34 || (value >= 8 && value <= 13 && value != 11))
                 {
@@ -122,7 +123,6 @@ namespace Sparrow.Json.Parsing
                     lastEscape = i + 1;
                     continue;
                 }
-
                 //Control character ascii values
                 if (value < 32)
                 {
@@ -136,8 +136,8 @@ namespace Sparrow.Json.Parsing
                     var to = str + i + 1 + ControlCharacterItemSize;
                     var sizeToCopy = len - i -1;
                     //here we only shifting by 5 bytes since we are going to override the byte at the current position.
-                    Memory.Copy(to, from, sizeToCopy);
-                   
+                    // source and destination blocks may overlap so we using Buffer.MemoryCopy to handle that scenario.
+                    Buffer.MemoryCopy(from, to, (uint)sizeToCopy, (uint)sizeToCopy);
                     str[i] = (byte)'\\';
                     str[i+1] = (byte)'u';
                     fixed (byte* controlString = AbstractBlittableJsonTextWriter.ControlCodeEscapes[value])

--- a/src/Sparrow/Memory.cs
+++ b/src/Sparrow/Memory.cs
@@ -1,3 +1,5 @@
+using System;
+using System.Diagnostics;
 using System.Runtime.CompilerServices;
 
 namespace Sparrow
@@ -162,6 +164,8 @@ namespace Sparrow
         [MethodImpl(MethodImplOptions.AggressiveInlining)]
         public static void Copy(byte* dest, byte* src, uint n)
         {
+            Debug.Assert(Math.Abs(dest - src) >= n, "overlapped copy using memcopy");
+
             Unsafe.CopyBlock(dest, src, n);
         }
 
@@ -169,6 +173,8 @@ namespace Sparrow
         [MethodImpl(MethodImplOptions.AggressiveInlining)]
         public static void Copy(byte* dest, byte* src, int n)
         {
+            Debug.Assert(Math.Abs(dest-src) >= n, "overlapped copy using memcopy");
+
             Unsafe.CopyBlock(dest, src, (uint)n);
         }
 

--- a/src/Sparrow/Utils/NativeMemory.cs
+++ b/src/Sparrow/Utils/NativeMemory.cs
@@ -127,7 +127,18 @@ namespace Sparrow.Utils
         
         private static byte* ThrowFailedToAllocate(long size, ThreadStats thread, OutOfMemoryException e)
         {
-            throw new OutOfMemoryException($"Failed to allocate additional {new Size(size, SizeUnit.Bytes)} to already allocated {new Size(thread.Allocations, SizeUnit.Bytes)}", e);
+            long allocated = 0;
+            foreach (var threadAllocationsValue in AllThreadStats)
+            {
+                allocated += threadAllocationsValue.TotalAllocated;
+            }
+            var managed = MemoryInformation.GetManagedMemoryInBytes();
+            var unmanagedMemory = MemoryInformation.GetUnManagedAllocationsInBytes();
+            throw new OutOfMemoryException($"Failed to allocate additional {new Size(size, SizeUnit.Bytes)} " +
+                                           $"to already allocated {new Size(thread.TotalAllocated, SizeUnit.Bytes)} by this thread. " +
+                                           $"Total allocated by all threads: {new Size(allocated, SizeUnit.Bytes)}, " +
+                                           $"Managed memory: {new Size(managed, SizeUnit.Bytes)}, " +
+                                           $"Un-managed memory: {new Size(unmanagedMemory, SizeUnit.Bytes)}", e);
         }
 
         private static void FixupReleasesFromOtherThreads(ThreadStats thread)

--- a/test/SlowTests/SlowTests/Bugs/VeryBigResultSet.cs
+++ b/test/SlowTests/SlowTests/Bugs/VeryBigResultSet.cs
@@ -2,22 +2,20 @@ using System;
 using System.Collections.Generic;
 using System.Linq;
 using FastTests;
-using Tests.Infrastructure;
 using Xunit;
 
 namespace SlowTests.SlowTests.Bugs
 {
     public class VeryBigResultSet : RavenTestBase
     {
-        [Theory64Bit]
-        [InlineData(15000)]
-        public void CanGetVeryBigResultSetsEvenThoughItIsBadForYou(int num)
+        [Fact]
+        public void CanGetVeryBigResultSetsEvenThoughItIsBadForYou()
         {
             using (var store = GetDocumentStore())
             {
                 using (var session = store.OpenSession())
                 {
-                    for (int i = 0; i < num; i++)
+                    for (int i = 0; i < 15000; i++)
                     {
                         session.Store(new User());
                     }
@@ -28,12 +26,12 @@ namespace SlowTests.SlowTests.Bugs
                 {
                     var users = session.Query<User>()
                                        .Customize(x => x.WaitForNonStaleResults(TimeSpan.FromMinutes(1)))
-                                       .Take(num + 5_000)
+                                       .Take(20000)
                                        .ToArray();
 
                     try
                     {
-                        Assert.Equal(num, users.Length);
+                        Assert.Equal(15000, users.Length);
                     }
                     catch (Exception)
                     {
@@ -42,12 +40,6 @@ namespace SlowTests.SlowTests.Bugs
                     }
                 }
             }
-        }
-
-        [Fact32Bit]
-        public void CanGetVeryBigResultSetsEvenThoughItIsBadForYou32()
-        {
-            CanGetVeryBigResultSetsEvenThoughItIsBadForYou(10_000);
         }
 
         private static void PrintMissedDocuments(User[] users)

--- a/test/SlowTests/Voron/Issues/RavenDB_11643_Voron.cs
+++ b/test/SlowTests/Voron/Issues/RavenDB_11643_Voron.cs
@@ -1,6 +1,7 @@
 ﻿using System;
 using System.IO;
 using FastTests.Voron;
+using Tests.Infrastructure;
 using Voron.Data.BTrees;
 using Xunit;
 
@@ -8,7 +9,7 @@ namespace SlowTests.Voron.Issues
 {
     public class RavenDB_11643_Voron : StorageTest
     {
-        [Fact]
+        [Fact64Bit]
         public void PageRefValidationOnBranchPagesShouldNotThrow()
         {
             using (var tx = Env.WriteTransaction())


### PR DESCRIPTION
 single allocation size limit when running on 32 bits ported from v4.1.