### PR TITLE
RavenDB-14086 Fix a race between methods that rely on `LastDatabaseRecordIndex`

### DIFF
--- a/src/Raven.Server/Documents/DatabasesLandlord.cs
+++ b/src/Raven.Server/Documents/DatabasesLandlord.cs
@@ -111,6 +111,7 @@ namespace Raven.Server.Documents
                 switch (changeType)
                 {
                     case ClusterDatabaseChangeType.RecordChanged:
+                    case ClusterDatabaseChangeType.ValueChanged:
                         if (task.IsCompleted)
                         {
                             NotifyDatabaseAboutStateChange(databaseName, task, index);
@@ -130,15 +131,6 @@ namespace Raven.Server.Documents
                                 NotifyPendingClusterTransaction(databaseName, done, index, changeType);
                             }
                         });
-                        break;
-                    case ClusterDatabaseChangeType.ValueChanged:
-                        if (task.IsCompleted)
-                        {
-                            NotifyDatabaseAboutValueChange(databaseName, task, index);
-                            return;
-                        }
-
-                        task.ContinueWith(done => { NotifyDatabaseAboutValueChange(databaseName, done, index); });
                         break;
                     case ClusterDatabaseChangeType.PendingClusterTransactions:
                     case ClusterDatabaseChangeType.ClusterTransactionCompleted:
@@ -405,22 +397,6 @@ namespace Raven.Server.Documents
                 if (_logger.IsInfoEnabled)
                 {
                     _logger.Info($"Failed to update database {changedDatabase} about new state", e);
-                }
-                // nothing to do here
-            }
-        }
-
-        private void NotifyDatabaseAboutValueChange(string changedDatabase, Task<DocumentDatabase> done, long index)
-        {
-            try
-            {
-                done.Result.ValueChanged(index);
-            }
-            catch (Exception e)
-            {
-                if (_logger.IsInfoEnabled)
-                {
-                    _logger.Info($"Failed to update database {changedDatabase} about new value", e);
                 }
                 // nothing to do here
             }

--- a/src/Raven.Server/Documents/DocumentDatabase.cs
+++ b/src/Raven.Server/Documents/DocumentDatabase.cs
@@ -239,12 +239,12 @@ namespace Raven.Server.Documents
 
         public StudioConfiguration StudioConfiguration { get; private set; }
 
-        private long _lastDatabaseRecordIndex;
+        private long _lastRaftIndexForStateChange;
 
-        public long LastDatabaseRecordIndex
+        public long LastRaftIndexForStateChange
         {
-            get => Volatile.Read(ref _lastDatabaseRecordIndex);
-            private set => _lastDatabaseRecordIndex = value; // we write this always under lock
+            get => Volatile.Read(ref _lastRaftIndexForStateChange);
+            private set => _lastRaftIndexForStateChange = value; // we write this always under lock
         }
 
         public bool CanUnload => Interlocked.Read(ref _preventUnloadCounter) == 0;
@@ -319,7 +319,7 @@ namespace Raven.Server.Documents
                 {
                     try
                     {
-                        NotifyFeaturesAboutStateChange(record, index);
+                        NotifyFeaturesAboutStateChange(record, index, ClusterStateMachine.All);
                     }
                     catch
                     {
@@ -1044,35 +1044,6 @@ namespace Raven.Server.Documents
         /// </summary>
         public event Action<DatabaseRecord> DatabaseRecordChanged;
 
-        public void ValueChanged(long index)
-        {
-            try
-            {
-                if (_databaseShutdown.IsCancellationRequested)
-                    ThrowDatabaseShutdown();
-
-                DatabaseRecord record;
-                using (_serverStore.ContextPool.AllocateOperationContext(out TransactionOperationContext context))
-                using (context.OpenReadTransaction())
-                {
-                    record = _serverStore.Cluster.ReadDatabase(context, Name);
-                }
-
-                NotifyFeaturesAboutValueChange(record, index);
-                RachisLogIndexNotifications.NotifyListenersAbout(index, null);
-
-            }
-            catch (Exception e)
-            {
-                RachisLogIndexNotifications.NotifyListenersAbout(index, e);
-
-                if (_databaseShutdown.IsCancellationRequested)
-                    ThrowDatabaseShutdown();
-
-                throw;
-            }
-        }
-
         public void StateChanged(long index)
         {
             try
@@ -1096,6 +1067,7 @@ namespace Raven.Server.Documents
                 StudioConfiguration = record.Studio;
 
                 NotifyFeaturesAboutStateChange(record, index);
+
                 RachisLogIndexNotifications.NotifyListenersAbout(index, null);
             }
             catch (Exception e)
@@ -1116,10 +1088,10 @@ namespace Raven.Server.Documents
                 throw;
             }
         }
-
-        private void NotifyFeaturesAboutStateChange(DatabaseRecord record, long index)
+        
+        private void NotifyFeaturesAboutStateChange(DatabaseRecord record, long index , ClusterStateMachine.DatabaseRecordChange changes = ClusterStateMachine.DatabaseRecordChange.None)
         {
-            if (CanSkip(record.DatabaseName, index))
+            if (CanSkipStateChange(record.DatabaseName, index))
                 return;
 
             var taken = false;
@@ -1128,7 +1100,7 @@ namespace Raven.Server.Documents
                 Monitor.TryEnter(_clusterLocker, TimeSpan.FromSeconds(5), ref taken);
                 try
                 {
-                    if (CanSkip(record.DatabaseName, index))
+                    if (CanSkipStateChange(record.DatabaseName, index))
                         return;
 
                     if (taken == false)
@@ -1140,20 +1112,57 @@ namespace Raven.Server.Documents
                         $"{Name} != {record.DatabaseName}");
 
                     if (_logger.IsInfoEnabled)
-                        _logger.Info($"Starting to process record {index} (current {LastDatabaseRecordIndex}) for {record.DatabaseName}.");
+                        _logger.Info($"Starting to process record {index} (last {LastRaftIndexForStateChange}) for {record.DatabaseName}.");
 
                     try
                     {
                         DatabaseGroupId = record.Topology.DatabaseTopologyIdBase64;
 
+                        if (changes == ClusterStateMachine.DatabaseRecordChange.None && 
+                            ServerStore.Cluster.CommandsHolder.TryGetValue(Name, out var queue))
+                        {
+                            while (queue.TryPeek(out var result) && result.Index <= index)
+                            {
+                                queue.TryDequeue(out _);
+                                changes |= result.Change;
+                            }
+                        }
+
                         SetUnusedDatabaseIds(record);
-                        InitializeFromDatabaseRecord(record);
-                        LastDatabaseRecordIndex = index;
-                        IndexStore.HandleDatabaseRecordChange(record, index);
-                        ReplicationLoader?.HandleDatabaseRecordChange(record);
-                        EtlLoader?.HandleDatabaseRecordChange(record);
+
+                        if (changes.HasFlag(ClusterStateMachine.DatabaseRecordChange.Subscription))
+                        {
+                            SubscriptionStorage?.HandleDatabaseRecordChange(record);
+                        }
+
+                        if (changes.HasFlag(ClusterStateMachine.DatabaseRecordChange.Replication))
+                        {
+                            ReplicationLoader?.HandleDatabaseRecordChange(record);
+                        }
+
+                        if (changes.HasFlag(ClusterStateMachine.DatabaseRecordChange.Backup))
+                        {
+                            PeriodicBackupRunner.UpdateConfigurations(record);
+                        }
+
+                        if (changes.HasFlag(ClusterStateMachine.DatabaseRecordChange.Configuration))
+                        {
+                            InitializeFromDatabaseRecord(record);
+                        }
+
+                        if (changes.HasFlag(ClusterStateMachine.DatabaseRecordChange.ETL))
+                        {
+                            EtlLoader?.HandleDatabaseRecordChange(record);
+                        }
+
+                        if (changes.HasFlag(ClusterStateMachine.DatabaseRecordChange.Index))
+                        {
+                            IndexStore.HandleDatabaseRecordChange(record, index);
+                        }
+
                         OnDatabaseRecordChanged(record);
-                        SubscriptionStorage?.HandleDatabaseRecordChange(record);
+
+                        LastRaftIndexForStateChange = index;
 
                         if (_logger.IsInfoEnabled)
                             _logger.Info($"Finish to process record {index} for {record.DatabaseName}.");
@@ -1190,47 +1199,17 @@ namespace Raven.Server.Documents
             }
         }
 
-        private bool CanSkip(string database, long index)
+        private bool CanSkipStateChange(string database, long index)
         {
-            if (LastDatabaseRecordIndex > index)
+            if (LastRaftIndexForStateChange > index)
             {
-                // index and LastDatabaseRecordIndex could have equal values when we transit from/to passive and want to update the tasks. 
+                // index and LastRaftIndexForStateChange could have equal values when we transit from/to passive and want to update the tasks. 
                 if (_logger.IsInfoEnabled)
-                    _logger.Info($"Skipping record {index} (current {LastDatabaseRecordIndex}) for {database} because it was already precessed.");
+                    _logger.Info($"Skipping record state change in index {index} (current {LastRaftIndexForStateChange}) for {database} because it was already precessed.");
                 return true;
             }
 
             return false;
-        }
-
-        private void NotifyFeaturesAboutValueChange(DatabaseRecord record, long index)
-        {
-            if (CanSkip(record.DatabaseName, index))
-                return;
-
-            var taken = false;
-            while (taken == false)
-            {
-                Monitor.TryEnter(_clusterLocker, TimeSpan.FromSeconds(5), ref taken);
-                try
-                {
-                    if (CanSkip(record.DatabaseName, index))
-                        return;
-
-                    if (taken == false)
-                        continue;
-                
-                    LastDatabaseRecordIndex = index;
-                    DatabaseShutdown.ThrowIfCancellationRequested();
-                    SubscriptionStorage?.HandleDatabaseRecordChange(record);
-                    EtlLoader?.HandleDatabaseValueChanged(record);
-                }
-                finally
-                {
-                    if (taken)
-                        Monitor.Exit(_clusterLocker);
-                }
-            }
         }
 
         public void RefreshFeatures()
@@ -1245,7 +1224,7 @@ namespace Raven.Server.Documents
             {
                 record = _serverStore.Cluster.ReadDatabase(context, Name, out index);
             }
-            NotifyFeaturesAboutStateChange(record, index);
+            NotifyFeaturesAboutStateChange(record, index, ClusterStateMachine.All);
         }
 
         private void InitializeFromDatabaseRecord(DatabaseRecord record)
@@ -1257,7 +1236,6 @@ namespace Raven.Server.Documents
             StudioConfiguration = record.Studio;
             DocumentsStorage.RevisionsStorage.InitializeFromDatabaseRecord(record);
             ExpiredDocumentsCleaner = ExpiredDocumentsCleaner.LoadConfigurations(this, record, ExpiredDocumentsCleaner);
-            PeriodicBackupRunner.UpdateConfigurations(record);
         }
 
         public string WhoseTaskIsIt(

--- a/src/Raven.Server/Documents/ETL/EtlLoader.cs
+++ b/src/Raven.Server/Documents/ETL/EtlLoader.cs
@@ -474,9 +474,14 @@ namespace Raven.Server.Documents.ETL
                     }
                 }
             });
+
+            if (_processes.Length > 0)
+            {
+                Reset(record);
+            }
         }
 
-        public void HandleDatabaseValueChanged(DatabaseRecord record)
+        private void Reset(DatabaseRecord record)
         {
             using (_serverStore.ContextPool.AllocateOperationContext(out TransactionOperationContext context))
             using (context.OpenReadTransaction())

--- a/src/Raven.Server/Rachis/Follower.cs
+++ b/src/Raven.Server/Rachis/Follower.cs
@@ -499,17 +499,16 @@ namespace Raven.Server.Rachis
 
             var timeToWait = (int)(_engine.ElectionTimeout.TotalMilliseconds / 4);
 
-
-                while (task.Wait(timeToWait) == false)
+            while (task.Wait(timeToWait) == false)
+            {
+                using (_engine.ContextPool.AllocateOperationContext(out JsonOperationContext context))
                 {
-                    using (_engine.ContextPool.AllocateOperationContext(out JsonOperationContext context))
-                    {
-                        // this may take a while, so we let the other side know that
-                        // we are still processing, and we reset our own timer while
-                        // this is happening
-                        MaybeNotifyLeaderThatWeAreStillAlive(context, sp);
-                    }
+                    // this may take a while, so we let the other side know that
+                    // we are still processing, and we reset our own timer while
+                    // this is happening
+                    MaybeNotifyLeaderThatWeAreStillAlive(context, sp);
                 }
+            }
 
             if (task.IsFaulted)
             {

--- a/src/Raven.Server/ServerWide/ServerStore.cs
+++ b/src/Raven.Server/ServerWide/ServerStore.cs
@@ -790,6 +790,9 @@ namespace Raven.Server.ServerWide
             {
                 foreach (var db in _engine.StateMachine.GetDatabaseNames(context))
                 {
+                    var queue = Cluster.ChangesHolder.GetOrAdd(db, _ => new ConcurrentQueue<(long Index, ClusterStateMachine.DatabaseRecordChange Change)>());
+                    queue.Enqueue((0, ClusterStateMachine.DatabaseRecordChange.All));
+
                     DatabasesLandlord.ClusterOnDatabaseChanged(this, (db, 0, "Init", DatabasesLandlord.ClusterDatabaseChangeType.RecordChanged));
                 }
 

--- a/test/SlowTests/Cluster/ClusterIndexNotificationsTest.cs
+++ b/test/SlowTests/Cluster/ClusterIndexNotificationsTest.cs
@@ -1,4 +1,5 @@
 ﻿using System;
+using System.Collections.Generic;
 using System.Linq;
 using System.Threading;
 using System.Threading.Tasks;
@@ -9,6 +10,7 @@ using Raven.Client.Exceptions;
 using Raven.Client.ServerWide.Operations;
 using Raven.Server.Utils;
 using SlowTests.Core.Utils.Entities;
+using SlowTests.Issues;
 using Tests.Infrastructure;
 using Xunit;
 
@@ -90,6 +92,22 @@ namespace SlowTests.Cluster
                     cts.Cancel();
                     task.Wait();
                 }
+            }
+        }
+
+        [Fact]
+        public async Task RavenDB_14086()
+        {
+            using (var store = GetDocumentStore())
+            {
+                var indexes = new List<Task>();
+                for (int i = 0; i < 100; i++)
+                {
+                    var index = new Index();
+                    indexes.Add(index.ExecuteAsync(store));
+                }
+               
+                await Task.WhenAll(indexes);
             }
         }
 

--- a/test/SlowTests/Server/Documents/ETL/RavenDB_8866.cs
+++ b/test/SlowTests/Server/Documents/ETL/RavenDB_8866.cs
@@ -1,5 +1,8 @@
 ﻿using System;
+using System.Collections.Generic;
+using System.Threading;
 using Raven.Client.Documents.Operations.ETL;
+using Raven.Client.ServerWide.Operations;
 using Raven.Tests.Core.Utils.Entities;
 using Xunit;
 
@@ -51,6 +54,76 @@ namespace SlowTests.Server.Documents.ETL
                 src.Maintenance.Send(new ResetEtlOperation("myConfiguration", "allUsers"));
 
                 Assert.True(resetDone.Wait(TimeSpan.FromMinutes(1)));
+            }
+        }
+
+        [Fact]
+        public void CanResetEtl2()
+        {
+            using (var src = GetDocumentStore())
+            using (var dest = GetDocumentStore())
+            {
+                using (var session = src.OpenSession())
+                {
+                    session.Store(new User());
+                    session.SaveChanges();
+                }
+
+                var configuration = new RavenEtlConfiguration()
+                {
+                    ConnectionStringName = "test",
+                    Name = "myConfiguration",
+                    Transforms =
+                    {
+                        new Transformation()
+                        {
+                            Name = "allUsers",
+                            Collections = {"Users"}
+                        }
+                    }
+                };
+
+                var mre = new ManualResetEvent(true);
+                var mre2 = new ManualResetEvent(false);
+                var etlDone = WaitForEtl(src, (n, s) =>
+                {
+                    mre.WaitOne();
+                    mre.Reset();
+
+                    mre2.Set();
+
+                    return true;
+                });
+
+                AddEtl(src, configuration, new RavenConnectionString
+                {
+                    Name = "test",
+                    TopologyDiscoveryUrls = dest.Urls,
+                    Database = dest.Database,
+                });
+
+                var set = new HashSet<string>
+                {
+                    "asd"
+                };
+
+                for (int i = 0; i < 10; i++)
+                {
+
+                    Assert.True(etlDone.Wait(TimeSpan.FromMinutes(1)), $"blah at {i}");
+
+                    mre.Set();
+
+                    Assert.True(mre2.WaitOne(TimeSpan.FromMinutes(1)), $"oops at {i}");
+                    mre2.Reset();
+
+                    var t1 = src.Maintenance.SendAsync(new ResetEtlOperation("myConfiguration", "allUsers"));
+
+                    for (int j = 0; j < 100; j++)
+                    {
+                        var t2 = src.Maintenance.Server.SendAsync(new UpdateUnusedDatabasesOperation(src.Database, set));
+                    }
+                }
             }
         }
     }


### PR DESCRIPTION
- Merge `ValueChanged` and `StateChange` to have a single code path, because notifying about raft index must mean that all the preceding indexes were executed as well.
This might not be the case when we notifiy seperatly on value and recrods changes.

- Track the raft commands per database and act accordingly.