### PR TITLE
RavenDB-13078 / RavenDB-14322 Making sure when we parse a document id…

### DIFF
--- a/src/Raven.Server/Documents/TimeSeries/TimeSeriesValuesSegment.cs
+++ b/src/Raven.Server/Documents/TimeSeries/TimeSeriesValuesSegment.cs
@@ -457,11 +457,11 @@ namespace Raven.Server.Documents.TimeSeries
                 switch (order)
                 {
                     case ParsingOrder.Id:
-                        docId = new LazyStringValue(null, ptr, i, context); // TODO arek - RavenDB-14322
-                        break;
+                       docId = context.GetLazyString(ptr, i);
+                       break;
 
                     case ParsingOrder.Name:
-                        name = new LazyStringValue(null, ptr + next, i - next, context); // TODO arek - RavenDB-14322
+                        name = context.GetLazyString(ptr + next, i - next);
                         break;
 
                     default:

--- a/src/Sparrow/Json/JsonOperationContext.cs
+++ b/src/Sparrow/Json/JsonOperationContext.cs
@@ -579,6 +579,33 @@ namespace Sparrow.Json
             }
         }
 
+        public unsafe LazyStringValue GetLazyString(byte* ptr, int size, bool longLived = false)
+        {
+            var state = new JsonParserState();
+            var maxByteCount = Encodings.Utf8.GetMaxByteCount(size);
+
+            int escapePositionsSize = JsonParserState.FindEscapePositionsMaxSize(ptr, size, out _);
+
+            int memorySize = maxByteCount + escapePositionsSize;
+            var memory = longLived ? GetLongLivedMemory(memorySize) : GetMemory(memorySize);
+
+            var address = memory.Address;
+
+            Memory.Copy(address, ptr, size);
+
+            state.FindEscapePositionsIn(address, ref size, escapePositionsSize);
+
+            state.WriteEscapePositionsTo(address + size);
+            LazyStringValue result = longLived == false ? AllocateStringValue(null, address, size) : new LazyStringValue(null, address, size, this);
+            result.AllocatedMemoryData = memory;
+
+            if (state.EscapePositions.Count > 0)
+            {
+                result.EscapePositions = state.EscapePositions.ToArray();
+            }
+            return result;
+        }
+
         [MethodImpl(MethodImplOptions.AggressiveInlining)]
         public unsafe LazyStringValue GetLazyStringValue(byte* ptr)
         {

--- a/src/Sparrow/Json/Parsing/JsonParserState.cs
+++ b/src/Sparrow/Json/Parsing/JsonParserState.cs
@@ -85,6 +85,46 @@ namespace Sparrow.Json.Parsing
             return (count + 1) * EscapePositionItemSize + controlCount * ControlCharacterItemSize;
         }
 
+        public static int FindEscapePositionsMaxSize(byte* str, int size, out int escapedCount)
+        {
+            var count = 0;
+            var controlCount = 0;
+
+            for (int i = 0; i < size; i++)
+            {
+                byte value = str[i];
+
+                // PERF: We use the values directly because it is 5x faster than iterating over a constant array.
+                // 8  => '\b' => 0000 1000
+                // 9  => '\t' => 0000 1001
+                // 10 => '\n' => 0000 1010
+
+                // 12 => '\f' => 0000 1100
+                // 13 => '\r' => 0000 1101
+
+                // 34 => '"'  => 0010 0010
+                // 92 => '\\' => 0101 1100
+
+                if (value == 92 || value == 34 || (value >= 8 && value <= 13 && value != 11))
+                {
+                    count++;
+                    continue;
+                }
+
+                if (value < 32)
+                {
+                    controlCount++;
+                }
+            }
+
+            escapedCount = controlCount;
+            // we take 5 because that is the max number of bytes for variable size int
+            // plus 1 for the actual number of positions
+
+            // NOTE: this is used by FindEscapePositionsIn, change only if you also modify FindEscapePositionsIn
+            return (count + 1) * EscapePositionItemSize + controlCount * ControlCharacterItemSize;
+        }
+
         [MethodImpl(MethodImplOptions.AggressiveInlining)]
         public void FindEscapePositionsIn(byte* str, ref int len, int previousComputedMaxSize)
         {


### PR DESCRIPTION
… or time series name from TS entry key we'll take into account escape positions. Also this way we create valid LSV - including number of escape positions written after the content so ObjectJsonParser will parse it properly.


https://issues.hibernatingrhinos.com/issue/RavenDB-14322