### PR TITLE
fix for RavenDB-12263

### DIFF
--- a/src/Raven.Server/Documents/Queries/Graph/RecursionQueryStep.cs
+++ b/src/Raven.Server/Documents/Queries/Graph/RecursionQueryStep.cs
@@ -1,5 +1,6 @@
 ﻿using System;
 using System.Collections.Generic;
+using System.Diagnostics;
 using System.Linq;
 using System.Threading.Tasks;
 using Microsoft.Extensions.Primitives;
@@ -22,6 +23,7 @@ namespace Raven.Server.Documents.Queries.Graph
         private readonly List<Match> _results = new List<Match>();
         private List<Match> _temp = new List<Match>();
         private readonly HashSet<string> _allLliases = new HashSet<string>();
+        
         private readonly HashSet<long> _visited = new HashSet<long>();
         private readonly Stack<RecursionState> _path = new Stack<RecursionState>();
         public int _index = -1;
@@ -304,29 +306,42 @@ namespace Raven.Server.Documents.Queries.Graph
             _path.Push(new RecursionState { Src = startingPoint.Data, Match = currentMatch });
 
             int aliasBaseIndex = 0;
-
             Document cur = startingPoint;
+
+            //this function is needed for "documentation" purposes
+            bool AddMatchToResultsAndCheckIfNeedToStop(Document current)
+            {
+                if (AddMatchToResults(current))
+                    return true;
+
+                _path.Pop();
+                return false;
+            }
+
             while (true)
             {
                 // the first item is always the root
                 if (_path.Count - 1 == _options.Max)
                 {
-                    if (AddMatch(cur))
+                    if (AddMatchToResultsAndCheckIfNeedToStop(cur))
                         return;
-                    _path.Pop();
                 }
                 else
                 {
-                    if (ProcessSingleResult(currentMatch, aliasBaseIndex, out var currentMatches) == false)
+                    //get relevant nodes to continue traversal over them
+                    //so if 'dogs/1' likes 'dogs/2' and 'dogs/1' likes 'dogs/3', _currentMatches_ will contain 'dogs/2' and 'dogs/3'
+                    if (TryGetNextNodesForTraversal(currentMatch, aliasBaseIndex, out var currentMatches) == false)
                     {
-                        if (AddMatch(cur))
-                        {
+                        //if we don't have any nodes to continue traversal, and we have "lazy" recursive strategy stop
+                        //recursive traversal because we found at least one matching path and it is enough.
+                        //(AddMatch returns 'true' if we have "lazy" strategy selected)
+                        //otherwise, just start back-tracking so we can add to results all permutations of a path - that is what _path.Pop() is doing
+                        if (AddMatchToResultsAndCheckIfNeedToStop(cur))
                             return;
-                        }
-                        _path.Pop();
                     }
                     else
                     {
+                        //store next traversal nodes in the last node of the path
                         _path.Peek().Matches = currentMatches;
                     }
                 }
@@ -340,13 +355,15 @@ namespace Raven.Server.Documents.Queries.Graph
                         return;
 
                     if (_options.Type == RecursiveMatchType.Lazy &&
-
-                        AddMatch(cur))
+                        AddMatchToResults(cur))
                     {
                         return;
                     }
 
                     var top = _path.Peek();
+
+                    //we have reached the end of traversal, so we backtrack.
+                    //this is needed if there are multiple possible paths that need to be traversed
                     if (top.Matches == null || top.Matches.Count == 0)
                     {
                         var current = top.Match.GetSingleDocumentResult(_outputAlias);
@@ -354,28 +371,44 @@ namespace Raven.Server.Documents.Queries.Graph
                         {
                             current = top.Match.GetSingleDocumentResult(_left.GetOutputAlias());
                         }
-                        if (current != null && AddMatch(current))
+                        if (current != null && AddMatchToResults(current))
                         {
                             return;
                         }
 
                         _path.Pop();
+
+                        //since we are backtracking, remove the node from the top of the path stack
                         _visited.Remove(top.Src.Location);
+
+                        //also, make sure to remove the last node in the iteration
+                        //if we don't do this, we will miss path permutation that includes the last node
+                        //this will happen IF and only IF there are multiple possible paths, since _visited values carry over
+                        //to next "branching" path traversal
+                        _visited.Remove(cur.Data.Location); 
                         continue;
                     }
+
+                    //currentMatch - next step in recursive traversal.
+                    //if we have "branching" path, start from last of them and remove it so we won't evaluate 
+                    //certain path twice
                     currentMatch = top.Matches[top.Matches.Count - 1];
                     cur = currentMatch.GetSingleDocumentResult(_outputAlias);
                     top.Matches.RemoveAt(top.Matches.Count - 1);
+                   
                     if (_visited.Add(cur.Data.Location) == false)
                     {
                         continue;
                     }
+
+                    //now, we add the currentMatch to "discovered" path and "jump" to resolution of the next step.
+                    //resolving next step of traversal is this line:  if (ProcessSingleResult(currentMatch, aliasBaseIndex, out var currentMatches) == false)
                     _path.Push(new RecursionState { Src = cur.Data, Match = currentMatch });
                     break;
                 }
             }
 
-            bool AddMatch(Document current)
+            bool AddMatchToResults(Document current)
             {
                 var top = _path.Peek();
                 if (top.AlreadyAdded)
@@ -449,7 +482,7 @@ namespace Raven.Server.Documents.Queries.Graph
         }
 
 
-        private bool ProcessSingleResult(Match match, int aliasBaseIndex, out List<Match> results)
+        private bool TryGetNextNodesForTraversal(Match match, int aliasBaseIndex, out List<Match> results)
         {
             _steps[0].Results.Clear();
             _steps[0].SingleMatch(match, _stepAliases[aliasBaseIndex]);

--- a/test/FastTests/Issues/RavenDB-12263.cs
+++ b/test/FastTests/Issues/RavenDB-12263.cs
@@ -1,0 +1,136 @@
+﻿using System;
+using System.Collections.Generic;
+using System.Linq;
+using System.Text;
+using FastTests.Graph;
+using Newtonsoft.Json.Linq;
+using Raven.Client.Documents;
+using Xunit;
+
+// ReSharper disable InconsistentNaming
+
+namespace FastTests.Issues
+{
+    public class RavenDB_12263 : RavenTestBase
+    {
+        private void CreateData(IDocumentStore store)
+        {
+          
+            using (var session = store.OpenSession())
+            {
+                session.Store(new Dog
+                {
+                    Id = "dogs/1",
+                    Likes = new []{"dogs/2", "dogs/3"}
+                });
+                session.Store(new Dog
+                {
+                    Id = "dogs/2",
+                    Likes = new []{"dogs/4"}
+                });
+                session.Store(new Dog
+                {
+                    Id = "dogs/4",
+                    Likes = new []{"dogs/6"}
+                });
+                session.Store(new Dog
+                {
+                    Id = "dogs/6",
+                    Likes = new []{"dogs/8"}
+                });
+                session.Store(new Dog
+                {
+                    Id = "dogs/3",
+                    Likes = new []{"dogs/5"}
+                });                
+                session.Store(new Dog
+                {
+                    Id = "dogs/5",
+                    Likes = new []{"dogs/7"}
+                });                
+                session.Store(new Dog
+                {
+                    Id = "dogs/7",
+                    Likes = new []{"dogs/8"}
+                });                
+                session.Store(new Dog
+                {
+                    Id = "dogs/8",
+                });   
+                session.SaveChanges();
+            }
+        }
+
+        [Fact]
+        public void All_paths_in_recursive_graph_queries_with_fixed_destination_should_return_proper_paths()
+        {
+            using(var store = GetDocumentStore())
+            {
+                CreateData(store);
+
+                using (var session = store.OpenSession())
+                {
+                    var results = session.Advanced.RawQuery<JObject>(@"
+                        match(Dogs as Buddy where id() = 'dogs/1') 
+                            -recursive as RecursiveLikes (all) 
+                                { [Likes as PathElement] -> 
+                                    (Dogs as TravelStep)
+                                } -[Likes as PathElement] -> 
+                                    (Dogs as TraversalDestination where id() = 'dogs/8')
+                        select 
+                        {
+                            IdOfTraversalStart : id(Buddy), 
+                            LikesPath : RecursiveLikes.map(x => x.PathElement).join('>>'), 
+                            IdOfTraversalEnd : id(TraversalDestination)
+                        }
+                    ").ToList();
+                    
+                    var likesPaths = results.Select(x => x["LikesPath"].Value<string>().Split(">>")).ToArray();
+                    Assert.Equal(2, likesPaths.Length);
+                    Assert.Equal(likesPaths[0],new []{"dogs/3", "dogs/5", "dogs/7" });
+                    Assert.Equal(likesPaths[1],new []{"dogs/2", "dogs/4", "dogs/6" });
+                }
+            }
+        }
+
+        [Fact]
+        public void All_paths_in_recursive_graph_queries_without_fixed_destination_should_return_proper_paths()
+        {
+            using(var store = GetDocumentStore())
+            {
+                CreateData(store);
+
+                using (var session = store.OpenSession())
+                {
+                    var results = session.Advanced.RawQuery<JObject>(@"
+                        match(Dogs as Buddy where id() = 'dogs/1') 
+                            -recursive as RecursiveLikes (all) 
+                                { [Likes as PathElement] -> 
+                                    (Dogs as TravelStep)
+                                }
+                        select 
+                        {
+                            IdOfTraversalStart : id(Buddy), 
+                            LikesPath : RecursiveLikes.map(x => x.PathElement).join('>>'), 
+                            IdOfTraversalEnd : id(TraversalDestination)
+                        }
+                    ").ToList();
+                    
+                    var likesPaths = results.Select(x => x["LikesPath"].Value<string>()).ToArray();
+
+                    Assert.Equal(8, likesPaths.Length);
+
+                    Assert.Contains("dogs/2>>dogs/4>>dogs/6>>dogs/8", likesPaths);
+                    Assert.Contains("dogs/2>>dogs/4>>dogs/6", likesPaths);
+                    Assert.Contains("dogs/2>>dogs/4", likesPaths);
+                    Assert.Contains("dogs/2", likesPaths);
+
+                    Assert.Contains("dogs/3>>dogs/5>>dogs/7>>dogs/8", likesPaths);
+                    Assert.Contains("dogs/3>>dogs/5>>dogs/7", likesPaths);
+                    Assert.Contains("dogs/3>>dogs/5", likesPaths);
+                    Assert.Contains("dogs/3", likesPaths);
+                }
+            }
+        }
+    }
+}


### PR DESCRIPTION
Make sure to include ALL path permutations in recursive graph queries when using "all" strategy.
(includes some very minor refactorings and comments for better code clarity)