### PR TITLE
RavenDB-16656 and RavenDB-16726

### DIFF
--- a/src/Raven.Client/Documents/Indexes/IndexingPerformanceOperation.cs
+++ b/src/Raven.Client/Documents/Indexes/IndexingPerformanceOperation.cs
@@ -28,5 +28,7 @@ namespace Raven.Client.Documents.Indexes
         public StorageCommitDetails CommitDetails { get; set; } 
 
         public IndexingPerformanceOperation[] Operations { get; set; }
+
+        public ReferenceRunDetails ReferenceDetails { get; set; }
     }
 }

--- a/src/Raven.Client/Documents/Indexes/ReduceRunDetails.cs
+++ b/src/Raven.Client/Documents/Indexes/ReduceRunDetails.cs
@@ -38,4 +38,22 @@
 
         public long AllocationBudget { get; set; }
     }
+
+    public class ReferenceRunDetails
+    {
+        public int ReferenceAttempts { get; set; }
+
+        public int ReferenceSuccesses { get; set; }
+
+        public int ReferenceErrors { get; set; }
+
+        public long ProcessPrivateMemory { get; set; }
+
+        public long ProcessWorkingSet { get; set; }
+
+        public long CurrentlyAllocated { get; set; }
+
+        public long AllocationBudget { get; set; }
+
+    }
 }

--- a/src/Raven.Server/Config/Categories/PerformanceHintsConfiguration.cs
+++ b/src/Raven.Server/Config/Categories/PerformanceHintsConfiguration.cs
@@ -53,5 +53,10 @@ namespace Raven.Server.Config.Categories
         [SizeUnit(SizeUnit.Megabytes)]
         [ConfigurationEntry("PerformanceHints.Memory.MinSwapSizeInMb", ConfigurationEntryScope.ServerWideOnly)]
         public Size MinSwapSize { get; set; }
+
+        [Description("The maximum number of LoadDocument()/LoadCompareExchangeValue() calls per a reference document/compare exchange value after which we will create a performance hint")]
+        [DefaultValue(1024)]
+        [ConfigurationEntry("PerformanceHints.Indexing.MaxNumberOfLoadsPerReference", ConfigurationEntryScope.ServerWideOrPerDatabase)]
+        public int MaxNumberOfLoadsPerReference { get; set; }
     }
 }

--- a/src/Raven.Server/Documents/Indexes/IndexingRunStats.cs
+++ b/src/Raven.Server/Documents/Indexes/IndexingRunStats.cs
@@ -31,6 +31,8 @@ namespace Raven.Server.Documents.Indexes
 
         public MapRunDetails MapDetails;
 
+        public ReferenceRunDetails ReferenceDetails;
+
         public StorageCommitDetails CommitDetails;
 
         public List<IndexingError> Errors;

--- a/src/Raven.Server/Documents/Indexes/IndexingStatsAggregator.cs
+++ b/src/Raven.Server/Documents/Indexes/IndexingStatsAggregator.cs
@@ -188,6 +188,10 @@ namespace Raven.Server.Documents.Indexes
         public void RecordMapReferenceAttempt()
         {
             _stats.MapReferenceAttempts++;
+
+            _stats.ReferenceDetails ??= new ReferenceRunDetails();
+
+            _stats.ReferenceDetails.ReferenceAttempts++;
         }
 
         public void RecordMapSuccess()
@@ -198,6 +202,10 @@ namespace Raven.Server.Documents.Indexes
         public void RecordMapReferenceSuccess()
         {
             _stats.MapReferenceSuccesses++;
+
+            _stats.ReferenceDetails ??= new ReferenceRunDetails();
+
+            _stats.ReferenceDetails.ReferenceSuccesses++;
         }
 
         public void RecordMapError()
@@ -208,6 +216,10 @@ namespace Raven.Server.Documents.Indexes
         public void RecordMapReferenceError()
         {
             _stats.MapReferenceErrors++;
+
+            _stats.ReferenceDetails ??= new ReferenceRunDetails();
+
+            _stats.ReferenceDetails.ReferenceErrors++;
         }
 
         public void RecordIndexingOutput()
@@ -290,6 +302,9 @@ namespace Raven.Server.Documents.Indexes
                     TreesReduceDetails = _stats.ReduceDetails.TreesReduceDetails
                 };
             }
+
+            if (_stats.ReferenceDetails != null && name == "References")
+                operation.ReferenceDetails = _stats.ReferenceDetails;
 
             if (_stats.MapDetails != null && name == "Map")
                 operation.MapDetails = _stats.MapDetails;
@@ -382,6 +397,22 @@ namespace Raven.Server.Documents.Indexes
             _stats.LuceneMergeDetails.MergedFilesCount += mergeStats.NumberOfFiles;
             _stats.LuceneMergeDetails.MergedDocumentsCount += mergeStats.TotalDocuments;
             _stats.LuceneMergeDetails.ExecutedMergesCount++;
+        }
+
+        public void RecordReferenceAllocations(long allocated)
+        {
+            _stats.ReferenceDetails ??= new ReferenceRunDetails();
+
+            _stats.ReferenceDetails.CurrentlyAllocated = allocated;
+        }
+
+        public void RecordReferenceMemoryStats(long currentProcessWorkingSet, long currentProcessPrivateMemorySize, long currentBudget)
+        {
+            _stats.ReferenceDetails ??= new ReferenceRunDetails();
+
+            _stats.ReferenceDetails.AllocationBudget = currentBudget;
+            _stats.ReferenceDetails.ProcessPrivateMemory = currentProcessPrivateMemorySize;
+            _stats.ReferenceDetails.ProcessWorkingSet = currentProcessWorkingSet;
         }
     }
 }

--- a/src/Raven.Server/Documents/Indexes/MapReduce/ReduceMapResultsBase.cs
+++ b/src/Raven.Server/Documents/Indexes/MapReduce/ReduceMapResultsBase.cs
@@ -206,7 +206,7 @@ namespace Raven.Server.Documents.Indexes.MapReduce
 
                 stats.RecordReduceSuccesses(numberOfEntriesToReduce);
 
-                _index.UpdateThreadAllocations(indexContext, writer, stats, updateReduceStats: true);
+                _index.UpdateThreadAllocations(indexContext, writer, stats, IndexingWorkType.Reduce);
                 
             }
             catch (Exception e) when (e.IsIndexError())
@@ -399,7 +399,7 @@ namespace Raven.Server.Documents.Indexes.MapReduce
                     parentPagesToAggregate.Add(branchesToAggregate.First());
                 }
 
-                _index.UpdateThreadAllocations(indexContext, writer, stats, updateReduceStats: true);
+                _index.UpdateThreadAllocations(indexContext, writer, stats, IndexingWorkType.Reduce);
             }
 
             if (compressedEmptyLeafs != null && compressedEmptyLeafs.Count > 0)

--- a/src/Raven.Server/Documents/Indexes/Workers/CanContinueBatchParameters.cs
+++ b/src/Raven.Server/Documents/Indexes/Workers/CanContinueBatchParameters.cs
@@ -1,0 +1,44 @@
+﻿using System;
+using System.Diagnostics;
+using Raven.Server.Documents.Indexes.Persistence.Lucene;
+using Raven.Server.ServerWide.Context;
+
+namespace Raven.Server.Documents.Indexes.Workers
+{
+    public readonly struct CanContinueBatchParameters
+    {
+        public CanContinueBatchParameters(IndexingStatsScope stats, IndexingWorkType workType, QueryOperationContext queryContext, TransactionOperationContext indexingContext,
+            Lazy<IndexWriteOperation> indexWriteOperation, long currentEtag, long maxEtag, long count,
+            Stopwatch sw)
+        {
+            Stats = stats;
+            WorkType = workType;
+            QueryContext = queryContext;
+            IndexingContext = indexingContext;
+            IndexWriteOperation = indexWriteOperation;
+            CurrentEtag = currentEtag;
+            MaxEtag = maxEtag;
+            Count = count;
+            Sw = sw;
+        }
+
+        public IndexingStatsScope Stats { get; }
+
+        public IndexingWorkType WorkType { get; }
+
+        public QueryOperationContext QueryContext { get; }
+
+        public TransactionOperationContext IndexingContext { get; }
+
+        public Lazy<IndexWriteOperation> IndexWriteOperation { get; }
+
+        public long CurrentEtag { get; }
+
+        public long MaxEtag { get; }
+
+        public long Count { get; }
+
+        public Stopwatch Sw { get; }
+
+    }
+}

--- a/src/Raven.Server/Documents/Indexes/Workers/CleanupDocuments.cs
+++ b/src/Raven.Server/Documents/Indexes/Workers/CleanupDocuments.cs
@@ -96,7 +96,7 @@ namespace Raven.Server.Documents.Indexes.Workers
 
                                 _index.HandleDelete(tombstone, collection, writeOperation, indexContext, collectionStats);
 
-                                batchContinuationResult = _index.CanContinueBatch(stats, queryContext, indexContext, writeOperation, lastEtag, lastCollectionEtag,
+                                batchContinuationResult = _index.CanContinueBatch(stats, IndexingWorkType.Cleanup, queryContext, indexContext, writeOperation, lastEtag, lastCollectionEtag,
                                     totalProcessedCount, sw, ref maxTimeForDocumentTransactionToRemainOpen);
 
                                 if (batchContinuationResult != Index.CanContinueBatchResult.True)

--- a/src/Raven.Server/Documents/Indexes/Workers/CleanupDocuments.cs
+++ b/src/Raven.Server/Documents/Indexes/Workers/CleanupDocuments.cs
@@ -96,8 +96,11 @@ namespace Raven.Server.Documents.Indexes.Workers
 
                                 _index.HandleDelete(tombstone, collection, writeOperation, indexContext, collectionStats);
 
-                                batchContinuationResult = _index.CanContinueBatch(stats, IndexingWorkType.Cleanup, queryContext, indexContext, writeOperation, lastEtag, lastCollectionEtag,
-                                    totalProcessedCount, sw, ref maxTimeForDocumentTransactionToRemainOpen);
+                                var parameters = new CanContinueBatchParameters(stats, IndexingWorkType.Cleanup, queryContext, indexContext, writeOperation, lastEtag,
+                                    lastCollectionEtag,
+                                    totalProcessedCount, sw);
+
+                                batchContinuationResult = _index.CanContinueBatch(in parameters, ref maxTimeForDocumentTransactionToRemainOpen);
 
                                 if (batchContinuationResult != Index.CanContinueBatchResult.True)
                                 {

--- a/src/Raven.Server/Documents/Indexes/Workers/HandleReferences.cs
+++ b/src/Raven.Server/Documents/Indexes/Workers/HandleReferences.cs
@@ -287,8 +287,10 @@ namespace Raven.Server.Documents.Indexes.Workers
 
                             bool CanContinueReferenceBatch()
                             {
-                                batchContinuationResult = _index.CanContinueBatch(stats, IndexingWorkType.References, queryContext, indexContext, writeOperation, 
-                                    lastEtag, lastCollectionEtag, totalProcessedCount, sw, ref maxTimeForDocumentTransactionToRemainOpen);
+                                var parameters = new CanContinueBatchParameters(stats, IndexingWorkType.References, queryContext, indexContext, writeOperation,
+                                    lastEtag, lastCollectionEtag, totalProcessedCount, sw);
+
+                                batchContinuationResult = _index.CanContinueBatch(in parameters, ref maxTimeForDocumentTransactionToRemainOpen);
                                 if (batchContinuationResult != Index.CanContinueBatchResult.True)
                                 {
                                     keepRunning = batchContinuationResult == Index.CanContinueBatchResult.RenewTransaction;

--- a/src/Raven.Server/Documents/Indexes/Workers/HandleReferences.cs
+++ b/src/Raven.Server/Documents/Indexes/Workers/HandleReferences.cs
@@ -216,6 +216,9 @@ namespace Raven.Server.Documents.Indexes.Workers
                                         }
 
                                         var items = GetItemsFromCollectionThatReference(queryContext, indexContext, collection, referencedItem, lastIndexedEtag, indexed, referenceState);
+
+                                        var numberOfReferencedItemLoad = 0;
+
                                         using (var itemsEnumerator = _index.GetMapEnumerator(items, collection, indexContext, collectionStats, _index.Type))
                                         {
                                             long lastIndexedParentEtag = 0;
@@ -236,6 +239,8 @@ namespace Raven.Server.Documents.Indexes.Workers
                                                 totalProcessedCount++;
                                                 collectionStats.RecordMapReferenceAttempt();
                                                 stats.RecordDocumentSize(current.Size);
+
+                                                numberOfReferencedItemLoad++;
 
                                                 try
                                                 {
@@ -261,6 +266,9 @@ namespace Raven.Server.Documents.Indexes.Workers
                                                 _index.UpdateThreadAllocations(indexContext, writeOperation, stats, IndexingWorkType.References);
                                             }
                                         }
+
+                                        if (numberOfReferencedItemLoad > 0) 
+                                            _index.CheckReferenceLoadsPerformanceHintLimit(referencedItem, numberOfReferencedItemLoad);
 
                                         if (earlyExit)
                                             break;

--- a/src/Raven.Server/Documents/Indexes/Workers/HandleReferences.cs
+++ b/src/Raven.Server/Documents/Indexes/Workers/HandleReferences.cs
@@ -258,7 +258,7 @@ namespace Raven.Server.Documents.Indexes.Workers
                                                         $"Failed to execute mapping function on {current.Id}. Exception: {e}");
                                                 }
 
-                                                _index.UpdateThreadAllocations(indexContext, writeOperation, stats, updateReduceStats: false);
+                                                _index.UpdateThreadAllocations(indexContext, writeOperation, stats, IndexingWorkType.References);
                                             }
                                         }
 
@@ -279,7 +279,7 @@ namespace Raven.Server.Documents.Indexes.Workers
 
                             bool CanContinueReferenceBatch()
                             {
-                                batchContinuationResult = _index.CanContinueBatch(stats, queryContext, indexContext, writeOperation, 
+                                batchContinuationResult = _index.CanContinueBatch(stats, IndexingWorkType.References, queryContext, indexContext, writeOperation, 
                                     lastEtag, lastCollectionEtag, totalProcessedCount, sw, ref maxTimeForDocumentTransactionToRemainOpen);
                                 if (batchContinuationResult != Index.CanContinueBatchResult.True)
                                 {

--- a/src/Raven.Server/Documents/Indexes/Workers/IndexingWorkType.cs
+++ b/src/Raven.Server/Documents/Indexes/Workers/IndexingWorkType.cs
@@ -1,0 +1,11 @@
+﻿namespace Raven.Server.Documents.Indexes.Workers
+{
+    public enum IndexingWorkType
+    {
+        None,
+        Cleanup,
+        References,
+        Map,
+        Reduce
+    }
+}

--- a/src/Raven.Server/Documents/Indexes/Workers/MapItems.cs
+++ b/src/Raven.Server/Documents/Indexes/Workers/MapItems.cs
@@ -122,8 +122,10 @@ namespace Raven.Server.Documents.Indexes.Workers
                                                                                 $"Exception: {e}");
                                     }
 
-                                    batchContinuationResult = _index.CanContinueBatch(collectionStats, IndexingWorkType.Map, queryContext, indexContext, writeOperation, 
-                                        lastEtag, lastCollectionEtag, totalProcessedCount, sw, ref maxTimeForDocumentTransactionToRemainOpen);
+                                    var parameters = new CanContinueBatchParameters(collectionStats, IndexingWorkType.Map, queryContext, indexContext, writeOperation,
+                                        lastEtag, lastCollectionEtag, totalProcessedCount, sw);
+
+                                    batchContinuationResult = _index.CanContinueBatch(in parameters, ref maxTimeForDocumentTransactionToRemainOpen);
                                     if (batchContinuationResult != Index.CanContinueBatchResult.True)
                                     {
                                         keepRunning = batchContinuationResult == Index.CanContinueBatchResult.RenewTransaction;

--- a/src/Raven.Server/Documents/Indexes/Workers/MapItems.cs
+++ b/src/Raven.Server/Documents/Indexes/Workers/MapItems.cs
@@ -122,7 +122,7 @@ namespace Raven.Server.Documents.Indexes.Workers
                                                                                 $"Exception: {e}");
                                     }
 
-                                    batchContinuationResult = _index.CanContinueBatch(collectionStats, queryContext, indexContext, writeOperation, 
+                                    batchContinuationResult = _index.CanContinueBatch(collectionStats, IndexingWorkType.Map, queryContext, indexContext, writeOperation, 
                                         lastEtag, lastCollectionEtag, totalProcessedCount, sw, ref maxTimeForDocumentTransactionToRemainOpen);
                                     if (batchContinuationResult != Index.CanContinueBatchResult.True)
                                     {

--- a/src/Raven.Server/NotificationCenter/Notifications/Details/IndexingReferenceLoadWarning.cs
+++ b/src/Raven.Server/NotificationCenter/Notifications/Details/IndexingReferenceLoadWarning.cs
@@ -1,0 +1,175 @@
+﻿using System;
+using System.Collections.Generic;
+using System.Diagnostics;
+using Raven.Server.Documents.Indexes.Workers;
+using Sparrow.Json.Parsing;
+
+namespace Raven.Server.NotificationCenter.Notifications.Details
+{
+    public class IndexingReferenceLoadWarning : INotificationDetails
+    {
+        internal const int MaxNumberOfDetailsPerIndex = 10;
+
+        public Dictionary<string, WarningDetails> Warnings { get; }
+
+
+        public IndexingReferenceLoadWarning()
+        {
+            Warnings = new Dictionary<string, WarningDetails>(StringComparer.OrdinalIgnoreCase);
+        }
+
+        public void Update(string indexName, WarningDetails warning)
+        {
+            if (Warnings.TryGetValue(indexName, out var warningDetails) == false)
+                Warnings[indexName] = warningDetails = new WarningDetails();
+
+            foreach (var (_, reference) in warning.Top10LoadedReferences)
+            {
+                warningDetails.Add(reference);
+            }
+
+            warningDetails.LastWarningTime = warning.LastWarningTime;
+        }
+
+        public DynamicJsonValue ToJson()
+        {
+            var djv = new DynamicJsonValue();
+
+            foreach (var key in Warnings.Keys)
+            {
+                var details = Warnings[key];
+                if (details == null)
+                    continue;
+
+                var list = new DynamicJsonValue();
+
+                foreach (var reference in details.Top10LoadedReferences)
+                {
+                    list[reference.Key] = new DynamicJsonValue
+                    {
+                        [nameof(LoadedReference.ReferenceId)] = reference.Value.ReferenceId,
+                        [nameof(LoadedReference.NumberOfLoads)] = reference.Value.NumberOfLoads
+                    };
+                }
+
+                djv[key] = new DynamicJsonValue
+                {
+                    [nameof(WarningDetails.Top10LoadedReferences)] = list,
+                    [nameof(WarningDetails.LastWarningTime)] = details.LastWarningTime
+                };
+            }
+
+            return new DynamicJsonValue(GetType())
+            {
+                [nameof(Warnings)] = djv
+            };
+        }
+
+        public class WarningDetails
+        {
+            private readonly SortedList<int, LoadedReference> _sortedTop10 = new(AllowDuplicatedNumberOfLoadsComparer.Instance);
+
+            public Dictionary<string, LoadedReference> Top10LoadedReferences { get; set; } = new();
+
+            public DateTime LastWarningTime { get; set; }
+
+            public bool Add(HandleReferencesBase.Reference reference, int numberOfLoads)
+            {
+                EnsureCollectionsSync();
+
+                if (ShouldAdd(numberOfLoads) == false)
+                    return false;
+
+                var referenceToAdd = new LoadedReference
+                {
+                    ReferenceId = reference.Key.ToString(),
+                    NumberOfLoads = numberOfLoads
+                };
+
+                return Add(referenceToAdd);
+            }
+
+            public bool Add(LoadedReference reference)
+            {
+                EnsureCollectionsSync();
+
+                if (ShouldAdd(reference.NumberOfLoads) == false)
+                    return false;
+
+                if (Top10LoadedReferences.TryGetValue(reference.ReferenceId, out LoadedReference existingReference))
+                {
+                    var indexOfValue = _sortedTop10.IndexOfValue(existingReference);
+                    _sortedTop10.RemoveAt(indexOfValue);
+
+                    existingReference.NumberOfLoads = reference.NumberOfLoads;
+
+                    _sortedTop10.Add(existingReference.NumberOfLoads, existingReference);
+                }
+                else
+                {
+                    if (Top10LoadedReferences.TryAdd(reference.ReferenceId, reference))
+                    {
+                        _sortedTop10.Add(reference.NumberOfLoads, reference);
+                    }
+                }
+
+                while (_sortedTop10.Count > MaxNumberOfDetailsPerIndex)
+                {
+                    LoadedReference lowest = _sortedTop10.Values[0];
+
+                    Top10LoadedReferences.Remove(lowest.ReferenceId);
+
+                    _sortedTop10.RemoveAt(0);
+                }
+
+                Debug.Assert(_sortedTop10.Count == Top10LoadedReferences.Count, "_sortedTop10.Count == Top10LoadedReferences.Count");
+
+                return true;
+            }
+
+            private void EnsureCollectionsSync()
+            {
+                if (_sortedTop10.Count == Top10LoadedReferences.Count) 
+                    return;
+
+                _sortedTop10.Clear();
+
+                foreach ((_, LoadedReference reference) in Top10LoadedReferences)
+                {
+                    _sortedTop10[reference.NumberOfLoads] = reference;
+                }
+            }
+
+            private bool ShouldAdd(int numberOfLoads)
+            {
+                if (_sortedTop10.Count < MaxNumberOfDetailsPerIndex)
+                    return true;
+
+                if (numberOfLoads <= _sortedTop10.Keys[0])
+                    return false;
+
+                return true;
+            }
+        }
+
+        public class LoadedReference
+        {
+            public string ReferenceId { get; set; }
+
+            public int NumberOfLoads { get; set; }
+        }
+
+        private class AllowDuplicatedNumberOfLoadsComparer : IComparer<int>
+        {
+            public static AllowDuplicatedNumberOfLoadsComparer Instance = new AllowDuplicatedNumberOfLoadsComparer();
+
+            public int Compare(int x, int y)
+            {
+                if (x == y)
+                    return 1; // to allow duplicates
+
+                return x - y;
+            }
+        }
+    }
+}

--- a/src/Raven.Server/NotificationCenter/Notifications/PerformanceHintType.cs
+++ b/src/Raven.Server/NotificationCenter/Notifications/PerformanceHintType.cs
@@ -10,6 +10,7 @@
         UnusedCapacity,
         SlowIO,
         SqlEtl_SlowSql,
-        HugeDocuments
+        HugeDocuments,
+        Indexing_References
     }
 }

--- a/src/Raven.Studio/typescript/common/notifications/notificationCenter.ts
+++ b/src/Raven.Studio/typescript/common/notifications/notificationCenter.ts
@@ -35,6 +35,7 @@ import generateClientCertificateDetails = require("viewmodels/common/notificatio
 import compactDatabaseDetails = require("viewmodels/common/notificationCenter/detailViewer/operations/compactDatabaseDetails");
 import indexingDetails = require("viewmodels/common/notificationCenter/detailViewer/performanceHint/indexingDetails");
 import slowSqlDetails = require("viewmodels/common/notificationCenter/detailViewer/performanceHint/slowSqlDetails");
+import indexingReferencesDetails = require("viewmodels/common/notificationCenter/detailViewer/performanceHint/indexingReferencesDetails");
 import slowWriteDetails = require("viewmodels/common/notificationCenter/detailViewer/performanceHint/slowWriteDetails");
 import pagingDetails = require("viewmodels/common/notificationCenter/detailViewer/performanceHint/pagingDetails");
 import hugeDocumentsDetails = require("viewmodels/common/notificationCenter/detailViewer/performanceHint/hugeDocumentsDetails");
@@ -147,6 +148,7 @@ class notificationCenter {
             // performance hints:
             indexingDetails,
             slowSqlDetails,
+            indexingReferencesDetails,
             slowWriteDetails,
             pagingDetails,
             requestLatencyDetails,

--- a/src/Raven.Studio/typescript/viewmodels/common/notificationCenter/detailViewer/performanceHint/indexingReferencesDetails.ts
+++ b/src/Raven.Studio/typescript/viewmodels/common/notificationCenter/detailViewer/performanceHint/indexingReferencesDetails.ts
@@ -1,0 +1,119 @@
+import app = require("durandal/app");
+import abstractNotification = require("common/notifications/models/abstractNotification");
+import notificationCenter = require("common/notifications/notificationCenter");
+import virtualGridController = require("widgets/virtualGrid/virtualGridController");
+import textColumn = require("widgets/virtualGrid/columns/textColumn");
+import columnPreviewPlugin = require("widgets/virtualGrid/columnPreviewPlugin");
+import generalUtils = require("common/generalUtils");
+import actionColumn = require("widgets/virtualGrid/columns/actionColumn");
+import performanceHint = require("common/notifications/models/performanceHint");
+import abstractPerformanceHintDetails = require("viewmodels/common/notificationCenter/detailViewer/performanceHint/abstractPerformanceHintDetails");
+
+interface indexReferencesDetailsItem {
+    referenceId: string;
+    numberOfLoads: number;
+}
+
+interface indexingReferencesItem {
+    indexName: string;
+    lastWarningTime: string;
+    details: indexReferencesDetailsItem[];
+}
+
+class indexingReferencesDetails extends abstractPerformanceHintDetails {
+
+    currentDetails = ko.observable<indexingReferencesItem>();
+    
+    tableItems: indexingReferencesItem[] = [];
+    private gridController = ko.observable<virtualGridController<indexingReferencesItem>>();
+    private columnPreview = new columnPreviewPlugin<indexingReferencesItem>();
+
+    constructor(hint: performanceHint, notificationCenter: notificationCenter) {
+        super(hint, notificationCenter);
+
+        const warnings = (this.hint.details() as Raven.Server.NotificationCenter.Notifications.Details.IndexingReferenceLoadWarning).Warnings;
+        this.tableItems = this.mapDto(warnings);
+
+        // newest first
+        this.tableItems.reverse();
+    }
+    
+    private mapDto(details: Record<string, Raven.Server.NotificationCenter.Notifications.Details.IndexingReferenceLoadWarning.WarningDetails>): indexingReferencesItem[] {
+        return Object.keys(details)
+            .map(key => ({
+                indexName: key,
+                lastWarningTime: details[key].LastWarningTime,
+                details: this.mapDetails(details[key].Top10LoadedReferences)
+            }));
+    }
+    
+    private mapDetails(details: Record<string, Raven.Server.NotificationCenter.Notifications.Details.IndexingReferenceLoadWarning.LoadedReference>): indexReferencesDetailsItem[] {
+        return Object.keys(details)
+            .map(key => ({
+                documentId: key,
+                referenceId: details[key].ReferenceId,
+                numberOfLoads: details[key].NumberOfLoads
+            }));
+    }
+
+    compositionComplete() {
+        super.compositionComplete();
+
+        const grid = this.gridController();
+        grid.headerVisible(true);
+
+        grid.init((s, t) => this.fetcher(s, t), () => {
+            return [
+                    new textColumn<indexingReferencesItem>(grid, x => x.indexName, "Index Name", "40%", {
+                        sortable: "number"
+                    }),
+                    new textColumn<indexingReferencesItem>(grid, x => generalUtils.formatUtcDateAsLocal(x.lastWarningTime), "Last Warning Date", "30%", {
+                        sortable: x => x.lastWarningTime
+                    }),
+                    new actionColumn<indexingReferencesItem>(
+                        grid, item => this.showDetails(item), "Reference IDs", `Show top 10 loaded references`, "30%",
+                        {
+                            title: () => 'Show details'
+                        })
+                ];
+        });
+        
+        this.columnPreview.install(".indexingReferencesDetails", ".js-indexing-references-details-tooltip",
+            (details: indexingReferencesItem,
+             column: textColumn<indexingReferencesItem>,
+             e: JQueryEventObject, onValue: (context: any, valueToCopy?: string) => void) => {
+                if (!(column instanceof actionColumn)) {
+                    if (column.header === "Date") {
+                        onValue(moment.utc(details.lastWarningTime), details.lastWarningTime);
+                    } else {
+                        const value = column.getCellValue(details);
+                        if (value) {
+                            onValue(generalUtils.escapeHtml(value), value);
+                        }
+                    }
+                }
+            });
+    }
+    
+    private showDetails(item: indexingReferencesItem) {
+        this.currentDetails(item);
+    }
+    
+    private fetcher(skip: number, take: number): JQueryPromise<pagedResult<indexingReferencesItem>> {
+        return $.Deferred<pagedResult<indexingReferencesItem>>()
+            .resolve({
+                items: this.tableItems,
+                totalResultCount: this.tableItems.length
+            });
+    }
+
+    static supportsDetailsFor(notification: abstractNotification) {
+        return (notification instanceof performanceHint) && notification.hintType() === "Indexing_References";
+    }
+
+    static showDetailsFor(hint: performanceHint, center: notificationCenter) {
+        return app.showBootstrapDialog(new indexingReferencesDetails(hint, center));
+    }
+}
+
+export = indexingReferencesDetails;

--- a/src/Raven.Studio/typescript/viewmodels/database/indexes/indexPerformance.ts
+++ b/src/Raven.Studio/typescript/viewmodels/database/indexes/indexPerformance.ts
@@ -1266,6 +1266,19 @@ class indexPerformance extends viewModelBase {
                 tooltipHtml += mapDetails;
             }
 
+            if (element.ReferenceDetails) {
+                let referenceDetails: string;
+                referenceDetails = `<div class="tooltip-header">Reference details</div>`;
+                referenceDetails += `<div class="tooltip-li">Reference attempts: <div class="value">${element.ReferenceDetails.ReferenceAttempts.toLocaleString()} </div></div>`;
+                referenceDetails += `<div class="tooltip-li">Reference successes: <div class="value">${element.ReferenceDetails.ReferenceSuccesses.toLocaleString()} </div></div>`;
+                referenceDetails += `<div class="tooltip-li">Reference errors: <div class="value">${element.ReferenceDetails.ReferenceErrors.toLocaleString()} </div></div>`;
+                referenceDetails += `<div class="tooltip-li">Allocation budget: <div class="value">${generalUtils.formatBytesToSize(element.ReferenceDetails.AllocationBudget)}</div></div>`;
+                referenceDetails += `<div class="tooltip-li">Currently allocated: <div class="value">${generalUtils.formatBytesToSize(element.ReferenceDetails.CurrentlyAllocated)} </div></div>`;
+                referenceDetails += `<div class="tooltip-li">Process private memory: <div class="value">${generalUtils.formatBytesToSize(element.ReferenceDetails.ProcessPrivateMemory)}</div></div>`;
+                referenceDetails += `<div class="tooltip-li">Process working set: <div class="value">${generalUtils.formatBytesToSize(element.ReferenceDetails.ProcessWorkingSet)}</div></div>`;
+                tooltipHtml += referenceDetails;
+            }
+
             if (element.ReduceDetails) {
                 let reduceDetails: string;
 

--- a/src/Raven.Studio/wwwroot/App/views/common/notificationCenter/detailViewer/performanceHint/indexingReferencesDetails.html
+++ b/src/Raven.Studio/wwwroot/App/views/common/notificationCenter/detailViewer/performanceHint/indexingReferencesDetails.html
@@ -1,0 +1,64 @@
+<div class="modal-dialog modal-lg indexingReferencesDetails" id="js-indexing-references-details" role="document">
+    <div class="modal-content force-text-wrap-word" tabindex="-1">
+        <div class="modal-header">
+            <button type="button" class="close" data-bind="click: close" aria-hidden="true">
+                <i class="icon-cancel"></i>
+            </button>
+            <div data-bind="with: hint">
+                <h3 class="modal-title" id="myModalLabel" data-bind="text: title, attr:{ class: 'modal-title ' + headerClass() }"></h3>
+                <div class="notification-time" data-bind="text: displayDate().format('LLL')"></div>
+            </div>
+        </div>
+        <div class="modal-body">
+            <h3 data-bind="html: hint.message"></h3>
+            <div class="margin-bottom" style="position: relative; height: 300px">
+                <virtual-grid style="height: 300px" class="resizable flex-window" params="controller: gridController"></virtual-grid>
+            </div>
+            <div data-bind="with: currentDetails">
+                <div class="flex-horizontal">
+                    <h3>Details:</h3>
+                </div>
+                <div class="modal-details">
+                    <div class="details-item">
+                        <div class="row">
+                            <div class="col-sm-3 text-right">
+                                Index Name
+                            </div>
+                            <div class="col-sm-9 details-value">
+                                <span data-bind="text: indexName"></span>
+                            </div>
+                        </div>
+                    </div>
+                    <div class="details-item">
+                        <div class="row">
+                            <div class="col-sm-3 text-right">
+                                Last warning time
+                            </div>
+                            <div class="col-sm-9 details-value">
+                                <span data-bind="text: lastWarningTime"></span>
+                            </div>
+                        </div>
+                    </div>
+                    <table class="table table-striped">
+                        <thead>
+                            <tr>
+                                <th>Reference ID</th>
+                                <th>Number of loads</th>
+                            </tr>
+                        </thead>
+                        <tbody data-bind="foreach: details">
+                            <tr>
+                                <td data-bind="text: referenceId"></td>
+                                <td data-bind="text: numberOfLoads.toLocaleString()"></td>
+                            </tr>
+                        </tbody>
+                    </table>
+                </div>
+            </div>
+        </div>
+        <div class="modal-footer" data-bind="compose: 'common/notificationCenter/detailViewer/performanceHint/footerPartial.html'">
+        </div>
+    </div>
+</div>
+<div class="tooltip json-preview js-indexing-references-details-tooltip" style="opacity: 0">
+</div>

--- a/test/FastTests/Issues/RavenDB-6250.cs
+++ b/test/FastTests/Issues/RavenDB-6250.cs
@@ -80,7 +80,8 @@ namespace FastTests.Issues
                PerformanceHintType.RequestLatency,
                PerformanceHintType.UnusedCapacity,
                PerformanceHintType.SqlEtl_SlowSql,
-               PerformanceHintType.HugeDocuments
+               PerformanceHintType.HugeDocuments,
+               PerformanceHintType.Indexing_References
             };
 
             var operationWithoutDetails = new HashSet<PerformanceHintType>

--- a/test/SlowTests/Issues/RavenDB_16656.cs
+++ b/test/SlowTests/Issues/RavenDB_16656.cs
@@ -1,0 +1,75 @@
+﻿using System.Collections.Generic;
+using System.Linq;
+using FastTests;
+using Orders;
+using Raven.Client.Documents.Indexes;
+using Xunit;
+using Xunit.Abstractions;
+
+namespace SlowTests.Issues
+{
+    public class RavenDB_16656 : RavenTestBase
+    {
+        public RavenDB_16656(ITestOutputHelper output) : base(output)
+        {
+        }
+
+        [Fact]
+        public void ShouldIncludeReferenceIndexingDetails()
+        {
+            using (var store = GetDocumentStore())
+            {
+                var index = new Products_ByCategory();
+                index.Execute(store);
+
+                using (var session = store.OpenSession())
+                {
+                    session.Store(new Category { Id = "categories/0", Name = "foo"});
+                    session.Store(new Category { Id = "categories/1", Name = "bar"});
+
+                    for (int i = 0; i < 200; i++)
+                    {
+                        session.Store(new Product { Category = $"categories/{i % 2}"});
+                    }
+
+                    session.SaveChanges();
+                }
+
+                WaitForIndexing(store);
+
+                using (var session = store.OpenSession())
+                {
+                    session.Store(new Category { Id = "categories/1", Name = "baz" });
+
+                    session.SaveChanges();
+                }
+
+                WaitForIndexing(store);
+
+                var indexInstance = GetDatabase(store.Database).Result.IndexStore.GetIndex(index.IndexName);
+
+                var stats = indexInstance.GetIndexingPerformance();
+
+                 var referenceRunDetails = stats.SelectMany(x => x.Details.Operations.Select(y => y.ReferenceDetails)).Where(x => x != null && x.ReferenceAttempts > 0).ToList();
+
+                 Assert.Equal(1, referenceRunDetails.Count);
+                 Assert.Equal(100, referenceRunDetails[0].ReferenceAttempts);
+                 Assert.Equal(100, referenceRunDetails[0].ReferenceSuccesses);
+                 Assert.Equal(0, referenceRunDetails[0].ReferenceErrors);
+            }
+        }
+
+        private class Products_ByCategory : AbstractIndexCreationTask<Product>
+        {
+            public Products_ByCategory()
+            {
+                Map = products => from product in products
+                    let category = LoadDocument<Category>(product.Category)
+                    select new
+                    {
+                        CategoryId = category.Name
+                    };
+            }
+        }
+    }
+}

--- a/test/SlowTests/Issues/RavenDB_16726.cs
+++ b/test/SlowTests/Issues/RavenDB_16726.cs
@@ -1,0 +1,185 @@
+﻿using System;
+using System.Linq;
+using System.Threading.Tasks;
+using FastTests;
+using Orders;
+using Raven.Client.Documents.Conventions;
+using Raven.Client.Documents.Indexes;
+using Raven.Server.NotificationCenter.Notifications;
+using Raven.Server.NotificationCenter.Notifications.Details;
+using Sparrow.Json;
+using Sparrow.Json.Parsing;
+using Sparrow.Server.Collections;
+using Xunit;
+using Xunit.Abstractions;
+
+namespace SlowTests.Issues
+{
+    public class RavenDB_16726 : RavenTestBase
+    {
+        public RavenDB_16726(ITestOutputHelper output) : base(output)
+        {
+        }
+
+        [Fact]
+        public async Task Should_create_performance_hint_notification_when_exceeding_max_number_of_LoadDocument_calls_per_reference()
+        {
+            using (var store = GetDocumentStore())
+            {
+                var db = await GetDatabase(store.Database);
+                db.Configuration.PerformanceHints.MaxNumberOfLoadsPerReference = 10;
+
+                db.NotificationCenter.Indexing.MinUpdateInterval = TimeSpan.MinValue;
+
+                var index = new Products_ByCategory();
+
+                using (var session = store.OpenSession())
+                {
+                    session.Store(new Category { Id = "categories/0", Name = "foo"});
+                    session.Store(new Category { Id = "categories/1", Name = "bar"});
+
+                    for (int i = 0; i < 200; i++)
+                    {
+                        session.Store(new Product { Category = $"categories/{i % 2}"});
+                    }
+
+                    session.SaveChanges();
+                }
+
+                await index.ExecuteAsync(store);
+
+                WaitForIndexing(store);
+
+                var notificationsQueue = new AsyncQueue<DynamicJsonValue>();
+
+                using (db.NotificationCenter.TrackActions(notificationsQueue, null))
+                {
+                    using (var session = store.OpenSession())
+                    {
+                        session.Store(new Category { Id = "categories/0", Name = "abc" });
+                        
+                        session.SaveChanges();
+                    }
+
+                    WaitForIndexing(store);
+
+                    Tuple<bool, DynamicJsonValue> performanceHint;
+
+                    do
+                    {
+                        performanceHint = await notificationsQueue.TryDequeueAsync(TimeSpan.FromSeconds(5));
+                    } while (performanceHint.Item2["Type"].ToString() != NotificationType.PerformanceHint.ToString());
+
+                    Assert.NotNull(performanceHint.Item2);
+
+                    Assert.Equal("We have detected high number of LoadDocument() / LoadCompareExchangeValue() calls per single reference item. The update of a reference will result in reindexing all documents that reference it. Please see Indexing Performance graph to check the performance of your indexes.",
+                        performanceHint.Item2[nameof(PerformanceHint.Message)]);
+
+                    Assert.Equal(PerformanceHintType.Indexing_References, performanceHint.Item2[nameof(PerformanceHint.HintType)]);
+
+                    var details = performanceHint.Item2[nameof(PerformanceHint.Details)] as DynamicJsonValue;
+
+                    Assert.NotNull(details);
+
+                    using (var ctx = JsonOperationContext.ShortTermSingleUse())
+                    {
+                        var json = ctx.ReadObject(details, "foo");
+
+                        var detailsObject = DocumentConventions.DefaultForServer.Serialization.DefaultConverter.FromBlittable<IndexingReferenceLoadWarning>(json, "bar");
+
+                        Assert.Contains("Products/ByCategory", detailsObject.Warnings.Keys);
+                        Assert.Equal(1, detailsObject.Warnings.Count);
+
+                        var top10LoadedReferences = detailsObject.Warnings["Products/ByCategory"].Top10LoadedReferences;
+
+                        Assert.Equal(1, top10LoadedReferences.Count);
+                        Assert.Equal("categories/0", top10LoadedReferences["categories/0"].ReferenceId);
+                        Assert.Equal(100, top10LoadedReferences["categories/0"].NumberOfLoads);
+                    }
+
+                    // update of the hint
+
+                    using (var session = store.OpenSession())
+                    {
+                        session.Store(new Category { Id = "categories/1", Name = "def" });
+
+                        session.SaveChanges();
+                    }
+
+                    WaitForIndexing(store);
+
+                    db.NotificationCenter.Indexing.UpdateIndexing(null);
+
+                    do
+                    {
+                        performanceHint = await notificationsQueue.TryDequeueAsync(TimeSpan.FromSeconds(5));
+                    } while (performanceHint.Item2["Type"].ToString() != NotificationType.PerformanceHint.ToString());
+
+                    details = performanceHint.Item2[nameof(PerformanceHint.Details)] as DynamicJsonValue;
+
+                    Assert.NotNull(details);
+
+                    using (var ctx = JsonOperationContext.ShortTermSingleUse())
+                    {
+                        var json = ctx.ReadObject(details, "foo");
+
+                        var detailsObject = DocumentConventions.DefaultForServer.Serialization.DefaultConverter.FromBlittable<IndexingReferenceLoadWarning>(json, "bar");
+
+
+                        Assert.Contains("Products/ByCategory", detailsObject.Warnings.Keys);
+                        Assert.Equal(1, detailsObject.Warnings.Count);
+
+                        var top10LoadedReferences = detailsObject.Warnings["Products/ByCategory"].Top10LoadedReferences;
+
+                        Assert.Equal(2, top10LoadedReferences.Count);
+
+                        Assert.Equal("categories/0", top10LoadedReferences["categories/0"].ReferenceId);
+                        Assert.Equal(100, top10LoadedReferences["categories/0"].NumberOfLoads);
+
+
+                        Assert.Equal("categories/1", top10LoadedReferences["categories/1"].ReferenceId);
+                        Assert.Equal(100, top10LoadedReferences["categories/1"].NumberOfLoads);
+                    }
+                }
+            }
+        }
+
+        [Fact]
+        public void Can_add_and_update_reference_load_warning_details()
+        {
+            var warningDetails = new IndexingReferenceLoadWarning.WarningDetails();
+
+            for (int i = 0; i < IndexingReferenceLoadWarning.MaxNumberOfDetailsPerIndex + 4; i++)
+            {
+                var added = warningDetails.Add(new IndexingReferenceLoadWarning.LoadedReference { NumberOfLoads = i + 1, ReferenceId = $"categories/{i}" });
+
+                Assert.True(added);
+            }
+
+            Assert.Equal(IndexingReferenceLoadWarning.MaxNumberOfDetailsPerIndex, warningDetails.Top10LoadedReferences.Count);
+
+            // update item by greater NumberOfLoads
+            Assert.True(warningDetails.Add(new IndexingReferenceLoadWarning.LoadedReference { NumberOfLoads = 1000, ReferenceId = "categories/5" }));
+            Assert.Equal(IndexingReferenceLoadWarning.MaxNumberOfDetailsPerIndex, warningDetails.Top10LoadedReferences.Count);
+            Assert.Equal(1000, warningDetails.Top10LoadedReferences["categories/5"].NumberOfLoads);
+
+            // update item by lower NumberOfLoads
+            Assert.True(warningDetails.Add(new IndexingReferenceLoadWarning.LoadedReference { NumberOfLoads = 100, ReferenceId = "categories/5" }));
+            Assert.Equal(IndexingReferenceLoadWarning.MaxNumberOfDetailsPerIndex, warningDetails.Top10LoadedReferences.Count);
+            Assert.Equal(100, warningDetails.Top10LoadedReferences["categories/5"].NumberOfLoads);
+        }
+
+        private class Products_ByCategory : AbstractIndexCreationTask<Product>
+        {
+            public Products_ByCategory()
+            {
+                Map = products => from product in products
+                    let category = LoadDocument<Category>(product.Category)
+                    select new
+                    {
+                        CategoryId = category.Name
+                    };
+            }
+        }
+    }
+}

--- a/tools/TypingsGenerator/Program.cs
+++ b/tools/TypingsGenerator/Program.cs
@@ -218,6 +218,7 @@ namespace TypingsGenerator
             scripter.AddType(typeof(HugeDocumentInfo));
             scripter.AddType(typeof(RequestLatencyDetail));
             scripter.AddType(typeof(WarnIndexOutputsPerDocument));
+            scripter.AddType(typeof(IndexingReferenceLoadWarning));
 
             // subscriptions
             scripter.AddType(typeof(SubscriptionConnectionStats));


### PR DESCRIPTION
### Issue link

https://issues.hibernatingrhinos.com/issue/RavenDB-16656
https://issues.hibernatingrhinos.com/issue/RavenDB-16726

### Additional description

This PR contains 2 improvements:

1. RavenDB-16656: It exposes the details of References phase during indexing. In particular the number of processed references:
![image](https://user-images.githubusercontent.com/376551/131488510-46f83862-8633-41ed-b981-391c971bd6b4.png)


2. RavenDB-16726: It adds a performance hint which warns users about referencing a single document from multiple ones during indexing. If the reference documents are frequently updated then it might trigger heavy indexing work.

![image](https://user-images.githubusercontent.com/376551/131489504-ce04622f-cb6e-4e89-95ee-346e9cde9acb.png)

### Type of change

- Usability

### How risky is the change?

- Low 

### Backward compatibility

- Not relevant

### Is it platform specific issue?

- No

### Documentation update

- This change requires a documentation update. YouTrack issue has been tagged by `Documentation Required`. 

### Testing 

- Tests have been added that prove the fix is effective or that the feature works

### Is there any existing behavior change of other features due to this change?

- No

### UI work

- RavenDB-16656: Handled
- RavenDB-16726: The alert is shown in the Studio but it requires to show alert details
