### PR TITLE
RavenDB-14759

### DIFF
--- a/src/Raven.Server/Documents/Replication/IncomingReplicationHandler.cs
+++ b/src/Raven.Server/Documents/Replication/IncomingReplicationHandler.cs
@@ -1171,6 +1171,7 @@ namespace Raven.Server.Documents.Replication
 
                 _attachmentStreamsTempFile.Dispose();
 
+                _replicationFromAnotherSource.Dispose();
             }
             finally
             {

--- a/src/Raven.Server/Documents/Replication/OutgoingReplicationHandler.cs
+++ b/src/Raven.Server/Documents/Replication/OutgoingReplicationHandler.cs
@@ -44,7 +44,7 @@ namespace Raven.Server.Documents.Replication
 
         internal readonly DocumentDatabase _database;
         private readonly Logger _log;
-        private readonly AsyncManualResetEvent _waitForChanges = new AsyncManualResetEvent();
+        private readonly AsyncManualResetEvent _waitForChanges;
         private readonly CancellationTokenSource _cts;
         private PoolOfThreads.LongRunningWork _longRunningSendingWork;
         internal readonly ReplicationLoader _parent;
@@ -56,7 +56,7 @@ namespace Raven.Server.Documents.Replication
 
         private TcpClient _tcpClient;
 
-        private readonly AsyncManualResetEvent _connectionDisposed = new AsyncManualResetEvent();
+        private readonly AsyncManualResetEvent _connectionDisposed;
         public bool IsConnectionDisposed => _connectionDisposed.IsSet;
         private JsonOperationContext.ManagedPinnedBuffer _buffer;
 
@@ -88,6 +88,10 @@ namespace Raven.Server.Documents.Replication
         {
             _parent = parent;
             _database = database;
+
+            _connectionDisposed = new AsyncManualResetEvent(_database.DatabaseShutdown);
+            _waitForChanges = new AsyncManualResetEvent(_database.DatabaseShutdown);
+
             Destination = node;
             _external = external;
             _log = LoggingSource.Instance.GetLogger<OutgoingReplicationHandler>(_database.Name);

--- a/src/Raven.Server/Documents/Replication/OutgoingReplicationHandler.cs
+++ b/src/Raven.Server/Documents/Replication/OutgoingReplicationHandler.cs
@@ -1123,6 +1123,9 @@ namespace Raven.Server.Documents.Replication
             {
                 //was already disposed? we don't care, we are disposing
             }
+
+            _connectionDisposed.Dispose();
+            _waitForChanges.Dispose();
         }
 
         private void DisposeTcpClient()


### PR DESCRIPTION
- dispose Stream and TcpClient under lock in TcpConnectionOptions
- all AsyncManualResetEvents in IncomingReplicationHandler and OutgoingReplicationHandler should be bound to database shutdown so the interruption will be immediate
- always dispose stream in InterruptibleRead, even if we haven't created any reading tasks