### PR TITLE
RavenDB-12393 Fixing memory leak in BlittableMetadataModifier usage

### DIFF
--- a/src/Raven.Server/Documents/BlittableMetadataModifier.cs
+++ b/src/Raven.Server/Documents/BlittableMetadataModifier.cs
@@ -24,6 +24,15 @@ namespace Raven.Server.Documents
             _ctx = context;
         }
 
+        public BlittableMetadataModifier(JsonOperationContext context, bool legacyImport, bool readLegacyEtag, DatabaseItemType operateOnTypes)
+        {
+            _ctx = context;
+            ReadFirstEtagOfLegacyRevision = legacyImport;
+            ReadLegacyEtag = readLegacyEtag;
+            OperateOnTypes = operateOnTypes;
+
+
+        }
         public LazyStringValue Id;
         public string ChangeVector;
         public DocumentFlags Flags;


### PR DESCRIPTION
* Moved responsibility of clearing allocation of the modifier to the context