### PR TITLE
RavenDB-16507 Making the acquirement and usage of a pager state more robust by:

### DIFF
--- a/src/Voron/Impl/IPagerLevelTransactionState.cs
+++ b/src/Voron/Impl/IPagerLevelTransactionState.cs
@@ -13,7 +13,7 @@ namespace Voron.Impl
 
         event Action<IPagerLevelTransactionState> OnDispose;
         event Action<IPagerLevelTransactionState> BeforeCommitFinalization;
-        void EnsurePagerStateReference(PagerState state);
+        void EnsurePagerStateReference(ref PagerState state);
         StorageEnvironment Environment { get; }
         bool IsWriteTransaction { get; }
     }

--- a/src/Voron/Impl/Journal/JournalReader.cs
+++ b/src/Voron/Impl/Journal/JournalReader.cs
@@ -693,7 +693,7 @@ namespace Voron.Impl.Journal
         public event Action<IPagerLevelTransactionState> OnDispose;
         public event Action<IPagerLevelTransactionState> BeforeCommitFinalization;
 
-        void IPagerLevelTransactionState.EnsurePagerStateReference(PagerState state)
+        void IPagerLevelTransactionState.EnsurePagerStateReference(ref PagerState state)
         {
             //nothing to do
         }

--- a/src/Voron/Impl/Journal/WriteAheadJournal.cs
+++ b/src/Voron/Impl/Journal/WriteAheadJournal.cs
@@ -1624,7 +1624,7 @@ namespace Voron.Impl.Journal
 
             var compressionPagerTxState = tempEncCompressionPagerTxState ?? tx;
 
-            compressionPagerTxState.EnsurePagerStateReference(pagerState);
+            compressionPagerTxState.EnsurePagerStateReference(ref pagerState);
 
             _compressionPager.EnsureMapped(compressionPagerTxState, 0, pagesRequired);
             var txHeaderPtr = _compressionPager.AcquirePagePointer(compressionPagerTxState, 0);
@@ -1723,7 +1723,7 @@ namespace Voron.Impl.Journal
                     throw;
                 }
 
-                compressionPagerTxState.EnsurePagerStateReference(pagerState);
+                compressionPagerTxState.EnsurePagerStateReference(ref pagerState);
                 _compressionPager.EnsureMapped(compressionPagerTxState, pagesWritten, outputBufferInPages);
 
                 txHeaderPtr = _compressionPager.AcquirePagePointer(compressionPagerTxState, pagesWritten);

--- a/src/Voron/Impl/PagerState.cs
+++ b/src/Voron/Impl/PagerState.cs
@@ -100,7 +100,7 @@ namespace Voron.Impl
 
         public readonly byte* MapBase; // { get; set; }
 
-        private bool _released;
+        internal bool _released;
 
         public void Release()
         {
@@ -153,7 +153,7 @@ namespace Voron.Impl
 #endif
         }
 
-        private void ThrowInvalidPagerState()
+        internal void ThrowInvalidPagerState()
         {
             throw new ObjectDisposedException("Cannot add reference to a disposed pager state for " + _pager.FileName);
         }

--- a/src/Voron/Impl/Paging/TempPagerTransaction.cs
+++ b/src/Voron/Impl/Paging/TempPagerTransaction.cs
@@ -55,7 +55,7 @@ namespace Voron.Impl.Paging
         public event Action<IPagerLevelTransactionState> OnDispose;
         public event Action<IPagerLevelTransactionState> BeforeCommitFinalization;
 
-        public void EnsurePagerStateReference(PagerState state)
+        public void EnsurePagerStateReference(ref PagerState state)
         {
         }
 

--- a/src/Voron/Impl/Scratch/ScratchBufferFile.cs
+++ b/src/Voron/Impl/Scratch/ScratchBufferFile.cs
@@ -139,7 +139,7 @@ namespace Voron.Impl.Scratch
         public PageFromScratchBuffer Allocate(LowLevelTransaction tx, int numberOfPages, int sizeToAllocate)
         {
             var pagerState = _scratchPager.EnsureContinuous(_lastUsedPage, sizeToAllocate);
-            tx?.EnsurePagerStateReference(pagerState);
+            tx?.EnsurePagerStateReference(ref pagerState);
 
             var result = new PageFromScratchBuffer(_scratchNumber, _lastUsedPage, sizeToAllocate, numberOfPages);
             _allocatedPagesCount += numberOfPages;

--- a/src/Voron/Impl/Scratch/ScratchBufferPool.cs
+++ b/src/Voron/Impl/Scratch/ScratchBufferPool.cs
@@ -242,7 +242,9 @@ namespace Voron.Impl.Scratch
 
             try
             {
-                tx.EnsurePagerStateReference(current.File.PagerState);
+                var scratchPagerState = current.File.PagerState;
+
+                tx.EnsurePagerStateReference(ref scratchPagerState);
 
                 return current.File.Allocate(tx, numberOfPages, size);
             }

--- a/src/Voron/StorageEnvironment.cs
+++ b/src/Voron/StorageEnvironment.cs
@@ -590,7 +590,7 @@ namespace Voron
                 }
 
                 var state = _dataPager.PagerState;
-                tx.EnsurePagerStateReference(state);
+                tx.EnsurePagerStateReference(ref state);
 
                 return new Transaction(tx);
             }
@@ -698,7 +698,7 @@ namespace Voron
                 }
 
                 var state = _dataPager.PagerState;
-                tx.EnsurePagerStateReference(state);
+                tx.EnsurePagerStateReference(ref state);
 
                 return tx;
             }

--- a/test/SlowTests/Voron/Bugs/RavenDB_13265.cs
+++ b/test/SlowTests/Voron/Bugs/RavenDB_13265.cs
@@ -34,7 +34,9 @@ namespace SlowTests.Voron.Bugs
                     dataFilePager.EnsureContinuous(5000, 1);
                 }))
                 {
-                    tx.LowLevelTransaction.EnsurePagerStateReference(dataFilePager.PagerState);
+                    var state = dataFilePager.PagerState;
+
+                    tx.LowLevelTransaction.EnsurePagerStateReference(ref state);
 
                     Assert.Contains(dataFilePager.PagerState, testingStuff.GetPagerStates());
                 }

--- a/test/SlowTests/Voron/Issues/RavenDB_16507.cs
+++ b/test/SlowTests/Voron/Issues/RavenDB_16507.cs
@@ -1,0 +1,39 @@
+﻿using FastTests.Voron;
+using Xunit;
+using Xunit.Abstractions;
+
+namespace SlowTests.Voron.Issues
+{
+    public class RavenDB_16507 : StorageTest
+    {
+        public RavenDB_16507(ITestOutputHelper output) : base(output)
+        {
+        }
+        
+        [Fact]
+        public unsafe void AcquirePagePointerMustNotUseDisposedPagerState()
+        {
+            RequireFileBasedPager();
+
+            using (var tx = Env.ReadTransaction())
+            {
+                var dataFilePager = tx.LowLevelTransaction.DataPager;
+
+                dataFilePager.EnsureContinuous(1000, 1);
+
+                var testingStuff = tx.LowLevelTransaction.ForTestingPurposesOnly();
+
+                using (testingStuff.CallDuringEnsurePagerStateReference(() =>
+                {
+                    dataFilePager.EnsureContinuous(5000, 1);
+                }))
+                {
+                    // under the covers this was using the pager state that has been disposed by above call dataFilePager.EnsureContinuous(5000, 1);
+                    // now we have a check for that which throw an exception when this is the case
+
+                    tx.LowLevelTransaction.DataPager.AcquirePagePointer(tx.LowLevelTransaction, 0);
+                }
+            }
+        }
+    }
+}


### PR DESCRIPTION
- using EnsurePagerStateReference method when we want to get a pager state - it guarantees that we'll get the latest state and will add ref atomically
- releasing the pager state if any exception happens - it's very impornant because we already called AddRef()
- passing state paramter as ref to EnsurePagerStateReference because we might have further usage of this variable and inside EnsurePagerStateReference we could get newest state (while the one passed as parameter could be disposed)

https://issues.hibernatingrhinos.com/issue/RavenDB-16507
https://issues.hibernatingrhinos.com/issue/RavenDB-16128