### PR TITLE
fix for RavenDB-12563

### DIFF
--- a/src/Raven.Server/Documents/Queries/Parser/QueryParser.cs
+++ b/src/Raven.Server/Documents/Queries/Parser/QueryParser.cs
@@ -816,7 +816,8 @@ namespace Raven.Server.Documents.Queries.Parser
                     {
                         Alias = list[i].Alias,
                         EdgeType = list[i - 1].EdgeType,
-                        IsEdge = list[i].IsEdge
+                        IsEdge = list[i].IsEdge,
+                        Recursive = list[i].Recursive
                     };
                     clauses.Add(new PatternMatchElementExpression
                     {


### PR DESCRIPTION
Better errors for invalid graph query syntax when using recursive clause