### PR TITLE
RavenDB-12015 - fixing AVE

### DIFF
--- a/src/Raven.Server/Documents/Indexes/MapReduce/MapReduceIndexingContext.cs
+++ b/src/Raven.Server/Documents/Indexes/MapReduce/MapReduceIndexingContext.cs
@@ -37,16 +37,21 @@ namespace Raven.Server.Documents.Indexes.MapReduce
 
         public void Dispose()
         {
-            DocumentMapEntries?.Dispose();
-            DocumentMapEntries = null;
-            MapPhaseTree = null;
-            ReducePhaseTree = null;
-            ProcessedDocEtags.Clear();
-            ProcessedTombstoneEtags.Clear();
-            StoreByReduceKeyHash.Clear();
-            FreedPages.Clear();
-
-            StoreNextMapResultId();
+            try
+            {
+                StoreNextMapResultId();
+            }
+            finally
+            {
+                DocumentMapEntries?.Dispose();
+                DocumentMapEntries = null;
+                MapPhaseTree = null;
+                ReducePhaseTree = null;
+                ProcessedDocEtags.Clear();
+                ProcessedTombstoneEtags.Clear();
+                StoreByReduceKeyHash.Clear();
+                FreedPages.Clear();
+            }
         }
 
         public unsafe void StoreNextMapResultId()

--- a/src/Raven.Server/Documents/Indexes/MapReduce/MapReduceIndexingContext.cs
+++ b/src/Raven.Server/Documents/Indexes/MapReduce/MapReduceIndexingContext.cs
@@ -1,6 +1,7 @@
 ﻿using System;
 using System.Collections.Generic;
 using Sparrow;
+using Sparrow.Logging;
 using Voron;
 using Voron.Data.BTrees;
 using Voron.Data.Fixed;
@@ -9,6 +10,8 @@ namespace Raven.Server.Documents.Indexes.MapReduce
 {
     public class MapReduceIndexingContext : IDisposable
     {
+        private static readonly Logger Logger = LoggingSource.Instance.GetLogger<MapReduceResultsStore>("MapReduceIndexingContext");
+
         internal static Slice LastMapResultIdKey;
 
         public FixedSizeTree DocumentMapEntries;
@@ -34,7 +37,6 @@ namespace Raven.Server.Documents.Indexes.MapReduce
 
         public void Dispose()
         {
-            StoreNextMapResultId();
             DocumentMapEntries?.Dispose();
             DocumentMapEntries = null;
             MapPhaseTree = null;
@@ -43,6 +45,8 @@ namespace Raven.Server.Documents.Indexes.MapReduce
             ProcessedTombstoneEtags.Clear();
             StoreByReduceKeyHash.Clear();
             FreedPages.Clear();
+
+            StoreNextMapResultId();
         }
 
         public unsafe void StoreNextMapResultId()
@@ -50,8 +54,18 @@ namespace Raven.Server.Documents.Indexes.MapReduce
             if (MapPhaseTree.Llt.Environment.Options.IsCatastrophicFailureSet)
                 return; // avoid re-throwing it
 
-            using (MapPhaseTree.DirectAdd(LastMapResultIdKey, sizeof(long), out byte* ptr))
-                *(long*)ptr = NextMapResultId;
+            try
+            {
+                using (MapPhaseTree.DirectAdd(LastMapResultIdKey, sizeof(long), out byte* ptr))
+                    *(long*)ptr = NextMapResultId;
+            }
+            catch (Exception e)
+            {
+                if (Logger.IsInfoEnabled)
+                    Logger.Info("Failed to store next map result id", e);
+
+                throw;
+            }
         }
 
         public unsafe void Initialize(Tree mapEntriesTree)


### PR DESCRIPTION
when we get an exception in the dispose of MapReduceIndexingContext we don't clear the internal structures and try to reuse it in the next transaction