### PR TITLE
RavenDB-16139

### DIFF
--- a/src/Raven.Server/Config/Categories/IndexingConfiguration.cs
+++ b/src/Raven.Server/Config/Categories/IndexingConfiguration.cs
@@ -158,7 +158,7 @@ namespace Raven.Server.Config.Categories
         public Size? TransactionSizeLimit { get; protected set; }
 
         [Description("Transaction size limit, for encrypted database only, after which an index will stop and complete the current batch")]
-        [DefaultValue(64)]
+        [DefaultValue(96)]
         [SizeUnit(SizeUnit.Megabytes)]
         [IndexUpdateType(IndexUpdateType.Refresh)]
         [ConfigurationEntry("Indexing.Encrypted.TransactionSizeLimitInMb", ConfigurationEntryScope.ServerWideOrPerDatabase)]

--- a/src/Raven.Server/Config/Categories/StorageConfiguration.cs
+++ b/src/Raven.Server/Config/Categories/StorageConfiguration.cs
@@ -129,7 +129,7 @@ namespace Raven.Server.Config.Categories
         public bool IgnoreDataIntegrityErrorsOfAlreadySyncedTransactions { get; set; }
 
         [Description("EXPERT: Disable encryption buffer pooling.")]
-        [DefaultValue(false)]
+        [DefaultValue(true)]
         [ConfigurationEntry("Storage.Encrypted.DisableBuffersPooling", ConfigurationEntryScope.ServerWideOnly)]
         public bool DisableEncryptionBuffersPooling { get; set; }
     }


### PR DESCRIPTION
- temporary disable Encryption Buffers Pool
- increase Indexing.Encrypted.TransactionSizeLimitInMb to 96