### PR TITLE
RavenDB-13449 fix

### DIFF
--- a/src/Raven.Server/ServerWide/Commands/Subscriptions/PutSubscriptionBatchCommand.cs
+++ b/src/Raven.Server/ServerWide/Commands/Subscriptions/PutSubscriptionBatchCommand.cs
@@ -1,4 +1,5 @@
 ﻿using System.Collections.Generic;
+using System.IO;
 using Sparrow.Json;
 using Sparrow.Json.Parsing;
 
@@ -23,6 +24,9 @@ namespace Raven.Server.ServerWide.Commands.Subscriptions
             var dja = new DynamicJsonArray();
             foreach (var command in Commands)
             {
+                //precaution, prevent invalid subscription batch commands being sent.
+                if(command.SubscriptionId == null && string.IsNullOrEmpty(command.SubscriptionName))
+                    throw new InvalidDataException($"Invalid {nameof(PutSubscriptionCommand)}: {nameof(PutSubscriptionCommand.SubscriptionId)} or {nameof(PutSubscriptionCommand.SubscriptionName)} must not be empty. This should not happen and is likely due to a bug.");
                 dja.Add(command.ToJson(context));
             }
             djv[nameof(Commands)] = dja;


### PR DESCRIPTION
Make sure to register notification event only once per Raft command (even if it is a batch command that executes multiple Raft commands under the same index)