### PR TITLE
RavenDB-16464 Fixing unreleased allocations in scratch buffers which made that scratch files were never cleaned up.

### DIFF
--- a/src/Voron/Impl/Scratch/ScratchBufferPool.cs
+++ b/src/Voron/Impl/Scratch/ScratchBufferPool.cs
@@ -3,8 +3,10 @@ using Sparrow.Binary;
 using System;
 using System.Collections.Concurrent;
 using System.Collections.Generic;
+using System.IO;
 using System.Linq;
 using System.Runtime.CompilerServices;
+using Sparrow.Logging;
 using Sparrow.LowMemory;
 using Sparrow.Server;
 using Sparrow.Server.Exceptions;
@@ -49,9 +51,12 @@ namespace Voron.Impl.Scratch
         private readonly MultipleUseFlag _lowMemoryFlag = new MultipleUseFlag();
 
         private readonly ScratchSpaceUsageMonitor _scratchSpaceMonitor; // it tracks total size of all scratches (active and recycled)
+        private readonly Logger _logger;
 
         public ScratchBufferPool(StorageEnvironment env)
         {
+            _logger = LoggingSource.Instance.GetLogger<ScratchBufferPool>(Path.GetFileName(env.ToString()));
+
             _disposeOnceRunner = new DisposeOnce<ExceptionRetry>(() =>
             {
                 if (_pagerStatesAllScratchesCache != null)
@@ -392,8 +397,10 @@ namespace Voron.Impl.Scratch
             _scratchBuffers.AddOrUpdate(scratch.Number, scratch, (_, __) => scratch);
         }
 
-        private void RemoveInactiveScratches(ScratchBufferItem except)
+        private int RemoveInactiveScratches(ScratchBufferItem except)
         {
+            var removed = 0;
+
             foreach (var item in _scratchBuffers)
             {
                 var scratchBufferItem = item.Value;
@@ -411,8 +418,12 @@ namespace Voron.Impl.Scratch
                     scratchBufferItem.File.Dispose();
 
                     _scratchSpaceMonitor.Decrease(scratchBufferItem.File.NumberOfAllocatedPages * Constants.Storage.PageSize);
+
+                    removed++;
                 }
             }
+
+            return removed;
         }
 
         private static void ThrowUnableToRemoveScratch(ScratchBufferItem scratchBufferItem)
@@ -491,9 +502,14 @@ namespace Voron.Impl.Scratch
                 {
                     using (_env.WriteTransaction(context: byteStringContext))
                     {
-                        RemoveInactiveScratches(_current);
+                        var removedInactive = RemoveInactiveScratches(_current);
 
-                        RemoveInactiveRecycledScratches();
+                        var removedInactiveRecycled = RemoveInactiveRecycledScratches();
+
+                        if (_logger.IsInfoEnabled)
+                        {
+                            _logger.Info($"Cleanup of {nameof(ScratchBufferPool)} removed: {removedInactive} inactive scratches and {removedInactiveRecycled} inactive from the recycle area");
+                        }
                     }
                 }
                 catch (TimeoutException)
@@ -511,10 +527,12 @@ namespace Voron.Impl.Scratch
             }
         }
 
-        private void RemoveInactiveRecycledScratches()
+        private int RemoveInactiveRecycledScratches()
         {
             if (_recycleArea.Count == 0)
-                return;
+                return 0;
+
+            var removed = 0;
 
             var scratchNode = _recycleArea.First;
             while (scratchNode != null)
@@ -529,10 +547,14 @@ namespace Voron.Impl.Scratch
                     _scratchSpaceMonitor.Decrease(recycledScratch.File.NumberOfAllocatedPages * Constants.Storage.PageSize);
 
                     _recycleArea.Remove(scratchNode);
+
+                    removed++;
                 }
 
                 scratchNode = next;
             }
+
+            return removed;
         }
 
         [MethodImpl(MethodImplOptions.AggressiveInlining)]

--- a/src/Voron/Impl/Scratch/ScratchBufferPoolInfo.cs
+++ b/src/Voron/Impl/Scratch/ScratchBufferPoolInfo.cs
@@ -1,3 +1,4 @@
+using System;
 using System.Collections.Generic;
 
 namespace Voron.Impl.Scratch
@@ -20,6 +21,8 @@ namespace Voron.Impl.Scratch
         public long PerScratchFileSizeLimitInMB { get; set; }
 
         public List<ScratchFileUsage> ScratchFilesUsage { get; set; }
+
+        public DateTime CurrentUtcTime { get; set; }
     }
 
     public class MostAvailableFreePagesBySize
@@ -28,11 +31,21 @@ namespace Voron.Impl.Scratch
         public long ValidAfterTransactionId { get; set; }
     }
 
+    public class AllocatedPageInScratchBuffer
+    {
+        public int ScratchFileNumber { get; set; }
+        public long PositionInScratchBuffer { get; set; }
+        public long Size { get; set; }
+        public int NumberOfPages { get; set; }
+        public long ScratchPageNumber { get; set; }
+    }
+
     public class ScratchFileUsage
     {
         public ScratchFileUsage()
         {
             MostAvailableFreePages = new List<MostAvailableFreePagesBySize>();
+            First10AllocatedPages = new List<AllocatedPageInScratchBuffer>();
         }
 
         public string Name { get; set; }
@@ -48,5 +61,15 @@ namespace Voron.Impl.Scratch
         public bool CanBeDeleted { get; set; }
 
         public List<MostAvailableFreePagesBySize> MostAvailableFreePages { get; set; }
+
+        public List<AllocatedPageInScratchBuffer> First10AllocatedPages { get; set; }
+
+        public bool IsInRecycleArea { get; set; }
+
+        public DateTime? LastResetTime { get; set; }
+
+        public int NumberOfResets { get; set; }
+
+        public DateTime? LastFreeTime { get; set; }
     }
 }

--- a/src/Voron/StorageEnvironment.cs
+++ b/src/Voron/StorageEnvironment.cs
@@ -815,6 +815,20 @@ namespace Voron
             return new ExitWriteLock(_txCommit);
         }
 
+        internal bool IsInPreventNewReadTransactionsMode => _txCommit.IsWriteLockHeld;
+
+        internal bool TryPreventNewReadTransactions(TimeSpan timeout, out IDisposable exitWriteLock)
+        {
+            if (_txCommit.TryEnterWriteLock(timeout))
+            {
+                exitWriteLock = new ExitWriteLock(_txCommit);
+                return true;
+            }
+
+            exitWriteLock = null;
+            return false;
+        }
+
         public struct ExitWriteLock : IDisposable
         {
             readonly ReaderWriterLockSlim _rwls;

--- a/test/FastTests/Voron/Bugs/RavenDB_16464.cs
+++ b/test/FastTests/Voron/Bugs/RavenDB_16464.cs
@@ -1,0 +1,75 @@
+﻿using System;
+using System.Collections.Generic;
+using Voron;
+using Voron.Impl.Journal;
+using Xunit;
+using Xunit.Abstractions;
+
+namespace FastTests.Voron.Bugs
+{
+    public class RavenDB_16464 : StorageTest
+    {
+        public RavenDB_16464(ITestOutputHelper output) : base(output)
+        {
+        }
+
+        private const int _64KB = 64 * 1024;
+
+        protected override void Configure(StorageEnvironmentOptions options)
+        {
+            options.MaxScratchBufferSize = _64KB * 4;
+            options.ManualFlushing = true;
+            options.ManualSyncing = true;
+            options.MaxLogFileSize = _64KB;
+        }
+
+        [Fact]
+        public void ShouldFreeAllocationsInScratchBuffersSoTheyCanBeCleaned()
+        {
+            RequireFileBasedPager();
+
+            var r = new Random(3);
+
+            for (int j = 0; j < 2; j++)
+            {
+                using (var tx = Env.WriteTransaction())
+                {
+                    var tree = tx.CreateTree("tree");
+
+                    for (int i = 0; i < 8; i++)
+                    {
+                        var overflowSize = r.Next(5, 10);
+
+                        var bytes = new byte[overflowSize * 8192];
+
+                        r.NextBytes(bytes);
+
+                        tree.Add("items/" + i, bytes);
+                    }
+
+                    tx.Commit();
+                }
+            }
+
+            Assert.Equal(3, Env.Journal.Files.Count); 
+            Assert.Equal(0, Env.Journal.CurrentFile.Available4Kbs); // this is very important condition to run into the issue - see details in RavenDB-16464
+
+            Env.FlushLogToDataFile(); // this will flush all journals, the issue was that it also marked all of them as unused so they were removed from _files list, but didn't free the allocations in scratch buffers to ensure we don't free pages that can be still read
+
+            using (var readTx = Env.ReadTransaction())
+            {
+                var journalSnapshots = readTx.LowLevelTransaction.JournalSnapshots;
+
+                Assert.Equal(0, journalSnapshots.Count); // _files collection was cleaned during the flush
+            }
+
+            Env.FlushLogToDataFile();
+
+            Env.Cleanup(tryCleanupRecycledJournals: true);
+
+            var scratchBufferPoolInfo = Env.ScratchBufferPool.InfoForDebug(Env.PossibleOldestReadTransaction(null));
+
+            Assert.Equal(1, scratchBufferPoolInfo.ScratchFilesUsage.Count);
+        }
+    }
+}

--- a/test/SlowTests/Voron/Bugs/InvalidReleasesOfScratchPages.cs
+++ b/test/SlowTests/Voron/Bugs/InvalidReleasesOfScratchPages.cs
@@ -63,9 +63,7 @@ namespace SlowTests.Voron.Bugs
 
                 env.FlushLogToDataFile(); // non read nor write transactions, so it should flush and release everything from scratch
 
-                // we keep track of the pages in scratch for one additional transaction, to avoid race
-                // condition with FlushLogToDataFile concurrently with new read transactions
-                Assert.Equal(2, env.ScratchBufferPool.GetNumberOfAllocations(0)); 
+                Assert.Equal(0, env.ScratchBufferPool.GetNumberOfAllocations(0)); 
             }
         }
     }


### PR DESCRIPTION
The issue was that we didn't clean all pages in scrach files because potentially there could be some read transactions still looking at those pages but at the same time we decided that related journals are unused so we removed them from in-memory list of journals. That resulted in the bug that we never freed some allocations in the scratch buffer files.