### PR TITLE
Revert "RavenDB-15984 add encryption as extra dimention for benchmark…

### DIFF
--- a/test/BenchmarkTests/BenchmarkTestBase.cs
+++ b/test/BenchmarkTests/BenchmarkTestBase.cs
@@ -48,7 +48,7 @@ namespace BenchmarkTests
             var co = new ServerCreationOptions
             {
                 CustomSettings = customSettings,
-                RunInMemory = !Encrypted, 
+                RunInMemory = false, 
                 RegisterForDisposal = false,
                 NodeTag = "A",
                 DataDirectory = RavenTestHelper.NewDataPath("benchmark", 0, true)


### PR DESCRIPTION
… tests - temporarly run non-encypted tests in memory"

This reverts commit 7849960dbfd6f576063320fab6ea66b0351cf9b9.