### PR TITLE
RavenDB-17198

### DIFF
--- a/scripts/updateFrameworkVersion.ps1
+++ b/scripts/updateFrameworkVersion.ps1
@@ -8,9 +8,9 @@ function UpdateCsprojTargetFrameworkVersion ( $csproj, $version ) {
 }
 
 function UpdateServerOptions ( $serverOptionsFile, $version ) {
-    $versionPattern = [regex]'(?sm)public string FrameworkVersion { get; set; } = "[A-Za-z0-9-\.\r\n\s]*";'
+    $versionPattern = [regex]'(?sm)public string FrameworkVersion { get; set; } = "[A-Za-z0-9-\.\r\n\s\+]*";'
     $result = [System.IO.File]::ReadAllText($serverOptionsFile)
-    $result = $versionPattern.Replace($result, "public string FrameworkVersion { get; set; } = ""$version"";")
+    $result = $versionPattern.Replace($result, "public string FrameworkVersion { get; set; } = ""$version+"";")
     [System.IO.File]::WriteAllText($serverOptionsFile, $result, [System.Text.Encoding]::UTF8)
 }
 

--- a/src/Raven.Embedded/ServerOptions.cs
+++ b/src/Raven.Embedded/ServerOptions.cs
@@ -11,7 +11,7 @@ namespace Raven.Embedded
 
         internal static string AltServerDirectory = Path.Combine(AppContext.BaseDirectory, "bin", "RavenDBServer");
 
-        public string FrameworkVersion { get; set; } = "3.1.19";
+        public string FrameworkVersion { get; set; } = "3.1.18+";
 
         public string LogsPath { get; set; } = Path.Combine(AppContext.BaseDirectory, "RavenDB", "Logs");
 

--- a/src/Raven.Embedded/ServerOptions.cs
+++ b/src/Raven.Embedded/ServerOptions.cs
@@ -11,7 +11,7 @@ namespace Raven.Embedded
 
         internal static string AltServerDirectory = Path.Combine(AppContext.BaseDirectory, "bin", "RavenDBServer");
 
-        public string FrameworkVersion { get; set; } = "3.1.18+";
+        public string FrameworkVersion { get; set; } = "3.1.19+";
 
         public string LogsPath { get; set; } = Path.Combine(AppContext.BaseDirectory, "RavenDB", "Logs");
 

--- a/test/EmbeddedTests/RuntimeFrameworkVersionMatcherTests.cs
+++ b/test/EmbeddedTests/RuntimeFrameworkVersionMatcherTests.cs
@@ -106,7 +106,12 @@ namespace EmbeddedTests
             Assert.Equal("3.1.1+", runtime.ToString());
             Assert.Equal("3.1.3", RuntimeFrameworkVersionMatcher.Match(runtime, runtimes));
 
-            var e = Assert.Throws<InvalidOperationException>(() => new RuntimeFrameworkVersionMatcher.RuntimeFrameworkVersion("6.0.0+-preview.6.21352.12"));
+            runtime = new RuntimeFrameworkVersionMatcher.RuntimeFrameworkVersion("3.1.4+");
+            Assert.Equal("3.1.4+", runtime.ToString());
+            var e = Assert.Throws<InvalidOperationException>(() => RuntimeFrameworkVersionMatcher.Match(runtime, runtimes));
+            Assert.Contains("Could not find a matching runtime for '3.1.4+'. Available runtimes:", e.Message);
+
+            e = Assert.Throws<InvalidOperationException>(() => new RuntimeFrameworkVersionMatcher.RuntimeFrameworkVersion("6.0.0+-preview.6.21352.12"));
             Assert.Equal("Cannot set 'Patch' with value '0+' because '+' is not allowed when Suffix ('preview.6.21352.12') is set.", e.Message);
 
             e = Assert.Throws<InvalidOperationException>(() => new RuntimeFrameworkVersionMatcher.RuntimeFrameworkVersion("6+"));


### PR DESCRIPTION
### Issue link

https://issues.hibernatingrhinos.com/issue/RavenDB-17198

### Additional description

Added support for using '+' in Patch in ServerOptions.FrameworkVersion

### Type of change

- New feature

### How risky is the change?

- Moderate - default was changed to the one with '+' - if matching will not work as expected Embedded servers will not go up

### Backward compatibility

- Non breaking change

### Is it platform specific issue?

- No

### Documentation update

- No documentation update is needed 

### Testing 

- Tests have been added that prove the fix is effective or that the feature works

### Is there any existing behavior change of other features due to this change?

- Yes. Embedded will match from now on to the newest version runtime

### UI work

- No UI work is needed
