### PR TITLE
RavenDB-17159 Wrong number of revision with timeseries after import

### DIFF
--- a/src/Raven.Server/Documents/Handlers/TimeSeriesHandler.cs
+++ b/src/Raven.Server/Documents/Handlers/TimeSeriesHandler.cs
@@ -956,7 +956,7 @@ namespace Raven.Server.Documents.Handlers
                             if (tss.TryAppendEntireSegmentFromSmuggler(context, slicer.TimeSeriesKeySlice, collectionName, item))
                             {
                                 // on import we remove all @time-series from the document, so we need to re-add them
-                                tss.AddTimeSeriesNameToMetadata(context, item.DocId, item.Name);
+                                tss.AddTimeSeriesNameToMetadata(context, item.DocId, item.Name, NonPersistentDocumentFlags.FromSmuggler);
                                 continue;
                             }
                         }

--- a/src/Raven.Server/Documents/Revisions/RevisionsStorage.cs
+++ b/src/Raven.Server/Documents/Revisions/RevisionsStorage.cs
@@ -286,6 +286,9 @@ namespace Raven.Server.Documents.Revisions
                 if (nonPersistentFlags.Contain(NonPersistentDocumentFlags.ByAttachmentUpdate))
                     return false;
 
+                if (nonPersistentFlags.Contain(NonPersistentDocumentFlags.ByTimeSeriesUpdate))
+                    return false;
+
                 if (configuration == ConflictConfiguration.Default || configuration.Disabled)
                     return false;
             }

--- a/src/Raven.Server/Documents/TimeSeries/TimeSeriesStorage.cs
+++ b/src/Raven.Server/Documents/TimeSeries/TimeSeriesStorage.cs
@@ -1626,7 +1626,7 @@ namespace Raven.Server.Documents.TimeSeries
             }
         }
 
-        public void AddTimeSeriesNameToMetadata(DocumentsOperationContext ctx, string docId, string tsName)
+        public void AddTimeSeriesNameToMetadata(DocumentsOperationContext ctx, string docId, string tsName, NonPersistentDocumentFlags nonPersistentFlags = NonPersistentDocumentFlags.None)
         {
             var tss = _documentDatabase.DocumentsStorage.TimeSeriesStorage;
             if (tss.Stats.GetStats(ctx, docId, tsName).Count == 0)
@@ -1696,7 +1696,7 @@ namespace Raven.Server.Documents.TimeSeries
             using (data)
             {
                 var newDocumentData = ctx.ReadObject(doc.Data, docId, BlittableJsonDocumentBuilder.UsageMode.ToDisk);
-                _documentDatabase.DocumentsStorage.Put(ctx, doc.Id, null, newDocumentData, flags: flags, nonPersistentFlags: NonPersistentDocumentFlags.ByTimeSeriesUpdate);
+                _documentDatabase.DocumentsStorage.Put(ctx, doc.Id, null, newDocumentData, flags: flags, nonPersistentFlags: nonPersistentFlags |= NonPersistentDocumentFlags.ByTimeSeriesUpdate);
             }
         }
 

--- a/test/SlowTests/Issues/RavenDB-17159.cs
+++ b/test/SlowTests/Issues/RavenDB-17159.cs
@@ -1,0 +1,62 @@
+﻿using System;
+using System.IO;
+using System.Threading.Tasks;
+using FastTests;
+using FastTests.Utils;
+using Raven.Client.Documents.Smuggler;
+using Raven.Tests.Core.Utils.Entities;
+using Xunit;
+using Xunit.Abstractions;
+
+namespace SlowTests.Issues
+{
+    public class RavenDB_17159 : RavenTestBase
+    {
+        public RavenDB_17159(ITestOutputHelper output) : base(output)
+        {
+        }
+
+        [Fact]
+        public async Task WrongNumberOfRevisionWithTimeSeriesAfterImport()
+        {
+            var file = GetTempFileName();
+            try
+            {
+                using (var store1 = GetDocumentStore(new Options
+                {
+                    ModifyDatabaseName = s => $"{s}_1"
+                }))
+                using (var store2 = GetDocumentStore(new Options
+                {
+                    ModifyDatabaseName = s => $"{s}_2"
+                }))
+                {
+                    await RevisionsHelper.SetupRevisions(Server.ServerStore, store1.Database);
+                    using (var session = store1.OpenAsyncSession())
+                    {
+                        var user = new User {Name = "Name1", LastName = "LastName1"};
+                        await session.StoreAsync(user, "users/1");
+                        session.TimeSeriesFor("users/1", "heartbeat").Append(DateTime.Today, 100, "aa");
+                        await session.SaveChangesAsync();
+                    }
+
+                    var operation = await store1.Smuggler.ExportAsync(new DatabaseSmugglerExportOptions(), file);
+                    await operation.WaitForCompletionAsync(TimeSpan.FromMinutes(1));
+
+                    operation = await store2.Smuggler.ImportAsync(new DatabaseSmugglerImportOptions(), file);
+                    await operation.WaitForCompletionAsync(TimeSpan.FromMinutes(1));
+
+                    using (var session = store2.OpenAsyncSession())
+                    {
+                        var revisionsMetadata = await session.Advanced.Revisions.GetMetadataForAsync("users/1");
+                        Assert.Equal(3, revisionsMetadata.Count);
+                    }
+                }
+            }
+            finally
+            {
+                File.Delete(file);
+            }
+        }
+    }
+}


### PR DESCRIPTION
### Issue link

https://issues.hibernatingrhinos.com/issue/RavenDB-17159

### Additional description

When we import TimeSeriesUpdate there is no need to create new revision

_Please delete below the options that are not relevant_

### Type of change

- Bug fix

### How risky is the change?

- Low 

### Backward compatibility

- Not relevant

### Is it platform specific issue?

- No

### Documentation update

- No documentation update is needed 

### Testing 

- Tests have been added that prove the fix is effective or that the feature works

### Is there any existing behavior change of other features due to this change?

- No

### UI work

- No UI work is needed
