### PR TITLE
RDoc-1995 - missing deletes during live import

### DIFF
--- a/src/Raven.Server/Smuggler/Migration/Importer.cs
+++ b/src/Raven.Server/Smuggler/Migration/Importer.cs
@@ -84,7 +84,7 @@ namespace Raven.Server.Smuggler.Migration
 
                     var importInfo = new ImportInfo
                     {
-                        LastEtag = smugglerResult.GetLastEtag() + 1,
+                        LastEtag = Math.Max(previousImportInfo?.LastEtag ?? 0, smugglerResult.GetLastEtag() + 1),
                         LastRaftIndex = Math.Max(previousImportInfo?.LastRaftIndex ?? 0, smugglerResult.GetLastRaftIndex() + 1),
                         ServerUrl = Options.ServerUrl,
                         DatabaseName = Options.DatabaseName

--- a/src/Raven.Server/Smuggler/Migration/Importer.cs
+++ b/src/Raven.Server/Smuggler/Migration/Importer.cs
@@ -132,8 +132,17 @@ namespace Raven.Server.Smuggler.Migration
 
             if (importInfo != null)
             {
-                databaseSmugglerOptionsServerSide.OperateOnTypes |= DatabaseItemType.Tombstones;
-                databaseSmugglerOptionsServerSide.OperateOnTypes |= DatabaseItemType.CompareExchangeTombstones;
+                if (Options.OperateOnTypes.HasFlag(DatabaseItemType.Documents))
+                {
+                    databaseSmugglerOptionsServerSide.OperateOnTypes |= DatabaseItemType.Tombstones;
+                    Options.OperateOnTypes |= DatabaseItemType.Tombstones;
+                }
+
+                if (Options.OperateOnTypes.HasFlag(DatabaseItemType.CompareExchange))
+                {
+                    databaseSmugglerOptionsServerSide.OperateOnTypes |= DatabaseItemType.CompareExchangeTombstones;
+                    Options.OperateOnTypes |= DatabaseItemType.CompareExchangeTombstones;
+                }
             }
 
             var json = JsonConvert.SerializeObject(databaseSmugglerOptionsServerSide);

--- a/test/SlowTests/Issues/RDoc-1995.cs
+++ b/test/SlowTests/Issues/RDoc-1995.cs
@@ -1,0 +1,106 @@
+﻿using System.Collections.Generic;
+using System.Threading.Tasks;
+using FastTests;
+using Raven.Client.Documents;
+using Raven.Client.Documents.Operations;
+using Raven.Client.Documents.Session;
+using Raven.Client.Documents.Smuggler;
+using Raven.Server.Smuggler.Migration;
+using SlowTests.Core.Utils.Entities;
+using Xunit;
+using Xunit.Abstractions;
+
+namespace SlowTests.Issues
+{
+    public class RDoc_1995 : RavenTestBase
+    {
+        public RDoc_1995(ITestOutputHelper output) : base(output)
+        {
+        }
+
+        [Fact]
+        public async Task Can_Live_Import_Tombstones()
+        {
+            using (var store1 = GetDocumentStore())
+            using (var store2 = GetDocumentStore())
+            {
+                const string id = "test";
+
+                using (var session1 = store1.OpenAsyncSession(new SessionOptions
+                {
+                    TransactionMode = TransactionMode.ClusterWide
+                }))
+                {
+                    await session1.StoreAsync(new User {Name = "Grisha"}, id);
+                    session1.Advanced.ClusterTransaction.CreateCompareExchangeValue(id, 3);
+                    await session1.SaveChangesAsync();
+                }
+
+                await Migrate(store1, store2);
+
+                using (var session2 = store2.OpenAsyncSession(new SessionOptions
+                {
+                    TransactionMode = TransactionMode.ClusterWide
+                }))
+                {
+                    var user = await session2.LoadAsync<User>(id);
+                    Assert.NotNull(user);
+
+                    var cmpValue = await session2.Advanced.ClusterTransaction.GetCompareExchangeValueAsync<int>(id);
+                    Assert.NotNull(cmpValue);
+                }
+
+                using (var session1 = store1.OpenAsyncSession(new SessionOptions
+                {
+                    TransactionMode = TransactionMode.ClusterWide
+                }))
+                {
+                    session1.Delete(id);
+                    var cmpValue = await session1.Advanced.ClusterTransaction.GetCompareExchangeValueAsync<int>(id);
+                    session1.Advanced.ClusterTransaction.DeleteCompareExchangeValue(id, cmpValue.Index);
+                    await session1.SaveChangesAsync();
+                }
+
+                await Migrate(store1, store2);
+
+                using (var session2 = store2.OpenAsyncSession(new SessionOptions
+                {
+                    TransactionMode = TransactionMode.ClusterWide
+                }))
+                {
+                    var user = await session2.LoadAsync<User>(id);
+                    Assert.Null(user);
+
+                    var cmpValue = await session2.Advanced.ClusterTransaction.GetCompareExchangeValueAsync<int>(id);
+                    Assert.Null(cmpValue);
+                }
+            }
+        }
+
+        private async Task Migrate(DocumentStore store1, DocumentStore store2)
+        {
+            var migrate = new Migrator(
+                new DatabasesMigrationConfiguration
+                {
+                    ServerUrl = Server.WebUrl,
+                    Databases = new List<DatabaseMigrationSettings>
+                    {
+                        new DatabaseMigrationSettings {DatabaseName = store1.Database, OperateOnTypes = DatabaseItemType.Documents,}
+                    }
+                }, Server.ServerStore);
+
+            await migrate.UpdateBuildInfoIfNeeded();
+
+            var operationId =
+                migrate.StartMigratingSingleDatabase(
+                    new DatabaseMigrationSettings {DatabaseName = store1.Database, OperateOnTypes = DatabaseItemType.Documents | DatabaseItemType.CompareExchange,},
+                    GetDocumentDatabaseInstanceFor(store2).Result);
+
+            WaitForValue(() =>
+            {
+                var operation = store2.Maintenance.Send(new GetOperationStateOperation(operationId));
+                return operation.Status == OperationStatus.Completed;
+            }, true);
+        }
+    }
+}

--- a/test/SlowTests/Issues/RDoc-1995.cs
+++ b/test/SlowTests/Issues/RDoc-1995.cs
@@ -3,6 +3,7 @@ using System.Threading.Tasks;
 using FastTests;
 using Raven.Client.Documents;
 using Raven.Client.Documents.Operations;
+using Raven.Client.Documents.Operations.CompareExchange;
 using Raven.Client.Documents.Session;
 using Raven.Client.Documents.Smuggler;
 using Raven.Server.Smuggler.Migration;
@@ -26,53 +27,128 @@ namespace SlowTests.Issues
             {
                 const string id = "test";
 
-                using (var session1 = store1.OpenAsyncSession(new SessionOptions
+                using (var session = store1.OpenAsyncSession(new SessionOptions
                 {
                     TransactionMode = TransactionMode.ClusterWide
                 }))
                 {
-                    await session1.StoreAsync(new User {Name = "Grisha"}, id);
-                    session1.Advanced.ClusterTransaction.CreateCompareExchangeValue(id, 3);
-                    await session1.SaveChangesAsync();
+                    await session.StoreAsync(new User {Name = "Grisha"}, id);
+                    session.Advanced.ClusterTransaction.CreateCompareExchangeValue(id, 3);
+                    await session.SaveChangesAsync();
                 }
 
                 await Migrate(store1, store2);
 
-                using (var session2 = store2.OpenAsyncSession(new SessionOptions
+                using (var session = store2.OpenAsyncSession(new SessionOptions
                 {
                     TransactionMode = TransactionMode.ClusterWide
                 }))
                 {
-                    var user = await session2.LoadAsync<User>(id);
+                    var user = await session.LoadAsync<User>(id);
                     Assert.NotNull(user);
 
-                    var cmpValue = await session2.Advanced.ClusterTransaction.GetCompareExchangeValueAsync<int>(id);
+                    var cmpValue = await session.Advanced.ClusterTransaction.GetCompareExchangeValueAsync<int>(id);
                     Assert.NotNull(cmpValue);
                 }
 
-                using (var session1 = store1.OpenAsyncSession(new SessionOptions
+                using (var session = store1.OpenAsyncSession(new SessionOptions
                 {
                     TransactionMode = TransactionMode.ClusterWide
                 }))
                 {
-                    session1.Delete(id);
-                    var cmpValue = await session1.Advanced.ClusterTransaction.GetCompareExchangeValueAsync<int>(id);
-                    session1.Advanced.ClusterTransaction.DeleteCompareExchangeValue(id, cmpValue.Index);
-                    await session1.SaveChangesAsync();
+                    session.Delete(id);
+                    var cmpValue = await session.Advanced.ClusterTransaction.GetCompareExchangeValueAsync<int>(id);
+                    session.Advanced.ClusterTransaction.DeleteCompareExchangeValue(id, cmpValue.Index);
+                    await session.SaveChangesAsync();
                 }
 
                 await Migrate(store1, store2);
 
-                using (var session2 = store2.OpenAsyncSession(new SessionOptions
+                using (var session = store2.OpenAsyncSession(new SessionOptions
                 {
                     TransactionMode = TransactionMode.ClusterWide
                 }))
                 {
-                    var user = await session2.LoadAsync<User>(id);
+                    var user = await session.LoadAsync<User>(id);
                     Assert.Null(user);
 
-                    var cmpValue = await session2.Advanced.ClusterTransaction.GetCompareExchangeValueAsync<int>(id);
+                    var cmpValue = await session.Advanced.ClusterTransaction.GetCompareExchangeValueAsync<int>(id);
                     Assert.Null(cmpValue);
+                }
+            }
+        }
+
+        [Fact]
+        public async Task Can_Live_Import_CompareExchange_Incremental()
+        {
+            using (var store1 = GetDocumentStore())
+            using (var store2 = GetDocumentStore())
+            {
+                const string id1 = "test1";
+
+                using (var session = store1.OpenAsyncSession(new SessionOptions
+                {
+                    TransactionMode = TransactionMode.ClusterWide
+                }))
+                {
+                    session.Advanced.ClusterTransaction.CreateCompareExchangeValue(id1, 3);
+                    await session.SaveChangesAsync();
+                }
+
+                await Migrate(store1, store2);
+
+                using (var session = store2.OpenAsyncSession(new SessionOptions
+                {
+                    TransactionMode = TransactionMode.ClusterWide
+                }))
+                {
+                    var cmpValue = await session.Advanced.ClusterTransaction.GetCompareExchangeValueAsync<int>(id1);
+                    Assert.NotNull(cmpValue);
+                }
+
+                using (var session = store2.OpenAsyncSession(new SessionOptions
+                {
+                    TransactionMode = TransactionMode.ClusterWide
+                }))
+                {
+                    var cmpValue = await session.Advanced.ClusterTransaction.GetCompareExchangeValueAsync<int>(id1);
+                    session.Advanced.ClusterTransaction.DeleteCompareExchangeValue(id1, cmpValue.Index);
+                    await session.SaveChangesAsync();
+                }
+
+                await Migrate(store1, store2);
+
+                using (var session = store2.OpenAsyncSession(new SessionOptions
+                {
+                    TransactionMode = TransactionMode.ClusterWide
+                }))
+                {
+                    var cmpValue = await session.Advanced.ClusterTransaction.GetCompareExchangeValueAsync<int>(id1);
+                    Assert.Null(cmpValue);
+                }
+
+                const string id2 = "test2";
+                using (var session = store1.OpenAsyncSession(new SessionOptions
+                {
+                    TransactionMode = TransactionMode.ClusterWide
+                }))
+                {
+                    session.Advanced.ClusterTransaction.CreateCompareExchangeValue(id2, 5);
+                    await session.SaveChangesAsync();
+                }
+
+                await Migrate(store1, store2);
+
+                using (var session = store2.OpenAsyncSession(new SessionOptions
+                {
+                    TransactionMode = TransactionMode.ClusterWide
+                }))
+                {
+                    var cmpValue1 = await session.Advanced.ClusterTransaction.GetCompareExchangeValueAsync<int>(id1);
+                    Assert.Null(cmpValue1);
+
+                    var cmpValue2 = await session.Advanced.ClusterTransaction.GetCompareExchangeValueAsync<int>(id2);
+                    Assert.NotNull(cmpValue2);
                 }
             }
         }


### PR DESCRIPTION
### Issue link

https://issues.hibernatingrhinos.com/issue/RDoc-1995

### Additional description

- Fix live import that misses deletes.
- If we don't have documents to import, update the etag correctly

### Type of change

- Bug fix

### How risky is the change?

- Low 

### Testing 

- Tests have been added that prove the fix is effective or that the feature works
