### PR TITLE
RavenDB-17174 When restore, execute database cluster transaction commands directly from DocumentDestination

### DIFF
--- a/src/Raven.Server/Documents/DocumentDatabase.cs
+++ b/src/Raven.Server/Documents/DocumentDatabase.cs
@@ -450,48 +450,51 @@ namespace Raven.Server.Documents
 
                 _hasClusterTransaction.Reset();
 
-                using (ServerStore.ContextPool.AllocateOperationContext(out TransactionOperationContext context))
-                using (context.OpenReadTransaction())
+                try
                 {
-                    try
+                    using (ServerStore.ContextPool.AllocateOperationContext(out TransactionOperationContext context))
+                    using (context.OpenReadTransaction())
                     {
-                        var batch = new List<ClusterTransactionCommand.SingleClusterDatabaseCommand>(
-                            ClusterTransactionCommand.ReadCommandsBatch(context, Name, fromCount: _nextClusterCommand, take: 256));
-
-                        if (batch.Count == 0)
-                        {
-                            continue;
-                        }
-
-                        var mergedCommands = new BatchHandler.ClusterTransactionMergedCommand(this, batch);
-                        try
-                        {
-                            //If we get a database shutdown while we process a cluster tx command this
-                            //will cause us to stop running and disposing the context while its memory is still been used by the merger execution
-                            await TxMerger.Enqueue(mergedCommands);
-                        }
-                        catch (Exception e)
-                        {
-                            if (_logger.IsInfoEnabled)
-                            {
-                                _logger.Info($"Failed to execute cluster transaction batch (count: {batch.Count}), will retry them one-by-one.", e);
-                            }
-                            await ExecuteClusterTransactionOneByOne(batch);
-                            continue;
-                        }
-                        foreach (var command in batch)
-                        {
-                            OnClusterTransactionCompletion(command, mergedCommands);
-                        }
-                    }
-                    catch (Exception e)
-                    {
-                        if (_logger.IsInfoEnabled)
-                        {
-                            _logger.Info($"Can't perform cluster transaction on database '{Name}'.", e);
-                        }
+                        await ExecuteClusterTransaction(context);
                     }
                 }
+                catch (Exception e)
+                {
+                    if (_logger.IsInfoEnabled)
+                    {
+                        _logger.Info($"Can't perform cluster transaction on database '{Name}'.", e);
+                    }
+                }
+            }
+        }
+
+        public async Task ExecuteClusterTransaction(TransactionOperationContext context)
+        {
+            var batch = new List<ClusterTransactionCommand.SingleClusterDatabaseCommand>(
+                ClusterTransactionCommand.ReadCommandsBatch(context, Name, fromCount: _nextClusterCommand, take: 256));
+
+            if (batch.Count == 0)
+                return;
+
+            var mergedCommands = new BatchHandler.ClusterTransactionMergedCommand(this, batch);
+            try
+            {
+                //If we get a database shutdown while we process a cluster tx command this
+                //will cause us to stop running and disposing the context while its memory is still been used by the merger execution
+                await TxMerger.Enqueue(mergedCommands);
+            }
+            catch (Exception e)
+            {
+                if (_logger.IsInfoEnabled)
+                {
+                    _logger.Info($"Failed to execute cluster transaction batch (count: {batch.Count}), will retry them one-by-one.", e);
+                }
+                await ExecuteClusterTransactionOneByOne(batch);
+                return;
+            }
+            foreach (var command in batch)
+            {
+                OnClusterTransactionCompletion(command, mergedCommands);
             }
         }
 

--- a/src/Raven.Server/Documents/PeriodicBackup/BackupTask.cs
+++ b/src/Raven.Server/Documents/PeriodicBackup/BackupTask.cs
@@ -149,11 +149,11 @@ namespace Raven.Server.Documents.PeriodicBackup
                     settings => PutServerWideBackupConfigurationCommand.UpdateSettingsForLocal(settings, _database.Name));
 
                 GenerateFolderNameAndBackupDirectory(localSettings, _startTimeUtc, out var nowAsString, out var folderName, out var backupDirectory);
-                var startDocumentEtag = _isFullBackup == false ? _previousBackupStatus.LastEtag : null;
+                var startEtag = _isFullBackup == false ? _previousBackupStatus.LastEtag : null;
                 var startRaftIndex = _isFullBackup == false ? _previousBackupStatus.LastRaftIndex.LastEtag : null;
 
                 var fileName = GetFileName(_isFullBackup, backupDirectory.FullPath, nowAsString, _configuration.BackupType, out string backupFilePath);
-                var internalBackupResult = CreateLocalBackupOrSnapshot(runningBackupStatus, backupFilePath, startDocumentEtag, startRaftIndex);
+                var internalBackupResult = CreateLocalBackupOrSnapshot(runningBackupStatus, backupFilePath, startEtag, startRaftIndex);
 
                 runningBackupStatus.LocalBackup.BackupDirectory = _backupToLocalFolder ? backupDirectory.FullPath : null;
                 runningBackupStatus.LocalBackup.TempFolderUsed = _backupToLocalFolder == false;
@@ -184,7 +184,7 @@ namespace Raven.Server.Documents.PeriodicBackup
                     }
                 }
 
-                runningBackupStatus.LastEtag = internalBackupResult.LastDocumentEtag;
+                runningBackupStatus.LastEtag = internalBackupResult.LastEtag;
                 runningBackupStatus.LastDatabaseChangeVector = internalBackupResult.LastDatabaseChangeVector;
                 runningBackupStatus.LastRaftIndex.LastEtag = internalBackupResult.LastRaftIndex;
                 runningBackupStatus.FolderName = folderName;
@@ -539,12 +539,12 @@ namespace Raven.Server.Documents.PeriodicBackup
 
         private class InternalBackupResult
         {
-            public long LastDocumentEtag { get; set; }
+            public long LastEtag { get; set; }
             public string LastDatabaseChangeVector { get; set; }
             public long LastRaftIndex { get; set; }
         }
 
-        private InternalBackupResult CreateLocalBackupOrSnapshot(PeriodicBackupStatus status, string backupFilePath, long? startDocumentEtag, long? startRaftIndex)
+        private InternalBackupResult CreateLocalBackupOrSnapshot(PeriodicBackupStatus status, string backupFilePath, long? startEtag, long? startRaftIndex)
         {
             var internalBackupResult = new InternalBackupResult();
 
@@ -571,7 +571,7 @@ namespace Raven.Server.Documents.PeriodicBackup
                         options.OperateOnTypes |= DatabaseItemType.Tombstones;
                         options.OperateOnTypes |= DatabaseItemType.CompareExchangeTombstones;
 
-                        var currentBackupResult = CreateBackup(options, tempBackupFilePath, startDocumentEtag, startRaftIndex);
+                        var currentBackupResult = CreateBackup(options, tempBackupFilePath, startEtag, startRaftIndex);
 
                         if (_isFullBackup)
                         {
@@ -582,7 +582,7 @@ namespace Raven.Server.Documents.PeriodicBackup
                             if (_backupResult.GetLastEtag() == _previousBackupStatus.LastEtag &&
                                 _backupResult.GetLastRaftIndex() == _previousBackupStatus.LastRaftIndex.LastEtag)
                             {
-                                internalBackupResult.LastDocumentEtag = startDocumentEtag ?? 0;
+                                internalBackupResult.LastEtag = startEtag ?? 0;
                                 internalBackupResult.LastDatabaseChangeVector = _previousBackupStatus.LastDatabaseChangeVector;
                                 internalBackupResult.LastRaftIndex = startRaftIndex ?? 0;
                             }
@@ -597,7 +597,7 @@ namespace Raven.Server.Documents.PeriodicBackup
                         // snapshot backup
                         ValidateFreeSpaceForSnapshot(tempBackupFilePath);
 
-                        (internalBackupResult.LastDocumentEtag, internalBackupResult.LastDatabaseChangeVector) = _database.ReadLastEtagAndChangeVector();
+                        (internalBackupResult.LastEtag, internalBackupResult.LastDatabaseChangeVector) = _database.ReadLastEtagAndChangeVector();
                         internalBackupResult.LastRaftIndex = GetDatabaseEtagForBackup();
                         var databaseSummary = _database.GetDatabaseSummary();
                         var indexesCount = _database.IndexStore.Count;
@@ -773,7 +773,7 @@ namespace Raven.Server.Documents.PeriodicBackup
                         throw new InvalidOperationException($" {outputStream.GetType()} not supported");
                 }
 
-                currentBackupResults.LastDocumentEtag = smugglerSource.LastEtag;
+                currentBackupResults.LastEtag = smugglerSource.LastEtag;
                 currentBackupResults.LastDatabaseChangeVector = smugglerSource.LastDatabaseChangeVector;
                 currentBackupResults.LastRaftIndex = smugglerSource.LastRaftIndex;
 

--- a/src/Raven.Server/Smuggler/Documents/DatabaseDestination.cs
+++ b/src/Raven.Server/Smuggler/Documents/DatabaseDestination.cs
@@ -653,10 +653,8 @@ namespace Raven.Server.Smuggler.Documents
                     if (rawDatabaseRecord.DatabaseState == DatabaseStateStatus.RestoreInProgress)
                     {
                         await _database.ExecuteClusterTransaction(writeContext);
-                        ClusterTransactionCommand.DeleteCommands(writeContext, _database.Name, long.MaxValue);
                     }
                 }
-                
                 await _database.RachisLogIndexNotifications.WaitForIndexNotification(clusterTransactionResult.Index, _token);
             }
 

--- a/src/Raven.Server/Smuggler/Documents/DatabaseDestination.cs
+++ b/src/Raven.Server/Smuggler/Documents/DatabaseDestination.cs
@@ -591,7 +591,7 @@ namespace Raven.Server.Smuggler.Documents
                     await SendAddOrUpdateCommandsAsync(_context);
 
                 if (_clusterTransactionCommands.Length >= BatchSize)
-                    await SendClusterTransactionsAsync(_context);
+                    await SendClusterTransactionsAsync();
             }
 
             public async ValueTask WriteTombstoneKeyAsync(string key)
@@ -610,44 +610,54 @@ namespace Raven.Server.Smuggler.Documents
                 using (_documentContextHolder)
                 using (_clusterTransactionCommands)
                 {
-                    await SendClusterTransactionsAsync(_context);
+                    await SendClusterTransactionsAsync();
                     await SendAddOrUpdateCommandsAsync(_context);
                     await SendRemoveCommandsAsync(_context);
                 }
             }
 
-            private async ValueTask SendClusterTransactionsAsync(JsonOperationContext context)
+            private async ValueTask SendClusterTransactionsAsync()
             {
                 if (_clusterTransactionCommands.Length == 0)
                     return;
 
-                using (_database.ClusterTransactionWaiter.CreateTask(out var taskId))
+                var parsedCommands = _clusterTransactionCommands.GetArraySegment();
+
+                var raftRequestId = RaftIdGenerator.NewId();
+                var options = new ClusterTransactionCommand.ClusterTransactionOptions(string.Empty, disableAtomicDocumentWrites: false, ClusterCommandsVersionManager.CurrentClusterMinimalVersion);
+                var topology = _database.ServerStore.LoadDatabaseTopology(_database.Name);
+
+                var clusterTransactionCommand = new ClusterTransactionCommand(_database.Name, _database.IdentityPartsSeparator, topology, parsedCommands, options, raftRequestId);
+                clusterTransactionCommand.FromBackup = true;
+
+                var clusterTransactionResult = await _database.ServerStore.SendToLeaderAsync(clusterTransactionCommand);
+                for (int i = 0; i < _clusterTransactionCommands.Length; i++)
                 {
-                    var parsedCommands = _clusterTransactionCommands.GetArraySegment();
-
-                    var raftRequestId = RaftIdGenerator.NewId();
-                    var options = new ClusterTransactionCommand.ClusterTransactionOptions(taskId, disableAtomicDocumentWrites: false, ClusterCommandsVersionManager.CurrentClusterMinimalVersion);
-                    var topology = _database.ServerStore.LoadDatabaseTopology(_database.Name);
-
-                    var clusterTransactionCommand = new ClusterTransactionCommand(_database.Name, _database.IdentityPartsSeparator, topology, parsedCommands, options, raftRequestId);
-                    clusterTransactionCommand.FromBackup = true;
-
-                    var clusterTransactionResult = await _database.ServerStore.SendToLeaderAsync(clusterTransactionCommand);
-                    for (int i = 0; i < _clusterTransactionCommands.Length; i++)
-                    { 
-                        _clusterTransactionCommands[i].Document.Dispose();
-                        _clusterTransactionCommands[i].OriginalChangeVector.Dispose();
-                    }
-             
-                    _clusterTransactionCommands.Clear();
-                    _documentContextHolder.Reset();
-
-                    if (clusterTransactionResult.Result is List<string> errors)
-                        throw new ConcurrencyException($"Failed to execute cluster transaction due to the following issues: {string.Join(Environment.NewLine, errors)}"); //TODO
-
-                    await _database.ServerStore.Cluster.WaitForIndexNotification(clusterTransactionResult.Index);
-                    await _database.ClusterTransactionWaiter.WaitForResults(taskId, _token);
+                    _clusterTransactionCommands[i].Document.Dispose();
+                    _clusterTransactionCommands[i].OriginalChangeVector.Dispose();
                 }
+
+                _clusterTransactionCommands.Clear();
+                _documentContextHolder.Reset();
+
+                if (clusterTransactionResult.Result is List<string> errors)
+                    throw new ConcurrencyException($"Failed to execute cluster transaction due to the following issues: {string.Join(Environment.NewLine, errors)}");
+
+                await _database.ServerStore.Cluster.WaitForIndexNotification(clusterTransactionResult.Index);
+
+                //When restoring from snapshot the database doesn't exist yet and we cannot rely on the DocumentDatabase to execute the database cluster transaction commands
+                using (_database.ServerStore.ContextPool.AllocateOperationContext(out TransactionOperationContext writeContext))
+                using (writeContext.OpenWriteTransaction())
+                using (var rawDatabaseRecord = _database.ServerStore.Cluster.ReadRawDatabaseRecord(writeContext, _database.Name, out _))
+                {
+                    if (rawDatabaseRecord.DatabaseState == DatabaseStateStatus.RestoreInProgress)
+                    {
+                        await _database.ExecuteClusterTransaction(writeContext);
+                        ClusterTransactionCommand.DeleteCommands(writeContext, _database.Name, long.MaxValue);
+                    }
+                }
+                
+                await _database.RachisLogIndexNotifications.WaitForIndexNotification(clusterTransactionResult.Index, _token);
             }
 
             private async ValueTask SendAddOrUpdateCommandsAsync(JsonOperationContext context)


### PR DESCRIPTION
### Issue link

https://issues.hibernatingrhinos.com/issue/RavenDB-RavenDB-17174

### Additional description

The issue:
In import cluster-wide atomic guarded documents, we send the documents to the cluster to create the atomic guard compare exchange.
After the cluster-wide transaction command where sent, we wait for its database commands to be executed by the DocumentDatabase.
But while restoring from snapshot the DocumentDatabase isn't fully initialized and we cannot rely on it to execute the database commands.

The solution:
Execute the database cluster-wide transaction directly from the DocumentDestination when restoring from a snapshot.

### Type of change
- Bug fix

### How risky is the change?
- Moderate 

### Backward compatibility
- Non-breaking change


### Is it a platform-specific issue?
- Yes. v5.2 and up


### Testing 
- Tests have been added that prove the fix is effective or that the feature works

### Is there any existing behavior change of other features due to this change?
- No

### UI work
- No UI work is needed
