### PR TITLE
RavenDB-16705 fixed issue with StreamsTempFile

### DIFF
--- a/src/Raven.Server/Documents/Replication/IncomingReplicationHandler.cs
+++ b/src/Raven.Server/Documents/Replication/IncomingReplicationHandler.cs
@@ -575,6 +575,7 @@ namespace Raven.Server.Documents.Replication
             var sw = Stopwatch.StartNew();
             Task task = null;
 
+            using (_attachmentStreamsTempFile.Scope())
             using (var incomingReplicationAllocator = new IncomingReplicationAllocator(documentsContext, _database))
             using (var dataForReplicationCommand = new DataForReplicationCommand
             {
@@ -672,8 +673,6 @@ namespace Raven.Server.Documents.Replication
                         // in a bad state and likely in the process of shutting 
                         // down
                     }
-
-                    _attachmentStreamsTempFile?.Reset();
                 }
             }
         }

--- a/src/Raven.Server/Documents/StreamsTempFile.cs
+++ b/src/Raven.Server/Documents/StreamsTempFile.cs
@@ -1,5 +1,8 @@
 ﻿using System;
 using System.IO;
+using System.Runtime.CompilerServices;
+using Raven.Client.Util;
+using Raven.Server.Indexing;
 using Raven.Server.ServerWide;
 using Raven.Server.Utils;
 using Sparrow.Utils;
@@ -11,15 +14,16 @@ namespace Raven.Server.Documents
     {
         private readonly string _tempFile;
         private readonly StorageEnvironment _environment;
-        private readonly FileStream _file;
-        private bool _reading;
-        private Stream _previousInstance;
+        internal readonly TempFileStream _file;
+        internal bool _reading;
+        private InnerStream _previousInstance;
+
         public StreamsTempFile(string tempFile, StorageEnvironment environment)
         {
             _tempFile = tempFile;
             _environment = environment;
 
-            _file = SafeFileStream.Create(_tempFile, FileMode.CreateNew, FileAccess.ReadWrite, FileShare.ReadWrite, 4096, FileOptions.DeleteOnClose | FileOptions.SequentialScan);
+            _file = new TempFileStream(SafeFileStream.Create(_tempFile, FileMode.CreateNew, FileAccess.ReadWrite, FileShare.ReadWrite, 4096, FileOptions.DeleteOnClose | FileOptions.SequentialScan));
         }
 
         public Stream StartNewStream()
@@ -28,24 +32,29 @@ namespace Raven.Server.Documents
                 throw new NotSupportedException("The temp file was already moved to reading mode");
 
             _previousInstance?.Flush();
-            if (_environment.Options.Encryption.IsEnabled)
-            {
-                _previousInstance = new TempCryptoStream(_file);
-            }
-            else
-            {
-                _previousInstance = new InnerPartStream(_file, this);
-            }
+            _previousInstance = _environment.Options.Encryption.IsEnabled
+                ? new InnerStream(new TempCryptoStream(_file), this)
+                : new InnerStream(new InnerPartStream(_file), this);
+
             return _previousInstance;
         }
 
-        public void Reset()
-        {
-            _reading = false;
+        public long Generation;
 
-            const int _128mb = 128 * 1024 * 1024;
-            if (_file.Length > _128mb)
-                _file.SetLength(_128mb);
+        public IDisposable Scope()
+        {
+            return new DisposableAction(() =>
+            {
+                _previousInstance = null;
+
+                Generation++;
+                _reading = false;
+                _file.ResetLength();
+
+                const int _128mb = 128 * 1024 * 1024;
+                if (_file.InnerStream.Length > _128mb)
+                    _file.InnerStream.SetLength(_128mb);
+            });
         }
 
         public void Dispose()
@@ -60,18 +69,105 @@ namespace Raven.Server.Documents
             }
         }
 
+        private class InnerStream : Stream
+        {
+            private readonly Stream _stream;
+            private readonly StreamsTempFile _parent;
+
+            private readonly long _generation;
+
+            public InnerStream(Stream stream, StreamsTempFile parent)
+            {
+                _stream = stream ?? throw new ArgumentNullException(nameof(stream));
+                _parent = parent ?? throw new ArgumentNullException(nameof(parent));
+                _generation = parent.Generation;
+            }
+
+            public override void Flush()
+            {
+                if (CanWrite == false)
+                    throw new NotSupportedException();
+
+                _stream.Flush();
+            }
+
+            public override int Read(byte[] buffer, int offset, int count)
+            {
+                if (CanRead == false)
+                    throw new NotSupportedException();
+
+                _parent._reading = true;
+
+                return _stream.Read(buffer, offset, count);
+            }
+
+            public override long Seek(long offset, SeekOrigin origin)
+            {
+                AssertGeneration();
+
+                _parent._reading = true;
+
+                return _stream.Seek(offset, origin);
+            }
+
+            public override void SetLength(long value)
+            {
+                AssertGeneration();
+
+                _stream.SetLength(value);
+            }
+
+            public override void Write(byte[] buffer, int offset, int count)
+            {
+                if (CanWrite == false)
+                    throw new NotSupportedException();
+
+                _stream.Write(buffer, offset, count);
+            }
+
+            public override bool CanRead => _parent.Generation == _generation;
+
+            public override bool CanSeek => true;
+
+            public override bool CanWrite => _parent._reading == false && _parent.Generation == _generation;
+
+            public override long Length => _stream.Length;
+
+            public override long Position
+            {
+                get => _stream.Position;
+                set
+                {
+                    AssertGeneration();
+
+                    _stream.Position = value;
+                }
+            }
+
+            protected override void Dispose(bool disposing)
+            {
+                AssertGeneration();
+
+                _stream.Dispose();
+            }
+
+            [MethodImpl(MethodImplOptions.AggressiveInlining)]
+            private void AssertGeneration()
+            {
+                if (_parent.Generation != _generation)
+                    throw new NotSupportedException($"Invalid generation. Parent: {_parent.Generation}. Current: {_generation}");
+            }
+        }
+
         private class InnerPartStream : Stream
         {
             private readonly Stream _file;
-            private readonly StreamsTempFile _parent;
             private readonly long _startPosition;
             private long _length;
-            private bool _reading;
 
-            public InnerPartStream(Stream file, StreamsTempFile parent)
+            public InnerPartStream(Stream file)
             {
                 _file = file;
-                _parent = parent;
                 _startPosition = file.Position;
             }
 
@@ -81,9 +177,6 @@ namespace Raven.Server.Documents
 
             public override int Read(byte[] buffer, int offset, int count)
             {
-                if (_reading == false)
-                    throw new NotSupportedException();
-
                 var remaining = (_startPosition + _length) - _file.Position;
                 if (remaining < count)
                     count = (int)remaining;
@@ -95,8 +188,6 @@ namespace Raven.Server.Documents
                 if (origin != SeekOrigin.Begin || offset != 0)
                     throw new NotSupportedException();
 
-                _reading = true;
-                _parent._reading = true;
                 return _file.Seek(_startPosition + offset, origin);
             }
 
@@ -107,17 +198,15 @@ namespace Raven.Server.Documents
 
             public override void Write(byte[] buffer, int offset, int count)
             {
-                if (_reading)
-                    throw new NotSupportedException();
                 _file.Write(buffer, offset, count);
                 _length += count;
             }
 
-            public override bool CanRead => _reading;
+            public override bool CanRead => true;
 
-            public override bool CanSeek { get; } = true;
+            public override bool CanSeek => true;
 
-            public override bool CanWrite => _reading == false;
+            public override bool CanWrite => true;
 
             public override long Length => _length;
 

--- a/src/Raven.Server/Indexing/TempFileCache.cs
+++ b/src/Raven.Server/Indexing/TempFileCache.cs
@@ -228,9 +228,9 @@ namespace Raven.Server.Indexing
             get => InnerStream.Position;
             set
             {
-                if(value > _length)
+                if (value > _length)
                     throw new ArgumentOutOfRangeException($"Cannot set position ({value}) beyond the end of the file ({_length})");
-                InnerStream.Position = value;   
+                InnerStream.Position = value;
             }
         }
 

--- a/src/Raven.Server/ServerWide/TempCryptoStream.cs
+++ b/src/Raven.Server/ServerWide/TempCryptoStream.cs
@@ -1,15 +1,12 @@
 ﻿using System;
 using System.Diagnostics;
 using System.IO;
-using Raven.Server.Utils;
 using Sparrow.Server;
-using Sparrow.Utils;
 
 namespace Raven.Server.ServerWide
 {
     public unsafe class TempCryptoStream : Stream
     {
-        private readonly string _file;
         private bool _ignoreSetLength;
         private readonly Stream _stream;
         private readonly MemoryStream _authenticationTags = new MemoryStream();
@@ -17,8 +14,11 @@ namespace Raven.Server.ServerWide
         private readonly long _startPosition;
 
         public Stream InnerStream => _stream;
+
         public override bool CanRead => true;
+
         public override bool CanSeek => true;
+
         public override bool CanWrite => true;
 
         public override long Length
@@ -39,14 +39,9 @@ namespace Raven.Server.ServerWide
         private readonly byte[] _internalBuffer;    // Temp buffer for one block only
         private int _bufferIndex;    // The position in the block buffer.
         private int _bufferValidIndex;
-        private bool _needToWrite = false;
+        private bool _needToWrite;
         private long _blockNumber;
         private long _maxLength;
-
-        public TempCryptoStream(string file) : this(SafeFileStream.Create(file, FileMode.CreateNew, FileAccess.ReadWrite, FileShare.None, 4096, FileOptions.DeleteOnClose))
-        {
-            _file = file;
-        }
 
         public TempCryptoStream IgnoreSetLength()
         {
@@ -114,7 +109,6 @@ namespace Raven.Server.ServerWide
                 }
             }
         }
-
 
         public override void Flush()
         {
@@ -286,11 +280,6 @@ namespace Raven.Server.ServerWide
 
         protected override void Dispose(bool disposing)
         {
-            if (_file != null)
-            {
-                _stream.Dispose();
-                PosixFile.DeleteOnClose(_file);
-            }
         }
     }
 }

--- a/test/FastTests/Sparrow/EncryptionTests.cs
+++ b/test/FastTests/Sparrow/EncryptionTests.cs
@@ -1,12 +1,15 @@
 ﻿using System;
+using System.Collections.Generic;
 using System.IO;
 using System.Text;
 using FastTests.Utils;
 using FastTests.Voron;
 using FastTests.Voron.FixedSize;
+using Raven.Server.Documents;
 using Raven.Server.ServerWide;
 using Sparrow;
 using Sparrow.Server;
+using Sparrow.Utils;
 using Voron;
 using Voron.Data;
 using Voron.Impl.Paging;
@@ -65,7 +68,8 @@ namespace FastTests.Sparrow
         public unsafe void WriteSeekAndReadInTempCryptoStream(int seed)
         {
             using (var options = StorageEnvironmentOptions.ForPath(DataDir))
-            using (var stream = new TempCryptoStream(Path.Combine(DataDir, "EncryptedTempFile")))
+            using (var file = SafeFileStream.Create(Path.Combine(DataDir, "EncryptedTempFile"), FileMode.CreateNew, FileAccess.ReadWrite, FileShare.None, 4096, FileOptions.DeleteOnClose))
+            using (var stream = new TempCryptoStream(file))
             {
                 var r = new Random(seed);
 
@@ -102,6 +106,85 @@ namespace FastTests.Sparrow
                     offset += read;
                 }
                 Assert.Equal(bytes, readBytes);
+            }
+        }
+
+        [Fact]
+        public unsafe void StreamsTempFile_With_Encryption_ShouldNotThrow_When_NotAllStreamsWereRead()
+        {
+            using (var options = StorageEnvironmentOptions.ForPath(DataDir))
+            {
+                options.Encryption.MasterKey = Sodium.GenerateRandomBuffer((int)Sodium.crypto_aead_xchacha20poly1305_ietf_keybytes());
+                using (var environment = new StorageEnvironment(options))
+                {
+                    using (var temp = new StreamsTempFile(Path.Combine(DataDir, "EncryptedTempFile"), environment))
+                    {
+                        for (int j = 0; j < 10; j++)
+                        {
+                            using (temp.Scope())
+                            {
+                                var streams = new List<Stream>();
+                                for (var i = 0; i < 10; i++)
+                                {
+                                    var stream = temp.StartNewStream();
+                                    var bytes = new byte[1024];
+                                    fixed (byte* b = bytes)
+                                    {
+                                        Memory.Set(b, (byte)i, bytes.Length);
+                                    }
+
+                                    stream.Write(bytes, 0, bytes.Length);
+                                    stream.Flush();
+                                    streams.Add(stream);
+                                }
+
+                                streams[0].Seek(0, SeekOrigin.Begin);
+                            }
+
+                            Assert.Equal(0, temp._file.Position);
+                            Assert.Equal(0, temp._file.Length);
+                            Assert.True(temp._file.InnerStream.Length > 0);
+                        }
+                    }
+                }
+            }
+        }
+
+        [Fact]
+        public unsafe void StreamsTempFile_With_Encryption_ShouldThrow_When_SeekAndWrite_AreMixed_Without_ExecutingReset()
+        {
+            using (var options = StorageEnvironmentOptions.ForPath(DataDir))
+            {
+                options.Encryption.MasterKey = Sodium.GenerateRandomBuffer((int)Sodium.crypto_aead_xchacha20poly1305_ietf_keybytes());
+                using (var environment = new StorageEnvironment(options))
+                {
+                    using (var temp = new StreamsTempFile(Path.Combine(DataDir, "EncryptedTempFile"), environment))
+                    {
+                        var bytes = new byte[1024];
+                        fixed (byte* b = bytes)
+                        {
+                            Memory.Set(b, (byte)'I', bytes.Length);
+                        }
+
+                        Stream stream;
+                        using (temp.Scope())
+                        {
+                            stream = temp.StartNewStream();
+                            
+                            stream.Write(bytes, 0, bytes.Length);
+                            stream.Flush();
+
+                            stream.Seek(0, SeekOrigin.Begin);
+
+                            var read = stream.Read(new Span<byte>(new byte[10]));
+                            Assert.Equal(10, read);
+
+                            Assert.Throws<NotSupportedException>(() => stream.Write(bytes, 0, bytes.Length));
+                        }
+
+                        Assert.Throws<NotSupportedException>(() => stream.Write(bytes, 0, bytes.Length));
+                    }
+                }
             }
         }
     }

--- a/test/SlowTests/Issues/RavenDB_10836.cs
+++ b/test/SlowTests/Issues/RavenDB_10836.cs
@@ -23,10 +23,10 @@ namespace SlowTests.Issues
             {
                 long length = int.MaxValue;
 
-                length +=  4096;
+                length += 4096;
 
                 file.SetLength(length);
-                
+
                 using (var stream = new TempCryptoStream(file))
                 {
                     var bytes = new byte[4096];
@@ -41,11 +41,11 @@ namespace SlowTests.Issues
                     stream.Position = length - 4096 + 1;
 
                     stream.Write(bytes, 0, bytes.Length);
-                    
+
                     stream.Seek(0, SeekOrigin.Begin);
 
                     var readBytes = new byte[bytes.Length];
-                    
+
                     var read = stream.Read(readBytes, 0, readBytes.Length);
 
                     Assert.Equal(4096, read);


### PR DESCRIPTION
- if we would not read all the streams till the end and Reset was called then when TempCryptoStream was used underneath it would cause write exceptions until the StreamsTempFile was disposed - this could cause replication to hang because there is a single instance of StreamsTempFile there