### PR TITLE
RavenDB-15919 snapshot SubscriptionState

### DIFF
--- a/src/Raven.Server/ServerWide/ClusterStateMachine.cs
+++ b/src/Raven.Server/ServerWide/ClusterStateMachine.cs
@@ -2434,7 +2434,9 @@ namespace Raven.Server.ServerWide
 
             (CompareExchangeTombstones.Content, ClusterCommandsVersionManager.Base42CommandsVersion,SnapshotEntryType.Command),
             (CertificatesSlice.Content, ClusterCommandsVersionManager.Base42CommandsVersion,SnapshotEntryType.Command),
-            (RachisLogHistory.LogHistorySlice.Content, 42_000,SnapshotEntryType.Core)
+            (RachisLogHistory.LogHistorySlice.Content, 42_000,SnapshotEntryType.Core),
+
+            (SubscriptionState.Content, 53_000, SnapshotEntryType.Command)
         };
 
         public override bool ShouldSnapshot(Slice slice, RootObjectType type)


### PR DESCRIPTION

### Issue link

https://issues.hibernatingrhinos.com/issue/RavenDB-15919

### Additional description

When adding new node to the cluster we need also to send the `SubscriptionState` table as part of the snapshot

### Type of change

- Bug fix

### How risky is the change?

- Low

### Backward compatibility

Not relevant since we can't add nodes to the cluster with lower version

### Is it platform specific issue?

- No

### Documentation update

- No documentation update is needed 

### Testing 

- Tests been added

### Is there any existing behavior change of other features due to this change?

- No

### UI work

- No UI work is needed
