### PR TITLE
RavenDB-12351 Fixing Fix issue when sync can be run with or without pre and pro sync tasks

### DIFF
--- a/src/Voron/Impl/Journal/WriteAheadJournal.cs
+++ b/src/Voron/Impl/Journal/WriteAheadJournal.cs
@@ -977,7 +977,7 @@ namespace Voron.Impl.Journal
                                 _task = null;
                                 return false;
                             }
-                        } while (_task != task);
+                        } while (_task != null);
 
                         return true;
                     }


### PR DESCRIPTION
The problem was if the flush lock was occupied the sync operation pass the task it needs to do under flush lock to flush operation but without waiting to finish. 
This was the situation in `WaitToGatherInformationToStartSync` and in `WaitForUpdateDatabaseStateAfterSync`