### PR TITLE
RavenDB-17483 - Fix GetAll subscriptions debug endpoint to get all connections when subscription is concurrent

### DIFF
--- a/src/Raven.Server/Documents/Handlers/SubscriptionsHandler.cs
+++ b/src/Raven.Server/Documents/Handlers/SubscriptionsHandler.cs
@@ -341,6 +341,7 @@ namespace Raven.Server.Documents.Handlers
                         [nameof(SubscriptionState.Disabled)] = x.Disabled,
                         [nameof(SubscriptionState.LastClientConnectionTime)] = x.LastClientConnectionTime,
                         [nameof(SubscriptionState.LastBatchAckTime)] = x.LastBatchAckTime,
+                        ["Connection"] = GetSubscriptionConnectionJson(x.Connection),
                         ["Connections"] = GetSubscriptionConnectionsJson(x.Connections),
                         ["RecentConnections"] = x.RecentConnections?.Select(r => new DynamicJsonValue()
                         {

--- a/src/Raven.Server/Documents/Handlers/SubscriptionsHandler.cs
+++ b/src/Raven.Server/Documents/Handlers/SubscriptionsHandler.cs
@@ -341,7 +341,7 @@ namespace Raven.Server.Documents.Handlers
                         [nameof(SubscriptionState.Disabled)] = x.Disabled,
                         [nameof(SubscriptionState.LastClientConnectionTime)] = x.LastClientConnectionTime,
                         [nameof(SubscriptionState.LastBatchAckTime)] = x.LastBatchAckTime,
-                        ["Connection"] = GetSubscriptionConnectionJson(x.Connection),
+                        ["Connections"] = GetSubscriptionConnectionsJson(x.Connections),
                         ["RecentConnections"] = x.RecentConnections?.Select(r => new DynamicJsonValue()
                         {
                             ["State"] = new DynamicJsonValue()
@@ -393,6 +393,14 @@ namespace Raven.Server.Documents.Handlers
                     }
                 }
             }
+        }
+
+        private static DynamicJsonArray GetSubscriptionConnectionsJson(List<SubscriptionConnection> subscriptionList)
+        {
+            if (subscriptionList == null)
+                return new DynamicJsonArray();
+
+            return new DynamicJsonArray(subscriptionList.Select(s => GetSubscriptionConnectionJson(s)));
         }
 
         private static DynamicJsonValue GetSubscriptionConnectionJson(SubscriptionConnection x)

--- a/src/Raven.Server/Documents/Subscriptions/SubscriptionStorage.cs
+++ b/src/Raven.Server/Documents/Subscriptions/SubscriptionStorage.cs
@@ -356,7 +356,14 @@ namespace Raven.Server.Documents.Subscriptions
                     yield break;
 
                 var subscriptionState = JsonDeserializationClient.SubscriptionState(keyValue.Value);
-                var subscriptionGeneralData = new SubscriptionGeneralDataAndStats(subscriptionState);
+                var subscriptionConnectionsState = GetSubscriptionConnectionsState(serverStoreContext, subscriptionState.SubscriptionName);
+
+                var subscriptionGeneralData = new SubscriptionGeneralDataAndStats(subscriptionState)
+                {
+                    Connections = subscriptionConnectionsState?.GetConnections(),
+                    RecentConnections = subscriptionConnectionsState?.RecentConnections,
+                    RecentRejectedConnections = subscriptionConnectionsState?.RecentRejectedConnections
+                };
                 GetSubscriptionInternal(subscriptionGeneralData, history);
                 yield return subscriptionGeneralData;
             }
@@ -474,7 +481,14 @@ namespace Raven.Server.Documents.Subscriptions
                 throw new SubscriptionDoesNotExistException($"Subscription with name '{name}' was not found in server store");
 
             var subscriptionState = JsonDeserializationClient.SubscriptionState(subscriptionBlittable);
-            var subscriptionJsonValue = new SubscriptionGeneralDataAndStats(subscriptionState);
+            var subscriptionConnectionsState = GetSubscriptionConnectionsState(context, subscriptionState.SubscriptionName);
+
+            var subscriptionJsonValue = new SubscriptionGeneralDataAndStats(subscriptionState)
+            {
+                Connections = subscriptionConnectionsState?.GetConnections(),
+                RecentConnections = subscriptionConnectionsState?.RecentConnections,
+                RecentRejectedConnections = subscriptionConnectionsState?.RecentRejectedConnections
+            };
             return subscriptionJsonValue;
         }
 
@@ -537,7 +551,6 @@ namespace Raven.Server.Documents.Subscriptions
         public class SubscriptionGeneralDataAndStats : SubscriptionState
         {
             public List<SubscriptionConnection> Connections;
-            public SubscriptionConnection Connection => Connections?.FirstOrDefault();
             public IEnumerable<SubscriptionConnection> RecentConnections;
             public IEnumerable<SubscriptionConnection> RecentRejectedConnections;
 

--- a/src/Raven.Server/Documents/Subscriptions/SubscriptionStorage.cs
+++ b/src/Raven.Server/Documents/Subscriptions/SubscriptionStorage.cs
@@ -550,6 +550,7 @@ namespace Raven.Server.Documents.Subscriptions
 
         public class SubscriptionGeneralDataAndStats : SubscriptionState
         {
+            public SubscriptionConnection Connection => Connections?.FirstOrDefault();
             public List<SubscriptionConnection> Connections;
             public IEnumerable<SubscriptionConnection> RecentConnections;
             public IEnumerable<SubscriptionConnection> RecentRejectedConnections;


### PR DESCRIPTION
### Issue link

https://issues.hibernatingrhinos.com/issue/RavenDB-17483

### Additional description

Fixed a subscription handler endpoint to get a list of connections instead of one. 

### Type of change

- Bug fix

### Backward compatibility

- No place in studio seems to be using this endpoint.
- Client API uses this endpoint but removes the response properties that have been changed in this issue and doesn't return them to the user.

### Is it platform specific issue?

- No

### Documentation update

- No documentation update is needed 

### Testing 

- It has been verified by manual testing

### Is there any existing behavior change of other features due to this change?

- No

### UI work

- No UI work is needed
