### PR TITLE
RavenDB-17326 Fixed case mismatch between table definition and table name used in loadTo() call in SQL ETL

### DIFF
--- a/src/Raven.Server/Documents/ETL/Providers/SQL/SqlDocumentTransformer.cs
+++ b/src/Raven.Server/Documents/ETL/Providers/SQL/SqlDocumentTransformer.cs
@@ -36,7 +36,7 @@ namespace Raven.Server.Documents.ETL.Providers.SQL
 
             LoadToDestinations = destinationTables;
 
-            _tables = new Dictionary<string, SqlTableWithRecords>(destinationTables.Length);
+            _tables = new Dictionary<string, SqlTableWithRecords>(destinationTables.Length, StringComparer.OrdinalIgnoreCase);
             _tablesForScript = new List<SqlEtlTable>(destinationTables.Length);
 
             // ReSharper disable once ForCanBeConvertedToForeach


### PR DESCRIPTION
### Issue link

https://issues.hibernatingrhinos.com/issue/RavenDB-17326

### Additional description

This fixes the case sensitivity problem between table name used in the configuration and the name used in the script as part of `loadTo<tableName>()` call

### Type of change

- Bug fix

### How risky is the change?

- Low 

### Backward compatibility

- Not relevant

### Is it platform specific issue?

- No

### Documentation update

- This change requires a documentation update. It would be good to document it explicitly that we are case insensitive

### Testing 

- Tests have been added that prove the fix is effective or that the feature works
 - Internal classes added to the test class (e.g. entity or index definition classes) have the lowest possible access modifier (preferable `private`) 
- It has been verified by manual testing

### Is there any existing behavior change of other features due to this change?

- No

### UI work

- No UI work is needed
