### PR TITLE
RavenDB-17248  When Admin Logs are paused and clear is clicked - it s…

### DIFF
--- a/src/Raven.Studio/typescript/viewmodels/manage/adminLogs.ts
+++ b/src/Raven.Studio/typescript/viewmodels/manage/adminLogs.ts
@@ -383,10 +383,6 @@ class adminLogs extends viewModelBase {
         // set flag to true, since list reset is async
         this.duringManualScrollEvent = true;
         this.tailEnabled(true);
-        
-        if (!this.liveClient()) {
-            this.resumeLogs();
-        }
     }
     
     exportToFile() {


### PR DESCRIPTION
…tarts showing logs again

### Issue link
https://issues.hibernatingrhinos.com/issue/RavenDB-17248

### Additional description
Do not resume logs upon 'Clear'

### Type of change
- Bug fix

### How risky is the change?
- Low 

### Backward compatibility
- Non breaking change

### Is it platform specific issue?
- No

### Documentation update
- No documentation update is needed 

### Testing 
- It has been verified by manual testing

### Is there any existing behavior change of other features due to this change?
- No

### UI work
- No UI work is needed
