### PR TITLE
RavenDB-17485 Incorrect results in time series table for group by action

### DIFF
--- a/src/Raven.Studio/typescript/viewmodels/database/query/query.ts
+++ b/src/Raven.Studio/typescript/viewmodels/database/query/query.ts
@@ -1509,7 +1509,7 @@ class query extends viewModelBase {
             this.effectiveFetcher = ko.observable<fetcherType>(() => {
                 return $.when({
                     items: tab.value.Results.map(x => new document(x)),
-                    totalResultCount: tab.value.Count
+                    totalResultCount: tab.value.Results.length
                 });
             });
 


### PR DESCRIPTION
### Issue link
https://issues.hibernatingrhinos.com/issue/RavenDB-17485

### Additional description
Fix length of items for the grid in the time series table results

### Type of change
- Bug fix

### How risky is the change?
- Low 

### Backward compatibility
- Non breaking change

### Is it platform specific issue?
- No

### Documentation update
- No documentation update is needed 

### Testing 
- It has been verified by manual testing

### Is there any existing behavior change of other features due to this change?
- No

### UI work
- No UI work is needed
