### PR TITLE
RavenDB-14759

### DIFF
--- a/src/Raven.Server/Documents/DatabaseInfoCache.cs
+++ b/src/Raven.Server/Documents/DatabaseInfoCache.cs
@@ -51,7 +51,7 @@ namespace Raven.Server.Documents
                 using (var id = context.GetLazyString(databaseName.ToLowerInvariant()))
                 using (var json = context.ReadObject(databaseInfo, "DatabaseInfo", BlittableJsonDocumentBuilder.UsageMode.ToDisk))
                 {
-                    using (var tx = context.OpenWriteTransaction())
+                    using (var tx = context.OpenWriteTransaction(TimeSpan.FromSeconds(5)))
                     {
                         var table = tx.InnerTransaction.OpenTable(_databaseInfoSchema, DatabaseInfoSchema.DatabaseInfoTree);
                         using (table.Allocate(out TableValueBuilder tvb))

--- a/src/Raven.Server/Documents/Replication/ReplicationLoader.cs
+++ b/src/Raven.Server/Documents/Replication/ReplicationLoader.cs
@@ -438,6 +438,9 @@ namespace Raven.Server.Documents.Replication
 
                 foreach (var failure in _reconnectQueue)
                 {
+                    if (Database.DatabaseShutdown.IsCancellationRequested)
+                        return;
+
                     try
                     {
                         if (_reconnectQueue.TryRemove(failure) == false)

--- a/src/Raven.Server/RavenServer.cs
+++ b/src/Raven.Server/RavenServer.cs
@@ -75,7 +75,7 @@ namespace Raven.Server
 
         private static readonly Logger Logger = LoggingSource.Instance.GetLogger<RavenServer>("Server");
         private readonly Logger _authAuditLog = LoggingSource.AuditLog.GetLogger("AuthenticateCertificate", "Audit");
-        private TestingStuff _forTestingPurposes;
+        internal TestingStuff _forTestingPurposes;
 
         public readonly RavenConfiguration Configuration;
 
@@ -2614,6 +2614,7 @@ namespace Raven.Server
         {
             internal bool ThrowExceptionInListenToNewTcpConnection = false;
             internal bool ThrowExceptionInTrafficWatchTcp = false;
+            internal bool GatherVerboseDatabaseDisposeInformation = false;
         }
     }
 }

--- a/test/RachisTests/DatabaseCluster/ClusterDatabaseMaintenance.cs
+++ b/test/RachisTests/DatabaseCluster/ClusterDatabaseMaintenance.cs
@@ -280,6 +280,9 @@ namespace RachisTests.DatabaseCluster
                 [RavenConfiguration.GetKey(x => x.Cluster.MoveToRehabGraceTime)] = "5",
             };
             var cluster = await CreateRaftCluster(clusterSize, false, 0, watcherCluster: true, customSettings: settings);
+
+            Servers.ForEach(x => x.ForTestingPurposesOnly().GatherVerboseDatabaseDisposeInformation = true);
+
             using (var store = new DocumentStore { Urls = new[] { cluster.Leader.WebUrl } }.Initialize())
             {
                 var names = new List<string>();
@@ -312,6 +315,8 @@ namespace RachisTests.DatabaseCluster
                     DataDirectory = result.DataDirectory,
                     CustomSettings = settings
                 });
+
+                cluster.Nodes[2].ForTestingPurposesOnly().GatherVerboseDatabaseDisposeInformation = true;
 
                 var preferredCount = new Dictionary<string, int> { ["A"] = 0, ["B"] = 0, ["C"] = 0 };
 

--- a/test/Tests.Infrastructure/TestBase.cs
+++ b/test/Tests.Infrastructure/TestBase.cs
@@ -13,6 +13,7 @@ using System.Threading;
 using System.Threading.Tasks;
 using Newtonsoft.Json.Linq;
 using Raven.Client;
+using Raven.Client.Extensions;
 using Raven.Client.Http;
 using Raven.Client.Util;
 using Raven.Debug.StackTrace;
@@ -782,7 +783,7 @@ namespace FastTests
             return Task.CompletedTask;
         }
 
-        protected static void DisposeServer(RavenServer server, int timeoutInMs = 60_000)
+        protected static void DisposeServer(RavenServer server, int timeoutInMs = 300_000)
         {
             if (server == null)
                 return;
@@ -794,6 +795,7 @@ namespace FastTests
             var debugTag = server.DebugTag;
             var timeout = TimeSpan.FromMilliseconds(timeoutInMs);
 
+            using (DebugHelper.GatherVerboseDatabaseDisposeInformation(server, timeoutInMs))
             using (var mre = new ManualResetEventSlim())
             {
                 server.AfterDisposal += () => mre.Set();
@@ -806,7 +808,7 @@ namespace FastTests
             }
         }
 
-        protected static async Task DisposeServerAsync(RavenServer server, int timeoutInMs = 60_000)
+        protected static async Task DisposeServerAsync(RavenServer server, int timeoutInMs = 300_000)
         {
             if (server == null)
                 return;
@@ -818,6 +820,7 @@ namespace FastTests
             var debugTag = server.DebugTag;
             var timeout = TimeSpan.FromMilliseconds(timeoutInMs);
 
+            using (await DebugHelper.GatherVerboseDatabaseDisposeInformationAsync(server, timeoutInMs))
             using (var mre = new AsyncManualResetEvent())
             {
                 server.AfterDisposal += () => mre.Set();
@@ -849,7 +852,6 @@ namespace FastTests
 
                     throw new InvalidOperationException($"Could not dispose server with URL '{url}' and DebugTag: '{debugTag}' in '{timeout}'. StackTraces available at: '{tempPath}'");
                 }
-
             }
         }
     }

--- a/test/Tests.Infrastructure/Utils/DebugHelper.cs
+++ b/test/Tests.Infrastructure/Utils/DebugHelper.cs
@@ -1,0 +1,85 @@
+﻿using System;
+using System.Collections.Concurrent;
+using System.Text;
+using System.Threading.Tasks;
+using Raven.Client.Extensions;
+using Raven.Client.Util;
+using Raven.Server;
+using Raven.Server.Documents;
+using Xunit;
+
+namespace Tests.Infrastructure.Utils
+{
+    internal static class DebugHelper
+    {
+        public static async Task<IDisposable> GatherVerboseDatabaseDisposeInformationAsync(RavenServer server, int timeoutInMs)
+        {
+            if (server?._forTestingPurposes == null || server._forTestingPurposes.GatherVerboseDatabaseDisposeInformation == false)
+                return null;
+
+            var databaseDisposeLog = new ConcurrentDictionary<string, ConcurrentQueue<string>>(StringComparer.OrdinalIgnoreCase);
+
+            foreach (var databaseTask in server.ServerStore.DatabasesLandlord.DatabasesCache.Values)
+            {
+                if (databaseTask.IsFaulted)
+                    continue;
+
+                Assert.True(await databaseTask.WaitWithTimeout(TimeSpan.FromMilliseconds(timeoutInMs)));
+                var database = await databaseTask;
+                AttachDatabaseDisposeLog(databaseDisposeLog, database);
+            }
+
+            return new DisposableAction(() =>
+            {
+                PrintDatabaseDisposeLog(databaseDisposeLog);
+            });
+        }
+
+        public static IDisposable GatherVerboseDatabaseDisposeInformation(RavenServer server, int timeoutInMs)
+        {
+            if (server?._forTestingPurposes == null || server._forTestingPurposes.GatherVerboseDatabaseDisposeInformation == false)
+                return null;
+
+            var databaseDisposeLog = new ConcurrentDictionary<string, ConcurrentQueue<string>>(StringComparer.OrdinalIgnoreCase);
+
+            foreach (var databaseTask in server.ServerStore.DatabasesLandlord.DatabasesCache.Values)
+            {
+                if (databaseTask.IsFaulted)
+                    continue;
+
+                Assert.True(databaseTask.Wait(TimeSpan.FromMilliseconds(timeoutInMs)));
+                var database = databaseTask.Result;
+                AttachDatabaseDisposeLog(databaseDisposeLog, database);
+            }
+
+            return new DisposableAction(() =>
+            {
+                PrintDatabaseDisposeLog(databaseDisposeLog);
+            });
+        }
+
+        private static void AttachDatabaseDisposeLog(ConcurrentDictionary<string, ConcurrentQueue<string>> log, DocumentDatabase database)
+        {
+            database.ForTestingPurposesOnly().DisposeLog += (name, message) =>
+            {
+                var logs = log.GetOrAdd(name, _ => new ConcurrentQueue<string>());
+                logs.Enqueue($"[{DateTime.UtcNow:O}] {message}");
+            };
+        }
+
+        private static void PrintDatabaseDisposeLog(ConcurrentDictionary<string, ConcurrentQueue<string>> log)
+        {
+            if (log == null)
+                return;
+
+            var sb = new StringBuilder($"Databases Dispose Log:{Environment.NewLine}");
+            foreach (var kvp in log)
+            {
+                foreach (string message in kvp.Value)
+                    sb.AppendLine($"[{kvp.Key}] {message}");
+            }
+
+            Console.WriteLine(sb);
+        }
+    }
+}

--- a/test/Tryouts/Program.cs
+++ b/test/Tryouts/Program.cs
@@ -2,6 +2,7 @@ using System;
 using System.Diagnostics;
 using System.Threading.Tasks;
 using FastTests.Client;
+using RachisTests.DatabaseCluster;
 using SlowTests.Bugs;
 using SlowTests.Client.Counters;
 using SlowTests.Cluster;
@@ -18,7 +19,7 @@ namespace Tryouts
         {
             XunitLogging.RedirectStreams = false;
         }
-        
+
         public static async Task Main(string[] args)
         {
             Console.WriteLine(Process.GetCurrentProcess().Id);
@@ -30,9 +31,9 @@ namespace Tryouts
                 try
                 {
                     using (var testOutputHelper = new ConsoleTestOutputHelper())
-                    using (var test = new ClusterTransactionTests(testOutputHelper))
+                    using (var test = new ClusterDatabaseMaintenance(testOutputHelper))
                     {
-                        await test.ClusterTransactionWaitForIndexes(10);
+                        await test.ReshuffleAfterPromotion();
                     }
                 }
                 catch (Exception e)


### PR DESCRIPTION
- wait only up to 5 seconds for tx lock when writing database info
- added verbose dispose log to use in tests
- increased dispose time to 5 minutes