### PR TITLE
RavenDB-16598 Expose wait time in the stats if an index is waiting for the lock which limits the concurrently running indexes

### DIFF
--- a/src/Raven.Client/Documents/Indexes/IndexingOperation.cs
+++ b/src/Raven.Client/Documents/Indexes/IndexingOperation.cs
@@ -53,7 +53,11 @@ namespace Raven.Client.Documents.Indexes
             public static string GetMapEntries = "GetMapEntries";
             public static string SaveOutputDocuments = "SaveOutputDocuments";
             public static string DeleteOutputDocuments = "DeleteOutputDocuments";
+        }
 
+        internal static class Wait
+        {
+            public const string AcquireConcurrentlyRunningIndexesLock = "Wait/ConcurrentlyRunningIndexesLimit";
         }
     }
 }

--- a/src/Raven.Server/Documents/Indexes/Index.cs
+++ b/src/Raven.Server/Documents/Indexes/Index.cs
@@ -1034,14 +1034,10 @@ namespace Raven.Server.Documents.Indexes
 
                         bool didWork = false;
 
-                        IndexingStatsAggregator stats = null;
-                        
-                        DocumentDatabase.ServerStore.ServerWideConcurrentlyRunningIndexesLock?.Acquire(_indexingProcessCancellationTokenSource.Token);
+                        var stats = _lastStats = new IndexingStatsAggregator(DocumentDatabase.IndexStore.Identities.GetNextIndexingStatsId(), _lastStats);
 
                         try
                         {
-                            stats = _lastStats = new IndexingStatsAggregator(DocumentDatabase.IndexStore.Identities.GetNextIndexingStatsId(), _lastStats);
-
                             if (_logger.IsInfoEnabled)
                                 _logger.Info($"Starting indexing for '{Name}'.");
 
@@ -1054,6 +1050,17 @@ namespace Raven.Server.Documents.Indexes
                                 try
                                 {
                                     _indexingProcessCancellationTokenSource.Token.ThrowIfCancellationRequested();
+
+                                    if (DocumentDatabase.ServerStore.ServerWideConcurrentlyRunningIndexesLock != null)
+                                    {
+                                        if (DocumentDatabase.ServerStore.ServerWideConcurrentlyRunningIndexesLock.TryAcquire(TimeSpan.Zero, _indexingProcessCancellationTokenSource.Token) == false)
+                                        {
+                                            using (scope.For(IndexingOperation.Wait.AcquireConcurrentlyRunningIndexesLock))
+                                            {
+                                                DocumentDatabase.ServerStore.ServerWideConcurrentlyRunningIndexesLock.Acquire(_indexingProcessCancellationTokenSource.Token);
+                                            }
+                                        }
+                                    }
 
                                     try
                                     {
@@ -1079,6 +1086,8 @@ namespace Raven.Server.Documents.Indexes
                                     }
                                     finally
                                     {
+                                        DocumentDatabase.ServerStore.ServerWideConcurrentlyRunningIndexesLock?.Release();
+
                                         _indexingInProgress.Release();
 
                                         if (_batchStopped)
@@ -1218,9 +1227,7 @@ namespace Raven.Server.Documents.Indexes
                         }
                         finally
                         {
-                            DocumentDatabase.ServerStore.ServerWideConcurrentlyRunningIndexesLock?.Release();
-
-                            stats?.Complete();
+                            stats.Complete();
                         }
 
                         if (batchCompleted)

--- a/src/Raven.Studio/typescript/viewmodels/database/indexes/indexPerformance.ts
+++ b/src/Raven.Studio/typescript/viewmodels/database/indexes/indexPerformance.ts
@@ -156,6 +156,7 @@ class indexPerformance extends viewModelBase {
     private static readonly brushSectionIndexesWorkHeight = 22;
     private static readonly brushSectionLineWidth = 1;
     private static readonly trackHeight = 18; // height used for callstack item
+    private static readonly waitTrackPadding = 4;
     private static readonly stackPadding = 1; // space between call stacks
     private static readonly trackMargin = 4;
     private static readonly closedTrackPadding = 2;
@@ -248,6 +249,7 @@ class indexPerformance extends viewModelBase {
         stripeTextColor: undefined as string,
         progressStripes: undefined as string,
         tracks: {
+            "Wait/ConcurrentlyRunningIndexesLimit": undefined as string,
             "Collection": undefined as string,
             "Indexing": undefined as string,
             "Cleanup": undefined as string,
@@ -827,7 +829,7 @@ class indexPerformance extends viewModelBase {
         this.data.forEach(indexStats => {
             indexStats.Performance.forEach(perfStat => {
                 const perfStatsWithCache = perfStat as IndexingPerformanceStatsWithCache;
-                const start = perfStatsWithCache.StartedAsDate;
+                const start = perfStatsWithCache.StartedAsDateExcludingWaitTime;
                 let end: Date;
                 if (perfStat.Completed) {
                     end = perfStatsWithCache.CompletedAsDate;
@@ -954,7 +956,8 @@ class indexPerformance extends viewModelBase {
                 const perfLength = performance.length;
                 for (let perfIdx = 0; perfIdx < perfLength; perfIdx++) {
                     const perf = performance[perfIdx];
-                    const startDate = (perf as IndexingPerformanceStatsWithCache).StartedAsDate;
+                    const perfWithCache = perf as IndexingPerformanceStatsWithCache;
+                    const startDate = perfWithCache.StartedAsDate;
 
                     const startDateAsInt = startDate.getTime();
                     if (visibleEndDateAsInt < startDateAsInt) {
@@ -964,20 +967,22 @@ class indexPerformance extends viewModelBase {
                     if (startDateAsInt + perf.DurationInMs < visibleStartDateAsInt)
                         continue;
                     
+                    if (perfWithCache.WaitOperation && perfWithCache.WaitOperation.DurationInMs > 1) {
+                        this.drawWaitTime(context, xScale(perfWithCache.StartedAsDate), stripesYStart, extentFunc, yOffset !== 0, perfWithCache.WaitOperation);
+                    }
                     
-                    const x1 = xScale(startDate);
-                    
-                    this.drawStripes(0, perf, context, [perf.Details], x1, stripesYStart, yOffset, extentFunc, perfStat.Name);
+                    const x1 = xScale(perfWithCache.StartedAsDateExcludingWaitTime);
+                    this.drawStripes(0, perf, context, [perfWithCache.DetailsExcludingWaitTime], x1, stripesYStart, yOffset, extentFunc, perfStat.Name);
 
                     if (!perf.Completed) {
-                        this.findInProgressAction(context, perf, extentFunc, x1, stripesYStart, yOffset);
+                        this.findInProgressAction(context, perfWithCache, extentFunc, x1, stripesYStart, yOffset);
                     }
                 }
             }
         });
     }
 
-    private findInProgressAction(context: CanvasRenderingContext2D, perf: Raven.Client.Documents.Indexes.IndexingPerformanceStats, extentFunc: (duration: number) => number,
+    private findInProgressAction(context: CanvasRenderingContext2D, perf: IndexingPerformanceStatsWithCache, extentFunc: (duration: number) => number,
         xStart: number, yStart: number, yOffset: number): void {
 
         const extractor = (perfs: Raven.Client.Documents.Indexes.IndexingPerformanceOperation[], xStart: number, yStart: number, yOffset: number) => {
@@ -996,7 +1001,7 @@ class indexPerformance extends viewModelBase {
             });
         };
 
-        extractor([perf.Details], xStart, yStart, yOffset);
+        extractor([perf.DetailsExcludingWaitTime], xStart, yStart, yOffset);
     }
 
     private getColorForOperation(operationName: string): string {
@@ -1012,6 +1017,18 @@ class indexPerformance extends viewModelBase {
         throw new Error("Unable to find color for: " + operationName);
     }
 
+    
+    private drawWaitTime(context: CanvasRenderingContext2D, xStart: number, yStart: number, extentFunc: (duration: number) => number, trackIsOpened: boolean, op: Raven.Client.Documents.Indexes.IndexingPerformanceOperation) {
+        context.fillStyle = this.getColorForOperation("Wait/ConcurrentlyRunningIndexesLimit");
+        const dx = extentFunc(op.DurationInMs);
+        
+        context.fillRect(xStart, yStart + indexPerformance.waitTrackPadding, dx, indexPerformance.trackHeight - 2 * indexPerformance.waitTrackPadding);
+        
+        if (trackIsOpened && dx >= 0.8) {
+            this.hitTest.registerTrackItem(xStart, yStart + indexPerformance.waitTrackPadding, dx, indexPerformance.trackHeight - 2 * indexPerformance.waitTrackPadding, op);
+        }
+    }
+    
     private drawStripes(level: number, rootPerf:Raven.Client.Documents.Indexes.IndexingPerformanceStats, 
                         context: CanvasRenderingContext2D, operations: Array<Raven.Client.Documents.Indexes.IndexingPerformanceOperation>, 
                         xStart: number, yStart: number, yOffset: number, extentFunc: (duration: number) => number, indexName?: string) {
@@ -1399,7 +1416,14 @@ class indexPerformance extends viewModelBase {
             exportFileName = `indexPerf of ${this.activeDatabase().name} ${moment().format("YYYY-MM-DD HH-mm")}`; 
         }
 
-        const keysToIgnore: Array<keyof IndexingPerformanceStatsWithCache | keyof IndexingPerformanceOperationWithParent> = ["StartedAsDate", "CompletedAsDate", "Parent"];
+        const keysToIgnore: Array<keyof IndexingPerformanceStatsWithCache | keyof IndexingPerformanceOperationWithParent> = [
+            "StartedAsDate", 
+            "CompletedAsDate", 
+            "Parent",
+            "StartedAsDateExcludingWaitTime",
+            "WaitOperation",
+            "DetailsExcludingWaitTime"
+        ];
         fileDownloader.downloadAsJson(this.data, exportFileName + ".json", exportFileName, (key, value) => {
             if (_.includes(keysToIgnore, key)) {
                 return undefined;

--- a/src/Raven.Studio/typings/_studio/dto.d.ts
+++ b/src/Raven.Studio/typings/_studio/dto.d.ts
@@ -306,8 +306,11 @@ declare module studio.settings {
 }
 
 interface IndexingPerformanceStatsWithCache extends Raven.Client.Documents.Indexes.IndexingPerformanceStats {
-    StartedAsDate: Date; // used for caching
-    CompletedAsDate: Date; // user for caching
+    StartedAsDate: Date;
+    StartedAsDateExcludingWaitTime: Date;
+    WaitOperation: Raven.Client.Documents.Indexes.IndexingPerformanceOperation;
+    CompletedAsDate: Date;
+    DetailsExcludingWaitTime: Raven.Client.Documents.Indexes.IndexingPerformanceOperation;
 }
 
 interface IOMetricsRecentStatsWithCache extends Raven.Server.Utils.IoMetrics.IOMetricsRecentStats {

--- a/src/Raven.Studio/wwwroot/App/views/database/indexes/indexPerformance.html
+++ b/src/Raven.Studio/wwwroot/App/views/database/indexes/indexPerformance.html
@@ -81,6 +81,7 @@
                     <div class="stripeTextColor"></div>
                     <div class="progressStripes"></div>
                     <div class="tracks">
+                        <div class="concurrentlyRunning" data-property="Wait/ConcurrentlyRunningIndexesLimit"></div>
                         <div class="collection" data-property="Collection"></div>
                         <div class="indexing" data-property="Indexing"></div>
                         <div class="cleanup" data-property="Cleanup"></div>

--- a/src/Raven.Studio/wwwroot/Content/css/pages/index-performance.less
+++ b/src/Raven.Studio/wwwroot/Content/css/pages/index-performance.less
@@ -69,6 +69,10 @@
         .aggregationBlittableJson {
             color: #ec407a;
         }
+        
+        .concurrentlyRunning {
+            color: rgba(136, 136, 136, 0.2);
+        }
 
         .references {
             color: #ac2258;


### PR DESCRIPTION
https://issues.hibernatingrhinos.com/issue/RavenDB-16598