### PR TITLE
RavenDB-15516 sinks should not affect hubs global change vector

### DIFF
--- a/src/Raven.Server/Documents/DocumentPutAction.cs
+++ b/src/Raven.Server/Documents/DocumentPutAction.cs
@@ -355,7 +355,7 @@ namespace Raven.Server.Documents
             if (fromReplication == false)
             {
                 context.LastDatabaseChangeVector ??= GetDatabaseChangeVector(context);
-                oldChangeVector = ChangeVectorUtils.MergeVectors(oldChangeVector, context.LastDatabaseChangeVector);
+                oldChangeVector = ChangeVectorUtils.MergeVectors(context.LastDatabaseChangeVector, oldChangeVector);
             }
 
             changeVector = SetDocumentChangeVectorForLocalChange(context, lowerId, oldChangeVector, newEtag);

--- a/src/Raven.Server/Documents/Handlers/PullReplicationHandler.cs
+++ b/src/Raven.Server/Documents/Handlers/PullReplicationHandler.cs
@@ -78,11 +78,8 @@ namespace Raven.Server.Documents.Handlers
                 access.Validate(hubDefinition.WithFiltering);
 
                 using var cert = new X509Certificate2(Convert.FromBase64String(access.CertificateBase64));
-                var publicKeyPinningHash = cert.GetPublicKeyPinningHash();
 
-                var command = new RegisterReplicationHubAccessCommand(Database.Name, hubTaskName, access, publicKeyPinningHash, cert.Thumbprint, GetRaftRequestIdFromQuery(),
-                    cert.Issuer, cert.Subject, cert.NotBefore, cert.NotAfter);
-                
+                var command = new RegisterReplicationHubAccessCommand(Database.Name, hubTaskName, access, cert, GetRaftRequestIdFromQuery());
                 var result = await Server.ServerStore.SendToLeaderAsync(command);
                 await WaitForIndexToBeApplied(context, result.Index);
 

--- a/src/Raven.Server/Documents/Replication/ChangeVectorExtensions.cs
+++ b/src/Raven.Server/Documents/Replication/ChangeVectorExtensions.cs
@@ -63,15 +63,8 @@ namespace Raven.Server.Documents.Replication
             } while (tag != 0);
         }
 
-        public static int FromBase26(string tag)
-        {
-            var val = 0;
-            for (int i = 0; i < tag.Length; i++)
-            {
-                val *= 26;
-                val += (tag[i] - 'A');
-            }
-            return val;
-        }
+        public static int FromBase26(string tag) => tag.ParseNodeTag();
+
+        public static readonly int SinkTag = FromBase26("SINK");
     }
 }

--- a/src/Raven.Server/Documents/Replication/ReplicationLoader.cs
+++ b/src/Raven.Server/Documents/Replication/ReplicationLoader.cs
@@ -295,12 +295,12 @@ namespace Raven.Server.Documents.Replication
                     switch (header.AuthorizeInfo.AuthorizeAs)
                     {
                         case TcpConnectionHeaderMessage.AuthorizationInfo.AuthorizeMethod.PullReplication:
-                            if ((pullReplicationDefinition.Mode & PullReplicationMode.HubToSink) != PullReplicationMode.HubToSink)
+                            if (pullReplicationDefinition.Mode.HasFlag(PullReplicationMode.HubToSink) == false)
                                 throw new InvalidOperationException($"Replication hub {header.AuthorizeInfo.AuthorizationFor} does not support Pull Replication");
                             CreatePullReplicationAsHub(tcpConnectionOptions, buffer, supportedVersions, pullReplicationDefinition, header);
                             return;
                         case TcpConnectionHeaderMessage.AuthorizationInfo.AuthorizeMethod.PushReplication:
-                            if ((pullReplicationDefinition.Mode & PullReplicationMode.SinkToHub) != PullReplicationMode.SinkToHub)
+                            if (pullReplicationDefinition.Mode.HasFlag(PullReplicationMode.SinkToHub) == false)
                                 throw new InvalidOperationException($"Replication hub {header.AuthorizeInfo.AuthorizationFor} does not support Push Replication");
                             if (certificate == null)
                                 throw new InvalidOperationException("Incoming filtered replication is only supported when using a certificate");
@@ -372,7 +372,13 @@ namespace Raven.Server.Documents.Replication
         public void RunPullReplicationAsSink(TcpConnectionOptions tcpConnectionOptions, JsonOperationContext.MemoryBuffer buffer, PullReplicationAsSink destination)
         {
             string[] allowedPaths = DetailedReplicationHubAccess.Preferred(destination.AllowedHubToSinkPaths, destination.AllowedSinkToHubPaths);
-            var newIncoming = CreateIncomingReplicationHandler(tcpConnectionOptions, buffer, allowedPaths, destination.HubName);
+            var pullParams = new IncomingPullReplicationParams
+            {
+                Name = destination.HubName,
+                AllowedPaths = allowedPaths,
+                Mode = PullReplicationMode.HubToSink
+            };
+            var newIncoming = CreateIncomingReplicationHandler(tcpConnectionOptions, buffer, pullParams);
             newIncoming.Failed += RetryPullReplication;
 
             PoolOfThreads.PooledThread.ResetCurrentThreadName();
@@ -403,7 +409,18 @@ namespace Raven.Server.Documents.Replication
         private void CreateIncomingInstance(TcpConnectionOptions tcpConnectionOptions, string[] allowedPaths, string pullReplicationName,
                         JsonOperationContext.MemoryBuffer buffer)
         {
-            var newIncoming = CreateIncomingReplicationHandler(tcpConnectionOptions, buffer, allowedPaths, pullReplicationName);
+            IncomingPullReplicationParams pullParams = null;
+            if (pullReplicationName != null)
+            {
+                pullParams = new IncomingPullReplicationParams
+                {
+                    Name = pullReplicationName,
+                    AllowedPaths = allowedPaths,
+                    Mode = PullReplicationMode.SinkToHub
+                };
+            }
+            
+            var newIncoming = CreateIncomingReplicationHandler(tcpConnectionOptions, buffer, pullParams);
             newIncoming.Failed += OnIncomingReceiveFailed;
 
             // need to safeguard against two concurrent connection attempts
@@ -426,21 +443,26 @@ namespace Raven.Server.Documents.Replication
             }
         }
 
+        public class IncomingPullReplicationParams
+        {
+            public string Name;
+            public string[] AllowedPaths;
+            public PullReplicationMode Mode;
+        }
+
         private IncomingReplicationHandler CreateIncomingReplicationHandler(
             TcpConnectionOptions tcpConnectionOptions,
             JsonOperationContext.MemoryBuffer buffer,
-            string[] allowedPaths,
-            string pullReplicationName)
+            IncomingPullReplicationParams incomingPullParams)
         {
-            var getLatestEtagMessage = IncomingInitialHandshake(tcpConnectionOptions, allowedPaths, buffer);
+            var getLatestEtagMessage = IncomingInitialHandshake(tcpConnectionOptions, incomingPullParams?.AllowedPaths, buffer);
 
             var newIncoming = new IncomingReplicationHandler(
                 tcpConnectionOptions,
                 getLatestEtagMessage,
                 this,
                 buffer,
-                allowedPaths,
-                pullReplicationName);
+                incomingPullParams);
 
             newIncoming.DocumentsReceived += OnIncomingReceiveSucceeded;
             return newIncoming;

--- a/src/Raven.Server/Rachis/RachisConsensus.cs
+++ b/src/Raven.Server/Rachis/RachisConsensus.cs
@@ -1933,8 +1933,10 @@ namespace Raven.Server.Rachis
             if (nodeTag == InitialTag)
                 return;
 
-            if (nodeTag.Equals("RAFT"))
-                ThrowInvalidNodeTag(nodeTag, "It is a reserved tag.");
+            if (nodeTag.Equals("RAFT", StringComparison.OrdinalIgnoreCase))
+                ThrowInvalidNodeTag(nodeTag, "RAFT is a reserved tag.");
+            if (nodeTag.Equals("SINK", StringComparison.OrdinalIgnoreCase))
+                ThrowInvalidNodeTag(nodeTag, "SINK is a reserved tag.");
             if (nodeTag.Length > 4)
                 ThrowInvalidNodeTag(nodeTag, "Max node tag length is 4.");
             // Node tag must not contain ':' or '-' chars as they are in use in change vector.

--- a/src/Raven.Server/RavenServer.cs
+++ b/src/Raven.Server/RavenServer.cs
@@ -2493,16 +2493,18 @@ namespace Raven.Server
             {
                 try
                 {
-                    await ServerStore.SendToLeaderAsync(new RegisterReplicationHubAccessCommand(database, hub, new ReplicationHubAccess
+                    var access = new ReplicationHubAccess
                     {
                         AllowedHubToSinkPaths = replicationHubAccess.AllowedHubToSinkPaths,
                         AllowedSinkToHubPaths = replicationHubAccess.AllowedSinkToHubPaths,
                         Name = replicationHubAccess.Name,
                         CertificateBase64 = Convert.ToBase64String(certificate.Export(X509ContentType.Cert)),
-                    }, certificate.GetPublicKeyPinningHash(), certificate.Thumbprint, RaftIdGenerator.NewId(), certificate.Issuer, certificate.Subject, certificate.NotBefore, certificate.NotAfter)
-                    {
-                        RegisteringSamePublicKeyPinningHash = true
-                    })
+                    };
+
+                    await ServerStore.SendToLeaderAsync(new RegisterReplicationHubAccessCommand(database, hub, access, certificate, RaftIdGenerator.NewId())
+                        {
+                            RegisteringSamePublicKeyPinningHash = true
+                        })
                         .ConfigureAwait(false);
                 }
                 catch (Exception e)

--- a/src/Raven.Server/ServerWide/ClusterStateMachine.cs
+++ b/src/Raven.Server/ServerWide/ClusterStateMachine.cs
@@ -1782,17 +1782,7 @@ namespace Raven.Server.ServerWide
             using (Slice.From(context.Allocator, (command.Database + "/" + command.HubName + "/" + command.CertificateThumbprint).ToLowerInvariant(), out var keySlice))
             using (Slice.From(context.Allocator, (command.Database + "/" + command.HubName + "/" + command.CertificatePublicKeyHash).ToLowerInvariant(),
                 out var publicKeySlice))
-            using (var obj = context.ReadObject(new DynamicJsonValue
-            {
-                [nameof(command.AllowedHubToSinkPaths)] = command.AllowedHubToSinkPaths,
-                [nameof(command.AllowedSinkToHubPaths)] = command.AllowedSinkToHubPaths,
-                [nameof(command.HubName)] = command.HubName,
-                [nameof(command.Issuer)] = command.Issuer,
-                [nameof(command.NotBefore)] = command.NotBefore,
-                [nameof(command.NotAfter)] = command.NotAfter,
-                [nameof(command.Subject)] = command.Subject,
-                [nameof(command.Name)] = command.Name,
-            }, "inner-val"))
+            using (var obj = context.ReadObject(command.PrepareForStorage(), "inner-val"))
             {
                 if (_clusterAuditLog.IsInfoEnabled)
                     _clusterAuditLog.Info(
@@ -1813,7 +1803,7 @@ namespace Raven.Server.ServerWide
                     }
                 }
 
-                if (!command.RegisteringSamePublicKeyPinningHash)
+                if (command.RegisteringSamePublicKeyPinningHash == false)
                     return;
 
                 // here we'll clear the old values

--- a/src/Raven.Server/Smuggler/Documents/DatabaseDestination.cs
+++ b/src/Raven.Server/Smuggler/Documents/DatabaseDestination.cs
@@ -1639,8 +1639,7 @@ namespace Raven.Server.Smuggler.Documents
                 byte[] buffer = Convert.FromBase64String(access.CertificateBase64);
                 using var cert = new X509Certificate2(buffer);
 
-                _commands.Add(new RegisterReplicationHubAccessCommand(_database.Name,hub,access, cert.GetPublicKeyPinningHash(),
-                    cert.Thumbprint,RaftIdGenerator.DontCareId,cert.Issuer, cert.Subject, cert.NotBefore, cert.NotAfter));
+                _commands.Add(new RegisterReplicationHubAccessCommand(_database.Name, hub, access, cert, RaftIdGenerator.DontCareId));
 
                 if (_commands.Count < batchSize)
                     return;

--- a/test/SlowTests/Issues/FilteredReplicationTests.cs
+++ b/test/SlowTests/Issues/FilteredReplicationTests.cs
@@ -4,6 +4,7 @@ using System.IO;
 using System.Security.Cryptography.X509Certificates;
 using System.Text;
 using System.Threading.Tasks;
+using FastTests.Server.Replication;
 using Raven.Client.Documents;
 using Raven.Client.Documents.Operations.ConnectionStrings;
 using Raven.Client.Documents.Operations.ETL;
@@ -13,17 +14,17 @@ using Raven.Client.Documents.Session;
 using Raven.Client.Documents.Session.TimeSeries;
 using Raven.Client.Documents.Smuggler;
 using Raven.Client.Exceptions;
+using Raven.Client.ServerWide;
 using Raven.Client.ServerWide.Operations.Certificates;
 using Raven.Server.Documents;
 using Raven.Server.Documents.Replication;
 using Raven.Server.ServerWide.Context;
-using Tests.Infrastructure;
 using Xunit;
 using Xunit.Abstractions;
 
 namespace SlowTests.Issues
 {
-    public class FilteredReplicationTests : ClusterTestBase
+    public class FilteredReplicationTests : ReplicationTestBase
     {
         public FilteredReplicationTests(ITestOutputHelper output) : base(output)
         {
@@ -621,6 +622,7 @@ namespace SlowTests.Issues
             public bool FromSink1;
             public bool FromSink2;
             public bool Completed;
+            public string Source;
         }
 
         [Fact]
@@ -653,6 +655,7 @@ namespace SlowTests.Issues
             {
                 Name = "both",
                 Mode = PullReplicationMode.SinkToHub | PullReplicationMode.HubToSink,
+                WithFiltering = true
             }));
 
             await hubStore.Maintenance.SendAsync(new RegisterReplicationHubAccessOperation("both", new ReplicationHubAccess
@@ -747,6 +750,299 @@ namespace SlowTests.Issues
                 var sink2GlobalCv = DocumentsStorage.GetDatabaseChangeVector(ctx);
                 Assert.Equal(3, sink2GlobalCv.ToChangeVector().Length);
             }
+
+            async Task SetupSink(DocumentStore sinkStore)
+            {
+                await sinkStore.Maintenance.SendAsync(new PutConnectionStringOperation<RavenConnectionString>(new RavenConnectionString
+                {
+                    Database = hubStore.Database, Name = hubStore.Database + "ConStr", TopologyDiscoveryUrls = hubStore.Urls
+                }));
+                await sinkStore.Maintenance.SendAsync(new UpdatePullReplicationAsSinkOperation(new PullReplicationAsSink
+                {
+                    ConnectionStringName = hubStore.Database + "ConStr",
+                    Mode = PullReplicationMode.SinkToHub | PullReplicationMode.HubToSink,
+                    CertificateWithPrivateKey = Convert.ToBase64String(pullCert.Export(X509ContentType.Pfx)),
+                    HubName = "both",
+                    AllowedHubToSinkPaths = new[] {"*",},
+                    AllowedSinkToHubPaths = new[] {"*"}
+                }));
+            }
+        }
+
+        
+        [Fact]
+        public async Task Sinks_should_not_update_hubs_change_vector_with_conflicts()
+        {
+            var certificates = SetupServerAuthentication();
+            var adminCert = RegisterClientCertificate(certificates.ServerCertificate.Value, certificates
+                .ClientCertificate1.Value, new Dictionary<string, DatabaseAccess>(), SecurityClearance.ClusterAdmin);
+
+            using var hubStore = GetDocumentStore(new Options
+            {
+                AdminCertificate = adminCert,
+                ClientCertificate = adminCert,
+            });
+            using var sinkStore1 = GetDocumentStore(new Options
+            {
+                AdminCertificate = adminCert,
+                ClientCertificate = adminCert,
+            });
+            using var sinkStore2 = GetDocumentStore(new Options
+            {
+                AdminCertificate = adminCert,
+                ClientCertificate = adminCert,
+            });
+
+            using (var s = sinkStore1.OpenAsyncSession())
+            {
+                await s.StoreAsync(new Propagation
+                {
+                    Source = "Sink1"
+                }, "common");
+                await s.SaveChangesAsync();
+            }
+
+            using (var s = sinkStore2.OpenAsyncSession())
+            {
+                await s.StoreAsync(new Propagation
+                {
+                    Source = "Sink2"
+                }, "common");
+                await s.SaveChangesAsync();
+            }
+
+            using (var s = hubStore.OpenAsyncSession())
+            {
+                await s.StoreAsync(new Propagation
+                {
+                    Source = "Hub"
+                }, "common");
+                await s.SaveChangesAsync();
+            }
+
+            var pullCert = new X509Certificate2(File.ReadAllBytes(certificates.ClientCertificate2Path), (string)null,
+                X509KeyStorageFlags.Exportable);
+
+            await hubStore.Maintenance.SendAsync(new PutPullReplicationAsHubOperation(new PullReplicationDefinition
+            {
+                Name = "both",
+                Mode = PullReplicationMode.SinkToHub | PullReplicationMode.HubToSink,
+                WithFiltering = true
+            }));
+
+            await hubStore.Maintenance.SendAsync(new RegisterReplicationHubAccessOperation("both", new ReplicationHubAccess
+            {
+                Name = "Arava",
+                AllowedSinkToHubPaths = new[]
+                {
+                    "*",
+                },
+                AllowedHubToSinkPaths = new[]
+                {
+                    "*"
+                },
+                CertificateBase64 = Convert.ToBase64String(pullCert.Export(X509ContentType.Cert)),
+            }));
+
+            await SetupSink(sinkStore1);
+            await SetupSink(sinkStore2);
+
+            EnsureReplicating(hubStore, sinkStore1);
+            EnsureReplicating(sinkStore1,hubStore);
+            
+            EnsureReplicating(hubStore, sinkStore2);
+            EnsureReplicating(sinkStore2,hubStore);
+
+            EnsureReplicating(sinkStore1, sinkStore2);
+            EnsureReplicating(sinkStore2,sinkStore1);
+            
+            Assert.True(WaitForDocument<Propagation>(hubStore, "common", x => x.Source == "Hub"));
+            Assert.True(WaitForDocument<Propagation>(sinkStore1, "common", x => x.Source  == "Hub"));
+            Assert.True(WaitForDocument<Propagation>(sinkStore2, "common", x => x.Source  == "Hub"));
+
+            var hubDb = await GetDocumentDatabaseInstanceFor(hubStore);
+            var sink1Db = await GetDocumentDatabaseInstanceFor(sinkStore1);
+            var sink2Db = await GetDocumentDatabaseInstanceFor(sinkStore2);
+
+            using (hubDb.DocumentsStorage.ContextPool.AllocateOperationContext(out DocumentsOperationContext ctx))
+            using (ctx.OpenReadTransaction())
+            {
+                var hubGlobalCv = DocumentsStorage.GetDatabaseChangeVector(ctx);
+                Assert.Equal(1, hubGlobalCv.ToChangeVector().Length);
+            }
+
+            using (sink1Db.DocumentsStorage.ContextPool.AllocateOperationContext(out DocumentsOperationContext ctx))
+            using (ctx.OpenReadTransaction())
+            {
+                var sink1GlobalCv = DocumentsStorage.GetDatabaseChangeVector(ctx);
+                Assert.Equal(3, sink1GlobalCv.ToChangeVector().Length);
+            }
+
+            using (sink2Db.DocumentsStorage.ContextPool.AllocateOperationContext(out DocumentsOperationContext ctx))
+            using (ctx.OpenReadTransaction())
+            {
+                var sink2GlobalCv = DocumentsStorage.GetDatabaseChangeVector(ctx);
+                Assert.Equal(3, sink2GlobalCv.ToChangeVector().Length);
+            }
+
+            await EnsureNoReplicationLoop(Server, hubStore.Database);
+            await EnsureNoReplicationLoop(Server, sinkStore1.Database);
+            await EnsureNoReplicationLoop(Server, sinkStore2.Database);
+
+            async Task SetupSink(DocumentStore sinkStore)
+            {
+                await sinkStore.Maintenance.SendAsync(new PutConnectionStringOperation<RavenConnectionString>(new RavenConnectionString
+                {
+                    Database = hubStore.Database, Name = hubStore.Database + "ConStr", TopologyDiscoveryUrls = hubStore.Urls
+                }));
+                await sinkStore.Maintenance.SendAsync(new UpdatePullReplicationAsSinkOperation(new PullReplicationAsSink
+                {
+                    ConnectionStringName = hubStore.Database + "ConStr",
+                    Mode = PullReplicationMode.SinkToHub | PullReplicationMode.HubToSink,
+                    CertificateWithPrivateKey = Convert.ToBase64String(pullCert.Export(X509ContentType.Pfx)),
+                    HubName = "both",
+                    AllowedHubToSinkPaths = new[] {"*",},
+                    AllowedSinkToHubPaths = new[] {"*"}
+                }));
+            }
+        }
+
+        [Fact]
+        public async Task Sinks_should_not_update_hubs_change_vector_with_conflicts2()
+        {
+            var certificates = SetupServerAuthentication();
+            var adminCert = RegisterClientCertificate(certificates.ServerCertificate.Value, certificates
+                .ClientCertificate1.Value, new Dictionary<string, DatabaseAccess>(), SecurityClearance.ClusterAdmin);
+
+            using var hubStore = GetDocumentStore(new Options
+            {
+                AdminCertificate = adminCert,
+                ClientCertificate = adminCert,
+                ModifyDatabaseRecord = r => r.ConflictSolverConfig = new ConflictSolver
+                {
+                    ResolveToLatest = false
+                }
+            });
+            using var sinkStore1 = GetDocumentStore(new Options
+            {
+                AdminCertificate = adminCert,
+                ClientCertificate = adminCert,
+                ModifyDatabaseRecord = r => r.ConflictSolverConfig = new ConflictSolver
+                {
+                    ResolveToLatest = false
+                }
+            });
+            using var sinkStore2 = GetDocumentStore(new Options
+            {
+                AdminCertificate = adminCert,
+                ClientCertificate = adminCert,
+                ModifyDatabaseRecord = r => r.ConflictSolverConfig = new ConflictSolver
+                {
+                    ResolveToLatest = false
+                }
+            });
+
+            using (var s = sinkStore1.OpenAsyncSession())
+            {
+                await s.StoreAsync(new Propagation
+                {
+                    Source = "Sink1"
+                }, "common");
+                await s.SaveChangesAsync();
+            }
+
+            using (var s = sinkStore2.OpenAsyncSession())
+            {
+                await s.StoreAsync(new Propagation
+                {
+                    Source = "Sink2"
+                }, "common");
+                await s.SaveChangesAsync();
+            }
+
+            using (var s = hubStore.OpenAsyncSession())
+            {
+                await s.StoreAsync(new Propagation
+                {
+                    Source = "Hub"
+                }, "common");
+                await s.SaveChangesAsync();
+            }
+
+            var pullCert = new X509Certificate2(File.ReadAllBytes(certificates.ClientCertificate2Path), (string)null,
+                X509KeyStorageFlags.Exportable);
+
+            await hubStore.Maintenance.SendAsync(new PutPullReplicationAsHubOperation(new PullReplicationDefinition
+            {
+                Name = "both",
+                Mode = PullReplicationMode.SinkToHub | PullReplicationMode.HubToSink,
+                WithFiltering = true
+            }));
+
+            await hubStore.Maintenance.SendAsync(new RegisterReplicationHubAccessOperation("both", new ReplicationHubAccess
+            {
+                Name = "Arava",
+                AllowedSinkToHubPaths = new[]
+                {
+                    "*",
+                },
+                AllowedHubToSinkPaths = new[]
+                {
+                    "*"
+                },
+                CertificateBase64 = Convert.ToBase64String(pullCert.Export(X509ContentType.Cert)),
+            }));
+
+            await SetupSink(sinkStore1);
+            await SetupSink(sinkStore2);
+
+            EnsureReplicating(hubStore, sinkStore1);
+            EnsureReplicating(sinkStore1,hubStore);
+            
+            EnsureReplicating(hubStore, sinkStore2);
+            EnsureReplicating(sinkStore2,hubStore);
+
+            EnsureReplicating(sinkStore1, sinkStore2);
+            EnsureReplicating(sinkStore2,sinkStore1);
+
+            await WaitForConflict(hubStore, "common");
+            await WaitForConflict(sinkStore1, "common");
+            await WaitForConflict(sinkStore2, "common");
+
+            await UpdateConflictResolver(hubStore, resolveToLatest: true);
+
+            Assert.True(WaitForDocument<Propagation>(hubStore, "common", x => x.Source == "Hub"));
+            Assert.True(WaitForDocument<Propagation>(sinkStore1, "common", x => x.Source  == "Hub"));
+            Assert.True(WaitForDocument<Propagation>(sinkStore2, "common", x => x.Source  == "Hub"));
+
+            var hubDb = await GetDocumentDatabaseInstanceFor(hubStore);
+            var sink1Db = await GetDocumentDatabaseInstanceFor(sinkStore1);
+            var sink2Db = await GetDocumentDatabaseInstanceFor(sinkStore2);
+
+            using (hubDb.DocumentsStorage.ContextPool.AllocateOperationContext(out DocumentsOperationContext ctx))
+            using (ctx.OpenReadTransaction())
+            {
+                var hubGlobalCv = DocumentsStorage.GetDatabaseChangeVector(ctx);
+                Assert.Equal(1, hubGlobalCv.ToChangeVector().Length);
+            }
+
+            using (sink1Db.DocumentsStorage.ContextPool.AllocateOperationContext(out DocumentsOperationContext ctx))
+            using (ctx.OpenReadTransaction())
+            {
+                var sink1GlobalCv = DocumentsStorage.GetDatabaseChangeVector(ctx);
+                Assert.Equal(3, sink1GlobalCv.ToChangeVector().Length);
+            }
+
+            using (sink2Db.DocumentsStorage.ContextPool.AllocateOperationContext(out DocumentsOperationContext ctx))
+            using (ctx.OpenReadTransaction())
+            {
+                var sink2GlobalCv = DocumentsStorage.GetDatabaseChangeVector(ctx);
+                Assert.Equal(3, sink2GlobalCv.ToChangeVector().Length);
+            }
+
+            await EnsureNoReplicationLoop(Server, hubStore.Database);
+            await EnsureNoReplicationLoop(Server, sinkStore1.Database);
+            await EnsureNoReplicationLoop(Server, sinkStore2.Database);
 
             async Task SetupSink(DocumentStore sinkStore)
             {

--- a/test/SlowTests/Issues/RavenDB_6292.cs
+++ b/test/SlowTests/Issues/RavenDB_6292.cs
@@ -82,7 +82,7 @@ namespace SlowTests.Issues
 
                 await SetupReplicationAsync(store1, store2);
 
-                WaitForConflict(store2, "addresses/1");
+                await WaitForConflict(store2, "addresses/1");
 
                 using (var session = store2.OpenSession())
                 {
@@ -216,8 +216,8 @@ namespace SlowTests.Issues
 
                 await SetupReplicationAsync(store1, store2);
 
-                WaitForConflict(store2, "companies/1");
-                WaitForConflict(store2, "companies/2");
+                await WaitForConflict(store2, "companies/1");
+                await WaitForConflict(store2, "companies/2");
 
                 var database = await GetDocumentDatabaseInstanceFor(store2);
                 database.Time.UtcDateTime = () => DateTime.UtcNow.AddMinutes(10);
@@ -244,29 +244,6 @@ namespace SlowTests.Issues
             };
 
             await ExpirationHelper.SetupExpiration(store, Server.ServerStore, config);
-        }
-
-        private static void WaitForConflict(IDocumentStore store, string id)
-        {
-            var sw = Stopwatch.StartNew();
-            while (sw.Elapsed < TimeSpan.FromSeconds(10))
-            {
-                try
-                {
-                    using (var session = store.OpenSession())
-                    {
-                        session.Load<dynamic>(id);
-                    }
-
-                    Thread.Sleep(10);
-                }
-                catch (ConflictException)
-                {
-                    return;
-                }
-            }
-
-            throw new InvalidOperationException($"Waited '{sw.Elapsed}' for conflict on '{id}' but it did not happen.");
         }
     }
 }

--- a/test/SlowTests/Server/RecordingTransactionOperationsMergerTests.cs
+++ b/test/SlowTests/Server/RecordingTransactionOperationsMergerTests.cs
@@ -1072,30 +1072,6 @@ namespace SlowTests.Server
             throw new InvalidOperationException($"Waited '{sw.Elapsed}' for conflict to be resolved on '{id}' but it did not happen.");
         }
 
-        private static async Task WaitForConflict(IDocumentStore slave, string id, int timeout = 15_000)
-        {
-            var timeoutAsTimeSpan = TimeSpan.FromMilliseconds(timeout);
-            var sw = Stopwatch.StartNew();
-
-            while (sw.Elapsed < timeoutAsTimeSpan)
-            {
-                using (var session = slave.OpenAsyncSession())
-                {
-                    try
-                    {
-                        await session.LoadAsync<User>(id);
-                        await Task.Delay(100);
-                    }
-                    catch (ConflictException)
-                    {
-                        return;
-                    }
-                }
-            }
-
-            throw new InvalidOperationException($"Waited '{sw.Elapsed}' for conflict on '{id}' but it did not happen.");
-        }
-
         [Fact]
         public async Task RecordingDeleteAttachmentCommand()
         {

--- a/test/SlowTests/Server/RecordingTransactionOperationsMergerTests.cs
+++ b/test/SlowTests/Server/RecordingTransactionOperationsMergerTests.cs
@@ -656,7 +656,7 @@ namespace SlowTests.Server
                 store.Maintenance.Send(new StartTransactionsRecordingOperation(recordFilePath));
 
                 var command = new IncomingReplicationHandler.MergedUpdateDatabaseChangeVectorCommand(
-                    expectedChangeVector, 5, Guid.NewGuid().ToString(), new AsyncManualResetEvent());
+                    expectedChangeVector, 5, Guid.NewGuid().ToString(), new AsyncManualResetEvent(), isHub: false);
 
                 var database = await GetDocumentDatabaseInstanceFor(store);
                 await database.TxMerger.Enqueue(command);

--- a/test/Tests.Infrastructure/RavenTestBase.cs
+++ b/test/Tests.Infrastructure/RavenTestBase.cs
@@ -846,6 +846,30 @@ namespace FastTests
             return mre;
         }
 
+        protected static async Task WaitForConflict(IDocumentStore slave, string id, int timeout = 15_000)
+        {
+            var timeoutAsTimeSpan = TimeSpan.FromMilliseconds(timeout);
+            var sw = Stopwatch.StartNew();
+
+            while (sw.Elapsed < timeoutAsTimeSpan)
+            {
+                using (var session = slave.OpenAsyncSession())
+                {
+                    try
+                    {
+                        await session.LoadAsync<dynamic>(id);
+                        await Task.Delay(100);
+                    }
+                    catch (ConflictException)
+                    {
+                        return;
+                    }
+                }
+            }
+
+            throw new InvalidOperationException($"Waited '{sw.Elapsed}' for conflict on '{id}' but it did not happen.");
+        }
+
         protected static bool WaitForCounterReplication(IEnumerable<IDocumentStore> stores, string docId, string counterName, long expected, TimeSpan timeout)
         {
             long? val = null;


### PR DESCRIPTION
Note that we do not change the change vector of the document itself, but only the global database change vector.