### PR TITLE
RavenDB-13535 An item with the same key has already been added on outgoing replication

### DIFF
--- a/src/Raven.Server/Documents/AttachmentsStorage.cs
+++ b/src/Raven.Server/Documents/AttachmentsStorage.cs
@@ -73,7 +73,8 @@ namespace Raven.Server.Documents
             AttachmentsSchema.DefineFixedSizeIndex(new TableSchema.FixedSizeSchemaIndexDef
             {
                 StartIndex = (int)AttachmentsTable.Etag,
-                Name = AttachmentsEtagSlice
+                Name = AttachmentsEtagSlice,
+                IsGlobal = true
             });
             AttachmentsSchema.DefineIndex(new TableSchema.SchemaIndexDef
             {

--- a/test/SlowTests/Client/Attachments/AttachmentsReplication.cs
+++ b/test/SlowTests/Client/Attachments/AttachmentsReplication.cs
@@ -5,7 +5,6 @@ using System.Linq;
 using System.Threading;
 using System.Threading.Tasks;
 using FastTests;
-using FastTests.Server.Documents.Revisions;
 using FastTests.Server.Replication;
 using FastTests.Utils;
 using Orders;
@@ -16,8 +15,9 @@ using Raven.Client.Documents.Operations;
 using Raven.Client.Documents.Operations.Attachments;
 using Raven.Client.Documents.Session;
 using Raven.Client.ServerWide;
+using Raven.Server.Config;
 using Raven.Server.Documents;
-using Raven.Server.Utils;
+using Raven.Server.ServerWide.Context;
 using Raven.Tests.Core.Utils.Entities;
 using Sparrow.Json;
 using Xunit;
@@ -1136,6 +1136,74 @@ namespace SlowTests.Client.Attachments
 
                 await AssertAttachments(store1, new[] { "a1" });
                 await AssertAttachments(store2, new[] { "a1" });
+            }
+        }
+
+        [Fact]
+        public async Task RavenDB_13535()
+        {
+            using (var server = GetNewServer(runInMemory: false, customSettings: new Dictionary<string, string>
+            {
+                [RavenConfiguration.GetKey(x => x.Replication.MaxSizeToSend)] = 1.ToString()
+            }))
+            using (var store1 = GetDocumentStore(new Options{Server = server, RunInMemory = false}))
+            using (var store2 = GetDocumentStore(new Options{Server = server, RunInMemory = false}))
+            using (var store3 = GetDocumentStore(new Options{Server = server, RunInMemory = false}))
+            {
+                using (var session = store1.OpenAsyncSession())
+                using (var a1 = new MemoryStream(new byte[2 * 1024 * 1024]))
+                {
+                    var user = new User();
+                    await session.StoreAsync(user, "foo");
+                    session.Advanced.Attachments.Store(user, "dummy", a1);
+                    await session.SaveChangesAsync();
+                }
+
+                using (var session = store1.OpenAsyncSession())
+                {
+                    var user = await session.LoadAsync<User>("foo");
+                    user.Name = "Karmel";
+                    await session.SaveChangesAsync();
+                }
+
+                var db1 = await server.ServerStore.DatabasesLandlord.TryGetOrCreateResourceStore(store1.Database);
+                var mre = new ManualResetEventSlim(true);
+                db1.ReplicationLoader.DebugWaitAndRunReplicationOnce = mre;
+
+                await SetupReplicationAsync(store1, store2);
+
+                var db2 = await server.ServerStore.DatabasesLandlord.TryGetOrCreateResourceStore(store2.Database);
+
+                var count = WaitForValue(() =>
+                {
+                    using (db2.DocumentsStorage.ContextPool.AllocateOperationContext(out DocumentsOperationContext ctx))
+                    using (ctx.OpenReadTransaction())
+                    {
+                        return db2.DocumentsStorage.AttachmentsStorage.GetNumberOfAttachments(ctx).AttachmentCount;
+                    }
+                }, 1);
+                Assert.Equal(1, count);
+                
+                db2.ServerStore.DatabasesLandlord.UnloadDirectly(db2.Name);
+
+                using (var session = store2.OpenAsyncSession())
+                {
+                    await session.StoreAsync(new User(), "bar");
+                    await session.SaveChangesAsync();
+                }
+
+                await SetupReplicationAsync(store2, store3);
+
+                var db3 = await server.ServerStore.DatabasesLandlord.TryGetOrCreateResourceStore(store3.Database);
+                count = WaitForValue(() =>
+                {
+                    using (db3.DocumentsStorage.ContextPool.AllocateOperationContext(out DocumentsOperationContext ctx))
+                    using (ctx.OpenReadTransaction())
+                    {
+                        return db3.DocumentsStorage.AttachmentsStorage.GetNumberOfAttachments(ctx).AttachmentCount;
+                    }
+                }, 1);
+                Assert.Equal(1, count);
             }
         }
     }

--- a/test/Tests.Infrastructure/RavenTestBase.cs
+++ b/test/Tests.Infrastructure/RavenTestBase.cs
@@ -101,7 +101,7 @@ namespace FastTests
                         name = options.ModifyDatabaseName(name) ?? name;
 
                     var hardDelete = true;
-                    var runInMemory = true;
+                    var runInMemory = options.RunInMemory;
 
                     var pathToUse = options.Path;
                     if (pathToUse == null)
@@ -636,6 +636,7 @@ namespace FastTests
             private Action<DatabaseRecord> _modifyDatabaseRecord;
             private Func<string, string> _modifyDatabaseName;
             private string _path;
+            private bool _runInMemory = true;
 
             public static readonly Options Default = new Options(true);
 
@@ -739,6 +740,15 @@ namespace FastTests
                 {
                     AssertNotFrozen();
                     _createDatabase = value;
+                }
+            }
+            public bool RunInMemory
+            {
+                get => _runInMemory;
+                set
+                {
+                    AssertNotFrozen();
+                    _runInMemory = value;
                 }
             }
 


### PR DESCRIPTION
The issue here is that reading the last etag on database startup yield wrong value, because the attachment voron index for reading the last etag wasn't global.

The case where this could happened:
1. Sending a replication batch where the attachment is the last item 
2. The destination restarts the database after receiving that batch. 