### PR TITLE
RavenDB-12623: Fixing problem with same ThreadIdHolder being present …

### DIFF
--- a/src/Raven.Server/Documents/Handlers/Debugging/MemoryDebugHandler.cs
+++ b/src/Raven.Server/Documents/Handlers/Debugging/MemoryDebugHandler.cs
@@ -284,7 +284,7 @@ namespace Raven.Server.Documents.Handlers.Debugging
                 var ids = new DynamicJsonArray(stats.OrderByDescending(x => x.TotalAllocated).Select(x => new DynamicJsonValue
                 {
                     ["Id"] = x.UnmanagedThreadId,
-                    ["ManagedThreadId"] = x.Id,
+                    ["ManagedThreadId"] = x.ManagedThreadId,
                     ["Allocations"] = x.TotalAllocated,
                     ["HumaneAllocations"] = Size.Humane(x.TotalAllocated)
                 }));
@@ -298,7 +298,7 @@ namespace Raven.Server.Documents.Handlers.Debugging
                 {
                     var threadStats = stats.First();
                     groupStats["Id"] = threadStats.UnmanagedThreadId;
-                    groupStats["ManagedThreadId"] = threadStats.Id;
+                    groupStats["ManagedThreadId"] = threadStats.ManagedThreadId;
                 }
                 else
                 {

--- a/src/Raven.Server/Documents/Handlers/Debugging/TransactionDebugHandler.cs
+++ b/src/Raven.Server/Documents/Handlers/Debugging/TransactionDebugHandler.cs
@@ -85,7 +85,7 @@ namespace Raven.Server.Documents.Handlers.Debugging
             return new DynamicJsonValue
             {
                 [nameof(TxInfoResult.TransactionId)] = lowLevelTransaction.Id,
-                [nameof(TxInfoResult.ThreadId)] = lowLevelTransaction.CurrentTransactionHolder?.Id,
+                [nameof(TxInfoResult.ThreadId)] = lowLevelTransaction.CurrentTransactionHolder?.ManagedThreadId,
                 [nameof(TxInfoResult.ThreadName)] = lowLevelTransaction.CurrentTransactionHolder?.Name,
                 [nameof(TxInfoResult.StartTime)] = lowLevelTransaction.TxStartTime.GetDefaultRavenFormat(isUtc: true),
                 [nameof(TxInfoResult.TotalTime)] = $"{(DateTime.UtcNow - lowLevelTransaction.TxStartTime).TotalMilliseconds} mSecs",

--- a/src/Raven.Server/Utils/ThreadsUsage.cs
+++ b/src/Raven.Server/Utils/ThreadsUsage.cs
@@ -68,7 +68,7 @@ namespace Raven.Server.Utils
                         if (threadAllocations.TryGetValue((ulong)thread.Id, out var threadStats))
                         {
                             threadName = threadStats.Name ?? "Thread Pool Thread";
-                            managedThreadId = threadStats.Id;
+                            managedThreadId = threadStats.ManagedThreadId;
                         }
 
                         var threadState = GetThreadInfoOrDefault<ThreadState?>(() => thread.ThreadState);

--- a/src/Sparrow/Json/JsonContextPoolBase.cs
+++ b/src/Sparrow/Json/JsonContextPoolBase.cs
@@ -133,7 +133,6 @@ namespace Sparrow.Json
                             _releaser.ThreadIdHolders.Add(copy[i]);
                             return;
                         }
-                        return;
                     }
                 }
                 

--- a/src/Sparrow/Json/JsonContextPoolBase.cs
+++ b/src/Sparrow/Json/JsonContextPoolBase.cs
@@ -427,12 +427,12 @@ namespace Sparrow.Json
                 _nativeMemoryCleaner.Dispose();
 
 #if Debug
-                var z = new HashSet<ContextStack>();
+                var allThreadsContextStacks = new HashSet<ContextStack>();
 #endif
                 foreach (var kvp in EnumerateAllThreadContexts())
                 {
 #if Debug
-                    if (z.Add(kvp) == false)
+                    if (allThreadsContextStacks.Add(kvp) == false)
                     {
                         throw new InvalidOperationException("threads list is not unique");
                     }

--- a/src/Sparrow/Json/JsonContextPoolBase.cs
+++ b/src/Sparrow/Json/JsonContextPoolBase.cs
@@ -249,17 +249,20 @@ namespace Sparrow.Json
 
                 _contextStacksByThreadId.TryRemove(NativeMemory.CurrentThreadStats.InternalId, out _);
 
-                // we want to clear our JsonContextPool's current thread's state from the _releaser, but to avoid touching any other states
-                foreach (var threadIdHolder in _threadIds)
+                if (_releaser != null)
                 {
-                    if (Interlocked.CompareExchange(ref threadIdHolder.ThreadId, -1, NativeMemory.CurrentThreadStats.InternalId) == NativeMemory.CurrentThreadStats.InternalId)
+                    // we want to clear our JsonContextPool's current thread's state from the _releaser, but to avoid touching any other states
+                    foreach (var threadIdHolder in _threadIds)
                     {
-                        _releaser.RemoveThreadIdHolder(threadIdHolder);
-                        break;
+                        if (Interlocked.CompareExchange(ref threadIdHolder.ThreadId, -1, NativeMemory.CurrentThreadStats.InternalId) == NativeMemory.CurrentThreadStats.InternalId)
+                        {
+                            _releaser.RemoveThreadIdHolder(threadIdHolder);
+                            break;
+                        }
                     }
-                }
 
-                _releaser.RemoveContextPool(this);
+                    _releaser.RemoveContextPool(this);
+                }
 
                 if (current == null)
                     return;

--- a/src/Sparrow/Json/JsonContextPoolBase.cs
+++ b/src/Sparrow/Json/JsonContextPoolBase.cs
@@ -67,7 +67,7 @@ namespace Sparrow.Json
 
             public ContextStackThreadReleaser()
             {
-                _threadId = NativeMemory.CurrentThreadStats.Id;
+                _threadId = NativeMemory.CurrentThreadStats.InternalId;
             }
 
             ~ContextStackThreadReleaser()
@@ -224,13 +224,13 @@ namespace Sparrow.Json
 
         private ContextStack MaybeGetCurrentContextStack()
         {
-            _contextStacksByThreadId.TryGetValue(NativeMemory.CurrentThreadStats.Id, out var x);
+            _contextStacksByThreadId.TryGetValue(NativeMemory.CurrentThreadStats.InternalId, out var x);
             return x;
         }
 
         private ContextStack GetCurrentContextStack()
         {
-            return _contextStacksByThreadId.GetOrAdd(NativeMemory.CurrentThreadStats.Id, 
+            return _contextStacksByThreadId.GetOrAdd(NativeMemory.CurrentThreadStats.InternalId, 
                 currentThreadId =>
                 {
                     EnsureCurrentThreadContextWillBeReleased(currentThreadId);
@@ -247,12 +247,12 @@ namespace Sparrow.Json
             {
                 current = MaybeGetCurrentContextStack()?.Head;
 
-                _contextStacksByThreadId.TryRemove(NativeMemory.CurrentThreadStats.Id, out _);
+                _contextStacksByThreadId.TryRemove(NativeMemory.CurrentThreadStats.InternalId, out _);
 
                 // we want to clear our JsonContextPool's current thread's state from the _releaser, but to avoid touching any other states
                 foreach (var threadIdHolder in _threadIds)
                 {
-                    if (Interlocked.CompareExchange(ref threadIdHolder.ThreadId, -1, NativeMemory.CurrentThreadStats.Id) == NativeMemory.CurrentThreadStats.Id)
+                    if (Interlocked.CompareExchange(ref threadIdHolder.ThreadId, -1, NativeMemory.CurrentThreadStats.InternalId) == NativeMemory.CurrentThreadStats.InternalId)
                     {
                         _releaser.RemoveThreadIdHolder(threadIdHolder);
                         break;

--- a/src/Sparrow/Utils/NativeMemory.cs
+++ b/src/Sparrow/Utils/NativeMemory.cs
@@ -46,6 +46,8 @@ namespace Sparrow.Utils
 
             public long TotalAllocated => Allocations - ReleasesFromOtherThreads;
 
+            private static int _uniqueThreadId = 0;
+
             public long CurrentlyAllocatedForProcessing;
 
             public bool IsThreadAlive()
@@ -71,7 +73,7 @@ namespace Sparrow.Utils
             public ThreadStats()
             {
                 _threadInstance = Thread.CurrentThread;
-                Id = _threadInstance.ManagedThreadId;
+                Id = Interlocked.Increment(ref _uniqueThreadId);                    
                 UnmanagedThreadId = PlatformDetails.GetCurrentThreadId();
             }
         }

--- a/src/Sparrow/Utils/NativeMemory.cs
+++ b/src/Sparrow/Utils/NativeMemory.cs
@@ -41,6 +41,7 @@ namespace Sparrow.Utils
             public long Allocations;
             public long ReleasesFromOtherThreads;
             private Thread _threadInstance;
+            private readonly int ManagedThreadId;
             private string _lastName = "Unknown";
             public string Name => _threadInstance?.Name ?? _lastName;
 
@@ -73,6 +74,7 @@ namespace Sparrow.Utils
             public ThreadStats()
             {
                 _threadInstance = Thread.CurrentThread;
+                ManagedThreadId = _threadInstance.ManagedThreadId;
                 Id = Interlocked.Increment(ref _uniqueThreadId);                    
                 UnmanagedThreadId = PlatformDetails.GetCurrentThreadId();
             }

--- a/src/Sparrow/Utils/NativeMemory.cs
+++ b/src/Sparrow/Utils/NativeMemory.cs
@@ -36,12 +36,12 @@ namespace Sparrow.Utils
 
         public class ThreadStats
         {
-            public int Id;
+            public int InternalId;
             public ulong UnmanagedThreadId;
             public long Allocations;
             public long ReleasesFromOtherThreads;
             private Thread _threadInstance;
-            private readonly int ManagedThreadId;
+            public readonly int ManagedThreadId;
             private string _lastName = "Unknown";
             public string Name => _threadInstance?.Name ?? _lastName;
 
@@ -75,7 +75,7 @@ namespace Sparrow.Utils
             {
                 _threadInstance = Thread.CurrentThread;
                 ManagedThreadId = _threadInstance.ManagedThreadId;
-                Id = Interlocked.Increment(ref _uniqueThreadId);                    
+                InternalId = Interlocked.Increment(ref _uniqueThreadId);                    
                 UnmanagedThreadId = PlatformDetails.GetCurrentThreadId();
             }
         }

--- a/src/Voron/StorageEnvironment.cs
+++ b/src/Voron/StorageEnvironment.cs
@@ -713,7 +713,7 @@ namespace Voron
                 currentWriteTransactionHolder == NativeMemory.CurrentThreadStats)
             {
                 throw new InvalidOperationException($"A write transaction is already opened by thread name: " +
-                                                    $"{currentWriteTransactionHolder.Name}, Id: {currentWriteTransactionHolder.Id}");
+                                                    $"{currentWriteTransactionHolder.Name}, Id: {currentWriteTransactionHolder.ManagedThreadId}");
             }
         }
 
@@ -753,7 +753,7 @@ namespace Voron
 
             var message = $"Waited for {wait} for transaction write lock, but could not get it";
             if (copy != null)
-                message += $", the tx is currently owned by thread {copy.Id} - {copy.Name}, OS thread id: {copy.UnmanagedThreadId}";
+                message += $", the tx is currently owned by thread {copy.ManagedThreadId} - {copy.Name}, OS thread id: {copy.UnmanagedThreadId}";
 
             throw new TimeoutException(message);
         }
@@ -768,7 +768,7 @@ namespace Voron
 
             var message = $"Waited for {wait} for read access of the flushing in progress lock, but could not get it";
             if (copy != null)
-                message += $", the flushing in progress lock is currently owned by thread {copy.Id} - {copy.Name}";
+                message += $", the flushing in progress lock is currently owned by thread {copy.ManagedThreadId} - {copy.Name}";
 
             throw new TimeoutException(message);
         }

--- a/test/FastTests/Issues/RavenDB_12623.cs
+++ b/test/FastTests/Issues/RavenDB_12623.cs
@@ -1,0 +1,59 @@
+﻿using System;
+using System.Collections.Generic;
+using System.Text;
+using System.Threading;
+using Raven.Server.ServerWide.Context;
+using Sparrow.Json;
+using Voron;
+using Xunit;
+
+namespace FastTests.Issues
+{
+    public class RavenDB_12623:IDisposable
+    {
+        [Fact]
+        public void ContextPoolsShouldNotLeakThreadIdData()
+        {            
+            var p1 = new TransactionContextPool(new StorageEnvironment(StorageEnvironmentOptions.CreateMemoryOnly()));
+            var p2 = new TransactionContextPool(new StorageEnvironment(StorageEnvironmentOptions.CreateMemoryOnly()));
+
+            p1.AllocateOperationContext(out JsonOperationContext ctx);
+
+            var t = new Thread(() =>
+            {
+                p2.AllocateOperationContext(out JsonOperationContext _1);
+                p1.AllocateOperationContext(out JsonOperationContext _).Dispose();
+            });
+            t.Start();
+            p2.AllocateOperationContext(out JsonOperationContext ___);
+
+            t.Join();
+
+            t = null;
+
+            GC.Collect();
+            GC.WaitForPendingFinalizers();
+            GC.Collect();
+
+            t = new Thread(() =>
+            {
+
+                p1.AllocateOperationContext(out JsonOperationContext _);
+                p1 = null;
+                p2.AllocateOperationContext(out JsonOperationContext ctx2);
+
+                GC.Collect();
+                GC.WaitForPendingFinalizers();
+                GC.Collect();
+
+                p2.AllocateOperationContext(out JsonOperationContext ctx3);
+            });
+            t.Start();
+            t.Join();
+        }
+
+        public void Dispose()
+        {
+        }
+    }
+}


### PR DESCRIPTION
…in two context pools, causing thread ids duplicates and overruns.

Also, added assertion code to catch that kind of issues, if they reappear