### PR TITLE
RavenDB-17278 Query parameters from studio are sent in wrong format

### DIFF
--- a/src/Raven.Studio/typescript/commands/database/query/queryCommand.ts
+++ b/src/Raven.Studio/typescript/commands/database/query/queryCommand.ts
@@ -78,9 +78,9 @@ class queryCommand extends commandBase {
             if (line.endsWith("}") && line.startsWith("{")) {
                 try {
                     // check if this is valid JSON, if so, can send it
-                    JSON.parse(line);
+                    const lineObj = JSON.parse(line);
                     const q = arrayOfLines.splice(0, index).join("\n");
-                    return [line, q];
+                    return [lineObj, q];
                 } catch (e){
                     // ignore non JSON data
                 }


### PR DESCRIPTION
### Issue link
https://issues.hibernatingrhinos.com/issue/RavenDB-17278

### Additional description
Send correct param format for this query syntax:
```
from index 'Product/Search'where Name = $p0
{"p0":"Chai"}
```

### Type of change
- Bug fix

### How risky is the change?
- Low 

### Backward compatibility
- Non breaking change

### Is it platform specific issue?
- No

### Documentation update
- No documentation update is needed 

### Testing 
- It has been verified by manual testing

### Is there any existing behavior change of other features due to this change?
- No

### UI work
- No UI work is needed
