### PR TITLE
RavenDB-13041 Changing the approach of dealing with refreshes of indexes in ES

### DIFF
--- a/src/Raven.Server/Documents/ETL/Providers/Elasticsearch/ElasticsearchIndexWriterSimulator.cs
+++ b/src/Raven.Server/Documents/ETL/Providers/Elasticsearch/ElasticsearchIndexWriterSimulator.cs
@@ -15,6 +15,9 @@ namespace Raven.Server.Documents.ETL.Providers.ElasticSearch
             if (records.InsertOnlyMode == false)
             {
                 // first, delete all the rows that might already exist there
+
+                result.Add(GenerateRefreshIndexCommandText(records.IndexName.ToLower()));
+
                 result.Add(GenerateDeleteItemsCommandText(records.IndexName.ToLower(), records.IndexIdProperty,
                     records.Deletes));
             }
@@ -22,6 +25,15 @@ namespace Raven.Server.Documents.ETL.Providers.ElasticSearch
             result.AddRange(GenerateInsertItemsCommandText(records.IndexName.ToLower(), records, context));
 
             return result;
+        }
+
+        private string GenerateRefreshIndexCommandText(string indexName)
+        {
+            var sb = new StringBuilder("POST ")
+                .Append(indexName)
+                .AppendLine("/_refresh");
+
+                return sb.ToString();
         }
 
         private string GenerateDeleteItemsCommandText(string indexName, string idField, List<ElasticSearchItem> elasticSearchItems)

--- a/src/Raven.Server/Documents/ETL/Providers/Elasticsearch/ElasticsearchIndexWriterSimulator.cs
+++ b/src/Raven.Server/Documents/ETL/Providers/Elasticsearch/ElasticsearchIndexWriterSimulator.cs
@@ -16,8 +16,6 @@ namespace Raven.Server.Documents.ETL.Providers.ElasticSearch
             {
                 // first, delete all the rows that might already exist there
 
-                result.Add(GenerateRefreshIndexCommandText(records.IndexName.ToLower()));
-
                 result.Add(GenerateDeleteItemsCommandText(records.IndexName.ToLower(), records.IndexIdProperty,
                     records.Deletes));
             }
@@ -25,15 +23,6 @@ namespace Raven.Server.Documents.ETL.Providers.ElasticSearch
             result.AddRange(GenerateInsertItemsCommandText(records.IndexName.ToLower(), records, context));
 
             return result;
-        }
-
-        private string GenerateRefreshIndexCommandText(string indexName)
-        {
-            var sb = new StringBuilder("POST ")
-                .Append(indexName)
-                .AppendLine("/_refresh");
-
-                return sb.ToString();
         }
 
         private string GenerateDeleteItemsCommandText(string indexName, string idField, List<ElasticSearchItem> elasticSearchItems)
@@ -62,7 +51,7 @@ namespace Raven.Server.Documents.ETL.Providers.ElasticSearch
 
                 var sb = new StringBuilder("POST ")
                     .Append(indexName)
-                    .AppendLine("/_delete_by_query")
+                    .AppendLine("/_delete_by_query?refresh=true")
                     .AppendLine(resultJson);
 
                 return sb.ToString();
@@ -77,7 +66,7 @@ namespace Raven.Server.Documents.ETL.Providers.ElasticSearch
             {
                 var sb = new StringBuilder("POST ")
                     .Append(indexName)
-                    .AppendLine("/_bulk");
+                    .AppendLine("/_bulk?refresh=wait_for");
 
                 foreach (var item in index.Inserts)
                 {

--- a/test/SlowTests/Server/Documents/ETL/Elasticsearch/ElasticSearchEtlTestBase.cs
+++ b/test/SlowTests/Server/Documents/ETL/Elasticsearch/ElasticSearchEtlTestBase.cs
@@ -22,11 +22,6 @@ namespace SlowTests.Server.Documents.ETL.ElasticSearch
             ConcurrentEsEtlTests.Wait();
         }
 
-        protected void EnsureNonStaleElasticResults(ElasticClient client)
-        {
-            client.Indices.Refresh(new RefreshRequest(Indices.All));
-        }
-
         protected IDisposable GetElasticClient(out ElasticClient client)
         {
             var localClient = client = ElasticSearchHelper.CreateClient(new ElasticSearchConnectionString { Nodes = ElasticSearchTestNodes.Instance.VerifiedNodes.Value });

--- a/test/SlowTests/Server/Documents/ETL/Elasticsearch/ElasticSearchEtlTests.cs
+++ b/test/SlowTests/Server/Documents/ETL/Elasticsearch/ElasticSearchEtlTests.cs
@@ -4,7 +4,6 @@ using System.Linq;
 using System.Runtime.CompilerServices;
 using System.Security.Cryptography;
 using System.Text;
-using System.Threading;
 using System.Threading.Tasks;
 using Newtonsoft.Json.Linq;
 using Raven.Client.Documents;
@@ -80,10 +79,11 @@ loadToOrders(orderData);
                 
                 etlDone.Wait(TimeSpan.FromMinutes(1));
 
-                EnsureNonStaleElasticResults(client);
-
                 var ordersCount = client.Count<object>(c => c.Index(OrderIndexName));
                 var orderLinesCount = client.Count<object>(c => c.Index(OrderLinesIndexName));
+
+                Assert.True(ordersCount.IsValid);
+                Assert.True(orderLinesCount.IsValid);
 
                 Assert.Equal(1, ordersCount.Count);
                 Assert.Equal(2, orderLinesCount.Count);
@@ -99,10 +99,11 @@ loadToOrders(orderData);
                 
                 etlDone.Wait(TimeSpan.FromMinutes(1));
 
-                EnsureNonStaleElasticResults(client);
-
                 var ordersCountAfterDelete = client.Count<object>(c => c.Index(OrderIndexName));
                 var orderLinesCountAfterDelete = client.Count<object>(c => c.Index(OrderLinesIndexName));
+
+                Assert.True(ordersCount.IsValid);
+                Assert.True(orderLinesCount.IsValid);
 
                 Assert.Equal(0, ordersCountAfterDelete.Count);
                 Assert.Equal(0, orderLinesCountAfterDelete.Count);
@@ -143,8 +144,6 @@ loadToOrders(orderData);
 
                 etlDone.Wait(TimeSpan.FromMinutes(1));
 
-                EnsureNonStaleElasticResults(client);
-
                 var ordersCount = client.Count<object>(c => c.Index(OrderIndexName));
                 var orderLinesCount = client.Count<object>(c => c.Index(OrderLinesIndexName));
 
@@ -165,9 +164,6 @@ loadToOrders(orderData);
 
                 etlDone.Wait(TimeSpan.FromMinutes(1));
 
-                EnsureNonStaleElasticResults(client);
-
-                Thread.Sleep(3000);
                 var ordersCountAfterDelete = client.Count<object>(c => c.Index(OrderIndexName));
                 var orderLinesCountAfterDelete = client.Count<object>(c => c.Index(OrderLinesIndexName));
 
@@ -247,8 +243,6 @@ loadToOrders(orderData);
 
                 etlDone.Wait(TimeSpan.FromMinutes(1));
 
-                EnsureNonStaleElasticResults(client);
-
                 var orderResponse = client.Search<object>(d => d
                     .Index(OrderIndexName)
                     .Query(q => q
@@ -288,8 +282,6 @@ loadToOrders(orderData);
 
                 etlDone.Wait(TimeSpan.FromMinutes(1));
 
-                EnsureNonStaleElasticResults(client);
-
                 var ordersCountAfterDelete = client.Count<object>(c => c.Index(OrderIndexName));
                 var orderLinesCountAfterDelete = client.Count<object>(c => c.Index(OrderLinesIndexName));
                 
@@ -321,8 +313,6 @@ loadToOrders(orderData);
 
                 etlDone.Wait(TimeSpan.FromSeconds(30));
 
-                EnsureNonStaleElasticResults(client);
-
                 var ordersCount = client.Count<object>(c => c.Index(OrderIndexName));
                 var orderLinesCount = client.Count<object>(c => c.Index(OrderLinesIndexName));
 
@@ -339,8 +329,6 @@ loadToOrders(orderData);
                 }
 
                 etlDone.Wait(TimeSpan.FromSeconds(90));
-
-                EnsureNonStaleElasticResults(client);
 
                 var ordersCountAfterDelete = client.Count<object>(c => c.Index(OrderIndexName));
                 var orderLinesCountAfterDelete = client.Count<object>(c => c.Index(OrderLinesIndexName));
@@ -372,8 +360,6 @@ loadToOrders(orderData);
                 var etlDone = WaitForEtl(store, (n, statistics) => statistics.LoadSuccesses != 0);
 
                 etlDone.Wait(TimeSpan.FromMinutes(1));
-
-                EnsureNonStaleElasticResults(client);
 
                 var orderResponse = client.Search<object>(d => d
                     .Index(OrderIndexName)
@@ -410,8 +396,6 @@ loadToOrders(orderData);
                 }
 
                 etlDone.Wait(TimeSpan.FromMinutes(2));
-
-                EnsureNonStaleElasticResults(client);
 
                 var orderResponse1 = client.Search<object>(d => d
                     .Index(OrderIndexName)
@@ -452,8 +436,6 @@ loadToOrders(orderData);
                 }
                 
                 etlDone.Wait(TimeSpan.FromSeconds(20));
-
-                EnsureNonStaleElasticResults(client);
 
                 var userResponse1 = client.Search<object>(d => d
                     .Index("users")
@@ -497,8 +479,6 @@ loadToOrders(orderData);
                 }
 
                 etlDone.Wait(TimeSpan.FromSeconds(20));
-
-                EnsureNonStaleElasticResults(client);
 
                 var userResponse3 = client.Search<object>(d => d
                     .Index("users")
@@ -550,8 +530,6 @@ loadToOrders(orderData);
                 }
 
                 etlDone.Wait(TimeSpan.FromSeconds(30));
-                
-                EnsureNonStaleElasticResults(client);
 
                 var userResponse = client.Search<object>(d => d
                     .Index("users")
@@ -587,8 +565,6 @@ loadToOrders(orderData);
 
                 etlDone.Wait(TimeSpan.FromMinutes(1));
 
-                EnsureNonStaleElasticResults(client);
-
                 var userResponse = client.Search<object>(d => d
                     .Index("users")
                     .Query(q => q
@@ -610,8 +586,6 @@ loadToOrders(orderData);
                 }
 
                 etlDone.Wait(TimeSpan.FromMinutes(1));
-
-                EnsureNonStaleElasticResults(client);
 
                 userResponse = client.Search<object>(d => d
                     .Index("users")
@@ -730,8 +704,6 @@ loadToOrders(orderData);
 
                 etlDone.Wait(TimeSpan.FromMinutes(1));
 
-                EnsureNonStaleElasticResults(client);
-
                 var userResponse1 = client.Search<object>(d => d
                     .Index("users")
                     .Query(q => q
@@ -816,19 +788,17 @@ loadToOrders(orderData);
 
                     var orderLines = result.Summary.First(x => x.IndexName == "orderlines");
 
-                    Assert.Equal(3, orderLines.Commands.Length); // refresh, delete by query and bulk
+                    Assert.Equal(2, orderLines.Commands.Length); // delete by query and bulk
 
-                    Assert.StartsWith("POST orderlines/_refresh", orderLines.Commands[0]);
-                    Assert.StartsWith("POST orderlines/_delete_by_query", orderLines.Commands[1]);
-                    Assert.StartsWith("POST orderlines/_bulk", orderLines.Commands[2]);
+                    Assert.StartsWith("POST orderlines/_delete_by_query?refresh=true", orderLines.Commands[0]);
+                    Assert.StartsWith("POST orderlines/_bulk?refresh=wait_for", orderLines.Commands[1]);
 
                     var orders = result.Summary.First(x => x.IndexName == "orders");
 
-                    Assert.Equal(3, orders.Commands.Length);  // refresh, delete by query and bulk
+                    Assert.Equal(2, orders.Commands.Length);  // refresh, delete by query and bulk
 
-                    Assert.StartsWith("POST orders/_refresh", orders.Commands[0]);
-                    Assert.StartsWith("POST orders/_delete_by_query", orders.Commands[1]);
-                    Assert.StartsWith("POST orders/_bulk", orders.Commands[2]);
+                    Assert.StartsWith("POST orders/_delete_by_query?refresh=true", orders.Commands[0]);
+                    Assert.StartsWith("POST orders/_bulk?refresh=wait_for", orders.Commands[1]);
 
                     Assert.Equal("test output", result.DebugOutput[0]);
                 }
@@ -891,11 +861,11 @@ loadToOrders(orderData);
 
                     var orderLines = result.Summary.First(x => x.IndexName == "orderlines");
 
-                    Assert.Equal(2, orderLines.Commands.Length); // refresh and delete by query
+                    Assert.Equal(1, orderLines.Commands.Length); // delete
 
                     var orders = result.Summary.First(x => x.IndexName == "orders");
 
-                    Assert.Equal(2, orders.Commands.Length); // refresh and delete by query
+                    Assert.Equal(1, orders.Commands.Length); // delete by query
                 }
                 
                 using (var session = store.OpenAsyncSession())

--- a/test/SlowTests/Server/Documents/ETL/Elasticsearch/ElasticSearchEtlTests.cs
+++ b/test/SlowTests/Server/Documents/ETL/Elasticsearch/ElasticSearchEtlTests.cs
@@ -816,17 +816,19 @@ loadToOrders(orderData);
 
                     var orderLines = result.Summary.First(x => x.IndexName == "orderlines");
 
-                    Assert.Equal(2, orderLines.Commands.Length); // delete and bulk
+                    Assert.Equal(3, orderLines.Commands.Length); // refresh, delete by query and bulk
 
-                    Assert.StartsWith("POST orderlines/_delete_by_query", orderLines.Commands[0]);
-                    Assert.StartsWith("POST orderlines/_bulk", orderLines.Commands[1]);
+                    Assert.StartsWith("POST orderlines/_refresh", orderLines.Commands[0]);
+                    Assert.StartsWith("POST orderlines/_delete_by_query", orderLines.Commands[1]);
+                    Assert.StartsWith("POST orderlines/_bulk", orderLines.Commands[2]);
 
                     var orders = result.Summary.First(x => x.IndexName == "orders");
 
-                    Assert.Equal(2, orders.Commands.Length); // delete and bulk
+                    Assert.Equal(3, orders.Commands.Length);  // refresh, delete by query and bulk
 
-                    Assert.StartsWith("POST orders/_delete_by_query", orders.Commands[0]);
-                    Assert.StartsWith("POST orders/_bulk", orders.Commands[1]);
+                    Assert.StartsWith("POST orders/_refresh", orders.Commands[0]);
+                    Assert.StartsWith("POST orders/_delete_by_query", orders.Commands[1]);
+                    Assert.StartsWith("POST orders/_bulk", orders.Commands[2]);
 
                     Assert.Equal("test output", result.DebugOutput[0]);
                 }
@@ -889,11 +891,11 @@ loadToOrders(orderData);
 
                     var orderLines = result.Summary.First(x => x.IndexName == "orderlines");
 
-                    Assert.Equal(1, orderLines.Commands.Length); // delete
+                    Assert.Equal(2, orderLines.Commands.Length); // refresh and delete by query
 
                     var orders = result.Summary.First(x => x.IndexName == "orders");
 
-                    Assert.Equal(1, orders.Commands.Length); // delete
+                    Assert.Equal(2, orders.Commands.Length); // refresh and delete by query
                 }
                 
                 using (var session = store.OpenAsyncSession())

--- a/test/SlowTests/Server/Documents/ETL/Elasticsearch/ElasticSearchEtlTests.cs
+++ b/test/SlowTests/Server/Documents/ETL/Elasticsearch/ElasticSearchEtlTests.cs
@@ -252,18 +252,18 @@ loadToOrders(orderData);
                 var orderResponse = client.Search<object>(d => d
                     .Index(OrderIndexName)
                     .Query(q => q
-                        .Match(p => p
+                        .Term(p => p
                             .Field("Id")
-                            .Query("orders/1-a"))
+                            .Value("orders/1-a"))
                     )
                 );
 
                 var orderLineResponse = client.Search<object>(d => d
                     .Index(OrderLinesIndexName)
                     .Query(q => q
-                        .Match(p => p
+                        .Term(p => p
                             .Field("OrderId")
-                            .Query("orders/1-a"))
+                            .Value("orders/1-a"))
                     )
                 );
 
@@ -378,9 +378,9 @@ loadToOrders(orderData);
                 var orderResponse = client.Search<object>(d => d
                     .Index(OrderIndexName)
                     .Query(q => q
-                        .Match(p => p
+                        .Term(p => p
                             .Field("Id")
-                            .Query("orders/1-a"))
+                            .Value("orders/1-a"))
                     )
                 );
 
@@ -416,9 +416,9 @@ loadToOrders(orderData);
                 var orderResponse1 = client.Search<object>(d => d
                     .Index(OrderIndexName)
                     .Query(q => q
-                        .Match(p => p
+                        .Term(p => p
                             .Field("Id")
-                            .Query("orders/1-a"))
+                            .Value("orders/1-a"))
                     )
                 );
 
@@ -458,9 +458,9 @@ loadToOrders(orderData);
                 var userResponse1 = client.Search<object>(d => d
                     .Index("users")
                     .Query(q => q
-                        .MatchPhrase(p => p
+                        .Term(p => p
                             .Field("UserId")
-                            .Query("users/1"))
+                            .Value("users/1"))
                     )
                 );
 
@@ -472,9 +472,9 @@ loadToOrders(orderData);
                 var userResponse2 = client.Search<object>(d => d
                     .Index("users")
                     .Query(q => q
-                        .MatchPhrase(p => p
+                        .Term(p => p
                             .Field("UserId")
-                            .Query("people/1"))
+                            .Value("people/1"))
                     )
                 );
 
@@ -503,9 +503,9 @@ loadToOrders(orderData);
                 var userResponse3 = client.Search<object>(d => d
                     .Index("users")
                     .Query(q => q
-                        .MatchPhrase(p => p
+                        .Term(p => p
                             .Field("UserId")
-                            .Query("users/1"))
+                            .Value("users/1"))
                     )
                 );
 
@@ -517,9 +517,9 @@ loadToOrders(orderData);
                 var userResponse4 = client.Search<object>(d => d
                     .Index("users")
                     .Query(q => q
-                        .MatchPhrase(p => p
+                        .Term(p => p
                             .Field("UserId")
-                            .Query("people/1"))
+                            .Value("people/1"))
                     )
                 );
 
@@ -556,9 +556,9 @@ loadToOrders(orderData);
                 var userResponse = client.Search<object>(d => d
                     .Index("users")
                     .Query(q => q
-                        .Match(p => p
+                        .Term(p => p
                             .Field("UserId")
-                            .Query("users/1"))
+                            .Value("users/1"))
                     )
                 );
 
@@ -592,9 +592,9 @@ loadToOrders(orderData);
                 var userResponse = client.Search<object>(d => d
                     .Index("users")
                     .Query(q => q
-                        .Match(p => p
+                        .Term(p => p
                             .Field("UserId")
-                            .Query("users/1"))
+                            .Value("users/1"))
                     )
                 );
 
@@ -616,9 +616,9 @@ loadToOrders(orderData);
                 userResponse = client.Search<object>(d => d
                     .Index("users")
                     .Query(q => q
-                        .Match(p => p
+                        .Term(p => p
                             .Field("UserId")
-                            .Query("users/1"))
+                            .Value("users/1"))
                     )
                 );
 
@@ -713,7 +713,7 @@ loadToOrders(orderData);
                             }
                         },
                         AllowEtlOnNonEncryptedChannel = true
-                    }, new ElasticSearchConnectionString {Name = "test", Nodes = new[] {"http://localhost:9200"}});
+                    }, new ElasticSearchConnectionString {Name = "test", Nodes = ElasticSearchTestNodes.Instance.VerifiedNodes.Value });
 
                 var db = GetDatabase(src.Database).Result;
 
@@ -735,9 +735,9 @@ loadToOrders(orderData);
                 var userResponse1 = client.Search<object>(d => d
                     .Index("users")
                     .Query(q => q
-                        .MatchPhrase(p => p
+                        .Term(p => p
                             .Field("UserId")
-                            .Query("users/1-a"))
+                            .Value("users/1-a"))
                     )
                 );
 


### PR DESCRIPTION
### Issue link

https://issues.hibernatingrhinos.com/issue/RavenDB-13041

### Additional description

Changing the implementation so now we wait for inserted records to be indexes by Elastic search using `refresh=wait_for` to follow their recommendation (https://www.elastic.co/guide/en/elasticsearch/reference/current/indices-refresh.html). Also waiting explicitly when doing delete by query.

### Type of change

- Bug fix

### How risky is the change?

- Low 

### Backward compatibility

- Not relevant

### Is it platform specific issue?

- No

### Documentation update

- Documentation of this feature is WIP

### Testing 

- Tests have been added that prove the fix is effective or that the feature works
- It has been verified by manual testing

### Is there any existing behavior change of other features due to this change?

- No

### UI work

- No UI work is needed
