### PR TITLE
RavenDB-14229 Allow to group by additional values from the timeseries tag

### DIFF
--- a/src/Raven.Client/Documents/Queries/TimeSeries/TimeSeriesAggregation.cs
+++ b/src/Raven.Client/Documents/Queries/TimeSeries/TimeSeriesAggregation.cs
@@ -146,7 +146,7 @@ namespace Raven.Client.Documents.Queries.TimeSeries
         public double[] Max, Min, Last, First, Average, Sum;
         public DateTime To, From;
 
-        public string Key { get; private set; }
+        public object Key { get; private set; }
 
         [OnDeserialized]
         internal void OnNewtonSoftJsonDeserialized(StreamingContext context)

--- a/src/Raven.Client/Documents/Queries/TimeSeries/TimeSeriesAggregation.cs
+++ b/src/Raven.Client/Documents/Queries/TimeSeries/TimeSeriesAggregation.cs
@@ -118,7 +118,7 @@ namespace Raven.Client.Documents.Queries.TimeSeries
 
         [JsonIgnore]
         private TimeSeriesStreamEnumerator<TResult> _timeSeriesStream;
-
+        
         void ITimeSeriesQueryStreamResult.SetStream(StreamOperation.TimeSeriesStreamEnumerator stream)
         {
             _timeSeriesStream = new TimeSeriesStreamEnumerator<TResult>(stream);
@@ -145,6 +145,8 @@ namespace Raven.Client.Documents.Queries.TimeSeries
         public long[] Count;
         public double[] Max, Min, Last, First, Average, Sum;
         public DateTime To, From;
+
+        public string Key { get; private set; }
 
         [OnDeserialized]
         internal void OnNewtonSoftJsonDeserialized(StreamingContext context)

--- a/src/Raven.Client/Documents/Queries/TimeSeries/TimeSeriesQueryable.cs
+++ b/src/Raven.Client/Documents/Queries/TimeSeries/TimeSeriesQueryable.cs
@@ -122,6 +122,6 @@ namespace Raven.Client.Documents.Queries.TimeSeries
     {
         public void WithOptions(TimeSeriesAggregationOptions options);
         public ITimeSeriesAggregationOperations ByTag();
-        public ITimeSeriesAggregationOperations ByTag<TEntity>(Func<TEntity, object> selector);
+        public ITimeSeriesAggregationOperations ByTag<TEntity>(Expression<Func<TEntity, object>> selector);
     }
 }

--- a/src/Raven.Client/Documents/Queries/TimeSeries/TimeSeriesQueryable.cs
+++ b/src/Raven.Client/Documents/Queries/TimeSeries/TimeSeriesQueryable.cs
@@ -121,5 +121,7 @@ namespace Raven.Client.Documents.Queries.TimeSeries
     public interface ITimeSeriesAggregationOperations
     {
         public void WithOptions(TimeSeriesAggregationOptions options);
+        public ITimeSeriesAggregationOperations ByTag();
+        public ITimeSeriesAggregationOperations ByTag<TEntity>(Func<TEntity, object> selector);
     }
 }

--- a/src/Raven.Client/Documents/Queries/TimeSeries/TimeSeriesWhereClauseVisitor.cs
+++ b/src/Raven.Client/Documents/Queries/TimeSeries/TimeSeriesWhereClauseVisitor.cs
@@ -97,9 +97,9 @@ namespace Raven.Client.Documents.Queries.TimeSeries
             return expression is ParameterExpression p && p.Name == _alias;
         }
 
-        private bool ShouldRename(Expression expression)
+        private bool ShouldRename(ParameterExpression expression)
         {
-            return expression is ParameterExpression p && _renameTagAlias.From == p.Name;
+            return _renameTagAlias.From == expression.Name;
         }
 
         protected override Expression VisitConstant(ConstantExpression node)

--- a/src/Raven.Client/Documents/Session/Operations/StreamOperation.cs
+++ b/src/Raven.Client/Documents/Session/Operations/StreamOperation.cs
@@ -202,9 +202,15 @@ namespace Raven.Client.Documents.Session.Operations
                 if (_state.CurrentTokenType != JsonParserToken.StartArray)
                     UnmanagedJsonParserHelper.ThrowInvalidJson(_peepingTomStream);
             }
+            
+            private bool _done;
+            private bool _disposed;
 
             public async ValueTask DisposeAsync()
             {
+                if (_disposed)
+                    return;
+
                 if (_done == false)
                 {
                     while (await MoveNextAsync().ConfigureAwait(false))
@@ -218,9 +224,10 @@ namespace Raven.Client.Documents.Session.Operations
 
                 if (_state.CurrentTokenType != JsonParserToken.EndObject)
                     UnmanagedJsonParserHelper.ThrowInvalidJson(_peepingTomStream);
+
+                _disposed = true;
             }
 
-            private bool _done;
 
             public async ValueTask<bool> MoveNextAsync()
             {

--- a/src/Raven.Server/Documents/Queries/Results/AggregationHolder.cs
+++ b/src/Raven.Server/Documents/Queries/Results/AggregationHolder.cs
@@ -1,0 +1,413 @@
+﻿using System;
+using System.Collections;
+using System.Collections.Generic;
+using System.Diagnostics;
+using System.Linq;
+using Raven.Client.Documents.Queries.TimeSeries;
+using Raven.Server.Documents.Indexes.Static;
+using Raven.Server.Documents.Queries.AST;
+using Sparrow;
+using Sparrow.Json;
+using Sparrow.Json.Parsing;
+using Sparrow.Server;
+using Voron;
+
+namespace Raven.Server.Documents.Queries.Results
+{
+    public class AggregationHolder
+    {
+        // local pool, for current query
+        private readonly ObjectPool<TimeSeriesAggregation[], TimeSeriesAggregationReset> _pool;
+
+        private readonly ByteStringContext _context;
+        private readonly InterpolationType _interpolationType;
+
+        private readonly AggregationType[] _types;
+        private readonly string[] _names;
+
+        private Dictionary<ulong, TimeSeriesAggregation[]> _current;
+        private Dictionary<ulong, PreviousAggregation> _previous;
+
+        private Dictionary<ulong, string> _keyNames;
+        private Dictionary<object, ulong> _keyCache;
+
+        public bool HasValues => _current?.Count > 0;
+
+        public AggregationHolder(ByteStringContext context, Dictionary<AggregationType, string> types, InterpolationType interpolationType)
+        {
+            _context = context;
+
+            _names = types.Values.ToArray();
+            _types = types.Keys.ToArray();
+
+            _interpolationType = interpolationType;
+            _pool = new ObjectPool<TimeSeriesAggregation[], TimeSeriesAggregationReset>(TimeSeriesAggregationFactory);
+        }
+
+        private TimeSeriesAggregation[] TimeSeriesAggregationFactory()
+        {
+            var bucket = new TimeSeriesAggregation[_types.Length];
+            for (int i = 0; i < _types.Length; i++)
+            {
+                var type = _types[i];
+                var name = _names?[i];
+                bucket[i] = new TimeSeriesAggregation(type, name);
+            }
+
+            return bucket;
+        }
+
+
+        public TimeSeriesAggregation[] this[object bucket]
+        {
+            get
+            {
+                var key = GetKey(bucket);
+                _current ??= new Dictionary<ulong, TimeSeriesAggregation[]>();
+                if (_current.TryGetValue(key, out var value))
+                    return value;
+
+                return _current[key] = _pool.Allocate();
+            }
+        }
+
+        public IEnumerable<DynamicJsonValue> AddCurrentToResults(RangeGroup range, double? scale)
+        {
+            if (_interpolationType != InterpolationType.None)
+            {
+                foreach (var gap in FillMissingGaps(range.Start, scale))
+                {
+                    yield return gap;
+                }
+            }
+
+            foreach (var kvp in _current)
+            {
+                var key = kvp.Key;
+                var value = kvp.Value;
+
+                if (value[0].Any == false)
+                    continue;
+
+                yield return ToJson(scale, range.Start, range.End, key, value);
+
+                if (_interpolationType == InterpolationType.None)
+                {
+                    _pool.Free(value);
+                    continue;
+                }
+
+                UpdatePrevious(key, range, value);
+            }
+
+            _current = null;
+        }
+
+        private DynamicJsonValue ToJson(double? scale, DateTime? from, DateTime? to, ulong key, TimeSeriesAggregation[] value)
+        {
+            if (from == DateTime.MinValue)
+                from = null;
+            if (to == DateTime.MaxValue)
+                to = null;
+
+            var result = new DynamicJsonValue
+            {
+                [nameof(TimeSeriesRangeAggregation.From)] = from, 
+                [nameof(TimeSeriesRangeAggregation.To)] = to, 
+                [nameof(TimeSeriesRangeAggregation.Key)] = GetNameFromKey(key)
+            };
+
+            for (int i = 0; i < value.Length; i++)
+            {
+                result[value[i].Name] = new DynamicJsonArray(value[i].GetFinalValues(scale).Cast<object>());
+            }
+
+            return result;
+        }
+
+        private IEnumerable<(ulong Key, PreviousAggregation Previous, TimeSeriesAggregation[] Current)> GetGapsPerBucket(DateTime to)
+        {
+            if (_current == null || _previous == null)
+                yield break;
+
+            foreach (var previous in _previous)
+            {
+                var key = previous.Key;
+                if (_current.ContainsKey(key) == false)
+                    continue;
+
+                var gapData = previous.Value;
+                if (gapData.Range.WithinNextRange(to))
+                    continue;
+
+                yield return (key, previous.Value, _current[key]);
+
+                _previous.Remove(key);
+                _pool.Free(previous.Value.Data);
+            }
+        }
+
+        private string GetNameFromKey(ulong key)
+        {
+            if (_keyNames == null)
+                return null;
+
+            if (_keyNames.TryGetValue(key, out var name))
+                return name;
+
+            return null;
+        }
+
+        private void UpdatePrevious(ulong key, RangeGroup range, TimeSeriesAggregation[] values)
+        {
+            _previous ??= new Dictionary<ulong, PreviousAggregation>();
+            if (_previous.TryGetValue(key, out var result) == false)
+            {
+                result = _previous[key] = new PreviousAggregation();
+            }
+            else
+            {
+                _pool.Free(result.Data);
+            }
+
+            result.Data = values;
+            result.Range = range;
+        }
+
+        private ulong GetKey(object value)
+        {
+            if (value == null)
+                return 0;
+
+            _keyCache ??= new Dictionary<object, ulong>();
+            if (_keyCache.TryGetValue(value, out var key) == false)
+                key = _keyCache[key] = CalculateKey(value);
+
+            _keyNames ??= new Dictionary<ulong, string>();
+            _keyNames.TryAdd(key, value.ToString());
+            return key;
+        }
+
+        private unsafe ulong CalculateKey(object value)
+        {
+            if (value == null || value is DynamicNullObject)
+                return 0;
+
+            if (value is LazyStringValue lsv)
+                return Hashing.XXHash64.Calculate(lsv.Buffer, (ulong)lsv.Size);
+
+            if (value is string s)
+            {
+                using (Slice.From(_context, s, out Slice str))
+                    return Hashing.XXHash64.Calculate(str.Content.Ptr, (ulong)str.Size);
+            }
+
+            if (value is LazyCompressedStringValue lcsv)
+                return Hashing.XXHash64.Calculate(lcsv.Buffer, (ulong)lcsv.CompressedSize);
+
+            if (value is long l)
+            {
+                unchecked
+                {
+                    return (ulong)l;
+                }
+            }
+
+            if (value is ulong ul)
+                return ul;
+
+            if (value is decimal d)
+                return Hashing.XXHash64.Calculate((byte*)&d, sizeof(decimal));
+
+            if (value is int num)
+                return (ulong)num;
+
+            if (value is bool b)
+                return b ? 1UL : 2UL;
+
+            if (value is double dbl)
+                return (ulong)dbl;
+
+            if (value is LazyNumberValue lnv)
+                return CalculateKey(lnv.Inner);
+
+            long? ticks = null;
+            if (value is DateTime time)
+                ticks = time.Ticks;
+            if (value is DateTimeOffset offset)
+                ticks = offset.Ticks;
+            if (value is TimeSpan span)
+                ticks = span.Ticks;
+
+            if (ticks.HasValue)
+            {
+                var t = ticks.Value;
+                return (ulong)t;
+            }
+
+            if (value is BlittableJsonReaderObject json)
+            {
+                var hash = 0UL;
+                var prop = new BlittableJsonReaderObject.PropertyDetails();
+
+                for (int i = 0; i < json.Count; i++)
+                {
+                    // this call ensures properties to be returned in the same order, regardless their storing order
+                    json.GetPropertyByIndex(i, ref prop);
+
+                    hash += CalculateKey(prop.Value);
+                }
+
+                return hash;
+            }
+
+            if (value is IEnumerable enumerable)
+            {
+                var hash = 0UL;
+                foreach (var item in enumerable)
+                {
+                    hash += CalculateKey(item);
+                }
+
+                return hash;
+            }
+
+            if (value is DynamicJsonValue djv)
+            {
+                var hash = 0UL;
+                foreach (var item in djv.Properties)
+                {
+                    hash += CalculateKey(item.Value);
+                }
+
+                return hash;
+            }
+
+            throw new NotSupportedException($"Unable to group by type: {value.GetType()}");
+        }
+
+        public class PreviousAggregation
+        {
+            public RangeGroup Range;
+
+            public TimeSeriesAggregation[] Data;
+        }
+
+        private IEnumerable<DynamicJsonValue> FillMissingGaps(DateTime to, double? scale)
+        {
+            foreach (var result in GetGapsPerBucket(to))
+            {
+                var gapData = result.Previous;
+
+                var from = gapData.Range.Start; // we have this point
+                gapData.Range.MoveToNextRange();
+
+                var start = gapData.Range.Start; // this one we miss
+                var end = gapData.Range.End;
+
+                var startData = result.Previous.Data;
+                var endData = result.Current;
+
+                Debug.Assert(start < to, "Invalid gap data");
+
+                var point = start;
+
+                switch (_interpolationType)
+                {
+                    case InterpolationType.Linear:
+                        
+                        Debug.Assert(startData.Length == endData.Length, "Invalid aggregation stats");
+
+                        var numberOfAggregations = startData.Length;
+                        var initial = new List<double>[numberOfAggregations];
+                        var final = new List<double>[numberOfAggregations];
+                        for (int i = 0; i < numberOfAggregations; i++)
+                        {
+                            Debug.Assert(startData[i].Aggregation == endData[i].Aggregation, "Invalid aggregation type");
+                            initial[i] = new List<double>(startData[i].GetFinalValues(scale));
+                            final[i] = new List<double>(endData[i].GetFinalValues(scale));
+                        }
+
+                        var numberOfValues = Math.Min(startData[0].NumberOfValues, endData[0].NumberOfValues);
+                        var interpolated = new double[numberOfValues];
+
+                        while (start < to)
+                        {
+                            var gap = new DynamicJsonValue
+                            {
+                                [nameof(TimeSeriesRangeAggregation.From)] = start,
+                                [nameof(TimeSeriesRangeAggregation.To)] = end,
+                                [nameof(TimeSeriesRangeAggregation.Key)] = GetNameFromKey(result.Key)
+                            };
+
+                            var quotient = (double)(point.Ticks - from.Ticks) / (to.Ticks - from.Ticks);
+                            for (int i = 0; i < startData.Length; i++)
+                            {
+                                LinearInterpolation(quotient, initial[i], final[i], interpolated);
+                                gap[startData[i].Name] = new DynamicJsonArray(interpolated.Cast<object>());
+                            }
+                            
+                            yield return gap;
+
+                            gapData.Range.MoveToNextRange();
+                            start = gapData.Range.Start;
+                            end = gapData.Range.End;
+
+                            point = start;
+                        }
+
+                        break;
+                    case InterpolationType.Nearest:
+
+                        while (start < to)
+                        {
+                            var nearest = point - from <= to - point
+                                ? startData
+                                : endData;
+
+                            yield return ToJson(scale, start, end, result.Key, nearest);
+
+                            gapData.Range.MoveToNextRange();
+                            start = gapData.Range.Start;
+                            end = gapData.Range.End;
+
+                            point = start;
+                        }
+
+                        break;
+                    default:
+                        throw new ArgumentOutOfRangeException("Unknown InterpolationType : " + _interpolationType);
+                }
+            }
+        }
+
+        private static void LinearInterpolation(double quotient, List<double> valuesA, List<double> valuesB, double[] result)
+        {
+            var minLength = Math.Min(valuesA.Count, valuesB.Count);
+            if (minLength < valuesA.Count)
+            {
+                valuesA.RemoveRange(minLength - 1, valuesA.Count - minLength);
+            }
+
+            for (var index = 0; index < minLength; index++)
+            {
+                var yb = valuesB[index];
+                var ya = valuesA[index];
+
+                // y = yA + (yB - yA) * ((x - xa) / (xb - xa))
+                result[index] = ya + (yb - ya) * quotient;
+            }
+        }
+
+        private struct TimeSeriesAggregationReset : IResetSupport<TimeSeriesAggregation[]>
+        {
+            public void Reset(TimeSeriesAggregation[] values)
+            {
+                for (var index = 0; index < values.Length; index++)
+                {
+                    values[index].Init();
+                }
+            }
+        }
+    }
+}

--- a/src/Raven.Server/Documents/TimeSeries/TimeSeriesReader.cs
+++ b/src/Raven.Server/Documents/TimeSeries/TimeSeriesReader.cs
@@ -4,7 +4,6 @@ using System.Collections.Generic;
 using System.Linq;
 using Raven.Client.Documents.Operations.TimeSeries;
 using Raven.Client.Documents.Session.TimeSeries;
-using Raven.Server.Documents.Queries.AST;
 using Raven.Server.ServerWide.Context;
 using Sparrow;
 using Sparrow.Binary;

--- a/src/Sparrow/Json/LazyStringValue.cs
+++ b/src/Sparrow/Json/LazyStringValue.cs
@@ -144,6 +144,11 @@ namespace Sparrow.Json
             Memory.Copy(dest, _buffer, _size);
         }
 
+        public LazyStringValue Clone(JsonOperationContext context)
+        {
+            return context.GetLazyString(_buffer, _size);
+        }
+
         public bool HasStringValue => _string != null;
 
         [ThreadStatic]

--- a/test/SlowTests/Client/TimeSeries/Query/TimeSeriesGroupByTag.cs
+++ b/test/SlowTests/Client/TimeSeries/Query/TimeSeriesGroupByTag.cs
@@ -86,7 +86,7 @@ namespace SlowTests.Client.TimeSeries.Query
             }
         }
 
-         [Fact]
+        [Fact]
         public void CanGroupByTagLinq()
         {
             using (var store = GetDocumentStore())

--- a/test/SlowTests/Client/TimeSeries/Query/TimeSeriesGroupByTag.cs
+++ b/test/SlowTests/Client/TimeSeries/Query/TimeSeriesGroupByTag.cs
@@ -1,0 +1,579 @@
+﻿using System;
+using System.Collections.Generic;
+using System.Linq;
+using FastTests;
+using Raven.Client.Documents;
+using Raven.Client.Documents.Linq;
+using Raven.Client.Documents.Queries;
+using Raven.Client.Documents.Queries.TimeSeries;
+using Raven.Tests.Core.Utils.Entities;
+using Sparrow;
+using Xunit;
+using Xunit.Abstractions;
+
+namespace SlowTests.Client.TimeSeries.Query
+{
+    public class TimeSeriesGroupByTag : RavenTestBase
+    {
+        public TimeSeriesGroupByTag(ITestOutputHelper output) : base(output)
+        {
+        }
+
+        [Fact]
+        public void CanGroupByTagRql()
+        {
+            using (var store = GetDocumentStore())
+            {
+                var baseline = RavenTestHelper.UtcToday;
+
+                using (var session = store.OpenSession())
+                {
+                    session.Store(new { Name = "Oren" }, "users/ayende");
+
+                    var tsf = session.TimeSeriesFor("users/ayende", "Heartrate");
+                    tsf.Append(baseline.AddMinutes(61), new[] { 59d }, "watches/fitbit");
+                    tsf.Append(baseline.AddMinutes(62), new[] { 79d }, "watches/fitbit");
+                    tsf.Append(baseline.AddMinutes(63), new[] { 69d }, "watches/apple");
+
+                    session.SaveChanges();
+                }
+
+                using (var session = store.OpenSession())
+                {
+                    var query = session.Advanced.RawQuery<TimeSeriesAggregationResult>(@"
+    declare timeseries out(u) 
+    {
+        from u.Heartrate between $start and $end
+        group by 1h, tag
+        select min(), max(), first(), last()
+    }
+    from @all_docs as u
+    where id() == 'users/ayende'
+    select out(u)
+")
+                        .AddParameter("start", baseline.EnsureUtc())
+                        .AddParameter("end", baseline.AddDays(1).EnsureUtc());
+
+                    var agg = query.First();
+                    
+                    Assert.Equal(3, agg.Count);
+
+                    Assert.Equal(2, agg.Results.Length);
+
+                    var val1 = agg.Results[0];
+
+                    Assert.Equal(59, val1.First[0]);
+                    Assert.Equal(59, val1.Min[0]);
+
+                    Assert.Equal(79, val1.Last[0]);
+                    Assert.Equal(79, val1.Max[0]);
+
+                    Assert.Equal(baseline.AddMinutes(60), val1.From, RavenTestHelper.DateTimeComparer.Instance);
+                    Assert.Equal(baseline.AddMinutes(120), val1.To, RavenTestHelper.DateTimeComparer.Instance);
+
+                    var val2 = agg.Results[1];
+
+                    Assert.Equal(69, val2.First[0]);
+                    Assert.Equal(69, val2.Min[0]);
+
+                    Assert.Equal(69, val2.Last[0]);
+                    Assert.Equal(69, val2.Max[0]);
+
+                    Assert.Equal(baseline.AddMinutes(60), val2.From, RavenTestHelper.DateTimeComparer.Instance);
+                    Assert.Equal(baseline.AddMinutes(120), val2.To, RavenTestHelper.DateTimeComparer.Instance);
+                }
+            }
+        }
+
+         [Fact]
+        public void CanGroupByTagLinq()
+        {
+            using (var store = GetDocumentStore())
+            {
+                var baseline = RavenTestHelper.UtcToday;
+
+                using (var session = store.OpenSession())
+                {
+                    session.Store(new User { Name = "Oren" }, "users/ayende");
+
+                    var tsf = session.TimeSeriesFor("users/ayende", "Heartrate");
+                    tsf.Append(baseline.AddMinutes(61), new[] { 59d }, "watches/fitbit");
+                    tsf.Append(baseline.AddMinutes(62), new[] { 79d }, "watches/fitbit");
+                    tsf.Append(baseline.AddMinutes(63), new[] { 69d }, "watches/apple");
+
+                    session.SaveChanges();
+                }
+
+                using (var session = store.OpenSession())
+                {
+                    var query = session.Query<User>()
+                        .Select(u => RavenQuery.TimeSeries(u, "Heartrate",baseline.EnsureUtc(), baseline.AddDays(1).EnsureUtc())
+                            .GroupBy(g => g
+                                    .Hours(1)
+                                    .ByTag()
+                                   )
+                            .Select(g => new
+                            {
+                                First = g.First(),
+                                Max = g.Max(),
+                                Min = g.Min(),
+                                Last = g.Last(),
+                            })
+                            .ToList());
+
+                    var agg = query.First();
+                    
+                    Assert.Equal(3, agg.Count);
+
+                    Assert.Equal(2, agg.Results.Length);
+
+                    var val1 = agg.Results[0];
+
+                    Assert.Equal(59, val1.First[0]);
+                    Assert.Equal(59, val1.Min[0]);
+
+                    Assert.Equal(79, val1.Last[0]);
+                    Assert.Equal(79, val1.Max[0]);
+
+                    Assert.Equal(baseline.AddMinutes(60), val1.From, RavenTestHelper.DateTimeComparer.Instance);
+                    Assert.Equal(baseline.AddMinutes(120), val1.To, RavenTestHelper.DateTimeComparer.Instance);
+
+                    var val2 = agg.Results[1];
+
+                    Assert.Equal(69, val2.First[0]);
+                    Assert.Equal(69, val2.Min[0]);
+
+                    Assert.Equal(69, val2.Last[0]);
+                    Assert.Equal(69, val2.Max[0]);
+
+                    Assert.Equal(baseline.AddMinutes(60), val2.From, RavenTestHelper.DateTimeComparer.Instance);
+                    Assert.Equal(baseline.AddMinutes(120), val2.To, RavenTestHelper.DateTimeComparer.Instance);
+                }
+            }
+        }
+
+        [Fact]
+        public void CanGroupByLoadedTagRql()
+        {
+            using (var store = GetDocumentStore())
+            {
+                var baseline = PopulateCanGroupByLoadedTag(store);
+
+                using (var session = store.OpenSession())
+                {
+                    var query = session.Advanced.RawQuery<TimeSeriesAggregationResult>(@"
+    declare timeseries out(u) 
+    {
+        from u.Heartrate between $start and $end
+        load Tag as watch
+        group by 1month, watch.Accuracy
+        select avg(), max()
+    }
+    from people as u
+    select out(u)
+")
+                        .AddParameter("start", baseline.EnsureUtc())
+                        .AddParameter("end", baseline.AddMonths(2).EnsureUtc());
+
+                    var result = query.First();
+
+                    Assert.Equal(6, result.Count);
+
+                    var agg = result.Results;
+
+                    Assert.Equal(3, agg.Length);
+
+                    var monthBaseline = new DateTime(baseline.Year, baseline.Month, 1);
+
+                    var val1 = agg[0];
+                    Assert.Equal(10, double.Parse(val1.Key));
+                    Assert.Equal(monthBaseline, val1.From, RavenTestHelper.DateTimeComparer.Instance);
+                    Assert.Equal(monthBaseline.AddMonths(1), val1.To, RavenTestHelper.DateTimeComparer.Instance);
+                    Assert.Equal(3, val1.Count[0]);
+
+                    var val2 = agg[1];
+                    Assert.Equal(10, double.Parse(val2.Key));
+                    Assert.Equal(monthBaseline.AddMonths(1), val2.From, RavenTestHelper.DateTimeComparer.Instance);
+                    Assert.Equal(monthBaseline.AddMonths(2), val2.To, RavenTestHelper.DateTimeComparer.Instance);
+                    Assert.Equal(2, val2.Count[0]);
+
+                    var val3 = agg[2];
+                    Assert.Equal(5, double.Parse(val3.Key));
+                    Assert.Equal(monthBaseline.AddMonths(1), val3.From, RavenTestHelper.DateTimeComparer.Instance);
+                    Assert.Equal(monthBaseline.AddMonths(2), val3.To, RavenTestHelper.DateTimeComparer.Instance);
+                    Assert.Equal(1, val3.Count[0]);
+                }
+            }
+        }
+
+        [Fact]
+        public void CanGroupByLoadedTagLinq()
+        {
+            using (var store = GetDocumentStore())
+            {
+                var baseline = PopulateCanGroupByLoadedTag(store);
+
+                using (var session = store.OpenSession())
+                {
+                    var query = session.Query<TimeSeriesLinqQuery.Person>()
+                        .Select(u => RavenQuery.TimeSeries(u, "Heartrate", baseline.EnsureUtc(), baseline.AddMonths(2).EnsureUtc())
+                            .GroupBy(g => g
+                                .Months(1)
+                                .ByTag<TimeSeriesLinqQuery.Watch>(w => w.Accuracy)
+                            )
+                            .Select(g => new {Average = g.Average(), Max = g.Max()})
+                            .ToList());
+
+                    var result = query.First();
+
+                    Assert.Equal(6, result.Count);
+
+                    var agg = result.Results;
+
+                    Assert.Equal(3, agg.Length);
+
+                    var monthBaseline = new DateTime(baseline.Year, baseline.Month, 1);
+
+                    var val1 = agg[0];
+                    Assert.Equal(10, double.Parse(val1.Key));
+                    Assert.Equal(monthBaseline, val1.From, RavenTestHelper.DateTimeComparer.Instance);
+                    Assert.Equal(monthBaseline.AddMonths(1), val1.To, RavenTestHelper.DateTimeComparer.Instance);
+                    Assert.Equal(3, val1.Count[0]);
+
+                    var val2 = agg[1];
+                    Assert.Equal(10, double.Parse(val2.Key));
+                    Assert.Equal(monthBaseline.AddMonths(1), val2.From, RavenTestHelper.DateTimeComparer.Instance);
+                    Assert.Equal(monthBaseline.AddMonths(2), val2.To, RavenTestHelper.DateTimeComparer.Instance);
+                    Assert.Equal(2, val2.Count[0]);
+
+                    var val3 = agg[2];
+                    Assert.Equal(5, double.Parse(val3.Key));
+                    Assert.Equal(monthBaseline.AddMonths(1), val3.From, RavenTestHelper.DateTimeComparer.Instance);
+                    Assert.Equal(monthBaseline.AddMonths(2), val3.To, RavenTestHelper.DateTimeComparer.Instance);
+                    Assert.Equal(1, val3.Count[0]);
+                }
+            }
+        }
+
+        [Fact]
+        public void CanGroupByLoadedTagWithTagFilter()
+        {
+            using (var store = GetDocumentStore())
+            {
+                var baseline = PopulateCanGroupByLoadedTag(store);
+
+                using (var session = store.OpenSession())
+                {
+                    var query = session.Query<TimeSeriesLinqQuery.Person>()
+                        .Select(u => RavenQuery.TimeSeries(u, "Heartrate", baseline.EnsureUtc(), baseline.AddMonths(2).EnsureUtc())
+                            .LoadByTag<TimeSeriesLinqQuery.Watch>().Where((entry, watch) => watch.Manufacturer != "Sony")
+                            .GroupBy(g => g
+                                .Months(1)
+                                .ByTag<TimeSeriesLinqQuery.Watch>(w => w.Accuracy)
+                            )
+                            .Select(g => new {Average = g.Average(), Max = g.Max()})
+                            .ToList());
+
+                    var result = query.First();
+
+                    Assert.Equal(5, result.Count);
+
+                    var agg = result.Results;
+
+                    Assert.Equal(2, agg.Length);
+
+                    var monthBaseline = new DateTime(baseline.Year, baseline.Month, 1);
+
+                    var val1 = agg[0];
+                    Assert.Equal(10, double.Parse(val1.Key));
+                    Assert.Equal(monthBaseline, val1.From, RavenTestHelper.DateTimeComparer.Instance);
+                    Assert.Equal(monthBaseline.AddMonths(1), val1.To, RavenTestHelper.DateTimeComparer.Instance);
+                    Assert.Equal(3, val1.Count[0]);
+
+                    var val2 = agg[1];
+                    Assert.Equal(10, double.Parse(val2.Key));
+                    Assert.Equal(monthBaseline.AddMonths(1), val2.From, RavenTestHelper.DateTimeComparer.Instance);
+                    Assert.Equal(monthBaseline.AddMonths(2), val2.To, RavenTestHelper.DateTimeComparer.Instance);
+                    Assert.Equal(2, val2.Count[0]);
+                }
+            }
+        }
+
+        [Fact]
+        public void CanGroupByTagWithInterpolationRql()
+        {
+            using (var store = GetDocumentStore())
+            {
+                var baseline = PopulateCanGroupByTagWithInterpolation(store);
+
+                using (var session = store.OpenSession())
+                {
+                    var query = session.Advanced.RawQuery<TimeSeriesAggregationResult>(@"
+    declare timeseries out(u) 
+    {
+        from u.Heartrate between $start and $end
+        group by 1h, tag
+        with interpolation(linear)
+        select avg(), max()
+    }
+    from people as u
+    select out(u)
+")
+                        .AddParameter("start", baseline.EnsureUtc())
+                        .AddParameter("end", baseline.AddMonths(2).EnsureUtc());
+
+                    var result = query.First();
+
+                    Assert.Equal(32 * 3, result.Count);
+
+                    var agg = result.Results;
+
+                    Assert.Equal(32 * 3, agg.Length);
+
+                    var groups = agg.GroupBy(x => x.Key);
+
+                    foreach (var group in groups)
+                    {
+                        var key = group.Key;
+                        var value = group.OrderBy(x => x.From).ToArray();
+                        Assert.Equal(32, value.Length);
+                        for (int i = 0; i < value.Length; i++)
+                        {
+                            var val = value[i];
+                            switch (key)
+                            {
+                                case "watches/fitbit":
+                                    Assert.Equal(i * 10, val.Average[0]);
+                                    break;
+                                case "watches/apple":
+                                    Assert.Equal(i * 100, val.Average[0]);
+                                    break;
+                                case "watches/sony":
+                                    Assert.Equal(i * 1000, val.Average[0]);
+                                    break;
+                                default:
+                                    throw new ArgumentException();
+                            }
+                            Assert.Equal(baseline.AddHours(i), val.From, RavenTestHelper.DateTimeComparer.Instance);
+                            Assert.Equal(baseline.AddHours(i + 1), val.To, RavenTestHelper.DateTimeComparer.Instance);
+                        }
+                    }
+                }
+            }
+        }
+
+        [Fact]
+        public void CanGroupByTagWithInterpolationLinq()
+        {
+            using (var store = GetDocumentStore())
+            {
+                var baseline = PopulateCanGroupByTagWithInterpolation(store);
+
+                using (var session = store.OpenSession())
+                {
+                    var query = session.Query<TimeSeriesLinqQuery.Person>()
+                        .Select(u => RavenQuery.TimeSeries(u, "Heartrate",baseline.EnsureUtc(), baseline.AddMonths(2).EnsureUtc())
+                            //    .LoadByTag<TimeSeriesLinqQuery.Watch>().Where((entry, watch) => true)
+                            .GroupBy(g => g
+                                .Hours(1)
+                                .ByTag()
+                                .WithOptions(new TimeSeriesAggregationOptions
+                                {
+                                    Interpolation = InterpolationType.Linear
+                                }))
+                            .Select(g => new
+                            {
+                                Max = g.Max(),
+                                Average = g.Average(),
+                            })
+                            .ToList());
+
+
+                    var result = query.First();
+
+                    Assert.Equal(32 * 3, result.Count);
+
+                    var agg = result.Results;
+
+                    Assert.Equal(32 * 3, agg.Length);
+
+                    var groups = agg.GroupBy(x => x.Key);
+
+                    foreach (var group in groups)
+                    {
+                        var key = group.Key;
+                        var value = group.OrderBy(x => x.From).ToArray();
+                        Assert.Equal(32, value.Length);
+                        for (int i = 0; i < value.Length; i++)
+                        {
+                            var val = value[i];
+                            switch (key)
+                            {
+                                case "watches/fitbit":
+                                    Assert.Equal(i * 10, val.Average[0]);
+                                    break;
+                                case "watches/apple":
+                                    Assert.Equal(i * 100, val.Average[0]);
+                                    break;
+                                case "watches/sony":
+                                    Assert.Equal(i * 1000, val.Average[0]);
+                                    break;
+                                default:
+                                    throw new ArgumentException();
+                            }
+                            Assert.Equal(baseline.AddHours(i), val.From, RavenTestHelper.DateTimeComparer.Instance);
+                            Assert.Equal(baseline.AddHours(i + 1), val.To, RavenTestHelper.DateTimeComparer.Instance);
+                        }
+                    }
+                }
+            }
+        }
+
+
+        [Fact]
+        public void CanStreamGroupByTagWithInterpolation()
+        {
+            using (var store = GetDocumentStore())
+            {
+                var baseline = PopulateCanGroupByTagWithInterpolation(store);
+
+                using (var session = store.OpenSession())
+                {
+                    var query = session.Query<TimeSeriesLinqQuery.Person>()
+                        .Select(u => RavenQuery.TimeSeries(u, "Heartrate",baseline.EnsureUtc(), baseline.AddMonths(2).EnsureUtc())
+                            .GroupBy(g => g
+                                .Hours(1)
+                                .ByTag()
+                                .WithOptions(new TimeSeriesAggregationOptions
+                                {
+                                    Interpolation = InterpolationType.Linear
+                                }))
+                            .Select(g => new
+                            {
+                                Max = g.Max(),
+                                Average = g.Average(),
+                            })
+                            .ToList());
+
+                    var dic = new Dictionary<string, List<TimeSeriesRangeAggregation>>();
+                    using (var docStream = session.Advanced.Stream(query))
+                    {
+                        while (docStream.MoveNext())
+                        {
+                            using (var entryStream = docStream.Current.Result.Stream)
+                            {
+                                while (entryStream.MoveNext())
+                                {
+                                    var current = entryStream.Current;
+
+                                    dic.TryAdd(current.Key, new List<TimeSeriesRangeAggregation>());
+                                    dic[current.Key].Add(current);
+                                }
+                            }
+                        }
+                    }
+
+                    Assert.Equal(3, dic.Count);
+
+                    foreach (var group in dic)
+                    {
+                        var key = group.Key;
+                        var value = group.Value.OrderBy(x => x.From).ToArray();
+                        Assert.Equal(32, value.Length);
+                        for (int i = 0; i < value.Length; i++)
+                        {
+                            var val = value[i];
+                            switch (key)
+                            {
+                                case "watches/fitbit":
+                                    Assert.Equal(i * 10, val.Average[0]);
+                                    break;
+                                case "watches/apple":
+                                    Assert.Equal(i * 100, val.Average[0]);
+                                    break;
+                                case "watches/sony":
+                                    Assert.Equal(i * 1000, val.Average[0]);
+                                    break;
+                                default:
+                                    throw new ArgumentException();
+                            }
+                            Assert.Equal(baseline.AddHours(i), val.From, RavenTestHelper.DateTimeComparer.Instance);
+                            Assert.Equal(baseline.AddHours(i + 1), val.To, RavenTestHelper.DateTimeComparer.Instance);
+                        }
+                    }
+                }
+            }
+        }
+
+        private static DateTime PopulateCanGroupByLoadedTag(DocumentStore store)
+        {
+            var baseline = DateTime.Today;
+
+            using (var session = store.OpenSession())
+            {
+                session.Store(new TimeSeriesLinqQuery.Person {Age = 25}, "people/1");
+
+                session.Store(new TimeSeriesLinqQuery.Watch {Manufacturer = "Fitbit", Accuracy = 10}, "watches/fitbit");
+
+                session.Store(new TimeSeriesLinqQuery.Watch {Manufacturer = "Apple", Accuracy = 10}, "watches/apple");
+
+                session.Store(new TimeSeriesLinqQuery.Watch {Manufacturer = "Sony", Accuracy = 5}, "watches/sony");
+
+                var tsf = session.TimeSeriesFor("people/1", "HeartRate");
+
+                tsf.Append(baseline.AddMinutes(61), new[] {59d}, "watches/fitbit");
+                tsf.Append(baseline.AddMinutes(62), new[] {79d}, "watches/apple");
+                tsf.Append(baseline.AddMinutes(63), new[] {69d}, "watches/fitbit");
+
+                tsf.Append(baseline.AddMonths(1).AddMinutes(61), new[] {159d}, "watches/apple");
+                tsf.Append(baseline.AddMonths(1).AddMinutes(62), new[] {179d}, "watches/sony");
+                tsf.Append(baseline.AddMonths(1).AddMinutes(63), new[] {169d}, "watches/fitbit");
+
+
+                session.SaveChanges();
+            }
+
+            return baseline;
+        }
+
+        private static DateTime PopulateCanGroupByTagWithInterpolation(DocumentStore store)
+        {
+            var baseline = DateTime.Today;
+
+            using (var session = store.OpenSession())
+            {
+                session.Store(new TimeSeriesLinqQuery.Person {Age = 25}, "people/1");
+
+                var tsf = session.TimeSeriesFor("people/1", "HeartRate");
+
+                tsf.Append(baseline.AddMinutes(1), new[] {0d}, "watches/fitbit");
+                tsf.Append(baseline.AddMinutes(2), new[] {0d}, "watches/apple");
+                tsf.Append(baseline.AddMinutes(3), new[] {0d}, "watches/sony");
+
+                for (int i = 1; i <= 30; i++)
+                {
+                    switch (i % 3)
+                    {
+                        case 1:
+                            tsf.Append(baseline.AddHours(i).AddMinutes(1), new[] {10d * i}, "watches/fitbit");
+                            break;
+                        case 2:
+                            tsf.Append(baseline.AddHours(i).AddMinutes(2), new[] {100d * i}, "watches/apple");
+                            break;
+                        case 0:
+                            tsf.Append(baseline.AddHours(i).AddMinutes(3), new[] {1000d * i}, "watches/sony");
+                            break;
+                    }
+                }
+
+                tsf.Append(baseline.AddHours(31).AddMinutes(1), new[] {310d}, "watches/fitbit");
+                tsf.Append(baseline.AddHours(31).AddMinutes(2), new[] {3100d}, "watches/apple");
+                tsf.Append(baseline.AddHours(31).AddMinutes(3), new[] {31000d}, "watches/sony");
+
+                session.SaveChanges();
+            }
+
+            return baseline;
+        }
+    }
+}

--- a/test/SlowTests/Client/TimeSeries/Query/TimeSeriesLinqQuery.cs
+++ b/test/SlowTests/Client/TimeSeries/Query/TimeSeriesLinqQuery.cs
@@ -22,7 +22,7 @@ namespace SlowTests.Client.TimeSeries.Query
         {
         }
 
-        private class Person
+        public class Person
         {
             public string Id { get; set; }
 
@@ -33,7 +33,7 @@ namespace SlowTests.Client.TimeSeries.Query
             public string WorksAt { get; set; }
         }
 
-        private class Watch
+        public class Watch
         {
             public string Manufacturer { get; set; }
 

--- a/test/SlowTests/Client/TimeSeries/Query/TimeSeriesLinqQuery.cs
+++ b/test/SlowTests/Client/TimeSeries/Query/TimeSeriesLinqQuery.cs
@@ -1,4 +1,5 @@
 ﻿using System;
+using System.Collections.Generic;
 using System.Linq;
 using System.Threading.Tasks;
 using FastTests;
@@ -38,6 +39,10 @@ namespace SlowTests.Client.TimeSeries.Query
             public string Manufacturer { get; set; }
 
             public double Accuracy { get; set; }
+
+            public int? Year { get; set; }
+
+            public List<string> Prizes { get; set; }
 
         }
 


### PR DESCRIPTION
things to note:
1. this will have a performance penalty, since we need to iterate over each individual value
2. the (time) order of results is not guaranteed when using interpolation. (so we can't assume it in general)
3. returned result contains new field "Key" which is simply the ToString of the grouped by field