### PR TITLE
RavenDB-12771 fixing resolved document and revisions behaviour

### DIFF
--- a/src/Raven.Server/Documents/AttachmentsStorage.cs
+++ b/src/Raven.Server/Documents/AttachmentsStorage.cs
@@ -341,6 +341,7 @@ namespace Raven.Server.Documents
                 var attachments = GetAttachmentsMetadataForDocument(context, lowerDocumentId);
 
                 var flags = TableValueToFlags((int)DocumentsTable.Flags, ref copyTvr);
+                flags = flags.Strip(DocumentFlags.FromClusterTransaction | DocumentFlags.Resolved);
 
                 data.Modifications = new DynamicJsonValue(data);
                 if (data.TryGet(Constants.Documents.Metadata.Key, out BlittableJsonReaderObject metadata))

--- a/src/Raven.Server/Documents/ConflictsStorage.cs
+++ b/src/Raven.Server/Documents/ConflictsStorage.cs
@@ -336,7 +336,7 @@ namespace Raven.Server.Documents
                             nonPersistentFlags |= NonPersistentDocumentFlags.ResolveCountersConflict;
 
                         _documentsStorage.RevisionsStorage.Put(
-                            context, conflicted.Id, conflicted.Doc, conflicted.Flags | DocumentFlags.Conflicted, nonPersistentFlags, conflicted.ChangeVector,
+                            context, conflicted.Id, conflicted.Doc, conflicted.Flags | DocumentFlags.Conflicted | DocumentFlags.HasRevisions, nonPersistentFlags, conflicted.ChangeVector,
                             conflicted.LastModified.Ticks,
                             collectionName: collection, configuration: RevisionsStorage.ConflictConfiguration.Default);
                     }

--- a/src/Raven.Server/Documents/CountersStorage.cs
+++ b/src/Raven.Server/Documents/CountersStorage.cs
@@ -693,7 +693,7 @@ namespace Raven.Server.Documents
             if (hadModifications == false)
                 return;
 
-            var flags = doc.Flags.Strip(DocumentFlags.FromClusterTransaction);
+            var flags = doc.Flags.Strip(DocumentFlags.FromClusterTransaction | DocumentFlags.Resolved);
             if (counters.Count == 0)
             {
                 flags = flags.Strip(DocumentFlags.HasCounters);

--- a/src/Raven.Server/Documents/DocumentPutAction.cs
+++ b/src/Raven.Server/Documents/DocumentPutAction.cs
@@ -222,7 +222,6 @@ namespace Raven.Server.Documents
             }
         }
 
-        [MethodImpl(MethodImplOptions.AggressiveInlining)]
         private void UpdateChangeVectorIfNeeded(DocumentsOperationContext context, NonPersistentDocumentFlags nonPersistentFlags, ref string changeVector, ref long newEtag)
         {
             // when having an external replication we must generate a new change vector for the resolved conflict.

--- a/src/Raven.Server/Documents/DocumentPutAction.cs
+++ b/src/Raven.Server/Documents/DocumentPutAction.cs
@@ -150,8 +150,8 @@ namespace Raven.Server.Documents
                         CountersStorage.AssertCounters(document, flags);
                     }
 
-                    var shouldVersion = _documentDatabase.DocumentsStorage.RevisionsStorage.ShouldVersionDocument(collectionName, nonPersistentFlags, oldDoc, document,
-                        ref flags, out var configuration);
+                    var shouldVersion = _documentDatabase.DocumentsStorage.RevisionsStorage.ShouldVersionDocument(
+                        collectionName, nonPersistentFlags, oldDoc, document, context, id, ref flags, out var configuration);
                     if (shouldVersion)
                     {
                         if (ShouldVersionOldDocument(flags, oldDoc))

--- a/src/Raven.Server/Documents/DocumentPutAction.cs
+++ b/src/Raven.Server/Documents/DocumentPutAction.cs
@@ -1,5 +1,4 @@
 using System;
-using System.Collections.Generic;
 using System.Diagnostics;
 using System.IO;
 using System.Runtime.CompilerServices;
@@ -13,7 +12,6 @@ using Sparrow.Json.Parsing;
 using Voron;
 using Voron.Data.Tables;
 using System.Linq;
-using Raven.Client.Documents.Operations.Revisions;
 using Raven.Client.Exceptions;
 using Sparrow;
 using static Raven.Server.Documents.DocumentsStorage;
@@ -224,6 +222,7 @@ namespace Raven.Server.Documents
             }
         }
 
+        [MethodImpl(MethodImplOptions.AggressiveInlining)]
         private void UpdateChangeVectorIfNeeded(DocumentsOperationContext context, NonPersistentDocumentFlags nonPersistentFlags, ref string changeVector, ref long newEtag)
         {
             // when having an external replication we must generate a new change vector for the resolved conflict.
@@ -315,7 +314,7 @@ namespace Raven.Server.Documents
             return (changeVector, nonPersistentFlags);
         }
 
-        private bool UpdateLastDatabaseChangeVector(DocumentsOperationContext context, string changeVector, DocumentFlags flags, NonPersistentDocumentFlags nonPersistentFlags)
+        private static bool UpdateLastDatabaseChangeVector(DocumentsOperationContext context, string changeVector, DocumentFlags flags, NonPersistentDocumentFlags nonPersistentFlags)
         {
             // this is raft created document, so it must contain only the RAFT element 
             if (flags.Contain(DocumentFlags.FromClusterTransaction))

--- a/src/Raven.Server/Documents/DocumentsStorage.cs
+++ b/src/Raven.Server/Documents/DocumentsStorage.cs
@@ -353,8 +353,8 @@ namespace Raven.Server.Documents
                 return context.LastDatabaseChangeVector;
             }
 
-            var result = ChangeVectorUtils.TryUpdateChangeVector(DocumentDatabase.ServerStore.NodeTag, Environment.Base64Id, newEtag, changeVector);
-            return result.ChangeVector;
+            context.LastDatabaseChangeVector = ChangeVectorUtils.TryUpdateChangeVector(DocumentDatabase.ServerStore.NodeTag, Environment.Base64Id, newEtag, changeVector).ChangeVector;
+            return context.LastDatabaseChangeVector;
         }
 
         public string GetNewChangeVector(DocumentsOperationContext context)

--- a/src/Raven.Server/Documents/Revisions/RevisionsStorage.cs
+++ b/src/Raven.Server/Documents/Revisions/RevisionsStorage.cs
@@ -250,9 +250,11 @@ namespace Raven.Server.Documents.Revisions
             return Configuration.Default ?? _emptyConfiguration;
         }
 
+        [MethodImpl(MethodImplOptions.AggressiveInlining)]
         public bool ShouldVersionDocument(CollectionName collectionName, NonPersistentDocumentFlags nonPersistentFlags,
-            BlittableJsonReaderObject existingDocument, BlittableJsonReaderObject document, ref DocumentFlags documentFlags,
-            out RevisionsCollectionConfiguration configuration)
+            BlittableJsonReaderObject existingDocument, BlittableJsonReaderObject document, 
+            DocumentsOperationContext context, string id, 
+            ref DocumentFlags documentFlags, out RevisionsCollectionConfiguration configuration)
         {
             configuration = GetRevisionsConfiguration(collectionName.Name);
 
@@ -285,6 +287,7 @@ namespace Raven.Server.Documents.Revisions
 
             if (configuration.MinimumRevisionsToKeep == 0)
             {
+                DeleteRevisionsFor(context, id);
                 documentFlags = documentFlags.Strip(DocumentFlags.HasRevisions);
                 return false;
             }
@@ -318,6 +321,7 @@ namespace Raven.Server.Documents.Revisions
             return true;
         }
 
+        [MethodImpl(MethodImplOptions.AggressiveInlining)]
         public void Put(DocumentsOperationContext context, string id, BlittableJsonReaderObject document,
             DocumentFlags flags, NonPersistentDocumentFlags nonPersistentFlags, string changeVector, long lastModifiedTicks,
             RevisionsCollectionConfiguration configuration = null, CollectionName collectionName = null)

--- a/src/Raven.Server/Documents/Revisions/RevisionsStorage.cs
+++ b/src/Raven.Server/Documents/Revisions/RevisionsStorage.cs
@@ -280,8 +280,14 @@ namespace Raven.Server.Documents.Revisions
             if (Configuration == null)
                 return false;
 
-            if (configuration.Disabled || configuration.MinimumRevisionsToKeep == 0)
+            if (configuration.Disabled)
                 return false;
+
+            if (configuration.MinimumRevisionsToKeep == 0)
+            {
+                documentFlags = documentFlags.Strip(DocumentFlags.HasRevisions);
+                return false;
+            }
 
             if (existingDocument == null)
             {

--- a/test/FastTests/Server/Documents/Revisions/RevisionsTests.cs
+++ b/test/FastTests/Server/Documents/Revisions/RevisionsTests.cs
@@ -165,12 +165,19 @@ namespace FastTests.Server.Documents.Revisions
                     await session.StoreAsync(company);
                     await session.SaveChangesAsync();
                 }
+
                 using (var session = store.OpenAsyncSession())
                 {
                     var company3 = await session.LoadAsync<Company>(company.Id);
                     var metadata = session.Advanced.GetMetadataFor(company3);
 
                     Assert.False(metadata.TryGetValue(Constants.Documents.Metadata.Flags, out _));
+                }
+
+                using (var session = store.OpenAsyncSession())
+                {
+                    var companiesList = await session.Advanced.Revisions.GetForAsync<Company>(company.Id);
+                    Assert.Equal(0, companiesList.Count);
                 }
             }
         }

--- a/test/FastTests/Server/Replication/ReplicationTestBase.cs
+++ b/test/FastTests/Server/Replication/ReplicationTestBase.cs
@@ -238,7 +238,7 @@ namespace FastTests.Server.Replication
             {
                 var databaseWatcher = new ExternalReplication(store.Database, $"ConnectionString-{store.Identifier}");
                 ModifyReplicationDestination(databaseWatcher);
-                tasks.Add(AddWatcherToReplicationTopology(fromStore, databaseWatcher));
+                tasks.Add(AddWatcherToReplicationTopology(fromStore, databaseWatcher, store.Urls));
             }
             await Task.WhenAll(tasks);
             foreach (var task in tasks)


### PR DESCRIPTION
- modifing a resovled document should keep the HasRevisions flags
- A revision that has the 'Conflicted' flag shouldn't overwrite the document
- fix various database change vector merging
- adding counter to a resovled document should not generate a revision