### PR TITLE
RavenDB-12470 Allow CPU usage to be greater than 100%

### DIFF
--- a/src/Raven.Server/Utils/Cpu/CpuUsageExtensionPoint.cs
+++ b/src/Raven.Server/Utils/Cpu/CpuUsageExtensionPoint.cs
@@ -194,9 +194,9 @@ namespace Raven.Server.Utils.Cpu
                 HandleError($"Can't read {propertyName} property from : {Environment.NewLine + blittable}.");
                 return false;
             }
-            if (cpuUsage < 0 || cpuUsage > 100)
+            if (cpuUsage < 0)
             {
-                HandleError($"{nameof(ExtensionPointData.MachineCpuUsage)} should be between 0 to 100 : {Environment.NewLine + blittable}.");
+                HandleError($"{nameof(ExtensionPointData.MachineCpuUsage)} can't be negative : {Environment.NewLine + blittable}.");
                 return false;
             }
 

--- a/src/Raven.Server/Utils/Cpu/CpuUsageExtensionPoint.cs
+++ b/src/Raven.Server/Utils/Cpu/CpuUsageExtensionPoint.cs
@@ -200,6 +200,9 @@ namespace Raven.Server.Utils.Cpu
                 return false;
             }
 
+            if (cpuUsage > 100)
+                cpuUsage = 100;
+
             return true;
         }
 


### PR DESCRIPTION
http://issues.hibernatingrhinos.com/issue/RavenDB-12470
In Kubernetes the CPU usage that comes from metrics server can be more than 100%
so the `CpuUsageExtensionPoint` modified to accept it as a valid value