### PR TITLE
RavenDB-14870

### DIFF
--- a/src/Raven.Server/Documents/DocumentsTransaction.cs
+++ b/src/Raven.Server/Documents/DocumentsTransaction.cs
@@ -2,6 +2,7 @@
 using System.Collections.Generic;
 using System.Threading;
 using Raven.Client.Documents.Changes;
+using Raven.Server.Documents.Indexes;
 using Raven.Server.Documents.Replication;
 using Raven.Server.ServerWide;
 using Raven.Server.ServerWide.Context;
@@ -143,6 +144,13 @@ namespace Raven.Server.Documents
                 _collectionCache = new Dictionary<string, CollectionName>(OrdinalIgnoreCaseStringStructComparer.Instance);
 
             _collectionCache.Add(collectionName, name);
+        }
+
+        public void ForgetAbout(Document doc)
+        {
+            if (doc == null)
+                return;
+            InnerTransaction.ForgetAbout(doc.StorageId);
         }
     }
 }

--- a/src/Raven.Server/Documents/Indexes/Auto/AutoIndexDocsEnumerator.cs
+++ b/src/Raven.Server/Documents/Indexes/Auto/AutoIndexDocsEnumerator.cs
@@ -1,6 +1,7 @@
 ﻿using System.Collections;
 using System.Collections.Generic;
 using Raven.Client.Documents.Indexes;
+using Raven.Server.ServerWide.Context;
 
 namespace Raven.Server.Documents.Indexes.Auto
 {
@@ -16,10 +17,13 @@ namespace Raven.Server.Documents.Indexes.Auto
             _itemsEnumerator = items.GetEnumerator();
         }
 
-        public bool MoveNext(out IEnumerable resultsOfCurrentDocument, out long? etag)
+        public bool MoveNext(DocumentsOperationContext ctx, out IEnumerable resultsOfCurrentDocument, out long? etag)
         {
             using (_documentReadStats.Start())
             {
+                ctx.Transaction.ForgetAbout(_results[0]);
+                _results[0]?.Dispose();
+
                 var moveNext = _itemsEnumerator.MoveNext();
 
                 var document = (Document)_itemsEnumerator.Current?.Item;

--- a/src/Raven.Server/Documents/Indexes/IIndexedDocumentsEnumerator.cs
+++ b/src/Raven.Server/Documents/Indexes/IIndexedDocumentsEnumerator.cs
@@ -1,11 +1,12 @@
 ﻿using System;
 using System.Collections;
+using Raven.Server.ServerWide.Context;
 
 namespace Raven.Server.Documents.Indexes
 {
     public interface IIndexedItemEnumerator : IDisposable
     {
-        bool MoveNext(out IEnumerable resultsOfCurrentDocument, out long? etag);
+        bool MoveNext(DocumentsOperationContext ctx, out IEnumerable resultsOfCurrentDocument, out long? etag);
 
         void OnError();
 

--- a/src/Raven.Server/Documents/Indexes/Static/StaticIndexItemEnumerator.cs
+++ b/src/Raven.Server/Documents/Indexes/Static/StaticIndexItemEnumerator.cs
@@ -4,6 +4,7 @@ using System.Collections.Generic;
 using System.Linq;
 using Raven.Client;
 using Raven.Client.Documents.Indexes;
+using Raven.Server.ServerWide.Context;
 
 namespace Raven.Server.Documents.Indexes.Static
 {
@@ -78,10 +79,13 @@ namespace Raven.Server.Documents.Indexes.Static
             _filter = filter;
         }
 
-        public bool MoveNext(out IEnumerable resultsOfCurrentDocument, out long? etag)
+        public bool MoveNext(DocumentsOperationContext ctx, out IEnumerable resultsOfCurrentDocument, out long? etag)
         {
             using (_documentReadStats?.Start())
             {
+                if(Current is DocumentIndexItem di && di.Item is Document d)
+                    ctx.Transaction.ForgetAbout(d);
+
                 Current?.Dispose();
                 etag = null;
 

--- a/src/Raven.Server/Documents/Indexes/Workers/HandleReferences.cs
+++ b/src/Raven.Server/Documents/Indexes/Workers/HandleReferences.cs
@@ -225,7 +225,7 @@ namespace Raven.Server.Documents.Indexes.Workers
 
                                     using (var itemsEnumerator = _index.GetMapEnumerator(items, collection, indexContext, collectionStats, _index.Type))
                                     {
-                                        while (itemsEnumerator.MoveNext(out IEnumerable mapResults, out var etag))
+                                        while (itemsEnumerator.MoveNext(queryContext.Documents, out IEnumerable mapResults, out var etag))
                                         {
                                             token.ThrowIfCancellationRequested();
 

--- a/src/Raven.Server/Documents/Indexes/Workers/MapItems.cs
+++ b/src/Raven.Server/Documents/Indexes/Workers/MapItems.cs
@@ -76,7 +76,7 @@ namespace Raven.Server.Documents.Indexes.Workers
                             {
                                 while (true)
                                 {
-                                    if (itemEnumerator.MoveNext(out IEnumerable mapResults, out var etag) == false)
+                                    if (itemEnumerator.MoveNext(queryContext.Documents, out IEnumerable mapResults, out var etag) == false)
                                     {
                                         if (etag > lastEtag)
                                             lastEtag = etag.Value;

--- a/src/Voron/Impl/Transaction.cs
+++ b/src/Voron/Impl/Transaction.cs
@@ -17,8 +17,12 @@ namespace Voron.Impl
     public unsafe class Transaction : IDisposable
     {
         private Dictionary<Tuple<Tree, Slice>, Tree> _multiValueTrees;
+        private Dictionary<long, ByteString> _cachedDecompressedBuffersByStorageId;
 
-        private  LowLevelTransaction _lowLevelTransaction;
+        internal Dictionary<long, ByteString> CachedDecompressedBuffersByStorageId =>
+            _cachedDecompressedBuffersByStorageId ??= new Dictionary<long, ByteString>();
+
+        private LowLevelTransaction _lowLevelTransaction;
 
         public LowLevelTransaction LowLevelTransaction
         {
@@ -591,6 +595,15 @@ namespace Voron.Impl
             {
                 _tables.Remove(nameSlice);
             }
+        }
+
+        public void ForgetAbout(in long storageId)
+        {
+            if (_cachedDecompressedBuffersByStorageId == null)
+                return;
+
+            if (_cachedDecompressedBuffersByStorageId.Remove(storageId, out var t))
+                Allocator.Release(ref t);
         }
     }
 }


### PR DESCRIPTION
* Provide a way to tell the transaction that a particular document is of no interest to us during indexing
* Allow to forget compression buffer to allow us better memory for indexing of compressed values.
* fixing an issue with PeepInReadStream not liking dirty buffers.