### PR TITLE
RavenDB-12556 Assign to `_journalsToDelete` moved from the task that passed to write transaction

### DIFF
--- a/src/Voron/Impl/Journal/WriteAheadJournal.cs
+++ b/src/Voron/Impl/Journal/WriteAheadJournal.cs
@@ -642,8 +642,18 @@ namespace Voron.Impl.Journal
                     _waitForJournalStateUpdateUnderTx.Reset();
                     ExceptionDispatchInfo edi = null;
                     var sp = Stopwatch.StartNew();
+
+                    foreach (var unused in unusedJournals)
+                    {
+                        _journalsToDelete[unused.Number] = unused;
+                    }
+
+                    var singleUseFlag = new SingleUseFlag();
                     Action<LowLevelTransaction> currentAction = txw =>
                     {
+                        if (singleUseFlag.Raise() == false)
+                            throw new InvalidOperationException("Tried to update journal state after flush twice");
+
                         try
                         {
                             UpdateJournalStateUnderWriteTransactionLock(txw, lastProcessedJournal, lastFlushedTransactionId, unusedJournals);
@@ -728,11 +738,6 @@ namespace Voron.Impl.Journal
                 _lastFlushedJournalId = lastProcessedJournal;
                 _lastFlushedTransactionId = lastFlushedTransactionId;
                 _lastFlushedJournal = _waj._files.First(x => x.Number == lastProcessedJournal);
-
-                foreach (var unused in unusedJournals)
-                {
-                    _journalsToDelete[unused.Number] = unused;
-                }
 
                 if (unusedJournals.Count > 0)
                 {
@@ -996,7 +1001,7 @@ namespace Voron.Impl.Journal
                 {
                     public readonly Func<bool> Task;
                     public readonly SingleUseFlag DoneFlag = new SingleUseFlag();
-                    public ExceptionDispatchInfo Error;
+                    public Exception Error;
                     public volatile bool Result = true;
 
                     public AssignedTask(Func<bool> task) => Task = task;
@@ -1048,7 +1053,8 @@ namespace Voron.Impl.Journal
 
                             if (current.DoneFlag.IsRaised())
                             {
-                                current.Error?.Throw();
+                                if (current.Error != null)
+                                    throw new AggregateException("Unable to complete flush", current.Error);
                                 return current.Result;
                             }
                         }
@@ -1058,7 +1064,7 @@ namespace Voron.Impl.Journal
                         return false;
                     }
                 }
-                
+
                 public void RunTaskIfNotAlreadyRan()
                 {
                     AssertRunTaskWithLock();
@@ -1072,7 +1078,7 @@ namespace Voron.Impl.Journal
                     }
                     catch (Exception e)
                     {
-                        current.Error = ExceptionDispatchInfo.Capture(e);
+                        current.Error = e;
                     }
                     finally
                     {

--- a/src/Voron/Impl/Journal/WriteAheadJournal.cs
+++ b/src/Voron/Impl/Journal/WriteAheadJournal.cs
@@ -1054,7 +1054,7 @@ namespace Voron.Impl.Journal
                             if (current.DoneFlag.IsRaised())
                             {
                                 if (current.Error != null)
-                                    throw new AggregateException("Unable to complete flush", current.Error);
+                                    throw new InvalidOperationException("The lock task failed", current.Error);
                                 return current.Result;
                             }
                         }

--- a/test/SlowTests/Voron/Storage/SyncFlushTimingTest.cs
+++ b/test/SlowTests/Voron/Storage/SyncFlushTimingTest.cs
@@ -470,7 +470,7 @@ namespace SlowTests.Voron.Storage
                 }
 
                 worker.WaitThrow(TimeSpan.FromSeconds(10));
-                Assert.Equal(typeof(DataException), worker.Exception.GetType());
+                Assert.Equal(typeof(DataException), worker.Exception.InnerException.GetType());
             }
             catch (Exception)
             {
@@ -516,7 +516,7 @@ namespace SlowTests.Voron.Storage
 
                 Assert.Equal(0, throwWorker.Job.TimesJobDone);
                 Assert.Equal(1, worker.Job.TimesJobDone);
-                Assert.Equal(typeof(DataException), throwWorker.Exception.GetType());
+                Assert.Equal(typeof(DataException), throwWorker.Exception.InnerException.GetType());
                 Assert.Equal(null, worker.Exception);
             }
             catch (Exception)


### PR DESCRIPTION
https://issues.hibernatingrhinos.com/issue/RavenDB-12556

When the flush operation finishes flushing it try to update journals state under "write transaction lock"
Part of this is to update the `_journalsToDelete` dictionary
If the write transaction lock was taken the flush operation passes the update task to the "write transaction lock" owner.
Meanwhile, the flush operation looks if there is sync task that needs flush lock and runs it
One of the sync tasks that assigned to flush operation include iteration over `_journalsToDelete` dictionary
so that can lead to concurrency issue