### PR TITLE
RavenDB-16705

### DIFF
--- a/src/Raven.Server/Documents/Revisions/RevisionsStorage.cs
+++ b/src/Raven.Server/Documents/Revisions/RevisionsStorage.cs
@@ -378,7 +378,7 @@ namespace Raven.Server.Documents.Revisions
             if (configuration == null)
                 configuration = GetRevisionsConfiguration(collectionName.Name);
 
-            if (configuration.Disabled && 
+            if (configuration.Disabled &&
                 nonPersistentFlags.Contain(NonPersistentDocumentFlags.FromReplication) == false)
                 return false;
 
@@ -406,7 +406,7 @@ namespace Raven.Server.Documents.Revisions
                 PutFromRevisionIfChangeVectorIsGreater(context, document, id, changeVector, lastModifiedTicks, flags, nonPersistentFlags);
 
                 if (table.VerifyKeyExists(changeVectorSlice)) // we might create
-                    return true; 
+                    return true;
 
                 flags |= DocumentFlags.Revision;
                 var etag = _database.DocumentsStorage.GenerateNextEtag();
@@ -504,7 +504,7 @@ namespace Raven.Server.Documents.Revisions
                 }
 
                 nonPersistentFlags |= NonPersistentDocumentFlags.SkipRevisionCreation;
-                flags = flags.Strip(DocumentFlags.Revision);
+                flags = flags.Strip(DocumentFlags.Revision | DocumentFlags.DeleteRevision);
 
                 if (document == null)
                 {

--- a/src/Sparrow/Json/BlittableJsonReaderObject.cs
+++ b/src/Sparrow/Json/BlittableJsonReaderObject.cs
@@ -1387,14 +1387,13 @@ namespace Sparrow.Json
         [Conditional("DEBUG")]
         public static void AssertNoModifications(BlittableJsonReaderObject data, string id, bool assertChildren, bool assertRemovals = true, bool assertProperties = true)
         {
-            data.AssertContextNotDisposed();
-
             if (assertRemovals == false && assertProperties == false)
                 throw new InvalidOperationException($"Both {nameof(assertRemovals)} and {nameof(assertProperties)} cannot be set to false.");
 
             if (data == null)
                 return;
 
+            data.AssertContextNotDisposed();
             data.NoCache = true;
 
             if (assertRemovals && data.Modifications?.Removals?.Count > 0 && data.Modifications.SourceIndex < data.Count)

--- a/test/SlowTests/Issues/RavenDB_16705.cs
+++ b/test/SlowTests/Issues/RavenDB_16705.cs
@@ -83,6 +83,8 @@ namespace SlowTests.Issues
                 Assert.NotNull(WaitForDocumentWithAttachmentToReplicate<User>(destination, documentId1, attachmentName2, 15 * 1000));
                 Assert.NotNull(WaitForDocumentWithAttachmentToReplicate<User>(destination, documentId2, attachmentName1, 15 * 1000));
                 Assert.NotNull(WaitForDocumentWithAttachmentToReplicate<User>(destination, documentId2, attachmentName2, 15 * 1000));
+
+                await EnsureNoReplicationLoop(Server, destination.Database);
             }
 
             static void ModifyAttachment(AttachmentsStorage attachmentStorage, DocumentsOperationContext context, string documentId, string attachmentName, string contentType)

--- a/test/SlowTests/Issues/RavenDB_16705.cs
+++ b/test/SlowTests/Issues/RavenDB_16705.cs
@@ -1,0 +1,99 @@
+﻿using System.IO;
+using System.Threading.Tasks;
+using FastTests.Server.Replication;
+using Raven.Client.Documents.Attachments;
+using Raven.Server.Config;
+using Raven.Server.Documents;
+using Raven.Server.ServerWide.Context;
+using SlowTests.Core.Utils.Entities;
+using Xunit;
+using Xunit.Abstractions;
+
+namespace SlowTests.Issues
+{
+    public class RavenDB_16705 : ReplicationTestBase
+    {
+        public RavenDB_16705(ITestOutputHelper output) : base(output)
+        {
+        }
+
+        [Fact]
+        public async Task BatchingWithMissingAttachmentsShouldNotCauseReplicationLoop()
+        {
+            using (var source = GetDocumentStore(new Options
+            {
+                ModifyDatabaseRecord = record => record.Settings[RavenConfiguration.GetKey(x => x.Replication.MaxItemsCount)] = "1"
+            }))
+            using (var destination = GetDocumentStore())
+            {
+                const string documentId1 = "users/1-A";
+                const string documentId2 = "users/2-A";
+                const string attachmentName1 = "foo1.png";
+                const string attachmentName2 = "foo2.png";
+                const string contentType = "image/png";
+
+                using (var session = source.OpenAsyncSession())
+                using (var stream1 = new MemoryStream(new byte[] { 1, 2, 3 }))
+                using (var stream2 = new MemoryStream(new byte[] { 1, 2, 3 }))
+                {
+                    await session.StoreAsync(new User { Name = "Foo" }, documentId1);
+                    session.Advanced.Attachments.Store(documentId1, attachmentName1, stream1, contentType);
+                    session.Advanced.Attachments.Store(documentId1, attachmentName2, stream2, contentType);
+                    await session.SaveChangesAsync();
+                }
+
+                using (var session = source.OpenAsyncSession())
+                using (var stream1 = new MemoryStream(new byte[] { 1, 2, 3 }))
+                using (var stream2 = new MemoryStream(new byte[] { 1, 2, 3 }))
+                {
+                    await session.StoreAsync(new User { Name = "Foo" }, documentId2);
+                    session.Advanced.Attachments.Store(documentId2, attachmentName1, stream1, contentType);
+                    session.Advanced.Attachments.Store(documentId2, attachmentName2, stream2, contentType);
+                    await session.SaveChangesAsync();
+                }
+
+                var documentDatabase = (await GetDocumentDatabaseInstanceFor(source));
+                var documentsStorage = documentDatabase.DocumentsStorage;
+
+                using (documentsStorage.ContextPool.AllocateOperationContext(out DocumentsOperationContext context))
+                using (var tx = context.OpenWriteTransaction())
+                {
+                    var attachmentStorage = documentsStorage.AttachmentsStorage;
+
+                    ModifyAttachment(attachmentStorage, context, documentId1, attachmentName1, contentType);
+                    ModifyAttachment(attachmentStorage, context, documentId1, attachmentName2, contentType);
+
+                    tx.Commit();
+                }
+
+                using (documentsStorage.ContextPool.AllocateOperationContext(out DocumentsOperationContext context))
+                using (var tx = context.OpenWriteTransaction())
+                {
+                    var attachmentStorage = documentsStorage.AttachmentsStorage;
+
+                    ModifyAttachment(attachmentStorage, context, documentId2, attachmentName1, contentType);
+                    ModifyAttachment(attachmentStorage, context, documentId2, attachmentName2, contentType);
+
+                    tx.Commit();
+                }
+
+                await SetupReplicationAsync(source, destination);
+
+                Assert.NotNull(WaitForDocumentWithAttachmentToReplicate<User>(destination, documentId1, attachmentName1, 15 * 1000));
+                Assert.NotNull(WaitForDocumentWithAttachmentToReplicate<User>(destination, documentId1, attachmentName2, 15 * 1000));
+                Assert.NotNull(WaitForDocumentWithAttachmentToReplicate<User>(destination, documentId2, attachmentName1, 15 * 1000));
+                Assert.NotNull(WaitForDocumentWithAttachmentToReplicate<User>(destination, documentId2, attachmentName2, 15 * 1000));
+            }
+
+            static void ModifyAttachment(AttachmentsStorage attachmentStorage, DocumentsOperationContext context, string documentId, string attachmentName, string contentType)
+            {
+                var attachment = attachmentStorage.GetAttachment(context, documentId, attachmentName, AttachmentType.Document, null);
+
+                using (var stream = new MemoryStream(new byte[] { 1, 2, 3 }))
+                {
+                    attachmentStorage.PutAttachment(context, documentId, attachmentName, contentType, attachment.Base64Hash.ToString(), null, stream, updateDocument: false);
+                }
+            }
+        }
+    }
+}


### PR DESCRIPTION
- fixed NRE in BlittableJsonReaderObject.AssertNoModifications when data is null
- stripping DeleteRevision flag to avoid NRE in IncomingReplicationHandler
- fixed possible endless replication loop when we do have missing attachments but max batch size is limiting the batch