### PR TITLE
RavenDB-13979 Making sure we add type of Where clause to RootTypes if…

### DIFF
--- a/src/Raven.Client/Documents/Linq/RavenQueryProviderProcessor.cs
+++ b/src/Raven.Client/Documents/Linq/RavenQueryProviderProcessor.cs
@@ -1549,7 +1549,8 @@ The recommended method is to use full text search (mark the field as Analyzed an
                 case "Select":
                     {
                         if (expression.Arguments[0].Type.GetTypeInfo().IsGenericType &&
-                                expression.Arguments[0].Type.GetGenericTypeDefinition() == typeof(IQueryable<>) &&
+                            (expression.Arguments[0].Type.GetGenericTypeDefinition() == typeof(IQueryable<>) ||
+                            expression.Arguments[0].Type.GetGenericTypeDefinition() == typeof(IRavenQueryable<>)) &&
                             expression.Arguments[0].Type != expression.Arguments[1].Type)
                         {
                             _documentQuery.AddRootType(expression.Arguments[0].Type.GetGenericArguments()[0]);

--- a/test/SlowTests/Issues/RavenDB_13979.cs
+++ b/test/SlowTests/Issues/RavenDB_13979.cs
@@ -1,0 +1,57 @@
+﻿using System.Linq;
+using FastTests;
+using Raven.Tests.Core.Utils.Entities;
+using Raven.Client.Documents;
+using Raven.Client.Documents.Linq;
+using Xunit;
+
+namespace SlowTests.Issues
+{
+    public class RavenDB_13979 : RavenTestBase
+    {
+        [Fact]
+        public void ShouldTranslateIdPropertyToIdFunctionInQueryWithWhereExactOverload()
+        {
+            using (var store = GetDocumentStore())
+            {
+                using (var session = store.OpenSession())
+                {
+                    session.Store(new Post(), "posts/1");
+
+                    session.SaveChanges();
+
+                    var query = session.Query<Post>()
+                        .Where(x => x.Id == "posts/1", false)
+                        .Select(x => new PostModel
+                        {
+                            Title = x.Title,
+
+                        });
+
+                    Assert.Equal("from Posts where id() = $p0 select Title", query.ToString());
+
+                    var postModels = query.ToList();
+
+                    Assert.Equal(1, postModels.Count);
+
+                    query = session.Query<Post>()
+                        .Where(x => x.Id == "posts/1", true)
+                        .Select(x => new PostModel
+                        {
+                            Title = x.Title,
+
+                        });
+
+                    Assert.Equal("from Posts where exact(id() = $p0) select Title", query.ToString());
+
+                    // Assert.Equal(1, query.ToList().Count); - would fail due to RavenDB-13980
+                }
+            }
+        }
+
+        private class PostModel
+        {
+            public string Title { get; set; }
+        }
+    }
+}


### PR DESCRIPTION
… expression type is IRavenQueryable. The case was the usage of Where overload with 'exact' parameter