### PR TITLE
RavenDB-17237 Making sure that only a single thread can run ExecuteIndexing() method.

### DIFF
--- a/test/SlowTests/Issues/RavenDB_15746_ThrottledManualResetEventSlimTests.cs
+++ b/test/SlowTests/Issues/RavenDB_15746_ThrottledManualResetEventSlimTests.cs
@@ -125,7 +125,7 @@ namespace SlowTests.Issues
         [Fact]
         public void CanEnableDisableThrottlingTimer()
         {
-            using (var mre = new ThrottledManualResetEventSlim(TimeSpan.FromSeconds(1), throttlingBehavior: ThrottledManualResetEventSlim.ThrottlingBehavior.ManualManagement))
+            using (var mre = new ThrottledManualResetEventSlim(TimeSpan.FromSeconds(1), timerManagement: ThrottledManualResetEventSlim.TimerManagement.Manual))
             {
                 mre.Set();
 

--- a/test/SlowTests/Issues/RavenDB_17237.cs
+++ b/test/SlowTests/Issues/RavenDB_17237.cs
@@ -1,0 +1,103 @@
+﻿using System;
+using System.Linq;
+using System.Threading;
+using System.Threading.Tasks;
+using FastTests;
+using Orders;
+using Raven.Client;
+using Raven.Client.Documents.Indexes;
+using Raven.Client.Documents.Operations.Indexes;
+using Raven.Server.Config;
+using Xunit;
+using Xunit.Abstractions;
+
+namespace SlowTests.Issues
+{
+    public class RavenDB_17237 : RavenTestBase
+    {
+        public RavenDB_17237(ITestOutputHelper output) : base(output)
+        {
+        }
+
+        [Fact]
+        public async Task MustNotDisableThrottlingTimerOnUpdatingIndexDefinitionOfThrottledIndex()
+        {
+            using (var store = GetDocumentStore())
+            {
+                var indexDef = new Orders_ByOrderedAtAndShippedAt(storeFields: false)
+                {
+                    Configuration = {[RavenConfiguration.GetKey(x => x.Indexing.ThrottlingTimeInterval)] = "1000"}
+                };
+
+                await indexDef.ExecuteAsync(store);
+
+                WaitForIndexing(store);
+
+                var database = await GetDatabase(store.Database);
+
+                var index = database.IndexStore.GetIndex(indexDef.IndexName);
+
+                using (var session = store.OpenSession())
+                {
+                    session.Store(new Order { ShippedAt = DateTime.Now, OrderedAt = DateTime.Now });
+
+                    session.SaveChanges();
+                }
+
+                WaitForIndexing(store);
+
+                Assert.Equal(TimeSpan.FromSeconds(1), index._mre.ThrottlingInterval);
+                Assert.NotNull(index._mre._timerTask);
+                Assert.False(index._mre.Wait(100, CancellationToken.None));
+
+                // update index def
+
+                store.Maintenance.Send(new StopIndexingOperation());
+
+                var updatedIndexDef = new Orders_ByOrderedAtAndShippedAt(storeFields: true)
+                {
+                    Configuration = {[RavenConfiguration.GetKey(x => x.Indexing.ThrottlingTimeInterval)] = "1000"}
+                };
+
+                await updatedIndexDef.ExecuteAsync(store);
+
+                var replacementIndex = database.IndexStore.GetIndex(Constants.Documents.Indexing.SideBySideIndexNamePrefix + updatedIndexDef.IndexName);
+
+                using (replacementIndex.ForTestingPurposesOnly().CallDuringFinallyOfExecuteIndexing(() =>
+                {
+                    // stop the current index for a moment to ensure that a new thread will start - the one after renaming the replacement index
+                    Thread.Sleep(2000);
+                }))
+                {
+                    store.Maintenance.Send(new StartIndexingOperation());
+                }
+
+                WaitForIndexing(store);
+
+                Assert.NotNull(replacementIndex._mre._timerTask);
+                Assert.False(replacementIndex._mre.Wait(100, CancellationToken.None));
+
+                using (var session = store.OpenSession())
+                {
+                    session.Store(new Order {ShippedAt = DateTime.Now, OrderedAt = DateTime.Now});
+
+                    session.SaveChanges();
+                }
+
+                WaitForIndexing(store);
+            }
+        }
+
+        private class Orders_ByOrderedAtAndShippedAt : AbstractIndexCreationTask<Order>
+        {
+            public Orders_ByOrderedAtAndShippedAt(bool storeFields)
+            {
+                Map = orders => from o in orders
+                    select new {o.OrderedAt, o.ShippedAt};
+
+                if (storeFields)
+                    StoreAllFields(FieldStorage.Yes);
+            }
+        }
+    }
+}


### PR DESCRIPTION
### Issue link

https://issues.hibernatingrhinos.com/issue/RavenDB-17237

### Additional description

This fixes the problem with modifying ThrottledManualResetEventSlim instance concurrently by a just replaced side-by-side index (we call `StartIndexingThread()` which will do `EnableThrottlingTimer()` but we're about to call  `DisableThrottlingTimer()` on the same instance when exiting current thread). That resulted in stopping the internal throttling timer and not processing updated documents by the index.

### Type of change

- Bug fix

### How risky is the change?

- Low 

### Backward compatibility

- Not relevant

### Is it platform specific issue?

- No

### Documentation update

- No documentation update is needed 

### Testing 

- Tests have been added that prove the fix is effective or that the feature works
- It has been verified by manual testing

### Is there any existing behavior change of other features due to this change?

- No

### UI work

- No UI work is needed
