### PR TITLE
RavenDB-17354 Adding a test which verifies that we can disable journal recycling by setting "Storage.MaxNumberOfRecyclableJournals" option to 0

### DIFF
--- a/test/SlowTests/Voron/Issues/RavenDB_17354.cs
+++ b/test/SlowTests/Voron/Issues/RavenDB_17354.cs
@@ -1,0 +1,58 @@
+﻿using System;
+using System.IO;
+using FastTests.Voron;
+using Voron;
+using Voron.Impl.Journal;
+using Xunit;
+using Xunit.Abstractions;
+
+namespace SlowTests.Voron.Issues
+{
+    public class RavenDB_17354 : StorageTest
+    {
+        public RavenDB_17354(ITestOutputHelper output) : base(output)
+        {
+        }
+
+        protected override void Configure(StorageEnvironmentOptions options)
+        {
+            options.ManualFlushing = true;
+            options.MaxNumberOfRecyclableJournals = 0;
+        }
+
+        [Fact]
+        public void Can_disable_journals_recycling()
+        {
+            RequireFileBasedPager();
+
+            Assert.Equal(0, Env.Options.MaxNumberOfRecyclableJournals);
+
+            var r = new Random(1);
+
+            var bytes = new byte[1024];
+
+            for (int i = 0; i < 1000; i++)
+            {
+                using (var tx = Env.WriteTransaction())
+                {
+                    r.NextBytes(bytes);
+
+                    tx.CreateTree("items").Add($"item/{i}", new MemoryStream(bytes));
+
+                    tx.Commit();
+                }
+            }
+
+            Env.FlushLogToDataFile();
+
+            using (var op = new WriteAheadJournal.JournalApplicator.SyncOperation(Env.Journal.Applicator))
+            {
+                op.SyncDataFile();
+            }
+
+            var journalPath = ((StorageEnvironmentOptions.DirectoryStorageEnvironmentOptions)Env.Options).JournalPath.FullPath;
+
+            Assert.Equal(0, new DirectoryInfo(journalPath).GetFiles($"{StorageEnvironmentOptions.RecyclableJournalFileNamePrefix}*").Length);
+        }
+    }
+}


### PR DESCRIPTION
### Issue link

https://issues.hibernatingrhinos.com/issue/RavenDB-17354

### Additional description

Added test which verifies that we can disable the journals recycling by setting the limit to 0

### Type of change

- Added test

### How risky is the change?

- Low 

### Backward compatibility

- Not relevant

### Is it platform specific issue?

- No

### Documentation update

- No documentation update is needed 

### Testing 

- Tests have been added that prove the fix is effective or that the feature works

### Is there any existing behavior change of other features due to this change?

- No

### UI work

- No UI work is needed
