### PR TITLE
RavenDB-12661 Fixing the order of disposing blittables in ApplyMetada…

### DIFF
--- a/src/Raven.Client/Documents/Session/Operations/BatchOperation.cs
+++ b/src/Raven.Client/Documents/Session/Operations/BatchOperation.cs
@@ -163,19 +163,18 @@ namespace Raven.Client.Documents.Session.Operations
                 return;
 
             documentInfo.MetadataInstance = null;
-            using (var old = documentInfo.Metadata)
+
+            using (documentInfo.Document)
+            using (documentInfo.Metadata)
             {
                 documentInfo.Metadata = _session.Context.ReadObject(documentInfo.Metadata, id);
                 documentInfo.Metadata.Modifications = null;
-            }
 
-            documentInfo.Document.Modifications = new DynamicJsonValue(documentInfo.Document)
-            {
-                [Constants.Documents.Metadata.Key] = documentInfo.Metadata
-            };
+                documentInfo.Document.Modifications = new DynamicJsonValue(documentInfo.Document)
+                {
+                    [Constants.Documents.Metadata.Key] = documentInfo.Metadata
+                };
 
-            using (var old = documentInfo.Document)
-            {
                 documentInfo.Document = _session.Context.ReadObject(documentInfo.Document, id);
                 documentInfo.Document.Modifications = null;
             }

--- a/test/SlowTests/Issues/RavenDB_12661.cs
+++ b/test/SlowTests/Issues/RavenDB_12661.cs
@@ -1,0 +1,45 @@
+﻿using System.IO;
+using System.Threading.Tasks;
+using FastTests;
+using Raven.Client.Documents.Session;
+using Xunit;
+
+namespace SlowTests.Issues
+{
+    public class RavenDB_12661 : RavenTestBase
+    {
+        [Fact]
+        public async Task Can_delete_simple_attachment()
+        {
+            using (var store = GetDocumentStore())
+            {
+                using (var session = store.OpenAsyncSession())
+                {
+                    var document = new TestDocument { Id = "docs/1" };
+                    await session.StoreAsync(document);
+
+                    using (StoreTestFile(session, document, "test.txt", "test"))
+                    {
+                        await session.SaveChangesAsync();
+                    }
+                }
+
+                using (var session = store.OpenAsyncSession())
+                {
+                    var document = await session.LoadAsync<TestDocument>("docs/1");
+
+                    session.Advanced.Attachments.Delete(document, "test.txt");
+
+                    await session.SaveChangesAsync();
+                }
+            }
+        }
+
+        private MemoryStream StoreTestFile<T>(IAsyncDocumentSession session, T entity, string filename, string content)
+        {
+            var stream = new MemoryStream();
+            session.Advanced.Attachments.Store(entity, filename, stream, "text/plain");
+            return stream;
+        }
+    }
+}


### PR DESCRIPTION
…taModifications so we can reread the document while metadata has been already modified.