### PR TITLE
RavenDB-17297  Studio '/' path should return 'Redirect' instead of 'M…

### DIFF
--- a/src/Raven.Server/Web/System/StudioHandler.cs
+++ b/src/Raven.Server/Web/System/StudioHandler.cs
@@ -700,7 +700,7 @@ namespace Raven.Server.Web.System
         public Task RavenRoot()
         {
             HttpContext.Response.Headers["Location"] = "/studio/index.html";
-            HttpContext.Response.StatusCode = (int)HttpStatusCode.MovedPermanently;
+            HttpContext.Response.StatusCode = (int)HttpStatusCode.Redirect;
 
             return Task.CompletedTask;
         }


### PR DESCRIPTION
…ovedPermanently'

### Issue link
https://issues.hibernatingrhinos.com/issue/RavenDB-17297

### Additional description
Return 'Redirect' 302 instead of 'MovedPermanently' 301

### Type of change
- Bug fix

### How risky is the change?
- Low 

### Backward compatibility
- Non breaking change

### Is it platform specific issue?
- No

### Documentation update
- No documentation update is needed 

### Testing 
- It has been verified by manual testing

### Is there any existing behavior change of other features due to this change?
- No

### UI work
- No UI work is needed
