### PR TITLE
RavenDB-17024 Add support for arm64 Docker image in build scripts

### DIFF
--- a/docker/common.ps1
+++ b/docker/common.ps1
@@ -49,8 +49,8 @@ function GetUbuntuImageTags($repo, $version, $arch) {
         }
         "arm64v8" {
             return @(
-                "$($repo):$($version)-ubuntu.18.04-arm64v8",
-                "$($repo):4.2-ubuntu-arm64v8-latest"
+                "$($repo):$($version)-ubuntu.20.04-arm64v8",
+                "$($repo):5.1-ubuntu-arm64v8-latest"
                 )
                 break;
         }

--- a/docker/ravendb-ubuntu/Dockerfile.arm64v8
+++ b/docker/ravendb-ubuntu/Dockerfile.arm64v8
@@ -1,4 +1,4 @@
-FROM mcr.microsoft.com/dotnet/runtime-deps:3.1-bionic-arm64v8
+FROM mcr.microsoft.com/dotnet/runtime-deps:5.0-focal-arm64v8
 
 RUN apt-get update \
     && apt-get install -y \


### PR DESCRIPTION
https://issues.hibernatingrhinos.com/issue/RavenDB-17024
Merge v4.2 to v5.1

- New feature

- Low risk


### Backward compatibility

- Non breaking change


### Is it platform specific issue?

- ARM64

### Documentation update

- Need to update dockerhub readme

### Testing 

- It has been verified by manual testing

### Is there any existing behavior change of other features due to this change?

- No

- No UI work is needed
