### PR TITLE
RavenDB-12275 Short circuit of clauses in graph queries

### DIFF
--- a/src/Raven.Server/Documents/Queries/Graph/CollectionDestinationQueryStep.cs
+++ b/src/Raven.Server/Documents/Queries/Graph/CollectionDestinationQueryStep.cs
@@ -1,6 +1,7 @@
 ﻿using System;
 using System.Collections.Generic;
 using System.Threading.Tasks;
+using Raven.Client;
 using Raven.Server.ServerWide.Context;
 using Sparrow;
 
@@ -12,9 +13,11 @@ namespace Raven.Server.Documents.Queries.Graph
         private HashSet<string> _aliases;
         DocumentsOperationContext _context;
         DocumentsStorage _documentStorage;
+        private string _colectionName;
 
-        public CollectionDestinationQueryStep(Sparrow.StringSegment alias, DocumentsOperationContext documentsContext, DocumentsStorage documentStorage)
+        public CollectionDestinationQueryStep(Sparrow.StringSegment alias, DocumentsOperationContext documentsContext, DocumentsStorage documentStorage, string collectionName)
         {
+            _colectionName = collectionName;
             _alias = alias;
             _aliases = new HashSet<string> { alias };
             _context = documentsContext;
@@ -23,7 +26,7 @@ namespace Raven.Server.Documents.Queries.Graph
 
         public IGraphQueryStep Clone()
         {
-            return new CollectionDestinationQueryStep(_alias, _context, _documentStorage);
+            return new CollectionDestinationQueryStep(_alias, _context, _documentStorage, _colectionName);
         }
 
         public void Analyze(GraphQueryRunner.Match match, Action<string, object> addNode, Action<object, string> addEdge)
@@ -52,6 +55,11 @@ namespace Raven.Server.Documents.Queries.Graph
             throw new NotImplementedException("Query step of type CollectionDestinationQueryStep should not be invoking 'GetNext' method this is an indication of a bug.");
         }
 
+        public bool IsEmpty()
+        {
+            return _documentStorage.GetCollection(_colectionName, _context).Count == 0;
+        }
+
         public string GetOutputAlias()
         {
             return _alias;
@@ -66,7 +74,9 @@ namespace Raven.Server.Documents.Queries.Graph
         {
             var document = _documentStorage.Get(_context, id);
             match = new GraphQueryRunner.Match();
-            if (document != null)
+            if (_colectionName == string.Empty /* in the case of alias like '_'*/ || document != null && document.TryGetMetadata(out var metadata) 
+                && metadata.TryGetWithoutThrowingOnError(Constants.Documents.Metadata.Collection, out string cn)
+                && cn == _colectionName)
             {                
                 match.Set(_alias, document);
                 return true;

--- a/src/Raven.Server/Documents/Queries/Graph/EdgeFollowingRecursionQueryStep.cs
+++ b/src/Raven.Server/Documents/Queries/Graph/EdgeFollowingRecursionQueryStep.cs
@@ -31,6 +31,11 @@ namespace Raven.Server.Documents.Queries.Graph
             _allAliases.UnionWith(right.GetAllAliases());
         }
 
+        public bool IsEmpty()
+        {
+            return _results.Count == 0;
+        }
+
         public IGraphQueryStep Clone()
         {
             return new EdgeFollowingRecursionQueryStep((RecursionQueryStep)_left.Clone(), _right.Clone(),_queryParameters);

--- a/src/Raven.Server/Documents/Queries/Graph/EdgeQueryStep.cs
+++ b/src/Raven.Server/Documents/Queries/Graph/EdgeQueryStep.cs
@@ -113,6 +113,9 @@ namespace Raven.Server.Documents.Queries.Graph
         private void CompleteInitialization()
         {
             _index = 0;
+            if(_right.IsEmpty())
+                return;
+
             var edgeAlias = _edgePath.Alias;
             var edge = _edgesExpression;
             edge.EdgeAlias = edgeAlias;

--- a/src/Raven.Server/Documents/Queries/Graph/GraphQueryPlan.cs
+++ b/src/Raven.Server/Documents/Queries/Graph/GraphQueryPlan.cs
@@ -102,10 +102,10 @@ namespace Raven.Server.Documents.Queries.Graph
                     if(negated)
                         return new IntersectionQueryStep<Except>(left, right);
 
-                    return new IntersectionQueryStep<Intersection>(left, right);
+                    return new IntersectionQueryStep<Intersection>(left, right, returnEmptyIfRightEmpty:true);
 
                case OperatorType.Or:
-                    return new IntersectionQueryStep<Union>(left, right);
+                    return new IntersectionQueryStep<Union>(left, right, returnEmptyIfLeftEmpty:false);
 
                 default:
                     throw new ArgumentOutOfRangeException($"Unexpected binary expression of type: {be.Operator}");

--- a/src/Raven.Server/Documents/Queries/Graph/IGraphQueryStep.cs
+++ b/src/Raven.Server/Documents/Queries/Graph/IGraphQueryStep.cs
@@ -20,6 +20,8 @@ namespace Raven.Server.Documents.Queries.Graph
             Action<string, object> addNode, 
             Action<object, string> addEdge);
 
+        bool IsEmpty();
+
         IGraphQueryStep Clone();
     }
 }

--- a/src/Raven.Server/Documents/Queries/Graph/QueryPlanRewriter.cs
+++ b/src/Raven.Server/Documents/Queries/Graph/QueryPlanRewriter.cs
@@ -81,7 +81,7 @@ namespace Raven.Server.Documents.Queries.Graph
             var left = Visit(iqsu.Left);
             var right = Visit(iqsu.Right);
 
-            return new IntersectionQueryStep<Union>(left, right);
+            return new IntersectionQueryStep<Union>(left, right, returnEmptyIfLeftEmpty:false);
         }
 
         public virtual IGraphQueryStep VisitIntersectionQueryStepIntersection(IntersectionQueryStep<Intersection> iqsi)
@@ -89,7 +89,7 @@ namespace Raven.Server.Documents.Queries.Graph
             var left = Visit(iqsi.Left);
             var right = Visit(iqsi.Right);
 
-            return new IntersectionQueryStep<Intersection>(left, right);
+            return new IntersectionQueryStep<Intersection>(left, right, returnEmptyIfRightEmpty: true);
         }
 
         public virtual IGraphQueryStep VisitRecursionQueryStep(RecursionQueryStep rqs)

--- a/src/Raven.Server/Documents/Queries/Graph/QueryQueryStep.cs
+++ b/src/Raven.Server/Documents/Queries/Graph/QueryQueryStep.cs
@@ -43,7 +43,12 @@ namespace Raven.Server.Documents.Queries.Graph
 
         public static CollectionDestinationQueryStep ToCollectionDestinationQueryStep(DocumentsStorage documentsStorage, QueryQueryStep qqs)
         {
-            return new CollectionDestinationQueryStep(qqs._alias, qqs._context, documentsStorage);
+            return new CollectionDestinationQueryStep(qqs._alias, qqs._context, documentsStorage, qqs._queryMetadata.CollectionName);
+        }
+
+        public bool IsEmpty()
+        {
+            return _results.Count == 0;
         }
 
         public IGraphQueryStep Clone()

--- a/src/Raven.Server/Documents/Queries/Graph/RecursionQueryStep.cs
+++ b/src/Raven.Server/Documents/Queries/Graph/RecursionQueryStep.cs
@@ -90,6 +90,11 @@ namespace Raven.Server.Documents.Queries.Graph
             _outputAlias = _stepAliases.Last();
         }
 
+        public bool IsEmpty()
+        {
+            return _results.Count == 0;
+        }
+
         public IGraphQueryStep Clone()
         {
             return new RecursionQueryStep(_left.Clone(), new List<SingleEdgeMatcher>(_steps), _recursive, _options);


### PR DESCRIPTION
* will not run right hand side query step for union and edge query steps
* Added IsEmpty to IGraphQueryStep
* Fixed a bug where CollectionDestinationQueryStep won't actually filter documents not from the desired collection.