### PR TITLE
RavenDB-17206 Collection size limitation when using "Not In" clause

### DIFF
--- a/test/SlowTests/Issues/RavenDB-17206.cs
+++ b/test/SlowTests/Issues/RavenDB-17206.cs
@@ -1,0 +1,89 @@
+using System.Linq;
+using System.Threading.Tasks;
+using FastTests;
+using Raven.Client.Documents;
+using Raven.Client.Documents.Indexes;
+using Raven.Client.Documents.Linq;
+using Xunit;
+using Xunit.Abstractions;
+
+namespace SlowTests.Issues
+{
+    public class RavenDB_17206 : RavenTestBase
+    {
+        public RavenDB_17206(ITestOutputHelper output) : base(output)
+        {
+        }
+
+        [Fact]
+        public async Task EntryIsNotPresentInMapReduceIndexWithMoreThan128Terms()
+        {
+            const string locationIdentifier = "locations/12345-A";
+
+            using var store = GetDocumentStore();
+            await store.ExecuteIndexAsync(new SearchIndex());
+
+            using var session = store.OpenAsyncSession();
+            session.Advanced.MaxNumberOfRequestsPerSession = 10000;
+            await session.StoreAsync(new TestObj
+            {
+                Id = locationIdentifier,
+                Prop = "-1"
+            });
+
+            await session.SaveChangesAsync();
+
+            WaitForIndexing(store);
+            WaitForUserToContinueTheTest(store);
+
+            const int i = 1000;
+            var list = new[] { "-1" }.Concat(Enumerable.Range(0, i).Select(i => i.ToString()).ToArray());
+            var ravenQueryable = session
+                .Query<SearchIndex.Entry, SearchIndex>()
+                .Where(x => x.Prop.In(list));
+            var location = await ravenQueryable
+                .OfType<TestObj>()
+                .FirstOrDefaultAsync();
+
+            Assert.NotNull(location);
+
+            list = Enumerable.Range(0, i).Select(i => i.ToString()).ToArray();
+            ravenQueryable = session
+                .Query<SearchIndex.Entry, SearchIndex>()
+                .Where(x => x.Prop.In(list) == false);
+            location = await ravenQueryable
+                .OfType<TestObj>()
+                .FirstOrDefaultAsync();
+
+            Assert.True(location != null, $"Max Length {i}"); // <--------------- Fails here --------------
+        }
+
+        private class SearchIndex : AbstractMultiMapIndexCreationTask<SearchIndex.Entry>
+        {
+            public override string IndexName => "Search";
+
+            public SearchIndex()
+            {
+                AddMap<TestObj>(locations =>
+                    from location in locations
+
+                    select new Entry
+                    {
+                        Prop = location.Prop,
+                    }
+                );
+            }
+
+            public class Entry
+            {
+                public string Prop { get; set; }
+            }
+        }
+
+        private class TestObj
+        {
+            public string Id { get; set; }
+            public string Prop { get; set; }
+        }
+    }
+}


### PR DESCRIPTION
### Issue link

https://issues.hibernatingrhinos.com/issue/RavenDB-17206

### Additional description

A negation on `in` query will result in querying of `DocID` scorer before calling to `NextDoc()`, we used to return `0` there if there were no results, which would match a valid document.

Now we'll return the proper value for the query, in this case, that there are no results. We do that by remember the last value, so we can properly `DocID()` without extra costs. 

### Type of change

- Bug fix

### How risky is the change?

- Moderate 
Changes query behavior, but it is an area well covered with tests.

### Testing 

Added tests to this issue, and relying on already existing tests.