### PR TITLE
RavenDB-17264 - removing the AGPL alert shouldn't prevent us from loading the license

### DIFF
--- a/src/Raven.Server/Commercial/LicenseManager.cs
+++ b/src/Raven.Server/Commercial/LicenseManager.cs
@@ -201,8 +201,6 @@ namespace Raven.Server.Commercial
             try
             {
                 SetLicense(GetLicenseStatus(license));
-
-                RemoveAgplAlert();
             }
             catch (Exception e)
             {
@@ -222,6 +220,7 @@ namespace Raven.Server.Commercial
                 _serverStore.NotificationCenter.Add(alert);
             }
 
+            RemoveAgplAlert();
             LicenseChanged?.Invoke();
 
             if (firstRun == false)
@@ -242,7 +241,15 @@ namespace Raven.Server.Commercial
 
         private void RemoveAgplAlert()
         {
-            _serverStore.NotificationCenter.Dismiss(AlertRaised.GetKey(AlertType.LicenseManager_AGPL3, null));
+            try
+            {
+                _serverStore.NotificationCenter.Dismiss(AlertRaised.GetKey(AlertType.LicenseManager_AGPL3, null));
+            }
+            catch (Exception e)
+            {
+                // nothing we do can here, we'll try to remove it on next restart or when reloading the license
+                Logger.Info("Failed to remove the AGPL alert", e);
+            }
         }
 
         public void ReloadLicenseLimits(bool firstRun = false)

--- a/src/Raven.Server/Commercial/LicenseManager.cs
+++ b/src/Raven.Server/Commercial/LicenseManager.cs
@@ -241,14 +241,19 @@ namespace Raven.Server.Commercial
 
         private void RemoveAgplAlert()
         {
+            var id = AlertRaised.GetKey(AlertType.LicenseManager_AGPL3, null);
+            if (_serverStore.NotificationCenter.Exists(id) == false)
+                return;
+
             try
             {
-                _serverStore.NotificationCenter.Dismiss(AlertRaised.GetKey(AlertType.LicenseManager_AGPL3, null));
+                _serverStore.NotificationCenter.Dismiss(id);
             }
             catch (Exception e)
             {
                 // nothing we do can here, we'll try to remove it on next restart or when reloading the license
-                Logger.Info("Failed to remove the AGPL alert", e);
+                if (Logger.IsOperationsEnabled)
+                    Logger.Operations("Failed to remove the AGPL alert", e);
             }
         }
 

--- a/src/Raven.Server/NotificationCenter/NotificationCenter.cs
+++ b/src/Raven.Server/NotificationCenter/NotificationCenter.cs
@@ -168,6 +168,11 @@ namespace Raven.Server.NotificationCenter
             Add(NotificationUpdated.Create(id, NotificationUpdateType.Dismissed));
         }
 
+        public bool Exists(string id)
+        {
+            return _notificationsStorage.Exists(id);
+        }
+
         public string GetDatabaseFor(string id) => _notificationsStorage.GetDatabaseFor(id);
 
         public void Postpone(string id, DateTime until)


### PR DESCRIPTION
### Issue link

https://issues.hibernatingrhinos.com/issue/RavenDB-17264

### Additional description

Removing the AGPL alert shouldn't prevent us from loading the license

### Type of change

- Optimization

### How risky is the change?

- Low 

### Testing 

- It has been verified by manual testing
