### PR TITLE
RavenDB-16446

### DIFF
--- a/src/Raven.Server/Indexing/TempFileCache.cs
+++ b/src/Raven.Server/Indexing/TempFileCache.cs
@@ -192,7 +192,9 @@ namespace Raven.Server.Indexing
 
         public override void SetLength(long value)
         {
-            InnerStream.SetLength(value);
+            if (InnerStream.Length < value)
+                InnerStream.SetLength(value);
+
             _length = value;
         }
 

--- a/src/Raven.Server/Indexing/VoronIndexOutput.cs
+++ b/src/Raven.Server/Indexing/VoronIndexOutput.cs
@@ -47,7 +47,7 @@ namespace Raven.Server.Indexing
                 _indexOutputFilesSummary.Increment(len);
                 if (_ms != null)
                 {
-                    if (_ms.Length + len <= _ms.Capacity)
+                    if (_ms.Capacity - _ms.Position - len >= 0)
                     {
                         _ms.Write(b, offset, len);
                         return;


### PR DESCRIPTION
- do not shrink inner stream in TempFileCache
- take into account position when calculating if we can fit data in the memory stream