### PR TITLE
RavenDB-14057 If CertificateExec is defined instead of CertificateExe…

### DIFF
--- a/src/Raven.Server/Config/Categories/SecurityConfiguration.cs
+++ b/src/Raven.Server/Config/Categories/SecurityConfiguration.cs
@@ -148,7 +148,8 @@ namespace Raven.Server.Config.Categories
 
         public bool IsCertificateConfigured =>
             string.IsNullOrWhiteSpace(CertificatePath) == false ||
-            string.IsNullOrWhiteSpace(CertificateLoadExec) == false;
+            string.IsNullOrWhiteSpace(CertificateLoadExec) == false ||
+            string.IsNullOrWhiteSpace(CertificateExec) == false;
 
         public bool AuthenticationEnabled => IsCertificateConfigured;
 


### PR DESCRIPTION
…cLoad we throw the wrong error