### PR TITLE
RavenDB-13749 Reverting changed default value for Logs.RetentionTimeI…

### DIFF
--- a/src/Raven.Server/Config/Categories/ConfigurationCategory.cs
+++ b/src/Raven.Server/Config/Categories/ConfigurationCategory.cs
@@ -230,6 +230,11 @@ namespace Raven.Server.Config.Categories
                             {
                                 property.SetValue(this, new Size(Math.Max(Convert.ToInt32(value), minValue.Int32Value), sizeUnit.Unit));
                             }
+                            else if (property.PropertyType == typeof(TimeSetting) ||
+                                     property.PropertyType == typeof(TimeSetting?))
+                            {
+                                property.SetValue(this, new TimeSetting(Math.Max(Convert.ToInt32(value), minValue.Int32Value), timeUnit.Unit));
+                            }
                             else
                             {
                                 throw new NotSupportedException("Min value for " + property.PropertyType + " is not supported. Property name: " + property.Name);

--- a/src/Raven.Server/Config/Categories/LogsConfiguration.cs
+++ b/src/Raven.Server/Config/Categories/LogsConfiguration.cs
@@ -27,8 +27,8 @@ namespace Raven.Server.Config.Categories
         public Size MaxFileSize { get; set; }
 
         [Description("How far back we should retain log entries in hours")]
-        [DefaultValue(null)]
-        [MinValue(3 * 24)]
+        [DefaultValue(3 * 24)]
+        [MinValue(24)]
         [TimeUnit(TimeUnit.Hours)]
         [ConfigurationEntry("Logs.RetentionTimeInHrs", ConfigurationEntryScope.ServerWideOnly)]
         public TimeSetting? RetentionTime { get; set; }

--- a/test/SlowTests/Issues/RavenDB_13749.cs
+++ b/test/SlowTests/Issues/RavenDB_13749.cs
@@ -1,0 +1,35 @@
+﻿using System;
+using System.Collections.Generic;
+using FastTests;
+using Raven.Server.Config;
+using Xunit;
+
+namespace SlowTests.Issues
+{
+    public class RavenDB_13749 : RavenTestBase
+    {
+        [Fact]
+        public void CanSetLogsRetentionTime()
+        {
+            using (var server = GetNewServer(runInMemory: true, customSettings: new Dictionary<string, string>
+            {
+                [RavenConfiguration.GetKey(x => x.Logs.RetentionTime)] = "100"
+            }))
+            {
+                Assert.Equal(new TimeSpan(100, 0, 0), server.Configuration.Logs.RetentionTime.Value.AsTimeSpan);
+            }
+        }
+
+        [Fact]
+        public void SettingLogsRetentionTimeToVeryLowValueWillSetMinValueAnyway()
+        {
+            using (var server = GetNewServer(runInMemory: true, customSettings: new Dictionary<string, string>
+            {
+                [RavenConfiguration.GetKey(x => x.Logs.RetentionTime)] = "1"
+            }))
+            {
+                Assert.Equal(new TimeSpan(24, 0, 0), server.Configuration.Logs.RetentionTime.Value.AsTimeSpan);
+            }
+        }
+    }
+}


### PR DESCRIPTION
…nHrs option introduced in #9204 (from 3 days to null). Added support for min value for TimeSettings.