### PR TITLE
fix for RavenDB-12187

### DIFF
--- a/src/Raven.Server/Documents/Queries/AST/QueryExpression.cs
+++ b/src/Raven.Server/Documents/Queries/AST/QueryExpression.cs
@@ -130,6 +130,11 @@ namespace Raven.Server.Documents.Queries.AST
         {
             switch (left)
             {
+                case BlittableJsonReaderObject leftBlittableJson:
+                    if (right is BlittableJsonReaderObject rightBlittableJson)
+                        return leftBlittableJson.Equals(rightBlittableJson, true);
+
+                    throw new NotSupportedException("Cannot compare objects with non-objects.");
                 case long l:
                     switch (right)
                     {

--- a/src/Sparrow/Json/BlittableJsonReaderObject.cs
+++ b/src/Sparrow/Json/BlittableJsonReaderObject.cs
@@ -1122,15 +1122,13 @@ namespace Sparrow.Json
             if (ReferenceEquals(this, obj))
                 return true;
 
-            var blittableJson = obj as BlittableJsonReaderObject;
-
-            if (blittableJson != null)
+            if (obj is BlittableJsonReaderObject blittableJson)
                 return Equals(blittableJson);
 
             return false;
         }
 
-        protected bool Equals(BlittableJsonReaderObject other)
+        public bool Equals(BlittableJsonReaderObject other, bool ignoreRavenProperties = false)
         {
             if (_propCount != other._propCount)
                 return false;
@@ -1148,6 +1146,8 @@ namespace Sparrow.Json
                 GetPropertyTypeAndPosition(i, metadataSize, out var token, out var position, out var id);
 
                 var propertyName = GetPropertyName(id);
+                if(ignoreRavenProperties && propertyName.StartsWith('@'))
+                    continue;
 
                 var otherId = other.GetPropertyIndex(propertyName);
 

--- a/test/FastTests/Issues/RavenDB-12187.cs
+++ b/test/FastTests/Issues/RavenDB-12187.cs
@@ -1,0 +1,38 @@
+﻿using System.Linq;
+using Newtonsoft.Json.Linq;
+using Xunit;
+
+namespace FastTests.Issues
+{
+    public class RavenDB_12187 : RavenTestBase
+    {
+        [Fact]
+        public void Query_with_cycle_and_where_should_work()
+        {
+            using (var store = GetDocumentStore())
+            {
+                CreateDataWithMultipleEdgesOfTheSameType(store);
+                WaitForUserToContinueTheTest(store);
+                using (var session = store.OpenSession())
+                {
+                    var query = session.Advanced.RawQuery<JObject>(@"
+                        match (Dogs as d1)-[Likes]->(Dogs as d2) 
+                        where d1 != d2
+                        select id(d1) as d1, id(d2) as d2
+                    ").ToList();
+                    Assert.Equal(3, query.Count); //sanity check
+
+                    query = session.Advanced.RawQuery<JObject>(@"
+                        match (Dogs as d1)-[Likes]->(Dogs as d2) 
+                        where d1 = d2
+                        select id(d1) as d1, id(d2) as d2
+                    ").ToList();
+
+                    Assert.Equal(1, query.Count);
+                    Assert.Equal("dogs/2-A", query[0]["d1"].Value<string>());
+                    
+                }
+            }
+        }    
+    }
+}

--- a/test/Tests.Infrastructure/RavenTestBase.cs
+++ b/test/Tests.Infrastructure/RavenTestBase.cs
@@ -856,7 +856,7 @@ namespace FastTests
                 arava.Likes = new[] { oscar.Id };
                 arava.Dislikes = new[] { pheobe.Id };
 
-                //dogs/2 => dogs/1,dogs/3 (cycle!)
+                //dogs/2 => dogs/2,dogs/3 (cycle!)
                 oscar.Likes = new[] { oscar.Id, pheobe.Id };
                 oscar.Dislikes = new string[0];
 


### PR DESCRIPTION
In graph queries, support equals and not equals between aliases in "where" clauses, so the following queries *should* work now:
```
match (Dogs as d1)-[Likes]->(Dogs as d2) 
where d1 != d2
```
Note that the following won't work at this stage (if I understand correctly, @talweiss1982 is going to handle this use-case in one of his tasks)
```
match (Dogs as d1)-[Likes]->(Dogs as d2) 
where id(d1) != id(d2)
```
In general, any method call in "where" clauses won't be parsed correctly by the QueryParser (more specifically, this is because QueryParser::Operator() method lacks the necessary code to parse this)