### PR TITLE
RavenDB-17175 Ensure deleting revision from the correct collection

### DIFF
--- a/src/Raven.Server/Documents/Revisions/RevisionsStorage.cs
+++ b/src/Raven.Server/Documents/Revisions/RevisionsStorage.cs
@@ -708,7 +708,7 @@ namespace Raven.Server.Documents.Revisions
 
         public void DeleteRevision(DocumentsOperationContext context, Slice key, string collection, string changeVector, long lastModifiedTicks)
         {
-            var collectionName = new CollectionName(collection);
+            var collectionName = _documentsStorage.ExtractCollectionName(context, collection);
             var table = EnsureRevisionTableCreated(context.Transaction.InnerTransaction, collectionName);
 
             long revisionEtag;
@@ -726,8 +726,8 @@ namespace Raven.Server.Documents.Revisions
                 {
                     // We request to delete revision with the wrong collection
                     var revision = TableValueToRevision(context, ref tvr);
-                    var currentCollection = CollectionName.GetCollectionName(revision.Data);
-                    table = EnsureRevisionTableCreated(context.Transaction.InnerTransaction, new CollectionName(currentCollection));
+                    var currentCollection = _documentsStorage.ExtractCollectionName(context, revision.Data);
+                    table = EnsureRevisionTableCreated(context.Transaction.InnerTransaction, currentCollection);
 
                     if (table.IsOwned(tvr.Id) == false) // this shouldn't happened
                         throw new VoronErrorException(

--- a/src/Voron/Data/RawData/ActiveRawDataSmallSection.cs
+++ b/src/Voron/Data/RawData/ActiveRawDataSmallSection.cs
@@ -267,6 +267,7 @@ namespace Voron.Data.RawData
             return 32;
         }
 
+        [MethodImpl(MethodImplOptions.AggressiveInlining)]
         public bool IsOwned(long id)
         {
             var posInPage = (int)(id % Constants.Storage.PageSize);

--- a/src/Voron/Data/Tables/Table.cs
+++ b/src/Voron/Data/Tables/Table.cs
@@ -334,7 +334,7 @@ namespace Voron.Data.Tables
         public void Delete(long id)
         {
             if (IsOwned(id) == false)
-                ThrowNotOwned();
+                ThrowNotOwned(id);
 
             AssertWritableTable();
 
@@ -408,10 +408,10 @@ namespace Voron.Data.Tables
             ActiveDataSmallSection.DeleteSection(sectionPageNumber);
         }
 
-        private void ThrowNotOwned()
+        private void ThrowNotOwned(long id)
         {
-            Debug.Assert(false, $"Trying to delete a value from the wrong table ('{Name}')");
-            throw new VoronErrorException($"Trying to delete a value from the wrong table ('{Name}')");
+            Debug.Assert(false, $"Trying to delete a value (id:{id}) from the wrong table ('{Name}')");
+            throw new VoronErrorException($"Trying to delete a value (id:{id}) from the wrong table ('{Name}')");
         }
 
         private void ThrowInvalidAttemptToRemoveValueFromIndexAndNotFindingIt(long id, Slice indexDefName)

--- a/src/Voron/Data/Tables/Table.cs
+++ b/src/Voron/Data/Tables/Table.cs
@@ -331,6 +331,12 @@ namespace Voron.Data.Tables
 
         public void Delete(long id)
         {
+            if (IsOwned(id) == false)
+            {
+                Debug.Assert(false, $"Trying to delete a values (id:{id}) from the wrong table ('{Name}')");
+                throw new VoronErrorException($"Trying to delete a values (id:{id}) from the wrong table ('{Name}')");
+            }
+
             AssertWritableTable();
 
             var ptr = DirectRead(id, out int size);

--- a/src/Voron/Data/Tables/Table.cs
+++ b/src/Voron/Data/Tables/Table.cs
@@ -2,6 +2,7 @@ using System;
 using System.Collections.Generic;
 using System.Diagnostics;
 using System.IO;
+using System.Runtime.CompilerServices;
 using Sparrow;
 using Sparrow.Server;
 using Voron.Data.BTrees;
@@ -314,6 +315,7 @@ namespace Voron.Data.Tables
             }
         }
 
+        [MethodImpl(MethodImplOptions.AggressiveInlining)]
         public bool IsOwned(long id)
         {
             var posInPage = id % Constants.Storage.PageSize;
@@ -332,10 +334,7 @@ namespace Voron.Data.Tables
         public void Delete(long id)
         {
             if (IsOwned(id) == false)
-            {
-                Debug.Assert(false, $"Trying to delete a values (id:{id}) from the wrong table ('{Name}')");
-                throw new VoronErrorException($"Trying to delete a values (id:{id}) from the wrong table ('{Name}')");
-            }
+                ThrowNotOwned();
 
             AssertWritableTable();
 
@@ -407,6 +406,12 @@ namespace Voron.Data.Tables
             }
 
             ActiveDataSmallSection.DeleteSection(sectionPageNumber);
+        }
+
+        private void ThrowNotOwned()
+        {
+            Debug.Assert(false, $"Trying to delete a value from the wrong table ('{Name}')");
+            throw new VoronErrorException($"Trying to delete a value from the wrong table ('{Name}')");
         }
 
         private void ThrowInvalidAttemptToRemoveValueFromIndexAndNotFindingIt(long id, Slice indexDefName)


### PR DESCRIPTION
### Issue link

https://issues.hibernatingrhinos.com/issue/RavenDB-17175

### Additional description

When receiving deleted revision via replication we need to ensure that we delete it from the correct collection.

### Type of change

- Bug fix

### How risky is the change?

- Low 
- Moderate 

The fix on its own isn't risky, but I've added a validation, that might expose additional bugs and cause users to complain about it (if they exist).

### Backward compatibility

- Not relevant

### Is it platform specific issue?

- No

### Documentation update

- No documentation update is needed 

### Testing 

- Tests have been added that prove the fix is effective or that the feature works

### Is there any existing behavior change of other features due to this change?

- No

### UI work

- No UI work is needed
