### PR TITLE
fix for RavenDB-12276

### DIFF
--- a/src/Raven.Server/Documents/DocumentsStorage.cs
+++ b/src/Raven.Server/Documents/DocumentsStorage.cs
@@ -1534,9 +1534,9 @@ namespace Raven.Server.Documents
             }
         }
 
-        public CollectionStats GetCollection(string collection, DocumentsOperationContext context)
+        public CollectionStats GetCollection(string collection, DocumentsOperationContext context, bool throwIfDoesNotExist = false)
         {
-            var collectionName = GetCollection(collection, throwIfDoesNotExist: false);
+            var collectionName = GetCollection(collection, throwIfDoesNotExist);
             if (collectionName == null)
             {
                 return new CollectionStats

--- a/src/Raven.Server/Documents/Queries/AbstractQueryRunner.cs
+++ b/src/Raven.Server/Documents/Queries/AbstractQueryRunner.cs
@@ -33,16 +33,17 @@ namespace Raven.Server.Documents.Queries
             Database = database;
         }
 
-        public Index GetIndex(string indexName)
+        public Index GetIndex(string indexName, bool throwIfDoesNotExist = false)
         {
             var index = Database.IndexStore.GetIndex(indexName);
-            if (index == null)
+            if (index == null && !throwIfDoesNotExist)
                 IndexDoesNotExistException.ThrowFor(indexName);
 
             return index;
         }
 
-        public abstract Task<DocumentQueryResult> ExecuteQuery(IndexQueryServerSide query, DocumentsOperationContext documentsContext, long? existingResultEtag, OperationCancelToken token);
+        public abstract Task<DocumentQueryResult> ExecuteQuery(IndexQueryServerSide query, DocumentsOperationContext documentsContext, long? existingResultEtag,
+            OperationCancelToken token, bool throwIfDoesNotExist = false);
 
         public abstract Task ExecuteStreamQuery(IndexQueryServerSide query, DocumentsOperationContext documentsContext, HttpResponse response,
             IStreamDocumentQueryResultWriter writer, OperationCancelToken token);

--- a/src/Raven.Server/Documents/Queries/Dynamic/DynamicQueryRunner.cs
+++ b/src/Raven.Server/Documents/Queries/Dynamic/DynamicQueryRunner.cs
@@ -31,12 +31,12 @@ namespace Raven.Server.Documents.Queries.Dynamic
         public override async Task ExecuteStreamQuery(IndexQueryServerSide query, DocumentsOperationContext documentsContext, HttpResponse response, IStreamDocumentQueryResultWriter writer,
             OperationCancelToken token)
         {
-            var index = await MatchIndex(query, true, customStalenessWaitTimeout: TimeSpan.FromSeconds(60), documentsContext, token.Token);
+            var index = await MatchIndex(query, true, customStalenessWaitTimeout: TimeSpan.FromSeconds(60), docsContext: documentsContext, token: token.Token);
 
             await index.StreamQuery(response, writer, query, documentsContext, token);
         }
 
-        public override async Task<DocumentQueryResult> ExecuteQuery(IndexQueryServerSide query, DocumentsOperationContext documentsContext, long? existingResultEtag, OperationCancelToken token)
+        public override async Task<DocumentQueryResult> ExecuteQuery(IndexQueryServerSide query, DocumentsOperationContext documentsContext, long? existingResultEtag, OperationCancelToken token, bool throwIfDoesNotExist = false)
         {
             Index index;
             using (query.Timings?.For(nameof(QueryTimingsScope.Names.Optimizer)))

--- a/src/Raven.Server/Documents/Queries/Graph/GraphQueryPlan.cs
+++ b/src/Raven.Server/Documents/Queries/Graph/GraphQueryPlan.cs
@@ -12,10 +12,10 @@ namespace Raven.Server.Documents.Queries.Graph
     {
         private IGraphQueryStep _rootQueryStep;
         private IndexQueryServerSide _query;
-        private DocumentsOperationContext _context;
-        private long? _resultEtag;
-        private OperationCancelToken _token;
-        private DocumentDatabase _database;
+        private readonly DocumentsOperationContext _context;
+        private readonly long? _resultEtag;
+        private readonly OperationCancelToken _token;
+        private readonly DocumentDatabase _database;
         public GraphQuery GraphQuery => _query.Metadata.Query.GraphQuery;
 
         public GraphQueryPlan(IndexQueryServerSide query, DocumentsOperationContext context, long? resultEtag,

--- a/src/Raven.Server/Documents/Queries/Graph/QueryQueryStep.cs
+++ b/src/Raven.Server/Documents/Queries/Graph/QueryQueryStep.cs
@@ -54,7 +54,7 @@ namespace Raven.Server.Documents.Queries.Graph
                 return default;
 
             var results = _queryRunner.ExecuteQuery(new IndexQueryServerSide(_queryMetadata),
-                  _context, _resultEtag, _token);
+                  _context, _resultEtag, _token, true);
 
             if (results.IsCompleted)
             {

--- a/src/Raven.Server/Documents/Queries/GraphQueryRunner.cs
+++ b/src/Raven.Server/Documents/Queries/GraphQueryRunner.cs
@@ -38,7 +38,7 @@ namespace Raven.Server.Documents.Queries
         }
 
         public override async Task<DocumentQueryResult> ExecuteQuery(IndexQueryServerSide query, DocumentsOperationContext documentsContext, long? existingResultEtag,
-            OperationCancelToken token)
+            OperationCancelToken token, bool throwIfDoesNotExist = false)
         {
             using (var timingScope = new QueryTimingsScope())
             {

--- a/src/Raven.Server/Documents/Queries/InvalidQueryRunner.cs
+++ b/src/Raven.Server/Documents/Queries/InvalidQueryRunner.cs
@@ -20,7 +20,7 @@ namespace Raven.Server.Documents.Queries
         {
         }
 
-        public override Task<DocumentQueryResult> ExecuteQuery(IndexQueryServerSide query, DocumentsOperationContext documentsContext, long? existingResultEtag, OperationCancelToken token)
+        public override Task<DocumentQueryResult> ExecuteQuery(IndexQueryServerSide query, DocumentsOperationContext documentsContext, long? existingResultEtag, OperationCancelToken token, bool throwIfDoesNotExist = false)
         {
             throw new NotSupportedException(ErrorMessage);
         }

--- a/src/Raven.Server/Documents/Queries/QueryRunner.cs
+++ b/src/Raven.Server/Documents/Queries/QueryRunner.cs
@@ -54,7 +54,7 @@ namespace Raven.Server.Documents.Queries
             return _static;
         }
 
-        public override async Task<DocumentQueryResult> ExecuteQuery(IndexQueryServerSide query, DocumentsOperationContext documentsContext, long? existingResultEtag, OperationCancelToken token)
+        public override async Task<DocumentQueryResult> ExecuteQuery(IndexQueryServerSide query, DocumentsOperationContext documentsContext, long? existingResultEtag, OperationCancelToken token, bool throwIfDoesNotExist = false)
         {
             ObjectDisposedException lastException = null;
             for (var i = 0; i < NumberOfRetries; i++)
@@ -69,7 +69,7 @@ namespace Raven.Server.Documents.Queries
                         if (scope == null)
                             sw = Stopwatch.StartNew();
 
-                        result = await GetRunner(query).ExecuteQuery(query, documentsContext, existingResultEtag, token);
+                        result = await GetRunner(query).ExecuteQuery(query, documentsContext, existingResultEtag, token, throwIfDoesNotExist);
                     }
 
                     result.DurationInMs = sw != null ? (long)sw.Elapsed.TotalMilliseconds : (long)scope.Duration.TotalMilliseconds;

--- a/src/Raven.Server/Documents/Queries/StaticIndexQueryRunner.cs
+++ b/src/Raven.Server/Documents/Queries/StaticIndexQueryRunner.cs
@@ -20,9 +20,9 @@ namespace Raven.Server.Documents.Queries
         {
         }
 
-        public override Task<DocumentQueryResult> ExecuteQuery(IndexQueryServerSide query, DocumentsOperationContext documentsContext, long? existingResultEtag, OperationCancelToken token)
+        public override Task<DocumentQueryResult> ExecuteQuery(IndexQueryServerSide query, DocumentsOperationContext documentsContext, long? existingResultEtag, OperationCancelToken token, bool throwIfDoesNotExist = false)
         {
-            var index = GetIndex(query.Metadata.IndexName);
+            var index = GetIndex(query.Metadata.IndexName, throwIfDoesNotExist);
 
             if (query.Metadata.HasOrderByRandom == false && existingResultEtag.HasValue)
             {

--- a/test/FastTests/Graph/BasicGraphQueries.cs
+++ b/test/FastTests/Graph/BasicGraphQueries.cs
@@ -83,6 +83,18 @@ namespace FastTests.Graph
         }
 
         [Fact]
+        public void Query_with_non_existing_collection_should_fail()
+        {
+            using (var store = GetDocumentStore())
+            {
+                using (var session = store.OpenSession())
+                {
+                    Assert.Throws<RavenException>(() => session.Advanced.RawQuery<JObject>(@"match (FooBar)").ToList());
+                }
+            }
+        }
+
+        [Fact]
         public void Query_with_no_matches_and_without_select_should_return_empty_result()
         {
             using (var store = GetDocumentStore())


### PR DESCRIPTION
Make graph queries throw when trying to fetch vertices from non-existing collection + relevant test