### PR TITLE
RavenDB-12382: Most cases of MemoryStream now use the Recyclable one.

### DIFF
--- a/src/Raven.Client/Http/RequestExecutor.cs
+++ b/src/Raven.Client/Http/RequestExecutor.cs
@@ -1190,7 +1190,7 @@ namespace Raven.Client.Http
             if (response != null)
             {
                 var stream = await response.Content.ReadAsStreamAsync().ConfigureAwait(false);
-                var ms = new MemoryStream(); // todo: have a pool of those
+                var ms = context.CreateMemoryStream();
                 await stream.CopyToAsync(ms).ConfigureAwait(false);
                 try
                 {

--- a/src/Raven.Client/ServerWide/Commands/GetRawStreamResultCommand.cs
+++ b/src/Raven.Client/ServerWide/Commands/GetRawStreamResultCommand.cs
@@ -51,7 +51,7 @@ namespace Raven.Client.ServerWide.Commands
 
         public override void SetResponseRaw(HttpResponseMessage response, Stream stream, JsonOperationContext context)
         {
-            Result = new MemoryStream();
+            Result = context.CreateMemoryStream();
             stream.CopyTo(Result);
         }
 

--- a/src/Raven.Client/ServerWide/Operations/Certificates/CreateClientCertificateOperation.cs
+++ b/src/Raven.Client/ServerWide/Operations/Certificates/CreateClientCertificateOperation.cs
@@ -103,13 +103,15 @@ namespace Raven.Client.ServerWide.Operations.Certificates
                 if (response == null)
                     return;
 
-                var ms = new MemoryStream();
-                stream.CopyTo(ms);
-
-                Result = new CertificateRawData
+                using (var ms = context.CreateMemoryStream())
                 {
-                    RawData = ms.ToArray()
-                };
+                    stream.CopyTo(ms);
+
+                    Result = new CertificateRawData
+                    {
+                        RawData = ms.ToArray()
+                    };
+                }
             }
         }
     }

--- a/src/Raven.Server/Documents/Handlers/Admin/RachisAdminHandler.cs
+++ b/src/Raven.Server/Documents/Handlers/Admin/RachisAdminHandler.cs
@@ -63,8 +63,8 @@ namespace Raven.Server.Documents.Handlers.Admin
 
                     var (etag, result) = await ServerStore.Engine.PutAsync(command);
                     HttpContext.Response.StatusCode = (int)HttpStatusCode.OK;
-                    var ms = context.CheckoutMemoryStream();
-                    try
+
+                    using (var ms = context.CreateMemoryStream())
                     {
                         using (var writer = new BlittableJsonTextWriter(context, ms))
                         {
@@ -79,10 +79,6 @@ namespace Raven.Server.Documents.Handlers.Admin
                         // now that we know that we properly serialized it
                         ms.Position = 0;
                         await ms.CopyToAsync(ResponseBodyStream());
-                    }
-                    finally
-                    {
-                        context.ReturnMemoryStream(ms);
                     }
                 }
                 catch (NotLeadingException e)

--- a/src/Raven.Server/ServerWide/TempCryptoStream.cs
+++ b/src/Raven.Server/ServerWide/TempCryptoStream.cs
@@ -19,13 +19,7 @@ namespace Raven.Server.ServerWide
         public override bool CanSeek => true;
         public override bool CanWrite => true;
 
-        public override long Length
-        {
-            get
-            {
-                return _maxLength;
-            }
-        }
+        public override long Length => _maxLength;
 
         public override long Position
         {

--- a/src/Raven.Server/Smuggler/Documents/Handlers/SmugglerHandler.cs
+++ b/src/Raven.Server/Smuggler/Documents/Handlers/SmugglerHandler.cs
@@ -312,8 +312,8 @@ namespace Raven.Server.Smuggler.Documents.Handlers
             }
 
             using (ContextPool.AllocateOperationContext(out DocumentsOperationContext finalContext))
-            {
-                var memoryStream = new MemoryStream();
+            using (var memoryStream = finalContext.CreateMemoryStream())
+            {               
                 WriteImportResult(finalContext, finalResult, memoryStream);
                 memoryStream.Position = 0;
                 try

--- a/src/Raven.Server/Smuggler/Documents/StreamSource.cs
+++ b/src/Raven.Server/Smuggler/Documents/StreamSource.cs
@@ -978,6 +978,8 @@ namespace Raven.Server.Smuggler.Documents
                 _result.LegacyLastAttachmentEtag = etag;
             }
 
+            //TODO: We should figure out a way to avoid using MemoryStream here to avoid huge allocations to happen when
+            //      big data needs to be sent over the wire.
             var memoryStream = new MemoryStream();
 
             fixed (char* pdata = base64data)

--- a/src/Raven.Server/TrafficWatch/TrafficWatchHandler.cs
+++ b/src/Raven.Server/TrafficWatch/TrafficWatchHandler.cs
@@ -55,7 +55,7 @@ namespace Raven.Server.TrafficWatch
                                         ["Exception"] = ex
                                     });
                                 }
-
+                                
                                 ms.TryGetBuffer(out ArraySegment<byte> bytes);
                                 await webSocket.SendAsync(bytes, WebSocketMessageType.Text, true, ServerStore.ServerShutdown);
                             }

--- a/src/Raven.Server/Utils/Cli/RavenCli.cs
+++ b/src/Raven.Server/Utils/Cli/RavenCli.cs
@@ -947,8 +947,8 @@ namespace Raven.Server.Utils.Cli
 
         public static string ConvertResultToString(ScriptRunnerResult result)
         {
-            var ms = new MemoryStream();
             using (var ctx = JsonOperationContext.ShortTermSingleUse())
+            using (var ms = ctx.CreateMemoryStream())
             using (var writer = new BlittableJsonTextWriter(ctx, ms))
             {
                 writer.WriteStartObject();
@@ -983,10 +983,10 @@ namespace Raven.Server.Utils.Cli
 
                 writer.WriteEndObject();
                 writer.Flush();
-            }
 
-            var str = Encoding.UTF8.GetString(ms.ToArray());
-            return str;
+                var str = Encoding.UTF8.GetString(ms.ToArray());
+                return str;
+            }
         }
 
         private static bool CommandLowMem(List<string> args, RavenCli cli)

--- a/src/Raven.Server/Web/Authentication/AdminCertificatesHandler.cs
+++ b/src/Raven.Server/Web/Authentication/AdminCertificatesHandler.cs
@@ -115,7 +115,7 @@ namespace Raven.Server.Web.Authentication
 
             var res = await serverStore.PutValueInClusterAsync(new PutCertificateCommand(Constants.Certificates.Prefix + selfSignedCertificate.Thumbprint, newCertDef));
             await serverStore.Cluster.WaitForIndexNotification(res.Index);
-
+            
             var ms = new MemoryStream();
             using (var archive = new ZipArchive(ms, ZipArchiveMode.Create, true))
             {

--- a/src/Sparrow/Json/BlittableJsonReaderArray.cs
+++ b/src/Sparrow/Json/BlittableJsonReaderArray.cs
@@ -39,7 +39,7 @@ namespace Sparrow.Json
 
         public override string ToString()
         {
-            using (var memoryStream = new MemoryStream())
+            using (var memoryStream = this._context.CreateMemoryStream())
             using (var tw = new BlittableJsonTextWriter(_context, memoryStream))
             {
                 tw.WriteValue(BlittableJsonToken.StartArray, this);

--- a/src/Sparrow/Json/BlittableJsonReaderObject.cs
+++ b/src/Sparrow/Json/BlittableJsonReaderObject.cs
@@ -29,7 +29,7 @@ namespace Sparrow.Json
 
         public override string ToString()
         {
-            using (var memoryStream = new MemoryStream())
+            using (var memoryStream = this._context.CreateMemoryStream())
             {
                 WriteJsonTo(memoryStream);
                 memoryStream.Position = 0;

--- a/src/Sparrow/Sparrow.csproj
+++ b/src/Sparrow/Sparrow.csproj
@@ -38,6 +38,7 @@
   </ItemGroup>
   <ItemGroup>
     <PackageReference Include="Microsoft.CSharp" Version="4.5.0" />
+    <PackageReference Include="Microsoft.IO.RecyclableMemoryStream" Version="1.2.2" />
     <PackageReference Include="System.Buffers" Version="4.5.0" />
     <PackageReference Include="System.Runtime.CompilerServices.Unsafe" Version="4.5.2" />
     <PackageReference Include="System.Threading.Tasks.Extensions" Version="4.5.1" />


### PR DESCRIPTION
Dont push it yet, we should do a proper insert benchmark test to ensure the change does not cause a big regression on raw performance.