### PR TITLE
RavenDB-14503 Handle stats for time-series

### DIFF
--- a/src/Raven.Client/Documents/Operations/TimeSeries/TimeSeriesStats.cs
+++ b/src/Raven.Client/Documents/Operations/TimeSeries/TimeSeriesStats.cs
@@ -4,6 +4,7 @@
 //  </copyright>
 // -----------------------------------------------------------------------
 
+using System;
 using System.Collections.Generic;
 using System.Linq;
 using Sparrow.Json.Parsing;
@@ -35,13 +36,17 @@ namespace Raven.Client.Documents.Operations.TimeSeries
     {
         public string Name { get; set; }
         public long NumberOfEntries { get; set; }
-        
+        public DateTime StartDate { get; set; }
+        public DateTime EndDate { get; set; }
+
         public DynamicJsonValue ToJson()
         {
             return new DynamicJsonValue
             {
                 [nameof(Name)] = Name,
-                [nameof(NumberOfEntries)] = NumberOfEntries
+                [nameof(NumberOfEntries)] = NumberOfEntries,
+                [nameof(StartDate)] = StartDate,
+                [nameof(EndDate)] = EndDate
             };
         }
         

--- a/src/Raven.Server/Documents/Handlers/TimeSeriesHandler.cs
+++ b/src/Raven.Server/Documents/Handlers/TimeSeriesHandler.cs
@@ -76,10 +76,9 @@ namespace Raven.Server.Documents.Handlers
                             writer.WriteComma();
                         }
                         first = false;
-                        
-                        var reader = Database.DocumentsStorage.TimeSeriesStorage.GetReader(context, documentId, tsName, DateTime.MinValue, DateTime.MaxValue);
-                        var entries = reader.GetNumberOfEntries();
-                        
+
+                        var stats = Database.DocumentsStorage.TimeSeriesStorage.GetStatsFor(context, documentId, tsName);
+
                         writer.WriteStartObject();
                         
                         writer.WritePropertyName(nameof(TimeSeriesItemDetail.Name));
@@ -88,8 +87,18 @@ namespace Raven.Server.Documents.Handlers
                         writer.WriteComma();
                         
                         writer.WritePropertyName(nameof(TimeSeriesItemDetail.NumberOfEntries));
-                        writer.WriteInteger(entries);
-                        
+                        writer.WriteInteger(stats.Count);
+
+                        writer.WriteComma();
+
+                        writer.WritePropertyName(nameof(TimeSeriesItemDetail.StartDate));
+                        writer.WriteDateTime(stats.Start, isUtc: true);
+
+                        writer.WriteComma();
+
+                        writer.WritePropertyName(nameof(TimeSeriesItemDetail.EndDate));
+                        writer.WriteDateTime(stats.End, isUtc: true);
+
                         writer.WriteEndObject();
                     }
                     

--- a/src/Raven.Server/Documents/TimeSeries/TimeSeriesValuesSegment.cs
+++ b/src/Raven.Server/Documents/TimeSeries/TimeSeriesValuesSegment.cs
@@ -82,6 +82,8 @@ namespace Raven.Server.Documents.TimeSeries
 
         public int NumberOfEntries => Header->NumberOfEntries;
 
+        public int NumberOfLiveEntries => SegmentValues.Span[0].Count;
+
         public void Initialize(int numberOfValues)
         {
             new Span<byte>(_buffer, _capacity).Clear();


### PR DESCRIPTION
- store the total count in a dedicated tree. So we can retrive it fast.
- lookup for the start/end date time