### PR TITLE
RavenDB-12806 Added cancellation token when waiting for index lock. W…

### DIFF
--- a/src/Raven.Server/Documents/Handlers/IndexHandler.cs
+++ b/src/Raven.Server/Documents/Handlers/IndexHandler.cs
@@ -52,7 +52,7 @@ namespace Raven.Server.Documents.Handlers
 
             while (Database.DatabaseShutdown.IsCancellationRequested == false)
             {
-                if (Database.IndexStore.TryReplaceIndexes(name, newIndex.Name))
+                if (Database.IndexStore.TryReplaceIndexes(name, newIndex.Name, Database.DatabaseShutdown))
                     break;
             }
 

--- a/src/Raven.Server/Documents/Indexes/Index.cs
+++ b/src/Raven.Server/Documents/Indexes/Index.cs
@@ -1117,7 +1117,7 @@ namespace Raven.Server.Documents.Indexes
                                             // in this case, worst case scenario we'll handle this in the next batch
                                             while (_indexingProcessCancellationTokenSource.IsCancellationRequested == false)
                                             {
-                                                if (DocumentDatabase.IndexStore.TryReplaceIndexes(originalName, Definition.Name))
+                                                if (DocumentDatabase.IndexStore.TryReplaceIndexes(originalName, Definition.Name, _indexingProcessCancellationTokenSource.Token))
                                                 {
                                                     StartIndexingThread();
                                                     return;

--- a/src/Raven.Server/Documents/Indexes/IndexStore.cs
+++ b/src/Raven.Server/Documents/Indexes/IndexStore.cs
@@ -44,7 +44,7 @@ namespace Raven.Server.Documents.Indexes
         private readonly ServerStore _serverStore;
 
         private readonly CollectionOfIndexes _indexes = new CollectionOfIndexes();
-        private readonly ConcurrentDictionary<string, object> _indexLocks = new ConcurrentDictionary<string, object>(StringComparer.OrdinalIgnoreCase);
+        private readonly ConcurrentDictionary<string, SemaphoreSlim> _indexLocks = new ConcurrentDictionary<string, SemaphoreSlim>(StringComparer.OrdinalIgnoreCase);
 
         private bool _initialized;
 
@@ -104,7 +104,11 @@ namespace Raven.Server.Documents.Indexes
 
         private void HandleAutoIndexChange(string name, AutoIndexDefinitionBase definition)
         {
-            lock (GetIndexLock(name))
+            var indexLock = GetIndexLock(name);
+
+            indexLock.Wait(_documentDatabase.DatabaseShutdown);
+            
+            try
             {
                 var creationOptions = IndexCreationOptions.Create;
                 var existingIndex = GetIndex(name);
@@ -157,6 +161,10 @@ namespace Raven.Server.Documents.Indexes
                     throw new NotImplementedException($"Unknown index definition type: {definition.GetType().FullName}");
 
                 CreateIndexInternal(index);
+            }
+            finally
+            {
+                indexLock.Release();
             }
         }
 
@@ -233,6 +241,10 @@ namespace Raven.Server.Documents.Indexes
                     var indexName = name;
                     if (_logger.IsInfoEnabled)
                         _logger.Info($"Could not update static index {name}", exception);
+
+                    if (exception is OperationCanceledException)
+                        return;
+
                     //If we don't have the index in memory this means that it is corrupted when trying to load it
                     //If we do have the index and it is not faulted this means that this is the replacement index that is faulty
                     //If we already have a replacement that is faulty don't add a new one
@@ -254,7 +266,11 @@ namespace Raven.Server.Documents.Indexes
 
         private void HandleStaticIndexChange(string name, IndexDefinition definition)
         {
-            lock (GetIndexLock(name))
+            var indexLock = GetIndexLock(name);
+
+            indexLock.Wait(_documentDatabase.DatabaseShutdown);
+
+            try
             {
                 var creationOptions = IndexCreationOptions.Create;
                 var currentIndex = GetIndex(name);
@@ -329,6 +345,10 @@ namespace Raven.Server.Documents.Indexes
                 }
 
                 CreateIndexInternal(index);
+            }
+            finally
+            {
+                indexLock.Release();
             }
         }
 
@@ -1266,11 +1286,22 @@ namespace Raven.Server.Documents.Indexes
             }
         }
 
-        public bool TryReplaceIndexes(string oldIndexName, string replacementIndexName)
+        public bool TryReplaceIndexes(string oldIndexName, string replacementIndexName, CancellationToken token)
         {
             try
             {
-                lock (GetIndexLock(oldIndexName))
+                var indexLock = GetIndexLock(oldIndexName);
+
+                try
+                {
+                    indexLock.Wait(token);
+                }
+                catch (OperationCanceledException)
+                {
+                    return false;
+                }
+
+                try
                 {
                     if (_indexes.TryGetByName(replacementIndexName, out Index newIndex) == false)
                         return true;
@@ -1380,6 +1411,10 @@ namespace Raven.Server.Documents.Indexes
 
                     return true;
                 }
+                finally
+                {
+                    indexLock.Release();
+                }
             }
             catch (IOException)
             {
@@ -1395,9 +1430,9 @@ namespace Raven.Server.Documents.Indexes
             }
         }
 
-        private object GetIndexLock(string name)
+        private SemaphoreSlim GetIndexLock(string name)
         {
-            return _indexLocks.GetOrAdd(name, n => new object());
+            return _indexLocks.GetOrAdd(name, n => new SemaphoreSlim(1, 1));
         }
 
         private void ExecuteIndexAction(Action action)


### PR DESCRIPTION
…e should stop waiting for index replacement if database is being stopped

HRINT-1058 Prevent deadlock during global server disposal due to index replacement (caused by Queries_will_work_during_index_replacements test)