### PR TITLE
RavenDB-15399 Recreating metadata should ignore time-series with 0 entries

### DIFF
--- a/src/Raven.Server/Documents/TimeSeries/TimeSeriesPolicyRunner.cs
+++ b/src/Raven.Server/Documents/TimeSeries/TimeSeriesPolicyRunner.cs
@@ -105,9 +105,9 @@ namespace Raven.Server.Documents.TimeSeries
             {
                 await WaitOrThrowOperationCanceled(_checkFrequency);
 
-                await RunRollups();
+                await RunRollups(propagateException: false);
 
-                await DoRetention();
+                await DoRetention(propagateException: false);
             }
         }
 
@@ -267,7 +267,7 @@ namespace Raven.Server.Documents.TimeSeries
             }
         }
 
-        internal async Task RunRollups()
+        internal async Task RunRollups(bool propagateException = true)
         {
             var now = _database.Time.GetUtcNow();
             try
@@ -314,10 +314,14 @@ namespace Raven.Server.Documents.TimeSeries
             {
                 if (Logger.IsOperationsEnabled)
                     Logger.Operations($"Failed to roll-up time series for '{_database.Name}' which are older than {now}", e);
+
+                if (propagateException)
+                    throw;
+
             }
         }
 
-        internal async Task DoRetention()
+        internal async Task DoRetention(bool propagateException = true)
         {
             var topology = _database.ServerStore.LoadDatabaseTopology(_database.Name);
             var isFirstInTopology = string.Equals(topology.Members.FirstOrDefault(), _database.ServerStore.NodeTag, StringComparison.OrdinalIgnoreCase);
@@ -362,6 +366,9 @@ namespace Raven.Server.Documents.TimeSeries
             {
                 if (Logger.IsOperationsEnabled)
                     Logger.Operations($"Failed to execute time series retention for database '{_database.Name}'", e);
+
+                if (propagateException)
+                    throw;
             }
         }
 

--- a/src/Raven.Server/Documents/TimeSeries/TimeSeriesStats.cs
+++ b/src/Raven.Server/Documents/TimeSeries/TimeSeriesStats.cs
@@ -323,7 +323,11 @@ namespace Raven.Server.Documents.TimeSeries
             {
                 foreach (var result in table.SeekByPrimaryKeyPrefix(documentKeyPrefix, Slices.Empty, 0))
                 {
-                    yield return DocumentsStorage.TableValueToChangeVector(context, (int)StatsColumns.Name, ref result.Value.Reader);
+                    var name = DocumentsStorage.TableValueToChangeVector(context, (int)StatsColumns.Name, ref result.Value.Reader);
+                    if (GetStats(context, docId, name).Count == 0)
+                        continue;
+
+                    yield return name;
                 }
             }
         }

--- a/src/Raven.Server/Documents/TimeSeries/TimeSeriesStorage.cs
+++ b/src/Raven.Server/Documents/TimeSeries/TimeSeriesStorage.cs
@@ -1493,70 +1493,42 @@ namespace Raven.Server.Documents.TimeSeries
             if (doc == null)
                 return;
 
-            try
-            {
-                newName = GetOriginalName(ctx, docId, newName);
-            }
-            catch (Exception e)
-            {
-                var error = $"Unable to locate the original time-series '{newName}' in document '{docId}'";
-                if (_logger.IsInfoEnabled)
-                    _logger.Info(error, e);
-            }
+            newName = GetOriginalName(ctx, docId, newName);
 
             var data = doc.Data;
-            BlittableJsonReaderArray tsNames = null;
-            if (doc.TryGetMetadata(out var metadata))
-            {
-                metadata.TryGet(Constants.Documents.Metadata.TimeSeries, out tsNames);
-            }
+            if (doc.TryGetMetadata(out var metadata) == false)
+                return;
+
+            if (metadata.TryGet(Constants.Documents.Metadata.TimeSeries, out BlittableJsonReaderArray tsNames) == false)
+                return;
 
             if (tsNames == null)
+                return;
+
+            if (tsNames.BinarySearch(newName, StringComparison.OrdinalIgnoreCase) < 0)
+                return;
+
+            var tsNamesList = new List<string>(tsNames.Length + 1);
+            for (var i = 0; i < tsNames.Length; i++)
             {
-                // shouldn't happen
-
-                if (metadata == null)
-                {
-                    data.Modifications = new DynamicJsonValue(data)
-                    {
-                        [Constants.Documents.Metadata.Key] = new DynamicJsonValue
-                        {
-                            [Constants.Documents.Metadata.TimeSeries] = new[] { newName }
-                        }
-                    };
-                }
-                else
-                {
-                    metadata.Modifications = new DynamicJsonValue(metadata)
-                    {
-                        [Constants.Documents.Metadata.TimeSeries] = new[] { newName }
-                    };
-                }
+                var val = tsNames.GetStringByIndex(i);
+                if (val == null)
+                    continue;
+                tsNamesList.Add(val);
             }
-            else
+
+            var location = tsNames.BinarySearch(newName, StringComparison.Ordinal);
+            if (location < 0)
             {
-                var tsNamesList = new List<string>(tsNames.Length + 1);
-                for (var i = 0; i < tsNames.Length; i++)
-                {
-                    var val = tsNames.GetStringByIndex(i);
-                    if (val == null)
-                        continue;
-                    tsNamesList.Add(val);
-                }
-
-                var location = tsNames.BinarySearch(newName, StringComparison.Ordinal);
-                if (location < 0)
-                {
-                    tsNamesList.Insert(~location, newName);
-                }
-
-                tsNamesList.Remove(oldName);
-
-                metadata.Modifications = new DynamicJsonValue(metadata)
-                {
-                    [Constants.Documents.Metadata.TimeSeries] = tsNamesList
-                };
+                tsNamesList.Insert(~location, newName);
             }
+
+            tsNamesList.Remove(oldName);
+
+            metadata.Modifications = new DynamicJsonValue(metadata)
+            {
+                [Constants.Documents.Metadata.TimeSeries] = tsNamesList
+            };
 
             var flags = doc.Flags.Strip(DocumentFlags.FromClusterTransaction | DocumentFlags.Resolved);
             flags |= DocumentFlags.HasTimeSeries;
@@ -1580,16 +1552,7 @@ namespace Raven.Server.Documents.TimeSeries
             if (doc == null)
                 return;
 
-            try
-            {
-                tsName = GetOriginalName(ctx, docId, tsName);
-            }
-            catch (Exception e)
-            {
-                var error = $"Unable to locate the original time-series '{tsName}' in document '{docId}'";
-                if (_logger.IsInfoEnabled)
-                    _logger.Info(error, e);
-            }
+            tsName = GetOriginalName(ctx, docId, tsName);
 
             var data = doc.Data;
             BlittableJsonReaderArray tsNames = null;
@@ -1651,11 +1614,27 @@ namespace Raven.Server.Documents.TimeSeries
             }
         }
 
-        public string GetOriginalName(DocumentsOperationContext context, string docId, string lowerName)
+        public string GetOriginalName(DocumentsOperationContext ctx, string docId, string tsName)
+        {
+            try
+            {
+                return GetOriginalNameInternal(ctx, docId, tsName);
+            }
+            catch (Exception e)
+            {
+                var error = $"Unable to locate the original time-series '{tsName}' of document '{docId}'";
+                if (_logger.IsInfoEnabled)
+                    _logger.Info(error, e);
+            }
+
+            return tsName;
+        }
+
+        private string GetOriginalNameInternal(DocumentsOperationContext context, string docId, string lowerName)
         {
             var name = Stats.GetTimeSeriesNameOriginalCasing(context, docId, lowerName);
             if (name == null)
-                throw new InvalidOperationException($"Can't find the time-series '{lowerName}' in document '{docId}'");
+                throw new InvalidOperationException($"Can't find the time-series '{lowerName}' of document '{docId}'");
 
             return name;
         }

--- a/src/Raven.Server/Smuggler/Documents/DatabaseSource.cs
+++ b/src/Raven.Server/Smuggler/Documents/DatabaseSource.cs
@@ -473,7 +473,7 @@ namespace Raven.Server.Smuggler.Documents
                     {
                         yield return new TimeSeriesItem
                         {
-                            Name =  GetOriginalName(_context, ts.DocId, ts.Name),
+                            Name =  _database.DocumentsStorage.TimeSeriesStorage.GetOriginalName(_context, ts.DocId, ts.Name),
                             DocId = ts.DocId,
                             Baseline = ts.Start,
                             ChangeVector = ts.ChangeVector,
@@ -492,7 +492,7 @@ namespace Raven.Server.Smuggler.Documents
             {
                 yield return new TimeSeriesItem
                 {
-                    Name = GetOriginalName(_context, ts.DocId, ts.Name),
+                    Name = _database.DocumentsStorage.TimeSeriesStorage.GetOriginalName(_context, ts.DocId, ts.Name),
                     DocId = ts.DocId,
                     Baseline = ts.Start,
                     ChangeVector = ts.ChangeVector,
@@ -502,22 +502,6 @@ namespace Raven.Server.Smuggler.Documents
                     Etag = ts.Etag
                 };
             }
-        }
-
-        public string GetOriginalName(DocumentsOperationContext context, string docId, string name)
-        {
-            try
-            {
-                return _database.DocumentsStorage.TimeSeriesStorage.GetOriginalName(context, docId, name);
-            }
-            catch (Exception e)
-            {
-                var error = $"An error occured during finding the original time-series '{name}' in document '{docId}'";
-                if (_logger.IsInfoEnabled)
-                    _logger.Info(error, e);
-            }
-
-            return name;
         }
 
         public long SkipType(DatabaseItemType type, Action<long> onSkipped, CancellationToken token)


### PR DESCRIPTION
The method `GetOriginalName` will not throw, so rollups/indexes/replication will can continue to work.
In worst case we will get the lowered name.
