### PR TITLE
RDBS-52 Fixing unhandled case of leaf compression:

### DIFF
--- a/src/Raven.Server/Documents/Indexes/MapReduce/ReduceMapResultsBase.cs
+++ b/src/Raven.Server/Documents/Indexes/MapReduce/ReduceMapResultsBase.cs
@@ -294,7 +294,7 @@ namespace Raven.Server.Documents.Indexes.MapReduce
                         }
 
                         throw new UnexpectedReduceTreePageException(
-                            $"Encountered empty page which isn't a root. Page {leafPage} in '{tree.Name}' tree.");
+                            $"Encountered empty page which isn't a root. Page {leafPage} in '{tree.Name}' tree (tree state: {tree.State})");
                     }
 
                     var parentPage = tree.GetParentPageOf(leafPage);

--- a/src/Voron/Data/Compression/CompressionResult.cs
+++ b/src/Voron/Data/Compression/CompressionResult.cs
@@ -9,5 +9,7 @@ namespace Voron.Data.Compression
         public byte* CompressionOutputPtr;
 
         public CompressedNodesHeader Header;
+
+        public bool InvalidateFromCache;
     }
 }

--- a/src/Voron/Debugging/DebugStuff.cs
+++ b/src/Voron/Debugging/DebugStuff.cs
@@ -320,8 +320,9 @@ namespace Voron.Debugging
         private static unsafe void RenderPage(Tree tree, TreePage page, TextWriter sw, string text, bool open)
         {
             sw.WriteLine(
-               "<ul><li><input type='checkbox' id='page-{0}' {3} /><label for='page-{0}'>{4}: Page {0:#,#;;0} - {1} - {2:#,#;;0} entries</label><ul>",
-               page.PageNumber, page.IsLeaf ? "Leaf" : "Branch", page.NumberOfEntries, open ? "checked" : "", text);
+               "<ul><li><input type='checkbox' id='page-{0}' {3} /><label for='page-{0}'>{4}: Page {0:#,#;;0} - {1} - {2:#,#;;0} entries {5}</label><ul>",
+               page.PageNumber, page.IsLeaf ? "Leaf" : "Branch", page.NumberOfEntries, open ? "checked" : "", text, 
+               page.IsCompressed? $"(Compressed ({page.CompressionHeader->NumberOfCompressedEntries} entries [uncompressed/compressed: {page.CompressionHeader->UncompressedSize}/{page.CompressionHeader->CompressedSize}])" : string.Empty);
 
             for (int i = 0; i < page.NumberOfEntries; i++)
             {

--- a/test/SlowTests/Voron/LeafsCompression/RDBS_52.cs
+++ b/test/SlowTests/Voron/LeafsCompression/RDBS_52.cs
@@ -1,0 +1,59 @@
+﻿using System;
+using System.IO;
+using FastTests.Voron;
+using Voron.Data.BTrees;
+using Voron.Debugging;
+using Voron.Global;
+using Xunit;
+
+namespace SlowTests.Voron.LeafsCompression
+{
+    public class RDBS_52 : StorageTest
+    {
+        [Fact]
+        public unsafe void MustNotCreateEmptyNonCompressedPage()
+        {
+            using (var tx = Env.WriteTransaction())
+            {
+                tx.CreateTree("tree", flags: TreeFlags.LeafsCompressed);
+
+                tx.Commit();
+            }
+
+            using (var tx = Env.WriteTransaction())
+            {
+                var tree = tx.ReadTree("tree");
+
+                Assert.True(tree.State.Flags.HasFlag(TreeFlags.LeafsCompressed));
+                
+                var bytes = new byte[3070];
+
+                const int numberOfItems = 21;
+
+                for (int i = 0; i < numberOfItems; i++)
+                {
+                    tree.Add("items/" + i, new MemoryStream(bytes));
+                }
+
+                for (int i = 0; i < numberOfItems; i++)
+                {
+                    tree.Delete("items/" + i);
+                }
+                
+                tree.Add("newItem", new MemoryStream(new byte[3700]));
+
+                foreach (var pageNumber in tree.AllPages())
+                {
+                    var page = new TreePage(tx.LowLevelTransaction.GetPage(pageNumber).Pointer, Constants.Storage.PageSize);
+
+                    if (page.IsCompressed == false)
+                    {
+                        Assert.NotEqual(0, page.NumberOfEntries);
+                    }
+                }
+
+                Assert.Equal(1, tree.AllPages().Count);
+            }
+        }
+    }
+}


### PR DESCRIPTION
- we can have a  compressed page which is full but after decompression is empty (there is a tombstone for each compressed entry)
- passing such page to the page splitter resulted in creating a leaf page with 0 entries

We'll behave as follow:

- if there is nothing to compress let's return just empty page from TryGetCompressedTempPage
- on attempt to writing such page back to original one just modify it so it will be empty (and no longer compressed)