### PR TITLE
RavenDB-17461 Replace DocId initial value to avoid getting unnecessary documents in 'Not In'.

### DIFF
--- a/src/Raven.Server/Documents/Queries/LuceneIntegration/InQuery.cs
+++ b/src/Raven.Server/Documents/Queries/LuceneIntegration/InQuery.cs
@@ -174,7 +174,7 @@ namespace Raven.Server.Documents.Queries.LuceneIntegration
                     {
                         if (hasValue == false)
                         {
-                            _currentDocId = termDocs.Doc;
+                            _currentDocId = -1;
                             hasValue = true;
                         }
 


### PR DESCRIPTION
### Issue link

https://issues.hibernatingrhinos.com/issue/RavenDB-17461

### Additional description
Change the initial value of DocId due to Lucene sources: https://lucenenet.apache.org/docs/3.0.3/d3/d45/_doc_id_set_iterator_8cs_source.html

If init is NO_MORE_DOCS Lucene will not exclude any documents.  So we always set it to -1 and have sure that NextDoc is called at least once.



### Type of change

- Bug fix


### How risky is the change?

- Low 


### Backward compatibility


- Not relevant

### Is it platform specific issue?


- No

### Documentation update

- No documentation update is needed 

### Testing 

- Tests have been added that prove the fix is effective or that the feature works


### Is there any existing behavior change of other features due to this change?

- No

### UI work

- No UI work is needed
