### PR TITLE
RavenDB-12227 -  Added support for compaction of fixed size trees tha…

### DIFF
--- a/src/Voron/Data/Fixed/FixedSizeIterators.cs
+++ b/src/Voron/Data/Fixed/FixedSizeIterators.cs
@@ -237,9 +237,6 @@ namespace Voron.Data.Fixed
             {
                 AssertNoChanges();
 
-                if (_currentPage == null)
-                    throw new InvalidOperationException("No current page was set");
-
                 while (_currentPage != null)
                 {
                     _currentPage.LastSearchPosition++;

--- a/src/Voron/Impl/Compaction/StorageCompaction.cs
+++ b/src/Voron/Impl/Compaction/StorageCompaction.cs
@@ -171,7 +171,7 @@ namespace Voron.Impl.Compaction
                                 continue; // we don't copy the allocator storage
                             }
 
-                            copiedTrees = CopyFixedSizeTrees(compactedEnv, progressReport, txr, rootIterator, treeName, copiedTrees, totalTreesCount, context, token);
+                            copiedTrees = CopyFixedSizeTreeFromRoot(compactedEnv, progressReport, txr, rootIterator, treeName, copiedTrees, totalTreesCount, context, token);
                             break;
                         case RootObjectType.Table:
                             copiedTrees = CopyTableTree(compactedEnv, progressReport, txr, treeName, copiedTrees, totalTreesCount, context, token);
@@ -184,10 +184,9 @@ namespace Voron.Impl.Compaction
             }
         }
 
-        private static long CopyFixedSizeTrees(StorageEnvironment compactedEnv, Action<StorageCompactionProgress> progressReport, Transaction txr,
+        private static long CopyFixedSizeTreeFromRoot(StorageEnvironment compactedEnv, Action<StorageCompactionProgress> progressReport, Transaction txr,
             TreeIterator rootIterator, string treeName, long copiedTrees, long totalTreesCount, TransactionPersistentContext context, CancellationToken token)
         {
-
             var treeNameSlice = rootIterator.CurrentKey.Clone(txr.Allocator);
 
             var header = (FixedSizeTreeHeader.Embedded*)txr.LowLevelTransaction.RootObjects.DirectRead(treeNameSlice);
@@ -196,49 +195,64 @@ namespace Voron.Impl.Compaction
 
             Report(copiedTrees, totalTreesCount, 0, fst.NumberOfEntries, progressReport, $"Copying fixed size tree '{treeName}'. Progress: 0/{fst.NumberOfEntries} entries.", treeName);
 
+            CopyFixedSizeTree(fst, txw => txw.FixedTreeFor(treeNameSlice, header->ValueSize), compactedEnv, context, copiedEntries =>
+            {
+                Report(copiedTrees, totalTreesCount, copiedEntries, fst.NumberOfEntries, progressReport,
+                    $"Copying fixed size tree '{treeName}'. Progress: {copiedEntries}/{fst.NumberOfEntries} entries.", treeName);
+            }, () =>
+            {
+                copiedTrees++;
+                Report(copiedTrees, totalTreesCount, fst.NumberOfEntries, fst.NumberOfEntries, progressReport,
+                    $"Finished copying fixed size tree '{treeName}'. {fst.NumberOfEntries} entries copied.", treeName);
+            }, token);
+
+            return copiedTrees;
+        }
+
+        private static void CopyFixedSizeTree(FixedSizeTree fst, Func<Transaction, FixedSizeTree> createDestinationTree, StorageEnvironment compactedEnv, TransactionPersistentContext context, Action<long> onEntriesCopiedProgress, Action onAllEntriesCopied, CancellationToken token)
+        {
             using (var it = fst.Iterate())
             {
                 var copiedEntries = 0L;
                 if (it.Seek(Int64.MinValue) == false)
-                    return copiedTrees;
+                    return;
 
                 do
                 {
                     token.ThrowIfCancellationRequested();
                     using (var txw = compactedEnv.WriteTransaction(context))
                     {
-                        var snd = txw.FixedTreeFor(treeNameSlice, header->ValueSize);
+                        var snd = createDestinationTree(txw);
                         var transactionSize = 0L;
 
                         do
                         {
                             token.ThrowIfCancellationRequested();
 
-                            Slice val;
-                            using (it.Value(out val))
+                            using (it.Value(out var val))
                                 snd.Add(it.CurrentKey, val);
                             transactionSize += fst.ValueSize + sizeof(long);
                             copiedEntries++;
 
                             var reportRate = fst.NumberOfEntries / 33 + 1;
                             if (copiedEntries % reportRate == 0)
-                                Report(copiedTrees, totalTreesCount, copiedEntries, fst.NumberOfEntries, progressReport, $"Copying fixed size tree '{treeName}'. Progress: {copiedEntries}/{fst.NumberOfEntries} entries.", treeName);
-
+                            {
+                                onEntriesCopiedProgress(copiedEntries);
+                            }
                         } while (transactionSize < compactedEnv.Options.MaxScratchBufferSize / 2 && it.MoveNext());
 
                         txw.Commit();
                     }
 
+                    compactedEnv.FlushLogToDataFile();
+
                     if (fst.NumberOfEntries == copiedEntries)
                     {
-                        copiedTrees++;
-                        Report(copiedTrees, totalTreesCount, copiedEntries, fst.NumberOfEntries, progressReport, $"Finished copying fixed size tree '{treeName}'. Progress: {copiedEntries}/{fst.NumberOfEntries} entries.", treeName);
+                        onAllEntriesCopied();
                     }
 
-                    compactedEnv.FlushLogToDataFile();
                 } while (it.MoveNext());
             }
-            return copiedTrees;
         }
 
         private static long CopyVariableSizeTree(StorageEnvironment compactedEnv, Action<StorageCompactionProgress> progressReport, Transaction txr, string treeName, long copiedTrees, long totalTreesCount, TransactionPersistentContext context, CancellationToken token)
@@ -270,7 +284,10 @@ namespace Voron.Impl.Compaction
                     var transactionSize = 0L;
 
                     token.ThrowIfCancellationRequested();
-                    using (var txw = compactedEnv.WriteTransaction(context))
+
+                    var txw = compactedEnv.WriteTransaction(context);
+
+                    try
                     {
                         var newTree = txw.ReadTree(treeName);
 
@@ -323,6 +340,57 @@ namespace Voron.Impl.Compaction
                                     transactionSize += stream.Length;
                                 }
                             }
+                            else if (existingTree.State.Flags == TreeFlags.FixedSizeTrees)
+                            {
+                                var reader = existingTree.GetValueReaderFromHeader(existingTreeIterator.Current);
+
+                                if (reader.Length >= sizeof(FixedSizeTreeHeader.Embedded))
+                                {
+                                    var header = (FixedSizeTreeHeader.Embedded*)reader.Base;
+
+                                    if (header->RootObjectType == RootObjectType.FixedSizeTree || header->RootObjectType == RootObjectType.EmbeddedFixedSizeTree)
+                                    {
+                                        // CopyFixedSizeTree will open dedicated write transaction to copy fixed size tree
+
+                                        txw.Commit();
+                                        txw.Dispose();
+                                        txw = null;
+
+                                        var fixedSizeTreeName = key;
+                                        var fst = existingTree.FixedTreeFor(fixedSizeTreeName, (byte)header->ValueSize);
+
+                                        var currentCopiedTrees = copiedTrees;
+                                        var currentCopiedEntries = copiedEntries;
+
+                                        CopyFixedSizeTree(fst, tx =>
+                                        {
+                                            var treeInCompactedEnv = tx.ReadTree(treeName);
+                                            return treeInCompactedEnv.FixedTreeFor(fixedSizeTreeName, (byte)header->ValueSize);
+                                        }, compactedEnv, context, copiedFstEntries =>
+                                        {
+                                            Report(currentCopiedTrees, totalTreesCount, currentCopiedEntries, existingTree.State.NumberOfEntries, progressReport,
+                                                $"Copying fixed size tree '{fixedSizeTreeName}' inside '{treeName}' tree. Progress: {copiedFstEntries}/{fst.NumberOfEntries} entries.",
+                                                treeName);
+                                        }, () =>
+                                        {
+                                            Report(currentCopiedTrees, totalTreesCount, currentCopiedEntries, existingTree.State.NumberOfEntries, progressReport,
+                                                $"Finished copying fixed size tree '{fixedSizeTreeName}' inside '{treeName}' tree. {fst.NumberOfEntries} entries copied.",
+                                                treeName);
+                                        }, token);
+
+                                        IncrementNumberOfCopiedEntries();
+                                        break; // let's open new transaction after copying fixed size tree
+                                    }
+                                }
+
+                                // if the entry wasn't recognized as fixed size tree then let's store it as regular value
+
+                                using (var value = existingTree.Read(key).Reader.AsStream())
+                                {
+                                    newTree.Add(key, value);
+                                    transactionSize += value.Length;
+                                }
+                            }
                             else
                             {
                                 using (var value = existingTree.Read(key).Reader.AsStream())
@@ -332,15 +400,25 @@ namespace Voron.Impl.Compaction
                                 }
                             }
 
-                            copiedEntries++;
+                            IncrementNumberOfCopiedEntries();
 
-                            var reportRate = existingTree.State.NumberOfEntries / 33 + 1;
-                            if (copiedEntries % reportRate == 0)
-                                Report(copiedTrees, totalTreesCount, copiedEntries, existingTree.State.NumberOfEntries, progressReport, $"Copying variable size tree '{treeName}'. Progress: {copiedEntries}/{existingTree.State.NumberOfEntries} entries.", treeName);
+                            void IncrementNumberOfCopiedEntries()
+                            {
+                                copiedEntries++;
+
+                                var reportRate = existingTree.State.NumberOfEntries / 33 + 1;
+                                if (copiedEntries % reportRate == 0)
+                                    Report(copiedTrees, totalTreesCount, copiedEntries, existingTree.State.NumberOfEntries, progressReport,
+                                        $"Copying variable size tree '{treeName}'. Progress: {copiedEntries}/{existingTree.State.NumberOfEntries} entries.", treeName);
+                            }
 
                         } while (transactionSize < compactedEnv.Options.MaxScratchBufferSize / 2 && existingTreeIterator.MoveNext());
 
-                        txw.Commit();
+                        txw?.Commit();
+                    }
+                    finally
+                    {
+                        txw?.Dispose();
                     }
 
                     if (copiedEntries == existingTree.State.NumberOfEntries)

--- a/test/SlowTests/Issues/RavenDB_12227.cs
+++ b/test/SlowTests/Issues/RavenDB_12227.cs
@@ -1,0 +1,139 @@
+﻿using System.IO;
+using FastTests.Voron;
+using FastTests.Voron.Util;
+using Voron;
+using Voron.Impl.Compaction;
+using Voron.Util.Conversion;
+using Xunit;
+
+namespace SlowTests.Issues
+{
+    public class RavenDB_12227 : StorageTest
+    {
+        [Theory]
+        [InlineData(8)]
+        [InlineData(16)]
+        [InlineData(128)]
+        [InlineData(1024 * 256)]
+        public void Can_compact_fixed_size_tree_stored_inside_variable_size_tree(int count)
+        {
+            RequireFileBasedPager();
+
+            var bytes = new byte[48];
+
+            Slice.From(Allocator, "main-tree", out Slice mainTreeId);
+            Slice.From(Allocator, "fst-tree", out Slice fstTreeIdreeId);
+
+            var smallValue = new byte[] {1, 2, 3};
+
+            var bigValue = new byte[128];
+
+            for (int i = 0; i < 128; i++)
+            {
+                bigValue[i] = (byte)i;
+            }
+
+            using (var tx = Env.WriteTransaction())
+            {
+                var mainTree = tx.CreateTree(mainTreeId);
+
+                var fst = mainTree.FixedTreeFor(fstTreeIdreeId, valSize: 48);
+
+                for (int i = 0; i < count; i++)
+                {
+                    EndianBitConverter.Little.CopyBytes(i, bytes, 0);
+                    fst.Add(i, bytes);
+                    Slice read;
+                    using (fst.Read(i, out read))
+                    {
+                        Assert.True(read.HasValue);
+                    }
+                }
+
+                mainTree.Add("small", smallValue);
+                mainTree.Add("big", bigValue);
+
+
+                tx.Commit();
+            }
+
+            Env.Dispose();
+
+            var compactedData = Path.Combine(DataDir, "Compacted");
+            StorageCompaction.Execute(StorageEnvironmentOptions.ForPath(DataDir),
+                (StorageEnvironmentOptions.DirectoryStorageEnvironmentOptions)StorageEnvironmentOptions.ForPath(compactedData));
+
+            using (var compacted = new StorageEnvironment(StorageEnvironmentOptions.ForPath(compactedData)))
+            {
+                using (var tx = compacted.ReadTransaction())
+                {
+                    var mainTree = tx.CreateTree(mainTreeId);
+
+                    var fst = mainTree.FixedTreeFor(fstTreeIdreeId, valSize: 48);
+
+                    for (int i = 0; i < count; i++)
+                    {
+                        Assert.True(fst.Contains(i), $"at {i}");
+                        Slice read;
+                        using (fst.Read(i, out read))
+                        {
+                            read.CopyTo(bytes);
+                            Assert.Equal(i, EndianBitConverter.Little.ToInt32(bytes, 0));
+                        }
+                    }
+
+                    var readResult = mainTree.Read("small");
+                    Assert.Equal(smallValue, readResult.Reader.AsStream().ReadData());
+
+                    readResult = mainTree.Read("big");
+                    Assert.Equal(bigValue, readResult.Reader.AsStream().ReadData());
+                }
+            }
+        }
+
+
+        [Theory]
+        [InlineData(8)]
+        [InlineData(1024 * 256)]
+        public void MoveNext_should_not_throw_after_iterating_over_all_items(int count)
+        {
+            var bytes = new byte[48];
+            Slice.From(Allocator, "test", out Slice treeId);
+
+            using (var tx = Env.WriteTransaction())
+            {
+                var fst = tx.FixedTreeFor(treeId, valSize: 48);
+
+                for (int i = 0; i < count; i++)
+                {
+                    EndianBitConverter.Little.CopyBytes(i, bytes, 0);
+                    fst.Add(i, bytes);
+                    Slice read;
+                    using (fst.Read(i, out read))
+                    {
+                        Assert.True(read.HasValue);
+                    }
+                }
+
+                tx.Commit();
+            }
+
+            using (var tx = Env.ReadTransaction())
+            {
+                var fst = tx.FixedTreeFor(treeId, valSize: 48);
+
+                using (var it = fst.Iterate())
+                {
+                    it.Seek(long.MinValue);
+
+                    while (it.MoveNext())
+                    {
+                        
+                    }
+
+                    Assert.False(it.MoveNext());
+                }
+            }
+        }
+    }
+}


### PR DESCRIPTION
…t aren't stored in $Root but inside regular trees. Actually we have only one such usage in RavenDB code, in map-reduce indexes (ResultsStoreTypes inside ReducePhaseTree tree), but map-reduce indexes aren't compacted anyway.

- Fixed behavior of LargeIterator - we shouldn't throw exception after iterating over all entries, that's how we behave in other iterators