### PR TITLE
[For testing purposes] RavenDB-17194 Invalid handling of journals created based on recyclable ones during the storage recovery on startup

### DIFF
--- a/src/Voron/Impl/Journal/JournalReader.cs
+++ b/src/Voron/Impl/Journal/JournalReader.cs
@@ -241,7 +241,12 @@ namespace Voron.Impl.Journal
             var transactionSizeIn4Kb = GetTransactionSizeIn4Kb(current);
 
             _readAt4Kb += transactionSizeIn4Kb;
-            LastTransactionHeader = current;
+
+            if (LastTransactionHeader == null || LastTransactionHeader->TransactionId < current->TransactionId) // precaution
+            {
+                if (current->TransactionId > _journalInfo.LastSyncedTransactionId)
+                    LastTransactionHeader = current;
+            }
         }
 
         private bool IsAlreadySyncTransaction(TransactionHeader* current)
@@ -281,7 +286,8 @@ namespace Voron.Impl.Journal
             {
                 Debug.Assert(transactionHeaders.Count == 0 || LastTransactionHeader->TransactionId > transactionHeaders.Last().TransactionId);
 
-                transactionHeaders.Add(*LastTransactionHeader);
+                if (LastTransactionHeader != null)
+                    transactionHeaders.Add(*LastTransactionHeader);
             }
             ZeroRecoveryBufferIfNeeded(this, options);
 
@@ -376,6 +382,9 @@ namespace Voron.Impl.Journal
             if (current->TransactionId < 0)
                 return false;
 
+            if (IsOldTransactionFromRecycledJournal(current))
+                return false;
+
             current = EnsureTransactionMapped(current, pageNumber, positionInsidePage);
             bool hashIsValid;
             if (options.Encryption.IsEnabled)
@@ -444,6 +453,8 @@ namespace Voron.Impl.Journal
                         return true;
                     }
 
+                    AssertValidLastPageNumber(current);
+
                     if (hashIsValid && _firstValidTransactionHeader == null)
                         _firstValidTransactionHeader = current;
 
@@ -463,7 +474,7 @@ namespace Voron.Impl.Journal
                     if (CanIgnoreDataIntegrityErrorBecauseTxWasSynced(current, options))
                     {
                         options.InvokeIntegrityErrorOfAlreadySyncedData(this,
-                            $"Encountered integrity error of transaction data which has been already synced (tx id: {current->TransactionId}, last synced tx: {_journalInfo.LastSyncedTransactionId}, journal: {_journalInfo.CurrentJournal}). Negative tx id diff: {txIdDiff}. " +
+                            $"Encountered integrity error of transaction data which has been already synced  when reading {_journalPager.FileName} file (tx id: {current->TransactionId}, current journal: {_journalInfo.CurrentJournal}, last synced tx: {_journalInfo.LastSyncedTransactionId}, last synced journal: {_journalInfo.LastSyncedJournal}). Negative tx id diff: {txIdDiff}. " +
                             "Safely continuing the startup recovery process.", null);
 
                         return true;
@@ -503,20 +514,7 @@ namespace Voron.Impl.Journal
                     }
                 }
 
-                // if (txIdDiff == 1) :
-                if (current->LastPageNumber <= 0)
-                {
-                    if (CanIgnoreDataIntegrityErrorBecauseTxWasSynced(current, options))
-                    {
-                        options.InvokeIntegrityErrorOfAlreadySyncedData(this,
-                            $"Invalid last page number ({current->LastPageNumber}) in the header of transaction which has been already synced (tx id: {current->TransactionId}, last synced tx: {_journalInfo.LastSyncedTransactionId}, journal: {_journalInfo.CurrentJournal}). " +
-                            $"Safely continuing the startup recovery process. Debug details - file header {_currentFileHeader}", null);
-
-                        return true;
-                    }
-
-                    throw new InvalidDataException("Last page number after committed transaction must be greater than 0. Debug details - file header {_currentFileHeader}");
-                }
+                AssertValidLastPageNumber(current);
             }
 
             if (hashIsValid == false)
@@ -538,6 +536,24 @@ namespace Voron.Impl.Journal
                 _firstValidTransactionHeader = current;
 
             return true;
+
+            void AssertValidLastPageNumber(TransactionHeader* transactionHeader)
+            {
+                if (transactionHeader->LastPageNumber <= 0)
+                {
+                    if (CanIgnoreDataIntegrityErrorBecauseTxWasSynced(transactionHeader, options))
+                    {
+                        options.InvokeIntegrityErrorOfAlreadySyncedData(this,
+                            $"Invalid last page number ({transactionHeader->LastPageNumber}) in the header of transaction which has been already synced (tx id: {transactionHeader->TransactionId}, last synced tx: {_journalInfo.LastSyncedTransactionId}, journal: {_journalInfo.CurrentJournal}). " +
+                            $"Safely continuing the startup recovery process. Debug details - file header {_currentFileHeader}", null);
+                    }
+                    else
+                    {
+                        throw new InvalidDataException(
+                            $"Last page number after committed transaction must be greater than 0. Debug details - file header {_currentFileHeader}");
+                    }
+                }
+            }
         }
 
         private bool CanIgnoreDataIntegrityErrorBecauseTxWasSynced(TransactionHeader* currentTx, StorageEnvironmentOptions options)
@@ -546,8 +562,22 @@ namespace Voron.Impl.Journal
             // then we can continue the recovery regardless encountered errors
 
             return options.IgnoreDataIntegrityErrorsOfAlreadySyncedTransactions &&
-                   IsAlreadySyncTransaction(currentTx) &&
-                   (_firstValidTransactionHeader == null || currentTx->TransactionId > _firstValidTransactionHeader->TransactionId); // when reusing journal we might encounter a transaction with valid Id but it comes from already deleted (and reused journal)
+                   IsAlreadySyncTransaction(currentTx); 
+        }
+
+        private bool IsOldTransactionFromRecycledJournal(TransactionHeader* currentTx)
+        {
+            // when reusing journal we might encounter a transaction with valid Id but it comes from already deleted (and reused journal - recyclable one)
+
+            if (_firstValidTransactionHeader != null && currentTx->TransactionId < _firstValidTransactionHeader->TransactionId)
+                return true;
+
+            if (LastTransactionHeader != null && currentTx->TransactionId < LastTransactionHeader->TransactionId)
+                return true;
+
+
+
+            return false;
         }
 
         private TransactionHeader* EnsureTransactionMapped(TransactionHeader* current, long pageNumber, long positionInsidePage)

--- a/src/Voron/Impl/Journal/WriteAheadJournal.cs
+++ b/src/Voron/Impl/Journal/WriteAheadJournal.cs
@@ -211,6 +211,12 @@ namespace Voron.Impl.Journal
 
                             if (lastReadHeaderPtr != null)
                             {
+                                if (lastFlushedJournal != -1 && lastReadHeaderPtr->TransactionId < lastFlushedTxId)
+                                {
+                                    throw new InvalidOperationException(
+                                        $"After recovering {pager} file we got tx {lastReadHeaderPtr->TransactionId} as the last one but it's lower than last flushed transaction - tx {lastFlushedTxId} (from {StorageEnvironmentOptions.JournalName(lastFlushedJournal)})");
+                                }
+
                                 *txHeader = *lastReadHeaderPtr;
                                 lastFlushedTxId = txHeader->TransactionId;
 
@@ -323,7 +329,7 @@ namespace Voron.Impl.Journal
                     "First transaction initializing the structure of Voron database is corrupted. Cannot access internal database metadata. Create a new database to recover.");
 
             Debug.Assert(lastFlushedTxId >= 0);
-            Debug.Assert(lastFlushedJournal >= 0);
+            // Debug.Assert(lastFlushedJournal >= 0); explicitly commented - it's valid state to not flush any pages from processed journal if we had already everything synced or journal was empty
             Debug.Assert(lastProcessedJournal >= 0);
 
             if (journalFiles.Count > 0)
@@ -361,7 +367,7 @@ namespace Voron.Impl.Journal
 #if DEBUG
                 if (instanceOfLastFlushedJournal == null)
                 {
-                    Debug.Assert(toDelete.Count == 0 || (toDelete.Count == 1 && deleteLastJournal),
+                    Debug.Assert(toDelete.Count == 0 || (toDelete.Count >= 1 && deleteLastJournal),
                         $"Last flushed journal (number: {lastFlushedJournal}) doesn't exist so we didn't call {nameof(_journalApplicator.SetLastFlushed)}" +
                         $" and didn't mark to delete last journal but," +
                         $" there are still some journals to delete ({string.Join(", ", toDelete.Select(x => x.Number))}. )");
@@ -1146,7 +1152,11 @@ namespace Voron.Impl.Journal
 
                     _currentTotalWrittenBytes = Interlocked.Read(ref _parent._totalWrittenButUnsyncedBytes);
                     _lastFlushed.Journal.SetLastReadTxHeader(_lastFlushed.TransactionId, ref _transactionHeader);
-                    if (_lastFlushed.TransactionId != _transactionHeader.TransactionId)
+
+                    if (_transactionHeader.HeaderMarker != Constants.TransactionHeaderMarker)
+                        return false;
+
+                    if ( _lastFlushed.TransactionId != _transactionHeader.TransactionId)
                     {
                         ThrowErrorWhenSyncingDataFile(_lastFlushed, _transactionHeader, _parent._waj._env);
                     }

--- a/test/SlowTests/Voron/Backups/Incremental.cs
+++ b/test/SlowTests/Voron/Backups/Incremental.cs
@@ -52,6 +52,8 @@ namespace SlowTests.Voron.Backups
                 tx.Commit();
             }
 
+            long nextPageNumberBeforeBackup = Env.NextPageNumber;
+
             BackupMethods.Incremental.ToFile(Env, _incrementalBackupTestUtils.IncrementalBackupFile(0));
 
             var options = StorageEnvironmentOptions.ForPath(_incrementalBackupTestUtils.RestoredStoragePath);
@@ -61,6 +63,7 @@ namespace SlowTests.Voron.Backups
 
             using (var env = new StorageEnvironment(options))
             {
+                Assert.Equal(nextPageNumberBeforeBackup, env.NextPageNumber);
 
                 using (var tx = env.ReadTransaction())
                 {
@@ -256,6 +259,8 @@ namespace SlowTests.Voron.Backups
             var usedByLastTransaction = Env.Journal.CurrentFile.WritePosIn4KbPosition - writePos;
             Assert.Equal(0, usedByLastTransaction);
 
+            long nextPageNumberBeforeBackup = Env.NextPageNumber;
+
             backedUpPages = BackupMethods.Incremental.ToFile(Env, _incrementalBackupTestUtils.IncrementalBackupFile(1));
 
             Assert.Equal(usedByLastTransaction, backedUpPages);
@@ -271,6 +276,8 @@ namespace SlowTests.Voron.Backups
 
             using (var env = new StorageEnvironment(options))
             {
+                Assert.Equal(nextPageNumberBeforeBackup, env.NextPageNumber);
+
                 using (var tx = env.ReadTransaction())
                 {
                     var tree = tx.CreateTree("foo");
@@ -317,6 +324,8 @@ namespace SlowTests.Voron.Backups
                 tx.Commit();
             }
 
+            long nextPageNumberBeforeBackup = Env.NextPageNumber;
+
             BackupMethods.Incremental.ToFile(Env, _incrementalBackupTestUtils.IncrementalBackupFile(0));
 
             var options = StorageEnvironmentOptions.ForPath(_incrementalBackupTestUtils.RestoredStoragePath);
@@ -329,6 +338,8 @@ namespace SlowTests.Voron.Backups
 
             using (var env = new StorageEnvironment(options))
             {
+                Assert.Equal(nextPageNumberBeforeBackup, env.NextPageNumber);
+
                 using (var tx = env.ReadTransaction())
                 {
                     var tree = tx.ReadTree("test");

--- a/test/SlowTests/Voron/Issues/RavenDB_17194.cs
+++ b/test/SlowTests/Voron/Issues/RavenDB_17194.cs
@@ -1,0 +1,321 @@
+﻿using System;
+using System.IO;
+using FastTests.Voron;
+using Voron;
+using Voron.Impl.Journal;
+using Xunit;
+using Xunit.Abstractions;
+
+namespace SlowTests.Voron.Issues
+{
+    public class RavenDB_17194 : StorageTest
+    {
+        public RavenDB_17194(ITestOutputHelper output) : base(output)
+        {
+        }
+
+        protected override void Configure(StorageEnvironmentOptions options)
+        {
+            options.ManualFlushing = true;
+            options.ManualSyncing = true;
+            options.MaxLogFileSize = 65536;
+
+            // we set those options in RavenDB
+            options.IgnoreDataIntegrityErrorsOfAlreadySyncedTransactions = true;
+            options.OnIntegrityErrorOfAlreadySyncedData += (sender, eventArgs) =>
+            {
+                // ignore in tests, in RavenDB we put an alert in that case, but it doesn't prevent the startup process from proceeding
+            };
+        }
+
+        [Fact]
+        public void MustNotReadAndProceedWithRecyclableButEffectivelyEmptyJournalOnRecovery()
+        {
+            RequireFileBasedPager();
+
+            long lastCommittedTxId = -1;
+
+            var r = new Random(10_09_2021);
+
+            for (int i = 0; i < 20; i++)
+            {
+                using (var tx = Env.WriteTransaction())
+                {
+                    var tree = tx.CreateTree("foo");
+
+                    tree.Add($"items/{i}", new byte[]{ 1, 2, 3, (byte)i });
+
+                    tx.Commit();
+
+                    lastCommittedTxId = tx.LowLevelTransaction.Id;
+                }
+            }
+
+            Assert.Equal(2, Env.Journal.Files.Count);
+
+            Env.FlushLogToDataFile();
+
+            using (var operation = new WriteAheadJournal.JournalApplicator.SyncOperation(Env.Journal.Applicator))
+            {
+                operation.SyncDataFile();
+            }
+
+            Assert.Equal(1, Env.Journal.Files.Count);
+
+            var journalPath = ((StorageEnvironmentOptions.DirectoryStorageEnvironmentOptions)Env.Options).JournalPath.FullPath;
+
+
+            var journalsForReuse = new DirectoryInfo(journalPath).GetFiles($"{StorageEnvironmentOptions.RecyclableJournalFileNamePrefix}*");
+
+            Assert.Equal(1, journalsForReuse.Length);
+
+
+            using (var tx = Env.WriteTransaction())
+            {
+                // we are writing big values in this tx to ensure we'll have NextFile() call that will create a new journal (based on the recyclable journal file that exists)
+
+                for (int i = 0; i < 100; i++)
+                {
+                    var bytes = new byte[2000];
+
+                    r.NextBytes(bytes);
+
+                    tx.CreateTree("bar").Add($"bigValues/{i}", bytes);
+                }
+
+                Assert.Throws<InvalidOperationException>(() =>
+                {
+                    using (tx.LowLevelTransaction.ForTestingPurposesOnly().CallJustBeforeWritingToJournal(() => throw new InvalidOperationException()))
+                    {
+                        tx.Commit();
+                    }
+                });
+            }
+
+            // we failed to commit the above transaction and write data to file but we managed to create _empty_ journal file
+            // this journal was created based on the recyclable journal which had old transactions already there that causes problems during recovery below
+
+            RestartDatabase();
+
+            using (var tx = Env.WriteTransaction())
+            {
+                Assert.Equal(lastCommittedTxId + 1, tx.LowLevelTransaction.Id);
+            }
+        }
+
+
+        [Fact]
+        public void TheCaseWithTwoEmptyJournalFiles()
+        {
+            RequireFileBasedPager();
+
+            long lastCommittedTxId = -1;
+
+            var r = new Random(10_09_2021);
+
+            for (int i = 0; i < 20; i++)
+            {
+                using (var tx = Env.WriteTransaction())
+                {
+                    var tree = tx.CreateTree("foo");
+
+                    tree.Add($"items/{i}", new byte[] { 1, 2, 3, (byte)i });
+
+                    tx.Commit();
+
+                    lastCommittedTxId = tx.LowLevelTransaction.Id;
+                }
+            }
+
+            Assert.Equal(2, Env.Journal.Files.Count);
+
+
+            var journalPath = ((StorageEnvironmentOptions.DirectoryStorageEnvironmentOptions)Env.Options).JournalPath.FullPath;
+
+
+            var journalsForReuse = new DirectoryInfo(journalPath).GetFiles($"{StorageEnvironmentOptions.RecyclableJournalFileNamePrefix}*");
+
+            Assert.Equal(0, journalsForReuse.Length);
+
+
+            using (var tx = Env.WriteTransaction())
+            {
+                // we are writing big values in this tx to ensure we'll have NextFile() call that will create a new journal (empty file - not recyclable)
+
+                for (int i = 0; i < 100; i++)
+                {
+                    var bytes = new byte[2000];
+
+                    r.NextBytes(bytes);
+
+                    tx.CreateTree("bar").Add($"bigValues/{i}", bytes);
+                }
+
+                Assert.Throws<InvalidOperationException>(() =>
+                {
+                    using (tx.LowLevelTransaction.ForTestingPurposesOnly().CallJustBeforeWritingToJournal(() => throw new InvalidOperationException()))
+                    {
+                        tx.Commit();
+                    }
+                });
+            }
+
+            // we failed to commit the above transaction and write data to file but we managed to create _empty_ journal file
+
+            using (var operation = new WriteAheadJournal.JournalApplicator.SyncOperation(Env.Journal.Applicator))
+            {
+                operation.SyncDataFile();
+            }
+
+            RestartDatabase();
+
+            using (var tx = Env.WriteTransaction())
+            {
+                // we are writing big values in this tx to ensure we'll have NextFile() call that will create a new journal (again - empty file)
+
+                for (int i = 0; i < 100; i++)
+                {
+                    var bytes = new byte[2000];
+
+                    r.NextBytes(bytes);
+
+                    tx.CreateTree("bar").Add($"bigValues/{i}", bytes);
+                }
+
+                Assert.Throws<InvalidOperationException>(() =>
+                {
+                    using (tx.LowLevelTransaction.ForTestingPurposesOnly().CallJustBeforeWritingToJournal(() => throw new InvalidOperationException()))
+                    {
+                        tx.Commit();
+                    }
+                });
+            }
+
+            // we failed to commit the above transaction and write data to file but we managed to create _empty_ journal file
+            // at this point we have 2 empty journal files and that caused Debug.Assert() to fail in WriteAheadJournal.RecoverDatabase()
+
+            using (var operation = new WriteAheadJournal.JournalApplicator.SyncOperation(Env.Journal.Applicator))
+            {
+                operation.SyncDataFile();
+            }
+
+            RestartDatabase();
+
+            using (var tx = Env.WriteTransaction())
+            {
+                Assert.Equal(lastCommittedTxId + 1, tx.LowLevelTransaction.Id);
+            }
+        }
+
+        [Fact]
+        public void FirstJournalIsEmptyButContainsDataBecauseWasCreatedFromRecyclable()
+        {
+            RequireFileBasedPager();
+
+            long lastCommittedTxId = -1;
+
+            var r = new Random(10_09_2021);
+
+            for (int i = 0; i < 28; i++)
+            {
+                using (var tx = Env.WriteTransaction())
+                {
+                    var tree = tx.CreateTree("foo");
+
+                    tree.Add($"items/{i}", new byte[] { 1, 2, 3, (byte)i });
+
+                    tx.Commit();
+
+                    lastCommittedTxId = tx.LowLevelTransaction.Id;
+                }
+            }
+
+            Assert.Equal(2, Env.Journal.Files.Count);
+
+            Env.FlushLogToDataFile();
+
+            using (var operation = new WriteAheadJournal.JournalApplicator.SyncOperation(Env.Journal.Applicator))
+            {
+                operation.SyncDataFile();
+            }
+
+            var journalPath = ((StorageEnvironmentOptions.DirectoryStorageEnvironmentOptions)Env.Options).JournalPath.FullPath;
+
+
+            var journalsForReuse = new DirectoryInfo(journalPath).GetFiles($"{StorageEnvironmentOptions.RecyclableJournalFileNamePrefix}*");
+
+            Assert.Equal(1, journalsForReuse.Length);
+
+
+            using (var tx = Env.WriteTransaction())
+            {
+                // we are writing big values in this tx to ensure we'll have NextFile() call that will create a new journal (based on the recyclable journal file that exists)
+
+                for (int i = 0; i < 100; i++)
+                {
+                    var bytes = new byte[2000];
+
+                    r.NextBytes(bytes);
+
+                    tx.CreateTree("bar").Add($"bigValues/{i}", bytes);
+                }
+
+                Assert.Throws<InvalidOperationException>(() =>
+                {
+                    using (tx.LowLevelTransaction.ForTestingPurposesOnly().CallJustBeforeWritingToJournal(() => throw new InvalidOperationException()))
+                    {
+                        tx.Commit();
+                    }
+                });
+            }
+
+            // we failed to commit the above transaction and write data to file but we managed to create _empty_ journal file
+            // this journal was created based on the recyclable journal which had old transactions already there that caused problems during recovery below
+
+            using (var operation = new WriteAheadJournal.JournalApplicator.SyncOperation(Env.Journal.Applicator))
+            {
+                operation.SyncDataFile();
+            }
+
+            RestartDatabase();
+
+            using (var tx = Env.WriteTransaction())
+            {
+                // we are writing big values in this tx to ensure we'll have NextFile() call that will create a new journal (empty one)
+
+                for (int i = 0; i < 100; i++)
+                {
+                    var bytes = new byte[2000];
+
+                    r.NextBytes(bytes);
+
+                    tx.CreateTree("bar").Add($"bigValues/{i}", bytes);
+                }
+
+                Assert.Throws<InvalidOperationException>(() =>
+                {
+                    using (tx.LowLevelTransaction.ForTestingPurposesOnly().CallJustBeforeWritingToJournal(() => throw new InvalidOperationException()))
+                    {
+                        tx.Commit();
+                    }
+                });
+            }
+
+            // we failed to commit the above transaction and write data to file but we managed to create _empty_ journal file
+
+            using (var operation = new WriteAheadJournal.JournalApplicator.SyncOperation(Env.Journal.Applicator))
+            {
+                operation.SyncDataFile();
+            }
+
+            // at this point, the first journal is empty but it has old transactions data because it was created based on recyclable journal file
+
+            RestartDatabase();
+
+            using (var tx = Env.WriteTransaction())
+            {
+                Assert.Equal(lastCommittedTxId + 1, tx.LowLevelTransaction.Id);
+            }
+        }
+    }
+}

--- a/test/SlowTests/Voron/RavenDB_13940_Encrypted.cs
+++ b/test/SlowTests/Voron/RavenDB_13940_Encrypted.cs
@@ -421,7 +421,7 @@ namespace SlowTests.Voron
 
             StopDatabase();
 
-            CorruptJournal(lastJournal, sizeof(TransactionHeader) + 5, Constants.Size.Kilobyte * 4 * 6);
+            CorruptJournal(lastJournal, sizeof(TransactionHeader) + 5, Constants.Size.Kilobyte * 4 * 7);
 
             Assert.Throws<InvalidJournalException>(StartDatabase);
         }


### PR DESCRIPTION
### Issue link

https://issues.hibernatingrhinos.com/issue/RavenDB-17194

### Additional description

This is draft PR used to testing purposes only. It's gonna be closed and a new one will be opened which will include all details. Known issue here - randomly failing tests in `RavenDB_13940`