### PR TITLE
RavenDB-16511 Fix index replacement

### DIFF
--- a/src/Raven.Server/Documents/Indexes/Index.cs
+++ b/src/Raven.Server/Documents/Indexes/Index.cs
@@ -185,6 +185,8 @@ namespace Raven.Server.Documents.Indexes
         private readonly ReaderWriterLockSlim _currentlyRunningQueriesLock = new ReaderWriterLockSlim();
         private readonly MultipleUseFlag _priorityChanged = new MultipleUseFlag();
         private readonly MultipleUseFlag _hadRealIndexingWorkToDo = new MultipleUseFlag();
+        internal bool HadRealIndexingWork => _hadRealIndexingWorkToDo.IsRaised();
+
         private readonly MultipleUseFlag _definitionChanged = new MultipleUseFlag();
         private Size _initialManagedAllocations;
 
@@ -1176,7 +1178,7 @@ namespace Raven.Server.Documents.Indexes
                                     {
                                         var originalName = Name.Replace(Constants.Documents.Indexing.SideBySideIndexNamePrefix, string.Empty, StringComparison.OrdinalIgnoreCase);
                                         _isReplacing = true;
-
+                                        
                                         if (batchCompleted)
                                         {
                                             // this side-by-side index will be replaced in a second, notify about indexing success
@@ -3876,8 +3878,10 @@ namespace Raven.Server.Documents.Indexes
 
             onBeforeEnvironmentDispose?.Invoke();
 
-            _environment.Dispose();
+            IndexPersistence.Dispose();
 
+            _environment.Dispose();
+            
             return new DisposableAction(() =>
             {
                 // restart environment

--- a/src/Raven.Server/Documents/Indexes/IndexStore.cs
+++ b/src/Raven.Server/Documents/Indexes/IndexStore.cs
@@ -1980,13 +1980,27 @@ namespace Raven.Server.Documents.Indexes
             if (_forTestingPurposes != null)
                 return _forTestingPurposes;
 
-            return _forTestingPurposes = new TestingStuff();
+            return _forTestingPurposes = new TestingStuff(this);
         }
 
         internal class TestingStuff
         {
+            private readonly IndexStore _parent;
             internal Action DuringIndexReplacement_AfterUpdatingCollectionOfIndexes;
             internal Action DuringIndexReplacement_OnOldIndexDeletion;
+
+            public TestingStuff(IndexStore parent)
+            {
+                _parent = parent;
+            }
+
+            public void RunFakeIndex(Index index)
+            {
+                // create the SemaphoreSlim
+                _parent.GetIndexLock(index.Name);
+
+                _parent.StartIndex(index);
+            }
         }
     }
 

--- a/src/Raven.Server/Indexing/LuceneVoronDirectory.cs
+++ b/src/Raven.Server/Indexing/LuceneVoronDirectory.cs
@@ -13,7 +13,7 @@ namespace Raven.Server.Indexing
         private readonly StorageEnvironment _environment;
         private readonly string _name;
         private readonly IndexOutputFilesSummary _indexOutputFilesSummary;
-        private readonly TempFileCache _tmpFileCache;
+        internal readonly TempFileCache TempFileCache;
 
         public string Name => _name;
 
@@ -38,7 +38,7 @@ namespace Raven.Server.Indexing
 
             _indexOutputFilesSummary = new IndexOutputFilesSummary();
             
-            _tmpFileCache = new TempFileCache(environment.Options);
+            TempFileCache = new TempFileCache(environment.Options);
         }
 
         public override bool FileExists(string name, IState s)
@@ -194,7 +194,7 @@ namespace Raven.Server.Indexing
             if (state == null)
                 throw new ArgumentNullException(nameof(s));
 
-            return new VoronIndexOutput(_tmpFileCache, name, state.Transaction, _name, _indexOutputFilesSummary);
+            return new VoronIndexOutput(TempFileCache, name, state.Transaction, _name, _indexOutputFilesSummary);
         }
 
         public IDisposable SetTransaction(Transaction tx, out IState state)
@@ -214,7 +214,7 @@ namespace Raven.Server.Indexing
 
         protected override void Dispose(bool disposing)
         {
-            _tmpFileCache.Dispose();
+            TempFileCache.Dispose();
         }
 
         public void ResetAllocations()

--- a/test/SlowTests/Issues/RavenDB_16511.cs
+++ b/test/SlowTests/Issues/RavenDB_16511.cs
@@ -1,0 +1,107 @@
+﻿using System;
+using System.Collections.Generic;
+using System.Linq;
+using System.Text;
+using System.Threading;
+using System.Threading.Tasks;
+using FastTests;
+using Raven.Client;
+using Raven.Client.Documents.Changes;
+using Raven.Client.Documents.Indexes;
+using Raven.Client.Documents.Operations.Indexes;
+using Raven.Client.Exceptions;
+using Raven.Client.Util;
+using Raven.Server.Config;
+using Raven.Server.Documents.Indexes;
+using Raven.Server.Documents.Indexes.Static;
+using Raven.Server.Documents.Queries;
+using Raven.Server.ServerWide;
+using Raven.Server.ServerWide.Context;
+using Sparrow.Json.Parsing;
+using Xunit;
+using Xunit.Abstractions;
+
+namespace SlowTests.Issues
+{
+    public class RavenDB_16511 : RavenLowLevelTestBase
+    {
+        [Fact]
+        public async Task ReplaceIndexShouldWork()
+        {
+
+            using (var database = CreateDocumentDatabase(runInMemory: false))
+            {
+                var testingStuff = database.IndexStore.ForTestingPurposesOnly(); 
+
+                using (var index = MapIndex.CreateNew(new IndexDefinition() {Name = "Users_ByName", Maps = {"from user in docs.Users select new { user.Name }"},},
+                    database))
+                {
+
+                    index.IndexPersistence.LuceneDirectory.TempFileCache.SetMemoryStreamCapacity(1);
+                    testingStuff.RunFakeIndex(index);
+
+                    using (var context = DocumentsOperationContext.ShortTermSingleUse(database))
+                    {
+                        using (var tx = context.OpenWriteTransaction())
+                        {
+                            using (var doc = CreateDocument(context, "users/1",
+                                new DynamicJsonValue
+                                {
+                                    ["Name"] = "John", [Constants.Documents.Metadata.Key] = new DynamicJsonValue {[Constants.Documents.Metadata.Collection] = "Users"}
+                                }))
+                            {
+                                database.DocumentsStorage.Put(context, "users/1", null, doc);
+                            }
+
+                            using (var doc = CreateDocument(context, "users/2",
+                                new DynamicJsonValue
+                                {
+                                    ["Name"] = "Edward",
+                                    [Constants.Documents.Metadata.Key] = new DynamicJsonValue {[Constants.Documents.Metadata.Collection] = "Users"}
+                                }))
+                            {
+                                database.DocumentsStorage.Put(context, "users/2", null, doc);
+                            }
+
+                            tx.Commit();
+                        }
+                    }
+
+                    while (index.HadRealIndexingWork == false)
+                    {
+                        await Task.Delay(100);
+                    }
+
+                    var mre = new SemaphoreSlim(initialCount: 0);
+
+                    database.Changes.OnIndexChange += change =>
+                    {
+                        if (change.Type == IndexChangeTypes.SideBySideReplace)
+                            mre.Release();
+                    };
+
+                    using (var newIndex = MapIndex.CreateNew(
+                        new IndexDefinition()
+                        {
+                            Name = $"{Constants.Documents.Indexing.SideBySideIndexNamePrefix}Users_ByName",
+                            Maps = {" from user in docs.Users select new { user.Name }"},
+                        },
+                        database))
+                    {
+                        newIndex.IndexPersistence.LuceneDirectory.TempFileCache.SetMemoryStreamCapacity(1);
+                        testingStuff.RunFakeIndex(newIndex);
+
+                        Assert.True(await mre.WaitAsync(TimeSpan.FromSeconds(15)), "Index wasn't replaced");
+
+                        Assert.True(newIndex.Status == IndexRunningStatus.Running);
+                    }
+
+                }
+            }
+        }
+
+        public RavenDB_16511(ITestOutputHelper output) : base(output)
+        {
+        }
+    }
+}


### PR DESCRIPTION
Upon replacement, we need to dispose the IndexPersistence in order to release the temp files, so we can move them.