### PR TITLE
RavenDB-13130 Minor - fixing edge that when we didn't detect that a p…

### DIFF
--- a/src/Voron/Data/Tables/NewPageAllocator.cs
+++ b/src/Voron/Data/Tables/NewPageAllocator.cs
@@ -235,7 +235,7 @@ namespace Voron.Data.Tables
                 }
 
                 if (it.CurrentKey > pageNumber ||
-                    it.CurrentKey + NumberOfPagesInSection < pageNumber)
+                    it.CurrentKey + NumberOfPagesInSection <= pageNumber)
                     ThrowInvalidPageReleased(pageNumber);
 
                 var positionInBuffer = (int)(pageNumber - it.CurrentKey);

--- a/test/SlowTests/Voron/Issues/RavenDB_13130.cs
+++ b/test/SlowTests/Voron/Issues/RavenDB_13130.cs
@@ -1,0 +1,26 @@
+﻿using System;
+using FastTests.Voron;
+using Voron.Data.Tables;
+using Xunit;
+
+namespace SlowTests.Voron.Issues
+{
+    public class RavenDB_13130 : StorageTest
+    {
+        [Fact]
+        public void Should_throw_on_attempt_to_free_page_which_was_not_allocated_by_NewPageAllocator()
+        {
+            using (var tx = Env.WriteTransaction())
+            {
+                var parent = tx.CreateTree("parent");
+
+                var allocator = new NewPageAllocator(tx.LowLevelTransaction, parent);
+                allocator.Create();
+
+                var pageAllocatedDirectly = tx.LowLevelTransaction.AllocatePage(1);
+
+                Assert.Throws<InvalidOperationException>(() => allocator.FreePage(pageAllocatedDirectly.PageNumber));
+            }
+        }
+    }
+}


### PR DESCRIPTION
…age wasn't allocated by NewPageAllocator but we allowed to free it