### PR TITLE
RavenDB-14059 Upgrading a watcher node from 4.1 to 4.2 shouldn't throw NotSupportedException

### DIFF
--- a/src/Raven.Server/Rachis/RachisConsensus.cs
+++ b/src/Raven.Server/Rachis/RachisConsensus.cs
@@ -1186,7 +1186,7 @@ namespace Raven.Server.Rachis
             if (ServerVersion.IsNightlyOrDev(version))
                 return;
 
-            if (clusterTopology.Members.ContainsKey(Tag) == false)
+            if (clusterTopology.Promotables.ContainsKey(Tag))
             {
                 if (version >= 40_000 && version < 42_000)
                     throw new NotSupportedException($"You cannot add a new node in version {ServerVersion.FullVersion} to a pre 4.2 cluster, " +


### PR DESCRIPTION
This change will allow adding new watcher node to an older cluster.

But to me this is less critical than preventing an upgrade of a watcher node from 4.1 to 4.2 in an existing 4.1 cluster.