### PR TITLE
RavenDB-17115 have an exclusive access to lock the memory

### DIFF
--- a/src/Raven.Client/Http/RequestExecutor.cs
+++ b/src/Raven.Client/Http/RequestExecutor.cs
@@ -2174,14 +2174,14 @@ namespace Raven.Client.Http
             }
         }
 
-        public async Task<(int, ServerNode)> GetRequestedNode(string nodeTag)
+        public async Task<(int Index, ServerNode Node)> GetRequestedNode(string nodeTag)
         {
             await EnsureNodeSelector().ConfigureAwait(false);
 
             return _nodeSelector.GetRequestedNode(nodeTag);
         }
 
-        public async Task<(int, ServerNode)> GetPreferredNode()
+        public async Task<(int Index, ServerNode Node)> GetPreferredNode()
         {
             await EnsureNodeSelector().ConfigureAwait(false);
 

--- a/src/Raven.Server/Documents/DatabasesLandlord.cs
+++ b/src/Raven.Server/Documents/DatabasesLandlord.cs
@@ -324,8 +324,6 @@ namespace Raven.Server.Documents
                 try
                 {
                     removeLockAndReturn = DatabasesCache.RemoveLockAndReturn(dbName, CompleteDatabaseUnloading, out var database);
-                    if (removeLockAndReturn == null)
-                        return; // database already removed
                     databaseId = database?.DbBase64Id;
                 }
                 catch (AggregateException ae) when (nameof(DeleteDatabase).Equals(ae.InnerException.Data["Source"]))

--- a/src/Raven.Server/Documents/Handlers/Debugging/MemoryDebugHandler.cs
+++ b/src/Raven.Server/Documents/Handlers/Debugging/MemoryDebugHandler.cs
@@ -260,7 +260,7 @@ namespace Raven.Server.Documents.Handlers.Debugging
                 [nameof(MemoryInfo.UnmanagedAllocations)] = Size.Humane(totalUnmanagedAllocations),
                 [nameof(MemoryInfo.EncryptionBuffersInUse)] = Size.Humane(encryptionBuffers.CurrentlyInUseSize),
                 [nameof(MemoryInfo.EncryptionBuffersPool)] = Size.Humane(encryptionBuffers.TotalPoolSize),
-                [nameof(MemoryInfo.EncryptionLockedMemory)] = Sodium.LockedMemory.ToString(),
+                [nameof(MemoryInfo.EncryptionLockedMemory)] = Size.Humane(Sodium.LockedBytes),
                 [nameof(MemoryInfo.MemoryMapped)] = Size.Humane(totalMapping),
                 [nameof(MemoryInfo.ScratchDirtyMemory)] = memInfo.TotalScratchDirtyMemory.ToString(),
                 [nameof(MemoryInfo.IsHighDirty)] = dirtyMemoryState.IsHighDirty,

--- a/src/Raven.Server/Documents/Handlers/Debugging/MemoryDebugHandler.cs
+++ b/src/Raven.Server/Documents/Handlers/Debugging/MemoryDebugHandler.cs
@@ -14,6 +14,7 @@ using Sparrow.Json.Parsing;
 using Sparrow.LowMemory;
 using Sparrow.Platform;
 using Sparrow.Platform.Posix;
+using Sparrow.Server;
 using Sparrow.Server.Platform.Win32;
 using Sparrow.Utils;
 using Size = Raven.Client.Util.Size;
@@ -271,6 +272,7 @@ namespace Raven.Server.Documents.Handlers.Debugging
                 [nameof(MemoryInfo.LowMemLastFiveMinute)] = memoryUsageRecords.Low.LastFiveMinutes.ToString(),
                 [nameof(MemoryInfo.HighMemSinceStartup)] = memoryUsageRecords.High.SinceStartup.ToString(),
                 [nameof(MemoryInfo.LowMemSinceStartup)] = memoryUsageRecords.Low.SinceStartup.ToString(),
+                [nameof(MemoryInfo.LockedMemory)] = Sodium.LockedMemory.ToString(),
             };
 
             writer.WritePropertyName(nameof(MemoryInformation));
@@ -475,6 +477,7 @@ namespace Raven.Server.Documents.Handlers.Debugging
             public string LowMemLastFiveMinute { get; set; }
             public string HighMemSinceStartup { get; set; }
             public string LowMemSinceStartup { get; set; }
+            public string LockedMemory { get; set; }
             public MemoryInfoMappingItem[] Mappings { get; set; }
         }
 

--- a/src/Raven.Server/Documents/Handlers/Debugging/MemoryDebugHandler.cs
+++ b/src/Raven.Server/Documents/Handlers/Debugging/MemoryDebugHandler.cs
@@ -260,6 +260,7 @@ namespace Raven.Server.Documents.Handlers.Debugging
                 [nameof(MemoryInfo.UnmanagedAllocations)] = Size.Humane(totalUnmanagedAllocations),
                 [nameof(MemoryInfo.EncryptionBuffersInUse)] = Size.Humane(encryptionBuffers.CurrentlyInUseSize),
                 [nameof(MemoryInfo.EncryptionBuffersPool)] = Size.Humane(encryptionBuffers.TotalPoolSize),
+                [nameof(MemoryInfo.EncryptionLockedMemory)] = Sodium.LockedMemory.ToString(),
                 [nameof(MemoryInfo.MemoryMapped)] = Size.Humane(totalMapping),
                 [nameof(MemoryInfo.ScratchDirtyMemory)] = memInfo.TotalScratchDirtyMemory.ToString(),
                 [nameof(MemoryInfo.IsHighDirty)] = dirtyMemoryState.IsHighDirty,
@@ -272,7 +273,6 @@ namespace Raven.Server.Documents.Handlers.Debugging
                 [nameof(MemoryInfo.LowMemLastFiveMinute)] = memoryUsageRecords.Low.LastFiveMinutes.ToString(),
                 [nameof(MemoryInfo.HighMemSinceStartup)] = memoryUsageRecords.High.SinceStartup.ToString(),
                 [nameof(MemoryInfo.LowMemSinceStartup)] = memoryUsageRecords.Low.SinceStartup.ToString(),
-                [nameof(MemoryInfo.LockedMemory)] = Sodium.LockedMemory.ToString(),
             };
 
             writer.WritePropertyName(nameof(MemoryInformation));
@@ -465,6 +465,7 @@ namespace Raven.Server.Documents.Handlers.Debugging
             public string UnmanagedAllocations { get; set; }
             public string EncryptionBuffersInUse { get; set; }
             public string EncryptionBuffersPool { get; set; }
+            public string EncryptionLockedMemory { get; set; }
             public string MemoryMapped { get; set; }
             public string ScratchDirtyMemory { get; set; }
             public bool IsHighDirty { get; set; }
@@ -477,7 +478,6 @@ namespace Raven.Server.Documents.Handlers.Debugging
             public string LowMemLastFiveMinute { get; set; }
             public string HighMemSinceStartup { get; set; }
             public string LowMemSinceStartup { get; set; }
-            public string LockedMemory { get; set; }
             public MemoryInfoMappingItem[] Mappings { get; set; }
         }
 

--- a/src/Raven.Server/Documents/ResourceCache.cs
+++ b/src/Raven.Server/Documents/ResourceCache.cs
@@ -165,20 +165,10 @@ namespace Raven.Server.Documents
 
                 task.IgnoreUnobservedExceptions();
 
-                bool found = false;
-                while (found == false)
+                if (_caseInsensitive.TryGetValue(databaseName, out current) == false)
                 {
-                    found = _caseInsensitive.TryGetValue(databaseName, out current);
-                    if (found == false)
-                    {
-                        resource = default(TResource);
-                        if (_caseInsensitive.TryAdd(databaseName, task) == false)
-                            continue;
-                        return new DisposableAction(() =>
-                        {
-                            TryRemove(databaseName, out _);
-                        });
-                    }
+                    resource = default;
+                    return null;
                 }
 
                 if (current.IsCompleted == false)

--- a/src/Raven.Server/Rachis/RachisLogHistory.cs
+++ b/src/Raven.Server/Rachis/RachisLogHistory.cs
@@ -279,6 +279,18 @@ namespace Raven.Server.Rachis
             }
         }
 
+        public string GetHistoryLogsAsString(TransactionOperationContext context)
+        {
+            var sb = new StringBuilder();
+
+            foreach (var entry in GetHistoryLogs(context))
+            {
+                sb.AppendLine(context.ReadObject(entry, "raft-command-history").ToString());
+            }
+
+            return sb.ToString();
+        }
+
         public IEnumerable<DynamicJsonValue> GetHistoryLogs(TransactionOperationContext context)
         {
             var table = context.Transaction.InnerTransaction.OpenTable(LogHistoryTable, LogHistorySlice);

--- a/src/Raven.Server/ServerWide/ClusterStateMachine.cs
+++ b/src/Raven.Server/ServerWide/ClusterStateMachine.cs
@@ -2770,6 +2770,15 @@ namespace Raven.Server.ServerWide
                 return items.VerifyKeyExists(key);
         }
 
+        public bool DatabaseExists(string name)
+        {
+            using (ContextPoolForReadOnlyOperations.AllocateOperationContext(out TransactionOperationContext context))
+            using (context.OpenReadTransaction())
+            {
+                return DatabaseExists(context, name);
+            }
+        }
+
         public DatabaseRecord ReadDatabase(TransactionOperationContext context, string name, out long etag)
         {
             using (var databaseRecord = ReadRawDatabaseRecord(context, name, out etag))

--- a/src/Sparrow.Server/Sodium.cs
+++ b/src/Sparrow.Server/Sodium.cs
@@ -275,7 +275,7 @@ namespace Sparrow.Server
 
         private static long _lockedBytes;
 
-        public static Size LockedMemory => new Size(_lockedBytes, SizeUnit.Bytes);
+        public static long LockedBytes => _lockedBytes;
 
         [MethodImpl(MethodImplOptions.AggressiveInlining)]
         public static int Lock(byte* addr, UIntPtr len)

--- a/src/Voron/Impl/Paging/Windows32BitsMemoryMapPager.cs
+++ b/src/Voron/Impl/Paging/Windows32BitsMemoryMapPager.cs
@@ -238,17 +238,8 @@ namespace Voron.Impl.Paging
         private void LockMemory32Bits(byte* address, long sizeToLock, TransactionState state)
         {
             try
-            {                
-                if (Sodium.sodium_mlock(address, (UIntPtr)sizeToLock) != 0)
-                {
-                    lock (WorkingSetIncreaseLocker)
-                    { 
-                        if (Sodium.sodium_mlock(address, (UIntPtr)sizeToLock) != 0 && DoNotConsiderMemoryLockFailureAsCatastrophicError == false)
-                        {
-                            TryHandleFailureToLockMemory(address, sizeToLock);
-                        }                    
-                    }
-                }
+            {
+                Lock(address, sizeToLock, state);
             }
             catch (Exception e)
             {
@@ -260,7 +251,7 @@ namespace Voron.Impl.Paging
         {
             try
             {
-                Sodium.sodium_munlock(address, (UIntPtr)sizeToUnlock);
+                Sodium.Unlock(address, (UIntPtr)sizeToUnlock);
             }
             catch (Exception e)
             {

--- a/test/SlowTests/Issues/EncryptedDatabaseGroup.cs
+++ b/test/SlowTests/Issues/EncryptedDatabaseGroup.cs
@@ -22,6 +22,30 @@ namespace SlowTests.Issues
         public EncryptedDatabaseGroup(ITestOutputHelper output) : base(output)
         {
         }
+        
+        [Fact]
+        public async Task CanLockMemoryUnderHighContention() // this is a probabilistic test
+        {
+             DebuggerAttachedTimeout.DisableLongTimespan = true;
+            var (nodes, leader, certificates) = await CreateRaftClusterWithSsl(7, watcherCluster: true);
+
+            EncryptedCluster(nodes, certificates, out var databaseName);
+
+            var options = new Options
+            {
+                Server = leader,
+                ReplicationFactor = 7,
+                ClientCertificate = certificates.ClientCertificate1.Value,
+                AdminCertificate = certificates.ServerCertificate.Value,
+                ModifyDatabaseName = _ => databaseName,
+                Encrypted = true,
+                RunInMemory = false
+            };
+            using (var store = GetDocumentStore(options))
+            {
+                await TrySavingDocument(store, 1);
+            }
+        }
 
         [Fact]
         public async Task CanRemoveNodeWithNoKey()

--- a/test/SlowTests/Issues/EncryptedDatabaseGroup.cs
+++ b/test/SlowTests/Issues/EncryptedDatabaseGroup.cs
@@ -24,30 +24,6 @@ namespace SlowTests.Issues
         }
         
         [Fact]
-        public async Task CanLockMemoryUnderHighContention() // this is a probabilistic test
-        {
-             DebuggerAttachedTimeout.DisableLongTimespan = true;
-            var (nodes, leader, certificates) = await CreateRaftClusterWithSsl(7, watcherCluster: true);
-
-            EncryptedCluster(nodes, certificates, out var databaseName);
-
-            var options = new Options
-            {
-                Server = leader,
-                ReplicationFactor = 7,
-                ClientCertificate = certificates.ClientCertificate1.Value,
-                AdminCertificate = certificates.ServerCertificate.Value,
-                ModifyDatabaseName = _ => databaseName,
-                Encrypted = true,
-                RunInMemory = false
-            };
-            using (var store = GetDocumentStore(options))
-            {
-                await TrySavingDocument(store, 1);
-            }
-        }
-
-        [Fact]
         public async Task CanRemoveNodeWithNoKey()
         {
              DebuggerAttachedTimeout.DisableLongTimespan = true;

--- a/test/SlowTests/Issues/RavenDB-17141.cs
+++ b/test/SlowTests/Issues/RavenDB-17141.cs
@@ -35,5 +35,24 @@ namespace SlowTests.Issues
                 Assert.Equal(1, Server.ServerStore.DatabasesLandlord.DatabasesCache.DetailsCount);
             }
         }
+
+        [Fact]
+        public async Task CanDeleteDisabledDatabase()
+        {
+            using (var store = GetDocumentStore(new Options
+            {
+                RunInMemory = false, 
+                DeleteDatabaseOnDispose = false
+            }))
+            {
+                var result = await store.Maintenance.Server.SendAsync(new ToggleDatabasesStateOperation(store.Database, disable: true));
+                Assert.True(result.Success);
+                Assert.True(result.Disabled);
+
+                await store.Maintenance.Server.SendAsync(new DeleteDatabasesOperation(store.Database, hardDelete: true));
+
+                Assert.False(Server.ServerStore.Cluster.DatabaseExists(store.Database));
+            }
+        }
     }
 }

--- a/test/StressTests/Server/Encryption/EncryptionStressTests.cs
+++ b/test/StressTests/Server/Encryption/EncryptionStressTests.cs
@@ -1,0 +1,78 @@
+﻿using System;
+using System.Collections.Generic;
+using System.Diagnostics;
+using System.Text;
+using System.Threading.Tasks;
+using FastTests.Graph;
+using Raven.Client.Documents;
+using Raven.Server.Utils;
+using Sparrow.Platform;
+using Tests.Infrastructure;
+using Xunit;
+using Xunit.Abstractions;
+
+namespace StressTests.Server.Encryption
+{
+    public class EncryptionStressTests : ClusterTestBase
+    {
+        public EncryptionStressTests(ITestOutputHelper output) : base(output)
+        {
+        }
+
+        [Fact]
+        public async Task CanLockMemoryUnderHighContention() // this is a probabilistic test
+        {
+            using var process = Process.GetCurrentProcess();
+            IntPtr minWorkingSet = default;
+
+            if (PlatformDetails.RunningOnPosix == false)
+            {
+                minWorkingSet = process.MinWorkingSet;
+            }
+
+            try
+            {
+                DebuggerAttachedTimeout.DisableLongTimespan = true;
+                var (nodes, leader, certificates) = await CreateRaftClusterWithSsl(7, watcherCluster: true);
+
+                EncryptedCluster(nodes, certificates, out var databaseName);
+
+                var options = new Options
+                {
+                    Server = leader,
+                    ReplicationFactor = 7,
+                    ClientCertificate = certificates.ClientCertificate1.Value,
+                    AdminCertificate = certificates.ServerCertificate.Value,
+                    ModifyDatabaseName = _ => databaseName,
+                    Encrypted = true,
+                    RunInMemory = false
+                };
+                using (var store = GetDocumentStore(options))
+                {
+                    await TrySavingDocument(store, 6);
+                }
+            }
+            finally
+            {
+                if (PlatformDetails.RunningOnPosix == false)
+                {
+                    process.MinWorkingSet = minWorkingSet;
+                    process.MaxWorkingSet = minWorkingSet;
+                }
+            }
+            
+        }
+
+        private static async Task TrySavingDocument(DocumentStore store, int? replicas = null)
+        {
+            using (var session = store.OpenAsyncSession())
+            {
+                if (replicas.HasValue)
+                    session.Advanced.WaitForReplicationAfterSaveChanges(replicas: replicas.Value);
+
+                await session.StoreAsync(new User { Name = "Foo" });
+                await session.SaveChangesAsync();
+            }
+        }
+    }
+}

--- a/test/Tests.Infrastructure/RavenTestBase.cs
+++ b/test/Tests.Infrastructure/RavenTestBase.cs
@@ -230,7 +230,7 @@ namespace FastTests
                     using (nodes[i].ServerStore.ContextPool.AllocateOperationContext(out TransactionOperationContext context))
                     {
                         context.OpenReadTransaction();
-                        message += $"{Environment.NewLine}Log state for non responsing server:{Environment.NewLine}{context.ReadObject(nodes[i].ServerStore.GetLogDetails(context), "LogSummary/" + i)}";
+                        message += $"{Environment.NewLine}Log state for non responsing server:{Environment.NewLine}{nodes[i].ServerStore.Engine.LogHistory.GetHistoryLogsAsString(context)}";
                     }
                 }
             }


### PR DESCRIPTION
### Issue link

https://issues.hibernatingrhinos.com/issue/RavenDB-17115

### Additional description

There are 2 fixes here. 

~~1 - if the database was already removed, avoid re-adding a faulty task to the cache.
Since it might end-up throwing an exception upon actually adding that database.~~

2 - Have an exclusive access to lock the memory
Might be a race when one thread increase the WS but another one locks the memory.

### Type of change

- Bug fix
- Optimization

### How risky is the change?

- Moderate 

### Is it platform specific issue?

- The memory locking is relevant only for windows

### Testing 

- It has been verified by manual testing 
Run in a loop creation of an encrypted database on 7 nodes (reset the WS each iteration)

### Is there any existing behavior change of other features due to this change?

- No
