### PR TITLE
RavenDB-8451 DR support for encrypted database

### DIFF
--- a/test/SlowTests/Authentication/AuthenticationEncryptionTests.cs
+++ b/test/SlowTests/Authentication/AuthenticationEncryptionTests.cs
@@ -115,7 +115,7 @@ namespace SlowTests.Authentication
             {
                 store.Maintenance.Send(new CreateSampleDataOperation());
 
-                
+
                 using (var commands = store.Commands())
                 {
                     // create auto map index
@@ -222,7 +222,7 @@ namespace SlowTests.Authentication
 
                 var deleteOperation = store.Operations.Send(new DeleteByQueryOperation(new IndexQuery() { Query = "FROM orders" }));
                 await deleteOperation.WaitForCompletionAsync(TimeSpan.FromSeconds(60));
-                
+
                 var oldSize = StorageCompactionTestsSlow.GetDirSize(new DirectoryInfo(path));
 
                 var compactOperation = store.Maintenance.Server.Send(new CompactDatabaseOperation(new CompactSettings

--- a/test/SlowTests/Authentication/AuthenticationEncryptionTests.cs
+++ b/test/SlowTests/Authentication/AuthenticationEncryptionTests.cs
@@ -26,7 +26,7 @@ namespace SlowTests.Authentication
         [Fact]
         public async Task CanUseEncryption()
         {
-            string dbName = SetupEncryptedDatabase(out X509Certificate2 adminCert);
+            string dbName = SetupEncryptedDatabase(out X509Certificate2 adminCert, out var _);
 
             using (var store = GetDocumentStore(new Options
             {

--- a/test/SlowTests/Issues/RavenDB-8451.cs
+++ b/test/SlowTests/Issues/RavenDB-8451.cs
@@ -1,0 +1,78 @@
+﻿using System;
+using System.Collections.Generic;
+using System.IO;
+using System.Linq;
+using System.Security.Cryptography.X509Certificates;
+using System.Text;
+using System.Threading;
+using System.Threading.Tasks;
+using FastTests;
+using Raven.Client.Documents.Operations;
+using Raven.Client.Documents.Smuggler;
+using Tests.Infrastructure;
+using Voron.Recovery;
+using Xunit;
+
+namespace SlowTests.Issues
+{
+    public class RavenDB_8451: RavenTestBase
+    {
+        [Fact64Bit]
+        public async Task CanRecoverEncryptedDatabase()
+        {
+            string dbName = SetupEncryptedDatabase(out X509Certificate2 adminCert, out var masterKey);
+
+            var dbPath = NewDataPath(prefix: Guid.NewGuid().ToString());
+            var recoveryExportPath = NewDataPath(prefix: Guid.NewGuid().ToString());
+
+            DatabaseStatistics databaseStatistics;
+
+            using (var store = GetDocumentStore(new Options()
+            {
+                AdminCertificate = adminCert,
+                ClientCertificate = adminCert,
+                ModifyDatabaseName = s => dbName,
+                ModifyDatabaseRecord = record => record.Encrypted = true,
+                Path = dbPath
+            }))
+            {
+                store.Maintenance.Send(new CreateSampleDataOperation());
+
+                databaseStatistics = store.Maintenance.Send(new GetStatisticsOperation());
+            }
+           
+            using (var recovery = new Recovery(new VoronRecoveryConfiguration()
+            {
+                LoggingMode = Sparrow.Logging.LogMode.None,
+                DataFileDirectory = dbPath,
+                PathToDataFile = Path.Combine(dbPath, "Raven.voron"),
+                OutputFileName = Path.Combine(recoveryExportPath, "recovery.ravendump"),
+                MasterKey = masterKey
+            }))
+            {
+                recovery.Execute(TextWriter.Null, CancellationToken.None);
+            }
+            
+
+            using (var store = GetDocumentStore(new Options()
+            {
+                AdminCertificate = adminCert,
+                ClientCertificate = adminCert,
+            }))
+            {
+                var op = await store.Smuggler.ImportAsync(new DatabaseSmugglerImportOptions()
+                {
+
+                }, Path.Combine(recoveryExportPath, "recovery-2-Documents.ravendump"));
+
+                op.WaitForCompletion(TimeSpan.FromMinutes(2));
+
+                var currentStats = store.Maintenance.Send(new GetStatisticsOperation());
+
+                // + 1 as recovery adds some artificial items
+                Assert.Equal(databaseStatistics.CountOfAttachments + 1, currentStats.CountOfAttachments);
+                Assert.Equal(databaseStatistics.CountOfDocuments + 1, currentStats.CountOfDocuments);
+            }
+        }
+    }
+}

--- a/test/SlowTests/Issues/RavenDB_12151.cs
+++ b/test/SlowTests/Issues/RavenDB_12151.cs
@@ -119,7 +119,7 @@ namespace SlowTests.Issues
         [Fact]
         public void IndexingWhenEncryptedTransactionSizeLimitLimitExceeded()
         {
-            string dbName = SetupEncryptedDatabase(out X509Certificate2 adminCert);
+            string dbName = SetupEncryptedDatabase(out X509Certificate2 adminCert, out var _);
 
             using (var store = GetDocumentStore(new Options()
             {

--- a/test/Tests.Infrastructure/RavenTestBase.cs
+++ b/test/Tests.Infrastructure/RavenTestBase.cs
@@ -718,7 +718,7 @@ namespace FastTests
 
             return serverCertPath;
         }
-        protected string SetupEncryptedDatabase(out X509Certificate2 adminCert, [CallerMemberName] string caller = null)
+        protected string SetupEncryptedDatabase(out X509Certificate2 adminCert,out byte[] masterKey, [CallerMemberName] string caller = null)
         {
             var serverCertPath = SetupServerAuthentication();
             var dbName = GetDatabaseName(caller);
@@ -729,6 +729,8 @@ namespace FastTests
             {
                 rand.GetBytes(buffer);
             }
+
+            masterKey = buffer;
 
             var base64Key = Convert.ToBase64String(buffer);
 

--- a/tools/Voron.Recovery/CommandLineApp.cs
+++ b/tools/Voron.Recovery/CommandLineApp.cs
@@ -69,6 +69,8 @@ namespace Voron.Recovery
 
                 var loggingModeArg = cmd.Option("--LoggingMode", "Logging mode: Operations or Information.", CommandOptionType.SingleValue);
 
+                var masterKey = cmd.Option("--MasterKey", "Encryption key: base64 string of the encryption master key", CommandOptionType.SingleValue);
+
                 cmd.OnExecute(() =>
                 {
                     VoronRecoveryConfiguration config = new VoronRecoveryConfiguration
@@ -161,6 +163,21 @@ namespace Voron.Recovery
                         config.LoggingMode = mode;
                     }
 
+                    if (masterKey.HasValue())
+                    {
+                        var value = masterKey.Value();
+                        byte[] key;
+                        try
+                        {
+                            key = Convert.FromBase64String(value);
+                        }
+                        catch
+                        {
+                            return ExitWithError($"{nameof(config.MasterKey)} argument value ({value}) is not a valid base64 string", cmd);
+                        }
+                           
+                        config.MasterKey = key;
+                    }
                     using (var recovery = new Recovery(config))
                     {
                         var cts = new CancellationTokenSource();

--- a/tools/Voron.Recovery/Recovery.cs
+++ b/tools/Voron.Recovery/Recovery.cs
@@ -321,7 +321,7 @@ namespace Voron.Recovery
                                                 break;
                                             }
                                             
-                                            valid = ValidateOverflowPage(nextPage, eof, (long)nextStreamHeader, ref mem);
+                                            valid = ValidateOverflowPage(nextPage, eof, startOffset, ref mem);
                                             
                                             //we already advance the pointer inside the validation
                                             if (valid == false)
@@ -509,8 +509,6 @@ namespace Voron.Recovery
                 tx.Dispose();
                 tx = new TempPagerTransaction();
             }
-
-            PageHeader header = *(PageHeader*)mem;
 
             long pageNumber = (long)((PageHeader*)mem)->PageNumber;
             var res = Pager.AcquirePagePointer(tx, pageNumber);
@@ -884,7 +882,7 @@ namespace Voron.Recovery
             //pageHeader might be a buffer address we need to verify we don't exceed the original memory boundary here
             var numberOfPages = VirtualPagerLegacyExtensions.GetNumberOfOverflowPages(pageHeader->OverflowSize);
             var sizeOfPages = numberOfPages * _pageSize;
-            var endOfOverflow = startOffset + sizeOfPages;
+            var endOfOverflow = (long)mem + sizeOfPages;
             // the endOfOverflow can be equal to eof if the last page is overflow
             if (endOfOverflow > (long)eof)
             {

--- a/tools/Voron.Recovery/VoronRecoveryConfiguration.cs
+++ b/tools/Voron.Recovery/VoronRecoveryConfiguration.cs
@@ -14,5 +14,7 @@ namespace Voron.Recovery
         public bool DisableCopyOnWriteMode { get; set; }
         public bool? IgnoreInvalidJournalErrors { get; set; }
         public LogMode LoggingMode { get; set; } = LogMode.Operations;
+
+        public byte[] MasterKey { get; set; }
     }
 }


### PR DESCRIPTION
A high-level explanation for this PR:
For encrypted database we need to decrypt pages there were 2 options:
1) Use crypto pager and avoid code duplication and code deviation (if a bug was found in the encryption pager), will require active transaction though.
2) Write a decryption object that holds encryption buffer pool, this can avoid having to deal with the transaction but still have to allocate the same buffers.

I decided to go with option 1.

The majority of the complexity is that the acquired pointer from the decrypted page is not sequential while the code was relying on that fact.
The solution was using a page pointer where it can either point to the same page if it was not decrypted or to a buffer if it is a decrypted page.
