### PR TITLE
RavenDB-17138 check for topology update at the end of each request

### DIFF
--- a/src/Raven.Server/Web/ServerRequestHandler.cs
+++ b/src/Raven.Server/Web/ServerRequestHandler.cs
@@ -1,4 +1,5 @@
-﻿using Raven.Client;
+﻿using System.Threading.Tasks;
+using Raven.Client;
 
 namespace Raven.Server.Web
 {
@@ -8,9 +9,16 @@ namespace Raven.Server.Web
         {
             base.Init(context);
 
+            context.HttpContext.Response.OnStarting(() => CheckForTopologyChanges(context));
+        }
+
+        public Task CheckForTopologyChanges(RequestHandlerContext context)
+        {
             var topologyEtag = GetLongFromHeaders(Constants.Headers.TopologyEtag);
             if (topologyEtag.HasValue && Server.ServerStore.HasTopologyChanged(topologyEtag.Value))
                 context.HttpContext.Response.Headers[Constants.Headers.RefreshTopology] = "true";
+
+            return Task.CompletedTask;
         }
     }
 }

--- a/test/StressTests/Cluster/ClusterIndexNotificationsTestStress.cs
+++ b/test/StressTests/Cluster/ClusterIndexNotificationsTestStress.cs
@@ -32,7 +32,7 @@ namespace StressTests.Cluster
                 using (testingStuff.CallDuringDocumentDatabaseInternalDispose(() =>
                 {
                     var sw = Stopwatch.StartNew();
-                    while (sw.Elapsed < TimeSpan.FromSeconds(31))
+                    while (sw.Elapsed < TimeSpan.FromSeconds(18))
                         Thread.Sleep(1000);
                 }))
                 {


### PR DESCRIPTION
It might happened that an operation like add/remove/bootstrap changed the cluster/database topology.
We want to the let the client know about it right away and not wait for the next request.