### PR TITLE
RavenDB-14326 / RavenDB-14220 We must not keep reduce outputs as obje…

### DIFF
--- a/src/Raven.Server/Documents/Indexes/MapReduce/OutputToCollection/OutputReduceIndexWriteOperation.cs
+++ b/src/Raven.Server/Documents/Indexes/MapReduce/OutputToCollection/OutputReduceIndexWriteOperation.cs
@@ -28,8 +28,6 @@ namespace Raven.Server.Documents.Indexes.MapReduce.OutputToCollection
 
         public override void Commit(IndexingStatsScope stats)
         {
-            _outputReduceToCollectionCommand.SetIndexingStatsScope(stats);
-
             var enqueue = DocumentDatabase.TxMerger.Enqueue(_outputReduceToCollectionCommand);
 
             using (_txHolder.AcquireTransaction(out _))
@@ -54,7 +52,7 @@ namespace Raven.Server.Documents.Indexes.MapReduce.OutputToCollection
         {
             base.IndexDocument(key, document, stats, indexContext);
 
-            _outputReduceToCollectionCommand.AddReduce(key, document);
+            _outputReduceToCollectionCommand.AddReduce(key, document, stats);
         }
 
         public override void Delete(LazyStringValue key, IndexingStatsScope stats)


### PR DESCRIPTION
…cts (results of reduce fuction) because it might has properties like LazyStringValue or a blittable JSON which points to memory of _decompressed_ page. The decompressed page memory is valid only during evaluation of reduce function for a given page and we release it afterwards. So we must not use it after a temporary, decompressed page is returned to the pool.

This effectively reverts: https://github.com/ravendb/ravendb/pull/9852