### PR TITLE
RavenDB-12543 We must not update PTT of the journal file immediately …

### DIFF
--- a/src/Voron/Impl/Journal/JournalFile.cs
+++ b/src/Voron/Impl/Journal/JournalFile.cs
@@ -177,7 +177,7 @@ namespace Voron.Impl.Journal
         /// <summary>
         /// write transaction's raw page data into journal
         /// </summary>
-        public void Write(LowLevelTransaction tx, CompressedPagesResult pages, LazyTransactionBuffer lazyTransactionScratch)
+        public UpdatePageTranslationTableAction Write(LowLevelTransaction tx, CompressedPagesResult pages, LazyTransactionBuffer lazyTransactionScratch)
         {
             var ptt = new Dictionary<long, PagePosition>(NumericEqualityComparer.BoxedInstanceInt64);
             var cur4KbPos = _writePosIn4Kb;
@@ -240,20 +240,9 @@ namespace Voron.Impl.Journal
                 }
             }
 
-            using (_locker2.Lock())
-            {
-                _pageTranslationTable.SetItems(tx, ptt);
-                // it is important that the last write position will be set
-                // _after_ the PTT update, because a flush that is concurrent 
-                // with the write will first get the WritePosIn4KB and then 
-                // do the flush based on the PTT. Worst case, we'll flush 
-                // more then we need, but won't get into a position where we
-                // think we flushed, and then realize that we didn't.
-                Interlocked.Add(ref _writePosIn4Kb, pages.NumberOf4Kbs);
-            }
+            return new UpdatePageTranslationTableAction(this, tx, ptt, pages.NumberOf4Kbs);
         }
 
-       
         private void UpdatePageTranslationTable(LowLevelTransaction tx, HashSet<PagePosition> unused, Dictionary<long, PagePosition> ptt)
         {
             // REVIEW: This number do not grow easily. There is no way we can go higher than int.MaxValue
@@ -381,6 +370,39 @@ namespace Voron.Impl.Journal
 
             _scratchPagesPositionsPool.Free(unusedPages);
             _scratchPagesPositionsPool.Free(unusedAndFree);
+        }
+
+        public struct UpdatePageTranslationTableAction
+        {
+            private readonly JournalFile _parent;
+            private readonly LowLevelTransaction _tx;
+            private readonly Dictionary<long, PagePosition> _ptt;
+            private readonly int _numberOfWritten4Kbs;
+
+            public UpdatePageTranslationTableAction(JournalFile parent, LowLevelTransaction tx, Dictionary<long, PagePosition> ptt, int numberOfWritten4Kbs)
+            {
+                _parent = parent;
+                _tx = tx;
+                _ptt = ptt;
+                _numberOfWritten4Kbs = numberOfWritten4Kbs;
+            }
+
+            public void ExecuteAfterCommit()
+            {
+                Debug.Assert(_tx.Committed);
+
+                using (_parent._locker2.Lock())
+                {
+                    _parent._pageTranslationTable.SetItems(_tx, _ptt);
+                    // it is important that the last write position will be set
+                    // _after_ the PTT update, because a flush that is concurrent 
+                    // with the write will first get the WritePosIn4KB and then 
+                    // do the flush based on the PTT. Worst case, we'll flush 
+                    // more then we need, but won't get into a position where we
+                    // think we flushed, and then realize that we didn't.
+                    Interlocked.Add(ref _parent._writePosIn4Kb, _numberOfWritten4Kbs);
+                }
+            }
         }
     }
 }

--- a/src/Voron/Impl/Journal/WriteAheadJournal.cs
+++ b/src/Voron/Impl/Journal/WriteAheadJournal.cs
@@ -1290,7 +1290,7 @@ namespace Voron.Impl.Journal
                 }
 
                 sp.Restart();
-                CurrentFile.Write(tx, journalEntry, _lazyTransactionBuffer);
+                journalEntry.UpdatePageTranslationTable = CurrentFile.Write(tx, journalEntry, _lazyTransactionBuffer);
                 sp.Stop();
                 _lastCompressionAccelerationInfo.WriteDuration = sp.Elapsed;
                 _lastCompressionAccelerationInfo.CalculateOptimalAcceleration();
@@ -1710,6 +1710,7 @@ namespace Voron.Impl.Journal
         public byte* Base;
         public int NumberOf4Kbs;
         public int NumberOfUncompressedPages;
+        public JournalFile.UpdatePageTranslationTableAction? UpdatePageTranslationTable;
     }
 }
 

--- a/test/SlowTests/Voron/Issues/RavenDB_12543.cs
+++ b/test/SlowTests/Voron/Issues/RavenDB_12543.cs
@@ -1,0 +1,68 @@
+﻿using System;
+using FastTests.Voron;
+using Voron;
+using Xunit;
+
+namespace SlowTests.Voron.Issues
+{
+    public class RavenDB_12543 : StorageTest
+    {
+        protected override void Configure(StorageEnvironmentOptions options)
+        {
+            options.ManualFlushing = true;
+        }
+
+        [Fact]
+        public void Must_not_update_PTT_during_stage2_of_commit()
+        {
+            RequireFileBasedPager();
+
+            var buffer = new byte[256];
+
+            new Random().NextBytes(buffer);
+            
+            using (var tx = Env.WriteTransaction())
+            {
+                var tree = tx.CreateTree("test");
+
+                for (int i = 0; i < 100; i++)
+                {
+                    tree.Add("items/" + i, buffer);
+                }
+
+                tx.LowLevelTransaction.SimulateThrowingOnCommitStage2 = true;
+
+                Assert.Throws<InvalidOperationException>(() => tx.Commit());
+            }
+
+            using (var tx = Env.WriteTransaction())
+            {
+                tx.LowLevelTransaction.EnsureNoDuplicateTransactionId_Forced(tx.LowLevelTransaction.Id);
+
+                var tree = tx.CreateTree("test");
+
+                for (int i = 0; i < 100; i++)
+                {
+                    tree.Add("items/" + i, buffer);
+                }
+
+                tx.Commit();
+            }
+
+            RestartDatabase();
+
+            using (var tx = Env.ReadTransaction())
+            {
+                var tree = tx.ReadTree("test");
+
+                for (int i = 0; i < 100; i++)
+                {
+                    var valueReader = tree.Read("items/" + i).Reader;
+                    Assert.Equal(buffer, valueReader.ReadBytes(valueReader.Length).ToArray());
+                }
+
+                tx.Commit();
+            }
+        }
+    }
+}


### PR DESCRIPTION
…after writing a transaction to it because if CommitStage2_WriteToJournal fails then we end up with invalid state of PTT (contains records of uncommited transaction)