### PR TITLE
RavenDB-12547 If we fail on SetFilePointerEx / SetEndOfFile then gett…

### DIFF
--- a/src/Voron/Platform/Win32/Win32NativeFileMethods.cs
+++ b/src/Voron/Platform/Win32/Win32NativeFileMethods.cs
@@ -114,15 +114,17 @@ namespace Voron.Platform.Win32
         {
             if (SetFilePointerEx(fileHandle, length, IntPtr.Zero, Win32NativeFileMoveMethod.Begin) == false)
             {
-                var filePath = GetFilePath();
                 var exception = new Win32Exception(Marshal.GetLastWin32Error());
+                var filePath = GetFilePath();
+                
                 throw new IOException($"Could not move the pointer of file {filePath}", exception);
             }
 
             if (SetEndOfFile(fileHandle) == false)
             {
-                var filePath = GetFilePath();
                 var lastError = Marshal.GetLastWin32Error();
+                var filePath = GetFilePath();
+
                 if (lastError == (int) Win32NativeFileErrors.ERROR_DISK_FULL)
                 {
                     var driveInfo = DiskSpaceChecker.GetDiskSpaceInfo(filePath);


### PR DESCRIPTION
…ing the last error code needs to the first method that is called. Otherwise we override it by GetFilePath() which also does sys calls.