### PR TITLE
RavenDB-17339 Support for nested projections in LINQ.

### DIFF
--- a/src/Raven.Client/Documents/Linq/RavenQueryProviderProcessor.cs
+++ b/src/Raven.Client/Documents/Linq/RavenQueryProviderProcessor.cs
@@ -2879,7 +2879,18 @@ The recommended method is to use full text search (mark the field as Analyzed an
                 {
                     var name = GetSelectPath(newExpression.Members[index]);
 
-                    AddJsProjection(name, newExpression.Arguments[index], sb, index != 0);
+                    if (newExpression.Arguments[index] is MemberInitExpression or NewExpression)
+                    {
+                        if (index > 0)
+                            sb.Append(", ");
+                        
+                        _jsProjectionNames.Add(name);
+                        sb.Append(name).Append(" : ").Append(TranslateSelectBodyToJs(newExpression.Arguments[index]));
+                    }
+                    else
+                    {
+                        AddJsProjection(name, newExpression.Arguments[index], sb, index != 0);
+                    }
                 }
             }
 
@@ -2892,7 +2903,18 @@ The recommended method is to use full text search (mark the field as Analyzed an
                         continue;
 
                     var name = GetSelectPath(field.Member);
+                    if (field.Expression is MemberInitExpression)
+                    {
+                        if (index > 0)
+                            sb.Append(", ");
+                        
+                        _jsProjectionNames.Add(name);
+                        sb.Append(name).Append(" : ").Append(TranslateSelectBodyToJs(field.Expression));
+                        continue;
+                    }
+                   
                     AddJsProjection(name, field.Expression, sb, index != 0);
+                    
                 }
             }
 

--- a/test/SlowTests/Issues/RavenDB-17339.cs
+++ b/test/SlowTests/Issues/RavenDB-17339.cs
@@ -1,0 +1,100 @@
+﻿using System.Linq;
+using FastTests;
+using Raven.Client.Documents.Linq;
+using Raven.Client.Documents.Queries;
+using Xunit;
+using Xunit.Abstractions;
+
+namespace SlowTests.Issues
+{
+    public class RavenDB_17339 : RavenTestBase
+    {
+        public RavenDB_17339(ITestOutputHelper output) : base(output)
+        {
+        }
+
+        [Fact]
+        public void CanRawProjectOnNestedTypes()
+        {
+            using var store = GetDocumentStore();
+            {
+                using var session = store.OpenSession();
+                session.Store(new MyEntity() { Value = 123, Result = new() { RawValue = 1234 } });
+                session.SaveChanges();
+            }
+            {
+                using var session = store.OpenSession();
+                var firstQuery = session.Query<MyEntity>()
+                    .Customize(q => q.WaitForNonStaleResults())
+                    .Select(e => new Result { RawValue = RavenQuery.Raw<int>("e.Value") })
+                    .ToList();
+                Assert.Equal(1, firstQuery.Count);
+                Assert.Equal(123, firstQuery[0].RawValue);
+
+                var secondQuery = session.Query<MyEntity>()
+                    .Customize(q => q.WaitForNonStaleResults())
+                    .Select(e => new { Nested = new Result { RawValue = RavenQuery.Raw<int>("e.Value") } })
+                    .ToList();
+                Assert.Equal(1, secondQuery.Count);
+                Assert.Equal(123, secondQuery[0].Nested.RawValue);
+
+                var thirdQuery = session.Query<MyEntity>()
+                    .Customize(q => q.WaitForNonStaleResults())
+                    .Select(e => new { Nested = new Result { RawValue = e.Value } })
+                    .ToList();
+                Assert.Equal(1, thirdQuery.Count);
+                Assert.Equal(123, thirdQuery[0].Nested.RawValue);
+
+                var q5 = session.Query<MyEntity>()
+                    .Select(e => new { Foo = e.Value, Nested = new Result { RawValue = RavenQuery.Raw<int>("e.Value") } })
+                    .ToList();
+                Assert.Equal(1, q5.Count);
+                Assert.Equal(123, q5[0].Nested.RawValue);
+
+                var q6 = session.Query<MyEntity>()
+                    .Select(e => new { Nested = new { RawValue = RavenQuery.Raw<int>("e.Value") } })
+                    .ToList();
+                Assert.Equal(1, q6.Count);
+                Assert.Equal(123, q6[0].Nested.RawValue);
+
+                var q7 = session.Query<MyEntity>()
+                    .Select(e => new
+                    {
+                        Nested = new { RawValue = new Result { RawValue = RavenQuery.Raw<int>("e.Value") } },
+                        Test = new Result { RawValue = RavenQuery.Raw<int>("e.Value") }
+                    })
+                    .ToList();
+                Assert.Equal(1, q7.Count);
+                Assert.Equal(123, q7[0].Nested.RawValue.RawValue);
+
+                var q8 = session.Query<MyEntity>()
+                    .Select(e => new { Abc = 1, Cba = 2, RawValue = RavenQuery.Raw<int>("e.Value"), Nest = new Result { RawValue = RavenQuery.Raw<int>("e.Value") } })
+                    .ToList();
+                Assert.Equal(1, q8[0].Abc);
+                Assert.Equal(2, q8[0].Cba);
+                Assert.Equal(123, q8[0].RawValue);
+                Assert.Equal(123, q8[0].Nest.RawValue);
+
+                var q9 = session.Query<MyEntity>()
+                    .Select(
+                        e => new MyEntity() { Id = "test", Result = new Result { RawValue = RavenQuery.Raw<int>("e.Value") }, Value = RavenQuery.Raw<int>("e.Value") })
+                    .ToList();
+                Assert.Equal("test", q9[0].Id);
+                Assert.Equal(123, q9[0].Result.RawValue);
+                Assert.Equal(123, q9[0].Value);
+            }
+        }
+
+        private class MyEntity
+        {
+            public string Id { get; set; }
+            public int Value { get; set; }
+            public Result Result { get; set; }
+        }
+
+        private class Result
+        {
+            public int RawValue { get; set; }
+        }
+    }
+}


### PR DESCRIPTION
### Issue link

https://issues.hibernatingrhinos.com/issue/RavenDB-17339

### Additional description

Added support for nested projections in LINQ.

### Type of change

- Bug fix

### How risky is the change?

- Moderate 


### Backward compatibility

- Not relevant

### Is it platform specific issue?

- No

### Documentation update

- No documentation update is needed 

### Testing 

- Tests have been added that prove the fix is effective or that the feature works

### Is there any existing behavior change of other features due to this change?

- No

### UI work

- No UI work is needed
