### PR TITLE
RavenDB-7070 targeting fixes

### DIFF
--- a/src/Directory.Build.props
+++ b/src/Directory.Build.props
@@ -24,7 +24,7 @@
     <AssemblyOriginatorKeyFile>..\..\RavenDB.snk</AssemblyOriginatorKeyFile>
 
   </PropertyGroup>
-  <PropertyGroup Condition="'$(TargetFramework)' == 'netcoreapp2.2'">
+  <PropertyGroup Condition="'$(TargetFramework)' == 'netcoreapp2.1' OR '$(TargetFramework)' == 'netcoreapp2.2'">
     <DefineConstants>$(DefineConstants);NETCOREAPP</DefineConstants>
   </PropertyGroup>
   <ItemGroup>

--- a/src/Raven.Client/Raven.Client.csproj
+++ b/src/Raven.Client/Raven.Client.csproj
@@ -3,7 +3,7 @@
     <Version></Version>
     <Description>RavenDB Client is the client library for accessing RavenDB</Description>
     <Authors>Hibernating Rhinos</Authors>
-    <TargetFrameworks>netcoreapp2.2;netcoreapp2.1;netstandard2.0</TargetFrameworks>
+    <TargetFrameworks>netcoreapp2.1;netstandard2.0</TargetFrameworks>
     <DefineConstants>$(DefineConstants);PORTABLE</DefineConstants>
     <AllowUnsafeBlocks>true</AllowUnsafeBlocks>
     <AssemblyName>Raven.Client</AssemblyName>
@@ -37,11 +37,6 @@
     <!-- this is required for the nuget build to properly include the right files -->
     <Content Include="..\Sparrow\bin\Release\netcoreapp2.1\Sparrow.dll">
       <PackagePath>lib/netcoreapp2.1/</PackagePath>
-      <Pack>true</Pack>
-    </Content>
-    <!-- this is required for the nuget build to properly include the right files -->
-    <Content Include="..\Sparrow\bin\Release\netcoreapp2.2\Sparrow.dll">
-      <PackagePath>lib/netcoreapp2.2/</PackagePath>
       <Pack>true</Pack>
     </Content>
   </ItemGroup>

--- a/src/Raven.Client/Raven.Client.csproj
+++ b/src/Raven.Client/Raven.Client.csproj
@@ -3,7 +3,7 @@
     <Version></Version>
     <Description>RavenDB Client is the client library for accessing RavenDB</Description>
     <Authors>Hibernating Rhinos</Authors>
-    <TargetFrameworks>netcoreapp2.2;netstandard2.0</TargetFrameworks>
+    <TargetFrameworks>netcoreapp2.2;netcoreapp2.1;netstandard2.0</TargetFrameworks>
     <DefineConstants>$(DefineConstants);PORTABLE</DefineConstants>
     <AllowUnsafeBlocks>true</AllowUnsafeBlocks>
     <AssemblyName>Raven.Client</AssemblyName>
@@ -32,6 +32,11 @@
     <!-- this is required for the nuget build to properly include the right files -->
     <Content Include="..\Sparrow\bin\Release\netstandard2.0\Sparrow.dll">
       <PackagePath>lib/netstandard2.0/</PackagePath>
+      <Pack>true</Pack>
+    </Content>
+    <!-- this is required for the nuget build to properly include the right files -->
+    <Content Include="..\Sparrow\bin\Release\netcoreapp2.1\Sparrow.dll">
+      <PackagePath>lib/netcoreapp2.1/</PackagePath>
       <Pack>true</Pack>
     </Content>
     <!-- this is required for the nuget build to properly include the right files -->

--- a/src/Sparrow/Sparrow.csproj
+++ b/src/Sparrow/Sparrow.csproj
@@ -1,7 +1,6 @@
 ﻿<Project Sdk="Microsoft.NET.Sdk">
   <PropertyGroup>
-    <TargetFrameworks>netstandard2.0;netcoreapp2.2</TargetFrameworks>
-    <RuntimeFrameworkVersion>2.2.0</RuntimeFrameworkVersion>
+    <TargetFrameworks>netstandard2.0;netcoreapp2.1;netcoreapp2.2</TargetFrameworks>
     <AllowUnsafeBlocks>true</AllowUnsafeBlocks>
     <AssemblyName>Sparrow</AssemblyName>
     <PackageId>Sparrow</PackageId>

--- a/test/SlowTests/Server/Documents/PeriodicBackup/EncryptedBackupTest.cs
+++ b/test/SlowTests/Server/Documents/PeriodicBackup/EncryptedBackupTest.cs
@@ -256,7 +256,9 @@ namespace SlowTests.Server.Documents.PeriodicBackup
                         {
                             Key = Convert.ToBase64String(key)
                         }
-                    }));
+                    }))
+                    {
+                    }
                 });
                 Assert.IsType<CryptographicException>(e.InnerException);
             }

--- a/test/SlowTests/Server/RecordingTransactionOperationsMergerTests.cs
+++ b/test/SlowTests/Server/RecordingTransactionOperationsMergerTests.cs
@@ -1296,9 +1296,7 @@ namespace SlowTests.Server
         {
             var filePath = NewDataPath();
 
-            const string newName = "Balilo";
             var user = new User { Name = "Baruch" };
-
 
             //Recording
             using (var store = GetDocumentStore())

--- a/tools/Raven.Debug/Raven.Debug.csproj
+++ b/tools/Raven.Debug/Raven.Debug.csproj
@@ -13,7 +13,7 @@
   </ItemGroup>
 
   <ItemGroup>
-    <PackageReference Include="Microsoft.Diagnostics.Runtime" Version="1.0.0" />
+    <PackageReference Include="Microsoft.Diagnostics.Runtime" Version="1.0.2" />
     <PackageReference Include="Microsoft.Extensions.CommandLineUtils" Version="1.1.1" />
     <PackageReference Include="Newtonsoft.Json" Version="12.0.1" />
   </ItemGroup>


### PR DESCRIPTION
- we cannot get rid of the netcoreapp2.1, someone might be using this target from RavenDB.Client nuget package
- RavenDB.Client does not need to target netcoreapp2.2, we are not using any features from that target yet