### PR TITLE
RavenDB-16906 : TimeSeriesFor - better error on null entity

### DIFF
--- a/src/Raven.Client/Documents/Session/SessionTimeSeriesBase.cs
+++ b/src/Raven.Client/Documents/Session/SessionTimeSeriesBase.cs
@@ -38,9 +38,12 @@ namespace Raven.Client.Documents.Session
 
         protected SessionTimeSeriesBase(InMemoryDocumentSessionOperations session, object entity, string name)
         {
+            if (entity == null)
+                throw new ArgumentNullException(nameof(entity));
+
             if (session.DocumentsByEntity.TryGetValue(entity, out DocumentInfo document) == false || document == null)
             {
-                ThrowEntityNotInSession(entity);
+                ThrowEntityNotInSession();
                 return;
             }
 
@@ -127,9 +130,9 @@ namespace Raven.Client.Documents.Session
         }
 
 
-        protected void ThrowEntityNotInSession(object entity)
+        protected static void ThrowEntityNotInSession()
         {
-            throw new ArgumentException("entity is not associated with the session, cannot add timeseries to it. " +
+            throw new ArgumentException("entity is not associated with the session, cannot perform timeseries operations on it. " +
                                         "Use documentId instead or track the entity in the session.");
         }
 

--- a/test/SlowTests/Client/TimeSeries/Issues/RavenDB-16906.cs
+++ b/test/SlowTests/Client/TimeSeries/Issues/RavenDB-16906.cs
@@ -1,0 +1,29 @@
+﻿using System;
+using FastTests;
+using Xunit;
+using Xunit.Abstractions;
+using User = SlowTests.Core.Utils.Entities.User;
+
+namespace SlowTests.Client.TimeSeries.Issues
+{
+    public class RavenDB_16906 : RavenTestBase
+    {
+        public RavenDB_16906(ITestOutputHelper output) : base(output)
+        {
+        }
+
+        [Fact]
+        public void TimeSeriesFor_ShouldThrowBetterError_OnNullEntity()
+        {
+            using (var store = GetDocumentStore())
+            {
+                using (var session = store.OpenSession())
+                {
+                    var user = session.Load<User>("users/1");
+                    var e = Assert.Throws<ArgumentNullException>(() => session.TimeSeriesFor(user, "HeartRate"));
+                    Assert.Contains("Value cannot be null. (Parameter 'entity')", e.Message);
+                }
+            }
+        }
+    }
+}


### PR DESCRIPTION
https://issues.hibernatingrhinos.com/issue/RavenDB-16906