### PR TITLE
RavenDB-12764 create a revision from incoming replication

### DIFF
--- a/src/Raven.Server/Documents/Revisions/RevisionsStorage.cs
+++ b/src/Raven.Server/Documents/Revisions/RevisionsStorage.cs
@@ -273,9 +273,6 @@ namespace Raven.Server.Documents.Revisions
             if (nonPersistentFlags.Contain(NonPersistentDocumentFlags.Resolved))
                 return true;
 
-            if (nonPersistentFlags.Contain(NonPersistentDocumentFlags.FromReplication))
-                return false; // no need, since we put the revision directly from replication
-
             if (Configuration == null)
                 return false;
 


### PR DESCRIPTION
If we have an extrnal replication to a destination with revisions enabled, we have to generate a new revision upon arrival.
Since revisions keep the original change vector which is also the primary key, we can create a revision directly.