### PR TITLE
RavenDB-14325 Allow multiple tombstone in different collections

### DIFF
--- a/src/Raven.Server/Documents/DocumentPutAction.cs
+++ b/src/Raven.Server/Documents/DocumentPutAction.cs
@@ -599,12 +599,16 @@ namespace Raven.Server.Documents
             var tombstoneTable = context.Transaction.InnerTransaction.OpenTable(TombstonesSchema, collectionName.GetTableName(CollectionTableType.Tombstones));
             using (Slice.External(context.Allocator, lowerId, lowerSize, out Slice id))
             {
-                if (tombstoneTable.ReadByKey(id, out var reader) == false)
-                    return;
-
-                if (tombstoneTable.IsOwned(reader.Id))
+                foreach (var (tombstoneKey, tvh) in tombstoneTable.SeekByPrimaryKeyPrefix(id, Slices.Empty, 0))
                 {
-                    tombstoneTable.Delete(reader.Id);
+                    if (IsTombstoneOfId(tombstoneKey, id) == false)
+                        return;
+
+                    if (tombstoneTable.IsOwned(tvh.Reader.Id))
+                    {
+                        tombstoneTable.Delete(tvh.Reader.Id);
+                        return; // there could be only one tombstone per collection
+                    }
                 }
             }
         }

--- a/src/Raven.Server/Documents/DocumentsStorage.cs
+++ b/src/Raven.Server/Documents/DocumentsStorage.cs
@@ -1208,13 +1208,12 @@ namespace Raven.Server.Documents
                 result.Collection = TableValueToId(context, (int)TombstoneTable.Collection, ref tvr);
                 result.Flags = TableValueToFlags((int)TombstoneTable.Flags, ref tvr);
                 result.LastModified = TableValueToDateTime((int)TombstoneTable.LastModified, ref tvr);
+                result.LowerId = UnwrapLowerIdIfNeeded(context, result.LowerId);
             }
             else if (result.Type == Tombstone.TombstoneType.Revision)
             {
                 result.Collection = TableValueToId(context, (int)TombstoneTable.Collection, ref tvr);
             }
-
-            result.LowerId = UnwrapLowerIdIfNeeded(context, result.LowerId);
 
             return result;
         }
@@ -1572,7 +1571,6 @@ namespace Raven.Server.Documents
 
             return (newEtag, changeVector);
         }
-
         private Slice ModifyLowerIdIfNeeded(DocumentsOperationContext context, Table table, Slice lowerId)
         {
             if (table.ReadByKey(lowerId, out _) == false)
@@ -1583,7 +1581,7 @@ namespace Raven.Server.Documents
 
             *(long*)(newLowerId.Content.Ptr + length) = ConflictedTombstoneIdMarkerLong;
             *(long*)(newLowerId.Content.Ptr + length + sizeof(long)) = Bits.SwapBytes(GenerateNextEtag()); // now the id will be unique
-
+            
             return newLowerId;
         }
 

--- a/src/Raven.Server/Documents/Replication/ReplicationLoader.cs
+++ b/src/Raven.Server/Documents/Replication/ReplicationLoader.cs
@@ -114,7 +114,7 @@ namespace Raven.Server.Documents.Replication
                     foreach (var external in externals)
                     {
                         var state = GetExternalReplicationState(_server, Database.Name, external.TaskId, ctx);
-                        var myEtag = ChangeVectorUtils.GetEtagById(state.SourceChangeVector, Database.DbBase64Id);
+                        var myEtag = ChangeVectorUtils.GetEtagById(state.DestinationChangeVector, Database.DbBase64Id);
                         minEtag = Math.Min(myEtag, minEtag);
                     }
                 }

--- a/src/Sparrow/Json/LazyStringValue.cs
+++ b/src/Sparrow/Json/LazyStringValue.cs
@@ -354,11 +354,22 @@ namespace Sparrow.Json
             if (IsDisposed)
                 ThrowAlreadyDisposed();
 
-            if (AllocatedMemoryData != null)
+            ReturnAllocatedMemory();
+
+            IsDisposed = true;
+        }
+
+        private void ReturnAllocatedMemory()
+        {
+            if (AllocatedMemoryData == null) 
+                return;
+            
+            if (_context.Generation == AllocatedMemoryData.ContextGeneration)
             {
                 _context.ReturnMemory(AllocatedMemoryData);
             }
-            IsDisposed = true;
+
+            AllocatedMemoryData = null;
         }
 
         public bool Contains(char value)
@@ -1009,6 +1020,9 @@ namespace Sparrow.Json
         public void Renew(string str, byte* buffer, int size)
         {
             Debug.Assert(size >= 0);
+
+            ReturnAllocatedMemory();
+
             _size = size;
             _buffer = buffer;
             _string = str;

--- a/test/SlowTests/Issues/RavenDB_11664.cs
+++ b/test/SlowTests/Issues/RavenDB_11664.cs
@@ -57,37 +57,6 @@ namespace SlowTests.Issues
             }
         }
 
-        [Fact]
-        public async Task CanDeleteDocumentWhenCollectionWasChanged()
-        {
-            using (var store = GetDocumentStore())
-            {
-                using (var commands = store.Commands())
-                {
-                    commands.Put("Key/1", null, new { }, new Dictionary<string, object>
-                    {
-                        {Constants.Documents.Metadata.Collection, "Orders"}
-                    });
-
-                    commands.Delete("key/1", null);
-
-                    commands.Put("Key/1", null, new { }, new Dictionary<string, object>
-                    {
-                        {Constants.Documents.Metadata.Collection, "Companies"}
-                    });
-
-                    var e = Assert.Throws<RavenException>(() => commands.Delete("key/1", null));
-                    Assert.Contains("Could not delete document 'key/1' from collection 'Companies' because tombstone", e.Message);
-
-                    var database = await GetDatabase(store.Database);
-
-                    await database.TombstoneCleaner.ExecuteCleanup();
-
-                    commands.Delete("key/1", null);
-                }
-            }
-        }
-
         private static Stream GetDump(string name)
         {
             var assembly = typeof(RavenDB_9912).Assembly;

--- a/test/SlowTests/Server/Replication/ReplicationCleanTombstones.cs
+++ b/test/SlowTests/Server/Replication/ReplicationCleanTombstones.cs
@@ -424,6 +424,8 @@ namespace SlowTests.Server.Replication
         [Fact]
         public async Task CanReplicateTombstonesFromDifferentCollections()
         {
+            var id = "Oren\r\nEini";
+
             using (var store1 = GetDocumentStore())
             using (var store2 = GetDocumentStore())
             {
@@ -432,31 +434,31 @@ namespace SlowTests.Server.Replication
 
                 using (var session = store1.OpenSession())
                 {
-                    session.Store(new User { Name = "Karmel" }, "foo/bar");
+                    session.Store(new User { Name = "Karmel" }, id);
                     session.SaveChanges();
                 }
 
                 await SetupReplicationAsync(store1, store2);
-                Assert.True(WaitForDocument(store2, "foo/bar"));
+                Assert.True(WaitForDocument(store2, id));
 
                 using (var session = store1.OpenSession())
                 {
-                    session.Delete("foo/bar");
+                    session.Delete(id);
                     session.SaveChanges();
                 }
                 EnsureReplicating(store1, store2);
 
                 using (var session = store1.OpenSession())
                 {
-                    session.Store(new Company { Name = "Karmel" }, "foo/bar");
+                    session.Store(new Company { Name = "Karmel" }, id);
                     session.SaveChanges();
                 }
-                Assert.True(WaitForDocument(store2, "foo/bar"));
+                Assert.True(WaitForDocument(store2, id));
 
 
                 using (var session = store1.OpenSession())
                 {
-                    session.Delete("foo/bar");
+                    session.Delete(id);
                     session.SaveChanges();
                 }
                 EnsureReplicating(store1, store2);


### PR DESCRIPTION
So far we can't have two tombstones in different collections and we need for the cleaner to claim the old one before we can generate a new tombstone.
This is a problem because if you have an etl, external replication to a non-existing/broken destination the old tombstone will be never claimed and breaks replication for ever.

The idea here is to add a suffix to the tombstone ID if one is already exists (maybe we should always added the suffix?).
This way we don't have conflict. Indexing, replication and all other feature shouldn't behave differently, since strip the suffix when materializing the tombstone.