### PR TITLE
RavenDB-14127 properly notify listeners about database record apply

### DIFF
--- a/src/Raven.Server/Documents/DatabasesLandlord.cs
+++ b/src/Raven.Server/Documents/DatabasesLandlord.cs
@@ -502,7 +502,21 @@ namespace Raven.Server.Documents
                 if (awaiter.IsCompleted == false)
                 {
                     cts.Cancel();
-                    ThrowServerIsBeingDisposed(databaseName);
+                    try
+                    {
+                        ThrowServerIsBeingDisposed(databaseName);
+                    }
+                    finally
+                    {
+                        try
+                        {
+                            awaiter.GetResult()?.Dispose();
+                        }
+                        catch
+                        {
+                            // nothing to do here
+                        }
+                    }
                 }
 
                 return awaiter.GetResult();

--- a/src/Raven.Server/Documents/DatabasesLandlord.cs
+++ b/src/Raven.Server/Documents/DatabasesLandlord.cs
@@ -108,54 +108,28 @@ namespace Raven.Server.Documents
                 if (task.IsCanceled || task.IsFaulted)
                     return;
 
+                var database = task.Result;
+
                 switch (changeType)
                 {
                     case ClusterDatabaseChangeType.RecordChanged:
-                        if (task.IsCompleted)
+                        database.StateChanged(index);
+                        if (type == ClusterStateMachine.SnapshotInstalled)
                         {
-                            NotifyDatabaseAboutStateChange(databaseName, task, index);
-                            if (type == ClusterStateMachine.SnapshotInstalled)
-                            {
-                                NotifyPendingClusterTransaction(databaseName, task, index, changeType);
-                            }
-
-                            return;
+                            database.NotifyOnPendingClusterTransaction(index, changeType);
                         }
-
-                        task.ContinueWith(done =>
-                        {
-                            NotifyDatabaseAboutStateChange(databaseName, done, index);
-                            if (type == ClusterStateMachine.SnapshotInstalled)
-                            {
-                                NotifyPendingClusterTransaction(databaseName, done, index, changeType);
-                            }
-                        });
                         break;
+
                     case ClusterDatabaseChangeType.ValueChanged:
-                        if (task.IsCompleted)
-                        {
-                            NotifyDatabaseAboutValueChange(databaseName, task, index);
-                            return;
-                        }
-
-                        task.ContinueWith(done => { NotifyDatabaseAboutValueChange(databaseName, done, index); });
+                        database.ValueChanged(index);
                         break;
+
                     case ClusterDatabaseChangeType.PendingClusterTransactions:
                     case ClusterDatabaseChangeType.ClusterTransactionCompleted:
-                        if (task.IsCompleted)
-                        {
-                            task.Result.DatabaseGroupId = topology.DatabaseTopologyIdBase64;
-                            NotifyPendingClusterTransaction(databaseName, task, index, changeType);
-                            return;
-                        }
-
-                        task.ContinueWith(done =>
-                        {
-                            done.Result.DatabaseGroupId = topology.DatabaseTopologyIdBase64;
-                            NotifyPendingClusterTransaction(databaseName, done, index, changeType);
-                        });
-
+                        database.DatabaseGroupId = topology.DatabaseTopologyIdBase64;
+                        database.NotifyOnPendingClusterTransaction(index, changeType);
                         break;
+
                     default:
                         ThrowUnknownClusterDatabaseChangeType(changeType);
                         break;
@@ -177,11 +151,12 @@ namespace Raven.Server.Documents
             }
             catch (Exception e)
             {
-                var title = $"Failed to digest change of type '{changeType}' for database '{databaseName}'";
+                var title = $"Failed to digest change of type '{changeType}' for database '{databaseName}' at index {index}";
                 if (_logger.IsInfoEnabled)
                     _logger.Info(title, e);
                 _serverStore.NotificationCenter.Add(AlertRaised.Create(databaseName, title, e.Message, AlertType.DeletionError, NotificationSeverity.Error,
                     details: new ExceptionDetails(e)));
+                throw;
             }
             finally
             {
@@ -197,7 +172,6 @@ namespace Raven.Server.Documents
             switch (type)
             {
                 case nameof(PutServerWideBackupConfigurationCommand):
-                    return true;
                 case nameof(UpdatePeriodicBackupStatusCommand):
                     return true;
                 default:
@@ -265,21 +239,6 @@ namespace Raven.Server.Documents
         private void UnloadDatabaseInternal(string databaseName)
         {
             DatabasesCache.RemoveLockAndReturn(databaseName, CompleteDatabaseUnloading, out _).Dispose();
-        }
-
-        public void NotifyPendingClusterTransaction(string name, Task<DocumentDatabase> task, long index, ClusterDatabaseChangeType changeType)
-        {
-            try
-            {
-                task.Result.NotifyOnPendingClusterTransaction(index, changeType);
-            }
-            catch (Exception e)
-            {
-                if (_logger.IsInfoEnabled)
-                {
-                    _logger.Info($"Failed to notify the database '{name}' about new cluster transactions.", e);
-                }
-            }
         }
 
         public bool ShouldDeleteDatabase(TransactionOperationContext context, string dbName, RawDatabaseRecord rawRecord)
@@ -392,38 +351,6 @@ namespace Raven.Server.Documents
 
                     NotifyLeaderAboutRemoval(dbName, databaseId);
                 }, TaskContinuationOptions.OnlyOnFaulted);
-        }
-
-        private void NotifyDatabaseAboutStateChange(string changedDatabase, Task<DocumentDatabase> done, long index)
-        {
-            try
-            {
-                done.Result.StateChanged(index);
-            }
-            catch (Exception e)
-            {
-                if (_logger.IsInfoEnabled)
-                {
-                    _logger.Info($"Failed to update database {changedDatabase} about new state", e);
-                }
-                // nothing to do here
-            }
-        }
-
-        private void NotifyDatabaseAboutValueChange(string changedDatabase, Task<DocumentDatabase> done, long index)
-        {
-            try
-            {
-                done.Result.ValueChanged(index);
-            }
-            catch (Exception e)
-            {
-                if (_logger.IsInfoEnabled)
-                {
-                    _logger.Info($"Failed to update database {changedDatabase} about new value", e);
-                }
-                // nothing to do here
-            }
         }
 
         public TimeSpan DatabaseLoadTimeout => _serverStore.Configuration.Server.MaxTimeForTaskToWaitForDatabaseToLoad.AsTimeSpan;

--- a/src/Raven.Server/Documents/Handlers/Admin/RachisAdminHandler.cs
+++ b/src/Raven.Server/Documents/Handlers/Admin/RachisAdminHandler.cs
@@ -104,15 +104,7 @@ namespace Raven.Server.Documents.Handlers.Admin
         public async Task WaitForIndex()
         {
             var index = GetLongQueryString("index");
-            try
-            {
-                await ServerStore.Cluster.WaitForIndexNotification(index);
-                HttpContext.Response.StatusCode = (int)HttpStatusCode.OK;
-            }
-            catch
-            {
-                HttpContext.Response.StatusCode = (int)HttpStatusCode.RequestTimeout;
-            }
+            await ServerStore.Cluster.WaitForIndexNotification(index);
         }
 
         [RavenAction("/admin/cluster/observer/suspend", "POST", AuthorizationStatus.Operator, CorsMode = CorsMode.Cluster)]

--- a/src/Raven.Server/Raven.Server.csproj
+++ b/src/Raven.Server/Raven.Server.csproj
@@ -107,6 +107,7 @@
     <PackageReference Include="Microsoft.Win32.Registry" Version="4.6.0" />
     <PackageReference Include="MySql.Data" Version="8.0.17" />
     <PackageReference Include="NCrontab.Advanced" Version="1.3.21" />
+    <PackageReference Include="Nito.AsyncEx" Version="5.0.0" />
     <PackageReference Include="Npgsql" Version="4.1.1" />
     <PackageReference Include="Oracle.ManagedDataAccess.Core" Version="2.19.50" />
     <PackageReference Include="Portable.BouncyCastle" Version="1.8.5" />

--- a/src/Raven.Server/ServerWide/ClusterStateMachine.cs
+++ b/src/Raven.Server/ServerWide/ClusterStateMachine.cs
@@ -210,9 +210,53 @@ namespace Raven.Server.ServerWide
             });
         }
 
-        public event EventHandler<(string DatabaseName, long Index, string Type, DatabasesLandlord.ClusterDatabaseChangeType ChangeType)> DatabaseChanged;
+        public delegate Task DatabaseChangedDelegate(string databaseName, long index, string type, DatabasesLandlord.ClusterDatabaseChangeType changeType);
+        public delegate Task ValueChangedDelegate(long index, string type);
 
-        public event EventHandler<(long Index, string Type)> ValueChanged;
+        private DatabaseChangedDelegate[] _onDatabaseChanged = Array.Empty<DatabaseChangedDelegate>();
+        private ValueChangedDelegate[] _onValueChanged = Array.Empty<ValueChangedDelegate>();
+
+        public event DatabaseChangedDelegate DatabaseChanged
+        {
+            add
+            {
+                _onDatabaseChanged = _onDatabaseChanged.Concat(new[] {value}).ToArray();
+            }
+            remove
+            {
+                _onDatabaseChanged = _onDatabaseChanged.Where(x=> x != value).ToArray();
+            }
+        }
+
+        public event ValueChangedDelegate ValueChanged
+        {
+            add
+            {
+                _onValueChanged = _onValueChanged.Concat(new[] { value }).ToArray();
+            }
+            remove
+            {
+                _onValueChanged = _onValueChanged.Where(x => x != value).ToArray();
+            }
+        }
+
+        private async Task OnDatabaseChanges(string databaseName, long index, string type, DatabasesLandlord.ClusterDatabaseChangeType changeType)
+        {
+            var changes = _onDatabaseChanged;
+            foreach (var act in changes)
+            {
+                await act(databaseName, index, type, changeType);
+            }
+        }
+
+        private async Task OnValueChanges(long index, string type)
+        {
+            var changes = _onValueChanged;
+            foreach (var act in changes)
+            {
+                await act(index, type);
+            }
+        }
 
         private readonly RachisLogIndexNotifications _rachisLogIndexNotifications = new RachisLogIndexNotifications(CancellationToken.None);
 
@@ -465,7 +509,7 @@ namespace Raven.Server.ServerWide
 
             PutSubscriptionCommand updateCommand = null;
             Exception exception = null;
-            var actionsByDatabase = new Dictionary<string, Action>();
+            var actionsByDatabase = new Dictionary<string, List<Func<Task>>>();
             var items = context.Transaction.InnerTransaction.OpenTable(ItemsSchema, Items);
             try
             {
@@ -490,12 +534,17 @@ namespace Raven.Server.ServerWide
 
                     if (actionsByDatabase.ContainsKey(database) == false)
                     {
-                        actionsByDatabase[database] = () =>
-                            DatabaseChanged?.Invoke(this, (database, index, nameof(PutSubscriptionCommand), DatabasesLandlord.ClusterDatabaseChangeType.ValueChanged));
+                        actionsByDatabase[database] = new List<Func<Task>>();
                     }
+
+                    actionsByDatabase[database].Add(() =>
+                        OnDatabaseChanges(database, index, nameof(PutSubscriptionCommand), DatabasesLandlord.ClusterDatabaseChangeType.ValueChanged));
                 }
 
-                ExecuteManyOnDispose(context, index, type, actionsByDatabase.Values.ToList());
+                foreach (var action in actionsByDatabase)
+                {
+                    ExecuteManyOnDispose(context, index, type, action.Value);
+                }
             }
             catch (Exception e)
             {
@@ -925,7 +974,7 @@ namespace Raven.Server.ServerWide
                 var removed = removedCmd.RemovedNode;
                 var items = context.Transaction.InnerTransaction.OpenTable(ItemsSchema, Items);
 
-                var actions = new List<Action>();
+                var tasks = new List<Func<Task>>();
 
                 foreach (var record in ReadAllDatabases(context))
                 {
@@ -939,8 +988,9 @@ namespace Raven.Server.ServerWide
                             if (record.DeletionInProgress.Count == 0 && record.Topology.Count == 0 || deleteNow)
                             {
                                 DeleteDatabaseRecord(context, index, items, lowerKey, record.DatabaseName, serverStore);
-                                actions.Add(() => DatabaseChanged?.Invoke(this,
-                                    (record.DatabaseName, index, nameof(RemoveNodeFromCluster), DatabasesLandlord.ClusterDatabaseChangeType.RecordChanged)));
+                                tasks.Add(()=>OnDatabaseChanges(record.DatabaseName, index, nameof(RemoveNodeFromCluster),
+                                    DatabasesLandlord.ClusterDatabaseChangeType.RecordChanged));
+
                                 continue;
                             }
                         }
@@ -962,11 +1012,10 @@ namespace Raven.Server.ServerWide
                         UpdateValue(index, items, lowerKey, key, updated);
                     }
 
-                    actions.Add(() => DatabaseChanged?.Invoke(this,
-                        (record.DatabaseName, index, nameof(RemoveNodeFromCluster), DatabasesLandlord.ClusterDatabaseChangeType.RecordChanged)));
+                    tasks.Add(()=>OnDatabaseChanges(record.DatabaseName, index, nameof(RemoveNodeFromCluster), DatabasesLandlord.ClusterDatabaseChangeType.RecordChanged));
                 }
 
-                ExecuteManyOnDispose(context, index, nameof(RemoveNodeFromCluster), actions);
+                ExecuteManyOnDispose(context, index, nameof(RemoveNodeFromCluster), tasks);
             }
             catch (Exception e)
             {
@@ -979,12 +1028,12 @@ namespace Raven.Server.ServerWide
             }
         }
 
-        private void ExecuteManyOnDispose(TransactionOperationContext context, long index, string type, List<Action> actions)
+        private void ExecuteManyOnDispose(TransactionOperationContext context, long index, string type, List<Func<Task>> tasks)
         {
             context.Transaction.InnerTransaction.LowLevelTransaction.AfterCommitWhenNewReadTransactionsPrevented += () =>
             {
                 _rachisLogIndexNotifications.AddTask(index);
-                var count = actions.Count;
+                var count = tasks.Count;
 
                 if (count == 0)
                 {
@@ -992,33 +1041,36 @@ namespace Raven.Server.ServerWide
                     return;
                 }
 
-                var exceptionAggregator =
-                    new ExceptionAggregator(_parent.Log, $"the raft index {index} is committed, but an error occured during executing the {type} command.");
-
-                foreach (var action in actions)
+                context.Transaction.InnerTransaction.LowLevelTransaction.OnDispose += tx =>
                 {
-                    TaskExecutor.Execute(_ =>
+                    var exceptionAggregator =
+                        new ExceptionAggregator(_parent.Log, $"the raft index {index} is committed, but an error occured during executing the {type} command.");
+
+                    foreach (var task in tasks)
                     {
-                        exceptionAggregator.Execute(action);
-                        if (Interlocked.Decrement(ref count) == 0)
+                        Task.Run(async () =>
                         {
-                            Exception error = null;
-                            try
+                            await exceptionAggregator.ExecuteAsync(task());
+                            if (Interlocked.Decrement(ref count) == 0)
                             {
-                                exceptionAggregator.ThrowIfNeeded();
+                                Exception error = null;
+                                try
+                                {
+                                    exceptionAggregator.ThrowIfNeeded();
+                                }
+                                catch (Exception e)
+                                {
+                                    error = e;
+                                }
+                                finally
+                                {
+                                    _rachisLogIndexNotifications.NotifyListenersAbout(index, error);
+                                    _rachisLogIndexNotifications.SetTaskCompleted(index, error);
+                                }
                             }
-                            catch (Exception e)
-                            {
-                                error = e;
-                            }
-                            finally
-                            {
-                                _rachisLogIndexNotifications.NotifyListenersAbout(index, error);
-                                _rachisLogIndexNotifications.SetTaskCompleted(index, error);
-                            }
-                        }
-                    }, null);
-                }
+                        });
+                    }
+                };
             };
         }
 
@@ -1686,7 +1738,13 @@ namespace Raven.Server.ServerWide
         {
             context.Transaction.InnerTransaction.LowLevelTransaction.AfterCommitWhenNewReadTransactionsPrevented += () =>
             {
-                ExecuteAsyncTask(index, () => ValueChanged?.Invoke(this, (index, type)));
+                // we do this under the write tx lock before we update the last applied index
+                _rachisLogIndexNotifications.AddTask(index);
+
+                context.Transaction.InnerTransaction.LowLevelTransaction.OnDispose += tx =>
+                {
+                    ExecuteAsyncTask(index, () => OnValueChanges(index, type));
+                };
             };
         }
 
@@ -1694,22 +1752,24 @@ namespace Raven.Server.ServerWide
         {
             context.Transaction.InnerTransaction.LowLevelTransaction.AfterCommitWhenNewReadTransactionsPrevented += () =>
             {
-                ExecuteAsyncTask(index, () => DatabaseChanged?.Invoke(this, (databaseName, index, type, change)));
+                // we do this under the write tx lock before we update the last applied index
+                _rachisLogIndexNotifications.AddTask(index);
+
+                context.Transaction.InnerTransaction.LowLevelTransaction.OnDispose += tx =>
+                {
+                    ExecuteAsyncTask(index, () => OnDatabaseChanges(databaseName, index, type, change));
+                };
             };
         }
 
-        private void ExecuteAsyncTask(long index, Action action)
+        private void ExecuteAsyncTask(long index, Func<Task> task)
         {
-            // we do this under the write tx lock before we update the last applied index
-            _rachisLogIndexNotifications.AddTask(index);
-
-            TaskExecutor.Execute(_ =>
+            Task.Run(async () =>
             {
                 Exception error = null;
-
                 try
                 {
-                    action();
+                    await task();
                 }
                 catch (Exception e)
                 {
@@ -1720,7 +1780,7 @@ namespace Raven.Server.ServerWide
                     _rachisLogIndexNotifications.NotifyListenersAbout(index, error);
                     _rachisLogIndexNotifications.SetTaskCompleted(index, error);
                 }
-            }, null);
+            });
         }
 
         private void UpdateDatabase(TransactionOperationContext context, string type, BlittableJsonReaderObject cmd, long index, Leader leader, ServerStore serverStore)
@@ -2039,7 +2099,7 @@ namespace Raven.Server.ServerWide
             if (toShrink.Count == 0)
                 return;
 
-            var actions = new List<Action>();
+            var tasks = new List<Func<Task>>();
             var type = "ClusterTopologyChanged";
 
             foreach (var record in toShrink)
@@ -2059,11 +2119,10 @@ namespace Raven.Server.ServerWide
                     UpdateValue(index, items, valueNameLowered, valueName, updatedDatabaseBlittable);
                 }
 
-                actions.Add(() => DatabaseChanged?.Invoke(this,
-                    (record.DatabaseName, index, type, DatabasesLandlord.ClusterDatabaseChangeType.RecordChanged)));
+                tasks.Add(() => OnDatabaseChanges(record.DatabaseName, index, type, DatabasesLandlord.ClusterDatabaseChangeType.RecordChanged));
             }
 
-            ExecuteManyOnDispose(context, index, type, actions);
+            ExecuteManyOnDispose(context, index, type, tasks);
         }
 
         public unsafe void PutLocalState(TransactionOperationContext context, string thumbprint, BlittableJsonReaderObject value)
@@ -2991,7 +3050,7 @@ namespace Raven.Server.ServerWide
 
         private void ApplyDatabaseRecordUpdates(List<(string Key, BlittableJsonReaderObject DatabaseRecord, string DatabaseName)> toUpdate, string type, long index, Table items, TransactionOperationContext context)
         {
-            var actions = new List<Action> { () => ValueChanged?.Invoke(this, (index, type)) };
+            var tasks = new List<Func<Task>> { () => OnValueChanges(index, type) };
 
             foreach (var update in toUpdate)
             {
@@ -3001,10 +3060,10 @@ namespace Raven.Server.ServerWide
                     UpdateValue(index, items, valueNameLowered, valueName, update.DatabaseRecord);
                 }
 
-                actions.Add(() => DatabaseChanged?.Invoke(this, (update.DatabaseName, index, type, DatabasesLandlord.ClusterDatabaseChangeType.RecordChanged)));
+                tasks.Add(() => OnDatabaseChanges(update.DatabaseName, index, type, DatabasesLandlord.ClusterDatabaseChangeType.RecordChanged));
             }
 
-            ExecuteManyOnDispose(context, index, type, actions);
+            ExecuteManyOnDispose(context, index, type, tasks);
         }
 
         public const string SnapshotInstalled = "SnapshotInstalled";
@@ -3028,27 +3087,19 @@ namespace Raven.Server.ServerWide
                 token.ThrowIfCancellationRequested();
 
                 // there is potentially a lot of work to be done here so we are responding to the change on a separate task.
-                var onDatabaseChanged = DatabaseChanged;
-                if (onDatabaseChanged != null)
+                foreach (var db in GetDatabaseNames(context))
                 {
-                    var listOfDatabaseName = GetDatabaseNames(context).ToList();
-                    TaskExecutor.Execute(_ =>
+                    var t = Task.Run(async () =>
                     {
-                        foreach (var db in listOfDatabaseName)
-                        {
-                            onDatabaseChanged.Invoke(this, (db, lastIncludedIndex, SnapshotInstalled, DatabasesLandlord.ClusterDatabaseChangeType.RecordChanged));
-                        }
-                    }, null);
+                        await OnDatabaseChanges(db, lastIncludedIndex, SnapshotInstalled, DatabasesLandlord.ClusterDatabaseChangeType.RecordChanged);
+                    }, token);
                 }
 
-                var onValueChanged = ValueChanged;
-                if (onValueChanged != null)
+                var t2 = Task.Run(async () =>
                 {
-                    TaskExecutor.Execute(_ =>
-                    {
-                        onValueChanged.Invoke(this, (lastIncludedIndex, nameof(InstallUpdatedServerCertificateCommand)));
-                    }, null);
-                }
+                    await OnValueChanges(lastIncludedIndex, nameof(InstallUpdatedServerCertificateCommand));
+                }, token);
+               
                 context.Transaction.Commit();
             }
             token.ThrowIfCancellationRequested();
@@ -3160,7 +3211,24 @@ namespace Raven.Server.ServerWide
             var task = tcs.Task;
 
             if (task.IsCompleted)
+            {
+                if (task.IsFaulted)
+                {
+                    try
+                    {
+                        await task; // will throw on error
+                    }
+                    catch (Exception e)
+                    {
+                        ThrowApplyException(index, e);
+                    }
+                }
+
+                if (task.IsCanceled)
+                    ThrowCanceledException(index, LastModifiedIndex);
+
                 return true;
+            }
 
             var result = await Task.WhenAny(task, waitingTask.Value);
 
@@ -3202,6 +3270,11 @@ namespace Raven.Server.ServerWide
             throw new TimeoutException(openingString +
                                        $"Last commit index is: {lastModifiedIndex}. " +
                                        $"Number of errors is: {_numberOfErrors}." + closingString);
+        }
+
+        private void ThrowApplyException(long index, Exception e)
+        {
+            throw new InvalidOperationException($"Index {index} was successfully committed, but the apply failed.", e);
         }
 
         private string PrintLastNotifications()

--- a/src/Raven.Server/ServerWide/Commands/DeleteDatabaseCommand.cs
+++ b/src/Raven.Server/ServerWide/Commands/DeleteDatabaseCommand.cs
@@ -20,7 +20,7 @@ namespace Raven.Server.ServerWide.Commands
 
         public DeleteDatabaseCommand(string databaseName, string uniqueRequestId) : base(databaseName, uniqueRequestId)
         {
-            ErrorOnDatabaseDoesNotExists = true;
+            ErrorOnDatabaseDoesNotExists = false;
         }
 
         public override void Initialize(ServerStore serverStore, TransactionOperationContext context)

--- a/src/Raven.Server/ServerWide/Commands/DeleteDatabaseCommand.cs
+++ b/src/Raven.Server/ServerWide/Commands/DeleteDatabaseCommand.cs
@@ -37,6 +37,7 @@ namespace Raven.Server.ServerWide.Commands
             {
                 record.DeletionInProgress = new Dictionary<string, DeletionInProgressStatus>();
             }
+
             if (FromNodes != null && FromNodes.Length > 0) 
             {
                 foreach (var node in FromNodes)
@@ -75,8 +76,10 @@ namespace Raven.Server.ServerWide.Commands
                     Stamp = record.Topology.Stamp,
                     ReplicationFactor = 0
                 };
-
             }
+
+            record.Topology.Stamp.Index = etag;
+
             return null;
         }
 

--- a/src/Raven.Server/ServerWide/Commands/UpdateDatabaseCommand.cs
+++ b/src/Raven.Server/ServerWide/Commands/UpdateDatabaseCommand.cs
@@ -10,7 +10,7 @@ namespace Raven.Server.ServerWide.Commands
     public abstract class UpdateDatabaseCommand : CommandBase
     {
         public string DatabaseName;
-        public bool ErrorOnDatabaseDoesNotExists;
+        public bool ErrorOnDatabaseDoesNotExists = true;
 
         protected UpdateDatabaseCommand() { }
 

--- a/src/Raven.Server/Utils/ExceptionAggregator.cs
+++ b/src/Raven.Server/Utils/ExceptionAggregator.cs
@@ -1,4 +1,5 @@
 using System;
+using System.Threading.Tasks;
 using Sparrow.Collections;
 using Sparrow.Logging;
 
@@ -26,6 +27,18 @@ namespace Raven.Server.Utils
             try
             {
                 action();
+            }
+            catch (Exception e)
+            {
+                _list.Add(e);
+            }
+        }
+
+        public async Task ExecuteAsync(Task task)
+        {
+            try
+            {
+                await task;
             }
             catch (Exception e)
             {

--- a/src/Raven.Server/Web/System/AdminDatabasesHandler.cs
+++ b/src/Raven.Server/Web/System/AdminDatabasesHandler.cs
@@ -198,7 +198,7 @@ namespace Raven.Server.Web.System
                 {
                     // the node was added successfully, but failed to start 
                     // in this case we don't want the request executor of the client to fail-over (so we wouldn't create an additional node)
-                    throw new InvalidOperationException(e.Message);
+                    throw new InvalidOperationException(e.Message, e);
                 }
 
                 HttpContext.Response.StatusCode = (int)HttpStatusCode.Created;

--- a/test/RachisTests/AddNodeToClusterTests.cs
+++ b/test/RachisTests/AddNodeToClusterTests.cs
@@ -538,7 +538,8 @@ namespace RachisTests
                     Topology = new DatabaseTopology
                     {
                         Members = new List<string> {cluster.Leader.ServerStore.NodeTag,firstFollowerTag},
-                        ReplicationFactor = 2
+                        ReplicationFactor = 2,
+                        Stamp = new LeaderStamp()
                     }
                 },
                 Name = db

--- a/test/SlowTests/Issues/RavenDB_7589.cs
+++ b/test/SlowTests/Issues/RavenDB_7589.cs
@@ -29,15 +29,17 @@ namespace SlowTests.Issues
 
             var mre = new ManualResetEventSlim();
 
-            Server.ServerStore.Cluster.DatabaseChanged += (sender, tuple) =>
+            Server.ServerStore.Cluster.DatabaseChanged += (arg1,arg2,arg3,arg4) =>
             {
-                if (tuple.Type != nameof(RemoveNodeFromDatabaseCommand))
-                    return;
+                if (arg3 != nameof(RemoveNodeFromDatabaseCommand))
+                    return Task.CompletedTask;
 
                 var value = Interlocked.Increment(ref _numberOfDatabasesRemoved);
 
                 if (value == 3)
                     mre.Set();
+
+                return Task.CompletedTask;
             };
 
             var path = NewDataPath(forceCreateDir: true);

--- a/test/Tests.Infrastructure/TestExtensions.cs
+++ b/test/Tests.Infrastructure/TestExtensions.cs
@@ -19,7 +19,7 @@ namespace Tests.Infrastructure
             if (task.IsCompletedSuccessfully)
                 return true;
             if (task.Exception != null)
-                throw task.Exception.GetBaseException();
+                await task;
             throw new Exception($"Should never reach this code path. {task.Status}, timeout: {timeout}");
         }
     }


### PR DESCRIPTION
- Don't use `ContinueWith`, but wait for the the database to be loaded before notifying success.
- Rethrow exceptions, so they will be properly notified.  