### PR TITLE
RavenDB-15884 JS indexes added support for return block statements in…

### DIFF
--- a/src/Raven.Server/Documents/Indexes/Static/JavaScriptIndexUtils.cs
+++ b/src/Raven.Server/Documents/Indexes/Static/JavaScriptIndexUtils.cs
@@ -12,6 +12,19 @@ namespace Raven.Server.Documents.Indexes.Static
 {
     public static class JavaScriptIndexUtils
     {
+        public static IEnumerable<ReturnStatement> GetReturnStatements(IFunction function)
+        {
+            if (function is ArrowFunctionExpression arrowFunction && arrowFunction.Body is ObjectExpression objectExpression)
+            {
+                // looks like we have following case:
+                // x => ({ Name: x.Name })
+                // wrap with return statement and we're done
+                return new[] { new ReturnStatement(objectExpression) };
+            }
+
+            return GetReturnStatements(function.Body);
+        }
+        
         public static IEnumerable<ReturnStatement> GetReturnStatements(Node stmt)
         {
             // here we only traverse the single statement, we don't try to traverse into

--- a/src/Raven.Server/Documents/Indexes/Static/JavaScriptMapOperation.cs
+++ b/src/Raven.Server/Documents/Indexes/Static/JavaScriptMapOperation.cs
@@ -116,7 +116,7 @@ namespace Raven.Server.Documents.Indexes.Static
                 theFuncAst = res.Value.FunctionAst;
             }
 
-            foreach (var returnStatement in JavaScriptIndexUtils.GetReturnStatements(theFuncAst.Body))
+            foreach (var returnStatement in JavaScriptIndexUtils.GetReturnStatements(theFuncAst))
             {
                 if (returnStatement.Argument == null) // return;
                     continue;


### PR DESCRIPTION
… group by + allow arrow functions which return objects (w/o explicit return) in js indexes map