### PR TITLE
RavenDB-15562 BlittableMetadataModifier check whole "@timeseries" string to prevent mismatch

### DIFF
--- a/src/Raven.Server/Documents/BlittableMetadataModifier.cs
+++ b/src/Raven.Server/Documents/BlittableMetadataModifier.cs
@@ -398,7 +398,8 @@ namespace Raven.Server.Documents
                 case 11: // @timeseries
                     // always remove the @timeseries metadata
                     if (state.StringBuffer[0] != (byte)'@' ||
-                        *(long*)(state.StringBuffer + 1) != 7598247067624761716)
+                        *(long*)(state.StringBuffer + 1) != 7598247067624761716 ||
+                        *(short*)(state.StringBuffer + 1 + sizeof(long)) != 29541)
                     {
                         aboutToReadPropertyName = true;
                         return true;


### PR DESCRIPTION
https://issues.hibernatingrhinos.com/issue/RavenDB-15562