### PR TITLE
RDBC-322 in RequestExecutor.FirstTopologyUpdate check for 'initialUrl…

### DIFF
--- a/src/Raven.Client/Http/RequestExecutor.cs
+++ b/src/Raven.Client/Http/RequestExecutor.cs
@@ -580,11 +580,6 @@ namespace Raven.Client.Http
                 }
                 catch (Exception e)
                 {
-                    if (initialUrls.Length == 0)
-                    {
-                        _lastKnownUrls = initialUrls;
-                        throw new InvalidOperationException("Cannot get topology from server: " + url, e);
-                    }
                     list.Add((url, e));
                 }
             }


### PR DESCRIPTION
…s.Length == 0' is redundant