### PR TITLE
Fix for RavenDB-12542

### DIFF
--- a/src/Raven.Server/Documents/Queries/AST/IndexVertexExpression.cs
+++ b/src/Raven.Server/Documents/Queries/AST/IndexVertexExpression.cs
@@ -1,0 +1,37 @@
+﻿using Microsoft.Extensions.Primitives;
+
+namespace Raven.Server.Documents.Queries.AST
+{
+    public class IndexVertexExpression: QueryExpression
+    {
+        public StringSegment IndexName;
+        public QueryExpression Filter;
+        public StringSegment? Alias;
+
+        public override string ToString()
+        {
+            var result = $"index '{IndexName}'";
+
+            if (Filter != null)
+                result += $" {Filter}";
+
+            if (Alias.HasValue)
+                result += $" as {Alias}";
+
+            return result;
+        }
+
+        public override string GetText(IndexQueryServerSide parent) => ToString();
+
+        public override bool Equals(QueryExpression other)
+        {
+            if (other == null || !(other is IndexVertexExpression indexVertexExpression))
+                return false;
+
+            if (!(indexVertexExpression.Filter?.Equals(Filter) ?? true))
+                return false;
+
+            return indexVertexExpression.IndexName.Equals(IndexName);
+        }
+    }
+}

--- a/src/Raven.Server/Documents/Queries/Parser/QueryParser.cs
+++ b/src/Raven.Server/Documents/Queries/Parser/QueryParser.cs
@@ -355,7 +355,10 @@ namespace Raven.Server.Documents.Queries.Parser
             }
 
             if (Scanner.TryPeek("INDEX") && TryParseExpressionAfterFromKeyword(out var fromClause, out _))
-            {                
+            {
+                if (isEdge)
+                    throw new InvalidQueryException("Unexpected index query expression - they are forbidden to be inside edge query elements.");
+
                 var query = new Query
                 {
                     From = fromClause

--- a/test/SlowTests/Issues/RavenDB-12542.cs
+++ b/test/SlowTests/Issues/RavenDB-12542.cs
@@ -1,0 +1,132 @@
+﻿using System.Linq;
+using FastTests;
+using FastTests.Server.Basic.Entities;
+using Newtonsoft.Json.Linq;
+using Raven.Client.Documents.Indexes;
+using Raven.Client.Exceptions;
+using Raven.Server.Documents.Queries.Parser;
+using Xunit;
+
+namespace SlowTests.Issues
+{
+    public class RavenDB_12542 : RavenTestBase
+    {
+        [Fact]
+        public void Single_node_index_query_should_work()
+        {
+            using (var store = GetDocumentStore())
+            {
+                CreateNorthwindDatabase(store);
+                WaitForIndexing(store);
+                using (var session = store.OpenSession())
+                {
+                    var queryResultsFromIndex =
+                        session.Advanced.RawQuery<JObject>("match (index 'Orders/Totals' as o)").ToArray();
+
+                    var queryResultsFromCollection =
+                        session.Advanced.RawQuery<JObject>("match (Orders as o)").ToArray();
+
+                    Assert.Equal(queryResultsFromCollection, queryResultsFromIndex);
+
+                }
+            }
+        }
+
+        [Fact]
+        public void Where_clause_in_index_node_expression_should_work()
+        {
+            using (var store = GetDocumentStore())
+            {
+                CreateNorthwindDatabase(store);
+                new Index_Orders_ByEmployee().Execute(store);
+                WaitForIndexing(store);
+
+                using (var session = store.OpenSession())
+                {
+                    var queryResultsFromIndex =
+                        session.Advanced.RawQuery<JObject>("match (index 'Orders/Totals' where Employee = 'employees/4-A')").ToArray();
+
+                    var queryResultsFromCollection =
+                        session.Advanced.RawQuery<JObject>("from index 'Orders/ByEmployee' where Employee = 'employees/4-A'").ToArray();
+
+                    Assert.Equal(queryResultsFromCollection, queryResultsFromIndex);
+
+                }
+            }
+        }
+
+        public class Index_Orders_ByEmployee : AbstractIndexCreationTask
+        {
+            public override string IndexName => "Orders/ByEmployee";
+
+            public override IndexDefinition CreateIndexDefinition()
+            {
+                return new IndexDefinition
+                {
+                    Maps =
+                    {
+                        @"from order in docs.Orders select new { order.Employee }"
+                    }
+                };
+            }
+        }
+
+        [Fact]
+        public void Select_clause_inside_node_expressions_should_throw()
+        {
+            using (var store = GetDocumentStore())
+            {
+                CreateNorthwindDatabase(store);
+                WaitForIndexing(store);
+                using (var session = store.OpenSession())
+                {
+                    Assert.Throws<InvalidQueryException>(() => session.Advanced.RawQuery<JObject>("match (index 'Orders/Totals' as o select Employee)").ToArray());
+                    Assert.Throws<InvalidQueryException>(() => session.Advanced.RawQuery<JObject>("match (Orders as o select Employee)").ToArray());
+                }
+            }
+        }
+
+        [Fact]
+        public void Pattern_match_node_index_query_should_work()
+        {
+            using (var store = GetDocumentStore())
+            {
+                CreateNorthwindDatabase(store);
+                new IndexOrdersProductsWithPricePerUnit().Execute(store);
+                WaitForIndexing(store);
+                using (var session = store.OpenSession())
+                {
+                    var queryResults =
+                        session.Advanced.RawQuery<JObject>(
+                            @"match (index 'Orders/Totals')-[Lines where PricePerUnit > 200 select Product]->(index 'Product/Search' as ps)
+                              select id(ps) as ProductId
+                             ").ToArray().Select(x => x["ProductId"].Value<string>()).ToArray();
+
+                    var referenceQueryResults = session.Advanced.RawQuery<Order>(@"from index 'Orders/ProductsWithPricePerUnit' where PricePerUnit > 200")
+                        .ToArray()
+                        .SelectMany(x => x.Lines).ToArray().Where(x => x.PricePerUnit > 200).Select(x =>x.Product).ToArray();
+
+                    Assert.Equal(referenceQueryResults, queryResults);
+                }
+            }
+        }
+
+        public class IndexOrdersProductsWithPricePerUnit : AbstractIndexCreationTask
+        {
+            public override string IndexName => "Orders/ProductsWithPricePerUnit";
+
+            public override IndexDefinition CreateIndexDefinition()
+            {
+                return new IndexDefinition
+                {
+                    Maps =
+                    {
+                          @"from order in docs.Orders
+                            from orderLine in order.Lines
+                            select new { Product = orderLine.Product, PricePerUnit = orderLine.PricePerUnit }"
+                    }
+                };
+            }
+        }
+    }
+}

--- a/test/SlowTests/Issues/RavenDB-12542.cs
+++ b/test/SlowTests/Issues/RavenDB-12542.cs
@@ -72,6 +72,22 @@ namespace SlowTests.Issues
         }
 
         [Fact]
+        public void Index_query_expression_inside_edge_expressions_should_throw()
+        {
+            using (var store = GetDocumentStore())
+            {
+                CreateNorthwindDatabase(store);
+                WaitForIndexing(store);
+                using (var session = store.OpenSession())
+                {
+                    //this use-case is a bit silly, but why not throw explicit & informative exception even in such case :)
+                    Assert.Throws<InvalidQueryException>(() => session.Advanced.RawQuery<JObject>("match (Employee as e)-[index 'Orders/Totals' as o select Employee]->(Employee as anotherE)").ToArray());
+                }
+            }
+        }
+
+
+        [Fact]
         public void Select_clause_inside_node_expressions_should_throw()
         {
             using (var store = GetDocumentStore())


### PR DESCRIPTION
* Support nodes that have index query expressions without needing to define an explicit WITH clause.
For example, the following query should work:
 ```match (from index 'Orders/Totals')-[Lines where PricePerUnit > 200 select Product]->(from index 'Product/Search')```
* Throw more informative exceptions for invalid syntax