### PR TITLE
RavenDB-17362 Clear replay of batch command before executing

### DIFF
--- a/src/Raven.Server/Documents/Handlers/BatchHandler.cs
+++ b/src/Raven.Server/Documents/Handlers/BatchHandler.cs
@@ -726,7 +726,7 @@ namespace Raven.Server.Documents.Handlers
                     Debug.Assert(false, "Shouldn't happen - cluster tx run via normal means");
                     return 0;// should never happened
                 }
-
+                Reply.Clear();
                 _disposables.Clear();
 
                 DocumentsStorage.PutOperationResults? lastPutResult = null;


### PR DESCRIPTION
### Issue link

https://issues.hibernatingrhinos.com/issue/RavenDB-17362

### Additional description
1. A batch command with Put followed by command B are queued in the Trx merger.
2. First, the Trx merger tries to execute them on the same transaction.
3. The batch command succeeds but command B fails so the transaction is aborted.
4. The commands are sent to be executed one by one. The batch success again.
5. The server sends the response for the batch command with the change vector of the aborted commit.

Solution: to clear the reply before rerun

### Type of change
- Bugfix

### How risky is the change?
- Low 

### Backward compatibility
- Not relevant

### Is it platform specific issue?
- No

### Documentation update
- No documentation update is needed 

### Testing 
- Tests have been added that prove the fix is effective or that the feature works

### Is there any existing behavior change of other features due to this change?
- No

### UI work
- No UI work is needed
