### PR TITLE
RavenDB-14700 Improved logging when ETL process is stopped - checking…

### DIFF
--- a/src/Raven.Client/Documents/Operations/ETL/EtlConfiguration.cs
+++ b/src/Raven.Client/Documents/Operations/ETL/EtlConfiguration.cs
@@ -158,7 +158,7 @@ namespace Raven.Client.Documents.Operations.ETL
             if (config.ConnectionStringName != ConnectionStringName)
                 differences |= EtlConfigurationCompareDifferences.ConnectionStringName;
 
-            if (config.Name != Name)
+            if (config.Name.Equals(Name, StringComparison.OrdinalIgnoreCase) == false)
                 differences |= EtlConfigurationCompareDifferences.ConfigurationName;
 
             if (config.MentorNode != MentorNode)

--- a/src/Raven.Client/Documents/Operations/ETL/Transformation.cs
+++ b/src/Raven.Client/Documents/Operations/ETL/Transformation.cs
@@ -310,7 +310,7 @@ namespace Raven.Client.Documents.Operations.ETL
             if (collections.Count != 0)
                 differences |= EtlConfigurationCompareDifferences.TransformationCollectionsCount;
 
-            if (transformation.Name != Name)
+            if (transformation.Name.Equals(Name, StringComparison.OrdinalIgnoreCase) == false)
                 differences |= EtlConfigurationCompareDifferences.TransformationName;
 
             if (transformation.Script != Script)


### PR DESCRIPTION
… what node is responsible for it. Making sure that ETL config names are case insensitive.