### PR TITLE
RavenDB-12015 - fixing AVE

### DIFF
--- a/src/Raven.Server/Documents/Indexes/MapReduce/MapReduceIndexingContext.cs
+++ b/src/Raven.Server/Documents/Indexes/MapReduce/MapReduceIndexingContext.cs
@@ -1,6 +1,7 @@
 ﻿using System;
 using System.Collections.Generic;
 using Sparrow;
+using Sparrow.Logging;
 using Voron;
 using Voron.Data.BTrees;
 using Voron.Data.Fixed;
@@ -9,6 +10,8 @@ namespace Raven.Server.Documents.Indexes.MapReduce
 {
     public class MapReduceIndexingContext : IDisposable
     {
+        private static readonly Logger Logger = LoggingSource.Instance.GetLogger<MapReduceResultsStore>("MapReduceIndexingContext");
+
         internal static Slice LastMapResultIdKey;
 
         public FixedSizeTree DocumentMapEntries;
@@ -40,15 +43,22 @@ namespace Raven.Server.Documents.Indexes.MapReduce
 
         public void Dispose()
         {
-            StoreNextMapResultId();
-            DocumentMapEntries?.Dispose();
-            DocumentMapEntries = null;
-            MapPhaseTree = null;
-            ReducePhaseTree = null;
-            PageModifiedInReduceTree = null;
-            ProcessedDocEtags.Clear();
-            ProcessedTombstoneEtags.Clear();
-            StoreByReduceKeyHash.Clear();
+            try
+            {
+                StoreNextMapResultId();
+            }
+            finally
+            {
+                StoreNextMapResultId();
+                DocumentMapEntries?.Dispose();
+                DocumentMapEntries = null;
+                MapPhaseTree = null;
+                ReducePhaseTree = null;
+                PageModifiedInReduceTree = null;
+                ProcessedDocEtags.Clear();
+                ProcessedTombstoneEtags.Clear();
+                StoreByReduceKeyHash.Clear();
+            }
         }
 
         public unsafe void StoreNextMapResultId()
@@ -56,8 +66,18 @@ namespace Raven.Server.Documents.Indexes.MapReduce
             if (MapPhaseTree.Llt.Environment.Options.IsCatastrophicFailureSet)
                 return; // avoid re-throwing it
 
-            using (MapPhaseTree.DirectAdd(LastMapResultIdKey, sizeof(long), out byte* ptr))
-                *(long*)ptr = NextMapResultId;
+            try
+            {
+                using (MapPhaseTree.DirectAdd(LastMapResultIdKey, sizeof(long), out byte* ptr))
+                    *(long*)ptr = NextMapResultId;
+            }
+            catch (Exception e)
+            {
+                if (Logger.IsInfoEnabled)
+                    Logger.Info("Failed to store next map result id", e);
+
+                throw;
+            }
         }
 
         public unsafe void Initialize(Tree mapEntriesTree)

--- a/src/Raven.Server/Documents/Indexes/MapReduce/MapReduceIndexingContext.cs
+++ b/src/Raven.Server/Documents/Indexes/MapReduce/MapReduceIndexingContext.cs
@@ -49,7 +49,6 @@ namespace Raven.Server.Documents.Indexes.MapReduce
             }
             finally
             {
-                StoreNextMapResultId();
                 DocumentMapEntries?.Dispose();
                 DocumentMapEntries = null;
                 MapPhaseTree = null;


### PR DESCRIPTION
when we get an exception in the dispose of MapReduceIndexingContext we don't clear the internal structures and try to reuse it in the next transaction