### PR TITLE
RavenDB-16482 CopyFileStream errors should be logged at Operation level

### DIFF
--- a/src/Raven.Server/Indexing/VoronIndexOutput.cs
+++ b/src/Raven.Server/Indexing/VoronIndexOutput.cs
@@ -150,8 +150,8 @@ namespace Raven.Server.Indexing
             }
             catch (Exception e)
             {
-                if (Logger.IsInfoEnabled)
-                    Logger.Info($"Failed to copy the file: {_name}", e);
+                if (Logger.IsOperationsEnabled)
+                    Logger.Operations($"Failed to copy the file: {_name}", e);
 
                 _indexOutputFilesSummary.SetWriteError();
 


### PR DESCRIPTION
https://issues.hibernatingrhinos.com/issue/RavenDB-16482