### PR TITLE
Revert "RavenDB-12945 removed GlobalHttpClientTimeout"

### DIFF
--- a/src/Raven.Client/Documents/Commands/QueryCommand.cs
+++ b/src/Raven.Client/Documents/Commands/QueryCommand.cs
@@ -31,7 +31,16 @@ namespace Raven.Client.Documents.Commands
             _indexEntriesOnly = indexEntriesOnly;
 
             if (indexQuery.WaitForNonStaleResultsTimeout.HasValue && indexQuery.WaitForNonStaleResultsTimeout != TimeSpan.MaxValue)
-                Timeout = indexQuery.WaitForNonStaleResultsTimeout.Value.Add(AdditionalTimeToAddToTimeout);
+            {
+                var timeout = indexQuery.WaitForNonStaleResultsTimeout.Value;
+                if (timeout < RequestExecutor.GlobalHttpClientTimeout) // if it is greater than it will throw in RequestExecutor
+                {
+                    timeout =  RequestExecutor.GlobalHttpClientTimeout - timeout > AdditionalTimeToAddToTimeout 
+                        ? timeout.Add(AdditionalTimeToAddToTimeout) : RequestExecutor.GlobalHttpClientTimeout; // giving the server an opportunity to finish the response
+                }
+
+                Timeout = timeout;
+            }
         }
 
         public override HttpRequestMessage CreateRequest(JsonOperationContext ctx, ServerNode node, out string url)


### PR DESCRIPTION
This reverts commit c9636dee71cd32fec64454e68d4fedf6689df238.