### PR TITLE
RavenDB-12744 A resolved document must preserve the original change v…

### DIFF
--- a/src/Raven.Server/Documents/AttachmentsStorage.cs
+++ b/src/Raven.Server/Documents/AttachmentsStorage.cs
@@ -1119,7 +1119,7 @@ namespace Raven.Server.Documents
             return (doc, name);
         }
 
-#if DEBUG
+        [Conditional("DEBUG")]
         public static void AssertAttachments(BlittableJsonReaderObject document, DocumentFlags flags)
         {
             if ((flags & DocumentFlags.HasAttachments) == DocumentFlags.HasAttachments)
@@ -1139,6 +1139,5 @@ namespace Raven.Server.Documents
                 }
             }
         }
-#endif
     }
 }

--- a/src/Raven.Server/Documents/CountersStorage.cs
+++ b/src/Raven.Server/Documents/CountersStorage.cs
@@ -648,6 +648,7 @@ namespace Raven.Server.Documents
             }
         }
 
+        [Conditional("DEBUG")]
         public static void AssertCounters(BlittableJsonReaderObject document, DocumentFlags flags)
         {
             if ((flags & DocumentFlags.HasCounters) == DocumentFlags.HasCounters)

--- a/src/Raven.Server/Documents/DocumentFlags.cs
+++ b/src/Raven.Server/Documents/DocumentFlags.cs
@@ -41,7 +41,8 @@ namespace Raven.Server.Documents
         Resolved = 0x80,
         SkipRevisionCreation = 0x100,
         ResolveCountersConflict = 0x200,
-        ByCountersUpdate = 0x400
+        ByCountersUpdate = 0x400,
+        FromResolver = 0x800
     }
 
     public static class EnumExtensions

--- a/src/Raven.Server/Documents/Replication/ConflictManager.cs
+++ b/src/Raven.Server/Documents/Replication/ConflictManager.cs
@@ -210,7 +210,10 @@ namespace Raven.Server.Documents.Replication
 
                 // no real conflict here, both documents have identical content
                 var mergedChangeVector = ChangeVectorUtils.MergeVectors(incomingChangeVector, existingDoc.ChangeVector);
-                var nonPersistentFlags = compareResult.HasFlag(DocumentCompareResult.AttachmentsNotEqual)
+
+                var nonPersistentFlags = NonPersistentDocumentFlags.FromResolver;
+
+                nonPersistentFlags |= compareResult.HasFlag(DocumentCompareResult.AttachmentsNotEqual)
                     ? NonPersistentDocumentFlags.ResolveAttachmentsConflict : NonPersistentDocumentFlags.None;
                 
                 if (compareResult.HasFlag(DocumentCompareResult.CountersNotEqual))                

--- a/test/SlowTests/Server/Replication/ReplicationAutomaticConflictResolution.cs
+++ b/test/SlowTests/Server/Replication/ReplicationAutomaticConflictResolution.cs
@@ -388,7 +388,6 @@ return out;
                 {
                     var user = session.Load<User>("users/1");
                     Assert.Null(user);
-                    WaitForUserToContinueTheTest(slave);
                     VerifyRevisionsAfterConflictResolving(session);
                 }
             }


### PR DESCRIPTION
…ector to avoid ping-pong replication

but it must update the global change vector.