### PR TITLE
Memory "leak" Insights - for review

### DIFF
--- a/src/Raven.Client/Documents/Session/AsyncDocumentSession.cs
+++ b/src/Raven.Client/Documents/Session/AsyncDocumentSession.cs
@@ -139,10 +139,16 @@ namespace Raven.Client.Documents.Session
 
                 if (NoTracking)
                     throw new InvalidOperationException($"Cannot execute '{nameof(SaveChangesAsync)}' when entity tracking is disabled in session.");
-
-                await RequestExecutor.ExecuteAsync(command, Context, SessionInfo, token).ConfigureAwait(false);
-                UpdateSessionAfterSaveChanges(command.Result);
-                saveChangesOperation.SetResult(command.Result);
+                try
+                {
+                    await RequestExecutor.ExecuteAsync(command, Context, SessionInfo, token).ConfigureAwait(false);
+                    UpdateSessionAfterSaveChanges(command.Result);
+                    saveChangesOperation.SetResult(command.Result);
+                }
+                finally
+                {
+                    command.Result?.Results?.Dispose();
+                }
             }
         }
     }

--- a/src/Raven.Client/Documents/Session/DocumentSession.cs
+++ b/src/Raven.Client/Documents/Session/DocumentSession.cs
@@ -86,10 +86,16 @@ namespace Raven.Client.Documents.Session
 
                 if (NoTracking)
                     throw new InvalidOperationException($"Cannot execute '{nameof(SaveChanges)}' when entity tracking is disabled in session.");
-
-                RequestExecutor.Execute(command, Context, sessionInfo: SessionInfo);
-                UpdateSessionAfterSaveChanges(command.Result);
-                saveChangesOperation.SetResult(command.Result);
+                try
+                {
+                    RequestExecutor.Execute(command, Context, sessionInfo: SessionInfo);
+                    UpdateSessionAfterSaveChanges(command.Result);
+                    saveChangesOperation.SetResult(command.Result);
+                }
+                finally
+                {
+                    command.Result?.Results?.Dispose();
+                }
             }
         }
 

--- a/src/Sparrow/Json/JsonOperationContext.cs
+++ b/src/Sparrow/Json/JsonOperationContext.cs
@@ -1,5 +1,6 @@
 ﻿using System;
 using System.Buffers;
+using System.Collections.Concurrent;
 using System.Collections.Generic;
 using System.Diagnostics;
 using System.IO;
@@ -49,8 +50,8 @@ namespace Sparrow.Json
         }
 
         private int _numberOfAllocatedPathCaches = -1;
-        private readonly PathCacheHolder[] _allocatePathCaches = new PathCacheHolder[512];
-        private readonly Stack<MemoryStream> _cachedMemoryStreams = new Stack<MemoryStream>();
+        private PathCacheHolder[] _allocatePathCaches = new PathCacheHolder[512];
+        private Stack<MemoryStream> _cachedMemoryStreams = new Stack<MemoryStream>();
 
         private int _numberOfAllocatedStringsValues;
         private readonly FastList<LazyStringValue> _allocateStringValues = new FastList<LazyStringValue>(256);
@@ -1036,7 +1037,10 @@ namespace Sparrow.Json
 
                 _pooledArrays = null;
             }
-        }
+            //TODO:Don't PR this, just testing.
+            PathCacheHolder[] _allocatePathCaches = new PathCacheHolder[512];
+            Stack<MemoryStream> _cachedMemoryStreams = new Stack<MemoryStream>();
+    }
 
         public void Write(Stream stream, BlittableJsonReaderObject json)
         {


### PR DESCRIPTION
This PR is about memory utilization when using session.Store to bulk insert documents rather than bulkInsert.Store.
On the same workload, 32 threads each putting 8192 documents of the same size (two guid fields as strings) the bulk insert uses about 200MB steadily the session store will grow until it will throw OOM and crash.

The first place i saw that we leak some memory is the Context cached paths there is quite a large memory left there but it is not the main reason for the leak and cleaning those paths might hurt performance for some scenarios where we reset the context but keep using it for the same type of operation (e.g smuggler or bulk insert)

After cleaning the paths there still seems to be too many BlittableReaderObjects left even after calling the GC.Collect on all generations looking at them they looked like the save changes results and looking at the code we indeed never dispose of those blittable readers we even have a remark that we are doing it on purpose (will be collected when context will be reset)
There are two issues here:
1. The context (request executor from the document store) grows quite big
2. The reader objects seem to somehow survive the GC collect and we accumulate enough of them that they show on the dumpheap as a major memory leak ( i saw 200M of them and they are 114bytes big)

In conclusion, I'm not sure regarding my changes to the context field but I think it is safe to dispose of the save changes response as it is already a clone of the cached object (and I ran slow test which seems to be okay with it)

@ayende @ppekrol @arekpalinski @maximburyak @redknightlois please have a look.