### PR TITLE
RavenDB-11650

### DIFF
--- a/src/Raven.Client/Documents/Queries/QueryResult.cs
+++ b/src/Raven.Client/Documents/Queries/QueryResult.cs
@@ -20,6 +20,12 @@ namespace Raven.Client.Documents.Queries
         /// </summary>
         public int TotalResults { get; set; }
 
+       /// <summary>
+       /// The total results for the query, taking into account the 
+       /// offset / limit clauses for this query
+       /// </summary>
+        public int TotalResultsWithOffsetAndLimit { get; set; }
+
         /// <summary>
         /// Gets or sets the skipped results
         /// </summary>

--- a/src/Raven.Server/Documents/Indexes/Index.cs
+++ b/src/Raven.Server/Documents/Indexes/Index.cs
@@ -2288,6 +2288,13 @@ namespace Raven.Server.Documents.Indexes
                                     foreach (var document in documents)
                                     {
                                         resultToFill.TotalResults = totalResults.Value;
+                                        if (query.Offset != null || query.Limit != null)
+                                        {
+                                            resultToFill.TotalResultsWithOffsetAndLimit = Math.Min(
+                                                query.Limit ?? int.MaxValue, 
+                                                totalResults.Value - (query.Offset ?? 0)
+                                                );
+                                        }
                                         resultToFill.AddResult(document.Result);
 
                                         if (document.Highlightings != null)

--- a/src/Raven.Server/Documents/Queries/Dynamic/CollectionQueryRunner.cs
+++ b/src/Raven.Server/Documents/Queries/Dynamic/CollectionQueryRunner.cs
@@ -158,6 +158,14 @@ namespace Raven.Server.Documents.Queries.Dynamic
                     resultToFill.AddCounterIncludes(includeCountersCommand);
 
                 resultToFill.TotalResults = (totalResults.Value == 0 && resultToFill.Results.Count != 0) ? -1 : totalResults.Value;
+
+                if (query.Offset != null || query.Limit != null)
+                {
+                    resultToFill.TotalResultsWithOffsetAndLimit = Math.Min(
+                        query.Limit ?? int.MaxValue,
+                        resultToFill.TotalResults - (query.Offset ?? 0)
+                        );
+                }
             }
         }
 

--- a/src/Raven.Server/Documents/Queries/IndexQueryServerSide.cs
+++ b/src/Raven.Server/Documents/Queries/IndexQueryServerSide.cs
@@ -18,6 +18,11 @@ namespace Raven.Server.Documents.Queries
     public class IndexQueryServerSide : IndexQuery<BlittableJsonReaderObject>
     {
         [JsonDeserializationIgnore]
+        public int? Offset;
+        [JsonDeserializationIgnore]
+        public int? Limit;
+
+        [JsonDeserializationIgnore]
         public QueryMetadata Metadata { get; private set; }
 
         [JsonDeserializationIgnore]
@@ -100,13 +105,18 @@ namespace Raven.Server.Documents.Queries
                 if (result.Metadata.Query.Offset != null)
                 {
                     var start = (int)QueryBuilder.GetLongValue(result.Metadata.Query, result.Metadata, result.QueryParameters, result.Metadata.Query.Offset, 0);
+                    result.Offset = start;
                     result.Start = result.Start != 0 || json.TryGet(nameof(Start), out int _)
                         ? Math.Min(start, result.Start)
                         : start;
                 }
 
                 if (result.Metadata.Query.Limit != null)
-                    result.PageSize = Math.Min((int)QueryBuilder.GetLongValue(result.Metadata.Query, result.Metadata, result.QueryParameters, result.Metadata.Query.Limit, int.MaxValue), result.PageSize);
+                {
+                    var limit = (int)QueryBuilder.GetLongValue(result.Metadata.Query, result.Metadata, result.QueryParameters, result.Metadata.Query.Limit, int.MaxValue);
+                    result.Limit = limit;   
+                    result.PageSize = Math.Min(limit, result.PageSize);
+                }
 
                 if (tracker != null)
                     tracker.Query = result.Query;
@@ -184,13 +194,15 @@ namespace Raven.Server.Documents.Queries
 
                 if (result.Metadata.Query.Offset != null)
                 {
-                    start += (int)QueryBuilder.GetLongValue(result.Metadata.Query, result.Metadata, result.QueryParameters, result.Metadata.Query.Offset, 0);
-                    result.Start = start ;
+                    var offset = (int)QueryBuilder.GetLongValue(result.Metadata.Query, result.Metadata, result.QueryParameters, result.Metadata.Query.Offset, 0);
+                    result.Offset = offset;
+                    result.Start = start + offset;
                 }
 
                 if (result.Metadata.Query.Limit != null)
                 {
                     pageSize = (int)QueryBuilder.GetLongValue(result.Metadata.Query, result.Metadata, result.QueryParameters, result.Metadata.Query.Limit, int.MaxValue);
+                    result.Limit = pageSize;
                     result.PageSize = Math.Min(result.PageSize, pageSize);
                 }
 

--- a/src/Raven.Server/Documents/Queries/IndexQueryServerSide.cs
+++ b/src/Raven.Server/Documents/Queries/IndexQueryServerSide.cs
@@ -146,9 +146,6 @@ namespace Raven.Server.Documents.Queries
                     PageSize = pageSize,
                 };
 
-                var startSet = false;
-                var pageSizeSet = false;
-
                 foreach (var item in httpContext.Request.Query)
                 {
                     try
@@ -172,12 +169,6 @@ namespace Raven.Server.Documents.Queries
                             case "skipDuplicateChecking":
                                 result.SkipDuplicateChecking = bool.Parse(item.Value[0]);
                                 break;
-                            case RequestHandler.StartParameter:
-                                startSet = true;
-                                break;
-                            case RequestHandler.PageSizeParameter:
-                                pageSizeSet = true;
-                                break;
                         }
                     }
                     catch (Exception e)
@@ -193,18 +184,14 @@ namespace Raven.Server.Documents.Queries
 
                 if (result.Metadata.Query.Offset != null)
                 {
-                    start = (int)QueryBuilder.GetLongValue(result.Metadata.Query, result.Metadata, result.QueryParameters, result.Metadata.Query.Offset, 0);
-                    result.Start = startSet
-                        ? Math.Min(start, result.Start)
-                        : start;
+                    start += (int)QueryBuilder.GetLongValue(result.Metadata.Query, result.Metadata, result.QueryParameters, result.Metadata.Query.Offset, 0);
+                    result.Start = start ;
                 }
 
                 if (result.Metadata.Query.Limit != null)
                 {
                     pageSize = (int)QueryBuilder.GetLongValue(result.Metadata.Query, result.Metadata, result.QueryParameters, result.Metadata.Query.Limit, int.MaxValue);
-                    result.Start = pageSizeSet
-                        ? Math.Min(pageSize, result.PageSize)
-                        : pageSize;
+                    result.PageSize = Math.Min(result.PageSize, pageSize);
                 }
 
                 if (tracker != null)

--- a/src/Raven.Server/Documents/Queries/Parser/QueryParser.cs
+++ b/src/Raven.Server/Documents/Queries/Parser/QueryParser.cs
@@ -193,6 +193,10 @@ namespace Raven.Server.Documents.Queries.Parser
                     offset = first;
                     limit = second;
                 }
+                else
+                {
+                    limit = first;
+                }
             }
 
             if (Scanner.TryScan("OFFSET"))

--- a/src/Raven.Server/Json/BlittableJsonTextWriterExtensions.cs
+++ b/src/Raven.Server/Json/BlittableJsonTextWriterExtensions.cs
@@ -69,6 +69,11 @@ namespace Raven.Server.Json
             writer.WriteInteger(result.TotalResults);
             writer.WriteComma();
 
+            writer.WritePropertyName(nameof(result.TotalResultsWithOffsetAndLimit));
+            writer.WriteInteger(result.TotalResultsWithOffsetAndLimit);
+            writer.WriteComma();
+
+
             writer.WritePropertyName(nameof(result.DurationInMs));
             writer.WriteInteger(result.DurationInMs);
             writer.WriteComma();
@@ -84,6 +89,10 @@ namespace Raven.Server.Json
 
             writer.WritePropertyName(nameof(result.TotalResults));
             writer.WriteInteger(result.TotalResults);
+            writer.WriteComma();
+
+            writer.WritePropertyName(nameof(result.TotalResultsWithOffsetAndLimit));
+            writer.WriteInteger(result.TotalResultsWithOffsetAndLimit);
             writer.WriteComma();
 
             writer.WritePropertyName(nameof(result.DurationInMs));
@@ -213,6 +222,10 @@ namespace Raven.Server.Json
             writer.WriteInteger(result.TotalResults);
             writer.WriteComma();
 
+            writer.WritePropertyName(nameof(result.TotalResultsWithOffsetAndLimit));
+            writer.WriteInteger(result.TotalResultsWithOffsetAndLimit);
+            writer.WriteComma();
+
             writer.WritePropertyName(nameof(result.SkippedResults));
             writer.WriteInteger(result.SkippedResults);
             writer.WriteComma();
@@ -232,6 +245,10 @@ namespace Raven.Server.Json
 
             writer.WritePropertyName(nameof(result.TotalResults));
             writer.WriteInteger(result.TotalResults);
+            writer.WriteComma();
+
+            writer.WritePropertyName(nameof(result.TotalResultsWithOffsetAndLimit));
+            writer.WriteInteger(result.TotalResultsWithOffsetAndLimit);
             writer.WriteComma();
 
             writer.WritePropertyName(nameof(result.SkippedResults));


### PR DESCRIPTION
- If user specifies limit / offset in the query itself and in the query string (common in studio):
    - the limit will be the minimum between the querystring variable and the limit in the query.
    - the offset will be the offset from the query PLUS the offset in the query string. This is to allow paging in the studio of queries with offset in them.
- Properly apply limit offset clause