### PR TITLE
RavenDB-17420 Allow to define boost on in queries

### DIFF
--- a/src/Raven.Server/Documents/Queries/LuceneIntegration/InQuery.cs
+++ b/src/Raven.Server/Documents/Queries/LuceneIntegration/InQuery.cs
@@ -66,12 +66,13 @@ namespace Raven.Server.Documents.Queries.LuceneIntegration
         {
             private readonly InQuery _parent;
             private readonly Searcher _searcher;
-            private float _queryWeight = 1.0f;
+            private float _queryWeight;
 
             public InQueryWeight(InQuery parent, Searcher searcher)
             {
                 _parent = parent;
                 _searcher = searcher;
+                _queryWeight = parent.Boost;
             }
             public override Lucene.Net.Search.Explanation Explain(IndexReader reader, int doc, IState state)
             {

--- a/test/SlowTests/Issues/RavenDB-17420.cs
+++ b/test/SlowTests/Issues/RavenDB-17420.cs
@@ -1,0 +1,43 @@
+﻿using System.Diagnostics;
+using System.Linq;
+using FastTests;
+using Raven.Client.Documents.Linq;
+using Raven.Client.Documents.Linq.Indexing;
+using Xunit;
+using Xunit.Abstractions;
+
+namespace SlowTests.Issues
+{
+    public class RavenDB_17420 : RavenTestBase
+    {
+        public RavenDB_17420(ITestOutputHelper output) : base(output)
+        {
+        }
+
+        private class Item
+        {
+            public string Name;
+        }
+        
+        [Fact]
+        public void Can_use_boost_on_in_query()
+        {
+            using var store = GetDocumentStore();
+
+            using (var s = store.OpenSession())
+            {
+                s.Store(new Item{Name = "ET"});
+                s.SaveChanges();
+            }
+
+            using (var s = store.OpenSession())
+            {
+                Item first = s.Advanced. DocumentQuery<Item>()
+                    .WhereIn(x=>x.Name, new[]{"ET", "Alien"}).Boost(0)
+                    .First();
+
+                Assert.Equal(0, s.Advanced.GetMetadataFor(first).GetDouble("@index-score"));
+            }
+        }
+    }
+}


### PR DESCRIPTION
### Issue link

https://issues.hibernatingrhinos.com/issue/RavenDB-RavenDB-17420

### Additional description

Pass the boost value to `in` queries, rather than compute them statically. 

### Type of change

- Bug fix
- 
### How risky is the change?

- Low 

### Backward compatibility

- Non breaking change

### Is it platform specific issue?

- No

### Documentation update

- No documentation update is needed 

### Testing 

- Tests have been added that prove the fix is effective or that the feature works

### Is there any existing behavior change of other features due to this change?

- No

### UI work

- No UI work is needed
