### PR TITLE
RavenDB-15312 Make sure we won't get negative values about available memory when process or job memory limits are defined

### DIFF
--- a/src/Sparrow.Server/LowMemory/MemoryInformation.cs
+++ b/src/Sparrow.Server/LowMemory/MemoryInformation.cs
@@ -645,8 +645,8 @@ namespace Sparrow.LowMemory
                 if (maxSize != long.MaxValue)
                 {
                     long workingSet64 = Process.GetCurrentProcess().WorkingSet64;
-                    availableMemoryForProcessingInBytes = maxSize - workingSet64;
-                    availPageFile = maxSize - workingSet64;
+                    availableMemoryForProcessingInBytes = Math.Max(maxSize - workingSet64, 0);
+                    availPageFile = Math.Max(maxSize - workingSet64, 0);
                     totalPageFile = maxSize;
                     memoryStatusUllAvailPhys = Math.Min(availableMemoryForProcessingInBytes, memoryStatusUllAvailPhys);
                     remarks = "Memory limited by Job Object limits";


### PR DESCRIPTION
PR comment fix - https://github.com/ravendb/ravendb/pull/12506/files#r673836549