### PR TITLE
RavenDB-14464: On operation initialization exchange the _result task …

### DIFF
--- a/src/Raven.Client/Documents/Operations/Operation.cs
+++ b/src/Raven.Client/Documents/Operations/Operation.cs
@@ -21,7 +21,7 @@ namespace Raven.Client.Documents.Operations
         private readonly DocumentConventions _conventions;
         private readonly Task _additionalTask;
         private readonly long _id;
-        private readonly TaskCompletionSource<IOperationResult> _result = new TaskCompletionSource<IOperationResult>(TaskCreationOptions.RunContinuationsAsynchronously);
+        private TaskCompletionSource<IOperationResult> _result = new TaskCompletionSource<IOperationResult>(TaskCreationOptions.RunContinuationsAsynchronously);
         private readonly SemaphoreSlim _lock = new SemaphoreSlim(1, 1);
 
         public Action<IOperationProgress> OnProgressChanged;
@@ -55,6 +55,8 @@ namespace Raven.Client.Documents.Operations
 
         private async Task Initialize()
         {
+            _result = _result.Task.IsCompleted ? new TaskCompletionSource<IOperationResult>(TaskCreationOptions.RunContinuationsAsynchronously) : _result;
+
             try
             {
                 await Process().ConfigureAwait(false);

--- a/test/SlowTests/Issues/RavenDB_14464.cs
+++ b/test/SlowTests/Issues/RavenDB_14464.cs
@@ -83,8 +83,8 @@ namespace SlowTests.Issues
                         {
                             if (serverToggled == false)
                             {
-                                Assert.True(e.GetType() == typeof(TimeoutException));
-                                Assert.True(e.Message.Contains("did not get a reply for operation"));
+                                Assert.True(e.GetType() == typeof(TimeoutException), "e.GetType() == typeof(TimeoutException)");
+                                Assert.True(e.Message.Contains("did not get a reply for operation"), "e.Message.Contains('did not get a reply for operation')");
                                 while (server.Disposed == false)
                                 {
                                     await Task.Delay(500);
@@ -92,8 +92,8 @@ namespace SlowTests.Issues
                                 serverToggled = true;
                             }
 
-                            Assert.True(e.GetType() == typeof(InvalidOperationException));
-                            Assert.True(e.Message.StartsWith("Could not fetch state of operation"));
+                            Assert.True(e.GetType() == typeof(InvalidOperationException), "e.GetType() == typeof(InvalidOperationException)");
+                            Assert.True(e.Message.StartsWith("Could not fetch state of operation"), "e.Message.StartsWith('Could not fetch state of operation')");
                             await Task.Delay(1000);
                         }
                     }

--- a/test/SlowTests/Issues/RavenDB_14464.cs
+++ b/test/SlowTests/Issues/RavenDB_14464.cs
@@ -1,0 +1,148 @@
+﻿using System;
+using System.Collections.Generic;
+using System.Linq;
+using System.Threading.Tasks;
+using Raven.Client.Documents;
+using Raven.Client.Documents.Indexes;
+using Raven.Client.Documents.Operations;
+using Raven.Client.Documents.Queries;
+using Raven.Server;
+using Raven.Server.Config;
+using Raven.Tests.Core.Utils.Entities;
+using Tests.Infrastructure;
+using Xunit;
+using Xunit.Abstractions;
+
+namespace SlowTests.Issues
+{
+    public class RavenDB_14464 : ClusterTestBase
+    {
+        public RavenDB_14464(ITestOutputHelper output) : base(output)
+        {
+        }
+
+        private class Company_ByName : AbstractIndexCreationTask<Company>
+        {
+            public Company_ByName()
+            {
+                Map = companies => from c in companies
+                                   select new
+                                   {
+                                       c.Name
+                                   };
+            }
+        }
+
+        [Fact]
+        public async Task CanUseChangesApiAndToggleServer()
+        {
+            var server = GetNewServer(new ServerCreationOptions
+            {
+                RunInMemory = false
+            });
+
+            using (var store = GetDocumentStore(new Options
+            {
+                ModifyDocumentStore = documentStore =>
+                {
+                    documentStore.Conventions.OperationStatusFetchMode = OperationStatusFetchMode.ChangesApi;
+                    documentStore.OnFailedRequest += (sender, args) => { };
+                },
+                Server = server,
+                RunInMemory = false
+            }))
+            {
+                new Company_ByName().Execute(store);
+                put_1500_companies(store);
+
+                WaitForIndexing(store);
+
+                var task = Task.Run(async () =>
+                {
+                    var operation = await store.Operations.SendAsync(new DeleteByQueryOperation(new IndexQuery { Query = $"FROM INDEX '{new Company_ByName().IndexName}'" }, new QueryOperationOptions
+                    {
+                        MaxOpsPerSecond = 1
+                    }));
+                    var serverToggled = false;
+
+                    while (store.WasDisposed == false)
+                    {
+                        try
+                        {
+                            if (serverToggled)
+                            {
+                                await operation.WaitForCompletionAsync();
+                            }
+                            else
+                            {
+                                await operation.WaitForCompletionAsync(TimeSpan.FromSeconds(1));
+                            }
+                            break;
+                        }
+                        catch (Exception e)
+                        {
+                            if (serverToggled == false)
+                            {
+                                Assert.True(e.GetType() == typeof(TimeoutException));
+                                Assert.True(e.Message.Contains("did not get a reply for operation"));
+                                while (server.Disposed == false)
+                                {
+                                    await Task.Delay(500);
+                                }
+                                serverToggled = true;
+                            }
+
+                            Assert.True(e.GetType() == typeof(InvalidOperationException));
+                            Assert.True(e.Message.StartsWith("Could not fetch state of operation"));
+                            await Task.Delay(1000);
+                        }
+                    }
+                });
+
+                await Task.Delay(1000);
+                server = await ToggleServer(server);
+                await Task.Delay(5000);
+                server = await ToggleServer(server);
+                await Task.Delay(5000);
+            }
+        }
+
+        private static void put_1500_companies(DocumentStore store)
+        {
+            using (var session = store.OpenSession())
+            {
+                for (int i = 0; i < 1500; i++)
+                {
+                    session.Store(new Company { Name = $"Company {i}" });
+                }
+
+                session.SaveChanges();
+            }
+        }
+
+        private async Task<RavenServer> ToggleServer(RavenServer node)
+        {
+            if (node.Disposed)
+            {
+                var settings = new Dictionary<string, string>
+                {
+                    [RavenConfiguration.GetKey(x => x.Replication.ReplicationMinimalHeartbeat)] = "1",
+                    [RavenConfiguration.GetKey(x => x.Replication.RetryReplicateAfter)] = "3",
+                    [RavenConfiguration.GetKey(x => x.Cluster.AddReplicaTimeout)] = "10",
+                    [RavenConfiguration.GetKey(x => x.Core.ServerUrls)] = node.WebUrl,
+                    [RavenConfiguration.GetKey(x => x.Cluster.ElectionTimeout)] = node.Configuration.Cluster.ElectionTimeout.AsTimeSpan.TotalMilliseconds.ToString()
+                };
+
+                var dataDir = node.Configuration.Core.DataDirectory.FullPath.Split('/').Last();
+
+                node = base.GetNewServer(new ServerCreationOptions() { DeletePrevious = false, RunInMemory = false, CustomSettings = settings, PartialPath = dataDir });
+            }
+            else
+            {
+                var nodeInfo = await DisposeServerAndWaitForFinishOfDisposalAsync(node);
+            }
+
+            return node;
+        }
+    }
+}

--- a/test/StressTests/Issues/RavenDB_14464.cs
+++ b/test/StressTests/Issues/RavenDB_14464.cs
@@ -13,7 +13,7 @@ using Tests.Infrastructure;
 using Xunit;
 using Xunit.Abstractions;
 
-namespace SlowTests.Issues
+namespace StressTests.Issues
 {
     public class RavenDB_14464 : ClusterTestBase
     {
@@ -83,8 +83,8 @@ namespace SlowTests.Issues
                         {
                             if (serverToggled == false)
                             {
-                                Assert.True(e.GetType() == typeof(TimeoutException), "e.GetType() == typeof(TimeoutException)");
-                                Assert.True(e.Message.Contains("did not get a reply for operation"), "e.Message.Contains('did not get a reply for operation')");
+                                Assert.Equal(typeof(TimeoutException), e.GetType());
+                                Assert.Contains(e.Message, "did not get a reply for operation");
                                 while (server.Disposed == false)
                                 {
                                     await Task.Delay(500);
@@ -92,8 +92,8 @@ namespace SlowTests.Issues
                                 serverToggled = true;
                             }
 
-                            Assert.True(e.GetType() == typeof(InvalidOperationException), "e.GetType() == typeof(InvalidOperationException)");
-                            Assert.True(e.Message.StartsWith("Could not fetch state of operation"), "e.Message.StartsWith('Could not fetch state of operation')");
+                            Assert.Equal(typeof(InvalidOperationException), e.GetType());
+                            Assert.StartsWith(e.Message, "Could not fetch state of operation");
                             await Task.Delay(1000);
                         }
                     }


### PR DESCRIPTION
…with new if it is already completed