### PR TITLE
RavenDB-16860 Added Storage.MaxNumberOfRecyclableJournals configuration option

### DIFF
--- a/src/Raven.Server/Config/Categories/StorageConfiguration.cs
+++ b/src/Raven.Server/Config/Categories/StorageConfiguration.cs
@@ -132,5 +132,11 @@ namespace Raven.Server.Config.Categories
         [DefaultValue(false)]
         [ConfigurationEntry("Storage.Encrypted.DisableBuffersPooling", ConfigurationEntryScope.ServerWideOnly)]
         public bool DisableEncryptionBuffersPooling { get; set; }
+
+        [Description("Max number of recyclable journals that will be reused. ")]
+        [DefaultValue(32)]
+        [MinValue(0)]
+        [ConfigurationEntry("Storage.MaxNumberOfRecyclableJournals", ConfigurationEntryScope.ServerWideOrPerDatabase)]
+        public int MaxNumberOfRecyclableJournals { get; set; }
     }
 }

--- a/src/Raven.Server/Documents/CompactDatabaseTask.cs
+++ b/src/Raven.Server/Documents/CompactDatabaseTask.cs
@@ -175,6 +175,7 @@ namespace Raven.Server.Documents
             options.PrefetchResetThreshold = configuration.Storage.PrefetchResetThreshold.GetValue(SizeUnit.Bytes);
             options.SyncJournalsCountThreshold = documentDatabase.Configuration.Storage.SyncJournalsCountThreshold;
             options.SkipChecksumValidationOnDatabaseLoading = documentDatabase.Configuration.Storage.SkipChecksumValidationOnDatabaseLoading;
+            options.MaxNumberOfRecyclableJournals = documentDatabase.Configuration.Storage.MaxNumberOfRecyclableJournals;
         }
 
         private static void SwitchDatabaseDirectories(string basePath, string backupDirectory, string compactDirectory)

--- a/src/Raven.Server/Documents/ConfigurationStorage.cs
+++ b/src/Raven.Server/Documents/ConfigurationStorage.cs
@@ -61,6 +61,7 @@ namespace Raven.Server.Documents
             options.IgnoreInvalidJournalErrors = db.Configuration.Storage.IgnoreInvalidJournalErrors;
             options.SkipChecksumValidationOnDatabaseLoading = db.Configuration.Storage.SkipChecksumValidationOnDatabaseLoading;
             options.IgnoreDataIntegrityErrorsOfAlreadySyncedTransactions = db.Configuration.Storage.IgnoreDataIntegrityErrorsOfAlreadySyncedTransactions;
+            options.MaxNumberOfRecyclableJournals = db.Configuration.Storage.MaxNumberOfRecyclableJournals;
 
             DirectoryExecUtils.SubscribeToOnDirectoryInitializeExec(options, db.Configuration.Storage, db.Name, DirectoryExecUtils.EnvironmentType.Configuration, Logger);
 

--- a/src/Raven.Server/Documents/DocumentsStorage.cs
+++ b/src/Raven.Server/Documents/DocumentsStorage.cs
@@ -254,6 +254,7 @@ namespace Raven.Server.Documents
             options.IgnoreInvalidJournalErrors = DocumentDatabase.Configuration.Storage.IgnoreInvalidJournalErrors;
             options.SkipChecksumValidationOnDatabaseLoading = DocumentDatabase.Configuration.Storage.SkipChecksumValidationOnDatabaseLoading;
             options.IgnoreDataIntegrityErrorsOfAlreadySyncedTransactions = DocumentDatabase.Configuration.Storage.IgnoreDataIntegrityErrorsOfAlreadySyncedTransactions;
+            options.MaxNumberOfRecyclableJournals = DocumentDatabase.Configuration.Storage.MaxNumberOfRecyclableJournals;
 
             try
             {

--- a/src/Raven.Server/Documents/Indexes/Index.cs
+++ b/src/Raven.Server/Documents/Indexes/Index.cs
@@ -517,6 +517,7 @@ namespace Raven.Server.Documents.Indexes
             options.IgnoreInvalidJournalErrors = documentDatabase.Configuration.Storage.IgnoreInvalidJournalErrors;
             options.SkipChecksumValidationOnDatabaseLoading = documentDatabase.Configuration.Storage.SkipChecksumValidationOnDatabaseLoading;
             options.IgnoreDataIntegrityErrorsOfAlreadySyncedTransactions = documentDatabase.Configuration.Storage.IgnoreDataIntegrityErrorsOfAlreadySyncedTransactions;
+            options.MaxNumberOfRecyclableJournals = documentDatabase.Configuration.Storage.MaxNumberOfRecyclableJournals;
 
             if (documentDatabase.ServerStore.GlobalIndexingScratchSpaceMonitor != null)
                 options.ScratchSpaceUsage.AddMonitor(documentDatabase.ServerStore.GlobalIndexingScratchSpaceMonitor);

--- a/src/Voron/StorageEnvironmentOptions.cs
+++ b/src/Voron/StorageEnvironmentOptions.cs
@@ -528,6 +528,8 @@ namespace Voron
             public override void TryStoreJournalForReuse(VoronPathSetting filename)
             {
                 var reusedCount = 0;
+                var reusedLimit = Math.Min(_lastReusedJournalCountOnSync, MaxNumberOfRecyclableJournals);
+
                 try
                 {
                     var oldFileName = Path.GetFileName(filename.FullPath);
@@ -542,7 +544,7 @@ namespace Voron
                     {
                         reusedCount = _journalsForReuse.Count;
 
-                        if (reusedCount > _lastReusedJournalCountOnSync)
+                        if (ShouldRemoveJournal())
                         {
                             if (File.Exists(newName))
                                 File.Delete(newName);
@@ -561,7 +563,7 @@ namespace Voron
                 catch (Exception ex)
                 {
                     if (_log.IsInfoEnabled)
-                        _log.Info(reusedCount > _lastReusedJournalCountOnSync ? "Can't remove" : "Can't store" + " journal for reuse : " + filename, ex);
+                        _log.Info(ShouldRemoveJournal() ? "Can't remove" : "Can't store" + " journal for reuse : " + filename, ex);
                     try
                     {
                         if (File.Exists(filename.FullPath))
@@ -571,6 +573,11 @@ namespace Voron
                     {
                         // nothing we can do about it
                     }
+                }
+
+                bool ShouldRemoveJournal()
+                {
+                    return reusedCount >= reusedLimit;
                 }
             }
 
@@ -1224,6 +1231,8 @@ namespace Voron
         public bool? IgnoreInvalidJournalErrors { get; set; }
         public bool IgnoreDataIntegrityErrorsOfAlreadySyncedTransactions { get; set; }
         public bool SkipChecksumValidationOnDatabaseLoading { get; set; }
+
+        public int MaxNumberOfRecyclableJournals { get; set; } = 32;
 
         private readonly Logger _log;
 

--- a/test/SlowTests/Voron/Issues/RavenDB_16860.cs
+++ b/test/SlowTests/Voron/Issues/RavenDB_16860.cs
@@ -1,0 +1,59 @@
+﻿using System;
+using System.IO;
+using System.Threading;
+using FastTests.Voron;
+using Voron;
+using Voron.Impl.Journal;
+using Xunit;
+using Xunit.Abstractions;
+
+namespace SlowTests.Voron.Issues
+{
+    public class RavenDB_16860 : StorageTest
+    {
+        public RavenDB_16860(ITestOutputHelper output) : base(output)
+        {
+        }
+
+        protected override void Configure(StorageEnvironmentOptions options)
+        {
+            options.ManualFlushing = true;
+            options.MaxNumberOfRecyclableJournals = 3;
+        }
+
+        [Fact]
+        public void Should_limit_number_of_recycled_journals()
+        {
+            RequireFileBasedPager();
+
+            Assert.Equal(3, Env.Options.MaxNumberOfRecyclableJournals);
+
+            var r = new Random(1);
+
+            var bytes = new byte[1024];
+
+            for (int i = 0; i < 1000; i++)
+            {
+                using (var tx = Env.WriteTransaction())
+                {
+                    r.NextBytes(bytes);
+
+                    tx.CreateTree("items").Add($"item/{i}", new MemoryStream(bytes));
+
+                    tx.Commit();
+                }
+            }
+
+            Env.FlushLogToDataFile();
+
+            using (var op = new WriteAheadJournal.JournalApplicator.SyncOperation(Env.Journal.Applicator))
+            {
+                op.SyncDataFile();
+            }
+
+            var journalPath = ((StorageEnvironmentOptions.DirectoryStorageEnvironmentOptions)Env.Options).JournalPath.FullPath;
+
+            Assert.Equal(3, new DirectoryInfo(journalPath).GetFiles($"{StorageEnvironmentOptions.RecyclableJournalFileNamePrefix}*").Length);
+        }
+    }
+}


### PR DESCRIPTION
(default: 32 files, so that will give us 8 GB of recyclable journals in total per storage environment)

https://issues.hibernatingrhinos.com/issue/RavenDB-16860