### PR TITLE
RavenDB-17346 : Verify we fall back to a not compressed communication if license doesn't support it

### DIFF
--- a/src/Raven.Client/Documents/Subscriptions/SubscriptionWorker.cs
+++ b/src/Raven.Client/Documents/Subscriptions/SubscriptionWorker.cs
@@ -338,7 +338,7 @@ namespace Raven.Client.Documents.Subscriptions
                         return new TcpConnectionHeaderMessage.NegotiationResponse
                         {
                             Version = reply.Version, 
-                            DataCompression = reply.DataCompression
+                            LicensedFeatures = reply.LicensedFeatures
                         };
 
                     case TcpConnectionStatus.AuthorizationFailed:
@@ -350,7 +350,7 @@ namespace Raven.Client.Documents.Subscriptions
                             return new TcpConnectionHeaderMessage.NegotiationResponse
                             {
                                 Version = reply.Version,
-                                DataCompression = reply.DataCompression
+                                LicensedFeatures = reply.LicensedFeatures
                             };
                         }
                         //Kindly request the server to drop the connection
@@ -364,7 +364,7 @@ namespace Raven.Client.Documents.Subscriptions
                 return new TcpConnectionHeaderMessage.NegotiationResponse
                 {
                     Version = reply.Version,
-                    DataCompression = reply.DataCompression
+                    LicensedFeatures = reply.LicensedFeatures
                 };
             }
         }

--- a/src/Raven.Client/Documents/Subscriptions/SubscriptionWorker.cs
+++ b/src/Raven.Client/Documents/Subscriptions/SubscriptionWorker.cs
@@ -285,7 +285,10 @@ namespace Raven.Client.Documents.Subscriptions
                 DestinationNodeTag = CurrentNodeTag,
                 DestinationUrl = chosenUrl,
                 DestinationServerId = tcpInfo.ServerId,
-                CompressionSupport = compressionSupport
+                LicensedFeatures = new LicensedFeatures
+                {
+                    DataCompression = compressionSupport
+                }
             };
 
             return await TcpNegotiation.NegotiateProtocolVersionAsync(context, stream, parameters).ConfigureAwait(false);

--- a/src/Raven.Client/ServerWide/Tcp/LicensedFeatures.cs
+++ b/src/Raven.Client/ServerWide/Tcp/LicensedFeatures.cs
@@ -1,0 +1,17 @@
+﻿using Sparrow.Json.Parsing;
+
+namespace Raven.Client.ServerWide.Tcp
+{
+    public class LicensedFeatures
+    {
+        public bool DataCompression;
+
+        public DynamicJsonValue ToJson()
+        {
+            return new DynamicJsonValue
+            {
+                [nameof(DataCompression)] = DataCompression
+            };
+        }
+    }
+}

--- a/src/Raven.Client/ServerWide/Tcp/TcpConnectionHeader.cs
+++ b/src/Raven.Client/ServerWide/Tcp/TcpConnectionHeader.cs
@@ -465,6 +465,14 @@ namespace Raven.Client.ServerWide.Tcp
             Supported
         }
 
+        public class NegotiationResponse
+        {
+            public int Version;
+
+            public bool DataCompression;
+        }
+
+
         public static SupportedStatus OperationVersionSupported(OperationTypes operationType, int version, out int current)
         {
             current = -1;

--- a/src/Raven.Client/ServerWide/Tcp/TcpConnectionHeader.cs
+++ b/src/Raven.Client/ServerWide/Tcp/TcpConnectionHeader.cs
@@ -176,6 +176,20 @@ namespace Raven.Client.ServerWide.Tcp
                 ProtocolVersion = version;
             }
 
+            internal SupportedFeatures(SupportedFeatures source)
+            {
+                ProtocolVersion = source.ProtocolVersion;
+                Ping = source.Ping;
+                None = source.None;
+                Drop = source.Drop;
+                Subscription = source.Subscription;
+                Cluster = source.Cluster;
+                Heartbeats = source.Heartbeats;
+                TestConnection = source.TestConnection;
+                Replication = source.Replication;
+                DataCompression = source.DataCompression;
+            }
+
             public PingFeatures Ping { get; set; }
             public NoneFeatures None { get; set; }
             public DropFeatures Drop { get; set; }
@@ -469,9 +483,13 @@ namespace Raven.Client.ServerWide.Tcp
         {
             public int Version;
 
-            public bool DataCompression;
+            public LicensedFeatures LicensedFeatures;
         }
 
+        public class LicensedFeatures
+        {
+            public bool DataCompression;
+        }
 
         public static SupportedStatus OperationVersionSupported(OperationTypes operationType, int version, out int current)
         {

--- a/src/Raven.Client/ServerWide/Tcp/TcpConnectionHeader.cs
+++ b/src/Raven.Client/ServerWide/Tcp/TcpConnectionHeader.cs
@@ -57,7 +57,7 @@ namespace Raven.Client.ServerWide.Tcp
 
         public AuthorizationInfo AuthorizeInfo { get; set; }
 
-        public bool CompressionSupport { get; set; }
+        public LicensedFeatures LicensedFeatures { get; set; }
 
         public DetailedReplicationHubAccess ReplicationHubAccess;
 
@@ -484,11 +484,6 @@ namespace Raven.Client.ServerWide.Tcp
             public int Version;
 
             public LicensedFeatures LicensedFeatures;
-        }
-
-        public class LicensedFeatures
-        {
-            public bool DataCompression;
         }
 
         public static SupportedStatus OperationVersionSupported(OperationTypes operationType, int version, out int current)

--- a/src/Raven.Client/ServerWide/Tcp/TcpConnectionHeaderResponse.cs
+++ b/src/Raven.Client/ServerWide/Tcp/TcpConnectionHeaderResponse.cs
@@ -5,7 +5,7 @@
         public TcpConnectionStatus Status { get; set; }
         public string Message { get; set; }
         public int Version { get; set; }
-        public bool DataCompression { get; set; }
+        public TcpConnectionHeaderMessage.LicensedFeatures LicensedFeatures { get; set; }
     }
 
     public enum TcpConnectionStatus

--- a/src/Raven.Client/ServerWide/Tcp/TcpConnectionHeaderResponse.cs
+++ b/src/Raven.Client/ServerWide/Tcp/TcpConnectionHeaderResponse.cs
@@ -5,6 +5,7 @@
         public TcpConnectionStatus Status { get; set; }
         public string Message { get; set; }
         public int Version { get; set; }
+        public bool DataCompression { get; set; }
     }
 
     public enum TcpConnectionStatus

--- a/src/Raven.Client/ServerWide/Tcp/TcpConnectionHeaderResponse.cs
+++ b/src/Raven.Client/ServerWide/Tcp/TcpConnectionHeaderResponse.cs
@@ -5,7 +5,7 @@
         public TcpConnectionStatus Status { get; set; }
         public string Message { get; set; }
         public int Version { get; set; }
-        public TcpConnectionHeaderMessage.LicensedFeatures LicensedFeatures { get; set; }
+        public LicensedFeatures LicensedFeatures { get; set; }
     }
 
     public enum TcpConnectionStatus

--- a/src/Raven.Client/ServerWide/Tcp/TcpNegotiation.cs
+++ b/src/Raven.Client/ServerWide/Tcp/TcpNegotiation.cs
@@ -41,7 +41,7 @@ namespace Raven.Client.ServerWide.Tcp
                     await SendTcpVersionInfoAsync(context, writer, parameters, current).ConfigureAwait(false);
                     var response = await parameters.ReadResponseAndGetVersionCallbackAsync(context, writer, stream, parameters.DestinationUrl).ConfigureAwait(false);
                     var version = response.Version;
-                    dataCompression = response.DataCompression;
+                    dataCompression = response.LicensedFeatures?.DataCompression ?? false;
 
                     if (Log.IsInfoEnabled)
                     {
@@ -73,9 +73,11 @@ namespace Raven.Client.ServerWide.Tcp
                 }
 
                 var supportedFeatures = TcpConnectionHeaderMessage.GetSupportedFeaturesFor(parameters.Operation, current);
-                supportedFeatures.DataCompression = dataCompression;
-                
-                return supportedFeatures;
+
+                return new TcpConnectionHeaderMessage.SupportedFeatures(supportedFeatures)
+                {
+                    DataCompression = dataCompression
+                };
             }
         }
 

--- a/src/Raven.Client/ServerWide/Tcp/TcpNegotiation.cs
+++ b/src/Raven.Client/ServerWide/Tcp/TcpNegotiation.cs
@@ -96,7 +96,7 @@ namespace Raven.Client.ServerWide.Tcp
                 [nameof(TcpConnectionHeaderMessage.OperationVersion)] = currentVersion,
                 [nameof(TcpConnectionHeaderMessage.AuthorizeInfo)] = parameters.AuthorizeInfo?.ToJson(),
                 [nameof(TcpConnectionHeaderMessage.ServerId)] = parameters.DestinationServerId,
-                [nameof(TcpConnectionHeaderMessage.CompressionSupport)] = parameters.CompressionSupport.ToString()
+                [nameof(TcpConnectionHeaderMessage.LicensedFeatures)] = parameters.LicensedFeatures?.ToJson()
             });
 
             await writer.FlushAsync().ConfigureAwait(false);
@@ -131,6 +131,6 @@ namespace Raven.Client.ServerWide.Tcp
         public string DestinationUrl { get; set; }
         public string DestinationServerId { get; set; }
         public CancellationToken CancellationToken { get; set; }
-        public bool CompressionSupport { get; set; }
+        public LicensedFeatures LicensedFeatures { get; set; }
     }
 }

--- a/src/Raven.Server/Documents/Replication/OutgoingReplicationHandler.cs
+++ b/src/Raven.Server/Documents/Replication/OutgoingReplicationHandler.cs
@@ -769,7 +769,7 @@ namespace Raven.Server.Documents.Replication
                         return new TcpConnectionHeaderMessage.NegotiationResponse
                         {
                             Version = headerResponse.Version,
-                            DataCompression = headerResponse.DataCompression
+                            LicensedFeatures = headerResponse.LicensedFeatures
                         };
 
                     case TcpConnectionStatus.AuthorizationFailed:
@@ -779,8 +779,8 @@ namespace Raven.Server.Documents.Replication
                         {
                             return new TcpConnectionHeaderMessage.NegotiationResponse
                             {
-                                Version = headerResponse.Version, 
-                                DataCompression = headerResponse.DataCompression
+                                Version = headerResponse.Version,
+                                LicensedFeatures = headerResponse.LicensedFeatures
                             };
                         }
 

--- a/src/Raven.Server/Documents/Replication/OutgoingReplicationHandler.cs
+++ b/src/Raven.Server/Documents/Replication/OutgoingReplicationHandler.cs
@@ -723,7 +723,10 @@ namespace Raven.Server.Documents.Replication
                     Version = TcpConnectionHeaderMessage.ReplicationTcpVersion,
                     AuthorizeInfo = authorizationInfo,
                     DestinationServerId = info?.ServerId,
-                    CompressionSupport = _parent._server.LicenseManager.LicenseStatus.HasTcpDataCompression
+                    LicensedFeatures = new LicensedFeatures
+                    {
+                        DataCompression = _parent._server.LicenseManager.LicenseStatus.HasTcpDataCompression
+                    }
                 };
 
                 _interruptibleRead = new InterruptibleRead(_database.DocumentsStorage.ContextPool, stream);

--- a/src/Raven.Server/Documents/Replication/OutgoingReplicationHandler.cs
+++ b/src/Raven.Server/Documents/Replication/OutgoingReplicationHandler.cs
@@ -248,9 +248,8 @@ namespace Raven.Server.Documents.Replication
                     {
                         _stream = new ReadWriteCompressedStream(_stream, _buffer);
                         _tcpConnectionOptions.Stream = _stream;
+                        _interruptibleRead = new InterruptibleRead(_database.DocumentsStorage.ContextPool, _stream);
                     }
-
-                    _interruptibleRead = new InterruptibleRead(_database.DocumentsStorage.ContextPool, _stream);
 
                     if (socketResult.SupportedFeatures.Replication.PullReplication)
                     {
@@ -731,15 +730,15 @@ namespace Raven.Server.Documents.Replication
 
                 try
                 {
-                //This will either throw or return acceptable protocol version.
-                SupportedFeatures = TcpNegotiation.Sync.NegotiateProtocolVersion(documentsContext, stream, parameters);
-                return Task.FromResult(SupportedFeatures);
-            }
+                    //This will either throw or return acceptable protocol version.
+                    SupportedFeatures = TcpNegotiation.Sync.NegotiateProtocolVersion(documentsContext, stream, parameters);
+                    return Task.FromResult(SupportedFeatures);
+                }
                 catch
                 {
                     _interruptibleRead.Dispose();
                     throw;
-        }
+                }
             }
         }
 

--- a/src/Raven.Server/RavenServer.cs
+++ b/src/Raven.Server/RavenServer.cs
@@ -2224,7 +2224,10 @@ namespace Raven.Server
             {
                 [nameof(TcpConnectionHeaderResponse.Status)] = status.ToString(),
                 [nameof(TcpConnectionHeaderResponse.Version)] = version,
-                [nameof(TcpConnectionHeaderResponse.DataCompression)] = dataCompression
+                [nameof(TcpConnectionHeaderResponse.LicensedFeatures)] = new DynamicJsonValue
+                {
+                    [nameof(TcpConnectionHeaderResponse.LicensedFeatures.DataCompression)] = dataCompression
+                }
             };
 
             if (error != null)

--- a/src/Raven.Server/ServerWide/ClusterStateMachine.cs
+++ b/src/Raven.Server/ServerWide/ClusterStateMachine.cs
@@ -3421,7 +3421,8 @@ namespace Raven.Server.ServerWide
                     case TcpConnectionStatus.Ok:
                         return new TcpConnectionHeaderMessage.NegotiationResponse
                         {
-                            Version = reply.Version
+                            Version = reply.Version,
+                            LicensedFeatures = reply.LicensedFeatures
                         };
                     case TcpConnectionStatus.AuthorizationFailed:
                         throw new AuthorizationException($"Unable to access  {url} because {reply.Message}");
@@ -3430,7 +3431,8 @@ namespace Raven.Server.ServerWide
                         {
                             return new TcpConnectionHeaderMessage.NegotiationResponse
                             {
-                                Version = reply.Version
+                                Version = reply.Version,
+                                LicensedFeatures = reply.LicensedFeatures
                             };
                         }
                         //Kindly request the server to drop the connection

--- a/src/Raven.Server/ServerWide/ClusterStateMachine.cs
+++ b/src/Raven.Server/ServerWide/ClusterStateMachine.cs
@@ -3446,13 +3446,10 @@ namespace Raven.Server.ServerWide
                         throw new InvalidOperationException($"Unable to access  {url} because {reply.Message}");
                     case TcpConnectionStatus.InvalidNetworkTopology:
                         throw new InvalidNetworkTopologyException($"Unable to access {url} because {reply.Message}");
+                    default:
+                        throw new InvalidOperationException($"Unable to read header response, invalid TcpConnectionStatus : {reply.Status}");
                 }
             }
-
-            return new TcpConnectionHeaderMessage.NegotiationResponse
-            {
-                Version = TcpConnectionHeaderMessage.ClusterTcpVersion
-            };
         }
 
         public override async Task<RachisConnection> ConnectToPeer(string url, string tag, X509Certificate2 certificate, CancellationToken token)

--- a/src/Raven.Server/ServerWide/Maintenance/ClusterMaintenanceSupervisor.cs
+++ b/src/Raven.Server/ServerWide/Maintenance/ClusterMaintenanceSupervisor.cs
@@ -451,7 +451,8 @@ namespace Raven.Server.ServerWide.Maintenance
                         case TcpConnectionStatus.Ok:
                             return new TcpConnectionHeaderMessage.NegotiationResponse
                             {
-                                Version = headerResponse.Version
+                                Version = headerResponse.Version,
+                                LicensedFeatures = headerResponse.LicensedFeatures
                             };
                         case TcpConnectionStatus.AuthorizationFailed:
                             throw new AuthorizationException(
@@ -461,7 +462,8 @@ namespace Raven.Server.ServerWide.Maintenance
                             {
                                 return new TcpConnectionHeaderMessage.NegotiationResponse
                                 {
-                                    Version = headerResponse.Version
+                                    Version = headerResponse.Version,
+                                    LicensedFeatures = headerResponse.LicensedFeatures
                                 };
                             }
                             //Kindly request the server to drop the connection

--- a/src/Raven.Server/ServerWide/Tcp/Sync/TcpNegotiateParameters.cs
+++ b/src/Raven.Server/ServerWide/Tcp/Sync/TcpNegotiateParameters.cs
@@ -3,7 +3,6 @@ using System.IO;
 using Raven.Client.ServerWide.Tcp;
 using Sparrow.Json;
 using Sparrow.Json.Sync;
-using Sparrow.Server.Json.Sync;
 
 namespace Raven.Server.ServerWide.Tcp.Sync
 {
@@ -17,6 +16,6 @@ namespace Raven.Server.ServerWide.Tcp.Sync
         /// If the respond is 'None' the function should throw.
         /// If the respond is 'TcpMismatch' the function should return the read version.
         /// </summary>
-        public Func<JsonOperationContext, BlittableJsonTextWriter, Stream, string, int> ReadResponseAndGetVersionCallback { get; set; }
+        public Func<JsonOperationContext, BlittableJsonTextWriter, Stream, string, TcpConnectionHeaderMessage.NegotiationResponse> ReadResponseAndGetVersionCallback { get; set; }
     }
 }

--- a/src/Raven.Server/ServerWide/Tcp/Sync/TcpNegotiationSyncExtensions.cs
+++ b/src/Raven.Server/ServerWide/Tcp/Sync/TcpNegotiationSyncExtensions.cs
@@ -31,7 +31,7 @@ namespace Raven.Server.ServerWide.Tcp.Sync
                     SendTcpVersionInfo(context, writer, parameters, current);
                     var response = parameters.ReadResponseAndGetVersionCallback(context, writer, stream, parameters.DestinationUrl);
                     var version = response.Version;
-                    dataCompression = response.DataCompression;
+                    dataCompression = response.LicensedFeatures?.DataCompression ?? false;
 
                     if (Log.IsInfoEnabled)
                     {
@@ -63,9 +63,11 @@ namespace Raven.Server.ServerWide.Tcp.Sync
                 }
 
                 var supportedFeatures = TcpConnectionHeaderMessage.GetSupportedFeaturesFor(parameters.Operation, current);
-                supportedFeatures.DataCompression = dataCompression;
 
-                return supportedFeatures;
+                return new TcpConnectionHeaderMessage.SupportedFeatures(supportedFeatures)
+                {
+                    DataCompression = dataCompression
+                };
             }
         }
 

--- a/src/Raven.Server/ServerWide/Tcp/Sync/TcpNegotiationSyncExtensions.cs
+++ b/src/Raven.Server/ServerWide/Tcp/Sync/TcpNegotiationSyncExtensions.cs
@@ -22,7 +22,7 @@ namespace Raven.Server.ServerWide.Tcp.Sync
             using (var writer = new BlittableJsonTextWriter(context, stream))
             {
                 var current = parameters.Version;
-                bool dataCompression = false;
+                bool dataCompression;
                 while (true)
                 {
                     if (parameters.CancellationToken.IsCancellationRequested)
@@ -64,6 +64,7 @@ namespace Raven.Server.ServerWide.Tcp.Sync
 
                 var supportedFeatures = TcpConnectionHeaderMessage.GetSupportedFeaturesFor(parameters.Operation, current);
                 supportedFeatures.DataCompression = dataCompression;
+
                 return supportedFeatures;
             }
         }

--- a/src/Raven.Server/ServerWide/Tcp/Sync/TcpNegotiationSyncExtensions.cs
+++ b/src/Raven.Server/ServerWide/Tcp/Sync/TcpNegotiationSyncExtensions.cs
@@ -86,7 +86,7 @@ namespace Raven.Server.ServerWide.Tcp.Sync
                 [nameof(TcpConnectionHeaderMessage.OperationVersion)] = currentVersion,
                 [nameof(TcpConnectionHeaderMessage.AuthorizeInfo)] = parameters.AuthorizeInfo?.ToJson(),
                 [nameof(TcpConnectionHeaderMessage.ServerId)] = parameters.DestinationServerId,
-                [nameof(TcpConnectionHeaderMessage.CompressionSupport)] = parameters.CompressionSupport
+                [nameof(TcpConnectionHeaderMessage.LicensedFeatures)] = parameters.LicensedFeatures?.ToJson()
 
             });
             writer.Flush();

--- a/test/InterversionTests/ReplicationTests.cs
+++ b/test/InterversionTests/ReplicationTests.cs
@@ -52,12 +52,13 @@ namespace InterversionTests
             Assert.True(replicationLoader.OutgoingFailureInfo.Any(ofi => ofi.Value.Errors.Select(x => x.Message).Any(x => x.Contains("TimeSeries"))));
         }
 
-        [Fact]
-        public async Task CanReplicateToOldServerWithLowerReplicationProtocolVersion()
+        [Theory]
+        [InlineData("4.2.117")]
+        [InlineData("5.2.3")]
+        public async Task CanReplicateToOldServerWithLowerReplicationProtocolVersion(string version)
         {
             // https://issues.hibernatingrhinos.com/issue/RavenDB-17346
 
-            const string version = "4.2.117";
             using var oldStore = await GetDocumentStoreAsync(version);
             using var store = GetDocumentStore();
             {

--- a/test/Tests.Infrastructure/InterversionTest/ConfigurableRavenServerLocator.cs
+++ b/test/Tests.Infrastructure/InterversionTest/ConfigurableRavenServerLocator.cs
@@ -18,8 +18,10 @@ namespace Tests.Infrastructure.InterversionTest
             _serverDirPath = serverDirPath;
             _dataDir = dataDir;
             _serverUrl = url;
-
-            _commandsArg = "--Http.UseLibuv=true";
+            if (version.StartsWith("4."))
+            {
+                _commandsArg = "--Http.UseLibuv=true";
+            }
             if (version.StartsWith("4.0") == false)
             {
                 _commandsArg += " --Features.Availability=Experimental";


### PR DESCRIPTION
### Issue link

https://issues.hibernatingrhinos.com/issue/RavenDB-17346

### Additional description

When negotiating on protocol version to decide on `SupportedFeatures`, both sides also need to decide if to use `TcpDataCompression`, based on their license
If only one of the sides has the `TcpDataCompression` feature and the other side doesn't, we drop to not-compressed communication

### Type of change

- Bug fix

### How risky is the change?

- Moderate 

### Testing 

- It has been verified by manual testing
