### PR TITLE
RavenDB-17123 Query over index with spatial field in studio is showing __ignored for that field

### DIFF
--- a/src/Raven.Server/Documents/Indexes/Persistence/Lucene/Documents/AnonymousLuceneDocumentConverter.cs
+++ b/src/Raven.Server/Documents/Indexes/Persistence/Lucene/Documents/AnonymousLuceneDocumentConverter.cs
@@ -99,7 +99,12 @@ namespace Raven.Server.Documents.Indexes.Persistence.Lucene.Documents
 
                 if (storedValue != null && shouldSkip == false)
                 {
-                    storedValue[property.Key] = TypeConverter.ToBlittableSupportedType(value, flattenArrays: true);
+                    var blittableValue = TypeConverter.ToBlittableSupportedType(value, flattenArrays: true);
+
+                    if (blittableValue is string && blittableValue.Equals("__ignored"))
+                        continue;
+
+                    storedValue[property.Key] = blittableValue;
                 }
             }
 

--- a/src/Raven.Server/Documents/Indexes/Persistence/Lucene/Documents/AnonymousLuceneDocumentConverter.cs
+++ b/src/Raven.Server/Documents/Indexes/Persistence/Lucene/Documents/AnonymousLuceneDocumentConverter.cs
@@ -99,9 +99,9 @@ namespace Raven.Server.Documents.Indexes.Persistence.Lucene.Documents
 
                 if (storedValue != null && shouldSkip == false)
                 {
-                    var blittableValue = TypeConverter.ToBlittableSupportedType(value, out bool ignoredReturnType, flattenArrays: true);
+                    var blittableValue = TypeConverter.ToBlittableSupportedType(value, out TypeConverter.BlittableSupportedReturnType returnType, flattenArrays: true);
 
-                    if (ignoredReturnType)
+                    if (returnType == TypeConverter.BlittableSupportedReturnType.Ignored)
                         continue;
 
                     storedValue[property.Key] = blittableValue;

--- a/src/Raven.Server/Documents/Indexes/Persistence/Lucene/Documents/AnonymousLuceneDocumentConverter.cs
+++ b/src/Raven.Server/Documents/Indexes/Persistence/Lucene/Documents/AnonymousLuceneDocumentConverter.cs
@@ -99,9 +99,9 @@ namespace Raven.Server.Documents.Indexes.Persistence.Lucene.Documents
 
                 if (storedValue != null && shouldSkip == false)
                 {
-                    var blittableValue = TypeConverter.ToBlittableSupportedType(value, flattenArrays: true);
+                    var blittableValue = TypeConverter.ToBlittableSupportedType(value, out TypeConverter.BlittableSupportedReturnType blittableSupportedReturnType, flattenArrays: true);
 
-                    if (blittableValue is string && blittableValue.Equals("__ignored"))
+                    if (blittableSupportedReturnType == TypeConverter.BlittableSupportedReturnType.Ignored)
                         continue;
 
                     storedValue[property.Key] = blittableValue;

--- a/src/Raven.Server/Documents/Indexes/Persistence/Lucene/Documents/AnonymousLuceneDocumentConverter.cs
+++ b/src/Raven.Server/Documents/Indexes/Persistence/Lucene/Documents/AnonymousLuceneDocumentConverter.cs
@@ -99,9 +99,9 @@ namespace Raven.Server.Documents.Indexes.Persistence.Lucene.Documents
 
                 if (storedValue != null && shouldSkip == false)
                 {
-                    var blittableValue = TypeConverter.ToBlittableSupportedType(value, out TypeConverter.BlittableSupportedReturnType blittableSupportedReturnType, flattenArrays: true);
+                    var blittableValue = TypeConverter.ToBlittableSupportedType(value, out bool ignoredReturnType, flattenArrays: true);
 
-                    if (blittableSupportedReturnType == TypeConverter.BlittableSupportedReturnType.Ignored)
+                    if (ignoredReturnType)
                         continue;
 
                     storedValue[property.Key] = blittableValue;

--- a/src/Raven.Server/Utils/TypeConverter.cs
+++ b/src/Raven.Server/Utils/TypeConverter.cs
@@ -184,8 +184,18 @@ namespace Raven.Server.Utils
             return ToBlittableSupportedType(value, value, flattenArrays, forIndexing, 0, engine, context);
         }
 
+        public static object ToBlittableSupportedType(object value, out BlittableSupportedReturnType blittableSupportedReturnType, bool flattenArrays = false, bool forIndexing = false, Engine engine = null, JsonOperationContext context = null)
+        {
+            var blittableSupportedType = ToBlittableSupportedType(value, value, flattenArrays, forIndexing, 0, engine, context);
 
-        private enum BlittableSupportedReturnType : int
+            _supportedTypeCache.TryGet(value.GetType(), out BlittableSupportedReturnType returnType);
+            blittableSupportedReturnType = returnType;
+
+            return blittableSupportedType;
+        }
+
+
+        public enum BlittableSupportedReturnType : int
         {
             Null = 0,
             Same = 1,

--- a/src/Raven.Server/Utils/TypeConverter.cs
+++ b/src/Raven.Server/Utils/TypeConverter.cs
@@ -184,18 +184,15 @@ namespace Raven.Server.Utils
             return ToBlittableSupportedType(value, value, flattenArrays, forIndexing, 0, engine, context);
         }
 
-        public static object ToBlittableSupportedType(object value, out BlittableSupportedReturnType blittableSupportedReturnType, bool flattenArrays = false, bool forIndexing = false, Engine engine = null, JsonOperationContext context = null)
+        public static object ToBlittableSupportedType(object value, out bool ignoredReturnType, bool flattenArrays = false, bool forIndexing = false, Engine engine = null, JsonOperationContext context = null)
         {
-            var blittableSupportedType = ToBlittableSupportedType(value, value, flattenArrays, forIndexing, 0, engine, context);
+            ignoredReturnType = false || (value is IEnumerable<IFieldable> || value is IFieldable);
 
-            _supportedTypeCache.TryGet(value.GetType(), out BlittableSupportedReturnType returnType);
-            blittableSupportedReturnType = returnType;
-
-            return blittableSupportedType;
+            return ToBlittableSupportedType(value, value, flattenArrays, forIndexing, 0, engine, context);
         }
 
 
-        public enum BlittableSupportedReturnType : int
+        private enum BlittableSupportedReturnType : int
         {
             Null = 0,
             Same = 1,

--- a/test/SlowTests/Issues/RavenDB-17123.cs
+++ b/test/SlowTests/Issues/RavenDB-17123.cs
@@ -1,0 +1,224 @@
+﻿using System.Collections.Generic;
+using System.Linq;
+using FastTests;
+using Orders;
+using Raven.Client.Documents;
+using Raven.Client.Documents.Indexes;
+using Xunit;
+using Xunit.Abstractions;
+
+namespace SlowTests.Issues
+{
+    public class RavenDB_17123 : RavenTestBase
+    {
+        public RavenDB_17123(ITestOutputHelper output) : base(output)
+        {
+        }
+
+        [Fact]
+        public void CreateFieldsShouldNotDisplayAsIgnored()
+        {
+            var createFieldIndex = new CreateFieldIndex();
+            var simpleIndex = new SimpleIndex();
+
+            using (var store = GetDocumentStore())
+            {
+                createFieldIndex.Execute(store);
+                simpleIndex.Execute(store);
+
+                const int count = 300;
+
+                using (var bulk = store.BulkInsert())
+                {
+                    for (int i = 0; i < count; i++)
+                    {
+                        bulk.Store(new Order()
+                        {
+                            Company = $"companies/{i}",
+                            Employee = $"employee/{i}",
+                            Lines = new List<OrderLine>()
+                            {
+                                new OrderLine()
+                                {
+                                    Product = $"products/{i}",
+                                    ProductName = new string((char)0, 1) + "/" + i
+                                },
+                                new OrderLine()
+                                {
+                                    Product = $"products/{i}",
+                                    ProductName = new string((char)0, 1) + "/" + i
+                                },
+                            }
+                        });
+                    }
+                }
+
+                WaitForIndexing(store);
+
+                using (var session = store.OpenSession())
+                {
+                    var query = session.Query<Result, CreateFieldIndex>()
+                        .ProjectInto<Result>()
+                        .ToList();
+
+                    Assert.Equal(count, query.Count);
+                    foreach (var value in query)
+                    {
+                        Assert.Null(value.Total); // Result.Total is null instead of "__ignored"
+                    }
+
+                    query = session.Query<Result, SimpleIndex>()
+                        .ProjectInto<Result>()
+                        .ToList();
+
+                    long totalExpected = 12;
+
+                    foreach (var value in query)
+                    {
+                        Assert.NotNull(value.Total);
+                        Assert.Equal(totalExpected, value.Total);
+                    }
+                }
+            }
+        }
+
+        [Fact]
+        public void SpatialCreateFieldsShouldNotDisplayAsIgnored()
+        {
+            var createSpatialFieldIndex = new CreateSpatialFieldIndex();
+            var simpleIndex = new SimpleIndex();
+
+            using (var store = GetDocumentStore())
+            {
+                createSpatialFieldIndex.Execute(store);
+                simpleIndex.Execute(store);
+
+                const int count = 300;
+
+                using (var bulk = store.BulkInsert())
+                {
+                    for (int i = 0; i < count; i++)
+                    {
+                        bulk.Store(new Order()
+                        {
+                            Company = $"companies/{i}",
+                            Employee = $"employee/{i}",
+                            Lines = new List<OrderLine>()
+                            {
+                                new OrderLine()
+                                {
+                                    Product = $"products/{i}",
+                                    ProductName = new string((char)0, 1) + "/" + i
+                                },
+                                new OrderLine()
+                                {
+                                    Product = $"products/{i}",
+                                    ProductName = new string((char)0, 1) + "/" + i
+                                },
+                            }
+                        });
+                    }
+                }
+
+                WaitForIndexing(store);
+
+                using (var session = store.OpenSession())
+                {
+                    var query = session.Query<Result, CreateSpatialFieldIndex>()
+                        .ProjectInto<Result>()
+                        .ToList();
+
+                    Assert.Equal(count, query.Count);
+                    foreach (var value in query)
+                    {
+                        Assert.Null(value.Total); // Result.Total is null instead of "__ignored"
+                    }
+
+                    query = session.Query<Result, SimpleIndex>()
+                        .ProjectInto<Result>()
+                        .ToList();
+
+                    long totalExpected = 12;
+
+                    foreach (var value in query)
+                    {
+                        Assert.NotNull(value.Total);
+                        Assert.Equal(totalExpected, value.Total);
+                    }
+                }
+            }
+        }
+
+        public class Result
+        {
+            public string ProductName;
+            public object Total;
+        }
+
+        private class SimpleIndex : AbstractIndexCreationTask<Order, Result>
+        {
+            public SimpleIndex()
+            {
+                Map = orders => from order in orders
+                    from item in order.Lines
+                    select new
+                    {
+                        ProductName = item.ProductName,
+                        Total = item.Discount
+                    };
+
+                Reduce = results => from result in results
+                    group result by result.ProductName into g
+                    select new
+                    {
+                        ProductName = g.Key,
+                        Total = 12
+                    };
+            }
+        }
+
+        private class CreateSpatialFieldIndex : AbstractIndexCreationTask<Order, Result>
+        {
+            public CreateSpatialFieldIndex()
+            {
+                    Map = orders => from order in orders
+                                    from item in order.Lines
+                                    select new
+                                    {
+                                        ProductName = item.ProductName,
+                                        Total = item.Discount
+                                    };
+
+                    Reduce = results => from result in results
+                                        group result by result.ProductName into g
+                                        select new
+                                        {
+                                            ProductName = g.Key,
+                                            Total = CreateSpatialField(54.2, 23.2)
+                                        };
+            }
+        }
+
+        private class CreateFieldIndex : AbstractIndexCreationTask<Order, Result>
+        {
+            public CreateFieldIndex()
+            {
+                Map = orders => from order in orders
+                    from item in order.Lines
+                    select new
+                    {
+                        ProductName = item.ProductName,
+                        Total = item.Discount
+                    };
+
+                Reduce = results => from result in results
+                    group result by result.ProductName into g
+                    select new
+                    {
+                        ProductName = g.Key,
+                        Total = CreateField("Total", 23.2)
+                    };
+            }
+        }
+    }
+}


### PR DESCRIPTION
### Issue link

https://issues.hibernatingrhinos.com/issue/RavenDB-17123

### Additional description

Remove "__ignored" value on index result when using `CreateField` or `CreateSpatialField` over Reduce.

### Type of change

- Bug fix/Optimization

### How risky is the change?

- Low 

### Backward compatibility

- Non breaking change

### Is it platform specific issue?

- No

### Documentation update

- No documentation update is needed 

### Testing 

- Tests have been added that prove the fix is effective or that the feature works

### Is there any existing behavior change of other features due to this change?

- No

### UI work

- No UI work is needed
