### PR TITLE
RavenDB-13409 fix

### DIFF
--- a/src/Raven.Server/ServerWide/Context/TransactionOperationContext.cs
+++ b/src/Raven.Server/ServerWide/Context/TransactionOperationContext.cs
@@ -115,9 +115,11 @@ namespace Raven.Server.ServerWide.Context
 
         protected internal override void Reset(bool forceResetLongLivedAllocator = false)
         {
+            CloseTransaction();
+
+
             base.Reset(forceResetLongLivedAllocator);
 
-            CloseTransaction();
 
             Allocator.Reset();
         }


### PR DESCRIPTION
Tweak Reset() order of transaction context to make sure we do not tryto dispose already disposed blittables