### PR TITLE
RavenDB-17353 - `GetNodeTagById` method return redundant whitespace at the beginning of a node tag

### DIFF
--- a/src/Raven.Server/Utils/ChangeVectorUtils.cs
+++ b/src/Raven.Server/Utils/ChangeVectorUtils.cs
@@ -289,6 +289,8 @@ namespace Raven.Server.Utils
                 return null;
 
             var start = changeVector.LastIndexOf(", ", endOfNodeTag - 1, StringComparison.OrdinalIgnoreCase) + 1;
+            if (start > 1)
+                start++;
 
             return changeVector.Substring(start, endOfNodeTag - start);
         }

--- a/test/SlowTests/Issues/RavenDB_17353.cs
+++ b/test/SlowTests/Issues/RavenDB_17353.cs
@@ -1,0 +1,30 @@
+﻿using System;
+using FastTests;
+using Raven.Server.Utils;
+using Xunit;
+using Xunit.Abstractions;
+
+namespace SlowTests.Issues
+{
+    public class RavenDB_17353 : RavenTestBase
+    {
+        public RavenDB_17353(ITestOutputHelper output) : base(output)
+        {
+        }
+
+        [Fact]
+        public void CheckGetNodeByTag()
+        {
+            const string dbid1 = "07e2GrSMdkunq1AC+KgwIg";
+            const string dbid2 = "F9I6Egqwm0Kz+K0oFVIR9Q";
+            const string cv = "C:8397-07e2GrSMdkunq1AC+KgwIg, A:8917-3UiZOcXaZ0+d6GI/VTr//A, B:8397-5FYpkl5TX0SPlIBPwjmhUw, A:2568-F9I6Egqwm0Kz+K0oFVIR9Q, A:13366-IG4VwBTOnkqoT/uwgm2OQg, A:2568-OSKWIRBEDEGoAxbEIiFJeQ";
+            
+            var nodeTag = ChangeVectorUtils.GetNodeTagById(cv, dbid1);
+            Assert.Equal("C", nodeTag);
+
+            nodeTag = ChangeVectorUtils.GetNodeTagById(cv, dbid2);
+            Assert.NotEqual(" A", nodeTag); 
+            Assert.Equal("A", nodeTag); 
+        }
+    }
+}


### PR DESCRIPTION

### Issue link

https://issues.hibernatingrhinos.com/issue/RavenDB-17353


### Type of change

- Bug fix

### How risky is the change?

- Low 

### Backward compatibility

- Non breaking change

### Is it platform specific issue?

- No

### Documentation update

- No documentation update is needed 

### Testing 

- It has been verified by manual testing

### Is there any existing behavior change of other features due to this change?

- No

### UI work

- No UI work is needed
