### PR TITLE
RavenDB-17199 use DeleteOnCloseZipArchive

### DIFF
--- a/src/Raven.Server/Documents/PeriodicBackup/Restore/AzureRestorePoints.cs
+++ b/src/Raven.Server/Documents/PeriodicBackup/Restore/AzureRestorePoints.cs
@@ -7,6 +7,7 @@ using Raven.Client.Documents.Operations.Backups;
 using Raven.Server.Config.Categories;
 using Raven.Server.Documents.PeriodicBackup.Azure;
 using Raven.Server.ServerWide.Context;
+using Raven.Server.Utils;
 
 namespace Raven.Server.Documents.PeriodicBackup.Restore
 {
@@ -56,7 +57,7 @@ namespace Raven.Server.Documents.PeriodicBackup.Restore
         {
             var blob = await _client.GetBlobAsync(filePath);
             var file = await RestoreBackupTaskBase.CopyRemoteStreamLocally(blob.Data, _configuration.TempPath);
-            return new ZipArchive(file, ZipArchiveMode.Read);
+            return new DeleteOnCloseZipArchive(file, ZipArchiveMode.Read);
         }
 
         protected override string GetFileName(string fullPath)

--- a/src/Raven.Server/Documents/PeriodicBackup/Restore/GoogleCloudRestorePoints.cs
+++ b/src/Raven.Server/Documents/PeriodicBackup/Restore/GoogleCloudRestorePoints.cs
@@ -8,6 +8,7 @@ using Raven.Client.Documents.Operations.Backups;
 using Raven.Server.Config.Categories;
 using Raven.Server.Documents.PeriodicBackup.GoogleCloud;
 using Raven.Server.ServerWide.Context;
+using Raven.Server.Utils;
 
 namespace Raven.Server.Documents.PeriodicBackup.Restore
 {
@@ -58,7 +59,7 @@ namespace Raven.Server.Documents.PeriodicBackup.Restore
         {
             Stream downloadObject = _client.DownloadObject(filePath);
             var file = await RestoreBackupTaskBase.CopyRemoteStreamLocally(downloadObject, _configuration.TempPath);
-            return new ZipArchive(downloadObject, ZipArchiveMode.Read);
+            return new DeleteOnCloseZipArchive(downloadObject, ZipArchiveMode.Read);
         }
 
         protected override string GetFileName(string fullPath)

--- a/src/Raven.Server/Documents/PeriodicBackup/Restore/RestoreFromAzure.cs
+++ b/src/Raven.Server/Documents/PeriodicBackup/Restore/RestoreFromAzure.cs
@@ -6,6 +6,7 @@ using System.Threading.Tasks;
 using Raven.Client.Documents.Operations.Backups;
 using Raven.Server.Documents.PeriodicBackup.Azure;
 using Raven.Server.ServerWide;
+using Raven.Server.Utils;
 
 namespace Raven.Server.Documents.PeriodicBackup.Restore
 {
@@ -29,7 +30,7 @@ namespace Raven.Server.Documents.PeriodicBackup.Restore
         {
             var blob = await _client.GetBlobAsync(path);
             var file = await CopyRemoteStreamLocally(blob.Data);
-            return new ZipArchive(file, ZipArchiveMode.Read);
+            return new DeleteOnCloseZipArchive(file, ZipArchiveMode.Read);
         }
 
         protected override async Task<List<string>> GetFilesForRestore()

--- a/src/Raven.Server/Documents/PeriodicBackup/Restore/RestoreFromGoogleCloud.cs
+++ b/src/Raven.Server/Documents/PeriodicBackup/Restore/RestoreFromGoogleCloud.cs
@@ -6,6 +6,7 @@ using System.Threading.Tasks;
 using Raven.Client.Documents.Operations.Backups;
 using Raven.Server.Documents.PeriodicBackup.GoogleCloud;
 using Raven.Server.ServerWide;
+using Raven.Server.Utils;
 using Sparrow.Server.Utils;
 
 namespace Raven.Server.Documents.PeriodicBackup.Restore
@@ -30,7 +31,7 @@ namespace Raven.Server.Documents.PeriodicBackup.Restore
         {
             Stream stream = _client.DownloadObject(path);
             var file = await CopyRemoteStreamLocally(stream);
-            return new ZipArchive(file, ZipArchiveMode.Read);
+            return new DeleteOnCloseZipArchive(file, ZipArchiveMode.Read);
         }
 
         protected override async Task<List<string>> GetFilesForRestore()

--- a/src/Raven.Server/Documents/PeriodicBackup/Restore/RestoreFromS3.cs
+++ b/src/Raven.Server/Documents/PeriodicBackup/Restore/RestoreFromS3.cs
@@ -8,6 +8,7 @@ using Raven.Client.Documents.Operations.Backups;
 using Raven.Server.Documents.PeriodicBackup.Aws;
 using Raven.Server.Indexing;
 using Raven.Server.ServerWide;
+using Raven.Server.Utils;
 
 namespace Raven.Server.Documents.PeriodicBackup.Restore
 {
@@ -32,7 +33,7 @@ namespace Raven.Server.Documents.PeriodicBackup.Restore
         {
             var blob = await _client.GetObjectAsync(path);
             var file = await CopyRemoteStreamLocally(blob.Data);
-            return new ZipArchive(file, ZipArchiveMode.Read);
+            return new DeleteOnCloseZipArchive(file, ZipArchiveMode.Read);
         }
 
         protected override async Task<List<string>> GetFilesForRestore()

--- a/src/Raven.Server/Documents/PeriodicBackup/Restore/S3RestorePoints.cs
+++ b/src/Raven.Server/Documents/PeriodicBackup/Restore/S3RestorePoints.cs
@@ -7,15 +7,18 @@ using Raven.Client.Documents.Operations.Backups;
 using Raven.Server.Config.Categories;
 using Raven.Server.Documents.PeriodicBackup.Aws;
 using Raven.Server.ServerWide.Context;
+using Raven.Server.Utils;
 
 namespace Raven.Server.Documents.PeriodicBackup.Restore
 {
     public class S3RestorePoints : RestorePointsBase
     {
+        private readonly BackupConfiguration _configuration;
         private readonly RavenAwsS3Client _client;
 
         public S3RestorePoints(BackupConfiguration configuration, SortedList<DateTime, RestorePoint> sortedList, TransactionOperationContext context, S3Settings s3Settings) : base(sortedList, context)
         {
+            _configuration = configuration;
             _client = new RavenAwsS3Client(s3Settings, configuration);
         }
 
@@ -70,7 +73,8 @@ namespace Raven.Server.Documents.PeriodicBackup.Restore
         protected override async Task<ZipArchive> GetZipArchive(string filePath)
         {
             var blob = await _client.GetObjectAsync(filePath);
-            return new ZipArchive(blob.Data, ZipArchiveMode.Read);
+            var file = await RestoreBackupTaskBase.CopyRemoteStreamLocally(blob.Data, _configuration.TempPath);
+            return new DeleteOnCloseZipArchive(file, ZipArchiveMode.Read);
         }
 
         protected override string GetFileName(string fullPath)

--- a/src/Raven.Server/Utils/DeleteOnCloseZipArchive.cs
+++ b/src/Raven.Server/Utils/DeleteOnCloseZipArchive.cs
@@ -5,16 +5,12 @@ namespace Raven.Server.Utils
 {
     public class DeleteOnCloseZipArchive : ZipArchive
     {
-        private readonly FileStream _stream;
-
-        public DeleteOnCloseZipArchive(Stream stream) : base(stream)
-        {
-            _stream = stream as FileStream;
-        }
+        private readonly string _filePath;
 
         public DeleteOnCloseZipArchive(Stream stream, ZipArchiveMode mode) : base(stream, mode)
         {
-            _stream = stream as FileStream;
+            if (stream is FileStream fs)
+                _filePath = fs.Name;
         }
 
         protected override void Dispose(bool disposing)
@@ -25,8 +21,8 @@ namespace Raven.Server.Utils
             }
             finally
             {
-                if (_stream != null)
-                    PosixFile.DeleteOnClose(_stream.Name);
+                if (_filePath != null)
+                    PosixFile.DeleteOnClose(_filePath);
             }
         }
     }

--- a/src/Raven.Server/Utils/DeleteOnCloseZipArchive.cs
+++ b/src/Raven.Server/Utils/DeleteOnCloseZipArchive.cs
@@ -1,0 +1,33 @@
+﻿using System.IO;
+using System.IO.Compression;
+
+namespace Raven.Server.Utils
+{
+    public class DeleteOnCloseZipArchive : ZipArchive
+    {
+        private readonly FileStream _stream;
+
+        public DeleteOnCloseZipArchive(Stream stream) : base(stream)
+        {
+            _stream = stream as FileStream;
+        }
+
+        public DeleteOnCloseZipArchive(Stream stream, ZipArchiveMode mode) : base(stream, mode)
+        {
+            _stream = stream as FileStream;
+        }
+
+        protected override void Dispose(bool disposing)
+        {
+            try
+            {
+                base.Dispose(disposing);
+            }
+            finally
+            {
+                if (_stream != null)
+                    PosixFile.DeleteOnClose(_stream.Name);
+            }
+        }
+    }
+}

--- a/src/Sparrow.Server/Utils/EchoStream.cs
+++ b/src/Sparrow.Server/Utils/EchoStream.cs
@@ -86,16 +86,9 @@ namespace Sparrow.Server.Utils
             _buffers = new BlockingCollection<byte[]>(_maxQueueDepth);
         }
 
-        // we override the xxxxAsync functions because the default base class shares state between ReadAsync and WriteAsync, which causes a hang if both are called at once
-        public new Task WriteAsync(byte[] buffer, int offset, int count, CancellationToken cancellationToken)
+        public override Task WriteAsync(byte[] buffer, int offset, int count, CancellationToken cancellationToken)
         {
             return Task.Run(() => Write(buffer, offset, count), cancellationToken);
-        }
-
-        // we override the xxxxAsync functions because the default base class shares state between ReadAsync and WriteAsync, which causes a hang if both are called at once
-        public new Task<int> ReadAsync(byte[] buffer, int offset, int count, CancellationToken cancellationToken)
-        {
-            return Task.Run(() => Read(buffer, offset, count), cancellationToken);
         }
 
         public override void Write(byte[] buffer, int offset, int count)
@@ -117,6 +110,11 @@ namespace Sparrow.Server.Utils
                 throw new TimeoutException("EchoStream Write() Timeout");
 
             _length += count;
+        }
+
+        public override Task<int> ReadAsync(byte[] buffer, int offset, int count, CancellationToken cancellationToken)
+        {
+            return Task.Run(() => Read(buffer, offset, count), cancellationToken);
         }
 
         public override int Read(byte[] buffer, int offset, int count)


### PR DESCRIPTION
### Issue link

https://issues.hibernatingrhinos.com/issue/RavenDB-17199

### Additional description

Using DeleteOnCloseZipArchive to fix the issue with DeleteOnClose not working on Linux

### Type of change

- Bug fix

### How risky is the change?

- Low 

### Backward compatibility

- Not relevant

### Is it platform specific issue?

- Yes. Posix

### Documentation update

- No documentation update is needed 

### Is there any existing behavior change of other features due to this change?

- No

### UI work

- No UI work is needed
