### PR TITLE
RavenDB-17477 Skipping a test that is the suspicion of test hangs

### DIFF
--- a/test/SlowTests/Server/Documents/ETL/Elasticsearch/RavenDB_17477.cs
+++ b/test/SlowTests/Server/Documents/ETL/Elasticsearch/RavenDB_17477.cs
@@ -14,7 +14,7 @@ namespace SlowTests.Server.Documents.ETL.ElasticSearch
         {
         }
 
-        [RequiresElasticSearchFact]
+        [RequiresElasticSearchFact(Skip = "Suspicion that this test causes test hangs")]
         public void ShouldErrorAndAlertOnInvalidIndexSetupInElastic()
         {
             using (var store = GetDocumentStore())


### PR DESCRIPTION
### Issue link

https://issues.hibernatingrhinos.com/issue/RavenDB-17477

### Additional description

I have a suspicion that this tests somehow makes that 5.3 test builds are hanging.

### Type of change

- Tests fix

### How risky is the change?

- Low 

### Backward compatibility

- Not relevant

### Is it platform specific issue?

- No

### Documentation update

- No documentation update is needed 

### Testing 

- Not relevant

### Is there any existing behavior change of other features due to this change?

- No

### UI work

- No UI work is needed
