### PR TITLE
RavenDB-11871 Journal applicator keep applying journals even if the i…

### DIFF
--- a/src/Voron/Impl/Journal/WriteAheadJournal.cs
+++ b/src/Voron/Impl/Journal/WriteAheadJournal.cs
@@ -123,6 +123,9 @@ namespace Voron.Impl.Journal
             if (_currentJournalFileSize < minRequiredSize)
             {
                 _currentJournalFileSize = Bits.NextPowerOf2(minRequiredSize);
+                if (_currentJournalFileSize > _env.Options.MaxLogFileSize)
+                    _currentJournalFileSize = Math.Max(_env.Options.MaxLogFileSize, minRequiredSize);
+
                 actualLogSize = _currentJournalFileSize;
             }
 

--- a/test/SlowTests/Voron/RavenDB-11871.cs
+++ b/test/SlowTests/Voron/RavenDB-11871.cs
@@ -1,0 +1,68 @@
+﻿using System;
+using System.Collections.Generic;
+using System.IO;
+using System.Text;
+using FastTests.Voron;
+using Voron.Impl.Journal;
+using Xunit;
+
+namespace SlowTests.Voron
+{
+    public class RavenDB_11871 : StorageTest
+    {
+        [Fact]
+        public void WillNotRetainJournalsAfterSync()
+        {
+            RequireFileBasedPager();
+
+            Options.ManualFlushing = true;
+            Options.MaxLogFileSize = 1024 * 1024;
+
+            for (int X = 0; X < 3; X++)
+            {
+                using (var tx = Env.WriteTransaction())
+                {
+                    var tree = tx.CreateTree("t");
+
+                    for (int i = 0; i < 50_000; i++)
+                    {
+                        tree.Add(i.ToString() + "-" + X, Guid.NewGuid().ToByteArray());
+                    }
+
+                    tx.Commit();
+                }
+            }
+
+            Env.FlushLogToDataFile();
+
+            var journalsDir = Path.Combine(DataDir, "Journals");
+
+            Assert.NotEmpty(Directory.GetFiles(journalsDir, "*.journal"));
+
+            using (var tx = Env.WriteTransaction())
+            {
+                var tree = tx.CreateTree("t");
+
+                for (int i = 0; i < 50_000; i++)
+                {
+                    tree.Add(i.ToString() + "-5", Guid.NewGuid().ToByteArray());
+                }
+
+                tx.Commit();
+            }
+
+            using (var op = new WriteAheadJournal.JournalApplicator.SyncOperation(Env.Journal.Applicator))
+            {
+                op.SyncDataFile();
+            }
+            Env.FlushLogToDataFile();
+
+            using (var op = new WriteAheadJournal.JournalApplicator.SyncOperation(Env.Journal.Applicator))
+            {
+                op.SyncDataFile();
+            }
+
+            Assert.Empty(Directory.GetFiles(journalsDir, "*.journal"));
+        }
+    }
+}


### PR DESCRIPTION
…ndexes didn't change for hours

The issue was that we tried to create journals that are power of 2, but if the transaction size was greater than the size of the journal, we would create a journal file that was bigger than the actual transaction size.
That, in turn, would lead to having available space in the journal file, so we would keep it around after sync.
This change is simply to ensure that the size of the journal file will be either the max journal size or the space the transaction requires. In this case, after a large transaction, we'll no longer have any space there and can clear the large journal file.
As a result, on recovery, we'll not have any journal files to apply and can reduce the speed we take to startup