### PR TITLE
RavenDB-12874: CanPreformSeveralClusterTransactions - add NoTimeouts(…

### DIFF
--- a/test/SlowTests/Cluster/ClusterTransactionTests.cs
+++ b/test/SlowTests/Cluster/ClusterTransactionTests.cs
@@ -109,6 +109,7 @@ namespace SlowTests.Cluster
         [InlineData(5)]
         public async Task CanPreformSeveralClusterTransactions(int numberOfNodes)
         {
+            NoTimeouts();
             var numOfSessions = 10;
             var docsPerSession = 2;
             var leader = await CreateRaftClusterAndGetLeader(numberOfNodes);

--- a/test/Tests.Infrastructure/ClusterTestBase.cs
+++ b/test/Tests.Infrastructure/ClusterTestBase.cs
@@ -50,6 +50,14 @@ namespace Tests.Infrastructure
             }
         }
 
+        protected void SetTimeouts()
+        {
+            foreach (var server in Servers)
+            {
+                server.ServerStore.Engine.Timeout.Disable = false;
+            }
+        }
+
         protected async Task CreateAndWaitForClusterDatabase(string databaseName, IDocumentStore store, int replicationFactor = 2)
         {
             if (Servers.Count == 0)


### PR DESCRIPTION
…) to prevent flackiness due to slow response while slow testing