### PR TITLE
RavenDB-17175 Fix conflict between document and deletion on different collections

### DIFF
--- a/src/Raven.Server/Documents/DocumentPutAction.cs
+++ b/src/Raven.Server/Documents/DocumentPutAction.cs
@@ -572,19 +572,24 @@ namespace Raven.Server.Documents
 
         private static void DeleteTombstoneIfNeeded(DocumentsOperationContext context, CollectionName collectionName, byte* lowerId, int lowerSize)
         {
-            var tombstoneTable = context.Transaction.InnerTransaction.OpenTable(TombstonesSchema, collectionName.GetTableName(CollectionTableType.Tombstones));
             using (Slice.External(context.Allocator, lowerId, lowerSize, out Slice id))
             {
-                foreach (var (tombstoneKey, tvh) in tombstoneTable.SeekByPrimaryKeyPrefix(id, Slices.Empty, 0))
-                {
-                    if (IsTombstoneOfId(tombstoneKey, id) == false)
-                        return;
+                DeleteTombstoneIfNeeded(context, collectionName, id);
+            }
+        }
 
-                    if (tombstoneTable.IsOwned(tvh.Reader.Id))
-                    {
-                        tombstoneTable.Delete(tvh.Reader.Id);
-                        return; // there could be only one tombstone per collection
-                    }
+        public static void DeleteTombstoneIfNeeded(DocumentsOperationContext context, CollectionName collectionName, Slice id)
+        {
+            var tombstoneTable = context.Transaction.InnerTransaction.OpenTable(TombstonesSchema, collectionName.GetTableName(CollectionTableType.Tombstones));
+            foreach (var (tombstoneKey, tvh) in tombstoneTable.SeekByPrimaryKeyPrefix(id, Slices.Empty, 0))
+            {
+                if (IsTombstoneOfId(tombstoneKey, id) == false)
+                    return;
+
+                if (tombstoneTable.IsOwned(tvh.Reader.Id))
+                {
+                    tombstoneTable.Delete(tvh.Reader.Id);
+                    return;
                 }
             }
         }

--- a/src/Raven.Server/Documents/DocumentsStorage.cs
+++ b/src/Raven.Server/Documents/DocumentsStorage.cs
@@ -1478,13 +1478,8 @@ namespace Raven.Server.Documents
                     ExtractCollectionName(context, collectionName.Name);
                 }
 
-                var tombstoneTable = context.Transaction.InnerTransaction.OpenTable(TombstonesSchema,
-                    collectionName.GetTableName(CollectionTableType.Tombstones));
-
-                if (tombstoneTable.IsOwned(local.Tombstone.StorageId))
-                {
-                    tombstoneTable.Delete(local.Tombstone.StorageId);
-                }
+                DocumentPutAction.DeleteTombstoneIfNeeded(context, collectionName, lowerId);
+               
                 DocumentFlags flags;
                 var localFlags = local.Tombstone.Flags.Strip(DocumentFlags.FromClusterTransaction);
                 if (nonPersistentFlags.Contain(NonPersistentDocumentFlags.ByEnforceRevisionConfiguration))


### PR DESCRIPTION
### Issue link

https://issues.hibernatingrhinos.com/issue/RavenDB-17175

### Additional description

Since we allow to have tombstones with the same id on different collections, we need to delete the proper one when overwritten via replication.

### Type of change

- Bug fix

### How risky is the change?

- Low 

### Backward compatibility

- Not relevant

### Is it platform specific issue?

- No

### Documentation update

- No documentation update is needed 

### Testing 

- Test added that prove the fix is effective
- It has been verified by manual testing

### Is there any existing behavior change of other features due to this change?

- No

### UI work

- No UI work is needed
