### PR TITLE
RavenDB-12404 Improve Counters Batch performance

### DIFF
--- a/src/Raven.Server/Documents/BlittableMetadataModifier.cs
+++ b/src/Raven.Server/Documents/BlittableMetadataModifier.cs
@@ -361,26 +361,25 @@ namespace Raven.Server.Documents
                     break;
 
                 case 9: // @counters
-                    if (OperateOnTypes.HasFlag(DatabaseItemType.Counters) == false)
-                    {
-                        if (state.StringBuffer[0] != (byte)'@' ||
+                    // always remove the @counters metadata
+                    // not doing so might cause us to have counter on the document but not in the storage.
+                    // the counters will be updated when we import the counters themselves
+                    if (state.StringBuffer[0] != (byte)'@' ||
                         *(long*)(state.StringBuffer + 1) != 8318823012450529123)
-                        {
-                            aboutToReadPropertyName = true;
-                            return true;
-                        }
-
-                        if (reader.Read() == false)
-                        {
-                            _verifyStartArray = true;
-                            _state = State.IgnoreArray;
-                            aboutToReadPropertyName = false;
-                            return true;
-                        }
-                        goto case -2;
+                    {
+                        aboutToReadPropertyName = true;
+                        return true;
                     }
-                    
-                    return true;
+
+                    if (reader.Read() == false)
+                    {
+                        _verifyStartArray = true;
+                        _state = State.IgnoreArray;
+                        aboutToReadPropertyName = false;
+                        return true;
+                    }
+                    goto case -2;
+
                 case 12: // @index-score OR @attachments
                     if (state.StringBuffer[0] == (byte)'@')
                     {   // @index-score

--- a/src/Raven.Server/Documents/CountersStorage.cs
+++ b/src/Raven.Server/Documents/CountersStorage.cs
@@ -409,12 +409,12 @@ namespace Raven.Server.Documents
 
             using (GetCounterPartialKey(context, docId, out var key))
             {
-                var prev = string.Empty;
+                LazyStringValue prev = null;
                 foreach (var result in table.SeekByPrimaryKeyPrefix(key, Slices.Empty, 0))
                 {
                     var current = ExtractCounterName(context, result.Value.Reader);
 
-                    if (prev.Equals(current))
+                    if (prev?.Equals(current) == true)
                     {
                         // already seen this one, skip it 
                         continue;
@@ -422,6 +422,7 @@ namespace Raven.Server.Documents
 
                     yield return current;
 
+                    prev?.Dispose();
                     prev = current;
                 }
             }
@@ -676,61 +677,72 @@ namespace Raven.Server.Documents
             return fst.NumberOfEntries;
         }
 
-        public void UpdateDocumentCounters(DocumentsOperationContext context, BlittableJsonReaderObject doc, string docId)
+        public void UpdateDocumentCounters(DocumentsOperationContext context, BlittableJsonReaderObject doc, string docId,
+            SortedSet<string> countersToAdd, HashSet<string> countersToRemove)
         {
+            if (countersToRemove.Count == 0 && countersToAdd.Count == 0)
+                return;
+
             BlittableJsonReaderArray metadataCounters = null;
             if (doc.TryGet(Constants.Documents.Metadata.Key, out BlittableJsonReaderObject metadata))
             {
                 metadata.TryGet(Constants.Documents.Metadata.Counters, out metadataCounters);
             }
 
-            var counters = GetCountersForDocument(context, docId).ToList();
+            var counters = GetCountersForDocument(metadataCounters, countersToAdd, countersToRemove, out var hadModifications);
+            if (hadModifications == false)
+                return;
 
-            var flags = DocumentFlags.None;
-            if (counters.Count == 0)
+            var flags = counters.Count == 0 ? DocumentFlags.None : DocumentFlags.HasCounters;
+            doc.Modifications = new DynamicJsonValue(doc);
+            if (metadata == null)
             {
-                if (metadataCounters == null)
+                doc.Modifications[Constants.Documents.Metadata.Key] = new DynamicJsonValue
                 {
-                    return;
-                }
-
-                metadata.Modifications = new DynamicJsonValue(metadata);
-                metadata.Modifications.Remove(Constants.Documents.Metadata.Counters);
-                doc.Modifications = new DynamicJsonValue(doc)
-                {
-                    [Constants.Documents.Metadata.Key] = metadata
+                    [Constants.Documents.Metadata.Counters] = new DynamicJsonArray(counters)
                 };
             }
             else
             {
-                if (metadataCounters != null &&
-                    metadataCounters.SequenceEqual(counters))
+                metadata.Modifications = new DynamicJsonValue(metadata)
                 {
-                    return;
-                }
-
-                doc.Modifications = new DynamicJsonValue(doc);
-                if (metadata == null)
-                {
-                    doc.Modifications[Constants.Documents.Metadata.Key] = new DynamicJsonValue
-                    {
-                        [Constants.Documents.Metadata.Counters] = new DynamicJsonArray(counters)
-                    };
-                }
-                else
-                {
-                    metadata.Modifications = new DynamicJsonValue(metadata)
-                    {
-                        [Constants.Documents.Metadata.Counters] = new DynamicJsonArray(counters)
-                    };
-                    doc.Modifications[Constants.Documents.Metadata.Key] = metadata;
-                }
-
-                flags = DocumentFlags.HasCounters;
+                    [Constants.Documents.Metadata.Counters] = new DynamicJsonArray(counters)
+                };
+                doc.Modifications[Constants.Documents.Metadata.Key] = metadata;
             }
 
             var data = context.ReadObject(doc, docId, BlittableJsonDocumentBuilder.UsageMode.ToDisk);
             _documentDatabase.DocumentsStorage.Put(context, docId, null, data, flags: flags, nonPersistentFlags: NonPersistentDocumentFlags.ByCountersUpdate);
+        }
+
+        private static SortedSet<string> GetCountersForDocument(BlittableJsonReaderArray metadataCounters, SortedSet<string> countersToAdd, HashSet<string> countersToRemove, out bool modified)
+        {
+            modified = false;
+            if (metadataCounters == null)
+            {
+                modified = true;
+                return countersToAdd;
+            }
+
+            foreach (var counter in metadataCounters)
+            {
+                var str = counter.ToString();
+                if (countersToRemove.Contains(str))
+                {
+                    modified = true;
+                    continue;
+                }
+
+                countersToAdd.Add(str);
+            }
+
+            if (modified == false)
+            {
+                // if no counter was removed, we can be sure that there are no modification when the counter's count in the metadata is equal to the count of countersToAdd 
+                modified = countersToAdd.Count != metadataCounters.Length;
+            }
+
+            return countersToAdd;
         }
     }
 }

--- a/src/Raven.Server/Documents/Handlers/CountersHandler.cs
+++ b/src/Raven.Server/Documents/Handlers/CountersHandler.cs
@@ -83,16 +83,17 @@ namespace Raven.Server.Documents.Handlers
                 _dictionary = new Dictionary<string, List<CounterOperation>>();
             }
 
-            public void Add(string id, CounterOperation op, out bool isNew)
+            public int Add(string id, CounterOperation op, out bool isNew)
             {
                 isNew = false;
                 if (_dictionary.TryGetValue(id, out var existing) == false)
                 {
                     isNew = true;
                     _dictionary[id] = new List<CounterOperation> { op };
-                    return;
+                    return 1;
                 }
                 existing.Add(op);
+                return existing.Count;
             }
 
             protected override int ExecuteCmd(DocumentsOperationContext context)

--- a/src/Raven.Server/Documents/Handlers/CountersHandler.cs
+++ b/src/Raven.Server/Documents/Handlers/CountersHandler.cs
@@ -129,17 +129,23 @@ namespace Raven.Server.Documents.Handlers
                         {
                             case CounterOperationType.Increment:
                                 LastChangeVector =
-                                    _database.DocumentsStorage.CountersStorage.IncrementCounter(context, docId, docCollection, operation.CounterName, operation.Delta);
+                                    _database.DocumentsStorage.CountersStorage.IncrementCounter(context, docId, docCollection, operation.CounterName, operation.Delta, out var exists);
                                 GetCounterValue(context, _database, docId, operation.CounterName, _replyWithAllNodesValues, CountersDetail);
 
-                                countersToAdd.Add(operation.CounterName);
-                                countersToRemove.Remove(operation.CounterName);
+                                if (exists == false)
+                                {
+                                    // if exists it is already on the document's metadata
+                                    countersToAdd.Add(operation.CounterName);
+                                    countersToRemove.Remove(operation.CounterName);
+                                }
+
                                 break;
                             case CounterOperationType.Delete:
                                 if (_fromEtl && doc == null)
                                     break;
 
                                 LastChangeVector = _database.DocumentsStorage.CountersStorage.DeleteCounter(context, docId, docCollection, operation.CounterName);
+
                                 countersToAdd.Remove(operation.CounterName);
                                 countersToRemove.Add(operation.CounterName);
                                 break;

--- a/src/Raven.Server/Documents/Patch/ScriptRunner.cs
+++ b/src/Raven.Server/Documents/Patch/ScriptRunner.cs
@@ -747,7 +747,7 @@ namespace Raven.Server.Documents.Patch
                     value = args[2].AsNumber();
                 }
 
-                _database.DocumentsStorage.CountersStorage.IncrementCounter(_docsCtx, id, CollectionName.GetCollectionName(docBlittable), name, (long)value);
+                _database.DocumentsStorage.CountersStorage.IncrementCounter(_docsCtx, id, CollectionName.GetCollectionName(docBlittable), name, (long)value, out _);
 
                 if (metadata.TryGet(Constants.Documents.Metadata.Counters, out BlittableJsonReaderArray counters) == false ||
                     counters.BinarySearch(name, StringComparison.OrdinalIgnoreCase) < 0)

--- a/src/Raven.Server/Smuggler/Documents/DatabaseDestination.cs
+++ b/src/Raven.Server/Smuggler/Documents/DatabaseDestination.cs
@@ -674,7 +674,7 @@ namespace Raven.Server.Smuggler.Documents
             private CountersHandler.ExecuteCounterBatchCommand _prevCommand;
             private Task _prevCommandTask = Task.CompletedTask;
             private int _batchSize;
-            private const int _maxBatchSize = 10000;
+            private const int MaxBatchSize = 1_024;
 
             public CounterActions(DocumentDatabase database)
             {
@@ -696,8 +696,9 @@ namespace Raven.Server.Smuggler.Documents
                     ChangeVector = counter.ChangeVector
                 };
 
-                _cmd.Add(counter.DocumentId, counterOp);
-                _batchSize++;
+                _cmd.Add(counter.DocumentId, counterOp, out var isNew);
+                if (isNew)
+                    _batchSize++;
             }
 
             public void WriteCounter(CounterDetail counterDetail)
@@ -713,7 +714,7 @@ namespace Raven.Server.Smuggler.Documents
 
             private void HandleBatchOfCountersIfNecessary()
             {
-                if (_batchSize < _maxBatchSize)
+                if (_batchSize < MaxBatchSize)
                     return;
 
                 var prevCommand = _prevCommand;

--- a/src/Sparrow/Json/JsonOperationContext.cs
+++ b/src/Sparrow/Json/JsonOperationContext.cs
@@ -109,7 +109,7 @@ namespace Sparrow.Json
             }
 
             var allocateStringValue = new LazyStringValue(str, ptr, size, this);
-            if (_numberOfAllocatedStringsValues < 25 * 1000)
+            if (_numberOfAllocatedStringsValues < 32 * 1_024)
             {
                 _allocateStringValues.Add(allocateStringValue);
                 _numberOfAllocatedStringsValues++;


### PR DESCRIPTION
- Try to aggrigate counters by doc id.
- Import documents removes @counter in order to be consistent on counters import.
- On counter inc/put don't iterate over all the existing counters on disk, instead rely on the document's metadata.
- Keep the counters sorted by name.