### PR TITLE
RavenDB-12407: PR fixes:

### DIFF
--- a/src/Sparrow/ByteString.cs
+++ b/src/Sparrow/ByteString.cs
@@ -730,9 +730,7 @@ namespace Sparrow
         public void Reset()
         {
             if (_disposed)
-            {
-                if (_isFinalizerThread)
-                    return;
+            {                
                 ThrowObjectDisposed();
             }
                 
@@ -1580,8 +1578,7 @@ namespace Sparrow
                 _internalReadyToUseMemorySegments.Clear();
             }
         }
-
-        [ThreadStatic] private static bool _isFinalizerThread;
+        
         private readonly SharedMultipleUseFlag _lowMemoryFlag;
 
         private void ReleaseSegment(SegmentInformation segment)
@@ -1592,8 +1589,7 @@ namespace Sparrow
             _totalAllocated -= segment.Size;
 
             // Check if we can release this memory segment back to the pool.
-            if (_isFinalizerThread || 
-                segment.Memory.Size > ByteStringContext.MaxAllocationBlockSizeInBytes ||
+            if (segment.Memory.Size > ByteStringContext.MaxAllocationBlockSizeInBytes ||
                 _lowMemoryFlag)
             {
                 segment.Memory.Dispose();

--- a/src/Sparrow/Json/BlittableWriter.cs
+++ b/src/Sparrow/Json/BlittableWriter.cs
@@ -251,13 +251,7 @@ namespace Sparrow.Json
         {
             ThreadLocalCleanup.ReleaseThreadLocalState += CleanPropertyArrayOffset;
         }
-
-        ~BlittableWriter()
-        {
-            _unmanagedWriteBuffer.Kill();
-        }
-
-
+     
         public static void CleanPropertyArrayOffset()
         {
             _propertyArrayOffset = null;
@@ -773,7 +767,6 @@ namespace Sparrow.Json
 
             _compressionBuffer = null;
             _innerBuffer = null;
-            GC.SuppressFinalize(this);
         }
     }
 }

--- a/src/Sparrow/Json/JsonOperationContext.cs
+++ b/src/Sparrow/Json/JsonOperationContext.cs
@@ -422,15 +422,7 @@ namespace Sparrow.Json
 
                 _parent._managedBuffers.Push(_buffer);
                 _buffer = null;
-            }
-            
-            public void Kill()
-            {
-                if (_buffer == null)
-                    return;
-                _buffer.Dispose();                
-                _buffer = null;
-            }
+            }         
 
             private static void ThrowParentWasDisposed()
             {

--- a/src/Sparrow/Json/Parsing/ObjectJsonParser.cs
+++ b/src/Sparrow/Json/Parsing/ObjectJsonParser.cs
@@ -203,8 +203,6 @@ namespace Sparrow.Json.Parsing
             _disposed = true;
             if (_currentStateBuffer != null)
                 _ctx.ReturnMemory(_currentStateBuffer);
-
-            GC.SuppressFinalize(this);
         }
 
         public bool Read()

--- a/src/Sparrow/Json/UnmanagedBuffersPool.cs
+++ b/src/Sparrow/Json/UnmanagedBuffersPool.cs
@@ -185,8 +185,6 @@ namespace Sparrow.Json
 
         public void Return(AllocatedMemoryData returned)
         {
-            GC.SuppressFinalize(returned);
-
 #if MEM_GUARD
             ElectricFencedMemory.Free(returned.Address);
 #else

--- a/src/Sparrow/Json/UnmanagedWriteBuffer.cs
+++ b/src/Sparrow/Json/UnmanagedWriteBuffer.cs
@@ -15,7 +15,6 @@ namespace Sparrow.Json
         void WriteByte(byte data);
         void EnsureSingleChunk(JsonParserState state);
         void EnsureSingleChunk(out byte* ptr, out int size);
-        void Kill();
     }
 
     public unsafe struct UnmanagedStreamBuffer : IUnmanagedWriteBuffer
@@ -129,12 +128,7 @@ namespace Sparrow.Json
         public void EnsureSingleChunk(out byte* ptr, out int size)
         {
             throw new NotSupportedException();
-        }
-
-        public void Kill()
-        {   
-            _returnBuffer.Kill();            
-        }
+        }        
     }
 
     public unsafe struct UnmanagedWriteBuffer : IUnmanagedWriteBuffer
@@ -522,11 +516,6 @@ Grow:
 
             ptr = _head.Address;
             size = _head.Used;
-        }
-
-        public void Kill()
-        {
-            // nothing to do here
-        }
+        }  
     }
 }


### PR DESCRIPTION
* Removing _isFinalizerThread property from ByteString.cs
* Removing redundant finalizer from BlittableWriter
* Fixing memory leak caused by DocumentsContextPool contexts being returned to the wrong context pool
* Removing ReturnBuffer Kill functionality
* Removing redundant GC.SuppressFinalizer calls

https://issues.hibernatingrhinos.com/issue/RavenDB-12407