### PR TITLE
RavenDB-17095 Validate Raven ETL has the `transforms` property set

### DIFF
--- a/src/Raven.Client/Documents/Operations/ETL/EtlConfiguration.cs
+++ b/src/Raven.Client/Documents/Operations/ETL/EtlConfiguration.cs
@@ -57,6 +57,9 @@ namespace Raven.Client.Documents.Operations.ETL
 
             var uniqueNames = new HashSet<string>(StringComparer.OrdinalIgnoreCase);
 
+            if (Transforms.Count == 0)
+                throw new InvalidOperationException($"'{nameof(Transforms)}' list cannot be empty.");
+            
             foreach (var script in Transforms)
             {
                 script.Validate(ref errors, EtlType);

--- a/test/SlowTests/Server/Documents/ETL/Raven/RavenDB_17095.cs
+++ b/test/SlowTests/Server/Documents/ETL/Raven/RavenDB_17095.cs
@@ -1,0 +1,35 @@
+﻿using System;
+using Xunit;
+using Xunit.Abstractions;
+using System.Collections.Generic;
+using Raven.Client.Documents.Operations.ETL;
+
+namespace SlowTests.Server.Documents.ETL.Raven
+{
+    public class RavenDB_17095 : EtlTestBase
+    {
+        public RavenDB_17095(ITestOutputHelper output) : base(output)
+        {
+        }
+        
+        [Fact]
+        public void Should_throw_when_transforms_is_empty()
+        {
+            var configuration = new RavenEtlConfiguration {ConnectionStringName = "test", Name = "myConfig", MentorNode = "A", Transforms = new List<Transformation>()};
+            configuration.Initialize(new RavenConnectionString());
+            var e = Assert.Throws<InvalidOperationException>(() => configuration.Validate(out List<string> _));
+            Assert.Equal($"'{nameof(RavenEtlConfiguration.Transforms)}' list cannot be empty.",e.Message);
+        }
+        
+        [Fact]
+        public void Should_pass_when_transforms_is_not_empty()
+        {
+            var configuration = new RavenEtlConfiguration
+            {
+                ConnectionStringName = "test", Name = "myConfig", MentorNode = "A", Transforms = new List<Transformation> {new()}
+            };
+            configuration.Initialize(new RavenConnectionString());
+            configuration.Validate(out List<string> _);
+        }
+    }
+}

--- a/test/SlowTests/Smuggler/BackupDatabaseRecordTests.cs
+++ b/test/SlowTests/Smuggler/BackupDatabaseRecordTests.cs
@@ -140,7 +140,8 @@ namespace SlowTests.Smuggler
                         MentorNode = "A",
                         Name = "Etl",
                         TaskId = 4,
-                        TestMode = true
+                        TestMode = true,
+                        Transforms = new List<Transformation>{new() {Script = "",Collections = new List<string>{"Orders"},Name ="testScript"}}
                     }));
 
                     store1.Maintenance.Send(new AddEtlOperation<SqlConnectionString>(new SqlEtlConfiguration()
@@ -155,7 +156,8 @@ namespace SlowTests.Smuggler
                             },
                         Name = "sql",
                         ParameterizeDeletes = false,
-                        MentorNode = "A"
+                        MentorNode = "A",
+                        Transforms = new List<Transformation>{new() {Script = "",Collections = new List<string>{"Orders"},Name ="testScript"}}
                     }));
                     await store1.Maintenance.SendAsync(new UpdatePeriodicBackupOperation(config));
 
@@ -329,7 +331,8 @@ namespace SlowTests.Smuggler
                         MentorNode = "A",
                         Name = "Etl",
                         TaskId = 4,
-                        TestMode = true
+                        TestMode = true,
+                        Transforms = new List<Transformation>{new() {Script = "",Collections = new List<string>{"Orders"},Name ="testScript"}}
                     }));
 
                     store1.Maintenance.Send(new AddEtlOperation<SqlConnectionString>(new SqlEtlConfiguration()
@@ -344,7 +347,8 @@ namespace SlowTests.Smuggler
                             },
                         Name = "sql",
                         ParameterizeDeletes = false,
-                        MentorNode = "A"
+                        MentorNode = "A",
+                        Transforms = new List<Transformation>{new() {Script = "",Collections = new List<string>{"Orders"},Name ="testScript"}}
                     }));
                     var migrate = new Migrator(new DatabasesMigrationConfiguration
                     {
@@ -720,25 +724,29 @@ namespace SlowTests.Smuggler
                     {
                         ConnectionStringName = "con1",
                         Name = "etl1",
-                        AllowEtlOnNonEncryptedChannel = true
+                        AllowEtlOnNonEncryptedChannel = true,
+                        Transforms = new List<Transformation>{new() {Script = "",Collections = new List<string>{"Orders"},Name ="testScript"}}
                     };
                     var etlConfiguration2 = new RavenEtlConfiguration
                     {
                         ConnectionStringName = "con2",
                         Name = "etl2",
-                        AllowEtlOnNonEncryptedChannel = true
+                        AllowEtlOnNonEncryptedChannel = true,
+                        Transforms = new List<Transformation>{new() {Script = "",Collections = new List<string>{"Orders"},Name ="testScript"}}
                     };
                     var etlConfiguration3 = new RavenEtlConfiguration
                     {
                         ConnectionStringName = "con3",
                         Name = "etl1",
-                        AllowEtlOnNonEncryptedChannel = false
+                        AllowEtlOnNonEncryptedChannel = false,
+                        Transforms = new List<Transformation>{new() {Script = "",Collections = new List<string>{"Orders"},Name ="testScript"}}
                     };
                     var etlConfiguration4 = new RavenEtlConfiguration
                     {
                         ConnectionStringName = "con4",
                         Name = "etl4",
-                        AllowEtlOnNonEncryptedChannel = true
+                        AllowEtlOnNonEncryptedChannel = true,
+                        Transforms = new List<Transformation>{new() {Script = "",Collections = new List<string>{"Orders"},Name ="testScript"}}
                     };
                     WaitForUserToContinueTheTest(store1);
                     await store1.Maintenance.SendAsync(new AddEtlOperation<RavenConnectionString>(etlConfiguration));
@@ -784,6 +792,7 @@ namespace SlowTests.Smuggler
                         ConnectionStringName = "scon1",
                         Name = "setl1",
                         AllowEtlOnNonEncryptedChannel = true,
+                        Transforms = new List<Transformation>{new() {Script = "",Collections = new List<string>{"Orders"},Name ="testScript"}},
                         SqlTables =
                         {
                             new SqlEtlTable {TableName = "Orders", DocumentIdColumn = "Id"},
@@ -796,6 +805,7 @@ namespace SlowTests.Smuggler
                         ConnectionStringName = "scon2",
                         Name = "setl2",
                         AllowEtlOnNonEncryptedChannel = true,
+                        Transforms = new List<Transformation>{new() {Script = "",Collections = new List<string>{"Orders"},Name ="testScript"}},
                         SqlTables =
                         {
                             new SqlEtlTable {TableName = "Orders", DocumentIdColumn = "Id"},
@@ -808,6 +818,7 @@ namespace SlowTests.Smuggler
                         ConnectionStringName = "scon3",
                         Name = "setl1",
                         AllowEtlOnNonEncryptedChannel = true,
+                        Transforms = new List<Transformation>{new() {Script = "",Collections = new List<string>{"Orders"},Name ="testScript"}},
                         SqlTables =
                         {
                             new SqlEtlTable {TableName = "Orders", DocumentIdColumn = "Id"},
@@ -820,6 +831,7 @@ namespace SlowTests.Smuggler
                         ConnectionStringName = "scon4",
                         Name = "setl4",
                         AllowEtlOnNonEncryptedChannel = true,
+                        Transforms = new List<Transformation>{new() {Script = "",Collections = new List<string>{"Orders"},Name ="testScript"}},
                         SqlTables =
                         {
                             new SqlEtlTable {TableName = "Orders", DocumentIdColumn = "Id"},
@@ -1057,7 +1069,8 @@ namespace SlowTests.Smuggler
                     MentorNode = "A",
                     Name = "Etl",
                     TaskId = 4,
-                    TestMode = true
+                    TestMode = true,
+                    Transforms = new List<Transformation>{new() {Script = "",Collections = new List<string>{"Orders"},Name ="testScript"}}
                 }));
 
                 store.Maintenance.Send(new AddEtlOperation<SqlConnectionString>(new SqlEtlConfiguration()
@@ -1072,7 +1085,8 @@ namespace SlowTests.Smuggler
                             },
                     Name = "sql",
                     ParameterizeDeletes = false,
-                    MentorNode = "A"
+                    MentorNode = "A",
+                    Transforms = new List<Transformation>{new() {Script = "",Collections = new List<string>{"Orders"},Name ="testScript"}}
                 }));
 
                 using (var session = store.OpenAsyncSession())


### PR DESCRIPTION

### Issue link

https://issues.hibernatingrhinos.com/issue/RavenDB-17095

### Additional description

Added ETL Configuration Transforms collection emptiness check and passing tests for it.

### Type of change

- Bug fix

### How risky is the change?

- Low 

### Backward compatibility

- Non breaking change

### Is it platform specific issue?

- No

### Documentation update

- No documentation update is needed 

### Testing 

- Tests have been added that prove the fix is effective or that the feature works

### Is there any existing behavior change of other features due to this change?

- No

### UI work

- No UI work is needed
