### PR TITLE
RavenDB-12295 Unexpected ConcurrencyException when using optimistic c…

### DIFF
--- a/src/Raven.Server/Documents/ConflictsStorage.cs
+++ b/src/Raven.Server/Documents/ConflictsStorage.cs
@@ -784,7 +784,8 @@ namespace Raven.Server.Documents
                     context.GetLazyString(mergedChangeVector),
                     latestConflict.LastModified.Ticks,
                     changeVector,
-                    latestConflict.Flags).Etag;
+                    latestConflict.Flags, 
+                    NonPersistentDocumentFlags.None).Etag;
             }
 
             return collectionName;

--- a/src/Raven.Server/Documents/DocumentsStorage.cs
+++ b/src/Raven.Server/Documents/DocumentsStorage.cs
@@ -1352,7 +1352,11 @@ namespace Raven.Server.Documents
         {
             var newEtag = GenerateNextEtag();
 
-            if (string.IsNullOrEmpty(changeVector))
+            if (flags.Contain(DocumentFlags.FromReplication))
+            {
+                changeVector = docChangeVector;
+            }
+            else if (string.IsNullOrEmpty(changeVector))
             {
                 changeVector = ConflictsStorage.GetMergedConflictChangeVectorsAndDeleteConflicts(
                     context,

--- a/test/SlowTests/Server/Replication/ReplicationBasicTestsSlow.cs
+++ b/test/SlowTests/Server/Replication/ReplicationBasicTestsSlow.cs
@@ -6,7 +6,6 @@ using System.Threading.Tasks;
 using FastTests.Server.Replication;
 using Raven.Client.Documents.Operations.Replication;
 using Raven.Client.ServerWide.Operations.Certificates;
-using Raven.Server.ServerWide.Context;
 using Raven.Tests.Core.Utils.Entities;
 using Xunit;
 
@@ -89,111 +88,6 @@ namespace SlowTests.Server.Replication
                 Assert.NotNull(replicated2);
                 Assert.Equal("Jane Dow", replicated2.Name);
                 Assert.Equal(31, replicated2.Age);
-            }
-        }
-
-        [Fact]
-        public async Task DontReplicateTombstoneBack()
-        {
-            var dbName1 = DbName + "-1";
-            var dbName2 = DbName + "-2";
-
-            using (var store1 = GetDocumentStore(new Options
-            {
-                ModifyDatabaseName = s => dbName1
-            }))
-            using (var store2 = GetDocumentStore(new Options
-            {
-                ModifyDatabaseName = s => dbName2
-            }))
-            {
-                string changeVector1;
-                var documentDatabase = await Server.ServerStore.DatabasesLandlord.TryGetOrCreateResourceStore(dbName1);
-
-                using (var session = store1.OpenSession())
-                {
-                    var user = new User
-                    {
-                        Name = "John Dow",
-                        Age = 30
-                    };
-                    session.Store(user, "users/1");
-                    session.SaveChanges();
-                    session.Delete(user);
-                    session.SaveChanges();
-
-                    using (documentDatabase.DocumentsStorage.ContextPool.AllocateOperationContext(out DocumentsOperationContext context))
-                    using (context.OpenReadTransaction())
-                    {
-                        changeVector1 = documentDatabase.DocumentsStorage.GetDocumentOrTombstone(context, "users/1").Tombstone.ChangeVector;
-                    }
-                }
-                await SetupReplicationAsync(store1, store2);
-                await SetupReplicationAsync(store2, store1);
-
-                Assert.True(WaitForDocumentDeletion(store2, "users/1"));
-                await Task.Delay((int)(documentDatabase.ReplicationLoader.MinimalHeartbeatInterval * 2.5));
-
-                using (documentDatabase.DocumentsStorage.ContextPool.AllocateOperationContext(out DocumentsOperationContext context))
-                using (context.OpenReadTransaction())
-                {
-                    var changeVector2 = documentDatabase.DocumentsStorage.GetDocumentOrTombstone(context, "users/1").Tombstone.ChangeVector;
-                    Assert.Equal(changeVector1, changeVector2);
-                }
-            }
-        }
-
-        [Fact]
-        public async Task RavenDB_12295()
-        {
-            var dbName1 = DbName + "-1";
-            var dbName2 = DbName + "-2";
-
-            using (var store1 = GetDocumentStore(new Options
-            {
-                ModifyDatabaseName = s => dbName1
-            }))
-            using (var store2 = GetDocumentStore(new Options
-            {
-                ModifyDatabaseName = s => dbName2
-            }))
-            {
-                using (var session = store1.OpenSession())
-                {
-                    var user = new User
-                    {
-                        Name = "John Dow",
-                        Age = 30
-                    };
-                    session.Store(user, "users/1");
-                    session.SaveChanges();
-
-                    session.Delete(user);
-                    session.SaveChanges();
-                }
-
-                await SetupReplicationAsync(store1, store2);
-                await SetupReplicationAsync(store2, store1);
-
-                using (var session = store1.OpenSession())
-                {
-                    session.Advanced.UseOptimisticConcurrency = true;
-
-                    var user = new User
-                    {
-                        Name = "John Dow",
-                        Age = 30
-                    };
-                    session.Store(user, "users/1");
-                    session.SaveChanges();
-
-                    await Task.Delay(2500);
-
-                    var changeVector = session.Advanced.GetChangeVectorFor(user);
-
-                    session.Delete(user.Id, changeVector);
-                    session.SaveChanges();
-                }
             }
         }
 

--- a/test/SlowTests/Server/Replication/ReplicationBasicTestsSlow.cs
+++ b/test/SlowTests/Server/Replication/ReplicationBasicTestsSlow.cs
@@ -5,10 +5,8 @@ using System.Security.Cryptography.X509Certificates;
 using System.Threading.Tasks;
 using FastTests.Server.Replication;
 using Raven.Client.Documents.Operations.Replication;
-using Raven.Client.ServerWide;
-using Raven.Client.ServerWide.Operations;
 using Raven.Client.ServerWide.Operations.Certificates;
-using Raven.Server.Commercial;
+using Raven.Server.ServerWide.Context;
 using Raven.Tests.Core.Utils.Entities;
 using Xunit;
 
@@ -91,6 +89,111 @@ namespace SlowTests.Server.Replication
                 Assert.NotNull(replicated2);
                 Assert.Equal("Jane Dow", replicated2.Name);
                 Assert.Equal(31, replicated2.Age);
+            }
+        }
+
+        [Fact]
+        public async Task DontReplicateTombstoneBack()
+        {
+            var dbName1 = DbName + "-1";
+            var dbName2 = DbName + "-2";
+
+            using (var store1 = GetDocumentStore(new Options
+            {
+                ModifyDatabaseName = s => dbName1
+            }))
+            using (var store2 = GetDocumentStore(new Options
+            {
+                ModifyDatabaseName = s => dbName2
+            }))
+            {
+                string changeVector1;
+                var documentDatabase = await Server.ServerStore.DatabasesLandlord.TryGetOrCreateResourceStore(dbName1);
+
+                using (var session = store1.OpenSession())
+                {
+                    var user = new User
+                    {
+                        Name = "John Dow",
+                        Age = 30
+                    };
+                    session.Store(user, "users/1");
+                    session.SaveChanges();
+                    session.Delete(user);
+                    session.SaveChanges();
+
+                    using (documentDatabase.DocumentsStorage.ContextPool.AllocateOperationContext(out DocumentsOperationContext context))
+                    using (context.OpenReadTransaction())
+                    {
+                        changeVector1 = documentDatabase.DocumentsStorage.GetDocumentOrTombstone(context, "users/1").Tombstone.ChangeVector;
+                    }
+                }
+                await SetupReplicationAsync(store1, store2);
+                await SetupReplicationAsync(store2, store1);
+
+                Assert.True(WaitForDocumentDeletion(store2, "users/1"));
+                await Task.Delay((int)(documentDatabase.ReplicationLoader.MinimalHeartbeatInterval * 2.5));
+
+                using (documentDatabase.DocumentsStorage.ContextPool.AllocateOperationContext(out DocumentsOperationContext context))
+                using (context.OpenReadTransaction())
+                {
+                    var changeVector2 = documentDatabase.DocumentsStorage.GetDocumentOrTombstone(context, "users/1").Tombstone.ChangeVector;
+                    Assert.Equal(changeVector1, changeVector2);
+                }
+            }
+        }
+
+        [Fact]
+        public async Task RavenDB_12295()
+        {
+            var dbName1 = DbName + "-1";
+            var dbName2 = DbName + "-2";
+
+            using (var store1 = GetDocumentStore(new Options
+            {
+                ModifyDatabaseName = s => dbName1
+            }))
+            using (var store2 = GetDocumentStore(new Options
+            {
+                ModifyDatabaseName = s => dbName2
+            }))
+            {
+                using (var session = store1.OpenSession())
+                {
+                    var user = new User
+                    {
+                        Name = "John Dow",
+                        Age = 30
+                    };
+                    session.Store(user, "users/1");
+                    session.SaveChanges();
+
+                    session.Delete(user);
+                    session.SaveChanges();
+                }
+
+                await SetupReplicationAsync(store1, store2);
+                await SetupReplicationAsync(store2, store1);
+
+                using (var session = store1.OpenSession())
+                {
+                    session.Advanced.UseOptimisticConcurrency = true;
+
+                    var user = new User
+                    {
+                        Name = "John Dow",
+                        Age = 30
+                    };
+                    session.Store(user, "users/1");
+                    session.SaveChanges();
+
+                    await Task.Delay(2500);
+
+                    var changeVector = session.Advanced.GetChangeVectorFor(user);
+
+                    session.Delete(user.Id, changeVector);
+                    session.SaveChanges();
+                }
             }
         }
 


### PR DESCRIPTION
…oncurrency in a cluster

Normally, when we receive a document/tombstone from replication we store it with the original change vector, so it wouldn't replicate back.

The bug occurred when we received a tombstone without having a document first and stored it with a completely new change vector.