### PR TITLE
RavenDB-17193 Use higher timeout when exporting files from a file system using Smuggler

### DIFF
--- a/Raven.Database/Smuggler/SmugglerRemoteFilesOperations.cs
+++ b/Raven.Database/Smuggler/SmugglerRemoteFilesOperations.cs
@@ -190,7 +190,7 @@ namespace Raven.Smuggler
                     PrimaryStore.AsyncFilesCommands.UrlFor() + uri, 
                     HttpMethods.Post, 
                     commands.PrimaryCredentials, 
-                    commands.Conventions))
+                    commands.Conventions, timeout: TimeSpan.FromHours(12)))
                 .AddOperationHeaders(commands.OperationsHeaders);
             
             try


### PR DESCRIPTION
### Issue link

https://issues.hibernatingrhinos.com/issue/RavenDB-17193

### Additional description

It fixes the issue of exporting files from a big file systems with the usage of Raven.Smuggler

### Type of change

- Bug fix

### How risky is the change?

- Low 

### Backward compatibility

- Non breaking change

### Is it platform specific issue?

- No

### Documentation update

- No documentation update is needed 

### Testing 

- It has been verified by manual testing

### Is there any existing behavior change of other features due to this change?

- No

### UI work

- No UI work is needed
