### PR TITLE
fix for RavenDB-12198

### DIFF
--- a/src/Raven.Server/Documents/Queries/Parser/QueryParser.cs
+++ b/src/Raven.Server/Documents/Queries/Parser/QueryParser.cs
@@ -432,7 +432,7 @@ namespace Raven.Server.Documents.Queries.Parser
                         alias = collection.FieldValue;
                     }
                     //by this point we know AS' keyword is not the next token because Alias() checks for that
-                    else if (Scanner.TryPeekNextToken(c => c != ' ' && c != ')' && c != ']', out var token) && token.IsIdentifier())
+                    else if (Scanner.TryPeekNextToken(c => c != ')' && c != ']', out var token) && token.IsIdentifier())
                     {
                         if (isEdge && !token.Equals("where",StringComparison.OrdinalIgnoreCase) && !token.Equals("select",StringComparison.OrdinalIgnoreCase))
                         {

--- a/src/Raven.Server/Documents/Queries/Parser/QueryParser.cs
+++ b/src/Raven.Server/Documents/Queries/Parser/QueryParser.cs
@@ -7,7 +7,6 @@ using Microsoft.Extensions.Primitives;
 using Raven.Client.Exceptions;
 using Raven.Server.Documents.Queries.AST;
 using Raven.Server.Extensions;
-// ReSharper disable ConditionIsAlwaysTrueOrFalse
 
 namespace Raven.Server.Documents.Queries.Parser
 {

--- a/src/Raven.Server/Documents/Queries/Parser/QueryScanner.cs
+++ b/src/Raven.Server/Documents/Queries/Parser/QueryScanner.cs
@@ -250,12 +250,6 @@ namespace Raven.Server.Documents.Queries.Parser
                 tokenOffset++; //include the whitespace too
                 tokenLength = currentToken.Length;
             }
-            else
-            {
-                if(_q[tokenOffset] == ' ')
-                    while (_q[tokenOffset] == ' ')
-                        tokenOffset++;
-            }
 
             while (peekOffset < _q.Length && predicate(_q[peekOffset]))
             {

--- a/src/Raven.Server/Extensions/StringExtensions.cs
+++ b/src/Raven.Server/Extensions/StringExtensions.cs
@@ -22,14 +22,14 @@ namespace Raven.Server.Extensions
                 return false;
 
             if (token.Length == 1)
-                return char.IsLetter(token[0]);
+                return char.IsLetter(token[0]) || token[0] == '_';
             
-            if (!char.IsLetter(token[0]))
+            if (!char.IsLetter(token[0]) && token[0] != '_')
                 return false;
 
             for (int i = 1; i < token.Length; i++)
             {
-                if (!char.IsLetterOrDigit(token[i]))
+                if (!char.IsLetterOrDigit(token[i]) && token[i] != '_')
                     return false;
             }
 

--- a/src/Raven.Server/Extensions/StringExtensions.cs
+++ b/src/Raven.Server/Extensions/StringExtensions.cs
@@ -3,6 +3,7 @@ using System.Collections.Generic;
 using System.IO;
 using System.Linq;
 using System.Text;
+using Microsoft.Extensions.Primitives;
 
 namespace Raven.Server.Extensions
 {
@@ -13,6 +14,26 @@ namespace Raven.Server.Extensions
             return self.Split(new[] { ';' }, StringSplitOptions.RemoveEmptyEntries)
                 .Select(x => x.Trim())
                 .ToList();
+        }
+
+        public static bool IsIdentifier(this StringSegment token)
+        {
+            if (token.Length == 0)
+                return false;
+
+            if (token.Length == 1)
+                return char.IsLetter(token[0]);
+            
+            if (!char.IsLetter(token[0]))
+                return false;
+
+            for (int i = 1; i < token.Length; i++)
+            {
+                if (!char.IsLetterOrDigit(token[i]))
+                    return false;
+            }
+
+            return true;
         }
 
         public static string NormalizeLineEnding(this string script)

--- a/test/SlowTests/Issues/RavenDB-12198.cs
+++ b/test/SlowTests/Issues/RavenDB-12198.cs
@@ -1,0 +1,84 @@
+﻿using System;
+using System.Linq;
+using FastTests;
+using Newtonsoft.Json.Linq;
+using Raven.Client.Exceptions;
+using Xunit;
+
+namespace SlowTests.Issues
+{
+    public class RavenDB_12198 : RavenTestBase
+    {
+        [Fact]
+        public void Missing_as_keyword_should_properly_throw_in_non_recursive_query()
+        {
+            using (var store = GetDocumentStore())
+            {
+                CreateMoviesData(store);
+                using (var session = store.OpenSession())
+                {
+                    var e = Assert.Throws<InvalidQueryException>(() => session.Advanced.RawQuery<JObject>(@"
+                       match (Users u1 where Name = 'A')-[HasRated select Movie]->(Movies as m)
+                    ").ToArray());
+
+                    Assert.True(e.Message.Contains("invalid",StringComparison.OrdinalIgnoreCase) && e.Message.Contains("alias",StringComparison.OrdinalIgnoreCase) && e.Message.Contains("u1",StringComparison.OrdinalIgnoreCase));
+                }
+            }
+        }
+
+        [Fact]
+        public void Select_in_node_without_alias_should_properly_throw()
+        {
+            using (var store = GetDocumentStore())
+            {
+                CreateMoviesData(store);
+                using (var session = store.OpenSession())
+                {
+                    var e = Assert.Throws<InvalidQueryException>(() => session.Advanced.RawQuery<JObject>(@"
+                       match (Users select Name)-[HasRated select Movie]->(Movies as m)
+                    ").ToArray());
+
+                    Assert.True(e.Message.Contains("select",StringComparison.OrdinalIgnoreCase) && e.Message.Contains("forbidden",StringComparison.OrdinalIgnoreCase));
+                }
+            }
+        }
+
+        //  match (Employees where id() = 'employees/7-A')- recursive as n { [ReportsTo as m]->(Employees as boss) }
+        //select e.FirstName as Employee, n.m as MiddleManagement, boss.FirstName as Boss
+        [Fact]
+        public void Missing_as_keyword_should_properly_throw_in_recursive_query()
+        {
+            using (var store = GetDocumentStore())
+            {
+                CreateNorthwindDatabase(store);
+                using (var session = store.OpenSession())
+                {
+                    var e = Assert.Throws<InvalidQueryException>(() => session.Advanced.RawQuery<JObject>(@"
+                        match (Employees as e where id() = 'employees/7-A')- recursive as n { [ReportsTo as m]->(Employees boss) }
+                        select e.FirstName as Employee, n.m as MiddleManagement, boss.FirstName as Boss
+                    ").ToArray());
+
+                    Assert.True(e.Message.Contains("invalid",StringComparison.OrdinalIgnoreCase) && e.Message.Contains("alias",StringComparison.OrdinalIgnoreCase) && e.Message.Contains("boss",StringComparison.OrdinalIgnoreCase));
+                }
+            }
+        }
+
+        [Fact]
+        public void Missing_as_keyword_with_where_should_properly_throw_in_recursive_query()
+        {
+            using (var store = GetDocumentStore())
+            {
+                CreateNorthwindDatabase(store);
+                WaitForUserToContinueTheTest(store);
+                using (var session = store.OpenSession())
+                {
+                    var e = Assert.Throws<InvalidQueryException>(() => session.Advanced.RawQuery<JObject>(@"
+                        match (Employees e where id() = 'employees/7-A')- recursive as n { [ReportsTo as m]->(Employees as boss) }
+                        select e.FirstName as Employee, n.m as MiddleManagement, boss.FirstName as Boss
+                    ").ToArray());
+                    Assert.True(e.Message.Contains("invalid",StringComparison.OrdinalIgnoreCase) && e.Message.Contains("alias",StringComparison.OrdinalIgnoreCase) && e.Message.Contains("e",StringComparison.OrdinalIgnoreCase));
+                }
+            }
+        }
+    }
+}

--- a/test/SlowTests/Issues/RavenDB-12198.cs
+++ b/test/SlowTests/Issues/RavenDB-12198.cs
@@ -27,6 +27,23 @@ namespace SlowTests.Issues
         }
 
         [Fact]
+        public void Missing_as_keyword_in_node_without_additional_clauses_should_properly_throw_in_non_recursive_query()
+        {
+            using (var store = GetDocumentStore())
+            {
+                CreateMoviesData(store);
+                using (var session = store.OpenSession())
+                {
+                    var e = Assert.Throws<InvalidQueryException>(() => session.Advanced.RawQuery<JObject>(@"
+                       match (Users u1)-[HasRated select Movie]->(Movies as m)
+                    ").ToArray());
+
+                    Assert.True(e.Message.Contains("invalid",StringComparison.OrdinalIgnoreCase) && e.Message.Contains("alias",StringComparison.OrdinalIgnoreCase) && e.Message.Contains("u1",StringComparison.OrdinalIgnoreCase));
+                }
+            }
+        }
+
+        [Fact]
         public void Select_in_node_without_alias_should_properly_throw()
         {
             using (var store = GetDocumentStore())


### PR DESCRIPTION
1)Make sure to throw proper exceptions for missing "AS" keyword before an alias
2)Throw when using 'select' in node element that doesn't have explicit alias
(RavenDB-12198)