### PR TITLE
RavenDB-12543 We must not update PTT of the journal file immediately …

### DIFF
--- a/src/Voron/Impl/Journal/WriteAheadJournal.cs
+++ b/src/Voron/Impl/Journal/WriteAheadJournal.cs
@@ -1270,7 +1270,7 @@ namespace Voron.Impl.Journal
                 }
 
                 sp.Restart();
-                CurrentFile.Write(tx, journalEntry, _lazyTransactionBuffer);
+                journalEntry.UpdatePageTranslationTable = CurrentFile.Write(tx, journalEntry, _lazyTransactionBuffer);
                 sp.Stop();
                 _lastCompressionAccelerationInfo.WriteDuration = sp.Elapsed;
                 _lastCompressionAccelerationInfo.CalculateOptimalAcceleration();
@@ -1690,6 +1690,7 @@ namespace Voron.Impl.Journal
         public byte* Base;
         public int NumberOf4Kbs;
         public int NumberOfUncompressedPages;
+        public JournalFile.UpdatePageTranslationTableAction? UpdatePageTranslationTable;
     }
 }
 

--- a/test/SlowTests/Voron/Issues/RavenDB_12543.cs
+++ b/test/SlowTests/Voron/Issues/RavenDB_12543.cs
@@ -1,0 +1,68 @@
+﻿using System;
+using FastTests.Voron;
+using Voron;
+using Xunit;
+
+namespace SlowTests.Voron.Issues
+{
+    public class RavenDB_12543 : StorageTest
+    {
+        protected override void Configure(StorageEnvironmentOptions options)
+        {
+            options.ManualFlushing = true;
+        }
+
+        [Fact]
+        public void Must_not_update_PTT_during_stage2_of_commit()
+        {
+            RequireFileBasedPager();
+
+            var buffer = new byte[256];
+
+            new Random().NextBytes(buffer);
+            
+            using (var tx = Env.WriteTransaction())
+            {
+                var tree = tx.CreateTree("test");
+
+                for (int i = 0; i < 100; i++)
+                {
+                    tree.Add("items/" + i, buffer);
+                }
+
+                tx.LowLevelTransaction.SimulateThrowingOnCommitStage2 = true;
+
+                Assert.Throws<InvalidOperationException>(() => tx.Commit());
+            }
+
+            using (var tx = Env.WriteTransaction())
+            {
+                tx.LowLevelTransaction.EnsureNoDuplicateTransactionId_Forced(tx.LowLevelTransaction.Id);
+
+                var tree = tx.CreateTree("test");
+
+                for (int i = 0; i < 100; i++)
+                {
+                    tree.Add("items/" + i, buffer);
+                }
+
+                tx.Commit();
+            }
+
+            RestartDatabase();
+
+            using (var tx = Env.ReadTransaction())
+            {
+                var tree = tx.ReadTree("test");
+
+                for (int i = 0; i < 100; i++)
+                {
+                    var valueReader = tree.Read("items/" + i).Reader;
+                    Assert.Equal(buffer, valueReader.ReadBytes(valueReader.Length).ToArray());
+                }
+
+                tx.Commit();
+            }
+        }
+    }
+}


### PR DESCRIPTION
…after writing a transaction to it because if CommitStage2_WriteToJournal fails then we end up with invalid state of PTT (contains records of uncommited transaction)