### PR TITLE
RavenDB-12778 fix

### DIFF
--- a/src/Raven.Server/Utils/Cli/RavenCli.cs
+++ b/src/Raven.Server/Utils/Cli/RavenCli.cs
@@ -280,7 +280,7 @@ namespace Raven.Server.Utils.Cli
 
         private static bool CommandOpenBrowser(List<string> args, RavenCli cli)
         {
-            if (cli._usingNamedPipes == false)
+            if (cli._usingNamedPipes)
             {
                 WriteText("'openBrowser' command not supported on remote pipe connection", WarningColor, cli);
                 return true;
@@ -308,7 +308,7 @@ namespace Raven.Server.Utils.Cli
 
         private static bool CommandStats(List<string> args, RavenCli cli)
         {
-            if (cli._usingNamedPipes == false)
+            if (cli._usingNamedPipes)
             {
                 // beware not to allow this from remote - will disable local console!                
                 WriteText("'stats' command not supported on remote pipe connection. Use `info` or `prompt %M` instead", TextColor, cli);
@@ -328,7 +328,7 @@ namespace Raven.Server.Utils.Cli
 
         private static bool CommandTopThreads(List<string> args, RavenCli cli)
         {
-            if (cli._usingNamedPipes == false)
+            if (cli._usingNamedPipes)
             {
                 // beware not to allow this from remote - will disable local console!                
                 WriteText("'topThreads' command not supported on remote pipe connection.", TextColor, cli);


### PR DESCRIPTION
Make sure to separate "color in console" and "use named pipes" flags in RavenCli. This makes the cli not to use "named pipes" mode when running in interactive mode, regardless if the "parent process id" is passed or not.
Also make sure that commands that are not supported in "named pipes" mode throw exceptions PROPERLY.