### PR TITLE
RavenDB-17225 removed space from Tombstones.RetentionTimeWithReplicat…

### DIFF
--- a/src/Raven.Server/Config/Attributes/ConfigurationEntryAttribute.cs
+++ b/src/Raven.Server/Config/Attributes/ConfigurationEntryAttribute.cs
@@ -12,8 +12,17 @@ namespace Raven.Server.Config.Attributes
     [AttributeUsage(AttributeTargets.Property, AllowMultiple = true)]
     public class ConfigurationEntryAttribute : Attribute
     {
-        public ConfigurationEntryAttribute(string key, ConfigurationEntryScope scope, [CallerLineNumber]int order = 0, bool setDefaultValueIfNeeded = true, bool isSecured = false) // the default order is the order of declaration in a configuration class
+        public ConfigurationEntryAttribute(string key, ConfigurationEntryScope scope, [CallerLineNumber] int order = 0, bool setDefaultValueIfNeeded = true, bool isSecured = false) // the default order is the order of declaration in a configuration class
         {
+            if (string.IsNullOrWhiteSpace(key))
+                throw new ArgumentNullException(nameof(key));
+
+#if DEBUG
+            var trimmedKey = key.Trim();
+            if (key != trimmedKey)
+                throw new InvalidOperationException($"Configuration Key '{key}' contains white-space characters.");
+#endif
+
             Key = key;
             Order = order;
             SetDefaultValueIfNeeded = setDefaultValueIfNeeded;

--- a/src/Raven.Server/Config/Categories/TombstoneConfiguration.cs
+++ b/src/Raven.Server/Config/Categories/TombstoneConfiguration.cs
@@ -16,7 +16,7 @@ namespace Raven.Server.Config.Categories
 
         [DefaultValue(336)]
         [TimeUnit(TimeUnit.Hours)]
-        [ConfigurationEntry("Tombstones.RetentionTimeWithReplicationHubInHrs ", ConfigurationEntryScope.ServerWideOrPerDatabase)]
+        [ConfigurationEntry("Tombstones.RetentionTimeWithReplicationHubInHrs", ConfigurationEntryScope.ServerWideOrPerDatabase)]
         [Description("Time (in hours) to save tombsones when we have hub replication definition.")]
         public TimeSetting RetentionTimeWithReplicationHub { get; set; }
 


### PR DESCRIPTION
### Issue link

https://issues.hibernatingrhinos.com/issue/RavenDB-17225

### Additional description

Fixed 'Tombstones.RetentionTimeWithReplicationHubInHrs' key and added additional validation (in DEBUG) to prevent that from happening in the future.

### Type of change

- Bug fix

### How risky is the change?

- Low 

### Backward compatibility

- Not relevant

### Is it platform specific issue?

- No

### Documentation update

- No documentation update is needed 

### Testing 

- It has been verified by manual testing

### Is there any existing behavior change of other features due to this change?

- No

### UI work

- No UI work is needed
