### PR TITLE
RavenDB-13768 Making encryption test easy to write

### DIFF
--- a/src/Raven.Server/ServerWide/ServerStore.cs
+++ b/src/Raven.Server/ServerWide/ServerStore.cs
@@ -1433,7 +1433,7 @@ namespace Raven.Server.ServerWide
             if (record != null && record.Encrypted && record.Topology.RelevantFor(NodeTag))
             {
                 throw new InvalidOperationException(
-                    $"Can't delete secret key for a database ({name})that is relevant for this node ({NodeTag}), please delete the database before deleting the secret key.");
+                    $"Can't delete secret key for a database ({name}) that is relevant for this node ({NodeTag}), please delete the database before deleting the secret key.");
             }
             var tree = context.Transaction.InnerTransaction.CreateTree("SecretKeys");
 

--- a/src/Raven.Server/Web/System/AdminDatabasesHandler.cs
+++ b/src/Raven.Server/Web/System/AdminDatabasesHandler.cs
@@ -269,6 +269,11 @@ namespace Raven.Server.Web.System
                     throw licenseLimit;
                 }
 
+                if (databaseRecord.Encrypted && databaseRecord.Topology?.DynamicNodesDistribution == true)
+                {
+                    throw new InvalidOperationException($"Cannot enable 'DynamicNodesDistribution' for encrypted database");
+                }
+
                 if (ServerStore.DatabasesLandlord.IsDatabaseLoaded(name) == false)
                 {
                     using (await ServerStore.DatabasesLandlord.UnloadAndLockDatabase(name, "Checking if we need to recreate indexes"))
@@ -782,6 +787,11 @@ namespace Raven.Server.Web.System
                 long index;
                 using (context.OpenReadTransaction())
                     databaseRecord = ServerStore.Cluster.ReadDatabase(context, name, out index);
+
+                if (databaseRecord.Encrypted)
+                {
+					throw new InvalidOperationException($"Cannot toggle 'DynamicNodesDistribution' for encrypted database");
+                }
 
                 if (enable == databaseRecord.Topology.DynamicNodesDistribution)
                     return;

--- a/src/Raven.Server/Web/System/AdminDatabasesHandler.cs
+++ b/src/Raven.Server/Web/System/AdminDatabasesHandler.cs
@@ -271,7 +271,7 @@ namespace Raven.Server.Web.System
 
                 if (databaseRecord.Encrypted && databaseRecord.Topology?.DynamicNodesDistribution == true)
                 {
-                    throw new InvalidOperationException($"Cannot enable 'DynamicNodesDistribution' for encrypted database");
+                    throw new InvalidOperationException($"Cannot enable '{nameof(DatabaseTopology.DynamicNodesDistribution)}' for encrypted database: " + name);
                 }
 
                 if (ServerStore.DatabasesLandlord.IsDatabaseLoaded(name) == false)
@@ -585,7 +585,7 @@ namespace Raven.Server.Web.System
 
                     var baseDataDirectory = ServerStore.Configuration.Core.DataDirectory.FullPath;
 
-                    var destinationPath = string.IsNullOrEmpty(restoreConfigurationJson.DataDirectory) == false 
+                    var destinationPath = string.IsNullOrEmpty(restoreConfigurationJson.DataDirectory) == false
                         ? new PathSetting(restoreConfigurationJson.DataDirectory, baseDataDirectory).FullPath
                         : RavenConfiguration.GetDataDirectoryPath(ServerStore.Configuration.Core, databaseName, ResourceType.Database);
 
@@ -790,7 +790,7 @@ namespace Raven.Server.Web.System
 
                 if (databaseRecord.Encrypted)
                 {
-					throw new InvalidOperationException($"Cannot toggle 'DynamicNodesDistribution' for encrypted database");
+                    throw new InvalidOperationException($"Cannot toggle '{nameof(DatabaseTopology.DynamicNodesDistribution)}' for encrypted database: " + name);
                 }
 
                 if (enable == databaseRecord.Topology.DynamicNodesDistribution)
@@ -1427,7 +1427,7 @@ namespace Raven.Server.Web.System
                                 IOExtensions.DeleteFile(tmpFile);
                             else if (process.HasExited == false && string.IsNullOrEmpty(tmpFile) == false)
                             {
-                                if(ProcessExtensions.TryKill(process))
+                                if (ProcessExtensions.TryKill(process))
                                     IOExtensions.DeleteFile(tmpFile);
                                 else
                                 {

--- a/test/SlowTests/Issues/EncryptedDatabaseGroup.cs
+++ b/test/SlowTests/Issues/EncryptedDatabaseGroup.cs
@@ -1,0 +1,97 @@
+﻿using System;
+using System.Collections.Generic;
+using System.Linq;
+using System.Security.Cryptography.X509Certificates;
+using System.Text;
+using System.Threading.Tasks;
+using Esprima.Ast;
+using FastTests;
+using FastTests.Graph;
+using Raven.Client.Documents;
+using Raven.Client.Documents.Conventions;
+using Raven.Client.ServerWide.Operations;
+using Raven.Client.ServerWide.Operations.Certificates;
+using Raven.Server.Config;
+using Raven.Server.ServerWide.Context;
+using Tests.Infrastructure;
+using Xunit;
+
+namespace SlowTests.Issues
+{
+    public class EncryptedDatabaseGroup: ClusterTestBase
+    {
+        [Fact]
+        public async Task AddingNodeToEncryptedDatabaseGroupShouldThrow()
+        {
+            var (nodes, leader) = await CreateRaftClusterWithSsl(3);            
+
+            var option = new Options
+            {
+                Server = leader,
+                ReplicationFactor = 2,
+                Encrypted = true
+            };
+
+            using (var store = GetDocumentStore(option))
+            {
+                var res = await store.Maintenance.Server.SendAsync(new AddDatabaseNodeOperation(store.Database));
+                await WaitForRaftIndexToBeAppliedInCluster(res.RaftCommandIndex, TimeSpan.FromSeconds(15));
+                var notInDbGroupServer = Servers.Single(s => res.Topology.Members.Contains(s.ServerStore.NodeTag) == false);
+                var dbName = store.Database;
+                using (var notInDbGroupStore = GetDocumentStore(new Options
+                {
+                    Server = notInDbGroupServer,
+                    CreateDatabase = false,
+                    ModifyDocumentStore = ds => ds.Conventions.DisableTopologyUpdates = true,
+                    ClientCertificate = option.ClientCertificate,
+                    ModifyDatabaseName = _ => dbName
+                }))
+                {
+                    await Assert.ThrowsAsync<Raven.Client.Exceptions.Database.DatabaseLoadFailureException>(async ()=> await TrySavingDocument(notInDbGroupStore));
+                    PutSecrectKeyForDatabaseInServersStore(dbName, notInDbGroupServer);
+                    await notInDbGroupServer.ServerStore.DatabasesLandlord.TryGetOrCreateResourceStore(dbName, true);
+                    await TrySavingDocument(notInDbGroupStore);
+                }                
+            }
+        }
+
+        private static async Task TrySavingDocument(DocumentStore store)
+        {
+            using (var session = store.OpenAsyncSession())
+            {
+                await session.StoreAsync(new User {Name = "Foo"});
+                await session.SaveChangesAsync();
+            }
+        }
+
+        [Fact]
+        public async Task DeletingMasterKeyForExistedEncryptedDatabaseShouldFail()
+        {
+            var (nodes, server) = await CreateRaftClusterWithSsl(1);
+
+            var option = new Options
+            {
+                Server = server,
+                Encrypted = true
+            };
+            using (var store = GetDocumentStore(option))
+            {
+                await TrySavingDocument(store);
+                using (server.ServerStore.ContextPool.AllocateOperationContext(out TransactionOperationContext ctx))                
+                {
+                    using (ctx.OpenWriteTransaction())
+                    {
+                        Assert.Throws<InvalidOperationException>(() => server.ServerStore.DeleteSecretKey(ctx, store.Database));
+                    }
+
+                    store.Maintenance.Server.Send(new DeleteDatabasesOperation(store.Database, true));
+                    using (ctx.OpenWriteTransaction())
+                    {
+                        server.ServerStore.DeleteSecretKey(ctx, store.Database);
+                    }
+                }
+                
+            }
+        }
+    }
+}

--- a/test/Tests.Infrastructure/ClusterTestBase.cs
+++ b/test/Tests.Infrastructure/ClusterTestBase.cs
@@ -437,6 +437,19 @@ namespace Tests.Infrastructure
             return leader;
         }
 
+        protected async Task<(List<RavenServer> Nodes, RavenServer Leader)> CreateRaftClusterWithSsl(
+            int numberOfNodes,
+            bool shouldRunInMemory = true,
+            int? leaderIndex = null,
+            bool createNewCert = false,
+            string serverCertPath = null,
+            IDictionary<string, string> customSettings = null,
+            List<IDictionary<string, string>> customSettingsList = null,
+            bool watcherCluster = false)
+        {
+            return await CreateRaftCluster(numberOfNodes, shouldRunInMemory, leaderIndex, useSsl: true, createNewCert, serverCertPath, customSettings, customSettingsList,
+                watcherCluster);
+        }
 
         protected async Task<(List<RavenServer> Nodes, RavenServer Leader)> CreateRaftCluster(
             int numberOfNodes,


### PR DESCRIPTION
* prevent dynamic node distribution for encrypted DatabaseInfoCache
* preventing the deletion of encryption key for an active encrypted database