### PR TITLE
RavenDB-12754: Prevent resize of compression pager when not needed

### DIFF
--- a/src/Voron/Impl/Journal/WriteAheadJournal.cs
+++ b/src/Voron/Impl/Journal/WriteAheadJournal.cs
@@ -1725,16 +1725,13 @@ namespace Voron.Impl.Journal
             if ((DateTime.UtcNow - _lastCompressionBufferReduceCheck).TotalMinutes < 5)
                 return false;
 
-            if (_maxNumberOfPagesRequiredForCompressionBuffer > _compressionPager.NumberOfAllocatedPages / 2)
-            {
-                // we recently used at least half of the compression buffer,
-                // no point in reducing size yet, we'll try to do it again next time
-                return false;
-            }
+            
+            // prevent resize if we recently used at least half of the compression buffer
+            var preventResize = _maxNumberOfPagesRequiredForCompressionBuffer > _compressionPager.NumberOfAllocatedPages / 2;
 
             _maxNumberOfPagesRequiredForCompressionBuffer = 0;
             _lastCompressionBufferReduceCheck = DateTime.UtcNow;
-            return true;
+            return !preventResize;
         }
 
         public void TryReduceSizeOfCompressionBufferIfNeeded()

--- a/src/Voron/Impl/Journal/WriteAheadJournal.cs
+++ b/src/Voron/Impl/Journal/WriteAheadJournal.cs
@@ -1725,11 +1725,11 @@ namespace Voron.Impl.Journal
             if ((DateTime.UtcNow - _lastCompressionBufferReduceCheck).TotalMinutes < 5)
                 return false;
 
-            if (_maxNumberOfPagesRequiredForCompressionBuffer < _compressionPager.NumberOfAllocatedPages / 2)
+            if (_maxNumberOfPagesRequiredForCompressionBuffer > _compressionPager.NumberOfAllocatedPages / 2)
             {
                 // we recently used at least half of the compression buffer,
                 // no point in reducing size yet, we'll try to do it again next time
-                return true;
+                return false;
             }
 
             _maxNumberOfPagesRequiredForCompressionBuffer = 0;

--- a/src/Voron/Impl/Journal/WriteAheadJournal.cs
+++ b/src/Voron/Impl/Journal/WriteAheadJournal.cs
@@ -1682,8 +1682,8 @@ namespace Voron.Impl.Journal
 
         public void ReduceSizeOfCompressionBufferIfNeeded(bool forceReduce = false)
         {
-            var initialSize = _env.Options.InitialFileSize ?? _env.Options.InitialLogFileSize;
-            if (ShouldReduceSizeOfCompressionPager(initialSize, forceReduce) == false)
+            var maxSize = _env.Options.MaxScratchBufferSize;
+            if (ShouldReduceSizeOfCompressionPager(maxSize, forceReduce) == false)
                 return;
 
             // the compression pager is too large, we probably had a big transaction and now can
@@ -1691,15 +1691,15 @@ namespace Voron.Impl.Journal
             if (forceReduce == false && _logger.IsOperationsEnabled)
             {
                 _logger.Operations(
-                    $"Compression buffer: {_compressionPager} has reached size {new Size(_compressionPager.NumberOfAllocatedPages * Constants.Storage.PageSize, SizeUnit.Bytes)} which is more than the initial size " +
-                    $"of {new Size(initialSize, SizeUnit.Bytes)}. Will trim it now to the max size allowed. If this is happen on a regular basis," +
+                    $"Compression buffer: {_compressionPager} has reached size {new Size(_compressionPager.NumberOfAllocatedPages * Constants.Storage.PageSize, SizeUnit.Bytes)} which is more than the maximum size " +
+                    $"of {new Size(maxSize, SizeUnit.Bytes)}. Will trim it now to the max size allowed. If this is happen on a regular basis," +
                     " consider raising the limit (MaxScratchBufferSize option control it), since it can cause performance issues");
             }
 
             _lastCompressionBufferReduceCheck = DateTime.UtcNow;
 
             _compressionPager.Dispose();
-            _compressionPager = CreateCompressionPager(initialSize);
+            _compressionPager = CreateCompressionPager(maxSize);
         }
 
         public void ZeroCompressionBufferIfNeeded(IPagerLevelTransactionState tx)
@@ -1713,10 +1713,10 @@ namespace Voron.Impl.Journal
             Sodium.sodium_memzero(pagePointer, (UIntPtr)compressionBufferSize);
         }
 
-        private bool ShouldReduceSizeOfCompressionPager(long initialSize, bool forceReduce)
+        private bool ShouldReduceSizeOfCompressionPager(long maxSize, bool forceReduce)
         {
             var compressionBufferSize = _compressionPager.NumberOfAllocatedPages * Constants.Storage.PageSize;
-            if (compressionBufferSize <= initialSize)
+            if (compressionBufferSize <= maxSize)
                 return false;
 
             if (forceReduce)
@@ -1724,7 +1724,6 @@ namespace Voron.Impl.Journal
 
             if ((DateTime.UtcNow - _lastCompressionBufferReduceCheck).TotalMinutes < 5)
                 return false;
-
             
             // prevent resize if we recently used at least half of the compression buffer
             var preventResize = _maxNumberOfPagesRequiredForCompressionBuffer > _compressionPager.NumberOfAllocatedPages / 2;


### PR DESCRIPTION
The compression pager is reduced in size even when it is not needed. 

As far as I understood, the lines of code I have changed should prevent a resize if the max used pages by the buffer are close to the number of already allocated pages to prevent expensive reallocations. 

They did not so far, as a `return true` resizes the buffer; and as the default return also returned `true`. I changed this behaviour to reflect the behaviour described in the already existing comment.