### PR TITLE
RavenDB-13655

### DIFF
--- a/src/Raven.Server/Background/BackgroundWorkBase.cs
+++ b/src/Raven.Server/Background/BackgroundWorkBase.cs
@@ -134,7 +134,7 @@ namespace Raven.Server.Background
 
         protected abstract Task DoWork();
 
-        public void Dispose()
+        public virtual void Dispose()
         {
             try
             {

--- a/src/Raven.Server/Dashboard/MachineResourcesNotificationSender.cs
+++ b/src/Raven.Server/Dashboard/MachineResourcesNotificationSender.cs
@@ -105,7 +105,7 @@ namespace Raven.Server.Dashboard
             return machineResources;
         }
 
-        public new void Dispose()
+        public override void Dispose()
         {
             base.Dispose();
 

--- a/src/Raven.Server/Documents/ChangesClientConnection.cs
+++ b/src/Raven.Server/Documents/ChangesClientConnection.cs
@@ -25,7 +25,7 @@ namespace Raven.Server.Documents
         private readonly DocumentDatabase _documentDatabase;
         private readonly AsyncQueue<ChangeValue> _sendQueue = new AsyncQueue<ChangeValue>();
 
-        private readonly CancellationTokenSource _cts = new CancellationTokenSource();
+        private readonly CancellationTokenSource _cts;
         private readonly CancellationToken _disposeToken;
 
         private readonly DateTime _startedAt;
@@ -67,6 +67,7 @@ namespace Raven.Server.Documents
             _webSocket = webSocket;
             _documentDatabase = documentDatabase;
             _startedAt = SystemTime.UtcNow;
+            _cts = CancellationTokenSource.CreateLinkedTokenSource(documentDatabase.DatabaseShutdown);
             _disposeToken = _cts.Token;
         }
 

--- a/src/Raven.Server/Documents/DocumentDatabase.cs
+++ b/src/Raven.Server/Documents/DocumentDatabase.cs
@@ -645,7 +645,7 @@ namespace Raven.Server.Documents
                         connection.Dispose();
                     });
                 }
-                
+
                 exceptionAggregator.Execute(() =>
                 {
                     TxMerger?.Dispose();

--- a/src/Raven.Server/Documents/Handlers/ChangesHandler.cs
+++ b/src/Raven.Server/Documents/Handlers/ChangesHandler.cs
@@ -190,6 +190,9 @@ namespace Raven.Server.Documents.Handlers
                     Database.Changes.Disconnect(connection.Id);
                 }
             }
+
+            Database.DatabaseShutdown.ThrowIfCancellationRequested();
+
             await sendTask;
         }
 

--- a/src/Raven.Server/Documents/Indexes/Index.cs
+++ b/src/Raven.Server/Documents/Indexes/Index.cs
@@ -220,7 +220,14 @@ namespace Raven.Server.Documents.Indexes
             {
                 using (DrainRunningQueries())
                     DisposeIndex();
+
+                RemoveIndexFromCache();
             });
+        }
+
+        protected virtual void RemoveIndexFromCache()
+        {
+
         }
 
         protected virtual void DisposeIndex()
@@ -238,6 +245,8 @@ namespace Raven.Server.Documents.Indexes
                     DocumentDatabase.TombstoneCleaner.Unsubscribe(this);
 
                     DocumentDatabase.Changes.OnIndexChange -= HandleIndexChange;
+
+                    DocumentDatabase = null;
                 }
 
                 _indexValidationStalenessCheck = null;
@@ -262,6 +271,8 @@ namespace Raven.Server.Documents.Indexes
                 exceptionAggregator.Execute(() => { _contextPool?.Dispose(); });
 
                 exceptionAggregator.Execute(() => { _indexingProcessCancellationTokenSource?.Dispose(); });
+
+                RemoveIndexFromCache();
 
                 exceptionAggregator.ThrowIfNeeded();
             }

--- a/src/Raven.Server/Documents/Indexes/Index.cs
+++ b/src/Raven.Server/Documents/Indexes/Index.cs
@@ -2833,7 +2833,7 @@ namespace Raven.Server.Documents.Indexes
         [MethodImpl(MethodImplOptions.AggressiveInlining)]
         private void AssertIndexState(bool assertState = true)
         {
-            DocumentDatabase.DatabaseShutdown.ThrowIfCancellationRequested();
+            DocumentDatabase?.DatabaseShutdown.ThrowIfCancellationRequested();
 
             if (assertState && _isCompactionInProgress)
                 ThrowCompactionInProgress();

--- a/src/Raven.Server/Documents/Indexes/Index.cs
+++ b/src/Raven.Server/Documents/Indexes/Index.cs
@@ -220,8 +220,6 @@ namespace Raven.Server.Documents.Indexes
             {
                 using (DrainRunningQueries())
                     DisposeIndex();
-
-                RemoveIndexFromCache();
             });
         }
 
@@ -272,7 +270,7 @@ namespace Raven.Server.Documents.Indexes
 
                 exceptionAggregator.Execute(() => { _indexingProcessCancellationTokenSource?.Dispose(); });
 
-                RemoveIndexFromCache();
+                exceptionAggregator.Execute(RemoveIndexFromCache);
 
                 exceptionAggregator.ThrowIfNeeded();
             }

--- a/src/Raven.Server/Documents/Indexes/MapReduce/Static/MapReduceIndex.cs
+++ b/src/Raven.Server/Documents/Indexes/MapReduce/Static/MapReduceIndex.cs
@@ -58,6 +58,11 @@ namespace Raven.Server.Documents.Indexes.MapReduce.Static
             _isSideBySide = null;
         }
 
+        protected override void RemoveIndexFromCache()
+        {
+            _compiled.RemoveIndexFromCache();
+        }
+
         protected override void HandleDocumentChange(DocumentChange change)
         {
             if (HandleAllDocs == false && Collections.Contains(change.CollectionName) == false &&

--- a/src/Raven.Server/Documents/Indexes/Static/IndexCompilationCache.cs
+++ b/src/Raven.Server/Documents/Indexes/Static/IndexCompilationCache.cs
@@ -50,7 +50,12 @@ namespace Raven.Server.Documents.Indexes.Static
 
             try
             {
-                return result.Value;
+                var index = result.Value;
+                if (index is JavaScriptIndex javaScriptIndex)
+                {
+                    javaScriptIndex.TryRemoveFromCache = () => { IndexCache.TryRemove(key, out _); };
+                }
+                return index;
             }
             catch (Exception)
             {

--- a/src/Raven.Server/Documents/Indexes/Static/JavaScriptIndex.cs
+++ b/src/Raven.Server/Documents/Indexes/Static/JavaScriptIndex.cs
@@ -19,6 +19,7 @@ namespace Raven.Server.Documents.Indexes.Static
 {
     public class JavaScriptIndex : StaticIndexBase
     {
+
         private const string GlobalDefinitions = "globalDefinition";
         private const string MapsProperty = "maps";
         private const string CollectionProperty = "collection";
@@ -61,6 +62,13 @@ namespace Raven.Server.Documents.Indexes.Static
 
                 ProcessFields(definition, collectionFunctions);
             }
+        }
+
+        public Action TryRemoveFromCache { get; set; }
+
+        public override void RemoveIndexFromCache()
+        {
+            TryRemoveFromCache?.Invoke();
         }
 
         private void ProcessFields(IndexDefinition definition, Dictionary<string, List<JavaScriptMapOperation>> collectionFunctions)

--- a/src/Raven.Server/Documents/Indexes/Static/MapIndex.cs
+++ b/src/Raven.Server/Documents/Indexes/Static/MapIndex.cs
@@ -151,6 +151,11 @@ namespace Raven.Server.Documents.Indexes.Static
             }
         }
 
+        protected override void RemoveIndexFromCache()
+        {
+            _compiled.RemoveIndexFromCache();
+        }
+
         public override Dictionary<string, HashSet<CollectionName>> GetReferencedCollections()
         {
             return _compiled.ReferencedCollections;

--- a/src/Raven.Server/Documents/Indexes/Static/StaticIndexBase.cs
+++ b/src/Raven.Server/Documents/Indexes/Static/StaticIndexBase.cs
@@ -317,5 +317,9 @@ namespace Raven.Server.Documents.Indexes.Static
 
             return Convert.ToDouble(value);
         }
+
+        public virtual void RemoveIndexFromCache()
+        {
+        }
     }
 }

--- a/src/Raven.Server/Documents/Replication/ReplicationLoader.cs
+++ b/src/Raven.Server/Documents/Replication/ReplicationLoader.cs
@@ -45,7 +45,7 @@ namespace Raven.Server.Documents.Replication
 
         internal ManualResetEventSlim DebugWaitAndRunReplicationOnce;
 
-        public readonly DocumentDatabase Database;
+        public DocumentDatabase Database;
         private SingleUseFlag _isInitialized = new SingleUseFlag();
 
         private readonly Timer _reconnectAttemptTimer;
@@ -1230,6 +1230,7 @@ namespace Raven.Server.Documents.Replication
 
             Database.TombstoneCleaner?.Unsubscribe(this);
 
+            Database = null;
             ea.ThrowIfNeeded();
         }
 

--- a/src/Sparrow.Server/ByteString.cs
+++ b/src/Sparrow.Server/ByteString.cs
@@ -517,7 +517,7 @@ namespace Sparrow.Server
         {
             SegmentsPool = new ThreadLocal<StackHeader<UnmanagedGlobalSegment>>(() => new StackHeader<UnmanagedGlobalSegment>(), trackAllValues: true);
             LowMemoryFlag = new SharedMultipleUseFlag();
-            Cleaner = new NativeMemoryCleaner<StackHeader<UnmanagedGlobalSegment>, UnmanagedGlobalSegment>(() => SegmentsPool.Values, LowMemoryFlag, TimeSpan.FromMinutes(1), TimeSpan.FromMinutes(1));
+            Cleaner = new NativeMemoryCleaner<StackHeader<UnmanagedGlobalSegment>, UnmanagedGlobalSegment>(typeof(ByteStringMemoryCache), _ => SegmentsPool.Values, LowMemoryFlag, TimeSpan.FromMinutes(1), TimeSpan.FromMinutes(1));
 
             ThreadLocalCleanup.ReleaseThreadLocalState += CleanForCurrentThread;
 

--- a/src/Sparrow/Json/JsonContextPoolBase.cs
+++ b/src/Sparrow/Json/JsonContextPoolBase.cs
@@ -161,7 +161,7 @@ namespace Sparrow.Json
         protected JsonContextPoolBase()
         {
             ThreadLocalCleanup.ReleaseThreadLocalState += CleanThreadLocalState;
-            _nativeMemoryCleaner = new NativeMemoryCleaner<ContextStack, T>(()=> EnumerateAllThreadContexts().ToList(),
+            _nativeMemoryCleaner = new NativeMemoryCleaner<ContextStack, T>(this, s => ((JsonContextPoolBase<T>)s).EnumerateAllThreadContexts().ToList(),
                 LowMemoryFlag, TimeSpan.FromMinutes(1), TimeSpan.FromMinutes(1));
             LowMemoryNotification.Instance?.RegisterLowMemoryHandler(this);
         }

--- a/src/Voron/StorageEnvironment.cs
+++ b/src/Voron/StorageEnvironment.cs
@@ -469,6 +469,8 @@ namespace Voron
 
                 OnLogsApplied = null;
 
+                _options.NullifyHandlers();
+
                 foreach (var disposable in new IDisposable[]
                 {
                     _journal,

--- a/src/Voron/StorageEnvironmentOptions.cs
+++ b/src/Voron/StorageEnvironmentOptions.cs
@@ -4,6 +4,7 @@ using System.Collections.Concurrent;
 using System.Collections.Generic;
 using System.Diagnostics;
 using System.IO;
+using System.Runtime.CompilerServices;
 using System.Runtime.ExceptionServices;
 using System.Runtime.InteropServices;
 using System.Threading;
@@ -1091,6 +1092,8 @@ namespace Voron
 
         public unsafe void Dispose()
         {
+            NullifyHandlers();
+
             var copy = MasterKey;
             if (copy != null)
             {
@@ -1104,6 +1107,14 @@ namespace Voron
             ScratchSpaceUsage?.Dispose();
 
             Disposing();
+        }
+
+        [MethodImpl(MethodImplOptions.AggressiveInlining)]
+        public void NullifyHandlers()
+        {
+            SchemaUpgrader = null;
+            OnRecoveryError = null;
+            OnNonDurableFileSystemError = null;
         }
 
         protected abstract void Disposing();

--- a/src/Voron/StorageEnvironmentOptions.cs
+++ b/src/Voron/StorageEnvironmentOptions.cs
@@ -1109,7 +1109,6 @@ namespace Voron
             Disposing();
         }
 
-        [MethodImpl(MethodImplOptions.AggressiveInlining)]
         public void NullifyHandlers()
         {
             SchemaUpgrader = null;

--- a/test/BenchmarkTests/BenchmarkTestBase.cs
+++ b/test/BenchmarkTests/BenchmarkTestBase.cs
@@ -18,15 +18,18 @@ namespace BenchmarkTests
     {
         public abstract Task InitAsync(DocumentStore store);
 
-        protected override RavenServer GetNewServer(IDictionary<string, string> customSettings = null, bool deletePrevious = true, bool runInMemory = true, string partialPath = null,
-            string customConfigPath = null)
+        protected override RavenServer GetNewServer(ServerCreationOptions options = null)
         {
-            if (customSettings == null)
-                customSettings = new Dictionary<string, string>();
+            if (options == null)
+            {
+                options = new ServerCreationOptions();
+            }
+            if (options.CustomSettings == null)
+                options.CustomSettings = new Dictionary<string, string>();
 
-            customSettings[RavenConfiguration.GetKey(x => x.Databases.MaxIdleTime)] = int.MaxValue.ToString();
+            options.CustomSettings[RavenConfiguration.GetKey(x => x.Databases.MaxIdleTime)] = int.MaxValue.ToString();
 
-            return base.GetNewServer(customSettings, deletePrevious, false, partialPath, customConfigPath);
+            return base.GetNewServer(options);
         }
 
         protected DocumentStore GetSimpleDocumentStore(string databaseName, bool deleteDatabaseOnDispose = true)

--- a/test/FastTests/Client/Subscriptions/SubscriptionsBasic.cs
+++ b/test/FastTests/Client/Subscriptions/SubscriptionsBasic.cs
@@ -469,10 +469,17 @@ namespace FastTests.Client.Subscriptions
             SubscriptionWorker<dynamic> subscriptionWorker = null;
             try
             {
-                server = GetNewServer(runInMemory: false, customSettings: new Dictionary<string, string>()
+                var co = new ServerCreationOptions
                 {
-                    [RavenConfiguration.GetKey(x => x.Core.DataDirectory)] = dataPath
-                });
+                    RunInMemory = false,
+                    CustomSettings = new Dictionary<string, string>()
+                    {
+                        [RavenConfiguration.GetKey(x => x.Core.DataDirectory)] = dataPath
+                    },
+                    RegisterForDisposal = false
+                };
+
+                server = GetNewServer(co);
 
                 store = new DocumentStore()
                 {

--- a/test/InterversionTests/MixedClusterTestBase.cs
+++ b/test/InterversionTests/MixedClusterTestBase.cs
@@ -28,21 +28,25 @@ namespace InterversionTests
             public string Url;
         }
 
-        protected override RavenServer GetNewServer(IDictionary<string, string> customSettings = null, bool deletePrevious = true, bool runInMemory = true, string partialPath = null,
-            string customConfigPath = null)
+        protected override RavenServer GetNewServer(ServerCreationOptions options = null)
         {
-            if (customSettings == null)
-                customSettings = new Dictionary<string, string>();
+            if (options == null)
+            {
+                options = new ServerCreationOptions();
+            }
+
+            if (options.CustomSettings == null)
+                options.CustomSettings = new Dictionary<string, string>();
             var key = RavenConfiguration.GetKey(x => x.Http.UseLibuv);
-            if (customSettings.ContainsKey(key) == false)
-                customSettings[key] = "true";
-            return base.GetNewServer(customSettings, deletePrevious, runInMemory, partialPath, customConfigPath);
+            if (options.CustomSettings.ContainsKey(key) == false)
+                options.CustomSettings[key] = "true";
+            return base.GetNewServer(options);
         }
 
         protected async Task<(RavenServer Leader, List<ProcessNode> Peers, List<RavenServer> LocalPeers)> CreateMixedCluster(
             string[] peers, int localPeers = 0, IDictionary<string, string> customSettings = null, X509Certificate2 certificate = null)
         {
-            var leaderServer = GetNewServer(customSettings);
+            var leaderServer = GetNewServer(new ServerCreationOptions {CustomSettings = customSettings});
             leaderServer.ServerStore.EnsureNotPassive(leaderServer.WebUrl);
 
             var nodeAdded = new ManualResetEvent(false);
@@ -68,7 +72,7 @@ namespace InterversionTests
 
                 for (int i = 0; i < localPeers; i++)
                 {
-                    var peer = GetNewServer(customSettings);
+                    var peer = GetNewServer(new ServerCreationOptions{CustomSettings = customSettings});
                     var addCommand = new AddClusterNodeCommand(peer.WebUrl);
                     await requestExecutor.ExecuteAsync(addCommand, context);
                     Assert.True(nodeAdded.WaitOne(TimeSpan.FromSeconds(30)));

--- a/test/RachisTests/AddNodeToClusterTests.cs
+++ b/test/RachisTests/AddNodeToClusterTests.cs
@@ -583,10 +583,10 @@ namespace RachisTests
             }
 
             var result = await DisposeServerAndWaitForFinishOfDisposalAsync(cluster.Leader);
-            cluster.Leader = GetNewServer(deletePrevious: false, runInMemory: false, partialPath: result.DataDir, customSettings: new Dictionary<string, string>
+            cluster.Leader = GetNewServer(new ServerCreationOptions {DeletePrevious = false, RunInMemory = false, PartialPath = result.DataDir, CustomSettings = new Dictionary<string, string>
             {
                 [RavenConfiguration.GetKey(x => x.Core.ServerUrls)] = result.Url
-            });
+            }});
 
             var topology = cluster.Leader.ServerStore.GetClusterTopology();
             Assert.Equal(3, topology.AllNodes.Count);

--- a/test/RachisTests/DatabaseCluster/EtlFailover.cs
+++ b/test/RachisTests/DatabaseCluster/EtlFailover.cs
@@ -328,10 +328,13 @@ namespace RachisTests.DatabaseCluster
                 var currentTaskNodeServer = srcNodes.Servers.Single(s => s.ServerStore.NodeTag == currentNodeNodeTag);
 
                 // start server which originally was handling ETL task
-                GetNewServer(new Dictionary<string, string>()
-                {
-                    {RavenConfiguration.GetKey(x => x.Core.ServerUrls), originalServerUrl}
-                }, runInMemory: false, deletePrevious: false, partialPath: originalServerDataDir);
+                GetNewServer(new ServerCreationOptions
+                    {
+                        CustomSettings = new Dictionary<string, string>
+                        {
+                            {RavenConfiguration.GetKey(x => x.Core.ServerUrls), originalServerUrl}
+                        }, RunInMemory = false, DeletePrevious = false, PartialPath = originalServerDataDir
+                    });
 
                 using (var store = new DocumentStore
                 {

--- a/test/RachisTests/DatabaseCluster/RemoveNodeFromCluster.cs
+++ b/test/RachisTests/DatabaseCluster/RemoveNodeFromCluster.cs
@@ -263,10 +263,12 @@ namespace RachisTests.DatabaseCluster
             {
                 await cluster.Leader.ServerStore.RemoveFromClusterAsync("B");
                 var result = await DisposeServerAndWaitForFinishOfDisposalAsync(cluster.Leader);
-                cluster.Leader = GetNewServer(deletePrevious: false, runInMemory: false, partialPath: result.DataDir, customSettings: new Dictionary<string, string>
+                cluster.Leader = GetNewServer(new ServerCreationOptions
+                {
+                    DeletePrevious = false, RunInMemory = false, PartialPath = result.DataDir, CustomSettings = new Dictionary<string, string>
                 {
                     [RavenConfiguration.GetKey(x => x.Core.ServerUrls)] = result.Url
-                });
+                }});
 
                 await cluster.Leader.ServerStore.WaitForState(RachisState.Leader, CancellationToken.None);
                 Assert.NotNull(await store.Maintenance.Server.SendAsync(new GetDatabaseRecordOperation(dbName)));

--- a/test/RachisTests/DisableNodeOnClusterTest.cs
+++ b/test/RachisTests/DisableNodeOnClusterTest.cs
@@ -62,7 +62,10 @@ namespace RachisTests
 
                 Assert.NotEqual(re.Url, firstNodeUrl);
                 settings[RavenConfiguration.GetKey(x => x.Core.ServerUrls)] = firstNodeUrl;
-                Servers.Add(GetNewServer(settings, runInMemory: false, deletePrevious: false, partialPath: nodePath));
+                Servers.Add(GetNewServer(new ServerCreationOptions
+                {
+                    CustomSettings = settings, RunInMemory = false, DeletePrevious = false, PartialPath = nodePath
+                }));
                 await re.CheckNodeStatusNow(tag);
                 Assert.True(WaitForValue(() => firstNodeUrl == re.Url, true));
             }

--- a/test/RachisTests/SubscriptionsFailover.cs
+++ b/test/RachisTests/SubscriptionsFailover.cs
@@ -805,14 +805,17 @@ namespace RachisTests
                     Assert.True(await subscriptionRetryBegins.WaitAsync(TimeSpan.FromSeconds(30)));
 
                     leader = Servers[0] = 
-                        GetNewServer(new Dictionary<string, string>
+                        GetNewServer(new ServerCreationOptions
+                        {
+                            CustomSettings = new Dictionary<string, string>
                             {
                                 {RavenConfiguration.GetKey(x => x.Core.PublicServerUrl), leaderUrl},
                                 {RavenConfiguration.GetKey(x => x.Core.ServerUrls), leaderUrl}
                             },
-                            runInMemory: false,
-                            deletePrevious: false,
-                            partialPath: leaderDataDir);
+                            RunInMemory = false,
+                            DeletePrevious = false,
+                            PartialPath = leaderDataDir
+                        });
                     
                     Assert.True(await batchProccessed.WaitAsync(TimeSpan.FromSeconds(60)));
                     Assert.True(await batchedAcked.WaitAsync(TimeSpan.FromSeconds(60)));

--- a/test/SlowTests/Client/Attachments/AttachmentsReplication.cs
+++ b/test/SlowTests/Client/Attachments/AttachmentsReplication.cs
@@ -1143,10 +1143,16 @@ namespace SlowTests.Client.Attachments
         [Fact]
         public async Task RavenDB_13535()
         {
-            using (var server = GetNewServer(runInMemory: false, customSettings: new Dictionary<string, string>
+            var co = new ServerCreationOptions
             {
-                [RavenConfiguration.GetKey(x => x.Replication.MaxSizeToSend)] = 1.ToString()
-            }))
+                RunInMemory = false,
+                CustomSettings = new Dictionary<string, string>
+                {
+                    [RavenConfiguration.GetKey(x => x.Replication.MaxSizeToSend)] = 1.ToString()
+                },
+                RegisterForDisposal = false
+            };
+            using (var server = GetNewServer(co))
             using (var store1 = GetDocumentStore(new Options { Server = server, RunInMemory = false }))
             using (var store2 = GetDocumentStore(new Options { Server = server, RunInMemory = false }))
             using (var store3 = GetDocumentStore(new Options { Server = server, RunInMemory = false }))

--- a/test/SlowTests/Client/Counters/CountersReplication.cs
+++ b/test/SlowTests/Client/Counters/CountersReplication.cs
@@ -463,9 +463,14 @@ namespace SlowTests.Client.Counters
         public async Task RestoreAndReplicateCounters()
         {
             var backupPath = NewDataPath(suffix: "BackupFolder");
-            using (var server = GetNewServer(new Dictionary<string, string>
-            {
-                [RavenConfiguration.GetKey(x => x.Replication.MaxItemsCount)] = 1.ToString()
+            using (var server = GetNewServer(
+                new ServerCreationOptions
+                {
+                    CustomSettings = new Dictionary<string, string>
+                    {
+                        [RavenConfiguration.GetKey(x => x.Replication.MaxItemsCount)] = 1.ToString()                
+                    },
+                    RegisterForDisposal = false
             }))
             {
                 using (var store1 = GetDocumentStore(new Options

--- a/test/SlowTests/Cluster/ClusterModesForRequestExecutorTest.cs
+++ b/test/SlowTests/Cluster/ClusterModesForRequestExecutorTest.cs
@@ -35,7 +35,7 @@ namespace SlowTests.Cluster
         public async Task ProxyServer_should_work()
         {
             int serverPort = 10000;
-            using (var server = GetNewServer(GetServerSettingsForPort(false, out var _)))
+            using (var server = GetNewServer(new ServerCreationOptions{CustomSettings = GetServerSettingsForPort(false, out var _), RegisterForDisposal = false}))
             using (var proxy = new ProxyServer(ref serverPort, Convert.ToInt32(server.ServerStore.GetNodeHttpServerUrl().Split(':')[2])))
             {
                 Servers.Add(server);

--- a/test/SlowTests/Cluster/ClusterTransactionTests.cs
+++ b/test/SlowTests/Cluster/ClusterTransactionTests.cs
@@ -32,17 +32,21 @@ namespace SlowTests.Cluster
 {
     public class ClusterTransactionTests : ReplicationTestBase
     {
-        protected override RavenServer GetNewServer(IDictionary<string, string> customSettings = null, bool deletePrevious = true, bool runInMemory = true, string partialPath = null,
-            string customConfigPath = null)
+        protected override RavenServer GetNewServer(ServerCreationOptions options = null)
         {
-            if (customSettings == null)
-                customSettings = new Dictionary<string, string>();
+            if (options == null)
+            {
+                options = new ServerCreationOptions();
+            }
 
-            customSettings[RavenConfiguration.GetKey(x => x.Cluster.OperationTimeout)] = "60";
-            customSettings[RavenConfiguration.GetKey(x => x.Cluster.StabilizationTime)] = "10";
-            customSettings[RavenConfiguration.GetKey(x => x.Cluster.TcpConnectionTimeout)] = "30000";
+            if (options.CustomSettings == null)
+                options.CustomSettings = new Dictionary<string, string>();
 
-            return base.GetNewServer(customSettings, deletePrevious, runInMemory, partialPath, customConfigPath);
+            options.CustomSettings[RavenConfiguration.GetKey(x => x.Cluster.OperationTimeout)] = "60";
+            options.CustomSettings[RavenConfiguration.GetKey(x => x.Cluster.StabilizationTime)] = "10";
+            options.CustomSettings[RavenConfiguration.GetKey(x => x.Cluster.TcpConnectionTimeout)] = "30000";
+
+            return base.GetNewServer(options);
         }
 
         [Fact]
@@ -1045,11 +1049,16 @@ namespace SlowTests.Cluster
                 }
 
                 // revive the SUT node
-                var revived = Servers[1] = GetNewServer(new Dictionary<string, string>
+                var revived = Servers[1] = GetNewServer(new ServerCreationOptions{ CustomSettings = new Dictionary<string, string>
                 {
                     [RavenConfiguration.GetKey(x => x.Core.ServerUrls)] = url,
                     [RavenConfiguration.GetKey(x => x.Cluster.ElectionTimeout)] = "400"
-                }, runInMemory: false, deletePrevious: false, partialPath: dataDir);
+                },
+                    RunInMemory = false,
+                    DeletePrevious = false,
+                    PartialPath = dataDir,
+                    RegisterForDisposal = false
+                });
                 using (var revivedStore = new DocumentStore()
                 {
                     Urls = new[] { revived.WebUrl },
@@ -1075,11 +1084,11 @@ namespace SlowTests.Cluster
                         Assert.Equal(2, count);
 
                         // revive another node so we should have a functional cluster now
-                        Servers[2] = GetNewServer(new Dictionary<string, string>
+                        Servers[2] = GetNewServer(new ServerCreationOptions { CustomSettings = new Dictionary<string, string>
                         {
                             [RavenConfiguration.GetKey(x => x.Core.ServerUrls)] = url2,
                             [RavenConfiguration.GetKey(x => x.Cluster.ElectionTimeout)] = "400"
-                        }, runInMemory: false, deletePrevious: false, partialPath: dataDir2);
+                        }, RunInMemory = false, DeletePrevious =  false, PartialPath = dataDir2});
 
                         // wait for the log to apply on the SUT node
                         using (var cts = new CancellationTokenSource(TimeSpan.FromSeconds(15)))

--- a/test/SlowTests/Issues/RDBC-282.cs
+++ b/test/SlowTests/Issues/RDBC-282.cs
@@ -21,7 +21,7 @@ namespace SlowTests.Issues
         [Fact]
         public async Task ChangesApiShouldReconnectToServerWhenServerReturn()
         {
-            var server = GetNewServer(runInMemory: false);
+            var server = GetNewServer(new ServerCreationOptions { RunInMemory = false, RegisterForDisposal = false});
             try
             {
                 using (var store = GetDocumentStore(new Options { Server = server, Path = Path.Combine(server.Configuration.Core.DataDirectory.FullPath, "ChangesApiShouldReconnectToServerWhenServerReturn") }))
@@ -45,7 +45,7 @@ namespace SlowTests.Issues
                     {
                         {RavenConfiguration.GetKey(x => x.Core.ServerUrls), url}
                     };
-                    server = GetNewServer(runInMemory: false, deletePrevious: false, partialPath: nodePath, customSettings: settings);
+                    server = GetNewServer(new ServerCreationOptions {RunInMemory= false, DeletePrevious = false, PartialPath = nodePath, CustomSettings = settings});
                     await taskObservable.EnsureConnectedNow();
                     PushUser(store);
                     value = WaitForValue(() => list.Count, 2);

--- a/test/SlowTests/Issues/RavenDB-13697.cs
+++ b/test/SlowTests/Issues/RavenDB-13697.cs
@@ -37,13 +37,20 @@ namespace SlowTests.Issues
 
                 var dbRecord = new DatabaseRecord(documentStore.Database);
                 var operation = new CreateDatabaseOperation(dbRecord);
-                await documentStore.Maintenance.Server.SendAsync(operation).ConfigureAwait(false);
-
-                Version dbVersion;
-                using (var session = documentStore.OpenAsyncSession())
+                try
                 {
-                    // should work
-                    dbVersion = await session.LoadAsync<Version>("TheVersion").ConfigureAwait(false);
+                    await documentStore.Maintenance.Server.SendAsync(operation).ConfigureAwait(false);
+
+                    Version dbVersion;
+                    using (var session = documentStore.OpenAsyncSession())
+                    {
+                        // should work
+                        dbVersion = await session.LoadAsync<Version>("TheVersion").ConfigureAwait(false);
+                    }
+                }
+                finally
+                {
+                    await documentStore.Maintenance.Server.SendAsync(new DeleteDatabasesOperation(documentStore.Database, true));
                 }
             }
         }

--- a/test/SlowTests/Issues/RavenDB_13284.cs
+++ b/test/SlowTests/Issues/RavenDB_13284.cs
@@ -14,8 +14,14 @@ namespace SlowTests.Issues
         [Fact]
         public async Task ExternalReplicationCanReestablishAfterServerRestarts()
         {
-            var serverSrc = GetNewServer(runInMemory: false);
-            var serverDst = GetNewServer(runInMemory: false);
+            var serverSrc = GetNewServer(new ServerCreationOptions
+            {
+                RunInMemory = false
+            });
+            var serverDst = GetNewServer(new ServerCreationOptions
+            {
+                RunInMemory = false
+            });
             using (var storeSrc = GetDocumentStore(new Options
             {
                 Server = serverSrc,
@@ -52,7 +58,7 @@ namespace SlowTests.Issues
                 }
 
                 // Bring destination server up
-                serverDst = GetNewServer(runInMemory: false, deletePrevious: false, partialPath: nodePath, customSettings: settings);
+                serverDst = GetNewServer(new ServerCreationOptions{RunInMemory = false, DeletePrevious = false, PartialPath = nodePath, CustomSettings = settings});
 
                 Assert.True(WaitForDocument(storeDst, "user/2"));
             }

--- a/test/SlowTests/Issues/RavenDB_13749.cs
+++ b/test/SlowTests/Issues/RavenDB_13749.cs
@@ -11,10 +11,10 @@ namespace SlowTests.Issues
         [Fact]
         public void CanSetLogsRetentionTime()
         {
-            using (var server = GetNewServer(runInMemory: true, customSettings: new Dictionary<string, string>
+            using (var server = GetNewServer(new ServerCreationOptions{RunInMemory = true, CustomSettings = new Dictionary<string, string>
             {
                 [RavenConfiguration.GetKey(x => x.Logs.RetentionTime)] = "100"
-            }))
+            }}))
             {
                 Assert.Equal(new TimeSpan(100, 0, 0), server.Configuration.Logs.RetentionTime.Value.AsTimeSpan);
             }
@@ -23,10 +23,10 @@ namespace SlowTests.Issues
         [Fact]
         public void SettingLogsRetentionTimeToVeryLowValueWillSetMinValueAnyway()
         {
-            using (var server = GetNewServer(runInMemory: true, customSettings: new Dictionary<string, string>
+            using (var server = GetNewServer(new ServerCreationOptions{ RunInMemory = true, CustomSettings = new Dictionary<string, string>
             {
                 [RavenConfiguration.GetKey(x => x.Logs.RetentionTime)] = "1"
-            }))
+            }}))
             {
                 Assert.Equal(new TimeSpan(24, 0, 0), server.Configuration.Logs.RetentionTime.Value.AsTimeSpan);
             }

--- a/test/SlowTests/Issues/RavenDB_7912.cs
+++ b/test/SlowTests/Issues/RavenDB_7912.cs
@@ -44,14 +44,14 @@ namespace SlowTests.Issues
                         var url = Servers[1].WebUrl;
                         var dataDir = Servers[1].Configuration.Core.DataDirectory.FullPath.Split('/').Last();
 
-                        Servers[1] = GetNewServer(new Dictionary<string, string>
+                        Servers[1] = GetNewServer(new ServerCreationOptions {CustomSettings = new Dictionary<string, string>
                             {
                                 {RavenConfiguration.GetKey(x => x.Core.PublicServerUrl), url},
                                 {RavenConfiguration.GetKey(x => x.Core.ServerUrls), url}
                             },
-                            runInMemory: false,
-                            deletePrevious: false,
-                            partialPath: dataDir);
+                            RunInMemory = false,
+                            DeletePrevious = false,
+                            PartialPath = dataDir});
 
                         Assert.True(await WaitForDatabaseToBeDeleted(Servers[1], databaseName, TimeSpan.FromSeconds(30), cts.Token));
                     }

--- a/test/SlowTests/SchemaUpgrade/Server/From18Test.cs
+++ b/test/SlowTests/SchemaUpgrade/Server/From18Test.cs
@@ -26,7 +26,7 @@ namespace SlowTests.SchemaUpgrade.Server
 
             ZipFile.ExtractToDirectory(zipPath.FullPath, folder);
 
-            using (var server = GetNewServer(deletePrevious: false, runInMemory: false, partialPath: folder))
+            using (var server = GetNewServer(new ServerCreationOptions{DeletePrevious = false, RunInMemory = false, PartialPath = folder, RegisterForDisposal = false}))
             using (server.ServerStore.ContextPool.AllocateOperationContext(out TransactionOperationContext context))
             using (context.OpenReadTransaction())
             {

--- a/test/SlowTests/Server/Documents/PeriodicBackup/RavenDB-11139.cs
+++ b/test/SlowTests/Server/Documents/PeriodicBackup/RavenDB-11139.cs
@@ -953,7 +953,7 @@ namespace SlowTests.Server.Documents.PeriodicBackup
 
             ZipFile.ExtractToDirectory(zipPath.FullPath, folder);
 
-            using (var server = GetNewServer(deletePrevious: false, runInMemory: false, partialPath: folder))
+            using (var server = GetNewServer(new ServerCreationOptions {DeletePrevious = false, RunInMemory = false, PartialPath = folder, RegisterForDisposal = false}))
             {
                 using (server.ServerStore.ContextPool.AllocateOperationContext(out TransactionOperationContext context))
                 using (context.OpenReadTransaction())

--- a/test/SlowTests/Server/Documents/PeriodicBackup/RavenDB-13229.cs
+++ b/test/SlowTests/Server/Documents/PeriodicBackup/RavenDB-13229.cs
@@ -133,7 +133,7 @@ namespace SlowTests.Server.Documents.PeriodicBackup
 
             ZipFile.ExtractToDirectory(zipPath.FullPath, folder);
 
-            using (var server = GetNewServer(deletePrevious: false, runInMemory: false, partialPath: folder))
+            using (var server = GetNewServer(new ServerCreationOptions { DeletePrevious = false, RunInMemory = false, PartialPath = folder, RegisterForDisposal = false}))
             {
                 using (server.ServerStore.ContextPool.AllocateOperationContext(out TransactionOperationContext context))
                 using (context.OpenReadTransaction())
@@ -176,7 +176,7 @@ namespace SlowTests.Server.Documents.PeriodicBackup
 
             ZipFile.ExtractToDirectory(zipPath.FullPath, folder);
 
-            using (var server = GetNewServer(deletePrevious: false, runInMemory: false, partialPath: folder))
+            using (var server = GetNewServer(new ServerCreationOptions {DeletePrevious = false, RunInMemory = false, PartialPath = folder, RegisterForDisposal = false}))
             {
                 using (server.ServerStore.ContextPool.AllocateOperationContext(out TransactionOperationContext context))
                 using (context.OpenReadTransaction())

--- a/test/SlowTests/Server/Replication/PullReplicationTests.cs
+++ b/test/SlowTests/Server/Replication/PullReplicationTests.cs
@@ -355,8 +355,8 @@ namespace SlowTests.Server.Replication
             var sinkDB = GetDatabaseName();
             var pullReplicationName = $"{hubDB}-pull";
 
-            var hubServer = GetNewServer(hubSettings);
-            var sinkServer = GetNewServer(sinkSettings);
+            var hubServer = GetNewServer(new ServerCreationOptions{CustomSettings = hubSettings});
+            var sinkServer = GetNewServer(new ServerCreationOptions { CustomSettings = sinkSettings});
 
             var hubAdminCert = new X509Certificate2(hubCertPath, (string)null, X509KeyStorageFlags.MachineKeySet);
             var sinkAdminCert = new X509Certificate2(sinkCertPath, (string)null, X509KeyStorageFlags.MachineKeySet);

--- a/test/StressTests/Cluster/ClusterStressTests.cs
+++ b/test/StressTests/Cluster/ClusterStressTests.cs
@@ -18,18 +18,21 @@ namespace StressTests.Cluster
     public class ClusterStressTests : ReplicationTestBase
     {
         // the values are lower to make the cluster less stable
-        protected override RavenServer GetNewServer(IDictionary<string, string> customSettings = null, bool deletePrevious = true, bool runInMemory = true, string partialPath = null,
-            string customConfigPath = null)
+        protected override RavenServer GetNewServer(ServerCreationOptions options = null)
         {
-            if (customSettings == null)
-                customSettings = new Dictionary<string, string>();
+            if (options == null)
+            {
+                options = new ServerCreationOptions();
+            }
+            if (options.CustomSettings == null)
+                options.CustomSettings = new Dictionary<string, string>();
 
-            customSettings[RavenConfiguration.GetKey(x => x.Cluster.OperationTimeout)] = "10";
-            customSettings[RavenConfiguration.GetKey(x => x.Cluster.StabilizationTime)] = "1";
-            customSettings[RavenConfiguration.GetKey(x => x.Cluster.TcpConnectionTimeout)] = "3000";
-            customSettings[RavenConfiguration.GetKey(x => x.Cluster.ElectionTimeout)] = "50";
+            options.CustomSettings[RavenConfiguration.GetKey(x => x.Cluster.OperationTimeout)] = "10";
+            options.CustomSettings[RavenConfiguration.GetKey(x => x.Cluster.StabilizationTime)] = "1";
+            options.CustomSettings[RavenConfiguration.GetKey(x => x.Cluster.TcpConnectionTimeout)] = "3000";
+            options.CustomSettings[RavenConfiguration.GetKey(x => x.Cluster.ElectionTimeout)] = "50";
 
-            return base.GetNewServer(customSettings, deletePrevious, runInMemory, partialPath, customConfigPath);
+            return base.GetNewServer(options);
         }
 
         [Fact]

--- a/test/Tests.Infrastructure/ClusterTestBase.cs
+++ b/test/Tests.Infrastructure/ClusterTestBase.cs
@@ -503,8 +503,13 @@ namespace Tests.Infrastructure
                     serverUrl = UseFiddlerUrl("http://127.0.0.1:0");
                     customSettings[RavenConfiguration.GetKey(x => x.Core.ServerUrls)] = serverUrl;
                 }
-
-                var server = GetNewServer(customSettings, runInMemory: shouldRunInMemory);
+                var co = new ServerCreationOptions
+                {
+                    CustomSettings = customSettings,
+                    RunInMemory = shouldRunInMemory,
+                    RegisterForDisposal = false
+                };
+                var server = GetNewServer(co);
                 var port = Convert.ToInt32(server.ServerStore.GetNodeHttpServerUrl().Split(':')[2]);
                 var prefix = useSsl ? "https" : "http";
                 serverUrl = UseFiddlerUrl($"{prefix}://127.0.0.1:{port}");
@@ -564,7 +569,13 @@ namespace Tests.Infrastructure
                 var customSettings = GetServerSettingsForPort(useSsl, out serverUrl);
 
                 int proxyPort = 10000;
-                var server = GetNewServer(customSettings, runInMemory: shouldRunInMemory);
+                var co = new ServerCreationOptions
+                {
+                    CustomSettings = customSettings,
+                    RunInMemory = shouldRunInMemory,
+                    RegisterForDisposal = false
+                };
+                var server = GetNewServer(co);
                 var proxy = new ProxyServer(ref proxyPort, Convert.ToInt32(server.ServerStore.GetNodeHttpServerUrl()), delay);
                 serversToProxies.Add(server, proxy);
 


### PR DESCRIPTION
* Refactored GetNewServer so it will be disposed of if not in a using statement (at the test dispose)
* fix to byte[] leak
* decoupling NativeMemoryCleaner from context and nullifying handlers in env options
* fixed javascript index leak from the index compilation cache
* more minor nullification fixes to cutdown gcroot issues