### PR TITLE
RavenDB-16020 & RavenDB-16021

### DIFF
--- a/src/Raven.Server/Config/Categories/StorageConfiguration.cs
+++ b/src/Raven.Server/Config/Categories/StorageConfiguration.cs
@@ -91,6 +91,12 @@ namespace Raven.Server.Config.Categories
         [ConfigurationEntry("Storage.SyncJournalsCountThreshold", ConfigurationEntryScope.ServerWideOrPerDatabase)]
         public int SyncJournalsCountThreshold { get; set; }
 
+        [Description("Max amount of unsynchronized bytes before requesting a sync and removing unused journal files.")]
+        [DefaultValue(256)]
+        [SizeUnit(SizeUnit.Megabytes)]
+        [ConfigurationEntry("Storage.SyncJournalsMaxSizeInMegabytesThreshold", ConfigurationEntryScope.ServerWideOrPerDatabase)]
+        public Size SyncJournalsMaxSizeInMegabytesThreshold { get; set; }
+
         /// <summary>
         /// Specifies the time interval between each IoMetrics Cleaner run
         /// </summary>

--- a/src/Raven.Server/Documents/CompactDatabaseTask.cs
+++ b/src/Raven.Server/Documents/CompactDatabaseTask.cs
@@ -194,6 +194,7 @@ namespace Raven.Server.Documents
             options.PrefetchSegmentSize = configuration.Storage.PrefetchBatchSize.GetValue(SizeUnit.Bytes);
             options.PrefetchResetThreshold = configuration.Storage.PrefetchResetThreshold.GetValue(SizeUnit.Bytes);
             options.SyncJournalsCountThreshold = documentDatabase.Configuration.Storage.SyncJournalsCountThreshold;
+            options.SyncJournalsMaxSizeInMegabytesThreshold = documentDatabase.Configuration.Storage.SyncJournalsMaxSizeInMegabytesThreshold;
             options.SkipChecksumValidationOnDatabaseLoading = documentDatabase.Configuration.Storage.SkipChecksumValidationOnDatabaseLoading;
         }
 

--- a/src/Raven.Server/Documents/ConfigurationStorage.cs
+++ b/src/Raven.Server/Documents/ConfigurationStorage.cs
@@ -57,6 +57,7 @@ namespace Raven.Server.Documents
             options.PrefetchSegmentSize = db.Configuration.Storage.PrefetchBatchSize.GetValue(SizeUnit.Bytes);
             options.PrefetchResetThreshold = db.Configuration.Storage.PrefetchResetThreshold.GetValue(SizeUnit.Bytes);
             options.SyncJournalsCountThreshold = db.Configuration.Storage.SyncJournalsCountThreshold;
+            options.SyncJournalsMaxSizeInMegabytesThreshold = db.Configuration.Storage.SyncJournalsMaxSizeInMegabytesThreshold;
             options.IgnoreInvalidJournalErrors = db.Configuration.Storage.IgnoreInvalidJournalErrors;
             options.SkipChecksumValidationOnDatabaseLoading = db.Configuration.Storage.SkipChecksumValidationOnDatabaseLoading;
             options.IgnoreDataIntegrityErrorsOfAlreadySyncedTransactions = db.Configuration.Storage.IgnoreDataIntegrityErrorsOfAlreadySyncedTransactions;

--- a/src/Raven.Server/Documents/DocumentsStorage.cs
+++ b/src/Raven.Server/Documents/DocumentsStorage.cs
@@ -248,6 +248,7 @@ namespace Raven.Server.Documents
             options.PrefetchSegmentSize = DocumentDatabase.Configuration.Storage.PrefetchBatchSize.GetValue(SizeUnit.Bytes);
             options.PrefetchResetThreshold = DocumentDatabase.Configuration.Storage.PrefetchResetThreshold.GetValue(SizeUnit.Bytes);
             options.SyncJournalsCountThreshold = DocumentDatabase.Configuration.Storage.SyncJournalsCountThreshold;
+            options.SyncJournalsMaxSizeInMegabytesThreshold = DocumentDatabase.Configuration.Storage.SyncJournalsMaxSizeInMegabytesThreshold;
             options.IgnoreInvalidJournalErrors = DocumentDatabase.Configuration.Storage.IgnoreInvalidJournalErrors;
             options.SkipChecksumValidationOnDatabaseLoading = DocumentDatabase.Configuration.Storage.SkipChecksumValidationOnDatabaseLoading;
             options.IgnoreDataIntegrityErrorsOfAlreadySyncedTransactions = DocumentDatabase.Configuration.Storage.IgnoreDataIntegrityErrorsOfAlreadySyncedTransactions;

--- a/src/Raven.Server/Documents/Indexes/Index.cs
+++ b/src/Raven.Server/Documents/Indexes/Index.cs
@@ -629,6 +629,7 @@ namespace Raven.Server.Documents.Indexes
             options.PrefetchSegmentSize = documentDatabase.Configuration.Storage.PrefetchBatchSize.GetValue(SizeUnit.Bytes);
             options.PrefetchResetThreshold = documentDatabase.Configuration.Storage.PrefetchResetThreshold.GetValue(SizeUnit.Bytes);
             options.SyncJournalsCountThreshold = documentDatabase.Configuration.Storage.SyncJournalsCountThreshold;
+            options.SyncJournalsMaxSizeInMegabytesThreshold = documentDatabase.Configuration.Storage.SyncJournalsMaxSizeInMegabytesThreshold;
             options.IgnoreInvalidJournalErrors = documentDatabase.Configuration.Storage.IgnoreInvalidJournalErrors;
             options.SkipChecksumValidationOnDatabaseLoading = documentDatabase.Configuration.Storage.SkipChecksumValidationOnDatabaseLoading;
             options.IgnoreDataIntegrityErrorsOfAlreadySyncedTransactions = documentDatabase.Configuration.Storage.IgnoreDataIntegrityErrorsOfAlreadySyncedTransactions;

--- a/src/Raven.Server/Indexing/VoronIndexOutput.cs
+++ b/src/Raven.Server/Indexing/VoronIndexOutput.cs
@@ -55,7 +55,7 @@ namespace Raven.Server.Indexing
                 if (options.Encryption.IsEnabled)
                     return new TempCryptoStream(_fileTempPath, ignoreSetLength: true);
 
-                return SafeFileStream.Create(_fileTempPath, FileMode.CreateNew, FileAccess.ReadWrite, FileShare.ReadWrite, 4096, FileOptions.DeleteOnClose);
+                return SafeFileStream.Create(_fileTempPath, FileMode.CreateNew, FileAccess.ReadWrite, FileShare.ReadWrite, Voron.Global.Constants.Size.Megabyte, FileOptions.DeleteOnClose);
             }
             catch (IOException ioe) when (ioe.IsOutOfDiskSpaceException())
             {

--- a/src/Raven.Server/ServerWide/ServerStore.cs
+++ b/src/Raven.Server/ServerWide/ServerStore.cs
@@ -660,9 +660,11 @@ namespace Raven.Server.ServerWide
             options.PrefetchSegmentSize = Configuration.Storage.PrefetchBatchSize.GetValue(SizeUnit.Bytes);
             options.PrefetchResetThreshold = Configuration.Storage.PrefetchResetThreshold.GetValue(SizeUnit.Bytes);
             options.SyncJournalsCountThreshold = Configuration.Storage.SyncJournalsCountThreshold;
+            options.SyncJournalsMaxSizeInMegabytesThreshold = Configuration.Storage.SyncJournalsMaxSizeInMegabytesThreshold;
             options.IgnoreInvalidJournalErrors = Configuration.Storage.IgnoreInvalidJournalErrors;
             options.SkipChecksumValidationOnDatabaseLoading = Configuration.Storage.SkipChecksumValidationOnDatabaseLoading;
             options.IgnoreDataIntegrityErrorsOfAlreadySyncedTransactions = Configuration.Storage.IgnoreDataIntegrityErrorsOfAlreadySyncedTransactions;
+            options.SyncJournalsMaxSizeInMegabytesThreshold = Configuration.Storage.SyncJournalsMaxSizeInMegabytesThreshold;
 
             DirectoryExecUtils.SubscribeToOnDirectoryInitializeExec(options, Configuration.Storage, nameof(DirectoryExecUtils.EnvironmentType.System), DirectoryExecUtils.EnvironmentType.System, Logger);
 

--- a/src/Voron/GlobalFlushingBehavior.cs
+++ b/src/Voron/GlobalFlushingBehavior.cs
@@ -197,17 +197,15 @@ namespace Voron
                     continue;
 
                 var sizeOfUnflushedTransactionsInJournalFile = envToFlush.SizeOfUnflushedTransactionsInJournalFile;
-
                 if (sizeOfUnflushedTransactionsInJournalFile == 0)
                     continue; // nothing to do
 
-
                 if (sizeOfUnflushedTransactionsInJournalFile < envToFlush.Options.MaxNumberOfPagesInJournalBeforeFlush)
-                {
-                    // we haven't reached the point where we have to flush, but we might want to, if we have enough 
-                    // resources available, if we have more than half the flushing capacity, we can do it now, otherwise, we'll wait
+                {                   
+                    // We haven't yet reached the point where we have to flush, but we might want to, if we have enough 
+                    // resources available. If there are no flushes running we can try to do it, otherwise, we'll wait
                     // until it is actually required.
-                    if (_concurrentFlushesAvailable.CurrentCount < StorageEnvironment.MaxConcurrentFlushes / 2)
+                    if (_concurrentFlushesAvailable.CurrentCount != StorageEnvironment.MaxConcurrentFlushes)
                         continue;
 
                     // At the same time, we want to avoid excessive flushes, so we'll limit it to once in a while if we don't

--- a/src/Voron/Impl/Journal/WriteAheadJournal.cs
+++ b/src/Voron/Impl/Journal/WriteAheadJournal.cs
@@ -579,7 +579,7 @@ namespace Voron.Impl.Journal
             }
 
 
-            public void ApplyLogsToDataFile(CancellationToken token, TimeSpan timeToWait)
+            public void ApplyLogsToDataFile(CancellationToken token, TimeSpan timeToWait, bool suggestSync = true)
             {
                 if (token.IsCancellationRequested)
                     return;
@@ -706,7 +706,8 @@ namespace Voron.Impl.Journal
 
                     ApplyJournalStateAfterFlush(token, lastProcessedJournal, lastFlushedTransactionId, unusedJournals, byteStringContext);
 
-                    _waj._env.SuggestSyncDataFile();
+                    if (suggestSync)
+                        _waj._env.SuggestSyncDataFile();
                 }
                 finally
                 {

--- a/src/Voron/StorageEnvironmentOptions.cs
+++ b/src/Voron/StorageEnvironmentOptions.cs
@@ -75,8 +75,8 @@ namespace Voron
             {
                 _forceUsing32BitsPager = value;
                 MaxLogFileSize = (value ? 32 : 256) * Constants.Size.Megabyte;
-                MaxScratchBufferSize = (value ? 32 : 256) * Constants.Size.Megabyte;
-                MaxNumberOfPagesInJournalBeforeFlush = (value ? 4 : 32) * Constants.Size.Megabyte / Constants.Storage.PageSize;
+                MaxScratchBufferSize = (value ? 32 : 256) * Constants.Size.Megabyte;                
+                MaxNumberOfPagesInJournalBeforeFlush = (value ? 4 : 128) * Constants.Size.Megabyte / Constants.Storage.PageSize;
             }
         }
 
@@ -182,6 +182,8 @@ namespace Voron
             }
         }
 
+        public Size SyncJournalsMaxSizeInMegabytesThreshold { get; set; }
+
         public bool OwnsPagers { get; set; }
 
         public bool ManualFlushing { get; set; }
@@ -258,13 +260,11 @@ namespace Voron
                 if (_log.IsOperationsEnabled)
                     _log.Operations($"Catastrophic failure in {this}, StackTrace:'{stacktrace}'", e);
             });
-
-
-            
-
+          
             PrefetchSegmentSize = 4 * Constants.Size.Megabyte;
             PrefetchResetThreshold = shouldConfigPagersRunInLimitedMemoryEnvironment?256*(long)Constants.Size.Megabyte: 8 * (long)Constants.Size.Gigabyte;
             SyncJournalsCountThreshold = 2;
+            SyncJournalsMaxSizeInMegabytesThreshold = new Size(128, SizeUnit.Megabytes);
 
             ScratchSpaceUsage = new ScratchSpaceUsageMonitor();
         }
@@ -1194,7 +1194,7 @@ namespace Voron
             get
             {
                 if (_timeToSyncAfterFlushInSec < 1)
-                    _timeToSyncAfterFlushInSec = 30;
+                    _timeToSyncAfterFlushInSec = 120;
                 return _timeToSyncAfterFlushInSec;
             }
             set => _timeToSyncAfterFlushInSec = value;


### PR DESCRIPTION
The changes revolve around diminishing the IO impact of unbuffered access (in the case of Voron-Lucene's writing process) and improving the sync behavior and heuristic to make it more predictable. The old policy would suggest a Sync after every flush, the new policy will under low load wait by default 120 secs and under load after a certain amount of bytes are ready to be sync. In writing heavy environments waiting to sync larger amounts is better. The sync behavior doesn't show a measurable impact on IO starved systems or in the indexing process (which is more compute-bound) but it does on high-performance bulk inserting systems. 