### PR TITLE
RavenDB-14394 Allow deserializing an object with a property set to Enumerable.Empty<T>()

### DIFF
--- a/src/Raven.Client/Json/Converters/JsonLinqEnumerableConverter.cs
+++ b/src/Raven.Client/Json/Converters/JsonLinqEnumerableConverter.cs
@@ -39,6 +39,12 @@ namespace Raven.Client.Json.Converters
         }
 
         /// <summary>
+        /// Gets a value indicating whether this <see cref="JsonConverter"/> can read JSON.
+        /// </summary>
+        /// <value><c>true</c> if this <see cref="JsonConverter"/> can read JSON; otherwise, <c>false</c>.</value>
+        public override bool CanRead => false;
+        
+        /// <summary>
         /// Reads the JSON representation of the object.
         /// </summary>
         /// <remarks>

--- a/test/FastTests/Client/Load.cs
+++ b/test/FastTests/Client/Load.cs
@@ -1,4 +1,6 @@
 ﻿using System.Collections.Generic;
+using System.Linq;
+using System.Threading.Tasks;
 using Raven.Client.Documents.Commands;
 using Raven.Tests.Core.Utils.Entities;
 using Sparrow.Json;
@@ -190,6 +192,36 @@ namespace FastTests.Client
                 {
                     rq1.Execute(cmd, ctx);
                 }
+            }
+        }
+        
+        private class ToStore
+        {
+            public IEnumerable<string> Prop { get; set; }
+        }
+        
+        private class ContainEnumerableEmpty
+        {
+            public IEnumerable<string> Prop { get; set; } = Enumerable.Empty<string>();
+        }
+        
+        [Fact]
+        public async Task LoadDoc_WhenContainEnumerableEmpty_ShouldWork()
+        {
+            const string id = "someId";
+            var prop = new []{"something"};
+            
+            using var store = GetDocumentStore();
+             
+            using (var session = store.OpenAsyncSession())
+            {
+                await session.StoreAsync(new ToStore{Prop = prop}, id);
+                await session.SaveChangesAsync();
+            }
+            using (var session = store.OpenAsyncSession())
+            {
+                var load = await session.LoadAsync<ContainEnumerableEmpty>(id);
+                Assert.Equal(prop, load.Prop);
             }
         }
     }


### PR DESCRIPTION
https://issues.hibernatingrhinos.com/issue/RavenDB-14394