### PR TITLE
RavenDB-12610

### DIFF
--- a/src/Raven.Server/Web/RequestHandler.cs
+++ b/src/Raven.Server/Web/RequestHandler.cs
@@ -165,7 +165,7 @@ namespace Raven.Server.Web
                 {
                     cts.CancelAfter(ServerStore.Configuration.Cluster.OperationTimeout.AsTimeSpan);
 
-                    var waitingTasks = new List<Task>();
+                    var waitingTasks = new List<Task<Exception>>();
                     List<Exception> exceptions = null;
 
                     foreach (var member in members)
@@ -181,10 +181,10 @@ namespace Raven.Server.Web
                         var task = await Task.WhenAny(waitingTasks);
                         waitingTasks.Remove(task);
 
-                        if (task.IsCompletedSuccessfully)
+                        if (task.Result == null)
                             continue;
 
-                        var exception = task.Exception.ExtractSingleInnerException();
+                        var exception = task.Result.ExtractSingleInnerException();
 
                         if (exceptions == null)
                             exceptions = new List<Exception>();
@@ -220,19 +220,25 @@ namespace Raven.Server.Web
                 }
             }
 
-            async Task ExecuteTask(RequestExecutor executor, string nodeTag, CancellationToken token)
+            async Task<Exception> ExecuteTask(RequestExecutor executor, string nodeTag, CancellationToken token)
             {
                 try
                 {
                     await executor.ExecuteAsync(new WaitForRaftIndexCommand(index), context, token: token);
+                    return null;
                 }
                 catch (RavenException re) when (re.InnerException is HttpRequestException)
                 {
                     // we want to throw for self-checks
                     if (nodeTag == ServerStore.NodeTag)
-                        throw;
+                        return re;
 
                     // ignore - we are ok when connection with a node cannot be established (test: AddDatabaseOnDisconnectedNode)
+                    return null;
+                }
+                catch (Exception e)
+                {
+                    return e;
                 }
             }
         }

--- a/test/RachisTests/DatabaseCluster/ClusterDatabaseMaintenance.cs
+++ b/test/RachisTests/DatabaseCluster/ClusterDatabaseMaintenance.cs
@@ -631,7 +631,7 @@ namespace RachisTests.DatabaseCluster
 
             var databaseName = GetDatabaseName();
             var groupSize = 3;
-            var newUrl = "http://" + Environment.MachineName + ":0";
+            var newUrl = "http://127.0.0.1:0";
             string nodeTag;
 
             var leader = await CreateRaftClusterAndGetLeader(groupSize, shouldRunInMemory: false, leaderIndex: 0, customSettings: new Dictionary<string, string>

--- a/test/RachisTests/DatabaseCluster/ReplicationTests.cs
+++ b/test/RachisTests/DatabaseCluster/ReplicationTests.cs
@@ -703,9 +703,9 @@ namespace RachisTests.DatabaseCluster
                 {
                     var user = await session.LoadAsync<User>("users/2");
                     var changeVector = session.Advanced.GetChangeVectorFor(user);
-                    Assert.True(changeVector.Contains("A:1-"));
-                    Assert.True(changeVector.Contains("B:2-"));
-                    Assert.True(changeVector.Contains("C:1-"));
+                    Assert.True(changeVector.Contains("A:1-"), $"No A:1- in {changeVector}");
+                    Assert.True(changeVector.Contains("B:2-"), $"No B:1- in {changeVector}");
+                    Assert.True(changeVector.Contains("C:1-"), $"No C:1- in {changeVector}");
                 }
             }
         }


### PR DESCRIPTION
- canceling the task sets the wrapping task state to canceled as well, and we need an exception, so we are returning the exception instead of throwing now
- added better failure assertion messages to AddGlobalChangeVectorToNewDocument