### PR TITLE
RavenDB-16269 decreased logging level to information, most of errors …

### DIFF
--- a/src/Raven.Server/Documents/Indexes/Static/IndexCompiler.cs
+++ b/src/Raven.Server/Documents/Indexes/Static/IndexCompiler.cs
@@ -93,8 +93,8 @@ namespace Raven.Server.Documents.Indexes.Static
                 }
                 catch (Exception e)
                 {
-                    if (Logger.IsOperationsEnabled)
-                        Logger.Operations($"Could not load additional assembly from '{path}'.", e);
+                    if (Logger.IsInfoEnabled)
+                        Logger.Info($"Could not load additional assembly from '{path}'.", e);
                 }
             }
 


### PR DESCRIPTION
…are false alarms, but still we want to be able to see the messages if needed, hence the information level