### PR TITLE
RavenDB-16330 High memory consumption during storage report on encrypted database

### DIFF
--- a/src/Voron/Data/BTrees/Tree.Stream.cs
+++ b/src/Voron/Data/BTrees/Tree.Stream.cs
@@ -363,15 +363,11 @@ namespace Voron.Data.BTrees
                     if (buffer.Pointer != page.Pointer)
                         continue;
 
-                    if (buffer.OriginalSize != null && buffer.OriginalSize == 0)
-                    {
-                        // Pages that are marked with OriginalSize = 0 were separated from a larger allocation, we cannot free them directly.
-                        // The first page of the section will be returned and when it will be freed, all the other parts will be freed as well.
+                    if (CryptoPager.CanReturnBuffer(buffer) == false)
                         return;
-                    }
 
                     _llt._pageLocator.Reset(page.PageNumber);
-                    pagerStates.Remove(page.PageNumber);
+                    pagerStates.RemoveBuffer(page.PageNumber);
 
                     var cryptoPager = (CryptoPager)pager;
                     cryptoPager.ReturnBuffer(buffer);

--- a/src/Voron/Impl/LowLevelTransaction.cs
+++ b/src/Voron/Impl/LowLevelTransaction.cs
@@ -30,7 +30,7 @@ namespace Voron.Impl
         private readonly StorageEnvironment _env;
         private readonly long _id;
         private readonly ByteStringContext _allocator;
-        private readonly PageLocator _pageLocator;
+        internal readonly PageLocator _pageLocator;
         private bool _disposeAllocator;
         internal long DecompressedBufferBytes;
         internal TestingStuff _forTestingPurposes;

--- a/src/Voron/Impl/Paging/CryptoPager.cs
+++ b/src/Voron/Impl/Paging/CryptoPager.cs
@@ -34,14 +34,15 @@ namespace Voron.Impl.Paging
         }
 
         [MethodImpl(MethodImplOptions.AggressiveInlining)]
-        public bool TryGetValue(long i, out EncryptionBuffer value)
+        public bool TryGetValue(long pageNumber, out EncryptionBuffer value)
         {
-            return _loadedBuffers.TryGetValue(i, out value);
+            return _loadedBuffers.TryGetValue(pageNumber, out value);
         }
 
-        public bool Remove(long i)
+        [MethodImpl(MethodImplOptions.AggressiveInlining)]
+        public bool RemoveBuffer(long pageNumber)
         {
-            return _loadedBuffers.Remove(i);
+            return _loadedBuffers.Remove(pageNumber);
         }
 
         public EncryptionBuffer this[long index]
@@ -252,13 +253,13 @@ namespace Voron.Impl.Paging
                     AllocatingThread = encBuffer.AllocatingThread
                 };
 
-                if (i < actualNumberOfAllocatedScratchPages) 
+                if (i < actualNumberOfAllocatedScratchPages)
                 {
                     // when we commit the tx, the pager will realize that we need to write this page
 
                     // we do this only for the encryption buffers are are going to be in use - we might allocate more under the covers because we're adjusting the size to the power of 2
                     // we must not encrypt such extra allocated memory because we might have garbage there resulting in segmentation fault on attempt to encrypt that
-                    
+
                     buffer.Modified = true;
                 }
 
@@ -361,15 +362,23 @@ namespace Voron.Impl.Paging
 
             foreach (var buffer in state)
             {
-                if (buffer.Value.OriginalSize != null && buffer.Value.OriginalSize == 0)
-                {
-                    // Pages that are marked with OriginalSize = 0 were separated from a larger allocation, we cannot free them directly.
-                    // The first page of the section will be returned and when it will be freed, all the other parts will be freed as well.
+                if (CanReturnBuffer(buffer.Value) == false)
                     continue;
-                }
 
                 ReturnBuffer(buffer.Value);
             }
+        }
+
+        internal static bool CanReturnBuffer(EncryptionBuffer buffer)
+        {
+            if (buffer.OriginalSize != null && buffer.OriginalSize == 0)
+            {
+                // Pages that are marked with OriginalSize = 0 were separated from a larger allocation, we cannot free them directly.
+                // The first page of the section will be returned and when it will be freed, all the other parts will be freed as well.
+                return false;
+            }
+
+            return true;
         }
 
         internal void ReturnBuffer(EncryptionBuffer buffer)

--- a/src/Voron/Impl/Paging/CryptoPager.cs
+++ b/src/Voron/Impl/Paging/CryptoPager.cs
@@ -39,6 +39,11 @@ namespace Voron.Impl.Paging
             return _loadedBuffers.TryGetValue(i, out value);
         }
 
+        public bool Remove(long i)
+        {
+            return _loadedBuffers.Remove(i);
+        }
+
         public EncryptionBuffer this[long index]
         {
             get => _loadedBuffers[index];
@@ -367,7 +372,7 @@ namespace Voron.Impl.Paging
             }
         }
 
-        private void ReturnBuffer(EncryptionBuffer buffer)
+        internal void ReturnBuffer(EncryptionBuffer buffer)
         {
             if (buffer.OriginalSize != null && buffer.OriginalSize != 0)
             {


### PR DESCRIPTION
### Issue link

https://issues.hibernatingrhinos.com/issue/RavenDB-16330

### Additional description

The problem is related to the fact that storage reports retrieves Stream Info for all of the streams, which in encrypted database causes a lot of additional allocations, because each page needs to be decrypted first. The solution is to retrieve the decrypted page, read all necessary info from it and then release the encryption buffer immediatelly.

### Type of change

- Optimization

### How risky is the change?

- Low (

### Backward compatibility

- Non breaking change

### Is it platform specific issue?

- No

### Documentation update

- No documentation update is needed 

### Testing 

- It has been verified by manual testing

### Is there any existing behavior change of other features due to this change?

- No

### UI work

- No UI work is needed
