### PR TITLE
RavenDB-12823 should mutate the revision flags to include `Conflicted…

### DIFF
--- a/src/Raven.Server/Documents/Replication/ConflictManager.cs
+++ b/src/Raven.Server/Documents/Replication/ConflictManager.cs
@@ -92,7 +92,7 @@ namespace Raven.Server.Documents.Replication
                     if (local != null)
                         conflicts.Add(local);
 
-                    var resolved = _conflictResolver.ResolveToLatest(documentsContext, conflicts);
+                    var resolved = _conflictResolver.ResolveToLatest(conflicts);
                     _conflictResolver.PutResolvedDocument(documentsContext, resolved, conflictedDoc);
 
                     return;

--- a/src/Raven.Server/Documents/Revisions/RevisionsStorage.cs
+++ b/src/Raven.Server/Documents/Revisions/RevisionsStorage.cs
@@ -724,7 +724,6 @@ namespace Raven.Server.Documents.Revisions
             using (Slice.From(context.Allocator, changeVector, out var changeVectorSlice))
             {
                 var revisionExists = table.ReadByKey(changeVectorSlice,out var tvr);
-                // Revisions are immutable.
                 if (revisionExists)
                 {
                     MarkRevisionsAsConflictedIfNeeded(context, lowerId, idSlice, flags, tvr, table, changeVectorSlice);


### PR DESCRIPTION
…` once conflict is resolved