### PR TITLE
RavenDB-16418 IAsyncDocumentSession.StreamAsync method forcedly cast …

### DIFF
--- a/src/Raven.Client/Documents/Session/AbstractDocumentQuery.cs
+++ b/src/Raven.Client/Documents/Session/AbstractDocumentQuery.cs
@@ -86,9 +86,9 @@ namespace Raven.Client.Documents.Session
 
         protected readonly List<LoadToken> LoadTokens;
 
-        protected internal FieldsToFetchToken FieldsToFetchToken;
+        public FieldsToFetchToken FieldsToFetchToken { get; set; }
 
-        protected internal readonly bool IsProjectInto;
+        public bool IsProjectInto { get; }
 
         protected LinkedList<QueryToken> WhereTokens = new LinkedList<QueryToken>();
 
@@ -233,7 +233,7 @@ namespace Raven.Client.Documents.Session
             return new LazyQueryOperation<T>(TheSession, QueryOperation, AfterQueryExecutedCallback);
         }
 
-        protected internal QueryOperation InitializeQueryOperation()
+        public QueryOperation InitializeQueryOperation()
         {
             var beforeQueryExecutedEventArgs = new BeforeQueryEventArgs(TheSession, this);
             TheSession.OnBeforeQueryInvoke(beforeQueryExecutedEventArgs);

--- a/src/Raven.Client/Documents/Session/AsyncDocumentQuery.cs
+++ b/src/Raven.Client/Documents/Session/AsyncDocumentQuery.cs
@@ -23,8 +23,8 @@ namespace Raven.Client.Documents.Session
     /// <summary>
     /// A query against a Raven index
     /// </summary>
-    public partial class AsyncDocumentQuery<T> : AbstractDocumentQuery<T, AsyncDocumentQuery<T>>, IAsyncDocumentQuery<T>,
-        IAsyncRawDocumentQuery<T>, IAsyncGraphQuery<T>, IDocumentQueryGenerator
+    public partial class AsyncDocumentQuery<T> : AbstractDocumentQuery<T, AsyncDocumentQuery<T>>, IAbstractDocumentQueryImpl<T>,
+        IAsyncRawDocumentQuery<T>, IAsyncGraphQuery<T>, IDocumentQueryGenerator, IAsyncDocumentQuery<T>
     {
         /// <summary>
         /// Initializes a new instance of the <see cref="AsyncDocumentQuery{T}"/> class.

--- a/src/Raven.Client/Documents/Session/DocumentQuery.cs
+++ b/src/Raven.Client/Documents/Session/DocumentQuery.cs
@@ -21,7 +21,7 @@ namespace Raven.Client.Documents.Session
     /// <summary>
     /// A query against a Raven index
     /// </summary>
-    public partial class DocumentQuery<T> : AbstractDocumentQuery<T, DocumentQuery<T>>, IDocumentQuery<T>, IRawDocumentQuery<T>, IGraphQuery<T>, IDocumentQueryGenerator
+    public partial class DocumentQuery<T> : AbstractDocumentQuery<T, DocumentQuery<T>>, IDocumentQuery<T>, IRawDocumentQuery<T>, IGraphQuery<T>, IDocumentQueryGenerator, IAbstractDocumentQueryImpl<T>
     {
         /// <summary>
         /// Initializes a new instance of the <see cref="DocumentQuery{T}"/> class.

--- a/src/Raven.Client/Documents/Session/DocumentSession.Stream.cs
+++ b/src/Raven.Client/Documents/Session/DocumentSession.Stream.cs
@@ -66,7 +66,7 @@ namespace Raven.Client.Documents.Session
         {
             using (enumerator)
             {
-                var documentQuery = ((DocumentQuery<T>)query);
+                var documentQuery = (IAbstractDocumentQueryImpl<T>)query;
                 var fieldsToFetch = documentQuery.FieldsToFetchToken;
                 var isProjectInto = documentQuery.IsProjectInto;
 

--- a/src/Raven.Client/Documents/Session/IAbstractDocumentQueryImpl.cs
+++ b/src/Raven.Client/Documents/Session/IAbstractDocumentQueryImpl.cs
@@ -1,0 +1,20 @@
+﻿using Raven.Client.Documents.Session.Operations;
+using Raven.Client.Documents.Session.Tokens;
+
+namespace Raven.Client.Documents.Session
+{
+    /// <summary>
+    /// This is used as an abstraction for the implementation
+    /// of a query when passing to other parts of the
+    /// query infrastructure. Meant to be internal only, making
+    /// this public to allow mocking / instrumentation. 
+    /// </summary>
+    public interface IAbstractDocumentQueryImpl<T>
+    {
+        FieldsToFetchToken FieldsToFetchToken { get; set; }
+
+        bool IsProjectInto { get; }
+
+        QueryOperation InitializeQueryOperation();
+    }
+}


### PR DESCRIPTION
…IAsyncDocumentQuery<T> to concreate AsyncDocumentQuery<T> class implementation

Fixes #11914 