### PR TITLE
RavenDB-14519 External replication fixes

### DIFF
--- a/src/Raven.Client/Documents/Operations/Replication/ExternalReplicationBase.cs
+++ b/src/Raven.Client/Documents/Operations/Replication/ExternalReplicationBase.cs
@@ -47,6 +47,12 @@ namespace Raven.Client.Documents.Operations.Replication
             ConnectionStringName = connectionStringName;
         }
 
+        public void AssertValidReplication()
+        {
+            if (string.IsNullOrEmpty(ConnectionStringName))
+                throw new ArgumentNullException(nameof(ConnectionStringName));
+        }
+
         public static void RemoveExternalReplication<T>(List<T> replicationTasks, long taskId) where T : ExternalReplicationBase
         {
             foreach (var task in replicationTasks)
@@ -92,12 +98,24 @@ namespace Raven.Client.Documents.Operations.Replication
             if (other is ExternalReplicationBase externalReplication)
             {
                 return string.Equals(ConnectionStringName, externalReplication.ConnectionStringName, StringComparison.OrdinalIgnoreCase) &&
-                       TaskId == externalReplication.TaskId &&
-                       string.Equals(externalReplication.Name, Name, StringComparison.OrdinalIgnoreCase) &&
-                       string.Equals(externalReplication.Database, Database, StringComparison.OrdinalIgnoreCase);
+                       string.Equals(externalReplication.Database, Database, StringComparison.OrdinalIgnoreCase) &&
+                       TaskId == externalReplication.TaskId;
             }
 
             return false;
+        }
+
+        public bool Equals(ExternalReplicationBase other) => IsEqualTo(other);
+        
+        public override bool Equals(object obj)
+        {
+            if (ReferenceEquals(null, obj))
+                return false;
+            if (ReferenceEquals(this, obj))
+                return true;
+            if (obj.GetType() != GetType())
+                return false;
+            return IsEqualTo((ExternalReplicationBase)obj);
         }
 
         public string GetMentorNode()

--- a/src/Raven.Client/Documents/Replication/ReplicationNode.cs
+++ b/src/Raven.Client/Documents/Replication/ReplicationNode.cs
@@ -87,7 +87,7 @@ namespace Raven.Client.Documents.Replication
 
         public override string ToString()
         {
-            var str = $"{Url} - {Database}";
+            var str = $"{FromString()}";
             if (Disabled)
                 str += " - DISABLED";
             return str;

--- a/src/Raven.Server/ServerWide/Commands/UpdateExternalReplicationCommand.cs
+++ b/src/Raven.Server/ServerWide/Commands/UpdateExternalReplicationCommand.cs
@@ -20,6 +20,8 @@ namespace Raven.Server.ServerWide.Commands
 
         public override string UpdateDatabaseRecord(DatabaseRecord record, long etag)
         {
+            Watcher.AssertValidReplication();
+
             if (Watcher == null)
                 return null;
 
@@ -30,7 +32,7 @@ namespace Raven.Server.ServerWide.Commands
             else
             {
                 //modified watcher, remove the old one
-                ExternalReplication.RemoveExternalReplication(record.ExternalReplications, Watcher.TaskId);
+                ExternalReplicationBase.RemoveExternalReplication(record.ExternalReplications, Watcher.TaskId);
             }
             //this covers the case of a new watcher and edit of an old watcher
             if (string.IsNullOrEmpty(Watcher.Name))

--- a/test/SlowTests/Server/Replication/ExternalReplicationTests.cs
+++ b/test/SlowTests/Server/Replication/ExternalReplicationTests.cs
@@ -6,10 +6,14 @@ using System.Threading.Tasks;
 using FastTests.Server.Replication;
 using Raven.Client.Documents;
 using Raven.Client.Documents.Operations;
+using Raven.Client.Documents.Operations.ConnectionStrings;
+using Raven.Client.Documents.Operations.ETL;
+using Raven.Client.Documents.Operations.OngoingTasks;
 using Raven.Client.Documents.Operations.Replication;
 using Raven.Client.ServerWide;
 using Raven.Client.ServerWide.Operations;
 using Raven.Server.Config;
+using Raven.Server.ServerWide.Commands;
 using Raven.Tests.Core.Utils.Entities;
 using Tests.Infrastructure;
 using Xunit;
@@ -121,6 +125,79 @@ namespace SlowTests.Server.Replication
                 Assert.True(WaitForDocument(store2, "foo/bar"));
                 var elapsedTime = DateTime.UtcNow - date;
                 Assert.True(elapsedTime >= delay && elapsedTime < elapsed, $" only {elapsed}/{delay} ticks elapsed");
+            }
+        }
+
+        [Fact]
+        public async Task CanChangeConnectionString()
+        {
+            using (var store1 = GetDocumentStore())
+            using (var store2 = GetDocumentStore())
+            {
+                var externalReplication = new ExternalReplication
+                {
+                    ConnectionStringName = "ExReplication"
+                };
+                await store1.Maintenance.SendAsync(new PutConnectionStringOperation<RavenConnectionString>(new RavenConnectionString
+                {
+                    Name = externalReplication.ConnectionStringName,
+                    Database = "NotExist",
+                    TopologyDiscoveryUrls = store1.Urls
+                }));
+                await store1.Maintenance.SendAsync(new UpdateExternalReplicationOperation(externalReplication));
+
+                using (var s1 = store1.OpenSession())
+                {
+                    s1.Store(new User(), "foo/bar");
+                    s1.SaveChanges();
+                }
+
+                Assert.False(WaitForDocument(store2, "foo/bar", timeout: 5_000));
+
+                await store1.Maintenance.SendAsync(new PutConnectionStringOperation<RavenConnectionString>(new RavenConnectionString
+                {
+                    Name = externalReplication.ConnectionStringName,
+                    Database = store2.Database,
+                    TopologyDiscoveryUrls = store1.Urls
+                }));
+
+                Assert.True(WaitForDocument(store2, "foo/bar", timeout: 5_000));
+
+                await store1.Maintenance.SendAsync(new PutConnectionStringOperation<RavenConnectionString>(new RavenConnectionString
+                {
+                    Name = externalReplication.ConnectionStringName,
+                    Database = "NotExist",
+                    TopologyDiscoveryUrls = store1.Urls
+                }));
+
+                using (var s1 = store1.OpenSession())
+                {
+                    s1.Store(new User(), "foo/bar/2");
+                    s1.SaveChanges();
+                }
+                Assert.False(WaitForDocument(store2, "foo/bar/2", timeout: 5_000));
+            }
+        }
+
+
+        [Fact]
+        public async Task ExternalReplicationToNonExistingDatabase()
+        {
+            using (var store1 = GetDocumentStore())
+            using (var store2 = GetDocumentStore())
+            {
+                var externalTask = new ExternalReplication(store2.Database + "test", $"Connection to {store2.Database} test");
+                await AddWatcherToReplicationTopology(store1, externalTask);
+            }
+        }
+
+        [Fact]
+        public async Task ExternalReplicationToNonExistingNode()
+        {
+            using (var store1 = GetDocumentStore())
+            {
+                var externalTask = new ExternalReplication(store1.Database + "test", $"Connection to {store1.Database} test");
+                await AddWatcherToReplicationTopology(store1, externalTask, new []{"http://1.2.3.4:8080"});
             }
         }
 

--- a/test/SlowTests/Server/Replication/PullReplicationTests.cs
+++ b/test/SlowTests/Server/Replication/PullReplicationTests.cs
@@ -288,7 +288,7 @@ namespace SlowTests.Server.Replication
             DebuggerAttachedTimeout.DisableLongTimespan = true;
 
             var definitionName = $"pull-replication {GetDatabaseName()}";
-            var timeout = 3_000;
+            var timeout = 10_000;
 
             using (var sink = GetDocumentStore())
             using (var hub = GetDocumentStore())

--- a/test/SlowTests/Server/Replication/ReplicationIndexesAndTransformers.cs
+++ b/test/SlowTests/Server/Replication/ReplicationIndexesAndTransformers.cs
@@ -141,9 +141,6 @@ namespace SlowTests.Server.Replication
                 var userByName = new UserByNameIndex();
                 userByName.Execute(source);
 
-
-                await SetupReplicationAsync(source, destination);
-
                 var sw = Stopwatch.StartNew();
                 var destIndexNames = new string[0];
                 var timeout = Debugger.IsAttached ? 60 * 1000000 : 3000;
@@ -156,6 +153,8 @@ namespace SlowTests.Server.Replication
                 Assert.Equal(2, destIndexNames.Length);
                 Assert.True(destIndexNames.Contains(userByAge.IndexName));
                 Assert.True(destIndexNames.Contains(userByName.IndexName));
+
+                WaitForUserToContinueTheTest(source);
             }
         }
     }

--- a/test/Tests.Infrastructure/TestBase.cs
+++ b/test/Tests.Infrastructure/TestBase.cs
@@ -529,6 +529,7 @@ namespace FastTests
 
                 configuration.SetSetting(RavenConfiguration.GetKey(x => x.Replication.ReplicationMinimalHeartbeat), "1");
                 configuration.SetSetting(RavenConfiguration.GetKey(x => x.Replication.RetryReplicateAfter), "3");
+                configuration.SetSetting(RavenConfiguration.GetKey(x => x.Replication.RetryMaxTimeout), "3");
                 configuration.SetSetting(RavenConfiguration.GetKey(x => x.Cluster.AddReplicaTimeout), "10");
 
                 if (options.CustomSettings != null)


### PR DESCRIPTION
- Impl Equals for external replicaiton so the HashSet will work as expected.
- Create a task for fetching the tcp info, since it is a blocking call (and we are under lock).
- Don't try to reconnect if the external replication was removed.
- Have a backoff upon error when fetching tcp info