### PR TITLE
RavenDB-14044 Error in ClusterMaintenanceSupervisor

### DIFF
--- a/src/Raven.Server/ServerWide/Maintenance/ClusterMaintenanceSupervisor.cs
+++ b/src/Raven.Server/ServerWide/Maintenance/ClusterMaintenanceSupervisor.cs
@@ -216,6 +216,7 @@ namespace Raven.Server.ServerWide.Maintenance
                         using (_cts.Token.Register(tcpClient.Dispose))
                         using (_contextPool.AllocateOperationContext(out JsonOperationContext context))
                         using (var timeoutEvent = new TimeoutEvent(receiveFromWorkerTimeout, $"Timeout event for: {_name}", singleShot: false))
+                        using (context.GetManagedBuffer(out var readBuffer))
                         {
                             timeoutEvent.Start(OnTimeout);
                             var unchangedReports = new List<DatabaseStatusReport>();
@@ -228,7 +229,7 @@ namespace Raven.Server.ServerWide.Maintenance
                                 try
                                 {
                                     // even if there is a timeout event, we will keep waiting on the same connection until the TCP timeout occurs.
-                                    rawReport = context.ReadForMemory(stream, _readStatusUpdateDebugString);
+                                    rawReport = context.ParseToMemory(stream, _readStatusUpdateDebugString, BlittableJsonDocumentBuilder.UsageMode.None, readBuffer);
                                     timeoutEvent.Defer(_parent._leaderClusterTag);
                                 }
                                 catch (Exception e)


### PR DESCRIPTION
The root cause to this issue is that the supervisor, that collects status info from other nodes didn't handle properly the case when the there is more than one status report in the network buffer.
In that case, it parsed the first report and abandoned the part of the second report, so in the next iteration the parsing of the second report failed.