### PR TITLE
RDBS-45: Add UseRssInsteadOfMemUsageInContainer for use together with…

### DIFF
--- a/src/Raven.Server/Config/Categories/MemoryConfiguration.cs
+++ b/src/Raven.Server/Config/Categories/MemoryConfiguration.cs
@@ -39,5 +39,10 @@ namespace Raven.Server.Config.Categories
         [SizeUnit(SizeUnit.Megabytes)]
         [ConfigurationEntry("Memory.MaxFreeCommittedMemoryToKeepInMb", ConfigurationEntryScope.ServerWideOnly)]
         public Size MaxFreeCommittedMemoryToKeepInMb { get; set; }
+
+        [Description("Use 'Rss'instead of 'memory.usage_in_bytes minus Shared Clean Memory' value to determine machine memory usage in docker instance. Default set to true. Applicable only with environment variable RAVEN_IN_DOCKER set to Y. Will use configuration option LowMemoryLimit with RavenDB process Rss value")]
+        [DefaultValue(true)]
+        [ConfigurationEntry("Memory.UseRssInsteadOfMemUsageInContainer", ConfigurationEntryScope.ServerWideOnly)]
+        public bool UseRssInsteadOfMemUsageInContainer { get; set; }
     }
 }

--- a/src/Raven.Server/Config/Categories/MemoryConfiguration.cs
+++ b/src/Raven.Server/Config/Categories/MemoryConfiguration.cs
@@ -12,7 +12,7 @@ namespace Raven.Server.Config.Categories
             var memoryInfo = MemoryInformation.GetMemoryInfo();
 
             LowMemoryLimit = Size.Min(
-                new Size(2, SizeUnit.Gigabytes), 
+                new Size(2, SizeUnit.Gigabytes),
                 memoryInfo.TotalPhysicalMemory / 10);
         }
 
@@ -40,7 +40,7 @@ namespace Raven.Server.Config.Categories
         [ConfigurationEntry("Memory.MaxFreeCommittedMemoryToKeepInMb", ConfigurationEntryScope.ServerWideOnly)]
         public Size MaxFreeCommittedMemoryToKeepInMb { get; set; }
 
-        [Description("Use 'Rss'instead of 'memory.usage_in_bytes minus Shared Clean Memory' value to determine machine memory usage in docker instance. Default set to true. Applicable only with environment variable RAVEN_IN_DOCKER set to Y. Will use configuration option LowMemoryLimit with RavenDB process Rss value")]
+        [Description("EXPERT: Use 'RSS' instead of 'memory.usage_in_bytes minus Shared Clean Memory' value to determine machine memory usage in docker instance. Applicable only with environment variable RAVEN_IN_DOCKER is set to 'true' and only when running on Linux. Will use configuration option 'Memory.LowMemoryLimitInMb' with RavenDB process RSS value. Default: true.")]
         [DefaultValue(true)]
         [ConfigurationEntry("Memory.UseRssInsteadOfMemUsageInContainer", ConfigurationEntryScope.ServerWideOnly)]
         public bool UseRssInsteadOfMemUsageInContainer { get; set; }

--- a/src/Raven.Server/ServerWide/ServerStore.cs
+++ b/src/Raven.Server/ServerWide/ServerStore.cs
@@ -492,7 +492,7 @@ namespace Raven.Server.ServerWide
         {
             Configuration.CheckDirectoryPermissions();
 
-            LowMemoryNotification.Instance.Initialize(Configuration.Memory.LowMemoryLimit, LowMemoryMonitor.Instance, ServerShutdown);
+            LowMemoryNotification.Instance.Initialize(Configuration.Memory.LowMemoryLimit, Configuration.Memory.UseRssInsteadOfMemUsageInContainer, LowMemoryMonitor.Instance, ServerShutdown);
 
             MemoryInformation.SetFreeCommittedMemory(
                 Configuration.Memory.MinimumFreeCommittedMemoryPercentage,

--- a/src/Sparrow.Server/LowMemory/MemoryInformation.cs
+++ b/src/Sparrow.Server/LowMemory/MemoryInformation.cs
@@ -329,7 +329,8 @@ namespace Sparrow.LowMemory
             {
                 // running in a limited cgroup
                 var commitedMemoryInBytes = 0L;
-                var cgroupMemoryUsage = KernelVirtualFileSystemUtils.ReadNumberFromCgroupFile(CgroupMemoryUsage);
+                var cgroupMemoryUsage = (PlatformDetails.RunningOnDocker && LowMemoryNotification.Instance.UseRssInsteadOfMemUsageInContainer) ? // RDBS-45
+                                        GetRssMemoryUsage() : KernelVirtualFileSystemUtils.ReadNumberFromCgroupFile(CgroupMemoryUsage);
                 if (cgroupMemoryUsage != null)
                 {
                     commitedMemoryInBytes = cgroupMemoryUsage.Value;

--- a/src/Sparrow/LowMemory/LowMemoryNotification.cs
+++ b/src/Sparrow/LowMemory/LowMemoryNotification.cs
@@ -116,8 +116,9 @@ namespace Sparrow.LowMemory
         public bool LowMemoryState { get; private set; }
 
         public Size LowMemoryThreshold { get; private set; }
+        public bool UseRssInsteadOfMemUsageInContainer { get; private set; }
 
-        public void Initialize(Size lowMemoryThreshold, AbstractLowMemoryMonitor monitor, CancellationToken shutdownNotification)
+        public void Initialize(Size lowMemoryThreshold, bool useRssInsteadOfMemUsageInContainer, AbstractLowMemoryMonitor monitor, CancellationToken shutdownNotification)
         {
             if (_initialized)
                 return;
@@ -129,6 +130,7 @@ namespace Sparrow.LowMemory
 
                 _initialized = true;
                 LowMemoryThreshold = lowMemoryThreshold;
+                UseRssInsteadOfMemUsageInContainer = useRssInsteadOfMemUsageInContainer;
                 _lowMemoryMonitor = monitor;
 
                 var thread = new Thread(MonitorMemoryUsage)

--- a/src/Sparrow/Platform/PlatformDetails.cs
+++ b/src/Sparrow/Platform/PlatformDetails.cs
@@ -22,7 +22,7 @@ namespace Sparrow.Platform
         public static readonly bool CanPrefetch;
         public static readonly bool CanDiscardMemory;
 
-        public static bool RunningOnDocker => string.Equals(Environment.GetEnvironmentVariable("RAVEN_IN_DOCKER"), "true", StringComparison.OrdinalIgnoreCase);
+        public static readonly bool RunningOnDocker = string.Equals(Environment.GetEnvironmentVariable("RAVEN_IN_DOCKER"), "true", StringComparison.OrdinalIgnoreCase);
 
         static PlatformDetails()
         {

--- a/src/Sparrow/Platform/PlatformDetails.cs
+++ b/src/Sparrow/Platform/PlatformDetails.cs
@@ -22,10 +22,12 @@ namespace Sparrow.Platform
         public static readonly bool CanPrefetch;
         public static readonly bool CanDiscardMemory;
 
-        public static readonly bool RunningOnDocker = string.Equals(Environment.GetEnvironmentVariable("RAVEN_IN_DOCKER"), "true", StringComparison.OrdinalIgnoreCase);
+        public static bool RunningOnDocker;
 
         static PlatformDetails()
         {
+            RunningOnDocker = string.Equals(Environment.GetEnvironmentVariable("RAVEN_IN_DOCKER"), "true", StringComparison.OrdinalIgnoreCase);
+
             if (TryGetWindowsVersion(out var version))
             {
                 IsWindows8OrNewer = version >= 6.19M;

--- a/test/FastTests/Issues/RavenDB_9379.cs
+++ b/test/FastTests/Issues/RavenDB_9379.cs
@@ -1,6 +1,8 @@
 ﻿using System;
+using System.Reflection;
 using Raven.Server.Config;
 using Raven.Server.Utils.Cli;
+using Sparrow.Platform;
 using Xunit;
 
 namespace FastTests.Issues
@@ -61,14 +63,15 @@ namespace FastTests.Issues
             };
 
             var oldEnv = Environment.GetEnvironmentVariables();
-            const string RavenInDocker = "RAVEN_IN_DOCKER";
+            var oldRunningInDocker = PlatformDetails.RunningOnDocker;
             const string RemoveUnsecuredCliArg = "REMOVE_UNSECURED_CLI_ARG_AFTER_RESTART";
 
             string[] updatedArgs;
             try
             {
+                PlatformDetails.RunningOnDocker = true;
+                Assert.True(PlatformDetails.RunningOnDocker, "PlatformDetails.RunningOnDocker");
 
-                Environment.SetEnvironmentVariable(RavenInDocker, "true");
                 Environment.SetEnvironmentVariable(RemoveUnsecuredCliArg, "true");
 
                 var confBeforeRestart = RavenConfiguration.CreateForServer(null);
@@ -80,7 +83,8 @@ namespace FastTests.Issues
             }
             finally
             {
-                Environment.SetEnvironmentVariable(RavenInDocker, oldEnv[RavenInDocker] as string);
+                PlatformDetails.RunningOnDocker = oldRunningInDocker;
+                Assert.Equal(oldRunningInDocker, PlatformDetails.RunningOnDocker);
                 Environment.SetEnvironmentVariable(RemoveUnsecuredCliArg, oldEnv[RemoveUnsecuredCliArg] as string);
             }
 


### PR DESCRIPTION
… RunningOnDocker=Y, to avoid too EOOM on docker instances, assuming RavenDB is the only process in the container