### PR TITLE
RavenDB-17493 `StatefulTimestampValue` should reflect unique values

### DIFF
--- a/src/Raven.Client/Documents/Operations/TimeSeries/TimeSeriesRangeResult.cs
+++ b/src/Raven.Client/Documents/Operations/TimeSeries/TimeSeriesRangeResult.cs
@@ -13,7 +13,6 @@ namespace Raven.Client.Documents.Operations.TimeSeries
         public TimeSeriesEntry[] Entries;
         public long? TotalResults;
         internal string Hash;
-        public int? SkippedResults;
 
         public BlittableJsonReaderObject Includes;
 

--- a/src/Raven.Server/Documents/Handlers/TimeSeriesHandler.cs
+++ b/src/Raven.Server/Documents/Handlers/TimeSeriesHandler.cs
@@ -387,6 +387,8 @@ namespace Raven.Server.Documents.Handlers
 
             var incrementalValues = new Dictionary<long, TimeSeriesEntry>();
             var reader = new TimeSeriesReader(context, docId, name, from, to, offset: null);
+            reader.ForceYieldDuplicateValues();
+
             var dbCv = context.LastDatabaseChangeVector ?? DocumentsStorage.GetDatabaseChangeVector(context);
 
             // init hash

--- a/src/Raven.Server/Documents/Queries/Results/TimeSeries/AggregationHolder.cs
+++ b/src/Raven.Server/Documents/Queries/Results/TimeSeries/AggregationHolder.cs
@@ -24,6 +24,8 @@ namespace Raven.Server.Documents.Queries.Results.TimeSeries
         private readonly InterpolationType _interpolationType;
 
         private readonly AggregationType[] _types;
+        public bool Contains(AggregationType type) => _types.Contains(type);
+
         private readonly string[] _names;
         private double? _percentile;
 

--- a/src/Raven.Server/Documents/Queries/Results/TimeSeries/TimeSeriesRetriever.cs
+++ b/src/Raven.Server/Documents/Queries/Results/TimeSeries/TimeSeriesRetriever.cs
@@ -775,7 +775,7 @@ namespace Raven.Server.Documents.Queries.Results.TimeSeries
 
         private static bool IsLastDuplicate(TimeSeriesValuesSegment segment, AggregationHolder aggregationHolder)
         {
-            return segment.Version == SegmentVersion.DuplicateLast && aggregationHolder.Contains(AggregationType.Last);
+            return segment.Version.ContainsLastValueDuplicate && aggregationHolder.Contains(AggregationType.Last);
         }
 
         private (long Count, DateTime Start, DateTime End) GetStatsAndRemoveQuotesIfNeeded(string documentId)

--- a/src/Raven.Server/Documents/Queries/Results/TimeSeries/TimeSeriesRetriever.cs
+++ b/src/Raven.Server/Documents/Queries/Results/TimeSeries/TimeSeriesRetriever.cs
@@ -232,7 +232,7 @@ namespace Raven.Server.Documents.Queries.Results.TimeSeries
                         // if the range it cover needs to be broken up to multiple ranges.
                         // For example, if the segment covers 3 days, but we have group by 1 hour,
                         // we still have to deal with the individual values
-                        if (it.Segment.End > rangeSpec.End || _individualValuesOnly)
+                        if (it.Segment.End > rangeSpec.End || _individualValuesOnly || IsLastDuplicate(it.Segment.Summary, aggregationHolder))
                         {
                             foreach (var value in AggregateIndividualItems(it.Segment.Values))
                             {
@@ -771,6 +771,11 @@ namespace Raven.Server.Documents.Queries.Results.TimeSeries
 
                 return field.FieldValueWithoutAlias;
             }
+        }
+
+        private static bool IsLastDuplicate(TimeSeriesValuesSegment segment, AggregationHolder aggregationHolder)
+        {
+            return segment.Version == SegmentVersion.DuplicateLast && aggregationHolder.Contains(AggregationType.Last);
         }
 
         private (long Count, DateTime Start, DateTime End) GetStatsAndRemoveQuotesIfNeeded(string documentId)

--- a/src/Raven.Server/Documents/TimeSeries/SegmentHeader.cs
+++ b/src/Raven.Server/Documents/TimeSeries/SegmentHeader.cs
@@ -23,14 +23,35 @@ namespace Raven.Server.Documents.TimeSeries
         public fixed byte Reserved[1];
     }
 
-    public enum SegmentVersion : byte
+    [StructLayout(LayoutKind.Explicit, Size = 1)]
+    public struct SegmentVersion
+    {
+        [FieldOffset(0)]
+        public Version Number;
+
+        public static SegmentVersion Create() => new SegmentVersion(Version.Baseline);
+
+        private SegmentVersion(Version number)
+        {
+            Number = number;
+        }
+
+        public bool ContainsDuplicates => (Number & Version.Duplicates) != 0;
+        public void SetDuplicates() => Number |= Version.Duplicates;
+
+        public void SetLastValueDuplicate() => Number |= (Version.LastDuplicate | Version.Duplicates);
+        public void ClearLastValueDuplicate() => Number &= ~Version.LastDuplicate;
+        public bool ContainsLastValueDuplicate => (Number & Version.LastDuplicate) != 0;
+    }
+
+    public enum Version : byte
     {
         V50000 = 0,
         V50001 = 1,
+        Baseline = V50001,
 
-        ContainDuplicates = byte.MaxValue, // segment contain duplicates
-        DuplicateLast = byte.MaxValue - 1, // last value in the segment is a duplicate
-
-        Baseline = V50001
+        // last 2 bits treated as flags
+        Duplicates = 0b0100_0000, // segment contain duplicates
+        LastDuplicate = 0b1000_0000 // last value in the segment is a duplicate
     }
 }

--- a/src/Raven.Server/Documents/TimeSeries/SegmentHeader.cs
+++ b/src/Raven.Server/Documents/TimeSeries/SegmentHeader.cs
@@ -27,8 +27,9 @@ namespace Raven.Server.Documents.TimeSeries
     {
         V50000 = 0,
         V50001 = 1,
-        ContainDuplicates = 2, // segment contain duplicates
-        DuplicateLast = 3, // last value in the segment is a duplicate
+
+        ContainDuplicates = byte.MaxValue, // segment contain duplicates
+        DuplicateLast = byte.MaxValue - 1, // last value in the segment is a duplicate
 
         Baseline = V50001
     }

--- a/src/Raven.Server/Documents/TimeSeries/SegmentHeader.cs
+++ b/src/Raven.Server/Documents/TimeSeries/SegmentHeader.cs
@@ -26,8 +26,10 @@ namespace Raven.Server.Documents.TimeSeries
     public enum SegmentVersion : byte
     {
         V50000 = 0,
-        Baseline = 1,
+        V50001 = 1,
         ContainDuplicates = 2, // segment contain duplicates
-        DuplicateLast = 3 // last value in the segment is a duplicate
+        DuplicateLast = 3, // last value in the segment is a duplicate
+
+        Baseline = V50001
     }
 }

--- a/src/Raven.Server/Documents/TimeSeries/SegmentHeader.cs
+++ b/src/Raven.Server/Documents/TimeSeries/SegmentHeader.cs
@@ -27,6 +27,7 @@ namespace Raven.Server.Documents.TimeSeries
     {
         V50000 = 0,
         V50001 = 1,
-        Current = V50001
+        ContainDuplicates = 2, // segment contain duplicates
+        DuplicateLast = 3 // last value in the segment is a duplicate
     }
 }

--- a/src/Raven.Server/Documents/TimeSeries/SegmentHeader.cs
+++ b/src/Raven.Server/Documents/TimeSeries/SegmentHeader.cs
@@ -26,7 +26,7 @@ namespace Raven.Server.Documents.TimeSeries
     public enum SegmentVersion : byte
     {
         V50000 = 0,
-        V50001 = 1,
+        Baseline = 1,
         ContainDuplicates = 2, // segment contain duplicates
         DuplicateLast = 3 // last value in the segment is a duplicate
     }

--- a/src/Raven.Server/Documents/TimeSeries/TimeSeriesRollups.cs
+++ b/src/Raven.Server/Documents/TimeSeries/TimeSeriesRollups.cs
@@ -881,7 +881,7 @@ namespace Raven.Server.Documents.TimeSeries
                     // if the range it cover needs to be broken up to multiple ranges.
                     // For example, if the segment covers 3 days, but we have group by 1 hour,
                     // we still have to deal with the individual values
-                    if (it.Segment.End > rangeSpec.End || it.Segment.Summary.Version == SegmentVersion.DuplicateLast)
+                    if (it.Segment.End > rangeSpec.End || it.Segment.Summary.Version.ContainsLastValueDuplicate)
                     {
                         AggregateIndividualItems(it.Segment.Values);
                     }

--- a/src/Raven.Server/Documents/TimeSeries/TimeSeriesRollups.cs
+++ b/src/Raven.Server/Documents/TimeSeries/TimeSeriesRollups.cs
@@ -881,7 +881,7 @@ namespace Raven.Server.Documents.TimeSeries
                     // if the range it cover needs to be broken up to multiple ranges.
                     // For example, if the segment covers 3 days, but we have group by 1 hour,
                     // we still have to deal with the individual values
-                    if (it.Segment.End > rangeSpec.End)
+                    if (it.Segment.End > rangeSpec.End || it.Segment.Summary.Version == SegmentVersion.DuplicateLast)
                     {
                         AggregateIndividualItems(it.Segment.Values);
                     }

--- a/src/Raven.Server/Documents/TimeSeries/TimeSeriesStorage.cs
+++ b/src/Raven.Server/Documents/TimeSeries/TimeSeriesStorage.cs
@@ -941,6 +941,9 @@ namespace Raven.Server.Documents.TimeSeries
 
             public long AppendExistingSegment(TimeSeriesValuesSegment newValueSegment)
             {
+                if (newValueSegment.RecomputeRequired)
+                    newValueSegment = newValueSegment.Recompute(_context.Allocator);
+
                 (_currentChangeVector, _currentEtag) = _tss.GenerateChangeVector(_context);
 
                 ValidateSegment(newValueSegment);
@@ -2327,6 +2330,9 @@ namespace Raven.Server.Documents.TimeSeries
         {
             if (segment.NumberOfBytes > MaxSegmentSize)
                 throw new ArgumentOutOfRangeException("Attempted to write a time series segment that is larger (" + segment.NumberOfBytes + ") than the maximum size allowed.");
+
+            if (segment.RecomputeRequired)
+                throw new InvalidOperationException("Recomputation of this segment is required.");
         }
 
         public long GetNumberOfTimeSeriesSegments(DocumentsOperationContext context)

--- a/src/Raven.Studio/typescript/viewmodels/database/documents/editDocumentConnectedDocuments.ts
+++ b/src/Raven.Studio/typescript/viewmodels/database/documents/editDocumentConnectedDocuments.ts
@@ -201,13 +201,7 @@ class connectedDocuments {
         
         this.timeSeriesColumns = [
             new textColumn<timeSeriesItem>(this.gridController() as virtualGridController<any>, x => x.name, "Timeseries Name", "145px"),
-            new textColumn<timeSeriesItem>(
-                this.gridController() as virtualGridController<any>, 
-                    x => x.numberOfEntries.toLocaleString() + (timeSeriesEntryModel.isIncrementalName(x.name) ? ' <i class="icon-info"></i> ' : ''), 
-                "Timeseries items count",
-                "60px", {
-                    useRawValue: () => true
-                }),
+            new textColumn<timeSeriesItem>(this.gridController() as virtualGridController<any>, x => x.numberOfEntries, "Timeseries items count", "60px"),
             new textColumn<timeSeriesItem>(this.gridController() as virtualGridController<any>, x => dateFormatter(x.startDate) + " - " + dateFormatter(x.endDate), "Timeseries date range", "170px"),
             new actionColumn<timeSeriesItem>(this.gridController() as virtualGridController<any>,
                 x => this.goToTimeSeriesEdit(x),
@@ -259,13 +253,7 @@ class connectedDocuments {
                     if (column.header === "Timeseries date range") {
                         onValue(timeSeriesItem.startDate + " - " + timeSeriesItem.endDate);
                     } else if (column.header === "Timeseries items count") {
-                        // TODO: add link to documentation when available..
-                        if (timeSeriesEntryModel.isIncrementalName(timeSeriesItem.name))  {
-                            onValue(`Raw number of incremental entries: ${timeSeriesItem.numberOfEntries.toLocaleString()}<br>May have duplicate entries for the same timestamp per node.`,
-                                timeSeriesItem.numberOfEntries.toLocaleString());
-                        } else {
-                            onValue(timeSeriesItem.numberOfEntries.toLocaleString());
-                        }
+                        onValue(timeSeriesItem.numberOfEntries);
                     } else {
                         const value = column.getCellValue(item);
                         onValue(value);

--- a/src/Raven.Studio/typescript/viewmodels/database/timeSeries/editTimeSeries.ts
+++ b/src/Raven.Studio/typescript/viewmodels/database/timeSeries/editTimeSeries.ts
@@ -25,8 +25,6 @@ import popoverUtils = require("common/popoverUtils");
 class timeSeriesInfo {
     name = ko.observable<string>();
     numberOfEntries = ko.observable<number>();
-    hasMoreResults = ko.observable<boolean>(false);
-    
     nameAndNumberFormatted: KnockoutComputed<string>;
     
     constructor(name: string, numberOfEntries: number) {
@@ -39,9 +37,8 @@ class timeSeriesInfo {
     private initObservables(): void {
         this.nameAndNumberFormatted = ko.pureComputed(() => {
             const numberPart = this.numberOfEntries().toLocaleString();
-            const moreResultsPart = this.hasMoreResults() ? "+" : "";
             
-            return `${this.name()} (${numberPart}${moreResultsPart})`;
+            return `${this.name()} (${numberPart})`;
         });
     }
 }
@@ -70,8 +67,6 @@ class editTimeSeries extends viewModelBase {
     private gridController = ko.observable<virtualGridController<Raven.Client.Documents.Session.TimeSeries.TimeSeriesEntry>>();
     private columnPreview = new columnPreviewPlugin<Raven.Client.Documents.Session.TimeSeries.TimeSeriesEntry>();
 
-    private nextItemToFetchIndex = 0 as number;
-    
     private columnsCacheInfo = {
         hasTag: false,
         valuesCount: 0
@@ -271,33 +266,20 @@ class editTimeSeries extends viewModelBase {
         const db = this.activeDatabase();
 
         if (timeSeriesName) {
-            new getTimeSeriesCommand(this.documentId(), timeSeriesName, db, this.nextItemToFetchIndex, 100, true)
+            new getTimeSeriesCommand(this.documentId(), timeSeriesName, db, skip, 100, true)
                 .execute()
                 .done(result => {
-                    const totalCount = skip + result.Entries.length;
-                    const skipped = result.SkippedResults || 0;
-
-                    const hasMore = this.nextItemToFetchIndex + result.Entries.length + skipped < result.TotalResults;
-                    
-                    if (hasMore) {
-                        this.nextItemToFetchIndex += result.Entries.length + skipped;
-                    } else {
-                        this.nextItemToFetchIndex = 0;
-                    }
                     
                     const items = result.Entries;
-                    const totalResultCount = totalCount || 0;
                     
                     const series = this.getSeriesFromList(timeSeriesName);
                     if (series) {
-                        const countForUI = hasMore ? totalCount - 1 : totalCount;
-                        series.numberOfEntries(countForUI);
-                        series.hasMoreResults(hasMore);
+                        series.numberOfEntries(result.TotalResults);
                     }
 
                     fetchTask.resolve({
                         items,
-                        totalResultCount: hasMore ? totalResultCount + 1 : totalResultCount
+                        totalResultCount: result.TotalResults
                     })
                 })
                 .fail((response: JQueryXHR) => {
@@ -410,7 +392,6 @@ class editTimeSeries extends viewModelBase {
         this.cleanColumnsCache();
         
         this.timeSeriesName(name);
-        this.nextItemToFetchIndex = 0;
         
         router.navigate(appUrl.forEditTimeSeries(name, this.documentId(), this.activeDatabase()), false);
         
@@ -436,9 +417,6 @@ class editTimeSeries extends viewModelBase {
                     case "reloadCurrent":
                         this.refresh();
                 }
-            })
-            .always(() => {
-                this.nextItemToFetchIndex = 0;
             });
     }
     

--- a/src/Sparrow/Json/LazyStringValue.cs
+++ b/src/Sparrow/Json/LazyStringValue.cs
@@ -153,6 +153,14 @@ namespace Sparrow.Json
             return context.GetLazyString(_buffer, _size, longLived: false);
         }
 
+        public LazyStringValue CloneOnSameContext()
+        {
+            if (_size == 0)
+                return _context.Empty;
+
+            return _context.GetLazyString(_buffer, _size, longLived: false);
+        }
+
         public bool HasStringValue => _string != null;
 
         [ThreadStatic]

--- a/test/SlowTests/Client/TimeSeries/Issues/RavenDB-15804.cs
+++ b/test/SlowTests/Client/TimeSeries/Issues/RavenDB-15804.cs
@@ -1411,7 +1411,7 @@ namespace SlowTests.Client.TimeSeries.Issues
             }
         }
 
-        [Fact(Skip = "Waiting for RavenDB-17486")]
+        [Fact]
         public async Task CheckSkippedResultsCalculationWithLargeTimeSeries()
         {
             var baseline = DateTime.UtcNow;
@@ -1469,7 +1469,7 @@ namespace SlowTests.Client.TimeSeries.Issues
                         .Send(new GetTimeSeriesOperation("users/ayende", IncrementalTsName, start: start, pageSize: pageSize, returnFullResults: true));
 
                     Assert.Equal(pageSize, values.Entries.Length);
-                    Assert.Equal((start + pageSize - 1) * 2, values.Entries.Last().Value);
+                    Assert.Equal((start + pageSize) * 2, values.Entries.Last().Value);
                 }
             }
         }
@@ -1807,7 +1807,7 @@ select timeseries(
                         var segment = db.DocumentsStorage.TimeSeriesStorage.GetSegmentsFrom(context, 0)
                             .Single();
                         Assert.True(segment.Segment.Version.ContainsDuplicates);
-                        Assert.True(segment.Segment.Version.ContainsLastValueDuplicate);
+                        Assert.False(segment.Segment.Version.ContainsLastValueDuplicate);
                         var values = segment.Segment.SegmentValues.Span[0];
 
                         Assert.Equal(3, values.Count);

--- a/test/SlowTests/Client/TimeSeries/Issues/RavenDB-15804.cs
+++ b/test/SlowTests/Client/TimeSeries/Issues/RavenDB-15804.cs
@@ -1697,7 +1697,9 @@ namespace SlowTests.Client.TimeSeries.Issues
                     {
                         var segment = db.DocumentsStorage.TimeSeriesStorage.GetSegmentsFrom(context, 0)
                             .Single();
-                        Assert.Equal(SegmentVersion.DuplicateLast, segment.Segment.Version);
+                        Assert.True(segment.Segment.Version.ContainsDuplicates);
+                        Assert.True(segment.Segment.Version.ContainsLastValueDuplicate);
+
                         var values = segment.Segment.SegmentValues.Span[0];
 
                         Assert.Equal(2, values.Count);
@@ -1804,7 +1806,8 @@ select timeseries(
                     {
                         var segment = db.DocumentsStorage.TimeSeriesStorage.GetSegmentsFrom(context, 0)
                             .Single();
-                        Assert.Equal(SegmentVersion.ContainDuplicates, segment.Segment.Version);
+                        Assert.True(segment.Segment.Version.ContainsDuplicates);
+                        Assert.True(segment.Segment.Version.ContainsLastValueDuplicate);
                         var values = segment.Segment.SegmentValues.Span[0];
 
                         Assert.Equal(3, values.Count);


### PR DESCRIPTION
### Issue link

https://issues.hibernatingrhinos.com/issue/RavenDB-17493

### Additional description

In case of duplicate values we cannot calculate properly the Min/Max/First/Last of the segment, because the value is the sum of all the duplicates.

So we will mark this segment as 'Contain Duplicates` and recalculate before persisting the segment.

Another issue is the `Last`, we use it to xor with the last value, so we always need to update it, even for partial values.

This will yield wrong `Last` value if the last value is a duplicate one.

For that case we introduced another segment version called `Last Is Duplicate` so only when querying for `Last` we will open the entire segment instead of taking in the the `StatefulTimestampValue`

As a side effect of this change, we now record in the stats the number of unique entries, instead of the number of raw entries.
Maybe will require a revise of the `GetIncrementalTimeSeriesRange` method.
### Type of change

- Bug fix

### How risky is the change?

- Moderate 

### Backward compatibility

- Ensured. 
We change the segment version only if we detect duplicate values, which can happened only for incremental TS.

### Is it platform specific issue?

- No

### Documentation update

- No documentation update is needed 

### Testing 

- Tests have been added that prove the fix is effective or that the feature works

### Is there any existing behavior change of other features due to this change?

- No

### UI work

- Yes
We now record in the stats the number of unique entries, instead of the number of raw entries. 

