### PR TITLE
RavenDB-14784 added the ability to load attachment

### DIFF
--- a/src/Raven.Client/Documents/Indexes/AbstractIndexCreationTask.cs
+++ b/src/Raven.Client/Documents/Indexes/AbstractIndexCreationTask.cs
@@ -52,6 +52,14 @@ namespace Raven.Client.Documents.Indexes
         }
 
         /// <summary>
+        /// Allows to retrieve attachment of the document
+        /// </summary>
+        public IAttachmentObject LoadAttachment(object doc, string name)
+        {
+            throw new NotSupportedException("This is here as a marker only");
+        }
+
+        /// <summary>
         /// Allow to access an entity as a document
         /// </summary>
         protected IJsonObject AsJson(object doc)

--- a/src/Raven.Client/Documents/Indexes/AbstractIndexCreationTask.cs
+++ b/src/Raven.Client/Documents/Indexes/AbstractIndexCreationTask.cs
@@ -60,6 +60,14 @@ namespace Raven.Client.Documents.Indexes
         }
 
         /// <summary>
+        /// Allows to retrieve attachments of the document
+        /// </summary>
+        public IEnumerable<IAttachmentObject> LoadAttachments(object doc)
+        {
+            throw new NotSupportedException("This is here as a marker only");
+        }
+
+        /// <summary>
         /// Allow to access an entity as a document
         /// </summary>
         protected IJsonObject AsJson(object doc)

--- a/src/Raven.Client/Documents/Indexes/IAttachmentObject.cs
+++ b/src/Raven.Client/Documents/Indexes/IAttachmentObject.cs
@@ -1,0 +1,19 @@
+﻿using System.Text;
+
+namespace Raven.Client.Documents.Indexes
+{
+    public interface IAttachmentObject
+    {
+        public string Name { get; }
+
+        public string Hash { get; }
+
+        public string ContentType { get; }
+
+        public long Size { get; }
+
+        public string GetContentAsString();
+
+        public string GetContentAsString(Encoding encoding);
+    }
+}

--- a/src/Raven.Client/Documents/Indexes/IAttachmentObject.cs
+++ b/src/Raven.Client/Documents/Indexes/IAttachmentObject.cs
@@ -1,4 +1,5 @@
-﻿using System.Text;
+﻿using System.IO;
+using System.Text;
 
 namespace Raven.Client.Documents.Indexes
 {
@@ -15,5 +16,7 @@ namespace Raven.Client.Documents.Indexes
         public string GetContentAsString();
 
         public string GetContentAsString(Encoding encoding);
+
+        public Stream GetContentAsStream();
     }
 }

--- a/src/Raven.Client/Documents/Indexes/IndexingOperation.cs
+++ b/src/Raven.Client/Documents/Indexes/IndexingOperation.cs
@@ -10,6 +10,8 @@ namespace Raven.Client.Documents.Indexes
     {
         public const string LoadDocument = nameof(AbstractIndexCreationTask.LoadDocument);
 
+        public const string LoadAttachment = nameof(AbstractIndexCreationTask.LoadAttachment);
+
         public const string LoadCompareExchangeValue = nameof(AbstractIndexCreationTask.LoadCompareExchangeValue);
 
         internal static class Map

--- a/src/Raven.Server/Documents/AttachmentsStorage.cs
+++ b/src/Raven.Server/Documents/AttachmentsStorage.cs
@@ -608,6 +608,7 @@ namespace Raven.Server.Documents
             if (stream == null)
                 throw new FileNotFoundException($"Attachment's stream {name} on {documentId} was not found. This should not happen and is likely a bug.");
             attachment.Stream = stream;
+            attachment.Size = stream.Length;
 
             return attachment;
         }

--- a/src/Raven.Server/Documents/Indexes/Static/CurrentIndexingScope.cs
+++ b/src/Raven.Server/Documents/Indexes/Static/CurrentIndexingScope.cs
@@ -109,24 +109,29 @@ namespace Raven.Server.Documents.Indexes.Static
             }
         }
 
-        public unsafe dynamic LoadAttachment(DynamicBlittableJson document, string attachmentName)
+        public unsafe dynamic LoadAttachment(string documentId, string attachmentName)
         {
             using (_loadAttachmentStats?.Start() ?? (_loadAttachmentStats = _stats?.For(IndexingOperation.LoadAttachment)))
             {
-                if (document == null)
-                    return DynamicNullObject.Null;
-
-                var id = GetSourceId(document);
-
                 if (attachmentName == null)
                     return DynamicNullObject.Null;
 
-                var attachment = _documentsStorage.AttachmentsStorage.GetAttachment(QueryContext.Documents, id, attachmentName, AttachmentType.Document, null);
+                var attachment = _documentsStorage.AttachmentsStorage.GetAttachment(QueryContext.Documents, documentId, attachmentName, AttachmentType.Document, null);
                 if (attachment == null)
                     return DynamicNullObject.Null;
 
                 return new DynamicAttachment(attachment);
             }
+        }
+
+        public unsafe dynamic LoadAttachment(DynamicBlittableJson document, string attachmentName)
+        {
+            if (document == null)
+                return DynamicNullObject.Null;
+
+            var id = GetSourceId(document);
+
+            return LoadAttachment(id, attachmentName);
         }
 
         public unsafe dynamic LoadDocument(LazyStringValue keyLazy, string keyString, string collectionName)

--- a/src/Raven.Server/Documents/Indexes/Static/DynamicAttachment.cs
+++ b/src/Raven.Server/Documents/Indexes/Static/DynamicAttachment.cs
@@ -72,11 +72,20 @@ namespace Raven.Server.Documents.Indexes.Static
         {
             if (_contentAsString == null)
             {
+                _attachment.Stream.Position = 0;
+
                 using (var sr = new StreamReader(_attachment.Stream, encoding))
                     _contentAsString = sr.ReadToEnd();
             }
 
             return _contentAsString;
+        }
+
+        public Stream GetContentAsStream()
+        {
+            _attachment.Stream.Position = 0;
+
+            return _attachment.Stream;
         }
 
         protected override bool TryGetByName(string name, out object result)

--- a/src/Raven.Server/Documents/Indexes/Static/DynamicAttachment.cs
+++ b/src/Raven.Server/Documents/Indexes/Static/DynamicAttachment.cs
@@ -1,0 +1,88 @@
+﻿using System;
+using System.IO;
+using System.Text;
+using Raven.Client.Documents.Indexes;
+
+namespace Raven.Server.Documents.Indexes.Static
+{
+    public class DynamicAttachment : AbstractDynamicObject, IAttachmentObject
+    {
+        private readonly Attachment _attachment;
+
+        private string _hash;
+
+        private string _contentAsString;
+
+        public DynamicAttachment(Attachment attachment)
+        {
+            _attachment = attachment ?? throw new ArgumentNullException(nameof(attachment));
+        }
+
+        public override dynamic GetId()
+        {
+            throw new NotSupportedException();
+        }
+
+        public override bool Set(object item)
+        {
+            throw new NotSupportedException();
+        }
+
+        public string Name
+        {
+            get
+            {
+                return _attachment.Name;
+            }
+        }
+
+        public string ContentType
+        {
+            get
+            {
+                return _attachment.ContentType;
+            }
+        }
+
+        public string Hash
+        {
+            get
+            {
+                if (_hash == null)
+                    _hash = _attachment.Base64Hash.ToString();
+
+                return _hash;
+            }
+        }
+
+        public long Size
+        {
+            get
+            {
+                return _attachment.Size;
+            }
+        }
+
+        public string GetContentAsString()
+        {
+            return GetContentAsString(Encoding.UTF8);
+        }
+
+        public string GetContentAsString(Encoding encoding)
+        {
+            if (_contentAsString == null)
+            {
+                using (var sr = new StreamReader(_attachment.Stream, encoding))
+                    _contentAsString = sr.ReadToEnd();
+            }
+
+            return _contentAsString;
+        }
+
+        protected override bool TryGetByName(string name, out object result)
+        {
+            result = DynamicNullObject.Null;
+            return true;
+        }
+    }
+}

--- a/src/Raven.Server/Documents/Indexes/Static/IndexCompiler.cs
+++ b/src/Raven.Server/Documents/Indexes/Static/IndexCompiler.cs
@@ -84,6 +84,7 @@ namespace Raven.Server.Documents.Indexes.Static
             SyntaxFactory.UsingDirective(SyntaxFactory.IdentifierName("System.Collections.Generic")),
             SyntaxFactory.UsingDirective(SyntaxFactory.IdentifierName("System.Globalization")),
             SyntaxFactory.UsingDirective(SyntaxFactory.IdentifierName("System.Linq")),
+            SyntaxFactory.UsingDirective(SyntaxFactory.IdentifierName("System.Text")),
             SyntaxFactory.UsingDirective(SyntaxFactory.IdentifierName("System.Text.RegularExpressions")),
 
             SyntaxFactory.UsingDirective(SyntaxFactory.IdentifierName("Lucene.Net.Documents")),

--- a/src/Raven.Server/Documents/Indexes/Static/JavaScriptIndex.cs
+++ b/src/Raven.Server/Documents/Indexes/Static/JavaScriptIndex.cs
@@ -48,7 +48,9 @@ function map(name, lambda) {
             engine.SetValue("getMetadata", new ClrFunctionInstance(_engine, "getMetadata", MetadataFor));
             engine.SetValue("metadataFor", new ClrFunctionInstance(_engine, "metadataFor", MetadataFor));
             engine.SetValue("timeSeriesNamesFor", new ClrFunctionInstance(_engine, "timeSeriesNamesFor", TimeSeriesNamesFor));
-            engine.SetValue("counterNamesFor", new ClrFunctionInstance(_engine, "counterNamesFor", TimeSeriesNamesFor));
+            engine.SetValue("counterNamesFor", new ClrFunctionInstance(_engine, "counterNamesFor", CounterNamesFor));
+            engine.SetValue("loadAttachment", new ClrFunctionInstance(engine, "loadAttachment", LoadAttachment));
+            engine.SetValue("loadAttachments", new ClrFunctionInstance(engine, "loadAttachment", LoadAttachments));
             engine.SetValue("id", new ClrFunctionInstance(_engine, "id", GetDocumentId));
         }
 
@@ -153,6 +155,22 @@ function map(name, lambda) {
 
             return _javaScriptUtils.GetCounterNamesFor(self, args);
         }
+
+        private JsValue LoadAttachment(JsValue self, JsValue[] args)
+        {
+            var scope = CurrentIndexingScope.Current;
+            scope.RegisterJavaScriptUtils(_javaScriptUtils);
+
+            return _javaScriptUtils.LoadAttachment(self, args);
+        }
+
+        private JsValue LoadAttachments(JsValue self, JsValue[] args)
+        {
+            var scope = CurrentIndexingScope.Current;
+            scope.RegisterJavaScriptUtils(_javaScriptUtils);
+
+            return _javaScriptUtils.LoadAttachments(self, args);
+        }
     }
 
     public abstract class AbstractJavaScriptIndex : AbstractStaticIndexBase
@@ -214,7 +232,8 @@ function map(name, lambda) {
             if (Definition.Maps == null || Definition.Maps.Count == 0)
                 ThrowIndexCreationException("does not contain any mapping functions to process.");
 
-            var mappingFunctions = Definition.Maps.ToList();;
+            var mappingFunctions = Definition.Maps.ToList();
+            ;
             modifyMappingFunctions?.Invoke(mappingFunctions);
 
             return mappingFunctions;

--- a/src/Raven.Server/Documents/Indexes/Static/StaticIndexBase.cs
+++ b/src/Raven.Server/Documents/Indexes/Static/StaticIndexBase.cs
@@ -250,6 +250,21 @@ namespace Raven.Server.Documents.Indexes.Static
             }
         }
 
+        public dynamic LoadAttachments(dynamic doc)
+        {
+            if (CurrentIndexingScope.Current == null)
+                throw new InvalidOperationException($"Indexing scope was not initialized.");
+
+            if (doc is DynamicNullObject)
+                return DynamicNullObject.Null;
+
+            var document = doc as DynamicBlittableJson;
+            if (document == null)
+                throw new InvalidOperationException($"{nameof(LoadAttachments)} may only be called with a non-null entity as a parameter, but was called with a parameter of type {doc.GetType().FullName}: {doc}");
+
+            return CurrentIndexingScope.Current.LoadAttachments(document);
+        }
+
         public dynamic LoadAttachment(dynamic doc, object attachmentName)
         {
             if (CurrentIndexingScope.Current == null)

--- a/src/Raven.Server/Documents/Indexes/Static/StaticIndexBase.cs
+++ b/src/Raven.Server/Documents/Indexes/Static/StaticIndexBase.cs
@@ -250,6 +250,30 @@ namespace Raven.Server.Documents.Indexes.Static
             }
         }
 
+        public dynamic LoadAttachment(dynamic doc, object attachmentName)
+        {
+            if (CurrentIndexingScope.Current == null)
+                throw new InvalidOperationException($"Indexing scope was not initialized. Attachment Name: {attachmentName}");
+
+            if (doc is DynamicNullObject)
+                return DynamicNullObject.Null;
+
+            var document = doc as DynamicBlittableJson;
+            if (document == null)
+                throw new InvalidOperationException($"{nameof(LoadAttachment)} may only be called with a non-null entity as a first parameter, but was called with a parameter of type {doc.GetType().FullName}: {doc}");
+
+            if (attachmentName is LazyStringValue attachmentNameLazy)
+                return CurrentIndexingScope.Current.LoadAttachment(document, attachmentNameLazy);
+
+            if (attachmentName is string attachmentNameString)
+                return CurrentIndexingScope.Current.LoadAttachment(document, attachmentNameString);
+
+            if (attachmentName is DynamicNullObject)
+                return DynamicNullObject.Null;
+
+            throw new InvalidOperationException($"{nameof(LoadAttachment)} may only be called with a string, but was called with a parameter of type {attachmentName.GetType().FullName}: {attachmentName}");
+        }
+
         public dynamic LoadDocument<TIgnored>(object keyOrEnumerable, string collectionName)
         {
             return LoadDocument(keyOrEnumerable, collectionName);

--- a/src/Raven.Server/Documents/Patch/AttachmentObjectInstance.cs
+++ b/src/Raven.Server/Documents/Patch/AttachmentObjectInstance.cs
@@ -1,0 +1,147 @@
+﻿using System;
+using System.Collections.Generic;
+using System.Text;
+using Jint;
+using Jint.Native;
+using Jint.Native.Object;
+using Jint.Runtime;
+using Jint.Runtime.Descriptors;
+using Jint.Runtime.Interop;
+using Raven.Client.Documents.Indexes;
+using Raven.Server.Documents.Indexes.Static;
+
+namespace Raven.Server.Documents.Patch
+{
+    public class AttachmentObjectInstance : ObjectInstance
+    {
+        private const string GetContentAsStringMethodName = "getContentAsString";
+
+        private static PropertyDescriptor ImplicitNull = new PropertyDescriptor(DynamicJsNull.ImplicitNull, writable: false, enumerable: false, configurable: false);
+
+        private readonly Dictionary<JsValue, PropertyDescriptor> _properties = new Dictionary<JsValue, PropertyDescriptor>();
+
+        private readonly DynamicAttachment _attachment;
+
+        public AttachmentObjectInstance(Engine engine, DynamicAttachment attachment) : base(engine)
+        {
+            _attachment = attachment ?? throw new ArgumentNullException(nameof(attachment));
+
+            SetPrototypeOf(engine.Object.PrototypeObject);
+        }
+
+        private JsValue GetContentAsString(JsValue self, JsValue[] args)
+        {
+            var encoding = Encoding.UTF8;
+            if (args.Length > 0)
+            {
+                if (args[0].IsString() == false)
+                    throw new InvalidOperationException($"Encoding parameter must be of type string and convertible to one of the .NET supported encodings, but was '{args[0]}'.");
+
+                var encodingAsString = args[0].AsString();
+                if (string.Equals(encodingAsString, nameof(Encoding.UTF8), StringComparison.OrdinalIgnoreCase))
+                    encoding = Encoding.UTF8;
+                else if (string.Equals(encodingAsString, nameof(Encoding.Default), StringComparison.OrdinalIgnoreCase))
+                    encoding = Encoding.Default;
+                else if (string.Equals(encodingAsString, nameof(Encoding.ASCII), StringComparison.OrdinalIgnoreCase))
+                    encoding = Encoding.ASCII;
+                else if (string.Equals(encodingAsString, nameof(Encoding.BigEndianUnicode), StringComparison.OrdinalIgnoreCase))
+                    encoding = Encoding.BigEndianUnicode;
+                else if (string.Equals(encodingAsString, nameof(Encoding.Unicode), StringComparison.OrdinalIgnoreCase))
+                    encoding = Encoding.Unicode;
+                else if (string.Equals(encodingAsString, nameof(Encoding.UTF32), StringComparison.OrdinalIgnoreCase))
+                    encoding = Encoding.UTF32;
+                else if (string.Equals(encodingAsString, nameof(Encoding.UTF7), StringComparison.OrdinalIgnoreCase))
+                    encoding = Encoding.UTF7;
+                else
+                    throw new InvalidOperationException($"Encoding parameter must be of type string and convertible to one of the .NET supported encodings, but was '{encodingAsString}'.");
+            }
+
+            return new JsString(_attachment.GetContentAsString(encoding));
+        }
+
+        public override bool DefineOwnProperty(JsValue property, PropertyDescriptor desc)
+        {
+            throw new NotSupportedException();
+        }
+
+        public override bool Delete(JsValue property)
+        {
+            throw new NotSupportedException();
+        }
+
+        public override IEnumerable<KeyValuePair<JsValue, PropertyDescriptor>> GetOwnProperties()
+        {
+            throw new NotSupportedException();
+        }
+
+        public override PropertyDescriptor GetOwnProperty(JsValue property)
+        {
+            if (_properties.TryGetValue(property, out var value) == false)
+            {
+                if (property == nameof(IAttachmentObject.Name))
+                    value = new PropertyDescriptor(new JsString(_attachment.Name), writable: false, enumerable: false, configurable: false);
+                else if (property == nameof(IAttachmentObject.ContentType))
+                    value = new PropertyDescriptor(new JsString(_attachment.ContentType), writable: false, enumerable: false, configurable: false);
+                else if (property == nameof(IAttachmentObject.Hash))
+                    value = new PropertyDescriptor(new JsString(_attachment.Hash), writable: false, enumerable: false, configurable: false);
+                else if (property == nameof(IAttachmentObject.Size))
+                    value = new PropertyDescriptor(_attachment.Size, writable: false, enumerable: false, configurable: false);
+                else if (property == GetContentAsStringMethodName)
+                    value = new PropertyDescriptor(new ClrFunctionInstance(Engine, GetContentAsStringMethodName, GetContentAsString), writable: false, enumerable: false, configurable: false);
+
+                if (value != null)
+                    _properties[property] = value;
+            }
+
+            if (value == null)
+                value = ImplicitNull;
+
+            return value;
+        }
+
+        public override List<JsValue> GetOwnPropertyKeys(Types types = Types.String | Types.Symbol)
+        {
+            throw new NotSupportedException();
+        }
+
+        public override bool HasOwnProperty(JsValue property)
+        {
+            throw new NotSupportedException();
+        }
+
+        public override bool HasProperty(JsValue property)
+        {
+            throw new NotSupportedException();
+        }
+
+        public override JsValue PreventExtensions()
+        {
+            throw new NotSupportedException();
+        }
+
+        public override void RemoveOwnProperty(JsValue property)
+        {
+            throw new NotSupportedException();
+        }
+
+        public override bool Set(JsValue property, JsValue value, JsValue receiver)
+        {
+            throw new NotSupportedException();
+        }
+
+        protected override void AddProperty(JsValue property, PropertyDescriptor descriptor)
+        {
+            throw new NotSupportedException();
+        }
+
+        protected override void SetOwnProperty(JsValue property, PropertyDescriptor desc)
+        {
+            throw new NotSupportedException();
+        }
+
+        protected override bool TryGetProperty(JsValue property, out PropertyDescriptor descriptor)
+        {
+            throw new NotSupportedException();
+        }
+    }
+}

--- a/src/Raven.Server/Documents/Patch/ScriptRunner.cs
+++ b/src/Raven.Server/Documents/Patch/ScriptRunner.cs
@@ -230,6 +230,7 @@ namespace Raven.Server.Documents.Patch
 
                 ScriptEngine.SetValue("load", new ClrFunctionInstance(ScriptEngine, "load", LoadDocument));
                 ScriptEngine.SetValue("LoadDocument", new ClrFunctionInstance(ScriptEngine, "LoadDocument", ThrowOnLoadDocument));
+
                 ScriptEngine.SetValue("loadPath", new ClrFunctionInstance(ScriptEngine, "loadPath", LoadDocumentByPath));
                 ScriptEngine.SetValue("del", new ClrFunctionInstance(ScriptEngine, "del", DeleteDocument));
                 ScriptEngine.SetValue("DeleteDocument", new ClrFunctionInstance(ScriptEngine, "DeleteDocument", ThrowOnDeleteDocument));
@@ -436,8 +437,8 @@ namespace Raven.Server.Documents.Patch
                         CollectionName.GetCollectionName(doc),
                         timeSeries,
                         new[] { toAppend });
-                    
-                    if (DebugMode) 
+
+                    if (DebugMode)
                     {
                         DebugActions.AppendTimeSeries.Add(new DynamicJsonValue
                         {
@@ -494,7 +495,7 @@ namespace Raven.Server.Documents.Patch
                 };
                 _database.DocumentsStorage.TimeSeriesStorage.DeleteTimestampRange(_docsCtx, deletionRangeRequest);
 
-                if (DebugMode) 
+                if (DebugMode)
                 {
                     DebugActions.DeleteTimeSeries.Add(new DynamicJsonValue
                     {
@@ -553,8 +554,8 @@ namespace Raven.Server.Documents.Patch
                     entry.Set(nameof(TimeSeriesEntry.Values), jsValues);
                     entry.Set(nameof(TimeSeriesEntry.IsRollup), singleResult.Type == SingleResultType.RolledUp);
                     entries.Add(entry);
-                    
-                    if (DebugMode) 
+
+                    if (DebugMode)
                     {
                         DebugActions.GetTimeSeries.Add(new DynamicJsonValue
                         {
@@ -567,8 +568,8 @@ namespace Raven.Server.Documents.Patch
                         });
                     }
                 }
-               
-                if (DebugMode && entries.Count == 0) 
+
+                if (DebugMode && entries.Count == 0)
                 {
                     DebugActions.GetTimeSeries.Add(new DynamicJsonValue
                     {
@@ -576,7 +577,7 @@ namespace Raven.Server.Documents.Patch
                         ["Exists"] = false
                     });
                 }
-                
+
                 return ScriptEngine.Array.Construct(entries.ToArray());
             }
 
@@ -1076,7 +1077,7 @@ namespace Raven.Server.Documents.Patch
                 if (raw == false)
                 {
                     var counterValue = _database.DocumentsStorage.CountersStorage.GetCounterValue(_docsCtx, id, name)?.Value ?? JsValue.Null;
-                  
+
                     if (DebugMode)
                     {
                         DebugActions.GetCounter.Add(new DynamicJsonValue
@@ -1086,7 +1087,7 @@ namespace Raven.Server.Documents.Patch
                             ["Exists"] = counterValue != JsValue.Null
                         });
                     }
-                    
+
                     return counterValue;
                 }
 
@@ -1172,11 +1173,11 @@ namespace Raven.Server.Documents.Patch
 
                     DocumentCountersToUpdate[id] = tuple;
                 }
-                
+
                 if (DebugMode)
                 {
                     var newValue = _database.DocumentsStorage.CountersStorage.GetCounterValue(_docsCtx, id, name)?.Value;
-                    
+
                     DebugActions.IncrementCounter.Add(new DynamicJsonValue
                     {
                         ["Name"] = name,
@@ -1248,7 +1249,7 @@ namespace Raven.Server.Documents.Patch
                 {
                     DebugActions.DeleteCounter.Add(name);
                 }
-                
+
                 return JsBoolean.True;
             }
 
@@ -1683,7 +1684,7 @@ namespace Raven.Server.Documents.Patch
                         ["Exists"] = document != null
                     });
                 }
-                
+
                 return JavaScriptUtils.TranslateToJs(ScriptEngine, _jsonCtx, document);
             }
 

--- a/test/SlowTests/Client/Indexing/Counters/BasicCountersIndexes_JavaScript.cs
+++ b/test/SlowTests/Client/Indexing/Counters/BasicCountersIndexes_JavaScript.cs
@@ -1,5 +1,4 @@
-﻿using System;
-using System.Collections.Generic;
+﻿using System.Collections.Generic;
 using System.Linq;
 using System.Threading.Tasks;
 using FastTests;
@@ -1210,8 +1209,6 @@ return ({
         [Fact]
         public void CounterNamesFor()
         {
-            var now = DateTime.UtcNow.Date;
-
             using (var store = GetDocumentStore())
             {
                 var index = new Companies_ByCounterNames();
@@ -1239,8 +1236,8 @@ return ({
                 {
                     var company = session.Load<Company>("companies/1");
 
-                    session.TimeSeriesFor(company, "HeartRate").Append(now, new[] { 2.5d }, "tag1");
-                    session.TimeSeriesFor(company, "HeartRate2").Append(now, new[] { 3.5d }, "tag2");
+                    session.CountersFor(company).Increment("HeartRate", 3);
+                    session.CountersFor(company).Increment("HeartRate2", 7);
 
                     session.SaveChanges();
                 }

--- a/test/SlowTests/Issues/RavenDB_14784.cs
+++ b/test/SlowTests/Issues/RavenDB_14784.cs
@@ -33,6 +33,8 @@ namespace SlowTests.Issues
                 public long AttachmentSize { get; set; }
 
                 public string AttachmentContent { get; set; }
+
+                public Stream AttachmentContentStream { get; set; }
             }
 
             public Companies_With_Attachments()
@@ -46,8 +48,11 @@ namespace SlowTests.Issues
                                        AttachmentContentType = attachment.ContentType,
                                        AttachmentHash = attachment.Hash,
                                        AttachmentSize = attachment.Size,
-                                       AttachmentContent = attachment.GetContentAsString(Encoding.UTF8)
+                                       AttachmentContent = attachment.GetContentAsString(Encoding.UTF8),
+                                       AttachmentContentStream = attachment.GetContentAsStream()
                                    };
+
+                Store(nameof(Result.AttachmentContentStream), FieldStorage.Yes);
             }
         }
 
@@ -137,6 +142,9 @@ namespace SlowTests.Issues
                 terms = store.Maintenance.Send(new GetTermsOperation(index.IndexName, nameof(Companies_With_Attachments.Result.AttachmentContent), fromValue: null));
                 Assert.Equal(0, terms.Length);
 
+                terms = store.Maintenance.Send(new GetTermsOperation(index.IndexName, nameof(Companies_With_Attachments.Result.AttachmentContentStream), fromValue: null));
+                Assert.Equal(0, terms.Length);
+
                 store.Maintenance.Send(new StopIndexingOperation());
 
                 using (var session = store.OpenSession())
@@ -179,6 +187,9 @@ namespace SlowTests.Issues
                 terms = store.Maintenance.Send(new GetTermsOperation(index.IndexName, nameof(Companies_With_Attachments.Result.AttachmentContent), fromValue: null));
                 Assert.Equal(1, terms.Length);
                 Assert.Contains("<hello_world>", terms);
+
+                terms = store.Maintenance.Send(new GetTermsOperation(index.IndexName, nameof(Companies_With_Attachments.Result.AttachmentContentStream), fromValue: null));
+                Assert.Equal(0, terms.Length);
 
                 store.Maintenance.Send(new StopIndexingOperation());
 
@@ -223,6 +234,9 @@ namespace SlowTests.Issues
                 Assert.Equal(1, terms.Length);
                 Assert.Contains("<hello_cosmos>", terms);
 
+                terms = store.Maintenance.Send(new GetTermsOperation(index.IndexName, nameof(Companies_With_Attachments.Result.AttachmentContentStream), fromValue: null));
+                Assert.Equal(0, terms.Length);
+
                 // live update
                 using (var session = store.OpenSession())
                 {
@@ -257,6 +271,9 @@ namespace SlowTests.Issues
                 terms = store.Maintenance.Send(new GetTermsOperation(index.IndexName, nameof(Companies_With_Attachments.Result.AttachmentContent), fromValue: null));
                 Assert.Equal(1, terms.Length);
                 Assert.Contains("<hello_moon>", terms);
+
+                terms = store.Maintenance.Send(new GetTermsOperation(index.IndexName, nameof(Companies_With_Attachments.Result.AttachmentContentStream), fromValue: null));
+                Assert.Equal(0, terms.Length);
             }
         }
 

--- a/test/SlowTests/Issues/RavenDB_14784.cs
+++ b/test/SlowTests/Issues/RavenDB_14784.cs
@@ -18,7 +18,7 @@ namespace SlowTests.Issues
         {
         }
 
-        private class Companies_WithAttachments : AbstractIndexCreationTask<Company>
+        private class Companies_With_Attachments : AbstractIndexCreationTask<Company>
         {
             public class Result
             {
@@ -35,10 +35,44 @@ namespace SlowTests.Issues
                 public string AttachmentContent { get; set; }
             }
 
-            public Companies_WithAttachments()
+            public Companies_With_Attachments()
             {
                 Map = companies => from company in companies
                                    let attachment = LoadAttachment(company, company.ExternalId)
+                                   select new Result
+                                   {
+                                       CompanyName = company.Name,
+                                       AttachmentName = attachment.Name,
+                                       AttachmentContentType = attachment.ContentType,
+                                       AttachmentHash = attachment.Hash,
+                                       AttachmentSize = attachment.Size,
+                                       AttachmentContent = attachment.GetContentAsString(Encoding.UTF8)
+                                   };
+            }
+        }
+
+        private class Companies_With_Multiple_Attachments : AbstractIndexCreationTask<Company>
+        {
+            public class Result
+            {
+                public string CompanyName { get; set; }
+
+                public string AttachmentName { get; set; }
+
+                public string AttachmentContentType { get; set; }
+
+                public string AttachmentHash { get; set; }
+
+                public long AttachmentSize { get; set; }
+
+                public string AttachmentContent { get; set; }
+            }
+
+            public Companies_With_Multiple_Attachments()
+            {
+                Map = companies => from company in companies
+                                   let attachments = LoadAttachments(company)
+                                   from attachment in attachments
                                    select new Result
                                    {
                                        CompanyName = company.Name,
@@ -56,7 +90,7 @@ namespace SlowTests.Issues
         {
             using (var store = GetDocumentStore())
             {
-                var index = new Companies_WithAttachments();
+                var index = new Companies_With_Attachments();
                 index.Execute(store);
 
                 store.Maintenance.Send(new StopIndexingOperation());
@@ -84,23 +118,23 @@ namespace SlowTests.Issues
                 Assert.False(staleness.IsStale);
                 Assert.Equal(0, staleness.StalenessReasons.Count);
 
-                var terms = store.Maintenance.Send(new GetTermsOperation(index.IndexName, nameof(Companies_WithAttachments.Result.CompanyName), fromValue: null));
+                var terms = store.Maintenance.Send(new GetTermsOperation(index.IndexName, nameof(Companies_With_Attachments.Result.CompanyName), fromValue: null));
                 Assert.Equal(1, terms.Length);
                 Assert.Equal("hr", terms[0]);
 
-                terms = store.Maintenance.Send(new GetTermsOperation(index.IndexName, nameof(Companies_WithAttachments.Result.AttachmentName), fromValue: null));
+                terms = store.Maintenance.Send(new GetTermsOperation(index.IndexName, nameof(Companies_With_Attachments.Result.AttachmentName), fromValue: null));
                 Assert.Equal(0, terms.Length);
 
-                terms = store.Maintenance.Send(new GetTermsOperation(index.IndexName, nameof(Companies_WithAttachments.Result.AttachmentContentType), fromValue: null));
+                terms = store.Maintenance.Send(new GetTermsOperation(index.IndexName, nameof(Companies_With_Attachments.Result.AttachmentContentType), fromValue: null));
                 Assert.Equal(0, terms.Length);
 
-                terms = store.Maintenance.Send(new GetTermsOperation(index.IndexName, nameof(Companies_WithAttachments.Result.AttachmentHash), fromValue: null));
+                terms = store.Maintenance.Send(new GetTermsOperation(index.IndexName, nameof(Companies_With_Attachments.Result.AttachmentHash), fromValue: null));
                 Assert.Equal(0, terms.Length);
 
-                terms = store.Maintenance.Send(new GetTermsOperation(index.IndexName, nameof(Companies_WithAttachments.Result.AttachmentSize), fromValue: null));
+                terms = store.Maintenance.Send(new GetTermsOperation(index.IndexName, nameof(Companies_With_Attachments.Result.AttachmentSize), fromValue: null));
                 Assert.Equal(0, terms.Length);
 
-                terms = store.Maintenance.Send(new GetTermsOperation(index.IndexName, nameof(Companies_WithAttachments.Result.AttachmentContent), fromValue: null));
+                terms = store.Maintenance.Send(new GetTermsOperation(index.IndexName, nameof(Companies_With_Attachments.Result.AttachmentContent), fromValue: null));
                 Assert.Equal(0, terms.Length);
 
                 store.Maintenance.Send(new StopIndexingOperation());
@@ -122,27 +156,27 @@ namespace SlowTests.Issues
 
                 WaitForIndexing(store);
 
-                terms = store.Maintenance.Send(new GetTermsOperation(index.IndexName, nameof(Companies_WithAttachments.Result.CompanyName), fromValue: null));
+                terms = store.Maintenance.Send(new GetTermsOperation(index.IndexName, nameof(Companies_With_Attachments.Result.CompanyName), fromValue: null));
                 Assert.Equal(1, terms.Length);
                 Assert.Contains("hr", terms);
 
-                terms = store.Maintenance.Send(new GetTermsOperation(index.IndexName, nameof(Companies_WithAttachments.Result.AttachmentName), fromValue: null));
+                terms = store.Maintenance.Send(new GetTermsOperation(index.IndexName, nameof(Companies_With_Attachments.Result.AttachmentName), fromValue: null));
                 Assert.Equal(1, terms.Length);
                 Assert.Contains("file.txt", terms);
 
-                terms = store.Maintenance.Send(new GetTermsOperation(index.IndexName, nameof(Companies_WithAttachments.Result.AttachmentContentType), fromValue: null));
+                terms = store.Maintenance.Send(new GetTermsOperation(index.IndexName, nameof(Companies_With_Attachments.Result.AttachmentContentType), fromValue: null));
                 Assert.Equal(1, terms.Length);
                 Assert.Contains("application/text", terms);
 
-                terms = store.Maintenance.Send(new GetTermsOperation(index.IndexName, nameof(Companies_WithAttachments.Result.AttachmentHash), fromValue: null));
+                terms = store.Maintenance.Send(new GetTermsOperation(index.IndexName, nameof(Companies_With_Attachments.Result.AttachmentHash), fromValue: null));
                 Assert.Equal(1, terms.Length);
                 Assert.NotNull(terms[0]);
 
-                terms = store.Maintenance.Send(new GetTermsOperation(index.IndexName, nameof(Companies_WithAttachments.Result.AttachmentSize), fromValue: null));
+                terms = store.Maintenance.Send(new GetTermsOperation(index.IndexName, nameof(Companies_With_Attachments.Result.AttachmentSize), fromValue: null));
                 Assert.Equal(1, terms.Length);
                 Assert.Contains("13", terms);
 
-                terms = store.Maintenance.Send(new GetTermsOperation(index.IndexName, nameof(Companies_WithAttachments.Result.AttachmentContent), fromValue: null));
+                terms = store.Maintenance.Send(new GetTermsOperation(index.IndexName, nameof(Companies_With_Attachments.Result.AttachmentContent), fromValue: null));
                 Assert.Equal(1, terms.Length);
                 Assert.Contains("<hello_world>", terms);
 
@@ -165,27 +199,27 @@ namespace SlowTests.Issues
 
                 WaitForIndexing(store);
 
-                terms = store.Maintenance.Send(new GetTermsOperation(index.IndexName, nameof(Companies_WithAttachments.Result.CompanyName), fromValue: null));
+                terms = store.Maintenance.Send(new GetTermsOperation(index.IndexName, nameof(Companies_With_Attachments.Result.CompanyName), fromValue: null));
                 Assert.Equal(1, terms.Length);
                 Assert.Contains("hr", terms);
 
-                terms = store.Maintenance.Send(new GetTermsOperation(index.IndexName, nameof(Companies_WithAttachments.Result.AttachmentName), fromValue: null));
+                terms = store.Maintenance.Send(new GetTermsOperation(index.IndexName, nameof(Companies_With_Attachments.Result.AttachmentName), fromValue: null));
                 Assert.Equal(1, terms.Length);
                 Assert.Contains("file.txt", terms);
 
-                terms = store.Maintenance.Send(new GetTermsOperation(index.IndexName, nameof(Companies_WithAttachments.Result.AttachmentContentType), fromValue: null));
+                terms = store.Maintenance.Send(new GetTermsOperation(index.IndexName, nameof(Companies_With_Attachments.Result.AttachmentContentType), fromValue: null));
                 Assert.Equal(1, terms.Length);
                 Assert.Contains("application/text", terms);
 
-                terms = store.Maintenance.Send(new GetTermsOperation(index.IndexName, nameof(Companies_WithAttachments.Result.AttachmentHash), fromValue: null));
+                terms = store.Maintenance.Send(new GetTermsOperation(index.IndexName, nameof(Companies_With_Attachments.Result.AttachmentHash), fromValue: null));
                 Assert.Equal(1, terms.Length);
                 Assert.NotNull(terms[0]);
 
-                terms = store.Maintenance.Send(new GetTermsOperation(index.IndexName, nameof(Companies_WithAttachments.Result.AttachmentSize), fromValue: null));
+                terms = store.Maintenance.Send(new GetTermsOperation(index.IndexName, nameof(Companies_With_Attachments.Result.AttachmentSize), fromValue: null));
                 Assert.Equal(1, terms.Length);
                 Assert.Contains("14", terms);
 
-                terms = store.Maintenance.Send(new GetTermsOperation(index.IndexName, nameof(Companies_WithAttachments.Result.AttachmentContent), fromValue: null));
+                terms = store.Maintenance.Send(new GetTermsOperation(index.IndexName, nameof(Companies_With_Attachments.Result.AttachmentContent), fromValue: null));
                 Assert.Equal(1, terms.Length);
                 Assert.Contains("<hello_cosmos>", terms);
 
@@ -200,29 +234,215 @@ namespace SlowTests.Issues
 
                 WaitForIndexing(store);
 
-                terms = store.Maintenance.Send(new GetTermsOperation(index.IndexName, nameof(Companies_WithAttachments.Result.CompanyName), fromValue: null));
+                terms = store.Maintenance.Send(new GetTermsOperation(index.IndexName, nameof(Companies_With_Attachments.Result.CompanyName), fromValue: null));
                 Assert.Equal(1, terms.Length);
                 Assert.Contains("hr", terms);
 
-                terms = store.Maintenance.Send(new GetTermsOperation(index.IndexName, nameof(Companies_WithAttachments.Result.AttachmentName), fromValue: null));
+                terms = store.Maintenance.Send(new GetTermsOperation(index.IndexName, nameof(Companies_With_Attachments.Result.AttachmentName), fromValue: null));
                 Assert.Equal(1, terms.Length);
                 Assert.Contains("file.txt", terms);
 
-                terms = store.Maintenance.Send(new GetTermsOperation(index.IndexName, nameof(Companies_WithAttachments.Result.AttachmentContentType), fromValue: null));
+                terms = store.Maintenance.Send(new GetTermsOperation(index.IndexName, nameof(Companies_With_Attachments.Result.AttachmentContentType), fromValue: null));
                 Assert.Equal(1, terms.Length);
                 Assert.Contains("application/text", terms);
 
-                terms = store.Maintenance.Send(new GetTermsOperation(index.IndexName, nameof(Companies_WithAttachments.Result.AttachmentHash), fromValue: null));
+                terms = store.Maintenance.Send(new GetTermsOperation(index.IndexName, nameof(Companies_With_Attachments.Result.AttachmentHash), fromValue: null));
                 Assert.Equal(1, terms.Length);
                 Assert.NotNull(terms[0]);
 
-                terms = store.Maintenance.Send(new GetTermsOperation(index.IndexName, nameof(Companies_WithAttachments.Result.AttachmentSize), fromValue: null));
+                terms = store.Maintenance.Send(new GetTermsOperation(index.IndexName, nameof(Companies_With_Attachments.Result.AttachmentSize), fromValue: null));
                 Assert.Equal(1, terms.Length);
                 Assert.Contains("12", terms);
 
-                terms = store.Maintenance.Send(new GetTermsOperation(index.IndexName, nameof(Companies_WithAttachments.Result.AttachmentContent), fromValue: null));
+                terms = store.Maintenance.Send(new GetTermsOperation(index.IndexName, nameof(Companies_With_Attachments.Result.AttachmentContent), fromValue: null));
                 Assert.Equal(1, terms.Length);
                 Assert.Contains("<hello_moon>", terms);
+            }
+        }
+
+        [Fact]
+        public void Can_Index_Multiple_Attachments()
+        {
+            using (var store = GetDocumentStore())
+            {
+                var index = new Companies_With_Multiple_Attachments();
+                index.Execute(store);
+
+                store.Maintenance.Send(new StopIndexingOperation());
+
+                var staleness = store.Maintenance.Send(new GetIndexStalenessOperation(index.IndexName));
+                Assert.False(staleness.IsStale);
+                Assert.Equal(0, staleness.StalenessReasons.Count);
+
+                using (var session = store.OpenSession())
+                {
+                    session.Store(new Company { Name = "HR" }, "companies/1");
+                    session.SaveChanges();
+                }
+
+                staleness = store.Maintenance.Send(new GetIndexStalenessOperation(index.IndexName));
+                Assert.True(staleness.IsStale);
+                Assert.Equal(1, staleness.StalenessReasons.Count);
+                Assert.Contains("There are still some documents to process", staleness.StalenessReasons[0]);
+
+                store.Maintenance.Send(new StartIndexingOperation());
+
+                WaitForIndexing(store);
+
+                staleness = store.Maintenance.Send(new GetIndexStalenessOperation(index.IndexName));
+                Assert.False(staleness.IsStale);
+                Assert.Equal(0, staleness.StalenessReasons.Count);
+
+                var terms = store.Maintenance.Send(new GetTermsOperation(index.IndexName, nameof(Companies_With_Attachments.Result.CompanyName), fromValue: null));
+                Assert.Equal(0, terms.Length);
+
+                terms = store.Maintenance.Send(new GetTermsOperation(index.IndexName, nameof(Companies_With_Attachments.Result.AttachmentName), fromValue: null));
+                Assert.Equal(0, terms.Length);
+
+                terms = store.Maintenance.Send(new GetTermsOperation(index.IndexName, nameof(Companies_With_Attachments.Result.AttachmentContentType), fromValue: null));
+                Assert.Equal(0, terms.Length);
+
+                terms = store.Maintenance.Send(new GetTermsOperation(index.IndexName, nameof(Companies_With_Attachments.Result.AttachmentHash), fromValue: null));
+                Assert.Equal(0, terms.Length);
+
+                terms = store.Maintenance.Send(new GetTermsOperation(index.IndexName, nameof(Companies_With_Attachments.Result.AttachmentSize), fromValue: null));
+                Assert.Equal(0, terms.Length);
+
+                terms = store.Maintenance.Send(new GetTermsOperation(index.IndexName, nameof(Companies_With_Attachments.Result.AttachmentContent), fromValue: null));
+                Assert.Equal(0, terms.Length);
+
+                store.Maintenance.Send(new StopIndexingOperation());
+
+                using (var session = store.OpenSession())
+                {
+                    var company = session.Load<Company>("companies/1");
+                    session.Advanced.Attachments.Store(company, "file.txt", new MemoryStream(Encoding.UTF8.GetBytes("<Hello_World>")), "application/text");
+                    session.Advanced.Attachments.Store(company, "file2.txt", new MemoryStream(Encoding.UTF8.GetBytes("<Aloha_World>")), "application/text");
+
+                    session.SaveChanges();
+                }
+
+                staleness = store.Maintenance.Send(new GetIndexStalenessOperation(index.IndexName));
+                Assert.True(staleness.IsStale);
+                Assert.Equal(1, staleness.StalenessReasons.Count);
+                Assert.Contains("There are still some documents to process", staleness.StalenessReasons[0]);
+
+                store.Maintenance.Send(new StartIndexingOperation());
+
+                WaitForIndexing(store);
+
+                terms = store.Maintenance.Send(new GetTermsOperation(index.IndexName, nameof(Companies_With_Attachments.Result.CompanyName), fromValue: null));
+                Assert.Equal(1, terms.Length);
+                Assert.Contains("hr", terms);
+
+                terms = store.Maintenance.Send(new GetTermsOperation(index.IndexName, nameof(Companies_With_Attachments.Result.AttachmentName), fromValue: null));
+                Assert.Equal(2, terms.Length);
+                Assert.Contains("file.txt", terms);
+                Assert.Contains("file2.txt", terms);
+
+                terms = store.Maintenance.Send(new GetTermsOperation(index.IndexName, nameof(Companies_With_Attachments.Result.AttachmentContentType), fromValue: null));
+                Assert.Equal(1, terms.Length);
+                Assert.Contains("application/text", terms);
+
+                terms = store.Maintenance.Send(new GetTermsOperation(index.IndexName, nameof(Companies_With_Attachments.Result.AttachmentHash), fromValue: null));
+                Assert.Equal(2, terms.Length);
+                Assert.NotNull(terms[0]);
+                Assert.NotNull(terms[1]);
+
+                terms = store.Maintenance.Send(new GetTermsOperation(index.IndexName, nameof(Companies_With_Attachments.Result.AttachmentSize), fromValue: null));
+                Assert.Equal(1, terms.Length);
+                Assert.Contains("13", terms);
+
+                terms = store.Maintenance.Send(new GetTermsOperation(index.IndexName, nameof(Companies_With_Attachments.Result.AttachmentContent), fromValue: null));
+                Assert.Equal(2, terms.Length);
+                Assert.Contains("<hello_world>", terms);
+                Assert.Contains("<aloha_world>", terms);
+
+                store.Maintenance.Send(new StopIndexingOperation());
+
+                using (var session = store.OpenSession())
+                {
+                    var company = session.Load<Company>("companies/1");
+                    session.Advanced.Attachments.Store(company, "file.txt", new MemoryStream(Encoding.UTF8.GetBytes("<Hello_Cosmos>")), "application/text");
+
+                    session.SaveChanges();
+                }
+
+                staleness = store.Maintenance.Send(new GetIndexStalenessOperation(index.IndexName));
+                Assert.True(staleness.IsStale);
+                Assert.Equal(1, staleness.StalenessReasons.Count);
+                Assert.Contains("There are still some documents to process", staleness.StalenessReasons[0]);
+
+                store.Maintenance.Send(new StartIndexingOperation());
+
+                WaitForIndexing(store);
+
+                terms = store.Maintenance.Send(new GetTermsOperation(index.IndexName, nameof(Companies_With_Attachments.Result.CompanyName), fromValue: null));
+                Assert.Equal(1, terms.Length);
+                Assert.Contains("hr", terms);
+
+                terms = store.Maintenance.Send(new GetTermsOperation(index.IndexName, nameof(Companies_With_Attachments.Result.AttachmentName), fromValue: null));
+                Assert.Equal(2, terms.Length);
+                Assert.Contains("file.txt", terms);
+                Assert.Contains("file2.txt", terms);
+
+                terms = store.Maintenance.Send(new GetTermsOperation(index.IndexName, nameof(Companies_With_Attachments.Result.AttachmentContentType), fromValue: null));
+                Assert.Equal(1, terms.Length);
+                Assert.Contains("application/text", terms);
+
+                terms = store.Maintenance.Send(new GetTermsOperation(index.IndexName, nameof(Companies_With_Attachments.Result.AttachmentHash), fromValue: null));
+                Assert.Equal(2, terms.Length);
+                Assert.NotNull(terms[0]);
+                Assert.NotNull(terms[1]);
+
+                terms = store.Maintenance.Send(new GetTermsOperation(index.IndexName, nameof(Companies_With_Attachments.Result.AttachmentSize), fromValue: null));
+                Assert.Equal(2, terms.Length);
+                Assert.Contains("13", terms);
+                Assert.Contains("14", terms);
+
+                terms = store.Maintenance.Send(new GetTermsOperation(index.IndexName, nameof(Companies_With_Attachments.Result.AttachmentContent), fromValue: null));
+                Assert.Equal(2, terms.Length);
+                Assert.Contains("<hello_cosmos>", terms);
+                Assert.Contains("<aloha_world>", terms);
+
+                // live update
+                using (var session = store.OpenSession())
+                {
+                    var company = session.Load<Company>("companies/1");
+                    session.Advanced.Attachments.Store(company, "file2.txt", new MemoryStream(Encoding.UTF8.GetBytes("<Aloha_Moon>")), "application/text");
+
+                    session.SaveChanges();
+                }
+
+                WaitForIndexing(store);
+
+                terms = store.Maintenance.Send(new GetTermsOperation(index.IndexName, nameof(Companies_With_Attachments.Result.CompanyName), fromValue: null));
+                Assert.Equal(1, terms.Length);
+                Assert.Contains("hr", terms);
+
+                terms = store.Maintenance.Send(new GetTermsOperation(index.IndexName, nameof(Companies_With_Attachments.Result.AttachmentName), fromValue: null));
+                Assert.Equal(2, terms.Length);
+                Assert.Contains("file.txt", terms);
+                Assert.Contains("file2.txt", terms);
+
+                terms = store.Maintenance.Send(new GetTermsOperation(index.IndexName, nameof(Companies_With_Attachments.Result.AttachmentContentType), fromValue: null));
+                Assert.Equal(1, terms.Length);
+                Assert.Contains("application/text", terms);
+
+                terms = store.Maintenance.Send(new GetTermsOperation(index.IndexName, nameof(Companies_With_Attachments.Result.AttachmentHash), fromValue: null));
+                Assert.Equal(2, terms.Length);
+                Assert.NotNull(terms[0]);
+                Assert.NotNull(terms[1]);
+
+                terms = store.Maintenance.Send(new GetTermsOperation(index.IndexName, nameof(Companies_With_Attachments.Result.AttachmentSize), fromValue: null));
+                Assert.Equal(2, terms.Length);
+                Assert.Contains("12", terms);
+                Assert.Contains("14", terms);
+
+                terms = store.Maintenance.Send(new GetTermsOperation(index.IndexName, nameof(Companies_With_Attachments.Result.AttachmentContent), fromValue: null));
+                Assert.Equal(2, terms.Length);
+                Assert.Contains("<hello_cosmos>", terms);
+                Assert.Contains("<aloha_moon>", terms);
             }
         }
     }

--- a/test/SlowTests/Issues/RavenDB_14784.cs
+++ b/test/SlowTests/Issues/RavenDB_14784.cs
@@ -1,4 +1,5 @@
-﻿using System.IO;
+﻿using System.Collections.Generic;
+using System.IO;
 using System.Linq;
 using System.Text;
 using FastTests;
@@ -53,6 +54,27 @@ namespace SlowTests.Issues
                                    };
 
                 Store(nameof(Result.AttachmentContentStream), FieldStorage.Yes);
+            }
+        }
+
+        private class Companies_With_Attachments_JavaScript : AbstractJavaScriptIndexCreationTask
+        {
+            public Companies_With_Attachments_JavaScript()
+            {
+                Maps = new HashSet<string>
+                {
+                    @"map('Companies', function (company) {
+var attachment = loadAttachment(company, company.ExternalId);
+return {
+    CompanyName: company.Name,
+    AttachmentName: attachment.Name,
+    AttachmentContentType: attachment.ContentType,
+    AttachmentHash: attachment.Hash,
+    AttachmentSize: attachment.Size,
+    AttachmentContent: attachment.getContentAsString('utf8')
+};
+})"
+                };
             }
         }
 
@@ -460,6 +482,193 @@ namespace SlowTests.Issues
                 Assert.Equal(2, terms.Length);
                 Assert.Contains("<hello_cosmos>", terms);
                 Assert.Contains("<aloha_moon>", terms);
+            }
+        }
+
+        [Fact]
+        public void Can_Index_Attachments_JavaScript()
+        {
+            using (var store = GetDocumentStore())
+            {
+                var index = new Companies_With_Attachments_JavaScript();
+                index.Execute(store);
+
+                store.Maintenance.Send(new StopIndexingOperation());
+
+                var staleness = store.Maintenance.Send(new GetIndexStalenessOperation(index.IndexName));
+                Assert.False(staleness.IsStale);
+                Assert.Equal(0, staleness.StalenessReasons.Count);
+
+                using (var session = store.OpenSession())
+                {
+                    session.Store(new Company { Name = "HR", ExternalId = "file.txt" }, "companies/1");
+                    session.SaveChanges();
+                }
+
+                staleness = store.Maintenance.Send(new GetIndexStalenessOperation(index.IndexName));
+                Assert.True(staleness.IsStale);
+                Assert.Equal(1, staleness.StalenessReasons.Count);
+                Assert.Contains("There are still some documents to process", staleness.StalenessReasons[0]);
+
+                store.Maintenance.Send(new StartIndexingOperation());
+
+                WaitForIndexing(store);
+
+                staleness = store.Maintenance.Send(new GetIndexStalenessOperation(index.IndexName));
+                Assert.False(staleness.IsStale);
+                Assert.Equal(0, staleness.StalenessReasons.Count);
+
+                var terms = store.Maintenance.Send(new GetTermsOperation(index.IndexName, nameof(Companies_With_Attachments.Result.CompanyName), fromValue: null));
+                Assert.Equal(1, terms.Length);
+                Assert.Equal("hr", terms[0]);
+
+                terms = store.Maintenance.Send(new GetTermsOperation(index.IndexName, nameof(Companies_With_Attachments.Result.AttachmentName), fromValue: null));
+                Assert.Equal(0, terms.Length);
+
+                terms = store.Maintenance.Send(new GetTermsOperation(index.IndexName, nameof(Companies_With_Attachments.Result.AttachmentContentType), fromValue: null));
+                Assert.Equal(0, terms.Length);
+
+                terms = store.Maintenance.Send(new GetTermsOperation(index.IndexName, nameof(Companies_With_Attachments.Result.AttachmentHash), fromValue: null));
+                Assert.Equal(0, terms.Length);
+
+                terms = store.Maintenance.Send(new GetTermsOperation(index.IndexName, nameof(Companies_With_Attachments.Result.AttachmentSize), fromValue: null));
+                Assert.Equal(0, terms.Length);
+
+                terms = store.Maintenance.Send(new GetTermsOperation(index.IndexName, nameof(Companies_With_Attachments.Result.AttachmentContent), fromValue: null));
+                Assert.Equal(0, terms.Length);
+
+                terms = store.Maintenance.Send(new GetTermsOperation(index.IndexName, nameof(Companies_With_Attachments.Result.AttachmentContentStream), fromValue: null));
+                Assert.Equal(0, terms.Length);
+
+                store.Maintenance.Send(new StopIndexingOperation());
+
+                using (var session = store.OpenSession())
+                {
+                    var company = session.Load<Company>("companies/1");
+                    session.Advanced.Attachments.Store(company, "file.txt", new MemoryStream(Encoding.UTF8.GetBytes("<Hello_World>")), "application/text");
+
+                    session.SaveChanges();
+                }
+
+                staleness = store.Maintenance.Send(new GetIndexStalenessOperation(index.IndexName));
+                Assert.True(staleness.IsStale);
+                Assert.Equal(1, staleness.StalenessReasons.Count);
+                Assert.Contains("There are still some documents to process", staleness.StalenessReasons[0]);
+
+                store.Maintenance.Send(new StartIndexingOperation());
+
+                WaitForIndexing(store);
+
+                terms = store.Maintenance.Send(new GetTermsOperation(index.IndexName, nameof(Companies_With_Attachments.Result.CompanyName), fromValue: null));
+                Assert.Equal(1, terms.Length);
+                Assert.Contains("hr", terms);
+
+                terms = store.Maintenance.Send(new GetTermsOperation(index.IndexName, nameof(Companies_With_Attachments.Result.AttachmentName), fromValue: null));
+                Assert.Equal(1, terms.Length);
+                Assert.Contains("file.txt", terms);
+
+                terms = store.Maintenance.Send(new GetTermsOperation(index.IndexName, nameof(Companies_With_Attachments.Result.AttachmentContentType), fromValue: null));
+                Assert.Equal(1, terms.Length);
+                Assert.Contains("application/text", terms);
+
+                terms = store.Maintenance.Send(new GetTermsOperation(index.IndexName, nameof(Companies_With_Attachments.Result.AttachmentHash), fromValue: null));
+                Assert.Equal(1, terms.Length);
+                Assert.NotNull(terms[0]);
+
+                terms = store.Maintenance.Send(new GetTermsOperation(index.IndexName, nameof(Companies_With_Attachments.Result.AttachmentSize), fromValue: null));
+                Assert.Equal(1, terms.Length);
+                Assert.Contains("13", terms);
+
+                terms = store.Maintenance.Send(new GetTermsOperation(index.IndexName, nameof(Companies_With_Attachments.Result.AttachmentContent), fromValue: null));
+                Assert.Equal(1, terms.Length);
+                Assert.Contains("<hello_world>", terms);
+
+                terms = store.Maintenance.Send(new GetTermsOperation(index.IndexName, nameof(Companies_With_Attachments.Result.AttachmentContentStream), fromValue: null));
+                Assert.Equal(0, terms.Length);
+
+                store.Maintenance.Send(new StopIndexingOperation());
+
+                using (var session = store.OpenSession())
+                {
+                    var company = session.Load<Company>("companies/1");
+                    session.Advanced.Attachments.Store(company, "file.txt", new MemoryStream(Encoding.UTF8.GetBytes("<Hello_Cosmos>")), "application/text");
+
+                    session.SaveChanges();
+                }
+
+                staleness = store.Maintenance.Send(new GetIndexStalenessOperation(index.IndexName));
+                Assert.True(staleness.IsStale);
+                Assert.Equal(1, staleness.StalenessReasons.Count);
+                Assert.Contains("There are still some documents to process", staleness.StalenessReasons[0]);
+
+                store.Maintenance.Send(new StartIndexingOperation());
+
+                WaitForIndexing(store);
+
+                terms = store.Maintenance.Send(new GetTermsOperation(index.IndexName, nameof(Companies_With_Attachments.Result.CompanyName), fromValue: null));
+                Assert.Equal(1, terms.Length);
+                Assert.Contains("hr", terms);
+
+                terms = store.Maintenance.Send(new GetTermsOperation(index.IndexName, nameof(Companies_With_Attachments.Result.AttachmentName), fromValue: null));
+                Assert.Equal(1, terms.Length);
+                Assert.Contains("file.txt", terms);
+
+                terms = store.Maintenance.Send(new GetTermsOperation(index.IndexName, nameof(Companies_With_Attachments.Result.AttachmentContentType), fromValue: null));
+                Assert.Equal(1, terms.Length);
+                Assert.Contains("application/text", terms);
+
+                terms = store.Maintenance.Send(new GetTermsOperation(index.IndexName, nameof(Companies_With_Attachments.Result.AttachmentHash), fromValue: null));
+                Assert.Equal(1, terms.Length);
+                Assert.NotNull(terms[0]);
+
+                terms = store.Maintenance.Send(new GetTermsOperation(index.IndexName, nameof(Companies_With_Attachments.Result.AttachmentSize), fromValue: null));
+                Assert.Equal(1, terms.Length);
+                Assert.Contains("14", terms);
+
+                terms = store.Maintenance.Send(new GetTermsOperation(index.IndexName, nameof(Companies_With_Attachments.Result.AttachmentContent), fromValue: null));
+                Assert.Equal(1, terms.Length);
+                Assert.Contains("<hello_cosmos>", terms);
+
+                terms = store.Maintenance.Send(new GetTermsOperation(index.IndexName, nameof(Companies_With_Attachments.Result.AttachmentContentStream), fromValue: null));
+                Assert.Equal(0, terms.Length);
+
+                // live update
+                using (var session = store.OpenSession())
+                {
+                    var company = session.Load<Company>("companies/1");
+                    session.Advanced.Attachments.Store(company, "file.txt", new MemoryStream(Encoding.UTF8.GetBytes("<Hello_Moon>")), "application/text");
+
+                    session.SaveChanges();
+                }
+
+                WaitForIndexing(store);
+
+                terms = store.Maintenance.Send(new GetTermsOperation(index.IndexName, nameof(Companies_With_Attachments.Result.CompanyName), fromValue: null));
+                Assert.Equal(1, terms.Length);
+                Assert.Contains("hr", terms);
+
+                terms = store.Maintenance.Send(new GetTermsOperation(index.IndexName, nameof(Companies_With_Attachments.Result.AttachmentName), fromValue: null));
+                Assert.Equal(1, terms.Length);
+                Assert.Contains("file.txt", terms);
+
+                terms = store.Maintenance.Send(new GetTermsOperation(index.IndexName, nameof(Companies_With_Attachments.Result.AttachmentContentType), fromValue: null));
+                Assert.Equal(1, terms.Length);
+                Assert.Contains("application/text", terms);
+
+                terms = store.Maintenance.Send(new GetTermsOperation(index.IndexName, nameof(Companies_With_Attachments.Result.AttachmentHash), fromValue: null));
+                Assert.Equal(1, terms.Length);
+                Assert.NotNull(terms[0]);
+
+                terms = store.Maintenance.Send(new GetTermsOperation(index.IndexName, nameof(Companies_With_Attachments.Result.AttachmentSize), fromValue: null));
+                Assert.Equal(1, terms.Length);
+                Assert.Contains("12", terms);
+
+                terms = store.Maintenance.Send(new GetTermsOperation(index.IndexName, nameof(Companies_With_Attachments.Result.AttachmentContent), fromValue: null));
+                Assert.Equal(1, terms.Length);
+                Assert.Contains("<hello_moon>", terms);
+
+                terms = store.Maintenance.Send(new GetTermsOperation(index.IndexName, nameof(Companies_With_Attachments.Result.AttachmentContentStream), fromValue: null));
+                Assert.Equal(0, terms.Length);
             }
         }
     }

--- a/test/SlowTests/Issues/RavenDB_14784.cs
+++ b/test/SlowTests/Issues/RavenDB_14784.cs
@@ -112,6 +112,27 @@ return {
             }
         }
 
+        private class Companies_With_Multiple_Attachments_JavaScript : AbstractJavaScriptIndexCreationTask
+        {
+            public Companies_With_Multiple_Attachments_JavaScript()
+            {
+                Maps = new HashSet<string>
+                {
+                    @"map('Companies', function (company) {
+var attachments = loadAttachments(company);
+return attachments.map(attachment => ({
+    CompanyName: company.Name,
+    AttachmentName: attachment.Name,
+    AttachmentContentType: attachment.ContentType,
+    AttachmentHash: attachment.Hash,
+    AttachmentSize: attachment.Size,
+    AttachmentContent: attachment.getContentAsString('utf8')
+}));
+})"
+                };
+            }
+        }
+
         [Fact]
         public void Can_Index_Attachments()
         {
@@ -669,6 +690,192 @@ return {
 
                 terms = store.Maintenance.Send(new GetTermsOperation(index.IndexName, nameof(Companies_With_Attachments.Result.AttachmentContentStream), fromValue: null));
                 Assert.Equal(0, terms.Length);
+            }
+        }
+
+        [Fact]
+        public void Can_Index_Multiple_Attachments_JavaScript()
+        {
+            using (var store = GetDocumentStore())
+            {
+                var index = new Companies_With_Multiple_Attachments_JavaScript();
+                index.Execute(store);
+
+                store.Maintenance.Send(new StopIndexingOperation());
+
+                var staleness = store.Maintenance.Send(new GetIndexStalenessOperation(index.IndexName));
+                Assert.False(staleness.IsStale);
+                Assert.Equal(0, staleness.StalenessReasons.Count);
+
+                using (var session = store.OpenSession())
+                {
+                    session.Store(new Company { Name = "HR" }, "companies/1");
+                    session.SaveChanges();
+                }
+
+                staleness = store.Maintenance.Send(new GetIndexStalenessOperation(index.IndexName));
+                Assert.True(staleness.IsStale);
+                Assert.Equal(1, staleness.StalenessReasons.Count);
+                Assert.Contains("There are still some documents to process", staleness.StalenessReasons[0]);
+
+                store.Maintenance.Send(new StartIndexingOperation());
+
+                WaitForIndexing(store);
+
+                staleness = store.Maintenance.Send(new GetIndexStalenessOperation(index.IndexName));
+                Assert.False(staleness.IsStale);
+                Assert.Equal(0, staleness.StalenessReasons.Count);
+
+                var terms = store.Maintenance.Send(new GetTermsOperation(index.IndexName, nameof(Companies_With_Attachments.Result.CompanyName), fromValue: null));
+                Assert.Equal(0, terms.Length);
+
+                terms = store.Maintenance.Send(new GetTermsOperation(index.IndexName, nameof(Companies_With_Attachments.Result.AttachmentName), fromValue: null));
+                Assert.Equal(0, terms.Length);
+
+                terms = store.Maintenance.Send(new GetTermsOperation(index.IndexName, nameof(Companies_With_Attachments.Result.AttachmentContentType), fromValue: null));
+                Assert.Equal(0, terms.Length);
+
+                terms = store.Maintenance.Send(new GetTermsOperation(index.IndexName, nameof(Companies_With_Attachments.Result.AttachmentHash), fromValue: null));
+                Assert.Equal(0, terms.Length);
+
+                terms = store.Maintenance.Send(new GetTermsOperation(index.IndexName, nameof(Companies_With_Attachments.Result.AttachmentSize), fromValue: null));
+                Assert.Equal(0, terms.Length);
+
+                terms = store.Maintenance.Send(new GetTermsOperation(index.IndexName, nameof(Companies_With_Attachments.Result.AttachmentContent), fromValue: null));
+                Assert.Equal(0, terms.Length);
+
+                store.Maintenance.Send(new StopIndexingOperation());
+
+                using (var session = store.OpenSession())
+                {
+                    var company = session.Load<Company>("companies/1");
+                    session.Advanced.Attachments.Store(company, "file.txt", new MemoryStream(Encoding.UTF8.GetBytes("<Hello_World>")), "application/text");
+                    session.Advanced.Attachments.Store(company, "file2.txt", new MemoryStream(Encoding.UTF8.GetBytes("<Aloha_World>")), "application/text");
+
+                    session.SaveChanges();
+                }
+
+                staleness = store.Maintenance.Send(new GetIndexStalenessOperation(index.IndexName));
+                Assert.True(staleness.IsStale);
+                Assert.Equal(1, staleness.StalenessReasons.Count);
+                Assert.Contains("There are still some documents to process", staleness.StalenessReasons[0]);
+
+                store.Maintenance.Send(new StartIndexingOperation());
+
+                WaitForIndexing(store);
+
+                terms = store.Maintenance.Send(new GetTermsOperation(index.IndexName, nameof(Companies_With_Attachments.Result.CompanyName), fromValue: null));
+                Assert.Equal(1, terms.Length);
+                Assert.Contains("hr", terms);
+
+                terms = store.Maintenance.Send(new GetTermsOperation(index.IndexName, nameof(Companies_With_Attachments.Result.AttachmentName), fromValue: null));
+                Assert.Equal(2, terms.Length);
+                Assert.Contains("file.txt", terms);
+                Assert.Contains("file2.txt", terms);
+
+                terms = store.Maintenance.Send(new GetTermsOperation(index.IndexName, nameof(Companies_With_Attachments.Result.AttachmentContentType), fromValue: null));
+                Assert.Equal(1, terms.Length);
+                Assert.Contains("application/text", terms);
+
+                terms = store.Maintenance.Send(new GetTermsOperation(index.IndexName, nameof(Companies_With_Attachments.Result.AttachmentHash), fromValue: null));
+                Assert.Equal(2, terms.Length);
+                Assert.NotNull(terms[0]);
+                Assert.NotNull(terms[1]);
+
+                terms = store.Maintenance.Send(new GetTermsOperation(index.IndexName, nameof(Companies_With_Attachments.Result.AttachmentSize), fromValue: null));
+                Assert.Equal(1, terms.Length);
+                Assert.Contains("13", terms);
+
+                terms = store.Maintenance.Send(new GetTermsOperation(index.IndexName, nameof(Companies_With_Attachments.Result.AttachmentContent), fromValue: null));
+                Assert.Equal(2, terms.Length);
+                Assert.Contains("<hello_world>", terms);
+                Assert.Contains("<aloha_world>", terms);
+
+                store.Maintenance.Send(new StopIndexingOperation());
+
+                using (var session = store.OpenSession())
+                {
+                    var company = session.Load<Company>("companies/1");
+                    session.Advanced.Attachments.Store(company, "file.txt", new MemoryStream(Encoding.UTF8.GetBytes("<Hello_Cosmos>")), "application/text");
+
+                    session.SaveChanges();
+                }
+
+                staleness = store.Maintenance.Send(new GetIndexStalenessOperation(index.IndexName));
+                Assert.True(staleness.IsStale);
+                Assert.Equal(1, staleness.StalenessReasons.Count);
+                Assert.Contains("There are still some documents to process", staleness.StalenessReasons[0]);
+
+                store.Maintenance.Send(new StartIndexingOperation());
+
+                WaitForIndexing(store);
+
+                terms = store.Maintenance.Send(new GetTermsOperation(index.IndexName, nameof(Companies_With_Attachments.Result.CompanyName), fromValue: null));
+                Assert.Equal(1, terms.Length);
+                Assert.Contains("hr", terms);
+
+                terms = store.Maintenance.Send(new GetTermsOperation(index.IndexName, nameof(Companies_With_Attachments.Result.AttachmentName), fromValue: null));
+                Assert.Equal(2, terms.Length);
+                Assert.Contains("file.txt", terms);
+                Assert.Contains("file2.txt", terms);
+
+                terms = store.Maintenance.Send(new GetTermsOperation(index.IndexName, nameof(Companies_With_Attachments.Result.AttachmentContentType), fromValue: null));
+                Assert.Equal(1, terms.Length);
+                Assert.Contains("application/text", terms);
+
+                terms = store.Maintenance.Send(new GetTermsOperation(index.IndexName, nameof(Companies_With_Attachments.Result.AttachmentHash), fromValue: null));
+                Assert.Equal(2, terms.Length);
+                Assert.NotNull(terms[0]);
+                Assert.NotNull(terms[1]);
+
+                terms = store.Maintenance.Send(new GetTermsOperation(index.IndexName, nameof(Companies_With_Attachments.Result.AttachmentSize), fromValue: null));
+                Assert.Equal(2, terms.Length);
+                Assert.Contains("13", terms);
+                Assert.Contains("14", terms);
+
+                terms = store.Maintenance.Send(new GetTermsOperation(index.IndexName, nameof(Companies_With_Attachments.Result.AttachmentContent), fromValue: null));
+                Assert.Equal(2, terms.Length);
+                Assert.Contains("<hello_cosmos>", terms);
+                Assert.Contains("<aloha_world>", terms);
+
+                // live update
+                using (var session = store.OpenSession())
+                {
+                    var company = session.Load<Company>("companies/1");
+                    session.Advanced.Attachments.Store(company, "file2.txt", new MemoryStream(Encoding.UTF8.GetBytes("<Aloha_Moon>")), "application/text");
+
+                    session.SaveChanges();
+                }
+
+                WaitForIndexing(store);
+
+                terms = store.Maintenance.Send(new GetTermsOperation(index.IndexName, nameof(Companies_With_Attachments.Result.CompanyName), fromValue: null));
+                Assert.Equal(1, terms.Length);
+                Assert.Contains("hr", terms);
+
+                terms = store.Maintenance.Send(new GetTermsOperation(index.IndexName, nameof(Companies_With_Attachments.Result.AttachmentName), fromValue: null));
+                Assert.Equal(2, terms.Length);
+                Assert.Contains("file.txt", terms);
+                Assert.Contains("file2.txt", terms);
+
+                terms = store.Maintenance.Send(new GetTermsOperation(index.IndexName, nameof(Companies_With_Attachments.Result.AttachmentContentType), fromValue: null));
+                Assert.Equal(1, terms.Length);
+                Assert.Contains("application/text", terms);
+
+                terms = store.Maintenance.Send(new GetTermsOperation(index.IndexName, nameof(Companies_With_Attachments.Result.AttachmentHash), fromValue: null));
+                Assert.Equal(2, terms.Length);
+                Assert.NotNull(terms[0]);
+                Assert.NotNull(terms[1]);
+
+                terms = store.Maintenance.Send(new GetTermsOperation(index.IndexName, nameof(Companies_With_Attachments.Result.AttachmentSize), fromValue: null));
+                Assert.Equal(2, terms.Length);
+                Assert.Contains("12", terms);
+                Assert.Contains("14", terms);
+
+                terms = store.Maintenance.Send(new GetTermsOperation(index.IndexName, nameof(Companies_With_Attachments.Result.AttachmentContent), fromValue: null));
+                Assert.Equal(2, terms.Length);
+                Assert.Contains("<hello_cosmos>", terms);
+                Assert.Contains("<aloha_moon>", terms);
             }
         }
     }


### PR DESCRIPTION
TODO:
- add 'GetContentAsStream' so during Lucene conversion we will be able to write byte[] directly without doing any encoding