### PR TITLE
RavenDB-12525 Failing test: SlowTests.Issues.RavenDB_5435.CanCompact

### DIFF
--- a/src/Voron/StorageEnvironment.cs
+++ b/src/Voron/StorageEnvironment.cs
@@ -45,7 +45,7 @@ namespace Voron
 
         internal IndirectReference SelfReference = new IndirectReference();
 
-        public void SuggestSyncDataFileSyncDataFile()
+        public void SuggestSyncDataFile()
         {
             GlobalFlushingBehavior.GlobalFlusher.Value.SuggestSyncEnvironment(this);
         }
@@ -248,7 +248,7 @@ namespace Voron
                             GlobalFlushingBehavior.GlobalFlusher.Value.MaybeFlushEnvironment(this);
 
                         else if (Journal.Applicator.TotalWrittenButUnsyncedBytes != 0)
-                            SuggestSyncDataFileSyncDataFile();
+                            SuggestSyncDataFile();
                     }
                     else
                     {


### PR DESCRIPTION
When there was nothing to sync the sync operation stop to collect the state
but instead of exiting the operation is continued to sync and update
because the operation didn't collect the state it stayed with the default values that were 0
and the header was updated to that values

Main:
http://issues.hibernatingrhinos.com/issue/RavenDB-12525

Related:
http://issues.hibernatingrhinos.com/issue/RavenDB-12351
http://issues.hibernatingrhinos.com/issue/RavenDB-12517
