### PR TITLE
fix for RavenDB-12276 : In graph queries, throw error if the collection doesn't exist 

### DIFF
--- a/src/Raven.Server/Documents/Queries/AbstractQueryRunner.cs
+++ b/src/Raven.Server/Documents/Queries/AbstractQueryRunner.cs
@@ -26,7 +26,7 @@ namespace Raven.Server.Documents.Queries
 {
     public abstract class AbstractQueryRunner
     {
-        protected readonly DocumentDatabase Database;
+        public readonly DocumentDatabase Database;
 
         protected AbstractQueryRunner(DocumentDatabase database)
         {

--- a/src/Raven.Server/Documents/Queries/Graph/QueryQueryStep.cs
+++ b/src/Raven.Server/Documents/Queries/Graph/QueryQueryStep.cs
@@ -39,6 +39,11 @@ namespace Raven.Server.Documents.Queries.Graph
             _context = documentsContext;
             _resultEtag = existingResultEtag;
             _token = token;
+
+            if (!string.IsNullOrEmpty(queryMetadata.CollectionName)) //not a '_' collection
+            {
+                var _ = _queryRunner.Database.DocumentsStorage.GetCollection(queryMetadata.CollectionName, throwIfDoesNotExist: true);
+            }
         }
 
         public bool IsCollectionQuery => _queryMetadata.IsCollectionQuery;

--- a/test/FastTests/FastTests.csproj
+++ b/test/FastTests/FastTests.csproj
@@ -1,7 +1,7 @@
 ﻿<Project Sdk="Microsoft.NET.Sdk">
   <PropertyGroup>
     <TargetFramework>netcoreapp2.1</TargetFramework>
-    <RuntimeFrameworkVersion>2.1.6</RuntimeFrameworkVersion>
+    <RuntimeFrameworkVersion>2.1.5</RuntimeFrameworkVersion>
     <AllowUnsafeBlocks>true</AllowUnsafeBlocks>
     <AssemblyName>FastTests</AssemblyName>
     <PackageId>FastTests</PackageId>

--- a/test/FastTests/Graph/BasicGraphQueries.cs
+++ b/test/FastTests/Graph/BasicGraphQueries.cs
@@ -120,8 +120,8 @@ namespace FastTests.Graph
                 CreateMoviesData(store);
                 using (var session = store.OpenSession())
                 {
-                    var allVerticesQuery = session.Advanced.RawQuery<JObject>(@"match (v)").ToList();
-                    Assert.False(allVerticesQuery.Any(row => row.ContainsKey("v"))); //we have "flat" results
+                    var allVerticesQuery = session.Advanced.RawQuery<JObject>(@"match (_ as v)").ToList();
+                    Assert.False(allVerticesQuery.Any(row => row.ContainsKey("_ as v"))); //we have "flat" results
                 }
             }
         }
@@ -134,7 +134,7 @@ namespace FastTests.Graph
                 CreateMoviesData(store);
                 using (var session = store.OpenSession())
                 {
-                    var allVerticesQuery = session.Advanced.RawQuery<JObject>(@"match (u)-[HasRated select Movie]->(m)").ToList();
+                    var allVerticesQuery = session.Advanced.RawQuery<JObject>(@"match (_ as u)-[HasRated select Movie]->(_ as m)").ToList();
                     Assert.True(allVerticesQuery.All(row => row.ContainsKey("m")));
                     Assert.True(allVerticesQuery.All(row => row.ContainsKey("u")));
                 }
@@ -423,6 +423,18 @@ select son.Name as Son, evil.Name as Evil")
                     Assert.Equal(1, results.Count);
                     Assert.Equal("Longo", results[0].Evil);
                     Assert.Equal("Otho Sackville-Baggins", results[0].Son);
+                }
+            }
+        }
+
+        [Fact]
+        public void Query_with_non_existing_collection_should_fail()
+        {
+            using (var store = GetDocumentStore())
+            {
+                using (var session = store.OpenSession())
+                {
+                    Assert.Throws<RavenException>(() => session.Advanced.RawQuery<JObject>(@"match (FooBar)").ToList());
                 }
             }
         }


### PR DESCRIPTION
Also, fix affected tests