### PR TITLE
RavenDB-14106 Invalid error handling when replication attempts to talk to idle database

### DIFF
--- a/src/Raven.Server/RavenServerStartup.cs
+++ b/src/Raven.Server/RavenServerStartup.cs
@@ -329,7 +329,8 @@ namespace Raven.Server
                 exception is DatabaseConcurrentLoadTimeoutException ||
                 exception is NodeIsPassiveException ||
                 exception is ClientVersionMismatchException ||
-                exception is DatabaseSchemaErrorException)
+                exception is DatabaseSchemaErrorException || 
+                exception is DatabaseIdleException)
             {
                 response.StatusCode = (int)HttpStatusCode.ServiceUnavailable;
                 return;

--- a/test/SlowTests/Server/Replication/ExternalReplicationTests.cs
+++ b/test/SlowTests/Server/Replication/ExternalReplicationTests.cs
@@ -128,6 +128,7 @@ namespace SlowTests.Server.Replication
                 {
                     [RavenConfiguration.GetKey(x => x.Databases.MaxIdleTime)] = "10",
                     [RavenConfiguration.GetKey(x => x.Databases.FrequencyToCheckForIdle)] = "3",
+                    [RavenConfiguration.GetKey(x => x.Replication.RetryMaxTimeout)] = "1",
                     [RavenConfiguration.GetKey(x => x.Core.RunInMemory)] = "false"
 
                 }
@@ -215,6 +216,7 @@ namespace SlowTests.Server.Replication
                 [RavenConfiguration.GetKey(x => x.Cluster.ElectionTimeout)] = "300",
                 [RavenConfiguration.GetKey(x => x.Cluster.StabilizationTime)] = "1",
                 [RavenConfiguration.GetKey(x => x.Databases.MaxIdleTime)] = "10",
+                [RavenConfiguration.GetKey(x => x.Replication.RetryMaxTimeout)] = "1",
                 [RavenConfiguration.GetKey(x => x.Databases.FrequencyToCheckForIdle)] = "3",
                 [RavenConfiguration.GetKey(x => x.Core.RunInMemory)] = "false"
             });


### PR DESCRIPTION
- don't log IdleDatabaseException as error, since it is an expected one when replication try to fetch tcp info.
- fix back-off when we fail to get tcp info