### PR TITLE
RavenDB-13695 : fix MethodDynamicParametersRewriter

### DIFF
--- a/test/FastTests/Client/Indexing/IndexExtensionFromClient.cs
+++ b/test/FastTests/Client/Indexing/IndexExtensionFromClient.cs
@@ -1,4 +1,5 @@
 ﻿using System;
+using System.Collections;
 using System.Collections.Generic;
 using System.Globalization;
 using System.IO;
@@ -8,6 +9,7 @@ using FastTests.Server.Basic.Entities;
 using NodaTime;
 using Raven.Client.Documents.Indexes;
 using Raven.Client.ServerWide.Operations;
+using Raven.Tests.Core.Utils.Entities;
 using Xunit;
 using static FastTests.Client.Indexing.PeopleUtil;
 
@@ -75,6 +77,477 @@ namespace My.Crazy.Namespace
             }
         }
 
+        [Fact]
+        public void CanUseMethodFromExtensionsInIndex_List()
+        {
+            using (var store = GetDocumentStore())
+            {
+                store.ExecuteIndex(new PeopleIndex1());
+
+                using (var session = store.OpenSession())
+                {
+                    session.Store(new Person
+                    {
+                        Name = "aviv",
+                        Friends = new List<string>
+                        {
+                            "jerry", "bob", "ayende"
+                        }
+                    });
+
+                    session.Store(new Person
+                    {
+                        Name = "reeb",
+                        Friends = new List<string>
+                        {
+                            "david", "ayende"
+                        }
+                    });
+
+                    session.SaveChanges();
+                }
+
+                WaitForIndexing(store);
+
+                using (var session = store.OpenSession())
+                {
+                    var person = session.Query<Person, PeopleIndex1>().Single();
+                    Assert.Equal("aviv", person.Name);
+                }
+            }
+        }
+
+        [Fact]
+        public void CanUseMethodFromExtensionsInIndex_Dictionary()
+        {
+            using (var store = GetDocumentStore())
+            {
+                store.ExecuteIndex(new PeopleIndex2());
+
+                using (var session = store.OpenSession())
+                {
+                    session.Store(new Person
+                    {
+                        Name = "aviv",
+                        Contacts = new Dictionary<string, long>
+                        {
+                            {
+                                "jerry", 5554866812
+                            },
+                            {
+                                "bob", 5554866813
+                            },
+                            {
+                                "ayende", 5554866814
+                            }
+                        }
+
+                    });
+
+                    session.Store(new Person
+                    {
+                        Name = "reeb",
+                        Contacts = new Dictionary<string, long>
+                        {
+                            {
+                                "david", 5554866815
+                            },
+                            {
+                                "ayende", 5554866814
+                            }
+                        }
+                    });
+
+                    session.SaveChanges();
+                }
+
+                WaitForIndexing(store);
+
+                using (var session = store.OpenSession())
+                {
+                    var person = session.Query<Person, PeopleIndex2>().Single();
+                    Assert.Equal("aviv", person.Name);
+                }
+            }
+        }
+
+        [Fact]
+        public void CanUseMethodFromExtensionsInIndex_ICollection()
+        {
+            using (var store = GetDocumentStore())
+            {
+                store.ExecuteIndex(new PeopleIndex3());
+
+                using (var session = store.OpenSession())
+                {
+                    session.Store(new Person
+                    {
+                        Name = "aviv",
+                        FriendsCollection = new List<string>
+                        {
+                            "jerry",
+                            "bob"
+                        }
+
+                    });
+
+                    session.Store(new Person
+                    {
+                        Name = "reeb",
+                        FriendsCollection = new List<string>
+                        {
+                            "jerry",
+                            "david",
+                            "ayende"
+                        }
+                    });
+
+                    session.SaveChanges();
+                }
+
+                WaitForIndexing(store);
+
+                using (var session = store.OpenSession())
+                {
+                    var person = session.Query<Person, PeopleIndex3>().Single();
+                    Assert.Equal("aviv", person.Name);
+                }
+            }
+        }
+
+        [Fact]
+        public void CanUseMethodFromExtensionsInIndex_Hashset()
+        {
+            using (var store = GetDocumentStore())
+            {
+                store.ExecuteIndex(new PeopleIndex4());
+
+                using (var session = store.OpenSession())
+                {
+                    session.Store(new Person
+                    {
+                        Name = "aviv",
+                        FriendsHashset = new HashSet<string>
+                        {
+                            "jerry",
+                            "bob"
+                        }
+
+                    });
+
+                    session.Store(new Person
+                    {
+                        Name = "reeb",
+                        FriendsHashset = new HashSet<string>
+                        {
+                            "jerry",
+                            "david",
+                            "ayende"
+                        }
+                    });
+
+                    session.SaveChanges();
+                }
+
+                WaitForIndexing(store);
+
+                using (var session = store.OpenSession())
+                {
+                    var person = session.Query<Person, PeopleIndex4>().Single();
+                    Assert.Equal("aviv", person.Name);
+                }
+            }
+        }
+
+        [Fact]
+        public void CanUseMethodFromExtensionsInIndex_ListOfUsers()
+        {
+            using (var store = GetDocumentStore())
+            {
+                store.ExecuteIndex(new PeopleIndex5());
+
+                using (var session = store.OpenSession())
+                {
+                    session.Store(new Person
+                    {
+                        Name = "aviv",
+                        UserFriends = new List<User>
+                        {
+                            new User
+                            {
+                                Name = "jerry"
+                            },
+                            new User
+                            {
+                                Name = "bob"
+                            }
+                        }
+
+                    });
+
+                    session.Store(new Person
+                    {
+                        Name = "reeb",
+                        UserFriends = new List<User>
+                        {
+                            new User
+                            {
+                                Name = "david"
+                            },
+                            new User
+                            {
+                                Name = "ayende"
+                            }
+                        }
+                    });
+
+                    session.SaveChanges();
+                }
+
+                WaitForIndexing(store);
+
+                using (var session = store.OpenSession())
+                {
+                    var person = session.Query<Person, PeopleIndex5>().Single();
+                    Assert.Equal("aviv", person.Name);
+                }
+            }
+        }
+
+        [Fact]
+        public void CanUseMethodFromExtensionsInIndex_Array()
+        {
+            using (var store = GetDocumentStore())
+            {
+                store.ExecuteIndex(new PeopleIndex6());
+
+                using (var session = store.OpenSession())
+                {
+                    session.Store(new Person
+                    {
+                        Name = "aviv",
+                        FriendsArray = new[]
+                        {
+                            new User
+                            {
+                                Name = "jerry"
+                            },
+                            new User
+                            {
+                                Name = "bob"
+                            }
+                        }
+
+                    });
+
+                    session.Store(new Person
+                    {
+                        Name = "reeb",
+                        FriendsArray = new[]
+                        {
+                            new User
+                            {
+                                Name = "david"
+                            },
+                            new User
+                            {
+                                Name = "ayende"
+                            }
+                        }
+                    });
+
+                    session.SaveChanges();
+                }
+
+                WaitForIndexing(store);
+
+                using (var session = store.OpenSession())
+                {
+                    var person = session.Query<Person, PeopleIndex6>().Single();
+                    Assert.Equal("aviv", person.Name);
+                }
+            }
+        }
+
+        [Fact]
+        public void CanUseMethodFromExtensionsInIndex_MyList()
+        {
+            using (var store = GetDocumentStore())
+            {
+                store.ExecuteIndex(new PeopleIndex7());
+
+                using (var session = store.OpenSession())
+                {
+                    session.Store(new Person
+                    {
+                        Name = "aviv",
+                        MyList = new MyList<string>
+                        {
+                            "julian", "ricky", "ayende"
+                        }
+                    });
+
+                    session.Store(new Person
+                    {
+                        Name = "reeb",
+                        MyList = new MyList<string>
+                        {
+                            "david", "ayende"
+                        }
+                    });
+
+                    session.SaveChanges();
+                }
+
+                WaitForIndexing(store);
+
+                using (var session = store.OpenSession())
+                {
+                    var person = session.Query<Person, PeopleIndex7>().Single();
+                    Assert.Equal("aviv", person.Name);
+                }
+            }
+        }
+
+        [Fact]
+        public void CanUseMethodFromExtensionsInIndex_MyEnumerable()
+        {
+            using (var store = GetDocumentStore())
+            {
+                store.ExecuteIndex(new PeopleIndex8());
+
+                using (var session = store.OpenSession())
+                {
+                    session.Store(new Person
+                    {
+                        Name = "aviv",
+                        MyEnumerable = new MyEnumerable<string>(new List<string>
+                        {
+                            "julian", "ricky", "ayende"
+                        })
+                    });
+
+                    session.Store(new Person
+                    {
+                        Name = "reeb",
+                        MyEnumerable = new MyEnumerable<string>(new List<string>
+                        {
+                            "david", "ayende"
+                        })
+                    });
+
+                    session.SaveChanges();
+                }
+
+                WaitForIndexing(store);
+
+                using (var session = store.OpenSession())
+                {
+                    var person = session.Query<Person, PeopleIndex8>().Single();
+                    Assert.Equal("aviv", person.Name);
+                }
+            }
+        }
+
+        [Fact]
+        public void CanUseMethodFromExtensionsInIndex_DateTime()
+        {
+            using (var store = GetDocumentStore())
+            {
+                store.ExecuteIndex(new PeopleIndex9());
+
+                using (var session = store.OpenSession())
+                {
+                    session.Store(new Person
+                    {
+                        Name = "aviv",
+                        Event = new Event
+                        {
+                            StartTime = new DateTime(2018, 1, 1),
+                            EndTime = new DateTime(2020, 1, 1)
+                        }
+                    });
+
+                    session.Store(new Person
+                    {
+                        Name = "reeb",
+                        Event = new Event
+                        {
+                            StartTime = new DateTime(2018, 1, 1),
+                            EndTime = new DateTime(2018, 2, 1)
+                        }
+                    });
+
+                    session.SaveChanges();
+                }
+
+                WaitForIndexing(store);
+
+                using (var session = store.OpenSession())
+                {
+                    var person = session.Query<Person, PeopleIndex9>().Single();
+                    Assert.Equal("reeb", person.Name);
+                }
+            }
+        }
+
+        [Fact(Skip = "need to use DynamicDictionary. waiting for PR from Egor")]
+        public void CanUseMethodFromExtensionsInIndex_DictionaryFunctions()
+        {
+            using (var store = GetDocumentStore())
+            {
+                store.ExecuteIndex(new PeopleIndex10());
+
+                using (var session = store.OpenSession())
+                {
+                    session.Store(new Person
+                    {
+                        Name = "aviv",
+                        Contacts = new Dictionary<string, long>
+                        {
+                            {
+                                "jerry", 5554866812
+                            },
+                            {
+                                "bob", 5554866813
+                            },
+                            {
+                                "ayende", 5554866814
+                            }
+                        }
+
+                    });
+
+                    session.Store(new Person
+                    {
+                        Name = "reeb",
+                        Contacts = new Dictionary<string, long>
+                        {
+                            {
+                                "david", 5554866815
+                            },
+                            {
+                                "ayende", 5554866814
+                            },
+                            {
+                                "home", 1024
+                            }
+                        }
+                    });
+
+                    session.SaveChanges();
+                }
+
+                WaitForIndexing(store);
+
+                using (var session = store.OpenSession())
+                {
+                    var person = session.Query<Person, PeopleIndex10>().Single();
+                    Assert.Equal("reeb", person.Name);
+                }
+            }
+        }
+
         private class RealCountry : AbstractIndexCreationTask<Order>
         {
             public RealCountry(string getRealCountry)
@@ -117,7 +590,34 @@ namespace My.Crazy.Namespace
         private class Person
         {
             public string Name { get; set; }
+
             public uint Age { get; set; }
+
+            public List<string> Friends { get; set; }
+
+            public Dictionary<string, long> Contacts { get; set; }
+
+            public ICollection<string> FriendsCollection { get; set; }
+
+            public HashSet<string> FriendsHashset { get; set; }
+
+            public IEnumerable<User> UserFriends { get; set; }
+
+            public User[] FriendsArray { get; set; }
+
+            public MyList<string> MyList { get; set; }
+
+            public MyEnumerable<string> MyEnumerable { get; set; }
+
+            public Event Event { get; set; }
+
+        }
+
+        private class Event
+        {
+            public DateTime StartTime { get; set; }
+            public DateTime? EndTime { get; set; }
+
         }
 
         private class PeopleByEmail : AbstractIndexCreationTask<Person>
@@ -130,10 +630,10 @@ namespace My.Crazy.Namespace
             public PeopleByEmail()
             {
                 Map = people => from person in people
-                                select new
-                                {
-                                    _ = CreateField("Email", CalculatePersonEmail(person.Name, person.Age), true, true),
-                                };
+                    select new
+                    {
+                        _ = CreateField("Email", CalculatePersonEmail(person.Name, person.Age), true, true),
+                    };
                 AdditionalSources = new Dictionary<string, string>
                 {
                     {
@@ -158,6 +658,418 @@ namespace My.Crazy.Namespace
                 };
             }
         }
+
+        private class PeopleIndex1 : AbstractIndexCreationTask<Person>
+        {
+            public PeopleIndex1()
+            {
+                Map = people => from person in people
+                                where Foo1(person.Friends)
+                                select new
+                                {
+                                    person.Name
+                                };
+
+
+                AdditionalSources = new Dictionary<string, string>
+                {
+                    {
+                        "PeopleUtil",
+                        @"
+using System.Collections.Generic;
+using System.Linq;
+namespace ETIS
+{
+    public static class PeopleUtil
+    {
+        public static bool Foo1(List<string> friends)
+        {
+            return friends.Count(n => n != ""ayende"") > 1;
+        }
+    }
+}
+"
+                    }
+                };
+            }
+        }
+
+        private class PeopleIndex2 : AbstractIndexCreationTask<Person>
+        {
+            public PeopleIndex2()
+            {
+                Map = people => from person in people
+                                where Foo2(person.Contacts)
+                                select new
+                                {
+                                    person.Name
+                                };
+
+                AdditionalSources = new Dictionary<string, string>
+                {
+                    {
+                        "PeopleUtil",
+                        @"
+using System.Collections.Generic;
+using System.Linq;
+namespace ETIS
+{
+    public static class PeopleUtil
+    {
+        public static bool Foo2(Dictionary<string, long> friends)
+        {
+            return friends.Count(n => n.Key != ""ayende"") > 1;
+        }
+    }
+}
+"
+                    }
+                };
+            }
+        }
+
+        private class PeopleIndex3 : AbstractIndexCreationTask<Person>
+        {
+            public PeopleIndex3()
+            {
+                Map = people => from person in people
+                                where Foo3(person.FriendsCollection)
+                                select new
+                                {
+                                    person.Name
+                                };
+
+                AdditionalSources = new Dictionary<string, string>
+                {
+                    {
+                        "PeopleUtil",
+                        @"
+using System.Collections.Generic;
+using System.Linq;
+namespace ETIS
+{
+    public static class PeopleUtil
+    {
+         public static bool Foo3(ICollection<string> friends)
+        {
+            return friends.All(n => n != ""ayende"");
+        }
+    }
+}
+"
+                    }
+                };
+            }
+        }
+
+        private class PeopleIndex4 : AbstractIndexCreationTask<Person>
+        {
+            public PeopleIndex4()
+            {
+                Map = people => from person in people
+                                where Foo4(person.FriendsHashset)
+                                select new
+                                {
+                                    person.Name
+                                };
+
+                AdditionalSources = new Dictionary<string, string>
+                {
+                    {
+                        "PeopleUtil",
+                        @"
+using System.Collections.Generic;
+using System.Linq;
+namespace ETIS
+{
+    public static class PeopleUtil
+    {
+        public static bool Foo4(HashSet<string> friends)
+        {
+            return friends.All(n => n != ""ayende"");
+        }
+    }
+}
+"
+                    }
+                };
+            }
+        }
+
+        private class PeopleIndex5 : AbstractIndexCreationTask<Person>
+        {
+            public PeopleIndex5()
+            {
+                Map = people => from person in people
+                                where Foo5(person.UserFriends)
+                                select new
+                                {
+                                    person.Name
+                                };
+
+                AdditionalSources = new Dictionary<string, string>
+                {
+                    {
+                        "PeopleUtil",
+                        @"
+using System.Collections.Generic;
+using System.Linq;
+namespace ETIS
+{
+    public static class PeopleUtil
+    {
+        public class User
+        {
+            public string Name { get; set; }
+        }
+
+        public static bool Foo5(IEnumerable<User> friends)
+        {
+            return friends.All(n => n.Name != ""ayende"");
+        }
+    }
+}
+"
+                    }
+                };
+            }
+        }
+
+        private class PeopleIndex6 : AbstractIndexCreationTask<Person>
+        {
+            public PeopleIndex6()
+            {
+                Map = people => from person in people
+                                where Foo6(person.FriendsArray)
+                                select new
+                                {
+                                    person.Name
+                                };
+
+                AdditionalSources = new Dictionary<string, string>
+                {
+                    {
+                        "PeopleUtil",
+                        @"
+using System.Collections.Generic;
+using System.Linq;
+namespace ETIS
+{
+    public static class PeopleUtil
+    {
+        public class User
+        {
+            public string Name { get; set; }
+        }
+
+        public static bool Foo6(User[] friends)
+        {
+            return friends.All(n => n.Name != ""ayende"");
+        }
+    }
+}
+"
+                    }
+                };
+            }
+        }
+
+        private class PeopleIndex7 : AbstractIndexCreationTask<Person>
+        {
+            public PeopleIndex7()
+            {
+                Map = people => from person in people
+                    where Foo7(person.MyList)
+                    select new
+                    {
+                        person.Name
+                    };
+
+                AdditionalSources = new Dictionary<string, string>
+                {
+                    {
+                        "PeopleUtil",
+                        @"
+using System.Collections.Generic;
+using System.Linq;
+namespace ETIS
+{
+    public static class PeopleUtil
+    {
+        public class MyList<T> : List<T>
+        {
+        }
+
+        public static bool Foo7(MyList<string> friends)
+        {
+            return friends.Count(n => n != ""ayende"") > 1;
+        }
+    }
+}
+"
+                    }
+                };
+            }
+        }
+
+        private class PeopleIndex8 : AbstractIndexCreationTask<Person>
+        {
+            public PeopleIndex8()
+            {
+                Map = people => from person in people
+                    where Foo8(person.MyEnumerable)
+                    select new
+                    {
+                        person.Name
+                    };
+
+                AdditionalSources = new Dictionary<string, string>
+                {
+                    {
+                        "PeopleUtil",
+                        @"
+using System.Collections;
+using System.Collections.Generic;
+using System.Linq;
+namespace ETIS
+{
+    public static class PeopleUtil
+    {
+        public class MyEnumerable<T> : IEnumerable<T>
+        {
+            private IEnumerable<T> _list;
+            public MyEnumerable()
+            {
+            }
+
+            public MyEnumerable(IEnumerable<T> list)
+            {
+                _list = list;
+            }
+            public IEnumerator<T> GetEnumerator()
+            {
+                return _list.GetEnumerator();
+            }
+
+            IEnumerator IEnumerable.GetEnumerator()
+            {
+                return GetEnumerator();
+            }
+        }
+
+        public static bool Foo8(MyEnumerable<string> friends)
+        {
+            return friends.Count(n => n != ""ayende"") > 1;
+        }
+    }
+}
+"
+                    }
+                };
+            }
+        }
+
+        private class PeopleIndex9 : AbstractIndexCreationTask<Person>
+        {
+            public PeopleIndex9()
+            {
+                Map = people => from person in people
+                    where Foo9(person.Event.StartTime, person.Event.EndTime).TotalDays < 100
+                    select new
+                    {
+                        person.Name
+                    };
+
+                AdditionalSources = new Dictionary<string, string>
+                {
+                    {
+                        "PeopleUtil",
+                        @"
+using System;
+namespace ETIS
+{
+    public static class PeopleUtil
+    {
+        public static TimeSpan Foo9(DateTime start, DateTime? end)
+        {
+            if (end.HasValue == false)
+                return TimeSpan.MaxValue;
+            return end.Value - start;
+        }
+    }
+}
+"
+                    }
+                };
+            }
+        }
+
+        private class PeopleIndex10 : AbstractIndexCreationTask<Person>
+        {
+            public PeopleIndex10()
+            {
+                Map = people => from person in people
+                    where Foo10(person.Contacts) > 100 
+                    select new
+                    {
+                        person.Name
+                    };
+
+                AdditionalSources = new Dictionary<string, string>
+                {
+                    {
+                        "PeopleUtil",
+                        @"
+using System.Collections.Generic;
+using System.Linq;
+namespace ETIS
+{
+    public static class PeopleUtil
+    {
+        public static long Foo10(Dictionary<string, long> friends)
+        {
+            if (friends == null)
+                return -1;
+            if (friends.ContainsKey(""home""))
+                return 0;
+            return friends.Values.Sum(x => x);
+        }
+    }
+}
+"
+                    }
+                };
+            }
+        }
+
+    }
+
+    public class MyList<T> : List<T>
+    {
+
+    }
+
+    public class MyEnumerable<T> : IEnumerable<T>
+    {
+        private IEnumerable<T> _list;
+        public MyEnumerable()
+        {
+            
+        }
+
+        public MyEnumerable(IEnumerable<T> list)
+        {
+            _list = list;
+        }
+        public IEnumerator<T> GetEnumerator()
+        {
+            return _list.GetEnumerator();
+        }
+
+        IEnumerator IEnumerable.GetEnumerator()
+        {
+            return GetEnumerator();
+        }
     }
 
     public static class PeopleUtil
@@ -166,6 +1078,62 @@ namespace My.Crazy.Namespace
         {
             //The code below intention is just to make sure NodaTime is compiling with our index
             return $"{name}.{Instant.FromDateTimeUtc(DateTime.Now.ToUniversalTime()).ToDateTimeUtc().Year - age}@ayende.com";
+        }
+
+        public static bool Foo1(List<string> friends)
+        {
+            return friends.Count(n => n != "ayende") > 1;
+        }
+
+        public static bool Foo2(Dictionary<string, long> friends)
+        {
+            return friends.Count(n => n.Key != "ayende") > 1;
+        }
+
+        public static bool Foo3(ICollection<string> friends)
+        {
+            return friends.All(n => n != "ayende");
+        }
+
+        public static bool Foo4(HashSet<string> friends)
+        {
+            return friends.All(n => n != "ayende");
+        }
+
+        public static bool Foo5(IEnumerable<User> friends)
+        {
+            return friends.All(n => n.Name != "ayende");
+        }
+
+        public static bool Foo6(User[] friends)
+        {
+            return friends.All(n => n.Name != "ayende");
+        }
+
+        public static bool Foo7(MyList<string> friends)
+        {
+            return friends.Count(n => n != "ayende") > 1;
+        }
+
+        public static bool Foo8(MyEnumerable<string> friends)
+        {
+            return friends.Count(n => n != "ayende") > 1;
+        }
+
+        public static TimeSpan Foo9(DateTime start, DateTime? end)
+        {
+            if (end.HasValue == false)
+                return TimeSpan.MaxValue;
+            return end.Value - start;
+        }
+
+        public static long Foo10(Dictionary<string, long> friends)
+        {
+            if (friends == null)
+                return -1;
+            if (friends.ContainsKey("home"))
+                return 0;
+            return friends.Values.Sum(x => x);
         }
     }
 }

--- a/test/FastTests/Issues/RavenDB-13058.cs
+++ b/test/FastTests/Issues/RavenDB-13058.cs
@@ -1,7 +1,6 @@
 ﻿using System;
 using System.Collections.Generic;
 using System.Linq;
-using System.Text;
 using Raven.Client.Documents.Indexes;
 using Raven.Client.Exceptions.Documents.Compilation;
 using Xunit;

--- a/test/SlowTests/Issues/RavenDB-13695.cs
+++ b/test/SlowTests/Issues/RavenDB-13695.cs
@@ -4,6 +4,7 @@ using FastTests;
 using Raven.Client.Documents.Indexes;
 using Xunit;
 
+
 namespace SlowTests.Issues
 {
     public class RavenDB_13695 : RavenTestBase
@@ -85,7 +86,7 @@ namespace ETIS
         }
 
         [Fact]
-        public void CanPutIndexWithAdditionalSource()
+        public void CanCompileAdditionalSource()
         {
             using (var store = GetDocumentStore())
             {
@@ -121,5 +122,334 @@ namespace ETIS
             }
         }
 
+        [Fact]
+        public void CanCompileAdditionalSource_List()
+        {
+            using (var store = GetDocumentStore())
+            {
+                using (var session = store.OpenSession())
+                {
+                    session.Store(new NewsDocument
+                    {
+                        AuthorNames = new List<string>
+                        {
+                            "garcia", "weir"
+                        }
+                    });
+
+                    session.Store(new NewsDocument());
+
+                    session.SaveChanges();
+
+                }
+
+                // should not throw
+                var index = new NewsDocumentIndex
+                {
+                    AdditionalSources = new Dictionary<string, string>
+                    {
+                        ["DateTimeExtension"] = @"
+
+using System;
+using System.Collections.Generic;
+using System.Linq;
+
+namespace ETIS
+{
+    public static class DateTimeExtension
+    {
+        public static bool Foo(List<DateTime?> startTimes)
+        {
+            if (startTimes == null)
+                return false;
+
+            return startTimes.Count(x => x.Value.Year > 2000) < 10;
+        }
+    }
+}
+
+"
+                    }
+                };
+
+                index.Execute(store);
+
+                WaitForIndexing(store);
+
+                using (var session = store.OpenSession())
+                {
+                    var q = session.Query<NewsDocumentIndex.Info, NewsDocumentIndex>()
+                        .Where(doc => doc.AuthorNamesStr == "garcia, weir")
+                        .ToList();
+
+                    Assert.Single(q);
+                }
+
+            }
+        }
+
+        [Fact]
+        public void CanCompileAdditionalSource_IList()
+        {
+            using (var store = GetDocumentStore())
+            {
+                using (var session = store.OpenSession())
+                {
+                    session.Store(new NewsDocument
+                    {
+                        AuthorNames = new List<string>
+                        {
+                            "garcia", "weir"
+                        }
+                    });
+
+                    session.Store(new NewsDocument());
+
+                    session.SaveChanges();
+
+                }
+
+                // should not throw
+                var index = new NewsDocumentIndex
+                {
+                    AdditionalSources = new Dictionary<string, string>
+                    {
+                        ["DateTimeExtension"] = @"
+
+using System;
+using System.Collections.Generic;
+using System.Linq;
+
+namespace ETIS
+{
+    public static class DateTimeExtension
+    {
+        public static bool Foo(IList<DateTime?> startTimes)
+        {
+            if (startTimes == null)
+                return false;
+
+            return startTimes.Count(x => x.Value.Year > 2000) < 10;
+        }
+    }
+}
+
+"
+                    }
+                };
+
+                index.Execute(store);
+
+                WaitForIndexing(store);
+
+                using (var session = store.OpenSession())
+                {
+                    var q = session.Query<NewsDocumentIndex.Info, NewsDocumentIndex>()
+                        .Where(doc => doc.AuthorNamesStr == "garcia, weir")
+                        .ToList();
+
+                    Assert.Single(q);
+                }
+
+            }
+        }
+
+        [Fact]
+        public void CanCompileAdditionalSource_ICollection()
+        {
+            using (var store = GetDocumentStore())
+            {
+                using (var session = store.OpenSession())
+                {
+                    session.Store(new NewsDocument
+                    {
+                        AuthorNames = new List<string>
+                        {
+                            "garcia", "weir"
+                        }
+                    });
+
+                    session.Store(new NewsDocument());
+
+                    session.SaveChanges();
+
+                }
+
+                // should not throw
+                var index = new NewsDocumentIndex
+                {
+                    AdditionalSources = new Dictionary<string, string>
+                    {
+                        ["DateTimeExtension"] = @"
+
+using System;
+using System.Collections.Generic;
+using System.Linq;
+
+namespace ETIS
+{
+    public static class DateTimeExtension
+    {
+        public static bool Foo(ICollection<string> names)
+        {
+            if (names == null)
+                return false;
+
+            return names.Count(x => x != ""ayende"") < 10;
+        }
+    }
+}
+
+"
+                    }
+                };
+
+                index.Execute(store);
+
+                WaitForIndexing(store);
+
+                using (var session = store.OpenSession())
+                {
+                    var q = session.Query<NewsDocumentIndex.Info, NewsDocumentIndex>()
+                        .Where(doc => doc.AuthorNamesStr == "garcia, weir")
+                        .ToList();
+
+                    Assert.Single(q);
+                }
+
+            }
+        }
+
+        [Fact]
+        public void CanCompileAdditionalSource_Hashset()
+        {
+            using (var store = GetDocumentStore())
+            {
+                using (var session = store.OpenSession())
+                {
+                    session.Store(new NewsDocument
+                    {
+                        AuthorNames = new List<string>
+                        {
+                            "garcia", "weir"
+                        }
+                    });
+
+                    session.Store(new NewsDocument());
+
+                    session.SaveChanges();
+
+                }
+
+                // should not throw
+                var index = new NewsDocumentIndex
+                {
+                    AdditionalSources = new Dictionary<string, string>
+                    {
+                        ["DateTimeExtension"] = @"
+
+using System;
+using System.Collections.Generic;
+using System.Linq;
+
+namespace ETIS
+{
+    public static class DateTimeExtension
+    {
+        public static bool Foo(HashSet<long> numbers)
+        {
+            if (numbers == null)
+                return false;
+
+            return numbers.Count(x => x > 100) < 10;
+        }
+    }
+}
+
+"
+                    }
+                };
+
+                index.Execute(store);
+
+                WaitForIndexing(store);
+
+                using (var session = store.OpenSession())
+                {
+                    var q = session.Query<NewsDocumentIndex.Info, NewsDocumentIndex>()
+                        .Where(doc => doc.AuthorNamesStr == "garcia, weir")
+                        .ToList();
+
+                    Assert.Single(q);
+                }
+
+            }
+        }
+
+        [Fact]
+        public void CanCompileAdditionalSource_Dictionary()
+        {
+            using (var store = GetDocumentStore())
+            {
+                using (var session = store.OpenSession())
+                {
+                    session.Store(new NewsDocument
+                    {
+                        AuthorNames = new List<string>
+                        {
+                            "garcia", "weir"
+                        }
+                    });
+
+                    session.Store(new NewsDocument());
+
+                    session.SaveChanges();
+
+                }
+
+                // should not throw
+                var index = new NewsDocumentIndex
+                {
+                    AdditionalSources = new Dictionary<string, string>
+                    {
+                        ["DateTimeExtension"] = @"
+
+using System;
+using System.Collections.Generic;
+using System.Linq;
+
+namespace ETIS
+{
+    public static class DateTimeExtension
+    {
+        public static bool Foo(Dictionary<string, long> dictionary)
+        {
+            if (dictionary == null)
+                return false;
+
+            return dictionary.Count(x => x.Value > 100) < 10;
+        }
+    }
+}
+
+"
+                    }
+                };
+
+                index.Execute(store);
+
+                WaitForIndexing(store);
+
+                using (var session = store.OpenSession())
+                {
+                    var q = session.Query<NewsDocumentIndex.Info, NewsDocumentIndex>()
+                        .Where(doc => doc.AuthorNamesStr == "garcia, weir")
+                        .ToList();
+
+                    Assert.Single(q);
+                }
+
+            }
+        }
     }
 }

--- a/test/SlowTests/Issues/RavenDB-13695.cs
+++ b/test/SlowTests/Issues/RavenDB-13695.cs
@@ -1,0 +1,125 @@
+﻿using System.Collections.Generic;
+using System.Linq;
+using FastTests;
+using Raven.Client.Documents.Indexes;
+using Xunit;
+
+namespace SlowTests.Issues
+{
+    public class RavenDB_13695 : RavenTestBase
+    {
+        private class NewsDocument
+        {
+            public List<string> AuthorNames { get; set; }
+        }
+
+        private class DocumentInfo
+        {
+        }
+
+        private class NewsDocumentIndex : AbstractIndexCreationTask<NewsDocument, NewsDocumentIndex.Info>
+        {
+            public static string StaticIndexName = "ETIS/NewsDocumentIndex";
+
+            public override string IndexName
+            {
+                get { return StaticIndexName; }
+            }
+
+            public class Info : DocumentInfo
+            {
+                public string AuthorNamesStr { get; set; }
+
+            }
+
+            public NewsDocumentIndex()
+            {
+                Map = docs => from d in docs
+                              select new Info
+                              {
+                                  AuthorNamesStr = d.AuthorNames != null ? string.Join(", ", d.AuthorNames.OrderBy(x => x)) : string.Empty,
+                              };
+
+
+                AdditionalSources = new Dictionary<string, string>()
+                {
+                    ["DateTimeExtension4"] = @"
+
+using System;
+using System.Collections.Generic;
+using System.Linq;
+
+namespace ETIS
+{
+    public static class DateTimeExtension4
+    {
+        public static IEnumerable<int> GetYearsRepresented(List<DateTime?> startTimes, IEnumerable<DateTime?> endTimes)
+        {
+            if (startTimes == null || endTimes == null)
+                return null;
+
+            var years = new List<int>();
+            var tuples = startTimes.Zip(endTimes, (x, y) => new Tuple<DateTime?, DateTime?>(x, y)).ToList();
+
+            foreach (var pair in tuples)
+            {
+                if (!pair.Item1.HasValue)
+                    return null;
+                if (!pair.Item2.HasValue)
+                    continue;
+                var startYear = pair.Item1.Value.Year;
+                var endYear = pair.Item2.Value.Year;
+                if (endYear - startYear < 0)
+                    continue;
+                years.AddRange(Enumerable.Range(startYear, endYear - startYear + 1));
+            }
+
+            return years;
+        }
+    }
+}
+
+"
+                };
+            }
+        }
+
+        [Fact]
+        public void CanPutIndexWithAdditionalSource()
+        {
+            using (var store = GetDocumentStore())
+            {
+                using (var session = store.OpenSession())
+                {
+                    session.Store(new NewsDocument
+                    {
+                        AuthorNames = new List<string>
+                        {
+                            "garcia", "weir"
+                        }
+                    });
+
+                    session.Store(new NewsDocument());
+
+                    session.SaveChanges();
+
+                }
+
+                // should not throw
+                new NewsDocumentIndex().Execute(store);
+
+                WaitForIndexing(store);
+                using (var session = store.OpenSession())
+                {
+                    var q = session.Query<NewsDocumentIndex.Info, NewsDocumentIndex>()
+                        .Where(doc => doc.AuthorNamesStr == "garcia, weir")
+                        .ToList();
+
+                    Assert.Single(q);
+                }
+
+            }
+        }
+
+    }
+}


### PR DESCRIPTION
- rewriter should change type to dynamic when type is unknown in server side
- if parameter is a collection, change to DynamicArray
- need to pre-compile the extensions in order to have the semantic model when rewriting
- for dictionary parameters we need to use the new DynamicDictionary type (still WIP, will apply changes once @garayx  work is merged)

https://issues.hibernatingrhinos.com/issue/RavenDB-13695