### PR TITLE
RavenDB-14244 - Skip writing the last index etag after server restart

### DIFF
--- a/src/Raven.Server/Documents/Indexes/Workers/MapDocuments.cs
+++ b/src/Raven.Server/Documents/Indexes/Workers/MapDocuments.cs
@@ -155,6 +155,12 @@ namespace Raven.Server.Documents.Indexes.Workers
                         moreWorkFound = true;
                     }
 
+                    if (lastMappedEtag == lastEtag)
+                    {
+                        // the last etag hasn't changed
+                        continue;
+                    }
+
                     if (_index.Type.IsMap())
                     {
                         _index.SaveLastState();


### PR DESCRIPTION
https://issues.hibernatingrhinos.com/issue/RavenDB-14244