### PR TITLE
RavenDB-16824  Index history - Deployment Stats

### DIFF
--- a/src/Raven.Studio/typescript/viewmodels/database/indexes/editIndex.ts
+++ b/src/Raven.Studio/typescript/viewmodels/database/indexes/editIndex.ts
@@ -78,6 +78,7 @@ class editIndex extends viewModelBase {
     
     previewItem = ko.observable<Raven.Client.ServerWide.IndexHistoryEntry>();
     previewDefinition = ko.observable<string>();
+    previewItemNodes: KnockoutComputed<string[]>;
     
     defaultDeploymentMode = ko.observable<Raven.Client.Documents.Indexes.IndexDeploymentMode>();
     defaultDeploymentModeFormatted = ko.pureComputed(() => {
@@ -175,9 +176,12 @@ class editIndex extends viewModelBase {
             this.previewEditor = aceEditorBindingHandler.getEditorBySelection(this.$previewEditor);
             this.previewEditor.setOption("wrap", true);
 
-            $('.deployment-time [data-toggle="tooltip"]').tooltip({
-                html: true
-            });
+            setTimeout(() => this.initRollingTooltip(), 0);
+            setTimeout(() => this.previewEditor.resize(), 0);
+        })
+        
+        this.previewItemNodes = ko.pureComputed<string[]>(() => {
+            return this.previewItem() ? Object.keys(this.previewItem().RollingDeployment).reverse() : [];
         })
     }
 
@@ -398,6 +402,12 @@ class editIndex extends viewModelBase {
 
     previewIndex(item: Raven.Client.ServerWide.IndexHistoryEntry) {
         this.previewItem(item);
+    }
+
+    initRollingTooltip() {
+        $('.history-rolling-deployment-area [data-toggle="tooltip"]').tooltip({
+            html: true
+        });
     }
 
     getTimeTooltip(utcTime: string, isRevisionTime: boolean = false) {

--- a/src/Raven.Studio/typescript/viewmodels/database/indexes/editIndex.ts
+++ b/src/Raven.Studio/typescript/viewmodels/database/indexes/editIndex.ts
@@ -176,8 +176,7 @@ class editIndex extends viewModelBase {
             this.previewEditor = aceEditorBindingHandler.getEditorBySelection(this.$previewEditor);
             this.previewEditor.setOption("wrap", true);
 
-            setTimeout(() => this.initRollingTooltip(), 0);
-            setTimeout(() => this.previewEditor.resize(), 0);
+            setTimeout(() => this.onPreviewItemChange(), 0);
         })
         
         this.previewItemNodes = ko.pureComputed<string[]>(() => {
@@ -404,10 +403,12 @@ class editIndex extends viewModelBase {
         this.previewItem(item);
     }
 
-    initRollingTooltip() {
+    onPreviewItemChange() {
         $('.history-rolling-deployment-area [data-toggle="tooltip"]').tooltip({
             html: true
         });
+        
+        this.previewEditor.resize();
     }
 
     getTimeTooltip(utcTime: string, isRevisionTime: boolean = false) {

--- a/src/Raven.Studio/wwwroot/App/views/database/indexes/editIndex.html
+++ b/src/Raven.Studio/wwwroot/App/views/database/indexes/editIndex.html
@@ -767,49 +767,96 @@
         <span class="caret"></span>
     </button>
     <div class="dropdown-menu slidein-style history-dropdown-container" aria-labelledby="dropdownIndexHistory" data-bind="dropdownPanel: true">
-            <div class="history-dropdown row">
-                <div class="col-md-3 no-padding-right">
-                    <h3 class="margin-left margin-top margin-top-lg margin-bottom margin-bottom-lg">Index Creation Time</h3>
-                    <div class="history-list-container margin-left">
-                        <ul class="history-list" data-bind="foreach: indexHistory">
-                            <li data-bind="css: { selected: $data === $parent.previewItem() }, event: { mouseenter: $parent.previewIndex }, attr: { 'data-original-title': $parent.creationTimeTooltip($data) }"
-                                data-placement="right" data-toggle="tooltip" data-animation="true">
-                                <a href="#" class="history-link close-panel" data-bind="click: $parent.useIndexRevisionItem.bind($parent, $data)">
-                                    <span class="created-at" data-bind="text: $parent.createdAtFormatted($data)"></span>
-                                </a>
-                            </li>
-                        </ul>
-                    </div>
+        <div class="history-dropdown row">
+            <div class="col-md-3 no-padding-right">
+                <h3 class="margin-left margin-top margin-top-lg margin-bottom margin-bottom-lg">Index Creation Time</h3>
+                <div class="history-list-container margin-left">
+                    <ul class="history-list" data-bind="foreach: indexHistory">
+                        <li data-bind="css: { selected: $data === $parent.previewItem() }, event: { mouseenter: $parent.previewIndex },
+                                       attr: { 'data-original-title': $parent.getTimeTooltip($data.CreatedAt, true) }"
+                            data-placement="bottom" data-toggle="tooltip" data-animation="true">
+                            <a href="#" class="history-link close-panel" data-bind="click: $parent.useIndexRevisionItem.bind($parent, $data)">
+                                <span class="created-at" data-bind="text: $parent.getLocalTime($data.CreatedAt)"></span>
+                            </a>
+                        </li>
+                    </ul>
                 </div>
-                <div class="col-md-9 no-padding-right">
-                    <div class="row">
-                        <div class="margin-right margin-top pull-right">
-                            <div class="btn-group margin-top margin-top-sm">
-                                <button class="btn btn-success close-panel" data-bind="click: loadIndexDefinitionFromHistory" title="Load the full definition of this index revision">
-                                    <i class="icon-load-index"></i>
-                                    <span>Load Index</span>
-                                </button>
-                                <button type="button" class="btn btn-success dropdown-toggle" data-toggle="dropdown" aria-haspopup="true" aria-expanded="false">
-                                    <span class="caret"></span>
-                                    <span class="sr-only">Toggle Dropdown</span>
-                                </button>
-                                <ul class="dropdown-menu dropdown-menu-right">
-                                    <li title="Load the Map & Reduce methods only" class="close-panel margin-top margin-top-xs margin-bottom margin-bottom-xs">
-                                        <a href="#" data-bind="click: $root.loadMapReduceFromHistory">
-                                            <i class="icon-load-map-reduce"></i><span>Load Map & Reduce Only</span>
-                                        </a>
-                                    </li>
-                                </ul>
-                            </div>
-                        </div>
-                        <div>
-                            <h3 class="margin-left margin-top margin-top-lg margin-bottom margin-bottom-lg">Index Definition Preview</h3>
+            </div>
+            <div class="col-md-9 no-padding-right">
+                <div class="row">
+                    <div class="margin-right margin-top pull-right">
+                        <div class="btn-group margin-top margin-top-sm">
+                            <button class="btn btn-success close-panel" data-bind="click: loadIndexDefinitionFromHistory" title="Load the full definition of this index revision">
+                                <i class="icon-load-index"></i>
+                                <span>Load Index</span>
+                            </button>
+                            <button type="button" class="btn btn-success dropdown-toggle" data-toggle="dropdown" aria-haspopup="true" aria-expanded="false">
+                                <span class="caret"></span>
+                                <span class="sr-only">Toggle Dropdown</span>
+                            </button>
+                            <ul class="dropdown-menu dropdown-menu-right">
+                                <li title="Load the Map & Reduce methods only" class="close-panel margin-top margin-top-xs margin-bottom margin-bottom-xs">
+                                    <a href="#" data-bind="click: $root.loadMapReduceFromHistory">
+                                        <i class="icon-load-map-reduce"></i><span>Load Map & Reduce Only</span>
+                                    </a>
+                                </li>
+                            </ul>
                         </div>
                     </div>
                     <div>
-                        <pre id="previewEditor" class="form-control history-preview-area" data-bind="aceEditor: { code: previewDefinition, lang: 'ace/mode/json_newline_friendly', readOnly: true }"></pre>
+                        <h3 class="margin-left margin-top margin-top-lg margin-bottom margin-bottom-lg">Index Definition Preview</h3>
+                    </div>
+                </div>
+                <div id="definition-preview" data-bind="attr: { class: previewItem() &&  Object.keys(previewItem().RollingDeployment).length === 0 ? 'no-rolling-info' : 'has-rolling-info' }">
+                    <pre id="previewEditor" class="form-control history-preview-area" data-bind="aceEditor: { code: previewDefinition, lang: 'ace/mode/json_newline_friendly', readOnly: true }"></pre>
+                </div>
+                <h3 class="margin-top margin-top-lg">Index Deployment Stats
+                    <span data-bind="text: previewItem() && Object.keys(previewItem().RollingDeployment).length === 0 ? ' - Parallel' : ' - Rolling'"></span>
+                </h3>
+                <div data-bind="if: previewItem">
+                    <div data-bind="if: Object.keys(previewItem().RollingDeployment).length === 0">
+                        <span>Index was deployed in parallel</span>
+                    </div>
+                    <div data-bind="if: Object.keys(previewItem().RollingDeployment).length" class="history-rolling-deployment-area">
+                        <table class="table table-striped table-condensed deployment-time">
+                            <thead>
+                                <tr>
+                                    <th>Node</th>
+                                    <th>Started</th>
+                                    <th>Finished</th>
+                                    <th>Duration</th>
+                                    <th>State</th>
+                                </tr>
+                            </thead>
+                            <tbody data-bind="foreach: Object.keys(previewItem().RollingDeployment)">
+                                <tr>
+                                    <td>
+                                        <div><strong data-bind="text: $data"></strong></div>
+                                    </td>
+                                    <td>
+                                        <div data-bind="text: $parent.getLocalTime($parent.previewItem().RollingDeployment[$data].StartedAt),
+                                                        attr: { 'data-original-title': $parent.getTimeTooltip($parent.previewItem().RollingDeployment[$data].StartedAt) }"
+                                             data-placement="top" data-toggle="tooltip" data-animation="true">
+                                        </div>
+                                    </td>
+                                    <td>
+                                        <div data-bind="text: $parent.getLocalTime($parent.previewItem().RollingDeployment[$data].FinishedAt),
+                                                        attr: { 'data-original-title': $parent.getTimeTooltip($parent.previewItem().RollingDeployment[$data].FinishedAt) }"
+                                             data-placement="top" data-toggle="tooltip" data-animation="true"> 
+                                        </div>
+                                    </td>
+                                    <td>
+                                        <div data-bind="text: $parent.getDeploymentDuration($parent.previewItem(), $data)"></div>
+                                    </td>
+                                    <td>
+                                        <div data-bind="text: $parent.previewItem().RollingDeployment[$data].State"></div>
+                                    </td>
+                                </tr>
+                            </tbody>
+                        </table>
                     </div>
                 </div>
             </div>
+        </div>
     </div>
 </script>

--- a/src/Raven.Studio/wwwroot/App/views/database/indexes/editIndex.html
+++ b/src/Raven.Studio/wwwroot/App/views/database/indexes/editIndex.html
@@ -807,28 +807,25 @@
                         <h3 class="margin-left margin-top margin-top-lg margin-bottom margin-bottom-lg">Index Definition Preview</h3>
                     </div>
                 </div>
-                <div id="definition-preview" data-bind="attr: { class: previewItem() &&  Object.keys(previewItem().RollingDeployment).length === 0 ? 'no-rolling-info' : 'has-rolling-info' }">
+                <div id="definition-preview" data-bind="attr: { class: previewItem() && previewItemNodes().length === 0 ? 'no-rolling-info' : 'has-rolling-info' }">
                     <pre id="previewEditor" class="form-control history-preview-area" data-bind="aceEditor: { code: previewDefinition, lang: 'ace/mode/json_newline_friendly', readOnly: true }"></pre>
                 </div>
-                <h3 class="margin-top margin-top-lg">Index Deployment Stats
-                    <span data-bind="text: previewItem() && Object.keys(previewItem().RollingDeployment).length === 0 ? ' - Parallel' : ' - Rolling'"></span>
-                </h3>
                 <div data-bind="if: previewItem">
-                    <div data-bind="if: Object.keys(previewItem().RollingDeployment).length === 0">
-                        <span>Index was deployed in parallel</span>
-                    </div>
-                    <div data-bind="if: Object.keys(previewItem().RollingDeployment).length" class="history-rolling-deployment-area">
-                        <table class="table table-striped table-condensed deployment-time">
-                            <thead>
+                    <div data-bind="if: previewItemNodes().length">
+                        <div>
+                            <h3 class="margin-top margin-top-lg">Rolling Deployment Stats</h3>
+                        </div>
+                        <div class="history-rolling-deployment-area">
+                            <table class="table table-striped table-condensed">
+                                <thead>
                                 <tr>
                                     <th>Node</th>
                                     <th>Started</th>
                                     <th>Finished</th>
                                     <th>Duration</th>
-                                    <th>State</th>
                                 </tr>
-                            </thead>
-                            <tbody data-bind="foreach: Object.keys(previewItem().RollingDeployment)">
+                                </thead>
+                                <tbody data-bind="foreach: previewItemNodes">
                                 <tr>
                                     <td>
                                         <div><strong data-bind="text: $data"></strong></div>
@@ -842,18 +839,16 @@
                                     <td>
                                         <div data-bind="text: $parent.getLocalTime($parent.previewItem().RollingDeployment[$data].FinishedAt),
                                                         attr: { 'data-original-title': $parent.getTimeTooltip($parent.previewItem().RollingDeployment[$data].FinishedAt) }"
-                                             data-placement="top" data-toggle="tooltip" data-animation="true"> 
+                                             data-placement="top" data-toggle="tooltip" data-animation="true">
                                         </div>
                                     </td>
                                     <td>
                                         <div data-bind="text: $parent.getDeploymentDuration($parent.previewItem(), $data)"></div>
                                     </td>
-                                    <td>
-                                        <div data-bind="text: $parent.previewItem().RollingDeployment[$data].State"></div>
-                                    </td>
                                 </tr>
-                            </tbody>
-                        </table>
+                                </tbody>
+                            </table>
+                        </div>
                     </div>
                 </div>
             </div>

--- a/src/Raven.Studio/wwwroot/Content/css/pages/edit-index.less
+++ b/src/Raven.Studio/wwwroot/Content/css/pages/edit-index.less
@@ -93,7 +93,7 @@
 
     #definition-preview.no-rolling-info {
         .history-preview-area:not(.fullScreen-editor) {
-            height: 500px !important;
+            height: 630px !important;
         }
     }
 

--- a/src/Raven.Studio/wwwroot/Content/css/pages/edit-index.less
+++ b/src/Raven.Studio/wwwroot/Content/css/pages/edit-index.less
@@ -29,8 +29,8 @@
     
     .history-dropdown-container {
         background-color: @gray-darker;
-        max-height: 700px;
-        height: 700px;
+        max-height: 730px;
+        height: 730px;
         width: 1000px;
         
         h3 {
@@ -47,7 +47,7 @@
         background-color: @well-bg;
         padding: @grid-gutter-width/4;
         position: relative;
-        height: 600px;
+        height: 630px;
         padding: 0;
     }
     
@@ -85,8 +85,26 @@
         }
     }
 
-    .history-preview-area {
-        height: 600px !important;
+    #definition-preview.has-rolling-info {
+        .history-preview-area:not(.fullScreen-editor) {
+            height: 400px !important;
+        }
+    }
+
+    #definition-preview.no-rolling-info {
+        .history-preview-area:not(.fullScreen-editor) {
+            height: 500px !important;
+        }
+    }
+
+    .history-rolling-deployment-area {
+        max-height: 160px;
+        overflow: auto;
+
+        .tooltip-inner {
+            min-width: 260px;
+            text-align: left;
+        }
     }
     
     .analyzer-dropdown {


### PR DESCRIPTION
### Issue link
https://issues.hibernatingrhinos.com/issue/RavenDB-16824

### Additional description
Added the **rolling deployment stats** in the **Index History dropdown dialog**.
Local '_start_' & '_finish_' times are shown, UTC is available in the tooltip.

### Type of change
- New feature

### How risky is the change?
- Low 

### Backward compatibility
- Not relevant

### Is it a platform-specific issue?
- No

### Documentation update
- This change requires a documentation update. 

### Testing 
- It has been verified by manual testing

### Is there any existing behavior change of other features due to this change?
- No

### UI work
- There is some tooltip issue with this PR - Need to discuss w/ @ml054 => Resolved in the latest commit

