### PR TITLE
RavenDB-15984 add encryption as extra dimention for benchmark tests -…

### DIFF
--- a/test/BenchmarkTests/BenchmarkTestBase.cs
+++ b/test/BenchmarkTests/BenchmarkTestBase.cs
@@ -48,7 +48,7 @@ namespace BenchmarkTests
             var co = new ServerCreationOptions
             {
                 CustomSettings = customSettings,
-                RunInMemory = false, 
+                RunInMemory = !Encrypted, 
                 RegisterForDisposal = false,
                 NodeTag = "A",
                 DataDirectory = RavenTestHelper.NewDataPath("benchmark", 0, true)


### PR DESCRIPTION
… temporarly run non-encypted tests in memory