### PR TITLE
RavenDB-17086 Clear query results when running an empty query

### DIFF
--- a/src/Raven.Studio/typescript/viewmodels/database/query/query.ts
+++ b/src/Raven.Studio/typescript/viewmodels/database/query/query.ts
@@ -1038,6 +1038,9 @@ class query extends viewModelBase {
                         this.getQueriedIndexInfo();
                     })
                     .fail((request: JQueryXHR) => {
+                        this.rawJsonUrl(null);
+                        this.queryStats(null);
+                        this.totalResultsForUi(0);
                         resultsTask.reject(request);
                     });
                 

--- a/src/Raven.Studio/wwwroot/App/views/database/query/query.html
+++ b/src/Raven.Studio/wwwroot/App/views/database/query/query.html
@@ -47,7 +47,7 @@
                         </div>
                     </div>
                     <div class="query-controls">
-                        <button class="btn btn-primary btn-block btn-lg text-center run-query" data-bind="click: _.partial(runQuery, null), css: { 'btn-spinner': isLoading }">
+                        <button class="btn btn-primary btn-block btn-lg text-center run-query" data-bind="click: _.partial(runQuery, null), css: { 'btn-spinner': isLoading }, enable: criteria().queryText().trim()">
                             <i class="icon-play2 icon-lg"></i><br />
                             <small class="kbd"><kbd>ctrl</kbd> <strong>+</strong> <kbd>enter</kbd></small>
                         </button>
@@ -60,7 +60,7 @@
         <div class="flex-window-head">
             <h2 class="on-base-background">
                 Results
-                <a target="_blank" href="#" title="Show raw output" data-bind="attr: { href: rawJsonUrl }"><i class="icon-link"></i></a>
+                <a target="_blank" href="#" title="Show raw output" data-bind="attr: { href: rawJsonUrl }, visible: queryStats"><i class="icon-link"></i></a>
             </h2>
             <div class="clearfix">
                 <div class="pull-left btn-group">


### PR DESCRIPTION
### Issue link

https://issues.hibernatingrhinos.com/issue/RavenDB-17086

### Additional description
Disable the Run Query button when query is empty

### Type of change
- Bug fix

### How risky is the change?
- Low 

### Backward compatibility
- Non breaking change

### Is it platform specific issue?
- No

### Documentation update
- No documentation update is needed 

### Testing 
- It has been verified by manual testing

### Is there any existing behavior change of other features due to this change?
- No

### UI work
- No UI work is needed
