### PR TITLE
RavenDB-13517 - removed cancellation token

### DIFF
--- a/src/Raven.Server/Documents/ETL/LiveEtlPerformanceCollector.cs
+++ b/src/Raven.Server/Documents/ETL/LiveEtlPerformanceCollector.cs
@@ -121,7 +121,7 @@ namespace Raven.Server.Documents.ETL
 
             var latestStat = processAndPerformanceStats.Handler.GetLatestPerformanceStats();
             if (latestStat != null)
-                processAndPerformanceStats.Performance.Add(latestStat, CancellationToken);
+                processAndPerformanceStats.Performance.Add(latestStat);
         }
 
         protected override List<EtlTaskPerformanceStats> PreparePerformanceStats()

--- a/src/Raven.Server/Documents/Indexes/LiveIndexingPerformanceCollector.cs
+++ b/src/Raven.Server/Documents/Indexes/LiveIndexingPerformanceCollector.cs
@@ -135,7 +135,7 @@ namespace Raven.Server.Documents.Indexes
             var indexInstance = Database.IndexStore.GetIndex(indexAndPerformanceStats.Handler);
             var latestStat = indexInstance?.GetLatestIndexingStat();
             if (latestStat != null)
-                indexAndPerformanceStats.Performance.Add(latestStat, CancellationToken);
+                indexAndPerformanceStats.Performance.Add(latestStat);
         }
 
         private class IndexAndPerformanceStatsList : HandlerAndPerformanceStatsList<string, IndexingStatsAggregator>

--- a/src/Raven.Server/Documents/Replication/LiveReplicationPerformanceCollector.cs
+++ b/src/Raven.Server/Documents/Replication/LiveReplicationPerformanceCollector.cs
@@ -181,7 +181,7 @@ namespace Raven.Server.Documents.Replication
 
             var latestStat = stats.Handler.GetLatestReplicationPerformance();
             if (latestStat != null)
-                stats.Performance.Add(latestStat, CancellationToken);
+                stats.Performance.Add(latestStat);
         }
 
         private void IncomingHandlerRemoved(IncomingReplicationHandler handler)
@@ -210,7 +210,7 @@ namespace Raven.Server.Documents.Replication
 
             var latestStat = stats.Handler.GetLatestReplicationPerformance();
             if (latestStat != null)
-                stats.Performance.Add(latestStat, CancellationToken);
+                stats.Performance.Add(latestStat);
         }
 
         private class ReplicationHandlerAndPerformanceStatsList<THandler, TStatsAggregator> : HandlerAndPerformanceStatsList<THandler, TStatsAggregator>


### PR DESCRIPTION
not needed when adding stats to the blocking collection