### PR TITLE
RavenDB-17385  Elasticsearch ETL: allow to add more than one collecti…

### DIFF
--- a/src/Raven.Studio/typescript/models/database/tasks/ongoingTaskElasticSearchEtlTransformationModel.ts
+++ b/src/Raven.Studio/typescript/models/database/tasks/ongoingTaskElasticSearchEtlTransformationModel.ts
@@ -5,11 +5,17 @@ import jsonUtil = require("common/jsonUtil");
 class ongoingTaskElasticSearchTransformationModel {
     name = ko.observable<string>();
     script = ko.observable<string>();
-    collection = ko.observable<string>();
 
-    collectionColorIndex: KnockoutComputed<number>;
+    static readonly applyToAllCollectionsText = "Apply to All Collections";
+    
     isNew = ko.observable<boolean>(true);
     resetScript = ko.observable<boolean>(false);
+
+    inputCollection = ko.observable<string>();
+    transformScriptCollections = ko.observableArray<string>([]);
+    
+    canAddCollection: KnockoutComputed<boolean>;
+    applyScriptForAllCollections = ko.observable<boolean>(false);
 
     validationGroup: KnockoutValidationGroup;
 
@@ -22,14 +28,22 @@ class ongoingTaskElasticSearchTransformationModel {
         this.initValidation();
     }
 
-    initObservables() {
-        this.collectionColorIndex = ko.pureComputed(() => collectionsTracker.default.getCollectionColorIndex(this.collection()));
+    static isApplyToAll(colectionName: string){
+        return colectionName === ongoingTaskElasticSearchTransformationModel.applyToAllCollectionsText;
+    }
 
+    initObservables(): void {
+        this.canAddCollection = ko.pureComputed(() => {
+            const collectionToAdd = this.inputCollection();
+            return collectionToAdd && !this.transformScriptCollections().find(x => x === collectionToAdd);
+        });
+        
         this.dirtyFlag = new ko.DirtyFlag([
             this.name,
             this.script,
-            this.collection,
-            this.resetScript
+            this.resetScript,
+            this.applyScriptForAllCollections,
+            this.transformScriptCollections
         ], false, jsonUtil.newLineNormalizingHashFunction);
     }
 
@@ -46,15 +60,15 @@ class ongoingTaskElasticSearchTransformationModel {
 
     toDto(): Raven.Client.Documents.Operations.ETL.Transformation {
         return {
-            ApplyToAllDocuments: false,
-            Collections: [this.collection()],
+            ApplyToAllDocuments: this.applyScriptForAllCollections(),
+            Collections: this.applyScriptForAllCollections() ? null : this.transformScriptCollections(),
             Disabled: false,
             Name: this.name(),
             Script: this.script()
         }
     }
 
-    private initValidation() {
+    private initValidation(): void {
         this.name.extend({
             required: true
         })
@@ -64,30 +78,67 @@ class ongoingTaskElasticSearchTransformationModel {
             aceValidation: true
         });
 
-        this.collection.extend({
-            required: true
+        this.transformScriptCollections.extend({
+            validation: [
+                {
+                    validator: () => this.applyScriptForAllCollections() || this.transformScriptCollections().length > 0,
+                    message: "At least one collection is required"
+                }
+            ]
         });
 
         this.validationGroup = ko.validatedObservable({
             name: this.name,
             script: this.script,
-            collection: this.collection
+            transformScriptCollections: this.transformScriptCollections
         });
     }
 
-    update(dto: Raven.Client.Documents.Operations.ETL.Transformation, isNew: boolean, resetScript: boolean) {
+    addCollection(): void {
+        this.addWithBlink(this.inputCollection());
+    }
+
+    removeCollection(collection: string): void {
+        this.transformScriptCollections.remove(collection);
+        this.applyScriptForAllCollections(false);
+    }
+
+    addWithBlink(collectionName: string): void {
+        if (ongoingTaskElasticSearchTransformationModel.isApplyToAll(collectionName)) {
+            this.applyScriptForAllCollections(true);
+            this.transformScriptCollections([ongoingTaskElasticSearchTransformationModel.applyToAllCollectionsText]);
+        } else {
+            this.applyScriptForAllCollections(false);
+            _.remove(this.transformScriptCollections(), x => x === ongoingTaskElasticSearchTransformationModel.applyToAllCollectionsText);
+            this.transformScriptCollections.unshift(collectionName);
+        }
+
+        this.inputCollection("");
+
+        // blink on newly created item
+        $(".collection-list li").first().addClass("blink-style");
+    }
+
+    update(dto: Raven.Client.Documents.Operations.ETL.Transformation, isNew: boolean, resetScript: boolean): void {
         this.name(dto.Name);
         this.script(dto.Script);
-        this.collection(dto.Collections[0]);
+        
+        this.transformScriptCollections(dto.Collections || []);
+        this.applyScriptForAllCollections(dto.ApplyToAllDocuments);
+
+        if (this.applyScriptForAllCollections()) {
+            this.transformScriptCollections([ongoingTaskElasticSearchTransformationModel.applyToAllCollectionsText]);
+        }
+        
         this.isNew(isNew);
         this.resetScript(resetScript);
     }
 
-    getCollectionEntry(collectionName: string) {
+    getCollectionEntry(collectionName: string): number {
         return collectionsTracker.default.getCollectionColorIndex(collectionName);
     }
 
-    hasUpdates(oldItem: this) {
+    hasUpdates(oldItem: this): boolean {
         const hashFunction = jsonUtil.newLineNormalizingHashFunctionWithIgnoredFields(["__moduleId__", "validationGroup"]);
         return hashFunction(this) !== hashFunction(oldItem);
     }

--- a/src/Raven.Studio/wwwroot/App/views/database/tasks/editElasticSearchEtlTask.html
+++ b/src/Raven.Studio/wwwroot/App/views/database/tasks/editElasticSearchEtlTask.html
@@ -172,8 +172,15 @@
                                         <span data-bind="text: name"></span>
                                         <span class="text-warning" data-bind="visible: dirtyFlag().isDirty">*</span>
                                     </div>
-                                    <div class="collections">Collection: <span
-                                        data-bind="text: collection, attr: { class: 'collection-color-' + getCollectionEntry(collection) }"></span>
+                                    <div class="collections">
+                                        Collections:
+                                        <span class="etl-collections" title="The Collections transformed"
+                                              data-bind="foreach: transformScriptCollections, visible: !applyScriptForAllCollections() && transformScriptCollections().length">
+                                            <span data-bind="text: $data, attr: { class: 'collection-color-' + $parent.getCollectionEntry($data) }"></span>
+                                        </span>
+                                        <span class="etl-collections" data-bind="visible: applyScriptForAllCollections" title="The Collections transformed">
+                                            <span>All collections</span>
+                                        </span>
                                     </div>
                                 </div>
                                 <div class="actions">
@@ -209,21 +216,41 @@
                             <div class="help-block" data-bind="validationMessage: script"></div>
                         </div>
                     </div>
-                    <div class="form-group margin-top margin-top-lg">
-                        <label><strong>Collection:</strong></label>
-                        <div class="flex-grow" data-bind="validationOptions: { insertMessages: false }, validationElement: collection">
-                            <div class="dropdown btn-block">
-                                <input type="text" class="form-control dropdown-toggle" data-toggle="dropdown" title="Select/enter the collection name"
-                                       data-bind="textInput: collection" placeholder="Select (or enter) a collection">
-                                <span class="caret dropdown-toggle" data-toggle="dropdown"></span>
-                                <ul class="dropdown-menu"
-                                    data-bind="foreach: $root.createCollectionNameAutocompleter(collection)">
-                                    <li data-bind="click: _.partial($root.useCollection, $data)">
-                                        <a href="#" data-bind="text: $data"></a>
-                                    </li>
-                                </ul>
+                    <div class="margin-bottom margin-top margin-top-lg">
+                        <div class="flex-horizontal margin-bottom">
+                            <div class="flex-grow">
+                                <div class="dropdown btn-block flex-grow">
+                                    <input class="form-control dropdown-toggle" placeholder="Select (or enter) a collection" data-toggle="dropdown" autocomplete="off"
+                                           data-bind="textInput: inputCollection, attr: { id: 'collectionNameInput' }, disable: $root.collections().length === 0" />
+                                    <span class="caret dropdown-toggle" data-toggle="dropdown"></span>
+                                    <ul class="dropdown-menu" role="menu" style="display: none;"
+                                        data-bind="autoComplete: '#collectionNameInput', foreach: $root.createCollectionNameAutoCompleter(transformScriptCollections, inputCollection)">
+                                        <li role="presentation" data-bind="click: $parent.addWithBlink.bind($parent, $data)">
+                                            <a role="menuitem" tabindex="-1" href="#">
+                                                <span data-bind="text: $data"></span>
+                                            </a>
+                                            <div class="divider" data-bind="visible: $root.constructor.isApplyToAll($data)"></div>
+                                        </li>
+                                    </ul>
+                                    <div data-bind="validationOptions: { errorsAsTitle: false }, validationElement: transformScriptCollections">
+                                        <div class="help-block" data-bind="validationMessage: transformScriptCollections"></div>
+                                    </div>
+                                </div>
                             </div>
-                            <span class="help-block" data-bind="validationMessage: collection"></span>
+                            <div>
+                                <button class="btn btn-info" data-bind="click: addCollection, enable: inputCollection() && canAddCollection()">
+                                    <i class="icon-plus"></i><span>Add Collection</span>
+                                </button>
+                            </div>
+                        </div>
+                        <div data-bind="visible: transformScriptCollections().length" class="margin-top">
+                            <label><strong>Collections Selected:</strong></label>
+                            <ul class="well collection-list" data-bind="foreach: transformScriptCollections">
+                                <li>
+                                    <div class="name" data-bind="text: $data"></div>
+                                    <a title="Remove collection" href="#" data-bind="click: $parent.removeCollection.bind($parent, $data)"><i class="icon-trash"></i></a>
+                                </li>
+                            </ul>
                         </div>
                     </div>
                     <div class="toggle margin-top margin-top-lg margin-bottom" data-bind="visible: !isNew() && !$root.enableTestArea()">


### PR DESCRIPTION
…on in UI

### Issue link
https://issues.hibernatingrhinos.com/issue/RavenDB-17385

### Additional description
Allow adding more than one collection in the script definition

### Type of change
- Bug fix

### How risky is the change?
- Low 

### Backward compatibility
- Non breaking change

### Is it platform specific issue?
- No

### Documentation update
Documentation for Elasticsearch is currently in progress

### Testing 
- It has been verified by manual testing

### Is there any existing behavior change of other features due to this change?
- No

### UI work
- No UI work is needed
