### PR TITLE
Make JavaScriptConversionExtensions public

### DIFF
--- a/src/Raven.Client/Util/JavascriptConversionExtensions.cs
+++ b/src/Raven.Client/Util/JavascriptConversionExtensions.cs
@@ -18,7 +18,7 @@ using Sparrow.Extensions;
 
 namespace Raven.Client.Util
 {
-    internal class JavascriptConversionExtensions
+    public class JavascriptConversionExtensions
     {
         internal const string TransparentIdentifier = "<>h__TransparentIdentifier";
         private const string DefaultAliasPrefix = "__rvn";


### PR DESCRIPTION
Simple change to expose Linq2Js extensions so clients can reuse them.

https://issues.hibernatingrhinos.com/issue/RavenDB-13823