### PR TITLE
RavenDB-14707 Send a DELETE command when IsEmptyScript is false

### DIFF
--- a/src/Raven.Server/Documents/ETL/Providers/Raven/RavenEtlDocumentTransformer.cs
+++ b/src/Raven.Server/Documents/ETL/Providers/Raven/RavenEtlDocumentTransformer.cs
@@ -474,7 +474,7 @@ namespace Raven.Server.Documents.ETL.Providers.Raven
 
                 if (_script.IsLoadedToDefaultCollection(item, collection))
                 {
-                    if (operation == OperationType.Delete || _transformation.IsAddingAttachments || _transformation.IsAddingCounters)
+                    if (operation == OperationType.Delete || _transformation.IsAddingAttachments || _transformation.IsAddingCounters || _transformation.IsEmptyScript == false)
                         _currentRun.Delete(new DeleteCommandData(item.DocumentId, null));
                 }
                 else

--- a/test/SlowTests/Server/Documents/ETL/Raven/RavenDB_14707.cs
+++ b/test/SlowTests/Server/Documents/ETL/Raven/RavenDB_14707.cs
@@ -1,0 +1,64 @@
+﻿using System;
+using System.Collections.Generic;
+using System.Text;
+using Xunit;
+using Xunit.Abstractions;
+using Raven.Tests.Core.Utils.Entities;
+using System.IO;
+
+namespace SlowTests.Server.Documents.ETL.Raven
+{
+    public class RavenDB_14707 : EtlTestBase
+    {
+        public RavenDB_14707(ITestOutputHelper output) : base(output)
+        {
+        }
+
+        [Fact]
+        public void Should_delete_existing_document_when_filtered_by_script()
+        {
+            using (var src = GetDocumentStore())
+            using (var dest = GetDocumentStore())
+            {
+                AddEtl(src, dest, "Users", script: @"if (this.Name == 'Joe Doe') loadToUsers(this);");
+
+                var etlDone = WaitForEtl(src, (n, s) => s.LoadSuccesses > 0);
+
+                using (var session = src.OpenSession())
+                {
+                    session.Store(new User()
+                    {
+                        Name = "Joe Doe"
+                    }, "users/1");
+
+                    session.SaveChanges();
+                }
+
+                etlDone.Wait(TimeSpan.FromMinutes(1));
+
+                using (var session = dest.OpenSession())
+                {
+                    var user = session.Load<User>("users/1");
+                    Assert.NotNull(user);
+                }
+
+                etlDone.Reset();
+
+                using (var session = src.OpenSession())
+                {
+                    var user = session.Load<User>("users/1");
+                    user.Name = "John Doe";
+                    session.SaveChanges();
+                }
+
+                etlDone.Wait(TimeSpan.FromMinutes(1));
+
+                using (var session = dest.OpenSession())
+                {
+                    var user = session.Load<User>("users/1");
+                    Assert.Null(user);
+                }
+            }
+        }
+    }
+}

--- a/test/SlowTests/Server/Documents/ETL/Raven/RavenDB_9072.cs
+++ b/test/SlowTests/Server/Documents/ETL/Raven/RavenDB_9072.cs
@@ -86,7 +86,7 @@ loadToOrders(orderData);"
 
                         Assert.Equal(0, result.TransformationErrors.Count);
 
-                        Assert.Equal(4, result.Commands.Count);
+                        Assert.Equal(5, result.Commands.Count);
 
                         Assert.Equal(1, result.Commands.OfType<DeletePrefixedCommandData>().Count());
                         Assert.Equal(3, result.Commands.OfType<PutCommandDataWithBlittableJson>().Count());


### PR DESCRIPTION
This change will make sure a DELETE command will be send when the ETL task contains a script. This is needed because sometimes you want to filter what will be send to the destination database.

In the (added) test case a transform script is present that will make sure only documents with Name "Joe Doe" are loaded to the destination database. The fix makes sure the document is deleted when at a later time the name changes.

I'va also changed test case for RavenDB_9072 because the fix results in a extra DELETE command so Commands.Count changes from 4 to 5.