### PR TITLE
RavenDB-15548 Modify database client configuration Etag to use same incremental Etag as server wide client configuration

### DIFF
--- a/src/Raven.Server/Documents/Handlers/Admin/AdminConfigurationHandler.cs
+++ b/src/Raven.Server/Documents/Handlers/Admin/AdminConfigurationHandler.cs
@@ -49,6 +49,7 @@ namespace Raven.Server.Documents.Handlers.Admin
             }
 
             NoContentStatus();
+            HttpContext.Response.Headers[Constants.Headers.RefreshClientConfiguration] = "true";
             HttpContext.Response.StatusCode = (int)HttpStatusCode.Created;
         }
 

--- a/src/Raven.Server/Documents/Handlers/ConfigurationHandler.cs
+++ b/src/Raven.Server/Documents/Handlers/ConfigurationHandler.cs
@@ -43,9 +43,8 @@ namespace Raven.Server.Documents.Handlers
             var inherit = GetBoolValueQueryString("inherit", required: false) ?? true;
 
             var configuration = Database.ClientConfiguration;
-            long etag = configuration?.Etag ?? -1;
-            var serverConfiguration = GetServerClientConfiguration(out long serverIndex);
-            etag = Hashing.Combine(etag, serverIndex);
+            var serverConfiguration = GetServerClientConfiguration();
+            
             if (inherit && (configuration == null || configuration.Disabled) && serverConfiguration != null)
             {
                 configuration = serverConfiguration;
@@ -65,7 +64,7 @@ namespace Raven.Server.Documents.Handlers
                     writer.WriteStartObject();
 
                     writer.WritePropertyName(nameof(GetClientConfigurationOperation.Result.Etag));
-                    writer.WriteInteger(etag);
+                    writer.WriteInteger(Database.GetClientConfigurationEtag());
                     writer.WriteComma();
 
                     writer.WritePropertyName(nameof(GetClientConfigurationOperation.Result.Configuration));
@@ -85,7 +84,7 @@ namespace Raven.Server.Documents.Handlers
             return Task.CompletedTask;
         }
 
-        private ClientConfiguration GetServerClientConfiguration(out long index)
+        private ClientConfiguration GetServerClientConfiguration()
         {
             using (ServerStore.ContextPool.AllocateOperationContext(out TransactionOperationContext context))
             {
@@ -95,8 +94,6 @@ namespace Raven.Server.Documents.Handlers
                     var config =  clientConfigurationJson != null
                         ? JsonDeserializationServer.ClientConfiguration(clientConfigurationJson)
                         : null;
-
-                    index = config?.Etag ?? ServerStore.LastClientConfigurationIndex;
 
                     return config;
                 }

--- a/src/Raven.Server/ServerWide/ClusterStateMachine.cs
+++ b/src/Raven.Server/ServerWide/ClusterStateMachine.cs
@@ -1345,12 +1345,12 @@ namespace Raven.Server.ServerWide
                         }
                     }
 
-                    bool isClientConfigChanged;
+                    bool shouldSetClientConfigEtag;
                     var dbId = Constants.Documents.Prefix + addDatabaseCommand.Name;
                     using (var oldDatabaseRecord = Read(context, dbId, out _))
                     {
                         VerifyUnchangedTasks(oldDatabaseRecord);
-                        isClientConfigChanged = IsClientConfigChanged(newDatabaseRecord, oldDatabaseRecord);
+                        shouldSetClientConfigEtag = ShouldSetClientConfigEtag(newDatabaseRecord, oldDatabaseRecord);
                     }
 
                     using (var databaseRecordAsJson = UpdateDatabaseRecordIfNeeded())
@@ -1409,7 +1409,7 @@ namespace Raven.Server.ServerWide
 
                     BlittableJsonReaderObject UpdateDatabaseRecordIfNeeded()
                     {
-                        if (isClientConfigChanged)
+                        if (shouldSetClientConfigEtag)
                         {
                             addDatabaseCommand.Record.Client.Etag = index;
                             return EntityToBlittable.ConvertCommandToBlittable(addDatabaseCommand.Record, context);
@@ -1459,7 +1459,7 @@ namespace Raven.Server.ServerWide
             }
         }
 
-        private static bool IsClientConfigChanged(BlittableJsonReaderObject newDatabaseRecord, BlittableJsonReaderObject oldDatabaseRecord)
+        private static bool ShouldSetClientConfigEtag(BlittableJsonReaderObject newDatabaseRecord, BlittableJsonReaderObject oldDatabaseRecord)
         {
             const string clientPropName = nameof(DatabaseRecord.Client);
             if (newDatabaseRecord.TryGet(clientPropName, out BlittableJsonReaderObject newDbClientConfig) == false || newDbClientConfig == null) 

--- a/test/SlowTests/Client/ClientConfigurationTests.cs
+++ b/test/SlowTests/Client/ClientConfigurationTests.cs
@@ -1,5 +1,6 @@
 ﻿using System.Threading.Tasks;
 using FastTests;
+using Raven.Client.Documents;
 using Raven.Client.Documents.Operations.Configuration;
 using Raven.Client.Http;
 using Raven.Client.ServerWide.Operations.Configuration;
@@ -62,29 +63,44 @@ namespace SlowTests.Client
         [Fact]
         public async Task ChangeClientConfiguration_ShouldUpdateTheClient()
         {
-            var (_, leader) = await CreateRaftCluster(3);
-            using var store = GetDocumentStore(new Options{Server = leader, });
+            var putDatabaseClientConfigDisabled = new PutClientConfigurationOperation(new ClientConfiguration { Disabled = true });
+            const int numberOfNodes = 3;
+
+            var (_, leader) = await CreateRaftCluster(numberOfNodes, watcherCluster:true);
+            using var store = GetDocumentStore(new Options
+                {
+                    Server = leader,
+                    ReplicationFactor = numberOfNodes,
+                    ModifyDocumentStore = documentStore =>
+                    {
+                        documentStore.Conventions.ReadBalanceBehavior = ReadBalanceBehavior.RoundRobin;
+                        documentStore.Conventions.MaxNumberOfRequestsPerSession = 99;
+                    }
+                });
             var requestExecutor = store.GetRequestExecutor();
 
             var origin = requestExecutor.Conventions.MaxNumberOfRequestsPerSession;
-            await store.Maintenance.SendAsync(new PutClientConfigurationOperation(new ClientConfiguration { MaxNumberOfRequestsPerSession = 100, Disabled = false }));
+            await store.Maintenance.SendAsync(new PutClientConfigurationOperation(GetClientConfiguration(100)));
             await AssertWaitForClientConfiguration(100);
-            
-            await store.Maintenance.SendAsync(new PutClientConfigurationOperation(new ClientConfiguration { Disabled = true }));
+
+            await store.Maintenance.SendAsync(putDatabaseClientConfigDisabled);
             await AssertWaitForClientConfiguration(origin);
             
-            await store.Maintenance.SendAsync(new PutClientConfigurationOperation(new ClientConfiguration { MaxNumberOfRequestsPerSession = 101, Disabled = false }));
-            await store.Maintenance.Server.SendAsync(new PutServerWideClientConfigurationOperation(new ClientConfiguration { MaxNumberOfRequestsPerSession = 102, Disabled = false }));
+            await store.Maintenance.SendAsync(new PutClientConfigurationOperation(GetClientConfiguration(101)));
+            await store.Maintenance.Server.SendAsync(new PutServerWideClientConfigurationOperation(GetClientConfiguration(102)));
             await AssertWaitForClientConfiguration(101);
                 
-            await store.Maintenance.SendAsync(new PutClientConfigurationOperation(new ClientConfiguration { Disabled = true}));
+            await store.Maintenance.SendAsync(putDatabaseClientConfigDisabled);
             await AssertWaitForClientConfiguration(102);
                 
-            await store.Maintenance.SendAsync(new PutClientConfigurationOperation(new ClientConfiguration { MaxNumberOfRequestsPerSession = 103, Disabled = false }));
+            await store.Maintenance.SendAsync(new PutClientConfigurationOperation(GetClientConfiguration(103)));
             await AssertWaitForClientConfiguration(103);
 
-            await store.Maintenance.SendAsync(new PutClientConfigurationOperation(new ClientConfiguration { Disabled = true}));
+            await store.Maintenance.SendAsync(putDatabaseClientConfigDisabled);
             await AssertWaitForClientConfiguration(102);
+            
+            await store.Maintenance.Server.SendAsync(new PutServerWideClientConfigurationOperation(new ClientConfiguration{Disabled = true}));
+            await AssertWaitForClientConfiguration(origin);
             
             async Task AssertWaitForClientConfiguration(int maxNumberOfRequestsPerSession)
             {
@@ -95,6 +111,16 @@ namespace SlowTests.Client
                     return requestExecutor.Conventions.MaxNumberOfRequestsPerSession;
                 }, maxNumberOfRequestsPerSession);
                 Assert.Equal(maxNumberOfRequestsPerSession, requestExecutor.Conventions.MaxNumberOfRequestsPerSession);
+            }
+
+            static ClientConfiguration GetClientConfiguration(int maxNumberOfRequestsPerSession)
+            {
+                return new ClientConfiguration
+                {
+                    ReadBalanceBehavior = ReadBalanceBehavior.RoundRobin, 
+                    MaxNumberOfRequestsPerSession = maxNumberOfRequestsPerSession, 
+                    Disabled = false
+                };
             }
         }
 
@@ -127,23 +153,29 @@ namespace SlowTests.Client
         {
             DoNotReuseServer(); // we modify global server configuration, and it impacts other tests
             using (var store = GetDocumentStore())
+            using (var testedStore = new DocumentStore
+            {
+                Database = store.Database,
+                Urls = store.Urls,
+            }.Initialize())
             {
                 store.Maintenance.Send(new PutClientConfigurationOperation(new ClientConfiguration { ReadBalanceBehavior = ReadBalanceBehavior.RoundRobin, Disabled = false }));
                 store.Maintenance.Server.Send(new PutServerWideClientConfigurationOperation(new ClientConfiguration { ReadBalanceBehavior = ReadBalanceBehavior.FastestNode, Disabled = false }));
 
-                using (var session = store.OpenSession())
+                using (var session = testedStore.OpenSession())
                 {
+                    var before = session.Advanced.RequestExecutor.NumberOfServerRequests;
                     session.Load<dynamic>("users/1"); // forcing client configuration update
-                    Assert.Equal(5, session.Advanced.RequestExecutor.NumberOfServerRequests);
+                    Assert.Equal(2, session.Advanced.RequestExecutor.NumberOfServerRequests - before);
                 }
 
-                using (var session = store.OpenSession())
+                using (var session = testedStore.OpenSession())
                 {
+                    var before = session.Advanced.RequestExecutor.NumberOfServerRequests;
                     session.Load<dynamic>("users/1");
-                    Assert.Equal(6, session.Advanced.RequestExecutor.NumberOfServerRequests);
+                    Assert.Equal(1, session.Advanced.RequestExecutor.NumberOfServerRequests - before);
                 }
             }
         }
-
     }
 }

--- a/test/SlowTests/Issues/RavenDB-14880.cs
+++ b/test/SlowTests/Issues/RavenDB-14880.cs
@@ -48,13 +48,7 @@ namespace SlowTests.Issues
                 var re = store.GetRequestExecutor(databaseName);
                 var configurationChanges = new List<long>();
 
-                re.ClientConfigurationChanged += (sender, tuple) =>
-                {
-                    // since this is a cluster operation, when we fail-over to another node for reads,
-                    // the other node might not get the configuration change yet and we might get the "old" configuration back
-                    if(configurationChanges.Contains(tuple.RaftCommandIndex) == false)
-                        configurationChanges.Add(tuple.RaftCommandIndex);
-                };
+                re.ClientConfigurationChanged += (sender, tuple) => configurationChanges.Add(tuple.RaftCommandIndex);
 
                 SetClientConfiguration(new ClientConfiguration
                 {

--- a/test/SlowTests/Issues/RavenDB_4636.cs
+++ b/test/SlowTests/Issues/RavenDB_4636.cs
@@ -56,20 +56,10 @@ namespace SlowTests.Issues
 
                 store.Maintenance.Send(new PutClientConfigurationOperation(new ClientConfiguration { MaxNumberOfRequestsPerSession = 15 }));
 
-                using (var session = store.OpenSession())
-                {
-                    session.Load<dynamic>("users/1"); // forcing client configuration update
-                }
-
                 Assert.Equal(30, store.Conventions.MaxNumberOfRequestsPerSession);
                 Assert.Equal(15, requestExecutor.Conventions.MaxNumberOfRequestsPerSession);
 
                 store.Maintenance.Send(new PutClientConfigurationOperation(new ClientConfiguration { MaxNumberOfRequestsPerSession = 15, Disabled = true }));
-
-                using (var session = store.OpenSession())
-                {
-                    session.Load<dynamic>("users/1"); // forcing client configuration update
-                }
 
                 Assert.Equal(30, store.Conventions.MaxNumberOfRequestsPerSession);
                 Assert.Equal(30, requestExecutor.Conventions.MaxNumberOfRequestsPerSession);


### PR DESCRIPTION
https://issues.hibernatingrhinos.com/issue/RavenDB-15548

Two remain issues will remain as discussed:
* Mix cluster (some node with this fix and some not) can cause unnecessary client configuration update and/or not update a necessary configuration.
* If the client cached a higher value then the current incremental ETag (returned from Hash.Combine of database and server-wide client configuration) then the server will think the client has a more up to date client configuration.