### PR TITLE
RavenDB-15802 Fixing concurrent usage of the context. We were passing the context to the operation running in the background e.g. patch and using the same context for WriteOperationIdAndNodeTag()

### DIFF
--- a/src/Raven.Server/Documents/Handlers/QueriesHandler.cs
+++ b/src/Raven.Server/Documents/Handlers/QueriesHandler.cs
@@ -356,8 +356,7 @@ namespace Raven.Server.Documents.Handlers
                         TrafficWatchQuery(query);
 
                     ExecuteQueryOperation(query,
-                        (runner, options, onProgress, token) => runner.ExecuteDeleteQuery(query, options, context, onProgress, token),
-                        context, returnContextToPool, Operations.Operations.OperationType.DeleteByQuery);
+                        (runner, options, onProgress, token) => runner.ExecuteDeleteQuery(query, options, context, onProgress, token), returnContextToPool, Operations.Operations.OperationType.DeleteByQuery);
 
                     return Task.CompletedTask;
                 }
@@ -484,7 +483,7 @@ namespace Raven.Server.Documents.Handlers
                 ExecuteQueryOperation(query,
                     (runner, options, onProgress, token) => runner.ExecutePatchQuery(
                         query, options, patch, query.QueryParameters, context, onProgress, token),
-                    context, returnContextToPool, Operations.Operations.OperationType.UpdateByQuery);
+                    returnContextToPool, Operations.Operations.OperationType.UpdateByQuery);
 
                 return Task.CompletedTask;
             }
@@ -514,7 +513,6 @@ namespace Raven.Server.Documents.Handlers
                 QueryOperationOptions,
                 Action<IOperationProgress>, OperationCancelToken,
                 Task<IOperationResult>> operation,
-                DocumentsOperationContext context,
                 IDisposable returnContextToPool,
                 Operations.Operations.OperationType operationType)
         {
@@ -538,6 +536,7 @@ namespace Raven.Server.Documents.Handlers
                 operationType,
                 onProgress => operation(Database.QueryRunner, options, onProgress, token), operationId, details, token);
 
+            using (ContextPool.AllocateOperationContext(out JsonOperationContext context))
             using (var writer = new BlittableJsonTextWriter(context, ResponseBodyStream()))
             {
                 writer.WriteOperationIdAndNodeTag(context, operationId, ServerStore.NodeTag);

--- a/src/Raven.Server/Web/Studio/StudioCollectionsHandler.cs
+++ b/src/Raven.Server/Web/Studio/StudioCollectionsHandler.cs
@@ -305,13 +305,13 @@ namespace Raven.Server.Web.Studio
             return Task.CompletedTask;
         }
 
-        private void ExecuteCollectionOperation(Func<CollectionRunner, string, CollectionOperationOptions, Action<IOperationProgress>, OperationCancelToken, Task<IOperationResult>> operation, DocumentsOperationContext context, IDisposable returnContextToPool, Documents.Operations.Operations.OperationType operationType, HashSet<string> excludeIds)
+        private void ExecuteCollectionOperation(Func<CollectionRunner, string, CollectionOperationOptions, Action<IOperationProgress>, OperationCancelToken, Task<IOperationResult>> operation, DocumentsOperationContext docsContext, IDisposable returnContextToPool, Documents.Operations.Operations.OperationType operationType, HashSet<string> excludeIds)
         {
             var collectionName = GetStringQueryString("name");
 
             var token = CreateTimeLimitedCollectionOperationToken();
 
-            var collectionRunner = new StudioCollectionRunner(Database, context, excludeIds);
+            var collectionRunner = new StudioCollectionRunner(Database, docsContext, excludeIds);
 
             var operationId = Database.Operations.GetNextOperationId();
 
@@ -323,6 +323,7 @@ namespace Raven.Server.Web.Studio
 
             task.ContinueWith(_ => returnContextToPool.Dispose());
 
+            using (ContextPool.AllocateOperationContext(out JsonOperationContext context))
             using (var writer = new BlittableJsonTextWriter(context, ResponseBodyStream()))
             {
                 writer.WriteOperationIdAndNodeTag(context, operationId, ServerStore.NodeTag);


### PR DESCRIPTION
https://issues.hibernatingrhinos.com/issue/RavenDB-15802