### PR TITLE
RavenDB-14288 - BeforeConversionToDocument and AfterConversionToDocument are called more than once on SaveChanges

### DIFF
--- a/Raven.Client.Lightweight/Document/BulkInsertOperation.cs
+++ b/Raven.Client.Lightweight/Document/BulkInsertOperation.cs
@@ -101,7 +101,7 @@ namespace Raven.Client.Document
             if (tag != null)
                 metadata.Add(Constants.RavenEntityName, tag);
 
-            var data = entityToJson.ConvertEntityToJson(id, entity, metadata);
+            var data = entityToJson.ConvertEntityToJson(id, entity, metadata, executeListeners: true);
 
             OnBeforeEntityInsert(id, data, metadata);
 

--- a/Raven.Client.Lightweight/Document/EntityToJson.cs
+++ b/Raven.Client.Lightweight/Document/EntityToJson.cs
@@ -31,11 +31,14 @@ namespace Raven.Client.Document
 
         public readonly Dictionary<object, Dictionary<string, JToken>> MissingDictionary = new Dictionary<object, Dictionary<string, JToken>>(ObjectReferenceEqualityComparer<object>.Default);
 
-        public RavenJObject ConvertEntityToJson(string key, object entity, RavenJObject metadata)
+        public RavenJObject ConvertEntityToJson(string key, object entity, RavenJObject metadata, bool executeListeners)
         {
-            foreach (var extendedDocumentConversionListener in Listeners.ConversionListeners)
+            if (executeListeners)
             {
-                extendedDocumentConversionListener.BeforeConversionToDocument(key, entity, metadata);
+                foreach (var extendedDocumentConversionListener in Listeners.ConversionListeners)
+                {
+                    extendedDocumentConversionListener.BeforeConversionToDocument(key, entity, metadata);
+                }
             }
 
             var entityType = entity.GetType();
@@ -49,9 +52,12 @@ namespace Raven.Client.Document
 
             SetClrType(entityType, metadata);
 
-            foreach (var extendedDocumentConversionListener in Listeners.ConversionListeners)
+            if (executeListeners)
             {
-                extendedDocumentConversionListener.AfterConversionToDocument(key, entity, objectAsJson, metadata);
+                foreach (var extendedDocumentConversionListener in Listeners.ConversionListeners)
+                {
+                    extendedDocumentConversionListener.AfterConversionToDocument(key, entity, objectAsJson, metadata);
+                }
             }
 
             return objectAsJson;

--- a/Raven.Client.Lightweight/Document/InMemoryDocumentSessionOperations.cs
+++ b/Raven.Client.Lightweight/Document/InMemoryDocumentSessionOperations.cs
@@ -900,7 +900,7 @@ more responsive application.
                                                     "You cannot change the document key property of a entity loaded into the session");
             }
 
-            var json = EntityToJson.ConvertEntityToJson(documentMetadata.Key, entity, documentMetadata.Metadata);
+            var json = EntityToJson.ConvertEntityToJson(documentMetadata.Key, entity, documentMetadata.Metadata, executeListeners: true);
 
             var etag = (UseOptimisticConcurrency && documentMetadata.ConcurrencyCheckMode != ConcurrencyCheckMode.Disabled) || documentMetadata.ConcurrencyCheckMode == ConcurrencyCheckMode.Forced
                            ? (documentMetadata.ETag ?? Etag.Empty)
@@ -942,7 +942,7 @@ more responsive application.
                 documentMetadata.Key = batchResult.Key;
                 documentMetadata.OriginalMetadata = (RavenJObject)batchResult.Metadata.CloneToken();
                 documentMetadata.Metadata = batchResult.Metadata;
-                documentMetadata.OriginalValue = EntityToJson.ConvertEntityToJson(documentMetadata.Key, entity, documentMetadata.Metadata);
+                documentMetadata.OriginalValue = EntityToJson.ConvertEntityToJson(documentMetadata.Key, entity, documentMetadata.Metadata, executeListeners: false);
 
                 GenerateEntityIdOnTheClient.TrySetIdentity(entity, batchResult.Key);
 
@@ -1210,7 +1210,7 @@ more responsive application.
                 documentMetadata.Metadata.Value<bool>(Constants.RavenReadOnly))
                 return false;
 
-            var newObj = EntityToJson.ConvertEntityToJson(documentMetadata.Key, entity, documentMetadata.Metadata);
+            var newObj = EntityToJson.ConvertEntityToJson(documentMetadata.Key, entity, documentMetadata.Metadata, executeListeners: false);
             var changedData = changes != null ? new List<DocumentsChanges>() : null;
 
             var isObjectEquals = RavenJToken.DeepEquals(newObj, documentMetadata.OriginalValue, changedData);

--- a/Raven.Tests.Issues/Raven.Tests.Issues.csproj
+++ b/Raven.Tests.Issues/Raven.Tests.Issues.csproj
@@ -138,6 +138,7 @@
     <Compile Include="NtpServers.cs" />
     <Compile Include="RavenDB-10635.cs" />
     <Compile Include="RavenDB-10815.cs" />
+    <Compile Include="RavenDB-14288.cs" />
     <Compile Include="RavenDB-10888.cs" />
     <Compile Include="RavenDB-12868.cs" />
     <Compile Include="RavenDB-7972.cs" />

--- a/Raven.Tests.Issues/RavenDB-14288.cs
+++ b/Raven.Tests.Issues/RavenDB-14288.cs
@@ -1,0 +1,59 @@
+﻿using Raven.Client.Listeners;
+using Raven.Json.Linq;
+using Raven.Tests.Common;
+using Raven.Tests.Common.Dto;
+using Xunit;
+
+namespace Raven.Tests.Issues
+{
+    public class RavenDB_14288 : RavenTest
+    {
+        [Fact]
+        public void IDocumentConversionListener_runs_only_once()
+        {
+            using (var store = NewDocumentStore())
+            {
+                var listener = new ConvertionListener();
+                store.RegisterListener(listener);
+
+                using (var session = store.OpenSession())
+                {
+                    var account = new User
+                    {
+                        Name = "Grisha"
+                    };
+
+                    session.Store(account);
+                    session.SaveChanges();
+                }
+
+                Assert.Equal(1, listener.NumberOfCallsToBeforeConversionToDocument);
+                Assert.Equal(1, listener.NumberOfCallsToAfterConversionToDocument);
+            }
+        }
+
+        public class ConvertionListener : IDocumentConversionListener
+        {
+            public int NumberOfCallsToBeforeConversionToDocument;
+            public int NumberOfCallsToAfterConversionToDocument;
+
+            public void BeforeConversionToDocument(string key, object entity, RavenJObject metadata)
+            {
+                NumberOfCallsToBeforeConversionToDocument++;
+            }
+
+            public void AfterConversionToDocument(string key, object entity, RavenJObject document, RavenJObject metadata)
+            {
+                NumberOfCallsToAfterConversionToDocument++;
+            }
+
+            public void BeforeConversionToEntity(string key, RavenJObject document, RavenJObject metadata)
+            {
+            }
+
+            public void AfterConversionToEntity(string key, RavenJObject document, RavenJObject metadata, object entity)
+            {
+            }
+        }
+    }
+}

--- a/Raven.Tests/Bugs/Metadata/MetadataPropertyInEntity.cs
+++ b/Raven.Tests/Bugs/Metadata/MetadataPropertyInEntity.cs
@@ -28,7 +28,9 @@ namespace Raven.Tests.Bugs.Metadata
         {
             using(var store = NewDocumentStore())
             {
-                using(var session = store.OpenSession())
+                store.RegisterListener(new MetadataToPropertyConvertionListener());
+
+                using (var session = store.OpenSession())
                 {
                     var account = new Account
                     {
@@ -39,7 +41,7 @@ namespace Raven.Tests.Bugs.Metadata
                     session.SaveChanges();
                 }
 
-                store.RegisterListener(new MetadataToPropertyConvertionListener());
+                
 
                 using (var session = store.OpenSession())
                 {


### PR DESCRIPTION
https://issues.hibernatingrhinos.com/issue/RavenDB-14288