### PR TITLE
RavenDB-16736 Fixing memory leak when running distinc query by disposing results that are skipped

### DIFF
--- a/src/Raven.Server/Documents/Indexes/Persistence/Lucene/IndexReadOperation.cs
+++ b/src/Raven.Server/Documents/Indexes/Persistence/Lucene/IndexReadOperation.cs
@@ -156,6 +156,8 @@ namespace Raven.Server.Documents.Indexes.Persistence.Lucene
                         var result = retriever.Get(document, scoreDoc, _state);
                         if (scope.TryIncludeInResults(result) == false)
                         {
+                            result.Dispose();
+
                             skippedResults.Value++;
                             continue;
                         }
@@ -402,6 +404,8 @@ namespace Raven.Server.Documents.Indexes.Persistence.Lucene
                     var result = retriever.Get(document, new ScoreDoc(indexResult.LuceneId,indexResult.Score), _state);
                     if (scope.TryIncludeInResults(result) == false)
                     {
+                        result.Dispose();
+
                         skippedResults.Value++;
                         skippedResultsInCurrentLoop++;
                         continue;


### PR DESCRIPTION
https://issues.hibernatingrhinos.com/issue/RavenDB-16736