### PR TITLE
RavenDB-17393: do not cancel running backup if the task got active by other node

### DIFF
--- a/src/Raven.Server/Documents/PeriodicBackup/BackupTask.cs
+++ b/src/Raven.Server/Documents/PeriodicBackup/BackupTask.cs
@@ -127,6 +127,8 @@ namespace Raven.Server.Documents.PeriodicBackup
             {
                 if (_forTestingPurposes != null && _forTestingPurposes.SimulateFailedBackup)
                     throw new Exception(nameof(_forTestingPurposes.SimulateFailedBackup));
+                if (_forTestingPurposes != null && _forTestingPurposes.OnBackupTaskRunHoldBackupExecution != null)
+                    _forTestingPurposes.OnBackupTaskRunHoldBackupExecution.Task.Wait();
 
                 if (runningBackupStatus.LocalBackup == null)
                     runningBackupStatus.LocalBackup = new LocalBackup();

--- a/src/Raven.Server/Documents/PeriodicBackup/PeriodicBackup.cs
+++ b/src/Raven.Server/Documents/PeriodicBackup/PeriodicBackup.cs
@@ -60,18 +60,21 @@ namespace Raven.Server.Documents.PeriodicBackup
             return new DisposableAction(() => _updateBackupTaskSemaphore.Release());
         }
 
-        public void DisableFutureBackups()
+        public void DisableFutureBackups(bool cancelRunningBackup)
         {
             using (UpdateBackupTask())
             {
-                CancelFutureTasks();
+                CancelFutureTasks(cancelRunningBackup);
             }
         }
 
-        private void CancelFutureTasks()
+        private void CancelFutureTasks(bool cancelRunningBackup = true)
         {
             _backupTimer?.Dispose();
             _backupTimer = null;
+
+            if (cancelRunningBackup == false)
+                return;
 
             try
             {

--- a/src/Raven.Server/Documents/PeriodicBackup/PeriodicBackupRunner.cs
+++ b/src/Raven.Server/Documents/PeriodicBackup/PeriodicBackupRunner.cs
@@ -732,7 +732,7 @@ namespace Raven.Server.Documents.PeriodicBackup
                     taskStatus = TaskStatus.ClusterDown;
                     _forTestingPurposes.ClusterDownStatusSimulated = true;
                 }
-                else if (_forTestingPurposes.SimulateActiveByOtherNodeStatus)
+                else if (_forTestingPurposes.SimulateActiveByOtherNodeStatus_Reschedule)
                 {
                     taskStatus = TaskStatus.ActiveByOtherNode;
                 }
@@ -751,7 +751,7 @@ namespace Raven.Server.Documents.PeriodicBackup
                     break;
                 default:
                     msg = $"Backup {backupInfo.TaskId}, current status is {taskStatus}, the backup will be canceled on current node.";
-                    periodicBackup.DisableFutureBackups();
+                    periodicBackup.DisableFutureBackups(cancelRunningBackup: true);
                     break;
             }
 
@@ -863,6 +863,17 @@ namespace Raven.Server.Documents.PeriodicBackup
                 allBackupTaskIds.Add(newBackupTaskId);
 
                 var taskState = GetTaskStatus(databaseRecord.Topology, periodicBackupConfiguration);
+                if (_forTestingPurposes != null)
+                {
+                    if (_forTestingPurposes.SimulateActiveByOtherNodeStatus_UpdateConfigurations)
+                    {
+                        taskState = TaskStatus.ActiveByOtherNode;
+                    }
+                    else if (_forTestingPurposes.SimulateDisableNodeStatus_UpdateConfigurations)
+                    {
+                        taskState = TaskStatus.Disabled;
+                    }
+                }
 
                 UpdatePeriodicBackup(newBackupTaskId, periodicBackupConfiguration, taskState);
             }
@@ -916,9 +927,14 @@ namespace Raven.Server.Documents.PeriodicBackup
             switch (taskState)
             {
                 case TaskStatus.Disabled:
+                    existingBackupState.DisableFutureBackups(cancelRunningBackup: true);
+                    if (_logger.IsOperationsEnabled)
+                        _logger.Operations($"Backup task '{taskId}' state is '{taskState}', will cancel the backup for it.");
+
+                    return;
                 case TaskStatus.ActiveByOtherNode:
                     // the task is disabled or this node isn't responsible for the backup task
-                    existingBackupState.DisableFutureBackups();
+                    existingBackupState.DisableFutureBackups(cancelRunningBackup: false);
 
                     if (_logger.IsOperationsEnabled)
                         _logger.Operations($"Backup task '{taskId}' state is '{taskState}', will cancel the timer for it.");
@@ -1151,8 +1167,12 @@ namespace Raven.Server.Documents.PeriodicBackup
         {
             internal bool SimulateClusterDownStatus;
             internal bool ClusterDownStatusSimulated;
-            internal bool SimulateActiveByOtherNodeStatus;
+            internal bool SimulateActiveByOtherNodeStatus_Reschedule;
+            internal bool SimulateActiveByOtherNodeStatus_UpdateConfigurations;
+            internal bool SimulateDisableNodeStatus_UpdateConfigurations;
             internal bool SimulateFailedBackup;
+
+            internal TaskCompletionSource<object> OnBackupTaskRunHoldBackupExecution;
         }
     }
 }

--- a/test/SlowTests/Server/Documents/PeriodicBackup/PeriodicBackupSlowTests.cs
+++ b/test/SlowTests/Server/Documents/PeriodicBackup/PeriodicBackupSlowTests.cs
@@ -1127,7 +1127,7 @@ namespace SlowTests.Server.Documents.PeriodicBackup
                 var tag = responsibleDatabase.PeriodicBackupRunner.WhoseTaskIsIt(taskId);
                 Assert.Equal(server.ServerStore.NodeTag, tag);
 
-                responsibleDatabase.PeriodicBackupRunner.ForTestingPurposesOnly().SimulateActiveByOtherNodeStatus = true;
+                responsibleDatabase.PeriodicBackupRunner.ForTestingPurposesOnly().SimulateActiveByOtherNodeStatus_Reschedule = true;
                 var pb = responsibleDatabase.PeriodicBackupRunner.PeriodicBackups.First();
                 Assert.NotNull(pb);
 
@@ -1584,6 +1584,147 @@ namespace SlowTests.Server.Documents.PeriodicBackup
                         Assert.Equal(1, stats.CountOfDocuments);
                         Assert.Equal(1, stats.CountOfAttachments);
                     }
+                }
+            }
+        }
+
+        [Fact, Trait("Category", "Smuggler")]
+        public async Task ShouldKeepTheBackupRunningIfItGotActiveByOtherNodeWhileRunning()
+        {
+            var backupPath = NewDataPath(suffix: "BackupFolder");
+            using (var server = GetNewServer())
+            using (var store = GetDocumentStore(new Options
+            {
+                Server = server
+            }))
+            {
+                const string documentId = "Users/1";
+                using (var session = store.OpenAsyncSession())
+                {
+                    await session.StoreAsync(new User { Name = "Grisha" }, documentId);
+                    await session.SaveChangesAsync();
+                }
+
+                var config = Backup.CreateBackupConfiguration(backupPath);
+
+
+                var documentDatabase = await server.ServerStore.DatabasesLandlord.TryGetOrCreateResourceStore(store.Database).ConfigureAwait(false);
+                Assert.NotNull(documentDatabase);
+                var tcs = new TaskCompletionSource<object>();
+                documentDatabase.PeriodicBackupRunner.ForTestingPurposesOnly().OnBackupTaskRunHoldBackupExecution = tcs;
+                try
+                {
+                    var backupTaskId = await Backup.UpdateConfigAndRunBackupAsync(server, config, store, opStatus: OperationStatus.InProgress);
+                    var record1 = await store.Maintenance.Server.SendAsync(new GetDatabaseRecordOperation(store.Database));
+                    var backups1 = record1.PeriodicBackups;
+                    Assert.Equal(1, backups1.Count);
+
+                    var taskId = backups1.First().TaskId;
+                    var responsibleDatabase = await server.ServerStore.DatabasesLandlord.TryGetOrCreateResourceStore(store.Database).ConfigureAwait(false);
+                    Assert.NotNull(responsibleDatabase);
+                    var tag = responsibleDatabase.PeriodicBackupRunner.WhoseTaskIsIt(taskId);
+                    Assert.Equal(server.ServerStore.NodeTag, tag);
+
+                    responsibleDatabase.PeriodicBackupRunner.ForTestingPurposesOnly().SimulateActiveByOtherNodeStatus_UpdateConfigurations = true;
+                    responsibleDatabase.PeriodicBackupRunner.UpdateConfigurations(record1);
+                    tcs.SetResult(null);
+
+                    responsibleDatabase.PeriodicBackupRunner._forTestingPurposes = null;
+                    var getPeriodicBackupStatus = new GetPeriodicBackupStatusOperation(taskId);
+                    PeriodicBackupStatus status = null;
+                    var val = WaitForValue(() =>
+                    {
+                        status = store.Maintenance.Send(getPeriodicBackupStatus).Status;
+                        return status?.LastFullBackup != null;
+                    }, true, timeout: 66666, interval: 444);
+                    Assert.NotNull(status);
+                    Assert.Null(status.Error);
+                    Assert.True(val, "Failed to complete the backup in time");
+                }
+                finally
+                {
+                    try
+                    {
+                        tcs.TrySetResult(null);
+                    }
+                    catch
+                    {
+                        // ignored
+                    }
+
+                    documentDatabase.PeriodicBackupRunner.ForTestingPurposesOnly().OnBackupTaskRunHoldBackupExecution = null;
+                }
+            }
+        }
+
+        [Fact, Trait("Category", "Smuggler")]
+        public async Task ShouldCancelTheBackupRunningIfItGotDisabledWhileRunning()
+        {
+            var backupPath = NewDataPath(suffix: "BackupFolder");
+            using (var server = GetNewServer())
+            using (var store = GetDocumentStore(new Options
+            {
+                Server = server
+            }))
+            {
+                const string documentId = "Users/1";
+                using (var session = store.OpenAsyncSession())
+                {
+                    await session.StoreAsync(new User { Name = "Grisha" }, documentId);
+                    await session.SaveChangesAsync();
+                }
+
+                var config = Backup.CreateBackupConfiguration(backupPath);
+
+                var documentDatabase = await server.ServerStore.DatabasesLandlord.TryGetOrCreateResourceStore(store.Database).ConfigureAwait(false);
+                Assert.NotNull(documentDatabase);
+                var tcs = new TaskCompletionSource<object>();
+                documentDatabase.PeriodicBackupRunner.ForTestingPurposesOnly().OnBackupTaskRunHoldBackupExecution = tcs;
+                try
+                {
+                    var backupTaskId = await Backup.UpdateConfigAndRunBackupAsync(server, config, store, opStatus: OperationStatus.InProgress);
+                    var record1 = await store.Maintenance.Server.SendAsync(new GetDatabaseRecordOperation(store.Database));
+                    var backups1 = record1.PeriodicBackups;
+                    Assert.Equal(1, backups1.Count);
+
+                    var taskId = backups1.First().TaskId;
+                    var responsibleDatabase = await server.ServerStore.DatabasesLandlord.TryGetOrCreateResourceStore(store.Database).ConfigureAwait(false);
+                    Assert.NotNull(responsibleDatabase);
+                    var tag = responsibleDatabase.PeriodicBackupRunner.WhoseTaskIsIt(taskId);
+                    Assert.Equal(server.ServerStore.NodeTag, tag);
+
+                    responsibleDatabase.PeriodicBackupRunner.ForTestingPurposesOnly().SimulateDisableNodeStatus_UpdateConfigurations = true;
+                    responsibleDatabase.PeriodicBackupRunner.UpdateConfigurations(record1);
+                    tcs.SetResult(null);
+
+                    responsibleDatabase.PeriodicBackupRunner._forTestingPurposes = null;
+                    var getPeriodicBackupStatus = new GetPeriodicBackupStatusOperation(taskId);
+                    var val = WaitForValue(() =>
+                    {
+                        var status = store.Maintenance.Send(getPeriodicBackupStatus).Status;
+                        if (status == null)
+                            return false;
+
+                        if (status.LocalBackup == null)
+                            return false;
+                        if (string.IsNullOrEmpty(status.LocalBackup.Exception))
+                            return false;
+
+                        return status.LocalBackup.Exception.StartsWith("System.OperationCanceledException: The operation was canceled.");
+                    }, true, timeout: 66666, interval: 444);
+                    Assert.True(val, "Failed to complete the backup in time");
+                }
+                finally
+                {
+                    try
+                    {
+                        tcs.TrySetResult(null);
+                    }
+                    catch
+                    {
+                        // ignored
+                    }
+                    documentDatabase.PeriodicBackupRunner.ForTestingPurposesOnly().OnBackupTaskRunHoldBackupExecution = null;
                 }
             }
         }


### PR DESCRIPTION


### Issue link

https://issues.hibernatingrhinos.com/issue/RavenDB-17393

### Additional description

if the task status got changed to ActiveByOtherNode while the backup task was running if was canceling the backup task.

### Type of change

- Bug fix

### How risky is the change?

- Low 

### Backward compatibility

- Not relevant

### Is it platform specific issue?

- No

### Documentation update
- No documentation update is needed 

### Testing 

- Tests have been added that prove the fix is effective or that the feature works
- It has been verified by manual testing

### Is there any existing behavior change of other features due to this change?

- No

### UI work

- No UI work is needed
