### PR TITLE
RavenDB-16253 : Cannot append timeseries with DateTime.MinValue

### DIFF
--- a/src/Raven.Server/Documents/TimeSeries/TimeSeriesStats.cs
+++ b/src/Raven.Server/Documents/TimeSeries/TimeSeriesStats.cs
@@ -210,6 +210,13 @@ namespace Raven.Server.Documents.TimeSeries
 
             void HandleLiveSegment()
             {
+                if (segment.NumberOfEntries == 1 && start > end)
+                {
+                    // new series
+                    start = end = baseline;
+                    return;
+                }
+
                 var lastTimestamp = GetLastLiveTimestamp(context, segment, baseline);
 
                 if (lastTimestamp > end)

--- a/test/SlowTests/Client/TimeSeries/Issues/RavenDB_16253.cs
+++ b/test/SlowTests/Client/TimeSeries/Issues/RavenDB_16253.cs
@@ -1,0 +1,34 @@
+﻿using System;
+using FastTests;
+using Raven.Tests.Core.Utils.Entities;
+using Xunit;
+using Xunit.Abstractions;
+
+namespace SlowTests.Client.TimeSeries.Issues
+{
+    public class RavenDB_16253 : RavenTestBase
+    {
+        public RavenDB_16253(ITestOutputHelper output) : base(output)
+        {
+        }
+
+        private const string DocId = "users/ayende";
+
+        [Fact]
+        public void CanAppendMinValueTimestamp()
+        {
+            using (var store = GetDocumentStore())
+            {
+                var timeSeries = "HeartRate";
+
+                using (var session = store.OpenSession())
+                {
+                    session.Store(new User(), DocId);
+                    var timeSeriesFor = session.TimeSeriesFor(DocId, timeSeries);
+                    timeSeriesFor.Append(DateTime.MinValue, 0, "watches/fitbit");
+                    session.SaveChanges();
+                }
+            }
+        }
+    }
+}


### PR DESCRIPTION
https://issues.hibernatingrhinos.com/issue/RavenDB-16253