### PR TITLE
RavenDB-17405 Fix test connection to Elasticsearch URL

### DIFF
--- a/src/Raven.Studio/typescript/commands/database/cluster/testElasticSearchNodeConnectionCommand.ts
+++ b/src/Raven.Studio/typescript/commands/database/cluster/testElasticSearchNodeConnectionCommand.ts
@@ -1,9 +1,10 @@
 import commandBase = require("commands/commandBase");
 import endpoints = require("endpoints");
+import database = require("models/resources/database");
 
 class testElasticSearchNodeConnectionCommand extends commandBase {
 
-    constructor(private serverUrl: string, private authenticationDto: Raven.Client.Documents.Operations.ETL.ElasticSearch.Authentication) {
+    constructor(private db: database, private serverUrl: string, private authenticationDto: Raven.Client.Documents.Operations.ETL.ElasticSearch.Authentication) {
         super();
     }
 
@@ -15,7 +16,7 @@ class testElasticSearchNodeConnectionCommand extends commandBase {
         const url = endpoints.databases.elasticSearchEtlConnection.adminEtlElasticsearchTestConnection + this.urlEncodeArgs(args);
         const payload = this.authenticationDto;
 
-        return this.post<Raven.Server.Web.System.NodeConnectionTestResult>(url, JSON.stringify(payload), null, { dataType: undefined })
+        return this.post<Raven.Server.Web.System.NodeConnectionTestResult>(url, JSON.stringify(payload), this.db, { dataType: undefined })
             .fail((response: JQueryXHR) => this.reportError(`Failed to test Elasticsearch connection`, response.responseText, response.statusText))
             .done((result: Raven.Server.Web.System.NodeConnectionTestResult) => {
                 if (!result.Success) {

--- a/src/Raven.Studio/typescript/models/database/settings/connectionStringElasticSearchEtlModel.ts
+++ b/src/Raven.Studio/typescript/models/database/settings/connectionStringElasticSearchEtlModel.ts
@@ -305,8 +305,8 @@ class connectionStringElasticSearchEtlModel extends connectionStringModel {
         }
     }
 
-    testConnection(urlToTest: discoveryUrl): JQueryPromise<Raven.Server.Web.System.NodeConnectionTestResult> {
-        return new testElasticSearchNodeConnectionCommand(urlToTest.discoveryUrlName(), this.authentication().toDto())
+    testConnection(db: database, urlToTest: discoveryUrl): JQueryPromise<Raven.Server.Web.System.NodeConnectionTestResult> {
+        return new testElasticSearchNodeConnectionCommand(db, urlToTest.discoveryUrlName(), this.authentication().toDto())
             .execute()
             .done((result) => {
                 if (result.Error) {

--- a/src/Raven.Studio/typescript/viewmodels/database/settings/connectionStrings.ts
+++ b/src/Raven.Studio/typescript/viewmodels/database/settings/connectionStrings.ts
@@ -481,7 +481,7 @@ class connectionStrings extends viewModelBase {
         this.spinners.test(true);
         elasticConnectionString.selectedUrlToTest(urlToTest.discoveryUrlName());
 
-        elasticConnectionString.testConnection(urlToTest)
+        elasticConnectionString.testConnection(this.activeDatabase(), urlToTest)
             .done(result => this.testConnectionResult(result))
             .always(() => {
                 this.spinners.test(false);


### PR DESCRIPTION
### Issue link

https://issues.hibernatingrhinos.com/issue/RavenDB-17405

### Additional description
Fix the test connection for Elasticsearch URL

### Type of change
- Bug fix

### How risky is the change?
- Low 

### Backward compatibility
- Non breaking change

### Is it platform specific issue?
- No

### Documentation update
- No documentation update is needed 

### Testing 
- It has been verified by manual testing

### Is there any existing behavior change of other features due to this change?
- No

### UI work
- No UI work is needed
