### PR TITLE
RavenDB-16042 validate if index was created for our database to avoida situation where data was copied from one database to another

### DIFF
--- a/src/Raven.Server/Config/Categories/IndexingConfiguration.cs
+++ b/src/Raven.Server/Config/Categories/IndexingConfiguration.cs
@@ -229,6 +229,12 @@ namespace Raven.Server.Config.Categories
         [ConfigurationEntry("Indexing.MaxNumberOfConcurrentlyRunningIndexes", ConfigurationEntryScope.ServerWideOnly)]
         public int? MaxNumberOfConcurrentlyRunningIndexes { get; set; }
 
+        [Description("EXPERT: Allows to open an index without checking if current Database ID matched the one for which index was created.")]
+        [DefaultValue(false)]
+        [IndexUpdateType(IndexUpdateType.None)]
+        [ConfigurationEntry("Indexing.SkipDatabaseIdValidationOnIndexOpening", ConfigurationEntryScope.ServerWideOrPerDatabase)]
+        public bool SkipDatabaseIdValidationOnIndexOpening { get; set; }
+
         protected override void ValidateProperty(PropertyInfo property)
         {
             var updateTypeAttribute = property.GetCustomAttribute<IndexUpdateTypeAttribute>();

--- a/src/Raven.Server/Documents/DocumentDatabase.cs
+++ b/src/Raven.Server/Documents/DocumentDatabase.cs
@@ -271,15 +271,13 @@ namespace Raven.Server.Documents
         {
             try
             {
-                var generateNewDatabaseId = (options & InitializeOptions.GenerateNewDatabaseId) == InitializeOptions.GenerateNewDatabaseId;
-
                 Configuration.CheckDirectoryPermissions();
 
                 _addToInitLog("Initializing NotificationCenter");
                 NotificationCenter.Initialize(this);
 
                 _addToInitLog("Initializing DocumentStorage");
-                DocumentsStorage.Initialize(generateNewDatabaseId);
+                DocumentsStorage.Initialize((options & InitializeOptions.GenerateNewDatabaseId) == InitializeOptions.GenerateNewDatabaseId);
                 _addToInitLog("Starting Transaction Merger");
                 TxMerger.Start();
                 _addToInitLog("Initializing ConfigurationStorage");
@@ -304,7 +302,7 @@ namespace Raven.Server.Documents
                 PeriodicBackupRunner = new PeriodicBackupRunner(this, _serverStore, wakeup);
 
                 _addToInitLog("Initializing IndexStore (async)");
-                _indexStoreTask = IndexStore.InitializeAsync(record, generateNewDatabaseId, index, _addToInitLog);
+                _indexStoreTask = IndexStore.InitializeAsync(record, index, _addToInitLog);
                 _addToInitLog("Initializing Replication");
                 ReplicationLoader?.Initialize(record, index);
                 _addToInitLog("Initializing ETL");
@@ -672,7 +670,7 @@ namespace Raven.Server.Documents
 
                 _forTestingPurposes?.DisposeLog?.Invoke(Name, $"Drained all requests. Took: {sp.Elapsed}");
             }
-            
+
             var exceptionAggregator = new ExceptionAggregator(_logger, $"Could not dispose {nameof(DocumentDatabase)} {Name}");
 
             _forTestingPurposes?.DisposeLog?.Invoke(Name, "Acquiring cluster lock");
@@ -1355,7 +1353,7 @@ namespace Raven.Server.Documents
                                     _logger.Operations(msg);
 
 #if !RELEASE
-                                    Console.WriteLine(msg);   
+                                    Console.WriteLine(msg);
 #endif
                                 }
                             }

--- a/src/Raven.Server/Documents/DocumentDatabase.cs
+++ b/src/Raven.Server/Documents/DocumentDatabase.cs
@@ -271,13 +271,15 @@ namespace Raven.Server.Documents
         {
             try
             {
+                var generateNewDatabaseId = (options & InitializeOptions.GenerateNewDatabaseId) == InitializeOptions.GenerateNewDatabaseId;
+
                 Configuration.CheckDirectoryPermissions();
 
                 _addToInitLog("Initializing NotificationCenter");
                 NotificationCenter.Initialize(this);
 
                 _addToInitLog("Initializing DocumentStorage");
-                DocumentsStorage.Initialize((options & InitializeOptions.GenerateNewDatabaseId) == InitializeOptions.GenerateNewDatabaseId);
+                DocumentsStorage.Initialize(generateNewDatabaseId);
                 _addToInitLog("Starting Transaction Merger");
                 TxMerger.Start();
                 _addToInitLog("Initializing ConfigurationStorage");
@@ -302,7 +304,7 @@ namespace Raven.Server.Documents
                 PeriodicBackupRunner = new PeriodicBackupRunner(this, _serverStore, wakeup);
 
                 _addToInitLog("Initializing IndexStore (async)");
-                _indexStoreTask = IndexStore.InitializeAsync(record, index, _addToInitLog);
+                _indexStoreTask = IndexStore.InitializeAsync(record, generateNewDatabaseId, index, _addToInitLog);
                 _addToInitLog("Initializing Replication");
                 ReplicationLoader?.Initialize(record, index);
                 _addToInitLog("Initializing ETL");

--- a/src/Raven.Server/Documents/Indexes/Index.cs
+++ b/src/Raven.Server/Documents/Indexes/Index.cs
@@ -370,12 +370,12 @@ namespace Raven.Server.Documents.Indexes
                         e);
                 }
 
-                if (generateNewDatabaseId == false)
+                if (documentDatabase.Configuration.Indexing.SkipDatabaseIdValidationOnIndexOpening == false && generateNewDatabaseId == false)
                 {
                     var databaseId = IndexStorage.ReadDatabaseId(name, environment);
                     if (databaseId != null) // backward compatibility
                     {
-                        if (databaseId != documentDatabase.DbBase64Id) 
+                        if (databaseId != documentDatabase.DbBase64Id)
                             throw new IndexOpenException($"Could not open index because stored database ID ('{databaseId}') is different than current database ID ('{documentDatabase.DbBase64Id}'). A common reason for this is that the index was copied from another database.");
                     }
                 }

--- a/src/Raven.Server/Documents/Indexes/Index.cs
+++ b/src/Raven.Server/Documents/Indexes/Index.cs
@@ -376,7 +376,7 @@ namespace Raven.Server.Documents.Indexes
                     if (databaseId != null) // backward compatibility
                     {
                         if (databaseId != documentDatabase.DbBase64Id) 
-                            throw new IndexOpenException($"Could not open index because stored database ID ('{databaseId}') is different than current database ID ('{documentDatabase.DbBase64Id}'). This is often an indication that data was copied directly from a different database.");
+                            throw new IndexOpenException($"Could not open index because stored database ID ('{databaseId}') is different than current database ID ('{documentDatabase.DbBase64Id}'). A common reason for this is that the index was copied from another database.");
                     }
                 }
 

--- a/src/Raven.Server/Documents/Indexes/IndexStore.cs
+++ b/src/Raven.Server/Documents/Indexes/IndexStore.cs
@@ -568,7 +568,7 @@ namespace Raven.Server.Documents.Indexes
             }
         }
 
-        public Task InitializeAsync(DatabaseRecord record, long raftIndex, Action<string> addToInitLog)
+        public Task InitializeAsync(DatabaseRecord record, bool generateNewDatabaseId, long raftIndex, Action<string> addToInitLog)
         {
             if (_initialized)
                 throw new InvalidOperationException($"{nameof(IndexStore)} was already initialized.");
@@ -580,7 +580,7 @@ namespace Raven.Server.Documents.Indexes
             return Task.Run(() =>
             {
                 if (_documentDatabase.Configuration.Indexing.RunInMemory == false)
-                    OpenIndexesFromRecord(record, raftIndex, addToInitLog);
+                    OpenIndexesFromRecord(record, generateNewDatabaseId, raftIndex, addToInitLog);
 
                 HandleSorters(record, raftIndex);
             });
@@ -1265,7 +1265,7 @@ namespace Raven.Server.Documents.Indexes
             }
         }
 
-        private void OpenIndexesFromRecord(DatabaseRecord record, long raftIndex, Action<string> addToInitLog)
+        private void OpenIndexesFromRecord(DatabaseRecord record, bool generateNewDatabaseId, long raftIndex, Action<string> addToInitLog)
         {
             var path = _documentDatabase.Configuration.Indexing.StoragePath;
 
@@ -1293,7 +1293,7 @@ namespace Raven.Server.Documents.Indexes
                     var sp = Stopwatch.StartNew();
 
                     addToInitLog($"Initializing static index: `{name}`");
-                    OpenIndex(path, indexPath, exceptions, name, staticIndexDefinition: definition, autoIndexDefinition: null);
+                    OpenIndex(path, indexPath, exceptions, name, staticIndexDefinition: definition, autoIndexDefinition: null, generateNewDatabaseId);
 
                     if (Logger.IsInfoEnabled)
                         Logger.Info($"Initialized static index: `{name}`, took: {sp.ElapsedMilliseconds:#,#;;0}ms");
@@ -1315,7 +1315,7 @@ namespace Raven.Server.Documents.Indexes
                     var sp = Stopwatch.StartNew();
 
                     addToInitLog($"Initializing auto index: `{name}`");
-                    OpenIndex(path, indexPath, exceptions, name, staticIndexDefinition: null, autoIndexDefinition: definition);
+                    OpenIndex(path, indexPath, exceptions, name, staticIndexDefinition: null, autoIndexDefinition: definition, generateNewDatabaseId);
 
                     if (Logger.IsInfoEnabled)
                         Logger.Info($"Initialized auto index: `{name}`, took: {sp.ElapsedMilliseconds:#,#;;0}ms");
@@ -1344,7 +1344,7 @@ namespace Raven.Server.Documents.Indexes
             var indexPath = path.Combine(safeName).FullPath;
             var exceptions = new List<Exception>();
 
-            OpenIndex(path, indexPath, exceptions, index.Name, index.GetIndexDefinition(), null);
+            OpenIndex(path, indexPath, exceptions, index.Name, index.GetIndexDefinition(), null, generateNewDatabaseId: false);
 
             if (exceptions.Count > 0)
             {
@@ -1360,13 +1360,13 @@ namespace Raven.Server.Documents.Indexes
                 });
         }
 
-        private void OpenIndex(PathSetting path, string indexPath, List<Exception> exceptions, string name, IndexDefinition staticIndexDefinition, AutoIndexDefinition autoIndexDefinition)
+        private void OpenIndex(PathSetting path, string indexPath, List<Exception> exceptions, string name, IndexDefinition staticIndexDefinition, AutoIndexDefinition autoIndexDefinition, bool generateNewDatabaseId)
         {
             Index index = null;
 
             try
             {
-                index = Index.Open(indexPath, _documentDatabase);
+                index = Index.Open(indexPath, _documentDatabase, generateNewDatabaseId);
 
                 var differences = IndexDefinitionCompareDifferences.None;
 

--- a/src/Raven.Server/Documents/PeriodicBackup/Restore/RestoreBackupTaskBase.cs
+++ b/src/Raven.Server/Documents/PeriodicBackup/Restore/RestoreBackupTaskBase.cs
@@ -337,7 +337,7 @@ namespace Raven.Server.Documents.PeriodicBackup.Restore
                         }
 
                         if (snapshotRestore)
-                            RegenerateIndexes(configuration, database);
+                            RegenerateDatabaseIdInIndexes(configuration, database);
                     }
 
                     // after the db for restore is done, we can safely set the db state to normal and write the DatabaseRecord
@@ -400,7 +400,7 @@ namespace Raven.Server.Documents.PeriodicBackup.Restore
                 Dispose();
             }
 
-            void RegenerateIndexes(RavenConfiguration configuration, DocumentDatabase database)
+            void RegenerateDatabaseIdInIndexes(RavenConfiguration configuration, DocumentDatabase database)
             {
                 // this code will generate new DatabaseId for each index.
                 // This is something that we need to do when snapshot restore is executed to match the newly generated database id

--- a/src/Raven.Server/Documents/PeriodicBackup/Restore/RestoreBackupTaskBase.cs
+++ b/src/Raven.Server/Documents/PeriodicBackup/Restore/RestoreBackupTaskBase.cs
@@ -406,6 +406,9 @@ namespace Raven.Server.Documents.PeriodicBackup.Restore
                 // This is something that we need to do when snapshot restore is executed to match the newly generated database id
 
                 var indexesPath = configuration.Indexing.StoragePath.FullPath;
+                if (Directory.Exists(indexesPath) == false)
+                    return;
+
                 foreach (var indexPath in Directory.GetDirectories(indexesPath))
                 {
                     Index index = null;

--- a/src/Raven.Server/Exceptions/IndexOpenException.cs
+++ b/src/Raven.Server/Exceptions/IndexOpenException.cs
@@ -4,7 +4,7 @@ namespace Raven.Server.Exceptions
 {
     public class IndexDisposingException : Exception
     {
-     
+
         public IndexDisposingException()
         {
         }
@@ -20,6 +20,11 @@ namespace Raven.Server.Exceptions
 
     public class IndexOpenException : Exception
     {
+        public IndexOpenException(string message)
+            : base(message)
+        {
+        }
+
         public IndexOpenException(string message, Exception e)
             : base(message, e)
         {

--- a/src/Raven.Server/Web/System/AdminDatabasesHandler.cs
+++ b/src/Raven.Server/Web/System/AdminDatabasesHandler.cs
@@ -342,7 +342,7 @@ namespace Raven.Server.Web.System
                         if (documentDatabase.DatabaseShutdown.IsCancellationRequested)
                             return;
 
-                        index = Index.Open(indexPath, documentDatabase);
+                        index = Index.Open(indexPath, documentDatabase, generateNewDatabaseId: false);
                         if (index == null)
                             continue;
 

--- a/test/SlowTests/Issues/RavenDB13650.cs
+++ b/test/SlowTests/Issues/RavenDB13650.cs
@@ -16,7 +16,9 @@ namespace SlowTests.Issues
 
         private class User
         {
+#pragma warning disable 649
             public Dictionary<string, string> Items;
+#pragma warning restore 649
         }
 
         private class User_Index : AbstractIndexCreationTask<User>

--- a/test/SlowTests/Issues/RavenDB_16042.cs
+++ b/test/SlowTests/Issues/RavenDB_16042.cs
@@ -4,7 +4,6 @@ using FastTests;
 using Orders;
 using Raven.Client.Documents.Indexes;
 using Raven.Client.Documents.Operations.Backups;
-using Raven.Client.Documents.Operations.Indexes;
 using Raven.Client.ServerWide;
 using Raven.Client.ServerWide.Operations;
 using Raven.Server.Config;

--- a/test/SlowTests/Issues/RavenDB_16042.cs
+++ b/test/SlowTests/Issues/RavenDB_16042.cs
@@ -1,0 +1,78 @@
+﻿using System.Linq;
+using System.Threading.Tasks;
+using FastTests;
+using Orders;
+using Raven.Client.Documents.Indexes;
+using Raven.Client.Documents.Operations.Indexes;
+using Raven.Server.Config;
+using Raven.Server.Documents.Indexes.Errors;
+using Raven.Server.Documents.Indexes.Static;
+using Raven.Server.Utils;
+using Xunit;
+using Xunit.Abstractions;
+
+namespace SlowTests.Issues
+{
+    public class RavenDB_16042 : RavenTestBase
+    {
+        public RavenDB_16042(ITestOutputHelper output) : base(output)
+        {
+        }
+
+        [Fact]
+        public async Task Should_Not_Be_Able_To_Open_Index_Copied_From_Different_Database()
+        {
+            var options = new Options
+            {
+                RunInMemory = false,
+                ModifyDatabaseRecord = r =>
+                {
+                    r.Settings[RavenConfiguration.GetKey(x => x.Core.ThrowIfAnyIndexCannotBeOpened)] = "false";
+                }
+            };
+
+            using (var store1 = GetDocumentStore(options))
+            using (var store2 = GetDocumentStore(options))
+            {
+                await new Products_ByName().ExecuteAsync(store1);
+                await new Products_ByName().ExecuteAsync(store2);
+
+                var database1 = await GetDocumentDatabaseInstanceFor(store1);
+                var database2 = await GetDocumentDatabaseInstanceFor(store2);
+
+                var indexPath1 = database1.IndexStore.GetIndex(new Products_ByName().IndexName).Configuration.StoragePath.FullPath;
+                var indexPath2 = database2.IndexStore.GetIndex(new Products_ByName().IndexName).Configuration.StoragePath.FullPath;
+
+                Server.ServerStore.DatabasesLandlord.UnloadDirectly(store1.Database);
+                Server.ServerStore.DatabasesLandlord.UnloadDirectly(store2.Database);
+
+                database1 = await GetDocumentDatabaseInstanceFor(store1);
+
+                var index1 = database1.IndexStore.GetIndex(new Products_ByName().IndexName);
+                Assert.IsType(typeof(MapIndex), index1);
+
+                Server.ServerStore.DatabasesLandlord.UnloadDirectly(store1.Database);
+
+                IOExtensions.DeleteDirectory(indexPath2);
+                IOExtensions.MoveDirectory(indexPath1, indexPath2);
+
+                database2 = await GetDocumentDatabaseInstanceFor(store2);
+
+                var index2 = database2.IndexStore.GetIndex(new Products_ByName().IndexName);
+                Assert.IsType(typeof(FaultyInMemoryIndex), index2);
+            }
+        }
+
+        private class Products_ByName : AbstractIndexCreationTask<Product>
+        {
+            public Products_ByName()
+            {
+                Map = products => from product in products
+                                  select new
+                                  {
+                                      product.Name
+                                  };
+            }
+        }
+    }
+}


### PR DESCRIPTION
### Issue link

https://issues.hibernatingrhinos.com/issue/RavenDB-16042

### Additional description

We want to avoid a situation when data was copied from one database to another, this is why early detection is introduced in this PR. Indexes will be marked as faulty.

### Type of change

- New feature

### How risky is the change?

- Moderate 

### Backward compatibility

- Ensured. We cannot do anything here, when Database ID is not stored we do not do the check. It will be stored later on or on new indexes.

### Is it platform specific issue?

- No

### Documentation update

- This change requires a documentation update. Please mark the issue on YouTrack using `Documentation Required` tag.

### Testing 

- Tests have been added that prove the fix is effective or that the feature works

### Is there any existing behavior change of other features due to this change?

- No

### UI work

- No UI work is needed
