### PR TITLE
RavenDB-15645 segment max value can be negative

### DIFF
--- a/src/Raven.Client/Documents/Session/TimeSeries/TimeSeriesEntry.cs
+++ b/src/Raven.Client/Documents/Session/TimeSeries/TimeSeriesEntry.cs
@@ -157,13 +157,17 @@ namespace Raven.Client.Documents.Session.TimeSeries
             foreach (var memberInfo in mapping)
             {
                 var index = memberInfo.Key;
-                if (index >= values.Length)
-                    continue;
+                var value = double.NaN;
+                if (index < values.Length)
+                {
+                    if (asRollup)
+                        index *= 6;
 
-                if (asRollup)
-                    index *= 6;
+                    value = values[index];
+                }
+                
                 var member = memberInfo.Value;
-                member.SetValue(ref obj, values[index]);
+                member.SetValue(ref obj, value);
             }
 
             return obj;

--- a/src/Raven.Server/Documents/TimeSeries/TimeSeriesStorage.cs
+++ b/src/Raven.Server/Documents/TimeSeries/TimeSeriesStorage.cs
@@ -2040,15 +2040,32 @@ namespace Raven.Server.Documents.TimeSeries
 
             if (segment.NumberOfLiveEntries > 0)
             {
-                foreach (var state in segment.SegmentValues.Span)
+                for (var index = 0; index < segment.SegmentValues.Span.Length; index++)
                 {
+                    var state = segment.SegmentValues.Span[index];
+                    if (state.Count == 0)
+                    {
+                        // all followed dimensions must be zero as well
+                        for (; index < segment.SegmentValues.Span.Length; index++)
+                        {
+                            state = segment.SegmentValues.Span[index];
+                            Debug.Assert(state.Count == 0, "Count not zero");
+                            Debug.Assert(double.IsNaN(state.First), "First must be NaN");
+                            Debug.Assert(double.IsNaN(state.Min), "Min must be NaN");
+                            Debug.Assert(double.IsNaN(state.Max), "Max must be NaN");
+
+                            Debug.Assert(state.Last == 0, "Last not zero");
+                            Debug.Assert(state.Sum == 0, "Sum not zero");
+                        }
+                        break;
+                    }
+
                     Debug.Assert(double.IsNaN(state.First) == false, "First is NaN");
                     Debug.Assert(double.IsNaN(state.Last) == false, "Last is NaN");
                     Debug.Assert(double.IsNaN(state.Min) == false, "Min is NaN");
                     Debug.Assert(double.IsNaN(state.Max) == false, "Max is NaN");
                     Debug.Assert(double.IsNaN(state.Sum) == false, "Sum is NaN");
                     Debug.Assert(double.IsNaN(state.Count) == false, "Count is NaN");
-                    Debug.Assert(state.Count > 0, "Count is Zero");
                 }
 
                 if (name.Contains(TimeSeriesConfiguration.TimeSeriesRollupSeparator))

--- a/src/Raven.Server/Documents/TimeSeries/TimeSeriesValuesSegment.cs
+++ b/src/Raven.Server/Documents/TimeSeries/TimeSeriesValuesSegment.cs
@@ -178,7 +178,7 @@ namespace Raven.Server.Documents.TimeSeries
                 {
                     for (int i = 0; i < vals.Length; i++)
                     {
-                        prevs[i].Min = prevs[i].First = vals[i];
+                        prevs[i].Max = prevs[i].Min = prevs[i].First = vals[i];
                     }
                 }
 

--- a/test/SlowTests/Client/TimeSeries/Query/TimeSeriesLinqQuery.cs
+++ b/test/SlowTests/Client/TimeSeries/Query/TimeSeriesLinqQuery.cs
@@ -321,6 +321,57 @@ namespace SlowTests.Client.TimeSeries.Query
         }
 
         [Fact]
+        public void MaxCanGoNegative()
+        {
+            using (var store = GetDocumentStore())
+            {
+                var baseline = DateTime.Today;
+
+                using (var session = store.OpenSession())
+                {
+                    session.Store(new User
+                    {
+                        Name = "Oren",
+                        Age = 35
+                    }, "users/ayende");
+
+                    var tsf = session.TimeSeriesFor("users/ayende", "HeartRate");
+
+                    tsf.Append(baseline.AddMinutes(63), new[] { -69d }, "watches/fitbit");
+
+
+                    session.SaveChanges();
+                }
+
+                using (var session = store.OpenSession())
+                {
+                    var query = session.Query<User>()
+                        .Where(u => u.Age > 21)
+                        .Select(u => RavenQuery.TimeSeries("Heartrate")
+                            .GroupBy(g => g.Months(1))
+                            .Select(g => new
+                            {
+                                Avg = g.Average(),
+                                Max = g.Max()
+                            })
+                            .ToList());
+
+                    var result = query.ToList();
+
+                    Assert.Equal(1, result.Count);
+                    Assert.Equal(1, result[0].Count);
+
+                    var agg = result[0].Results;
+
+                    Assert.Equal(1, agg.Length);
+                    
+                    Assert.Equal(-69, agg[0].Average[0]);
+                    Assert.Equal(-69, agg[0].Max[0]);
+                }
+            }
+        }
+
+        [Fact]
         public void CanQueryTimeSeriesAggregation_WhereTagIn()
         {
             using (var store = GetDocumentStore())


### PR DESCRIPTION
\+ typed api fix (Non-existing time-series typed value is NaN)