### PR TITLE
RavenDB-17476 Add the document ID property automatically to JSON if missing before sending to Elasticsearch

### DIFF
--- a/src/Raven.Server/Documents/ETL/Providers/Elasticsearch/ElasticSearchEtl.cs
+++ b/src/Raven.Server/Documents/ETL/Providers/Elasticsearch/ElasticSearchEtl.cs
@@ -1,5 +1,6 @@
 ﻿using System;
 using System.Collections.Generic;
+using System.Diagnostics;
 using System.Linq;
 using System.Text;
 using Elasticsearch.Net;
@@ -117,12 +118,12 @@ namespace Raven.Server.Documents.ETL.Providers.ElasticSearch
                     {
                         foreach (ElasticSearchItem insert in inserts)
                         {
-                            if (insert.Property == null)
+                            if (insert.TransformationResult == null)
                                 continue;
 
                             stream.Write(IndexBulkActionBytes);
 
-                            using (var json = EnsureLowerCasedIndexIdProperty(context, insert.Property.RawValue, index))
+                            using (var json = EnsureLowerCasedIndexIdProperty(context, insert.TransformationResult, index))
                             using (var writer = new BlittableJsonTextWriter(context, stream))
                             {
                                 writer.WriteNewLine();
@@ -153,10 +154,21 @@ namespace Raven.Server.Documents.ETL.Providers.ElasticSearch
             {
                 using (var old = json)
                 {
-                    json.Modifications = new DynamicJsonValue(json) { [index.DocumentIdProperty] = LowerCaseIndexIdProperty(idProperty) };
+                    json.Modifications = new DynamicJsonValue(json) { [index.DocumentIdProperty] = LowerCaseDocumentIdProperty(idProperty) };
 
                     json = context.ReadObject(json, "es-etl-load");
                 }
+            }
+            else if (json.Modifications != null)
+            {
+                // document id property was not added by user, so we inserted the lowercased id in ElasticSearchDocumentTransformer.LoadToFunction
+#if DEBUG
+                var docIdProperty = json.Modifications.Properties.First(x => x.Name == index.DocumentIdProperty);
+
+                Debug.Assert(docIdProperty.Value.ToString() == docIdProperty.Value.ToString().ToLowerInvariant());
+#endif
+
+                json = context.ReadObject(json, "es-etl-load");
             }
 
             return json;
@@ -170,7 +182,7 @@ namespace Raven.Server.Documents.ETL.Providers.ElasticSearch
 
             foreach (ElasticSearchItem delete in index.Deletes)
             {
-                idsToDelete.Add(LowerCaseIndexIdProperty(delete.DocumentId));
+                idsToDelete.Add(LowerCaseDocumentIdProperty(delete.DocumentId));
             }
 
             var deleteResponse = _client.DeleteByQuery<string>(d => d
@@ -222,7 +234,7 @@ namespace Raven.Server.Documents.ETL.Providers.ElasticSearch
                 throw new ElasticSearchLoadException($"Failed to create '{indexName}' index. Debug Information: {response.DebugInformation}", response.OriginalException);
         }
 
-        internal static string LowerCaseIndexIdProperty(LazyStringValue id)
+        internal static string LowerCaseDocumentIdProperty(LazyStringValue id)
         {
             return id.ToLowerInvariant();
         }

--- a/src/Raven.Server/Documents/ETL/Providers/Elasticsearch/ElasticSearchItem.cs
+++ b/src/Raven.Server/Documents/ETL/Providers/Elasticsearch/ElasticSearchItem.cs
@@ -1,4 +1,6 @@
-﻿namespace Raven.Server.Documents.ETL.Providers.ElasticSearch
+﻿using Sparrow.Json;
+
+namespace Raven.Server.Documents.ETL.Providers.ElasticSearch
 {
     public class ElasticSearchItem : ExtractedItem
     {
@@ -19,7 +21,7 @@
         public ElasticSearchItem(Tombstone tombstone, string collection) : base(tombstone, collection, EtlItemType.Document)
         {
         }
-        
-        public ElasticSearchProperty Property { get; set; }
+
+        public BlittableJsonReaderObject TransformationResult { get; set; }
     }
 }

--- a/src/Raven.Server/Documents/ETL/Providers/Elasticsearch/ElasticSearchProperty.cs
+++ b/src/Raven.Server/Documents/ETL/Providers/Elasticsearch/ElasticSearchProperty.cs
@@ -1,9 +1,0 @@
-using Sparrow.Json;
-
-namespace Raven.Server.Documents.ETL.Providers.ElasticSearch
-{
-    public class ElasticSearchProperty
-    {
-        public BlittableJsonReaderObject RawValue { get; set; }
-    }
-}

--- a/src/Raven.Server/Documents/ETL/Providers/Elasticsearch/ElasticsearchIndexWriterSimulator.cs
+++ b/src/Raven.Server/Documents/ETL/Providers/Elasticsearch/ElasticsearchIndexWriterSimulator.cs
@@ -31,7 +31,7 @@ namespace Raven.Server.Documents.ETL.Providers.ElasticSearch
 
             foreach (var item in elasticSearchItems)
             {
-                idsToDelete.Add(ElasticSearchEtl.LowerCaseIndexIdProperty(item.DocumentId));
+                idsToDelete.Add(ElasticSearchEtl.LowerCaseDocumentIdProperty(item.DocumentId));
             }
 
             using (var context = JsonOperationContext.ShortTermSingleUse())
@@ -70,7 +70,7 @@ namespace Raven.Server.Documents.ETL.Providers.ElasticSearch
 
                 foreach (var item in index.Inserts)
                 {
-                    using (var json = ElasticSearchEtl.EnsureLowerCasedIndexIdProperty(context, item.Property.RawValue, index))
+                    using (var json = ElasticSearchEtl.EnsureLowerCasedIndexIdProperty(context, item.TransformationResult, index))
                     {
                         sb.AppendLine(ElasticSearchEtl.IndexBulkAction);
                         sb.AppendLine(json.ToString());

--- a/test/SlowTests/Server/Documents/ETL/Elasticsearch/ElasticSearchEtlTests.cs
+++ b/test/SlowTests/Server/Documents/ETL/Elasticsearch/ElasticSearchEtlTests.cs
@@ -915,37 +915,6 @@ loadToOrders(orderData);
             }
         }
 
-        protected void SetupElasticEtl(DocumentStore store, string script, IEnumerable<string> collections = null, bool applyToAllDocuments = false,
-            global::Raven.Client.Documents.Operations.ETL.ElasticSearch.Authentication authentication = null, [CallerMemberName] string caller = null)
-        {
-            var connectionStringName = $"{store.Database}@{store.Urls.First()} to ELASTIC";
-
-            AddEtl(store,
-                new ElasticSearchEtlConfiguration
-                {
-                    Name = connectionStringName,
-                    ConnectionStringName = connectionStringName,
-                    ElasticIndexes =
-                    {
-                        new ElasticSearchIndex {IndexName = $"Orders", DocumentIdProperty = "Id"},
-                        new ElasticSearchIndex {IndexName = $"OrderLines", DocumentIdProperty = "OrderId"},
-                        new ElasticSearchIndex {IndexName = $"Users", DocumentIdProperty = "UserId"},
-                    },
-                    Transforms =
-                    {
-                        new Transformation
-                        {
-                            Name = $"ETL : {connectionStringName}",
-                            Collections = new List<string>(collections),
-                            Script = script,
-                            ApplyToAllDocuments = applyToAllDocuments
-                        }
-                    }
-                },
-
-                new ElasticSearchConnectionString { Name = connectionStringName, Nodes = ElasticSearchTestNodes.Instance.VerifiedNodes.Value, Authentication = authentication });
-        }
-
         private class Order
         {
             public Address Address { get; set; }

--- a/test/SlowTests/Server/Documents/ETL/Elasticsearch/RavenDB_17476.cs
+++ b/test/SlowTests/Server/Documents/ETL/Elasticsearch/RavenDB_17476.cs
@@ -1,0 +1,172 @@
+﻿using System;
+using System.Collections.Generic;
+using System.Linq;
+using System.Threading.Tasks;
+using Orders;
+using Raven.Client.Documents.Operations.ConnectionStrings;
+using Raven.Client.Documents.Operations.ETL;
+using Raven.Client.Documents.Operations.ETL.ElasticSearch;
+using Raven.Server.Documents.ETL.Providers.ElasticSearch;
+using Raven.Server.Documents.ETL.Providers.ElasticSearch.Test;
+using Raven.Server.ServerWide.Context;
+using Tests.Infrastructure;
+using Xunit;
+using Xunit.Abstractions;
+
+namespace SlowTests.Server.Documents.ETL.ElasticSearch
+{
+
+    public class RavenDB_17476 : ElasticSearchEtlTestBase
+    {
+        public RavenDB_17476(ITestOutputHelper output) : base(output)
+        {
+        }
+
+        private const string ScriptWithNoIdMethodUsage = @"
+var orderData = {
+    OrderLinesCount: this.OrderLines.length,
+    TotalCost: 0
+};
+
+for (var i = 0; i < this.Lines.length; i++) {
+    var line = this.Lines[i];
+    var cost = (line.Quantity * line.PricePerUnit) *  ( 1 - line.Discount);
+    orderData.TotalCost += cost;
+    loadToOrderLines({
+        Qty: line.Quantity,
+        Product: line.Product,
+        Cost: cost
+    });
+}
+
+loadToOrders(orderData);
+";
+
+        [RequiresElasticSearchFact]
+        public void CanOmitDocumentIdPropertyInJsonPassedToLoadTo()
+        {
+            using (var store = GetDocumentStore())
+            using (GetElasticClient(out var client))
+            {
+                SetupElasticEtl(store, ScriptWithNoIdMethodUsage, new List<string> { "Orders" });
+
+                var etlDone = WaitForEtl(store, (n, statistics) => statistics.LoadSuccesses != 0);
+
+                using (var session = store.OpenSession())
+                {
+                    session.Store(new Order
+                    {
+                        Lines = new List<OrderLine>
+                        {
+                            new OrderLine { PricePerUnit = 3, Product = "Cheese", Quantity = 3 },
+                            new OrderLine { PricePerUnit = 4, Product = "Bear", Quantity = 2 },
+                        }
+                    });
+                    session.SaveChanges();
+                }
+
+                etlDone.Wait(TimeSpan.FromMinutes(1));
+
+                var ordersCount = client.Count<object>(c => c.Index("orders"));
+                var orderLinesCount = client.Count<object>(c => c.Index("orderlines"));
+
+                Assert.True(ordersCount.IsValid);
+                Assert.True(orderLinesCount.IsValid);
+
+                Assert.Equal(1, ordersCount.Count);
+                Assert.Equal(2, orderLinesCount.Count);
+
+                etlDone.Reset();
+
+                using (var session = store.OpenSession())
+                {
+                    session.Delete("orders/1-A");
+
+                    session.SaveChanges();
+                }
+
+                etlDone.Wait(TimeSpan.FromMinutes(1));
+
+                var ordersCountAfterDelete = client.Count<object>(c => c.Index("orders"));
+                var orderLinesCountAfterDelete = client.Count<object>(c => c.Index("orderlines"));
+
+                Assert.True(ordersCount.IsValid);
+                Assert.True(orderLinesCount.IsValid);
+
+                Assert.Equal(0, ordersCountAfterDelete.Count);
+                Assert.Equal(0, orderLinesCountAfterDelete.Count);
+            }
+        }
+
+        [Fact]
+        public async Task TestScriptWillHaveDocumentIdPropertiesNotAddedExplicitlyInTheScript()
+        {
+            using (var store = GetDocumentStore())
+            {
+                using (var session = store.OpenAsyncSession())
+                {
+                    await session.StoreAsync(new Order
+                    {
+                        Lines = new List<OrderLine>
+                        {
+                            new OrderLine { PricePerUnit = 3, Product = "Milk", Quantity = 3 },
+                            new OrderLine { PricePerUnit = 4, Product = "Bear", Quantity = 2 },
+                        }
+                    });
+                    await session.SaveChangesAsync();
+                }
+
+                var result1 = store.Maintenance.Send(new PutConnectionStringOperation<ElasticSearchConnectionString>(new ElasticSearchConnectionString
+                {
+                    Name = "simulate", Nodes = new[] { "http://localhost:9200" }
+                }));
+                Assert.NotNull(result1.RaftCommandIndex);
+
+                var database = GetDatabase(store.Database).Result;
+
+                using (database.DocumentsStorage.ContextPool.AllocateOperationContext(out DocumentsOperationContext context))
+                {
+                    using (ElasticSearchEtl.TestScript(
+                               new TestElasticSearchEtlScript
+                               {
+                                   DocumentId = "orders/1-A",
+                                   Configuration = new ElasticSearchEtlConfiguration
+                                   {
+                                       Name = "simulate",
+                                       ConnectionStringName = "simulate",
+                                       ElasticIndexes =
+                                       {
+                                           new ElasticSearchIndex { IndexName = "Orders", DocumentIdProperty = "Id" },
+                                           new ElasticSearchIndex { IndexName = "OrderLines", DocumentIdProperty = "OrderId" },
+                                           new ElasticSearchIndex { IndexName = "NotUsedInScript", DocumentIdProperty = "OrderId" },
+                                       },
+                                       Transforms =
+                                       {
+                                           new Transformation { Collections = { "Orders" }, Name = "OrdersAndLines", Script = ScriptWithNoIdMethodUsage }
+                                       }
+                                   }
+                               }, database, database.ServerStore, context, out var testResult))
+                    {
+                        var result = (ElasticSearchEtlTestScriptResult)testResult;
+
+                        Assert.Equal(0, result.TransformationErrors.Count);
+
+                        Assert.Equal(2, result.Summary.Count);
+
+                        var orderLines = result.Summary.First(x => x.IndexName == "orderlines");
+
+                        Assert.Equal(2, orderLines.Commands.Length); // delete by query and bulk
+
+                        Assert.Contains(@"""OrderId"":""orders/1-a""", orderLines.Commands[1]);
+
+                        var orders = result.Summary.First(x => x.IndexName == "orders");
+
+                        Assert.Equal(2, orders.Commands.Length); // delete by query and bulk
+
+                        Assert.Contains(@"""Id"":""orders/1-a""", orders.Commands[1]);
+                    }
+                }
+            }
+        }
+    }
+}


### PR DESCRIPTION
### Issue link

https://issues.hibernatingrhinos.com/issue/RavenDB-17476

### Additional description

If a user doesn't provide the property with RavenDB document ID explicitly then we're adding it automatically to the transformation JSON result

### Type of change

- UX enhancement

### How risky is the change?

- Low 

### Backward compatibility

- Not relevant

### Is it platform specific issue?

- No

### Documentation update

- This change requires a documentation update. Please mark the issue on YouTrack using `Documentation Required` tag.

### Testing 

- Tests have been added that prove the fix is effective or that the feature works

### Is there any existing behavior change of other features due to this change?

- No

### UI work

- No UI work is needed
