### PR TITLE
RavenDB-16507/HRINT-2222 If a pager state has been already added to t…

### DIFF
--- a/src/Voron/Impl/LowLevelTransaction.cs
+++ b/src/Voron/Impl/LowLevelTransaction.cs
@@ -1278,7 +1278,12 @@ namespace Voron.Impl
 
             _lastState = state;
 
-            _pagerStates.Add(state);
+            if (_pagerStates.Add(state) == false)
+            {
+                // the state is already on the list but we already added a reference to it so now we need to release it
+
+                state.Release();
+            }
         }
 
         [MethodImpl(MethodImplOptions.AggressiveInlining)]


### PR DESCRIPTION
…he list then we must release a ref count because we have incremented it during state.CurrentPager.GetPagerStateAndAddRefAtomically()


https://issues.hibernatingrhinos.com/issue/HRINT-2222

This fix is related to changes made here: https://github.com/ravendb/ravendb/pull/12008