### PR TITLE
RavenDB-17477 Verify existing Elasticsearch index definition that property having doc id isn't analyzed

### DIFF
--- a/src/Raven.Server/Documents/ETL/Providers/Elasticsearch/ElasticSearchEtl.cs
+++ b/src/Raven.Server/Documents/ETL/Providers/Elasticsearch/ElasticSearchEtl.cs
@@ -14,6 +14,8 @@ using Raven.Server.Documents.ETL.Stats;
 using Raven.Server.Documents.Replication.ReplicationItems;
 using Raven.Server.Documents.TimeSeries;
 using Raven.Server.Exceptions.ETL.ElasticSearch;
+using Raven.Server.NotificationCenter.Notifications;
+using Raven.Server.NotificationCenter.Notifications.Details;
 using Raven.Server.ServerWide;
 using Raven.Server.ServerWide.Context;
 using Sparrow.Json;
@@ -107,7 +109,7 @@ namespace Raven.Server.Documents.ETL.Providers.ElasticSearch
             {
                 string indexName = index.IndexName.ToLower();
 
-                EnsureIndexExists(indexName, index);
+                EnsureIndexExistsAndValidateIfNeeded(indexName, index);
 
                 if (index.InsertOnlyMode == false)
                     count += DeleteByQueryOnIndexIdProperty(index);
@@ -202,7 +204,7 @@ namespace Raven.Server.Documents.ETL.Providers.ElasticSearch
             return (int)deleteResponse.Deleted;
         }
 
-        private void EnsureIndexExists(string indexName, ElasticSearchIndexWithRecords index)
+        private void EnsureIndexExistsAndValidateIfNeeded(string indexName, ElasticSearchIndexWithRecords index)
         {
             if (_existingIndexes.Contains(indexName) == false && _client.Indices.Exists(new IndexExistsRequest(Indices.Index(indexName))).Exists == false)
             {
@@ -212,6 +214,20 @@ namespace Raven.Server.Documents.ETL.Providers.ElasticSearch
             }
             else
             {
+                var indexResponse = _client.Indices.Get(new GetIndexDescriptor(Indices.Index(indexName)));
+
+                var mappingsProperties = indexResponse.Indices[indexName].Mappings.Properties;
+
+                if (mappingsProperties.TryGetValue(new PropertyName(index.DocumentIdProperty), out var propertyDefinition) == false)
+                    throw new ElasticSearchLoadException(
+                        $"The index '{indexName}' doesn't contain the mapping for '{index.DocumentIdProperty}' property. " +
+                        "This property is meant to store RavenDB document ID so it needs to be defined as a non-analyzed field, with type 'keyword' to avoid having full-text-search on it.");
+
+                if (propertyDefinition.Type == null || propertyDefinition.Type.Equals("keyword", StringComparison.OrdinalIgnoreCase) == false)
+                    throw new ElasticSearchLoadException(
+                        $"The index '{indexName}' has invalid mapping for '{index.DocumentIdProperty}' property. " +
+                        "This property is meant to store RavenDB document ID so it needs to be defined as a non-analyzed field, with type 'keyword' to avoid having full-text-search on it.");
+
                 _existingIndexes.Add(indexName);
             }
         }

--- a/test/SlowTests/Server/Documents/ETL/Elasticsearch/ElasticSearchEtlTestBase.cs
+++ b/test/SlowTests/Server/Documents/ETL/Elasticsearch/ElasticSearchEtlTestBase.cs
@@ -28,14 +28,14 @@ namespace SlowTests.Server.Documents.ETL.ElasticSearch
         }
 
         protected void SetupElasticEtl(DocumentStore store, string script, IEnumerable<string> collections = null, bool applyToAllDocuments = false,
-            global::Raven.Client.Documents.Operations.ETL.ElasticSearch.Authentication authentication = null, [CallerMemberName] string caller = null)
+            global::Raven.Client.Documents.Operations.ETL.ElasticSearch.Authentication authentication = null, [CallerMemberName] string caller = null, string configurationName = null, string transformationName = null)
         {
             var connectionStringName = $"{store.Database}@{store.Urls.First()} to ELASTIC";
 
             AddEtl(store,
                 new ElasticSearchEtlConfiguration
                 {
-                    Name = connectionStringName,
+                    Name = configurationName ?? connectionStringName,
                     ConnectionStringName = connectionStringName,
                     ElasticIndexes =
                     {
@@ -47,7 +47,7 @@ namespace SlowTests.Server.Documents.ETL.ElasticSearch
                     {
                         new Transformation
                         {
-                            Name = $"ETL : {connectionStringName}",
+                            Name = transformationName ?? $"ETL : {connectionStringName}",
                             Collections = new List<string>(collections),
                             Script = script,
                             ApplyToAllDocuments = applyToAllDocuments

--- a/test/SlowTests/Server/Documents/ETL/Elasticsearch/RavenDB_17477.cs
+++ b/test/SlowTests/Server/Documents/ETL/Elasticsearch/RavenDB_17477.cs
@@ -1,0 +1,58 @@
+﻿using System;
+using System.Collections.Generic;
+using System.Linq;
+using Orders;
+using Tests.Infrastructure;
+using Xunit;
+using Xunit.Abstractions;
+
+namespace SlowTests.Server.Documents.ETL.ElasticSearch
+{
+    public class RavenDB_17477 : ElasticSearchEtlTestBase
+    {
+        public RavenDB_17477(ITestOutputHelper output) : base(output)
+        {
+        }
+
+        [RequiresElasticSearchFact]
+        public void ShouldErrorAndAlertOnInvalidIndexSetupInElastic()
+        {
+            using (var store = GetDocumentStore())
+            using (GetElasticClient(out var client))
+            {
+                client.Indices.Create("orders", c => c
+                    .Map(m => m
+                        .Properties(p => p
+                            .MatchOnlyText(t => t
+                                .Name("Id")))));
+
+                SetupElasticEtl(store, @"
+var orderData = {
+    Id: id(this),
+    OrderLinesCount: this.Lines.length,
+    TotalCost: 0
+};
+
+loadToOrders(orderData);
+", new List<string> { "orders" }, configurationName: "my-etl", transformationName: "my-transformation");
+                var etlDone = WaitForEtl(store, (n, statistics) => statistics.LoadErrors != 0);
+
+                using (var session = store.OpenSession())
+                {
+                    session.Store(new Order { Lines = new List<OrderLine>() });
+                    session.SaveChanges();
+                }
+
+                etlDone.Wait(TimeSpan.FromSeconds(15));
+
+                using (GetDatabase(store.Database).Result.NotificationCenter.GetStored(out var alerts, false))
+                {
+                    var alert = alerts.Where(x => x.Json.ToString().Contains("The index 'orders' has invalid mapping for 'Id' property."));
+
+                    Assert.NotNull(alert);
+                }
+
+            }
+        }
+    }
+}


### PR DESCRIPTION
### Issue link

https://issues.hibernatingrhinos.com/issue/RavenDB-17477

### Additional description

If an elasticsearch index was created by user then let's verify on a attempt to use it that the property where RavenDB document ID is going to be put isn't analized so we'll be able to properly delete by query.

### Type of change

- UX enhancement

### How risky is the change?

- Low 

### Backward compatibility

- Not relevant

### Is it platform specific issue?

- Yes. Please list the affected platforms.
- No

### Documentation update

- No documentation update is needed 

### Testing 

- Tests have been added that prove the fix is effective or that the feature works

### Is there any existing behavior change of other features due to this change?

- No

### UI work

- No UI work is needed
