### PR TITLE
fix for RavenDB-12542

### DIFF
--- a/src/Raven.Server/Documents/Queries/AST/IndexVertexExpression.cs
+++ b/src/Raven.Server/Documents/Queries/AST/IndexVertexExpression.cs
@@ -1,0 +1,37 @@
+﻿using Microsoft.Extensions.Primitives;
+
+namespace Raven.Server.Documents.Queries.AST
+{
+    public class IndexVertexExpression: QueryExpression
+    {
+        public StringSegment IndexName;
+        public QueryExpression Filter;
+        public StringSegment? Alias;
+
+        public override string ToString()
+        {
+            var result = $"index '{IndexName}'";
+
+            if (Filter != null)
+                result += $" {Filter}";
+
+            if (Alias.HasValue)
+                result += $" as {Alias}";
+
+            return result;
+        }
+
+        public override string GetText(IndexQueryServerSide parent) => ToString();
+
+        public override bool Equals(QueryExpression other)
+        {
+            if (other == null || !(other is IndexVertexExpression indexVertexExpression))
+                return false;
+
+            if (!(indexVertexExpression.Filter?.Equals(Filter) ?? true))
+                return false;
+
+            return indexVertexExpression.IndexName.Equals(IndexName);
+        }
+    }
+}

--- a/src/Raven.Server/Documents/Queries/Parser/QueryParser.cs
+++ b/src/Raven.Server/Documents/Queries/Parser/QueryParser.cs
@@ -52,48 +52,76 @@ namespace Raven.Server.Documents.Queries.Parser
 
         public Query Parse(QueryType queryType = QueryType.Select, bool recursive = false)
         {
-            var q = new Query
+            if(!TryParse(out var query, out var message, queryType, recursive))
+                ThrowParseException(message);
+
+            return query;
+        }
+
+        public bool TryParse(out Query query,out string message, QueryType queryType = QueryType.Select, bool recursive = false)
+        {
+            query = new Query
             {
                 QueryText = Scanner.Input
             };
+            message = string.Empty;
 
             while (Scanner.TryScan("DECLARE"))
             {
                 var (name, func) = DeclaredFunction();
 
-                if (q.TryAddFunction(name, func) == false)
-                    ThrowParseException(name + " function was declared multiple times");
+                if (query.TryAddFunction(name, func) == false)
+                {
+                    message = $"{name} function was declared multiple times";
+                    return false;
+                }
             }
 
             while (Scanner.TryScan("WITH"))
             {
                 if (recursive)
-                    ThrowParseException("With clause is not allow inside inner query");
+                {
+                    message = "With clause is not allow inside inner query";
+                    return false;
+                }
 
-                WithClause(q);
+                WithClause(query);
             }
 
             if (Scanner.TryScan("MATCH") == false)
             {
-                if (q.GraphQuery != null)
-                    ThrowParseException("Missing a 'match' clause after 'with' clause");
+                if (query.GraphQuery != null)
+                {
+                    message = "Missing a 'match' clause after 'with' clause";
+                    return false;
+                }
 
-                q.From = FromClause();
+                if (!TryParseFromClause(out var fromClause, out message))
+                    return false;
+
+                query.From = fromClause;
 
                 if (Scanner.TryScan("GROUP BY"))
-                    q.GroupBy = GroupBy();
+                    query.GroupBy = GroupBy();
 
-                if (Scanner.TryScan("WHERE") && Expression(out q.Where) == false)
-                    ThrowParseException("Unable to parse WHERE clause");
+                if (Scanner.TryScan("WHERE") && Expression(out query.Where) == false)
+                {
+                    message = "Unable to parse WHERE clause";
+                    return false;
+                }
             }
             else
             {
-                if (q.GraphQuery == null)
-                    q.GraphQuery = new GraphQuery();
+                if (query.GraphQuery == null)
+                    query.GraphQuery = new GraphQuery();
 
-                if (BinaryGraph(q.GraphQuery, out var op) == false)
-                    ThrowParseException("Unexpected input when trying to parse the MATCH clause");
-                q.GraphQuery.MatchClause = op;
+                if (BinaryGraph(query.GraphQuery, out var op) == false)
+                {
+                    message = "Unexpected input when trying to parse the MATCH clause";
+                    return false;
+                }
+
+                query.GraphQuery.MatchClause = op;
 
                 if (_synteticWithQueries != null)
                 {
@@ -102,11 +130,11 @@ namespace Raven.Server.Documents.Queries.Parser
                         if (sq.IsEdge)
                         {
                             var with = new WithEdgesExpression(sq.Filter, sq.Path, sq.Project, null);
-                            q.TryAddWithEdgePredicates(with, alias);
+                            query.TryAddWithEdgePredicates(with, alias);
                         }
                         else
                         {
-                            q.TryAddWithClause(new Query
+                            query.TryAddWithClause(new Query
                             {
                                 From = new FromClause
                                 {
@@ -119,41 +147,53 @@ namespace Raven.Server.Documents.Queries.Parser
                     _synteticWithQueries.Clear();
                 }
 
-                if (Scanner.TryScan("WHERE") && Expression(out q.GraphQuery.Where) == false)
-                    ThrowParseException("Unable to parse MATCH's WHERE clause");
+                if (Scanner.TryScan("WHERE") && Expression(out query.GraphQuery.Where) == false)
+                {
+                    message = "Unable to parse MATCH's WHERE clause";
+                    return false;
+                }
             }
 
             if (Scanner.TryScan("ORDER BY"))
-                q.OrderBy = OrderBy();
+                query.OrderBy = OrderBy();
 
             if (Scanner.TryScan("LOAD"))
-                q.Load = SelectClauseExpressions("LOAD", false);
+                query.Load = SelectClauseExpressions("LOAD", false);
 
             switch (queryType)
             {
                 case QueryType.Select:
                     if (Scanner.TryScan("SELECT"))
-                        q.Select = SelectClause("SELECT", q);
+                        query.Select = SelectClause("SELECT", query);
                     if (Scanner.TryScan("INCLUDE"))
-                        q.Include = IncludeClause();
+                        query.Include = IncludeClause();
                     break;
                 case QueryType.Update:
 
-                    if(q.GraphQuery != null)
-                        ThrowParseException("Update operations cannot use graph queries");
+                    if (query.GraphQuery != null)
+                    {
+                        message = "Update operations cannot use graph queries";
+                        return false;
+                    }
 
                     if (Scanner.TryScan("UPDATE") == false)
-                        ThrowParseException("Update operations must end with UPDATE clause");
+                    {
+                        message = "Update operations must end with UPDATE clause";
+                        return false;
+                    }
 
                     var functionStart = Scanner.Position;
                     if (Scanner.FunctionBody() == false)
-                        ThrowParseException("Update clause must have a single function body");
+                    {
+                        message = "Update clause must have a single function body";
+                        return false;
+                    }
 
-                    q.UpdateBody = Scanner.Input.Substring(functionStart, Scanner.Position - functionStart);
+                    query.UpdateBody = Scanner.Input.Substring(functionStart, Scanner.Position - functionStart);
                     try
                     {
                         // validate the js code
-                        ValidateScript("function test()" + q.UpdateBody);
+                        ValidateScript("function test()" + query.UpdateBody);
                     }
                     catch (Exception e)
                     {
@@ -166,13 +206,17 @@ namespace Raven.Server.Documents.Queries.Parser
                     break;
             }
 
-            Paging(out q.Offset, out q.Limit);
+            Paging(out query.Offset, out query.Limit);
 
             if (recursive == false && Scanner.AtEndOfInput() == false)
-                ThrowParseException("Expected end of query");
+            {
+                message = "Expected end of query";
+                return false;
+            }
 
-            return q;
+            return true;
         }
+
 
         private void Paging(out ValueExpression offset, out ValueExpression limit)
         {
@@ -304,60 +348,70 @@ namespace Raven.Server.Documents.Queries.Parser
 
             SynteticWithQuery prev = default;
             var start = Scanner.Position;
-            if (Field(out var collection) == false)
+            if (TryParse(out var query, out _, recursive: true) && query.From.Index)
             {
-                if (isEdge)
-                {
-                    ThrowParseException("Unable to read edge alias");
-                }
-                if (Scanner.TryPeek(')'))// anonymous alias () accepts everything
-                {
-                    alias = "__alias" + (++_counter);
-                    AddWithQuery(new FieldExpression(new List<StringSegment>()), null, alias, null, false, start, false);
-                    return true;
-                }
-                alias = default;
-                return false;
-            }
-
-            if (Scanner.TryPeek(')'))
-            {
-                alias = GenerateAlias(implicitPrefix, collection);
-
-                if (gq.HasAlias(alias))
-                    return true;
-
-                if (_synteticWithQueries?.TryGetValue(collection.FieldValue, out prev) == true && !prev.IsEdge)
-                    return true;
-
-                AddWithQuery(collection, null, alias, null, isEdge, start, true);
-                return true;
-            }
-
-            if (collection.FieldValue == "_") // (_ as e) anonymous alias
-                collection = new FieldExpression(new List<StringSegment>());
-
-            if (Alias(true, out var maybeAlias) == false)
-            {
-                if(gq.HasAlias(collection.FieldValue) ||
-                    isEdge == false && _synteticWithQueries?.ContainsKey(collection.FieldValue) == true
-                    )
-                {
-                    alias = collection.FieldValue;
-                }
-                else
-                {
-                    alias = GenerateAlias(implicitPrefix, collection);
-                }
-            }
-            else if(maybeAlias.Value == "_")
-            {
-                alias = "__alias" + (++_counter);
+                alias = query.From.Alias ?? new StringSegment($"index_{string.Join('_', query.From.From.Compound).Replace('/', '_')}_{++_counter}");
+                gq.WithDocumentQueries.TryAdd(alias, query);
             }
             else
             {
-                alias = maybeAlias.Value;
-            }
+                if (Field(out var collection) == false)
+                {
+                    if (isEdge)
+                    {
+                        ThrowParseException("Unable to read edge alias");
+                    }
+
+                    if (Scanner.TryPeek(')')) // anonymous alias () accepts everything
+                    {
+                        alias = "__alias" + (++_counter);
+                        AddWithQuery(new FieldExpression(new List<StringSegment>()), null, alias, null, false, start, false);
+                        return true;
+                    }
+
+                    alias = default;
+                    return false;
+                }
+
+                if (Scanner.TryPeek(')'))
+                {
+                    alias = GenerateAlias(implicitPrefix, collection);
+
+                    if (gq.HasAlias(alias))
+                        return true;
+
+                    if (_synteticWithQueries?.TryGetValue(collection.FieldValue, out prev) == true && !prev.IsEdge)
+                        return true;
+
+                    AddWithQuery(collection, null, alias, null, isEdge, start, true);
+                    return true;
+                }
+
+                if (collection.FieldValue == "_") // (_ as e) anonymous alias
+                    collection = new FieldExpression(new List<StringSegment>());
+
+                if (Alias(true, out var maybeAlias) == false)
+                {
+                    if (gq.HasAlias(collection.FieldValue) ||
+                        isEdge == false && _synteticWithQueries?.ContainsKey(collection.FieldValue) == true
+                    )
+                    {
+                        alias = collection.FieldValue;
+                    }
+                    else
+                    {
+                        alias = GenerateAlias(implicitPrefix, collection);
+                    }
+                }
+                else if (maybeAlias.Value == "_")
+                {
+                    alias = "__alias" + (++_counter);
+                }
+                else
+                {
+                    alias = maybeAlias.Value;
+                }
+            
 
             QueryExpression filter = null;
             if (Scanner.TryScan("WHERE"))
@@ -383,7 +437,7 @@ namespace Raven.Server.Documents.Queries.Parser
                 return true;
         
             AddWithQuery(collection, project, alias, filter, isEdge, start, maybeAlias == null);
-
+                }
             return true;
         }
 
@@ -482,6 +536,7 @@ namespace Raven.Server.Documents.Queries.Parser
         {
             if (Scanner.TryScan('(') == false)
                 throw new InvalidQueryException("MATCH operator expected a '(', but didn't get it.", Scanner.Input, null);
+
 
             if (GraphAlias(gq, false, default, out var alias) == false)
             {
@@ -1134,19 +1189,26 @@ namespace Raven.Server.Documents.Queries.Parser
             return select;
         }
 
-
-        private FromClause FromClause()
+        private bool TryParseFromClause(out FromClause fromClause, out string message)
         {
+            fromClause = default;
+            message = string.Empty;
             if (Scanner.TryScan("FROM") == false)
-                ThrowParseException("Expected FROM clause");
+            {
+                message = "Expected FROM clause";
+                return false;
+            }
 
             FieldExpression field;
             QueryExpression filter = null;
-            bool index = false;
+            var index = false;
             if (Scanner.TryScan("INDEX"))
             {
                 if (Field(out field) == false)
-                    ThrowParseException("Expected FROM INDEX source");
+                {
+                    message = "Expected FROM INDEX source";
+                    return false;
+                }
 
                 index = true;
             }
@@ -1154,28 +1216,48 @@ namespace Raven.Server.Documents.Queries.Parser
             {
 
                 if (Field(out field) == false)
-                    ThrowParseException("Expected FROM source");
+                {
+                    message = "Expected FROM clause";
+                    return false;
+                }
 
                 if (Scanner.TryScan('(')) // FROM  Collection ( filter )
                 {
                     if (Expression(out filter) == false)
-                        ThrowParseException("Expected filter in filtered FORM clause");
+                    {
+                        message = "Expected filter in filtered FROM clause";
+                        return false;
+                    }
 
                     if (Scanner.TryScan(')') == false)
-                        ThrowParseException("Expected closing parenthesis in filtered FORM clause after filter");
+                    {
+                        message = "Expected closing parenthesis in filtered FORM clause after filter";
+                        return false;
+                    }
                 }
             }
 
 
             Alias(false, out var alias);
 
-            return new FromClause
+            fromClause = new FromClause
             {
                 From = field,
                 Alias = alias,
                 Filter = filter,
                 Index = index
             };
+
+
+            return true;
+        }
+
+        private FromClause FromClause()
+        {
+            if(!TryParseFromClause(out var fromClause, out var msg))
+                ThrowParseException(msg);
+
+            return fromClause;
         }
 
         private static readonly string[] AliasKeywords =

--- a/test/SlowTests/Issues/RavenDB-12542.cs
+++ b/test/SlowTests/Issues/RavenDB-12542.cs
@@ -1,0 +1,76 @@
+﻿using System.Linq;
+using FastTests;
+using FastTests.Server.Basic.Entities;
+using Newtonsoft.Json.Linq;
+using Raven.Client.Documents.Indexes;
+using Xunit;
+
+namespace SlowTests.Issues
+{
+    public class RavenDB_12542 : RavenTestBase
+    {
+        [Fact]
+        public void Single_node_index_query_should_work()
+        {
+            using (var store = GetDocumentStore())
+            {
+                CreateNorthwindDatabase(store);
+                WaitForIndexing(store);
+                using (var session = store.OpenSession())
+                {
+                    var queryResultsFromIndex =
+                        session.Advanced.RawQuery<JObject>("match (from index 'Orders/Totals')").ToArray();
+
+                    var queryResultsFromCollection =
+                        session.Advanced.RawQuery<JObject>("match (Orders as o)").ToArray();
+
+                    Assert.Equal(queryResultsFromCollection, queryResultsFromIndex);
+
+                }
+            }
+        }
+
+        [Fact]
+        public void Pattern_match_node_index_query_should_work()
+        {
+            using (var store = GetDocumentStore())
+            {
+                CreateNorthwindDatabase(store);
+                new IndexOrdersProductsWithPricePerUnit().Execute(store);
+                WaitForIndexing(store);
+                using (var session = store.OpenSession())
+                {
+                    var queryResults =
+                        session.Advanced.RawQuery<JObject>(
+                            @"match (from index 'Orders/Totals')-[Lines where PricePerUnit > 200 select Product]->(from index 'Product/Search' as ps)
+                              select id(ps) as ProductId
+                             ").ToArray().Select(x => x["ProductId"].Value<string>()).ToArray();
+
+                    var referenceQueryResults = session.Advanced.RawQuery<Order>(@"from index 'Orders/ProductsWithPricePerUnit' where PricePerUnit > 200")
+                        .ToArray()
+                        .SelectMany(x => x.Lines).ToArray().Where(x => x.PricePerUnit > 200).Select(x =>x.Product).ToArray();
+
+                    Assert.Equal(referenceQueryResults, queryResults);
+                }
+            }
+        }
+
+        public class IndexOrdersProductsWithPricePerUnit : AbstractIndexCreationTask
+        {
+            public override string IndexName => "Orders/ProductsWithPricePerUnit";
+
+            public override IndexDefinition CreateIndexDefinition()
+            {
+                return new IndexDefinition
+                {
+                    Maps =
+                    {
+                          @"from order in docs.Orders
+                            from orderLine in order.Lines
+                            select new { Product = orderLine.Product, PricePerUnit = orderLine.PricePerUnit }"
+                    }
+                };
+            }
+        }
+    }
+}


### PR DESCRIPTION
In graph queries, support vertices that query indexes without being defined in explicit WITH clause.
For example, the following query should properly work:
```match (from index 'Orders/Totals')-[Lines where PricePerUnit > 200 select Product]->(from index 'Product/Search')```

Under the hood, in this case the query parser will create WITH clauses that match the "from index" statements inside the vertex definitions