### PR TITLE
RavenDB-13181 Counters replication discrepancies

### DIFF
--- a/src/Raven.Client/Documents/Operations/Counters/CounterBatch.cs
+++ b/src/Raven.Client/Documents/Operations/Counters/CounterBatch.cs
@@ -88,6 +88,7 @@ namespace Raven.Client.Documents.Operations.Counters
         public long Delta;
 
         internal string ChangeVector;
+        public string DocumentId;
 
         public static CounterOperation Parse(BlittableJsonReaderObject input)
         {

--- a/src/Raven.Client/Documents/Operations/Counters/CounterBatch.cs
+++ b/src/Raven.Client/Documents/Operations/Counters/CounterBatch.cs
@@ -89,7 +89,6 @@ namespace Raven.Client.Documents.Operations.Counters
         public long Delta;
 
         internal string ChangeVector;
-        [JsonProperty]
         internal string DocumentId;
 
         public static CounterOperation Parse(BlittableJsonReaderObject input)

--- a/src/Raven.Client/Documents/Operations/Counters/CounterBatch.cs
+++ b/src/Raven.Client/Documents/Operations/Counters/CounterBatch.cs
@@ -2,6 +2,7 @@
 using System.Collections.Generic;
 using System.IO;
 using System.Linq;
+using Newtonsoft.Json;
 using Sparrow.Json;
 using Sparrow.Json.Parsing;
 
@@ -88,7 +89,8 @@ namespace Raven.Client.Documents.Operations.Counters
         public long Delta;
 
         internal string ChangeVector;
-        public string DocumentId;
+        [JsonProperty]
+        internal string DocumentId;
 
         public static CounterOperation Parse(BlittableJsonReaderObject input)
         {

--- a/src/Raven.Server/Documents/Handlers/CountersHandler.cs
+++ b/src/Raven.Server/Documents/Handlers/CountersHandler.cs
@@ -40,7 +40,6 @@ namespace Raven.Server.Documents.Handlers
             private readonly bool _fromEtl;
             private readonly bool _fromSmuggler;
             private readonly List<CounterOperation> _list;
-            //private readonly Dictionary<string, List<CounterOperation>> _dictionary;
             public long ErrorCount;
             public ExecuteCounterBatchCommand(DocumentDatabase database, CounterBatch counterBatch)
             {

--- a/src/Raven.Server/Documents/PeriodicBackup/Restore/RestoreBackupTask.cs
+++ b/src/Raven.Server/Documents/PeriodicBackup/Restore/RestoreBackupTask.cs
@@ -311,8 +311,7 @@ namespace Raven.Server.Documents.PeriodicBackup.Restore
             {
                 AuthorizationStatus = AuthorizationStatus.DatabaseAdmin,
                 OperateOnTypes = DatabaseItemType.CompareExchange | DatabaseItemType.Identities,
-                SkipRevisionCreation = true,
-                KeepOriginalChangeVector = true
+                SkipRevisionCreation = true
             };
             var lastPath = Path.Combine(_restoreConfiguration.BackupLocation, lastFile);
 
@@ -458,8 +457,7 @@ namespace Raven.Server.Documents.PeriodicBackup.Restore
             {
                 AuthorizationStatus = AuthorizationStatus.DatabaseAdmin,
                 OperateOnTypes = ~(DatabaseItemType.CompareExchange | DatabaseItemType.Identities),
-                SkipRevisionCreation = true,
-                KeepOriginalChangeVector = true
+                SkipRevisionCreation = true
             };
 
             options.OperateOnTypes |= DatabaseItemType.LegacyDocumentDeletions;

--- a/src/Raven.Server/Documents/ReplayTxCommandHelper.cs
+++ b/src/Raven.Server/Documents/ReplayTxCommandHelper.cs
@@ -226,6 +226,7 @@ namespace Raven.Server.Documents
             jsonSerializer.Converters.Add(LazyStringValueJsonConverter.Instance);
             jsonSerializer.Converters.Add(StreamConverter.Instance);
             jsonSerializer.Converters.Add(BlittableJsonReaderArrayConverter.Instance);
+            jsonSerializer.Converters.Add(CounterOperationConverter.Instance);
             return jsonSerializer;
         }
     }

--- a/src/Raven.Server/Json/Converters/CounterOperationConverter.cs
+++ b/src/Raven.Server/Json/Converters/CounterOperationConverter.cs
@@ -1,0 +1,88 @@
+﻿using System;
+using Newtonsoft.Json;
+using Raven.Client.Documents.Operations.Counters;
+using Raven.Client.Json;
+
+namespace Raven.Server.Json.Converters
+{
+    internal class CounterOperationConverter : RavenTypeJsonConverter<CounterOperation>
+    {
+        public static CounterOperationConverter Instance = new CounterOperationConverter();
+
+        private CounterOperationConverter()
+        {
+        }
+
+        protected override void WriteJson(BlittableJsonWriter writer, CounterOperation value, JsonSerializer serializer)
+        {
+            if (value == null)
+            {
+                writer.WriteNull();
+                return;
+            }
+
+            writer.WriteStartObject();
+
+            writer.WritePropertyName(nameof(CounterOperation.CounterName));
+            if (value.CounterName != null)
+                writer.WriteValue(value.CounterName);
+            else
+                writer.WriteNull();
+
+            writer.WritePropertyName(nameof(CounterOperation.Delta));
+            writer.WriteValue(value.Delta);
+
+            writer.WritePropertyName(nameof(CounterOperation.Type));
+            writer.WriteValue(value.Type);
+
+            writer.WritePropertyName(nameof(CounterOperation.DocumentId));
+            if (value.DocumentId != null)
+                writer.WriteValue(value.DocumentId);
+            else
+                writer.WriteNull();
+
+            writer.WritePropertyName(nameof(CounterOperation.ChangeVector));
+            if (value.ChangeVector != null)
+                writer.WriteValue(value.ChangeVector);
+            else
+                writer.WriteNull();
+
+            writer.WriteEndObject();
+        }
+
+        internal override CounterOperation ReadJson(BlittableJsonReader blittableReader)
+        {
+            var result = new CounterOperation();
+
+            do
+            {
+                blittableReader.Read();
+                if (blittableReader.TokenType == JsonToken.EndObject)
+                    return result;
+                if (blittableReader.TokenType != JsonToken.PropertyName)
+                    throw new InvalidOperationException("Expected PropertyName, Got " + blittableReader.TokenType);
+
+                var property = (string)blittableReader.Value;
+                switch (property)
+                {
+                    case nameof(CounterOperation.CounterName):
+                        result.CounterName = blittableReader.ReadAsString();
+                        break;
+                    case nameof(CounterOperation.Delta):
+                        blittableReader.Read();
+                        result.Delta = (long)blittableReader.Value;
+                        break;
+                    case nameof(CounterOperation.Type):
+                        result.Type = Enum.Parse<CounterOperationType>(blittableReader.ReadAsString());
+                        break;
+                    case nameof(CounterOperation.DocumentId):
+                        result.DocumentId = blittableReader.ReadAsString();
+                        break;
+                    case nameof(CounterOperation.ChangeVector):
+                        result.ChangeVector = blittableReader.ReadAsString();
+                        break;
+                }
+            } while (true);
+        }
+    }
+}

--- a/src/Raven.Server/Smuggler/Documents/Data/DatabaseSmugglerOptionsServerSide.cs
+++ b/src/Raven.Server/Smuggler/Documents/Data/DatabaseSmugglerOptionsServerSide.cs
@@ -19,8 +19,6 @@ namespace Raven.Server.Smuggler.Documents.Data
 
         public AuthorizationStatus AuthorizationStatus { get; set; } = AuthorizationStatus.ValidUser;
 
-        public bool KeepOriginalChangeVector { get; set; }
-
         public new bool SkipRevisionCreation
         {
 #pragma warning disable 618

--- a/src/Raven.Server/Smuggler/Documents/DatabaseDestination.cs
+++ b/src/Raven.Server/Smuggler/Documents/DatabaseDestination.cs
@@ -1154,7 +1154,7 @@ namespace Raven.Server.Smuggler.Documents
             {
                 var counterOp = new CounterOperation
                 {
-                    Type = CounterOperationType.Increment,
+                    Type = CounterOperationType.Put,
                     CounterName = counter.CounterName,
                     Delta = counter.TotalValue,
                     ChangeVector = counter.ChangeVector

--- a/test/SlowTests/Client/Counters/CountersReplication.cs
+++ b/test/SlowTests/Client/Counters/CountersReplication.cs
@@ -1,11 +1,18 @@
 ﻿using System;
 using System.Collections.Generic;
+using System.IO;
 using System.Linq;
+using System.Threading;
 using System.Threading.Tasks;
 using FastTests.Server.Replication;
 using Raven.Client;
+using Raven.Client.Documents.Operations;
+using Raven.Client.Documents.Operations.Backups;
 using Raven.Client.Documents.Operations.Counters;
+using Raven.Client.Documents.Session;
 using Raven.Client.ServerWide;
+using Raven.Client.ServerWide.Operations;
+using Raven.Server.Config;
 using Raven.Server.Documents;
 using Raven.Server.ServerWide.Context;
 using Raven.Tests.Core.Utils.Entities;
@@ -460,6 +467,119 @@ namespace SlowTests.Client.Counters
                     Assert.Equal(Tombstone.TombstoneType.Counter, tombstones[1].Type);
                 }
             }
+        }
+
+        [Fact]
+        public async Task RestoreAndReplicateCounters()
+        {
+            var backupPath = NewDataPath(suffix: "BackupFolder");
+            using (var server = GetNewServer(new Dictionary<string, string>
+            {
+                [RavenConfiguration.GetKey(x => x.Replication.MaxItemsCount)] = 1.ToString()
+            }))
+            {
+                using (var store1 = GetDocumentStore(new Options
+                {
+                    Server = server
+                }))
+                using (var store2 = GetDocumentStore(new Options
+                {
+                    Server = server,
+                    CreateDatabase = false
+                }))
+                using (var store3 = GetDocumentStore(new Options
+                {
+                    Server = server
+                }))
+                {
+                    using (var session = store1.OpenAsyncSession())
+                    {
+                        await session.StoreAsync(new User { Name = "Name1" }, "users/1");
+                        await session.StoreAsync(new User { Name = "Name2" }, "users/2");
+                        session.CountersFor("users/1").Increment("likes", 100);
+                        session.CountersFor("users/2").Increment("downloads", 500);
+
+                        await session.SaveChangesAsync();
+                    }
+
+                    using (var session = store1.OpenAsyncSession())
+                    {
+                        // need to be in a different transaction in order to split the replication into batches
+                        session.CountersFor("users/1").Increment("dislikes", 200);
+                        await session.SaveChangesAsync();
+                    }
+
+                    var config = new PeriodicBackupConfiguration
+                    {
+                        BackupType = BackupType.Backup,
+                        LocalSettings = new LocalSettings
+                        {
+                            FolderPath = backupPath
+                        },
+                        IncrementalBackupFrequency = "* * * * *" //every minute
+                    };
+
+                    var backupTaskId = (await store1.Maintenance.SendAsync(new UpdatePeriodicBackupOperation(config))).TaskId;
+                    await store1.Maintenance.SendAsync(new StartBackupOperation(true, backupTaskId));
+
+                    var getPeriodicBackupStatus = new GetPeriodicBackupStatusOperation(backupTaskId);
+                    SpinWait.SpinUntil(() =>
+                    {
+                        var getPeriodicBackupResult = store1.Maintenance.Send(getPeriodicBackupStatus);
+                        return getPeriodicBackupResult.Status?.LastEtag > 0;
+                    }, TimeSpan.FromSeconds(15));
+
+                    var restore = new RestoreBackupOperation(new RestoreBackupConfiguration
+                    {
+                        BackupLocation = Directory.GetDirectories(backupPath).First(),
+                        DatabaseName = store2.Database,
+                    });
+
+                    var result = await store2.Maintenance.Server.SendAsync(restore);
+                    result.WaitForCompletion();
+
+                    var stats = await store2.Maintenance.SendAsync(new GetStatisticsOperation());
+                    Assert.Equal(2, stats.CountOfDocuments);
+                    Assert.Equal(3, stats.CountOfCounters);
+
+                    using (var session = store2.OpenAsyncSession())
+                    {
+                        await AssertCounters(session);
+                    }
+
+                    await SetupReplicationAsync(store2, store3);
+
+                    using (var session = store2.OpenAsyncSession())
+                    {
+                        await session.StoreAsync(new User(), "marker");
+                        await session.SaveChangesAsync();
+                    }
+
+                    Assert.NotNull(WaitForDocumentToReplicate<User>(store3, "marker", 10_000));
+
+                    using (var session = store3.OpenAsyncSession())
+                    {
+                        await AssertCounters(session);
+                    }
+                }
+            }
+        }
+
+        private static async Task AssertCounters(IAsyncDocumentSession session)
+        {
+            var user1 = await session.LoadAsync<User>("users/1");
+            var user2 = await session.LoadAsync<User>("users/2");
+
+            Assert.Equal("Name1", user1.Name);
+            Assert.Equal("Name2", user2.Name);
+
+            var dic = await session.CountersFor(user1).GetAllAsync();
+            Assert.Equal(2, dic.Count);
+            Assert.Equal(100, dic["likes"]);
+            Assert.Equal(200, dic["dislikes"]);
+
+            var val = await session.CountersFor(user2).GetAsync("downloads");
+            Assert.Equal(500, val);
         }
     }
 }

--- a/test/SlowTests/Server/Documents/PeriodicBackup/PeriodicBackupSlowTests.cs
+++ b/test/SlowTests/Server/Documents/PeriodicBackup/PeriodicBackupSlowTests.cs
@@ -501,7 +501,7 @@ namespace SlowTests.Server.Documents.PeriodicBackup
                     using (ctx.OpenReadTransaction())
                     {
                         var databaseChangeVector = DocumentsStorage.GetDatabaseChangeVector(ctx);
-                        Assert.Equal($"A:6-{originalDatabase.DbBase64Id}, A:6-{restoredDatabase.DbBase64Id}", databaseChangeVector);
+                        Assert.Equal($"A:8-{restoredDatabase.DbBase64Id}", databaseChangeVector);
                     }
                 }
             }
@@ -602,7 +602,7 @@ namespace SlowTests.Server.Documents.PeriodicBackup
                     using (ctx.OpenReadTransaction())
                     {
                         var databaseChangeVector = DocumentsStorage.GetDatabaseChangeVector(ctx);
-                        Assert.Equal($"A:7-{originalDatabase.DbBase64Id}, A:7-{restoredDatabase.DbBase64Id}", databaseChangeVector);
+                        Assert.Equal($"A:3-{originalDatabase.DbBase64Id}, A:9-{restoredDatabase.DbBase64Id}", databaseChangeVector);
                     }
                 }
             }


### PR DESCRIPTION
The underlying issue is that we resotred not in the insertion order in which the document, revisions, coutners, etc. were putted in the original database.
In the restored database this could cause that a document with higher change vector will have a lower local etag a therefore will skip the replication of doucments with lower change vector.

- Remove keep original change vector
- Insert the counters by insertion order