### PR TITLE
RavenDB-14461

### DIFF
--- a/src/Raven.Client/Documents/Session/Operations/Lazy/LazyLoadOperation.cs
+++ b/src/Raven.Client/Documents/Session/Operations/Lazy/LazyLoadOperation.cs
@@ -50,7 +50,7 @@ namespace Raven.Client.Documents.Session.Operations.Lazy
 
         public LazyLoadOperation<T> ById(string id)
         {
-            if (id == null)
+            if (string.IsNullOrWhiteSpace(id))
                 return this;
 
             if (_ids == null)
@@ -61,7 +61,10 @@ namespace Raven.Client.Documents.Session.Operations.Lazy
 
         public LazyLoadOperation<T> ByIds(IEnumerable<string> ids)
         {
-            _ids = ids.ToArray();
+            _ids = ids
+                .Where(id => string.IsNullOrWhiteSpace(id) == false)
+                .Distinct(StringComparer.OrdinalIgnoreCase)
+                .ToArray();
 
             return this;
         }

--- a/src/Raven.Client/Documents/Session/Operations/LoadOperation.cs
+++ b/src/Raven.Client/Documents/Session/Operations/LoadOperation.cs
@@ -173,7 +173,7 @@ namespace Raven.Client.Documents.Session.Operations
 
             if (_includeAllCounters || _countersToInclude != null)
             {
-                _session.RegisterCounters(result.CounterIncludes, _ids.ToArray(), _countersToInclude, _includeAllCounters);
+                _session.RegisterCounters(result.CounterIncludes, _ids, _countersToInclude, _includeAllCounters);
             }
 
             foreach (var document in GetDocumentsFromResult(result))

--- a/src/Raven.Client/Documents/Session/Operations/LoadOperation.cs
+++ b/src/Raven.Client/Documents/Session/Operations/LoadOperation.cs
@@ -44,7 +44,7 @@ namespace Raven.Client.Documents.Session.Operations
 
         public LoadOperation ById(string id)
         {
-            if (id == null)
+            if (string.IsNullOrWhiteSpace(id))
                 return this;
 
             if (_ids == null)
@@ -75,7 +75,7 @@ namespace Raven.Client.Documents.Session.Operations
         public LoadOperation ByIds(IEnumerable<string> ids)
         {
             _ids = ids
-                .Where(x => x != null)
+                .Where(id => string.IsNullOrWhiteSpace(id) == false)
                 .Distinct(StringComparer.OrdinalIgnoreCase)
                 .ToArray();
 

--- a/test/SlowTests/Issues/RavenDB_14461.cs
+++ b/test/SlowTests/Issues/RavenDB_14461.cs
@@ -1,7 +1,4 @@
-﻿using System;
-using System.Collections.Generic;
-using System.Text;
-using System.Threading.Tasks;
+﻿using System.Threading.Tasks;
 using FastTests;
 using Orders;
 using Raven.Client.Documents.Session;
@@ -71,6 +68,51 @@ namespace SlowTests.Issues
                 }))
                 {
                     Assert.Empty(await session.Advanced.LoadStartingWithAsync<Company>("orders/"));
+                }
+            }
+        }
+
+        [Fact]
+        public async Task FindByEmptyCollectionShouldWork()
+        {
+            using (var store = GetDocumentStore())
+            {
+                using (var session = store.OpenSession())
+                {
+                    var ids = new string[] { };
+                    var objs = session.Load<Company>(ids);
+
+                    Assert.NotNull(objs);
+                }
+
+                using (var session = store.OpenSession(new SessionOptions
+                {
+                    NoTracking = true
+                }))
+                {
+                    var ids = new string[] { };
+                    var objs = session.Load<Company>(ids);
+
+                    Assert.NotNull(objs);
+                }
+
+                using (var session = store.OpenAsyncSession())
+                {
+                    var ids = new string[] { };
+                    var objs = await session.LoadAsync<Company>(ids);
+
+                    Assert.NotNull(objs);
+                }
+
+                using (var session = store.OpenAsyncSession(new SessionOptions
+                {
+                    NoTracking = true
+                }))
+                {
+                    var ids = new string[] { };
+                    var objs = await session.LoadAsync<Company>(ids);
+
+                    Assert.NotNull(objs);
                 }
             }
         }

--- a/test/SlowTests/Issues/RavenDB_14461.cs
+++ b/test/SlowTests/Issues/RavenDB_14461.cs
@@ -1,6 +1,7 @@
 ﻿using System.Threading.Tasks;
 using FastTests;
 using Orders;
+using Raven.Client.Documents;
 using Raven.Client.Documents.Session;
 using Xunit;
 using Xunit.Abstractions;
@@ -18,56 +19,68 @@ namespace SlowTests.Issues
         {
             using (var store = GetDocumentStore())
             {
-                using (var session = store.OpenSession())
+                AssertLoad(store, noTracking: false);
+                AssertLoad(store, noTracking: true);
+
+                await AssertLoadAsync(store, noTracking: false);
+                await AssertLoadAsync(store, noTracking: true);
+
+                AssertLoadStartsWith(store, noTracking: false);
+                AssertLoadStartsWith(store, noTracking: true);
+
+                await AssertLoadStartsWithAsync(store, noTracking: false);
+                await AssertLoadStartsWithAsync(store, noTracking: true);
+            }
+
+            void AssertLoad(DocumentStore store, bool noTracking)
+            {
+                using (var session = store.OpenSession(new SessionOptions { NoTracking = noTracking }))
                 {
                     Assert.Null(session.Load<Company>("orders/1"));
                 }
 
-                using (var session = store.OpenSession())
+                using (var session = store.OpenSession(new SessionOptions { NoTracking = noTracking }))
                 {
-                    Assert.Empty(session.Advanced.LoadStartingWith<Company>("orders/"));
+                    Assert.Null(session.Advanced.Lazily.Load<Company>("orders/1").Value);
                 }
+            }
 
-                using (var session = store.OpenAsyncSession())
+            async Task AssertLoadAsync(DocumentStore store, bool noTracking)
+            {
+                using (var session = store.OpenAsyncSession(new SessionOptions { NoTracking = noTracking }))
                 {
                     Assert.Null(await session.LoadAsync<Company>("orders/1"));
                 }
 
-                using (var session = store.OpenAsyncSession())
+                using (var session = store.OpenAsyncSession(new SessionOptions { NoTracking = noTracking }))
                 {
-                    Assert.Empty(await session.Advanced.LoadStartingWithAsync<Company>("orders/"));
+                    Assert.Null(await session.Advanced.Lazily.LoadAsync<Company>("orders/1").Value);
                 }
+            }
 
-                using (var session = store.OpenSession(new SessionOptions
-                {
-                    NoTracking = true
-                }))
-                {
-                    Assert.Null(session.Load<Company>("orders/1"));
-                }
-
-                using (var session = store.OpenSession(new SessionOptions
-                {
-                    NoTracking = true
-                }))
+            void AssertLoadStartsWith(DocumentStore store, bool noTracking)
+            {
+                using (var session = store.OpenSession(new SessionOptions { NoTracking = noTracking }))
                 {
                     Assert.Empty(session.Advanced.LoadStartingWith<Company>("orders/"));
                 }
 
-                using (var session = store.OpenAsyncSession(new SessionOptions
+                using (var session = store.OpenSession(new SessionOptions { NoTracking = noTracking }))
                 {
-                    NoTracking = true
-                }))
-                {
-                    Assert.Null(await session.LoadAsync<Company>("orders/1"));
+                    Assert.Empty(session.Advanced.Lazily.LoadStartingWith<Company>("orders/").Value);
                 }
+            }
 
-                using (var session = store.OpenAsyncSession(new SessionOptions
-                {
-                    NoTracking = true
-                }))
+            async Task AssertLoadStartsWithAsync(DocumentStore store, bool noTracking)
+            {
+                using (var session = store.OpenAsyncSession(new SessionOptions { NoTracking = noTracking }))
                 {
                     Assert.Empty(await session.Advanced.LoadStartingWithAsync<Company>("orders/"));
+                }
+
+                using (var session = store.OpenAsyncSession(new SessionOptions { NoTracking = noTracking }))
+                {
+                    Assert.Empty(await session.Advanced.Lazily.LoadStartingWithAsync<Company>("orders/").Value);
                 }
             }
         }
@@ -77,42 +90,54 @@ namespace SlowTests.Issues
         {
             using (var store = GetDocumentStore())
             {
-                using (var session = store.OpenSession())
+                AssertLoad(store, ids: new string[] { }, noTracking: false);
+                AssertLoad(store, ids: new string[] { }, noTracking: true);
+
+                AssertLoad(store, ids: new string[] { string.Empty }, noTracking: false);
+                AssertLoad(store, ids: new string[] { string.Empty }, noTracking: true);
+
+                await AssertLoadAsync(store, ids: new string[] { }, noTracking: false);
+                await AssertLoadAsync(store, ids: new string[] { }, noTracking: true);
+
+                await AssertLoadAsync(store, ids: new string[] { string.Empty }, noTracking: false);
+                await AssertLoadAsync(store, ids: new string[] { string.Empty }, noTracking: true);
+            }
+
+            void AssertLoad(DocumentStore store, string[] ids, bool noTracking)
+            {
+                using (var session = store.OpenSession(new SessionOptions { NoTracking = noTracking }))
                 {
-                    var ids = new string[] { };
                     var objs = session.Load<Company>(ids);
 
                     Assert.NotNull(objs);
+                    Assert.Empty(objs);
                 }
 
-                using (var session = store.OpenSession(new SessionOptions
+                using (var session = store.OpenSession(new SessionOptions { NoTracking = noTracking }))
                 {
-                    NoTracking = true
-                }))
-                {
-                    var ids = new string[] { };
-                    var objs = session.Load<Company>(ids);
+                    var objs = session.Advanced.Lazily.Load<Company>(ids).Value;
 
                     Assert.NotNull(objs);
+                    Assert.Empty(objs);
                 }
+            }
 
-                using (var session = store.OpenAsyncSession())
+            async Task AssertLoadAsync(DocumentStore store, string[] ids, bool noTracking)
+            {
+                using (var session = store.OpenAsyncSession(new SessionOptions { NoTracking = noTracking }))
                 {
-                    var ids = new string[] { };
                     var objs = await session.LoadAsync<Company>(ids);
 
                     Assert.NotNull(objs);
+                    Assert.Empty(objs);
                 }
 
-                using (var session = store.OpenAsyncSession(new SessionOptions
+                using (var session = store.OpenAsyncSession(new SessionOptions { NoTracking = noTracking }))
                 {
-                    NoTracking = true
-                }))
-                {
-                    var ids = new string[] { };
-                    var objs = await session.LoadAsync<Company>(ids);
+                    var objs = await session.Advanced.Lazily.LoadAsync<Company>(ids).Value;
 
                     Assert.NotNull(objs);
+                    Assert.Empty(objs);
                 }
             }
         }


### PR DESCRIPTION
- NoTracking session should behave same as regular one when loading empty array
- removed redundant operation when loading by array of ids