### PR TITLE
RavenDB-17419 Throws when detects whole document comparison in a conditional statement.

### DIFF
--- a/test/SlowTests/Issues/RavenDB-17419.cs
+++ b/test/SlowTests/Issues/RavenDB-17419.cs
@@ -1,0 +1,41 @@
+﻿using System.Linq;
+using FastTests;
+using Raven.Client.Documents.Linq;
+using Raven.Client.Exceptions;
+using Xunit;
+using Xunit.Abstractions;
+
+namespace SlowTests.Issues
+{
+    public class RavenDb17419 : RavenTestBase
+    {
+        public RavenDb17419(ITestOutputHelper output) : base(output)
+        {
+        }
+
+        [Fact]
+        public void ThrowsWhenComparingWholeDocument()
+        {
+            using var store = GetDocumentStore();
+            using(var session = store.OpenSession())
+            {
+                session.Store(new Employee(){ Name = "123" });
+                session.SaveChanges();
+            }
+
+            using(var session = store.OpenSession())
+            {
+                var exception = Assert.Throws<InvalidQueryException>(() => session.Query<Employee>().Where(e => e != null).ToList());
+                Assert.Equal(RavenQueryProviderProcessor<object>.WholeDocumentComparisonExceptionMessage, exception.Message);
+                
+                exception = Assert.Throws<InvalidQueryException>(() => session.Query<Employee>().Where(e => e == null).ToList());
+                Assert.Equal(RavenQueryProviderProcessor<object>.WholeDocumentComparisonExceptionMessage, exception.Message);
+            }
+        }
+        
+        private class Employee
+        {
+            public string Name { get; set; }
+        }
+    }
+}


### PR DESCRIPTION
### Issue link

https://issues.hibernatingrhinos.com/issue/RavenDB-17419


### Additional description

Inform the user that whole document comparison is forbidden in a conditional statement.

### Type of change

- Bug fix


### How risky is the change?


- Moderate 


### Backward compatibility

- Not relevant

### Is it platform specific issue?
.
- No

### Documentation update

- No documentation update is needed 

### Testing 

- Tests have been added that prove the fix is effective or that the feature works


### Is there any existing behavior change of other features due to this change?

- No

### UI work

- No UI work is needed
