### PR TITLE
[WIP] RavenDB-10956 Support remove CV entries from a specific database

### DIFF
--- a/src/Raven.Client/ServerWide/DatabaseRecord.cs
+++ b/src/Raven.Client/ServerWide/DatabaseRecord.cs
@@ -15,6 +15,17 @@ using Raven.Client.Exceptions.Documents.Indexes;
 
 namespace Raven.Client.ServerWide
 {
+    public class RemoveChangeVectors
+    {
+        public List<string> IgnoredList;
+
+        public long Index;
+
+        public List<string> Confirmations;
+
+        public bool ShouldUpdateGlobal;
+    }
+
     public class DatabaseRecordWithEtag : DatabaseRecord
     {
         public long Etag { get; set; }
@@ -64,6 +75,8 @@ namespace Raven.Client.ServerWide
         public ExpirationConfiguration Expiration;
 
         public List<PeriodicBackupConfiguration> PeriodicBackups = new List<PeriodicBackupConfiguration>();
+
+        public RemoveChangeVectors RemoveChangeVectors;
 
         public List<ExternalReplication> ExternalReplications = new List<ExternalReplication>();
 

--- a/src/Raven.Server/Documents/Replication/OutgoingReplicationHandler.cs
+++ b/src/Raven.Server/Documents/Replication/OutgoingReplicationHandler.cs
@@ -368,6 +368,8 @@ namespace Raven.Server.Documents.Replication
                         {
                             try
                             {
+                                RaftIndex = _parent._server.LastRaftCommitIndex;
+
                                 if (Destination is InternalReplication dest)
                                 {
                                     _parent.EnsureNotDeleted(dest.NodeTag);
@@ -427,6 +429,8 @@ namespace Raven.Server.Documents.Replication
                     if (_cts.IsCancellationRequested)
                         break;
 
+                    RaftIndex = _parent._server.LastRaftCommitIndex;
+
                     // open tx
                     // read current change vector compare to last sent
                     // if okay, send cv
@@ -474,6 +478,8 @@ namespace Raven.Server.Documents.Replication
                 _waitForChanges.Reset();
             }
         }
+
+        public long RaftIndex;
 
         private void InitialHandshake()
         {

--- a/src/Raven.Server/Documents/Replication/ReplicationDocumentSender.cs
+++ b/src/Raven.Server/Documents/Replication/ReplicationDocumentSender.cs
@@ -278,12 +278,13 @@ namespace Raven.Server.Documents.Replication
                             else if (item.Type == ReplicationBatchItem.ReplicationItemType.Attachment)
                                 size += item.Stream.Length;
 
+                            DocumentDatabase.RemoveIgnoredChangeVectors(_parent._database.IgnoredChangeVectors, ref item.ChangeVector);
+
                             if (AddReplicationItemToBatch(item, _stats.Storage, skippedReplicationItemsInfo) == false)
                                 continue;
 
                             numberOfItemsSent++;
                         }
-
                     }
                     
                     if (_log.IsInfoEnabled)

--- a/src/Raven.Server/Json/JsonDeserializationServer.cs
+++ b/src/Raven.Server/Json/JsonDeserializationServer.cs
@@ -163,6 +163,8 @@ namespace Raven.Server.Json
 
         public static readonly Func<BlittableJsonReaderObject, SingleNodeDataDirectoryResult> SingleNodeDataDirectoryResult = GenerateJsonDeserializationRoutine<SingleNodeDataDirectoryResult>();
 
+        public static readonly Func<BlittableJsonReaderObject, RemoveChangeVectors> RemoveChangeVectors = GenerateJsonDeserializationRoutine<RemoveChangeVectors>();
+
         public class Parameters
         {
             private Parameters()

--- a/src/Raven.Server/ServerWide/ClusterCommandsVersionManager.cs
+++ b/src/Raven.Server/ServerWide/ClusterCommandsVersionManager.cs
@@ -101,7 +101,10 @@ namespace Raven.Server.ServerWide
             [nameof(UpdatePullReplicationAsHubCommand)] = Base42CommandsVersion,
             [nameof(CleanCompareExchangeTombstonesCommand)] = Base42CommandsVersion,
             [nameof(PutSubscriptionBatchCommand)] = Base42CommandsVersion,
-            [nameof(EditDatabaseClientConfigurationCommand)] = Base42CommandsVersion
+            [nameof(EditDatabaseClientConfigurationCommand)] = Base42CommandsVersion,
+
+            [nameof(RemoveChangeVectorCommand)] = Base42CommandsVersion,
+            [nameof(ConfirmRemoveChangeVectorCommand)] = Base42CommandsVersion
         };
 
         public static bool CanPutCommand(string command)

--- a/src/Raven.Server/ServerWide/ClusterStateMachine.cs
+++ b/src/Raven.Server/ServerWide/ClusterStateMachine.cs
@@ -345,6 +345,8 @@ namespace Raven.Server.ServerWide
                     case nameof(UpdatePullReplicationAsHubCommand):
                     case nameof(UpdatePullReplicationAsSinkCommand):
                     case nameof(EditDatabaseClientConfigurationCommand):
+                    case nameof(RemoveChangeVectorCommand):
+                    case nameof(ConfirmRemoveChangeVectorCommand):
                         UpdateDatabase(context, type, cmd, index, leader, serverStore);
                         break;
                     case nameof(UpdatePeriodicBackupStatusCommand):

--- a/src/Raven.Server/ServerWide/Commands/RemoveChangeVectorCommand.cs
+++ b/src/Raven.Server/ServerWide/Commands/RemoveChangeVectorCommand.cs
@@ -1,0 +1,84 @@
+﻿using System;
+using System.Collections.Generic;
+using System.Text;
+using Raven.Client.ServerWide;
+using Sparrow.Json.Parsing;
+
+namespace Raven.Server.ServerWide.Commands
+{
+    public class ConfirmRemoveChangeVectorCommand : UpdateDatabaseCommand
+    {
+        public string Node;
+
+        public ConfirmRemoveChangeVectorCommand():base(null) { } // for de-serialize
+
+        public ConfirmRemoveChangeVectorCommand(string databaseName, string node) : base(databaseName)
+        {
+            Node = node;
+        }
+
+        public override string UpdateDatabaseRecord(DatabaseRecord record, long etag)
+        {
+            if (record.RemoveChangeVectors == null)
+                throw new InvalidOperationException("No change vector removal progress was found.");
+
+            if (record.Topology.RelevantFor(Node) == false)
+                throw new InvalidOperationException($"Node {Node} is not relevant for the current topology.");
+
+            if (record.RemoveChangeVectors.Confirmations.Contains(Node) == false)
+                record.RemoveChangeVectors.Confirmations.Add(Node);
+
+            
+            if (record.RemoveChangeVectors.Confirmations.Count == record.Topology.Count)
+            {
+                foreach (var node in record.Topology.AllNodes)
+                {
+                    if (record.RemoveChangeVectors.Confirmations.Contains(node) == false)
+                        throw new InvalidOperationException($"Inconsistent confirmations, node {node} is missing, this is likely a bug.");
+                }
+                record.RemoveChangeVectors.ShouldUpdateGlobal = true;
+                record.RemoveChangeVectors.IgnoredList = null;
+                record.RemoveChangeVectors.Confirmations = null;
+                record.RemoveChangeVectors.Index = 0;
+            }
+            return null;
+        }
+
+        public override void FillJson(DynamicJsonValue json)
+        {
+            json[nameof(Node)] = Node;
+        }
+    }
+
+    public class RemoveChangeVectorCommand : UpdateDatabaseCommand
+    {
+        public List<string> IgnoreList;
+
+        public RemoveChangeVectorCommand():base(null) { } // for de-serialize
+
+        public RemoveChangeVectorCommand(string databaseName, List<string> ignoreList) : base(databaseName)
+        {
+            IgnoreList = ignoreList;
+        }
+
+        public override string UpdateDatabaseRecord(DatabaseRecord record, long etag)
+        {
+            if (record.RemoveChangeVectors?.Index > 0)
+                throw new InvalidOperationException("Remove change vector command is already in progress.");
+
+            record.RemoveChangeVectors = new RemoveChangeVectors
+            {
+                Confirmations = new List<string>(),
+                IgnoredList = IgnoreList,
+                Index = etag
+            };
+
+            return null;
+        }
+
+        public override void FillJson(DynamicJsonValue json)
+        {
+            json[nameof(IgnoreList)] = new DynamicJsonArray(IgnoreList);
+        }
+    }
+}

--- a/src/Raven.Server/ServerWide/JsonDeserializationCluster.cs
+++ b/src/Raven.Server/ServerWide/JsonDeserializationCluster.cs
@@ -160,7 +160,9 @@ namespace Raven.Server.ServerWide
             [nameof(UpdateSnmpDatabaseIndexesMappingCommand)] = GenerateJsonDeserializationRoutine<UpdateSnmpDatabaseIndexesMappingCommand>(),
             [nameof(RemoveEtlProcessStateCommand)] = GenerateJsonDeserializationRoutine<RemoveEtlProcessStateCommand>(),
             [nameof(PutSortersCommand)] = GenerateJsonDeserializationRoutine<PutSortersCommand>(),
-            [nameof(DeleteSorterCommand)] = GenerateJsonDeserializationRoutine<DeleteSorterCommand>()
+            [nameof(DeleteSorterCommand)] = GenerateJsonDeserializationRoutine<DeleteSorterCommand>(),
+            [nameof(RemoveChangeVectorCommand)] = GenerateJsonDeserializationRoutine<RemoveChangeVectorCommand>(),
+            [nameof(ConfirmRemoveChangeVectorCommand)] = GenerateJsonDeserializationRoutine<ConfirmRemoveChangeVectorCommand>()
         };
     }
 }


### PR DESCRIPTION
The removal occurs in 2 phases.
First we send command for removal of specific CVs. Upon committing the command each node will strip those CVs from _outgoing_ replication. So the peers will not receive documents with those CVs.

Only when all outgoing connections of a node stripping those CVs the node will confirm the removal command.
In the second phase when all nodes confirmed the 1st phase it is safe to remove those CVs from the global database change vector.