### PR TITLE
RavenDB-17208 Fixed RavenETL empty script test issue

### DIFF
--- a/src/Raven.Server/Documents/ETL/Providers/OLAP/Handlers/OlapEtlHandler.cs
+++ b/src/Raven.Server/Documents/ETL/Providers/OLAP/Handlers/OlapEtlHandler.cs
@@ -20,12 +20,15 @@ namespace Raven.Server.Documents.ETL.Providers.OLAP.Handlers
 
                 var testScript = JsonDeserializationServer.TestOlapEtlScript(testConfig);
 
-                var result = (OlapEtlTestScriptResult)OlapEtl.TestScript(testScript, Database, ServerStore, context);
-
-                await using (var writer = new AsyncBlittableJsonTextWriter(context, ResponseBodyStream()))
+                using (OlapEtl.TestScript(testScript, Database, ServerStore, context, out var testResult))
                 {
-                    var djv = (DynamicJsonValue)TypeConverter.ToBlittableSupportedType(result);
-                    writer.WriteObject(context.ReadObject(djv, "olap-etl-test"));
+                    var result = (OlapEtlTestScriptResult)testResult;
+                    
+                    await using (var writer = new AsyncBlittableJsonTextWriter(context, ResponseBodyStream()))
+                    {
+                        var djv = (DynamicJsonValue)TypeConverter.ToBlittableSupportedType(result);
+                        writer.WriteObject(context.ReadObject(djv, "olap-etl-test"));
+                    }
                 }
             }
         }

--- a/src/Raven.Server/Documents/ETL/Providers/SQL/Handlers/SqlEtlHandler.cs
+++ b/src/Raven.Server/Documents/ETL/Providers/SQL/Handlers/SqlEtlHandler.cs
@@ -68,12 +68,15 @@ namespace Raven.Server.Documents.ETL.Providers.SQL.Handlers
                 var dbDoc = await context.ReadForMemoryAsync(RequestBodyStream(), "TestSqlEtlScript");
                 var testScript = JsonDeserializationServer.TestSqlEtlScript(dbDoc);
 
-                var result = (SqlEtlTestScriptResult)SqlEtl.TestScript(testScript, Database, ServerStore, context);
-
-                await using (var writer = new AsyncBlittableJsonTextWriter(context, ResponseBodyStream()))
+                using (SqlEtl.TestScript(testScript, Database, ServerStore, context, out var testResult))
                 {
-                    var djv = (DynamicJsonValue)TypeConverter.ToBlittableSupportedType(result);
-                    writer.WriteObject(context.ReadObject(djv, "et/sql/test"));
+                    var result = (SqlEtlTestScriptResult)testResult;
+                    
+                    await using (var writer = new AsyncBlittableJsonTextWriter(context, ResponseBodyStream()))
+                    {
+                        var djv = (DynamicJsonValue)TypeConverter.ToBlittableSupportedType(result);
+                        writer.WriteObject(context.ReadObject(djv, "et/sql/test"));
+                    }
                 }
             }
         }

--- a/test/SlowTests/Server/Documents/ETL/Raven/RavenDB_12011.cs
+++ b/test/SlowTests/Server/Documents/ETL/Raven/RavenDB_12011.cs
@@ -41,7 +41,7 @@ namespace SlowTests.Server.Documents.ETL.Raven
 
                     using (database.DocumentsStorage.ContextPool.AllocateOperationContext(out DocumentsOperationContext context))
                     {
-                        var result = (RavenEtlTestScriptResult)RavenEtl.TestScript(new TestRavenEtlScript
+                        using (RavenEtl.TestScript(new TestRavenEtlScript
                         {
                             DocumentId = "orders/1-A",
                             IsDelete = true,
@@ -52,10 +52,7 @@ namespace SlowTests.Server.Documents.ETL.Raven
                                 {
                                     new Transformation()
                                     {
-                                        Collections =
-                                        {
-                                            "Orders"
-                                        },
+                                        Collections = {"Orders"},
                                         Name = "OrdersAndLines",
                                         Script =
                                             @"
@@ -81,14 +78,17 @@ loadToOrders(orderData);
                                     }
                                 }
                             }
-                        }, database, database.ServerStore, context);
+                        }, database, database.ServerStore, context, out var testResult))
+                        {
+                            var result = (RavenEtlTestScriptResult)testResult;
+                            
+                            Assert.Equal(0, result.TransformationErrors.Count);
 
-                        Assert.Equal(0, result.TransformationErrors.Count);
+                            Assert.Equal(2, result.Commands.Count);
 
-                        Assert.Equal(2, result.Commands.Count);
-
-                        Assert.IsType(typeof(DeletePrefixedCommandData), result.Commands[0]);
-                        Assert.IsType(typeof(DeleteCommandData), result.Commands[1]);
+                            Assert.IsType(typeof(DeletePrefixedCommandData), result.Commands[0]);
+                            Assert.IsType(typeof(DeleteCommandData), result.Commands[1]);
+                        }
                     }
                 }
 
@@ -117,7 +117,7 @@ loadToOrders(orderData);
 
                     using (database.DocumentsStorage.ContextPool.AllocateOperationContext(out DocumentsOperationContext context))
                     {
-                        var result = (RavenEtlTestScriptResult)RavenEtl.TestScript(new TestRavenEtlScript
+                        using (RavenEtl.TestScript(new TestRavenEtlScript
                         {
                             DocumentId = "users/1",
                             IsDelete = true,
@@ -128,10 +128,7 @@ loadToOrders(orderData);
                                 {
                                     new Transformation()
                                     {
-                                        Collections =
-                                        {
-                                            "Users"
-                                        },
+                                        Collections = {"Users"},
                                         Name = "Users",
                                         Script =
                                             @"
@@ -145,13 +142,16 @@ function deleteDocumentsOfUsersBehavior(docId) {
                                     }
                                 }
                             }
-                        }, database, database.ServerStore, context);
+                        }, database, database.ServerStore, context, out var testResult))
+                        {
+                            var result = (RavenEtlTestScriptResult)testResult;
+                            
+                            Assert.Equal(0, result.TransformationErrors.Count);
 
-                        Assert.Equal(0, result.TransformationErrors.Count);
+                            Assert.Equal(0, result.Commands.Count);
 
-                        Assert.Equal(0, result.Commands.Count);
-
-                        Assert.Equal("document: users/1", result.DebugOutput[0]);
+                            Assert.Equal("document: users/1", result.DebugOutput[0]);
+                        }
                     }
                 }
 


### PR DESCRIPTION
### Issue link

https://issues.hibernatingrhinos.com/issue/RavenDB-17208

### Additional description

We can execute RavenETL without a transform script. Clicking "Test Script" in the studio has resulted in an error,
![image](https://user-images.githubusercontent.com/25389585/137921274-5f9d5d4b-956a-4cab-b7b3-b0ebb30d9357.png)
that I've fixed by extending the scope of Transaction created in EtlProcess.TestScript.
Previously closing transaction inside TestScript resulted in object disposal before reading from the context in PostScriptTest.

Now we return Disposable from function, which we can put in the using block. The previous result is now returned with an out parameter. 
![image](https://user-images.githubusercontent.com/25389585/137920713-7168a232-0587-4c30-bdb3-ddc5859165b6.png)

I have also updated every usage of TestScript.

### Type of change
- Bug fix

### How risky is the change?

- Low 

### Backward compatibility

- Non breaking change

### Is it platform specific issue?

- No

### Testing 

- It has been verified by manual testing

### Is there any existing behavior change of other features due to this change?

- No

### UI work

- No UI work is needed
