### PR TITLE
Support for StreamQueryStatistics in async client API

### DIFF
--- a/src/Raven.Client/Documents/Session/IAsyncAdvancedSessionOperations.Stream.cs
+++ b/src/Raven.Client/Documents/Session/IAsyncAdvancedSessionOperations.Stream.cs
@@ -33,6 +33,16 @@ namespace Raven.Client.Documents.Session
         ///     <para>Does NOT track the entities in the session, and will not includes changes there when SaveChanges() is called</para>
         /// </summary>
         /// <param name="query">Query to stream results for</param>
+        /// <param name="streamQueryStats">Information about the performed query</param>
+        /// <param name="token">The cancellation token.</param>
+        Task<IAsyncEnumerator<StreamResult<T>>> StreamAsync<T>(IAsyncDocumentQuery<T> query, out StreamQueryStatistics streamQueryStats, CancellationToken token = default(CancellationToken));
+
+        /// <summary>
+        ///     Stream the results on the query to the client, converting them to
+        ///     CLR types along the way.
+        ///     <para>Does NOT track the entities in the session, and will not includes changes there when SaveChanges() is called</para>
+        /// </summary>
+        /// <param name="query">Query to stream results for</param>
         /// <param name="token">The cancellation token.</param>
         Task<IAsyncEnumerator<StreamResult<T>>> StreamAsync<T>(IAsyncRawDocumentQuery<T> query, CancellationToken token = default(CancellationToken));
 
@@ -42,8 +52,28 @@ namespace Raven.Client.Documents.Session
         ///     <para>Does NOT track the entities in the session, and will not includes changes there when SaveChanges() is called</para>
         /// </summary>
         /// <param name="query">Query to stream results for</param>
+        /// <param name="streamQueryStats">Information about the performed query</param>
+        /// <param name="token">The cancellation token.</param>
+        Task<IAsyncEnumerator<StreamResult<T>>> StreamAsync<T>(IAsyncRawDocumentQuery<T> query, out StreamQueryStatistics streamQueryStats, CancellationToken token = default(CancellationToken));
+
+        /// <summary>
+        ///     Stream the results on the query to the client, converting them to
+        ///     CLR types along the way.
+        ///     <para>Does NOT track the entities in the session, and will not includes changes there when SaveChanges() is called</para>
+        /// </summary>
+        /// <param name="query">Query to stream results for</param>
         /// <param name="token">The cancellation token.</param>
         Task<IAsyncEnumerator<StreamResult<T>>> StreamAsync<T>(IQueryable<T> query, CancellationToken token = default(CancellationToken));
+
+        /// <summary>
+        ///     Stream the results on the query to the client, converting them to
+        ///     CLR types along the way.
+        ///     <para>Does NOT track the entities in the session, and will not includes changes there when SaveChanges() is called</para>
+        /// </summary>
+        /// <param name="query">Query to stream results for</param>
+        /// <param name="streamQueryStats">Information about the performed query</param>
+        /// <param name="token">The cancellation token.</param>
+        Task<IAsyncEnumerator<StreamResult<T>>> StreamAsync<T>(IQueryable<T> query, out StreamQueryStatistics streamQueryStats, CancellationToken token = default(CancellationToken));
 
         /// <summary>
         ///     Stream the results of documents search to the client, converting them to CLR types along the way.

--- a/test/SlowTests/Core/Streaming/QueryStreaming.cs
+++ b/test/SlowTests/Core/Streaming/QueryStreaming.cs
@@ -100,9 +100,9 @@ namespace SlowTests.Core.Streaming
                         Assert.IsType<User>(reader.Current.Document);
                     }
 
-                    Assert.Equal(stats.IndexName, "Users/ByName");
-                    Assert.Equal(stats.TotalResults, 100);
-                    Assert.Equal(stats.IndexTimestamp.Year, DateTime.Now.Year);
+                    Assert.Equal("Users/ByName", stats.IndexName);
+                    Assert.Equal(100, stats.TotalResults);
+                    Assert.Equal(DateTime.Now.Year, stats.IndexTimestamp.Year);
                 }
 
                 using (var session = store.OpenSession())
@@ -116,9 +116,9 @@ namespace SlowTests.Core.Streaming
                         Assert.IsType<User>(reader.Current.Document);
                     }
 
-                    Assert.Equal(stats.IndexName, "Users/ByName");
-                    Assert.Equal(stats.TotalResults, 100);
-                    Assert.Equal(stats.IndexTimestamp.Year, DateTime.Now.Year);
+                    Assert.Equal("Users/ByName", stats.IndexName);
+                    Assert.Equal(100, stats.TotalResults);
+                    Assert.Equal(DateTime.Now.Year, stats.IndexTimestamp.Year); 
                 }
             }
         }


### PR DESCRIPTION
I was missing support for StreamQueryStatistics in the async client API.
I don't actually like the current API, but I didn't want to introduce any breaking changes and tried to be consistent with the sync API.