### PR TITLE
RavenDB-17263 : Incorrect Custom Partition Value when testing OLAP script

### DIFF
--- a/src/Raven.Server/Documents/ETL/Providers/OLAP/OlapDocumentTransformer.cs
+++ b/src/Raven.Server/Documents/ETL/Providers/OLAP/OlapDocumentTransformer.cs
@@ -65,10 +65,11 @@ namespace Raven.Server.Documents.ETL.Providers.OLAP
             DocumentScript.ScriptEngine.SetValue("partitionBy", new ClrFunctionInstance(DocumentScript.ScriptEngine, "partitionBy", PartitionBy));
             DocumentScript.ScriptEngine.SetValue("noPartition", new ClrFunctionInstance(DocumentScript.ScriptEngine, "noPartition", NoPartition));
 
-            if (_config.CustomPartitionValue != null)
-            {
-                DocumentScript.ScriptEngine.SetValue(CustomPartition, new JsString(_config.CustomPartitionValue));
-            }
+            var customPartitionValue = _config.CustomPartitionValue != null
+                ? new JsString(_config.CustomPartitionValue)
+                : JsValue.Undefined;
+
+            DocumentScript.ScriptEngine.SetValue(CustomPartition, customPartitionValue);
         }
 
         protected override string[] LoadToDestinations { get; }

--- a/test/SlowTests/Server/Documents/ETL/Olap/RavenDB_17263.cs
+++ b/test/SlowTests/Server/Documents/ETL/Olap/RavenDB_17263.cs
@@ -1,0 +1,123 @@
+﻿using System;
+using System.Threading.Tasks;
+using Orders;
+using Raven.Client.Documents.Operations.ETL;
+using Raven.Client.Documents.Operations.ETL.OLAP;
+using Raven.Server.Documents.ETL.Providers.OLAP;
+using Raven.Server.Documents.ETL.Providers.OLAP.Test;
+using Raven.Server.ServerWide.Context;
+using Xunit;
+using Xunit.Abstractions;
+
+namespace SlowTests.Server.Documents.ETL.Olap
+{
+    public class RavenDB_17263 : EtlTestBase
+    {
+        public RavenDB_17263(ITestOutputHelper output) : base(output)
+        {
+        }
+
+        [Fact]
+        public async Task ShouldNotReuseCustomPartitionFromPreviousTestRun()
+        {
+            using (var store = GetDocumentStore())
+            {
+                var baseline = new DateTime(2020, 1, 1);
+
+                using (var session = store.OpenAsyncSession())
+                {
+                    for (int i = 0; i < 31; i++)
+                    {
+                        await session.StoreAsync(new Order
+                        {
+                            Id = $"orders/{i}",
+                            OrderedAt = baseline.AddDays(i),
+                            ShipVia = $"shippers/{i}",
+                            Company = $"companies/{i}"
+                        });
+                    }
+
+                    for (int i = 0; i < 28; i++)
+                    {
+                        await session.StoreAsync(new Order
+                        {
+                            Id = $"orders/{i + 31}",
+                            OrderedAt = baseline.AddMonths(1).AddDays(i),
+                            ShipVia = $"shippers/{i + 31}",
+                            Company = $"companies/{i + 31}"
+                        });
+                    }
+
+                    await session.SaveChangesAsync();
+                }
+
+                var database = await GetDatabase(store.Database);
+                var configuration = new OlapEtlConfiguration
+                {
+                    Name = "simulate",
+                    Transforms =
+                    {
+                        new Transformation
+                        {
+                            Collections = { "Orders" },
+                            Name = "MonthlyOrders",
+                            Script =
+                                @"
+                                    var orderDate = new Date(this.OrderedAt);
+                                    var year = orderDate.getFullYear();
+                                    var month = orderDate.getMonth();
+                                    var key = new Date(year, month);
+
+                                    loadToOrders(partitionBy(['order_date', key], ['location', $customPartitionValue]),
+                                    {
+                                        Company : this.Company,
+                                        ShipVia : this.ShipVia
+                                    });
+                                    "
+                        }
+                    },
+                    CustomPartitionValue = "USA"
+                };
+
+                using (database.DocumentsStorage.ContextPool.AllocateOperationContext(out DocumentsOperationContext context))
+                {
+                    using (OlapEtl.TestScript(new TestOlapEtlScript
+                    {
+                        DocumentId = "orders/1",
+                        Configuration = configuration
+                    }, database, database.ServerStore, context, out var testResult))
+                    {
+                        var result = (OlapEtlTestScriptResult)testResult;
+
+                        Assert.Equal(1, result.ItemsByPartition.Count);
+
+                        Assert.Equal(4, result.ItemsByPartition[0].Columns.Count);
+
+                        Assert.Equal("Orders/order_date=2020-01-01-00-00/location=USA", result.ItemsByPartition[0].Key);
+                    }
+                }
+
+                configuration.CustomPartitionValue = null;
+
+                using (database.DocumentsStorage.ContextPool.AllocateOperationContext(out DocumentsOperationContext context))
+                {
+                    using (OlapEtl.TestScript(new TestOlapEtlScript
+                    {
+                        DocumentId = "orders/1",
+                        Configuration = configuration
+                    }, database, database.ServerStore, context, out var testResult))
+                    {
+                        var result = (OlapEtlTestScriptResult)testResult;
+
+                        Assert.Equal(1, result.ItemsByPartition.Count);
+
+                        Assert.Equal(4, result.ItemsByPartition[0].Columns.Count);
+
+                        Assert.Equal("Orders/order_date=2020-01-01-00-00/location=undefined", result.ItemsByPartition[0].Key);
+                    }
+                }
+
+            }
+        }
+    }
+}


### PR DESCRIPTION
### Issue link

https://issues.hibernatingrhinos.com/issue/RavenDB-17263

### Additional description

when `OlapConfiguration.CustomPartitionValue` is undefined, we shouldn't reuse ScriptEngine's $customPartitionValue from previous test run

### Type of change

- Bug fix

### How risky is the change?

- Low 

### Testing 

- Tests have been added that prove the fix is effective or that the feature works