### PR TITLE
HRINT-1576

### DIFF
--- a/src/Raven.Client/Http/RequestExecutor.cs
+++ b/src/Raven.Client/Http/RequestExecutor.cs
@@ -358,7 +358,7 @@ namespace Raven.Client.Http
                 ? 1024
                 : 256;
 
-            ContextPool = new JsonContextPool(Conventions.MaxContextSizeToKeep, maxNumberOfContextsToKeepInGlobalStack);
+            ContextPool = new JsonContextPool(Conventions.MaxContextSizeToKeep, maxNumberOfContextsToKeepInGlobalStack, 1024);
 
             DefaultTimeout = Conventions.RequestTimeout;
             SecondBroadcastAttemptTimeout = conventions.SecondBroadcastAttemptTimeout;

--- a/src/Raven.Server/ServerWide/Context/DocumentsContextPool.cs
+++ b/src/Raven.Server/ServerWide/Context/DocumentsContextPool.cs
@@ -4,10 +4,8 @@
 //  </copyright>
 // -----------------------------------------------------------------------
 
-using System;
 using Raven.Server.Documents;
 using Sparrow.Json;
-using Sparrow.Platform;
 
 namespace Raven.Server.ServerWide.Context
 {
@@ -22,9 +20,9 @@ namespace Raven.Server.ServerWide.Context
 
         protected override DocumentsOperationContext CreateContext()
         {
-            return _database.Is32Bits ? 
-                new DocumentsOperationContext(_database, 32 * 1024, 4 * 1024, LowMemoryFlag) :
-                new DocumentsOperationContext(_database, 64 * 1024, 16 * 1024, LowMemoryFlag);
+            return _database.Is32Bits ?
+                new DocumentsOperationContext(_database, 32 * 1024, 4 * 1024, 8 * 1024, LowMemoryFlag) :
+                new DocumentsOperationContext(_database, 64 * 1024, 16 * 1024, 32 * 1024, LowMemoryFlag);
         }
 
         public override void Dispose()

--- a/src/Raven.Server/ServerWide/Context/DocumentsOperationContext.cs
+++ b/src/Raven.Server/ServerWide/Context/DocumentsOperationContext.cs
@@ -27,10 +27,10 @@ namespace Raven.Server.ServerWide.Context
         protected internal override void Reset(bool forceResetLongLivedAllocator = false)
         {
             base.Reset(forceResetLongLivedAllocator);
-            
+
             // make sure that we don't remember an old value here from a previous
-            // tx. This can be an issue if we resort to context stealing from 
-            // other threads, so we are going the safe route and ensuring that 
+            // tx. This can be an issue if we resort to context stealing from
+            // other threads, so we are going the safe route and ensuring that
             // we always create a new instance
             LastDatabaseChangeVector = null;
             LastReplicationEtagFrom = null;
@@ -39,12 +39,12 @@ namespace Raven.Server.ServerWide.Context
 
         public static DocumentsOperationContext ShortTermSingleUse(DocumentDatabase documentDatabase)
         {
-            var shortTermSingleUse = new DocumentsOperationContext(documentDatabase, 4096, 1024, SharedMultipleUseFlag.None);
+            var shortTermSingleUse = new DocumentsOperationContext(documentDatabase, 4096, 1024, 32 * 1024, SharedMultipleUseFlag.None);
             return shortTermSingleUse;
         }
 
-        public DocumentsOperationContext(DocumentDatabase documentDatabase, int initialSize, int longLivedSize, SharedMultipleUseFlag lowMemoryFlag) :
-            base(initialSize, longLivedSize, lowMemoryFlag)
+        public DocumentsOperationContext(DocumentDatabase documentDatabase, int initialSize, int longLivedSize, int maxNumberOfAllocatedStringValues, SharedMultipleUseFlag lowMemoryFlag)
+            : base(initialSize, longLivedSize, maxNumberOfAllocatedStringValues, lowMemoryFlag)
         {
             _documentDatabase = documentDatabase;
         }
@@ -70,7 +70,7 @@ namespace Raven.Server.ServerWide.Context
         {
             var tx = new DocumentsTransaction(this, _documentDatabase.DocumentsStorage.Environment.WriteTransaction(PersistentContext, Allocator, timeout), _documentDatabase.Changes);
 
-            CurrentTxMarker = (short) tx.InnerTransaction.LowLevelTransaction.Id;
+            CurrentTxMarker = (short)tx.InnerTransaction.LowLevelTransaction.Id;
 
             var options = _documentDatabase.DocumentsStorage.Environment.Options;
 
@@ -80,7 +80,7 @@ namespace Raven.Server.ServerWide.Context
                 options.TransactionsMode = TransactionsMode.Safe;
             }
 
-            tx.InnerTransaction.LowLevelTransaction.IsLazyTransaction = 
+            tx.InnerTransaction.LowLevelTransaction.IsLazyTransaction =
                 options.TransactionsMode == TransactionsMode.Lazy;
             // IsLazyTransaction can be overriden later by a specific feature like bulk insert
 
@@ -94,12 +94,11 @@ namespace Raven.Server.ServerWide.Context
         public bool ShouldRenewTransactionsToAllowFlushing()
         {
             // if we have the same transaction id right now, there hasn't been write since we started the transaction
-            // so there isn't really a major point in renewing the transaction, since we wouldn't be releasing any 
+            // so there isn't really a major point in renewing the transaction, since we wouldn't be releasing any
             // resources (scratch space, mostly) back to the system, let us continue with the current one.
 
             return Transaction?.InnerTransaction.LowLevelTransaction.Id !=
-                   _documentDatabase.DocumentsStorage.Environment.CurrentReadTransactionId ;
-
+                   _documentDatabase.DocumentsStorage.Environment.CurrentReadTransactionId;
         }
     }
 }

--- a/src/Raven.Server/ServerWide/Context/TransactionContextPool.cs
+++ b/src/Raven.Server/ServerWide/Context/TransactionContextPool.cs
@@ -4,15 +4,13 @@
 //  </copyright>
 // -----------------------------------------------------------------------
 
-using System;
-using System.Threading;
 using Sparrow;
 using Sparrow.Json;
 using Voron;
 
 namespace Raven.Server.ServerWide.Context
 {
-    public class TransactionContextPool : JsonContextPoolBase<TransactionOperationContext> ,ITransactionContextPool
+    public class TransactionContextPool : JsonContextPoolBase<TransactionOperationContext>, ITransactionContextPool
     {
         private StorageEnvironment _storageEnvironment;
 
@@ -24,16 +22,22 @@ namespace Raven.Server.ServerWide.Context
         protected override TransactionOperationContext CreateContext()
         {
             int initialSize;
+            int longLivedSize;
+            int maxNumberOfAllocatedStringValues;
             if (_storageEnvironment.Options.RunningOn32Bits)
             {
                 initialSize = 4096;
+                longLivedSize = 4 * 1024;
+                maxNumberOfAllocatedStringValues = 8 * 1024;
             }
             else
             {
-                initialSize = 32*1024;
+                initialSize = 32 * 1024;
+                longLivedSize = 16 * 1024;
+                maxNumberOfAllocatedStringValues = 32 * 1024;
             }
 
-            return new TransactionOperationContext(_storageEnvironment, initialSize, 16*1024, LowMemoryFlag);
+            return new TransactionOperationContext(_storageEnvironment, initialSize, longLivedSize, maxNumberOfAllocatedStringValues, LowMemoryFlag);
         }
 
         public override void Dispose()

--- a/src/Raven.Server/ServerWide/Context/TransactionOperationContext.cs
+++ b/src/Raven.Server/ServerWide/Context/TransactionOperationContext.cs
@@ -1,8 +1,8 @@
 ﻿using System;
 using Sparrow.Json;
-using Voron;
 using Sparrow.Server;
 using Sparrow.Threading;
+using Voron;
 
 namespace Raven.Server.ServerWide.Context
 {
@@ -12,8 +12,8 @@ namespace Raven.Server.ServerWide.Context
 
         public bool IgnoreStalenessDueToReduceOutputsToDelete;
 
-        public TransactionOperationContext(StorageEnvironment environment, int initialSize, int longLivedSize, SharedMultipleUseFlag lowMemoryFlag) :
-            base(initialSize, longLivedSize, lowMemoryFlag)
+        public TransactionOperationContext(StorageEnvironment environment, int initialSize, int longLivedSize, int maxNumberOfAllocatedStringValues, SharedMultipleUseFlag lowMemoryFlag)
+            : base(initialSize, longLivedSize, maxNumberOfAllocatedStringValues, lowMemoryFlag)
         {
             _environment = environment;
         }
@@ -48,8 +48,8 @@ namespace Raven.Server.ServerWide.Context
 
         public TTransaction Transaction;
 
-        protected TransactionOperationContext(int initialSize, int longLivedSize, SharedMultipleUseFlag lowMemoryFlag):
-            base(initialSize, longLivedSize, lowMemoryFlag)
+        protected TransactionOperationContext(int initialSize, int longLivedSize, int maxNumberOfAllocatedStringValues, SharedMultipleUseFlag lowMemoryFlag)
+            : base(initialSize, longLivedSize, maxNumberOfAllocatedStringValues, lowMemoryFlag)
         {
             PersistentContext = new TransactionPersistentContext();
             Allocator = new ByteStringContext(lowMemoryFlag);
@@ -64,7 +64,6 @@ namespace Raven.Server.ServerWide.Context
 
             return Transaction;
         }
-
 
         public TTransaction CloneReadTransaction()
         {
@@ -95,7 +94,7 @@ namespace Raven.Server.ServerWide.Context
                 return 2;
             if (value < 0)
                 return (short)-value;
-            
+
             return value;
         }
 
@@ -135,7 +134,7 @@ namespace Raven.Server.ServerWide.Context
             Transaction?.Dispose();
             Transaction = null;
         }
-        
+
         public override void Dispose()
         {
             base.Dispose();
@@ -147,9 +146,7 @@ namespace Raven.Server.ServerWide.Context
         {
             CloseTransaction();
 
-
             base.Reset(forceResetLongLivedAllocator);
-
 
             Allocator.Reset();
         }

--- a/src/Sparrow/Json/ArenaMemoryAllocator.cs
+++ b/src/Sparrow/Json/ArenaMemoryAllocator.cs
@@ -7,9 +7,11 @@ using Sparrow.Binary;
 using Sparrow.Global;
 using Sparrow.Platform;
 using Sparrow.Threading;
+
 #if MEM_GUARD
 using Sparrow.Platform;
 #endif
+
 using Sparrow.Utils;
 
 namespace Sparrow.Json
@@ -142,11 +144,14 @@ namespace Sparrow.Json
             _used += size;
             TotalUsed += size;
 
-            Return: return allocation;
+        Return:
+            return allocation;
 #endif
 
-            ErrorDisposed: ThrowAlreadyDisposedException();
-            ErrorResetted: ThrowInvalidAllocateFromResetWithoutRenew();
+        ErrorDisposed:
+            ThrowAlreadyDisposedException();
+        ErrorResetted:
+            ThrowInvalidAllocateFromResetWithoutRenew();
             return null; // Will never happen.
         }
 
@@ -177,7 +182,7 @@ namespace Sparrow.Json
             {
                 newBuffer = NativeMemory.AllocateMemory(newSize, out thread);
             }
-            catch (OutOfMemoryException oom ) 
+            catch (OutOfMemoryException oom)
                 when (oom.Data?.Contains("Recoverable") != true) // this can be raised if the commit charge is low
             {
                 // we were too eager with memory allocations?
@@ -203,7 +208,7 @@ namespace Sparrow.Json
         {
             if (AvoidOverAllocation || PlatformDetails.Is32Bits)
                 return ApplyLimit(Bits.PowerOf2(requestedSize));
-            
+
             // we need the next allocation to cover at least the next expansion (also doubling)
             // so we'll allocate 3 times as much as was requested, or as much as we already have
             // the idea is that a single allocation can server for multiple (increasing in size) calls
@@ -217,8 +222,8 @@ namespace Sparrow.Json
                 if (size > SingleAllocationSizeLimit.Value)
                 {
                     var sizeInMb = requestedSize / Constants.Size.Megabyte + (requestedSize % Constants.Size.Megabyte == 0 ? 0 : 1);
-					return sizeInMb * Constants.Size.Megabyte;
-        		}
+                    return sizeInMb * Constants.Size.Megabyte;
+                }
 
                 return size;
             }
@@ -274,7 +279,7 @@ namespace Sparrow.Json
             if (_ptrStart != null)
                 NativeMemory.Free(_ptrStart, _allocated, _allocatingThread);
 
-            // we'll allocate some multiple of the currently allocated amount, that will prevent big spikes in memory 
+            // we'll allocate some multiple of the currently allocated amount, that will prevent big spikes in memory
             // consumption and has the worst case usage of doubling memory utilization
 
             var newSize = (_used / _allocated + (_used % _allocated == 0 ? 0 : 1)) * _allocated;
@@ -311,6 +316,7 @@ namespace Sparrow.Json
         {
             Dispose(true);
         }
+
         public void Dispose(bool disposing)
         {
             if (!_isDisposed?.Raise() ?? true)
@@ -341,7 +347,7 @@ namespace Sparrow.Json
             {
                 if (disposing)
                     Monitor.Exit(this);
-            }            
+            }
         }
 
         [MethodImpl(MethodImplOptions.AggressiveInlining)]
@@ -350,12 +356,11 @@ namespace Sparrow.Json
             if (_isDisposed ?? true)
                 return;
 
-
             var address = allocation.Address;
 
 #if DEBUG
             Debug.Assert(address != _ptrCurrent);
-            Debug.Assert(allocation.IsReturned==false);
+            Debug.Assert(allocation.IsReturned == false);
             allocation.IsReturned = true;
 
 #endif
@@ -375,13 +380,12 @@ namespace Sparrow.Json
                 // in the memory we just freed :-)
 
                 // note that this fragmentation will be healed by the call to ResetArena
-                // trying to do this on the fly is too expensive. 
+                // trying to do this on the fly is too expensive.
 
                 Debug.Assert(Bits.PowerOf2(allocation.SizeInBytes) == allocation.SizeInBytes,
                     "Allocation size must always be a power of two"
                 );
                 Debug.Assert(allocation.SizeInBytes >= sizeof(FreeSection));
-
 
                 var index = Bits.MostSignificantBit(allocation.SizeInBytes) - 1;
                 var section = (FreeSection*)address;
@@ -428,6 +432,7 @@ namespace Sparrow.Json
         public bool IsLongLived;
         public bool IsReturned;
         private byte* _address;
+
         public byte* Address
         {
             get
@@ -454,9 +459,9 @@ namespace Sparrow.Json
 
         private void ThrowObjectDisposedException()
         {
-           throw new ObjectDisposedException(nameof(AllocatedMemoryData));
+            throw new ObjectDisposedException(nameof(AllocatedMemoryData));
         }
-#endif
 
+#endif
     }
 }

--- a/src/Sparrow/Json/JsonContextPool.cs
+++ b/src/Sparrow/Json/JsonContextPool.cs
@@ -1,27 +1,32 @@
-﻿namespace Sparrow.Json
+﻿using Sparrow.Platform;
+
+namespace Sparrow.Json
 {
     public class JsonContextPool : JsonContextPoolBase<JsonOperationContext>
     {
+        private readonly int _maxNumberOfAllocatedStringValuesPerContext;
+
         public JsonContextPool()
         {
         }
 
         public JsonContextPool(Size? maxContextSizeToKeep)
-            : this(maxContextSizeToKeep, null)
+            : this(maxContextSizeToKeep, null, PlatformDetails.Is32Bits == false ? 32 * 1024 : 8 * 1024)
         {
         }
 
-        internal JsonContextPool(Size? maxContextSizeToKeep, long? maxNumberOfContextsToKeepInGlobalStack)
+        internal JsonContextPool(Size? maxContextSizeToKeep, long? maxNumberOfContextsToKeepInGlobalStack, int maxNumberOfAllocatedStringValuesPerContext)
             : base(maxContextSizeToKeep, maxNumberOfContextsToKeepInGlobalStack)
         {
+            _maxNumberOfAllocatedStringValuesPerContext = maxNumberOfAllocatedStringValuesPerContext;
         }
 
         protected override JsonOperationContext CreateContext()
         {
             if (Platform.PlatformDetails.Is32Bits)
-                return new JsonOperationContext(4096, 16 * 1024, LowMemoryFlag);
+                return new JsonOperationContext(4096, 16 * 1024, _maxNumberOfAllocatedStringValuesPerContext, LowMemoryFlag);
 
-            return new JsonOperationContext(32 * 1024, 16 * 1024, LowMemoryFlag);
+            return new JsonOperationContext(32 * 1024, 16 * 1024, _maxNumberOfAllocatedStringValuesPerContext, LowMemoryFlag);
         }
     }
 }

--- a/src/Sparrow/Json/JsonOperationContext.cs
+++ b/src/Sparrow/Json/JsonOperationContext.cs
@@ -33,6 +33,7 @@ namespace Sparrow.Json
         private const int MaxInitialStreamSize = 16 * 1024 * 1024;
         private readonly int _initialSize;
         private readonly int _longLivedSize;
+        private readonly int _maxNumberOfAllocatedStringValues;
         private readonly ArenaMemoryAllocator _arenaAllocator;
         private ArenaMemoryAllocator _arenaAllocatorForLongLivedValues;
         private AllocatedMemoryData _tempBuffer;
@@ -106,7 +107,7 @@ namespace Sparrow.Json
             }
 
             var allocateStringValue = new LazyStringValue(str, ptr, size, this);
-            if (_numberOfAllocatedStringsValues < 32 * 1_024)
+            if (_numberOfAllocatedStringsValues < _maxNumberOfAllocatedStringValues)
             {
                 _allocateStringValues.Add(allocateStringValue);
                 _numberOfAllocatedStringsValues++;
@@ -304,10 +305,10 @@ namespace Sparrow.Json
 
         public static JsonOperationContext ShortTermSingleUse()
         {
-            return new JsonOperationContext(4096, 1024, SharedMultipleUseFlag.None);
+            return new JsonOperationContext(4096, 1024, 32 * 1024, SharedMultipleUseFlag.None);
         }
 
-        public JsonOperationContext(int initialSize, int longLivedSize, SharedMultipleUseFlag lowMemoryFlag)
+        public JsonOperationContext(int initialSize, int longLivedSize, int maxNumberOfAllocatedStringValues, SharedMultipleUseFlag lowMemoryFlag)
         {
             Debug.Assert(lowMemoryFlag != null);
             _disposeOnceRunner = new DisposeOnce<SingleAttempt>(() =>
@@ -363,6 +364,7 @@ namespace Sparrow.Json
 
             _initialSize = initialSize;
             _longLivedSize = longLivedSize;
+            _maxNumberOfAllocatedStringValues = maxNumberOfAllocatedStringValues;
             _arenaAllocator = new ArenaMemoryAllocator(lowMemoryFlag, initialSize);
             _arenaAllocatorForLongLivedValues = new ArenaMemoryAllocator(lowMemoryFlag, longLivedSize);
             CachedProperties = new CachedProperties(this);
@@ -1016,10 +1018,16 @@ namespace Sparrow.Json
                 _fieldNames.Clear();
                 CachedProperties = null; // need to release this so can be collected
             }
+
+            for (var i = 0; i < _numberOfAllocatedStringsValues; i++)
+                _allocateStringValues[i].Reset();
+
+            _numberOfAllocatedStringsValues = 0;
+
             _objectJsonParser.Reset(null);
             _arenaAllocator.ResetArena();
-            _numberOfAllocatedStringsValues = 0;
-            _generation = _generation + 1;
+
+            _generation++;
 
             if (_pooledArrays != null)
             {

--- a/src/Sparrow/Json/LazyStringValue.cs
+++ b/src/Sparrow/Json/LazyStringValue.cs
@@ -1017,6 +1017,12 @@ namespace Sparrow.Json
         }
 
         [MethodImpl(MethodImplOptions.AggressiveInlining)]
+        public void Reset()
+        {
+            Renew(null, null, 0);
+        }
+
+        [MethodImpl(MethodImplOptions.AggressiveInlining)]
         public void Renew(string str, byte* buffer, int size)
         {
             Debug.Assert(size >= 0);

--- a/test/FastTests/Blittable/BlittableJsonWriterTests/ManualBuilderTests.cs
+++ b/test/FastTests/Blittable/BlittableJsonWriterTests/ManualBuilderTests.cs
@@ -20,7 +20,7 @@ namespace FastTests.Blittable.BlittableJsonWriterTests
         [Fact]
         public void BasicObject()
         {
-            using (var context = new JsonOperationContext(1024, 1024 * 4, SharedMultipleUseFlag.None))
+            using (var context = new JsonOperationContext(1024, 1024 * 4, 32 * 1024, SharedMultipleUseFlag.None))
             {
                 using (var builder = new ManualBlittableJsonDocumentBuilder<UnmanagedWriteBuffer>(context))
                 {
@@ -41,11 +41,10 @@ namespace FastTests.Blittable.BlittableJsonWriterTests
             }
         }
 
-
         [Fact]
         public void BasicEmptyObject()
         {
-            using (var context = new JsonOperationContext(1024, 1024 * 4, SharedMultipleUseFlag.None))
+            using (var context = new JsonOperationContext(1024, 1024 * 4, 32 * 1024, SharedMultipleUseFlag.None))
             {
                 using (var builder = new ManualBlittableJsonDocumentBuilder<UnmanagedWriteBuffer>(context))
                 {
@@ -68,7 +67,7 @@ namespace FastTests.Blittable.BlittableJsonWriterTests
         [Fact]
         public void BasicNestedEmptyObject()
         {
-            using (var context = new JsonOperationContext(1024, 1024 * 4, SharedMultipleUseFlag.None))
+            using (var context = new JsonOperationContext(1024, 1024 * 4, 32 * 1024, SharedMultipleUseFlag.None))
             {
                 using (var builder = new ManualBlittableJsonDocumentBuilder<UnmanagedWriteBuffer>(context))
                 {
@@ -99,7 +98,7 @@ namespace FastTests.Blittable.BlittableJsonWriterTests
         [Fact]
         public void BasicIntFlatStructure()
         {
-            using (var context = new JsonOperationContext(1024, 1024 * 4, SharedMultipleUseFlag.None))
+            using (var context = new JsonOperationContext(1024, 1024 * 4, 32 * 1024, SharedMultipleUseFlag.None))
             {
                 using (var builder = new ManualBlittableJsonDocumentBuilder<UnmanagedWriteBuffer>(context))
                 {
@@ -131,11 +130,10 @@ namespace FastTests.Blittable.BlittableJsonWriterTests
             }
         }
 
-
         [Fact]
         public void BasicIntNestedStructure()
         {
-            using (var context = new JsonOperationContext(1024, 1024 * 4, SharedMultipleUseFlag.None))
+            using (var context = new JsonOperationContext(1024, 1024 * 4, 32 * 1024, SharedMultipleUseFlag.None))
             {
                 using (var builder = new ManualBlittableJsonDocumentBuilder<UnmanagedWriteBuffer>(context))
                 {
@@ -180,7 +178,6 @@ namespace FastTests.Blittable.BlittableJsonWriterTests
                     var reader = builder.CreateReader();
                     var stream = new MemoryStream();
 
-
                     Assert.Equal(2, reader.Count);
 
                     var data = reader["Data"] as BlittableJsonReaderObject;
@@ -197,7 +194,7 @@ namespace FastTests.Blittable.BlittableJsonWriterTests
         [Fact]
         public void BasicIntDeeperNestedStructure()
         {
-            using (var context = new JsonOperationContext(1024, 1024 * 4, SharedMultipleUseFlag.None))
+            using (var context = new JsonOperationContext(1024, 1024 * 4, 32 * 1024, SharedMultipleUseFlag.None))
             {
                 using (var builder = new ManualBlittableJsonDocumentBuilder<UnmanagedWriteBuffer>(context))
                 {
@@ -319,7 +316,7 @@ namespace FastTests.Blittable.BlittableJsonWriterTests
         [Fact]
         public void FlatObjectWithEmptyArray()
         {
-            using (var context = new JsonOperationContext(1024, 1024 * 4, SharedMultipleUseFlag.None))
+            using (var context = new JsonOperationContext(1024, 1024 * 4, 32 * 1024, SharedMultipleUseFlag.None))
             {
                 using (var builder = new ManualBlittableJsonDocumentBuilder<UnmanagedWriteBuffer>(context))
                 {
@@ -351,7 +348,6 @@ namespace FastTests.Blittable.BlittableJsonWriterTests
                     Assert.Equal(0, array.Length);
 
                     Assert.Equal(55, int.Parse(reader["Height"].ToString(), CultureInfo.InvariantCulture));
-
                 }
             }
         }
@@ -359,7 +355,7 @@ namespace FastTests.Blittable.BlittableJsonWriterTests
         [Fact]
         public void FlatObjectWithArrayOfEmptyObjects()
         {
-            using (var context = new JsonOperationContext(1024, 1024 * 4, SharedMultipleUseFlag.None))
+            using (var context = new JsonOperationContext(1024, 1024 * 4, 32 * 1024, SharedMultipleUseFlag.None))
             {
                 using (var builder = new ManualBlittableJsonDocumentBuilder<UnmanagedWriteBuffer>(context))
                 {
@@ -390,7 +386,6 @@ namespace FastTests.Blittable.BlittableJsonWriterTests
 
                     using (var reader = builder.CreateReader())
                     {
-
                         Assert.Equal(2, reader.Count);
 
                         var array = reader["MyArray"] as BlittableJsonReaderArray;
@@ -404,7 +399,6 @@ namespace FastTests.Blittable.BlittableJsonWriterTests
 
                         Assert.Equal(55, int.Parse(reader["Height"].ToString(), CultureInfo.InvariantCulture));
                     }
-
                 }
             }
         }
@@ -412,7 +406,7 @@ namespace FastTests.Blittable.BlittableJsonWriterTests
         [Fact]
         public void FlatObjectWithIntArrayTest()
         {
-            using (var context = new JsonOperationContext(1024, 1024 * 4, SharedMultipleUseFlag.None))
+            using (var context = new JsonOperationContext(1024, 1024 * 4, 32 * 1024, SharedMultipleUseFlag.None))
             {
                 using (var builder = new ManualBlittableJsonDocumentBuilder<UnmanagedWriteBuffer>(context))
                 {
@@ -449,16 +443,14 @@ namespace FastTests.Blittable.BlittableJsonWriterTests
                         Assert.Equal(i, int.Parse(array[i].ToString(), CultureInfo.InvariantCulture));
 
                     Assert.Equal(55, int.Parse(reader["Height"].ToString(), CultureInfo.InvariantCulture));
-
                 }
             }
         }
 
-
         [Fact]
         public void ObjectWithNestedIntArrayTest()
         {
-            using (var context = new JsonOperationContext(1024, 1024 * 4, SharedMultipleUseFlag.None))
+            using (var context = new JsonOperationContext(1024, 1024 * 4, 32 * 1024, SharedMultipleUseFlag.None))
             {
                 using (var builder = new ManualBlittableJsonDocumentBuilder<UnmanagedWriteBuffer>(context))
                 {
@@ -506,7 +498,6 @@ namespace FastTests.Blittable.BlittableJsonWriterTests
 
                         for (var j = 0; j < 8; j++)
                             Assert.Equal(i, int.Parse(innerArray[i].ToString(), CultureInfo.InvariantCulture));
-
                     }
                     Assert.Equal(55, int.Parse(reader["Height"].ToString(), CultureInfo.InvariantCulture));
                 }
@@ -516,7 +507,7 @@ namespace FastTests.Blittable.BlittableJsonWriterTests
         [Fact]
         public void FlatObjectWithObjectArray()
         {
-            using (var context = new JsonOperationContext(1024, 1024 * 4, SharedMultipleUseFlag.None))
+            using (var context = new JsonOperationContext(1024, 1024 * 4, 32 * 1024, SharedMultipleUseFlag.None))
             {
                 using (var builder = new ManualBlittableJsonDocumentBuilder<UnmanagedWriteBuffer>(context))
                 {
@@ -564,7 +555,6 @@ namespace FastTests.Blittable.BlittableJsonWriterTests
                             Assert.Equal(i, int.Parse(nested["NestedNode"].ToString(), CultureInfo.InvariantCulture));
                         }
 
-
                         Assert.Equal(55, int.Parse(reader["Height"].ToString(), CultureInfo.InvariantCulture));
                     }
                 }
@@ -574,7 +564,7 @@ namespace FastTests.Blittable.BlittableJsonWriterTests
         [Fact]
         public void FlatObjectWithObjectArrayWithNestedArray()
         {
-            using (var context = new JsonOperationContext(1024, 1024 * 4, SharedMultipleUseFlag.None))
+            using (var context = new JsonOperationContext(1024, 1024 * 4, 32 * 1024, SharedMultipleUseFlag.None))
             {
                 using (var builder = new ManualBlittableJsonDocumentBuilder<UnmanagedWriteBuffer>(context))
                 {
@@ -601,7 +591,6 @@ namespace FastTests.Blittable.BlittableJsonWriterTests
                                                 }
                                                 builder.WriteArrayEnd();
                                             }
-
                                         }
                                         builder.WriteObjectEnd();
                                     }
@@ -642,7 +631,7 @@ namespace FastTests.Blittable.BlittableJsonWriterTests
         [Fact]
         public void SimpleArrayDocument()
         {
-            using (var context = new JsonOperationContext(1024, 1024 * 4, SharedMultipleUseFlag.None))
+            using (var context = new JsonOperationContext(1024, 1024 * 4, 32 * 1024, SharedMultipleUseFlag.None))
             {
                 using (var builder = new ManualBlittableJsonDocumentBuilder<UnmanagedWriteBuffer>(context))
                 {
@@ -663,11 +652,9 @@ namespace FastTests.Blittable.BlittableJsonWriterTests
 
                     for (var i = 0; i < 8; i++)
                         Assert.Equal(i, int.Parse(reader[i].ToString(), CultureInfo.InvariantCulture));
-
                 }
             }
         }
-
 
         [Theory]
         [InlineData(byte.MaxValue)]
@@ -675,7 +662,7 @@ namespace FastTests.Blittable.BlittableJsonWriterTests
         [InlineData(short.MaxValue + 1)]
         public void BigDepthTest(int propertiesAmount)
         {
-            using (var context = new JsonOperationContext(1024, 1024 * 4, SharedMultipleUseFlag.None))
+            using (var context = new JsonOperationContext(1024, 1024 * 4, 32 * 1024, SharedMultipleUseFlag.None))
             {
                 using (var builder = new ManualBlittableJsonDocumentBuilder<UnmanagedWriteBuffer>(context))
                 {
@@ -683,7 +670,7 @@ namespace FastTests.Blittable.BlittableJsonWriterTests
 
                     builder.StartWriteObjectDocument();
                     builder.StartWriteObject();
-                    
+
                     for (int i = 0; i < propertiesAmount; i++)
                     {
                         builder.WritePropertyName("Data" + i);
@@ -708,7 +695,6 @@ namespace FastTests.Blittable.BlittableJsonWriterTests
                         var val = reader["Age" + i];
                         Assert.Equal(i, int.Parse(val.ToString(), CultureInfo.InvariantCulture));
                     }
-
                 }
             }
         }
@@ -716,7 +702,7 @@ namespace FastTests.Blittable.BlittableJsonWriterTests
         [Fact]
         public unsafe void ReadDataTypesTest()
         {
-            using (var context = new JsonOperationContext(1024, 1024 * 4, SharedMultipleUseFlag.None))
+            using (var context = new JsonOperationContext(1024, 1024 * 4, 32 * 1024, SharedMultipleUseFlag.None))
             {
                 BlittableJsonReaderObject embeddedReader;
                 using (var builder = new ManualBlittableJsonDocumentBuilder<UnmanagedWriteBuffer>(context))
@@ -786,13 +772,12 @@ namespace FastTests.Blittable.BlittableJsonWriterTests
                     builder.WritePropertyName("StringEscapedCharsAndNonAscii");
                     builder.WriteValue(longEscapedCharsAndNonAsciiString);
 
-
                     var lsvString = "\"fooאbar\"";
                     var lsvStringBytes = Encoding.UTF8.GetBytes(lsvString);
                     fixed (byte* b = lsvStringBytes)
                     {
                         var escapePositionsMaxSize = JsonParserState.FindEscapePositionsMaxSize(lsvString, out _);
-                        var lsv = context.AllocateStringValue(null,b,lsvStringBytes.Length);
+                        var lsv = context.AllocateStringValue(null, b, lsvStringBytes.Length);
                         var escapePositions = new FastList<int>();
                         var len = lsvStringBytes.Length;
                         JsonParserState.FindEscapePositionsIn(escapePositions, b, ref len, escapePositionsMaxSize);
@@ -812,7 +797,7 @@ namespace FastTests.Blittable.BlittableJsonWriterTests
                     reader.BlittableValidation();
 
                     Assert.Equal(17, reader.Count);
-                    Assert.Equal(float.MinValue, float.Parse(reader["FloatMin"].ToString(),CultureInfo.InvariantCulture));
+                    Assert.Equal(float.MinValue, float.Parse(reader["FloatMin"].ToString(), CultureInfo.InvariantCulture));
                     Assert.Equal(float.MaxValue, float.Parse(reader["FloatMax"].ToString(), CultureInfo.InvariantCulture));
                     Assert.Equal(ushort.MinValue, ushort.Parse(reader["UshortMin"].ToString(), CultureInfo.InvariantCulture));
                     Assert.Equal(ushort.MaxValue, ushort.Parse(reader["UshortMax"].ToString(), CultureInfo.InvariantCulture));

--- a/test/FastTests/Client/Load.cs
+++ b/test/FastTests/Client/Load.cs
@@ -10,7 +10,7 @@ using Xunit.Abstractions;
 
 namespace FastTests.Client
 {
-    public class Load :  RavenTestBase
+    public class Load : RavenTestBase
     {
         public Load(ITestOutputHelper output) : base(output)
         {
@@ -43,14 +43,14 @@ namespace FastTests.Client
             {
                 using (var session = store.OpenSession())
                 {
-                    session.Store(new User {Name = "RavenDB"}, "users/1");
-                    session.Store(new User {Name = "Hibernating Rhinos"}, "users/2");
+                    session.Store(new User { Name = "RavenDB" }, "users/1");
+                    session.Store(new User { Name = "Hibernating Rhinos" }, "users/2");
                     session.SaveChanges();
                 }
 
                 using (var newSession = store.OpenSession())
                 {
-                    var user = newSession.Load<User>(new[] {"users/1", "users/2"});
+                    var user = newSession.Load<User>(new[] { "users/1", "users/2" });
                     Assert.Equal(user.Count, 2);
                 }
             }
@@ -70,7 +70,7 @@ namespace FastTests.Client
 
                 using (var newSession = store.OpenSession())
                 {
-                    var user1 = newSession.Load<User>((string) null);
+                    var user1 = newSession.Load<User>((string)null);
                     Assert.Null(user1);
                 }
             }
@@ -188,34 +188,34 @@ namespace FastTests.Client
                 }
                 var rq1 = store.GetRequestExecutor();
                 var cmd = new GetDocumentsCommand(ids.ToArray(), null, true);
-                using (var ctx = new JsonOperationContext(1024, 1024, SharedMultipleUseFlag.None))
+                using (var ctx = new JsonOperationContext(1024, 1024, 32 * 1024, SharedMultipleUseFlag.None))
                 {
                     rq1.Execute(cmd, ctx);
                 }
             }
         }
-        
+
         private class ToStore
         {
             public IEnumerable<string> Prop { get; set; }
         }
-        
+
         private class ContainEnumerableEmpty
         {
             public IEnumerable<string> Prop { get; set; } = Enumerable.Empty<string>();
         }
-        
+
         [Fact]
         public async Task LoadDoc_WhenContainEnumerableEmpty_ShouldWork()
         {
             const string id = "someId";
-            var prop = new []{"something"};
-            
+            var prop = new[] { "something" };
+
             using var store = GetDocumentStore();
-             
+
             using (var session = store.OpenAsyncSession())
             {
-                await session.StoreAsync(new ToStore{Prop = prop}, id);
+                await session.StoreAsync(new ToStore { Prop = prop }, id);
                 await session.SaveChangesAsync();
             }
             using (var session = store.OpenAsyncSession())

--- a/test/FastTests/Server/Documents/Indexing/BloomFilterTests.cs
+++ b/test/FastTests/Server/Documents/Indexing/BloomFilterTests.cs
@@ -17,7 +17,7 @@ namespace FastTests.Server.Documents.Indexing
         [Fact]
         public void Basic()
         {
-            using (var context = new TransactionOperationContext(Env, 1024, 1024, SharedMultipleUseFlag.None))
+            using (var context = new TransactionOperationContext(Env, 1024, 1024, 32 * 1024, SharedMultipleUseFlag.None))
             {
                 using (var tx = Env.WriteTransaction())
                 {
@@ -51,7 +51,7 @@ namespace FastTests.Server.Documents.Indexing
                         Assert.True(filter.Contains(key1));
                         Assert.True(filter.Contains(key2));
                         Assert.Equal(2, filter.Count);
-                        
+
                         context.ReturnMemory(key1.AllocatedMemoryData);
                         context.ReturnMemory(key2.AllocatedMemoryData);
                     }
@@ -64,7 +64,7 @@ namespace FastTests.Server.Documents.Indexing
         [Fact]
         public void CanPersist()
         {
-            using (var context = new TransactionOperationContext(Env, 1024, 1024, SharedMultipleUseFlag.None))
+            using (var context = new TransactionOperationContext(Env, 1024, 1024, 32 * 1024, SharedMultipleUseFlag.None))
             {
                 var key1 = context.GetLazyString("orders/1");
 
@@ -101,7 +101,7 @@ namespace FastTests.Server.Documents.Indexing
         [Fact]
         public void CheckWritability()
         {
-            using (var context = new TransactionOperationContext(Env, 1024, 1024, SharedMultipleUseFlag.None))
+            using (var context = new TransactionOperationContext(Env, 1024, 1024, 32 * 1024, SharedMultipleUseFlag.None))
             {
                 var key1 = context.GetLazyString("orders/1");
                 var key2 = context.GetLazyString("orders/2");
@@ -149,7 +149,7 @@ namespace FastTests.Server.Documents.Indexing
         [Fact]
         public void CheckReadonly()
         {
-            using (var context = new TransactionOperationContext(Env, 1024, 1024, SharedMultipleUseFlag.None))
+            using (var context = new TransactionOperationContext(Env, 1024, 1024, 32 * 1024, SharedMultipleUseFlag.None))
             {
                 using (var tx = context.OpenWriteTransaction())
                 {
@@ -182,7 +182,7 @@ namespace FastTests.Server.Documents.Indexing
         [Fact]
         public void WillExpand()
         {
-            using (var context = new TransactionOperationContext(Env, 1024, 1024, SharedMultipleUseFlag.None))
+            using (var context = new TransactionOperationContext(Env, 1024, 1024, 32 * 1024, SharedMultipleUseFlag.None))
             {
                 using (var tx = context.OpenWriteTransaction())
                 {
@@ -215,7 +215,7 @@ namespace FastTests.Server.Documents.Indexing
         [Fact]
         public void CannotMixFilters()
         {
-            using (var context = new TransactionOperationContext(Env, 1024, 1024, SharedMultipleUseFlag.None))
+            using (var context = new TransactionOperationContext(Env, 1024, 1024, 32 * 1024, SharedMultipleUseFlag.None))
             {
                 using (var tx = context.OpenWriteTransaction())
                 {
@@ -234,7 +234,7 @@ namespace FastTests.Server.Documents.Indexing
         [Fact]
         public void WillGetConsumedFromStorage()
         {
-            using (var context = new TransactionOperationContext(Env, 1024, 1024, SharedMultipleUseFlag.None))
+            using (var context = new TransactionOperationContext(Env, 1024, 1024, 32 * 1024, SharedMultipleUseFlag.None))
             {
                 using (var tx = context.OpenWriteTransaction())
                 {

--- a/test/FastTests/Server/Documents/Indexing/BloomFilterTests.cs
+++ b/test/FastTests/Server/Documents/Indexing/BloomFilterTests.cs
@@ -51,9 +51,6 @@ namespace FastTests.Server.Documents.Indexing
                         Assert.True(filter.Contains(key1));
                         Assert.True(filter.Contains(key2));
                         Assert.Equal(2, filter.Count);
-
-                        context.ReturnMemory(key1.AllocatedMemoryData);
-                        context.ReturnMemory(key2.AllocatedMemoryData);
                     }
 
                     tx.Commit();
@@ -93,8 +90,6 @@ namespace FastTests.Server.Documents.Indexing
                         Assert.Equal(1, filter.Count);
                     }
                 }
-
-                context.ReturnMemory(key1.AllocatedMemoryData);
             }
         }
 
@@ -140,9 +135,6 @@ namespace FastTests.Server.Documents.Indexing
                         Assert.True(filter.Writable);
                     }
                 }
-
-                context.ReturnMemory(key1.AllocatedMemoryData);
-                context.ReturnMemory(key2.AllocatedMemoryData);
             }
         }
 

--- a/test/FastTests/Server/Documents/Indexing/Lucene/LazyStringValueReaderTests.cs
+++ b/test/FastTests/Server/Documents/Indexing/Lucene/LazyStringValueReaderTests.cs
@@ -84,7 +84,6 @@ namespace FastTests.Server.Documents.Indexing.Lucene
 
                 Assert.Equal(expected, stringResult);
                 Assert.Equal(expected, readerResult.ReadToEnd());
-                _ctx.ReturnMemory(lazyString.AllocatedMemoryData);
             }
         }
 

--- a/test/FastTests/Server/Documents/Indexing/Static/DynamicBlittableJsonTests.cs
+++ b/test/FastTests/Server/Documents/Indexing/Static/DynamicBlittableJsonTests.cs
@@ -69,7 +69,6 @@ namespace FastTests.Server.Documents.Indexing.Static
                 Assert.Equal(2, user.Friends.Length);
                 Assert.Equal("Users", user[Constants.Documents.Metadata.Key][Constants.Documents.Metadata.Collection]);
                 Assert.Equal(now, user[Constants.Documents.Metadata.Key].Value<DateTime>(Constants.Documents.Metadata.LastModified));
-                _ctx.ReturnMemory(stringValue.AllocatedMemoryData);
             }
         }
 

--- a/test/FastTests/Server/Documents/Operations/BasicOperationsTests.cs
+++ b/test/FastTests/Server/Documents/Operations/BasicOperationsTests.cs
@@ -32,7 +32,7 @@ namespace FastTests.Server.Documents.Operations
 
                 db.Changes.OnOperationStatusChange += notifications.Add;
 
-                db.Operations.AddOperation(null,"Operations Test", (Raven.Server.Documents.Operations.Operations.OperationType) 0, 
+                db.Operations.AddOperation(null, "Operations Test", (Raven.Server.Documents.Operations.Operations.OperationType)0,
                     onProgress => Task.Factory.StartNew<IOperationResult>(() =>
                     {
                         var p = new DeterminateProgress
@@ -103,7 +103,7 @@ namespace FastTests.Server.Documents.Operations
                 db.Operations.AddOperation(null, "Operations Test", (Raven.Server.Documents.Operations.Operations.OperationType)0,
                     onProgress => Task.Factory.StartNew<IOperationResult>(() =>
                     {
-                       throw new Exception("Something bad happened");
+                        throw new Exception("Something bad happened");
                     }), operationId, token: OperationCancelToken.None);
 
                 OperationStatusChange change;
@@ -163,7 +163,7 @@ namespace FastTests.Server.Documents.Operations
                 }
             };
 
-            using (var context = new JsonOperationContext(1024, 1024, SharedMultipleUseFlag.None))
+            using (var context = new JsonOperationContext(1024, 1024, 32 * 1024, SharedMultipleUseFlag.None))
             {
                 var json = context.ReadObject(state.ToJson(), "state");
                 var progress = json["Progress"];
@@ -184,7 +184,7 @@ namespace FastTests.Server.Documents.Operations
                 }
             };
 
-            using (var context = new JsonOperationContext(1024, 1024, SharedMultipleUseFlag.None))
+            using (var context = new JsonOperationContext(1024, 1024, 32 * 1024, SharedMultipleUseFlag.None))
             {
                 var json = context.ReadObject(state.ToJson(), "state");
                 var result = json["Result"] as BlittableJsonReaderObject;

--- a/test/SlowTests/Blittable/BlittableJsonWriterTests/ManualBuilderTestsSlow.cs
+++ b/test/SlowTests/Blittable/BlittableJsonWriterTests/ManualBuilderTestsSlow.cs
@@ -20,7 +20,7 @@ namespace SlowTests.Blittable.BlittableJsonWriterTests
         [InlineData(short.MaxValue + 1)]
         public void BigAmountOfProperties(int propertiesAmount)
         {
-            using (var context = new JsonOperationContext(1024, 1024 * 4, SharedMultipleUseFlag.None))
+            using (var context = new JsonOperationContext(1024, 1024 * 4, 32 * 1024, SharedMultipleUseFlag.None))
             {
                 using (var builder = new ManualBlittableJsonDocumentBuilder<UnmanagedWriteBuffer>(context))
                 {

--- a/test/SlowTests/Utils/ConflictResolverTests.cs
+++ b/test/SlowTests/Utils/ConflictResolverTests.cs
@@ -18,13 +18,13 @@ namespace SlowTests.Utils
         [Fact]
         public void CanResolveEmpty()
         {
-            using (var ctx = new JsonOperationContext(4096, 16*1024, SharedMultipleUseFlag.None))
+            using (var ctx = new JsonOperationContext(4096, 16 * 1024, 32 * 1024, SharedMultipleUseFlag.None))
             {
                 DynamicJsonValue obj1 = new DynamicJsonValue();
                 DynamicJsonValue obj2 = new DynamicJsonValue();
 
                 var conflictResovlerAdvisor = new ConflictResolverAdvisor(
-                    new List<BlittableJsonReaderObject> {ctx.ReadObject(obj1, "doc/1"), ctx.ReadObject(obj2, "doc/1")},
+                    new List<BlittableJsonReaderObject> { ctx.ReadObject(obj1, "doc/1"), ctx.ReadObject(obj2, "doc/1") },
                     ctx);
                 var resolvled = conflictResovlerAdvisor.Resolve().Document;
 
@@ -35,7 +35,7 @@ namespace SlowTests.Utils
         [Fact]
         public void CanResolveIdentical()
         {
-            using (var ctx = new JsonOperationContext(4096, 16*1024, SharedMultipleUseFlag.None))
+            using (var ctx = new JsonOperationContext(4096, 16 * 1024, 32 * 1024, SharedMultipleUseFlag.None))
             {
                 DynamicJsonValue obj1 = new DynamicJsonValue();
                 DynamicJsonValue obj2 = new DynamicJsonValue();
@@ -43,7 +43,7 @@ namespace SlowTests.Utils
                 obj2["name"] = "Oren";
 
                 var conflictResovlerAdvisor = new ConflictResolverAdvisor(
-                    new List<BlittableJsonReaderObject> {ctx.ReadObject(obj1, "doc/1"), ctx.ReadObject(obj2, "doc/1")},
+                    new List<BlittableJsonReaderObject> { ctx.ReadObject(obj1, "doc/1"), ctx.ReadObject(obj2, "doc/1") },
                     ctx);
                 var resolvled = conflictResovlerAdvisor.Resolve().Document;
 
@@ -56,7 +56,7 @@ namespace SlowTests.Utils
         [Fact]
         public void CanResolveTwoEmptyArrays()
         {
-            using (var ctx = new JsonOperationContext(4096, 16*1024, SharedMultipleUseFlag.None))
+            using (var ctx = new JsonOperationContext(4096, 16 * 1024, 32 * 1024, SharedMultipleUseFlag.None))
             {
                 DynamicJsonValue obj1 = new DynamicJsonValue();
                 DynamicJsonValue obj2 = new DynamicJsonValue();
@@ -64,7 +64,7 @@ namespace SlowTests.Utils
                 obj2["name"] = new DynamicJsonArray();
 
                 var conflictResovlerAdvisor = new ConflictResolverAdvisor(
-                    new List<BlittableJsonReaderObject> {ctx.ReadObject(obj1, "doc/1"), ctx.ReadObject(obj2, "doc/1")},
+                    new List<BlittableJsonReaderObject> { ctx.ReadObject(obj1, "doc/1"), ctx.ReadObject(obj2, "doc/1") },
                     ctx);
                 var resolvled = conflictResovlerAdvisor.Resolve().Document;
 
@@ -77,22 +77,22 @@ namespace SlowTests.Utils
         [Fact]
         public void CanResolveOneEmptyArraysAndOneWithValue()
         {
-            using (var ctx = new JsonOperationContext(4096, 16*1024, SharedMultipleUseFlag.None))
+            using (var ctx = new JsonOperationContext(4096, 16 * 1024, 32 * 1024, SharedMultipleUseFlag.None))
             {
                 DynamicJsonValue obj1 = new DynamicJsonValue();
                 DynamicJsonValue obj2 = new DynamicJsonValue();
-                obj1["name"] = new DynamicJsonArray {1};
+                obj1["name"] = new DynamicJsonArray { 1 };
                 obj2["name"] = new DynamicJsonArray();
 
                 var conflictResovlerAdvisor = new ConflictResolverAdvisor(
-                    new List<BlittableJsonReaderObject> {ctx.ReadObject(obj1, "doc/1"), ctx.ReadObject(obj2, "doc/1")},
+                    new List<BlittableJsonReaderObject> { ctx.ReadObject(obj1, "doc/1"), ctx.ReadObject(obj2, "doc/1") },
                     ctx);
                 var resolvled = conflictResovlerAdvisor.Resolve().Document;
 
                 BlittableJsonReaderArray name;
                 resolvled.TryGet("name", out name);
                 Assert.Equal(">>>> auto merged array start", name[0].ToString());
-                Assert.Equal((long) 1, name[1]);
+                Assert.Equal((long)1, name[1]);
                 Assert.Equal("<<<< auto merged array end", name[2].ToString());
             }
         }
@@ -100,7 +100,7 @@ namespace SlowTests.Utils
         [Fact]
         public void CanMergeAdditionalProperties()
         {
-            using (var ctx = new JsonOperationContext(4096, 16*1024, SharedMultipleUseFlag.None))
+            using (var ctx = new JsonOperationContext(4096, 16 * 1024, 32 * 1024, SharedMultipleUseFlag.None))
             {
                 DynamicJsonValue obj1 = new DynamicJsonValue();
                 DynamicJsonValue obj2 = new DynamicJsonValue();
@@ -108,7 +108,7 @@ namespace SlowTests.Utils
                 obj2["Age"] = 2;
 
                 var conflictResovlerAdvisor = new ConflictResolverAdvisor(
-                    new List<BlittableJsonReaderObject> {ctx.ReadObject(obj1, "doc/1"), ctx.ReadObject(obj2, "doc/1")},
+                    new List<BlittableJsonReaderObject> { ctx.ReadObject(obj1, "doc/1"), ctx.ReadObject(obj2, "doc/1") },
                     ctx);
                 var resolvled = conflictResovlerAdvisor.Resolve().Document;
 
@@ -125,7 +125,7 @@ namespace SlowTests.Utils
         [Fact]
         public void CanDetectAndSuggestOptionsForConflict_SimpleProp()
         {
-            using (var ctx = new JsonOperationContext(4096, 16*1024, SharedMultipleUseFlag.None))
+            using (var ctx = new JsonOperationContext(4096, 16 * 1024, 32 * 1024, SharedMultipleUseFlag.None))
             {
                 DynamicJsonValue obj1 = new DynamicJsonValue();
                 DynamicJsonValue obj2 = new DynamicJsonValue();
@@ -133,7 +133,7 @@ namespace SlowTests.Utils
                 obj2["Name"] = "Ayende";
 
                 var conflictResovlerAdvisor = new ConflictResolverAdvisor(
-                    new List<BlittableJsonReaderObject> {ctx.ReadObject(obj1, "doc/1"), ctx.ReadObject(obj2, "doc/1")},
+                    new List<BlittableJsonReaderObject> { ctx.ReadObject(obj1, "doc/1"), ctx.ReadObject(obj2, "doc/1") },
                     ctx);
                 var resolvled = conflictResovlerAdvisor.Resolve().Document;
 
@@ -149,7 +149,7 @@ namespace SlowTests.Utils
         [Fact]
         public void CanMergeProperties_Nested()
         {
-            using (var ctx = new JsonOperationContext(4096, 16*1024, SharedMultipleUseFlag.None))
+            using (var ctx = new JsonOperationContext(4096, 16 * 1024, 32 * 1024, SharedMultipleUseFlag.None))
             {
                 DynamicJsonValue obj1 = new DynamicJsonValue();
                 DynamicJsonValue obj2 = new DynamicJsonValue();
@@ -163,7 +163,7 @@ namespace SlowTests.Utils
                 };
 
                 var conflictResovlerAdvisor = new ConflictResolverAdvisor(
-                    new List<BlittableJsonReaderObject> {ctx.ReadObject(obj1, "doc/1"), ctx.ReadObject(obj2, "doc/1")},
+                    new List<BlittableJsonReaderObject> { ctx.ReadObject(obj1, "doc/1"), ctx.ReadObject(obj2, "doc/1") },
                     ctx);
                 var resolvled = conflictResovlerAdvisor.Resolve().Document;
 
@@ -177,7 +177,7 @@ namespace SlowTests.Utils
         [Fact]
         public void CanDetectConflict_DifferentValues()
         {
-            using (var ctx = new JsonOperationContext(4096, 16*1024, SharedMultipleUseFlag.None))
+            using (var ctx = new JsonOperationContext(4096, 16 * 1024, 32 * 1024, SharedMultipleUseFlag.None))
             {
                 DynamicJsonValue obj1 = new DynamicJsonValue();
                 DynamicJsonValue obj2 = new DynamicJsonValue();
@@ -188,14 +188,14 @@ namespace SlowTests.Utils
                 obj2["Name"] = "Eini";
 
                 var conflictResovlerAdvisor = new ConflictResolverAdvisor(
-                    new List<BlittableJsonReaderObject> {ctx.ReadObject(obj1, "doc/1"), ctx.ReadObject(obj2, "doc/1")},
+                    new List<BlittableJsonReaderObject> { ctx.ReadObject(obj1, "doc/1"), ctx.ReadObject(obj2, "doc/1") },
                     ctx);
                 var resolvled = conflictResovlerAdvisor.Resolve().Document;
 
                 BlittableJsonReaderArray name;
                 resolvled.TryGet("Name", out name);
                 Assert.Equal(">>>> conflict start", name[0].ToString());
-                Assert.Equal("Oren", ((BlittableJsonReaderObject) name[1])["First"].ToString());
+                Assert.Equal("Oren", ((BlittableJsonReaderObject)name[1])["First"].ToString());
                 Assert.Equal("Eini", name[2].ToString());
                 Assert.Equal("<<<< conflict end", name[3].ToString());
             }
@@ -204,15 +204,15 @@ namespace SlowTests.Utils
         [Fact]
         public void CanMergeArrays()
         {
-            using (var ctx = new JsonOperationContext(4096, 16*1024, SharedMultipleUseFlag.None))
+            using (var ctx = new JsonOperationContext(4096, 16 * 1024, 32 * 1024, SharedMultipleUseFlag.None))
             {
                 DynamicJsonValue obj1 = new DynamicJsonValue();
                 DynamicJsonValue obj2 = new DynamicJsonValue();
-                obj1["Nicks"] = new DynamicJsonArray {"Oren"};
-                obj2["Nicks"] = new DynamicJsonArray {"Ayende"};
+                obj1["Nicks"] = new DynamicJsonArray { "Oren" };
+                obj2["Nicks"] = new DynamicJsonArray { "Ayende" };
 
                 var conflictResovlerAdvisor = new ConflictResolverAdvisor(
-                    new List<BlittableJsonReaderObject> {ctx.ReadObject(obj1, "doc/1"), ctx.ReadObject(obj2, "doc/1")},
+                    new List<BlittableJsonReaderObject> { ctx.ReadObject(obj1, "doc/1"), ctx.ReadObject(obj2, "doc/1") },
                     ctx);
                 var resolvled = conflictResovlerAdvisor.Resolve().Document;
 
@@ -228,25 +228,25 @@ namespace SlowTests.Utils
         [Fact]
         public void CanMergeArrays_SameStart()
         {
-            using (var ctx = new JsonOperationContext(4096, 16*1024, SharedMultipleUseFlag.None))
+            using (var ctx = new JsonOperationContext(4096, 16 * 1024, 32 * 1024, SharedMultipleUseFlag.None))
             {
                 DynamicJsonValue obj1 = new DynamicJsonValue();
                 DynamicJsonValue obj2 = new DynamicJsonValue();
-                obj1["Comments"] = new DynamicJsonArray {1, 2, 4};
-                obj2["Comments"] = new DynamicJsonArray {1, 2, 5};
+                obj1["Comments"] = new DynamicJsonArray { 1, 2, 4 };
+                obj2["Comments"] = new DynamicJsonArray { 1, 2, 5 };
 
                 var conflictResovlerAdvisor = new ConflictResolverAdvisor(
-                    new List<BlittableJsonReaderObject> {ctx.ReadObject(obj1, "doc/1"), ctx.ReadObject(obj2, "doc/1")},
+                    new List<BlittableJsonReaderObject> { ctx.ReadObject(obj1, "doc/1"), ctx.ReadObject(obj2, "doc/1") },
                     ctx);
                 var resolvled = conflictResovlerAdvisor.Resolve().Document;
 
                 BlittableJsonReaderArray comments;
                 resolvled.TryGet("Comments", out comments);
                 Assert.Equal(">>>> auto merged array start", comments[0].ToString());
-                Assert.Equal((long) 1, comments[1]);
-                Assert.Equal((long) 2, comments[2]);
-                Assert.Equal((long) 4, comments[3]);
-                Assert.Equal((long) 5, comments[4]);
+                Assert.Equal((long)1, comments[1]);
+                Assert.Equal((long)2, comments[2]);
+                Assert.Equal((long)4, comments[3]);
+                Assert.Equal((long)5, comments[4]);
                 Assert.Equal("<<<< auto merged array end", comments[5].ToString());
             }
         }
@@ -254,7 +254,7 @@ namespace SlowTests.Utils
         [Fact]
         public void CanResolveEmptyWithMetadata()
         {
-            using (var ctx = new JsonOperationContext(4096, 16*1024, SharedMultipleUseFlag.None))
+            using (var ctx = new JsonOperationContext(4096, 16 * 1024, 32 * 1024, SharedMultipleUseFlag.None))
             {
                 DynamicJsonValue obj1 = new DynamicJsonValue();
                 DynamicJsonValue obj2 = new DynamicJsonValue();
@@ -262,7 +262,7 @@ namespace SlowTests.Utils
                 obj2["@metadata"] = new DynamicJsonValue();
 
                 var conflictResovlerAdvisor = new ConflictResolverAdvisor(
-                    new List<BlittableJsonReaderObject> {ctx.ReadObject(obj1, "doc/1"), ctx.ReadObject(obj2, "doc/1")},
+                    new List<BlittableJsonReaderObject> { ctx.ReadObject(obj1, "doc/1"), ctx.ReadObject(obj2, "doc/1") },
                     ctx);
                 var resolvled = conflictResovlerAdvisor.Resolve().Metadata;
 
@@ -273,7 +273,7 @@ namespace SlowTests.Utils
         [Fact]
         public void CanResolveIdenticalMetadata()
         {
-            using (var ctx = new JsonOperationContext(4096, 16*1024, SharedMultipleUseFlag.None))
+            using (var ctx = new JsonOperationContext(4096, 16 * 1024, 32 * 1024, SharedMultipleUseFlag.None))
             {
                 DynamicJsonValue obj1 = new DynamicJsonValue();
                 DynamicJsonValue obj2 = new DynamicJsonValue();
@@ -287,7 +287,7 @@ namespace SlowTests.Utils
                 };
 
                 var conflictResovlerAdvisor = new ConflictResolverAdvisor(
-                    new List<BlittableJsonReaderObject> {ctx.ReadObject(obj1, "doc/1"), ctx.ReadObject(obj2, "doc/1")},
+                    new List<BlittableJsonReaderObject> { ctx.ReadObject(obj1, "doc/1"), ctx.ReadObject(obj2, "doc/1") },
                     ctx);
                 var resolvled = conflictResovlerAdvisor.Resolve().Metadata;
 
@@ -300,7 +300,7 @@ namespace SlowTests.Utils
         [Fact]
         public void CanResolveTwoEmptyArraysInMetadata()
         {
-            using (var ctx = new JsonOperationContext(4096, 16*1024, SharedMultipleUseFlag.None))
+            using (var ctx = new JsonOperationContext(4096, 16 * 1024, 32 * 1024, SharedMultipleUseFlag.None))
             {
                 DynamicJsonValue obj1 = new DynamicJsonValue();
                 DynamicJsonValue obj2 = new DynamicJsonValue();
@@ -314,7 +314,7 @@ namespace SlowTests.Utils
                 };
 
                 var conflictResovlerAdvisor = new ConflictResolverAdvisor(
-                    new List<BlittableJsonReaderObject> {ctx.ReadObject(obj1, "doc/1"), ctx.ReadObject(obj2, "doc/1")},
+                    new List<BlittableJsonReaderObject> { ctx.ReadObject(obj1, "doc/1"), ctx.ReadObject(obj2, "doc/1") },
                     ctx);
                 var resolvled = conflictResovlerAdvisor.Resolve().Metadata;
 
@@ -327,13 +327,13 @@ namespace SlowTests.Utils
         [Fact]
         public void CanResolveOneEmptyArraysAndOneWithValueInMetadata()
         {
-            using (var ctx = new JsonOperationContext(4096, 16*1024, SharedMultipleUseFlag.None))
+            using (var ctx = new JsonOperationContext(4096, 16 * 1024, 32 * 1024, SharedMultipleUseFlag.None))
             {
                 DynamicJsonValue obj1 = new DynamicJsonValue();
                 DynamicJsonValue obj2 = new DynamicJsonValue();
                 obj1["@metadata"] = new DynamicJsonValue
                 {
-                    ["Foo"] = new DynamicJsonArray {1}
+                    ["Foo"] = new DynamicJsonArray { 1 }
                 };
                 obj2["@metadata"] = new DynamicJsonValue
                 {
@@ -341,23 +341,22 @@ namespace SlowTests.Utils
                 };
 
                 var conflictResovlerAdvisor = new ConflictResolverAdvisor(
-                    new List<BlittableJsonReaderObject> {ctx.ReadObject(obj1, "doc/1"), ctx.ReadObject(obj2, "doc/1")},
+                    new List<BlittableJsonReaderObject> { ctx.ReadObject(obj1, "doc/1"), ctx.ReadObject(obj2, "doc/1") },
                     ctx);
                 var resolvled = conflictResovlerAdvisor.Resolve().Metadata;
 
                 BlittableJsonReaderArray foo;
                 resolvled.TryGet("Foo", out foo);
                 Assert.Equal(">>>> auto merged array start", foo[0].ToString());
-                Assert.Equal((long) 1, foo[1]);
+                Assert.Equal((long)1, foo[1]);
                 Assert.Equal("<<<< auto merged array end", foo[2].ToString());
             }
         }
 
-
         [Fact]
         public void CanMergeAdditionalMetadata()
         {
-            using (var ctx = new JsonOperationContext(4096, 16*1024, SharedMultipleUseFlag.None))
+            using (var ctx = new JsonOperationContext(4096, 16 * 1024, 32 * 1024, SharedMultipleUseFlag.None))
             {
                 DynamicJsonValue obj1 = new DynamicJsonValue();
                 DynamicJsonValue obj2 = new DynamicJsonValue();
@@ -371,7 +370,7 @@ namespace SlowTests.Utils
                 };
 
                 var conflictResovlerAdvisor = new ConflictResolverAdvisor(
-                    new List<BlittableJsonReaderObject> {ctx.ReadObject(obj1, "doc/1"), ctx.ReadObject(obj2, "doc/1")},
+                    new List<BlittableJsonReaderObject> { ctx.ReadObject(obj1, "doc/1"), ctx.ReadObject(obj2, "doc/1") },
                     ctx);
                 var resolvled = conflictResovlerAdvisor.Resolve().Metadata;
 
@@ -387,7 +386,7 @@ namespace SlowTests.Utils
         [Fact]
         public void CanDetectAndSuggestOptionsForConflict_SimpleMetadata()
         {
-            using (var ctx = new JsonOperationContext(4096, 16*1024, SharedMultipleUseFlag.None))
+            using (var ctx = new JsonOperationContext(4096, 16 * 1024, 32 * 1024, SharedMultipleUseFlag.None))
             {
                 DynamicJsonValue obj1 = new DynamicJsonValue();
                 DynamicJsonValue obj2 = new DynamicJsonValue();
@@ -401,7 +400,7 @@ namespace SlowTests.Utils
                 };
 
                 var conflictResovlerAdvisor = new ConflictResolverAdvisor(
-                    new List<BlittableJsonReaderObject> {ctx.ReadObject(obj1, "doc/1"), ctx.ReadObject(obj2, "doc/1")},
+                    new List<BlittableJsonReaderObject> { ctx.ReadObject(obj1, "doc/1"), ctx.ReadObject(obj2, "doc/1") },
                     ctx);
                 var resolvled = conflictResovlerAdvisor.Resolve().Metadata;
 


### PR DESCRIPTION
- resetting LSV in allocatedStringValues on Reset to release the materialized strings so GC can collect them
- restrict the amount of allocatedStringValues in Client API to 1024
