### PR TITLE
RavenDB-13265 Fixing UnauthorizedAccessException during disposal or d…

### DIFF
--- a/test/SlowTests/Voron/Bugs/RavenDB_13265.cs
+++ b/test/SlowTests/Voron/Bugs/RavenDB_13265.cs
@@ -1,0 +1,39 @@
+﻿using FastTests.Voron;
+using Voron;
+using Xunit;
+
+namespace SlowTests.Voron.Bugs
+{
+    public class RavenDB_13265 : StorageTest
+    {
+        protected override void Configure(StorageEnvironmentOptions options)
+        {
+            options.ManualFlushing = true;
+        }
+
+        [Fact]
+        public void EnsurePagerStateReferenceMustAdd_Current_PagerStateToCollectionSoWeWillReleaseItsReferenceOnTxDispose()
+        {
+            RequireFileBasedPager();
+
+            using (var tx = Env.WriteTransaction())
+            {
+                var dataFilePager = tx.LowLevelTransaction.DataPager;
+
+                dataFilePager.EnsureContinuous(1000, 1);
+
+                var testingStuff = tx.LowLevelTransaction.ForTestingPurposesOnly();
+                
+                using (testingStuff.CallDuringEnsurePagerStateReference(() =>
+                {
+                    dataFilePager.EnsureContinuous(5000, 1);
+                }))
+                {
+                    tx.LowLevelTransaction.EnsurePagerStateReference(dataFilePager.PagerState);
+
+                    Assert.Contains(dataFilePager.PagerState, testingStuff.GetPagerStates());
+                }
+            }
+        }
+    }
+}

--- a/test/SlowTests/Voron/Issues/RavenDB_12543.cs
+++ b/test/SlowTests/Voron/Issues/RavenDB_12543.cs
@@ -30,7 +30,7 @@ namespace SlowTests.Voron.Issues
                     tree.Add("items/" + i, buffer);
                 }
 
-                tx.LowLevelTransaction.SimulateThrowingOnCommitStage2 = true;
+                tx.LowLevelTransaction.ForTestingPurposesOnly().SimulateThrowingOnCommitStage2 = true;
 
                 Assert.Throws<InvalidOperationException>(() => tx.Commit());
             }


### PR DESCRIPTION
…eletion of a database or an index. The issue was that LowLevelTransaction.EnsurePagerState did not add a pager state to the collection which we use during tx dispose to release pager states. In result we were still holding a reference to Voron data file. Note it required a data pager state to be changed in the background during EnsurePagerState (journals flushing) so it was not very likely to happen.