### PR TITLE
RavenDB-17382 Broken replication due to document in different collect…

### DIFF
--- a/src/Raven.Client/Constants.cs
+++ b/src/Raven.Client/Constants.cs
@@ -206,6 +206,8 @@ namespace Raven.Client
             public class Collections
             {
                 public const string AllDocumentsCollection = "@all_docs";
+
+                public const string EmptyCollection = "@empty";
             }
 
             public class Indexing

--- a/src/Raven.Server/Documents/CollectionName.cs
+++ b/src/Raven.Server/Documents/CollectionName.cs
@@ -32,7 +32,6 @@ namespace Raven.Server.Documents
 
     public class CollectionName
     {
-        public const string EmptyCollection = "@empty";
         public const string HiLoCollection = "@hilo";
 
         public static readonly StringSegment EmptyCollectionSegment;
@@ -52,7 +51,7 @@ namespace Raven.Server.Documents
 
         static CollectionName()
         {
-            EmptyCollectionSegment = new StringSegment(EmptyCollection);
+            EmptyCollectionSegment = new StringSegment(Constants.Documents.Collections.EmptyCollection);
             MetadataKeySegment = new StringSegment(Constants.Documents.Metadata.Key);
             MetadataCollectionSegment = new StringSegment(Constants.Documents.Metadata.Collection);
         }
@@ -180,14 +179,14 @@ namespace Raven.Server.Documents
         public static string GetCollectionName(BlittableJsonReaderObject document)
         {
             if (document == null)
-                return EmptyCollection;
+                return Constants.Documents.Collections.EmptyCollection;
 
             document.NoCache = true;
             if (document.TryGet(MetadataKeySegment, out BlittableJsonReaderObject metadata) == false ||
                 metadata.TryGet(MetadataCollectionSegment, out string collectionName) == false ||
                 collectionName == null)
             {
-                collectionName = EmptyCollection;
+                collectionName = Constants.Documents.Collections.EmptyCollection;
             }
 
             return collectionName;

--- a/src/Raven.Server/Utils/ReplicationUtils.cs
+++ b/src/Raven.Server/Utils/ReplicationUtils.cs
@@ -49,7 +49,7 @@ namespace Raven.Server.Utils
                 metadata.TryGet(Constants.Documents.Metadata.Collection, out string actualCollection) == false ||
                 actualCollection != collection)
             {
-                if (collection == CollectionName.EmptyCollection)
+                if (collection == Constants.Documents.Collections.EmptyCollection)
                     return;
 
                 ThrowInvalidCollectionAfterResolve(collection, null);

--- a/test/SlowTests/Issues/RavenDB-17382.cs
+++ b/test/SlowTests/Issues/RavenDB-17382.cs
@@ -1,0 +1,136 @@
+﻿using System;
+using System.Collections.Generic;
+using System.Linq;
+using System.Threading.Tasks;
+using FastTests;
+using FastTests.Server.Replication;
+using Raven.Client.Documents.Operations;
+using Raven.Client.Documents.Operations.OngoingTasks;
+using Raven.Tests.Core.Utils.Entities;
+using Xunit;
+using Xunit.Abstractions;
+
+namespace SlowTests.Issues
+{
+    public class RavenDB_17382 : ReplicationTestBase
+    {
+        public RavenDB_17382(ITestOutputHelper output) : base(output)
+        {
+        }
+
+        public readonly string DbName = "TestDB" + Guid.NewGuid();
+
+        [Fact]
+        public async Task ReplicateDocumentsFromDifferentCollectionsUpdate()
+        {
+            using (var store1 = GetDocumentStore())
+            using (var store2 = GetDocumentStore())
+            {
+                var ongoing = await SetupReplicationAsync(store1, store2);
+
+                using (var session = store1.OpenSession())
+                {
+                    session.Store(new User {Name = "John Dow", Age = 30}, "users/1");
+
+                    session.SaveChanges();
+                }
+
+                WaitForDocumentToReplicate<User>(store2, "users/1", 15000);
+
+                await DeleteOngoingTask(store1, ongoing[0].TaskId, OngoingTaskType.Replication);
+                var tasks = await GetOngoingTasks(store1.Database);
+                Assert.Equal(0, tasks.Count);
+
+                using (var session = store1.OpenSession())
+                {
+                    session.Delete("users/1");
+
+                    session.SaveChanges();
+                }
+
+                var database = await Server.ServerStore.DatabasesLandlord.TryGetOrCreateResourceStore(store1.Database);
+                await database.TombstoneCleaner.ExecuteCleanup();
+
+                using (var session = store1.OpenSession())
+                {
+                    session.Store(new Employee { FirstName = "Toli"}, "users/1");
+
+                    session.SaveChanges();
+                }
+
+                await SetupReplicationAsync(store1, store2);
+
+                using (var session = store1.OpenSession())
+                {
+                    session.Store(new User { Name = "John Dow", Age = 30 }, "Marker");
+
+                    session.SaveChanges();
+                }
+
+                await WaitForDocumentToReplicateAsync<User>(store2, "Marker", 15000);
+
+                var stats = await store2.Maintenance.SendAsync(new GetStatisticsOperation());
+                Assert.Equal(1, stats.CountOfDocuments);
+                Assert.Equal(1, stats.CountOfDocumentsConflicts);
+
+                var conflicts = (await store2.Commands().GetConflictsForAsync("users/1")).ToList();
+                Assert.Equal(2, conflicts.Count);
+
+            }
+        }
+
+        [Fact]
+        public async Task ReplicateDocumentsFromDifferentCollectionsConflict()
+        {
+            using (var store1 = GetDocumentStore())
+            using (var store2 = GetDocumentStore())
+            {
+                using (var session = store1.OpenSession())
+                {
+                    session.Store(new User { Name = "John Dow", Age = 30 }, "users/1");
+                    session.SaveChanges();
+                }
+
+                using (var session = store2.OpenAsyncSession())
+                {
+                    await session.StoreAsync(new Employee { FirstName = "Toli" }, "users/1");
+                    await session.SaveChangesAsync();
+                }
+
+                await SetupReplicationAsync(store1, store2);
+
+                using (var session = store1.OpenSession())
+                {
+                    session.Store(new User { Name = "John Dow", Age = 30 }, "Marker");
+
+                    session.SaveChanges();
+                }
+
+                await WaitForDocumentToReplicateAsync<User>(store2, "Marker", 15000);
+
+                var stats = await store2.Maintenance.SendAsync(new GetStatisticsOperation());
+                Assert.Equal(1, stats.CountOfDocuments);
+                Assert.Equal(1, stats.CountOfDocumentsConflicts);
+
+                var conflicts = (await store2.Commands().GetConflictsForAsync("users/1")).ToList();
+                Assert.Equal(2, conflicts.Count);
+
+            }
+        }
+
+        private async Task<List<OngoingTask>> GetOngoingTasks(string name)
+        {
+            var tasks = new Dictionary<long, OngoingTask>();
+            foreach (var server in Servers)
+            {
+                var handler = await InstantiateOutgoingTaskHandler(name, server);
+                foreach (var task in handler.GetOngoingTasksInternal().OngoingTasksList)
+                {
+                    if (tasks.ContainsKey(task.TaskId) == false && task.TaskConnectionStatus != OngoingTaskConnectionStatus.NotOnThisNode)
+                        tasks.Add(task.TaskId, task);
+                }
+            }
+            return tasks.Values.ToList();
+        }
+    }
+}

--- a/test/SlowTests/Server/Replication/ReplicationConflictsTests.cs
+++ b/test/SlowTests/Server/Replication/ReplicationConflictsTests.cs
@@ -720,7 +720,7 @@ namespace SlowTests.Server.Replication
 
                 await SetupReplicationAsync(store1, store3);
                 await SetupReplicationAsync(store2, store3);
-
+                WaitForUserToContinueTheTest(store1);
                 Assert.Equal(3, WaitUntilHasConflict(store3, "foo/bar", 3).Length);
             }
         }
@@ -772,7 +772,7 @@ namespace SlowTests.Server.Replication
             }
         }
 
-        [Fact]
+        [Fact(Skip= "Conflict for for document in different collections can be resolved only manually - Issue RavenDB-17382")]
         public async Task Conflict_should_be_created_and_resolved_for_document_in_different_collections()
         {
             const string dbName1 = "FooBar-1";
@@ -968,7 +968,7 @@ namespace SlowTests.Server.Replication
             }
         }
 
-        [Fact]
+        [Fact(Skip = "Conflict for for document in different collections can be resolved only manually - Issue RavenDB-17382")]
         public async Task Should_not_resolve_conflcit_with_script_when_they_from_different_collection()
         {
             using (var store1 = GetDocumentStore(options: new Options


### PR DESCRIPTION
…ions

### Issue link

https://issues.hibernatingrhinos.com/issue/RavenDB-17382

### Additional description
When we replicate a document with the same id and different collections in the source and destination, we mark that document as conflicted (won't be solved by latest or script) and continue with the replication.

_Please delete below the options that are not relevant_

### Type of change

- Bug fix

### How risky is the change?

- Low 

### Backward compatibility

- Breaking change

### Is it platform specific issue?

- No

### Documentation update

- This change requires a documentation update. Please mark the issue on YouTrack using `Documentation Required` tag.

### Testing 

- Tests have been added that prove the fix is effective or that the feature works

### Is there any existing behavior change of other features due to this change?

- No

### UI work

- No UI work is needed
