### PR TITLE
RavenDB-11800 Restarting the server should preserve the cluster topology

### DIFF
--- a/src/Raven.Server/Rachis/Candidate.cs
+++ b/src/Raven.Server/Rachis/Candidate.cs
@@ -66,6 +66,16 @@ namespace Raven.Server.Rachis
                         return;
                     }
 
+                    if (_engine.RequestSnapshot)
+                    {
+                        // we aren't allowed to be elected for leadership if we requested a snapshot 
+                        if (_engine.Log.IsOperationsEnabled)
+                        {
+                            _engine.Log.Operations("we aren't allowed to be elected for leadership if we requested a snapshot");
+                        }
+                        return;
+                    }
+
                     if (IsForcedElection)
                     {
                         CastVoteForSelf(ElectionTerm + 1, "Voting for self in forced elections");

--- a/test/RachisTests/AddNodeToClusterTests.cs
+++ b/test/RachisTests/AddNodeToClusterTests.cs
@@ -14,9 +14,12 @@ using Raven.Client.Exceptions.Cluster;
 using Raven.Client.Http;
 using Raven.Client.ServerWide;
 using Raven.Client.ServerWide.Operations;
+using Raven.Server;
 using Raven.Server.Config;
+using Raven.Server.Rachis;
 using Raven.Server.ServerWide.Commands;
 using Raven.Server.ServerWide.Context;
+using Raven.Server.Utils;
 using Raven.Server.Web.System;
 using Raven.Tests.Core.Utils.Entities;
 using Sparrow.Json;
@@ -516,6 +519,31 @@ namespace RachisTests
             }
         }
 
+        [Fact]
+        public async Task ResetServerShouldPreserveTopology()
+        {
+            var cluster = await CreateRaftCluster(3, shouldRunInMemory: false);
+            var followers = cluster.Nodes.Where(x => x != cluster.Leader);
+            DebuggerAttachedTimeout.DisableLongTimespan = true;
+
+            foreach (var follower in followers)
+            {
+                
+                while (cluster.Leader.ServerStore.Engine.CurrentLeader.TryModifyTopology(follower.ServerStore.NodeTag, follower.ServerStore.Engine.Url, Leader.TopologyModification.NonVoter, out var task) == false)
+                {
+                    await task;
+                }
+            }
+
+            var result = await DisposeServerAndWaitForFinishOfDisposalAsync(cluster.Leader);
+            cluster.Leader = GetNewServer(deletePrevious: false, runInMemory: false, partialPath: result.DataDir, customSettings: new Dictionary<string, string>
+            {
+                [RavenConfiguration.GetKey(x => x.Core.ServerUrls)] = result.Url
+            });
+
+            var topology = cluster.Leader.ServerStore.GetClusterTopology();
+            Assert.Equal(3, topology.AllNodes.Count);
+        }
         private async Task WaitForAssertion(Action action)
         {
             var sp = Stopwatch.StartNew();


### PR DESCRIPTION
The issue was, that we treated a single member in the cluster topology as a single node in the topology