### PR TITLE
RavenDB-15929 ThreadUsage consider two thread with same CpuUsage and TotalProcessorTime as the same one fixed

### DIFF
--- a/src/Raven.Server/Dashboard/ThreadsInfo.cs
+++ b/src/Raven.Server/Dashboard/ThreadsInfo.cs
@@ -34,7 +34,10 @@ namespace Raven.Server.Dashboard
                 if (compareByCpu != 0)
                     return compareByCpu;
 
-                return y.TotalProcessorTime.CompareTo(x.TotalProcessorTime);
+                int compareTo = y.TotalProcessorTime.CompareTo(x.TotalProcessorTime);
+                if (compareTo != 0)
+                    return compareTo;
+                return y.Id.CompareTo(x.Id);
             }
         }
 

--- a/test/FastTests/Server/ThreadUsageTests.cs
+++ b/test/FastTests/Server/ThreadUsageTests.cs
@@ -1,0 +1,37 @@
+﻿using System;
+using System.Linq;
+using System.Threading.Tasks;
+using Raven.Client.Documents.Indexes;
+using Raven.Client.Documents.Operations.Indexes;
+using Raven.Server.Documents.Indexes;
+using Raven.Server.Documents.Indexes.Auto;
+using Raven.Server.Utils;
+using Xunit;
+using Xunit.Abstractions;
+
+namespace FastTests.Server
+{
+    public class ThreadUsageTests : RavenLowLevelTestBase
+    {
+        public ThreadUsageTests(ITestOutputHelper output) : base(output)
+        {
+        }
+
+        [Fact]
+        public async Task ThreadUsage_WhenThreadsHaveSameCpuUsageAndTotalProcessorTime_ShouldListThemBoth()
+        {
+            using (var database = CreateDocumentDatabase())
+            {
+                using var index1 = await database.IndexStore.CreateIndex(new AutoMapIndexDefinition("Companies", new[] { new AutoIndexField { Name = "Name" } }), Guid.NewGuid().ToString());
+                using var index2 = await database.IndexStore.CreateIndex(new AutoMapIndexDefinition("Users", new[] { new AutoIndexField { Name = "Age" } }), Guid.NewGuid().ToString());
+                {
+                    var threadsUsage = new ThreadsUsage();
+                    var threadsInfo = threadsUsage.Calculate();
+                    var threadNames = threadsInfo.List.Select(ti => ti.Name).ToArray();
+                    Assert.Contains(index1._indexingThread.Name, threadNames);
+                    Assert.Contains(index2._indexingThread.Name, threadNames);
+                }
+            }
+        }
+    }
+}


### PR DESCRIPTION
https://issues.hibernatingrhinos.com/issue/RavenDB-15929