### PR TITLE
HRMarketing-1104 Changing links from Google Groups to GitHub

### DIFF
--- a/src/Raven.Studio/wwwroot/App/views/shell/about.html
+++ b/src/Raven.Studio/wwwroot/App/views/shell/about.html
@@ -240,9 +240,16 @@
                         <small class="text-muted">We're here for you <br />24/7</small>
                     </div>
                     <div class="community">
-                        <a href="https://groups.google.com/forum/#!forum/ravendb" target="_blank" class="btn btn-info btn-block">
-                            <i class="icon-newtab"></i> <span>ACCESS</span>
-                        </a>
+                        <div class="dropup">
+                            <button class="btn btn-info btn-block dropdown-toggle" type="button" id="dropdownMenu2" data-toggle="dropdown" aria-haspopup="true" aria-expanded="false">
+                                <i class="icon-newtab"></i> <span>ACCESS</span>
+                                <span class="caret"></span>
+                            </button>
+                            <ul class="dropdown-menu" aria-labelledby="dropdownMenu2">
+                                <li><a href="https://github.com/ravendb/ravendb/discussions" target="_blank">Github Discussions </a></li>
+                                <li><a href="https://groups.google.com/forum/#!forum/ravendb" target="_blank">Google Groups (Archive) </a></li>
+                            </ul>
+                        </div>
                     </div>
                     <div class="grid-span-2 professional production" data-bind="visible: canUpgradeSupport">
                         <a target="_blank" class="btn btn-success btn-block" data-bind="attr: { href: isCloud() ? 'https://cloud.ravendb.net/pricing#support-options' : 'http://ravendb.net/support' }">
@@ -251,7 +258,16 @@
                     </div>
                 </div>
                 <div class="padding" data-bind="visible: !hasLicense()">
-                    <a href="https://groups.google.com/forum/#!forum/ravendb" target="_blank" class="btn btn-info btn-block"><i class="icon-newtab"></i> <span>ACCESS</span></a>
+                    <div class="dropup">
+                        <button class="btn btn-info btn-block dropdown-toggle" type="button" id="dropdownMenu2" data-toggle="dropdown" aria-haspopup="true" aria-expanded="false">
+                            <i class="icon-newtab"></i> <span>ACCESS</span>
+                            <span class="caret"></span>
+                        </button>
+                        <ul class="dropdown-menu" aria-labelledby="dropdownMenu2">
+                            <li><a href="https://github.com/ravendb/ravendb/discussions" target="_blank">Github Discussions </a></li>
+                            <li><a href="https://groups.google.com/forum/#!forum/ravendb" target="_blank">Google Groups (Archive) </a></li>
+                        </ul>
+                    </div>
                 </div>
             </div>
         </div>


### PR DESCRIPTION
### Issue link

https://issues.hibernatingrhinos.com/issue/HRMarketing-1104

### Additional description

In About changed the community support link to dropup with two options: Github Discussions and Google Groups

### Type of change

- New feature

### How risky is the change?

- Not relevant

### Backward compatibility

- Not relevant

### UI work

- No UI work is needed
