### PR TITLE
RavenDB-12414 change revision behaviour

### DIFF
--- a/src/Raven.Server/Documents/DocumentPutAction.cs
+++ b/src/Raven.Server/Documents/DocumentPutAction.cs
@@ -99,21 +99,25 @@ namespace Raven.Server.Documents
 
                     var oldFlags = TableValueToFlags((int)DocumentsTable.Flags, ref oldValue);
 
-                    if ((nonPersistentFlags & NonPersistentDocumentFlags.FromReplication) != NonPersistentDocumentFlags.FromReplication)
+                    if (nonPersistentFlags.Contain(NonPersistentDocumentFlags.FromReplication) == false)
                     {
-                        if ((nonPersistentFlags & NonPersistentDocumentFlags.ByAttachmentUpdate) != NonPersistentDocumentFlags.ByAttachmentUpdate &&
-                            (oldFlags & DocumentFlags.HasAttachments) == DocumentFlags.HasAttachments)
+                        if (nonPersistentFlags.Contain(NonPersistentDocumentFlags.ByAttachmentUpdate) == false &&
+                            oldFlags .Contain(DocumentFlags.HasAttachments))
                         {
                             flags |= DocumentFlags.HasAttachments;
                         }
 
-                        if ((nonPersistentFlags & NonPersistentDocumentFlags.ByCountersUpdate) != NonPersistentDocumentFlags.ByCountersUpdate &&
-                            (oldFlags & DocumentFlags.HasCounters) == DocumentFlags.HasCounters)
+                        if (nonPersistentFlags.Contain(NonPersistentDocumentFlags.ByCountersUpdate) == false &&
+                            oldFlags.Contain(DocumentFlags.HasCounters))
                         {
                             flags |= DocumentFlags.HasCounters;
                         }
-                    }
 
+                        if (oldFlags.Contain(DocumentFlags.HasRevisions))
+                        {
+                            flags |= DocumentFlags.HasRevisions;
+                        }
+                    }
                 }
 
                 var result = BuildChangeVectorAndResolveConflicts(context, id, lowerId, newEtag, document, changeVector, expectedChangeVector, flags, oldValue);
@@ -173,17 +177,22 @@ namespace Raven.Server.Documents
 #endif
                     }
 
-                    if (nonPersistentFlags.Contain(NonPersistentDocumentFlags.FromReplication) == false && 
-                        (flags.Contain(DocumentFlags.Resolved) || 
-                        _documentDatabase.DocumentsStorage.RevisionsStorage.Configuration != null
-                        ))
+                    var shouldVersion = _documentDatabase.DocumentsStorage.RevisionsStorage.ShouldVersionDocument(collectionName, nonPersistentFlags, oldDoc, document,
+                        ref flags, out RevisionsCollectionConfiguration configuration);
+                    if (shouldVersion)
                     {
-                        var shouldVersion = _documentDatabase.DocumentsStorage.RevisionsStorage.ShouldVersionDocument(collectionName, nonPersistentFlags, oldDoc, document,
-                            ref flags, out RevisionsCollectionConfiguration configuration);
-                        if (shouldVersion)
+                        if (flags.Contain(DocumentFlags.HasRevisions) == false && oldDoc != null)
                         {
-                            _documentDatabase.DocumentsStorage.RevisionsStorage.Put(context, id, document, flags, nonPersistentFlags, changeVector, modifiedTicks, configuration, collectionName);
+                            var oldFlags = TableValueToFlags((int)DocumentsTable.Flags, ref oldValue);
+                            var oldChangeVector = TableValueToChangeVector(context, (int)DocumentsTable.ChangeVector, ref oldValue);
+                            var oldTicks = TableValueToDateTime((int)DocumentsTable.LastModified, ref oldValue);
+                            
+                            _documentDatabase.DocumentsStorage.RevisionsStorage.Put(context, id, oldDoc, oldFlags | DocumentFlags.HasRevisions, NonPersistentDocumentFlags.None,
+                                oldChangeVector, oldTicks.Ticks, configuration, collectionName);
                         }
+                        flags |= DocumentFlags.HasRevisions;
+
+                        _documentDatabase.DocumentsStorage.RevisionsStorage.Put(context, id, document, flags, nonPersistentFlags, changeVector, modifiedTicks, configuration, collectionName);
                     }
                 }
 

--- a/src/Raven.Server/Documents/Handlers/CountersHandler.cs
+++ b/src/Raven.Server/Documents/Handlers/CountersHandler.cs
@@ -38,6 +38,7 @@ namespace Raven.Server.Documents.Handlers
             private readonly DocumentDatabase _database;
             private readonly bool _replyWithAllNodesValues;
             private readonly bool _fromEtl;
+            private readonly bool _fromSmuggler;
             private readonly Dictionary<string, List<CounterOperation>> _dictionary;
 
             public ExecuteCounterBatchCommand(DocumentDatabase database, CounterBatch counterBatch)
@@ -79,6 +80,7 @@ namespace Raven.Server.Documents.Handlers
             // used only from smuggler import
             public ExecuteCounterBatchCommand(DocumentDatabase database)
             {
+                _fromSmuggler = true;
                 _database = database;
                 _dictionary = new Dictionary<string, List<CounterOperation>>();
             }
@@ -184,7 +186,11 @@ namespace Raven.Server.Documents.Handlers
 
                     if (doc != null)
                     {
-                        _database.DocumentsStorage.CountersStorage.UpdateDocumentCounters(context, doc.Data, docId, countersToAdd, countersToRemove);
+                        var nonPersistentFlags = NonPersistentDocumentFlags.ByCountersUpdate;
+                        if (_fromSmuggler)
+                            nonPersistentFlags |= NonPersistentDocumentFlags.FromSmuggler;
+
+                        _database.DocumentsStorage.CountersStorage.UpdateDocumentCounters(context, doc, docId, countersToAdd, countersToRemove, nonPersistentFlags);
                         doc.Data?.Dispose(); // we cloned the data, so we can dispose it.
                     }
 

--- a/src/Raven.Server/Documents/Revisions/RevisionsStorage.cs
+++ b/src/Raven.Server/Documents/Revisions/RevisionsStorage.cs
@@ -268,9 +268,10 @@ namespace Raven.Server.Documents.Revisions
                     return false;
             }
 
-            // no need to keep revision if no configuration is defined, unless it is a conflict resolution
-            if (Configuration == null && 
-                documentFlags.Contain(DocumentFlags.Resolved) == false)
+            if (documentFlags.Contain(DocumentFlags.Resolved))
+                return true;
+
+            if (Configuration == null)
             {
                 documentFlags = documentFlags.Strip(DocumentFlags.HasRevisions);
                 return false;
@@ -292,7 +293,13 @@ namespace Raven.Server.Documents.Revisions
 
                 // we are not going to create a revision if it's an import from v3
                 // (since this import is going to import revisions as well)
-                return nonPersistentFlags.Contain(NonPersistentDocumentFlags.LegacyHasRevisions) == false;
+                if (nonPersistentFlags.Contain(NonPersistentDocumentFlags.LegacyHasRevisions))
+                {
+                    documentFlags |= DocumentFlags.HasRevisions;
+                    return false;
+                }
+
+                return true;
             }
 
             // compare the contents of the existing and the new document

--- a/test/SlowTests/Issues/RavenDB-12204.cs
+++ b/test/SlowTests/Issues/RavenDB-12204.cs
@@ -11,7 +11,7 @@ namespace SlowTests.Issues
 {
     public class RavenDB_12204 : RavenTestBase
     {
-        [Fact(Skip = "RavenDB-12414")]
+        [Fact]
         public async Task CanMigrateFromRavenDb()
         {
             var file = Path.Combine(NewDataPath(forceCreateDir: true), "export.ravendbdump");


### PR DESCRIPTION
- If document exists and we enable the revisions then changing a document will generate 2 revisions, the old doc and the current one.

- When revisions are enabled, importing a document will be considered as put.

- Import counters will not generate new revisions even if revisions are enabled.