### PR TITLE
RavenDB-17492 : stop replication on attempt to send incremental time series to an old server

### DIFF
--- a/src/Raven.Client/ServerWide/Tcp/TcpConnectionHeader.cs
+++ b/src/Raven.Client/ServerWide/Tcp/TcpConnectionHeader.cs
@@ -253,6 +253,7 @@ namespace Raven.Client.ServerWide.Tcp
                 public bool ClusterTransaction;
                 public bool PullReplication;
                 public bool TimeSeries;
+                public bool IncrementalTimeSeries;
             }
         }
 
@@ -381,7 +382,8 @@ namespace Raven.Client.ServerWide.Tcp
                             PullReplication = true,
                             TimeSeries = true,
                             CaseInsensitiveCounters = true,
-                            ClusterTransaction = true
+                            ClusterTransaction = true,
+                            IncrementalTimeSeries = true
                         }
                     },
                     [ReplicationWithTimeSeries] = new SupportedFeatures(ReplicationWithTimeSeries)

--- a/src/Raven.Server/Documents/Replication/ReplicationDocumentSender.cs
+++ b/src/Raven.Server/Documents/Replication/ReplicationDocumentSender.cs
@@ -401,6 +401,11 @@ namespace Raven.Server.Documents.Replication
             {
                 AssertNotClusterTransactionDocumentForLegacyReplication(item);
             }
+
+            if (_parent.SupportedFeatures.Replication.TimeSeries == false)
+            {
+                AssertNotTimeSeriesForLegacyReplication(item);
+            }
         }
 
         private bool CanContinueBatch(ReplicationState state, ref long next)
@@ -428,10 +433,6 @@ namespace Raven.Server.Documents.Replication
                 }
             }
 
-            if (_parent.SupportedFeatures.Replication.TimeSeries == false)
-            {
-                AssertNotTimeSeriesForLegacyReplication(state.Item);
-            }
             if (_parent.SupportedFeatures.Replication.IncrementalTimeSeries == false)
             {
                 AssertNotIncrementalTimeSeriesForLegacyReplication(state.Item);

--- a/src/Raven.Server/Documents/Replication/ReplicationDocumentSender.cs
+++ b/src/Raven.Server/Documents/Replication/ReplicationDocumentSender.cs
@@ -253,6 +253,8 @@ namespace Raven.Server.Documents.Replication
 
                             _parent.CancellationToken.ThrowIfCancellationRequested();
 
+                            AssertNoLegacyReplicationViolation(item);
+
                             if (replicationState.LastTransactionMarker != item.TransactionMarker)
                             {
                                 replicationState.Item = item;
@@ -388,6 +390,19 @@ namespace Raven.Server.Documents.Replication
             }
         }
 
+        private void AssertNoLegacyReplicationViolation(ReplicationBatchItem item)
+        {
+            if (_parent.SupportedFeatures.Replication.CountersBatch == false)
+            {
+                AssertNotCounterForLegacyReplication(item);
+            }
+
+            if (_parent.SupportedFeatures.Replication.ClusterTransaction == false)
+            {
+                AssertNotClusterTransactionDocumentForLegacyReplication(item);
+            }
+        }
+
         private bool CanContinueBatch(ReplicationState state, ref long next)
         {
             if (MissingAttachmentsInLastBatch)
@@ -417,17 +432,6 @@ namespace Raven.Server.Documents.Replication
             {
                 AssertNotTimeSeriesForLegacyReplication(state.Item);
             }
-
-            if (_parent.SupportedFeatures.Replication.CountersBatch == false)
-            {
-                AssertNotCounterForLegacyReplication(state.Item);
-            }
-
-            if (_parent.SupportedFeatures.Replication.ClusterTransaction == false)
-            {
-                AssertNotClusterTransactionDocumentForLegacyReplication(state.Item);
-            }
-
             if (_parent.SupportedFeatures.Replication.IncrementalTimeSeries == false)
             {
                 AssertNotIncrementalTimeSeriesForLegacyReplication(state.Item);

--- a/src/Raven.Server/Documents/Replication/ReplicationDocumentSender.cs
+++ b/src/Raven.Server/Documents/Replication/ReplicationDocumentSender.cs
@@ -406,6 +406,11 @@ namespace Raven.Server.Documents.Replication
             {
                 AssertNotTimeSeriesForLegacyReplication(item);
             }
+
+            if (_parent.SupportedFeatures.Replication.IncrementalTimeSeries == false)
+            {
+                AssertNotIncrementalTimeSeriesForLegacyReplication(item);
+            }
         }
 
         private bool CanContinueBatch(ReplicationState state, ref long next)
@@ -431,11 +436,6 @@ namespace Raven.Server.Documents.Replication
                         return false;
                     }
                 }
-            }
-
-            if (_parent.SupportedFeatures.Replication.IncrementalTimeSeries == false)
-            {
-                AssertNotIncrementalTimeSeriesForLegacyReplication(state.Item);
             }
 
             // We want to limit batch sizes to reasonable limits.

--- a/test/InterversionTests/RavenDB-17518.cs
+++ b/test/InterversionTests/RavenDB-17518.cs
@@ -1,0 +1,81 @@
+﻿using System.Linq;
+using System.Threading.Tasks;
+using Raven.Client.Documents;
+using Raven.Client.Documents.Operations.ConnectionStrings;
+using Raven.Client.Documents.Operations.ETL;
+using Raven.Client.Documents.Operations.OngoingTasks;
+using Raven.Client.Documents.Operations.Replication;
+using Raven.Client.Exceptions;
+using Raven.Tests.Core.Utils.Entities;
+using Tests.Infrastructure;
+using Xunit;
+using Xunit.Abstractions;
+
+namespace InterversionTests
+{
+    public class RavenDB_17518 : InterversionTestBase
+    {
+        public RavenDB_17518(ITestOutputHelper output) : base(output)
+        {
+        }
+
+        [Fact]
+        public async Task ShouldNotReplicateCountersToOldServer()
+        {
+            const string docId = "users/1";
+            using (var oldStore = await GetDocumentStoreAsync("4.0.7"))
+            using (var store = GetDocumentStore())
+            {
+                using (var session = store.OpenAsyncSession())
+                {
+                    await session.StoreAsync(new User { Name = "ayende" }, docId);
+                    session.CountersFor(docId)
+                        .Increment("likes");
+                    await session.SaveChangesAsync();
+                }
+
+                using (var session = store.OpenAsyncSession())
+                {
+                    var u = await session.LoadAsync<User>(docId);
+                    session.CountersFor(u)
+                        .Increment("likes");
+
+                    u.Name = "oren";
+
+                    await session.SaveChangesAsync();
+                }
+
+                await SetupReplication(store, oldStore);
+
+                var replicationLoader = (await GetDocumentDatabaseInstanceFor(store)).ReplicationLoader;
+                Assert.NotEmpty(replicationLoader.OutgoingFailureInfo);
+                Assert.True(WaitForValue(() => replicationLoader.OutgoingFailureInfo.Any(ofi => ofi.Value.RetriesCount > 2), true));
+                Assert.True(replicationLoader.OutgoingFailureInfo.Any(ofi => ofi.Value.Errors.Any(x => x.GetType() == typeof(LegacyReplicationViolationException))));
+                Assert.True(replicationLoader.OutgoingFailureInfo.Any(ofi => ofi.Value.Errors.Select(x => x.Message).Any(x => x.Contains("CounterGroup"))));
+            }
+        }
+
+        private static async Task<ModifyOngoingTaskResult> SetupReplication(IDocumentStore src, IDocumentStore dst)
+        {
+            var csName = $"cs-to-{dst.Database}";
+            var result = await src.Maintenance.SendAsync(new PutConnectionStringOperation<RavenConnectionString>(new RavenConnectionString
+            {
+                Name = csName,
+                Database = dst.Database,
+                TopologyDiscoveryUrls = new[]
+                {
+                    dst.Urls.First()
+                }
+            }));
+            Assert.NotNull(result.RaftCommandIndex);
+
+            var op = new UpdateExternalReplicationOperation(new ExternalReplication(dst.Database.ToLowerInvariant(), csName)
+            {
+                Name = $"ExternalReplicationTo{dst.Database}",
+                Url = dst.Urls.First()
+            });
+
+            return await src.Maintenance.SendAsync(op);
+        }
+    }
+}

--- a/test/InterversionTests/RavenDB-17518.cs
+++ b/test/InterversionTests/RavenDB-17518.cs
@@ -1,4 +1,5 @@
-﻿using System.Linq;
+﻿using System;
+using System.Linq;
 using System.Threading.Tasks;
 using Raven.Client.Documents;
 using Raven.Client.Documents.Operations.ConnectionStrings;
@@ -52,6 +53,42 @@ namespace InterversionTests
                 Assert.True(WaitForValue(() => replicationLoader.OutgoingFailureInfo.Any(ofi => ofi.Value.RetriesCount > 2), true));
                 Assert.True(replicationLoader.OutgoingFailureInfo.Any(ofi => ofi.Value.Errors.Any(x => x.GetType() == typeof(LegacyReplicationViolationException))));
                 Assert.True(replicationLoader.OutgoingFailureInfo.Any(ofi => ofi.Value.Errors.Select(x => x.Message).Any(x => x.Contains("CounterGroup"))));
+            }
+        }
+
+        [Fact]
+        public async Task ShouldNotReplicateTimeSeriesToOldServer()
+        {
+            const string docId = "users/1";
+            using (var oldStore = await GetDocumentStoreAsync("4.2.117"))
+            using (var store = GetDocumentStore())
+            {
+                using (var session = store.OpenAsyncSession())
+                {
+                    await session.StoreAsync(new User { Name = "ayende" }, docId);
+                    session.TimeSeriesFor(docId, "HeartRate")
+                        .Append(DateTime.UtcNow, 1);
+                    await session.SaveChangesAsync();
+                }
+
+                using (var session = store.OpenAsyncSession())
+                {
+                    var u = await session.LoadAsync<User>(docId);
+                    session.TimeSeriesFor(u, "HeartRate")
+                        .Append(DateTime.UtcNow, 1);
+
+                    u.Name = "oren";
+
+                    await session.SaveChangesAsync();
+                }
+
+                await SetupReplication(store, oldStore);
+
+                var replicationLoader = (await GetDocumentDatabaseInstanceFor(store)).ReplicationLoader;
+                Assert.NotEmpty(replicationLoader.OutgoingFailureInfo);
+                Assert.True(WaitForValue(() => replicationLoader.OutgoingFailureInfo.Any(ofi => ofi.Value.RetriesCount > 2), true));
+                Assert.True(replicationLoader.OutgoingFailureInfo.Any(ofi => ofi.Value.Errors.Any(x => x.GetType() == typeof(LegacyReplicationViolationException))));
+                Assert.True(replicationLoader.OutgoingFailureInfo.Any(ofi => ofi.Value.Errors.Select(x => x.Message).Any(x => x.Contains("TimeSeries"))));
             }
         }
 

--- a/test/InterversionTests/ReplicationTests.cs
+++ b/test/InterversionTests/ReplicationTests.cs
@@ -1,12 +1,14 @@
 ﻿using System;
 using System.Linq;
 using System.Threading.Tasks;
+using Raven.Client;
 using Raven.Client.Documents;
 using Raven.Client.Documents.Operations;
 using Raven.Client.Documents.Operations.ConnectionStrings;
 using Raven.Client.Documents.Operations.ETL;
 using Raven.Client.Documents.Operations.OngoingTasks;
 using Raven.Client.Documents.Operations.Replication;
+using Raven.Client.Documents.Operations.TimeSeries;
 using Raven.Client.Exceptions;
 using Raven.Tests.Core.Utils.Entities;
 using Tests.Infrastructure;
@@ -79,6 +81,118 @@ namespace InterversionTests
 
             Assert.True(WaitForDocument<User>(oldStore, "users/1", u => u.Name == "Egor"));
         }
+
+        [Fact]
+        public async Task IncrementalTimeSeriesWithDuplicatesShouldNotBreakReplicationToOldServer()
+        {
+            const string version = "5.2.3";
+            const string incrementalTsName = Constants.Headers.IncrementalTimeSeriesPrefix + "HeartRate";
+            const string docId = "users/1";
+            var baseline = DateTime.UtcNow;
+
+            using (var oldStore = await GetDocumentStoreAsync(version))
+            using (var storeA = GetDocumentStore())
+            using (var storeB = GetDocumentStore())
+            {
+                await SetupReplication(storeA, storeB);
+                await SetupReplication(storeB, storeA);
+
+                using (var session = storeA.OpenAsyncSession())
+                {
+                    await session.StoreAsync(new User { Name = "ayende" }, docId);
+                    await session.SaveChangesAsync();
+                }
+                Assert.True(WaitForDocument<User>(storeB, docId, u => u.Name == "ayende"));
+
+                // increment on storeA
+                using (var session = storeA.OpenSession())
+                {
+                    session.IncrementalTimeSeriesFor(docId, incrementalTsName)
+                        .Increment(baseline, 1);
+
+                    session.SaveChanges();
+                }
+                await EnsureReplicatingAsync(storeA, storeB);
+
+                // increment on storeB
+                using (var session = storeB.OpenSession())
+                {
+                    session.IncrementalTimeSeriesFor(docId, incrementalTsName)
+                        .Increment(baseline, 1);
+
+                    session.SaveChanges();
+                }
+                await EnsureReplicatingAsync(storeB, storeA);
+
+                foreach (var store in new[] { storeA, storeB })
+                {
+                    var values = store.Operations
+                        .Send(new GetTimeSeriesOperation(docId, incrementalTsName, returnFullResults: true));
+
+                    Assert.NotNull(values.TotalResults);
+                    Assert.NotNull(values.SkippedResults);
+
+                    Assert.Equal(2, values.TotalResults);
+                    Assert.Equal(1, values.SkippedResults);
+
+                    foreach (var entry in values.Entries)
+                    {
+                        Assert.NotEmpty(entry.NodeValues);
+                        Assert.Equal(2, entry.NodeValues.Count);
+
+                        foreach (var nodeValue in entry.NodeValues)
+                        {
+                            Assert.Equal(1, nodeValue.Value.Length);
+                            Assert.Equal(1, nodeValue.Value[0]);
+                        }
+                    }
+                }
+
+                // replicate to old server
+                // this replication batch should work, because the destination will append the entire ts-segment
+                await SetupReplication(storeA, oldStore);
+
+                await EnsureReplicatingAsync(storeA, oldStore);
+                await EnsureNoReplicationLoop(Server, storeA.Database);
+
+                // increment on storeA
+                using (var session = storeA.OpenSession())
+                {
+                    session.IncrementalTimeSeriesFor(docId, incrementalTsName)
+                        .Increment(baseline, 1);
+
+                    session.SaveChanges();
+                }
+
+                // now the destination can't append the entire segment and will enumerate all values
+                await EnsureReplicatingAsync(storeA, oldStore);
+                await EnsureNoReplicationLoop(Server, storeA.Database);
+            }
+        }
+
+        private static async Task<ModifyOngoingTaskResult> SetupReplication(IDocumentStore src, IDocumentStore dst)
+        {
+            var csName = $"cs-to-{dst.Database}";
+            var result = await src.Maintenance.SendAsync(new PutConnectionStringOperation<RavenConnectionString>(new RavenConnectionString
+            {
+                Name = csName,
+                Database = dst.Database,
+                TopologyDiscoveryUrls = new[]
+                {
+                    dst.Urls.First()
+                }
+            }));
+            Assert.NotNull(result.RaftCommandIndex);
+
+            var op = new UpdateExternalReplicationOperation(new ExternalReplication(dst.Database.ToLowerInvariant(), csName)
+            {
+                Name = $"ExternalReplicationTo{dst.Database}",
+                Url = dst.Urls.First()
+            });
+
+            return await src.Maintenance.SendAsync(op);
+        }
+
 
         private static async Task<ModifyOngoingTaskResult> SetupReplication(IDocumentStore store, ExternalReplicationBase watcher)
         {


### PR DESCRIPTION
### Issue link

https://issues.hibernatingrhinos.com/issue/RavenDB-17492

### Additional description

- add `IncrementalTimeSeries` to `SupportedFeatures.Replication`
- stop replication and throw an error on attempt to replicate incremental time series to an old node with a lower protocol version
- add inter version test