### PR TITLE
RavenDB-15870 / RavenDB-15856 Let's try to throw ObjectDisposedExcept…

### DIFF
--- a/src/Voron/Data/Compression/DecompressionBuffersPool.cs
+++ b/src/Voron/Data/Compression/DecompressionBuffersPool.cs
@@ -139,6 +139,10 @@ namespace Voron.Data.Compression
                 {
                     // we could dispose the pager during the cleanup
                 }
+                catch (Exception)
+                {
+                    // if we couldn't ensure valid pointer then we cannot proceed with that buffer
+                }
             }
 
             if (tmp == null)

--- a/src/Voron/Impl/Paging/Windows32BitsMemoryMapPager.cs
+++ b/src/Voron/Impl/Paging/Windows32BitsMemoryMapPager.cs
@@ -354,6 +354,11 @@ namespace Voron.Impl.Paging
                     }
                     else
                     {
+                        const int INVALID_HANDLE = 6;
+
+                        if (lastWin32Error == INVALID_HANDLE && Disposed)
+                            ThrowAlreadyDisposedException();
+
                         throw new Win32Exception(
                             $"Unable to map {size / Constants.Size.Kilobyte:#,#0} kb starting at {startPage} on {FileName} (lastWin32Error={lastWin32Error})",
                             new Win32Exception(lastWin32Error));


### PR DESCRIPTION
…ion if we get InvalidHandle error code in 32 bits pager. In general if we don't manage to ensure vald pager pointer then we cannot use the buffer for decompression.