### PR TITLE
RavenDB-16886 fix unable to purge package if it's unconfigured due to non-existent directory

### DIFF
--- a/scripts/linux/pkg/deb/assets/ravendb/debian/ravendb.postrm
+++ b/scripts/linux/pkg/deb/assets/ravendb/debian/ravendb.postrm
@@ -25,9 +25,9 @@ case "$1" in
 
     purge)
     
-    rm -r /var/lib/ravendb
-    rm -r /var/log/ravendb
-    rm -r /etc/ravendb
+    rm -rf /var/lib/ravendb
+    rm -rf /var/log/ravendb
+    rm -rf /etc/ravendb
 
     ;;
 

--- a/scripts/linux/pkg/deb/assets/test.sh
+++ b/scripts/linux/pkg/deb/assets/test.sh
@@ -259,12 +259,22 @@ function assert_ravendb_uninstalled {
 function test_package_local {
     pkgFilename=$1
 
-    echo "Testing the package $pkgFilename"
+    echo "# apt update"
+    apt update -qq
+
+    echo "# Testing the package $pkgFilename"
     
-    echo "Install package."
+    echo "# Install package."
     dpkg -i $pkgFilename
     
     set -e
+    dpkg -P ravendb
+
+    set +e
+    dpkg -i $pkgFilename
+
+    set -e
+
     export DEBIAN_FRONTEND=noninteractive 
     apt-get -y -f install
 
@@ -276,7 +286,7 @@ function test_package_local {
         return 1
     fi
 
-    echo "Remove package."
+    echo "# Remove package."
     dpkg -r ravendb
 
     if ! assert_ravendb_uninstalled; then
@@ -291,8 +301,11 @@ function test_package_local {
 function test_package_systemd {
     pkgFilename=$1
 
-    echo "Testing the package $pkgFilename"
-    echo "Install package."
+    echo "# apt update"
+    apt update -qq
+
+    echo "# Testing the package $pkgFilename"
+    echo "# Install package."
     dpkg -i $pkgFilename
 
     set -e
@@ -310,7 +323,7 @@ function test_package_systemd {
         return 1
     fi
 
-    echo "Remove package."
+    echo "# Remove package."
     dpkg -r ravendb
 
     if ! assert_ravendb_uninstalled; then
@@ -321,7 +334,7 @@ function test_package_systemd {
         return 1
     fi
 
-    echo "Package works fine as a systemd daemon."
+    echo "# Package works fine as a systemd daemon."
     set +e
 }
 

--- a/scripts/linux/pkg/deb/ubuntu_test.Dockerfile
+++ b/scripts/linux/pkg/deb/ubuntu_test.Dockerfile
@@ -6,16 +6,6 @@ ARG DISTRO_VERSION_NAME
 ARG DOTNET_RUNTIME_VERSION
 ARG DOTNET_RUNTIME_DEPS
 
-
-# # install deps for package testing
-# RUN apt update \ 
-#     && apt install -y curl wget \
-#     && wget https://packages.microsoft.com/config/ubuntu/${DISTRO_VERSION}/packages-microsoft-prod.deb -O packages-microsoft-prod.deb \
-#     && dpkg -i ./packages-microsoft-prod.deb \
-#     && apt update \
-#     && apt install -y apt-transport-https \
-#     && apt update 
-
 RUN apt update && apt install -y curl
 
 WORKDIR /test


### PR DESCRIPTION
Plus changed the message upon installation:
```
### RavenDB Setup ###
#
#  Please navigate to http://127.0.0.1:53700 in your web browser to complete setting up RavenDB.
#  If you set up the server SSH connection, you can setup tunneling for RavenDB setup port by executing the following command on your local:
#  For a public address:    ssh -N -L localhost:53700:localhost:53700 username@83.14.110.161
#  For an internal address:  ssh -N -L localhost:53700:localhost:53700 username@0d6f1dc86493
#
#  Then proceed with the setup on your local machine by navigating to http://localhost:53700
#
###
```