### PR TITLE
RavenDB-17268 - Expose generating the next id in AsyncMultiDatabaseHiLoIdGenerator

### DIFF
--- a/src/Raven.Client/Documents/DocumentStore.cs
+++ b/src/Raven.Client/Documents/DocumentStore.cs
@@ -43,6 +43,8 @@ namespace Raven.Client.Documents
 
         private string _identifier;
 
+        public AsyncMultiDatabaseHiLoIdGenerator AsyncMultiDatabaseHiLoIdGenerator => _asyncMultiDbHiLo;
+
         /// <summary>
         /// Gets or sets the identifier for this store.
         /// </summary>

--- a/src/Raven.Client/Documents/DocumentStore.cs
+++ b/src/Raven.Client/Documents/DocumentStore.cs
@@ -43,7 +43,7 @@ namespace Raven.Client.Documents
 
         private string _identifier;
 
-        public AsyncMultiDatabaseHiLoIdGenerator AsyncMultiDatabaseHiLoIdGenerator => _asyncMultiDbHiLo;
+        public IHiLoIdGenerator HiLoIdGenerator => _asyncMultiDbHiLo;
 
         /// <summary>
         /// Gets or sets the identifier for this store.

--- a/src/Raven.Client/Documents/DocumentStore.cs
+++ b/src/Raven.Client/Documents/DocumentStore.cs
@@ -43,7 +43,7 @@ namespace Raven.Client.Documents
 
         private string _identifier;
 
-        public IHiLoIdGenerator HiLoIdGenerator => _asyncMultiDbHiLo;
+        public override IHiLoIdGenerator HiLoIdGenerator => _asyncMultiDbHiLo;
 
         /// <summary>
         /// Gets or sets the identifier for this store.

--- a/src/Raven.Client/Documents/DocumentStoreBase.cs
+++ b/src/Raven.Client/Documents/DocumentStoreBase.cs
@@ -7,6 +7,7 @@ using System.Threading.Tasks;
 using Raven.Client.Documents.BulkInsert;
 using Raven.Client.Documents.Changes;
 using Raven.Client.Documents.Conventions;
+using Raven.Client.Documents.Identity;
 using Raven.Client.Documents.Indexes;
 using Raven.Client.Documents.Operations;
 using Raven.Client.Documents.Operations.Indexes;
@@ -54,6 +55,8 @@ namespace Raven.Client.Documents
         public abstract IDisposable AggressivelyCacheFor(TimeSpan cacheDuration, AggressiveCacheMode mode, string database = null);
 
         public abstract IDisposable DisableAggressiveCaching(string database = null);
+
+        public abstract IHiLoIdGenerator HiLoIdGenerator { get; }
 
         public abstract string Identifier { get; set; }
 

--- a/src/Raven.Client/Documents/IDocumentStore.cs
+++ b/src/Raven.Client/Documents/IDocumentStore.cs
@@ -12,6 +12,7 @@ using System.Threading.Tasks;
 using Raven.Client.Documents.BulkInsert;
 using Raven.Client.Documents.Changes;
 using Raven.Client.Documents.Conventions;
+using Raven.Client.Documents.Identity;
 using Raven.Client.Documents.Indexes;
 using Raven.Client.Documents.Operations;
 using Raven.Client.Documents.Session;
@@ -29,6 +30,8 @@ namespace Raven.Client.Documents
     public interface IDocumentStore : IDisposalNotification
     {
         X509Certificate2 Certificate { get; }
+
+        IHiLoIdGenerator HiLoIdGenerator { get; }
 
         event EventHandler<BeforeStoreEventArgs> OnBeforeStore;
 

--- a/src/Raven.Client/Documents/Identity/AsyncMultiDatabaseHiLoIdGenerator.cs
+++ b/src/Raven.Client/Documents/Identity/AsyncMultiDatabaseHiLoIdGenerator.cs
@@ -10,7 +10,7 @@ using Raven.Client.Extensions;
 
 namespace Raven.Client.Documents.Identity
 {
-    public class AsyncMultiDatabaseHiLoIdGenerator
+    public class AsyncMultiDatabaseHiLoIdGenerator : IHiLoIdGenerator
     {
         protected readonly DocumentStore Store;
 

--- a/src/Raven.Client/Documents/Identity/AsyncMultiDatabaseHiLoIdGenerator.cs
+++ b/src/Raven.Client/Documents/Identity/AsyncMultiDatabaseHiLoIdGenerator.cs
@@ -4,6 +4,7 @@
 //  </copyright>
 // -----------------------------------------------------------------------
 
+using System;
 using System.Collections.Concurrent;
 using System.Threading.Tasks;
 using Raven.Client.Extensions;
@@ -29,11 +30,23 @@ namespace Raven.Client.Documents.Identity
             return generator.GenerateDocumentIdAsync(entity);
         }
 
-        public Task<long> GenerateNextIdForAsync(string database, string tag)
+        public Task<long> GenerateNextIdForAsync(string database, object entity)
+        {
+            var collectionName = Store.Conventions.GetCollectionName(entity);
+            return GenerateNextIdForAsync(database, collectionName);
+        }
+
+        public Task<long> GenerateNextIdForAsync(string database, Type type)
+        {
+            var collectionName = Store.Conventions.GetCollectionName(type);
+            return GenerateNextIdForAsync(database, collectionName);
+        }
+
+        public Task<long> GenerateNextIdForAsync(string database, string collectionName)
         {
             database = Store.GetDatabase(database);
             var generator = _generators.GetOrAdd(database, GenerateAsyncMultiTypeHiLoFunc);
-            return generator.GenerateNextIdForAsync(tag);
+            return generator.GenerateNextIdForAsync(collectionName);
         }
 
         public virtual AsyncMultiTypeHiLoIdGenerator GenerateAsyncMultiTypeHiLoFunc(string database)

--- a/src/Raven.Client/Documents/Identity/AsyncMultiDatabaseHiLoIdGenerator.cs
+++ b/src/Raven.Client/Documents/Identity/AsyncMultiDatabaseHiLoIdGenerator.cs
@@ -29,6 +29,13 @@ namespace Raven.Client.Documents.Identity
             return generator.GenerateDocumentIdAsync(entity);
         }
 
+        public Task<long> GenerateNextIdForAsync(string database, string tag)
+        {
+            database = Store.GetDatabase(database);
+            var generator = _generators.GetOrAdd(database, GenerateAsyncMultiTypeHiLoFunc);
+            return generator.GenerateNextIdForAsync(tag);
+        }
+
         public virtual AsyncMultiTypeHiLoIdGenerator GenerateAsyncMultiTypeHiLoFunc(string database)
         {
             return new AsyncMultiTypeHiLoIdGenerator(Store, database);

--- a/src/Raven.Client/Documents/Identity/AsyncMultiTypeHiLoIdGenerator.cs
+++ b/src/Raven.Client/Documents/Identity/AsyncMultiTypeHiLoIdGenerator.cs
@@ -100,9 +100,9 @@ namespace Raven.Client.Documents.Identity
             }
         }
 
-        public async Task<long> GenerateNextIdForAsync(string tag)
+        public async Task<long> GenerateNextIdForAsync(string collectionName)
         {
-            if (_idGeneratorsByTag.TryGetValue(tag, out var value))
+            if (_idGeneratorsByTag.TryGetValue(collectionName, out var value))
             {
                 return await value.NextIdAsync().ConfigureAwait(false);
             }
@@ -111,11 +111,11 @@ namespace Raven.Client.Documents.Identity
 
             try
             {
-                if (_idGeneratorsByTag.TryGetValue(tag, out value))
+                if (_idGeneratorsByTag.TryGetValue(collectionName, out value))
                     return await value.NextIdAsync().ConfigureAwait(false);
 
-                value = CreateGeneratorFor(tag);
-                _idGeneratorsByTag.TryAdd(tag, value);
+                value = CreateGeneratorFor(collectionName);
+                _idGeneratorsByTag.TryAdd(collectionName, value);
             }
             finally
             {

--- a/src/Raven.Client/Documents/Identity/AsyncMultiTypeHiLoIdGenerator.cs
+++ b/src/Raven.Client/Documents/Identity/AsyncMultiTypeHiLoIdGenerator.cs
@@ -100,6 +100,31 @@ namespace Raven.Client.Documents.Identity
             }
         }
 
+        public async Task<long> GenerateNextIdForAsync(string tag)
+        {
+            if (_idGeneratorsByTag.TryGetValue(tag, out var value))
+            {
+                return await value.NextIdAsync().ConfigureAwait(false);
+            }
+
+            await _generatorLock.WaitAsync().ConfigureAwait(false);
+
+            try
+            {
+                if (_idGeneratorsByTag.TryGetValue(tag, out value))
+                    return await value.NextIdAsync().ConfigureAwait(false);
+
+                value = CreateGeneratorFor(tag);
+                _idGeneratorsByTag.TryAdd(tag, value);
+            }
+            finally
+            {
+                _generatorLock.Release();
+            }
+
+            return await value.NextIdAsync().ConfigureAwait(false);
+        }
+
         protected virtual AsyncHiLoIdGenerator CreateGeneratorFor(string tag)
         {
             return new AsyncHiLoIdGenerator(tag, Store, DbName, _identityPartsSeparator);
@@ -110,7 +135,7 @@ namespace Raven.Client.Documents.Identity
             await ReturnUnusedRange(_idGeneratorsByTag.Values).ConfigureAwait(false);
         }
 
-        private async static Task ReturnUnusedRange(IEnumerable<AsyncHiLoIdGenerator> generators)
+        private static async Task ReturnUnusedRange(IEnumerable<AsyncHiLoIdGenerator> generators)
         {
             foreach (var generator in generators)
                 await generator.ReturnUnusedRangeAsync().ConfigureAwait(false);

--- a/src/Raven.Client/Documents/Identity/IHiLoIdGenerator.cs
+++ b/src/Raven.Client/Documents/Identity/IHiLoIdGenerator.cs
@@ -1,11 +1,14 @@
+using System;
 using System.Threading.Tasks;
 
 namespace Raven.Client.Documents.Identity
 {
     public interface IHiLoIdGenerator
     {
-        Task<string> GenerateDocumentIdAsync(string database, object entity);
+        Task<long> GenerateNextIdForAsync(string database, object entity);
 
-        Task<long> GenerateNextIdForAsync(string database, string tag);
+        Task<long> GenerateNextIdForAsync(string database, Type type);
+
+        Task<long> GenerateNextIdForAsync(string database, string collectionName);
     }
 }

--- a/src/Raven.Client/Documents/Identity/IHiLoIdGenerator.cs
+++ b/src/Raven.Client/Documents/Identity/IHiLoIdGenerator.cs
@@ -1,0 +1,11 @@
+using System.Threading.Tasks;
+
+namespace Raven.Client.Documents.Identity
+{
+    public interface IHiLoIdGenerator
+    {
+        Task<string> GenerateDocumentIdAsync(string database, object entity);
+
+        Task<long> GenerateNextIdForAsync(string database, string tag);
+    }
+}

--- a/test/FastTests/Client/HiLo.cs
+++ b/test/FastTests/Client/HiLo.cs
@@ -127,10 +127,10 @@ namespace FastTests.Client
 
                 Parallel.For(0, count, _ =>
                 {
-                    var id = store.AsyncMultiDatabaseHiLoIdGenerator.GenerateNextIdForAsync(null, "Users").GetAwaiter().GetResult();
+                    var id = store.HiLoIdGenerator.GenerateNextIdForAsync(null, "Users").GetAwaiter().GetResult();
                     Assert.True(usersIds.TryAdd(id));
 
-                    id = store.AsyncMultiDatabaseHiLoIdGenerator.GenerateNextIdForAsync(null, "Products").GetAwaiter().GetResult();
+                    id = store.HiLoIdGenerator.GenerateNextIdForAsync(null, "Products").GetAwaiter().GetResult();
                     Assert.True(productsIds.TryAdd(id));
                 });
 

--- a/test/FastTests/Client/HiLo.cs
+++ b/test/FastTests/Client/HiLo.cs
@@ -132,10 +132,22 @@ namespace FastTests.Client
 
                     id = store.HiLoIdGenerator.GenerateNextIdForAsync(null, "Products").GetAwaiter().GetResult();
                     Assert.True(productsIds.TryAdd(id));
+
+                    id = store.HiLoIdGenerator.GenerateNextIdForAsync(null, typeof(User)).GetAwaiter().GetResult();
+                    Assert.True(usersIds.TryAdd(id));
+
+                    id = store.HiLoIdGenerator.GenerateNextIdForAsync(null, new Product()).GetAwaiter().GetResult();
+                    Assert.True(productsIds.TryAdd(id));
+
+                    id = store.HiLoIdGenerator.GenerateNextIdForAsync(null, new User()).GetAwaiter().GetResult();
+                    Assert.True(usersIds.TryAdd(id));
+
+                    id = store.HiLoIdGenerator.GenerateNextIdForAsync(null, typeof(Product)).GetAwaiter().GetResult();
+                    Assert.True(productsIds.TryAdd(id));
                 });
 
-                Assert.Equal(count * 2, usersIds.Count);
-                Assert.Equal(count * 2, productsIds.Count);
+                Assert.Equal(count * 4, usersIds.Count);
+                Assert.Equal(count * 4, productsIds.Count);
             }
         }
 


### PR DESCRIPTION
### Issue link

https://issues.hibernatingrhinos.com/issue/RavenDB-17268

### Additional description

Expose the `AsyncMultiDatabaseHiLoIdGenerator` in `DocumentStore` and the option to generate the next id without the tag.

### How risky is the change?

- Low 

### Backward compatibility

- Non breaking change

### Testing 

- Tests have been added that prove the fix is effective or that the feature works

### UI work

- No UI work is needed
