### PR TITLE
RavenDB-12793 

### DIFF
--- a/src/Voron/Impl/Scratch/ScratchBufferFile.cs
+++ b/src/Voron/Impl/Scratch/ScratchBufferFile.cs
@@ -48,16 +48,23 @@ namespace Voron.Impl.Scratch
             scratchPager.AllocatedInBytesFunc = () => AllocatedPagesCount * Constants.Storage.PageSize;
 
             _disposeOnceRunner = new DisposeOnce<SingleAttempt>(() =>
-            {
+            {                
                 _scratchPager.PagerState.DiscardOnTxCopy = true;
                 _scratchPager.Dispose();
+                ClearDictionaries();
             });
+        }
+
+        [MethodImpl(MethodImplOptions.AggressiveInlining)]
+        private void ClearDictionaries()
+        {
+            _allocatedPages.Clear();
+            _freePagesBySizeAvailableImmediately.Clear();
+            _freePagesBySize.Clear();
         }
 
         public void Reset()
         {
-            _allocatedPages.Clear();
-
 #if VALIDATE
             foreach (var free in _freePagesBySizeAvailableImmediately)
             {
@@ -70,10 +77,6 @@ namespace Voron.Impl.Scratch
                     _scratchPager.UnprotectPageRange(freeAndAvailablePagePointer, freeAndAvailablePageSize, true);
                 }
             }            
-#endif
-            _freePagesBySizeAvailableImmediately.Clear();
-
-#if VALIDATE
             foreach (var free in _freePagesBySize)
             {
                 foreach (var val in free.Value)
@@ -86,7 +89,7 @@ namespace Voron.Impl.Scratch
                 }
             }
 #endif
-            _freePagesBySize.Clear();
+            ClearDictionaries();
             _txIdAfterWhichLatestFreePagesBecomeAvailable = -1;
             _lastUsedPage = 0;
             _allocatedPagesCount = 0;

--- a/src/Voron/Impl/Scratch/ScratchBufferPool.cs
+++ b/src/Voron/Impl/Scratch/ScratchBufferPool.cs
@@ -81,6 +81,8 @@ namespace Voron.Impl.Scratch
 
                     _recycleArea.RemoveFirst();
                 }
+
+                _current = null;
             });
 
             _env = env;

--- a/test/StressTests/Server/Replication/ExternalReplicationStressTests.cs
+++ b/test/StressTests/Server/Replication/ExternalReplicationStressTests.cs
@@ -1,4 +1,5 @@
-﻿using System.Threading.Tasks;
+﻿using System;
+using System.Threading.Tasks;
 using FastTests;
 using FastTests.Server.Replication;
 using SlowTests.Server.Replication;
@@ -15,21 +16,6 @@ namespace StressTests.Server.Replication
             for (int i = 0; i < 100; i++)
             {
                 Parallel.For(0, 10, RavenTestHelper.DefaultParallelOptions, _ =>
-                {
-                    using (var test = new ExternalReplicationTests())
-                    {
-                        test.ExternalReplicationShouldWorkWithSmallTimeoutStress().Wait();
-                    }
-                });
-            }
-        }
-
-        [Fact32Bit]
-        public void ExternalReplicationShouldWorkWithSmallTimeoutStress32()
-        {
-            for (int i = 0; i < 100; i++)
-            {
-                Parallel.For(0, 5, RavenTestHelper.DefaultParallelOptions, _ =>
                 {
                     using (var test = new ExternalReplicationTests())
                     {


### PR DESCRIPTION
@ayende I have reverted the task runner to its original form since the modifications made by you still kept references to the DocumentDatabase and I could see the leak in the dump we took