### PR TITLE
RavenDB-16614 Atomic read write in cluster wide transaction without c…

### DIFF
--- a/src/Raven.Client/Documents/Commands/Batches/BatchCommand.cs
+++ b/src/Raven.Client/Documents/Commands/Batches/BatchCommand.cs
@@ -18,7 +18,8 @@ namespace Raven.Client.Documents.Commands.Batches
         public bool? DisableAtomicDocumentWrites { get; }
         public string RaftUniqueRequestId { get; } = RaftIdGenerator.NewId();
 
-        public ClusterWideBatchCommand(DocumentConventions conventions, IList<ICommandData> commands, BatchOptions options = null, bool? disableAtomicDocumentsWrites = null) : base(conventions, commands, options, TransactionMode.ClusterWide)
+        public ClusterWideBatchCommand(DocumentConventions conventions, IList<ICommandData> commands, BatchOptions options = null, bool? disableAtomicDocumentsWrites = null) : 
+            base(conventions, context: null, commands, options, TransactionMode.ClusterWide)
         {
             DisableAtomicDocumentWrites = disableAtomicDocumentsWrites;
         }
@@ -39,13 +40,12 @@ namespace Raven.Client.Documents.Commands.Batches
         private bool? _supportsAtomicWrites;
         private readonly List<Stream> _attachmentStreams;
         private readonly HashSet<Stream> _uniqueAttachmentStreams;
-        private readonly JsonOperationContext _context;
         private readonly DocumentConventions _conventions;
         private readonly IList<ICommandData> _commands;
         private readonly BatchOptions _options;
         private readonly TransactionMode _mode;
 
-        public SingleNodeBatchCommand(DocumentConventions conventions,  IList<ICommandData> commands, BatchOptions options = null, TransactionMode mode = TransactionMode.SingleNode)
+        public SingleNodeBatchCommand(DocumentConventions conventions, JsonOperationContext context, IList<ICommandData> commands, BatchOptions options = null, TransactionMode mode = TransactionMode.SingleNode)
         {
             _conventions = conventions ?? throw new ArgumentNullException(nameof(conventions));
             _commands = commands ?? throw new ArgumentNullException(nameof(commands));

--- a/src/Raven.Client/Documents/Commands/Batches/BatchCommand.cs
+++ b/src/Raven.Client/Documents/Commands/Batches/BatchCommand.cs
@@ -15,10 +15,21 @@ namespace Raven.Client.Documents.Commands.Batches
 {
     internal class ClusterWideBatchCommand : SingleNodeBatchCommand, IRaftCommand
     {
+        public bool? DisableAtomicDocumentWrites { get; }
         public string RaftUniqueRequestId { get; } = RaftIdGenerator.NewId();
 
-        public ClusterWideBatchCommand(DocumentConventions conventions, JsonOperationContext context, IList<ICommandData> commands, BatchOptions options = null) : base(conventions, context, commands, options, TransactionMode.ClusterWide)
+        public ClusterWideBatchCommand(DocumentConventions conventions, JsonOperationContext context, IList<ICommandData> commands, BatchOptions options = null, bool? disableAtomicDocumentsWrites = null) : base(conventions, context, commands, options, TransactionMode.ClusterWide)
         {
+            DisableAtomicDocumentWrites = disableAtomicDocumentsWrites;
+        }
+
+        protected override void AppendOptions(StringBuilder sb)
+        {
+            base.AppendOptions(sb);
+            if (DisableAtomicDocumentWrites == null)
+                return;
+            sb.Append("&disableAtomicDocumentWrites=")
+                .Append(DisableAtomicDocumentWrites.Value ? "true" : "false");
         }
     }
 
@@ -103,7 +114,7 @@ namespace Raven.Client.Documents.Commands.Batches
                 request.Content = multipartContent;
             }
 
-            var sb = new StringBuilder($"{node.Url}/databases/{node.Database}/bulk_docs");
+            var sb = new StringBuilder($"{node.Url}/databases/{node.Database}/bulk_docs?");
 
             AppendOptions(sb);
 
@@ -126,12 +137,10 @@ namespace Raven.Client.Documents.Commands.Batches
             Result = JsonDeserializationClient.BatchCommandResult(response);
         }
 
-        private void AppendOptions(StringBuilder sb)
+        protected virtual void AppendOptions(StringBuilder sb)
         {
             if (_options == null)
                 return;
-
-            sb.Append("?");
 
             var replicationOptions = _options.ReplicationOptions;
             if (replicationOptions != null)

--- a/src/Raven.Client/Documents/Commands/Batches/BatchCommand.cs
+++ b/src/Raven.Client/Documents/Commands/Batches/BatchCommand.cs
@@ -18,7 +18,7 @@ namespace Raven.Client.Documents.Commands.Batches
         public bool? DisableAtomicDocumentWrites { get; }
         public string RaftUniqueRequestId { get; } = RaftIdGenerator.NewId();
 
-        public ClusterWideBatchCommand(DocumentConventions conventions, JsonOperationContext context, IList<ICommandData> commands, BatchOptions options = null, bool? disableAtomicDocumentsWrites = null) : base(conventions, context, commands, options, TransactionMode.ClusterWide)
+        public ClusterWideBatchCommand(DocumentConventions conventions, IList<ICommandData> commands, BatchOptions options = null, bool? disableAtomicDocumentsWrites = null) : base(conventions, commands, options, TransactionMode.ClusterWide)
         {
             DisableAtomicDocumentWrites = disableAtomicDocumentsWrites;
         }
@@ -55,20 +55,20 @@ namespace Raven.Client.Documents.Commands.Batches
             _commandsAsJson = new BlittableJsonReaderObject[_commands.Count];
             foreach (var command in commands)
             {
-                if (command is PutAttachmentCommandData putAttachmentCommandData == false) 
-                    continue;
-                
-                if (_attachmentStreams == null)
+                if (command is PutAttachmentCommandData putAttachmentCommandData)
                 {
-                    _attachmentStreams = new List<Stream>();
-                    _uniqueAttachmentStreams = new HashSet<Stream>();
-                }
+                    if (_attachmentStreams == null)
+                    {
+                        _attachmentStreams = new List<Stream>();
+                        _uniqueAttachmentStreams = new HashSet<Stream>();
+                    }
 
-                var stream = putAttachmentCommandData.Stream;
-                PutAttachmentCommandHelper.ValidateStream(stream);
-                if (_uniqueAttachmentStreams.Add(stream) == false)
-                    PutAttachmentCommandHelper.ThrowStreamWasAlreadyUsed();
-                _attachmentStreams.Add(stream);
+                    var stream = putAttachmentCommandData.Stream;
+                    PutAttachmentCommandHelper.ValidateStream(stream);
+                    if (_uniqueAttachmentStreams.Add(stream) == false)
+                        PutAttachmentCommandHelper.ThrowStreamWasAlreadyUsed();
+                    _attachmentStreams.Add(stream);
+                }
             }
             
             Timeout = options?.RequestTimeout;

--- a/src/Raven.Client/Documents/Commands/Batches/DeleteCommandData.cs
+++ b/src/Raven.Client/Documents/Commands/Batches/DeleteCommandData.cs
@@ -13,18 +13,19 @@ namespace Raven.Client.Documents.Commands.Batches
         {
             
         }
-        public DeleteCommandData(string id, string changeVector, string oldChangeVector)
+        public DeleteCommandData(string id, string changeVector, string originalChangeVector)
         {
             Id = id ?? throw new ArgumentNullException(nameof(id));
             ChangeVector = changeVector;
-            OldChangeVector = oldChangeVector;
+            OriginalChangeVector = originalChangeVector;
         }
 
-        public string OldChangeVector { get; }
+        public string OriginalChangeVector { get; }
         public string Id { get; }
         public string Name { get; } = null;
         public string ChangeVector { get; }
         public CommandType Type { get; } = CommandType.DELETE;
+        public BlittableJsonReaderObject Document { get; set; }
 
         public virtual DynamicJsonValue ToJson(DocumentConventions conventions, JsonOperationContext context)
         {
@@ -33,10 +34,11 @@ namespace Raven.Client.Documents.Commands.Batches
                 [nameof(Id)] = Id,
                 [nameof(ChangeVector)] = ChangeVector,
                 [nameof(Type)] = Type.ToString(),
+                [nameof(Document)] = Document
             };
-            if (OldChangeVector != null)
+            if (OriginalChangeVector != null)
             {
-                json[nameof(OldChangeVector)] = OldChangeVector;
+                json[nameof(OriginalChangeVector)] = OriginalChangeVector;
             }
             return json;
         }

--- a/src/Raven.Client/Documents/Commands/Batches/DeleteCommandData.cs
+++ b/src/Raven.Client/Documents/Commands/Batches/DeleteCommandData.cs
@@ -9,24 +9,38 @@ namespace Raven.Client.Documents.Commands.Batches
     public class DeleteCommandData : ICommandData
     {
         public DeleteCommandData(string id, string changeVector)
+            :this(id, changeVector, changeVector)
+        {
+            
+        }
+        public DeleteCommandData(string id, string changeVector, string oldChangeVector)
         {
             Id = id ?? throw new ArgumentNullException(nameof(id));
             ChangeVector = changeVector;
+            OldChangeVector = oldChangeVector;
         }
 
+        public string OldChangeVector { get; }
         public string Id { get; }
         public string Name { get; } = null;
         public string ChangeVector { get; }
         public CommandType Type { get; } = CommandType.DELETE;
+        public BlittableJsonReaderObject Document { get; set; }
 
         public virtual DynamicJsonValue ToJson(DocumentConventions conventions, JsonOperationContext context)
         {
-            return new DynamicJsonValue
+            var json = new DynamicJsonValue
             {
                 [nameof(Id)] = Id,
                 [nameof(ChangeVector)] = ChangeVector,
-                [nameof(Type)] = Type.ToString()
+                [nameof(Type)] = Type.ToString(),
+                [nameof(Document)] = Document
             };
+            if (OldChangeVector != null)
+            {
+                json[nameof(OldChangeVector)] = OldChangeVector;
+            }
+            return json;
         }
 
         public void OnBeforeSaveChanges(InMemoryDocumentSessionOperations session)

--- a/src/Raven.Client/Documents/Commands/Batches/DeleteCommandData.cs
+++ b/src/Raven.Client/Documents/Commands/Batches/DeleteCommandData.cs
@@ -25,7 +25,6 @@ namespace Raven.Client.Documents.Commands.Batches
         public string Name { get; } = null;
         public string ChangeVector { get; }
         public CommandType Type { get; } = CommandType.DELETE;
-        public BlittableJsonReaderObject Document { get; set; }
 
         public virtual DynamicJsonValue ToJson(DocumentConventions conventions, JsonOperationContext context)
         {
@@ -34,7 +33,6 @@ namespace Raven.Client.Documents.Commands.Batches
                 [nameof(Id)] = Id,
                 [nameof(ChangeVector)] = ChangeVector,
                 [nameof(Type)] = Type.ToString(),
-                [nameof(Document)] = Document
             };
             if (OldChangeVector != null)
             {

--- a/src/Raven.Client/Documents/Commands/Batches/DeletePrefixedCommandData.cs
+++ b/src/Raven.Client/Documents/Commands/Batches/DeletePrefixedCommandData.cs
@@ -6,7 +6,7 @@ namespace Raven.Client.Documents.Commands.Batches
 {
     public class DeletePrefixedCommandData : DeleteCommandData
     {
-        public DeletePrefixedCommandData(string prefix) : base(prefix, null)
+        public DeletePrefixedCommandData(string prefix) : base(prefix, null, null)
         {
         }
         

--- a/src/Raven.Client/Documents/Commands/Batches/DeletePrefixedCommandData.cs
+++ b/src/Raven.Client/Documents/Commands/Batches/DeletePrefixedCommandData.cs
@@ -6,7 +6,7 @@ namespace Raven.Client.Documents.Commands.Batches
 {
     public class DeletePrefixedCommandData : DeleteCommandData
     {
-        public DeletePrefixedCommandData(string prefix) : base(prefix, null, null)
+        public DeletePrefixedCommandData(string prefix) : base(prefix, null)
         {
         }
         

--- a/src/Raven.Client/Documents/Commands/Batches/PutCommandDataBase.cs
+++ b/src/Raven.Client/Documents/Commands/Batches/PutCommandDataBase.cs
@@ -8,13 +8,13 @@ namespace Raven.Client.Documents.Commands.Batches
 {
     internal class PutCommandDataWithBlittableJson : PutCommandDataBase<BlittableJsonReaderObject>
     {
-        public PutCommandDataWithBlittableJson(string id, string changeVector, string oldChangeVector, BlittableJsonReaderObject document)
-            : base(id, changeVector, oldChangeVector, document)
+        public PutCommandDataWithBlittableJson(string id, string changeVector, string originalChangeVector, BlittableJsonReaderObject document)
+            : base(id, changeVector, originalChangeVector, document)
         {
         }
         
-        public PutCommandDataWithBlittableJson(string id, string changeVector, string oldChangeVector, BlittableJsonReaderObject document, ForceRevisionStrategy strategy)
-            : base(id, changeVector, oldChangeVector, document, strategy)
+        public PutCommandDataWithBlittableJson(string id, string changeVector, string originalChangeVector, BlittableJsonReaderObject document, ForceRevisionStrategy strategy)
+            : base(id, changeVector, originalChangeVector, document, strategy)
         {
         }
 
@@ -30,8 +30,8 @@ namespace Raven.Client.Documents.Commands.Batches
         {
             
         }
-        public PutCommandData(string id, string changeVector, string oldChangeVector, DynamicJsonValue document)
-            : base(id, changeVector, oldChangeVector, document)
+        public PutCommandData(string id, string changeVector, string originalChangeVector, DynamicJsonValue document)
+            : base(id, changeVector, originalChangeVector, document)
         {
         }
 
@@ -40,8 +40,8 @@ namespace Raven.Client.Documents.Commands.Batches
         {
         }
         
-        public PutCommandData(string id, string changeVector, string oldChangeVector, DynamicJsonValue document, ForceRevisionStrategy strategy)
-            : base(id, changeVector, oldChangeVector, document, strategy)
+        public PutCommandData(string id, string changeVector, string originalChangeVector, DynamicJsonValue document, ForceRevisionStrategy strategy)
+            : base(id, changeVector, originalChangeVector, document, strategy)
         {
         }
 
@@ -52,14 +52,14 @@ namespace Raven.Client.Documents.Commands.Batches
 
     public abstract class PutCommandDataBase<T> : ICommandData
     {
-        protected PutCommandDataBase(string id, string changeVector, string oldChangeVector, T document, ForceRevisionStrategy strategy = ForceRevisionStrategy.None)
+        protected PutCommandDataBase(string id, string changeVector, string originalChangeVector, T document, ForceRevisionStrategy strategy = ForceRevisionStrategy.None)
         {
             if (document == null)
                 throw new ArgumentNullException(nameof(document));
 
             Id = id;
             ChangeVector = changeVector;
-            OldChangeVector = oldChangeVector;
+            OriginalChangeVector = originalChangeVector;
             Document = document;
             ForceRevisionCreationStrategy = strategy;
         }
@@ -68,7 +68,7 @@ namespace Raven.Client.Documents.Commands.Batches
         public string Name { get; } = null;
         public string ChangeVector { get; }
         
-        public string OldChangeVector { get; }
+        public string OriginalChangeVector { get; }
         public T Document { get; }
         public CommandType Type { get; } = CommandType.PUT;
         public ForceRevisionStrategy ForceRevisionCreationStrategy { get; }
@@ -82,9 +82,9 @@ namespace Raven.Client.Documents.Commands.Batches
                 [nameof(Document)] = Document,
                 [nameof(Type)] = Type.ToString()
             };
-            if (OldChangeVector != null)
+            if (OriginalChangeVector != null)
             {
-                json[nameof(OldChangeVector)] = OldChangeVector;
+                json[nameof(OriginalChangeVector)] = OriginalChangeVector;
             }
             
             if (ForceRevisionCreationStrategy != ForceRevisionStrategy.None)

--- a/src/Raven.Client/Documents/Commands/Batches/PutCommandDataBase.cs
+++ b/src/Raven.Client/Documents/Commands/Batches/PutCommandDataBase.cs
@@ -8,13 +8,13 @@ namespace Raven.Client.Documents.Commands.Batches
 {
     internal class PutCommandDataWithBlittableJson : PutCommandDataBase<BlittableJsonReaderObject>
     {
-        public PutCommandDataWithBlittableJson(string id, string changeVector, BlittableJsonReaderObject document)
-            : base(id, changeVector, document)
+        public PutCommandDataWithBlittableJson(string id, string changeVector, string oldChangeVector, BlittableJsonReaderObject document)
+            : base(id, changeVector, oldChangeVector, document)
         {
         }
         
-        public PutCommandDataWithBlittableJson(string id, string changeVector, BlittableJsonReaderObject document, ForceRevisionStrategy strategy)
-            : base(id, changeVector, document, strategy)
+        public PutCommandDataWithBlittableJson(string id, string changeVector, string oldChangeVector, BlittableJsonReaderObject document, ForceRevisionStrategy strategy)
+            : base(id, changeVector, oldChangeVector, document, strategy)
         {
         }
 
@@ -25,13 +25,23 @@ namespace Raven.Client.Documents.Commands.Batches
 
     public class PutCommandData : PutCommandDataBase<DynamicJsonValue>
     {
-        public PutCommandData(string id, string changeVector, DynamicJsonValue document)
-            : base(id, changeVector, document)
+        public PutCommandData(string id, string changeVector,  DynamicJsonValue document)
+            :base(id, changeVector, changeVector, document)
+        {
+            
+        }
+        public PutCommandData(string id, string changeVector, string oldChangeVector, DynamicJsonValue document)
+            : base(id, changeVector, oldChangeVector, document)
+        {
+        }
+
+        public PutCommandData(string id, string changeVector, DynamicJsonValue document, ForceRevisionStrategy strategy)
+            :this(id, changeVector, changeVector, document, strategy)
         {
         }
         
-        public PutCommandData(string id, string changeVector, DynamicJsonValue document, ForceRevisionStrategy strategy)
-            : base(id, changeVector, document, strategy)
+        public PutCommandData(string id, string changeVector, string oldChangeVector, DynamicJsonValue document, ForceRevisionStrategy strategy)
+            : base(id, changeVector, oldChangeVector, document, strategy)
         {
         }
 
@@ -42,13 +52,14 @@ namespace Raven.Client.Documents.Commands.Batches
 
     public abstract class PutCommandDataBase<T> : ICommandData
     {
-        protected PutCommandDataBase(string id, string changeVector, T document, ForceRevisionStrategy strategy = ForceRevisionStrategy.None)
+        protected PutCommandDataBase(string id, string changeVector, string oldChangeVector, T document, ForceRevisionStrategy strategy = ForceRevisionStrategy.None)
         {
             if (document == null)
                 throw new ArgumentNullException(nameof(document));
 
             Id = id;
             ChangeVector = changeVector;
+            OldChangeVector = oldChangeVector;
             Document = document;
             ForceRevisionCreationStrategy = strategy;
         }
@@ -56,6 +67,8 @@ namespace Raven.Client.Documents.Commands.Batches
         public string Id { get; }
         public string Name { get; } = null;
         public string ChangeVector { get; }
+        
+        public string OldChangeVector { get; }
         public T Document { get; }
         public CommandType Type { get; } = CommandType.PUT;
         public ForceRevisionStrategy ForceRevisionCreationStrategy { get; }
@@ -69,6 +82,10 @@ namespace Raven.Client.Documents.Commands.Batches
                 [nameof(Document)] = Document,
                 [nameof(Type)] = Type.ToString()
             };
+            if (OldChangeVector != null)
+            {
+                json[nameof(OldChangeVector)] = OldChangeVector;
+            }
             
             if (ForceRevisionCreationStrategy != ForceRevisionStrategy.None)
             {

--- a/src/Raven.Client/Documents/Conventions/DocumentConventions.cs
+++ b/src/Raven.Client/Documents/Conventions/DocumentConventions.cs
@@ -1126,8 +1126,8 @@ namespace Raven.Client.Documents.Conventions
         internal bool AnyQueryMethodConverters => _listOfQueryMethodConverters.Count > 0;
 
         /// <summary>
-        /// EXPERT: When the TransactionMode is 'ClusterWide', will disable atomic document writes and validate only compare exchange
-        /// values that are manually added to the user.
+        /// EXPERT: Disable automatic atomic writes with cluster write transactions. If set to 'true', will only consider explicitly
+        /// added compare exchange values to validate cluster wide transactions."
         /// </summary>
         public bool? DisableAtomicDocumentWritesInClusterWideTransaction
         {

--- a/src/Raven.Client/Documents/Conventions/DocumentConventions.cs
+++ b/src/Raven.Client/Documents/Conventions/DocumentConventions.cs
@@ -261,6 +261,7 @@ namespace Raven.Client.Documents.Conventions
         private bool _sendApplicationIdentifier;
         private Size _maxContextSizeToKeep;
         private ISerializationConventions _serialization;
+        private bool? _disableAtomicDocumentWritesInClusterWideTransaction;
 
         public Func<InMemoryDocumentSessionOperations, object, string, bool> ShouldIgnoreEntityChanges
         {
@@ -1123,6 +1124,20 @@ namespace Raven.Client.Documents.Conventions
         }
 
         internal bool AnyQueryMethodConverters => _listOfQueryMethodConverters.Count > 0;
+
+        /// <summary>
+        /// EXPERT: When the TransactionMode is 'ClusterWide', will disable atomic document writes and validate only compare exchange
+        /// values that are manually added to the user.
+        /// </summary>
+        public bool? DisableAtomicDocumentWritesInClusterWideTransaction
+        {
+            get => _disableAtomicDocumentWritesInClusterWideTransaction;
+            set
+            {
+                AssertNotFrozen();
+                _disableAtomicDocumentWritesInClusterWideTransaction = value;
+            }
+        }
 
         internal bool TryConvertQueryMethod<T>(QueryMethodConverter.Parameters<T> parameters)
         {

--- a/src/Raven.Client/Documents/DocumentStore.cs
+++ b/src/Raven.Client/Documents/DocumentStore.cs
@@ -124,7 +124,10 @@ namespace Raven.Client.Documents
         /// <returns></returns>
         public override IDocumentSession OpenSession()
         {
-            return OpenSession(new SessionOptions());
+            return OpenSession(new SessionOptions
+            {
+                DisableAtomicDocumentWritesInClusterWideTransaction = Conventions.DisableAtomicDocumentWritesInClusterWideTransaction
+            });
         }
 
         /// <summary>
@@ -134,7 +137,8 @@ namespace Raven.Client.Documents
         {
             return OpenSession(new SessionOptions
             {
-                Database = database
+                Database = database,
+                DisableAtomicDocumentWritesInClusterWideTransaction = Conventions.DisableAtomicDocumentWritesInClusterWideTransaction
             });
         }
 

--- a/src/Raven.Client/Documents/Session/InMemoryDocumentSessionOperations.cs
+++ b/src/Raven.Client/Documents/Session/InMemoryDocumentSessionOperations.cs
@@ -1021,11 +1021,6 @@ more responsive application.
                         }
 
                         var deleteCommandData = new DeleteCommandData(documentInfo.Id, changeVector, documentInfo.ChangeVector);
-                        if (TransactionMode == TransactionMode.ClusterWide)
-                        {
-                            // we need this to send the cluster transaction index to the cluster state machine
-                            deleteCommandData.Document = documentInfo.Metadata;
-                        }
                         result.SessionCommands.Add(deleteCommandData);
                     }
                 }

--- a/src/Raven.Client/Documents/Session/Operations/BatchOperation.cs
+++ b/src/Raven.Client/Documents/Session/Operations/BatchOperation.cs
@@ -54,7 +54,7 @@ namespace Raven.Client.Documents.Session.Operations
                     _session.DisableAtomicDocumentWritesInClusterWideTransaction);
             }
 
-            return new SingleNodeBatchCommand(_session.Conventions, result.SessionCommands, result.Options);
+            return new SingleNodeBatchCommand(_session.Conventions, _session.Context, result.SessionCommands, result.Options);
         }
 
         public void SetResult(BatchCommandResult result)

--- a/src/Raven.Client/Documents/Session/Operations/BatchOperation.cs
+++ b/src/Raven.Client/Documents/Session/Operations/BatchOperation.cs
@@ -48,7 +48,11 @@ namespace Raven.Client.Documents.Session.Operations
             _entities = result.Entities;
 
             if (_session.TransactionMode == TransactionMode.ClusterWide)
-                return new ClusterWideBatchCommand(_session.Conventions, _session.Context, result.SessionCommands, result.Options);
+            {
+                return new ClusterWideBatchCommand(_session.Conventions, _session.Context, 
+                    result.SessionCommands, result.Options, 
+                    _session.DisableAtomicDocumentWritesInClusterWideTransaction);
+            }
 
             return new SingleNodeBatchCommand(_session.Conventions, _session.Context, result.SessionCommands, result.Options);
         }

--- a/src/Raven.Client/Documents/Session/Operations/BatchOperation.cs
+++ b/src/Raven.Client/Documents/Session/Operations/BatchOperation.cs
@@ -49,12 +49,12 @@ namespace Raven.Client.Documents.Session.Operations
 
             if (_session.TransactionMode == TransactionMode.ClusterWide)
             {
-                return new ClusterWideBatchCommand(_session.Conventions, _session.Context, 
+                return new ClusterWideBatchCommand(_session.Conventions, 
                     result.SessionCommands, result.Options, 
                     _session.DisableAtomicDocumentWritesInClusterWideTransaction);
             }
 
-            return new SingleNodeBatchCommand(_session.Conventions, _session.Context, result.SessionCommands, result.Options);
+            return new SingleNodeBatchCommand(_session.Conventions, result.SessionCommands, result.Options);
         }
 
         public void SetResult(BatchCommandResult result)

--- a/src/Raven.Client/Documents/Session/SessionOptions.cs
+++ b/src/Raven.Client/Documents/Session/SessionOptions.cs
@@ -25,8 +25,8 @@ namespace Raven.Client.Documents.Session
         public TransactionMode TransactionMode { get; set; }
 
         /// <summary>
-        /// EXPERT: When the TransactionMode is 'ClusterWide', will disable atomic document writes and validate only compare exchange
-        /// values that are manually added to the user.
+        ///EXPERT: Disable automatic atomic writes with cluster write transactions. If set to 'true',
+        /// will only consider explicitly added compare exchange values to validate cluster wide transactions."
         /// </summary>
         public bool? DisableAtomicDocumentWritesInClusterWideTransaction { get; set; }
     }

--- a/src/Raven.Client/Documents/Session/SessionOptions.cs
+++ b/src/Raven.Client/Documents/Session/SessionOptions.cs
@@ -5,7 +5,7 @@ namespace Raven.Client.Documents.Session
     public enum TransactionMode
     {
         SingleNode,
-        ClusterWide
+        ClusterWide,
     }
 
     public class SessionOptions
@@ -23,5 +23,11 @@ namespace Raven.Client.Documents.Session
         /// Any document store or delete will be part of this session's cluster transaction.
         /// </summary>
         public TransactionMode TransactionMode { get; set; }
+
+        /// <summary>
+        /// EXPERT: When the TransactionMode is 'ClusterWide', will disable atomic document writes and validate only compare exchange
+        /// values that are manually added to the user.
+        /// </summary>
+        public bool? DisableAtomicDocumentWritesInClusterWideTransaction { get; set; }
     }
 }

--- a/src/Raven.Client/Http/ServerNode.cs
+++ b/src/Raven.Client/Http/ServerNode.cs
@@ -47,6 +47,8 @@ namespace Raven.Client.Http
         
         public string LastServerVersion { get; private set; }
         
+        internal bool SupportsAtomicClusterWrites { get; set; }
+        
         public bool ShouldUpdateServerVersion()
         {            
             if (LastServerVersion == null || _lastServerVersionCheck > 100)
@@ -59,7 +61,17 @@ namespace Raven.Client.Http
         public void UpdateServerVersion (string serverVersion)
         {
             LastServerVersion = serverVersion;
-            _lastServerVersionCheck = 0;            
+            _lastServerVersionCheck = 0;
+            if (serverVersion != null && Version.TryParse(serverVersion, out var ver))
+            {
+                // 5.2 or higher
+                SupportsAtomicClusterWrites = ver.Major == 5 && ver.Minor >= 2 || 
+                                              ver.Major > 5;
+            }
+            else
+            {
+                SupportsAtomicClusterWrites = false;
+            }
         }
 
         public void DiscardServerVersion()

--- a/src/Raven.Client/Json/Serialization/NewtonsoftJson/Internal/BlittableJsonWriter.cs
+++ b/src/Raven.Client/Json/Serialization/NewtonsoftJson/Internal/BlittableJsonWriter.cs
@@ -277,10 +277,13 @@ namespace Raven.Client.Json.Serialization.NewtonsoftJson.Internal
                     WriteDictionary(iDictionary);
                     break;
                 case DynamicJsonValue val:
+                    _manualBlittableJsonDocumentBuilder.StartWriteObject();
                     foreach (var prop in val.Properties)
                     {
+                        _manualBlittableJsonDocumentBuilder.WritePropertyName(prop.Name);
                         WritePropertyValue(prop.Name, prop.Value);
                     }
+                    _manualBlittableJsonDocumentBuilder.WriteObjectEnd();
                     break;
                 case IEnumerable enumerable:
                     _manualBlittableJsonDocumentBuilder.StartWriteArray();

--- a/src/Raven.Client/ServerWide/DatabaseTopology.cs
+++ b/src/Raven.Client/ServerWide/DatabaseTopology.cs
@@ -375,6 +375,7 @@ $"NodeTag of 'InternalReplication' can't be modified after 'GetHashCode' was inv
         }
 
         public string DatabaseTopologyIdBase64;
+        public string ClusterTransactionIdBase64;
 
         [JsonIgnore]
         public int Count => Members.Count + Promotables.Count + Rehabs.Count;
@@ -412,6 +413,7 @@ $"NodeTag of 'InternalReplication' can't be modified after 'GetHashCode' was inv
                 [nameof(DynamicNodesDistribution)] = DynamicNodesDistribution,
                 [nameof(ReplicationFactor)] = ReplicationFactor,
                 [nameof(DatabaseTopologyIdBase64)] = DatabaseTopologyIdBase64,
+                [nameof(ClusterTransactionIdBase64)] = ClusterTransactionIdBase64,
                 [nameof(PriorityOrder)] = PriorityOrder != null ? new DynamicJsonArray(PriorityOrder) : null
             };
         }

--- a/src/Raven.Server/Config/Categories/ClusterConfiguration.cs
+++ b/src/Raven.Server/Config/Categories/ClusterConfiguration.cs
@@ -117,5 +117,10 @@ namespace Raven.Server.Config.Categories
         [DefaultValue(10_000)]
         [ConfigurationEntry("Cluster.MaxChangeVectorDistance", ConfigurationEntryScope.ServerWideOnly)]
         public long MaxChangeVectorDistance { get; set; }
+        
+        [Description("EXPERT: Disable automatic atomic writes with cluster write transactions. If set to 'true', will only consider explicitly added compare exchange values to validate cluster wide transactions.")]
+        [DefaultValue(false)]
+        [ConfigurationEntry("Cluster.DisableAtomicDocumentWrites", ConfigurationEntryScope.ServerWideOrPerDatabase)]
+        public bool DisableAtomicDocumentWrites { get; set; }
     }
 }

--- a/src/Raven.Server/Config/RavenConfiguration.cs
+++ b/src/Raven.Server/Config/RavenConfiguration.cs
@@ -104,7 +104,7 @@ namespace Raven.Server.Config
         internal CommandLineConfigurationSource CommandLineSettings =>
             _configBuilder.Sources.OfType<CommandLineConfigurationSource>().FirstOrDefault();
 
-        private RavenConfiguration(string resourceName, ResourceType resourceType, string customConfigPath = null)
+        private RavenConfiguration(string resourceName, ResourceType resourceType, string customConfigPath = null, bool skipEnvironmentVariables = false)
         {
             _logger = LoggingSource.Instance.GetLogger<RavenConfiguration>(resourceName);
 
@@ -113,7 +113,8 @@ namespace Raven.Server.Config
             _customConfigPath = customConfigPath;
             PathSettingBase<string>.ValidatePath(_customConfigPath);
             _configBuilder = new ConfigurationBuilder();
-            AddEnvironmentVariables();
+            if(skipEnvironmentVariables == false)
+                AddEnvironmentVariables();
             AddJsonConfigurationVariables(customConfigPath);
 
             Settings = _configBuilder.Build();
@@ -373,7 +374,7 @@ namespace Raven.Server.Config
         /// </summary>
         internal static RavenConfiguration CreateForTesting(string name, ResourceType resourceType, string customConfigPath = null)
         {
-            return new RavenConfiguration(name, resourceType, customConfigPath);
+            return new RavenConfiguration(name, resourceType, customConfigPath, skipEnvironmentVariables: true);
         }
 
         private static string GenerateDefaultDataDirectory(string template, ResourceType type, string name)

--- a/src/Raven.Server/Documents/AttachmentsStorage.cs
+++ b/src/Raven.Server/Documents/AttachmentsStorage.cs
@@ -381,7 +381,7 @@ namespace Raven.Server.Documents
                 }
 
                 data = context.ReadObject(data, documentId, BlittableJsonDocumentBuilder.UsageMode.ToDisk);
-                return _documentsStorage.Put(context, documentId, null, data, null, null, flags, NonPersistentDocumentFlags.ByAttachmentUpdate).ChangeVector;
+                return _documentsStorage.Put(context, documentId, null, data, null, null, null, flags, NonPersistentDocumentFlags.ByAttachmentUpdate).ChangeVector;
             }
             finally
             {

--- a/src/Raven.Server/Documents/DatabasesLandlord.cs
+++ b/src/Raven.Server/Documents/DatabasesLandlord.cs
@@ -164,6 +164,7 @@ namespace Raven.Server.Documents
                         case ClusterDatabaseChangeType.PendingClusterTransactions:
                         case ClusterDatabaseChangeType.ClusterTransactionCompleted:
                             database.DatabaseGroupId = topology.DatabaseTopologyIdBase64;
+                            database.ClusterTransactionId = topology.ClusterTransactionIdBase64;
                             database.NotifyOnPendingClusterTransaction(index, changeType);
                             break;
 
@@ -820,7 +821,7 @@ namespace Raven.Server.Documents
             {
                 if (databaseRecord == null)
                     return null;
-
+                
                 var record = databaseRecord.MaterializedRecord;
                 if (record.Encrypted)
                 {

--- a/src/Raven.Server/Documents/DocumentDatabase.cs
+++ b/src/Raven.Server/Documents/DocumentDatabase.cs
@@ -89,6 +89,7 @@ namespace Raven.Server.Documents
         private long _preventUnloadCounter;
 
         public string DatabaseGroupId;
+        public string ClusterTransactionId;
 
         public readonly ClusterTransactionWaiter ClusterTransactionWaiter;
 
@@ -1185,6 +1186,7 @@ namespace Raven.Server.Documents
                     try
                     {
                         DatabaseGroupId = record.Topology.DatabaseTopologyIdBase64;
+                        ClusterTransactionId = record.Topology.ClusterTransactionIdBase64;
 
                         SetUnusedDatabaseIds(record);
                         InitializeFromDatabaseRecord(record);

--- a/src/Raven.Server/Documents/DocumentPutAction.cs
+++ b/src/Raven.Server/Documents/DocumentPutAction.cs
@@ -19,6 +19,8 @@ using Raven.Server.Documents.Replication;
 using Sparrow.Server;
 using static Raven.Server.Documents.DocumentsStorage;
 using Constants = Raven.Client.Constants;
+using Raven.Server.ServerWide;
+using Raven.Server.ServerWide.Commands;
 
 namespace Raven.Server.Documents
 {
@@ -54,11 +56,44 @@ namespace Raven.Server.Documents
             }
         }
 
+        private struct CompareClusterTransactionId
+        {
+            private readonly ServerStore _serverStore;
+            private readonly DocumentPutAction _parent;
+
+            public CompareClusterTransactionId(DocumentPutAction parent)
+            {
+                _serverStore = parent._documentDatabase.ServerStore;
+                _parent = parent;
+            }
+
+            public void ValidateAtomicGuard(string id, NonPersistentDocumentFlags nonPersistentDocumentFlags, string changeVector)
+            {
+                if (nonPersistentDocumentFlags != NonPersistentDocumentFlags.None) // replication or engine running an operation, we can skip checking it 
+                    return;
+
+                long indexFromOChangeVector = ChangeVectorUtils.GetEtagById(changeVector, _parent._documentDatabase.ClusterTransactionId);
+                if (indexFromOChangeVector == 0)
+                    return;
+                
+                using var _ = _serverStore.ContextPool.AllocateOperationContext(out TransactionOperationContext clusterContext);
+                clusterContext.OpenReadTransaction();
+                var guardId = CompareExchangeKey.GetStorageKey(_parent._documentDatabase.Name, ClusterTransactionCommand.GetAtomicGuardKey(id));
+                var (indexFromCluster, val) = _serverStore.Cluster.GetCompareExchangeValue(clusterContext, guardId);
+                if(indexFromOChangeVector != indexFromCluster)
+                {
+                    throw new ConcurrencyException($"Cannot PUT document '{id}' because its change vector's cluster transaction index is set to {indexFromOChangeVector} " +
+                                                   $"but the compare exchange guard ('{ClusterTransactionCommand.GetAtomicGuardKey(id)}') is set to {indexFromCluster}");
+                }
+            }
+        }
+
         public PutOperationResults PutDocument(DocumentsOperationContext context, string id,
             string expectedChangeVector,
             BlittableJsonReaderObject document,
             long? lastModifiedTicks = null,
             string changeVector = null,
+            string oldChangeVectorForClusterTransactionIndexCheck = null,
             DocumentFlags flags = DocumentFlags.None,
             NonPersistentDocumentFlags nonPersistentFlags = NonPersistentDocumentFlags.None)
         {
@@ -73,6 +108,12 @@ namespace Raven.Server.Documents
 
             var newEtag = _documentsStorage.GenerateNextEtag();
             var modifiedTicks = _documentsStorage.GetOrCreateLastModifiedTicks(lastModifiedTicks);
+            
+            var compareClusterTransaction = new CompareClusterTransactionId(this);
+            if (oldChangeVectorForClusterTransactionIndexCheck != null)
+            {
+                compareClusterTransaction.ValidateAtomicGuard(id, nonPersistentFlags, oldChangeVectorForClusterTransactionIndexCheck);
+            }
 
             id = BuildDocumentId(id, newEtag, out bool knownNewId);
             using (DocumentIdWorker.GetLowerIdSliceAndStorageKey(context, id, out Slice lowerId, out Slice idPtr))
@@ -105,11 +146,15 @@ namespace Raven.Server.Documents
                     // "" / empty - means, must be new
                     // anything else - must match exactly
 
+                    oldChangeVector = TableValueToChangeVector(context, (int)DocumentsTable.ChangeVector, ref oldValue);
                     if (expectedChangeVector != null) 
                     {
-                        oldChangeVector = TableValueToChangeVector(context, (int)DocumentsTable.ChangeVector, ref oldValue);
                         if (string.Compare(expectedChangeVector, oldChangeVector, StringComparison.Ordinal) != 0)
                             ThrowConcurrentException(id, expectedChangeVector, oldChangeVector);
+                    }
+                    if (oldChangeVectorForClusterTransactionIndexCheck == null)
+                    {
+                        compareClusterTransaction.ValidateAtomicGuard(id, nonPersistentFlags, oldChangeVector);
                     }
 
                     oldDoc = new BlittableJsonReaderObject(oldValue.Read((int)DocumentsTable.Data, out int oldSize), oldSize, context);
@@ -173,7 +218,6 @@ namespace Raven.Server.Documents
                     {
                         if (_documentDatabase.DocumentsStorage.RevisionsStorage.ShouldVersionOldDocument(context, flags, oldDoc, oldChangeVector, collectionName))
                         {
-                            oldChangeVector = TableValueToChangeVector(context, (int)DocumentsTable.ChangeVector, ref oldValue);
                             var oldFlags = TableValueToFlags((int)DocumentsTable.Flags, ref oldValue);
                             var oldTicks = TableValueToDateTime((int)DocumentsTable.LastModified, ref oldValue);
                             

--- a/src/Raven.Server/Documents/DocumentPutAction.cs
+++ b/src/Raven.Server/Documents/DocumentPutAction.cs
@@ -397,7 +397,7 @@ namespace Raven.Server.Documents
             }
 
             changeVector = SetDocumentChangeVectorForLocalChange(context, lowerId, oldChangeVector, newEtag);
-            context.SkipChangeVectorValidation = _documentsStorage.TryRemoveUnusedIds(ref changeVector);
+            context.SkipChangeVectorValidation = _documentsStorage.TryRemoveUnusedIds(ref changeVector, removeTrxn: true);
             return (changeVector, nonPersistentFlags);
         }
 

--- a/src/Raven.Server/Documents/DocumentsStorage.cs
+++ b/src/Raven.Server/Documents/DocumentsStorage.cs
@@ -453,12 +453,17 @@ namespace Raven.Server.Documents
             return true;
         }
 
-        public bool TryRemoveUnusedIds(ref string changeVector)
+        public bool TryRemoveUnusedIds(ref string changeVector, bool removeTrxn = false)
         {
             if (string.IsNullOrEmpty(changeVector))
                 return false;
 
             var list = UnusedDatabaseIds;
+            if (removeTrxn)
+            {
+                list ??= new HashSet<string>();
+                list.Add(DocumentDatabase.ClusterTransactionId);
+            }
             if (list == null || list.Count == 0)
                 return false;
 

--- a/src/Raven.Server/Documents/DocumentsStorage.cs
+++ b/src/Raven.Server/Documents/DocumentsStorage.cs
@@ -1941,25 +1941,51 @@ namespace Raven.Server.Documents
         public static void FlagsProperlySet(DocumentFlags flags, string changeVector)
         {
             var cvArray = changeVector.ToChangeVector();
-
+            var expectedValues = new int[] { ChangeVectorParser.RaftInt, ChangeVectorParser.TrxnInt };
             if (flags.Contain(DocumentFlags.FromClusterTransaction))
             {
-                if (cvArray.Length != 1)
+                switch (cvArray.Length)
                 {
-                    Debug.Assert(false, $"FromClusterTransaction, expect change vector of length 1, {changeVector}");
-                }
-                if (cvArray[0].NodeTag != ChangeVectorParser.RaftInt)
-                {
-                    Debug.Assert(false, $"FromClusterTransaction, expect only RAFT, {changeVector}");
+                    case 1:
+                        if (cvArray[0].NodeTag != ChangeVectorParser.RaftInt)
+                        {
+                            Debug.Assert(false, $"FromClusterTransaction, expect RAFT, {changeVector}");
+                        }
+                        break;
+                    case 2:
+                        if (expectedValues.Contains(cvArray[0].NodeTag) == false ||
+                            expectedValues.Contains(cvArray[1].NodeTag) == false ||
+                            cvArray[0].NodeTag == cvArray[1].NodeTag)
+                        {
+                            Debug.Assert(false, $"FromClusterTransaction, expect RAFT or TRXN, {changeVector}");
+                        }
+                        break;
+                    default:
+                       Debug.Assert(false, $"FromClusterTransaction, expect change vector of length 1 or 2, {changeVector}");
+                        break;
                 }
             }
 
-            if (cvArray.Length == 1 && cvArray[0].NodeTag == ChangeVectorParser.RaftInt)
+            switch (cvArray.Length)
             {
-                if (flags.Contain(DocumentFlags.FromClusterTransaction) == false)
-                {
-                    Debug.Assert(false, $"flags must set FromClusterTransaction for the change vector: {changeVector}");
-                }
+                case 1:
+                    if (cvArray[0].NodeTag == ChangeVectorParser.RaftInt)
+                    {
+                        if (flags.Contain(DocumentFlags.FromClusterTransaction) == false)
+                        {
+                            Debug.Assert(false, $"flags must set FromClusterTransaction for the change vector: {changeVector}");
+                        }
+                    }
+                    break;
+                case 2:
+                    if (expectedValues.Contains(cvArray[0].NodeTag) && expectedValues.Contains(cvArray[1].NodeTag))
+                    {
+                        if (flags.Contain(DocumentFlags.FromClusterTransaction) == false)
+                        {
+                            Debug.Assert(false, $"flags must set FromClusterTransaction for the change vector: {changeVector}");
+                        }
+                    }
+                    break;
             }
         }
 
@@ -2057,9 +2083,10 @@ namespace Raven.Server.Documents
         [MethodImpl(MethodImplOptions.AggressiveInlining)]
         public PutOperationResults Put(DocumentsOperationContext context, string id,
             string expectedChangeVector, BlittableJsonReaderObject document, long? lastModifiedTicks = null, string changeVector = null,
+            string oldChangeVectorForClusterTransactionIndexCheck = null,
             DocumentFlags flags = DocumentFlags.None, NonPersistentDocumentFlags nonPersistentFlags = NonPersistentDocumentFlags.None)
         {
-            return DocumentPut.PutDocument(context, id, expectedChangeVector, document, lastModifiedTicks, changeVector, flags, nonPersistentFlags);
+            return DocumentPut.PutDocument(context, id, expectedChangeVector, document, lastModifiedTicks, changeVector, oldChangeVectorForClusterTransactionIndexCheck, flags, nonPersistentFlags);
         }
 
         public long GetNumberOfDocumentsToProcess(DocumentsOperationContext context, string collection, long afterEtag, out long totalCount)

--- a/src/Raven.Server/Documents/DocumentsStorage.cs
+++ b/src/Raven.Server/Documents/DocumentsStorage.cs
@@ -453,17 +453,12 @@ namespace Raven.Server.Documents
             return true;
         }
 
-        public bool TryRemoveUnusedIds(ref string changeVector, bool removeTrxn = false)
+        public bool TryRemoveUnusedIds(ref string changeVector)
         {
             if (string.IsNullOrEmpty(changeVector))
                 return false;
 
             var list = UnusedDatabaseIds;
-            if (removeTrxn)
-            {
-                list ??= new HashSet<string>();
-                list.Add(DocumentDatabase.ClusterTransactionId);
-            }
             if (list == null || list.Count == 0)
                 return false;
 
@@ -2335,6 +2330,10 @@ namespace Raven.Server.Documents
                 // case 4: incoming change vector A:11, B:12, C:10 -> update                (original: conflict, after: update)
 
                 var original = ChangeVectorUtils.GetConflictStatus(remote, local);
+                
+                remote = remote.StripTrxnTags();
+                local = local.StripTrxnTags();
+
                 TryRemoveUnusedIds(ref remote);
                 skipValidation = TryRemoveUnusedIds(ref local);
                 var after = ChangeVectorUtils.GetConflictStatus(remote, local);

--- a/src/Raven.Server/Documents/ETL/Providers/Raven/RavenEtl.cs
+++ b/src/Raven.Server/Documents/ETL/Providers/Raven/RavenEtl.cs
@@ -161,7 +161,7 @@ namespace Raven.Server.Documents.ETL.Providers.Raven
                 };
             }
 
-            using (var batchCommand = new SingleNodeBatchCommand(DocumentConventions.DefaultForServer, commands, options))
+            using (var batchCommand = new SingleNodeBatchCommand(DocumentConventions.DefaultForServer, context, commands, options))
             {
                 var duration = Stopwatch.StartNew();
 

--- a/src/Raven.Server/Documents/ETL/Providers/Raven/RavenEtl.cs
+++ b/src/Raven.Server/Documents/ETL/Providers/Raven/RavenEtl.cs
@@ -161,7 +161,7 @@ namespace Raven.Server.Documents.ETL.Providers.Raven
                 };
             }
 
-            using (var batchCommand = new SingleNodeBatchCommand(DocumentConventions.DefaultForServer, context, commands, options))
+            using (var batchCommand = new SingleNodeBatchCommand(DocumentConventions.DefaultForServer, commands, options))
             {
                 var duration = Stopwatch.StartNew();
 

--- a/src/Raven.Server/Documents/ETL/Providers/Raven/RavenEtlDocumentTransformer.cs
+++ b/src/Raven.Server/Documents/ETL/Providers/Raven/RavenEtlDocumentTransformer.cs
@@ -318,7 +318,7 @@ namespace Raven.Server.Documents.ETL.Providers.Raven
                         {
                             if (item.IsAttachmentTombstone == false)
                             {
-                                _currentRun.Delete(new DeleteCommandData(item.DocumentId, null));
+                                _currentRun.Delete(new DeleteCommandData(item.DocumentId, null, null));
                             }
                             else
                             {
@@ -802,7 +802,7 @@ namespace Raven.Server.Documents.ETL.Providers.Raven
                         && _transformation.TimeSeries.IsAddingTimeSeries == false
                         && _currentRun.IsDocumentLoadedToSameCollection(item.DocumentId))
                         continue;
-                    _currentRun.Delete(new DeleteCommandData(item.DocumentId, null));
+                    _currentRun.Delete(new DeleteCommandData(item.DocumentId, null, null));
                     isLoadedToDefaultCollectionDeleted = true;
                 }
                 else

--- a/src/Raven.Server/Documents/ETL/Providers/Raven/RavenEtlScriptRun.cs
+++ b/src/Raven.Server/Documents/ETL/Providers/Raven/RavenEtlScriptRun.cs
@@ -62,7 +62,7 @@ namespace Raven.Server.Documents.ETL.Providers.Raven
 
             var commands = _fullDocuments[id] = new List<ICommandData>();
 
-            commands.Add(new PutCommandDataWithBlittableJson(id, null, doc));
+            commands.Add(new PutCommandDataWithBlittableJson(id, null,null, doc));
 
             _stats.IncrementBatchSize(doc.Size);
 
@@ -284,7 +284,7 @@ namespace Raven.Server.Documents.ETL.Providers.Raven
             {
                 foreach (var put in _putsByJsReference)
                 {
-                    commands.Add(new PutCommandDataWithBlittableJson(put.Value.Id, null, put.Value.Document));
+                    commands.Add(new PutCommandDataWithBlittableJson(put.Value.Id, null, null, put.Value.Document));
 
                     if (_addAttachments != null && _addAttachments.TryGetValue(put.Key, out var putAttachments))
                     {

--- a/src/Raven.Server/Documents/Expiration/ExpirationStorage.cs
+++ b/src/Raven.Server/Documents/Expiration/ExpirationStorage.cs
@@ -4,6 +4,7 @@ using System.Diagnostics;
 using System.Globalization;
 using System.Threading;
 using Raven.Client;
+using Raven.Client.Exceptions;
 using Raven.Client.Exceptions.Documents;
 using Raven.Server.ServerWide.Context;
 using Sparrow;
@@ -290,7 +291,21 @@ namespace Raven.Server.Documents.Expiration
 
                                     using (var updated = context.ReadObject(doc.Data, doc.Id, BlittableJsonDocumentBuilder.UsageMode.ToDisk))
                                     {
-                                        _database.DocumentsStorage.Put(context, doc.Id, doc.ChangeVector, updated, flags: doc.Flags.Strip(DocumentFlags.FromClusterTransaction));
+                                        try
+                                        {
+                                            _database.DocumentsStorage.Put(context, doc.Id, doc.ChangeVector, updated, flags: doc.Flags.Strip(DocumentFlags.FromClusterTransaction));
+                                        }
+                                        catch (ConcurrencyException)
+                                        {
+                                            // This is expected and safe to ignore
+                                            // It can happen if there is a mismatch with the Cluster-Transaction-Index, which will
+                                            // sort itself out when the cluster & database will be in sync again
+                                        }
+                                        catch (DocumentConflictException)
+                                        {
+                                            // no good way to handle this, we'll wait to resolve
+                                            // the issue when the conflict is resolved
+                                        }
                                     }
                                 }
                             }

--- a/src/Raven.Server/Documents/Handlers/BatchHandler.cs
+++ b/src/Raven.Server/Documents/Handlers/BatchHandler.cs
@@ -659,6 +659,11 @@ namespace Raven.Server.Documents.Handlers
                     }
 
                     var updatedChangeVector = ChangeVectorUtils.TryUpdateChangeVector("RAFT", Database.DatabaseGroupId, count, global);
+
+                    if (options.DisableAtomicDocumentWrites == false)
+                        updatedChangeVector = ChangeVectorUtils.TryUpdateChangeVector("TRXN", Database.ClusterTransactionId, command.Index,
+                            updatedChangeVector.ChangeVector ?? global);
+
                     if (updatedChangeVector.IsValid)
                     {
                         context.LastDatabaseChangeVector = updatedChangeVector.ChangeVector;

--- a/src/Raven.Server/Documents/Handlers/BatchHandler.cs
+++ b/src/Raven.Server/Documents/Handlers/BatchHandler.cs
@@ -799,7 +799,7 @@ namespace Raven.Server.Documents.Handlers
                                 }
 
                                 putResult = Database.DocumentsStorage.Put(context, cmd.Id, cmd.ChangeVector, cmd.Document, 
-                                    oldChangeVectorForClusterTransactionIndexCheck: cmd.OldChangeVector, flags: flags);
+                                    oldChangeVectorForClusterTransactionIndexCheck: cmd.OriginalChangeVector, flags: flags);
                             }
                             catch (Voron.Exceptions.VoronConcurrencyErrorException)
                             {

--- a/src/Raven.Server/Documents/Handlers/BatchHandler.cs
+++ b/src/Raven.Server/Documents/Handlers/BatchHandler.cs
@@ -22,6 +22,7 @@ using Raven.Client.Exceptions.Documents;
 using Raven.Client.Json;
 using Raven.Server.Documents.Indexes;
 using Raven.Server.Documents.Patch;
+using Raven.Server.Documents.Replication;
 using Raven.Server.Json;
 using Raven.Server.Rachis;
 using Raven.Server.Routing;
@@ -65,7 +66,9 @@ namespace Raven.Server.Documents.Handlers
                 {
                     BatchTrafficWatch(command.ParsedCommands);
                 }
-
+                
+                var disableAtomicDocumentWrites = GetBoolValueQueryString("disableAtomicDocumentWrites", required: false) ?? 
+                    Database.Configuration.Cluster.DisableAtomicDocumentWrites;
                 var waitForIndexesTimeout = GetTimeSpanQueryString("waitForIndexesTimeout", required: false);
                 var waitForIndexThrow = GetBoolValueQueryString("waitForIndexThrow", required: false) ?? true;
                 var specifiedIndexesQueryString = HttpContext.Request.Query["waitForSpecificIndex"];
@@ -82,7 +85,8 @@ namespace Raven.Server.Documents.Handlers
                         {
                             WaitForIndexesTimeout = waitForIndexesTimeout,
                             WaitForIndexThrow = waitForIndexThrow,
-                            SpecifiedIndexesQueryString = specifiedIndexesQueryString.Count > 0 ? specifiedIndexesQueryString.ToList() : null
+                            SpecifiedIndexesQueryString = specifiedIndexesQueryString.Count > 0 ? specifiedIndexesQueryString.ToList() : null,
+                            DisableAtomicDocumentWrites = disableAtomicDocumentWrites
                         };
                         await HandleClusterTransaction(context, command, options);
                     }
@@ -195,7 +199,7 @@ namespace Raven.Server.Documents.Handlers
             if (topology.Promotables.Contains(ServerStore.NodeTag))
                 throw new DatabaseNotRelevantException("Cluster transaction can't be handled by a promotable node.");
 
-            var clusterTransactionCommand = new ClusterTransactionCommand(Database.Name, Database.IdentityPartsSeparator, topology.DatabaseTopologyIdBase64, command.ParsedCommands, options, raftRequestId);
+            var clusterTransactionCommand = new ClusterTransactionCommand(Database.Name, Database.IdentityPartsSeparator, topology, command.ParsedCommands, options, raftRequestId);
             var result = await ServerStore.SendToLeaderAsync(clusterTransactionCommand);
 
             if (result.Result is List<string> errors)
@@ -513,8 +517,7 @@ namespace Raven.Server.Documents.Handlers
             {
                 var global = context.LastDatabaseChangeVector ??
                              (context.LastDatabaseChangeVector = DocumentsStorage.GetDatabaseChangeVector(context));
-                var dbGrpId = Database.DatabaseGroupId;
-                var current = ChangeVectorUtils.GetEtagById(global, dbGrpId);
+                var current = ChangeVectorUtils.GetEtagById(global, Database.DatabaseGroupId);
 
                 Replies.Clear();
                 Options.Clear();
@@ -538,7 +541,11 @@ namespace Raven.Server.Documents.Handlers
                         foreach (BlittableJsonReaderObject blittableCommand in commands)
                         {
                             count++;
-                            var changeVector = $"RAFT:{count}-{dbGrpId}";
+                            var changeVector = $"{ChangeVectorParser.RaftTag}:{count}-{Database.DatabaseGroupId}";
+                            if (command.DisableAtomicDocumentWrites == false)
+                            {
+                                changeVector += $",{ChangeVectorParser.TrxnTag}:{command.Index}-{Database.ClusterTransactionId}";
+                            }
                             var cmd = JsonDeserializationServer.ClusterTransactionDataCommand(blittableCommand);
 
                             switch (cmd.Type)
@@ -651,7 +658,7 @@ namespace Raven.Server.Documents.Handlers
                         context.LastDatabaseChangeVector = global;
                     }
 
-                    var updatedChangeVector = ChangeVectorUtils.TryUpdateChangeVector("RAFT", dbGrpId, count, global);
+                    var updatedChangeVector = ChangeVectorUtils.TryUpdateChangeVector("RAFT", Database.DatabaseGroupId, count, global);
                     if (updatedChangeVector.IsValid)
                     {
                         context.LastDatabaseChangeVector = updatedChangeVector.ChangeVector;
@@ -791,7 +798,8 @@ namespace Raven.Server.Documents.Handlers
                                     flags |= DocumentFlags.HasRevisions;
                                 }
 
-                                putResult = Database.DocumentsStorage.Put(context, cmd.Id, cmd.ChangeVector, cmd.Document, flags: flags);
+                                putResult = Database.DocumentsStorage.Put(context, cmd.Id, cmd.ChangeVector, cmd.Document, 
+                                    oldChangeVectorForClusterTransactionIndexCheck: cmd.OldChangeVector, flags: flags);
                             }
                             catch (Voron.Exceptions.VoronConcurrencyErrorException)
                             {

--- a/src/Raven.Server/Documents/Handlers/BatchHandler.cs
+++ b/src/Raven.Server/Documents/Handlers/BatchHandler.cs
@@ -26,6 +26,7 @@ using Raven.Server.Documents.Replication;
 using Raven.Server.Json;
 using Raven.Server.Rachis;
 using Raven.Server.Routing;
+using Raven.Server.ServerWide;
 using Raven.Server.ServerWide.Commands;
 using Raven.Server.ServerWide.Context;
 using Raven.Server.Smuggler;
@@ -67,8 +68,8 @@ namespace Raven.Server.Documents.Handlers
                     BatchTrafficWatch(command.ParsedCommands);
                 }
                 
-                var disableAtomicDocumentWrites = GetBoolValueQueryString("disableAtomicDocumentWrites", required: false) ?? 
-                    Database.Configuration.Cluster.DisableAtomicDocumentWrites;
+                var disableAtomicDocumentWrites = GetBoolValueQueryString("disableAtomicDocumentWrites", required: false) ??
+                                                  Database.Configuration.Cluster.DisableAtomicDocumentWrites;
                 var waitForIndexesTimeout = GetTimeSpanQueryString("waitForIndexesTimeout", required: false);
                 var waitForIndexThrow = GetBoolValueQueryString("waitForIndexThrow", required: false) ?? true;
                 var specifiedIndexesQueryString = HttpContext.Request.Query["waitForSpecificIndex"];
@@ -199,7 +200,7 @@ namespace Raven.Server.Documents.Handlers
             if (topology.Promotables.Contains(ServerStore.NodeTag))
                 throw new DatabaseNotRelevantException("Cluster transaction can't be handled by a promotable node.");
 
-            var clusterTransactionCommand = new ClusterTransactionCommand(Database.Name, Database.IdentityPartsSeparator, topology, command.ParsedCommands, options, raftRequestId);
+            var clusterTransactionCommand = new ClusterTransactionCommand(Database.Name, Database.IdentityPartsSeparator, topology, command.ParsedCommands, options, raftRequestId, ClusterCommandsVersionManager.CurrentClusterMinimalVersion);
             var result = await ServerStore.SendToLeaderAsync(clusterTransactionCommand);
 
             if (result.Result is List<string> errors)

--- a/src/Raven.Server/Documents/Handlers/BatchHandler.cs
+++ b/src/Raven.Server/Documents/Handlers/BatchHandler.cs
@@ -147,8 +147,10 @@ namespace Raven.Server.Documents.Handlers
                 return;
             }
 
-            if (clientVersion.Major <= 5 && clientVersion.Minor < 2)
+            if (clientVersion.Major < 5 || (clientVersion.Major == 5 && clientVersion.Minor < 2))
+            {
                 disableAtomicDocumentWrites = true;
+            }
         }
 
         private static void ValidateCommandForClusterWideTransaction(MergedBatchCommand command)

--- a/src/Raven.Server/Documents/Handlers/BatchRequestParser.cs
+++ b/src/Raven.Server/Documents/Handlers/BatchRequestParser.cs
@@ -40,7 +40,7 @@ namespace Raven.Server.Documents.Handlers
             public BlittableJsonReaderObject CreateIfMissing;
             public BlittableJsonReaderObject PatchIfMissingArgs;
             public LazyStringValue ChangeVector;
-            public LazyStringValue OldChangeVector;
+            public LazyStringValue OriginalChangeVector;
             public bool IdPrefixed;
             public long Index;
             public bool FromEtl;
@@ -595,12 +595,12 @@ namespace Raven.Server.Documents.Handlers
                             commandData.ChangeVector = GetLazyStringValue(ctx, state);
                         }
                         break;
-                    case CommandPropertyName.OldChangeVector:
+                    case CommandPropertyName.OriginalChangeVector:
                         while (parser.Read() == false)
                             await RefillParserBuffer(stream, buffer, parser, token);
                         if (state.CurrentTokenType == JsonParserToken.Null)
                         {
-                            commandData.OldChangeVector = null;
+                            commandData.OriginalChangeVector = null;
                         }
                         else
                         {
@@ -609,7 +609,7 @@ namespace Raven.Server.Documents.Handlers
                                 ThrowUnexpectedToken(JsonParserToken.String, state);
                             }
 
-                            commandData.OldChangeVector = GetLazyStringValue(ctx, state);
+                            commandData.OriginalChangeVector = GetLazyStringValue(ctx, state);
                         }
                         break;
 
@@ -872,7 +872,7 @@ namespace Raven.Server.Documents.Handlers
             Ids,
             Document,
             ChangeVector,
-            OldChangeVector,
+            OriginalChangeVector,
             Patch,
             PatchIfMissing,
             CreateIfMissing,
@@ -1029,13 +1029,16 @@ namespace Raven.Server.Documents.Handlers
                         *(short*)(state.StringBuffer + sizeof(long) + sizeof(int)) == 28265 &&
                         state.StringBuffer[14] == (byte)'g')
                         return CommandPropertyName.CreateIfMissing;
-                    if (*(long*)state.StringBuffer == 7453001533779897423 &&
-                        *(int*)(state.StringBuffer + sizeof(long)) == 1667585637 &&
-                        *(short*)(state.StringBuffer + sizeof(long) + sizeof(int)) == 28532 &&
-                        state.StringBuffer[14] == (byte)'r')
-                        return CommandPropertyName.OldChangeVector;
-
+        
                     return CommandPropertyName.NoSuchProperty;
+                
+                case 20:
+                    if (*(long*)state.StringBuffer == 7809644627822735951 &&
+                        *(long*)(state.StringBuffer + sizeof(long)) == 7302135340735752259 &&
+                        *(int*)(state.StringBuffer + sizeof(long) + sizeof(long)) == 1919906915)
+                        return CommandPropertyName.OriginalChangeVector;
+                    return CommandPropertyName.NoSuchProperty;
+
 
                 case 29:
                     if (*(long*)state.StringBuffer == 8531315664536891206 &&

--- a/src/Raven.Server/Documents/Patch/PatchDocumentCommand.cs
+++ b/src/Raven.Server/Documents/Patch/PatchDocumentCommand.cs
@@ -210,6 +210,7 @@ namespace Raven.Server.Documents.Patch
                                     result.ModifiedDocument,
                                     lastModifiedTicks: null,
                                     changeVector: null,
+                                    oldChangeVectorForClusterTransactionIndexCheck: null,
                                     originalDocument.Flags.Strip(DocumentFlags.FromClusterTransaction),
                                     nonPersistentFlags);
                             }

--- a/src/Raven.Server/Documents/PeriodicBackup/Restore/RestoreBackupTaskBase.cs
+++ b/src/Raven.Server/Documents/PeriodicBackup/Restore/RestoreBackupTaskBase.cs
@@ -246,6 +246,8 @@ namespace Raven.Server.Documents.PeriodicBackup.Restore
                         databaseRecord.DatabaseState = DatabaseStateStatus.RestoreInProgress;
 
                         await SaveDatabaseRecordAsync(databaseName, databaseRecord, restoreSettings.DatabaseValues, result, onProgress);
+                        database.ClusterTransactionId = databaseRecord.Topology.ClusterTransactionIdBase64;
+                        database.DatabaseGroupId = databaseRecord.Topology.DatabaseTopologyIdBase64;
 
                         using (database.DocumentsStorage.ContextPool.AllocateOperationContext(out DocumentsOperationContext context))
                         {

--- a/src/Raven.Server/Documents/Replication/ChangeVectorExtensions.cs
+++ b/src/Raven.Server/Documents/Replication/ChangeVectorExtensions.cs
@@ -67,7 +67,5 @@ namespace Raven.Server.Documents.Replication
         }
 
         public static int FromBase26(string tag) => tag.ParseNodeTag();
-
-        public static readonly int SinkTag = FromBase26("SINK");
     }
 }

--- a/src/Raven.Server/Documents/Replication/ChangeVectorParser.cs
+++ b/src/Raven.Server/Documents/Replication/ChangeVectorParser.cs
@@ -8,8 +8,10 @@ namespace Raven.Server.Documents.Replication
     {
         public const string RaftTag = "RAFT";
         public const string TrxnTag = "TRXN";
-        public static int RaftInt = RaftTag.ParseNodeTag();
-        public static int TrxnInt = TrxnTag.ParseNodeTag();
+        public const string SinkTag = "SINK";
+        public static readonly int RaftInt = RaftTag.ParseNodeTag();
+        public static readonly int TrxnInt = TrxnTag.ParseNodeTag();
+        public static readonly int SinkInt = SinkTag.ParseNodeTag();
 
         private enum State
         {

--- a/src/Raven.Server/Documents/Replication/ChangeVectorParser.cs
+++ b/src/Raven.Server/Documents/Replication/ChangeVectorParser.cs
@@ -7,7 +7,9 @@ namespace Raven.Server.Documents.Replication
     public static class ChangeVectorParser
     {
         public const string RaftTag = "RAFT";
+        public const string TrxnTag = "TRXN";
         public static int RaftInt = RaftTag.ParseNodeTag();
+        public static int TrxnInt = TrxnTag.ParseNodeTag();
 
         private enum State
         {

--- a/src/Raven.Server/Documents/Replication/IncomingReplicationHandler.cs
+++ b/src/Raven.Server/Documents/Replication/IncomingReplicationHandler.cs
@@ -1367,7 +1367,7 @@ namespace Raven.Server.Documents.Replication
                         {
                             DbId = entry.DbId,
                             Etag = entry.Etag,
-                            NodeTag = ChangeVectorExtensions.SinkTag
+                            NodeTag = ChangeVectorParser.SinkInt
                         });
 
                         context.DbIdsToIgnore ??= new HashSet<string>();
@@ -1393,7 +1393,7 @@ namespace Raven.Server.Documents.Replication
 
                 foreach (var entry in incoming)
                 {
-                    if (entry.NodeTag == ChangeVectorExtensions.SinkTag)
+                    if (entry.NodeTag == ChangeVectorParser.SinkInt)
                     {
                         var found = global?.Find(x => x.DbId == entry.DbId) ?? default;
                         if (found.Etag > 0)

--- a/src/Raven.Server/Documents/Replication/IncomingReplicationHandler.cs
+++ b/src/Raven.Server/Documents/Replication/IncomingReplicationHandler.cs
@@ -1256,7 +1256,7 @@ namespace Raven.Server.Documents.Replication
                                             }
 
                                             database.DocumentsStorage.Put(context, doc.Id, null, resolvedDocument, doc.LastModifiedTicks,
-                                                rcvdChangeVector, flags, nonPersistentFlags);
+                                                rcvdChangeVector, null, flags, nonPersistentFlags);
                                         }
                                         else
                                         {

--- a/src/Raven.Server/Documents/Replication/ReplicationLoader.cs
+++ b/src/Raven.Server/Documents/Replication/ReplicationLoader.cs
@@ -1863,6 +1863,7 @@ namespace Raven.Server.Documents.Replication
 
         public async Task<int> WaitForReplicationAsync(int numberOfReplicasToWaitFor, TimeSpan waitForReplicasTimeout, string lastChangeVector)
         {
+            lastChangeVector = lastChangeVector.StripTrxnTags();
             var sp = Stopwatch.StartNew();
             while (true)
             {

--- a/src/Raven.Server/Documents/Replication/ResolveConflictOnReplicationConfigurationChange.cs
+++ b/src/Raven.Server/Documents/Replication/ResolveConflictOnReplicationConfigurationChange.cs
@@ -292,7 +292,7 @@ namespace Raven.Server.Documents.Replication
                 // we always want to merge the counters and attachments, even if the user specified a script
                 var nonPersistentFlags = NonPersistentDocumentFlags.ResolveCountersConflict | NonPersistentDocumentFlags.ResolveAttachmentsConflict | NonPersistentDocumentFlags.ResolveTimeSeriesConflict |
                                          NonPersistentDocumentFlags.FromResolver | NonPersistentDocumentFlags.Resolved;
-                _database.DocumentsStorage.Put(context, resolved.Id, null, clone, null, changeVector, resolved.Flags | DocumentFlags.Resolved, nonPersistentFlags: nonPersistentFlags);
+                _database.DocumentsStorage.Put(context, resolved.Id, null, clone, null, changeVector, null, resolved.Flags | DocumentFlags.Resolved, nonPersistentFlags: nonPersistentFlags);
             }
         }
 

--- a/src/Raven.Server/Documents/Revisions/RevisionsStorage.cs
+++ b/src/Raven.Server/Documents/Revisions/RevisionsStorage.cs
@@ -559,7 +559,7 @@ namespace Raven.Server.Documents.Revisions
                     return;
                 }
                 _documentsStorage.Put(context, id, null, document, lastModifiedTicks, changeVector,
-                    flags, nonPersistentFlags);
+                    null, flags, nonPersistentFlags);
             }
         }
 

--- a/src/Raven.Server/ServerWide/ClusterStateMachine.cs
+++ b/src/Raven.Server/ServerWide/ClusterStateMachine.cs
@@ -880,10 +880,10 @@ namespace Raven.Server.ServerWide
             try
             {
                 clusterTransaction = (ClusterTransactionCommand)JsonDeserializationCluster.Commands[nameof(ClusterTransactionCommand)](cmd);
-                UpdateDatabaseRecordId(context, index, clusterTransaction);
+                var dbTopology = UpdateDatabaseRecordId(context, index, clusterTransaction);
 
                 var compareExchangeItems = context.Transaction.InnerTransaction.OpenTable(CompareExchangeSchema, CompareExchange);
-                var error = clusterTransaction.ExecuteCompareExchangeCommands(context, index, compareExchangeItems);
+                var error = clusterTransaction.ExecuteCompareExchangeCommands(dbTopology, context, index, compareExchangeItems);
                 if (error == null)
                 {
                     clusterTransaction.SaveCommandsBatch(context, index);
@@ -910,7 +910,7 @@ namespace Raven.Server.ServerWide
             }
         }
 
-        private void UpdateDatabaseRecordId(ClusterOperationContext context, long index, ClusterTransactionCommand clusterTransaction)
+        private DatabaseTopology UpdateDatabaseRecordId(ClusterOperationContext context, long index, ClusterTransactionCommand clusterTransaction)
         {
             var rawRecord = ReadRawDatabaseRecord(context, clusterTransaction.DatabaseName);
 
@@ -918,11 +918,12 @@ namespace Raven.Server.ServerWide
                 throw DatabaseDoesNotExistException.CreateWithMessage(clusterTransaction.DatabaseName, $"Could not execute update command of type '{nameof(ClusterTransactionCommand)}'.");
 
             var topology = rawRecord.Topology;
-            if (topology.DatabaseTopologyIdBase64 == null)
+            if (topology.DatabaseTopologyIdBase64 == null || topology.ClusterTransactionIdBase64 == null)
             {
                 var items = context.Transaction.InnerTransaction.OpenTable(ItemsSchema, Items);
                 var databaseRecordJson = rawRecord.Raw;
-                topology.DatabaseTopologyIdBase64 = clusterTransaction.DatabaseRecordId;
+                topology.DatabaseTopologyIdBase64 ??= clusterTransaction.DatabaseRecordId;
+                topology.ClusterTransactionIdBase64 ??= clusterTransaction.ClusterTransactionId;
                 var dbKey = $"db/{clusterTransaction.DatabaseName}";
                 using (Slice.From(context.Allocator, dbKey, out var valueName))
                 using (Slice.From(context.Allocator, dbKey.ToLowerInvariant(), out var valueNameLowered))
@@ -940,6 +941,7 @@ namespace Raven.Server.ServerWide
                     UpdateValue(index, items, valueNameLowered, valueName, databaseRecordJson);
                 }
             }
+            return topology;
         }
 
         private void ConfirmReceiptServerCertificate(ClusterOperationContext context, BlittableJsonReaderObject cmd, long index, ServerStore serverStore)

--- a/src/Raven.Server/ServerWide/ClusterStateMachine.cs
+++ b/src/Raven.Server/ServerWide/ClusterStateMachine.cs
@@ -882,6 +882,12 @@ namespace Raven.Server.ServerWide
                 clusterTransaction = (ClusterTransactionCommand)JsonDeserializationCluster.Commands[nameof(ClusterTransactionCommand)](cmd);
                 var dbTopology = UpdateDatabaseRecordId(context, index, clusterTransaction);
 
+                if (clusterTransaction.SerializedDatabaseCommands != null &&
+                    clusterTransaction.SerializedDatabaseCommands.TryGet(nameof(ClusterTransactionCommand.Options), out BlittableJsonReaderObject blittableOptions))
+                {
+                    clusterTransaction.Options = JsonDeserializationServer.ClusterTransactionOptions(blittableOptions);
+                }
+
                 var compareExchangeItems = context.Transaction.InnerTransaction.OpenTable(CompareExchangeSchema, CompareExchange);
                 var error = clusterTransaction.ExecuteCompareExchangeCommands(dbTopology, context, index, compareExchangeItems);
                 if (error == null)

--- a/src/Raven.Server/ServerWide/Commands/ClusterTransactionCommand.cs
+++ b/src/Raven.Server/ServerWide/Commands/ClusterTransactionCommand.cs
@@ -155,10 +155,12 @@ namespace Raven.Server.ServerWide.Commands
 
         public List<string> ExecuteCompareExchangeCommands(DatabaseTopology dbTopology, ClusterOperationContext context, long index, Table items)
         {
-            if (DisableAtomicDocumentWrites == false)
+            if (DisableAtomicDocumentWrites == false && 
+                ClusterCommandsVersionManager.CurrentClusterMinimalVersion >= 52_000) // for mixed cluster, retain the old behaviour
             {
                 EnsureAtomicDocumentWrites(dbTopology, context, items, index);
             }
+
             if (ClusterCommands == null || ClusterCommands.Count == 0)
                 return null;
 
@@ -222,7 +224,8 @@ namespace Raven.Server.ServerWide.Commands
         {
             if (SerializedDatabaseCommands == null)
                 return;
-            if(SerializedDatabaseCommands.TryGet(nameof(DatabaseCommands), out BlittableJsonReaderArray commands) == false)
+
+            if (SerializedDatabaseCommands.TryGet(nameof(DatabaseCommands), out BlittableJsonReaderArray commands) == false)
                 return;
             
             ClusterCommands ??= new List<ClusterTransactionDataCommand>();

--- a/src/Raven.Server/ServerWide/Commands/ClusterTransactionCommand.cs
+++ b/src/Raven.Server/ServerWide/Commands/ClusterTransactionCommand.cs
@@ -49,7 +49,7 @@ namespace Raven.Server.ServerWide.Commands
                 return new ClusterTransactionDataCommand
                 {
                     Id = command.Id,
-                    ChangeVector = command.OldChangeVector ?? command.ChangeVector,
+                    ChangeVector = command.OriginalChangeVector ?? command.ChangeVector,
                     Document = command.Document,
                     Index = command.Index,
                     Type = command.Type
@@ -104,7 +104,7 @@ namespace Raven.Server.ServerWide.Commands
         [JsonDeserializationIgnore]
         public ClusterTransactionOptions Options;
         
-        public bool DisableAtomicDocumentWrites;
+        public bool? DisableAtomicDocumentWrites;
 
         [JsonDeserializationIgnore]
         public readonly List<ClusterTransactionDataCommand> DatabaseCommands = new List<ClusterTransactionDataCommand>();

--- a/src/Raven.Server/ServerWide/Commands/CompareExchangeCommands.cs
+++ b/src/Raven.Server/ServerWide/Commands/CompareExchangeCommands.cs
@@ -138,22 +138,24 @@ namespace Raven.Server.ServerWide.Commands
 
         }
 
+        public const long InvalidIndexValue = -1;
+        
         public unsafe bool Validate(ClusterOperationContext context, Table items, long index, out long currentIndex)
         {
-            currentIndex = -1;
+            currentIndex = InvalidIndexValue ;
             using (Slice.From(context.Allocator, ActualKey, out Slice keySlice))
             {
                 if (items.ReadByKey(keySlice, out var reader))
                 {
                     currentIndex = *(long*)reader.Read((int)ClusterStateMachine.CompareExchangeTable.Index, out var _);
 
-                    if (index == -1)
+                    if (index == InvalidIndexValue )
                         return true;
 
                     return Index == currentIndex;
                 }
             }
-            return index == 0 || index == -1;
+            return index == 0 || index == InvalidIndexValue;
         }
 
         public override DynamicJsonValue ToJson(JsonOperationContext context)

--- a/src/Raven.Server/ServerWide/Commands/CompareExchangeCommands.cs
+++ b/src/Raven.Server/ServerWide/Commands/CompareExchangeCommands.cs
@@ -146,10 +146,14 @@ namespace Raven.Server.ServerWide.Commands
                 if (items.ReadByKey(keySlice, out var reader))
                 {
                     currentIndex = *(long*)reader.Read((int)ClusterStateMachine.CompareExchangeTable.Index, out var _);
+
+                    if (index == -1)
+                        return true;
+
                     return Index == currentIndex;
                 }
             }
-            return index == 0;
+            return index == 0 || index == -1;
         }
 
         public override DynamicJsonValue ToJson(JsonOperationContext context)

--- a/src/Raven.Server/ServerWide/Context/DocumentsOperationContext.cs
+++ b/src/Raven.Server/ServerWide/Context/DocumentsOperationContext.cs
@@ -2,6 +2,7 @@
 using System.Collections.Generic;
 using Raven.Server.Documents;
 using Raven.Server.Documents.Replication;
+using Raven.Server.Utils;
 using Sparrow.Threading;
 using Voron;
 
@@ -16,6 +17,8 @@ namespace Raven.Server.ServerWide.Context
             get => _lastDatabaseChangeVector;
             set
             {
+                value = value.StripTrxnTags();
+
                 if (DbIdsToIgnore == null || DbIdsToIgnore.Count == 0 || string.IsNullOrEmpty(value))
                 {
                     _lastDatabaseChangeVector = value;

--- a/src/Raven.Server/ServerWide/ServerStore.cs
+++ b/src/Raven.Server/ServerWide/ServerStore.cs
@@ -2534,6 +2534,9 @@ namespace Raven.Server.ServerWide
             if (string.IsNullOrEmpty(record.Topology.DatabaseTopologyIdBase64))
                 record.Topology.DatabaseTopologyIdBase64 = Guid.NewGuid().ToBase64Unpadded();
 
+            if (string.IsNullOrEmpty(record.Topology.ClusterTransactionIdBase64))
+                record.Topology.ClusterTransactionIdBase64 = Guid.NewGuid().ToBase64Unpadded();
+
             record.Topology.Stamp ??= new LeaderStamp();
             record.Topology.Stamp.Term = _engine.CurrentTerm;
             record.Topology.Stamp.LeadersTicks = _engine.CurrentLeader?.LeaderShipDuration ?? 0;

--- a/src/Raven.Server/Smuggler/Documents/DatabaseDestination.cs
+++ b/src/Raven.Server/Smuggler/Documents/DatabaseDestination.cs
@@ -623,10 +623,10 @@ namespace Raven.Server.Smuggler.Documents
                     var parsedCommands = _clusterTransactionCommands.GetArraySegment();
 
                     var raftRequestId = RaftIdGenerator.NewId();
-                    var options = new ClusterTransactionCommand.ClusterTransactionOptions(taskId);
+                    var options = new ClusterTransactionCommand.ClusterTransactionOptions(taskId, disableAtomicDocumentWrites: false, ClusterCommandsVersionManager.CurrentClusterMinimalVersion);
                     var topology = _database.ServerStore.LoadDatabaseTopology(_database.Name);
 
-                    var clusterTransactionCommand = new ClusterTransactionCommand(_database.Name, _database.IdentityPartsSeparator, topology, parsedCommands, options, raftRequestId, ClusterCommandsVersionManager.CurrentClusterMinimalVersion);
+                    var clusterTransactionCommand = new ClusterTransactionCommand(_database.Name, _database.IdentityPartsSeparator, topology, parsedCommands, options, raftRequestId);
                     var clusterTransactionResult = await _database.ServerStore.SendToLeaderAsync(clusterTransactionCommand);
                     for (int i = 0; i < _clusterTransactionCommands.Length; i++)
                     {

--- a/src/Raven.Server/Smuggler/Documents/DatabaseDestination.cs
+++ b/src/Raven.Server/Smuggler/Documents/DatabaseDestination.cs
@@ -626,7 +626,7 @@ namespace Raven.Server.Smuggler.Documents
                     var options = new ClusterTransactionCommand.ClusterTransactionOptions(taskId);
                     var topology = _database.ServerStore.LoadDatabaseTopology(_database.Name);
 
-                    var clusterTransactionCommand = new ClusterTransactionCommand(_database.Name, _database.IdentityPartsSeparator, topology, parsedCommands, options, raftRequestId);
+                    var clusterTransactionCommand = new ClusterTransactionCommand(_database.Name, _database.IdentityPartsSeparator, topology, parsedCommands, options, raftRequestId, ClusterCommandsVersionManager.CurrentClusterMinimalVersion);
                     var clusterTransactionResult = await _database.ServerStore.SendToLeaderAsync(clusterTransactionCommand);
                     for (int i = 0; i < _clusterTransactionCommands.Length; i++)
                     {

--- a/src/Raven.Server/Smuggler/Documents/DatabaseDestination.cs
+++ b/src/Raven.Server/Smuggler/Documents/DatabaseDestination.cs
@@ -595,7 +595,7 @@ namespace Raven.Server.Smuggler.Documents
                     if (_operationContext.readTrx == null || _operationContext.readTrx.Disposed)
                         _operationContext.readTrx = _operationContext.ctx.OpenReadTransaction();
 
-                    using var doc = _database.DocumentsStorage.Get(_operationContext.ctx, docId);
+                    var doc = _database.DocumentsStorage.Get(_operationContext.ctx, docId, DocumentFields.Data);
                     if (doc == null)
                         return;
 
@@ -605,7 +605,6 @@ namespace Raven.Server.Smuggler.Documents
                         Document = doc.Data,
                         Type = CommandType.PUT
                     });
-                    doc.Data = null;
                 }
                 _compareExchangeAddOrUpdateCommands.Add(new AddOrUpdateCompareExchangeCommand(_database.Name, key, value, 0, _context, RaftIdGenerator.DontCareId, fromBackup: true));
 

--- a/src/Raven.Server/Smuggler/Documents/Handlers/SmugglerHandler.cs
+++ b/src/Raven.Server/Smuggler/Documents/Handlers/SmugglerHandler.cs
@@ -876,7 +876,7 @@ namespace Raven.Server.Smuggler.Documents.Handlers
             using (token)
             using (var source = new StreamSource(stream, context, Database))
             {
-                var destination = new DatabaseDestination(Database);
+                var destination = new DatabaseDestination(Database, token.Token);
                 var smuggler = new DatabaseSmuggler(Database, source, destination, Database.Time, options, result, onProgress, token.Token);
 
                 await smuggler.ExecuteAsync();

--- a/src/Raven.Server/Utils/ChangeVectorUtils.cs
+++ b/src/Raven.Server/Utils/ChangeVectorUtils.cs
@@ -353,5 +353,39 @@ namespace Raven.Server.Utils
 
             return rest;
         }
+
+        public static string StripSinkTags(this string from, string exclude)
+        {
+            return from.StripTags(ChangeVectorParser.SinkTag, exclude);
+        }
+
+        public static string StripTrxnTags(this string from)
+        {
+            return from.StripTags(ChangeVectorParser.TrxnTag, exclude: null);
+        }
+
+        private static string StripTags(this string from, string tag, string exclude)
+        {
+            if (from == null)
+                return null;
+
+            if (from.Contains(tag, StringComparison.OrdinalIgnoreCase) == false)
+                return from;
+
+            var newChangeVector = new List<ChangeVectorEntry>();
+            var changeVectorList = from.ToChangeVectorList();
+            var tagAsInt = ChangeVectorExtensions.FromBase26(tag);
+
+            foreach (var entry in changeVectorList)
+            {
+                if (entry.NodeTag != tagAsInt ||
+                    exclude?.Contains(entry.DbId) == true)
+                {
+                    newChangeVector.Add(entry);
+                }
+            }
+
+            return newChangeVector.SerializeVector();
+        }
     }
 }

--- a/src/Raven.Server/Utils/ChangeVectorUtils.cs
+++ b/src/Raven.Server/Utils/ChangeVectorUtils.cs
@@ -262,6 +262,9 @@ namespace Raven.Server.Utils
             if (changeVector == null)
                 return 0;
 
+            if (id == null)
+                throw new ArgumentNullException(nameof(id));
+
             var index = changeVector.IndexOf("-" + id, StringComparison.Ordinal);
             if (index == -1)
                 return 0;

--- a/src/Raven.Server/Utils/ChangeVectorUtils.cs
+++ b/src/Raven.Server/Utils/ChangeVectorUtils.cs
@@ -216,10 +216,9 @@ namespace Raven.Server.Utils
             if (string.IsNullOrEmpty(vectorBstring))
                 return vectorAstring;
 
-            if (_mergeVectorBuffer == null)
-                _mergeVectorBuffer = new EquatableList<ChangeVectorEntry>();
+            _mergeVectorBuffer ??= new List<ChangeVectorEntry>();
             _mergeVectorBuffer.Clear();
-
+  
             ChangeVectorParser.MergeChangeVector(vectorAstring, _mergeVectorBuffer);
             ChangeVectorParser.MergeChangeVector(vectorBstring, _mergeVectorBuffer);
 

--- a/src/Raven.Server/Web/System/AdminDatabasesHandler.cs
+++ b/src/Raven.Server/Web/System/AdminDatabasesHandler.cs
@@ -448,11 +448,13 @@ namespace Raven.Server.Web.System
             }
             else
             {
-                if (databaseRecord.Topology == null)
-                    databaseRecord.Topology = new DatabaseTopology();
+                databaseRecord.Topology ??= new DatabaseTopology();
 
                 databaseRecord.Topology.ReplicationFactor = Math.Min(replicationFactor, clusterTopology.AllNodes.Count);
             }
+
+            databaseRecord.Topology.ClusterTransactionIdBase64 ??= Guid.NewGuid().ToBase64Unpadded();
+            databaseRecord.Topology.DatabaseTopologyIdBase64 ??= Guid.NewGuid().ToBase64Unpadded();
 
             var (newIndex, result) = await ServerStore.WriteDatabaseRecordAsync(name, databaseRecord, index, raftRequestId);
             await ServerStore.WaitForCommitIndexChange(RachisConsensus.CommitIndexModification.GreaterOrEqual, newIndex);

--- a/src/Sparrow/Json/Parsing/ObjectJsonParser.cs
+++ b/src/Sparrow/Json/Parsing/ObjectJsonParser.cs
@@ -72,6 +72,7 @@ namespace Sparrow.Json.Parsing
                 throw new InvalidOperationException(
                     "Cannot remove in memory property when setup with a source blittable json object");
             var index = Properties.FindIndex(x => x.Name == property);
+            if (index == -1) return;
             Properties.RemoveAt(index);
         }
 

--- a/test/RachisTests/DatabaseCluster/AtomicClusterReadWriteTests.cs
+++ b/test/RachisTests/DatabaseCluster/AtomicClusterReadWriteTests.cs
@@ -1,0 +1,281 @@
+﻿using System;
+using System.Collections.Concurrent;
+using System.Collections.Generic;
+using System.Linq;
+using System.Threading;
+using System.Threading.Tasks;
+using FastTests.Server.Replication;
+using Raven.Client.Documents;
+using Raven.Client.Documents.Conventions;
+using Raven.Client.Documents.Operations.CompareExchange;
+using Raven.Client.Documents.Session;
+using Raven.Client.Documents.Smuggler;
+using Raven.Client.Exceptions;
+using Raven.Client.Util;
+using Raven.Server;
+using Raven.Tests.Core.Utils.Entities;
+using Sparrow.Server;
+using Xunit;
+using Xunit.Abstractions;
+
+namespace RachisTests.DatabaseCluster
+{
+    public class AtomicClusterReadWriteTests : ReplicationTestBase
+    {
+        public AtomicClusterReadWriteTests(ITestOutputHelper output) : base(output)
+        {
+        }
+
+        class TestObj
+        {
+            public string Id { get; set; }
+            public string Prop { get; set; }
+        }
+
+        [Fact]
+        public async Task ClusterWideTransaction_WhenStore_ShouldCreateCompareExchange()
+        {
+            var (nodes, leader) = await CreateRaftCluster(3);
+            using var store = GetDocumentStore(new Options {Server = leader, ReplicationFactor = nodes.Count});
+
+            var entity = new TestObj();
+            using (var session = store.OpenAsyncSession(new SessionOptions { TransactionMode = TransactionMode.ClusterWide }))
+            {
+                await session.StoreAsync(entity);
+                await session.SaveChangesAsync();
+            }
+
+            var result = await store.Operations.SendAsync(new GetCompareExchangeValuesOperation<User>(""));
+            Assert.Single(result);
+            Assert.EndsWith(entity.Id, result.Single().Key, StringComparison.OrdinalIgnoreCase);
+        }
+
+        [Fact]
+        public async Task ClusterWideTransaction_WhenDisableAndStore_ShouldNotCreateCompareExchange()
+        {
+            var (nodes, leader) = await CreateRaftCluster(3);
+            using var store = GetDocumentStore(new Options {Server = leader, ReplicationFactor = nodes.Count});
+
+            var entity = new TestObj();
+            using (var session = store.OpenAsyncSession(new SessionOptions { TransactionMode = TransactionMode.ClusterWide, DisableAtomicDocumentWritesInClusterWideTransaction = true}))
+            {
+                await session.StoreAsync(entity);
+                await session.SaveChangesAsync();
+            }
+
+            var result = await store.Operations.SendAsync(new GetCompareExchangeValuesOperation<User>(""));
+            Assert.Empty(result);
+        }
+
+        [Fact]
+        public async Task ClusterWideTransaction_WhenLoadAndUpdateInParallel_ShouldSucceedOnlyInTheFirst()
+        {
+            var (nodes, leader) = await CreateRaftCluster(3);
+            using var documentStore = GetDocumentStore(new Options {Server = leader, ReplicationFactor = nodes.Count});
+
+            using var disposable = LocalGetDocumentStores(nodes, documentStore.Database, out var stores);
+
+            var entity = new TestObj();
+            using (var session = documentStore.OpenAsyncSession(new SessionOptions { TransactionMode = TransactionMode.ClusterWide }))
+            {
+                await session.StoreAsync(entity);
+                await session.SaveChangesAsync();
+            }
+            await WaitForDocumentInClusterAsync<TestObj>(documentStore.GetRequestExecutor().Topology.Nodes, entity.Id, u => u != null, TimeSpan.FromSeconds(10));
+
+            var barrier = new Barrier(3);
+            var exceptions = new ConcurrentBag<Exception>();
+            var tasks = Enumerable.Range(0, stores.Length)
+                .Select(i => Task.Run(async () =>
+                {
+                    using var session = stores[i].OpenAsyncSession(new SessionOptions {TransactionMode = TransactionMode.ClusterWide});
+                    var loaded = await session.LoadAsync<TestObj>(entity.Id);
+                    barrier.SignalAndWait();
+
+                    loaded.Prop = "Change" + i;
+
+                    try
+                    {
+                        await session.SaveChangesAsync();
+                    }
+                    catch (Exception e)
+                    {
+                        exceptions.Add(e);
+                    }
+                }));
+
+            await Task.WhenAll(tasks);
+            Assert.Equal(2, exceptions.Count);
+            foreach (var exception in exceptions)
+            {
+                Assert.IsType<ConcurrencyException>(exception);
+            }
+        }
+
+        [Fact]
+        public async Task ClusterWideTransaction_WhenLoadAndDeleteWhileUpdated_ShouldSucceedOnlyInTheFirst()
+        {
+            var (nodes, leader) = await CreateRaftCluster(3, shouldRunInMemory: false);
+
+            using var documentStore = GetDocumentStore(new Options {Server = leader, ReplicationFactor = nodes.Count});
+
+            var entity = new TestObj();
+            using (var session = documentStore.OpenAsyncSession(new SessionOptions { TransactionMode = TransactionMode.ClusterWide }))
+            {
+                await session.StoreAsync(entity);
+                await session.SaveChangesAsync();
+            }
+
+            await LoadAndDeleteWhileUpdated(nodes, documentStore.Database, entity.Id);
+        }
+
+        [Fact]
+        public async Task ClusterWideTransaction_WhenImportThenLoadAndDeleteWhileUpdated_ShouldSucceedOnlyInTheFirst()
+        {
+            var (nodes, leader) = await CreateRaftCluster(3);
+            using var documentStore = GetDocumentStore(new Options { Server = leader, ReplicationFactor = nodes.Count });
+
+            var entity = new TestObj();
+            using (var source = GetDocumentStore())
+            {
+                using var session = source.OpenAsyncSession(new SessionOptions { TransactionMode = TransactionMode.ClusterWide });
+                await session.StoreAsync(entity);
+                await session.SaveChangesAsync();
+
+                var operation = await source.Smuggler.ExportAsync(new DatabaseSmugglerExportOptions(), documentStore.Smuggler);
+                await operation.WaitForCompletionAsync(TimeSpan.FromMinutes(1));
+            }
+
+            await LoadAndDeleteWhileUpdated(nodes, documentStore.Database, entity.Id);
+        }
+
+        private static async Task LoadAndDeleteWhileUpdated(List<RavenServer> nodes, string database, string entityId)
+        {
+            using var disposable = LocalGetDocumentStores(nodes, database, out var stores);
+
+            var amre = new AsyncManualResetEvent();
+            var amre2 = new AsyncManualResetEvent();
+            var task = Task.Run(async () =>
+            {
+                using var session = stores[0].OpenAsyncSession(new SessionOptions {TransactionMode = TransactionMode.ClusterWide});
+                var loaded = await session.LoadAsync<TestObj>(entityId);
+                amre.Set();
+
+                session.Delete(loaded);
+
+                await amre2.WaitAsync();
+                await Assert.ThrowsAnyAsync<ConcurrencyException>(() => session.SaveChangesAsync());
+            });
+            await amre.WaitAsync();
+            using (var session = stores[1].OpenAsyncSession(new SessionOptions {TransactionMode = TransactionMode.ClusterWide}))
+            {
+                var loaded = await session.LoadAsync<TestObj>(entityId);
+                loaded.Prop = "Changed";
+                await session.SaveChangesAsync();
+                amre2.Set();
+            }
+
+            await task;
+        }
+
+        [Fact]
+        public async Task ClusterWideTransaction_WhenLoadAndUpdateWhileDeleted_ShouldSucceedOnlyInTheFirst()
+        {
+            var (nodes, leader) = await CreateRaftCluster(3, shouldRunInMemory: false);
+
+            using var documentStore = GetDocumentStore(new Options {Server = leader, ReplicationFactor = nodes.Count});
+
+            var entity = new TestObj();
+            using (var session = documentStore.OpenAsyncSession(new SessionOptions { TransactionMode = TransactionMode.ClusterWide }))
+            {
+                await session.StoreAsync(entity);
+                await session.SaveChangesAsync();
+            }
+
+            await LoadAndUpdateWhileDeleted(nodes, documentStore.Database, entity.Id);
+        }
+        
+        [Fact]
+        public async Task ClusterWideTransaction_WhenImportThenLoadAndUpdateWhileDeleted_ShouldSucceedOnlyInTheFirst()
+        {
+            var (nodes, leader) = await CreateRaftCluster(3);
+            using var documentStore = GetDocumentStore(new Options { Server = leader, ReplicationFactor = nodes.Count });
+
+            var entity = new TestObj();
+            using (var source = GetDocumentStore())
+            {
+                using var session = source.OpenAsyncSession(new SessionOptions { TransactionMode = TransactionMode.ClusterWide });
+                await session.StoreAsync(entity);
+                await session.SaveChangesAsync();
+
+                var operation = await source.Smuggler.ExportAsync(new DatabaseSmugglerExportOptions(), documentStore.Smuggler);
+                await operation.WaitForCompletionAsync(TimeSpan.FromMinutes(1));
+                WaitForUserToContinueTheTest(source);
+            }
+
+            await LoadAndUpdateWhileDeleted(nodes, documentStore.Database, entity.Id);
+        }
+
+        private static async Task LoadAndUpdateWhileDeleted(List<RavenServer> nodes, string database, string entityId)
+        {
+            using var disposable = LocalGetDocumentStores(nodes, database, out var stores);
+
+            var amre = new AsyncManualResetEvent();
+            var amre2 = new AsyncManualResetEvent();
+            var task = Task.Run(async () =>
+            {
+                using var session = stores[0].OpenAsyncSession(new SessionOptions {TransactionMode = TransactionMode.ClusterWide});
+                var loaded = await session.LoadAsync<TestObj>(entityId);
+                amre.Set();
+
+                loaded.Prop = "Changed";
+
+                await amre2.WaitAsync();
+                await Assert.ThrowsAnyAsync<ConcurrencyException>(() => session.SaveChangesAsync());
+            });
+            await amre.WaitAsync();
+            using (var session = stores[1].OpenAsyncSession(new SessionOptions {TransactionMode = TransactionMode.ClusterWide}))
+            {
+                var loaded = await session.LoadAsync<TestObj>(entityId);
+                session.Delete(loaded);
+                await session.SaveChangesAsync();
+
+                amre2.Set();
+            }
+
+            await task;
+        }
+
+
+        private static IDisposable LocalGetDocumentStores(List<RavenServer> nodes, string database, out IDocumentStore[] stores)
+        {
+            stores = new IDocumentStore[nodes.Count];
+            var internalStore = stores;
+            var disposable = new DisposableAction(() =>
+            {
+                foreach (var s in internalStore)
+                {
+                    try
+                    {
+                        s?.Dispose();
+                    }
+                    catch
+                    {
+                        // ignored
+                    }
+                }
+            });
+
+            for (int i = 0; i < nodes.Count; i++)
+            {
+                var store = new DocumentStore
+                {
+                    Urls = new[] {nodes[i].WebUrl}, Database = database, Conventions = new DocumentConventions {DisableTopologyUpdates = true}
+                }.Initialize();
+                stores[i] = store;
+            }
+
+            return disposable;
+        }
+    }
+}

--- a/test/RachisTests/DatabaseCluster/AtomicClusterReadWriteTests.cs
+++ b/test/RachisTests/DatabaseCluster/AtomicClusterReadWriteTests.cs
@@ -1,19 +1,20 @@
 ﻿using System;
 using System.Collections.Concurrent;
 using System.Collections.Generic;
+using System.IO;
 using System.Linq;
 using System.Threading;
 using System.Threading.Tasks;
 using FastTests.Server.Replication;
 using Raven.Client.Documents;
 using Raven.Client.Documents.Conventions;
+using Raven.Client.Documents.Operations.Backups;
 using Raven.Client.Documents.Operations.CompareExchange;
 using Raven.Client.Documents.Session;
 using Raven.Client.Documents.Smuggler;
 using Raven.Client.Exceptions;
 using Raven.Client.Util;
 using Raven.Server;
-using Raven.Tests.Core.Utils.Entities;
 using Sparrow.Server;
 using Xunit;
 using Xunit.Abstractions;
@@ -45,7 +46,7 @@ namespace RachisTests.DatabaseCluster
                 await session.SaveChangesAsync();
             }
 
-            var result = await store.Operations.SendAsync(new GetCompareExchangeValuesOperation<User>(""));
+            var result = await store.Operations.SendAsync(new GetCompareExchangeValuesOperation<TestObj>(""));
             Assert.Single(result);
             Assert.EndsWith(entity.Id, result.Single().Key, StringComparison.OrdinalIgnoreCase);
         }
@@ -63,7 +64,7 @@ namespace RachisTests.DatabaseCluster
                 await session.SaveChangesAsync();
             }
 
-            var result = await store.Operations.SendAsync(new GetCompareExchangeValuesOperation<User>(""));
+            var result = await store.Operations.SendAsync(new GetCompareExchangeValuesOperation<TestObj>(""));
             Assert.Empty(result);
         }
 
@@ -113,7 +114,7 @@ namespace RachisTests.DatabaseCluster
         }
 
         [Fact]
-        public async Task ClusterWideTransaction_WhenLoadAndDeleteWhileUpdated_ShouldSucceedOnlyInTheFirst()
+        public async Task ClusterWideTransaction_WhenLoadAndDeleteWhileUpdated_ShouldFailDeletion()
         {
             var (nodes, leader) = await CreateRaftCluster(3, shouldRunInMemory: false);
 
@@ -130,7 +131,7 @@ namespace RachisTests.DatabaseCluster
         }
 
         [Fact]
-        public async Task ClusterWideTransaction_WhenImportThenLoadAndDeleteWhileUpdated_ShouldSucceedOnlyInTheFirst()
+        public async Task ClusterWideTransaction_WhenImportThenLoadAndDeleteWhileUpdated_ShouldFailDeletion()
         {
             var (nodes, leader) = await CreateRaftCluster(3);
             using var documentStore = GetDocumentStore(new Options { Server = leader, ReplicationFactor = nodes.Count });
@@ -161,7 +162,7 @@ namespace RachisTests.DatabaseCluster
             var amre2 = new AsyncManualResetEvent();
             var task = Task.Run(async () =>
             {
-                using var session = stores[0].OpenAsyncSession(new SessionOptions {TransactionMode = TransactionMode.ClusterWide});
+                using var session = stores[0].OpenAsyncSession(new SessionOptions { TransactionMode = TransactionMode.ClusterWide });
                 var loaded = await session.LoadAsync<TestObj>(entityId);
                 amre.Set();
 
@@ -171,7 +172,7 @@ namespace RachisTests.DatabaseCluster
                 await Assert.ThrowsAnyAsync<ConcurrencyException>(() => session.SaveChangesAsync());
             });
             await amre.WaitAsync();
-            using (var session = stores[1].OpenAsyncSession(new SessionOptions {TransactionMode = TransactionMode.ClusterWide}))
+            using (var session = stores[1].OpenAsyncSession(new SessionOptions { TransactionMode = TransactionMode.ClusterWide }))
             {
                 var loaded = await session.LoadAsync<TestObj>(entityId);
                 loaded.Prop = "Changed";
@@ -182,8 +183,151 @@ namespace RachisTests.DatabaseCluster
             await task;
         }
 
+        [Theory]
+        [InlineData(1)]
+        [InlineData(1, false)]
+        [InlineData(2 * 1024)]// DatabaseDestination.DatabaseCompareExchangeActions.BatchSize
+        public async Task ClusterWideTransaction_WhenRestoreFromIncrementalBackupAfterStoreAndDelete_ShouldDeleteInTheDestination(int count, bool withLoad = true)
+        {
+            var backupPath = NewDataPath(suffix: "BackupFolder");
+
+            var (nodes, leader) = await CreateRaftCluster(3);
+            using var documentStore = GetDocumentStore(new Options { Server = leader, ReplicationFactor = nodes.Count });
+
+            var notDelete = $"TestObjs/{count}";
+            using (var source = GetDocumentStore())
+            {
+                var config = new PeriodicBackupConfiguration { LocalSettings = new LocalSettings { FolderPath = backupPath }, IncrementalBackupFrequency = "0 0 */12 * *" };
+                var backupTaskId = (await source.Maintenance.SendAsync(new UpdatePeriodicBackupOperation(config))).TaskId;
+
+                using (var session = source.OpenAsyncSession(new SessionOptions { TransactionMode = TransactionMode.ClusterWide}))
+                {
+                    for (int i = 0; i < count; i++)
+                    {
+                        await session.StoreAsync(new TestObj(), $"TestObjs/{i}");
+                    }
+                    await session.StoreAsync(new TestObj(), notDelete);
+                    await session.SaveChangesAsync();
+                }
+
+                var backupStatus = await source.Maintenance.SendAsync(new StartBackupOperation(false, backupTaskId));
+                await backupStatus.WaitForCompletionAsync();
+
+                using (var session = source.OpenAsyncSession(new SessionOptions { TransactionMode = TransactionMode.ClusterWide }))
+                {
+                    session.Advanced.MaxNumberOfRequestsPerSession += count;
+                    for (int i = 0; i < count; i++)
+                    {
+                        if(withLoad)
+                            await session.LoadAsync<TestObj>($"TestObjs/{i}");
+                        session.Delete($"TestObjs/{i}");
+                    }
+                    
+                    await session.SaveChangesAsync();
+                }
+
+                var backupStatus2 = await source.Maintenance.SendAsync(new StartBackupOperation(false, backupTaskId));
+                await backupStatus2.WaitForCompletionAsync();
+
+                await documentStore.Smuggler.ImportIncrementalAsync(new DatabaseSmugglerImportOptions(), Directory.GetDirectories(backupPath).First());
+            }
+
+            await AssertClusterWaitForNotNull(nodes, documentStore.Database, async s =>
+            {
+                using var session = s.OpenAsyncSession();
+                return await session.LoadAsync<TestObj>(notDelete);
+            });
+
+            var r = await AssertWaitForSingleAsync(async () => await documentStore.Operations.SendAsync(new GetCompareExchangeValuesOperation<TestObj>("")));
+            Assert.EndsWith(notDelete, r.Single().Key, StringComparison.OrdinalIgnoreCase);
+        }
+
+        [Theory]
+        [InlineData(1)]
+        [InlineData(2 * 1024)]// DatabaseDestination.DatabaseCompareExchangeActions.BatchSize
+        public async Task ClusterWideTransaction_WhenRestoreFromIncrementalBackupAfterStoreAndUpdate_ShouldCompleteImportWithNoException(int count)
+        {
+            const string modified = "Modified";
+            var backupPath = NewDataPath(suffix: "BackupFolder");
+
+            var (nodes, leader) = await CreateRaftCluster(3);
+            using var documentStore = GetDocumentStore(new Options { Server = leader, ReplicationFactor = nodes.Count });
+
+            var notToModify = $"TestObjs/{count}";
+            using (var source = GetDocumentStore())
+            {
+                var config = new PeriodicBackupConfiguration { LocalSettings = new LocalSettings { FolderPath = backupPath }, IncrementalBackupFrequency = "0 0 */12 * *" };
+                var backupTaskId = (await source.Maintenance.SendAsync(new UpdatePeriodicBackupOperation(config))).TaskId;
+
+                using (var session = source.OpenAsyncSession(new SessionOptions { TransactionMode = TransactionMode.ClusterWide}))
+                {
+                    for (int i = 0; i < count; i++)
+                    {
+                        await session.StoreAsync(new TestObj(), $"TestObjs/{i}");
+                    }
+                    await session.StoreAsync(new TestObj(), notToModify);
+                    await session.SaveChangesAsync();
+                }
+
+                var backupStatus = await source.Maintenance.SendAsync(new StartBackupOperation(false, backupTaskId));
+                await backupStatus.WaitForCompletionAsync();
+
+                using (var session = source.OpenAsyncSession(new SessionOptions { TransactionMode = TransactionMode.ClusterWide }))
+                {
+                    session.Advanced.MaxNumberOfRequestsPerSession += count;
+
+                    for (int i = 0; i < count; i++)
+                    {
+                        var r = await session.LoadAsync<TestObj>($"TestObjs/{i}");
+                        r.Prop = modified;
+                        await session.StoreAsync(r);
+                    }
+
+                    await session.SaveChangesAsync();
+                }
+
+                var backupStatus2 = await source.Maintenance.SendAsync(new StartBackupOperation(false, backupTaskId));
+                await backupStatus2.WaitForCompletionAsync();
+
+                await documentStore.Smuggler.ImportIncrementalAsync(new DatabaseSmugglerImportOptions(), Directory.GetDirectories(backupPath).First());
+            }
+
+            await AssertClusterWaitForNotNull(nodes, documentStore.Database, async s =>
+            {
+                using var session = s.OpenAsyncSession();
+                return await session.LoadAsync<TestObj>(notToModify);
+            });
+            
+            await AssertClusterWaitForValue(nodes, documentStore.Database, async s =>
+            {
+                using var session = s.OpenAsyncSession();
+                var loadAsync = await session.LoadAsync<TestObj>($"TestObjs/{count - 1}");
+                return loadAsync?.Prop;
+            }, modified);
+            
+            await AssertWaitForCountAsync(async () => await documentStore.Operations.SendAsync(new GetCompareExchangeValuesOperation<TestObj>("")), count + 1);
+        }
+
         [Fact]
-        public async Task ClusterWideTransaction_WhenLoadAndUpdateWhileDeleted_ShouldSucceedOnlyInTheFirst()
+        public async Task ClusterWideTransaction_WhenRestoreFromIncrementalBackupAfterStoreAndUpdateWithoutLoad_ShouldFail()
+        {
+            const string docId = "TestObjs/1";
+            using var source = GetDocumentStore();
+            using (var session = source.OpenAsyncSession(new SessionOptions { TransactionMode = TransactionMode.ClusterWide }))
+            {
+                await session.StoreAsync(new TestObj(), docId);
+                await session.SaveChangesAsync();
+            }
+
+            using (var session = source.OpenAsyncSession(new SessionOptions { TransactionMode = TransactionMode.ClusterWide }))
+            {
+                await session.StoreAsync(new TestObj { Prop = "Modified" }, docId);
+                await Assert.ThrowsAnyAsync<ConcurrencyException>(async () => await session.SaveChangesAsync());
+            }
+        }
+
+        [Fact]
+        public async Task ClusterWideTransaction_WhenLoadAndUpdateWhileDeleted_ShouldFailUpdate()
         {
             var (nodes, leader) = await CreateRaftCluster(3, shouldRunInMemory: false);
 
@@ -200,7 +344,7 @@ namespace RachisTests.DatabaseCluster
         }
         
         [Fact]
-        public async Task ClusterWideTransaction_WhenImportThenLoadAndUpdateWhileDeleted_ShouldSucceedOnlyInTheFirst()
+        public async Task ClusterWideTransaction_WhenImportThenLoadAndUpdateWhileDeleted_ShouldFailUpdate()
         {
             var (nodes, leader) = await CreateRaftCluster(3);
             using var documentStore = GetDocumentStore(new Options { Server = leader, ReplicationFactor = nodes.Count });
@@ -254,10 +398,16 @@ namespace RachisTests.DatabaseCluster
             await task;
         }
 
-
         private static IDisposable LocalGetDocumentStores(List<RavenServer> nodes, string database, out IDocumentStore[] stores)
         {
-            stores = new IDocumentStore[nodes.Count];
+            var urls = nodes.Select(n => n.WebUrl).ToArray();
+
+            return LocalGetDocumentStores(urls, database, out stores);
+        }
+
+        private static IDisposable LocalGetDocumentStores(string[] urls, string database, out IDocumentStore[] stores)
+        {
+            stores = new IDocumentStore[urls.Length];
             var internalStore = stores;
             var disposable = new DisposableAction(() =>
             {
@@ -274,12 +424,9 @@ namespace RachisTests.DatabaseCluster
                 }
             });
 
-            for (int i = 0; i < nodes.Count; i++)
+            for (int i = 0; i < urls.Length; i++)
             {
-                var store = new DocumentStore
-                {
-                    Urls = new[] {nodes[i].WebUrl}, Database = database, Conventions = new DocumentConventions {DisableTopologyUpdates = true}
-                }.Initialize();
+                var store = new DocumentStore {Urls = new[] {urls[i]}, Database = database, Conventions = new DocumentConventions {DisableTopologyUpdates = true}}.Initialize();
                 stores[i] = store;
             }
 

--- a/test/SlowTests/Cluster/ClusterTransactionTests.cs
+++ b/test/SlowTests/Cluster/ClusterTransactionTests.cs
@@ -322,7 +322,10 @@ namespace SlowTests.Cluster
                 // we kill one server so we would not clean the pending cluster transactions.
                 await DisposeAndRemoveServer(toDispose);
 
-                using (var session = store.OpenAsyncSession(new SessionOptions {TransactionMode = TransactionMode.ClusterWide}))
+                using (var session = store.OpenAsyncSession(new SessionOptions {
+                    TransactionMode = TransactionMode.ClusterWide,
+                    DisableAtomicDocumentWritesInClusterWideTransaction = true
+                }))
                 {
                     session.Advanced.ClusterTransaction.CreateCompareExchangeValue("usernames/karmel", user1);
                     await session.StoreAsync(user1, "foo/bar");
@@ -401,7 +404,8 @@ namespace SlowTests.Cluster
             using (var store = GetDocumentStore())
             using (var session = store.OpenAsyncSession(new SessionOptions
             {
-                TransactionMode = TransactionMode.ClusterWide
+                TransactionMode = TransactionMode.ClusterWide,
+                DisableAtomicDocumentWritesInClusterWideTransaction = true
             }))
             {
                 session.Advanced.ClusterTransaction.CreateCompareExchangeValue("usernames/ayende", user1);
@@ -472,7 +476,8 @@ namespace SlowTests.Cluster
             {
                 using (var session = store.OpenAsyncSession(new SessionOptions
                 {
-                    TransactionMode = TransactionMode.ClusterWide
+                    TransactionMode = TransactionMode.ClusterWide,
+                    DisableAtomicDocumentWritesInClusterWideTransaction = true
                 }))
                 {
                     session.Advanced.ClusterTransaction.CreateCompareExchangeValue("usernames/ayende", user1);
@@ -484,7 +489,8 @@ namespace SlowTests.Cluster
 
                 using (var session = store.OpenAsyncSession(new SessionOptions
                 {
-                    TransactionMode = TransactionMode.ClusterWide
+                    TransactionMode = TransactionMode.ClusterWide,
+                    DisableAtomicDocumentWritesInClusterWideTransaction = true
                 }))
                 {
                     session.Advanced.ClusterTransaction.DeleteCompareExchangeValue("usernames/ayende", store.GetLastTransactionIndex(store.Database) ?? 0);
@@ -496,7 +502,8 @@ namespace SlowTests.Cluster
 
                 using (var session = store.OpenAsyncSession(new SessionOptions
                 {
-                    TransactionMode = TransactionMode.ClusterWide
+                    TransactionMode = TransactionMode.ClusterWide,
+                    DisableAtomicDocumentWritesInClusterWideTransaction = true
                 }))
                 {
                     session.Advanced.ClusterTransaction.CreateCompareExchangeValue("usernames/ayende", user1);
@@ -834,7 +841,8 @@ namespace SlowTests.Cluster
 
                 using (var session = store.OpenAsyncSession(new SessionOptions
                 {
-                    TransactionMode = TransactionMode.ClusterWide
+                    TransactionMode = TransactionMode.ClusterWide,
+                    DisableAtomicDocumentWritesInClusterWideTransaction = true
                 }))
                 {
                     await session.StoreAsync(new User { Name = "Aviv1" }, "users/1");
@@ -843,7 +851,8 @@ namespace SlowTests.Cluster
 
                 using (var session = store.OpenAsyncSession(new SessionOptions
                 {
-                    TransactionMode = TransactionMode.ClusterWide
+                    TransactionMode = TransactionMode.ClusterWide,
+                    DisableAtomicDocumentWritesInClusterWideTransaction = true
                 }))
                 {
                     await session.StoreAsync(new User { Name = "Aviv2" }, "users/1");
@@ -855,7 +864,8 @@ namespace SlowTests.Cluster
 
                 using (var session = store.OpenAsyncSession(new SessionOptions
                 {
-                    TransactionMode = TransactionMode.ClusterWide
+                    TransactionMode = TransactionMode.ClusterWide,
+                    DisableAtomicDocumentWritesInClusterWideTransaction = true
                 }))
                 {
                     session.Delete("users/1");
@@ -883,7 +893,8 @@ namespace SlowTests.Cluster
             {
                 using (var session = store.OpenAsyncSession(new SessionOptions
                 {
-                    TransactionMode = TransactionMode.ClusterWide
+                    TransactionMode = TransactionMode.ClusterWide,
+                    DisableAtomicDocumentWritesInClusterWideTransaction = true
                 }))
                 {
                     await session.StoreAsync(new User { Name = "Aviv1" }, "users/1");
@@ -892,7 +903,8 @@ namespace SlowTests.Cluster
 
                 using (var session = store.OpenAsyncSession(new SessionOptions
                 {
-                    TransactionMode = TransactionMode.ClusterWide
+                    TransactionMode = TransactionMode.ClusterWide,
+                    DisableAtomicDocumentWritesInClusterWideTransaction = true
                 }))
                 {
                     await session.StoreAsync(new Employee { FirstName = "Aviv2" }, "users/1");
@@ -911,7 +923,8 @@ namespace SlowTests.Cluster
 
                 using (var session = store.OpenAsyncSession(new SessionOptions
                 {
-                    TransactionMode = TransactionMode.ClusterWide
+                    TransactionMode = TransactionMode.ClusterWide,
+                    DisableAtomicDocumentWritesInClusterWideTransaction = true
                 }))
                 {
                     await session.StoreAsync(new User { Name = "Aviv1" }, "users/1");
@@ -920,7 +933,8 @@ namespace SlowTests.Cluster
 
                 using (var session = store.OpenAsyncSession(new SessionOptions
                 {
-                    TransactionMode = TransactionMode.ClusterWide
+                    TransactionMode = TransactionMode.ClusterWide,
+                    DisableAtomicDocumentWritesInClusterWideTransaction = true
                 }))
                 {
                     await session.StoreAsync(new Employee { FirstName = "Aviv2" }, "users/1");

--- a/test/SlowTests/Cluster/NServiceBusCaseTest.cs
+++ b/test/SlowTests/Cluster/NServiceBusCaseTest.cs
@@ -1,0 +1,137 @@
+﻿using System;
+using System.Collections.Generic;
+using System.Linq;
+using System.Text;
+using System.Threading.Tasks;
+using Raven.Client.Documents;
+using Raven.Client.Documents.Conventions;
+using Raven.Client.Documents.Session;
+using Raven.Client.Http;
+using Raven.Client.ServerWide.Operations;
+using Tests.Infrastructure;
+using Xunit;
+using Xunit.Abstractions;
+
+namespace SlowTests.Cluster
+{
+    public class NServiceBusCaseTest : ClusterTestBase
+    {
+        public NServiceBusCaseTest(ITestOutputHelper output) : base(output)
+        {
+        }
+
+        const string SagaDataIdPrefix = "SampleSagaDatas";
+        const int NumberOfConcurrentUpdates = 50;
+        const int MaxRetryAttempts = 50;
+
+        [Fact]
+        public async Task ConcurrentArrayUpdate()
+        {
+            var cluster = await CreateRaftCluster(3, watcherCluster: true);
+            using (var store = GetDocumentStore(new Options
+            {
+                ModifyDocumentStore = s => s.Conventions = new DocumentConventions
+                {
+                    ReadBalanceBehavior = ReadBalanceBehavior.RoundRobin, 
+                    LoadBalanceBehavior = LoadBalanceBehavior.UseSessionContext
+                },
+                Server = cluster.Leader,
+                ReplicationFactor = 3
+            }))
+            {
+
+                var sagaDataStableId = SagaDataIdPrefix + "/" + Guid.NewGuid();
+                var results = await Execute(store, sagaDataStableId);
+
+                await ValidateResults(store, sagaDataStableId, results);
+
+                var failedUpdates = results.Where(r => !r.Succeeded).ToList();
+
+                if (failedUpdates.Any())
+                {
+                    Assert.True(false, $"{failedUpdates.Count} updated failed. {string.Join(Environment.NewLine, failedUpdates.Select(f => f.ErrorMessage))}");
+                }
+
+                using var checkSession = store.OpenAsyncSession();
+                var sagaData = await checkSession.LoadAsync<SampleSagaData>(sagaDataStableId);
+
+                var diff = Enumerable.Range(0, NumberOfConcurrentUpdates - 1)
+                    .Except(failedUpdates.Select(fu => fu.Index))
+                    .Except(sagaData.HandledIndexes)
+                    .ToList();
+
+                if (diff.Any())
+                {
+                    Assert.True(false, $"Cannot find an update for the following index(es): {string.Join(Environment.NewLine, diff)}");
+                }
+            }
+        }
+
+        private static async Task<bool> ValidateResults(IDocumentStore store, string sagaDataStableId, (bool Succeeded, int Index, string ErrorMessage)[] results)
+        {
+            using var checkSession = store.OpenAsyncSession();
+            var sagaData = await checkSession.LoadAsync<SampleSagaData>(sagaDataStableId);
+
+            var updatesFailedDueToConcurrency = results.Where(r => !r.Succeeded).ToList();
+
+            var diff = Enumerable.Range(0, NumberOfConcurrentUpdates - 1)
+                .Except(updatesFailedDueToConcurrency.Select(fu => fu.Index))
+                .Except(sagaData.HandledIndexes)
+                .ToList();
+
+            return diff.Count == 0;
+        }
+
+        static async Task<(bool Succeeded, int Index, string ErrorMessage)[]> Execute(IDocumentStore store, string sagaDataStableId)
+        {
+
+            using (var storeItOnceSession = store.OpenAsyncSession(new SessionOptions() {TransactionMode = TransactionMode.ClusterWide}))
+            {
+                await storeItOnceSession.StoreAsync(new SampleSagaData() {Id = sagaDataStableId});
+                await storeItOnceSession.SaveChangesAsync();
+            }
+
+            var pendingTasks = new List<Task<(bool Succeeded, int Index, string ErrorMessage)>>();
+            for (var i = 0; i < NumberOfConcurrentUpdates; i++)
+            {
+                pendingTasks.Add(TouchSaga(i, store, sagaDataStableId));
+            }
+
+            return await Task.WhenAll(pendingTasks);
+        }
+
+        static async Task<(bool, int, string)> TouchSaga(int index, IDocumentStore store, string sagaDataStableId)
+        {
+            var attempts = 0;
+            Exception lastError = null;
+
+            while (attempts <= MaxRetryAttempts)
+            {
+                try
+                {
+                    using var session = store.OpenAsyncSession(new SessionOptions() {TransactionMode = TransactionMode.ClusterWide});
+                    session.Advanced.SessionInfo.SetContext(index.ToString()); // distribute the writes
+                    var sagaData = await session.LoadAsync<SampleSagaData>(sagaDataStableId);
+                    sagaData.HandledIndexes.Add(index);
+                    await session.SaveChangesAsync();
+
+                    return (true, index, string.Empty);
+                }
+                catch (Exception ex)
+                {
+                    attempts++;
+                    lastError = ex;
+                    await Task.Delay(50);
+                }
+            }
+
+            return (false, index, $"Failed after {attempts} attempts, while handling index {index}, last error: {lastError?.Message}");
+        }
+    }
+
+    class SampleSagaData
+    {
+        public string Id { get; set; }
+        public List<int> HandledIndexes { get; set; } = new List<int>();
+    }
+}

--- a/test/SlowTests/Issues/RavenDB-11795.cs
+++ b/test/SlowTests/Issues/RavenDB-11795.cs
@@ -3,6 +3,7 @@ using System.Globalization;
 using System.Linq;
 using FastTests;
 using Raven.Client.Documents.Indexes;
+using Raven.Server.Utils;
 using Xunit;
 using Xunit.Abstractions;
 
@@ -114,6 +115,8 @@ namespace SlowTests.Issues
                     session.SaveChanges();
                 }
 
+                CultureHelper.Cultures.TryGetValue(CultureInfo.CurrentCulture.Name, out var culture);
+
                 using (var session = store.OpenSession())
                 {
                     var query = session.Query<Booking>()
@@ -124,14 +127,14 @@ namespace SlowTests.Issues
                         });
 
                     Assert.Equal("from 'Bookings' as x where x.FirstName = $p0 " +
-                                 $"select {{ StartDate : toStringWithFormat(x.Start, \"{CultureInfo.CurrentCulture.Name}\") }}"
+                                 $"select {{ StartDate : toStringWithFormat(x.Start, \"{culture.Name}\") }}"
                         , query.ToString());
 
                     var result = query.Single();
 
                     // Assert
                     Assert.NotNull(result);
-                    Assert.Equal(start.ToString(CultureInfo.CurrentCulture), result.StartDate);
+                    Assert.Equal(start.ToString(culture), result.StartDate);
 
                 }
             }

--- a/test/SlowTests/Issues/RavenDB-16614.cs
+++ b/test/SlowTests/Issues/RavenDB-16614.cs
@@ -1,0 +1,329 @@
+﻿using System.Collections.Generic;
+using System.Linq;
+using System.Runtime.CompilerServices;
+using System.Threading;
+using System.Threading.Tasks;
+using FastTests;
+using FastTests.Server.Replication;
+using Raven.Client;
+using Raven.Client.Documents.Session;
+using Raven.Client.Documents.Smuggler;
+using Raven.Client.Exceptions;
+using Raven.Client.ServerWide.Operations;
+using Raven.Server;
+using Raven.Server.Config;
+using Raven.Server.Documents.Replication;
+using Raven.Server.ServerWide.Commands;
+using Raven.Server.Utils;
+using Xunit;
+using Xunit.Abstractions;
+
+namespace SlowTests.Issues
+{
+    public class RavenDB_16614 : ReplicationTestBase
+    {
+        public RavenDB_16614(ITestOutputHelper output) : base(output)
+        {
+        }
+
+        protected override RavenServer GetNewServer(ServerCreationOptions options = null, [CallerMemberName] string caller = null)
+        {
+            if (options == null)
+            {
+                options = new ServerCreationOptions();
+            }
+
+            if (options.CustomSettings == null)
+                options.CustomSettings = new Dictionary<string, string>();
+
+            options.CustomSettings[RavenConfiguration.GetKey(x => x.Cluster.OperationTimeout)] = "60";
+            options.CustomSettings[RavenConfiguration.GetKey(x => x.Cluster.StabilizationTime)] = "10";
+            options.CustomSettings[RavenConfiguration.GetKey(x => x.Cluster.TcpConnectionTimeout)] = "30000";
+
+            return base.GetNewServer(options, caller);
+        }
+        private class User
+        {
+            public string Name;
+        }
+        
+        [Fact]
+        public async Task WillDeleteOrphanedAtomicGuards_AfterRestoreFromBackup()
+        {
+            var leader = await CreateRaftClusterAndGetLeader(1);
+            using var store = GetDocumentStore(new Options {Server = leader, ReplicationFactor = 3});
+
+            using (var session = store.OpenAsyncSession(new SessionOptions {TransactionMode = TransactionMode.ClusterWide}))
+            {
+                session.Advanced.ClusterTransaction.CreateCompareExchangeValue(
+                    ClusterTransactionCommand.GetAtomicGuardKey("users/phoebe"),
+                    "users/pheobe"
+                );// this forces us to create an orphan!
+                await session.StoreAsync(new User {Name = "arava"}, "users/arava");
+                await session.SaveChangesAsync();
+            }
+           
+            string tempFileName = GetTempFileName();
+
+            var op = await store.Smuggler.ExportAsync(new DatabaseSmugglerExportOptions(), tempFileName, CancellationToken.None);
+            await op.WaitForCompletionAsync();
+
+            // we are simulating a scenario where we took a backup midway through removing an atomic guard
+
+            using var store2 = GetDocumentStore(caller: store.Database + "_Restored");
+
+            op = await store2.Smuggler.ImportAsync(new DatabaseSmugglerImportOptions(), tempFileName, CancellationToken.None);
+            await op.WaitForCompletionAsync();
+            
+            using (var session = store2.OpenAsyncSession(new SessionOptions
+            {
+                TransactionMode = TransactionMode.ClusterWide
+            }))
+            {
+                var val = await session.Advanced.ClusterTransaction.GetCompareExchangeValueAsync<string>(
+                    ClusterTransactionCommand.GetAtomicGuardKey("users/phoebe")
+                );
+                Assert.Null(val);
+
+                val = await session.Advanced.ClusterTransaction.GetCompareExchangeValueAsync<string>(
+                    ClusterTransactionCommand.GetAtomicGuardKey("users/arava")
+                );
+                var arava = await session.LoadAsync<User>("users/arava");
+                var cv  = session.Advanced.GetChangeVectorFor(arava);
+                var cti = cv.ToChangeVectorList().Single(x=>x.NodeTag == ChangeVectorParser.TrxnInt);
+                var record = await store2.Maintenance.Server.SendAsync(new GetDatabaseRecordOperation(store2.Database));
+                Assert.Equal(val.Index, cti.Etag);
+            }
+        }
+        
+        [Fact]
+        public async Task CanHandleConflictsWithClusterTransactionIndex()
+        {
+            var leader = await CreateRaftClusterAndGetLeader(1);
+            using var store = GetDocumentStore(new Options {Server = leader, ReplicationFactor = 3});
+            using var store2 = GetDocumentStore(new Options {Server = leader, ReplicationFactor = 3});
+
+            using (var session = store.OpenAsyncSession(new SessionOptions {TransactionMode = TransactionMode.ClusterWide}))
+            {
+                await session.StoreAsync(new User {Name = "arava"}, "users/arava");
+                await session.StoreAsync(new User {Name = "marker"}, "marker");
+                await session.SaveChangesAsync();
+            }
+
+            using (var session2 = store2.OpenAsyncSession(new SessionOptions {TransactionMode = TransactionMode.ClusterWide}))
+            {
+                await session2.StoreAsync(new User {Name = "Arava"}, "users/arava");
+                await session2.SaveChangesAsync();
+            }
+
+            await SetupReplicationAsync(store, store2);
+
+            Assert.True(WaitForDocument(store2, "marker"));
+            WaitForUserToContinueTheTest(store2);
+            using (var session2 = store2.OpenAsyncSession(new SessionOptions {TransactionMode = TransactionMode.ClusterWide}))
+            {
+                var arava = await session2.LoadAsync<User>("users/arava");
+                var cv  = session2.Advanced.GetChangeVectorFor(arava);
+                var cti = cv.ToChangeVectorList().Where(x=>x.NodeTag == ChangeVectorParser.TrxnInt).ToList();
+                Assert.Equal(2, cti.Count);
+                Assert.Equal("Arava", arava.Name);
+            }
+        }
+        
+        [Fact]
+        public async Task WillMarkClusterWideDocumentsWithTransactionId()
+        {
+            var leader = await CreateRaftClusterAndGetLeader(1);
+            using var store = GetDocumentStore(new Options {Server = leader, ReplicationFactor = 3});
+
+            using (var session = store.OpenAsyncSession(new SessionOptions {TransactionMode = TransactionMode.ClusterWide}))
+            {
+                await session.StoreAsync(new User {Name = "arava"}, "users/arava");
+                await session.SaveChangesAsync();
+            }
+
+            using (var session = store.OpenAsyncSession(new SessionOptions { TransactionMode = TransactionMode.ClusterWide }))
+            {
+                var arava = await session.LoadAsync<User>("users/arava");
+                var metadata = session.Advanced.GetMetadataFor(arava);
+                var cv  = session.Advanced.GetChangeVectorFor(arava);
+                var cti = cv.ToChangeVectorList().Single(x=>x.NodeTag == ChangeVectorParser.TrxnInt);
+                var guard = await session.Advanced.ClusterTransaction.GetCompareExchangeValueAsync<object>(ClusterTransactionCommand.GetAtomicGuardKey("users/arava"));
+                Assert.Equal(cti.Etag, guard.Index);
+            }
+        }
+
+        [Fact]
+        public async Task WillGetGoodErrorOnMismatchClusterTxId()
+        {
+            var leader = await CreateRaftClusterAndGetLeader(1);
+            using var store = GetDocumentStore(new Options { Server = leader, ReplicationFactor = 3 });
+
+            using (var session = store.OpenAsyncSession(new SessionOptions { TransactionMode = TransactionMode.ClusterWide }))
+            {
+                await session.StoreAsync(new User { Name = "arava" }, "users/arava");
+                await session.SaveChangesAsync();
+            }
+
+            using (var session = store.OpenAsyncSession(new SessionOptions { TransactionMode = TransactionMode.ClusterWide }))
+            {
+                var arava = await session.LoadAsync<User>("users/arava");
+                
+                using (var nested = store.OpenAsyncSession(new SessionOptions { TransactionMode = TransactionMode.ClusterWide }))
+                {
+                    var arava2 = await nested.LoadAsync<User>("users/arava");
+                    arava2.Name += "nested";
+                    await nested.SaveChangesAsync();
+                }
+              
+                arava.Name += "-modified";
+                var err = await Assert.ThrowsAsync<ConcurrencyException>(() => session.SaveChangesAsync());
+                Assert.Contains("Failed to execute cluster transaction due to the following issues: " +
+                    "Guard compare exchange value 'rvn-atomic/users/arava' index does not match ", err.Message);
+            }
+        }
+
+        [Fact]
+        public async Task WillFailNormalTransactionThatDoesNotMatchAtomicGuardIndex()
+        {
+            var leader = await CreateRaftClusterAndGetLeader(1);
+            using var store = GetDocumentStore(new Options { Server = leader, ReplicationFactor = 3 });
+
+            using (var session = store.OpenAsyncSession(new SessionOptions { TransactionMode = TransactionMode.ClusterWide }))
+            {
+                await session.StoreAsync(new User { Name = "arava" }, "users/arava");
+                await session.SaveChangesAsync();
+            }
+
+            using (var session = store.OpenAsyncSession(new SessionOptions { 
+                TransactionMode = TransactionMode.SingleNode // important, NOT a cluster wide transaction
+            }))
+            {
+                var arava = await session.LoadAsync<User>("users/arava");
+                
+                using (var nested = store.OpenAsyncSession(new SessionOptions { TransactionMode = TransactionMode.ClusterWide }))
+                {
+                    var arava2 = await nested.LoadAsync<User>("users/arava");
+                    arava2.Name += "nested";
+                    await nested.SaveChangesAsync();
+                }
+                 
+                arava.Name += "-modified";
+                await Assert.ThrowsAsync<ConcurrencyException>(() => session.SaveChangesAsync());
+            }
+        }
+
+        [Fact]
+        public async Task CanDeleteCmpXchgValue()
+        {
+            var leader = await CreateRaftClusterAndGetLeader(1);
+            using var store = GetDocumentStore(new Options { Server = leader, ReplicationFactor = 3 });
+
+            using (var session = store.OpenAsyncSession(new SessionOptions { TransactionMode = TransactionMode.ClusterWide }))
+            {
+                await session.StoreAsync(new User { Name = "arava" }, "users/arava");
+                await session.SaveChangesAsync();
+            }
+            using (var session = store.OpenAsyncSession(new SessionOptions { TransactionMode = TransactionMode.ClusterWide }))
+            {
+                session.Delete("users/arava");
+                await session.SaveChangesAsync();
+            }
+
+            using (var session = store.OpenAsyncSession(new SessionOptions { TransactionMode = TransactionMode.ClusterWide }))
+            {
+                var arava = await session.LoadAsync<User>("users/arava");
+                Assert.Null(arava);
+                var guard = await session.Advanced.ClusterTransaction.GetCompareExchangeValueAsync<object>("rvn-atomic-guard/users/arava");
+                Assert.Null(guard);
+            }
+        }
+
+
+        [Fact]
+        public async Task CanModifyDocumentAfterFirstTime()
+        {
+            var leader = await CreateRaftClusterAndGetLeader(1);
+            using var store = GetDocumentStore(new Options { Server = leader, ReplicationFactor = 3 });
+
+            using (var session = store.OpenAsyncSession(new SessionOptions { TransactionMode = TransactionMode.ClusterWide }))
+            {
+                await session.StoreAsync(new User { Name = "arava" }, "users/arava");
+                await session.StoreAsync(new User { Name = "phoebe" }, "users/phoebe");
+                await session.SaveChangesAsync();
+            }
+
+            using (var session = store.OpenAsyncSession(new SessionOptions { TransactionMode = TransactionMode.ClusterWide }))
+            {
+                var arava = await session.LoadAsync<User>("users/arava");
+                arava.Name = "Arava Eini";
+                var phoebe = await session.LoadAsync<User>("users/phoebe");
+                phoebe.Name = "Phoebe Eini";
+                await session.SaveChangesAsync();
+            }
+        }
+
+        [Fact]
+        public async Task ModificationInAnotherTransactionWillFail()
+        {
+            var leader = await CreateRaftClusterAndGetLeader(1);
+            using var store = GetDocumentStore(new Options { Server = leader, ReplicationFactor = 3 });
+
+            using (var session = store.OpenAsyncSession(new SessionOptions { TransactionMode = TransactionMode.ClusterWide }))
+            {
+                await session.StoreAsync(new User { Name = "arava" }, "users/arava");
+                await session.StoreAsync(new User { Name = "phoebe" }, "users/phoebe");
+                await session.SaveChangesAsync();
+            }
+
+            using (var session = store.OpenAsyncSession(new SessionOptions { TransactionMode = TransactionMode.ClusterWide }))
+            {
+                var user = await session.LoadAsync<User>("users/arava");
+                user.Name = "Arava Eini";
+                var user2 = await session.LoadAsync<User>("users/phoebe");
+                user2.Name = "Phoebe Eini";
+
+                using (var conflictedSession = store.OpenAsyncSession(new SessionOptions {TransactionMode = TransactionMode.ClusterWide}))
+                {
+                    var conflictedArava = await conflictedSession.LoadAsync<User>("users/arava");
+                    conflictedArava.Name = "Arava!";
+                    await conflictedSession.SaveChangesAsync();
+                }
+
+                await Assert.ThrowsAsync<ConcurrencyException>(() => session.SaveChangesAsync());
+            }
+        }
+
+
+        [Fact]
+        public async Task ModificationInAnotherTransactionWillFailWithDelete()
+        {
+            var leader = await CreateRaftClusterAndGetLeader(1);
+            using var store = GetDocumentStore(new Options { Server = leader, ReplicationFactor = 3 });
+
+            using (var session = store.OpenAsyncSession(new SessionOptions { TransactionMode = TransactionMode.ClusterWide }))
+            {
+                await session.StoreAsync(new User { Name = "arava" }, "users/arava");
+                await session.StoreAsync(new User { Name = "phoebe" }, "users/phoebe");
+                await session.SaveChangesAsync();
+            }
+
+            using (var session = store.OpenAsyncSession(new SessionOptions { TransactionMode = TransactionMode.ClusterWide }))
+            {
+                var user = await session.LoadAsync<User>("users/arava");
+                session.Delete(user);
+                var user2 = await session.LoadAsync<User>("users/phoebe");
+                user2.Name = "Phoebe Eini";
+
+                using (var conflictedSession = store.OpenAsyncSession(new SessionOptions { TransactionMode = TransactionMode.ClusterWide }))
+                {
+                    var conflictedArava = await conflictedSession.LoadAsync<User>("users/arava");
+                    conflictedArava.Name = "Arava!";
+                    await conflictedSession.SaveChangesAsync();
+                }
+
+                await Assert.ThrowsAsync<ConcurrencyException>(() => session.SaveChangesAsync());
+            }
+        }
+    }
+}

--- a/test/SlowTests/Issues/RavenDB_13890.cs
+++ b/test/SlowTests/Issues/RavenDB_13890.cs
@@ -30,7 +30,7 @@ namespace SlowTests.Issues
                         Url = "http://dummy:1234"
                     };
 
-                    var batchCommand = new SingleNodeBatchCommand(store.Conventions, new List<ICommandData>());
+                    var batchCommand = new SingleNodeBatchCommand(store.Conventions, context,new List<ICommandData>());
                     var uri = requestExecutor.CreateRequest(context, dummy, batchCommand, out _);
                     Assert.DoesNotContain("raft", uri.RequestUri.ToString());
 

--- a/test/SlowTests/Issues/RavenDB_13890.cs
+++ b/test/SlowTests/Issues/RavenDB_13890.cs
@@ -30,11 +30,11 @@ namespace SlowTests.Issues
                         Url = "http://dummy:1234"
                     };
 
-                    var batchCommand = new SingleNodeBatchCommand(store.Conventions, context, new List<ICommandData>());
+                    var batchCommand = new SingleNodeBatchCommand(store.Conventions, new List<ICommandData>());
                     var uri = requestExecutor.CreateRequest(context, dummy, batchCommand, out _);
                     Assert.DoesNotContain("raft", uri.RequestUri.ToString());
 
-                    var clusterBatchCommand = new ClusterWideBatchCommand(store.Conventions, context, new List<ICommandData>());
+                    var clusterBatchCommand = new ClusterWideBatchCommand(store.Conventions, new List<ICommandData>());
                     uri = requestExecutor.CreateRequest(context, dummy, clusterBatchCommand, out _);
                     Assert.Contains("raft", uri.RequestUri.ToString());
                 }

--- a/test/SlowTests/Issues/RavenDB_16156.cs
+++ b/test/SlowTests/Issues/RavenDB_16156.cs
@@ -56,5 +56,41 @@ namespace SlowTests.Issues
                 await EnsureReplicatingAsync(store1,store2);
             }
         }
+
+        [Fact]
+        public async Task CanRecreatedFromDeletedClusterTx2()
+        {
+            using (var store1 = GetDocumentStore())
+            {
+
+                using (var session = store1.OpenAsyncSession(new SessionOptions
+                {
+                    TransactionMode = TransactionMode.ClusterWide
+                }))
+                {
+                    await session.StoreAsync(new Person(), "karmel");
+                    await session.SaveChangesAsync();
+                }
+
+                using (var session = store1.OpenAsyncSession())
+                {
+                    var p = await session.LoadAsync<Person>( "karmel");
+                    p.Name = "Karmel";
+                    await session.SaveChangesAsync();
+                }
+               
+                for (int i = 0; i < 9; i++)
+                {
+                    using (var session = store1.OpenAsyncSession())
+                    {
+                        await session.StoreAsync(new Person
+                        {
+                            Name = i.ToString()
+                        },"karmel2");
+                        await session.SaveChangesAsync();
+                    }
+                }
+            }
+        }
     }
 }

--- a/test/SlowTests/Issues/RavenDB_16156.cs
+++ b/test/SlowTests/Issues/RavenDB_16156.cs
@@ -92,5 +92,72 @@ namespace SlowTests.Issues
                 }
             }
         }
+
+        [Fact]
+        public async Task CanRecreatedFromDeletedClusterTx3()
+        {
+            using (var store1 = GetDocumentStore())
+            using (var store2 = GetDocumentStore())
+            {
+                using (var session = store1.OpenAsyncSession(new SessionOptions
+                {
+                    TransactionMode = TransactionMode.ClusterWide
+                }))
+                {
+                    await session.StoreAsync(new Person(), "karmel");
+                    await session.SaveChangesAsync();
+                }
+
+                using (var session = store1.OpenAsyncSession(new SessionOptions
+                {
+                    TransactionMode = TransactionMode.ClusterWide
+                }))
+                {
+                    session.Delete("karmel");
+                    await session.SaveChangesAsync();
+                }
+
+                for (int i = 0; i < 9; i++)
+                {
+                    using (var session = store1.OpenAsyncSession())
+                    {
+                        await session.StoreAsync(new Person
+                        {
+                            Name = i.ToString()
+                        },"karmel");
+                        await session.SaveChangesAsync();
+                    }
+                }
+
+                await SetupReplicationAsync(store1, store2);
+                await SetupReplicationAsync(store2, store1);
+                await EnsureReplicatingAsync(store1,store2);
+
+                using (var session = store1.OpenAsyncSession(new SessionOptions
+                {
+                    TransactionMode = TransactionMode.ClusterWide
+                }))
+                {
+                    await session.StoreAsync(new Person
+                    {
+                        Name = "Store2"
+                    },"store2/karmel");
+                    await session.SaveChangesAsync();
+                }
+
+                await EnsureReplicatingAsync(store2,store1);
+
+                using (var session = store1.OpenAsyncSession())
+                {
+                    await session.StoreAsync(new Person
+                    {
+                        Name = "Store1"
+                    },"store1/karmel");
+                    await session.SaveChangesAsync();
+                }
+
+                WaitForUserToContinueTheTest(store2);
+            }
+        }
     }
 }

--- a/test/SlowTests/RavenDB-15796.cs
+++ b/test/SlowTests/RavenDB-15796.cs
@@ -80,7 +80,7 @@ namespace SlowTests
                         {
                             var result = new InMemoryDocumentSessionOperations.SaveChangesData((InMemoryDocumentSessionOperations)session2);
                             result.SessionCommands.Add(new PutCommandDataWithBlittableJson("users/1", null, null, blittableJson));
-                            var sbc = new SingleNodeBatchCommand(DocumentConventions.Default, context, result.SessionCommands, result.Options);
+                            var sbc = new SingleNodeBatchCommand(DocumentConventions.Default, result.SessionCommands, result.Options);
                             await requestExecutor.ExecuteAsync(sbc, context);
                         }
                     }

--- a/test/SlowTests/RavenDB-15796.cs
+++ b/test/SlowTests/RavenDB-15796.cs
@@ -80,7 +80,7 @@ namespace SlowTests
                         {
                             var result = new InMemoryDocumentSessionOperations.SaveChangesData((InMemoryDocumentSessionOperations)session2);
                             result.SessionCommands.Add(new PutCommandDataWithBlittableJson("users/1", null, null, blittableJson));
-                            var sbc = new SingleNodeBatchCommand(DocumentConventions.Default, result.SessionCommands, result.Options);
+                            var sbc = new SingleNodeBatchCommand(DocumentConventions.Default, context, result.SessionCommands, result.Options);
                             await requestExecutor.ExecuteAsync(sbc, context);
                         }
                     }

--- a/test/SlowTests/RavenDB-15796.cs
+++ b/test/SlowTests/RavenDB-15796.cs
@@ -79,7 +79,7 @@ namespace SlowTests
                         using (var blittableJson = await context.ReadForMemoryAsync(stringStream, "Reading of foo/bar"))
                         {
                             var result = new InMemoryDocumentSessionOperations.SaveChangesData((InMemoryDocumentSessionOperations)session2);
-                            result.SessionCommands.Add(new PutCommandDataWithBlittableJson("users/1", null, blittableJson));
+                            result.SessionCommands.Add(new PutCommandDataWithBlittableJson("users/1", null, null, blittableJson));
                             var sbc = new SingleNodeBatchCommand(DocumentConventions.Default, context, result.SessionCommands, result.Options);
                             await requestExecutor.ExecuteAsync(sbc, context);
                         }

--- a/test/Tests.Infrastructure/DocumentStoreExtensions.cs
+++ b/test/Tests.Infrastructure/DocumentStoreExtensions.cs
@@ -241,7 +241,7 @@ namespace FastTests
 
             public async Task BatchAsync(List<ICommandData> commands)
             {
-                var command = new SingleNodeBatchCommand(_store.Conventions, commands);
+                var command = new SingleNodeBatchCommand(_store.Conventions, Context, commands);
 
                 await RequestExecutor.ExecuteAsync(command, Context);
             }

--- a/test/Tests.Infrastructure/DocumentStoreExtensions.cs
+++ b/test/Tests.Infrastructure/DocumentStoreExtensions.cs
@@ -241,7 +241,7 @@ namespace FastTests
 
             public async Task BatchAsync(List<ICommandData> commands)
             {
-                var command = new SingleNodeBatchCommand(_store.Conventions, Context, commands);
+                var command = new SingleNodeBatchCommand(_store.Conventions, commands);
 
                 await RequestExecutor.ExecuteAsync(command, Context);
             }

--- a/test/Tests.Infrastructure/RavenTestBase.cs
+++ b/test/Tests.Infrastructure/RavenTestBase.cs
@@ -1,4 +1,5 @@
 ﻿using System;
+using System.Collections;
 using System.Collections.Concurrent;
 using System.Collections.Generic;
 using System.Diagnostics;
@@ -699,6 +700,24 @@ namespace FastTests
 
             return entriesCount;
         }
+
+        protected static async Task<TC> AssertWaitForSingleAsync<TC>(Func<Task<TC>> act, int timeout = 15000, int interval = 100) where TC : ICollection
+        {
+            var ret = await WaitForSingleAsync(act, timeout, interval);
+            Assert.Single(ret);
+            return ret;
+        }
+        protected static async Task<TC> AssertWaitForCountAsync<TC>(Func<Task<TC>> act, int count, int timeout = 15000, int interval = 100) where TC : ICollection
+        {
+            var ret = await WaitForCountAsync(act, count, timeout, interval);
+            Assert.True(ret.Count == count, $"Expected {count}, Actual {ret.Count}");
+            return ret;
+        }
+
+        protected static async Task<TC> WaitForSingleAsync<TC>(Func<Task<TC>> act,int timeout = 15000, int interval = 100) where  TC : ICollection =>
+            await WaitForCountAsync(act, 1, timeout, interval);
+        protected static async Task<TC> WaitForCountAsync<TC>(Func<Task<TC>> act, int count,int timeout = 15000, int interval = 100) where  TC : ICollection =>
+            await WaitForPredicateAsync(a => a != null && a.Count == count, act, timeout, interval);
 
         protected static async Task<T> AssertWaitForGreaterThanAsync<T>(Func<Task<T>> act, T val, int timeout = 15000, int interval = 100) where T : IComparable
         {


### PR DESCRIPTION
…onflicts.

* Cluster wide transactions now will default to creating atomic guards (compare exchange values) that match the modified documents in the transaction. This will ensure that all the documents are modified seamlessly across multiple concurrent cluster wide transactions.
* This behavior can be disabled using DisableAtomicDocumentWritesInClusterWideTransaction flag at the document store, session and database/server levels, but is otherwise on by default.
* atomic compare exchange values has the format: rvn-atomic/{document-id} and contains a reference their owner document.
* Created ClusterTransactionId property in the DatabaseRecord, which is used for database group key for cluster wide transaction index. This can be used to compare to atomic guards, compare exchange values that need to match the same index.
* The ClusterTransactionId is used to enhance change vectors of cluster wide transactions. You can identify them using the TXRN tag.
* @refresh and @expires now handle failed concurrency and conflict errors better
* On import, we'll reset the relevant change vector to match the appropriate compare exchange values as well as remove any orphan guards
* Standard transactions also check whatever the document was modified in a cluster wide transaction and prevent saving documents with the wrong cluster transaction index, which should alleviate issues with mismatched versions
* Such checks do not apply when accepting data via replication, to prevent a failure of transaction matches from breaking replication between nodes.
* The client will now send the OldChangeVector always to the server. This is used to check whatever the document is modified from an up to date version compared to the cluster transaction index.

Misc:
* Fixed metadata save of complex objects
* Fixed concurrent collection usage on Candidate
* Fixed test failure when using WellKnownCertificates as environment variables