### PR TITLE
RavenDB-13703 Allow disposing of EmbeddableDocumentStore even if it was not initialized

### DIFF
--- a/Raven.Database/Client/EmbeddableDocumentStore.cs
+++ b/Raven.Database/Client/EmbeddableDocumentStore.cs
@@ -218,7 +218,8 @@ namespace Raven.Client.Embedded
         }
         public void Dispose()
         {
-            Inner.Dispose();
+            if (_inner != null)
+                _inner.Dispose();
         }
 
         public event EventHandler AfterDispose


### PR DESCRIPTION
It should be possible to dispose an `EmbeddableDocumentStore` even if `Initialize` wasn't called. Without this patch `Dispose` throws an exception which in my opinion doesn't make sense and might masquerade other problems the client code has