### PR TITLE
RavenDB-17124 - fixed Sink Tasks URLs are incorrect

### DIFF
--- a/src/Raven.Server/Documents/Replication/ReplicationLoader.cs
+++ b/src/Raven.Server/Documents/Replication/ReplicationLoader.cs
@@ -1650,6 +1650,22 @@ namespace Raven.Server.Documents.Replication
             return (null, OngoingTaskConnectionStatus.NotActive);
         }
 
+        public (string Url, OngoingTaskConnectionStatus Status) GetPullReplicationDestination(long taskId, string db)
+        {
+            //outgoing connections have the same task id per pull replication
+            foreach (var outgoing in OutgoingConnections)
+            {
+                if (outgoing is ExternalReplication ex && ex.TaskId == taskId && outgoing.Database == db)
+                    return (ex.Url, OngoingTaskConnectionStatus.Active);
+            }
+            foreach (var reconnect in ReconnectQueue)
+            {
+                if (reconnect is ExternalReplication ex && ex.TaskId == taskId && reconnect.Database == db)
+                    return (ex.Url, OngoingTaskConnectionStatus.Reconnect);
+            }
+            return (null, OngoingTaskConnectionStatus.NotActive);
+        }
+
         private void OnIncomingReceiveFailed(IncomingReplicationHandler instance, Exception e)
         {
             using (instance)

--- a/src/Raven.Server/Documents/Replication/ReplicationLoader.cs
+++ b/src/Raven.Server/Documents/Replication/ReplicationLoader.cs
@@ -1655,12 +1655,12 @@ namespace Raven.Server.Documents.Replication
             //outgoing connections have the same task id per pull replication
             foreach (var outgoing in OutgoingConnections)
             {
-                if (outgoing is ExternalReplication ex && ex.TaskId == taskId && outgoing.Database == db)
+                if (outgoing is ExternalReplication ex && ex.TaskId == taskId && db.Equals(outgoing.Database, StringComparison.OrdinalIgnoreCase))
                     return (ex.Url, OngoingTaskConnectionStatus.Active);
             }
             foreach (var reconnect in ReconnectQueue)
             {
-                if (reconnect is ExternalReplication ex && ex.TaskId == taskId && reconnect.Database == db)
+                if (reconnect is ExternalReplication ex && ex.TaskId == taskId && db.Equals(reconnect.Database, StringComparison.OrdinalIgnoreCase))
                     return (ex.Url, OngoingTaskConnectionStatus.Reconnect);
             }
             return (null, OngoingTaskConnectionStatus.NotActive);

--- a/src/Raven.Server/Web/System/OngoingTasksHandler.cs
+++ b/src/Raven.Server/Web/System/OngoingTasksHandler.cs
@@ -191,7 +191,7 @@ namespace Raven.Server.Web.System
 
         private OngoingTaskPullReplicationAsHub GetPullReplicationAsHubTaskInfo(ClusterTopology clusterTopology, ExternalReplication ex)
         {
-            var connectionResult = Database.ReplicationLoader.GetExternalReplicationDestination(ex.TaskId);
+            var connectionResult = Database.ReplicationLoader.GetPullReplicationDestination(ex.TaskId, ex.Database);
             var tag = Server.ServerStore.NodeTag; // we can't know about pull replication tasks on other nodes.
 
             return new OngoingTaskPullReplicationAsHub


### PR DESCRIPTION
### Issue link

https://issues.hibernatingrhinos.com/issue/RavenDB-17124

### Additional description

Sink URLs were fetched under the assumption that each outgoing sink instance has a unique task id, so it kept fetching the first one in the outgoing list. Created a dedicated function that checks according to database name as well. 

_Please delete below the options that are not relevant_

### Type of change

- Bug fix

### How risky is the change?

- Low 

### Backward compatibility

- Non breaking change

### Is it platform specific issue?

- No

### Documentation update

- No documentation update is needed 

### Testing 

- Test added

### Is there any existing behavior change of other features due to this change?

- No

### UI work

- No UI work is needed
