### PR TITLE
RavenDB-16923

### DIFF
--- a/src/Raven.Server/Rachis/Elector.cs
+++ b/src/Raven.Server/Rachis/Elector.cs
@@ -386,8 +386,6 @@ namespace Raven.Server.Rachis
 
             if (_electorLongRunningWork != null && _electorLongRunningWork.ManagedThreadId != Thread.CurrentThread.ManagedThreadId)
                 _electorLongRunningWork.Join(int.MaxValue);
-
-            _engine.InMemoryDebug.RemoveRecorderOlderThan(DateTime.UtcNow.AddMinutes(-5));
         }
     }
 }

--- a/src/Raven.Server/Rachis/Elector.cs
+++ b/src/Raven.Server/Rachis/Elector.cs
@@ -1,4 +1,5 @@
 using System;
+using System.Diagnostics;
 using System.Threading;
 using Raven.Client.Http;
 using Raven.Client.ServerWide;
@@ -10,8 +11,6 @@ namespace Raven.Server.Rachis
 {
     public class Elector : IDisposable
     {
-        private const int TimeToWaitForElectorToFinishInMs = 60 * 1000;
-
         private readonly RachisConsensus _engine;
         private readonly RemoteConnection _connection;
         private PoolOfThreads.LongRunningWork _electorLongRunningWork;
@@ -23,14 +22,11 @@ namespace Raven.Server.Rachis
             _connection = connection;
         }
 
-        public void RunAndWait()
+        public void Run()
         {
-            var name = $"Elector for candidate {_connection.Source}";
+            _engine.AppendElector(this);
 
-            _electorLongRunningWork = PoolOfThreads.GlobalRavenThreadPool.LongRunning(x => HandleVoteRequest(), null, name);
-
-            if (_electorLongRunningWork.Join(TimeToWaitForElectorToFinishInMs) == false)
-                throw new InvalidOperationException($"{name} did not finish processing in {TimeToWaitForElectorToFinishInMs}ms."); // throwing will dispose the elector
+            _electorLongRunningWork = PoolOfThreads.GlobalRavenThreadPool.LongRunning(x => HandleVoteRequest(), null, $"Elector for candidate {_connection.Source}");
         }
 
         public override string ToString()
@@ -54,241 +50,252 @@ namespace Raven.Server.Rachis
                     }
                 }
 
-                while (_engine.IsDisposed == false)
+                using (this)
                 {
-                    using (_engine.ContextPool.AllocateOperationContext(out TransactionOperationContext context))
+                    while (_engine.IsDisposed == false)
                     {
-                        var rv = _connection.Read<RequestVote>(context);
-
-                        if (_engine.Log.IsInfoEnabled)
+                        using (_engine.ContextPool.AllocateOperationContext(out TransactionOperationContext context))
                         {
-                            var election = rv.IsTrialElection ? "Trial" : "Real";
-                            _engine.Log.Info($"Received ({election}) 'RequestVote' from {rv.Source}: Election is {rv.ElectionResult} in term {rv.Term} while our current term is {_engine.CurrentTerm}, " +
-                                $"Forced election is {rv.IsForcedElection}. (Sent from:{rv.SendingThread})");
-                        }
+                            var rv = _connection.Read<RequestVote>(context);
 
-                        //We are getting a request to vote for our known leader
-                        if (_engine.LeaderTag == rv.Source)
-                        {
-                            _engine.LeaderTag = null;
-                            //If we are followers we want to drop the connection with the leader right away.
-                            //We shouldn't be in any other state since if we are candidate our leaderTag should be null but its safer to verify.
-                            if (_engine.CurrentState == RachisState.Follower)
-                                _engine.SetNewState(RachisState.Follower, null, _engine.CurrentTerm, $"We got a vote request from our leader {rv.Source} so we switch to leaderless state.");
-                        }
-
-                        ClusterTopology clusterTopology;
-                        long lastLogIndex;
-                        long lastLogTerm;
-                        string whoGotMyVoteIn;
-                        long lastVotedTerm;
-
-                        using (context.OpenReadTransaction())
-                        {
-                            lastLogIndex = _engine.GetLastEntryIndex(context);
-                            lastLogTerm = _engine.GetTermForKnownExisting(context, lastLogIndex);
-                            (whoGotMyVoteIn, lastVotedTerm) = _engine.GetWhoGotMyVoteIn(context, rv.Term);
-
-                            clusterTopology = _engine.GetTopology(context);
-                        }
-
-                        // this should be only the case when we where once in a cluster, then we were brought down and our data was wiped.
-                        if (clusterTopology.TopologyId == null)
-                        {
-                            _connection.Send(context, new RequestVoteResponse
+                            if (_engine.Log.IsInfoEnabled)
                             {
-                                Term = rv.Term,
-                                VoteGranted = true,
-                                Message = "I might vote for you, because I'm not part of any cluster."
-                            });
-                            continue;
-                        }
-
-                        if (clusterTopology.Members.ContainsKey(rv.Source) == false &&
-                            clusterTopology.Promotables.ContainsKey(rv.Source) == false &&
-                            clusterTopology.Watchers.ContainsKey(rv.Source) == false)
-                        {
-                            _connection.Send(context, new RequestVoteResponse
-                            {
-                                Term = _engine.CurrentTerm,
-                                VoteGranted = false,
-                                // we only report to the node asking for our vote if we are the leader, this gives
-                                // the oust node a authoritative confirmation that they were removed from the cluster
-                                NotInTopology = _engine.CurrentState == RachisState.Leader,
-                                Message = $"Node {rv.Source} is not in my topology, cannot vote for it"
-                            });
-                            return;
-                        }
-
-                        var currentTerm = _engine.CurrentTerm;
-                        if (rv.Term == currentTerm && rv.ElectionResult == ElectionResult.Won)
-                        {
-                            if (Follower.CheckIfValidLeader(_engine, _connection, out var negotiation))
-                            {
-                                var follower = new Follower(_engine, negotiation.Term, _connection);
-                                follower.AcceptConnection(negotiation);
-                                _electionWon = true;
+                                var election = rv.IsTrialElection ? "Trial" : "Real";
+                                _engine.Log.Info($"Received ({election}) 'RequestVote' from {rv.Source}: Election is {rv.ElectionResult} in term {rv.Term} while our current term is {_engine.CurrentTerm}, " +
+                                    $"Forced election is {rv.IsForcedElection}. (Sent from:{rv.SendingThread})");
                             }
 
-                            return;
-                        }
-
-                        if (rv.ElectionResult != ElectionResult.InProgress)
-                        {
-                            return;
-                        }
-
-                        if (rv.Term <= _engine.CurrentTerm)
-                        {
-                            _connection.Send(context, new RequestVoteResponse
+                            //We are getting a request to vote for our known leader
+                            if (_engine.LeaderTag == rv.Source)
                             {
-                                Term = _engine.CurrentTerm,
-                                VoteGranted = false,
-                                Message = "My term is higher or equals to yours"
-                            });
-                            return;
-                        }
+                                _engine.LeaderTag = null;
+                                //If we are followers we want to drop the connection with the leader right away.
+                                //We shouldn't be in any other state since if we are candidate our leaderTag should be null but its safer to verify.
+                                if (_engine.CurrentState == RachisState.Follower)
+                                    _engine.SetNewState(RachisState.Follower, null, _engine.CurrentTerm, $"We got a vote request from our leader {rv.Source} so we switch to leaderless state.");
+                            }
 
-                        if (rv.LastLogTerm < lastLogTerm)
-                        {
-                            _connection.Send(context, new RequestVoteResponse
+                            ClusterTopology clusterTopology;
+                            long lastLogIndex;
+                            long lastLogTerm;
+                            string whoGotMyVoteIn;
+                            long lastVotedTerm;
+
+                            using (context.OpenReadTransaction())
+                            {
+                                lastLogIndex = _engine.GetLastEntryIndex(context);
+                                lastLogTerm = _engine.GetTermForKnownExisting(context, lastLogIndex);
+                                (whoGotMyVoteIn, lastVotedTerm) = _engine.GetWhoGotMyVoteIn(context, rv.Term);
+
+                                clusterTopology = _engine.GetTopology(context);
+                            }
+
+                            // this should be only the case when we where once in a cluster, then we were brought down and our data was wiped.
+                            if (clusterTopology.TopologyId == null)
+                            {
+                                _connection.Send(context, new RequestVoteResponse
+                                {
+                                    Term = rv.Term,
+                                    VoteGranted = true,
+                                    Message = "I might vote for you, because I'm not part of any cluster."
+                                });
+                                continue;
+                            }
+
+                            if (clusterTopology.Members.ContainsKey(rv.Source) == false &&
+                                clusterTopology.Promotables.ContainsKey(rv.Source) == false &&
+                                clusterTopology.Watchers.ContainsKey(rv.Source) == false)
+                            {
+                                _connection.Send(context, new RequestVoteResponse
+                                {
+                                    Term = _engine.CurrentTerm,
+                                    VoteGranted = false,
+                                    // we only report to the node asking for our vote if we are the leader, this gives
+                                    // the oust node a authoritative confirmation that they were removed from the cluster
+                                    NotInTopology = _engine.CurrentState == RachisState.Leader,
+                                    Message = $"Node {rv.Source} is not in my topology, cannot vote for it"
+                                });
+                                return;
+                            }
+
+                            var currentTerm = _engine.CurrentTerm;
+                            if (rv.Term == currentTerm && rv.ElectionResult == ElectionResult.Won)
+                            {
+                                if (Follower.CheckIfValidLeader(_engine, _connection, out var negotiation))
+                                {
+                                    _electionWon = true;
+                                    try
+                                    {
+                                        var follower = new Follower(_engine, negotiation.Term, _connection);
+                                        follower.AcceptConnection(negotiation);
+                                    }
+                                    catch
+                                    {
+                                        _electionWon = false;
+                                        throw;
+                                    }
+                                }
+
+                                return;
+                            }
+
+                            if (rv.ElectionResult != ElectionResult.InProgress)
+                            {
+                                return;
+                            }
+
+                            if (rv.Term <= _engine.CurrentTerm)
+                            {
+                                _connection.Send(context, new RequestVoteResponse
+                                {
+                                    Term = _engine.CurrentTerm,
+                                    VoteGranted = false,
+                                    Message = "My term is higher or equals to yours"
+                                });
+                                return;
+                            }
+
+                            if (rv.LastLogTerm < lastLogTerm)
+                            {
+                                _connection.Send(context, new RequestVoteResponse
                                 {
                                     Term = _engine.CurrentTerm,
                                     VoteGranted = false,
                                     Message = $"My last log term is {lastLogTerm} and higher than yours {rv.LastLogTerm}"
                                 });
-                            return;
-                        }
+                                return;
+                            }
 
 
-                        if (rv.IsForcedElection == false &&
-                            (
-                                _engine.CurrentState == RachisState.Leader ||
-                                _engine.CurrentState == RachisState.LeaderElect
+                            if (rv.IsForcedElection == false &&
+                                (
+                                    _engine.CurrentState == RachisState.Leader ||
+                                    _engine.CurrentState == RachisState.LeaderElect
+                                )
                             )
-                        )
-                        {
-                            _connection.Send(context, new RequestVoteResponse
+                            {
+                                _connection.Send(context, new RequestVoteResponse
                                 {
                                     Term = _engine.CurrentLeader.Term,
                                     VoteGranted = false,
                                     Message = "I'm a leader in good standing, coup will be resisted"
                                 });
-                            return;
-                        }
+                                return;
+                            }
 
-                        if (whoGotMyVoteIn != null && whoGotMyVoteIn != rv.Source)
-                        {
-                            _connection.Send(context, new RequestVoteResponse
+                            if (whoGotMyVoteIn != null && whoGotMyVoteIn != rv.Source)
+                            {
+                                _connection.Send(context, new RequestVoteResponse
                                 {
                                     Term = _engine.CurrentTerm,
                                     VoteGranted = false,
                                     Message = $"Already voted in {rv.LastLogTerm}, for {whoGotMyVoteIn}"
                                 });
-                            continue;
-                        }
+                                continue;
+                            }
 
-                        if (lastVotedTerm > rv.Term)
-                        {
-                            _connection.Send(context, new RequestVoteResponse
+                            if (lastVotedTerm > rv.Term)
+                            {
+                                _connection.Send(context, new RequestVoteResponse
                                 {
                                     Term = _engine.CurrentTerm,
                                     VoteGranted = false,
                                     Message = $"Already voted for another node in {lastVotedTerm}"
                                 });
-                            continue;
-                        }
-
-                        if (rv.Term > _engine.CurrentTerm + 1)
-                        {
-                            // trail election is often done on the current term + 1, but if there is any
-                            // election on a term that is greater than the current term plus one, we should
-                            // consider this an indication that the cluster was able to move past our term
-                            // and update the term accordingly
-                            using (context.OpenWriteTransaction())
-                            {
-                                // double checking things under the transaction lock
-                                if (rv.Term > _engine.CurrentTerm + 1)
-                                {
-                                    _engine.CastVoteInTerm(context, rv.Term - 1, null, "Noticed that the term in the cluster grew beyond what I was familiar with, increasing it");
-                                }
-                                context.Transaction.Commit();
+                                continue;
                             }
 
-                            _connection.Send(context, new RequestVoteResponse
+                            if (rv.Term > _engine.CurrentTerm + 1)
                             {
-                                Term = _engine.CurrentTerm,
-                                VoteGranted = false,
-                                Message = $"Increasing my term to {_engine.CurrentTerm}"
-                            });
-                            continue;
-                        }
+                                // trail election is often done on the current term + 1, but if there is any
+                                // election on a term that is greater than the current term plus one, we should
+                                // consider this an indication that the cluster was able to move past our term
+                                // and update the term accordingly
+                                using (context.OpenWriteTransaction())
+                                {
+                                    // double checking things under the transaction lock
+                                    if (rv.Term > _engine.CurrentTerm + 1)
+                                    {
+                                        _engine.CastVoteInTerm(context, rv.Term - 1, null, "Noticed that the term in the cluster grew beyond what I was familiar with, increasing it");
+                                    }
+                                    context.Transaction.Commit();
+                                }
 
-                        if (rv.IsTrialElection)
-                        {
-                            if (_engine.Timeout.ExpiredLastDeferral(_engine.ElectionTimeout.TotalMilliseconds / 2, out string currentLeader) == false
-                                && string.IsNullOrEmpty(currentLeader) == false) // if we are leaderless we can't refuse to cast our vote.
-                            {
                                 _connection.Send(context, new RequestVoteResponse
+                                {
+                                    Term = _engine.CurrentTerm,
+                                    VoteGranted = false,
+                                    Message = $"Increasing my term to {_engine.CurrentTerm}"
+                                });
+                                continue;
+                            }
+
+                            if (rv.IsTrialElection)
+                            {
+                                if (_engine.Timeout.ExpiredLastDeferral(_engine.ElectionTimeout.TotalMilliseconds / 2, out string currentLeader) == false
+                                    && string.IsNullOrEmpty(currentLeader) == false) // if we are leaderless we can't refuse to cast our vote.
+                                {
+                                    _connection.Send(context, new RequestVoteResponse
                                     {
                                         Term = _engine.CurrentTerm,
                                         VoteGranted = false,
                                         Message = $"My leader {currentLeader} is keeping me up to date, so I don't want to vote for you"
                                     });
-                                continue;
-                            }
+                                    continue;
+                                }
 
-                            if (lastLogTerm == rv.LastLogTerm && lastLogIndex > rv.LastLogIndex)
-                            {
-                                _connection.Send(context, new RequestVoteResponse
+                                if (lastLogTerm == rv.LastLogTerm && lastLogIndex > rv.LastLogIndex)
+                                {
+                                    _connection.Send(context, new RequestVoteResponse
                                     {
                                         Term = _engine.CurrentTerm,
                                         VoteGranted = false,
                                         Message = $"My log {lastLogIndex} is more up to date than yours {rv.LastLogIndex}"
                                     });
+                                    continue;
+                                }
+
+                                _connection.Send(context, new RequestVoteResponse
+                                {
+                                    Term = rv.Term,
+                                    VoteGranted = true,
+                                    Message = "I might vote for you"
+                                });
                                 continue;
                             }
 
-                            _connection.Send(context, new RequestVoteResponse
+
+                            _engine.ForTestingPurposes?.BeforeCastingForRealElection();
+
+                            HandleVoteResult result;
+                            using (context.OpenWriteTransaction())
                             {
-                                Term = rv.Term,
-                                VoteGranted = true,
-                                Message = "I might vote for you"
-                            });
-                            continue;
-                        }
-
-
-                        _engine.ForTestingPurposes?.BeforeCastingForRealElection();
-
-                        HandleVoteResult result;
-                        using (context.OpenWriteTransaction())
-                        {
-                            result = ShouldGrantVote(context, lastLogIndex, rv);
-                            if (result.DeclineVote == false)
-                            {
-                                _engine.CastVoteInTerm(context, rv.Term, rv.Source, "Casting vote as elector");
-                                context.Transaction.Commit();
+                                result = ShouldGrantVote(context, lastLogIndex, rv);
+                                if (result.DeclineVote == false)
+                                {
+                                    _engine.CastVoteInTerm(context, rv.Term, rv.Source, "Casting vote as elector");
+                                    context.Transaction.Commit();
+                                }
                             }
-                        }
 
-                        if (result.DeclineVote)
-                        {
-                            _connection.Send(context, new RequestVoteResponse
+                            if (result.DeclineVote)
                             {
-                                Term = result.VotedTerm,
-                                VoteGranted = false,
-                                Message = result.DeclineReason
-                            });
-                        }
-                        else
-                        {
-                            _connection.Send(context, new RequestVoteResponse
+                                _connection.Send(context, new RequestVoteResponse
+                                {
+                                    Term = result.VotedTerm,
+                                    VoteGranted = false,
+                                    Message = result.DeclineReason
+                                });
+                            }
+                            else
                             {
-                                Term = rv.Term,
-                                VoteGranted = true,
-                                Message = "I've voted for you"
-                            });
+                                _connection.Send(context, new RequestVoteResponse
+                                {
+                                    Term = rv.Term,
+                                    VoteGranted = true,
+                                    Message = "I've voted for you"
+                                });
+                            }
                         }
                     }
                 }

--- a/src/Raven.Server/Rachis/RachisConsensus.cs
+++ b/src/Raven.Server/Rachis/RachisConsensus.cs
@@ -33,6 +33,7 @@ using Sparrow.Server.Utils;
 using System.Linq;
 using Raven.Server.Rachis.Remote;
 using System.Net.Security;
+using Sparrow.Collections;
 
 namespace Raven.Server.Rachis
 {
@@ -1172,8 +1173,8 @@ namespace Raven.Server.Rachis
                     switch (initialMessage.InitialMessageType)
                     {
                         case InitialMessageType.RequestVote:
-                            var elector = new Elector(this, remoteConnection);
-                            elector.Run();
+                            using (var elector = new Elector(this, remoteConnection))
+                                elector.RunAndWait();
                             break;
                         case InitialMessageType.AppendEntries:
                             if (Follower.CheckIfValidLeader(this, remoteConnection, out var negotiation))

--- a/src/Raven.Server/RavenServer.cs
+++ b/src/Raven.Server/RavenServer.cs
@@ -1877,7 +1877,7 @@ namespace Raven.Server
 
         private void ListenToNewTcpConnection(TcpListener listener)
         {
-            Task.Run(async () =>
+            Task.Factory.StartNew(async () =>
             {
                 var tcpClient = await AcceptTcpClientAsync(listener);
                 if (tcpClient == null)
@@ -1979,7 +1979,7 @@ namespace Raven.Server
                         _tcpLogger.Info("Failure when processing tcp connection", e);
                     }
                 }
-            });
+            }, TaskCreationOptions.LongRunning);
         }
 
         private async Task DispatchTcpConnection(TcpConnectionHeaderMessage header, TcpConnectionOptions tcp, JsonOperationContext.ManagedPinnedBuffer buffer)

--- a/src/Raven.Server/RavenServer.cs
+++ b/src/Raven.Server/RavenServer.cs
@@ -362,7 +362,7 @@ namespace Raven.Server
                 {
                     msg += $" Automatic renewal is no longer possible. Please check the logs for errors and contact support@ravendb.net.";
                 }
-                
+
                 ServerStore.NotificationCenter.Add(AlertRaised.Create(null, CertificateReplacement.CertReplaceAlertTitle, msg, AlertType.Certificates_Expiration, NotificationSeverity.Error));
 
                 if (Logger.IsOperationsEnabled)
@@ -388,7 +388,7 @@ namespace Raven.Server
 
                 ServerStore.NotificationCenter.Add(AlertRaised.Create(null, CertificateReplacement.CertReplaceAlertTitle, msg, AlertType.Certificates_Expiration, severity));
 
-                if (Logger.IsOperationsEnabled) 
+                if (Logger.IsOperationsEnabled)
                     Logger.Operations(msg);
             }
             else
@@ -906,7 +906,7 @@ namespace Raven.Server
         public void RefreshClusterCertificateTimerCallback(object state)
         {
             RefreshClusterCertificate(state, RaftIdGenerator.NewId());
-            
+
             try
             {
                 UpdateCertificateExpirationAlert();
@@ -1366,7 +1366,7 @@ namespace Raven.Server
                     if (Logger.IsOperationsEnabled)
                         Logger.Operations($"You are using the configuration property '{RavenConfiguration.GetKey(x => x.Security.CertificateLoadExec)}', without specifying '{RavenConfiguration.GetKey(x => x.Security.CertificateRenewExec)}' and '{RavenConfiguration.GetKey(x => x.Security.CertificateChangeExec)}'. This configuration requires you to renew the certificate manually across the entire cluster.");
                 }
-                
+
                 return LoadCertificate();
             }
             catch (Exception e)
@@ -1979,7 +1979,7 @@ namespace Raven.Server
                         _tcpLogger.Info("Failure when processing tcp connection", e);
                     }
                 }
-            }, TaskCreationOptions.LongRunning);
+            });
         }
 
         private async Task DispatchTcpConnection(TcpConnectionHeaderMessage header, TcpConnectionOptions tcp, JsonOperationContext.ManagedPinnedBuffer buffer)


### PR DESCRIPTION
- Elector should set thread priority to AboveNormal like Follower
- Background worker should self dispose like in Follower to avoid TCP connection leak
- Registering elector in engine disposables to avoid background worker leak which could result in TCP connection leak