### PR TITLE
RavenDB-14555

### DIFF
--- a/src/Sparrow/Collections/LimitedConcurrentSet.cs
+++ b/src/Sparrow/Collections/LimitedConcurrentSet.cs
@@ -1,10 +1,9 @@
 ﻿using System.Collections.Concurrent;
 using System.Threading;
-using System.Transactions;
 
 namespace Sparrow.Collections
 {
-    public class LimitedConcurrentSet<T>
+    internal class LimitedConcurrentSet<T>
     {
         private readonly int _max;
         private int _count;

--- a/src/Sparrow/Logging/LogMessageEntry.cs
+++ b/src/Sparrow/Logging/LogMessageEntry.cs
@@ -1,13 +1,11 @@
 using System.Collections.Generic;
 using System.IO;
 using System.Net.WebSockets;
-using System.Threading;
 using System.Threading.Tasks;
-using Sparrow.Collections;
 
 namespace Sparrow.Logging
 {
-    public class LogMessageEntry
+    internal class LogMessageEntry
     {
         public MemoryStream Data;
         public TaskCompletionSource<object> Task;

--- a/src/Sparrow/Utils/CurrentProcessorIdHelper.cs
+++ b/src/Sparrow/Utils/CurrentProcessorIdHelper.cs
@@ -3,14 +3,14 @@ using System.Threading;
 
 namespace Sparrow.Utils
 {
-    public static class CurrentProcessorIdHelper
+    internal static class CurrentProcessorIdHelper
     {
         public static int GetCurrentProcessorId()
         {
-#if NETCOREAPP3_1
-            return Thread.GetCurrentProcessorId();
-#else
+#if NETSTANDARD2_0
             return Thread.CurrentThread.ManagedThreadId % Environment.ProcessorCount;
+#else
+            return Thread.GetCurrentProcessorId();
 #endif
         }
     }


### PR DESCRIPTION
- marking classes as internal
- only netstandard2.0 does not have Thread.GetCurrentProcessorId