### PR TITLE
RavenDB-17502 Fixing the usage of transaction operation context in `DatabaseRequestHandler.DatabaseConfigurations` since  `setupConfigurationFunc` might return a blittable that's used later on

### DIFF
--- a/src/Raven.Server/Documents/DatabaseRequestHandler.cs
+++ b/src/Raven.Server/Documents/DatabaseRequestHandler.cs
@@ -60,7 +60,7 @@ namespace Raven.Server.Documents
             using (ServerStore.ContextPool.AllocateOperationContext(out TransactionOperationContext context))
             {
                 var configurationJson = await context.ReadForMemoryAsync(RequestBodyStream(), debug);
-                var result = await DatabaseConfigurations(setupConfigurationFunc, raftRequestId, configurationJson, beforeSetupConfiguration);
+                var result = await DatabaseConfigurations(setupConfigurationFunc, context, raftRequestId, configurationJson, beforeSetupConfiguration);
 
                 if (result.Configuration == null)
                     return;
@@ -80,7 +80,7 @@ namespace Raven.Server.Documents
         }
 
 
-        protected async Task<(long Index, T Configuration)> DatabaseConfigurations<T>(SetupFunc<T> setupConfigurationFunc, string raftRequestId, T configurationJson, RefAction<T> beforeSetupConfiguration = null)
+        protected async Task<(long Index, T Configuration)> DatabaseConfigurations<T>(SetupFunc<T> setupConfigurationFunc, TransactionOperationContext context,  string raftRequestId, T configurationJson, RefAction<T> beforeSetupConfiguration = null)
         {
             if (await CanAccessDatabaseAsync(Database.Name, requireAdmin: true, requireWrite: true) == false)
                 return (-1, default);
@@ -90,15 +90,12 @@ namespace Raven.Server.Documents
 
             await ServerStore.EnsureNotPassiveAsync();
 
-            using (ServerStore.ContextPool.AllocateOperationContext(out TransactionOperationContext context))
-            {
-                beforeSetupConfiguration?.Invoke(Database.Name, ref configurationJson, context);
+            beforeSetupConfiguration?.Invoke(Database.Name, ref configurationJson, context);
 
-                var (index, _) = await setupConfigurationFunc(context, Database.Name, configurationJson, raftRequestId);
-                await WaitForIndexToBeApplied(context, index);
+            var (index, _) = await setupConfigurationFunc(context, Database.Name, configurationJson, raftRequestId);
+            await WaitForIndexToBeApplied(context, index);
 
-                return (index, configurationJson);
-            }
+            return (index, configurationJson);
         }
 
         protected async Task WaitForIndexToBeApplied(TransactionOperationContext context, long index)

--- a/src/Raven.Server/Integrations/PostgreSQL/Handlers/PostgreSqlIntegrationHandler.cs
+++ b/src/Raven.Server/Integrations/PostgreSQL/Handlers/PostgreSqlIntegrationHandler.cs
@@ -135,7 +135,8 @@ namespace Raven.Server.Integrations.PostgreSQL.Handlers
 
                     users.Add(newUser);
 
-                    await DatabaseConfigurations(ServerStore.ModifyPostgreSqlConfiguration, RaftIdGenerator.DontCareId, config);
+                    using (Database.ServerStore.ContextPool.AllocateOperationContext(out TransactionOperationContext transactionOperationContext))
+                        await DatabaseConfigurations(ServerStore.ModifyPostgreSqlConfiguration, transactionOperationContext, RaftIdGenerator.DontCareId, config);
                 }
             }
 
@@ -188,7 +189,8 @@ namespace Raven.Server.Integrations.PostgreSQL.Handlers
 
                     users.Remove(userToDelete);
 
-                    await DatabaseConfigurations(ServerStore.ModifyPostgreSqlConfiguration, RaftIdGenerator.DontCareId, config);
+                    using (Database.ServerStore.ContextPool.AllocateOperationContext(out TransactionOperationContext transactionOperationContext))
+                        await DatabaseConfigurations(ServerStore.ModifyPostgreSqlConfiguration, transactionOperationContext, RaftIdGenerator.DontCareId, config);
                 }
             }
 


### PR DESCRIPTION
### Issue link

https://issues.hibernatingrhinos.com/issue/RavenDB-17502

### Additional description

Fixing occasional "Could not allocated long lived memory, because the context is after Reset() but before Renew()." exception that was caused by the usage of invalid context introduced in https://github.com/ravendb/ravendb/commit/af3b3d41711f11c8366a60bdfc91559be15080d3#diff-ce0cb353d22ac1844f5a57c05f051e5e8cc73eba5561984bcf584b3f41bc1159R93

### Type of change

- Regression bug fix

### How risky is the change?

- Low 

### Backward compatibility

- Not relevant

### Is it platform specific issue?

- No.  Although it has been revealed by tests running on x86

### Documentation update

- No documentation update is needed 

### Testing 

- It has been verified by running tests from `SlowTests.Server.Documents.PeriodicBackup` directory in x86 mode

### Is there any existing behavior change of other features due to this change?

- No

### UI work

- No UI work is needed
