### PR TITLE
RavenDB-12524 During the recovery let's validate the page checksum if…

### DIFF
--- a/src/Voron/Impl/Journal/JournalReader.cs
+++ b/src/Voron/Impl/Journal/JournalReader.cs
@@ -129,7 +129,7 @@ namespace Voron.Impl.Journal
             for (var i = 0; i < current->PageCount; i++)
             {
                 if(pageInfoPtr[i].PageNumber > current->LastPageNumber)
-                    throw new InvalidDataException($"Transaction {current->TransactionId} contains refeence to page {pageInfoPtr[i].PageNumber} which is after the last allocated page {current->LastPageNumber}");
+                    throw new InvalidDataException($"Transaction {current->TransactionId} contains reference to page {pageInfoPtr[i].PageNumber} which is after the last allocated page {current->LastPageNumber}");
             }
 
             for (var i = 0; i < current->PageCount; i++)
@@ -166,7 +166,28 @@ namespace Voron.Impl.Journal
  
                 if (pageInfoPtr[i].DiffSize == 0)
                 {
-                    Memory.Copy(pagePtr, outputPage + totalRead, pageInfoPtr[i].Size);
+                    if (pageInfoPtr[i].Size == 0)
+                    {
+                        // diff contained no changes
+                        continue;
+                    }
+
+                    var journalPagePtr = outputPage + totalRead;
+
+                    if (options.EncryptionEnabled == false)
+                    {
+                        var pageHeader = (PageHeader*)journalPagePtr;
+
+                        var checksum = StorageEnvironment.CalculatePageChecksum((byte*)pageHeader, pageNumber, out var expectedChecksum);
+                        if (checksum != expectedChecksum)
+                        {
+                            throw new InvalidDataException(
+                                $"Invalid checksum for page {pageNumber} in transaction {current->TransactionId}, journal file {_journalPager} might be corrupted, expected hash to be {expectedChecksum} but was {checksum}." +
+                                $"Data from journal has not been applied to data file {_dataPager} yet");
+                        }
+                    }
+
+                    Memory.Copy(pagePtr, journalPagePtr, pageInfoPtr[i].Size);
                     totalRead += pageInfoPtr[i].Size;
 
                     if (options.EncryptionEnabled)


### PR DESCRIPTION
… DiffSize == 0 (full page is copied from journal to data file). Since the journal has entire page (not the diff) we can do that directly on journal's data _before_ we copy it to the data file.