### PR TITLE
RavenDB-13765: Recover datafile into recovered database

### DIFF
--- a/test/SlowTests/Issues/RavenDB-8451.cs
+++ b/test/SlowTests/Issues/RavenDB-8451.cs
@@ -69,8 +69,7 @@ namespace SlowTests.Issues
                 store.Maintenance.Send(new CreateSampleDataOperation());
                 databaseStatistics = store.Maintenance.Send(new GetStatisticsOperation());
 
-                var _ = store.Maintenance.Server.Send(new CreateDatabaseOperation(new DatabaseRecord {DatabaseName = recoverDbName}));
-
+                store.Maintenance.Server.Send(new CreateDatabaseOperation(new DatabaseRecord {DatabaseName = recoverDbName}));
 
                 var recoveredDatabase = await GetDatabase(recoverDbName);
                 using (var recovery = new Recovery(new VoronRecoveryConfiguration()
@@ -93,7 +92,7 @@ namespace SlowTests.Issues
                 AdminCertificate = certificates.ServerCertificate.Value,
                 ClientCertificate = certificates.ServerCertificate.Value,
             }))
-            using (var __ = EnsureDatabaseDeletion(recoverDbName, store))
+            using (EnsureDatabaseDeletion(recoverDbName, store))
             {
                 var currentStats = store.Maintenance.ForDatabase(recoverDbName).Send(new GetStatisticsOperation());
 

--- a/test/SlowTests/Issues/RavenDB_11904.cs
+++ b/test/SlowTests/Issues/RavenDB_11904.cs
@@ -40,7 +40,7 @@ namespace SlowTests.Issues
                 store.Maintenance.Send(new CreateSampleDataOperation());
                 databaseStatistics = store.Maintenance.Send(new GetStatisticsOperation());
 
-                var _ = store.Maintenance.Server.Send(new CreateDatabaseOperation(new DatabaseRecord {DatabaseName = recoverDbName}));
+                store.Maintenance.Server.Send(new CreateDatabaseOperation(new DatabaseRecord {DatabaseName = recoverDbName}));
 
                 journals = new DirectoryInfo(Path.Combine(dbPath, "Journals")).GetFiles();
 
@@ -80,7 +80,7 @@ namespace SlowTests.Issues
             // let's import the recovery files
 
             using (var store = GetDocumentStore())
-            using (var __ = EnsureDatabaseDeletion(recoverDbName, store))
+            using (EnsureDatabaseDeletion(recoverDbName, store))
             {
                 var currentStats = store.Maintenance.ForDatabase(recoverDbName).Send(new GetStatisticsOperation());
 

--- a/test/SlowTests/Issues/RavenDB_11904.cs
+++ b/test/SlowTests/Issues/RavenDB_11904.cs
@@ -5,7 +5,6 @@ using System.Threading;
 using System.Threading.Tasks;
 using FastTests;
 using Raven.Client.Documents.Operations;
-using Raven.Client.Documents.Smuggler;
 using Raven.Client.ServerWide;
 using Raven.Client.ServerWide.Operations;
 using Tests.Infrastructure;

--- a/test/SlowTests/Issues/RavenDB_11905.cs
+++ b/test/SlowTests/Issues/RavenDB_11905.cs
@@ -32,7 +32,7 @@ namespace SlowTests.Issues
                 Path = dbPath
             }))
             {
-                var _ = store.Maintenance.Server.Send(new CreateDatabaseOperation(new DatabaseRecord {DatabaseName = recoverDbName}));
+                store.Maintenance.Server.Send(new CreateDatabaseOperation(new DatabaseRecord {DatabaseName = recoverDbName}));
             }
 
             var recoveredDatabase = await GetDatabase(recoverDbName);
@@ -49,7 +49,7 @@ namespace SlowTests.Issues
             }
             
             using (var store = GetDocumentStore())
-            using (var __ = EnsureDatabaseDeletion(recoverDbName, store))
+            using (EnsureDatabaseDeletion(recoverDbName, store))
             {
                 var databaseStatistics = store.Maintenance.Send(new GetStatisticsOperation());
 

--- a/test/SlowTests/Issues/RavenDB_11905.cs
+++ b/test/SlowTests/Issues/RavenDB_11905.cs
@@ -41,7 +41,7 @@ namespace SlowTests.Issues
                 LoggingMode = Sparrow.Logging.LogMode.None,
                 DataFileDirectory = dbPath,
                 PathToDataFile = Path.Combine(dbPath, "Raven.voron"),
-                OutputFileName = Path.Combine(recoveryExportPath, "recovery.ravendump"),
+                LoggingOutputPath = Path.Combine(recoveryExportPath, "recovery.ravendump"),
                 RecoveredDatabase = recoveredDatabase
             }))
             {

--- a/test/SlowTests/Issues/RavenDB_11905.cs
+++ b/test/SlowTests/Issues/RavenDB_11905.cs
@@ -41,7 +41,7 @@ namespace SlowTests.Issues
                 LoggingMode = Sparrow.Logging.LogMode.None,
                 DataFileDirectory = dbPath,
                 PathToDataFile = Path.Combine(dbPath, "Raven.voron"),
-                LoggingOutputPath = Path.Combine(recoveryExportPath, "recovery.ravendump"),
+                LoggingOutputPath = Path.Combine(recoveryExportPath),
                 RecoveredDatabase = recoveredDatabase
             }))
             {
@@ -49,14 +49,8 @@ namespace SlowTests.Issues
             }
             
             using (var store = GetDocumentStore())
+            using (var __ = EnsureDatabaseDeletion(recoverDbName, store))
             {
-                var op = await store.Smuggler.ImportAsync(new DatabaseSmugglerImportOptions()
-                {
-
-                }, Path.Combine(recoveryExportPath, "recovery-2-Documents.ravendump"));
-
-                op.WaitForCompletion(TimeSpan.FromMinutes(2));
-
                 var databaseStatistics = store.Maintenance.Send(new GetStatisticsOperation());
 
                 Assert.Equal(0, databaseStatistics.CountOfAttachments);

--- a/test/SlowTests/Voron/RecoveryTest.cs
+++ b/test/SlowTests/Voron/RecoveryTest.cs
@@ -181,8 +181,8 @@ namespace SlowTests.Voron
             Assert.True(flushed, "Test requires successful flush to log");
 
             string recoverDbName = $"RecoverDB_{Guid.NewGuid().ToString()}";
-            var _ = store.Maintenance.Server.Send(new CreateDatabaseOperation(new DatabaseRecord {DatabaseName = recoverDbName}));
-            using var x = EnsureDatabaseDeletion(recoverDbName, store);
+            store.Maintenance.Server.Send(new CreateDatabaseOperation(new DatabaseRecord {DatabaseName = recoverDbName}));
+            using var _ = EnsureDatabaseDeletion(recoverDbName, store);
             using var recoveredDatabase = await GetDatabase(recoverDbName);
 
             // run recovery

--- a/test/SlowTests/Voron/RecoveryTest.cs
+++ b/test/SlowTests/Voron/RecoveryTest.cs
@@ -1,0 +1,274 @@
+using System;
+using System.Collections.Generic;
+using System.IO;
+using System.Linq;
+using System.Text;
+using System.Threading;
+using System.Threading.Tasks;
+using FastTests.Server.Replication;
+using FastTests.Utils;
+using Raven.Client.ServerWide;
+using Raven.Client.ServerWide.Operations;
+using Sparrow.Logging;
+using Tests.Infrastructure;
+using Voron;
+using Voron.Recovery;
+using Xunit;
+using Xunit.Abstractions;
+
+namespace SlowTests.Voron
+{
+    public class RecoveryTest : ReplicationTestBase
+    {
+        public RecoveryTest(ITestOutputHelper output) : base(output)
+        { }
+
+        private class Entity
+        {
+            public string Name;
+            public int Number;
+        }
+
+        [Fact64Bit]
+        public async Task FullRecoverDatabaseWithDocsRevsAttachmentsCountersConflicts()
+        {
+            var rnd = new Random(123);
+            var dbPath = NewDataPath(prefix: Guid.NewGuid().ToString());
+            using var store = GetDocumentStore(new Options()
+            {
+                Path = dbPath,
+                ModifyDatabaseRecord = record =>
+                {
+                    record.ConflictSolverConfig = new ConflictSolver
+                    {
+                        ResolveToLatest = false,
+                        ResolveByCollection = new Dictionary<string, ScriptResolver>()
+                    };
+                }
+            });
+
+            var database = await GetDocumentDatabaseInstanceFor(store, store.Database);
+            var type = database.GetAllStoragesEnvironment().Single(t => t.Type == StorageEnvironmentWithType.StorageEnvironmentType.Documents);
+            var env = type.Environment;
+            env.Options.ManualFlushing = true;
+
+            using (var session = store.OpenSession())
+            {
+                session.Store(new Entity {Name = "Simple Document", Number = 1}, "doc/1");
+                session.Store(new Entity {Name = "Simple with Attachment", Number = 2}, "doc/2");
+                session.SaveChanges();
+            }
+
+            await RevisionsHelper.SetupRevisions(Server.ServerStore, store.Database);
+
+            using (var session = store.OpenSession())
+            {
+                session.Store(new Entity {Name = "Simple with Attachments and will have revisions", Number = 3}, "doc/3");
+                session.Store(new Entity {Name = "Simple with Overlapping Attachments and will have revisions", Number = 4}, "doc/4");
+                session.Store(new Entity {Name = "Will be conflicted document", Number = 5}, "doc/5");
+                session.Store(new Entity {Name = "Contains Counters", Number = 6}, "doc/6");
+                session.SaveChanges();
+            }
+
+            var files = new List<string>();
+            var randomArray = new byte[4096];
+            for (int i = 0; i < 10; i++)
+            {
+                var file = Path.GetTempFileName();
+                if (File.Exists(file))
+                    File.Delete(file);
+                File.WriteAllText(file, "This is a test file " + Guid.NewGuid() + Environment.NewLine);
+                await using (var stream = File.AppendText(file))
+                {
+                    for (int j = 0; j < rnd.Next(1, 20); j++)
+                    {
+                        rnd.NextBytes(randomArray);
+                        stream.Write(Encoding.UTF8.GetString(randomArray, 0, 4096 - rnd.Next(0, 25)));
+                    }
+
+                    stream.Flush();
+                }
+
+                files.Add(file);
+            }
+
+            var fileItem = files.ToArray();
+            await using (var fs = File.Open(fileItem[0], FileMode.Open))
+            using (var session = store.OpenSession())
+            {
+                session.Advanced.Attachments.Store("doc/2", "testAttachment.txt", fs, "text/txt");
+                session.SaveChanges();
+            }
+
+            for (int i = 1; i <= 6; i++)
+            {
+                await using (var fs = File.Open(fileItem[i], FileMode.Open))
+                using (var session = store.OpenSession())
+                {
+                    var entity = session.Load<Entity>("doc/3");
+                    entity.Number = 10 + i;
+                    session.Store(entity);
+                    var filename = "samefilename.txt";
+                    if (i == 3)
+                        filename = "differentfilename.txt";
+                    session.Advanced.Attachments.Store("doc/3", filename, fs, "text/txt");
+                    session.SaveChanges();
+                }
+            }
+
+            for (int i = 7; i < 12; i++)
+            {
+                var j = i - ((i >= 10) ? 3 : 0); // duplicate some files
+                await using (var fs = File.Open(fileItem[j], FileMode.Open))
+                using (var session = store.OpenSession())
+                {
+                    var entity = session.Load<Entity>("doc/4");
+                    entity.Number = 10 + i;
+                    session.Store(entity);
+                    var filename = "samefilename.txt";
+                    if (j == 9)
+                        filename = "differentfilename.txt";
+                    session.Advanced.Attachments.Store("doc/4", filename, fs, "text/txt");
+                    session.SaveChanges();
+                }
+            }
+
+            using var conflictingStore = GetDocumentStore(new Options()
+            {
+                Path = NewDataPath(prefix: Guid.NewGuid().ToString()),
+                ModifyDatabaseRecord = record =>
+                {
+                    record.ConflictSolverConfig = new ConflictSolver {ResolveToLatest = false, ResolveByCollection = new Dictionary<string, ScriptResolver>()};
+                }
+            });
+            using (var session = conflictingStore.OpenSession())
+            {
+                session.Store(new Entity {Name = "Conflicting doc", Number = 101}, "doc/5");
+                session.Store(new Entity {Name = "ReplicationMarker", Number = 123}, "replicateMarker/1");
+                session.SaveChanges();
+            }
+
+            using (var session = store.OpenSession())
+            {
+                var entity = session.Load<Entity>("doc/5");
+
+                entity.Number = 100;
+
+                session.SaveChanges();
+            }
+
+            using (var session = store.OpenSession())
+            {
+                session.CountersFor("doc/6").Increment("testCounter");
+                session.SaveChanges();
+
+                session.CountersFor("doc/6").Increment("testCounter");
+                session.SaveChanges();
+            }
+
+            await SetupReplicationAsync(conflictingStore, store);
+            await SetupReplicationAsync(store, conflictingStore);
+
+            Assert.True(WaitForDocument(store, "replicateMarker/1"));
+
+
+            var flushed = false;
+            env.OnLogsApplied += () =>
+            {
+                flushed = true;
+            };
+            env.FlushLogToDataFile();
+            Assert.True(flushed, "Test requires successful flush to log");
+
+            string recoverDbName = $"RecoverDB_{Guid.NewGuid().ToString()}";
+            var _ = store.Maintenance.Server.Send(new CreateDatabaseOperation(new DatabaseRecord {DatabaseName = recoverDbName}));
+            using var recoveredDatabase = await GetDatabase(recoverDbName);
+
+            // run recovery
+            var recoveryExportPath = NewDataPath(prefix: Guid.NewGuid().ToString());
+            using (var recovery = new global::Voron.Recovery.Recovery(new VoronRecoveryConfiguration()
+            {
+                LoggingMode = LogMode.None,
+                DataFileDirectory = dbPath,
+                PathToDataFile = Path.Combine(dbPath, "Raven.voron"),
+                OutputFileName = Path.Combine(recoveryExportPath, "recovery.ravendump"),
+                RecoveredDatabase = recoveredDatabase
+            }))
+            {
+                var result = recovery.Execute(TextWriter.Null, CancellationToken.None);
+            }
+
+            using (var recoveredSession = store.OpenSession(recoverDbName))
+            {
+                var doc1 = recoveredSession.Load<Entity>("doc/1");
+                var doc2 = recoveredSession.Load<Entity>("doc/2");
+                var doc3 = recoveredSession.Load<Entity>("doc/3");
+                var doc4 = recoveredSession.Load<Entity>("doc/4");
+                var doc6 = recoveredSession.Load<Entity>("doc/6");
+                Assert.Throws<Raven.Client.Exceptions.Documents.DocumentConflictException>(() =>
+                {
+                    var doc5 = recoveredSession.Load<Entity>("doc/5");
+                });
+                var msg = "Failed to recover specific document: ";
+                Assert.True(doc1 != null, $"{msg}doc/1");
+                Assert.True(doc2 != null, $"{msg}doc/2");
+                Assert.True(doc3 != null, $"{msg}doc/3");
+                Assert.True(doc4 != null, $"{msg}doc/4");
+                Assert.True(doc6 != null, $"{msg}doc/6");
+
+
+                msg = "Invalid doc content: ";
+                Assert.True("Simple Document".Equals(doc1.Name), $"{msg}doc/1");
+                Assert.True("Simple with Attachment".Equals(doc2.Name), $"{msg}doc/2");
+                Assert.True("Simple with Attachments and will have revisions".Equals(doc3.Name), $"{msg}doc/3");
+                Assert.True("Simple with Overlapping Attachments and will have revisions".Equals(doc4.Name), $"{msg}doc/4");
+                Assert.True("Contains Counters".Equals(doc6.Name), $"{msg}doc/6");
+                Assert.True(doc1.Number == 1, $"{msg}doc/1");
+                Assert.True(doc2.Number == 2, $"{msg}doc/2");
+                Assert.True(doc3.Number == 16, $"{msg}doc/3");
+                Assert.True(doc4.Number == 21, $"{msg}doc/4");
+
+                var revisions1 = recoveredSession.Advanced.Revisions.GetFor<Entity>("doc/1");
+                var revisions2 = recoveredSession.Advanced.Revisions.GetFor<Entity>("doc/2");
+                var revisions3 = recoveredSession.Advanced.Revisions.GetFor<Entity>("doc/3");
+                var revisions4 = recoveredSession.Advanced.Revisions.GetFor<Entity>("doc/4");
+
+                msg = "Invalid number of revisions for: ";
+                // because of the nature of recovery (stripping attachments, storing, and then reattaching) we may find more revisions then in the original db
+                Assert.True(revisions1?.Count == 0, $"{msg}doc/1");
+                Assert.True(revisions2?.Count >= 2, $"{msg}doc/2");
+                Assert.True(revisions3?.Count >= 5, $"{msg}doc/3");
+                Assert.True(revisions4?.Count >= 5, $"{msg}doc/4");
+
+                msg = "Couldn't get recovered attachment: ";
+                var attachment1 = recoveredSession.Advanced.Attachments.GetNames(doc1);
+                var attachment2 = recoveredSession.Advanced.Attachments.GetNames(doc2);
+                var attachment3 = recoveredSession.Advanced.Attachments.GetNames(doc3);
+                var attachment4 = recoveredSession.Advanced.Attachments.GetNames(doc4);
+                Assert.True(attachment1?.Length == 0, $"{msg}doc/1, count={attachment1?.Length}");
+                Assert.True(attachment2?.Length == 1, $"{msg}doc/2, count={attachment2?.Length}");
+                Assert.True(attachment3?.Length == 2, $"{msg}doc/3, count={attachment3?.Length}");
+                Assert.True(attachment4?.Length == 2, $"{msg}doc/4, count={attachment4?.Length}");
+
+                var counter6 = recoveredSession.CountersFor("doc/6")?.Get("testCounter");
+                Assert.NotNull(counter6);
+                Assert.Equal(counter6, 2L);
+            }
+
+
+            // we perform again the recovery just in order to cover some code that usually isn't covered in recover process 'alreadyExistingAttachments.Count > 0' @ void WriteDocumentInternal(Document document, IDocumentActions actions)
+            using var recoveredDatabase2 = await GetDatabase(recoverDbName);
+            using (var recovery = new global::Voron.Recovery.Recovery(new VoronRecoveryConfiguration()
+            {
+                LoggingMode = LogMode.None,
+                DataFileDirectory = dbPath,
+                PathToDataFile = Path.Combine(dbPath, "Raven.voron"),
+                OutputFileName = Path.Combine(recoveryExportPath, "recovery.ravendump"),
+                RecoveredDatabase = recoveredDatabase2
+            }))
+            {
+                var result = recovery.Execute(TextWriter.Null, CancellationToken.None);
+            }
+        }
+    }
+}

--- a/tools/Voron.Recovery/DocumentItemsRecovery.cs
+++ b/tools/Voron.Recovery/DocumentItemsRecovery.cs
@@ -1,0 +1,147 @@
+using System.IO;
+using Raven.Client.Documents.Operations.Counters;
+using Raven.Server.Documents;
+using Raven.Server.ServerWide.Context;
+using Raven.Server.Smuggler.Documents;
+using Sparrow.Json;
+using Sparrow.Json.Parsing;
+using Raven.Client.Documents.Smuggler;
+using Raven.Client.Extensions;
+using Sparrow.Logging;
+using Voron.Data;
+
+
+namespace Voron.Recovery
+{
+    public static class DocumentItemsRecovery
+    {
+        public static void WriteCounterItem(CounterGroupDetail counterGroupDetail, DocumentDatabase database, DatabaseDestination databaseDestination, string orphanCountersDocIdPrefix,
+            DocumentsOperationContext context, SmugglerResult results, string recoveryLogCollection, Slice attachmentSlice,
+            string logDocId, Logger logger, bool skipDocExistence = false)
+        {
+            if (skipDocExistence == false)
+            {
+                using (var tx = context.OpenWriteTransaction())
+                {
+                    using (var originalDoc = database.DocumentsStorage.Get(context, counterGroupDetail.DocumentId))
+                    {
+                        if (originalDoc == null)
+                        {
+                            var orphanDocId = $"{orphanCountersDocIdPrefix}/{counterGroupDetail.DocumentId}";
+                            using (var orphanDoc = database.DocumentsStorage.Get(context, orphanDocId))
+                            {
+                                if (orphanDoc == null)
+                                {
+                                    using (var doc = context.ReadObject(
+                                        new DynamicJsonValue
+                                        {
+                                            [nameof(RecoveryConstants.OriginalDocId)] = counterGroupDetail.DocumentId.ToString(),
+                                            [Raven.Client.Constants.Documents.Metadata.Key] = new DynamicJsonValue
+                                            {
+                                                [Raven.Client.Constants.Documents.Metadata.Collection] = recoveryLogCollection
+                                            }
+                                        }, orphanDocId, BlittableJsonDocumentBuilder.UsageMode.ToDisk))
+                                    {
+                                        database.DocumentsStorage.Put(context, orphanDocId, null, doc);
+                                    }
+                                }
+
+                                counterGroupDetail.DocumentId.Dispose();
+                                counterGroupDetail.DocumentId = context.GetLazyString(orphanDocId);
+
+                                tx.Commit();
+                            }
+                        }
+                    }
+                }
+            }
+
+            using var actions = databaseDestination.Counters(results);
+            actions.WriteCounter(counterGroupDetail);
+        }
+
+        public static void WriteAttachment(string hash, string name, string contentType, Stream attachmentStream, long totalSize,
+            DocumentDatabase database, DocumentsOperationContext context, string orphanCountersDocIdPrefix, string recoveryLogCollection, Slice attachmentsSlice,
+            string logDocId, Logger logger)
+        {
+            // store this attachment either under relevant orphan doc, or under already seen doc
+            using (var tx = context.OpenWriteTransaction())
+            {
+                var orphanAttachmentDocId = RecoveredDatabaseCreator.GetOrphanAttachmentDocId(orphanCountersDocIdPrefix, hash);
+                var orphanAttachmentDoc = database.DocumentsStorage.Get(context, orphanAttachmentDocId);
+                if (orphanAttachmentDoc != null)
+                {
+                    // check which documents already seen for this attachment and attach it to them
+                    orphanAttachmentDoc.Data.Modifications = new DynamicJsonValue(orphanAttachmentDoc.Data);
+                    foreach (var docId in orphanAttachmentDoc.Data.GetPropertyNames())
+                    {
+                        if (docId.Equals(Raven.Client.Constants.Documents.Metadata.Key) || docId.Equals(Raven.Client.Constants.Documents.Metadata.Collection))
+                            continue;
+                        if (orphanAttachmentDoc.Data.TryGetMember(docId, out var attachmentDataObj) == false)
+                            continue;
+                        if (!(attachmentDataObj is BlittableJsonReaderObject attachmentData))
+                            continue;
+
+                        var seenDoc = database.DocumentsStorage.Get(context, docId);
+                        if (seenDoc != null)
+                        {
+                            if (attachmentData.TryGet(nameof(RecoveryConstants.Name), out string originalName) == false)
+                                originalName = name;
+                            if (attachmentData.TryGet(nameof(RecoveryConstants.ContentType), out string originalContentType) == false)
+                                originalContentType = contentType;
+                            orphanAttachmentDoc.Data.Modifications.Remove(docId);
+                            var attachmentDetails = database.DocumentsStorage.AttachmentsStorage.PutAttachment(context, docId, originalName, originalContentType, hash, null,
+                                attachmentStream);
+                            if (attachmentDetails.Size != totalSize)
+                            {
+                                RecoveredDatabaseCreator.Log(
+                                    $"Attachment {originalName} of doc {docId} stream size is {attachmentDetails.Size} which is not as reported in datafile: {totalSize}",
+                                    logDocId, logger, context, database);
+                            }
+                        }
+                    }
+
+                    using (var newDocument = context.ReadObject(orphanAttachmentDoc.Data, orphanAttachmentDoc.Id,
+                        BlittableJsonDocumentBuilder.UsageMode.ToDisk))
+                    {
+
+                        if (newDocument.GetPropertyNames().Length == 1) // 1 for @metadata
+                        {
+                            database.DocumentsStorage.Delete(context, orphanAttachmentDoc.Id, null);
+                        }
+                        else
+                        {
+                            var metadata = orphanAttachmentDoc.Data.GetMetadata();
+                            if (metadata != null)
+                                metadata.Modifications = new DynamicJsonValue(metadata) {[Raven.Client.Constants.Documents.Metadata.Collection] = recoveryLogCollection};
+                            database.DocumentsStorage.Put(context, orphanAttachmentDoc.Id, null, newDocument);
+                        }
+                    }
+                }
+                else
+                {
+                    VoronStream existingStream = null;
+                    using (var tree = context.Transaction.InnerTransaction.CreateTree(attachmentsSlice))
+                    {
+                        existingStream = tree.ReadStream(hash);
+                    }
+                    // although no previous doc asked for this attachment, it still might appear from previous recovery sessions on the same recovered database. If so - ignore this WriteAttachment call
+                    if (existingStream == null)
+                    {
+                        using (var newDocument = context.ReadObject(
+                            new DynamicJsonValue
+                            {
+                                [Raven.Client.Constants.Documents.Metadata.Key] = new DynamicJsonValue {[Raven.Client.Constants.Documents.Metadata.Collection] = recoveryLogCollection}
+                            },
+                            orphanAttachmentDocId, BlittableJsonDocumentBuilder.UsageMode.ToDisk))
+                        {
+                            database.DocumentsStorage.Put(context, orphanAttachmentDocId, null, newDocument);
+                            database.DocumentsStorage.AttachmentsStorage.PutAttachment(context, orphanAttachmentDocId, name, contentType, hash, null, attachmentStream);
+                        }
+                    }
+                }
+                tx.Commit();
+            }
+        }
+    }
+}

--- a/tools/Voron.Recovery/DocumentRecovery.cs
+++ b/tools/Voron.Recovery/DocumentRecovery.cs
@@ -1,0 +1,216 @@
+using System;
+using System.Collections.Generic;
+using Raven.Client.Documents.Operations.Attachments;
+using Raven.Client.Documents.Operations.Counters;
+using Raven.Client.Documents.Operations.Revisions;
+using Raven.Client.Documents.Session;
+using Raven.Client.Json;
+using Raven.Client.Util;
+using Raven.Server.Documents;
+using Raven.Server.ServerWide.Context;
+using Raven.Server.Smuggler.Documents;
+using Raven.Server.Smuggler.Documents.Data;
+using Sparrow.Json;
+using Sparrow.Json.Parsing;
+using Raven.Client.Documents.Smuggler;
+using Raven.Client.Extensions;
+using Sparrow.Logging;
+
+
+namespace Voron.Recovery
+{
+    public static class DocumentRecovery
+    {
+        public static void WriteDocument(Document document, DocumentDatabase database, DatabaseDestination databaseDestination, string orphanCountersDocIdPrefix,
+            DocumentsOperationContext context, SmugglerResult results, string recoveryLogCollection, Slice attachmentSlice,
+            string logDocId, Logger logger)
+        {
+            var actions = databaseDestination.Documents();
+            WriteDocumentInternal(document, actions, database, databaseDestination, orphanCountersDocIdPrefix, context, results, recoveryLogCollection, attachmentSlice, logDocId, logger);
+        }
+
+        public static void WriteRevision(
+            Document document, DocumentDatabase database, DatabaseDestination databaseDestination, string orphanCountersDocIdPrefix,
+            DocumentsOperationContext context, SmugglerResult results, string recoveryLogCollection, Slice attachmentSlice,
+            string logDocId, Logger logger)
+        {
+            if (database.DocumentsStorage.RevisionsStorage.Configuration == null)
+            {
+                var revisionsConfiguration = new RevisionsConfiguration {Default = new RevisionsCollectionConfiguration {Disabled = false}};
+                var configurationJson = EntityToBlittable.ConvertCommandToBlittable(revisionsConfiguration, context);
+                (long index, _) = database.ServerStore.ModifyDatabaseRevisions(context, database.Name, configurationJson, Guid.NewGuid().ToString()).Result;
+                AsyncHelpers.RunSync(() => database.RachisLogIndexNotifications.WaitForIndexNotification(index, database.ServerStore.Engine.OperationTimeout));
+            }
+
+            var actions = databaseDestination.RevisionDocuments();
+            WriteDocumentInternal(document, actions, database, databaseDestination, orphanCountersDocIdPrefix, context, results, recoveryLogCollection, attachmentSlice, logDocId, logger);
+        }
+
+        public static void WriteConflict(DocumentConflict conflict, DatabaseDestination databaseDestination, SmugglerResult progress)
+        {
+            using var actions = databaseDestination.Conflicts();
+            actions.WriteConflict(conflict, progress.Conflicts);
+        }
+
+
+        private static void WriteDocumentInternal(
+            Document document, IDocumentActions actions, DocumentDatabase database, DatabaseDestination databaseDestination, string orphanCountersDocIdPrefix,
+            DocumentsOperationContext context, SmugglerResult progress, string recoveryLogCollection, Slice attachmentsSlice,
+            string logDocId, Logger logger)
+        {
+            BlittableJsonReaderObject metadata = document.Data.GetMetadata();
+
+            bool hadCountersFlag = false;
+            if (document.Flags.HasFlag(DocumentFlags.Revision) == false && // revisions contain _snapshot_ of counter, only the current doc will have counter
+                document.Flags.HasFlag(DocumentFlags.HasCounters))
+            {
+                // remove all counter names, and later on search if we saw orphan counters - and add them to this doc
+                // after that if counter is discovered it will be written to this existing doc
+                metadata.Modifications = new DynamicJsonValue(metadata);
+                metadata.Modifications.Remove(Raven.Client.Constants.Documents.Metadata.Counters);
+                document.Data.Modifications = new DynamicJsonValue(document.Data) {[Raven.Client.Constants.Documents.Metadata.Key] = metadata};
+                document.Flags = document.Flags.Strip(DocumentFlags.HasCounters); // later on counters will add back this flag
+                hadCountersFlag = true;
+            }
+
+
+            IMetadataDictionary[] attachments = null;
+            if (document.Flags.HasFlag(DocumentFlags.HasAttachments))
+            {
+                var metadataDictionary = new MetadataAsDictionary(metadata);
+                attachments = metadataDictionary.GetObjects(Raven.Client.Constants.Documents.Metadata.Attachments);
+                metadata.Modifications = new DynamicJsonValue(metadata);
+                metadata.Modifications.Remove(Raven.Client.Constants.Documents.Metadata.Attachments);
+                document.Data.Modifications = new DynamicJsonValue(document.Data) {[Raven.Client.Constants.Documents.Metadata.Key] = metadata};
+
+                // Part of the recovery process is stripping DocumentFlags.HasAttachments, writing the doc and then adding the attachments.
+                // This _might_ add additional revisions to the recovered database (it will start adding after discovering the first revision..)
+                document.Flags = document.Flags.Strip(DocumentFlags.HasAttachments);
+            }
+
+            using (document.Data)
+                document.Data = context.ReadObject(document.Data, document.Id, BlittableJsonDocumentBuilder.UsageMode.ToDisk);
+
+            var item = new DocumentItem {Document = document};
+            actions.WriteDocument(item, progress.Documents);
+            actions.Dispose();
+
+            if (hadCountersFlag)
+            {
+                List<CounterGroupDetail> counterGroupDetailCloneList = null;
+                using (var tx = context.OpenWriteTransaction())
+                {
+                    // Try get orphan counter document.
+                    // if hasn't - do nothing, when we face counter it will be stored in this created document
+                    var orphanCounterDocId = $"{orphanCountersDocIdPrefix}/{document.Id}";
+                    var orphanCounterDoc = database.DocumentsStorage.Get(context, orphanCounterDocId);
+                    if (orphanCounterDoc != null)
+                    {
+
+                        foreach (var counterGroupDetail in database.DocumentsStorage.CountersStorage.GetCounterValuesForDocument(context, orphanCounterDocId))
+                        {
+                            var counterGroupDetailClone = new CounterGroupDetail
+                            {
+                                ChangeVector = context.GetLazyString(counterGroupDetail.ChangeVector.ToString()),
+                                DocumentId = context.GetLazyString(document.Id.ToString()), // replace back to the original Id
+                                Etag = counterGroupDetail.Etag,
+                                Values = counterGroupDetail.Values.Clone(context)
+                            };
+                            if (counterGroupDetailCloneList == null)
+                                counterGroupDetailCloneList = new List<CounterGroupDetail>();
+                            counterGroupDetailCloneList.Add(counterGroupDetailClone);
+                        }
+
+                        database.DocumentsStorage.Delete(context, orphanCounterDocId, null);
+                    }
+
+                    tx.Commit();
+                }
+
+                if (counterGroupDetailCloneList != null)
+                    foreach (CounterGroupDetail groupDetailClone in counterGroupDetailCloneList)
+                        DocumentItemsRecovery.WriteCounterItem(groupDetailClone, database, databaseDestination, orphanCountersDocIdPrefix, context, progress, recoveryLogCollection, attachmentsSlice, logDocId, logger, true);
+            }
+
+            if (attachments != null)
+            {
+                foreach (var attachment in attachments)
+                {
+                    var hash = attachment.GetString(nameof(AttachmentName.Hash));
+                    var name = attachment.GetString(nameof(AttachmentName.Name));
+                    var contentType = attachment.GetString(nameof(AttachmentName.ContentType));
+
+                    if (string.IsNullOrEmpty(hash) || string.IsNullOrEmpty(name))
+                    {
+                        RecoveredDatabaseCreator.Log(
+                            $"Document {document.Id} has attachment flag set with empty hash / name",
+                            logDocId, logger, context, database);
+                        continue;
+                    }
+
+                    using (var tx = context.OpenWriteTransaction())
+                    {
+                        // if attachment already exists, attach it to this doc and remove from orphan
+                        // otherwise create a doc consists the hash as doc Id for later use
+
+                        using (var tree = context.Transaction.InnerTransaction.CreateTree(attachmentsSlice))
+                        {
+                            var orphanAttachmentDocId = RecoveredDatabaseCreator.GetOrphanAttachmentDocId(orphanCountersDocIdPrefix, hash);
+                            var existingStream = tree.ReadStream(hash);
+                            if (existingStream != null)
+                            {
+                                // This document points to an attachment which is already in db and already pointed by another document
+                                // we just need to point again this document to the attachment
+                                try
+                                {
+                                    database.DocumentsStorage.AttachmentsStorage.PutAttachment(context, document.Id, name, contentType, hash, null,
+                                        existingStream);
+
+                                    var noLongerOrphanAttachmentDoc = database.DocumentsStorage.Get(context, orphanAttachmentDocId);
+                                    if (noLongerOrphanAttachmentDoc != null)
+                                        database.DocumentsStorage.Delete(context, noLongerOrphanAttachmentDoc.Id, null);
+                                }
+                                finally
+                                {
+                                    existingStream.Dispose();
+                                }
+                            }
+                            else
+                            {
+                                var orphanAttachmentDoc = database.DocumentsStorage.Get(context, orphanAttachmentDocId);
+                                if (orphanAttachmentDoc == null)
+                                {
+                                    using (var doc = context.ReadObject(
+                                        new DynamicJsonValue
+                                        {
+                                            [document.Id] = new DynamicJsonValue {[nameof(RecoveryConstants.Name)] = name, [nameof(RecoveryConstants.ContentType)] = contentType},
+                                            [Raven.Client.Constants.Documents.Metadata.Key] = new DynamicJsonValue
+                                            {
+                                                [Raven.Client.Constants.Documents.Metadata.Collection] = recoveryLogCollection
+                                            }
+                                        }, orphanAttachmentDocId, BlittableJsonDocumentBuilder.UsageMode.ToDisk)
+                                    )
+                                    {
+                                        database.DocumentsStorage.Put(context, orphanAttachmentDocId, null, doc);
+                                    }
+                                }
+                                else
+                                {
+                                    orphanAttachmentDoc.Data.Modifications = new DynamicJsonValue(orphanAttachmentDoc.Data)
+                                    {
+                                        [document.Id] = new DynamicJsonValue {[nameof(RecoveryConstants.Name)] = name, [nameof(RecoveryConstants.ContentType)] = contentType}
+                                    };
+                                    var newDocument = context.ReadObject(orphanAttachmentDoc.Data, orphanAttachmentDoc.Id,
+                                        BlittableJsonDocumentBuilder.UsageMode.ToDisk);
+                                    database.DocumentsStorage.Put(context, orphanAttachmentDoc.Id, null, newDocument);
+                                }
+                            }
+
+                            tx.Commit();
+                        }
+                    }
+                }
+            }
+        }
+    }
+}

--- a/tools/Voron.Recovery/RecoveredDatabaseCreator.cs
+++ b/tools/Voron.Recovery/RecoveredDatabaseCreator.cs
@@ -1,0 +1,433 @@
+using System;
+using System.Collections.Generic;
+using System.Globalization;
+using System.IO;
+using Raven.Client;
+using Raven.Client.Documents.Operations.Attachments;
+using Raven.Client.Documents.Operations.Counters;
+using Raven.Client.Documents.Operations.Revisions;
+using Raven.Client.Documents.Session;
+using Raven.Client.Documents.Smuggler;
+using Raven.Client.Json;
+using Raven.Server.Documents;
+using Raven.Server.ServerWide;
+using Raven.Server.Smuggler.Documents;
+using Raven.Server.Smuggler.Documents.Data;
+using Sparrow.Json;
+using Raven.Client.Extensions;
+using Raven.Client.Util;
+using Raven.Server.ServerWide.Context;
+using Sparrow.Json.Parsing;
+using Sparrow.Logging;
+using Sparrow.Server;
+using Sparrow.Threading;
+using Voron.Data;
+
+namespace Voron.Recovery
+{
+    public class RecoveredDatabaseCreator : IDisposable
+    {
+        public static RecoveredDatabaseCreator RecoveredDbTools(DocumentDatabase documentDatabase, string recoverySession, Logger logger) => new RecoveredDatabaseCreator(documentDatabase, recoverySession, logger);
+
+        private readonly DatabaseDestination _databaseDestination;
+        private readonly SmugglerResult _results;
+        private readonly DocumentsOperationContext _context;
+        private readonly DocumentDatabase _database;
+        private readonly IDisposable _contextDisposal;
+        private readonly Logger _logger;
+        private readonly string _logDocId;
+        private readonly string _orphanAttachmentsDocIdPrefix;
+        private readonly string _orphanCountersDocIdPrefix;
+        private readonly Slice _attachmentsSlice;
+        private readonly ByteStringContext _byteStringContext;
+        private readonly string _recoveryLogCollection;
+        private string GetOrphanAttachmentDocId(string hash) => $"{_orphanAttachmentsDocIdPrefix}/{hash}";
+
+        private RecoveredDatabaseCreator(DocumentDatabase documentDatabase, string recoverySession, Logger logger)
+        {
+            _logger = logger;
+            _recoveryLogCollection = $"RecoveryLog-{recoverySession}";
+            _orphanAttachmentsDocIdPrefix = $"OrphanAttachments/{recoverySession}";
+            _orphanCountersDocIdPrefix = $"OrphanCounters/{recoverySession}";
+            _logDocId = $"Log/{recoverySession}";
+            _database = documentDatabase;
+            _databaseDestination = new DatabaseDestination(documentDatabase);
+            _results = new SmugglerResult();
+            _databaseDestination.Initialize(new DatabaseSmugglerOptionsServerSide(), _results, ServerVersion.Build);
+            _contextDisposal = _database.DocumentsStorage.ContextPool.AllocateOperationContext(out _context);
+            _byteStringContext = new ByteStringContext(SharedMultipleUseFlag.None);
+            Slice.From(_byteStringContext, "Attachments", ByteStringType.Immutable, out _attachmentsSlice);
+
+            using (var tx = _context.OpenWriteTransaction())
+            {
+                using (var doc = _context.ReadObject(
+                    new DynamicJsonValue
+                    {
+                        ["RecoverySession"] = recoverySession,
+                        ["RecoveryStarted"] = DateTime.Now,
+                        [Constants.Documents.Metadata.Key] = new DynamicJsonValue {[Constants.Documents.Metadata.Collection] = _recoveryLogCollection}
+                    }, _logDocId, BlittableJsonDocumentBuilder.UsageMode.ToDisk)
+                )
+                {
+                    _database.DocumentsStorage.Put(_context, _logDocId, null, doc);
+                }
+                tx.Commit();
+            }
+        }
+
+        public void WriteDocument(Document document)
+        {
+            var actions = _databaseDestination.Documents();
+            WriteDocumentInternal(document, actions);
+        }
+
+        public void WriteRevision(Document document)
+        {
+            if (_database.DocumentsStorage.RevisionsStorage.Configuration == null)
+            {
+                var revisionsConfiguration = new RevisionsConfiguration {Default = new RevisionsCollectionConfiguration {Disabled = false}};
+                var configurationJson = EntityToBlittable.ConvertCommandToBlittable(revisionsConfiguration, _context);
+                (long index, _) = _database.ServerStore.ModifyDatabaseRevisions(_context, _database.Name, configurationJson, Guid.NewGuid().ToString()).Result;
+                AsyncHelpers.RunSync(() => _database.RachisLogIndexNotifications.WaitForIndexNotification(index, _database.ServerStore.Engine.OperationTimeout));
+            }
+            var actions = _databaseDestination.RevisionDocuments();
+            WriteDocumentInternal(document, actions);
+        }
+
+        public void WriteCounterItem(CounterGroupDetail counterGroupDetail, bool skipDocExistance = false)
+        {
+            if (skipDocExistance == false)
+            {
+                using (var tx = _context.OpenWriteTransaction())
+                {
+                    Document originalDoc = _database.DocumentsStorage.Get(_context, counterGroupDetail.DocumentId);
+                    if (originalDoc == null)
+                    {
+                        var orphanDocId = $"{_orphanCountersDocIdPrefix}/{counterGroupDetail.DocumentId}";
+                        var orphanDoc = _database.DocumentsStorage.Get(_context, orphanDocId);
+                        if (orphanDoc == null)
+                        {
+                            using (var doc = _context.ReadObject(
+                                new DynamicJsonValue
+                                {
+                                    ["OriginalDocId"] = counterGroupDetail.DocumentId.ToString(),
+                                    [Constants.Documents.Metadata.Key] = new DynamicJsonValue {[Constants.Documents.Metadata.Collection] = _recoveryLogCollection}
+                                }, orphanDocId, BlittableJsonDocumentBuilder.UsageMode.ToDisk))
+                            {
+                                var _ = _database.DocumentsStorage.Put(_context, orphanDocId, null, doc);
+                            }
+                        }
+
+                        counterGroupDetail.DocumentId.Dispose();
+                        counterGroupDetail.DocumentId = _context.GetLazyString(orphanDocId);
+
+                        tx.Commit();
+                    }
+                }
+            }
+
+            using var actions = _databaseDestination.Counters(_results);
+            actions.WriteCounter(counterGroupDetail);
+        }
+
+        public void WriteAttachment(string hash, string name, string contentType, Stream attachmentStream)
+        {
+            // store this attachment either under relevant orphan doc, or under already seen doc
+            using (var tx = _context.OpenWriteTransaction())
+            {
+                var orphanAttachmentDocId = GetOrphanAttachmentDocId(hash);
+                var orphanAttachmentDoc = _database.DocumentsStorage.Get(_context, orphanAttachmentDocId);
+                if (orphanAttachmentDoc != null)
+                {
+                    // check which documents already seen for this attachment and attach it to them
+                    orphanAttachmentDoc.Data.Modifications = new DynamicJsonValue(orphanAttachmentDoc.Data);
+                    foreach (var docId in orphanAttachmentDoc.Data.GetPropertyNames())
+                    {
+                        if (docId.Equals(Constants.Documents.Metadata.Key) || docId.Equals(Constants.Documents.Metadata.Collection))
+                            continue;
+                        if (orphanAttachmentDoc.Data.TryGetMember(docId, out var attachmentDataObj) == false)
+                            continue;
+                        if (!(attachmentDataObj is BlittableJsonReaderObject attachmentData))
+                            continue;
+
+                        var seenDoc = _database.DocumentsStorage.Get(_context, docId);
+                        if (seenDoc != null)
+                        {
+                            if (attachmentData.TryGet("Name", out string originalName) == false)
+                                originalName = name;
+                            if (attachmentData.TryGet("ContentType", out string originalContentType) == false)
+                                originalContentType = contentType;
+                            orphanAttachmentDoc.Data.Modifications.Remove(docId);
+                            _database.DocumentsStorage.AttachmentsStorage.PutAttachment(_context, docId, originalName, originalContentType, hash, null,
+                                attachmentStream);
+                        }
+                    }
+
+                    using (var newDocument = _context.ReadObject(orphanAttachmentDoc.Data, orphanAttachmentDoc.Id,
+                        BlittableJsonDocumentBuilder.UsageMode.ToDisk))
+                    {
+
+                        if (newDocument.GetPropertyNames().Length == 1) // 1 for @metadata and @collection
+                        {
+                            _database.DocumentsStorage.Delete(_context, orphanAttachmentDoc.Id, null);
+                        }
+                        else
+                        {
+                            var metadata = orphanAttachmentDoc.Data.GetMetadata();
+                            if (metadata != null)
+                                metadata.Modifications = new DynamicJsonValue(metadata) {[Constants.Documents.Metadata.Collection] = _recoveryLogCollection};
+                            _database.DocumentsStorage.Put(_context, orphanAttachmentDoc.Id, null, newDocument);
+                        }
+                    }
+                }
+                else
+                {
+                    VoronStream existingStream = null;
+                    using (var tree = _context.Transaction.InnerTransaction.CreateTree(_attachmentsSlice))
+                    {
+                        existingStream = tree.ReadStream(hash);
+                    }
+                    // although no previous doc asked for this attachment, it still might appear from previous recovery sessions. If so - ignore this WriteAttachment call
+                    if (existingStream == null)
+                    {
+                        using (var newDocument = _context.ReadObject(
+                            new DynamicJsonValue
+                            {
+                                [Constants.Documents.Metadata.Key] = new DynamicJsonValue {[Constants.Documents.Metadata.Collection] = _recoveryLogCollection}
+                            },
+                            orphanAttachmentDocId, BlittableJsonDocumentBuilder.UsageMode.ToDisk))
+                        {
+                            _database.DocumentsStorage.Put(_context, orphanAttachmentDocId, null, newDocument);
+                            _database.DocumentsStorage.AttachmentsStorage.PutAttachment(_context, orphanAttachmentDocId, name, contentType, hash, null, attachmentStream);
+                        }
+                    }
+                }
+                tx.Commit();
+            }
+        }
+
+        public void WriteConflict(DocumentConflict conflict)
+        {
+            using var actions = _databaseDestination.Conflicts();
+            actions.WriteConflict(conflict, _results.Conflicts);
+        }
+
+        private void WriteDocumentInternal(Document document, IDocumentActions actions)
+        {
+            BlittableJsonReaderObject metadata = null;
+
+            bool hadCountersFlag = false;
+            if (document.Flags.HasFlag(DocumentFlags.Revision) == false && // revisions contain _snapshot_ of counter, only the current doc will have counter
+                document.Flags.HasFlag(DocumentFlags.HasCounters))
+            {
+                metadata = document.Data.GetMetadata();
+                if (metadata == null)
+                {
+                    Log($"Document {document.Id} has counters flag set but was unable to read its metadata and remove the counter names from it");
+                    // Logging and storing without counters
+                }
+                else
+                {
+                    // remove all counter names, and later on search if we saw orphan counters - and add them to this doc
+                    // after that if counter is discovered it will be written to this existing doc
+                    metadata.Modifications = new DynamicJsonValue(metadata);
+                    metadata.Modifications.Remove(Constants.Documents.Metadata.Counters);
+                    document.Data.Modifications = new DynamicJsonValue(document.Data) {[Constants.Documents.Metadata.Key] = metadata};
+                }
+
+                document.Flags = document.Flags.Strip(DocumentFlags.HasCounters); // later on counters will add back this flag
+                hadCountersFlag = true;
+            }
+
+
+            IMetadataDictionary[] attachments = null;
+            if (document.Flags.HasFlag(DocumentFlags.HasAttachments))
+            {
+                metadata ??= document.Data.GetMetadata();
+                if (metadata == null)
+                {
+                    Log($"Document {document.Id} has attachment flag set but was unable to read its metadata and retrieve the attachments hashes");
+                    // Logging and storing without attachments
+                }
+                else
+                {
+                    var metadataDictionary = new MetadataAsDictionary(metadata);
+                    attachments = metadataDictionary.GetObjects(Constants.Documents.Metadata.Attachments);
+
+                    metadata.Modifications = new DynamicJsonValue(metadata);
+                    metadata.Modifications.Remove(Constants.Documents.Metadata.Attachments);
+                    document.Data.Modifications = new DynamicJsonValue(document.Data) {[Constants.Documents.Metadata.Key] = metadata};
+                }
+
+                // Part of the recovery process is stripping DocumentFlags.HasAttachments, writing the doc and then adding the attachments.
+                // This _might_ add additional revisions to the recovered database (it will start adding after discovering the first revision..)
+                document.Flags = document.Flags.Strip(DocumentFlags.HasAttachments);
+            }
+
+            if (metadata != null)
+            {
+                using (document.Data)
+                {
+                    document.Data = _context.ReadObject(document.Data, document.Id, BlittableJsonDocumentBuilder.UsageMode.ToDisk);
+                }
+            }
+
+            var item = new DocumentItem {Document = document};
+            actions.WriteDocument(item, _results.Documents);
+            actions.Dispose();
+
+            if (hadCountersFlag)
+            {
+                List<CounterGroupDetail> counterGroupDetailCloneList = null;
+                using (var tx = _context.OpenWriteTransaction())
+                {
+                    // Try get orphan counter document.
+                    // if hasn't - do nothing, when we face counter it will be stored in this created document
+                    var orphanCounterDocId = $"{_orphanCountersDocIdPrefix}/{document.Id}";
+                    var orphanCounterDoc = _database.DocumentsStorage.Get(_context, orphanCounterDocId);
+                    if (orphanCounterDoc != null)
+                    {
+
+                        foreach (var counterGroupDetail in _database.DocumentsStorage.CountersStorage.GetCounterValuesForDocument(_context, orphanCounterDocId))
+                        {
+                            var counterGroupDetailClone = new CounterGroupDetail
+                            {
+                                ChangeVector = _context.GetLazyString(counterGroupDetail.ChangeVector.ToString()),
+                                DocumentId = _context.GetLazyString(document.Id.ToString()), // replace back to the original Id
+                                Etag = counterGroupDetail.Etag,
+                                Values = counterGroupDetail.Values.Clone(_context)
+                            };
+                            if (counterGroupDetailCloneList == null)
+                                counterGroupDetailCloneList = new List<CounterGroupDetail>();
+                            counterGroupDetailCloneList.Add(counterGroupDetailClone);
+                        }
+
+                        _database.DocumentsStorage.Delete(_context, orphanCounterDocId, null);
+                    }
+
+                    tx.Commit();
+                }
+
+                if (counterGroupDetailCloneList != null)
+                    foreach (CounterGroupDetail groupDetailClone in counterGroupDetailCloneList)
+                        WriteCounterItem(groupDetailClone, true);
+            }
+
+            if (attachments != null)
+            {
+                foreach (var attachment in attachments)
+                {
+                    var hash = attachment.GetString(nameof(AttachmentName.Hash));
+                    var name = attachment.GetString(nameof(AttachmentName.Name));
+                    var contentType = attachment.GetString(nameof(AttachmentName.ContentType));
+
+                    if (string.IsNullOrEmpty(hash) || string.IsNullOrEmpty(name))
+                    {
+                        Log($"Document {document.Id} has attachment flag set with empty hash / name");
+                        continue;
+                    }
+
+                    using (var tx = _context.OpenWriteTransaction())
+                    {
+                        // if attachment already exists, attach it to this doc and remove from orphan
+                        // otherwise create a doc consists the hash as doc Id for later use
+
+                        using (var tree = _context.Transaction.InnerTransaction.CreateTree(_attachmentsSlice))
+                        {
+                            var orphanAttachmentDocId = GetOrphanAttachmentDocId(hash);
+                            var existingStream = tree.ReadStream(hash);
+                            if (existingStream != null)
+                            {
+                                // This document points to an attachment which is already in db and already pointed by another document
+                                // we just need to point again this document to the attachment
+                                try
+                                {
+                                    _database.DocumentsStorage.AttachmentsStorage.PutAttachment(_context, document.Id, name, contentType, hash, null,
+                                        existingStream);
+
+                                    var noLongerOrphanAttachmentDoc = _database.DocumentsStorage.Get(_context, orphanAttachmentDocId);
+                                    if (noLongerOrphanAttachmentDoc != null)
+                                        _database.DocumentsStorage.Delete(_context, noLongerOrphanAttachmentDoc.Id, null);
+                                }
+                                finally
+                                {
+                                    existingStream.Dispose();
+                                }
+                            }
+                            else
+                            {
+                                var orphanAttachmentDoc = _database.DocumentsStorage.Get(_context, orphanAttachmentDocId);
+                                if (orphanAttachmentDoc == null)
+                                {
+                                    using (var doc = _context.ReadObject(
+                                        new DynamicJsonValue
+                                        {
+                                            [document.Id] = new DynamicJsonValue {["Name"] = name, ["ContentType"] = contentType},
+                                            [Constants.Documents.Metadata.Key] = new DynamicJsonValue {[Constants.Documents.Metadata.Collection] = _recoveryLogCollection}
+                                        }, orphanAttachmentDocId, BlittableJsonDocumentBuilder.UsageMode.ToDisk)
+                                    )
+                                    {
+                                        _database.DocumentsStorage.Put(_context, orphanAttachmentDocId, null, doc);
+                                    }
+                                }
+                                else
+                                {
+                                    orphanAttachmentDoc.Data.Modifications = new DynamicJsonValue(orphanAttachmentDoc.Data)
+                                    {
+                                        [document.Id] = new DynamicJsonValue {["Name"] = name, ["ContentType"] = contentType}
+                                    };
+                                    var newDocument = _context.ReadObject(orphanAttachmentDoc.Data, orphanAttachmentDoc.Id,
+                                        BlittableJsonDocumentBuilder.UsageMode.ToDisk);
+                                    _database.DocumentsStorage.Put(_context, orphanAttachmentDoc.Id, null, newDocument);
+                                }
+                            }
+
+                            tx.Commit();
+                        }
+                    }
+                }
+            }
+        }
+
+        public void Log(string msg, Exception ex = null)
+        {
+            if (_logger.IsOperationsEnabled)
+                _logger.Operations(msg, ex);
+
+            DocumentsTransaction tx = null;
+            if (_context.HasTransaction == false)
+                tx = _context.OpenWriteTransaction();
+            try
+            {
+                var logDoc = _database.DocumentsStorage.Get(_context, _logDocId);
+                if (ex != null)
+                    msg += $". Exception: {ex}";
+                logDoc.Data.Modifications = new DynamicJsonValue
+                {
+                    [DateTime.Now.ToString(CultureInfo.InvariantCulture)] = msg
+                };
+                var newDocument = _context.ReadObject(logDoc.Data, _logDocId, BlittableJsonDocumentBuilder.UsageMode.ToDisk);
+                _database.DocumentsStorage.Put(_context, _logDocId, null, newDocument);
+                tx?.Commit();
+            }
+            finally
+            {
+                tx?.Dispose();
+            }
+        }
+
+        public void Dispose()
+        {
+            using (var tx = _context.OpenWriteTransaction())
+            {
+                var logDoc = _database.DocumentsStorage.Get(_context, _logDocId);
+                logDoc.Data.Modifications = new DynamicJsonValue(logDoc.Data) {["RecoveryFinished"] = DateTime.Now};
+                var newDocument = _context.ReadObject(logDoc.Data, _logDocId, BlittableJsonDocumentBuilder.UsageMode.ToDisk);
+                _database.DocumentsStorage.Put(_context, _logDocId, null, newDocument);
+                tx.Commit();
+            }
+            _contextDisposal.Dispose();
+            _byteStringContext.Dispose();
+        }
+    }
+}

--- a/tools/Voron.Recovery/RecoveredDatabaseCreator.cs
+++ b/tools/Voron.Recovery/RecoveredDatabaseCreator.cs
@@ -66,6 +66,11 @@ namespace Voron.Recovery
             _byteStringContext = new ByteStringContext(SharedMultipleUseFlag.None);
             Slice.From(_byteStringContext, "Attachments", ByteStringType.Immutable, out _attachmentsSlice);
 
+            CreateRecoveryLogDocument(recoverySession);
+        }
+
+        private void CreateRecoveryLogDocument(string recoverySession)
+        {
             using (var tx = _context.OpenWriteTransaction())
             {
                 using (var doc = _context.ReadObject(
@@ -127,7 +132,7 @@ namespace Voron.Recovery
                                             }
                                         }, orphanDocId, BlittableJsonDocumentBuilder.UsageMode.ToDisk))
                                     {
-                                        var _ = _database.DocumentsStorage.Put(_context, orphanDocId, null, doc);
+                                        _database.DocumentsStorage.Put(_context, orphanDocId, null, doc);
                                     }
                                 }
 

--- a/tools/Voron.Recovery/RecoveredDatabaseCreator.cs
+++ b/tools/Voron.Recovery/RecoveredDatabaseCreator.cs
@@ -1,27 +1,18 @@
 using System;
-using System.Collections.Generic;
 using System.Globalization;
 using System.IO;
-using Raven.Client;
-using Raven.Client.Documents.Operations.Attachments;
 using Raven.Client.Documents.Operations.Counters;
-using Raven.Client.Documents.Operations.Revisions;
-using Raven.Client.Documents.Session;
 using Raven.Client.Documents.Smuggler;
-using Raven.Client.Json;
 using Raven.Server.Documents;
 using Raven.Server.ServerWide;
 using Raven.Server.Smuggler.Documents;
 using Raven.Server.Smuggler.Documents.Data;
 using Sparrow.Json;
-using Raven.Client.Extensions;
-using Raven.Client.Util;
 using Raven.Server.ServerWide.Context;
 using Sparrow.Json.Parsing;
 using Sparrow.Logging;
 using Sparrow.Server;
 using Sparrow.Threading;
-using Voron.Data;
 using Document = Raven.Server.Documents.Document;
 
 namespace Voron.Recovery
@@ -42,14 +33,8 @@ namespace Voron.Recovery
         private readonly Slice _attachmentsSlice;
         private readonly ByteStringContext _byteStringContext;
         private readonly string _recoveryLogCollection;
-        private string GetOrphanAttachmentDocId(string hash) => $"{_orphanAttachmentsDocIdPrefix}/{hash}";
 
-        private static class Constants
-        {
-            public static string Name;
-            public static string ContentType;
-            public static string OriginalDocId;
-        }
+        internal static string GetOrphanAttachmentDocId(string docName, string hash) => $"{docName}/{hash}";
 
         private RecoveredDatabaseCreator(DocumentDatabase documentDatabase, string recoverySession, Logger logger)
         {
@@ -88,330 +73,42 @@ namespace Voron.Recovery
             }
         }
 
-        public void WriteDocument(Document document)
+        public static void Log(string msg, string logDocId, Logger logger, DocumentsOperationContext context, DocumentDatabase database, Exception ex = null)
         {
-            var actions = _databaseDestination.Documents();
-            WriteDocumentInternal(document, actions);
-        }
-
-        public void WriteRevision(Document document)
-        {
-            if (_database.DocumentsStorage.RevisionsStorage.Configuration == null)
-            {
-                var revisionsConfiguration = new RevisionsConfiguration {Default = new RevisionsCollectionConfiguration {Disabled = false}};
-                var configurationJson = EntityToBlittable.ConvertCommandToBlittable(revisionsConfiguration, _context);
-                (long index, _) = _database.ServerStore.ModifyDatabaseRevisions(_context, _database.Name, configurationJson, Guid.NewGuid().ToString()).Result;
-                AsyncHelpers.RunSync(() => _database.RachisLogIndexNotifications.WaitForIndexNotification(index, _database.ServerStore.Engine.OperationTimeout));
-            }
-            var actions = _databaseDestination.RevisionDocuments();
-            WriteDocumentInternal(document, actions);
-        }
-
-        public void WriteCounterItem(CounterGroupDetail counterGroupDetail, bool skipDocExistence = false)
-        {
-            if (skipDocExistence == false)
-            {
-                using (var tx = _context.OpenWriteTransaction())
-                {
-                    using (var originalDoc = _database.DocumentsStorage.Get(_context, counterGroupDetail.DocumentId))
-                    {
-                        if (originalDoc == null)
-                        {
-                            var orphanDocId = $"{_orphanCountersDocIdPrefix}/{counterGroupDetail.DocumentId}";
-                            using (var orphanDoc = _database.DocumentsStorage.Get(_context, orphanDocId))
-                            {
-                                if (orphanDoc == null)
-                                {
-                                    using (var doc = _context.ReadObject(
-                                        new DynamicJsonValue
-                                        {
-                                            [nameof(Constants.OriginalDocId)] = counterGroupDetail.DocumentId.ToString(),
-                                            [Raven.Client.Constants.Documents.Metadata.Key] = new DynamicJsonValue
-                                            {
-                                                [Raven.Client.Constants.Documents.Metadata.Collection] = _recoveryLogCollection
-                                            }
-                                        }, orphanDocId, BlittableJsonDocumentBuilder.UsageMode.ToDisk))
-                                    {
-                                        _database.DocumentsStorage.Put(_context, orphanDocId, null, doc);
-                                    }
-                                }
-
-                                counterGroupDetail.DocumentId.Dispose();
-                                counterGroupDetail.DocumentId = _context.GetLazyString(orphanDocId);
-
-                                tx.Commit();
-                            }
-                        }
-                    }
-                }
-            }
-
-            using var actions = _databaseDestination.Counters(_results);
-            actions.WriteCounter(counterGroupDetail);
-        }
-
-        public void WriteAttachment(string hash, string name, string contentType, Stream attachmentStream, long totalSize)
-        {
-            // store this attachment either under relevant orphan doc, or under already seen doc
-            using (var tx = _context.OpenWriteTransaction())
-            {
-                var orphanAttachmentDocId = GetOrphanAttachmentDocId(hash);
-                var orphanAttachmentDoc = _database.DocumentsStorage.Get(_context, orphanAttachmentDocId);
-                if (orphanAttachmentDoc != null)
-                {
-                    // check which documents already seen for this attachment and attach it to them
-                    orphanAttachmentDoc.Data.Modifications = new DynamicJsonValue(orphanAttachmentDoc.Data);
-                    foreach (var docId in orphanAttachmentDoc.Data.GetPropertyNames())
-                    {
-                        if (docId.Equals(Raven.Client.Constants.Documents.Metadata.Key) || docId.Equals(Raven.Client.Constants.Documents.Metadata.Collection))
-                            continue;
-                        if (orphanAttachmentDoc.Data.TryGetMember(docId, out var attachmentDataObj) == false)
-                            continue;
-                        if (!(attachmentDataObj is BlittableJsonReaderObject attachmentData))
-                            continue;
-
-                        var seenDoc = _database.DocumentsStorage.Get(_context, docId);
-                        if (seenDoc != null)
-                        {
-                            if (attachmentData.TryGet(nameof(Constants.Name), out string originalName) == false)
-                                originalName = name;
-                            if (attachmentData.TryGet(nameof(Constants.ContentType), out string originalContentType) == false)
-                                originalContentType = contentType;
-                            orphanAttachmentDoc.Data.Modifications.Remove(docId);
-                            var attachmentDetails = _database.DocumentsStorage.AttachmentsStorage.PutAttachment(_context, docId, originalName, originalContentType, hash, null,
-                                attachmentStream);
-                            if (attachmentDetails.Size != totalSize)
-                            {
-                                Log("Attachment " + originalName + " of doc " + docId + " stream size is " + attachmentDetails.Size + " which is not as reported in datafile: " + totalSize);
-                            }
-                        }
-                    }
-
-                    using (var newDocument = _context.ReadObject(orphanAttachmentDoc.Data, orphanAttachmentDoc.Id,
-                        BlittableJsonDocumentBuilder.UsageMode.ToDisk))
-                    {
-
-                        if (newDocument.GetPropertyNames().Length == 1) // 1 for @metadata
-                        {
-                            _database.DocumentsStorage.Delete(_context, orphanAttachmentDoc.Id, null);
-                        }
-                        else
-                        {
-                            var metadata = orphanAttachmentDoc.Data.GetMetadata();
-                            if (metadata != null)
-                                metadata.Modifications = new DynamicJsonValue(metadata) {[Raven.Client.Constants.Documents.Metadata.Collection] = _recoveryLogCollection};
-                            _database.DocumentsStorage.Put(_context, orphanAttachmentDoc.Id, null, newDocument);
-                        }
-                    }
-                }
-                else
-                {
-                    VoronStream existingStream = null;
-                    using (var tree = _context.Transaction.InnerTransaction.CreateTree(_attachmentsSlice))
-                    {
-                        existingStream = tree.ReadStream(hash);
-                    }
-                    // although no previous doc asked for this attachment, it still might appear from previous recovery sessions on the same recovered database. If so - ignore this WriteAttachment call
-                    if (existingStream == null)
-                    {
-                        using (var newDocument = _context.ReadObject(
-                            new DynamicJsonValue
-                            {
-                                [Raven.Client.Constants.Documents.Metadata.Key] = new DynamicJsonValue {[Raven.Client.Constants.Documents.Metadata.Collection] = _recoveryLogCollection}
-                            },
-                            orphanAttachmentDocId, BlittableJsonDocumentBuilder.UsageMode.ToDisk))
-                        {
-                            _database.DocumentsStorage.Put(_context, orphanAttachmentDocId, null, newDocument);
-                            _database.DocumentsStorage.AttachmentsStorage.PutAttachment(_context, orphanAttachmentDocId, name, contentType, hash, null, attachmentStream);
-                        }
-                    }
-                }
-                tx.Commit();
-            }
-        }
-
-        public void WriteConflict(DocumentConflict conflict)
-        {
-            using var actions = _databaseDestination.Conflicts();
-            actions.WriteConflict(conflict, _results.Conflicts);
-        }
-
-        private void WriteDocumentInternal(Document document, IDocumentActions actions)
-        {
-            BlittableJsonReaderObject metadata = document.Data.GetMetadata();
-
-            bool hadCountersFlag = false;
-            if (document.Flags.HasFlag(DocumentFlags.Revision) == false && // revisions contain _snapshot_ of counter, only the current doc will have counter
-                document.Flags.HasFlag(DocumentFlags.HasCounters))
-            {
-                // remove all counter names, and later on search if we saw orphan counters - and add them to this doc
-                // after that if counter is discovered it will be written to this existing doc
-                metadata.Modifications = new DynamicJsonValue(metadata);
-                metadata.Modifications.Remove(Raven.Client.Constants.Documents.Metadata.Counters);
-                document.Data.Modifications = new DynamicJsonValue(document.Data) {[Raven.Client.Constants.Documents.Metadata.Key] = metadata};
-                document.Flags = document.Flags.Strip(DocumentFlags.HasCounters); // later on counters will add back this flag
-                hadCountersFlag = true;
-            }
-
-
-            IMetadataDictionary[] attachments = null;
-            if (document.Flags.HasFlag(DocumentFlags.HasAttachments))
-            {
-                var metadataDictionary = new MetadataAsDictionary(metadata);
-                attachments = metadataDictionary.GetObjects(Raven.Client.Constants.Documents.Metadata.Attachments);
-                metadata.Modifications = new DynamicJsonValue(metadata);
-                metadata.Modifications.Remove(Raven.Client.Constants.Documents.Metadata.Attachments);
-                document.Data.Modifications = new DynamicJsonValue(document.Data) {[Raven.Client.Constants.Documents.Metadata.Key] = metadata};
-
-                // Part of the recovery process is stripping DocumentFlags.HasAttachments, writing the doc and then adding the attachments.
-                // This _might_ add additional revisions to the recovered database (it will start adding after discovering the first revision..)
-                document.Flags = document.Flags.Strip(DocumentFlags.HasAttachments);
-            }
-
-            using (document.Data)
-                document.Data = _context.ReadObject(document.Data, document.Id, BlittableJsonDocumentBuilder.UsageMode.ToDisk);
-
-            var item = new DocumentItem {Document = document};
-            actions.WriteDocument(item, _results.Documents);
-            actions.Dispose();
-
-            if (hadCountersFlag)
-            {
-                List<CounterGroupDetail> counterGroupDetailCloneList = null;
-                using (var tx = _context.OpenWriteTransaction())
-                {
-                    // Try get orphan counter document.
-                    // if hasn't - do nothing, when we face counter it will be stored in this created document
-                    var orphanCounterDocId = $"{_orphanCountersDocIdPrefix}/{document.Id}";
-                    var orphanCounterDoc = _database.DocumentsStorage.Get(_context, orphanCounterDocId);
-                    if (orphanCounterDoc != null)
-                    {
-
-                        foreach (var counterGroupDetail in _database.DocumentsStorage.CountersStorage.GetCounterValuesForDocument(_context, orphanCounterDocId))
-                        {
-                            var counterGroupDetailClone = new CounterGroupDetail
-                            {
-                                ChangeVector = _context.GetLazyString(counterGroupDetail.ChangeVector.ToString()),
-                                DocumentId = _context.GetLazyString(document.Id.ToString()), // replace back to the original Id
-                                Etag = counterGroupDetail.Etag,
-                                Values = counterGroupDetail.Values.Clone(_context)
-                            };
-                            if (counterGroupDetailCloneList == null)
-                                counterGroupDetailCloneList = new List<CounterGroupDetail>();
-                            counterGroupDetailCloneList.Add(counterGroupDetailClone);
-                        }
-
-                        _database.DocumentsStorage.Delete(_context, orphanCounterDocId, null);
-                    }
-
-                    tx.Commit();
-                }
-
-                if (counterGroupDetailCloneList != null)
-                    foreach (CounterGroupDetail groupDetailClone in counterGroupDetailCloneList)
-                        WriteCounterItem(groupDetailClone, true);
-            }
-
-            if (attachments != null)
-            {
-                foreach (var attachment in attachments)
-                {
-                    var hash = attachment.GetString(nameof(AttachmentName.Hash));
-                    var name = attachment.GetString(nameof(AttachmentName.Name));
-                    var contentType = attachment.GetString(nameof(AttachmentName.ContentType));
-
-                    if (string.IsNullOrEmpty(hash) || string.IsNullOrEmpty(name))
-                    {
-                        Log($"Document {document.Id} has attachment flag set with empty hash / name");
-                        continue;
-                    }
-
-                    using (var tx = _context.OpenWriteTransaction())
-                    {
-                        // if attachment already exists, attach it to this doc and remove from orphan
-                        // otherwise create a doc consists the hash as doc Id for later use
-
-                        using (var tree = _context.Transaction.InnerTransaction.CreateTree(_attachmentsSlice))
-                        {
-                            var orphanAttachmentDocId = GetOrphanAttachmentDocId(hash);
-                            var existingStream = tree.ReadStream(hash);
-                            if (existingStream != null)
-                            {
-                                // This document points to an attachment which is already in db and already pointed by another document
-                                // we just need to point again this document to the attachment
-                                try
-                                {
-                                    _database.DocumentsStorage.AttachmentsStorage.PutAttachment(_context, document.Id, name, contentType, hash, null,
-                                        existingStream);
-
-                                    var noLongerOrphanAttachmentDoc = _database.DocumentsStorage.Get(_context, orphanAttachmentDocId);
-                                    if (noLongerOrphanAttachmentDoc != null)
-                                        _database.DocumentsStorage.Delete(_context, noLongerOrphanAttachmentDoc.Id, null);
-                                }
-                                finally
-                                {
-                                    existingStream.Dispose();
-                                }
-                            }
-                            else
-                            {
-                                var orphanAttachmentDoc = _database.DocumentsStorage.Get(_context, orphanAttachmentDocId);
-                                if (orphanAttachmentDoc == null)
-                                {
-                                    using (var doc = _context.ReadObject(
-                                        new DynamicJsonValue
-                                        {
-                                            [document.Id] = new DynamicJsonValue {[nameof(Constants.Name)] = name, [nameof(Constants.ContentType)] = contentType},
-                                            [Raven.Client.Constants.Documents.Metadata.Key] = new DynamicJsonValue {[Raven.Client.Constants.Documents.Metadata.Collection] = _recoveryLogCollection}
-                                        }, orphanAttachmentDocId, BlittableJsonDocumentBuilder.UsageMode.ToDisk)
-                                    )
-                                    {
-                                        _database.DocumentsStorage.Put(_context, orphanAttachmentDocId, null, doc);
-                                    }
-                                }
-                                else
-                                {
-                                    orphanAttachmentDoc.Data.Modifications = new DynamicJsonValue(orphanAttachmentDoc.Data)
-                                    {
-                                        [document.Id] = new DynamicJsonValue {[nameof(Constants.Name)] = name, [nameof(Constants.ContentType)] = contentType}
-                                    };
-                                    var newDocument = _context.ReadObject(orphanAttachmentDoc.Data, orphanAttachmentDoc.Id,
-                                        BlittableJsonDocumentBuilder.UsageMode.ToDisk);
-                                    _database.DocumentsStorage.Put(_context, orphanAttachmentDoc.Id, null, newDocument);
-                                }
-                            }
-
-                            tx.Commit();
-                        }
-                    }
-                }
-            }
-        }
-
-        public void Log(string msg, Exception ex = null)
-        {
-            if (_logger.IsOperationsEnabled)
-                _logger.Operations(msg, ex);
+            if (logger.IsOperationsEnabled)
+                logger.Operations(msg, ex);
 
             DocumentsTransaction tx = null;
-            if (_context.HasTransaction == false)
-                tx = _context.OpenWriteTransaction();
+            if (context.HasTransaction == false)
+                tx = context.OpenWriteTransaction();
             try
             {
-                var logDoc = _database.DocumentsStorage.Get(_context, _logDocId);
+                var logDoc = database.DocumentsStorage.Get(context, logDocId);
                 if (ex != null)
                     msg += $". Exception: {ex}";
                 logDoc.Data.Modifications = new DynamicJsonValue
                 {
                     [DateTime.Now.ToString(CultureInfo.InvariantCulture)] = msg
                 };
-                var newDocument = _context.ReadObject(logDoc.Data, _logDocId, BlittableJsonDocumentBuilder.UsageMode.ToDisk);
-                _database.DocumentsStorage.Put(_context, _logDocId, null, newDocument);
+                var newDocument = context.ReadObject(logDoc.Data, logDocId, BlittableJsonDocumentBuilder.UsageMode.ToDisk);
+                database.DocumentsStorage.Put(context, logDocId, null, newDocument);
                 tx?.Commit();
             }
             finally
             {
                 tx?.Dispose();
+            }
+        }
+
+        public void LogWithException(string msg, Exception ex)
+        {
+            try
+            {
+                Log(msg, _logDocId, _logger, _context, _database, ex);
+            }
+            catch (Exception)
+            {
+                // ignore
             }
         }
 
@@ -427,6 +124,37 @@ namespace Voron.Recovery
             }
             _contextDisposal.Dispose();
             _byteStringContext.Dispose();
+        }
+
+        public void WriteAttachment(string hash, string name, string contentType, FileStream attachmentsStream, long totalSize)
+        {
+            DocumentItemsRecovery.WriteAttachment(hash, name, contentType, attachmentsStream, totalSize,
+                _database, _context, _orphanCountersDocIdPrefix, _recoveryLogCollection, _attachmentsSlice,
+                _logDocId, _logger);
+        }
+
+        public void WriteCounterItem(CounterGroupDetail counterGroup)
+        {
+            DocumentItemsRecovery.WriteCounterItem(
+                counterGroup, _database, _databaseDestination, _orphanCountersDocIdPrefix, _context, _results, _recoveryLogCollection, _attachmentsSlice, _logDocId, _logger);
+        }
+
+        public void WriteDocument(Document document)
+        {
+            DocumentRecovery.WriteDocument(
+                document, _database, _databaseDestination, _orphanCountersDocIdPrefix, _context, _results, _recoveryLogCollection, _attachmentsSlice, _logDocId, _logger);
+        }
+
+        public void WriteRevision(Document revision)
+        {
+            DocumentRecovery.WriteRevision(
+                revision, _database, _databaseDestination, _orphanCountersDocIdPrefix, _context, _results, _recoveryLogCollection, _attachmentsSlice, _logDocId, _logger);
+        }
+
+        public void WriteConflict(DocumentConflict conflict)
+        {
+            DocumentRecovery.WriteConflict(
+                conflict, _databaseDestination, _results);
         }
     }
 }

--- a/tools/Voron.Recovery/Recovery.cs
+++ b/tools/Voron.Recovery/Recovery.cs
@@ -512,14 +512,7 @@ namespace Voron.Recovery
                             var message =
                                 $"Unexpected exception at position {GetFilePosition(startOffset, mem)}:{Environment.NewLine} {e}";
                             mem = PrintErrorAndAdvanceMem(message, mem);
-                            try
-                            {
-                                recoveredTool.Log(message, e);
-                            }
-                            catch (Exception)
-                            {
-                                // ignore
-                            }
+                            recoveredTool.LogWithException(message, e);
                         }
 
                     PrintRecoveryProgress(startOffset, mem, eof, DateTime.UtcNow);

--- a/tools/Voron.Recovery/RecoveryConstants.cs
+++ b/tools/Voron.Recovery/RecoveryConstants.cs
@@ -1,0 +1,9 @@
+namespace Voron.Recovery
+{
+    internal static class RecoveryConstants
+    {
+            public static string Name;
+            public static string ContentType;
+            public static string OriginalDocId;
+    }
+}

--- a/tools/Voron.Recovery/VoronRecoveryConfiguration.cs
+++ b/tools/Voron.Recovery/VoronRecoveryConfiguration.cs
@@ -1,4 +1,5 @@
-﻿using Sparrow.Logging;
+﻿using Raven.Server.Documents;
+using Sparrow.Logging;
 
 namespace Voron.Recovery
 {
@@ -17,6 +18,8 @@ namespace Voron.Recovery
         public LogMode LoggingMode { get; set; } = LogMode.Operations;
 
         public byte[] MasterKey { get; set; }
-        public bool IgnoreInvalidPagesInARow { get; set; } 
+        public bool IgnoreInvalidPagesInARow { get; set; }
+
+        public DocumentDatabase RecoveredDatabase { get; set; }
     }
 }

--- a/tools/Voron.Recovery/VoronRecoveryConfiguration.cs
+++ b/tools/Voron.Recovery/VoronRecoveryConfiguration.cs
@@ -7,7 +7,7 @@ namespace Voron.Recovery
     {
         public string PathToDataFile { get; set; }
         public string DataFileDirectory { get; set; }
-        public string OutputFileName { get; set; }
+        public string LoggingOutputPath { get; set; }
         public int PageSizeInKB { get; set; } = 8;
         public int InitialContextSizeInMB { get; set; } = 1;
         public int InitialContextLongLivedSizeInKB { get; set; } = 16;


### PR DESCRIPTION
As first stage, this code recovers successfully documents, attachments, revisions, and counters. It is also recovering conflicts (however it doesn't considering order). Need to add times series.

After that need to remove old exported dump files. 
