### PR TITLE
RavenDB-15140 The token of null ValueExpression set to "null"

### DIFF
--- a/src/Raven.Server/Documents/Queries/Parser/QueryScanner.cs
+++ b/src/Raven.Server/Documents/Queries/Parser/QueryScanner.cs
@@ -315,6 +315,8 @@ namespace Raven.Server.Documents.Queries.Parser
                         continue;
                 }
 
+                _tokenStart = _pos;
+                _tokenLength = match.Length;
                 _pos += match.Length;
                 Column += match.Length;
                 found = match;


### PR DESCRIPTION
https://issues.hibernatingrhinos.com/issue/RavenDB-15140

I tested "from Commands where null = Error" as well but in this scenario, it fails while the assumption is the left value is a field.
Result of the parser:
```
if (this.null === this.Error )
{
 return true;

}
```
Do we want to support it?