### PR TITLE
RavenDB-15993 Separate context for builder in StreamOperation & reset+renew context on too high cachedProperties amount & memory size

### DIFF
--- a/src/Raven.Client/Documents/Session/Operations/StreamOperation.cs
+++ b/src/Raven.Client/Documents/Session/Operations/StreamOperation.cs
@@ -345,7 +345,7 @@ namespace Raven.Client.Documents.Session.Operations
             {
                 AssertInitialized();
 
-                CheckIfContextNeedsToBeRenewed();
+                CheckIfContextOrCacheNeedToBeRenewed();
 
                 _timeSeriesIt?.Dispose();
 
@@ -387,7 +387,7 @@ namespace Raven.Client.Documents.Session.Operations
             {
                 AssertInitialized();
 
-                CheckIfContextNeedsToBeRenewed();
+                CheckIfContextOrCacheNeedToBeRenewed();
 
                 if (_timeSeriesIt != null)
                     await _timeSeriesIt.DisposeAsync().ConfigureAwait(false);
@@ -573,7 +573,7 @@ namespace Raven.Client.Documents.Session.Operations
                 }
             }
 
-            private void CheckIfContextNeedsToBeRenewed()
+            private void CheckIfContextOrCacheNeedToBeRenewed()
             {
                 if (_builderContext.AllocatedMemory > 4 * 1024 * 1024 ||
                     _docsCountOnCachedRenewSession > _maxDocsCountOnCachedRenewSession)
@@ -584,8 +584,11 @@ namespace Raven.Client.Documents.Session.Operations
                     return;
                 }
 
-                if (_builder.NeedResetPropertiesCache())
-                    _builderContext.CachedProperties = new CachedProperties(_builderContext);
+                if (_builder.NeedClearPropertiesCache())
+                {
+                    _builderContext.CachedProperties.ClearRenew();
+                    return;
+                }
                 
                 ++_docsCountOnCachedRenewSession;
             }

--- a/src/Sparrow/Json/BlittableJsonDocumentBuilder.cs
+++ b/src/Sparrow/Json/BlittableJsonDocumentBuilder.cs
@@ -490,7 +490,7 @@ namespace Sparrow.Json
             return "Building json for " + _debugTag;
         }
 
-        public bool NeedResetPropertiesCache()
+        public bool NeedClearPropertiesCache()
         {
             return _context.CachedProperties.PropertiesDiscovered > CachedProperties.CachedPropertiesSize;
         }

--- a/src/Sparrow/Json/CachedProperties.cs
+++ b/src/Sparrow/Json/CachedProperties.cs
@@ -47,6 +47,25 @@ namespace Sparrow.Json
             _cachedSorts = null;
         }
 
+        public void Clear()
+        {
+            Reset();
+            _docPropNames.Clear();
+            _propertiesSortOrder.Clear();
+            _propertyNameToId.Clear();
+            _propertyNameCounter = 0;
+            _propertiesNeedSorting = false;
+            PropertiesDiscovered = 0;
+            _hasDuplicates = false;
+            DocumentNumber = 0;
+        }
+
+        public void ClearRenew()
+        {
+            Clear();
+            Renew();
+        }
+
         private struct PropertySorter : IComparer<BlittableJsonDocumentBuilder.PropertyTag>
         {
             private readonly CachedProperties properties;

--- a/src/Sparrow/Json/Parsing/UnmanagedJsonParserHelper.cs
+++ b/src/Sparrow/Json/Parsing/UnmanagedJsonParserHelper.cs
@@ -173,10 +173,9 @@ namespace Sparrow.Json.Parsing
             {
                 if (docsCountOnCachedRenewSession <= 16 * 1024)
                 {
-
                     if (cachedItemsRenew)
                     {
-                        context.CachedProperties = new CachedProperties(context);
+                        context.CachedProperties.ClearRenew();
                         ++docsCountOnCachedRenewSession;
                     }
                 }
@@ -194,8 +193,7 @@ namespace Sparrow.Json.Parsing
 
                 using (var builder = new BlittableJsonDocumentBuilder(context, BlittableJsonDocumentBuilder.UsageMode.None, "readArray/singleResult", parser, state))
                 {
-                    if (cachedItemsRenew == false)
-                        cachedItemsRenew = builder.NeedResetPropertiesCache();
+                    cachedItemsRenew = builder.NeedClearPropertiesCache();
                     ReadObject(builder, peepingTomStream, parser, buffer);
 
                     yield return builder.CreateReader();

--- a/test/SlowTests/Core/Streaming/QueryStreaming.cs
+++ b/test/SlowTests/Core/Streaming/QueryStreaming.cs
@@ -5,6 +5,7 @@
 // -----------------------------------------------------------------------
 
 using System;
+using System.Collections.Generic;
 using System.Diagnostics;
 using System.Linq;
 using System.Threading.Tasks;
@@ -240,10 +241,16 @@ namespace SlowTests.Core.Streaming
         [Fact]
         public async Task QueryStream_WhenDocsContainsMultipleUniqPropertyNames_ShouldNotBeVeryVerySlow()
         {
-            using var store = GetDocumentStore();
-
-            var objs = Enumerable.Range(0, 100000).Select(_ => new DynamicJsonValue
+            using var store = GetDocumentStore(new Options
             {
+                ModifyDocumentStore = s => s.Conventions.FindClrType = (t, b) => "SomeType"
+            });
+
+            var objs = Enumerable.Range(0, 50000).Select(_ => new Dictionary<string, string>
+            {
+                [Guid.NewGuid().ToString("n")] = "someValue",
+                [Guid.NewGuid().ToString("n")] = "someValue",
+                [Guid.NewGuid().ToString("n")] = "someValue",
                 [Guid.NewGuid().ToString("n")] = "someValue",
                 [Guid.NewGuid().ToString("n")] = "someValue",
                 [Guid.NewGuid().ToString("n")] = "someValue"
@@ -259,7 +266,7 @@ namespace SlowTests.Core.Streaming
                     {
                         await session.StoreAsync(obj);
                         i++;
-                        if (i % 100 == 0)
+                        if (i % 50 == 0)
                         {
                             await session.SaveChangesAsync();
                             session.Dispose();


### PR DESCRIPTION
https://issues.hibernatingrhinos.com/issue/RavenDB-15993

The main issue here is not the memory even so there is a little bit of issue with memory.
But the cause is multiple unique property names.
This leads to a bigger problem where we can have thousands of cached properties and we spend very significant time searching in the inner collections in CachedProperties.