### PR TITLE
RavenDB-16450 Import MultiGetCommand from 5.0 and set result to  use cloned Blittable instead of Blittable based on cached memory

### DIFF
--- a/src/Raven.Client/Documents/Commands/MultiGet/GetRequest.cs
+++ b/src/Raven.Client/Documents/Commands/MultiGet/GetRequest.cs
@@ -40,6 +40,8 @@ namespace Raven.Client.Documents.Commands.MultiGet
             }
         }
 
+        public bool CanCacheAggressively { get; set; } = true;
+
         public IContent Content { get; set; }
 
         public GetRequest()

--- a/src/Raven.Client/Documents/Commands/MultiGet/MultiGetCommand.cs
+++ b/src/Raven.Client/Documents/Commands/MultiGet/MultiGetCommand.cs
@@ -324,20 +324,25 @@ namespace Raven.Client.Documents.Commands.MultiGet
 
         private class Cached : IDisposable
         {
-            public readonly (HttpCache.ReleaseCacheItem Release, BlittableJsonReaderObject Cached)[] Values;
+            private readonly int _size;
+            public (HttpCache.ReleaseCacheItem Release, BlittableJsonReaderObject Cached)[] Values;
 
             public Cached(int size)
             {
+                _size = size;
                 Values = ArrayPool<(HttpCache.ReleaseCacheItem, BlittableJsonReaderObject)>.Shared.Rent(size);
             }
 
             public void Dispose()
             {
-                for (int i = 0; i < Values.Length; i++)
+                if(Values == null)
+                    return;
+                for (int i = 0; i < _size; i++)
                 {
                     Values[i].Release.Dispose();
                 }
                 ArrayPool<(HttpCache.ReleaseCacheItem, BlittableJsonReaderObject)>.Shared.Return(Values);
+                Values = null;
             }
         }
     }

--- a/src/Raven.Client/Documents/Session/AsyncDocumentSession.Lazy.cs
+++ b/src/Raven.Client/Documents/Session/AsyncDocumentSession.Lazy.cs
@@ -113,7 +113,7 @@ namespace Raven.Client.Documents.Session
         private async Task<bool> ExecuteLazyOperationsSingleStep(ResponseTimeInformation responseTimeInformation, List<GetRequest> requests, Stopwatch sw, CancellationToken token = default)
         {
             var multiGetOperation = new MultiGetOperation(this);
-            var multiGetCommand = multiGetOperation.CreateRequest(requests);
+            using var multiGetCommand = multiGetOperation.CreateRequest(requests);
             await RequestExecutor.ExecuteAsync(multiGetCommand, Context, sessionInfo: SessionInfo, token: token).ConfigureAwait(false);
             var responses = multiGetCommand.Result;
             if (multiGetCommand.AggressivelyCached == false)

--- a/src/Raven.Client/Documents/Session/AsyncDocumentSession.Lazy.cs
+++ b/src/Raven.Client/Documents/Session/AsyncDocumentSession.Lazy.cs
@@ -82,8 +82,6 @@ namespace Raven.Client.Documents.Session
                 {
                     var sw = Stopwatch.StartNew();
 
-                    IncrementRequestCount();
-
                     var responseTimeDuration = new ResponseTimeInformation();
 
                     while (await ExecuteLazyOperationsSingleStep(responseTimeDuration, requests, sw, token).ConfigureAwait(false))
@@ -118,6 +116,8 @@ namespace Raven.Client.Documents.Session
             var multiGetCommand = multiGetOperation.CreateRequest(requests);
             await RequestExecutor.ExecuteAsync(multiGetCommand, Context, sessionInfo: SessionInfo, token: token).ConfigureAwait(false);
             var responses = multiGetCommand.Result;
+            if (multiGetCommand.AggressivelyCached == false)
+                IncrementRequestCount();
 
             for (var i = 0; i < PendingLazyOperations.Count; i++)
             {

--- a/src/Raven.Client/Documents/Session/DocumentSession.cs
+++ b/src/Raven.Client/Documents/Session/DocumentSession.cs
@@ -175,8 +175,6 @@ namespace Raven.Client.Documents.Session
             {
                 var sw = Stopwatch.StartNew();
 
-                IncrementRequestCount();
-
                 var responseTimeDuration = new ResponseTimeInformation();
 
                 while (ExecuteLazyOperationsSingleStep(responseTimeDuration, requests, sw))
@@ -208,6 +206,8 @@ namespace Raven.Client.Documents.Session
             var multiGetCommand = multiGetOperation.CreateRequest(requests);
             RequestExecutor.Execute(multiGetCommand, Context, sessionInfo: SessionInfo);
             var responses = multiGetCommand.Result;
+            if (multiGetCommand.AggressivelyCached == false)
+                IncrementRequestCount();
 
             for (var i = 0; i < PendingLazyOperations.Count; i++)
             {

--- a/src/Raven.Client/Documents/Session/DocumentSession.cs
+++ b/src/Raven.Client/Documents/Session/DocumentSession.cs
@@ -203,7 +203,7 @@ namespace Raven.Client.Documents.Session
         private bool ExecuteLazyOperationsSingleStep(ResponseTimeInformation responseTimeInformation, List<GetRequest> requests, Stopwatch sw)
         {
             var multiGetOperation = new MultiGetOperation(this);
-            var multiGetCommand = multiGetOperation.CreateRequest(requests);
+            using var multiGetCommand = multiGetOperation.CreateRequest(requests);
             RequestExecutor.Execute(multiGetCommand, Context, sessionInfo: SessionInfo);
             var responses = multiGetCommand.Result;
             if (multiGetCommand.AggressivelyCached == false)

--- a/src/Raven.Client/Documents/Session/Operations/Lazy/LazyQueryOperation.cs
+++ b/src/Raven.Client/Documents/Session/Operations/Lazy/LazyQueryOperation.cs
@@ -26,6 +26,7 @@ namespace Raven.Client.Documents.Session.Operations.Lazy
         {
             return new GetRequest
             {
+                CanCacheAggressively = _queryOperation.IndexQuery.DisableCaching == false && _queryOperation.IndexQuery.WaitForNonStaleResults == false,
                 Url = "/queries",
                 Method = HttpMethod.Post,
                 Query = $"?queryHash={_queryOperation.IndexQuery.GetQueryHash(ctx, _session.JsonSerializer)}",

--- a/src/Raven.Client/Documents/Session/Operations/Lazy/LazySuggestionQueryOperation.cs
+++ b/src/Raven.Client/Documents/Session/Operations/Lazy/LazySuggestionQueryOperation.cs
@@ -29,6 +29,7 @@ namespace Raven.Client.Documents.Session.Operations.Lazy
         {
             return new GetRequest
             {
+                CanCacheAggressively = _indexQuery.DisableCaching == false && _indexQuery.WaitForNonStaleResults == false,
                 Url = "/queries",
                 Method = HttpMethod.Post,
                 Query = $"?queryHash={_indexQuery.GetQueryHash(ctx, _session.JsonSerializer)}",

--- a/src/Raven.Client/Documents/Session/Operations/MultiGetOperation.cs
+++ b/src/Raven.Client/Documents/Session/Operations/MultiGetOperation.cs
@@ -15,7 +15,7 @@ namespace Raven.Client.Documents.Session.Operations
 
         public MultiGetCommand CreateRequest(List<GetRequest> requests)
         {
-            return new MultiGetCommand(_session.RequestExecutor.Cache, requests);
+            return new MultiGetCommand(_session.RequestExecutor, requests);
         }
 
         public void SetResult(BlittableArrayResult result)

--- a/src/Raven.Client/Http/HttpCache.cs
+++ b/src/Raven.Client/Http/HttpCache.cs
@@ -83,8 +83,6 @@ namespace Raven.Client.Http
                 // Do the actual deallocation. 
                 if (Allocation != null)
                 {
-                    
-
                     Cache._unmanagedBuffersPool.Return(Allocation);
                     Interlocked.Add(ref Cache._totalSize, -Size);
                 }

--- a/src/Raven.Client/Http/HttpCache.cs
+++ b/src/Raven.Client/Http/HttpCache.cs
@@ -127,7 +127,7 @@ namespace Raven.Client.Http
 #endif 
             var mem = _unmanagedBuffersPool.Allocate(result.Size);
             result.CopyTo(mem.Address);
-            if (Interlocked.Add(ref _totalSize, result.Size) > _maxSize)
+            if (Interlocked.Add(ref _totalSize, mem.SizeInBytes) > _maxSize)
             {
                 if (_isFreeSpaceRunning == false)
                     Task.Run(FreeSpace);

--- a/src/Raven.Client/Http/RequestExecutor.cs
+++ b/src/Raven.Client/Http/RequestExecutor.cs
@@ -885,6 +885,8 @@ namespace Raven.Client.Http
                 command.FailoverTopologyEtag = _nodeSelector?.Topology?.Etag ?? InitialTopologyEtag;
 
             var request = CreateRequest(context, chosenNode, command, out string url);
+            if (request == null) return;
+
             var noCaching = sessionInfo?.NoCaching ?? false;
 
             using (var cachedItem = GetFromCache(context, command, !noCaching, url, out string cachedChangeVector, out BlittableJsonReaderObject cachedValue))
@@ -1362,6 +1364,7 @@ namespace Raven.Client.Http
         internal HttpRequestMessage CreateRequest<TResult>(JsonOperationContext ctx, ServerNode node, RavenCommand<TResult> command, out string url)
         {
             var request = command.CreateRequest(ctx, node, out url);
+            if (request == null) return null;
 
             var builder = new UriBuilder(url);
 

--- a/test/SlowTests/Bugs/Caching/UseCachingInLazyTests.cs
+++ b/test/SlowTests/Bugs/Caching/UseCachingInLazyTests.cs
@@ -393,7 +393,7 @@ namespace SlowTests.Bugs.Caching
                         .Select(i => new GetRequest { Url = "/docs", Query = $"?&id={Uri.EscapeDataString($"TestObjs/{i}")}", });
 
                 var multiGetOperation = new MultiGetOperation((AsyncDocumentSession)session);
-                var multiGetCommand = multiGetOperation.CreateRequest(requests.ToList());
+                using var multiGetCommand = multiGetOperation.CreateRequest(requests.ToList());
 
                 var requestExecutor = store.GetRequestExecutor();
                 using (requestExecutor.ContextPool.AllocateOperationContext(out var context))

--- a/test/SlowTests/Bugs/Caching/UseCachingInLazyTests.cs
+++ b/test/SlowTests/Bugs/Caching/UseCachingInLazyTests.cs
@@ -1,0 +1,433 @@
+﻿using System;
+using System.Collections.Generic;
+using System.Linq;
+using System.Threading.Tasks;
+using Esprima.Ast;
+using FastTests;
+using Lextm.SharpSnmpLib.Messaging;
+using Raven.Client.Documents;
+using Raven.Client.Documents.Commands.MultiGet;
+using Raven.Client.Documents.Session;
+using Raven.Client.Documents.Session.Operations;
+using Raven.Client.Extensions;
+using Raven.Client.Http;
+using Sparrow;
+using Sparrow.Json;
+using Sparrow.Server;
+using Xunit;
+using Xunit.Abstractions;
+using Size = Sparrow.Size;
+using TimeoutException = System.TimeoutException;
+
+namespace SlowTests.Bugs.Caching
+{
+    public class UseCachingInLazyTests : RavenTestBase
+    {
+        public UseCachingInLazyTests(ITestOutputHelper output) : base(output)
+        {
+        }
+
+        public class AsyncTestCaseHolder
+        {
+            public Func<IAsyncDocumentSession, string, Task> LoadFuncAsync;
+        }
+
+
+        private static async Task LoadFuncAsync(IAsyncDocumentSession s, string id) => _ = await s.LoadAsync<Doc>(id);
+        private static async Task LazilyLoadFuncAsync(IAsyncDocumentSession s, string id) => _ = await s.Advanced.Lazily.LoadAsync<Doc>(id).Value;
+
+        public static IEnumerable<object[]> AsyncTestCases
+        {
+            get
+            {
+                return new[]
+                {
+                    new object[] {nameof(LoadFuncAsync), new AsyncTestCaseHolder {LoadFuncAsync = LoadFuncAsync}},
+                    new object[] {nameof(LazilyLoadFuncAsync), new AsyncTestCaseHolder {LoadFuncAsync = LazilyLoadFuncAsync}}
+                };
+            }
+        }
+
+        [Theory]
+        [MemberData(nameof(AsyncTestCases))]
+        public async Task LazilyLoadAsync_WhenDoNotTrackChanges_ShouldNotCreateExtraRequest(string xunitId, AsyncTestCaseHolder testCaseHolder)
+        {
+            using var store = GetDocumentStore();
+
+            var numberOfRequest = await AggressiveCacheOnLazilyLoadAsyncTest(store, testCaseHolder, AggressiveCacheMode.DoNotTrackChanges);
+
+            Assert.Equal(0, numberOfRequest);
+        }
+
+        [Fact]
+        public async Task LazilyLoadAsync_WhenTrackChangesAndChange_ShouldCreateExtraRequest()
+        {
+            using var store = GetDocumentStore();
+
+            var numberOfRequest = await AggressiveCacheOnLazilyLoadAsyncTest(store, LazilyLoadFuncAsync, AggressiveCacheMode.TrackChanges);
+
+            Assert.Equal(1, numberOfRequest);
+        }
+
+        [Fact]
+        public async Task LazilyLoadAsync_WhenTrackChangesAndDoesntChange_ShouldNotCreateExtraRequest()
+        {
+            using var store = GetDocumentStore();
+
+            var numberOfRequest = await AggressiveCacheOnLazilyLoadAsyncTest(store, LazilyLoadFuncAsync, AggressiveCacheMode.TrackChanges, false);
+
+            Assert.Equal(0, numberOfRequest);
+        }
+
+        private async Task<long> AggressiveCacheOnLazilyLoadAsyncTest(
+            IDocumentStore store,
+            AsyncTestCaseHolder testCaseHolder,
+            AggressiveCacheMode aggressiveCacheMode,
+            bool createVersion2 = true)
+        {
+            return await AggressiveCacheOnLazilyLoadAsyncTest(store, testCaseHolder.LoadFuncAsync, aggressiveCacheMode, createVersion2);
+        }
+
+        private static async Task<long> AggressiveCacheOnLazilyLoadAsyncTest(
+            IDocumentStore store,
+            Func<IAsyncDocumentSession, string, Task> loadFuncAsync,
+            AggressiveCacheMode aggressiveCacheMode,
+            bool createVersion2 = true)
+        {
+            const string docId = "doc-1";
+
+            using (var session = store.OpenAsyncSession())
+            {
+                await session.StoreAsync(new Doc(), docId);
+                await session.SaveChangesAsync();
+            }
+
+            using (var session = store.OpenAsyncSession())
+            using (session.Advanced.DocumentStore.AggressivelyCacheFor(TimeSpan.FromMinutes(5), AggressiveCacheMode.TrackChanges))
+            {
+                await loadFuncAsync(session, docId);
+            }
+
+            if (createVersion2)
+            {
+                var amre = new AsyncManualResetEvent();
+                var observable = store.Changes().ForDocument(docId);
+                await observable.EnsureSubscribedNow();
+                observable.Subscribe(_ => amre.Set());
+
+                using var session = store.OpenAsyncSession();
+                await session.StoreAsync(new Doc { Version = "2" }, docId);
+                await session.SaveChangesAsync();
+
+                await amre.WaitAsync(TimeSpan.FromSeconds(30));
+            }
+
+            using (var session = store.OpenAsyncSession())
+            using (session.Advanced.DocumentStore.AggressivelyCacheFor(TimeSpan.FromMinutes(5), aggressiveCacheMode))
+            {
+                var loadAsync = session.Advanced.Lazily.LoadAsync<Doc>(docId);
+                _ = await loadAsync.Value;
+                return session.Advanced.NumberOfRequests;
+            }
+        }
+
+
+        private static void LoadFunc(IDocumentSession s, string id) => _ = s.Load<Doc>(id);
+        private static void LazilyLoadFunc(IDocumentSession s, string id) => _ = s.Advanced.Lazily.Load<Doc>(id).Value;
+
+        public class TestCaseHolder
+        {
+            public Action<IDocumentSession, string> LoadFunc;
+        }
+
+        public static IEnumerable<object[]> TestCases
+        {
+            get
+            {
+                yield return new object[] { nameof(LoadFunc), new TestCaseHolder { LoadFunc = LoadFunc } };
+                yield return new object[] { nameof(LazilyLoadFunc), new TestCaseHolder { LoadFunc = LazilyLoadFunc } };
+            }
+        }
+
+        [Theory]
+        [MemberData(nameof(TestCases))]
+        public async Task LazilyLoad_WhenDoNotTrackChanges_ShouldNotCreateExtraRequest(string caseName, TestCaseHolder testCaseHolder)
+        {
+            using var store = GetDocumentStore();
+
+            var numberOfRequest = await AggressiveCacheOnLazilyLoadTest(store, testCaseHolder, AggressiveCacheMode.DoNotTrackChanges);
+
+            Assert.Equal(0, numberOfRequest);
+        }
+
+        [Fact]
+        public async Task LazilyLoad_WhenTrackChangesAndChange_ShouldCreateExtraRequest()
+        {
+            using var store = GetDocumentStore();
+
+            var numberOfRequest = await AggressiveCacheOnLazilyLoadTest(store, LazilyLoadFunc, AggressiveCacheMode.TrackChanges);
+
+            Assert.Equal(1, numberOfRequest);
+        }
+
+
+        [Fact]
+        public async Task LazilyLoad_WhenTrackChangesAndDoesntChange_ShouldNotCreateExtraRequest()
+        {
+            using var store = GetDocumentStore();
+
+            var numberOfRequest = await AggressiveCacheOnLazilyLoadTest(store, LazilyLoadFunc, AggressiveCacheMode.TrackChanges, false);
+
+            Assert.Equal(0, numberOfRequest);
+        }
+
+        private async Task<long> AggressiveCacheOnLazilyLoadTest(
+            IDocumentStore store,
+            TestCaseHolder testCaseHolder,
+            AggressiveCacheMode doNotTrackChanges,
+            bool createVersion2 = true)
+        {
+            return await AggressiveCacheOnLazilyLoadTest(store, testCaseHolder.LoadFunc, doNotTrackChanges, createVersion2);
+        }
+
+        private static async Task<long> AggressiveCacheOnLazilyLoadTest(
+            IDocumentStore store,
+            Action<IDocumentSession, string> loadFunc,
+            AggressiveCacheMode aggressiveCacheMode,
+            bool createVersion2 = true)
+        {
+            const string docId = "doc-1";
+
+            using (var session = store.OpenAsyncSession())
+            {
+                await session.StoreAsync(new Doc(), docId);
+                await session.SaveChangesAsync();
+            }
+
+            using (var session = store.OpenSession())
+            using (session.Advanced.DocumentStore.AggressivelyCacheFor(TimeSpan.FromMinutes(5), AggressiveCacheMode.TrackChanges))
+            {
+                loadFunc(session, docId);
+            }
+
+            if (createVersion2)
+            {
+                var amre = new AsyncManualResetEvent();
+                var observable = store.Changes().ForDocument(docId);
+                await observable.EnsureSubscribedNow();
+                observable.Subscribe(_ => amre.Set());
+
+                using var session = store.OpenAsyncSession();
+                await session.StoreAsync(new Doc { Version = "2" }, docId);
+                await session.SaveChangesAsync();
+
+                await amre.WaitAsync(TimeSpan.FromSeconds(30));
+            }
+
+            using (var session = store.OpenSession())
+            using (session.Advanced.DocumentStore.AggressivelyCacheFor(TimeSpan.FromMinutes(5), aggressiveCacheMode))
+            {
+                _ = session.Advanced.Lazily.Load<Doc>(docId).Value;
+                return session.Advanced.NumberOfRequests;
+            }
+        }
+
+        public class Doc
+        {
+            public string Version { get; set; }
+        }
+
+        [Fact]
+        public async Task LazilyLoad_WhenOneOfLoadedIsCachedAndNotModified_ShouldNotBeNull()
+        {
+            const string cachedId = "TestObjs/cached";
+            const string notCachedId = "TestObjs/notCached";
+
+            using var store = GetDocumentStore();
+            store.AggressivelyCacheFor(TimeSpan.FromMinutes(5));
+            using (var session = store.OpenAsyncSession())
+            {
+                await session.StoreAsync(new TestObj(), cachedId);
+                await session.StoreAsync(new TestObj(), notCachedId);
+                await session.SaveChangesAsync();
+            }
+
+            using (var session = store.OpenAsyncSession())
+            {
+                //Load to cache
+                var a = await session.Advanced.Lazily.LoadAsync<TestObj>(cachedId).Value;
+            }
+
+            using (var session = store.OpenAsyncSession())
+            {
+                var lazy = session.Advanced.Lazily.LoadAsync<TestObj>(cachedId);
+                _ = await session.Advanced.Lazily.LoadAsync<TestObj>(notCachedId).Value;
+                Assert.NotNull(await lazy.Value);
+            }
+
+        }
+
+        [Fact]
+        public async Task LazilyLoad_WhenSessionTrackResultFromFreedCacheItems_ShouldUseUnfreedMemory()
+        {
+            const int docsCount = 50;
+
+
+            using var store = GetDocumentStore(new Options
+            {
+                ModifyDocumentStore = documentStore => documentStore.Conventions.MaxHttpCacheSize = new Size(1, SizeUnit.Megabytes)
+            });
+
+            await using (var bulk = store.BulkInsert())
+            {
+                var random = new Random();
+
+                for (int i = 0; i < docsCount; i++)
+                {
+                    await bulk.StoreAsync(new TestObj
+                    {
+                        LargeContent = string.Create(18000, (object)null,
+                            (chars, _) =>
+                            {
+                                foreach (ref char c in chars)
+                                {
+                                    c = (char)random.Next(char.MaxValue);
+                                }
+                            })
+                    }, $"TestObjs/{i}");
+                }
+            }
+
+            //Cache results
+            using (var session = store.OpenAsyncSession())
+            {
+                for (int i = 0; i < 15; i++)
+                {
+                    _ = session.Advanced.Lazily.LoadAsync<TestObj>($"TestObjs/{i}");
+                }
+                await session.Advanced.Eagerly.ExecuteAllPendingLazyOperationsAsync();
+            }
+
+            using (var session = store.OpenAsyncSession())
+            {
+                session.Advanced.MaxNumberOfRequestsPerSession = docsCount + 30;
+
+                for (int i = 0; i < docsCount; i++)
+                {
+                    var lazy = session.Advanced.Lazily.LoadAsync<TestObj>($"TestObjs/{i}");
+                    await lazy.Value;
+                }
+
+                //Used to fail here if used memory of freed cache items
+                await session.SaveChangesAsync();
+            }
+        }
+
+        [Fact]
+        public async Task LazilyLoad_WhenTheCachedCleanedBeforeUsingTheResults_ShouldGetUnfreedResults()
+        {
+            var random = new Random(0);
+            string largeContent = string.Create(30000, (object)null,
+                (chars, _) =>
+                {
+                    foreach (ref char c in chars)
+                    {
+                        c = (char)random.Next(char.MaxValue);
+                    }
+                });
+
+            var conventionsMaxHttpCacheSize = new Size(1, SizeUnit.Megabytes);
+
+            using var store = GetDocumentStore(new Options
+            {
+                ModifyDocumentStore = documentStore =>
+                {
+                    documentStore.Conventions.MaxHttpCacheSize = conventionsMaxHttpCacheSize;
+                }
+            });
+            store.AggressivelyCache();
+
+            async Task<int> GetSingleDocSize()
+            {
+                const string id = "TestObjs/sizeCheck";
+                using (var session = store.OpenAsyncSession())
+                {
+                    await session.StoreAsync(new TestObj {LargeContent = largeContent}, id);
+                    await session.SaveChangesAsync();
+                }
+
+                using (var session = store.OpenAsyncSession())
+                {
+                    var doc = await session.LoadAsync<BlittableJsonReaderObject>(id);
+                    return doc.Size;
+                }
+            }
+            int singleDocSize = await GetSingleDocSize();
+
+            var fullCacheDocCount = (int)(conventionsMaxHttpCacheSize.GetValue(SizeUnit.Bytes) / singleDocSize);
+
+            int docCount = 4 * fullCacheDocCount;
+            await using (var bulk = store.BulkInsert())
+            {
+                for (int i = 0; i < docCount; i++)
+                {
+                    await bulk.StoreAsync(new TestObj { LargeContent = largeContent }, $"TestObjs/{i}");
+                }
+            }
+
+            int safetyRange = (int)(fullCacheDocCount * 0.2); //To make sure we don't exceed the max cache size and free the cached items
+            int cachedCount = fullCacheDocCount - safetyRange;
+            using (var session = store.OpenAsyncSession())
+            {
+                for (int i = 0; i < cachedCount; i++)
+                {
+                    session.Advanced.Lazily.LoadAsync<TestObj>($"TestObjs/{i}");
+                }
+                await session.Advanced.Eagerly.ExecuteAllPendingLazyOperationsAsync();
+            }
+
+            using (var session = store.OpenAsyncSession())
+            {
+                var requests =
+                    Enumerable.Range(0, cachedCount)
+                        .Select(i => new GetRequest { Url = "/docs", Query = $"?&id={Uri.EscapeDataString($"TestObjs/{i}")}", });
+
+                var multiGetOperation = new MultiGetOperation((AsyncDocumentSession)session);
+                var multiGetCommand = multiGetOperation.CreateRequest(requests.ToList());
+
+                var requestExecutor = store.GetRequestExecutor();
+                using (requestExecutor.ContextPool.AllocateOperationContext(out var context))
+                {
+                    await requestExecutor.ExecuteAsync(multiGetCommand, context).ConfigureAwait(false);
+                    
+                    using (var session2 = store.OpenAsyncSession())
+                    {
+                        session2.Advanced.MaxNumberOfRequestsPerSession = 1000;
+
+                        for (var i = cachedCount; i < docCount; i++)
+                        {
+                            _ = session2.Advanced.Lazily.LoadAsync<TestObj>($"TestObjs/{i}");
+                        }
+                        await session2.Advanced.Eagerly.ExecuteAllPendingLazyOperationsAsync();
+                    }
+
+                    foreach (var getResponse in multiGetCommand.Result)
+                    {
+                        var blittable = (BlittableJsonReaderObject)getResponse.Result;
+                        blittable.BlittableValidation();
+                    }
+                }
+                
+                await session.SaveChangesAsync();
+            }
+        }
+
+        public class TestObj
+        {
+            public string Id { get; set; }
+            public string LargeContent { get; set; }
+        }
+
+        public class NewTest { }
+    }
+}

--- a/test/SlowTests/Tests/MultiGet/MultiGetBasic.cs
+++ b/test/SlowTests/Tests/MultiGet/MultiGetBasic.cs
@@ -49,7 +49,7 @@ namespace SlowTests.Tests.MultiGet
 
                 using (var commands = store.Commands())
                 {
-                    var command = new MultiGetCommand(commands.RequestExecutor, new List<GetRequest>
+                    using var command = new MultiGetCommand(commands.RequestExecutor, new List<GetRequest>
                     {
                         new GetRequest
                         {
@@ -103,7 +103,7 @@ namespace SlowTests.Tests.MultiGet
 
                 using (var commands = store.Commands())
                 {
-                    var command = new MultiGetCommand(commands.RequestExecutor, new List<GetRequest>
+                    using var command = new MultiGetCommand(commands.RequestExecutor, new List<GetRequest>
                     {
                         new GetRequest
                         {
@@ -150,7 +150,7 @@ namespace SlowTests.Tests.MultiGet
 
                 using (var commands = store.Commands())
                 {
-                    var command = new MultiGetCommand(commands.RequestExecutor, new List<GetRequest>
+                    using var firstCommand = new MultiGetCommand(commands.RequestExecutor, new List<GetRequest>
                     {
                         new GetRequest
                         {
@@ -164,12 +164,12 @@ namespace SlowTests.Tests.MultiGet
                         }
                     });
 
-                    commands.RequestExecutor.Execute(command, commands.Context);
+                    commands.RequestExecutor.Execute(firstCommand, commands.Context);
 
-                    Assert.True(command.Result[0].Headers.ContainsKey("ETag"));
-                    Assert.True(command.Result[1].Headers.ContainsKey("ETag"));
+                    Assert.True(firstCommand.Result[0].Headers.ContainsKey("ETag"));
+                    Assert.True(firstCommand.Result[1].Headers.ContainsKey("ETag"));
 
-                    command = new MultiGetCommand(commands.RequestExecutor, new List<GetRequest>
+                    using var secondCommand = new MultiGetCommand(commands.RequestExecutor, new List<GetRequest>
                     {
                         new GetRequest
                         {
@@ -177,7 +177,7 @@ namespace SlowTests.Tests.MultiGet
                             Query = "?id=users/1-A",
                             Headers =
                             {
-                                {"If-None-Match", command.Result[0].Headers["ETag"]}
+                                {"If-None-Match", firstCommand.Result[0].Headers["ETag"]}
                             }
                         },
                         new GetRequest
@@ -186,15 +186,15 @@ namespace SlowTests.Tests.MultiGet
                             Query = "?id=users/2-A",
                             Headers =
                             {
-                                {"If-None-Match", command.Result[1].Headers["ETag"]}
+                                {"If-None-Match", firstCommand.Result[1].Headers["ETag"]}
                             }
                         }
                     });
 
-                    commands.RequestExecutor.Execute(command, commands.Context);
+                    commands.RequestExecutor.Execute(secondCommand, commands.Context);
 
-                    Assert.Equal(HttpStatusCode.NotModified, command.Result[0].StatusCode);
-                    Assert.Equal(HttpStatusCode.NotModified, command.Result[1].StatusCode);
+                    Assert.Equal(HttpStatusCode.NotModified, secondCommand.Result[0].StatusCode);
+                    Assert.Equal(HttpStatusCode.NotModified, secondCommand.Result[1].StatusCode);
                 }
             }
         }

--- a/test/SlowTests/Tests/MultiGet/MultiGetBasic.cs
+++ b/test/SlowTests/Tests/MultiGet/MultiGetBasic.cs
@@ -49,7 +49,7 @@ namespace SlowTests.Tests.MultiGet
 
                 using (var commands = store.Commands())
                 {
-                    var command = new MultiGetCommand(commands.RequestExecutor.Cache, new List<GetRequest>
+                    var command = new MultiGetCommand(commands.RequestExecutor, new List<GetRequest>
                     {
                         new GetRequest
                         {
@@ -103,7 +103,7 @@ namespace SlowTests.Tests.MultiGet
 
                 using (var commands = store.Commands())
                 {
-                    var command = new MultiGetCommand(commands.RequestExecutor.Cache, new List<GetRequest>
+                    var command = new MultiGetCommand(commands.RequestExecutor, new List<GetRequest>
                     {
                         new GetRequest
                         {
@@ -150,7 +150,7 @@ namespace SlowTests.Tests.MultiGet
 
                 using (var commands = store.Commands())
                 {
-                    var command = new MultiGetCommand(commands.RequestExecutor.Cache, new List<GetRequest>
+                    var command = new MultiGetCommand(commands.RequestExecutor, new List<GetRequest>
                     {
                         new GetRequest
                         {
@@ -169,7 +169,7 @@ namespace SlowTests.Tests.MultiGet
                     Assert.True(command.Result[0].Headers.ContainsKey("ETag"));
                     Assert.True(command.Result[1].Headers.ContainsKey("ETag"));
 
-                    command = new MultiGetCommand(commands.RequestExecutor.Cache, new List<GetRequest>
+                    command = new MultiGetCommand(commands.RequestExecutor, new List<GetRequest>
                     {
                         new GetRequest
                         {


### PR DESCRIPTION
https://issues.hibernatingrhinos.com/issue/RavenDB-16450