### PR TITLE
RavenDB-15068 Cluster wide transaction - better error when storing doc with empty string id or white spaces

### DIFF
--- a/src/Raven.Server/ServerWide/Commands/ClusterTransactionCommand.cs
+++ b/src/Raven.Server/ServerWide/Commands/ClusterTransactionCommand.cs
@@ -131,11 +131,13 @@ namespace Raven.Server.ServerWide.Commands
 
         private static void ClusterCommandValidation(ClusterTransactionDataCommand command)
         {
-            var lastChar = command.Id[command.Id.Length - 1];
+            if(string.IsNullOrWhiteSpace(command.Id))
+                throw new RachisApplyException($"In {nameof(ClusterTransactionDataCommand)} document id cannot be null, empty or white spaces as part of cluster transaction. " +
+                                               $"{nameof(command.Type)}:({command.Type}), {nameof(command.Index)}:({command.Index})");
+                
+            var lastChar = command.Id[^1];
             if (lastChar == '/' || lastChar == '|')
-            {
                 throw new RachisApplyException($"Document id {command.Id} cannot end with '|' or '/' as part of cluster transaction");
-            }
         }
 
         public List<string> ExecuteCompareExchangeCommands(TransactionOperationContext context, long index, Table items)

--- a/test/SlowTests/Cluster/ClusterTransactionTests.cs
+++ b/test/SlowTests/Cluster/ClusterTransactionTests.cs
@@ -21,6 +21,7 @@ using Raven.Server;
 using Raven.Server.Config;
 using Raven.Server.Documents;
 using Raven.Server.Documents.Replication;
+using Raven.Server.Rachis;
 using Raven.Server.ServerWide.Commands;
 using Raven.Server.ServerWide.Context;
 using Raven.Server.Utils;
@@ -1234,6 +1235,44 @@ namespace SlowTests.Cluster
 
                     var compareExchangeValue = await session.Advanced.ClusterTransaction.GetCompareExchangeValueAsync<List<string>>(id);
                     Assert.True(value.SequenceEqual(compareExchangeValue.Value));
+                }
+            }
+        }
+
+        [Theory]
+        [InlineData("")]
+        [InlineData(" ")]
+        [InlineData(@"
+")]
+        public async Task ClusterWideTransaction_WhenStoreDocWithEmptyStringId_ShouldThrowInformativeError(string id)
+        {
+            var e = await Assert.ThrowsAnyAsync<RavenException>(async () =>
+            {
+                using var store = GetDocumentStore();
+                using var session = store.OpenAsyncSession(new SessionOptions
+                {
+                    TransactionMode = TransactionMode.ClusterWide
+                });
+                
+                var entity = new User {Id = id};
+                await session.StoreAsync(entity);
+                await session.SaveChangesAsync();
+                WaitForUserToContinueTheTest(store);
+            });
+            Assert.True(ContainsRachisException(e));
+
+            static bool ContainsRachisException(Exception e)
+            {
+                while (true)
+                {
+                    if (e.ToString().Contains(nameof(RachisApplyException)))
+                        return true;
+                    if (e is AggregateException ae) 
+                        return ae.InnerExceptions.Any(ContainsRachisException);
+
+                    if (e.InnerException == null) 
+                        return false;
+                    e = e.InnerException;
                 }
             }
         }


### PR DESCRIPTION
https://issues.hibernatingrhinos.com/issue/RavenDB-15068