### PR TITLE
fix for RavenDB-12494

### DIFF
--- a/src/Raven.Server/Routing/RequestRouter.cs
+++ b/src/Raven.Server/Routing/RequestRouter.cs
@@ -114,7 +114,7 @@ namespace Raven.Server.Routing
                 {
                     using (reqCtx.Database.DatabaseInUse(tryMatch.Value.SkipUsagesCount))
                     {
-                        if (context.Response.Headers.TryGetValue(Constants.Headers.LastKnownClusterTransactionIndex, out var value)
+                        if (context.Request.Headers.TryGetValue(Constants.Headers.LastKnownClusterTransactionIndex, out var value)
                             && long.TryParse(value, out var index)
                             && index < reqCtx.Database.RachisLogIndexNotifications.LastModifiedIndex)
                         {


### PR DESCRIPTION
In RequestRouter, make sure to check the Request and not Response headers for cluster-wide transaction's LastKnownClusterTransactionIndex. (otherwise we would not be waiting for the cluster transaction _at all_, because the waiting code never executes)