### PR TITLE
RavenDB-13041 Increasing the timeout for pinging ES instance. Making sure we're checking if ES is available just once. That fixes the issue with slow startup of SlowTests.

### DIFF
--- a/src/Raven.Server/Documents/ETL/Providers/Elasticsearch/ElasticSearchHelper.cs
+++ b/src/Raven.Server/Documents/ETL/Providers/Elasticsearch/ElasticSearchHelper.cs
@@ -9,12 +9,18 @@ namespace Raven.Server.Documents.ETL.Providers.ElasticSearch
 {
     public static class ElasticSearchHelper
     {
-        public static ElasticClient CreateClient(ElasticSearchConnectionString connectionString)
+        public static ElasticClient CreateClient(ElasticSearchConnectionString connectionString, TimeSpan? requestTimeout = null, TimeSpan? pingTimeout = null)
         {
             Uri[] nodesUrls = connectionString.Nodes.Select(x => new Uri(x)).ToArray();
 
             StaticConnectionPool pool = new StaticConnectionPool(nodesUrls);
             ConnectionSettings settings = new ConnectionSettings(pool);
+
+            if (requestTimeout != null)
+                settings.RequestTimeout(requestTimeout.Value);
+
+            if (pingTimeout != null)
+                settings.PingTimeout(pingTimeout.Value);
 
             if (connectionString.Authentication != null)
             {

--- a/test/SlowTests/Server/Documents/ETL/Elasticsearch/ElasticSearchEtlTests.cs
+++ b/test/SlowTests/Server/Documents/ETL/Elasticsearch/ElasticSearchEtlTests.cs
@@ -171,6 +171,7 @@ loadToOrders(orderData);
                 Assert.Equal(0, orderLinesCountAfterDelete.Count);
             }
         }
+
         [Fact]
         public void Simple_script_error_expected()
         {
@@ -892,7 +893,7 @@ loadToOrders(orderData);
             }
         }
 
-        [Fact]
+        [RequiresElasticSearchFact]
         public async Task ShouldImportTask()
         {
             using (var srcStore = GetDocumentStore())

--- a/test/Tests.Infrastructure/ConnectionString/ElasticSearchTestNodes.cs
+++ b/test/Tests.Infrastructure/ConnectionString/ElasticSearchTestNodes.cs
@@ -65,7 +65,7 @@ namespace Tests.Infrastructure.ConnectionString
             {
                 try
                 {
-                    var client = ElasticSearchHelper.CreateClient(new ElasticSearchConnectionString { Nodes = nodes });
+                    var client = ElasticSearchHelper.CreateClient(new ElasticSearchConnectionString { Nodes = nodes }, requestTimeout: TimeSpan.FromSeconds(1), pingTimeout: TimeSpan.FromSeconds(1));
 
                     response = client.Ping();
 

--- a/test/Tests.Infrastructure/RequiresElasticSearchFactAttribute.cs
+++ b/test/Tests.Infrastructure/RequiresElasticSearchFactAttribute.cs
@@ -5,9 +5,16 @@ namespace Tests.Infrastructure
 {
     public class RequiresElasticSearchFactAttribute : FactAttribute
     {
+        private static readonly bool _canConnect;
+
+        static RequiresElasticSearchFactAttribute()
+        {
+            _canConnect = ElasticSearchTestNodes.Instance.CanConnect();
+        }
+
         public RequiresElasticSearchFactAttribute()
         {
-            if (ElasticSearchTestNodes.Instance.CanConnect() == false)
+            if (_canConnect == false)
                 Skip = "Test requires ElasticSearch instance";
         }
     }


### PR DESCRIPTION
### Issue link
https://issues.hibernatingrhinos.com/issue/RavenDB-13041

### Additional description

This fixes the problem that running a test from SlowTests took very long time. The issue was related to added `[RequiresElasticSearchFact]` which checks if we have ES instance available when running tests. The problem was that the ping timeout was very long and we checked it for every tests that has this attribute applied.

### Type of change

- Bug fix

### How risky is the change?

- Low 

### Backward compatibility

- Not relevant

### Is it platform specific issue?

- No

### Documentation update

- No documentation update is needed 

### Testing 

- It's related to tests infrastructure only 

### Is there any existing behavior change of other features due to this change?

- No

### UI work

- No UI work is needed
