### PR TITLE
RavenDB-13292

### DIFF
--- a/src/Raven.Client/Documents/BulkInsert/BulkInsertOperation.cs
+++ b/src/Raven.Client/Documents/BulkInsert/BulkInsertOperation.cs
@@ -397,11 +397,10 @@ namespace Raven.Client.Documents.BulkInsert
             var stateRequest = new GetOperationStateOperation.GetOperationStateCommand(_requestExecutor.Conventions, _operationId);
             await _requestExecutor.ExecuteAsync(stateRequest, _context, sessionInfo: null, token: _token).ConfigureAwait(false);
 
-            if (!(stateRequest.Result.Result is OperationExceptionResult error))
+            if (!(stateRequest.Result?.Result is OperationExceptionResult error))
                 return null;
             return new BulkInsertAbortedException(error.Error);
         }
-
 
         private GZipStream _compressedStream;
         private Stream _requestBodyStream;


### PR DESCRIPTION
fixed an NRE that could happen when there is a proxy like nginx and there is a request limit available there (bad configuration). The proxy holds the buffer for the operation so the operation cleaner thinks that there is nothing going on, so the get operation status request returns 404 and null (which cases NRE). By avoiding that NRE we will propagate the original exception to the user (request to long from nginx).