### PR TITLE
RavenDB-16803 / RavenDB-16507 Fixing another case where a newly created read transaction could get an already disposed pager state of a scratch file.

### DIFF
--- a/src/Voron/Impl/Journal/WriteAheadJournal.cs
+++ b/src/Voron/Impl/Journal/WriteAheadJournal.cs
@@ -867,7 +867,7 @@ namespace Voron.Impl.Journal
                         // let's try to prevent running new read transactions so we'll be able to free more scratch pages and delete more journals
                         // in particular we might clean the last journal so we won't need to apply it on restart - see RavenDB-11871 
 
-                        if (_waj._env.IsInPreventNewTransactionsMode || _waj._env.TryPreventNewReadTransactions(TimeSpan.Zero, out exitPreventNewTransactions))
+                        if (_waj._env.IsInPreventNewTransactionsMode || _waj._env.TryPreventNewTransactions(TimeSpan.Zero, out exitPreventNewTransactions))
                         {
                             // we managed to prevent from new read transactions, let's verify that we're still the only active transaction
 

--- a/src/Voron/Impl/Paging/AbstractPager.cs
+++ b/src/Voron/Impl/Paging/AbstractPager.cs
@@ -494,10 +494,10 @@ namespace Voron.Impl.Paging
         public abstract override string ToString();
 
 
-        public static void ThrowAlreadyDisposedException()
+        public void ThrowAlreadyDisposedException()
         {
             // this is a separate method because we don't want to have an exception throwing in the hot path
-            throw new ObjectDisposedException("The pager is already disposed");
+            throw new ObjectDisposedException($"The pager is already disposed ({ToString()})");
         }
 
         protected void ThrowOnInvalidPageNumber(long pageNumber)

--- a/src/Voron/StorageEnvironment.cs
+++ b/src/Voron/StorageEnvironment.cs
@@ -815,7 +815,7 @@ namespace Voron
 
         internal bool IsInPreventNewTransactionsMode => _txCreation.IsWriteLockHeld;
 
-        internal bool TryPreventNewReadTransactions(TimeSpan timeout, out IDisposable exitWriteLock)
+        internal bool TryPreventNewTransactions(TimeSpan timeout, out IDisposable exitWriteLock)
         {
             if (_txCreation.TryEnterWriteLock(timeout))
             {


### PR DESCRIPTION
This time it applies to scratches from the recycle area. Those can be disposed by ScratchBufferPool.Free() call but then we need to have UpdateCacheForPagerStatesOfAllScratches() before the actual dispose.

https://issues.hibernatingrhinos.com/issue/RavenDB-16803

Again, the issue has been revealed by changes made in PR https://github.com/ravendb/ravendb/pull/12008

It's very similar case like in https://github.com/ravendb/ravendb/pull/12118 but this time it's related to scratches from the recycle area