### PR TITLE
RavenDB-15475 Adding unused database Ids to import/export for prevent ing "conflict" in import destination cluster replication

### DIFF
--- a/src/Raven.Client/Documents/Smuggler/SmugglerResult.cs
+++ b/src/Raven.Client/Documents/Smuggler/SmugglerResult.cs
@@ -254,9 +254,6 @@ namespace Raven.Client.Documents.Smuggler
                 if (ClientConfigurationUpdated)
                     json[nameof(ClientConfigurationUpdated)] = ClientConfigurationUpdated;
 
-                if (ConflictSolverConfigUpdated)
-                    json[nameof(ConflictSolverConfigUpdated)] = ClientConfigurationUpdated;
-
                 if (PeriodicBackupsUpdated)
                     json[nameof(PeriodicBackupsUpdated)] = PeriodicBackupsUpdated;
 
@@ -329,8 +326,8 @@ namespace Raven.Client.Documents.Smuggler
                 if (ClientConfigurationUpdated)
                     sb.AppendLine("- Client");
                 
-                if (ClientConfigurationUpdated)
-                    sb.AppendLine("- Unused Database Ids");
+                if (UnusedDatabaseIdsUpdated)
+                    sb.AppendLine("- Unused Database IDs");
 
                 if (sb.Length == 0)
                     return string.Empty;

--- a/src/Raven.Client/Documents/Smuggler/SmugglerResult.cs
+++ b/src/Raven.Client/Documents/Smuggler/SmugglerResult.cs
@@ -229,6 +229,8 @@ namespace Raven.Client.Documents.Smuggler
             public bool SqlConnectionStringsUpdated { get; set; }
 
             public bool ClientConfigurationUpdated { get; set; }
+            
+            public bool UnusedDatabaseIdsUpdated { get; set; }
 
             public override DynamicJsonValue ToJson()
             {
@@ -275,6 +277,9 @@ namespace Raven.Client.Documents.Smuggler
 
                 if (HubPullReplicationsUpdated)
                     json[nameof(HubPullReplicationsUpdated)] = HubPullReplicationsUpdated;
+                
+                if (UnusedDatabaseIdsUpdated)
+                    json[nameof(UnusedDatabaseIdsUpdated)] = UnusedDatabaseIdsUpdated;
 
                 return json;
             }
@@ -323,6 +328,9 @@ namespace Raven.Client.Documents.Smuggler
 
                 if (ClientConfigurationUpdated)
                     sb.AppendLine("- Client");
+                
+                if (ClientConfigurationUpdated)
+                    sb.AppendLine("- Unused Database Ids");
 
                 if (sb.Length == 0)
                     return string.Empty;

--- a/src/Raven.Client/Documents/Smuggler/SmugglerResult.cs
+++ b/src/Raven.Client/Documents/Smuggler/SmugglerResult.cs
@@ -254,6 +254,9 @@ namespace Raven.Client.Documents.Smuggler
                 if (ClientConfigurationUpdated)
                     json[nameof(ClientConfigurationUpdated)] = ClientConfigurationUpdated;
 
+                if (ConflictSolverConfigUpdated)
+                    json[nameof(ConflictSolverConfigUpdated)] = ConflictSolverConfigUpdated;
+                
                 if (PeriodicBackupsUpdated)
                     json[nameof(PeriodicBackupsUpdated)] = PeriodicBackupsUpdated;
 

--- a/src/Raven.Server/Smuggler/Documents/DatabaseDestination.cs
+++ b/src/Raven.Server/Smuggler/Documents/DatabaseDestination.cs
@@ -569,7 +569,10 @@ namespace Raven.Server.Smuggler.Documents
                 var currentDatabaseRecord = _database.ReadDatabaseRecord();
                 var tasks = new List<Task<(long Index, object Result)>>();
 
-                if (databaseRecord?.ConflictSolverConfig != null)
+                if (databaseRecord == null)
+                    return;
+                
+                if (databaseRecord.ConflictSolverConfig != null)
                 {
                     if (currentDatabaseRecord?.ConflictSolverConfig != null)
                     {
@@ -591,7 +594,7 @@ namespace Raven.Server.Smuggler.Documents
                     progress.ConflictSolverConfigUpdated = true;
                 }
 
-                if (databaseRecord?.PeriodicBackups.Count > 0)
+                if (databaseRecord.PeriodicBackups.Count > 0)
                 {
                     if (_log.IsInfoEnabled)
                         _log.Info("Configuring periodic backups configuration from smuggler");
@@ -612,7 +615,7 @@ namespace Raven.Server.Smuggler.Documents
                     progress.PeriodicBackupsUpdated = true;
                 }
 
-                if (databaseRecord?.SinkPullReplications.Count > 0)
+                if (databaseRecord.SinkPullReplications.Count > 0)
                 {
                     if (_log.IsInfoEnabled)
                         _log.Info("Configuring sink pull replication configuration from smuggler");
@@ -635,7 +638,7 @@ namespace Raven.Server.Smuggler.Documents
                     progress.SinkPullReplicationsUpdated = true;
                 }
 
-                if (databaseRecord?.HubPullReplications.Count > 0)
+                if (databaseRecord.HubPullReplications.Count > 0)
                 {
                     if (_log.IsInfoEnabled)
                         _log.Info("Configuring hub pull replication configuration from smuggler");
@@ -659,7 +662,7 @@ namespace Raven.Server.Smuggler.Documents
                     progress.HubPullReplicationsUpdated = true;
                 }
 
-                if (databaseRecord?.Sorters.Count > 0)
+                if (databaseRecord.Sorters.Count > 0)
                 {
                     if (_log.IsInfoEnabled)
                         _log.Info("Configuring sorters configuration from smuggler");
@@ -672,7 +675,7 @@ namespace Raven.Server.Smuggler.Documents
                     progress.SortersUpdated = true;
                 }
 
-                if (databaseRecord?.ExternalReplications.Count > 0)
+                if (databaseRecord.ExternalReplications.Count > 0)
                 {
                     if (_log.IsInfoEnabled)
                         _log.Info("Configuring external replications configuration from smuggler");
@@ -695,7 +698,7 @@ namespace Raven.Server.Smuggler.Documents
                     progress.ExternalReplicationsUpdated = true;
                 }
 
-                if (databaseRecord?.RavenEtls.Count > 0)
+                if (databaseRecord.RavenEtls.Count > 0)
                 {
                     if (_log.IsInfoEnabled)
                         _log.Info("Configuring raven etls configuration from smuggler");
@@ -715,7 +718,7 @@ namespace Raven.Server.Smuggler.Documents
                     progress.RavenEtlsUpdated = true;
                 }
 
-                if (databaseRecord?.SqlEtls.Count > 0)
+                if (databaseRecord.SqlEtls.Count > 0)
                 {
                     if (_log.IsInfoEnabled)
                         _log.Info("Configuring sql etls configuration from smuggler");
@@ -735,7 +738,7 @@ namespace Raven.Server.Smuggler.Documents
                     progress.SqlEtlsUpdated = true;
                 }
 
-                if (databaseRecord?.Revisions != null)
+                if (databaseRecord.Revisions != null)
                 {
                     if (currentDatabaseRecord?.Revisions != null)
                     {
@@ -753,14 +756,14 @@ namespace Raven.Server.Smuggler.Documents
                     progress.RevisionsConfigurationUpdated = true;
                 }
 
-                if (databaseRecord?.RevisionsForConflicts != null)
+                if (databaseRecord.RevisionsForConflicts != null)
                 {
                     if (_log.IsInfoEnabled)
                         _log.Info("Configuring revisions for conflicts from smuggler");
                     tasks.Add(_database.ServerStore.SendToLeaderAsync(new EditRevisionsForConflictsConfigurationCommand(databaseRecord.RevisionsForConflicts, _database.Name, RaftIdGenerator.DontCareId)));
                 }
 
-                if (databaseRecord?.Expiration != null)
+                if (databaseRecord.Expiration != null)
                 {
                     if (_log.IsInfoEnabled)
                         _log.Info("Configuring expiration from smuggler");
@@ -768,7 +771,7 @@ namespace Raven.Server.Smuggler.Documents
                     progress.ExpirationConfigurationUpdated = true;
                 }
 
-                if (databaseRecord?.Refresh != null)
+                if (databaseRecord.Refresh != null)
                 {
                     if (_log.IsInfoEnabled)
                         _log.Info("Configuring refresh from smuggler");
@@ -776,7 +779,7 @@ namespace Raven.Server.Smuggler.Documents
                     progress.RefreshConfigurationUpdated = true;
                 }
 
-                if (databaseRecord?.RavenConnectionStrings.Count > 0)
+                if (databaseRecord.RavenConnectionStrings.Count > 0)
                 {
                     if (_log.IsInfoEnabled)
                         _log.Info("Configuring Raven connection strings configuration from smuggler");
@@ -787,7 +790,7 @@ namespace Raven.Server.Smuggler.Documents
                     progress.RavenConnectionStringsUpdated = true;
                 }
 
-                if (databaseRecord?.SqlConnectionStrings.Count > 0)
+                if (databaseRecord.SqlConnectionStrings.Count > 0)
                 {
                     if (_log.IsInfoEnabled)
                         _log.Info("Configuring SQL connection strings from smuggler");
@@ -798,13 +801,23 @@ namespace Raven.Server.Smuggler.Documents
                     progress.SqlConnectionStringsUpdated = true;
                 }
 
-                if (databaseRecord?.Client != null)
+                if (databaseRecord.Client != null)
                 {
                     if (_log.IsInfoEnabled)
                         _log.Info("Configuring client configuration from smuggler");
 
                     tasks.Add(_database.ServerStore.SendToLeaderAsync(new EditDatabaseClientConfigurationCommand(databaseRecord.Client, _database.Name, RaftIdGenerator.DontCareId)));
                     progress.ClientConfigurationUpdated = true;
+                }
+                
+                if (databaseRecord.UnusedDatabaseIds != null && databaseRecord.UnusedDatabaseIds.Count > 0)
+                {
+                    if (_log.IsInfoEnabled)
+                        _log.Info("Set unused database Ids from smuggler");
+
+                    tasks.Add(_database.ServerStore.SendToLeaderAsync(new UpdateUnusedDatabaseIdsCommand(_database.Name, databaseRecord.UnusedDatabaseIds, RaftIdGenerator.DontCareId)));
+
+                    progress.UnusedDatabaseIdsUpdated = true;
                 }
 
                 if (tasks.Count == 0)

--- a/src/Raven.Server/Smuggler/Documents/StreamDestination.cs
+++ b/src/Raven.Server/Smuggler/Documents/StreamDestination.cs
@@ -178,7 +178,10 @@ namespace Raven.Server.Smuggler.Documents
 
                 _writer.WritePropertyName(nameof(databaseRecord.Encrypted));
                 _writer.WriteBool(databaseRecord.Encrypted);
+                _writer.WriteComma();
 
+                _writer.WriteArray(nameof(databaseRecord.UnusedDatabaseIds), databaseRecord.UnusedDatabaseIds);
+                
                 if (databaseRecordItemType.Contain(DatabaseRecordItemType.ConflictSolverConfig))
                 {
                     _writer.WriteComma();

--- a/src/Raven.Server/Smuggler/Documents/StreamSource.cs
+++ b/src/Raven.Server/Smuggler/Documents/StreamSource.cs
@@ -211,7 +211,8 @@ namespace Raven.Server.Smuggler.Documents
                 {
                     foreach (var id in unusedDatabaseIds)
                     {
-                        Debug.Assert(id is LazyStringValue || id is LazyCompressedStringValue);
+                        if(id is LazyStringValue == false && id is LazyCompressedStringValue == false)
+                            throw new InvalidOperationException($"{nameof(databaseRecord.UnusedDatabaseIds)} should be a collection of strings but got {id.GetType()}");
                         databaseRecord.UnusedDatabaseIds.Add(id.ToString());
                     }
                 }

--- a/src/Raven.Server/Smuggler/Documents/StreamSource.cs
+++ b/src/Raven.Server/Smuggler/Documents/StreamSource.cs
@@ -206,6 +206,15 @@ namespace Raven.Server.Smuggler.Documents
                     }
                 }
 
+                if (reader.TryGet(nameof(databaseRecord.UnusedDatabaseIds), out BlittableJsonReaderArray unusedDatabaseIds) &&
+                    unusedDatabaseIds != null)
+                {
+                    foreach (LazyStringValue id in unusedDatabaseIds)
+                    {
+                        databaseRecord.UnusedDatabaseIds.Add(id);
+                    }
+                }
+                
                 if (reader.TryGet(nameof(databaseRecord.ExternalReplications), out BlittableJsonReaderArray externalReplications) &&
                     externalReplications != null)
                 {

--- a/src/Raven.Server/Smuggler/Documents/StreamSource.cs
+++ b/src/Raven.Server/Smuggler/Documents/StreamSource.cs
@@ -209,9 +209,10 @@ namespace Raven.Server.Smuggler.Documents
                 if (reader.TryGet(nameof(databaseRecord.UnusedDatabaseIds), out BlittableJsonReaderArray unusedDatabaseIds) &&
                     unusedDatabaseIds != null)
                 {
-                    foreach (LazyStringValue id in unusedDatabaseIds)
+                    foreach (var id in unusedDatabaseIds)
                     {
-                        databaseRecord.UnusedDatabaseIds.Add(id);
+                        Debug.Assert(id is LazyStringValue || id is LazyCompressedStringValue);
+                        databaseRecord.UnusedDatabaseIds.Add(id.ToString());
                     }
                 }
                 

--- a/test/FastTests/Server/Documents/Revisions/ReplicationRevisionsTests.cs
+++ b/test/FastTests/Server/Documents/Revisions/ReplicationRevisionsTests.cs
@@ -1,7 +1,11 @@
+using System.IO;
 using System.Linq;
+using System.Threading;
 using System.Threading.Tasks;
 using FastTests.Server.Replication;
 using Raven.Client.Documents;
+using Raven.Client.Documents.Operations;
+using Raven.Client.Documents.Operations.Backups;
 using Raven.Client.Documents.Operations.Revisions;
 using Raven.Client.Documents.Session;
 using Raven.Client.Documents.Smuggler;
@@ -20,7 +24,7 @@ namespace FastTests.Server.Documents.Revisions
         }
         
         [Fact]
-        public async Task ReplicateRevision_WhenSourceDataFromReplicationAndDocDeleted_ShouldNotResuscitateTheDoc()
+        public async Task ReplicateRevision_WhenSourceDataFromExportAndDocDeleted_ShouldNotResuscitateTheDoc()
         {
             var exportFile = GetTempFileName();
             
@@ -87,6 +91,96 @@ namespace FastTests.Server.Documents.Revisions
                         () => Assert.Equal(0, firstNodeDocs.Length),
                         () => Assert.Equal(0, secondNodeDocs.Length));
                 }
+            }
+        }
+
+        [Fact]
+        public async Task ReplicateRevision_WhenSourceDataFromIncrementalBackupAndDocDeleted_ShouldNotResuscitateTheDoc()
+        {
+            var backupPath = NewDataPath(suffix: "BackupFolder");
+            
+            var (nodes, leader) = await CreateRaftCluster(2);
+            var nodeTags = nodes.Select(n => n.ServerStore.NodeTag).ToArray();
+
+            string firstNode;
+            using (var store = GetDocumentStore(new Options {Server = leader, ReplicationFactor = 1}))
+            {
+                await store.Maintenance.SendAsync(new ConfigureRevisionsOperation(new RevisionsConfiguration{Default = new RevisionsCollectionConfiguration()}));
+                firstNode = await AssertWaitForNotNullAsync(async () =>
+                    (await store.Maintenance.Server.SendAsync(new GetDatabaseRecordOperation(store.Database))).Topology.Members?.FirstOrDefault());
+
+                var entity = new User();
+                using (var session = store.OpenAsyncSession())
+                {
+                    //Add first revision with first node tag
+                    await session.StoreAsync(entity);
+                    await session.SaveChangesAsync();
+                }
+                
+                var config = new PeriodicBackupConfiguration
+                {
+                    LocalSettings = new LocalSettings { FolderPath = backupPath },
+                    IncrementalBackupFrequency = "* * * * *" //every minute
+                };
+                var backupTaskId = (await store.Maintenance.SendAsync(new UpdatePeriodicBackupOperation(config))).TaskId;
+                await (await SendAsync(store, new StartBackupOperation(true, backupTaskId))).WaitForCompletionAsync();
+                
+                await store.Maintenance.Server.SendAsync(new AddDatabaseNodeOperation(store.Database));
+                await AssertWaitForValueAsync(async () => (await store.Maintenance.Server.SendAsync(new GetDatabaseRecordOperation(store.Database))).Topology.Members?.Count, 2);
+                
+                await store.Maintenance.Server.SendAsync(new DeleteDatabasesOperation(store.Database, true, nodeTags.First(n => n == firstNode)));
+                await AssertWaitForValueAsync(async () =>
+                {
+                    var dbRecord = await store.Maintenance.Server.SendAsync(new GetDatabaseRecordOperation(store.Database));
+                    return dbRecord?.DeletionInProgress == null || dbRecord.DeletionInProgress.Count == 0;
+                }, true);
+
+                using (var session = store.OpenAsyncSession())
+                {
+                    //Add update revision with second node tag
+                    entity.Name = "Changed";
+                    await session.StoreAsync(entity);
+                    await session.SaveChangesAsync();
+                    
+                    // Add delete revision with second node tag
+                    session.Delete(entity.Id);
+                    await session.SaveChangesAsync();
+                }
+
+                await (await SendAsync(store, new StartBackupOperation(false, backupTaskId))).WaitForCompletionAsync();
+            }
+
+            using (var store = GetDocumentStore(new Options {Server = leader, ReplicationFactor = 2}))
+            {
+                await store.Smuggler.ImportIncrementalAsync(new DatabaseSmugglerImportOptions(), Directory.GetDirectories(backupPath).First());
+
+                using var re1 = RequestExecutor.CreateForSingleNodeWithConfigurationUpdates(nodes[0].WebUrl, store.Database, null, store.Conventions);
+                using var re2 = RequestExecutor.CreateForSingleNodeWithConfigurationUpdates(nodes[1].WebUrl, store.Database, null, store.Conventions);
+                using (var firstSession = store.OpenAsyncSession(new SessionOptions{RequestExecutor = re1}))
+                using (var secondSession = store.OpenAsyncSession(new SessionOptions{RequestExecutor = re2}))
+                {
+                    WaitForIndexing(store, store.Database, nodeTag:nodes[0].ServerStore.NodeTag);
+                    var firstNodeDocs = await firstSession.Query<User>().ToArrayAsync();
+                    
+                    WaitForIndexing(store, store.Database, nodeTag:nodes[1].ServerStore.NodeTag);
+                    var secondNodeDocs = await secondSession.Query<User>().ToArrayAsync();
+
+                    RavenTestHelper.AssertAll(
+                        () => Assert.Equal(0, firstNodeDocs.Length),
+                        () => Assert.Equal(0, secondNodeDocs.Length));
+                }
+            }
+        }
+
+        private static async Task<Operation> SendAsync(IDocumentStore store, IMaintenanceOperation<StartBackupOperationResult> operation, CancellationToken token = default)
+        {
+            var re = store.GetRequestExecutor();
+            using (re.ContextPool.AllocateOperationContext(out var context))
+            {
+                var command = operation.GetCommand(re.Conventions, context);
+
+                await re.ExecuteAsync(command, context, null, token).ConfigureAwait(false);
+                return new Operation(re, () => store.Changes(store.Database), re.Conventions, command.Result.OperationId, command.SelectedNodeTag ?? command.Result.ResponsibleNode);
             }
         }
     }

--- a/test/FastTests/Server/Documents/Revisions/ReplicationRevisionsTests.cs
+++ b/test/FastTests/Server/Documents/Revisions/ReplicationRevisionsTests.cs
@@ -1,0 +1,93 @@
+using System.Linq;
+using System.Threading.Tasks;
+using FastTests.Server.Replication;
+using Raven.Client.Documents;
+using Raven.Client.Documents.Operations.Revisions;
+using Raven.Client.Documents.Session;
+using Raven.Client.Documents.Smuggler;
+using Raven.Client.Http;
+using Raven.Client.ServerWide.Operations;
+using Raven.Tests.Core.Utils.Entities;
+using Xunit;
+using Xunit.Abstractions;
+
+namespace FastTests.Server.Documents.Revisions
+{
+    public class ReplicationRevisionsTests : ReplicationTestBase
+    {
+        public ReplicationRevisionsTests(ITestOutputHelper output) : base(output)
+        {
+        }
+        
+        [Fact]
+        public async Task ReplicateRevision_WhenSourceDataFromReplicationAndDocDeleted_ShouldNotResuscitateTheDoc()
+        {
+            var exportFile = GetTempFileName();
+            
+            var (nodes, leader) = await CreateRaftCluster(2);
+            var nodeTags = nodes.Select(n => n.ServerStore.NodeTag).ToArray();
+
+            string firstNode;
+            using (var store = GetDocumentStore(new Options {Server = leader, ReplicationFactor = 1}))
+            {
+                await store.Maintenance.SendAsync(new ConfigureRevisionsOperation(new RevisionsConfiguration{Default = new RevisionsCollectionConfiguration()}));
+                firstNode = await AssertWaitForNotNullAsync(async () =>
+                    (await store.Maintenance.Server.SendAsync(new GetDatabaseRecordOperation(store.Database))).Topology.Members?.FirstOrDefault());
+
+                var entity = new User();
+                using (var session = store.OpenAsyncSession())
+                {
+                    //Add first revision with first node tag
+                    await session.StoreAsync(entity);
+                    await session.SaveChangesAsync();
+                }
+                await store.Maintenance.Server.SendAsync(new AddDatabaseNodeOperation(store.Database));
+                await AssertWaitForValueAsync(async () => (await store.Maintenance.Server.SendAsync(new GetDatabaseRecordOperation(store.Database))).Topology.Members?.Count, 2);
+                
+                await store.Maintenance.Server.SendAsync(new DeleteDatabasesOperation(store.Database, true, nodeTags.First(n => n == firstNode)));
+                await AssertWaitForValueAsync(async () =>
+                {
+                    var dbRecord = await store.Maintenance.Server.SendAsync(new GetDatabaseRecordOperation(store.Database));
+                    return dbRecord?.DeletionInProgress == null || dbRecord.DeletionInProgress.Count == 0;
+                }, true);
+
+                using (var session = store.OpenAsyncSession())
+                {
+                    //Add update revision with second node tag
+                    entity.Name = "Changed";
+                    await session.StoreAsync(entity);
+                    await session.SaveChangesAsync();
+                    
+                    // Add delete revision with second node tag
+                    session.Delete(entity.Id);
+                    await session.SaveChangesAsync();
+                }
+
+                var operation = await store.Smuggler.ExportAsync(new DatabaseSmugglerExportOptions(), exportFile);
+                await operation.WaitForCompletionAsync();
+            }
+
+            using (var store = GetDocumentStore(new Options {Server = leader, ReplicationFactor = 2}))
+            {
+                var operation = await store.Smuggler.ImportAsync(new DatabaseSmugglerImportOptions(), exportFile);
+                await operation.WaitForCompletionAsync();
+
+                using var re1 = RequestExecutor.CreateForSingleNodeWithConfigurationUpdates(nodes[0].WebUrl, store.Database, null, store.Conventions);
+                using var re2 = RequestExecutor.CreateForSingleNodeWithConfigurationUpdates(nodes[1].WebUrl, store.Database, null, store.Conventions);
+                using (var firstSession = store.OpenAsyncSession(new SessionOptions{RequestExecutor = re1}))
+                using (var secondSession = store.OpenAsyncSession(new SessionOptions{RequestExecutor = re2}))
+                {
+                    WaitForIndexing(store, store.Database, nodeTag:nodes[0].ServerStore.NodeTag);
+                    var firstNodeDocs = await firstSession.Query<User>().ToArrayAsync();
+                    
+                    WaitForIndexing(store, store.Database, nodeTag:nodes[1].ServerStore.NodeTag);
+                    var secondNodeDocs = await secondSession.Query<User>().ToArrayAsync();
+
+                    RavenTestHelper.AssertAll(
+                        () => Assert.Equal(0, firstNodeDocs.Length),
+                        () => Assert.Equal(0, secondNodeDocs.Length));
+                }
+            }
+        }
+    }
+}

--- a/test/SlowTests/Server/Replication/ReplicationRevisionsTests.cs
+++ b/test/SlowTests/Server/Replication/ReplicationRevisionsTests.cs
@@ -1,3 +1,4 @@
+using System.Collections.Generic;
 using System.IO;
 using System.Linq;
 using System.Threading;
@@ -11,11 +12,12 @@ using Raven.Client.Documents.Session;
 using Raven.Client.Documents.Smuggler;
 using Raven.Client.Http;
 using Raven.Client.ServerWide.Operations;
+using Raven.Server.Config;
 using Raven.Tests.Core.Utils.Entities;
 using Xunit;
 using Xunit.Abstractions;
 
-namespace FastTests.Server.Documents.Revisions
+namespace SlowTests.Server.Replication
 {
     public class ReplicationRevisionsTests : ReplicationTestBase
     {
@@ -27,15 +29,17 @@ namespace FastTests.Server.Documents.Revisions
         public async Task ReplicateRevision_WhenSourceDataFromExportAndDocDeleted_ShouldNotResuscitateTheDoc()
         {
             var exportFile = GetTempFileName();
-            
-            var (nodes, leader) = await CreateRaftCluster(2);
+            var settings = new Dictionary<string,string>()
+            {
+                [RavenConfiguration.GetKey(x => x.Cluster.OperationTimeout)] = "120",
+            };
+            var (nodes, leader) = await CreateRaftCluster(2, customSettings: settings);
             var nodeTags = nodes.Select(n => n.ServerStore.NodeTag).ToArray();
 
-            string firstNode;
             using (var store = GetDocumentStore(new Options {Server = leader, ReplicationFactor = 1}))
             {
                 await store.Maintenance.SendAsync(new ConfigureRevisionsOperation(new RevisionsConfiguration{Default = new RevisionsCollectionConfiguration()}));
-                firstNode = await AssertWaitForNotNullAsync(async () =>
+                var firstNode = await AssertWaitForNotNullAsync(async () =>
                     (await store.Maintenance.Server.SendAsync(new GetDatabaseRecordOperation(store.Database))).Topology.Members?.FirstOrDefault());
 
                 var entity = new User();
@@ -71,25 +75,35 @@ namespace FastTests.Server.Documents.Revisions
                 await operation.WaitForCompletionAsync();
             }
 
-            using (var store = GetDocumentStore(new Options {Server = leader, ReplicationFactor = 2}))
+            using (var store = GetDocumentStore(new Options {Server = leader, ReplicationFactor = 1}))
             {
+                var srcTag = await AssertWaitForNotNullAsync(async () =>
+                    (await store.Maintenance.Server.SendAsync(new GetDatabaseRecordOperation(store.Database))).Topology.Members.FirstOrDefault());
+                
+                var src = nodes.First(n => n.ServerStore.NodeTag == srcTag);
+                var dest = nodes.First(n => n.ServerStore.NodeTag != srcTag);
+                
                 var operation = await store.Smuggler.ImportAsync(new DatabaseSmugglerImportOptions(), exportFile);
                 await operation.WaitForCompletionAsync();
-
-                using var re1 = RequestExecutor.CreateForSingleNodeWithConfigurationUpdates(nodes[0].WebUrl, store.Database, null, store.Conventions);
-                using var re2 = RequestExecutor.CreateForSingleNodeWithConfigurationUpdates(nodes[1].WebUrl, store.Database, null, store.Conventions);
-                using (var firstSession = store.OpenAsyncSession(new SessionOptions{RequestExecutor = re1}))
-                using (var secondSession = store.OpenAsyncSession(new SessionOptions{RequestExecutor = re2}))
+                
+                using (var session = store.OpenAsyncSession())
                 {
-                    WaitForIndexing(store, store.Database, nodeTag:nodes[0].ServerStore.NodeTag);
-                    var firstNodeDocs = await firstSession.Query<User>().ToArrayAsync();
-                    
-                    WaitForIndexing(store, store.Database, nodeTag:nodes[1].ServerStore.NodeTag);
-                    var secondNodeDocs = await secondSession.Query<User>().ToArrayAsync();
+                    WaitForIndexing(store, store.Database, nodeTag:src.ServerStore.NodeTag);
+                    var firstNodeDocs = await session.Query<User>().ToArrayAsync();
+                    Assert.Equal(0, firstNodeDocs.Length);
+                }
+                
+                await AssertWaitForNotNullAsync(async () => await store.Maintenance.Server.SendAsync(new AddDatabaseNodeOperation(store.Database)), 30000);
+                await AssertWaitForValueAsync(async () => (await store.Maintenance.Server.SendAsync(new GetDatabaseRecordOperation(store.Database))).Topology.Members?.Count, 2);
 
-                    RavenTestHelper.AssertAll(
-                        () => Assert.Equal(0, firstNodeDocs.Length),
-                        () => Assert.Equal(0, secondNodeDocs.Length));
+                await store.GetRequestExecutor().UpdateTopologyAsync(new RequestExecutor.UpdateTopologyParameters(new ServerNode { Url = store.Urls.First(), Database = store.Database }));
+
+                using var re = RequestExecutor.CreateForSingleNodeWithConfigurationUpdates(dest.WebUrl, store.Database, null, store.Conventions);
+                using (var secondSession = store.OpenAsyncSession(new SessionOptions{RequestExecutor = re}))
+                {
+                    WaitForIndexing(store, store.Database, nodeTag:dest.ServerStore.NodeTag);
+                    var secondNodeDocs = await secondSession.Query<User>().ToArrayAsync();
+                    Assert.Equal(0, secondNodeDocs.Length);
                 }
             }
         }
@@ -97,20 +111,21 @@ namespace FastTests.Server.Documents.Revisions
         [Fact]
         public async Task ReplicateRevision_WhenSourceDataFromIncrementalBackupAndDocDeleted_ShouldNotResuscitateTheDoc()
         {
-            var backupPath = NewDataPath(suffix: "BackupFolder");
+            var backupPath = NewDataPath(suffix: "BackupFolder", forceCreateDir: true);
             
             var (nodes, leader) = await CreateRaftCluster(2);
-            var nodeTags = nodes.Select(n => n.ServerStore.NodeTag).ToArray();
 
-            string firstNode;
-            using (var store = GetDocumentStore(new Options {Server = leader, ReplicationFactor = 1}))
+            using (var store = GetDocumentStore(new Options {Server = leader, ReplicationFactor = 2}))
             {
                 await store.Maintenance.SendAsync(new ConfigureRevisionsOperation(new RevisionsConfiguration{Default = new RevisionsCollectionConfiguration()}));
-                firstNode = await AssertWaitForNotNullAsync(async () =>
+                var firstNodeTag = await AssertWaitForNotNullAsync(async () =>
                     (await store.Maintenance.Server.SendAsync(new GetDatabaseRecordOperation(store.Database))).Topology.Members?.FirstOrDefault());
-
+                var firstNode = nodes.First(n => n.ServerStore.NodeTag == firstNodeTag);
+                var secondNode = nodes.First(n => n.ServerStore.NodeTag != firstNodeTag);
+                
                 var entity = new User();
-                using (var session = store.OpenAsyncSession())
+                using (var re = RequestExecutor.CreateForSingleNodeWithConfigurationUpdates(firstNode.WebUrl, store.Database, null, store.Conventions))
+                using (var session = store.OpenAsyncSession(new SessionOptions{RequestExecutor = re}))
                 {
                     //Add first revision with first node tag
                     await session.StoreAsync(entity);
@@ -119,16 +134,14 @@ namespace FastTests.Server.Documents.Revisions
                 
                 var config = new PeriodicBackupConfiguration
                 {
+                    MentorNode = secondNode.ServerStore.NodeTag,
                     LocalSettings = new LocalSettings { FolderPath = backupPath },
-                    IncrementalBackupFrequency = "* * * * *" //every minute
+                    IncrementalBackupFrequency = "0 * * * *"
                 };
                 var backupTaskId = (await store.Maintenance.SendAsync(new UpdatePeriodicBackupOperation(config))).TaskId;
                 await (await SendAsync(store, new StartBackupOperation(true, backupTaskId))).WaitForCompletionAsync();
                 
-                await store.Maintenance.Server.SendAsync(new AddDatabaseNodeOperation(store.Database));
-                await AssertWaitForValueAsync(async () => (await store.Maintenance.Server.SendAsync(new GetDatabaseRecordOperation(store.Database))).Topology.Members?.Count, 2);
-                
-                await store.Maintenance.Server.SendAsync(new DeleteDatabasesOperation(store.Database, true, nodeTags.First(n => n == firstNode)));
+                await store.Maintenance.Server.SendAsync(new DeleteDatabasesOperation(store.Database, true, firstNodeTag));
                 await AssertWaitForValueAsync(async () =>
                 {
                     var dbRecord = await store.Maintenance.Server.SendAsync(new GetDatabaseRecordOperation(store.Database));
@@ -150,24 +163,33 @@ namespace FastTests.Server.Documents.Revisions
                 await (await SendAsync(store, new StartBackupOperation(false, backupTaskId))).WaitForCompletionAsync();
             }
 
-            using (var store = GetDocumentStore(new Options {Server = leader, ReplicationFactor = 2}))
+            using (var store = GetDocumentStore(new Options {Server = leader, ReplicationFactor = 1}))
             {
+                var srcTag = await AssertWaitForNotNullAsync(async () =>
+                    (await store.Maintenance.Server.SendAsync(new GetDatabaseRecordOperation(store.Database))).Topology.Members.FirstOrDefault());
+                
+                var src = nodes.First(n => n.ServerStore.NodeTag == srcTag);
+                var dest = nodes.First(n => n.ServerStore.NodeTag != srcTag);
                 await store.Smuggler.ImportIncrementalAsync(new DatabaseSmugglerImportOptions(), Directory.GetDirectories(backupPath).First());
-
-                using var re1 = RequestExecutor.CreateForSingleNodeWithConfigurationUpdates(nodes[0].WebUrl, store.Database, null, store.Conventions);
-                using var re2 = RequestExecutor.CreateForSingleNodeWithConfigurationUpdates(nodes[1].WebUrl, store.Database, null, store.Conventions);
-                using (var firstSession = store.OpenAsyncSession(new SessionOptions{RequestExecutor = re1}))
-                using (var secondSession = store.OpenAsyncSession(new SessionOptions{RequestExecutor = re2}))
+                
+                using (var session = store.OpenAsyncSession())
                 {
-                    WaitForIndexing(store, store.Database, nodeTag:nodes[0].ServerStore.NodeTag);
-                    var firstNodeDocs = await firstSession.Query<User>().ToArrayAsync();
-                    
-                    WaitForIndexing(store, store.Database, nodeTag:nodes[1].ServerStore.NodeTag);
-                    var secondNodeDocs = await secondSession.Query<User>().ToArrayAsync();
+                    WaitForIndexing(store, store.Database, nodeTag:src.ServerStore.NodeTag);
+                    var firstNodeDocs = await session.Query<User>().ToArrayAsync();
+                    Assert.Equal(0, firstNodeDocs.Length);
+                }
+                
+                await AssertWaitForNotNullAsync(async () => await store.Maintenance.Server.SendAsync(new AddDatabaseNodeOperation(store.Database)), 30000);
+                await AssertWaitForValueAsync(async () => (await store.Maintenance.Server.SendAsync(new GetDatabaseRecordOperation(store.Database))).Topology.Members?.Count, 2);
 
-                    RavenTestHelper.AssertAll(
-                        () => Assert.Equal(0, firstNodeDocs.Length),
-                        () => Assert.Equal(0, secondNodeDocs.Length));
+                await store.GetRequestExecutor().UpdateTopologyAsync(new RequestExecutor.UpdateTopologyParameters(new ServerNode { Url = store.Urls.First(), Database = store.Database }));
+
+                using var re = RequestExecutor.CreateForSingleNodeWithConfigurationUpdates(dest.WebUrl, store.Database, null, store.Conventions);
+                using (var secondSession = store.OpenAsyncSession(new SessionOptions{RequestExecutor = re}))
+                {
+                    WaitForIndexing(store, store.Database, nodeTag:dest.ServerStore.NodeTag);
+                    var secondNodeDocs = await secondSession.Query<User>().ToArrayAsync();
+                    Assert.Equal(0, secondNodeDocs.Length);
                 }
             }
         }
@@ -180,7 +202,8 @@ namespace FastTests.Server.Documents.Revisions
                 var command = operation.GetCommand(re.Conventions, context);
 
                 await re.ExecuteAsync(command, context, null, token).ConfigureAwait(false);
-                return new Operation(re, () => store.Changes(store.Database), re.Conventions, command.Result.OperationId, command.SelectedNodeTag ?? command.Result.ResponsibleNode);
+                var selectedNodeTag = command.SelectedNodeTag ?? command.Result.ResponsibleNode;
+                return new Operation(re, () => store.Changes(store.Database, selectedNodeTag), re.Conventions, command.Result.OperationId, selectedNodeTag);
             }
         }
     }


### PR DESCRIPTION
https://issues.hibernatingrhinos.com/issue/RavenDB-15475

To reproduce the issue there need to be two steps before the replication:
1. The document and its revision have to come from export/backup & import.
2. last revision has to be a deletion revision.
* One obligate state - the first revision has a "conflict" with the deletion.

Reason:
1. If the document came from the same database the `UnusedDatabaseIds` solve the conflict.
2. The `import` deal first with documents so if the document is not deleted the first revision will be created by the destination of the import and be the same as the final document so all the rest of the revision will be treated as conflict but the final result be the desired document.

One way to solve it is to import the `UnusedDatabaseIds` as well (as proposed in this PR).
Another way can be to remove the unused database Ids from the document in the import process but this will require specific treatment in documents that there change vector composed of just unused database ids.