### PR TITLE
RavenDB-15741 Move EncryptionBuffersPool to per core model.

### DIFF
--- a/src/Voron/Impl/EncryptionBuffersPool.cs
+++ b/src/Voron/Impl/EncryptionBuffersPool.cs
@@ -48,12 +48,13 @@ namespace Voron.Impl
 
         public byte* Get(int numberOfPages, out int size, out NativeMemory.ThreadStats thread)
         {
-            numberOfPages = Bits.PowerOf2(numberOfPages); ;
-            size = numberOfPages * Constants.Storage.PageSize;
+            var numberOfPagesPowerOfTwo = Bits.PowerOf2(numberOfPages); ;
+            size = numberOfPagesPowerOfTwo * Constants.Storage.PageSize;
 
-            if (Disabled || numberOfPages > MaxNumberOfPagesToCache)
+            if (Disabled || numberOfPagesPowerOfTwo > MaxNumberOfPagesToCache)
             {
                 // We don't want to pool large buffers
+                size = numberOfPages * Constants.Storage.PageSize;
                 return PlatformSpecific.NativeMemory.Allocate4KbAlignedMemory(size, out thread);
             }
 

--- a/src/Voron/Impl/EncryptionBuffersPool.cs
+++ b/src/Voron/Impl/EncryptionBuffersPool.cs
@@ -46,10 +46,10 @@ namespace Voron.Impl
             _cleanupTimer = new Timer(CleanupTimer, null, TimeSpan.FromMinutes(1), TimeSpan.FromMinutes(1));
         }
 
-        public byte* Get(int numberOfPages, out NativeMemory.ThreadStats thread)
+        public byte* Get(int numberOfPages, out int size, out NativeMemory.ThreadStats thread)
         {
             numberOfPages = Bits.PowerOf2(numberOfPages); ;
-            int size = numberOfPages * Constants.Storage.PageSize;
+            size = numberOfPages * Constants.Storage.PageSize;
 
             if (Disabled || numberOfPages > MaxNumberOfPagesToCache)
             {
@@ -76,7 +76,6 @@ namespace Voron.Impl
             if (ptr == null)
                 return;
 
-            size = Bits.PowerOf2(size);
             Sodium.sodium_memzero(ptr, (UIntPtr)size);
 
             if (Disabled || size / Constants.Storage.PageSize > MaxNumberOfPagesToCache || 

--- a/src/Voron/Impl/Paging/CryptoPager.cs
+++ b/src/Voron/Impl/Paging/CryptoPager.cs
@@ -199,7 +199,6 @@ namespace Voron.Impl.Paging
             var pageHeader = (PageHeader*)pagePointer;
 
             int numberOfPages = VirtualPagerLegacyExtensions.GetNumberOfPages(pageHeader);
-            var size = numberOfPages * Constants.Storage.PageSize;
 
             buffer = GetBufferAndAddToTxState(pageNumber, state, numberOfPages);
 

--- a/src/Voron/Impl/Paging/CryptoPager.cs
+++ b/src/Voron/Impl/Paging/CryptoPager.cs
@@ -247,11 +247,11 @@ namespace Voron.Impl.Paging
 
         private EncryptionBuffer GetBufferAndAddToTxState(long pageNumber, CryptoTransactionState state, int numberOfPages)
         {
-            var ptr = EncryptionBuffersPool.Instance.Get(numberOfPages, out var thread);
+            var ptr = EncryptionBuffersPool.Instance.Get(numberOfPages, out var size, out var thread);
 
             var buffer = new EncryptionBuffer
             {
-                Size = numberOfPages * Constants.Storage.PageSize,
+                Size = size,
                 Pointer = ptr,
                 AllocatingThread = thread
             };

--- a/src/Voron/Impl/Paging/CryptoPager.cs
+++ b/src/Voron/Impl/Paging/CryptoPager.cs
@@ -181,7 +181,7 @@ namespace Voron.Impl.Paging
             }
 
             // allocate new buffer
-            buffer = GetBufferAndAddToTxState(pageNumber, state, size);
+            buffer = GetBufferAndAddToTxState(pageNumber, state, numberOfPages);
             buffer.Modified = true;
 
             return buffer.Pointer;
@@ -198,9 +198,10 @@ namespace Voron.Impl.Paging
 
             var pageHeader = (PageHeader*)pagePointer;
 
-            var size = VirtualPagerLegacyExtensions.GetNumberOfPages(pageHeader) * Constants.Storage.PageSize;
+            int numberOfPages = VirtualPagerLegacyExtensions.GetNumberOfPages(pageHeader);
+            var size = numberOfPages * Constants.Storage.PageSize;
 
-            buffer = GetBufferAndAddToTxState(pageNumber, state, size);
+            buffer = GetBufferAndAddToTxState(pageNumber, state, numberOfPages);
 
             Memory.Copy(buffer.Pointer, pagePointer, buffer.Size);
 
@@ -244,13 +245,13 @@ namespace Voron.Impl.Paging
             // encBuffer.Hash = remains the same
         }
 
-        private EncryptionBuffer GetBufferAndAddToTxState(long pageNumber, CryptoTransactionState state, int size)
+        private EncryptionBuffer GetBufferAndAddToTxState(long pageNumber, CryptoTransactionState state, int numberOfPages)
         {
-            var ptr = EncryptionBuffersPool.Instance.Get(size, out var thread);
+            var ptr = EncryptionBuffersPool.Instance.Get(numberOfPages, out var thread);
 
             var buffer = new EncryptionBuffer
             {
-                Size = size,
+                Size = numberOfPages * Constants.Storage.PageSize,
                 Pointer = ptr,
                 AllocatingThread = thread
             };

--- a/test/FastTests/Voron/EncryptionBufferPool.cs
+++ b/test/FastTests/Voron/EncryptionBufferPool.cs
@@ -23,7 +23,7 @@ namespace FastTests.Voron
             var i = 1;
             var toFree = new List<(IntPtr, long)>();
 
-            while (i < new Size(64, SizeUnit.Megabytes).GetDoubleValue(SizeUnit.Bytes))
+            while (i < 8192)
             {
                 var ptr = encryptionBuffersPool.Get(i, out _);
                 toFree.Add(((IntPtr)ptr, i));
@@ -65,7 +65,7 @@ namespace FastTests.Voron
             var i = 1;
             var toFree = new List<(IntPtr, long)>();
 
-            while (i <= new Size(8, SizeUnit.Megabytes).GetValue(SizeUnit.Bytes))
+            while (i <= 1024)
             {
                 var ptr = encryptionBuffersPool.Get(i, out _);
                 toFree.Add(((IntPtr)ptr, i));
@@ -88,18 +88,17 @@ namespace FastTests.Voron
             stats = encryptionBuffersPool.GetStats();
             Assert.Equal(0, stats.TotalSize);
 
-            var size = 8 * 1024;
-            var pointer = encryptionBuffersPool.Get(size, out _);
-            encryptionBuffersPool.Return(pointer, size, NativeMemory.ThreadAllocations.Value, encryptionBuffersPool.Generation);
+            var pointer = encryptionBuffersPool.Get(1, out _);
+            encryptionBuffersPool.Return(pointer, 8192, NativeMemory.ThreadAllocations.Value, encryptionBuffersPool.Generation);
 
             // will cache the buffer
             stats = encryptionBuffersPool.GetStats();
-            Assert.Equal(size, stats.TotalSize);
+            Assert.Equal(8192, stats.TotalSize);
 
             // will continue to cache the buffer
             encryptionBuffersPool.LowMemory(lowMemorySeverity);
             stats = encryptionBuffersPool.GetStats();
-            Assert.Equal(size, stats.TotalSize);
+            Assert.Equal(8192, stats.TotalSize);
 
             encryptionBuffersPool.LowMemoryOver();
             ClearMemory(encryptionBuffersPool);
@@ -113,7 +112,7 @@ namespace FastTests.Voron
             var i = 1;
             var toFree = new List<(IntPtr, long)>();
 
-            while (i <= new Size(8, SizeUnit.Megabytes).GetValue(SizeUnit.Bytes))
+            while (i <= 1024)
             {
                 var ptr = encryptionBuffersPool.Get(i, out _);
                 toFree.Add(((IntPtr)ptr, i));
@@ -147,7 +146,7 @@ namespace FastTests.Voron
             var toFree = new List<(IntPtr, long)>();
 
             var generation = encryptionBuffersPool.Generation;
-            while (i <= new Size(8, SizeUnit.Megabytes).GetValue(SizeUnit.Bytes))
+            while (i <= 1024)
             {
                 var ptr = encryptionBuffersPool.Get(i, out _);
                 toFree.Add(((IntPtr)ptr, i));
@@ -179,13 +178,13 @@ namespace FastTests.Voron
             var stats = encryptionBuffersPool.GetStats();
             Assert.Equal(0, stats.TotalSize);
 
-            encryptionBuffersPool.Return(ptr, 1, NativeMemory.ThreadAllocations.Value, encryptionBuffersPool.Generation);
+            encryptionBuffersPool.Return(ptr, 8192, NativeMemory.ThreadAllocations.Value, encryptionBuffersPool.Generation);
             stats = encryptionBuffersPool.GetStats();
-            Assert.Equal(1, stats.TotalSize);
+            Assert.Equal(8192, stats.TotalSize);
 
             encryptionBuffersPool.LowMemory(LowMemorySeverity.Low);
             stats = encryptionBuffersPool.GetStats();
-            Assert.Equal(1, stats.TotalSize);
+            Assert.Equal(8192, stats.TotalSize);
 
             ClearMemory(encryptionBuffersPool);
         }

--- a/test/FastTests/Voron/EncryptionBufferPool.cs
+++ b/test/FastTests/Voron/EncryptionBufferPool.cs
@@ -25,7 +25,7 @@ namespace FastTests.Voron
 
             while (i < 8192)
             {
-                var ptr = encryptionBuffersPool.Get(i, out _);
+                var ptr = encryptionBuffersPool.Get(i, out var size, out _);
                 toFree.Add(((IntPtr)ptr, i));
 
                 i *= 2;
@@ -67,7 +67,7 @@ namespace FastTests.Voron
 
             while (i <= 1024)
             {
-                var ptr = encryptionBuffersPool.Get(i, out _);
+                var ptr = encryptionBuffersPool.Get(i, out _, out _);
                 toFree.Add(((IntPtr)ptr, i));
 
                 i *= 2;
@@ -88,7 +88,7 @@ namespace FastTests.Voron
             stats = encryptionBuffersPool.GetStats();
             Assert.Equal(0, stats.TotalSize);
 
-            var pointer = encryptionBuffersPool.Get(1, out _);
+            var pointer = encryptionBuffersPool.Get(1, out var size, out _);
             encryptionBuffersPool.Return(pointer, 8192, NativeMemory.ThreadAllocations.Value, encryptionBuffersPool.Generation);
 
             // will cache the buffer
@@ -114,7 +114,7 @@ namespace FastTests.Voron
 
             while (i <= 1024)
             {
-                var ptr = encryptionBuffersPool.Get(i, out _);
+                var ptr = encryptionBuffersPool.Get(i, out var size, out _);
                 toFree.Add(((IntPtr)ptr, i));
 
                 i *= 2;
@@ -148,7 +148,7 @@ namespace FastTests.Voron
             var generation = encryptionBuffersPool.Generation;
             while (i <= 1024)
             {
-                var ptr = encryptionBuffersPool.Get(i, out _);
+                var ptr = encryptionBuffersPool.Get(i, out var size, out _);
                 toFree.Add(((IntPtr)ptr, i));
 
                 i *= 2;
@@ -174,17 +174,17 @@ namespace FastTests.Voron
         {
             var encryptionBuffersPool = new EncryptionBuffersPool();
 
-            var ptr = encryptionBuffersPool.Get(1, out _);
+            var ptr = encryptionBuffersPool.Get(1, out var size, out _);
             var stats = encryptionBuffersPool.GetStats();
             Assert.Equal(0, stats.TotalSize);
 
             encryptionBuffersPool.Return(ptr, 8192, NativeMemory.ThreadAllocations.Value, encryptionBuffersPool.Generation);
             stats = encryptionBuffersPool.GetStats();
-            Assert.Equal(8192, stats.TotalSize);
+            Assert.Equal(size, stats.TotalSize);
 
             encryptionBuffersPool.LowMemory(LowMemorySeverity.Low);
             stats = encryptionBuffersPool.GetStats();
-            Assert.Equal(8192, stats.TotalSize);
+            Assert.Equal(size, stats.TotalSize);
 
             ClearMemory(encryptionBuffersPool);
         }


### PR DESCRIPTION
* We'll keep track of encryption buffer by power of 2 _page sizes_. In other words, 1,2,4,8,16 .. 128 pages (8KB ... 1 MB)
* Beyond that, we'll just allocate / deallocate directly.
* All data is shared on a per core model, instead of concurrent stack model