### PR TITLE
RavenDB-16371 introduced IndexStartupBehavior

### DIFF
--- a/src/Raven.Server/Config/Categories/IndexingConfiguration.cs
+++ b/src/Raven.Server/Config/Categories/IndexingConfiguration.cs
@@ -217,10 +217,16 @@ namespace Raven.Server.Config.Categories
         public bool IndexEmptyEntries { get; set; }
 
         [Description("Indicates how error indexes should behave on database startup when they are loaded. By default they are not started.")]
-        [DefaultValue(IndexStartupBehavior.Default)]
+        [DefaultValue(ErrorIndexStartupBehaviorType.Default)]
         [IndexUpdateType(IndexUpdateType.None)]
         [ConfigurationEntry("Indexing.ErrorIndexStartupBehavior", ConfigurationEntryScope.ServerWideOrPerDatabase)]
-        public IndexStartupBehavior ErrorIndexStartupBehavior { get; set; }
+        public ErrorIndexStartupBehaviorType ErrorIndexStartupBehavior { get; set; }
+
+        [Description("Indicates how indexes should behave on database startup when they are loaded. By default they are started immediately.")]
+        [DefaultValue(IndexStartupBehaviorType.Default)]
+        [IndexUpdateType(IndexUpdateType.None)]
+        [ConfigurationEntry("Indexing.IndexStartupBehavior", ConfigurationEntryScope.ServerWideOrPerDatabase)]
+        public IndexStartupBehaviorType IndexStartupBehavior { get; set; }
 
         [Description("Limits the number of concurrently running and processing indexes on the server. Default: null (no limit)")]
         [DefaultValue(null)]
@@ -242,11 +248,19 @@ namespace Raven.Server.Config.Categories
                 throw new InvalidOperationException($"No {nameof(IndexUpdateTypeAttribute)} available for '{property.Name}' property.");
         }
 
-        public enum IndexStartupBehavior
+        public enum ErrorIndexStartupBehaviorType
         {
             Default,
             Start,
             ResetAndStart
+        }
+
+        public enum IndexStartupBehaviorType
+        {
+            Default,
+            Immediate,
+            Pause,
+            Delay
         }
     }
 }

--- a/src/Raven.Server/Documents/DatabasesLandlord.cs
+++ b/src/Raven.Server/Documents/DatabasesLandlord.cs
@@ -78,6 +78,7 @@ namespace Raven.Server.Documents
             internal Action<ServerStore> BeforeHandleClusterDatabaseChanged;
             internal int? HoldDocumentDatabaseCreation = null;
             internal bool PreventedRehabOfIdleDatabase = false;
+            internal Action<DocumentDatabase> OnBeforeDocumentDatabaseInitialization;
         }
 
         private async Task HandleClusterDatabaseChanged(string databaseName, long index, string type, ClusterDatabaseChangeType changeType)
@@ -753,6 +754,8 @@ namespace Raven.Server.Documents
 
                 if (ForTestingPurposes?.HoldDocumentDatabaseCreation != null)
                     Thread.Sleep(ForTestingPurposes.HoldDocumentDatabaseCreation.Value);
+
+                ForTestingPurposes?.OnBeforeDocumentDatabaseInitialization?.Invoke(documentDatabase);
 
                 documentDatabase.Initialize(InitializeOptions.None, wakeup);
 

--- a/src/Raven.Server/Documents/Indexes/IndexStore.cs
+++ b/src/Raven.Server/Documents/Indexes/IndexStore.cs
@@ -83,7 +83,7 @@ namespace Raven.Server.Documents.Indexes
             StoppedConcurrentIndexBatches = new SemaphoreSlim(stoppedConcurrentIndexBatches);
         }
 
-        public int HandleDatabaseRecordChange(DatabaseRecord record, long raftIndex)
+        public int HandleDatabaseRecordChange(DatabaseRecord record, long raftIndex, bool startIndexes = true)
         {
             if (record == null)
                 return 0;
@@ -104,47 +104,50 @@ namespace Raven.Server.Documents.Indexes
 
                 indexesToDelete = new ConcurrentSet<Index>();
 
-                var sp = Stopwatch.StartNew();
-
-                if (Logger.IsInfoEnabled)
-                    Logger.Info($"Starting {newIndexesToStart.Count} new index{(newIndexesToStart.Count > 1 ? "es" : string.Empty)}");
-
-                ExecuteForIndexes(newIndexesToStart, index =>
+                if (startIndexes)
                 {
-                    var indexLock = GetIndexLock(index.Name);
+                    var sp = Stopwatch.StartNew();
 
-                    try
-                    {
-                        indexLock.Wait(_documentDatabase.DatabaseShutdown);
-                    }
-                    catch (OperationCanceledException e)
-                    {
-                        AddToIndexesToDelete(index);
+                    if (Logger.IsInfoEnabled)
+                        Logger.Info($"Starting {newIndexesToStart.Count} new index{(newIndexesToStart.Count > 1 ? "es" : string.Empty)}");
 
-                        _documentDatabase.RachisLogIndexNotifications.NotifyListenersAbout(raftIndex, e);
-                        return;
-                    }
-
-                    try
+                    ExecuteForIndexes(newIndexesToStart, index =>
                     {
-                        StartIndex(index);
-                    }
-                    catch (Exception e)
-                    {
-                        AddToIndexesToDelete(index);
+                        var indexLock = GetIndexLock(index.Name);
 
-                        _documentDatabase.RachisLogIndexNotifications.NotifyListenersAbout(raftIndex, e);
-                        if (Logger.IsInfoEnabled)
-                            Logger.Info($"Could not start index `{index.Name}`", e);
-                    }
-                    finally
-                    {
-                        indexLock.Release();
-                    }
-                });
+                        try
+                        {
+                            indexLock.Wait(_documentDatabase.DatabaseShutdown);
+                        }
+                        catch (OperationCanceledException e)
+                        {
+                            AddToIndexesToDelete(index);
 
-                if (Logger.IsInfoEnabled)
-                    Logger.Info($"Started {newIndexesToStart.Count} new index{(newIndexesToStart.Count > 1 ? "es" : string.Empty)}, took: {sp.ElapsedMilliseconds}ms");
+                            _documentDatabase.RachisLogIndexNotifications.NotifyListenersAbout(raftIndex, e);
+                            return;
+                        }
+
+                        try
+                        {
+                            StartIndex(index);
+                        }
+                        catch (Exception e)
+                        {
+                            AddToIndexesToDelete(index);
+
+                            _documentDatabase.RachisLogIndexNotifications.NotifyListenersAbout(raftIndex, e);
+                            if (Logger.IsInfoEnabled)
+                                Logger.Info($"Could not start index '{index.Name}'", e);
+                        }
+                        finally
+                        {
+                            indexLock.Release();
+                        }
+                    });
+
+                    if (Logger.IsInfoEnabled)
+                        Logger.Info($"Started {newIndexesToStart.Count} new index{(newIndexesToStart.Count > 1 ? "es" : string.Empty)}, took: {sp.ElapsedMilliseconds}ms");
+                }
 
                 var numberOfIndexesToDelete = HandleIndexesToDelete();
 
@@ -1207,7 +1210,7 @@ namespace Raven.Server.Documents.Indexes
             exceptionAggregator.ThrowIfNeeded();
         }
 
-        private Index ResetIndexInternal(Index index)
+        private Index ResetIndexInternal(Index index, bool start = true)
         {
             using (IndexLock(index.Name))
             {
@@ -1250,7 +1253,8 @@ namespace Raven.Server.Documents.Indexes
                         }
                     }
 
-                    StartIndex(index);
+                    if (start)
+                        StartIndex(index);
 
                     return index;
                 }
@@ -1278,6 +1282,15 @@ namespace Raven.Server.Documents.Indexes
 
             var totalSp = Stopwatch.StartNew();
 
+            bool startIndex = false;
+            switch (_documentDatabase.Configuration.Indexing.IndexStartupBehavior)
+            {
+                case IndexingConfiguration.IndexStartupBehaviorType.Default:
+                case IndexingConfiguration.IndexStartupBehaviorType.Immediate:
+                    startIndex = true;
+                    break;
+            }
+
             foreach (var kvp in record.Indexes)
             {
                 if (_documentDatabase.DatabaseShutdown.IsCancellationRequested)
@@ -1293,7 +1306,7 @@ namespace Raven.Server.Documents.Indexes
                     var sp = Stopwatch.StartNew();
 
                     addToInitLog($"Initializing static index: `{name}`");
-                    OpenIndex(path, indexPath, exceptions, name, staticIndexDefinition: definition, autoIndexDefinition: null);
+                    OpenIndex(path, indexPath, exceptions, name, startIndex, staticIndexDefinition: definition, autoIndexDefinition: null);
 
                     if (Logger.IsInfoEnabled)
                         Logger.Info($"Initialized static index: `{name}`, took: {sp.ElapsedMilliseconds:#,#;;0}ms");
@@ -1315,18 +1328,45 @@ namespace Raven.Server.Documents.Indexes
                     var sp = Stopwatch.StartNew();
 
                     addToInitLog($"Initializing auto index: `{name}`");
-                    OpenIndex(path, indexPath, exceptions, name, staticIndexDefinition: null, autoIndexDefinition: definition);
+                    OpenIndex(path, indexPath, exceptions, name, startIndex, staticIndexDefinition: null, autoIndexDefinition: definition);
 
                     if (Logger.IsInfoEnabled)
                         Logger.Info($"Initialized auto index: `{name}`, took: {sp.ElapsedMilliseconds:#,#;;0}ms");
                 }
             }
 
+            ForTestingPurposesOnly().AfterIndexesOpen?.Invoke();
+
+            switch (_documentDatabase.Configuration.Indexing.IndexStartupBehavior)
+            {
+                case IndexingConfiguration.IndexStartupBehaviorType.Delay:
+
+                    ExecuteForIndexes(GetIndexes(), index =>
+                    {
+                        try
+                        {
+                            switch (index.Status)
+                            {
+                                case IndexRunningStatus.Paused:
+                                    index.Start();
+                                    break;
+                            }
+                        }
+                        catch (Exception e)
+                        {
+                            addToInitLog($"Could not start index '{index.Name}': {e}");
+                        }
+                    });
+
+                    break;
+            }
+
             // loading the new indexes
             var startIndexSp = Stopwatch.StartNew();
 
             addToInitLog("Starting new indexes");
-            var startedIndexes = HandleDatabaseRecordChange(record, raftIndex);
+            startIndex = _documentDatabase.Configuration.Indexing.IndexStartupBehavior != IndexingConfiguration.IndexStartupBehaviorType.Pause;
+            var startedIndexes = HandleDatabaseRecordChange(record, raftIndex, startIndex);
             addToInitLog($"Started {startedIndexes} new index{(startedIndexes > 1 ? "es" : string.Empty)}, took: {startIndexSp.ElapsedMilliseconds}ms");
 
             addToInitLog($"IndexStore initialization is completed, took: {totalSp.ElapsedMilliseconds:#,#;;0}ms");
@@ -1344,7 +1384,7 @@ namespace Raven.Server.Documents.Indexes
             var indexPath = path.Combine(safeName).FullPath;
             var exceptions = new List<Exception>();
 
-            OpenIndex(path, indexPath, exceptions, index.Name, index.GetIndexDefinition(), null);
+            OpenIndex(path, indexPath, exceptions, index.Name, startIndex: true, index.GetIndexDefinition(), null);
 
             if (exceptions.Count > 0)
             {
@@ -1360,7 +1400,7 @@ namespace Raven.Server.Documents.Indexes
                 });
         }
 
-        private void OpenIndex(PathSetting path, string indexPath, List<Exception> exceptions, string name, IndexDefinition staticIndexDefinition, AutoIndexDefinition autoIndexDefinition)
+        private void OpenIndex(PathSetting path, string indexPath, List<Exception> exceptions, string name, bool startIndex, IndexDefinition staticIndexDefinition, AutoIndexDefinition autoIndexDefinition)
         {
             Index index = null;
 
@@ -1391,18 +1431,17 @@ namespace Raven.Server.Documents.Indexes
                     UpdateStaticIndexLockModeAndPriority(staticIndexDefinition, index, differences);
                 }
 
-                var startIndex = true;
                 if (index.State == IndexState.Error)
                 {
                     switch (_documentDatabase.Configuration.Indexing.ErrorIndexStartupBehavior)
                     {
-                        case IndexingConfiguration.IndexStartupBehavior.Start:
+                        case IndexingConfiguration.ErrorIndexStartupBehaviorType.Start:
                             index.SetState(IndexState.Normal);
                             break;
 
-                        case IndexingConfiguration.IndexStartupBehavior.ResetAndStart:
-                            index = ResetIndexInternal(index);
-                            startIndex = false; // reset already starts the index
+                        case IndexingConfiguration.ErrorIndexStartupBehaviorType.ResetAndStart:
+                            index = ResetIndexInternal(index, startIndex);
+                            startIndex = false; // reset will start the index if requested
                             break;
                     }
                 }
@@ -2017,6 +2056,7 @@ namespace Raven.Server.Documents.Indexes
             private readonly IndexStore _parent;
             internal Action DuringIndexReplacement_AfterUpdatingCollectionOfIndexes;
             internal Action DuringIndexReplacement_OnOldIndexDeletion;
+            internal Action AfterIndexesOpen;
             internal Action<string> AfterIndexCreation;
 
             public TestingStuff(IndexStore parent)

--- a/test/SlowTests/Issues/RavenDB_14641.cs
+++ b/test/SlowTests/Issues/RavenDB_14641.cs
@@ -23,12 +23,12 @@ namespace SlowTests.Issues
         {
             var path = NewDataPath();
 
-            using (var store = GetDocumentStore(new Options { Path = path, ModifyDatabaseRecord = record => record.Settings[RavenConfiguration.GetKey(x => x.Indexing.ErrorIndexStartupBehavior)] = IndexingConfiguration.IndexStartupBehavior.Start.ToString() }))
+            using (var store = GetDocumentStore(new Options { Path = path, ModifyDatabaseRecord = record => record.Settings[RavenConfiguration.GetKey(x => x.Indexing.ErrorIndexStartupBehavior)] = IndexingConfiguration.ErrorIndexStartupBehaviorType.Start.ToString() }))
             {
                 await IndexStartupBehaviorTestInternal(store);
             }
 
-            using (var store = GetDocumentStore(new Options { Path = path, ModifyDatabaseRecord = record => record.Settings[RavenConfiguration.GetKey(x => x.Indexing.ErrorIndexStartupBehavior)] = IndexingConfiguration.IndexStartupBehavior.ResetAndStart.ToString() }))
+            using (var store = GetDocumentStore(new Options { Path = path, ModifyDatabaseRecord = record => record.Settings[RavenConfiguration.GetKey(x => x.Indexing.ErrorIndexStartupBehavior)] = IndexingConfiguration.ErrorIndexStartupBehaviorType.ResetAndStart.ToString() }))
             {
                 await IndexStartupBehaviorTestInternal(store);
             }

--- a/test/SlowTests/Issues/RavenDB_16371.cs
+++ b/test/SlowTests/Issues/RavenDB_16371.cs
@@ -1,0 +1,98 @@
+﻿using System;
+using FastTests;
+using Orders;
+using Raven.Server.Config;
+using Raven.Server.Config.Categories;
+using System.Linq;
+using System.Threading;
+using Raven.Client.Documents.Indexes;
+using Raven.Client.Documents.Operations.Indexes;
+using SlowTests.Core.Utils.Indexes;
+using Xunit;
+using Xunit.Abstractions;
+
+namespace SlowTests.Issues
+{
+    public class RavenDB_16371 : RavenTestBase
+    {
+        public RavenDB_16371(ITestOutputHelper output) : base(output)
+        {
+        }
+
+        [Theory]
+        [InlineData(IndexingConfiguration.IndexStartupBehaviorType.Default)]
+        [InlineData(IndexingConfiguration.IndexStartupBehaviorType.Delay)]
+        [InlineData(IndexingConfiguration.IndexStartupBehaviorType.Immediate)]
+        [InlineData(IndexingConfiguration.IndexStartupBehaviorType.Pause)]
+        public void IndexStartupBehaviorType_Should_Work_Correctly(IndexingConfiguration.IndexStartupBehaviorType type)
+        {
+            DoNotReuseServer();
+
+            using (var store = GetDocumentStore(new Options
+            {
+                RunInMemory = false,
+                ModifyDatabaseRecord = r => r.Settings[RavenConfiguration.GetKey(x => x.Indexing.IndexStartupBehavior)] = type.ToString()
+            }))
+            {
+                string autoIndexName;
+                using (var session = store.OpenSession())
+                {
+                    session.Query<Company>()
+                        .Statistics(out var stats)
+                        .Where(x => x.Name == "HR")
+                        .ToList(); // create auto-index
+
+                    autoIndexName = stats.IndexName;
+                }
+
+                var index = new Companies_CompanyByType();
+                index.Execute(store);
+                var staticIndexName = index.IndexName;
+
+                // IndexStartupBehaviorType should not affect newly created indexes
+                var indexStats = store.Maintenance.Send(new GetIndexStatisticsOperation(autoIndexName));
+                Assert.Equal(IndexRunningStatus.Running, indexStats.Status);
+
+                indexStats = store.Maintenance.Send(new GetIndexStatisticsOperation(staticIndexName));
+                Assert.Equal(IndexRunningStatus.Running, indexStats.Status);
+
+                Server.ServerStore.DatabasesLandlord.UnloadDirectly(store.Database);
+
+                if (type == IndexingConfiguration.IndexStartupBehaviorType.Delay)
+                {
+                    Server.ServerStore.DatabasesLandlord.ForTestingPurposesOnly().OnBeforeDocumentDatabaseInitialization = database =>
+                    {
+                        database.IndexStore.ForTestingPurposesOnly().AfterIndexesOpen = () =>
+                        {
+                            foreach (var index in database.IndexStore.GetIndexes())
+                                Assert.Equal(IndexRunningStatus.Paused, index.Status);
+                        };
+                    };
+                }
+
+                IndexRunningStatus expectedStatus;
+                switch (type)
+                {
+                    case IndexingConfiguration.IndexStartupBehaviorType.Default:
+                    case IndexingConfiguration.IndexStartupBehaviorType.Immediate:
+                    case IndexingConfiguration.IndexStartupBehaviorType.Delay:
+                        expectedStatus = IndexRunningStatus.Running;
+                        break;
+                    case IndexingConfiguration.IndexStartupBehaviorType.Pause:
+                        expectedStatus = IndexRunningStatus.Paused;
+                        break;
+                    default:
+                        throw new ArgumentOutOfRangeException(nameof(type), type, null);
+                }
+
+                Server.ServerStore.DatabasesLandlord.TryGetOrCreateResourceStore(store.Database); // start loading the database
+
+                indexStats = store.Maintenance.Send(new GetIndexStatisticsOperation(autoIndexName));
+                Assert.Equal(expectedStatus, indexStats.Status);
+
+                indexStats = store.Maintenance.Send(new GetIndexStatisticsOperation(staticIndexName));
+                Assert.Equal(expectedStatus, indexStats.Status);
+            }
+        }
+    }
+}


### PR DESCRIPTION
### Issue link

https://issues.hibernatingrhinos.com/issue/RavenDB-16371
https://issues.hibernatingrhinos.com/issue/RavenDB-16024

### Additional description

Added the ability to manipulate index startup behavior on database load with following options:
- Default (Immediate)
- Immediate (Start as soon as index is opened)
- Pause (Opens the index, but does not start it)
- Delay (Opens all of the indexes, then starts them)

### Type of change

- New feature
### How risky is the change?

- Moderate 

### Backward compatibility

- Non breaking change

### Is it platform specific issue?

- No

### Documentation update

- This change requires a documentation update. Please mark the issue on YouTrack using `Documentation Required` tag.

### Testing 

- Tests have been added that prove the fix is effective or that the feature works

### Is there any existing behavior change of other features due to this change?

- No

### UI work

- No UI work is needed
