### PR TITLE
RavenDB-16762

### DIFF
--- a/src/Raven.Server/Documents/Indexes/Persistence/Lucene/LuceneIndexPersistence.cs
+++ b/src/Raven.Server/Documents/Indexes/Persistence/Lucene/LuceneIndexPersistence.cs
@@ -79,7 +79,6 @@ namespace Raven.Server.Documents.Indexes.Persistence.Lucene
             _disposeOnce = new DisposeOnce<SingleAttempt>(() =>
             {
                 DisposeWriters();
-                TempFileCache.Dispose();
 
                 _lastReader?.Dispose();
                 _indexSearcherHolder?.Dispose();
@@ -90,6 +89,8 @@ namespace Raven.Server.Documents.Indexes.Persistence.Lucene
                 {
                     directory.Value?.Dispose();
                 }
+
+                TempFileCache?.Dispose();
             });
 
             var fields = index.Definition.IndexFields.Values;

--- a/src/Raven.Server/Documents/Indexes/Persistence/Lucene/LuceneIndexPersistence.cs
+++ b/src/Raven.Server/Documents/Indexes/Persistence/Lucene/LuceneIndexPersistence.cs
@@ -180,7 +180,7 @@ namespace Raven.Server.Documents.Indexes.Persistence.Lucene
 
         public void CleanWritersIfNeeded()
         {
-            if(_indexWriterCleanupNeeded == false)
+            if (_indexWriterCleanupNeeded == false)
                 return;
 
             DisposeWriters();

--- a/src/Raven.Server/Documents/Indexes/Persistence/Lucene/LuceneSuggestionIndexWriter.cs
+++ b/src/Raven.Server/Documents/Indexes/Persistence/Lucene/LuceneSuggestionIndexWriter.cs
@@ -172,6 +172,7 @@ namespace Raven.Server.Documents.Indexes.Persistence.Lucene
                     if (_alreadySeen.Contains(word))
                         continue;
 
+                    _indexSearcher ??= new IndexSearcher(_directory, true, state);
                     if (_indexSearcher.DocFreq(_fWordTerm.CreateTerm(word), state) <= 0)
                     {
                         // the word does not exist in the gramindex
@@ -200,6 +201,11 @@ namespace Raven.Server.Documents.Indexes.Persistence.Lucene
                 LuceneIndexWriter.TryThrowingBetterException(e, _directory);
 
                 throw;
+            }
+            finally
+            {
+                _indexSearcher?.Dispose();
+                _indexSearcher = null;
             }
         }
 
@@ -272,9 +278,6 @@ namespace Raven.Server.Documents.Indexes.Persistence.Lucene
             _indexWriter.SetMaxBufferedDocs(IndexWriter.DISABLE_AUTO_FLUSH);
             _indexWriter.SetRAMBufferSizeMB(50);
             _indexWriter.MergeFactor = 300;
-
-            _indexSearcher = new IndexSearcher(_directory, true, state);
-
         }
 
         private void DisposeIndexWriter(bool waitForMerges = true)

--- a/src/Raven.Server/Documents/Indexes/Persistence/Lucene/LuceneSuggestionIndexWriter.cs
+++ b/src/Raven.Server/Documents/Indexes/Persistence/Lucene/LuceneSuggestionIndexWriter.cs
@@ -285,6 +285,8 @@ namespace Raven.Server.Documents.Indexes.Persistence.Lucene
             if (_indexWriter == null)
                 return;
 
+            _alreadySeen.Clear();
+
             var searcher = _indexSearcher;
             _indexSearcher = null;
 

--- a/src/Raven.Server/Indexing/LuceneVoronDirectory.cs
+++ b/src/Raven.Server/Indexing/LuceneVoronDirectory.cs
@@ -213,7 +213,6 @@ namespace Raven.Server.Indexing
 
         protected override void Dispose(bool disposing)
         {
-            TempFileCache.Dispose();
         }
 
         public void ResetAllocations()

--- a/src/Raven.Server/Indexing/TempFileCache.cs
+++ b/src/Raven.Server/Indexing/TempFileCache.cs
@@ -25,13 +25,16 @@ namespace Raven.Server.Indexing
         private const int MaxFilesToKeepInCache = 32;
         private int _memoryStreamCapacity = 128 * Constants.Size.Kilobyte;
 
+        public int FilesCount => _files.Count;
+
         public TempFileCache(StorageEnvironmentOptions options)
         {
             _options = options;
             string path = _options.TempPath.FullPath;
             if (Directory.Exists(path) == false)
                 Directory.CreateDirectory(path);
-            foreach (string file in Directory.GetDirectories(path, "lucene-*" + StorageEnvironmentOptions.DirectoryStorageEnvironmentOptions.TempFileExtension))
+
+            foreach (string file in Directory.GetFiles(path, "lucene-*" + StorageEnvironmentOptions.DirectoryStorageEnvironmentOptions.TempFileExtension))
             {
                 var info = new FileInfo(file);
                 if (info.Length > MaxFileSizeToKeepInBytes ||
@@ -53,6 +56,7 @@ namespace Raven.Server.Indexing
                         // if can't open, just ignore it.
                         continue;
                     }
+
                     _files.Enqueue(fileStream);
                 }
             }

--- a/src/Raven.Server/Indexing/TempFileCache.cs
+++ b/src/Raven.Server/Indexing/TempFileCache.cs
@@ -1,7 +1,6 @@
 using System;
 using System.Collections.Concurrent;
 using System.IO;
-using System.Threading;
 using Raven.Server.ServerWide;
 using Raven.Server.Utils;
 using Sparrow.Global;
@@ -40,14 +39,7 @@ namespace Raven.Server.Indexing
                 var info = new FileInfo(file);
                 if (info.Length > MaxFileSizeToKeepInBytes || _files.Count >= MaxFilesToKeepInCache)
                 {
-                    try
-                    {
-                        File.Delete(file);
-                    }
-                    catch (IOException)
-                    {
-                        // if can't delete, just ignore it.
-                    }
+                    IOExtensions.DeleteFile(file);
                 }
                 else
                 {

--- a/test/SlowTests/Issues/RavenDB_16511.cs
+++ b/test/SlowTests/Issues/RavenDB_16511.cs
@@ -26,7 +26,7 @@ namespace SlowTests.Issues
                     database))
                 {
 
-                    index.IndexPersistence.LuceneDirectory.TempFileCache.SetMemoryStreamCapacity(1);
+                    index.IndexPersistence.TempFileCache.SetMemoryStreamCapacity(1);
                     testingStuff.RunFakeIndex(index);
 
                     using (var context = DocumentsOperationContext.ShortTermSingleUse(database))
@@ -77,7 +77,7 @@ namespace SlowTests.Issues
                         },
                         database))
                     {
-                        newIndex.IndexPersistence.LuceneDirectory.TempFileCache.SetMemoryStreamCapacity(1);
+                        newIndex.IndexPersistence.TempFileCache.SetMemoryStreamCapacity(1);
                         testingStuff.RunFakeIndex(newIndex);
 
                         Assert.True(await mre.WaitAsync(TimeSpan.FromSeconds(15)), "Index wasn't replaced");

--- a/test/SlowTests/Issues/RavenDB_9381.cs
+++ b/test/SlowTests/Issues/RavenDB_9381.cs
@@ -15,8 +15,9 @@ namespace SlowTests.Issues
         public void Lucene_directory_must_be_aware_of_created_outputs()
         {
             using (var tx = Env.WriteTransaction())
+            using (var cache = new TempFileCache(Env.Options))
             {
-                var dir = new LuceneVoronDirectory(tx, Env);
+                var dir = new LuceneVoronDirectory(tx, Env, cache);
 
                 var state = new VoronState(tx);
 

--- a/test/SlowTests/Tests/TempFileCacheTests.cs
+++ b/test/SlowTests/Tests/TempFileCacheTests.cs
@@ -38,5 +38,27 @@ namespace SlowTests.Tests
                 Assert.Equal(1, cache.FilesCount);
             }
         }
+
+        [Fact]
+        public void Skip_files_that_are_in_use()
+        {
+            var path = new VoronPathSetting(NewDataPath());
+            var environment = new StorageEnvironmentOptions.DirectoryStorageEnvironmentOptions(path, path, path, null, null);
+
+            for (var i = 0; i < TempFileCache.MaxFilesToKeepInCache; i++)
+            {
+                using (File.Create(TempFileCache.GetTempFileName(environment)))
+                {
+                }
+            }
+
+            using (File.Create(Path.Combine(environment.TempPath.FullPath,
+                TempFileCache.FilePrefix + "Z" + StorageEnvironmentOptions.DirectoryStorageEnvironmentOptions.TempFileExtension)))
+            {
+                using (new TempFileCache(environment))
+                {
+                }
+            }
+        }
     }
 }

--- a/test/SlowTests/Tests/TempFileCacheTests.cs
+++ b/test/SlowTests/Tests/TempFileCacheTests.cs
@@ -1,0 +1,42 @@
+﻿using System;
+using System.Collections.Concurrent;
+using System.Collections.Generic;
+using System.IO;
+using System.Threading.Tasks;
+using FastTests;
+using Raven.Client.Documents;
+using Raven.Client.Documents.Operations;
+using Raven.Client.Documents.Subscriptions;
+using Raven.Server.Indexing;
+using Sparrow.Server;
+using Voron;
+using Voron.Exceptions;
+using Voron.Util.Settings;
+using Xunit;
+using Xunit.Abstractions;
+
+namespace SlowTests.Tests
+{
+    public class TempFileCacheTests : RavenTestBase
+    {
+        public TempFileCacheTests(ITestOutputHelper output) : base(output)
+        {
+        }
+
+        [Fact]
+        public void Can_reuse_files_for_cache()
+        {
+            var path = new VoronPathSetting(NewDataPath());
+            var environment = new StorageEnvironmentOptions.DirectoryStorageEnvironmentOptions(path, path, path, null, null);
+
+            using (File.Create(TempFileCache.GetTempFileName(environment)))
+            {
+            }
+
+            using (var cache = new TempFileCache(environment))
+            {
+                Assert.Equal(1, cache.FilesCount);
+            }
+        }
+    }
+}


### PR DESCRIPTION
### Issue link

https://issues.hibernatingrhinos.com/issue/RavenDB-16762

### Additional description

- fix AVE when using an index with suggestions by recreating the index searcher when needed.
- reuse the files for the `TempFileCache`
- use one instance of `TempFileCache` for a single index

### Type of change

- Bug fix

### How risky is the change?

- Low 

### Backward compatibility

- Not relevant

### Is it platform specific issue?

- No

### Documentation update

- No documentation update is needed 

### Testing 

- Tests have been added that prove the fix is effective or that the feature works (for the `TempFileCache`)
- It has been verified by manual testing (Lucene suggestions behavior)

### Is there any existing behavior change of other features due to this change?

- No

### UI work

- No UI work is needed
