### PR TITLE
RavenDB-16609

### DIFF
--- a/src/Raven.Server/Monitoring/Snmp/Objects/Database/5.1/5.1.9/TotalDatabaseWritesPerSecond.cs
+++ b/src/Raven.Server/Monitoring/Snmp/Objects/Database/5.1/5.1.9/TotalDatabaseWritesPerSecond.cs
@@ -1,0 +1,32 @@
+using Lextm.SharpSnmpLib;
+using Raven.Server.Documents;
+using Raven.Server.ServerWide;
+
+namespace Raven.Server.Monitoring.Snmp.Objects.Database
+{
+    public class TotalDatabaseWritesPerSecond : DatabaseBase<Gauge32>
+    {
+        public TotalDatabaseWritesPerSecond(ServerStore serverStore)
+            : base(serverStore, SnmpOids.Databases.General.TotalWritesPerSecond)
+        {
+        }
+
+        protected override Gauge32 GetData()
+        {
+            var count = 0;
+            foreach (var database in GetLoadedDatabases())
+                count += GetCountSafely(database, GetCount);
+
+            return new Gauge32(count);
+        }
+
+        private static int GetCount(DocumentDatabase database)
+        {
+            var value = database.Metrics.Docs.PutsPerSec.OneMinuteRate
+                        + database.Metrics.Attachments.PutsPerSec.OneMinuteRate
+                        + database.Metrics.Counters.PutsPerSec.OneMinuteRate;
+
+            return (int)value;
+        }
+    }
+}

--- a/src/Raven.Server/Monitoring/Snmp/Objects/Database/5.2.X/6/DatabaseDataWrittenPerSecond.cs
+++ b/src/Raven.Server/Monitoring/Snmp/Objects/Database/5.2.X/6/DatabaseDataWrittenPerSecond.cs
@@ -1,0 +1,33 @@
+// -----------------------------------------------------------------------
+//  <copyright file="DatabaseOpenedCount.cs" company="Hibernating Rhinos LTD">
+//      Copyright (c) Hibernating Rhinos LTD. All rights reserved.
+//  </copyright>
+// -----------------------------------------------------------------------
+
+using Lextm.SharpSnmpLib;
+using Raven.Server.Documents;
+
+namespace Raven.Server.Monitoring.Snmp.Objects.Database
+{
+    public class DatabaseDataWrittenPerSecond : DatabaseScalarObjectBase<Gauge32>
+    {
+        public DatabaseDataWrittenPerSecond(string databaseName, DatabasesLandlord landlord, int index)
+            : base(databaseName, landlord, SnmpOids.Databases.DataWrittenPerSecond, index)
+        {
+        }
+
+        protected override Gauge32 GetData(DocumentDatabase database)
+        {
+            return new Gauge32(GetCount(database));
+        }
+
+        private static int GetCount(DocumentDatabase database)
+        {
+            var value = database.Metrics.Docs.BytesPutsPerSec.OneMinuteRate
+                        + database.Metrics.Attachments.BytesPutsPerSec.OneMinuteRate
+                        + database.Metrics.Counters.BytesPutsPerSec.OneMinuteRate;
+
+            return (int)value;
+        }
+    }
+}

--- a/src/Raven.Server/Monitoring/Snmp/Objects/Database/5.2.X/6/DatabaseWritesPerSecond.cs
+++ b/src/Raven.Server/Monitoring/Snmp/Objects/Database/5.2.X/6/DatabaseWritesPerSecond.cs
@@ -1,0 +1,33 @@
+// -----------------------------------------------------------------------
+//  <copyright file="DatabaseOpenedCount.cs" company="Hibernating Rhinos LTD">
+//      Copyright (c) Hibernating Rhinos LTD. All rights reserved.
+//  </copyright>
+// -----------------------------------------------------------------------
+
+using Lextm.SharpSnmpLib;
+using Raven.Server.Documents;
+
+namespace Raven.Server.Monitoring.Snmp.Objects.Database
+{
+    public class DatabaseWritesPerSecond : DatabaseScalarObjectBase<Gauge32>
+    {
+        public DatabaseWritesPerSecond(string databaseName, DatabasesLandlord landlord, int index)
+            : base(databaseName, landlord, SnmpOids.Databases.WritesPerSecond, index)
+        {
+        }
+
+        protected override Gauge32 GetData(DocumentDatabase database)
+        {
+            return new Gauge32(GetCount(database));
+        }
+
+        private static int GetCount(DocumentDatabase database)
+        {
+            var value = database.Metrics.Docs.PutsPerSec.OneMinuteRate
+                        + database.Metrics.Attachments.PutsPerSec.OneMinuteRate
+                        + database.Metrics.Counters.PutsPerSec.OneMinuteRate;
+
+            return (int)value;
+        }
+    }
+}

--- a/src/Raven.Server/Monitoring/Snmp/Objects/Server/1.7/ServerRequestAverageDuration.cs
+++ b/src/Raven.Server/Monitoring/Snmp/Objects/Server/1.7/ServerRequestAverageDuration.cs
@@ -1,0 +1,21 @@
+using Lextm.SharpSnmpLib;
+using Raven.Server.Utils;
+
+namespace Raven.Server.Monitoring.Snmp.Objects.Server
+{
+    public class ServerRequestAverageDuration : ScalarObjectBase<Gauge32>
+    {
+        private readonly MetricCounters _metrics;
+
+        public ServerRequestAverageDuration(MetricCounters metrics)
+            : base(SnmpOids.Server.RequestAverageDuration)
+        {
+            _metrics = metrics;
+        }
+
+        protected override Gauge32 GetData()
+        {
+            return new Gauge32((int)_metrics.Requests.AverageDuration.GetRate());
+        }
+    }
+}

--- a/src/Raven.Server/Monitoring/Snmp/SnmpDatabase.cs
+++ b/src/Raven.Server/Monitoring/Snmp/SnmpDatabase.cs
@@ -92,6 +92,9 @@ namespace Raven.Server.Monitoring.Snmp
             _objectStore.Add(new DatabaseTotalStorageSize(_databaseName, _databaseLandlord, _databaseIndex));
             _objectStore.Add(new DatabaseStorageDiskRemainingSpace(_databaseName, _databaseLandlord, _databaseIndex));
 
+            _objectStore.Add(new DatabaseWritesPerSecond(_databaseName, _databaseLandlord, _databaseIndex));
+            _objectStore.Add(new DatabaseDataWrittenPerSecond(_databaseName, _databaseLandlord, _databaseIndex));
+
             //AddIndexesFromMappingDocument();
         }
 

--- a/src/Raven.Server/Monitoring/Snmp/SnmpOids.cs
+++ b/src/Raven.Server/Monitoring/Snmp/SnmpOids.cs
@@ -459,6 +459,12 @@ namespace Raven.Server.Monitoring.Snmp
                 [Description("Number of reduces per second for map-reduce indexes (one minute rate) in all loaded databases")]
                 public const string TotalMapReduceIndexReducedPerSecond = "5.1.8.3";
 
+                [Description("Number of writes (documents, attachments, counters) in all loaded databases")]
+                public const string TotalWritesPerSecond = "5.1.9.1";
+
+                [Description("Number of bytes written (documents, attachments, counters) in all loaded databases")]
+                public const string TotalDataWrittenPerSecond = "5.1.9.2";
+
                 public static DynamicJsonArray ToJson()
                 {
                     var array = new DynamicJsonArray();

--- a/src/Raven.Server/Monitoring/Snmp/SnmpOids.cs
+++ b/src/Raven.Server/Monitoring/Snmp/SnmpOids.cs
@@ -337,6 +337,12 @@ namespace Raven.Server.Monitoring.Snmp
             [Description("Number of error indexes")]
             public const string NumberOfErrorIndexes = "5.2.{0}.5.6";
 
+            [Description("Number of writes (documents, attachments, counters)")]
+            public const string WritesPerSecond = "5.2.{0}.6.1";
+
+            [Description("Number of bytes written (documents, attachments, counters)")]
+            public const string DataWrittenPerSecond = "5.2.{0}.6.2";
+
             public class Indexes
             {
                 private Indexes()

--- a/src/Raven.Server/Monitoring/Snmp/SnmpOids.cs
+++ b/src/Raven.Server/Monitoring/Snmp/SnmpOids.cs
@@ -116,6 +116,9 @@ namespace Raven.Server.Monitoring.Snmp
             [Description("Number of requests per second (one minute rate)")]
             public const string RequestsPerSecond = "1.7.3";
 
+            [Description("Average request time in milliseconds")]
+            public const string RequestAverageDuration = "1.7.4";
+
             [Description("Server last request time")]
             public const string LastRequestTime = "1.8";
 

--- a/src/Raven.Server/Monitoring/Snmp/SnmpWatcher.cs
+++ b/src/Raven.Server/Monitoring/Snmp/SnmpWatcher.cs
@@ -429,6 +429,9 @@ namespace Raven.Server.Monitoring.Snmp
             store.Add(new TotalDatabaseMapReduceIndexMappedPerSecond(server.ServerStore));
             store.Add(new TotalDatabaseMapReduceIndexReducedPerSecond(server.ServerStore));
 
+            store.Add(new TotalDatabaseWritesPerSecond(server.ServerStore));
+            store.Add(new TotalDatabaseDataWrittenPerSecond(server.ServerStore));
+
             store.Add(new ClusterNodeState(server.ServerStore));
             store.Add(new ClusterNodeTag(server.ServerStore));
 

--- a/src/Raven.Server/Monitoring/Snmp/SnmpWatcher.cs
+++ b/src/Raven.Server/Monitoring/Snmp/SnmpWatcher.cs
@@ -386,6 +386,7 @@ namespace Raven.Server.Monitoring.Snmp
             store.Add(new ServerConcurrentRequests(server.Metrics));
             store.Add(new ServerTotalRequests(server.Metrics));
             store.Add(new ServerRequestsPerSecond(server.Metrics));
+            store.Add(new ServerRequestAverageDuration(server.Metrics));
 
             store.Add(new ProcessCpu(server.MetricCacher, server.CpuUsageCalculator));
             store.Add(new MachineCpu(server.MetricCacher, server.CpuUsageCalculator));


### PR DESCRIPTION
### Issue link

https://issues.hibernatingrhinos.com/issue/RavenDB-16609

### Additional description

Exposed:
- Writes Per Second per database (1min rate)
- Bytes Written Per Second per database (1min rate)
- Total Writes Per Second for all databases (1min rate)
- Total Bytes Written Per Second for all databases (1min rate)
- Request Average Duration (server-wide) - per database was already exposed

### Type of change

- New feature

### How risky is the change?

- Low 

### Backward compatibility

- Not relevant

### Is it platform specific issue?

- No

### Documentation update

- This change requires a documentation update. Please mark the issue on YouTrack using `Documentation Required` tag.

### Testing 

- It has been verified by manual testing

### Is there any existing behavior change of other features due to this change?

- No

### UI work

- No UI work is needed
