### PR TITLE
RavenDB-16483: make sure the old task id is used for ValueChanges on …

### DIFF
--- a/src/Raven.Server/ServerWide/ClusterStateMachine.cs
+++ b/src/Raven.Server/ServerWide/ClusterStateMachine.cs
@@ -3114,7 +3114,7 @@ namespace Raven.Server.ServerWide
 
             const string dbKey = "db/";
             var toUpdate = new List<(string Key, BlittableJsonReaderObject DatabaseRecord, string DatabaseName)>();
-            (long? TaskId, string name) old = default;
+            long? oldTaskId = null;
             
             var allServerWideBackupNames = GetSeverWideBackupNames(context);
 
@@ -3147,7 +3147,10 @@ namespace Raven.Server.ServerWide
                             isBackupToEditFound = true;
 
                             if (backup.TryGet(nameof(PeriodicBackupConfiguration.TaskId), out long taskId))
+                            {
                                 periodicBackupConfiguration.TaskId = taskId;
+                                oldTaskId = taskId;
+                            }
                         }
                     }
 
@@ -3165,7 +3168,7 @@ namespace Raven.Server.ServerWide
                 }
             }
 
-            ApplyDatabaseRecordUpdates(toUpdate, type, old.TaskId ?? serverWideBackupConfiguration.TaskId, serverWideBackupConfiguration.TaskId, items, context);
+            ApplyDatabaseRecordUpdates(toUpdate, type, oldTaskId ?? serverWideBackupConfiguration.TaskId, serverWideBackupConfiguration.TaskId, items, context);
         }
 
         private static bool IsServerWideBackupToEdit(BlittableJsonReaderObject backup, 

--- a/test/SlowTests/Server/Documents/PeriodicBackup/ServerWideBackup.cs
+++ b/test/SlowTests/Server/Documents/PeriodicBackup/ServerWideBackup.cs
@@ -743,12 +743,46 @@ namespace SlowTests.Server.Documents.PeriodicBackup
                 Assert.Equal(1, server.ServerStore.IdleDatabases.Count);
 
                 // update the backup configuration
+                putConfiguration.Name = serverWideConfiguration.Name;
+                putConfiguration.TaskId = serverWideConfiguration.TaskId;
                 putConfiguration.FullBackupFrequency = "0 2 * * 0";
 
+                var oldName = result.Name;
                 result = await store.Maintenance.Server.SendAsync(new PutServerWideBackupConfigurationOperation(putConfiguration));
-                serverWideConfiguration = await store.Maintenance.Server.SendAsync(new GetServerWideBackupConfigurationOperation(result.Name));
-                Assert.Equal(incFreq, serverWideConfiguration.FullBackupFrequency);
-                Assert.Equal(incFreq, serverWideConfiguration.IncrementalBackupFrequency);
+
+                Exception ex = null;
+                try
+                {
+                    await server.ServerStore.Cluster.WaitForIndexNotification(result.RaftCommandIndex, TimeSpan.FromMinutes(1));
+                }
+                catch (Exception e)
+                {
+                    ex = e;
+                }
+                finally
+                {
+                    Assert.Null(ex);
+                }
+                
+                var record = await store.Maintenance.Server.SendAsync(new GetDatabaseRecordOperation(store.Database));
+                Assert.Equal(1, record.PeriodicBackups.Count);
+                PeriodicBackupConfiguration periodicBackupConfiguration = record.PeriodicBackups.First();
+
+                var newServerWideConfiguration = await store.Maintenance.Server.SendAsync(new GetServerWideBackupConfigurationOperation(result.Name));
+
+                // compare with periodic backup task 
+                Assert.NotEqual(newServerWideConfiguration.TaskId, periodicBackupConfiguration.TaskId); // backup task id in db record doesn't change
+                Assert.Equal(PutServerWideBackupConfigurationCommand.GetTaskNameForDatabase(oldName), periodicBackupConfiguration.Name);
+                Assert.Equal(incFreq, periodicBackupConfiguration.FullBackupFrequency);
+                Assert.Equal(incFreq, periodicBackupConfiguration.IncrementalBackupFrequency);
+                Assert.NotEqual(serverWideConfiguration.FullBackupFrequency, periodicBackupConfiguration.FullBackupFrequency);
+
+                // compare with previous server wide backup
+                Assert.NotEqual(serverWideConfiguration.TaskId, newServerWideConfiguration.TaskId); // task id in server storage get increased with each change
+                Assert.Equal(oldName, result.Name);
+                Assert.Equal(incFreq, newServerWideConfiguration.FullBackupFrequency);
+                Assert.Equal(incFreq, newServerWideConfiguration.IncrementalBackupFrequency);
+                Assert.NotEqual(serverWideConfiguration.FullBackupFrequency, newServerWideConfiguration.FullBackupFrequency);
                 Assert.Equal(1, server.ServerStore.IdleDatabases.Count);
             }
         }


### PR DESCRIPTION
…editing of server wide backup