### PR TITLE
RavenDB-13041 Better property name for Elasticsearch configuration option

### DIFF
--- a/src/Raven.Client/Documents/Operations/ETL/Elasticsearch/ElasticSearchEtlConfiguration.cs
+++ b/src/Raven.Client/Documents/Operations/ETL/Elasticsearch/ElasticSearchEtlConfiguration.cs
@@ -54,7 +54,7 @@ namespace Raven.Client.Documents.Operations.ETL.ElasticSearch
     {
         public string IndexName { get; set; }
 
-        public string IndexIdProperty { get; set; }
+        public string DocumentIdProperty { get; set; }
 
         public bool InsertOnlyMode { get; set; }
 
@@ -63,7 +63,7 @@ namespace Raven.Client.Documents.Operations.ETL.ElasticSearch
             return new DynamicJsonValue
             {
                 [nameof(IndexName)] = IndexName,
-                [nameof(IndexIdProperty)] = IndexIdProperty,
+                [nameof(DocumentIdProperty)] = DocumentIdProperty,
                 [nameof(InsertOnlyMode)] = InsertOnlyMode
             };
         }

--- a/src/Raven.Server/Documents/ETL/Providers/Elasticsearch/ElasticIndexWithRecords.cs
+++ b/src/Raven.Server/Documents/ETL/Providers/Elasticsearch/ElasticIndexWithRecords.cs
@@ -12,7 +12,7 @@ namespace Raven.Server.Documents.ETL.Providers.ElasticSearch
         public ElasticSearchIndexWithRecords(ElasticSearchIndex index)
         {
             IndexName = index.IndexName;
-            IndexIdProperty = index.IndexIdProperty;
+            DocumentIdProperty = index.DocumentIdProperty;
             InsertOnlyMode = index.InsertOnlyMode;
         }
     }

--- a/src/Raven.Server/Documents/ETL/Providers/Elasticsearch/ElasticSearchEtl.cs
+++ b/src/Raven.Server/Documents/ETL/Providers/Elasticsearch/ElasticSearchEtl.cs
@@ -149,11 +149,11 @@ namespace Raven.Server.Documents.ETL.Providers.ElasticSearch
         internal static BlittableJsonReaderObject EnsureLowerCasedIndexIdProperty(DocumentsOperationContext context, BlittableJsonReaderObject json,
             ElasticSearchIndexWithRecords index)
         {
-            if (json.TryGet(index.IndexIdProperty, out LazyStringValue idProperty))
+            if (json.TryGet(index.DocumentIdProperty, out LazyStringValue idProperty))
             {
                 using (var old = json)
                 {
-                    json.Modifications = new DynamicJsonValue(json) { [index.IndexIdProperty] = LowerCaseIndexIdProperty(idProperty) };
+                    json.Modifications = new DynamicJsonValue(json) { [index.DocumentIdProperty] = LowerCaseIndexIdProperty(idProperty) };
 
                     json = context.ReadObject(json, "es-etl-load");
                 }
@@ -178,7 +178,7 @@ namespace Raven.Server.Documents.ETL.Providers.ElasticSearch
                 .Refresh()
                 .Query(q => q
                     .Terms(p => p
-                        .Field(index.IndexIdProperty)
+                        .Field(index.DocumentIdProperty)
                         .Terms((IEnumerable<string>)idsToDelete))
                 )
             );
@@ -210,7 +210,7 @@ namespace Raven.Server.Documents.ETL.Providers.ElasticSearch
                 .Map(m => m
                     .Properties(p => p
                         .Keyword(t => t
-                            .Name(index.IndexIdProperty)))));
+                            .Name(index.DocumentIdProperty)))));
 
             // The request made it to the server but something went wrong in ElasticSearch (query parsing exception, non-existent index, etc)
             if (response.ServerError != null)

--- a/src/Raven.Server/Documents/ETL/Providers/Elasticsearch/ElasticsearchIndexWriterSimulator.cs
+++ b/src/Raven.Server/Documents/ETL/Providers/Elasticsearch/ElasticsearchIndexWriterSimulator.cs
@@ -16,7 +16,7 @@ namespace Raven.Server.Documents.ETL.Providers.ElasticSearch
             {
                 // first, delete all the rows that might already exist there
 
-                result.Add(GenerateDeleteItemsCommandText(records.IndexName.ToLower(), records.IndexIdProperty,
+                result.Add(GenerateDeleteItemsCommandText(records.IndexName.ToLower(), records.DocumentIdProperty,
                     records.Deletes));
             }
 

--- a/src/Raven.Studio/typescript/models/database/tasks/ongoingTaskElasticSearchEtlIndexModel.ts
+++ b/src/Raven.Studio/typescript/models/database/tasks/ongoingTaskElasticSearchEtlIndexModel.ts
@@ -29,7 +29,7 @@ class ongoingTaskElasticSearchEtlIndexModel {
         return new ongoingTaskElasticSearchEtlIndexModel(
             {
                 IndexName: "",
-                IndexIdProperty: "",
+                DocumentIdProperty: "",
                 InsertOnlyMode: false
             }, true);
     }
@@ -37,7 +37,7 @@ class ongoingTaskElasticSearchEtlIndexModel {
     toDto(): Raven.Client.Documents.Operations.ETL.ElasticSearch.ElasticSearchIndex {
         return {
             IndexName: this.indexName(),
-            IndexIdProperty: this.idProperty(),
+            DocumentIdProperty: this.idProperty(),
             InsertOnlyMode: this.insertOnlyMode()
         }
     }
@@ -80,7 +80,7 @@ class ongoingTaskElasticSearchEtlIndexModel {
 
     private update(dto: Raven.Client.Documents.Operations.ETL.ElasticSearch.ElasticSearchIndex, isNew: boolean) {
         this.indexName(dto.IndexName);
-        this.idProperty(dto.IndexIdProperty);
+        this.idProperty(dto.DocumentIdProperty);
         this.insertOnlyMode(dto.InsertOnlyMode);
         this.isNew(isNew);
     }

--- a/test/SlowTests/Server/Documents/ETL/Elasticsearch/ElasticSearchEtlTests.cs
+++ b/test/SlowTests/Server/Documents/ETL/Elasticsearch/ElasticSearchEtlTests.cs
@@ -184,8 +184,8 @@ loadToOrders(orderData);
                         Name = "myFirstEtl",
                         ElasticIndexes =
                         {
-                            new ElasticSearchIndex {IndexName = OrderIndexName, IndexIdProperty = "Id"},
-                            new ElasticSearchIndex {IndexName = OrderLinesIndexName, IndexIdProperty = "OrderId"},
+                            new ElasticSearchIndex {IndexName = OrderIndexName, DocumentIdProperty = "Id"},
+                            new ElasticSearchIndex {IndexName = OrderLinesIndexName, DocumentIdProperty = "OrderId"},
                         },
                         Transforms =
                         {
@@ -682,7 +682,7 @@ loadToOrders(orderData);
                     {
                         ConnectionStringName = "test",
                         Name = "myFirstEtl",
-                        ElasticIndexes = { new ElasticSearchIndex { IndexName = "Users", IndexIdProperty = "UserId" }, },
+                        ElasticIndexes = { new ElasticSearchIndex { IndexName = "Users", DocumentIdProperty = "UserId" }, },
                         Transforms =
                         {
                             new Transformation
@@ -776,9 +776,9 @@ loadToOrders(orderData);
                                 ConnectionStringName = "simulate",
                                 ElasticIndexes =
                                 {
-                                    new ElasticSearchIndex { IndexName = "Orders", IndexIdProperty = "Id" },
-                                    new ElasticSearchIndex { IndexName = "OrderLines", IndexIdProperty = "OrderId" },
-                                    new ElasticSearchIndex { IndexName = "NotUsedInScript", IndexIdProperty = "OrderId" },
+                                    new ElasticSearchIndex { IndexName = "Orders", DocumentIdProperty = "Id" },
+                                    new ElasticSearchIndex { IndexName = "OrderLines", DocumentIdProperty = "OrderId" },
+                                    new ElasticSearchIndex { IndexName = "NotUsedInScript", DocumentIdProperty = "OrderId" },
                                 },
                                 Transforms =
                                 {
@@ -856,9 +856,9 @@ loadToOrders(orderData);
                                 ConnectionStringName = "simulate",
                                 ElasticIndexes =
                                 {
-                                    new ElasticSearchIndex { IndexName = "Orders", IndexIdProperty = "Id" },
-                                    new ElasticSearchIndex { IndexName = "OrderLines", IndexIdProperty = "OrderId" },
-                                    new ElasticSearchIndex { IndexName = "NotUsedInScript", IndexIdProperty = "OrderId" },
+                                    new ElasticSearchIndex { IndexName = "Orders", DocumentIdProperty = "Id" },
+                                    new ElasticSearchIndex { IndexName = "OrderLines", DocumentIdProperty = "OrderId" },
+                                    new ElasticSearchIndex { IndexName = "NotUsedInScript", DocumentIdProperty = "OrderId" },
                                 },
                                 Transforms =
                                 {
@@ -927,9 +927,9 @@ loadToOrders(orderData);
                     ConnectionStringName = connectionStringName,
                     ElasticIndexes =
                     {
-                        new ElasticSearchIndex {IndexName = $"Orders", IndexIdProperty = "Id"},
-                        new ElasticSearchIndex {IndexName = $"OrderLines", IndexIdProperty = "OrderId"},
-                        new ElasticSearchIndex {IndexName = $"Users", IndexIdProperty = "UserId"},
+                        new ElasticSearchIndex {IndexName = $"Orders", DocumentIdProperty = "Id"},
+                        new ElasticSearchIndex {IndexName = $"OrderLines", DocumentIdProperty = "OrderId"},
+                        new ElasticSearchIndex {IndexName = $"Users", DocumentIdProperty = "UserId"},
                     },
                     Transforms =
                     {


### PR DESCRIPTION
### Issue link

https://issues.hibernatingrhinos.com/issue/RavenDB-13041

### Additional description

More meaningful property name which should indicate that it's about of document id property name (not index).

### Type of change

- Enhancement

### How risky is the change?

- Low 

### Backward compatibility

- Not relevant (we haven't released ES ETL officially yet)

### Is it platform specific issue?
- No

### Documentation update

- There is open PR for that. I will be updated accordingly.


### Is there any existing behavior change of other features due to this change?

- No

### UI work

- No UI work is needed
