### PR TITLE
RavenDB-15658 : fix failing test 

### DIFF
--- a/test/SlowTests/Client/TimeSeries/Query/TimeSeriesLinqQuery.cs
+++ b/test/SlowTests/Client/TimeSeries/Query/TimeSeriesLinqQuery.cs
@@ -2429,7 +2429,7 @@ namespace SlowTests.Client.TimeSeries.Query
         {
             using (var store = GetDocumentStore())
             {
-                var baseline = DateTime.Today;
+                var baseline = DateTime.Today.AddHours(12);
 
                 using (var session = store.OpenSession())
                 {


### PR DESCRIPTION
SlowTests.Client.TimeSeries.Query.TimeSeriesLinqQuery.CanQueryTimeSeriesAggregation_WithOffset
https://issues.hibernatingrhinos.com/issue/RavenDB-15658