### PR TITLE
RavenDB-13612 follower should report back the latest incoming entry index

### DIFF
--- a/src/Raven.Server/Rachis/FollowerAmbassador.cs
+++ b/src/Raven.Server/Rachis/FollowerAmbassador.cs
@@ -276,7 +276,7 @@ namespace Raven.Server.Rachis
                                             if (totalSize > Constants.Size.Megabyte)
                                                 break;
                                         }
-
+                                      
                                         appendEntries = new AppendEntries
                                         {
                                             ForceElections = ForceElectionsNow,
@@ -495,11 +495,10 @@ namespace Raven.Server.Rachis
                         _engine.Log.Info($"{ToString()}: sending empty snapshot to {_tag}");
                     }
 
-                    var index = Math.Min(earliestIndexEntry, _followerMatchIndex);
                     _connection.Send(context, new InstallSnapshot
                     {
-                        LastIncludedIndex = index,
-                        LastIncludedTerm = _engine.GetTermForKnownExisting(context, index),
+                        LastIncludedIndex = _followerMatchIndex,
+                        LastIncludedTerm = _engine.GetTermForKnownExisting(context, _followerMatchIndex),
                         Topology = _engine.GetTopologyRaw(context)
                     });
                     using (var binaryWriter = new BinaryWriter(stream, Encoding.UTF8, leaveOpen: true))

--- a/src/Raven.Server/Rachis/Leader.cs
+++ b/src/Raven.Server/Rachis/Leader.cs
@@ -293,17 +293,6 @@ namespace Raven.Server.Rachis
                     _shutdownRequested
                 };
 
-                var noopCmd = new DynamicJsonValue
-                {
-                    ["Command"] = "noop"
-                };
-                using (_engine.ContextPool.AllocateOperationContext(out TransactionOperationContext context))
-                using (var tx = context.OpenWriteTransaction())
-                using (var cmd = context.ReadObject(noopCmd, "noop-cmd"))
-                {
-                    _engine.InsertToLeaderLog(context, Term, cmd, RachisEntryFlags.Noop);
-                    tx.Commit();
-                }
                 _newEntry.Set(); //This is so the noop would register right away
                 while (_running)
                 {

--- a/src/Raven.Server/Rachis/RachisConsensus.cs
+++ b/src/Raven.Server/Rachis/RachisConsensus.cs
@@ -621,6 +621,17 @@ namespace Raven.Server.Rachis
                     throw new RachisInvalidOperationException("We cannot be elected for leadership if snapshot is requested.");
             }
 
+            if (rachisState == RachisState.LeaderElect)
+            {
+                var noopCmd = new DynamicJsonValue
+                {
+                    ["Type"] = $"Noop for {Tag} in term {expectedTerm}",
+                    ["Command"] = "noop",
+                    [nameof(CommandBase.UniqueRequestId)] = Guid.NewGuid().ToString()
+                };
+                InsertToLeaderLog(context, expectedTerm, context.ReadObject(noopCmd, "noop-cmd"), RachisEntryFlags.Noop);
+            }
+
             var sp = Stopwatch.StartNew();
             
             _currentLeader = null;
@@ -1260,7 +1271,7 @@ namespace Raven.Server.Rachis
 
                 var firstEntry = entries[firstIndexInEntriesThatWeHaveNotSeen];
                 //While we do support the case where we get the same entries, we expect them to have the same index/term up to the commit index.
-                if (firstEntry.Index < lastCommitIndex)
+                if (firstEntry.Index <= lastCommitIndex)
                 {
                     ThrowFatalError(firstEntry, GetTermFor(context, firstEntry.Index), lastCommitIndex, lastCommitTerm);
                 }

--- a/src/Raven.Server/Rachis/RachisStateMachine.cs
+++ b/src/Raven.Server/Rachis/RachisStateMachine.cs
@@ -38,9 +38,12 @@ namespace Raven.Server.Rachis
                     throw new InvalidOperationException("Expected to apply entry " + index + " but it isn't stored");
 
                 lastAppliedIndex = index;
-
+               
                 if (flags != RachisEntryFlags.StateMachineCommand)
+                {
+                    _parent.LogHistory.UpdateHistoryLog(context, index, _parent.CurrentTerm, cmd, null, null);
                     continue;
+                }
 
                 Apply(context, cmd, index, leader, serverStore);
                 

--- a/test/StressTests/Cluster/ClusterStressTests.cs
+++ b/test/StressTests/Cluster/ClusterStressTests.cs
@@ -1,0 +1,128 @@
+﻿using System;
+using System.Collections.Generic;
+using System.Text;
+using System.Threading;
+using System.Threading.Tasks;
+using FastTests.Server.Replication;
+using Raven.Client.Documents.Operations.CompareExchange;
+using Raven.Client.Documents.Session;
+using Raven.Server;
+using Raven.Server.Config;
+using Raven.Server.ServerWide.Context;
+using Raven.Server.Utils;
+using Raven.Tests.Core.Utils.Entities;
+using Xunit;
+
+namespace StressTests.Cluster
+{
+    public class ClusterStressTests : ReplicationTestBase
+    {
+        // the values are lower to make the cluster less stable
+        protected override RavenServer GetNewServer(IDictionary<string, string> customSettings = null, bool deletePrevious = true, bool runInMemory = true, string partialPath = null,
+            string customConfigPath = null)
+        {
+            if (customSettings == null)
+                customSettings = new Dictionary<string, string>();
+
+            customSettings[RavenConfiguration.GetKey(x => x.Cluster.OperationTimeout)] = "10";
+            customSettings[RavenConfiguration.GetKey(x => x.Cluster.StabilizationTime)] = "1";
+            customSettings[RavenConfiguration.GetKey(x => x.Cluster.TcpConnectionTimeout)] = "3000";
+            customSettings[RavenConfiguration.GetKey(x => x.Cluster.ElectionTimeout)] = "50";
+
+            return base.GetNewServer(customSettings, deletePrevious, runInMemory, partialPath, customConfigPath);
+        }
+
+        [Fact]
+        public async Task ParallelClusterTransactions()
+        {
+            DebuggerAttachedTimeout.DisableLongTimespan = true;
+            var numberOfNodes = 7;
+            var cluster = await CreateRaftCluster(numberOfNodes);
+            var db = GetDatabaseName();
+            using (GetDocumentStore(new Options
+            {
+                Server = cluster.Leader,
+                ReplicationFactor = numberOfNodes,
+                ModifyDatabaseName = _ => db
+            }))
+            {
+                var count = 0;
+                var tasks = new List<Task>();
+                var random = new Random();
+
+                for (int i = 0; i < 100; i++)
+                {
+                    var t = Task.Run(async () =>
+                    {
+                        var nodeNum = random.Next(0, numberOfNodes);
+                        using (var store = GetDocumentStore(new Options
+                        {
+                            Server = cluster.Nodes[nodeNum],
+                            CreateDatabase = false
+                        }))
+                        {
+                            for (int j = 0; j < 10; j++)
+                            {
+                                try
+                                {
+                                    await store.Operations.ForDatabase(db).SendAsync(new PutCompareExchangeValueOperation<User>($"usernames/{Interlocked.Increment(ref count)}", new User(), 0));
+
+                                    using (var session = store.OpenAsyncSession(db))
+                                    {
+                                        session.Advanced.SetTransactionMode(TransactionMode.ClusterWide);
+                                        session.Advanced.ClusterTransaction.CreateCompareExchangeValue($"usernames/{Interlocked.Increment(ref count)}", new User());
+                                        await session.StoreAsync(new User());
+                                        await session.SaveChangesAsync();
+                                    }
+                                }
+                                catch
+                                {
+                                    //
+                                }
+                            }
+                        }
+                    });
+                    tasks.Add(t);
+                }
+
+                foreach (var task in tasks)
+                {
+                    try
+                    {
+                        await task;
+                    }
+                    catch
+                    {
+                        // ignore
+                    }
+                }
+
+                var compareExchangeCount = new HashSet<long>();
+                var lastLog = 0L;
+
+                await ActionWithLeader((leader) =>
+                {
+                    using (leader.ServerStore.ContextPool.AllocateOperationContext(out TransactionOperationContext ctx))
+                    using (ctx.OpenReadTransaction())
+                    {
+                        lastLog = leader.ServerStore.Engine.GetLastEntryIndex(ctx);
+                    }
+                    return Task.CompletedTask;
+                });
+
+                foreach (var node in cluster.Nodes)
+                {
+                    await node.ServerStore.Cluster.WaitForIndexNotification(lastLog);
+
+                    using (node.ServerStore.ContextPool.AllocateOperationContext(out TransactionOperationContext ctx))
+                    using (ctx.OpenReadTransaction())
+                    {
+                        compareExchangeCount.Add(node.ServerStore.Cluster.GetNumberOfCompareExchange(ctx, db));
+                    }
+                }
+
+                Assert.Equal(1, compareExchangeCount.Count);
+            }
+        }
+    }
+}

--- a/test/Tryouts/Program.cs
+++ b/test/Tryouts/Program.cs
@@ -1,5 +1,7 @@
 using System;
 using SlowTests.Client.Counters;
+using SlowTests.Cluster;
+using StressTests.Cluster;
 
 namespace Tryouts
 {
@@ -10,9 +12,16 @@ namespace Tryouts
             for (int i = 0; i < 123; i++)
             {
                 Console.WriteLine(i);
-                using (var test = new QueryOnCounters())
+                try
                 {
-                    test.CountersShouldBeCachedOnCollection();
+                    using (var test = new ClusterStressTests())
+                    {
+                        test.ParallelClusterTransactions().Wait();
+                    }
+                }
+                catch (Exception e)
+                {
+                    Console.WriteLine(e);
                 }
             }
         }


### PR DESCRIPTION
The underlying issue was that the follower reported back his latest entry, which might be from a different term. (if this node was more up-to-date in the previous term)
This would cause the leader and the follower to commit different entries for the same index.

another cause that increased the probability to this issue is that the leader started to negotiate before appending 'noop' to his own log.
that might lead to a more up-to-date follower not to rewind his log.