### PR TITLE
Do not log TaskCanceledException with WARN

### DIFF
--- a/Raven.Database/Prefetching/PrefetchingBehavior.cs
+++ b/Raven.Database/Prefetching/PrefetchingBehavior.cs
@@ -1393,7 +1393,7 @@ namespace Raven.Database.Prefetching
         {
             return source.Task.ContinueWith(task =>
             {
-                if (task.Exception != null)
+                if (task.Exception != null && !(task.Exception.InnerException is TaskCanceledException))
                 {
                     log.WarnException("Error happened on discarded future work batch", task.Exception);
                 }


### PR DESCRIPTION
I asked this

```
Hi

We have a customer that see quite a few of those exceptions happening in the ravendb log

2019-01-06 18:55:49.7654|32|Warn|Raven.Database.Prefetching.PrefetchingBehavior|Error happened on discarded future work batch
System.AggregateException: One or more errors occurred. ---> System.AggregateException: One or more errors occurred. ---> System.Threading.Tasks.TaskCanceledException: A task was canceled.
   --- End of inner exception stack trace ---
   at System.Threading.Tasks.Task`1.GetResultCore(Boolean waitCompletionNotification)
   at Raven.Database.Prefetching.PrefetchingBehavior.<>c__DisplayClass97_0.<AddFutureBatch>b__2(Task`1 t)
   at System.Threading.Tasks.ContinuationResultTaskFromResultTask`2.InnerInvoke()
   at System.Threading.Tasks.Task.Execute()
   --- End of inner exception stack trace ---
---> (Inner Exception #0) System.AggregateException: One or more errors occurred. ---> System.Threading.Tasks.TaskCanceledException: A task was canceled.
   --- End of inner exception stack trace ---
   at System.Threading.Tasks.Task`1.GetResultCore(Boolean waitCompletionNotification)
   at Raven.Database.Prefetching.PrefetchingBehavior.<>c__DisplayClass97_0.<AddFutureBatch>b__2(Task`1 t)
   at System.Threading.Tasks.ContinuationResultTaskFromResultTask`2.InnerInvoke()
   at System.Threading.Tasks.Task.Execute()
---> (Inner Exception #0) System.Threading.Tasks.TaskCanceledException: A task was canceled.<---


ServiceControl Version
3.5.0

RavenDB Database Size
114gb

How often does the exception happen
~4 times every hour

I told the customer that this is an expected exception by RavenDB. It can happen when a future batch for an etag is already running. Then the prefetch behavior of RavenDB will cancel the newly scheduled prefetch task which then raises an OperationCanceledException that gets logged as WARN in the logfile.

But I wanted to double check if 4 times every hour is something to be worried about even though it is an expected exception? The client runs on RavenDB 3.5.7

Thanks for your help

Daniel
```

@ayende answer was

> No, it is expected.
> This probably shouldn't be logged at this level

So I figured I'll give it a go