### PR TITLE
RavenDB-13077

### DIFF
--- a/src/Raven.Server/ServerWide/Maintenance/ClusterObserver.cs
+++ b/src/Raven.Server/ServerWide/Maintenance/ClusterObserver.cs
@@ -147,7 +147,7 @@ namespace Raven.Server.ServerWide.Maintenance
 
             if (_lastLogs.TryGetValue(message, out var last))
             {
-                if (last + 60 > _iteration) 
+                if (last + 60 > _iteration)
                     // each iteration occur every 500 ms, so we update the log with the _same_ message every 30 sec (60 * 0.5s)
                     return;
             }
@@ -682,7 +682,7 @@ namespace Raven.Server.ServerWide.Maintenance
                         continue;
                     }
 
-                    if (_server.LicenseManager.CanDynamicallyDistributeNodes(out _) == false)
+                    if (_server.LicenseManager.CanDynamicallyDistributeNodes(withNotification: false, out _) == false)
                         continue;
 
                     // replace the bad promotable otherwise we will continue to add more and more nodes.
@@ -736,7 +736,7 @@ namespace Raven.Server.ServerWide.Maintenance
                         if (goodMembers < databaseTopology.ReplicationFactor &&
                             TryFindFitNode(rehab, dbName, databaseTopology, clusterTopology, current, out var node))
                         {
-                            if (_server.LicenseManager.CanDynamicallyDistributeNodes(out _) == false)
+                            if (_server.LicenseManager.CanDynamicallyDistributeNodes(withNotification: false, out _) == false)
                                 continue;
 
                             databaseTopology.Promotables.Add(node);
@@ -865,7 +865,7 @@ namespace Raven.Server.ServerWide.Maintenance
             }
 
             topology.DemotionReasons[member] = reason;
-            topology.PromotablesStatus[member] = nodeStats?.ServerReport.OutOfCpuCredits == true ? 
+            topology.PromotablesStatus[member] = nodeStats?.ServerReport.OutOfCpuCredits == true ?
                 DatabasePromotionStatus.OutOfCpuCredits : DatabasePromotionStatus.NotResponding;
 
             LogMessage($"Node {member} of database '{dbName}': {reason}", info: false, database: dbName);
@@ -960,7 +960,7 @@ namespace Raven.Server.ServerWide.Maintenance
 
             var indexesCatchedUp = CheckIndexProgress(
                 promotablePrevDbStats.LastEtag,
-                promotablePrevDbStats.LastIndexStats, 
+                promotablePrevDbStats.LastIndexStats,
                 promotableDbStats.LastIndexStats,
                 mentorCurrDbStats.LastIndexStats,
                 out var reason);

--- a/src/Raven.Server/Web/System/AdminDatabasesHandler.cs
+++ b/src/Raven.Server/Web/System/AdminDatabasesHandler.cs
@@ -264,7 +264,7 @@ namespace Raven.Server.Web.System
                 }
 
                 if ((databaseRecord.Topology?.DynamicNodesDistribution ?? false) &&
-                    Server.ServerStore.LicenseManager.CanDynamicallyDistributeNodes(out var licenseLimit) == false)
+                    Server.ServerStore.LicenseManager.CanDynamicallyDistributeNodes(withNotification: false, out var licenseLimit) == false)
                 {
                     throw licenseLimit;
                 }
@@ -565,7 +565,7 @@ namespace Raven.Server.Web.System
                 RestoreType restoreType;
                 if (restoreConfiguration.TryGet("Type", out string typeAsString))
                 {
-                    if(RestoreType.TryParse(typeAsString, out restoreType) == false)
+                    if (RestoreType.TryParse(typeAsString, out restoreType) == false)
                         throw new ArgumentException($"{typeAsString} is unknown backup type.");
                 }
                 else
@@ -581,7 +581,7 @@ namespace Raven.Server.Web.System
                 {
                     case RestoreType.Local:
                         var localConfiguration = JsonDeserializationCluster.RestoreBackupConfiguration(restoreConfiguration);
-                        restoreBackupTask  = new RestoreFromLocal(
+                        restoreBackupTask = new RestoreFromLocal(
                             ServerStore,
                             localConfiguration,
                             ServerStore.NodeTag,
@@ -591,12 +591,12 @@ namespace Raven.Server.Web.System
 
                     case RestoreType.S3:
                         var s3Configuration = JsonDeserializationCluster.RestoreS3BackupConfiguration(restoreConfiguration);
-                        restoreBackupTask  = new RestoreFromS3(
+                        restoreBackupTask = new RestoreFromS3(
                             ServerStore,
                             s3Configuration,
                             ServerStore.NodeTag,
                             cancelToken);
-                        databaseName = await ValidateFreeSpace(s3Configuration,  context, restoreBackupTask);
+                        databaseName = await ValidateFreeSpace(s3Configuration, context, restoreBackupTask);
 
                         break;
 
@@ -622,7 +622,7 @@ namespace Raven.Server.Web.System
             RestoreBackupTaskBase restoreBackupTask)
         {
             var extension = Path.GetExtension(restoreBackup.LastFileNameToRestore);
-            if (extension == Constants.Documents.PeriodicBackup.SnapshotExtension || 
+            if (extension == Constants.Documents.PeriodicBackup.SnapshotExtension ||
                 extension == Constants.Documents.PeriodicBackup.EncryptedSnapshotExtension)
             {
                 long backupSizeInBytes;
@@ -671,7 +671,7 @@ namespace Raven.Server.Web.System
                 if (destinationDriveInfo.TotalFreeSpace < desiredFreeSpace)
                     throw new ArgumentException($"No enough free space to restore a backup. Required space {desiredFreeSpace}, available space: {destinationDriveInfo.TotalFreeSpace}");
             }
-            
+
             HttpContext.Response.Headers[Constants.Headers.RefreshTopology] = "true";
             return restoreBackup.DatabaseName;
         }
@@ -831,7 +831,7 @@ namespace Raven.Server.Web.System
                     return;
 
                 if (enable &&
-                    Server.ServerStore.LicenseManager.CanDynamicallyDistributeNodes(out var licenseLimit) == false)
+                    Server.ServerStore.LicenseManager.CanDynamicallyDistributeNodes(withNotification: false, out var licenseLimit) == false)
                 {
                     throw licenseLimit;
                 }
@@ -1152,7 +1152,7 @@ namespace Raven.Server.Web.System
 
             return new Size(database.GetSizeOnDisk().Data.SizeInBytes, SizeUnit.Bytes);
         }
-        
+
         [RavenAction("/admin/databases/unused-ids", "POST", AuthorizationStatus.Operator)]
         public async Task SetUnusedDatabaseIds()
         {
@@ -1361,7 +1361,7 @@ namespace Raven.Server.Web.System
                                 IOExtensions.DeleteFile(tmpFile);
                             else if (process.HasExited == false && string.IsNullOrEmpty(tmpFile) == false)
                             {
-                                if(ProcessExtensions.TryKill(process))
+                                if (ProcessExtensions.TryKill(process))
                                     IOExtensions.DeleteFile(tmpFile);
                                 else
                                 {


### PR DESCRIPTION
- should not be able to activate license without dynamic node distribution when there are databases with dynamic node distribution enabled
- should not create notifications for dynamic node distribution during topology change, we cannot put a database or toggle dynamic node distribution without a valid license that contains that feature