### PR TITLE
RDBCL-1575: Cancel the backup timer if the backup task is ActiveByOtherNode

### DIFF
--- a/src/Raven.Server/Documents/PeriodicBackup/BackupTask.cs
+++ b/src/Raven.Server/Documents/PeriodicBackup/BackupTask.cs
@@ -162,7 +162,6 @@ namespace Raven.Server.Documents.PeriodicBackup
                         if (_logger.IsInfoEnabled)
                             _logger.Info(message);
 
-                        UpdateOperationId(runningBackupStatus);
                         runningBackupStatus.LastIncrementalBackup = _periodicBackup.StartTimeInUtc;
                         runningBackupStatus.LocalBackup.IncrementalBackupDurationInMs = 0;
                         DatabaseSmuggler.EnsureProcessed(_backupResult);
@@ -206,7 +205,6 @@ namespace Raven.Server.Documents.PeriodicBackup
                     }
                 }
 
-                UpdateOperationId(runningBackupStatus);
                 runningBackupStatus.LastEtag = internalBackupResult.LastDocumentEtag;
                 runningBackupStatus.LastDatabaseChangeVector = internalBackupResult.LastDatabaseChangeVector;
                 runningBackupStatus.LastRaftIndex.LastEtag = internalBackupResult.LastRaftIndex;
@@ -278,7 +276,7 @@ namespace Raven.Server.Documents.PeriodicBackup
                     runningBackupStatus.NodeTag = _serverStore.NodeTag;
                     runningBackupStatus.DurationInMs = totalSw.ElapsedMilliseconds;
                     runningBackupStatus.Version = ++_previousBackupStatus.Version;
-
+                    UpdateOperationId(runningBackupStatus);
                     _periodicBackup.BackupStatus = runningBackupStatus;
 
                     // save the backup status
@@ -642,6 +640,8 @@ namespace Raven.Server.Documents.PeriodicBackup
                     }
 
                     IOExtensions.RenameFile(tempBackupFilePath, backupFilePath);
+
+                    status.LocalBackup.Exception = null;
                 }
                 catch (Exception e)
                 {
@@ -845,7 +845,8 @@ namespace Raven.Server.Documents.PeriodicBackup
         {
             runningBackupStatus.LastOperationId = _operationId;
             if (_previousBackupStatus.LastOperationId == null ||
-                _previousBackupStatus.NodeTag != _serverStore.NodeTag)
+                _previousBackupStatus.NodeTag != _serverStore.NodeTag ||
+                _previousBackupStatus.Error != null)
                 return;
 
             // dismiss the previous operation

--- a/test/SlowTests/Server/Documents/PeriodicBackup/PeriodicBackupSlowTests.cs
+++ b/test/SlowTests/Server/Documents/PeriodicBackup/PeriodicBackupSlowTests.cs
@@ -1313,7 +1313,7 @@ namespace SlowTests.Server.Documents.PeriodicBackup
                 Assert.Null(status.LastFullBackup);
                 Assert.NotNull(status.LastFullBackupInternal);
                 var oldLastFullBackupInternal = status.LastFullBackupInternal;
-                Assert.True(status.IsFull);
+                Assert.True(status.IsFull, "status.IsFull");
                 Assert.Null(status.LastEtag);
                 Assert.Null(status.FolderName);
                 Assert.Null(status.LastIncrementalBackup);
@@ -1329,8 +1329,7 @@ namespace SlowTests.Server.Documents.PeriodicBackup
 
                 Assert.Null(status.LocalBackup.LastIncrementalBackup);
                 Assert.NotNull(status.NodeTag);
-                Assert.True(status.DurationInMs > 0);
-
+                Assert.True(status.DurationInMs >= 0, "status.DurationInMs >= 0");
                 // update backup task
                 config.TaskId = backupTaskId;
                 config.BackupEncryptionSettings = null;
@@ -1355,7 +1354,7 @@ namespace SlowTests.Server.Documents.PeriodicBackup
                 Assert.NotNull(status.LastFullBackupInternal);
                 Assert.NotEqual(oldLastFullBackupInternal, status.LastFullBackupInternal);
 
-                Assert.True(status.IsFull);
+                Assert.True(status.IsFull, "status.IsFull");
                 Assert.Equal(1, status.LastEtag);
                 Assert.NotNull(status.FolderName);
                 Assert.Null(status.LastIncrementalBackup);
@@ -1368,7 +1367,7 @@ namespace SlowTests.Server.Documents.PeriodicBackup
                 Assert.NotEqual(oldLastFullBackup, status.LocalBackup.LastFullBackup);
                 Assert.Null(status.LocalBackup.LastIncrementalBackup);
                 Assert.NotNull(status.NodeTag);
-                Assert.True(status.DurationInMs > 0);
+                Assert.True(status.DurationInMs > 0, "status.DurationInMs > 0");
             }
         }
 


### PR DESCRIPTION
so when the backup task is back to be ActiveByCurrentNode, the timer can be rearranged.