### PR TITLE
RavenDB-14790

### DIFF
--- a/src/Sparrow/PeepingTomStream.cs
+++ b/src/Sparrow/PeepingTomStream.cs
@@ -83,21 +83,25 @@ namespace Sparrow
             // representing single character, so 0x80 represent start of char in utf8)
             var originalStart = start;
 
-            for (var p = _bufferWindow.Pointer; (*(p + start) & 0x80) != 0; p++)
+            for (var p = _bufferWindow.Pointer; (*(p + start) & 0x80) != 0;)
             {
                 start++;
-                size--;
-
-                // requested size doesn't contains utf8 character
-                if (size == 0)
-                    return new byte[0];
 
                 // looped through the entire buffer without utf8 character found
                 if (start == originalStart)
                     return new byte[0];
 
                 if (start >= BufferWindowSize)
+                {
                     start = 0;
+                    continue;
+                }
+
+                size--;
+
+                // requested size doesn't contains utf8 character
+                if (size == 0)
+                    return new byte[0];
             }
             var buf = new byte[size];
             if (size == 0)


### PR DESCRIPTION
- we should not move pointer, offset is controlled by start
- if we are peeping when start is at the end of window, then we want to start from scratch before decreasing the peep size