### PR TITLE
RavenDB-17460: add snapshot of CompareExchangeByExpiration

### DIFF
--- a/src/Raven.Server/ServerWide/ClusterStateMachine.cs
+++ b/src/Raven.Server/ServerWide/ClusterStateMachine.cs
@@ -2331,7 +2331,8 @@ namespace Raven.Server.ServerWide
 
             (CompareExchangeTombstones.Content, ClusterCommandsVersionManager.Base42CommandsVersion,SnapshotEntryType.Command),
             (CertificatesSlice.Content, ClusterCommandsVersionManager.Base42CommandsVersion,SnapshotEntryType.Command),
-            (RachisLogHistory.LogHistorySlice.Content, 42_000,SnapshotEntryType.Core)
+            (RachisLogHistory.LogHistorySlice.Content, 42_000,SnapshotEntryType.Core),
+            (CompareExchangeExpirationStorage.CompareExchangeByExpiration.Content, 51_000, SnapshotEntryType.Command)
         };
 
         public override bool ShouldSnapshot(Slice slice, RootObjectType type)

--- a/src/Raven.Server/ServerWide/CompareExchangeExpirationStorage.cs
+++ b/src/Raven.Server/ServerWide/CompareExchangeExpirationStorage.cs
@@ -14,7 +14,15 @@ namespace Raven.Server.ServerWide
 {
     public class CompareExchangeExpirationStorage
     {
-        public static string CompareExchangeByExpiration = "CompareExchangeByExpiration";
+        public static readonly Slice CompareExchangeByExpiration;
+
+        static CompareExchangeExpirationStorage()
+        {
+            using (StorageEnvironment.GetStaticContext(out var ctx))
+            {
+                Slice.From(ctx, nameof(CompareExchangeByExpiration), out CompareExchangeByExpiration);
+            }
+        }
 
         public static unsafe void Put(ClusterOperationContext context, Slice keySlice, long ticks)
         {
@@ -39,7 +47,7 @@ namespace Raven.Server.ServerWide
             }
         }
 
-        private static IEnumerable<(Slice keySlice, long expiredTicks, Slice ticksSlice)> GetExpiredValues(ClusterOperationContext context, long currentTicks)
+        internal static IEnumerable<(Slice keySlice, long expiredTicks, Slice ticksSlice)> GetExpiredValues(ClusterOperationContext context, long currentTicks)
         {
             var expirationTree = context.Transaction.InnerTransaction.ReadTree(CompareExchangeByExpiration);
             using (var it = expirationTree.Iterate(false))


### PR DESCRIPTION
### Issue link

https://issues.hibernatingrhinos.com/issue/RavenDB-17460

### Additional description

fix that expired snapshot weren't appear when adding new node to cluster

### Type of change

- Bug fix

### How risky is the change?

- Low 

### Backward compatibility

- Not relevant

### Is it platform specific issue?

- No

### Documentation update

- No documentation update is needed 

### Testing 

- Tests have been added that prove the fix is effective or that the feature works

### Is there any existing behavior change of other features due to this change?

- No

### UI work

- No UI work is needed
