### PR TITLE
RavenDB-17079 fix - `Attachments.GetNames` missing retrievement data

### DIFF
--- a/src/Raven.Client/Documents/Session/DocumentSessionAttachmentsBase.cs
+++ b/src/Raven.Client/Documents/Session/DocumentSessionAttachmentsBase.cs
@@ -30,12 +30,12 @@ namespace Raven.Client.Documents.Session
             if (entity is string)
                 throw new ArgumentException($"{nameof(GetNames)} requires a tracked entity object, other types such as documentId are not valid.", nameof(entity));
             
-            if (Session.DocumentsByEntity.TryGetValue(entity, out var document) == false)
+            if (Session.DocumentsByEntity.TryGetValue(entity, out DocumentInfo document) == false)
                 ThrowEntityNotInSession(entity);
-
+            
             if (document.Metadata.TryGet(Constants.Documents.Metadata.Attachments, out BlittableJsonReaderArray attachments) == false)
                 return Array.Empty<AttachmentName>();
-
+           
             var results = new AttachmentName[attachments.Length];
             for (var i = 0; i < attachments.Length; i++)
             {

--- a/src/Raven.Client/Documents/Session/Operations/BatchOperation.cs
+++ b/src/Raven.Client/Documents/Session/Operations/BatchOperation.cs
@@ -258,7 +258,6 @@ namespace Raven.Client.Documents.Session.Operations
                     continue;
 
                 attachments.Add(attachment);
-                break;
             }
         }
 

--- a/test/SlowTests/Issues/RavenDB-17079.cs
+++ b/test/SlowTests/Issues/RavenDB-17079.cs
@@ -1,0 +1,60 @@
+using System.IO;
+using FastTests;
+using Raven.Client.Documents.Commands.Batches;
+using Xunit;
+using Xunit.Abstractions;
+
+namespace SlowTests.Issues
+{
+    public class RavenDB_17079 : RavenTestBase
+    {
+        public RavenDB_17079(ITestOutputHelper output) : base(output)
+        {
+        }
+        
+        [Fact]
+        public void RavenAttachmentIssue()
+        {
+            using (var store = GetDocumentStore())
+            {
+                using (var session = store.OpenSession())
+                {
+                    var employee = new Employee { Id = "One" };
+                    session.Store(employee);
+                    session.Advanced.Attachments.Store(employee, "file1", new MemoryStream(), "text/plain");
+                    session.Advanced.Attachments.Store(employee, "file2", new MemoryStream(), "text/plain");
+                    session.Advanced.Attachments.Store(employee, "file3", new MemoryStream(), "text/plain");
+                    session.SaveChanges();
+                }
+                
+                using (var session = store.OpenSession())
+                {
+                    
+                    var employee = session.Load<Employee>("One");
+                    var attachmentNames1 = session.Advanced.Attachments.GetNames(employee);
+                    Assert.Equal(3, attachmentNames1.Length);
+                    
+                    session.Advanced.Attachments.Delete(employee, "file3");
+                    session.SaveChanges();
+                    
+                    var attachmentNames = session.Advanced.Attachments.GetNames(employee);
+                    Assert.Equal(2, attachmentNames.Length);
+                }
+
+                using (var session = store.OpenSession())
+                {
+                    var employee = session.Load<Employee>("One");
+                    var attachmentNames = session.Advanced.Attachments.GetNames(employee);
+                    Assert.Equal(2, attachmentNames.Length);
+                }
+                WaitForUserToContinueTheTest(store);
+
+            }
+        }
+
+        public class Employee
+        {
+            public string Id { get; set; }
+        }
+    }
+}


### PR DESCRIPTION
Break statement caused the issue

https://issues.hibernatingrhinos.com/issue/RavenDB-17079