### PR TITLE
RavenDB-14882 : Enhance time-series client API

### DIFF
--- a/src/Raven.Client/Documents/Operations/TimeSeries/ConfigureTimeSeriesOperation.cs
+++ b/src/Raven.Client/Documents/Operations/TimeSeries/ConfigureTimeSeriesOperation.cs
@@ -1,6 +1,5 @@
 ﻿using System.Net.Http;
 using Raven.Client.Documents.Conventions;
-using Raven.Client.Documents.Session;
 using Raven.Client.Http;
 using Raven.Client.Json;
 using Raven.Client.Json.Converters;

--- a/src/Raven.Client/Documents/Operations/TimeSeries/GetMultipleTimeSeriesOperation.cs
+++ b/src/Raven.Client/Documents/Operations/TimeSeries/GetMultipleTimeSeriesOperation.cs
@@ -18,20 +18,6 @@ namespace Raven.Client.Documents.Operations.TimeSeries
         private readonly int _start;
         private readonly int _pageSize;
 
-        public GetMultipleTimeSeriesOperation(string docId, string timeseries, DateTime from, DateTime to, int start = 0, int pageSize = int.MaxValue)
-            : this(docId, start, pageSize)
-        {
-            _ranges = new List<TimeSeriesRange>
-            {
-                new TimeSeriesRange
-                {
-                    Name = timeseries,
-                    From = from,
-                    To = to
-                }
-            };
-        }
-
         public GetMultipleTimeSeriesOperation(string docId, IEnumerable<TimeSeriesRange> ranges, int start = 0, int pageSize = int.MaxValue)
             : this(docId, start, pageSize)
         {

--- a/src/Raven.Client/Documents/Operations/TimeSeries/GetMultipleTimeSeriesOperation.cs
+++ b/src/Raven.Client/Documents/Operations/TimeSeries/GetMultipleTimeSeriesOperation.cs
@@ -1,0 +1,122 @@
+﻿using System;
+using System.Collections.Generic;
+using System.Net.Http;
+using System.Text;
+using Raven.Client.Documents.Conventions;
+using Raven.Client.Http;
+using Raven.Client.Json.Converters;
+using Sparrow.Extensions;
+using Sparrow.Json;
+
+namespace Raven.Client.Documents.Operations.TimeSeries
+{
+    public class GetMultipleTimeSeriesOperation : IOperation<TimeSeriesDetails>
+    {
+        private readonly string _docId;
+        private readonly IEnumerable<TimeSeriesRange> _ranges;
+        private readonly int _start;
+        private readonly int _pageSize;
+
+        public GetMultipleTimeSeriesOperation(string docId, string timeseries, DateTime from, DateTime to, int start = 0, int pageSize = int.MaxValue)
+            : this(docId, start, pageSize)
+        {
+            _ranges = new List<TimeSeriesRange>
+            {
+                new TimeSeriesRange
+                {
+                    Name = timeseries,
+                    From = from,
+                    To = to
+                }
+            };
+        }
+
+        public GetMultipleTimeSeriesOperation(string docId, IEnumerable<TimeSeriesRange> ranges, int start = 0, int pageSize = int.MaxValue)
+            : this(docId, start, pageSize)
+        {
+            _ranges = ranges ?? throw new ArgumentNullException(nameof(ranges));
+        }
+
+        private GetMultipleTimeSeriesOperation(string docId, int start, int pageSize)
+        {
+            if (string.IsNullOrEmpty(docId))
+                throw new ArgumentNullException(nameof(docId));
+
+            _docId = docId;
+            _start = start;
+            _pageSize = pageSize;
+        }
+
+        public RavenCommand<TimeSeriesDetails> GetCommand(IDocumentStore store, DocumentConventions conventions, JsonOperationContext context, HttpCache cache)
+        {
+            return new GetMultipleTimeSeriesCommand(_docId, _ranges, _start, _pageSize);
+        }
+
+        internal class GetMultipleTimeSeriesCommand : RavenCommand<TimeSeriesDetails>
+        {
+            private readonly string _docId;
+            private readonly IEnumerable<TimeSeriesRange> _ranges;
+            private readonly int _start;
+            private readonly int _pageSize;
+
+            public GetMultipleTimeSeriesCommand(string docId, IEnumerable<TimeSeriesRange> ranges, int start, int pageSize)
+            {
+                _docId = docId ?? throw new ArgumentNullException(nameof(docId));
+                _ranges = ranges;
+                _start = start;
+                _pageSize = pageSize;
+            }
+
+            public override HttpRequestMessage CreateRequest(JsonOperationContext ctx, ServerNode node, out string url)
+            {
+                var pathBuilder = new StringBuilder(node.Url);
+                pathBuilder.Append("/databases/")
+                    .Append(node.Database)
+                    .Append("/timeseries/ranges")
+                    .Append("?docId=")
+                    .Append(Uri.EscapeDataString(_docId));
+
+                if (_start > 0)
+                {
+                    pathBuilder.Append("&start=")
+                        .Append(_start);
+                }
+
+                if (_pageSize < int.MaxValue)
+                {
+                    pathBuilder.Append("&pageSize=")
+                        .Append(_pageSize);
+                }
+
+                foreach (var range in _ranges)
+                {
+                    pathBuilder.Append("&name=")
+                        .Append(range.Name)
+                        .Append("&from=")
+                        .Append(range.From.GetDefaultRavenFormat())
+                        .Append("&to=")
+                        .Append(range.To.GetDefaultRavenFormat());
+                }
+
+                var request = new HttpRequestMessage
+                {
+                    Method = HttpMethod.Get
+                };
+
+                url = pathBuilder.ToString();
+
+                return request;
+            }
+
+            public override void SetResponse(JsonOperationContext context, BlittableJsonReaderObject response, bool fromCache)
+            {
+                if (response == null)
+                    return;
+
+                Result = JsonDeserializationClient.TimeSeriesDetails(response);
+            }
+
+            public override bool IsReadRequest => true;
+        }
+    }
+}

--- a/src/Raven.Client/Documents/Operations/TimeSeries/GetTimeSeriesOperation.cs
+++ b/src/Raven.Client/Documents/Operations/TimeSeries/GetTimeSeriesOperation.cs
@@ -21,6 +21,9 @@ namespace Raven.Client.Documents.Operations.TimeSeries
             if (string.IsNullOrEmpty(docId))
                 throw new ArgumentNullException(nameof(docId));
 
+            if (string.IsNullOrEmpty(timeseries))
+                throw new ArgumentNullException(nameof(timeseries));
+
             _docId = docId;
             _start = start;
             _pageSize = pageSize;
@@ -72,11 +75,11 @@ namespace Raven.Client.Documents.Operations.TimeSeries
                 }
 
                 pathBuilder.Append("&name=")
-                    .Append(_name)
+                    .Append(Uri.EscapeDataString(_name))
                     .Append("&from=")
-                    .Append(_from.GetDefaultRavenFormat())
+                    .Append(_from.EnsureUtc().GetDefaultRavenFormat())
                     .Append("&to=")
-                    .Append(_to.GetDefaultRavenFormat());
+                    .Append(_to.EnsureUtc().GetDefaultRavenFormat());
 
                 var request = new HttpRequestMessage
                 {

--- a/src/Raven.Client/Documents/Operations/TimeSeries/TimeSeriesDetails.cs
+++ b/src/Raven.Client/Documents/Operations/TimeSeries/TimeSeriesDetails.cs
@@ -1,0 +1,10 @@
+﻿using System.Collections.Generic;
+
+namespace Raven.Client.Documents.Operations.TimeSeries
+{
+    public class TimeSeriesDetails
+    {
+        public string Id;
+        public Dictionary<string, List<TimeSeriesRangeResult>> Values;
+    }
+}

--- a/src/Raven.Client/Documents/Operations/TimeSeries/TimeSeriesDetails.cs
+++ b/src/Raven.Client/Documents/Operations/TimeSeries/TimeSeriesDetails.cs
@@ -4,7 +4,7 @@ namespace Raven.Client.Documents.Operations.TimeSeries
 {
     public class TimeSeriesDetails
     {
-        public string Id;
-        public Dictionary<string, List<TimeSeriesRangeResult>> Values;
+        public string Id { get; set; }
+        public Dictionary<string, List<TimeSeriesRangeResult>> Values { get; set; }
     }
 }

--- a/src/Raven.Client/Documents/Session/InMemoryDocumentSessionOperations.cs
+++ b/src/Raven.Client/Documents/Session/InMemoryDocumentSessionOperations.cs
@@ -1251,6 +1251,7 @@ more responsive application.
                 DocumentsByEntity.Evict(entity);
                 DocumentsById.Remove(documentInfo.Id);
                 _countersByDocId?.Remove(documentInfo.Id);
+                _timeSeriesByDocId?.Remove(documentInfo.Id);
             }
 
             DeletedEntities.Evict(entity);

--- a/src/Raven.Client/Json/Converters/JsonDeserializationClient.cs
+++ b/src/Raven.Client/Json/Converters/JsonDeserializationClient.cs
@@ -148,6 +148,8 @@ namespace Raven.Client.Json.Converters
 
         public static readonly Func<BlittableJsonReaderObject, TimeSeriesDetails> TimeSeriesDetails = GenerateJsonDeserializationRoutine<TimeSeriesDetails>();
 
+        public static readonly Func<BlittableJsonReaderObject, TimeSeriesRangeResult> TimeSeriesRangeResult = GenerateJsonDeserializationRoutine<TimeSeriesRangeResult>();
+
         internal static readonly Func<BlittableJsonReaderObject, ExceptionDispatcher.ExceptionSchema> ExceptionSchema = GenerateJsonDeserializationRoutine<ExceptionDispatcher.ExceptionSchema>();
 
         internal static readonly Func<BlittableJsonReaderObject, DeleteDatabaseResult> DeleteDatabaseResult = GenerateJsonDeserializationRoutine<DeleteDatabaseResult>();

--- a/src/Raven.Server/Documents/ComputeHttpEtags.cs
+++ b/src/Raven.Server/Documents/ComputeHttpEtags.cs
@@ -74,7 +74,7 @@ namespace Raven.Server.Documents
 
                         foreach (var rangeResult in kvp.Value)
                         {
-                            HashNumber(state, rangeResult.Entries.Length);
+                            HashNumber(state, rangeResult.Entries?.Length ?? 0);
                             HashChangeVector(state, rangeResult.Hash);
                         }
                     }

--- a/test/SlowTests/Client/TimeSeries/BulkInsert.cs
+++ b/test/SlowTests/Client/TimeSeries/BulkInsert.cs
@@ -602,16 +602,16 @@ namespace SlowTests.Client.TimeSeries
                 using (var session = store.OpenSession())
                 {
                     var vals = session.TimeSeriesFor(documentId, "Heartrate")
-                        .Get(baseline.AddMinutes(-10), baseline.AddMinutes(-5))
+                        .Get(baseline.AddMinutes(-10), baseline.AddMinutes(-5))?
                         .ToList();
 
-                    Assert.Equal(0, vals.Count);
+                    Assert.Null(vals);
 
                     vals = session.TimeSeriesFor(documentId, "Heartrate")
-                        .Get(baseline.AddMinutes(5), baseline.AddMinutes(9))
+                        .Get(baseline.AddMinutes(5), baseline.AddMinutes(9))?
                         .ToList();
 
-                    Assert.Equal(0, vals.Count);
+                    Assert.Null(vals);
                 }
             }
         }
@@ -920,11 +920,11 @@ namespace SlowTests.Client.TimeSeries
                 {
                     var vals = session.TimeSeriesFor(documentId, "Heartrate")
                         .Get(DateTime.MinValue, DateTime.MaxValue);
-                    Assert.Equal(0, vals.Count());
+                    Assert.Null(vals);
 
-                    vals = session.TimeSeriesFor(documentId, "Heartrate")
+                    vals = session.TimeSeriesFor(documentId, "Heartrate2")
                         .Get(DateTime.MinValue, DateTime.MaxValue);
-                    Assert.Equal(0, vals.Count());
+                    Assert.Null(vals);
                 }
             }
         }

--- a/test/SlowTests/Client/TimeSeries/Issues/RavenDB-14293.cs
+++ b/test/SlowTests/Client/TimeSeries/Issues/RavenDB-14293.cs
@@ -40,9 +40,9 @@ namespace SlowTests.Client.TimeSeries.Issues
                 using (var session = store.OpenSession())
                 {
                     var vals = session.TimeSeriesFor("users/ayende", "Heartrate")
-                        .Get(DateTime.MinValue, DateTime.MaxValue)
+                        .Get(DateTime.MinValue, DateTime.MaxValue)?
                         .ToList();
-                    Assert.Equal(0, vals.Count);
+                    Assert.Null(vals);
                 }
             }
         }

--- a/test/SlowTests/Client/TimeSeries/Issues/RavenDB-14633.cs
+++ b/test/SlowTests/Client/TimeSeries/Issues/RavenDB-14633.cs
@@ -60,7 +60,7 @@ namespace SlowTests.Client.TimeSeries.Issues
                 var re = store.GetRequestExecutor();
                 using (re.ContextPool.AllocateOperationContext(out var context))
                 {
-                    var tsCommand = new GetTimeSeriesOperation.GetTimeSeriesCommand(documentId, new List<TimeSeriesRange>
+                    var tsCommand = new GetMultipleTimeSeriesOperation.GetMultipleTimeSeriesCommand(documentId, new List<TimeSeriesRange>
                     {
                         new TimeSeriesRange
                         {
@@ -118,7 +118,7 @@ namespace SlowTests.Client.TimeSeries.Issues
                 var re = store.GetRequestExecutor();
                 using (re.ContextPool.AllocateOperationContext(out var context))
                 {
-                    var tsCommand = new GetTimeSeriesOperation.GetTimeSeriesCommand(documentId, new List<TimeSeriesRange>
+                    var tsCommand = new GetMultipleTimeSeriesOperation.GetMultipleTimeSeriesCommand(documentId, new List<TimeSeriesRange>
                     {
                         new TimeSeriesRange
                         {
@@ -182,7 +182,7 @@ namespace SlowTests.Client.TimeSeries.Issues
                 {
                     for (int i = 0; i < 3; i++)
                     {
-                        var tsCommand = new GetTimeSeriesOperation.GetTimeSeriesCommand(documentId, new List<TimeSeriesRange>
+                        var tsCommand = new GetMultipleTimeSeriesOperation.GetMultipleTimeSeriesCommand(documentId, new List<TimeSeriesRange>
                         {
                             new TimeSeriesRange
                             {
@@ -221,7 +221,7 @@ namespace SlowTests.Client.TimeSeries.Issues
 
                     // verify that we don't get cached results
 
-                    var command = new GetTimeSeriesOperation.GetTimeSeriesCommand(documentId,
+                    var command = new GetMultipleTimeSeriesOperation.GetMultipleTimeSeriesCommand(documentId,
                         new List<TimeSeriesRange>
                         {
                             new TimeSeriesRange
@@ -288,10 +288,10 @@ namespace SlowTests.Client.TimeSeries.Issues
                 var re = store.GetRequestExecutor();
                 using (re.ContextPool.AllocateOperationContext(out var context))
                 {
-                    GetTimeSeriesOperation.GetTimeSeriesCommand tsCommand = default;
+                    GetMultipleTimeSeriesOperation.GetMultipleTimeSeriesCommand tsCommand;
                     for (int i = 0; i < 3; i++)
                     {
-                        tsCommand = new GetTimeSeriesOperation.GetTimeSeriesCommand(documentId, new List<TimeSeriesRange>
+                        tsCommand = new GetMultipleTimeSeriesOperation.GetMultipleTimeSeriesCommand(documentId, new List<TimeSeriesRange>
                         {
                             new TimeSeriesRange
                             {
@@ -331,7 +331,7 @@ namespace SlowTests.Client.TimeSeries.Issues
 
                     // verify that we don't get cached results
 
-                    tsCommand = new GetTimeSeriesOperation.GetTimeSeriesCommand(documentId, new List<TimeSeriesRange>
+                    tsCommand = new GetMultipleTimeSeriesOperation.GetMultipleTimeSeriesCommand(documentId, new List<TimeSeriesRange>
                     {
                         new TimeSeriesRange
                         {
@@ -359,7 +359,7 @@ namespace SlowTests.Client.TimeSeries.Issues
                     // request with a different 'start'
                     // verify that we don't get cached results
 
-                    tsCommand = new GetTimeSeriesOperation.GetTimeSeriesCommand(documentId, new List<TimeSeriesRange>
+                    tsCommand = new GetMultipleTimeSeriesOperation.GetMultipleTimeSeriesCommand(documentId, new List<TimeSeriesRange>
                     {
                         new TimeSeriesRange
                         {
@@ -436,7 +436,7 @@ namespace SlowTests.Client.TimeSeries.Issues
                         }
                     };
 
-                    var tsCommand = new GetTimeSeriesOperation.GetTimeSeriesCommand(documentId, ranges, 0, int.MaxValue);
+                    var tsCommand = new GetMultipleTimeSeriesOperation.GetMultipleTimeSeriesCommand(documentId, ranges, 0, int.MaxValue);
                     re.Execute(tsCommand, context);
                     var timesSeriesDetails = tsCommand.Result;
 
@@ -530,7 +530,7 @@ namespace SlowTests.Client.TimeSeries.Issues
                         }
                     };
 
-                    var tsCommand = new GetTimeSeriesOperation.GetTimeSeriesCommand(documentId, ranges, 10, 150);
+                    var tsCommand = new GetMultipleTimeSeriesOperation.GetMultipleTimeSeriesCommand(documentId, ranges, 10, 150);
                     re.Execute(tsCommand, context);
                     var timesSeriesDetails = tsCommand.Result;
 
@@ -624,11 +624,11 @@ namespace SlowTests.Client.TimeSeries.Issues
                         }
                     };
 
-                    GetTimeSeriesOperation.GetTimeSeriesCommand tsCommand;
+                    GetMultipleTimeSeriesOperation.GetMultipleTimeSeriesCommand tsCommand;
 
                     for (int i = 0; i < 3; i++)
                     {
-                        tsCommand = new GetTimeSeriesOperation.GetTimeSeriesCommand(documentId, ranges, 0, int.MaxValue);
+                        tsCommand = new GetMultipleTimeSeriesOperation.GetMultipleTimeSeriesCommand(documentId, ranges, 0, int.MaxValue);
                         re.Execute(tsCommand, context);
                         var timesSeriesDetails = tsCommand.Result;
 
@@ -682,7 +682,7 @@ namespace SlowTests.Client.TimeSeries.Issues
 
                     // verify that we don't get cached results
 
-                    tsCommand = new GetTimeSeriesOperation.GetTimeSeriesCommand(documentId, ranges, 0, int.MaxValue);
+                    tsCommand = new GetMultipleTimeSeriesOperation.GetMultipleTimeSeriesCommand(documentId, ranges, 0, int.MaxValue);
                     re.Execute(tsCommand, context);
 
                     Assert.Equal(HttpStatusCode.OK, tsCommand.StatusCode);
@@ -751,11 +751,11 @@ namespace SlowTests.Client.TimeSeries.Issues
                         }
                     };
 
-                    GetTimeSeriesOperation.GetTimeSeriesCommand tsCommand;
+                    GetMultipleTimeSeriesOperation.GetMultipleTimeSeriesCommand tsCommand;
 
                     for (int i = 0; i < 3; i++)
                     {
-                        tsCommand = new GetTimeSeriesOperation.GetTimeSeriesCommand(documentId, ranges, 10, 150);
+                        tsCommand = new GetMultipleTimeSeriesOperation.GetMultipleTimeSeriesCommand(documentId, ranges, 10, 150);
                         re.Execute(tsCommand, context);
                         var timesSeriesDetails = tsCommand.Result;
 
@@ -810,7 +810,7 @@ namespace SlowTests.Client.TimeSeries.Issues
 
                     // verify that we don't get cached results
 
-                    tsCommand = new GetTimeSeriesOperation.GetTimeSeriesCommand(documentId, ranges, 10, 150);
+                    tsCommand = new GetMultipleTimeSeriesOperation.GetMultipleTimeSeriesCommand(documentId, ranges, 10, 150);
                     re.Execute(tsCommand, context);
 
                     Assert.Equal(HttpStatusCode.OK, tsCommand.StatusCode);
@@ -823,7 +823,7 @@ namespace SlowTests.Client.TimeSeries.Issues
                     // request with a different 'start'
                     // verify that we don't get cached results
 
-                    tsCommand = new GetTimeSeriesOperation.GetTimeSeriesCommand(documentId, new List<TimeSeriesRange>
+                    tsCommand = new GetMultipleTimeSeriesOperation.GetMultipleTimeSeriesCommand(documentId, new List<TimeSeriesRange>
                     {
                         new TimeSeriesRange()
                         {

--- a/test/SlowTests/Client/TimeSeries/Issues/RavenDB-14633.cs
+++ b/test/SlowTests/Client/TimeSeries/Issues/RavenDB-14633.cs
@@ -2,15 +2,9 @@
 using System.Collections.Generic;
 using System.Linq;
 using System.Net;
-using System.Net.Http;
-using System.Text;
 using FastTests;
 using Raven.Client.Documents.Operations.TimeSeries;
-using Raven.Client.Http;
-using Raven.Client.Json.Converters;
 using Raven.Tests.Core.Utils.Entities;
-using Sparrow.Extensions;
-using Sparrow.Json;
 using Xunit;
 using Xunit.Abstractions;
 

--- a/test/SlowTests/Client/TimeSeries/Issues/RavenDB-14651.cs
+++ b/test/SlowTests/Client/TimeSeries/Issues/RavenDB-14651.cs
@@ -50,14 +50,12 @@ namespace SlowTests.Client.TimeSeries.Issues
 
                 store.Operations.Send(timeSeriesBatch);
 
-                var timesSeriesDetails = store.Operations.Send(
+                var rangeResult = store.Operations.Send(
                     new GetTimeSeriesOperation("users/ayende", "Heartrate", DateTime.MinValue, DateTime.MaxValue));
 
-                Assert.Equal("users/ayende", timesSeriesDetails.Id);
-                Assert.Equal(1, timesSeriesDetails.Values.Count);
-                Assert.Equal(1, timesSeriesDetails.Values["Heartrate"][0].Entries.Length);
+                Assert.Equal(1, rangeResult.Entries.Length);
 
-                var value = timesSeriesDetails.Values["Heartrate"][0].Entries[0];
+                var value = rangeResult.Entries[0];
 
                 Assert.Equal(59d, value.Values[0]);
                 Assert.Null(value.Tag);
@@ -87,15 +85,12 @@ namespace SlowTests.Client.TimeSeries.Issues
                     session.SaveChanges();
                 }
 
-
-                var timesSeriesDetails = store.Operations.Send(
+                var rangeResult = store.Operations.Send(
                     new GetTimeSeriesOperation("users/ayende", "Heartrate", DateTime.MinValue, DateTime.MaxValue));
 
-                Assert.Equal("users/ayende", timesSeriesDetails.Id);
-                Assert.Equal(1, timesSeriesDetails.Values.Count);
-                Assert.Equal(1, timesSeriesDetails.Values["Heartrate"][0].Entries.Length);
+                Assert.Equal(1, rangeResult.Entries.Length);
 
-                var value = timesSeriesDetails.Values["Heartrate"][0].Entries[0];
+                var value = rangeResult.Entries[0];
 
                 Assert.Equal(59d, value.Values[0]);
                 Assert.Null(value.Tag);
@@ -123,14 +118,12 @@ namespace SlowTests.Client.TimeSeries.Issues
                     session.SaveChanges();
                 }
 
-                var timesSeriesDetails = store.Operations.Send(
+                var rangeResult = store.Operations.Send(
                     new GetTimeSeriesOperation("users/ayende", "Heartrate", DateTime.MinValue, DateTime.MaxValue));
 
-                Assert.Equal("users/ayende", timesSeriesDetails.Id);
-                Assert.Equal(1, timesSeriesDetails.Values.Count);
-                Assert.Equal(1, timesSeriesDetails.Values["Heartrate"][0].Entries.Length);
+                Assert.Equal(1, rangeResult.Entries.Length);
 
-                var value = timesSeriesDetails.Values["Heartrate"][0].Entries[0];
+                var value = rangeResult.Entries[0];
 
                 Assert.Equal(59d, value.Values[0]);
                 Assert.Equal("watches/fitbit", value.Tag);

--- a/test/SlowTests/Client/TimeSeries/Operations/TimeSeriesOperations.cs
+++ b/test/SlowTests/Client/TimeSeries/Operations/TimeSeriesOperations.cs
@@ -56,14 +56,12 @@ namespace SlowTests.Client.TimeSeries.Operations
 
                 store.Operations.Send(timeSeriesBatch);
 
-                var timesSeriesDetails = store.Operations.Send(
+                var timeSeriesRangeResult = store.Operations.Send(
                     new GetTimeSeriesOperation(documentId, "Heartrate", DateTime.MinValue, DateTime.MaxValue));
 
-                Assert.Equal(documentId, timesSeriesDetails.Id);
-                Assert.Equal(1, timesSeriesDetails.Values.Count);
-                Assert.Equal(1, timesSeriesDetails.Values["Heartrate"][0].Entries.Length);
+                Assert.Equal(1, timeSeriesRangeResult.Entries.Length);
 
-                var value = timesSeriesDetails.Values["Heartrate"][0].Entries[0];
+                var value = timeSeriesRangeResult.Entries[0];
 
                 Assert.Equal(59d, value.Values[0]);
                 Assert.Equal("watches/fitbit", value.Tag);
@@ -105,12 +103,10 @@ namespace SlowTests.Client.TimeSeries.Operations
 
                 store.Operations.Send(timeSeriesBatch);
 
-                var timesSeriesDetails = store.Operations.Send(
+                var timeSeriesRangeResult = store.Operations.Send(
                     new GetTimeSeriesOperation("users/ayende", "Heartrate", baseline.AddMonths(-2), baseline.AddMonths(-1)));
 
-                Assert.Equal("users/ayende", timesSeriesDetails.Id);
-                Assert.Equal(1, timesSeriesDetails.Values.Count);
-                Assert.Equal(0, timesSeriesDetails.Values["Heartrate"][0].Entries.Length);
+                Assert.Null(timeSeriesRangeResult.Entries);
 
                 using (var session = store.OpenSession())
                 {
@@ -174,26 +170,24 @@ namespace SlowTests.Client.TimeSeries.Operations
 
                 store.Operations.Send(timeSeriesBatch);
 
-                var timesSeriesDetails = store.Operations.Send(
+                var timeSeriesRangeResult = store.Operations.Send(
                     new GetTimeSeriesOperation(documentId, "Heartrate", DateTime.MinValue, DateTime.MaxValue));
 
-                Assert.Equal(documentId, timesSeriesDetails.Id);
-                Assert.Equal(1, timesSeriesDetails.Values.Count);
-                Assert.Equal(3, timesSeriesDetails.Values["Heartrate"][0].Entries.Length);
+                Assert.Equal(3, timeSeriesRangeResult.Entries.Length);
 
-                var value = timesSeriesDetails.Values["Heartrate"][0].Entries[0];
+                var value = timeSeriesRangeResult.Entries[0];
 
                 Assert.Equal(59d, value.Values[0]);
                 Assert.Equal("watches/fitbit", value.Tag);
                 Assert.Equal(baseline.AddSeconds(1), value.Timestamp, RavenTestHelper.DateTimeComparer.Instance);
 
-                value = timesSeriesDetails.Values["Heartrate"][0].Entries[1];
+                value = timeSeriesRangeResult.Entries[1];
 
                 Assert.Equal(61d, value.Values[0]);
                 Assert.Equal("watches/fitbit", value.Tag);
                 Assert.Equal(baseline.AddSeconds(2), value.Timestamp, RavenTestHelper.DateTimeComparer.Instance);
 
-                value = timesSeriesDetails.Values["Heartrate"][0].Entries[2];
+                value = timeSeriesRangeResult.Entries[2];
 
                 Assert.Equal(60d, value.Values[0]);
                 Assert.Equal("watches/apple-watch", value.Tag);
@@ -273,12 +267,10 @@ namespace SlowTests.Client.TimeSeries.Operations
 
                 store.Operations.Send(timeSeriesBatch);
 
-                var timesSeriesDetails = store.Operations.Send(
+                var timeSeriesRangeResult = store.Operations.Send(
                     new GetTimeSeriesOperation(documentId, "Heartrate", DateTime.MinValue, DateTime.MaxValue));
 
-                Assert.Equal(documentId, timesSeriesDetails.Id);
-                Assert.Equal(1, timesSeriesDetails.Values.Count);
-                Assert.Equal(5, timesSeriesDetails.Values["Heartrate"][0].Entries.Length);
+                Assert.Equal(5, timeSeriesRangeResult.Entries.Length);
 
 
                 timeSeriesOp = new TimeSeriesOperation
@@ -298,22 +290,20 @@ namespace SlowTests.Client.TimeSeries.Operations
 
                 store.Operations.Send(timeSeriesBatch);
 
-                timesSeriesDetails = store.Operations.Send(
+                timeSeriesRangeResult = store.Operations.Send(
                     new GetTimeSeriesOperation(documentId, "Heartrate", DateTime.MinValue, DateTime.MaxValue));
 
-                Assert.Equal(documentId, timesSeriesDetails.Id);
-                Assert.Equal(1, timesSeriesDetails.Values.Count);
-                Assert.Equal(3, timesSeriesDetails.Values["Heartrate"][0].Entries.Length);
+                Assert.Equal(3, timeSeriesRangeResult.Entries.Length);
 
-                var value = timesSeriesDetails.Values["Heartrate"][0].Entries[0];
+                var value = timeSeriesRangeResult.Entries[0];
                 Assert.Equal(59d, value.Values[0]);
                 Assert.Equal(baseline.AddSeconds(1), value.Timestamp, RavenTestHelper.DateTimeComparer.Instance);
 
-                value = timesSeriesDetails.Values["Heartrate"][0].Entries[1];
+                value = timeSeriesRangeResult.Entries[1];
                 Assert.Equal(62.5d, value.Values[0]);
                 Assert.Equal(baseline.AddSeconds(4), value.Timestamp, RavenTestHelper.DateTimeComparer.Instance);
 
-                value = timesSeriesDetails.Values["Heartrate"][0].Entries[2];
+                value = timeSeriesRangeResult.Entries[2];
                 Assert.Equal(62d, value.Values[0]);
                 Assert.Equal(baseline.AddSeconds(5), value.Timestamp, RavenTestHelper.DateTimeComparer.Instance);
 
@@ -530,12 +520,10 @@ namespace SlowTests.Client.TimeSeries.Operations
 
                 store.Operations.Send(timeSeriesBatch);
 
-                var timesSeriesDetails = store.Operations.Send(
+                var timeSeriesRangeResult = store.Operations.Send(
                     new GetTimeSeriesOperation(documentId, "Heartrate", DateTime.MinValue, DateTime.MaxValue));
 
-                Assert.Equal(documentId, timesSeriesDetails.Id);
-                Assert.Equal(1, timesSeriesDetails.Values.Count);
-                Assert.Equal(3, timesSeriesDetails.Values["Heartrate"][0].Entries.Length);
+                Assert.Equal(3, timeSeriesRangeResult.Entries.Length);
 
                 timeSeriesOp = new TimeSeriesOperation
                 {
@@ -584,26 +572,24 @@ namespace SlowTests.Client.TimeSeries.Operations
 
                 store.Operations.Send(timeSeriesBatch);
 
-                timesSeriesDetails = store.Operations.Send(
+                timeSeriesRangeResult = store.Operations.Send(
                     new GetTimeSeriesOperation(documentId, "Heartrate", DateTime.MinValue, DateTime.MaxValue));
 
-                Assert.Equal(documentId, timesSeriesDetails.Id);
-                Assert.Equal(1, timesSeriesDetails.Values.Count);
-                Assert.Equal(4, timesSeriesDetails.Values["Heartrate"][0].Entries.Length);
+                Assert.Equal(4, timeSeriesRangeResult.Entries.Length);
 
-                var value = timesSeriesDetails.Values["Heartrate"][0].Entries[0];
+                var value = timeSeriesRangeResult.Entries[0];
                 Assert.Equal(59d, value.Values[0]);
                 Assert.Equal(baseline.AddSeconds(1), value.Timestamp, RavenTestHelper.DateTimeComparer.Instance);
 
-                value = timesSeriesDetails.Values["Heartrate"][0].Entries[1];
+                value = timeSeriesRangeResult.Entries[1];
                 Assert.Equal(60d, value.Values[0]);
                 Assert.Equal(baseline.AddSeconds(4), value.Timestamp, RavenTestHelper.DateTimeComparer.Instance);
 
-                value = timesSeriesDetails.Values["Heartrate"][0].Entries[2];
+                value = timeSeriesRangeResult.Entries[2];
                 Assert.Equal(62.5d, value.Values[0]);
                 Assert.Equal(baseline.AddSeconds(5), value.Timestamp, RavenTestHelper.DateTimeComparer.Instance);
 
-                value = timesSeriesDetails.Values["Heartrate"][0].Entries[3];
+                value = timeSeriesRangeResult.Entries[3];
                 Assert.Equal(62d, value.Values[0]);
                 Assert.Equal(baseline.AddSeconds(6), value.Timestamp, RavenTestHelper.DateTimeComparer.Instance);
 
@@ -717,7 +703,7 @@ namespace SlowTests.Client.TimeSeries.Operations
                 store.Operations.Send(timeSeriesBatch);
 
                 var timesSeriesDetails = store.Operations.Send(
-                    new GetTimeSeriesOperation(documentId, new List<TimeSeriesRange>
+                    new GetMultipleTimeSeriesOperation(documentId, new List<TimeSeriesRange>
                     {
                         new TimeSeriesRange
                         {
@@ -851,7 +837,7 @@ namespace SlowTests.Client.TimeSeries.Operations
                 // get ranges from multiple time series in a single request
 
                 var timesSeriesDetails = store.Operations.Send(
-                    new GetTimeSeriesOperation(documentId, new List<TimeSeriesRange>
+                    new GetMultipleTimeSeriesOperation(documentId, new List<TimeSeriesRange>
                     {
                         new TimeSeriesRange
                         {
@@ -986,7 +972,7 @@ namespace SlowTests.Client.TimeSeries.Operations
                 store.Operations.Send(timeSeriesBatch);
 
                 var ex = Assert.Throws<ArgumentNullException>(() => store.Operations.Send(
-                    new GetTimeSeriesOperation("users/ayende", null)));
+                    new GetMultipleTimeSeriesOperation("users/ayende", null)));
 
                 Assert.Contains("Value cannot be null. (Parameter 'ranges')", ex.Message);
             }
@@ -1028,7 +1014,7 @@ namespace SlowTests.Client.TimeSeries.Operations
                 store.Operations.Send(timeSeriesBatch);
 
                 var ex = Assert.Throws<RavenException>(() => store.Operations.Send(
-                    new GetTimeSeriesOperation("users/ayende", new List<TimeSeriesRange>
+                    new GetMultipleTimeSeriesOperation("users/ayende", new List<TimeSeriesRange>
                     {
                         new TimeSeriesRange
                         {

--- a/test/SlowTests/Client/TimeSeries/Patch/TimeSeriesPatchTests.cs
+++ b/test/SlowTests/Client/TimeSeries/Patch/TimeSeriesPatchTests.cs
@@ -322,18 +322,17 @@ for(i = 0; i < args.toAppend.length; i++){
                 using (var session = store.OpenAsyncSession())
                 {
                     var entries = (await session.TimeSeriesFor(documentId, timeseries)
-                            .GetAsync(DateTime.MinValue, DateTime.MaxValue))
-                        .ToList();
+                            .GetAsync(DateTime.MinValue, DateTime.MaxValue))?.ToList();
 
-                    Assert.Equal(values.Length - 1 - (toIndex - fromIndex), entries.Count);
+                    Assert.Equal(values.Length - 1 - (toIndex - fromIndex), (entries?.Count ?? 0));
                     foreach (var expected in expectedValues)
                     {
                         if (expected.Item1 >= toRemoveFrom || expected.Item1 <= toRemoveTo) 
                             continue;
                         
-                        Assert.Equal(expected.Item1, entries[0].Timestamp, RavenTestHelper.DateTimeComparer.Instance);
-                        Assert.Equal(expected.Item2, entries[0].Values[0]);
-                        Assert.Equal(tag, entries[0].Tag);
+                        Assert.Equal(expected.Item1, entries[0]?.Timestamp, RavenTestHelper.DateTimeComparer.Instance);
+                        Assert.Equal(expected.Item2, entries[0]?.Values[0]);
+                        Assert.Equal(tag, entries[0]?.Tag);
                     }
                 }
             }

--- a/test/SlowTests/Client/TimeSeries/Patch/TimeSeriesPatchTests.cs
+++ b/test/SlowTests/Client/TimeSeries/Patch/TimeSeriesPatchTests.cs
@@ -330,9 +330,9 @@ for(i = 0; i < args.toAppend.length; i++){
                         if (expected.Item1 >= toRemoveFrom || expected.Item1 <= toRemoveTo) 
                             continue;
                         
-                        Assert.Equal(expected.Item1, entries[0]?.Timestamp, RavenTestHelper.DateTimeComparer.Instance);
-                        Assert.Equal(expected.Item2, entries[0]?.Values[0]);
-                        Assert.Equal(tag, entries[0]?.Tag);
+                        Assert.Equal(expected.Item1, entries[0].Timestamp, RavenTestHelper.DateTimeComparer.Instance);
+                        Assert.Equal(expected.Item2, entries[0].Values[0]);
+                        Assert.Equal(tag, entries[0].Tag);
                     }
                 }
             }

--- a/test/SlowTests/Client/TimeSeries/Session/TimeSeriesIncludes.cs
+++ b/test/SlowTests/Client/TimeSeries/Session/TimeSeriesIncludes.cs
@@ -555,7 +555,7 @@ namespace SlowTests.Client.TimeSeries.Session
                     Assert.True(((InMemoryDocumentSessionOperations)session).TimeSeriesByDocId.TryGetValue("users/ayende", out var cache));
                     Assert.True(cache.TryGetValue("Heartrate", out var ranges));
                     Assert.Equal(1, ranges.Count);
-                    Assert.Empty(ranges[0].Entries);
+                    Assert.Null(ranges[0].Entries);
                     Assert.Equal(baseline.AddMinutes(-30), ranges[0].From, RavenTestHelper.DateTimeComparer.Instance);
                     Assert.Equal(baseline.AddMinutes(-10), ranges[0].To, RavenTestHelper.DateTimeComparer.Instance);
 
@@ -589,7 +589,7 @@ namespace SlowTests.Client.TimeSeries.Session
 
                     Assert.True(cache.TryGetValue("BloodPressure", out ranges));
                     Assert.Equal(1, ranges.Count);
-                    Assert.Empty(ranges[0].Entries);
+                    Assert.Null(ranges[0].Entries);
                     Assert.Equal(baseline.AddMinutes(10), ranges[0].From, RavenTestHelper.DateTimeComparer.Instance);
                     Assert.Equal(baseline.AddMinutes(30), ranges[0].To, RavenTestHelper.DateTimeComparer.Instance);
 
@@ -1394,7 +1394,7 @@ namespace SlowTests.Client.TimeSeries.Session
                     Assert.True(((InMemoryDocumentSessionOperations)session).TimeSeriesByDocId.TryGetValue("users/ayende", out var cache));
                     Assert.True(cache.TryGetValue("Heartrate", out var ranges));
                     Assert.Equal(1, ranges.Count);
-                    Assert.Empty(ranges[0].Entries);
+                    Assert.Null(ranges[0].Entries);
                     Assert.Equal(baseline.AddMinutes(-30), ranges[0].From, RavenTestHelper.DateTimeComparer.Instance);
                     Assert.Equal(baseline.AddMinutes(-10), ranges[0].To, RavenTestHelper.DateTimeComparer.Instance);
 
@@ -1428,11 +1428,9 @@ namespace SlowTests.Client.TimeSeries.Session
 
                     Assert.True(cache.TryGetValue("BloodPressure", out ranges));
                     Assert.Equal(1, ranges.Count);
-                    Assert.Empty(ranges[0].Entries);
+                    Assert.Null(ranges[0].Entries);
                     Assert.Equal(baseline.AddMinutes(10), ranges[0].From, RavenTestHelper.DateTimeComparer.Instance);
                     Assert.Equal(baseline.AddMinutes(30), ranges[0].To, RavenTestHelper.DateTimeComparer.Instance);
-
-
                 }
             }
         }

--- a/test/SlowTests/Client/TimeSeries/Session/TimeSeriesRangesCache.cs
+++ b/test/SlowTests/Client/TimeSeries/Session/TimeSeriesRangesCache.cs
@@ -598,10 +598,10 @@ namespace SlowTests.Client.TimeSeries.Session
                 using (var session = store.OpenSession())
                 {
                     var vals = session.TimeSeriesFor("users/ayende", "Heartrate")
-                        .Get(baseline.AddHours(-2), baseline.AddHours(-1))
+                        .Get(baseline.AddHours(-2), baseline.AddHours(-1))?
                         .ToList();
 
-                    Assert.Equal(0, vals.Count);
+                    Assert.Null(vals);
                     Assert.Equal(1, session.Advanced.NumberOfRequests);
 
                     // should not go to server

--- a/test/SlowTests/Client/TimeSeries/Session/TimeSeriesSessionTests.cs
+++ b/test/SlowTests/Client/TimeSeries/Session/TimeSeriesSessionTests.cs
@@ -490,16 +490,16 @@ namespace SlowTests.Client.TimeSeries.Session
                 using (var session = store.OpenSession())
                 {
                     var vals = session.TimeSeriesFor("users/ayende", "Heartrate")
-                        .Get(baseline.AddMinutes(-10), baseline.AddMinutes(-5))
+                        .Get(baseline.AddMinutes(-10), baseline.AddMinutes(-5))?
                         .ToList();
 
-                    Assert.Equal(0, vals.Count);
+                    Assert.Null(vals);
 
                     vals = session.TimeSeriesFor("users/ayende", "Heartrate")
-                        .Get(baseline.AddMinutes(5), baseline.AddMinutes(9))
+                        .Get(baseline.AddMinutes(5), baseline.AddMinutes(9))?
                         .ToList();
 
-                    Assert.Equal(0, vals.Count);
+                    Assert.Null(vals);
                 }
             }
         }
@@ -794,10 +794,10 @@ namespace SlowTests.Client.TimeSeries.Session
                 using (var session = store.OpenSession())
                 {
                     var vals = session.TimeSeriesFor(id, "Heartrate").Get(DateTime.MinValue, DateTime.MaxValue);
-                    Assert.Equal(0, vals.Count());
+                    Assert.Null(vals);
 
                     vals = session.TimeSeriesFor(id, "Heartrate2").Get(DateTime.MinValue, DateTime.MaxValue);
-                    Assert.Equal(0, vals.Count());
+                    Assert.Null(vals);
                 }
             }
         }

--- a/test/SlowTests/Client/TimeSeries/Session/TimeSeriesSessionTests.cs
+++ b/test/SlowTests/Client/TimeSeries/Session/TimeSeriesSessionTests.cs
@@ -898,11 +898,11 @@ namespace SlowTests.Client.TimeSeries.Session
                     Assert.Equal(2, cache.Count);
                     Assert.True(cache.TryGetValue("Heartrate", out var ranges));
                     Assert.Equal(2, ranges.Count);
-                    Assert.Equal(baseline, ranges[0].From);
-                    Assert.Equal(baseline.AddMinutes(10), ranges[0].To);
+                    Assert.Equal(baseline, ranges[0].From, RavenTestHelper.DateTimeComparer.Instance);
+                    Assert.Equal(baseline.AddMinutes(10), ranges[0].To, RavenTestHelper.DateTimeComparer.Instance);
                     Assert.Equal(11, ranges[0].Entries.Length);
-                    Assert.Equal(baseline.AddMinutes(20), ranges[1].From);
-                    Assert.Equal(baseline.AddMinutes(50), ranges[1].To);
+                    Assert.Equal(baseline.AddMinutes(20), ranges[1].From, RavenTestHelper.DateTimeComparer.Instance);
+                    Assert.Equal(baseline.AddMinutes(50), ranges[1].To, RavenTestHelper.DateTimeComparer.Instance);
                     Assert.Equal(31, ranges[1].Entries.Length);
                     Assert.True(cache.TryGetValue("BloodPressure", out ranges));
                     Assert.Equal(1, ranges.Count);

--- a/test/SlowTests/Client/TimeSeries/TimeSeriesStatsUpdate.cs
+++ b/test/SlowTests/Client/TimeSeries/TimeSeriesStatsUpdate.cs
@@ -85,7 +85,9 @@ namespace SlowTests.Client.TimeSeries
 
                 store.Operations.Send(new TimeSeriesBatchOperation("users/1-A", abc));
                 var ts = store.Operations.Send(new GetTimeSeriesOperation("users/1-A", "test", DateTime.MinValue, DateTime.MaxValue));
-                Assert.Equal(0, ts.Values["test"][0].Entries.Length);
+
+                // GetTimeSeriesOperation should return null on non-existing timeseries 
+                Assert.Null(ts);
             }
         }
 
@@ -122,8 +124,8 @@ namespace SlowTests.Client.TimeSeries
                 }))
                 {
                     var ts = session.TimeSeriesFor("users/1-A", "HR");
-                    var after2delete = ts.Get(DateTime.MinValue, DateTime.MaxValue).ToList();
-                    Assert.Equal(0, after2delete.Count);
+                    var after2delete = ts.Get(DateTime.MinValue, DateTime.MaxValue)?.ToList();
+                    Assert.Null(after2delete);
                 }
             }
         }
@@ -166,8 +168,8 @@ namespace SlowTests.Client.TimeSeries
                 }))
                 {
                     var ts = session.TimeSeriesFor("users/1-A", "HR");
-                    var after2delete = ts.Get(DateTime.MinValue, DateTime.MaxValue).ToList();
-                    Assert.Equal(0, after2delete.Count);
+                    var after2delete = ts.Get(DateTime.MinValue, DateTime.MaxValue)?.ToList();
+                    Assert.Null(after2delete);
                 }
             }
         }

--- a/test/SlowTests/Smuggler/SmugglerApiTests.cs
+++ b/test/SlowTests/Smuggler/SmugglerApiTests.cs
@@ -1065,12 +1065,12 @@ namespace SlowTests.Smuggler
                         var values = await session.TimeSeriesFor(user1, "Heartrate")
                             .GetAsync(DateTime.MinValue, DateTime.MaxValue);
 
-                        Assert.Empty(values);
+                        Assert.Null(values);
 
                         values = await session.TimeSeriesFor(user2, "Heartrate")
                             .GetAsync(DateTime.MinValue, DateTime.MaxValue);
 
-                        Assert.Empty(values);
+                        Assert.Null(values);
                     }
 
                 }
@@ -1146,12 +1146,12 @@ namespace SlowTests.Smuggler
                         var values = await session.TimeSeriesFor(user1, "Heartrate")
                             .GetAsync(DateTime.MinValue, DateTime.MaxValue);
 
-                        Assert.Empty(values);
+                        Assert.Null(values);
 
                         values = await session.TimeSeriesFor(user2, "Heartrate")
                             .GetAsync(DateTime.MinValue, DateTime.MaxValue);
 
-                        Assert.Empty(values);
+                        Assert.Null(values);
                     }
 
                 }


### PR DESCRIPTION
https://issues.hibernatingrhinos.com/issue/RavenDB-14882
- Have separate command for getting multi time-series and only one time-series
- Get non-existing TS should return null instead an empty array (both from session and from GetTimeSeriesOperation)
- Evict TS upon entity eviction