### PR TITLE
RavenDB-15336

### DIFF
--- a/test/SlowTests/Issues/RavenDB_14881.cs
+++ b/test/SlowTests/Issues/RavenDB_14881.cs
@@ -1,10 +1,12 @@
-﻿using System.Collections.Generic;
+﻿using System;
+using System.Collections.Generic;
 using System.Threading.Tasks;
 using FastTests;
 using Raven.Client.Documents.Operations;
 using Raven.Client.Documents.Operations.Revisions;
 using Raven.Client.ServerWide;
 using Raven.Tests.Core.Utils.Entities;
+using Sparrow.Server;
 using Xunit;
 using Xunit.Abstractions;
 
@@ -17,16 +19,24 @@ namespace SlowTests.Issues
         {
         }
 
-        [Fact]
-        public async Task can_get_detailed_collection_statistics()
+        [Theory]
+        [InlineData(true)]
+        [InlineData(false)]
+        public async Task can_get_detailed_collection_statistics(bool compressed)
         {
             string strCollectionName = "Companies";
             using (var store = GetDocumentStore(new Options
             {
-                ModifyDatabaseRecord = record => record.DocumentsCompression = new DocumentsCompressionConfiguration
+                ModifyDatabaseRecord = record =>
                 {
-                    Collections = null,
-                    CompressRevisions = false
+                    if (!compressed)
+                    {
+                        record.DocumentsCompression = new DocumentsCompressionConfiguration
+                        {
+                            Collections = null,
+                            CompressRevisions = false
+                        };
+                    }
                 }
             }))
             {
@@ -46,12 +56,18 @@ namespace SlowTests.Issues
 
                 var result = await store.Maintenance.SendAsync(new ConfigureRevisionsOperation(configuration));
 
+                
+
                 // insert sample data
                 using (var bulk = store.BulkInsert())
                 {
                     for (var i = 0; i < 20; i++)
                     {
-                        bulk.Store(new Company { Id = "company/" + i, Name = "name" + i });
+                        bulk.Store(new Company
+                        {
+                            Id = "company/" + i,
+                            Name = Convert.ToBase64String(Sodium.GenerateRandomBuffer(128 * 8))
+                        });
                     }
                 }
 
@@ -68,7 +84,7 @@ namespace SlowTests.Issues
                     using (var session = store.OpenAsyncSession())
                     {
                         var company = await session.LoadAsync<Company>("company/1");
-                        company.Name += i;
+                        company.Name = Convert.ToBase64String(Sodium.GenerateRandomBuffer(128*8));
                         await session.StoreAsync(company);
                         await session.SaveChangesAsync();
                     }
@@ -84,7 +100,6 @@ namespace SlowTests.Issues
                 // query the detailed collection statistics again, to check if the physical size changed after the revisions were created
                 var detailedCollectionStats_afterDataChanged = await store.Maintenance.SendAsync(new GetDetailedCollectionStatisticsOperation());
                 Assert.Equal(20, detailedCollectionStats_afterDataChanged.Collections[strCollectionName].CountOfDocuments);
-
                 long sizeInBytesWithRevisions = detailedCollectionStats_afterDataChanged.Collections[strCollectionName].Size.SizeInBytes;
                 Assert.True(sizeInBytesWithRevisions > sizeInBytesWithoutRevisions);
             }

--- a/test/Tryouts/Program.cs
+++ b/test/Tryouts/Program.cs
@@ -1,17 +1,8 @@
 using System;
 using System.Diagnostics;
 using System.Threading.Tasks;
-using FastTests.Blittable;
-using FastTests.Client;
-using FastTests.Client.Indexing;
-using FastTests.Issues;
-using SlowTests.Client.Counters;
-using SlowTests.Cluster;
 using SlowTests.Issues;
-using SlowTests.Voron;
-using Sparrow;
 using Tests.Infrastructure;
-using Xunit.Sdk;
 
 namespace Tryouts
 {
@@ -21,19 +12,19 @@ namespace Tryouts
         {
             XunitLogging.RedirectStreams = false;
         }
-        
+
         public static async Task Main(string[] args)
         {
             Console.WriteLine(Process.GetCurrentProcess().Id);
             //for (int i = 0; i < 10_000; i++)
             {
-               // Console.WriteLine($"Starting to run {i}");
+                // Console.WriteLine($"Starting to run {i}");
                 try
                 {
                     using (var testOutputHelper = new ConsoleTestOutputHelper())
                     using (var test = new RavenDB_9645(testOutputHelper))
                     {
-                        test.Should_correctly_reduce_after_updating_all_documents(5000);
+                        test.Should_correctly_reduce_after_updating_all_documents(5000, compressed: true);
                     }
                 }
                 catch (Exception e)

--- a/test/Tryouts/Program.cs
+++ b/test/Tryouts/Program.cs
@@ -25,15 +25,15 @@ namespace Tryouts
         public static async Task Main(string[] args)
         {
             Console.WriteLine(Process.GetCurrentProcess().Id);
-            for (int i = 0; i < 10_000; i++)
+            //for (int i = 0; i < 10_000; i++)
             {
-                Console.WriteLine($"Starting to run {i}");
+               // Console.WriteLine($"Starting to run {i}");
                 try
                 {
                     using (var testOutputHelper = new ConsoleTestOutputHelper())
-                    using (var test = new RavenDB_10600(testOutputHelper))
+                    using (var test = new RavenDB_9645(testOutputHelper))
                     {
-                        await test.TransformScriptShouldWorkWhenAttachmentsArePresentAndShouldBeAbleToSkipDocumentsUsingThrow();
+                        test.Should_correctly_reduce_after_updating_all_documents(5000);
                     }
                 }
                 catch (Exception e)

--- a/tools/Voron.Recovery/Recovery.cs
+++ b/tools/Voron.Recovery/Recovery.cs
@@ -626,7 +626,7 @@ namespace Voron.Recovery
                 var subKeyLen = (int)Sodium.crypto_aead_xchacha20poly1305_ietf_keybytes();
                 var subKey = stackalloc byte[subKeyLen];
 
-                var recoveryFiles = Directory.GetFiles(_config.DataFileDirectory, "*.Recovery");
+                var recoveryFiles = Directory.GetFiles(_config.DataFileDirectory, TableValueCompressor.CompressionRecoveryExtensionGlob);
                 foreach (string recoveryFile in recoveryFiles)
                 {
                     try


### PR DESCRIPTION
- Invalidation of compression cache depends on the _value_, not the schema
- Fixing recovery not using the right extension for compression dictionaries
- Make sure that we report the ActiveCandidateSection as well in the table report
- Changed the test to ensure that even under compression, there would be easily noticed size differences with revisions