### PR TITLE
RavenDB-17173 fix restore of snapshot backups when compression recovery files were backed up

### DIFF
--- a/src/Voron/Data/Tables/TableValueCompressor.cs
+++ b/src/Voron/Data/Tables/TableValueCompressor.cs
@@ -20,7 +20,7 @@ namespace Voron.Data.Tables
         // resources by needlessly compressing data
         private const int OverheadSize = 32;
 
-        private const string CompressionRecoveryExtension = ".compression-recovery";
+        internal const string CompressionRecoveryExtension = ".compression-recovery";
         public const string CompressionRecoveryExtensionGlob = "*" + CompressionRecoveryExtension;
         private readonly TableValueBuilder _builder;
 

--- a/src/Voron/Impl/Backup/FullBackup.cs
+++ b/src/Voron/Impl/Backup/FullBackup.cs
@@ -113,8 +113,8 @@ namespace Voron.Impl.Backup
 
                     JournalInfo journalInfo = env.HeaderAccessor.Get(ptr => ptr->Journal);
                     var startingJournal = journalInfo.LastSyncedJournal;
-                    if (env.Options.JournalExists(startingJournal) == false && 
-                        journalInfo.Flags.HasFlag(JournalInfoFlags.IgnoreMissingLastSyncJournal) || 
+                    if (env.Options.JournalExists(startingJournal) == false &&
+                        journalInfo.Flags.HasFlag(JournalInfoFlags.IgnoreMissingLastSyncJournal) ||
                         startingJournal == -1)
                     {
                         startingJournal++;
@@ -186,7 +186,9 @@ namespace Voron.Impl.Backup
 
                             using (src)
                             {
-                                var recoveryPart = package.CreateEntry(Path.Combine(basePath, src.Name), compressionLevel);
+                                var srcFileName = Path.GetFileName(recoveryFile);
+
+                                var recoveryPart = package.CreateEntry(Path.Combine(basePath, srcFileName), compressionLevel);
                                 using var dst = recoveryPart.Open();
                                 src.CopyTo(dst);
                             }

--- a/test/SlowTests/Server/Documents/PeriodicBackup/PeriodicBackupSlowTests.cs
+++ b/test/SlowTests/Server/Documents/PeriodicBackup/PeriodicBackupSlowTests.cs
@@ -40,6 +40,7 @@ using Sparrow.Json;
 using Sparrow.Server.Json.Sync;
 using Tests.Infrastructure;
 using Tests.Infrastructure.Entities;
+using Voron.Data.Tables;
 using Xunit;
 using Xunit.Abstractions;
 
@@ -477,7 +478,7 @@ namespace SlowTests.Server.Documents.PeriodicBackup
                 }
 
                 var config = Backup.CreateBackupConfiguration(backupPath, backupType: BackupType.Snapshot);
-                config.SnapshotSettings = new SnapshotSettings {CompressionLevel = compressionLevel};
+                config.SnapshotSettings = new SnapshotSettings { CompressionLevel = compressionLevel };
                 var backupTaskId = await Backup.UpdateConfigAndRunBackupAsync(Server, config, store);
 
                 using (var session = store.OpenAsyncSession())
@@ -529,6 +530,63 @@ namespace SlowTests.Server.Documents.PeriodicBackup
                         Assert.Contains($"A:8-{originalDatabase.DbBase64Id}", databaseChangeVector);
                         Assert.Contains($"A:10-{restoredDatabase.DbBase64Id}", databaseChangeVector);
                     }
+                }
+            }
+        }
+
+        [Fact, Trait("Category", "Smuggler")]
+        public async Task can_backup_and_restore_snapshot_with_compression()
+        {
+            var backupPath = NewDataPath(suffix: "BackupFolder");
+            using (var store = GetDocumentStore(new Options
+            {
+                RunInMemory = false,
+                ModifyDatabaseRecord = record =>
+                {
+                    record.DocumentsCompression = new DocumentsCompressionConfiguration
+                    {
+                        Collections = new[] { "Orders" },
+                        CompressRevisions = true
+                    };
+                }
+            }))
+            {
+                await store.Maintenance.SendAsync(new CreateSampleDataOperation());
+
+                var sourceStats = await store.Maintenance.SendAsync(new GetStatisticsOperation());
+
+                var database = await GetDocumentDatabaseInstanceFor(store);
+                var databasePath = database.Configuration.Core.DataDirectory.FullPath;
+                var compressionRecovery = Directory.GetFiles(databasePath, TableValueCompressor.CompressionRecoveryExtensionGlob);
+                Assert.Equal(2, compressionRecovery.Length);
+
+                var config = Backup.CreateBackupConfiguration(backupPath, backupType: BackupType.Snapshot);
+                config.SnapshotSettings = new SnapshotSettings { CompressionLevel = CompressionLevel.NoCompression };
+                var backupTaskId = await Backup.UpdateConfigAndRunBackupAsync(Server, config, store);
+
+                var lastEtag = store.Maintenance.Send(new GetStatisticsOperation()).LastDocEtag;
+                await Backup.RunBackupAndReturnStatusAsync(Server, backupTaskId, store, isFullBackup: false, expectedEtag: lastEtag);
+
+                // restore the database with a different name
+                string restoredDatabaseName = $"restored_database_snapshot-{Guid.NewGuid()}";
+                var backupLocation = Directory.GetDirectories(backupPath).First();
+                using (ReadOnly(backupLocation))
+                using (Backup.RestoreDatabase(store, new RestoreBackupConfiguration
+                {
+                    BackupLocation = backupLocation,
+                    DatabaseName = restoredDatabaseName
+                }))
+                {
+                    // exception was throw during restore that compression recovery files were already existing
+
+                    var restoreStats = await store.Maintenance.SendAsync(new GetStatisticsOperation());
+
+                    Assert.Equal(sourceStats.CountOfDocuments, restoreStats.CountOfDocuments);
+
+                    database = await GetDocumentDatabaseInstanceFor(store, restoredDatabaseName);
+                    databasePath = database.Configuration.Core.DataDirectory.FullPath;
+                    compressionRecovery = Directory.GetFiles(databasePath, TableValueCompressor.CompressionRecoveryExtensionGlob);
+                    Assert.Equal(2, compressionRecovery.Length);
                 }
             }
         }


### PR DESCRIPTION
### Issue link

https://issues.hibernatingrhinos.com/issue/RavenDB-17173

### Additional description

the underlying issue was that we were putting full path when compression recovery files were backed up using snapshot
because of that the end restore directory was not a sub-directory of a restore path
which could result in a file already exists exception

### Type of change

- Bug fix

### How risky is the change?

- Low 

### Backward compatibility

- Ensured. During restore we are checking if the end directory is a subdirectory of a restore directory. If not then we are checking all file extensions in that directory, if we have 1 and it is .compression-recovery one then we are skipping - if not we are throwing (should not happen)

### Is it platform specific issue?

- No

### Documentation update

- No documentation update is needed 

### Testing 

- Tests have been added that prove the fix is effective or that the feature works
- It has been verified by manual testing

### Is there any existing behavior change of other features due to this change?

- No

### UI work

- No UI work is needed
