### PR TITLE
RavenDB-14457 added the ability to configure HttpVersion via Conventions

### DIFF
--- a/src/Raven.Client/Documents/Conventions/DocumentConventions.cs
+++ b/src/Raven.Client/Documents/Conventions/DocumentConventions.cs
@@ -164,6 +164,7 @@ namespace Raven.Client.Documents.Conventions
 
             var httpCacheSizeInMb = PlatformDetails.Is32Bits ? 32 : 128;
             MaxHttpCacheSize = new Size(httpCacheSizeInMb, SizeUnit.Megabytes);
+            HttpVersion = System.Net.HttpVersion.Version11;
 
             OperationStatusFetchMode = OperationStatusFetchMode.ChangesApi;
 
@@ -206,7 +207,7 @@ namespace Raven.Client.Documents.Conventions
         private TimeSpan _firstBroadcastAttemptTimeout;
 
         private ReadBalanceBehavior _readBalanceBehavior;
-        private Func<Type, BlittableJsonReaderObject, object> _deserializeEntityFromBlittable;        
+        private Func<Type, BlittableJsonReaderObject, object> _deserializeEntityFromBlittable;
         private bool _preserveDocumentPropertiesNotFoundOnModel;
         private Size _maxHttpCacheSize;
         private bool? _useCompression;
@@ -214,6 +215,18 @@ namespace Raven.Client.Documents.Conventions
         private Func<Type, bool> _typeIsKnownServerSide = _ => false;
         private OperationStatusFetchMode _operationStatusFetchMode;
         private string _topologyCacheLocation;
+        private Version _httpVersion;
+
+        public Version HttpVersion
+        {
+            get => _httpVersion;
+            set
+            {
+                AssertNotFrozen();
+                _httpVersion = value;
+            }
+        }
+
         public Func<MemberInfo, string> PropertyNameConverter
         {
             get => _propertyNameConverter;
@@ -339,7 +352,7 @@ namespace Raven.Client.Documents.Conventions
             }
         }
 
-        
+
 
         /// <summary>
         ///     By default, the field 'Id' field will be added to dynamic objects, this allows to disable this behavior.
@@ -880,7 +893,7 @@ namespace Raven.Client.Documents.Conventions
             CustomizeJsonSerializer(jsonSerializer);
             CustomizeJsonDeserializer(jsonSerializer);
             PostJsonSerializerInitiation(jsonSerializer);
-            return jsonSerializer;            
+            return jsonSerializer;
         }
 
         /// <summary>

--- a/src/Raven.Client/Http/RequestExecutor.cs
+++ b/src/Raven.Client/Http/RequestExecutor.cs
@@ -812,7 +812,7 @@ namespace Raven.Client.Http
             {
                 if (cachedChangeVector != null)
                 {
-                    if (TryGetFromCache(context, command, cachedItem, cachedValue)) 
+                    if (TryGetFromCache(context, command, cachedItem, cachedValue))
                         return;
                 }
 
@@ -884,10 +884,10 @@ namespace Raven.Client.Http
 
                 tasks[0] = refreshTopology
                     ? UpdateTopologyAsync(new ServerNode
-                        {
-                            Url = chosenNode.Url, 
-                            Database = _databaseName
-                        }, 0,
+                    {
+                        Url = chosenNode.Url,
+                        Database = _databaseName
+                    }, 0,
                         debugTag: refreshTopology ? "refresh-topology-header" : refreshClientConfiguration ? "refresh-client-configuration-header" : null)
                     : Task.CompletedTask;
 
@@ -902,14 +902,14 @@ namespace Raven.Client.Http
         }
 
         private async Task<HttpResponseMessage> SendRequestToServer<TResult>(
-            ServerNode chosenNode, 
-            int? nodeIndex, 
-            JsonOperationContext context, 
-            RavenCommand<TResult> command, 
-            bool shouldRetry, 
-            SessionInfo sessionInfo, 
-            HttpRequestMessage request, 
-            string url, 
+            ServerNode chosenNode,
+            int? nodeIndex,
+            JsonOperationContext context,
+            RavenCommand<TResult> command,
+            bool shouldRetry,
+            SessionInfo sessionInfo,
+            HttpRequestMessage request,
+            string url,
             CancellationToken token)
         {
             try
@@ -1007,10 +1007,10 @@ namespace Raven.Client.Http
         }
 
         private async Task<HttpResponseMessage> SendAsync<TResult>(
-            ServerNode chosenNode, 
-            RavenCommand<TResult> command, 
-            SessionInfo sessionInfo, 
-            HttpRequestMessage request, 
+            ServerNode chosenNode,
+            RavenCommand<TResult> command,
+            SessionInfo sessionInfo,
+            HttpRequestMessage request,
             CancellationToken token)
         {
             var preferredTask = command.SendAsync(HttpClient, request, token);
@@ -1039,7 +1039,7 @@ namespace Raven.Client.Http
                             "since this command dependent on a cluster transaction which this node doesn't support");
                     }
                 }
-                    
+
             }
 
             return response;
@@ -1172,7 +1172,7 @@ namespace Raven.Client.Http
                    selector.Topology?.Nodes?.Count > 1 &&
                    command.IsReadRequest &&
                    command.ResponseType == RavenCommandResponseType.Object &&
-                   chosenNode != null && 
+                   chosenNode != null &&
                    command is IBroadcast == false;
         }
 
@@ -1200,7 +1200,7 @@ namespace Raven.Client.Http
                     disposable = ContextPool.AllocateOperationContext(out var tmpCtx);
                     var request = CreateRequest(tmpCtx, nodes[i], command, out _);
                     SetRequestHeaders(null, null, request);
-                    
+
                     Interlocked.Increment(ref NumberOfServerRequests);
 
                     var copy = disposable;
@@ -1290,7 +1290,10 @@ namespace Raven.Client.Http
             {
                 command.SetTimeout(command.Timeout ?? _firstBroadcastAttemptTimeout);
             }
-            
+
+            if (Conventions.HttpVersion != null)
+                request.Version = Conventions.HttpVersion;
+
             request.RequestUri = builder.Uri;
 
             return request;
@@ -1452,7 +1455,7 @@ namespace Raven.Client.Http
             if (command is IBroadcast == false)
                 return false;
 
-            if (TopologyNodes == null || 
+            if (TopologyNodes == null ||
                 TopologyNodes.Count < 2)
                 return false;
 
@@ -1490,7 +1493,7 @@ namespace Raven.Client.Http
                     foreach (var broadcastState in broadcastTasks)
                     {
                         // we can't dispose it right away, we need for the task to be completed in order not to have a concurrent usage of the context.
-                        broadcastState.Key?.ContinueWith(_=> broadcastState.Value.ReturnContext.Dispose(), TaskContinuationOptions.ExecuteSynchronously);
+                        broadcastState.Key?.ContinueWith(_ => broadcastState.Value.ReturnContext.Dispose(), TaskContinuationOptions.ExecuteSynchronously);
                     }
                 }
             }
@@ -1507,7 +1510,7 @@ namespace Raven.Client.Http
                     var node = _nodeSelector.Topology.Nodes[failed.Index];
 
                     command.FailedNodes[node] = completed.Exception?.ExtractSingleInnerException() ?? new UnsuccessfulRequestException(failed.Node.Url);
-                    
+
                     _nodeSelector.OnFailedRequest(failed.Index);
 
                     tasks.Remove(completed);


### PR DESCRIPTION
`null` -> framework default (.Net Core 2.1 and 2.2 -> HTTP 2.0, others 1.1)
`default` -> 1.1