### PR TITLE
RavenDB-12268 - cleanup the recycled scratch buffers only when there is no open read transaction that is still using it

### DIFF
--- a/src/Raven.Server/Documents/Indexes/Index.cs
+++ b/src/Raven.Server/Documents/Indexes/Index.cs
@@ -1197,6 +1197,11 @@ namespace Raven.Server.Documents.Indexes
             }
         }
 
+        public void Cleanup()
+        {
+            _environment?.Cleanup();
+        }
+
         protected virtual bool ShouldReplace()
         {
             return false;
@@ -1807,7 +1812,7 @@ namespace Raven.Server.Documents.Indexes
 
                 Stop(disableIndex: true);
                 SetState(IndexState.Disabled);
-                _environment?.Cleanup();
+                Cleanup();
             }
         }
 

--- a/src/Raven.Server/Documents/Indexes/Index.cs
+++ b/src/Raven.Server/Documents/Indexes/Index.cs
@@ -1131,11 +1131,13 @@ namespace Raven.Server.Documents.Indexes
                                     _logger.Info($"Indexing exceeded global limit for scratch space usage. Going to flush environment of '{Name}' index and forcing sync of data file");
 
                                 GlobalFlushingBehavior.GlobalFlusher.Value.MaybeFlushEnvironment(storageEnvironment);
-                                GlobalFlushingBehavior.GlobalFlusher.Value.ForceSyncEnvironment(storageEnvironment);
 
                                 if (_logsAppliedEvent.Wait(Configuration.MaxTimeToWaitAfterFlushAndSyncWhenExceedingScratchSpaceLimit.AsTimeSpan))
                                 {
-                                    // we've just flushed let's try to cleanup scratch space immediately
+                                    // we've just flushed let's start the sync process
+                                    GlobalFlushingBehavior.GlobalFlusher.Value.ForceSyncEnvironment(storageEnvironment);
+
+                                    // and cleanup scratch space immediately
                                     storageEnvironment.Cleanup();
                                 }
                             }

--- a/src/Raven.Server/Documents/Indexes/IndexStore.cs
+++ b/src/Raven.Server/Documents/Indexes/IndexStore.cs
@@ -1108,6 +1108,11 @@ namespace Raven.Server.Documents.Indexes
 
         public void RunIdleOperations()
         {
+            foreach (var index in _indexes)
+            {
+                index.StorageCleanup();
+            }
+
             long etag;
             using (_serverStore.ContextPool.AllocateOperationContext(out TransactionOperationContext context))
             using (context.OpenReadTransaction())

--- a/src/Raven.Server/Documents/Indexes/IndexStore.cs
+++ b/src/Raven.Server/Documents/Indexes/IndexStore.cs
@@ -1110,7 +1110,7 @@ namespace Raven.Server.Documents.Indexes
         {
             foreach (var index in _indexes)
             {
-                index.StorageCleanup();
+                index.Cleanup();
             }
 
             long etag;

--- a/src/Raven.Server/Documents/Indexes/IndexStore.cs
+++ b/src/Raven.Server/Documents/Indexes/IndexStore.cs
@@ -1111,7 +1111,7 @@ namespace Raven.Server.Documents.Indexes
             long etag;
             using (_serverStore.ContextPool.AllocateOperationContext(out TransactionOperationContext context))
             using (context.OpenReadTransaction())
-                _serverStore.Cluster.ReadDatabase(context, _documentDatabase.Name, out etag);
+                _serverStore.Cluster.ReadRawDatabase(context, _documentDatabase.Name, out etag);
 
             AsyncHelpers.RunSync(() => RunIdleOperationsAsync(etag));
         }

--- a/test/SlowTests/Voron/Issues/RavenDB-12268.cs
+++ b/test/SlowTests/Voron/Issues/RavenDB-12268.cs
@@ -1,0 +1,63 @@
+﻿using System;
+using System.IO;
+using FastTests.Voron;
+using Sparrow;
+using Voron;
+using Xunit;
+
+namespace SlowTests.Voron.Issues
+{
+    public class RavenDB_12268 : StorageTest
+    {
+        [Fact]
+        public void UsedScratchBuffersArentDeleted()
+        {
+            // prevent the work of the global flushing behavior
+            Env.Options.MaxNumberOfPagesInJournalBeforeFlush = long.MaxValue;
+            Env.Options.MaxScratchBufferSize = new Size(64, SizeUnit.Kilobytes).GetValue(SizeUnit.Bytes);
+
+            using (var tx = Env.WriteTransaction())
+            {
+                tx.CreateTree("tree");
+                tx.Commit();
+            }
+            
+            var random = new Random(1);
+            var bytes = new byte[1024 * 8];
+
+            using (var tx = Env.WriteTransaction())
+            {
+                var tree = tx.ReadTree("tree");
+                for (var i = 0; i < 128; i++)
+                {
+                    random.NextBytes(bytes);
+                    tree.Add(i.ToString(), new MemoryStream(bytes));
+                }
+
+                tx.Commit();
+            }
+
+            using (var tx = Env.NewLowLevelTransaction(new TransactionPersistentContext(),
+                TransactionFlags.ReadWrite, timeout: TimeSpan.FromMilliseconds(500)))
+            {
+                tx.ModifyPage(0);
+                tx.Commit();
+            }
+
+            Env.BackgroundFlushWritesToDataFile();
+
+            using (Env.ReadTransaction())
+            {
+                var infoForDebug = Env.ScratchBufferPool.InfoForDebug(0);
+                var numberOfScratchBuffers = infoForDebug.NumberOfScratchFiles;
+
+                Env.ScratchBufferPool.Cleanup();
+                infoForDebug = Env.ScratchBufferPool.InfoForDebug(0);
+
+                // the number of scratch buffers cannot be smaller since we are holding a read tx
+                // but it can be larger because we are creating an empty write tx inside the cleanup
+                Assert.True(numberOfScratchBuffers <= infoForDebug.NumberOfScratchFiles);
+            }
+        }
+    }
+}


### PR DESCRIPTION
http://issues.hibernatingrhinos.com/issue/RavenDB-12268