### PR TITLE
RavenDB-17285 Added size limit switch for IndexEntries query.

### DIFF
--- a/src/Raven.Server/Documents/Handlers/QueriesHandler.cs
+++ b/src/Raven.Server/Documents/Handlers/QueriesHandler.cs
@@ -558,7 +558,8 @@ namespace Raven.Server.Documents.Handlers
         {
             if (string.Equals(debug, "entries", StringComparison.OrdinalIgnoreCase))
             {
-                await IndexEntries(queryContext, token, tracker, method);
+                var ignoreLimit = GetBoolValueQueryString("ignoreLimit", required: false) ?? false;
+                await IndexEntries(queryContext, token, tracker, method, ignoreLimit);
                 return;
             }
 
@@ -588,12 +589,12 @@ namespace Raven.Server.Documents.Handlers
             throw new NotSupportedException($"Not supported query debug operation: '{debug}'");
         }
 
-        private async Task IndexEntries(QueryOperationContext queryContext, OperationCancelToken token, RequestTimeTracker tracker, HttpMethod method)
+        private async Task IndexEntries(QueryOperationContext queryContext, OperationCancelToken token, RequestTimeTracker tracker, HttpMethod method, bool ignoreLimit)
         {
             var indexQuery = await GetIndexQuery(queryContext.Documents, method, tracker);
             var existingResultEtag = GetLongFromHeaders("If-None-Match");
 
-            var result = await Database.QueryRunner.ExecuteIndexEntriesQuery(indexQuery, queryContext, existingResultEtag, token);
+            var result = await Database.QueryRunner.ExecuteIndexEntriesQuery(indexQuery, queryContext, ignoreLimit, existingResultEtag, token);
 
             if (result.NotModified)
             {

--- a/src/Raven.Server/Documents/Handlers/Streaming/StreamingHandler.cs
+++ b/src/Raven.Server/Documents/Handlers/Streaming/StreamingHandler.cs
@@ -155,6 +155,7 @@ namespace Raven.Server.Documents.Handlers.Streaming
 
                 var format = GetStringQueryString("format", false);
                 var debug = GetStringQueryString("debug", false);
+                var ignoreLimit = GetBoolValueQueryString("ignoreLimit", required: false) ?? false;
                 var properties = GetStringValuesQueryString("field", false);
                 var propertiesArray = properties.Count == 0 ? null : properties.ToArray();
                 // set the exported file name prefix
@@ -168,7 +169,7 @@ namespace Raven.Server.Documents.Handlers.Streaming
                         {
                             try
                             {
-                                await Database.QueryRunner.ExecuteStreamIndexEntriesQuery(query, queryContext, HttpContext.Response, writer, token).ConfigureAwait(false);
+                                await Database.QueryRunner.ExecuteStreamIndexEntriesQuery(query, queryContext, HttpContext.Response, writer, ignoreLimit, token).ConfigureAwait(false);
                             }
                             catch (IndexDoesNotExistException)
                             {
@@ -242,6 +243,7 @@ namespace Raven.Server.Documents.Handlers.Streaming
 
                 var format = GetStringQueryString("format", false);
                 var debug = GetStringQueryString("debug", false);
+                var ignoreLimit = GetBoolValueQueryString("ignoreLimit", required: false) ?? false;
                 var properties = GetStringValuesQueryString("field", false);
                 var propertiesArray = properties.Count == 0 ? null : properties.ToArray();
 
@@ -256,7 +258,7 @@ namespace Raven.Server.Documents.Handlers.Streaming
                         {
                             try
                             {
-                                await Database.QueryRunner.ExecuteStreamIndexEntriesQuery(query, queryContext, HttpContext.Response, writer, token).ConfigureAwait(false);
+                                await Database.QueryRunner.ExecuteStreamIndexEntriesQuery(query, queryContext, HttpContext.Response, writer, ignoreLimit, token).ConfigureAwait(false);
                             }
                             catch (IndexDoesNotExistException)
                             {

--- a/src/Raven.Server/Documents/Indexes/Index.cs
+++ b/src/Raven.Server/Documents/Indexes/Index.cs
@@ -2954,10 +2954,10 @@ namespace Raven.Server.Documents.Indexes
         }
 
         public virtual async Task StreamIndexEntriesQuery(HttpResponse response, IStreamQueryResultWriter<BlittableJsonReaderObject> writer,
-            IndexQueryServerSide query, QueryOperationContext queryContext, OperationCancelToken token)
+            IndexQueryServerSide query, QueryOperationContext queryContext, bool ignoreLimit, OperationCancelToken token)
         {
             var result = new StreamDocumentIndexEntriesQueryResult(response, writer, token);
-            await IndexEntriesQueryInternal(result, query, queryContext, token);
+            await IndexEntriesQueryInternal(result, query, queryContext, ignoreLimit, token);
             result.Flush();
 
             DocumentDatabase.QueryMetadataCache.MaybeAddToCache(query.Metadata, Name);
@@ -3258,6 +3258,7 @@ namespace Raven.Server.Documents.Indexes
             TQueryResult resultToFill,
             IndexQueryServerSide query,
             QueryOperationContext queryContext,
+            bool ignoreLimit,
             OperationCancelToken token)
           where TQueryResult : QueryResultServerSide<BlittableJsonReaderObject>
         {
@@ -3327,7 +3328,7 @@ namespace Raven.Server.Documents.Indexes
                         {
                             var totalResults = new Reference<int>();
 
-                            foreach (var indexEntry in reader.IndexEntries(query, totalResults, queryContext.Documents, GetOrAddSpatialField, token.Token))
+                            foreach (var indexEntry in reader.IndexEntries(query, totalResults, queryContext.Documents, GetOrAddSpatialField, ignoreLimit, token.Token))
                             {
                                 resultToFill.TotalResults = totalResults.Value;
                                 resultToFill.LongTotalResults = totalResults.Value;
@@ -3562,10 +3563,11 @@ namespace Raven.Server.Documents.Indexes
         public virtual async Task<IndexEntriesQueryResult> IndexEntries(
             IndexQueryServerSide query,
             QueryOperationContext queryContext,
+            bool ignoreLimit,
             OperationCancelToken token)
         {
             var result = new IndexEntriesQueryResult();
-            await IndexEntriesQueryInternal(result, query, queryContext, token);
+            await IndexEntriesQueryInternal(result, query, queryContext, ignoreLimit, token);
             return result;
         }
 

--- a/src/Raven.Server/Documents/Indexes/Persistence/Lucene/IndexReadOperation.cs
+++ b/src/Raven.Server/Documents/Indexes/Persistence/Lucene/IndexReadOperation.cs
@@ -791,7 +791,7 @@ namespace Raven.Server.Documents.Indexes.Persistence.Lucene
             }
         }
 
-        public IEnumerable<BlittableJsonReaderObject> IndexEntries(IndexQueryServerSide query, Reference<int> totalResults, DocumentsOperationContext documentsContext, Func<string, SpatialField> getSpatialField, CancellationToken token)
+        public IEnumerable<BlittableJsonReaderObject> IndexEntries(IndexQueryServerSide query, Reference<int> totalResults, DocumentsOperationContext documentsContext, Func<string, SpatialField> getSpatialField, bool ignoreLimit, CancellationToken token)
         {
             var docsToGet = GetPageSize(_searcher, query.PageSize);
             var position = query.Start;
@@ -800,7 +800,7 @@ namespace Raven.Server.Documents.Indexes.Persistence.Lucene
             using (GetSort(query, _index, getSpatialField, documentsContext, out var sort))
             {
                 var search = ExecuteQuery(luceneQuery, query.Start, docsToGet, sort);
-                var termsDocs = IndexedTerms.ReadAllEntriesFromIndex(_searcher.IndexReader, documentsContext, _state);
+                var termsDocs = IndexedTerms.ReadAllEntriesFromIndex(_searcher.IndexReader, documentsContext, ignoreLimit, _state);
 
                 totalResults.Value = search.TotalHits;
 

--- a/src/Raven.Server/Documents/Indexes/Persistence/Lucene/IndexedTerms.cs
+++ b/src/Raven.Server/Documents/Indexes/Persistence/Lucene/IndexedTerms.cs
@@ -66,9 +66,9 @@ namespace Raven.Server.Documents.Indexes.Persistence.Lucene
             }
         }
 
-        public static BlittableJsonReaderObject[] ReadAllEntriesFromIndex(IndexReader reader, JsonOperationContext context, IState state)
+        public static BlittableJsonReaderObject[] ReadAllEntriesFromIndex(IndexReader reader, JsonOperationContext context, bool ignoreLimit, IState state)
         {
-            if (reader.MaxDoc > 512 * 1024)
+            if (reader.MaxDoc > 512 * 1024 && ignoreLimit == false)
             {
                 throw new InvalidOperationException($"Refusing to extract all index entries from an index with: {reader.MaxDoc:#,#;;0} " +
                                                     "entries, because of the probable time / memory costs associated with that." +

--- a/src/Raven.Server/Documents/Queries/AbstractQueryRunner.cs
+++ b/src/Raven.Server/Documents/Queries/AbstractQueryRunner.cs
@@ -50,9 +50,9 @@ namespace Raven.Server.Documents.Queries
             IStreamQueryResultWriter<Document> writer, OperationCancelToken token);
 
         public abstract Task ExecuteStreamIndexEntriesQuery(IndexQueryServerSide query, QueryOperationContext queryContext, HttpResponse response,
-            IStreamQueryResultWriter<BlittableJsonReaderObject> writer, OperationCancelToken token);
+            IStreamQueryResultWriter<BlittableJsonReaderObject> writer, bool ignoreLimit, OperationCancelToken token);
 
-        public abstract Task<IndexEntriesQueryResult> ExecuteIndexEntriesQuery(IndexQueryServerSide query, QueryOperationContext queryContext, long? existingResultEtag, OperationCancelToken token);
+        public abstract Task<IndexEntriesQueryResult> ExecuteIndexEntriesQuery(IndexQueryServerSide query, QueryOperationContext queryContext, bool ignoreLimit, long? existingResultEtag, OperationCancelToken token);
 
         public abstract Task<IOperationResult> ExecuteDeleteQuery(IndexQueryServerSide query, QueryOperationOptions options, QueryOperationContext queryContext, Action<IOperationProgress> onProgress, OperationCancelToken token);
 

--- a/src/Raven.Server/Documents/Queries/Dynamic/CollectionQueryRunner.cs
+++ b/src/Raven.Server/Documents/Queries/Dynamic/CollectionQueryRunner.cs
@@ -77,13 +77,13 @@ namespace Raven.Server.Documents.Queries.Dynamic
             }
         }
 
-        public override Task<IndexEntriesQueryResult> ExecuteIndexEntriesQuery(IndexQueryServerSide query, QueryOperationContext queryContext, long? existingResultEtag, OperationCancelToken token)
+        public override Task<IndexEntriesQueryResult> ExecuteIndexEntriesQuery(IndexQueryServerSide query, QueryOperationContext queryContext, bool ignoreLimit, long? existingResultEtag, OperationCancelToken token)
         {
             throw new NotSupportedException("Collection query is handled directly by documents storage so index entries aren't created underneath");
         }
 
         public override Task ExecuteStreamIndexEntriesQuery(IndexQueryServerSide query, QueryOperationContext queryContext, HttpResponse response,
-            IStreamQueryResultWriter<BlittableJsonReaderObject> writer, OperationCancelToken token)
+            IStreamQueryResultWriter<BlittableJsonReaderObject> writer, bool ignoreLimit, OperationCancelToken token)
         {
             throw new NotSupportedException("Collection query is handled directly by documents storage so index entries aren't created underneath");
         }

--- a/src/Raven.Server/Documents/Queries/Dynamic/DynamicQueryRunner.cs
+++ b/src/Raven.Server/Documents/Queries/Dynamic/DynamicQueryRunner.cs
@@ -63,7 +63,7 @@ namespace Raven.Server.Documents.Queries.Dynamic
             }
         }
 
-        public override async Task<IndexEntriesQueryResult> ExecuteIndexEntriesQuery(IndexQueryServerSide query, QueryOperationContext queryContext, long? existingResultEtag, OperationCancelToken token)
+        public override async Task<IndexEntriesQueryResult> ExecuteIndexEntriesQuery(IndexQueryServerSide query, QueryOperationContext queryContext, bool ignoreLimit, long? existingResultEtag, OperationCancelToken token)
         {
             var index = await MatchIndex(query, false, null, token.Token);
 
@@ -81,12 +81,12 @@ namespace Raven.Server.Documents.Queries.Dynamic
 
             using (QueryRunner.MarkQueryAsRunning(index.Name, query, token))
             {
-                return await index.IndexEntries(query, queryContext, token);
+                return await index.IndexEntries(query, queryContext, ignoreLimit, token);
             }
         }
 
         public override Task ExecuteStreamIndexEntriesQuery(IndexQueryServerSide query, QueryOperationContext queryContext, HttpResponse response,
-            IStreamQueryResultWriter<BlittableJsonReaderObject> writer, OperationCancelToken token)
+            IStreamQueryResultWriter<BlittableJsonReaderObject> writer, bool ignoreLimit, OperationCancelToken token)
         {
             throw new NotSupportedException("Collection query is handled directly by documents storage so index entries aren't created underneath");
         }

--- a/src/Raven.Server/Documents/Queries/GraphQueryRunner.cs
+++ b/src/Raven.Server/Documents/Queries/GraphQueryRunner.cs
@@ -105,7 +105,7 @@ namespace Raven.Server.Documents.Queries
             return await ExecuteQuery(res, query, queryContext, existingResultEtag, token);
         }
 
-        public override Task ExecuteStreamIndexEntriesQuery(IndexQueryServerSide query, QueryOperationContext queryContext, HttpResponse response, IStreamQueryResultWriter<BlittableJsonReaderObject> writer,
+        public override Task ExecuteStreamIndexEntriesQuery(IndexQueryServerSide query, QueryOperationContext queryContext, HttpResponse response, IStreamQueryResultWriter<BlittableJsonReaderObject> writer, bool ignoreLimit,
             OperationCancelToken token)
         {
             throw new NotImplementedException();
@@ -338,7 +338,7 @@ namespace Raven.Server.Documents.Queries
             throw new NotSupportedException("You cannot delete based on graph query");
         }
 
-        public override Task<IndexEntriesQueryResult> ExecuteIndexEntriesQuery(IndexQueryServerSide query, QueryOperationContext queryContext, long? existingResultEtag, OperationCancelToken token)
+        public override Task<IndexEntriesQueryResult> ExecuteIndexEntriesQuery(IndexQueryServerSide query, QueryOperationContext queryContext, bool ignoreLimit, long? existingResultEtag, OperationCancelToken token)
         {
             throw new NotSupportedException("Graph queries do not expose index queries");
         }

--- a/src/Raven.Server/Documents/Queries/InvalidQueryRunner.cs
+++ b/src/Raven.Server/Documents/Queries/InvalidQueryRunner.cs
@@ -32,13 +32,13 @@ namespace Raven.Server.Documents.Queries
             throw new NotSupportedException(ErrorMessage);
         }
 
-        public override Task<IndexEntriesQueryResult> ExecuteIndexEntriesQuery(IndexQueryServerSide query, QueryOperationContext queryContext, long? existingResultEtag, OperationCancelToken token)
+        public override Task<IndexEntriesQueryResult> ExecuteIndexEntriesQuery(IndexQueryServerSide query, QueryOperationContext queryContext, bool ignoreLimit, long? existingResultEtag, OperationCancelToken token)
         {
             throw new NotSupportedException(ErrorMessage);
         }
 
         public override Task ExecuteStreamIndexEntriesQuery(IndexQueryServerSide query, QueryOperationContext queryContext, HttpResponse response,
-            IStreamQueryResultWriter<BlittableJsonReaderObject> writer, OperationCancelToken token)
+            IStreamQueryResultWriter<BlittableJsonReaderObject> writer, bool ignoreLimit, OperationCancelToken token)
         {
             throw new NotSupportedException(ErrorMessage);
         }

--- a/src/Raven.Server/Documents/Queries/QueryRunner.cs
+++ b/src/Raven.Server/Documents/Queries/QueryRunner.cs
@@ -146,7 +146,7 @@ namespace Raven.Server.Documents.Queries
         }
 
         public override async Task ExecuteStreamIndexEntriesQuery(IndexQueryServerSide query, QueryOperationContext queryContext, HttpResponse response,
-            IStreamQueryResultWriter<BlittableJsonReaderObject> writer, OperationCancelToken token)
+            IStreamQueryResultWriter<BlittableJsonReaderObject> writer, bool ignoreLimit, OperationCancelToken token)
         {
             Exception lastException = null;
             for (var i = 0; i < NumberOfRetries; i++)
@@ -154,7 +154,7 @@ namespace Raven.Server.Documents.Queries
                 try
                 {
                     queryContext.CloseTransaction();
-                    await GetRunner(query).ExecuteStreamIndexEntriesQuery(query, queryContext, response, writer, token);
+                    await GetRunner(query).ExecuteStreamIndexEntriesQuery(query, queryContext, response, writer, ignoreLimit, token);
                     return;
                 }
                 catch (ObjectDisposedException e)
@@ -318,14 +318,14 @@ namespace Raven.Server.Documents.Queries
             throw CreateRetriesFailedException(lastException);
         }
 
-        public override async Task<IndexEntriesQueryResult> ExecuteIndexEntriesQuery(IndexQueryServerSide query, QueryOperationContext queryContext, long? existingResultEtag, OperationCancelToken token)
+        public override async Task<IndexEntriesQueryResult> ExecuteIndexEntriesQuery(IndexQueryServerSide query, QueryOperationContext queryContext, bool ignoreLimit, long? existingResultEtag, OperationCancelToken token)
         {
             Exception lastException = null;
             for (var i = 0; i < NumberOfRetries; i++)
             {
                 try
                 {
-                    return await GetRunner(query).ExecuteIndexEntriesQuery(query, queryContext, existingResultEtag, token);
+                    return await GetRunner(query).ExecuteIndexEntriesQuery(query, queryContext, ignoreLimit, existingResultEtag, token);
                 }
                 catch (ObjectDisposedException e)
                 {

--- a/src/Raven.Server/Documents/Queries/StaticIndexQueryRunner.cs
+++ b/src/Raven.Server/Documents/Queries/StaticIndexQueryRunner.cs
@@ -52,7 +52,7 @@ namespace Raven.Server.Documents.Queries
             }
         }
 
-        public override async Task ExecuteStreamIndexEntriesQuery(IndexQueryServerSide query, QueryOperationContext queryContext, HttpResponse response, IStreamQueryResultWriter<BlittableJsonReaderObject> writer, OperationCancelToken token)
+        public override async Task ExecuteStreamIndexEntriesQuery(IndexQueryServerSide query, QueryOperationContext queryContext, HttpResponse response, IStreamQueryResultWriter<BlittableJsonReaderObject> writer, bool ignoreLimit, OperationCancelToken token)
         {
             var index = GetIndex(query.Metadata.IndexName);
 
@@ -60,11 +60,11 @@ namespace Raven.Server.Documents.Queries
 
             using (QueryRunner.MarkQueryAsRunning(index.Name, query, token, true))
             {
-                await index.StreamIndexEntriesQuery(response, writer, query, queryContext, token);
+                await index.StreamIndexEntriesQuery(response, writer, query, queryContext, ignoreLimit, token);
             }
         }
 
-        public override async Task<IndexEntriesQueryResult> ExecuteIndexEntriesQuery(IndexQueryServerSide query, QueryOperationContext queryContext, long? existingResultEtag, OperationCancelToken token)
+        public override async Task<IndexEntriesQueryResult> ExecuteIndexEntriesQuery(IndexQueryServerSide query, QueryOperationContext queryContext, bool ignoreLimit, long? existingResultEtag, OperationCancelToken token)
         {
             var index = GetIndex(query.Metadata.IndexName);
 
@@ -79,7 +79,7 @@ namespace Raven.Server.Documents.Queries
 
             using (QueryRunner.MarkQueryAsRunning(index.Name, query, token))
             {
-                return await index.IndexEntries(query, queryContext, token);
+                return await index.IndexEntries(query, queryContext, ignoreLimit, token);
             }
         }
 


### PR DESCRIPTION


### Issue link

https://issues.hibernatingrhinos.com/issue/RavenDB-17285

### Additional description

Added size limit switch for IndexEntries query. This feature allows users to query even when the index has over 512*1024 entries.
Risk: possible OutOfMemoryException.

### Type of change


- New feature


### How risky is the change?

- Not relevant

### Backward compatibility

- Not relevant

### Is it platform specific issue?

- No

### Documentation update

- No documentation update is needed 

### Testing 

- It has been verified by manual testing

### Is there any existing behavior change of other features due to this change?

- No

### UI work

- It requires further work in the Studio

