### PR TITLE
fix for RavenDB-12591

### DIFF
--- a/src/Raven.Server/Documents/Queries/Graph/QueryQueryStep.cs
+++ b/src/Raven.Server/Documents/Queries/Graph/QueryQueryStep.cs
@@ -62,6 +62,9 @@ namespace Raven.Server.Documents.Queries.Graph
         {
             get
             {
+                if (HasWhereClause) //TODO: verify with Tal how good is this change
+                    return false;
+
                 if (_queryMetadata.IsCollectionQuery == false)
                     return false;
 

--- a/test/SlowTests/Graph/IntersectionTests.cs
+++ b/test/SlowTests/Graph/IntersectionTests.cs
@@ -867,7 +867,6 @@ namespace SlowTests.Graph
             using (var store = GetDocumentStore())
             {
                 CreateMoviesData(store);
-                WaitForUserToContinueTheTest(store);
                 using (var session = store.OpenSession())
                 {
                     var results = session.Advanced.RawQuery<JObject>(@"


### PR DESCRIPTION
1) Make sure not to replace QueryQueryStep during query optimization if it has where clause (its replacement step ignores where clause).
2) fix a test with invalid assert (the test itself with invalid and was passing because of the query results were wrong due to https://issues.hibernatingrhinos.com/issue/RavenDB-12567)