### PR TITLE
RavenDB-17267 Dispose Tcp client in Ping & TestConnection operations

### DIFF
--- a/src/Raven.Client/Util/TcpUtils.cs
+++ b/src/Raven.Client/Util/TcpUtils.cs
@@ -274,8 +274,10 @@ namespace Raven.Client.Util
 
             public void Dispose()
             {
-                TcpClient?.Dispose();
-                Stream?.Dispose();
+                using (TcpClient)
+                using (Stream)
+                {
+                }
             }
         }
 

--- a/src/Raven.Server/Documents/Handlers/Debugging/NodeDebugHandler.cs
+++ b/src/Raven.Server/Documents/Handlers/Debugging/NodeDebugHandler.cs
@@ -153,10 +153,12 @@ namespace Raven.Server.Documents.Handlers.Debugging
                 
                 using (ServerStore.ContextPool.AllocateOperationContext(out JsonOperationContext context))
                 {
-                    List<string> log = new();
+                    var log = new List<string>();
 
-                    await TcpUtils.ConnectSecuredTcpSocket(info, ServerStore.Engine.ClusterCertificate, Server.CipherSuitesPolicy,
+                    var tcpSocketResult = await TcpUtils.ConnectSecuredTcpSocket(info, ServerStore.Engine.ClusterCertificate, Server.CipherSuitesPolicy,
                         TcpConnectionHeaderMessage.OperationTypes.Ping, NegotiationCallback, context, ServerStore.Engine.TcpConnectionTimeout, log, cts.Token);
+                    await tcpSocketResult.Stream.DisposeAsync();
+                    tcpSocketResult.TcpClient.Dispose();
 
                     result.Log = log;
 

--- a/src/Raven.Server/Documents/Handlers/Debugging/NodeDebugHandler.cs
+++ b/src/Raven.Server/Documents/Handlers/Debugging/NodeDebugHandler.cs
@@ -157,8 +157,8 @@ namespace Raven.Server.Documents.Handlers.Debugging
 
                     var tcpSocketResult = await TcpUtils.ConnectSecuredTcpSocket(info, ServerStore.Engine.ClusterCertificate, Server.CipherSuitesPolicy,
                         TcpConnectionHeaderMessage.OperationTypes.Ping, NegotiationCallback, context, ServerStore.Engine.TcpConnectionTimeout, log, cts.Token);
-                    await tcpSocketResult.Stream.DisposeAsync();
-                    tcpSocketResult.TcpClient.Dispose();
+
+                    tcpSocketResult.Dispose();
 
                     result.Log = log;
 

--- a/src/Raven.Server/Documents/Handlers/Debugging/NodeDebugHandler.cs
+++ b/src/Raven.Server/Documents/Handlers/Debugging/NodeDebugHandler.cs
@@ -155,10 +155,10 @@ namespace Raven.Server.Documents.Handlers.Debugging
                 {
                     var log = new List<string>();
 
-                    var tcpSocketResult = await TcpUtils.ConnectSecuredTcpSocket(info, ServerStore.Engine.ClusterCertificate, Server.CipherSuitesPolicy,
-                        TcpConnectionHeaderMessage.OperationTypes.Ping, NegotiationCallback, context, ServerStore.Engine.TcpConnectionTimeout, log, cts.Token);
-
-                    tcpSocketResult.Dispose();
+                    using (await TcpUtils.ConnectSecuredTcpSocket(info, ServerStore.Engine.ClusterCertificate, Server.CipherSuitesPolicy,
+                        TcpConnectionHeaderMessage.OperationTypes.Ping, NegotiationCallback, context, ServerStore.Engine.TcpConnectionTimeout, log, cts.Token))
+                    {
+                    }
 
                     result.Log = log;
 

--- a/src/Raven.Server/ServerWide/ClusterStateMachine.cs
+++ b/src/Raven.Server/ServerWide/ClusterStateMachine.cs
@@ -3483,24 +3483,23 @@ namespace Raven.Server.ServerWide
                     SupportedFeatures = supportedFeatures,
                     Disconnect = () =>
                     {
+                        try
                         {
-                            try
-                            {
-                                tcpClient.Client.Disconnect(false);
-                            }
-                            catch (ObjectDisposedException)
-                            {
-                                //Happens, we don't really care at this point
-                            }
+                            tcpClient.Client.Disconnect(false);
+                            stream.Dispose();
+                            tcpClient.Dispose();
+                        }
+                        catch (ObjectDisposedException)
+                        {
+                            //Happens, we don't really care at this point
                         }
                     }
                 };
             }
             catch (Exception)
             {
-                if (stream != null)
-                    await stream.DisposeAsync();
                 tcpClient?.Dispose();
+                stream?.Dispose();
                 throw;
             }
         }

--- a/src/Raven.Server/ServerWide/ClusterStateMachine.cs
+++ b/src/Raven.Server/ServerWide/ClusterStateMachine.cs
@@ -3485,9 +3485,11 @@ namespace Raven.Server.ServerWide
                     {
                         try
                         {
-                            tcpClient.Client.Disconnect(false);
-                            stream.Dispose();
-                            tcpClient.Dispose();
+                            using (tcpClient)
+                            using (stream)
+                            {
+                                tcpClient.Client.Disconnect(false);
+                            }
                         }
                         catch (ObjectDisposedException)
                         {
@@ -3498,8 +3500,10 @@ namespace Raven.Server.ServerWide
             }
             catch (Exception)
             {
-                tcpClient?.Dispose();
-                stream?.Dispose();
+                using (tcpClient)
+                await using (stream)
+                {
+                }
                 throw;
             }
         }

--- a/src/Raven.Server/Web/System/TestConnectionHandler.cs
+++ b/src/Raven.Server/Web/System/TestConnectionHandler.cs
@@ -59,8 +59,7 @@ namespace Raven.Server.Web.System
                 var tcpSocketResult = await TcpUtils.ConnectSecuredTcpSocket(tcpConnectionInfo, server.Certificate.Certificate, server.CipherSuitesPolicy,
                     TcpConnectionHeaderMessage.OperationTypes.TestConnection,
                     NegotiateWithRemote, ctx, timeout, negLogs, token);
-                await tcpSocketResult.Stream.DisposeAsync();
-                tcpSocketResult.TcpClient.Dispose();
+                tcpSocketResult.Dispose();
             }
 
             result.Log = negLogs;

--- a/src/Raven.Server/Web/System/TestConnectionHandler.cs
+++ b/src/Raven.Server/Web/System/TestConnectionHandler.cs
@@ -56,9 +56,11 @@ namespace Raven.Server.Web.System
 
             using (server.ServerStore.ContextPool.AllocateOperationContext(out JsonOperationContext ctx))
             {
-                await TcpUtils.ConnectSecuredTcpSocket(tcpConnectionInfo, server.Certificate.Certificate, server.CipherSuitesPolicy,
+                var tcpSocketResult = await TcpUtils.ConnectSecuredTcpSocket(tcpConnectionInfo, server.Certificate.Certificate, server.CipherSuitesPolicy,
                     TcpConnectionHeaderMessage.OperationTypes.TestConnection,
                     NegotiateWithRemote, ctx, timeout, negLogs, token);
+                await tcpSocketResult.Stream.DisposeAsync();
+                tcpSocketResult.TcpClient.Dispose();
             }
 
             result.Log = negLogs;

--- a/src/Raven.Server/Web/System/TestConnectionHandler.cs
+++ b/src/Raven.Server/Web/System/TestConnectionHandler.cs
@@ -56,10 +56,9 @@ namespace Raven.Server.Web.System
 
             using (server.ServerStore.ContextPool.AllocateOperationContext(out JsonOperationContext ctx))
             {
-                var tcpSocketResult = await TcpUtils.ConnectSecuredTcpSocket(tcpConnectionInfo, server.Certificate.Certificate, server.CipherSuitesPolicy,
+                using var tcpSocketResult = await TcpUtils.ConnectSecuredTcpSocket(tcpConnectionInfo, server.Certificate.Certificate, server.CipherSuitesPolicy,
                     TcpConnectionHeaderMessage.OperationTypes.TestConnection,
                     NegotiateWithRemote, ctx, timeout, negLogs, token);
-                tcpSocketResult.Dispose();
             }
 
             result.Log = negLogs;


### PR DESCRIPTION
### Issue link

https://issues.hibernatingrhinos.com/issue/RavenDB-17267

### Additional description
The main fix here is to dispose the TCP client on Ping & TestConnection operations
I also fixed the URLs list to not contain duplicate

### Type of change
- Bug fix

### How risky is the change?
- Low 

### Backward compatibility
- Not relevant

### Is it platform specific issue?
- No

### Documentation update
- No documentation update is needed 

### Testing 
I managed to test it manually by creating a cluster of two nodes and calling `/admin/debug/node/ping` continuously.
When the TCP clients are **not** disposed a lot (hundreds) of TCP connections stay on `CLOSE_WAITE`
When the TCP clients are disposed the TCP connections immediately become `TIME_WAITE`
For some reason, I didn't get the same result on the test. 
When the TCP clients have not disposed the TCP connections become `CLOSE_WAITE` but also cleaned immediately.
Since I couldn't get consistent results from the tests and `Dispose` is obvious here I left it without tests.

### Is there any existing behavior change of other features due to this change?
- No

### UI work
- No UI work is needed
