### PR TITLE
Fix for RavenDB-12567

### DIFF
--- a/src/Raven.Server/Documents/Queries/Graph/RecursionQueryStep.cs
+++ b/src/Raven.Server/Documents/Queries/Graph/RecursionQueryStep.cs
@@ -22,9 +22,10 @@ namespace Raven.Server.Documents.Queries.Graph
         private readonly List<string> _stepAliases = new List<string>();
         private readonly List<Match> _results = new List<Match>();
         private List<Match> _temp = new List<Match>();
+        private readonly HashSet<Match> _traversedPaths = new HashSet<Match>();
         private readonly HashSet<string> _allLliases = new HashSet<string>();
         
-        private readonly HashSet<long> _visited = new HashSet<long>();
+        private readonly HashSet<PathSegment> _visited = new HashSet<PathSegment>();
         private readonly Stack<RecursionState> _path = new Stack<RecursionState>();
         public int _index = -1;
         private bool _skipMaterialization;
@@ -61,7 +62,7 @@ namespace Raven.Server.Documents.Queries.Graph
             _allLliases.Add(_recursive.Alias.Value);
         }
 
-         public RecursionQueryStep(IGraphQueryStep left, RecursionQueryStep rqs)
+        public RecursionQueryStep(IGraphQueryStep left, RecursionQueryStep rqs)
         {
             _left = left;
             _steps = rqs._steps;
@@ -302,11 +303,13 @@ namespace Raven.Server.Documents.Queries.Graph
             if (startingPoint == null)
                 return;
 
-            _visited.Add(startingPoint.Data.Location);
+            _visited.Add(new PathSegment(0,startingPoint.Data.Location));
             _path.Push(new RecursionState { Src = startingPoint.Data, Match = currentMatch });
 
             int aliasBaseIndex = 0;
             Document cur = startingPoint;
+            
+            var alreadyTraversedPaths = new HashSet<MatchCollection>();
 
             //this function is needed for "documentation" purposes
             bool AddMatchToResultsAndCheckIfNeedToStop(Document current)
@@ -379,13 +382,8 @@ namespace Raven.Server.Documents.Queries.Graph
                         _path.Pop();
 
                         //since we are backtracking, remove the node from the top of the path stack
-                        _visited.Remove(top.Src.Location);
+                        _visited.Remove(new PathSegment(top.Src.Location,cur.Data.Location));
 
-                        //also, make sure to remove the last node in the iteration
-                        //if we don't do this, we will miss path permutation that includes the last node
-                        //this will happen IF and only IF there are multiple possible paths, since _visited values carry over
-                        //to next "branching" path traversal
-                        _visited.Remove(cur.Data.Location); 
                         continue;
                     }
 
@@ -396,14 +394,15 @@ namespace Raven.Server.Documents.Queries.Graph
                     cur = currentMatch.GetSingleDocumentResult(_outputAlias);
                     top.Matches.RemoveAt(top.Matches.Count - 1);
                    
-                    if (_visited.Add(cur.Data.Location) == false)
+                    if (_visited.Add(new PathSegment(top.Src.Location, cur.Data.Location)) == false)
                     {
                         continue;
                     }
 
                     //now, we add the currentMatch to "discovered" path and "jump" to resolution of the next step.
                     //resolving next step of traversal is this line:  if (ProcessSingleResult(currentMatch, aliasBaseIndex, out var currentMatches) == false)
-                    _path.Push(new RecursionState { Src = cur.Data, Match = currentMatch });
+                    var state = new RecursionState { Src = cur.Data, Match = currentMatch };
+                    _path.Push(state);
                     break;
                 }
             }
@@ -418,7 +417,7 @@ namespace Raven.Server.Documents.Queries.Graph
                     return false;
 
                 var match = new Match(originalMatch);
-                var list = new List<Match>();
+                var list = new MatchCollection();
                 foreach (var item in _path)
                 {
                     var one = new Match();
@@ -434,7 +433,12 @@ namespace Raven.Server.Documents.Queries.Graph
 
                     list.Add(one);
                 }
+
                 list.Reverse();
+
+                //add each distinct path only once
+                if (alreadyTraversedPaths.Add(list) == false)
+                    return false;
 
                 match.Set(_recursive.Alias, list);
                 match.Set(_outputAlias, current);
@@ -530,7 +534,7 @@ namespace Raven.Server.Documents.Queries.Graph
             var prev = match.GetResult(_left.GetOutputAlias());
 
             var result = match.GetResult(_recursive.Alias.Value);
-            if (!(result is List<Match> matches))
+            if (!(result is MatchCollection matches))
                 return;
 
             foreach (var singleMatch in matches)

--- a/src/Raven.Server/Documents/Queries/GraphQueryRunner.Match.cs
+++ b/src/Raven.Server/Documents/Queries/GraphQueryRunner.Match.cs
@@ -1,9 +1,8 @@
 ﻿using System;
+using System.Collections;
 using System.Collections.Generic;
 using System.Linq;
 using Microsoft.Extensions.Primitives;
-using Raven.Server.Documents.Queries.AST;
-using Sparrow;
 using Sparrow.Json;
 using Sparrow.Json.Parsing;
 
@@ -11,7 +10,92 @@ namespace Raven.Server.Documents.Queries
 {
     public partial class GraphQueryRunner
     {
-        public unsafe struct Match
+        public struct PathSegment : IEquatable<PathSegment>
+        {
+            public readonly long From;
+            public readonly long To;
+
+            public PathSegment(long @from, long to)
+            {
+                From = @from;
+                To = to;
+            }
+
+            public bool Equals(PathSegment other)
+            {
+                return From == other.From && To == other.To;
+            }
+
+            public override bool Equals(object obj)
+            {
+                if (ReferenceEquals(null, obj)) return false;
+                return obj is PathSegment segment && Equals(segment);
+            }
+
+            public override int GetHashCode() => HashCode.Combine(From, To);
+        }
+
+        public class MatchCollection : IEquatable<MatchCollection>, IEnumerable<Match>
+        {
+            private List<Match> _data = new List<Match>();
+
+            public IEnumerator<Match> GetEnumerator() => _data.GetEnumerator();
+            IEnumerator IEnumerable.GetEnumerator() => GetEnumerator();
+            public void Add(Match item) => _data.Add(item);
+
+            public void AddRange(IEnumerable<Match> items)
+            {
+                foreach (var item in items)
+                    _data.Add(item);
+            }
+
+            public void Reverse() => _data.Reverse();
+            public void Clear() => _data.Clear();
+            public int Count => _data.Count;
+            public bool IsReadOnly => false;
+
+            public bool Equals(MatchCollection other)
+            {
+                if (ReferenceEquals(null, other)) 
+                    return false;
+                return ReferenceEquals(this, other) || Equals(other._data);
+            }
+
+            public bool Equals(List<Match> other)
+            {
+                if (other?.Count != Count)
+                    return false;
+                for (var i = 0; i < _data.Count; i++)
+                {
+                    if (_data[i].Equals(other[i]) == false)
+                        return false;
+                }
+                return true;
+            }
+
+            public override bool Equals(object obj)
+            {
+                if (ReferenceEquals(null, obj)) 
+                    return false;
+                if (ReferenceEquals(this, obj)) 
+                    return true;
+
+                return obj.GetType() == GetType() && Equals((MatchCollection)obj);
+            }
+
+            public override int GetHashCode()
+            {
+                int hash = Count;
+
+                foreach (var item in _data)
+                {
+                    hash = HashCode.Combine(item.GetHashCode(), hash);
+                }
+                return hash;
+            }
+        }
+
+        public unsafe struct Match : IEquatable<Match>
         {
             private Dictionary<string, object> _inner;
 
@@ -21,11 +105,46 @@ namespace Raven.Server.Documents.Queries
 
             public bool Empty => _inner == null || _inner.Count == 0;
 
+            public bool Equals(Match other)
+            {
+                if (other.Count != Count)
+                    return false;
+
+                foreach (var kvp in _inner)
+                {
+                    if (other._inner.TryGetValue(kvp.Key, out var otherVal) == false)
+                        return false;
+
+                    if (Equals(kvp.Value, otherVal) == false)
+                        return false;
+                }
+
+                return true;
+            }
+
+            public override bool Equals(object obj)
+            {
+                if (ReferenceEquals(null, obj)) return false;
+                return obj is Match match && Equals(match);
+            }
+
             public override string ToString()
             {
                 if (_inner == null)
                     return "<empty>";
                 return string.Join(", ", _inner.Select(x => x.Key + " - " + GetNameOfValue(x.Value)));
+            }
+
+            public override int GetHashCode()
+            {
+                int hash = Count;
+
+                foreach (var item in _inner)
+                {
+                    hash = HashCode.Combine(hash, item.Key.GetHashCode(), item.Value?.GetHashCode() ?? -1);
+                }
+
+                return hash;
             }
 
             private static object GetNameOfValue(object x)
@@ -127,7 +246,7 @@ namespace Raven.Server.Documents.Queries
                     {
                         j[item.Key] = d.Data;
                     }
-                    else  if(item.Value is List<Match> matches)
+                    else  if(item.Value is MatchCollection matches)
                     {
                         var array = new DynamicJsonArray();
                         foreach (var m in matches)

--- a/src/Raven.Server/Documents/Queries/Results/GraphQueryResultRetriever.cs
+++ b/src/Raven.Server/Documents/Queries/Results/GraphQueryResultRetriever.cs
@@ -91,18 +91,11 @@ namespace Raven.Server.Documents.Queries.Results
                             case BlittableJsonReaderObject bjro:
                                 args[i] = bjro;
                                 break;
-                            case List<Match> matches:
-                                var array = new DynamicJsonArray();
-                                foreach (var m in matches)
-                                {
-                                    var djv = new DynamicJsonValue();
-                                    m.PopulateVertices(djv);
-                                    array.Add(djv);
-                                }
-
-                                var dummy = new DynamicJsonValue();
-                                dummy["Dummy"] = array;
-                                args[i] = _context.ReadObject(dummy, "graph/arg")["Dummy"];
+                            case List<Match> matchList:
+                                CreateArgsFromMatchList(matchList, args, i);
+                                break;
+                            case MatchCollection matchCollection:
+                                CreateArgsFromMatchList(matchCollection, args, i);
                                 break;
                             case string s:
                                 args[i] = s;
@@ -147,7 +140,7 @@ namespace Raven.Server.Documents.Queries.Results
                                 return immediateResult;
                             break;
                         }
-                        case List<Match> matches:
+                        case MatchCollection matches:
                             var array = new DynamicJsonArray();
                             foreach (var m in matches)
                             {
@@ -186,6 +179,21 @@ namespace Raven.Server.Documents.Queries.Results
             {
                 Data = context.ReadObject(result, "projection result")
             };
+        }
+
+        private void CreateArgsFromMatchList(IEnumerable<Match> matchCollection, object[] args, int i)
+        {
+            var array = new DynamicJsonArray();
+            foreach (var m in matchCollection)
+            {
+                var djv = new DynamicJsonValue();
+                m.PopulateVertices(djv);
+                array.Add(djv);
+            }
+
+            var dummy = new DynamicJsonValue();
+            dummy["Dummy"] = array;
+            args[i] = _context.ReadObject(dummy, "graph/arg")["Dummy"];
         }
     }
 }

--- a/src/Sparrow/Json/LazyCompressedStringValue.cs
+++ b/src/Sparrow/Json/LazyCompressedStringValue.cs
@@ -1,5 +1,6 @@
 using System;
 using Sparrow.Compression;
+using static Sparrow.Hashing;
 
 namespace Sparrow.Json
 {
@@ -10,6 +11,41 @@ namespace Sparrow.Json
         public readonly int UncompressedSize;
         public readonly int CompressedSize;
         public string String;
+
+        protected bool Equals(LazyCompressedStringValue other)
+        {
+            var size = CompressedSize;
+            if (other.CompressedSize != size)
+                return false;
+
+            return Memory.CompareInline(Buffer, other.Buffer, size) == 0;
+        }
+
+        public override bool Equals(object obj)
+        {
+            if (ReferenceEquals(null, obj)) return false;
+            if (ReferenceEquals(this, obj)) return true;
+            
+            switch (obj)
+            {
+                case LazyCompressedStringValue lcsv:
+                    return Equals(lcsv);
+                case LazyStringValue lsv:
+                    return lsv.Equals(ToLazyStringValue());
+                case string str:
+                    return str.Equals(ToString());
+            }
+
+            return false;
+        }
+
+        public override int GetHashCode()
+        {
+            unchecked
+            {
+                return (int)XXHash64.Calculate(Buffer, (ulong)CompressedSize);
+            }
+        }
 
         /// <summary>
         /// Returns uncompressed data in form of LazyStringValue

--- a/test/FastTests/Issues/RavenDB-12567.cs
+++ b/test/FastTests/Issues/RavenDB-12567.cs
@@ -72,7 +72,25 @@ namespace FastTests.Issues
                     ").ToList();
 
                     Assert.Equal(queryResults.Count, 7);
-                    //TODO : finish assertion in this test (after verifying that the code is good)
+
+                    var stronglyTypedQueryResults = queryResults.Select(x => new
+                    {
+                        Start = x["Start"].Value<string>(),
+                        Path = x["Path"].Value<string>()
+                    }).ToArray();
+
+                    var dog1StartResults = stronglyTypedQueryResults.Where(x => x.Start == "dogs/1").ToArray();
+                    var dog2StartResults = stronglyTypedQueryResults.Where(x => x.Start == "dogs/2").ToArray();
+
+                    Assert.Contains(dog1StartResults, x => x.Path == "dogs/2->dogs/1->dogs/1");
+                    Assert.Contains(dog1StartResults, x => x.Path == "dogs/2->dogs/1");
+                    Assert.Contains(dog1StartResults, x => x.Path == "dogs/2");
+                    Assert.Contains(dog1StartResults, x => x.Path == "dogs/1");
+
+                    Assert.Contains(dog2StartResults, x => x.Path == "dogs/1");
+                    Assert.Contains(dog2StartResults, x => x.Path == "dogs/1->dogs/1");
+                    Assert.Contains(dog2StartResults, x => x.Path == "dogs/1->dogs/2");
+
                 }
             }
         }

--- a/test/FastTests/Issues/RavenDB-12567.cs
+++ b/test/FastTests/Issues/RavenDB-12567.cs
@@ -1,0 +1,80 @@
+﻿using System.Linq;
+using FastTests.Graph;
+using Newtonsoft.Json.Linq;
+using Xunit;
+
+namespace FastTests.Issues
+{
+    public class RavenDB_12567 : RavenTestBase
+    {
+        [Fact]
+        public void Recursive_queries_should_handle_self_cycles_properly()
+        {
+            using (var store = GetDocumentStore())
+            {
+                using (var session = store.OpenSession())
+                {
+                    session.Store(new Dog
+                    {
+                        Name = "Arava",
+                        Likes = new [] { "dogs/1" }
+                    },"dogs/1");
+                    session.SaveChanges();
+                }
+
+                using (var session = store.OpenSession())
+                {
+                    var queryResults = session.Advanced.RawQuery<JObject>(@"
+                        match (Dogs as d1)- recursive as r (all) { [Likes as path]->(Dogs as d2) }
+                        select {
+                            Start: id(d1), 
+                            Path: r.map(x => x.path).join('->')
+                        }
+                    ").ToList();
+
+                    Assert.True(queryResults.Count == 1);
+
+                    Assert.Equal("dogs/1",queryResults[0]["Start"].Value<string>());
+                    Assert.Equal("dogs/1",queryResults[0]["Path"].Value<string>());
+                }
+            }
+        }
+
+        [Fact]
+        public void Recursive_queries_with_self_cycles_and_regular_cycles_should_properly_work()
+        {
+            using (var store = GetDocumentStore())
+            {
+                using (var session = store.OpenSession())
+                {
+                    session.Store(new Dog
+                    {
+                        Name = "Arava",
+                        Likes = new [] { "dogs/1", "dogs/2" }
+                    },"dogs/1");
+
+                    session.Store(new Dog
+                    {
+                        Name = "Oscar",
+                        Likes = new [] { "dogs/1" }
+                    },"dogs/2");
+                    session.SaveChanges();
+                }
+
+                using (var session = store.OpenSession())
+                {
+                    var queryResults = session.Advanced.RawQuery<JObject>(@"
+                        match (Dogs as d1)- recursive as r (all) { [Likes as path]->(Dogs as d2) }
+                        select {
+                            Start: id(d1), 
+                            Path: r.map(x => x.path).join('->')
+                        }
+                    ").ToList();
+
+                    Assert.Equal(queryResults.Count, 7);
+                    //TODO : finish assertion in this test (after verifying that the code is good)
+                }
+            }
+        }
+    }
+}

--- a/test/SlowTests/Graph/BasicGraphQueries.cs
+++ b/test/SlowTests/Graph/BasicGraphQueries.cs
@@ -363,20 +363,24 @@ match (Employees as e where id() = 'employees/7-A')-recursive as n (longest) { [
 select e.FirstName as Employee, n.m as MiddleManagement, boss.FirstName as Boss
 ", store =>
             {
-                using (var s = store.OpenSession())
+                using (var s = store.OpenSession())                
                 {
+                    //add self-cycle at "employees/2-A"
                     var e = s.Load<Employee>("employees/2-A");
                     e.ReportsTo = e.Id;
                     s.SaveChanges();
                 }
-
+                WaitForUserToContinueTheTest(store);
             });
             Assert.Equal(1, results.Count);
+
             foreach (var item in results)
             {
                 Assert.Equal("Andrew", item.Boss);
                 Assert.Equal("Robert", item.Employee);
-                Assert.Equal(new[] { "employees/5-A", "employees/2-A" }, item.MiddleManagement);
+                
+                //because of self-cycle of "employees/2-A" we see it twice in the path
+                Assert.Equal(new[] { "employees/5-A", "employees/2-A", "employees/2-A" }, item.MiddleManagement);
             }
         }
 


### PR DESCRIPTION
Make sure to properly handle cycles and self-cycles in graph queries especially with recursive clause. In recursive clauses, handle "visited" list that has "from" and "to" path segments, and make sure we add to results only unique paths