### PR TITLE
RavenDB-12452

### DIFF
--- a/src/Raven.Server/Documents/ETL/Providers/Raven/RavenEtl.cs
+++ b/src/Raven.Server/Documents/ETL/Providers/Raven/RavenEtl.cs
@@ -85,7 +85,7 @@ namespace Raven.Server.Documents.ETL.Providers.Raven
             return Transformation.IsEmptyScript;
         }
 
-        protected override bool ShouldTrackCounters()
+        public override bool ShouldTrackCounters()
         {
             // we track counters only if script is empty (then we send all counters together with documents) or
             // when load counter behavior functions are defined, otherwise counters are send on document updates

--- a/src/Raven.Server/Documents/ETL/Providers/SQL/SqlEtl.cs
+++ b/src/Raven.Server/Documents/ETL/Providers/SQL/SqlEtl.cs
@@ -47,7 +47,7 @@ namespace Raven.Server.Documents.ETL.Providers.SQL
             return false;
         }
 
-        protected override bool ShouldTrackCounters()
+        public override bool ShouldTrackCounters()
         {
             return false;
         }


### PR DESCRIPTION
- EtlLoader should subscribe to document and counter changes only if there are any processes defined
- Unsubscribe if we remove all ETLs
- Don't trigger ETL process run on counter change if it doesn't track counters