### PR TITLE
RavenDB-12931 When getting pages of a table tree we don't need to gra…

### DIFF
--- a/src/Voron/Data/BTrees/Tree.cs
+++ b/src/Voron/Data/BTrees/Tree.cs
@@ -1203,12 +1203,12 @@ namespace Voron.Data.BTrees
                     }
                     else
                     {
+                        if (State.RootObjectType == RootObjectType.Table) // tables might have mixed values, fixed size trees inside have dedicated handling
+                            continue;
+
                         if ((State.Flags & TreeFlags.FixedSizeTrees) == TreeFlags.FixedSizeTrees)
                         {
                             var valueReader = GetValueReaderFromHeader(node);
-
-                            if (FixedSizeTree.IsFixedSizeTreeHeader(valueReader.Base, valueReader.Length) == false)
-                                continue;
 
                             var valueSize = ((FixedSizeTreeHeader.Embedded*)valueReader.Base)->ValueSize;
 

--- a/src/Voron/Data/Fixed/FixedSizeTree.cs
+++ b/src/Voron/Data/Fixed/FixedSizeTree.cs
@@ -1698,34 +1698,5 @@ namespace Voron.Data.Fixed
 
             _newPageAllocator = newPageAllocator;
         }
-
-        public static bool IsFixedSizeTreeHeader(byte* ptr, long size)
-        {
-            var header = (FixedSizeTreeHeader.Embedded*)ptr;
-
-            switch (header->RootObjectType)
-            {
-                case RootObjectType.EmbeddedFixedSizeTree:
-                    if (size < sizeof(FixedSizeTreeHeader.Embedded))
-                        return false;
-                    break;
-                case RootObjectType.FixedSizeTree:
-                    if (size != sizeof(FixedSizeTreeHeader.Large))
-                        return false;
-                    break;
-                default:
-                    return false;
-            }
-
-            var valueSize = header->ValueSize;
-
-            var entrySize = sizeof(long) + valueSize;
-            var maxEmbeddedEntries = (Constants.Storage.PageSize / 8) / entrySize;
-
-            if (maxEmbeddedEntries == 0)
-                return false;
-
-            return true;
-        }
     }
 }

--- a/src/Voron/Impl/Transaction.cs
+++ b/src/Voron/Impl/Transaction.cs
@@ -520,6 +520,15 @@ namespace Voron.Impl
                 return true;
             });
 
+            if (schema.Key.IsGlobal == false)
+            {
+                var pkTree = table.GetTree(schema.Key);
+
+                DeleteTree(pkTree, isInRoot: false);
+
+                tableTree.Delete(pkTree.Name);
+            }
+
             // index trees should be already removed but just in case let's go over them and ensure they're really deleted
 
             foreach (var indexDef in schema.Indexes.Values)
@@ -533,6 +542,8 @@ namespace Voron.Impl
                 var indexTree = table.GetTree(indexDef);
 
                 DeleteTree(indexTree, isInRoot: false);
+
+                tableTree.Delete(indexTree.Name);
             }
 
             foreach (var indexDef in schema.FixedSizeIndexes.Values)
@@ -546,6 +557,8 @@ namespace Voron.Impl
                 var index = table.GetFixedSizeTree(indexDef);
 
                 DeleteFixedTree(index, isInRoot: false);
+
+                tableTree.Delete(index.Name);
             }
 
             // raw data sections


### PR DESCRIPTION
…b pages of nested FST. In operations like delete table or get table report we're dealing with fixed size trees at higher level.

In continuation of the following discussion: https://github.com/aviv86/ravendb/commit/e3abdb178fb86b4addfba3a996ab02afd07399c5#r32763015