### PR TITLE
RavenDB-17242: Sorting using multiple comparers.

### DIFF
--- a/src/Corax/Queries/SortingMatch.Comparers.cs
+++ b/src/Corax/Queries/SortingMatch.Comparers.cs
@@ -8,7 +8,7 @@ using System.Threading.Tasks;
 
 namespace Corax.Queries
 {
-    partial struct SortingMatch
+    unsafe partial struct SortingMatch
     {                     
         private static class BasicComparers
         {
@@ -280,6 +280,73 @@ namespace Corax.Queries
             public int CompareSequence(ReadOnlySpan<byte> sx, ReadOnlySpan<byte> sy)
             {
                 return -BasicComparers.CompareAscending(sx, sy);
+            }
+        }
+
+        internal struct SequenceItem
+        {
+            public readonly byte* Ptr;
+            public readonly int Size;
+
+            public SequenceItem(byte* ptr, int size)
+            {
+                Ptr = ptr;
+                Size = size;
+            }
+        }
+
+        internal struct NumericalItem<T> where T : unmanaged
+        {
+            public readonly T Value;
+            public NumericalItem(in T value)
+            {
+                Value = value;
+            }
+        }
+
+        internal struct MatchComparer<T, W> : IComparer<MatchComparer<T, W>.Item>
+            where T : IMatchComparer
+            where W : struct
+        {
+            public struct Item
+            {
+                public long Key;
+                public W Value;
+            }
+
+            private readonly T _comparer;
+
+            public MatchComparer(in T comparer)
+            {
+                _comparer = comparer;
+            }
+
+            [MethodImpl(MethodImplOptions.AggressiveInlining)]
+            public int Compare(Item ix, Item iy)
+            {
+                if (ix.Key > 0 && iy.Key > 0)
+                {
+                    if (typeof(W) == typeof(SequenceItem))
+                    {
+                        return _comparer.CompareSequence(
+                            new ReadOnlySpan<byte>(((SequenceItem)(object)ix.Value).Ptr, ((SequenceItem)(object)ix.Value).Size),
+                            new ReadOnlySpan<byte>(((SequenceItem)(object)iy.Value).Ptr, ((SequenceItem)(object)iy.Value).Size));
+                    }
+                    else if (typeof(W) == typeof(NumericalItem<long>))
+                    {
+                        return _comparer.CompareNumerical(((NumericalItem<long>)(object)ix.Value).Value, ((NumericalItem<long>)(object)iy.Value).Value);
+                    }
+                    else if (typeof(W) == typeof(NumericalItem<double>))
+                    {
+                        return _comparer.CompareNumerical(((NumericalItem<double>)(object)ix.Value).Value, ((NumericalItem<double>)(object)iy.Value).Value);
+                    }
+                }
+                else if (ix.Key > 0)
+                {
+                    return 1;
+                }
+
+                return -1;
             }
         }
     }

--- a/src/Corax/Queries/SortingMatch.Erasure.cs
+++ b/src/Corax/Queries/SortingMatch.Erasure.cs
@@ -19,7 +19,7 @@ namespace Corax.Queries
         }
 
         public long TotalResults => _functionTable.TotalResultsFunc(ref this);
-        
+
         public long Count => throw new NotSupportedException();
 
         public QueryCountConfidence Confidence => throw new NotSupportedException();

--- a/src/Corax/Queries/SortingMultiMatch.Erasure.cs
+++ b/src/Corax/Queries/SortingMultiMatch.Erasure.cs
@@ -1,0 +1,269 @@
+﻿using System;
+using System.Runtime.CompilerServices;
+
+namespace Corax.Queries
+{
+    public unsafe partial struct SortingMultiMatch : IQueryMatch
+    {
+        private readonly FunctionTable _functionTable;
+        private IQueryMatch _inner;
+
+        internal SortingMultiMatch(IQueryMatch match, FunctionTable functionTable)
+        {
+            _inner = match;
+            _functionTable = functionTable;
+        }
+
+        public long TotalResults => _functionTable.TotalResultsFunc(ref this);
+
+        public long Count => throw new NotSupportedException();
+
+        public QueryCountConfidence Confidence => throw new NotSupportedException();
+
+        [MethodImpl(MethodImplOptions.AggressiveInlining)]
+        public int Fill(Span<long> buffer)
+        {
+            return _functionTable.FillFunc(ref this, buffer);
+        }
+
+        [MethodImpl(MethodImplOptions.AggressiveInlining)]
+        public int AndWith(Span<long> buffer)
+        {
+            throw new NotSupportedException($"{nameof(SortingMatch)} does not support the operation of {nameof(AndWith)}.");
+        }
+
+        internal class FunctionTable
+        {
+            public readonly delegate*<ref SortingMultiMatch, Span<long>, int> FillFunc;
+            public readonly delegate*<ref SortingMultiMatch, long> TotalResultsFunc;
+
+            public FunctionTable(
+                delegate*<ref SortingMultiMatch, Span<long>, int> fillFunc,
+                delegate*<ref SortingMultiMatch, long> totalResultsFunc)
+            {
+                FillFunc = fillFunc;
+                TotalResultsFunc = totalResultsFunc;
+            }
+        }
+
+        public struct NullComparer : IMatchComparer
+        {
+            public MatchCompareFieldType FieldType => throw new NotSupportedException();
+
+            public int FieldId => throw new NotSupportedException();
+
+            public int CompareById(long idx, long idy) { throw new NotSupportedException(); }
+
+            public int CompareNumerical<T>(T sx, T sy) where T : unmanaged { throw new NotSupportedException(); }
+
+            public int CompareSequence(ReadOnlySpan<byte> sx, ReadOnlySpan<byte> sy) { throw new NotSupportedException(); }
+        }
+
+        private static class StaticFunctionCache<TInner, TComparer1, TComparer2, TComparer3, TComparer4, TComparer5, TComparer6, TComparer7, TComparer8, TComparer9>
+            where TInner : IQueryMatch
+            where TComparer1 : struct, IMatchComparer
+            where TComparer2 : struct, IMatchComparer
+            where TComparer3 : struct, IMatchComparer
+            where TComparer4 : struct, IMatchComparer
+            where TComparer5 : struct, IMatchComparer
+            where TComparer6 : struct, IMatchComparer
+            where TComparer7 : struct, IMatchComparer
+            where TComparer8 : struct, IMatchComparer
+            where TComparer9 : struct, IMatchComparer
+        {
+            public static readonly FunctionTable FunctionTable;
+
+            static StaticFunctionCache()
+            {
+                static long CountFunc(ref SortingMultiMatch match)
+                {
+                    return ((SortingMultiMatch<TInner, TComparer1, TComparer2, TComparer3, TComparer4, TComparer5, TComparer6, TComparer7, TComparer8, TComparer9>)match._inner).TotalResults;
+                }
+                static int FillFunc(ref SortingMultiMatch match, Span<long> matches)
+                {
+                    if (match._inner is SortingMultiMatch<TInner, TComparer1, TComparer2, TComparer3, TComparer4, TComparer5, TComparer6, TComparer7, TComparer8, TComparer9> inner)
+                    {
+                        var result = inner.Fill(matches);
+                        match._inner = inner;
+                        return result;
+                    }
+                    return 0;
+                }
+
+                FunctionTable = new FunctionTable(&FillFunc, &CountFunc);
+            }
+        }
+
+        [MethodImpl(MethodImplOptions.AggressiveInlining)]
+        private static SortingMultiMatch Create<TInner, TComparer1, TComparer2, TComparer3, TComparer4, TComparer5, TComparer6, TComparer7, TComparer8, TComparer9>(
+            in SortingMultiMatch<TInner, TComparer1, TComparer2, TComparer3, TComparer4, TComparer5, TComparer6, TComparer7, TComparer8, TComparer9> query)
+            where TInner : IQueryMatch
+            where TComparer1 : struct, IMatchComparer
+            where TComparer2 : struct, IMatchComparer
+            where TComparer3 : struct, IMatchComparer
+            where TComparer4 : struct, IMatchComparer
+            where TComparer5 : struct, IMatchComparer
+            where TComparer6 : struct, IMatchComparer
+            where TComparer7 : struct, IMatchComparer
+            where TComparer8 : struct, IMatchComparer
+            where TComparer9 : struct, IMatchComparer
+        {
+            return new SortingMultiMatch(query,
+                StaticFunctionCache<TInner,
+                TComparer1, TComparer2, TComparer3,
+                TComparer4, TComparer5, TComparer6,
+                TComparer7, TComparer8, TComparer9>.FunctionTable);
+        }
+
+        public static SortingMultiMatch Create<TInner, TComparer1, TComparer2, TComparer3, TComparer4, TComparer5, TComparer6, TComparer7, TComparer8, TComparer9>(
+            IndexSearcher searcher, TInner inner,
+            TComparer1 comparer1, TComparer2 comparer2, TComparer3 comparer3,
+            TComparer4 comparer4, TComparer5 comparer5, TComparer6 comparer6,
+            TComparer7 comparer7, TComparer8 comparer8, TComparer9 comparer9
+            )
+            where TInner : IQueryMatch
+            where TComparer1 : struct, IMatchComparer
+            where TComparer2 : struct, IMatchComparer
+            where TComparer3 : struct, IMatchComparer
+            where TComparer4 : struct, IMatchComparer
+            where TComparer5 : struct, IMatchComparer
+            where TComparer6 : struct, IMatchComparer
+            where TComparer7 : struct, IMatchComparer
+            where TComparer8 : struct, IMatchComparer
+            where TComparer9 : struct, IMatchComparer
+        {
+            return Create(
+                new SortingMultiMatch<TInner, TComparer1, TComparer2, TComparer3, TComparer4, TComparer5, TComparer6, TComparer7, TComparer8, TComparer9>(
+                    searcher, inner,
+                    comparer1, comparer2, comparer3,
+                    comparer4, comparer5, comparer6,
+                    comparer7, comparer8, comparer9));
+        }
+
+        public static SortingMultiMatch Create<TInner, TComparer1, TComparer2, TComparer3, TComparer4, TComparer5, TComparer6, TComparer7, TComparer8>(
+            IndexSearcher searcher, TInner inner,
+            TComparer1 comparer1, TComparer2 comparer2, TComparer3 comparer3,
+            TComparer4 comparer4, TComparer5 comparer5, TComparer6 comparer6,
+            TComparer7 comparer7, TComparer8 comparer8)
+            where TInner : IQueryMatch
+            where TComparer1 : struct, IMatchComparer
+            where TComparer2 : struct, IMatchComparer
+            where TComparer3 : struct, IMatchComparer
+            where TComparer4 : struct, IMatchComparer
+            where TComparer5 : struct, IMatchComparer
+            where TComparer6 : struct, IMatchComparer
+            where TComparer7 : struct, IMatchComparer
+            where TComparer8 : struct, IMatchComparer
+        {
+            return Create(
+                new SortingMultiMatch<TInner, TComparer1, TComparer2, TComparer3, TComparer4, TComparer5, TComparer6, TComparer7, TComparer8, NullComparer>(
+                    searcher, inner,
+                    comparer1, comparer2, comparer3,
+                    comparer4, comparer5, comparer6,
+                    comparer7, comparer8));
+        }
+
+        public static SortingMultiMatch Create<TInner, TComparer1, TComparer2, TComparer3, TComparer4, TComparer5, TComparer6, TComparer7>(
+            IndexSearcher searcher, TInner inner,
+            TComparer1 comparer1, TComparer2 comparer2, TComparer3 comparer3,
+            TComparer4 comparer4, TComparer5 comparer5, TComparer6 comparer6,
+            TComparer7 comparer7)
+            where TInner : IQueryMatch
+            where TComparer1 : struct, IMatchComparer
+            where TComparer2 : struct, IMatchComparer
+            where TComparer3 : struct, IMatchComparer
+            where TComparer4 : struct, IMatchComparer
+            where TComparer5 : struct, IMatchComparer
+            where TComparer6 : struct, IMatchComparer
+            where TComparer7 : struct, IMatchComparer
+        {
+            return Create(
+                new SortingMultiMatch<TInner, TComparer1, TComparer2, TComparer3, TComparer4, TComparer5, TComparer6, TComparer7, NullComparer, NullComparer>(
+                    searcher, inner,
+                    comparer1, comparer2, comparer3,
+                    comparer4, comparer5, comparer6,
+                    comparer7));
+        }
+
+        public static SortingMultiMatch Create<TInner, TComparer1, TComparer2, TComparer3, TComparer4, TComparer5, TComparer6>(
+            IndexSearcher searcher, TInner inner,
+            TComparer1 comparer1, TComparer2 comparer2, TComparer3 comparer3,
+            TComparer4 comparer4, TComparer5 comparer5, TComparer6 comparer6)
+            where TInner : IQueryMatch
+            where TComparer1 : struct, IMatchComparer
+            where TComparer2 : struct, IMatchComparer
+            where TComparer3 : struct, IMatchComparer
+            where TComparer4 : struct, IMatchComparer
+            where TComparer5 : struct, IMatchComparer
+            where TComparer6 : struct, IMatchComparer
+        {
+            return Create(
+                new SortingMultiMatch<TInner, TComparer1, TComparer2, TComparer3, TComparer4, TComparer5, TComparer6, NullComparer, NullComparer, NullComparer>(
+                    searcher, inner,
+                    comparer1, comparer2, comparer3,
+                    comparer4, comparer5, comparer6));
+        }
+
+        public static SortingMultiMatch Create<TInner, TComparer1, TComparer2, TComparer3, TComparer4, TComparer5>(
+            IndexSearcher searcher, TInner inner,
+            TComparer1 comparer1, TComparer2 comparer2, TComparer3 comparer3,
+            TComparer4 comparer4, TComparer5 comparer5)
+            where TInner : IQueryMatch
+            where TComparer1 : struct, IMatchComparer
+            where TComparer2 : struct, IMatchComparer
+            where TComparer3 : struct, IMatchComparer
+            where TComparer4 : struct, IMatchComparer
+            where TComparer5 : struct, IMatchComparer
+        {
+            return Create(
+                new SortingMultiMatch<TInner, TComparer1, TComparer2, TComparer3, TComparer4, TComparer5, NullComparer, NullComparer, NullComparer, NullComparer>(
+                    searcher, inner,
+                    comparer1, comparer2, comparer3,
+                    comparer4, comparer5));
+        }
+
+        public static SortingMultiMatch Create<TInner, TComparer1, TComparer2, TComparer3, TComparer4>(
+            IndexSearcher searcher, TInner inner,
+            TComparer1 comparer1, TComparer2 comparer2, TComparer3 comparer3,
+            TComparer4 comparer4)
+            where TInner : IQueryMatch
+            where TComparer1 : struct, IMatchComparer
+            where TComparer2 : struct, IMatchComparer
+            where TComparer3 : struct, IMatchComparer
+            where TComparer4 : struct, IMatchComparer
+        {
+            return Create(
+                new SortingMultiMatch<TInner, TComparer1, TComparer2, TComparer3, TComparer4, NullComparer, NullComparer, NullComparer, NullComparer, NullComparer>(
+                    searcher, inner,
+                    comparer1, comparer2, comparer3,
+                    comparer4));
+        }
+
+        public static SortingMultiMatch Create<TInner, TComparer1, TComparer2, TComparer3>(
+            IndexSearcher searcher, TInner inner,
+            TComparer1 comparer1, TComparer2 comparer2, TComparer3 comparer3)
+            where TInner : IQueryMatch
+            where TComparer1 : struct, IMatchComparer
+            where TComparer2 : struct, IMatchComparer
+            where TComparer3 : struct, IMatchComparer
+        {
+            return Create(
+                new SortingMultiMatch<TInner, TComparer1, TComparer2, TComparer3, NullComparer, NullComparer, NullComparer, NullComparer, NullComparer, NullComparer>(
+                    searcher, inner,
+                    comparer1, comparer2, comparer3));
+        }
+
+        public static SortingMultiMatch Create<TInner, TComparer1, TComparer2>(
+            IndexSearcher searcher, TInner inner,
+            TComparer1 comparer1, TComparer2 comparer2)
+            where TInner : IQueryMatch
+            where TComparer1 : struct, IMatchComparer
+            where TComparer2 : struct, IMatchComparer
+        {
+            return Create(
+                new SortingMultiMatch<TInner, TComparer1, TComparer2, NullComparer, NullComparer, NullComparer, NullComparer, NullComparer, NullComparer, NullComparer>(
+                    searcher, inner,
+                    comparer1, comparer2));
+        }
+    }
+}

--- a/test/FastTests/Corax/OrderByMultiSorting.cs
+++ b/test/FastTests/Corax/OrderByMultiSorting.cs
@@ -1,0 +1,181 @@
+﻿using System;
+using System.Collections.Generic;
+using System.Linq;
+using System.Text;
+using System.Threading.Tasks;
+using Corax;
+using Corax.Queries;
+using FastTests.Voron;
+using Sparrow.Server;
+using Sparrow.Threading;
+using Voron;
+using Xunit;
+using Xunit.Abstractions;
+using static Corax.Queries.SortingMatch;
+
+namespace FastTests.Corax
+{
+
+    public class OrderByMultiSortingTests : StorageTest
+    {
+        private List<IndexSingleNumericalEntry<long, long>> longList = new();
+        private IndexSearcher _indexSearcher;
+        private const int IndexId = 0, Content1 = 1, Content2 = 2;
+
+        public OrderByMultiSortingTests(ITestOutputHelper output) : base(output)
+        {
+        }
+
+        [Fact]
+        public void OrderByNoRepetitions()
+        {
+            PrepareData();
+
+            IndexEntries();
+            longList.Sort(CompareDescending);
+            using var searcher = new IndexSearcher(Env);
+            {
+                var match1 = searcher.AllEntries();
+
+                var comparer1 = new DescendingMatchComparer(searcher, Content1, MatchCompareFieldType.Integer);
+                var comparer2 = new AscendingMatchComparer(searcher, Content2, MatchCompareFieldType.Integer);
+                var match = SortingMultiMatch.Create(searcher, match1, comparer1, comparer2);
+
+                List<string> sortedByCorax = new();
+                Span<long> ids = stackalloc long[2048];
+                int read = 0;
+                do
+                {
+                    read = match.Fill(ids);
+                    for (int i = 0; i < read; ++i)
+                        sortedByCorax.Add(searcher.GetIdentityFor(ids[i]));
+                }
+                while (read != 0);
+
+                for (int i = 0; i < longList.Count; ++i)
+                    Assert.Equal(longList[i].Id, sortedByCorax[i]);
+
+                Assert.Equal(1000, sortedByCorax.Count);
+            }
+        }
+
+        [Fact]
+        public void OrderByWithRepetitions()
+        {
+            PrepareData();
+            PrepareData(inverse:true);
+
+            IndexEntries();
+            longList.Sort(CompareAscendingThenDescending);
+            using var searcher = new IndexSearcher(Env);
+            {
+                var match1 = searcher.AllEntries();
+
+                var comparer1 = new AscendingMatchComparer(searcher, Content1, MatchCompareFieldType.Integer);
+                var comparer2 = new DescendingMatchComparer(searcher, Content2, MatchCompareFieldType.Integer);
+               
+                var match = SortingMultiMatch.Create(searcher, match1, comparer1, comparer2);
+
+                List<string> sortedByCorax = new();
+                Span<long> ids = stackalloc long[2048];
+                int read = 0;
+                do
+                {
+                    read = match.Fill(ids);
+                    for (int i = 0; i < read; ++i)
+                        sortedByCorax.Add(searcher.GetIdentityFor(ids[i]));
+                }
+                while (read != 0);
+
+                for (int i = 0; i < longList.Count; ++i)
+                {                    
+                    Assert.Equal(longList[i].Id, sortedByCorax[i]);
+                }
+                    
+
+                Assert.Equal(2000, sortedByCorax.Count);
+            }
+        }
+
+        private static int CompareAscending(IndexSingleNumericalEntry<long, long> value1, IndexSingleNumericalEntry<long, long> value2)
+        {
+            return value1.Content1.CompareTo(value2.Content1);
+        }
+
+        private static int CompareAscendingThenDescending(IndexSingleNumericalEntry<long, long> value1, IndexSingleNumericalEntry<long, long> value2)
+        {
+            var result = value1.Content1.CompareTo(value2.Content1);
+            if (result == 0)
+                return value2.Content2.CompareTo(value1.Content2);
+            return result;
+        }
+
+        private static int CompareDescending(IndexSingleNumericalEntry<long, long> value1, IndexSingleNumericalEntry<long, long> value2)
+        {
+            return value2.Content1.CompareTo(value1.Content1);
+        }
+
+        private void PrepareData(bool inverse = false)
+        {
+            for (int i = 0; i < 1000; ++i)
+            {
+                longList.Add(new IndexSingleNumericalEntry<long, long>
+                {
+                    Id = inverse ? $"list/1000-{i}" : $"list/{i}",
+                    Content1 = i,
+                    Content2 = inverse ? 1000 - i : i
+                });
+            }
+        }
+
+        private void IndexEntries()
+        {
+            using var bsc = new ByteStringContext(SharedMultipleUseFlag.None);
+            Dictionary<Slice, int> knownFields = CreateKnownFields(bsc);
+
+            const int bufferSize = 4096;
+            using var _ = bsc.Allocate(bufferSize, out ByteString buffer);
+
+            {
+                using var indexWriter = new IndexWriter(Env);
+                foreach (var entry in longList)
+                {
+                    var entryWriter = new IndexEntryWriter(buffer.ToSpan(), knownFields);
+                    var data = CreateIndexEntry(ref entryWriter, entry);
+                    indexWriter.Index(entry.Id, data, knownFields);
+                }
+                indexWriter.Commit();
+            }
+        }
+
+        private Span<byte> CreateIndexEntry(ref IndexEntryWriter entryWriter, IndexSingleNumericalEntry<long, long> entry)
+        {
+            entryWriter.Write(IndexId, Encoding.UTF8.GetBytes(entry.Id));
+            entryWriter.Write(Content1, Encoding.UTF8.GetBytes(entry.Content1.ToString()), entry.Content1, Convert.ToDouble(entry.Content1));
+            entryWriter.Write(Content2, Encoding.UTF8.GetBytes(entry.Content2.ToString()), entry.Content2, Convert.ToDouble(entry.Content2));
+            entryWriter.Finish(out var output);
+            return output;
+        }
+
+        private Dictionary<Slice, int> CreateKnownFields(ByteStringContext bsc)
+        {
+            Slice.From(bsc, "Id", ByteStringType.Immutable, out Slice idSlice);
+            Slice.From(bsc, "Content1", ByteStringType.Immutable, out Slice content1Slice);
+            Slice.From(bsc, "Content2", ByteStringType.Immutable, out Slice content2Slice);
+
+            return new Dictionary<Slice, int>
+            {
+                [idSlice] = IndexId,
+                [content1Slice] = Content1,
+                [content2Slice] = Content2,            
+            };
+        }
+
+        private class IndexSingleNumericalEntry<T1, T2>
+        {
+            public string Id { get; set; }
+            public T1 Content1 { get; set; }
+            public T2 Content2 { get; set; }
+        }
+    }
+}


### PR DESCRIPTION
### Issue link

https://issues.hibernatingrhinos.com/issue/RavenDB-17242

### Additional description

Implementation of sorting using generic comparers. The current version support up to 9 different comparers. This sorter also support type erasure mechanics in order to avoid having to deal with very complex generic types and the `.Create()` API supports simplified versions with `NullComparer`. The runtime will create the proper code when less than the amount of comparers are used.