### PR TITLE
RavenDB-14468

### DIFF
--- a/src/Raven.Server/Documents/CollectionRunner.cs
+++ b/src/Raven.Server/Documents/CollectionRunner.cs
@@ -83,7 +83,7 @@ namespace Raven.Server.Documents
                     ids.Clear();
                     using (context.OpenReadTransaction())
                     {
-                        foreach (var document in GetDocuments(context, collectionName, startEtag, internalQueryOperationStart, OperationBatchSize, isAllDocs, DocumentFields.Id | DocumentFields.Etag))
+                        foreach (var document in GetDocuments(context, collectionName, startEtag, internalQueryOperationStart, OperationBatchSize, isAllDocs, DocumentFields.Id))
                         {
                             internalQueryOperationStart++;
 

--- a/src/Raven.Server/Documents/Document.cs
+++ b/src/Raven.Server/Documents/Document.cs
@@ -109,15 +109,10 @@ namespace Raven.Server.Documents
         None = 0,
         Id = 1 << 0,
         LowerId = 1 << 1,
-        Etag = 1 << 2,
-        StorageId = 1 << 3,
         Data = 1 << 4,
         ChangeVector = 1 << 5,
-        LastModified = 1 << 6,
-        Flags = 1 << 7,
-        TransactionMarker = 1 << 8,
 
-        All = Id | LowerId | Etag | StorageId | Data | ChangeVector | LastModified | Flags | TransactionMarker
+        All = Id | LowerId | Data | ChangeVector
     }
 
 

--- a/src/Raven.Server/Documents/Document.cs
+++ b/src/Raven.Server/Documents/Document.cs
@@ -106,7 +106,7 @@ namespace Raven.Server.Documents
     [Flags]
     public enum DocumentFields
     {
-        None = 0,
+        Default = 0,
         Id = 1 << 0,
         LowerId = 1 << 1,
         Data = 1 << 4,

--- a/src/Raven.Server/Documents/DocumentsStorage.cs
+++ b/src/Raven.Server/Documents/DocumentsStorage.cs
@@ -1196,17 +1196,11 @@ namespace Raven.Server.Documents
         {
             var result = new Document();
 
-            if (fields.Contain(DocumentFields.StorageId))
-                result.StorageId = tvr.Id;
-
             if (fields.Contain(DocumentFields.LowerId))
                 result.LowerId = TableValueToString(context, (int)DocumentsTable.LowerId, ref tvr);
 
             if (fields.Contain(DocumentFields.Id))
                 result.Id = TableValueToId(context, (int)DocumentsTable.Id, ref tvr);
-
-            if (fields.Contain(DocumentFields.Etag))
-                result.Etag = TableValueToEtag((int)DocumentsTable.Etag, ref tvr);
 
             if (fields.Contain(DocumentFields.Data))
                 result.Data = new BlittableJsonReaderObject(tvr.Read((int)DocumentsTable.Data, out int size), size, context);
@@ -1214,13 +1208,11 @@ namespace Raven.Server.Documents
             if (fields.Contain(DocumentFields.ChangeVector))
                 result.ChangeVector = TableValueToChangeVector(context, (int)DocumentsTable.ChangeVector, ref tvr);
 
-            if (fields.Contain(DocumentFields.LastModified))
-                result.LastModified = TableValueToDateTime((int)DocumentsTable.LastModified, ref tvr);
-
+            result.Etag = TableValueToEtag((int)DocumentsTable.Etag, ref tvr);
+            result.LastModified = TableValueToDateTime((int)DocumentsTable.LastModified, ref tvr);
             result.Flags = TableValueToFlags((int)DocumentsTable.Flags, ref tvr);
-
-            if (fields.Contain(DocumentFields.TransactionMarker))
-                result.TransactionMarker = TableValueToShort((int)DocumentsTable.TransactionMarker, nameof(DocumentsTable.TransactionMarker), ref tvr);
+            result.StorageId = tvr.Id;
+            result.TransactionMarker = TableValueToShort((int)DocumentsTable.TransactionMarker, nameof(DocumentsTable.TransactionMarker), ref tvr);
 
             return result;
         }

--- a/src/Raven.Server/Documents/DocumentsStorage.cs
+++ b/src/Raven.Server/Documents/DocumentsStorage.cs
@@ -1217,8 +1217,7 @@ namespace Raven.Server.Documents
             if (fields.Contain(DocumentFields.LastModified))
                 result.LastModified = TableValueToDateTime((int)DocumentsTable.LastModified, ref tvr);
 
-            if (fields.Contain(DocumentFields.Flags))
-                result.Flags = TableValueToFlags((int)DocumentsTable.Flags, ref tvr);
+            result.Flags = TableValueToFlags((int)DocumentsTable.Flags, ref tvr);
 
             if (fields.Contain(DocumentFields.TransactionMarker))
                 result.TransactionMarker = TableValueToShort((int)DocumentsTable.TransactionMarker, nameof(DocumentsTable.TransactionMarker), ref tvr);

--- a/src/Raven.Server/Documents/Handlers/IndexHandler.cs
+++ b/src/Raven.Server/Documents/Handlers/IndexHandler.cs
@@ -814,7 +814,7 @@ namespace Raven.Server.Documents.Handlers
                             {
                                 case IndexSourceType.Documents:
                                     var etag = Database.DocumentsStorage.GetLastDocumentEtag(context, collection);
-                                    var document = Database.DocumentsStorage.GetDocumentsFrom(context, collection, etag, 0, 1).FirstOrDefault();
+                                    var document = Database.DocumentsStorage.GetDocumentsFrom(context, collection, etag, 0, 1, DocumentFields.Default).FirstOrDefault();
                                     if (document != null && document.LastModified > baseLine)
                                         baseLine = document.LastModified;
                                     break;

--- a/src/Raven.Server/Documents/Handlers/IndexHandler.cs
+++ b/src/Raven.Server/Documents/Handlers/IndexHandler.cs
@@ -814,7 +814,7 @@ namespace Raven.Server.Documents.Handlers
                             {
                                 case IndexSourceType.Documents:
                                     var etag = Database.DocumentsStorage.GetLastDocumentEtag(context, collection);
-                                    var document = Database.DocumentsStorage.GetDocumentsFrom(context, collection, etag, 0, 1, DocumentFields.LastModified).FirstOrDefault();
+                                    var document = Database.DocumentsStorage.GetDocumentsFrom(context, collection, etag, 0, 1).FirstOrDefault();
                                     if (document != null && document.LastModified > baseLine)
                                         baseLine = document.LastModified;
                                     break;

--- a/src/Raven.Server/Documents/Handlers/TimeSeriesHandler.cs
+++ b/src/Raven.Server/Documents/Handlers/TimeSeriesHandler.cs
@@ -292,6 +292,21 @@ namespace Raven.Server.Documents.Handlers
 
                     var tss = _database.DocumentsStorage.TimeSeriesStorage;
 
+                    if (operation?.Removals != null)
+                    {
+                        foreach (var removal in operation.Removals)
+                        {
+                            LastChangeVector = tss.RemoveTimestampRange(context,
+                                operation.DocumentId,
+                                docCollection,
+                                removal.Name,
+                                removal.From,
+                                removal.To
+                            );
+                            changes++;
+                        }
+                    }
+
                     if (_appendDictionary != null)
                     {
                         foreach (var kvp in _appendDictionary)
@@ -322,20 +337,6 @@ namespace Raven.Server.Documents.Handlers
                         changes++;
                     }
 
-                    if (operation?.Removals != null)
-                    {
-                        foreach (var removal in operation.Removals)
-                        {
-                            LastChangeVector = tss.RemoveTimestampRange(context,
-                                operation.DocumentId,
-                                docCollection,
-                                removal.Name,
-                                removal.From,
-                                removal.To
-                            );
-                            changes++;
-                        }
-                    }
                 }
 
                 return changes;

--- a/src/Raven.Server/Documents/Indexes/Workers/HandleReferences.cs
+++ b/src/Raven.Server/Documents/Indexes/Workers/HandleReferences.cs
@@ -310,7 +310,7 @@ namespace Raven.Server.Documents.Indexes.Workers
         protected IEnumerable<Reference> GetItemReferences(DocumentsOperationContext databaseContext, CollectionName referencedCollection, long lastEtag, int start, int pageSize)
         {
             return _documentsStorage
-                .GetDocumentsFrom(databaseContext, referencedCollection.Name, lastEtag + 1, 0, pageSize, DocumentFields.Id | DocumentFields.Etag)
+                .GetDocumentsFrom(databaseContext, referencedCollection.Name, lastEtag + 1, 0, pageSize, DocumentFields.Id)
                 .Select(document =>
                 {
                     _reference.Key = document.Id;


### PR DESCRIPTION
- We must always return the document flags, we assert on them.
- A time series batch will first process removals, and then appends