### PR TITLE
Enable running https server on Docker

### DIFF
--- a/docker/ravendb-ubuntu/run-raven.sh
+++ b/docker/ravendb-ubuntu/run-raven.sh
@@ -1,6 +1,8 @@
 #!/bin/bash
 COMMAND="./Raven.Server"
-export RAVEN_ServerUrl="http://$(hostname):8080"
+
+RAVEN_SERVER_SCHEME="${RAVEN_SERVER_SCHEME:-http}"
+export RAVEN_ServerUrl="${RAVEN_SERVER_SCHEME}://$(hostname):8080"
 
 if [ ! -z "$RAVEN_SETTINGS" ]; then
     echo "$RAVEN_SETTINGS" > settings.json


### PR DESCRIPTION
### Issue link

https://issues.hibernatingrhinos.com/issue/RavenDB-...

### Additional description

When running https server cluster in Docker, for example in docker-compose, setting RAVEN_Security_Certificate_Path environment variable will enable server to listen on HTTPS, but PublicURL scheme will not match, so therefore error produced would be:
```
Unhandled exception. System.ArgumentException: ServerUrl and PublicServerUrl schemes do not match
```
this patch handles that case.

### Type of change

- Bug fix

### How risky is the change?

- Low 


### Backward compatibility

- Non breaking change


### Is it platform specific issue?

- Yes. 
Docker only

### Documentation update

- No documentation update is needed 

### Testing 

- It has been verified by manual testing

### Is there any existing behavior change of other features due to this change?

- No

### UI work

- No UI work is needed
