### PR TITLE
RavenDB-17079 fix - `Attachments.GetNames ` not returning the correct number of attachment after deletion 

### DIFF
--- a/src/Raven.Client/Documents/Session/Operations/BatchOperation.cs
+++ b/src/Raven.Client/Documents/Session/Operations/BatchOperation.cs
@@ -258,7 +258,6 @@ namespace Raven.Client.Documents.Session.Operations
                     continue;
 
                 attachments.Add(attachment);
-                break;
             }
         }
 

--- a/test/SlowTests/Issues/RavenDB-17079.cs
+++ b/test/SlowTests/Issues/RavenDB-17079.cs
@@ -1,0 +1,54 @@
+using System.IO;
+using FastTests;
+using Raven.Client.Documents.Commands.Batches;
+using Raven.Tests.Core.Utils.Entities;
+using Xunit;
+using Xunit.Abstractions;
+
+namespace SlowTests.Issues
+{
+    public class RavenDB_17079 : RavenTestBase
+    {
+        public RavenDB_17079(ITestOutputHelper output) : base(output)
+        {
+        }
+        
+        [Fact]
+        public void Should_Return_Appropriate_Number_Of_Attachments_After_Deletion()
+        {
+            using (var store = GetDocumentStore())
+            {
+                var employee = new Employee { Id = "One" };
+                using (var session = store.OpenSession())
+                {
+                    session.Store(employee);
+                    session.Advanced.Attachments.Store(employee, "file1", new MemoryStream(), "text/plain");
+                    session.Advanced.Attachments.Store(employee, "file2", new MemoryStream(), "text/plain");
+                    session.Advanced.Attachments.Store(employee, "file3", new MemoryStream(), "text/plain");
+                    session.SaveChanges();
+                }
+                
+                using (var session = store.OpenSession())
+                { 
+                    employee = session.Load<Employee>(employee.Id);
+                    var attachmentNames1 = session.Advanced.Attachments.GetNames(employee);
+                    Assert.Equal(3, attachmentNames1.Length);
+                    
+                    session.Advanced.Attachments.Delete(employee, "file3");
+                    session.SaveChanges();
+                    
+                    var attachmentNames = session.Advanced.Attachments.GetNames(employee);
+                    Assert.Equal(2, attachmentNames.Length);
+                }
+
+                using (var session = store.OpenSession())
+                {
+                    employee = session.Load<Employee>(employee.Id);
+                    var attachmentNames = session.Advanced.Attachments.GetNames(employee);
+                    Assert.Equal(2, attachmentNames.Length);
+                }
+            }
+        }
+
+    }
+}


### PR DESCRIPTION
`GetNames` should return the appropriate number of attachments after deletion

The cause was _break statment_ 