### PR TITLE
RavenDB-12725 Check sum issue

### DIFF
--- a/src/Voron/Constants.cs
+++ b/src/Voron/Constants.cs
@@ -8,7 +8,7 @@ namespace Voron.Global
 {
     public unsafe class Constants
     {
-        public const int CurrentVersion = 22;
+        public const int CurrentVersion = 23;
 
         public const ulong MagicMarker = 0xB16BAADC0DEF0015;
         public const ulong TransactionHeaderMarker = 0x1A4C92AD90ABC123;

--- a/src/Voron/Exceptions/InvalidJournalException.cs
+++ b/src/Voron/Exceptions/InvalidJournalException.cs
@@ -1,4 +1,5 @@
 ﻿using System;
+using Voron.Impl.Journal;
 
 namespace Voron.Exceptions
 {
@@ -6,12 +7,20 @@ namespace Voron.Exceptions
     {
         public long Number { get; }
 
-        public InvalidJournalException(long number, string path) : base($"No such journal '{path}'")
+        public InvalidJournalException(long number, string path, JournalInfo journalInfo) : base($"No such journal '{path}'. Journal details: " +
+                                                                                                 $"{nameof(journalInfo.CurrentJournal)} - {journalInfo.CurrentJournal}, " +
+                                                                                                 $"{nameof(journalInfo.LastSyncedJournal)} - {journalInfo.LastSyncedJournal}, " +
+                                                                                                 $"{nameof(journalInfo.LastSyncedTransactionId)} - {journalInfo.LastSyncedTransactionId}" +
+                                                                                                 $"{nameof(journalInfo.Flags)} - {journalInfo.Flags}")
         {
             Number = number;
         }
 
-        public InvalidJournalException(long number) : base($"No such journal '{number}'")
+        public InvalidJournalException(long number, JournalInfo journalInfo) : base($"No such journal '{number}'. Journal details: " +
+                                                                                    $"{nameof(journalInfo.CurrentJournal)} - {journalInfo.CurrentJournal}, " +
+                                                                                    $"{nameof(journalInfo.LastSyncedJournal)} - {journalInfo.LastSyncedJournal}, " +
+                                                                                    $"{nameof(journalInfo.LastSyncedTransactionId)} - {journalInfo.LastSyncedTransactionId}" +
+                                                                                    $"{nameof(journalInfo.Flags)} - {journalInfo.Flags}")
         {
             Number = number;
         }

--- a/src/Voron/Exceptions/VoronUnrecoverableErrorException.cs
+++ b/src/Voron/Exceptions/VoronUnrecoverableErrorException.cs
@@ -18,7 +18,8 @@ namespace Voron.Exceptions
             {
                 var lastTxState = tx.GetTxState();
                 tx.MarkTransactionAsFailed();
-                throw new VoronUnrecoverableErrorException($"{message}. LastTxState: {lastTxState}");
+                throw new VoronUnrecoverableErrorException($"{message}. LastTxState: {lastTxState}"
+                    + Environment.NewLine + " @ " + tx.Environment.Options.DataPager.FileName.FullPath);
             }
             catch (Exception e)
             {
@@ -30,7 +31,7 @@ namespace Voron.Exceptions
         {
             try
             {
-                throw new VoronUnrecoverableErrorException(message);
+                throw new VoronUnrecoverableErrorException(message + Environment.NewLine + " @ " + env.Options.DataPager.FileName.FullPath);
             }
             catch (Exception e)
             {
@@ -43,7 +44,8 @@ namespace Voron.Exceptions
         {
             try
             {
-                throw new VoronUnrecoverableErrorException(message);
+                throw new VoronUnrecoverableErrorException(message
+                    + Environment.NewLine + " @ " + options.DataPager.FileName.FullPath);
             }
             catch (Exception e)
             {
@@ -56,7 +58,8 @@ namespace Voron.Exceptions
         {
             try
             {
-                throw new VoronUnrecoverableErrorException(message, inner);
+                throw new VoronUnrecoverableErrorException(message
+                    + Environment.NewLine + " @ " + env.Options.DataPager.FileName.FullPath, inner);
             }
             catch (Exception e)
             {
@@ -69,7 +72,8 @@ namespace Voron.Exceptions
         {
             try
             {
-                throw new VoronUnrecoverableErrorException(message, inner);
+                throw new VoronUnrecoverableErrorException(message
+                    + Environment.NewLine + " @ " + options.DataPager.FileName.FullPath, inner);
             }
             catch (Exception e)
             {

--- a/src/Voron/Impl/Backup/FullBackup.cs
+++ b/src/Voron/Impl/Backup/FullBackup.cs
@@ -81,8 +81,8 @@ namespace Voron.Impl.Backup
         }
 
         private static void Backup(
-            StorageEnvironment env, CompressionLevel compression, AbstractPager dataPager, 
-            ZipArchive package, string basePath, DataCopier copier, 
+            StorageEnvironment env, CompressionLevel compression, AbstractPager dataPager,
+            ZipArchive package, string basePath, DataCopier copier,
             Action<(string Message, int FilesCount)> infoNotify,
             CancellationToken cancellationToken = default)
         {
@@ -110,7 +110,15 @@ namespace Voron.Impl.Backup
                     var files = env.Journal.Files; // thread safety copy
 
                     JournalInfo journalInfo = env.HeaderAccessor.Get(ptr => ptr->Journal);
-                    for (var journalNum = journalInfo.CurrentJournal - journalInfo.JournalFilesCount + 1;
+                    var startingJournal = journalInfo.LastSyncedJournal;
+                    if (env.Options.JournalExists(startingJournal) == false && 
+                        journalInfo.Flags.HasFlag(JournalInfoFlags.IgnoreMissingLastSyncJournal) || 
+                        startingJournal == -1)
+                    {
+                        startingJournal++;
+                    }
+
+                    for (var journalNum = startingJournal;
                         journalNum <= journalInfo.CurrentJournal;
                         journalNum++)
                     {
@@ -121,7 +129,7 @@ namespace Voron.Impl.Backup
                         if (journalFile == null)
                         {
                             long journalSize;
-                            using (var pager = env.Options.OpenJournalPager(journalNum))
+                            using (var pager = env.Options.OpenJournalPager(journalNum, journalInfo))
                             {
                                 journalSize = Bits.NextPowerOf2(pager.NumberOfAllocatedPages * Constants.Storage.PageSize);
                             }

--- a/src/Voron/Impl/Journal/JournalInfo.cs
+++ b/src/Voron/Impl/Journal/JournalInfo.cs
@@ -4,23 +4,36 @@
 //  </copyright>
 // -----------------------------------------------------------------------
 
+using System;
 using System.Runtime.InteropServices;
 
 namespace Voron.Impl.Journal
 {
-	[StructLayout(LayoutKind.Explicit, Pack = 1)]
-	public struct JournalInfo
-	{
-		[FieldOffset(0)]
-		public long CurrentJournal;
+    [StructLayout(LayoutKind.Explicit, Pack = 1)]
+    public unsafe struct JournalInfo
+    {
+        public const int NumberOfReservedBytes = 3;
 
-		[FieldOffset(8)]
-		public long LastSyncedJournal;
+        [FieldOffset(0)]
+        public long CurrentJournal;
 
-		[FieldOffset(16)]
-		public long LastSyncedTransactionId;
+        [FieldOffset(8)]
+        public long LastSyncedJournal;
+
+        [FieldOffset(16)]
+        public long LastSyncedTransactionId;
 
         [FieldOffset(24)]
-        public int JournalFilesCount;
+        public fixed byte Reserved[NumberOfReservedBytes];
+
+        [FieldOffset(27)]
+        public JournalInfoFlags Flags;
+    }
+
+    [Flags]
+    public enum JournalInfoFlags : byte
+    {
+        None = 0,
+        IgnoreMissingLastSyncJournal = 1
     }
 }

--- a/src/Voron/Impl/Journal/WriteAheadJournal.cs
+++ b/src/Voron/Impl/Journal/WriteAheadJournal.cs
@@ -41,7 +41,6 @@ namespace Voron.Impl.Journal
         private long _journalIndex = -1;
 
         private readonly JournalApplicator _journalApplicator;
-        private readonly ModifyHeaderAction _updateLogInfo;
 
         private ImmutableAppendOnlyList<JournalFile> _files = ImmutableAppendOnlyList<JournalFile>.Empty;
         internal JournalFile CurrentFile;
@@ -70,14 +69,6 @@ namespace Voron.Impl.Journal
             _dataPager = _env.Options.DataPager;
             _currentJournalFileSize = env.Options.InitialLogFileSize;
             _headerAccessor = env.HeaderAccessor;
-            _updateLogInfo = header =>
-            {
-                var journalFilesCount = _files.Count;
-                var currentJournal = journalFilesCount > 0 ? _journalIndex : -1;
-                header->Journal.CurrentJournal = currentJournal;
-                header->Journal.JournalFilesCount = journalFilesCount;
-                header->IncrementalBackup.LastCreatedJournal = _journalIndex;
-            };
 
             _compressionPager = CreateCompressionPager(_env.Options.InitialFileSize ?? _env.Options.InitialLogFileSize);
             _journalApplicator = new JournalApplicator(this);
@@ -143,7 +134,11 @@ namespace Voron.Impl.Journal
 
             _files = _files.Append(journal);
 
-            _headerAccessor.Modify(_updateLogInfo);
+            _headerAccessor.Modify(header=>
+            {
+                header->Journal.CurrentJournal = journal.Number;
+                header->IncrementalBackup.LastCreatedJournal = journal.Number;
+            });
 
             return journal;
         }
@@ -156,18 +151,11 @@ namespace Voron.Impl.Journal
 
             var logInfo = _headerAccessor.Get(ptr => ptr->Journal);
 
-            if (logInfo.JournalFilesCount == 0)
-            {
-                _journalIndex = logInfo.LastSyncedJournal;
-                return false;
-            }
-
-            var oldestLogFileStillInUse = logInfo.CurrentJournal - logInfo.JournalFilesCount + 1;
             if (_env.Options.IncrementalBackupEnabled == false && _env.Options.CopyOnWriteMode == false)
             {
                 // we want to check that we cleanup old log files if they aren't needed
                 // this is more just to be safe than anything else, they shouldn't be there.
-                var unusedfiles = oldestLogFileStillInUse;
+                var unusedfiles = logInfo.LastSyncedJournal;
                 while (true)
                 {
                     unusedfiles--;
@@ -176,26 +164,32 @@ namespace Voron.Impl.Journal
                 }
             }
 
-            var lastSyncedTransactionId = logInfo.LastSyncedTransactionId;
-
-
             var modifiedPages = new HashSet<long>();
 
             var journalFiles = new List<JournalFile>();
-            long lastSyncedTxId = -1;
-            long lastSyncedJournal = logInfo.LastSyncedJournal;
-            for (var journalNumber = oldestLogFileStillInUse; journalNumber <= logInfo.CurrentJournal; journalNumber++)
+            long lastSyncedTxId = logInfo.LastSyncedTransactionId;
+            long lastSyncJournal = logInfo.LastSyncedJournal;
+
+            // the last sync journal is allowed to be deleted, it might have been fully synced, which is fine
+            // we rely on the lastSyncedTxId to verify correctness.
+            var journalToStartReadingFrom = logInfo.LastSyncedJournal;
+            if (_env.Options.JournalExists(journalToStartReadingFrom) == false && 
+                logInfo.Flags.HasFlag(JournalInfoFlags.IgnoreMissingLastSyncJournal) || 
+                journalToStartReadingFrom == -1)
+                journalToStartReadingFrom++;
+
+            for (var journalNumber = journalToStartReadingFrom; journalNumber <= logInfo.CurrentJournal; journalNumber++)
             {
                 addToInitLog?.Invoke($"Recovering journal {journalNumber} (upto last journal {logInfo.CurrentJournal})");
                 var initialSize = _env.Options.InitialFileSize ?? _env.Options.InitialLogFileSize;
                 var journalRecoveryName = StorageEnvironmentOptions.JournalRecoveryName(journalNumber);
                 using (var recoveryPager = _env.Options.CreateTemporaryBufferPager(journalRecoveryName, initialSize))
-                using (var pager = _env.Options.OpenJournalPager(journalNumber))
+                using (var pager = _env.Options.OpenJournalPager(journalNumber, logInfo))
                 {
                     RecoverCurrentJournalSize(pager);
 
                     var transactionHeader = txHeader->TransactionId == 0 ? null : txHeader;
-                    using (var journalReader = new JournalReader(pager, _dataPager, recoveryPager, modifiedPages, lastSyncedTransactionId, transactionHeader))
+                    using (var journalReader = new JournalReader(pager, _dataPager, recoveryPager, modifiedPages, logInfo, transactionHeader))
                     {
                         var transactionHeaders = journalReader.RecoverAndValidate(_env.Options);
 
@@ -205,21 +199,18 @@ namespace Voron.Impl.Journal
                         {
                             *txHeader = *lastReadHeaderPtr;
                             lastSyncedTxId = txHeader->TransactionId;
-                            lastSyncedJournal = journalNumber;
+                            lastSyncJournal = journalNumber;
                         }
 
                         pager.Dispose(); // need to close it before we open the journal writer
 
-                        if (lastSyncedTxId != -1 && (journalReader.RequireHeaderUpdate || journalNumber == logInfo.CurrentJournal))
-                        {
-                            var jrnlWriter = _env.Options.CreateJournalWriter(journalNumber,
-                                pager.NumberOfAllocatedPages * Constants.Storage.PageSize);
-                            var jrnlFile = new JournalFile(_env, jrnlWriter, journalNumber);
-                            jrnlFile.InitFrom(journalReader, transactionHeaders);
-                            jrnlFile.AddRef(); // creator reference - write ahead log
+                        var jrnlWriter = _env.Options.CreateJournalWriter(journalNumber,
+                               pager.NumberOfAllocatedPages * Constants.Storage.PageSize);
+                        var jrnlFile = new JournalFile(_env, jrnlWriter, journalNumber);
+                        jrnlFile.InitFrom(journalReader, transactionHeaders);
+                        jrnlFile.AddRef(); // creator reference - write ahead log
 
-                            journalFiles.Add(jrnlFile);
-                        }
+                        journalFiles.Add(jrnlFile);
 
                         if (journalReader.RequireHeaderUpdate) //this should prevent further loading of transactions
                         {
@@ -274,22 +265,13 @@ namespace Voron.Impl.Journal
                     "First transaction initializing the structure of Voron database is corrupted. Cannot access internal database metadata. Create a new database to recover.");
 
             Debug.Assert(lastSyncedTxId >= 0);
-            Debug.Assert(lastSyncedJournal >= 0);
+            Debug.Assert(lastSyncJournal >= 0);
 
-            _journalIndex = lastSyncedJournal;
+            _journalIndex = lastSyncJournal;
 
             if (_env.Options.CopyOnWriteMode == false)
             {
-                _headerAccessor.Modify(
-                    header =>
-                    {
-                        header->Journal.CurrentJournal = lastSyncedJournal;
-                        header->Journal.JournalFilesCount = _files.Count;
-                        header->IncrementalBackup.LastCreatedJournal = _journalIndex;
-                    });
-
-                CleanupInvalidJournalFiles(lastSyncedJournal);
-                CleanupUnusedJournalFiles(oldestLogFileStillInUse, lastSyncedJournal);
+                CleanupNewerInvalidJournalFiles(lastSyncJournal);
             }
 
             if (_files.Count > 0)
@@ -303,17 +285,7 @@ namespace Voron.Impl.Journal
             return requireHeaderUpdate;
         }
 
-        private void CleanupUnusedJournalFiles(long oldestLogFileStillInUse, long lastSyncedJournal)
-        {
-            var logFile = oldestLogFileStillInUse;
-            while (logFile < lastSyncedJournal)
-            {
-                _env.Options.TryDeleteJournal(logFile);
-                logFile++;
-            }
-        }
-
-        private void CleanupInvalidJournalFiles(long lastSyncedJournal)
+        private void CleanupNewerInvalidJournalFiles(long lastSyncedJournal)
         {
             // we want to check that we cleanup newer log files, since everything from
             // the current file is considered corrupted
@@ -436,30 +408,7 @@ namespace Voron.Impl.Journal
                 }
             }
         }
-
-        public void Clear(LowLevelTransaction tx)
-        {
-            if (tx.Flags != TransactionFlags.ReadWrite)
-                throw new InvalidOperationException("Clearing of write ahead journal should be called only from a write transaction");
-
-            foreach (var journalFile in _files)
-            {
-                journalFile.Release();
-            }
-            _files = ImmutableAppendOnlyList<JournalFile>.Empty;
-            CurrentFile = null;
-        }
-
-        public class JournalSyncEventArgs : EventArgs
-        {
-            public long OldestTransactionId { get; private set; }
-
-            public JournalSyncEventArgs(long oldestTransactionId)
-            {
-                OldestTransactionId = oldestTransactionId;
-            }
-        }
-
+        
         public sealed class JournalApplicator : IDisposable
         {
             private readonly ConcurrentDictionary<long, JournalFile> _journalsToDelete = new ConcurrentDictionary<long, JournalFile>();
@@ -484,6 +433,8 @@ namespace Voron.Impl.Journal
                     Journal = journal;
                     JournalsToDelete = journalsToDelete;
                 }
+
+                public bool IsValid => Journal != null && JournalsToDelete != null;
             }
 
             private LastFlushState _lastFlushed = new LastFlushState(0, 0, null, null);
@@ -889,6 +840,8 @@ namespace Voron.Impl.Journal
 
                 public Task Task => _tcs.Task;
 
+                internal Action AfterGatherInformationAction;
+
                 public bool SyncDataFile()
                 {
                     _fsyncLockTaken = _parent._fsyncLock.Wait(0);
@@ -901,6 +854,8 @@ namespace Voron.Impl.Journal
 
                     if (_parent._flushLockTaskResponsible.WaitForTaskToBeDone(GatherInformationToStartSync) == false)
                         return false;
+
+                    AfterGatherInformationAction?.Invoke();
 
                     if (_parent._waj._env.Disposed)
                         return false;
@@ -922,7 +877,19 @@ namespace Voron.Impl.Journal
                         return false;
 
                     Interlocked.Add(ref _parent._totalWrittenButUnsyncedBytes, -_currentTotalWrittenBytes);
-                    _parent.UpdateFileHeaderAfterDataFileSync(_lastFlushed.JournalId, _lastFlushed.TransactionId, ref _transactionHeader);
+
+                    var ignoreLastSyncJournalMissing = false;
+                    foreach (var item in _lastFlushed.JournalsToDelete)
+                    {
+                        if(item.Number == _lastFlushed.JournalId)
+                        {
+                            // we are about to delete it, so safe to ignore this
+                            ignoreLastSyncJournalMissing = true;
+                            break;
+                        }
+                    }
+
+                    _parent.UpdateFileHeaderAfterDataFileSync(_lastFlushed.JournalId, _lastFlushed.TransactionId, ignoreLastSyncJournalMissing, ref _transactionHeader);
 
                     foreach (var toDelete in _lastFlushed.JournalsToDelete)
                     {
@@ -969,6 +936,10 @@ namespace Voron.Impl.Journal
                         return false; // we have already disposed, nothing to do here
 
                     _lastFlushed = _parent._lastFlushed;
+
+                    if (_lastFlushed.IsValid == false)
+                        return false;
+
                     if (_lastFlushed.DoneFlag.IsRaised())
                         // nothing was flushed since we last synced, nothing to do
                         return false;
@@ -1208,8 +1179,11 @@ namespace Voron.Impl.Journal
                 return unusedJournalFiles;
             }
 
-            private void UpdateFileHeaderAfterDataFileSync(long lastSyncedJournal,
-                long lastSyncedTransactionId, ref TransactionHeader lastReadTxHeader)
+            private void UpdateFileHeaderAfterDataFileSync(
+                long lastSyncedJournal,
+                long lastSyncedTransactionId,
+                bool ignoreLastSyncJournalMissing,
+                ref TransactionHeader lastReadTxHeader)
             {
                 Debug.Assert(lastSyncedJournal != -1);
                 Debug.Assert(lastSyncedTransactionId != -1);
@@ -1222,13 +1196,18 @@ namespace Voron.Impl.Journal
                 {
                     header->TransactionId = transactionId;
                     header->LastPageNumber = lastPageNumber;
-
+                    
                     header->Journal.LastSyncedJournal = lastSyncedJournal;
                     header->Journal.LastSyncedTransactionId = lastSyncedTransactionId;
 
-                    header->Root = treeRootHeader;
+                    Memory.Set(header->Journal.Reserved, 0, JournalInfo.NumberOfReservedBytes);
 
-                    _waj._updateLogInfo(header);
+                    if (ignoreLastSyncJournalMissing)
+                        header->Journal.Flags |= JournalInfoFlags.IgnoreMissingLastSyncJournal;
+                    else
+                        header->Journal.Flags &= ~JournalInfoFlags.IgnoreMissingLastSyncJournal;
+
+                    header->Root = treeRootHeader;
                 });
             }
 
@@ -1308,7 +1287,18 @@ namespace Voron.Impl.Journal
                 _waj._files = _waj._files.RemoveFront(1);
                 _waj.CurrentFile = null;
 
-                _waj._headerAccessor.Modify(header => _waj._updateLogInfo(header));
+                _waj._headerAccessor.Modify(header =>
+                {
+                    header->Journal.CurrentJournal = -1;
+
+                    if (current.Number != header->Journal.LastSyncedJournal)
+                    {
+                        throw new InvalidOperationException($"Attempted to remove a journal ({current.Number}) that hasn't been synced yet (last synced journal: {header->Journal.LastSyncedJournal})");
+                    }
+
+                    Memory.Set(header->Journal.Reserved, 0, JournalInfo.NumberOfReservedBytes);
+                    header->Journal.Flags |= JournalInfoFlags.IgnoreMissingLastSyncJournal;
+                });
 
                 current.DeleteOnClose = true;
                 current.Release();

--- a/src/Voron/Schema/IVoronSchemaUpdate.cs
+++ b/src/Voron/Schema/IVoronSchemaUpdate.cs
@@ -1,0 +1,9 @@
+﻿using Voron.Impl.FileHeaders;
+
+namespace Voron.Schema
+{
+    public interface IVoronSchemaUpdate
+    {
+        bool Update(int currentVersion, StorageEnvironmentOptions options, HeaderAccessor headerAccessor, out int versionAfterUpgrade);
+    }
+}

--- a/src/Voron/Schema/Updates/From22.cs
+++ b/src/Voron/Schema/Updates/From22.cs
@@ -1,0 +1,26 @@
+﻿using Sparrow;
+using Voron.Impl.FileHeaders;
+using Voron.Impl.Journal;
+
+namespace Voron.Schema.Updates
+{
+    public class From22 : IVoronSchemaUpdate
+    {
+        public unsafe bool Update(int currentVersion, StorageEnvironmentOptions options, HeaderAccessor headerAccessor, out int versionAfterUpgrade)
+        {
+            headerAccessor.Modify(header =>
+            {
+                Memory.Set(header->Journal.Reserved, 0, JournalInfo.NumberOfReservedBytes);
+                
+                if (options.JournalExists(header->Journal.LastSyncedJournal))
+                    header->Journal.Flags = JournalInfoFlags.None;
+                else
+                    header->Journal.Flags = JournalInfoFlags.IgnoreMissingLastSyncJournal;
+            });
+
+            versionAfterUpgrade = 23;
+
+            return true;
+        }
+    }
+}

--- a/src/Voron/Schema/VoronSchemaUpdater.cs
+++ b/src/Voron/Schema/VoronSchemaUpdater.cs
@@ -1,0 +1,38 @@
+﻿using System;
+using Voron.Global;
+using Voron.Impl.FileHeaders;
+
+namespace Voron.Schema
+{
+    public class VoronSchemaUpdater
+    {
+        private readonly HeaderAccessor _headerAccessor;
+        private readonly StorageEnvironmentOptions _options;
+
+        public VoronSchemaUpdater(HeaderAccessor headerAccessor, StorageEnvironmentOptions options)
+        {
+            _headerAccessor = headerAccessor;
+            _options = options;
+        }
+
+        public unsafe void Update()
+        {
+            while (_headerAccessor.Get(header => header->Version) < Constants.CurrentVersion)
+            {
+                var currentVersion = _headerAccessor.Get(header => header->Version);
+                var name = $"Voron.Schema.Updates.From{currentVersion}";
+
+                var schemaUpdateType = typeof(IVoronSchemaUpdate).Assembly.GetType(name);
+                if (schemaUpdateType == null)
+                    break;
+
+                var schemaUpdate = (IVoronSchemaUpdate)Activator.CreateInstance(schemaUpdateType);
+
+                if (schemaUpdate.Update(currentVersion, _options, _headerAccessor, out var versionAfterUpdate) == false)
+                    break;
+
+                _headerAccessor.Modify(header => header->Version = versionAfterUpdate);
+            }
+        }
+    }
+}

--- a/test/FastTests/Voron/ValidHeaders.cs
+++ b/test/FastTests/Voron/ValidHeaders.cs
@@ -58,7 +58,6 @@ namespace FastTests.Voron
             ptr->Root.RootPageNumber = (long)rnd.NextDouble();
 
             ptr->Journal.CurrentJournal = (long)rnd.NextDouble();
-            ptr->Journal.JournalFilesCount = rnd.Next();
             ptr->Journal.LastSyncedJournal = (long)rnd.NextDouble();
             ptr->Journal.LastSyncedTransactionId = (long)rnd.NextDouble();
 
@@ -89,7 +88,6 @@ namespace FastTests.Voron
             Assert.Equal(ptr->Root.RootPageNumber, (long)rnd.NextDouble());
 
             Assert.Equal(ptr->Journal.CurrentJournal, (long)rnd.NextDouble());
-            Assert.Equal(ptr->Journal.JournalFilesCount, rnd.Next());
             Assert.Equal(ptr->Journal.LastSyncedJournal, (long)rnd.NextDouble());
             Assert.Equal(ptr->Journal.LastSyncedTransactionId, (long)rnd.NextDouble());
 

--- a/test/SlowTests/Voron/RavenDB_12725.cs
+++ b/test/SlowTests/Voron/RavenDB_12725.cs
@@ -1,0 +1,144 @@
+﻿using System;
+using System.IO;
+using FastTests.Voron;
+using Voron;
+using Voron.Data.BTrees;
+using Voron.Impl.Backup;
+using Voron.Impl.Journal;
+using Voron.Util.Settings;
+using Xunit;
+
+namespace SlowTests.Voron
+{
+    public class RavenDB_12725 : StorageTest
+    {
+        protected override void Configure(StorageEnvironmentOptions options)
+        {
+            options.ManualFlushing = true;
+            options.ManualSyncing = true;
+            options.MaxLogFileSize = 1 * 1024 * 1024;
+        }
+
+        [Fact]
+        public void Recovery_must_not_delete_journals_that_havent_been_synced_yet()
+        {
+            RequireFileBasedPager();
+
+            var r = new Random();
+            var bytes = new byte[512];
+
+            for (int i = 0; i < 10; i++)
+            {
+                using (var tx = Env.WriteTransaction())
+                {
+                    Tree tree = tx.CreateTree("tree");
+
+                    for (int j = 0; j < 100; j++)
+                    {
+                        r.NextBytes(bytes);
+                        tree.Add(new string((char) j, 1000), bytes);
+                    }
+
+                    tx.Commit();
+                }
+            }
+
+            Env.FlushLogToDataFile();
+
+            for (int i = 0; i < 10; i++)
+            {
+                using (var tx = Env.WriteTransaction())
+                {
+                    Tree tree = tx.CreateTree("tree");
+
+                    for (int j = 0; j < 100; j++)
+                    {
+                        r.NextBytes(bytes);
+                        tree.Add(new string((char)j, 1000), bytes);
+                    }
+
+                    tx.Commit();
+                }
+            }
+
+            using (var operation = new WriteAheadJournal.JournalApplicator.SyncOperation(Env.Journal.Applicator)
+            {
+                AfterGatherInformationAction = () => Env.FlushLogToDataFile()
+            })
+            {
+                var syncResult = operation.SyncDataFile();
+            }
+
+            RestartDatabase();
+        }
+
+        [Fact]
+        public void Full_backup_must_backup_journals_that_we_havent_synced_yet()
+        {
+            RequireFileBasedPager();
+
+            var r = new Random();
+            var bytes = new byte[512];
+
+            for (int i = 0; i < 10; i++)
+            {
+                using (var tx = Env.WriteTransaction())
+                {
+                    Tree tree = tx.CreateTree("tree");
+
+                    for (int j = 0; j < 100; j++)
+                    {
+                        r.NextBytes(bytes);
+                        tree.Add(new string((char)j, 1000), bytes);
+                    }
+
+                    tx.Commit();
+                }
+            }
+
+            Env.FlushLogToDataFile();
+
+            for (int i = 0; i < 10; i++)
+            {
+                using (var tx = Env.WriteTransaction())
+                {
+                    Tree tree = tx.CreateTree("tree");
+
+                    for (int j = 0; j < 100; j++)
+                    {
+                        r.NextBytes(bytes);
+                        tree.Add(new string((char)j, 1000), bytes);
+                    }
+
+                    tx.Commit();
+                }
+            }
+
+            using (var operation = new WriteAheadJournal.JournalApplicator.SyncOperation(Env.Journal.Applicator)
+            {
+                AfterGatherInformationAction = () =>
+                {
+                    Env.FlushLogToDataFile();
+                }
+            })
+            {
+                var syncResult = operation.SyncDataFile();
+            }
+
+            var voronDataDir = new VoronPathSetting(DataDir);
+
+            BackupMethods.Full.ToFile(Env, voronDataDir.Combine("voron-test.backup"));
+
+            BackupMethods.Full.Restore(voronDataDir.Combine("voron-test.backup"), voronDataDir.Combine("backup-test.data"));
+
+            var options = StorageEnvironmentOptions.ForPath(Path.Combine(DataDir, "backup-test.data"));
+            options.MaxLogFileSize = Env.Options.MaxLogFileSize;
+
+            using (var env = new StorageEnvironment(options))
+            {
+                
+            }
+        }
+
+    }
+}

--- a/test/SlowTests/Voron/RavenDB_12725_2.cs
+++ b/test/SlowTests/Voron/RavenDB_12725_2.cs
@@ -1,0 +1,214 @@
+﻿using System;
+using System.IO;
+using FastTests.Voron;
+using Voron;
+using Voron.Data.BTrees;
+using Voron.Impl.Backup;
+using Voron.Impl.Journal;
+using Voron.Util.Settings;
+using Xunit;
+
+namespace SlowTests.Voron
+{
+    public class RavenDB_12725_2 : StorageTest
+    {
+        protected override void Configure(StorageEnvironmentOptions options)
+        {
+            options.ManualFlushing = true;
+            options.ManualSyncing = true;
+            options.MaxLogFileSize = 4096;
+        }
+
+
+        [Fact]
+        public void After_backup_and_restore_recovery_must_not_throw_missing_journal_if_we_have_synced_everything()
+        {
+            RequireFileBasedPager();
+
+            var r = new Random(1); // we must use seed to ensure we always fill up the journal
+            var bytes = new byte[512];
+
+            for (int i = 0; i < 10; i++)
+            {
+                using (var tx = Env.WriteTransaction())
+                {
+                    Tree tree = tx.CreateTree("tree");
+
+                    for (int j = 0; j < 100; j++)
+                    {
+                        r.NextBytes(bytes);
+                        tree.Add(new string((char)j, 1000), bytes);
+                    }
+
+                    tx.Commit();
+                }
+            }
+
+            Env.FlushLogToDataFile();
+
+            for (int i = 0; i < 20; i++)
+            {
+                using (var tx = Env.WriteTransaction())
+                {
+                    Tree tree = tx.CreateTree("tree");
+
+                    for (int j = 0; j < 100; j++)
+                    {
+                        r.NextBytes(bytes);
+                        tree.Add(new string((char)j, 1000), bytes);
+                    }
+
+                    tx.Commit();
+                }
+            }
+
+            // here we're filling up the last journal completely, we'll have Available4Kbs == 0 after the commit
+
+            using (var tx = Env.WriteTransaction())
+            {
+                Tree tree = tx.CreateTree("tree");
+
+                for (int j = 0; j < 226; j++)
+                {
+                    var specialBytes = new byte[1024];
+
+                    r.NextBytes(specialBytes);
+                    tree.Add(new string((char)j, 1000), specialBytes);
+                }
+
+                tx.Commit();
+            }
+
+            Env.FlushLogToDataFile();
+
+            using (var operation = new WriteAheadJournal.JournalApplicator.SyncOperation(Env.Journal.Applicator))
+            {
+                var syncResult = operation.SyncDataFile();
+            }
+
+            var voronDataDir = new VoronPathSetting(DataDir);
+
+            BackupMethods.Full.ToFile(Env, voronDataDir.Combine("voron-test.backup"));
+
+            BackupMethods.Full.Restore(voronDataDir.Combine("voron-test.backup"), voronDataDir.Combine("backup-test.data"));
+
+            var options = StorageEnvironmentOptions.ForPath(Path.Combine(DataDir, "backup-test.data"));
+            options.MaxLogFileSize = Env.Options.MaxLogFileSize;
+
+            using (var env = new StorageEnvironment(options))
+            {
+                using (var tx = env.ReadTransaction())
+                {
+                    using (var it = tx.ReadTree("tree").Iterate(prefetch: false))
+                    {
+                        Assert.True(it.Seek(Slices.BeforeAllKeys));
+
+                        var count = 0;
+
+                        do
+                        {
+                            count++;
+                        } while (it.MoveNext());
+
+                        Assert.Equal(226, count);
+                    }
+                }
+            }
+        }
+
+        [Fact]
+        public void Recovery_must_not_throw_missing_journal_if_we_have_synced_everything()
+        {
+            RequireFileBasedPager();
+
+            var r = new Random(1); // we must use seed to ensure we always fill up the journal
+            var bytes = new byte[512];
+
+            for (int i = 0; i < 10; i++)
+            {
+                using (var tx = Env.WriteTransaction())
+                {
+                    Tree tree = tx.CreateTree("tree");
+
+                    for (int j = 0; j < 100; j++)
+                    {
+                        r.NextBytes(bytes);
+                        tree.Add(new string((char)j, 1000), bytes);
+                    }
+
+                    tx.Commit();
+                }
+            }
+
+            Env.FlushLogToDataFile();
+
+            for (int i = 0; i < 20; i++)
+            {
+                using (var tx = Env.WriteTransaction())
+                {
+                    Tree tree = tx.CreateTree("tree");
+
+                    for (int j = 0; j < 100; j++)
+                    {
+                        r.NextBytes(bytes);
+                        tree.Add(new string((char)j, 1000), bytes);
+                    }
+
+                    tx.Commit();
+                }
+            }
+
+            // here we're filling up the last journal completely, we'll have Available4Kbs == 0 after the commit
+
+            using (var tx = Env.WriteTransaction())
+            {
+                Tree tree = tx.CreateTree("tree");
+
+                for (int j = 0; j < 226; j++)
+                {
+                    var specialBytes = new byte[1024];
+
+                    r.NextBytes(specialBytes);
+                    tree.Add(new string((char)j, 1000), specialBytes);
+                }
+
+                tx.Commit();
+            }
+
+            Env.FlushLogToDataFile();
+
+            using (var operation = new WriteAheadJournal.JournalApplicator.SyncOperation(Env.Journal.Applicator))
+            {
+                var syncResult = operation.SyncDataFile();
+            }
+
+            RestartDatabase();
+
+            using (var tx = Env.WriteTransaction())
+            {
+                tx.CreateTree("foobar");
+
+                tx.Commit();
+            }
+
+            RestartDatabase();
+
+            using (var tx = Env.ReadTransaction())
+            {
+                using (var it = tx.ReadTree("tree").Iterate(prefetch: false))
+                {
+                    Assert.True(it.Seek(Slices.BeforeAllKeys));
+
+                    var count = 0;
+
+                    do
+                    {
+                        count++;
+                    } while (it.MoveNext());
+
+                    Assert.Equal(226, count);
+                }
+            }
+        }
+    }
+}

--- a/test/SlowTests/Voron/RavenDB_12725_3.cs
+++ b/test/SlowTests/Voron/RavenDB_12725_3.cs
@@ -1,0 +1,41 @@
+﻿using System.IO;
+using FastTests;
+using FastTests.Voron;
+using Raven.Server.Config.Settings;
+using Voron;
+using Voron.Global;
+using Xunit;
+
+namespace SlowTests.Voron
+{
+    public class RavenDB_12725_3 : StorageTest
+    {
+        [Fact]
+        public void Voron_schema_update_will_update_headers_file_and_bump_version_there()
+        {
+            var dataDir = RavenTestHelper.NewDataPath(nameof(Voron_schema_update_will_update_headers_file_and_bump_version_there), 0, forceCreateDir: true);
+
+            var path = new PathSetting($"SchemaUpgrade/Issues/DocumentsVersion/schema_9");
+            var schemaDir = new DirectoryInfo(path.FullPath);
+            Assert.Equal(true, schemaDir.Exists);
+            CopyAll(schemaDir, new DirectoryInfo(Path.GetFullPath(dataDir)));
+
+            using (var env = new StorageEnvironment(StorageEnvironmentOptions.ForPath(dataDir)))
+            {
+                unsafe
+                {
+                    Assert.Equal(Constants.CurrentVersion, env.HeaderAccessor.Get(ptr => ptr->Version));
+                }
+            }
+        }
+
+        private static void CopyAll(DirectoryInfo source, DirectoryInfo target)
+        {
+            foreach (var fi in source.GetFiles())
+                fi.CopyTo(Path.Combine(target.FullName, fi.Name), true);
+
+            foreach (var diSourceSubDir in source.GetDirectories())
+                CopyAll(diSourceSubDir, target.CreateSubdirectory(diSourceSubDir.Name));
+        }
+    }
+}

--- a/test/SlowTests/Voron/RavenDB_12725_4.cs
+++ b/test/SlowTests/Voron/RavenDB_12725_4.cs
@@ -1,0 +1,82 @@
+﻿using System;
+using System.IO;
+using System.Linq;
+using FastTests.Voron;
+using Voron;
+using Voron.Data.BTrees;
+using Voron.Exceptions;
+using Voron.Impl.Journal;
+using Xunit;
+
+namespace SlowTests.Voron
+{
+    public class RavenDB_12725_4 : StorageTest
+    {
+        protected override void Configure(StorageEnvironmentOptions options)
+        {
+            options.ManualFlushing = true;
+            options.ManualSyncing = true;
+            options.MaxLogFileSize = 1 * 1024 * 1024;
+        }
+
+        [Fact]
+        public void Should_throw_on_missing_journal_during_recovery()
+        {
+            RequireFileBasedPager();
+
+            var r = new Random(1);
+            var bytes = new byte[512];
+
+            for (int i = 0; i < 10; i++)
+            {
+                using (var tx = Env.WriteTransaction())
+                {
+                    Tree tree = tx.CreateTree("tree");
+
+                    for (int j = 0; j < 100; j++)
+                    {
+                        r.NextBytes(bytes);
+                        tree.Add(new string((char)j, 1000), bytes);
+                    }
+
+                    tx.Commit();
+                }
+            }
+
+            Env.FlushLogToDataFile();
+
+            using (var operation = new WriteAheadJournal.JournalApplicator.SyncOperation(Env.Journal.Applicator))
+            {
+                operation.SyncDataFile();
+            }
+
+            for (int i = 0; i < 10; i++)
+            {
+                using (var tx = Env.WriteTransaction())
+                {
+                    Tree tree = tx.CreateTree("tree");
+
+                    for (int j = 0; j < 100; j++)
+                    {
+                        r.NextBytes(bytes);
+                        tree.Add(new string((char)j, 1000), bytes);
+                    }
+
+                    tx.Commit();
+                }
+            }
+
+            Env.FlushLogToDataFile();
+
+            StopDatabase();
+
+            var journalPath = ((StorageEnvironmentOptions.DirectoryStorageEnvironmentOptions)Env.Options).JournalPath.FullPath;
+
+            var firstJournal = new DirectoryInfo(journalPath).GetFiles("*.journal").OrderBy(x => x.Name).First();
+
+            File.Delete(firstJournal.FullName);
+
+            Assert.Throws<InvalidJournalException>(StartDatabase);
+        }
+    }
+}


### PR DESCRIPTION
- Changing the way we're detecting what range of journal files is necessary to properly recover on database startup. The issue was that that we relied on JournalFilesCount which was in-memory state and under some conditions could be invalid. In result, on recovery startup, we were deleting a journal that had page that were not applied to data file yet.
- Applying the same logic when taking a full backup so we won't miss any journal file
- Added validation to the recovery which will prevent from loading a database if _first_ journal file is missing
- We no longer delete any journals after we apply their data to the data file - we must not do it because we don't sync the data file during the recovery. The first flush will schedule the data file sync which will remove already synced journals.
- We no longer modify the headers after the recovery process - as we don't delete any journals there now
- Changed the format FileHeader (JournalInfo.JournalFilesCount changed to JournalInfo.Reserved and JournalInfo.Flags) and bumping Voron version. Added relevant schema update.
- Enhanced exception messages

Original PR: https://github.com/ravendb/ravendb/pull/8538