### PR TITLE
RavenDB-12921 - Client failover for more than 2 nodes fails

### DIFF
--- a/src/Raven.Client/Http/NodeSelector.cs
+++ b/src/Raven.Client/Http/NodeSelector.cs
@@ -81,7 +81,7 @@ namespace Raven.Client.Http
         {
             // if there are all marked as failed, we'll chose the first
             // one so the user will get an error (or recover :-) );
-            if(state.Nodes.Count == 0)
+            if (state.Nodes.Count == 0)
                 throw new AllTopologyNodesDownException("There are no nodes in the topology at all");
 
             return (0, state.Nodes[0]);

--- a/src/Raven.Client/Http/RequestExecutor.cs
+++ b/src/Raven.Client/Http/RequestExecutor.cs
@@ -1077,7 +1077,7 @@ namespace Raven.Client.Http
 
             if (nodeIndex.HasValue == false)
             {
-                //We executed request over a node not in the topology. This means no failover...
+                // we executed request over a node not in the topology. This means no failover...
                 return false;
             }
 
@@ -1096,7 +1096,7 @@ namespace Raven.Client.Http
 
             OnFailedRequest(url, e);
 
-            await ExecuteAsync(currentNode, currentIndex, context, command, shouldRetry: default, sessionInfo: sessionInfo, token: token).ConfigureAwait(false);
+            await ExecuteAsync(currentNode, currentIndex, context, command, shouldRetry: true, sessionInfo: sessionInfo, token: token).ConfigureAwait(false);
 
             return true;
         }
@@ -1182,7 +1182,7 @@ namespace Raven.Client.Http
                     }
 
                     if (_failedNodesTimers.TryRemove(nodeStatus.Node, out status))
-                            status.Value.Dispose();
+                        status.Value.Dispose();
 
                     _nodeSelector?.RestoreNodeIndex(nodeStatus.NodeIndex);
                 }

--- a/test/SlowTests/Issues/RavenDB-12921.cs
+++ b/test/SlowTests/Issues/RavenDB-12921.cs
@@ -1,0 +1,126 @@
+﻿using System;
+using System.Linq;
+using System.Threading.Tasks;
+using FastTests.Server.Basic.Entities;
+using Raven.Client.Documents;
+using Raven.Client.Documents.Session;
+using Raven.Client.Exceptions;
+using Tests.Infrastructure;
+using Xunit;
+
+namespace SlowTests.Issues
+{
+    public class RavenDB_12921 : ClusterTestBase
+    {
+        [Theory]
+        [InlineData(3)]
+        [InlineData(5)]
+        [InlineData(7)]
+        public async Task Can_failover_after_consecutive_failures(int nodes)
+        {
+            const string databaseName = "test";
+            var leader = await CreateRaftClusterAndGetLeader(nodes);
+            using (var store = new DocumentStore
+            {
+                Urls = new[] { leader.WebUrl },
+                Database = databaseName
+            }.Initialize())
+            {
+                var (index, _) = await CreateDatabaseInCluster(databaseName, nodes, leader.WebUrl);
+                await WaitForRaftIndexToBeAppliedInCluster(index, TimeSpan.FromSeconds(30));
+                const string id = "orders/1";
+
+                using (var session = (DocumentSession)store.OpenSession())
+                {
+                    session.Store(new Order { Company = "Hibernating Rhinos" }, id);
+                    session.SaveChanges();
+
+                    Assert.True(await WaitForDocumentInClusterAsync<Order>(
+                        session,
+                        "orders/1",
+                        u => u.Company.Equals("Hibernating Rhinos"),
+                        TimeSpan.FromSeconds(10)));
+                }
+
+                using (var session = store.OpenSession())
+                {
+                    var order = session.Load<Order>(id);
+                    Assert.NotNull(order);
+                }
+
+                // dispose the first topology nodes, forcing the requestExecutor to failover to the last one
+                var requestExecutor = store.GetRequestExecutor();
+                for (var i = 0; i < requestExecutor.TopologyNodes.Count - 1; i++)
+                {
+                    var serverToDispose = Servers.FirstOrDefault(
+                        srv => srv.ServerStore.NodeTag.Equals(requestExecutor.TopologyNodes[i].ClusterTag, StringComparison.OrdinalIgnoreCase));
+                    Assert.NotNull(serverToDispose);
+
+                    DisposeServerAndWaitForFinishOfDisposal(serverToDispose);
+                }
+
+                using (var session = store.OpenSession())
+                {
+                    var order = session.Load<Order>(id);
+                    Assert.NotNull(order);
+                }
+            }
+        }
+
+        [Theory]
+        [InlineData(3)]
+        [InlineData(5)]
+        [InlineData(7)]
+        public async Task Will_throw_when_all_nodes_are_down(int nodes)
+        {
+            const string databaseName = "test";
+            var leader = await CreateRaftClusterAndGetLeader(nodes);
+            using (var store = new DocumentStore
+            {
+                Urls = new []{ leader .WebUrl },
+                Database = databaseName
+            }.Initialize())
+            {
+                var (index, _) = await CreateDatabaseInCluster(databaseName, nodes, leader.WebUrl);
+                await WaitForRaftIndexToBeAppliedInCluster(index, TimeSpan.FromSeconds(30));
+
+                const string id = "orders/1";
+
+                using (var session = (DocumentSession)store.OpenSession())
+                {
+                    session.Store(new Order { Company = "Hibernating Rhinos" }, id);
+                    session.SaveChanges();
+
+                    Assert.True(await WaitForDocumentInClusterAsync<Order>(
+                        session,
+                        "orders/1",
+                        u => u.Company.Equals("Hibernating Rhinos"),
+                        TimeSpan.FromSeconds(10)));
+                }
+
+                using (var session = store.OpenSession())
+                {
+                    var order = session.Load<Order>(id);
+                    Assert.NotNull(order);
+                }
+
+                // dispose the first topology nodes, forcing the requestExecutor to failover to the last one
+                var requestExecutor = store.GetRequestExecutor();
+                for (var i = 0; i < requestExecutor.TopologyNodes.Count; i++)
+                {
+                    var serverToDispose = Servers.FirstOrDefault(
+                        srv => srv.ServerStore.NodeTag.Equals(requestExecutor.TopologyNodes[i].ClusterTag, StringComparison.OrdinalIgnoreCase));
+                    Assert.NotNull(serverToDispose);
+
+                    DisposeServerAndWaitForFinishOfDisposal(serverToDispose);
+                }
+
+                using (var session = store.OpenSession())
+                {
+                    var exception = Assert.Throws<AllTopologyNodesDownException>(() => session.Load<Order>(id));
+                    Assert.Contains("to all configured nodes in the topology, none of the attempt succeeded", exception.Message);
+                }
+            }
+        }
+    }
+}

--- a/test/SlowTests/Issues/RavenDB-12921.cs
+++ b/test/SlowTests/Issues/RavenDB-12921.cs
@@ -104,12 +104,12 @@ namespace SlowTests.Issues
                     Assert.NotNull(order);
                 }
 
-                // dispose the first topology nodes, forcing the requestExecutor to failover to the last one
+                // dispose all topology nodes
                 var requestExecutor = store.GetRequestExecutor();
-                for (var i = 0; i < requestExecutor.TopologyNodes.Count; i++)
+                foreach (var node in requestExecutor.TopologyNodes)
                 {
                     var serverToDispose = Servers.FirstOrDefault(
-                        srv => srv.ServerStore.NodeTag.Equals(requestExecutor.TopologyNodes[i].ClusterTag, StringComparison.OrdinalIgnoreCase));
+                        srv => srv.ServerStore.NodeTag.Equals(node.ClusterTag, StringComparison.OrdinalIgnoreCase));
                     Assert.NotNull(serverToDispose);
 
                     DisposeServerAndWaitForFinishOfDisposal(serverToDispose);


### PR DESCRIPTION
https://issues.hibernatingrhinos.com/issue/RavenDB-12921