### PR TITLE
RavenDB-12823 Inconsistent documents number in the cluster when there…

### DIFF
--- a/src/Raven.Server/Documents/ConflictsStorage.cs
+++ b/src/Raven.Server/Documents/ConflictsStorage.cs
@@ -527,7 +527,7 @@ namespace Raven.Server.Documents
         }
 
         public (string ChangeVector, NonPersistentDocumentFlags NonPersistentFlags) MergeConflictChangeVectorIfNeededAndDeleteConflicts(
-            string documentChangeVector, DocumentsOperationContext context, string id, long newEtag, BlittableJsonReaderObject document)
+            string documentChangeVector, DocumentsOperationContext context, string id, BlittableJsonReaderObject document)
         {
             var result = DeleteConflictsFor(context, id, document);
             if (result.ChangeVectors == null ||
@@ -570,7 +570,7 @@ namespace Raven.Server.Documents
             var tx = context.Transaction.InnerTransaction;
             var conflictsTable = tx.OpenTable(ConflictsSchema, ConflictsSlice);
 
-            var fromSmuggler = (nonPersistentFlags & NonPersistentDocumentFlags.FromSmuggler) == NonPersistentDocumentFlags.FromSmuggler;
+            var fromSmuggler = nonPersistentFlags.Contain(NonPersistentDocumentFlags.FromSmuggler);
 
             using (DocumentIdWorker.GetLowerIdSliceAndStorageKey(context, id, out Slice lowerId, out Slice idPtr))
             {
@@ -651,6 +651,8 @@ namespace Raven.Server.Documents
                     using (GetConflictsIdPrefix(context, lowerId, out Slice prefixSlice))
                     {
                         var conflicts = GetConflictsFor(context, prefixSlice);
+                        Debug.Assert(conflicts.Count > 0);
+
                         foreach (var conflict in conflicts)
                         {
                             var conflictStatus = ChangeVectorUtils.GetConflictStatus(incomingChangeVector, conflict.ChangeVector);
@@ -665,7 +667,7 @@ namespace Raven.Server.Documents
                                     {
                                         return; // we already have a conflict with equal content, no need to create another one
                                     }
-                                    break; // we'll add this conflict if no one else also includes it
+                                    continue; // we'll add this conflict if no one else also includes it
                                 case ConflictStatus.AlreadyMerged:
                                     return; // we already have a conflict that includes this version
                                 default:
@@ -676,12 +678,6 @@ namespace Raven.Server.Documents
                 }
 
                 var etag = _documentsStorage.GenerateNextEtag();
-                if (context.LastDatabaseChangeVector == null)
-                    context.LastDatabaseChangeVector = GetDatabaseChangeVector(context);
-                
-                var result = ChangeVectorUtils.TryUpdateChangeVector(_documentDatabase.ServerStore.NodeTag, _documentDatabase.DbBase64Id, etag, context.LastDatabaseChangeVector);
-                if (result.IsValid)
-                    context.LastDatabaseChangeVector = result.ChangeVector;
 
                 byte* doc = null;
                 var docSize = 0;
@@ -836,7 +832,7 @@ namespace Raven.Server.Documents
                     if (status == ConflictStatus.Conflict)
                     {
                         conflictingVector = existingConflict.ChangeVector;
-                        return status;
+                        return ConflictStatus.Conflict;
                     }
                 }
                 // this document will resolve the conflicts when putted


### PR DESCRIPTION
… are conflicts

- fixing that adding a conflict could set back the database change vector.
- when there are conflicts in the database we take a different code path for putting a document and need to update the change vector correctly.