### PR TITLE
RavenDB-17317 - Time series value does not update across all nodes

### DIFF
--- a/src/Raven.Server/Documents/Replication/IncomingReplicationHandler.cs
+++ b/src/Raven.Server/Documents/Replication/IncomingReplicationHandler.cs
@@ -625,25 +625,25 @@ namespace Raven.Server.Documents.Replication
         private void ValidateIncomingReplicationItemsPaths(DataForReplicationCommand dataForReplicationCommand)
         {
             HashSet<Slice> expectedAttachmentStreams = null;
-            
+
             foreach (var item in dataForReplicationCommand.ReplicatedItems)
             {
                 if (_allowedPathsValidator != null)
                 {
-                if (_allowedPathsValidator.ShouldAllow(item) == false)
-                {
-                    throw new InvalidOperationException("Attempted to replicate " + _allowedPathsValidator.GetItemInformation(item) +
-                                                        ", which is not allowed, according to the allowed paths policy. Replication aborted");
-                }
+                    if (_allowedPathsValidator.ShouldAllow(item) == false)
+                    {
+                        throw new InvalidOperationException("Attempted to replicate " + _allowedPathsValidator.GetItemInformation(item) +
+                                                            ", which is not allowed, according to the allowed paths policy. Replication aborted");
+                    }
 
-                switch (item)
-                {
-                    case AttachmentReplicationItem a:
-                        expectedAttachmentStreams ??= new HashSet<Slice>(SliceComparer.Instance);
-                        expectedAttachmentStreams.Add(a.Key);
-                        break;
+                    switch (item)
+                    {
+                        case AttachmentReplicationItem a:
+                            expectedAttachmentStreams ??= new HashSet<Slice>(SliceComparer.Instance);
+                            expectedAttachmentStreams.Add(a.Key);
+                            break;
+                    }
                 }
-            }
 
                 if (_preventIncomingSinkDeletions)
                 {
@@ -1016,7 +1016,7 @@ namespace Raven.Server.Documents.Replication
                     return operationsCount;
 
                 operationsCount++;
-                
+
                 context.LastDatabaseChangeVector = ChangeVectorUtils.MergeVectors(current, _changeVector);
                 context.Transaction.InnerTransaction.LowLevelTransaction.OnDispose += _ =>
                 {
@@ -1064,10 +1064,10 @@ namespace Raven.Server.Documents.Replication
 
             public void BeforeSendingToTxMerger(PreventDeletionsMode? preventDeletionsMode, DocumentsOperationContext ctx)
             {
-                if(preventDeletionsMode?.HasFlag(PreventDeletionsMode.PreventSinkToHubDeletions) == false ||
+                if (preventDeletionsMode?.HasFlag(PreventDeletionsMode.PreventSinkToHubDeletions) == false ||
                                       _mode != PullReplicationMode.SinkToHub)
                     return;
-                
+
                 foreach (var item in _replicationInfo.ReplicatedItems)
                 {
                     if (item is DocumentReplicationItem doc)
@@ -1105,12 +1105,12 @@ namespace Raven.Server.Documents.Replication
 
                         operationsCount++;
 
-                        if (_isSink) 
+                        if (_isSink)
                             ReplaceKnownSinkEntries(context, ref item.ChangeVector);
 
                         var changeVectorToMerge = item.ChangeVector;
 
-                        if (_isHub) 
+                        if (_isHub)
                             changeVectorToMerge = ReplaceUnknownEntriesWithSinkTag(context, ref item.ChangeVector);
 
                         var rcvdChangeVector = item.ChangeVector;
@@ -1130,9 +1130,9 @@ namespace Raven.Server.Documents.Replication
                                 {
                                     if (database.DocumentsStorage.AttachmentsStorage.AttachmentExists(context, attachment.Base64Hash) == false)
                                     {
-                                            Debug.Assert(localAttachment == null || AttachmentsStorage.GetAttachmentTypeByKey(attachment.Key) != AttachmentType.Revision,
-                                                "the stream should have been written when the revision was added by the document");
-                                            database.DocumentsStorage.AttachmentsStorage.PutAttachmentStream(context, attachment.Key, attachmentStream.Base64Hash, attachmentStream.Stream);
+                                        Debug.Assert(localAttachment == null || AttachmentsStorage.GetAttachmentTypeByKey(attachment.Key) != AttachmentType.Revision,
+                                            "the stream should have been written when the revision was added by the document");
+                                        database.DocumentsStorage.AttachmentsStorage.PutAttachmentStream(context, attachment.Key, attachmentStream.Base64Hash, attachmentStream.Stream);
                                     }
 
                                     handledAttachmentStreams.Add(attachment.Base64Hash);
@@ -1206,13 +1206,7 @@ namespace Raven.Server.Documents.Replication
                                 };
                                 var removedChangeVector = tss.DeleteTimestampRange(context, deletionRangeRequest, rcvdChangeVector);
 
-                                var status = ChangeVectorUtils.GetConflictStatus(removedChangeVector, rcvdChangeVector);
-                                if (status == ConflictStatus.Update)
-                                {
-                                    var databaseChangeVector = context.LastDatabaseChangeVector ?? DocumentsStorage.GetDatabaseChangeVector(context);
-                                    context.LastDatabaseChangeVector = ChangeVectorUtils.MergeVectors(databaseChangeVector, removedChangeVector);
-                                }
-                                else if (removedChangeVector != null)
+                                if (removedChangeVector != null)
                                     context.LastDatabaseChangeVector = ChangeVectorUtils.MergeVectors(removedChangeVector, rcvdChangeVector);
 
                                 break;
@@ -1225,7 +1219,7 @@ namespace Raven.Server.Documents.Replication
                                 {
                                     var msg = $"Detected an item of type Incremental-TimeSeries : '{segment.Name}' on document '{docId}', " +
                                               $"while replication protocol version '{_replicationInfo.SupportedFeatures.ProtocolVersion}' does not support Incremental-TimeSeries feature.";
-                                    
+
                                     database.NotificationCenter.Add(AlertRaised.Create(
                                         database.Name,
                                         "Incoming Replication",
@@ -1243,7 +1237,7 @@ namespace Raven.Server.Documents.Replication
                                     context.LastDatabaseChangeVector = ChangeVectorUtils.MergeVectors(databaseChangeVector, segment.ChangeVector);
                                     continue;
                                 }
-                                
+
                                 var options = new TimeSeriesStorage.AppendOptions
                                 {
                                     VerifyName = false,
@@ -1421,7 +1415,7 @@ namespace Raven.Server.Documents.Replication
                     //context.LastDatabaseChangeVector being an empty string is valid in the case of receiving docs into
                     //an empty database via filtered pull replication, since it does not modify the db's change vector
                     Debug.Assert(context.LastDatabaseChangeVector != null, $"database: {context.DocumentDatabase.Name};");
-                    
+
                     // instead of : SetLastReplicatedEtagFrom -> _incoming.ConnectionInfo.SourceDatabaseId, _lastEtag , we will store in context and write once right before commit (one time instead of repeating on all docs in the same Tx)
                     if (context.LastReplicationEtagFrom == null)
                         context.LastReplicationEtagFrom = new Dictionary<string, long>();
@@ -1484,8 +1478,8 @@ namespace Raven.Server.Documents.Replication
 
                 changeVector = newIncoming.SerializeVector();
 
-                return knownEntries.Count > 0 ? 
-                    knownEntries.SerializeVector() : 
+                return knownEntries.Count > 0 ?
+                    knownEntries.SerializeVector() :
                     null;
             }
 

--- a/src/Raven.Server/Documents/Replication/IncomingReplicationHandler.cs
+++ b/src/Raven.Server/Documents/Replication/IncomingReplicationHandler.cs
@@ -1205,7 +1205,14 @@ namespace Raven.Server.Documents.Replication
                                     To = deletedRange.To
                                 };
                                 var removedChangeVector = tss.DeleteTimestampRange(context, deletionRangeRequest, rcvdChangeVector);
-                                if (removedChangeVector != null)
+
+                                var status = ChangeVectorUtils.GetConflictStatus(removedChangeVector, rcvdChangeVector);
+                                if (status == ConflictStatus.Update)
+                                {
+                                    var databaseChangeVector = context.LastDatabaseChangeVector ?? DocumentsStorage.GetDatabaseChangeVector(context);
+                                    context.LastDatabaseChangeVector = ChangeVectorUtils.MergeVectors(databaseChangeVector, removedChangeVector);
+                                }
+                                else if (removedChangeVector != null)
                                     context.LastDatabaseChangeVector = ChangeVectorUtils.MergeVectors(removedChangeVector, rcvdChangeVector);
 
                                 break;

--- a/src/Raven.Server/Documents/TimeSeries/TimeSeriesStorage.cs
+++ b/src/Raven.Server/Documents/TimeSeries/TimeSeriesStorage.cs
@@ -424,7 +424,7 @@ namespace Raven.Server.Documents.TimeSeries
                             deleted = readOnlySegment.NumberOfLiveEntries;
                             holder.AddNewValue(baseline, new double[numberOfValues], Slices.Empty.AsSpan(), ref newSegment, TimeSeriesValuesSegment.Dead);
                             holder.AddNewValue(readOnlySegment.GetLastTimestamp(baseline), new double[numberOfValues], Slices.Empty.AsSpan(), ref newSegment, TimeSeriesValuesSegment.Dead);
-                            holder.AppendDeadSegment(newSegment, fromUpdateStatus: true, changeVectorFromReplication: remoteChangeVector);
+                            holder.AppendDeadSegment(newSegment, fromUpdateStatus: conflictStatus == ConflictStatus.Update, changeVectorFromReplication: remoteChangeVector);
                             if (updateMetadata)
                             {
                                 // this ts was completely deleted
@@ -668,7 +668,7 @@ namespace Raven.Server.Documents.TimeSeries
             TimeSeriesValuesSegment segment,
             DateTime baseline)
         {
-            if (EnsureNoOverlap(context, key, collectionName, segment, baseline) == false)
+            if (IsOverlapping(context, key, collectionName, segment, baseline))
                 return false;
 
             using (var slicer = new TimeSeriesSliceHolder(context, documentId, name, collectionName.Name).WithBaseline(baseline))
@@ -706,7 +706,6 @@ namespace Raven.Server.Documents.TimeSeries
             TimeSeriesValuesSegment segment,
             DateTime baseline)
         {
-
             if (IsOverlapping(context, key, collectionName, segment, baseline))
                 return false;
 
@@ -832,6 +831,10 @@ namespace Raven.Server.Documents.TimeSeries
 
                 var prevSegment = TableValueToSegment(ref tvr, out var prevBaseline);
                 var last = prevSegment.GetLastTimestamp(prevBaseline);
+
+                if (baseline == prevBaseline && last == myLastTimestamp)
+                    return false;
+
                 return last >= baseline;
             }
         }

--- a/src/Raven.Server/Documents/TimeSeries/TimeSeriesStorage.cs
+++ b/src/Raven.Server/Documents/TimeSeries/TimeSeriesStorage.cs
@@ -669,18 +669,28 @@ namespace Raven.Server.Documents.TimeSeries
             TimeSeriesValuesSegment segment,
             DateTime baseline)
         {
-            if (IsOverlapping(context, key, collectionName, segment, baseline))
+            if (IsOverlapping(context, key, collectionName, segment, baseline, canUpdateExistingSegment: true))
                 return false;
 
             using (var holder = new TimeSeriesSegmentHolder(this, context, documentId, name, collectionName, fromReplicationChangeVector: changeVector, timeStamp: baseline))
             {
                 if (holder.LoadCurrentSegment() == false)
-                {
                     holder.AppendToNewSegment(segment, baseline, changeVectorFromReplication: changeVector);
-                    return true;
-                }
+                else
+                    holder.AppendExistingSegment(segment, changeVectorFromReplication: changeVector);
 
-                holder.AppendExistingSegment(segment, changeVectorFromReplication: changeVector);
+
+                context.Transaction.AddAfterCommitNotification(new TimeSeriesChange
+                {
+                    CollectionName = collectionName.Name,
+                    ChangeVector = holder.ChangeVector,
+                    DocumentId = documentId,
+                    Name = name,
+                    Type = TimeSeriesChangeTypes.Put,
+                    From = DateTime.MinValue,
+                    To = DateTime.MaxValue
+                });
+
                 return true;
             }
 
@@ -688,6 +698,12 @@ namespace Raven.Server.Documents.TimeSeries
 
         public bool TryAppendEntireSegmentFromSmuggler(DocumentsOperationContext context, Slice key, CollectionName collectionName, TimeSeriesItem item)
         {
+            if (item.Segment.NumberOfLiveEntries == 0)
+            {
+                // in case of a dead segment we need to update the stats properly
+                return AppendEntireSegment(context, key, item.DocId, context.GetLazyStringForFieldWithCaching(item.Name), collectionName, null, item.Segment, item.Baseline);
+            }
+
             // we will generate new change vector, so we pass null here
             return TryPutSegmentDirectly(context, key, item.DocId, context.GetLazyStringForFieldWithCaching(item.Name), collectionName, null, item.Segment, item.Baseline);
         }
@@ -708,7 +724,7 @@ namespace Raven.Server.Documents.TimeSeries
             // if this segment isn't overlap with any other we can put it directly
             using (var holder = new TimeSeriesSegmentHolder(this, context, documentId, name, collectionName, fromReplicationChangeVector: changeVector, timeStamp: baseline))
             {
-                holder.AppendToNewSegment(segment, baseline, changeVectorFromReplication: changeVector);
+                holder.AppendToNewSegment(segment, baseline);
 
                 context.Transaction.AddAfterCommitNotification(new TimeSeriesChange
                 {
@@ -768,7 +784,8 @@ namespace Raven.Server.Documents.TimeSeries
             Slice key,
             CollectionName collectionName,
             TimeSeriesValuesSegment segment,
-            DateTime baseline)
+            DateTime baseline,
+            bool canUpdateExistingSegment = false)
         {
             var table = GetOrCreateTimeSeriesTable(context.Transaction.InnerTransaction, collectionName);
             using (Slice.From(context.Allocator, key.Content.Ptr, key.Size - sizeof(long), ByteStringType.Immutable, out var prefix))
@@ -799,7 +816,7 @@ namespace Raven.Server.Documents.TimeSeries
                 var prevSegment = TableValueToSegment(ref tvr, out var prevBaseline);
                 var last = prevSegment.GetLastTimestamp(prevBaseline);
 
-                if (baseline == prevBaseline && last == myLastTimestamp)
+                if (canUpdateExistingSegment && baseline == prevBaseline && last == myLastTimestamp)
                     return false;
 
                 return last >= baseline;
@@ -941,8 +958,7 @@ namespace Raven.Server.Documents.TimeSeries
                     newValueSegment = newValueSegment.Recompute(_context.Allocator);
 
                 _currentEtag = _tss._documentsStorage.GenerateNextEtag();
-                changeVectorFromReplication ??= _tss._documentsStorage.GetNewChangeVector(_context, _currentEtag);
-                _currentChangeVector = changeVectorFromReplication;
+                _currentChangeVector = changeVectorFromReplication ?? _tss._documentsStorage.GetNewChangeVector(_context, _currentEtag);
 
                 ValidateSegment(newValueSegment);
                 if (newValueSegment.NumberOfLiveEntries == 0)
@@ -975,8 +991,7 @@ namespace Raven.Server.Documents.TimeSeries
             public void AppendDeadSegment(TimeSeriesValuesSegment newValueSegment, string changeVectorFromReplication = null)
             {
                 _currentEtag = _tss._documentsStorage.GenerateNextEtag();
-                changeVectorFromReplication ??= _tss._documentsStorage.GetNewChangeVector(_context, _currentEtag);
-                _currentChangeVector = changeVectorFromReplication;
+                _currentChangeVector = changeVectorFromReplication ?? _tss._documentsStorage.GetNewChangeVector(_context, _currentEtag);
 
                 ValidateSegment(newValueSegment);
                 MarkSegmentAsPendingDeletion(_context, _collection.Name, _currentEtag);
@@ -1007,8 +1022,7 @@ namespace Raven.Server.Documents.TimeSeries
                 SliceHolder.SetBaselineToKey(BaselineDate);
 
                 _currentEtag = _tss._documentsStorage.GenerateNextEtag();
-                changeVectorFromReplication ??= _tss._documentsStorage.GetNewChangeVector(_context, _currentEtag);
-                _currentChangeVector = changeVectorFromReplication;
+                _currentChangeVector = changeVectorFromReplication ?? _tss._documentsStorage.GetNewChangeVector(_context, _currentEtag);
 
                 _tss.Stats.UpdateStats(_context, SliceHolder, _collection, newSegment, BaselineDate, newSegment.NumberOfLiveEntries);
                 _tss._documentDatabase.TimeSeriesPolicyRunner?.MarkSegmentForPolicy(_context, SliceHolder, baseline, _currentChangeVector, newSegment.NumberOfLiveEntries);

--- a/src/Raven.Server/Documents/TimeSeries/TimeSeriesStorage.cs
+++ b/src/Raven.Server/Documents/TimeSeries/TimeSeriesStorage.cs
@@ -724,6 +724,7 @@ namespace Raven.Server.Documents.TimeSeries
                 if (holder.LoadCurrentSegment())
                 {
                     // should never happen 
+                    Debug.Assert(false, "Trying to insert a new segment, but load one with overlapping ranges ");
                     return false;
                 }
 

--- a/src/Raven.Server/Documents/TimeSeries/TimeSeriesStorage.cs
+++ b/src/Raven.Server/Documents/TimeSeries/TimeSeriesStorage.cs
@@ -398,9 +398,11 @@ namespace Raven.Server.Documents.TimeSeries
                         if (baseline > end)
                             return false;
 
+                        ConflictStatus conflictStatus = ConflictStatus.AlreadyMerged;
                         if (remoteChangeVector != null)
                         {
-                            if (ChangeVectorUtils.GetConflictStatus(remoteChangeVector, holder.ReadOnlyChangeVector) == ConflictStatus.AlreadyMerged)
+                            conflictStatus = ChangeVectorUtils.GetConflictStatus(remoteChangeVector, holder.ReadOnlyChangeVector);
+                            if (conflictStatus == ConflictStatus.AlreadyMerged)
                             {
                                 // the deleted range is older than this segment, so we don't touch this segment
                                 return false;
@@ -461,7 +463,7 @@ namespace Raven.Server.Documents.TimeSeries
 
                         if (segmentChanged)
                         {
-                            var count = holder.AppendExistingSegment(newSegment);
+                            var count = holder.AppendExistingSegment(newSegment, fromUpdateStatus: conflictStatus == ConflictStatus.Update, changeVectorFromReplication: remoteChangeVector);
                             if (count == 0 && updateMetadata)
                             {
                                 // this ts was completely deleted

--- a/src/Raven.Server/Documents/TimeSeries/TimeSeriesStorage.cs
+++ b/src/Raven.Server/Documents/TimeSeries/TimeSeriesStorage.cs
@@ -898,6 +898,8 @@ namespace Raven.Server.Documents.TimeSeries
                 _name = name;
 
                 FromReplication = fromReplicationChangeVector != null;
+                if (context.LastDatabaseChangeVector == null) 
+                    _tss.GenerateChangeVector(context, fromReplicationChangeVector);
             }
 
             public TimeSeriesSegmentHolder(

--- a/src/Raven.Server/Documents/TimeSeries/TimeSeriesStorage.cs
+++ b/src/Raven.Server/Documents/TimeSeries/TimeSeriesStorage.cs
@@ -417,17 +417,20 @@ namespace Raven.Server.Documents.TimeSeries
 
                         newSegment.Initialize(numberOfValues);
 
-                        // TODO: RavenDB-14851 manipulating segments as a whole must be done carefully in a distributed env
-                        // if (baseline >= from && end <= to) // entire segment can be deleted
-                        // {
-                        //     // update properly the start/end of the time-series
-                        //     holder.AddNewValue(baseline, new double[readOnlySegment.NumberOfValues], Slices.Empty.AsSpan(), ref newSegment, TimeSeriesValuesSegment.Dead);
-                        //     holder.AddNewValue(readOnlySegment.GetLastTimestamp(baseline), new double[readOnlySegment.NumberOfValues], Slices.Empty.AsSpan(), ref newSegment, TimeSeriesValuesSegment.Dead);
-                        //     holder.AppendDeadSegment(newSegment);
-                        //
-                        //     removeOccurred = true;
-                        //     return true;
-                        // }
+                        if (canDeleteEntireSegment && readOnlySegment.NumberOfLiveEntries > 1)
+                        {
+                            deleted = readOnlySegment.NumberOfLiveEntries;
+                            holder.AddNewValue(baseline, new double[numberOfValues], Slices.Empty.AsSpan(), ref newSegment, TimeSeriesValuesSegment.Dead);
+                            holder.AddNewValue(readOnlySegment.GetLastTimestamp(baseline), new double[numberOfValues], Slices.Empty.AsSpan(), ref newSegment, TimeSeriesValuesSegment.Dead);
+                            holder.AppendDeadSegment(newSegment, fromUpdateStatus: true, changeVectorFromReplication: remoteChangeVector);
+                            if (updateMetadata)
+                            {
+                                // this ts was completely deleted
+                                RemoveTimeSeriesNameFromMetadata(context, slicer.DocId, slicer.Name);
+                            }
+
+                            return true;
+                        }
 
                         var segmentChanged = false;
                         using (var enumerator = readOnlySegment.GetEnumerator(context.Allocator))
@@ -474,17 +477,17 @@ namespace Raven.Server.Documents.TimeSeries
         }
 
         private DateTime? BaselineOfNextSegment(Slice key, Slice prefix, Table table, DateTime baseline)
-        {
+                {
             var offset = key.Size - sizeof(long);
             *(long*)(key.Content.Ptr + offset) = Bits.SwapBytes(baseline.Ticks / 10_000);
 
             foreach (var (_, tvh) in table.SeekByPrimaryKeyPrefix(prefix, key, 0))
-            {
-                return GetBaseline(tvh.Reader);
-            }
+                    {
+                        return GetBaseline(tvh.Reader);
+                    }
 
-            return null;
-        }
+                    return null;
+                }
 
         private static DateTime GetBaseline(TableValueReader reader)
         {
@@ -645,21 +648,7 @@ namespace Raven.Server.Documents.TimeSeries
 
                 if (status == ConflictStatus.Update)
                 {
-                    // TODO: RavenDB-14851 currently this is not working as expected, and cause values to disappear
-                    // we can put the segment directly only if the incoming segment doesn't overlap with any existing one
-                    // using (Slice.From(context.Allocator, dbId.Content.Ptr, dbId.Size - sizeof(long), ByteStringType.Immutable, out var prefix))
-                    // {
-                    //     if (IsOverlapWithHigherSegment(prefix) == false)
-                    //     {
-                    //         var segmentReadOnlyBuffer = tvr.Read((int)TimeSeriesTable.Segment, out int size);
-                    //         var readOnlySegment = new TimeSeriesValuesSegment(segmentReadOnlyBuffer, size);
-                    //         Stats.UpdateCountOfExistingStats(context, documentId, name, collectionName, -readOnlySegment.NumberOfLiveEntries);
-                    //
-                    //         AppendEntireSegment();
-                    //
-                    //         return true;
-                    //     }
-                    // }
+                    return AppendEntireSegment(context, key, documentId, name, collectionName, changeVector, segment, baseline);
                 }
 
                 return false;
@@ -668,8 +657,39 @@ namespace Raven.Server.Documents.TimeSeries
             return TryPutSegmentDirectly(context, key, documentId, name, collectionName, changeVector, segment, baseline);
         }
 
+        private bool AppendEntireSegment(DocumentsOperationContext context,
+            Slice key,
+            string documentId,
+            string name,
+            CollectionName collectionName,
+            string changeVectorFromReplication,
+            TimeSeriesValuesSegment segment,
+            DateTime baseline)
+        {
+            if (IsOverlapping(context, key, collectionName, segment, baseline))
+                return false;
+
+            using (var slicer = new TimeSeriesSliceHolder(context, documentId, name, collectionName.Name).WithBaseline(baseline))
+            {
+                using (var holder = new TimeSeriesSegmentHolder(this, context, slicer, documentId, name, collectionName, changeVectorFromReplication))
+                {
+                    if (holder.LoadCurrentSegment() == false)
+                        return false;
+
+                    holder.AppendExistingSegment(segment, fromUpdateStatus: true, changeVectorFromReplication: changeVectorFromReplication);
+                    return true;
+                }
+            }
+        }
+
         public bool TryAppendEntireSegmentFromSmuggler(DocumentsOperationContext context, Slice key, CollectionName collectionName, TimeSeriesItem item)
         {
+            if (item.Segment.NumberOfLiveEntries == 0)
+            {
+                // in case of dead segment, we need to update the stats properly
+                return AppendEntireSegment(context, key, item.DocId, context.GetLazyStringForFieldWithCaching(item.Name), collectionName, item.ChangeVector, item.Segment, item.Baseline);
+            }
+
             // we will generate new change vector, so we pass null here
             return TryPutSegmentDirectly(context, key, item.DocId, context.GetLazyStringForFieldWithCaching(item.Name), collectionName, null, item.Segment, item.Baseline);
         }
@@ -771,6 +791,10 @@ namespace Raven.Server.Documents.TimeSeries
 
                 var prevSegment = TableValueToSegment(ref tvr, out var prevBaseline);
                 var last = prevSegment.GetLastTimestamp(prevBaseline);
+
+                if (prevBaseline == baseline && last == myLastTimestamp) // if prevSegment is the current segment (first segment)
+                    return false;
+
                 return last >= baseline;
             }
         }
@@ -793,25 +817,25 @@ namespace Raven.Server.Documents.TimeSeries
                 var lastTimestamp = segment.GetLastTimestamp(baseline);
                 var nextSegmentBaseline = BaselineOfNextSegment(key, prefix, table, baseline);
                 return lastTimestamp >= nextSegmentBaseline;
-            }
+        }
 
             bool IsOverlapWithLowerSegment(Slice prefix)
-            {
+        {
                 var myLastTimestamp = segment.GetLastTimestamp(baseline);
                 TableValueReader tvr;
                 using (Slice.From(context.Allocator, key.Content.Ptr, key.Size, ByteStringType.Immutable, out var lastKey))
-                {
+            {
                     *(long*)(lastKey.Content.Ptr + lastKey.Size - sizeof(long)) = Bits.SwapBytes(myLastTimestamp.Ticks / 10_000);
                     if (table.SeekOneBackwardByPrimaryKeyPrefix(prefix, lastKey, out tvr) == false)
-                    {
+                {
                         return false;
-                    }
                 }
+            }
 
                 var prevSegment = TableValueToSegment(ref tvr, out var prevBaseline);
                 var last = prevSegment.GetLastTimestamp(prevBaseline);
                 return last >= baseline;
-            }
+        }
         }
 
 
@@ -943,12 +967,20 @@ namespace Raven.Server.Documents.TimeSeries
                 _tss.Stats.UpdateCountOfExistingStats(_context, SliceHolder, _collection, -ReadOnlySegment.NumberOfLiveEntries);
             }
 
-            public long AppendExistingSegment(TimeSeriesValuesSegment newValueSegment)
+            public long AppendExistingSegment(TimeSeriesValuesSegment newValueSegment, bool fromUpdateStatus = false, string changeVectorFromReplication = null)
             {
                 if (newValueSegment.RecomputeRequired)
                     newValueSegment = newValueSegment.Recompute(_context.Allocator);
 
                 (_currentChangeVector, _currentEtag) = _tss.GenerateChangeVector(_context);
+                if (fromUpdateStatus)
+                {
+                    _currentEtag = _tss._documentsStorage.GenerateNextEtag();
+                    changeVectorFromReplication ??= _tss._documentsStorage.GetNewChangeVector(_context, _currentEtag);
+                    _currentChangeVector = changeVectorFromReplication;
+                }
+                else
+                    (_currentChangeVector, _currentEtag) = _tss.GenerateChangeVector(_context);
 
                 ValidateSegment(newValueSegment);
                 if (newValueSegment.NumberOfLiveEntries == 0)
@@ -978,15 +1010,21 @@ namespace Raven.Server.Documents.TimeSeries
                 return count;
             }
 
-            private void AppendDeadSegment(TimeSeriesValuesSegment newValueSegment)
+            public void AppendDeadSegment(TimeSeriesValuesSegment newValueSegment, bool fromUpdateStatus = false, string changeVectorFromReplication = null)
             {
-                (_currentChangeVector, _currentEtag) = _tss.GenerateChangeVector(_context);
+                if (fromUpdateStatus)
+                {
+                    _currentEtag = _tss._documentsStorage.GenerateNextEtag();
+                    changeVectorFromReplication ??= _tss._documentsStorage.GetNewChangeVector(_context, _currentEtag);
+                    _currentChangeVector = changeVectorFromReplication;
+                }
+                else
+                    (_currentChangeVector, _currentEtag) = _tss.GenerateChangeVector(_context);
 
                 ValidateSegment(newValueSegment);
                 MarkSegmentAsPendingDeletion(_context, _collection.Name, _currentEtag);
 
                 ReduceCountBeforeAppend();
-                //TODO: unused code, check if the number of modified entries is correct
                 _tss.Stats.UpdateStats(_context, SliceHolder, _collection, newValueSegment, BaselineDate, ReadOnlySegment.NumberOfLiveEntries);
 
                 using (Table.Allocate(out var tvb))
@@ -1044,7 +1082,7 @@ namespace Raven.Server.Documents.TimeSeries
             public void AddNewValue(DateTime time, Span<double> values, Span<byte> tagSlice, ref TimeSeriesValuesSegment segment, ulong status)
             {
                 AddValueInternal(time, values, tagSlice, ref segment, status);
-                _context.DocumentDatabase.TimeSeriesPolicyRunner?.MarkForPolicy(_context, SliceHolder, time, status);
+                    _context.DocumentDatabase.TimeSeriesPolicyRunner?.MarkForPolicy(_context, SliceHolder, time, status);
             }
 
             public void AddExistingValue(DateTime time, Span<double> values, Span<byte> tagSlice, ref TimeSeriesValuesSegment segment, ulong status)
@@ -1064,9 +1102,9 @@ namespace Raven.Server.Documents.TimeSeries
                         if (FromReplication)
                             RaiseAlertOnMaxCapacityForSingleSegmentReached(values);
 
-                        throw new InvalidDataException(
+                            throw new InvalidDataException(
                             $"Segment reached to capacity and cannot receive more values with {time} timestamp on time series {_name} for {_docId} on database '{_tss._documentDatabase.Name}'. " +
-                            "You may choose a different timestamp.");
+                                "You may choose a different timestamp.");
                     }
 
                     if (segmentLastTimestamp == time) // special split segment case
@@ -1142,42 +1180,42 @@ namespace Raven.Server.Documents.TimeSeries
                 var newValueSegment = new TimeSeriesValuesSegment(SliceHolder.SegmentBuffer.Ptr, MaxSegmentSize);
                 newValueSegment.Initialize(valuesLength);
 
-                using (_context.Allocator.Allocate(valuesLength * sizeof(double), out var valuesBuffer))
+                    using (_context.Allocator.Allocate(valuesLength * sizeof(double), out var valuesBuffer))
                 using (_context.Allocator.Allocate(timeSeriesValuesSegment.NumberOfValues * sizeof(TimestampState), out var stateBuffer))
-                {
+                    {
                     var localValues = new Span<double>(valuesBuffer.Ptr, timeSeriesValuesSegment.NumberOfValues);
                     var localState = new Span<TimestampState>(stateBuffer.Ptr, timeSeriesValuesSegment.NumberOfValues);
-                    var localTag = new TimeSeriesValuesSegment.TagPointer();
+                        var localTag = new TimeSeriesValuesSegment.TagPointer();
 
                     using (var enumerator = timeSeriesValuesSegment.GetEnumerator(_context.Allocator))
-                    {
-                        while (enumerator.MoveNext(out var localTimestamp, localValues, localState, ref localTag, out var localStatus))
                         {
-                            var currentLocalTime = originalBaseline.AddMilliseconds(localTimestamp);
-
-                            if (currentLocalTime < trimTimestamp)
+                            while (enumerator.MoveNext(out var localTimestamp, localValues, localState, ref localTag, out var localStatus))
                             {
+                                var currentLocalTime = originalBaseline.AddMilliseconds(localTimestamp);
+
+                                if (currentLocalTime < trimTimestamp)
+                                {
                                 newValueSegment.Append(_context.Allocator, localTimestamp, localValues, localTag.AsSpan(), localStatus);
-                                continue;
-                            }
+                                    continue;
+                                }
 
                             AppendExistingSegment(newValueSegment);
                             newValueSegment.Initialize(localValues.Length);
                             newValueSegment.Append(_context.Allocator, 0, localValues, localTag.AsSpan(), localStatus);
                             UpdateBaseline(localTimestamp);
 
-                            while (enumerator.MoveNext(out localTimestamp, localValues, localState, ref localTag, out localStatus))
-                            {
-                                currentLocalTime = originalBaseline.AddMilliseconds(localTimestamp);
+                                while (enumerator.MoveNext(out localTimestamp, localValues, localState, ref localTag, out localStatus))
+                                {
+                                    currentLocalTime = originalBaseline.AddMilliseconds(localTimestamp);
                                 var timestampDiff = ((currentLocalTime - BaselineDate).Ticks / 10_000);
                                 newValueSegment.Append(_context.Allocator, (int)timestampDiff, localValues, localTag.AsSpan(), localStatus);
+                                }
                             }
                         }
                     }
-                }
 
                 timeSeriesValuesSegment = newValueSegment;
-            }
+                }
 
             private void DiscardsAllEntriesAtSameTimestampToSingleDeadEntry(ref TimeSeriesValuesSegment timeSeriesSegment, Span<byte> currentTag, Span<double> values)
             {
@@ -1553,7 +1591,7 @@ namespace Raven.Server.Documents.TimeSeries
                 if (currentTimestamp >= next.Timestamp)
                     throw new InvalidDataException(
                         $"The entries of '{Name}' time-series for document '{DocumentId}' must be sorted by their timestamps, and cannot contain duplicate timestamps. " +
-                        $"Got: current '{currentTimestamp:O}', next '{next.Timestamp:O}', make sure your measures have at least 1ms interval.");
+                                                   $"Got: current '{currentTimestamp:O}', next '{next.Timestamp:O}', make sure your measures have at least 1ms interval.");
 
                 if (next.Values.Length == 0 && // dead values can have 0 length
                     next.Status == TimeSeriesValuesSegment.Live)
@@ -2713,8 +2751,8 @@ namespace Raven.Server.Documents.TimeSeries
                 using (var slicer = new TimeSeriesSliceHolder(context, docId, name).WithBaseline(baseline))
                 {
                     Debug.Assert(tss.EnsureNoOverlap(context, slicer.TimeSeriesKeySlice, collectionName, segment, baseline), "Segment is overlapping another segment");
-                }
             }
+        }
         }
 
         internal enum TimeSeriesTable

--- a/src/Raven.Server/Documents/TimeSeries/TimeSeriesStorage.cs
+++ b/src/Raven.Server/Documents/TimeSeries/TimeSeriesStorage.cs
@@ -424,7 +424,7 @@ namespace Raven.Server.Documents.TimeSeries
                             deleted = readOnlySegment.NumberOfLiveEntries;
                             holder.AddNewValue(baseline, new double[numberOfValues], Slices.Empty.AsSpan(), ref newSegment, TimeSeriesValuesSegment.Dead);
                             holder.AddNewValue(readOnlySegment.GetLastTimestamp(baseline), new double[numberOfValues], Slices.Empty.AsSpan(), ref newSegment, TimeSeriesValuesSegment.Dead);
-                            holder.AppendDeadSegment(newSegment, conflictStatusIsUpdate: conflictStatus == ConflictStatus.Update, changeVectorFromReplication: remoteChangeVector);
+                            holder.AppendDeadSegment(newSegment, changeVectorFromReplication: remoteChangeVector);
                             if (updateMetadata)
                             {
                                 // in case this deleted segment was the only segment that exists for this TS
@@ -464,7 +464,7 @@ namespace Raven.Server.Documents.TimeSeries
 
                         if (segmentChanged)
                         {
-                            var count = holder.AppendExistingSegment(newSegment, conflictStatusIsUpdate: conflictStatus == ConflictStatus.Update, changeVectorFromReplication: remoteChangeVector);
+                            var count = holder.AppendExistingSegment(newSegment, changeVectorFromReplication: remoteChangeVector);
                             if (count == 0 && updateMetadata)
                             {
                                 // this ts was completely deleted
@@ -676,11 +676,11 @@ namespace Raven.Server.Documents.TimeSeries
             {
                 if (holder.LoadCurrentSegment() == false)
                 {
-                    holder.AppendToNewSegment(segment, baseline, conflictStatusIsUpdate: true, changeVector: changeVector);
+                    holder.AppendToNewSegment(segment, baseline, changeVectorFromReplication: changeVector);
                     return true;
                 }
 
-                holder.AppendExistingSegment(segment, conflictStatusIsUpdate: true, changeVectorFromReplication: changeVector);
+                holder.AppendExistingSegment(segment, changeVectorFromReplication: changeVector);
                 return true;
             }
 
@@ -708,7 +708,7 @@ namespace Raven.Server.Documents.TimeSeries
             // if this segment isn't overlap with any other we can put it directly
             using (var holder = new TimeSeriesSegmentHolder(this, context, documentId, name, collectionName, fromReplicationChangeVector: changeVector, timeStamp: baseline))
             {
-                holder.AppendToNewSegment(segment, baseline, conflictStatusIsUpdate: changeVector != null, changeVector: changeVector);
+                holder.AppendToNewSegment(segment, baseline, changeVectorFromReplication: changeVector);
 
                 context.Transaction.AddAfterCommitNotification(new TimeSeriesChange
                 {
@@ -935,19 +935,14 @@ namespace Raven.Server.Documents.TimeSeries
                 _tss.Stats.UpdateCountOfExistingStats(_context, SliceHolder, _collection, -ReadOnlySegment.NumberOfLiveEntries);
             }
 
-            public long AppendExistingSegment(TimeSeriesValuesSegment newValueSegment, bool conflictStatusIsUpdate = false, string changeVectorFromReplication = null)
+            public long AppendExistingSegment(TimeSeriesValuesSegment newValueSegment, string changeVectorFromReplication = null)
             {
                 if (newValueSegment.RecomputeRequired)
                     newValueSegment = newValueSegment.Recompute(_context.Allocator);
 
-                if (conflictStatusIsUpdate)
-                {
-                    _currentEtag = _tss._documentsStorage.GenerateNextEtag();
-                    changeVectorFromReplication ??= _tss._documentsStorage.GetNewChangeVector(_context, _currentEtag);
-                    _currentChangeVector = changeVectorFromReplication;
-                }
-                else
-                    (_currentChangeVector, _currentEtag) = _tss.GenerateChangeVector(_context);
+                _currentEtag = _tss._documentsStorage.GenerateNextEtag();
+                changeVectorFromReplication ??= _tss._documentsStorage.GetNewChangeVector(_context, _currentEtag);
+                _currentChangeVector = changeVectorFromReplication;
 
                 ValidateSegment(newValueSegment);
                 if (newValueSegment.NumberOfLiveEntries == 0)
@@ -977,16 +972,11 @@ namespace Raven.Server.Documents.TimeSeries
                 return count;
             }
 
-            public void AppendDeadSegment(TimeSeriesValuesSegment newValueSegment, bool conflictStatusIsUpdate = false, string changeVectorFromReplication = null)
+            public void AppendDeadSegment(TimeSeriesValuesSegment newValueSegment, string changeVectorFromReplication = null)
             {
-                if (conflictStatusIsUpdate)
-                {
-                    _currentEtag = _tss._documentsStorage.GenerateNextEtag();
-                    changeVectorFromReplication ??= _tss._documentsStorage.GetNewChangeVector(_context, _currentEtag);
-                    _currentChangeVector = changeVectorFromReplication;
-                }
-                else
-                    (_currentChangeVector, _currentEtag) = _tss.GenerateChangeVector(_context);
+                _currentEtag = _tss._documentsStorage.GenerateNextEtag();
+                changeVectorFromReplication ??= _tss._documentsStorage.GetNewChangeVector(_context, _currentEtag);
+                _currentChangeVector = changeVectorFromReplication;
 
                 ValidateSegment(newValueSegment);
                 MarkSegmentAsPendingDeletion(_context, _collection.Name, _currentEtag);
@@ -1009,19 +999,16 @@ namespace Raven.Server.Documents.TimeSeries
                 EnsureStatsAndDataIntegrity(_context, _docId, _name, newValueSegment, _collection, BaselineDate);
             }
 
-            public void AppendToNewSegment(TimeSeriesValuesSegment newSegment, DateTime baseline, bool conflictStatusIsUpdate = false, string changeVector = null)
+            public void AppendToNewSegment(TimeSeriesValuesSegment newSegment, DateTime baseline, string changeVectorFromReplication = null)
             {
+                ValidateSegment(newSegment);
+
                 BaselineDate = EnsureMillisecondsPrecision(baseline);
                 SliceHolder.SetBaselineToKey(BaselineDate);
 
-                if (conflictStatusIsUpdate)
-                {
-                    _currentEtag = _tss._documentsStorage.GenerateNextEtag();
-                    changeVector ??= _tss._documentsStorage.GetNewChangeVector(_context, _currentEtag);
-                    _currentChangeVector = changeVector;
-                }
-                else
-                    (_currentChangeVector, _currentEtag) = _tss.GenerateChangeVector(_context);
+                _currentEtag = _tss._documentsStorage.GenerateNextEtag();
+                changeVectorFromReplication ??= _tss._documentsStorage.GetNewChangeVector(_context, _currentEtag);
+                _currentChangeVector = changeVectorFromReplication;
 
                 _tss.Stats.UpdateStats(_context, SliceHolder, _collection, newSegment, BaselineDate, newSegment.NumberOfLiveEntries);
                 _tss._documentDatabase.TimeSeriesPolicyRunner?.MarkSegmentForPolicy(_context, SliceHolder, baseline, _currentChangeVector, newSegment.NumberOfLiveEntries);
@@ -1049,34 +1036,11 @@ namespace Raven.Server.Documents.TimeSeries
 
             public void AppendToNewSegment(SingleResult item)
             {
-                BaselineDate = EnsureMillisecondsPrecision(item.Timestamp);
-                SliceHolder.SetBaselineToKey(BaselineDate);
-
                 var newSegment = new TimeSeriesValuesSegment(SliceHolder.SegmentBuffer.Ptr, MaxSegmentSize);
                 newSegment.Initialize(item.Values.Length);
                 newSegment.Append(_context.Allocator, 0, item.Values.Span, SliceHolder.TagAsSpan(item.Tag), item.Status);
 
-                ValidateSegment(newSegment);
-
-                _tss.Stats.UpdateStats(_context, SliceHolder, _collection, newSegment, BaselineDate, 1);
-                _tss._documentDatabase.TimeSeriesPolicyRunner?.MarkForPolicy(_context, SliceHolder, BaselineDate, item.Status);
-
-                (_currentChangeVector, _currentEtag) = _tss.GenerateChangeVector(_context);
-
-                using (Slice.From(_context.Allocator, _currentChangeVector, out Slice cv))
-                using (Table.Allocate(out TableValueBuilder tvb))
-                {
-                    tvb.Add(SliceHolder.TimeSeriesKeySlice);
-                    tvb.Add(Bits.SwapBytes(_currentEtag));
-                    tvb.Add(cv);
-                    tvb.Add(newSegment.Ptr, newSegment.NumberOfBytes);
-                    tvb.Add(SliceHolder.CollectionSlice);
-                    tvb.Add(_context.GetTransactionMarker());
-
-                    Table.Insert(tvb);
-                }
-
-                EnsureStatsAndDataIntegrity(_context, _docId, _name, newSegment, _collection, BaselineDate);
+                AppendToNewSegment(newSegment, item.Timestamp);
             }
 
             public void AddNewValue(SingleResult result, ref TimeSeriesValuesSegment segment)

--- a/test/SlowTests/Issues/RavenDB_17317.cs
+++ b/test/SlowTests/Issues/RavenDB_17317.cs
@@ -34,7 +34,6 @@ namespace SlowTests.Issues
                     session.SaveChanges();
                 }
 
-
                 for (int i = 0; i < 10; i++)
                 {
                     using (var session = storeA.OpenSession())
@@ -73,7 +72,7 @@ namespace SlowTests.Issues
                 using (var session = storeA.OpenSession())
                 {
                     var ts = session.IncrementalTimeSeriesFor("users/ayende", "INC:Downloads");
-                    ts.Increment(baseline, 1);
+                    ts.Increment(baseline, -1);
                     session.SaveChanges();
                 }
 
@@ -90,8 +89,8 @@ namespace SlowTests.Issues
                     var tsB = sessionB.IncrementalTimeSeriesFor("users/ayende", "INC:Downloads").Get();
 
                     Assert.Equal(tsA.Length, tsB.Length);
-                    Assert.Equal(21, tsA[0].Value);
-                    Assert.Equal(21, tsB[0].Value);
+                    Assert.Equal(19, tsA[0].Value);
+                    Assert.Equal(19, tsB[0].Value);
 
                     for (int i = 1; i < tsA.Length; i++)
                     {

--- a/test/SlowTests/Issues/RavenDB_17317.cs
+++ b/test/SlowTests/Issues/RavenDB_17317.cs
@@ -1,0 +1,264 @@
+﻿using System;
+using System.Threading.Tasks;
+using FastTests.Server.Replication;
+using Xunit;
+using Xunit.Abstractions;
+
+namespace SlowTests.Issues
+{
+    public class RavenDB_17317 : ReplicationTestBase
+    {
+        public RavenDB_17317(ITestOutputHelper output) : base(output)
+        {
+        }
+
+        [Fact]
+        public async Task CanReplicateEntireSegmentOnUpdate_IncrementalTimeSeries()
+        {
+            var baseline = DateTime.UtcNow;
+
+            using (var storeA = GetDocumentStore())
+            using (var storeB = GetDocumentStore())
+            {
+                using (var session = storeA.OpenSession())
+                {
+                    session.Store(new User { Name = "user/1" }, "users/ayende");
+                    session.SaveChanges();
+                }
+
+                using (var session = storeB.OpenSession())
+                {
+                    session.Store(new User { Name = "user/1" }, "users/ayende");
+                    session.SaveChanges();
+                }
+
+
+                for (int i = 0; i < 10; i++)
+                {
+                    using (var session = storeA.OpenSession())
+                    {
+                        var ts = session.IncrementalTimeSeriesFor("users/ayende", "INC:Downloads");
+
+                        for (int j = 0; j < 10; j++)
+                            ts.Increment(baseline.AddMinutes(j), 1);
+
+                        session.SaveChanges();
+                    }
+                }
+
+                for (int i = 0; i < 10; i++)
+                {
+                    using (var session = storeB.OpenSession())
+                    {
+                        var ts = session.IncrementalTimeSeriesFor("users/ayende", "INC:Downloads");
+
+                        for (int j = 0; j < 10; j++)
+                            ts.Increment(baseline.AddMinutes(j), 1);
+
+                        session.SaveChanges();
+                    }
+                }
+
+                await SetupReplicationAsync(storeA, storeB);
+                await SetupReplicationAsync(storeB, storeA);
+
+                await EnsureReplicatingAsync(storeA, storeB);
+                await EnsureReplicatingAsync(storeB, storeA);
+
+                await EnsureNoReplicationLoop(Server, storeA.Database);
+                await EnsureNoReplicationLoop(Server, storeB.Database);
+
+                using (var session = storeA.OpenSession())
+                {
+                    var ts = session.IncrementalTimeSeriesFor("users/ayende", "INC:Downloads");
+                    ts.Increment(baseline, 1);
+                    session.SaveChanges();
+                }
+
+                await EnsureReplicatingAsync(storeA, storeB);
+                await EnsureReplicatingAsync(storeB, storeA);
+
+                await EnsureNoReplicationLoop(Server, storeA.Database);
+                await EnsureNoReplicationLoop(Server, storeB.Database);
+
+                using (var sessionA = storeA.OpenSession())
+                using (var sessionB = storeB.OpenSession())
+                {
+                    var tsA = sessionA.IncrementalTimeSeriesFor("users/ayende", "INC:Downloads").Get();
+                    var tsB = sessionB.IncrementalTimeSeriesFor("users/ayende", "INC:Downloads").Get();
+
+                    Assert.Equal(tsA.Length, tsB.Length);
+                    Assert.Equal(21, tsA[0].Value);
+                    Assert.Equal(21, tsB[0].Value);
+
+                    for (int i = 1; i < tsA.Length; i++)
+                    {
+                        Assert.Equal(20, tsA[i].Value);
+                        Assert.Equal(20, tsB[i].Value);
+                    }
+                }
+            }
+        }
+
+        [Fact]
+        public async Task CanReplicateEntireSegmentOnUpdate_TimeSeries()
+        {
+            var baseline = DateTime.UtcNow;
+
+            using (var storeA = GetDocumentStore())
+            using (var storeB = GetDocumentStore())
+            {
+                using (var session = storeA.OpenSession())
+                {
+                    session.Store(new User { Name = "user/1" }, "users/ayende");
+                    session.SaveChanges();
+                }
+
+                using (var session = storeB.OpenSession())
+                {
+                    session.Store(new User { Name = "user/1" }, "users/ayende");
+                    session.SaveChanges();
+                }
+
+
+                using (var session = storeA.OpenSession())
+                {
+                    var ts = session.TimeSeriesFor("users/ayende", "HeartRates");
+
+                    for (int j = 0; j < 10; j++)
+                        ts.Append(baseline.AddMinutes(j), 100);
+
+                    session.SaveChanges();
+                }
+
+                using (var session = storeB.OpenSession())
+                {
+                    var ts = session.TimeSeriesFor("users/ayende", "HeartRates");
+
+                    for (int j = 0; j < 10; j++)
+                        ts.Append(baseline.AddMinutes(j), 100);
+
+                    session.SaveChanges();
+                }
+
+                await SetupReplicationAsync(storeA, storeB);
+                await SetupReplicationAsync(storeB, storeA);
+
+                await EnsureReplicatingAsync(storeA, storeB);
+                await EnsureReplicatingAsync(storeB, storeA);
+
+                await EnsureNoReplicationLoop(Server, storeA.Database);
+                await EnsureNoReplicationLoop(Server, storeB.Database);
+
+                using (var session = storeA.OpenSession())
+                {
+                    var ts = session.TimeSeriesFor("users/ayende", "HeartRates");
+                    ts.Append(baseline, 50);
+                    session.SaveChanges();
+                }
+
+                await EnsureReplicatingAsync(storeA, storeB);
+                await EnsureReplicatingAsync(storeB, storeA);
+
+                await EnsureNoReplicationLoop(Server, storeA.Database);
+                await EnsureNoReplicationLoop(Server, storeB.Database);
+
+                using (var sessionA = storeA.OpenSession())
+                using (var sessionB = storeB.OpenSession())
+                {
+                    var tsA = sessionA.TimeSeriesFor("users/ayende", "HeartRates").Get();
+                    var tsB = sessionB.TimeSeriesFor("users/ayende", "HeartRates").Get();
+
+                    Assert.Equal(tsA.Length, tsB.Length);
+                    Assert.Equal(50, tsA[0].Value);
+                    Assert.Equal(50, tsB[0].Value);
+
+                    for (int i = 1; i < tsA.Length; i++)
+                    {
+                        Assert.Equal(100, tsA[i].Value);
+                        Assert.Equal(100, tsB[i].Value);
+                    }
+                }
+            }
+        }
+
+        [Fact]
+        public async Task CanDeleteEntireSegment()
+        {
+            var baseline = DateTime.UtcNow;
+
+            using (var storeA = GetDocumentStore())
+            using (var storeB = GetDocumentStore())
+            {
+                using (var session = storeA.OpenSession())
+                {
+                    session.Store(new User { Name = "user/1" }, "users/ayende");
+                    session.SaveChanges();
+                }
+
+                using (var session = storeB.OpenSession())
+                {
+                    session.Store(new User { Name = "user/1" }, "users/ayende");
+                    session.SaveChanges();
+                }
+
+                using (var session = storeA.OpenSession())
+                {
+                    var ts = session.TimeSeriesFor("users/ayende", "HeartRates");
+
+                    for (int j = 0; j < 10; j++)
+                        ts.Append(baseline.AddMinutes(j), 100);
+
+                    session.SaveChanges();
+                }
+
+                using (var session = storeB.OpenSession())
+                {
+                    var ts = session.TimeSeriesFor("users/ayende", "HeartRates");
+
+                    for (int j = 0; j < 10; j++)
+                        ts.Append(baseline.AddMinutes(j), 100);
+
+                    session.SaveChanges();
+                }
+
+                await SetupReplicationAsync(storeA, storeB);
+                await SetupReplicationAsync(storeB, storeA);
+
+                await EnsureReplicatingAsync(storeA, storeB);
+                await EnsureReplicatingAsync(storeB, storeA);
+
+                await EnsureNoReplicationLoop(Server, storeA.Database);
+                await EnsureNoReplicationLoop(Server, storeB.Database);
+
+                using (var session = storeA.OpenSession())
+                {
+                    var ts = session.TimeSeriesFor("users/ayende", "HeartRates");
+                    ts.Delete();
+                    session.SaveChanges();
+                }
+
+                await EnsureReplicatingAsync(storeA, storeB);
+                await EnsureReplicatingAsync(storeB, storeA);
+
+                await EnsureNoReplicationLoop(Server, storeA.Database);
+                await EnsureNoReplicationLoop(Server, storeB.Database);
+
+                using (var sessionA = storeA.OpenSession())
+                using (var sessionB = storeB.OpenSession())
+                {
+                    var tsA = sessionA.TimeSeriesFor("users/ayende", "HeartRates").Get();
+                    var tsB = sessionB.TimeSeriesFor("users/ayende", "HeartRates").Get();
+
+                    Assert.Null(tsA);
+                    Assert.Null(tsB);
+                }
+            }
+        }
+
+        private class User
+        {
+            public string Name;
+        }
+    }
+}

--- a/test/SlowTests/Server/Documents/TimeSeries/TimeSeriesTombstoneCleaner.cs
+++ b/test/SlowTests/Server/Documents/TimeSeries/TimeSeriesTombstoneCleaner.cs
@@ -318,8 +318,7 @@ namespace SlowTests.Server.Documents.TimeSeries
                     Assert.True(await WaitForDocumentInClusterAsync<User>(cluster.Nodes, store.Database, markerId, (u) => u.Id == markerId, Debugger.IsAttached ? TimeSpan.FromSeconds(60) : TimeSpan.FromSeconds(15)));
                 }
 
-                // TODO: RavenDB-16914
-                //  Assert.True(await WaitForChangeVectorInClusterAsync(cluster.Nodes, database));
+                Assert.True(await WaitForChangeVectorInClusterAsync(cluster.Nodes, database), "await WaitForChangeVectorInClusterAsync(cluster.Nodes, database)");
 
                 foreach (var server in cluster.Nodes)
                 {


### PR DESCRIPTION
### Issue link

https://issues.hibernatingrhinos.com/issue/RavenDB-17317
original issue - https://issues.hibernatingrhinos.com/issue/RavenDB-14851

### Type of change

- Bug fix
- Optimization

### How risky is the change?

- Low 

### Backward compatibility

- Not relevant

### Is it platform specific issue?

- No

### Documentation update

- No documentation update is needed 

### Testing 

- Tests have been added that prove the fix is effective or that the feature works
- It has been verified by manual testing

### Is there any existing behavior change of other features due to this change?

- Yes. Time Series & Incremental Time Series conflict resolving behavior:
** On replication `Update`:
*** before changes: instead of choosing the newest version without comparing each segment value -> we compare each value and choose the highest values (as in `Conflict `status flow). 
*** after changes: accept the update.

For example:
* TS "HeartRates" on 3 nodes [A, B, C], with a single entry: 
{Timestamp: 12:00:00, Value: 75, Tag: "watches/fitbit"}.
* Node B edits the existing entry's value to 4.

**"HeartRates"**

before the change: 
```
Node A: {Timestamp: 12:00:00, Value: 75, Tag: "watches/fitbit"}
Node B: {Timestamp: 12:00:00, Value: 4, Tag: "watches/fitbit"}
Node C: {Timestamp: 12:00:00, Value: 75, Tag: "watches/fitbit"}
```

after the change:
```
Node A: {Timestamp: 12:00:00, Value: 4, Tag: "watches/fitbit"}
Node B: {Timestamp: 12:00:00, Value: 4, Tag: "watches/fitbit"}
Node C: {Timestamp: 12:00:00, Value: 4, Tag: "watches/fitbit"}
```

### UI work

- No UI work is needed
