### PR TITLE
RavenDB-15919 - Fix test

### DIFF
--- a/test/SlowTests/Client/Subscriptions/ConcurrentSubscriptionsTests.cs
+++ b/test/SlowTests/Client/Subscriptions/ConcurrentSubscriptionsTests.cs
@@ -165,7 +165,7 @@ namespace SlowTests.Client.Subscriptions
                     Strategy = SubscriptionOpeningStrategy.Concurrent,
                     MaxDocsPerBatch = 2
                 }))
-                await using (var Subscription2 = store.Subscriptions.GetSubscriptionWorker<User>(new SubscriptionWorkerOptions(id)
+                await using (var subscription2 = store.Subscriptions.GetSubscriptionWorker<User>(new SubscriptionWorkerOptions(id)
                 {
                     Strategy = SubscriptionOpeningStrategy.Concurrent,
                     TimeToWaitBeforeConnectionRetry = TimeSpan.FromSeconds(5),
@@ -188,7 +188,7 @@ namespace SlowTests.Client.Subscriptions
                     var waitBeforeConn1FinishesSecondBatch = new AsyncManualResetEvent();
                     var batchesProcessedByConn1 = 0;
 
-                    var _ = Subscription2.Run(async x =>
+                    var _ = subscription2.Run(async x =>
                     {
                         foreach (var item in x.Items)
                         {
@@ -220,7 +220,7 @@ namespace SlowTests.Client.Subscriptions
                         }
 
                         batchesProcessedByConn1++;
-                        if (batchesProcessedByConn1 == 2)
+                        if (batchesProcessedByConn1 == 1)
                         {
                             waitUntilConn1FinishesBatch.Set();
                             await waitBeforeConn1FinishesSecondBatch.WaitAsync();


### PR DESCRIPTION
### Issue link

https://issues.hibernatingrhinos.com/issue/RavenDB-15919

### Additional description

fixed 'ResendWhenDocumentIsProcessedByAnotherConnection' to match change in subscription behavior.

### Type of change

- Fix test

### How risky is the change?

- Low 

### Backward compatibility

- Not relevant

### Is it platform specific issue?

- No

### Documentation update

- No documentation update is needed 

### Testing 

- Tests have been added that prove the fix is effective or that the feature works

### Is there any existing behavior change of other features due to this change?

- No

### UI work

- No UI work is needed
