### PR TITLE
RavenDB-17177 use default conventions when deserializing IOperationResult to avoid a situation when serializer with TypeNameHandling.None is used

### DIFF
--- a/src/Raven.Client/Documents/BulkInsert/BulkInsertOperation.cs
+++ b/src/Raven.Client/Documents/BulkInsert/BulkInsertOperation.cs
@@ -418,7 +418,7 @@ namespace Raven.Client.Documents.BulkInsert
 
         private async Task<BulkInsertAbortedException> GetExceptionFromOperation()
         {
-            var stateRequest = new GetOperationStateOperation.GetOperationStateCommand(_requestExecutor.Conventions, _operationId, _nodeTag);
+            var stateRequest = new GetOperationStateOperation.GetOperationStateCommand(_operationId, _nodeTag);
             await ExecuteAsync(stateRequest, token: _token).ConfigureAwait(false);
 
             if (!(stateRequest.Result?.Result is OperationExceptionResult error))

--- a/src/Raven.Client/Documents/Operations/GetOperationStateOperation.cs
+++ b/src/Raven.Client/Documents/Operations/GetOperationStateOperation.cs
@@ -24,19 +24,17 @@ namespace Raven.Client.Documents.Operations
 
         public RavenCommand<OperationState> GetCommand(DocumentConventions conventions, JsonOperationContext context)
         {
-            return new GetOperationStateCommand(conventions, _id, _nodeTag);
+            return new GetOperationStateCommand(_id, _nodeTag);
         }
 
         internal class GetOperationStateCommand : RavenCommand<OperationState>
         {
             public override bool IsReadRequest => true;
 
-            private readonly DocumentConventions _conventions;
             private readonly long _id;
 
-            public GetOperationStateCommand(DocumentConventions conventions, long id, string nodeTag = null)
+            public GetOperationStateCommand( long id, string nodeTag = null)
             {
-                _conventions = conventions;
                 _id = id;
                 SelectedNodeTag = nodeTag;
                 Timeout = TimeSpan.FromSeconds(15);
@@ -57,7 +55,7 @@ namespace Raven.Client.Documents.Operations
                 if (response == null)
                     return;
 
-                Result = (OperationState)_conventions.DeserializeEntityFromBlittable(typeof(OperationState), response);
+                Result = (OperationState)DocumentConventions.Default.DeserializeEntityFromBlittable(typeof(OperationState), response);
             }
         }
     }

--- a/src/Raven.Client/Documents/Operations/Operation.cs
+++ b/src/Raven.Client/Documents/Operations/Operation.cs
@@ -215,7 +215,7 @@ namespace Raven.Client.Documents.Operations
 
         protected virtual RavenCommand<OperationState> GetOperationStateCommand(DocumentConventions conventions, long id, string nodeTag = null)
         {
-            return new GetOperationStateOperation.GetOperationStateCommand(conventions, id, nodeTag);
+            return new GetOperationStateOperation.GetOperationStateCommand(id, nodeTag);
         }
 
         public void OnNext(OperationStatusChange change)

--- a/test/SlowTests/Issues/RavenDB_17177.cs
+++ b/test/SlowTests/Issues/RavenDB_17177.cs
@@ -1,0 +1,33 @@
+﻿using System;
+using System.Threading.Tasks;
+using FastTests;
+using Newtonsoft.Json;
+using Raven.Client.Documents.Smuggler;
+using Xunit;
+using Xunit.Abstractions;
+
+namespace SlowTests.Issues
+{
+    public class RavenDB_17177 : RavenTestBase
+    {
+        public RavenDB_17177(ITestOutputHelper output) : base(output)
+        {
+        }
+
+        [Fact]
+        public async Task Can_WaitForOperation_When_TypeNameHandling_Is_None()
+        {
+            using (var store = GetDocumentStore(new Options
+            {
+                ModifyDocumentStore = s => s.Conventions.CustomizeJsonSerializer = serializer => serializer.TypeNameHandling = TypeNameHandling.None
+            }))
+            {
+                var tempFile = GetTempFileName();
+
+                var operation = await store.Smuggler.ExportAsync(new DatabaseSmugglerExportOptions(), tempFile);
+
+                await operation.WaitForCompletionAsync(TimeSpan.FromSeconds(15)); // throws
+            }
+        }
+    }
+}


### PR DESCRIPTION
### Issue link

https://issues.hibernatingrhinos.com/issue/RavenDB-17177

### Additional description

Should be safe to do so, because those types are defined by us on the server-side. Nothing 'entity' related should be there.

### Type of change

- Bug fix

### How risky is the change?

- Low 

### Backward compatibility

- Non breaking change

### Is it platform specific issue?

- No

### Documentation update

- No documentation update is needed 

### Testing 

- Tests have been added that prove the fix is effective or that the feature works

### Is there any existing behavior change of other features due to this change?

- No

### UI work

- No UI work is needed
