### PR TITLE
RavenDB-15291 Making sure that we we increment tx marker during schem…

### DIFF
--- a/src/Raven.Server/ServerWide/Context/TransactionOperationContext.cs
+++ b/src/Raven.Server/ServerWide/Context/TransactionOperationContext.cs
@@ -41,6 +41,8 @@ namespace Raven.Server.ServerWide.Context
     public abstract class TransactionOperationContext<TTransaction> : JsonOperationContext
         where TTransaction : RavenTransaction
     {
+        internal const short DefaultTransactionMarker = 2;
+
         public readonly ByteStringContext Allocator;
         public readonly TransactionPersistentContext PersistentContext;
 
@@ -89,7 +91,7 @@ namespace Raven.Server.ServerWide.Context
             var value = (short)(CurrentTxMarker + TransactionMarkerOffset);
 
             if (value == 0)
-                return 2;
+                return DefaultTransactionMarker;
             if (value < 0)
                 return (short)-value;
 

--- a/src/Raven.Server/Storage/Schema/UpdateStep.cs
+++ b/src/Raven.Server/Storage/Schema/UpdateStep.cs
@@ -1,13 +1,16 @@
-﻿using Raven.Server.Documents;
+﻿using System;
+using Raven.Server.Documents;
 using Voron.Impl;
 using Voron.Schema;
 using Raven.Server.ServerWide;
+using Raven.Server.ServerWide.Context;
 
 namespace Raven.Server.Storage.Schema
 {
     public class UpdateStep
     {
         private readonly SchemaUpgradeTransactions _transactions;
+        private short? _lastCommittedTxMarker;
 
         public UpdateStep(SchemaUpgradeTransactions transactions)
         {
@@ -19,9 +22,19 @@ namespace Raven.Server.Storage.Schema
         public DocumentsStorage DocumentsStorage;
         public ClusterStateMachine ClusterStateMachine;
 
-        public void Commit()
+        public void Commit(DocumentsOperationContext txContext)
         {
+            if (txContext != null)
+            {
+                if (txContext.GetTransactionMarker() == _lastCommittedTxMarker)
+                    throw new InvalidOperationException(
+                        $"You're commiting transaction step with the same transaction marker as it was previously committed - {_lastCommittedTxMarker}. Did you forget to set it to write transaction id?");
+            }
+
             _transactions.Commit();
+
+            if (txContext != null)
+                _lastCommittedTxMarker = txContext.GetTransactionMarker();
         }
 
         public void RenewTransactions()

--- a/src/Raven.Server/Storage/Schema/Updates/Documents/42017/From41016.cs
+++ b/src/Raven.Server/Storage/Schema/Updates/Documents/42017/From41016.cs
@@ -151,6 +151,8 @@ namespace Raven.Server.Storage.Schema.Updates.Documents
 
                 using (step.DocumentsStorage.ContextPool.AllocateOperationContext(out DocumentsOperationContext context))
                 {
+                    context.TransactionMarkerOffset = (short)step.WriteTx.LowLevelTransaction.Id;
+
                     var commit = false;
 
                     foreach (var item in GetCounters(readTable, context))
@@ -225,7 +227,7 @@ namespace Raven.Server.Storage.Schema.Updates.Documents
 
                     if (commit)
                     {
-                        step.Commit();
+                        step.Commit(context);
                         step.RenewTransactions();
 
                         step.DocumentsStorage.CountersStorage = new CountersStorage(step.DocumentsStorage.DocumentDatabase, step.WriteTx);

--- a/src/Raven.Server/Storage/Schema/Updates/Documents/50000/From42017.cs
+++ b/src/Raven.Server/Storage/Schema/Updates/Documents/50000/From42017.cs
@@ -85,6 +85,8 @@ namespace Raven.Server.Storage.Schema.Updates.Documents
 
                 using (step.DocumentsStorage.ContextPool.AllocateOperationContext(out DocumentsOperationContext context))
                 {
+                    context.TransactionMarkerOffset = (short)step.WriteTx.LowLevelTransaction.Id;
+
                     var commit = false;
 
                     foreach (var counterGroup in GetCounters(readTable, context, currentPrefix))
@@ -125,7 +127,7 @@ namespace Raven.Server.Storage.Schema.Updates.Documents
 
                     if (commit)
                     {
-                        step.Commit();
+                        step.Commit(context);
                         step.RenewTransactions();
                         currentDocId = null;
                         continue;

--- a/src/Raven.Server/Storage/Schema/Updates/Server/42019/From42018.cs
+++ b/src/Raven.Server/Storage/Schema/Updates/Server/42019/From42018.cs
@@ -91,7 +91,7 @@ namespace Raven.Server.Storage.Schema.Updates.Server
 
                 if (continueAfterCommit)
                 {
-                    step.Commit();
+                    step.Commit(null);
                     step.RenewTransactions();
                 }
             }


### PR DESCRIPTION
…a update. The problem was that we always default to 2 which in turn cause to create huge replication batch.