### PR TITLE
RavenDB-15645 avoid segment split for different number of values

### DIFF
--- a/src/Raven.Server/Documents/TimeSeries/SegmentHeader.cs
+++ b/src/Raven.Server/Documents/TimeSeries/SegmentHeader.cs
@@ -18,6 +18,14 @@ namespace Raven.Server.Documents.TimeSeries
         [FieldOffset(13)]
         public byte NumberOfValues;
         [FieldOffset(14)]
-        public fixed byte Reserved[2];
+        public SegmentVersion Version;
+        [FieldOffset(15)]
+        public fixed byte Reserved[1];
+    }
+
+    public enum SegmentVersion : byte
+    {
+        V50000 = 0,
+        V50001 = 1
     }
 }

--- a/src/Raven.Server/Documents/TimeSeries/SegmentHeader.cs
+++ b/src/Raven.Server/Documents/TimeSeries/SegmentHeader.cs
@@ -26,6 +26,7 @@ namespace Raven.Server.Documents.TimeSeries
     public enum SegmentVersion : byte
     {
         V50000 = 0,
-        V50001 = 1
+        V50001 = 1,
+        Current = V50001
     }
 }

--- a/src/Raven.Server/Documents/TimeSeries/StatefulTimeStampValue.cs
+++ b/src/Raven.Server/Documents/TimeSeries/StatefulTimeStampValue.cs
@@ -76,5 +76,6 @@ namespace Raven.Server.Documents.TimeSeries
     {
         public byte LeadingZeroes;
         public byte TrailingZeroes;
+        public long LastValidValue;
     }
 }

--- a/src/Raven.Server/Documents/TimeSeries/TimeSeriesStorage.cs
+++ b/src/Raven.Server/Documents/TimeSeries/TimeSeriesStorage.cs
@@ -1215,7 +1215,7 @@ namespace Raven.Server.Documents.TimeSeries
 
                             if (EnsureNumberOfValues(segmentHolder.ReadOnlySegment.NumberOfValues, ref current))
                             {
-                                if (TryAppendToCurrentSegment(context, segmentHolder, appendEnumerator, out var newValueFetched))
+                                if (TryAppendToCurrentSegment(context, segmentHolder, appendEnumerator, current, out var newValueFetched))
                                     break;
 
                                 if (newValueFetched)
@@ -1302,16 +1302,15 @@ namespace Raven.Server.Documents.TimeSeries
             return segmentNumberOfValues == current.Values.Length;
         }
 
-        private bool TryAppendToCurrentSegment(
-            DocumentsOperationContext context,
+        private bool TryAppendToCurrentSegment(DocumentsOperationContext context,
             TimeSeriesSegmentHolder segmentHolder,
             IEnumerator<SingleResult> appendEnumerator,
+            SingleResult current,
             out bool newValueFetched)
         {
             var segment = segmentHolder.ReadOnlySegment;
             var slicer = segmentHolder.SliceHolder;
 
-            var current = appendEnumerator.Current;
             var lastTimestamp = segment.GetLastTimestamp(segmentHolder.BaselineDate);
             var nextSegmentBaseline = BaselineOfNextSegment(segmentHolder, current.Timestamp) ?? DateTime.MaxValue;
 

--- a/src/Raven.Server/Documents/TimeSeries/TimeSeriesValuesSegment.cs
+++ b/src/Raven.Server/Documents/TimeSeries/TimeSeriesValuesSegment.cs
@@ -116,7 +116,7 @@ namespace Raven.Server.Documents.TimeSeries
             Header->NumberOfValues = (byte)numberOfValues;
             Header->SizeOfTags = 1;
             Header->PreviousTagIndex = byte.MaxValue;// invalid tag value
-            Header->Version = SegmentVersion.V50001;
+            Header->Version = SegmentVersion.Current;
         }
 
         public bool Append(ByteStringContext allocator, int deltaFromStart, double val, Span<byte> tag, ulong status)


### PR DESCRIPTION
If we append 10 entries when the first has 3 values and the rest only one,
we would call segment split 9 times.