### PR TITLE
fix for RavenDB-12564

### DIFF
--- a/src/Raven.Server/Documents/Handlers/QueriesHandler.cs
+++ b/src/Raven.Server/Documents/Handlers/QueriesHandler.cs
@@ -195,7 +195,7 @@ namespace Raven.Server.Documents.Handlers
 
             var json = await context.ReadForMemoryAsync(RequestBodyStream(), "index/query");
 
-            return IndexQueryServerSide.Create(HttpContext, json, Database.QueryMetadataCache, tracker);
+            return IndexQueryServerSide.Create(HttpContext, json, Database.QueryMetadataCache, tracker, Database);
         }
 
         private async Task SuggestQuery(IndexQueryServerSide indexQuery, DocumentsOperationContext context, OperationCancelToken token)
@@ -377,7 +377,7 @@ namespace Raven.Server.Documents.Handlers
                 if (reader.TryGet("Query", out BlittableJsonReaderObject queryJson) == false || queryJson == null)
                     throw new BadRequestException("Missing 'Query' property.");
 
-                var query = IndexQueryServerSide.Create(HttpContext, queryJson, Database.QueryMetadataCache, null, QueryType.Update);
+                var query = IndexQueryServerSide.Create(HttpContext, queryJson, Database.QueryMetadataCache, null, queryType: QueryType.Update);
 
                 if (TrafficWatchManager.HasRegisteredClients)
                     TrafficWatchQuery(query);
@@ -471,7 +471,7 @@ namespace Raven.Server.Documents.Handlers
                 if (reader.TryGet("Query", out BlittableJsonReaderObject queryJson) == false || queryJson == null)
                     throw new BadRequestException("Missing 'Query' property.");
 
-                var query = IndexQueryServerSide.Create(HttpContext, queryJson, Database.QueryMetadataCache, null, QueryType.Update);
+                var query = IndexQueryServerSide.Create(HttpContext, queryJson, Database.QueryMetadataCache, null, queryType: QueryType.Update);
 
                 if (TrafficWatchManager.HasRegisteredClients)
                     TrafficWatchQuery(query);

--- a/src/Raven.Server/Documents/Queries/AST/FieldExpression.cs
+++ b/src/Raven.Server/Documents/Queries/AST/FieldExpression.cs
@@ -1,7 +1,6 @@
 using System.Collections.Generic;
 using System.Text;
 using Microsoft.Extensions.Primitives;
-using Sparrow;
 
 namespace Raven.Server.Documents.Queries.AST
 {

--- a/src/Raven.Server/Documents/Queries/AST/GraphQuery.cs
+++ b/src/Raven.Server/Documents/Queries/AST/GraphQuery.cs
@@ -9,7 +9,7 @@ namespace Raven.Server.Documents.Queries.AST
     {
         public HashSet<StringSegment> RecursiveMatches = new HashSet<StringSegment>(StringSegmentComparer.Ordinal);
 
-        public Dictionary<StringSegment, Query> WithDocumentQueries = new Dictionary<StringSegment, Query>();
+        public Dictionary<StringSegment, (bool implicitAlias, Query withQuery)> WithDocumentQueries = new Dictionary<StringSegment, (bool implicitAlias, Query)>();
 
         public Dictionary<StringSegment, WithEdgesExpression> WithEdgePredicates = new Dictionary<StringSegment, WithEdgesExpression>();
 

--- a/src/Raven.Server/Documents/Queries/AST/GraphQuerySyntaxValidatorVisitor.cs
+++ b/src/Raven.Server/Documents/Queries/AST/GraphQuerySyntaxValidatorVisitor.cs
@@ -1,16 +1,54 @@
-﻿using System.Runtime.CompilerServices;
+﻿using System.Collections.Generic;
+using System.Runtime.CompilerServices;
+using Microsoft.Extensions.Primitives;
 using Raven.Client.Exceptions;
 
 namespace Raven.Server.Documents.Queries.AST
 {
     public class GraphQuerySyntaxValidatorVisitor : QueryVisitor
     {
-        public static GraphQuerySyntaxValidatorVisitor Instance { get; } = new GraphQuerySyntaxValidatorVisitor();
+        private readonly GraphQuery _query;
+        private readonly HashSet<StringSegment> _aliases = new HashSet<StringSegment>(StringSegmentComparer.OrdinalIgnoreCase);
+
+        public GraphQuerySyntaxValidatorVisitor(GraphQuery query)
+        {
+            _query = query;
+        }
 
         private enum QueryStepElementType
         {
             Vertex,
             Edge
+        }
+        
+        private void ThrowIfDuplicateAlias(MatchPath path)
+        {
+            if (path.Field != null)
+            {
+                if (_aliases.Contains(path.Alias) && !path.Alias.Equals(path.Field.FieldValue))
+                {
+                    var isImplicitAlias = false;
+                    if (path.IsEdge && _query.WithEdgePredicates.TryGetValue(path.Alias, out var withEdge))
+                    {
+                        isImplicitAlias = withEdge.ImplicitAlias;
+                    }
+                    else if(_query.WithDocumentQueries.TryGetValue(path.Alias, out var withQuery))
+                    {
+                        isImplicitAlias = withQuery.implicitAlias;
+                    }
+
+                    if (isImplicitAlias)
+                        throw new InvalidQueryException($"Found redefinition of an implicit alias '{path.Alias}', this is not allowed. Note: If you specify nodes or edges without an alias, for example like this: '(Employees)', then implicit alias will be generated. ", _query.QueryText);
+
+                    throw new InvalidQueryException($"Found redefinition of alias '{path.Alias}', this is not allowed. The correct syntax is to have only single alias definition in the form of '(Employees as e)'", _query.QueryText);
+                }
+
+                _aliases.Add(path.Alias);
+            }
+            else if (!_aliases.Contains(path.Alias) && !_query.WithDocumentQueries.ContainsKey(path.Alias) && !_query.WithEdgePredicates.ContainsKey(path.Alias))
+            {
+                throw new InvalidQueryException($"Found duplicate alias '{path.Alias}', this is not allowed", _query.QueryText);
+            }
         }
 
         public override void VisitPatternMatchElementExpression(PatternMatchElementExpression elementExpression)
@@ -21,8 +59,10 @@ namespace Raven.Server.Documents.Queries.AST
                 if (elements[0].IsEdge)
                     ThrowExpectedVertexButFoundEdge(elements[0],elementExpression);
             }
-            else 
+            else
             {
+                ThrowIfDuplicateAlias(elements[0]);
+
                 if (elements[0].IsEdge && !elements[0].Recursive.HasValue)
                     ThrowExpectedVertexButFoundEdge(elements[0],elementExpression);
 
@@ -32,16 +72,20 @@ namespace Raven.Server.Documents.Queries.AST
                 var last = QueryStepElementType.Vertex; //we just verified that the first (or last) is a vertex
                 for (var i = 1; i < elements.Length; i++)
                 {
-                    QueryStepElementType next;
+                    QueryStepElementType next;                    
                     var nextIsRecursive = false;
                     if (elements[i].Recursive.HasValue)
-                    {
+                    {                        
                         var matchPath = elements[i].Recursive.Value.Pattern;
+                        foreach(var path in matchPath )
+                            ThrowIfDuplicateAlias(path);
+
                         next = DetermineEdgeOrVertex(matchPath[0]);
                         nextIsRecursive = true;
                     }
                     else
                     {
+                        ThrowIfDuplicateAlias(elements[i]);
                         next = DetermineEdgeOrVertex(elements[i]);
                     }
 

--- a/src/Raven.Server/Documents/Queries/AST/PatternMatchElementExpression.cs
+++ b/src/Raven.Server/Documents/Queries/AST/PatternMatchElementExpression.cs
@@ -233,19 +233,23 @@ namespace Raven.Server.Documents.Queries.AST
 
     public struct MatchPath
     {
+        public FieldExpression Field;
         public StringSegment Alias;
         public EdgeType EdgeType;
         public bool IsEdge;
         public RecursiveMatch? Recursive;
+        public bool IsImplicit;
 
-        public MatchPath CloneWithDifferentEdgeType(EdgeType type)
+        public MatchPath CloneWithDifferentEdgeType(EdgeType type, bool cloneWithField = true)
         {
             return new MatchPath
             {
                 Alias = Alias,
                 EdgeType = type,
                 IsEdge = IsEdge,
-                Recursive = Recursive
+                Recursive = Recursive,
+                Field = cloneWithField ? Field : null,
+                IsImplicit = IsImplicit
             };
         }
 

--- a/src/Raven.Server/Documents/Queries/AST/Query.cs
+++ b/src/Raven.Server/Documents/Queries/AST/Query.cs
@@ -41,7 +41,7 @@ namespace Raven.Server.Documents.Queries.AST
             return sb.ToString();
         }
 
-        public void TryAddWithClause(Query query, StringSegment alias)
+        public void TryAddWithClause(Query query, StringSegment alias, bool implicitAlias)
         {
             if (GraphQuery == null)
             {
@@ -53,18 +53,17 @@ namespace Raven.Server.Documents.Queries.AST
                 if (query.From.From.Compound.Count == 0)
                     return; // reusing an alias defined explicitly before
 
-                if(existing.From.From.Compound.Count == 0)
+                if(existing.withQuery.From.From.Compound.Count == 0)
                 {
                     // using an alias that is defined _later_ in the query
-                    GraphQuery.WithDocumentQueries[alias] = query;
+                    GraphQuery.WithDocumentQueries[alias] = (implicitAlias, query);
                     return;
                 }
 
-                throw new InvalidQueryException($"Allias {alias} is already in use on a diffrent 'With' clause",
-                    QueryText, null);
+                throw new InvalidQueryException($"Alias {alias} is already in use on a different 'With' clause", QueryText);
             }
 
-            GraphQuery.WithDocumentQueries.Add(alias, query);
+            GraphQuery.WithDocumentQueries.Add(alias, (implicitAlias, query));
         }
 
         public void TryAddWithEdgePredicates(WithEdgesExpression expr, StringSegment alias)

--- a/src/Raven.Server/Documents/Queries/AST/QueryVisitor.cs
+++ b/src/Raven.Server/Documents/Queries/AST/QueryVisitor.cs
@@ -92,10 +92,10 @@ namespace Raven.Server.Documents.Queries.AST
                 VisitSelectFunctionBody(q.SelectFunctionBody.FunctionText);
         }
 
-        public virtual void VisitWithClauses(Dictionary<StringSegment, Query> expression)
+        public virtual void VisitWithClauses(Dictionary<StringSegment, (bool isImplicitAlias, Query withQuery)> expression)
         {
             foreach (var withClause in expression)
-                Visit(withClause.Value);
+                Visit(withClause.Value.withQuery);
         }
         public virtual void VisitWithEdgePredicates(Dictionary<StringSegment, WithEdgesExpression> expression)
         {

--- a/src/Raven.Server/Documents/Queries/AST/StringQueryVisitor.cs
+++ b/src/Raven.Server/Documents/Queries/AST/StringQueryVisitor.cs
@@ -352,14 +352,14 @@ namespace Raven.Server.Documents.Queries.AST
             }
         }
 
-        public override void VisitWithClauses(Dictionary<StringSegment, Query> expression)
+        public override void VisitWithClauses(Dictionary<StringSegment, (bool isImplicitAlias, Query withQuery)> expression)
         {
             foreach (var withClause in expression)
             {
                 EnsureLine();
                 _sb.Append("WITH {");
                 _indent++;
-                Visit(withClause.Value);
+                Visit(withClause.Value.withQuery);
                 _indent--;
                 EnsureLine();
                 _sb.Append("} AS ").Append(withClause.Key.Value);

--- a/src/Raven.Server/Documents/Queries/AST/WithEdgesExpression.cs
+++ b/src/Raven.Server/Documents/Queries/AST/WithEdgesExpression.cs
@@ -1,7 +1,6 @@
 ﻿using System.Collections.Generic;
 using System.Text;
 using Microsoft.Extensions.Primitives;
-using Sparrow;
 
 namespace Raven.Server.Documents.Queries.AST
 {
@@ -18,6 +17,8 @@ namespace Raven.Server.Documents.Queries.AST
         public StringSegment EdgeAlias;
 
         public FieldExpression Project;
+
+        public bool ImplicitAlias;
 
         public WithEdgesExpression(QueryExpression @where, FieldExpression path, FieldExpression project, List<(QueryExpression Expression, OrderByFieldType FieldType, bool Ascending)> orderBy)
         {

--- a/src/Raven.Server/Documents/Queries/Graph/GraphQueryPlan.cs
+++ b/src/Raven.Server/Documents/Queries/Graph/GraphQueryPlan.cs
@@ -40,10 +40,9 @@ namespace Raven.Server.Documents.Queries.Graph
             _token = token;
         }
 
-
         public void BuildQueryPlan()
-        {
-            GraphQuerySyntaxValidatorVisitor.Instance.Visit(_query.Metadata.Query); //this will throw if the syntax will be bad
+        {            
+            new GraphQuerySyntaxValidatorVisitor(GraphQuery).Visit(_query.Metadata.Query); //this will throw if the syntax will be bad
             RootQueryStep = BuildQueryPlanForExpression(_query.Metadata.Query.GraphQuery.MatchClause);
             ClearUniqueQueriesFromIdenticalQueries();
         }
@@ -221,8 +220,8 @@ namespace Raven.Server.Documents.Queries.Graph
             }
             // TODO: we can tell at this point if it is a collection query or not,
             // TODO: in the future, we want to build a diffrent step for collection queries in the future.        
-            var queryMetadata = new QueryMetadata(query, _query.QueryParameters, 0);
-            var qqs = new QueryQueryStep(_database.QueryRunner, alias, query, queryMetadata, _query.QueryParameters, _context, _resultEtag, this, _token)
+            var queryMetadata = new QueryMetadata(query.withQuery, _query.QueryParameters, 0);
+            var qqs = new QueryQueryStep(_database.QueryRunner, alias, query.withQuery, queryMetadata, _query.QueryParameters, _context, _resultEtag, this, _token)
             {
                 CollectIntermediateResults = CollectIntermediateResults
             };

--- a/src/Raven.Server/Documents/Queries/IndexQueryServerSide.cs
+++ b/src/Raven.Server/Documents/Queries/IndexQueryServerSide.cs
@@ -74,11 +74,11 @@ namespace Raven.Server.Documents.Queries
             Metadata = new QueryMetadata(Query, queryParameters, 0);
         }
 
-        public static IndexQueryServerSide Create(
-            HttpContext httpContext,
+        public static IndexQueryServerSide Create(HttpContext httpContext,
             BlittableJsonReaderObject json,
             QueryMetadataCache cache,
             RequestTimeTracker tracker,
+            DocumentDatabase database = null,
             QueryType queryType = QueryType.Select)
         {
             IndexQueryServerSide result = null;
@@ -98,7 +98,7 @@ namespace Raven.Server.Documents.Queries
                     return result;
                 }
 
-                result.Metadata = new QueryMetadata(result.Query, result.QueryParameters, metadataHash, queryType);
+                result.Metadata = new QueryMetadata(result.Query, result.QueryParameters, metadataHash, queryType, database);
                 if (result.Metadata.HasTimings)
                     result.Timings = new QueryTimingsScope(start: false);
 

--- a/src/Raven.Server/Documents/Queries/QueryMetadata.cs
+++ b/src/Raven.Server/Documents/Queries/QueryMetadata.cs
@@ -22,7 +22,6 @@ using Raven.Server.Documents.Queries.Highlightings;
 using Raven.Server.Documents.Queries.Parser;
 using Raven.Server.Documents.Queries.Suggestions;
 using Raven.Server.Extensions;
-using Sparrow;
 using Sparrow.Json;
 using Sparrow.Utils;
 using BinaryExpression = Raven.Server.Documents.Queries.AST.BinaryExpression;
@@ -37,16 +36,16 @@ namespace Raven.Server.Documents.Queries
 
         public readonly Dictionary<StringSegment, (string PropertyPath, bool Array, bool Parameter, bool Quoted, string LoadFromAlias)> RootAliasPaths = new Dictionary<StringSegment, (string, bool, bool, bool, string)>();
 
-        public QueryMetadata(string query, BlittableJsonReaderObject parameters, ulong cacheKey, QueryType queryType = QueryType.Select)
-            : this(ParseQuery(query, queryType), parameters, cacheKey)
+        public QueryMetadata(string query, BlittableJsonReaderObject parameters, ulong cacheKey, QueryType queryType = QueryType.Select, DocumentDatabase database = null)
+            : this(ParseQuery(query, queryType, database), parameters, cacheKey)
         {
 
         }
 
-        private static Query ParseQuery(string q, QueryType queryType)
+        private static Query ParseQuery(string q, QueryType queryType, DocumentDatabase database = null)
         {
             var qp = new QueryParser();
-            qp.Init(q);
+            qp.Init(q, database?.DocumentsStorage);
             return qp.Parse(queryType);
         }
 

--- a/test/FastTests/Graph/Parsing.cs
+++ b/test/FastTests/Graph/Parsing.cs
@@ -243,8 +243,8 @@ match (Movies as m)<-[Rated as r]-( Users as u where City='Hadera' )
                 Assert.Equal("m", p.Path[2].Alias);
                 Assert.Equal(EdgeType.Right, p.Path[2].EdgeType);
 
-                Assert.Equal("FROM Users WHERE City = 'Hadera'", query.GraphQuery.WithDocumentQueries["u"].ToString().Trim());
-                Assert.Equal("FROM Movies", query.GraphQuery.WithDocumentQueries["m"].ToString().Trim());
+                Assert.Equal("FROM Users WHERE City = 'Hadera'", query.GraphQuery.WithDocumentQueries["u"].withQuery.ToString().Trim());
+                Assert.Equal("FROM Movies", query.GraphQuery.WithDocumentQueries["m"].withQuery.ToString().Trim());
                 Assert.Equal("WITH EDGES (Rated)", query.GraphQuery.WithEdgePredicates["r"].ToString().Trim());
             }
             else

--- a/test/SlowTests/Graph/IntersectionTests.cs
+++ b/test/SlowTests/Graph/IntersectionTests.cs
@@ -57,7 +57,7 @@ namespace SlowTests.Graph
                     var results = session.Advanced.RawQuery<JObject>(@"
                        match (Users as u1 where Name = 'A')-[HasRated select Movie]->(Movies as m)
                              OR
-                             (Users as u2 where Name = 'B')-[HasRated select Movie]->(Movies as m)
+                             (Users as u2 where Name = 'B')-[HasRated select Movie]->(m)
                        select u1.Name as u1, m.Name as movie, u2.Name as u2
                     ").ToList().Select(x => new
                     {
@@ -121,7 +121,7 @@ namespace SlowTests.Graph
                     var results = session.Advanced.RawQuery<JObject>(@"
                        match (Users as u1 where Name = 'A')-[HasRated select Movie]->(Movies as m)
                              AND
-                             (Users as u2 where Name = 'B')-[HasRated select Movie]->(Movies as m)
+                             (Users as u2 where Name = 'B')-[HasRated select Movie]->(m)
                        select u1.Name as u1, m.Name as movie, u2.Name as u2
                     ").ToList();
 
@@ -178,7 +178,7 @@ namespace SlowTests.Graph
                     var results = session.Advanced.RawQuery<JObject>(@"
                        match (Users as u1 where Name = 'A')-[HasRated select Movie]->(Movies as m)
                              AND
-                             (Users as u2 where Name = 'NON-EXISTENT')-[HasRated select Movie]->(Movies as m)
+                             (Users as u2 where Name = 'NON-EXISTENT')-[HasRated select Movie]->(m)
                        select u1.Name as u1, m.Name as movie, u2.Name as u2
                     ").ToList();
 
@@ -234,7 +234,7 @@ namespace SlowTests.Graph
                     var results = session.Advanced.RawQuery<JObject>(@"
                        match (Users as u1 where Name = 'NON-EXISTENT')-[HasRated select Movie]->(Movies as m)
                              AND
-                             (Users as u2 where Name = 'B')-[HasRated select Movie]->(Movies as m)
+                             (Users as u2 where Name = 'B')-[HasRated select Movie]->(m)
                        select u1.Name as u1, m.Name as movie, u2.Name as u2
                     ").ToList();
 
@@ -292,7 +292,7 @@ namespace SlowTests.Graph
                     var results = session.Advanced.RawQuery<JObject>(@"
                        match (Users as u1 where Name = 'A')-[HasRated select Movie]->(Movies as m)
                              AND NOT
-                             (Users as u2 where Name = 'B')-[HasRated select Movie]->(Movies as m)
+                             (Users as u2 where Name = 'B')-[HasRated select Movie]->(m)
                        select u1.Name as u1, m.Name as movie, u2.Name as u2
                     ").ToList();
 
@@ -350,7 +350,7 @@ namespace SlowTests.Graph
                     var results = session.Advanced.RawQuery<JObject>(@"
                        match (Users as u1 where Name = 'A')-[HasRated select Movie]->(Movies as m)
                              AND NOT
-                             (Users as u2 where Name = 'B')-[HasRated select Movie]->(Movies as m)
+                             (Users as u2 where Name = 'B')-[HasRated select Movie]->(m)
                        select u1.Name as u1, m.Name as movie, u2.Name as u2
                     ").ToList().Select(x => new
                     {
@@ -414,7 +414,7 @@ namespace SlowTests.Graph
                     var results = session.Advanced.RawQuery<JObject>(@"
                        match (Users as u1 where Name = 'A')-[HasRated select Movie]->(Movies as m)
                              AND NOT
-                             (Users as u2 where Name = 'NON-EXISTENT')-[HasRated select Movie]->(Movies as m)
+                             (Users as u2 where Name = 'NON-EXISTENT')-[HasRated select Movie]->(m)
                        select u1.Name as u1, m.Name as movie, u2.Name as u2
                     ").ToList().Select(x => new
                     {
@@ -480,7 +480,7 @@ namespace SlowTests.Graph
                     var results = session.Advanced.RawQuery<JObject>(@"
                        match (Users as u1 where Name = 'A')-[HasRated select Movie]->(Movies as m)
                              OR
-                             (Users as u2 where Name = 'B')-[HasRated select Movie]->(Movies as m)
+                             (Users as u2 where Name = 'B')-[HasRated select Movie]->(m)
                        select u1.Name as u1, m.Name as movie, u2.Name as u2
                     ").ToList().Select(x => new
                     {
@@ -548,7 +548,7 @@ namespace SlowTests.Graph
                     var results = session.Advanced.RawQuery<JObject>(@"
                        match (Users as u1 where Name = 'NON-EXISTENT')-[HasRated select Movie]->(Movies as m)
                              OR
-                             (Users as u2 where Name = 'B')-[HasRated select Movie]->(Movies as m)
+                             (Users as u2 where Name = 'B')-[HasRated select Movie]->(m)
                        select u1.Name as u1, m.Name as movie, u2.Name as u2
                     ").ToList().Select(x => new
                     {
@@ -614,7 +614,7 @@ namespace SlowTests.Graph
                     var results = session.Advanced.RawQuery<JObject>(@"
                        match (Users as u1 where Name = 'NON-EXISTENT')-[HasRated select Movie]->(Movies as m)
                              OR
-                             (Users as u2 where Name = 'NON-EXISTENT2')-[HasRated select Movie]->(Movies as m)
+                             (Users as u2 where Name = 'NON-EXISTENT2')-[HasRated select Movie]->(m)
                        select u1.Name as u1, m.Name as movie, u2.Name as u2
                     ").ToList();
 
@@ -672,7 +672,7 @@ namespace SlowTests.Graph
                     var results = session.Advanced.RawQuery<JObject>(@"
                        match (Users as u1 where Name = 'NON-EXISTENT')-[HasRated select Movie]->(Movies as m)
                              AND
-                             (Users as u2 where Name = 'NON-EXISTENT2')-[HasRated select Movie]->(Movies as m)
+                             (Users as u2 where Name = 'NON-EXISTENT2')-[HasRated select Movie]->(m)
                        select u1.Name as u1, m.Name as movie, u2.Name as u2
                     ").ToList();
 
@@ -730,7 +730,7 @@ namespace SlowTests.Graph
                     var results = session.Advanced.RawQuery<JObject>(@"
                        match (Users as u1 where Name = 'NON-EXISTENT')-[HasRated select Movie]->(Movies as m)
                              AND NOT
-                             (Users as u2 where Name = 'NON-EXISTENT2')-[HasRated select Movie]->(Movies as m)
+                             (Users as u2 where Name = 'NON-EXISTENT2')-[HasRated select Movie]->(m)
                        select u1.Name as u1, m.Name as movie, u2.Name as u2
                     ").ToList();
 
@@ -789,7 +789,7 @@ namespace SlowTests.Graph
                         session.Advanced.RawQuery<JObject>(@"
                            match (Users as u1 where Name = 'NON-EXISTENT')-[HasRated select Movie]->(Movies as m)
                                   FOOBAR 
-                                 (Users as u2 where Name = 'NON-EXISTENT2')-[HasRated select Movie]->(Movies as m)
+                                 (Users as u2 where Name = 'NON-EXISTENT2')-[HasRated select Movie]->(m)
                            select u1.Name as u1, m.Name as movie, u2.Name as u2
                         ").ToList());
                 }
@@ -844,7 +844,7 @@ namespace SlowTests.Graph
                     var results = session.Advanced.RawQuery<JObject>(@"
                        match (Users as u1 where Name = 'A')-[HasRated select Movie]->(Movies as m)
                              OR
-                             (Users as u2 where Name = 'NON-EXISTENT')-[HasRated select Movie]->(Movies as m)
+                             (Users as u2 where Name = 'NON-EXISTENT')-[HasRated select Movie]->(m)
                        select u1.Name as u1, m.Name as movie, u2.Name as u2
                     ").ToList().Select(x => new
                     {
@@ -871,7 +871,7 @@ namespace SlowTests.Graph
                 {
                     var results = session.Advanced.RawQuery<JObject>(@"
                        match(Users as u1)-[HasRated where Score > 1 select Movie]->(Movies as m where id() = 'movies/2')
-                         and (Users as u2)-[HasRated select Movie]->(Movies as m where id() = 'movies/2')
+                         and (Users as u2)-[HasRated select Movie]->(m)
                        select u1.Name as U1,u2.Name as U2
                     ").ToList().Select(x => new
                     {
@@ -897,7 +897,7 @@ namespace SlowTests.Graph
             {
                 CreateMoviesData(store);
                 using (var session = store.OpenSession())
-                {
+                {                  
                     var results = session.Advanced.RawQuery<JObject>(@"
                        match(Users as u1)-[HasRated where Score > 1 select Movie]->(Movies as m where id() = 'movies/2')<-[HasRated select Movie]-(Users as u2)                              
                        select u1.Name as U1,u2.Name as U2

--- a/test/SlowTests/Issues/RavenDB-12263.cs
+++ b/test/SlowTests/Issues/RavenDB-12263.cs
@@ -73,7 +73,7 @@ namespace SlowTests.Issues
                             -recursive as RecursiveLikes (all) 
                                 { [Likes as PathElement] -> 
                                     (Dogs as TravelStep)
-                                } -[Likes as PathElement] -> 
+                                } -[Likes] -> 
                                     (Dogs as TraversalDestination where id() = 'dogs/8')
                         select 
                         {

--- a/test/SlowTests/Issues/RavenDB-12397.cs
+++ b/test/SlowTests/Issues/RavenDB-12397.cs
@@ -36,12 +36,13 @@ namespace SlowTests.Issues
             using (var store = GetDocumentStore())
             {
                 CreateData(store);
+
                 using (var session = store.OpenSession())
                 {
                     var intersectionResults = session.Advanced.RawQuery<JObject>(
                         @"
                             match (Beers as beer)-[Style]->(BeerStyles as beerStyle) and
-                                  (Beers as beer)-[Brewery]->(Breweries as brewery)
+                                  (beer)-[Brewery]->(Breweries as brewery)
                         ").ToArray();
 
                     var unifiedIntersectionResults = session.Advanced.RawQuery<JObject>(
@@ -66,7 +67,7 @@ namespace SlowTests.Issues
                         @"
                             match 
                                   (Beers as beer)-[Style]->(BeerStyles as beerStyle) and
-                                  (Beers as anotherBeer)-[Style]->(BeerStyles as beerStyle)
+                                  (Beers as anotherBeer)-[Style]->(beerStyle)
                             where beer != anotherBeer
                         ").ToArray();
 
@@ -140,9 +141,9 @@ namespace SlowTests.Issues
                         @"
                             match 
                                 (Beers as anotherBeer)-[Brewery]->(Breweries as otherBrewery) and 
-                                (Beers as anotherBeer)-[Style]->(BeerStyles as beerStyle) and 
-                                (Beers as beer)-[Style]->(BeerStyles as beerStyle) and 
-                                (Beers as beer)-[Brewery]->(Breweries as brewery)
+                                (anotherBeer)-[Style]->(BeerStyles as beerStyle) and 
+                                (Beers as beer)-[Style]->(beerStyle) and 
+                                (beer)-[Brewery]->(Breweries as brewery)
                             where beer != anotherBeer
                         ").ToArray();
 

--- a/test/SlowTests/Issues/RavenDB-12468.cs
+++ b/test/SlowTests/Issues/RavenDB-12468.cs
@@ -68,7 +68,6 @@ namespace SlowTests.Issues
             using (var store = GetDocumentStore())
             {
                 CreateData(store);
-                WaitForUserToContinueTheTest(store);
                 using (var session = store.OpenSession())
                 {
                     var result = session.Advanced.RawQuery<JObject>(@"

--- a/test/SlowTests/Issues/RavenDB-12564.cs
+++ b/test/SlowTests/Issues/RavenDB-12564.cs
@@ -1,0 +1,107 @@
+﻿using System;
+using System.Linq;
+using FastTests;
+using Newtonsoft.Json.Linq;
+using Raven.Client.Exceptions;
+using Xunit;
+
+namespace SlowTests.Issues
+{
+    public class RavenDB_12564 : RavenTestBase
+    {
+        [Fact]
+        public void Should_implicitly_define_aliases_on_nodes_with_just_collections()
+        {
+            using (var store = GetDocumentStore())
+            {
+                CreateNorthwindDatabase(store);
+                using (var session = store.OpenSession())
+                {
+                    var results = session.Advanced.RawQuery<JObject>(@"match (Employees)-[ReportsTo]->(Employees)").ToArray();
+
+                    Assert.NotEmpty(results); //sanity check
+                    Assert.Equal(4, results[0].Count); // from, edge, to and @metadata
+                }
+            }
+        }
+
+        [Fact]
+        public void Should_conflict_on_implicitly_defined_aliases_on_nodes_with_just_collections()
+        {
+            using (var store = GetDocumentStore())
+            {
+                CreateNorthwindDatabase(store);
+                using (var session = store.OpenSession())
+                {
+                    var e = Assert.Throws<InvalidQueryException>(() =>
+                        session.Advanced.RawQuery<JObject>(@"match (Employees)-[ReportsTo]->(Employees)-[ReportsTo]->(Employees as Employees_2)").ToArray());
+
+                    Assert.True(e.Message.Contains("implicit",StringComparison.OrdinalIgnoreCase));
+                    Assert.True(e.Message.Contains("redefinition",StringComparison.OrdinalIgnoreCase));
+                    Assert.True(e.Message.Contains("alias",StringComparison.OrdinalIgnoreCase));
+                    Assert.True(e.Message.Contains("Employees_2",StringComparison.OrdinalIgnoreCase));                    
+                }
+            }
+        }
+
+        
+        [Fact]
+        public void Should_conflict_on_implicitly_defined_aliases_on_edges()
+        {
+            using (var store = GetDocumentStore())
+            {
+                CreateNorthwindDatabase(store);
+                using (var session = store.OpenSession())
+                {
+                    var e = Assert.Throws<InvalidQueryException>(() =>
+                        session.Advanced.RawQuery<JObject>(@"match (Employees)-[ReportsTo]->(Employees)-[ReportsTo as Employees_ReportsTo]->(Employees)").ToArray());
+
+                    Assert.True(e.Message.Contains("implicit",StringComparison.OrdinalIgnoreCase));
+                    Assert.True(e.Message.Contains("redefinition",StringComparison.OrdinalIgnoreCase));
+                    Assert.True(e.Message.Contains("alias",StringComparison.OrdinalIgnoreCase));
+                    Assert.True(e.Message.Contains("Employees_ReportsTo",StringComparison.OrdinalIgnoreCase));                    
+                }
+            }
+        }
+
+        [Fact]
+        public void Should_throw_when_query_without_recursive_has_duplicate_aliases()
+        {
+            using (var store = GetDocumentStore())
+            {
+                CreateDogDataWithCycle(store);
+
+                using (var session = store.OpenSession())
+                {
+                    var e = Assert.Throws<InvalidQueryException>(() => session.Advanced.RawQuery<JObject>(@"
+                        match (Dogs as d2)-[Likes]->(Dogs as d2)-[Likes]->(d2)").ToArray());
+                    
+                    Assert.False(e.Message.Contains("implicit",StringComparison.OrdinalIgnoreCase));
+                    Assert.True(e.Message.Contains("duplicate",StringComparison.OrdinalIgnoreCase));
+                    Assert.True(e.Message.Contains("alias",StringComparison.OrdinalIgnoreCase));
+                }
+            }
+
+        }
+
+        [Fact]
+        public void Should_throw_when_query_has_the_same_aliases_inside_and_outside_recursive()
+        {
+            using (var store = GetDocumentStore())
+            {
+                CreateDogDataWithCycle(store);
+
+                using (var session = store.OpenSession())
+                {
+                    var e = Assert.Throws<InvalidQueryException>(() => session.Advanced.RawQuery<JObject>(@"
+                        match (Dogs as d2)-recursive as r { [Likes as l] ->(Dogs as d2) }
+                        select d2.Name as dogName, r.l.Name as l, r.d2.Name as DogName2            ").ToArray());
+                    
+                    Assert.False(e.Message.Contains("implicit",StringComparison.OrdinalIgnoreCase));
+                    Assert.True(e.Message.Contains("duplicate",StringComparison.OrdinalIgnoreCase));
+                    Assert.True(e.Message.Contains("alias",StringComparison.OrdinalIgnoreCase));
+                }
+            }
+        }
+    }
+}

--- a/test/SlowTests/Issues/RavenDB-12638.cs
+++ b/test/SlowTests/Issues/RavenDB-12638.cs
@@ -53,8 +53,9 @@ namespace SlowTests.Issues
                 {
                    var e = Assert.Throws<InvalidQueryException>(() => session.Advanced.RawQuery<JObject>(
                         @"match (Employees as e) 
-                            -recursive as r1 { [ReportsTo]->(Employees as manager) }
-                            -recursive as r2 { [ReportsTo]->(Employees as manager) }").ToList());
+                            -recursive as r1 { [ReportsTo]->(Employees as m1) }
+                            -recursive as r2 { [ReportsTo]->(Employees as m2) }").ToList());
+
                     Assert.True(e.Message.Contains("recursive") && e.Message.Contains("adjacent"));
                 }
             }

--- a/test/SlowTests/Issues/RavenDB-12638.cs
+++ b/test/SlowTests/Issues/RavenDB-12638.cs
@@ -33,8 +33,8 @@ namespace SlowTests.Issues
                 {
                     var results = session.Advanced.RawQuery<JObject>(
                         @"match (Employees as e) 
-                            -recursive as r1 { [ReportsTo]->(Employees as manager) }-[ReportsTo]->(Employees as manager)
-                            -recursive as r2 { [ReportsTo]->(Employees as manager) }").ToList();
+                            -recursive as r1 { [ReportsTo]->(Employees as manager) }-[ReportsTo]->(Employees as finalManager)
+                            -recursive as r2 { [ReportsTo]->(Employees as manager2) }").ToList();
 
                     Assert.Equal(7, results.Count);
                 }


### PR DESCRIPTION
* Throw with informative errors on duplicate aliases in graph queries. Also throw on alias duplication if some of the aliases are inside a recursive clause - so we won't have duplicate aliases both in and out of recursive clauses.
* Make sure to throw with informative errors if we duplicate the implicit aliases as well
* Fix tests that had duplicate aliases in their queries