### PR TITLE
RavenDB-17228 Corax - support AllTermsMatch

### DIFF
--- a/src/Corax/IndexSearcher.cs
+++ b/src/Corax/IndexSearcher.cs
@@ -61,6 +61,11 @@ namespace Corax
             return Encoding.UTF8.GetString(data.Slice(len, size));
         }
 
+        public AllEntriesMatch AllEntries()
+        {
+            return new AllEntriesMatch(_transaction);
+        }
+
         // foreach term in 2010 .. 2020
         //     yield return TermMatch(field, term)// <-- one term , not sorted
 

--- a/src/Corax/Queries/AllEntriesMatch.cs
+++ b/src/Corax/Queries/AllEntriesMatch.cs
@@ -1,0 +1,68 @@
+﻿using System;
+using Voron;
+using Voron.Data.Containers;
+using Voron.Data.Sets;
+using Voron.Global;
+using Voron.Impl;
+
+namespace Corax.Queries
+{
+    public struct AllEntriesMatch : IQueryMatch
+    {
+        private readonly Transaction _tx;
+        private readonly long _count;
+        private Set.Iterator _entriesPagesIt;
+        private int _offset;
+        private Page _currentPage;
+        private long _entriesContainerId;
+
+        public unsafe AllEntriesMatch(Transaction tx)
+        {
+            _tx = tx;
+            _count = tx.LowLevelTransaction.RootObjects.ReadInt64(IndexWriter.NumberOfEntriesSlice) ?? 0;
+            _entriesContainerId = tx.OpenContainer(IndexWriter.EntriesContainerSlice);
+            _entriesPagesIt = Container.GetAllPagesSet(tx.LowLevelTransaction, _entriesContainerId).Iterate();
+            _offset = 0;
+            _currentPage = new Page(null);
+        }
+
+        public long Count => _count;
+        public QueryCountConfidence Confidence => QueryCountConfidence.High;
+        public unsafe int Fill(Span<long> matches)
+        {
+            while (true)
+            {
+                if (_currentPage.IsValid == false)
+                {
+                    if (_entriesPagesIt.MoveNext() == false)
+                    {
+                        return 0;
+                    }
+
+                    _currentPage = _tx.LowLevelTransaction.GetPage(_entriesPagesIt.Current);
+                    _offset = 0;
+                }
+            
+                var results = 0;
+                while (results + 1 < matches.Length)
+                {
+                    var read = Container.GetEntriesInto(_entriesContainerId, _offset, _currentPage, matches);
+                    if (read == 0)
+                    {
+                        _currentPage = new Page(null);
+                        break;
+                    }
+                    results += read;
+                    _offset += read;
+                }
+                return results;
+            }
+        }
+
+        public int AndWith(Span<long> prevMatches)
+        {
+            // this match *everything*, so ands with everything 
+            return prevMatches.Length;
+        }
+    }
+}

--- a/src/Voron/Impl/Transaction.cs
+++ b/src/Voron/Impl/Transaction.cs
@@ -152,7 +152,13 @@ namespace Voron.Impl
         public long OpenContainer(Slice name)
         {
             var exists = LowLevelTransaction.RootObjects.Read(name);
-            return exists?.Reader.ReadLittleEndianInt64() ?? Container.Create(LowLevelTransaction);
+            if (exists != null)
+            {
+                return exists.Reader.ReadLittleEndianInt64();
+            }
+            var id = Container.Create(LowLevelTransaction);
+            LowLevelTransaction.RootObjects.Add(name, id);
+            return id;
         }
 
         public Set OpenSet(string name)

--- a/test/FastTests/Corax/IndexSearcher.cs
+++ b/test/FastTests/Corax/IndexSearcher.cs
@@ -824,6 +824,39 @@ namespace FastTests.Corax
                 Assert.Equal(3, match.TotalResults);
             }
         }
+        
+        [Fact]
+        public void CanGetAllEntries()
+        {
+            var entry1 = new IndexSingleEntry
+            {
+                Id = "entry/1",
+                Content = "3"
+            };
+            var entry2 = new IndexEntry
+            {
+                Id = "entry/2",
+                Content = new string[] { "4", "2" },
+            };
+            var entry3 = new IndexSingleEntry
+            {
+                Id = "entry/3",
+                Content = "1"
+            };
+
+            IndexEntries(new[] { entry1, entry3 });
+            IndexEntries(new[] { entry2 });
+
+            using var searcher = new IndexSearcher(Env);
+            {
+                var all = searcher.AllEntries();
+                
+                Span<long> ids = stackalloc long[2];
+                Assert.Equal(2, all.Fill(ids));
+                Assert.Equal(1, all.Fill(ids));
+                Assert.Equal(0, all.Fill(ids));
+            }
+        }
 
         
         [Fact]


### PR DESCRIPTION
### Issue link

https://issues.hibernatingrhinos.com/issue/RavenDB-17228

### Additional description

Can now get all the entries in an index. We do that by iterating over the raw entries in the container. That happens to be in id order, but not guaranteed in general. 

Had to add a total number of entries in the index, since we weren't keeping track of that previously. 

### Remark

We still need to implement entry deletion

### Type of change

- New feature
