### PR TITLE
RavenDB-13093 Node not being deleted and hangs on pending for deletion

### DIFF
--- a/src/Raven.Server/Documents/DatabasesLandlord.cs
+++ b/src/Raven.Server/Documents/DatabasesLandlord.cs
@@ -197,20 +197,19 @@ namespace Raven.Server.Documents
         public bool ShouldDeleteDatabase(string dbName, DatabaseRecord record)
         {
             var deletionInProgress = DeletionInProgressStatus.No;
-            var directDelete = record.DeletionInProgress != null &&
-                               record.DeletionInProgress.TryGetValue(_serverStore.NodeTag, out deletionInProgress) &&
+            var directDelete = record.DeletionInProgress?.TryGetValue(_serverStore.NodeTag, out deletionInProgress) == true &&
                                deletionInProgress != DeletionInProgressStatus.No;
 
-            if (directDelete &&
-                record.Topology.Count == record.Topology.ReplicationFactor)
-            // If the deletion was issued form the cluster observer to maintain the replication factor we need to make sure
-            // the all the documents were replicated from this node, therefor the deletion will be called from the replication code.
-            {
-                DeleteDatabase(dbName, deletionInProgress, record);
-                return true;
-            }
+            if (directDelete == false)
+                return false;
 
-            return false;
+            if (record.Topology.Rehabs.Contains(_serverStore.NodeTag))
+                // If the deletion was issued form the cluster observer to maintain the replication factor we need to make sure
+                // that all the documents were replicated from this node, therefor the deletion will be called from the replication code.
+                return false;
+
+            DeleteDatabase(dbName, deletionInProgress, record);
+            return true;
         }
 
         public void DeleteDatabase(string dbName, DeletionInProgressStatus deletionInProgress, DatabaseRecord record)
@@ -227,6 +226,7 @@ namespace Raven.Server.Documents
                     // this is already in the process of being deleted, we can just exit and let another thread handle it
                     return;
                 }
+
                 if (deletionInProgress == DeletionInProgressStatus.HardDelete)
                 {
                     RavenConfiguration configuration;
@@ -283,16 +283,18 @@ namespace Raven.Server.Documents
                 NodeTag = _serverStore.NodeTag
             };
             _serverStore.SendToLeaderAsync(cmd)
-                .ContinueWith(t =>
+                .ContinueWith(async t =>
                 {
-                    if (t.Exception != null)
+                    var message = $"Failed to notify leader about removal of node {_serverStore.NodeTag} from database '{dbName}', will retry again in 15 seconds.";
+                    if (_logger.IsInfoEnabled)
                     {
-                        if (_logger.IsInfoEnabled)
-                        {
-                            _logger.Info($"Failed to notify leader about removal of node {_serverStore.NodeTag} from database {dbName}", t.Exception);
-                        }
+                        _logger.Info(message, t.Exception);
                     }
-                });
+
+                    await Task.Delay(TimeSpan.FromSeconds(15));
+
+                    NotifyLeaderAboutRemoval(dbName);
+                }, TaskContinuationOptions.OnlyOnFaulted);
         }
 
         private void NotifyDatabaseAboutStateChange(string changedDatabase, Task<DocumentDatabase> done, long index)

--- a/src/Raven.Server/ServerWide/Commands/DeleteDatabaseCommand.cs
+++ b/src/Raven.Server/ServerWide/Commands/DeleteDatabaseCommand.cs
@@ -46,9 +46,13 @@ namespace Raven.Server.ServerWide.Commands
                     {
                         DatabaseDoesNotExistException.ThrowWithMessage(record.DatabaseName, $"Request to delete database from node '{node}' failed.");
                     }
+
+                    // rehabs will be removed only once the replication sent all the documents to the mentor
+                    if (record.Topology.Promotables.Contains(node)) 
+                        record.Topology.RemoveFromTopology(node);
+
                     if (UpdateReplicationFactor)
                     {
-                        record.Topology.RemoveFromTopology(node);
                         record.Topology.ReplicationFactor--;
                     }
                     if (ClusterNodes.Contains(node))

--- a/test/RachisTests/DatabaseCluster/ClusterDatabaseMaintenance.cs
+++ b/test/RachisTests/DatabaseCluster/ClusterDatabaseMaintenance.cs
@@ -108,21 +108,21 @@ namespace RachisTests.DatabaseCluster
         public async Task MoveToRehabOnServerDown()
         {
             var clusterSize = 3;
-            var databaseName = "DemoteOnServerDown";
-            var leader = await CreateRaftClusterAndGetLeader(clusterSize, true, 0, customSettings: new Dictionary<string, string>
+            var databaseName = GetDatabaseName();
+            var cluster = await CreateRaftCluster(clusterSize, true, 0, customSettings: new Dictionary<string, string>
             {
                 [RavenConfiguration.GetKey(x => x.Cluster.MoveToRehabGraceTime)] = "4"
             });
             using (var store = new DocumentStore
             {
-                Urls = new[] { leader.WebUrl },
+                Urls = new[] { cluster.Leader.WebUrl },
                 Database = databaseName
             }.Initialize())
             {
                 var doc = new DatabaseRecord(databaseName);
                 var databaseResult = await store.Maintenance.Server.SendAsync(new CreateDatabaseOperation(doc, clusterSize));
                 Assert.Equal(clusterSize, databaseResult.Topology.Members.Count);
-                Servers[1].Dispose();
+                cluster.Nodes[1].Dispose();
 
                 var val = await WaitForValueAsync(async () => await GetMembersCount(store, databaseName), clusterSize - 1);
                 Assert.Equal(clusterSize - 1, val);
@@ -135,7 +135,7 @@ namespace RachisTests.DatabaseCluster
         public async Task PromoteOnCatchingUp()
         {
             var clusterSize = 3;
-            var databaseName = "PromoteOnCatchingUp";
+            var databaseName = GetDatabaseName();
             var leader = await CreateRaftClusterAndGetLeader(clusterSize, true, 0);
             using (var store = new DocumentStore
             {
@@ -183,7 +183,7 @@ namespace RachisTests.DatabaseCluster
         public async Task SuccessfulMaintenanceOnLeaderChange()
         {
             var clusterSize = 3;
-            var databaseName = "SuccessfulMaintenanceOnLeaderChange";
+            var databaseName = GetDatabaseName();
             var leader = await CreateRaftClusterAndGetLeader(clusterSize, true, 0);
             using (var store = new DocumentStore()
             {
@@ -216,7 +216,7 @@ namespace RachisTests.DatabaseCluster
         public async Task PromoteDatabaseNodeBackAfterReconnection()
         {
             var clusterSize = 3;
-            var databaseName = "PromoteDatabaseNodeBackAfterReconnection";
+            var databaseName = GetDatabaseName();
             var leader = await CreateRaftClusterAndGetLeader(clusterSize, false, 0, customSettings: new Dictionary<string, string>
             {
                 [RavenConfiguration.GetKey(x => x.Cluster.MoveToRehabGraceTime)] = "4"
@@ -258,7 +258,7 @@ namespace RachisTests.DatabaseCluster
         {
             //DebuggerAttachedTimeout.DisableLongTimespan = true;
             var clusterSize = 3;
-            var databaseName = "MoveToPassiveWhenRefusedConnectionFromAllNodes";
+            var databaseName = GetDatabaseName();
             var leader = await CreateRaftClusterAndGetLeader(clusterSize, false, 0, customSettings: new Dictionary<string, string>()
             {
                 [RavenConfiguration.GetKey(x => x.Cluster.ElectionTimeout)] = "600"
@@ -330,7 +330,7 @@ namespace RachisTests.DatabaseCluster
             DebuggerAttachedTimeout.DisableLongTimespan = true;
             var clusterSize = 3;
             var dbGroupSize = 2;
-            var databaseName = "RedistrebuteDatabaseIfNodeFailes";
+            var databaseName = GetDatabaseName();
             var leader = await CreateRaftClusterAndGetLeader(clusterSize, false, 0);
 
             using (var store = new DocumentStore
@@ -371,7 +371,7 @@ namespace RachisTests.DatabaseCluster
             DebuggerAttachedTimeout.DisableLongTimespan = true;
             var clusterSize = 5;
             var dbGroupSize = 3;
-            var databaseName = "RedistrebuteDatabaseOnCascadeFailure";
+            var databaseName = GetDatabaseName();
             var leader = await CreateRaftClusterAndGetLeader(clusterSize, false, 0);
 
             using (var store = new DocumentStore
@@ -411,7 +411,7 @@ namespace RachisTests.DatabaseCluster
         [Fact]
         public async Task RemoveNodeFromClusterWhileDeletion()
         {
-            var databaseName = "RemoveNodeFromClusterWhileDeletion" + Guid.NewGuid();
+            var databaseName = GetDatabaseName();
             var leader = await CreateRaftClusterAndGetLeader(3, leaderIndex: 0);
 
             using (var leaderStore = new DocumentStore
@@ -454,7 +454,7 @@ namespace RachisTests.DatabaseCluster
         [Fact]
         public async Task DontRemoveNodeWhileItHasNotReplicatedDocs()
         {
-            var databaseName = "DontRemoveNodeWhileItHasNotReplicatedDocs" + Guid.NewGuid();
+            var databaseName = GetDatabaseName();
             var leader = await CreateRaftClusterAndGetLeader(3, shouldRunInMemory: false);
 
             using (var leaderStore = new DocumentStore
@@ -552,7 +552,7 @@ namespace RachisTests.DatabaseCluster
         [Fact]
         public async Task Promote_immedtialty_should_work()
         {
-            var databaseName = "Promote_immedtialty_should_work" + Guid.NewGuid();
+            var databaseName = GetDatabaseName();
             var leader = await CreateRaftClusterAndGetLeader(3);
 
             using (var leaderStore = new DocumentStore
@@ -588,7 +588,7 @@ namespace RachisTests.DatabaseCluster
         [Fact]
         public async Task ChangeUrlOfSingleNodeCluster()
         {
-            var databaseName = "ChangeUrlOfSingleNodeCluster" + Guid.NewGuid();
+            var databaseName = GetDatabaseName();
             var leader = await CreateRaftClusterAndGetLeader(1, shouldRunInMemory: false);
 
             using (var leaderStore = new DocumentStore

--- a/test/Tests.Infrastructure/ClusterTestBase.cs
+++ b/test/Tests.Infrastructure/ClusterTestBase.cs
@@ -355,13 +355,17 @@ namespace Tests.Infrastructure
             mre.Wait();
         }
 
-        protected static async Task DisposeServerAndWaitForFinishOfDisposalAsync(RavenServer serverToDispose, CancellationToken token = default)
+        protected static async Task<(string DataDir, string Url)> DisposeServerAndWaitForFinishOfDisposalAsync(RavenServer serverToDispose, CancellationToken token = default)
         {
             var mre = new AsyncManualResetEvent();
+            var dataDir = serverToDispose.Configuration.Core.DataDirectory.FullPath.Split('/').Last();
+            var url = serverToDispose.WebUrl;
+
             serverToDispose.AfterDisposal += () => mre.Set();
             serverToDispose.Dispose();
 
             await mre.WaitAsync(token).ConfigureAwait(false);
+            return (dataDir, url);
         }
 
         protected async Task DisposeAndRemoveServer(RavenServer serverToDispose)
@@ -434,7 +438,7 @@ namespace Tests.Infrastructure
         }
 
         protected async Task<(List<RavenServer> Nodes, RavenServer Leader)> CreateRaftCluster(int numberOfNodes, bool shouldRunInMemory = true, int? leaderIndex = null, bool useSsl = false,
-            IDictionary<string, string> customSettings = null)
+            IDictionary<string, string> customSettings = null, bool watcherCluster = false)
         {
             leaderIndex = leaderIndex ?? _random.Next(0, numberOfNodes);
             RavenServer leader = null;
@@ -446,6 +450,7 @@ namespace Tests.Infrastructure
                 customSettings = customSettings ?? new Dictionary<string, string>()
                 {
                     [RavenConfiguration.GetKey(x => x.Cluster.MoveToRehabGraceTime)] = "1",
+                    [RavenConfiguration.GetKey(x => x.Cluster.AddReplicaTimeout)] = "1",
                     [RavenConfiguration.GetKey(x => x.Cluster.ElectionTimeout)] = _electionTimeoutInMs.ToString(),
                     [RavenConfiguration.GetKey(x => x.Cluster.StabilizationTime)] = "1",
                 };
@@ -484,8 +489,15 @@ namespace Tests.Infrastructure
                 }
                 var follower = clustersServers[i];
                 // ReSharper disable once PossibleNullReferenceException
-                await leader.ServerStore.AddNodeToClusterAsync(serversToPorts[follower]);
-                await follower.ServerStore.WaitForTopology(Leader.TopologyModification.Voter);
+                await leader.ServerStore.AddNodeToClusterAsync(serversToPorts[follower], asWatcher: watcherCluster);
+                if (watcherCluster)
+                {
+                    await follower.ServerStore.WaitForTopology(Leader.TopologyModification.NonVoter);
+                }
+                else
+                {
+                    await follower.ServerStore.WaitForTopology(Leader.TopologyModification.Voter);
+                }
             }
             // ReSharper disable once PossibleNullReferenceException
             var condition = await leader.ServerStore.WaitForState(RachisState.Leader, CancellationToken.None).WaitAsync(numberOfNodes * _electionTimeoutInMs * 5);


### PR DESCRIPTION
- In case the observer replace a promotable node with another promotable node, the redundant node it will not be deleted from the topology after catching up.
- Deleting a node create a raft command for removing it from the database group, in case the command failed we need to notify about it.