### PR TITLE
RavenDB-16581 On index editing screen duplicate name exception should…

### DIFF
--- a/src/Raven.Studio/typescript/models/database/index/indexDefinition.ts
+++ b/src/Raven.Studio/typescript/models/database/index/indexDefinition.ts
@@ -95,7 +95,8 @@ class indexDefinition {
         this.additionalSources(_.map(dto.AdditionalSources, (code, name) => additionalSource.create(name, code)));
 
         this.hasDuplicateFieldsNames = ko.pureComputed(() => {
-            return _.uniqBy(this.fields(), field => field.name()).length !== this.fields().length;
+            const nonEmptyFields = this.fields().filter(x => x.name());
+            return _.uniqBy(nonEmptyFields, field => field.name()).length !== nonEmptyFields.length;
         });
         
         if (!this.isAutoIndex()) {


### PR DESCRIPTION
…n't displayed for empty field names