### PR TITLE
RavenDB-17209 removing Debug assertions because Azure and AWS streams do not support getting length and checking the position

### DIFF
--- a/src/Raven.Server/Documents/PeriodicBackup/Restore/RestoreBackupTaskBase.cs
+++ b/src/Raven.Server/Documents/PeriodicBackup/Restore/RestoreBackupTaskBase.cs
@@ -139,12 +139,8 @@ namespace Raven.Server.Documents.PeriodicBackup.Restore
 
             try
             {
-                Debug.Assert(stream.Position == 0, "stream.Position == 0");
-                
                 await stream.CopyToAsync(file);
                 file.Seek(0, SeekOrigin.Begin);
-
-                Debug.Assert(stream.Length == file.Length, "stream.Length == file.Length");
 
                 return file;
             }


### PR DESCRIPTION
### Issue link

https://issues.hibernatingrhinos.com/issue/RavenDB-17209
https://issues.hibernatingrhinos.com/issue/RavenDB-17210

### Type of change

- Regression bug fix

### How risky is the change?

- Low 

### Backward compatibility

- Not relevant

### Is it platform specific issue?

- No

### Documentation update

- No documentation update is needed 

### Testing 

- Fixes `SlowTests.Server.Documents.PeriodicBackup.Restore.RestoreFromAzure.can_create_azure_snapshot_and_restore_using_restore_point`
- Fixes `SlowTests.Server.Documents.PeriodicBackup.Restore.RestoreFromAwsS3`

### Is there any existing behavior change of other features due to this change?

- No

### UI work

- No UI work is needed
