### PR TITLE
RavenDB-17183 added OAuth source to the exception message

### DIFF
--- a/src/Raven.Server/Smuggler/Migration/ApiKey/Authenticator.cs
+++ b/src/Raven.Server/Smuggler/Migration/ApiKey/Authenticator.cs
@@ -64,14 +64,14 @@ namespace Raven.Server.Smuggler.Migration.ApiKey
                     {
                         // We've already tried three times and failed
                         if (tries >= 3)
-                            throw ErrorResponseException.FromResponseMessage(response);
+                            throw ErrorResponseException.FromResponseMessage(response, $"Failed to get OAuth Token from '{requestUri}'.");
 
                         if (response.StatusCode != HttpStatusCode.PreconditionFailed)
-                            throw ErrorResponseException.FromResponseMessage(response);
+                            throw ErrorResponseException.FromResponseMessage(response, $"Failed to get OAuth Token from '{requestUri}'.");
 
                         var header = response.Headers.GetFirstValue("WWW-Authenticate");
                         if (header == null || header.StartsWith(OAuthHelper.Keys.WWWAuthenticateHeaderKey) == false)
-                            throw new ErrorResponseException(response, "Got invalid WWW-Authenticate value");
+                            throw new ErrorResponseException(response, $"Failed to get OAuth Token from '{requestUri}'. Got invalid WWW-Authenticate value");
 
                         var challengeDictionary = OAuthHelper.ParseDictionary(header.Substring(OAuthHelper.Keys.WWWAuthenticateHeaderKey.Length).Trim());
                         serverRSAExponent = challengeDictionary.GetOrDefault(OAuthHelper.Keys.RSAExponent);

--- a/src/Raven.Server/Smuggler/Migration/ApiKey/ErrorResponseException.cs
+++ b/src/Raven.Server/Smuggler/Migration/ApiKey/ErrorResponseException.cs
@@ -46,9 +46,18 @@ namespace Raven.Server.Smuggler.Migration.ApiKey
             ResponseString = responseString;
         }
 
-        public static ErrorResponseException FromResponseMessage(HttpResponseMessage response, bool readErrorString = true)
+        public static ErrorResponseException FromResponseMessage(HttpResponseMessage response, string msg, bool readErrorString = true)
         {
-            var sb = new StringBuilder("Status code: ").Append(response.StatusCode).AppendLine();
+            var sb = new StringBuilder();
+            if (string.IsNullOrEmpty(msg) == false)
+                sb
+                    .Append(msg)
+                    .Append(" ");
+
+            sb
+                .Append("Status code:")
+                .Append(response.StatusCode)
+                .AppendLine();
 
             string responseString = null;
             if (readErrorString && response.Content != null)
@@ -63,6 +72,7 @@ namespace Raven.Server.Smuggler.Migration.ApiKey
                     }
                 }
             }
+
             return new ErrorResponseException(response, sb.ToString(), null, null)
             {
                 ResponseString = responseString


### PR DESCRIPTION
### Issue link

https://issues.hibernatingrhinos.com/issue/RavenDB-17183

### Additional description

Additional message in OAuth exception for easier pinpointing the OAuth Source which can come from the response headers (and e.g. point to localhost)

### Type of change

- New feature

### How risky is the change?

- Low 

### Backward compatibility

- Not relevant

### Is it platform specific issue?

- No

### Documentation update

- No documentation update is needed 

### Testing 

- It has been verified by manual testing

### Is there any existing behavior change of other features due to this change?

- No

### UI work

- No UI work is needed
