### PR TITLE
RavenDB-16229 - Memory leak when patching a large collection

### DIFF
--- a/src/Raven.Server/Documents/CollectionRunner.cs
+++ b/src/Raven.Server/Documents/CollectionRunner.cs
@@ -116,6 +116,8 @@ namespace Raven.Server.Documents
                                     break;
                                 }
 
+                                context.Transaction.ForgetAbout(document);
+
                                 ids.Enqueue(document.Id);
                             }
                         }


### PR DESCRIPTION
https://issues.hibernatingrhinos.com/issue/RavenDB-16229