### PR TITLE
RavenDB-17200

### DIFF
--- a/src/Raven.Server/Documents/DocumentDatabase.cs
+++ b/src/Raven.Server/Documents/DocumentDatabase.cs
@@ -403,7 +403,7 @@ namespace Raven.Server.Documents
             }
         }
 
-        public IDisposable PreventFromUnloading()
+        public IDisposable PreventFromUnloadingByIdleOperations()
         {
             Interlocked.Increment(ref _preventUnloadCounter);
 

--- a/src/Raven.Server/Documents/Indexes/Index.cs
+++ b/src/Raven.Server/Documents/Indexes/Index.cs
@@ -1739,7 +1739,7 @@ namespace Raven.Server.Documents.Indexes
 
             bool mightBeMore = false;
 
-            using (DocumentDatabase.PreventFromUnloading())
+            using (DocumentDatabase.PreventFromUnloadingByIdleOperations())
             using (CultureHelper.EnsureInvariantCulture())
             using (DocumentDatabase.DocumentsStorage.ContextPool.AllocateOperationContext(out DocumentsOperationContext databaseContext))
             using (_contextPool.AllocateOperationContext(out TransactionOperationContext indexContext))

--- a/src/Raven.Server/Documents/PeriodicBackup/PeriodicBackupRunner.cs
+++ b/src/Raven.Server/Documents/PeriodicBackup/PeriodicBackupRunner.cs
@@ -635,7 +635,7 @@ namespace Raven.Server.Documents.PeriodicBackup
                 Thread.CurrentThread.Priority = ThreadPriority.BelowNormal;
                 NativeMemory.EnsureRegistered();
 
-                using (_database.PreventFromUnloading())
+                using (_database.PreventFromUnloadingByIdleOperations())
                 {
                     backupResult = (BackupResult)backupTask.RunPeriodicBackup(onProgress);
                     tcs.SetResult(backupResult);

--- a/test/SlowTests/Issues/RavenDB_10991.cs
+++ b/test/SlowTests/Issues/RavenDB_10991.cs
@@ -44,7 +44,7 @@ namespace SlowTests.Issues
 
                     database.LastAccessTime = DateTime.MinValue;
 
-                    using (database.PreventFromUnloading()) // should prevent from unloading
+                    using (database.PreventFromUnloadingByIdleOperations()) // should prevent from unloading
                         Server.ServerStore.IdleOperations(null);
 
                     Assert.True(landlord.LastRecentlyUsed.TryGetValue(name, out _));

--- a/test/SlowTests/Issues/RavenDB_17200.cs
+++ b/test/SlowTests/Issues/RavenDB_17200.cs
@@ -1,0 +1,39 @@
+﻿using FastTests;
+using Raven.Client.Documents.Operations.Indexes;
+using Raven.Client.ServerWide;
+using Raven.Client.ServerWide.Operations;
+using Tests.Infrastructure;
+using Xunit;
+using Xunit.Abstractions;
+
+namespace SlowTests.Issues
+{
+    public class RavenDB_17200 : RavenTestBase
+    {
+
+        public RavenDB_17200(ITestOutputHelper output) : base(output)
+        {
+        }
+
+        [Fact]
+        public void Should_Not_Throw_Nre_When_Compacting_Not_Existing_Index()
+        {
+            using (var documentStore = GetDocumentStore(new Options
+            {
+                RunInMemory = false
+            }))
+            {
+                var settings = new CompactSettings
+                {
+                    DatabaseName = documentStore.Database,
+                    Documents = true,
+                    Indexes = new[] { "DoesNotExist" }
+                };
+
+                var operation = documentStore.Maintenance.Server.Send(new CompactDatabaseOperation(settings));
+                operation.WaitForCompletion();
+            }
+        }
+
+    }
+}


### PR DESCRIPTION
### Issue link

https://issues.hibernatingrhinos.com/issue/RavenDB-17200

### Additional description

- prevent database from being unloaded during index compaction
- check if index exist to prevent NRE when compacting indexes - this can happen for auto indexes when they are merged and for replacement

### Type of change

- Bug fix

### How risky is the change?

- Low 

### Backward compatibility

- Not relevant

### Is it platform specific issue?

- No

### Documentation update

- No documentation update is needed 

### Testing 

- Tests have been added that prove the fix is effective or that the feature works

### Is there any existing behavior change of other features due to this change?

- No

### UI work

- No UI work is needed
