### PR TITLE
RavenDB-14250 Allow to fix database topology

### DIFF
--- a/src/Raven.Client/ServerWide/DatabaseTopology.cs
+++ b/src/Raven.Client/ServerWide/DatabaseTopology.cs
@@ -153,6 +153,40 @@ $"NodeTag of 'InternalReplication' can't be modified after 'GetHashCode' was inv
         public LeaderStamp Stamp;
         public bool DynamicNodesDistribution;
         public int ReplicationFactor = 1;
+        public List<string> PriorityOrder;
+
+        private readonly Random _random = new Random();
+        public int Shuffle(string _, string __)
+        {
+            return _random.Next(-100, 100);
+        }
+
+        public void ReorderMembers()
+        {
+            if (PriorityOrder == null || PriorityOrder.Count == 0)
+            {
+                Members.Sort(Shuffle);
+                return;
+            }
+
+            var members = new List<string>();
+            for (int i = 0; i < PriorityOrder.Count; i++)
+            {
+                var priorityNode = PriorityOrder[i];
+                if (Members.Contains(priorityNode))
+                    members.Add(priorityNode);
+            }
+
+            for (int i = 0; i < Members.Count; i++)
+            {
+                var member = Members[i];
+                if (members.Contains(member) == false)
+                    members.Add(member);
+            }
+
+            Members = members;
+        }
+
 
         public bool RelevantFor(string nodeTag)
         {
@@ -329,7 +363,8 @@ $"NodeTag of 'InternalReplication' can't be modified after 'GetHashCode' was inv
                 [nameof(DemotionReasons)] = DynamicJsonValue.Convert(DemotionReasons),
                 [nameof(DynamicNodesDistribution)] = DynamicNodesDistribution,
                 [nameof(ReplicationFactor)] = ReplicationFactor,
-                [nameof(DatabaseTopologyIdBase64)] = DatabaseTopologyIdBase64
+                [nameof(DatabaseTopologyIdBase64)] = DatabaseTopologyIdBase64,
+                [nameof(PriorityOrder)] = new DynamicJsonArray(PriorityOrder)
             };
         }
 

--- a/src/Raven.Client/ServerWide/DatabaseTopology.cs
+++ b/src/Raven.Client/ServerWide/DatabaseTopology.cs
@@ -140,6 +140,17 @@ $"NodeTag of 'InternalReplication' can't be modified after 'GetHashCode' was inv
         }
     }
 
+    public static class ThreadSafeRandom
+    {
+        [ThreadStatic]
+        private static Random _random;
+
+        public static int Shuffle(string _, string __)
+        {
+            return (_random ??= new Random()).Next(-100, 100);
+        }
+    }
+
     public class DatabaseTopology
     {
         public List<string> Members = new List<string>();
@@ -155,19 +166,12 @@ $"NodeTag of 'InternalReplication' can't be modified after 'GetHashCode' was inv
         public int ReplicationFactor = 1;
         public List<string> PriorityOrder;
 
-        private readonly Random _random = new Random();
-        public int Shuffle(string _, string __)
-        {
-            return _random.Next(-100, 100);
-        }
-
         public void ReorderMembers()
         {
+            Members.Sort(ThreadSafeRandom.Shuffle);
+
             if (PriorityOrder == null || PriorityOrder.Count == 0)
-            {
-                Members.Sort(Shuffle);
                 return;
-            }
 
             var members = new List<string>();
             for (int i = 0; i < PriorityOrder.Count; i++)

--- a/src/Raven.Client/ServerWide/DatabaseTopology.cs
+++ b/src/Raven.Client/ServerWide/DatabaseTopology.cs
@@ -140,12 +140,12 @@ $"NodeTag of 'InternalReplication' can't be modified after 'GetHashCode' was inv
         }
     }
 
-    public static class ThreadSafeRandom
+    internal static class ThreadSafeRandom
     {
         [ThreadStatic]
         private static Random _random;
 
-        public static int Shuffle(string _, string __)
+        internal static int Shuffle(string _, string __)
         {
             return (_random ??= new Random()).Next(-100, 100);
         }
@@ -166,7 +166,7 @@ $"NodeTag of 'InternalReplication' can't be modified after 'GetHashCode' was inv
         public int ReplicationFactor = 1;
         public List<string> PriorityOrder;
 
-        public void ReorderMembers()
+        internal void ReorderMembers()
         {
             Members.Sort(ThreadSafeRandom.Shuffle);
 

--- a/src/Raven.Client/ServerWide/Operations/ReorderDatabaseMembersOperation.cs
+++ b/src/Raven.Client/ServerWide/Operations/ReorderDatabaseMembersOperation.cs
@@ -21,7 +21,11 @@ namespace Raven.Client.ServerWide.Operations
         private readonly string _database;
         private readonly Parameters _parameters;
 
-        public ReorderDatabaseMembersOperation(string database, List<string> order, bool fixedTopology = false)
+        public ReorderDatabaseMembersOperation(string database, List<string> order) : this(database, order, false)
+        {
+        }
+
+        public ReorderDatabaseMembersOperation(string database, List<string> order, bool fixedTopology)
         {
             if (order == null || order.Count == 0)
                 throw new ArgumentException("Order list must contain values");

--- a/src/Raven.Client/ServerWide/Operations/ReorderDatabaseMembersOperation.cs
+++ b/src/Raven.Client/ServerWide/Operations/ReorderDatabaseMembersOperation.cs
@@ -15,12 +15,13 @@ namespace Raven.Client.ServerWide.Operations
         public class Parameters
         {
             public List<string> MembersOrder;
+            public bool Fixed;
         }
 
         private readonly string _database;
         private readonly Parameters _parameters;
 
-        public ReorderDatabaseMembersOperation(string database, List<string> order)
+        public ReorderDatabaseMembersOperation(string database, List<string> order, bool fixedTopology = false)
         {
             if (order == null || order.Count == 0)
                 throw new ArgumentException("Order list must contain values");
@@ -28,7 +29,8 @@ namespace Raven.Client.ServerWide.Operations
             _database = database;
             _parameters = new Parameters
             {
-                MembersOrder = order
+                MembersOrder = order,
+                Fixed = fixedTopology
             };
         }
 

--- a/src/Raven.Server/ServerWide/Maintenance/ClusterObserver.cs
+++ b/src/Raven.Server/ServerWide/Maintenance/ClusterObserver.cs
@@ -715,7 +715,7 @@ namespace Raven.Server.ServerWide.Maintenance
                     databaseTopology.Members.Add(promotable);
                     databaseTopology.PredefinedMentors.Remove(promotable);
                     RemoveOtherNodesIfNeeded(state, ref deletions);
-                    databaseTopology.Members.Sort(Shuffle);
+                    databaseTopology.ReorderMembers();
 
                     return $"Promoting node {promotable} to member";
                 }
@@ -778,7 +778,7 @@ namespace Raven.Server.ServerWide.Maintenance
                             databaseTopology.Members.Add(rehab);
                             databaseTopology.Rehabs.Remove(rehab);
                             RemoveOtherNodesIfNeeded(state, ref deletions);
-                            databaseTopology.Members.Sort(Shuffle);
+                            databaseTopology.ReorderMembers();
 
                             return $"Node {rehab} was recovered from rehabilitation and promoted back to member";
                         }
@@ -1334,13 +1334,6 @@ namespace Raven.Server.ServerWide.Maintenance
             {
                 return RawDatabase.GetSettings();
             }
-        }
-
-        private readonly Random _random = new Random();
-
-        public int Shuffle(string _, string __)
-        {
-            return _random.Next(-100, 100);
         }
     }
 }

--- a/src/Raven.Server/Web/System/AdminDatabasesHandler.cs
+++ b/src/Raven.Server/Web/System/AdminDatabasesHandler.cs
@@ -461,6 +461,8 @@ namespace Raven.Server.Web.System
                 topology.Members = reorderedTopology.Members;
                 topology.Promotables = reorderedTopology.Promotables;
                 topology.Rehabs = reorderedTopology.Rehabs;
+                if (parameters.Fixed)
+                    topology.PriorityOrder = parameters.MembersOrder;
 
                 var reorder = new UpdateTopologyCommand(name, GetRaftRequestIdFromQuery())
                 {


### PR DESCRIPTION
With this change the order of the members is fixed.
Note that as a side-effect moving from member to rehab is disabled.