### PR TITLE
RavenDB-17482 Expose number of faulted and errored databases in SNMP

### DIFF
--- a/src/Raven.Server/Monitoring/Snmp/Objects/Database/5.1/DatabaseBase.cs
+++ b/src/Raven.Server/Monitoring/Snmp/Objects/Database/5.1/DatabaseBase.cs
@@ -30,7 +30,7 @@ namespace Raven.Server.Monitoring.Snmp.Objects.Database
             {
                 var databaseTask = kvp.Value;
 
-                if (databaseTask.IsCompletedSuccessfully == false)
+                if (databaseTask == null || databaseTask.IsCompletedSuccessfully == false)
                     continue;
 
                 yield return databaseTask.Result;

--- a/src/Raven.Server/Monitoring/Snmp/Objects/Database/5.1/DatabaseFaultedCount.cs
+++ b/src/Raven.Server/Monitoring/Snmp/Objects/Database/5.1/DatabaseFaultedCount.cs
@@ -1,0 +1,35 @@
+using Lextm.SharpSnmpLib;
+using Raven.Server.ServerWide;
+
+namespace Raven.Server.Monitoring.Snmp.Objects.Database
+{
+    public class DatabaseFaultedCount : DatabaseBase<Integer32>
+    {
+        public DatabaseFaultedCount(ServerStore serverStore)
+            : base(serverStore, SnmpOids.Databases.General.FaultedCount)
+        {
+        }
+
+        protected override Integer32 GetData()
+        {
+            return new Integer32(GetCount());
+        }
+
+        private int GetCount()
+        {
+            var count = 0;
+            foreach (var kvp in ServerStore.DatabasesLandlord.DatabasesCache)
+            {
+                var databaseTask = kvp.Value;
+
+                if (databaseTask == null)
+                    continue;
+
+                if (databaseTask.IsFaulted)
+                    count++;
+            }
+
+            return count;
+        }
+    }
+}

--- a/src/Raven.Server/Monitoring/Snmp/SnmpOids.cs
+++ b/src/Raven.Server/Monitoring/Snmp/SnmpOids.cs
@@ -493,6 +493,9 @@ namespace Raven.Server.Monitoring.Snmp
                 [Description("Number of bytes written (documents, attachments, counters) in all loaded databases")]
                 public const string TotalDataWrittenPerSecond = "5.1.9.2";
 
+                [Description("Number of faulted databases")]
+                public const string FaultedCount = "5.1.10";
+
                 public static DynamicJsonArray ToJson()
                 {
                     var array = new DynamicJsonArray();

--- a/src/Raven.Server/Monitoring/Snmp/SnmpWatcher.cs
+++ b/src/Raven.Server/Monitoring/Snmp/SnmpWatcher.cs
@@ -421,6 +421,7 @@ namespace Raven.Server.Monitoring.Snmp
             store.Add(new DatabaseOldestBackup(server.ServerStore));
             store.Add(new DatabaseDisabledCount(server.ServerStore));
             store.Add(new DatabaseEncryptedCount(server.ServerStore));
+            store.Add(new DatabaseFaultedCount(server.ServerStore));
             store.Add(new DatabaseNodeCount(server.ServerStore));
 
             store.Add(new TotalDatabaseNumberOfIndexes(server.ServerStore));


### PR DESCRIPTION
### Issue link

https://issues.hibernatingrhinos.com/issue/RavenDB-17482

### Type of change

- New feature

### How risky is the change?

- Low 

### Backward compatibility

- Not relevant

### Is it platform specific issue?

- No

### Documentation update

- This change requires a documentation update. Please mark the issue on YouTrack using `Documentation Required` tag.

### Testing 

- It has been verified by manual testing

### Is there any existing behavior change of other features due to this change?

- No

### UI work

- No UI work is needed
