### PR TITLE
RavenDB-17418 Allow JS projection of Time Series values

### DIFF
--- a/src/Raven.Server/Documents/Patch/JavaScriptUtils.cs
+++ b/src/Raven.Server/Documents/Patch/JavaScriptUtils.cs
@@ -1,6 +1,7 @@
 ﻿using System;
 using System.Collections.Generic;
 using System.Diagnostics;
+using System.Linq;
 using System.Runtime.CompilerServices;
 using Jint;
 using Jint.Native;
@@ -14,6 +15,7 @@ using Raven.Server.Documents.Indexes;
 using Raven.Server.Documents.Indexes.Static;
 using Raven.Server.Documents.Indexes.Static.JavaScript;
 using Raven.Server.Documents.Queries.Results;
+using Raven.Server.Documents.Queries.Results.TimeSeries;
 using Sparrow.Json;
 using Sparrow.Json.Parsing;
 
@@ -261,6 +263,17 @@ namespace Raven.Server.Documents.Patch
 
         internal JsValue TranslateToJs(Engine engine, JsonOperationContext context, object o)
         {
+            if (o is TimeSeriesRetriever.TimeSeriesStreamingRetrieverResult tsrr)
+            {
+				// we are passing a streaming value to the JS engine, so we need
+				// to materalize all the results                var results = new DynamicJsonArray(tsrr.Stream);
+                var djv = new DynamicJsonValue
+                {
+                    ["Count"] = results.Count,
+                    ["Results"] = results
+                };
+                return new BlittableObjectInstance(engine, null, context.ReadObject(djv, "MaterializedStreamResults"), null, null, null);
+            }
             if (o is Tuple<Document, Lucene.Net.Documents.Document, IState, Dictionary<string, IndexField>, bool?, ProjectionOptions> t)
             {
                 var d = t.Item1;

--- a/src/Raven.Server/Documents/Patch/JavaScriptUtils.cs
+++ b/src/Raven.Server/Documents/Patch/JavaScriptUtils.cs
@@ -268,6 +268,7 @@ namespace Raven.Server.Documents.Patch
 				// we are passing a streaming value to the JS engine, so we need
 				// to materalize all the results
                 
+                
                 var results = new DynamicJsonArray(tsrr.Stream);
                 var djv = new DynamicJsonValue
                 {

--- a/src/Raven.Server/Documents/Patch/JavaScriptUtils.cs
+++ b/src/Raven.Server/Documents/Patch/JavaScriptUtils.cs
@@ -11,6 +11,7 @@ using Jint.Runtime;
 using Lucene.Net.Store;
 using Raven.Client;
 using Raven.Client.Documents.Operations.Attachments;
+using Raven.Client.Documents.Queries.TimeSeries;
 using Raven.Server.Documents.Indexes;
 using Raven.Server.Documents.Indexes.Static;
 using Raven.Server.Documents.Indexes.Static.JavaScript;
@@ -266,14 +267,14 @@ namespace Raven.Server.Documents.Patch
             if (o is TimeSeriesRetriever.TimeSeriesStreamingRetrieverResult tsrr)
             {
 				// we are passing a streaming value to the JS engine, so we need
-				// to materalize all the results
+				// to materialize all the results
                 
                 
                 var results = new DynamicJsonArray(tsrr.Stream);
                 var djv = new DynamicJsonValue
                 {
-                    ["Count"] = results.Count,
-                    ["Results"] = results
+                    [nameof(TimeSeriesAggregationResult.Count)] = results.Count,
+                    [nameof(TimeSeriesAggregationResult.Results)] = results
                 };
                 return new BlittableObjectInstance(engine, null, context.ReadObject(djv, "MaterializedStreamResults"), null, null, null);
             }

--- a/src/Raven.Server/Documents/Patch/JavaScriptUtils.cs
+++ b/src/Raven.Server/Documents/Patch/JavaScriptUtils.cs
@@ -266,7 +266,9 @@ namespace Raven.Server.Documents.Patch
             if (o is TimeSeriesRetriever.TimeSeriesStreamingRetrieverResult tsrr)
             {
 				// we are passing a streaming value to the JS engine, so we need
-				// to materalize all the results                var results = new DynamicJsonArray(tsrr.Stream);
+				// to materalize all the results
+                
+                var results = new DynamicJsonArray(tsrr.Stream);
                 var djv = new DynamicJsonValue
                 {
                     ["Count"] = results.Count,

--- a/src/Raven.Server/Documents/Queries/Results/QueryResultRetrieverBase.cs
+++ b/src/Raven.Server/Documents/Queries/Results/QueryResultRetrieverBase.cs
@@ -287,7 +287,7 @@ namespace Raven.Server.Documents.Queries.Results
                 key.StartsWith(Constants.TimeSeries.QueryFunction))
             {
                 doc.TimeSeriesStream ??= new TimeSeriesStream();
-                var value = (TimeSeriesRetriever.TimeSeriesRetrieverResult)fieldVal;
+                var value = (TimeSeriesRetriever.TimeSeriesStreamingRetrieverResult)fieldVal;
                 doc.TimeSeriesStream.TimeSeries = value.Stream;
                 doc.TimeSeriesStream.Key = key;
                 Json.BlittableJsonTextWriterExtensions.MergeMetadata(result, value.Metadata);
@@ -327,7 +327,7 @@ namespace Raven.Server.Documents.Queries.Results
                 case Document d:
                     return d;
 
-                case TimeSeriesRetriever.TimeSeriesRetrieverResult ts:
+                case TimeSeriesRetriever.TimeSeriesStreamingRetrieverResult ts:
                     return new Document
                     {
                         Id = doc.Id,

--- a/src/Raven.Server/Documents/Queries/Results/TimeSeries/TimeSeriesRetriever.cs
+++ b/src/Raven.Server/Documents/Queries/Results/TimeSeries/TimeSeriesRetriever.cs
@@ -905,15 +905,15 @@ namespace Raven.Server.Documents.Queries.Results.TimeSeries
             return _context.ReadObject(result, "timeseries/value");
         }
 
-        public class TimeSeriesRetrieverResult
+        public class TimeSeriesStreamingRetrieverResult
         {
             public IEnumerable<DynamicJsonValue> Stream;
             public DynamicJsonValue Metadata;
         }
 
-        public TimeSeriesRetrieverResult PrepareForStreaming(IEnumerable<DynamicJsonValue> array, bool addProjectionToResult, bool fromStudio)
+        public TimeSeriesStreamingRetrieverResult PrepareForStreaming(IEnumerable<DynamicJsonValue> array, bool addProjectionToResult, bool fromStudio)
         {
-            var result = new TimeSeriesRetrieverResult
+            var result = new TimeSeriesStreamingRetrieverResult
             {
                 Stream = array,
                 Metadata = new DynamicJsonValue()

--- a/test/SlowTests/Issues/RavenDB-17418.cs
+++ b/test/SlowTests/Issues/RavenDB-17418.cs
@@ -1,0 +1,111 @@
+﻿using System;
+using System.Collections.Generic;
+using FastTests;
+using Xunit;
+using Xunit.Abstractions;
+
+namespace SlowTests.Issues
+{
+    public class RavenDB_17418 : RavenTestBase
+    {
+        private class MyTimeSeriesResult
+        {
+            public int Count { get; set; }
+            public Dictionary<string, double> Results { get; set; }
+        }
+
+        private class Label
+        {
+            public string Name;
+            public string LabelId;
+        }
+        
+        private class Subject
+        {
+            public Label[] Labels;
+        }
+
+        
+        public RavenDB_17418(ITestOutputHelper output) : base(output)
+        {
+        }
+
+        [Fact]
+        public void CanStreamTimeSeriesProjection()
+        {
+            using var store = GetDocumentStore();
+            var startDate =  DateTime.Today;
+
+            using (var s = store.OpenSession())
+            {
+                Subject subject = new Subject
+                {
+                    Labels = new[]
+                    {
+                        new Label{Name = "Active", LabelId = "labels/1"},
+                        new Label{Name = "Running", LabelId = "labels/2"}
+
+                    }
+                };
+                s.Store(subject);
+                for (int i = 0; i < 100; i++)
+                {
+                    s.TimeSeriesFor(subject, "Welliba").Append(startDate.AddHours(i), i);
+                }
+                s.SaveChanges();
+            }
+
+            using (var session = store.OpenSession())
+            {
+                
+                var endDate = startDate.AddMonths(1);
+
+                var query = session.Advanced.RawQuery<MyTimeSeriesResult>(@"
+                declare timeseries welliba(o)
+                {
+                    from o.Welliba between $start and $end
+                    group by '1 days'
+                    select avg()
+                }
+
+                declare function strip(ts)
+                {
+                    var n  = {};
+                    var len = ts.Results.length;
+                    for(var i = 0 ; i < len; i++){
+                        n[ts.Results[i].From] = ts.Results[i].Average[0];
+                    }
+                    ts.Results = n;
+                    return ts;
+                }
+                from Subjects as s
+                where s.Labels[].LabelId all in ($l1, $l2)
+                select strip(welliba(s))
+            ")
+                    .AddParameter("start", startDate)
+                    .AddParameter("end", endDate)
+                    .AddParameter("l1", "labels/1")
+                    .AddParameter("l2", "labels/2");
+                // this works
+                List<MyTimeSeriesResult> timeSeriesResults = query.ToList();
+                Assert.NotEmpty(timeSeriesResults);
+                MyTimeSeriesResult firstResult = timeSeriesResults[0];
+                
+                WaitForUserToContinueTheTest(store);
+            
+                // this not
+                bool hasResults = false;
+                using (var docStream = session.Advanced.Stream(query))
+                {
+                    // throws exception here while calling MoveNext()
+                    while (docStream.MoveNext())
+                    {
+                        var document = docStream.Current;
+                        hasResults = true;
+                    }
+                }
+                Assert.True(hasResults);
+            }
+        }
+    }
+}


### PR DESCRIPTION
### Issue link

https://issues.hibernatingrhinos.com/issue/RavenDB-17418

### Additional description

When streaming results, we are using a dedicated code path to stream large results of time series values.
However, when we want to pass timeseries values to JS function to process internally, we need to materialize the value.

This PR teach the `TranslateJS` function how to do so.

_Please delete below the options that are not relevant_

### Type of change

- Bug fix

### How risky is the change?

- Low 

### Backward compatibility

- Non breaking change

Adding a new feature

### Is it platform specific issue?

- No

### Documentation update

- No documentation update is needed 

### Testing 

- Tests have been added that prove the fix is effective or that the feature works

### Is there any existing behavior change of other features due to this change?

- No

### UI work

- No UI work is needed
