### PR TITLE
RavenDB-14606 Switching ContextPool to per core model.  Removed some …

### DIFF
--- a/src/Raven.Server/Documents/Indexes/Index.cs
+++ b/src/Raven.Server/Documents/Indexes/Index.cs
@@ -991,8 +991,6 @@ namespace Raven.Server.Documents.Indexes
                     return; // can be null if we disposed immediately
                 try
                 {
-                    _contextPool.SetMostWorkInGoingToHappenOnThisThread();
-
                     DocumentDatabase.Changes.OnDocumentChange += HandleDocumentChange;
                     storageEnvironment.OnLogsApplied += HandleLogsApplied;
 

--- a/src/Raven.Server/ServerWide/Context/TransactionContextPool.cs
+++ b/src/Raven.Server/ServerWide/Context/TransactionContextPool.cs
@@ -15,16 +15,6 @@ namespace Raven.Server.ServerWide.Context
     {
         private StorageEnvironment _storageEnvironment;
 
-        // this is safe to do across instances, because all the pools in a thread are going to share
-        // the same optimizations
-        [ThreadStatic]
-        private static bool _mostlyThreadDedicatedWork;
-
-        public void SetMostWorkInGoingToHappenOnThisThread()
-        {
-            _mostlyThreadDedicatedWork = true;
-        }
-
         public TransactionContextPool(StorageEnvironment storageEnvironment)
         {
             _storageEnvironment = storageEnvironment;
@@ -40,14 +30,6 @@ namespace Raven.Server.ServerWide.Context
             else
             {
                 initialSize = 32*1024;
-
-                if (_mostlyThreadDedicatedWork)
-                {
-                    // if this is a context pool dedicated for a thread (like for indexes), we probably won't do a lot of 
-                    // work on that outside of its thread, so let not allocate a lot of memory for that. We just need enough
-                    // there process simple stuff like IsStale, etc, so let us start small
-                    initialSize = 16 * 1024 * 1024;  // the initial budget is 32 MB, so let us now blow through that all at once
-                }
             }
 
             return new TransactionOperationContext(_storageEnvironment, initialSize, 16*1024, LowMemoryFlag);

--- a/src/Raven.Server/Utils/PoolOfThreads.cs
+++ b/src/Raven.Server/Utils/PoolOfThreads.cs
@@ -193,7 +193,6 @@ namespace Raven.Server.Utils
                 {
                     Interlocked.Increment(ref _parent.TotalNumberOfThreads);
                     InitializeProcessThreads();
-                    JsonContextPoolWorkStealing.AvoidForCurrentThread = true;
 
                     LongRunningWork.CurrentPooledThread = this;
 


### PR DESCRIPTION
…behaviours that assume per thread model. We are now more consistent and conservative about how we retain memory and when we release it.