### PR TITLE
RavenDB-17435 If Pg server is already activeted then we shouldn't throw

### DIFF
--- a/src/Raven.Server/Integrations/PostgreSQL/PgServer.cs
+++ b/src/Raven.Server/Integrations/PostgreSQL/PgServer.cs
@@ -74,15 +74,11 @@ namespace Raven.Server.Integrations.PostgreSQL
 
                 if (activate)
                 {
-                    if (Active)
-                        throw new InvalidOperationException("Cannot start PgServer because it is already activated. Should not happen!");
-
-                    Start();
+                    if (Active == false)
+                        Start();
                 }
                 else
-                {
                     Stop();
-                }
             }
             catch (ObjectDisposedException)
             {


### PR DESCRIPTION
### Issue link

https://issues.hibernatingrhinos.com/issue/RavenDB-17435

### Additional description

We shouldn't throw on changing the license which already contained the pg sql integration feature

### Type of change

- Bug fix

### How risky is the change?

- Low 

### Backward compatibility


- Not relevant

### Is it platform specific issue?

- No

### Documentation update

- No documentation update is needed 

### Testing 


- It has been verified by manual testing

### Is there any existing behavior change of other features due to this change?

- No

### UI work

- No UI work is needed
