### PR TITLE
RavenDB-17167 release memory from blittables on evict

### DIFF
--- a/src/Raven.Client/Documents/Session/DocumentInfo.cs
+++ b/src/Raven.Client/Documents/Session/DocumentInfo.cs
@@ -6,7 +6,7 @@ namespace Raven.Client.Documents.Session
     /// <summary>
     /// Information held about an entity by the session
     /// </summary>
-    public class DocumentInfo
+    public class DocumentInfo : IDisposable
     {
         /// <summary>
         /// Gets or sets the id.
@@ -70,6 +70,15 @@ namespace Raven.Client.Documents.Session
                 ChangeVector = changeVector
             };
             return newDocumentInfo;
+        }
+
+        public void Dispose()
+        {
+            Metadata?.Dispose();
+            Metadata = null;
+
+            Document?.Dispose();
+            Document = null;
         }
     }
 }

--- a/src/Raven.Client/Documents/Session/InMemoryDocumentSessionOperations.cs
+++ b/src/Raven.Client/Documents/Session/InMemoryDocumentSessionOperations.cs
@@ -1231,12 +1231,11 @@ more responsive application.
         {
             if (DocumentsByEntity.TryGetValue(entity, out var documentInfo))
             {
-                using (documentInfo)
-                {
-                    DocumentsByEntity.Evict(entity);
-                    DocumentsById.Remove(documentInfo.Id);
-                    _countersByDocId?.Remove(documentInfo.Id);
-                }
+                DocumentsByEntity.Evict(entity);
+                DocumentsById.Remove(documentInfo.Id);
+                _countersByDocId?.Remove(documentInfo.Id);
+
+                documentInfo.Dispose();
             }
 
             DeletedEntities.Evict(entity);

--- a/test/SlowTests/Issues/RavenDB_13315.cs
+++ b/test/SlowTests/Issues/RavenDB_13315.cs
@@ -38,7 +38,7 @@ namespace SlowTests.Issues
                     Assert.False((session as InMemoryDocumentSessionOperations).HasChanged(user));
                     session.Delete("users/1", null);
                     session.SaveChanges();
-                    Assert.Equal(allocatedMemoryBeforeOperationsThatShouldHaveNoMemoryFootpring, context.AllocatedMemory);
+                    Assert.True(allocatedMemoryBeforeOperationsThatShouldHaveNoMemoryFootpring >= context.AllocatedMemory, $"{allocatedMemoryBeforeOperationsThatShouldHaveNoMemoryFootpring} >= {context.AllocatedMemory}");
                 }
             }
         }


### PR DESCRIPTION
### Issue link

https://issues.hibernatingrhinos.com/issue/RavenDB-17167

### Additional description

When removing DocumentInfo we should release blittables to reduce memory footprint.

### Type of change

- Bug fix

### How risky is the change?

- Moderate 

### Backward compatibility

- Not relevant

### Is it platform specific issue?

- No

### Documentation update

- No documentation update is needed 

### Testing 

- It has been verified by manual testing

### Is there any existing behavior change of other features due to this change?

- No

### UI work

- No UI work is needed
