### PR TITLE
RavenDB-12471 - DiskFullException doesn't result in client failover

### DIFF
--- a/src/Raven.Server/RavenServerStartup.cs
+++ b/src/Raven.Server/RavenServerStartup.cs
@@ -283,7 +283,8 @@ namespace Raven.Server
 
             if (exception is LowMemoryException ||
                 exception is OutOfMemoryException ||
-                exception is VoronUnrecoverableErrorException)
+                exception is VoronUnrecoverableErrorException ||
+                exception is DiskFullException)
             {
                 response.StatusCode = (int)HttpStatusCode.ServiceUnavailable;
                 return;


### PR DESCRIPTION
http://issues.hibernatingrhinos.com/issue/RavenDB-12471