### PR TITLE
RavenDB-14537 - Missing mapped reference document size in the stats

### DIFF
--- a/src/Raven.Server/Documents/Indexes/Workers/HandleReferences.cs
+++ b/src/Raven.Server/Documents/Indexes/Workers/HandleReferences.cs
@@ -194,6 +194,7 @@ namespace Raven.Server.Documents.Indexes.Workers
                                             collectionStats.RecordMapReferenceAttempt();
 
                                             var current = docsEnumerator.Current;
+                                            stats.RecordDocumentSize(current.Data.Size);
 
                                             if (indexWriter == null)
                                                 indexWriter = writeOperation.Value;


### PR DESCRIPTION
https://issues.hibernatingrhinos.com/issue/RavenDB-14537