### PR TITLE
RavenDB-14257 & RavenDB-14186 Cluster observer fixes

### DIFF
--- a/test/RachisTests/SubscriptionFailoverWIthWaitingChains.cs
+++ b/test/RachisTests/SubscriptionFailoverWIthWaitingChains.cs
@@ -301,15 +301,21 @@ namespace RachisTests
         {
             if (node.Disposed)
             {
+
+                var settings = new Dictionary<string, string>
+                {
+                    [RavenConfiguration.GetKey(x => x.Cluster.MoveToRehabGraceTime)] = "1",
+                    [RavenConfiguration.GetKey(x => x.Cluster.StabilizationTime)] = "1",
+                    [RavenConfiguration.GetKey(x => x.Cluster.AddReplicaTimeout)] = "1",
+                    [RavenConfiguration.GetKey(x => x.Core.ServerUrls)] = node.WebUrl
+                };
+
                 var dataDir = node.Configuration.Core.DataDirectory.FullPath.Split('/').Last();
                 node = GetNewServer(new ServerCreationOptions()
                 {
                     DeletePrevious = false,
                     RunInMemory = false,
-                    CustomSettings = new Dictionary<string, string>
-                    {
-                        [RavenConfiguration.GetKey(x => x.Core.ServerUrls)] = node.WebUrl
-                    },
+                    CustomSettings = settings,
                     PartialPath = dataDir
                 });
 


### PR DESCRIPTION
- Fix node replacement is too fast.
- Fix moving node to rehab too fast.