### PR TITLE
RavenDB-12274

### DIFF
--- a/src/Raven.Server/Documents/Handlers/BatchHandler.cs
+++ b/src/Raven.Server/Documents/Handlers/BatchHandler.cs
@@ -958,7 +958,6 @@ namespace Raven.Server.Documents.Handlers
                 foreach (var cmd in ParsedCommands)
                 {
                     cmd.Document?.Dispose();
-                    cmd.PatchCommand?.Dispose();
                 }
                 BatchRequestParser.ReturnBuffer(ParsedCommands);
                 AttachmentStreamsTempFile?.Dispose();

--- a/src/Raven.Server/Documents/Handlers/QueriesHandler.cs
+++ b/src/Raven.Server/Documents/Handlers/QueriesHandler.cs
@@ -330,7 +330,7 @@ namespace Raven.Server.Documents.Handlers
                 context.Write(writer, new DynamicJsonValue
                 {
                     ["Info"] = new DynamicJsonArray(command.DebugOutput),
-                    ["Actions"] = command.DebugActions?.GetDebugActions()
+                    ["Actions"] = command.DebugActions
                 });
 
                 writer.WriteEndObject();

--- a/src/Raven.Server/Documents/Patch/ScriptRunnerCache.cs
+++ b/src/Raven.Server/Documents/Patch/ScriptRunnerCache.cs
@@ -8,10 +8,11 @@ using JetBrains.Annotations;
 using Raven.Client.Extensions;
 using Raven.Server.Config;
 using Sparrow.Json.Parsing;
+using Sparrow.LowMemory;
 
 namespace Raven.Server.Documents.Patch
 {
-    public class ScriptRunnerCache
+    public class ScriptRunnerCache : ILowMemoryHandler
     {
         private readonly DocumentDatabase _database;
         private readonly RavenConfiguration _configuration;
@@ -39,6 +40,8 @@ namespace Raven.Server.Documents.Patch
         {
             _database = database;
             _configuration = configuration ?? throw new ArgumentNullException(nameof(configuration));
+
+            LowMemoryNotification.Instance.RegisterLowMemoryHandler(this);
         }
 
         public IEnumerable<DynamicJsonValue> GetDebugInfo(bool detailed = false)
@@ -137,6 +140,15 @@ namespace Raven.Server.Documents.Patch
             }
 
             return count;
+        }
+
+        public void LowMemory()
+        {
+            _cache.Clear();
+        }
+
+        public void LowMemoryOver()
+        {
         }
     }
 }


### PR DESCRIPTION
- ScriptRunnerCache should be cleared when in low-memory
- PatchDocumentCommand are checking-out patcher during execution and returning it back right after to avoid a situation when we will create a lot of Jint instances in single batch