### PR TITLE
RavenDB-17327 Allow to pass a SQL table name with a schema in the script

### DIFF
--- a/src/Raven.Client/Documents/Operations/ETL/Transformation.cs
+++ b/src/Raven.Client/Documents/Operations/ETL/Transformation.cs
@@ -22,7 +22,7 @@ namespace Raven.Client.Documents.Operations.ETL
 
         private static readonly Regex LoadToMethodRegex = new Regex($@"{LoadTo}(\w+)", RegexOptions.Compiled);
 
-        private static readonly Regex LoadToMethodRegexAlt = new Regex($@"{LoadTo}\(\'(\w+)\'|{LoadTo}\(\""(\w+)\""", RegexOptions.Compiled);
+        private static readonly Regex LoadToMethodRegexAlt = new Regex($@"{LoadTo}\(\'([\w\.]+)\'|{LoadTo}\(\""([\w\.]+)\""", RegexOptions.Compiled);
 
         private static readonly Regex LoadAttachmentMethodRegex = new Regex(LoadAttachment, RegexOptions.Compiled);
         private static readonly Regex AddAttachmentMethodRegex = new Regex(AddAttachment, RegexOptions.Compiled);


### PR DESCRIPTION
### Issue link

https://issues.hibernatingrhinos.com/issue/RavenDB-17327

### Additional description

Fixing the regex where we recognize the destination table name so a user can specify a schema name as well - `loadTo('schema.TableName', ... )`

### Type of change

- Bug fix

### How risky is the change?

- Low 

### Backward compatibility

- Not relevant

### Is it platform specific issue?

- No

### Documentation update

- We need to document that feature. 'Documentation Required` tag was added to the issue.

### Testing 

- Tests have been added that prove the fix is effective or that the feature works

### Is there any existing behavior change of other features due to this change?

- No

### UI work

- Validation improvements: https://issues.hibernatingrhinos.com/issue/RavenDB-17330 
