### PR TITLE
RavenDB-12172 add import option to skip server certificate validation

### DIFF
--- a/src/Raven.Server/Smuggler/Migration/AbstractMigrator.cs
+++ b/src/Raven.Server/Smuggler/Migration/AbstractMigrator.cs
@@ -18,6 +18,7 @@ namespace Raven.Server.Smuggler.Migration
         protected readonly HttpClient HttpClient;
         protected readonly string ApiKey;
         protected readonly bool EnableBasicAuthenticationOverUnsecuredHttp;
+        protected readonly bool SkipServerCertificateValidation;
         protected readonly DatabaseItemType OperateOnTypes;
         protected readonly bool RemoveAnalyzers;
         protected readonly bool ImportRavenFs;
@@ -34,6 +35,7 @@ namespace Raven.Server.Smuggler.Migration
             HttpClient = options.HttpClient;
             ApiKey = options.ApiKey;
             EnableBasicAuthenticationOverUnsecuredHttp = options.EnableBasicAuthenticationOverUnsecuredHttp;
+            SkipServerCertificateValidation = options.SkipServerCertificateValidation;
             OperateOnTypes = options.OperateOnTypes;
             RemoveAnalyzers = options.RemoveAnalyzers;
             ImportRavenFs = options.ImportRavenFs;

--- a/src/Raven.Server/Smuggler/Migration/ApiKey/Authenticator.cs
+++ b/src/Raven.Server/Smuggler/Migration/ApiKey/Authenticator.cs
@@ -12,10 +12,14 @@ namespace Raven.Server.Smuggler.Migration.ApiKey
 {
     public class Authenticator
     {
-        public static async Task<string> GetOAuthToken(string baseUrl, string oauthSource, string apiKey)
+        public static async Task<string> GetOAuthToken(
+            string baseUrl,
+            string oauthSource, 
+            string apiKey, 
+            bool skipServerCertificateValidation)
         {
             if (oauthSource == null)
-                throw new ArgumentNullException("oauthSource");
+                throw new ArgumentNullException(nameof(oauthSource));
 
             string serverRSAExponent = null;
             string serverRSAModulus = null;
@@ -31,6 +35,9 @@ namespace Raven.Server.Smuggler.Migration.ApiKey
             {
                 tries++;
                 var handler = new HttpClientHandler();
+
+                if (skipServerCertificateValidation)
+                    handler.ServerCertificateCustomValidationCallback = (message, certificate2, arg3, arg4) => true;
 
                 using (var httpClient = new HttpClient(handler))
                 {

--- a/src/Raven.Server/Smuggler/Migration/MigrationConfiguration.cs
+++ b/src/Raven.Server/Smuggler/Migration/MigrationConfiguration.cs
@@ -58,5 +58,7 @@ namespace Raven.Server.Smuggler.Migration
         public string ApiKey { get; set; }
 
         public bool EnableBasicAuthenticationOverUnsecuredHttp { get; set; }
+
+        public bool SkipServerCertificateValidation { get; set; }
     }
 }

--- a/src/Raven.Server/Smuggler/Migration/Migrator.cs
+++ b/src/Raven.Server/Smuggler/Migration/Migrator.cs
@@ -29,6 +29,7 @@ namespace Raven.Server.Smuggler.Migration
         private readonly ServerStore _serverStore;
         private readonly string _apiKey;
         private readonly bool _enableBasicAuthenticationOverUnsecuredHttp;
+        private readonly bool _skipServerCertificateValidation;
         private MajorVersion _buildMajorVersion;
         private int _buildVersion;
 
@@ -38,10 +39,14 @@ namespace Raven.Server.Smuggler.Migration
             _serverStore = serverStore;
             _buildMajorVersion = configuration.BuildMajorVersion;
             _buildVersion = configuration.BuildVersion;
+            _skipServerCertificateValidation = configuration.SkipServerCertificateValidation;
 
             //because of backward compatibility useCompression == false here
             var httpClientHandler = RequestExecutor.CreateHttpMessageHandler(_serverStore.Server.Certificate.Certificate, setSslProtocols: false, useCompression: false);
             httpClientHandler.UseDefaultCredentials = false;
+
+            if (configuration.SkipServerCertificateValidation)
+                httpClientHandler.ServerCertificateCustomValidationCallback = (message, certificate2, arg3, arg4) => true;
 
             if (string.IsNullOrWhiteSpace(configuration.ApiKey) == false)
             {
@@ -196,7 +201,7 @@ namespace Raven.Server.Smuggler.Migration
 
             try
             {
-                return await AbstractLegacyMigrator.GetResourcesToMigrate(_serverUrl, _httpClient, true, _apiKey, _enableBasicAuthenticationOverUnsecuredHttp, null, _serverStore.ServerShutdown);
+                return await AbstractLegacyMigrator.GetResourcesToMigrate(_serverUrl, _httpClient, true, _apiKey, _enableBasicAuthenticationOverUnsecuredHttp, _skipServerCertificateValidation, null, _serverStore.ServerShutdown);
             }
             catch (Exception e) when (e is UnauthorizedAccessException || e is AuthorizationException)
             {
@@ -214,7 +219,7 @@ namespace Raven.Server.Smuggler.Migration
             {
                 return buildMajorVersion == MajorVersion.V4
                     ? await Importer.GetDatabasesToMigrate(_serverUrl, _httpClient, _serverStore.ServerShutdown)
-                    : await AbstractLegacyMigrator.GetResourcesToMigrate(_serverUrl, _httpClient, false, _apiKey, _enableBasicAuthenticationOverUnsecuredHttp, isLegacyOAuthToken, _serverStore.ServerShutdown);
+                    : await AbstractLegacyMigrator.GetResourcesToMigrate(_serverUrl, _httpClient, false, _apiKey, _enableBasicAuthenticationOverUnsecuredHttp, _skipServerCertificateValidation, isLegacyOAuthToken, _serverStore.ServerShutdown);
             }
             catch (Exception e) when (e is UnauthorizedAccessException || e is AuthorizationException)
             {
@@ -258,6 +263,7 @@ namespace Raven.Server.Smuggler.Migration
                                 HttpClient = _httpClient,
                                 ApiKey = _apiKey,
                                 EnableBasicAuthenticationOverUnsecuredHttp = _enableBasicAuthenticationOverUnsecuredHttp,
+                                SkipServerCertificateValidation = _skipServerCertificateValidation,
                                 OperateOnTypes = databaseMigrationSettings.OperateOnTypes,
                                 RemoveAnalyzers = databaseMigrationSettings.RemoveAnalyzers,
                                 ImportRavenFs = databaseMigrationSettings.ImportRavenFs,

--- a/src/Raven.Server/Smuggler/Migration/MigratorOptions.cs
+++ b/src/Raven.Server/Smuggler/Migration/MigratorOptions.cs
@@ -21,6 +21,8 @@ namespace Raven.Server.Smuggler.Migration
 
         public bool EnableBasicAuthenticationOverUnsecuredHttp { get; set; }
 
+        public bool SkipServerCertificateValidation { get; set; }
+
         public DatabaseItemType OperateOnTypes { get; set; }
 
         public bool RemoveAnalyzers { get; set; }

--- a/src/Raven.Server/Web/System/DatabasesHandler.cs
+++ b/src/Raven.Server/Web/System/DatabasesHandler.cs
@@ -183,6 +183,7 @@ namespace Raven.Server.Web.System
             var domain = GetStringQueryString("domain", required: false);
             var apiKey = GetStringQueryString("apiKey", required: false);
             var enableBasicAuthenticationOverUnsecuredHttp = GetBoolValueQueryString("enableBasicAuthenticationOverUnsecuredHttp", required: false);
+            var skipServerCertificateValidation = GetBoolValueQueryString("skipServerCertificateValidation", required: false);
             var migrator = new Migrator(new SingleDatabaseMigrationConfiguration
             {
                 ServerUrl = serverUrl,
@@ -190,7 +191,8 @@ namespace Raven.Server.Web.System
                 Password = password,
                 Domain = domain,
                 ApiKey = apiKey,
-                EnableBasicAuthenticationOverUnsecuredHttp = enableBasicAuthenticationOverUnsecuredHttp ?? false
+                EnableBasicAuthenticationOverUnsecuredHttp = enableBasicAuthenticationOverUnsecuredHttp ?? false,
+                SkipServerCertificateValidation = skipServerCertificateValidation ?? false
             }, ServerStore);
             
             var buildInfo = await migrator.GetBuildInfo();

--- a/src/Raven.Studio/typescript/commands/database/studio/getRemoteServerVersionWithDatabasesCommand.ts
+++ b/src/Raven.Studio/typescript/commands/database/studio/getRemoteServerVersionWithDatabasesCommand.ts
@@ -5,7 +5,8 @@ class getRemoteServerVersionWithDatabasesCommand extends commandBase {
 
     constructor(private serverUrl: string,
         private userName: string, private password: string, private domain: string,
-        private apiKey: string, private enableBasicAuthenticationOverUnsecuredHttp: boolean) {
+        private apiKey: string, private enableBasicAuthenticationOverUnsecuredHttp: boolean,
+        private skipServerCertificateValidation: boolean) {
         super();
     }
 
@@ -16,7 +17,8 @@ class getRemoteServerVersionWithDatabasesCommand extends commandBase {
             password: this.password,
             domain: this.domain,
             apiKey: this.apiKey,
-            enableBasicAuthenticationOverUnsecuredHttp: this.enableBasicAuthenticationOverUnsecuredHttp
+            enableBasicAuthenticationOverUnsecuredHttp: this.enableBasicAuthenticationOverUnsecuredHttp,
+            skipServerCertificateValidation: this.skipServerCertificateValidation
         };
         
         const url = endpoints.global.databases.adminRemoteServerBuildVersion + this.urlEncodeArgs(args);

--- a/src/Raven.Studio/typescript/models/database/tasks/migrateRavenDbDatabaseModel.ts
+++ b/src/Raven.Studio/typescript/models/database/tasks/migrateRavenDbDatabaseModel.ts
@@ -33,6 +33,7 @@ class migrateRavenDbDatabaseModel {
     domain = ko.observable<string>();
     apiKey = ko.observable<string>();
     enableBasicAuthenticationOverUnsecuredHttp = ko.observable<boolean>();
+    skipServerCertificateValidation = ko.observable<boolean>();
 
     serverMajorVersionNumber: KnockoutComputed<string>;
     isRavenDb: KnockoutComputed<boolean>;
@@ -43,6 +44,7 @@ class migrateRavenDbDatabaseModel {
     showWindowsCredentialInputs: KnockoutComputed<boolean>;
     showApiKeyCredentialInputs: KnockoutComputed<boolean>;
     isUnsecuredBasicAuthentication: KnockoutComputed<boolean>;
+    isSecuredConnection: KnockoutComputed<boolean>;
 
     validationGroup: KnockoutValidationGroup;
     importDefinitionHasIncludes: KnockoutComputed<boolean>;
@@ -103,7 +105,8 @@ class migrateRavenDbDatabaseModel {
             ApiKey: this.showApiKeyCredentialInputs() ? this.apiKey() : null, 
             EnableBasicAuthenticationOverUnsecuredHttp: this.apiKey() ? this.enableBasicAuthenticationOverUnsecuredHttp() : false, 
             BuildMajorVersion: this.serverMajorVersion(),
-            BuildVersion: this.buildVersion()
+            BuildVersion: this.buildVersion(),
+            SkipServerCertificateValidation: this.isSecuredConnection() ? this.skipServerCertificateValidation() : false
         };
     }
 
@@ -181,6 +184,15 @@ class migrateRavenDbDatabaseModel {
             }
 
             return this.hasUnsecuredBasicAuthenticationOption() && url.toLowerCase().startsWith("http://");
+        });
+
+        this.isSecuredConnection = ko.pureComputed(() => {
+            const url = this.serverUrl();
+            if (!url) {
+                return false;
+            }
+
+            return url.toLowerCase().startsWith("https://");
         });
     }
     

--- a/src/Raven.Studio/typescript/viewmodels/database/tasks/migrateRavenDbDatabase.ts
+++ b/src/Raven.Studio/typescript/viewmodels/database/tasks/migrateRavenDbDatabase.ts
@@ -35,6 +35,7 @@ class migrateRavenDbDatabase extends viewModelBase {
         this.model.password.subscribe(() => debouncedDetection(false));
         this.model.apiKey.subscribe(() => debouncedDetection(false));
         this.model.enableBasicAuthenticationOverUnsecuredHttp.subscribe(() => debouncedDetection(false));
+        this.model.skipServerCertificateValidation.subscribe(() => debouncedDetection(false));
     }
 
     activate(args: any) {
@@ -65,10 +66,11 @@ class migrateRavenDbDatabase extends viewModelBase {
         const domain = this.model.showWindowsCredentialInputs() ? this.model.domain() : "";
         const apiKey = this.model.showApiKeyCredentialInputs() ? this.model.apiKey() : "";
         const enableBasicAuthenticationOverUnsecuredHttp = this.model.showApiKeyCredentialInputs() ? this.model.enableBasicAuthenticationOverUnsecuredHttp() : false;
+        const skipServerCertificateValidation = this.model.skipServerCertificateValidation() ? this.model.skipServerCertificateValidation() : false;
 
         const url = this.model.serverUrl();
         new getRemoteServerVersionWithDatabasesCommand(url, userName, password, domain,
-                apiKey, enableBasicAuthenticationOverUnsecuredHttp)
+                apiKey, enableBasicAuthenticationOverUnsecuredHttp, skipServerCertificateValidation)
             .execute()
             .done(info => {
                 if (info.MajorVersion !== "Unknown") {

--- a/src/Raven.Studio/wwwroot/App/views/database/tasks/migrateRavenDbDatabase.html
+++ b/src/Raven.Studio/wwwroot/App/views/database/tasks/migrateRavenDbDatabase.html
@@ -25,6 +25,16 @@
                             </div>
                         </div>
 
+                        <div>
+                            <div class="form-group" data-bind="visible: isSecuredConnection">
+                                <label class="control-label"></label>
+                                <div class="toggle">
+                                    <input class="styled" type="checkbox" id="skip-server-certificate-validation" data-bind="checked: skipServerCertificateValidation">
+                                    <label for="skip-server-certificate-validation">Skip Server Certificate Validation</label>
+                                </div>
+                            </div>
+                        </div>
+
                         <div class="form-group" data-bind="validationElement: serverMajorVersion">
                             <label class="control-label">Server Version</label>
                             <div class="flex-grow">


### PR DESCRIPTION
With these changes I was able to import from 3.5 server that was using certificate that was not trusted.