### PR TITLE
RavenDB-17376 Corax - compound order by support.

### DIFF
--- a/src/Corax/IndexSearcher.cs
+++ b/src/Corax/IndexSearcher.cs
@@ -175,29 +175,31 @@ namespace Corax
             return MultiTermMatch.Create(new MultiTermMatch<StartWithTermProvider>(_transaction.Allocator, new StartWithTermProvider(this, _transaction.Allocator, terms, field, 0, startWith)));
         }
 
-        public SortingMatch OrderByAscending<TInner>(in TInner set, int fieldId, MatchCompareFieldType entryFieldType = MatchCompareFieldType.Sequence, int take = -1)
+        public SortingMatch OrderByAscending<TInner>(in TInner set, int fieldId, MatchCompareFieldType entryFieldType = MatchCompareFieldType.Sequence, int take = -1, IMatchComparer innerComparer = null)
             where TInner : IQueryMatch
         {
-            return OrderBy<TInner, AscendingMatchComparer>(in set, fieldId, entryFieldType, take);
+            return OrderBy<TInner, AscendingMatchComparer>(in set, fieldId, entryFieldType, take, innerComparer);
         }
 
-        public SortingMatch OrderByDescending<TInner>(in TInner set, int fieldId, MatchCompareFieldType entryFieldType = MatchCompareFieldType.Sequence, int take = -1)
+        public SortingMatch OrderByDescending<TInner>(in TInner set, int fieldId, MatchCompareFieldType entryFieldType = MatchCompareFieldType.Sequence, int take = -1, IMatchComparer innerComparer = null)
             where TInner : IQueryMatch
         {
-            return OrderBy<TInner, DescendingMatchComparer>(in set, fieldId, entryFieldType, take);
+            return OrderBy<TInner, DescendingMatchComparer>(in set, fieldId, entryFieldType, take, innerComparer);
         }
 
-        public SortingMatch OrderBy<TInner, TComparer>(in TInner set, int fieldId, MatchCompareFieldType entryFieldType = MatchCompareFieldType.Sequence, int take = -1)
+        
+        
+        public SortingMatch OrderBy<TInner, TComparer>(in TInner set, int fieldId, MatchCompareFieldType entryFieldType = MatchCompareFieldType.Sequence, int take = -1, IMatchComparer innerComparer = null)
             where TInner : IQueryMatch
             where TComparer : IMatchComparer
         {
             if (typeof(TComparer) == typeof(AscendingMatchComparer))
             {
-                return Create(new SortingMatch<TInner, AscendingMatchComparer>(this, set, new AscendingMatchComparer(this, fieldId, entryFieldType), take));
+                return Create(new SortingMatch<TInner, AscendingMatchComparer>(this, set, new AscendingMatchComparer(this, fieldId, entryFieldType, innerComparer), take));
             }
             else if (typeof(TComparer) == typeof(DescendingMatchComparer))
             {
-                return Create(new SortingMatch<TInner, DescendingMatchComparer>(this, set, new DescendingMatchComparer(this, fieldId, entryFieldType), take));
+                return Create(new SortingMatch<TInner, DescendingMatchComparer>(this, set, new DescendingMatchComparer(this, fieldId, entryFieldType, innerComparer), take));
             }
             else if (typeof(TComparer) == typeof(CustomMatchComparer))
             {
@@ -207,6 +209,25 @@ namespace Corax
             throw new ArgumentException($"The comparer of type {typeof(TComparer).Name} is not supported. Isn't {nameof(OrderByCustomOrder)} the right call for it?");
         }
 
+        public IMatchComparer CreateInnerComparer<TComparer>(int fieldId, MatchCompareFieldType entryFieldType = MatchCompareFieldType.Sequence, IMatchComparer innerComparer = null)
+        {
+            if (typeof(TComparer) == typeof(AscendingMatchComparer))
+            {
+                return new AscendingMatchComparer(this, fieldId, entryFieldType, innerComparer);
+            }
+            if (typeof(TComparer) == typeof(DescendingMatchComparer))
+            {
+                return new DescendingMatchComparer(this, fieldId, entryFieldType, innerComparer);
+            }
+            
+            else if (typeof(TComparer) == typeof(CustomMatchComparer))
+            {
+                throw new ArgumentException($"Custom comparers can only be created through the {nameof(OrderByCustomOrder)}");
+            }
+
+            throw new ArgumentException($"The comparer of type {typeof(TComparer).Name} is not supported. Isn't {nameof(OrderByCustomOrder)} the right call for it?");
+        }
+        
         public SortingMatch OrderBy<TInner, TComparer>(in TInner set, in TComparer comparer, int take = -1)
             where TInner : IQueryMatch
             where TComparer : struct, IMatchComparer

--- a/src/Corax/Queries/IMatchComparer.cs
+++ b/src/Corax/Queries/IMatchComparer.cs
@@ -18,8 +18,8 @@ namespace Corax.Queries
 
         int CompareById(long idx, long idy);
 
-        int CompareSequence(ReadOnlySpan<byte> sx, ReadOnlySpan<byte> sy);
-        int CompareNumerical<T>(T sx, T sy) where T : unmanaged;
+        int CompareSequence(ReadOnlySpan<byte> sx, ReadOnlySpan<byte> sy, long idx, long idy);
+        int CompareNumerical<T>(T sx, T sy, long idx, long idy) where T : unmanaged;
     }
 
     internal static class BasicComparers

--- a/src/Corax/Queries/SortingMatch.cs
+++ b/src/Corax/Queries/SortingMatch.cs
@@ -63,15 +63,17 @@ namespace Corax.Queries
                     {
                         return _comparer.CompareSequence(
                             new ReadOnlySpan<byte>(((SequenceItem)(object)ix.Value).Ptr, ((SequenceItem)(object)ix.Value).Size),
-                            new ReadOnlySpan<byte>(((SequenceItem)(object)iy.Value).Ptr, ((SequenceItem)(object)iy.Value).Size));
+                            new ReadOnlySpan<byte>(((SequenceItem)(object)iy.Value).Ptr, ((SequenceItem)(object)iy.Value).Size), 
+                            ix.Key, 
+                            iy.Key);
                     }
                     else if (typeof(W) == typeof(NumericalItem<long>))
                     {
-                        return _comparer.CompareNumerical(((NumericalItem<long>)(object)ix.Value).Value, ((NumericalItem<long>)(object)iy.Value).Value);
+                        return _comparer.CompareNumerical(((NumericalItem<long>)(object)ix.Value).Value, ((NumericalItem<long>)(object)iy.Value).Value, ix.Key, iy.Key);
                     }
                     else if (typeof(W) == typeof(NumericalItem<double>))
                     {
-                        return _comparer.CompareNumerical(((NumericalItem<double>)(object)ix.Value).Value, ((NumericalItem<double>)(object)iy.Value).Value);
+                        return _comparer.CompareNumerical(((NumericalItem<double>)(object)ix.Value).Value, ((NumericalItem<double>)(object)iy.Value).Value, ix.Key,iy.Key);
                     }
                 }
                 else if (ix.Key > 0)

--- a/src/Raven.Server/Documents/Indexes/Persistence/Corax/CoraxIndexReadOperation.cs
+++ b/src/Raven.Server/Documents/Indexes/Persistence/Corax/CoraxIndexReadOperation.cs
@@ -61,6 +61,8 @@ namespace Raven.Server.Documents.Indexes.Persistence.Corax
                 int read = 0;
                 int docsToLoad = pageSize;
                 Skip(ref result, position, ref read, skippedResults, out var readCounter, ref ids, token);
+                /*if (position != 0)
+*/
                 
                 while (read != 0)
                 {

--- a/src/Raven.Server/Documents/Indexes/Persistence/Corax/CoraxIndexReadOperation.cs
+++ b/src/Raven.Server/Documents/Indexes/Persistence/Corax/CoraxIndexReadOperation.cs
@@ -2,13 +2,10 @@
 using System.Buffers;
 using System.Collections.Generic;
 using System.IO;
-using System.Linq;
-using System.Runtime.CompilerServices;
 using System.Threading;
 using Corax;
 using Corax.Queries;
 using Raven.Client;
-using Raven.Client.Documents.Linq;
 using Raven.Server.Documents.Indexes.Static.Spatial;
 using Raven.Server.Documents.Queries;
 using Raven.Server.Documents.Queries.Results;
@@ -61,9 +58,7 @@ namespace Raven.Server.Documents.Indexes.Persistence.Corax
                 int read = 0;
                 int docsToLoad = pageSize;
                 Skip(ref result, position, ref read, skippedResults, out var readCounter, ref ids, token);
-                /*if (position != 0)
-*/
-                
+               
                 while (read != 0)
                 {
                     for (int i = 0; i < read && docsToLoad != 0; --docsToLoad, ++i)


### PR DESCRIPTION
### Issue link

https://issues.hibernatingrhinos.com/issue/RavenDB-17376

### Additional description

Support for compound order by.

How does it work?
for example:
`order by FieldA, FieldB`
if FieldA items are equal we are going to check FieldB for those docs etc.

Implementation:
Stack of comparators.

### Type of change

- New feature


### How risky is the change?

- Not relevant

### Backward compatibility


- Not relevant

### Is it platform specific issue?


- No

### Documentation update


### Testing 

- Tests have been added that prove the fix is effective or that the feature works

### Is there any existing behavior change of other features due to this change?


- No

### UI work

- No UI work is needed
