### PR TITLE
RavenDB-16191 - Azure backup retention policy isn't working when the remote folder name is null

### DIFF
--- a/src/Raven.Server/Documents/PeriodicBackup/Retention/AzureRetentionPolicyRunner.cs
+++ b/src/Raven.Server/Documents/PeriodicBackup/Retention/AzureRetentionPolicyRunner.cs
@@ -25,7 +25,7 @@ namespace Raven.Server.Documents.PeriodicBackup.Retention
 
         protected override GetFoldersResult GetSortedFolders()
         {
-            var prefix = $"{_client.RemoteFolderName}{Delimiter}";
+            var prefix = string.IsNullOrWhiteSpace(_client.RemoteFolderName) ? string.Empty : $"{_client.RemoteFolderName}{Delimiter}";
             var result = _client.ListBlobs(prefix, Delimiter, listFolders: true, marker: _nextMarker);
             _nextMarker = result.NextMarker;
 


### PR DESCRIPTION
https://issues.hibernatingrhinos.com/issue/RavenDB-16191