### PR TITLE
RavenDB-12194

### DIFF
--- a/src/Raven.Client/Documents/Conventions/JsonNetBlittableEntitySerializer.cs
+++ b/src/Raven.Client/Documents/Conventions/JsonNetBlittableEntitySerializer.cs
@@ -1,4 +1,5 @@
 ﻿using System;
+using System.Threading;
 using Newtonsoft.Json;
 using Newtonsoft.Json.Linq;
 using Raven.Client.Documents.Identity;
@@ -9,42 +10,23 @@ namespace Raven.Client.Documents.Conventions
 {
     internal class JsonNetBlittableEntitySerializer
     {
-        private readonly DocumentConventions _conventions;
+        private readonly ThreadLocal<BlittableJsonReader> _reader;
 
-        [ThreadStatic]
-        private static BlittableJsonReader _reader;
-        [ThreadStatic]
-        private static JsonSerializer _serializer;
-        [ThreadStatic]
-        private static Action<JsonSerializer> _customize;
+        private readonly ThreadLocal<JsonSerializer> _serializer;
 
         private readonly GenerateEntityIdOnTheClient _generateEntityIdOnTheClient;
 
         public JsonNetBlittableEntitySerializer(DocumentConventions conventions)
         {
-            _conventions = conventions;
             _generateEntityIdOnTheClient = new GenerateEntityIdOnTheClient(conventions, null);
+            _serializer = new ThreadLocal<JsonSerializer>(conventions.CreateSerializer);
+            _reader = new ThreadLocal<BlittableJsonReader>(() => new BlittableJsonReader());
         }
 
-        public static void CleanThreadStatics()
-        {
-            _reader = null;
-            _serializer = null;
-        }
         public object EntityFromJsonStream(Type type, BlittableJsonReaderObject jsonObject)
         {
-            if (_reader == null)
-                _reader = new BlittableJsonReader();
-            if (_serializer == null ||
-                _conventions.CustomizeJsonSerializer != _customize)
-            {
-                // we need to keep track and see if the event has been changed,
-                // if so, we'll need a new instance of the serializer
-                _customize = _conventions.CustomizeJsonSerializer;
-                _serializer = _conventions.CreateSerializer();
-            }
+            _reader.Value.Init(jsonObject);
 
-            _reader.Init(jsonObject);
             using (DefaultRavenContractResolver.RegisterExtensionDataSetter((o, key, value) =>
             {
                 JToken id;
@@ -72,9 +54,8 @@ namespace Raven.Client.Documents.Conventions
                 }
             }))
             {
-                return _serializer.Deserialize(_reader, type);
+                return _serializer.Value.Deserialize(_reader.Value, type);
             }
-
         }
     }
 }


### PR DESCRIPTION
- Switching JsonNetBlittableEntitySerializer from ThreadStatic to ThreadLocal. This way the serializer specific for document store conventions won't be shared even if the we switch between document stores in _the same thread_.
- There is no longer the need to track CustomJsonSerializer action because conventions are frozen after document store initialization so the serializer can't change afterwards