### PR TITLE
RavenDB-17306 & RavenDB-17305 Better trust relationship between servers

### DIFF
--- a/test/SlowTests/Issues/RavenDB-17305.cs
+++ b/test/SlowTests/Issues/RavenDB-17305.cs
@@ -13,6 +13,7 @@ using Raven.Server.Utils;
 using Sparrow.Json;
 using Voron.Util;
 using Xunit;
+using Xunit.Abstractions;
 
 namespace SlowTests.Issues
 {
@@ -30,7 +31,7 @@ namespace SlowTests.Issues
             string certFileName = Path.GetTempFileName();
             using var _ = new DisposableAction(() => IOExtensions.DeleteFile(certFileName));
             File.WriteAllBytes(certFileName, certificate.Export(X509ContentType.Pkcs12));
-            SetupServerAuthentication(serverCertPath: certFileName);
+            SetupServerAuthentication(certificates: new TestCertificatesHolder(certFileName, null, null, null));
             var store = GetDocumentStore(new Options { ModifyDocumentStore = documentStore => documentStore.Certificate = new X509Certificate2(certFileName) });
 
             Assert.StartsWith("https", store.Urls[0]);
@@ -99,6 +100,10 @@ namespace SlowTests.Issues
                     }
                 }
             }
+        }
+
+        public RavenDB_17305(ITestOutputHelper output) : base(output)
+        {
         }
     }
 }

--- a/test/SlowTests/Issues/RavenDB-17305.cs
+++ b/test/SlowTests/Issues/RavenDB-17305.cs
@@ -1,0 +1,104 @@
+﻿using System;
+using System.IO;
+using System.Net.Http;
+using System.Security.Cryptography;
+using System.Security.Cryptography.X509Certificates;
+using FastTests;
+using Newtonsoft.Json;
+using Raven.Client.Documents;
+using Raven.Client.Documents.Conventions;
+using Raven.Client.Http;
+using Raven.Client.ServerWide.Operations;
+using Raven.Server.Utils;
+using Sparrow.Json;
+using Voron.Util;
+using Xunit;
+
+namespace SlowTests.Issues
+{
+    public class RavenDB_17305 : RavenTestBase
+    {
+        [Fact]
+        public void WillExplicitlyTrustOurOwnCertificate_SelfSigned()
+        {
+            var certificate = CertificateRequest(Environment.MachineName).CreateSelfSigned(DateTime.Today.AddDays(-1), DateTime.Today.AddDays(1));
+            ValidateServerCanTalkToItself(certificate);
+        }
+        
+        private void ValidateServerCanTalkToItself(X509Certificate2 certificate)
+        {
+            string certFileName = Path.GetTempFileName();
+            using var _ = new DisposableAction(() => IOExtensions.DeleteFile(certFileName));
+            File.WriteAllBytes(certFileName, certificate.Export(X509ContentType.Pkcs12));
+            SetupServerAuthentication(serverCertPath: certFileName);
+            var store = GetDocumentStore(new Options { ModifyDocumentStore = documentStore => documentStore.Certificate = new X509Certificate2(certFileName) });
+
+            Assert.StartsWith("https", store.Urls[0]);
+            
+            WaitForUserToContinueTheTest(store);
+
+            var results = store.Maintenance.Server.Send(new PingOperation());
+            Assert.Equal(1, results.Length);
+            Assert.Null(results[0].Error);
+        }
+
+        private static CertificateRequest CertificateRequest(string host)
+        {
+            RSA key = RSA.Create();
+            var certificateRequest =
+                new CertificateRequest(new X500DistinguishedName("CN=" + host), key, HashAlgorithmName.SHA256, RSASignaturePadding.Pkcs1)
+                {
+                    CertificateExtensions =
+                    {
+                        new X509BasicConstraintsExtension(true, false, 0, false),
+                        new X509KeyUsageExtension(
+                            X509KeyUsageFlags.KeyEncipherment | X509KeyUsageFlags.KeyCertSign | X509KeyUsageFlags.CrlSign | X509KeyUsageFlags.DigitalSignature, false),
+                        new X509EnhancedKeyUsageExtension(new OidCollection
+                        {
+                            new Oid("1.3.6.1.5.5.7.3.2"), // client authentication
+                            new Oid("1.3.6.1.5.5.7.3.1"), // server authentication
+                        }, true)
+                    }
+                };
+            return certificateRequest;
+        }
+
+        private class PingOperation : IServerOperation<PingOperation.PingResult[]>
+        {
+            public RavenCommand<PingResult[]> GetCommand(DocumentConventions conventions, JsonOperationContext context)
+            {
+                return new PingCommand();
+            }
+
+            public class PingResult
+            {
+                public string Url;
+                public int TcpInfoTime;
+                public int SendTime;
+                public int RceiveTime;
+                public string Error;
+                public string[] Log;
+            }
+
+            public class PingCommand : RavenCommand<PingResult[]>
+            {
+                public override bool IsReadRequest => true;
+
+                public override HttpRequestMessage CreateRequest(JsonOperationContext ctx, ServerNode node, out string url)
+                {
+                    url = $"{node.Url}/admin/debug/node/ping";
+                    return new HttpRequestMessage { Method = HttpMethod.Get };
+                }
+
+                public override void SetResponse(JsonOperationContext context, BlittableJsonReaderObject response, bool fromCache)
+                {
+                    // quick & dirty impl
+                    if (response.TryGetMember("Result", out var results) && results is BlittableJsonReaderArray array)
+                    {
+                        Result = JsonConvert.DeserializeObject<PingResult[]>(array.ToString());
+                    }
+                }
+            }
+        }
+    }
+}

--- a/test/SlowTests/Issues/RavenDB-17305.cs
+++ b/test/SlowTests/Issues/RavenDB-17305.cs
@@ -74,9 +74,9 @@ namespace SlowTests.Issues
             public class PingResult
             {
                 public string Url;
-                public int TcpInfoTime;
-                public int SendTime;
-                public int RceiveTime;
+                public long TcpInfoTime;
+                public long SendTime;
+                public long ReceiveTime;
                 public string Error;
                 public string[] Log;
             }


### PR DESCRIPTION
RavenDB-17305 RavenDB servers should trust the other side of a TLS connection if they use the same certificate
RavenDB-17306 Allow to configure explicitly trusted certificates via environment variables

### Issue link

https://issues.hibernatingrhinos.com/issue/RavenDB-RavenDB-17305 
https://issues.hibernatingrhinos.com/issue/RavenDB-RavenDB-17306 

### Additional description

This will teach RavenDB to trust (as a client) its own certificate as a server. This helps if the server certificate expired, the server will still be able to reach itself. Same if this is a self signed certificate. 

We also provide a mechanism to support quickly adding trust certificate manually via environment variable, for both clients & servers. This is to ensure that if the server certificate expired, the admin can still kick things into working shape while waiting for it to be applied.


### Type of change

- New feature

### How risky is the change?

- High

This impact the manner in which RavenDB evaluates other nodes in the network and needs to be locked at in terms of the security impact it has.

### Backward compatibility

- Ensured. Please explain how has it been implemented?

This allows more, does not detract.

### Is it platform specific issue?

- No

### Documentation update

- This change requires a documentation update. Please mark the issue on YouTrack using `Documentation Required` tag.


### Testing 

- Tests have been added that prove the fix is effective or that the feature works

**However** in our test infrastructure we are trusting all certs, which make it a PITA to test with this mechanism. 
The current tests are not really testing this.

### UI work

- It requires further work in the Studio

We probably want to list the explicitly trusted certificates like we do for `WellKnown`.
