### PR TITLE
RavenDB-17056

### DIFF
--- a/src/Raven.Server/Utils/ExceptionHelper.cs
+++ b/src/Raven.Server/Utils/ExceptionHelper.cs
@@ -1,5 +1,6 @@
 ﻿using System;
 using System.ComponentModel;
+using Raven.Server.Exceptions;
 using Sparrow.LowMemory;
 using Sparrow.Platform;
 using Sparrow.Server.Exceptions;
@@ -16,6 +17,7 @@ namespace Raven.Server.Utils
         {
             return IsOutOfMemory(e) == false &&
                    e is OperationCanceledException == false &&
+                   e is IndexAnalyzerException == false &&
                    IsRavenDiskFullException(e) == false;
         }
 


### PR DESCRIPTION
Detected during 5.1 to 5.2 merge: https://github.com/ravendb/ravendb/pull/12570

Happens now because we are creating the write operation lazily