### PR TITLE
RavenDB-17134 Allow a query result to output 0..N results to the quer…

### DIFF
--- a/src/Raven.Server/Documents/Indexes/Persistence/Lucene/IndexQueryingScope.cs
+++ b/src/Raven.Server/Documents/Indexes/Persistence/Lucene/IndexQueryingScope.cs
@@ -94,10 +94,21 @@ namespace Raven.Server.Documents.Indexes.Persistence.Lucene
             for (; _alreadyScannedForDuplicates < _query.Start; _alreadyScannedForDuplicates++)
             {
                 var scoreDoc = search.ScoreDocs[_alreadyScannedForDuplicates];
-                var document = _retriever.Get(_searcher.Doc(scoreDoc.Doc, _state), scoreDoc, _state);
+                var result = _retriever.Get(_searcher.Doc(scoreDoc.Doc, _state), scoreDoc, _state);
 
-                if (document.Data.Count > 0) // we don't consider empty projections to be relevant for distinct operations
-                    _alreadySeenProjections.Add(document.DataHash);
+                if (result.Document != null)
+                {
+                    if (result.Document.Data.Count > 0) // we don't consider empty projections to be relevant for distinct operations
+                        _alreadySeenProjections.Add(result.Document.DataHash);
+                }
+                else if(result.List != null)
+                {
+                    foreach (Document item in result.List)
+                    {
+                        if (item.Data.Count > 0) // we don't consider empty projections to be relevant for distinct operations
+                            _alreadySeenProjections.Add(item.DataHash);
+                    }
+                }
             }
         }
 

--- a/src/Raven.Server/Documents/Indexes/Persistence/Lucene/IndexReadOperation.cs
+++ b/src/Raven.Server/Documents/Indexes/Persistence/Lucene/IndexReadOperation.cs
@@ -155,6 +155,7 @@ namespace Raven.Server.Documents.Indexes.Persistence.Lucene
                             continue;
                         }
 
+                        bool markedAsSkipped = false;
                         var r = retriever.Get(document, scoreDoc, _state);
                         if (r.Document != null)
                         {
@@ -180,7 +181,12 @@ namespace Raven.Server.Documents.Indexes.Persistence.Lucene
                             {
                                 d?.Dispose();
 
-                                skippedResults.Value++;
+                                if (markedAsSkipped == false)
+                                {
+                                    skippedResults.Value++;
+                                    markedAsSkipped = true;
+                                }
+
                                 return default;
                             }
 

--- a/src/Raven.Server/Documents/Indexes/Persistence/Lucene/IndexReadOperation.cs
+++ b/src/Raven.Server/Documents/Indexes/Persistence/Lucene/IndexReadOperation.cs
@@ -166,12 +166,19 @@ namespace Raven.Server.Documents.Indexes.Persistence.Lucene
                         }
                         else if (r.List != null)
                         {
+                            int numberOfProjectedResults = 0;
                             foreach (Document item in r.List)
                             {
                                 var qr = CreateQueryResult(item);
                                 if(qr.Result == null)
                                     continue;
                                 yield return qr;
+                                numberOfProjectedResults++;
+                            }
+
+                            if (numberOfProjectedResults > 1)
+                            {
+                                totalResults.Value += numberOfProjectedResults - 1;
                             }
                         }
 

--- a/src/Raven.Server/Documents/Indexes/Persistence/Lucene/IndexReadOperation.cs
+++ b/src/Raven.Server/Documents/Indexes/Persistence/Lucene/IndexReadOperation.cs
@@ -181,6 +181,10 @@ namespace Raven.Server.Documents.Indexes.Persistence.Lucene
                                 totalResults.Value += numberOfProjectedResults - 1;
                             }
                         }
+                        else
+                        {
+                            skippedResults.Value++;
+                        }
 
                         QueryResult CreateQueryResult(Document d)
                         {

--- a/src/Raven.Server/Documents/Patch/JsBlittableBridge.cs
+++ b/src/Raven.Server/Documents/Patch/JsBlittableBridge.cs
@@ -515,12 +515,12 @@ namespace Raven.Server.Documents.Patch
                    property == Constants.Documents.Metadata.Flags;
         }
 
-        public static BlittableJsonReaderObject Translate(JsonOperationContext context, Engine scriptEngine, ObjectInstance objectInstance, IResultModifier modifier = null, BlittableJsonDocumentBuilder.UsageMode usageMode = BlittableJsonDocumentBuilder.UsageMode.None)
+        public static BlittableJsonReaderObject Translate(JsonOperationContext context, Engine scriptEngine, ObjectInstance objectInstance, IResultModifier modifier = null, BlittableJsonDocumentBuilder.UsageMode usageMode = BlittableJsonDocumentBuilder.UsageMode.None, bool isNested = false)
         {
             if (objectInstance == null)
                 return null;
 
-            if (objectInstance is BlittableObjectInstance boi && boi.Changed == false)
+            if (objectInstance is BlittableObjectInstance boi && boi.Changed == false && isNested == false)
                 return boi.Blittable.Clone(context);
 
             using (var writer = new ManualBlittableJsonDocumentBuilder<UnmanagedWriteBuffer>(context))

--- a/src/Raven.Server/Documents/Queries/CollectionQueryEnumerable.cs
+++ b/src/Raven.Server/Documents/Queries/CollectionQueryEnumerable.cs
@@ -89,6 +89,8 @@ namespace Raven.Server.Documents.Queries
             private readonly HashSet<ulong> _alreadySeenProjections;
             private long _start;
             private IEnumerator<Document> _inner;
+            private bool _hasProjections;
+            private List<Document>.Enumerator _projections;
             private int _innerCount;
             private readonly List<Slice> _ids;
             private readonly MapQueryResultRetriever _resultsRetriever;
@@ -163,32 +165,13 @@ namespace Raven.Server.Documents.Queries
 
                 while (true)
                 {
-                    if (_inner == null)
+                    var (hasNext, doc) = GetNextDocument();
+                    if (doc == null)
                     {
-                        _inner = GetDocuments().GetEnumerator();
-                        _innerCount = 0;
-                    }
-
-                    if (_inner.MoveNext() == false)
-                    {
-                        Current = null;
-
-                        if (_returnedResults >= _query.PageSize)
+                        if (hasNext == false)
                             return false;
-
-                        if (_innerCount < _query.PageSize)
-                            return false;
-
-                        _start += _query.PageSize;
-                        _inner = null;
                         continue;
                     }
-
-                    _innerCount++;
-
-                    var doc = _fieldsToFetch.IsProjection
-                        ? _resultsRetriever.GetProjectionFromDocument(_inner.Current, null, QueryResultRetrieverBase.ZeroScore, _fieldsToFetch, _context, null)
-                        : _inner.Current;
 
                     if (_query.SkipDuplicateChecking || _fieldsToFetch.IsDistinct == false)
                     {
@@ -207,6 +190,64 @@ namespace Raven.Server.Documents.Queries
                     if (_returnedResults >= _query.PageSize)
                         return false;
                 }
+            }
+
+            private (bool HasNext, Document Doc) GetNextDocument()
+            {
+                if (_hasProjections)
+                {
+                    if (_projections.MoveNext())
+                        return (true, _projections.Current);
+
+                    _hasProjections = false;
+                    _projections = default;
+                }
+                
+                if (_inner == null)
+                {
+                    _inner = GetDocuments().GetEnumerator();
+                    _innerCount = 0;
+                }
+
+                if (_inner.MoveNext() == false)
+                {
+                    Current = null;
+
+                    if (_returnedResults >= _query.PageSize)
+                        return (false, null);
+
+                    if (_innerCount < _query.PageSize)
+                        return (false, null);
+
+                    _start += _query.PageSize;
+                    _inner = null;
+                    return (true, null);
+                }
+
+                _innerCount++;
+
+                if (_fieldsToFetch.IsProjection)
+                {
+                    var result = _resultsRetriever.GetProjectionFromDocument(_inner.Current, null, QueryResultRetrieverBase.ZeroScore, _fieldsToFetch, _context, null);
+                    if (result.List != null)
+                    {
+                        var it = result.List.GetEnumerator();
+                        if (it.MoveNext() == false)
+                            return (true, null);
+                        _projections = it;
+                        _hasProjections = true;
+                        return (true, it.Current);
+                    }
+
+                    if (result.Document != null)
+                    {
+                        return (true, result.Document);
+                    }
+
+                    return (true, null);
+                }
+
+                return (true, _inner.Current);
             }
 
             private IEnumerable<Document> GetDocuments()
@@ -306,15 +347,44 @@ namespace Raven.Server.Documents.Queries
                     {
                         count++;
 
-                        var doc = _fieldsToFetch.IsProjection
-                            ? _resultsRetriever.GetProjectionFromDocument(document, null, QueryResultRetrieverBase.ZeroScore, _fieldsToFetch, _context, null)
-                            : _inner.Current;
+                        Document doc;
 
-                        if (doc.Data.Count <= 0)
-                            continue;
+                        if (_fieldsToFetch.IsProjection)
+                        {
+                            var result = _resultsRetriever.GetProjectionFromDocument(document, null, QueryResultRetrieverBase.ZeroScore, _fieldsToFetch, _context, null);
+                            if (result.Document != null)
+                            {
+                                if (IsStartingPoint(result.Document))
+                                    break;
+                            }
+                            else if (result.List != null)
+                            {
+                                bool match = false;
+                                foreach (Document item in result.List)
+                                {
+                                    if (IsStartingPoint(item))
+                                    {
+                                        match = true;
+                                        break;
+                                    }
+                                }
 
-                        if (_alreadySeenProjections.Add(doc.DataHash) && _alreadySeenProjections.Count == _query.Start)
-                            break;
+                                if (match)
+                                    break;
+                            }
+                        }
+                        else
+                        {
+                            if (IsStartingPoint(_inner.Current))
+                            {
+                                break;
+                            }
+                        }
+
+                        bool IsStartingPoint(Document d)
+                        {
+                            return d.Data.Count > 0 && _alreadySeenProjections.Add(d.DataHash) && _alreadySeenProjections.Count == _query.Start;
+                        }
                     }
 
                     if (_alreadySeenProjections.Count == _query.Start)

--- a/src/Raven.Server/Documents/Queries/CollectionQueryEnumerable.cs
+++ b/src/Raven.Server/Documents/Queries/CollectionQueryEnumerable.cs
@@ -347,8 +347,6 @@ namespace Raven.Server.Documents.Queries
                     {
                         count++;
 
-                        Document doc;
-
                         if (_fieldsToFetch.IsProjection)
                         {
                             var result = _resultsRetriever.GetProjectionFromDocument(document, null, QueryResultRetrieverBase.ZeroScore, _fieldsToFetch, _context, null);

--- a/src/Raven.Server/Documents/Queries/CollectionQueryEnumerable.cs
+++ b/src/Raven.Server/Documents/Queries/CollectionQueryEnumerable.cs
@@ -234,6 +234,7 @@ namespace Raven.Server.Documents.Queries
                         var it = result.List.GetEnumerator();
                         if (it.MoveNext() == false)
                             return (true, null);
+                        _totalResults.Value += result.List.Count - 1;
                         _projections = it;
                         _hasProjections = true;
                         return (true, it.Current);

--- a/src/Raven.Server/Documents/Queries/Results/GraphQueryResultRetriever.cs
+++ b/src/Raven.Server/Documents/Queries/Results/GraphQueryResultRetriever.cs
@@ -45,7 +45,7 @@ namespace Raven.Server.Documents.Queries.Results
             throw new InvalidQueryException($"Invalid projection behavior '{_query.ProjectionBehavior}'.Only default projection behavior can be used for graph queries.", _query.Query, _query.QueryParameters);
         }
 
-        public override Document Get(Lucene.Net.Documents.Document input, Lucene.Net.Search.ScoreDoc scoreDoc, IState state)
+        public override (Document Document, List<Document> List) Get(Lucene.Net.Documents.Document input, Lucene.Net.Search.ScoreDoc scoreDoc, IState state)
         {
             throw new NotSupportedException("Graph Queries do not deal with Lucene indexes.");
         }
@@ -125,8 +125,8 @@ namespace Raven.Server.Documents.Queries.Results
                     fieldVal = GetFunctionValue(fieldToFetch, null, args);
 
                     var immediateResult = AddProjectionToResult(item, OneScore, FieldsToFetch, result, key, fieldVal);
-                    if (immediateResult != null)
-                        return immediateResult;
+                    if (immediateResult.Document != null)
+                        return immediateResult.Document;
                 }
                 else
                 {
@@ -140,8 +140,8 @@ namespace Raven.Server.Documents.Queries.Results
                                     continue;
                                 d.EnsureMetadata();
                                 var immediateResult = AddProjectionToResult(d, OneScore, FieldsToFetch, result, key, fieldVal);
-                                if (immediateResult != null)
-                                    return immediateResult;
+                                if (immediateResult.Document != null)
+                                    return immediateResult.Document;
                                 break;
                             }
                         case BlittableJsonReaderObject bjro:
@@ -151,8 +151,8 @@ namespace Raven.Server.Documents.Queries.Results
                                     continue;
                                 doc.EnsureMetadata();
                                 var immediateResult = AddProjectionToResult(doc, OneScore, FieldsToFetch, result, key, fieldVal);
-                                if (immediateResult != null)
-                                    return immediateResult;
+                                if (immediateResult.Document != null)
+                                    return immediateResult.Document;
                                 break;
                             }
                         case MatchCollection matches:

--- a/src/Raven.Server/Documents/Queries/Results/IQueryResultRetriever.cs
+++ b/src/Raven.Server/Documents/Queries/Results/IQueryResultRetriever.cs
@@ -1,4 +1,5 @@
-﻿using Lucene.Net.Search;
+﻿using System.Collections.Generic;
+using Lucene.Net.Search;
 using Lucene.Net.Store;
 using Raven.Server.Documents.Indexes.Static.Spatial;
 
@@ -6,7 +7,7 @@ namespace Raven.Server.Documents.Queries.Results
 {
     public interface IQueryResultRetriever
     {
-        Document Get(Lucene.Net.Documents.Document input, ScoreDoc lucene, IState state);
+        (Document Document, List<Document> List) Get(Lucene.Net.Documents.Document input, ScoreDoc lucene, IState state);
 
         bool TryGetKey(Lucene.Net.Documents.Document document, IState state, out string key);
     }

--- a/src/Raven.Server/Documents/Queries/Results/MapQueryResultRetriever.cs
+++ b/src/Raven.Server/Documents/Queries/Results/MapQueryResultRetriever.cs
@@ -1,4 +1,5 @@
 ﻿using System;
+using System.Collections.Generic;
 using Lucene.Net.Store;
 using Raven.Client;
 using Raven.Server.Documents.Includes;
@@ -20,7 +21,7 @@ namespace Raven.Server.Documents.Queries.Results
             _context = context;
         }
 
-        public override Document Get(Lucene.Net.Documents.Document input, Lucene.Net.Search.ScoreDoc scoreDoc, IState state)
+        public override (Document Document, List<Document> List) Get(Lucene.Net.Documents.Document input, Lucene.Net.Search.ScoreDoc scoreDoc, IState state)
         {
             using (RetrieverScope?.Start())
             {
@@ -35,7 +36,7 @@ namespace Raven.Server.Documents.Queries.Results
                     var doc = DirectGet(null, id, DocumentFields, state);
 
                     FinishDocumentSetup(doc, scoreDoc);
-                    return doc;
+                    return (doc, null);
                 }
             }
         }

--- a/src/Raven.Server/Documents/Queries/Results/MapReduceQueryResultRetriever.cs
+++ b/src/Raven.Server/Documents/Queries/Results/MapReduceQueryResultRetriever.cs
@@ -1,4 +1,5 @@
 ﻿using System;
+using System.Collections.Generic;
 using Lucene.Net.Search;
 using Lucene.Net.Store;
 using Raven.Client;
@@ -92,7 +93,7 @@ namespace Raven.Server.Documents.Queries.Results
             };
         }
 
-        public override Document Get(Lucene.Net.Documents.Document input, ScoreDoc scoreDoc, IState state)
+        public override (Document Document, List<Document> List) Get(Lucene.Net.Documents.Document input, ScoreDoc scoreDoc, IState state)
         {
             if (FieldsToFetch.IsProjection)
                 return GetProjection(input, scoreDoc, null, state);
@@ -103,7 +104,7 @@ namespace Raven.Server.Documents.Queries.Results
 
                 FinishDocumentSetup(doc, scoreDoc);
 
-                return doc;
+                return (doc, null);
             }
         }
 

--- a/src/Raven.Server/Documents/Queries/Results/QueryResultRetrieverBase.cs
+++ b/src/Raven.Server/Documents/Queries/Results/QueryResultRetrieverBase.cs
@@ -337,7 +337,6 @@ namespace Raven.Server.Documents.Queries.Results
                     }
 
                     return (null, results);
-                    break;
                 case BlittableJsonReaderObject nested:
                     return (new Document
                     {

--- a/src/Raven.Server/Documents/Queries/Results/QueryResultRetrieverBase.cs
+++ b/src/Raven.Server/Documents/Queries/Results/QueryResultRetrieverBase.cs
@@ -1,11 +1,13 @@
 ﻿using System;
 using System.Collections.Generic;
 using System.Linq;
+using System.Runtime.CompilerServices;
 using Jint.Native;
 using Jint.Native.Object;
 using Jint.Runtime;
 using Lucene.Net.Documents;
 using Lucene.Net.Store;
+using Microsoft.Extensions.Azure;
 using Raven.Client;
 using Raven.Client.Documents.Indexes;
 using Raven.Client.Exceptions;
@@ -102,7 +104,7 @@ namespace Raven.Server.Documents.Queries.Results
             }
         }
 
-        public abstract Document Get(Lucene.Net.Documents.Document input, Lucene.Net.Search.ScoreDoc scoreDoc, IState state);
+        public abstract (Document Document, List<Document> List) Get(Lucene.Net.Documents.Document input, Lucene.Net.Search.ScoreDoc scoreDoc, IState state);
 
         public abstract bool TryGetKey(Lucene.Net.Documents.Document document, IState state, out string key);
 
@@ -114,7 +116,7 @@ namespace Raven.Server.Documents.Queries.Results
 
         protected abstract DynamicJsonValue GetCounterRaw(string docId, string name);
 
-        protected Document GetProjection(Lucene.Net.Documents.Document input, Lucene.Net.Search.ScoreDoc scoreDoc, string lowerId, IState state)
+        protected (Document Document, List<Document> List) GetProjection(Lucene.Net.Documents.Document input, Lucene.Net.Search.ScoreDoc scoreDoc, string lowerId, IState state)
         {
             using (_projectionScope = _projectionScope?.Start() ?? RetrieverScope?.For(nameof(QueryTimingsScope.Names.Projection)))
             {
@@ -132,7 +134,7 @@ namespace Raven.Server.Documents.Queries.Results
                                 FieldsToFetch.Projection.ThrowCouldNotExtractProjectionOnDocumentBecauseDocumentDoesNotExistException(lowerId);
                         }
 
-                        return null;
+                        return default;
                     }
 
                     return GetProjectionFromDocumentInternal(doc, input, scoreDoc, FieldsToFetch, _context, state);
@@ -196,7 +198,7 @@ namespace Raven.Server.Documents.Queries.Results
                             }
 
                             // we don't return partial results
-                            return null;
+                            return default;
                         }
                     }
 
@@ -211,7 +213,7 @@ namespace Raven.Server.Documents.Queries.Results
                             else
                                 ThrowInvalidQueryBodyResponse(fieldVal);
                             FinishDocumentSetup(doc, scoreDoc);
-                            return doc;
+                            return (doc, null);
                         }
 
                         if (fieldVal is List<object> list)
@@ -241,11 +243,11 @@ namespace Raven.Server.Documents.Queries.Results
                     };
                 }
 
-                return ReturnProjection(result, doc, scoreDoc, _context);
+                return (ReturnProjection(result, doc, scoreDoc, _context), null);
             }
         }
 
-        public Document GetProjectionFromDocument(Document doc, Lucene.Net.Documents.Document luceneDoc, Lucene.Net.Search.ScoreDoc scoreDoc, FieldsToFetch fieldsToFetch, JsonOperationContext context, IState state)
+        public (Document Document, List<Document> List) GetProjectionFromDocument(Document doc, Lucene.Net.Documents.Document luceneDoc, Lucene.Net.Search.ScoreDoc scoreDoc, FieldsToFetch fieldsToFetch, JsonOperationContext context, IState state)
         {
             using (RetrieverScope?.Start())
             using (_projectionScope = _projectionScope?.Start() ?? RetrieverScope?.For(nameof(QueryTimingsScope.Names.Projection)))
@@ -254,7 +256,7 @@ namespace Raven.Server.Documents.Queries.Results
             }
         }
 
-        private Document GetProjectionFromDocumentInternal(Document doc, Lucene.Net.Documents.Document luceneDoc, Lucene.Net.Search.ScoreDoc scoreDoc, FieldsToFetch fieldsToFetch, JsonOperationContext context, IState state)
+        private (Document Document, List<Document> List) GetProjectionFromDocumentInternal(Document doc, Lucene.Net.Documents.Document luceneDoc, Lucene.Net.Search.ScoreDoc scoreDoc, FieldsToFetch fieldsToFetch, JsonOperationContext context, IState state)
         {
             var result = new DynamicJsonValue();
 
@@ -274,14 +276,14 @@ namespace Raven.Server.Documents.Queries.Results
 
                 var immediateResult = AddProjectionToResult(doc, scoreDoc, fieldsToFetch, result, key, fieldVal);
 
-                if (immediateResult != null)
+                if (immediateResult.Document != null || immediateResult.List != null)
                     return immediateResult;
             }
 
-            return ReturnProjection(result, doc, scoreDoc, context);
+            return (ReturnProjection(result, doc, scoreDoc, context), null);
         }
 
-        protected Document AddProjectionToResult(Document doc, Lucene.Net.Search.ScoreDoc scoreDoc, FieldsToFetch fieldsToFetch, DynamicJsonValue result, string key, object fieldVal)
+        protected (Document Document, List<Document> List) AddProjectionToResult(Document doc, Lucene.Net.Search.ScoreDoc scoreDoc, FieldsToFetch fieldsToFetch, DynamicJsonValue result, string key, object fieldVal)
         {
             if (_query.IsStream &&
                 key.StartsWith(Constants.TimeSeries.QueryFunction))
@@ -291,26 +293,53 @@ namespace Raven.Server.Documents.Queries.Results
                 doc.TimeSeriesStream.TimeSeries = value.Stream;
                 doc.TimeSeriesStream.Key = key;
                 Json.BlittableJsonTextWriterExtensions.MergeMetadata(result, value.Metadata);
-                return null;
+                return default;
             }
 
             if (fieldsToFetch.SingleBodyOrMethodWithNoAlias)
             {
-                var newDoc = CreateNewDocument(doc, key, fieldVal);
-                FinishDocumentSetup(newDoc, scoreDoc);
-                return newDoc;
+                var r = CreateNewDocument(doc, key, fieldVal);
+                FinishDocumentSetup(r.Document, scoreDoc);
+                if (r.List == null) return r;
+                foreach (Document item in r.List)
+                {
+                    FinishDocumentSetup(item, scoreDoc);
+                }
+                return r;
+
             }
 
             AddProjectionToResult(result, key, fieldVal);
-            return null;
+            return default;
         }
 
-        private Document CreateNewDocument(Document doc, string key, object fieldVal)
+        private (Document Document, List<Document> List) CreateNewDocument(Document doc, string key, object fieldVal)
         {
             switch (fieldVal)
             {
+                case List<object> list:
+                    RuntimeHelpers.EnsureSufficientExecutionStack();
+                    var results = new List<Document>(list.Count);
+                    for (int i = 0; i < list.Count; i++)
+                    {
+                        var result = CreateNewDocument(doc, key, list[i]);
+                        if (result.Document != null)
+                        {
+                            results.Add(result.Document);
+                        }
+                        else if (result.List != null)
+                        {
+                            foreach (var document in result.List)
+                            {
+                                results.Add(document);
+                            }
+                        }
+                    }
+
+                    return (null, results);
+                    break;
                 case BlittableJsonReaderObject nested:
-                    return new Document
+                    return (new Document
                     {
                         Id = doc.Id,
                         ChangeVector = doc.ChangeVector,
@@ -322,13 +351,13 @@ namespace Raven.Server.Documents.Queries.Results
                         NonPersistentFlags = doc.NonPersistentFlags,
                         StorageId = doc.StorageId,
                         TransactionMarker = doc.TransactionMarker
-                    };
+                    }, null);
 
                 case Document d:
-                    return d;
+                    return (d, null);
 
                 case TimeSeriesRetriever.TimeSeriesRetrieverResult ts:
-                    return new Document
+                    return (new Document
                     {
                         Id = doc.Id,
                         ChangeVector = doc.ChangeVector,
@@ -345,14 +374,14 @@ namespace Raven.Server.Documents.Queries.Results
                             TimeSeries = ts.Stream,
                             Key = key
                         }
-                    };
+                    }, null);
 
                 default:
                     ThrowInvalidQueryBodyResponse(fieldVal);
                     break;
             }
 
-            return null;
+            return default;
         }
 
         protected static void AddProjectionToResult(DynamicJsonValue result, string key, object fieldVal)

--- a/test/SlowTests/Issues/RavenDB-17134.cs
+++ b/test/SlowTests/Issues/RavenDB-17134.cs
@@ -1,0 +1,185 @@
+using System;
+using System.Threading.Tasks;
+using FastTests;
+using Xunit;
+using Xunit.Abstractions;
+
+namespace SlowTests.Issues
+{
+    public class RavenDB_17134 : RavenTestBase
+    {
+        public RavenDB_17134(ITestOutputHelper output) : base(output)
+        {
+        }
+
+        public class TimeSeriesRange
+        {
+            public DateTime From, To;
+            public string Key;
+            public long[] Count;
+            public double[] Sum;
+        }
+
+        class Dog
+        {
+            public string Name;
+            public int Age;
+
+            public Dog(string name, int age)
+            {
+                Name = name;
+                Age = age;
+            }
+        }
+        class User
+        {
+            public Dog[] Dogs;
+        } 
+
+        [Fact]
+        public async Task CanProjectMultipleValuesFromSingleResultInCollectionQuery()
+        {
+            using var store = GetDocumentStore();
+
+            using (var session = store.OpenAsyncSession())
+            {
+                await session.StoreAsync(new User
+                {
+                    Dogs = new []
+                    {
+                        new Dog("Arava", 12), 
+                        new Dog("Pheobe", 7)
+                    }
+                });
+                await session.SaveChangesAsync();
+            }
+
+            using (var session = store.OpenAsyncSession())
+            {
+                var dogs = await session.Advanced.AsyncRawQuery<Dog>(@"
+declare function project(u) { return u.Dogs; }
+from Users  as u
+select project(u)
+")
+                    .Statistics(out var stats)
+                    .ToListAsync();
+                
+                Assert.Equal(2, stats.TotalResults);
+                Assert.Equal(2, dogs.Count);
+            }
+        } 
+        
+        [Fact]
+        public async Task CanProjectMultipleValuesFromSingleResultInIndexQuery()
+        {
+            using var store = GetDocumentStore();
+
+            using (var session = store.OpenAsyncSession())
+            {
+                await session.StoreAsync(new User
+                {
+                    Dogs = new []
+                    {
+                        new Dog("Arava", 12), 
+                        new Dog("Pheobe", 7)
+                    }
+                });
+                await session.SaveChangesAsync();
+            }
+
+            using (var session = store.OpenAsyncSession())
+            {
+                var dogs = await session.Advanced.AsyncRawQuery<Dog>(@"
+declare function project(u) { return u.Dogs; }
+from Users  as u
+where u.Dogs.Count > 0
+select project(u)
+")
+                    .Statistics(out var stats)
+                    .ToListAsync();
+                
+                Assert.Equal(2, stats.TotalResults);
+                Assert.Equal(2, dogs.Count);
+            }
+        } 
+
+        
+        [Fact]
+        public async Task CanProjectTimeSeriesInCollectionQuery()
+        {
+            using var store = GetDocumentStore();
+
+            using (var session = store.OpenAsyncSession())
+            {
+                User user = new User();
+                await session.StoreAsync(user);
+
+                var baseline = DateTime.Today;
+                session.TimeSeriesFor(user, "walks").Append(baseline, 45);
+                session.TimeSeriesFor(user, "walks").Append(baseline.AddHours(1), 7);
+                session.TimeSeriesFor(user, "walks").Append(baseline.AddDays(1), 47);
+                session.TimeSeriesFor(user, "walks").Append(baseline.AddDays(2), 43);
+                await session.SaveChangesAsync();
+            }
+
+            using (var session = store.OpenAsyncSession())
+            {
+                var range = await session.Advanced.AsyncRawQuery<TimeSeriesRange>(@"
+declare timeseries time_walked_by_day(e){
+    from e.Walks group by 1d select sum()
+}
+declare function project(e){
+    return time_walked_by_day(e).Results;
+}
+from Users as e
+select project(e)
+")
+                    .Statistics(out var stats)
+                    .ToListAsync();
+                
+                WaitForUserToContinueTheTest(store);
+                Assert.Equal(3, stats.TotalResults);
+                Assert.Equal(3, range.Count);
+            }
+        } 
+        
+        [Fact]
+        public async Task CanProjectTimeSeriesInIndexQuery()
+        {
+            using var store = GetDocumentStore();
+
+            using (var session = store.OpenAsyncSession())
+            {
+                User user = new User();
+                await session.StoreAsync(user);
+
+                var baseline = DateTime.Today;
+                session.TimeSeriesFor(user, "walks").Append(baseline, 45);
+                session.TimeSeriesFor(user, "walks").Append(baseline.AddHours(1), 7);
+                session.TimeSeriesFor(user, "walks").Append(baseline.AddDays(1), 47);
+                session.TimeSeriesFor(user, "walks").Append(baseline.AddDays(2), 43);
+                await session.SaveChangesAsync();
+            }
+
+            using (var session = store.OpenAsyncSession())
+            {
+                var range = await session.Advanced.AsyncRawQuery<TimeSeriesRange>(@"
+declare timeseries time_walked_by_day(e){
+    from e.Walks group by 1d select sum()
+}
+declare function project(e){
+    return time_walked_by_day(e).Results;
+}
+from Users as e
+where e.Dogs  == null
+select project(e)
+")
+                    .Statistics(out var stats)
+                    .ToListAsync();
+                
+                Assert.Equal(3, stats.TotalResults);
+                Assert.Equal(3, range.Count);
+            }
+        } 
+    }
+}


### PR DESCRIPTION
…y output

### Issue link

https://issues.hibernatingrhinos.com/issue/RavenDB-17134

### Additional description

This change allows RavenDB to output flatten multiple values per result from the index. The intent is to allow more complex queries and projections out to the user. 

### Type of change

- New feature

### How risky is the change?

- Moderate risk - we are changing the query engine. I doubt there will be any regression that won't be caught by the existing tests.

### Backward compatibility

- Non breaking change

The change make what was previously an error into a valid operation.
### Is it platform specific issue?


### Documentation update

- This change requires a documentation update. Please mark the issue on YouTrack using `Documentation Required` tag.

Will be done after review.

### Testing 

- Tests have been added that prove the fix is effective or that the feature works

Waiting for tests to see if the approach is valid or if there are other options.