### PR TITLE
RavenDB-12331

### DIFF
--- a/src/Raven.Server/Documents/Indexes/Index.cs
+++ b/src/Raven.Server/Documents/Indexes/Index.cs
@@ -989,6 +989,10 @@ namespace Raven.Server.Documents.Indexes
                                 {
                                     HandleOutOfMemoryException(oome, scope);
                                 }
+                                catch (EarlyOutOfMemoryException eoome)
+                                {
+                                    HandleOutOfMemoryException(eoome, scope);
+                                }
                                 catch (VoronUnrecoverableErrorException ide)
                                 {
                                     HandleIndexCorruption(scope, ide);
@@ -1319,7 +1323,7 @@ namespace Raven.Server.Documents.Indexes
             SetState(IndexState.Error);
         }
 
-        private void HandleOutOfMemoryException(OutOfMemoryException oome, IndexingStatsScope scope)
+        private void HandleOutOfMemoryException(Exception oome, IndexingStatsScope scope)
         {
             try
             {
@@ -1357,7 +1361,7 @@ namespace Raven.Server.Documents.Indexes
             }
         }
 
-        private static string OutOfMemoryDetails(OutOfMemoryException oome)
+        private static string OutOfMemoryDetails(Exception oome)
         {
             var memoryInfo = MemoryInformation.GetMemInfoUsingOneTimeSmapsReader();
 

--- a/src/Raven.Server/Documents/Indexes/IndexingRunStats.cs
+++ b/src/Raven.Server/Documents/Indexes/IndexingRunStats.cs
@@ -76,7 +76,7 @@ namespace Raven.Server.Documents.Indexes
             AddError(null, $"Critical exception occurred: {exception}", "Critical");
         }
 
-        public void AddMemoryError(OutOfMemoryException oome)
+        public void AddMemoryError(Exception oome)
         {
             AddError(null, $"Memory exception occurred: {oome}", "Memory");
         }

--- a/src/Raven.Server/Documents/Indexes/IndexingStatsAggregator.cs
+++ b/src/Raven.Server/Documents/Indexes/IndexingStatsAggregator.cs
@@ -140,7 +140,7 @@ namespace Raven.Server.Documents.Indexes
             _stats.AddCriticalError(e);
         }
 
-        public void AddMemoryError(OutOfMemoryException oome)
+        public void AddMemoryError(Exception oome)
         {
             _stats.AddMemoryError(oome);
         }

--- a/src/Raven.Server/Documents/Indexes/MapReduce/ReduceMapResultsBase.cs
+++ b/src/Raven.Server/Documents/Indexes/MapReduce/ReduceMapResultsBase.cs
@@ -187,7 +187,7 @@ namespace Raven.Server.Documents.Indexes.MapReduce
 
                 stats.RecordReduceSuccesses(numberOfEntriesToReduce);
             }
-            catch (Exception e) when (e is OperationCanceledException == false)
+            catch (Exception e) when (e.IsOperationCanceled() == false && e.IsOutOfMemory() == false)
             {
                 _index.ErrorIndexIfCriticalException(e);
 
@@ -298,7 +298,7 @@ namespace Raven.Server.Documents.Indexes.MapReduce
                             stats.RecordReduceSuccesses(leafPage.NumberOfEntries);
                         }
                     }
-                    catch (Exception e) when (e is OperationCanceledException == false)
+                    catch (Exception e) when (e.IsOperationCanceled() == false && e.IsOutOfMemory() == false)
                     {
                         if (failedAggregatedLeafs == null)
                             failedAggregatedLeafs = new Dictionary<long, Exception>();
@@ -367,7 +367,7 @@ namespace Raven.Server.Documents.Indexes.MapReduce
                             stats.RecordReduceSuccesses(page.NumberOfEntries);
                         }
                     }
-                    catch (Exception e) when (e is OperationCanceledException == false)
+                    catch (Exception e) when (e.IsOperationCanceled() == false && e.IsOutOfMemory() == false)
                     {
                         _index.ErrorIndexIfCriticalException(e);
 

--- a/src/Raven.Server/Documents/Indexes/Workers/MapDocuments.cs
+++ b/src/Raven.Server/Documents/Indexes/Workers/MapDocuments.cs
@@ -3,13 +3,13 @@ using System.Collections;
 using System.Collections.Generic;
 using System.Diagnostics;
 using System.Threading;
-using Lucene.Net.Index;
 using Raven.Client;
 using Raven.Client.Documents.Indexes;
 using Raven.Server.Config.Categories;
 using Raven.Server.Documents.Indexes.MapReduce;
 using Raven.Server.Documents.Indexes.Persistence.Lucene;
 using Raven.Server.ServerWide.Context;
+using Raven.Server.Utils;
 using Sparrow.Logging;
 using Voron;
 
@@ -110,7 +110,7 @@ namespace Raven.Server.Documents.Indexes.Workers
                                         resultsCount += numberOfResults;
                                         collectionStats.RecordMapSuccess();
                                     }
-                                    catch (Exception e)
+                                    catch (Exception e) when (e.IsOutOfMemory() == false)
                                     {
                                         docsEnumerator.OnError();
                                         _index.ErrorIndexIfCriticalException(e);

--- a/src/Raven.Server/Utils/ExceptionHelper.cs
+++ b/src/Raven.Server/Utils/ExceptionHelper.cs
@@ -1,0 +1,21 @@
+﻿using System;
+using System.Runtime.CompilerServices;
+using Sparrow.LowMemory;
+
+namespace Raven.Server.Utils
+{
+    public static class ExceptionHelper
+    {
+        [MethodImpl(MethodImplOptions.AggressiveInlining)]
+        public static bool IsOutOfMemory(this Exception e)
+        {
+            return e is OutOfMemoryException || e is EarlyOutOfMemoryException;
+        }
+
+        [MethodImpl(MethodImplOptions.AggressiveInlining)]
+        public static bool IsOperationCanceled(this Exception e)
+        {
+            return e is OperationCanceledException;
+        }
+    }
+}


### PR DESCRIPTION
- Catch EarlyOutOfMemoryException in ExecuteIndexing to prevent from erroring the index in the result of getting unexpected errors
- When EarlyOutOfMemoryException  of OutOfMemoryException is thrown then don't catch it when processing a document / map-result. The exception will be handled in HandleOutOfMemoryException.