### PR TITLE
RavenDB-17234 : Cannot contact watcher node using DocumentStore.Maintenance.Server.ForNode

### DIFF
--- a/src/Raven.Client/Http/ClusterRequestExecutor.cs
+++ b/src/Raven.Client/Http/ClusterRequestExecutor.cs
@@ -99,23 +99,7 @@ namespace Raven.Client.Http
                     ClusterTopologyLocalCache.TrySaving(TopologyHash, command.Result, Conventions, context);
 
                     var results = command.Result;
-                    var nodes = new List<ServerNode>();
-                    foreach (var member in results.Topology.Members)
-                    {
-                        nodes.Add(new ServerNode
-                        {
-                            Url = member.Value,
-                            ClusterTag = member.Key
-                        });
-                    }
-                    foreach (var watcher in results.Topology.Watchers)
-                    {
-                        nodes.Add(new ServerNode
-                        {
-                            Url = watcher.Value,
-                            ClusterTag = watcher.Key
-                        });
-                    }
+                    var nodes = ServerNode.CreateFrom(results.Topology);
 
                     var newTopology = new Topology
                     {
@@ -177,28 +161,13 @@ namespace Raven.Client.Http
             if (clusterTopology == null)
                 return false;
 
-            var nodes = new List<ServerNode>();
-            foreach (var member in clusterTopology.Topology.Members)
-            {
-                nodes.Add(new ServerNode
-                {
-                    Url = member.Value,
-                    ClusterTag = member.Key
-                });
-            }
-            foreach (var watcher in clusterTopology.Topology.Watchers)
-            {
-                nodes.Add(new ServerNode
-                {
-                    Url = watcher.Value,
-                    ClusterTag = watcher.Key
-                });
-            }
+            var nodes = ServerNode.CreateFrom(clusterTopology.Topology);
 
             _nodeSelector = new NodeSelector(new Topology
             {
                 Nodes = nodes
             });
+
             return true;
         }
     }

--- a/src/Raven.Client/Http/ClusterRequestExecutor.cs
+++ b/src/Raven.Client/Http/ClusterRequestExecutor.cs
@@ -99,16 +99,27 @@ namespace Raven.Client.Http
                     ClusterTopologyLocalCache.TrySaving(TopologyHash, command.Result, Conventions, context);
 
                     var results = command.Result;
+                    var nodes = new List<ServerNode>();
+                    foreach (var member in results.Topology.Members)
+                    {
+                        nodes.Add(new ServerNode
+                        {
+                            Url = member.Value,
+                            ClusterTag = member.Key
+                        });
+                    }
+                    foreach (var watcher in results.Topology.Watchers)
+                    {
+                        nodes.Add(new ServerNode
+                        {
+                            Url = watcher.Value,
+                            ClusterTag = watcher.Key
+                        });
+                    }
+
                     var newTopology = new Topology
                     {
-                        Nodes = new List<ServerNode>(
-                            from member in results.Topology.Members
-                            select new ServerNode
-                            {
-                                Url = member.Value,
-                                ClusterTag = member.Key
-                            }
-                        ),
+                        Nodes = nodes,
                         Etag = results.Etag
                     };
 
@@ -166,16 +177,27 @@ namespace Raven.Client.Http
             if (clusterTopology == null)
                 return false;
 
+            var nodes = new List<ServerNode>();
+            foreach (var member in clusterTopology.Topology.Members)
+            {
+                nodes.Add(new ServerNode
+                {
+                    Url = member.Value,
+                    ClusterTag = member.Key
+                });
+            }
+            foreach (var watcher in clusterTopology.Topology.Watchers)
+            {
+                nodes.Add(new ServerNode
+                {
+                    Url = watcher.Value,
+                    ClusterTag = watcher.Key
+                });
+            }
+
             _nodeSelector = new NodeSelector(new Topology
             {
-                Nodes = new List<ServerNode>(
-                    from member in clusterTopology.Topology.Members
-                    select new ServerNode
-                    {
-                        Url = member.Value,
-                        ClusterTag = member.Key
-                    }
-                )
+                Nodes = nodes
             });
             return true;
         }

--- a/src/Raven.Client/Http/ServerNode.cs
+++ b/src/Raven.Client/Http/ServerNode.cs
@@ -1,4 +1,5 @@
 ﻿using System;
+using System.Collections.Generic;
 
 namespace Raven.Client.Http
 {
@@ -26,9 +27,12 @@ namespace Raven.Client.Http
 
         public override bool Equals(object obj)
         {
-            if (ReferenceEquals(null, obj)) return false;
-            if (ReferenceEquals(this, obj)) return true;
-            if (obj.GetType() != GetType()) return false;
+            if (ReferenceEquals(null, obj))
+                return false;
+            if (ReferenceEquals(this, obj))
+                return true;
+            if (obj.GetType() != GetType())
+                return false;
             return Equals((ServerNode)obj);
         }
 
@@ -40,6 +44,33 @@ namespace Raven.Client.Http
                 hashCode = (hashCode * 397) ^ (Database?.GetHashCode() ?? 0);
                 return hashCode;
             }
+        }
+
+        internal static List<ServerNode> CreateFrom(ClusterTopology topology)
+        {
+            var nodes = new List<ServerNode>();
+            if (topology == null)
+                return nodes;
+
+            foreach (var member in topology.Members)
+            {
+                nodes.Add(new ServerNode
+                {
+                    Url = member.Value,
+                    ClusterTag = member.Key
+                });
+            }
+
+            foreach (var watcher in topology.Watchers)
+            {
+                nodes.Add(new ServerNode
+                {
+                    Url = watcher.Value,
+                    ClusterTag = watcher.Key
+                });
+            }
+
+            return nodes;
         }
     }
 }

--- a/test/SlowTests/Issues/RavenDB-17079.cs
+++ b/test/SlowTests/Issues/RavenDB-17079.cs
@@ -1,6 +1,5 @@
 using System.IO;
 using FastTests;
-using Raven.Client.Documents.Commands.Batches;
 using Raven.Tests.Core.Utils.Entities;
 using Xunit;
 using Xunit.Abstractions;

--- a/test/SlowTests/Issues/RavenDB-17234.cs
+++ b/test/SlowTests/Issues/RavenDB-17234.cs
@@ -1,0 +1,44 @@
+using System.Linq;
+using System.Threading.Tasks;
+using Raven.Client.Documents;
+using Raven.Client.Documents.Conventions;
+using Raven.Client.ServerWide.Operations;
+using Tests.Infrastructure;
+using Xunit;
+using Xunit.Abstractions;
+
+namespace SlowTests.Issues
+{
+    public class RavenDB_17234 : ClusterTestBase
+    {
+        public RavenDB_17234(ITestOutputHelper output) : base(output)
+        {
+        }
+
+        [Fact]
+        public async Task CanTargetOperationsAgainstWatcherNodeUsingDocumentStoreServerOperationsExecutor()
+        {
+            var databaseName = GetDatabaseName();
+            var (nodes, leader) = await CreateRaftCluster(2, watcherCluster: true);
+            var clusterTopology = leader.ServerStore.GetClusterTopology();
+
+            Assert.Equal(2, clusterTopology.AllNodes.Count);
+            Assert.Equal(1, clusterTopology.Members.Count);
+            Assert.Equal(1, clusterTopology.Watchers.Count);
+
+            await CreateDatabaseInCluster(databaseName, 2, leader.WebUrl);
+
+            using (var store = new DocumentStore
+            {
+                Urls = nodes.Select(n => n.WebUrl).ToArray(), 
+                Database = databaseName
+            }.Initialize())
+            {
+                var watcherTag = clusterTopology.Watchers.Single().Key;
+                var rec = await store.Maintenance.Server.ForNode(watcherTag).SendAsync(new GetDatabaseRecordOperation(databaseName));
+                Assert.NotNull(rec);
+                Assert.Equal(databaseName, rec.DatabaseName);
+            }
+        }
+    }
+}


### PR DESCRIPTION
### Issue link

https://issues.hibernatingrhinos.com/issue/RavenDB-17234

### Additional description

Added watcher nodes to `ClusterRequestExecutor` topology so that we can target operations against
watchers using `DocumentStore.Maintenance.Server.ForNode`

Until now `ClusterRequestExecutor` topology only had cluster members :
https://github.com/ravendb/ravendb/blob/v4.2/src/Raven.Client/Http/ClusterRequestExecutor.cs#L102-#L113

### Type of change

- Bug fix

### How risky is the change?

- Low 

### Backward compatibility

- Non breaking change

### Is it platform specific issue?

- No

### Documentation update

- No documentation update is needed 

### Testing 

- Tests have been added that prove the fix is effective or that the feature works

### Is there any existing behavior change of other features due to this change?

- No

### UI work

- No UI work is needed
