### PR TITLE
RavenDB-12193: UnobservedTaskExceptions should be handled now.

### DIFF
--- a/src/Raven.Client/Documents/Changes/DatabaseConnectionState.cs
+++ b/src/Raven.Client/Documents/Changes/DatabaseConnectionState.cs
@@ -2,6 +2,7 @@ using System;
 using System.Threading;
 using System.Threading.Tasks;
 using Raven.Client.Documents.Operations;
+using Raven.Client.Extensions;
 
 namespace Raven.Client.Documents.Changes
 {
@@ -20,6 +21,8 @@ namespace Raven.Client.Documents.Changes
         {
             if (_firstSet.Task.IsCompleted == false)
             {
+                var task =_firstSet.Task.IgnoreUnobservedExceptions();
+
                 connection.ContinueWith(t =>
                 {
                     if (t.IsFaulted)
@@ -27,7 +30,7 @@ namespace Raven.Client.Documents.Changes
                     else if (t.IsCanceled)
                         _firstSet.TrySetCanceled();
                     else
-                        _firstSet.SetResult(null);
+                        _firstSet.TrySetResult(null);
                 });
             }
             _connected = connection;

--- a/src/Raven.Server/Documents/DatabasesLandlord.cs
+++ b/src/Raven.Server/Documents/DatabasesLandlord.cs
@@ -737,6 +737,8 @@ namespace Raven.Server.Documents
                 }
             });
 
+            var t = tcs.IgnoreUnobservedExceptions();
+
             try
             {
                 var existing = DatabasesCache.Replace(dbName, tcs);

--- a/test/SlowTests/Issues/RavenDB_12193.cs
+++ b/test/SlowTests/Issues/RavenDB_12193.cs
@@ -1,0 +1,41 @@
+using System;
+using Xunit;
+using System.Threading;
+using System.Threading.Tasks;
+using FastTests;
+using Raven.Client.Documents.Changes;
+using Raven.Client.Extensions;
+using Raven.Tests.Core.Utils.Entities;
+
+namespace SlowTests.Issues
+{
+    public class RavenDB_12193 : RavenTestBase
+    {
+        // RavenDB-12481
+        [Fact]
+        public async Task Should_Throw_On_UnobservedTaskException()
+        {
+            var count = 0;
+
+            EventHandler<UnobservedTaskExceptionEventArgs> task = (sender, args) =>
+            {
+                Interlocked.Increment(ref count);
+            };
+
+            try
+            {
+                TaskScheduler.UnobservedTaskException += task;
+                using (GetDocumentStore().Changes().ForAllDocuments().Subscribe(change => {{}})){}
+
+                GC.Collect(GC.MaxGeneration, GCCollectionMode.Forced);
+
+                await Task.Delay(1000);
+                Assert.Equal(0, count);
+            }
+            finally
+            {
+                TaskScheduler.UnobservedTaskException -= task;
+            }
+        }
+    }
+}

--- a/test/SlowTests/Issues/RavenDB_12193.cs
+++ b/test/SlowTests/Issues/RavenDB_12193.cs
@@ -28,8 +28,8 @@ namespace SlowTests.Issues
                 using (GetDocumentStore().Changes().ForAllDocuments().Subscribe(change => {{}})){}
 
                 GC.Collect(GC.MaxGeneration, GCCollectionMode.Forced);
+                GC.WaitForPendingFinalizers();
 
-                await Task.Delay(1000);
                 Assert.Equal(0, count);
             }
             finally


### PR DESCRIPTION
RavenDB-12481