### PR TITLE
 RavenDB-13556 Improve client interaction with the cluster [WIP]

### DIFF
--- a/src/Raven.Client/Constants.cs
+++ b/src/Raven.Client/Constants.cs
@@ -54,6 +54,8 @@ namespace Raven.Client
             public const string TransferEncoding = "Transfer-Encoding";
             public const string ContentEncoding = "Content-Encoding";
             public const string ContentLength = "Content-Length";
+
+            public const string RaftCommandGuid = "Raft-Command-Guid";
         }
 
         public class Platform

--- a/src/Raven.Client/Documents/BulkInsert/BulkInsertOperation.cs
+++ b/src/Raven.Client/Documents/BulkInsert/BulkInsertOperation.cs
@@ -85,6 +85,8 @@ namespace Raven.Client.Documents.BulkInsert
         private class BulkInsertCommand : RavenCommand<HttpResponseMessage>
         {
             public override bool IsReadRequest => false;
+            public override bool IsClusterCommand => false;
+
             private readonly StreamExposerContent _stream;
             private readonly long _id;
 

--- a/src/Raven.Client/Documents/Commands/Batches/BatchCommand.cs
+++ b/src/Raven.Client/Documents/Commands/Batches/BatchCommand.cs
@@ -19,6 +19,7 @@ namespace Raven.Client.Documents.Commands.Batches
         private readonly HashSet<Stream> _uniqueAttachmentStreams;
         private readonly BatchOptions _options;
         private readonly TransactionMode _mode;
+        private readonly string _guid;
 
         public BatchCommand(DocumentConventions conventions, JsonOperationContext context, List<ICommandData> commands, BatchOptions options = null, TransactionMode mode = TransactionMode.SingleNode)
         {
@@ -51,6 +52,9 @@ namespace Raven.Client.Documents.Commands.Batches
                     _attachmentStreams.Add(stream);
                 }
             }
+
+            if (mode == TransactionMode.ClusterWide)
+                _guid = Guid.NewGuid().ToString();
 
             _options = options;
             _mode = mode;
@@ -118,10 +122,16 @@ namespace Raven.Client.Documents.Commands.Batches
 
         private void AppendOptions(StringBuilder sb)
         {
-            if (_options == null)
+            if (_options == null && _mode == TransactionMode.SingleNode)
                 return;
 
-            sb.AppendLine("?");
+            sb.Append("?");
+
+            if (_mode == TransactionMode.ClusterWide)
+                sb.Append($"guid={_guid}");
+
+            if(_options == null)
+                return;
 
             var replicationOptions = _options.ReplicationOptions;
             if (replicationOptions != null)

--- a/src/Raven.Client/Documents/Commands/Batches/BatchCommand.cs
+++ b/src/Raven.Client/Documents/Commands/Batches/BatchCommand.cs
@@ -19,7 +19,6 @@ namespace Raven.Client.Documents.Commands.Batches
         private readonly HashSet<Stream> _uniqueAttachmentStreams;
         private readonly BatchOptions _options;
         private readonly TransactionMode _mode;
-        private readonly string _guid;
 
         public BatchCommand(DocumentConventions conventions, JsonOperationContext context, List<ICommandData> commands, BatchOptions options = null, TransactionMode mode = TransactionMode.SingleNode)
         {
@@ -52,9 +51,6 @@ namespace Raven.Client.Documents.Commands.Batches
                     _attachmentStreams.Add(stream);
                 }
             }
-
-            if (mode == TransactionMode.ClusterWide)
-                _guid = Guid.NewGuid().ToString();
 
             _options = options;
             _mode = mode;
@@ -122,16 +118,10 @@ namespace Raven.Client.Documents.Commands.Batches
 
         private void AppendOptions(StringBuilder sb)
         {
-            if (_options == null && _mode == TransactionMode.SingleNode)
+            if (_options == null)
                 return;
 
             sb.Append("?");
-
-            if (_mode == TransactionMode.ClusterWide)
-                sb.Append($"guid={_guid}");
-
-            if(_options == null)
-                return;
 
             var replicationOptions = _options.ReplicationOptions;
             if (replicationOptions != null)
@@ -163,6 +153,7 @@ namespace Raven.Client.Documents.Commands.Batches
         }
 
         public override bool IsReadRequest => false;
+        public override bool IsClusterCommand => _mode == TransactionMode.ClusterWide;
 
         public void Dispose()
         {

--- a/src/Raven.Client/Documents/Commands/CreateSubscriptionCommand.cs
+++ b/src/Raven.Client/Documents/Commands/CreateSubscriptionCommand.cs
@@ -45,5 +45,6 @@ namespace Raven.Client.Documents.Commands
         }
 
         public override bool IsReadRequest => false;
+        public override bool IsClusterCommand => true;
     }
 }

--- a/src/Raven.Client/Documents/Commands/DeleteDocumentCommand.cs
+++ b/src/Raven.Client/Documents/Commands/DeleteDocumentCommand.cs
@@ -16,6 +16,8 @@ namespace Raven.Client.Documents.Commands
             _changeVector = changeVector;
         }
 
+        public override bool IsClusterCommand => false;
+
         public override HttpRequestMessage CreateRequest(JsonOperationContext ctx, ServerNode node, out string url)
         {
             EnsureIsNotNullOrEmpty(_id, nameof(_id));

--- a/src/Raven.Client/Documents/Commands/DeleteSubscriptionsCommand.cs
+++ b/src/Raven.Client/Documents/Commands/DeleteSubscriptionsCommand.cs
@@ -13,6 +13,8 @@ namespace Raven.Client.Documents.Commands
             _name = name;
         }
 
+        public override bool IsClusterCommand => true;
+
         public override HttpRequestMessage CreateRequest(JsonOperationContext ctx, ServerNode node, out string url)
         {
             url = $"{node.Url}/databases/{node.Database}/subscriptions?taskName={_name}";

--- a/src/Raven.Client/Documents/Commands/DropSubscriptionConnectionCommand.cs
+++ b/src/Raven.Client/Documents/Commands/DropSubscriptionConnectionCommand.cs
@@ -4,7 +4,7 @@ using Sparrow.Json;
 
 namespace Raven.Client.Documents.Commands
 {
-    public class DropSubscriptionConnectionCommand:RavenCommand
+    public class DropSubscriptionConnectionCommand : RavenCommand
     {
         private readonly string _name;
 
@@ -12,6 +12,9 @@ namespace Raven.Client.Documents.Commands
         {
             _name = name;
         }
+
+        public override bool IsClusterCommand => false;
+
         public override HttpRequestMessage CreateRequest(JsonOperationContext ctx, ServerNode node, out string url)
         {
             url = $"{node.Url}/databases/{node.Database}/subscriptions/drop?name={_name}";

--- a/src/Raven.Client/Documents/Commands/ExplainQueryCommand.cs
+++ b/src/Raven.Client/Documents/Commands/ExplainQueryCommand.cs
@@ -76,5 +76,6 @@ namespace Raven.Client.Documents.Commands
         }
 
         public override bool IsReadRequest => true;
+        public override bool IsClusterCommand => false;
     }
 }

--- a/src/Raven.Client/Documents/Commands/GetConflictsCommand.cs
+++ b/src/Raven.Client/Documents/Commands/GetConflictsCommand.cs
@@ -9,6 +9,7 @@ namespace Raven.Client.Documents.Commands
     {
         private readonly string _id;
         public override bool IsReadRequest => true;
+        public override bool IsClusterCommand => false;
 
         public GetConflictsCommand(string id)
         {

--- a/src/Raven.Client/Documents/Commands/GetDocumentsCommand.cs
+++ b/src/Raven.Client/Documents/Commands/GetDocumentsCommand.cs
@@ -199,5 +199,6 @@ namespace Raven.Client.Documents.Commands
         }
 
         public override bool IsReadRequest => true;
+        public override bool IsClusterCommand => false;
     }
 }

--- a/src/Raven.Client/Documents/Commands/GetNextOperationIdCommand.cs
+++ b/src/Raven.Client/Documents/Commands/GetNextOperationIdCommand.cs
@@ -7,6 +7,8 @@ namespace Raven.Client.Documents.Commands
     public class GetNextOperationIdCommand : RavenCommand<long>
     {
         public override bool IsReadRequest => false; // disable caching
+        public override bool IsClusterCommand => false;
+
         public override HttpRequestMessage CreateRequest(JsonOperationContext ctx, ServerNode node, out string url)
         {
             url = $"{node.Url}/databases/{node.Database}/operations/next-operation-id";

--- a/src/Raven.Client/Documents/Commands/GetRevisionsBinEntryCommand.cs
+++ b/src/Raven.Client/Documents/Commands/GetRevisionsBinEntryCommand.cs
@@ -53,5 +53,6 @@ namespace Raven.Client.Documents.Commands
         }
 
         public override bool IsReadRequest => true;
+        public override bool IsClusterCommand => false;
     }
 }

--- a/src/Raven.Client/Documents/Commands/GetRevisionsCommand.cs
+++ b/src/Raven.Client/Documents/Commands/GetRevisionsCommand.cs
@@ -99,5 +99,6 @@ namespace Raven.Client.Documents.Commands
         }
 
         public override bool IsReadRequest => true;
+        public override bool IsClusterCommand => false;
     }
 }

--- a/src/Raven.Client/Documents/Commands/GetSubscriptionStateCommand.cs
+++ b/src/Raven.Client/Documents/Commands/GetSubscriptionStateCommand.cs
@@ -10,6 +10,7 @@ namespace Raven.Client.Documents.Commands
     {
         private readonly string _subscriptionName;
         public override bool IsReadRequest => true;
+        public override bool IsClusterCommand => false;
 
         public GetSubscriptionStateCommand(string subscriptionName)
         {

--- a/src/Raven.Client/Documents/Commands/GetSubscriptionsCommand.cs
+++ b/src/Raven.Client/Documents/Commands/GetSubscriptionsCommand.cs
@@ -40,5 +40,6 @@ namespace Raven.Client.Documents.Commands
         }
 
         public override bool IsReadRequest => true;
+        public override bool IsClusterCommand => false;
     }
 }

--- a/src/Raven.Client/Documents/Commands/HeadAttachmentCommand.cs
+++ b/src/Raven.Client/Documents/Commands/HeadAttachmentCommand.cs
@@ -72,5 +72,6 @@ namespace Raven.Client.Documents.Commands
         }
 
         public override bool IsReadRequest => false;
+        public override bool IsClusterCommand => false;
     }
 }

--- a/src/Raven.Client/Documents/Commands/HeadDocumentCommand.cs
+++ b/src/Raven.Client/Documents/Commands/HeadDocumentCommand.cs
@@ -21,6 +21,7 @@ namespace Raven.Client.Documents.Commands
         }
 
         public override bool IsReadRequest => false;
+        public override bool IsClusterCommand => false;
 
         public override HttpRequestMessage CreateRequest(JsonOperationContext ctx, ServerNode node, out string url)
         {

--- a/src/Raven.Client/Documents/Commands/HiLoReturnCommand.cs
+++ b/src/Raven.Client/Documents/Commands/HiLoReturnCommand.cs
@@ -23,6 +23,8 @@ namespace Raven.Client.Documents.Commands
             _end = end;
         }
 
+        public override bool IsClusterCommand => false;
+
         public override HttpRequestMessage CreateRequest(JsonOperationContext ctx, ServerNode node, out string url)
         {
             url = $"{node.Url}/databases/{node.Database}/hilo/return?tag={_tag}&end={_end}&last={_last}";

--- a/src/Raven.Client/Documents/Commands/KillOperationCommand.cs
+++ b/src/Raven.Client/Documents/Commands/KillOperationCommand.cs
@@ -13,6 +13,8 @@ namespace Raven.Client.Documents.Commands
             _id = id;
         }
 
+        public override bool IsClusterCommand => false;
+
         public override HttpRequestMessage CreateRequest(JsonOperationContext ctx, ServerNode node, out string url)
         {
             url = $"{node.Url}/databases/{node.Database}/operations/kill?id={_id}";

--- a/src/Raven.Client/Documents/Commands/MultiGet/MultiGetCommand.cs
+++ b/src/Raven.Client/Documents/Commands/MultiGet/MultiGetCommand.cs
@@ -279,5 +279,6 @@ namespace Raven.Client.Documents.Commands.MultiGet
         }
 
         public override bool IsReadRequest => false;
+        public override bool IsClusterCommand => false;
     }
 }

--- a/src/Raven.Client/Documents/Commands/NextHiLoCommand.cs
+++ b/src/Raven.Client/Documents/Commands/NextHiLoCommand.cs
@@ -43,5 +43,6 @@ namespace Raven.Client.Documents.Commands
         }
 
         public override bool IsReadRequest => true;
+        public override bool IsClusterCommand => false;
     }
 }

--- a/src/Raven.Client/Documents/Commands/NextIdentityForCommand.cs
+++ b/src/Raven.Client/Documents/Commands/NextIdentityForCommand.cs
@@ -15,6 +15,7 @@ namespace Raven.Client.Documents.Commands
         }
 
         public override bool IsReadRequest { get; } = false;
+        public override bool IsClusterCommand => true;
 
         public override HttpRequestMessage CreateRequest(JsonOperationContext ctx, ServerNode node, out string url)
         {

--- a/src/Raven.Client/Documents/Commands/PutDocumentCommand.cs
+++ b/src/Raven.Client/Documents/Commands/PutDocumentCommand.cs
@@ -43,5 +43,6 @@ namespace Raven.Client.Documents.Commands
         }
 
         public override bool IsReadRequest => false;
+        public override bool IsClusterCommand => false;
     }
 }

--- a/src/Raven.Client/Documents/Commands/QueryCommand.cs
+++ b/src/Raven.Client/Documents/Commands/QueryCommand.cs
@@ -114,5 +114,6 @@ namespace Raven.Client.Documents.Commands
         }
 
         public override bool IsReadRequest => true;
+        public override bool IsClusterCommand => false;
     }
 }

--- a/src/Raven.Client/Documents/Commands/QueryStreamCommand.cs
+++ b/src/Raven.Client/Documents/Commands/QueryStreamCommand.cs
@@ -52,5 +52,6 @@ namespace Raven.Client.Documents.Commands
         }
 
         public override bool IsReadRequest => true;
+        public override bool IsClusterCommand => false;
     }
 }

--- a/src/Raven.Client/Documents/Commands/SeedIdentityForCommand.cs
+++ b/src/Raven.Client/Documents/Commands/SeedIdentityForCommand.cs
@@ -19,6 +19,7 @@ namespace Raven.Client.Documents.Commands
         }
 
         public override bool IsReadRequest { get; } = false;
+        public override bool IsClusterCommand => true;
 
         public override HttpRequestMessage CreateRequest(JsonOperationContext ctx, ServerNode node, out string url)
         {

--- a/src/Raven.Client/Documents/Commands/StreamCommand .cs
+++ b/src/Raven.Client/Documents/Commands/StreamCommand .cs
@@ -38,5 +38,6 @@ namespace Raven.Client.Documents.Commands
         }
 
         public override bool IsReadRequest => true;
+        public override bool IsClusterCommand => false;
     }
 }

--- a/src/Raven.Client/Documents/Operations/Attachments/DeleteAttachmentOperation.cs
+++ b/src/Raven.Client/Documents/Operations/Attachments/DeleteAttachmentOperation.cs
@@ -43,6 +43,8 @@ namespace Raven.Client.Documents.Operations.Attachments
                 _changeVector = changeVector;
             }
 
+            public override bool IsClusterCommand => false;
+
             public override HttpRequestMessage CreateRequest(JsonOperationContext ctx, ServerNode node, out string url)
             {
                 url = $"{node.Url}/databases/{node.Database}/attachments?id={Uri.EscapeDataString(_documentId)}&name={Uri.EscapeDataString(_name)}";

--- a/src/Raven.Client/Documents/Operations/Attachments/GetAttachmentOperation.cs
+++ b/src/Raven.Client/Documents/Operations/Attachments/GetAttachmentOperation.cs
@@ -124,6 +124,7 @@ namespace Raven.Client.Documents.Operations.Attachments
             }
 
             public override bool IsReadRequest => true;
+            public override bool IsClusterCommand => false;
         }
     }
 }

--- a/src/Raven.Client/Documents/Operations/Attachments/PutAttachmentOperation.cs
+++ b/src/Raven.Client/Documents/Operations/Attachments/PutAttachmentOperation.cs
@@ -80,6 +80,7 @@ namespace Raven.Client.Documents.Operations.Attachments
             }
 
             public override bool IsReadRequest => false;
+            public override bool IsClusterCommand => false;
         }
     }
 }

--- a/src/Raven.Client/Documents/Operations/Backups/GetPeriodicBackupStatusOperation.cs
+++ b/src/Raven.Client/Documents/Operations/Backups/GetPeriodicBackupStatusOperation.cs
@@ -23,6 +23,8 @@ namespace Raven.Client.Documents.Operations.Backups
         private class GetPeriodicBackupStatusCommand : RavenCommand<GetPeriodicBackupStatusOperationResult>
         {
             public override bool IsReadRequest => true;
+            public override bool IsClusterCommand => false;
+
             private readonly long _taskId;
 
             public GetPeriodicBackupStatusCommand(long taskId)

--- a/src/Raven.Client/Documents/Operations/Backups/StartBackupOperation.cs
+++ b/src/Raven.Client/Documents/Operations/Backups/StartBackupOperation.cs
@@ -25,6 +25,7 @@ namespace Raven.Client.Documents.Operations.Backups
         private class StartBackupCommand : RavenCommand<StartBackupOperationResult>
         {
             public override bool IsReadRequest => true;
+            public override bool IsClusterCommand => false;
 
             private readonly bool _isFullBackup;
             private readonly long _taskId;

--- a/src/Raven.Client/Documents/Operations/Backups/UpdatePeriodicBackupOperation.cs
+++ b/src/Raven.Client/Documents/Operations/Backups/UpdatePeriodicBackupOperation.cs
@@ -34,6 +34,7 @@ namespace Raven.Client.Documents.Operations.Backups
             }
 
             public override bool IsReadRequest => false;
+            public override bool IsClusterCommand => true;
 
             public override HttpRequestMessage CreateRequest(JsonOperationContext ctx, ServerNode node, out string url)
             {

--- a/src/Raven.Client/Documents/Operations/CompareExchange/DeleteCompareExchangeValueOperation.cs
+++ b/src/Raven.Client/Documents/Operations/CompareExchange/DeleteCompareExchangeValueOperation.cs
@@ -40,6 +40,7 @@ namespace Raven.Client.Documents.Operations.CompareExchange
             }
 
             public override bool IsReadRequest => true;
+            public override bool IsClusterCommand => true;
 
             public override HttpRequestMessage CreateRequest(JsonOperationContext ctx, ServerNode node, out string url)
             {

--- a/src/Raven.Client/Documents/Operations/CompareExchange/GetCompareExchangeValueOperation.cs
+++ b/src/Raven.Client/Documents/Operations/CompareExchange/GetCompareExchangeValueOperation.cs
@@ -36,6 +36,7 @@ namespace Raven.Client.Documents.Operations.CompareExchange
             }
 
             public override bool IsReadRequest => true;
+            public override bool IsClusterCommand => false;
 
             public override HttpRequestMessage CreateRequest(JsonOperationContext ctx, ServerNode node, out string url)
             {

--- a/src/Raven.Client/Documents/Operations/CompareExchange/GetCompareExchangeValuesOperation.cs
+++ b/src/Raven.Client/Documents/Operations/CompareExchange/GetCompareExchangeValuesOperation.cs
@@ -49,6 +49,7 @@ namespace Raven.Client.Documents.Operations.CompareExchange
             }
 
             public override bool IsReadRequest => true;
+            public override bool IsClusterCommand => false;
 
             public override HttpRequestMessage CreateRequest(JsonOperationContext ctx, ServerNode node, out string url)
             {

--- a/src/Raven.Client/Documents/Operations/CompareExchange/PutCompareExchangeValueOperation.cs
+++ b/src/Raven.Client/Documents/Operations/CompareExchange/PutCompareExchangeValueOperation.cs
@@ -52,6 +52,7 @@ namespace Raven.Client.Documents.Operations.CompareExchange
             }
 
             public override bool IsReadRequest => false;
+            public override bool IsClusterCommand => true;
 
             public override HttpRequestMessage CreateRequest(JsonOperationContext ctx, ServerNode node, out string url)
             {

--- a/src/Raven.Client/Documents/Operations/Configuration/GetClientConfigurationOperation.cs
+++ b/src/Raven.Client/Documents/Operations/Configuration/GetClientConfigurationOperation.cs
@@ -16,6 +16,7 @@ namespace Raven.Client.Documents.Operations.Configuration
         internal class GetClientConfigurationCommand : RavenCommand<Result>
         {
             public override bool IsReadRequest => false;
+            public override bool IsClusterCommand => false;
 
             public override HttpRequestMessage CreateRequest(JsonOperationContext ctx, ServerNode node, out string url)
             {

--- a/src/Raven.Client/Documents/Operations/Configuration/PutClientConfigurationOperation.cs
+++ b/src/Raven.Client/Documents/Operations/Configuration/PutClientConfigurationOperation.cs
@@ -38,6 +38,8 @@ namespace Raven.Client.Documents.Operations.Configuration
                 _configuration = EntityToBlittable.ConvertCommandToBlittable(configuration, context);
             }
 
+            public override bool IsClusterCommand => true;
+
             public override HttpRequestMessage CreateRequest(JsonOperationContext ctx, ServerNode node, out string url)
             {
                 url = $"{node.Url}/databases/{node.Database}/admin/configuration/client";

--- a/src/Raven.Client/Documents/Operations/ConnectionStrings/GetConnectionStringsOperation.cs
+++ b/src/Raven.Client/Documents/Operations/ConnectionStrings/GetConnectionStringsOperation.cs
@@ -46,6 +46,7 @@ namespace Raven.Client.Documents.Operations.ConnectionStrings
             }
 
             public override bool IsReadRequest => false;
+            public override bool IsClusterCommand => false;
 
             public override HttpRequestMessage CreateRequest(JsonOperationContext ctx, ServerNode node, out string url)
             {

--- a/src/Raven.Client/Documents/Operations/ConnectionStrings/PutConnectionStringOperation.cs
+++ b/src/Raven.Client/Documents/Operations/ConnectionStrings/PutConnectionStringOperation.cs
@@ -34,6 +34,7 @@ namespace Raven.Client.Documents.Operations.ConnectionStrings
             }
 
             public override bool IsReadRequest => false;
+            public override bool IsClusterCommand => true;
 
             public override HttpRequestMessage CreateRequest(JsonOperationContext ctx, ServerNode node, out string url)
             {

--- a/src/Raven.Client/Documents/Operations/ConnectionStrings/RemoveConnectionStringOperation.cs
+++ b/src/Raven.Client/Documents/Operations/ConnectionStrings/RemoveConnectionStringOperation.cs
@@ -30,6 +30,7 @@ namespace Raven.Client.Documents.Operations.ConnectionStrings
             }
 
             public override bool IsReadRequest => false;
+            public override bool IsClusterCommand => true;
 
             public override HttpRequestMessage CreateRequest(JsonOperationContext ctx, ServerNode node, out string url)
             {

--- a/src/Raven.Client/Documents/Operations/Counters/CounterBatchOperation.cs
+++ b/src/Raven.Client/Documents/Operations/Counters/CounterBatchOperation.cs
@@ -60,7 +60,7 @@ namespace Raven.Client.Documents.Operations.Counters
             }
 
             public override bool IsReadRequest => false;
-
+            public override bool IsClusterCommand => false;
         }
 
 

--- a/src/Raven.Client/Documents/Operations/Counters/GetCountersOperation.cs
+++ b/src/Raven.Client/Documents/Operations/Counters/GetCountersOperation.cs
@@ -147,6 +147,7 @@ namespace Raven.Client.Documents.Operations.Counters
             }
 
             public override bool IsReadRequest => true;
+            public override bool IsClusterCommand => false;
         }
     }
 }

--- a/src/Raven.Client/Documents/Operations/DeleteByQueryOperation.cs
+++ b/src/Raven.Client/Documents/Operations/DeleteByQueryOperation.cs
@@ -133,6 +133,7 @@ namespace Raven.Client.Documents.Operations
             }
 
             public override bool IsReadRequest => false;
+            public override bool IsClusterCommand => false;
         }
     }
 }

--- a/src/Raven.Client/Documents/Operations/ETL/AddEtlOperation.cs
+++ b/src/Raven.Client/Documents/Operations/ETL/AddEtlOperation.cs
@@ -35,6 +35,7 @@ namespace Raven.Client.Documents.Operations.ETL
             }
 
             public override bool IsReadRequest => false;
+            public override bool IsClusterCommand => true;
 
             public override HttpRequestMessage CreateRequest(JsonOperationContext ctx, ServerNode node, out string url)
             {

--- a/src/Raven.Client/Documents/Operations/ETL/ResetEtlOperation.cs
+++ b/src/Raven.Client/Documents/Operations/ETL/ResetEtlOperation.cs
@@ -34,6 +34,7 @@ namespace Raven.Client.Documents.Operations.ETL
             }
 
             public override bool IsReadRequest => false;
+            public override bool IsClusterCommand => true;
 
             public override HttpRequestMessage CreateRequest(JsonOperationContext ctx, ServerNode node, out string url)
             {

--- a/src/Raven.Client/Documents/Operations/ETL/UpdateEtlOperation.cs
+++ b/src/Raven.Client/Documents/Operations/ETL/UpdateEtlOperation.cs
@@ -39,6 +39,7 @@ namespace Raven.Client.Documents.Operations.ETL
             }
 
             public override bool IsReadRequest => false;
+            public override bool IsClusterCommand => true;
 
             public override HttpRequestMessage CreateRequest(JsonOperationContext ctx, ServerNode node, out string url)
             {

--- a/src/Raven.Client/Documents/Operations/Expiration/ConfigureExpirationOperation.cs
+++ b/src/Raven.Client/Documents/Operations/Expiration/ConfigureExpirationOperation.cs
@@ -32,6 +32,7 @@ namespace Raven.Client.Documents.Operations.Expiration
             }
 
             public override bool IsReadRequest => false;
+            public override bool IsClusterCommand => true;
 
             public override HttpRequestMessage CreateRequest(JsonOperationContext ctx, ServerNode node, out string url)
             {

--- a/src/Raven.Client/Documents/Operations/GetCollectionStatisticsOperation.cs
+++ b/src/Raven.Client/Documents/Operations/GetCollectionStatisticsOperation.cs
@@ -23,6 +23,7 @@ namespace Raven.Client.Documents.Operations
             }
 
             public override bool IsReadRequest => true;
+            public override bool IsClusterCommand => false;
 
             public override HttpRequestMessage CreateRequest(JsonOperationContext ctx, ServerNode node, out string url)
             {

--- a/src/Raven.Client/Documents/Operations/GetDetailedStatisticsOperation.cs
+++ b/src/Raven.Client/Documents/Operations/GetDetailedStatisticsOperation.cs
@@ -51,6 +51,7 @@ namespace Raven.Client.Documents.Operations
             }
 
             public override bool IsReadRequest => true;
+            public override bool IsClusterCommand => false;
         }
     }
 }

--- a/src/Raven.Client/Documents/Operations/GetOperationStateOperation.cs
+++ b/src/Raven.Client/Documents/Operations/GetOperationStateOperation.cs
@@ -22,6 +22,7 @@ namespace Raven.Client.Documents.Operations
         internal class GetOperationStateCommand : RavenCommand<OperationState>
         {
             public override bool IsReadRequest => true;
+            public override bool IsClusterCommand => false;
 
             private readonly DocumentConventions _conventions;
             private readonly long _id;

--- a/src/Raven.Client/Documents/Operations/GetStatisticsOperation.cs
+++ b/src/Raven.Client/Documents/Operations/GetStatisticsOperation.cs
@@ -51,6 +51,7 @@ namespace Raven.Client.Documents.Operations
             }
 
             public override bool IsReadRequest => true;
+            public override bool IsClusterCommand => false;
         }
     }
 }

--- a/src/Raven.Client/Documents/Operations/Identities/GetIdentitiesOperation.cs
+++ b/src/Raven.Client/Documents/Operations/Identities/GetIdentitiesOperation.cs
@@ -16,6 +16,7 @@ namespace Raven.Client.Documents.Operations.Identities
         private class GetIdentitiesCommand : RavenCommand<Dictionary<string, long>>
         {
             public override bool IsReadRequest => true;
+            public override bool IsClusterCommand => false;
 
             public override HttpRequestMessage CreateRequest(JsonOperationContext ctx, ServerNode node, out string url)
             {

--- a/src/Raven.Client/Documents/Operations/Indexes/DeleteIndexOperation.cs
+++ b/src/Raven.Client/Documents/Operations/Indexes/DeleteIndexOperation.cs
@@ -30,6 +30,8 @@ namespace Raven.Client.Documents.Operations.Indexes
                 _indexName = indexName ?? throw new ArgumentNullException(nameof(indexName));
             }
 
+            public override bool IsClusterCommand => true;
+
             public override HttpRequestMessage CreateRequest(JsonOperationContext ctx, ServerNode node, out string url)
             {
                 url = $"{node.Url}/databases/{node.Database}/indexes?name={Uri.EscapeDataString(_indexName)}";

--- a/src/Raven.Client/Documents/Operations/Indexes/DisableIndexOperation.cs
+++ b/src/Raven.Client/Documents/Operations/Indexes/DisableIndexOperation.cs
@@ -29,6 +29,8 @@ namespace Raven.Client.Documents.Operations.Indexes
                 _indexName = indexName ?? throw new ArgumentNullException(nameof(indexName));
             }
 
+            public override bool IsClusterCommand => false;
+
             public override HttpRequestMessage CreateRequest(JsonOperationContext ctx, ServerNode node, out string url)
             {
                 url = $"{node.Url}/databases/{node.Database}/admin/indexes/disable?name={Uri.EscapeDataString(_indexName)}";

--- a/src/Raven.Client/Documents/Operations/Indexes/EnableIndexOperation.cs
+++ b/src/Raven.Client/Documents/Operations/Indexes/EnableIndexOperation.cs
@@ -29,6 +29,8 @@ namespace Raven.Client.Documents.Operations.Indexes
                 _indexName = indexName ?? throw new ArgumentNullException(nameof(indexName));
             }
 
+            public override bool IsClusterCommand => false;
+
             public override HttpRequestMessage CreateRequest(JsonOperationContext ctx, ServerNode node, out string url)
             {
                 url = $"{node.Url}/databases/{node.Database}/admin/indexes/enable?name={Uri.EscapeDataString(_indexName)}";

--- a/src/Raven.Client/Documents/Operations/Indexes/GetIndexErrorsOperation.cs
+++ b/src/Raven.Client/Documents/Operations/Indexes/GetIndexErrorsOperation.cs
@@ -69,6 +69,7 @@ namespace Raven.Client.Documents.Operations.Indexes
             }
 
             public override bool IsReadRequest => true;
+            public override bool IsClusterCommand => false;
         }
     }
 }

--- a/src/Raven.Client/Documents/Operations/Indexes/GetIndexNamesOperation.cs
+++ b/src/Raven.Client/Documents/Operations/Indexes/GetIndexNamesOperation.cs
@@ -52,6 +52,7 @@ namespace Raven.Client.Documents.Operations.Indexes
             }
 
             public override bool IsReadRequest => true;
+            public override bool IsClusterCommand => false;
         }
     }
 }

--- a/src/Raven.Client/Documents/Operations/Indexes/GetIndexOperation.cs
+++ b/src/Raven.Client/Documents/Operations/Indexes/GetIndexOperation.cs
@@ -50,6 +50,7 @@ namespace Raven.Client.Documents.Operations.Indexes
             }
 
             public override bool IsReadRequest => true;
+            public override bool IsClusterCommand => false;
         }
     }
 }

--- a/src/Raven.Client/Documents/Operations/Indexes/GetIndexPerformanceStatisticsOperation.cs
+++ b/src/Raven.Client/Documents/Operations/Indexes/GetIndexPerformanceStatisticsOperation.cs
@@ -86,6 +86,7 @@ namespace Raven.Client.Documents.Operations.Indexes
             }
 
             public override bool IsReadRequest => true;
+            public override bool IsClusterCommand => false;
         }
     }
 }

--- a/src/Raven.Client/Documents/Operations/Indexes/GetIndexStatisticsOperation.cs
+++ b/src/Raven.Client/Documents/Operations/Indexes/GetIndexStatisticsOperation.cs
@@ -54,6 +54,7 @@ namespace Raven.Client.Documents.Operations.Indexes
             }
 
             public override bool IsReadRequest => true;
+            public override bool IsClusterCommand => false;
         }
     }
 }

--- a/src/Raven.Client/Documents/Operations/Indexes/GetIndexesOperation.cs
+++ b/src/Raven.Client/Documents/Operations/Indexes/GetIndexesOperation.cs
@@ -53,6 +53,7 @@ namespace Raven.Client.Documents.Operations.Indexes
             }
 
             public override bool IsReadRequest => true;
+            public override bool IsClusterCommand => false;
         }
     }
 }

--- a/src/Raven.Client/Documents/Operations/Indexes/GetIndexesStatisticsOperation.cs
+++ b/src/Raven.Client/Documents/Operations/Indexes/GetIndexesStatisticsOperation.cs
@@ -36,6 +36,7 @@ namespace Raven.Client.Documents.Operations.Indexes
             }
 
             public override bool IsReadRequest => true;
+            public override bool IsClusterCommand => false;
         }
     }
 }

--- a/src/Raven.Client/Documents/Operations/Indexes/GetIndexingStatusOperation.cs
+++ b/src/Raven.Client/Documents/Operations/Indexes/GetIndexingStatusOperation.cs
@@ -35,6 +35,7 @@ namespace Raven.Client.Documents.Operations.Indexes
             }
 
             public override bool IsReadRequest => true;
+            public override bool IsClusterCommand => false;
         }
     }
 }

--- a/src/Raven.Client/Documents/Operations/Indexes/GetTermsOperation.cs
+++ b/src/Raven.Client/Documents/Operations/Indexes/GetTermsOperation.cs
@@ -65,6 +65,7 @@ namespace Raven.Client.Documents.Operations.Indexes
             }
 
             public override bool IsReadRequest => true;
+            public override bool IsClusterCommand => false;
         }
     }
 }

--- a/src/Raven.Client/Documents/Operations/Indexes/IndexHasChangedOperation.cs
+++ b/src/Raven.Client/Documents/Operations/Indexes/IndexHasChangedOperation.cs
@@ -41,6 +41,7 @@ namespace Raven.Client.Documents.Operations.Indexes
             }
 
             public override bool IsReadRequest => false;
+            public override bool IsClusterCommand => false;
 
             public override HttpRequestMessage CreateRequest(JsonOperationContext ctx, ServerNode node, out string url)
             {

--- a/src/Raven.Client/Documents/Operations/Indexes/PutIndexesOperation.cs
+++ b/src/Raven.Client/Documents/Operations/Indexes/PutIndexesOperation.cs
@@ -82,6 +82,7 @@ namespace Raven.Client.Documents.Operations.Indexes
             }
 
             public override bool IsReadRequest => false;
+            public override bool IsClusterCommand => true;
         }
     }
 }

--- a/src/Raven.Client/Documents/Operations/Indexes/ResetIndexOperation.cs
+++ b/src/Raven.Client/Documents/Operations/Indexes/ResetIndexOperation.cs
@@ -30,6 +30,8 @@ namespace Raven.Client.Documents.Operations.Indexes
                 _indexName = indexName ?? throw new ArgumentNullException(nameof(indexName));
             }
 
+            public override bool IsClusterCommand => false;
+
             public override HttpRequestMessage CreateRequest(JsonOperationContext ctx, ServerNode node, out string url)
             {
                 url = $"{node.Url}/databases/{node.Database}/indexes?name={Uri.EscapeDataString(_indexName)}";

--- a/src/Raven.Client/Documents/Operations/Indexes/SetIndexesLockOperation.cs
+++ b/src/Raven.Client/Documents/Operations/Indexes/SetIndexesLockOperation.cs
@@ -71,6 +71,8 @@ namespace Raven.Client.Documents.Operations.Indexes
                 _parameters = EntityToBlittable.ConvertCommandToBlittable(parameters, context);
             }
 
+            public override bool IsClusterCommand => true;
+
             public override HttpRequestMessage CreateRequest(JsonOperationContext ctx, ServerNode node, out string url)
             {
                 url = $"{node.Url}/databases/{node.Database}/indexes/set-lock";

--- a/src/Raven.Client/Documents/Operations/Indexes/SetIndexesPriorityOperation.cs
+++ b/src/Raven.Client/Documents/Operations/Indexes/SetIndexesPriorityOperation.cs
@@ -57,6 +57,8 @@ namespace Raven.Client.Documents.Operations.Indexes
                 _parameters = EntityToBlittable.ConvertCommandToBlittable(parameters, context);
             }
 
+            public override bool IsClusterCommand => true;
+
             public override HttpRequestMessage CreateRequest(JsonOperationContext ctx, ServerNode node, out string url)
             {
                 url = $"{node.Url}/databases/{node.Database}/indexes/set-priority";

--- a/src/Raven.Client/Documents/Operations/Indexes/StartIndexOperation.cs
+++ b/src/Raven.Client/Documents/Operations/Indexes/StartIndexOperation.cs
@@ -29,6 +29,8 @@ namespace Raven.Client.Documents.Operations.Indexes
                 _indexName = indexName ?? throw new ArgumentNullException(nameof(indexName));
             }
 
+            public override bool IsClusterCommand => false;
+
             public override HttpRequestMessage CreateRequest(JsonOperationContext ctx, ServerNode node, out string url)
             {
                 url = $"{node.Url}/databases/{node.Database}/admin/indexes/start?name={Uri.EscapeDataString(_indexName)}";

--- a/src/Raven.Client/Documents/Operations/Indexes/StartIndexingOperation.cs
+++ b/src/Raven.Client/Documents/Operations/Indexes/StartIndexingOperation.cs
@@ -14,6 +14,8 @@ namespace Raven.Client.Documents.Operations.Indexes
 
         private class StartIndexingCommand : RavenCommand
         {
+            public override bool IsClusterCommand => false;
+
             public override HttpRequestMessage CreateRequest(JsonOperationContext ctx, ServerNode node, out string url)
             {
                 url = $"{node.Url}/databases/{node.Database}/admin/indexes/start";

--- a/src/Raven.Client/Documents/Operations/Indexes/StopIndexOperation.cs
+++ b/src/Raven.Client/Documents/Operations/Indexes/StopIndexOperation.cs
@@ -29,6 +29,8 @@ namespace Raven.Client.Documents.Operations.Indexes
                 _indexName = indexName ?? throw new ArgumentNullException(nameof(indexName));
             }
 
+            public override bool IsClusterCommand => false;
+
             public override HttpRequestMessage CreateRequest(JsonOperationContext ctx, ServerNode node, out string url)
             {
                 url = $"{node.Url}/databases/{node.Database}/admin/indexes/stop?name={Uri.EscapeDataString(_indexName)}";

--- a/src/Raven.Client/Documents/Operations/Indexes/StopIndexingOperation.cs
+++ b/src/Raven.Client/Documents/Operations/Indexes/StopIndexingOperation.cs
@@ -14,6 +14,8 @@ namespace Raven.Client.Documents.Operations.Indexes
 
         private class StopIndexingCommand : RavenCommand
         {
+            public override bool IsClusterCommand => false;
+
             public override HttpRequestMessage CreateRequest(JsonOperationContext ctx, ServerNode node, out string url)
             {
                 url = $"{node.Url}/databases/{node.Database}/admin/indexes/stop";

--- a/src/Raven.Client/Documents/Operations/OngoingTasks/DeleteOngoingTaskOperation.cs
+++ b/src/Raven.Client/Documents/Operations/OngoingTasks/DeleteOngoingTaskOperation.cs
@@ -54,6 +54,7 @@ namespace Raven.Client.Documents.Operations.OngoingTasks
             }
 
             public override bool IsReadRequest => false;
+            public override bool IsClusterCommand => true;
         }
     }
 }

--- a/src/Raven.Client/Documents/Operations/OngoingTasks/GetOngoingTaskInfoOperation.cs
+++ b/src/Raven.Client/Documents/Operations/OngoingTasks/GetOngoingTaskInfoOperation.cs
@@ -94,6 +94,7 @@ namespace Raven.Client.Documents.Operations.OngoingTasks
             }
 
             public override bool IsReadRequest => false;
+            public override bool IsClusterCommand => false;
         }
     }
 }

--- a/src/Raven.Client/Documents/Operations/OngoingTasks/ToggleOngoingTaskStateOperation.cs
+++ b/src/Raven.Client/Documents/Operations/OngoingTasks/ToggleOngoingTaskStateOperation.cs
@@ -56,6 +56,7 @@ namespace Raven.Client.Documents.Operations.OngoingTasks
             }
 
             public override bool IsReadRequest => false;
+            public override bool IsClusterCommand => true;
         }
     }
 }

--- a/src/Raven.Client/Documents/Operations/PatchByQueryOperation.cs
+++ b/src/Raven.Client/Documents/Operations/PatchByQueryOperation.cs
@@ -102,6 +102,7 @@ namespace Raven.Client.Documents.Operations
             }
 
             public override bool IsReadRequest => false;
+            public override bool IsClusterCommand => false;
         }
     }
 }

--- a/src/Raven.Client/Documents/Operations/PatchOperation.cs
+++ b/src/Raven.Client/Documents/Operations/PatchOperation.cs
@@ -93,6 +93,7 @@ namespace Raven.Client.Documents.Operations
             }
 
             public override bool IsReadRequest => false;
+            public override bool IsClusterCommand => false;
 
             public override HttpRequestMessage CreateRequest(JsonOperationContext ctx, ServerNode node, out string url)
             {

--- a/src/Raven.Client/Documents/Operations/Replication/GetReplicationPerformanceStatisticsOperation.cs
+++ b/src/Raven.Client/Documents/Operations/Replication/GetReplicationPerformanceStatisticsOperation.cs
@@ -25,6 +25,7 @@ namespace Raven.Client.Documents.Operations.Replication
             }
 
             public override bool IsReadRequest => false;
+            public override bool IsClusterCommand => false;
 
             public override HttpRequestMessage CreateRequest(JsonOperationContext ctx, ServerNode node, out string url)
             {

--- a/src/Raven.Client/Documents/Operations/Replication/UpdateExternalReplicationOperation.cs
+++ b/src/Raven.Client/Documents/Operations/Replication/UpdateExternalReplicationOperation.cs
@@ -62,6 +62,7 @@ namespace Raven.Client.Documents.Operations.Replication
             }
 
             public override bool IsReadRequest => false;
+            public override bool IsClusterCommand => true;
         }
     }
 

--- a/src/Raven.Client/Documents/Operations/Revisions/ConfigureRevisionsOperation.cs
+++ b/src/Raven.Client/Documents/Operations/Revisions/ConfigureRevisionsOperation.cs
@@ -32,6 +32,7 @@ namespace Raven.Client.Documents.Operations.Revisions
             }
 
             public override bool IsReadRequest => false;
+            public override bool IsClusterCommand => true;
 
             public override HttpRequestMessage CreateRequest(JsonOperationContext ctx, ServerNode node, out string url)
             {

--- a/src/Raven.Client/Documents/Operations/TransactionsRecording/ReplayTransactionsRecordingOperation.cs
+++ b/src/Raven.Client/Documents/Operations/TransactionsRecording/ReplayTransactionsRecordingOperation.cs
@@ -64,6 +64,7 @@ namespace Raven.Client.Documents.Operations.TransactionsRecording
             }
 
             public override bool IsReadRequest => false;
+            public override bool IsClusterCommand => false;
         }
     }
 }

--- a/src/Raven.Client/Documents/Operations/TransactionsRecording/StartTransactionsRecordingOperation.cs
+++ b/src/Raven.Client/Documents/Operations/TransactionsRecording/StartTransactionsRecordingOperation.cs
@@ -31,6 +31,8 @@ namespace Raven.Client.Documents.Operations.TransactionsRecording
                 _filePath = filePath;
             }
 
+            public override bool IsClusterCommand => false;
+
             public override HttpRequestMessage CreateRequest(JsonOperationContext ctx, ServerNode node, out string url)
             {
                 url = $"{node.Url}/databases/{node.Database}/admin/transactions/start-recording";

--- a/src/Raven.Client/Documents/Operations/TransactionsRecording/StopTransactionsRecordingOperation.cs
+++ b/src/Raven.Client/Documents/Operations/TransactionsRecording/StopTransactionsRecordingOperation.cs
@@ -14,6 +14,8 @@ namespace Raven.Client.Documents.Operations.TransactionsRecording
 
         private class StopTransactionsRecordingCommand : RavenCommand
         {
+            public override bool IsClusterCommand => false;
+
             public override HttpRequestMessage CreateRequest(JsonOperationContext ctx, ServerNode node, out string url)
             {
                 url = $"{node.Url}/databases/{node.Database}/admin/transactions/stop-recording";

--- a/src/Raven.Client/Documents/Smuggler/DatabaseSmuggler.cs
+++ b/src/Raven.Client/Documents/Smuggler/DatabaseSmuggler.cs
@@ -261,6 +261,8 @@ namespace Raven.Client.Documents.Smuggler
                 _tcs.TrySetCanceled();
             }
 
+            public override bool IsClusterCommand => false;
+
             public override HttpRequestMessage CreateRequest(JsonOperationContext ctx, ServerNode node, out string url)
             {
                 url = $"{node.Url}/databases/{node.Database}/smuggler/export?operationId={_operationId}";
@@ -295,6 +297,7 @@ namespace Raven.Client.Documents.Smuggler
             private readonly TaskCompletionSource<object> _tcs;
 
             public override bool IsReadRequest => false;
+            public override bool IsClusterCommand => false;
 
             public ImportCommand(DocumentConventions conventions, JsonOperationContext context, DatabaseSmugglerImportOptions options, Stream stream, long operationId, TaskCompletionSource<object> tcs)
             {

--- a/src/Raven.Client/Http/RavenCommand.cs
+++ b/src/Raven.Client/Http/RavenCommand.cs
@@ -37,6 +37,9 @@ namespace Raven.Client.Http
 
         public TResult Result;
         public abstract bool IsReadRequest { get; }
+        public abstract bool IsClusterCommand { get; }
+
+        public string Guid;
 
         public HttpStatusCode StatusCode;
 

--- a/src/Raven.Client/Http/RequestExecutor.cs
+++ b/src/Raven.Client/Http/RequestExecutor.cs
@@ -988,8 +988,19 @@ namespace Raven.Client.Http
 
             request.RequestUri = new Uri(url);
 
-            if (!request.Headers.Contains(Constants.Headers.ClientVersion))
+            if (request.Headers.Contains(Constants.Headers.ClientVersion) == false)
                 request.Headers.Add(Constants.Headers.ClientVersion, ClientVersion);
+
+            if (command.IsClusterCommand)
+            {
+                if (command.Guid == null)
+                {
+                    command.Guid = Guid.NewGuid().ToString();
+                }
+
+                if (request.Headers.Contains(Constants.Headers.RaftCommandGuid) == false)
+                    request.Headers.Add(Constants.Headers.RaftCommandGuid, command.Guid);
+            }
 
             return request;
         }

--- a/src/Raven.Client/ServerWide/Commands/CloseTcpConnectionCommand.cs
+++ b/src/Raven.Client/ServerWide/Commands/CloseTcpConnectionCommand.cs
@@ -13,7 +13,9 @@ namespace Raven.Client.ServerWide.Commands
             _id = id;
         }
 
-        
+
+        public override bool IsClusterCommand => false;
+
         public override HttpRequestMessage CreateRequest(JsonOperationContext ctx, ServerNode node, out string url)
         {
             url = $"{node.Url}/databases/{node.Database}/tcp?id={_id}";

--- a/src/Raven.Client/ServerWide/Commands/Cluster/AddClusterNodeCommand.cs
+++ b/src/Raven.Client/ServerWide/Commands/Cluster/AddClusterNodeCommand.cs
@@ -12,8 +12,9 @@ namespace Raven.Client.ServerWide.Commands.Cluster
         private readonly bool _watcher;
 
         public override bool IsReadRequest => false;
+        public override bool IsClusterCommand => true;
 
-        public AddClusterNodeCommand(string url, string tag, bool watcher)
+        public AddClusterNodeCommand(string url, string tag = null , bool watcher = false)
         {
             _url = url;
             _tag = tag;

--- a/src/Raven.Client/ServerWide/Commands/Cluster/DemoteClusterNodeCommand.cs
+++ b/src/Raven.Client/ServerWide/Commands/Cluster/DemoteClusterNodeCommand.cs
@@ -13,6 +13,7 @@ namespace Raven.Client.ServerWide.Commands.Cluster
         private readonly string _node;
 
         public override bool IsReadRequest => false;
+        public override bool IsClusterCommand => true;
 
         public DemoteClusterNodeCommand(string node)
         {

--- a/src/Raven.Client/ServerWide/Commands/Cluster/PromoteClusterNodeCommand.cs
+++ b/src/Raven.Client/ServerWide/Commands/Cluster/PromoteClusterNodeCommand.cs
@@ -13,6 +13,7 @@ namespace Raven.Client.ServerWide.Commands.Cluster
         private readonly string _node;
 
         public override bool IsReadRequest => false;
+        public override bool IsClusterCommand => true;
 
         public PromoteClusterNodeCommand(string node)
         {

--- a/src/Raven.Client/ServerWide/Commands/Cluster/RemoveClusterNodeCommand.cs
+++ b/src/Raven.Client/ServerWide/Commands/Cluster/RemoveClusterNodeCommand.cs
@@ -13,6 +13,7 @@ namespace Raven.Client.ServerWide.Commands.Cluster
         private readonly string _node;
 
         public override bool IsReadRequest => false;
+        public override bool IsClusterCommand => true;
 
         public RemoveClusterNodeCommand(string node)
         {

--- a/src/Raven.Client/ServerWide/Commands/GetClusterTopologyCommand.cs
+++ b/src/Raven.Client/ServerWide/Commands/GetClusterTopologyCommand.cs
@@ -39,5 +39,6 @@ namespace Raven.Client.ServerWide.Commands
         }
 
         public override bool IsReadRequest => true;
+        public override bool IsClusterCommand => false;
     }
 }

--- a/src/Raven.Client/ServerWide/Commands/GetDatabaseTopologyCommand.cs
+++ b/src/Raven.Client/ServerWide/Commands/GetDatabaseTopologyCommand.cs
@@ -49,5 +49,6 @@ namespace Raven.Client.ServerWide.Commands
         }
 
         public override bool IsReadRequest => true;
+        public override bool IsClusterCommand => false;
     }
 }

--- a/src/Raven.Client/ServerWide/Commands/GetNodeInfoCommand.cs
+++ b/src/Raven.Client/ServerWide/Commands/GetNodeInfoCommand.cs
@@ -44,5 +44,6 @@ namespace Raven.Client.ServerWide.Commands
         }
 
         public override bool IsReadRequest => true;
+        public override bool IsClusterCommand => false;
     }
 }

--- a/src/Raven.Client/ServerWide/Commands/GetRawStreamResultCommand.cs
+++ b/src/Raven.Client/ServerWide/Commands/GetRawStreamResultCommand.cs
@@ -26,6 +26,8 @@ namespace Raven.Client.ServerWide.Commands
         }
 
         public override bool IsReadRequest => true;
+        public override bool IsClusterCommand => false;
+
         public override HttpRequestMessage CreateRequest(JsonOperationContext ctx, ServerNode node, out string url)
         {
             url = _commandUrl.StartsWith("/") ? 

--- a/src/Raven.Client/ServerWide/Commands/GetTcpInfoCommand.cs
+++ b/src/Raven.Client/ServerWide/Commands/GetTcpInfoCommand.cs
@@ -50,6 +50,7 @@ namespace Raven.Client.ServerWide.Commands
 
         public ServerNode RequestedNode { get; private set; }
 
-        public override bool IsReadRequest => true;   
+        public override bool IsReadRequest => true;
+        public override bool IsClusterCommand => false;
     }
 }

--- a/src/Raven.Client/ServerWide/Commands/IsDatabaseLoadedCommand.cs
+++ b/src/Raven.Client/ServerWide/Commands/IsDatabaseLoadedCommand.cs
@@ -14,6 +14,7 @@ namespace Raven.Client.ServerWide.Commands
         }
 
         public override bool IsReadRequest => true;
+        public override bool IsClusterCommand => false;
 
         public override HttpRequestMessage CreateRequest(JsonOperationContext ctx, ServerNode node, out string url)
         {

--- a/src/Raven.Client/ServerWide/Commands/PutSecretKeyCommand.cs
+++ b/src/Raven.Client/ServerWide/Commands/PutSecretKeyCommand.cs
@@ -44,5 +44,6 @@ namespace Raven.Client.ServerWide.Commands
         }
         
         public override bool IsReadRequest => false;
+        public override bool IsClusterCommand => false;
     }
 }

--- a/src/Raven.Client/ServerWide/Commands/WaitForRaftIndexCommand.cs
+++ b/src/Raven.Client/ServerWide/Commands/WaitForRaftIndexCommand.cs
@@ -30,5 +30,6 @@ namespace Raven.Client.ServerWide.Commands
         }
 
         public override bool IsReadRequest => true;
+        public override bool IsClusterCommand => false;
     }
 }

--- a/src/Raven.Client/ServerWide/Operations/AddDatabaseNodeOperation.cs
+++ b/src/Raven.Client/ServerWide/Operations/AddDatabaseNodeOperation.cs
@@ -63,6 +63,7 @@ namespace Raven.Client.ServerWide.Operations
             }
 
             public override bool IsReadRequest => false;
+            public override bool IsClusterCommand => true;
         }
     }
 }

--- a/src/Raven.Client/ServerWide/Operations/Certificates/CreateClientCertificateOperation.cs
+++ b/src/Raven.Client/ServerWide/Operations/Certificates/CreateClientCertificateOperation.cs
@@ -46,6 +46,7 @@ namespace Raven.Client.ServerWide.Operations.Certificates
             }
 
             public override bool IsReadRequest => true;
+            public override bool IsClusterCommand => false;
 
             public override HttpRequestMessage CreateRequest(JsonOperationContext ctx, ServerNode node, out string url)
             {

--- a/src/Raven.Client/ServerWide/Operations/Certificates/DeleteCertificateOperation.cs
+++ b/src/Raven.Client/ServerWide/Operations/Certificates/DeleteCertificateOperation.cs
@@ -29,6 +29,8 @@ namespace Raven.Client.ServerWide.Operations.Certificates
                 _thumbprint = thumbprint ?? throw new ArgumentNullException(nameof(thumbprint));
             }
 
+            public override bool IsClusterCommand => true;
+
             public override HttpRequestMessage CreateRequest(JsonOperationContext ctx, ServerNode node, out string url)
             {
                 url = $"{node.Url}/admin/certificates?thumbprint=" + Uri.EscapeDataString(_thumbprint);

--- a/src/Raven.Client/ServerWide/Operations/Certificates/GetCertificateOperation.cs
+++ b/src/Raven.Client/ServerWide/Operations/Certificates/GetCertificateOperation.cs
@@ -31,6 +31,7 @@ namespace Raven.Client.ServerWide.Operations.Certificates
             }
 
             public override bool IsReadRequest => false;
+            public override bool IsClusterCommand => false;
 
             public override HttpRequestMessage CreateRequest(JsonOperationContext ctx, ServerNode node, out string url)
             {

--- a/src/Raven.Client/ServerWide/Operations/Certificates/GetCertificatesOperation.cs
+++ b/src/Raven.Client/ServerWide/Operations/Certificates/GetCertificatesOperation.cs
@@ -34,6 +34,7 @@ namespace Raven.Client.ServerWide.Operations.Certificates
             }
 
             public override bool IsReadRequest => false;
+            public override bool IsClusterCommand => false;
 
             public override HttpRequestMessage CreateRequest(JsonOperationContext ctx, ServerNode node, out string url)
             {

--- a/src/Raven.Client/ServerWide/Operations/Certificates/PutClientCertificateOperation.cs
+++ b/src/Raven.Client/ServerWide/Operations/Certificates/PutClientCertificateOperation.cs
@@ -45,6 +45,7 @@ namespace Raven.Client.ServerWide.Operations.Certificates
             }
 
             public override bool IsReadRequest => false;
+            public override bool IsClusterCommand => true;
 
             public override HttpRequestMessage CreateRequest(JsonOperationContext ctx, ServerNode node, out string url)
             {

--- a/src/Raven.Client/ServerWide/Operations/Certificates/ReplaceClusterCertificateOperation.cs
+++ b/src/Raven.Client/ServerWide/Operations/Certificates/ReplaceClusterCertificateOperation.cs
@@ -43,6 +43,7 @@ namespace Raven.Client.ServerWide.Operations.Certificates
             }
 
             public override bool IsReadRequest => false;
+            public override bool IsClusterCommand => true;
 
             public override HttpRequestMessage CreateRequest(JsonOperationContext ctx, ServerNode node, out string url)
             {

--- a/src/Raven.Client/ServerWide/Operations/CompactDatabaseOperation.cs
+++ b/src/Raven.Client/ServerWide/Operations/CompactDatabaseOperation.cs
@@ -66,6 +66,7 @@ namespace Raven.Client.ServerWide.Operations
             }
 
             public override bool IsReadRequest => false;
+            public override bool IsClusterCommand => false;
         }
     }
 }

--- a/src/Raven.Client/ServerWide/Operations/Configuration/GetServerWideClientConfigurationOperation.cs
+++ b/src/Raven.Client/ServerWide/Operations/Configuration/GetServerWideClientConfigurationOperation.cs
@@ -17,6 +17,7 @@ namespace Raven.Client.ServerWide.Operations.Configuration
         private class GetServerWideClientConfigurationCommand : RavenCommand<ClientConfiguration>
         {
             public override bool IsReadRequest => false;
+            public override bool IsClusterCommand => false;
 
             public override HttpRequestMessage CreateRequest(JsonOperationContext ctx, ServerNode node, out string url)
             {

--- a/src/Raven.Client/ServerWide/Operations/Configuration/PutServerWideClientConfigurationOperation.cs
+++ b/src/Raven.Client/ServerWide/Operations/Configuration/PutServerWideClientConfigurationOperation.cs
@@ -39,6 +39,8 @@ namespace Raven.Client.ServerWide.Operations.Configuration
                 _configuration = EntityToBlittable.ConvertCommandToBlittable(configuration,context);
             }
 
+            public override bool IsClusterCommand => true;
+
             public override HttpRequestMessage CreateRequest(JsonOperationContext ctx, ServerNode node, out string url)
             {
                 url = $"{node.Url}/admin/configuration/client";

--- a/src/Raven.Client/ServerWide/Operations/CreateDatabaseOperation.cs
+++ b/src/Raven.Client/ServerWide/Operations/CreateDatabaseOperation.cs
@@ -73,6 +73,7 @@ namespace Raven.Client.ServerWide.Operations
             }
 
             public override bool IsReadRequest => false;
+            public override bool IsClusterCommand => true;
         }
     }
 }

--- a/src/Raven.Client/ServerWide/Operations/DeleteDatabasesOperation.cs
+++ b/src/Raven.Client/ServerWide/Operations/DeleteDatabasesOperation.cs
@@ -83,6 +83,7 @@ namespace Raven.Client.ServerWide.Operations
             }
 
             public override bool IsReadRequest => false;
+            public override bool IsClusterCommand => true;
         }
 
         public class Parameters

--- a/src/Raven.Client/ServerWide/Operations/GetBuildNumberOperation.cs
+++ b/src/Raven.Client/ServerWide/Operations/GetBuildNumberOperation.cs
@@ -16,6 +16,7 @@ namespace Raven.Client.ServerWide.Operations
         private class GetBuildNumberCommand : RavenCommand<BuildNumber>
         {
             public override bool IsReadRequest => true;
+            public override bool IsClusterCommand => false;
 
             public override HttpRequestMessage CreateRequest(JsonOperationContext ctx, ServerNode node, out string url)
             {

--- a/src/Raven.Client/ServerWide/Operations/GetDatabaseNamesOperation.cs
+++ b/src/Raven.Client/ServerWide/Operations/GetDatabaseNamesOperation.cs
@@ -33,6 +33,7 @@ namespace Raven.Client.ServerWide.Operations
             }
 
             public override bool IsReadRequest => true;
+            public override bool IsClusterCommand => false;
 
             public override HttpRequestMessage CreateRequest(JsonOperationContext ctx, ServerNode node, out string url)
             {

--- a/src/Raven.Client/ServerWide/Operations/GetDatabaseRecordOperation.cs
+++ b/src/Raven.Client/ServerWide/Operations/GetDatabaseRecordOperation.cs
@@ -26,6 +26,7 @@ namespace Raven.Client.ServerWide.Operations
             private readonly string _database;
 
             public override bool IsReadRequest => false;
+            public override bool IsClusterCommand => false;
 
             public GetDatabaseRecordCommand(DocumentConventions conventions, string database)
             {

--- a/src/Raven.Client/ServerWide/Operations/GetServerWideOperationStateOperation.cs
+++ b/src/Raven.Client/ServerWide/Operations/GetServerWideOperationStateOperation.cs
@@ -23,6 +23,7 @@ namespace Raven.Client.ServerWide.Operations
         internal class GetServerWideOperationStateCommand : RavenCommand<OperationState>
         {
             public override bool IsReadRequest => true;
+            public override bool IsClusterCommand => false;
 
             private readonly DocumentConventions _conventions;
             private readonly long _id;

--- a/src/Raven.Client/ServerWide/Operations/Logs/GetLogsConfigurationOperation.cs
+++ b/src/Raven.Client/ServerWide/Operations/Logs/GetLogsConfigurationOperation.cs
@@ -17,6 +17,7 @@ namespace Raven.Client.ServerWide.Operations.Logs
         private class GetLogsConfigurationCommand : RavenCommand<GetLogsConfigurationResult>
         {
             public override bool IsReadRequest => true;
+            public override bool IsClusterCommand => false;
 
             public override HttpRequestMessage CreateRequest(JsonOperationContext ctx, ServerNode node, out string url)
             {

--- a/src/Raven.Client/ServerWide/Operations/Logs/SetLogsConfigurationOperation.cs
+++ b/src/Raven.Client/ServerWide/Operations/Logs/SetLogsConfigurationOperation.cs
@@ -37,6 +37,8 @@ namespace Raven.Client.ServerWide.Operations.Logs
                 _parameters = parameters ?? throw new ArgumentNullException(nameof(parameters));
             }
 
+            public override bool IsClusterCommand => false;
+
             public override HttpRequestMessage CreateRequest(JsonOperationContext ctx, ServerNode node, out string url)
             {
                 url = $"{node.Url}/admin/logs/configuration";

--- a/src/Raven.Client/ServerWide/Operations/Migration/OfflineMigrationOperation.cs
+++ b/src/Raven.Client/ServerWide/Operations/Migration/OfflineMigrationOperation.cs
@@ -35,6 +35,7 @@ namespace Raven.Client.ServerWide.Operations.Migration
             }
 
             public override bool IsReadRequest => false;
+            public override bool IsClusterCommand => false;
 
             public override HttpRequestMessage CreateRequest(JsonOperationContext ctx, ServerNode node, out string url)
             {

--- a/src/Raven.Client/ServerWide/Operations/ModifyConflictSolverOperation.cs
+++ b/src/Raven.Client/ServerWide/Operations/ModifyConflictSolverOperation.cs
@@ -75,6 +75,7 @@ namespace Raven.Client.ServerWide.Operations
             }
 
             public override bool IsReadRequest => false;
+            public override bool IsClusterCommand => true;
         }
     }
 }

--- a/src/Raven.Client/ServerWide/Operations/PromoteDatabaseNodeOperation.cs
+++ b/src/Raven.Client/ServerWide/Operations/PromoteDatabaseNodeOperation.cs
@@ -62,6 +62,7 @@ namespace Raven.Client.ServerWide.Operations
             }
 
             public override bool IsReadRequest => false;
+            public override bool IsClusterCommand => true;
         }
     }
 }

--- a/src/Raven.Client/ServerWide/Operations/ReorderDatabaseMembersOperation.cs
+++ b/src/Raven.Client/ServerWide/Operations/ReorderDatabaseMembersOperation.cs
@@ -68,6 +68,7 @@ namespace Raven.Client.ServerWide.Operations
             }
 
             public override bool IsReadRequest => false;
+            public override bool IsClusterCommand => true;
         }
 
     }

--- a/src/Raven.Client/ServerWide/Operations/RestoreBackupOperation.cs
+++ b/src/Raven.Client/ServerWide/Operations/RestoreBackupOperation.cs
@@ -27,6 +27,7 @@ namespace Raven.Client.ServerWide.Operations
         private class RestoreBackupCommand : RavenCommand<OperationIdResult>
         {
             public override bool IsReadRequest => false;
+            public override bool IsClusterCommand => false;
             private readonly DocumentConventions _conventions;
             private readonly RestoreBackupConfiguration _restoreConfiguration;
 

--- a/src/Raven.Client/ServerWide/Operations/ToggleDatabasesStateOperation.cs
+++ b/src/Raven.Client/ServerWide/Operations/ToggleDatabasesStateOperation.cs
@@ -95,6 +95,7 @@ namespace Raven.Client.ServerWide.Operations
             }
 
             public override bool IsReadRequest => false;
+            public override bool IsClusterCommand => true;
         }
 
         public class Parameters

--- a/src/Raven.Server/Documents/DatabaseRequestHandler.cs
+++ b/src/Raven.Server/Documents/DatabaseRequestHandler.cs
@@ -45,8 +45,9 @@ namespace Raven.Server.Documents
         protected delegate void RefAction(string databaseName, ref BlittableJsonReaderObject configuration, JsonOperationContext context);
 
         protected async Task DatabaseConfigurations(Func<TransactionOperationContext, string,
-           BlittableJsonReaderObject, Task<(long, object)>> setupConfigurationFunc,
+           BlittableJsonReaderObject, string, Task<(long, object)>> setupConfigurationFunc,
            string debug,
+           string guid,
            RefAction beforeSetupConfiguration = null,
            Action<DynamicJsonValue, BlittableJsonReaderObject, long> fillJson = null,
            HttpStatusCode statusCode = HttpStatusCode.OK)
@@ -64,7 +65,7 @@ namespace Raven.Server.Documents
                 var configurationJson = await context.ReadForMemoryAsync(RequestBodyStream(), debug);
                 beforeSetupConfiguration?.Invoke(Database.Name, ref configurationJson, context);
 
-                var (index, _) = await setupConfigurationFunc(context, Database.Name, configurationJson);
+                var (index, _) = await setupConfigurationFunc(context, Database.Name, configurationJson, guid);
                 DatabaseRecord dbRecord;
                 using (context.OpenReadTransaction())
                 {

--- a/src/Raven.Server/Documents/DatabasesLandlord.cs
+++ b/src/Raven.Server/Documents/DatabasesLandlord.cs
@@ -279,7 +279,7 @@ namespace Raven.Server.Documents
 
         private void NotifyLeaderAboutRemoval(string dbName)
         {
-            var cmd = new RemoveNodeFromDatabaseCommand(dbName)
+            var cmd = new RemoveNodeFromDatabaseCommand(dbName, Guid.NewGuid().ToString())
             {
                 NodeTag = _serverStore.NodeTag
             };

--- a/src/Raven.Server/Documents/ETL/EtlProcess.cs
+++ b/src/Raven.Server/Documents/ETL/EtlProcess.cs
@@ -628,7 +628,7 @@ namespace Raven.Server.Documents.ETL
                     {
                         var command = new UpdateEtlProcessStateCommand(Database.Name, Configuration.Name, Transformation.Name, Statistics.LastProcessedEtag,
                             ChangeVectorUtils.MergeVectors(Statistics.LastChangeVector, state.ChangeVector), _serverStore.NodeTag,
-                            _serverStore.LicenseManager.HasHighlyAvailableTasks());
+                            _serverStore.LicenseManager.HasHighlyAvailableTasks(), Guid.NewGuid().ToString());
 
                         var sendToLeaderTask = _serverStore.SendToLeaderAsync(command);
                         sendToLeaderTask.Wait(CancellationToken);

--- a/src/Raven.Server/Documents/Handlers/Admin/AdminConfigurationHandler.cs
+++ b/src/Raven.Server/Documents/Handlers/Admin/AdminConfigurationHandler.cs
@@ -24,7 +24,7 @@ namespace Raven.Server.Documents.Handlers.Admin
                 await UpdateDatabaseRecord(context, record =>
                 {
                     record.Studio = studioConfiguration;
-                });
+                }, GetRaftGuidFromHeaders());
             }
 
             NoContentStatus();
@@ -45,14 +45,14 @@ namespace Raven.Server.Documents.Handlers.Admin
                 {
                     record.Client = clientConfiguration;
                     record.Client.Etag++; // we don't care _what_ the value is, just that it is changing
-                });
+                }, GetRaftGuidFromHeaders());
             }
 
             NoContentStatus();
             HttpContext.Response.StatusCode = (int)HttpStatusCode.Created;
         }
 
-        private async Task UpdateDatabaseRecord(TransactionOperationContext context, Action<DatabaseRecord> action)
+        private async Task UpdateDatabaseRecord(TransactionOperationContext context, Action<DatabaseRecord> action, string guid)
         {
             if (context == null)
                 throw new ArgumentNullException(nameof(context));
@@ -65,7 +65,7 @@ namespace Raven.Server.Documents.Handlers.Admin
 
                 action(record);
 
-                var result = await ServerStore.WriteDatabaseRecordAsync(Database.Name, record, index);
+                var result = await ServerStore.WriteDatabaseRecordAsync(Database.Name, record, index, guid);
                 await Database.RachisLogIndexNotifications.WaitForIndexNotification(result.Index, ServerStore.Engine.OperationTimeout);
             }
         }

--- a/src/Raven.Server/Documents/Handlers/Admin/AdminIndexHandler.cs
+++ b/src/Raven.Server/Documents/Handlers/Admin/AdminIndexHandler.cs
@@ -68,7 +68,7 @@ namespace Raven.Server.Documents.Handlers.Admin
                             $"Index name must not start with '{Constants.Documents.Indexing.SideBySideIndexNamePrefix}'. Provided index name: '{indexDefinition.Name}'");
                     }
 
-                    var index = await Database.IndexStore.CreateIndex(indexDefinition, GetStringQueryString("guid", required: false));
+                    var index = await Database.IndexStore.CreateIndex(indexDefinition, Guid.NewGuid().ToString());
                     createdIndexes.Add(index.Name);
                 }
                 if (TrafficWatchManager.HasRegisteredClients)

--- a/src/Raven.Server/Documents/Handlers/Admin/AdminIndexHandler.cs
+++ b/src/Raven.Server/Documents/Handlers/Admin/AdminIndexHandler.cs
@@ -68,7 +68,7 @@ namespace Raven.Server.Documents.Handlers.Admin
                             $"Index name must not start with '{Constants.Documents.Indexing.SideBySideIndexNamePrefix}'. Provided index name: '{indexDefinition.Name}'");
                     }
 
-                    var index = await Database.IndexStore.CreateIndex(indexDefinition);
+                    var index = await Database.IndexStore.CreateIndex(indexDefinition, GetStringQueryString("guid", required: false));
                     createdIndexes.Add(index.Name);
                 }
                 if (TrafficWatchManager.HasRegisteredClients)

--- a/src/Raven.Server/Documents/Handlers/BatchHandler.cs
+++ b/src/Raven.Server/Documents/Handlers/BatchHandler.cs
@@ -188,8 +188,10 @@ namespace Raven.Server.Documents.Handlers
 
         private async Task HandleClusterTransaction(DocumentsOperationContext context, MergedBatchCommand command, ClusterTransactionCommand.ClusterTransactionOptions options)
         {
+            var guid = GetStringQueryString("guid", required: false);
+
             var record = ServerStore.LoadDatabaseRecord(Database.Name, out _);
-            var clusterTransactionCommand = new ClusterTransactionCommand(Database.Name, record.Topology.DatabaseTopologyIdBase64, command.ParsedCommands, options);
+            var clusterTransactionCommand = new ClusterTransactionCommand(Database.Name, record.Topology.DatabaseTopologyIdBase64, command.ParsedCommands, options, guid);
             var result = await ServerStore.SendToLeaderAsync(clusterTransactionCommand);
 
             if (result.Result is List<string> errors)

--- a/src/Raven.Server/Documents/Handlers/BatchHandler.cs
+++ b/src/Raven.Server/Documents/Handlers/BatchHandler.cs
@@ -188,7 +188,7 @@ namespace Raven.Server.Documents.Handlers
 
         private async Task HandleClusterTransaction(DocumentsOperationContext context, MergedBatchCommand command, ClusterTransactionCommand.ClusterTransactionOptions options)
         {
-            var guid = GetStringQueryString("guid", required: false);
+            var guid = GetRaftGuidFromHeaders();
 
             var record = ServerStore.LoadDatabaseRecord(Database.Name, out _);
             var clusterTransactionCommand = new ClusterTransactionCommand(Database.Name, record.Topology.DatabaseTopologyIdBase64, command.ParsedCommands, options, guid);

--- a/src/Raven.Server/Documents/Handlers/BatchRequestParser.cs
+++ b/src/Raven.Server/Documents/Handlers/BatchRequestParser.cs
@@ -241,7 +241,7 @@ namespace Raven.Server.Documents.Handlers
         private static async Task GetIdentitiesValues(JsonOperationContext ctx, DocumentDatabase database, ServerStore serverStore,
             List<string> identities, List<int> positionInListToCommandIndex, CommandData[] cmds)
         {
-            var newIds = await serverStore.GenerateClusterIdentitiesBatchAsync(database.Name, identities);
+            var newIds = await serverStore.GenerateClusterIdentitiesBatchAsync(database.Name, identities, Guid.NewGuid().ToString());
             Debug.Assert(newIds.Count == identities.Count);
 
             var emptyChangeVector = ctx.GetLazyString("");

--- a/src/Raven.Server/Documents/Handlers/DocumentHandler.cs
+++ b/src/Raven.Server/Documents/Handlers/DocumentHandler.cs
@@ -328,7 +328,7 @@ namespace Raven.Server.Documents.Handlers
 
                 if (id[id.Length - 1] == '|')
                 {
-                    var (_, clusterId, _) = await ServerStore.GenerateClusterIdentityAsync(id, Database.Name, GetStringQueryString("guid", required: false));
+                    var (_, clusterId, _) = await ServerStore.GenerateClusterIdentityAsync(id, Database.Name, GetRaftGuidFromHeaders());
                     id = clusterId;
                 }
 

--- a/src/Raven.Server/Documents/Handlers/DocumentHandler.cs
+++ b/src/Raven.Server/Documents/Handlers/DocumentHandler.cs
@@ -328,7 +328,7 @@ namespace Raven.Server.Documents.Handlers
 
                 if (id[id.Length - 1] == '|')
                 {
-                    var (_, clusterId, _) = await ServerStore.GenerateClusterIdentityAsync(id, Database.Name);
+                    var (_, clusterId, _) = await ServerStore.GenerateClusterIdentityAsync(id, Database.Name, GetStringQueryString("guid", required: false));
                     id = clusterId;
                 }
 

--- a/src/Raven.Server/Documents/Handlers/ExpirationHandler.cs
+++ b/src/Raven.Server/Documents/Handlers/ExpirationHandler.cs
@@ -41,7 +41,7 @@ namespace Raven.Server.Documents.Handlers
         [RavenAction("/databases/*/admin/expiration/config", "POST", AuthorizationStatus.DatabaseAdmin)]
         public async Task ConfigExpiration()
         {
-            await DatabaseConfigurations(ServerStore.ModifyDatabaseExpiration, "read-expiration-config");
+            await DatabaseConfigurations(ServerStore.ModifyDatabaseExpiration, "read-expiration-config", GetStringQueryString("guid", required: false));
         }
     }
 }

--- a/src/Raven.Server/Documents/Handlers/ExpirationHandler.cs
+++ b/src/Raven.Server/Documents/Handlers/ExpirationHandler.cs
@@ -41,7 +41,7 @@ namespace Raven.Server.Documents.Handlers
         [RavenAction("/databases/*/admin/expiration/config", "POST", AuthorizationStatus.DatabaseAdmin)]
         public async Task ConfigExpiration()
         {
-            await DatabaseConfigurations(ServerStore.ModifyDatabaseExpiration, "read-expiration-config", GetStringQueryString("guid", required: false));
+            await DatabaseConfigurations(ServerStore.ModifyDatabaseExpiration, "read-expiration-config", GetRaftGuidFromHeaders());
         }
     }
 }

--- a/src/Raven.Server/Documents/Handlers/IdentityHandler.cs
+++ b/src/Raven.Server/Documents/Handlers/IdentityHandler.cs
@@ -16,7 +16,7 @@ namespace Raven.Server.Documents.Handlers
             if (name[name.Length - 1] != '|')
                 name += '|';
 
-            var (_, _, newIdentityValue) = await Database.ServerStore.GenerateClusterIdentityAsync(name, Database.Name);
+            var (_, _, newIdentityValue) = await Database.ServerStore.GenerateClusterIdentityAsync(name, Database.Name, GetStringQueryString("guid", required: false));
 
             using (ContextPool.AllocateOperationContext(out DocumentsOperationContext context))
             using (var writer = new BlittableJsonTextWriter(context, ResponseBodyStream()))
@@ -42,7 +42,7 @@ namespace Raven.Server.Documents.Handlers
             if (name[name.Length - 1] != '|')
                 name += '|';
 
-            var newIdentityValue = await Database.ServerStore.UpdateClusterIdentityAsync(name, Database.Name, value.Value, forced);
+            var newIdentityValue = await Database.ServerStore.UpdateClusterIdentityAsync(name, Database.Name, value.Value, forced, GetStringQueryString("guid", required: false));
             using (ContextPool.AllocateOperationContext(out DocumentsOperationContext context))
             using (var writer = new BlittableJsonTextWriter(context, ResponseBodyStream()))
             {

--- a/src/Raven.Server/Documents/Handlers/IdentityHandler.cs
+++ b/src/Raven.Server/Documents/Handlers/IdentityHandler.cs
@@ -16,7 +16,7 @@ namespace Raven.Server.Documents.Handlers
             if (name[name.Length - 1] != '|')
                 name += '|';
 
-            var (_, _, newIdentityValue) = await Database.ServerStore.GenerateClusterIdentityAsync(name, Database.Name, GetStringQueryString("guid", required: false));
+            var (_, _, newIdentityValue) = await Database.ServerStore.GenerateClusterIdentityAsync(name, Database.Name, GetRaftGuidFromHeaders());
 
             using (ContextPool.AllocateOperationContext(out DocumentsOperationContext context))
             using (var writer = new BlittableJsonTextWriter(context, ResponseBodyStream()))
@@ -42,7 +42,7 @@ namespace Raven.Server.Documents.Handlers
             if (name[name.Length - 1] != '|')
                 name += '|';
 
-            var newIdentityValue = await Database.ServerStore.UpdateClusterIdentityAsync(name, Database.Name, value.Value, forced, GetStringQueryString("guid", required: false));
+            var newIdentityValue = await Database.ServerStore.UpdateClusterIdentityAsync(name, Database.Name, value.Value, forced, GetRaftGuidFromHeaders());
             using (ContextPool.AllocateOperationContext(out DocumentsOperationContext context))
             using (var writer = new BlittableJsonTextWriter(context, ResponseBodyStream()))
             {

--- a/src/Raven.Server/Documents/Handlers/IndexHandler.cs
+++ b/src/Raven.Server/Documents/Handlers/IndexHandler.cs
@@ -479,7 +479,7 @@ namespace Raven.Server.Documents.Handlers
                 auditLog.Info($"Index {name} DELETE by {clientCert?.Subject} {clientCert?.Thumbprint}");
             }
 
-            HttpContext.Response.StatusCode = await Database.IndexStore.TryDeleteIndexIfExists(name, GetStringQueryString("guid", required: false))
+            HttpContext.Response.StatusCode = await Database.IndexStore.TryDeleteIndexIfExists(name, GetRaftGuidFromHeaders())
                 ? (int)HttpStatusCode.NoContent
                 : (int)HttpStatusCode.NotFound;
         }

--- a/src/Raven.Server/Documents/Handlers/IndexHandler.cs
+++ b/src/Raven.Server/Documents/Handlers/IndexHandler.cs
@@ -479,7 +479,7 @@ namespace Raven.Server.Documents.Handlers
                 auditLog.Info($"Index {name} DELETE by {clientCert?.Subject} {clientCert?.Thumbprint}");
             }
 
-            HttpContext.Response.StatusCode = await Database.IndexStore.TryDeleteIndexIfExists(name)
+            HttpContext.Response.StatusCode = await Database.IndexStore.TryDeleteIndexIfExists(name, GetStringQueryString("guid", required: false))
                 ? (int)HttpStatusCode.NoContent
                 : (int)HttpStatusCode.NotFound;
         }
@@ -571,7 +571,7 @@ namespace Raven.Server.Documents.Handlers
 
                 foreach (var name in parameters.IndexNames)
                 {
-                    await Database.IndexStore.SetLock(name, parameters.Mode);
+                    await Database.IndexStore.SetLock(name, parameters.Mode, string.Empty); // TODO: can't use single guid here for multiple commands
                 }
             }
 
@@ -588,7 +588,7 @@ namespace Raven.Server.Documents.Handlers
 
                 foreach (var name in parameters.IndexNames)
                 {
-                    await Database.IndexStore.SetPriority(name, parameters.Priority);
+                    await Database.IndexStore.SetPriority(name, parameters.Priority, string.Empty); // TODO: can't use single guid here for multiple commands
                 }
 
                 NoContentStatus();

--- a/src/Raven.Server/Documents/Handlers/RevisionsHandler.cs
+++ b/src/Raven.Server/Documents/Handlers/RevisionsHandler.cs
@@ -60,7 +60,7 @@ namespace Raven.Server.Documents.Handlers
         [RavenAction("/databases/*/admin/revisions/config", "POST", AuthorizationStatus.DatabaseAdmin)]
         public async Task ConfigRevisions()
         {
-            await DatabaseConfigurations(ServerStore.ModifyDatabaseRevisions, "read-revisions-config", GetStringQueryString("guid", required: false));
+            await DatabaseConfigurations(ServerStore.ModifyDatabaseRevisions, "read-revisions-config", GetRaftGuidFromHeaders());
         }
 
         [RavenAction("/databases/*/revisions", "GET", AuthorizationStatus.ValidUser)]

--- a/src/Raven.Server/Documents/Handlers/RevisionsHandler.cs
+++ b/src/Raven.Server/Documents/Handlers/RevisionsHandler.cs
@@ -60,7 +60,7 @@ namespace Raven.Server.Documents.Handlers
         [RavenAction("/databases/*/admin/revisions/config", "POST", AuthorizationStatus.DatabaseAdmin)]
         public async Task ConfigRevisions()
         {
-            await DatabaseConfigurations(ServerStore.ModifyDatabaseRevisions, "read-revisions-config");
+            await DatabaseConfigurations(ServerStore.ModifyDatabaseRevisions, "read-revisions-config", GetStringQueryString("guid", required: false));
         }
 
         [RavenAction("/databases/*/revisions", "GET", AuthorizationStatus.ValidUser)]

--- a/src/Raven.Server/Documents/Handlers/SubscriptionsHandler.cs
+++ b/src/Raven.Server/Documents/Handlers/SubscriptionsHandler.cs
@@ -151,7 +151,7 @@ namespace Raven.Server.Documents.Handlers
                 var id = GetLongQueryString("id", required: false);
                 var disabled = GetBoolValueQueryString("disabled", required: false);
                 var mentor = options.MentorNode;
-                var subscriptionId = await Database.SubscriptionStorage.PutSubscription(options, id, disabled, mentor: mentor);
+                var subscriptionId = await Database.SubscriptionStorage.PutSubscription(options, GetStringQueryString("guid", required: false), id, disabled, mentor: mentor);
 
                 var name = options.Name ?? subscriptionId.ToString();
 
@@ -183,7 +183,7 @@ namespace Raven.Server.Documents.Handlers
         {
             var subscriptionName = GetQueryStringValueAndAssertIfSingleAndNotEmpty("taskName");
 
-            await Database.SubscriptionStorage.DeleteSubscription(subscriptionName);
+            await Database.SubscriptionStorage.DeleteSubscription(subscriptionName, GetStringQueryString("guid", required: false));
 
             await NoContent();
         }

--- a/src/Raven.Server/Documents/Handlers/SubscriptionsHandler.cs
+++ b/src/Raven.Server/Documents/Handlers/SubscriptionsHandler.cs
@@ -151,7 +151,7 @@ namespace Raven.Server.Documents.Handlers
                 var id = GetLongQueryString("id", required: false);
                 var disabled = GetBoolValueQueryString("disabled", required: false);
                 var mentor = options.MentorNode;
-                var subscriptionId = await Database.SubscriptionStorage.PutSubscription(options, GetStringQueryString("guid", required: false), id, disabled, mentor: mentor);
+                var subscriptionId = await Database.SubscriptionStorage.PutSubscription(options, GetRaftGuidFromHeaders(), id, disabled, mentor: mentor);
 
                 var name = options.Name ?? subscriptionId.ToString();
 
@@ -183,7 +183,7 @@ namespace Raven.Server.Documents.Handlers
         {
             var subscriptionName = GetQueryStringValueAndAssertIfSingleAndNotEmpty("taskName");
 
-            await Database.SubscriptionStorage.DeleteSubscription(subscriptionName, GetStringQueryString("guid", required: false));
+            await Database.SubscriptionStorage.DeleteSubscription(subscriptionName, GetRaftGuidFromHeaders());
 
             await NoContent();
         }

--- a/src/Raven.Server/Documents/PeriodicBackup/BackupTask.cs
+++ b/src/Raven.Server/Documents/PeriodicBackup/BackupTask.cs
@@ -807,7 +807,7 @@ namespace Raven.Server.Documents.PeriodicBackup
 
             try
             {
-                var command = new UpdatePeriodicBackupStatusCommand(_database.Name)
+                var command = new UpdatePeriodicBackupStatusCommand(_database.Name, Guid.NewGuid().ToString())
                 {
                     PeriodicBackupStatus = status
                 };

--- a/src/Raven.Server/Documents/PeriodicBackup/Restore/RestoreBackupTask.cs
+++ b/src/Raven.Server/Documents/PeriodicBackup/Restore/RestoreBackupTask.cs
@@ -206,7 +206,7 @@ namespace Raven.Server.Documents.PeriodicBackup.Restore
 
                             DisableOngoingTasksIfNeeded(databaseRecord);
 
-                            var (index, _) = await _serverStore.WriteDatabaseRecordAsync(databaseName, databaseRecord, null, restoreSettings.DatabaseValues, isRestore: true);
+                            var (index, _) = await _serverStore.WriteDatabaseRecordAsync(databaseName, databaseRecord, null, Guid.NewGuid().ToString(), restoreSettings.DatabaseValues, isRestore: true);
                             await _serverStore.Cluster.WaitForIndexNotification(index);
 
                             // restore identities & cmpXchg values
@@ -218,7 +218,7 @@ namespace Raven.Server.Documents.PeriodicBackup.Restore
                     databaseRecord = _serverStore.LoadDatabaseRecord(databaseName, out _);
                     databaseRecord.Disabled = false;
 
-                    var (updateIndex, _) = await _serverStore.WriteDatabaseRecordAsync(databaseName, databaseRecord, null);
+                    var (updateIndex, _) = await _serverStore.WriteDatabaseRecordAsync(databaseName, databaseRecord, null, Guid.NewGuid().ToString());
                     await _serverStore.Cluster.WaitForIndexNotification(updateIndex);
 
                     if (databaseRecord.Topology.RelevantFor(_serverStore.NodeTag))

--- a/src/Raven.Server/Documents/PeriodicBackup/Restore/RestoreBackupTask.cs
+++ b/src/Raven.Server/Documents/PeriodicBackup/Restore/RestoreBackupTask.cs
@@ -252,7 +252,7 @@ namespace Raven.Server.Documents.PeriodicBackup.Restore
                 }
                 else
                 {
-                    var deleteResult = await _serverStore.DeleteDatabaseAsync(_restoreConfiguration.DatabaseName, true, new[] { _serverStore.NodeTag });
+                    var deleteResult = await _serverStore.DeleteDatabaseAsync(_restoreConfiguration.DatabaseName, true, new[] { _serverStore.NodeTag }, Guid.NewGuid().ToString());
                     await _serverStore.Cluster.WaitForIndexNotification(deleteResult.Index);
                 }
 

--- a/src/Raven.Server/Documents/Queries/Dynamic/DynamicQueryRunner.cs
+++ b/src/Raven.Server/Documents/Queries/Dynamic/DynamicQueryRunner.cs
@@ -110,7 +110,7 @@ namespace Raven.Server.Documents.Queries.Dynamic
 
                 var definition = map.CreateAutoIndexDefinition();
 
-                index = await _indexStore.CreateIndex(definition);
+                index = await _indexStore.CreateIndex(definition, Guid.NewGuid().ToString());
 
                 if (query.WaitForNonStaleResultsTimeout.HasValue == false)
                 {
@@ -206,7 +206,7 @@ namespace Raven.Server.Documents.Queries.Dynamic
                     {
                         try
                         {
-                            await _indexStore.DeleteIndex(supersededIndex.Name);
+                            await _indexStore.DeleteIndex(supersededIndex.Name, Guid.NewGuid().ToString());
                         }
                         catch (IndexDoesNotExistException)
                         {

--- a/src/Raven.Server/Documents/Replication/OutgoingReplicationHandler.cs
+++ b/src/Raven.Server/Documents/Replication/OutgoingReplicationHandler.cs
@@ -427,7 +427,7 @@ namespace Raven.Server.Documents.Replication
 
         private void UpdateExternalReplicationInfo(long taskId)
         {
-            var command = new UpdateExternalReplicationStateCommand(_database.Name)
+            var command = new UpdateExternalReplicationStateCommand(_database.Name, Guid.NewGuid().ToString())
             {
                 ExternalReplicationState = new ExternalReplicationState
                 {

--- a/src/Raven.Server/Documents/Subscriptions/SubscriptionStorage.cs
+++ b/src/Raven.Server/Documents/Subscriptions/SubscriptionStorage.cs
@@ -55,9 +55,9 @@ namespace Raven.Server.Documents.Subscriptions
 
         }
 
-        public async Task<long> PutSubscription(SubscriptionCreationOptions options, long? subscriptionId = null, bool? disabled = false, string mentor = null)
+        public async Task<long> PutSubscription(SubscriptionCreationOptions options, string guid, long? subscriptionId = null, bool? disabled = false, string mentor = null)
         {
-            var command = new PutSubscriptionCommand(_db.Name, options.Query, mentor)
+            var command = new PutSubscriptionCommand(_db.Name, options.Query, mentor, guid)
             {
                 InitialChangeVector = options.ChangeVector,
                 SubscriptionName = options.Name,
@@ -84,7 +84,7 @@ namespace Raven.Server.Documents.Subscriptions
 
         public async Task AcknowledgeBatchProcessed(long id, string name, string changeVector, string previousChangeVector)
         {
-            var command = new AcknowledgeSubscriptionBatchCommand(_db.Name)
+            var command = new AcknowledgeSubscriptionBatchCommand(_db.Name, Guid.NewGuid().ToString())
             {
                 ChangeVector = changeVector,
                 NodeTag = _serverStore.NodeTag,
@@ -102,7 +102,7 @@ namespace Raven.Server.Documents.Subscriptions
 
         public async Task UpdateClientConnectionTime(long id, string name, string mentorNode = null)
         {
-            var command = new UpdateSubscriptionClientConnectionTime(_db.Name)
+            var command = new UpdateSubscriptionClientConnectionTime(_db.Name, Guid.NewGuid().ToString())
             {
                 NodeTag = _serverStore.NodeTag,
                 HasHighlyAvailableTasks = _serverStore.LicenseManager.HasHighlyAvailableTasks(),
@@ -154,9 +154,9 @@ namespace Raven.Server.Documents.Subscriptions
             }
         }
 
-        public async Task DeleteSubscription(string name)
+        public async Task DeleteSubscription(string name, string guid)
         {
-            var command = new DeleteSubscriptionCommand(_db.Name, name);
+            var command = new DeleteSubscriptionCommand(_db.Name, name, guid);
 
             var (etag, _) = await _serverStore.SendToLeaderAsync(command);
 

--- a/src/Raven.Server/Monitoring/Snmp/SnmpDatabase.cs
+++ b/src/Raven.Server/Monitoring/Snmp/SnmpDatabase.cs
@@ -149,7 +149,7 @@ namespace Raven.Server.Monitoring.Snmp
                             var result = await database.ServerStore.SendToLeaderAsync(new UpdateSnmpDatabaseIndexesMappingCommand(_databaseName, new List<string>
                             {
                                 change.Name
-                            }));
+                            }, Guid.NewGuid().ToString()));
 
                             await database.ServerStore.Cluster.WaitForIndexNotification(result.Index);
 
@@ -192,7 +192,7 @@ namespace Raven.Server.Monitoring.Snmp
                 {
                     context.CloseTransaction();
 
-                    var result = await database.ServerStore.SendToLeaderAsync(new UpdateSnmpDatabaseIndexesMappingCommand(database.Name, missingIndexes));
+                    var result = await database.ServerStore.SendToLeaderAsync(new UpdateSnmpDatabaseIndexesMappingCommand(database.Name, missingIndexes, Guid.NewGuid().ToString()));
                     await database.ServerStore.Cluster.WaitForIndexNotification(result.Index);
 
                     context.OpenReadTransaction();

--- a/src/Raven.Server/Monitoring/Snmp/SnmpWatcher.cs
+++ b/src/Raven.Server/Monitoring/Snmp/SnmpWatcher.cs
@@ -128,7 +128,7 @@ namespace Raven.Server.Monitoring.Snmp
                         {
                             context.CloseTransaction();
 
-                            var result = await _server.ServerStore.SendToLeaderAsync(new UpdateSnmpDatabasesMappingCommand(new List<string> { databaseName }));
+                            var result = await _server.ServerStore.SendToLeaderAsync(new UpdateSnmpDatabasesMappingCommand(new List<string> { databaseName }, Guid.NewGuid().ToString()));
                             await _server.ServerStore.Cluster.WaitForIndexNotification(result.Index);
 
                             context.OpenReadTransaction();
@@ -257,7 +257,7 @@ namespace Raven.Server.Monitoring.Snmp
                     {
                         context.CloseTransaction();
 
-                        var result = await _server.ServerStore.SendToLeaderAsync(new UpdateSnmpDatabasesMappingCommand(missingDatabases));
+                        var result = await _server.ServerStore.SendToLeaderAsync(new UpdateSnmpDatabasesMappingCommand(missingDatabases, Guid.NewGuid().ToString()));
                         await _server.ServerStore.Cluster.WaitForIndexNotification(result.Index);
 
                         context.OpenReadTransaction();

--- a/src/Raven.Server/Rachis/Leader.cs
+++ b/src/Raven.Server/Rachis/Leader.cs
@@ -472,7 +472,6 @@ namespace Raven.Server.Rachis
                 maxIndexOnQuorum = _engine.Apply(context, maxIndexOnQuorum, this, Stopwatch.StartNew());
 
                 context.Transaction.Commit();
-
                 _lastCommit = maxIndexOnQuorum;
             }
 
@@ -689,6 +688,7 @@ namespace Raven.Server.Rachis
                 using (context.OpenWriteTransaction())
                 {
                     var cmdsCount = 0;
+                    _engine.GetLastCommitIndex(context, out var lastCommitted, out _);
                     while (cmdsCount++ < 128 && _commandsQueue.TryDequeue(out var cmd))
                     {
                         if (cmd.Consumed.Raise() == false)
@@ -710,19 +710,42 @@ namespace Raven.Server.Rachis
                         var djv = cmd.Command.ToJson(context);
                         var cmdJson = context.ReadObject(djv, "raft/command");
 
-                        var index = _engine.InsertToLeaderLog(context, Term, cmdJson, RachisEntryFlags.StateMachineCommand);
+                        if (_engine.HasHistoryLog(context, cmdJson, out var index, out var result, out var exception))
+                        {
+                            // if this command is already committed, we can skip it and notify the caller about it
+                            if (lastCommitted >= index) 
+                            {
+                                if (exception != null)
+                                {
+                                    cmd.Tcs.TrySetException(new Exception(exception));
+                                }
+                                else
+                                {
+                                    result = GetConvertResult(cmd.Command)?.Apply(result) ?? cmd.Command.FromRemote(result);
+                                    var completed = new ValueTask<(long, object)>((index, result));
+                                    cmd.Tcs.TrySetResult(completed.AsTask());
+                                }
+                                list.Remove(cmd.Tcs);
+                                continue;
+                            }
+                        }
+                        else
+                        {
+                            index = _engine.InsertToLeaderLog(context, Term, cmdJson, RachisEntryFlags.StateMachineCommand);
+                        }
 
                         var tcs = new TaskCompletionSource<(long, object)>(TaskCreationOptions.RunContinuationsAsynchronously);
                         tasks.Add(tcs.Task);
                         var state = new
-                            CommandState // we need to add entry inside write tx lock to avoid
-                                         // a situation when command will be applied (and state set)
-                                         // before it is added to the entries list
+                            CommandState 
+                            // we need to add entry inside write tx lock to avoid
+                            // a situation when command will be applied (and state set)
+                            // before it is added to the entries list
                             {
                                 CommandIndex = index,
                                 TaskCompletionSource = tcs,
-                                ConvertResult = GetConvertResult(cmd.Command)
-                        };
+                                ConvertResult = GetConvertResult(cmd.Command),
+                            };
                         _entries[index] = state;
                     }
                     context.Transaction.Commit();
@@ -812,9 +835,10 @@ namespace Raven.Server.Rachis
                     {
                         _newEntriesArrived.TrySetCanceled();
                         var lastStateChangeReason = _engine.LastStateChangeReason;
-                        TimeoutException te = null;
+                        NotLeadingException te = null;
                         if (string.IsNullOrEmpty(lastStateChangeReason) == false)
-                            te = new TimeoutException(lastStateChangeReason);
+                            te = new NotLeadingException(lastStateChangeReason);
+
                         foreach (var entry in _entries)
                         {
                             if (te == null)
@@ -1083,6 +1107,7 @@ namespace Raven.Server.Rachis
             public ConvertResultAction ConvertResult;
             public TaskCompletionSource<(long, object)> TaskCompletionSource;
             public Action<TaskCompletionSource<(long, object)>> OnNotify;
+            public string Debug;
         }
 
         public class ConvertResultAction

--- a/src/Raven.Server/RavenServer.cs
+++ b/src/Raven.Server/RavenServer.cs
@@ -666,11 +666,8 @@ namespace Raven.Server
 
                 await ServerStore.Cluster.WaitForIndexNotification(res.Index);
 
-                await ServerStore.SendToLeaderAsync(new InstallUpdatedServerCertificateCommand
-                {
-                    Certificate = base64CertWithoutPassword, // includes the private key
-                    ReplaceImmediately = replaceImmediately
-                });
+                // TODO: pass guid
+                await ServerStore.SendToLeaderAsync(new InstallUpdatedServerCertificateCommand(base64CertWithoutPassword,replaceImmediately, string.Empty));
             }
             catch (Exception e)
             {

--- a/src/Raven.Server/ServerWide/ClusterStateMachine.cs
+++ b/src/Raven.Server/ServerWide/ClusterStateMachine.cs
@@ -124,6 +124,8 @@ namespace Raven.Server.ServerWide
                 return;
             }
 
+            ValidateGuid(cmd, type);
+            object result = null;
             var sw = Stopwatch.StartNew();
             try
             {
@@ -134,6 +136,7 @@ namespace Raven.Server.ServerWide
                         var errors = ExecuteClusterTransaction(context, cmd, index);
                         if (errors != null)
                         {
+                            result = errors;
                             leader?.SetStateOf(index, errors);
                         }
                         break;
@@ -164,7 +167,7 @@ namespace Raven.Server.ServerWide
                         if (ValidatePropertyExistence(cmd, nameof(IncrementClusterIdentityCommand), nameof(IncrementClusterIdentityCommand.Prefix), out errorMessage) == false)
                             throw new RachisApplyException(errorMessage);
 
-                        SetValueForTypedDatabaseCommand(context, type, cmd, index, leader, out object result);
+                        SetValueForTypedDatabaseCommand(context, type, cmd, index, leader, out result);
                         leader?.SetStateOf(index, result);
                         UpdateDatabaseRecordEtagForBackup(context, type, cmd, index);
                         break;
@@ -271,7 +274,10 @@ namespace Raven.Server.ServerWide
                     case nameof(AddDatabaseCommand):
                         var addedNodes = AddDatabase(context, cmd, index, leader);
                         if (addedNodes != null)
+                        {
+                            result = addedNodes;
                             leader?.SetStateOf(index, addedNodes);
+                        }
                         break;
                     default:
                         var massage = $"The command '{type}' is unknown and cannot be executed on server with version '{ServerVersion.FullVersion}'.{Environment.NewLine}" +
@@ -284,6 +290,7 @@ namespace Raven.Server.ServerWide
                 if (_parent.Log.IsInfoEnabled)
                     _parent.Log.Info($"Failed to execute command of type '{type}' on database '{DatabaseName}'", e);
 
+                _parent.UpdateHistoryLog(context, index, _parent.CurrentTerm, cmd, null, e);
                 NotifyLeaderAboutError(index, leader, e);
             }
             catch (Exception e)
@@ -300,6 +307,8 @@ namespace Raven.Server.ServerWide
             finally
             {
                 var executionTime = sw.Elapsed;
+
+                _parent.UpdateHistoryLog(context, index, _parent.CurrentTerm, cmd, result, null);
                 _rachisLogIndexNotifications.RecordNotification(new RecentLogIndexNotification
                 {
                     Type = type,
@@ -309,6 +318,15 @@ namespace Raven.Server.ServerWide
                     Term = leader?.Term,
                     LeaderShipDuration = leader?.LeaderShipDuration,
                 });
+            }
+        }
+
+        [Conditional("DEBUG")]
+        private static void ValidateGuid(BlittableJsonReaderObject cmd, string type)
+        {
+            if (cmd.TryGet(nameof(CommandBase.Guid), out string guid) == false)
+            {
+                throw new ArgumentNullException($"Guid is not provided in the command {type}.");
             }
         }
 

--- a/src/Raven.Server/ServerWide/Commands/AddDatabaseCommand.cs
+++ b/src/Raven.Server/ServerWide/Commands/AddDatabaseCommand.cs
@@ -14,6 +14,12 @@ namespace Raven.Server.ServerWide.Commands
         public bool Encrypted;
         public bool IsRestore;
 
+        public AddDatabaseCommand() { }
+
+        public AddDatabaseCommand(string guid) : base(guid)
+        {
+        }
+
         public override object FromRemote(object remoteResult)
         {
             var rc = new List<string>();

--- a/src/Raven.Server/ServerWide/Commands/AddOrUpdateCompareExchangeBatchCommand.cs
+++ b/src/Raven.Server/ServerWide/Commands/AddOrUpdateCompareExchangeBatchCommand.cs
@@ -15,7 +15,7 @@ namespace Raven.Server.ServerWide.Commands
         {
         }
 
-        public AddOrUpdateCompareExchangeBatchCommand(List<AddOrUpdateCompareExchangeCommand> commands, JsonOperationContext contextToWriteResult)
+        public AddOrUpdateCompareExchangeBatchCommand(List<AddOrUpdateCompareExchangeCommand> commands, JsonOperationContext contextToWriteResult, string guid) : base(guid)
         {
             Commands = commands;
             ContextToWriteResult = contextToWriteResult;

--- a/src/Raven.Server/ServerWide/Commands/CleanUpClusterStateCommand.cs
+++ b/src/Raven.Server/ServerWide/Commands/CleanUpClusterStateCommand.cs
@@ -14,6 +14,10 @@ namespace Raven.Server.ServerWide.Commands
         {
         }
 
+        public CleanUpClusterStateCommand(string guid) : base(guid)
+        {
+        }
+
         public unsafe Dictionary<string, long> Clean(TransactionOperationContext context, long index)
         {
             var affectedDatabases = new Dictionary<string, long>();

--- a/src/Raven.Server/ServerWide/Commands/ClusterTransactionCommand.cs
+++ b/src/Raven.Server/ServerWide/Commands/ClusterTransactionCommand.cs
@@ -101,10 +101,10 @@ namespace Raven.Server.ServerWide.Commands
         public ClusterTransactionCommand() { }
 
         public ClusterTransactionCommand(string databaseName, string recordId, ArraySegment<BatchRequestParser.CommandData> commandParsedCommands,
-            ClusterTransactionOptions options)
+            ClusterTransactionOptions options, string guid) : base(guid)
         {
             DatabaseName = databaseName;
-            DatabaseRecordId = recordId ?? Guid.NewGuid().ToBase64Unpadded();
+            DatabaseRecordId = recordId ?? System.Guid.NewGuid().ToBase64Unpadded();
             Options = options;
 
             foreach (var commandData in commandParsedCommands)
@@ -151,7 +151,7 @@ namespace Raven.Server.ServerWide.Commands
                 switch (clusterCommand.Type)
                 {
                     case CommandType.CompareExchangePUT:
-                        var put = new AddOrUpdateCompareExchangeCommand(DatabaseName, clusterCommand.Id, clusterCommand.Document, clusterCommand.Index, context);
+                        var put = new AddOrUpdateCompareExchangeCommand(DatabaseName, clusterCommand.Id, clusterCommand.Document, clusterCommand.Index, context, null);
                         if (put.Validate(context, items, clusterCommand.Index, out current) == false)
                         {
                             errors.Add(
@@ -161,7 +161,7 @@ namespace Raven.Server.ServerWide.Commands
                         toExecute.Add(put);
                         break;
                     case CommandType.CompareExchangeDELETE:
-                        var delete = new RemoveCompareExchangeCommand(DatabaseName, clusterCommand.Id, clusterCommand.Index, context);
+                        var delete = new RemoveCompareExchangeCommand(DatabaseName, clusterCommand.Id, clusterCommand.Index, context, null);
                         if (delete.Validate(context, items, clusterCommand.Index, out current) == false)
                         {
                             errors.Add($"Concurrency check failed for deleting the key '{clusterCommand.Id}'. Requested index: {clusterCommand.Index}, actual index: {current}");
@@ -392,6 +392,11 @@ namespace Raven.Server.ServerWide.Commands
                 return rc;
             }
             return base.FromRemote(remoteResult);
+        }
+
+        public override string AdditionalDebugInformation(Exception exception)
+        {
+            return $"guid: {Guid} {string.Join(", ", ClusterCommands.Select(c => c.Id))}";
         }
 
         public override DynamicJsonValue ToJson(JsonOperationContext context)

--- a/src/Raven.Server/ServerWide/Commands/CommandBase.cs
+++ b/src/Raven.Server/ServerWide/Commands/CommandBase.cs
@@ -13,11 +13,24 @@ namespace Raven.Server.ServerWide.Commands
         {
             return new DynamicJsonValue
             {
-                ["Type"] = GetType().Name
+                ["Type"] = GetType().Name,
+                [nameof(Guid)] = Guid
             };
         }
 
         public long? RaftCommandIndex;
+
+        // Unique id which is provided by the client in order to avoid re-applying the command if it sent to different nodes or on retry.
+        // if string.Empty passed, it will be treated as don't care,
+        // if (null) value is passed, it will be treated as a bug. (will throw an exception only in Debug builds to support old clients)
+        public string Guid;
+
+        protected CommandBase() { }
+
+        protected CommandBase(string guid)
+        {
+            Guid = guid;
+        }
 
         public static CommandBase CreateFrom(BlittableJsonReaderObject json)
         {

--- a/src/Raven.Server/ServerWide/Commands/CompareExchangeCommands.cs
+++ b/src/Raven.Server/ServerWide/Commands/CompareExchangeCommands.cs
@@ -27,9 +27,10 @@ namespace Raven.Server.ServerWide.Commands
             return (database + "/" + key).ToLowerInvariant();
         }
 
-        protected CompareExchangeCommandBase() { }
+        protected CompareExchangeCommandBase()
+        { }
 
-        protected CompareExchangeCommandBase(string database, string key, long index, JsonOperationContext context)
+        protected CompareExchangeCommandBase(string database, string key, long index, JsonOperationContext context, string guid) : base(guid)
         {
             if (string.IsNullOrEmpty(key))
                 throw new ArgumentNullException(nameof(key), "The key argument must have value");
@@ -114,7 +115,7 @@ namespace Raven.Server.ServerWide.Commands
     public class RemoveCompareExchangeCommand : CompareExchangeCommandBase
     {
         public RemoveCompareExchangeCommand() { }
-        public RemoveCompareExchangeCommand(string key, string database, long index, JsonOperationContext contextToReturnResult) : base(key, database, index, contextToReturnResult) { }
+        public RemoveCompareExchangeCommand(string key, string database, long index, JsonOperationContext contextToReturnResult, string guid) : base(key, database, index, contextToReturnResult, guid) { }
 
         public override unsafe (long Index, object Value) Execute(TransactionOperationContext context, Table items, long index)
         {
@@ -148,8 +149,8 @@ namespace Raven.Server.ServerWide.Commands
 
         public AddOrUpdateCompareExchangeCommand() { }
 
-        public AddOrUpdateCompareExchangeCommand(string database, string key, BlittableJsonReaderObject value, long index, JsonOperationContext contextToReturnResult) 
-            : base(database, key, index, contextToReturnResult)
+        public AddOrUpdateCompareExchangeCommand(string database, string key, BlittableJsonReaderObject value, long index, JsonOperationContext contextToReturnResult, string guid) 
+            : base(database, key, index, contextToReturnResult, guid)
         {
             if (key.Length > MaxNumberOfCompareExchangeKeyBytes || Encoding.GetByteCount(key) > MaxNumberOfCompareExchangeKeyBytes)
                 ThrowCompareExchangeKeyTooBig(key);

--- a/src/Raven.Server/ServerWide/Commands/ConnectionStrings/PutConnectionStringCommand.cs
+++ b/src/Raven.Server/ServerWide/Commands/ConnectionStrings/PutConnectionStringCommand.cs
@@ -10,12 +10,12 @@ namespace Raven.Server.ServerWide.Commands.ConnectionStrings
     {
         public T ConnectionString { get; protected set; }
 
-        protected PutConnectionStringCommand() : base(null)
+        protected PutConnectionStringCommand()
         {
             // for deserialization
         }
 
-        protected PutConnectionStringCommand(T connectionString, string databaseName) : base(databaseName)
+        protected PutConnectionStringCommand(T connectionString, string databaseName, string guid) : base(databaseName, guid)
         {
             ConnectionString = connectionString;
         }
@@ -33,7 +33,7 @@ namespace Raven.Server.ServerWide.Commands.ConnectionStrings
             // for deserialization
         }
 
-        public PutRavenConnectionStringCommand(RavenConnectionString connectionString, string databaseName) : base(connectionString, databaseName)
+        public PutRavenConnectionStringCommand(RavenConnectionString connectionString, string databaseName, string guid) : base(connectionString, databaseName, guid)
         {
             
         }
@@ -52,7 +52,7 @@ namespace Raven.Server.ServerWide.Commands.ConnectionStrings
             // for deserialization
         }
 
-        public PutSqlConnectionStringCommand(SqlConnectionString connectionString, string databaseName) : base(connectionString, databaseName)
+        public PutSqlConnectionStringCommand(SqlConnectionString connectionString, string databaseName, string guid) : base(connectionString, databaseName, guid)
         {
 
         }

--- a/src/Raven.Server/ServerWide/Commands/ConnectionStrings/RemoveConnectionStringCommand.cs
+++ b/src/Raven.Server/ServerWide/Commands/ConnectionStrings/RemoveConnectionStringCommand.cs
@@ -10,12 +10,12 @@ namespace Raven.Server.ServerWide.Commands.ConnectionStrings
     {
         public string ConnectionStringName { get; protected set; }
 
-        protected RemoveConnectionStringCommand() : base(null)
+        protected RemoveConnectionStringCommand()
         {
             // for deserialization
         }
 
-        protected RemoveConnectionStringCommand(string connectionStringName, string databaseName) : base(databaseName)
+        protected RemoveConnectionStringCommand(string connectionStringName, string databaseName, string guid) : base(databaseName, guid)
         {
             ConnectionStringName = connectionStringName;
         }
@@ -33,7 +33,7 @@ namespace Raven.Server.ServerWide.Commands.ConnectionStrings
             // for deserialization
         }
 
-        public RemoveRavenConnectionStringCommand(string connectionStringName, string databaseName) : base(connectionStringName, databaseName)
+        public RemoveRavenConnectionStringCommand(string connectionStringName, string databaseName, string guid) : base(connectionStringName, databaseName, guid)
         {
             
         }
@@ -52,7 +52,7 @@ namespace Raven.Server.ServerWide.Commands.ConnectionStrings
             // for deserialization
         }
 
-        public RemoveSqlConnectionStringCommand(string connectionStringName, string databaseName) : base(connectionStringName, databaseName)
+        public RemoveSqlConnectionStringCommand(string connectionStringName, string databaseName, string guid) : base(connectionStringName, databaseName, guid)
         {
 
         }

--- a/src/Raven.Server/ServerWide/Commands/DeleteDatabaseCommand.cs
+++ b/src/Raven.Server/ServerWide/Commands/DeleteDatabaseCommand.cs
@@ -14,12 +14,11 @@ namespace Raven.Server.ServerWide.Commands
         public string[] FromNodes;
         public bool UpdateReplicationFactor = true;
 
-        public DeleteDatabaseCommand() : base(null)
+        public DeleteDatabaseCommand()
         {
-            ErrorOnDatabaseDoesNotExists = true;
         }
 
-        public DeleteDatabaseCommand(string databaseName) : base(databaseName)
+        public DeleteDatabaseCommand(string databaseName, string guid) : base(databaseName, guid)
         {
             ErrorOnDatabaseDoesNotExists = true;
         }

--- a/src/Raven.Server/ServerWide/Commands/DeleteMultipleValuesCommand.cs
+++ b/src/Raven.Server/ServerWide/Commands/DeleteMultipleValuesCommand.cs
@@ -26,5 +26,13 @@ namespace Raven.Server.ServerWide.Commands
             if (Names.Contains(ServerStore.LicenseStorageKey) || Names.Any(name => name.StartsWith(Constants.Certificates.Prefix)))
                 throw new RachisApplyException("Attempted to use DeleteMultipleValuesCommand to delete certificates or a license, use dedicated commands for this.");
         }
+
+        public DeleteMultipleValuesCommand()
+        {
+        }
+
+        public DeleteMultipleValuesCommand(string guid) : base(guid)
+        {
+        }
     }
 }

--- a/src/Raven.Server/ServerWide/Commands/DeleteOngoingTaskCommand.cs
+++ b/src/Raven.Server/ServerWide/Commands/DeleteOngoingTaskCommand.cs
@@ -11,12 +11,12 @@ namespace Raven.Server.ServerWide.Commands
         public long TaskId;
         public OngoingTaskType TaskType;
 
-        public DeleteOngoingTaskCommand() : base(null)
+        public DeleteOngoingTaskCommand()
         {
 
         }
 
-        public DeleteOngoingTaskCommand(long taskId, OngoingTaskType taskType, string databaseName) : base(databaseName)
+        public DeleteOngoingTaskCommand(long taskId, OngoingTaskType taskType, string databaseName, string guid) : base(databaseName, guid)
         {
             TaskId = taskId;
             TaskType = taskType;

--- a/src/Raven.Server/ServerWide/Commands/DeleteValueCommand.cs
+++ b/src/Raven.Server/ServerWide/Commands/DeleteValueCommand.cs
@@ -23,5 +23,11 @@ namespace Raven.Server.ServerWide.Commands
             if (Name == ServerStore.LicenseStorageKey || Name.StartsWith(Constants.Certificates.Prefix))
                 throw new RachisApplyException("Attempted to use DeleteValueCommand to delete a certificate or a license, use dedicated commands for this.");
         }
+
+        public DeleteValueCommand() { }
+
+        public DeleteValueCommand(string guid) : base(guid)
+        {
+        }
     }
 }

--- a/src/Raven.Server/ServerWide/Commands/ETL/AddEtlCommand.cs
+++ b/src/Raven.Server/ServerWide/Commands/ETL/AddEtlCommand.cs
@@ -12,12 +12,12 @@ namespace Raven.Server.ServerWide.Commands.ETL
     {
         public T Configuration { get; protected set; }
 
-        protected AddEtlCommand() : base(null)
+        protected AddEtlCommand()
         {
             // for deserialization
         }
 
-        protected AddEtlCommand(T configuration, string databaseName) : base(databaseName)
+        protected AddEtlCommand(T configuration, string databaseName, string guid) : base(databaseName, guid)
         {
             Configuration = configuration;
         }
@@ -52,7 +52,7 @@ namespace Raven.Server.ServerWide.Commands.ETL
             // for deserialization
         }
 
-        public AddRavenEtlCommand(RavenEtlConfiguration configuration, string databaseName) : base(configuration, databaseName)
+        public AddRavenEtlCommand(RavenEtlConfiguration configuration, string databaseName, string guid) : base(configuration, databaseName, guid)
         {
 
         }
@@ -71,7 +71,7 @@ namespace Raven.Server.ServerWide.Commands.ETL
             // for deserialization
         }
 
-        public AddSqlEtlCommand(SqlEtlConfiguration configuration, string databaseName) : base(configuration, databaseName)
+        public AddSqlEtlCommand(SqlEtlConfiguration configuration, string databaseName, string guid) : base(configuration, databaseName, guid)
         {
 
         }

--- a/src/Raven.Server/ServerWide/Commands/ETL/DeleteEtlProcessStateCommand.cs
+++ b/src/Raven.Server/ServerWide/Commands/ETL/DeleteEtlProcessStateCommand.cs
@@ -11,12 +11,12 @@ namespace Raven.Server.ServerWide.Commands.ETL
 
         public string TransformationName { get; set; }
 
-        private RemoveEtlProcessStateCommand() : base(null)
+        private RemoveEtlProcessStateCommand()
         {
             // for deserialization
         }
 
-        public RemoveEtlProcessStateCommand(string databaseName, string configurationName, string transformationName) : base(databaseName)
+        public RemoveEtlProcessStateCommand(string databaseName, string configurationName, string transformationName, string guid) : base(databaseName, guid)
         {
             ConfigurationName = configurationName;
             TransformationName = transformationName;

--- a/src/Raven.Server/ServerWide/Commands/ETL/UpdateEtlCommand.cs
+++ b/src/Raven.Server/ServerWide/Commands/ETL/UpdateEtlCommand.cs
@@ -16,12 +16,12 @@ namespace Raven.Server.ServerWide.Commands.ETL
 
         public EtlType EtlType { get; protected set; }
 
-        protected UpdateEtlCommand() : base(null)
+        protected UpdateEtlCommand()
         {
             // for deserialization
         }
 
-        protected UpdateEtlCommand(long taskId, T configuration, EtlType type, string databaseName) : base(databaseName)
+        protected UpdateEtlCommand(long taskId, T configuration, EtlType type, string databaseName, string guid) : base(databaseName, guid)
         {
             TaskId = taskId;
             Configuration = configuration;
@@ -43,15 +43,15 @@ namespace Raven.Server.ServerWide.Commands.ETL
             // for deserialization
         }
 
-        public UpdateRavenEtlCommand(long taskId, RavenEtlConfiguration configuration, string databaseName) : base(taskId, configuration, EtlType.Raven, databaseName)
+        public UpdateRavenEtlCommand(long taskId, RavenEtlConfiguration configuration, string databaseName, string guid) : base(taskId, configuration, EtlType.Raven, databaseName, guid)
         {
 
         }
 
         public override string UpdateDatabaseRecord(DatabaseRecord record, long etag)
         {
-            new DeleteOngoingTaskCommand(TaskId, OngoingTaskType.RavenEtl, DatabaseName).UpdateDatabaseRecord(record, etag);
-            new AddRavenEtlCommand(Configuration, DatabaseName).UpdateDatabaseRecord(record, etag);
+            new DeleteOngoingTaskCommand(TaskId, OngoingTaskType.RavenEtl, DatabaseName, null).UpdateDatabaseRecord(record, etag);
+            new AddRavenEtlCommand(Configuration, DatabaseName, null).UpdateDatabaseRecord(record, etag);
 
             return null;
         }
@@ -64,15 +64,15 @@ namespace Raven.Server.ServerWide.Commands.ETL
             // for deserialization
         }
 
-        public UpdateSqlEtlCommand(long taskId, SqlEtlConfiguration configuration, string databaseName) : base(taskId, configuration, EtlType.Sql, databaseName)
+        public UpdateSqlEtlCommand(long taskId, SqlEtlConfiguration configuration, string databaseName, string guid) : base(taskId, configuration, EtlType.Sql, databaseName, guid)
         {
 
         }
 
         public override string UpdateDatabaseRecord(DatabaseRecord record, long etag)
         {
-            new DeleteOngoingTaskCommand(TaskId, OngoingTaskType.SqlEtl, DatabaseName).UpdateDatabaseRecord(record, etag);
-            new AddSqlEtlCommand(Configuration, DatabaseName).UpdateDatabaseRecord(record, etag);
+            new DeleteOngoingTaskCommand(TaskId, OngoingTaskType.SqlEtl, DatabaseName, null).UpdateDatabaseRecord(record, etag);
+            new AddSqlEtlCommand(Configuration, DatabaseName, null).UpdateDatabaseRecord(record, etag);
 
             return null;
         }

--- a/src/Raven.Server/ServerWide/Commands/ETL/UpdateEtlProcessStateCommand.cs
+++ b/src/Raven.Server/ServerWide/Commands/ETL/UpdateEtlProcessStateCommand.cs
@@ -23,13 +23,13 @@ namespace Raven.Server.ServerWide.Commands.ETL
 
         public bool HasHighlyAvailableTasks;
 
-        private UpdateEtlProcessStateCommand() : base(null)
+        private UpdateEtlProcessStateCommand()
         {
             // for deserialization
         }
 
         public UpdateEtlProcessStateCommand(string databaseName, string configurationName, string transformationName, long lastProcessedEtag, string changeVector,
-            string nodeTag, bool hasHighlyAvailableTasks) : base(databaseName)
+            string nodeTag, bool hasHighlyAvailableTasks, string guid) : base(databaseName, guid)
         {
             ConfigurationName = configurationName;
             TransformationName = transformationName;

--- a/src/Raven.Server/ServerWide/Commands/EditExpirationCommand.cs
+++ b/src/Raven.Server/ServerWide/Commands/EditExpirationCommand.cs
@@ -13,11 +13,11 @@ namespace Raven.Server.ServerWide.Commands
             databaseRecord.Expiration = Configuration;
         }
 
-        public EditExpirationCommand() : base(null)
+        public EditExpirationCommand()
         {
         }
 
-        public EditExpirationCommand(ExpirationConfiguration configuration, string databaseName) : base(databaseName)
+        public EditExpirationCommand(ExpirationConfiguration configuration, string databaseName, string guid) : base(databaseName, guid)
         {
             Configuration = configuration;
         }

--- a/src/Raven.Server/ServerWide/Commands/EditRevisionsConfigurationCommand.cs
+++ b/src/Raven.Server/ServerWide/Commands/EditRevisionsConfigurationCommand.cs
@@ -14,11 +14,11 @@ namespace Raven.Server.ServerWide.Commands
             databaseRecord.Revisions = Configuration;
         }
 
-        public EditRevisionsConfigurationCommand() : base(null)
+        public EditRevisionsConfigurationCommand()
         {
         }
 
-        public EditRevisionsConfigurationCommand(RevisionsConfiguration configuration, string databaseName) : base(databaseName)
+        public EditRevisionsConfigurationCommand(RevisionsConfiguration configuration, string databaseName, string guid) : base(databaseName, guid)
         {
             Configuration = configuration;
         }

--- a/src/Raven.Server/ServerWide/Commands/IncrementClusterIdentitiesBatchCommand.cs
+++ b/src/Raven.Server/ServerWide/Commands/IncrementClusterIdentitiesBatchCommand.cs
@@ -14,12 +14,11 @@ namespace Raven.Server.ServerWide.Commands
         public List<string> Identities;
 
         public IncrementClusterIdentitiesBatchCommand()
-            : base(null)
         {
             // for deserialization
         }
 
-        public IncrementClusterIdentitiesBatchCommand(string databaseName, List<string> identities) : base(databaseName)
+        public IncrementClusterIdentitiesBatchCommand(string databaseName, List<string> identities, string guid) : base(databaseName, guid)
         {
             Identities = identities;
             DatabaseName = databaseName;

--- a/src/Raven.Server/ServerWide/Commands/IncrementClusterIdentityCommand.cs
+++ b/src/Raven.Server/ServerWide/Commands/IncrementClusterIdentityCommand.cs
@@ -15,13 +15,12 @@ namespace Raven.Server.ServerWide.Commands
         public string Prefix { get; set; }
 
         public IncrementClusterIdentityCommand()
-            : base(null)
         {
             // for deserialization
         }
 
-        public IncrementClusterIdentityCommand(string databaseName, string prefix)
-            : base(databaseName)
+        public IncrementClusterIdentityCommand(string databaseName, string prefix, string guid)
+            : base(databaseName, guid)
         {
             Prefix = prefix;
         }

--- a/src/Raven.Server/ServerWide/Commands/Indexes/DeleteIndexCommand.cs
+++ b/src/Raven.Server/ServerWide/Commands/Indexes/DeleteIndexCommand.cs
@@ -7,13 +7,13 @@ namespace Raven.Server.ServerWide.Commands.Indexes
     {
         public string IndexName { get; set; }
 
-        public DeleteIndexCommand() : base(null)
+        public DeleteIndexCommand()
         {
             // for deserialization
         }
 
-        public DeleteIndexCommand(string name, string databaseName)
-            : base(databaseName)
+        public DeleteIndexCommand(string name, string databaseName, string guid)
+            : base(databaseName, guid)
         {
             IndexName = name;
         }

--- a/src/Raven.Server/ServerWide/Commands/Indexes/PutAutoIndexCommand.cs
+++ b/src/Raven.Server/ServerWide/Commands/Indexes/PutAutoIndexCommand.cs
@@ -18,12 +18,11 @@ namespace Raven.Server.ServerWide.Commands.Indexes
         public AutoIndexDefinition Definition;
 
         public PutAutoIndexCommand()
-            : base(null)
         {
         }
 
-        public PutAutoIndexCommand(AutoIndexDefinition definition, string databaseName)
-            : base(databaseName)
+        public PutAutoIndexCommand(AutoIndexDefinition definition, string databaseName, string guid)
+            : base(databaseName, guid)
         {
             Definition = definition;
         }
@@ -47,7 +46,7 @@ namespace Raven.Server.ServerWide.Commands.Indexes
             json[nameof(Definition)] = TypeConverter.ToBlittableSupportedType(Definition);
         }
 
-        public static PutAutoIndexCommand Create(AutoIndexDefinitionBase definition, string databaseName)
+        public static PutAutoIndexCommand Create(AutoIndexDefinitionBase definition, string databaseName, string guid)
         {
             var indexType = IndexType.None;
             var map = definition as AutoMapIndexDefinition;
@@ -61,7 +60,7 @@ namespace Raven.Server.ServerWide.Commands.Indexes
             if (indexType == IndexType.None)
                 throw new RachisApplyException($"Invalid definition type: {definition.GetType()}");
 
-            return new PutAutoIndexCommand(GetAutoIndexDefinition(definition, indexType), databaseName);
+            return new PutAutoIndexCommand(GetAutoIndexDefinition(definition, indexType), databaseName, guid);
         }
 
         public static AutoIndexDefinition GetAutoIndexDefinition(AutoIndexDefinitionBase definition, IndexType indexType)

--- a/src/Raven.Server/ServerWide/Commands/Indexes/PutIndexCommand.cs
+++ b/src/Raven.Server/ServerWide/Commands/Indexes/PutIndexCommand.cs
@@ -11,13 +11,13 @@ namespace Raven.Server.ServerWide.Commands.Indexes
     {
         public IndexDefinition Definition;
 
-        public PutIndexCommand() : base(null)
+        public PutIndexCommand()
         {
             // for deserialization
         }
 
-        public PutIndexCommand(IndexDefinition definition, string databaseName)
-            : base(databaseName)
+        public PutIndexCommand(IndexDefinition definition, string databaseName, string guid)
+            : base(databaseName, guid)
         {
             Definition = definition;
         }

--- a/src/Raven.Server/ServerWide/Commands/Indexes/SetIndexLockCommand.cs
+++ b/src/Raven.Server/ServerWide/Commands/Indexes/SetIndexLockCommand.cs
@@ -12,13 +12,13 @@ namespace Raven.Server.ServerWide.Commands.Indexes
 
         public IndexLockMode LockMode;
 
-        public SetIndexLockCommand() : base(null)
+        public SetIndexLockCommand()
         {
             // for deserialization
         }
 
-        public SetIndexLockCommand(string name, IndexLockMode mode, string databaseName)
-            : base(databaseName)
+        public SetIndexLockCommand(string name, IndexLockMode mode, string databaseName, string guid)
+            : base(databaseName, guid)
         {
             IndexName = name;
             LockMode = mode;

--- a/src/Raven.Server/ServerWide/Commands/Indexes/SetIndexPriorityCommand.cs
+++ b/src/Raven.Server/ServerWide/Commands/Indexes/SetIndexPriorityCommand.cs
@@ -10,13 +10,13 @@ namespace Raven.Server.ServerWide.Commands.Indexes
 
         public IndexPriority Priority;
 
-        public SetIndexPriorityCommand() : base(null)
+        public SetIndexPriorityCommand()
         {
             // for deserialization
         }
 
-        public SetIndexPriorityCommand(string name, IndexPriority priority, string databaseName)
-            : base(databaseName)
+        public SetIndexPriorityCommand(string name, IndexPriority priority, string databaseName, string guid)
+            : base(databaseName, guid)
         {
             IndexName = name;
             Priority = priority;

--- a/src/Raven.Server/ServerWide/Commands/Indexes/SetIndexStateCommand.cs
+++ b/src/Raven.Server/ServerWide/Commands/Indexes/SetIndexStateCommand.cs
@@ -12,13 +12,13 @@ namespace Raven.Server.ServerWide.Commands.Indexes
 
         public IndexState State;
 
-        public SetIndexStateCommand() : base(null)
+        public SetIndexStateCommand()
         {
             // for deserialization
         }
 
-        public SetIndexStateCommand([NotNull] string name, IndexState state, string databaseName)
-            : base(databaseName)
+        public SetIndexStateCommand([NotNull] string name, IndexState state, string databaseName, string guid)
+            : base(databaseName, guid)
         {
             if (string.IsNullOrEmpty(name))
                 throw new RachisApplyException($"Index name cannot be null or empty");

--- a/src/Raven.Server/ServerWide/Commands/InstallUpdatedServerCertificateCommand.cs
+++ b/src/Raven.Server/ServerWide/Commands/InstallUpdatedServerCertificateCommand.cs
@@ -1,4 +1,5 @@
-﻿using Raven.Server.ServerWide.Context;
+﻿using System;
+using Raven.Server.ServerWide.Context;
 using Sparrow.Json;
 using Sparrow.Json.Parsing;
 
@@ -14,7 +15,7 @@ namespace Raven.Server.ServerWide.Commands
             // for deserialization
         }
 
-        public InstallUpdatedServerCertificateCommand(string certificate, bool replaceImmediately)
+        public InstallUpdatedServerCertificateCommand(string certificate, bool replaceImmediately, string guid) : base(guid)
         {
             Certificate = certificate;
             ReplaceImmediately = replaceImmediately;
@@ -43,7 +44,7 @@ namespace Raven.Server.ServerWide.Commands
             // for deserialization
         }
 
-        public ConfirmReceiptServerCertificateCommand(string thumbprint)
+        public ConfirmReceiptServerCertificateCommand(string thumbprint) : base(string.Empty)
         {
             Thumbprint = thumbprint;
         }
@@ -68,6 +69,10 @@ namespace Raven.Server.ServerWide.Commands
         {
             AssertClusterAdmin(isClusterAdmin);
         }
+
+        public RecheckStatusOfServerCertificateCommand() : base(string.Empty)
+        {
+        }
     }
 
     public class ConfirmServerCertificateReplacedCommand : CommandBase
@@ -80,7 +85,7 @@ namespace Raven.Server.ServerWide.Commands
             // for deserialization
         }
 
-        public ConfirmServerCertificateReplacedCommand(string thumbprint, string oldThumbprint)
+        public ConfirmServerCertificateReplacedCommand(string thumbprint, string oldThumbprint) : base(string.Empty)
         {
             Thumbprint = thumbprint;
             OldThumbprint = oldThumbprint;
@@ -105,6 +110,10 @@ namespace Raven.Server.ServerWide.Commands
         public override void VerifyCanExecuteCommand(ServerStore store, TransactionOperationContext context, bool isClusterAdmin)
         {
             AssertClusterAdmin(isClusterAdmin);
+        }
+
+        public RecheckStatusOfServerCertificateReplacementCommand() : base(null)
+        {
         }
     }
 }

--- a/src/Raven.Server/ServerWide/Commands/ModifyConflictSolverCommand.cs
+++ b/src/Raven.Server/ServerWide/Commands/ModifyConflictSolverCommand.cs
@@ -7,9 +7,10 @@ namespace Raven.Server.ServerWide.Commands
     {
         public ConflictSolver Solver;
 
-        public ModifyConflictSolverCommand():base(null){}
+        public ModifyConflictSolverCommand()
+        { }
 
-        public ModifyConflictSolverCommand(string databaseName) : base(databaseName){}
+        public ModifyConflictSolverCommand(string databaseName, string guid) : base(databaseName, guid){}
         
         public override string UpdateDatabaseRecord(DatabaseRecord record, long etag)
         {

--- a/src/Raven.Server/ServerWide/Commands/Monitoring/Snmp/UpdateSnmpDatabaseIndexesMappingCommand.cs
+++ b/src/Raven.Server/ServerWide/Commands/Monitoring/Snmp/UpdateSnmpDatabaseIndexesMappingCommand.cs
@@ -17,13 +17,12 @@ namespace Raven.Server.ServerWide.Commands.Monitoring.Snmp
         public List<string> Indexes { get; set; }
 
         public UpdateSnmpDatabaseIndexesMappingCommand()
-            : base(null)
         {
             // for deserialization
         }
 
-        public UpdateSnmpDatabaseIndexesMappingCommand(string databaseName, List<string> indexes)
-            : base(databaseName)
+        public UpdateSnmpDatabaseIndexesMappingCommand(string databaseName, List<string> indexes, string guid)
+            : base(databaseName, guid)
         {
             Indexes = indexes;
         }

--- a/src/Raven.Server/ServerWide/Commands/Monitoring/Snmp/UpdateSnmpDatabasesMappingCommand.cs
+++ b/src/Raven.Server/ServerWide/Commands/Monitoring/Snmp/UpdateSnmpDatabasesMappingCommand.cs
@@ -12,9 +12,9 @@ namespace Raven.Server.ServerWide.Commands.Monitoring.Snmp
             Name = Constants.Monitoring.Snmp.DatabasesMappingKey;
         }
 
-        public UpdateSnmpDatabasesMappingCommand(List<string> databases)
-            : this()
+        public UpdateSnmpDatabasesMappingCommand(List<string> databases, string guid) : base(guid)
         {
+            Name = Constants.Monitoring.Snmp.DatabasesMappingKey;
             Value = databases;
         }
 

--- a/src/Raven.Server/ServerWide/Commands/PeriodicBackup/UpdatePeriodicBackupCommand.cs
+++ b/src/Raven.Server/ServerWide/Commands/PeriodicBackup/UpdatePeriodicBackupCommand.cs
@@ -9,13 +9,13 @@ namespace Raven.Server.ServerWide.Commands.PeriodicBackup
     {
         public PeriodicBackupConfiguration Configuration;
 
-        public UpdatePeriodicBackupCommand() : base(null)
+        public UpdatePeriodicBackupCommand()
         {
             // for deserialization
         }
 
-        public UpdatePeriodicBackupCommand(PeriodicBackupConfiguration configuration, string databaseName) 
-            : base(databaseName)
+        public UpdatePeriodicBackupCommand(PeriodicBackupConfiguration configuration, string databaseName, string guid) 
+            : base(databaseName, guid)
         {
             Configuration = configuration;
         }

--- a/src/Raven.Server/ServerWide/Commands/PeriodicBackup/UpdatePeriodicBackupStatusCommand.cs
+++ b/src/Raven.Server/ServerWide/Commands/PeriodicBackup/UpdatePeriodicBackupStatusCommand.cs
@@ -10,12 +10,12 @@ namespace Raven.Server.ServerWide.Commands.PeriodicBackup
         public PeriodicBackupStatus PeriodicBackupStatus;
 
         // ReSharper disable once UnusedMember.Local
-        private UpdatePeriodicBackupStatusCommand() : base(null)
+        private UpdatePeriodicBackupStatusCommand()
         {
             // for deserialization
         }
 
-        public UpdatePeriodicBackupStatusCommand(string databaseName) : base(databaseName)
+        public UpdatePeriodicBackupStatusCommand(string databaseName, string guid) : base(databaseName, guid)
         {
         }
 

--- a/src/Raven.Server/ServerWide/Commands/PromoteDatabaseNodeCommand.cs
+++ b/src/Raven.Server/ServerWide/Commands/PromoteDatabaseNodeCommand.cs
@@ -7,12 +7,12 @@ namespace Raven.Server.ServerWide.Commands
     {
         public string NodeTag;
 
-        public PromoteDatabaseNodeCommand() : base(null)
+        public PromoteDatabaseNodeCommand()
         {
 
         }
 
-        public PromoteDatabaseNodeCommand(string databaseName) : base(databaseName)
+        public PromoteDatabaseNodeCommand(string databaseName, string guid) : base(databaseName, guid)
         {
 
         }

--- a/src/Raven.Server/ServerWide/Commands/PutValueCommand.cs
+++ b/src/Raven.Server/ServerWide/Commands/PutValueCommand.cs
@@ -30,5 +30,13 @@ namespace Raven.Server.ServerWide.Commands
                 Name.StartsWith(Constants.Certificates.Prefix))
                 throw new InvalidOperationException("Attempted to use PutValueCommand to delete a certificate or license, use dedicated commands for this.");
         }
+
+        protected PutValueCommand(string guid) : base(guid)
+        {
+        }
+
+        protected PutValueCommand()
+        {
+        }
     }
 }

--- a/src/Raven.Server/ServerWide/Commands/RemoveNodeFromClusterCommand.cs
+++ b/src/Raven.Server/ServerWide/Commands/RemoveNodeFromClusterCommand.cs
@@ -11,6 +11,9 @@ namespace Raven.Server.ServerWide.Commands
         public RemoveNodeFromClusterCommand()
         {
         }
+        public RemoveNodeFromClusterCommand(string guid) : base(guid)
+        {
+        }
 
         public override DynamicJsonValue ToJson(JsonOperationContext context)
         {

--- a/src/Raven.Server/ServerWide/Commands/RemoveNodeFromDatabaseCommand.cs
+++ b/src/Raven.Server/ServerWide/Commands/RemoveNodeFromDatabaseCommand.cs
@@ -7,11 +7,11 @@ namespace Raven.Server.ServerWide.Commands
     {
         public string NodeTag;
 
-        public RemoveNodeFromDatabaseCommand() : base(null)
+        public RemoveNodeFromDatabaseCommand()
         {
         }
 
-        public RemoveNodeFromDatabaseCommand(string databaseName) : base(databaseName)
+        public RemoveNodeFromDatabaseCommand(string databaseName, string guid) : base(databaseName, guid)
         {
         }
 

--- a/src/Raven.Server/ServerWide/Commands/Subscriptions/AcknowledgeSubscriptionBatchCommand.cs
+++ b/src/Raven.Server/ServerWide/Commands/Subscriptions/AcknowledgeSubscriptionBatchCommand.cs
@@ -19,9 +19,9 @@ namespace Raven.Server.ServerWide.Commands.Subscriptions
         public DateTime LastTimeServerMadeProgressWithDocuments;
 
         // for serialization
-        private AcknowledgeSubscriptionBatchCommand() : base(null) { }
+        private AcknowledgeSubscriptionBatchCommand() { }
 
-        public AcknowledgeSubscriptionBatchCommand(string databaseName) : base(databaseName)
+        public AcknowledgeSubscriptionBatchCommand(string databaseName, string guid) : base(databaseName, guid)
         {
         }
 

--- a/src/Raven.Server/ServerWide/Commands/Subscriptions/DeleteSubscriptionCommand.cs
+++ b/src/Raven.Server/ServerWide/Commands/Subscriptions/DeleteSubscriptionCommand.cs
@@ -15,9 +15,9 @@ namespace Raven.Server.ServerWide.Commands.Subscriptions
         public string SubscriptionName;
 
         // for serialization
-        private DeleteSubscriptionCommand() : base(null) { }
+        private DeleteSubscriptionCommand() { }
 
-        public DeleteSubscriptionCommand(string databaseName, string subscriptionName) : base(databaseName)
+        public DeleteSubscriptionCommand(string databaseName, string subscriptionName, string guid) : base(databaseName, guid)
         {
             if (string.IsNullOrEmpty(subscriptionName))
                 throw new ArgumentNullException(nameof(subscriptionName));

--- a/src/Raven.Server/ServerWide/Commands/Subscriptions/PutSubscriptionCommand.cs
+++ b/src/Raven.Server/ServerWide/Commands/Subscriptions/PutSubscriptionCommand.cs
@@ -24,9 +24,9 @@ namespace Raven.Server.ServerWide.Commands.Subscriptions
         public string MentorNode;
 
         // for serialization
-        private PutSubscriptionCommand() : base(null) { }
+        private PutSubscriptionCommand() { }
 
-        public PutSubscriptionCommand(string databaseName, string query, string mentor) : base(databaseName)
+        public PutSubscriptionCommand(string databaseName, string query, string mentor, string guid) : base(databaseName, guid)
         {
             Query = query;
             MentorNode = mentor;

--- a/src/Raven.Server/ServerWide/Commands/Subscriptions/ToggleSubscriptionStateCommand.cs
+++ b/src/Raven.Server/ServerWide/Commands/Subscriptions/ToggleSubscriptionStateCommand.cs
@@ -18,9 +18,9 @@ namespace Raven.Server.ServerWide.Commands.Subscriptions
         public bool Disable;
 
         // for serialization
-        private ToggleSubscriptionStateCommand() : base(null) { }
+        private ToggleSubscriptionStateCommand() { }
 
-        public ToggleSubscriptionStateCommand([NotNull] string subscriptionName, bool disable, [NotNull] string databaseName) : base(databaseName)
+        public ToggleSubscriptionStateCommand([NotNull] string subscriptionName, bool disable, string databaseName, string guid) : base(databaseName, guid)
         {
             if (string.IsNullOrEmpty(subscriptionName))
                 throw new RachisApplyException($"Value cannot be null or empty. Param: {nameof(subscriptionName)}");

--- a/src/Raven.Server/ServerWide/Commands/Subscriptions/UpdateSubscriptionClientConnectionTime.cs
+++ b/src/Raven.Server/ServerWide/Commands/Subscriptions/UpdateSubscriptionClientConnectionTime.cs
@@ -13,9 +13,9 @@ namespace Raven.Server.ServerWide.Commands.Subscriptions
         public bool HasHighlyAvailableTasks;
         public DateTime LastClientConnectionTime;
 
-        private UpdateSubscriptionClientConnectionTime():base(null){}
+        private UpdateSubscriptionClientConnectionTime() {}
 
-        public UpdateSubscriptionClientConnectionTime(string databaseName) : base(databaseName)
+        public UpdateSubscriptionClientConnectionTime(string databaseName, string guid) : base(databaseName, guid)
         {
         }
 

--- a/src/Raven.Server/ServerWide/Commands/ToggleTaskStateCommand.cs
+++ b/src/Raven.Server/ServerWide/Commands/ToggleTaskStateCommand.cs
@@ -12,12 +12,12 @@ namespace Raven.Server.ServerWide.Commands
         public OngoingTaskType TaskType;
         public bool Disable;
 
-        public ToggleTaskStateCommand() : base(null)
+        public ToggleTaskStateCommand()
         {
 
         }
 
-        public ToggleTaskStateCommand(long taskId, OngoingTaskType type, bool disable, string databaseName) : base(databaseName)
+        public ToggleTaskStateCommand(long taskId, OngoingTaskType type, bool disable, string databaseName, string guid) : base(databaseName, guid)
         {
             TaskId = taskId;
             TaskType = type;

--- a/src/Raven.Server/ServerWide/Commands/UpdateClusterIdentityCommand.cs
+++ b/src/Raven.Server/ServerWide/Commands/UpdateClusterIdentityCommand.cs
@@ -16,12 +16,11 @@ namespace Raven.Server.ServerWide.Commands
         public Dictionary<string, long> Identities { get; set; }
 
         public UpdateClusterIdentityCommand()
-            : base(null)
         {
         }
 
-        public UpdateClusterIdentityCommand(string databaseName, Dictionary<string, long> identities, bool force)
-            : base(databaseName)
+        public UpdateClusterIdentityCommand(string databaseName, Dictionary<string, long> identities, bool force, string guid)
+            : base(databaseName, guid)
         {
             Identities = new Dictionary<string, long>(identities);
             Force = force;

--- a/src/Raven.Server/ServerWide/Commands/UpdateDatabaseCommand.cs
+++ b/src/Raven.Server/ServerWide/Commands/UpdateDatabaseCommand.cs
@@ -12,7 +12,9 @@ namespace Raven.Server.ServerWide.Commands
         public string DatabaseName;
         public bool ErrorOnDatabaseDoesNotExists;
 
-        protected UpdateDatabaseCommand(string databaseName)
+        protected UpdateDatabaseCommand() { }
+
+        protected UpdateDatabaseCommand(string databaseName, string guid) : base(guid)
         {
             DatabaseName = databaseName;
         }

--- a/src/Raven.Server/ServerWide/Commands/UpdateExternalReplicationCommand.cs
+++ b/src/Raven.Server/ServerWide/Commands/UpdateExternalReplicationCommand.cs
@@ -8,12 +8,12 @@ namespace Raven.Server.ServerWide.Commands
     {
         public ExternalReplication Watcher;
 
-        public UpdateExternalReplicationCommand() : base(null)
+        public UpdateExternalReplicationCommand()
         {
 
         }
 
-        public UpdateExternalReplicationCommand(string databaseName) : base(databaseName)
+        public UpdateExternalReplicationCommand(string databaseName, string guid) : base(databaseName, guid)
         {
 
         }

--- a/src/Raven.Server/ServerWide/Commands/UpdateExternalReplicationStateCommand.cs
+++ b/src/Raven.Server/ServerWide/Commands/UpdateExternalReplicationStateCommand.cs
@@ -9,12 +9,12 @@ namespace Raven.Server.ServerWide.Commands
     {
         public ExternalReplicationState ExternalReplicationState { get; set; }
 
-        private UpdateExternalReplicationStateCommand() : base(null)
+        private UpdateExternalReplicationStateCommand()
         {
             // for deserialization
         }
 
-        public UpdateExternalReplicationStateCommand(string databaseName) : base(databaseName)
+        public UpdateExternalReplicationStateCommand(string databaseName, string guid) : base(databaseName, guid)
         {
         }
 

--- a/src/Raven.Server/ServerWide/Commands/UpdateTopologyCommand.cs
+++ b/src/Raven.Server/ServerWide/Commands/UpdateTopologyCommand.cs
@@ -7,12 +7,12 @@ namespace Raven.Server.ServerWide.Commands
     {
         public DatabaseTopology Topology;
 
-        public UpdateTopologyCommand() : base(null)
+        public UpdateTopologyCommand()
         {
             //
         }
 
-        public UpdateTopologyCommand(string databaseName) : base(databaseName)
+        public UpdateTopologyCommand(string databaseName, string guid) : base(databaseName, guid)
         {
         }
 

--- a/src/Raven.Server/ServerWide/Commands/UpdateValueCommand.cs
+++ b/src/Raven.Server/ServerWide/Commands/UpdateValueCommand.cs
@@ -9,6 +9,7 @@ namespace Raven.Server.ServerWide.Commands
 
         public T Value;
 
+        protected UpdateValueCommand() { }
         public override DynamicJsonValue ToJson(JsonOperationContext context)
         {
             var djv = base.ToJson(context);
@@ -21,5 +22,9 @@ namespace Raven.Server.ServerWide.Commands
         public abstract object ValueToJson();
 
         public abstract BlittableJsonReaderObject GetUpdatedValue(JsonOperationContext context, BlittableJsonReaderObject previousValue);
+
+        protected UpdateValueCommand(string guid) : base(guid)
+        {
+        }
     }
 }

--- a/src/Raven.Server/ServerWide/Commands/UpdateValueForDatabaseCommand.cs
+++ b/src/Raven.Server/ServerWide/Commands/UpdateValueForDatabaseCommand.cs
@@ -12,6 +12,8 @@ namespace Raven.Server.ServerWide.Commands
     {
         public string DatabaseName { get; set; }
 
+        protected UpdateValueForDatabaseCommand() { }
+
         public abstract string GetItemId();
 
         public abstract void FillJson(DynamicJsonValue json);
@@ -64,7 +66,7 @@ namespace Raven.Server.ServerWide.Commands
             return null;
         }
 
-        protected UpdateValueForDatabaseCommand(string databaseName)
+        protected UpdateValueForDatabaseCommand(string databaseName, string guid) : base(guid)
         {
             DatabaseName = databaseName;
         }

--- a/src/Raven.Server/ServerWide/Maintenance/ClusterObserver.cs
+++ b/src/Raven.Server/ServerWide/Maintenance/ClusterObserver.cs
@@ -227,7 +227,7 @@ namespace Raven.Server.ServerWide.Maintenance
                             {
                                 AddToDecisionLog(database, updateReason);
 
-                                var cmd = new UpdateTopologyCommand(database)
+                                var cmd = new UpdateTopologyCommand(database, Guid.NewGuid().ToString())
                                 {
                                     Topology = databaseTopology,
                                     RaftCommandIndex = etag
@@ -291,7 +291,7 @@ namespace Raven.Server.ServerWide.Maintenance
 
                 if (cleanUpState != null)
                 {
-                    var cmd = new CleanUpClusterStateCommand
+                    var cmd = new CleanUpClusterStateCommand(Guid.NewGuid().ToString())
                     {
                         ClusterTransactionsCleanup = cleanUpState
                     };
@@ -372,7 +372,7 @@ namespace Raven.Server.ServerWide.Maintenance
 
                 if (state == IndexState.Idle && difference >= timeToWaitBeforeDeletingAutoIndexMarkedAsIdle.AsTimeSpan)
                 {
-                    await _engine.PutAsync(new DeleteIndexCommand(kvp.Key, databaseState.Name));
+                    await _engine.PutAsync(new DeleteIndexCommand(kvp.Key, databaseState.Name, Guid.NewGuid().ToString()));
 
                     AddToDecisionLog(databaseState.Name, $"Deleting idle auto-index '{kvp.Key}' because last query time value is '{difference}' and threshold is set to '{timeToWaitBeforeDeletingAutoIndexMarkedAsIdle.AsTimeSpan}'.");
 
@@ -381,7 +381,7 @@ namespace Raven.Server.ServerWide.Maintenance
 
                 if (state == IndexState.Normal && difference >= timeToWaitBeforeMarkingAutoIndexAsIdle.AsTimeSpan)
                 {
-                    await _engine.PutAsync(new SetIndexStateCommand(kvp.Key, IndexState.Idle, databaseState.Name));
+                    await _engine.PutAsync(new SetIndexStateCommand(kvp.Key, IndexState.Idle, databaseState.Name, Guid.NewGuid().ToString()));
 
                     AddToDecisionLog(databaseState.Name, $"Marking auto-index '{kvp.Key}' as idle because last query time value is '{difference}' and threshold is set to '{timeToWaitBeforeMarkingAutoIndexAsIdle.AsTimeSpan}'.");
 
@@ -390,7 +390,7 @@ namespace Raven.Server.ServerWide.Maintenance
 
                 if (state == IndexState.Idle && difference < timeToWaitBeforeMarkingAutoIndexAsIdle.AsTimeSpan)
                 {
-                    await _engine.PutAsync(new SetIndexStateCommand(kvp.Key, IndexState.Normal, databaseState.Name));
+                    await _engine.PutAsync(new SetIndexStateCommand(kvp.Key, IndexState.Normal, databaseState.Name, Guid.NewGuid().ToString()));
 
                     AddToDecisionLog(databaseState.Name, $"Marking idle auto-index '{kvp.Key}' as normal because last query time value is '{difference}' and threshold is set to '{timeToWaitBeforeMarkingAutoIndexAsIdle.AsTimeSpan}'.");
                 }
@@ -608,10 +608,9 @@ namespace Raven.Server.ServerWide.Maintenance
                     databaseTopology.Promotables.Add(node);
                     databaseTopology.DemotionReasons[node] = $"Just replaced the promotable node {promotable}";
                     databaseTopology.PromotablesStatus[node] = DatabasePromotionStatus.WaitingForFirstPromotion;
-                    var deletionCmd = new DeleteDatabaseCommand
+                    var deletionCmd = new DeleteDatabaseCommand(dbName, Guid.NewGuid().ToString())
                     {
                         ErrorOnDatabaseDoesNotExists = false,
-                        DatabaseName = dbName,
                         FromNodes = new[] { promotable },
                         HardDelete = _hardDeleteOnReplacement,
                         UpdateReplicationFactor = false
@@ -923,10 +922,9 @@ namespace Raven.Server.ServerWide.Maintenance
             LogMessage($"We reached the replication factor on database '{dbName}', so we try to remove redundant nodes from {string.Join(", ", nodesToDelete)}.",
                 info: false);
 
-            var deletionCmd = new DeleteDatabaseCommand
+            var deletionCmd = new DeleteDatabaseCommand(dbName, Guid.NewGuid().ToString())
             {
                 ErrorOnDatabaseDoesNotExists = false,
-                DatabaseName = dbName,
                 FromNodes = nodesToDelete.ToArray(),
                 HardDelete = _hardDeleteOnReplacement,
                 UpdateReplicationFactor = false,

--- a/src/Raven.Server/ServerWide/ServerStore.cs
+++ b/src/Raven.Server/ServerWide/ServerStore.cs
@@ -1856,7 +1856,7 @@ namespace Raven.Server.ServerWide
         }
 
         public Task<(long Index, object Result)> WriteDatabaseRecordAsync(
-            string databaseName, DatabaseRecord record, long? index,
+            string databaseName, DatabaseRecord record, long? index, string guid,
             Dictionary<string, BlittableJsonReaderObject> databaseValues = null, bool isRestore = false)
         {
             if (databaseValues == null)
@@ -1873,7 +1873,7 @@ namespace Raven.Server.ServerWide
                 LeadersTicks = _engine.CurrentLeader?.LeaderShipDuration ?? 0
             };
 
-            var addDatabaseCommand = new AddDatabaseCommand(string.Empty) // TODO: pass a proper guid
+            var addDatabaseCommand = new AddDatabaseCommand(guid)
             {
                 Name = databaseName,
                 RaftCommandIndex = index,
@@ -2213,6 +2213,7 @@ namespace Raven.Server.ServerWide
             private readonly BlittableJsonReaderObject _command;
             private bool _reachedLeader;
             public override bool IsReadRequest => false;
+            public override bool IsClusterCommand => true;
             public bool HasReachLeader() => _reachedLeader;
             private readonly string _source;
             private readonly string _commandType;

--- a/src/Raven.Server/Smuggler/Documents/Processors/IndexProcessor.cs
+++ b/src/Raven.Server/Smuggler/Documents/Processors/IndexProcessor.cs
@@ -57,11 +57,11 @@ namespace Raven.Server.Smuggler.Documents.Processors
             {
                 case IndexType.AutoMap:
                     var autoMapIndexDefinition = (AutoMapIndexDefinition)definition;
-                    AsyncHelpers.RunSync(() => database.IndexStore.CreateIndex(autoMapIndexDefinition));
+                    AsyncHelpers.RunSync(() => database.IndexStore.CreateIndex(autoMapIndexDefinition, Guid.NewGuid().ToString()));
                     break;
                 case IndexType.AutoMapReduce:
                     var autoMapReduceIndexDefinition = (AutoMapReduceIndexDefinition)definition;
-                    AsyncHelpers.RunSync(() => database.IndexStore.CreateIndex(autoMapReduceIndexDefinition));
+                    AsyncHelpers.RunSync(() => database.IndexStore.CreateIndex(autoMapReduceIndexDefinition, Guid.NewGuid().ToString()));
                     break;
                 case IndexType.Map:
                 case IndexType.MapReduce:

--- a/src/Raven.Server/Smuggler/Migration/Migrator.cs
+++ b/src/Raven.Server/Smuggler/Migration/Migrator.cs
@@ -340,7 +340,7 @@ namespace Raven.Server.Smuggler.Migration
                     }
                 };
 
-                var (index, _) = await _serverStore.WriteDatabaseRecordAsync(databaseName, databaseRecord, null);
+                var (index, _) = await _serverStore.WriteDatabaseRecordAsync(databaseName, databaseRecord, null, Guid.NewGuid().ToString());
                 await _serverStore.Cluster.WaitForIndexNotification(index);
             }
         }

--- a/src/Raven.Server/Web/RequestHandler.cs
+++ b/src/Raven.Server/Web/RequestHandler.cs
@@ -253,6 +253,11 @@ namespace Raven.Server.Web
             return HttpContext.WebSockets.IsWebSocketRequest;
         }
 
+        public string GetRaftGuidFromHeaders()
+        {
+            return GetStringFromHeaders(Constants.Headers.RaftCommandGuid) ?? Guid.NewGuid().ToString();
+        }
+
         protected string GetStringFromHeaders(string name)
         {
             var headers = HttpContext.Request.Headers[name];

--- a/src/Raven.Server/Web/Studio/SampleDataHandler.cs
+++ b/src/Raven.Server/Web/Studio/SampleDataHandler.cs
@@ -43,7 +43,7 @@ namespace Raven.Server.Web.Studio
                             Disabled = false
                         }
                     }
-                }, Database.Name, GetStringQueryString("guid", required: false));
+                }, Database.Name, GetRaftGuidFromHeaders());
 
                 var (index, _) = await ServerStore.SendToLeaderAsync(editRevisions);
                 await Database.RachisLogIndexNotifications.WaitForIndexNotification(index, Database.ServerStore.Engine.OperationTimeout);

--- a/src/Raven.Server/Web/Studio/SampleDataHandler.cs
+++ b/src/Raven.Server/Web/Studio/SampleDataHandler.cs
@@ -43,7 +43,7 @@ namespace Raven.Server.Web.Studio
                             Disabled = false
                         }
                     }
-                }, Database.Name);
+                }, Database.Name, GetStringQueryString("guid", required: false));
 
                 var (index, _) = await ServerStore.SendToLeaderAsync(editRevisions);
                 await Database.RachisLogIndexNotifications.WaitForIndexNotification(index, Database.ServerStore.Engine.OperationTimeout);

--- a/src/Raven.Server/Web/System/AdminDatabasesHandler.cs
+++ b/src/Raven.Server/Web/System/AdminDatabasesHandler.cs
@@ -622,7 +622,7 @@ namespace Raven.Server.Web.System
                 long index = -1;
                 foreach (var name in parameters.DatabaseNames)
                 {
-                    var (newIndex, _) = await ServerStore.DeleteDatabaseAsync(name, parameters.HardDelete, parameters.FromNodes);
+                    var (newIndex, _) = await ServerStore.DeleteDatabaseAsync(name, parameters.HardDelete, parameters.FromNodes, Guid.NewGuid().ToString());
                     index = newIndex;
                 }
                 await ServerStore.Cluster.WaitForIndexNotification(index);
@@ -809,7 +809,7 @@ namespace Raven.Server.Web.System
 
             using (ServerStore.ContextPool.AllocateOperationContext(out TransactionOperationContext context))
             {
-                var (index, _) = await ServerStore.PromoteDatabaseNode(name, nodeTag);
+                var (index, _) = await ServerStore.PromoteDatabaseNode(name, nodeTag, GetStringQueryString("guid", required: false));
                 await ServerStore.Cluster.WaitForIndexNotification(index);
 
                 HttpContext.Response.StatusCode = (int)HttpStatusCode.OK;
@@ -907,7 +907,7 @@ namespace Raven.Server.Web.System
                 {
                     var databaseRecord = ServerStore.Cluster.ReadDatabase(context, name, out _);
 
-                    var (index, _) = await ServerStore.ModifyConflictSolverAsync(name, conflictResolver);
+                    var (index, _) = await ServerStore.ModifyConflictSolverAsync(name, conflictResolver, GetStringQueryString("guid", required: false));
                     await ServerStore.Cluster.WaitForIndexNotification(index);
 
                     HttpContext.Response.StatusCode = (int)HttpStatusCode.Created;

--- a/src/Raven.Server/Web/System/AdminDatabasesHandler.cs
+++ b/src/Raven.Server/Web/System/AdminDatabasesHandler.cs
@@ -110,6 +110,7 @@ namespace Raven.Server.Web.System
             var name = GetQueryStringValueAndAssertIfSingleAndNotEmpty("name").Trim();
             var node = GetStringQueryString("node", false);
             var mentor = GetStringQueryString("mentor", false);
+            var guid = GetStringFromHeaders(Constants.Headers.RaftCommandGuid) ?? Guid.NewGuid().ToString();
 
             string errorMessage;
             if (ResourceNameValidator.IsValidResourceName(name, ServerStore.Configuration.Core.DataDirectory.FullPath, out errorMessage) == false)
@@ -180,7 +181,7 @@ namespace Raven.Server.Web.System
                 }
 
                 databaseRecord.Topology.ReplicationFactor++;
-                var (newIndex, _) = await ServerStore.WriteDatabaseRecordAsync(name, databaseRecord, index);
+                var (newIndex, _) = await ServerStore.WriteDatabaseRecordAsync(name, databaseRecord, index, guid);
 
                 await WaitForExecutionOnSpecificNode(context, clusterTopology, node, newIndex);
 
@@ -211,6 +212,8 @@ namespace Raven.Server.Web.System
             if (ResourceNameValidator.IsValidResourceName(name, ServerStore.Configuration.Core.DataDirectory.FullPath, out string errorMessage) == false)
                 throw new BadRequestException(errorMessage);
 
+            var guid = GetStringFromHeaders(Constants.Headers.RaftCommandGuid) ?? Guid.NewGuid().ToString();
+
             if (LoggingSource.AuditLog.IsInfoEnabled)
             {
                 var clientCert = GetCurrentCertificate();
@@ -218,7 +221,6 @@ namespace Raven.Server.Web.System
                 var auditLog = LoggingSource.AuditLog.GetLogger("DbMgmt", "Audit");
                 auditLog.Info($"Database {name} PUT by {clientCert?.Subject} ({clientCert?.Thumbprint})");
             }
-
 
             ServerStore.EnsureNotPassive();
             using (ServerStore.ContextPool.AllocateOperationContext(out TransactionOperationContext context))
@@ -256,7 +258,8 @@ namespace Raven.Server.Web.System
                         RecreateIndexes(databaseRecord);
                 }
 
-                var (newIndex, topology, nodeUrlsAddedTo) = await CreateDatabase(name, databaseRecord, context, replicationFactor, index);
+
+                var (newIndex, topology, nodeUrlsAddedTo) = await CreateDatabase(name, databaseRecord, context, replicationFactor, index, guid);
 
                 HttpContext.Response.StatusCode = (int)HttpStatusCode.Created;
 
@@ -343,7 +346,7 @@ namespace Raven.Server.Web.System
 
         }
 
-        private async Task<(long, DatabaseTopology, List<string>)> CreateDatabase(string name, DatabaseRecord databaseRecord, TransactionOperationContext context, int replicationFactor, long? index)
+        private async Task<(long, DatabaseTopology, List<string>)> CreateDatabase(string name, DatabaseRecord databaseRecord, TransactionOperationContext context, int replicationFactor, long? index, string guid)
         {
             var existingDatabaseRecord = ServerStore.Cluster.ReadDatabase(context, name, out long _);
 
@@ -385,7 +388,8 @@ namespace Raven.Server.Web.System
                 databaseRecord.Topology.ReplicationFactor = Math.Min(replicationFactor, clusterTopology.AllNodes.Count);
             }
 
-            var (newIndex, result) = await ServerStore.WriteDatabaseRecordAsync(name, databaseRecord, index);
+
+            var (newIndex, result) = await ServerStore.WriteDatabaseRecordAsync(name, databaseRecord, index, guid);
             await ServerStore.WaitForCommitIndexChange(RachisConsensus.CommitIndexModification.GreaterOrEqual, newIndex);
 
             var members = (List<string>)result;
@@ -699,6 +703,7 @@ namespace Raven.Server.Web.System
         {
             var name = GetQueryStringValueAndAssertIfSingleAndNotEmpty("name");
             var enable = GetBoolValueQueryString("enable") ?? true;
+            var guid = GetStringFromHeaders(Constants.Headers.RaftCommandGuid) ?? Guid.NewGuid().ToString();
 
             using (ServerStore.ContextPool.AllocateOperationContext(out TransactionOperationContext context))
             {
@@ -718,7 +723,7 @@ namespace Raven.Server.Web.System
 
                 databaseRecord.Topology.DynamicNodesDistribution = enable;
 
-                var (commandResultIndex, _) = await ServerStore.WriteDatabaseRecordAsync(name, databaseRecord, index);
+                var (commandResultIndex, _) = await ServerStore.WriteDatabaseRecordAsync(name, databaseRecord, index, guid);
                 await ServerStore.Cluster.WaitForIndexNotification(commandResultIndex);
 
                 NoContentStatus();
@@ -766,7 +771,7 @@ namespace Raven.Server.Web.System
 
                     databaseRecord.Disabled = disable;
 
-                    var (index, _) = await ServerStore.WriteDatabaseRecordAsync(name, databaseRecord, null);
+                    var (index, _) = await ServerStore.WriteDatabaseRecordAsync(name, databaseRecord, null, Guid.NewGuid().ToString());
                     await ServerStore.Cluster.WaitForIndexNotification(index);
 
                     resultList.Add(new DynamicJsonValue
@@ -809,7 +814,7 @@ namespace Raven.Server.Web.System
 
             using (ServerStore.ContextPool.AllocateOperationContext(out TransactionOperationContext context))
             {
-                var (index, _) = await ServerStore.PromoteDatabaseNode(name, nodeTag, GetStringQueryString("guid", required: false));
+                var (index, _) = await ServerStore.PromoteDatabaseNode(name, nodeTag, GetRaftGuidFromHeaders());
                 await ServerStore.Cluster.WaitForIndexNotification(index);
 
                 HttpContext.Response.StatusCode = (int)HttpStatusCode.OK;
@@ -907,7 +912,7 @@ namespace Raven.Server.Web.System
                 {
                     var databaseRecord = ServerStore.Cluster.ReadDatabase(context, name, out _);
 
-                    var (index, _) = await ServerStore.ModifyConflictSolverAsync(name, conflictResolver, GetStringQueryString("guid", required: false));
+                    var (index, _) = await ServerStore.ModifyConflictSolverAsync(name, conflictResolver, GetRaftGuidFromHeaders());
                     await ServerStore.Cluster.WaitForIndexNotification(index);
 
                     HttpContext.Response.StatusCode = (int)HttpStatusCode.Created;
@@ -1075,7 +1080,7 @@ namespace Raven.Server.Web.System
             using (ServerStore.ContextPool.AllocateOperationContext(out TransactionOperationContext context))
             {
                 context.OpenReadTransaction();
-                await CreateDatabase(databaseName, configuration.DatabaseRecord, context, 1, null);
+                await CreateDatabase(databaseName, configuration.DatabaseRecord, context, 1, null, Guid.NewGuid().ToString());
             }
 
             var database = await ServerStore.DatabasesLandlord.TryGetOrCreateResourceStore(databaseName, true);

--- a/src/Raven.Server/Web/System/CompareExchangeHandler.cs
+++ b/src/Raven.Server/Web/System/CompareExchangeHandler.cs
@@ -121,6 +121,7 @@ namespace Raven.Server.Web.System
         public async Task PutCompareExchangeValue()
         {
             var key = GetStringQueryString("key");
+            var guid = GetStringQueryString("guid", required: false);
 
             // ReSharper disable once PossibleInvalidOperationException
             var index = GetLongQueryString("index", true).Value;
@@ -130,21 +131,19 @@ namespace Raven.Server.Web.System
             using (ServerStore.ContextPool.AllocateOperationContext(out TransactionOperationContext context))
             {
                 var updateJson = await context.ReadForMemoryAsync(RequestBodyStream(), "read-unique-value");
-                var command = new AddOrUpdateCompareExchangeCommand(Database.Name, key, updateJson, index, context);
+                var command = new AddOrUpdateCompareExchangeCommand(Database.Name, key, updateJson, index, context, guid);
                 using (var writer = new BlittableJsonTextWriter(context, ResponseBodyStream()))
                 {
                     (var raftIndex, var response) = await ServerStore.SendToLeaderAsync(context, command);
                     await ServerStore.Cluster.WaitForIndexNotification(raftIndex);
-                    using (context.OpenReadTransaction())
+
+                    var result = (CompareExchangeCommandBase.CompareExchangeResult)response;
+                    context.Write(writer, new DynamicJsonValue
                     {
-                        var result = (CompareExchangeCommandBase.CompareExchangeResult)response;
-                        context.Write(writer, new DynamicJsonValue
-                        {
-                            [nameof(CompareExchangeResult<object>.Index)] = result.Index,
-                            [nameof(CompareExchangeResult<object>.Value)] = result.Value,
-                            [nameof(CompareExchangeResult<object>.Successful)] = result.Index == raftIndex
-                        });
-                    }
+                        [nameof(CompareExchangeResult<object>.Index)] = result.Index,
+                        [nameof(CompareExchangeResult<object>.Value)] = result.Value,
+                        [nameof(CompareExchangeResult<object>.Successful)] = result.Index == raftIndex
+                    });
                 }
             }
         }
@@ -153,6 +152,7 @@ namespace Raven.Server.Web.System
         public async Task DeleteCompareExchangeValue()
         {
             var key = GetStringQueryString("key");
+            var guid = GetStringQueryString("guid", required: false);
 
             // ReSharper disable once PossibleInvalidOperationException
             var index = GetLongQueryString("index", true).Value;
@@ -161,21 +161,19 @@ namespace Raven.Server.Web.System
 
             using (ServerStore.ContextPool.AllocateOperationContext(out TransactionOperationContext context))
             {
-                var command = new RemoveCompareExchangeCommand(Database.Name, key, index, context);
+                var command = new RemoveCompareExchangeCommand(Database.Name, key, index, context, guid);
                 using (var writer = new BlittableJsonTextWriter(context, ResponseBodyStream()))
                 {
                     (var raftIndex, var response) = await ServerStore.SendToLeaderAsync(context, command);
                     await ServerStore.Cluster.WaitForIndexNotification(raftIndex);
-                    using (context.OpenReadTransaction())
+
+                    var result = (CompareExchangeCommandBase.CompareExchangeResult)response;
+                    context.Write(writer, new DynamicJsonValue
                     {
-                        var result = (CompareExchangeCommandBase.CompareExchangeResult)response;
-                        context.Write(writer, new DynamicJsonValue
-                        {
-                            [nameof(CompareExchangeResult<object>.Index)] = result.Index,
-                            [nameof(CompareExchangeResult<object>.Value)] = result.Value,
-                            [nameof(CompareExchangeResult<object>.Successful)] = result.Index == raftIndex
-                        });
-                    }
+                        [nameof(CompareExchangeResult<object>.Index)] = result.Index,
+                        [nameof(CompareExchangeResult<object>.Value)] = result.Value,
+                        [nameof(CompareExchangeResult<object>.Successful)] = result.Index == raftIndex
+                    });
                 }
             }
         }

--- a/src/Raven.Server/Web/System/CompareExchangeHandler.cs
+++ b/src/Raven.Server/Web/System/CompareExchangeHandler.cs
@@ -121,7 +121,7 @@ namespace Raven.Server.Web.System
         public async Task PutCompareExchangeValue()
         {
             var key = GetStringQueryString("key");
-            var guid = GetStringQueryString("guid", required: false);
+            var guid = GetRaftGuidFromHeaders();
 
             // ReSharper disable once PossibleInvalidOperationException
             var index = GetLongQueryString("index", true).Value;
@@ -152,7 +152,7 @@ namespace Raven.Server.Web.System
         public async Task DeleteCompareExchangeValue()
         {
             var key = GetStringQueryString("key");
-            var guid = GetStringQueryString("guid", required: false);
+            var guid = GetRaftGuidFromHeaders();
 
             // ReSharper disable once PossibleInvalidOperationException
             var index = GetLongQueryString("index", true).Value;

--- a/src/Raven.Server/Web/System/TestConnectionHandler.cs
+++ b/src/Raven.Server/Web/System/TestConnectionHandler.cs
@@ -162,5 +162,6 @@ namespace Raven.Server.Web.System
         }
 
         public override bool IsReadRequest => true;
+        public override bool IsClusterCommand => false;
     }
 }

--- a/src/Voron/Data/Tables/Table.cs
+++ b/src/Voron/Data/Tables/Table.cs
@@ -1159,6 +1159,21 @@ namespace Voron.Data.Tables
         }
 
 
+        public TableValueHolder ReadFirst(TableSchema.FixedSizeSchemaIndexDef index)
+        {
+            var fst = GetFixedSizeTree(index);
+
+            using (var it = fst.Iterate())
+            {
+                if (it.Seek(0) == false)
+                    return null;
+
+                var result = new TableValueHolder();
+                GetTableValueReader(it, out result.Reader);
+                return result;
+            }
+        }
+
         public bool SeekOnePrimaryKey(Slice slice, out TableValueReader reader)
         {
             Debug.Assert(slice.Options != SliceOptions.Key, "Should be called with only AfterAllKeys or BeforeAllKeys");

--- a/test/FastTests/Issues/RavenDB-6341.cs
+++ b/test/FastTests/Issues/RavenDB-6341.cs
@@ -17,7 +17,8 @@ namespace FastTests.Issues
             nameof(RavenCommand<object>.Result),
             nameof(RavenCommand<object>.FailedNodes),
             nameof(RavenCommand<object>.StatusCode),
-            nameof(RavenCommand<object>.CancellationToken)
+            nameof(RavenCommand<object>.CancellationToken),
+            nameof(RavenCommand<object>.Guid)
         };
 
         [Fact]

--- a/test/FastTests/Server/Documents/Indexing/Auto/BasicAutoMapIndexing.cs
+++ b/test/FastTests/Server/Documents/Indexing/Auto/BasicAutoMapIndexing.cs
@@ -1422,7 +1422,7 @@ namespace FastTests.Server.Documents.Indexing.Auto
 
                 modifySettings(databaseRecord);
 
-                var (etag, _) = await Server.ServerStore.WriteDatabaseRecordAsync(databaseName, databaseRecord, null);
+                var (etag, _) = await Server.ServerStore.WriteDatabaseRecordAsync(databaseName, databaseRecord, null, Guid.NewGuid().ToString());
                 await Server.ServerStore.Cluster.WaitForIndexNotification(etag);
             }
         }

--- a/test/FastTests/Server/Documents/Indexing/Auto/BasicAutoMapIndexing.cs
+++ b/test/FastTests/Server/Documents/Indexing/Auto/BasicAutoMapIndexing.cs
@@ -102,8 +102,8 @@ namespace FastTests.Server.Documents.Indexing.Auto
                 var index2 = await database.IndexStore.CreateIndex(new AutoMapIndexDefinition("Users", new[] { name2 }));
                 Assert.NotNull(index2);
 
-                var task1 = database.IndexStore.SetLock(index2.Name, IndexLockMode.LockedError);
-                var task2 = database.IndexStore.SetPriority(index2.Name, IndexPriority.Low);
+                var task1 = database.IndexStore.SetLock(index2.Name, IndexLockMode.LockedError, Guid.NewGuid().ToString());
+                var task2 = database.IndexStore.SetPriority(index2.Name, IndexPriority.Low, Guid.NewGuid().ToString());
                 index2.SetState(IndexState.Disabled);
                 var task = Task.WhenAll(task1, task2);
 
@@ -174,7 +174,7 @@ namespace FastTests.Server.Documents.Indexing.Auto
 
             Assert.Equal(2, database.IndexStore.GetIndexesForCollection("Users").Count());
 
-            await database.IndexStore.DeleteIndex(index1.Name);
+            await database.IndexStore.DeleteIndex(index1.Name, Guid.NewGuid().ToString());
 
             if (index1.Configuration.RunInMemory == false)
                 Assert.True(SpinWait.SpinUntil(() => Directory.Exists(path1) == false, TimeSpan.FromSeconds(5)));
@@ -183,7 +183,7 @@ namespace FastTests.Server.Documents.Indexing.Auto
 
             Assert.Equal(1, indexes.Count);
 
-            await database.IndexStore.DeleteIndex(index2.Name);
+            await database.IndexStore.DeleteIndex(index2.Name, Guid.NewGuid().ToString());
 
             if (index1.Configuration.RunInMemory == false)
                 Assert.True(SpinWait.SpinUntil(() => Directory.Exists(path2) == false, TimeSpan.FromSeconds(5)));
@@ -955,7 +955,7 @@ namespace FastTests.Server.Documents.Indexing.Auto
             {
                 var index0 = await database.IndexStore.CreateIndex(new AutoMapIndexDefinition("Users", new[] { new AutoIndexField { Name = "Job", Storage = FieldStorage.No } }));
 
-                await database.ServerStore.Engine.PutAsync(new SetIndexStateCommand(index0.Name, IndexState.Idle, database.Name));
+                await database.ServerStore.Engine.PutAsync(new SetIndexStateCommand(index0.Name, IndexState.Idle, database.Name, Guid.NewGuid().ToString()));
 
                 var now = database.Time.GetUtcNow();
                 using (database.ServerStore.ContextPool.AllocateOperationContext(out TransactionOperationContext context))
@@ -1129,7 +1129,7 @@ namespace FastTests.Server.Documents.Indexing.Auto
                 WaitForIndex(database, index1.Name, index => index.State == IndexState.Normal);
                 WaitForIndex(database, index2.Name, index => index.State == IndexState.Idle);
 
-                await database.ServerStore.Engine.PutAsync(new SetIndexStateCommand(index2.Name, IndexState.Idle, database.Name));
+                await database.ServerStore.Engine.PutAsync(new SetIndexStateCommand(index2.Name, IndexState.Idle, database.Name, Guid.NewGuid().ToString()));
 
                 now = database.Time.GetUtcNow();
                 database.Time.UtcDateTime = () =>
@@ -1189,8 +1189,8 @@ namespace FastTests.Server.Documents.Indexing.Auto
                 WaitForIndex(database, index1.Name, index => index.State == IndexState.Idle);
                 WaitForIndex(database, index2.Name, index => index.State == IndexState.Idle);
 
-                await database.ServerStore.Engine.PutAsync(new SetIndexStateCommand(index1.Name, IndexState.Idle, database.Name));
-                await database.ServerStore.Engine.PutAsync(new SetIndexStateCommand(index2.Name, IndexState.Idle, database.Name));
+                await database.ServerStore.Engine.PutAsync(new SetIndexStateCommand(index1.Name, IndexState.Idle, database.Name, Guid.NewGuid().ToString()));
+                await database.ServerStore.Engine.PutAsync(new SetIndexStateCommand(index2.Name, IndexState.Idle, database.Name, Guid.NewGuid().ToString()));
 
 
                 now = database.Time.GetUtcNow();
@@ -1399,7 +1399,7 @@ namespace FastTests.Server.Documents.Indexing.Auto
                 Assert.Equal(IndexState.Error, index.State);
                 Assert.Equal(indexSafeName, IndexDefinitionBase.GetIndexNameSafeForFileSystem(index.Name));
 
-                await database.IndexStore.DeleteIndex(index.Name);
+                await database.IndexStore.DeleteIndex(index.Name, Guid.NewGuid().ToString());
 
                 for (int i = 0; i < 5; i++)
                 {

--- a/test/FastTests/Server/Documents/Indexing/Auto/BasicAutoMapReduceIndexing.cs
+++ b/test/FastTests/Server/Documents/Indexing/Auto/BasicAutoMapReduceIndexing.cs
@@ -259,8 +259,8 @@ namespace FastTests.Server.Documents.Indexing.Auto
                 var index = await database.IndexStore.CreateIndex(new AutoMapReduceIndexDefinition("Users", new[] { count, sum }, new[] { location }));
                 Assert.NotNull(index);
 
-                var task1 = database.IndexStore.SetLock(index.Name, IndexLockMode.LockedError);
-                var task2 = database.IndexStore.SetPriority(index.Name, IndexPriority.High);
+                var task1 = database.IndexStore.SetLock(index.Name, IndexLockMode.LockedError, Guid.NewGuid().ToString());
+                var task2 = database.IndexStore.SetPriority(index.Name, IndexPriority.High, Guid.NewGuid().ToString());
                 index.SetState(IndexState.Disabled);
                 var task = Task.WhenAll(task1, task2);
                 

--- a/test/FastTests/Server/Documents/Revisions/RevisionsTests.cs
+++ b/test/FastTests/Server/Documents/Revisions/RevisionsTests.cs
@@ -809,6 +809,8 @@ namespace FastTests.Server.Documents.Revisions
                     _parameters = EntityToBlittable.ConvertCommandToBlittable(parameters, context);
                 }
 
+                public override bool IsClusterCommand => false;
+
                 public override HttpRequestMessage CreateRequest(JsonOperationContext ctx, ServerNode node, out string url)
                 {
                     url = $"{node.Url}/databases/{node.Database}/admin/revisions";

--- a/test/FastTests/Server/Replication/ReplicationTestBase.cs
+++ b/test/FastTests/Server/Replication/ReplicationTestBase.cs
@@ -322,6 +322,7 @@ namespace FastTests.Server.Replication
         private class GetConnectionFailuresCommand : RavenCommand<Dictionary<string, string[]>>
         {
             public override bool IsReadRequest => true;
+            public override bool IsClusterCommand => false;
 
             public override HttpRequestMessage CreateRequest(JsonOperationContext ctx, ServerNode node, out string url)
             {
@@ -364,6 +365,7 @@ namespace FastTests.Server.Replication
         private class GetReplicationTombstonesCommand : RavenCommand<List<string>>
         {
             public override bool IsReadRequest => true;
+            public override bool IsClusterCommand => false;
 
             public override HttpRequestMessage CreateRequest(JsonOperationContext ctx, ServerNode node, out string url)
             {

--- a/test/FastTests/Server/ServerStore.cs
+++ b/test/FastTests/Server/ServerStore.cs
@@ -93,6 +93,7 @@ namespace FastTests.Server
             }
 
             public override bool IsReadRequest => false;
+            public override bool IsClusterCommand => true;
         }
 
         public class GetDatabaseDocumentTestCommand : RavenCommand<BlittableJsonReaderObject>
@@ -113,6 +114,7 @@ namespace FastTests.Server
             }
 
             public override bool IsReadRequest => true;
+            public override bool IsClusterCommand => false;
         }
     }
 }

--- a/test/FastTests/Utils/RevisionsHelper.cs
+++ b/test/FastTests/Utils/RevisionsHelper.cs
@@ -68,7 +68,7 @@ namespace FastTests.Utils
             using (var context = JsonOperationContext.ShortTermSingleUse())
             {
                 var configurationJson = EntityToBlittable.ConvertCommandToBlittable(configuration, context);
-                var (index, _) = await serverStore.ModifyDatabaseRevisions(context, database, configurationJson);
+                var (index, _) = await serverStore.ModifyDatabaseRevisions(context, database, configurationJson, Guid.NewGuid().ToString());
                 return index;
             }
         }

--- a/test/FastTests/Voron/Backups/BackupToOneZipFile.cs
+++ b/test/FastTests/Voron/Backups/BackupToOneZipFile.cs
@@ -1,4 +1,5 @@
-﻿using System.IO;
+﻿using System;
+using System.IO;
 using System.Linq;
 using System.Threading.Tasks;
 using FastTests.Server.Documents.Revisions;
@@ -33,7 +34,7 @@ namespace FastTests.Voron.Backups
                 await database.SubscriptionStorage.PutSubscription(new SubscriptionCreationOptions
                 {
                     Query = "from Users",
-                });
+                }, Guid.NewGuid().ToString());
 
                 await database.IndexStore.CreateIndex(new IndexDefinition()
                 {

--- a/test/RachisTests/AddNodeToClusterTests.cs
+++ b/test/RachisTests/AddNodeToClusterTests.cs
@@ -353,7 +353,7 @@ namespace RachisTests
                 Database = db
             }.Initialize())
             {
-                await cluster.Leader.ServerStore.SendToLeaderAsync(new AddDatabaseCommand
+                await cluster.Leader.ServerStore.SendToLeaderAsync(new AddDatabaseCommand(Guid.NewGuid().ToString())
                 {
                     Record = new DatabaseRecord(db)
                     {
@@ -398,7 +398,7 @@ namespace RachisTests
                 Database = db
             }.Initialize())
             {
-                await cluster.Leader.ServerStore.SendToLeaderAsync(new AddDatabaseCommand
+                await cluster.Leader.ServerStore.SendToLeaderAsync(new AddDatabaseCommand(Guid.NewGuid().ToString())
                 {
                     Record = new DatabaseRecord(db)
                     {
@@ -443,7 +443,7 @@ namespace RachisTests
                 Database = db
             }.Initialize())
             {
-                await cluster.Leader.ServerStore.SendToLeaderAsync(new AddDatabaseCommand
+                await cluster.Leader.ServerStore.SendToLeaderAsync(new AddDatabaseCommand(Guid.NewGuid().ToString())
                 {
                     Record = new DatabaseRecord(db)
                     {

--- a/test/RachisTests/AddNodeToClusterTests.cs
+++ b/test/RachisTests/AddNodeToClusterTests.cs
@@ -13,6 +13,7 @@ using Raven.Client.Exceptions;
 using Raven.Client.Exceptions.Cluster;
 using Raven.Client.Http;
 using Raven.Client.ServerWide;
+using Raven.Client.ServerWide.Commands.Cluster;
 using Raven.Client.ServerWide.Operations;
 using Raven.Server.Config;
 using Raven.Server.ServerWide.Commands;
@@ -534,29 +535,6 @@ namespace RachisTests
                     await Task.Delay(100);
                 }
             }
-        }
-
-        private class AddClusterNodeCommand : RavenCommand
-        {
-            private readonly string _url;
-
-            public AddClusterNodeCommand(string url)
-            {
-                _url = url;
-            }
-
-            public override HttpRequestMessage CreateRequest(JsonOperationContext ctx, ServerNode node, out string url)
-            {
-                url = $"{node.Url}/admin/cluster/node?url={_url}";
-
-                var request = new HttpRequestMessage
-                {
-                    Method = HttpMethod.Put
-                };
-
-                return request;
-            }
-
         }
     }
 }

--- a/test/RachisTests/ElectionTests.cs
+++ b/test/RachisTests/ElectionTests.cs
@@ -4,6 +4,7 @@ using System.Diagnostics;
 using System.Linq;
 using System.Threading;
 using System.Threading.Tasks;
+using Raven.Client.Exceptions.Cluster;
 using Raven.Client.ServerWide;
 using Raven.Server.Rachis;
 using Raven.Server.ServerWide.Context;
@@ -111,7 +112,7 @@ namespace RachisTests
 
             foreach (var invalidCommand in invalidCommands)
             {
-                await Assert.ThrowsAsync<TimeoutException>(() => invalidCommand);
+                await Assert.ThrowsAsync<NotLeadingException>(() => invalidCommand);
 
                 Assert.True(invalidCommand.IsCompleted);
                 Assert.NotEqual(TaskStatus.RanToCompletion, invalidCommand.Status);

--- a/test/RachisTests/SubscriptionsFailover.cs
+++ b/test/RachisTests/SubscriptionsFailover.cs
@@ -437,7 +437,7 @@ namespace RachisTests
                 var res = await documentDatabase.ServerStore.ModifyDatabaseRevisions(context,
                     defaultDatabase,
                     EntityToBlittable.ConvertCommandToBlittable(configuration,
-                        context));
+                        context), Guid.NewGuid().ToString());
 
                 foreach (var s in Servers)// need to wait for it on all servers
                 {

--- a/test/SlowTests/Authentication/SetupCommands.cs
+++ b/test/SlowTests/Authentication/SetupCommands.cs
@@ -29,6 +29,7 @@ namespace SlowTests.Authentication
             }
 
             public override bool IsReadRequest => false;
+            public override bool IsClusterCommand => false;
 
             public override HttpRequestMessage CreateRequest(JsonOperationContext ctx, ServerNode node, out string url)
             {
@@ -59,6 +60,7 @@ namespace SlowTests.Authentication
             }
 
             public override bool IsReadRequest => false;
+            public override bool IsClusterCommand => true;
 
             public override HttpRequestMessage CreateRequest(JsonOperationContext ctx, ServerNode node, out string url)
             {
@@ -89,6 +91,7 @@ namespace SlowTests.Authentication
             }
 
             public override bool IsReadRequest => false;
+            public override bool IsClusterCommand => true;
 
             public override HttpRequestMessage CreateRequest(JsonOperationContext ctx, ServerNode node, out string url)
             {

--- a/test/SlowTests/Client/Subscriptions/RavenDB_7384.cs
+++ b/test/SlowTests/Client/Subscriptions/RavenDB_7384.cs
@@ -63,7 +63,7 @@ namespace SlowTests.Client.Subscriptions
                     Name = "Subs1",
                     ChangeVector = Raven.Client.Constants.Documents.SubscriptionChangeVectorSpecialStates.DoNotChange.ToString(),
                     Query = "from Users"
-                }, subscriptionState.SubscriptionId, true);
+                }, Guid.NewGuid().ToString(), subscriptionState.SubscriptionId, true);
 
                 Assert.Equal(subscriptionTask, await Task.WhenAny(subscriptionTask, Task.Delay(_reasonableWaitTime)));
 
@@ -124,7 +124,7 @@ namespace SlowTests.Client.Subscriptions
                     ChangeVector = Raven.Client.Constants.Documents.SubscriptionChangeVectorSpecialStates.DoNotChange.ToString(),
                     Query = "from Users as u select {Name:'Jorgen'}"
 
-                }, subscriptionState.SubscriptionId);
+                }, Guid.NewGuid().ToString(), subscriptionState.SubscriptionId);
 
                 Assert.Equal(subscriptionTask, await Task.WhenAny(subscriptionTask, Task.Delay(_reasonableWaitTime)));
 

--- a/test/SlowTests/Client/Subscriptions/RavenDB_9117.cs
+++ b/test/SlowTests/Client/Subscriptions/RavenDB_9117.cs
@@ -70,7 +70,7 @@ namespace SlowTests.Client.Subscriptions
                     ChangeVector = cvBigger,
                     Name = subscriptionState.SubscriptionName,
                     Query = subscriptionState.Query
-                }, subscriptionState.SubscriptionId, false);
+                }, Guid.NewGuid().ToString(), subscriptionState.SubscriptionId, false);
 
                 await index.WaitWithTimeout(_reasonableWaitTime);
 

--- a/test/SlowTests/Client/Subscriptions/RevisionsSubscriptions.cs
+++ b/test/SlowTests/Client/Subscriptions/RevisionsSubscriptions.cs
@@ -49,7 +49,7 @@ namespace SlowTests.Client.Subscriptions
                     await Server.ServerStore.ModifyDatabaseRevisions(context,
                         store.Database,
                         EntityToBlittable.ConvertCommandToBlittable(configuration,
-                            context));
+                            context), Guid.NewGuid().ToString());
                 }
 
                 for (int i = 0; i < 10; i++)
@@ -129,7 +129,7 @@ namespace SlowTests.Client.Subscriptions
                     await Server.ServerStore.ModifyDatabaseRevisions(context,
                         store.Database,
                         EntityToBlittable.ConvertCommandToBlittable(configuration,
-                            context));
+                            context), Guid.NewGuid().ToString());
                 }
 
                 for (var j = 0; j < 10; j++)
@@ -228,7 +228,7 @@ select { Id: id(d.Current), Age: d.Current.Age }
                     await Server.ServerStore.ModifyDatabaseRevisions(context,
                         store.Database,
                         EntityToBlittable.ConvertCommandToBlittable(configuration,
-                            context));
+                            context), Guid.NewGuid().ToString());
                 }
 
                 for (int i = 0; i < 10; i++)
@@ -318,7 +318,7 @@ select { Id: id(d.Current), Age: d.Current.Age }
                     await Server.ServerStore.ModifyDatabaseRevisions(context,
                         store.Database,
                         EntityToBlittable.ConvertCommandToBlittable(configuration,
-                            context));
+                            context), Guid.NewGuid().ToString());
                 }
 
                 for (int i = 0; i < 10; i++)

--- a/test/SlowTests/Client/Subscriptions/SubscriptionScriptErrorHandling.cs
+++ b/test/SlowTests/Client/Subscriptions/SubscriptionScriptErrorHandling.cs
@@ -109,7 +109,7 @@ select project(d)
                     AsyncHelpers.RunSync(() => Server.ServerStore.ModifyDatabaseRevisions(context,
                         store.Database,
                         EntityToBlittable.ConvertCommandToBlittable(configuration,
-                            context)));
+                            context), Guid.NewGuid().ToString()));
                 }
 
                 var subscriptionId = store.Subscriptions.Create(new SubscriptionCreationOptions()

--- a/test/SlowTests/Client/Subscriptions/SubscriptionsBasic.cs
+++ b/test/SlowTests/Client/Subscriptions/SubscriptionsBasic.cs
@@ -194,7 +194,7 @@ namespace SlowTests.Client.Subscriptions
                         ChangeVector = cvBigger,
                         Name = subscriptionState.SubscriptionName,
                         Query = subscriptionState.Query
-                    }, subscriptionState.SubscriptionId, false);
+                    }, Guid.NewGuid().ToString(), subscriptionState.SubscriptionId, false);
 
                     await index.WaitWithTimeout(_reasonableWaitTime);
 

--- a/test/SlowTests/Cluster/ClusterTransactionTests.cs
+++ b/test/SlowTests/Cluster/ClusterTransactionTests.cs
@@ -20,6 +20,7 @@ using Raven.Server.Documents;
 using Raven.Server.Documents.Replication;
 using Raven.Server.ServerWide.Commands;
 using Raven.Server.ServerWide.Context;
+using Raven.Server.Utils;
 using Raven.Tests.Core.Utils.Entities;
 using Xunit;
 
@@ -61,6 +62,71 @@ namespace SlowTests.Cluster
                     Assert.Equal(user3.Name, user.Name);
                 }
             }
+        }
+
+        [Fact]
+        public async Task CanCreateClusterTransactionRequest2()
+        {
+            DebuggerAttachedTimeout.DisableLongTimespan = true;
+            var leader = await CreateRaftClusterAndGetLeader(2);
+            using (var leaderStore = GetDocumentStore(new Options
+            {
+                Server = leader,
+                ReplicationFactor = 2
+            }))
+            {
+                var count = 0;
+                var tasks = new List<Task>();
+                for (int i = 0; i < 100; i++)
+                {
+                    var t = Task.Run(async () =>
+                    {
+                        /*
+                        for (int j = 0; j < 10; j++)
+                        {
+                            leaderStore.Operations.SendAsync(new PutCompareExchangeValueOperation<User>($"usernames/{Interlocked.Increment(ref count)}", new User(), 0));
+                        }
+*/
+
+                        using (var session = leaderStore.OpenAsyncSession(new SessionOptions
+                        {
+                            TransactionMode = TransactionMode.ClusterWide
+                        }))
+                        {
+                            session.Advanced.ClusterTransaction.CreateCompareExchangeValue($"usernames/{Interlocked.Increment(ref count)}", new User());
+                            await session.SaveChangesAsync();
+                        }
+
+                        await ActionWithLeader((l) =>
+                        {
+                            l.ServerStore.Engine.CurrentLeader?.StepDown();
+                            return Task.CompletedTask;
+                        });
+                    });
+                    tasks.Add(t);
+                }
+
+                var hasExecption = false;
+
+                foreach (var task in tasks)
+                {
+                    try
+                    {
+                        await task;
+                    }
+                    catch (Exception e)
+                    {
+                        hasExecption = true;
+                        Console.WriteLine(task.Exception.InnerExceptions[0].Message);
+                    }
+                }
+
+                if (hasExecption)
+                {
+                    throw new InvalidOperationException();
+                }
+            }
+
         }
 
         [Fact]

--- a/test/SlowTests/Issues/RavenDB-8450.cs
+++ b/test/SlowTests/Issues/RavenDB-8450.cs
@@ -61,6 +61,7 @@ namespace SlowTests.Issues
             }
 
             public override bool IsReadRequest { get; } = false;
+            public override bool IsClusterCommand => false;
 
             public override HttpRequestMessage CreateRequest(JsonOperationContext ctx, ServerNode node, out string url)
             {

--- a/test/SlowTests/Issues/RavenDB_10546.cs
+++ b/test/SlowTests/Issues/RavenDB_10546.cs
@@ -92,6 +92,7 @@ namespace SlowTests.Issues
             private class GetStudioConfigurationCommand : RavenCommand<StudioConfiguration>
             {
                 public override bool IsReadRequest => false;
+                public override bool IsClusterCommand => false;
 
                 public override HttpRequestMessage CreateRequest(JsonOperationContext ctx, ServerNode node, out string url)
                 {
@@ -145,6 +146,8 @@ namespace SlowTests.Issues
                     _configuration = EntityToBlittable.ConvertCommandToBlittable(configuration, context);
                 }
 
+                public override bool IsClusterCommand => true;
+
                 public override HttpRequestMessage CreateRequest(JsonOperationContext ctx, ServerNode node, out string url)
                 {
                     url = $"{node.Url}/databases/{node.Database}/admin/configuration/studio";
@@ -191,6 +194,8 @@ namespace SlowTests.Issues
                     _configuration = EntityToBlittable.ConvertCommandToBlittable(configuration, context);
                 }
 
+                public override bool IsClusterCommand => true;
+
                 public override HttpRequestMessage CreateRequest(JsonOperationContext ctx, ServerNode node, out string url)
                 {
                     url = $"{node.Url}/admin/configuration/studio";
@@ -217,6 +222,7 @@ namespace SlowTests.Issues
             private class GetServerWideStudioConfigurationCommand : RavenCommand<ServerWideStudioConfiguration>
             {
                 public override bool IsReadRequest => false;
+                public override bool IsClusterCommand => false;
 
                 public override HttpRequestMessage CreateRequest(JsonOperationContext ctx, ServerNode node, out string url)
                 {

--- a/test/SlowTests/Issues/RavenDB_5051.cs
+++ b/test/SlowTests/Issues/RavenDB_5051.cs
@@ -60,6 +60,7 @@ namespace SlowTests.Issues
                 }
 
                 public override bool IsReadRequest => false;
+                public override bool IsClusterCommand => false;
 
                 public override HttpRequestMessage CreateRequest(JsonOperationContext ctx, ServerNode node, out string url)
                 {

--- a/test/SlowTests/Issues/RavenDB_5824.cs
+++ b/test/SlowTests/Issues/RavenDB_5824.cs
@@ -119,6 +119,7 @@ namespace SlowTests.Issues
                 }
 
                 public override bool IsReadRequest => true;
+                public override bool IsClusterCommand => false;
 
                 public override HttpRequestMessage CreateRequest(JsonOperationContext ctx, ServerNode node, out string url)
                 {

--- a/test/SlowTests/Issues/RavenDB_7162.cs
+++ b/test/SlowTests/Issues/RavenDB_7162.cs
@@ -45,6 +45,8 @@ namespace SlowTests.Issues
                 _value = value;
             }
 
+            public override bool IsClusterCommand => false;
+
             public override HttpRequestMessage CreateRequest(JsonOperationContext ctx, ServerNode node, out string url)
             {
                 url = $"{node.Url}/test/delay?value={(int)_value.TotalMilliseconds}";

--- a/test/SlowTests/Issues/RavenDB_9519.cs
+++ b/test/SlowTests/Issues/RavenDB_9519.cs
@@ -203,6 +203,7 @@ namespace SlowTests.Issues
             private readonly long _operationId;
 
             public override bool IsReadRequest => false;
+            public override bool IsClusterCommand => false;
 
             public CsvImportCommand(Stream stream, string collection, long operationId)
             {

--- a/test/SlowTests/Tests/Faceted/ConditionalGetHelper.cs
+++ b/test/SlowTests/Tests/Faceted/ConditionalGetHelper.cs
@@ -65,6 +65,7 @@ namespace SlowTests.Tests.Faceted
             }
 
             public override bool IsReadRequest => false;
+            public override bool IsClusterCommand => false;
 
             public override HttpRequestMessage CreateRequest(JsonOperationContext ctx, ServerNode node, out string url)
             {

--- a/test/Tests.Infrastructure/ClusterTestBase.cs
+++ b/test/Tests.Infrastructure/ClusterTestBase.cs
@@ -118,6 +118,7 @@ namespace Tests.Infrastructure
             }
 
             public override bool IsReadRequest => true;
+            public override bool IsClusterCommand => false;
         }
 
         protected async Task<bool> WaitUntilDatabaseHasState(DocumentStore store, TimeSpan timeout, Func<DatabaseRecord, bool> predicate)

--- a/test/Tests.Infrastructure/CreateSampleDataOperation.cs
+++ b/test/Tests.Infrastructure/CreateSampleDataOperation.cs
@@ -16,6 +16,7 @@ namespace Tests.Infrastructure
         private class CreateSampleDataCommand : RavenCommand
         {
             public override bool IsReadRequest => false;
+            public override bool IsClusterCommand => false;
 
             public override HttpRequestMessage CreateRequest(JsonOperationContext ctx, ServerNode node, out string url)
             {

--- a/test/Tests.Infrastructure/DocumentStoreExtensions.cs
+++ b/test/Tests.Infrastructure/DocumentStoreExtensions.cs
@@ -327,6 +327,7 @@ namespace FastTests
                 }
 
                 public override bool IsReadRequest => true;
+                public override bool IsClusterCommand => false;
 
                 public override HttpRequestMessage CreateRequest(JsonOperationContext ctx, ServerNode node, out string url)
                 {
@@ -370,6 +371,7 @@ namespace FastTests
                 }
 
                 public override bool IsReadRequest => false;
+                public override bool IsClusterCommand => false;
 
                 public override HttpRequestMessage CreateRequest(JsonOperationContext ctx, ServerNode node, out string url)
                 {

--- a/test/Tryouts/Program.cs
+++ b/test/Tryouts/Program.cs
@@ -30,7 +30,7 @@ namespace Tryouts
                 Console.WriteLine(i);
                 using (var test = new ClusterTransactionTests())
                 {
-                    test.CreateUniqueUser().Wait();
+                    test.CanCreateClusterTransactionRequest2().Wait();
                 }
             }
         }


### PR DESCRIPTION
Since this is a large PR the work is splitted into 2 commits:

1. enforcing the guid to all raft command (many files and some tests)
2. core changes

This is still WIP because the client side is still missing, each operation (that make sense) has to be altered to add a guid to it.

Only the cluster tx implemented the guid on the client-side for testing purpose. 