### PR TITLE
RavenDB-12941

### DIFF
--- a/src/Raven.Client/Http/RequestExecutor.cs
+++ b/src/Raven.Client/Http/RequestExecutor.cs
@@ -830,7 +830,7 @@ namespace Raven.Client.Http
 
         private void ThrowFailedToContactAllNodes<TResult>(RavenCommand<TResult> command, HttpRequestMessage request)
         {
-            if (command.FailedNodes.Count == 0) //precaution, should never happen at this point
+            if (command.FailedNodes == null || command.FailedNodes.Count == 0) //precaution, should never happen at this point
                 throw new InvalidOperationException("Received unsuccessful response and couldn't recover from it. Also, no record of exceptions per failed nodes. " +
                                                     "This is weird and should not happen.");
 
@@ -1019,7 +1019,7 @@ namespace Raven.Client.Http
 
                     await UpdateTopologyAsync(chosenNode, Timeout.Infinite, forceUpdate: true, debugTag: "handle-unsuccessful-response").ConfigureAwait(false);
                     var (index, node) = ChooseNodeForRequest(command, sessionInfo);
-                    await ExecuteAsync(node, index, context, command, shouldRetry: false, sessionInfo: sessionInfo, token: token).ConfigureAwait(false);
+                    await ExecuteAsync(node, index, context, command, shouldRetry: true, sessionInfo: sessionInfo, token: token).ConfigureAwait(false);
                     return true;
                 case HttpStatusCode.GatewayTimeout:
                 case HttpStatusCode.RequestTimeout:


### PR DESCRIPTION
- after receiving http status gone (caused by DatabaseNotRelevantException) and refreshing the topology, we need to execute the command once again with retries in order to check all nodes in the retrieved topology, not only the first one
- this behavior also avoids possible NRE in ThrowFailedToContactAllNodes