### PR TITLE
RavenDB-16966 Prevent early compare exchange context release

### DIFF
--- a/test/SlowTests/Issues/RavenDB_16966.cs
+++ b/test/SlowTests/Issues/RavenDB_16966.cs
@@ -1,0 +1,37 @@
+﻿using System;
+using System.Collections.Generic;
+using System.Text;
+using System.Threading.Tasks;
+using FastTests;
+using Raven.Client.Documents.Operations.CompareExchange;
+using Raven.Client.Exceptions;
+using Raven.Server.Utils;
+using Xunit;
+using Xunit.Abstractions;
+
+namespace SlowTests.Issues
+{
+    public class RavenDB_16966 : RavenTestBase
+    {
+        public RavenDB_16966(ITestOutputHelper output) : base(output)
+        {
+        }
+
+        [Fact]
+        public async Task KeepCompareExchangeContextEvenUponFailure()
+        {
+            DebuggerAttachedTimeout.DisableLongTimespan = true;
+            DoNotReuseServer();
+
+            using var store = GetDocumentStore();
+            Server.ServerStore.ForTestingPurposesOnly().SimulateCompareExchangeRequestDrop = true;
+
+            var ex = await Assert.ThrowsAsync<RavenException>(()=>store.Operations.SendAsync(new PutCompareExchangeValueOperation<string>("test", "Karmel", 0)));
+            Assert.Contains("Simulate Request Drop", ex.Message);
+
+            await AssertWaitForNotNullAsync(() => store.Operations.SendAsync(new GetCompareExchangeValueOperation<string>("test")));
+            var res = await store.Operations.SendAsync(new GetCompareExchangeValueOperation<string>("test"));
+            Assert.Equal("Karmel", res.Value);
+        }
+    }
+}


### PR DESCRIPTION
### Issue link

https://issues.hibernatingrhinos.com/issue/RavenDB-16966

### Additional description

`SendToLeaderAsync` has an overload that expected a context, which is used for passing compare exchange commands.
Those command has blittables both in the command it self and in the result.
If that context is prematurely released we might corrupt the compare exchange value/result (can happened if a timeout in the handler occurred)

So my solution to this, is to keep that context alive as long as the command is not done.

### Type of change

- Bug fix

### How risky is the change?

- Low/Moderate 

It is a very specific code path, but modifying context behavior always contain some risk. 

### Backward compatibility

- Not relevant

### Is it platform specific issue?

- No

### Documentation update

- No documentation update is needed 

### Testing 

- Tests have been added that prove the fix is effective or that the feature works

### Is there any existing behavior change of other features due to this change?

- No

### UI work

- No UI work is needed
