### PR TITLE
RavenDB-16995 fix Can_import_export_replication_certs test

### DIFF
--- a/test/SlowTests/Issues/FilteredReplicationTests.cs
+++ b/test/SlowTests/Issues/FilteredReplicationTests.cs
@@ -1391,12 +1391,13 @@ namespace SlowTests.Issues
             }));
 
             var file = GetTempFileName();
-            await storeA.Smuggler.ExportAsync(new DatabaseSmugglerExportOptions(), file);
+            var op = await storeA.Smuggler.ExportAsync(new DatabaseSmugglerExportOptions(), file);
+            await op.WaitForCompletionAsync();
 
             var accessResults = await storeB.Maintenance.SendAsync(new GetReplicationHubAccessOperation("both"));
             Assert.Empty(accessResults);
 
-            var op = await storeB.Smuggler.ImportAsync(new DatabaseSmugglerImportOptions(), file);
+            op = await storeB.Smuggler.ImportAsync(new DatabaseSmugglerImportOptions(), file);
             await op.WaitForCompletionAsync();
 
             accessResults = await storeB.Maintenance.SendAsync(new GetReplicationHubAccessOperation("both"));


### PR DESCRIPTION
### Issue link

https://issues.hibernatingrhinos.com/issue/RavenDB-16995

### Additional description

wait for export operation to complete

### Type of change

- test fix

### How risky is the change?

- Low 

### Backward compatibility

- Not relevant

### Is it platform specific issue?

- No

### Documentation update

- No documentation update is needed 

### Is there any existing behavior change of other features due to this change?

- No

### UI work

- No UI work is needed
