### PR TITLE
RavenDB-12904 Let's not include stats of current ETL batch to the ove…

### DIFF
--- a/src/Raven.Server/Documents/ETL/EtlProcess.cs
+++ b/src/Raven.Server/Documents/ETL/EtlProcess.cs
@@ -1057,7 +1057,8 @@ namespace Raven.Server.Documents.ETL
 
             var performance = _lastStats?.ToPerformanceLiveStats();
 
-            if (performance != null && performance.DurationInMs > 0)
+            if (performance != null && performance.DurationInMs > 0 &&
+                performance.SuccessfullyLoaded != false && FallbackTime != null)
             {
                 var processedPerSecondInCurrentBatch = performance.NumberOfExtractedItems.Sum(x => x.Value) / (performance.DurationInMs / 1000);
 


### PR DESCRIPTION
…rall progress if we're in fallback mode and the load was unsuccessful