### PR TITLE
RavenDB-17416 - Prevent us from throwing an exception during error handling

### DIFF
--- a/src/Raven.Server/Documents/Indexes/Index.cs
+++ b/src/Raven.Server/Documents/Indexes/Index.cs
@@ -1593,7 +1593,6 @@ namespace Raven.Server.Documents.Indexes
                                        $"going to try flushing and syncing the environment to cleanup the storage. " +
                                        $"Will wait for flush for: {timeToWaitInMilliseconds}ms", dfe);
 
-                storageEnvironment.Options.TryCleanupRecycledJournals();
                 FlushAndSync(storageEnvironment, timeToWaitInMilliseconds, true);
                 return;
             }
@@ -1604,6 +1603,7 @@ namespace Raven.Server.Documents.Indexes
             if (State == IndexState.Error)
                 return;
 
+            storageEnvironment.Options.TryCleanupRecycledJournals();
             SetErrorState($"State was changed due to excessive number of disk full errors ({diskFullErrors}).");
         }
 

--- a/src/Raven.Server/Documents/Indexes/Index.cs
+++ b/src/Raven.Server/Documents/Indexes/Index.cs
@@ -1609,18 +1609,26 @@ namespace Raven.Server.Documents.Indexes
 
         private void FlushAndSync(StorageEnvironment storageEnvironment, int timeToWaitInMilliseconds, bool tryCleanupRecycledJournals)
         {
-            // force flush and sync
-            var sp = Stopwatch.StartNew();
-            GlobalFlushingBehavior.GlobalFlusher.Value.MaybeFlushEnvironment(storageEnvironment);
-            if (_logsAppliedEvent.Wait(timeToWaitInMilliseconds, _indexingProcessCancellationTokenSource.Token))
+            try
             {
-                storageEnvironment.ForceSyncDataFile();
-            }
+                // force flush and sync
+                var sp = Stopwatch.StartNew();
+                GlobalFlushingBehavior.GlobalFlusher.Value.MaybeFlushEnvironment(storageEnvironment);
+                if (_logsAppliedEvent.Wait(timeToWaitInMilliseconds, _indexingProcessCancellationTokenSource.Token))
+                {
+                    storageEnvironment.ForceSyncDataFile();
+                }
 
-            var timeLeft = timeToWaitInMilliseconds - sp.ElapsedMilliseconds;
-            // wait for sync
-            if (timeLeft > 0)
-                Task.Delay((int)timeLeft, _indexingProcessCancellationTokenSource.Token).Wait();
+                var timeLeft = timeToWaitInMilliseconds - sp.ElapsedMilliseconds;
+                // wait for sync
+                if (timeLeft > 0)
+                    Task.Delay((int)timeLeft, _indexingProcessCancellationTokenSource.Token).Wait();
+            }
+            catch (OperationCanceledException)
+            {
+                // index was deleted or database was shutdown
+                return;
+            }
 
             storageEnvironment.Cleanup(tryCleanupRecycledJournals);
         }

--- a/src/Raven.Server/Documents/Indexes/Index.cs
+++ b/src/Raven.Server/Documents/Indexes/Index.cs
@@ -1593,6 +1593,7 @@ namespace Raven.Server.Documents.Indexes
                                        $"going to try flushing and syncing the environment to cleanup the storage. " +
                                        $"Will wait for flush for: {timeToWaitInMilliseconds}ms", dfe);
 
+                storageEnvironment.Options.TryCleanupRecycledJournals();
                 FlushAndSync(storageEnvironment, timeToWaitInMilliseconds, true);
                 return;
             }
@@ -1603,7 +1604,6 @@ namespace Raven.Server.Documents.Indexes
             if (State == IndexState.Error)
                 return;
 
-            storageEnvironment.Options.TryCleanupRecycledJournals();
             SetErrorState($"State was changed due to excessive number of disk full errors ({diskFullErrors}).");
         }
 


### PR DESCRIPTION
### Issue link

https://issues.hibernatingrhinos.com/issue/RavenDB-17416

### Additional description

- Prevent us from throwing an exception during error handling
- Try to cleanup recycled journals when trying to free up space (and not before setting the index to errored state)

### Type of change

- Bug fix

### How risky is the change?

- Low 

### Testing 

- It has been verified by manual testing
