### PR TITLE
RavenDB-16992 use SwapBytes for the deleted revision etag

### DIFF
--- a/src/Raven.Server/Documents/Revisions/RevisionsStorage.cs
+++ b/src/Raven.Server/Documents/Revisions/RevisionsStorage.cs
@@ -923,7 +923,7 @@ namespace Raven.Server.Documents.Revisions
                 tvb.Add(idSlice);
                 tvb.Add(revision.Data.BasePointer, revision.Data.Size);
                 tvb.Add((int)flags);
-                tvb.Add(deletedEtag);
+                tvb.Add(Bits.SwapBytes(deletedEtag));
                 tvb.Add(revision.LastModified.Ticks);
                 tvb.Add(context.GetTransactionMarker());
                 tvb.Add((int)resolvedFlag);
@@ -1623,7 +1623,7 @@ namespace Raven.Server.Documents.Revisions
 
                 var etag = TableValueToEtag((int)RevisionsTable.Etag, ref tvr.Reader);
                 var flags = TableValueToFlags((int)RevisionsTable.Flags, ref tvr.Reader);
-                Debug.Assert(revisionsBinEntryEtag <= etag, "Revisions bin entry etag candidate cannot meet a bigger etag.");
+                Debug.Assert(revisionsBinEntryEtag <= etag, $"Revisions bin entry for '{lowerId}' etag candidate ({etag}) cannot meet a bigger etag ({revisionsBinEntryEtag}).");
                 return (flags & DocumentFlags.DeleteRevision) == DocumentFlags.DeleteRevision && revisionsBinEntryEtag >= etag;
             }
         }


### PR DESCRIPTION
### Issue link

https://issues.hibernatingrhinos.com/issue/RavenDB-16992

### Additional description

In a rare code path where we mutating an already existing revision `SwapBytes` wasn't used for the indexed field `deleted revision etag` 

### Type of change

- Bug fix

### How risky is the change?

- Low 

### Backward compatibility

- Not relevant

### Is it platform specific issue?

- Yes. Please list the affected platforms.
- No

### Documentation update

- No documentation update is needed 

### Testing 

- Tests have been added that prove the fix is effective or that the feature works

### Is there any existing behavior change of other features due to this change?

- No

### UI work

- No UI work is needed
