### PR TITLE
RavenDB-17012 - add missing overloads to the interface

### DIFF
--- a/src/Raven.Client/Documents/IDocumentStore.cs
+++ b/src/Raven.Client/Documents/IDocumentStore.cs
@@ -185,6 +185,10 @@ namespace Raven.Client.Documents
 
         BulkInsertOperation BulkInsert(string database = null, CancellationToken token = default);
 
+        BulkInsertOperation BulkInsert(string database, BulkInsertOptions options, CancellationToken token = default);
+
+        BulkInsertOperation BulkInsert(BulkInsertOptions options, CancellationToken token = default);
+
         /// <summary>
         /// Provides methods to manage data subscriptions.
         /// </summary>

--- a/test/SlowTests/Issues/RavenDB-17012.cs
+++ b/test/SlowTests/Issues/RavenDB-17012.cs
@@ -4,6 +4,7 @@ using System.IO;
 using System.Text;
 using System.Threading.Tasks;
 using FastTests;
+using Raven.Client.Documents;
 using Raven.Client.Documents.BulkInsert;
 using Raven.Client.Documents.Operations;
 using Raven.Tests.Core.Utils.Entities;
@@ -24,7 +25,7 @@ namespace SlowTests.Issues
         [InlineData(5_000)]
         public async Task Can_SkipOverwriteIfUnchanged(int docsCount)
         {
-            using (var store = GetDocumentStore())
+            using (IDocumentStore store = GetDocumentStore())
             {
                 var docs = new List<User>();
 
@@ -64,7 +65,7 @@ namespace SlowTests.Issues
         [InlineData(5_000)]
         public async Task Can_SkipOverwriteIfUnchanged_SomeDocuments(int docsCount)
         {
-            using (var store = GetDocumentStore())
+            using (IDocumentStore store = GetDocumentStore())
             {
                 var docs = new List<User>();
 
@@ -104,7 +105,7 @@ namespace SlowTests.Issues
         [Fact]
         public async Task Can_SkipOverwriteIfUnchanged_With_Attachment()
         {
-            using (var store = GetDocumentStore())
+            using (IDocumentStore store = GetDocumentStore())
             {
                 var docId = Guid.NewGuid().ToString();
                 var attachmentName = Guid.NewGuid().ToString();
@@ -147,7 +148,7 @@ namespace SlowTests.Issues
         [Fact]
         public async Task Can_SkipOverwriteIfUnchanged_With_Counter()
         {
-            using (var store = GetDocumentStore())
+            using (IDocumentStore store = GetDocumentStore())
             {
                 var docId = Guid.NewGuid().ToString();
                 var counterName = Guid.NewGuid().ToString();
@@ -190,7 +191,7 @@ namespace SlowTests.Issues
         [Fact]
         public async Task Can_SkipOverwriteIfUnchanged_With_TimeSeries()
         {
-            using (var store = GetDocumentStore())
+            using (IDocumentStore store = GetDocumentStore())
             {
                 var docId = Guid.NewGuid().ToString();
                 var timeSeriesName = Guid.NewGuid().ToString();


### PR DESCRIPTION
### Issue link

https://issues.hibernatingrhinos.com/issue/RavenDB-17012

### Additional description

Add missing overloads to the `IDocumentStore` interface

### How risky is the change?

- Not relevant

### Backward compatibility

- Not relevant

### Is it platform specific issue?

- No

### Documentation update

- No documentation update is needed 

### Testing 

- Tests have been added that prove the fix is effective or that the feature works

### Is there any existing behavior change of other features due to this change?

- No

### UI work

- No UI work is needed
