### PR TITLE
RavenDB-12629 InvalidJournalException: No such journal on database re…

### DIFF
--- a/src/Voron/Impl/Journal/JournalFile.cs
+++ b/src/Voron/Impl/Journal/JournalFile.cs
@@ -278,7 +278,16 @@ namespace Voron.Impl.Journal
             _transactionHeaders = new List<TransactionHeader>(transactionHeaders);
         }
 
-        public bool DeleteOnClose { set { _journalWriter.DeleteOnClose = value; } }
+        public bool DeleteOnClose
+        {
+            set
+            {
+                var writer = _journalWriter;
+
+                if (writer != null)
+                    writer.DeleteOnClose = value;
+            }
+        }
 
 
         private static readonly ObjectPool<FastList<PagePosition>, FastList<PagePosition>.ResetBehavior> _scratchPagesPositionsPool = new ObjectPool<FastList<PagePosition>, FastList<PagePosition>.ResetBehavior>(() => new FastList<PagePosition>(), 10);


### PR DESCRIPTION
…covery:

- updating _journalsToDelete collection under write tx lock
- making journalsToDelete collection to be concurrent dictionary since UpdateJournalStateUnderWriteTransactionLock can be run concurrently with UpdateDatabaseStateAfterSync / GatherInformationToStartSync
- including the collection of journals to delete into LastFlushState so we have the snapshot state after the flushing when syncing (as of sync was requested)
- we remove items from _journalsToDelete _after_ we successfully sync