### PR TITLE
Avoid GetWaiter ChunkedRemoteBulkInsertOperation

### DIFF
--- a/Raven.Client.Lightweight/Document/ChunkedRemoteBulkInsertOperation.cs
+++ b/Raven.Client.Lightweight/Document/ChunkedRemoteBulkInsertOperation.cs
@@ -41,11 +41,7 @@ namespace Raven.Client.Document
             this.changes = changes;
             currentChunkSize = 0;
             RemoteBulkInsertOperationSwitches = 0;
-            using (NoSynchronizationContext.Scope())
-            {
-                var currentAsync = GetBulkInsertOperation().ConfigureAwait(false);
-                current= currentAsync.GetAwaiter().GetResult();
-            }
+            current = CreateBulkInsertOperation(cachedPreviousEmptyTask);
         }
 
         public Guid OperationId


### PR DESCRIPTION
Something that I noticed during my investigations. I couldn't understand why doing sync over async is required in the ctor of ChunkedRemoteBulkInsertOperation because judging by the code flow when we are creating a chunked operation it is always the root of the remote bulk operations therefore I think it safer to just create the underlying remote bulk operation. 