### PR TITLE
RavenDB-17451 : Add option to disable TCP compression

### DIFF
--- a/src/Raven.Client/Documents/Conventions/DocumentConventions.cs
+++ b/src/Raven.Client/Documents/Conventions/DocumentConventions.cs
@@ -262,6 +262,7 @@ namespace Raven.Client.Documents.Conventions
         private Size _maxContextSizeToKeep;
         private ISerializationConventions _serialization;
         private bool? _disableAtomicDocumentWritesInClusterWideTransaction;
+        private bool _disableTcpCompression;
 
         public Func<InMemoryDocumentSessionOperations, object, string, bool> ShouldIgnoreEntityChanges
         {
@@ -1136,6 +1137,20 @@ namespace Raven.Client.Documents.Conventions
             {
                 AssertNotFrozen();
                 _disableAtomicDocumentWritesInClusterWideTransaction = value;
+            }
+        }
+
+        /// <summary>
+        /// Disables the usage of TCP data compression.
+        /// </summary>
+        public bool DisableTcpCompression
+        {
+            get => _disableTcpCompression;
+            set
+            {
+                AssertNotFrozen();
+
+                _disableTcpCompression = value;
             }
         }
 

--- a/src/Raven.Client/Documents/Subscriptions/SubscriptionWorker.cs
+++ b/src/Raven.Client/Documents/Subscriptions/SubscriptionWorker.cs
@@ -278,7 +278,7 @@ namespace Raven.Client.Documents.Subscriptions
             bool compressionSupport = false;
 #if NETCOREAPP3_1_OR_GREATER
             var version = SubscriptionTcpVersion ?? TcpConnectionHeaderMessage.SubscriptionTcpVersion;
-            if (version >= 53_000)
+            if (version >= 53_000 && (_store.Conventions.DisableTcpCompression == false))
                 compressionSupport = true;
 #endif
 

--- a/src/Raven.Server/Config/Categories/DatabaseConfiguration.cs
+++ b/src/Raven.Server/Config/Categories/DatabaseConfiguration.cs
@@ -122,7 +122,7 @@ namespace Raven.Server.Config.Categories
 
         [Description("Whether to disable TCP data compression")]
         [DefaultValue(false)]
-        [ConfigurationEntry("Databases.DisableTcpCompression", ConfigurationEntryScope.ServerWideOrPerDatabase)]
+        [ConfigurationEntry("Databases.DisableTcpCompression", ConfigurationEntryScope.ServerWideOnly)]
         public bool DisableTcpCompression { get; set; }
     }
 }

--- a/src/Raven.Server/Config/Categories/DatabaseConfiguration.cs
+++ b/src/Raven.Server/Config/Categories/DatabaseConfiguration.cs
@@ -119,10 +119,5 @@ namespace Raven.Server.Config.Categories
         [SizeUnit(SizeUnit.Megabytes)]
         [ConfigurationEntry("Databases.PulseReadTransactionLimitInMb", ConfigurationEntryScope.ServerWideOrPerDatabase)]
         public Size PulseReadTransactionLimit { get; set; }
-
-        [Description("Whether to disable TCP data compression")]
-        [DefaultValue(false)]
-        [ConfigurationEntry("Databases.DisableTcpCompression", ConfigurationEntryScope.ServerWideOnly)]
-        public bool DisableTcpCompression { get; set; }
     }
 }

--- a/src/Raven.Server/Config/Categories/DatabaseConfiguration.cs
+++ b/src/Raven.Server/Config/Categories/DatabaseConfiguration.cs
@@ -119,5 +119,10 @@ namespace Raven.Server.Config.Categories
         [SizeUnit(SizeUnit.Megabytes)]
         [ConfigurationEntry("Databases.PulseReadTransactionLimitInMb", ConfigurationEntryScope.ServerWideOrPerDatabase)]
         public Size PulseReadTransactionLimit { get; set; }
+
+        [Description("Whether to disable TCP data compression")]
+        [DefaultValue(false)]
+        [ConfigurationEntry("Databases.DisableTcpCompression", ConfigurationEntryScope.ServerWideOrPerDatabase)]
+        public bool DisableTcpCompression { get; set; }
     }
 }

--- a/src/Raven.Server/Config/Categories/ServerConfiguration.cs
+++ b/src/Raven.Server/Config/Categories/ServerConfiguration.cs
@@ -109,5 +109,10 @@ namespace Raven.Server.Config.Categories
         [DefaultValue(false)]
         [ConfigurationEntry("Server.LogsStream.Disable", ConfigurationEntryScope.ServerWideOnly)]
         public bool DisableLogsStream { get; set; }
+
+        [Description("EXPERT: Disable TCP data compression")]
+        [DefaultValue(false)]
+        [ConfigurationEntry("Server.Tcp.Compression.Disable", ConfigurationEntryScope.ServerWideOnly)]
+        public bool DisableTcpCompression { get; set; }
     }
 }

--- a/src/Raven.Server/Documents/Replication/OutgoingReplicationHandler.cs
+++ b/src/Raven.Server/Documents/Replication/OutgoingReplicationHandler.cs
@@ -726,7 +726,7 @@ namespace Raven.Server.Documents.Replication
                     LicensedFeatures = new LicensedFeatures
                     {
                         DataCompression = _parent._server.LicenseManager.LicenseStatus.HasTcpDataCompression &&
-                                          _parent._server.Configuration.Databases.DisableTcpCompression == false
+                                          _parent._server.Configuration.Server.DisableTcpCompression == false
 
                     }
                 };

--- a/src/Raven.Server/Documents/Replication/OutgoingReplicationHandler.cs
+++ b/src/Raven.Server/Documents/Replication/OutgoingReplicationHandler.cs
@@ -726,8 +726,8 @@ namespace Raven.Server.Documents.Replication
                     LicensedFeatures = new LicensedFeatures
                     {
                         DataCompression = _parent._server.LicenseManager.LicenseStatus.HasTcpDataCompression &&
-                                          _parent._server.Configuration.Databases.DisableTcpCompression == false && 
-                                          _database.Configuration.Databases.DisableTcpCompression == false
+                                          _parent._server.Configuration.Databases.DisableTcpCompression == false
+
                     }
                 };
 

--- a/src/Raven.Server/Documents/Replication/OutgoingReplicationHandler.cs
+++ b/src/Raven.Server/Documents/Replication/OutgoingReplicationHandler.cs
@@ -725,7 +725,9 @@ namespace Raven.Server.Documents.Replication
                     DestinationServerId = info?.ServerId,
                     LicensedFeatures = new LicensedFeatures
                     {
-                        DataCompression = _parent._server.LicenseManager.LicenseStatus.HasTcpDataCompression
+                        DataCompression = _parent._server.LicenseManager.LicenseStatus.HasTcpDataCompression &&
+                                          _parent._server.Configuration.Databases.DisableTcpCompression == false && 
+                                          _database.Configuration.Databases.DisableTcpCompression == false
                     }
                 };
 

--- a/src/Raven.Server/RavenServer.cs
+++ b/src/Raven.Server/RavenServer.cs
@@ -2110,7 +2110,7 @@ namespace Raven.Server
                 if (header.LicensedFeatures != null)
                 {
                     header.LicensedFeatures.DataCompression &= ServerStore.LicenseManager.LicenseStatus.HasTcpDataCompression && 
-                                                               Configuration.Databases.DisableTcpCompression == false;
+                                                               Configuration.Server.DisableTcpCompression == false;
                 }
 
                 await RespondToTcpConnection(stream, context, err,

--- a/src/Raven.Server/RavenServer.cs
+++ b/src/Raven.Server/RavenServer.cs
@@ -2108,7 +2108,10 @@ namespace Raven.Server
                 //At this stage the error is not relevant.
 
                 if (header.LicensedFeatures != null)
-                    header.LicensedFeatures.DataCompression &= ServerStore.LicenseManager.LicenseStatus.HasTcpDataCompression;
+                {
+                    header.LicensedFeatures.DataCompression &= ServerStore.LicenseManager.LicenseStatus.HasTcpDataCompression && 
+                                                               Configuration.Databases.DisableTcpCompression == false;
+                }
 
                 await RespondToTcpConnection(stream, context, err,
                     authSuccessful ? TcpConnectionStatus.Ok : statusResult,

--- a/test/SlowTests/Core/AdminConsole/AdminJsConsoleTests.cs
+++ b/test/SlowTests/Core/AdminConsole/AdminJsConsoleTests.cs
@@ -4,6 +4,7 @@ using FastTests;
 using Newtonsoft.Json;
 using Newtonsoft.Json.Linq;
 using Raven.Client.Extensions;
+using Raven.Server;
 using Raven.Server.Config.Settings;
 using Raven.Server.Documents;
 using Raven.Server.Documents.Patch;
@@ -42,7 +43,12 @@ namespace SlowTests.Core.AdminConsole
 
         private JToken ExecuteScript(DocumentDatabase database, string script)
         {
-            var result = new AdminJsConsole(Server, database).ApplyScript(new AdminJsScript
+            return ExecuteScript(Server, database, script);
+        }
+
+        internal static JToken ExecuteScript(RavenServer server, DocumentDatabase database, string script)
+        {
+            var result = new AdminJsConsole(server, database).ApplyScript(new AdminJsScript
             (
                 script
             ));

--- a/test/SlowTests/Issues/RavenDB-17451.cs
+++ b/test/SlowTests/Issues/RavenDB-17451.cs
@@ -1,0 +1,43 @@
+using System.Threading.Tasks;
+using FastTests;
+using SlowTests.Core.AdminConsole;
+using Xunit;
+using Xunit.Abstractions;
+
+namespace SlowTests.Issues
+{
+    public class RavenDB_17451 : RavenTestBase
+    {
+        public RavenDB_17451(ITestOutputHelper output) : base(output)
+        {
+        }
+
+        [Fact]
+        public async Task CanModifyDisableDatabaseTcpCompressionConfiguration()
+        {
+            using (var store = GetDocumentStore())
+            {
+                var database = await GetDocumentDatabaseInstanceFor(store);
+                var configuration = database.Configuration;
+
+                Assert.False(configuration.Databases.DisableTcpCompression);
+
+                AdminJsConsoleTests.ExecuteScript(Server, database, "database.Configuration.Databases.DisableTcpCompression = true;");
+
+                Assert.True(configuration.Databases.DisableTcpCompression);
+            }
+        }
+
+        [Fact]
+        public void CanModifyDisableServerTcpCompressionConfiguration()
+        {
+            var configuration = Server.Configuration;
+
+            Assert.False(configuration.Databases.DisableTcpCompression);
+
+            AdminJsConsoleTests.ExecuteScript(Server, database: null, "server.Configuration.Databases.DisableTcpCompression = true;");
+
+            Assert.True(configuration.Databases.DisableTcpCompression);
+        }
+    }
+}

--- a/test/SlowTests/Issues/RavenDB-17451.cs
+++ b/test/SlowTests/Issues/RavenDB-17451.cs
@@ -1,43 +1,233 @@
+using System;
+using System.Collections.Concurrent;
+using System.Linq;
 using System.Threading.Tasks;
-using FastTests;
+using FastTests.Server.Replication;
+using Raven.Client.Documents.Subscriptions;
+using Raven.Tests.Core.Utils.Entities;
 using SlowTests.Core.AdminConsole;
 using Xunit;
 using Xunit.Abstractions;
 
 namespace SlowTests.Issues
 {
-    public class RavenDB_17451 : RavenTestBase
+    public class RavenDB_17451 : ReplicationTestBase
     {
         public RavenDB_17451(ITestOutputHelper output) : base(output)
         {
         }
 
-        [Fact]
-        public async Task CanModifyDisableDatabaseTcpCompressionConfiguration()
+        [Theory]
+        [InlineData(true)]
+        [InlineData(false)]
+        public async Task CanDisableTcpCompressionViaConfiguration_ReplicationTest(bool disableOnSrc)
         {
-            using (var store = GetDocumentStore())
+            var srcServer = GetNewServer(new ServerCreationOptions
             {
-                var database = await GetDocumentDatabaseInstanceFor(store);
-                var configuration = database.Configuration;
+                RunInMemory = false
+            });
+            var dstServer = GetNewServer(new ServerCreationOptions
+            {
+                RunInMemory = false
+            });
+            using (var srcStore = GetDocumentStore(new Options
+            {
+                Server = srcServer
+            }))
+            using (var dstStore1 = GetDocumentStore(new Options
+            {
+                Server = dstServer
+            }))
+            using (var dstStore2 = GetDocumentStore(new Options
+            {
+                Server = dstServer
+            }))
+            {
+                srcServer.ServerStore.LicenseManager.LicenseStatus.Attributes["tcpDataCompression"] = true;
+                dstServer.ServerStore.LicenseManager.LicenseStatus.Attributes["tcpDataCompression"] = true;
 
+                const string docId = "users/1";
+                using (var session = srcStore.OpenSession())
+                {
+                    session.Store(new User { Name = "ayende" }, docId);
+                    session.SaveChanges();
+                }
+
+                await SetupReplicationAsync(srcStore, dstStore1);
+
+                Assert.True(WaitForDocument<User>(dstStore1, docId, u => u.Name == "ayende"));
+
+                var srcDb = await srcServer.ServerStore.DatabasesLandlord.TryGetOrCreateResourceStore(srcStore.Database);
+
+                var tcpConnections = srcDb.RunningTcpConnections.ToList();
+
+                Assert.Equal(1, tcpConnections.Count);
+
+                var repToDst1TcpInfo = tcpConnections[0];
+
+                // assert compressed tcp connection to dst1
+                Assert.True(repToDst1TcpInfo.Stream is Sparrow.Utils.ReadWriteCompressedStream);
+
+                var serverToDisableOn = disableOnSrc ? srcServer : dstServer;
+                var configuration = serverToDisableOn.Configuration;
                 Assert.False(configuration.Databases.DisableTcpCompression);
 
-                AdminJsConsoleTests.ExecuteScript(Server, database, "database.Configuration.Databases.DisableTcpCompression = true;");
-
+                // modify configuration
+                AdminJsConsoleTests.ExecuteScript(serverToDisableOn, database: null, "server.Configuration.Databases.DisableTcpCompression = true;");
                 Assert.True(configuration.Databases.DisableTcpCompression);
+
+                await SetupReplicationAsync(srcStore, dstStore2);
+
+                Assert.True(WaitForDocument<User>(dstStore2, docId, u => u.Name == "ayende"));
+
+                tcpConnections = srcDb.RunningTcpConnections.ToList();
+                Assert.Equal(2, tcpConnections.Count);
+
+                var repToDst2TcpInfo = tcpConnections.Single(i => i.Id > repToDst1TcpInfo.Id);
+
+                // assert non-compressed tcp connection to dst2
+                Assert.False(repToDst2TcpInfo.Stream is Sparrow.Utils.ReadWriteCompressedStream);
             }
         }
 
         [Fact]
-        public void CanModifyDisableServerTcpCompressionConfiguration()
+        public async Task CanDisableTcpCompressionViaConfiguration_SubscriptionsTest()
         {
-            var configuration = Server.Configuration;
+            var server = GetNewServer(new ServerCreationOptions
+            {
+                RunInMemory = false
+            });
 
-            Assert.False(configuration.Databases.DisableTcpCompression);
+            using (var store = GetDocumentStore(new Options {Server = server}))
+            {
+                server.ServerStore.LicenseManager.LicenseStatus.Attributes["tcpDataCompression"] = true;
 
-            AdminJsConsoleTests.ExecuteScript(Server, database: null, "server.Configuration.Databases.DisableTcpCompression = true;");
+                var configuration = server.Configuration;
+                Assert.False(configuration.Databases.DisableTcpCompression);
 
-            Assert.True(configuration.Databases.DisableTcpCompression);
+                // modify configuration
+                AdminJsConsoleTests.ExecuteScript(server, database: null, "server.Configuration.Databases.DisableTcpCompression = true;");
+                Assert.True(configuration.Databases.DisableTcpCompression);
+
+                using (var session = store.OpenSession())
+                {
+                    for (int i = 0; i < 10; i++)
+                    {
+                        session.Store(new User());
+                    }
+
+                    session.SaveChanges();
+                }
+
+                var subscriptionCreationParams = new SubscriptionCreationOptions() {Query = "from Users"};
+                var subsId = await store.Subscriptions.CreateAsync(subscriptionCreationParams);
+                using (var subscription = store.Subscriptions.GetSubscriptionWorker<User>(new SubscriptionWorkerOptions(subsId)
+                {
+                    TimeToWaitBeforeConnectionRetry = TimeSpan.FromSeconds(5)
+                }))
+                {
+                    var list = new BlockingCollection<User>();
+                    GC.KeepAlive(subscription.Run(u =>
+                    {
+                        foreach (var item in u.Items)
+                        {
+                            list.Add(item.Result);
+                        }
+                    }));
+                    User user;
+                    for (var i = 0; i < 10; i++)
+                    {
+                        Assert.True(list.TryTake(out user, 1000));
+                    }
+
+                    Assert.False(list.TryTake(out user, 50));
+
+                    var db = await server.ServerStore.DatabasesLandlord.TryGetOrCreateResourceStore(store.Database);
+
+                    var tcpConnections = db.RunningTcpConnections.ToList();
+
+                    Assert.Equal(1, tcpConnections.Count);
+
+                    // assert non-compressed tcp connection
+                    Assert.False(tcpConnections[0].Stream is Sparrow.Utils.ReadWriteCompressedStream);
+                }
+            }
+        }
+
+
+        [Fact]
+        public async Task CanDisableTcpCompressionOnTheClientViaStoreConventions()
+        {
+            var server = GetNewServer(new ServerCreationOptions
+            {
+                RunInMemory = false
+            });
+
+            using (var store1 = GetDocumentStore(new Options
+            {
+                Server = server
+            }))
+            using (var store2 = GetDocumentStore(new Options
+            {
+                Server = server,
+                ModifyDocumentStore = s => s.Conventions.DisableTcpCompression = true
+            }))
+            {
+                server.ServerStore.LicenseManager.LicenseStatus.Attributes["tcpDataCompression"] = true;
+
+                var configuration = server.Configuration;
+                Assert.False(configuration.Databases.DisableTcpCompression);
+
+                foreach (var store in new [] {store1, store2})
+                {
+                    var compressionDisabled = store == store2;
+
+                    using (var session = store.OpenSession())
+                    {
+                        for (int i = 0; i < 10; i++)
+                        {
+                            session.Store(new User());
+                        }
+
+                        session.SaveChanges();
+                    }
+
+                    var subscriptionCreationParams = new SubscriptionCreationOptions()
+                    {
+                        Query = "from Users"
+                    };
+                    var subsId = await store.Subscriptions.CreateAsync(subscriptionCreationParams);
+                    using (var subscription = store.Subscriptions.GetSubscriptionWorker<User>(new SubscriptionWorkerOptions(subsId)
+                    {
+                        TimeToWaitBeforeConnectionRetry = TimeSpan.FromSeconds(5)
+                    }))
+                    {
+                        var list = new BlockingCollection<User>();
+                        GC.KeepAlive(subscription.Run(u =>
+                        {
+                            foreach (var item in u.Items)
+                            {
+                                list.Add(item.Result);
+                            }
+                        }));
+                        User user;
+                        for (var i = 0; i < 10; i++)
+                        {
+                            Assert.True(list.TryTake(out user, 1000));
+                        }
+                        Assert.False(list.TryTake(out user, 50));
+
+                        var db = await server.ServerStore.DatabasesLandlord.TryGetOrCreateResourceStore(store.Database);
+                        var tcpConnections = db.RunningTcpConnections.ToList();
+                        Assert.Equal(1, tcpConnections.Count);
+
+                        if (compressionDisabled)
+                            Assert.False(tcpConnections[0].Stream is Sparrow.Utils.ReadWriteCompressedStream);
+                        else
+                            Assert.True(tcpConnections[0].Stream is Sparrow.Utils.ReadWriteCompressedStream);
+                    }
+                }
+            }
         }
     }
 }


### PR DESCRIPTION
### Issue link

https://issues.hibernatingrhinos.com/issue/RavenDB-17451

### Additional description

- Add a new configuration entry `DisableTcpCompression` and take it's value into consideration during tcp negotiation
- Add a convention to `DocumentStore.Conventions` to allow to disable tcp compression on the client 

In case of a future bug or some other problem in TCP data compression, this new configuration entry will allow the user to drop to non-compressed communication 

### Testing 

- It has been verified by manual testing