### PR TITLE
RavenDB-17303 Ignore NULL_VALUE when sorting using alphanumeric

### DIFF
--- a/test/SlowTests/Issues/RavenDB-17303.cs
+++ b/test/SlowTests/Issues/RavenDB-17303.cs
@@ -1,0 +1,63 @@
+﻿using System.Linq;
+using FastTests;
+using Raven.Client.Documents;
+using Raven.Client.Documents.Indexes;
+using Raven.Client.Documents.Linq;
+using Raven.Client.Documents.Session;
+using Xunit;
+using Xunit.Abstractions;
+
+namespace SlowTests.Issues
+{
+    public class RavenDB_17303 : RavenTestBase
+    {
+        public RavenDB_17303(ITestOutputHelper output) : base(output)
+        {
+        }
+
+        private class Item
+        {
+            public string Name;
+        }
+
+        private class Index : AbstractIndexCreationTask<Item>
+        {
+            public Index()
+            {
+                Map = items => from i in items
+                    select new { i.Name };
+                Indexes[i => i.Name] = FieldIndexing.Exact;
+            }
+        }
+
+        [Fact]
+        public void SortNullsWithAlphaNumerics()
+        {
+            using var store = GetDocumentStore();
+
+            using (var s = store.OpenSession())
+            {
+                s.Store(new Item { Name = "1BC" });
+                s.Store(new Item { Name = null});
+                s.Store(new Item { Name = "02BC" });
+                s.Store(new Item { Name = "Pla" });
+                s.Store(new Item { Name = "Me" });
+                s.SaveChanges();
+            }
+            
+            new Index().Execute(store);
+            WaitForIndexing(store);
+            
+            using (var s = store.OpenSession())
+            {
+                var names = s.Query<Item, Index>()
+                    .OrderBy(x => x.Name, OrderingType.AlphaNumeric)
+                    .Select(x=>x.Name)
+                    .ToList();
+                WaitForUserToContinueTheTest(store);
+                Assert.Equal(new[]{null, "1BC", "02BC", "Me", "Pla"}, names);
+            }
+
+        }
+    }
+}


### PR DESCRIPTION
### Issue link

https://issues.hibernatingrhinos.com/issue/RavenDB-17303

### Additional description

Handle the scenario where we need to sort using alphanumeric on values that are using `exact` indexing option.
The term we store in this case is `NULL_VALUE`, which means that we are now sorting `null` in the middle.


### Type of change

- Bug fix

I thought the alpha numeric sorter that `NULL_VALUE` is a `null` value, which means that it is sorted first. 

### How risky is the change?

- Low 

### Backward compatibility

May change the sort order of queries. 

### Is it platform specific issue?
.
- No

### Documentation update

We probably should add some note in the documentation on how we sort nulls. 

### Testing 

- Tests have been added that prove the fix is effective or that the feature works

