### PR TITLE
RavenDB-14102 RavenDB Studio: patch fails parsing when string literal…

### DIFF
--- a/src/Raven.Server/Documents/Queries/Parser/QueryScanner.cs
+++ b/src/Raven.Server/Documents/Queries/Parser/QueryScanner.cs
@@ -343,7 +343,7 @@ namespace Raven.Server.Documents.Queries.Parser
                 else if (_q[i] != quoteChar)
                     continue;
 
-                if (i + 1 < _q.Length && _q[i + 1] == quoteChar)
+                if (i + 1 < _q.Length && (_q[i + 1] == quoteChar || (_q[i] == '\\' && _q[i + 1] == '\\')))
                 {
                     i++; // escape char
                     hasEscape = true;


### PR DESCRIPTION
… ends in backslash