### PR TITLE
RavenDB-15339 set 15 seconds default timeout

### DIFF
--- a/src/Raven.Client/Documents/Commands/GetRemoteTaskTopologyCommand.cs
+++ b/src/Raven.Client/Documents/Commands/GetRemoteTaskTopologyCommand.cs
@@ -16,6 +16,7 @@ namespace Raven.Client.Documents.Commands
             _remoteDatabase = remoteDatabase ?? throw new ArgumentNullException(nameof(remoteDatabase));
             _databaseGroupId = databaseGroupId ?? throw new ArgumentNullException(nameof(databaseGroupId));
             _remoteTask = remoteTask ?? throw new ArgumentNullException(nameof(remoteTask));
+            Timeout = TimeSpan.FromSeconds(15);
         }
 
         public override HttpRequestMessage CreateRequest(JsonOperationContext ctx, ServerNode node, out string url)

--- a/src/Raven.Client/Documents/Commands/GetTcpInfoForRemoteTaskCommand.cs
+++ b/src/Raven.Client/Documents/Commands/GetTcpInfoForRemoteTaskCommand.cs
@@ -20,6 +20,7 @@ namespace Raven.Client.Documents.Commands
             _remoteTask = remoteTask ?? throw new ArgumentNullException(nameof(remoteTask));
             _tag = tag;
             _verifyDatabase = verifyDatabase;
+            Timeout = TimeSpan.FromSeconds(15);
         }
 
         public override HttpRequestMessage CreateRequest(JsonOperationContext ctx, ServerNode node, out string url)

--- a/src/Raven.Client/ServerWide/Commands/GetDatabaseTopologyCommand.cs
+++ b/src/Raven.Client/ServerWide/Commands/GetDatabaseTopologyCommand.cs
@@ -14,6 +14,7 @@ namespace Raven.Client.ServerWide.Commands
         public GetDatabaseTopologyCommand()
         {
             CanCacheAggressively = false;
+            Timeout = TimeSpan.FromSeconds(15);
         }
 
         public GetDatabaseTopologyCommand(string debugTag, Guid? applicationIdentifier)
@@ -26,6 +27,7 @@ namespace Raven.Client.ServerWide.Commands
         {
             _debugTag = debugTag;
             CanCacheAggressively = false;
+            Timeout = TimeSpan.FromSeconds(15);
         }
 
         public override HttpRequestMessage CreateRequest(JsonOperationContext ctx, ServerNode node, out string url)

--- a/src/Raven.Client/ServerWide/Commands/GetTcpInfoCommand.cs
+++ b/src/Raven.Client/ServerWide/Commands/GetTcpInfoCommand.cs
@@ -1,4 +1,5 @@
-﻿using System.Net.Http;
+﻿using System;
+using System.Net.Http;
 using Raven.Client.Http;
 using Raven.Client.Json.Converters;
 using Sparrow.Json;
@@ -16,6 +17,7 @@ namespace Raven.Client.ServerWide.Commands
         public GetTcpInfoCommand(string tag)
         {
             _tag = tag;
+            Timeout = TimeSpan.FromSeconds(15);
         }
 
         public GetTcpInfoCommand(string tag, string dbName = null) : this(tag)

--- a/src/Raven.Server/Documents/Replication/ReplicationLoader.cs
+++ b/src/Raven.Server/Documents/Replication/ReplicationLoader.cs
@@ -1163,9 +1163,8 @@ namespace Raven.Server.Documents.Replication
         private static readonly string ExternalReplicationTag = "external-replication";
         private TcpConnectionInfo GetExternalReplicationTcpInfo(ExternalReplication exNode, X509Certificate2 certificate, string database)
         {
-            using (var requestExecutor = RequestExecutor.Create(exNode.ConnectionString.TopologyDiscoveryUrls, exNode.ConnectionString.Database, certificate,
-                DocumentConventions.DefaultForServer))
-            using (_server.ContextPool.AllocateOperationContext(out TransactionOperationContext ctx))
+            using (var requestExecutor = RequestExecutor.Create(exNode.ConnectionString.TopologyDiscoveryUrls, exNode.ConnectionString.Database, certificate, DocumentConventions.DefaultForServer))
+            using (Database.DocumentsStorage.ContextPool.AllocateOperationContext(out JsonOperationContext ctx))
             {
                 var cmd = new GetTcpInfoCommand(ExternalReplicationTag, database, Database.DbId.ToString(), Database.ReadLastEtag());
                 try

--- a/test/RachisTests/DatabaseCluster/ReplicationTests.cs
+++ b/test/RachisTests/DatabaseCluster/ReplicationTests.cs
@@ -7,14 +7,15 @@ using System.Threading.Tasks;
 using Esprima.Ast;
 using FastTests.Server.Replication;
 using Raven.Client.Documents;
-using Raven.Client.Documents.Operations.ConnectionStrings;
-using Raven.Client.Documents.Operations.ETL;
+using Raven.Client.Documents.Conventions;
 using Raven.Client.Documents.Operations.OngoingTasks;
 using Raven.Client.Documents.Operations.Replication;
 using Raven.Client.Documents.Session;
 using Raven.Client.Exceptions;
 using Raven.Client.Exceptions.Security;
+using Raven.Client.Http;
 using Raven.Client.ServerWide;
+using Raven.Client.ServerWide.Commands;
 using Raven.Client.ServerWide.Operations;
 using Raven.Client.ServerWide.Operations.Certificates;
 using Raven.Server;
@@ -22,6 +23,7 @@ using Raven.Server.Documents;
 using Raven.Server.Documents.Replication;
 using Raven.Server.ServerWide.Context;
 using Raven.Tests.Core.Utils.Entities;
+using Sparrow.Json;
 using Xunit;
 using Xunit.Abstractions;
 
@@ -888,6 +890,124 @@ namespace RachisTests.DatabaseCluster
                     }
 
                     Assert.True(WaitForDocument(dstStore, "users/2", 30_000));
+                }
+            }
+        }
+
+        [Fact]
+        public async Task GetFirstTopologyShouldTimeout()
+        {
+            var clusterSize = 1;
+            var srcLeader = await CreateRaftClusterAndGetLeader(clusterSize);
+            var dstLeader = await CreateRaftClusterAndGetLeader(clusterSize);
+
+            var dstDB = GetDatabaseName();
+            var srcDB = GetDatabaseName();
+
+            var dstTopology = await CreateDatabaseInCluster(dstDB, clusterSize, dstLeader.WebUrl);
+            var srcTopology = await CreateDatabaseInCluster(srcDB, clusterSize, srcLeader.WebUrl);
+
+            using (var srcStore = new DocumentStore()
+            {
+                Urls = new[] { srcLeader.WebUrl },
+                Database = srcDB,
+            }.Initialize())
+            using (var dstStore = new DocumentStore
+            {
+                Urls = new[] { dstLeader.WebUrl },
+                Database = dstDB,
+            }.Initialize())
+            {
+                
+                dstLeader.ServerStore.InitializationCompleted.Reset(true);
+                dstLeader.ServerStore.Initialized = false;
+
+                try
+                {
+                    var db = await srcLeader.ServerStore.DatabasesLandlord.TryGetOrCreateResourceStore(srcDB);
+                    var ex = await Assert.ThrowsAsync<AggregateException>(async () =>
+                    {
+                        var wait = Task.Delay(TimeSpan.FromSeconds(30));
+                        var exec = Task.Run(() =>
+                        {
+                            using (var requestExecutor = RequestExecutor.Create(new[] {dstLeader.WebUrl}, dstDB, null, DocumentConventions.DefaultForServer))
+                            using (db.DocumentsStorage.ContextPool.AllocateOperationContext(out JsonOperationContext ctx))
+                            {
+                                var cmd = new GetTcpInfoCommand("external-replication", db.Name, db.DbId.ToString(), db.ReadLastEtag());
+                                requestExecutor.Execute(cmd, ctx);
+                            }
+                        });
+
+                        var t = await Task.WhenAny(exec, wait);
+                        await t;
+                    });
+                    Assert.Contains("failed with timeout after 00:00:15", ex.Message);
+                }
+                finally
+                {
+                    dstLeader.ServerStore.Initialized = true;
+                    dstLeader.ServerStore.InitializationCompleted.Set();
+                }
+            }
+        }
+
+        [Fact]
+        public async Task GetTcpInfoShouldTimeout()
+        {
+            var clusterSize = 1;
+            var srcLeader = await CreateRaftClusterAndGetLeader(clusterSize);
+            var dstLeader = await CreateRaftClusterAndGetLeader(clusterSize);
+
+            var dstDB = GetDatabaseName();
+            var srcDB = GetDatabaseName();
+
+            await CreateDatabaseInCluster(dstDB, clusterSize, dstLeader.WebUrl);
+            await CreateDatabaseInCluster(srcDB, clusterSize, srcLeader.WebUrl);
+
+            using (var srcStore = new DocumentStore()
+            {
+                Urls = new[] { srcLeader.WebUrl },
+                Database = srcDB,
+            }.Initialize())
+            using (var dstStore = new DocumentStore
+            {
+                Urls = new[] { dstLeader.WebUrl },
+                Database = dstDB,
+            }.Initialize())
+            {
+                try
+                {
+                    var db = await srcLeader.ServerStore.DatabasesLandlord.TryGetOrCreateResourceStore(srcDB);
+                    var ex = await Assert.ThrowsAsync<RavenException>(async () =>
+                    {
+                        var wait = Task.Delay(TimeSpan.FromSeconds(30));
+                        var exec = Task.Run(() =>
+                        {
+                            using (var requestExecutor = RequestExecutor.Create(new[] {dstLeader.WebUrl}, dstDB, null,
+                                DocumentConventions.DefaultForServer))
+                            using (db.DocumentsStorage.ContextPool.AllocateOperationContext(out JsonOperationContext ctx))
+                            {
+                                var cmd = new GetTcpInfoCommand("external-replication", dstDB, db.DbId.ToString(), db.ReadLastEtag());
+                                requestExecutor.Execute(cmd, ctx);
+
+                                dstLeader.ServerStore.InitializationCompleted.Reset(true);
+                                dstLeader.ServerStore.Initialized = false;
+
+                                cmd = new GetTcpInfoCommand("external-replication", dstDB, db.DbId.ToString(), db.ReadLastEtag());
+                                requestExecutor.Execute(cmd, ctx);
+                            }
+                        });
+
+                        var t = await Task.WhenAny(exec, wait);
+                        await t;
+                    });
+
+                    Assert.Contains("failed with timeout after 00:00:15", ex.Message);
+                }
+                finally
+                {
+                    dstLeader.ServerStore.Initialized = true;
+                    dstLeader.ServerStore.InitializationCompleted.Set();
                 }
             }
         }


### PR DESCRIPTION
- `GetConnectionInfo` for external/pull replication
- Also the call for first topology should timeout