### PR TITLE
RavenDB-17148 Set TasksMax to infinity in ravendb service systemd uni…

### DIFF
--- a/scripts/linux/pkg/deb/assets/ravendb/debian/ravendb.service
+++ b/scripts/linux/pkg/deb/assets/ravendb/debian/ravendb.service
@@ -8,6 +8,7 @@ LimitNOFILE=65535
 LimitRSS=infinity
 LimitAS=infinity
 LimitMEMLOCK=infinity
+TasksMax=infinity
 User=ravendb
 StartLimitBurst=0
 Restart=on-failure

--- a/scripts/linux/ravendb.service
+++ b/scripts/linux/ravendb.service
@@ -1,5 +1,5 @@
 [Unit]
-Description=RavenDB v4.2
+Description=RavenDB NoSQL Database
 After=network.target
 
 [Service]
@@ -8,6 +8,7 @@ LimitNOFILE=65535
 LimitRSS=infinity
 LimitAS=infinity
 LimitMEMLOCK=infinity
+TasksMax=infinity
 User=RAVENDB_USERNAME
 StartLimitBurst=0
 Restart=on-failure


### PR DESCRIPTION
…t file

### Issue link

https://issues.hibernatingrhinos.com/issue/RavenDB-17148

### Additional description

Systemd services may have a limit on max number of forks/clones done by a process (they usually do on Ubuntu for example). For a large number of DBs (70+) with bunch of ongoing tasks set we've seen RavenDB reaching that limit and preventing the process from forking - `OutOfMemoryException` has been thrown in such cases and it lead to unexpected behaviour and 'freezing'. To overcome this issue we need to override the default limit by setting `TasksMax`.

### Type of change

- Bug fix/Optimization

### How risky is the change?

- Low 

### Backward compatibility

- Non breaking change


### Is it platform specific issue?

- Yes - Linux systemd service issue.

### Documentation update

- No documentation update is needed 

### Testing 

- It has been verified by manual testing

### Is there any existing behavior change of other features due to this change?

- No

### UI work

- No UI work is needed
