### PR TITLE
RavenDB-13425 Fixing certificate schema updates:

### DIFF
--- a/src/Raven.Server/ServerWide/ClusterStateMachine.cs
+++ b/src/Raven.Server/ServerWide/ClusterStateMachine.cs
@@ -1024,6 +1024,8 @@ namespace Raven.Server.ServerWide
 
         internal static unsafe void UpdateCertificate(Table certificates, Slice key, Slice hash, BlittableJsonReaderObject updated)
         {
+            Debug.Assert(key.ToString() == key.ToString().ToLowerInvariant(), $"Key of certificate table (thumbprint) must be lower cased while we got '{key}'");
+
             using (certificates.Allocate(out TableValueBuilder builder))
             {
                 builder.Add(key);

--- a/src/Raven.Server/Storage/Schema/SchemaUpgrader.cs
+++ b/src/Raven.Server/Storage/Schema/SchemaUpgrader.cs
@@ -12,7 +12,7 @@ namespace Raven.Server.Storage.Schema
     {
         internal class CurrentVersion
         {
-            public const int ServerVersion = 16;
+            public const int ServerVersion = 17;
 
             public const int ConfigurationVersion = 11;
 

--- a/src/Raven.Server/Storage/Schema/Updates/Server/From11.cs
+++ b/src/Raven.Server/Storage/Schema/Updates/Server/From11.cs
@@ -112,7 +112,7 @@ namespace Raven.Server.Storage.Schema.Updates.Server
 
                         using (Slice.From(step.WriteTx.Allocator, def.PublicKeyPinningHash, out Slice hashSlice))
                         using (Slice.From(step.WriteTx.Allocator, cert.ItemName, out Slice oldKeySlice)) // includes the 'certificates/' prefix
-                        using (Slice.From(step.WriteTx.Allocator, def.Thumbprint, out Slice newKeySlice))
+                        using (Slice.From(step.WriteTx.Allocator, def.Thumbprint.ToLowerInvariant(), out Slice newKeySlice))
                         {
                             // in this update we trim 'certificates/' prefix from key name, CollectionPrimaryKey and CollectionSecondaryKeys
                             DropCertificatePrefixFromDefinition(def, out _);

--- a/src/Raven.Server/Storage/Schema/Updates/Server/From16.cs
+++ b/src/Raven.Server/Storage/Schema/Updates/Server/From16.cs
@@ -1,0 +1,10 @@
+﻿namespace Raven.Server.Storage.Schema.Updates.Server
+{
+    public class From16 : ISchemaUpdate
+    {
+        public bool Update(UpdateStep step)
+        {
+            return From15.UpdateCertificatesTableInternal(step);
+        }
+    }
+}


### PR DESCRIPTION
- we must not call SeekByPrimaryKey(...).ToList() because it's meant to be used only in foreach loops because we share the same TableValueHolder under the covers (From15)
- created another schema update which makes sure we'll migrate all certificates (From16)
- making sure we lower case a key of certificates table entry (thumbprint) during schema updates (From11, From15) - added debug assertion