### PR TITLE
RavenDB-13384 Fixing syncing issue due to missing handling of empty j…

### DIFF
--- a/src/Voron/Impl/Journal/JournalFile.cs
+++ b/src/Voron/Impl/Journal/JournalFile.cs
@@ -25,7 +25,7 @@ namespace Voron.Impl.Journal
         private IJournalWriter _journalWriter;
         private long _writePosIn4Kb;
 
-        private List<TransactionHeader> _transactionHeaders;
+        internal List<TransactionHeader> _transactionHeaders;
 
         private readonly PageTable _pageTranslationTable = new PageTable();
 
@@ -50,7 +50,6 @@ namespace Voron.Impl.Journal
         {
             return string.Format("Number: {0}", Number);
         }
-
 
         internal long WritePosIn4KbPosition => Interlocked.Read(ref _writePosIn4Kb);
 

--- a/src/Voron/Impl/LowLevelTransaction.cs
+++ b/src/Voron/Impl/LowLevelTransaction.cs
@@ -31,7 +31,7 @@ namespace Voron.Impl
         private readonly ByteStringContext _allocator;
         private readonly PageLocator _pageLocator;
         private bool _disposeAllocator;
-        private TestingStuff _forTestingPurposes;
+        internal TestingStuff _forTestingPurposes;
 
         private Tree _root;
         public Tree RootObjects => _root;
@@ -1286,6 +1286,7 @@ namespace Voron.Impl
             internal bool SimulateThrowingOnCommitStage2 = false;
 
             internal Action ActionToCallDuringEnsurePagerStateReference;
+            internal Action ActionToCallJustBeforeWritingToJournal;
 
             public TestingStuff(LowLevelTransaction tx)
             {
@@ -1302,6 +1303,13 @@ namespace Voron.Impl
                 ActionToCallDuringEnsurePagerStateReference = action;
 
                 return new DisposableAction(() => ActionToCallDuringEnsurePagerStateReference = null);
+            }
+
+            internal IDisposable CallJustBeforeWritingToJournal(Action action)
+            {
+                ActionToCallJustBeforeWritingToJournal = action;
+
+                return new DisposableAction(() => ActionToCallJustBeforeWritingToJournal = null);
             }
 
             internal HashSet<PagerState> GetPagerStates()

--- a/test/FastTests/Voron/StorageTest.cs
+++ b/test/FastTests/Voron/StorageTest.cs
@@ -41,7 +41,15 @@ namespace FastTests.Voron
 
         protected void RestartDatabase()
         {
-            StopDatabase();
+            var isFileBasedEnv = Options is StorageEnvironmentOptions.DirectoryStorageEnvironmentOptions;
+
+            StopDatabase(shouldDisposeOptions: isFileBasedEnv);
+
+            if (isFileBasedEnv)
+            {
+                Options = StorageEnvironmentOptions.ForPath(DataDir);
+                Configure(Options);
+            }
 
             StartDatabase();
         }
@@ -64,10 +72,11 @@ namespace FastTests.Voron
             GC.KeepAlive(_storageEnvironment.Value); // force creation
         }
 
-        protected void StopDatabase()
+        protected void StopDatabase(bool shouldDisposeOptions = false)
         {
             var ownsPagers = Options.OwnsPagers;
-            Options.OwnsPagers = false;
+
+            Options.OwnsPagers = shouldDisposeOptions;
 
             _storageEnvironment.Value.Dispose();
 

--- a/test/SlowTests/Voron/Issues/RavenDB_10813.cs
+++ b/test/SlowTests/Voron/Issues/RavenDB_10813.cs
@@ -1,4 +1,5 @@
-﻿using FastTests.Voron;
+﻿using System.Linq;
+using FastTests.Voron;
 using Sparrow;
 using Voron;
 using Xunit;
@@ -7,11 +8,13 @@ namespace SlowTests.Voron.Issues
 {
     public class RavenDB_10813 : StorageTest
     {
+        private readonly byte[] _masterKey = Sodium.GenerateRandomBuffer((int)Sodium.crypto_aead_xchacha20poly1305_ietf_keybytes());
+
         protected override void Configure(StorageEnvironmentOptions options)
         {
             base.Configure(options);
 
-            options.MasterKey = Sodium.GenerateRandomBuffer((int)Sodium.crypto_aead_xchacha20poly1305_ietf_keybytes());
+            options.MasterKey = _masterKey.ToArray();
         }
 
         [Fact]

--- a/test/SlowTests/Voron/Issues/RavenDB_13384.cs
+++ b/test/SlowTests/Voron/Issues/RavenDB_13384.cs
@@ -1,0 +1,116 @@
+﻿using System;
+using FastTests.Voron;
+using Voron;
+using Voron.Impl.Journal;
+using Xunit;
+
+namespace SlowTests.Voron.Issues
+{
+    public class RavenDB_13384 : StorageTest
+    {
+        protected override void Configure(StorageEnvironmentOptions options)
+        {
+            options.ManualFlushing = true;
+            options.ManualSyncing = true;
+            options.MaxLogFileSize = 4096;
+        }
+
+        [Theory]
+        [InlineData(true)]
+        [InlineData(false)]
+        public void Recovery_should_handle_empty_journal_file_and_correctly_set_last_flushed_journal(bool runInMemory)
+        {
+            if (runInMemory == false)
+                RequireFileBasedPager();
+
+            using (var tx = Env.WriteTransaction())
+            {
+                tx.CreateTree("tree").Add("item", new byte[]{ 1, 2, 3});
+
+                tx.Commit();
+            }
+
+            var numberOfJournals = Env.Journal.Files.Count;
+
+            using (var tx = Env.WriteTransaction())
+            {
+                tx.CreateTree("tree").Add("item", new byte[] { 1, 2, 3 });
+
+                Assert.Throws<InvalidOperationException>(() =>
+                {
+                    using (tx.LowLevelTransaction.ForTestingPurposesOnly().CallJustBeforeWritingToJournal(() => throw new InvalidOperationException()))
+                    {
+                        tx.Commit();
+                    }
+                });
+            }
+
+            // we failed to commit the above transaction and write data to file 
+            // but we managed to create _empty_ journal file
+
+            Assert.Equal(numberOfJournals + 1, Env.Journal.Files.Count);
+
+            RestartDatabase();
+
+            using (var operation = new WriteAheadJournal.JournalApplicator.SyncOperation(Env.Journal.Applicator))
+            {
+                // attempt to sync throws the following exception:
+                // System.InvalidOperationException : The lock task failed
+                // ----Voron.Exceptions.VoronUnrecoverableErrorException : Error syncing the data file.The last sync tx is 2, but the journal's last tx id is -1, possible file corruption?
+
+                operation.SyncDataFile();
+            }
+
+            // let's make sure we can restart immediately after sync
+
+            RestartDatabase();
+
+            // there is nothing to flush but let's validate it won't throw
+
+            using (var operation = new WriteAheadJournal.JournalApplicator.SyncOperation(Env.Journal.Applicator))
+            {
+                operation.SyncDataFile();
+            }
+
+            // let's make sure we can put more stuff there
+
+            for (int i = 0; i < 5; i++)
+            {
+                using (var tx = Env.WriteTransaction())
+                {
+                    tx.CreateTree("tree").Add("item", new byte[] { 1, 2, 3 });
+
+                    tx.Commit();
+                }
+            }
+
+            RestartDatabase();
+
+            Env.FlushLogToDataFile();
+
+            using (var operation = new WriteAheadJournal.JournalApplicator.SyncOperation(Env.Journal.Applicator))
+            {
+                operation.SyncDataFile();
+            }
+
+            // lets add more data once again and force flushing and syncing
+
+            for (int i = 0; i < 5; i++)
+            {
+                using (var tx = Env.WriteTransaction())
+                {
+                    tx.CreateTree("tree").Add("item", new byte[] { 1, 2, 3 });
+
+                    tx.Commit();
+                }
+            }
+
+            Env.FlushLogToDataFile();
+
+            using (var operation = new WriteAheadJournal.JournalApplicator.SyncOperation(Env.Journal.Applicator))
+            {
+                operation.SyncDataFile();
+            }
+        }
+    }
+}


### PR DESCRIPTION
…ournal:

- we didn't take into account that a journal file might be created but effectively it's empty
- we need to have distinction during recovery between last processed and last flushed journal - the last processed one might be empty so we couldn't flush it
- the issue might happen when killing or crashing the server just before writing data to the journal
- improving exception message
- making sure that restarting an environment in tests does _disposal_ of storage environment options - otherwise we reuse journal writers between restarts (it revealed an issue in my initial fix)