### PR TITLE
RavenDB-12524 Recovery needs to take into account that a modified pag…

### DIFF
--- a/src/Voron/Impl/Journal/WriteAheadJournal.cs
+++ b/src/Voron/Impl/Journal/WriteAheadJournal.cs
@@ -234,12 +234,32 @@ namespace Voron.Impl.Journal
                 // corruption when applying journals at recovery time rather than at usage.
                 var tempTx = new TempPagerTransaction();
 
-                foreach (var modifiedPage in modifiedPages)
-                {
-                    var ptr = (PageHeader*)_dataPager.AcquirePagePointerWithOverflowHandling(tempTx, modifiedPage, null);
-                    _env.ValidatePageChecksum(modifiedPage, ptr);
+                var sortedPages = modifiedPages.ToArray();
+                Array.Sort(sortedPages);
 
-                    tempTx.Dispose(); // release any resources, we just wanted to validate things
+                long minPageChecked = -1;
+
+                // we need to iterate from the end in order to filter out pages that was overwritten by later transaction
+
+                for (var i = sortedPages.Length - 1; i >= 0; i--)
+                {
+                    using (tempTx) // release any resources, we just wanted to validate things
+                    {
+                        var modifiedPage = sortedPages[i];
+
+                        var ptr = (PageHeader*)_dataPager.AcquirePagePointerWithOverflowHandling(tempTx, modifiedPage, null);
+
+                        var maxPageRange = modifiedPage + VirtualPagerLegacyExtensions.GetNumberOfPages(ptr) - 1;
+
+                        if (minPageChecked != -1 && maxPageRange >= minPageChecked)
+                        {
+                            continue;
+                        }
+
+                        _env.ValidatePageChecksum(modifiedPage, ptr);
+
+                        minPageChecked = modifiedPage;
+                    }
                 }
             }
 

--- a/test/SlowTests/Voron/Issues/RavenDB_12524.cs
+++ b/test/SlowTests/Voron/Issues/RavenDB_12524.cs
@@ -1,5 +1,7 @@
 ﻿using FastTests.Voron;
+using Sparrow;
 using Voron;
+using Voron.Global;
 using Xunit;
 
 namespace SlowTests.Voron.Issues
@@ -53,6 +55,67 @@ namespace SlowTests.Voron.Issues
             using (var tx = Env.WriteTransaction())
             {
                 tx.LowLevelTransaction.AllocatePage(2, 20);
+
+                tx.Commit();
+            }
+
+            RestartDatabase();
+
+            using (var tx = Env.WriteTransaction())
+            {
+
+            }
+        }
+
+        [Fact]
+        public unsafe void RecoveryValidationNeedsToTakeIntoAccountFreedPages()
+        {
+            RequireFileBasedPager();
+
+            long pageNum;
+
+            using (var tx = Env.WriteTransaction())
+            {
+                tx.LowLevelTransaction.DataPager.EnsureContinuous(20, 10);
+
+                var page = tx.LowLevelTransaction.AllocatePage(50);
+
+                pageNum = page.PageNumber;
+
+                tx.Commit();
+            }
+
+            using (var tx = Env.WriteTransaction())
+            {
+                tx.LowLevelTransaction.FreePage(pageNum);
+
+                tx.Commit();
+            }
+
+            using (var tx = Env.WriteTransaction())
+            {
+                var p = tx.LowLevelTransaction.AllocatePage(10, 20);
+
+                p.Flags |= PageFlags.Overflow;
+                p.OverflowSize = 9 * Constants.Storage.PageSize;
+
+                Memory.Set(p.DataPointer, 1, 9 * Constants.Storage.PageSize);
+
+                tx.Commit();
+            }
+
+            using (var tx = Env.WriteTransaction())
+            {
+                tx.LowLevelTransaction.FreePage(20);
+
+                tx.Commit();
+            }
+
+            using (var tx = Env.WriteTransaction())
+            {
+                var p = tx.LowLevelTransaction.AllocatePage(2, 21);
+
+                Memory.Set(p.DataPointer, 2, Constants.Storage.PageSize);
 
                 tx.Commit();
             }


### PR DESCRIPTION
…e could be freed and overwritten in later transactions. So we need to filter them out. Eg.:

- tx1: allocate overflow on page #20
- tx2: free page #20
- tx3: allocate page #21

During the recovery we must not validate #20 as it isn't in use effectively (and it's content was overwritten by #21 in tx3)