### PR TITLE
RavenDB-11970 Lets Encrypt client : retry sending request once

### DIFF
--- a/src/Raven.Server/RavenServer.cs
+++ b/src/Raven.Server/RavenServer.cs
@@ -414,6 +414,8 @@ namespace Raven.Server
 
         private Task _currentRefreshTask = Task.CompletedTask;
 
+        public Task RefreshTask => _currentRefreshTask;
+
         public void RefreshClusterCertificateTimerCallback(object state)
         {
             RefreshClusterCertificate(state);

--- a/test/SlowTests/Authentication/AuthenticationLetsEncryptTests.cs
+++ b/test/SlowTests/Authentication/AuthenticationLetsEncryptTests.cs
@@ -33,7 +33,7 @@ namespace SlowTests.Authentication
         {
             var settingPath = Path.Combine(NewDataPath(forceCreateDir: true), "settings.json");
             var defaultSettingsPath = new PathSetting("settings.default.json").FullPath;
-            File.Copy(defaultSettingsPath, settingPath);
+            File.Copy(defaultSettingsPath, settingPath, true);
 
             UseNewLocalServer(customConfigPath: settingPath);
 
@@ -187,7 +187,18 @@ namespace SlowTests.Authentication
 
                 var result = mre.Wait(Debugger.IsAttached ? TimeSpan.FromMinutes(10) : TimeSpan.FromMinutes(2));
 
-                Assert.True(result, "Waited too long for the cluster cert to be replaced");
+                if (result == false && Server.RefreshTask.IsCompleted)
+                {
+                    if (Server.RefreshTask.IsFaulted || Server.RefreshTask.IsCanceled)
+                    {
+                        Assert.True(result,
+                            $"Refresh task failed to complete successfully. Exception: {Server.RefreshTask.Exception}");
+                    }
+
+                    Assert.True(result, "Refresh task completed successfully, waited too long for the cluster cert to be replaced");
+                }
+
+                Assert.True(result, "Refresh task didn't complete. Waited too long for the cluster cert to be replaced");
 
                 Assert.NotEqual(firstServerCertThumbprint, Server.Certificate.Certificate.Thumbprint);
             }


### PR DESCRIPTION
Not relevant for 4.0.x, the LE client was replaced