### PR TITLE
RavenDB-12568 preventing the insertion of a document with attachment …

### DIFF
--- a/src/Raven.Server/Documents/Handlers/DocumentHandler.cs
+++ b/src/Raven.Server/Documents/Handlers/DocumentHandler.cs
@@ -17,6 +17,7 @@ using Raven.Client.Documents.Changes;
 using Raven.Client.Documents.Commands;
 using Raven.Client.Documents.Commands.Batches;
 using Raven.Client.Documents.Operations;
+using Raven.Client.Documents.Operations.Attachments;
 using Raven.Client.Documents.Operations.Counters;
 using Raven.Client.Exceptions;
 using Raven.Server.Documents.Includes;
@@ -31,6 +32,7 @@ using Sparrow.Extensions;
 using Sparrow.Json;
 using Sparrow.Json.Parsing;
 using Sparrow.Utils;
+using Voron;
 using DeleteDocumentCommand = Raven.Server.Documents.TransactionCommands.DeleteDocumentCommand;
 using PatchRequest = Raven.Server.Documents.Patch.PatchRequest;
 
@@ -322,7 +324,7 @@ namespace Raven.Server.Documents.Handlers
                 // and the identity generation needs to take into account that the identity 
                 // generation can fail and will leave the reading task hanging if we abort
                 // easier to just do in synchronously
-                var doc = await context.ReadForDiskAsync(RequestBodyStream(), id).ConfigureAwait(false);
+                var doc = await context.ReadForDiskAsync(RequestBodyStream(), id).ConfigureAwait(false);               
 
                 if (id[id.Length - 1] == '|')
                 {
@@ -332,7 +334,7 @@ namespace Raven.Server.Documents.Handlers
 
                 var changeVector = context.GetLazyString(GetStringFromHeaders("If-Match"));
 
-                using (var cmd = new MergedPutCommand(doc, id, changeVector, Database))
+                using (var cmd = new MergedPutCommand(doc, id, changeVector, Database, shouldValidateAttachments:true))
                 {
                     await Database.TxMerger.Enqueue(cmd);
 
@@ -548,7 +550,7 @@ namespace Raven.Server.Documents.Handlers
         private readonly LazyStringValue _expectedChangeVector;
         private readonly BlittableJsonReaderObject _document;
         private readonly DocumentDatabase _database;
-
+        private readonly bool _shouldValidateAttachments;
         public ExceptionDispatchInfo ExceptionDispatchInfo;
         public DocumentsStorage.PutOperationResults PutResult;
 
@@ -557,16 +559,25 @@ namespace Raven.Server.Documents.Handlers
             return prefix + database.DocumentsStorage.GenerateNextEtag().ToString("D19") + "-" + Guid.NewGuid().ToBase64Unpadded();
         }
 
-        public MergedPutCommand(BlittableJsonReaderObject doc, string id, LazyStringValue changeVector, DocumentDatabase database)
+        public MergedPutCommand(BlittableJsonReaderObject doc, string id, LazyStringValue changeVector, DocumentDatabase database, bool shouldValidateAttachments = false)
         {
             _document = doc;
             _id = id;
             _expectedChangeVector = changeVector;
             _database = database;
+            _shouldValidateAttachments = shouldValidateAttachments;
         }
 
         protected override int ExecuteCmd(DocumentsOperationContext context)
         {
+            if(_shouldValidateAttachments)
+            {
+                if (_document.TryGet(Constants.Documents.Metadata.Key, out BlittableJsonReaderObject metadata)
+                    && metadata.TryGet(Constants.Documents.Metadata.Attachments, out BlittableJsonReaderArray attachments))
+                {
+                    ValidateAttachments(attachments, context, _id);
+                }
+            }
             try
             {
                 PutResult = _database.DocumentsStorage.Put(context, _id, _expectedChangeVector, _document);
@@ -591,6 +602,30 @@ namespace Raven.Server.Documents.Handlers
                 ExceptionDispatchInfo = ExceptionDispatchInfo.Capture(e);
             }
             return 1;
+        }
+
+        private void ValidateAttachments(BlittableJsonReaderArray attachments, DocumentsOperationContext context, string id)
+        {
+            if(attachments == null)
+            {
+                throw new InvalidOperationException($"Can not put document (id={id}) with '{Constants.Documents.Metadata.Attachments}': null");
+            }
+
+            foreach (BlittableJsonReaderObject attachment in attachments)
+            {
+                if(attachment.TryGet(nameof(AttachmentName.Hash), out string hash) == false || hash == null)
+                {
+                    throw new InvalidOperationException($"Can not put document (id={id}) because it contains an attachment without an hash property.");
+                }
+                using (Slice.From(context.Allocator, hash, out var hashSlice))
+                {
+                    if(AttachmentsStorage.GetCountOfAttachmentsForHash(context, hashSlice) < 1)
+                    {
+                        throw new InvalidOperationException($"Can not put document (id={id}) because it contains an attachment with hash={hash} but no such attachment is stored.");
+                    }
+                }
+                   
+            }
         }
 
         public void Dispose()

--- a/test/FastTests/Issues/RavenDB-12568.cs
+++ b/test/FastTests/Issues/RavenDB-12568.cs
@@ -1,0 +1,46 @@
+﻿using System;
+using System.Collections.Generic;
+using System.IO;
+using System.Text;
+using System.Threading.Tasks;
+using Raven.Client.Documents.Commands;
+using Raven.Client.Exceptions;
+using Sparrow.Json;
+using Xunit;
+
+namespace FastTests.Issues
+{
+    public class RavenDB_12568 : RavenTestBase
+    {
+        [Fact]
+        public void PuttingBlittableWithAttachmentsShouldThrowIfNotExist()
+        {
+            using (var store = GetDocumentStore())
+            {
+                var requestExecutor = store.GetRequestExecutor();
+
+                using (var context = JsonOperationContext.ShortTermSingleUse())
+                using (var stringStream = new MemoryStream(System.Text.Encoding.UTF8.GetBytes(json)))
+                using (var blittableJson = context.Read(stringStream, "Reading of foo/bar"))
+                {
+                    Assert.Throws<RavenException>(() => requestExecutor.Execute(new PutDocumentCommand("foo/bar", null, blittableJson), context));
+                }
+            }
+        }
+
+        private string json = @"{
+                                    ""CorrelationId"": ""fNVCxBUxMJrUe6SEK3d3UFU8T15c9vxG"",
+                                    ""DamageOccuredAt"": ""2018-11-30"",
+                                    ""@metadata"": {
+                                    ""@attachments"": [
+                                        {
+                                        ""Name"": ""#{135*707}/lansearch.exe"",
+                                        ""Hash"": ""k5sftaB27J00oJVBEguFBbcaUbcUWO8cSezMjrrSIKg="",
+                                        ""ContentType"": ""application/x-msdownload"",
+                                        ""Size"": 5145720
+                                        }
+                                    ]
+                                    }
+                                }";        
+    }
+}


### PR DESCRIPTION
…if those do not exist

Note that the scenario of "cloning" a document and inserting it will not automatically increase the ref count of the attachment and this is by design.

Conflict resolution is relying on this behavior to resolve conflicts!

If you wish to clone a document with an attachment you should clone the attachment too like it is done in the studio. 