### PR TITLE
RavenDB-12227 Skipping compaction of map-reduce indexes. The reason i…

### DIFF
--- a/src/Raven.Server/Documents/Indexes/Index.cs
+++ b/src/Raven.Server/Documents/Indexes/Index.cs
@@ -2947,6 +2947,16 @@ namespace Raven.Server.Documents.Indexes
 
             result.SizeBeforeCompactionInMb = CalculateIndexStorageSize().GetValue(SizeUnit.Megabytes);
 
+            if (Type.IsMapReduce())
+            {
+                result.AddMessage($"Skipping compaction of '{Name}' index because compaction of map-reduce indexes isn't supported");
+                onProgress?.Invoke(result.Progress);
+                result.TreeName = null;
+                result.SizeAfterCompactionInMb = result.SizeBeforeCompactionInMb;
+
+                return;
+            }
+
             result.AddMessage($"Starting compaction of index '{Name}'.");
             result.AddMessage($"Draining queries for {Name}.");
             onProgress?.Invoke(result.Progress);


### PR DESCRIPTION
…s that we refer to page numbers (PageNumberToReduceResult tree) but the compaction process is just re-arranging things without touching the data