### PR TITLE
RavenDB-14530 - Unable to import data from 4.2 to 5.0

### DIFF
--- a/src/Raven.Server/Smuggler/Migration/Importer.cs
+++ b/src/Raven.Server/Smuggler/Migration/Importer.cs
@@ -82,6 +82,12 @@ namespace Raven.Server.Smuggler.Migration
                         smugglerResult.Counters = new SmugglerProgressBase.CountsWithLastEtag();
                     }
 
+                    if ((_buildVersion >= 40000 && _buildVersion < 50000) || (_buildVersion >= 40 && _buildVersion < 50))
+                    {
+                        // prevent NRE, time series were added in 5.0
+                        smugglerResult.TimeSeries = new SmugglerProgressBase.CountsWithLastEtag();
+                    }
+
                     var importInfo = new ImportInfo
                     {
                         LastEtag = smugglerResult.GetLastEtag() + 1,


### PR DESCRIPTION
https://issues.hibernatingrhinos.com/issue/RavenDB-14530