### PR TITLE
fix for RavenDB-12678

### DIFF
--- a/src/Raven.Server/Documents/Queries/AST/FieldExpression.cs
+++ b/src/Raven.Server/Documents/Queries/AST/FieldExpression.cs
@@ -40,16 +40,16 @@ namespace Raven.Server.Documents.Queries.AST
         {
             if (Compound.Count == 1)
                 return Compound[0].Value;
-            return _field ?? (_field = JoinCompoundFragments(0, ignoreArrayQualifier));
+            return _field ?? (_field = JoinCompoundFragments(0));
         }
 
 
-        private string JoinCompoundFragments(int start, bool ignoreArrayQualifier = false)
+        private string JoinCompoundFragments(int start)
         {
             var sb = new StringBuilder();
             for (int i = start; i < Compound.Count; i++)
             {
-                if(ignoreArrayQualifier && Compound[i].Value == "[]")
+                if(i == start && Compound[i].Value == "[]") //field name starting from '[]' makes no sense
                     continue;
                 sb.Append(Compound[i].Value);
                 if (i + 1 < Compound.Count && Compound[i + 1] != "[]")
@@ -61,7 +61,7 @@ namespace Raven.Server.Documents.Queries.AST
         }
 
         public string FieldValueWithoutAlias => 
-            _fieldWithoutAlias ?? (_fieldWithoutAlias = JoinCompoundFragments(1,true));
+            _fieldWithoutAlias ?? (_fieldWithoutAlias = JoinCompoundFragments(1));
 
         public override string ToString()
         {

--- a/src/Raven.Server/Documents/Queries/AST/FieldExpression.cs
+++ b/src/Raven.Server/Documents/Queries/AST/FieldExpression.cs
@@ -20,6 +20,20 @@ namespace Raven.Server.Documents.Queries.AST
             Type = ExpressionType.Field;
         }
 
+        public bool HasCollectionOperator
+        {
+            get
+            {
+                for (int i = 1; i < Compound.Count; i++)
+                {
+                    if (Compound[i] == "[]")
+                        return true;
+                }
+
+                return false;
+            }
+        }
+
         public string FieldValue
         {
             get
@@ -37,6 +51,8 @@ namespace Raven.Server.Documents.Queries.AST
             var sb = new StringBuilder();
             for (int i = start; i < Compound.Count; i++)
             {
+                if(Compound[i].Value == "[]")
+                    continue;
                 sb.Append(Compound[i].Value);
                 if (i + 1 < Compound.Count && Compound[i + 1] != "[]")
                 {
@@ -46,16 +62,8 @@ namespace Raven.Server.Documents.Queries.AST
             return sb.ToString();
         }
 
-
-        public string FieldValueWithoutAlias
-        {
-            get
-            {
-                if (_fieldWithoutAlias == null)
-                    _fieldWithoutAlias = JoinCompoundFragments(1);
-                return _fieldWithoutAlias;
-            }
-        }
+        public string FieldValueWithoutAlias => 
+            _fieldWithoutAlias ?? (_fieldWithoutAlias = JoinCompoundFragments(1));
 
         public override string ToString()
         {

--- a/src/Raven.Server/Documents/Queries/AST/FieldExpression.cs
+++ b/src/Raven.Server/Documents/Queries/AST/FieldExpression.cs
@@ -34,24 +34,22 @@ namespace Raven.Server.Documents.Queries.AST
             }
         }
 
-        public string FieldValue
+        public string FieldValue => GetFieldValue(false);
+
+        private string GetFieldValue(bool ignoreArrayQualifier)
         {
-            get
-            {
-                if (Compound.Count == 1)
-                    return Compound[0].Value;
-                if (_field == null)
-                    _field = JoinCompoundFragments(0);
-                return _field;
-            }
+            if (Compound.Count == 1)
+                return Compound[0].Value;
+            return _field ?? (_field = JoinCompoundFragments(0, ignoreArrayQualifier));
         }
 
-        private string JoinCompoundFragments(int start)
+
+        private string JoinCompoundFragments(int start, bool ignoreArrayQualifier = false)
         {
             var sb = new StringBuilder();
             for (int i = start; i < Compound.Count; i++)
             {
-                if(Compound[i].Value == "[]")
+                if(ignoreArrayQualifier && Compound[i].Value == "[]")
                     continue;
                 sb.Append(Compound[i].Value);
                 if (i + 1 < Compound.Count && Compound[i + 1] != "[]")
@@ -63,7 +61,7 @@ namespace Raven.Server.Documents.Queries.AST
         }
 
         public string FieldValueWithoutAlias => 
-            _fieldWithoutAlias ?? (_fieldWithoutAlias = JoinCompoundFragments(1));
+            _fieldWithoutAlias ?? (_fieldWithoutAlias = JoinCompoundFragments(1,true));
 
         public override string ToString()
         {

--- a/src/Raven.Server/Documents/Queries/FieldsToFetch.cs
+++ b/src/Raven.Server/Documents/Queries/FieldsToFetch.cs
@@ -54,11 +54,13 @@ namespace Raven.Server.Documents.Queries
         {
             selectFieldKey = selectField.Alias ?? selectField.Name;
             var selectFieldName = selectField.Name;
+
             if (selectField.ValueTokenType != null)
             {
                 return new FieldToFetch(string.Empty, selectField, selectField.Alias,
                     canExtractFromIndex: false, isDocumentId: false);
             }
+
             if (selectField.Function != null)
             {
                 var fieldToFetch = new FieldToFetch(selectField.Name, selectField, selectField.Alias,
@@ -68,7 +70,7 @@ namespace Raven.Server.Documents.Queries
                 };
                 for (int j = 0; j < selectField.FunctionArgs.Length; j++)
                 {
-                    bool ignored = false;
+                    var ignored = false;
                     fieldToFetch.FunctionArgs[j] = GetFieldToFetch(indexDefinition,
                         selectField.FunctionArgs[j],
                         null,
@@ -110,10 +112,12 @@ namespace Raven.Server.Documents.Queries
                     return new FieldToFetch(selectFieldKey, selectField.GroupByKeyNames);
                 }
             }
+
             if (indexDefinition == null)
             {
                 return new FieldToFetch(selectFieldName, selectField, selectField.Alias, canExtractFromIndex: false, isDocumentId: false);
             }
+
             if (selectFieldName.Value.Length > 0)
             {
                 if (selectFieldName == Constants.Documents.Indexing.Fields.DocumentIdFieldName)

--- a/src/Raven.Server/Documents/Queries/GraphQueryRunner.cs
+++ b/src/Raven.Server/Documents/Queries/GraphQueryRunner.cs
@@ -143,6 +143,7 @@ namespace Raven.Server.Documents.Queries
                     }
                     else if (q.Select != null)
                     {
+                        //TODO : investigate fields to fetch
                         var fieldsToFetch = new FieldsToFetch(query.Metadata.SelectFields, null);
                         idc = new IncludeDocumentsCommand(Database.DocumentsStorage, documentsContext, query.Metadata.Includes, fieldsToFetch.IsProjection);
 

--- a/test/SlowTests/Issues/RavenDB-12678.cs
+++ b/test/SlowTests/Issues/RavenDB-12678.cs
@@ -1,0 +1,169 @@
+﻿using System;
+using System.Linq;
+using FastTests;
+using Newtonsoft.Json.Linq;
+using Raven.Client.Exceptions;
+using Xunit;
+
+namespace SlowTests.Issues
+{
+    public class RavenDB_12678 : RavenTestBase
+    {
+        [Fact]
+        public void Recursive_alias_without_select_should_work()
+        {
+            using (var store = GetDocumentStore())
+            {
+                CreateNorthwindDatabase(store);
+                using (var session = store.OpenSession())
+                {
+                    var results = session.Advanced.RawQuery<JObject>(@"
+                        match (Employees as e)- recursive as r (all) { [ReportsTo]->(Employees as m) }
+                    ").ToArray();
+
+                    //this is sanity check, the real "assert" is that the query above does not throw
+                    Assert.NotEmpty(results);
+                    Assert.True(results[0].ContainsKey("r"));
+                }
+            }
+        }
+
+        [Fact]
+        public void Recursive_alias_in_select_should_work()
+        {
+            using (var store = GetDocumentStore())
+            {
+                CreateNorthwindDatabase(store);
+                using (var session = store.OpenSession())
+                {
+                    var results = session.Advanced.RawQuery<JObject>(@"
+                        match (Employees as e)- recursive as r (all) { [ReportsTo]->(Employees as m) }
+                        select id(e), r
+                    ").ToArray();
+
+                    //this is sanity check, the real "assert" is that the query above does not throw
+                    Assert.NotEmpty(results);
+                    Assert.True(results[0].ContainsKey("r"));
+                }
+            }
+        }
+
+
+        [Fact]
+        public void Duplicate_function_calls_have_proper_error_message()
+        {
+            using (var store = GetDocumentStore())
+            {
+                CreateNorthwindDatabase(store);
+                using (var session = store.OpenSession())
+                {
+                    var e = Assert.Throws<InvalidQueryException>(() => session.Advanced.RawQuery<JObject>(@"
+                        match (Employees as e)-[ReportsTo]->(Employees as m)
+                        select id(e), id(m)
+                    ").ToArray());
+
+                    Assert.True(e.Message.Contains("duplicate", StringComparison.InvariantCultureIgnoreCase));
+                    Assert.True(e.Message.Contains("id", StringComparison.InvariantCultureIgnoreCase));
+                    Assert.True(e.Message.Contains("function", StringComparison.InvariantCultureIgnoreCase));
+                }
+            }
+        }
+
+        [Fact]
+        public void Alias_of_node_inside_recursive_clause_in_select_should_work()
+        {
+            using (var store = GetDocumentStore())
+            {
+                CreateNorthwindDatabase(store);
+                using (var session = store.OpenSession())
+                {
+                    var results = session.Advanced.RawQuery<JObject>(@"
+                        match (Employees as e)- recursive as r (all) { [ReportsTo]->(Employees as m) }
+                        select id(e), r.m
+                    ").ToArray();
+
+                    //this is sanity check, the real "assert" is that the query above does not throw
+                    Assert.NotEmpty(results);
+                    Assert.True(results[0].ContainsKey("m"));
+                }
+            }
+        }
+
+        [Fact]
+        public void Alias_of_node_inside_recursive_clause_with_indexer_token_on_recursive_alias_in_select_should_work()
+        {
+            using (var store = GetDocumentStore())
+            {
+                CreateNorthwindDatabase(store);
+                using (var session = store.OpenSession())
+                {
+                    var expectedResults = session.Advanced.RawQuery<JObject>(@"
+                        match (Employees as e)- recursive as r (all) { [ReportsTo]->(Employees as m) }
+                        select id(e), r.m
+                    ").ToArray();
+
+                    var results = session.Advanced.RawQuery<JObject>(@"
+                        match (Employees as e)- recursive as r (all) { [ReportsTo]->(Employees as m) }
+                        select id(e), r[].m
+                    ").ToArray();
+
+                    //this is sanity check, the real "assert" is that the query above does not throw
+                    Assert.NotEmpty(results);
+                    Assert.Equal(expectedResults, results);
+                }
+            }
+        }
+
+        [Fact]
+        public void Make_sure_invalid_recursive_alias_qualifier_throws_properly()
+        {
+            using (var store = GetDocumentStore())
+            {
+                CreateNorthwindDatabase(store);
+                using (var session = store.OpenSession())
+                {
+                    var e = Assert.Throws<InvalidQueryException>(() => session.Advanced.RawQuery<JObject>(@"
+                        match (Employees as e)- recursive as r[ (all) { [ReportsTo]->(Employees as m) }
+                        select id(e), r[].m
+                    ").ToArray());
+
+                    Assert.True(e.Message.Contains("expected", StringComparison.InvariantCultureIgnoreCase));
+                    Assert.True(e.Message.Contains("'['", StringComparison.InvariantCultureIgnoreCase));
+
+                    e = Assert.Throws<InvalidQueryException>(() => session.Advanced.RawQuery<JObject>(@"
+                        match (Employees as e)- recursive as r] (all) { [ReportsTo]->(Employees as m) }
+                        select id(e), r[].m
+                    ").ToArray());
+
+                    Assert.True(e.Message.Contains("expected", StringComparison.InvariantCultureIgnoreCase));
+                    Assert.True(e.Message.Contains("']'", StringComparison.InvariantCultureIgnoreCase));
+                }
+            }
+        }
+
+        [Fact]
+        public void Alias_of_node_inside_recursive_clause_with_indexer_token_on_recursive_alias_and_on_alias_in_select_should_work()
+        {
+            using (var store = GetDocumentStore())
+            {
+                CreateNorthwindDatabase(store);
+                using (var session = store.OpenSession())
+                {                    
+                    var expectedResults = session.Advanced.RawQuery<JObject>(@"
+                        match (Employees as e)- recursive as r (all) { [ReportsTo]->(Employees as m) }
+                        select id(e), r.m
+                    ").ToArray();
+
+                    var results = session.Advanced.RawQuery<JObject>(@"
+                        match (Employees as e)- recursive as r[] (all) { [ReportsTo]->(Employees as m) }
+                        select id(e), r[].m
+                    ").ToArray();
+
+                    //this is sanity check, the real "assert" is that the query above does not throw
+                    Assert.NotEmpty(results);
+                    Assert.Equal(expectedResults, results);
+                }
+            }
+        }    
+    }
+}


### PR DESCRIPTION
* Implicitly generate alias for function calls in non-javascript SELECT clauses (prevent NREs)
* Properly support array qualifier on aliases of recursive clauses (also handle couple of edge cases)