### PR TITLE
RavenDB-16965 : fix olap test failures

### DIFF
--- a/src/Raven.Server/Documents/ETL/Providers/OLAP/OlaptEtl.cs
+++ b/src/Raven.Server/Documents/ETL/Providers/OLAP/OlaptEtl.cs
@@ -331,7 +331,6 @@ namespace Raven.Server.Documents.ETL.Providers.OLAP
             _uploaderSettings.FilePath = localPath;
             _uploaderSettings.FileName = uploadInfo.FileName;
             _uploaderSettings.FolderName = uploadInfo.FolderName;
-            _uploaderSettings.SafeFolderName = uploadInfo.SafeFolderName;
             
             var backupUploader = new BackupUploader(_uploaderSettings, retentionPolicyParameters: null, Logger, GenerateUploadResult(), onProgress: ProgressNotification, _operationCancelToken);
 
@@ -365,7 +364,6 @@ namespace Raven.Server.Documents.ETL.Providers.OLAP
             _uploaderSettings.FilePath = null;
             _uploaderSettings.FileName = uploadInfo.FileName;
             _uploaderSettings.FolderName = uploadInfo.FolderName;
-            _uploaderSettings.SafeFolderName = uploadInfo.SafeFolderName;
 
             var backupUploader = new BackupUploader(_uploaderSettings, retentionPolicyParameters: null, Logger, GenerateUploadResult(), onProgress: ProgressNotification, _operationCancelToken);
 

--- a/src/Raven.Server/Documents/ETL/Providers/OLAP/ParquetTransformedItems.cs
+++ b/src/Raven.Server/Documents/ETL/Providers/OLAP/ParquetTransformedItems.cs
@@ -55,9 +55,6 @@ namespace Raven.Server.Documents.ETL.Providers.OLAP
         private const string DateTimeFormat = "yyyy-MM-dd-HH-mm-ss.ffffff";
         private const string Extension = "parquet";
 
-        private static readonly HashSet<char> SpecialChars = new HashSet<char> { '&', '@', ':', ',', '$', '=', '+', '?', ';', ' ', '"', '^', '`', '>', '<', '{', '}', '[', ']', '#', '\'', '~', '|' };
-        private const string EncodingFormat = "%{0:X2}";
-
         private static readonly HashSet<char> InvalidFileNameChars = Path.GetInvalidFileNameChars().ToHashSet();
 
         private static readonly long UnixEpochTicks = new DateTime(1970, 1, 1).Ticks;
@@ -135,8 +132,7 @@ namespace Raven.Server.Documents.ETL.Providers.OLAP
             uploadInfo = new UploadInfo
             {
                 FileName = $"{nowAsString}-{_fileNameSuffix}.{Extension}", 
-                FolderName = _key, 
-                SafeFolderName = _remoteFolderName
+                FolderName = _remoteFolderName, 
             };
 
             var localPath = Path.Combine(_tmpFilePath, _localFolderName ?? string.Empty, uploadInfo.FileName);
@@ -785,12 +781,6 @@ namespace Raven.Server.Documents.ETL.Providers.OLAP
                 if (@char == '/')
                 {
                     builder.Append('_');
-                    continue;
-                }
-
-                if (SpecialChars.Contains(@char) || @char <= 31 || @char == 127)
-                {
-                    builder.AppendFormat(EncodingFormat, (int)@char);
                     continue;
                 }
 

--- a/src/Raven.Server/Documents/ETL/Providers/OLAP/UploadInfo.cs
+++ b/src/Raven.Server/Documents/ETL/Providers/OLAP/UploadInfo.cs
@@ -4,6 +4,5 @@ namespace Raven.Server.Documents.ETL.Providers.OLAP
     {
         public string FileName;
         public string FolderName;
-        public string SafeFolderName;
     }
 }

--- a/test/SlowTests/Server/Documents/ETL/Olap/S3Tests.cs
+++ b/test/SlowTests/Server/Documents/ETL/Olap/S3Tests.cs
@@ -162,7 +162,7 @@ loadToOrders(partitionBy(key),
 
                         Assert.Equal(1, cloudObjects.FileInfoDetails.Count);
 
-                        var fullPath = cloudObjects.FileInfoDetails[0].FullPath.Replace("=", "%3D");
+                        var fullPath = cloudObjects.FileInfoDetails[0].FullPath;
                         var blob = await s3Client.GetObjectAsync(fullPath);
 
                         await using var ms = new MemoryStream();
@@ -332,7 +332,7 @@ loadToOrders(partitionBy(key), orderData);
                         Assert.Contains("2020-01-01", cloudObjects.FileInfoDetails[0].FullPath);
                         Assert.Contains("2020-02-01", cloudObjects.FileInfoDetails[1].FullPath);
 
-                        var fullPath = cloudObjects.FileInfoDetails[0].FullPath.Replace("=", "%3D");
+                        var fullPath = cloudObjects.FileInfoDetails[0].FullPath;
                         var blob = await s3Client.GetObjectAsync(fullPath);
 
                         await using var ms = new MemoryStream();
@@ -365,7 +365,7 @@ loadToOrders(partitionBy(key), orderData);
                         Assert.Contains("2020-01-01", cloudObjects.FileInfoDetails[0].FullPath);
                         Assert.Contains("2020-02-01", cloudObjects.FileInfoDetails[1].FullPath);
 
-                        var fullPath = cloudObjects.FileInfoDetails[1].FullPath.Replace("=", "%3D");
+                        var fullPath = cloudObjects.FileInfoDetails[1].FullPath;
                         var blob = await s3Client.GetObjectAsync(fullPath);
 
                         await using var ms = new MemoryStream();
@@ -689,7 +689,7 @@ loadToOrders(partitionBy(
 
                         foreach (var filePath in files)
                         {
-                            var blob = await s3Client.GetObjectAsync(filePath.Replace("=", "%3D"));
+                            var blob = await s3Client.GetObjectAsync(filePath);
                             await using var ms = new MemoryStream();
                             blob.Data.CopyTo(ms);
 


### PR DESCRIPTION
remove notation of 'safe-folder' and special chars handing (no need for that with the official clients)