### PR TITLE
RavenDB-15234 Dynamic fields. Client API throws exception when the fi…

### DIFF
--- a/src/Raven.Client/Documents/Linq/LinqPathProvider.cs
+++ b/src/Raven.Client/Documents/Linq/LinqPathProvider.cs
@@ -73,12 +73,10 @@ namespace Raven.Client.Documents.Linq
 
                     var itemKey = GetValueFromExpression(callExpression.Arguments[0], callExpression.Method.GetParameters()[0].ParameterType).ToString();
 
-                    itemKey = QueryFieldUtil.EscapeIfNecessary(itemKey, isPath: true);
-
                     return new Result
                     {
                         MemberType = callExpression.Method.ReturnType,
-                        IsNestedPath = false,
+                        IsNestedPath = true,
                         Path = parent.Path + "." + itemKey
                     };
                 }

--- a/src/Raven.Client/Documents/Queries/QueryFieldUtil.cs
+++ b/src/Raven.Client/Documents/Queries/QueryFieldUtil.cs
@@ -1,4 +1,6 @@
-﻿namespace Raven.Client.Documents.Queries
+﻿using System.Text;
+
+namespace Raven.Client.Documents.Queries
 {
     public static class QueryFieldUtil
     {
@@ -17,48 +19,94 @@
                 name == Constants.Documents.Indexing.Fields.SpatialShapeFieldName)
                 return name;
 
-            var escape = false;
+            if (ShouldEscape(name) == false)
+                return name;
+            
+            var sb = new StringBuilder(name);
+            var needEndQuote = false;
+            var lastTermStart = 0;
 
-            bool insideEscaped = false;
-
-            for (var i = 0; i < name.Length; i++)
+            for (int i = 0; i < sb.Length; i++)
             {
-                var c = name[i];
-
-                if (c == '\'' || c == '"')
+                var c = sb[i];
+                if ( i == 0 && char.IsLetter(c) == false && c != '_' && c != '@')
                 {
-                    insideEscaped = !insideEscaped;
+                    sb.Insert(lastTermStart, '"');
+                    needEndQuote = true;
                     continue;
                 }
 
-                if (i == 0)
+                if (isPath && c == '.')
                 {
-                    if (char.IsLetter(c) == false && c != '_' && c != '@' && insideEscaped == false)
+                    if (needEndQuote)
                     {
-                        escape = true;
-                        break;
-                    }
-                }
-                else
-                {
-                    if (char.IsLetterOrDigit(c) == false && c != '_' && c != '-' && c != '@' && c != '.' && c != '[' && c != ']' && insideEscaped == false)
-                    {
-                        escape = true;
-                        break;
+                        needEndQuote = false;
+                        sb.Insert(i, '\'');
+                        i++;
                     }
 
-                    if (isPath && c == '.' && insideEscaped == false)
-                    {
-                        escape = true;
-                        break;
-                    }
+                    lastTermStart = i+1;
+                    continue;
+                }
+                
+                if (char.IsLetterOrDigit(c) == false && c != '_' && c != '-' && c != '@' && c != '.' && c != '[' && c != ']' && needEndQuote == false)
+                {
+                    sb.Insert(lastTermStart, '\'');
+                    needEndQuote = true;
+                    continue;
                 }
             }
 
-            if (escape || insideEscaped)
-                return $"'{name}'";
+            if (needEndQuote)
+            {
+                sb.Append('\'');
+            }
 
-            return name;
+            return sb.ToString();
+
+                bool ShouldEscape(string s)
+            {
+                var escape = false;
+
+                bool insideEscaped = false;
+
+                for (var i = 0; i < s.Length; i++)
+                {
+                    var c = s[i];
+
+                    if (c == '\'' || c == '"')
+                    {
+                        insideEscaped = !insideEscaped;
+                        continue;
+                    }
+
+                    if (i == 0)
+                    {
+                        if (char.IsLetter(c) == false && c != '_' && c != '@' && insideEscaped == false)
+                        {
+                            escape = true;
+                            break;
+                        }
+                    }
+                    else
+                    {
+                        if (char.IsLetterOrDigit(c) == false && c != '_' && c != '-' && c != '@' && c != '.' && c != '[' && c != ']' && insideEscaped == false)
+                        {
+                            escape = true;
+                            break;
+                        }
+
+                        if (isPath && c == '.' && insideEscaped == false)
+                        {
+                            escape = true;
+                            break;
+                        }
+                    }
+                }
+
+                escape |= insideEscaped;
+                return escape;
+            }
         }
     }
 }

--- a/src/Raven.Client/Documents/Queries/QueryFieldUtil.cs
+++ b/src/Raven.Client/Documents/Queries/QueryFieldUtil.cs
@@ -31,7 +31,7 @@ namespace Raven.Client.Documents.Queries
                 var c = sb[i];
                 if ( i == 0 && char.IsLetter(c) == false && c != '_' && c != '@')
                 {
-                    sb.Insert(lastTermStart, '"');
+                    sb.Insert(lastTermStart, '\'');
                     needEndQuote = true;
                     continue;
                 }

--- a/src/Raven.Client/Documents/Session/AbstractDocumentQuery.cs
+++ b/src/Raven.Client/Documents/Session/AbstractDocumentQuery.cs
@@ -1584,7 +1584,7 @@ Use session.Query<T>() instead of session.Advanced.DocumentQuery<T>. The session
         private string EnsureValidFieldName(string fieldName, bool isNestedPath)
         {
             if (TheSession?.Conventions == null || isNestedPath || IsGroupBy)
-                return QueryFieldUtil.EscapeIfNecessary(fieldName);
+                return QueryFieldUtil.EscapeIfNecessary(fieldName, isNestedPath);
 
             foreach (var rootType in RootTypes)
             {

--- a/test/SlowTests/Issues/EncryptedDatabaseGroup.cs
+++ b/test/SlowTests/Issues/EncryptedDatabaseGroup.cs
@@ -35,7 +35,7 @@ namespace SlowTests.Issues
             using (var store = GetDocumentStore(options))
             {
                 var record = await store.Maintenance.Server.SendAsync(new GetDatabaseRecordOperation(store.Database));
-                var notInDbGroupServer = Servers.Single(s => record.Topology.Members.Contains(s.ServerStore.NodeTag) == false);
+                var notInDbGroupServer = Servers.Single(s => record.Topology.AllNodes.Contains(s.ServerStore.NodeTag) == false );
                 await Assert.ThrowsAsync<RavenException>(async () => await store.Maintenance.Server.SendAsync(new AddDatabaseNodeOperation(store.Database)));
 
                 var dbName = store.Database;

--- a/test/SlowTests/Issues/RavenDB-14361.cs
+++ b/test/SlowTests/Issues/RavenDB-14361.cs
@@ -63,7 +63,7 @@ namespace SlowTests.Issues
                 using (var session = store.OpenSession())
                 {
                     var q = session.Query<Test>()
-                        .Select(x => x.Headers["ABC.DEF"]);
+                        .Select(x => x.Headers["'ABC.DEF'"]);
 
                     var str = q.FirstOrDefault();
                     Assert.Equal("205fb229-2373-49da-9329-ab0c01096c6c", str);

--- a/test/SlowTests/Issues/RavenDB-15234.cs
+++ b/test/SlowTests/Issues/RavenDB-15234.cs
@@ -1,0 +1,80 @@
+using System.Collections.Generic;
+using System.Linq;
+using FastTests;
+using Raven.Client.Documents;
+using Raven.Client.Documents.Indexes;
+using Xunit;
+using Xunit.Abstractions;
+
+namespace SlowTests.Issues
+{
+    public class RavenDB_15234 : RavenTestBase
+    {
+
+        public RavenDB_15234(ITestOutputHelper output) : base(output)
+        {
+        }
+
+        public class Item
+        {
+            public Dictionary<string, string> Fields;
+        }
+
+        public class Index : AbstractIndexCreationTask<Item>
+        {
+            public Index()
+            {
+                Map = items => from item in items
+                    select new {_ = item.Fields.Select(f => CreateField("Fields_" + f.Key, f.Value))};
+            }
+        }
+        
+        [Fact]
+        public void CanUseFieldStartingWithNumber_InDynamicQuery()
+        {
+            using var store = GetDocumentStore();
+
+            using (var s = store.OpenSession())
+            {
+                var q = s.Query<Item>().Where(x => x.Fields["1-A"] == "Blue").ToString();
+                Assert.Equal("from 'Items' where Fields.1-A = $p0", q);
+            }
+        }
+        
+        [Fact]
+        public void CanUseFieldWithSlash_InDynamicQuery()
+        {
+            using var store = GetDocumentStore();
+
+            using (var s = store.OpenSession())
+            {
+                var q = s.Query<Item>().Where(x => x.Fields["users/1-A"] == "Blue").ToString();
+                Assert.Equal("from 'Items' where Fields.'users/1-A' = $p0", q);
+            }
+        }
+        
+        [Fact]
+        public void CanUseFieldStartingWithNumber_InStatic()
+        {
+            using var store = GetDocumentStore();
+            new Index().Execute(store);
+            using (var s = store.OpenSession())
+            {
+                var q = s.Query<Item, Index>().Where(x => x.Fields["1-A"] == "Blue").ToString();
+                Assert.Equal("from index 'Index' where Fields_1-A = $p0", q);
+            }
+        }
+        
+        [Fact]
+        public void CanUseFieldsWithSlash_InStatic()
+        {
+            using var store = GetDocumentStore();
+            new Index().Execute(store);
+            using (var s = store.OpenSession())
+            {
+                var q = s.Query<Item, Index>().Where(x => x.Fields["users/1-A"] == "Blue").ToString();
+                Assert.Equal("from index 'Index' where 'Fields_users/1-A' = $p0", q);
+            }
+        }
+    }
+}


### PR DESCRIPTION
…eld is treated as a dictionary with the key starting with a digit

RavenDB-15235 Dynamic fields. Client API mistreats the key when the field is treated as a dictionary and the key contains the slash ('/') symbol