### PR TITLE
RavenDB-15107  Filtered replication - Changed to Internal

### DIFF
--- a/src/Raven.Client/Documents/Operations/Replication/DetailedReplicationHubAccess.cs
+++ b/src/Raven.Client/Documents/Operations/Replication/DetailedReplicationHubAccess.cs
@@ -22,7 +22,7 @@ namespace Raven.Client.Documents.Operations.Replication
         }
     }
 
-    public class ReplicationHubAccessResponse
+    internal class ReplicationHubAccessResponse
     {
         public long RaftCommandIndex { get; set; }
     }


### PR DESCRIPTION
Leaving `'Response'` for now as `ReplicationHubAccessResult` is already used in

https://github.com/ravendb/ravendb/blob/dd4d680c333b5a72be837f47c21e1f91b92729d8/src/Raven.Client/Documents/Operations/Replication/ReplicationHubAccessResult.cs#L3