### PR TITLE
RavenDB-7070 fixing handing test on Linux (the path calculation was w…

### DIFF
--- a/test/SlowTests/Issues/RDBC-282.cs
+++ b/test/SlowTests/Issues/RDBC-282.cs
@@ -26,7 +26,7 @@ namespace SlowTests.Issues
         [Fact]
         public async Task ChangesApiShouldReconnectToServerWhenServerReturn()
         {
-            var server = GetNewServer(new ServerCreationOptions { RunInMemory = false, RegisterForDisposal = false});
+            var server = GetNewServer(new ServerCreationOptions { RunInMemory = false, RegisterForDisposal = false });
             try
             {
                 using (var store = GetDocumentStore(new Options { Server = server, Path = Path.Combine(server.Configuration.Core.DataDirectory.FullPath, "ChangesApiShouldReconnectToServerWhenServerReturn") }))
@@ -43,14 +43,13 @@ namespace SlowTests.Issues
                     var value = WaitForValue(() => list.Count, 1);
                     Assert.Equal(1, value);
                     var serverPath = server.Configuration.Core.DataDirectory.FullPath;
-                    var nodePath = serverPath.Split('/').Last();
                     var url = server.WebUrl;
                     await DisposeServerAndWaitForFinishOfDisposalAsync(server);
                     var settings = new Dictionary<string, string>
                     {
                         {RavenConfiguration.GetKey(x => x.Core.ServerUrls), url}
                     };
-                    server = GetNewServer(new ServerCreationOptions {RunInMemory= false, DeletePrevious = false, PartialPath = nodePath, CustomSettings = settings});
+                    server = GetNewServer(new ServerCreationOptions { RunInMemory = false, DeletePrevious = false, PartialPath = serverPath, CustomSettings = settings });
                     await taskObservable.EnsureConnectedNow();
                     PushUser(store);
                     value = WaitForValue(() => list.Count, 2);


### PR DESCRIPTION
…rong so we were creating a new server in a different path which caused changes to hang without end because node was passive)