### PR TITLE
RavenDB-17226 exit fast when we have a catastrophic failure in server storage - this will allow services to restart

### DIFF
--- a/src/Raven.Server/ServerWide/ServerStore.cs
+++ b/src/Raven.Server/ServerWide/ServerStore.cs
@@ -187,16 +187,19 @@ namespace Raven.Server.ServerWide
 
             CatastrophicFailureNotification = new CatastrophicFailureNotification((envId, path, exception, stacktrace) =>
             {
+                var message = $"Catastrophic failure in server storage located at '{path}', StackTrace: '{stacktrace}'";
+
                 try
                 {
                     if (Logger.IsOperationsEnabled)
-                        Logger.OperationsAsync($"Catastrophic failure in server storage located at '{path}', StackTrace:'{stacktrace}'", exception).Wait(TimeSpan.FromSeconds(1));
+                        Logger.OperationsAsync(message, exception).Wait(TimeSpan.FromSeconds(1));
                 }
                 catch
                 {
                     // nothing we can do
                 }
 
+                Console.Error.WriteLine($"{message}. Exception: {exception}");
                 Environment.Exit(29); // ERROR_WRITE_FAULT
             });
         }

--- a/src/Raven.Server/ServerWide/ServerStore.cs
+++ b/src/Raven.Server/ServerWide/ServerStore.cs
@@ -76,8 +76,8 @@ using Sparrow.Server.Utils;
 using Sparrow.Threading;
 using Sparrow.Utils;
 using Voron;
+using Voron.Exceptions;
 using Constants = Raven.Client.Constants;
-using Index = Raven.Server.Documents.Indexes.Index;
 
 namespace Raven.Server.ServerWide
 {
@@ -131,6 +131,8 @@ namespace Raven.Server.ServerWide
 
         public Operations Operations { get; }
 
+        public CatastrophicFailureNotification CatastrophicFailureNotification { get; }
+
         public ServerStore(RavenConfiguration configuration, RavenServer server)
         {
             // we want our servers to be robust get early errors about such issues
@@ -182,6 +184,21 @@ namespace Raven.Server.ServerWide
 
             if (Configuration.Indexing.MaxNumberOfConcurrentlyRunningIndexes != null)
                 ServerWideConcurrentlyRunningIndexesLock = new FifoSemaphore(Configuration.Indexing.MaxNumberOfConcurrentlyRunningIndexes.Value);
+
+            CatastrophicFailureNotification = new CatastrophicFailureNotification((envId, path, exception, stacktrace) =>
+            {
+                try
+                {
+                    if (Logger.IsOperationsEnabled)
+                        Logger.OperationsAsync($"Catastrophic failure in server storage located at '{path}', StackTrace:'{stacktrace}'", exception).Wait(TimeSpan.FromSeconds(1));
+                }
+                catch
+                {
+                    // nothing we can do
+                }
+
+                Environment.Exit(29); // ERROR_WRITE_FAULT
+            });
         }
 
         internal readonly FifoSemaphore ServerWideConcurrentlyRunningIndexesLock;
@@ -528,11 +545,11 @@ namespace Raven.Server.ServerWide
             StorageEnvironmentOptions options;
             if (Configuration.Core.RunInMemory)
             {
-                options = StorageEnvironmentOptions.CreateMemoryOnly();
+                options = StorageEnvironmentOptions.CreateMemoryOnly(null, null, null, CatastrophicFailureNotification);
             }
             else
             {
-                options = StorageEnvironmentOptions.ForPath(path.FullPath, null, null, IoChanges, null);
+                options = StorageEnvironmentOptions.ForPath(path.FullPath, null, null, IoChanges, CatastrophicFailureNotification);
                 var secretKey = Path.Combine(path.FullPath, "secret.key.encrypted");
                 if (File.Exists(secretKey))
                 {
@@ -657,7 +674,7 @@ namespace Raven.Server.ServerWide
             options.ForceUsing32BitsPager = Configuration.Storage.ForceUsing32BitsPager;
             options.EnablePrefetching = Configuration.Storage.EnablePrefetching;
             options.DiscardVirtualMemory = Configuration.Storage.DiscardVirtualMemory;
-            
+
             if (Configuration.Storage.MaxScratchBufferSize.HasValue)
                 options.MaxScratchBufferSize = Configuration.Storage.MaxScratchBufferSize.Value.GetValue(SizeUnit.Bytes);
             options.PrefetchSegmentSize = Configuration.Storage.PrefetchBatchSize.GetValue(SizeUnit.Bytes);


### PR DESCRIPTION
### Issue link

https://issues.hibernatingrhinos.com/issue/RavenDB-17226

### Additional description

Immediately exits the process when catastrophic failure occurs in server storage to disallow running database in an invalid state.

### Type of change

- Bug fix

### How risky is the change?

- Low 

### Backward compatibility

- Non breaking change

### Is it platform specific issue?

- No

### Documentation update

- No documentation update is needed 

### Testing 

- Will coordinate testing with @gregolsky 

### Is there any existing behavior change of other features due to this change?

- Yes. Program will stop working after catastrophic failure. Services should restart automatically.

### UI work

- No UI work is needed
