### PR TITLE
RavenDB-13794 Databases are not being removed during test execution

### DIFF
--- a/src/Raven.Server/Documents/DatabasesLandlord.cs
+++ b/src/Raven.Server/Documents/DatabasesLandlord.cs
@@ -286,7 +286,7 @@ namespace Raven.Server.Documents
                 try
                 {
                     removeLockAndReturn = DatabasesCache.RemoveLockAndReturn(dbName, CompleteDatabaseUnloading, out var database);
-                    databaseId = database.DbBase64Id;
+                    databaseId = database?.DbBase64Id;
                 }
                 catch (AggregateException ae) when (nameof(DeleteDatabase).Equals(ae.InnerException.Data["Source"]))
                 {


### PR DESCRIPTION
Since the database was already disposed, we are getting `null` when trying to lock it.