### PR TITLE
RavenDB-17054 We need to get the write lock when accessing compression.buffers during ZeroCompressionBuffer() call.

### DIFF
--- a/test/SlowTests/Voron/Issues/RavenDB_17054.cs
+++ b/test/SlowTests/Voron/Issues/RavenDB_17054.cs
@@ -1,0 +1,66 @@
+﻿using System;
+using System.Threading;
+using FastTests.Voron;
+using Sparrow.Server;
+using Voron;
+using Xunit;
+using Xunit.Abstractions;
+
+namespace SlowTests.Voron.Issues
+{
+    public class RavenDB_17054 : StorageTest
+    {
+        public RavenDB_17054(ITestOutputHelper output) : base(output)
+        {
+        }
+
+        protected override void Configure(StorageEnvironmentOptions options)
+        {
+            options.Encryption.MasterKey = Sodium.GenerateRandomBuffer((int)Sodium.crypto_aead_xchacha20poly1305_ietf_keybytes());
+            options.MaxScratchBufferSize = 65536 - 1; // to make ShouldReduceSizeOfCompressionPager() return true
+            options.Encryption.RegisterForJournalCompressionHandler();
+        }
+
+        [Fact]
+        public void WeNeedToTakeWriteLockWhenZeroCompressionBufferIsCalled()
+        {
+            var testingActionWasCalled = false;
+
+            Exception startTransactionException = null;
+
+            var zeroCompressionBufferThread = new Thread(() =>
+            {
+                try
+                {
+                    using (var tx = Env.WriteTransaction())
+                    {
+                        Env.Journal.ZeroCompressionBuffer(tx.LowLevelTransaction); // this can be called by an index e.g. when forceMemoryCleanup is true 
+                    }
+                }
+                catch (Exception e)
+                {
+                    startTransactionException = e;
+                }
+            });
+
+            Env.Journal.ForTestingPurposesOnly().OnReduceSizeOfCompressionBufferIfNeeded_RightAfterDisposingCompressionPager += () =>
+            {
+                testingActionWasCalled = true;
+
+                zeroCompressionBufferThread.Start();
+
+                Thread.Sleep(1000); // give the thread more time to ensure that ZeroCompressionBuffer will wait for _writeLock
+            };
+
+            // in RavenDB we call TryReduceSizeOfCompressionBufferIfNeeded when a database is idle, then we call IndexStore?.RunIdleOperations(mode)
+            // although an index can still run ZeroCompressionBuffer concurrently e.g. when forceMemoryCleanup is true
+            Env.Journal.TryReduceSizeOfCompressionBufferIfNeeded();
+
+            Assert.True(testingActionWasCalled);
+
+            Assert.True(zeroCompressionBufferThread.Join(TimeSpan.FromSeconds(30)), "zeroCompressionBufferThread.Join(TimeSpan.FromSeconds(30))");
+
+            Assert.Null(startTransactionException);
+        }
+    }
+}


### PR DESCRIPTION
In RavenDB we call it on our own if a database is encrypted from the tx merger and an index instance so we need to ensure it won't be called concurrently.

https://issues.hibernatingrhinos.com/issue/RavenDB-17054

For reference: We started to call `ZeroCompressionBuffer()` explicitly on our own in https://github.com/ravendb/ravendb/pull/10866