### PR TITLE
RavenDB-13405 : counters import improvements

### DIFF
--- a/src/Raven.Client/Documents/Session/AsyncSessionDocumentCounters.cs
+++ b/src/Raven.Client/Documents/Session/AsyncSessionDocumentCounters.cs
@@ -40,7 +40,7 @@ namespace Raven.Client.Documents.Session
             if ((Session.DocumentsById.TryGetValue(DocId, out var document) == false && cache.GotAll == false) ||
                 (document != null && document.Metadata.TryGet(Constants.Documents.Metadata.Counters,
                     out BlittableJsonReaderArray metadataCounters) &&
-                metadataCounters.BinarySearch(counter, StringComparison.OrdinalIgnoreCase) >= 0))
+                metadataCounters.BinarySearch(counter, StringComparison.Ordinal) >= 0))
 
             {
                 // we either don't have the document in session and GotAll = false,
@@ -86,7 +86,7 @@ namespace Raven.Client.Documents.Session
             {
                 if (cache.Values.TryGetValue(counter, out var val) ||
                     (document != null &&
-                     metadataCounters?.BinarySearch(counter, StringComparison.OrdinalIgnoreCase) < 0) ||
+                     metadataCounters?.BinarySearch(counter, StringComparison.Ordinal) < 0) ||
                     cache.GotAll)
                 {
                     // we either have value in cache,


### PR DESCRIPTION
- dispose blittable after each iteration (instead of at the end of the batch)
- cache documents and counter names during batch, and update all documents at the end of the batch
- different logic for updating document counters

https://issues.hibernatingrhinos.com/issue/RavenDB-13405