### PR TITLE
RavenDB-17109 Provide number of affected documents *before* executing…

### DIFF
--- a/src/Raven.Studio/typescript/models/database/patch/patchDocument.ts
+++ b/src/Raven.Studio/typescript/models/database/patch/patchDocument.ts
@@ -7,9 +7,6 @@ class patchDocument {
     name = ko.observable<string>("");
     query = ko.observable<string>("");
     recentPatch = ko.observable<boolean>(false);
-
-    queryHasError = ko.observable<boolean>(false);
-    updateHasError = ko.observable<boolean>(false);
     
     validationGroup: KnockoutValidationGroup;
 
@@ -25,16 +22,7 @@ class patchDocument {
     private initValidation() {
         this.query.extend({
             required: true,
-            aceValidation: true,
-            validation: [
-                {
-                    validator: () => !this.queryHasError(),
-                    message: "The query part of your patch script failed to execute. Please check the query syntax."
-                },
-                {
-                    validator: () => !this.updateHasError(),
-                    message: "Please check the update part of your patch script."
-                }]
+            aceValidation: true
         });
         
         this.validationGroup = ko.validatedObservable({

--- a/src/Raven.Studio/typescript/models/database/patch/patchDocument.ts
+++ b/src/Raven.Studio/typescript/models/database/patch/patchDocument.ts
@@ -7,6 +7,8 @@ class patchDocument {
     name = ko.observable<string>("");
     query = ko.observable<string>("");
     recentPatch = ko.observable<boolean>(false);
+
+    queryHasError = ko.observable<boolean>(false);
     
     validationGroup: KnockoutValidationGroup;
 
@@ -22,7 +24,12 @@ class patchDocument {
     private initValidation() {
         this.query.extend({
             required: true,
-            aceValidation: true
+            aceValidation: true,
+            validation: [
+                {
+                    validator: () => !this.queryHasError(),
+                    message: "The query part of your patch script failed to execute. Please check the query syntax."
+                }]
         });
         
         this.validationGroup = ko.validatedObservable({

--- a/src/Raven.Studio/typescript/models/database/patch/patchDocument.ts
+++ b/src/Raven.Studio/typescript/models/database/patch/patchDocument.ts
@@ -9,6 +9,7 @@ class patchDocument {
     recentPatch = ko.observable<boolean>(false);
 
     queryHasError = ko.observable<boolean>(false);
+    updateHasError = ko.observable<boolean>(false);
     
     validationGroup: KnockoutValidationGroup;
 
@@ -29,6 +30,10 @@ class patchDocument {
                 {
                     validator: () => !this.queryHasError(),
                     message: "The query part of your patch script failed to execute. Please check the query syntax."
+                },
+                {
+                    validator: () => !this.updateHasError(),
+                    message: "Please check the update part of your patch script."
                 }]
         });
         

--- a/src/Raven.Studio/typescript/viewmodels/database/patch/patch.ts
+++ b/src/Raven.Studio/typescript/viewmodels/database/patch/patch.ts
@@ -401,7 +401,7 @@ class patch extends viewModelBase {
                              `<div class="margin-bottom margin-bottom-lg text-info bg-info padding padding-xs">
                                  <ul class="margin-top">
                                      <li>
-                                         <small>Number of documents matching the Patch Query: <strong class="margin-left margin-left-sm">${matchingDocuments}</strong></small>
+                                         <small>Number of documents matching the Patch Query: <strong class="margin-left margin-left-sm">${matchingDocuments.toLocaleString()}</strong></small>
                                      </li>
                                      ${matchingDocuments > 0 ? warningMessage : ''}
                                  </ul>


### PR DESCRIPTION
… patch

### Issue link
https://issues.hibernatingrhinos.com/issue/RavenDB-17109

### Additional description
Show the estimated number of documents that will be processed by the Patch before the script is executed.
This number is actually the number matching the Query part of the patch script.
The actual number of documents that are processed can be smaller - info message was added to the popup.

### Type of change
- New feature

### How risky is the change?
- Low 

### Backward compatibility
- Non breaking change

### Is it platform specific issue?
- No

### Documentation update
- This change requires a documentation update. 

### Testing 
- It has been verified by manual testing

### Is there any existing behavior change of other features due to this change?
- No

### UI work
- No UI work is needed
