### PR TITLE
RavenDB-17329 : prevent from generating a corrupted deleted-counter-cv that stats with comma

### DIFF
--- a/src/Raven.Server/Documents/CountersStorage.cs
+++ b/src/Raven.Server/Documents/CountersStorage.cs
@@ -1795,11 +1795,6 @@ namespace Raven.Server.Documents
             long newEtag = -1;
             for (int i = 0; i < count; i++)
             {
-                if (i > 0)
-                {
-                    sb.Append(", ");
-                }
-
                 if (i != dbIdIndex)
                 {
                     var etag = ((CounterValues*)counterToDelete.Address + i)->Etag;
@@ -1807,36 +1802,32 @@ namespace Raven.Server.Documents
                         continue;
 
                     var dbId = dbIds[i].ToString();
-
-                    sb.Append(dbId)
-                        .Append(":")
-                        .Append(etag);
-
+                    AppendDbIdAndEtag(sb, dbId, etag);
                     continue;
                 }
 
                 newEtag = _documentDatabase.DocumentsStorage.GenerateNextEtag();
-                sb.Append(_documentDatabase.DbBase64Id)
-                    .Append(":")
-                    .Append(newEtag);
+                AppendDbIdAndEtag(sb, _documentDatabase.DbBase64Id, newEtag);
             }
 
             if (newEtag == -1)
             {
                 // add local part to delete change vector
-
-                if (count > 0)
-                {
-                    sb.Append(", ");
-                }
-
                 newEtag = _documentDatabase.DocumentsStorage.GenerateNextEtag();
-                sb.Append(_documentDatabase.DbBase64Id)
-                    .Append(":")
-                    .Append(newEtag);
+                AppendDbIdAndEtag(sb, _documentDatabase.DbBase64Id, newEtag);
             }
 
             return sb.ToString();
+        }
+
+        private static void AppendDbIdAndEtag(StringBuilder sb, string dbId, long etag)
+        {
+            if (sb.Length > 0)
+                sb.Append(", ");
+
+            sb.Append(dbId)
+                .Append(':')
+                .Append(etag);
         }
 
         public static LazyStringValue ExtractDocId(JsonOperationContext context, ref TableValueReader tvr)
@@ -2094,12 +2085,7 @@ namespace Raven.Server.Documents
             var sb = new StringBuilder();
             for (int i = 0; i < mergeVectorBuffer.Count; i++)
             {
-                if (i > 0)
-                    sb.Append(", ");
-
-                sb.Append(mergeVectorBuffer[i].DbId)
-                    .Append(":")
-                    .Append(mergeVectorBuffer[i].Etag);
+                AppendDbIdAndEtag(sb, mergeVectorBuffer[i].DbId, mergeVectorBuffer[i].Etag);
             }
 
             return sb.ToString();

--- a/test/SlowTests/Issues/RavenDB-17329.cs
+++ b/test/SlowTests/Issues/RavenDB-17329.cs
@@ -3,6 +3,7 @@ using System.Threading.Tasks;
 using Raven.Client.Documents;
 using Raven.Client.Documents.Conventions;
 using Raven.Client.Documents.Operations.Counters;
+using Raven.Client.ServerWide.Operations;
 using Raven.Tests.Core.Utils.Entities;
 using Tests.Infrastructure;
 using Xunit;
@@ -17,7 +18,7 @@ namespace SlowTests.Issues
         }
 
         [Fact]
-        public async Task RavenDb17329()
+        public async Task DeletingCounterWhenFirstPartialValueIsEmptyAndRemote_ShouldNotGenerateCorruptedDeleteCv()
         {
             var (_, leader) = await CreateRaftCluster(2);
             var dbName = GetDatabaseName();
@@ -64,6 +65,32 @@ namespace SlowTests.Issues
                     Assert.Equal(1, countersDetail.Counters.Count);
                     Assert.Null(countersDetail.Counters[0]);
                 }
+
+                foreach (var server in db.Servers)
+                {
+                    await EnsureNoReplicationLoop(server, dbName);
+                }
+
+                var rec = stores[0].Maintenance.Server.Send(new GetDatabaseRecordOperation(dbName));
+                var topology = rec.Topology;
+                Assert.Equal(2, topology.Count);
+                Assert.Equal(2, topology.Members.Count);
+
+                using (var s = stores[0].OpenSession())
+                {
+                    s.Store(new User { Name = "John doe" }, "users/2");
+                    s.SaveChanges();
+                }
+
+                Assert.True(WaitForDocument<User>(stores[1], "users/2", x => x.Name == "John doe"));
+
+                using (var s = stores[1].OpenSession())
+                {
+                    s.Store(new User { Name = "Jane doe" }, "users/3");
+                    s.SaveChanges();
+                }
+
+                Assert.True(WaitForDocument<User>(stores[0], "users/3", x => x.Name == "Jane doe"));
             }
             finally
             {

--- a/test/SlowTests/Issues/RavenDB-17329.cs
+++ b/test/SlowTests/Issues/RavenDB-17329.cs
@@ -1,0 +1,77 @@
+﻿using System.Linq;
+using System.Threading.Tasks;
+using Raven.Client.Documents;
+using Raven.Client.Documents.Conventions;
+using Raven.Client.Documents.Operations.Counters;
+using Raven.Tests.Core.Utils.Entities;
+using Tests.Infrastructure;
+using Xunit;
+using Xunit.Abstractions;
+
+namespace SlowTests.Issues
+{
+    public class RavenDB_17329 : ClusterTestBase
+    {
+        public RavenDB_17329(ITestOutputHelper output) : base(output)
+        {
+        }
+
+        [Fact]
+        public async Task RavenDb17329()
+        {
+            var (_, leader) = await CreateRaftCluster(2);
+            var dbName = GetDatabaseName();
+            var db = await CreateDatabaseInCluster(dbName, 2, leader.WebUrl);
+
+            var stores = db.Servers
+                .Select(s => new DocumentStore
+                {
+                    Database = dbName, 
+                    Urls = new[] {s.WebUrl}, 
+                    Conventions = new DocumentConventions
+                    {
+                        DisableTopologyUpdates = true
+                    }
+                }.Initialize())
+                .ToList();
+            try
+            {
+                using (var s = stores[0].OpenSession())
+                {
+                    s.Advanced.WaitForReplicationAfterSaveChanges();
+                    s.Store(new User { Name = "Aviv" }, "users/1");
+                    s.CountersFor("users/1").Increment("likes", 30);
+                    s.SaveChanges();
+                }
+
+                using (var s = stores[1].OpenSession())
+                {
+                    s.Advanced.WaitForReplicationAfterSaveChanges();
+                    s.CountersFor("users/1").Increment("dislikes", 2);
+                    s.SaveChanges();
+                }
+
+                using (var s = stores[1].OpenSession())
+                {
+                    s.Advanced.WaitForReplicationAfterSaveChanges();
+                    s.CountersFor("users/1").Delete("dislikes");
+                    s.SaveChanges();
+                }
+
+                foreach (var store in stores)
+                {
+                    var countersDetail = store.Operations.Send(new GetCountersOperation("users/1", new[] { "dislikes" }));
+                    Assert.Equal(1, countersDetail.Counters.Count);
+                    Assert.Null(countersDetail.Counters[0]);
+                }
+            }
+            finally
+            {
+                foreach (var item in stores)
+                {
+                    item.Dispose();
+                }
+            }
+        }
+    }
+}


### PR DESCRIPTION

### Issue link
https://issues.hibernatingrhinos.com/issue/RavenDB-17329

### Additional description

Bug fix in `CountersStorage.GenerateDeleteChangeVectorFromRawBlob` :
https://github.com/ravendb/ravendb/blob/v5.2/src/Raven.Server/Documents/CountersStorage.cs#L1784

Related to this change :
https://github.com/ravendb/ravendb/commit/223eb775d2ab160e9f2bb254161ca94fb829ee46#diff-fd38cbbe3f3841d14dc8b936f33bfb379549421c85438280fabea880ee240a5dR1800-R1802

When `i == 0` and `dbIdIndex != 0`, and `etag == 0` we end up with a corrupted delete-cv that starts with `", "` .
This can happen when on some db node we delete a counter which has as his first partial value an "empty" (`etag==0`) and *not local* partial value 

When replicated, we would fail on attempt to merge this deleted counter because of the corrupted delete-cv and throw an error, which will cause replication to get stuck 

### Type of change

- Bug fix

### How risky is the change?

- Low 

### Backward compatibility

- Not relevant

### Is it platform specific issue?

- No

### Documentation update

- No documentation update is needed 

### Testing 

- Tests have been added that prove the fix is effective or that the feature works
- It has been verified by manual testing

### Is there any existing behavior change of other features due to this change?

- No

### UI work
- No UI work is needed
