### PR TITLE
RavenDB-12806 Added cancellation token when waiting for index lock. W…

### DIFF
--- a/src/Raven.Server/Documents/Handlers/IndexHandler.cs
+++ b/src/Raven.Server/Documents/Handlers/IndexHandler.cs
@@ -44,7 +44,7 @@ namespace Raven.Server.Documents.Handlers
 
             while (Database.DatabaseShutdown.IsCancellationRequested == false)
             {
-                if (Database.IndexStore.TryReplaceIndexes(name, newIndex.Name))
+                if (Database.IndexStore.TryReplaceIndexes(name, newIndex.Name, Database.DatabaseShutdown))
                     break;
             }
 

--- a/src/Raven.Server/Documents/Indexes/Index.cs
+++ b/src/Raven.Server/Documents/Indexes/Index.cs
@@ -1062,7 +1062,7 @@ namespace Raven.Server.Documents.Indexes
                                             // in this case, worst case scenario we'll handle this in the next batch
                                             while (_indexingProcessCancellationTokenSource.IsCancellationRequested == false)
                                             {
-                                                if (DocumentDatabase.IndexStore.TryReplaceIndexes(originalName, Definition.Name))
+                                                if (DocumentDatabase.IndexStore.TryReplaceIndexes(originalName, Definition.Name, _indexingProcessCancellationTokenSource.Token))
                                                 {
                                                     StartIndexingThread();
                                                     return;


### PR DESCRIPTION
…e should stop waiting for index replacement if database is being stopped

HRINT-1058 Prevent deadlock during global server disposal due to index replacement (caused by Queries_will_work_during_index_replacements test)