### PR TITLE
RavenDB-16858 / RavenDB-16519 Getting back to use Queue instead of List.

### DIFF
--- a/src/Sparrow/Utils/FifoSemaphore.cs
+++ b/src/Sparrow/Utils/FifoSemaphore.cs
@@ -29,7 +29,7 @@ namespace Sparrow.Utils
     /// </remarks>
     internal class FifoSemaphore
     {
-        internal readonly List<OneTimeWaiter> _waitQueue;
+        internal readonly Queue<OneTimeWaiter> _waitQueue;
 
         private readonly object _lock;
 
@@ -42,7 +42,7 @@ namespace Sparrow.Utils
 
             _tokens = tokens;
             _lock = new object();
-            _waitQueue = new List<OneTimeWaiter>();
+            _waitQueue = new Queue<OneTimeWaiter>();
         }
 
         public bool TryAcquire(TimeSpan timeout, CancellationToken token)
@@ -63,7 +63,7 @@ namespace Sparrow.Utils
 
                 waiter = new OneTimeWaiter(token);
 
-                _waitQueue.Add(waiter);
+                _waitQueue.Enqueue(waiter);
             }
 
             using (waiter)
@@ -103,9 +103,7 @@ namespace Sparrow.Utils
                 {
                     if (_waitQueue.Count > 0)
                     {
-                        var waiter = _waitQueue[0];
-
-                        _waitQueue.RemoveAt(0);
+                        var waiter = _waitQueue.Dequeue();
 
                         if (waiter.TryRelease() == false)
                         {

--- a/test/SlowTests/Issues/RavenDB_16412_FifoSemaphoreTests.cs
+++ b/test/SlowTests/Issues/RavenDB_16412_FifoSemaphoreTests.cs
@@ -1,5 +1,6 @@
 ﻿using System;
 using System.Collections.Generic;
+using System.Linq;
 using System.Threading;
 using System.Threading.Tasks;
 using FastTests;
@@ -110,7 +111,7 @@ namespace SlowTests.Issues
 
                 Assert.Equal(1, @lock._waitQueue.Count);
 
-                Assert.True(@lock._waitQueue[0].IsCancelled);
+                Assert.True(@lock._waitQueue.First().IsCancelled);
             }
             finally
             {
@@ -133,7 +134,7 @@ namespace SlowTests.Issues
 
                 Assert.Equal(1, @lock._waitQueue.Count);
 
-                Assert.True(@lock._waitQueue[0].IsTimedOut);
+                Assert.True(@lock._waitQueue.First().IsTimedOut);
             }
             finally
             {


### PR DESCRIPTION
There is no need to use List since we changed the approach and don't remove cancelled or timedout waited from queue directly but it's handled in Release() method.


For reference: https://github.com/ravendb/ravendb/pull/12029 https://github.com/ravendb/ravendb/pull/12400