### PR TITLE
RavenDB-13302: Due to non thread safe _activeTx.ScanOldest call, we "…

### DIFF
--- a/src/Voron/Impl/Journal/WriteAheadJournal.cs
+++ b/src/Voron/Impl/Journal/WriteAheadJournal.cs
@@ -565,7 +565,6 @@ namespace Voron.Impl.Journal
                     if (_waj._env.Disposed)
                         return;
 
-
                     var jrnls = GetJournalSnapshots();
 
                     if (jrnls.Count == 0)
@@ -581,6 +580,8 @@ namespace Voron.Impl.Journal
 
                     long lastFlushedTransactionId = -1;
 
+                    // RavenDB-13302: we need to force a re-check this before we make decisions here
+                    _waj._env.ActiveTransactions.RecheckOldestTransaction();
                     long oldestActiveTransaction = _waj._env.ActiveTransactions.OldestTransaction;
 
                     foreach (var journalFile in jrnls)

--- a/src/Voron/Impl/Journal/WriteAheadJournal.cs
+++ b/src/Voron/Impl/Journal/WriteAheadJournal.cs
@@ -581,7 +581,7 @@ namespace Voron.Impl.Journal
                     long lastFlushedTransactionId = -1;
 
                     // RavenDB-13302: we need to force a re-check this before we make decisions here
-                    _waj._env.ActiveTransactions.RecheckOldestTransaction();
+                    _waj._env.ActiveTransactions.ForceRecheckingOldestTransactionByFlusherThread();
                     long oldestActiveTransaction = _waj._env.ActiveTransactions.OldestTransaction;
 
                     foreach (var journalFile in jrnls)

--- a/src/Voron/Util/ActiveTransactions.cs
+++ b/src/Voron/Util/ActiveTransactions.cs
@@ -30,7 +30,7 @@ namespace Voron.Util
             }
         }
 
-        public void RecheckOldestTransaction()
+        public void ForceRecheckingOldestTransactionByFlusherThread()
         {
             // RavenDB-13302
             // this is being run from the flusher, since we can afford to 
@@ -55,7 +55,7 @@ namespace Voron.Util
 
             while (tx.Id <= oldTx)
             {
-                var currentOldest = _activeTxs.ScanOldest(); // This is non-thread safe call (therefor from time to time we RecheckOldestTransaction)
+                var currentOldest = _activeTxs.ScanOldest(); // This is non-thread safe call (therefor from time to time we ForceRecheckingOldestTransactionByFlusherThread)
                 if (currentOldest == tx.Id)// another tx with same id, they can cleanup after us
                     break;
                 var result = Interlocked.CompareExchange(ref _oldestTransaction, currentOldest, oldTx);


### PR DESCRIPTION
…refreshing" OldestActiveTransaction member during flush