### PR TITLE
RavenDB-15868

### DIFF
--- a/src/Raven.Server/Commercial/LicenseHelper.cs
+++ b/src/Raven.Server/Commercial/LicenseHelper.cs
@@ -225,6 +225,9 @@ namespace Raven.Server.Commercial
         // returns true when this setting exists in settings.json
         private bool TryUpdatingSettingsJson(License newLicense, RSAParameters rsaParameters)
         {
+            if (File.Exists(_serverStore.Configuration.ConfigPath) == false)
+                return false;
+
             using (_serverStore.ContextPool.AllocateOperationContext(out TransactionOperationContext context))
             {
                 BlittableJsonReaderObject settingsJson;

--- a/src/Raven.Server/Commercial/LicenseManager.cs
+++ b/src/Raven.Server/Commercial/LicenseManager.cs
@@ -148,6 +148,9 @@ namespace Raven.Server.Commercial
 
         public async Task PutMyNodeInfoAsync()
         {
+            if (_serverStore.IsPassive())
+                return;
+
             if (await _licenseLimitsSemaphore.WaitAsync(0) == false)
                 return;
 


### PR DESCRIPTION
- avoid sending license update commands to cluster when it is passive
- if config does not exist return false instead of throwing