### PR TITLE
RavenDB-17199 GetZipArchiveForSnapshot() must use a temporary file in…

### DIFF
--- a/src/Raven.Server/Documents/PeriodicBackup/Restore/RestoreFromAzure.cs
+++ b/src/Raven.Server/Documents/PeriodicBackup/Restore/RestoreFromAzure.cs
@@ -28,7 +28,8 @@ namespace Raven.Server.Documents.PeriodicBackup.Restore
         protected override async Task<ZipArchive> GetZipArchiveForSnapshot(string path)
         {
             var blob = await _client.GetBlobAsync(path);
-            return new ZipArchive(blob.Data, ZipArchiveMode.Read);
+            var file = await CopyRemoteStreamLocally(blob.Data);
+            return new ZipArchive(file, ZipArchiveMode.Read);
         }
 
         protected override async Task<List<string>> GetFilesForRestore()

--- a/src/Raven.Server/Documents/PeriodicBackup/Restore/RestoreFromGoogleCloud.cs
+++ b/src/Raven.Server/Documents/PeriodicBackup/Restore/RestoreFromGoogleCloud.cs
@@ -26,9 +26,11 @@ namespace Raven.Server.Documents.PeriodicBackup.Restore
             return Task.FromResult(_client.DownloadObject(path));
         }
 
-        protected override Task<ZipArchive> GetZipArchiveForSnapshot(string path)
+        protected override async Task<ZipArchive> GetZipArchiveForSnapshot(string path)
         {
-            return Task.FromResult(new ZipArchive(_client.DownloadObject(path), ZipArchiveMode.Read));
+            Stream stream = _client.DownloadObject(path);
+            var file = await CopyRemoteStreamLocally(stream);
+            return new ZipArchive(file, ZipArchiveMode.Read);
         }
 
         protected override async Task<List<string>> GetFilesForRestore()

--- a/src/Raven.Server/Documents/PeriodicBackup/Restore/RestoreFromS3.cs
+++ b/src/Raven.Server/Documents/PeriodicBackup/Restore/RestoreFromS3.cs
@@ -1,3 +1,4 @@
+using System;
 using System.Collections.Generic;
 using System.IO;
 using System.IO.Compression;
@@ -5,6 +6,7 @@ using System.Linq;
 using System.Threading.Tasks;
 using Raven.Client.Documents.Operations.Backups;
 using Raven.Server.Documents.PeriodicBackup.Aws;
+using Raven.Server.Indexing;
 using Raven.Server.ServerWide;
 
 namespace Raven.Server.Documents.PeriodicBackup.Restore
@@ -29,7 +31,8 @@ namespace Raven.Server.Documents.PeriodicBackup.Restore
         protected override async Task<ZipArchive> GetZipArchiveForSnapshot(string path)
         {
             var blob = await _client.GetObjectAsync(path);
-            return new ZipArchive(blob.Data, ZipArchiveMode.Read);
+            var file = await CopyRemoteStreamLocally(blob.Data);
+            return new ZipArchive(file, ZipArchiveMode.Read);
         }
 
         protected override async Task<List<string>> GetFilesForRestore()


### PR DESCRIPTION
…stead of trying to stream the data

### Issue link

https://issues.hibernatingrhinos.com/issue/RavenDB-17199 

### Additional description

Will handle larger than 2GB snapshot files properly, by avoiding buffering them into memory due to `ZipArchive` reading them to `MemoryStream` (see: https://github.com/dotnet/runtime/issues/59027).

Will write to the temporary file store instead, meaning that we need to have enough storage to download the file and use that.
We'll delete the file when we are closing it. 

### Type of change

- Bug fix

### How risky is the change?

- Low 

We may need more disk space than previously, however, we read it all to memory before, so unlikely to be an actual issue.

### Backward compatibility

- Non breaking change

Change just where we are writing the file temporarily, not changing the behavior itself.

### Testing 

Covered by the existing tests.