### PR TITLE
RavenDB-8065 add missing Sparrow's dep to client csproj

### DIFF
--- a/src/Raven.Client/Raven.Client.csproj
+++ b/src/Raven.Client/Raven.Client.csproj
@@ -55,5 +55,6 @@
     <PackageReference Include="System.Runtime.InteropServices.RuntimeInformation" Version="4.3.0" />
     <PackageReference Include="System.Security.Cryptography.Cng" Version="4.5.0" />
     <PackageReference Include="System.Threading.Tasks.Extensions" Version="4.5.1" />
+    <PackageReference Include="Microsoft.Extensions.Primitives" Version="2.2.0-preview3-35497" />
   </ItemGroup>
 </Project>


### PR DESCRIPTION
```
	[Step 1/2] Since we embed Sparrow.dll in Client nuget package we need to include its dependencies in Raven.Client.csproj. Add 
[08:00:35]	[Step 1/2] missing package references to Raven.Client.csproj: Microsoft.Extensions.Primitives.
[08:00:35]	[Step 1/2] At C:\Builds\RavenDB-4.2-Nightly\scripts\nuget.ps1:30 char:9
[08:00:35]	[Step 1/2] +         throw "Since we embed Sparrow.dll in Client nuget package we  ...
[08:00:35]	[Step 1/2] +         ~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~
[08:00:35]	[Step 1/2]     + CategoryInfo          : OperationStopped: (Since we embed ...ons.Primitives.:String) [], RuntimeException
[08:00:35]	[Step 1/2]     + FullyQualifiedErrorId : Since we embed Sparrow.dll in Client nuget package we need to include its dependencies i 
[08:00:35]	[Step 1/2]    n Raven.Client.csproj. Add missing package references to Raven.Client.csproj: Microsoft.Extensions.Primitives.
[08:00:35]	[Step 1/2]  
[08:00:35]	[Step 1/2] Process exited with code 1
[08:00:35]	[Step 1/2] Process exited with code 1 (Step: Build (PowerShell))
[08:00:35]	[Step 1/2] Step Build (PowerShell) failed
```