### PR TITLE
RDBS-68 Prevent an attempt to create duplicated revision

### DIFF
--- a/src/Raven.Server/Documents/ConflictsStorage.cs
+++ b/src/Raven.Server/Documents/ConflictsStorage.cs
@@ -872,14 +872,42 @@ namespace Raven.Server.Documents
             else
                 return ConflictStatus.Update; //document with 'id' doesn't exist locally, so just do PUT
 
-            context.SkipChangeVectorValidation = context.DocumentDatabase.DocumentsStorage.TryRemoveUnusedIds(ref local);
-
-            status = ChangeVectorUtils.GetConflictStatus(changeVector, local);
+            status = GetConflictStatusForDocument(context, changeVector, local);
             if (status == ConflictStatus.Conflict)
             {
                 ConflictManager.AssertChangeVectorNotNull(local);
             }
             return status;
+        }
+
+        public static ConflictStatus GetConflictStatusForDocument(DocumentsOperationContext context, string remote, string local)
+        {
+            var originalStatus = ChangeVectorUtils.GetConflictStatus(remote, local);
+            if (originalStatus == ConflictStatus.Conflict && 
+                context.DocumentDatabase.DocumentsStorage.HasUnusedDatabaseIds())
+            {
+                // We need to distinguish between few cases here
+                // let's assume that node C was removed
+
+                // our local change vector is     A:10, B:10, C:10
+                // case 1: incoming change vector A:10, B:10, C:11  -> update           (original: update, after: already merged)
+                // case 2: incoming change vector A:11, B:10, C:10  -> update           (original: update, after: update)
+                // case 3: incoming change vector A:11, B:10        -> update           (original: conflict, after: update)
+                // case 4: incoming change vector A:10, B:10        -> already merged   (original: already merged, after: already merged)
+
+                // our local change vector is     A:11, B:10
+                // case 1: incoming change vector A:10, B:10, C:10 -> already merged        (original: conflict, after: already merged)        
+                // case 2: incoming change vector A:10, B:11, C:10 -> conflict              (original: conflict, after: conflict)
+                // case 3: incoming change vector A:11, B:10, C:10 -> update                (original: update, after: already merged)
+                // case 4: incoming change vector A:11, B:12, C:10 -> update                (original: conflict, after: update)
+
+                context.DocumentDatabase.DocumentsStorage.TryRemoveUnusedIds(ref remote);
+                context.SkipChangeVectorValidation = context.DocumentDatabase.DocumentsStorage.TryRemoveUnusedIds(ref local);
+
+                return ChangeVectorUtils.GetConflictStatus(remote, local);
+            }
+
+            return originalStatus;
         }
 
         public long GetNumberOfDocumentsConflicts(DocumentsOperationContext context)

--- a/src/Raven.Server/Documents/DocumentsStorage.cs
+++ b/src/Raven.Server/Documents/DocumentsStorage.cs
@@ -361,6 +361,15 @@ namespace Raven.Server.Documents
 
         internal HashSet<string> UnusedDatabaseIds;
 
+        public bool HasUnusedDatabaseIds()
+        {
+            var list = UnusedDatabaseIds;
+            if (list == null || list.Count == 0)
+                return false;
+
+            return true;
+        }
+
         public bool TryRemoveUnusedIds(ref string changeVector)
         {
             if (string.IsNullOrEmpty(changeVector))

--- a/src/Raven.Server/Documents/Replication/ConflictManager.cs
+++ b/src/Raven.Server/Documents/Replication/ConflictManager.cs
@@ -33,7 +33,6 @@ namespace Raven.Server.Documents.Replication
             long lastModifiedTicks,
             BlittableJsonReaderObject doc,
             string changeVector,
-            string conflictedChangeVector,
             DocumentFlags flags)
         {
             if (id.StartsWith(HiLoHandler.RavenHiloIdPrefix, StringComparison.OrdinalIgnoreCase))
@@ -74,10 +73,6 @@ namespace Raven.Server.Documents.Replication
 
                 if (_conflictResolver.ConflictSolver?.ResolveToLatest ?? true)
                 {
-                    if (conflictedChangeVector == null) //precaution
-                        throw new InvalidOperationException(
-                            "Detected conflict on replication, but could not figure out conflicted vector. This is not supposed to happen and is likely a bug.");
-
                     var conflicts = new List<DocumentConflict>
                     {
                         conflictedDoc.Clone()
@@ -97,6 +92,13 @@ namespace Raven.Server.Documents.Replication
 
                 _database.DocumentsStorage.ConflictsStorage.AddConflict(documentsContext, id, lastModifiedTicks, doc, changeVector, collection, flags);
             }
+        }
+
+        public static void AssertChangeVectorNotNull(string conflictedChangeVector)
+        {
+            if (conflictedChangeVector == null) //precaution
+                throw new InvalidOperationException(
+                    "Detected conflict on replication, but could not figure out conflicted vector. This is not supposed to happen and is likely a bug.");
         }
 
         private bool TryResolveConflictByScript(

--- a/src/Raven.Server/Documents/Replication/IncomingReplicationHandler.cs
+++ b/src/Raven.Server/Documents/Replication/IncomingReplicationHandler.cs
@@ -1365,8 +1365,7 @@ namespace Raven.Server.Documents.Replication
                                 }
 
                                 var hasRemoteClusterTx = item.Flags.Contain(DocumentFlags.FromClusterTransaction);
-                                var conflictStatus = ConflictsStorage.GetConflictStatusForDocument(context, item.Id, item.ChangeVector, out var conflictingVector,
-                                    out var hasLocalClusterTx);
+                                var conflictStatus = ConflictsStorage.GetConflictStatusForDocument(context, item.Id, item.ChangeVector, out var hasLocalClusterTx);
 
                                 var flags = item.Flags;
                                 var resolvedDocument = document;
@@ -1438,8 +1437,7 @@ namespace Raven.Server.Documents.Replication
                                             // that we need to distribute to our siblings
                                             IsIncomingReplication = false;
                                             _replicationInfo.ConflictManager.HandleConflictForDocument(context, item.Id, item.Collection, item.LastModifiedTicks,
-                                                document,
-                                                    rcvdChangeVector, conflictingVector, item.Flags);
+                                                document, rcvdChangeVector, item.Flags);
                                         }
 
                                         break;

--- a/src/Raven.Server/Documents/Revisions/RevisionsStorage.cs
+++ b/src/Raven.Server/Documents/Revisions/RevisionsStorage.cs
@@ -373,6 +373,9 @@ namespace Raven.Server.Documents.Revisions
 
                 PutFromRevisionIfChangeVectorIsGreater(context, document, id, changeVector, lastModifiedTicks, flags, nonPersistentFlags);
 
+                if (table.VerifyKeyExists(changeVectorSlice)) // we might create
+                    return true; 
+
                 flags |= DocumentFlags.Revision;
                 var etag = _database.DocumentsStorage.GenerateNextEtag();
                 var newEtagSwapBytes = Bits.SwapBytes(etag);

--- a/src/Raven.Server/Documents/Revisions/RevisionsStorage.cs
+++ b/src/Raven.Server/Documents/Revisions/RevisionsStorage.cs
@@ -459,7 +459,7 @@ namespace Raven.Server.Documents.Revisions
 
             using (DocumentIdWorker.GetLowerIdSliceAndStorageKey(context, id, out var lowerId, out _))
             {
-                var conflictStatus = ConflictsStorage.GetConflictStatusForDocument(context, id, changeVector, out _, out _);
+                var conflictStatus = ConflictsStorage.GetConflictStatusForDocument(context, id, changeVector, out _);
                 if (conflictStatus != ConflictStatus.Update)
                     return; // Do not modify the document.
 

--- a/test/FastTests/Server/Replication/ReplicationTestBase.cs
+++ b/test/FastTests/Server/Replication/ReplicationTestBase.cs
@@ -35,18 +35,7 @@ namespace FastTests.Server.Replication
         public ReplicationTestBase(ITestOutputHelper output) : base(output)
         {
         }
-        
-        protected void EnsureReplicating(DocumentStore src, DocumentStore dst)
-        {
-            var id = "marker/" + Guid.NewGuid();
-            using (var s = src.OpenSession())
-            {
-                s.Store(new { }, id);
-                s.SaveChanges();
-            }
-            Assert.NotNull(WaitForDocumentToReplicate<object>(dst, id, 15 * 1000));
-        }
-
+       
         protected Dictionary<string, string[]> GetConnectionFailures(DocumentStore store)
         {
             using (var commands = store.Commands())
@@ -153,24 +142,6 @@ namespace FastTests.Server.Replication
 
                 return command.Result;
             }
-        }
-
-        protected T WaitForDocumentToReplicate<T>(IDocumentStore store, string id, int timeout)
-            where T : class
-        {
-            var sw = Stopwatch.StartNew();
-            while (sw.ElapsedMilliseconds <= timeout)
-            {
-                using (var session = store.OpenSession(store.Database))
-                {
-                    var doc = session.Load<T>(id);
-                    if (doc != null)
-                        return doc;
-                }
-                Thread.Sleep(100);
-            }
-
-            return null;
         }
 
         protected T WaitForDocumentWithAttachmentToReplicate<T>(IDocumentStore store, string id, string attachmentName, int timeout)

--- a/test/RachisTests/DatabaseCluster/ClusterDatabaseMaintenance.cs
+++ b/test/RachisTests/DatabaseCluster/ClusterDatabaseMaintenance.cs
@@ -6,6 +6,7 @@ using System.Linq;
 using System.Threading;
 using System.Threading.Tasks;
 using FastTests;
+using Microsoft.CodeAnalysis.CSharp;
 using Raven.Client.Documents;
 using Raven.Client.Documents.Conventions;
 using Raven.Client.Documents.Indexes;
@@ -15,6 +16,7 @@ using Raven.Client.ServerWide;
 using Raven.Client.ServerWide.Operations;
 using Raven.Client.ServerWide.Operations.Certificates;
 using Raven.Client.Util;
+using Raven.Server;
 using Raven.Server.Config;
 using Raven.Server.Config.Categories;
 using Raven.Server.Documents;
@@ -1234,6 +1236,108 @@ namespace RachisTests.DatabaseCluster
                 var rev = await session.Advanced.Revisions.GetMetadataForAsync("foo/bar");
                 Assert.Equal(0, rev.Count);
             }
+        }
+
+        [Fact]
+        public async Task HandleConflictShouldTakeUnusedDatabasesIntoAccount2()
+        {
+            var database = GetDatabaseName();
+            var cluster = await CreateRaftCluster(3, watcherCluster: true);
+            var databaseResult = await CreateDatabaseInCluster(database, 3, cluster.Leader.WebUrl);
+
+            using var store1 = new DocumentStore
+            {
+                Database = database,
+                Urls = new[] { cluster.Nodes[0].WebUrl },
+                Conventions = new DocumentConventions
+                {
+                    DisableTopologyUpdates = true
+                }
+            }.Initialize();
+
+            using var store2 = new DocumentStore
+            {
+                Database = database,
+                Urls = new[] { cluster.Nodes[1].WebUrl },
+                Conventions = new DocumentConventions
+                {
+                    DisableTopologyUpdates = true
+                }
+            }.Initialize();
+
+            using var store3 = new DocumentStore
+            {
+                Database = database,
+                Urls = new[] { cluster.Nodes[2].WebUrl },
+                Conventions = new DocumentConventions
+                {
+                    DisableTopologyUpdates = true
+                }
+            }.Initialize();
+            
+            
+            var allStores = new [] {(DocumentStore)store1, (DocumentStore)store2, (DocumentStore)store3};
+            var toDelete = cluster.Nodes.First(n => n != cluster.Leader);
+            var toBeDeletedStore = allStores.Single(s => s.Urls[0] == toDelete.WebUrl);
+            var nonDeletedStores = allStores.Where(s => s.Urls[0] != toDelete.WebUrl).ToArray();
+            var nonDeletedNodes = cluster.Nodes.Where(n => n.ServerStore.NodeTag != toDelete.ServerStore.NodeTag).ToArray();
+            var deletedNode = cluster.Nodes.Single(n => n.ServerStore.NodeTag == toDelete.ServerStore.NodeTag);
+
+            var deletedStorage = await deletedNode.ServerStore.DatabasesLandlord.TryGetOrCreateResourceStore(database);
+            var mre = new ManualResetEventSlim(false);
+            deletedStorage.ReplicationLoader.DebugWaitAndRunReplicationOnce = mre;
+
+            var nonDeletedStorage1 = await nonDeletedNodes[0].ServerStore.DatabasesLandlord.TryGetOrCreateResourceStore(database);
+            var mre1 = new ManualResetEventSlim(false);
+            nonDeletedStorage1.ReplicationLoader.DebugWaitAndRunReplicationOnce = mre1;
+
+            var nonDeletedStorage2 = await nonDeletedNodes[1].ServerStore.DatabasesLandlord.TryGetOrCreateResourceStore(database);
+            var mre2 = new ManualResetEventSlim(false);
+            nonDeletedStorage2.ReplicationLoader.DebugWaitAndRunReplicationOnce = mre2;
+
+            using (var session = nonDeletedStores[0].OpenAsyncSession())
+            {
+                await session.StoreAsync(new User {Name = "Karmel"}, "foo/bar");
+                await session.SaveChangesAsync();
+            }
+
+            using (var session = toBeDeletedStore.OpenAsyncSession())
+            {
+                await session.StoreAsync(new User{Name = "Karmel2"}, "foo/bar");
+                await session.SaveChangesAsync();
+            }
+
+
+            using (var session = toBeDeletedStore.OpenSession())
+            {
+                var t = WaitForDocumentInClusterAsync<User>((DocumentSession)session, "foo/bar", u => u.Name == "Karmel2", TimeSpan.FromSeconds(15));
+
+                while (t.IsCompleted == false)
+                {
+                    mre.Set();
+                    await Task.Delay(250);
+                }
+
+                await t;
+            }
+
+            var deleteResult = await nonDeletedStores[0].Maintenance.Server.SendAsync(new DeleteDatabasesOperation(database, hardDelete: true, fromNode: toDelete.ServerStore.NodeTag, timeToWaitForConfirmation: TimeSpan.FromSeconds(15)));
+
+            await Task.WhenAll(nonDeletedNodes.Select(n =>
+                n.ServerStore.WaitForCommitIndexChange(RachisConsensus.CommitIndexModification.GreaterOrEqual, deleteResult.RaftCommandIndex + 1)));
+
+            var record = await nonDeletedStores[0].Maintenance.Server.SendAsync(new GetDatabaseRecordOperation(database));
+            Assert.Equal(1, record.UnusedDatabaseIds.Count);
+
+            nonDeletedStorage2.ReplicationLoader.DebugWaitAndRunReplicationOnce = null;
+            nonDeletedStorage1.ReplicationLoader.DebugWaitAndRunReplicationOnce = null;
+
+            mre1.Set();
+            mre2.Set();
+
+            await Task.Delay(1000);
+            EnsureReplicating(nonDeletedStores[0], nonDeletedStores[1]);
+            EnsureReplicating(nonDeletedStores[1], nonDeletedStores[0]);
         }
 
         [Fact]


### PR DESCRIPTION
If the incoming revision and the document are the same, but has an entry in the change vector that is unused _and_ it has a resolved flag.
We would try to double keep a revision with the same change vector