### PR TITLE
RavenDB-16221 :  InvalidQueryException thrown in studio when timeseries name is a number

### DIFF
--- a/src/Raven.Server/Documents/Queries/Results/TimeSeries/TimeSeriesRetriever.cs
+++ b/src/Raven.Server/Documents/Queries/Results/TimeSeries/TimeSeriesRetriever.cs
@@ -720,9 +720,6 @@ namespace Raven.Server.Documents.Queries.Results.TimeSeries
                         ? valueExpression.Token.Value
                         : valueExpression.GetValue(_queryParameters);
 
-                    if (!(val is string || val is LazyStringValue))
-                        throw new InvalidQueryException($"Unable to parse TimeSeries name from expression '{timeSeriesFunction.Source}'. " +
-                                                        $"Expected argument '{val}' to be a string, but got '{val.GetType()}'");
                     return val.ToString();
                 }
 

--- a/test/SlowTests/Client/TimeSeries/Issues/RavenDB-16221.cs
+++ b/test/SlowTests/Client/TimeSeries/Issues/RavenDB-16221.cs
@@ -1,0 +1,43 @@
+﻿using System;
+using FastTests;
+using Raven.Client.Documents.Queries.TimeSeries;
+using Xunit;
+using Xunit.Abstractions;
+using User = SlowTests.Core.Utils.Entities.User;
+
+namespace SlowTests.Client.TimeSeries.Issues
+{
+    public class RavenDB_16221 : RavenTestBase
+    {
+        public RavenDB_16221(ITestOutputHelper output) : base(output)
+        {
+        }
+
+        [Fact]
+        public void CanQueryTimeSeriesWithNumberAsName()
+        {
+            const string docId = "users/ayende";
+            const string timeseriesName = "123";
+
+            using (var store = GetDocumentStore())
+            {
+                using (var session = store.OpenSession())
+                {
+                    session.Store(new User(), docId);
+                    session.TimeSeriesFor(docId, timeseriesName).Append(DateTime.Now, 999);
+                    session.SaveChanges();
+                }
+
+                using (var session = store.OpenSession())
+                {
+                    var q = session.Advanced
+                        .RawQuery<TimeSeriesRawResult>($"from Users select timeseries(from {timeseriesName})")
+                        .First();
+
+                    Assert.Equal(999, q.Results[0].Value);
+
+                }
+            }
+        }
+    }
+}


### PR DESCRIPTION
https://issues.hibernatingrhinos.com/issue/RavenDB-16221