### PR TITLE
RavenDB-14695  clear the bitmap array

### DIFF
--- a/src/Raven.Server/Documents/Queries/LuceneIntegration/FastBitArray.cs
+++ b/src/Raven.Server/Documents/Queries/LuceneIntegration/FastBitArray.cs
@@ -12,6 +12,7 @@ namespace Raven.Server.Documents.Queries.LuceneIntegration
         public FastBitArray(int countOfBits)
         {
             _bits = ArrayPool<ulong>.Shared.Rent(countOfBits / 64 + (countOfBits % 64 == 0 ? 0 : 1));
+            new Span<ulong>(_bits).Clear();
         }
 
         public void Set(int index)


### PR DESCRIPTION
We cannot assume that the rented buffer is zeroed.