### PR TITLE
HRINT-1576

### DIFF
--- a/src/Raven.Client/Documents/Conventions/DocumentConventions.cs
+++ b/src/Raven.Client/Documents/Conventions/DocumentConventions.cs
@@ -182,6 +182,9 @@ namespace Raven.Client.Documents.Conventions
             _secondBroadcastAttemptTimeout = TimeSpan.FromSeconds(30);
 
             _sendApplicationIdentifier = true;
+            _maxContextSizeToKeep = PlatformDetails.Is32Bits == false
+                ? new Size(1, SizeUnit.Megabytes)
+                : new Size(256, SizeUnit.Kilobytes);
         }
 
         private bool _frozen;
@@ -227,6 +230,17 @@ namespace Raven.Client.Documents.Conventions
         private string _topologyCacheLocation;
         private Version _httpVersion;
         private bool _sendApplicationIdentifier;
+        private Size _maxContextSizeToKeep;
+
+        public Size MaxContextSizeToKeep
+        {
+            get => _maxContextSizeToKeep;
+            set
+            {
+                AssertNotFrozen();
+                _maxContextSizeToKeep = value;
+            }
+        }
 
         /// <summary>
         /// Enables sending a unique application identifier to the RavenDB Server that is used for Client API usage tracking.

--- a/src/Raven.Client/Documents/Conventions/DocumentConventions.cs
+++ b/src/Raven.Client/Documents/Conventions/DocumentConventions.cs
@@ -43,7 +43,8 @@ namespace Raven.Client.Documents.Conventions
 
         internal static readonly DocumentConventions DefaultForServer = new DocumentConventions
         {
-            SendApplicationIdentifier = false
+            SendApplicationIdentifier = false,
+            MaxContextSizeToKeep = new Size(PlatformDetails.Is32Bits == false ? 8 : 2, SizeUnit.Megabytes)
         };
 
         private static Dictionary<Type, string> _cachedDefaultTypeCollectionNames = new Dictionary<Type, string>();

--- a/src/Raven.Client/Http/RequestExecutor.cs
+++ b/src/Raven.Client/Http/RequestExecutor.cs
@@ -33,7 +33,6 @@ using Sparrow.Json;
 using Sparrow.Logging;
 using Sparrow.Platform;
 using Sparrow.Threading;
-using Size = Sparrow.Size;
 
 namespace Raven.Client.Http
 {
@@ -353,16 +352,14 @@ namespace Raven.Client.Http
 
             _lastReturnedResponse = DateTime.UtcNow;
 
-            var maxContextSizeToKeep = PlatformDetails.Is32Bits == false
-                ? new Size(1, SizeUnit.Megabytes)
-                : new Size(256, SizeUnit.Kilobytes);
+            Conventions = conventions.Clone();
 
             var maxNumberOfContextsToKeepInGlobalStack = PlatformDetails.Is32Bits == false
                 ? 1024
                 : 256;
 
-            ContextPool = new JsonContextPool(maxContextSizeToKeep, maxNumberOfContextsToKeepInGlobalStack);
-            Conventions = conventions.Clone();
+            ContextPool = new JsonContextPool(Conventions.MaxContextSizeToKeep, maxNumberOfContextsToKeepInGlobalStack);
+
             DefaultTimeout = Conventions.RequestTimeout;
             SecondBroadcastAttemptTimeout = conventions.SecondBroadcastAttemptTimeout;
             FirstBroadcastAttemptTimeout = conventions.FirstBroadcastAttemptTimeout;

--- a/src/Raven.Client/Http/RequestExecutor.cs
+++ b/src/Raven.Client/Http/RequestExecutor.cs
@@ -31,6 +31,7 @@ using Sparrow;
 using Sparrow.Collections;
 using Sparrow.Json;
 using Sparrow.Logging;
+using Sparrow.Platform;
 using Sparrow.Threading;
 using Size = Sparrow.Size;
 
@@ -352,7 +353,15 @@ namespace Raven.Client.Http
 
             _lastReturnedResponse = DateTime.UtcNow;
 
-            ContextPool = new JsonContextPool(new Size(8, SizeUnit.Megabytes));
+            var maxContextSizeToKeep = PlatformDetails.Is32Bits == false
+                ? new Size(1, SizeUnit.Megabytes)
+                : new Size(256, SizeUnit.Kilobytes);
+
+            var maxNumberOfContextsToKeepInGlobalStack = PlatformDetails.Is32Bits == false
+                ? 1024
+                : 256;
+
+            ContextPool = new JsonContextPool(maxContextSizeToKeep, maxNumberOfContextsToKeepInGlobalStack);
             Conventions = conventions.Clone();
             DefaultTimeout = Conventions.RequestTimeout;
             SecondBroadcastAttemptTimeout = conventions.SecondBroadcastAttemptTimeout;

--- a/src/Sparrow/Json/JsonContextPool.cs
+++ b/src/Sparrow/Json/JsonContextPool.cs
@@ -6,7 +6,13 @@
         {
         }
 
-        public JsonContextPool(Size? maxContextSizeToKeepInMb = null) : base(maxContextSizeToKeepInMb)
+        public JsonContextPool(Size? maxContextSizeToKeep)
+            : this(maxContextSizeToKeep, null)
+        {
+        }
+
+        internal JsonContextPool(Size? maxContextSizeToKeep, long? maxNumberOfContextsToKeepInGlobalStack)
+            : base(maxContextSizeToKeep, maxNumberOfContextsToKeepInGlobalStack)
         {
         }
 
@@ -14,8 +20,8 @@
         {
             if (Platform.PlatformDetails.Is32Bits)
                 return new JsonOperationContext(4096, 16 * 1024, LowMemoryFlag);
-                
-            return new JsonOperationContext(32*1024, 16*1024, LowMemoryFlag);
+
+            return new JsonOperationContext(32 * 1024, 16 * 1024, LowMemoryFlag);
         }
     }
 }

--- a/src/Sparrow/Json/JsonContextPoolBase.cs
+++ b/src/Sparrow/Json/JsonContextPoolBase.cs
@@ -1,24 +1,30 @@
 ﻿using System;
 using System.Collections.Concurrent;
+using System.Collections.Generic;
 using System.Threading;
 using Sparrow.LowMemory;
+using Sparrow.Platform;
 using Sparrow.Threading;
 using Sparrow.Utils;
 
 namespace Sparrow.Json
 {
-    public abstract class JsonContextPoolBase<T> : ILowMemoryHandler, IDisposable 
+    public abstract class JsonContextPoolBase<T> : ILowMemoryHandler, IDisposable
         where T : JsonOperationContext
     {
+        private readonly object _locker = new object();
+
         private long _generation;
         private bool _disposed;
 
         protected SharedMultipleUseFlag LowMemoryFlag = new SharedMultipleUseFlag();
         private readonly CancellationTokenSource _cts = new CancellationTokenSource();
         private readonly long _maxContextSizeToKeepInBytes;
+        private readonly long _maxNumberOfContextsToKeepInGlobalStack;
 
         private readonly T[][] _perCoreContexts;
-        private readonly ConcurrentQueue<T> _globalQueue = new ConcurrentQueue<T>();
+        private CountingConcurrentStack<T> _previousGlobalStack;
+        private CountingConcurrentStack<T> _currentGlobalStack = new CountingConcurrentStack<T>();
         private readonly Timer _idleTimer;
 
         protected JsonContextPoolBase()
@@ -28,18 +34,27 @@ namespace Sparrow.Json
             {
                 _perCoreContexts[i] = new T[64];
             }
-            _idleTimer = new Timer(IdleTimer, null, TimeSpan.FromMinutes(1), TimeSpan.FromMinutes(1));
+            _idleTimer = new Timer(CleanupTimer, null, TimeSpan.FromMinutes(1), TimeSpan.FromMinutes(1));
             LowMemoryNotification.Instance?.RegisterLowMemoryHandler(this);
             _maxContextSizeToKeepInBytes = long.MaxValue;
-
+            _maxNumberOfContextsToKeepInGlobalStack = PlatformDetails.Is32Bits == false
+                ? 4096
+                : 1024;
         }
 
-        protected JsonContextPoolBase(Size? maxContextSizeToKeepInMb) : this()
+        protected JsonContextPoolBase(Size? maxContextSizeToKeep)
+            : this()
         {
-            if (maxContextSizeToKeepInMb != null)
-                _maxContextSizeToKeepInBytes = maxContextSizeToKeepInMb.Value.GetValue(SizeUnit.Bytes);
+            if (maxContextSizeToKeep.HasValue)
+                _maxContextSizeToKeepInBytes = maxContextSizeToKeep.Value.GetValue(SizeUnit.Bytes);
         }
 
+        protected JsonContextPoolBase(Size? maxContextSizeToKeep, long? maxNumberOfContextsToKeepInGlobalStack)
+            : this(maxContextSizeToKeep)
+        {
+            if (maxNumberOfContextsToKeepInGlobalStack.HasValue)
+                _maxNumberOfContextsToKeepInGlobalStack = maxNumberOfContextsToKeepInGlobalStack.Value;
+        }
 
         public IDisposable AllocateOperationContext(out JsonOperationContext context)
         {
@@ -86,12 +101,8 @@ namespace Sparrow.Json
                 };
             }
 
-            while (_globalQueue.TryDequeue(out context))
+            if (TryGetFromStack(_previousGlobalStack, out context) || TryGetFromStack(_currentGlobalStack, out context))
             {
-                if (context.InUse.Raise() == false)
-                    continue;
-
-                context.Renew();
                 return new ReturnRequestContext
                 {
                     Parent = this,
@@ -107,6 +118,25 @@ namespace Sparrow.Json
                 Parent = this,
                 Context = context
             };
+
+            static bool TryGetFromStack(CountingConcurrentStack<T> stack, out T context)
+            {
+                context = default;
+
+                if (stack == null || stack.IsEmpty)
+                    return false;
+
+                while (stack.TryPop(out context))
+                {
+                    if (context.InUse.Raise() == false)
+                        continue;
+
+                    context.Renew();
+                    return true;
+                }
+
+                return false;
+            }
         }
 
         protected abstract T CreateContext();
@@ -152,56 +182,94 @@ namespace Sparrow.Json
             }
         }
 
-        private void IdleTimer(object _)
+        private DateTime _lastPerCoreCleanup = DateTime.UtcNow;
+        private readonly TimeSpan _perCoreCleanupInterval = TimeSpan.FromMinutes(5);
+
+        private DateTime _lastGlobalStackRebuild = DateTime.UtcNow;
+        private readonly TimeSpan _globalStackRebuildInterval = TimeSpan.FromMinutes(15);
+
+        private void CleanupTimer(object _)
         {
-            var currentTime = DateTime.UtcNow;
-            TimeSpan idleTime = TimeSpan.FromMinutes(5);
+            if (Monitor.TryEnter(_locker) == false)
+                return;
 
-            if (_globalQueue.IsEmpty)
+            try
             {
-                // we have nothing in global, let's check if we can clear the per core
-                foreach (var current in _perCoreContexts)
+                var currentTime = DateTime.UtcNow;
+                var idleTime = TimeSpan.FromMinutes(5);
+                var currentGlobalStack = _currentGlobalStack;
+
+                var perCoreCleanupNeeded = currentGlobalStack.IsEmpty || currentTime - _lastPerCoreCleanup >= _perCoreCleanupInterval;
+                if (perCoreCleanupNeeded)
                 {
-                    for (var index = 0; index < current.Length; index++)
+                    _lastPerCoreCleanup = currentTime;
+
+                    foreach (var current in _perCoreContexts)
                     {
-                        var context = current[index];
-                        if(context == null)
+                        for (var index = 0; index < current.Length; index++)
+                        {
+                            var context = current[index];
+                            if (context == null)
+                                continue;
+
+                            var timeInPool = currentTime - context.InPoolSince;
+                            if (timeInPool <= idleTime)
+                                continue;
+
+                            if (context.InUse.Raise() == false)
+                                continue;
+
+                            Interlocked.CompareExchange(ref current[index], null, context);
+                            context.Dispose();
+                        }
+                    }
+
+                    return;
+                }
+
+                using (var globalStackEnumerator = currentGlobalStack.GetEnumerator())
+                {
+                    while (globalStackEnumerator.MoveNext())
+                    {
+                        var context = globalStackEnumerator.Current;
+
+                        var timeInPool = currentTime - context.InPoolSince;
+                        if (timeInPool <= idleTime)
                             continue;
 
-                        if (currentTime - context.InPoolSince > idleTime)
-                            continue;
-
-                        if (!context.InUse.Raise())
-                            continue;
-
-                        Interlocked.CompareExchange(ref current[index], null, context);
-                        context.Dispose();
+                        if (context.InUse.Raise())
+                            context.Dispose();
                     }
                 }
 
-                return;
+                var globalStackRebuildNeeded = currentTime - _lastGlobalStackRebuild >= _globalStackRebuildInterval;
+
+                if (globalStackRebuildNeeded)
+                {
+                    _lastGlobalStackRebuild = currentTime;
+
+                    var previousGlobalStack = _previousGlobalStack;
+
+                    _currentGlobalStack = new CountingConcurrentStack<T>();
+                    _previousGlobalStack = currentGlobalStack;
+
+                    ClearStack(previousGlobalStack);
+                }
+            }
+            finally
+            {
+                Monitor.Exit(_locker);
             }
 
-            while (_globalQueue.TryPeek(out var context))
+            static void ClearStack(CountingConcurrentStack<T> stack)
             {
-                if (currentTime - context.InPoolSince < idleTime)
-                {
-                    break;
-                }
+                if (stack == null || stack.IsEmpty)
+                    return;
 
-                if (_globalQueue.TryDequeue(out context) == false)
-                    break;
-
-                if (currentTime - context.InPoolSince > idleTime)
+                while (stack.TryPop(out var context))
                 {
                     if (context.InUse.Raise())
                         context.Dispose();
-                }
-                else
-                {
-                    // was checked out, meaning there is activity, we are done now
-                    _globalQueue.Enqueue(context);
-                    break;
                 }
             }
         }
@@ -225,14 +293,24 @@ namespace Sparrow.Json
                 return;
             }
 
+            var currentGlobalStack = _currentGlobalStack;
+
             // couldn't find a place for it, let's add it to the global list
-            _globalQueue.Enqueue(context);
+            if (currentGlobalStack.Count >= _maxNumberOfContextsToKeepInGlobalStack)
+            {
+                context.Dispose();
+                return;
+            }
+
+            currentGlobalStack.Push(context);
         }
+
         public virtual void Dispose()
         {
             if (_disposed)
                 return;
-            lock (this)
+
+            lock (_locker)
             {
                 if (_disposed)
                     return;
@@ -241,10 +319,8 @@ namespace Sparrow.Json
                 _disposed = true;
                 _idleTimer.Dispose();
 
-                while (_globalQueue.TryDequeue(out var result))
-                {
-                    result.Dispose();
-                }
+                ClearStack(_previousGlobalStack);
+                ClearStack(_currentGlobalStack);
 
                 foreach (var coreContext in _perCoreContexts)
                 {
@@ -253,7 +329,17 @@ namespace Sparrow.Json
                         coreContext[i]?.Dispose();
                         coreContext[i] = null;
                     }
+                }
+            }
 
+            static void ClearStack(CountingConcurrentStack<T> stack)
+            {
+                if (stack == null || stack.IsEmpty)
+                    return;
+
+                while (stack.TryPop(out var context))
+                {
+                    context.Dispose();
                 }
             }
         }
@@ -270,11 +356,8 @@ namespace Sparrow.Json
 
             Interlocked.Increment(ref _generation);
 
-            while (_globalQueue.TryDequeue(out var result))
-            {
-                if (result.InUse.Raise())
-                    result.Dispose();
-            }
+            ClearStack(_previousGlobalStack);
+            ClearStack(_currentGlobalStack);
 
             foreach (var coreContext in _perCoreContexts)
             {
@@ -288,11 +371,57 @@ namespace Sparrow.Json
                     }
                 }
             }
+
+            static void ClearStack(CountingConcurrentStack<T> stack)
+            {
+                if (stack == null || stack.IsEmpty)
+                    return;
+
+                while (stack.TryPop(out var context))
+                {
+                    if (context.InUse.Raise())
+                        context.Dispose();
+                }
+            }
         }
 
         public void LowMemoryOver()
         {
             LowMemoryFlag.Lower();
+        }
+
+        private sealed class CountingConcurrentStack<TItem>
+        {
+            private readonly ConcurrentStack<TItem> _stack = new ConcurrentStack<TItem>();
+
+            private long _count;
+
+            public bool IsEmpty => _stack.IsEmpty;
+
+            public long Count => Interlocked.Read(ref _count);
+
+            public bool TryPop(out TItem item)
+            {
+                if (_stack.TryPop(out item) == false)
+                {
+                    item = default;
+                    return false;
+                }
+
+                Interlocked.Decrement(ref _count);
+                return true;
+            }
+
+            public void Push(TItem item)
+            {
+                _stack.Push(item);
+                Interlocked.Increment(ref _count);
+            }
+
+            public IEnumerator<TItem> GetEnumerator()
+            {
+                return _stack.GetEnumerator();
+            }
         }
     }
 }

--- a/src/Sparrow/Json/JsonContextPoolBase.cs
+++ b/src/Sparrow/Json/JsonContextPoolBase.cs
@@ -238,11 +238,11 @@ namespace Sparrow.Json
                         if (timeInPool <= idleTime)
                             continue;
 
-                        if (context.InUse.Raise())
-                        {
-                            context.Dispose();
-                            _numberOfContextsDisposedInGlobalStack++;
-                        }
+                        if (context.InUse.Raise() == false)
+                            continue;
+
+                        context.Dispose();
+                        _numberOfContextsDisposedInGlobalStack++;
                     }
                 }
 


### PR DESCRIPTION
- added limits to RequestExecutor context pool
- switch from Queue to Stack to constantly reuse same contexts instead of reusing all of them, this should allow to clear them more easily