### PR TITLE
RavenDB-16757 Include quotes in field name in indexing - WIP

### DIFF
--- a/src/Raven.Server/Documents/Indexes/Index.cs
+++ b/src/Raven.Server/Documents/Indexes/Index.cs
@@ -3103,7 +3103,7 @@ namespace Raven.Server.Documents.Indexes
         {
             foreach (var field in metadata.IndexFieldNames)
             {
-                AssertKnownField(field);
+                AssertKnownField(field.OriginalName ?? field.Value);
             }
 
             if (metadata.OrderBy != null)

--- a/src/Raven.Server/Documents/Indexes/IndexDefinitionBase.cs
+++ b/src/Raven.Server/Documents/Indexes/IndexDefinitionBase.cs
@@ -128,13 +128,18 @@ namespace Raven.Server.Documents.Indexes
 
             foreach (var field in mapFields)
             {
-                MapFields.Add(field.Name, field);
-
+                string fieldName = field.Name; 
+                if(field is AutoIndexField aif)
+                {
+                    fieldName = aif.OriginalName;
+                }
+                MapFields.Add(fieldName, field);
+                
                 if (field is AutoIndexField autoField)
                 {
                     foreach (var indexField in autoField.ToIndexFields())
                     {
-                        IndexFields.Add(indexField.Name, indexField);
+                        IndexFields.Add(indexField.OriginalName, indexField);
                     }
                 }
                 else if (field is IndexField indexField)

--- a/src/Raven.Server/Documents/Indexes/IndexField.cs
+++ b/src/Raven.Server/Documents/Indexes/IndexField.cs
@@ -145,6 +145,8 @@ namespace Raven.Server.Documents.Indexes
 
         public bool HasQuotedName { get; set; }
 
+        public string OriginalName => HasQuotedName ? $"'{Name}'" : Name;
+
         public AutoFieldIndexing Indexing { get; set; }
 
         public AutoSpatialOptions Spatial { get; set; }
@@ -202,7 +204,7 @@ namespace Raven.Server.Documents.Indexes
             {
                 Indexing = FieldIndexing.Default,
                 Name = Name,
-                OriginalName = HasQuotedName ? originalName : null,
+                OriginalName = originalName,
                 Storage = Storage,
                 HasSuggestions = HasSuggestions
             });

--- a/src/Raven.Server/Documents/Indexes/IndexStore.cs
+++ b/src/Raven.Server/Documents/Indexes/IndexStore.cs
@@ -300,7 +300,10 @@ namespace Raven.Server.Documents.Indexes
                 .MapFields
                 .Select(x =>
                 {
-                    var field = AutoIndexField.Create(x.Key, x.Value);
+                    var key = x.Key;
+                    if (key.Length >= 3 && x.Value.IsNameQuoted && key.First() == '\'' && key.Last() == '\'')
+                        key = x.Key[1..(key.Length - 1)];
+                    var field = AutoIndexField.Create(key, x.Value);
 
                     Debug.Assert(x.Value.GroupByArrayBehavior == GroupByArrayBehavior.NotApplicable);
 

--- a/src/Raven.Server/Documents/Indexes/Persistence/Lucene/Documents/LuceneDocumentConverterBase.cs
+++ b/src/Raven.Server/Documents/Indexes/Persistence/Lucene/Documents/LuceneDocumentConverterBase.cs
@@ -88,7 +88,7 @@ namespace Raven.Server.Documents.Indexes.Persistence.Lucene.Documents
         {
             var dictionary = new Dictionary<string, IndexField>(fields.Count, default(OrdinalStringStructComparer));
             foreach (var field in fields)
-                dictionary[field.Name] = field;
+                dictionary[field.OriginalName ?? field.Name] = field;
             _fields = dictionary;
 
             _indexImplicitNull = indexImplicitNull;
@@ -134,7 +134,7 @@ namespace Raven.Server.Documents.Indexes.Persistence.Lucene.Documents
         /// </summary>
         public int GetRegularFields<T>(T instance, IndexField field, object value, JsonOperationContext indexContext, out bool shouldSkip, bool nestedArray = false) where T : ILuceneDocumentWrapper
         {
-            var path = field.Name;
+            var path = field.OriginalName ?? field.Name;
 
             var valueType = GetValueType(value);
 

--- a/src/Raven.Server/Documents/Indexes/Persistence/Lucene/LuceneIndexPersistence.cs
+++ b/src/Raven.Server/Documents/Indexes/Persistence/Lucene/LuceneIndexPersistence.cs
@@ -122,7 +122,7 @@ namespace Raven.Server.Documents.Indexes.Persistence.Lucene
                     throw new NotSupportedException(_index.Type.ToString());
             }
 
-            _fields = fields.ToDictionary(x => x.Name, x => x);
+            _fields = fields.ToDictionary(x => x.OriginalName ?? x.Name, x => x);
 
             _indexSearcherHolder = new IndexSearcherHolder(CreateIndexSearcher, _index._indexStorage.DocumentDatabase);
 
@@ -131,7 +131,7 @@ namespace Raven.Server.Documents.Indexes.Persistence.Lucene
                 if (!field.Value.HasSuggestions)
                     continue;
 
-                string fieldName = field.Key;
+                string fieldName = field.Value.Name;
                 _suggestionsIndexSearcherHolders[fieldName] = new IndexSearcherHolder(state => new IndexSearcher(_suggestionsDirectories[fieldName], true, state), _index._indexStorage.DocumentDatabase);
             }
 

--- a/src/Raven.Server/Documents/Queries/Dynamic/DynamicQueryToIndexMatcher.cs
+++ b/src/Raven.Server/Documents/Queries/Dynamic/DynamicQueryToIndexMatcher.cs
@@ -204,7 +204,7 @@ namespace Raven.Server.Documents.Queries.Dynamic
 
             foreach (var field in query.MapFields.Values)
             {
-                if (definition.TryGetField(field.Name, out var indexField))
+                if (definition.TryGetField(field.Name.OriginalName, out var indexField) && field.Name.IsQuoted == indexField.HasQuotedName)
                 {
                     if (field.IsFullTextSearch && indexField.Indexing.HasFlag(AutoFieldIndexing.Search) == false)
                     {

--- a/src/Raven.Server/Documents/Queries/QueryBuilder.cs
+++ b/src/Raven.Server/Documents/Queries/QueryBuilder.cs
@@ -177,7 +177,7 @@ namespace Raven.Server.Documents.Queries
 
                             var (value, valueType) = GetValue(query, metadata, parameters, right, true);
 
-                            var (luceneFieldName, fieldType, termType) = GetLuceneField(fieldName, valueType);
+                            var (luceneFieldName, fieldType, termType) = GetLuceneField(fieldName.OriginalName ?? fieldName, valueType);
 
                             switch (fieldType)
                             {

--- a/src/Raven.Server/Documents/Queries/QueryFieldName.cs
+++ b/src/Raven.Server/Documents/Queries/QueryFieldName.cs
@@ -23,6 +23,8 @@ namespace Raven.Server.Documents.Queries
 
         public readonly bool IsQuoted;
 
+        public string OriginalName => IsQuoted && Value[0] != '\'' ? $"'{Value}'" : Value; 
+
         protected bool Equals(QueryFieldName other)
         {
             return string.Equals(Value, other.Value) && IsQuoted == other.IsQuoted;

--- a/test/SlowTests/Issues/RavenDB-16757.cs
+++ b/test/SlowTests/Issues/RavenDB-16757.cs
@@ -1,0 +1,59 @@
+﻿using System;
+using System.Linq;
+using FastTests;
+using Org.BouncyCastle.Asn1.Nist;
+using Raven.Client;
+using Raven.Client.Documents;
+using Raven.Client.Documents.Commands;
+using Sparrow.Json;
+using Sparrow.Json.Parsing;
+using Xunit;
+using Xunit.Abstractions;
+
+namespace SlowTests.Issues
+{
+    public class RavenDB_16757 : RavenTestBase
+    {
+        public RavenDB_16757(ITestOutputHelper output) : base(output)
+        {
+        }
+
+        [Fact]
+        public void ShouldWork()
+        {
+            using var store = GetDocumentStore();
+            PrepareData(store);
+            {
+                using var session = store.OpenSession();
+              //  var q0 = session.Advanced.RawQuery<dynamic>("from Users where Value = 1.0").ToList();
+                var q1 = session.Advanced.RawQuery<dynamic>("from Users where \"My.Name\" = \"Maciej\"").ToList();
+                Assert.Equal(1, q1.Count);
+                var q2 = session.Advanced.RawQuery<dynamic>("from Users where My.Name = \"Jan\"").ToList();
+                Assert.Equal(1, q2.Count);
+
+            }
+            WaitForUserToContinueTheTest(store);
+        }
+
+        private void PrepareData(DocumentStore store)
+        {
+            var requestExecutor = store.GetRequestExecutor();
+            using (requestExecutor.ContextPool.AllocateOperationContext(out JsonOperationContext ctx))
+            {
+                var djv = new DynamicJsonValue
+                {
+                    ["Value"] = "1.0",
+                    ["My.Name"] = "Maciej",
+                    ["My"] = new DynamicJsonValue { ["Name"] = "Jan", },
+                    [Constants.Documents.Metadata.Key] = new DynamicJsonValue { [Constants.Documents.Metadata.Collection] = "Users", }
+                };
+
+                var json = ctx.ReadObject(djv, "users/1");
+
+                var putCommand = new PutDocumentCommand("users/1", null, json);
+
+                requestExecutor.Execute(putCommand, ctx);
+            }
+        }
+    }
+}


### PR DESCRIPTION
### Please do not review it for now. I've pushed it only to run the full test.

### Issue link

https://issues.hibernatingrhinos.com/issue/RavenDB-16757
### Additional description

We need to consider quotes in names during indexing.
For example:
`{
"My.Name" : "first",
"My" : { "Name" : "second" }
}`

Field "My.Name" and My.Name represents two different objects in a document.


### Type of change

- Bug fix


### How risky is the change?

- High


### Backward compatibility

- Non breaking change

### Is it platform specific issue?

- No

### Documentation update



### Testing 

- Tests have been added that prove the fix is effective or that the feature works


### Is there any existing behavior change of other features due to this change?

- Yes. Please list the affected features/subsystems and provide appropriate explanation
- No

### UI work

- It requires further work in the Studio
