### PR TITLE
RavenDB-17088 Fixing 'Recursive write lock acquisitions not allowed in this mode' during RemoveInactiveScratches call

### DIFF
--- a/src/Voron/Impl/LowLevelTransaction.cs
+++ b/src/Voron/Impl/LowLevelTransaction.cs
@@ -1229,7 +1229,7 @@ namespace Voron.Impl
             // release scratch file page allocated for the transaction header
             Allocator.Release(ref _txHeaderMemory);
 
-            using (_env.IsInPreventNewTransactionsMode == false ? _env.PreventNewTransactions() : (IDisposable)null)
+            using (_env.PreventNewTransactions())
             {
                 _env.ScratchBufferPool.UpdateCacheForPagerStatesOfAllScratches();
                 _env.Journal.UpdateCacheForJournalSnapshots();

--- a/src/Voron/Impl/Scratch/ScratchBufferPool.cs
+++ b/src/Voron/Impl/Scratch/ScratchBufferPool.cs
@@ -300,7 +300,7 @@ namespace Voron.Impl.Scratch
 
             if (recycledScratchesToDispose != null)
             {
-                using (_env.IsInPreventNewTransactionsMode == false ? _env.PreventNewTransactions() : (IDisposable)null)
+                using (_env.PreventNewTransactions())
                 {
                     // we're about to dispose recycled scratch pagers, we need to update the cache so next transactions won't attempt to EnsurePagerStateReference() on them
 

--- a/src/Voron/StorageEnvironment.cs
+++ b/src/Voron/StorageEnvironment.cs
@@ -809,6 +809,9 @@ namespace Voron
 
         internal ExitWriteLock PreventNewTransactions()
         {
+            if (_txCreation.IsWriteLockHeld)
+                return default;
+            
             _txCreation.EnterWriteLock();
             return new ExitWriteLock(_txCreation);
         }
@@ -829,7 +832,7 @@ namespace Voron
 
         public struct ExitWriteLock : IDisposable
         {
-            readonly ReaderWriterLockSlim _rwls;
+            private readonly ReaderWriterLockSlim _rwls;
 
             public ExitWriteLock(ReaderWriterLockSlim rwls)
             {
@@ -838,7 +841,7 @@ namespace Voron
 
             public void Dispose()
             {
-                _rwls.ExitWriteLock();
+                _rwls?.ExitWriteLock();
             }
         }
 

--- a/test/SlowTests/Voron/Issues/RavenDB_17088.cs
+++ b/test/SlowTests/Voron/Issues/RavenDB_17088.cs
@@ -1,0 +1,63 @@
+﻿using System;
+using System.IO;
+using FastTests.Voron;
+using Voron;
+using Xunit;
+using Xunit.Abstractions;
+
+namespace SlowTests.Voron.Issues
+{
+    public class RavenDB_17088 : StorageTest
+    {
+        public RavenDB_17088(ITestOutputHelper output) : base(output)
+        {
+        }
+
+        protected override void Configure(StorageEnvironmentOptions options)
+        {
+            options.ManualFlushing = true;
+            options.ManualSyncing = true;
+            options.MaxScratchBufferSize = 64 * 1024 * 4;
+        }
+
+        [Fact]
+        public void CannotTryToGetPreventNewTransactionsLockRecursivelyDuringFlushing()
+        {
+            for (int i = 0; i < 100; i++)
+            {
+                using (var tx = Env.WriteTransaction())
+                {
+                    var tree = tx.CreateTree("items");
+
+                    tree.Add("items/" + i, new byte[] { 1, 2, 3 });
+
+                    tx.Commit();
+                }
+            }
+
+            Env.FlushLogToDataFile();
+
+            using (var tx = Env.WriteTransaction())
+            {
+                var tree = tx.CreateTree("items");
+
+                tree.Add("foo/0", new byte[] { 1, 2, 3 });
+
+                tx.Commit();
+            }
+
+            using (var tx = Env.WriteTransaction())
+            {
+                var tree = tx.CreateTree("items");
+
+                tree.Add("foo/1", new byte[] { 1, 2, 3 });
+
+                tx.Commit();
+            }
+
+            Env.ScratchBufferPool.RecycledScratchFileTimeout = TimeSpan.Zero; // by default we don't dispose scratches if they were recycled less than 1 minute ago
+
+            Env.FlushLogToDataFile();
+        }
+    }
+}


### PR DESCRIPTION
https://issues.hibernatingrhinos.com/issue/RavenDB-17088