### PR TITLE
RavenDB-17296 check if we have sufficient execution stack to process complex where clauses

### DIFF
--- a/src/Raven.Server/Documents/Queries/Parser/QueryParser.cs
+++ b/src/Raven.Server/Documents/Queries/Parser/QueryParser.cs
@@ -1,6 +1,7 @@
 using System;
 using System.Collections.Generic;
 using System.Linq;
+using System.Runtime.CompilerServices;
 using System.Text;
 using Esprima;
 using Raven.Client.Exceptions;
@@ -1566,6 +1567,8 @@ namespace Raven.Server.Documents.Queries.Parser
 
         private bool Binary(out QueryExpression op)
         {
+            RuntimeHelpers.EnsureSufficientExecutionStack();
+
             switch (_state)
             {
                 case NextTokenOptions.Parenthesis:

--- a/src/Raven.Server/Documents/Queries/Parser/QueryParser.cs
+++ b/src/Raven.Server/Documents/Queries/Parser/QueryParser.cs
@@ -1567,7 +1567,13 @@ namespace Raven.Server.Documents.Queries.Parser
 
         private bool Binary(out QueryExpression op)
         {
-            RuntimeHelpers.EnsureSufficientExecutionStack();
+            if (RuntimeHelpers.TryEnsureSufficientExecutionStack() == false)
+            {
+                ThrowQueryTooComplexException();
+
+                op = null; // code is unreachable
+                return false;
+            }
 
             switch (_state)
             {
@@ -1942,6 +1948,11 @@ namespace Raven.Server.Documents.Queries.Parser
                 .Append(msg);
 
             throw new ParseException(sb.ToString());
+        }
+
+        private void ThrowQueryTooComplexException()
+        {
+            throw new ParseException($"Query is too complex. Query: {Scanner.Input}");
         }
 
         private bool Value(out ValueExpression val)

--- a/src/Raven.Server/Documents/Queries/QueryBuilder.cs
+++ b/src/Raven.Server/Documents/Queries/QueryBuilder.cs
@@ -147,7 +147,8 @@ namespace Raven.Server.Documents.Queries
             QueryExpression expression, QueryMetadata metadata, IndexDefinitionBase indexDef,
             BlittableJsonReaderObject parameters, Analyzer analyzer, QueryBuilderFactories factories, bool exact = false, int? proximity = null)
         {
-            RuntimeHelpers.EnsureSufficientExecutionStack();
+            if (RuntimeHelpers.TryEnsureSufficientExecutionStack() == false)
+                ThrowQueryTooComplexException(metadata, parameters);
 
             if (expression == null)
                 return new MatchAllDocsQuery();
@@ -1334,6 +1335,11 @@ namespace Raven.Server.Documents.Queries
         {
             if (fieldType != ValueTokenType.Double && fieldType != ValueTokenType.Long)
                 ThrowValueTypeMismatch(fieldName, fieldType, ValueTokenType.Double);
+        }
+
+        private static void ThrowQueryTooComplexException(QueryMetadata metadata, BlittableJsonReaderObject parameters)
+        {
+            throw new InvalidQueryException($"Query is too complex", metadata.QueryText, parameters);
         }
 
         private static void ThrowUnhandledValueTokenType(ValueTokenType type)

--- a/src/Raven.Server/Platform/Posix/MemInfoReader.cs
+++ b/src/Raven.Server/Platform/Posix/MemInfoReader.cs
@@ -274,6 +274,12 @@ namespace Raven.Server.Platform.Posix
         [SnmpIndex(52)]
         public Size DirectMap1G { get; set; }
 
+        [SnmpIndex(53)]
+        public Size CmaTotal { get; set; }
+
+        [SnmpIndex(54)]
+        public Size CmaFree { get; set; }
+
         public Dictionary<string, Size> Other { get; set; }
 
         public void Set(string name, long value, SizeUnit unit)

--- a/test/SlowTests/Issues/RavenDB13650.cs
+++ b/test/SlowTests/Issues/RavenDB13650.cs
@@ -14,12 +14,12 @@ namespace SlowTests.Issues
         {
         }
 
-        public class User
+        private class User
         {
             public Dictionary<string, string> Items;
         }
 
-        public class User_Index : AbstractIndexCreationTask<User>
+        private class User_Index : AbstractIndexCreationTask<User>
         {
             public User_Index()
             {

--- a/test/SlowTests/Issues/RavenDB_13293.cs
+++ b/test/SlowTests/Issues/RavenDB_13293.cs
@@ -237,7 +237,7 @@ namespace SlowTests.Issues
             }
         }
 
-        public class MyBackup
+        private class MyBackup
         {
             public string BackupPath { get; set; }
             public long BackupTaskId { get; set; }
@@ -245,7 +245,7 @@ namespace SlowTests.Issues
             public string NodeTag { get; set; }
         }
 
-        public class User
+        private class User
         {
             public string Name { get; set; }
         }

--- a/test/SlowTests/Issues/RavenDB_17296.cs
+++ b/test/SlowTests/Issues/RavenDB_17296.cs
@@ -1,0 +1,48 @@
+﻿using System.Linq;
+using FastTests;
+using Raven.Client.Exceptions;
+using Raven.Tests.Core.Utils.Entities;
+using Xunit;
+using Xunit.Abstractions;
+
+namespace SlowTests.Issues
+{
+    public class RavenDB_17296 : RavenTestBase
+    {
+        public RavenDB_17296(ITestOutputHelper output) : base(output)
+        {
+        }
+
+        [Fact]
+        public void Should_Not_Kill_Server_Because_Of_Not_Sufficient_Execution_Stack()
+        {
+            using (var store = GetDocumentStore())
+            {
+                using (var session = store.OpenSession())
+                {
+                    var baseQuery = session.Advanced.DocumentQuery<User>();
+
+                    var first = true;
+                    for (var i = 0; i < 1_000; i++)
+                    {
+                        if (first == false)
+                            baseQuery.OrElse();
+
+                        baseQuery.OpenSubclause()
+                            .WhereEquals(x => x.Name, "grisha")
+                            .AndAlso()
+                            .WhereEquals(x => x.Name, "grisha")
+                            .AndAlso()
+                            .WhereNotEquals(x => x.Name, "1")
+                            .CloseSubclause();
+
+                        first = false;
+                    }
+
+                    var e = Assert.Throws<RavenException>(() => baseQuery.ToList());
+                    Assert.Contains("InsufficientExecutionStackException", e.Message);
+                }
+            }
+        }
+    }
+}


### PR DESCRIPTION
### Issue link

https://issues.hibernatingrhinos.com/issue/RavenDB-17296

### Additional description

For complex where clauses during query parsing we would fill the execution stack and die. Now we will be validating if it is sufficient and throw faster.

### Type of change

- Bug fix

### How risky is the change?

- Low 

### Backward compatibility

- Non breaking change

### Is it platform specific issue?

- No

### Documentation update

- No documentation update is needed 

### Testing 

- Tests have been added that prove the fix is effective or that the feature works

### Is there any existing behavior change of other features due to this change?

- No

### UI work

- No UI work is needed
