### PR TITLE
RavenDB-16467

### DIFF
--- a/src/Raven.Client/Documents/Indexes/IndexDefinition.cs
+++ b/src/Raven.Client/Documents/Indexes/IndexDefinition.cs
@@ -338,6 +338,8 @@ namespace Raven.Client.Documents.Indexes
                 result = (result * 397) ^ (Reduce?.GetHashCode() ?? 0);
                 result = (result * 397) ^ DictionaryHashCode(Fields);
                 result = (result * 397) ^ DictionaryHashCode(AdditionalSources);
+                result = (result * 397) ^ AdditionalAssemblies.Count;
+                result = (result * 397) ^ AdditionalAssemblies.GetEnumerableHashCode();
                 result = (result * 397) ^ (OutputReduceToCollection?.GetHashCode() ?? 0);
                 return result;
             }

--- a/test/SlowTests/Issues/RavenDB_15753.cs
+++ b/test/SlowTests/Issues/RavenDB_15753.cs
@@ -137,7 +137,7 @@ namespace SlowTests.Issues
                     Name = "HtmlIndex",
                     Maps =
                     {
-                        "from c in docs.Companies select new { Name = typeof(HtmlAgilityPack.HtmlNode).Name }"
+                        "from c in docs.Companies select new { Name = typeof(HtmlAgilityPack.HtmlNode).Assembly.FullName }"
                     },
                     AdditionalAssemblies =
                     {
@@ -157,6 +157,50 @@ namespace SlowTests.Issues
 
                 WaitForIndexing(store);
                 RavenTestHelper.AssertNoIndexErrors(store);
+
+                var terms = store.Maintenance.Send(new GetTermsOperation("HtmlIndex", "Name", null));
+                Assert.Equal(1, terms.Length);
+                Assert.Contains("1.11.28.0", terms[0]);
+
+                store.Maintenance.Send(new PutIndexesOperation(new IndexDefinition
+                {
+                    Name = "HtmlIndex",
+                    Maps =
+                    {
+                        "from c in docs.Companies select new { Name = typeof(HtmlAgilityPack.HtmlNode).Assembly.FullName }"
+                    },
+                    AdditionalAssemblies =
+                    {
+                        AdditionalAssembly.FromNuGet("HtmlAgilityPack", "1.11.32")
+                    }
+                }));
+
+                WaitForIndexing(store);
+                RavenTestHelper.AssertNoIndexErrors(store);
+
+                terms = store.Maintenance.Send(new GetTermsOperation("HtmlIndex", "Name", null));
+                Assert.Equal(1, terms.Length);
+                Assert.Contains("1.11.32.0", terms[0]);
+
+                store.Maintenance.Send(new PutIndexesOperation(new IndexDefinition
+                {
+                    Name = "HtmlIndex_2",
+                    Maps =
+                    {
+                        "from c in docs.Companies select new { Name = typeof(HtmlAgilityPack.HtmlNode).Assembly.FullName }"
+                    },
+                    AdditionalAssemblies =
+                    {
+                        AdditionalAssembly.FromNuGet("HtmlAgilityPack", "1.11.28")
+                    }
+                }));
+
+                WaitForIndexing(store);
+                RavenTestHelper.AssertNoIndexErrors(store);
+
+                terms = store.Maintenance.Send(new GetTermsOperation("HtmlIndex_2", "Name", null));
+                Assert.Equal(1, terms.Length);
+                Assert.Contains("1.11.28.0", terms[0]);
             }
         }
 


### PR DESCRIPTION
- take into account AdditionalAssemblies when creating IndexDefinition hash
- when loading assembly disable weak match (name only) from additional assemblies so we can register (and use) never version of the assembly if required
- register additional assembly under weak name if version is greater only