### PR TITLE
RavenDB-16078 Fixing another case where projecting the same document …

### DIFF
--- a/src/Raven.Server/Documents/Queries/Results/QueryResultRetrieverBase.cs
+++ b/src/Raven.Server/Documents/Queries/Results/QueryResultRetrieverBase.cs
@@ -611,6 +611,9 @@ namespace Raven.Server.Documents.Queries.Results
             //_loadedDocuments.Clear(); - explicitly not clearing this, we want to cache this for the duration of the query
 
             _loadedDocuments[document.Id ?? string.Empty] = document;
+
+            document.IgnoreDispose = true; // so we can do multiple projections of the same value
+
             if (fieldToFetch.QueryField.SourceAlias != null)
             {
                 if (fieldToFetch.QueryField.IsQuoted)
@@ -681,7 +684,7 @@ namespace Raven.Server.Documents.Queries.Results
                     {
                         _loadedDocuments[docId] = doc = LoadDocument(docId);
                         if (doc != null)
-                            doc.IgnoreDispose = true;
+                            doc.IgnoreDispose = true; // so we can do multiple projections of the same value
                     }
                 }
                 if (doc == null)

--- a/test/SlowTests/Issues/RavenDB-16078.cs
+++ b/test/SlowTests/Issues/RavenDB-16078.cs
@@ -12,6 +12,7 @@ namespace SlowTests.Issues
 
         private class Item
         {
+            public string Id { get; set; }
             public int Order;
             public string Ref;
         }
@@ -44,6 +45,43 @@ namespace SlowTests.Issues
                     {
                         // no match for "items/4", returns default value
                         Assert.Equal(0, it.Current.Document.Order);
+                    }
+                }
+                Assert.Equal(3, count);
+            }
+        }
+
+        [Fact]
+        public void CanStreamMultipleProjectionsOfSameValue_AnotherNRE()
+        {
+            using var store = GetDocumentStore();
+            using (var s = store.OpenSession())
+            {
+                s.Store(new Item { Id = "items/1",  Order = 1, Ref = "items/3" });
+                s.Store(new Item { Id = "items/2", Order = 2, Ref = "items/1" });
+                s.Store(new Item { Id = "items/3", Order = 3, Ref = "items/1" });
+                s.SaveChanges();
+            }
+
+            using (var s = store.OpenSession())
+            {
+                var q = s.Advanced.RawQuery<Item>("from Items as i load i.Ref as r select r");
+                using var it = s.Advanced.Stream(q);
+                var count = 0;
+                while (it.MoveNext())
+                {
+                    count++;
+                    if (it.Current.Document.Id == "items/1")
+                    {
+                        Assert.Equal(1, it.Current.Document.Order);
+                    }
+                    else if (it.Current.Document.Id == "items/2")
+                    {
+                        Assert.Equal(2, it.Current.Document.Order);
+                    }
+                    else
+                    {
+                        Assert.Equal(3, it.Current.Document.Order);
                     }
                 }
                 Assert.Equal(3, count);


### PR DESCRIPTION
…multiple times in the same query caused NRE during streaming. We disposed a loaded document immediately after writing it to the stream query response while there was another entry which also make use of this document.

https://issues.hibernatingrhinos.com/issue/RavenDB-16078

For reference - https://github.com/ravendb/ravendb/pull/11636