### PR TITLE
RavenDB-12204: Document metadata won't have hasCounter/hasRevisions flags when migrating without counters/revisions. 

### DIFF
--- a/src/Raven.Server/Documents/BlittableMetadataModifier.cs
+++ b/src/Raven.Server/Documents/BlittableMetadataModifier.cs
@@ -3,6 +3,7 @@ using System.Diagnostics;
 using System.IO;
 using System.Runtime.CompilerServices;
 using Raven.Client;
+using Raven.Client.Documents.Smuggler;
 using Raven.Server.Utils;
 using Sparrow;
 using Sparrow.Collections;
@@ -33,6 +34,7 @@ namespace Raven.Server.Documents
         // We'll generate a new change vector in this format: "RV:{revisionsCount}-{firstEtagOfLegacyRevision}"
         public bool ReadFirstEtagOfLegacyRevision;
         public bool ReadLegacyEtag;
+        public DatabaseItemType OperateOnTypes;
         public string LegacyEtag { get; private set; }
         private string _firstEtagOfLegacyRevision;
         private long _legacyRevisionsCount;
@@ -245,7 +247,22 @@ namespace Raven.Server.Documents
                     {
                         return true;
                     }
+                case -2: // IgnoreArrayProperty
+                    {
+                        if (state.CurrentTokenType != JsonParserToken.StartArray)
+                            ThrowInvalidArrayType(state, reader);
 
+                        while (state.CurrentTokenType != JsonParserToken.EndArray)
+                        {
+                            if (reader.Read() == false)
+                            {
+                                _state = State.IgnoreArray;
+                                aboutToReadPropertyName = false;
+                                return true;
+                            }
+                        }
+                        break;
+                    }
                 case -1: // IgnoreProperty
                     {
                         if (reader.Read() == false)
@@ -343,6 +360,27 @@ namespace Raven.Server.Documents
                     Flags = ReadFlags(state);
                     break;
 
+                case 9: // @counters
+                    if (OperateOnTypes.HasFlag(DatabaseItemType.Counters) == false)
+                    {
+                        if (state.StringBuffer[0] != (byte)'@' ||
+                        *(long*)(state.StringBuffer + 1) != 8318823012450529123)
+                        {
+                            aboutToReadPropertyName = true;
+                            return true;
+                        }
+
+                        if (reader.Read() == false)
+                        {
+                            _verifyStartArray = true;
+                            _state = State.IgnoreArray;
+                            aboutToReadPropertyName = false;
+                            return true;
+                        }
+                        goto case -2;
+                    }
+                    
+                    return true;
                 case 12: // @index-score
                     if (state.StringBuffer[0] != (byte)'@' ||
                         *(long*)(state.StringBuffer + 1) != 7166121427196997225 ||
@@ -518,18 +556,7 @@ namespace Raven.Server.Documents
                     // Raven-Replication-History is an array
                     if (isReplicationHistory)
                     {
-                        if (state.CurrentTokenType != JsonParserToken.StartArray)
-                            ThrowInvalidReplicationHistoryType(state, reader);
-
-                        do
-                        {
-                            if (reader.Read() == false)
-                            {
-                                _state = State.IgnoreArray;
-                                aboutToReadPropertyName = false;
-                                return true;
-                            }
-                        } while (state.CurrentTokenType != JsonParserToken.EndArray);
+                        goto case -2;
                     }
                     else if (state.CurrentTokenType == JsonParserToken.StartArray ||
                              state.CurrentTokenType == JsonParserToken.StartObject)
@@ -743,6 +770,11 @@ namespace Raven.Server.Documents
         private void ThrowInvalidReplicationHistoryType(JsonParserState state, IJsonParser reader)
         {
             throw new InvalidDataException($"Expected property @metadata.Raven-Replication-History to have array type, but was: {state.CurrentTokenType}. Id: '{Id ?? "N/A"}'. Around: {reader.GenerateErrorState()}");
+        }
+
+        private void ThrowInvalidArrayType(JsonParserState state, IJsonParser reader)
+        {
+            throw new InvalidDataException($"Expected property to have array type, but was: {state.CurrentTokenType}. Id: '{Id ?? "N/A"}'. Around: {reader.GenerateErrorState()}");
         }
 
         public void Dispose()

--- a/src/Raven.Server/Documents/Document.cs
+++ b/src/Raven.Server/Documents/Document.cs
@@ -70,6 +70,14 @@ namespace Raven.Server.Documents
             if (IndexScore.HasValue)
                 mutatedMetadata[Constants.Documents.Metadata.IndexScore] = IndexScore;
 
+            if (NonPersistentFlags.HasFlag(NonPersistentDocumentFlags.FromSmuggler) &&
+                Flags.HasFlag(DocumentFlags.HasCounters) == false &&
+                metadata != null &&
+                metadata.TryGet(Constants.Documents.Metadata.Counters, out BlittableJsonReaderArray _))
+            {
+                mutatedMetadata.Remove(Constants.Documents.Metadata.Counters);
+            }
+
             _hash = null;
         }
 

--- a/src/Raven.Server/Documents/Document.cs
+++ b/src/Raven.Server/Documents/Document.cs
@@ -70,14 +70,6 @@ namespace Raven.Server.Documents
             if (IndexScore.HasValue)
                 mutatedMetadata[Constants.Documents.Metadata.IndexScore] = IndexScore;
 
-            if (NonPersistentFlags.HasFlag(NonPersistentDocumentFlags.FromSmuggler) &&
-                Flags.HasFlag(DocumentFlags.HasCounters) == false &&
-                metadata != null &&
-                metadata.TryGet(Constants.Documents.Metadata.Counters, out BlittableJsonReaderArray _))
-            {
-                mutatedMetadata.Remove(Constants.Documents.Metadata.Counters);
-            }
-
             _hash = null;
         }
 

--- a/src/Raven.Server/Smuggler/Documents/StreamDestination.cs
+++ b/src/Raven.Server/Smuggler/Documents/StreamDestination.cs
@@ -422,7 +422,7 @@ namespace Raven.Server.Smuggler.Documents
                 Writer.WriteComma();
 
                 Writer.WritePropertyName(nameof(DocumentItem.CounterItem.Value));
-                Writer.WriteDouble(counterDetail.TotalValue);
+                Writer.WriteInteger(counterDetail.TotalValue);
                 Writer.WriteComma();
 
                 Writer.WritePropertyName(nameof(DocumentItem.CounterItem.ChangeVector));

--- a/src/Raven.Server/Smuggler/Documents/StreamSource.cs
+++ b/src/Raven.Server/Smuggler/Documents/StreamSource.cs
@@ -47,6 +47,7 @@ namespace Raven.Server.Smuggler.Documents
         private bool _readLegacyEtag;
 
         private Size _totalObjectsRead = new Size(0, SizeUnit.Bytes);
+        private DatabaseItemType _operateOnTypes;
 
         public StreamSource(Stream stream, DocumentsOperationContext context, DocumentDatabase database)
         {
@@ -69,6 +70,7 @@ namespace Raven.Server.Smuggler.Documents
             if (_state.CurrentTokenType != JsonParserToken.StartObject)
                 UnmanagedJsonParserHelper.ThrowInvalidJson("Expected start object, but got " + _state.CurrentTokenType, _peepingTomStream, _parser);
 
+            _operateOnTypes = options.OperateOnTypes;
             buildVersion = ReadBuildVersion();
             _buildVersionType = BuildVersion.Type(buildVersion);
 #pragma warning disable 618
@@ -709,7 +711,8 @@ namespace Raven.Server.Smuggler.Documents
             var modifier = new BlittableMetadataModifier(context)
             {
                 ReadFirstEtagOfLegacyRevision = legacyImport,
-                ReadLegacyEtag = _readLegacyEtag
+                ReadLegacyEtag = _readLegacyEtag,
+                OperateOnTypes = _operateOnTypes
             };
             var builder = CreateBuilder(context, modifier);
             try

--- a/src/Raven.Server/Smuggler/Migration/Importer.cs
+++ b/src/Raven.Server/Smuggler/Migration/Importer.cs
@@ -157,7 +157,8 @@ namespace Raven.Server.Smuggler.Migration
                 var destination = new DatabaseDestination(Parameters.Database);
                 var options = new DatabaseSmugglerOptionsServerSide
                 {
-                    TransformScript = Options.TransformScript
+                    TransformScript = Options.TransformScript,
+                    OperateOnTypes = Options.OperateOnTypes
                 };
                 var smuggler = new Documents.DatabaseSmuggler(Parameters.Database, source, destination, Parameters.Database.Time, options, Parameters.Result, Parameters.OnProgress, Parameters.CancelToken.Token);
 

--- a/test/SlowTests/Issues/RavenDB-12204.cs
+++ b/test/SlowTests/Issues/RavenDB-12204.cs
@@ -1,0 +1,127 @@
+﻿using System.IO;
+using System.Threading.Tasks;
+using FastTests;
+using FastTests.Utils;
+using Raven.Client.Documents.Smuggler;
+using Raven.Tests.Core.Utils.Entities;
+using Xunit;
+
+namespace SlowTests.Issues
+{
+    public class RavenDB_12204 : RavenTestBase
+    {
+        [Fact]
+        public async Task CanMigrateFromRavenDb()
+        {
+            var file = Path.GetTempFileName();
+            var id = "users/1";
+
+            using (var store1 = GetDocumentStore())
+            {
+                await RevisionsHelper.SetupRevisions(Server.ServerStore, store1.Database);
+                using (var session = store1.OpenAsyncSession())
+                {
+                    await session.StoreAsync(new User
+                    {
+                        Name = "Egor"
+                    }, id);
+                    {
+                        session.CountersFor(id).Increment("Downloads", int.MaxValue);
+                        session.CountersFor(id).Increment("ShouldBePositiveValueAfterSmuggler", long.MaxValue);
+                        session.CountersFor(id).Increment("LittleCounter", 500);
+                    }
+                    await session.SaveChangesAsync();
+                }
+                for (int i = 0; i < 10; i++)
+                {
+                    using (var session = store1.OpenAsyncSession())
+                    {
+                        var user = await session.LoadAsync<Company>(id);
+                        user.Name = "Egor " + i;
+                        await session.SaveChangesAsync();
+                    }
+                }
+                using (var session = store1.OpenAsyncSession())
+                {
+                    var revisionsMetadata = await session.Advanced.Revisions.GetMetadataForAsync(id);
+                    Assert.Equal(12, revisionsMetadata.Count);
+                }
+                await store1.Smuggler.ExportAsync(new DatabaseSmugglerExportOptions(), file);
+            }
+            // all data import
+            using (var store2 = GetDocumentStore())
+            {
+                await store2.Smuggler.ImportAsync(new DatabaseSmugglerImportOptions(), file);
+                using (var session = store2.OpenAsyncSession())
+                {
+                    var metadata = session.Advanced.GetMetadataFor(await session.LoadAsync<User>(id));
+                    Assert.Equal("HasRevisions, HasCounters", metadata.GetString("@flags"));
+                    var revisionsMetadata = await session.Advanced.Revisions.GetMetadataForAsync(id);
+                    Assert.Equal(13, revisionsMetadata.Count);  // +1 revision added when importing
+                    var dic = await session.CountersFor(id).GetAllAsync();
+                    Assert.Equal(3, dic.Count);
+                    Assert.Equal(int.MaxValue, dic["Downloads"]);
+                    Assert.Equal(long.MaxValue, dic["ShouldBePositiveValueAfterSmuggler"]);
+                    Assert.Equal(500, dic["LittleCounter"]);
+                }
+            }
+
+            // no DatabaseRecord, no RevisionDocuments, no Counters
+            using (var store3 = GetDocumentStore())
+            {
+                var importOptions = new DatabaseSmugglerImportOptions();
+                importOptions.OperateOnTypes -= DatabaseItemType.DatabaseRecord;
+                importOptions.OperateOnTypes -= DatabaseItemType.RevisionDocuments;
+                importOptions.OperateOnTypes -= DatabaseItemType.Counters;
+
+                await store3.Smuggler.ImportAsync(importOptions, file);
+                using (var session = store3.OpenAsyncSession())
+                {
+                    var metadata = session.Advanced.GetMetadataFor(await session.LoadAsync<User>(id));
+                    Assert.False(metadata.ContainsKey("@flags"));
+                    Assert.False(metadata.ContainsKey("@counters"));
+                    var revisionsMetadata = await session.Advanced.Revisions.GetMetadataForAsync(id);
+                    Assert.Equal(0, revisionsMetadata.Count);  // +1 revision added when importing
+                    var dic = await session.CountersFor(id).GetAllAsync();
+                    Assert.Equal(0, dic.Count);
+                }
+            }
+
+            // if doc has counters AND revisions => they must be kept.
+            using (var store4 = GetDocumentStore())
+            {
+                await RevisionsHelper.SetupRevisions(Server.ServerStore, store4.Database);
+                using (var session = store4.OpenAsyncSession())
+                {
+                    await session.StoreAsync(new User
+                    {
+                        Name = "Egor"
+                    }, id);
+                    {
+                        session.CountersFor(id).Increment("ShouldBeKeptAfterSmugglerImport", 322);
+                    }
+                    await session.SaveChangesAsync();
+                }
+                var importOptions = new DatabaseSmugglerImportOptions();
+                importOptions.OperateOnTypes -= DatabaseItemType.DatabaseRecord;
+                importOptions.OperateOnTypes -= DatabaseItemType.RevisionDocuments;
+                importOptions.OperateOnTypes -= DatabaseItemType.Counters;
+
+                await store4.Smuggler.ImportAsync(importOptions, file);
+
+                using (var session = store4.OpenAsyncSession())
+                {
+                    var user = await session.LoadAsync<User>(id);
+                    Assert.Equal("Egor 9", user.Name);   // check if document changed.
+                    var metadata = session.Advanced.GetMetadataFor(user);
+                    Assert.Equal("HasRevisions, HasCounters", metadata.GetString("@flags"));
+                    var revisionsMetadata = await session.Advanced.Revisions.GetMetadataForAsync(id);
+                    Assert.Equal(3, revisionsMetadata.Count);  // +1 revision added when importing
+                    var dic = await session.CountersFor(id).GetAllAsync();
+                    Assert.Equal(1, dic.Count);
+                    Assert.Equal(322, dic["ShouldBeKeptAfterSmugglerImport"]);
+                }
+            }
+        }
+    }
+}

--- a/test/SlowTests/Issues/RavenDB-12204.cs
+++ b/test/SlowTests/Issues/RavenDB-12204.cs
@@ -13,7 +13,7 @@ namespace SlowTests.Issues
         [Fact]
         public async Task CanMigrateFromRavenDb()
         {
-            var file = Path.GetTempFileName();
+            var file = Path.Combine(NewDataPath(forceCreateDir: true), "export.ravendbdump");
             var id = "users/1";
 
             using (var store1 = GetDocumentStore())


### PR DESCRIPTION
Also metadata won't have counters array when migrating without counters.