### PR TITLE
RavenDB-16383: Avoid having to retrieve from dictionary the id, metadata and collection fields

### DIFF
--- a/src/Raven.Client/Json/Serialization/NewtonsoftJson/Internal/BlittableJsonWriter.cs
+++ b/src/Raven.Client/Json/Serialization/NewtonsoftJson/Internal/BlittableJsonWriter.cs
@@ -23,7 +23,8 @@ namespace Raven.Client.Json.Serialization.NewtonsoftJson.Internal
         private readonly DocumentInfo _documentInfo;
 
         public BlittableJsonWriter(JsonOperationContext context, DocumentInfo documentInfo = null,
-            BlittableJsonDocumentBuilder.UsageMode? mode = null, BlittableWriter<UnmanagedWriteBuffer> writer = null)
+            BlittableJsonDocumentBuilder.UsageMode? mode = null, BlittableWriter<UnmanagedWriteBuffer> writer = null,
+            LazyStringValue idField = null, LazyStringValue keyField = null, LazyStringValue collectionField = null)
         {
             _manualBlittableJsonDocumentBuilder = new ManualBlittableJsonDocumentBuilder<UnmanagedWriteBuffer>(context, mode ?? BlittableJsonDocumentBuilder.UsageMode.None, writer);
             _manualBlittableJsonDocumentBuilder.Reset(mode ?? BlittableJsonDocumentBuilder.UsageMode.None);
@@ -31,9 +32,9 @@ namespace Raven.Client.Json.Serialization.NewtonsoftJson.Internal
             _documentInfo = documentInfo;
             _first = true;
 
-            _metadataKey = context.GetLazyStringForFieldWithCaching(Constants.Documents.Metadata.Key);
-            _metadataCollection = context.GetLazyStringForFieldWithCaching(Constants.Documents.Metadata.Collection);
-            _metadataId = context.GetLazyStringForFieldWithCaching(Constants.Documents.Metadata.Id);
+            _metadataId = idField ?? context.GetLazyStringForFieldWithCaching(Constants.Documents.Metadata.Id);
+            _metadataKey = keyField ?? context.GetLazyStringForFieldWithCaching(Constants.Documents.Metadata.Key);
+            _metadataCollection = collectionField ?? context.GetLazyStringForFieldWithCaching(Constants.Documents.Metadata.Collection);
         }
 
         public override void WriteStartObject()

--- a/src/Raven.Server/Documents/Indexes/MapReduce/Static/MapReduceIndex.cs
+++ b/src/Raven.Server/Documents/Indexes/MapReduce/Static/MapReduceIndex.cs
@@ -519,6 +519,7 @@ namespace Raven.Server.Documents.Indexes.MapReduce.Static
                 private readonly Dictionary<string, CompiledIndexField> _groupByFields;
                 private readonly ReduceKeyProcessor _reduceKeyProcessor;
                 private readonly Queue<(string PropertyName, object PropertyValue)> _propertyQueue = new Queue<(string PropertyName, object PropertyValue)>();
+                private readonly CurrentIndexingScope.MetadataFieldCache _metadataFields;
 
                 public Enumerator(IEnumerator enumerator, AnonymousObjectToBlittableMapResultsEnumerableWrapper parent, IndexingStatsScope createBlittableResult)
                 {
@@ -527,6 +528,8 @@ namespace Raven.Server.Documents.Indexes.MapReduce.Static
                     _createBlittableResult = createBlittableResult;
                     _groupByFields = _parent._groupByFields;
                     _reduceKeyProcessor = _parent._reduceKeyProcessor;
+
+                    _metadataFields = CurrentIndexingScope.Current.MetadataFields;
                 }
 
                 public bool MoveNext()
@@ -566,7 +569,10 @@ namespace Raven.Server.Documents.Indexes.MapReduce.Static
 
                         _parent._indexContext.CachedProperties.NewDocument();
 
-                        using (var writer = new BlittableJsonWriter(_parent._indexContext))
+                        using (var writer = new BlittableJsonWriter(_parent._indexContext, 
+                            idField: _metadataFields.Id, 
+                            keyField: _metadataFields.Key, 
+                            collectionField: _metadataFields.Collection))
                         {
                             writer.WriteStartObject();
 

--- a/src/Raven.Server/Documents/Indexes/Static/CurrentIndexingScope.cs
+++ b/src/Raven.Server/Documents/Indexes/Static/CurrentIndexingScope.cs
@@ -96,6 +96,41 @@ namespace Raven.Server.Documents.Indexes.Static
             }
         }
 
+        public class MetadataFieldCache
+        {
+            public readonly LazyStringValue Id;
+            public readonly LazyStringValue Key;
+            public readonly LazyStringValue Collection;
+
+            public MetadataFieldCache(LazyStringValue id, LazyStringValue key, LazyStringValue collection )
+            {
+                Id = id;
+                Key = key;
+                Collection = collection;
+            }
+        }
+
+        private MetadataFieldCache _metadataFields;
+        
+        public MetadataFieldCache MetadataFields
+        {
+            get
+            {
+                if (_metadataFields == null)
+                {
+                    var context = this.IndexContext;
+                    _metadataFields = new MetadataFieldCache(
+                        id: context.GetLazyStringForFieldWithCaching(Constants.Documents.Metadata.Id),
+                        key: context.GetLazyStringForFieldWithCaching(Constants.Documents.Metadata.Key),
+                        collection: context.GetLazyStringForFieldWithCaching(Constants.Documents.Metadata.Collection)
+                    );
+                }
+
+                return _metadataFields;
+            }
+        }
+
+
         public unsafe dynamic LoadAttachments(DynamicBlittableJson document)
         {
             if (document == null)

--- a/src/Sparrow/Json/JsonOperationContext.cs
+++ b/src/Sparrow/Json/JsonOperationContext.cs
@@ -1285,5 +1285,6 @@ namespace Sparrow.Json
         }
 
 #endif
+
     }
 }


### PR DESCRIPTION
This access to the dictionaries is done in the millions when indexing, therefore not having to look for them is a massive improvement in the CPU overhead of the process.