### PR TITLE
RavenDB-12823 a resolved document will generate a new change vector t…

### DIFF
--- a/src/Raven.Server/Documents/ConflictsStorage.cs
+++ b/src/Raven.Server/Documents/ConflictsStorage.cs
@@ -540,11 +540,12 @@ namespace Raven.Server.Documents
             {
                 documentChangeVector,
                 context.LastDatabaseChangeVector ?? GetDatabaseChangeVector(context),
-                ChangeVectorUtils.NewChangeVector(_documentDatabase.ServerStore.NodeTag, newEtag, _documentsStorage.Environment.Base64Id)
+                ChangeVectorUtils.NewChangeVector(_documentDatabase, newEtag)
             };
             changeVectorList.AddRange(result.ChangeVectors);
+            var merged = ChangeVectorUtils.MergeVectors(changeVectorList);
 
-            return (ChangeVectorUtils.MergeVectors(changeVectorList), result.NonPersistentFlags);
+            return (merged, result.NonPersistentFlags);
         }
 
         public void AddConflict(

--- a/src/Raven.Server/Documents/Replication/ConflictManager.cs
+++ b/src/Raven.Server/Documents/Replication/ConflictManager.cs
@@ -206,7 +206,7 @@ namespace Raven.Server.Documents.Replication
                 if (compareResult == DocumentCompareResult.NotEqual)
                     return false;
 
-                // no real conflict here, both documents have identical content
+                // no real conflict here, both documents have identical content so we only merge the change vector without increasing the local etag to prevent ping-pong replication
                 var mergedChangeVector = ChangeVectorUtils.MergeVectors(incomingChangeVector, existingDoc.ChangeVector);
 
                 var nonPersistentFlags = NonPersistentDocumentFlags.FromResolver;

--- a/src/Raven.Server/Documents/Replication/ResolveConflictOnReplicationConfigurationChange.cs
+++ b/src/Raven.Server/Documents/Replication/ResolveConflictOnReplicationConfigurationChange.cs
@@ -248,12 +248,15 @@ namespace Raven.Server.Documents.Replication
         {
             SaveConflictedDocumentsAsRevisions(context, resolved.Id, incoming);
 
+            // Resolved document should generate a new change vector, since it was changed locally. 
+            // In a cluster this may cause a ping-pong replication which will be settled down by the fact that a conflict with identical content doesn't increase the local etag
+            var changeVector = _database.DocumentsStorage.CreateNextDatabaseChangeVector(context, resolved.ChangeVector);
+
             if (resolved.Doc == null)
             {
                 using (Slice.External(context.Allocator, resolved.LowerId, out var lowerId))
                 {
-                    _database.DocumentsStorage.Delete(context, lowerId, resolved.Id, null,
-                        resolved.LastModified.Ticks, resolved.ChangeVector, new CollectionName(resolved.Collection),
+                    _database.DocumentsStorage.Delete(context, lowerId, resolved.Id, null,null, changeVector, new CollectionName(resolved.Collection),
                         documentFlags: resolved.Flags | DocumentFlags.Resolved | DocumentFlags.HasRevisions, nonPersistentFlags: NonPersistentDocumentFlags.FromResolver | NonPersistentDocumentFlags.Resolved);
                     return;
                 }
@@ -274,10 +277,10 @@ namespace Raven.Server.Documents.Replication
                 // we always want to merge the counters and attachments, even if the user specified a script
                 var nonPersistentFlags = NonPersistentDocumentFlags.ResolveCountersConflict | NonPersistentDocumentFlags.ResolveAttachmentsConflict |
                                          NonPersistentDocumentFlags.FromResolver | NonPersistentDocumentFlags.Resolved;
-                _database.DocumentsStorage.Put(context, resolved.Id, null, clone, resolved.LastModified.Ticks, resolved.ChangeVector, resolved.Flags | DocumentFlags.Resolved, nonPersistentFlags: nonPersistentFlags);
+                _database.DocumentsStorage.Put(context, resolved.Id, null, clone, null, changeVector, resolved.Flags | DocumentFlags.Resolved, nonPersistentFlags: nonPersistentFlags);
             }
         }
-
+        
         private void SaveConflictedDocumentsAsRevisions(DocumentsOperationContext context, string id, DocumentConflict incoming)
         {
             if (incoming == null)

--- a/src/Raven.Server/Utils/ChangeVectorUtils.cs
+++ b/src/Raven.Server/Utils/ChangeVectorUtils.cs
@@ -5,6 +5,7 @@ using System.Linq;
 using System.Runtime.CompilerServices;
 using System.Text;
 using Lucene.Net.Support;
+using Raven.Server.Documents;
 using Raven.Server.Documents.Replication;
 using Sparrow;
 using Sparrow.Utils;
@@ -112,6 +113,16 @@ namespace Raven.Server.Utils
                 num += s[start + i] - '0';
             }
             return num;
+        }
+
+        public static (bool IsValid, string ChangeVector) TryUpdateChangeVector(DocumentDatabase database, string oldChangeVector, long? etag = null)
+        {
+            if (etag == null)
+            {
+                etag = database.DocumentsStorage.GenerateNextEtag();
+            }
+
+            return TryUpdateChangeVector(database.ServerStore.NodeTag, database.DbBase64Id, etag.Value, oldChangeVector);
         }
 
         public static (bool IsValid, string ChangeVector) TryUpdateChangeVector(string nodeTag, string dbIdInBase64, long etag, string oldChangeVector)
@@ -227,6 +238,11 @@ namespace Raven.Server.Utils
             }
 
             return _mergeVectorBuffer.SerializeVector();
+        }
+
+        public static string NewChangeVector(DocumentDatabase database, long etag)
+        {
+            return NewChangeVector(database.ServerStore.NodeTag, etag, database.DbBase64Id);
         }
 
         public static string NewChangeVector(string nodeTag, long etag, string dbIdInBase64)

--- a/test/SlowTests/Cluster/ClusterTransactionTests.cs
+++ b/test/SlowTests/Cluster/ClusterTransactionTests.cs
@@ -799,8 +799,12 @@ namespace SlowTests.Cluster
                         var user = await session.LoadAsync<User>("foo/bar");
                         var changeVector = session.Advanced.GetChangeVectorFor(user);
                         Assert.NotNull(await session.Advanced.Revisions.GetAsync<User>(changeVector));
-                        var list = await session.Advanced.Revisions.GetForAsync<User>("foo/bar");
-                        Assert.Equal(2, list.Count);
+                        var count = await WaitForValueAsync((async () =>
+                        {
+                            var list = await session.Advanced.Revisions.GetForAsync<User>("foo/bar");
+                            return list.Count;
+                        }), 2);
+                        Assert.Equal(2, count);
 
                         // revive another node so we should have a functional cluster now
                         Servers[2] = GetNewServer(new Dictionary<string, string>
@@ -817,8 +821,12 @@ namespace SlowTests.Cluster
                         var database = await Servers[1].ServerStore.DatabasesLandlord.TryGetOrCreateResourceStore(leaderStore.Database);
                         await database.RachisLogIndexNotifications.WaitForIndexNotification(lastRaftIndex, TimeSpan.FromSeconds(15));
 
-                        list = await session.Advanced.Revisions.GetForAsync<User>("foo/bar");
-                        Assert.Equal(2, list.Count);
+                        count = await WaitForValueAsync((async () =>
+                        {
+                            var list = await session.Advanced.Revisions.GetForAsync<User>("foo/bar");
+                            return list.Count;
+                        }), 2);
+                        Assert.Equal(2, count);
                     }
                 }
             }

--- a/test/SlowTests/Server/Replication/ReplicationWithRevisions.cs
+++ b/test/SlowTests/Server/Replication/ReplicationWithRevisions.cs
@@ -249,14 +249,7 @@ namespace SlowTests.Server.Replication
                     var flags = metadata[0]["@flags"];
                     Assert.Equal((DocumentFlags.Revision | DocumentFlags.HasRevisions | DocumentFlags.FromReplication | DocumentFlags.Resolved).ToString(), flags);
                     flags = metadata[1]["@flags"];
-                    if (configureVersioning)
-                    {
-                        Assert.Equal((DocumentFlags.Revision | DocumentFlags.HasRevisions | DocumentFlags.Conflicted).ToString(), flags);
-                    }
-                    else
-                    {
-                        Assert.Equal((DocumentFlags.Revision | DocumentFlags.HasRevisions | DocumentFlags.FromReplication | DocumentFlags.Conflicted).ToString(), flags);
-                    }
+                    Assert.Equal((DocumentFlags.Revision | DocumentFlags.HasRevisions | DocumentFlags.Conflicted).ToString(), flags);
                     flags = metadata[2]["@flags"];
                     Assert.Equal((DocumentFlags.Revision | DocumentFlags.HasRevisions | DocumentFlags.FromReplication | DocumentFlags.Conflicted).ToString(), flags);
                 }


### PR DESCRIPTION
…o ensure it uniqueness across the nodes

Under a specific sequence of events we could end up with different documents having the same change vector