### PR TITLE
RavenDB-17072 fix patching cause `UseAfterFree detected`

### DIFF
--- a/src/Raven.Server/Documents/Patch/PatchDocumentCommand.cs
+++ b/src/Raven.Server/Documents/Patch/PatchDocumentCommand.cs
@@ -255,8 +255,11 @@ namespace Raven.Server.Documents.Patch
 
             if (originalDocument != null)
             {
-                // we clone it, to keep it safe from defrag due to the patch modifications
-                originalDocument.Data = originalDocument.Data?.CloneOnTheSameContext();
+                using (var oldData = originalDocument.Data)
+                {
+                    // we clone it, to keep it safe from defrag due to the patch modifications
+                    originalDocument.Data = originalDocument.Data?.CloneOnTheSameContext();
+                }
             }
 
             return originalDocument;

--- a/src/Raven.Server/Documents/Patch/ScriptRunner.cs
+++ b/src/Raven.Server/Documents/Patch/ScriptRunner.cs
@@ -889,10 +889,14 @@ namespace Raven.Server.Documents.Patch
                 }
                 if (obj.IsObject())
                 {
-                    var result = new ScriptRunnerResult(this, obj);
-                    using (var jsonObj = result.TranslateToObject(_jsonCtx))
+                    if (obj is BlittableObjectInstance boi && boi.Changed == false)
                     {
-                        return jsonObj.ToString();
+                        return boi.Blittable.ToString();
+                    }
+
+                    using (var blittable =  JsBlittableBridge.Translate(_jsonCtx, ScriptEngine, obj.AsObject()))
+                    {
+                        return blittable.ToString();
                     }
                 }
                 if (obj.IsBoolean())

--- a/src/Raven.Server/SqlMigration/JsPatcher.cs
+++ b/src/Raven.Server/SqlMigration/JsPatcher.cs
@@ -27,8 +27,11 @@ namespace Raven.Server.SqlMigration
         {
             if (_runner == null)
                 return document;
-            
-            return _runner.Run(_context, _context, "execute", new object[] { document }).TranslateToObject(_context);
+
+            using (var runner = _runner.Run(_context, _context, "execute", new object[] {document}))
+            {
+                return runner.TranslateToObject(_context);
+            }
         }
         
         public void Dispose()


### PR DESCRIPTION
The root cause was that we disposed an object that was "held" by an already disposed context

- Better error when patch failed
- Make sure we scope and dispose `ScriptRunnerResult` properly
- return results should clone to external context first
