### PR TITLE
RavenDB-12854 We must not use current tx when dealing with compressio…

### DIFF
--- a/src/Voron/Impl/Journal/WriteAheadJournal.cs
+++ b/src/Voron/Impl/Journal/WriteAheadJournal.cs
@@ -1354,50 +1354,62 @@ namespace Voron.Impl.Journal
             lock (_writeLock)
             {
                 var sp = Stopwatch.StartNew();
-                var journalEntry = PrepareToWriteToJournal(tx);
-                if (_logger.IsInfoEnabled)
+
+                IPagerLevelTransactionState tempEncCompressionPagerTxState = null;
+
+                if (_env.Options.EncryptionEnabled)
                 {
-                    _logger.Info($"Preparing to write tx {tx.Id} to journal with {journalEntry.NumberOfUncompressedPages:#,#} pages ({(journalEntry.NumberOfUncompressedPages * Constants.Storage.PageSize) / Constants.Size.Kilobyte:#,#} kb) in {sp.Elapsed} with {Math.Round(journalEntry.NumberOf4Kbs * 4d, 1):#,#.#;;0} kb compressed.");
+                    tempEncCompressionPagerTxState = new TempPagerTransaction(true);
                 }
 
-                if (tx.IsLazyTransaction && _lazyTransactionBuffer == null)
+                using (tempEncCompressionPagerTxState)
                 {
-                    _lazyTransactionBuffer = new LazyTransactionBuffer(_env.Options);
-                }
-
-                if (CurrentFile == null || CurrentFile.Available4Kbs < journalEntry.NumberOf4Kbs)
-                {
-                    _lazyTransactionBuffer?.WriteBufferToFile(CurrentFile, tx);
-                    CurrentFile = NextFile(journalEntry.NumberOf4Kbs);
+                    var journalEntry = PrepareToWriteToJournal(tx, tempEncCompressionPagerTxState);
                     if (_logger.IsInfoEnabled)
-                        _logger.Info($"New journal file created {CurrentFile.Number:D19}");
+                    {
+                        _logger.Info(
+                            $"Preparing to write tx {tx.Id} to journal with {journalEntry.NumberOfUncompressedPages:#,#} pages ({(journalEntry.NumberOfUncompressedPages * Constants.Storage.PageSize) / Constants.Size.Kilobyte:#,#} kb) in {sp.Elapsed} with {Math.Round(journalEntry.NumberOf4Kbs * 4d, 1):#,#.#;;0} kb compressed.");
+                    }
+
+                    if (tx.IsLazyTransaction && _lazyTransactionBuffer == null)
+                    {
+                        _lazyTransactionBuffer = new LazyTransactionBuffer(_env.Options);
+                    }
+
+                    if (CurrentFile == null || CurrentFile.Available4Kbs < journalEntry.NumberOf4Kbs)
+                    {
+                        _lazyTransactionBuffer?.WriteBufferToFile(CurrentFile, tx);
+                        CurrentFile = NextFile(journalEntry.NumberOf4Kbs);
+                        if (_logger.IsInfoEnabled)
+                            _logger.Info($"New journal file created {CurrentFile.Number:D19}");
+                    }
+
+                    sp.Restart();
+                    journalEntry.UpdatePageTranslationTableAndUnusedPages = CurrentFile.Write(tx, journalEntry, _lazyTransactionBuffer);
+                    sp.Stop();
+                    _lastCompressionAccelerationInfo.WriteDuration = sp.Elapsed;
+                    _lastCompressionAccelerationInfo.CalculateOptimalAcceleration();
+
+                    if (_logger.IsInfoEnabled)
+                        _logger.Info($"Writing {journalEntry.NumberOf4Kbs * 4:#,#} kb to journal {CurrentFile.Number:D19} took {sp.Elapsed}");
+
+                    journalFilePath = CurrentFile.JournalWriter.FileName.FullPath;
+
+                    if (CurrentFile.Available4Kbs == 0)
+                    {
+                        _lazyTransactionBuffer?.WriteBufferToFile(CurrentFile, tx);
+                        CurrentFile = null;
+                    }
+
+                    ZeroCompressionBufferIfNeeded(tempEncCompressionPagerTxState ?? tx);
+                    ReduceSizeOfCompressionBufferIfNeeded();
+
+                    return journalEntry;
                 }
-
-                sp.Restart();
-                journalEntry.UpdatePageTranslationTableAndUnusedPages = CurrentFile.Write(tx, journalEntry, _lazyTransactionBuffer);
-                sp.Stop();
-                _lastCompressionAccelerationInfo.WriteDuration = sp.Elapsed;
-                _lastCompressionAccelerationInfo.CalculateOptimalAcceleration();
-
-                if (_logger.IsInfoEnabled)
-                    _logger.Info($"Writing {journalEntry.NumberOf4Kbs * 4:#,#} kb to journal {CurrentFile.Number:D19} took {sp.Elapsed}");
-
-                journalFilePath = CurrentFile.JournalWriter.FileName.FullPath;
-
-                if (CurrentFile.Available4Kbs == 0)
-                {
-                    _lazyTransactionBuffer?.WriteBufferToFile(CurrentFile, tx);
-                    CurrentFile = null;
-                }
-
-                ZeroCompressionBufferIfNeeded(tx);
-                ReduceSizeOfCompressionBufferIfNeeded();
-
-                return journalEntry;
             }
         }
 
-        private CompressedPagesResult PrepareToWriteToJournal(LowLevelTransaction tx)
+        private CompressedPagesResult PrepareToWriteToJournal(LowLevelTransaction tx, IPagerLevelTransactionState tempEncCompressionPagerTxState)
         {
             var txPages = tx.GetTransactionPages();
             var numberOfPages = txPages.Count;
@@ -1431,10 +1443,12 @@ namespace Voron.Impl.Journal
                 throw;
             }
 
-            tx.EnsurePagerStateReference(pagerState);
+            var compressionPagerTxState = tempEncCompressionPagerTxState ?? tx;
 
-            _compressionPager.EnsureMapped(tx, 0, pagesRequired);
-            var txHeaderPtr = _compressionPager.AcquirePagePointer(tx, 0);
+            compressionPagerTxState.EnsurePagerStateReference(pagerState);
+
+            _compressionPager.EnsureMapped(compressionPagerTxState, 0, pagesRequired);
+            var txHeaderPtr = _compressionPager.AcquirePagePointer(compressionPagerTxState, 0);
             var txPageInfoPtr = txHeaderPtr + sizeof(TransactionHeader);
             var pagesInfo = (TransactionHeaderPageInfo*)txPageInfoPtr;
 
@@ -1530,10 +1544,10 @@ namespace Voron.Impl.Journal
                     throw;
                 }
 
-                tx.EnsurePagerStateReference(pagerState);
-                _compressionPager.EnsureMapped(tx, pagesWritten, outputBufferInPages);
+                compressionPagerTxState.EnsurePagerStateReference(pagerState);
+                _compressionPager.EnsureMapped(compressionPagerTxState, pagesWritten, outputBufferInPages);
 
-                txHeaderPtr = _compressionPager.AcquirePagePointer(tx, pagesWritten);
+                txHeaderPtr = _compressionPager.AcquirePagePointer(compressionPagerTxState, pagesWritten);
                 var compressionBuffer = txHeaderPtr + sizeof(TransactionHeader);
 
                 var compressionDuration = Stopwatch.StartNew();


### PR DESCRIPTION
…n buffer pager if encryption is on. The issue was that dispose of previous transaction could zero data in compression.buffers (CryptoPager.TxOnDispose) while it was already in use by another transaction (note that tx write lock is released before the tx dispose). The solution is to use temporary tx while working with compression.buffers pager so it won't be accessed concurrently.