### PR TITLE
RavenDB-15453

### DIFF
--- a/src/Raven.Server/Documents/Document.cs
+++ b/src/Raven.Server/Documents/Document.cs
@@ -101,6 +101,11 @@ namespace Raven.Server.Documents
 
             _disposed = true;
         }
+
+        public override string ToString()
+        {
+            return Id;
+        }
     }
 
     [Flags]

--- a/src/Raven.Server/Documents/Indexes/Index.cs
+++ b/src/Raven.Server/Documents/Indexes/Index.cs
@@ -3447,25 +3447,19 @@ namespace Raven.Server.Documents.Indexes
 
                 using (_contextPool.AllocateOperationContext(out TransactionOperationContext indexContext))
                 {
-                    bool shouldClose =false;
-                    if (context.AreTransactionsOpened() == false)
-                    {
-                        context.OpenReadTransaction();
-                        shouldClose = true;
-                    }
-
                     using (indexContext.OpenReadTransaction())
+                    using (OpenReadTransaction(context))
                     {
-                        try
-                        {
-                            return CalculateIndexEtag(context, indexContext, q, IsStale(context, indexContext));
-                        }
-                        finally
-                        {
-                            if(shouldClose)
-                                context.CloseTransaction();
-                        }
+                        return CalculateIndexEtag(context, indexContext, q, IsStale(context, indexContext));
                     }
+                }
+
+                static IDisposable OpenReadTransaction(QueryOperationContext context)
+                {
+                    if (context.AreTransactionsOpened())
+                        return null;
+
+                    return context.OpenReadTransaction();
                 }
             }
         }

--- a/src/Raven.Server/Documents/Indexes/Index.cs
+++ b/src/Raven.Server/Documents/Indexes/Index.cs
@@ -3448,9 +3448,17 @@ namespace Raven.Server.Documents.Indexes
                 using (_contextPool.AllocateOperationContext(out TransactionOperationContext indexContext))
                 {
                     using (indexContext.OpenReadTransaction())
-                    using (context.OpenReadTransaction())
                     {
-                        return CalculateIndexEtag(context, indexContext, q, IsStale(context, indexContext));
+                        DocumentsTransaction  d = null;
+                        if (context.Documents.HasTransaction == false)
+                        {
+                            d= context.Documents.OpenReadTransaction();
+                        }
+
+                        using (d)
+                        {
+                            return CalculateIndexEtag(context, indexContext, q, IsStale(context, indexContext));
+                        }
                     }
                 }
             }

--- a/src/Raven.Server/Documents/Queries/Graph/RecursionQueryStep.cs
+++ b/src/Raven.Server/Documents/Queries/Graph/RecursionQueryStep.cs
@@ -360,7 +360,6 @@ namespace Raven.Server.Documents.Queries.Graph
             if (startingPoint == null)
                 return;
 
-            _visited.Add(startingPoint.Data.Location);
             _path.Push(new RecursionState { Src = startingPoint.Data, Match = currentMatch });
 
             int aliasBaseIndex = 0;

--- a/src/Raven.Server/Documents/Queries/GraphQueryRunner.Match.cs
+++ b/src/Raven.Server/Documents/Queries/GraphQueryRunner.Match.cs
@@ -10,31 +10,6 @@ namespace Raven.Server.Documents.Queries
 {
     public partial class GraphQueryRunner
     {
-        public struct PathSegment : IEquatable<PathSegment>
-        {
-            public readonly long From;
-            public readonly long To;
-
-            public PathSegment(long @from, long to)
-            {
-                From = @from;
-                To = to;
-            }
-
-            public bool Equals(PathSegment other)
-            {
-                return From == other.From && To == other.To;
-            }
-
-            public override bool Equals(object obj)
-            {
-                if (ReferenceEquals(null, obj)) return false;
-                return obj is PathSegment segment && Equals(segment);
-            }
-
-            public override int GetHashCode() => HashCode.Combine(From, To);
-        }
-
         public class MatchCollection : IEquatable<MatchCollection>, IEnumerable<Match>
         {
             private List<Match> _data = new List<Match>();

--- a/test/FastTests/Issues/RavenDB-12567.cs
+++ b/test/FastTests/Issues/RavenDB-12567.cs
@@ -76,7 +76,7 @@ namespace FastTests.Issues
                         }
                     ").ToList();
 
-                    Assert.Equal(queryResults.Count, 7);
+                    Assert.Equal(queryResults.Count, 6);
 
                     var stronglyTypedQueryResults = queryResults.Select(x => new
                     {
@@ -87,13 +87,12 @@ namespace FastTests.Issues
                     var dog1StartResults = stronglyTypedQueryResults.Where(x => x.Start == "dogs/1").ToArray();
                     var dog2StartResults = stronglyTypedQueryResults.Where(x => x.Start == "dogs/2").ToArray();
 
-                    Assert.Contains(dog1StartResults, x => x.Path == "dogs/2->dogs/1->dogs/1");
                     Assert.Contains(dog1StartResults, x => x.Path == "dogs/2->dogs/1");
+                    Assert.Contains(dog1StartResults, x => x.Path == "dogs/1->dogs/2");
                     Assert.Contains(dog1StartResults, x => x.Path == "dogs/2");
                     Assert.Contains(dog1StartResults, x => x.Path == "dogs/1");
 
                     Assert.Contains(dog2StartResults, x => x.Path == "dogs/1");
-                    Assert.Contains(dog2StartResults, x => x.Path == "dogs/1->dogs/1");
                     Assert.Contains(dog2StartResults, x => x.Path == "dogs/1->dogs/2");
 
                 }

--- a/test/SlowTests/Graph/BasicGraphQueries.cs
+++ b/test/SlowTests/Graph/BasicGraphQueries.cs
@@ -447,8 +447,7 @@ select e.FirstName as Employee, n.m as MiddleManagement, boss.FirstName as Boss
                 Assert.Equal("Andrew", item.Boss);
                 Assert.Equal("Robert", item.Employee);
                 
-                //because of self-cycle of "employees/2-A" we see it twice in the path
-                Assert.Equal(new[] { "employees/5-A", "employees/2-A", "employees/2-A" }, item.MiddleManagement);
+                Assert.Equal(new[] { "employees/5-A", "employees/2-A" }, item.MiddleManagement);
             }
         }
 

--- a/test/SlowTests/Graph/RavenDB-15453.cs
+++ b/test/SlowTests/Graph/RavenDB-15453.cs
@@ -1,0 +1,73 @@
+﻿using System;
+using System.Collections.Generic;
+using System.Text;
+using FastTests;
+using Xunit;
+using Xunit.Abstractions;
+
+namespace SlowTests.Graph
+{
+    public class RavenDB_15453 : RavenTestBase
+    {
+        public RavenDB_15453(ITestOutputHelper output) : base(output)
+        {
+        }
+
+        public class Item
+        {
+            public string[] Links;
+        }
+
+        [Fact]
+        public void CanGetSingleShortestPath()
+        {
+            using var store = GetDocumentStore();
+            using (var s = store.OpenSession())
+            {
+                s.Store(new Item { Links = new[] { "items/2", "items/3" } }, "items/1");
+                s.Store(new Item { Links = new[] { "items/1", "items/2" } }, "items/2");
+                s.Store(new Item { Links = new[] { "items/2", "items/4" } }, "items/3");
+                s.Store(new Item { Links = new[] { "items/1", "items/2" } }, "items/4");
+                s.SaveChanges();
+            }
+
+            using (var s = store.OpenSession())
+            {
+                var r = s.Advanced.RawQuery<dynamic>(@"
+match (Items as Src where id() == 'items/1')
+ -recursive as Path (shortest){
+        [Links]->(Items as d)
+ }-[Links]->(Items as Dst where id() == 'items/2')")
+                    .ToList();
+                Assert.Equal(1, r.Count);
+                Assert.Equal(1, r[0].Path.Count);
+            }
+        }
+
+        [Fact]
+        public void CanGetSingleLongestPath()
+        {
+            using var store = GetDocumentStore();
+            using (var s = store.OpenSession())
+            {
+                s.Store(new Item { Links = new[] { "items/2", "items/3" } }, "items/1");
+                s.Store(new Item { Links = new[] { "items/1", "items/2" } }, "items/2");
+                s.Store(new Item { Links = new[] { "items/2", "items/4" } }, "items/3");
+                s.Store(new Item { Links = new[] { "items/1", "items/2" } }, "items/4");
+                s.SaveChanges();
+            }
+
+            using (var s = store.OpenSession())
+            {
+                var r = s.Advanced.RawQuery<dynamic>(@"
+match (Items as Src where id() == 'items/1')
+ -recursive as Path (longest){
+        [Links]->(Items as d)
+ }-[Links]->(Items as Dst where id() == 'items/2')")
+                    .ToList();
+                Assert.Equal(1, r.Count);
+                Assert.Equal(3, r[0].Path.Count);
+            }
+        }
+    }
+}

--- a/test/SlowTests/Graph/RavenDB-15453.cs
+++ b/test/SlowTests/Graph/RavenDB-15453.cs
@@ -13,7 +13,7 @@ namespace SlowTests.Graph
         {
         }
 
-        public class Item
+        private class Item
         {
             public string[] Links;
         }
@@ -66,7 +66,7 @@ match (Items as Src where id() == 'items/1')
  }-[Links]->(Items as Dst where id() == 'items/2')")
                     .ToList();
                 Assert.Equal(1, r.Count);
-                Assert.Equal(3, r[0].Path.Count);
+                Assert.Equal(4, r[0].Path.Count);
             }
         }
     }


### PR DESCRIPTION
- Fixing OOM when during recursive graph query on large graph
- Fixing tx already open when computing etag on query after the data was changed.