### PR TITLE
RavenDB-16105 CryptoPager.BreakLargeAllocationToSeparatePages needs t…

### DIFF
--- a/src/Voron/Impl/Journal/JournalReader.cs
+++ b/src/Voron/Impl/Journal/JournalReader.cs
@@ -382,7 +382,7 @@ namespace Voron.Impl.Journal
                 var size = (4 * Constants.Size.Kilobyte) * GetNumberOf4KbFor(sizeof(TransactionHeader) + pagesSize);
 
                 var ptr = PlatformSpecific.NativeMemory.Allocate4KbAlignedMemory(size, out var thread);
-                var buffer = new EncryptionBuffer
+                var buffer = new EncryptionBuffer(options.Encryption.EncryptionBuffersPool)
                 {
                     Pointer = ptr,
                     Size = size,

--- a/src/Voron/Impl/Paging/AbstractPager.cs
+++ b/src/Voron/Impl/Paging/AbstractPager.cs
@@ -324,7 +324,7 @@ namespace Voron.Impl.Paging
             return AcquirePagePointerInternal(tx, pageNumber, pagerState);
         }
 
-        public virtual void BreakLargeAllocationToSeparatePages(IPagerLevelTransactionState tx, long pageNumber)
+        public virtual void BreakLargeAllocationToSeparatePages(IPagerLevelTransactionState tx, long valuePositionInScratchBuffer, long actualNumberOfAllocatedScratchPages)
         {
             // This method is implemented only in Crypto Pager
         }

--- a/src/Voron/Impl/Scratch/ScratchBufferFile.cs
+++ b/src/Voron/Impl/Scratch/ScratchBufferFile.cs
@@ -338,7 +338,7 @@ namespace Voron.Impl.Scratch
                     new PageFromScratchBuffer(value.ScratchFileNumber, value.PositionInScratchBuffer + i, 1, 1));
             }
 
-            _scratchPager.BreakLargeAllocationToSeparatePages(tx, value.PositionInScratchBuffer);
+            _scratchPager.BreakLargeAllocationToSeparatePages(tx, value.PositionInScratchBuffer, value.NumberOfPages);
         }
 
         private static void InvalidAttemptToBreakupPageThatWasntAllocated(PageFromScratchBuffer value)

--- a/src/Voron/StorageEnvironmentOptions.cs
+++ b/src/Voron/StorageEnvironmentOptions.cs
@@ -19,6 +19,7 @@ using Sparrow.Server.Platform;
 using Sparrow.Server.Utils;
 using Sparrow.Utils;
 using Voron.Exceptions;
+using Voron.Impl;
 using Voron.Impl.FileHeaders;
 using Voron.Impl.Journal;
 using Voron.Impl.Paging;
@@ -1356,6 +1357,8 @@ namespace Voron
             public byte[] MasterKey;
 
             public bool IsEnabled => MasterKey != null;
+
+            public EncryptionBuffersPool EncryptionBuffersPool = EncryptionBuffersPool.Instance;
 
             public bool HasExternalJournalCompressionBufferHandlerRegistration { get; private set; }
 

--- a/test/SlowTests/Voron/Issues/RavenDB_16105.cs
+++ b/test/SlowTests/Voron/Issues/RavenDB_16105.cs
@@ -23,6 +23,7 @@ namespace SlowTests.Voron.Issues
         {
             options.ManualFlushing = true;
             options.Encryption.MasterKey = _masterKey.ToArray();
+            options.Encryption.EncryptionBuffersPool = new EncryptionBuffersPool();
         }
 
         [Fact]

--- a/test/SlowTests/Voron/Issues/RavenDB_16105.cs
+++ b/test/SlowTests/Voron/Issues/RavenDB_16105.cs
@@ -1,0 +1,99 @@
+﻿using System.Linq;
+using FastTests.Voron;
+using Sparrow;
+using Sparrow.Server;
+using Voron;
+using Voron.Data;
+using Voron.Global;
+using Voron.Impl;
+using Xunit;
+using Xunit.Abstractions;
+
+namespace SlowTests.Voron.Issues
+{
+    public class RavenDB_16105 : StorageTest
+    {
+        public RavenDB_16105(ITestOutputHelper output) : base(output)
+        {
+        }
+
+        private readonly byte[] _masterKey = Sodium.GenerateRandomBuffer((int)Sodium.crypto_aead_xchacha20poly1305_ietf_keybytes());
+
+        protected override void Configure(StorageEnvironmentOptions options)
+        {
+            options.ManualFlushing = true;
+            options.Encryption.MasterKey = _masterKey.ToArray();
+        }
+
+        [Fact]
+        public unsafe void MustNotEncryptBuffersThatWereExtraAllocatedJustToSatisfyPowerOf2Size()
+        {
+            RequireFileBasedPager();
+
+            using (var tx = Env.WriteTransaction())
+            {
+                tx.LowLevelTransaction.DataPager.EnsureContinuous(20, 100);
+
+                tx.LowLevelTransaction.AllocatePage(50);
+
+                tx.Commit();
+            }
+
+            var pageNumber = 10;
+            var numberOfAllocatedPages = 58;
+            int dataSizeOnSinglePage = Constants.Storage.PageSize - PageHeader.SizeOf;
+
+            using (var tx = Env.WriteTransaction())
+            {
+                // this will allocate encryption buffer of size 64 pages because we use Bits.PowerOf2(numberOfPages) under the covers
+                // in the scratch file the allocation will start at position 66
+                var p = tx.LowLevelTransaction.AllocatePage(numberOfAllocatedPages, pageNumber); 
+
+                p.Flags |= PageFlags.Overflow;
+                p.OverflowSize = 8 * Constants.Storage.PageSize;
+
+                tx.LowLevelTransaction.BreakLargeAllocationToSeparatePages(pageNumber); // this must not mark extra 6 pages (64 - 58 == 6) as valid for encryption on CryptoPager.TxOnCommit
+
+                for (int i = 0; i < numberOfAllocatedPages; i++)
+                {
+                    Page page = tx.LowLevelTransaction.GetPage(pageNumber + i);
+
+                    Memory.Set(page.DataPointer, (byte)i, dataSizeOnSinglePage);
+                }
+
+                var cryptoPagerTransactionState = ((IPagerLevelTransactionState)tx.LowLevelTransaction).CryptoPagerTransactionState;
+
+                var scratchFile = Env.ScratchBufferPool.GetScratchBufferFile(0);
+
+                var state = cryptoPagerTransactionState[scratchFile.File.Pager];
+
+                Assert.False(state[124].Modified); // starting position 66 in the scratch file + 58 pages of actual allocation
+                Assert.False(state[125].Modified);
+                Assert.False(state[126].Modified);
+                Assert.False(state[127].Modified);
+                Assert.False(state[128].Modified);
+                Assert.False(state[129].Modified);
+
+                for (int i = 0; i < numberOfAllocatedPages; i++)
+                {
+                    Assert.True(state[66 + i].Modified); // pages in use must have Modified = true
+                }
+
+                tx.Commit();
+            }
+
+            using (var tx = Env.ReadTransaction())
+            {
+                for (int i = 0; i < numberOfAllocatedPages; i++)
+                {
+                    Page page = tx.LowLevelTransaction.GetPage(pageNumber + i);
+
+                    for (int j = 0; j < dataSizeOnSinglePage; j++)
+                    {
+                        Assert.Equal(i, page.DataPointer[j]);
+                    }
+                }
+            }
+        }
+    }
+}


### PR DESCRIPTION
…o take into account that not all separated buffers are gonna be in use. We must not set Modfied: true for them since it might crash on attempt to encrypt such buffer because it expects to get valid PageHeader at the beginning of the buffer data.

The issue was introduced in #11311 because we started to pass number of pages instead of size in bytes to `EncryptionBuffersPool.Get`:

https://github.com/ravendb/ravendb/pull/11311/files#diff-0946b8099de6e96db92ea6bc7d643f665cf9872e17f6701d959262b2c4c45cafR49

After that change `CryptoPager.BreakLargeAllocationToSeparatePages` didn't take into account that not entire the encryption buffer is going to be in use. So on attempt to `EncryptPage` on tx commit:

https://github.com/ravendb/ravendb/blob/b6bda5da965668791663980c4e948d9f9226e000/src/Voron/Impl/Paging/CryptoPager.cs#L327

it could result in segfault because the content of buffer could contain garbage (_Important note_: on Linux the memory returned by `posix_memalign` is not zeroed, on Windows `VirtualAlloc` function automatically initializes returned memory to zero)

https://issues.hibernatingrhinos.com/issue/RavenDB-16105