### PR TITLE
RavenDB-16993 - Make CheckReferenceBecauseOfDocumentUpdate duration configurable

### DIFF
--- a/Raven.Database/Config/InMemoryRavenConfiguration.cs
+++ b/Raven.Database/Config/InMemoryRavenConfiguration.cs
@@ -504,6 +504,8 @@ namespace Raven.Database.Config
 
         public TimeSpan TimeToWaitBeforeMarkingIdleIndexAsAbandoned { get; private set; }
 
+        public TimeSpan CheckReferenceBecauseOfDocumentUpdateTimeout { get; set; }
+
         private void CheckDirectoryPermissions()
         {
             var tempPath = TempPath;

--- a/Raven.Database/Config/StronglyTypedRavenSettings.cs
+++ b/Raven.Database/Config/StronglyTypedRavenSettings.cs
@@ -232,6 +232,8 @@ namespace Raven.Database.Config
 
             TimeToWaitBeforeMarkingIdleIndexAsAbandoned = new TimeSpanSetting(settings["Raven/TimeToWaitBeforeMarkingIdleIndexAsAbandoned"], TimeSpan.FromHours(72), TimeSpanArgumentType.FromParse);
 
+            CheckReferenceBecauseOfDocumentUpdateTimeout = new TimeSpanSetting(settings["Raven/CheckReferenceBecauseOfDocumentUpdateTimeoutInSeconds"], TimeSpan.FromSeconds(30), TimeSpanArgumentType.FromParse);
+
             TimeToWaitBeforeRunningAbandonedIndexes = new TimeSpanSetting(settings["Raven/TimeToWaitBeforeRunningAbandonedIndexes"], TimeSpan.FromHours(3), TimeSpanArgumentType.FromParse);
 
             DisableClusterDiscovery = new BooleanSetting(settings["Raven/DisableClusterDiscovery"], false);
@@ -518,6 +520,8 @@ namespace Raven.Database.Config
         public TimeSpanSetting TimeToWaitBeforeMarkingAutoIndexAsIdle { get; private set; }
 
         public TimeSpanSetting TimeToWaitBeforeMarkingIdleIndexAsAbandoned { get; private set; }
+
+        public TimeSpanSetting CheckReferenceBecauseOfDocumentUpdateTimeout { get; private set; }
 
         public TimeSpanSetting TimeToWaitBeforeRunningAbandonedIndexes { get; private set; }
 

--- a/Raven.Database/Impl/DatabaseBulkOperations.cs
+++ b/Raven.Database/Impl/DatabaseBulkOperations.cs
@@ -148,6 +148,12 @@ namespace Raven.Database.Impl
                                     shouldWaitNow = true;
                                     break;
                                 }
+
+                                if (batchCount % 16 == 0 && duration.ElapsedMilliseconds > 5000)
+                                {
+                                    shouldWaitNow = true;
+                                    break;
+                                }
                             }
                         });
                     }

--- a/Raven.Tests.Core/Configuration/ConfigurationTests.cs
+++ b/Raven.Tests.Core/Configuration/ConfigurationTests.cs
@@ -231,6 +231,7 @@ namespace Raven.Tests.Core.Configuration
             configurationComparer.Assert(expected => expected.TimeToWaitBeforeRunningIdleIndexes.Value, actual => actual.TimeToWaitBeforeRunningIdleIndexes);
             configurationComparer.Assert(expected => expected.TimeToWaitBeforeRunningAbandonedIndexes.Value, actual => actual.TimeToWaitBeforeRunningAbandonedIndexes);
             configurationComparer.Assert(expected => expected.TimeToWaitBeforeMarkingIdleIndexAsAbandoned.Value, actual => actual.TimeToWaitBeforeMarkingIdleIndexAsAbandoned);
+            configurationComparer.Assert(expected => expected.CheckReferenceBecauseOfDocumentUpdateTimeout.Value, actual => actual.TimeToWaitBeforeMarkingIdleIndexAsAbandoned);
 
             configurationComparer.Assert(expected => expected.WebSockets.InitialBufferPoolSize.Value, actual => actual.WebSockets.InitialBufferPoolSize);
 


### PR DESCRIPTION
https://issues.hibernatingrhinos.com/issue/RavenDB-16993