### PR TITLE
RavenDB-13735 @refresh feature for doc update

### DIFF
--- a/src/Raven.Client/Constants.cs
+++ b/src/Raven.Client/Constants.cs
@@ -169,6 +169,8 @@ namespace Raven.Client
 
                 public const string Expires = "@expires";
 
+                public const string Refresh = "@refresh";
+
                 public const string HasValue = "HasValue";
 
                 public const string Etag = "@etag";

--- a/src/Raven.Client/Documents/Operations/Refresh/ConfigureExpirationOperation.cs
+++ b/src/Raven.Client/Documents/Operations/Refresh/ConfigureExpirationOperation.cs
@@ -1,0 +1,65 @@
+﻿using System.Net.Http;
+using Raven.Client.Documents.Conventions;
+using Raven.Client.Documents.Operations.Expiration;
+using Raven.Client.Documents.Session;
+using Raven.Client.Http;
+using Raven.Client.Json;
+using Raven.Client.Json.Converters;
+using Raven.Client.Util;
+using Sparrow.Json;
+
+namespace Raven.Client.Documents.Operations.Refresh
+{
+    public class ConfigureRefreshOperation : IMaintenanceOperation<ConfigureRefreshOperationResult>
+    {
+        private readonly RefreshConfiguration _configuration;
+
+        public ConfigureRefreshOperation(RefreshConfiguration configuration)
+        {
+            _configuration = configuration;
+        }
+
+        public RavenCommand<ConfigureRefreshOperationResult> GetCommand(DocumentConventions conventions, JsonOperationContext ctx)
+        {
+            return new ConfigureRefreshCommand(_configuration);
+        }
+
+        private class ConfigureRefreshCommand: RavenCommand<ConfigureRefreshOperationResult>, IRaftCommand
+        {
+            private readonly RefreshConfiguration _configuration;
+
+            public ConfigureRefreshCommand(RefreshConfiguration configuration)
+            {
+                _configuration = configuration;
+            }
+
+            public override bool IsReadRequest => false;
+            public override HttpRequestMessage CreateRequest(JsonOperationContext ctx, ServerNode node, out string url)
+            {
+                url = $"{node.Url}/databases/{node.Database}/admin/refresh/config";
+
+                var request = new HttpRequestMessage
+                {
+                    Method = HttpMethod.Post,
+                    Content = new BlittableJsonContent(stream =>
+                    {
+                        var config = EntityToBlittable.ConvertCommandToBlittable(_configuration, ctx);
+                        ctx.Write(stream, config);
+                    })
+                };
+
+                return request;
+            }
+
+            public override void SetResponse(JsonOperationContext context, BlittableJsonReaderObject response, bool fromCache)
+            {
+                if (response == null)
+                    ThrowInvalidResponse();
+
+                Result = JsonDeserializationClient.ConfigureRefreshOperationResult(response);
+            }
+
+            public string RaftUniqueRequestId { get; } = RaftIdGenerator.NewId();
+        }
+    }
+}

--- a/src/Raven.Client/Documents/Operations/Refresh/ConfigureRefreshOperation.cs
+++ b/src/Raven.Client/Documents/Operations/Refresh/ConfigureRefreshOperation.cs
@@ -1,6 +1,5 @@
 ﻿using System.Net.Http;
 using Raven.Client.Documents.Conventions;
-using Raven.Client.Documents.Operations.Expiration;
 using Raven.Client.Documents.Session;
 using Raven.Client.Http;
 using Raven.Client.Json;

--- a/src/Raven.Client/Documents/Operations/Refresh/ConfigureRefreshOperationResult.cs
+++ b/src/Raven.Client/Documents/Operations/Refresh/ConfigureRefreshOperationResult.cs
@@ -1,0 +1,7 @@
+namespace Raven.Client.Documents.Operations.Refresh
+{
+    public class ConfigureRefreshOperationResult
+    {
+        public long? RaftCommandIndex { get; set; }
+    }
+}

--- a/src/Raven.Client/Documents/Operations/Refresh/ExpirationConfiguration.cs
+++ b/src/Raven.Client/Documents/Operations/Refresh/ExpirationConfiguration.cs
@@ -1,0 +1,46 @@
+using System;
+using Sparrow.Json.Parsing;
+
+namespace Raven.Client.Documents.Operations.Refresh
+{
+    public class RefreshConfiguration : IDynamicJson
+    {
+        public bool Disabled { get; set; }
+
+        public long? RefreshFrequencyInSec { get; set; }
+
+
+        protected bool Equals(RefreshConfiguration other)
+        {
+            return Disabled == other.Disabled && RefreshFrequencyInSec == other.RefreshFrequencyInSec;
+        }
+
+        public override bool Equals(object obj)
+        {
+            if (ReferenceEquals(null, obj)) return false;
+            if (ReferenceEquals(this, obj)) return true;
+            if (obj.GetType() != this.GetType()) return false;
+            return Equals((RefreshConfiguration)obj);
+        }
+
+        public override int GetHashCode()
+        {
+            unchecked
+            {
+                var hashCode = Disabled.GetHashCode();
+                hashCode = (hashCode * 397) ^ RefreshFrequencyInSec.GetHashCode();
+                return hashCode;
+            }
+        }
+
+
+        public DynamicJsonValue ToJson()
+        {
+            return new DynamicJsonValue
+            {
+                [nameof(Disabled)] = Disabled,
+                [nameof(RefreshFrequencyInSec)] = RefreshFrequencyInSec,
+            };
+        }
+    }
+}

--- a/src/Raven.Client/Documents/Operations/Refresh/RefreshConfiguration.cs
+++ b/src/Raven.Client/Documents/Operations/Refresh/RefreshConfiguration.cs
@@ -1,4 +1,3 @@
-using System;
 using Sparrow.Json.Parsing;
 
 namespace Raven.Client.Documents.Operations.Refresh
@@ -17,9 +16,12 @@ namespace Raven.Client.Documents.Operations.Refresh
 
         public override bool Equals(object obj)
         {
-            if (ReferenceEquals(null, obj)) return false;
-            if (ReferenceEquals(this, obj)) return true;
-            if (obj.GetType() != this.GetType()) return false;
+            if (ReferenceEquals(null, obj))
+                return false;
+            if (ReferenceEquals(this, obj))
+                return true;
+            if (obj.GetType() != this.GetType())
+                return false;
             return Equals((RefreshConfiguration)obj);
         }
 

--- a/src/Raven.Client/Documents/Smuggler/SmugglerResult.cs
+++ b/src/Raven.Client/Documents/Smuggler/SmugglerResult.cs
@@ -222,6 +222,8 @@ namespace Raven.Client.Documents.Smuggler
 
             public bool ExpirationConfigurationUpdated { get; set; }
 
+            public bool RefreshConfigurationUpdated { get; set; }
+
             public bool RavenConnectionStringsUpdated { get; set; }
 
             public bool SqlConnectionStringsUpdated { get; set; }
@@ -237,6 +239,9 @@ namespace Raven.Client.Documents.Smuggler
 
                 if (ExpirationConfigurationUpdated)
                     json[nameof(ExpirationConfigurationUpdated)] = ExpirationConfigurationUpdated;
+
+                if (RefreshConfigurationUpdated)
+                    json[nameof(RefreshConfigurationUpdated)] = RefreshConfigurationUpdated;
 
                 if (RavenConnectionStringsUpdated)
                     json[nameof(RavenConnectionStringsUpdated)] = RavenConnectionStringsUpdated;
@@ -282,6 +287,9 @@ namespace Raven.Client.Documents.Smuggler
 
                 if (ExpirationConfigurationUpdated)
                     sb.AppendLine("- Expiration");
+
+                if (RefreshConfigurationUpdated)
+                    sb.AppendLine("- Refresh");
 
                 if (RavenConnectionStringsUpdated)
                     sb.AppendLine("- RavenDB Connection Strings");

--- a/src/Raven.Client/Json/BlittableJsonWriter.cs
+++ b/src/Raven.Client/Json/BlittableJsonWriter.cs
@@ -50,7 +50,8 @@ namespace Raven.Client.Json
                     if (prop.Name.Length > 0 && prop.Name[0] == '@')
                     {
                         if (prop.Name != Constants.Documents.Metadata.Collection && 
-                            prop.Name != Constants.Documents.Metadata.Expires && 
+                            prop.Name != Constants.Documents.Metadata.Expires &&
+                            prop.Name != Constants.Documents.Metadata.Refresh &&
                             prop.Name != Constants.Documents.Metadata.Edges)
                             continue; // system property, ignoring it
                     }

--- a/src/Raven.Client/Json/Converters/JsonDeserializationClient.cs
+++ b/src/Raven.Client/Json/Converters/JsonDeserializationClient.cs
@@ -12,6 +12,7 @@ using Raven.Client.Documents.Operations.Counters;
 using Raven.Client.Documents.Operations.ETL;
 using Raven.Client.Documents.Operations.Expiration;
 using Raven.Client.Documents.Operations.OngoingTasks;
+using Raven.Client.Documents.Operations.Refresh;
 using Raven.Client.Documents.Operations.Replication;
 using Raven.Client.Documents.Operations.Revisions;
 using Raven.Client.Documents.Operations.TransactionsRecording;
@@ -141,6 +142,8 @@ namespace Raven.Client.Json.Converters
         internal static readonly Func<BlittableJsonReaderObject, DeleteDatabaseResult> DeleteDatabaseResult = GenerateJsonDeserializationRoutine<DeleteDatabaseResult>();
 
         internal static readonly Func<BlittableJsonReaderObject, ConfigureExpirationOperationResult> ConfigureExpirationOperationResult = GenerateJsonDeserializationRoutine<ConfigureExpirationOperationResult>();
+
+        internal static readonly Func<BlittableJsonReaderObject, ConfigureRefreshOperationResult> ConfigureRefreshOperationResult = GenerateJsonDeserializationRoutine<ConfigureRefreshOperationResult>();
 
         internal static readonly Func<BlittableJsonReaderObject, UpdatePeriodicBackupOperationResult> ConfigurePeriodicBackupOperationResult = GenerateJsonDeserializationRoutine<UpdatePeriodicBackupOperationResult>();
 

--- a/src/Raven.Client/ServerWide/DatabaseRecord.cs
+++ b/src/Raven.Client/ServerWide/DatabaseRecord.cs
@@ -8,6 +8,7 @@ using Raven.Client.Documents.Operations.Configuration;
 using Raven.Client.Documents.Operations.ETL;
 using Raven.Client.Documents.Operations.ETL.SQL;
 using Raven.Client.Documents.Operations.Expiration;
+using Raven.Client.Documents.Operations.Refresh;
 using Raven.Client.Documents.Operations.Replication;
 using Raven.Client.Documents.Operations.Revisions;
 using Raven.Client.Documents.Queries.Sorting;
@@ -65,6 +66,8 @@ namespace Raven.Client.ServerWide
         public RevisionsConfiguration Revisions;
 
         public ExpirationConfiguration Expiration;
+
+        public RefreshConfiguration Refresh;
 
         public List<PeriodicBackupConfiguration> PeriodicBackups = new List<PeriodicBackupConfiguration>();
 

--- a/src/Raven.Server/Background/BackgroundWorkBase.cs
+++ b/src/Raven.Server/Background/BackgroundWorkBase.cs
@@ -79,6 +79,9 @@ namespace Raven.Server.Background
         {
             try
             {
+                if (time < TimeSpan.Zero)
+                    return;
+
                 // if cancellation requested then it will throw TaskCancelledException and we stop the work
                 await TimeoutManager.WaitFor(time, CancellationToken).ConfigureAwait(false); 
             }

--- a/src/Raven.Server/Documents/Expiration/ExpirationStorage.cs
+++ b/src/Raven.Server/Documents/Expiration/ExpirationStorage.cs
@@ -136,7 +136,7 @@ namespace Raven.Server.Documents.Expiration
                                     var document = _database.DocumentsStorage.Get(context, clonedId);
                                     if (document == null ||
                                         document.TryGetMetadata(out var metadata) == false || 
-                                        HasExpired(metadata, metadataPropertyToCheck, currentTime) == false)
+                                        HasPassed(metadata, metadataPropertyToCheck, currentTime) == false)
                                     {
                                         expiredDocs.Add((clonedId, null));
                                         continue;
@@ -186,7 +186,7 @@ namespace Raven.Server.Documents.Expiration
                 {
                     id = conflict.Id;
 
-                    if (HasExpired(conflict.Doc, currentTime))
+                    if (HasPassed(conflict.Doc, currentTime))
                         continue;
 
                     allExpired = false;
@@ -197,17 +197,17 @@ namespace Raven.Server.Documents.Expiration
             return (allExpired, id);
         }
 
-        public static bool HasExpired(BlittableJsonReaderObject data, DateTime currentTime)
+        public static bool HasPassed(BlittableJsonReaderObject data, DateTime currentTime)
         {
             // Validate that the expiration value in metadata is still the same.
             // We have to check this as the user can update this value.
             if (data.TryGet(Constants.Documents.Metadata.Key, out BlittableJsonReaderObject metadata) == false)
                 return false;
 
-            return HasExpired(metadata, Constants.Documents.Metadata.Expires, currentTime);
+            return HasPassed(metadata, Constants.Documents.Metadata.Expires, currentTime);
         }
 
-        private static bool HasExpired(BlittableJsonReaderObject metadata, string metadataPropertyName, DateTime currentTime)
+        private static bool HasPassed(BlittableJsonReaderObject metadata, string metadataPropertyName, DateTime currentTime)
         {
             if (metadata.TryGet(metadataPropertyName, out string expirationDate))
             {
@@ -238,7 +238,7 @@ namespace Raven.Server.Documents.Expiration
                             var doc = _database.DocumentsStorage.Get(context, ids.LowerId, throwOnConflict: true);
                             if (doc != null && doc.TryGetMetadata(out var metadata))
                             {
-                                if (HasExpired(metadata, Constants.Documents.Metadata.Expires, currentTime))
+                                if (HasPassed(metadata, Constants.Documents.Metadata.Expires, currentTime))
                                 {
                                     _database.DocumentsStorage.Delete(context, ids.LowerId, ids.Id, expectedChangeVector: null);
                                 }
@@ -275,7 +275,7 @@ namespace Raven.Server.Documents.Expiration
                         var doc = _database.DocumentsStorage.Get(context, ids.LowerId, throwOnConflict: false);
                         if (doc != null && doc.TryGetMetadata(out var metadata))
                         {
-                            if (HasExpired(metadata, Constants.Documents.Metadata.Refresh, currentTime))
+                            if (HasPassed(metadata, Constants.Documents.Metadata.Refresh, currentTime))
                             {
                                 // remove the @refresh tag
                                 metadata.Modifications = new Sparrow.Json.Parsing.DynamicJsonValue(metadata);

--- a/src/Raven.Server/Documents/Handlers/ExpirationHandler.cs
+++ b/src/Raven.Server/Documents/Handlers/ExpirationHandler.cs
@@ -43,5 +43,11 @@ namespace Raven.Server.Documents.Handlers
         {
             await DatabaseConfigurations(ServerStore.ModifyDatabaseExpiration, "read-expiration-config", GetRaftRequestIdFromQuery());
         }
+
+        [RavenAction("/databases/*/admin/refresh/config", "POST", AuthorizationStatus.DatabaseAdmin)]
+        public async Task ConfigRefresh()
+        {
+            await DatabaseConfigurations(ServerStore.ModifyDatabaseExpiration, "read-refresh-config", GetRaftRequestIdFromQuery());
+        }
     }
 }

--- a/src/Raven.Server/Documents/Handlers/ExpirationHandler.cs
+++ b/src/Raven.Server/Documents/Handlers/ExpirationHandler.cs
@@ -47,7 +47,7 @@ namespace Raven.Server.Documents.Handlers
         [RavenAction("/databases/*/admin/refresh/config", "POST", AuthorizationStatus.DatabaseAdmin)]
         public async Task ConfigRefresh()
         {
-            await DatabaseConfigurations(ServerStore.ModifyDatabaseExpiration, "read-refresh-config", GetRaftRequestIdFromQuery());
+            await DatabaseConfigurations(ServerStore.ModifyDatabaseRefresh, "read-refresh-config", GetRaftRequestIdFromQuery());
         }
     }
 }

--- a/src/Raven.Server/ServerWide/ClusterCommandsVersionManager.cs
+++ b/src/Raven.Server/ServerWide/ClusterCommandsVersionManager.cs
@@ -108,6 +108,7 @@ namespace Raven.Server.ServerWide
             [nameof(DeleteServerWideBackupConfigurationCommand)] = 42_001,
             [nameof(UpdateUnusedDatabaseIdsCommand)] = 42_002,
             [nameof(UpdateLicenseLimitsCommand)] = 42_002,
+            [nameof(EditRefreshCommand)] = 42_003,
         };
 
         public static bool CanPutCommand(string command)

--- a/src/Raven.Server/ServerWide/ClusterStateMachine.cs
+++ b/src/Raven.Server/ServerWide/ClusterStateMachine.cs
@@ -308,6 +308,7 @@ namespace Raven.Server.ServerWide
                     case nameof(EditRevisionsConfigurationCommand):
                     case nameof(UpdatePeriodicBackupCommand):
                     case nameof(EditExpirationCommand):
+                    case nameof(EditRefreshCommand):
                     case nameof(ModifyConflictSolverCommand):
                     case nameof(UpdateTopologyCommand):
                     case nameof(DeleteDatabaseCommand):
@@ -1846,6 +1847,7 @@ namespace Raven.Server.ServerWide
                 case nameof(SetIndexStateCommand):
                 case nameof(EditRevisionsConfigurationCommand):
                 case nameof(EditExpirationCommand):
+                case nameof(EditRefreshCommand):
                 case nameof(EditDatabaseClientConfigurationCommand):
                     databaseRecord.EtagForBackup = index;
                     break;

--- a/src/Raven.Server/ServerWide/Commands/EditRefreshCommand.cs
+++ b/src/Raven.Server/ServerWide/Commands/EditRefreshCommand.cs
@@ -1,0 +1,37 @@
+﻿using Raven.Client.Documents.Operations.Expiration;
+using Raven.Client.Documents.Operations.Refresh;
+using Raven.Client.ServerWide;
+using Raven.Server.Utils;
+using Sparrow.Json.Parsing;
+
+namespace Raven.Server.ServerWide.Commands
+{
+    public class EditRefreshCommand : UpdateDatabaseCommand
+    {
+        public RefreshConfiguration Configuration;
+        public void UpdateDatabaseRecord(DatabaseRecord databaseRecord)
+        {
+            databaseRecord.Refresh = Configuration;
+        }
+
+        public EditRefreshCommand()
+        {
+        }
+
+        public EditRefreshCommand(RefreshConfiguration configuration, string databaseName, string uniqueRequestId) : base(databaseName, uniqueRequestId)
+        {
+            Configuration = configuration;
+        }
+
+        public override string UpdateDatabaseRecord(DatabaseRecord record, long etag)
+        {
+            record.Refresh = Configuration;
+            return null;
+        }
+
+        public override void FillJson(DynamicJsonValue json)
+        {
+            json[nameof(Configuration)] = TypeConverter.ToBlittableSupportedType(Configuration);
+        }
+    }
+}

--- a/src/Raven.Server/ServerWide/JsonDeserializationCluster.cs
+++ b/src/Raven.Server/ServerWide/JsonDeserializationCluster.cs
@@ -5,6 +5,7 @@ using Raven.Client.Documents.Operations.Configuration;
 using Raven.Client.Documents.Operations.ETL;
 using Raven.Client.Documents.Operations.ETL.SQL;
 using Raven.Client.Documents.Operations.Expiration;
+using Raven.Client.Documents.Operations.Refresh;
 using Raven.Client.Documents.Operations.Replication;
 using Raven.Client.Documents.Operations.Revisions;
 using Raven.Client.Documents.Queries.Sorting;
@@ -52,6 +53,8 @@ namespace Raven.Server.ServerWide
         public static readonly Func<BlittableJsonReaderObject, RemoveNodeFromClusterCommand> RemoveNodeFromClusterCommand = GenerateJsonDeserializationRoutine<RemoveNodeFromClusterCommand>();
 
         public static readonly Func<BlittableJsonReaderObject, ExpirationConfiguration> ExpirationConfiguration = GenerateJsonDeserializationRoutine<ExpirationConfiguration>();
+
+        public static readonly Func<BlittableJsonReaderObject, RefreshConfiguration> RefreshConfiguration = GenerateJsonDeserializationRoutine<RefreshConfiguration>();
 
         public static readonly Func<BlittableJsonReaderObject, PeriodicBackupConfiguration> PeriodicBackupConfiguration = GenerateJsonDeserializationRoutine<PeriodicBackupConfiguration>();
 
@@ -110,6 +113,7 @@ namespace Raven.Server.ServerWide
             [nameof(EditRevisionsConfigurationCommand)] = GenerateJsonDeserializationRoutine<EditRevisionsConfigurationCommand>(),
             [nameof(EditDatabaseClientConfigurationCommand)] = GenerateJsonDeserializationRoutine<EditDatabaseClientConfigurationCommand>(),
             [nameof(EditExpirationCommand)] = GenerateJsonDeserializationRoutine<EditExpirationCommand>(),
+            [nameof(EditRefreshCommand)] = GenerateJsonDeserializationRoutine<EditRefreshCommand>(),
             [nameof(DeleteDatabaseCommand)] = GenerateJsonDeserializationRoutine<DeleteDatabaseCommand>(),
             [nameof(IncrementClusterIdentityCommand)] = GenerateJsonDeserializationRoutine<IncrementClusterIdentityCommand>(),
             [nameof(IncrementClusterIdentitiesBatchCommand)] = GenerateJsonDeserializationRoutine<IncrementClusterIdentitiesBatchCommand>(),

--- a/src/Raven.Server/ServerWide/ServerStore.cs
+++ b/src/Raven.Server/ServerWide/ServerStore.cs
@@ -1554,6 +1554,18 @@ namespace Raven.Server.ServerWide
             return SendToLeaderAsync(editExpiration);
         }
 
+        public Task<(long Index, object Result)> ModifyDatabaseRefresh(TransactionOperationContext context, string databaseName, BlittableJsonReaderObject configurationJson, string raftRequestId)
+        {
+            var refresh = JsonDeserializationCluster.RefreshConfiguration(configurationJson);
+            if (refresh.RefreshFrequencyInSec <= 0)
+            {
+                throw new InvalidOperationException(
+                    $"Refresh frequency for database '{databaseName}' must be greater than 0.");
+            }
+            var editExpiration = new EditRefreshCommand(refresh, databaseName, raftRequestId);
+            return SendToLeaderAsync(editExpiration);
+        }
+
         public Task<(long Index, object Result)> PutServerWideBackupConfigurationAsync(ServerWideBackupConfiguration configuration, string raftRequestId)
         {
             var command = new PutServerWideBackupConfigurationCommand(configuration, raftRequestId);

--- a/src/Raven.Server/Smuggler/Documents/DatabaseDestination.cs
+++ b/src/Raven.Server/Smuggler/Documents/DatabaseDestination.cs
@@ -756,6 +756,14 @@ namespace Raven.Server.Smuggler.Documents
                     progress.ExpirationConfigurationUpdated = true;
                 }
 
+                if (databaseRecord?.Refresh != null)
+                {
+                    if (_log.IsInfoEnabled)
+                        _log.Info("Configuring refresh from smuggler");
+                    tasks.Add(_database.ServerStore.SendToLeaderAsync(new EditRefreshCommand(databaseRecord.Refresh, _database.Name, RaftIdGenerator.DontCareId)));
+                    progress.RefreshConfigurationUpdated = true;
+                }
+
                 if (databaseRecord?.RavenConnectionStrings.Count > 0)
                 {
                     if (_log.IsInfoEnabled)

--- a/src/Raven.Server/Smuggler/Documents/DatabaseSmuggler.cs
+++ b/src/Raven.Server/Smuggler/Documents/DatabaseSmuggler.cs
@@ -598,7 +598,7 @@ namespace Raven.Server.Smuggler.Documents
                     }
 
                     if (_options.IncludeExpired == false &&
-                        ExpirationStorage.HasExpired(item.Document.Data, _time.GetUtcNow()))
+                        ExpirationStorage.HasPassed(item.Document.Data, _time.GetUtcNow()))
                     {
                         SkipDocument(item, result);
                         continue;

--- a/test/SlowTests/Issues/RavenDB-13735.cs
+++ b/test/SlowTests/Issues/RavenDB-13735.cs
@@ -1,0 +1,60 @@
+﻿using System;
+using System.Threading.Tasks;
+using FastTests;
+using Raven.Client.Documents;
+using Raven.Client.Documents.Operations.Refresh;
+using Xunit;
+
+namespace SlowTests.Issues
+{
+    public class RavenDB_13735 : RavenTestBase
+    {
+        private async Task SetupRefresh(DocumentStore store)
+        {
+            var config = new RefreshConfiguration
+            {
+                Disabled = false,
+                RefreshFrequencyInSec = 100,
+            };
+
+            var result = await store.Maintenance.SendAsync(new ConfigureRefreshOperation(config));
+            await WaitForRaftIndexToBeAppliedInCluster(result.RaftCommandIndex ?? 1, TimeSpan.FromMinutes(1));
+        }
+
+        [Fact]
+        public async Task RefreshWillUpdateDocumentChangeVector()
+        {
+            using (var store = GetDocumentStore())
+            {
+                await SetupRefresh(store);
+                string expectedChangeVector = null;
+                using (var session = store.OpenAsyncSession())
+                {
+                    var user = new { Name = "Oren" };
+                    await session.StoreAsync(user, "users/1-A");
+
+                    session.Advanced.GetMetadataFor(user)["@refresh"] = DateTime.UtcNow.AddHours(-1).ToString("o");
+
+                    await session.SaveChangesAsync();
+
+                    expectedChangeVector = session.Advanced.GetChangeVectorFor(user);
+                }
+
+                var database = await GetDocumentDatabaseInstanceFor(store);
+                database.Time.UtcDateTime = () => DateTime.UtcNow.AddMinutes(10);
+                var expiredDocumentsCleaner = database.ExpiredDocumentsCleaner;
+                await expiredDocumentsCleaner.RefreshDocs();
+
+                using (var session = store.OpenAsyncSession())
+                {
+                    var user = await session.LoadAsync<object>("users/1-A");
+                    Assert.NotNull(user);
+                    var actualChangeVector = session.Advanced.GetChangeVectorFor(user);
+
+                    Assert.NotEqual(expectedChangeVector, actualChangeVector);
+                }
+
+            }
+        }
+    }
+}

--- a/test/SlowTests/Issues/RavenDB_11909.cs
+++ b/test/SlowTests/Issues/RavenDB_11909.cs
@@ -81,7 +81,7 @@ namespace SlowTests.Issues
         [Fact]
         public void ThrowOnDatabaseRecordChanges()
         {
-            const int numberOfFields = 27;
+            const int numberOfFields = 28;
             const int numberOfProperties = 0;
             var tasksList = new List<string>
             {


### PR DESCRIPTION
This allows you to define a `"@refresh: <date>` metadata property.
If expiration is enabled, at around that date, RavenDB will automatically remove the `@refresh` property.
That is all.

This is done for the sole purpose of triggering actions on document modifications.
In particular, this gives us a very nice way to defer actions when using subscriptions.

Things that we still need to decide:
* This runs using the expiration mechanism, do we enable this by default (just for refresh?)
* In a cluster, what should the behavior be? Normally, this will happen on all nodes at the same time, generating a conflict. With expiration,the document is deleted. No biggie, the conflict ends up being the same thing. 
* Should we make this use `WhoseTaskIsIt` to decide for each topology who owns the refreshes?
* When using external replication, how would that work?