### PR TITLE
RavenDB-17345 - Legacy replication error for tombstones

### DIFF
--- a/src/Raven.Server/Documents/Handlers/LegacyReplicationHandler.cs
+++ b/src/Raven.Server/Documents/Handlers/LegacyReplicationHandler.cs
@@ -207,6 +207,20 @@ namespace Raven.Server.Documents.Handlers
             return Task.CompletedTask;
         }
 
+        [RavenAction("/databases/*/transformers/$", "PUT", AuthorizationStatus.ValidUser)]
+        public Task PutTransformer()
+        {
+            // nothing to do here
+            return Task.CompletedTask;
+        }
+
+        [RavenAction("/databases/*/transformers/$", "DELETE", AuthorizationStatus.ValidUser)]
+        public Task DeleteTransformer()
+        {
+            // nothing to do here
+            return Task.CompletedTask;
+        }
+
         private Guid GetRemoteServerInstanceId()
         {
             var remoteServerIdString = GetQueryStringValueAndAssertIfSingleAndNotEmpty("dbid");

--- a/src/Raven.Server/Smuggler/Documents/DatabaseSmuggler.cs
+++ b/src/Raven.Server/Smuggler/Documents/DatabaseSmuggler.cs
@@ -606,7 +606,7 @@ namespace Raven.Server.Smuggler.Documents
             var throwOnCollectionMismatchError = _options.OperateOnTypes.HasFlag(DatabaseItemType.Tombstones) == false;
             using (var actions = _destination.Documents(throwOnCollectionMismatchError))
             {
-                List<LazyStringValue> legacyIdsToDelete = null;
+                List<string> legacyIdsToDelete = null;
                 foreach (var item in _source.GetDocuments(_options.Collections, actions))
                 {
                     _token.ThrowIfCancellationRequested();
@@ -690,7 +690,7 @@ namespace Raven.Server.Smuggler.Documents
             return result.Documents;
         }
 
-        private void TryHandleLegacyDocumentTombstones(List<LazyStringValue> legacyIdsToDelete, IDocumentActions actions, SmugglerResult result)
+        private void TryHandleLegacyDocumentTombstones(List<string> legacyIdsToDelete, IDocumentActions actions, SmugglerResult result)
         {
             if (legacyIdsToDelete == null)
                 return;
@@ -732,7 +732,7 @@ namespace Raven.Server.Smuggler.Documents
             }
         }
 
-        private bool SkipDocument(BuildVersionType buildType, bool isPreV4Revision, DocumentItem item, SmugglerResult result, ref List<LazyStringValue> legacyIdsToDelete)
+        private bool SkipDocument(BuildVersionType buildType, bool isPreV4Revision, DocumentItem item, SmugglerResult result, ref List<string> legacyIdsToDelete)
         {
             if (buildType == BuildVersionType.V3 == false)
                 return false;
@@ -748,7 +748,7 @@ namespace Raven.Server.Smuggler.Documents
 
             if ((item.Document.NonPersistentFlags & NonPersistentDocumentFlags.LegacyDeleteMarker) == NonPersistentDocumentFlags.LegacyDeleteMarker)
             {
-                legacyIdsToDelete ??= new List<LazyStringValue>();
+                legacyIdsToDelete ??= new List<string>();
                 legacyIdsToDelete.Add(item.Document.Id);
                 return true;
             }


### PR DESCRIPTION
… disposed

### Issue link

https://issues.hibernatingrhinos.com/issue/RavenDB-17345

### Additional description

- We cannot use a context that was already disposed (by the `MergedBatchPutCommand`).
- Add more endpoints to ignore during replication from v3.x and lower.

_Please delete below the options that are not relevant_

### Type of change

- Bug fix

### How risky is the change?

- Low 

### Testing 

- It has been verified by manual testing

### Is there any existing behavior change of other features due to this change?

- No
