### PR TITLE
RavenDB-12473 Let's ignore write errors when updating index state to …

### DIFF
--- a/src/Raven.Server/Documents/Indexes/Auto/AutoMapIndex.cs
+++ b/src/Raven.Server/Documents/Indexes/Auto/AutoMapIndex.cs
@@ -41,9 +41,9 @@ namespace Raven.Server.Documents.Indexes.Auto
             SetPriority(definition.Priority);
         }
 
-        public override void SetState(IndexState state, bool inMemoryOnly = false)
+        public override void SetState(IndexState state, bool inMemoryOnly = false, bool ignoreWriteError = false)
         {
-            base.SetState(state, inMemoryOnly);
+            base.SetState(state, inMemoryOnly, ignoreWriteError);
             Definition.State = state;
         }
 

--- a/src/Raven.Server/Documents/Indexes/Errors/FaultyInMemoryIndex.cs
+++ b/src/Raven.Server/Documents/Indexes/Errors/FaultyInMemoryIndex.cs
@@ -125,7 +125,7 @@ namespace Raven.Server.Documents.Indexes.Errors
             throw new NotSupportedException($"Index {Name} is in-memory implementation of a faulty index", _e);
         }
 
-        public override void SetState(IndexState state, bool inMemoryOnly = false)
+        public override void SetState(IndexState state, bool inMemoryOnly = false, bool ignoreWriteError = false)
         {
             throw new NotSupportedException($"Index {Name} is in-memory implementation of a faulty index", _e);
         }

--- a/src/Raven.Server/Documents/Indexes/MapReduce/Auto/AutoMapReduceIndex.cs
+++ b/src/Raven.Server/Documents/Indexes/MapReduce/Auto/AutoMapReduceIndex.cs
@@ -81,9 +81,9 @@ namespace Raven.Server.Documents.Indexes.MapReduce.Auto
             SetPriority(definition.Priority);
         }
 
-        public override void SetState(IndexState state, bool inMemoryOnly = false)
+        public override void SetState(IndexState state, bool inMemoryOnly = false, bool ignoreWriteError = false)
         {
-            base.SetState(state, inMemoryOnly);
+            base.SetState(state, inMemoryOnly, ignoreWriteError);
             Definition.State = state;
         }
 


### PR DESCRIPTION
…Error in methods which handle exceptions. This way we won't end up with "Unexpected error in '{Name}' index. This should never happen."