### PR TITLE
RavenDB-12197 - Matching graph queries syntax to the rest of RQL

### DIFF
--- a/src/Raven.Server/Documents/Queries/AST/GraphQuery.cs
+++ b/src/Raven.Server/Documents/Queries/AST/GraphQuery.cs
@@ -8,9 +8,9 @@ namespace Raven.Server.Documents.Queries.AST
     {
         public HashSet<StringSegment> RecursiveMatches = new HashSet<StringSegment>(StringSegmentEqualityComparer.Instance);
 
-        public Dictionary<StringSegment, Query> WithDocumentQueries;
-     
-        public Dictionary<StringSegment, WithEdgesExpression> WithEdgePredicates;
+        public Dictionary<StringSegment, Query> WithDocumentQueries = new Dictionary<StringSegment, Query>();
+
+        public Dictionary<StringSegment, WithEdgesExpression> WithEdgePredicates = new Dictionary<StringSegment, WithEdgesExpression>();
 
         public QueryExpression MatchClause;
 
@@ -32,6 +32,17 @@ namespace Raven.Server.Documents.Queries.AST
                 DeclaredFunctions = new Dictionary<StringSegment, (string FunctionText, Esprima.Ast.Program Program)>(CaseInsensitiveStringSegmentEqualityComparer.Instance);
 
             return DeclaredFunctions.TryAdd(name, func);
+        }
+
+        public bool HasAlias(StringSegment alias)
+        {
+            if (WithDocumentQueries.ContainsKey(alias))
+                return true;
+            if (WithEdgePredicates.ContainsKey(alias))
+                return true;
+            if (RecursiveMatches.Contains(alias))
+                return true;
+            return false;
         }
 
         public override string ToString()

--- a/src/Raven.Server/Documents/Queries/AST/Query.cs
+++ b/src/Raven.Server/Documents/Queries/AST/Query.cs
@@ -47,11 +47,6 @@ namespace Raven.Server.Documents.Queries.AST
                 GraphQuery = new GraphQuery();                
             }
 
-            if (GraphQuery.WithDocumentQueries == null)
-            {
-                GraphQuery.WithDocumentQueries = new Dictionary<StringSegment, Query>();
-            }
-
             if (GraphQuery.WithDocumentQueries.TryGetValue(alias, out var existing))
             {
                 if (query.From.From.Compound.Count == 0)
@@ -76,11 +71,6 @@ namespace Raven.Server.Documents.Queries.AST
             if (GraphQuery == null)
             {
                 GraphQuery = new GraphQuery();               
-            }
-
-            if (GraphQuery.WithEdgePredicates == null)
-            {
-                GraphQuery.WithEdgePredicates = new Dictionary<StringSegment, WithEdgesExpression>();
             }
 
             if (GraphQuery.WithEdgePredicates.ContainsKey(alias))

--- a/src/Raven.Server/Documents/Queries/AST/QueryVisitor.cs
+++ b/src/Raven.Server/Documents/Queries/AST/QueryVisitor.cs
@@ -68,11 +68,9 @@ namespace Raven.Server.Documents.Queries.AST
 
         public void VisitGraph(GraphQuery q)
         {
-            if (q.WithDocumentQueries != null)
-                VisitWithClauses(q.WithDocumentQueries);
+            VisitWithClauses(q.WithDocumentQueries);
 
-            if (q.WithEdgePredicates != null)
-                VisitWithEdgePredicates(q.WithEdgePredicates);
+            VisitWithEdgePredicates(q.WithEdgePredicates);
 
             if (q.MatchClause != null)
                 VisitMatchExpression(q.MatchClause);

--- a/src/Raven.Server/Documents/Queries/AST/StringQueryVisitor.cs
+++ b/src/Raven.Server/Documents/Queries/AST/StringQueryVisitor.cs
@@ -389,15 +389,7 @@ namespace Raven.Server.Documents.Queries.AST
             if (withEdgesClause.Path != null)
             {
                 _sb.Append("(");
-                bool first = true;
-                foreach (var item in withEdgesClause.Path.Compound)
-                {
-                    if (first == false)
-                        _sb.Append(".");
-                    first = false;
-                    _sb.Append(item);
-                }
-
+                VisitExpression(withEdgesClause.Path);
                 _sb.Append(")");
             }
 

--- a/src/Raven.Server/Documents/Queries/AST/WithEdgesExpression.cs
+++ b/src/Raven.Server/Documents/Queries/AST/WithEdgesExpression.cs
@@ -16,12 +16,15 @@ namespace Raven.Server.Documents.Queries.AST
 
         public StringSegment EdgeAlias;
 
-        public WithEdgesExpression(QueryExpression @where, FieldExpression path, List<(QueryExpression Expression, OrderByFieldType FieldType, bool Ascending)> orderBy)
+        public FieldExpression Project;
+
+        public WithEdgesExpression(QueryExpression @where, FieldExpression path, FieldExpression project, List<(QueryExpression Expression, OrderByFieldType FieldType, bool Ascending)> orderBy)
         {
             Where = @where;
             OrderBy = orderBy;
             Type = ExpressionType.WithEdge;
             Path = path;
+            Project = project;
         }
 
         public override string ToString() => GetText();

--- a/src/Raven.Server/Documents/Queries/GraphQueryRunner.Match.cs
+++ b/src/Raven.Server/Documents/Queries/GraphQueryRunner.Match.cs
@@ -151,8 +151,11 @@ namespace Raven.Server.Documents.Queries
 
                 foreach (var item in _inner)
                 {
-                    if (item.Key.StartsWith("_"))
-                        continue;
+                    // This is used as the sources for the query, and as such, we need it to
+                    // process all results, even if they are anonymous
+                    //
+                    // if (item.Key.StartsWith("_"))
+                    //    continue;
 
                     if (item.Value is Document d)
                     {

--- a/src/Raven.Server/Documents/Queries/GraphQueryRunner.cs
+++ b/src/Raven.Server/Documents/Queries/GraphQueryRunner.cs
@@ -839,9 +839,9 @@ namespace Raven.Server.Documents.Queries
                List<Match> relatedMatches)
             {
                 bool hasResults = false;
-                if (edge.Where != null)
+                if (edge.Where != null || edge.Project != null)
                 {
-                    if (src.TryGetMember(edge.Path.Compound[0], out var value) == false)
+                    if (src.TryGetMember(edge.Path.FieldValue, out var value) == false)
                         return false;
 
                     switch (value)
@@ -850,22 +850,22 @@ namespace Raven.Server.Documents.Queries
                             foreach (var item in array)
                             {
                                 if (item is BlittableJsonReaderObject json &&
-                                    edge.Where.IsMatchedBy(json, _queryParameters))
+                                    edge.Where?.IsMatchedBy(json, _queryParameters) != false)
                                 {
-                                    hasResults |= TryGetMatchesAfterFiltering(edgeResult, json, edge.Path.FieldValueWithoutAlias, edgeResults, alias, edge.EdgeAlias, relatedMatches);
+                                    hasResults |= TryGetMatchesAfterFiltering(edgeResult, json, edge.Project.FieldValue, edgeResults, alias, edge.EdgeAlias, relatedMatches);
                                 }
                             }
                             break;
                         case BlittableJsonReaderObject json:
-                            if (edge.Where.IsMatchedBy(json, _queryParameters))
+                            if (edge.Where?.IsMatchedBy(json, _queryParameters) != false)
                             {
-                                hasResults |= TryGetMatchesAfterFiltering(edgeResult, json, edge.Path.FieldValueWithoutAlias, edgeResults, alias, edge.EdgeAlias, relatedMatches);
+                                hasResults |= TryGetMatchesAfterFiltering(edgeResult, json, edge.Project.FieldValue, edgeResults, alias, edge.EdgeAlias, relatedMatches);
                             }
                             break;
                     }
                     return hasResults;
                 }
-                else
+                else 
                 {
                     hasResults = TryGetMatchesAfterFiltering(edgeResult, src, edge.Path.FieldValue, edgeResults, alias, edge.EdgeAlias, relatedMatches);
                 }

--- a/src/Raven.Server/Documents/Queries/Parser/QueryScanner.cs
+++ b/src/Raven.Server/Documents/Queries/Parser/QueryScanner.cs
@@ -201,7 +201,7 @@ namespace Raven.Server.Documents.Queries.Parser
             return _q[_pos] == match;
         }
 
-        public bool TryScan(string match, bool skipWhitespace = true)
+        public bool TryPeek(string match, bool skipWhitespace = true)
         {
             if (SkipWhitespace(skipWhitespace) == false)
                 return false;
@@ -218,6 +218,14 @@ namespace Raven.Server.Documents.Queries.Parser
                    char.IsLetterOrDigit(_q[_pos + match.Length]))
                     return false;
             }
+
+            return true;
+        }
+
+        public bool TryScan(string match, bool skipWhitespace = true)
+        {
+            if (TryPeek(match, skipWhitespace) == false)
+                return false;
 
             _pos += match.Length;
             Column += match.Length;

--- a/test/FastTests/Graph/IntersectionTests.cs
+++ b/test/FastTests/Graph/IntersectionTests.cs
@@ -54,9 +54,9 @@ namespace FastTests.Graph
                 using (var session = store.OpenSession())
                 {
                     var results = session.Advanced.RawQuery<JObject>(@"
-                       match (u1:Users(Name = 'A'))-[:HasRated.Movie]->(m:Movies)
+                       match (Users as u1 where Name = 'A')-[HasRated select Movie]->(Movies as m)
                              OR
-                             (u2:Users(Name = 'B'))-[:HasRated.Movie]->(m:Movies)
+                             (Users as u2 where Name = 'B')-[HasRated select Movie]->(Movies as m)
                        select u1.Name as u1, m.Name as movie, u2.Name as u2
                     ").ToList().Select(x => new
                     {
@@ -118,9 +118,9 @@ namespace FastTests.Graph
                 using (var session = store.OpenSession())
                 {
                     var results = session.Advanced.RawQuery<JObject>(@"
-                       match (u1:Users(Name = 'A'))-[:HasRated.Movie]->(m:Movies)
+                       match (Users as u1 where Name = 'A')-[HasRated select Movie]->(Movies as m)
                              AND
-                             (u2:Users(Name = 'B'))-[:HasRated.Movie]->(m:Movies)
+                             (Users as u2 where Name = 'B')-[HasRated select Movie]->(Movies as m)
                        select u1.Name as u1, m.Name as movie, u2.Name as u2
                     ").ToList();
 
@@ -175,9 +175,9 @@ namespace FastTests.Graph
                 using (var session = store.OpenSession())
                 {
                     var results = session.Advanced.RawQuery<JObject>(@"
-                       match (u1:Users(Name = 'A'))-[:HasRated.Movie]->(m:Movies)
+                       match (Users as u1 where Name = 'A')-[HasRated select Movie]->(Movies as m)
                              AND
-                             (u2:Users(Name = 'NON-EXISTENT'))-[:HasRated.Movie]->(m:Movies)
+                             (Users as u2 where Name = 'NON-EXISTENT')-[HasRated select Movie]->(Movies as m)
                        select u1.Name as u1, m.Name as movie, u2.Name as u2
                     ").ToList();
 
@@ -231,9 +231,9 @@ namespace FastTests.Graph
                 using (var session = store.OpenSession())
                 {
                     var results = session.Advanced.RawQuery<JObject>(@"
-                       match (u1:Users(Name = 'NON-EXISTENT'))-[:HasRated.Movie]->(m:Movies)
+                       match (Users as u1 where Name = 'NON-EXISTENT')-[HasRated select Movie]->(Movies as m)
                              AND
-                             (u2:Users(Name = 'B'))-[:HasRated.Movie]->(m:Movies)
+                             (Users as u2 where Name = 'B')-[HasRated select Movie]->(Movies as m)
                        select u1.Name as u1, m.Name as movie, u2.Name as u2
                     ").ToList();
 
@@ -289,9 +289,9 @@ namespace FastTests.Graph
                 using (var session = store.OpenSession())
                 {
                     var results = session.Advanced.RawQuery<JObject>(@"
-                       match (u1:Users(Name = 'A'))-[:HasRated.Movie]->(m:Movies)
+                       match (Users as u1 where Name = 'A')-[HasRated select Movie]->(Movies as m)
                              AND NOT
-                             (u2:Users(Name = 'B'))-[:HasRated.Movie]->(m:Movies)
+                             (Users as u2 where Name = 'B')-[HasRated select Movie]->(Movies as m)
                        select u1.Name as u1, m.Name as movie, u2.Name as u2
                     ").ToList();
 
@@ -347,9 +347,9 @@ namespace FastTests.Graph
                 using (var session = store.OpenSession())
                 {
                     var results = session.Advanced.RawQuery<JObject>(@"
-                       match (u1:Users(Name = 'A'))-[:HasRated.Movie]->(m:Movies)
+                       match (Users as u1 where Name = 'A')-[HasRated select Movie]->(Movies as m)
                              AND NOT
-                             (u2:Users(Name = 'B'))-[:HasRated.Movie]->(m:Movies)
+                             (Users as u2 where Name = 'B')-[HasRated select Movie]->(Movies as m)
                        select u1.Name as u1, m.Name as movie, u2.Name as u2
                     ").ToList().Select(x => new
                     {
@@ -411,9 +411,9 @@ namespace FastTests.Graph
                 using (var session = store.OpenSession())
                 {
                     var results = session.Advanced.RawQuery<JObject>(@"
-                       match (u1:Users(Name = 'A'))-[:HasRated.Movie]->(m:Movies)
+                       match (Users as u1 where Name = 'A')-[HasRated select Movie]->(Movies as m)
                              AND NOT
-                             (u2:Users(Name = 'NON-EXISTENT'))-[:HasRated.Movie]->(m:Movies)
+                             (Users as u2 where Name = 'NON-EXISTENT')-[HasRated select Movie]->(Movies as m)
                        select u1.Name as u1, m.Name as movie, u2.Name as u2
                     ").ToList().Select(x => new
                     {
@@ -477,9 +477,9 @@ namespace FastTests.Graph
                 using (var session = store.OpenSession())
                 {
                     var results = session.Advanced.RawQuery<JObject>(@"
-                       match (u1:Users(Name = 'A'))-[:HasRated.Movie]->(m:Movies)
+                       match (Users as u1 where Name = 'A')-[HasRated select Movie]->(Movies as m)
                              OR
-                             (u2:Users(Name = 'B'))-[:HasRated.Movie]->(m:Movies)
+                             (Users as u2 where Name = 'B')-[HasRated select Movie]->(Movies as m)
                        select u1.Name as u1, m.Name as movie, u2.Name as u2
                     ").ToList().Select(x => new
                     {
@@ -545,9 +545,9 @@ namespace FastTests.Graph
                 using (var session = store.OpenSession())
                 {
                     var results = session.Advanced.RawQuery<JObject>(@"
-                       match (u1:Users(Name = 'NON-EXISTENT'))-[:HasRated.Movie]->(m:Movies)
+                       match (Users as u1 where Name = 'NON-EXISTENT')-[HasRated select Movie]->(Movies as m)
                              OR
-                             (u2:Users(Name = 'B'))-[:HasRated.Movie]->(m:Movies)
+                             (Users as u2 where Name = 'B')-[HasRated select Movie]->(Movies as m)
                        select u1.Name as u1, m.Name as movie, u2.Name as u2
                     ").ToList().Select(x => new
                     {
@@ -611,9 +611,9 @@ namespace FastTests.Graph
                 using (var session = store.OpenSession())
                 {
                     var results = session.Advanced.RawQuery<JObject>(@"
-                       match (u1:Users(Name = 'NON-EXISTENT'))-[:HasRated.Movie]->(m:Movies)
+                       match (Users as u1 where Name = 'NON-EXISTENT')-[HasRated select Movie]->(Movies as m)
                              OR
-                             (u2:Users(Name = 'NON-EXISTENT2'))-[:HasRated.Movie]->(m:Movies)
+                             (Users as u2 where Name = 'NON-EXISTENT2')-[HasRated select Movie]->(Movies as m)
                        select u1.Name as u1, m.Name as movie, u2.Name as u2
                     ").ToList();
 
@@ -669,9 +669,9 @@ namespace FastTests.Graph
                 using (var session = store.OpenSession())
                 {
                     var results = session.Advanced.RawQuery<JObject>(@"
-                       match (u1:Users(Name = 'NON-EXISTENT'))-[:HasRated.Movie]->(m:Movies)
+                       match (Users as u1 where Name = 'NON-EXISTENT')-[HasRated select Movie]->(Movies as m)
                              AND
-                             (u2:Users(Name = 'NON-EXISTENT2'))-[:HasRated.Movie]->(m:Movies)
+                             (Users as u2 where Name = 'NON-EXISTENT2')-[HasRated select Movie]->(Movies as m)
                        select u1.Name as u1, m.Name as movie, u2.Name as u2
                     ").ToList();
 
@@ -727,9 +727,9 @@ namespace FastTests.Graph
                 using (var session = store.OpenSession())
                 {
                     var results = session.Advanced.RawQuery<JObject>(@"
-                       match (u1:Users(Name = 'NON-EXISTENT'))-[:HasRated.Movie]->(m:Movies)
+                       match (Users as u1 where Name = 'NON-EXISTENT')-[HasRated select Movie]->(Movies as m)
                              AND NOT
-                             (u2:Users(Name = 'NON-EXISTENT2'))-[:HasRated.Movie]->(m:Movies)
+                             (Users as u2 where Name = 'NON-EXISTENT2')-[HasRated select Movie]->(Movies as m)
                        select u1.Name as u1, m.Name as movie, u2.Name as u2
                     ").ToList();
 
@@ -786,9 +786,9 @@ namespace FastTests.Graph
                 {
                     Assert.Throws<RavenException>(() => 
                         session.Advanced.RawQuery<JObject>(@"
-                           match (u1:Users(Name = 'NON-EXISTENT'))-[:HasRated.Movie]->(m:Movies)
+                           match (Users as u1 where Name = 'NON-EXISTENT')-[HasRated select Movie]->(Movies as m)
                                   FOOBAR 
-                                 (u2:Users(Name = 'NON-EXISTENT2'))-[:HasRated.Movie]->(m:Movies)
+                                 (Users as u2 where Name = 'NON-EXISTENT2')-[HasRated select Movie]->(Movies as m)
                            select u1.Name as u1, m.Name as movie, u2.Name as u2
                         ").ToList());
                 }
@@ -841,9 +841,9 @@ namespace FastTests.Graph
                 using (var session = store.OpenSession())
                 {
                     var results = session.Advanced.RawQuery<JObject>(@"
-                       match (u1:Users(Name = 'A'))-[:HasRated.Movie]->(m:Movies)
+                       match (Users as u1 where Name = 'A')-[HasRated select Movie]->(Movies as m)
                              OR
-                             (u2:Users(Name = 'NON-EXISTENT'))-[:HasRated.Movie]->(m:Movies)
+                             (Users as u2 where Name = 'NON-EXISTENT')-[HasRated select Movie]->(Movies as m)
                        select u1.Name as u1, m.Name as movie, u2.Name as u2
                     ").ToList().Select(x => new
                     {
@@ -870,8 +870,8 @@ namespace FastTests.Graph
                 using (var session = store.OpenSession())
                 {
                     var results = session.Advanced.RawQuery<JObject>(@"
-                       match (u1:Users)-[:HasRated(Score > 1).Movie]->(m:Movies(id() = 'movies/2'))
-                         and (u2:Users)-[:HasRated.Movie]->(m:Movies(id() = 'movies/2'))
+                       match(Users as u1)-[HasRated where Score > 1 select Movie]->(Movies as m where id() = 'movies/2')
+                         and (Users as u2)-[HasRated select Movie]->(Movies as m where id() = 'movies/2')
                        select u1.Name as U1,u2.Name as U2
                     ").ToList().Select(x => new
                     {
@@ -899,7 +899,7 @@ namespace FastTests.Graph
                 using (var session = store.OpenSession())
                 {
                     var results = session.Advanced.RawQuery<JObject>(@"
-                       match (u1:Users)-[:HasRated(Score > 1).Movie]->(m:Movies(id() = 'movies/2'))<-[:HasRated.Movie]-(u2:Users)                              
+                       match(Users as u1)-[HasRated where Score > 1 select Movie]->(Movies as m where id() = 'movies/2')<-[HasRated select Movie]-(Users as u2)                              
                        select u1.Name as U1,u2.Name as U2
                     ").ToList().Select(x => new
                     {
@@ -928,7 +928,7 @@ namespace FastTests.Graph
                 {
                     Assert.Throws<InvalidQueryException>(() =>
                         session.Advanced.RawQuery<JObject>(@"
-                            match (u1:Users)-[:HasRated(Score > 1).Movie]->(m:Movies) AND
+                            match(Users as u1)-[HasRated where Score > 1 select Movie]->(Movies as m) AND
                             select u1,u2
                         ").ToList());
                 }
@@ -945,7 +945,7 @@ namespace FastTests.Graph
                 {
                     Assert.Throws<InvalidQueryException>(() =>
                         session.Advanced.RawQuery<JObject>(@"
-                            match (u1:Users)-[:HasRated(Score > 1).Movie]->(m:Movies) OR
+                            match(Users as u1)-[HasRated where Score > 1 select Movie]->(Movies as m) OR
                             select u1,u2
                         ").ToList());
                 }

--- a/test/FastTests/Graph/Parsing.cs
+++ b/test/FastTests/Graph/Parsing.cs
@@ -16,7 +16,7 @@ namespace FastTests.Graph
     FROM Users
 } AS u
 MATCH (u)")]
-        [InlineData("with { from Users} as u match (u)-[r:Rated(Rating > 4)]->(m:Movies)", @"WITH {
+        [InlineData("with { from Users} as u match (u)-[Rated as r where Rating > 4]->(Movies as m)", @"WITH {
     FROM Users
 } AS u
 WITH {
@@ -26,7 +26,7 @@ WITH EDGES (Rated) {
     WHERE Rating > 4
 } AS r
 MATCH (u)-[r]->(m)")]
-        [InlineData("match (u:Users(id() == 'users/1-A'))-[r:Rated(Rating > 4)]->(m:Movies(Genre = $genre))", @"WITH {
+        [InlineData("match (Users as u where id() == 'users/1-A')-[Rated as r where Rating > 4]->(Movies as m where Genre = $genre)", @"WITH {
     FROM Users WHERE id() = 'users/1-A'
 } AS u
 WITH {
@@ -36,7 +36,7 @@ WITH EDGES (Rated) {
     WHERE Rating > 4
 } AS r
 MATCH (u)-[r]->(m)")]
-        [InlineData("match (u:Users)<-[r:Rated]-(m:Movies)", @"WITH {
+        [InlineData("match (Users as u)<-[Rated as r]-(Movies as m)", @"WITH {
     FROM Users
 } AS u
 WITH {
@@ -46,7 +46,7 @@ WITH EDGES (Rated) AS r
 MATCH (m)-[r]->(u)")]
         [InlineData(@"
 with { from Movies where Genre = $genre } as m
-match (u:Users)<-[r:Rated]-(m) and (actor:Actors)-[:ActedOn]->(m) and (u)-[:Likes]->(actor)", @"WITH {
+match (Users as u)<-[Rated as r]-(m) and (Actors as actor)-[ActedOn]->(m) and (u)-[Likes]->(actor)", @"WITH {
     FROM Movies WHERE Genre = $genre
 } AS m
 WITH {
@@ -61,7 +61,7 @@ WITH EDGES (Likes) AS __alias2
 MATCH ((m)-[r]->(u) AND ((actor)-[__alias1]->(m) AND (u)-[__alias2]->(actor)))")]
         [InlineData(@"
 with { from Movies where Genre = $genre } as m
-match ((u:Users)<-[r:Rated]-(m) and not (actor:Actors)-[:ActedOn]->(m)) or (u)-[:Likes]->(actor)", @"WITH {
+match ((Users as u)<-[Rated as r]-(m) and not (Actors as actor)-[ActedOn]->(m)) or (u)-[Likes]->(actor)", @"WITH {
     FROM Movies WHERE Genre = $genre
 } AS m
 WITH {
@@ -75,7 +75,7 @@ WITH EDGES (ActedOn) AS __alias1
 WITH EDGES (Likes) AS __alias2
 MATCH (((m)-[r]->(u) AND NOT ((actor)-[__alias1]->(m))) OR (u)-[__alias2]->(actor))")]
         [InlineData(@"with { from Movies where Genre = $genre } as m
-match (u:Users)<-[r:Rated]-(m)", @"WITH {
+match (Users as u)<-[Rated as r]-(m)", @"WITH {
     FROM Movies WHERE Genre = $genre
 } AS m
 WITH {
@@ -84,7 +84,7 @@ WITH {
 WITH EDGES (Rated) AS r
 MATCH (m)-[r]->(u)")]
         [InlineData(@"with { from Movies where Genre = $genre } as m
-match (u:Users)<-[r:Rated]-(m)->(a:Actor)", @"WITH {
+match (Users as u)<-[Rated as r]-(m)->(Actor as a)", @"WITH {
     FROM Movies WHERE Genre = $genre
 } AS m
 WITH {
@@ -99,6 +99,11 @@ MATCH ((m)-[r]->(u) AND (m)->(a))")]
         {
             var queryParser = new QueryParser();
             queryParser.Init(q);
+            var a = q.Contains("((");
+            if (a)
+            {
+                System.Console.WriteLine();
+            }
             var query = queryParser.Parse();
             var result = query.ToString();
             //System.Console.WriteLine(result);
@@ -134,7 +139,7 @@ match (u)
         {
             const string text = @"
 with { from Users } as src
-match (src)-[r1:Rated]->(m:Movie)<-[r2:Rated]-(dst:Users) and (dst:Users)-[a:PaidFor]->(m)
+match (src)-[Rated as r1]->(Movie as m)<-[Rated as r2]-(Users as dst) and (Users as dst)-[PaidFor as a]->(m)
 ";
             var queryParser = new QueryParser();
             queryParser.Init(text);
@@ -220,7 +225,7 @@ match (m)<-[r]-(u)
         public void CanRewriteQuery()
         {
             const string text = @"
-match (m:Movies)<-[r:Rated]-( u:Users(City='Hadera') )
+match (Movies as m)<-[Rated as r]-( Users as u where City='Hadera' )
 ";
             var queryParser = new QueryParser();
             queryParser.Init(text);

--- a/test/FastTests/Graph/VerticesFromIndexes.cs
+++ b/test/FastTests/Graph/VerticesFromIndexes.cs
@@ -20,7 +20,7 @@ namespace FastTests.Graph
                 {
                     var results = session.Advanced.RawQuery<JObject>(@"
                         with { from index 'Orders/ByCompany' } as o
-                        match (o)-[:Company]->(c:Companies)
+                        match (o)-[Company]->(Companies as c) 
                     ").ToList();
 
                     Assert.NotEmpty(results); //sanity check
@@ -50,7 +50,7 @@ namespace FastTests.Graph
                 {
                     var results = session.Advanced.RawQuery<Order>(@"
                         with { from index 'Orders/Totals' order by id() desc} as o
-                        match (o)-[:Company]->(c:Companies)
+                        match (o)-[Company]->(Companies as c)
                         select o
                     ").ToList();
 
@@ -74,7 +74,7 @@ namespace FastTests.Graph
                 {
                     var e = Assert.Throws<RavenException>(() => session.Advanced.RawQuery<JObject>(@"
                         with { from index 'Orders/ByCompany' } as byCompaniesMapReduceResults
-                        match (o:Orders)-[:Company]->(byCompaniesMapReduceResults)
+                        match (Orders as o)-[Company]->(byCompaniesMapReduceResults)
                     ").ToList());
 
                     Assert.IsType<InvalidOperationException>(e.InnerException);
@@ -94,7 +94,7 @@ namespace FastTests.Graph
                 {
                     var e = Assert.Throws<RavenException>(() => session.Advanced.RawQuery<JObject>(@"
                         with { from index 'Orders/ByCompany' } as indexQueryResults
-                        match (o:Orders)-[:Company]->(indexQueryResults)-[:Company]->(c:Companies)
+                        match (Orders as o)-[Company]->(indexQueryResults)-[Company]->(Companies as c)
                     ").ToList());
 
                     Assert.IsType<InvalidOperationException>(e.InnerException);


### PR DESCRIPTION
Changing the syntax to be more natural, see:
```
with { from Movies where Genre = $genre } as m
match (Users as u)<-[Rated as r]-(m) and (Actors as actor)-[ActedOn]->(m) and (u)-[Likes]->(actor)
```