### PR TITLE
RavenDB-17324 use IOExtensions with retries to CreateDirectory because Windows indexing mechanism might hold that causing UnauthorizedAccessException

### DIFF
--- a/src/Raven.Server/Documents/PeriodicBackup/PeriodicBackupRunner.cs
+++ b/src/Raven.Server/Documents/PeriodicBackup/PeriodicBackupRunner.cs
@@ -66,7 +66,7 @@ namespace Raven.Server.Documents.PeriodicBackup
 
             _database.TombstoneCleaner.Subscribe(this);
             IOExtensions.DeleteDirectory(_tempBackupPath.FullPath);
-            Directory.CreateDirectory(_tempBackupPath.FullPath);
+            IOExtensions.CreateDirectory(_tempBackupPath.FullPath);
         }
 
         public NextBackup GetNextBackupDetails(

--- a/src/Raven.Server/Utils/IOExtensions.cs
+++ b/src/Raven.Server/Utils/IOExtensions.cs
@@ -73,7 +73,7 @@ namespace Raven.Server.Utils
                 }
                 catch
                 {
-                }                
+                }
                 return false;
             }
         }
@@ -140,6 +140,31 @@ namespace Raven.Server.Utils
                 catch (UnauthorizedAccessException e)
                 {
                     TryHandlingError(directory, i, e);
+                }
+            }
+        }
+
+        public static void CreateDirectory(string directory)
+        {
+            for (var i = 0; i < Retries; i++)
+            {
+                try
+                {
+                    if (Directory.Exists(directory))
+                        return;
+
+                    Directory.CreateDirectory(directory);
+                    return;
+                }
+                catch (Exception)
+                {
+                    if (i == Retries - 1)
+                        throw;
+
+                    GC.Collect();
+                    GC.WaitForPendingFinalizers();
+
+                    Thread.Sleep(100);
                 }
             }
         }


### PR DESCRIPTION
### Issue link

https://issues.hibernatingrhinos.com/issue/RavenDB-17324

### Additional description

Happens on occasion on Windows machines on our CI. I'm suspecting this is related to Delete/Create pattern used when PeriodicBackupTemp directory is created 

### Type of change

- Bug fix

### How risky is the change?

- Low 

### Backward compatibility

- Not relevant

### Is it platform specific issue?

- No

### Documentation update

- No documentation update is needed 

### Testing 

- No testing was done

### Is there any existing behavior change of other features due to this change?

- No

### UI work

- No UI work is needed
