### PR TITLE
RavenDB-13640 If we fail during BeginAsyncCommitAndStartNewTransactio…

### DIFF
--- a/src/Voron/Impl/LowLevelTransaction.cs
+++ b/src/Voron/Impl/LowLevelTransaction.cs
@@ -873,24 +873,37 @@ namespace Voron.Impl
                   ? Task.Run(() => { CommitStage2_WriteToJournal(); return true; })
                   : NoWriteToJournalRequiredTask;
 
+            var usageIncremented = false;
+
             try
             {
+                _forTestingPurposes?.ActionToCallDuringBeginAsyncCommitAndStartNewTransaction?.Invoke();
+
                 _env.IncrementUsageOnNewTransaction();
+                usageIncremented = true;
+
                 _env.ActiveTransactions.Add(nextTx);
                 _env.WriteTransactionStarted();
+
 
                 return nextTx;
             }
             catch (Exception)
             {
-                // failure here means that we'll try to complete the current transaction normaly
+                // failure here means that we'll try to complete the current transaction normally
                 // then throw as if commit was called normally and the next transaction failed
 
-                _env.DecrementUsageOnTransactionCreationFailure();
+                try
+                {
+                    if (usageIncremented)
+                        _env.DecrementUsageOnTransactionCreationFailure();
 
-                EndAsyncCommit();
-
-                AsyncCommit = null;
+                    EndAsyncCommit();
+                }
+                finally
+                {
+                    AsyncCommit = null;
+                }
 
                 _disposed |= TxState.Errored;
 
@@ -1287,6 +1300,7 @@ namespace Voron.Impl
 
             internal Action ActionToCallDuringEnsurePagerStateReference;
             internal Action ActionToCallJustBeforeWritingToJournal;
+            internal Action ActionToCallDuringBeginAsyncCommitAndStartNewTransaction;
 
             public TestingStuff(LowLevelTransaction tx)
             {
@@ -1310,6 +1324,13 @@ namespace Voron.Impl
                 ActionToCallJustBeforeWritingToJournal = action;
 
                 return new DisposableAction(() => ActionToCallJustBeforeWritingToJournal = null);
+            }
+
+            internal IDisposable CallDuringBeginAsyncCommitAndStartNewTransaction(Action action)
+            {
+                ActionToCallDuringBeginAsyncCommitAndStartNewTransaction = action;
+
+                return new DisposableAction(() => ActionToCallDuringBeginAsyncCommitAndStartNewTransaction = null);
             }
 
             internal HashSet<PagerState> GetPagerStates()

--- a/test/SlowTests/Voron/Issues/RavenDB_13640.cs
+++ b/test/SlowTests/Voron/Issues/RavenDB_13640.cs
@@ -1,0 +1,50 @@
+﻿using System;
+using FastTests.Voron;
+using Voron;
+using Xunit;
+
+namespace SlowTests.Voron.Issues
+{
+    public class RavenDB_13640 : StorageTest
+    {
+        protected override void Configure(StorageEnvironmentOptions options)
+        {
+            options.ManualFlushing = true;
+        }
+
+        [Fact]
+        public void Should_properly_clear_transaction_after_begin_async_commit_failure()
+        {
+            var tx1 = Env.WriteTransaction();
+
+            try
+            {
+                var testingStuff = tx1.LowLevelTransaction.ForTestingPurposesOnly();
+
+                using (testingStuff.CallDuringBeginAsyncCommitAndStartNewTransaction(() => throw new InvalidOperationException()))
+                {
+                    tx1.LowLevelTransaction.BeforeCommitFinalization += delegate { throw  new InvalidOperationException();};
+
+                    Assert.Throws<InvalidOperationException>(() => tx1.BeginAsyncCommitAndStartNewTransaction());
+                }
+            }
+            finally
+            {
+                tx1?.Dispose();
+            }
+
+            // the issue was that the following was not released:
+            // StorageEnvironment._currentWriteTransactionHolder
+            // StorageEnvironment._writeTransactionRunning
+            // StorageEnvironment._transactionWriter
+            // during StorageEnvironment.TransactionCompleted on tx dispose because the transaction was still
+            // recognized as having AsyncCommit task in progress while we failed on BeginAsyncCommitAndStartNewTransaction
+
+            using (var tx = Env.WriteTransaction())
+            {
+                tx.LowLevelTransaction.ModifyPage(0);
+                tx.Commit();
+            }
+        }
+    }
+}


### PR DESCRIPTION
…n we have to _always_ null AsyncCommit in order to properly dispose the transaction. The killer was:

https://github.com/ravendb/ravendb/blob/d4f3e490adffcea0a9b2b804f34390756b7cfc89/src/Voron/StorageEnvironment.cs#L796-L797
so in result we never recovered from that state and transaction merger was constantly throwing "A write transaction is already opened by this thread "