### PR TITLE
RavenDB-13612 follower should report back the latest incoming entry index

### DIFF
--- a/src/Raven.Server/Rachis/Follower.cs
+++ b/src/Raven.Server/Rachis/Follower.cs
@@ -53,12 +53,12 @@ namespace Raven.Server.Rachis
         private void FollowerSteadyState()
         {
             var entries = new List<RachisEntry>();
-            long lastCommit = 0, lastTruncate = 0;
+            long lastCommit = 0, lastTruncate = 0, lastAcknowledgedIndex = 0;
             if (_engine.Log.IsInfoEnabled)
             {
                 _engine.Log.Info($"{ToString()}: Entering steady state");
             }
-            
+
             while (true)
             {
                 entries.Clear();
@@ -118,8 +118,6 @@ namespace Raven.Server.Rachis
                         }
                     }
 
-                    var lastLogIndex = appendEntries.PrevLogIndex;
-
                     // don't start write transaction for noop
                     if (lastCommit != appendEntries.LeaderCommit ||
                         lastTruncate != appendEntries.TruncateLogBefore ||
@@ -129,12 +127,12 @@ namespace Raven.Server.Rachis
                         {
                             // applying the leader state may take a while, we need to ping
                             // the server and let us know that we are still there
-                            var task = Concurrent_SendAppendEntriesPendingToLeaderAsync(cts, _term, lastLogIndex);
+                            var task = Concurrent_SendAppendEntriesPendingToLeaderAsync(cts, _term, appendEntries.PrevLogIndex);
                             try
                             {
                                 bool hasRemovedFromTopology;
 
-                                (hasRemovedFromTopology, lastLogIndex, lastTruncate, lastCommit) = ApplyLeaderStateToLocalState(sp,
+                                (hasRemovedFromTopology, lastAcknowledgedIndex, lastTruncate, lastCommit) = ApplyLeaderStateToLocalState(sp,
                                     context,
                                     entries,
                                     appendEntries);
@@ -191,7 +189,7 @@ namespace Raven.Server.Rachis
                     _connection.Send(context, new AppendEntriesResponse
                     {
                         CurrentTerm = _term,
-                        LastLogIndex = lastLogIndex,
+                        LastLogIndex = lastAcknowledgedIndex,
                         Success = true
                     });
 
@@ -246,9 +244,8 @@ namespace Raven.Server.Rachis
             }
         }
 
-        private (bool HasRemovedFromTopology, long LastLogIndex, long LastTruncate,  long LastCommit)  ApplyLeaderStateToLocalState(Stopwatch sp, TransactionOperationContext context, List<RachisEntry> entries, AppendEntries appendEntries)
+        private (bool HasRemovedFromTopology, long LastAcknowledgedIndex, long LastTruncate,  long LastCommit)  ApplyLeaderStateToLocalState(Stopwatch sp, TransactionOperationContext context, List<RachisEntry> entries, AppendEntries appendEntries)
         {
-            long lastLogIndex; 
             long lastTruncate;
             long lastCommit;
             
@@ -296,15 +293,15 @@ namespace Raven.Server.Rachis
                     }
                 }
 
-                lastLogIndex = _engine.GetLastEntryIndex(context);
-
                 var lastEntryIndexToCommit = Math.Min(
-                    lastLogIndex,
+                    _engine.GetLastEntryIndex(context),
                     appendEntries.LeaderCommit);
 
                 var lastAppliedIndex = _engine.GetLastCommitIndex(context);
+                var lastAppliedTerm = _engine.GetTermFor(context, lastEntryIndexToCommit);
 
-                if (lastEntryIndexToCommit > lastAppliedIndex)
+                // we start to commit only after we have any log with a term of the current leader
+                if (lastEntryIndexToCommit > lastAppliedIndex && lastAppliedTerm == appendEntries.Term)
                 {
                     lastAppliedIndex = _engine.Apply(context, lastEntryIndexToCommit, null, sp);
                 }
@@ -312,7 +309,7 @@ namespace Raven.Server.Rachis
                 lastTruncate = Math.Min(appendEntries.TruncateLogBefore, lastAppliedIndex);
                 _engine.TruncateLogBefore(context, lastTruncate);
 
-                lastCommit = lastEntryIndexToCommit;
+                lastCommit = lastAppliedIndex;
                 if (_engine.Log.IsInfoEnabled)
                 {
                     _engine.Log.Info($"{ToString()}: Ready to commit in {sp.Elapsed}");
@@ -326,7 +323,9 @@ namespace Raven.Server.Rachis
                 _engine.Log.Info($"{ToString()}: Processing entries request with {entries.Count} entries took {sp.Elapsed}");
             }
 
-            return (HasRemovedFromTopology: removedFromTopology,  LastLogIndex: lastLogIndex,  LastTruncate: lastTruncate,  LastCommit: lastCommit);
+            var lastAcknowledgedIndex = entries.Count == 0 ? appendEntries.PrevLogIndex : entries[entries.Count - 1].Index;
+
+            return (HasRemovedFromTopology: removedFromTopology, LastAcknowledgedIndex: lastAcknowledgedIndex,  LastTruncate: lastTruncate,  LastCommit: lastCommit);
         }
 
         public static bool CheckIfValidLeader(RachisConsensus engine, RemoteConnection connection, out LogLengthNegotiation negotiation)

--- a/src/Raven.Server/Rachis/FollowerAmbassador.cs
+++ b/src/Raven.Server/Rachis/FollowerAmbassador.cs
@@ -278,7 +278,7 @@ namespace Raven.Server.Rachis
                                             if (totalSize > Constants.Size.Megabyte)
                                                 break;
                                         }
-
+                                      
                                         appendEntries = new AppendEntries
                                         {
                                             ForceElections = ForceElectionsNow,
@@ -497,11 +497,10 @@ namespace Raven.Server.Rachis
                         _engine.Log.Info($"{ToString()}: sending empty snapshot to {_tag}");
                     }
 
-                    var index = Math.Min(earliestIndexEntry, _followerMatchIndex);
                     _connection.Send(context, new InstallSnapshot
                     {
-                        LastIncludedIndex = index,
-                        LastIncludedTerm = _engine.GetTermForKnownExisting(context, index),
+                        LastIncludedIndex = _followerMatchIndex,
+                        LastIncludedTerm = _engine.GetTermForKnownExisting(context, _followerMatchIndex),
                         Topology = _engine.GetTopologyRaw(context)
                     });
                     using (var binaryWriter = new BinaryWriter(stream, Encoding.UTF8, leaveOpen: true))

--- a/src/Raven.Server/Rachis/Leader.cs
+++ b/src/Raven.Server/Rachis/Leader.cs
@@ -293,17 +293,6 @@ namespace Raven.Server.Rachis
                     _shutdownRequested
                 };
 
-                var noopCmd = new DynamicJsonValue
-                {
-                    ["Command"] = "noop"
-                };
-                using (_engine.ContextPool.AllocateOperationContext(out TransactionOperationContext context))
-                using (var tx = context.OpenWriteTransaction())
-                using (var cmd = context.ReadObject(noopCmd, "noop-cmd"))
-                {
-                    _engine.InsertToLeaderLog(context, Term, cmd, RachisEntryFlags.Noop);
-                    tx.Commit();
-                }
                 _newEntry.Set(); //This is so the noop would register right away
                 while (_running)
                 {

--- a/test/StressTests/Cluster/ClusterStressTests.cs
+++ b/test/StressTests/Cluster/ClusterStressTests.cs
@@ -1,0 +1,128 @@
+﻿using System;
+using System.Collections.Generic;
+using System.Text;
+using System.Threading;
+using System.Threading.Tasks;
+using FastTests.Server.Replication;
+using Raven.Client.Documents.Operations.CompareExchange;
+using Raven.Client.Documents.Session;
+using Raven.Server;
+using Raven.Server.Config;
+using Raven.Server.ServerWide.Context;
+using Raven.Server.Utils;
+using Raven.Tests.Core.Utils.Entities;
+using Xunit;
+
+namespace StressTests.Cluster
+{
+    public class ClusterStressTests : ReplicationTestBase
+    {
+        // the values are lower to make the cluster less stable
+        protected override RavenServer GetNewServer(IDictionary<string, string> customSettings = null, bool deletePrevious = true, bool runInMemory = true, string partialPath = null,
+            string customConfigPath = null)
+        {
+            if (customSettings == null)
+                customSettings = new Dictionary<string, string>();
+
+            customSettings[RavenConfiguration.GetKey(x => x.Cluster.OperationTimeout)] = "10";
+            customSettings[RavenConfiguration.GetKey(x => x.Cluster.StabilizationTime)] = "1";
+            customSettings[RavenConfiguration.GetKey(x => x.Cluster.TcpConnectionTimeout)] = "3000";
+            customSettings[RavenConfiguration.GetKey(x => x.Cluster.ElectionTimeout)] = "50";
+
+            return base.GetNewServer(customSettings, deletePrevious, runInMemory, partialPath, customConfigPath);
+        }
+
+        [Fact]
+        public async Task ParallelClusterTransactions()
+        {
+            DebuggerAttachedTimeout.DisableLongTimespan = true;
+            var numberOfNodes = 7;
+            var cluster = await CreateRaftCluster(numberOfNodes);
+            var db = GetDatabaseName();
+            using (GetDocumentStore(new Options
+            {
+                Server = cluster.Leader,
+                ReplicationFactor = numberOfNodes,
+                ModifyDatabaseName = _ => db
+            }))
+            {
+                var count = 0;
+                var tasks = new List<Task>();
+                var random = new Random();
+
+                for (int i = 0; i < 100; i++)
+                {
+                    var t = Task.Run(async () =>
+                    {
+                        var nodeNum = random.Next(0, numberOfNodes);
+                        using (var store = GetDocumentStore(new Options
+                        {
+                            Server = cluster.Nodes[nodeNum],
+                            CreateDatabase = false
+                        }))
+                        {
+                            for (int j = 0; j < 10; j++)
+                            {
+                                try
+                                {
+                                    await store.Operations.ForDatabase(db).SendAsync(new PutCompareExchangeValueOperation<User>($"usernames/{Interlocked.Increment(ref count)}", new User(), 0));
+
+                                    using (var session = store.OpenAsyncSession(db))
+                                    {
+                                        session.Advanced.SetTransactionMode(TransactionMode.ClusterWide);
+                                        session.Advanced.ClusterTransaction.CreateCompareExchangeValue($"usernames/{Interlocked.Increment(ref count)}", new User());
+                                        await session.StoreAsync(new User());
+                                        await session.SaveChangesAsync();
+                                    }
+                                }
+                                catch
+                                {
+                                    //
+                                }
+                            }
+                        }
+                    });
+                    tasks.Add(t);
+                }
+
+                foreach (var task in tasks)
+                {
+                    try
+                    {
+                        await task;
+                    }
+                    catch
+                    {
+                        // ignore
+                    }
+                }
+
+                var compareExchangeCount = new HashSet<long>();
+                var lastLog = 0L;
+
+                await ActionWithLeader((leader) =>
+                {
+                    using (leader.ServerStore.ContextPool.AllocateOperationContext(out TransactionOperationContext ctx))
+                    using (ctx.OpenReadTransaction())
+                    {
+                        lastLog = leader.ServerStore.Engine.GetLastEntryIndex(ctx);
+                    }
+                    return Task.CompletedTask;
+                });
+
+                foreach (var node in cluster.Nodes)
+                {
+                    await node.ServerStore.Cluster.WaitForIndexNotification(lastLog);
+
+                    using (node.ServerStore.ContextPool.AllocateOperationContext(out TransactionOperationContext ctx))
+                    using (ctx.OpenReadTransaction())
+                    {
+                        compareExchangeCount.Add(node.ServerStore.Cluster.GetNumberOfCompareExchange(ctx, db));
+                    }
+                }
+
+                Assert.Equal(1, compareExchangeCount.Count);
+            }
+        }
+    }
+}


### PR DESCRIPTION
The underlying issue was that the follower reported back his latest entry, which might be from a different term.
This would cause the leader and the follower to commit different entries on the same index.

another cause that increased the probability to this issue is that the leader started to negotiate before appending 'noop' to his own log.
that might lead to a more up-to-date follower not to rewind his log.