### PR TITLE
RDBS-85 Fixed incorrect updates of last processed etags in ETL task s…

### DIFF
--- a/src/Raven.Server/Documents/ETL/Providers/Raven/RavenEtl.cs
+++ b/src/Raven.Server/Documents/ETL/Providers/Raven/RavenEtl.cs
@@ -61,6 +61,8 @@ namespace Raven.Server.Documents.ETL.Providers.Raven
             oldRequestExecutor?.Dispose();
         }
 
+        internal Action<RavenEtl> BeforeActualLoad = null;
+
         private static RequestExecutor CreateNewRequestExecutor(RavenEtlConfiguration configuration, ServerStore serverStore)
         {
             var certificate = serverStore.Server.Certificate.Certificate;
@@ -141,6 +143,8 @@ namespace Raven.Server.Documents.ETL.Providers.Raven
 
             try
             {
+                BeforeActualLoad?.Invoke(this);
+
                 AsyncHelpers.RunSync(() => _requestExecutor.ExecuteAsync(batchCommand, context, token: CancellationToken));
                 _recentUrl = _requestExecutor.Url;
 
@@ -153,7 +157,7 @@ namespace Raven.Server.Documents.ETL.Providers.Raven
                     ThrowTimeoutException(commands.Count, duration.Elapsed, e);
                 }
 
-                return 0;
+                throw;
             }
         }
 

--- a/test/SlowTests/Server/Documents/ETL/Raven/RDBS_85.cs
+++ b/test/SlowTests/Server/Documents/ETL/Raven/RDBS_85.cs
@@ -1,0 +1,143 @@
+﻿using System;
+using System.Linq;
+using System.Threading;
+using System.Threading.Tasks;
+using Raven.Server.Documents.ETL;
+using Raven.Server.Documents.ETL.Providers.Raven;
+using Raven.Tests.Core.Utils.Entities;
+using Xunit;
+using Xunit.Abstractions;
+
+namespace SlowTests.Server.Documents.ETL.Raven
+{
+    public class RDBS_85 : EtlTestBase
+    {
+        public RDBS_85(ITestOutputHelper output) : base(output)
+        {
+        }
+
+        [Fact]
+        public async Task MustNotSkipAnyDocumentsIfTaskIsCanceledDuringLoad()
+        {
+            using (var src = GetDocumentStore())
+            using (var dst = GetDocumentStore())
+            {
+                var etlDone = WaitForEtl(src, (n, statistics) => statistics.LoadSuccesses != 0);
+
+                AddEtl(src, dst, "users",
+                    @"loadToUsers(this)");
+
+                var srcDb = await GetDatabase(src.Database);
+
+                var process = (RavenEtl)srcDb.EtlLoader.Processes.First();
+
+                var afterStop = new ManualResetEvent(false);
+
+                process.BeforeActualLoad += p =>
+                {
+                    p.Stop("testing");
+                    afterStop.Set();
+                };
+
+                using (var session = src.OpenSession())
+                {
+                    session.Store(new User
+                    {
+                        Name = "Arek"
+                    }, "users/1");
+
+                    session.SaveChanges();
+                }
+
+                Assert.True(afterStop.WaitOne(TimeSpan.FromSeconds(30)));
+
+                using (var session = src.OpenSession())
+                {
+                    session.Store(new User
+                    {
+                        Name = "Karmel"
+                    }, "users/2");
+
+                    session.SaveChanges();
+                }
+
+                process.BeforeActualLoad = null;
+
+                process.Start();
+
+                Assert.True(etlDone.Wait(TimeSpan.FromSeconds(30)));
+
+                using (var session = dst.OpenSession())
+                {
+                    User[] users = session.Advanced.LoadStartingWith<User>("users/");
+
+                    Assert.Equal(2, users.Length);
+
+                    var user = session.Load<User>("users/2");
+                    Assert.NotNull(user);
+
+                    user = session.Load<User>("users/1");
+                    Assert.NotNull(user);
+                }
+            }
+        }
+
+        [Fact]
+        public async Task MustNotSkipAnyDocumentsIfLoadFailsAndThereWereSomeInternalFiltering()
+        {
+            using (var src = GetDocumentStore())
+            using (var dst = GetDocumentStore())
+            {
+                var etlDone = WaitForEtl(src, (n, statistics) => statistics.LoadSuccesses != 0);
+
+                AddEtl(src, dst, new string[0],
+                    @"loadToUsers(this)", applyToAllDocuments: true); // this will filter our HiLo docs under the covers
+
+                var srcDb = await GetDatabase(src.Database);
+
+                var process = (RavenEtl)srcDb.EtlLoader.Processes.First();
+
+                var afterLoadError = new ManualResetEvent(false);
+
+                process.BeforeActualLoad += p =>
+                {
+                    afterLoadError.Set();
+                    throw new Exception("Force the failure of the load of docs");
+                };
+
+                using (var session = src.OpenSession())
+                {
+                    session.Store(new User
+                    {
+                        Name = "Arek"
+                    });
+
+                    session.SaveChanges();
+                }
+
+                Assert.True(afterLoadError.WaitOne(TimeSpan.FromSeconds(30)));
+                
+                process.BeforeActualLoad = null;
+
+                using (var session = src.OpenSession())
+                {
+                    session.Store(new User
+                    {
+                        Name = "Karmel"
+                    });
+
+                    session.SaveChanges();
+                }
+
+                Assert.True(etlDone.Wait(TimeSpan.FromSeconds(30)));
+
+                using (var session = dst.OpenSession())
+                {
+                    User[] users = session.Advanced.LoadStartingWith<User>("users/");
+
+                    Assert.Equal(2, users.Length);
+                }
+            }
+        }
+    }
+}


### PR DESCRIPTION
…tate if the task was cancelled or there was load error and some internal filtering (e.g. filtering of HiLo docs)