### PR TITLE
RavenDB-7070 do not use ITestOutputHelper, it only displays results a…

### DIFF
--- a/test/SlowTests/Issues/RavenDB_6596.cs
+++ b/test/SlowTests/Issues/RavenDB_6596.cs
@@ -9,14 +9,11 @@ using FastTests.Client;
 using Sparrow.Platform;
 using Tests.Infrastructure;
 using Xunit;
-using Xunit.Abstractions;
 
 namespace SlowTests.Issues
 {
     public class RavenDB_6596 : NoDisposalNeeded
     {
-        private readonly ITestOutputHelper _output;
-
         private static readonly List<MethodInfo> _syncTests = new List<MethodInfo>();
 
         private static readonly List<MethodInfo> _asyncTests = new List<MethodInfo>();
@@ -36,11 +33,6 @@ namespace SlowTests.Issues
         static RavenDB_6596()
         {
             FindTests(typeof(CRUD).GetTypeInfo().Assembly, typeof(RavenDB_6596).GetTypeInfo().Assembly);
-        }
-
-        public RavenDB_6596(ITestOutputHelper output)
-        {
-            _output = output;
         }
 
         private static void FindTests(params Assembly[] assemblies)
@@ -103,7 +95,7 @@ namespace SlowTests.Issues
                     CultureInfo.DefaultThreadCurrentCulture = culture;
                     CultureInfo.DefaultThreadCurrentUICulture = culture;
 
-                    _output?.WriteLine($"\t\t{test.Name}");
+                    Console.WriteLine($"\t\t{test.Name}");
 
                     try
                     {
@@ -140,7 +132,7 @@ namespace SlowTests.Issues
                     CultureInfo.DefaultThreadCurrentCulture = culture;
                     CultureInfo.DefaultThreadCurrentUICulture = culture;
 
-                    _output?.WriteLine($"\t\t{test.Name}");
+                    Console.WriteLine($"\t\t{test.Name}");
 
                     try
                     {


### PR DESCRIPTION
…fter test failure or success, not when it hangs