### PR TITLE
RavenDB-12366

### DIFF
--- a/src/Raven.Server/Documents/Indexes/Persistence/Lucene/IndexReadOperation.cs
+++ b/src/Raven.Server/Documents/Indexes/Persistence/Lucene/IndexReadOperation.cs
@@ -207,10 +207,24 @@ namespace Raven.Server.Documents.Indexes.Persistence.Lucene
         private ExplanationResult GetQueryExplanations(ExplanationOptions options, Query luceneQuery, IndexSearcher searcher, ScoreDoc scoreDoc, Document document, global::Lucene.Net.Documents.Document luceneDocument)
         {
             string key;
-            if (options != null && string.IsNullOrWhiteSpace(options.GroupKey) == false)
-                key = luceneDocument.Get(options.GroupKey, _state);
+            var hasGroupKey = options != null && string.IsNullOrWhiteSpace(options.GroupKey) == false;
+            if (_indexType.IsMapReduce())
+            {
+                if (hasGroupKey)
+                {
+                    key = luceneDocument.Get(options.GroupKey, _state);
+                    if (key == null && document.Data.TryGet(options.GroupKey, out object value))
+                        key = value?.ToString();
+                }
+                else
+                    key = luceneDocument.Get(Constants.Documents.Indexing.Fields.ReduceKeyHashFieldName, _state);
+            }
             else
-                key = document.Id;
+            {
+                key = hasGroupKey
+                    ? luceneDocument.Get(options.GroupKey, _state)
+                    : document.Id;
+            }
 
             return new ExplanationResult
             {

--- a/src/Raven.Server/Documents/Queries/Results/MapReduceQueryResultRetriever.cs
+++ b/src/Raven.Server/Documents/Queries/Results/MapReduceQueryResultRetriever.cs
@@ -74,7 +74,14 @@ namespace Raven.Server.Documents.Queries.Results
                 return GetProjection(input, score, null, state);
 
             using (_storageScope = _storageScope?.Start() ?? RetrieverScope?.For(nameof(QueryTimingsScope.Names.Storage)))
-                return DirectGet(input, null, state);
+            {
+                var doc = DirectGet(input, null, state);
+
+                if (doc != null)
+                    doc.IndexScore = score;
+
+                return doc;
+            }
         }
 
         public override bool TryGetKey(Lucene.Net.Documents.Document document, IState state, out string key)

--- a/test/SlowTests/Issues/RavenDB_12366.cs
+++ b/test/SlowTests/Issues/RavenDB_12366.cs
@@ -1,0 +1,97 @@
+﻿using System.Linq;
+using System.Threading.Tasks;
+using FastTests;
+using Raven.Client;
+using Raven.Client.Documents.Indexes;
+using Raven.Client.Documents.Queries;
+using Raven.Client.Documents.Queries.Explanation;
+using Raven.Client.Extensions;
+using Sparrow.Json;
+using Xunit;
+
+namespace SlowTests.Issues
+{
+    public class RavenDB_12366 : RavenTestBase
+    {
+        [Fact]
+        public async Task MetadataTest()
+        {
+            using (var store = GetDocumentStore())
+            {
+                new DocsIndex().Execute(store);
+                using (var session = store.OpenAsyncSession())
+                {
+                    await session.StoreAsync(new Doc { Id = "doc-1", StrVal = "abc" });
+                    await session.StoreAsync(new Doc { Id = "doc-2", StrVal = "abd" });
+                    await session.StoreAsync(new Doc { Id = "doc-3", StrVal = "bcd" });
+                    await session.SaveChangesAsync();
+
+                    WaitForIndexing(store);
+
+                    var results = await session.Advanced.AsyncDocumentQuery<Doc, DocsIndex>()
+                        .IncludeExplanations(out Explanations explanations)
+                        .Search(x => x.StrVal, "ab*")
+                        .ToListAsync();
+
+                    // should not throw in explanations
+
+                    Assert.Equal(2, results.Count);
+
+                    results = await session.Advanced.AsyncDocumentQuery<Doc, DocsIndex>()
+                        .IncludeExplanations(new ExplanationOptions { GroupKey = "StrVal" }, out explanations)
+                        .Search(x => x.StrVal, "ab*")
+                        .ToListAsync();
+
+                    Assert.Equal(2, results.Count);
+
+                    using (var command = store.Commands())
+                    {
+                        var queryResult = await command.QueryAsync(new IndexQuery
+                        {
+                            Query = "from index 'DocsIndex' where search(StrVal, 'ab*')"
+                        });
+
+                        Assert.Equal(2, queryResult.Results.Length);
+                        foreach (BlittableJsonReaderObject json in queryResult.Results)
+                        {
+                            var metadata = json.GetMetadata();
+                            Assert.True(metadata.TryGet(Constants.Documents.Metadata.IndexScore, out float indexScore));
+                            Assert.True(indexScore > 0);
+                        }
+                    }
+                }
+            }
+        }
+
+        private class Doc
+        {
+            public string Id { get; set; }
+            public string StrVal { get; set; }
+        }
+
+        private class DocsIndex : AbstractMultiMapIndexCreationTask<Doc>
+        {
+            public DocsIndex()
+            {
+                AddMap<Doc>(docs =>
+                    from doc in docs
+                    select new
+                    {
+                        doc.Id,
+                        doc.StrVal,
+                    });
+
+                Reduce = results =>
+                    from result in results
+                    group result by result.Id
+                    into g
+                    let doc = g.First()
+                    select new
+                    {
+                        Id = g.Key,
+                        StrVal = doc.StrVal ?? null,
+                    };
+            }
+        }
+    }
+}


### PR DESCRIPTION
- @index-score will be attached to map-reduce results
- explanations for map-reduce will pick hash(key()) field if no group-key is present
- explanations for map-reduce will check if group-key field is stored in lucene first, but if it is not then attempt to get it from the result will be performed