### PR TITLE
RavenDB-14851 remove time-series replication optimizations

### DIFF
--- a/src/Raven.Server/Documents/Replication/IncomingReplicationHandler.cs
+++ b/src/Raven.Server/Documents/Replication/IncomingReplicationHandler.cs
@@ -1028,8 +1028,8 @@ namespace Raven.Server.Documents.Replication
                                     From = deletedRange.From,
                                     To = deletedRange.To
                                 };
-
-                                tss.RemoveTimestampRange(context, deletionRangeRequest, rcvdChangeVector);
+                                var removedChangeVector = tss.RemoveTimestampRange(context, deletionRangeRequest, rcvdChangeVector);
+                                context.LastDatabaseChangeVector = ChangeVectorUtils.MergeVectors(removedChangeVector, rcvdChangeVector);
                                 break;
                             case TimeSeriesReplicationItem segment:
                                 tss = database.DocumentsStorage.TimeSeriesStorage;

--- a/src/Raven.Server/Documents/TimeSeries/TimeSeriesStats.cs
+++ b/src/Raven.Server/Documents/TimeSeries/TimeSeriesStats.cs
@@ -159,6 +159,7 @@ namespace Raven.Server.Documents.TimeSeries
                 if (TryHandleDeadSegment() == false)
                 {
                     table.DeleteByKey(slicer.StatsKey);
+                    TimeSeriesStorage.RemoveTimeSeriesNameFromMetadata(context, slicer.DocId, slicer.Name);
                     return; // this ts was completely deleted
                 }
             }
@@ -186,7 +187,7 @@ namespace Raven.Server.Documents.TimeSeries
                 {
                     var reader = tss.GetReader(context, slicer.DocId, slicer.Name, start, DateTime.MaxValue);
                     var last = reader.Last();
-                    
+               
                     var lastValueInCurrentSegment = reader.ReadBaselineAsDateTime() == baseline;
                     end = lastValueInCurrentSegment ? lastTimestamp : last.Timestamp;
                 }
@@ -335,16 +336,16 @@ namespace Raven.Server.Documents.TimeSeries
             }
         }
 
-        public void DeleteStats(DocumentsOperationContext context, CollectionName collection, Slice key)
+        public bool DeleteStats(DocumentsOperationContext context, CollectionName collection, Slice key)
         {
             var table = GetOrCreateTable(context.Transaction.InnerTransaction, collection);
-            table.DeleteByKey(key);
+            return table.DeleteByKey(key);
         }
 
-        public void DeleteByPrimaryKeyPrefix(DocumentsOperationContext context, CollectionName collection, Slice key)
+        public bool DeleteByPrimaryKeyPrefix(DocumentsOperationContext context, CollectionName collection, Slice key)
         {
             var table = GetOrCreateTable(context.Transaction.InnerTransaction, collection);
-            table.DeleteByPrimaryKeyPrefix(key);
+            return table.DeleteByPrimaryKeyPrefix(key);
         }
 
         private Slice GetPolicy(TimeSeriesSliceHolder slicer)

--- a/src/Voron/Data/Tables/Table.cs
+++ b/src/Voron/Data/Tables/Table.cs
@@ -1467,7 +1467,10 @@ namespace Voron.Data.Tables
             using (var it = fst.Iterate())
             {
                 if (it.Seek(value) == false)
-                    return true;
+                    return false;
+
+                if (it.CurrentKey != value)
+                    return false;
 
                 Delete(it.CreateReaderForCurrent().ReadLittleEndianInt64());
                 return true;

--- a/test/FastTests/Voron/Tables/TableIndexes.cs
+++ b/test/FastTests/Voron/Tables/TableIndexes.cs
@@ -226,5 +226,63 @@ namespace FastTests.Voron.Tables
                 }
             }
         }
+
+        [Fact]
+        public void delete_by_fixed_sized_index()
+        {
+            using (var tx = Env.WriteTransaction())
+            {
+                Slice.From(tx.Allocator, "EtagIndexName", out var etagIndexName);
+                var fixedSizedIndex = new TableSchema.FixedSizeSchemaIndexDef
+                {
+                    Name = etagIndexName,
+                    IsGlobal = true,
+                    StartIndex = 1,
+                };
+
+                var tableSchema = new TableSchema()
+                    .DefineFixedSizeIndex(fixedSizedIndex)
+                    .DefineKey(new TableSchema.SchemaIndexDef
+                    {
+                        StartIndex = 0,
+                        Count = 1,
+                    });
+
+                tableSchema.Create(tx, "Items", 16);
+                var itemsTable = tx.OpenTable(tableSchema, "Items");
+                const long number1 = 1L;
+                const long number2 = 2L;
+                const long number3 = 3L;
+
+                using (itemsTable.Allocate(out TableValueBuilder builder))
+                using (Slice.From(tx.Allocator, "val1", out var key))
+                {
+                    builder.Add(key);
+                    builder.Add(Bits.SwapBytes(number1));
+                    itemsTable.Set(builder);
+                }
+
+                using (itemsTable.Allocate(out TableValueBuilder builder))
+                using (Slice.From(tx.Allocator, "val2", out var key))
+                {
+                    builder.Add(key);
+                    builder.Add(Bits.SwapBytes(number2));
+                    itemsTable.Set(builder);
+                }
+
+                using (itemsTable.Allocate(out TableValueBuilder builder))
+                using (Slice.From(tx.Allocator, "val3", out var key))
+                {
+                    builder.Add(key);
+                    builder.Add(Bits.SwapBytes(number3));
+                    itemsTable.Set(builder);
+                }
+                
+                Assert.False(itemsTable.DeleteByIndex(fixedSizedIndex, 0L));
+                Assert.True(itemsTable.DeleteByIndex(fixedSizedIndex, 2L));
+                Assert.True(itemsTable.DeleteByIndex(fixedSizedIndex, 3L));
+                Assert.True(itemsTable.DeleteByIndex(fixedSizedIndex, 1L));
+            }
+        }
     }
 }

--- a/test/SlowTests/Client/TimeSeries/Replication/TimeSeriesReplicationTests.cs
+++ b/test/SlowTests/Client/TimeSeries/Replication/TimeSeriesReplicationTests.cs
@@ -416,6 +416,9 @@ namespace SlowTests.Client.TimeSeries.Replication
                         }
                     }
                 }
+
+                await EnsureNoReplicationLoop(Server, storeA.Database);
+                await EnsureNoReplicationLoop(Server, storeB.Database);
             }
         }
 

--- a/test/SlowTests/Issues/RavenDB_14230.cs
+++ b/test/SlowTests/Issues/RavenDB_14230.cs
@@ -105,7 +105,7 @@ namespace SlowTests.Issues
                 Assert.Equal("users/1", timeSeriesChange.DocumentId);
                 Assert.Equal(TimeSeriesChangeTypes.Delete, timeSeriesChange.Type);
                 Assert.Equal("Likes", timeSeriesChange.Name);
-                Assert.Null(timeSeriesChange.ChangeVector); // we deleted entire segment
+                Assert.NotNull(timeSeriesChange.ChangeVector);
             }
         }
 

--- a/test/StressTests/Client/TimeSeries/TimeSeriesStress.cs
+++ b/test/StressTests/Client/TimeSeries/TimeSeriesStress.cs
@@ -6,6 +6,8 @@ using FastTests.Server.Replication;
 using Raven.Client.Documents.Operations.TimeSeries;
 using Raven.Client.Documents.Session;
 using Raven.Server;
+using Raven.Server.Config;
+using Raven.Server.Documents.TimeSeries;
 using Raven.Server.ServerWide.Context;
 using Raven.Tests.Core.Utils.Entities;
 using Sparrow;
@@ -70,10 +72,13 @@ namespace StressTests.Client.TimeSeries
 
                 var sp = Stopwatch.StartNew();
                 await Task.Delay((TimeSpan)retention / 2);
+                
+                WaitForUserToContinueTheTest(store);
 
                 var check = true;
                 while (check)
                 {
+                    Assert.True(sp.Elapsed < ((TimeSpan)retention).Add((TimeSpan)retention / 10),$"too long has passed {sp.Elapsed}, retention is {retention}");
                     await Task.Delay(100);
                     check = false;
                     foreach (var server in Servers)
@@ -98,6 +103,124 @@ namespace StressTests.Client.TimeSeries
                 }
 
                 Assert.True(sp.Elapsed < (TimeSpan)retention + (TimeSpan)retention / 10);
+                await Task.Delay(3000); // let the dust to settle
+
+                await EnsureNoReplicationLoop(Servers[0], store.Database);
+                await EnsureNoReplicationLoop(Servers[1], store.Database);
+                await EnsureNoReplicationLoop(Servers[2], store.Database);
+            }
+        }
+
+
+        [Fact]
+        public async Task ManyTimeSeriesRetention()
+        {
+            DefaultClusterSettings[RavenConfiguration.GetKey(x => x.Tombstones.CleanupInterval)] = 1.ToString();
+            var cluster = await CreateRaftCluster(3, watcherCluster: true);
+            using (var store = GetDocumentStore(new Options
+            {
+                Server = cluster.Leader,
+                ReplicationFactor = 3,
+                RunInMemory = false
+            }))
+            {
+                var retention = TimeSpan.FromSeconds(60);
+                var raw = new RawTimeSeriesPolicy(retention);
+                var config = new TimeSeriesConfiguration
+                {
+                    Collections = new Dictionary<string, TimeSeriesCollectionConfiguration>
+                    {
+                        ["Users"] = new TimeSeriesCollectionConfiguration
+                        {
+                            RawPolicy = raw,
+                            Policies = new List<TimeSeriesPolicy>
+                            {
+                                new TimeSeriesPolicy("ByMinute", TimeSpan.FromSeconds(60))
+                            }
+                        }
+                    },
+                    PolicyCheckFrequency = TimeSpan.FromSeconds(1)
+                };
+                
+                await store.Maintenance.SendAsync(new ConfigureTimeSeriesOperation(config));
+
+                for (int j = 0; j < 1024; j++)
+                {
+                    var now = DateTime.UtcNow;
+                    var baseline = now.Add(-retention * 2);
+                    var total = (int)retention.TotalSeconds * 2;
+
+                    using (var session = store.OpenSession())
+                    {
+                        var id = "users/karmel/" + j;
+                        session.Store(new User {Name = "Karmel"}, id);
+
+                        for (int i = 0; i < total; i++)
+                        {
+                            session.TimeSeriesFor(id, "Heartrate")
+                                .Append(baseline.AddSeconds(i), i);
+                        }
+                        session.SaveChanges();
+                    }
+                }
+
+                using (var session = store.OpenSession())
+                {
+                    session.Store(new User(),"marker");
+                    session.SaveChanges();
+
+                    await WaitForDocumentInClusterAsync<User>((DocumentSession)session, "marker", null, TimeSpan.FromSeconds(15));
+                }
+
+                var sp = Stopwatch.StartNew();
+                await Task.Delay(retention / 2);
+
+                WaitForUserToContinueTheTest(store);
+
+                var check = true;
+                while (check)
+                {
+                    Assert.True(sp.Elapsed < retention.Add(retention / 10),$"too long has passed {sp.Elapsed}, retention is {retention}");
+                    await Task.Delay(100);
+                    check = false;
+                    foreach (var server in Servers)
+                    {
+                        var database = await server.ServerStore.DatabasesLandlord.TryGetOrCreateResourceStore(store.Database);
+                        var tss = database.DocumentsStorage.TimeSeriesStorage;
+
+                        for (int j = 0; j < 1024; j++)
+                        {
+                            using (database.DocumentsStorage.ContextPool.AllocateOperationContext(out DocumentsOperationContext ctx))
+                            using (ctx.OpenReadTransaction())
+                            {
+                                var id = $"users/karmel/{j}";
+                                var stats = tss.Stats.GetStats(ctx, id, "Heartrate");
+
+                                TimeSeriesStorage.Reader reader;
+                                if (stats == default || stats.Count == 0)
+                                {
+                                    var name = config.Collections["Users"].Policies[0].GetTimeSeriesName("Heartrate");
+                                    stats = tss.Stats.GetStats(ctx, id, name);
+                                    reader = tss.GetReader(ctx, id, name, DateTime.MinValue, DateTime.MaxValue);
+
+                                    Assert.True(stats.Count > 0);
+                                    Assert.Equal(stats.Start, reader.First().Timestamp);
+                                    Assert.Equal(stats.End, reader.Last().Timestamp);
+                                    continue;
+                                }
+
+                                check = true;
+                                reader = tss.GetReader(ctx, id, "Heartrate", DateTime.MinValue, DateTime.MaxValue);
+                                Assert.Equal(stats.Start, reader.First().Timestamp);
+                                Assert.Equal(stats.End, reader.Last().Timestamp);
+                            }
+                        }
+                    }
+                }
+
+                await EnsureNoReplicationLoop(Servers[0], store.Database);
+                await EnsureNoReplicationLoop(Servers[1], store.Database);
+                await EnsureNoReplicationLoop(Servers[2], store.Database);
             }
         }
     }

--- a/test/Tests.Infrastructure/ClusterTestBase.cs
+++ b/test/Tests.Infrastructure/ClusterTestBase.cs
@@ -158,7 +158,7 @@ namespace Tests.Infrastructure
 
             var etag2 = storage.DocumentsStorage.GenerateNextEtag();
 
-            Assert.Equal(etag1 + 1, etag2);
+            Assert.True(etag1 + 1 == etag2,"Replication loop found :(");
         }
 
         public class GetDatabaseDocumentTestCommand : RavenCommand<DatabaseRecord>


### PR DESCRIPTION
The work on the rollup/retention revealed some replication issues.
This PR hopefully will bring the replication to a correct and stable state for all cases.
