### PR TITLE
RavenDB-17144 Ctrl+D/EOF handling

### DIFF
--- a/tools/rvn/AdminChannel.cs
+++ b/tools/rvn/AdminChannel.cs
@@ -131,7 +131,10 @@ namespace rvn
                         switch (delimiter)
                         {
                             case RavenCli.Delimiter.ReadLine:
-                                writer.WriteLine(Console.ReadLine());
+                                var readValue = Console.ReadLine();
+                                if (readValue == null)
+                                    Environment.Exit(0);
+                                writer.WriteLine(readValue);
                                 break;
                             case RavenCli.Delimiter.ReadKey:
                                 writer.Write(Console.ReadKey().KeyChar);


### PR DESCRIPTION
### Issue link

https://issues.hibernatingrhinos.com/issue/RavenDB-17144

### Additional description

Fixed the bug that has put rvn in endless loop while passing EOF to the admin-channel script via a .sh script.
Now ctrl+d/eof closes admin-channel.

### Type of change

- Bug fix

### How risky is the change?

- Low 

### Backward compatibility

- Non breaking change

### Is it platform specific issue?

- No

### Documentation update

- No documentation update is needed 

### Testing 

- It has been verified by manual testing

### Is there any existing behavior change of other features due to this change?
- No

### UI work

- No UI work is needed
