### PR TITLE
RavenDB-16353 introduced AbstractIndexCreationTask.NoTracking.LoadDocument

### DIFF
--- a/src/Raven.Client/Documents/Indexes/AbstractIndexCreationTask.cs
+++ b/src/Raven.Client/Documents/Indexes/AbstractIndexCreationTask.cs
@@ -15,8 +15,6 @@ using Raven.Client.Documents.Operations.Attachments;
 using Raven.Client.Documents.Operations.Indexes;
 using Raven.Client.Extensions;
 using Raven.Client.Util;
-using Sparrow.Json;
-using Sparrow.Json.Parsing;
 
 namespace Raven.Client.Documents.Indexes
 {
@@ -308,11 +306,12 @@ namespace Raven.Client.Documents.Indexes
         protected Expression<Func<IEnumerable<TDocument>, IEnumerable>> Map { get; set; }
     }
 
-    public abstract class AbstractCommonApiForIndexes
+    public abstract class AbstractCommonApiForIndexes : ILoadCommonApiForIndexes, ILoadCompareExchangeApiForIndexes
     {
         protected AbstractCommonApiForIndexes()
         {
             Configuration = new IndexConfiguration();
+            NoTracking = new NoTrackingCommonApiForIndexes();
         }
 
         /// <summary>
@@ -378,47 +377,7 @@ namespace Raven.Client.Documents.Indexes
             throw new NotSupportedException("This can only be run on the server side");
         }
 
-        /// <summary>
-        /// Loads the specified document during the indexing process
-        /// </summary>
-        public T LoadDocument<T>(string id)
-        {
-            throw new NotSupportedException("This can only be run on the server side");
-        }
-
-        /// <summary>
-        /// Loads the specified document during the indexing process
-        /// </summary>
-        public T LoadDocument<T>(string id, string collectionName)
-        {
-            throw new NotSupportedException("This can only be run on the server side");
-        }
-
-        /// <summary>
-        /// Loads the specified document during the indexing process
-        /// </summary>
-        public T[] LoadDocument<T>(IEnumerable<string> ids)
-        {
-            throw new NotSupportedException("This can only be run on the server side");
-        }
-
-        public T LoadCompareExchangeValue<T>(string key)
-        {
-            throw new NotSupportedException("This can only be run on the server side");
-        }
-
-        public T[] LoadCompareExchangeValue<T>(IEnumerable<string> keys)
-        {
-            throw new NotSupportedException("This can only be run on the server side");
-        }
-
-        /// <summary>
-        /// Loads the specified document during the indexing process
-        /// </summary>
-        public T[] LoadDocument<T>(IEnumerable<string> ids, string collectionName)
-        {
-            throw new NotSupportedException("This can only be run on the server side");
-        }
+        public NoTrackingCommonApiForIndexes NoTracking { get; }
 
         /// <summary>
         /// Allows to use lambdas recursively
@@ -457,5 +416,94 @@ namespace Raven.Client.Documents.Indexes
         public HashSet<AdditionalAssembly> AdditionalAssemblies { get; set; }
 
         public IndexConfiguration Configuration { get; set; }
+
+        public T LoadDocument<T>(string id)
+        {
+            throw new NotSupportedException("This can only be run on the server side");
+        }
+
+        public T LoadDocument<T>(string id, string collectionName)
+        {
+            throw new NotSupportedException("This can only be run on the server side");
+        }
+
+        public T[] LoadDocument<T>(IEnumerable<string> ids)
+        {
+            throw new NotSupportedException("This can only be run on the server side");
+        }
+
+        public T[] LoadDocument<T>(IEnumerable<string> ids, string collectionName)
+        {
+            throw new NotSupportedException("This can only be run on the server side");
+        }
+
+        public T LoadCompareExchangeValue<T>(string key)
+        {
+            throw new NotSupportedException("This can only be run on the server side");
+        }
+
+        public T[] LoadCompareExchangeValue<T>(IEnumerable<string> keys)
+        {
+            throw new NotSupportedException("This can only be run on the server side");
+        }
+    }
+
+    public class NoTrackingCommonApiForIndexes : ILoadCommonApiForIndexes
+    {
+        public T LoadDocument<T>(string id)
+        {
+            throw new NotSupportedException("This can only be run on the server side");
+        }
+
+        public T LoadDocument<T>(string id, string collectionName)
+        {
+            throw new NotSupportedException("This can only be run on the server side");
+        }
+
+        public T[] LoadDocument<T>(IEnumerable<string> ids)
+        {
+            throw new NotSupportedException("This can only be run on the server side");
+        }
+
+        public T[] LoadDocument<T>(IEnumerable<string> ids, string collectionName)
+        {
+            throw new NotSupportedException("This can only be run on the server side");
+        }
+    }
+
+    public interface ILoadCompareExchangeApiForIndexes
+    {
+        /// <summary>
+        /// Loads the specified compare exchange value during the indexing process
+        /// </summary>
+        public T LoadCompareExchangeValue<T>(string key);
+
+        /// <summary>
+        /// Loads the specified compare exchange values during the indexing process
+        /// </summary>
+        public T[] LoadCompareExchangeValue<T>(IEnumerable<string> keys);
+    }
+
+    public interface ILoadCommonApiForIndexes
+    {
+        /// <summary>
+        /// Loads the specified document during the indexing process
+        /// </summary>
+        public T LoadDocument<T>(string id);
+
+        /// <summary>
+        /// Loads the specified document during the indexing process
+        /// </summary>
+        public T LoadDocument<T>(string id, string collectionName);
+
+        /// <summary>
+        /// Loads the specified document during the indexing process
+        /// </summary>
+        public T[] LoadDocument<T>(IEnumerable<string> ids);
+
+        /// <summary>
+        /// Loads the specified document during the indexing process
+        /// </summary>
+        public T[] LoadDocument<T>(IEnumerable<string> ids, string collectionName);
     }
 }

--- a/src/Raven.Client/Documents/Indexes/ExpressionStringBuilder.cs
+++ b/src/Raven.Client/Documents/Indexes/ExpressionStringBuilder.cs
@@ -1474,7 +1474,7 @@ namespace Raven.Client.Documents.Indexes
                         Out("dynamic, ");
                     }
                     Out("dynamic>)(");
-                    if (methodInfo.Name == nameof(AbstractIndexCreationTask.LoadDocument))
+                    if (methodInfo.Name == nameof(ILoadCommonApiForIndexes.LoadDocument))
                     {
                         var type = methodInfo.GetGenericArguments()[0];
 
@@ -1602,6 +1602,11 @@ namespace Raven.Client.Documents.Indexes
                         // exists on both the server side and the client side
                         Out("this");
                     }
+                    else if (typeof(NoTrackingCommonApiForIndexes).IsAssignableFrom(expression.Type))
+                    {
+                        Out("this.");
+                        Out(nameof(AbstractCommonApiForIndexes.NoTracking));
+                    }
                     else if (isDictionaryObject)
                     {
                         Visit(expression);
@@ -1667,11 +1672,11 @@ namespace Raven.Client.Documents.Indexes
                         }
                         Out("Where");
                         break;
-                    case nameof(AbstractIndexCreationTask.LoadDocument):
-                        Out(nameof(AbstractIndexCreationTask.LoadDocument));
+                    case nameof(ILoadCommonApiForIndexes.LoadDocument):
+                        Out(nameof(ILoadCommonApiForIndexes.LoadDocument));
                         break;
-                    case nameof(AbstractIndexCreationTask.LoadCompareExchangeValue):
-                        Out(nameof(AbstractIndexCreationTask.LoadCompareExchangeValue));
+                    case nameof(ILoadCompareExchangeApiForIndexes.LoadCompareExchangeValue):
+                        Out(nameof(ILoadCompareExchangeApiForIndexes.LoadCompareExchangeValue));
                         break;
                     default:
                         Out(node.Method.Name);
@@ -1752,7 +1757,7 @@ namespace Raven.Client.Documents.Indexes
                 Out("\", StringComparison.Ordinal)");
             }
 
-            if (node.Method.Name == nameof(AbstractIndexCreationTask.LoadDocument))
+            if (node.Method.Name == nameof(ILoadCommonApiForIndexes.LoadDocument))
             {
                 var type = node.Method.GetGenericArguments()[0];
                 _loadDocumentTypes.Add(type);
@@ -1770,11 +1775,11 @@ namespace Raven.Client.Documents.Indexes
 
                     var argument = node.Arguments[1];
                     if (argument.NodeType != ExpressionType.Constant)
-                        throw new InvalidOperationException($"Invalid argument in {nameof(AbstractIndexCreationTask.LoadDocument)}. String constant was expected but was '{argument.NodeType}' with value '{argument}'.");
+                        throw new InvalidOperationException($"Invalid argument in {nameof(ILoadCommonApiForIndexes.LoadDocument)}. String constant was expected but was '{argument.NodeType}' with value '{argument}'.");
                 }
                 else
                 {
-                    throw new NotSupportedException($"Unknown overload of {nameof(AbstractIndexCreationTask.LoadDocument)} method");
+                    throw new NotSupportedException($"Unknown overload of {nameof(ILoadCommonApiForIndexes.LoadDocument)} method");
                 }
             }
 

--- a/src/Raven.Client/Documents/Indexes/IndexingOperation.cs
+++ b/src/Raven.Client/Documents/Indexes/IndexingOperation.cs
@@ -8,11 +8,11 @@ namespace Raven.Client.Documents.Indexes
 {
     internal static class IndexingOperation
     {
-        public const string LoadDocument = nameof(AbstractIndexCreationTask.LoadDocument);
+        public const string LoadDocument = nameof(ILoadCommonApiForIndexes.LoadDocument);
 
         public const string LoadAttachment = nameof(AbstractIndexCreationTask.LoadAttachment);
 
-        public const string LoadCompareExchangeValue = nameof(AbstractIndexCreationTask.LoadCompareExchangeValue);
+        public const string LoadCompareExchangeValue = nameof(ILoadCompareExchangeApiForIndexes.LoadCompareExchangeValue);
 
         internal static class Map
         {

--- a/src/Raven.Server/Documents/Indexes/Static/Roslyn/MapFunctionProcessor.cs
+++ b/src/Raven.Server/Documents/Indexes/Static/Roslyn/MapFunctionProcessor.cs
@@ -44,7 +44,8 @@ namespace Raven.Server.Documents.Indexes.Static.Roslyn
                 CoalesceRewriter.Instance,
                 InitializerExpressionRewriter.Instance,
                 NullRewriter.Instance,
-                IsRewriter.Instance
+                IsRewriter.Instance,
+                NoTrackingRewriter.Instance
             })
             {
                 node = rewriter.Visit(node);

--- a/src/Raven.Server/Documents/Indexes/Static/Roslyn/Rewriters/MethodDetectorRewriter.cs
+++ b/src/Raven.Server/Documents/Indexes/Static/Roslyn/Rewriters/MethodDetectorRewriter.cs
@@ -2,6 +2,7 @@
 using Microsoft.CodeAnalysis;
 using Microsoft.CodeAnalysis.CSharp;
 using Microsoft.CodeAnalysis.CSharp.Syntax;
+using Raven.Client.Documents.Indexes;
 
 namespace Raven.Server.Documents.Indexes.Static.Roslyn.Rewriters
 {
@@ -12,10 +13,13 @@ namespace Raven.Server.Documents.Indexes.Static.Roslyn.Rewriters
         public override SyntaxNode VisitInvocationExpression(InvocationExpressionSyntax node)
         {
             var expression = node.Expression.ToString();
+            if (NoTrackingRewriter.TryRemoveNoTracking(expression, out var newExpression))
+                expression = newExpression;
+
             switch (expression)
             {
                 case "this.LoadDocument":
-                case "LoadDocument":
+                case nameof(AbstractCommonApiForIndexes.LoadDocument):
                     Methods.HasLoadDocument = true;
                     break;
                 case "this.TransformWith":

--- a/src/Raven.Server/Documents/Indexes/Static/Roslyn/Rewriters/NoTrackingRewriter.cs
+++ b/src/Raven.Server/Documents/Indexes/Static/Roslyn/Rewriters/NoTrackingRewriter.cs
@@ -1,0 +1,42 @@
+﻿using System;
+using Microsoft.CodeAnalysis;
+using Microsoft.CodeAnalysis.CSharp;
+using Microsoft.CodeAnalysis.CSharp.Syntax;
+using Raven.Client.Documents.Indexes;
+
+namespace Raven.Server.Documents.Indexes.Static.Roslyn.Rewriters
+{
+    public class NoTrackingRewriter : CSharpSyntaxRewriter
+    {
+        public static readonly NoTrackingRewriter Instance = new NoTrackingRewriter();
+
+        private NoTrackingRewriter()
+        {
+        }
+
+        public override SyntaxNode VisitInvocationExpression(InvocationExpressionSyntax node)
+        {
+            var expression = node.Expression.ToString();
+            if (TryRemoveNoTracking(expression, out var newExpression) == false)
+                return base.VisitInvocationExpression(node);
+
+            var newNode = SyntaxFactory.ParseExpression(node.ToString().Replace(expression, newExpression));
+            return base.Visit(newNode);
+        }
+
+        public static bool TryRemoveNoTracking(string expression, out string result)
+        {
+            var toStrip = $"{nameof(AbstractCommonApiForIndexes.NoTracking)}.";
+            var index = expression.IndexOf(toStrip, StringComparison.InvariantCulture);
+
+            if (index is 0 or 5) // 5 - this.NoTracking
+            {
+                result = expression.Remove(index, toStrip.Length);
+                return true;
+            }
+
+            result = null;
+            return false;
+        }
+    }
+}

--- a/src/Raven.Server/Documents/Indexes/Static/Roslyn/Rewriters/NoTrackingRewriter.cs
+++ b/src/Raven.Server/Documents/Indexes/Static/Roslyn/Rewriters/NoTrackingRewriter.cs
@@ -26,17 +26,28 @@ namespace Raven.Server.Documents.Indexes.Static.Roslyn.Rewriters
 
         public static bool TryRemoveNoTracking(string expression, out string result)
         {
-            var toStrip = $"{nameof(AbstractCommonApiForIndexes.NoTracking)}.";
-            var index = expression.IndexOf(toStrip, StringComparison.InvariantCulture);
-
-            if (index is 0 or 5) // 5 - this.NoTracking
-            {
-                result = expression.Remove(index, toStrip.Length);
+            var toStrip = $"this.{nameof(AbstractCommonApiForIndexes.NoTracking)}.";
+            if (TryStrip(expression, toStrip, out result))
                 return true;
-            }
+
+            toStrip = $"{nameof(AbstractCommonApiForIndexes.NoTracking)}.";
+            if (TryStrip(expression, toStrip, out result))
+                return true;
 
             result = null;
             return false;
+
+            static bool TryStrip(string expression, string toStrip, out string result)
+            {
+                if (expression.StartsWith(toStrip))
+                {
+                    result = expression.Substring(toStrip.Length);
+                    return true;
+                }
+
+                result = null;
+                return false;
+            }
         }
     }
 }

--- a/src/Raven.Server/Documents/Indexes/Static/Roslyn/Rewriters/ReduceIndex/ReduceFunctionProcessor.cs
+++ b/src/Raven.Server/Documents/Indexes/Static/Roslyn/Rewriters/ReduceIndex/ReduceFunctionProcessor.cs
@@ -34,7 +34,8 @@ namespace Raven.Server.Documents.Indexes.Static.Roslyn.Rewriters.ReduceIndex
                 CoalesceRewriter.Instance,
                 InitializerExpressionRewriter.Instance,
                 NullRewriter.Instance,
-                IsRewriter.Instance
+                IsRewriter.Instance,
+                NoTrackingRewriter.Instance
             })
             {
                 node = rewriter.Visit(node);

--- a/test/SlowTests/Issues/RavenDB_16353.cs
+++ b/test/SlowTests/Issues/RavenDB_16353.cs
@@ -80,16 +80,6 @@ namespace SlowTests.Issues
                 terms = await store.Maintenance.SendAsync(new GetTermsOperation(productsBySupplier.IndexName, "Name", fromValue: null));
                 Assert.Equal(1, terms.Length);
                 Assert.Equal("john", terms[0]);
-
-                WaitForIndexing(store);
-
-                terms = await store.Maintenance.SendAsync(new GetTermsOperation(productsBySupplierNoTracking.IndexName, "Name", fromValue: null));
-                Assert.Equal(1, terms.Length);
-                Assert.Equal("bob", terms[0]);
-
-                terms = await store.Maintenance.SendAsync(new GetTermsOperation(productsBySupplier.IndexName, "Name", fromValue: null));
-                Assert.Equal(1, terms.Length);
-                Assert.Equal("john", terms[0]);
             }
         }
 

--- a/test/SlowTests/Issues/RavenDB_16353.cs
+++ b/test/SlowTests/Issues/RavenDB_16353.cs
@@ -1,0 +1,122 @@
+﻿using System.Linq;
+using System.Threading.Tasks;
+using FastTests;
+using Orders;
+using Raven.Client.Documents.Indexes;
+using Raven.Client.Documents.Operations.Indexes;
+using Xunit;
+using Xunit.Abstractions;
+
+namespace SlowTests.Issues
+{
+    public class RavenDB_16353 : RavenTestBase
+    {
+        public RavenDB_16353(ITestOutputHelper output) : base(output)
+        {
+        }
+
+        [Fact]
+        public async Task Can_Use_No_Tracking_For_Referenced_Items()
+        {
+            using (var store = GetDocumentStore())
+            {
+                var productsBySupplierNoTracking = new Products_BySupplier_NoTracking();
+                var productsBySupplier = new Products_BySupplier();
+
+                var map = productsBySupplierNoTracking.CreateIndexDefinition().Maps.First();
+                RavenTestHelper.AssertEqualRespectingNewLines("docs.Products.Select(product => new {\r\n    product = product,\r\n    supplier = this.NoTracking.LoadDocument(product.Supplier, \"Suppliers\")\r\n}).Select(this0 => new {\r\n    Name = this0.supplier.Name\r\n})", map);
+
+                await productsBySupplierNoTracking.ExecuteAsync(store);
+                await productsBySupplier.ExecuteAsync(store);
+
+                var database = await GetDocumentDatabaseInstanceFor(store);
+                var i = database.IndexStore.GetIndex(productsBySupplierNoTracking.IndexName);
+                Assert.Empty(i.GetReferencedCollections());
+
+                i = database.IndexStore.GetIndex(productsBySupplier.IndexName);
+                Assert.NotEmpty(i.GetReferencedCollections());
+
+                using (var session = store.OpenAsyncSession())
+                {
+                    var supplier = new Supplier { Name = "Bob" };
+
+                    await session.StoreAsync(supplier, "suppliers/1");
+
+                    var product = new Product
+                    {
+                        Name = "Cheese",
+                        Supplier = supplier.Id
+                    };
+
+                    await session.StoreAsync(product, "products/1");
+
+                    await session.SaveChangesAsync();
+                }
+
+                WaitForIndexing(store);
+
+                var terms = await store.Maintenance.SendAsync(new GetTermsOperation(productsBySupplierNoTracking.IndexName, "Name", fromValue: null));
+                Assert.Equal(1, terms.Length);
+                Assert.Equal("bob", terms[0]);
+
+                terms = await store.Maintenance.SendAsync(new GetTermsOperation(productsBySupplier.IndexName, "Name", fromValue: null));
+                Assert.Equal(1, terms.Length);
+                Assert.Equal("bob", terms[0]);
+
+                using (var session = store.OpenAsyncSession())
+                {
+                    var supplier = await session.LoadAsync<Supplier>("suppliers/1");
+                    supplier.Name = "John";
+
+                    await session.SaveChangesAsync();
+                }
+
+                WaitForIndexing(store);
+
+                terms = await store.Maintenance.SendAsync(new GetTermsOperation(productsBySupplierNoTracking.IndexName, "Name", fromValue: null));
+                Assert.Equal(1, terms.Length);
+                Assert.Equal("bob", terms[0]);
+
+                terms = await store.Maintenance.SendAsync(new GetTermsOperation(productsBySupplier.IndexName, "Name", fromValue: null));
+                Assert.Equal(1, terms.Length);
+                Assert.Equal("john", terms[0]);
+
+                WaitForIndexing(store);
+
+                terms = await store.Maintenance.SendAsync(new GetTermsOperation(productsBySupplierNoTracking.IndexName, "Name", fromValue: null));
+                Assert.Equal(1, terms.Length);
+                Assert.Equal("bob", terms[0]);
+
+                terms = await store.Maintenance.SendAsync(new GetTermsOperation(productsBySupplier.IndexName, "Name", fromValue: null));
+                Assert.Equal(1, terms.Length);
+                Assert.Equal("john", terms[0]);
+            }
+        }
+
+        private class Products_BySupplier_NoTracking : AbstractIndexCreationTask<Product>
+        {
+            public Products_BySupplier_NoTracking()
+            {
+                Map = products => from product in products
+                                  let supplier = NoTracking.LoadDocument<Supplier>(product.Supplier)
+                                  select new
+                                  {
+                                      Name = supplier.Name
+                                  };
+            }
+        }
+
+        private class Products_BySupplier : AbstractIndexCreationTask<Product>
+        {
+            public Products_BySupplier()
+            {
+                Map = products => from product in products
+                                  let supplier = LoadDocument<Supplier>(product.Supplier)
+                                  select new
+                                  {
+                                      Name = supplier.Name
+                                  };
+            }
+        }
+    }
+}


### PR DESCRIPTION
### Issue link

https://issues.hibernatingrhinos.com/issue/RavenDB-16353

### Additional description

Introduces NoTracking.LoadDocument methods in index - the whole mechanism works based on a fact that we are keeping list of references collections in a list and this is gathered by Roslyn visitors. Now when NoTracking is used, that list for that particular LoadDocument call is not filled hence index does not react to changes for items from that collection

### Type of change

- New feature

### How risky is the change?

- Moderate 

### Backward compatibility

- Non breaking change

### Is it platform specific issue?

- No

### Documentation update

- This change requires a documentation update. Please mark the issue on YouTrack using `Documentation Required` tag.

### Testing 

- Tests have been added that prove the fix is effective or that the feature works

### Is there any existing behavior change of other features due to this change?

- No

### UI work

- No UI work is needed
