### PR TITLE
RavenDB-17316 use default conventions to OperationState in OperationStatusChange because user conventions might have TypeNameHandling set to None (fixes SlowTests.Issues.RavenDB_17177.Can_WaitForOperation_When_TypeNameHandling_Is_None)

### DIFF
--- a/src/Raven.Client/Documents/Changes/DatabaseChanges.cs
+++ b/src/Raven.Client/Documents/Changes/DatabaseChanges.cs
@@ -673,7 +673,7 @@ namespace Raven.Client.Documents.Changes
                     }
                     break;
                 case nameof(OperationStatusChange):
-                    var operationStatusChange = OperationStatusChange.FromJson(value, _conventions);
+                    var operationStatusChange = OperationStatusChange.FromJson(value);
                     foreach (var state in states)
                     {
                         state.Send(operationStatusChange);

--- a/src/Raven.Client/Documents/Operations/OperationStatusChange.cs
+++ b/src/Raven.Client/Documents/Operations/OperationStatusChange.cs
@@ -20,7 +20,7 @@ namespace Raven.Client.Documents.Operations
             };
         }
 
-        internal static OperationStatusChange FromJson(BlittableJsonReaderObject value, DocumentConventions conventions)
+        internal static OperationStatusChange FromJson(BlittableJsonReaderObject value)
         {
             value.TryGet(nameof(OperationId), out long operationId);
             value.TryGet(nameof(State), out BlittableJsonReaderObject stateAsJson);
@@ -28,7 +28,7 @@ namespace Raven.Client.Documents.Operations
             return new OperationStatusChange
             {
                 OperationId = operationId,
-                State = (OperationState)conventions.DeserializeEntityFromBlittable(typeof(OperationState), stateAsJson)
+                State = (OperationState)DocumentConventions.Default.DeserializeEntityFromBlittable(typeof(OperationState), stateAsJson)
             };
         }
     }


### PR DESCRIPTION
### Issue link

https://issues.hibernatingrhinos.com/issue/RavenDB-17316

### Type of change

- Bug fix

### How risky is the change?

- Low 

### Backward compatibility

- Non breaking change

### Is it platform specific issue?

- No

### Documentation update

- No documentation update is needed 

### Testing 

- Tests have been added that prove the fix is effective or that the feature works

### Is there any existing behavior change of other features due to this change?

- No

### UI work

- No UI work is needed
