### PR TITLE
fix for RavenDB-12285

### DIFF
--- a/src/Raven.Client/Exceptions/InvalidQueryException.cs
+++ b/src/Raven.Client/Exceptions/InvalidQueryException.cs
@@ -25,7 +25,7 @@ namespace Raven.Client.Exceptions
         {
         }
 
-        public InvalidQueryException(string message, string queryText, BlittableJsonReaderObject parameters)
+        public InvalidQueryException(string message, string queryText, BlittableJsonReaderObject parameters = null)
             : base(BuildMessage(message, queryText, parameters))
         {
 

--- a/src/Raven.Server/Documents/Queries/Parser/QueryParser.cs
+++ b/src/Raven.Server/Documents/Queries/Parser/QueryParser.cs
@@ -516,12 +516,11 @@ namespace Raven.Server.Documents.Queries.Parser
                             if (GraphAlias(gq, true, alias, out alias) == false)
                                 throw new InvalidQueryException("MATCH identifier after '-['", Scanner.Input, null);
 
-                            var endingToken = Scanner.Position + 1;
+                            var endingPos = Scanner.Position + 1;
 
                             if (expectNode)
                             {
-                                throw new InvalidQueryException(
-                                    $@"Expected the alias '{alias}' to refer a node, but it refers to an edge.{Environment.NewLine}This is likely a mistake in the query as the expression {Scanner.Input.Substring(startingPos,endingToken - startingPos)} should probably be a node.");
+                                ThrowExpectedNodeButFoundEdge(alias, Scanner.Input.Substring(startingPos, endingPos - startingPos),Scanner.Input);
                             }
 
                             if (Scanner.TryScan(']') == false)
@@ -536,6 +535,7 @@ namespace Raven.Server.Documents.Queries.Parser
                             expectNode = true; //after each edge we expect a node
                             break;
                         case "<-":
+
                             last = list[list.Count - 1];
                             list[list.Count - 1] = new MatchPath
                             {
@@ -544,8 +544,8 @@ namespace Raven.Server.Documents.Queries.Parser
                                 EdgeType = EdgeType.Left,
                                 Recursive = last.Recursive
                             };
+
                             foundDash = true;
-                            expectNode = false;
 
                             continue;
                         case "<":
@@ -561,6 +561,12 @@ namespace Raven.Server.Documents.Queries.Parser
                                 EdgeType = EdgeType.Right,
                                 Recursive = last.Recursive
                             };
+
+                            if (expectNode && Scanner.TryPeek('['))
+                            {
+                                ThrowExpectedNodeButFoundEdge(last.Alias,last.ToString(), Scanner.Input);
+                            }
+                            
                             if (Scanner.TryScan('(') == false)
                             {
                                 var msg = $"({last.Alias})-> is not allowed, you should use ({last.Alias})-[...] instead.";
@@ -571,11 +577,14 @@ namespace Raven.Server.Documents.Queries.Parser
                             goto case "(";
 
                         case "(":
-                            if (expectNode == false && list[list.Count - 1].EdgeType != EdgeType.Left)
-                                throw new InvalidQueryException("Got '(', but it wasn't expected, did you forgot to use -> ? ", Scanner.Input, null);
 
+                            var start = Scanner.Position - 1;
                             if (GraphAlias(gq, false, default, out alias) == false)
                                 throw new InvalidQueryException("Couldn't get node's alias", Scanner.Input, null);
+                            var end = Scanner.Position + 1;
+
+                            if (expectNode == false)
+                                ThrowExpectedEdgeButFoundNode(alias,Scanner.Input.Substring(start, end - start),Scanner.Input);
 
                             if (Scanner.TryScan(')') == false)
                                 throw new InvalidQueryException("MATCH operator expected a ')' after reading: " + alias, Scanner.Input, null);
@@ -713,6 +722,18 @@ namespace Raven.Server.Documents.Queries.Parser
                     return true;
                 }
             }
+        }
+
+        private void ThrowExpectedEdgeButFoundNode(StringSegment alias, string invalidQueryElement, string query)
+        {
+            throw new InvalidQueryException(
+                $@"Expected the alias '{alias}' to refer an edge, but it refers to an node.{Environment.NewLine}This is likely a mistake in the query as the expression '{invalidQueryElement}' should probably be an edge.", query);
+        }
+
+        private void ThrowExpectedNodeButFoundEdge(StringSegment alias, string invalidQueryElement, string query)
+        {
+            throw new InvalidQueryException(
+                $@"Expected the alias '{alias}' to refer a node, but it refers to an edge.{Environment.NewLine}This is likely a mistake in the query as the expression '{invalidQueryElement}' should probably be a node.", query);
         }
 
         private static QueryExpression FinalProcessingOfMatchExpression(List<MatchPath> list)

--- a/test/FastTests/Graph/GraphPermissionTests.cs
+++ b/test/FastTests/Graph/GraphPermissionTests.cs
@@ -83,6 +83,7 @@ select  i.Name as Issue,
             using (var store = GetDocumentStore())
             {
                 CreateData(store);
+                WaitForUserToContinueTheTest(store);
                 using (var s = store.OpenSession())
                 {
                     var r = s.Advanced.RawQuery<Result>(Query)

--- a/test/FastTests/Graph/GraphPermissionTests.cs
+++ b/test/FastTests/Graph/GraphPermissionTests.cs
@@ -1,7 +1,9 @@
 ﻿using System;
 using System.Collections.Generic;
+using System.Linq;
 using System.Text;
 using Raven.Client.Documents;
+using Raven.Client.Exceptions;
 using Xunit;
 
 namespace FastTests.Graph
@@ -83,7 +85,6 @@ select  i.Name as Issue,
             using (var store = GetDocumentStore())
             {
                 CreateData(store);
-                WaitForUserToContinueTheTest(store);
                 using (var s = store.OpenSession())
                 {
                     var r = s.Advanced.RawQuery<Result>(Query)
@@ -114,5 +115,74 @@ select  i.Name as Issue,
             }
         }
 
+        [Fact]
+        public void Edge_instead_of_node_should_make_simple_left_to_right_query_fail()
+        {
+            using (var store = GetDocumentStore())
+            {
+                CreateData(store);
+                using (var s = store.OpenSession())
+                {
+                    Assert.Throws<InvalidQueryException>(() => s.Advanced.RawQuery<Result>("match (Issues as i)-[Groups]->[Groups as direct]").ToList());
+                }
+            }
+
+        }
+
+        [Fact]
+        public void Node_instead_of_edge_should_make_simple_left_to_right_query_fail()
+        {
+            using (var store = GetDocumentStore())
+            {
+                CreateData(store);
+                using (var s = store.OpenSession())
+                {
+                    //different type of mistake - writing node instead of edge
+                    Assert.Throws<InvalidQueryException>(() => s.Advanced.RawQuery<Result>("match (Issues as i)-(Groups)->(Groups as direct)").ToList());
+                }
+            }
+        }
+
+        [Fact]
+        public void Edge_instead_of_node_should_make_simple_right_to_left_query_fail()
+        {
+            using (var store = GetDocumentStore())
+            {
+                CreateData(store);
+                using (var s = store.OpenSession())
+                {
+                    Assert.Throws<InvalidQueryException>(() => s.Advanced.RawQuery<Result>("match (Groups as A)<-[Groups as B]<-[Issues as C]").ToList());
+                }
+            }
+        }
+
+        [Fact]
+        public void Node_instead_of_edge_should_make_simple_right_to_left_query_fail()
+        {
+            using (var store = GetDocumentStore())
+            {
+                CreateData(store);
+                using (var s = store.OpenSession())
+                {
+                    Assert.Throws<InvalidQueryException>(() => s.Advanced.RawQuery<Result>("match (Groups as A)<-(Groups as B)<-(Issues as C)").ToList());
+                }
+            }
+        }
+
+        [Fact]
+        public void Edge_instead_of_node_should_make_complex_query_fail()
+        {
+            using (var store = GetDocumentStore())
+            {
+                CreateData(store);
+                using (var s = store.OpenSession())
+                {
+                    Assert.Throws<InvalidQueryException>(() => s.Advanced.RawQuery<Result>(
+                        @"with {  from Users where id() = ""users/84"" } as u
+                          match   (Issues as i)-[Groups]->(Groups as g)<-[Parents]-[Groups as midpoint]<-[Groups]-(u)
+                          select  i.Name as Issue, u.Name as User").ToList());
+                }
+            }
+        }
     }
 }


### PR DESCRIPTION
Make sure that in graph queries after a node comes an edge, so the query (foo)-[bar]->[barfoo] should throw an appropriate error