### PR TITLE
RavenDB-14287 Increasing a timeout of  Databases.ConcurrentLoadTimeou…

### DIFF
--- a/src/Raven.Server/Config/Categories/DatabaseConfiguration.cs
+++ b/src/Raven.Server/Config/Categories/DatabaseConfiguration.cs
@@ -48,7 +48,7 @@ namespace Raven.Server.Config.Categories
         /// different databases get loaded at the same time
         /// </summary>
         [Description("The time in seconds to wait for a database to start loading when under load")]
-        [DefaultValue(10)]
+        [DefaultValue(60)]
         [TimeUnit(TimeUnit.Seconds)]
         [ConfigurationEntry("Databases.ConcurrentLoadTimeoutInSec", ConfigurationEntryScope.ServerWideOnly)]
         public TimeSetting ConcurrentLoadTimeout { get; set; }

--- a/src/Raven.Server/NotificationCenter/Notifications/AlertType.cs
+++ b/src/Raven.Server/NotificationCenter/Notifications/AlertType.cs
@@ -64,6 +64,8 @@ namespace Raven.Server.NotificationCenter.Notifications
 
         Throttling_CpuCreditsBalance,
 
-        IntegrityErrorOfAlreadySyncedData
+        IntegrityErrorOfAlreadySyncedData,
+
+        ConcurrentDatabaseLoadTimeout
     }
 }


### PR DESCRIPTION
…tInSec from 10 to 60 seconds. Throwing dedicated warning instead of scary exception.