### PR TITLE
RavenDB-12524 Fixed validation during the recovery process. If a page…

### DIFF
--- a/src/Voron/Impl/Journal/JournalReader.cs
+++ b/src/Voron/Impl/Journal/JournalReader.cs
@@ -157,6 +157,11 @@ namespace Voron.Impl.Journal
 
                 _modifiedPages.Add(pageNumber);
 
+                for (var j = 1; j < numberOfPagesOnDestination; j++)
+                {
+                    _modifiedPages.Remove(pageNumber + j);
+                }
+
                 _dataPager.UnprotectPageRange(pagePtr, (ulong)pageInfoPtr[i].Size);
  
                 if (pageInfoPtr[i].DiffSize == 0)

--- a/test/SlowTests/Voron/Issues/RavenDB_12524.cs
+++ b/test/SlowTests/Voron/Issues/RavenDB_12524.cs
@@ -1,0 +1,68 @@
+﻿using FastTests.Voron;
+using Voron;
+using Xunit;
+
+namespace SlowTests.Voron.Issues
+{
+    public class RavenDB_12524 : StorageTest
+    {
+        protected override void Configure(StorageEnvironmentOptions options)
+        {
+            options.ManualFlushing = true;
+        }
+
+        [Fact]
+        public void RecoveryValidationNeedsToTakeIntoAccountOverflows()
+        {
+            RequireFileBasedPager();
+
+            long pageNum;
+
+            using (var tx = Env.WriteTransaction())
+            {
+                tx.LowLevelTransaction.DataPager.EnsureContinuous(20, 10);
+
+                var page = tx.LowLevelTransaction.AllocatePage(50);
+
+                pageNum = page.PageNumber;
+
+                tx.Commit();
+            }
+
+            using (var tx = Env.WriteTransaction())
+            {
+                tx.LowLevelTransaction.FreePage(pageNum);
+
+                tx.Commit();
+            }
+
+            using (var tx = Env.WriteTransaction())
+            {
+                tx.LowLevelTransaction.AllocatePage(1, 21);
+
+                tx.Commit();
+            }
+
+            using (var tx = Env.WriteTransaction())
+            {
+                tx.LowLevelTransaction.FreePage(21);
+
+                tx.Commit();
+            }
+
+            using (var tx = Env.WriteTransaction())
+            {
+                tx.LowLevelTransaction.AllocatePage(2, 20);
+
+                tx.Commit();
+            }
+
+            RestartDatabase();
+
+            using (var tx = Env.WriteTransaction())
+            {
+
+            }
+        }
+    }
+}


### PR DESCRIPTION
… is overwritten by an overflow in later transaction (in the same journal or next one) then we need to removed it from the collection of modified pages during the recovery.