### PR TITLE
RavenDB-12761 Fixing race condition in test - make sure that Index.Re…

### DIFF
--- a/test/FastTests/Server/Documents/Indexing/Auto/BasicAutoMapIndexing.cs
+++ b/test/FastTests/Server/Documents/Indexing/Auto/BasicAutoMapIndexing.cs
@@ -420,8 +420,14 @@ namespace FastTests.Server.Documents.Indexing.Auto
                         new[] { new AutoIndexField { Name = "Name", Storage = FieldStorage.No } }),
                     database))
                 {
+                    var mre = new ManualResetEvent(false);
+
+                    database.IndexStore.IndexBatchCompleted = x => { mre.Set(); };
+
                     index.Start();
                     Assert.Equal(IndexRunningStatus.Running, index.Status);
+
+                    Assert.True(mre.WaitOne(TimeSpan.FromSeconds(15)));
 
                     IndexStats stats;
                     var batchStats = new IndexingRunStats();


### PR DESCRIPTION
…setErrors isn't called meanwhile when indexing thread starts