### PR TITLE
RavenDB-12371: Do not pre-reserve the space for the TransactionHeaders

### DIFF
--- a/src/Voron/Impl/Journal/JournalReader.cs
+++ b/src/Voron/Impl/Journal/JournalReader.cs
@@ -200,16 +200,16 @@ namespace Voron.Impl.Journal
             return true;
         }
 
-        public int RecoverAndValidate(StorageEnvironmentOptions options, TransactionHeader[] transactionHeaders)
+        public List<TransactionHeader> RecoverAndValidate(StorageEnvironmentOptions options)
         {
-            int index = 0;
+            var transactionHeaders = new List<TransactionHeader>();
             while (ReadOneTransactionToDataFile(options))
             {
-                transactionHeaders[index++] = *LastTransactionHeader;
+                transactionHeaders.Add(*LastTransactionHeader);
             }
             ZeroRecoveryBufferIfNeeded(this, options);
 
-            return index;
+            return transactionHeaders;
         }
 
         public void ZeroRecoveryBufferIfNeeded(IPagerLevelTransactionState tx, StorageEnvironmentOptions options)


### PR DESCRIPTION
The amount of instances of those lists are not that big, there is at first sight a need to pool those them. If they deem to be a problem, we can pool them.