### PR TITLE
RavenDB-17402 Can't query collection with multiple single quotes

### DIFF
--- a/src/Raven.Studio/package.json
+++ b/src/Raven.Studio/package.json
@@ -33,7 +33,7 @@
     "gulp-zip": "^5.1.0",
     "natives": "^1.1.6",
     "through2": "^4.0.2",
-    "typescript": "^4.2.4"
+    "typescript": "4.2.4"
   },
   "dependencies": {}
 }

--- a/src/Raven.Studio/typescript/common/queryUtil.ts
+++ b/src/Raven.Studio/typescript/common/queryUtil.ts
@@ -39,7 +39,7 @@ class queryUtil {
     
     private static wrapWithSingleQuotes(input: string) {
         if (input.includes("'")) {
-            input = input.replace("'", "''");
+            input = input.replace(/'/g, "''");
         }
         return "'" + input + "'";
     }


### PR DESCRIPTION
### Issue link
https://issues.hibernatingrhinos.com/issue/RavenDB-17402

### Additional description
1. escape all single quotes
2. fix typescript version in package json

### Type of change
- Bug fix

### How risky is the change?
- Low 

### Backward compatibility
- Non breaking change

### Is it platform specific issue?
- No

### Documentation update
- No documentation update is needed 

### Testing 
- It has been verified by manual testing

### Is there any existing behavior change of other features due to this change?
- No

### UI work
- No UI work is needed
