### PR TITLE
RavenDB-17448 use contentFiles to distribute the libzstd

### DIFF
--- a/scripts/nuget.ps1
+++ b/scripts/nuget.ps1
@@ -39,6 +39,8 @@ function BuildEmbeddedNuget ($projectDir, $outDir, $serverSrcDir, $studioZipPath
     $EMBEDDED_BUILD_OUT_DIR = [io.path]::combine($EMBEDDED_OUT_DIR, "build")
     $EMBEDDED_SERVER_OUT_DIR = [io.path]::combine($EMBEDDED_OUT_DIR, "contentFiles", "any", "any")
     
+    $LIB_ZSTD_DIR = [io.path]::combine($projectDir, "libs", "libzstd", "*")
+    
     $NETSTANDARD_TARGET = "netstandard2.0"
     $NET461_TARGET = "net461"
     
@@ -53,6 +55,7 @@ function BuildEmbeddedNuget ($projectDir, $outDir, $serverSrcDir, $studioZipPath
     & New-Item -ItemType Directory -Path $EMBEDDED_LIB_OUT_DIR_NET461 -Force
 
     Copy-Item $nuspec -Destination $EMBEDDED_NUSPEC
+    Copy-Item $LIB_ZSTD_DIR -Destination $EMBEDDED_SERVER_OUT_DIR
 
     $embeddedCsproj = Join-Path -Path $EMBEDDED_SRC_DIR -ChildPath "Raven.Embedded.csproj";
     

--- a/src/Raven.Client/Raven.Client.csproj
+++ b/src/Raven.Client/Raven.Client.csproj
@@ -85,33 +85,39 @@
   </ItemGroup>
   <ItemGroup>
     <None Include="..\..\libs\libzstd\libzstd.win.x64.dll" Link="libzstd.win.x64.dll">
-      <PackagePath>native/</PackagePath>
+      <PackagePath>contentFiles/any/any/</PackagePath>
       <CopyToOutputDirectory>PreserveNewest</CopyToOutputDirectory>
+      <PackageCopyToOutput>true</PackageCopyToOutput>
       <Pack>true</Pack>
     </None>
     <None Include="..\..\libs\libzstd\libzstd.win.x86.dll" Link="libzstd.win.x86.dll">
-      <PackagePath>native/</PackagePath>
+      <PackagePath>contentFiles/any/any/</PackagePath>
       <CopyToOutputDirectory>PreserveNewest</CopyToOutputDirectory>
+      <PackageCopyToOutput>true</PackageCopyToOutput>
       <Pack>true</Pack>
     </None>
     <None Include="..\..\libs\libzstd\libzstd.linux.x64.so" Link="libzstd.linux.x64.so">
-      <PackagePath>native/</PackagePath>
+      <PackagePath>contentFiles/any/any/</PackagePath>
       <CopyToOutputDirectory>PreserveNewest</CopyToOutputDirectory>
+      <PackageCopyToOutput>true</PackageCopyToOutput>
       <Pack>true</Pack>
     </None>
     <None Include="..\..\libs\libzstd\libzstd.arm.64.so" Link="libzstd.arm.64.so">
-      <PackagePath>native/</PackagePath>
+      <PackagePath>contentFiles/any/any/</PackagePath>
       <CopyToOutputDirectory>PreserveNewest</CopyToOutputDirectory>
+      <PackageCopyToOutput>true</PackageCopyToOutput>
       <Pack>true</Pack>
     </None>
-	  <None Include="..\..\libs\libzstd\libzstd.arm.32.so" Link="libzstd.arm.32.so">
-      <PackagePath>native/</PackagePath>
+    <None Include="..\..\libs\libzstd\libzstd.arm.32.so" Link="libzstd.arm.32.so">
+      <PackagePath>contentFiles/any/any/</PackagePath>
       <CopyToOutputDirectory>PreserveNewest</CopyToOutputDirectory>
+      <PackageCopyToOutput>true</PackageCopyToOutput>
       <Pack>true</Pack>
-	  </None>
+    </None>
     <None Include="..\..\libs\libzstd\libzstd.mac.x64.dylib" Link="libzstd.mac.x64.dylib">
-      <PackagePath>native/</PackagePath>
+      <PackagePath>contentFiles/any/any/</PackagePath>
       <CopyToOutputDirectory>PreserveNewest</CopyToOutputDirectory>
+      <PackageCopyToOutput>true</PackageCopyToOutput>
       <Pack>true</Pack>
     </None>
   </ItemGroup>

--- a/src/Raven.Client/RavenDB.Client.targets
+++ b/src/Raven.Client/RavenDB.Client.targets
@@ -1,7 +1,7 @@
 <?xml version="1.0" encoding="utf-8"?>
 <Project ToolsVersion="4.0" xmlns="http://schemas.microsoft.com/developer/msbuild/2003">
   <ItemGroup>
-    <Zstd Include="$(MSBuildThisFileDirectory)..\native\**\*" />
+    <Zstd Include="$(MSBuildThisFileDirectory)..\contentFiles\any\any\**\*" />
   </ItemGroup>
   <PropertyGroup>
     <PrepareForRunDependsOn>

--- a/src/Raven.Embedded/Raven.Embedded.nuspec.template
+++ b/src/Raven.Embedded/Raven.Embedded.nuspec.template
@@ -25,6 +25,7 @@
         </dependencies>
         <contentFiles>
             <files include="**/RavenDBServer/**/*.*" buildAction="None" copyToOutput="true" />
+            <files include="**/libzstd*.*" buildAction="None" copyToOutput="true" />
         </contentFiles>
     </metadata>
 </package>

--- a/src/Raven.Embedded/RavenDB.Embedded.targets
+++ b/src/Raven.Embedded/RavenDB.Embedded.targets
@@ -2,7 +2,7 @@
 <Project ToolsVersion="4.0" xmlns="http://schemas.microsoft.com/developer/msbuild/2003">
   <ItemGroup>
     <RavenDBServer Include="$(MSBuildThisFileDirectory)..\contentFiles\any\any\**\*" />
-    <Zstd Include="$(MSBuildThisFileDirectory)..\contentFiles\any\any\RavenDBServer\libzstd*.*" />
+    <Zstd Include="$(MSBuildThisFileDirectory)..\contentFiles\any\any\libzstd*.*" />
   </ItemGroup>
   <PropertyGroup>
     <PrepareForRunDependsOn>


### PR DESCRIPTION
### Issue link

https://issues.hibernatingrhinos.com/issue/RavenDB-17448

### Additional description

Use contentFiles to distribute the libzstd. Previous approach had issues with publish

### Type of change

- Bug fix

### How risky is the change?

- Moderate 

### Backward compatibility

- Non breaking change

### Is it platform specific issue?

- No

### Documentation update

- No documentation update is needed 

### Testing 

- It has been verified by manual testing

### Is there any existing behavior change of other features due to this change?

- No

### UI work

- No UI work is needed
