### PR TITLE
RavenDB-17466 Cluster version must not exceed `MyCommandsVersion`

### DIFF
--- a/src/Raven.Server/Rachis/Leader.cs
+++ b/src/Raven.Server/Rachis/Leader.cs
@@ -12,6 +12,7 @@ using Raven.Client.ServerWide;
 using Raven.Server.NotificationCenter.Notifications;
 using Raven.Server.NotificationCenter.Notifications.Details;
 using Raven.Server.Rachis.Remote;
+using Raven.Server.ServerWide;
 using Raven.Server.ServerWide.Commands;
 using Raven.Server.ServerWide.Context;
 using Raven.Server.Utils;
@@ -80,6 +81,7 @@ namespace Raven.Server.Rachis
         {
             Term = term;
             _engine = engine;
+            PeersVersion[engine.Tag] = ClusterCommandsVersionManager.MyCommandsVersion;
         }
 
         private MultipleUseFlag _running = new MultipleUseFlag();

--- a/src/Raven.Server/Rachis/RachisConsensus.cs
+++ b/src/Raven.Server/Rachis/RachisConsensus.cs
@@ -534,6 +534,7 @@ namespace Raven.Server.Rachis
             {
                 if (tx is LowLevelTransaction llt && llt.Committed)
                 {
+                    ClusterCommandsVersionManager.SetClusterVersion(ClusterCommandsVersionManager.MyCommandsVersion);
                     leader.Start();
                 }
             };

--- a/src/Raven.Server/ServerWide/ClusterCommandsVersionManager.cs
+++ b/src/Raven.Server/ServerWide/ClusterCommandsVersionManager.cs
@@ -124,11 +124,20 @@ namespace Raven.Server.ServerWide
 
         static ClusterCommandsVersionManager()
         {
-            MyCommandsVersion = _currentClusterMinimalVersion = Enumerable.Max(ClusterCommandsVersions.Values);
+            MyCommandsVersion = Enumerable.Max(ClusterCommandsVersions.Values);
+        }
+
+        public static void ThrowInvalidClusterVersion(int version)
+        {
+            throw new InvalidOperationException($"Can't set cluster version '{version}' that is higher then my version '{MyCommandsVersion}', " +
+                                                $"this is an indication that your are running in a mixed cluster and this node is not with the latest version.");
         }
 
         public static void SetClusterVersion(int version)
         {
+            if (MyCommandsVersion < version)
+                ThrowInvalidClusterVersion(version);
+
             int currentVersion;
             while (true)
             {


### PR DESCRIPTION
### Issue link

https://issues.hibernatingrhinos.com/issue/RavenDB-17466

### Additional description

In inter-version cluster if the elected leader was node in the old version, it would set the cluster version to a higher number then his own `MyCommandsVersion` property

### Type of change

- Bug fix

### How risky is the change?

- Low+

It affects only inter-version cluster(or cluster upgrade process) that has different set of raft commands

### Backward compatibility

Current behavior is broken and it shouldn't make things worse.

### Is it platform specific issue?

- No

### Documentation update

- No documentation update is needed 

### Testing 

- It has been verified by manual testing

### Is there any existing behavior change of other features due to this change?

- No

### UI work

- No UI work is needed
