### PR TITLE
RavenDB-17232 Ensure we put the `Artificial` flag properly

### DIFF
--- a/src/Raven.Server/Documents/DocumentsStorage.cs
+++ b/src/Raven.Server/Documents/DocumentsStorage.cs
@@ -1439,6 +1439,14 @@ namespace Raven.Server.Documents
             return result;
         }
 
+        public DeleteOperationResult? Delete(DocumentsOperationContext context, string id, DocumentFlags flags)
+        {
+            using (DocumentIdWorker.GetSliceFromId(context, id, out Slice lowerId))
+            {
+                return Delete(context, lowerId, id, expectedChangeVector:null, documentFlags: flags);
+            }
+        }
+
         public DeleteOperationResult? Delete(DocumentsOperationContext context, string id, string expectedChangeVector)
         {
             using (DocumentIdWorker.GetSliceFromId(context, id, out Slice lowerId))

--- a/src/Raven.Server/Documents/Indexes/MapReduce/OutputToCollection/DeleteReduceOutputDocumentsCommand.cs
+++ b/src/Raven.Server/Documents/Indexes/MapReduce/OutputToCollection/DeleteReduceOutputDocumentsCommand.cs
@@ -8,20 +8,18 @@ using Sparrow.Json.Parsing;
 
 namespace Raven.Server.Documents.Indexes.MapReduce.OutputToCollection
 {
-    public class DeleteReduceOutputDocumentsCommand : TransactionOperationsMerger.MergedTransactionCommand
+    public class DeleteReduceOutputDocumentsCommand : OutputReduceAbstractCommand
     {
-        private readonly DocumentDatabase _database;
         private readonly string _documentsPrefix;
         private readonly int _batchSize;
         private readonly string _originalPattern = null;
         private readonly OutputReferencesPattern _originalPatternForReduceOutputReferences = null;
 
-        public DeleteReduceOutputDocumentsCommand(DocumentDatabase database, string documentsPrefix, string originalPattern, int batchSize)
+        public DeleteReduceOutputDocumentsCommand(DocumentDatabase database, string documentsPrefix, string originalPattern, int batchSize) : base(database)
         {
             if (OutputReduceToCollectionCommand.IsOutputDocumentPrefix(documentsPrefix) == false)
                 throw new ArgumentException($"Invalid prefix to delete: {documentsPrefix}", nameof(documentsPrefix));
 
-            _database = database;
             _documentsPrefix = documentsPrefix;
             _batchSize = batchSize;
 
@@ -126,9 +124,9 @@ namespace Raven.Server.Documents.Indexes.MapReduce.OutputToCollection
                             ThrowIdsPropertyNotFound(referenceDocument.Id);
 
                         if (updatedIds.Length == 0)
-                            _database.DocumentsStorage.Delete(context, referenceDocument.Id, null);
+                            ArtificialDelete(context, referenceDocument.Id);
                         else
-                            _database.DocumentsStorage.Put(context, referenceDocument.Id, null, doc);
+                            ArtificialPut(context, referenceDocument.Id, doc);
                     }
                 }
             }

--- a/test/SlowTests/Core/Indexing/OutputReduceToCollectionClusterTests.cs
+++ b/test/SlowTests/Core/Indexing/OutputReduceToCollectionClusterTests.cs
@@ -1,0 +1,97 @@
+﻿using System;
+using System.Collections.Generic;
+using System.Linq;
+using System.Threading.Tasks;
+using Orders;
+using Raven.Client.Documents.Indexes;
+using Raven.Client.Documents.Operations;
+using Raven.Client.Documents.Session;
+using Tests.Infrastructure;
+using Xunit;
+using Xunit.Abstractions;
+
+namespace SlowTests.Core.Indexing
+{
+    public class OutputReduceToCollectionClusterTests : ClusterTestBase
+    {
+        public OutputReduceToCollectionClusterTests(ITestOutputHelper output) : base(output)
+        {
+        }
+
+        [Fact]
+        public async Task CanUpdatePatternReferencesCollectionNameWithoutConflicts()
+        {
+            var cluster = await CreateRaftCluster(numberOfNodes: 3, watcherCluster: true, shouldRunInMemory: false);
+            using (var store = GetDocumentStore(new Options {Server = cluster.Leader, ReplicationFactor = 3}))
+            {
+                using (var session = store.OpenSession())
+                {
+                    PutOrders(session);
+
+                    session.SaveChanges();
+                }
+
+                var indexToCreate = new Orders_ProfitByProductAndOrderedAt(referencesCollectionName: "Foo");
+                await indexToCreate.ExecuteAsync(store);
+
+                WaitForIndexingInTheCluster(store);
+
+                indexToCreate = new Orders_ProfitByProductAndOrderedAt(referencesCollectionName: "Bar");
+                await indexToCreate.ExecuteAsync(store);
+
+                WaitForIndexingInTheCluster(store);
+
+                indexToCreate = new Orders_ProfitByProductAndOrderedAt(referencesCollectionName: "Baz");
+                await indexToCreate.ExecuteAsync(store);
+
+                WaitForIndexingInTheCluster(store);
+
+                var stats = await store.Maintenance.SendAsync(new GetStatisticsOperation());
+                Assert.Equal(0, stats.CountOfRevisionDocuments);
+            }
+        }
+
+        private static void PutOrders(IDocumentSession session)
+        {
+            session.Store(
+                new Order()
+                {
+                    OrderedAt = new DateTime(2019, 10, 26),
+                    Lines = new List<OrderLine>() {new OrderLine() {Product = "products/1",}, new OrderLine() {Product = "products/2",}}
+                }, "orders/1");
+
+            session.Store(new Order() {OrderedAt = new DateTime(2019, 10, 25), Lines = new List<OrderLine>() {new OrderLine() {Product = "products/2",}}}, "orders/2");
+
+            session.Store(new Order() {OrderedAt = new DateTime(2019, 10, 24), Lines = new List<OrderLine>() {new OrderLine() {Product = "products/1",}}}, "orders/3");
+        }
+
+        private class Orders_ProfitByProductAndOrderedAt : AbstractIndexCreationTask<Order, Orders_ProfitByProductAndOrderedAt.Result>
+        {
+            public class Result
+            {
+                public DateTime OrderedAt { get; set; }
+                public string Product { get; set; }
+                public decimal Profit { get; set; }
+            }
+
+            public Orders_ProfitByProductAndOrderedAt(string referencesCollectionName = null)
+            {
+                Map = orders => from order in orders
+                    from line in order.Lines
+                    select new { line.Product, order.OrderedAt, Profit = line.Quantity * line.PricePerUnit * (1 - line.Discount) };
+
+                Reduce = results => from r in results
+                    group r by new { r.OrderedAt, r.Product }
+                    into g
+                    select new { g.Key.Product, g.Key.OrderedAt, Profit = g.Sum(r => r.Profit) };
+
+                OutputReduceToCollection = "Profits";
+
+                PatternForOutputReduceToCollectionReferences = x => $"reports/daily/{x.OrderedAt:yyyy-MM-dd}";
+                
+                if (referencesCollectionName != null)
+                    PatternReferencesCollectionName = referencesCollectionName;
+            }
+        }
+    }
+}


### PR DESCRIPTION
### Issue link

https://issues.hibernatingrhinos.com/issue/RavenDB-17232

### Additional description

Any modification to an output collection should have the `Artificial` flag set to prevent it being replicated.

### Type of change

- Bug fix

### How risky is the change?

- Low 

### Backward compatibility

- Not relevant

### Is it platform specific issue?

- No

### Documentation update

- No documentation update is needed 

### Testing 

- Tests have been added that prove the fix is effective or that the feature works
- It has been verified by manual testing

### Is there any existing behavior change of other features due to this change?

- No

### UI work

- No UI work is needed
