### PR TITLE
RavenDB-17346 : replication to a node that uses a different replication protocol-version fails

### DIFF
--- a/src/Raven.Server/Documents/Replication/InterruptibleRead.cs
+++ b/src/Raven.Server/Documents/Replication/InterruptibleRead.cs
@@ -135,14 +135,14 @@ namespace Raven.Server.Documents.Replication
 
             static void SafelyDispose(IDisposable toDispose)
             {
-            try
-            {
+                try
+                {
                     toDispose?.Dispose();
                 }
                 catch
-            {
-                // explicitly ignoring this
-            }
+                {
+                    // explicitly ignoring this
+                }
             }
         }
     }

--- a/src/Raven.Server/Documents/Replication/OutgoingReplicationHandler.cs
+++ b/src/Raven.Server/Documents/Replication/OutgoingReplicationHandler.cs
@@ -720,10 +720,17 @@ namespace Raven.Server.Documents.Replication
 
                 _interruptibleRead = new InterruptibleRead(_database.DocumentsStorage.ContextPool, stream);
 
-                //This will either throw or return acceptable protocol version.
-                SupportedFeatures = TcpNegotiation.Sync.NegotiateProtocolVersion(documentsContext, stream, parameters);
-                
-                return Task.FromResult(SupportedFeatures);
+                try
+                {
+                    //This will either throw or return acceptable protocol version.
+                    SupportedFeatures = TcpNegotiation.Sync.NegotiateProtocolVersion(documentsContext, stream, parameters);
+                    return Task.FromResult(SupportedFeatures);
+                }
+                catch
+                {
+                    _interruptibleRead.Dispose();
+                    throw;
+                }
             }
         }
 

--- a/src/Raven.Server/ServerWide/Tcp/Sync/TcpNegotiationSyncExtensions.cs
+++ b/src/Raven.Server/ServerWide/Tcp/Sync/TcpNegotiationSyncExtensions.cs
@@ -5,7 +5,6 @@ using Sparrow.Json;
 using Sparrow.Json.Parsing;
 using Sparrow.Json.Sync;
 using Sparrow.Logging;
-using Sparrow.Server.Json.Sync;
 
 namespace Raven.Server.ServerWide.Tcp.Sync
 {

--- a/test/InterversionTests/ReplicationTests.cs
+++ b/test/InterversionTests/ReplicationTests.cs
@@ -52,6 +52,33 @@ namespace InterversionTests
             Assert.True(replicationLoader.OutgoingFailureInfo.Any(ofi => ofi.Value.Errors.Select(x => x.Message).Any(x => x.Contains("TimeSeries"))));
         }
 
+        [Fact]
+        public async Task CanReplicateToOldServerWithLowerReplicationProtocolVersion()
+        {
+            // https://issues.hibernatingrhinos.com/issue/RavenDB-17346
+
+            const string version = "4.2.117";
+            using var oldStore = await GetDocumentStoreAsync(version);
+            using var store = GetDocumentStore();
+            {
+                using (var session = store.OpenAsyncSession())
+                {
+                    await session.StoreAsync(new User { Name = "Egor" }, "users/1");
+                    await session.SaveChangesAsync();
+                }
+            }
+
+            var externalTask = new ExternalReplication(oldStore.Database.ToLowerInvariant(), "MyConnectionString")
+            {
+                Name = "MyExternalReplication",
+                Url = oldStore.Urls.First()
+            };
+
+            await SetupReplication(store, externalTask);
+
+            Assert.True(WaitForDocument<User>(oldStore, "users/1", u => u.Name == "Egor"));
+        }
+
         private static async Task<ModifyOngoingTaskResult> SetupReplication(IDocumentStore store, ExternalReplicationBase watcher)
         {
             var result = await store.Maintenance.SendAsync(new PutConnectionStringOperation<RavenConnectionString>(new RavenConnectionString


### PR DESCRIPTION
### Issue link

https://issues.hibernatingrhinos.com/issue/RavenDB-17346

### Additional description

In method `ReadHeaderResponseAndThrowIfUnAuthorized` we're disposing `_interruptibleRead` and creating a new one : https://github.com/ravendb/ravendb/blob/v5.2/src/Raven.Server/Documents/Replication/OutgoingReplicationHandler.cs#L732-#L733

When negotiating with a node that has a *different* replication protocol version, this behaviour will cause an exception to be thrown. 
This is because the nodes will disagree on the protocol version the first time, so we reach `ReadHeaderResponseAndThrowIfUnAuthorized` a second time and call `_interruptibleRead?.Dispose()` - which will dispose the network stream and cause an error when attempting to read from `_interruptibleRead`.

### Type of change

- Bug fix

### How risky is the change?

- Moderate 

### Backward compatibility

- Ensured by testing 

### Testing 

- Tests have been added that prove the fix is effective or that the feature works
- It has been verified by manual testing