### PR TITLE
RavenDB-12926 AsyncManualResetEvent.WaitAsync(Cts) should work even i…

### DIFF
--- a/src/Sparrow/AsyncManualResetEvent.cs
+++ b/src/Sparrow/AsyncManualResetEvent.cs
@@ -53,6 +53,7 @@ namespace Sparrow
                 }
                 tcs.TrySetResult(t.Result);
             }, token);
+            token.Register(() => tcs.TrySetCanceled(token));
             return tcs.Task;
         }
 

--- a/test/FastTests/Issues/RavenDB-12926.cs
+++ b/test/FastTests/Issues/RavenDB-12926.cs
@@ -1,0 +1,42 @@
+﻿using System;
+using System.Collections.Generic;
+using System.Text;
+using System.Threading;
+using System.Threading.Tasks;
+using Raven.Server.Utils;
+using Sparrow;
+using Xunit;
+
+namespace FastTests.Issues
+{
+    public class RavenDB_12926: RavenTestBase
+    {
+        [Fact]
+        public void AsyncManualResetEventWaitAsyncWithCancellationShouldWork()
+        {
+            var amre = new AsyncManualResetEvent();
+            var cts = new CancellationTokenSource();
+            var are = new AutoResetEvent(false);
+            Task.Run(async() =>
+            {
+                try
+                {
+                    are.Set();
+                    await amre.WaitAsync(cts.Token);
+                    Assert.True(false, "AsyncManualResetEvent is expected to throw when canceled and it didn't");
+                }
+                finally
+                {
+                    are.Set();
+                }                
+            });
+            are.WaitOne();
+
+            //I want to test the AsyncManualResetEvent when the Cts is not canceled so i'm waiting abit
+            var start = DateTime.UtcNow;
+            SpinWait.SpinUntil(()=>DateTime.UtcNow - start > TimeSpan.FromMilliseconds(100));
+            cts.Cancel();
+            Assert.True(are.WaitOne(TimeSpan.FromSeconds(5)), "Waited for 30sec for AsyncManualResetEvent to be canceled be it didn't");
+        }
+    }
+}


### PR DESCRIPTION
…f original Cts is none