### PR TITLE
RavenDB-12778 fix

### DIFF
--- a/src/Raven.Server/Program.cs
+++ b/src/Raven.Server/Program.cs
@@ -315,11 +315,13 @@ namespace Raven.Server
 
             bool consoleColoring = true;
             if (server.Configuration.Embedded.ParentProcessId.HasValue)
+            {
                 //When opening an embedded server we must disable console coloring to avoid exceptions,
                 //due to the fact, we redirect standard input from the console.
                 consoleColoring = false;
-
-            return new RavenCli().Start(server, Console.Out, Console.In, consoleColoring);
+            }
+            
+            return new RavenCli().Start(server, Console.Out, Console.In, consoleColoring, false);
         }
 
         public static void WriteServerStatsAndWaitForEsc(RavenServer server)

--- a/src/Raven.Server/Utils/Pipes.cs
+++ b/src/Raven.Server/Utils/Pipes.cs
@@ -77,7 +77,7 @@ namespace Raven.Server.Utils
                     try
                     {
                         var cli = new RavenCli();
-                        var restart = cli.Start(ravenServer, writer, reader, false);
+                        var restart = cli.Start(ravenServer, writer, reader, false, true);
                         if (restart)
                         {
                             writer.WriteLine("Restarting Server...<DELIMETER_RESTART>");


### PR DESCRIPTION
Make sure to separate "color in console" and "use named pipes" flags in RavenCli. This makes the cli not to use "named pipes" mode when running in interactive mode, regardless if the "parent process id" is passed or not (RavenDB-12778)