### PR TITLE
RavenDB-14298 Avoid throwing ObjectDisposed during audit logging if the socket was closed

### DIFF
--- a/src/Raven.Server/RavenServer.cs
+++ b/src/Raven.Server/RavenServer.cs
@@ -1760,6 +1760,8 @@ namespace Raven.Server
                             TcpClient = tcpClient,
                         };
 
+                        var remoteEndPoint = tcpClient.Client.RemoteEndPoint;
+
                         try
                         {
                             var header = await NegotiateOperationVersion(stream, buffer, tcpClient, tcpAuditLog, cert, tcp);
@@ -1797,7 +1799,7 @@ namespace Raven.Server
                         finally
                         {
                             if (tcpAuditLog != null)
-                                tcpAuditLog.Info($"Closed TCP connection {tcpClient.Client.RemoteEndPoint} with certificate '{cert?.Subject} ({cert?.Thumbprint})'.");
+                                tcpAuditLog.Info($"Closed TCP connection {remoteEndPoint} with certificate '{cert?.Subject} ({cert?.Thumbprint})'.");
 
                         }
                     }


### PR DESCRIPTION
https://issues.hibernatingrhinos.com/issue/RavenDB-14298