### PR TITLE
RavenDB-11766 When studio collects index stats and some index throws …

### DIFF
--- a/src/Raven.Server/Documents/Handlers/IndexHandler.cs
+++ b/src/Raven.Server/Documents/Handlers/IndexHandler.cs
@@ -21,6 +21,8 @@ using Raven.Server.Documents.Patch;
 using Raven.Server.Documents.Queries;
 using Raven.Server.Documents.Queries.Dynamic;
 using Raven.Server.Json;
+using Raven.Server.NotificationCenter.Notifications;
+using Raven.Server.NotificationCenter.Notifications.Details;
 using Raven.Server.Routing;
 using Raven.Server.ServerWide;
 using Raven.Server.ServerWide.Context;
@@ -256,11 +258,49 @@ namespace Raven.Server.Documents.Handlers
                 using (context.OpenReadTransaction())
                 {
                     if (string.IsNullOrEmpty(name))
+                    {
                         indexStats = Database.IndexStore
                             .GetIndexes()
                             .OrderBy(x => x.Name)
-                            .Select(x => x.GetStats(calculateLag: true, calculateStaleness: true, documentsContext: context))
+                            .Select(x =>
+                            {
+                                try
+                                {
+                                    return x.GetStats(calculateLag: true, calculateStaleness: true, documentsContext: context);
+                                }
+                                catch (Exception e)
+                                {
+                                    if (Logger.IsOperationsEnabled)
+                                        Logger.Operations($"Failed to get stats of '{x.Name}' index", e);
+
+                                    Database.NotificationCenter.Add(AlertRaised.Create(Database.Name, $"Failed to get stats of '{x.Name}' index",
+                                        $"Exception was thrown on getting stats of '{x.Name}' index",
+                                        AlertType.Indexing_CouldNotGetStats, NotificationSeverity.Error, key: x.Name, details: new ExceptionDetails(e)));
+                                    
+                                    try
+                                    {
+                                        x.SetState(IndexState.Error, inMemoryOnly: true);
+                                    }
+                                    catch (Exception ex)
+                                    {
+                                        if (Logger.IsOperationsEnabled)
+                                            Logger.Operations($"Failed to change state of '{x.Name}' index to error after encountering exception when getting its stats.",
+                                                ex);
+                                    }
+                                    
+                                    return new IndexStats
+                                    {
+                                        Name = x.Name,
+                                        Type = x.Type,
+                                        State = IndexState.Error,
+                                        Status = x.Status,
+                                        LockMode = x.Definition.LockMode,
+                                        Priority = x.Definition.Priority,
+                                    };
+                                }
+                            })
                             .ToArray();
+                    }
                     else
                     {
                         var index = Database.IndexStore.GetIndex(name);
@@ -270,7 +310,7 @@ namespace Raven.Server.Documents.Handlers
                             return Task.CompletedTask;
                         }
 
-                        indexStats = new[] { index.GetStats(calculateLag: true, calculateStaleness: true, documentsContext: context) };
+                        indexStats = new[] {index.GetStats(calculateLag: true, calculateStaleness: true, documentsContext: context)};
                     }
                 }
 

--- a/src/Raven.Server/Documents/Indexes/Auto/AutoMapIndex.cs
+++ b/src/Raven.Server/Documents/Indexes/Auto/AutoMapIndex.cs
@@ -41,9 +41,9 @@ namespace Raven.Server.Documents.Indexes.Auto
             SetPriority(definition.Priority);
         }
 
-        public override void SetState(IndexState state)
+        public override void SetState(IndexState state, bool inMemoryOnly = false)
         {
-            base.SetState(state);
+            base.SetState(state, inMemoryOnly);
             Definition.State = state;
         }
 

--- a/src/Raven.Server/Documents/Indexes/Errors/FaultyInMemoryIndex.cs
+++ b/src/Raven.Server/Documents/Indexes/Errors/FaultyInMemoryIndex.cs
@@ -124,7 +124,7 @@ namespace Raven.Server.Documents.Indexes.Errors
             throw new NotSupportedException($"Index {Name} is in-memory implementation of a faulty index", _e);
         }
 
-        public override void SetState(IndexState state)
+        public override void SetState(IndexState state, bool inMemoryOnly = false)
         {
             throw new NotSupportedException($"Index {Name} is in-memory implementation of a faulty index", _e);
         }

--- a/src/Raven.Server/Documents/Indexes/Index.cs
+++ b/src/Raven.Server/Documents/Indexes/Index.cs
@@ -1154,7 +1154,7 @@ namespace Raven.Server.Documents.Indexes
                     try
                     {
                         DocumentDatabase.NotificationCenter.Add(AlertRaised.Create(DocumentDatabase.Name, $"Unexpected error in '{Name}' index",
-                            "Unexpected error in indexing thread. See details.", AlertType.UnexpectedIndexingThreadError, NotificationSeverity.Error,
+                            "Unexpected error in indexing thread. See details.", AlertType.Indexing_UnexpectedIndexingThreadError, NotificationSeverity.Error,
                             details: new ExceptionDetails(e)));
                     }
                     catch (Exception)
@@ -1646,7 +1646,7 @@ namespace Raven.Server.Documents.Indexes
             }
         }
 
-        public virtual void SetState(IndexState state)
+        public virtual void SetState(IndexState state, bool inMemoryOnly = false)
         {
             if (State == state)
                 return;
@@ -1664,9 +1664,12 @@ namespace Raven.Server.Documents.Indexes
                 if (_logger.IsInfoEnabled)
                     _logger.Info($"Changing state for '{Name})' from '{State}' to '{state}'.");
 
-
                 var oldState = State;
                 State = state;
+
+                if (inMemoryOnly)
+                    return;
+
                 try
                 {
                     // this might fail if we can't write, so we first update the in memory state

--- a/src/Raven.Server/Documents/Indexes/MapReduce/Auto/AutoMapReduceIndex.cs
+++ b/src/Raven.Server/Documents/Indexes/MapReduce/Auto/AutoMapReduceIndex.cs
@@ -81,9 +81,9 @@ namespace Raven.Server.Documents.Indexes.MapReduce.Auto
             SetPriority(definition.Priority);
         }
 
-        public override void SetState(IndexState state)
+        public override void SetState(IndexState state, bool inMemoryOnly = false)
         {
-            base.SetState(state);
+            base.SetState(state, inMemoryOnly);
             Definition.State = state;
         }
 

--- a/src/Raven.Server/NotificationCenter/Notifications/AlertType.cs
+++ b/src/Raven.Server/NotificationCenter/Notifications/AlertType.cs
@@ -52,6 +52,7 @@ namespace Raven.Server.NotificationCenter.Notifications
 
         OutOfMemoryException,
 
-        UnexpectedIndexingThreadError
+        Indexing_UnexpectedIndexingThreadError,
+        Indexing_CouldNotGetStats
     }
 }

--- a/test/SlowTests/Bugs/Indexing/ThrowingAnalyzer.cs
+++ b/test/SlowTests/Bugs/Indexing/ThrowingAnalyzer.cs
@@ -99,7 +99,7 @@ namespace SlowTests.Bugs.Indexing
                         session.SaveChanges();
                     }
 
-                    Assert.Throws<RavenException>(() => WaitForIndexing(store));
+                    WaitForIndexing(store, allowErrors: true);
                 }
 
                 var fooIndex = store.Maintenance.Send(new GetStatisticsOperation()).Indexes.First(x => x.Name == "foo");


### PR DESCRIPTION
…error then let's mark such index as errored and create notification with actual exception. This way the Indexes page in the studio can still operate and allow users to reset / delete corrupted index.