### PR TITLE
RDBS-108 Ensure the tombstone table is created

### DIFF
--- a/src/Raven.Server/Documents/DocumentsStorage.cs
+++ b/src/Raven.Server/Documents/DocumentsStorage.cs
@@ -1440,6 +1440,11 @@ namespace Raven.Server.Documents
                 {
                     collectionName = ExtractCollectionName(context, local.Tombstone.Collection);
                 }
+                else if (local.Tombstone.Collection.Equals(collectionName.Name) == false)
+                {
+                    // ensure the table for the tombstones is created
+                    ExtractCollectionName(context, collectionName.Name);
+                }
 
                 var tombstoneTable = context.Transaction.InnerTransaction.OpenTable(TombstonesSchema,
                     collectionName.GetTableName(CollectionTableType.Tombstones));


### PR DESCRIPTION
It might happened that we get in replication 2 tombstones with identical id, but different collection.
If that tombstone was the first entity in that collection we need to make sure the tables are properly created.