### PR TITLE
RavenDB-15877 Optimizing between queries

### DIFF
--- a/src/Raven.Server/Documents/Queries/AST/BetweenExpression.cs
+++ b/src/Raven.Server/Documents/Queries/AST/BetweenExpression.cs
@@ -5,6 +5,8 @@ namespace Raven.Server.Documents.Queries.AST
         public QueryExpression Source;
         public ValueExpression Max;
         public ValueExpression Min;
+        public bool MinInclusive = true;
+        public bool MaxInclusive = true;
 
         public BetweenExpression(QueryExpression source, ValueExpression min, ValueExpression max)
         {

--- a/src/Raven.Server/Documents/Queries/AST/BinaryExpression.cs
+++ b/src/Raven.Server/Documents/Queries/AST/BinaryExpression.cs
@@ -9,6 +9,31 @@ namespace Raven.Server.Documents.Queries.AST
         public QueryExpression Right;
         public bool Parenthesis;
 
+        public bool IsRangeOperation => Operator switch
+        {
+            OperatorType.GreaterThan => true,
+            OperatorType.GreaterThanEqual => true,
+            OperatorType.LessThan => true,
+            OperatorType.LessThanEqual => true,
+            _ => false,
+        };
+        public bool IsGreaterThan => Operator switch
+        {
+            OperatorType.GreaterThan => true,
+            OperatorType.GreaterThanEqual => true,
+            OperatorType.LessThan => true,
+            OperatorType.LessThanEqual => true,
+            _ => false,
+        };
+
+        public bool IsLessThan => Operator switch
+        {
+            OperatorType.LessThan => true,
+            OperatorType.LessThanEqual => true,
+            _ => false,
+        };
+
+
         public BinaryExpression(QueryExpression left, QueryExpression right, OperatorType op)
         {
             Left = left;

--- a/src/Raven.Server/Documents/Queries/LuceneIntegration/IRavenLuceneMethodQuery.cs
+++ b/src/Raven.Server/Documents/Queries/LuceneIntegration/IRavenLuceneMethodQuery.cs
@@ -1,8 +1,0 @@
-﻿namespace Raven.Server.Documents.Queries.LuceneIntegration
-{
-    public interface IRavenLuceneMethodQuery
-    {
-        IRavenLuceneMethodQuery Merge(IRavenLuceneMethodQuery other);
-        string Field { get; }
-    }
-}

--- a/src/Raven.Server/Documents/Queries/LuceneQueryHelper.cs
+++ b/src/Raven.Server/Documents/Queries/LuceneQueryHelper.cs
@@ -326,6 +326,7 @@ This edge-case has a very slim chance of happening, but still we should not igno
             return new Term(fieldName, analyzedTermString);
         }
 
+
         private static Query CreateRange(string fieldName, string minValue, LuceneTermType minValueType, bool inclusiveMin, string maxValue, LuceneTermType maxValueType, bool inclusiveMax, bool exact)
         {
             var minTermIsNullOrStar = minValueType == LuceneTermType.Null || minValue.Equals(Asterisk);
@@ -343,22 +344,9 @@ This edge-case has a very slim chance of happening, but still we should not igno
 
         private static Query CreateRange(string fieldName, double minValue, bool inclusiveMin, double maxValue, bool inclusiveMax)
         {
-            return NumericRangeQuery.NewDoubleRange(fieldName, 4, minValue, maxValue, inclusiveMin, inclusiveMax);
-        }
-
-        private static Occur PrefixToOccurrence(LucenePrefixOperator prefix, Occur defaultOccurrence)
-        {
-            switch (prefix)
-            {
-                case LucenePrefixOperator.None:
-                    return defaultOccurrence;
-                case LucenePrefixOperator.Plus:
-                    return Occur.MUST;
-                case LucenePrefixOperator.Minus:
-                    return Occur.MUST_NOT;
-                default:
-                    throw new ArgumentOutOfRangeException("Unknown query prefix " + prefix);
-            }
+            var query = NumericRangeQuery.NewDoubleRange(fieldName, 4, minValue, maxValue, inclusiveMin, inclusiveMax);
+            
+            return query;
         }
     }
 }

--- a/src/Raven.Server/Documents/Queries/LuceneQueryHelper.cs
+++ b/src/Raven.Server/Documents/Queries/LuceneQueryHelper.cs
@@ -122,19 +122,19 @@ namespace Raven.Server.Documents.Queries
             return CreateRange(fieldName, value, true, double.MaxValue, true);
         }
 
-        public static Query Between(string fieldName, LuceneTermType termType, string fromValue, string toValue, bool exact)
+        public static Query Between(string fieldName, LuceneTermType termType, string fromValue, bool fromInclusive, string toValue, bool toInclusive, bool exact)
         {
-            return CreateRange(fieldName, fromValue, termType, true, toValue, termType, true, exact);
+            return CreateRange(fieldName, fromValue, termType, fromInclusive, toValue, termType, toInclusive, exact);
         }
 
-        public static Query Between(string fieldName, long fromValue, long toValue)
+        public static Query Between(string fieldName, long fromValue, bool fromInclusive, long toValue, bool toInclusive)
         {
-            return CreateRange(fieldName, fromValue, true, toValue, true);
+            return CreateRange(fieldName, fromValue, fromInclusive, toValue, toInclusive);
         }
 
-        public static Query Between(string fieldName, double fromValue, double toValue)
+        public static Query Between(string fieldName, double fromValue, bool fromInclusive, double toValue, bool toInclusive)
         {
-            return CreateRange(fieldName, fromValue, true, toValue, true);
+            return CreateRange(fieldName, fromValue, fromInclusive, toValue, toInclusive);
         }
 
         public static Query Term(string fieldName, string term, LuceneTermType type, float? boost = null, float? similarity = null, bool exact = false)

--- a/src/Raven.Server/Documents/Queries/QueryBuilder.cs
+++ b/src/Raven.Server/Documents/Queries/QueryBuilder.cs
@@ -394,7 +394,7 @@ namespace Raven.Server.Documents.Queries
                     matches.Add(LuceneQueryHelper.GetTermValue(tuple.Value, termType, exact || tuple.Type == ValueTokenType.Parameter));
                 }
 
-                return new TermsMatchQuery(fieldName, matches);
+                return new InQuery(fieldName, matches);
             }
             if (expression is TrueExpression)
             {

--- a/src/Raven.Server/Documents/Queries/QueryBuilder.cs
+++ b/src/Raven.Server/Documents/Queries/QueryBuilder.cs
@@ -264,6 +264,33 @@ namespace Raven.Server.Documents.Queries
                         }
                     case OperatorType.And:
                         {
+                            // translate ((Foo >= $p1) and (Foo <= $p2)) to a more efficient between query
+                            if (@where.Left is BinaryExpression lbe && lbe.IsRangeOperation  && 
+                               @where.Right is BinaryExpression rbe && rbe.IsRangeOperation && lbe.Left.Equals(rbe.Left) && 
+                               lbe.Right is ValueExpression leftVal && rbe.Right is ValueExpression rightVal)
+                            {
+                                BetweenExpression bq = null;
+                                if (lbe.IsGreaterThan && rbe.IsLessThan)
+                                {
+                                    bq = new BetweenExpression(lbe.Left, leftVal, rightVal)
+                                    {
+                                        MinInclusive = lbe.Operator == OperatorType.GreaterThanEqual,
+                                        MaxInclusive = rbe.Operator == OperatorType.LessThanEqual,
+                                    };
+                                }
+
+                                if (lbe.IsLessThan && rbe.IsGreaterThan)
+                                {
+                                    bq = new BetweenExpression(lbe.Left, rightVal, leftVal)
+                                    {
+                                        MinInclusive = rbe.Operator == OperatorType.GreaterThanEqual,
+                                        MaxInclusive = lbe.Operator == OperatorType.LessThanEqual
+                                    };
+                                }
+                                if(bq != null)
+                                    return TranslateBetweenQuery(query, metadata, index, parameters, exact, bq, secondary);
+                            }
+
                             var left = ToLuceneQuery(serverContext, documentsContext, query, @where.Left, metadata, index, parameters, analyzer,
                                 factories, exact, secondary: secondary);
                             var right = ToLuceneQuery(serverContext, documentsContext, query, @where.Right, metadata, index, parameters, analyzer,
@@ -328,13 +355,7 @@ namespace Raven.Server.Documents.Queries
             }
             if (expression is BetweenExpression be)
             {
-                var betweenQuery = TranslateBetweenQuery(query, metadata, index, parameters, exact, be);
-                if(secondary && betweenQuery is TermRangeQuery q)
-                {
-                    q.RewriteMethod = _secondaryBetweenRewriteMethod;
-                }
-
-                return betweenQuery;
+                return TranslateBetweenQuery(query, metadata, index, parameters, exact, be, secondary);
             }
             if (expression is InExpression ie)
             {
@@ -423,7 +444,7 @@ namespace Raven.Server.Documents.Queries
             throw new InvalidQueryException("Unable to understand query", query.QueryText, parameters);
         }
 
-        private static Lucene.Net.Search.Query TranslateBetweenQuery(Query query, QueryMetadata metadata, Index index, BlittableJsonReaderObject parameters, bool exact, BetweenExpression be)
+        private static Lucene.Net.Search.Query TranslateBetweenQuery(Query query, QueryMetadata metadata, Index index, BlittableJsonReaderObject parameters, bool exact, BetweenExpression be, bool secondary)
         {
             var fieldName = ExtractIndexFieldName(query, parameters, be.Source, metadata);
             var (valueFirst, valueFirstType) = GetValue(query, metadata, parameters, be.Min);
@@ -431,6 +452,7 @@ namespace Raven.Server.Documents.Queries
 
             var (luceneFieldName, fieldType, termType) = GetLuceneField(fieldName, valueFirstType);
 
+            Lucene.Net.Search.Query betweenQuery;
             switch (fieldType)
             {
                 case LuceneFieldType.String:
@@ -446,18 +468,28 @@ namespace Raven.Server.Documents.Queries
 
                     var valueFirstAsString = GetValueAsString(valueFirst);
                     var valueSecondAsString = GetValueAsString(valueSecond);
-                    return LuceneQueryHelper.Between(luceneFieldName, termType, valueFirstAsString, valueSecondAsString, exact);
+                    betweenQuery = LuceneQueryHelper.Between(luceneFieldName, termType, valueFirstAsString, be.MinInclusive, valueSecondAsString, be.MaxInclusive, exact);
+                    break;
                 case LuceneFieldType.Long:
                     var valueFirstAsLong = (long)valueFirst;
                     var valueSecondAsLong = (long)valueSecond;
-                    return LuceneQueryHelper.Between(luceneFieldName, valueFirstAsLong, valueSecondAsLong);
+                    betweenQuery =  LuceneQueryHelper.Between(luceneFieldName, valueFirstAsLong, be.MinInclusive, valueSecondAsLong, be.MaxInclusive);
+                    break;
                 case LuceneFieldType.Double:
                     var valueFirstAsDouble = (double)valueFirst;
                     var valueSecondAsDouble = (double)valueSecond;
-                    return LuceneQueryHelper.Between(luceneFieldName, valueFirstAsDouble, valueSecondAsDouble);
+                    betweenQuery = LuceneQueryHelper.Between(luceneFieldName, valueFirstAsDouble, be.MinInclusive, valueSecondAsDouble, be.MaxInclusive);
+                    break;
                 default:
                     throw new ArgumentOutOfRangeException(nameof(fieldType), fieldType, null);
             }
+
+            if (secondary && betweenQuery is TermRangeQuery q)
+            {
+                q.RewriteMethod = _secondaryBetweenRewriteMethod;
+            }
+
+            return betweenQuery;
         }
 
         private static bool TryUseTime(Index index, string fieldName, object valueFirst, object valueSecond, bool exact, out long ticksFirst, out long ticksSecond)


### PR DESCRIPTION
Changing the settings for between queries that are used as secondary filter to avoid preloading a lot of data in most common situations.