### PR TITLE
RavenDB-14410 - TransactionSizeLimit is evaluated on every document indexing

### DIFF
--- a/src/Raven.Server/Documents/Indexes/Index.cs
+++ b/src/Raven.Server/Documents/Indexes/Index.cs
@@ -3352,6 +3352,9 @@ namespace Raven.Server.Documents.Indexes
         {
             get
             {
+                if (_transactionSizeLimit != null)
+                    return _transactionSizeLimit.Value;
+
                 var limit = DocumentDatabase.IsEncrypted
                     ? Configuration.EncryptedTransactionSizeLimit ?? Configuration.TransactionSizeLimit
                     : Configuration.TransactionSizeLimit;


### PR DESCRIPTION
https://issues.hibernatingrhinos.com/issue/RavenDB-14410