### PR TITLE
Raven.client added ToArrayAsync()

### DIFF
--- a/src/Raven.Client/Documents/LinqExtensions.cs
+++ b/src/Raven.Client/Documents/LinqExtensions.cs
@@ -314,6 +314,19 @@ namespace Raven.Client.Documents
         }
 
         /// <summary>
+        /// Returns an array of results for a query asynchronously. 
+        /// </summary>
+        public static Task<T[]> ToArrayAsync<T>(this IQueryable<T> source, CancellationToken token = default)
+        {
+            var provider = source.Provider as IRavenQueryProvider;
+            if (provider == null)
+                throw new ArgumentException("You can only use Raven Queryable with ToArrayAsync");
+
+            var documentQuery = provider.ToAsyncDocumentQuery<T>(source.Expression);
+            return documentQuery.ToArrayAsync(token);
+        }
+
+        /// <summary>
         /// Determines whether a sequence contains any elements.
         /// </summary>
         /// 

--- a/src/Raven.Client/Documents/Session/AsyncDocumentQuery.cs
+++ b/src/Raven.Client/Documents/Session/AsyncDocumentQuery.cs
@@ -771,7 +771,14 @@ namespace Raven.Client.Documents.Session
         }
 
         /// <inheritdoc />
-        Task<List<T>> IAsyncDocumentQueryBase<T>.ToListAsync(CancellationToken token)
+        async Task<List<T>> IAsyncDocumentQueryBase<T>.ToListAsync(CancellationToken token)
+        {
+            var items = await ExecuteQueryOperation(null, token).ConfigureAwait(false);
+            return items.ToList();
+        }
+
+        /// <inheritdoc />
+        Task<T[]> IAsyncDocumentQueryBase<T>.ToArrayAsync(CancellationToken token)
         {
             return ExecuteQueryOperation(null, token);
         }
@@ -819,7 +826,7 @@ namespace Raven.Client.Documents.Session
             return result.TotalResults > 0;
         }
 
-        private async Task<List<T>> ExecuteQueryOperation(int? take, CancellationToken token)
+        private async Task<T[]> ExecuteQueryOperation(int? take, CancellationToken token)
         {
             if (take.HasValue && (PageSize.HasValue == false || PageSize > take))
                 Take(take.Value);

--- a/src/Raven.Client/Documents/Session/DocumentQuery.cs
+++ b/src/Raven.Client/Documents/Session/DocumentQuery.cs
@@ -769,8 +769,10 @@ namespace Raven.Client.Documents.Session
         /// <inheritdoc />
         public IEnumerator<T> GetEnumerator()
         {
-            return ExecuteQueryOperation(null).GetEnumerator();
+            return GetEnumerable(ExecuteQueryOperation(null)).GetEnumerator();
         }
+
+        private IEnumerable<T> GetEnumerable(T[] arr) =>  arr;
 
         /// <inheritdoc />
         T IDocumentQueryBase<T>.First()
@@ -810,7 +812,7 @@ namespace Raven.Client.Documents.Session
             return queryResult.TotalResults > 0;
         }
 
-        private List<T> ExecuteQueryOperation(int? take)
+        private T[] ExecuteQueryOperation(int? take)
         {
             if (take.HasValue && (PageSize.HasValue == false || PageSize > take))
                 Take(take.Value);

--- a/src/Raven.Client/Documents/Session/IAsyncDocumentQuery.cs
+++ b/src/Raven.Client/Documents/Session/IAsyncDocumentQuery.cs
@@ -23,6 +23,11 @@ namespace Raven.Client.Documents.Session
         Task<List<T>> ToListAsync(CancellationToken token = default);
 
         /// <summary>
+        ///     Executed the query and returns the results.
+        /// </summary>
+        Task<T[]> ToArrayAsync(CancellationToken token = default);
+
+        /// <summary>
         ///     Returns first element or throws if sequence is empty.
         /// </summary>
         Task<T> FirstAsync(CancellationToken token = default);


### PR DESCRIPTION
The most common use of materialized queries is to use an immutable data structure, like an array instead of list.
This pull requests add support to async version of the equivalent async methos query.ToArrayAsync()
It also leverage the queryResult.TotalResults to allocate the array upfront instead of letting the list grow little by little.