### PR TITLE
RavenDB-13733 Fixing memory allocation for Span(byte* ptr, int.number…

### DIFF
--- a/src/Raven.Server/Documents/TimeSeries/TimeSeriesStorage.cs
+++ b/src/Raven.Server/Documents/TimeSeries/TimeSeriesStorage.cs
@@ -679,8 +679,8 @@ namespace Raven.Server.Documents.TimeSeries
                     var splitSegment = new TimeSeriesValuesSegment(buffer.Ptr, MaxSegmentSize);
                     splitSegment.Initialize(valuesCopy.Length);
 
-                    using (context.Allocator.Allocate(readOnlySegment.NumberOfValues + updatedValuesNewSize, out var valuesBuffer))
-                    using (context.Allocator.Allocate(readOnlySegment.NumberOfValues, out var stateBuffer))
+                    using (context.Allocator.Allocate((readOnlySegment.NumberOfValues + updatedValuesNewSize) * sizeof(double), out var valuesBuffer))
+                    using (context.Allocator.Allocate(readOnlySegment.NumberOfValues * sizeof(TimeStampState), out var stateBuffer))
                     {
                         Memory.Set(valuesBuffer.Ptr, 0, valuesBuffer.Length);
                         Memory.Set(stateBuffer.Ptr, 0, stateBuffer.Length);


### PR DESCRIPTION
…OfItems). We need to take into account the size of elements during allocation.