### PR TITLE
RavenDB-16188 Fixing ocassionally failing test. We might get VoronUnr…

### DIFF
--- a/test/SlowTests/Issues/RavenDB_6414.cs
+++ b/test/SlowTests/Issues/RavenDB_6414.cs
@@ -44,7 +44,7 @@ namespace SlowTests.Issues
                         database.GetAllStoragesEnvironment().First().Environment.Options.SetCatastrophicFailure(ExceptionDispatchInfo.Capture(e));
                     }
 
-                    var ex = Assert.Throws<Exception>(() =>
+                    var ex = Assert.ThrowsAny<Exception>(() =>
                     {
                         using (var context = DocumentsOperationContext.ShortTermSingleUse(database))
                         {


### PR DESCRIPTION
…ecoverableErrorException if the exception is raised by the background flusher.