### PR TITLE
RavenDB-12745 - Environment variables aren't being loaded when running Xunit in Debug

### DIFF
--- a/src/Raven.Server/Config/RavenConfiguration.cs
+++ b/src/Raven.Server/Config/RavenConfiguration.cs
@@ -464,7 +464,7 @@ namespace Raven.Server.Config
 
             public override void Load()
             {
-                Data = new Dictionary<string, string>();
+                Data = new Dictionary<string, string>(StringComparer.OrdinalIgnoreCase);
 
                 var envs = Environment.GetEnvironmentVariables().Cast<DictionaryEntry>();
                 foreach (var env in envs)


### PR DESCRIPTION
https://issues.hibernatingrhinos.com/issue/RavenDB-12745