### PR TITLE
RavenDB-14634 avoid blocking record change

### DIFF
--- a/src/Raven.Client/Documents/Changes/EvictItemsFromCacheBasedOnChanges.cs
+++ b/src/Raven.Client/Documents/Changes/EvictItemsFromCacheBasedOnChanges.cs
@@ -7,6 +7,7 @@
 using System;
 using System.Threading;
 using Raven.Client.Http;
+using Raven.Client.Util;
 
 namespace Raven.Client.Documents.Changes
 {
@@ -27,6 +28,11 @@ namespace Raven.Client.Documents.Changes
             _documentsSubscription = docSub.Subscribe(this);
             var indexSub = _changes.ForAllIndexes();
             _indexesSubscription = indexSub.Subscribe(this);
+        }
+
+        public void EnsureConnected()
+        {
+            AsyncHelpers.RunSync(_changes.EnsureConnectedNow);
         }
 
         public void OnNext(DocumentChange change)

--- a/src/Raven.Client/Documents/DocumentStore.cs
+++ b/src/Raven.Client/Documents/DocumentStore.cs
@@ -360,6 +360,7 @@ namespace Raven.Client.Documents
                     () => new EvictItemsFromCacheBasedOnChanges(this, database)));
             }
             GC.KeepAlive(lazy.Value); // here we force it to be evaluated
+            lazy.Value.EnsureConnected();
         }
 
         private AsyncDocumentSession OpenAsyncSessionInternal(SessionOptions options)

--- a/src/Raven.Client/Documents/Operations/Replication/InternalReplication.cs
+++ b/src/Raven.Client/Documents/Operations/Replication/InternalReplication.cs
@@ -1,0 +1,45 @@
+﻿using System;
+using Raven.Client.Documents.Replication;
+
+namespace Raven.Client.Documents.Operations.Replication
+{
+    public class InternalReplication : ReplicationNode
+    {
+        private string _nodeTag;
+        public string NodeTag
+        {
+            get => _nodeTag;
+            set
+            {
+                if (HashCodeSealed)
+                    throw new InvalidOperationException(
+                        $"NodeTag of 'InternalReplication' can't be modified after 'GetHashCode' was invoked, if you see this error it is likley a bug (NodeTag={_nodeTag} value={value} Url={Url}).");
+                _nodeTag = value;
+            }
+        }
+        public override string FromString()
+        {
+            return $"[{NodeTag}/{Url}]";
+        }
+
+        public override bool IsEqualTo(ReplicationNode other)
+        {
+            if (other is InternalReplication internalNode)
+            {
+                return base.IsEqualTo(internalNode) &&
+                       string.Equals(Url, internalNode.Url, StringComparison.OrdinalIgnoreCase);
+            }
+            return false;
+        }
+        
+        public override int GetHashCode()
+        {
+            unchecked
+            {
+                var hashCode = (int)CalculateStringHash(NodeTag);
+                HashCodeSealed = true;
+                return hashCode;
+            }
+        }
+    }
+}

--- a/src/Raven.Server/Documents/DatabasesLandlord.cs
+++ b/src/Raven.Server/Documents/DatabasesLandlord.cs
@@ -434,6 +434,17 @@ namespace Raven.Server.Documents
             {
                 var exceptionAggregator = new ExceptionAggregator(_logger, "Failure to dispose landlord");
 
+                try
+                {
+                    // prevent creating new databases
+                    _databaseSemaphore.Dispose();
+                }
+                catch (Exception e)
+                {
+                    if (_logger.IsInfoEnabled)
+                        _logger.Info("Failed to dispose resource semaphore", e);
+                }
+
                 // we don't want to wake up database during dispose.
                 var handles = new List<WaitHandle>();
                 foreach (var timer in _wakeupTimers.Values)
@@ -495,15 +506,7 @@ namespace Raven.Server.Documents
                 });
                 DatabasesCache.Clear();
 
-                try
-                {
-                    _databaseSemaphore.Dispose();
-                }
-                catch (Exception e)
-                {
-                    if (_logger.IsInfoEnabled)
-                        _logger.Info("Failed to dispose resource semaphore", e);
-                }
+                
 
                 exceptionAggregator.ThrowIfNeeded();
             }

--- a/src/Raven.Server/Documents/DatabasesLandlord.cs
+++ b/src/Raven.Server/Documents/DatabasesLandlord.cs
@@ -146,7 +146,7 @@ namespace Raven.Server.Documents
                     switch (changeType)
                     {
                         case ClusterDatabaseChangeType.RecordChanged:
-                            database.StateChanged(index);
+                            await database.StateChanged(index);
                             if (type == ClusterStateMachine.SnapshotInstalled)
                             {
                                 database.NotifyOnPendingClusterTransaction(index, changeType);

--- a/src/Raven.Server/Documents/DocumentDatabase.cs
+++ b/src/Raven.Server/Documents/DocumentDatabase.cs
@@ -304,9 +304,9 @@ namespace Raven.Server.Documents
                 _addToInitLog("Initializing IndexStore (async)");
                 _indexStoreTask = IndexStore.InitializeAsync(record, index, _addToInitLog);
                 _addToInitLog("Initializing Replication");
-                ReplicationLoader?.Initialize(record);
+                ReplicationLoader?.Initialize(record, index);
                 _addToInitLog("Initializing ETL");
-                EtlLoader.Initialize(record);
+                EtlLoader.Initialize(record, index);
 
                 TombstoneCleaner.Start();
 
@@ -670,7 +670,7 @@ namespace Raven.Server.Documents
 
                 _forTestingPurposes?.DisposeLog?.Invoke(Name, $"Drained all requests. Took: {sp.Elapsed}");
             }
-
+            
             var exceptionAggregator = new ExceptionAggregator(_logger, $"Could not dispose {nameof(DocumentDatabase)} {Name}");
 
             _forTestingPurposes?.DisposeLog?.Invoke(Name, "Acquiring cluster lock");
@@ -1234,7 +1234,7 @@ namespace Raven.Server.Documents
             }
         }
 
-        public void StateChanged(long index)
+        public async Task StateChanged(long index)
         {
             try
             {
@@ -1255,8 +1255,10 @@ namespace Raven.Server.Documents
 
                 StudioConfiguration = record.Studio;
 
-                NotifyFeaturesAboutStateChange(record, index);
-                RachisLogIndexNotifications.NotifyListenersAbout(index, null);
+                var result = NotifyFeaturesAboutStateChange(record, index);
+
+                await result.WaitForTasks;
+                RachisLogIndexNotifications.NotifyListenersAbout(result.Index, null);
             }
             catch (Exception e)
             {
@@ -1277,10 +1279,25 @@ namespace Raven.Server.Documents
             }
         }
 
-        private void NotifyFeaturesAboutStateChange(DatabaseRecord record, long index)
+        private class StateChangeResult
         {
+            public readonly long Index;
+            public Task EtlTask = Task.CompletedTask;
+            public Task IndexTask = Task.CompletedTask;
+
+            public Task WaitForTasks => Task.WhenAll(EtlTask, IndexTask);
+
+            public StateChangeResult(long index)
+            {
+                Index = index;
+            }
+        }
+
+        private StateChangeResult NotifyFeaturesAboutStateChange(DatabaseRecord record, long index)
+        {
+            var result = new StateChangeResult(index);
             if (CanSkipDatabaseRecordChange(record.DatabaseName, index))
-                return;
+                return result;
 
             var taken = false;
             while (taken == false)
@@ -1290,10 +1307,10 @@ namespace Raven.Server.Documents
                 try
                 {
                     if (CanSkipDatabaseRecordChange(record.DatabaseName, index))
-                        return;
+                        return result;
 
                     if (DatabaseShutdown.IsCancellationRequested)
-                        return;
+                        return result;
 
                     if (taken == false)
                         continue;
@@ -1310,9 +1327,9 @@ namespace Raven.Server.Documents
 
                         SetUnusedDatabaseIds(record);
                         InitializeFromDatabaseRecord(record);
-                        IndexStore.HandleDatabaseRecordChange(record, index);
-                        ReplicationLoader?.HandleDatabaseRecordChange(record);
-                        EtlLoader?.HandleDatabaseRecordChange(record);
+                        result.IndexTask = IndexStore.HandleDatabaseRecordChange(record, index);
+                        ReplicationLoader?.HandleDatabaseRecordChange(record, index);
+                        result.EtlTask = EtlLoader?.HandleDatabaseRecordChange(record, index);
                         SubscriptionStorage?.HandleDatabaseRecordChange(record);
 
                         OnDatabaseRecordChanged(record);
@@ -1335,6 +1352,8 @@ namespace Raven.Server.Documents
                         Monitor.Exit(_clusterLocker);
                 }
             }
+
+            return result;
         }
 
         private void SetUnusedDatabaseIds(DatabaseRecord record)

--- a/src/Raven.Server/Documents/ETL/EtlLoader.cs
+++ b/src/Raven.Server/Documents/ETL/EtlLoader.cs
@@ -27,7 +27,7 @@ namespace Raven.Server.Documents.ETL
     {
         private const string AlertTitle = "ETL loader";
 
-        private ConcurrentSet<EtlProcess> _processes = new ConcurrentSet<EtlProcess>();
+        private readonly ConcurrentSet<EtlProcess> _processes = new ConcurrentSet<EtlProcess>();
         private readonly ConcurrentSet<string> _uniqueConfigurationNames = new ConcurrentSet<string>(StringComparer.OrdinalIgnoreCase); // read and modified under a lock.
 
         private DatabaseRecord _databaseRecord;
@@ -57,7 +57,7 @@ namespace Raven.Server.Documents.ETL
             database.TombstoneCleaner.Subscribe(this);
         }
 
-        public EtlProcess[] Processes => _processes.ToArray();
+        public IEnumerable<EtlProcess> Processes => _processes;
 
         public List<RavenEtlConfiguration> RavenDestinations;
 

--- a/src/Raven.Server/Documents/ETL/Providers/Raven/RavenEtl.cs
+++ b/src/Raven.Server/Documents/ETL/Providers/Raven/RavenEtl.cs
@@ -173,9 +173,9 @@ namespace Raven.Server.Documents.ETL.Providers.Raven
             throw new TimeoutException(message, e);
         }
 
-        public override void Dispose()
+        public override void Dispose(string reason)
         {
-            base.Dispose();
+            base.Dispose(reason);
 
             if (_configuration.TestMode == false)
             {

--- a/src/Raven.Server/Documents/Indexes/CollectionOfIndexes.cs
+++ b/src/Raven.Server/Documents/Indexes/CollectionOfIndexes.cs
@@ -14,7 +14,7 @@ namespace Raven.Server.Documents.Indexes
         private readonly ConcurrentDictionary<string, ConcurrentSet<Index>> _indexesByCollection = 
             new ConcurrentDictionary<string, ConcurrentSet<Index>>(StringComparer.OrdinalIgnoreCase);
 
-        private class IndexNameComparer : IEqualityComparer<string>
+        public class IndexNameComparer : IEqualityComparer<string>
         {
             public static readonly IndexNameComparer Instance = new IndexNameComparer();
 

--- a/src/Raven.Server/Documents/Indexes/IndexStore.cs
+++ b/src/Raven.Server/Documents/Indexes/IndexStore.cs
@@ -146,7 +146,7 @@ namespace Raven.Server.Documents.Indexes
                     catch (Exception e)
                     {
                         if (lazyIndex.IsValueCreated)
-                            lazyIndex.Value.Dispose(delete: true);
+                            DeleteIndexInternal(lazyIndex.Value, raiseNotification: true);
 
                         _documentDatabase.RachisLogIndexNotifications.NotifyListenersAbout(raftIndex, e);
 

--- a/src/Raven.Server/Documents/Indexes/MapReduce/Auto/AutoMapReduceIndex.cs
+++ b/src/Raven.Server/Documents/Indexes/MapReduce/Auto/AutoMapReduceIndex.cs
@@ -290,9 +290,9 @@ namespace Raven.Server.Documents.Indexes.MapReduce.Auto
             }
         }
 
-        protected override void DisposeIndex()
+        protected override void DisposeIndex(bool delete)
         {
-            base.DisposeIndex();
+            base.DisposeIndex(delete);
             _reduceKeyProcessor.ReleaseBuffer();
         }
 

--- a/src/Raven.Server/Documents/Replication/ConflictManager.cs
+++ b/src/Raven.Server/Documents/Replication/ConflictManager.cs
@@ -72,7 +72,7 @@ namespace Raven.Server.Documents.Replication
                     conflictedDoc))
                     return;
 
-                if (_conflictResolver.ConflictSolver?.ResolveToLatest ?? true)
+                if (_database.ReplicationLoader.ConflictSolverConfig?.ResolveToLatest ?? true)
                 {
                     var conflicts = new List<DocumentConflict>
                     {

--- a/src/Raven.Server/Documents/ResourceCache.cs
+++ b/src/Raven.Server/Documents/ResourceCache.cs
@@ -22,8 +22,16 @@ namespace Raven.Server.Documents
         private readonly ConcurrentDictionary<StringSegment, Task<TResource>> _caseSensitive
             = new ConcurrentDictionary<StringSegment, Task<TResource>>(StringSegmentComparer.Ordinal);
 
+        private readonly ConcurrentDictionary<Task<TResource>, ResourceDetails> _resourceDetails
+            = new ConcurrentDictionary<Task<TResource>, ResourceDetails>();
+
         private readonly ConcurrentDictionary<StringSegment, ConcurrentSet<StringSegment>> _mappings =
             new ConcurrentDictionary<StringSegment, ConcurrentSet<StringSegment>>(StringSegmentComparer.OrdinalIgnoreCase);
+
+        public class ResourceDetails
+        {
+            public DateTime InCacheSince;
+        }
 
         /// <summary>
         /// This locks the entire cache. Use carefully.
@@ -36,6 +44,7 @@ namespace Raven.Server.Documents
         {
             _caseSensitive.Clear();
             _caseInsensitive.Clear();
+            _resourceDetails.Clear();
         }
 
         public bool TryGetValue(StringSegment resourceName, out Task<TResource> resourceTask)
@@ -44,7 +53,15 @@ namespace Raven.Server.Documents
                 return true;
             
             return UnlikelyTryGet(resourceName, out resourceTask);
-                
+        }
+
+        public bool TryGetValue(StringSegment resourceName, out Task<TResource> resourceTask, out ResourceDetails details)
+        {
+            details = null;
+            if (TryGetValue(resourceName, out resourceTask) == false)
+                return false;
+
+            return _resourceDetails.TryGetValue(resourceTask, out details);
         }
 
         private bool UnlikelyTryGet(StringSegment resourceName, out Task<TResource> resourceTask)
@@ -69,6 +86,8 @@ namespace Raven.Server.Documents
         {
             if (_caseInsensitive.TryRemove(resourceName, out resourceTask) == false)
                 return false;
+            
+            _resourceDetails.TryRemove(resourceTask, out _);
 
             lock (this)
             {
@@ -113,6 +132,13 @@ namespace Raven.Server.Documents
                     return value;
 
                 value = _caseInsensitive.GetOrAdd(databaseName, task);
+                if (value == task)
+                {
+                    _resourceDetails[task] = new ResourceDetails
+                    {
+                        InCacheSince = DateTime.UtcNow
+                    };
+                }
                 _caseSensitive[databaseName] = value;
                 _mappings[databaseName] = new ConcurrentSet<StringSegment>
                 {
@@ -195,6 +221,13 @@ namespace Raven.Server.Documents
                     existingTask = existing;
                     return task;
                 });
+
+                ResourceDetails details = null;
+                if (existingTask != null)
+                    _resourceDetails.TryRemove(existingTask, out details);
+
+                _resourceDetails[task] = details ?? new ResourceDetails{InCacheSince = SystemTime.UtcNow};
+
                 if (_mappings.TryGetValue(databaseName, out ConcurrentSet<StringSegment> mappings))
                 {
                     foreach (var mapping in mappings)

--- a/src/Raven.Server/Rachis/Leader.cs
+++ b/src/Raven.Server/Rachis/Leader.cs
@@ -856,6 +856,19 @@ namespace Raven.Server.Rachis
 
                         foreach (var entry in _entries)
                         {
+                            if (entry.Value.OnNotify != null)
+                            {
+                                try
+                                {
+                                    entry.Value.OnNotify(entry.Value.TaskCompletionSource);
+                                }
+                                catch (Exception e)
+                                {
+                                    entry.Value.TaskCompletionSource.TrySetException(e);
+                                    continue;
+                                }
+                            }
+
                             if (te == null)
                             {
                                 entry.Value.TaskCompletionSource.TrySetCanceled();

--- a/src/Raven.Server/ServerWide/Commands/UpdateTopologyCommand.cs
+++ b/src/Raven.Server/ServerWide/Commands/UpdateTopologyCommand.cs
@@ -1,4 +1,5 @@
-﻿using Raven.Client.ServerWide;
+﻿using System;
+using Raven.Client.ServerWide;
 using Sparrow.Json.Parsing;
 
 namespace Raven.Server.ServerWide.Commands
@@ -6,19 +7,23 @@ namespace Raven.Server.ServerWide.Commands
     public class UpdateTopologyCommand : UpdateDatabaseCommand
     {
         public DatabaseTopology Topology;
+        public DateTime At;
 
         public UpdateTopologyCommand()
         {
             //
         }
 
-        public UpdateTopologyCommand(string databaseName, string uniqueRequestId) : base(databaseName, uniqueRequestId)
+        public UpdateTopologyCommand(string databaseName, DateTime at, string uniqueRequestId) : base(databaseName, uniqueRequestId)
         {
+            At = at;
         }
 
         public override string UpdateDatabaseRecord(DatabaseRecord record, long etag)
         {
             record.Topology = Topology;
+            record.Topology.NodesModifiedAt = At;
+
             if (record.Topology.Stamp == null)
             {
                 record.Topology.Stamp = new LeaderStamp
@@ -36,6 +41,7 @@ namespace Raven.Server.ServerWide.Commands
         {
             json[nameof(Topology)] = Topology.ToJson();
             json[nameof(RaftCommandIndex)] = RaftCommandIndex;
+            json[nameof(At)] = At;
         }
     }
 }

--- a/src/Raven.Server/ServerWide/ServerStore.cs
+++ b/src/Raven.Server/ServerWide/ServerStore.cs
@@ -2353,6 +2353,7 @@ namespace Raven.Server.ServerWide
             record.Topology.Stamp ??= new LeaderStamp();
             record.Topology.Stamp.Term = _engine.CurrentTerm;
             record.Topology.Stamp.LeadersTicks = _engine.CurrentLeader?.LeaderShipDuration ?? 0;
+            record.Topology.NodesModifiedAt = SystemTime.UtcNow;
 
             var addDatabaseCommand = new AddDatabaseCommand(raftRequestId)
             {

--- a/src/Raven.Server/Smuggler/Documents/DatabaseDestination.cs
+++ b/src/Raven.Server/Smuggler/Documents/DatabaseDestination.cs
@@ -140,6 +140,7 @@ namespace Raven.Server.Smuggler.Documents
                 if (_batch != null)
                 {
                     _batch.AddIndex(indexDefinition, _source, _database.Time.GetUtcNow(), RaftIdGenerator.DontCareId);
+                    AsyncHelpers.RunSync(_batch.SaveIfNeeded);
                     return;
                 }
 
@@ -151,6 +152,7 @@ namespace Raven.Server.Smuggler.Documents
                 if (_batch != null)
                 {
                     _batch.AddIndex(indexDefinition, _source, _database.Time.GetUtcNow(), RaftIdGenerator.DontCareId);
+                    AsyncHelpers.RunSync(_batch.SaveIfNeeded);
                     return;
                 }
 

--- a/src/Raven.Server/Web/System/AdminDatabasesHandler.cs
+++ b/src/Raven.Server/Web/System/AdminDatabasesHandler.cs
@@ -186,7 +186,13 @@ namespace Raven.Server.Web.System
                 }
 
                 databaseRecord.Topology.ReplicationFactor++;
-                var (newIndex, _) = await ServerStore.WriteDatabaseRecordAsync(name, databaseRecord, index, raftRequestId);
+
+                var update = new UpdateTopologyCommand(name, raftRequestId)
+                {
+                    Topology = databaseRecord.Topology
+                };
+
+                var (newIndex, _) = await ServerStore.SendToLeaderAsync(update);
 
                 try
                 {

--- a/src/Raven.Server/Web/System/AdminDatabasesHandler.cs
+++ b/src/Raven.Server/Web/System/AdminDatabasesHandler.cs
@@ -187,7 +187,7 @@ namespace Raven.Server.Web.System
 
                 databaseRecord.Topology.ReplicationFactor++;
 
-                var update = new UpdateTopologyCommand(name, raftRequestId)
+                var update = new UpdateTopologyCommand(name, SystemTime.UtcNow, raftRequestId)
                 {
                     Topology = databaseRecord.Topology
                 };
@@ -465,7 +465,7 @@ namespace Raven.Server.Web.System
                 topology.Rehabs = reorderedTopology.Rehabs;
                 topology.PriorityOrder = parameters.Fixed ? parameters.MembersOrder : null;
 
-                var reorder = new UpdateTopologyCommand(name, GetRaftRequestIdFromQuery())
+                var reorder = new UpdateTopologyCommand(name, SystemTime.UtcNow, GetRaftRequestIdFromQuery())
                 {
                     Topology = topology
                 };

--- a/src/Raven.Server/Web/System/DatabasesHandler.cs
+++ b/src/Raven.Server/Web/System/DatabasesHandler.cs
@@ -5,6 +5,7 @@ using System.Net;
 using System.Threading.Tasks;
 using Raven.Client.Documents.Indexes;
 using Raven.Client.Documents.Operations.Configuration;
+using Raven.Client.Documents.Operations.Replication;
 using Raven.Client.Extensions;
 using Raven.Client.Http;
 using Raven.Client.ServerWide;

--- a/src/Sparrow/Threading/DisposeOnce.cs
+++ b/src/Sparrow/Threading/DisposeOnce.cs
@@ -38,6 +38,22 @@ namespace Sparrow.Threading
         }
     }
 
+    /// <summary>
+    /// Runs the dispose action. Ensures any threads that are running it	
+    /// concurrently wait for the dispose to finish if it is in progress.	    
+    /// 	
+    /// If the dispose has already happened, the <see cref="TOperationMode"/> defines	
+    /// how Dispose will react. The two approaches differ only in error	
+    /// handling.	
+    /// 	
+    /// When behavior is <see cref="ExceptionRetry"/>, we will retry the	
+    /// Dispose until it succeeds. Retry, however, happens on successive	
+    /// calls to Dispose, rather than in a single attempt.	
+    /// 	
+    /// When behavior is <see cref="SingleAttempt"/> or <see cref="SingleAttemptWithWaitForDisposeToFinish"/>, a failure means all	
+    /// subsequent calls will fail by throwing the same exception that	
+    /// was thrown by the action.	
+    /// </summary>
     public sealed class DisposeOnce<TOperationMode> : DisposeOnceAbstract<TOperationMode>
         where TOperationMode : struct, IDisposeOnceOperationMode
     {

--- a/src/Sparrow/Utils/ThreadingHelper.cs
+++ b/src/Sparrow/Utils/ThreadingHelper.cs
@@ -1,0 +1,21 @@
+﻿using System.Threading;
+
+namespace Sparrow.Utils
+{
+    internal static class ThreadingHelper
+    {
+        public static bool InterlockedExchangeMax(ref long location, long newValue)
+        {
+            long initialValue;
+
+            do
+            {
+                initialValue = location;
+                if (initialValue >= newValue)
+                    return false;
+            } while (Interlocked.CompareExchange(ref location, newValue, initialValue) != initialValue);
+
+            return true;
+        }
+    }
+}

--- a/test/RachisTests/DatabaseCluster/ClusterDatabaseMaintenance.cs
+++ b/test/RachisTests/DatabaseCluster/ClusterDatabaseMaintenance.cs
@@ -348,7 +348,7 @@ namespace RachisTests.DatabaseCluster
             {
                 [RavenConfiguration.GetKey(x => x.Cluster.ElectionTimeout)] = 300.ToString(),
                 [RavenConfiguration.GetKey(x => x.Cluster.StabilizationTime)] = "1",
-                [RavenConfiguration.GetKey(x => x.Cluster.MoveToRehabGraceTime)] = "10",
+                [RavenConfiguration.GetKey(x => x.Cluster.MoveToRehabGraceTime)] = "5",
                 [RavenConfiguration.GetKey(x => x.Cluster.RotatePreferredNodeGraceTime)] = "1",
                 [RavenConfiguration.GetKey(x => x.Replication.ReplicationMinimalHeartbeat)] = "15",
             };
@@ -412,7 +412,7 @@ namespace RachisTests.DatabaseCluster
             {
                 [RavenConfiguration.GetKey(x => x.Cluster.ElectionTimeout)] = 300.ToString(),
                 [RavenConfiguration.GetKey(x => x.Cluster.StabilizationTime)] = "1",
-                [RavenConfiguration.GetKey(x => x.Cluster.MoveToRehabGraceTime)] = "10",
+                [RavenConfiguration.GetKey(x => x.Cluster.MoveToRehabGraceTime)] = "5",
                 [RavenConfiguration.GetKey(x => x.Cluster.RotatePreferredNodeGraceTime)] = "1",
                 [RavenConfiguration.GetKey(x => x.Replication.ReplicationMinimalHeartbeat)] = "15",
             };
@@ -750,7 +750,7 @@ namespace RachisTests.DatabaseCluster
                 doc.Topology.Members.Add("B");
                 doc.Topology.Members.Add("C");
                 var databaseResult = await store.Maintenance.Server.SendAsync(new CreateDatabaseOperation(doc, dbGroupSize));
-                Assert.Equal(dbGroupSize, databaseResult.Topology.Members.Count);
+                Assert.True(dbGroupSize == databaseResult.Topology.Members.Count, databaseResult.Topology.ToString());
                 await WaitForRaftIndexToBeAppliedInCluster(databaseResult.RaftCommandIndex, TimeSpan.FromSeconds(10));
                 using (var session = store.OpenAsyncSession())
                 {

--- a/test/RachisTests/DatabaseCluster/ClusterDatabaseMaintenance.cs
+++ b/test/RachisTests/DatabaseCluster/ClusterDatabaseMaintenance.cs
@@ -758,8 +758,8 @@ namespace RachisTests.DatabaseCluster
                     await session.SaveChangesAsync();
                 }
                 Assert.True(await WaitForDocumentInClusterAsync<User>(doc.Topology, databaseName, "users/1", u => u.Name == "Karmel", TimeSpan.FromSeconds(5)));
-                DisposeServerAndWaitForFinishOfDisposal(Servers[1]);
-                DisposeServerAndWaitForFinishOfDisposal(Servers[2]);
+                await DisposeServerAndWaitForFinishOfDisposalAsync(Servers[1]);
+                await DisposeServerAndWaitForFinishOfDisposalAsync(Servers[2]);
 
                 // the db should move to D & E
                 var newTopology = new DatabaseTopology();

--- a/test/RachisTests/DatabaseCluster/ReplicationTests.cs
+++ b/test/RachisTests/DatabaseCluster/ReplicationTests.cs
@@ -53,6 +53,8 @@ namespace RachisTests.DatabaseCluster
                     }
                 };
                 var res = await store.Maintenance.Server.SendAsync(new CreateDatabaseOperation(doc));
+
+                Assert.False(res.Topology.Members.Single() == leader.ServerStore.NodeTag, res.Topology.ToString());
                 Assert.NotEqual(res.Topology.Members.First(), leader.ServerStore.NodeTag);
 
                 using (var session = store.OpenAsyncSession())

--- a/test/SlowTests/Server/Documents/ETL/Raven/RavenDB_13220.cs
+++ b/test/SlowTests/Server/Documents/ETL/Raven/RavenDB_13220.cs
@@ -1,5 +1,6 @@
 ﻿using System;
 using System.Collections.Generic;
+using System.Linq;
 using System.Security.Cryptography;
 using System.Text;
 using Raven.Client.Documents.Operations.ETL;
@@ -82,7 +83,7 @@ namespace SlowTests.Server.Documents.ETL
 
                 var db = GetDatabase(src.Database).Result;
 
-                Assert.Equal(1, db.EtlLoader.Processes.Length);
+                Assert.Equal(1, db.EtlLoader.Processes.Count());
 
                 var etlDone = WaitForEtl(src, (n, s) => s.LoadSuccesses > 0);
 
@@ -180,7 +181,7 @@ namespace SlowTests.Server.Documents.ETL
 
                 var db = GetDatabase(src.Database).Result;
 
-                Assert.Equal(1, db.EtlLoader.Processes.Length);
+                Assert.Equal(1, db.EtlLoader.Processes.Count());
 
                 var etlDone = WaitForEtl(src, (n, s) => s.LoadSuccesses > 0);
 

--- a/test/SlowTests/Server/Documents/ETL/RavenDB_10674.cs
+++ b/test/SlowTests/Server/Documents/ETL/RavenDB_10674.cs
@@ -1,4 +1,5 @@
 ﻿using System;
+using System.Linq;
 using System.Threading;
 using Raven.Client.Documents.Operations.ETL;
 using Raven.Tests.Core.Utils.Entities;
@@ -46,7 +47,7 @@ namespace SlowTests.Server.Documents.ETL
                     Database = "test",
                 });
 
-                var process = GetDatabase(src.Database).Result.EtlLoader.Processes[0];
+                var process = GetDatabase(src.Database).Result.EtlLoader.Processes.First();
 
                 Assert.True(SpinWait.SpinUntil(() =>
                 {

--- a/test/SlowTests/Server/Documents/ETL/RavenDB_11983.cs
+++ b/test/SlowTests/Server/Documents/ETL/RavenDB_11983.cs
@@ -1,4 +1,5 @@
-﻿using System.Threading.Tasks;
+﻿using System.Linq;
+using System.Threading.Tasks;
 using Raven.Client.Documents.Operations.ETL;
 using Sparrow.Json.Parsing;
 using Sparrow.Server.Collections;
@@ -49,7 +50,7 @@ namespace SlowTests.Server.Documents.ETL
                         Database = "Northwind",
                     });
 
-                    Assert.Equal(2, database.EtlLoader.Processes.Length);
+                    Assert.Equal(2, database.EtlLoader.Processes.Count());
 
                     AddEtl(store, new RavenEtlConfiguration()
                     {
@@ -77,7 +78,7 @@ namespace SlowTests.Server.Documents.ETL
                         Database = "Northwind",
                     });
 
-                    Assert.Equal(4, database.EtlLoader.Processes.Length);
+                    Assert.Equal(4, database.EtlLoader.Processes.Count());
                 }
             }
         }

--- a/test/SlowTests/Server/Documents/ETL/RavenDB_12809.cs
+++ b/test/SlowTests/Server/Documents/ETL/RavenDB_12809.cs
@@ -1,5 +1,6 @@
 ﻿using System;
 using System.Collections.Generic;
+using System.Linq;
 using System.Security.Cryptography;
 using System.Text;
 using Raven.Client.Documents.Operations.ETL;
@@ -76,7 +77,7 @@ namespace SlowTests.Server.Documents.ETL
 
                 var db = GetDatabase(src.Database).Result;
 
-                Assert.Equal(1, db.EtlLoader.Processes.Length);
+                Assert.Equal(1, db.EtlLoader.Processes.Count());
             }
         }
     }

--- a/test/SlowTests/Server/Documents/Indexing/MapReduce/OutputReduceToCollectionTests.cs
+++ b/test/SlowTests/Server/Documents/Indexing/MapReduce/OutputReduceToCollectionTests.cs
@@ -15,6 +15,7 @@ using Raven.Client.Documents.Queries;
 using Raven.Client.Documents.Smuggler;
 using Raven.Client.Exceptions.Documents.Indexes;
 using Raven.Server.Documents.Indexes.MapReduce.Static;
+using Raven.Server.Utils;
 using Xunit;
 using Xunit.Abstractions;
 
@@ -282,7 +283,7 @@ namespace SlowTests.Server.Documents.Indexing.MapReduce
         {
             using (var store = GetDocumentStore())
             {
-                store.ExecuteIndex(new DailyInvoicesIndex());
+                await store.ExecuteIndexAsync(new DailyInvoicesIndex());
 
                 var date = new DateTime(2017, 1, 1);
 
@@ -307,7 +308,7 @@ namespace SlowTests.Server.Documents.Indexing.MapReduce
 
                 WaitForIndexing(store);
 
-                store.Maintenance.Send(new StopIndexingOperation());
+                await store.Maintenance.SendAsync(new StopIndexingOperation());
 
                 await store.ExecuteIndexAsync(new Replacement_AverageFieldAdded.DailyInvoicesIndex());
 

--- a/test/SlowTests/Server/Replication/PullReplicationTests.cs
+++ b/test/SlowTests/Server/Replication/PullReplicationTests.cs
@@ -519,7 +519,7 @@ namespace SlowTests.Server.Replication
                     await WaitForValueAsync(async () => (await minionStore.Maintenance.Server.SendAsync(new GetDatabaseRecordOperation(minionDB))).Topology.Rehabs.Count,
                         1));
 
-                EnsureReplicating((DocumentStore)hubStore, (DocumentStore)minionStore);
+                await EnsureReplicatingAsync((DocumentStore)hubStore, (DocumentStore)minionStore);
 
                 connections = await WaitForValueAsync(() => mentorDatabase.ReplicationLoader.OutgoingConnections.Count(), 3);
                 Assert.Equal(3, connections);

--- a/test/SlowTests/Server/Replication/ReplicationCleanTombstones.cs
+++ b/test/SlowTests/Server/Replication/ReplicationCleanTombstones.cs
@@ -473,9 +473,9 @@ namespace SlowTests.Server.Replication
             EtlProcess etlP = null;
             foreach (var server in cluster.Nodes)
             {
-                if (( server.Disposed ) || (server.ServerStore.DatabasesLandlord.TryGetOrCreateResourceStore(store.Database).Result.EtlLoader.Processes.Length == 0))
+                if (( server.Disposed ) || (server.ServerStore.DatabasesLandlord.TryGetOrCreateResourceStore(store.Database).Result.EtlLoader.Processes.Any() == false))
                     continue;
-                etlP = server.ServerStore.DatabasesLandlord.TryGetOrCreateResourceStore(store.Database).Result.EtlLoader.Processes[0];
+                etlP = server.ServerStore.DatabasesLandlord.TryGetOrCreateResourceStore(store.Database).Result.EtlLoader.Processes.First();
             }
 
             var total = 0;

--- a/test/Tests.Infrastructure/RavenTestBase.cs
+++ b/test/Tests.Infrastructure/RavenTestBase.cs
@@ -661,7 +661,7 @@ namespace FastTests
         protected async Task<T> WaitAndAssertForGreaterThanAsync<T>(Func<Task<T>> act, T expectedVal, int timeout = 15000, int interval = 100) where T : IComparable
         {
             var actualValue = await WaitForGreaterThanAsync(act, expectedVal, timeout, interval);
-            Assert.True(actualValue.CompareTo(expectedVal) > 0);
+            Assert.True(actualValue.CompareTo(expectedVal) > 0, $"expectedVal:{expectedVal}, actualValue: {actualValue}");
             return actualValue;
         }
 


### PR DESCRIPTION
- don't create TCP connection for internal nodes under lock
- don't dispose Index under lock
- don't dispose ETL under lock
- don't wait for conflicts resolution under lock