### PR TITLE
RavenDB-16647 Pass actual memory info to OutOfMemoryDetails in OutOfMemoryNotifications when EarlyOutOfMemoryException is thrown

### DIFF
--- a/src/Raven.Server/NotificationCenter/OutOfMemoryNotifications.cs
+++ b/src/Raven.Server/NotificationCenter/OutOfMemoryNotifications.cs
@@ -66,7 +66,12 @@ namespace Raven.Server.NotificationCenter
 
         private static MessageDetails OutOfMemoryDetails(Exception exception)
         {
-            var memoryInfo = MemoryInformation.GetMemoryInformationUsingOneTimeSmapsReader();
+            MemoryInfoResult memoryInfo;
+
+            if (exception is EarlyOutOfMemoryException eoome && eoome.MemoryInfo != null)
+                memoryInfo = eoome.MemoryInfo.Value;
+            else
+                memoryInfo = MemoryInformation.GetMemoryInformationUsingOneTimeSmapsReader();
 
             return new MessageDetails
             {

--- a/src/Sparrow.Server/LowMemory/MemoryInformation.cs
+++ b/src/Sparrow.Server/LowMemory/MemoryInformation.cs
@@ -189,7 +189,7 @@ namespace Sparrow.LowMemory
         private static void ThrowInsufficientMemory(MemoryInfoResult memInfo)
         {
             LowMemoryNotification.Instance.SimulateLowMemoryNotification();
-            throw new EarlyOutOfMemoryException($"The amount of available memory to commit on the system is low. Commit charge: {memInfo.CurrentCommitCharge} / {memInfo.TotalCommittableMemory}. Memory: {memInfo.TotalPhysicalMemory - memInfo.AvailableMemory} / {memInfo.TotalPhysicalMemory}");
+            throw new EarlyOutOfMemoryException($"The amount of available memory to commit on the system is low. Commit charge: {memInfo.CurrentCommitCharge} / {memInfo.TotalCommittableMemory}. Memory: {memInfo.TotalPhysicalMemory - memInfo.AvailableMemory} / {memInfo.TotalPhysicalMemory}", memInfo);
         }
 
         [return: MarshalAs(UnmanagedType.Bool)]
@@ -691,12 +691,15 @@ namespace Sparrow.LowMemory
         {
         }
 
-        public EarlyOutOfMemoryException(string message) : base(message)
+        public EarlyOutOfMemoryException(string message, MemoryInfoResult memoryInfo) : base(message)
         {
+            MemoryInfo = memoryInfo;
         }
 
         public EarlyOutOfMemoryException(string message, Exception inner) : base(message, inner)
         {
         }
+
+        public MemoryInfoResult? MemoryInfo { get; }
     }
 }


### PR DESCRIPTION
https://issues.hibernatingrhinos.com/issue/RavenDB-16647