### PR TITLE
PrefetchingBehavior continuations can execute synchronously because they are short lived

### DIFF
--- a/Raven.Database/Prefetching/PrefetchingBehavior.cs
+++ b/Raven.Database/Prefetching/PrefetchingBehavior.cs
@@ -1283,7 +1283,7 @@ namespace Raven.Database.Prefetching
                         t.AssertNotFailed();
                     }
                     return t.Result;
-                })
+                }, CancellationToken.None, TaskContinuationOptions.ExecuteSynchronously, TaskScheduler.Default)
             };
 
             futureIndexBatch.Task.ContinueWith(t =>
@@ -1297,7 +1297,7 @@ namespace Raven.Database.Prefetching
                 {
                     // this is an expected race with the actual task, this is fine
                 }
-            });
+            }, CancellationToken.None, TaskContinuationOptions.ExecuteSynchronously, TaskScheduler.Default);
 
             var addFutureBatch = futureIndexBatches.TryAdd(nextEtag, futureIndexBatch);
             if (addFutureBatch == false)
@@ -1401,7 +1401,7 @@ namespace Raven.Database.Prefetching
                 {
                     log.Warn("WASTE: Discarding future work item without using it, to reduce memory usage");
                 }
-            });
+            }, CancellationToken.None, TaskContinuationOptions.ExecuteSynchronously, TaskScheduler.Default);
         }
 
         public void BatchProcessingComplete()


### PR DESCRIPTION
I was investigating an issue for a client and had to look into the PrefetchBehavior. I did not look into many details there but I have a hunch the continuations scheduled don't actually need to be scheduled. Adding `ExecuteSynchronously` can reduce the thread pool pressure on the server.

> Specifies that the continuation task should be executed synchronously. With this option specified, the continuation runs on the same thread that causes the antecedent task to transition into its final state. If the antecedent is already complete when the continuation is created, the continuation will run on the thread that creates the continuation. If the antecedent's CancellationTokenSource is disposed in a finally block (Finally in Visual Basic), a continuation with this option will run in that finally block. Only very short-running continuations should be executed synchronously.    Because the task executes synchronously, there is no need to call a method such as Wait() to ensure that the calling thread waits for the task to complete.

https://docs.microsoft.com/en-us/dotnet/api/system.threading.tasks.taskcontinuationoptions

Technically the `Task.WaitAll` in the dispose method

```
Task.WaitAll(futureIndexBatches.Values.Select(ObserveDiscardedTask).ToArray());
```

could be removed but I left it there since it doesn't hurt.



