### PR TITLE
RavenDB-17335 Import Data View: Rename 'From other' to 'From NoSQL'

### DIFF
--- a/src/Raven.Studio/typescript/viewmodels/database/tasks/importParent.ts
+++ b/src/Raven.Studio/typescript/viewmodels/database/tasks/importParent.ts
@@ -22,7 +22,7 @@ class importParent {
                     route: 'databases/tasks/import/migrateRavenDB',
                     moduleId: 'viewmodels/database/tasks/migrateRavenDbDatabase',
                     title: 'Import database from another RavenDB',
-                    tabName: "From RavenDB",
+                    tabName: "From RavenDB Server",
                     nav: true,
                     dynamicHash: appUrl.forCurrentDatabase().migrateRavenDbDatabaseUrl,
                     requiredAccess: "DatabaseReadWrite"
@@ -31,7 +31,7 @@ class importParent {
                     route: 'databases/tasks/import/csv',
                     moduleId: 'viewmodels/database/tasks/importCollectionFromCsv',
                     title: 'Import collection from CSV file',
-                    tabName: "From CSV file",
+                    tabName: "From CSV File",
                     nav: true,
                     dynamicHash: appUrl.forCurrentDatabase().importCollectionFromCsv,
                     requiredAccess: "DatabaseReadWrite"
@@ -49,7 +49,7 @@ class importParent {
                     route: 'databases/tasks/import/migrate',
                     moduleId: 'viewmodels/database/tasks/migrateDatabase',
                     title: 'Migrate database',
-                    tabName: "From other",
+                    tabName: "From NoSQL",
                     nav: true,
                     dynamicHash: appUrl.forCurrentDatabase().migrateDatabaseUrl,
                     requiredAccess: "DatabaseReadWrite"


### PR DESCRIPTION
### Issue link
https://issues.hibernatingrhinos.com/issue/RavenDB-17335

### Additional description
Rename import data tabs titles, i.e.: From other => From NoSQL

### Type of change
- Cosmetics

### How risky is the change?
- Low 

### Backward compatibility
- Non-breaking change

### Is it a platform-specific issue?
- No

### Documentation update
- This change requires a documentation update. 

### Testing 
- It has been verified by manual testing

### Is there any existing behavior change of other features due to this change?
- No

### UI work
- No UI work is needed
