### PR TITLE
RavenDB-17336 Add new sub-toggle: "Ignore the index query size limit"…

### DIFF
--- a/src/Raven.Studio/typescript/commands/database/query/queryCommand.ts
+++ b/src/Raven.Studio/typescript/commands/database/query/queryCommand.ts
@@ -133,7 +133,8 @@ f();
             debug: criteria.indexEntries() ? "entries" : undefined,
             addTimeSeriesNames: true,
             addSpatialProperties: true,
-            metadataOnly: typeof(criteria.metadataOnly()) !== 'undefined' ? criteria.metadataOnly() : undefined
+            metadataOnly: typeof(criteria.metadataOnly()) !== 'undefined' ? criteria.metadataOnly() : undefined,
+            ignoreLimit: this.criteria.ignoreIndexQueryLimit()
         };
         
         let urlArgs = this.urlEncodeArgs(argsForPOST);

--- a/src/Raven.Studio/typescript/models/database/query/queryCriteria.ts
+++ b/src/Raven.Studio/typescript/models/database/query/queryCriteria.ts
@@ -7,6 +7,8 @@ class queryCriteria {
     name = ko.observable<string>("");
     showFields = ko.observable<boolean>(false);
     indexEntries = ko.observable<boolean>(false);
+    ignoreIndexQueryLimit = ko.observable<boolean>(false);
+    
     queryText = ko.observable<string>("");
     metadataOnly = ko.observable<boolean>(false);
     recentQuery = ko.observable<boolean>(false);
@@ -15,7 +17,7 @@ class queryCriteria {
     
     validationGroup: KnockoutValidationGroup;
 
-    static empty() {
+    static empty(): queryCriteria{
         return new queryCriteria();
     }
 
@@ -24,7 +26,7 @@ class queryCriteria {
         this.initValidation();
     }
     
-    private initValidation() {
+    private initValidation(): void {
         this.queryText.extend({
             // We want to be able to send invalid queries in order to get the server side error as well.
             // aceValidation: true
@@ -35,7 +37,7 @@ class queryCriteria {
         })
     }
 
-    private initObservables() {
+    private initObservables(): void {
         this.showFields.subscribe(showFields => {
             if (showFields && this.indexEntries()) {
                 this.indexEntries(false);
@@ -46,10 +48,14 @@ class queryCriteria {
             if (indexEntries && this.showFields()) {
                 this.showFields(false);
             }
+            
+            if (!indexEntries) {
+                this.ignoreIndexQueryLimit(false);
+            }
         });
     }
 
-    updateUsing(storedQuery: storedQueryDto) {
+    updateUsing(storedQuery: storedQueryDto): void {
         this.queryText(storedQuery.queryText);
         this.recentQuery(storedQuery.recentQuery);
     }
@@ -67,7 +73,7 @@ class queryCriteria {
         };
     }
 
-    setSelectedIndex(indexName: string) {
+    setSelectedIndex(indexName: string): void {
         let rql = "from ";
         if (indexName.startsWith(queryUtil.DynamicPrefix)) {
             rql += indexName.substring(queryUtil.DynamicPrefix.length);
@@ -79,7 +85,7 @@ class queryCriteria {
         this.queryText(rql);
     }
 
-    copyFrom(incoming: queryDto) {
+    copyFrom(incoming: queryDto): void {
         this.name("");
         this.queryText(incoming.queryText);
         this.recentQuery(incoming.recentQuery);
@@ -92,6 +98,7 @@ class queryCriteria {
         clonedItem.queryText(this.queryText());
         clonedItem.showFields(this.showFields());
         clonedItem.indexEntries(this.indexEntries());
+        clonedItem.ignoreIndexQueryLimit(this.ignoreIndexQueryLimit());
         clonedItem.metadataOnly(this.metadataOnly());
         clonedItem.graphOutput(this.graphOutput());
         clonedItem.recentQuery(this.recentQuery());

--- a/src/Raven.Studio/wwwroot/App/views/database/query/query.html
+++ b/src/Raven.Studio/wwwroot/App/views/database/query/query.html
@@ -300,37 +300,23 @@
 </div>
 
 <script type="text/html" id="settings-template">
-    <div class="row settings-item">
-        <div class="col-xs-offset-1 col-xs-6">
-            <div class="control-label">Cache enabled</div>
+    <div class="padding padding-sm margin-top margin-top-sm margin-bottom margin-bottom-sm">
+        <div class="toggle margin-left">
+            <input id="cache" type="checkbox" data-bind="checked: cacheEnabled">
+            <label for="cache">Cache enabled</label>
         </div>
-        <div class="col-xs-5">
-            <div class="toggle flex-row">
-                <input type="checkbox" class="styled" data-bind="checked: cacheEnabled">
-                <label class="flex-end"></label>
-            </div>
+        <div class="toggle margin-left">
+            <input id="storedFields" type="checkbox" data-bind="checked: criteria().showFields, disable: isCollectionQuery() || isGraphQuery()">
+            <label for="storedFields">Show stored index fields only</label>
         </div>
-    </div>
-    <div class="row settings-item">
-        <div class="col-xs-offset-1 col-xs-6">
-            <div class="control-label">Show stored index fields only</div>
+        <div class="toggle margin-left">
+            <input id="rawEntries" type="checkbox" data-bind="checked: criteria().indexEntries, disable: isCollectionQuery() || isGraphQuery()">
+            <label for="rawEntries" data-bind="text: 'Show raw index entries instead of ' + (queryResultsContainMatchingDocuments() ? 'matching documents' : 'index results')"></label>
         </div>
-        <div class="col-xs-5">
-            <div class="toggle flex-row">
-                <input type="checkbox" class="styled" data-bind="checked: criteria().showFields, disable: isCollectionQuery() || isGraphQuery()">
-                <label class="flex-end"></label>
-            </div>
-        </div>
-    </div>
-    <div class="row settings-item">
-        <div class="col-xs-offset-1 col-xs-6">
-            <div class="control-label" data-bind="visible: queryResultsContainMatchingDocuments">Show the raw index entries instead of matching documents</div>
-            <div class="control-label" data-bind="visible: !queryResultsContainMatchingDocuments()">Show the raw index entries instead of index results</div>
-        </div>
-        <div class="col-xs-5">
-            <div class="toggle flex-row">
-                <input type="checkbox" class="styled" data-bind="checked: criteria().indexEntries, disable: isCollectionQuery() || isGraphQuery()">
-                <label class="flex-end"></label>
+        <div class="margin-left margin-left-lg" data-bind="collapse: criteria().indexEntries">
+            <div class="toggle margin-left margin-left-lg">
+                <input id="ignoreLimit" type="checkbox" data-bind="checked: criteria().ignoreIndexQueryLimit">
+                <label for="ignoreLimit">Ignore the index query size limit</label>
             </div>
         </div>
     </div>


### PR DESCRIPTION
… in query settings

### Issue link
https://issues.hibernatingrhinos.com/issue/RavenDB-17336

### Additional description
Added new sub-toggle: "Ignore the index query size limit" to query settings

### Type of change
- Bug fix

### How risky is the change?
- Low 
- 
### Backward compatibility
- Non breaking change

### Is it platform specific issue?
- No

### Documentation update
- This change requires a documentation update. 

### Testing 
- It has been verified by manual testing

### Is there any existing behavior change of other features due to this change?
- No

### UI work
- No UI work is needed
