### PR TITLE
RavenDB-13053 Sharding infrastructure

### DIFF
--- a/src/Raven.Client/ServerWide/DatabaseRecord.cs
+++ b/src/Raven.Client/ServerWide/DatabaseRecord.cs
@@ -48,6 +48,15 @@ namespace Raven.Client.ServerWide
 
         public DatabaseTopology Topology;
 
+        public DatabaseTopology[] Shards;
+
+        public List<ShardRangeAssignment> ShardAllocations = new List<ShardRangeAssignment>();
+        public class ShardRangeAssignment
+        {
+            public int RangeStart;
+            public int Shard;
+        }
+
         // public OnGoingTasks tasks;  tasks for this node..
         // list backup.. list sub .. list etl.. list repl(watchers).. list sql
 
@@ -256,6 +265,28 @@ namespace Raven.Client.ServerWide
                 count += AutoIndexes.Count;
 
             return count;
+        }
+
+        public bool ValidateTopologyNodes()
+        {
+            if (Topology != null && Topology.Count > 0)
+                return true;
+
+            return Shards != null && Shards.All(shard => shard?.Count > 0);
+        }
+
+        public IEnumerable<string> GetTopologyMembers(Func<DatabaseTopology, List<string>> get)
+        {
+            if (Topology != null)
+                return get(Topology);
+
+            var set = new HashSet<string>();
+            foreach (var shard in Shards)
+            {
+                set.UnionWith(get(shard));
+            }
+
+            return set.ToList();
         }
     }
 

--- a/src/Raven.Server/Documents/Handlers/ShardedCommand.cs
+++ b/src/Raven.Server/Documents/Handlers/ShardedCommand.cs
@@ -1,0 +1,70 @@
+﻿using System.Collections.Generic;
+using System.IO;
+using System.Net;
+using System.Net.Http;
+using System.Threading.Tasks;
+using Raven.Client.Http;
+using Sparrow.Json;
+
+namespace Raven.Server.Documents.Handlers
+{
+    public class ShardedCommand : RavenCommand<BlittableJsonReaderObject>
+    {
+        public BlittableJsonReaderObject Content;
+        public Dictionary<string, string> Headers = new Dictionary<string, string>();
+        public string Url;
+        public HttpMethod Method;
+
+        public HttpResponseMessage Response;
+
+        public override bool IsReadRequest => false;
+        public override HttpRequestMessage CreateRequest(JsonOperationContext ctx, ServerNode node, out string url)
+        {
+            url = $"{node.Url}/databases/{node.Database}{Url}";
+            var message = new HttpRequestMessage
+            {
+                Method = Method,
+                Content = Content == null ? null : new BlittableJsonContent(Content),
+            };
+            foreach ((string key, string value) in Headers)
+            {
+                message.Headers.Add(key, value);
+            }
+            return message;
+        }
+
+
+        public override Task<ResponseDisposeHandling> ProcessResponse(JsonOperationContext context, HttpCache cache, HttpResponseMessage response, string url)
+        {
+            Response = response;
+            return base.ProcessResponse(context, cache, response, url);
+        }
+
+        public override void SetResponse(JsonOperationContext context, BlittableJsonReaderObject response, bool fromCache)
+        {
+            Result = response;
+        }
+        internal class BlittableJsonContent : HttpContent
+        {
+            private readonly BlittableJsonReaderObject _data;
+
+            public BlittableJsonContent(BlittableJsonReaderObject data)
+            {
+                _data = data;
+                
+            }
+
+            protected override Task SerializeToStreamAsync(Stream stream, TransportContext context)
+            {
+                _data.WriteJsonTo(stream);
+                return Task.CompletedTask;
+            }
+
+            protected override bool TryComputeLength(out long length)
+            {
+                length = -1;
+                return false;
+            }
+        }
+    }
+}

--- a/src/Raven.Server/Documents/Handlers/ShardedDocumentHandler.cs
+++ b/src/Raven.Server/Documents/Handlers/ShardedDocumentHandler.cs
@@ -1,6 +1,15 @@
-﻿using System.Net;
+﻿using System;
+using System.IO.Compression;
+using System.Linq;
+using System.Net;
+using System.Net.Http;
+using System.Text;
 using System.Threading.Tasks;
+using Raven.Client;
+using Raven.Client.Documents.Commands.Batches;
+using Raven.Server.Extensions;
 using Raven.Server.Routing;
+using Raven.Server.ServerWide.Context;
 
 namespace Raven.Server.Documents.Handlers
 {
@@ -11,8 +20,69 @@ namespace Raven.Server.Documents.Handlers
         {
             var ids = GetStringValuesQueryString("id", required: false);
             var metadataOnly = GetBoolValueQueryString("metadataOnly", required: false) ?? false;
+            var includePaths = GetStringValuesQueryString("include", required: false);
+            var etag = GetStringFromHeaders("If-None-Match");
 
             HttpContext.Response.StatusCode = (int)HttpStatusCode.NotFound;
+
+            using (ContextPool.AllocateOperationContext(out TransactionOperationContext context))
+            {
+
+                var id = ids.Single(); // TODO: make it work with multiple shards
+
+                var shardId = ShardedContext.GetShardId(context, id);
+
+                var index = ShardedContext.GetShardIndex(shardId);
+
+                var cmd = new ShardedCommand
+                {
+                    Method = HttpMethod.Get,
+                    Url = $"/docs?id={Uri.EscapeUriString(id)}",
+                };
+                await ShardedContext.RequestExecutors[index].ExecuteAsync(cmd, context);
+                HttpContext.Response.Headers.Add(Constants.Headers.Etag, cmd.Response.Headers.ETag?.Tag);
+
+                HttpContext.Response.StatusCode = (int)cmd.StatusCode;
+                //TODO: Pass the ETag
+                cmd.Result.WriteJsonTo(ResponseBodyStream());
+            }
+        }
+
+        [RavenShardedAction("/databases/*/docs", "PUT")]
+        public async Task Put()
+        {
+            using (ContextPool.AllocateOperationContext(out TransactionOperationContext context))
+            {
+                var id = GetQueryStringValueAndAssertIfSingleAndNotEmpty("id");
+                var doc = await context.ReadForDiskAsync(RequestBodyStream(), id).ConfigureAwait(false);
+
+                if (id[id.Length - 1] == '|')
+                {
+                    // note that we use the _overall_ database for this, not the specific shards
+                    var (_, clusterId, _) = await ServerStore.GenerateClusterIdentityAsync(id, ShardedContext.DatabaseName, GetRaftRequestIdFromQuery());
+                    id = clusterId;
+                }
+                var changeVector = context.GetLazyString(GetStringFromHeaders("If-Match"));
+
+                var shardId = ShardedContext.GetShardId(context, id);
+
+                var index = ShardedContext.GetShardIndex(shardId);
+
+                var cmd = new ShardedCommand
+                {
+                    Method = HttpMethod.Put,
+                    Url = $"/docs?id={Uri.EscapeUriString(id)}",
+                    Content = doc,
+                    Headers =
+                    {
+                        ["If-Match"] = changeVector
+                    }
+                };
+                await ShardedContext.RequestExecutors[index].ExecuteAsync(cmd, context);
+                HttpContext.Response.StatusCode = (int)cmd.StatusCode;
+                //TODO: Pass the ETag
+                cmd.Result.WriteJsonTo(ResponseBodyStream());
+            }
         }
     }
 }

--- a/src/Raven.Server/Documents/Handlers/ShardedDocumentHandler.cs
+++ b/src/Raven.Server/Documents/Handlers/ShardedDocumentHandler.cs
@@ -1,0 +1,18 @@
+﻿using System.Net;
+using System.Threading.Tasks;
+using Raven.Server.Routing;
+
+namespace Raven.Server.Documents.Handlers
+{
+    public class ShardedDocumentHandler : ShardedRequestHandler
+    {
+        [RavenShardedAction("/databases/*/docs", "GET")]
+        public async Task Get()
+        {
+            var ids = GetStringValuesQueryString("id", required: false);
+            var metadataOnly = GetBoolValueQueryString("metadataOnly", required: false) ?? false;
+
+            HttpContext.Response.StatusCode = (int)HttpStatusCode.NotFound;
+        }
+    }
+}

--- a/src/Raven.Server/Documents/ShardedContext.cs
+++ b/src/Raven.Server/Documents/ShardedContext.cs
@@ -1,0 +1,84 @@
+﻿using System;
+using System.Linq;
+using Raven.Client.Documents.Conventions;
+using Raven.Client.Http;
+using Raven.Client.ServerWide;
+using Raven.Server.ServerWide;
+using Raven.Server.ServerWide.Context;
+using Sparrow;
+
+namespace Raven.Server.Documents
+{
+    public unsafe class ShardedContext
+    {
+        public const int NumberOfShards = 1024 * 1024;
+
+        private readonly DatabaseRecord _record;
+        public RequestExecutor[] RequestExecutors;
+
+        public ShardedContext(ServerStore server, DatabaseRecord record)
+        {
+            _record = record;
+            RequestExecutors = new RequestExecutor[record.Shards.Length];
+            for (int i = 0; i < record.Shards.Length; i++)
+            {
+                var allNodes = server.GetClusterTopology().AllNodes;
+                var urls = record.Shards[i].AllNodes.Select(tag => allNodes[tag]).ToArray();
+                RequestExecutors[i] = RequestExecutor.Create(
+                    urls,
+                    record.DatabaseName + "$" + i,
+                    server.Server.Certificate.Certificate,
+                    new DocumentConventions());
+            }
+        }
+
+        public string DatabaseName => _record.DatabaseName;
+
+        /// <summary>
+        /// The shard id is a hash of the document id, lower case, reduced to
+        /// 20 bits. This gives us 0 .. 1M range of shard ids and means that assuming
+        /// perfect distribution of data, each shard is going to have about 1MB of data
+        /// per TB of overall db size. That means that even for *very* large databases, the
+        /// size of the shard is still going to be manageable.
+        /// </summary>
+        public int GetShardId(TransactionOperationContext context, string key)
+        {
+            using (DocumentIdWorker.GetLowerIdSliceAndStorageKey(context, key, out var lowerId, out _))
+            {
+                byte* buffer = lowerId.Content.Ptr;
+                int size = lowerId.Size;
+
+                AdjustAfterSeparator((byte)'$', ref buffer, ref size);
+
+                if (size == 0)
+                    throw new ArgumentException("Key '" + key + "', has a shard id length of 0");
+
+                var hash = Hashing.XXHash64.Calculate(buffer, (ulong)size);
+                return (int)(hash % NumberOfShards);
+            }
+        }
+
+        private static void AdjustAfterSeparator(byte expected, ref byte* ptr, ref int len)
+        {
+            for (int i = len - 1; i > 0; i--)
+            {
+                if (ptr[i] != expected)
+                    continue;
+                ptr += i + 1;
+                len -= i - 1;
+                break;
+            }
+        }
+
+        public int GetShardIndex(int shardId)
+        {
+            for (int i = 0; i < _record.ShardAllocations.Count-1; i++)
+            {
+                if (shardId < _record.ShardAllocations[i + 1].RangeStart)
+                    return _record.ShardAllocations[i].Shard;
+            }
+
+            return _record.ShardAllocations[_record.ShardAllocations.Count - 1].Shard;
+        }
+    }
+}

--- a/src/Raven.Server/Documents/ShardedRequestHandler.cs
+++ b/src/Raven.Server/Documents/ShardedRequestHandler.cs
@@ -2,46 +2,21 @@
 using Raven.Server.ServerWide.Context;
 using Raven.Server.Web;
 using Sparrow;
+using Sparrow.Json;
 
 namespace Raven.Server.Documents
 {
-    public unsafe class ShardedRequestHandler : RequestHandler
+    public class ShardedRequestHandler : RequestHandler
     {
-        /// <summary>
-        /// The shard id is a hash of the document id, lower case, reduced to
-        /// 20 bits. This gives us 0 .. 1M range of shard ids and means that assuming
-        /// perfect distribution of data, each shard is going to have about 1MB of data
-        /// per TB of overall db size. That means that even for *very* large databases, the
-        /// size of the shard is still going to be manageable.
-        /// </summary>
-        protected int GetShardId(TransactionOperationContext context,string key)
+        public ShardedContext ShardedContext;
+        public TransactionContextPool ContextPool;
+
+        public override void Init(RequestHandlerContext context)
         {
-            using (DocumentIdWorker.GetLowerIdSliceAndStorageKey(context, key, out var lowerId, out _))
-            {
-                byte* buffer = lowerId.Content.Ptr;
-                int size = lowerId.Size;
-
-                AdjustAfterSeparator((byte)'$', ref buffer, ref size);
-
-                if (size == 0)
-                    throw new ArgumentException("Key '" + key + "', has a shard id length of 0");
-
-                var hash = Hashing.XXHash64.Calculate(buffer, (ulong)size);
-                var mixed = Hashing.Mix(hash);
-                return (int)(mixed & 0x0FFF);
-            }
-        }
-
-        private static void AdjustAfterSeparator(byte expected, ref byte* ptr, ref int len)
-        {
-            for (int i = len - 1; i > 0; i--)
-            {
-                if (ptr[i] != expected)
-                    continue;
-                ptr += i + 1;
-                len -= i - 1;
-                break;
-            }
+            base.Init(context);
+            ShardedContext = context.ShardedContext;
+            //TODO: We probably want to put it in the ShardedContext, not use the server one 
+            ContextPool = context.RavenServer.ServerStore.ContextPool;
         }
     }
 }

--- a/src/Raven.Server/Documents/ShardedRequestHandler.cs
+++ b/src/Raven.Server/Documents/ShardedRequestHandler.cs
@@ -1,9 +1,53 @@
-﻿using Raven.Server.Web;
+﻿using System;
+using System.Runtime.InteropServices;
+using Raven.Server.Web;
 
 namespace Raven.Server.Documents
 {
     public class ShardedRequestHandler : RequestHandler
     {
+        protected static ushort GetShardId(string key)
+        {
+            return Crc16.ComputeChecksum(MemoryMarshal.AsBytes(key.AsSpan()));
+        }
 
+        public static class Crc16
+        {
+            const ushort Polynomial = 0xA001;
+            static readonly ushort[] Table = new ushort[256];
+
+            public static ushort ComputeChecksum(ReadOnlySpan<byte> bytes)
+            {
+                ushort crc = 0;
+                for (int i = 0; i < bytes.Length; ++i)
+                {
+                    byte index = (byte)(crc ^ bytes[i]);
+                    crc = (ushort)((crc >> 8) ^ Table[index]);
+                }
+                return crc;
+            }
+
+            static Crc16()
+            {
+                for (ushort i = 0; i < Table.Length; ++i)
+                {
+                    ushort value = 0;
+                    var temp = i;
+                    for (byte j = 0; j < 8; ++j)
+                    {
+                        if (((value ^ temp) & 0x0001) != 0)
+                        {
+                            value = (ushort)((value >> 1) ^ Polynomial);
+                        }
+                        else
+                        {
+                            value >>= 1;
+                        }
+                        temp >>= 1;
+                    }
+                    Table[i] = value;
+                }
+            }
+        }
     }
 }

--- a/src/Raven.Server/Documents/ShardedRequestHandler.cs
+++ b/src/Raven.Server/Documents/ShardedRequestHandler.cs
@@ -1,0 +1,9 @@
+﻿using Raven.Server.Web;
+
+namespace Raven.Server.Documents
+{
+    public class ShardedRequestHandler : RequestHandler
+    {
+
+    }
+}

--- a/src/Raven.Server/Extensions/HttpExtensions.cs
+++ b/src/Raven.Server/Extensions/HttpExtensions.cs
@@ -1,5 +1,9 @@
 ﻿using System;
+using System.Collections.Generic;
+using System.Linq;
+using System.Net.Http;
 using Microsoft.AspNetCore.Http;
+using Raven.Client;
 
 namespace Raven.Server.Extensions
 {

--- a/src/Raven.Server/Routing/RavenActionAttribute.cs
+++ b/src/Raven.Server/Routing/RavenActionAttribute.cs
@@ -35,6 +35,19 @@ namespace Raven.Server.Routing
         }
     }
 
+    public class RavenShardedActionAttribute : Attribute
+    {
+        public string Path { get; }
+
+        public string Method { get; }
+
+        public RavenShardedActionAttribute(string path, string method)
+        {
+            Path = path;
+            Method = method;
+        }
+    }
+
     public enum AuthorizationStatus
     {
         ClusterAdmin,

--- a/src/Raven.Server/Routing/RequestRouter.cs
+++ b/src/Raven.Server/Routing/RequestRouter.cs
@@ -184,7 +184,11 @@ namespace Raven.Server.Routing
             {
                 var currentServerVersion = RavenVersionAttribute.Instance;
 
-                if (currentServerVersion.MajorVersion != clientVersion.Major || currentServerVersion.BuildVersion < clientVersion.Revision || currentServerVersion.BuildVersion == ServerVersion.DevBuildNumber || (clientVersion.Revision >= 40 && clientVersion.Revision < 50))
+                // TODO: Need to review this
+                if (currentServerVersion.MajorVersion != clientVersion.Major ||  
+                    currentServerVersion.BuildVersion < clientVersion.Revision || 
+                    //currentServerVersion.BuildVersion == ServerVersion.DevBuildNumber || 
+                    (clientVersion.Revision >= 40 && clientVersion.Revision < 50)) 
                 {
                     throw new ClientVersionMismatchException(
                         $"Failed to make a request from a newer client with build version {clientVersion} to an older server with build version {RavenVersionAttribute.Instance.AssemblyVersion}.{Environment.NewLine}" +

--- a/src/Raven.Server/Routing/RouteInformation.cs
+++ b/src/Raven.Server/Routing/RouteInformation.cs
@@ -6,6 +6,7 @@ using System.Threading.Tasks;
 using Raven.Client.Exceptions.Cluster;
 using Raven.Client.Exceptions.Database;
 using Raven.Server.Documents;
+using Raven.Server.Extensions;
 using Raven.Server.Web;
 using Sparrow;
 
@@ -25,6 +26,7 @@ namespace Raven.Server.Routing
         public bool DisableOnCpuCreditsExhaustion;
 
         private HandleRequest _request;
+        private HandleRequest _shardedRequest;
         private RouteType _typeOfRoute;
 
         public bool IsDebugInformationEndpoint;
@@ -50,17 +52,26 @@ namespace Raven.Server.Routing
 
         public RouteType TypeOfRoute => _typeOfRoute;
 
+        public void BuildSharded(MethodInfo shardedAction)
+        {
+            _shardedRequest = BuildInternal(shardedAction);
+        }
+
         public void Build(MethodInfo action)
         {
-            if (action.ReturnType != typeof(Task))
-                throw new InvalidOperationException(action.DeclaringType.FullName + "." + action.Name +
-                                                    " must return Task");
-
             if (typeof(DatabaseRequestHandler).IsAssignableFrom(action.DeclaringType))
             {
                 _typeOfRoute = RouteType.Databases;
             }
 
+            _request = BuildInternal(action);
+        }
+
+        private static HandleRequest BuildInternal(MethodInfo action)
+        {
+            if (action.ReturnType != typeof(Task))
+                throw new InvalidOperationException(action.DeclaringType?.FullName + "." + action.Name +
+                                                    " must return Task");
             // CurrentRequestContext currentRequestContext
             var currentRequestContext = Expression.Parameter(typeof(RequestHandlerContext), "currentRequestContext");
             // new Handler(currentRequestContext)
@@ -68,14 +79,15 @@ namespace Raven.Server.Routing
             var newExpression = Expression.New(constructorInfo);
             var handler = Expression.Parameter(action.DeclaringType, "handler");
 
-            var block = Expression.Block(typeof(Task), new[] { handler },
+            var block = Expression.Block(typeof(Task), new[] {handler},
                 Expression.Assign(handler, newExpression),
                 Expression.Call(handler, nameof(RequestHandler.Init), new Type[0], currentRequestContext),
                 Expression.Call(handler, action.Name, new Type[0]));
             // .Handle();
-            _request = Expression.Lambda<HandleRequest>(block, currentRequestContext).Compile();
+            var r = Expression.Lambda<HandleRequest>(block, currentRequestContext).Compile();
+            return r;
         }
-        
+
         public Task CreateDatabase(RequestHandlerContext context)
         {
             var databaseName = context.RouteMatch.GetCapture();
@@ -85,21 +97,28 @@ namespace Raven.Server.Routing
             }
 
             var databasesLandlord = context.RavenServer.ServerStore.DatabasesLandlord;
-            var database = databasesLandlord.TryGetOrCreateResourceStore(databaseName);
-
-            if (database.IsCompletedSuccessfully)
+            var result = databasesLandlord.TryGetOrCreateDatabase(databaseName);
+            switch (result.DatabaseStatus)
             {
-                context.Database = database.Result;
+                case DatabasesLandlord.DatabaseSearchResult.Status.Sharded:
+                    return null;
 
-                if (context.Database == null)
-                    DatabaseDoesNotExistException.Throw(databaseName.Value);
+                default:
+                    var database = result.DatabaseTask;
+                    if (database.IsCompletedSuccessfully)
+                    {
+                        context.Database = database.Result;
 
-                return context.Database?.DatabaseShutdown.IsCancellationRequested == false
-                    ? Task.CompletedTask
-                    : UnlikelyWaitForDatabaseToUnload(context, context.Database, databasesLandlord, databaseName);
+                        if (context.Database == null)
+                            DatabaseDoesNotExistException.Throw(databaseName.Value);
+
+                        return context.Database?.DatabaseShutdown.IsCancellationRequested == false
+                            ? Task.CompletedTask
+                            : UnlikelyWaitForDatabaseToUnload(context, context.Database, databasesLandlord, databaseName);
+                    }
+
+                    return UnlikelyWaitForDatabaseToLoad(context, database, databasesLandlord, databaseName);
             }
-
-            return UnlikelyWaitForDatabaseToLoad(context, database, databasesLandlord, databaseName);
         }
 
         private async Task UnlikelyWaitForDatabaseToUnload(RequestHandlerContext context, DocumentDatabase database,
@@ -156,7 +175,20 @@ namespace Raven.Server.Routing
             {
                 return Tuple.Create<HandleRequest, Task<HandleRequest>>(_request, null);
             }
+
             var database = CreateDatabase(context);
+            if (database == null)
+            {
+#if DEBUG
+                if (_shardedRequest == null)
+                {
+                    throw new InvalidOperationException("Unable to run request " + context.HttpContext.Request.GetFullUrl() +
+                                                        ", the database is sharded, but no shared route is defined for this operation!");
+                }
+#endif
+                return Tuple.Create<HandleRequest, Task<HandleRequest>>(_shardedRequest, null);
+            }
+
             if (database.Status == TaskStatus.RanToCompletion)
             {
                 return Tuple.Create<HandleRequest, Task<HandleRequest>>(_request, null);
@@ -180,5 +212,6 @@ namespace Raven.Server.Routing
         {
             return $"{nameof(Method)}: {Method}, {nameof(Path)}: {Path}, {nameof(AuthorizationStatus)}: {AuthorizationStatus}";
         }
+
     }
 }

--- a/src/Raven.Server/Routing/RouteInformation.cs
+++ b/src/Raven.Server/Routing/RouteInformation.cs
@@ -101,7 +101,10 @@ namespace Raven.Server.Routing
             switch (result.DatabaseStatus)
             {
                 case DatabasesLandlord.DatabaseSearchResult.Status.Sharded:
+                {
+                    context.ShardedContext = result.ShardedContext;
                     return null;
+                }
 
                 default:
                     var database = result.DatabaseTask;

--- a/src/Raven.Server/Routing/RouteScanner.cs
+++ b/src/Raven.Server/Routing/RouteScanner.cs
@@ -40,7 +40,7 @@ namespace Raven.Server.Routing
             var routes = new Dictionary<string, RouteInformation>(StringComparer.OrdinalIgnoreCase);
 
             var corsHandler = typeof(CorsPreflightHandler).GetMethod(nameof(CorsPreflightHandler.HandlePreflightRequest));
-            
+
             var actions = typeof(RouteScanner).GetTypeInfo().Assembly.GetTypes()
                 .SelectMany(type => type.GetMethods(BindingFlags.Instance | BindingFlags.Public | BindingFlags.DeclaredOnly))
                 .Where(type => type.IsDefined(typeof(RavenActionAttribute)))
@@ -57,32 +57,32 @@ namespace Raven.Server.Routing
                     {
                         // register endpoint for preflight request 
                         var optionsRouteKey = "OPTIONS" + route.Path;
-                        
+
                         // we don't check for duplicates here, as single endpoint like: /admin/cluster/node might have 2 verbs (PUT, DELETE),
                         // but we need single OPTIONS handler
-                        
+
                         if (routes.TryGetValue(optionsRouteKey, out RouteInformation optionsRouteInfo) == false)
                         {
                             routes[optionsRouteKey] = optionsRouteInfo = new RouteInformation(
-                                "OPTIONS", 
-                                route.Path, 
-                                route.RequiredAuthorization, 
+                                "OPTIONS",
+                                route.Path,
+                                route.RequiredAuthorization,
                                 route.SkipUsagesCount,
                                 route.CorsMode,
                                 route.IsDebugInformationEndpoint,
                                 route.DisableOnCpuCreditsExhaustion);
-                            
+
                             optionsRouteInfo.Build(corsHandler);
                         }
                     }
-                    
+
                     var routeKey = route.Method + route.Path;
                     if (routes.TryGetValue(routeKey, out RouteInformation routeInfo) == false)
                     {
                         routes[routeKey] = routeInfo = new RouteInformation(
-                            route.Method, 
-                            route.Path, 
-                            route.RequiredAuthorization, 
+                            route.Method,
+                            route.Path,
+                            route.RequiredAuthorization,
                             route.SkipUsagesCount,
                             route.CorsMode,
                             route.IsDebugInformationEndpoint,
@@ -96,9 +96,33 @@ namespace Raven.Server.Routing
                 }
             }
 
+            if (predicate == null)
+            {
+                var shardedActions = typeof(RouteScanner).GetTypeInfo().Assembly.GetTypes()
+                    .SelectMany(type => type.GetMethods(BindingFlags.Instance | BindingFlags.Public | BindingFlags.DeclaredOnly))
+                    .Where(type => type.IsDefined(typeof(RavenShardedActionAttribute)))
+                    .ToList();
+
+                foreach (var shardedAction in shardedActions)
+                {
+                    foreach (var route in shardedAction.GetCustomAttributes<RavenShardedActionAttribute>())
+                    {
+
+                        var routeKey = route.Method + route.Path;
+                        if (routes.TryGetValue(routeKey, out RouteInformation routeInfo) == false)
+                        {
+                            throw new InvalidOperationException(
+                                $"Sharded action {shardedAction.Name} on {shardedAction.DeclaringType} was specified, but there is matching normal action");
+                        }
+
+                        routeInfo.BuildSharded(shardedAction);
+                    }
+                }
+            }
+
             return routes;
         }
-        
+
     }
-    
+
 }

--- a/src/Raven.Server/ServerWide/ClusterStateMachine.cs
+++ b/src/Raven.Server/ServerWide/ClusterStateMachine.cs
@@ -1229,7 +1229,7 @@ namespace Raven.Server.ServerWide
             Exception exception = null;
             try
             {
-                Debug.Assert(addDatabaseCommand.Record.Topology.Count != 0, "Attempt to add database with no nodes");
+                Debug.Assert(addDatabaseCommand.Record.ValidateTopologyNodes(), "Attempt to add database with no nodes");
                 var items = context.Transaction.InnerTransaction.OpenTable(ItemsSchema, Items);
                 using (Slice.From(context.Allocator, "db/" + addDatabaseCommand.Name, out Slice valueName))
                 using (Slice.From(context.Allocator, "db/" + addDatabaseCommand.Name.ToLowerInvariant(), out Slice valueNameLowered))
@@ -1255,7 +1255,16 @@ namespace Raven.Server.ServerWide
                     {
                         UpdateValue(index, items, valueNameLowered, valueName, databaseRecordAsJson);
                         SetDatabaseValues(addDatabaseCommand.DatabaseValues, addDatabaseCommand.Name, context, index, items);
-                        return addDatabaseCommand.Record.Topology.Members;
+                        if(addDatabaseCommand.Record.Topology != null)
+                            return addDatabaseCommand.Record.Topology.Members;
+
+                        var set = new HashSet<string>();
+                        foreach (var shard in addDatabaseCommand.Record.Shards)
+                        {
+                            set.UnionWith(shard.Members);
+                        }
+
+                        return set.ToList();
                     }
 
                     void VerifyUnchangedTasks()
@@ -2483,11 +2492,41 @@ namespace Raven.Server.ServerWide
 
         public RawDatabaseRecord ReadRawDatabaseRecord(TransactionOperationContext context, string name, out long etag)
         {
+            int shardIndex = TryGetShardIndexAndDatabaseName(ref name);
+
             var rawRecord = ReadRawDatabase(context, name, out etag);
+
+            var databaseRecord = BuildShardedDatabaseRecord(context, rawRecord, shardIndex);
+            return new RawDatabaseRecord(context, databaseRecord);
+        }
+
+        private static BlittableJsonReaderObject BuildShardedDatabaseRecord(JsonOperationContext context, BlittableJsonReaderObject rawRecord, int shardIndex)
+        {
             if (rawRecord == null)
                 return null;
 
-            return new RawDatabaseRecord(rawRecord);
+            if (shardIndex != -1)
+            {
+                rawRecord = new RawDatabaseRecord(context, rawRecord)
+                    .GetShardedDatabaseRecord(shardIndex)
+                    .GetRecord();
+            }
+
+            return rawRecord;
+        }
+
+        private static int TryGetShardIndexAndDatabaseName(ref string name)
+        {
+            int shardIndex = name.IndexOf('$');
+            if (shardIndex != -1)
+            {
+                var slice = name.AsSpan().Slice(shardIndex + 1);
+                name = name.Substring(0, shardIndex);
+                if (int.TryParse(slice, out shardIndex) == false)
+                    throw new ArgumentNullException(nameof(name), "Unable to parse sharded database name: " + name);
+            }
+
+            return shardIndex;
         }
 
         public RawDatabaseRecord ReadRawDatabaseRecord(TransactionOperationContext context, string name)
@@ -2497,6 +2536,8 @@ namespace Raven.Server.ServerWide
 
         public bool DatabaseExists(TransactionOperationContext context, string name)
         {
+            TryGetShardIndexAndDatabaseName(ref name);
+
             var dbKey = "db/" + name.ToLowerInvariant();
             var items = context.Transaction.InnerTransaction.OpenTable(ItemsSchema, Items);
 
@@ -2510,22 +2551,25 @@ namespace Raven.Server.ServerWide
             var doc = ReadRawDatabase(context, name, out etag);
             if (doc == null)
                 return null;
-
             return JsonDeserializationCluster.DatabaseRecord(doc);
         }
 
         public BlittableJsonReaderObject ReadRawDatabase<T>(TransactionOperationContext<T> context, string name, out long etag)
             where T : RavenTransaction
         {
-            return Read(context, "db/" + name.ToLowerInvariant(), out etag);
+            int shardIndex = TryGetShardIndexAndDatabaseName(ref name);
+            var result = Read(context, "db/" + name.ToLowerInvariant(), out etag);
+            return BuildShardedDatabaseRecord(context, result, shardIndex);
         }
 
         public DatabaseTopology ReadDatabaseTopology(TransactionOperationContext context, string name)
         {
             using (var rawDatabaseRecord = ReadRawDatabase(context, name, out _))
             {
-                if (rawDatabaseRecord.TryGet(nameof(DatabaseRecord.Topology), out BlittableJsonReaderObject topology) == false)
+                if (rawDatabaseRecord.TryGet(nameof(DatabaseRecord.Topology), out BlittableJsonReaderObject topology) == false 
+                    || topology == null)
                     throw new InvalidOperationException($"The database record '{name}' doesn't contain topology.");
+
                 return JsonDeserializationCluster.DatabaseTopology(topology);
             }
         }

--- a/src/Raven.Server/ServerWide/Commands/DeleteDatabaseCommand.cs
+++ b/src/Raven.Server/ServerWide/Commands/DeleteDatabaseCommand.cs
@@ -60,9 +60,10 @@ namespace Raven.Server.ServerWide.Commands
             }
             else
             {
-                var allNodes = record.Topology.Members.Select(m => m)
-                    .Concat(record.Topology.Promotables.Select(p => p))
-                    .Concat(record.Topology.Rehabs.Select(r => r));
+                var allNodes = record.GetTopologyMembers(x=>x.Members)
+                    .Concat(record.GetTopologyMembers(x => x.Promotables))
+                    .Concat(record.GetTopologyMembers(x => x.Rehabs))
+                    .Distinct();
 
                 foreach (var node in allNodes)
                 {
@@ -72,7 +73,7 @@ namespace Raven.Server.ServerWide.Commands
 
                 record.Topology = new DatabaseTopology
                 {
-                    Stamp = record.Topology.Stamp,
+                    Stamp = record.Topology?.Stamp,
                     ReplicationFactor = 0
                 };
 

--- a/src/Raven.Server/ServerWide/Commands/RemoveNodeFromDatabaseCommand.cs
+++ b/src/Raven.Server/ServerWide/Commands/RemoveNodeFromDatabaseCommand.cs
@@ -34,6 +34,22 @@ namespace Raven.Server.ServerWide.Commands
             return null;
         }
 
+        public string UpdateShardedDatabaseRecord(DatabaseRecord record, int shardIndex, long etag)
+        {
+            record.Shards[shardIndex].RemoveFromTopology(NodeTag);
+            record.DeletionInProgress?.Remove($"{NodeTag}${shardIndex}");
+
+            if (DatabaseId == null)
+                return null;
+
+            if (record.UnusedDatabaseIds == null)
+                record.UnusedDatabaseIds = new HashSet<string>();
+
+            record.UnusedDatabaseIds.Add(DatabaseId);
+
+            return null;
+        }
+
         public override void FillJson(DynamicJsonValue json)
         {
             json[nameof(NodeTag)] = NodeTag;

--- a/src/Raven.Server/ServerWide/Maintenance/ClusterObserver.cs
+++ b/src/Raven.Server/ServerWide/Maintenance/ClusterObserver.cs
@@ -197,6 +197,13 @@ namespace Raven.Server.ServerWide.Maintenance
                                 continue;
                             }
 
+                            if (rawRecord.IsSharded())
+                            {
+                                if (DateTime.Today < new DateTime(2019, 10, 1))
+                                    continue; //TODO: Need to handle sharding here
+                                throw new InvalidOperationException("Need to handle sharded dbs in ClusterObserver!");
+                            }
+
                             var databaseTopology = rawRecord.GetTopology();
                             var topologyStamp = databaseTopology?.Stamp ?? new LeaderStamp
                             {

--- a/src/Raven.Server/ServerWide/RawDatabaseRecord.cs
+++ b/src/Raven.Server/ServerWide/RawDatabaseRecord.cs
@@ -9,16 +9,20 @@ using Raven.Client.Documents.Operations.Replication;
 using Raven.Client.Documents.Operations.Revisions;
 using Raven.Client.Documents.Queries.Sorting;
 using Raven.Client.ServerWide;
+using Raven.Server.ServerWide.Context;
 using Sparrow.Json;
+using Sparrow.Json.Parsing;
 
 namespace Raven.Server.ServerWide
 {
     public class RawDatabaseRecord : IDisposable
     {
+        private readonly JsonOperationContext _context;
         private readonly BlittableJsonReaderObject _record;
 
-        public RawDatabaseRecord(BlittableJsonReaderObject record)
+        public RawDatabaseRecord(JsonOperationContext context, BlittableJsonReaderObject record)
         {
+            _context = context;
             _record = record;
         }
 
@@ -59,10 +63,58 @@ namespace Raven.Server.ServerWide
 
         public DatabaseTopology GetTopology()
         {
-            if (_record.TryGet(nameof(DatabaseRecord.Topology), out BlittableJsonReaderObject rawTopology) == false)
+            if (_record.TryGet(nameof(DatabaseRecord.Topology), out BlittableJsonReaderObject rawTopology) == false 
+                || rawTopology == null)
                 return null;
 
             return JsonDeserializationCluster.DatabaseTopology(rawTopology);
+        }
+
+        public bool IsSharded()
+        {
+            _record.TryGet(nameof(DatabaseRecord.Shards), out BlittableJsonReaderArray array);
+            return array != null && array.Length > 0;
+        }
+
+        public RawDatabaseRecord GetShardedDatabaseRecord(int index)
+        {
+            _record.TryGet(nameof(DatabaseRecord.Shards), out BlittableJsonReaderArray array);
+            var name = GetDatabaseName();
+            var shardedTopology = (BlittableJsonReaderObject)array[index];
+            var shardName = name + "$" + index;
+            _record.Modifications = new DynamicJsonValue(_record)
+            {
+                [nameof(DatabaseRecord.DatabaseName)] = shardName,
+                [nameof(DatabaseRecord.Topology)] = shardedTopology,
+                [nameof(DatabaseRecord.ShardAllocations)] = null,
+                [nameof(DatabaseRecord.Shards)] = null,
+            };
+
+            return new RawDatabaseRecord(_context, _context.ReadObject(_record, shardName));
+        }
+
+        public IEnumerable<RawDatabaseRecord> GetShardedDatabaseRecords()
+        {
+            if(_record.TryGet(nameof(DatabaseRecord.Shards), out BlittableJsonReaderArray array) == false 
+               || array == null)
+                yield break;
+
+            var name = GetDatabaseName();
+
+            for (var index = 0; index < array.Length; index++)
+            {
+                var shardedTopology = (BlittableJsonReaderObject)array[index];
+                var shardName = name + "$" + index;
+                _record.Modifications = new DynamicJsonValue(_record)
+                {
+                    [nameof(DatabaseRecord.DatabaseName)] = shardName,
+                    [nameof(DatabaseRecord.Topology)] = shardedTopology,
+                    [nameof(DatabaseRecord.ShardAllocations)] = null,
+                    [nameof(DatabaseRecord.Shards)] = null,
+                };
+
+                yield return new RawDatabaseRecord(_context, _context.ReadObject(_record, shardName));
+            }
         }
 
         public DatabaseStateStatus GetDatabaseStateStatus()

--- a/src/Raven.Server/ServerWide/RawDatabaseRecord.cs
+++ b/src/Raven.Server/ServerWide/RawDatabaseRecord.cs
@@ -103,17 +103,20 @@ namespace Raven.Server.ServerWide
 
             for (var index = 0; index < array.Length; index++)
             {
-                var shardedTopology = (BlittableJsonReaderObject)array[index];
-                var shardName = name + "$" + index;
-                _record.Modifications = new DynamicJsonValue(_record)
+                using (var clone = _record.CloneOnTheSameContext())
                 {
-                    [nameof(DatabaseRecord.DatabaseName)] = shardName,
-                    [nameof(DatabaseRecord.Topology)] = shardedTopology,
-                    [nameof(DatabaseRecord.ShardAllocations)] = null,
-                    [nameof(DatabaseRecord.Shards)] = null,
-                };
+                    var shardedTopology = (BlittableJsonReaderObject)array[index];
+                    var shardName = name + "$" + index;
+                    clone.Modifications = new DynamicJsonValue(clone)
+                    {
+                        [nameof(DatabaseRecord.DatabaseName)] = shardName,
+                        [nameof(DatabaseRecord.Topology)] = shardedTopology,
+                        [nameof(DatabaseRecord.ShardAllocations)] = null,
+                        [nameof(DatabaseRecord.Shards)] = null,
+                    };
 
-                yield return new RawDatabaseRecord(_context, _context.ReadObject(_record, shardName));
+                    yield return new RawDatabaseRecord(_context, _context.ReadObject(clone, shardName));
+                }
             }
         }
 

--- a/src/Raven.Server/ServerWide/ServerStore.cs
+++ b/src/Raven.Server/ServerWide/ServerStore.cs
@@ -705,7 +705,7 @@ namespace Raven.Server.ServerWide
                         {
                             addDatabase.Record.ShardAllocations = new List<DatabaseRecord.ShardRangeAssignment>();
                             var start = 0;
-                            var step = ushort.MaxValue / addDatabase.Record.Shards.Length;
+                            var step = (1024*1024) / addDatabase.Record.Shards.Length;
                             for (int i = 0; i < addDatabase.Record.Shards.Length; i++)
                             {
                                 addDatabase.Record.ShardAllocations.Add(new DatabaseRecord.ShardRangeAssignment

--- a/src/Raven.Server/ServerWide/ServerStore.cs
+++ b/src/Raven.Server/ServerWide/ServerStore.cs
@@ -685,11 +685,49 @@ namespace Raven.Server.ServerWide
             switch (cmd)
             {
                 case AddDatabaseCommand addDatabase:
-                    if (addDatabase.Record.Topology.Count == 0)
+                    var clusterTopology = GetClusterTopology(ctx);
+                    if (addDatabase.Record.Topology != null )
                     {
-                        AssignNodesToDatabase(GetClusterTopology(ctx), addDatabase.Record);
+                        if (addDatabase.Record.Topology.Count == 0)
+                        {
+                            AssignNodesToDatabase(clusterTopology,
+                                addDatabase.Record.DatabaseName,
+                                addDatabase.Encrypted,
+                                addDatabase.Record.Topology);
+                        }
+                        Debug.Assert(addDatabase.Record.Topology.Count != 0, "Empty topology after AssignNodesToDatabase");
+
                     }
-                    Debug.Assert(addDatabase.Record.Topology.Count != 0, "Empty topology after AssignNodesToDatabase");
+                    else
+                    {
+                        if (addDatabase.Record.ShardAllocations == null ||
+                            addDatabase.Record.ShardAllocations.Count == 0)
+                        {
+                            addDatabase.Record.ShardAllocations = new List<DatabaseRecord.ShardRangeAssignment>();
+                            var start = 0;
+                            var step = ushort.MaxValue / addDatabase.Record.Shards.Length;
+                            for (int i = 0; i < addDatabase.Record.Shards.Length; i++)
+                            {
+                                addDatabase.Record.ShardAllocations.Add(new DatabaseRecord.ShardRangeAssignment
+                                {
+                                    Shard = i,
+                                    RangeStart = start
+                                });
+                                start += step;
+                            }
+                        }
+                        foreach (var shard in addDatabase.Record.Shards)
+                        {
+                            if(shard.Count == 0)
+                            {
+                                AssignNodesToDatabase(clusterTopology,
+                                    addDatabase.Record.DatabaseName,
+                                    addDatabase.Encrypted,
+                                    shard);
+                            }
+                            Debug.Assert(shard.Count != 0, "Empty shard topology after AssignNodesToDatabase");
+                        }
+                    }
                     break;
             }
         }
@@ -1990,34 +2028,32 @@ namespace Raven.Server.ServerWide
             return ((now - maxLastWork).TotalMinutes > 5) || ((now - database.LastIdleTime).TotalMinutes > 10);
         }
 
-        public void AssignNodesToDatabase(ClusterTopology clusterTopology, DatabaseRecord record)
+        public void AssignNodesToDatabase(ClusterTopology clusterTopology, string name, bool encrypted, DatabaseTopology databaseTopology)
         {
-            var topology = record.Topology;
-
-            Debug.Assert(topology != null);
+            Debug.Assert(databaseTopology != null);
 
             if (clusterTopology.AllNodes.Count == 0)
-                throw new InvalidOperationException($"Database {record.DatabaseName} cannot be created, because the cluster topology is empty (shouldn't happen)!");
+                throw new InvalidOperationException($"Database {name} cannot be created, because the cluster topology is empty (shouldn't happen)!");
 
-            if (record.Topology.ReplicationFactor == 0)
-                throw new InvalidOperationException($"Database {record.DatabaseName} cannot be created with replication factor of 0.");
+            if (databaseTopology.ReplicationFactor == 0)
+                throw new InvalidOperationException($"Database {name} cannot be created with replication factor of 0.");
 
             var clusterNodes = clusterTopology.Members.Keys
                 .Concat(clusterTopology.Watchers.Keys)
                 .ToList();
 
-            if (record.Encrypted)
+            if (encrypted)
             {
                 clusterNodes.RemoveAll(n => AdminDatabasesHandler.NotUsingHttps(clusterTopology.GetUrlFromTag(n)));
-                if (clusterNodes.Count < topology.ReplicationFactor)
+                if (clusterNodes.Count < databaseTopology.ReplicationFactor)
                     throw new InvalidOperationException(
-                        $"Database {record.DatabaseName} is encrypted and requires {topology.ReplicationFactor} node(s) which supports SSL. There are {clusterNodes.Count} such node(s) available in the cluster.");
+                        $"Database {name} is encrypted and requires {databaseTopology.ReplicationFactor} node(s) which supports SSL. There are {clusterNodes.Count} such node(s) available in the cluster.");
             }
 
-            if (clusterNodes.Count < topology.ReplicationFactor)
+            if (clusterNodes.Count < databaseTopology.ReplicationFactor)
             {
                 throw new InvalidOperationException(
-                    $"Database {record.DatabaseName} requires {topology.ReplicationFactor} node(s) but there are {clusterNodes.Count} nodes available in the cluster.");
+                    $"Database {name} requires {databaseTopology.ReplicationFactor} node(s) but there are {clusterNodes.Count} nodes available in the cluster.");
             }
 
 
@@ -2038,20 +2074,20 @@ namespace Raven.Server.ServerWide
             var offset = new Random().Next();
 
             // first we would prefer the connected nodes
-            var factor = topology.ReplicationFactor;
+            var factor = databaseTopology.ReplicationFactor;
             var count = Math.Min(clusterNodes.Count, factor);
             for (var i = 0; i < count; i++)
             {
                 factor--;
                 var selectedNode = clusterNodes[(i + offset) % clusterNodes.Count];
-                topology.Members.Add(selectedNode);
+                databaseTopology.Members.Add(selectedNode);
             }
 
             // only if all the online nodes are occupied, try to place on the disconnected
             for (int i = 0; i < Math.Min(disconnectedNodes.Count, factor); i++)
             {
                 var selectedNode = disconnectedNodes[(i + offset) % disconnectedNodes.Count];
-                topology.Members.Add(selectedNode);
+                databaseTopology.Members.Add(selectedNode);
             }
         }
 
@@ -2062,16 +2098,17 @@ namespace Raven.Server.ServerWide
             if (databaseValues == null)
                 databaseValues = new Dictionary<string, BlittableJsonReaderObject>();
 
-            Debug.Assert(record.Topology != null);
-
-            if (string.IsNullOrEmpty(record.Topology.DatabaseTopologyIdBase64))
-                record.Topology.DatabaseTopologyIdBase64 = Guid.NewGuid().ToBase64Unpadded();
-
-            record.Topology.Stamp = new LeaderStamp
+            if (record.Topology != null)
             {
-                Term = _engine.CurrentTerm,
-                LeadersTicks = _engine.CurrentLeader?.LeaderShipDuration ?? 0
-            };
+                InitializeTopology(record.Topology);
+            }
+            else
+            {
+                foreach (var shardTopology in record.Shards)
+                {
+                    InitializeTopology(shardTopology);
+                }
+            }
 
             var addDatabaseCommand = new AddDatabaseCommand(raftRequestId)
             {
@@ -2083,6 +2120,20 @@ namespace Raven.Server.ServerWide
             };
 
             return SendToLeaderAsync(addDatabaseCommand);
+
+            void InitializeTopology(DatabaseTopology topology)
+            {
+                Debug.Assert(topology != null);
+
+                if (string.IsNullOrEmpty(topology.DatabaseTopologyIdBase64))
+                    topology.DatabaseTopologyIdBase64 = Guid.NewGuid().ToBase64Unpadded();
+
+                topology.Stamp = new LeaderStamp
+                {
+                    Term = _engine.CurrentTerm,
+                    LeadersTicks = _engine.CurrentLeader?.LeaderShipDuration ?? 0
+                };
+            }
         }
 
         public void EnsureNotPassive(string publicServerUrl = null, string nodeTag = "A")

--- a/src/Raven.Server/Web/RequestHandlerContext.cs
+++ b/src/Raven.Server/Web/RequestHandlerContext.cs
@@ -10,5 +10,6 @@ namespace Raven.Server.Web
         public RavenServer RavenServer;
         public RouteMatch RouteMatch;
         public DocumentDatabase Database;
+        public ShardedContext ShardedContext;
     }
 }

--- a/src/Raven.Server/Web/System/AdminDatabasesHandler.cs
+++ b/src/Raven.Server/Web/System/AdminDatabasesHandler.cs
@@ -391,22 +391,17 @@ namespace Raven.Server.Web.System
             var clusterTopology = ServerStore.GetClusterTopology(context);
             ValidateClusterMembers(clusterTopology, databaseRecord);
 
-            if (databaseRecord.Topology?.Members?.Count > 0)
+            if (databaseRecord.Shards?.Length > 0)
             {
-                var topology = databaseRecord.Topology;
-                foreach (var member in topology.Members)
+                for (var i = 0; i < databaseRecord.Shards.Length; i++)
                 {
-                    if (clusterTopology.Contains(member) == false)
-                        throw new ArgumentException($"Failed to add node {member}, because we don't have it in the cluster.");
+                    databaseRecord.Shards[i] =
+                        UpdateDatabaseTopology(databaseRecord.Shards[i], clusterTopology, replicationFactor);
                 }
-                topology.ReplicationFactor = topology.Members.Count;
             }
             else
             {
-                if (databaseRecord.Topology == null)
-                    databaseRecord.Topology = new DatabaseTopology();
-
-                databaseRecord.Topology.ReplicationFactor = Math.Min(replicationFactor, clusterTopology.AllNodes.Count);
+                databaseRecord.Topology = UpdateDatabaseTopology(databaseRecord.Topology, clusterTopology, replicationFactor);
             }
 
 
@@ -425,9 +420,43 @@ namespace Raven.Server.Web.System
             using (ServerStore.ContextPool.AllocateOperationContext(out TransactionOperationContext ctx))
             using (ctx.OpenReadTransaction())
             {
-                var topology = ServerStore.Cluster.ReadDatabaseTopology(ctx, name);
+                DatabaseTopology topology;
+                if (databaseRecord.Shards?.Length > 0)
+                {
+                    topology = new DatabaseTopology
+                    {
+                        Members = nodeUrlsAddedTo,
+                    };
+                }
+                else
+                {
+                    topology = ServerStore.Cluster.ReadDatabaseTopology(ctx, name);
+                }
                 return (newIndex, topology, nodeUrlsAddedTo);
             }
+        }
+
+        private static DatabaseTopology UpdateDatabaseTopology(DatabaseTopology topology, ClusterTopology clusterTopology, int replicationFactor)
+        {
+            if (topology?.Members?.Count > 0)
+            {
+                foreach (var member in topology.Members)
+                {
+                    if (clusterTopology.Contains(member) == false)
+                        throw new ArgumentException($"Failed to add node {member}, because we don't have it in the cluster.");
+                }
+
+                topology.ReplicationFactor = topology.Members.Count;
+            }
+            else
+            {
+                if (topology == null)
+                    topology = new DatabaseTopology();
+
+                topology.ReplicationFactor = Math.Min(replicationFactor, clusterTopology.AllNodes.Count);
+            }
+
+            return topology;
         }
 
         [RavenAction("/admin/databases/reorder", "POST", AuthorizationStatus.Operator)]

--- a/src/Raven.Studio/typescript/common/serverNotificationCenterClient.ts
+++ b/src/Raven.Studio/typescript/common/serverNotificationCenterClient.ts
@@ -1,4 +1,4 @@
-/// <reference path="../../typings/tsd.d.ts" />
+Topl/// <reference path="../../typings/tsd.d.ts" />
 import changeSubscription = require("common/changeSubscription");
 import changesCallback = require("common/changesCallback");
 import endpoints = require("endpoints");

--- a/test/FastTests/Sharding/BasicSharding.cs
+++ b/test/FastTests/Sharding/BasicSharding.cs
@@ -1,0 +1,26 @@
+﻿using Xunit;
+
+namespace FastTests.Sharding
+{
+    public class BasicSharding : ShardedTestBase
+    {
+        public class User
+        {
+
+        }
+
+        [Fact]
+        public void CanCreateShardedDatabase()
+        {
+            using (var store = GetShardedDocumentStore())
+            {
+                WaitForUserToContinueTheTest(store);
+                using (var s = store.OpenSession())
+                {
+                    var u = s.Load<User>("users/1");
+                    Assert.Null(u);
+                }
+            }
+        }
+    }
+}

--- a/test/FastTests/Sharding/ShardedTestBase.cs
+++ b/test/FastTests/Sharding/ShardedTestBase.cs
@@ -1,0 +1,46 @@
+﻿using System.Collections.Generic;
+using System.Runtime.CompilerServices;
+using Raven.Client.Documents;
+using Raven.Client.ServerWide;
+using Raven.Client.ServerWide.Operations;
+
+namespace FastTests.Sharding
+{
+    public abstract class ShardedTestBase : RavenTestBase
+    {
+        protected IDocumentStore GetShardedDocumentStore(Options options = null, [CallerMemberName] string caller = null)
+        {
+            var name = GetDatabaseName(caller);
+            using (var store = new DocumentStore { Urls = new[] { Server.WebUrl } })
+            {
+                store.Initialize();
+                store.Maintenance.Server.Send(new CreateDatabaseOperation(new DatabaseRecord
+                {
+                    DatabaseName = name,
+                    Shards = new[]
+                    {
+                        new DatabaseTopology(),
+                        new DatabaseTopology(),
+                        new DatabaseTopology(),
+                    }
+                }));
+
+            }
+
+            DocumentStore documentStore = new DocumentStore
+            {
+                Urls = new[] { Server.WebUrl },
+                Database = name
+            };
+            documentStore.AfterDispose += (sender, args) =>
+            {
+                using (var store = new DocumentStore { Urls = new[] { Server.WebUrl } })
+                {
+                    store.Initialize();
+                    store.Maintenance.Server.Send(new DeleteDatabasesOperation(name, true));
+                }
+            };
+            return documentStore.Initialize();
+        }
+    }
+}

--- a/test/Tests.Infrastructure/RavenTestBase.cs
+++ b/test/Tests.Infrastructure/RavenTestBase.cs
@@ -628,7 +628,7 @@ namespace FastTests
                 do
                 {
                     Thread.Sleep(500);
-                } while (documentStore.Commands(database).Head("Debug/Done") == null && (debug == false || Debugger.IsAttached));
+                } while (true);
 
                 documentStore.Commands(database).Delete("Debug/Done", null);
             }


### PR DESCRIPTION
This is the very first step toward sharding. 
The idea is that we'll define a `Shards` property in the database record, which will define the nodes shards are located on. 
We'll also have a `ShardAllocations` map that will let us know based on shard id on which shard a document is.

I changed routing so we can create mirrors to database routes that will run the sharding logic.
For example, `PUT /databases/MyDb/docs?id=users/1` will compute the shard key from the document id and forward the call to the right shard.

`MyDb` is the sharded db (which will orchestrate the forwarding to the real nodes / databases). The real databases are `MyDB$0`, `MyDB$1`, etc. Note that `$` is not a valid db name by default, so users can't conflict with these.

Document ids are used to shard the documents. We run `XXHash64` on the output and the mod that with 1048576 (1M). The idea is that assuming perfect distribution, we'll have 1MB in each shard key per TB in the total database.
That make is feasible to move shards between nodes.

You can also control what shard a document will be on:  `users/1` and  `orders/321$users/1` will be on the same shard, for example.

Note that we have a few concepts here:

* Shards - 0 ... 1048576 - we have a lot of them. And they can move between nodes
* Fragments - `MyDB$0, `MyDb$1`, etc. - These are the databases that contain the shards. They are normal databases (although they share the same database record). 
* Database - `MyDb` - the actual sharded database, which is a set of routes that hold the sharding logic.

Of particular interest:

* ShardedContext - which contains the logic of sharding / holds request executors for the relevant nodes.
* Security between the nodes is using full server cert, was authenticated when reached the origin. There is no way to specify different security for the shard routes.
* There is no way to have a sharding route that isn't also an existing database route.
* Clients are *not* aware of sharding (the only client side change is the addition of a few field to the database record).
* `DeletionInProgress` can now contain sharded work, such as `A$0`, which indicate that we want to remove the `MyDb$0` from node `A`.

This PR is mostly about all the infrastructure that is required to actually get us going. We'll need to do quite a bit of work around implementing the routes, the logic, etc.
However, the most important bits are there and should allow us to start implementing this without having to do  a big bang integration.

