### PR TITLE
RavenDB-13655 skipping test that throws SO on 32-bit and avoiding AVE…

### DIFF
--- a/src/Raven.Server/Documents/DocumentDatabase.cs
+++ b/src/Raven.Server/Documents/DocumentDatabase.cs
@@ -487,7 +487,7 @@ namespace Raven.Server.Documents
                 var mergedCommand = new BatchHandler.ClusterTransactionMergedCommand(this, singleCommand);
                 try
                 {
-                    await TxMerger.Enqueue(mergedCommand).WithCancellation(DatabaseShutdown);
+                    await TxMerger.Enqueue(mergedCommand);
                     OnClusterTransactionCompletion(command, mergedCommand);
 
                     _clusterTransactionDelayOnFailure = 1000;

--- a/test/SlowTests/Issues/RavenDB_10621.cs
+++ b/test/SlowTests/Issues/RavenDB_10621.cs
@@ -9,7 +9,7 @@ namespace SlowTests.Issues
 {
     public class RavenDB_10621 : RavenTestBase
     {
-        [Fact]
+        [Fact(Skip = "Waiting for RavenDB-13830 to be resolved")]
         public void ShouldNotErrorIndexOnInvalidProgramException()
         {
             // if this test fails it's very likely the following issue got fixed: https://github.com/dotnet/coreclr/issues/14672
@@ -17,7 +17,6 @@ namespace SlowTests.Issues
             using (var store = GetDocumentStore())
             {
                 new BigIndexOutput().Execute(store);
-
                 using (var session = store.OpenSession())
                 {
                     session.Store(new ErroringDocument


### PR DESCRIPTION
… on cluster tx one by one