### PR TITLE
RavenDB-16635 Making sure that a newly created transaction won't get pager states of already disposed scratches.

### DIFF
--- a/src/Voron/Impl/Journal/WriteAheadJournal.cs
+++ b/src/Voron/Impl/Journal/WriteAheadJournal.cs
@@ -856,7 +856,7 @@ namespace Voron.Impl.Journal
                         // let's try to prevent running new read transactions so we'll be able to free more scratch pages and delete more journals
                         // in particular we might clean the last journal so we won't need to apply it on restart - see RavenDB-11871 
 
-                        if (_waj._env.IsInPreventNewReadTransactionsMode || _waj._env.TryPreventNewReadTransactions(TimeSpan.Zero, out exitPreventNewTransactions))
+                        if (_waj._env.IsInPreventNewTransactionsMode || _waj._env.TryPreventNewReadTransactions(TimeSpan.Zero, out exitPreventNewTransactions))
                         {
                             // we managed to prevent from new read transactions, let's verify that we're still the only active transaction
 

--- a/src/Voron/StorageEnvironment.cs
+++ b/src/Voron/StorageEnvironment.cs
@@ -86,7 +86,7 @@ namespace Voron
         private NativeMemory.ThreadStats _currentWriteTransactionHolder;
         private readonly AsyncManualResetEvent _writeTransactionRunning = new AsyncManualResetEvent();
         internal readonly ThreadHoppingReaderWriterLock FlushInProgressLock = new ThreadHoppingReaderWriterLock();
-        private readonly ReaderWriterLockSlim _txCommit = new ReaderWriterLockSlim();
+        private readonly ReaderWriterLockSlim _txCreation = new ReaderWriterLockSlim();
         private readonly CountdownEvent _envDispose = new CountdownEvent(1);
 
         private long _transactionsCounter;
@@ -573,7 +573,7 @@ namespace Voron
 
                 LowLevelTransaction tx;
 
-                _txCommit.EnterReadLock();
+                _txCreation.EnterReadLock();
                 try
                 {
                     _cancellationTokenSource.Token.ThrowIfCancellationRequested();
@@ -584,7 +584,7 @@ namespace Voron
                 }
                 finally
                 {
-                    _txCommit.ExitReadLock();
+                    _txCreation.ExitReadLock();
                 }
 
                 var state = _dataPager.PagerState;
@@ -668,7 +668,7 @@ namespace Voron
 
                 LowLevelTransaction tx;
 
-                _txCommit.EnterReadLock();
+                _txCreation.EnterReadLock();
                 try
                 {
                     _cancellationTokenSource.Token.ThrowIfCancellationRequested();
@@ -692,7 +692,7 @@ namespace Voron
                 }
                 finally
                 {
-                    _txCommit.ExitReadLock();
+                    _txCreation.ExitReadLock();
                 }
 
                 var state = _dataPager.PagerState;
@@ -807,19 +807,19 @@ namespace Voron
             return result;
         }
 
-        internal ExitWriteLock PreventNewReadTransactions()
+        internal ExitWriteLock PreventNewTransactions()
         {
-            _txCommit.EnterWriteLock();
-            return new ExitWriteLock(_txCommit);
+            _txCreation.EnterWriteLock();
+            return new ExitWriteLock(_txCreation);
         }
 
-        internal bool IsInPreventNewReadTransactionsMode => _txCommit.IsWriteLockHeld;
+        internal bool IsInPreventNewTransactionsMode => _txCreation.IsWriteLockHeld;
 
         internal bool TryPreventNewReadTransactions(TimeSpan timeout, out IDisposable exitWriteLock)
         {
-            if (_txCommit.TryEnterWriteLock(timeout))
+            if (_txCreation.TryEnterWriteLock(timeout))
             {
-                exitWriteLock = new ExitWriteLock(_txCommit);
+                exitWriteLock = new ExitWriteLock(_txCreation);
                 return true;
             }
 
@@ -849,7 +849,7 @@ namespace Voron
             if (ActiveTransactions.Contains(tx) == false)
                 return;
 
-            using (PreventNewReadTransactions())
+            using (PreventNewTransactions())
             {
                 Journal.Applicator.OnTransactionCommitted(tx);
                 ScratchBufferPool.UpdateCacheForPagerStatesOfAllScratches();

--- a/test/SlowTests/Voron/RavenDB_16635.cs
+++ b/test/SlowTests/Voron/RavenDB_16635.cs
@@ -1,0 +1,107 @@
+﻿using System;
+using System.Threading;
+using FastTests.Voron;
+using Voron;
+using Voron.Impl;
+using Xunit;
+using Xunit.Abstractions;
+
+namespace SlowTests.Voron
+{
+    public class RavenDB_16635 : StorageTest
+    {
+        public RavenDB_16635(ITestOutputHelper output) : base(output)
+        {
+        }
+
+        protected override void Configure(StorageEnvironmentOptions options)
+        {
+            options.ManualFlushing = true;
+            options.ManualSyncing = true;
+            options.MaxScratchBufferSize = 64 * 1024 * 4;
+        }
+
+        [Theory]
+        [InlineData(false)]
+        [InlineData(true)]
+        public void MustNotThrowObjectDisposedWhenCreatingNewTransaction(bool startWriteTransaction)
+        {
+            RequireFileBasedPager();
+
+            for (int i = 0; i < 100; i++)
+            {
+                using (var tx = Env.WriteTransaction())
+                {
+                    var tree = tx.CreateTree("items");
+
+                    tree.Add("items/" + i, new byte[] { 1, 2, 3 });
+
+                    tx.Commit();
+                }
+            }
+
+            Env.FlushLogToDataFile();
+
+            Exception startTransactionException = null;
+
+            var startTransactionThread = new Thread(() =>
+            {
+                try
+                {
+                    using (var tx = startWriteTransaction ? Env.WriteTransaction() : Env.ReadTransaction())
+                    {
+                        var pagerStates = tx.LowLevelTransaction.ForTestingPurposesOnly().GetPagerStates();
+
+                        Assert.Equal(2, pagerStates.Count); // data file, and one scratch file
+
+                        foreach (PagerState pagerState in pagerStates)
+                        {
+                            Assert.False(pagerState.CurrentPager.Disposed);
+                        }
+                    }
+                }
+                catch (Exception e)
+                {
+                    startTransactionException = e;
+                }
+            });
+
+            var startTransactionWasCalled = false;
+
+            using (Env.ScratchBufferPool.ForTestingPurposesOnly().CallDuringCleanupRightAfterRemovingInactiveJournals(() =>
+            {
+                startTransactionWasCalled = true;
+
+                startTransactionThread.Start();
+            }))
+            {
+                Env.ScratchBufferPool.Cleanup();
+            }
+
+            Assert.True(startTransactionWasCalled, "startTransactionWasCalled");
+
+            Assert.True(startTransactionThread.Join(TimeSpan.FromSeconds(30)), "startTransactionThread.Join(TimeSpan.FromSeconds(30))");
+            
+            Assert.Null(startTransactionException);
+        }
+
+        [Fact]
+        public unsafe void CannotUsePagerStateOfDisposedPager() // this test is just to verify that we properly throw on such invalid usage
+        {
+            RequireFileBasedPager();
+
+            var tempPager = Env.Options.CreateTemporaryBufferPager($"temp-{Guid.NewGuid()}", 16 * 1024);
+
+            var state = tempPager.PagerState;
+
+            state.AddRef();
+
+            tempPager.Dispose();
+
+            using (var tx = Env.ReadTransaction())
+            {
+                Assert.Throws<ObjectDisposedException>(() => tempPager.AcquirePagePointer(tx.LowLevelTransaction, 0, state));
+            }
+        }
+    }
+}


### PR DESCRIPTION
We must not allow to run the scratch buffer pool cleanup and create transactions at the same time.


See https://issues.hibernatingrhinos.com/issue/RavenDB-16635 for detailed explanation.

The issue has been revealed by changes made in PR https://github.com/ravendb/ravendb/pull/12008