### PR TITLE
RavenDB-7070

### DIFF
--- a/src/Sparrow/Json/BlittableJsonReaderObject.cs
+++ b/src/Sparrow/Json/BlittableJsonReaderObject.cs
@@ -956,10 +956,11 @@ namespace Sparrow.Json
 
         public void Dispose()
         {
-            AssertContextNotDisposed();
-
             if (_mem == null) //double dispose will do nothing
                 return;
+
+            AssertContextNotDisposed();
+
             if (_allocatedMemory != null && _buffer.IsDisposed == false)
             {
                 _context.ReturnMemory(_allocatedMemory);


### PR DESCRIPTION
- AssertContextNotDisposed should be called after checking if the BJRO is disposed
- disposing the BJRO in From11 schema upgrade