### PR TITLE
RavenDB-12724 Exposing the reason a test failed due to licensing failure

### DIFF
--- a/src/Raven.Server/Commercial/LicenseManager.cs
+++ b/src/Raven.Server/Commercial/LicenseManager.cs
@@ -540,14 +540,14 @@ namespace Raven.Server.Commercial
             });
         }
 
-        public void TryActivateLicense()
+        public (bool Success, string Reason) TryActivateLicense()
         {
             if (_licenseStatus.Type != LicenseType.None)
-                return;
+                return (true,null);
 
             var license = TryGetLicenseFromString() ?? TryGetLicenseFromPath();
             if (license == null)
-                return;
+                return (false, "No license from either string or path.");
 
             try
             {
@@ -557,7 +557,11 @@ namespace Raven.Server.Commercial
             {
                 if (Logger.IsInfoEnabled)
                     Logger.Info("Failed to activate license", e);
+
+                return (false, e.ToString());
             }
+
+            return (true, null);
         }
 
         private License TryGetLicenseFromPath()
@@ -1279,7 +1283,7 @@ namespace Raven.Server.Commercial
             if (_licenseStatus.HasExternalReplication)
                 return;
 
-            var details = $"Your current license ({_licenseStatus.Type}) does not allow adding external replication";
+            var details = $"Your current license (Type:{_licenseStatus.Type} Id:{_licenseStatus.Id}) does not allow adding external replication";
             throw GenerateLicenseLimit(LimitType.ExternalReplication, details);
         }
 

--- a/test/SlowTests/Server/Replication/ExternalReplicationTests.cs
+++ b/test/SlowTests/Server/Replication/ExternalReplicationTests.cs
@@ -16,15 +16,18 @@ namespace SlowTests.Server.Replication
         {
             using (var store1 = GetDocumentStore(new Options
             {
-                ModifyDatabaseName = s => $"{s}_FooBar-1"
+                ModifyDatabaseName = s => $"{s}_FooBar-1",
+                EnsureServerLicenseIsActivated = true
             }))
             using (var store2 = GetDocumentStore(new Options
             {
-                ModifyDatabaseName = s => $"{s}_FooBar-2"
+                ModifyDatabaseName = s => $"{s}_FooBar-2",
+                EnsureServerLicenseIsActivated = true
             }))
             using (var store3 = GetDocumentStore(new Options
             {
-                ModifyDatabaseName = s => $"{s}_FooBar-3"
+                ModifyDatabaseName = s => $"{s}_FooBar-3",
+                EnsureServerLicenseIsActivated = true
             }))
             {
                 await SetupReplicationAsync(store1, store2, store3);
@@ -44,8 +47,14 @@ namespace SlowTests.Server.Replication
         [Fact]
         public async Task DelayedExternalReplication()
         {
-            using (var store1 = GetDocumentStore())
-            using (var store2 = GetDocumentStore())
+            using (var store1 = GetDocumentStore(new Options
+            {
+                EnsureServerLicenseIsActivated = true
+            }))
+            using (var store2 = GetDocumentStore(new Options
+            {
+                EnsureServerLicenseIsActivated = true
+            }))
             {
                 var delay = TimeSpan.FromSeconds(5);
                 var externalTask = new ExternalReplication(store2.Database, "DelayedExternalReplication")

--- a/test/Tests.Infrastructure/RavenTestBase.cs
+++ b/test/Tests.Infrastructure/RavenTestBase.cs
@@ -181,6 +181,15 @@ namespace FastTests
                             await WaitForRaftIndexToBeAppliedInCluster(result.RaftCommandIndex, timeout);
                         });
                     }
+                    
+                    if (options.EnsureServerLicenseIsActivated)
+                    {
+                        var activation = Server.ServerStore.LicenseManager.TryActivateLicense();
+                        if (activation.Success == false)
+                        {
+                            throw new InvalidOperationException($"Was requested to ensure license is activated in, Test:{GetType().Name}, but failed to activate it because {activation.Reason}.");
+                        }
+                    }
 
                     store.BeforeDispose += (sender, args) =>
                     {
@@ -735,6 +744,7 @@ namespace FastTests
                 }
             }
 
+            public bool EnsureServerLicenseIsActivated { get; set; }
             private void AssertNotFrozen()
             {
                 if (_frozen)


### PR DESCRIPTION
I couldn't reproduce the failure, this could happen due to a few reasons from cluster timing issues to our licensing server not responding when the license expires.
What I did is expose the reason the license failed to load explicitly so the test will fail with the real reason.
I could easily ignore the test failure when this happens but I think it would be better to live this so we could know why we fail to activate the license.