### PR TITLE
Bulk insert session async all the way where possible

### DIFF
--- a/Raven.Client.Lightweight/Document/RemoteBulkInsertOperation.cs
+++ b/Raven.Client.Lightweight/Document/RemoteBulkInsertOperation.cs
@@ -521,7 +521,7 @@ namespace Raven.Client.Document
 
             if (previousTask != null && waitedForPreviousTask == false)
             {
-                Total += previousTask.Result;
+                Total += previousTask.GetAwaiter().GetResult();
                 waitedForPreviousTask = true;
             }
 

--- a/Raven.Tests.Web/Controllers/Commands/AsyncCommandsController.cs
+++ b/Raven.Tests.Web/Controllers/Commands/AsyncCommandsController.cs
@@ -121,14 +121,14 @@ namespace Raven.Tests.Web.Controllers.Commands
         }
 
         [Route("api/async/commands/getBulkInsertOperation")]
-        public Task<HttpResponseMessage> GetBulkInsertOperation()
+        public async Task<HttpResponseMessage> GetBulkInsertOperation()
         {
             using (var operation = DocumentStore.AsyncDatabaseCommands.GetBulkInsertOperation(new BulkInsertOptions(), DocumentStore.Changes()))
             {
-                operation.Write(Guid.NewGuid().ToString(), new RavenJObject(), new RavenJObject());
+                await operation.WriteAsync(Guid.NewGuid().ToString(), new RavenJObject(), new RavenJObject());
             }
 
-            return new CompletedTask<HttpResponseMessage>(new HttpResponseMessage());
+            return new HttpResponseMessage();
         }
 
         [Route("api/async/commands/getDocuments1")]


### PR DESCRIPTION
It seems to me the bulk insertion due to the sync over async problem is suffering quite a bit of starvation issues under load. This is a quick attempt to make things better by providing async write overloads that allows proper async flow in case of

```
            // if we haven't flushed the previous one yet, we will force
            // a disposal of both the previous one and the one before, to avoid
```

technically this is a breaking change but I assumed the low level interfaces can change given that they are not intended for public consumption.