### PR TITLE
RavenDB-15196 fix import time-series when the ts with original name is missing

### DIFF
--- a/src/Raven.Server/Documents/DocumentDatabase.cs
+++ b/src/Raven.Server/Documents/DocumentDatabase.cs
@@ -340,16 +340,16 @@ namespace Raven.Server.Documents
                 _serverStore.StorageSpaceMonitor.Subscribe(this);
 
                 TaskExecutor.Execute(_ =>
-               {
-                   try
-                   {
-                       NotifyFeaturesAboutStateChange(record, index);
-                   }
-                   catch
-                   {
+                {
+                    try
+                    {
+                        NotifyFeaturesAboutStateChange(record, index);
+                    }
+                    catch
+                    {
                         // We ignore the exception since it was caught in the function itself
                     }
-               }, null);
+                }, null);
 
                 Task.Run(async () =>
                 {


### PR DESCRIPTION
We importing TS by the etag, so it might happened that we will import the rollup, before the raw one.