### PR TITLE
RavenDB-16538 Fixing unhandled error in DetermineServerIp kills the server with bad error:

### DIFF
--- a/src/Raven.Server/Config/Categories/SecurityConfiguration.cs
+++ b/src/Raven.Server/Config/Categories/SecurityConfiguration.cs
@@ -187,10 +187,6 @@ namespace Raven.Server.Config.Categories
 
                 var isServerUrlHttps = uri.Scheme.Equals("https", StringComparison.OrdinalIgnoreCase);
 
-                var serverAddresses = DetermineServerIp(uri);
-                var unsecuredAccessAddressRange = configuration.Security.UnsecuredAccessAllowed;
-                var serverIsWithinUnsecuredAccessRange = serverAddresses.Any(x => SecurityUtils.IsUnsecuredAccessAllowedForAddress(unsecuredAccessAddressRange, x));
-
                 if (configuration.Security.AuthenticationEnabled)
                 {
                     if (isServerUrlHttps == false)
@@ -202,6 +198,11 @@ namespace Raven.Server.Config.Categories
                 {
                     if (isServerUrlHttps)
                         throw new InvalidOperationException($"Configured server address { string.Join(", ", configuration.Core.ServerUrls) } requires HTTPS. Please set up certification information under { RavenConfiguration.GetKey(x => x.Security.CertificatePath) } configuration key.");
+
+                    var serverAddresses = DetermineServerIp(uri);
+                    var unsecuredAccessAddressRange = configuration.Security.UnsecuredAccessAllowed;
+
+                    var serverIsWithinUnsecuredAccessRange = serverAddresses.Any(x => SecurityUtils.IsUnsecuredAccessAllowedForAddress(unsecuredAccessAddressRange, x));
 
                     if (serverIsWithinUnsecuredAccessRange == false)
                     {
@@ -229,7 +230,14 @@ namespace Raven.Server.Config.Categories
                 if (getHostAddressesTask.Wait(TimeSpan.FromSeconds(30)) == false)
                     throw new InvalidOperationException($"Could not obtain IP address from DNS {serverUri.DnsSafeHost} for 30 seconds.");
 
-                addresses = getHostAddressesTask.Result;
+                try
+                {
+                    addresses = getHostAddressesTask.Result;
+                }
+                catch (Exception e)
+                {
+                    throw new InvalidOperationException($"Failed to get IP address of {serverUri.DnsSafeHost} host", e);
+                }
             }
 
             if (addresses.Length == 0)

--- a/src/Raven.Server/Utils/UnhandledExceptions.cs
+++ b/src/Raven.Server/Utils/UnhandledExceptions.cs
@@ -6,7 +6,7 @@ namespace Raven.Server.Utils
 {
     public class UnhandledExceptions
     {
-        private static readonly TimeSpan TimeToWaitForLog = TimeSpan.FromSeconds(15);
+        internal static readonly TimeSpan TimeToWaitForLog = TimeSpan.FromSeconds(15);
 
         public static void Track(Logger logger)
         {


### PR DESCRIPTION
- Let's make sure that we see the acual host name which we failed to get the IP during Dns.GetHostAddressesAsync
- DetermineServerIp() is going to be called only if server is unsecured because it's needed only then so a failure there won't prevent a secured server to start
- Logging an exception thrown by the validation of the security configuration