### PR TITLE
RavenDB-13753 On server startup always copy the appropriate PAL and S…

### DIFF
--- a/src/Sparrow.Server/Platform/Pal.cs
+++ b/src/Sparrow.Server/Platform/Pal.cs
@@ -47,13 +47,7 @@ namespace Sparrow.Server.Platform
 
             try
             {
-                var toTime = DateTime.MinValue.Ticks;
-                if (File.Exists(toFilename))
-                    toTime = new FileInfo(toFilename).CreationTime.Ticks;
-
-                if (File.Exists(fromFilename) &&
-                    new FileInfo(fromFilename).CreationTime.Ticks > toTime)
-                    File.Copy(fromFilename, toFilename, overwrite: true);
+                File.Copy(fromFilename, toFilename, overwrite: true);
             }
             catch (IOException e)
             {

--- a/src/Sparrow.Server/Sodium.cs
+++ b/src/Sparrow.Server/Sodium.cs
@@ -42,13 +42,7 @@ namespace Sparrow.Server
 
             try
             {
-                var toTime = DateTime.MinValue.Ticks;
-                if (File.Exists(toFilename))
-                    toTime = new FileInfo(toFilename).CreationTime.Ticks;
-
-                if (File.Exists(fromFilename) &&
-                    new FileInfo(fromFilename).CreationTime.Ticks > toTime)
-                    File.Copy(fromFilename, toFilename, overwrite: true);
+                File.Copy(fromFilename, toFilename, overwrite: true);
             }
             catch (IOException e)
             {


### PR DESCRIPTION
…odium files. We must not relay on CreationDate because Windows deliberately retains the creation date from the old file if we copy and overwrite existing file. This is important for RavenDB updates if PAL or Sodium has changed meanwhile.