### PR TITLE
RDBCL-1977 / RavenDB-16869 Adding some checks to assert that we don't skip to update the transaction counter of already committed and flushed transaction.

### DIFF
--- a/src/Raven.Server/Documents/ConflictsStorage.cs
+++ b/src/Raven.Server/Documents/ConflictsStorage.cs
@@ -376,7 +376,7 @@ namespace Raven.Server.Documents
 
             // Only register the event if we actually deleted any conflicts
             var tx = context.Transaction.InnerTransaction.LowLevelTransaction;
-            tx.AfterCommitWhenNewReadTransactionsPrevented += _ =>
+            tx.AfterCommitWhenNewTransactionsPrevented += _ =>
             {
                 Interlocked.Add(ref ConflictsCount, -listCount);
             };
@@ -413,7 +413,7 @@ namespace Raven.Server.Documents
                     return;
 
                 var tx = context.Transaction.InnerTransaction.LowLevelTransaction;
-                tx.AfterCommitWhenNewReadTransactionsPrevented += _ =>
+                tx.AfterCommitWhenNewTransactionsPrevented += _ =>
                 {
                     Interlocked.Decrement(ref ConflictsCount);
                 };

--- a/src/Raven.Server/Documents/DocumentsStorage.cs
+++ b/src/Raven.Server/Documents/DocumentsStorage.cs
@@ -299,7 +299,7 @@ namespace Raven.Server.Documents
                 Environment = StorageLoader.OpenEnvironment(options, StorageEnvironmentWithType.StorageEnvironmentType.Documents);
 
                 Environment.NewTransactionCreated += SetTransactionCache;
-                Environment.AfterCommitWhenNewReadTransactionsPrevented += UpdateDocumentTransactionCache;
+                Environment.AfterCommitWhenNewTransactionsPrevented += UpdateDocumentTransactionCache;
 
                 using (var tx = Environment.WriteTransaction())
                 {

--- a/src/Raven.Server/Documents/Indexes/Index.cs
+++ b/src/Raven.Server/Documents/Indexes/Index.cs
@@ -1816,7 +1816,7 @@ namespace Raven.Server.Documents.Indexes
                                 llt.ImmutableExternalState = IndexPersistence.BuildStreamCacheAfterTx(llt.Transaction);
                             };
 
-                            tx.InnerTransaction.LowLevelTransaction.AfterCommitWhenNewReadTransactionsPrevented += llt =>
+                            tx.InnerTransaction.LowLevelTransaction.AfterCommitWhenNewTransactionsPrevented += llt =>
                             {
                                 IndexPersistence.PublishIndexCacheToNewTransactions((IndexTransactionCache)llt.ImmutableExternalState);
 

--- a/src/Raven.Server/Documents/Indexes/MapReduce/OutputToCollection/OutputReduceToCollectionActions.cs
+++ b/src/Raven.Server/Documents/Indexes/MapReduce/OutputToCollection/OutputReduceToCollectionActions.cs
@@ -227,7 +227,7 @@ namespace Raven.Server.Documents.Indexes.MapReduce.OutputToCollection
 
             reduceOutputsTree.Delete(prefix);
 
-            indexContext.Transaction.InnerTransaction.LowLevelTransaction.AfterCommitWhenNewReadTransactionsPrevented += __ =>
+            indexContext.Transaction.InnerTransaction.LowLevelTransaction.AfterCommitWhenNewTransactionsPrevented += __ =>
             {
                 // ensure that we delete it from in-memory state only after successful commit
                 _prefixesOfReduceOutputDocumentsToDelete.TryRemove(prefix, out _);

--- a/src/Raven.Server/Rachis/RachisConsensus.cs
+++ b/src/Raven.Server/Rachis/RachisConsensus.cs
@@ -781,7 +781,7 @@ namespace Raven.Server.Rachis
 
             PrevStates.LimitedSizeEnqueue(transition, 5);
 
-            context.Transaction.InnerTransaction.LowLevelTransaction.AfterCommitWhenNewReadTransactionsPrevented +=
+            context.Transaction.InnerTransaction.LowLevelTransaction.AfterCommitWhenNewTransactionsPrevented +=
                 _ => CurrentState = rachisState; //  we need this to happened while we still under the write lock
 
             context.Transaction.InnerTransaction.LowLevelTransaction.OnDispose += tx =>

--- a/src/Raven.Server/ServerWide/ClusterStateMachine.cs
+++ b/src/Raven.Server/ServerWide/ClusterStateMachine.cs
@@ -1112,7 +1112,7 @@ namespace Raven.Server.ServerWide
 
         private void ExecuteManyOnDispose(TransactionOperationContext context, long index, string type, List<Func<Task>> tasks)
         {
-            context.Transaction.InnerTransaction.LowLevelTransaction.AfterCommitWhenNewReadTransactionsPrevented += _ =>
+            context.Transaction.InnerTransaction.LowLevelTransaction.AfterCommitWhenNewTransactionsPrevented += _ =>
             {
                 _rachisLogIndexNotifications.AddTask(index);
                 var count = tasks.Count;
@@ -1891,7 +1891,7 @@ namespace Raven.Server.ServerWide
 
         private void NotifyValueChanged(TransactionOperationContext context, string type, long index)
         {
-            context.Transaction.InnerTransaction.LowLevelTransaction.AfterCommitWhenNewReadTransactionsPrevented += _ =>
+            context.Transaction.InnerTransaction.LowLevelTransaction.AfterCommitWhenNewTransactionsPrevented += _ =>
             {
                 // we do this under the write tx lock before we update the last applied index
                 _rachisLogIndexNotifications.AddTask(index);
@@ -1905,7 +1905,7 @@ namespace Raven.Server.ServerWide
 
         private void NotifyDatabaseAboutChanged(TransactionOperationContext context, string databaseName, long index, string type, DatabasesLandlord.ClusterDatabaseChangeType change)
         {
-            context.Transaction.InnerTransaction.LowLevelTransaction.AfterCommitWhenNewReadTransactionsPrevented += _ =>
+            context.Transaction.InnerTransaction.LowLevelTransaction.AfterCommitWhenNewTransactionsPrevented += _ =>
             {
                 // we do this under the write tx lock before we update the last applied index
                 _rachisLogIndexNotifications.AddTask(index);
@@ -2438,7 +2438,7 @@ namespace Raven.Server.ServerWide
 
         private void OnTransactionDispose(TransactionOperationContext context, long index)
         {
-            context.Transaction.InnerTransaction.LowLevelTransaction.AfterCommitWhenNewReadTransactionsPrevented += _ =>
+            context.Transaction.InnerTransaction.LowLevelTransaction.AfterCommitWhenNewTransactionsPrevented += _ =>
             {
                 _rachisLogIndexNotifications.AddTask(index);
                 NotifyAndSetCompleted(index);

--- a/src/Voron/Impl/LowLevelTransaction.cs
+++ b/src/Voron/Impl/LowLevelTransaction.cs
@@ -112,7 +112,7 @@ namespace Voron.Impl
             }
         }
         public event Action<IPagerLevelTransactionState> OnDispose;
-        public event Action<LowLevelTransaction> AfterCommitWhenNewReadTransactionsPrevented;
+        public event Action<LowLevelTransaction> AfterCommitWhenNewTransactionsPrevented;
 
         private readonly IFreeSpaceHandling _freeSpaceHandling;
         internal FixedSizeTree _freeSpaceTree;
@@ -1287,11 +1287,11 @@ namespace Voron.Impl
         }
 
         [MethodImpl(MethodImplOptions.AggressiveInlining)]
-        internal void OnAfterCommitWhenNewReadTransactionsPrevented()
+        internal void OnAfterCommitWhenNewTransactionsPrevented()
         {
             // the event cannot be called outside this class while we need to call it in 
             // StorageEnvironment.TransactionAfterCommit
-            AfterCommitWhenNewReadTransactionsPrevented?.Invoke(this);
+            AfterCommitWhenNewTransactionsPrevented?.Invoke(this);
         }
 
 

--- a/src/Voron/StorageEnvironment.cs
+++ b/src/Voron/StorageEnvironment.cs
@@ -683,7 +683,7 @@ namespace Voron
                     if (flags == TransactionFlags.ReadWrite)
                     {
                         tx.CurrentTransactionHolder = _currentWriteTransactionHolder;
-                        tx.AfterCommitWhenNewReadTransactionsPrevented += AfterCommitWhenNewReadTransactionsPrevented;
+                        tx.AfterCommitWhenNewTransactionsPrevented += AfterCommitWhenNewTransactionsPrevented;
                     }
 
                     ActiveTransactions.Add(tx);
@@ -749,6 +749,11 @@ namespace Voron
         private void ThrowCurrentlyDisposing()
         {
             throw new ObjectDisposedException("The environment " + Options.BasePath + " is currently being disposed");
+        }
+
+        private void ThrowCommittedAndFlushedTransactionNotFoundInActiveOnes(LowLevelTransaction llt)
+        {
+            throw new InvalidOperationException($"The transaction with ID '{llt.Id}' got committed and flushed but it wasn't found in the {nameof(ActiveTransactions)}");
         }
 
         internal void WriteTransactionStarted()
@@ -846,24 +851,29 @@ namespace Voron
         }
 
         public event Action<LowLevelTransaction> NewTransactionCreated;
-        public event Action<LowLevelTransaction> AfterCommitWhenNewReadTransactionsPrevented;
+        public event Action<LowLevelTransaction> AfterCommitWhenNewTransactionsPrevented;
         internal void TransactionAfterCommit(LowLevelTransaction tx)
         {
             if (ActiveTransactions.Contains(tx) == false)
+            {
+                if (tx.Committed && tx.FlushedToJournal)
+                    ThrowCommittedAndFlushedTransactionNotFoundInActiveOnes(tx);
+
                 return;
+            }
 
             using (PreventNewTransactions())
             {
-                Journal.Applicator.OnTransactionCommitted(tx);
-                ScratchBufferPool.UpdateCacheForPagerStatesOfAllScratches();
-                Journal.UpdateCacheForJournalSnapshots();
-
-                tx.OnAfterCommitWhenNewReadTransactionsPrevented();
-
                 if (tx.Committed && tx.FlushedToJournal)
                     Interlocked.Exchange(ref _transactionsCounter, tx.Id);
 
                 State = tx.State;
+
+                Journal.Applicator.OnTransactionCommitted(tx);
+                ScratchBufferPool.UpdateCacheForPagerStatesOfAllScratches();
+                Journal.UpdateCacheForJournalSnapshots();
+
+                tx.OnAfterCommitWhenNewTransactionsPrevented();
             }
         }
 

--- a/test/SlowTests/Voron/Issues/RDBCL_1977.cs
+++ b/test/SlowTests/Voron/Issues/RDBCL_1977.cs
@@ -1,0 +1,96 @@
+﻿using System;
+using FastTests.Voron;
+using Voron;
+using Xunit;
+using Xunit.Abstractions;
+
+namespace SlowTests.Voron.Issues;
+
+public class RDBCL_1977 : StorageTest
+{
+    public RDBCL_1977(ITestOutputHelper output) : base(output)
+    {
+    }
+
+    protected override void Configure(StorageEnvironmentOptions options)
+    {
+        base.Configure(options);
+
+        options.ManualFlushing = true;
+    }
+
+    [Fact]
+    public void MustNotAllowToCreateWriteTransactionAfterCatastrophicError()
+    {
+        var exceptionDuringStage3OfCommit = Assert.Throws<InvalidOperationException>(() =>
+        {
+            using (var tx = Env.WriteTransaction())
+            {
+                tx.LowLevelTransaction.AfterCommitWhenNewTransactionsPrevented += transaction => throw new InvalidOperationException(
+                    "Intentional error during CommitStage3_DisposeTransactionResources should mark the env in the catastrophic error state");
+
+                tx.Commit();
+            }
+        });
+
+        // this should throw because of AssertNoCatastrophicFailure() assertion on write tx creation
+        var exceptionOnTxCreation = Assert.Throws<InvalidOperationException>(() =>
+        {
+            using (Env.WriteTransaction())
+            {
+
+            }
+        });
+
+        Assert.Equal(exceptionDuringStage3OfCommit.Message, exceptionOnTxCreation.Message);
+
+        Assert.Throws<InvalidOperationException>(() => Env.Options.AssertNoCatastrophicFailure());
+
+        // Read transaction can be still created 
+        using (Env.ReadTransaction())
+        {
+            
+        }
+    }
+
+    [Fact]
+    public void MustNotAllowToCommitWriteTransactionDuringAfterCommitWhenNewTransactionsPrevented()
+    {
+        var ex = Assert.Throws<InvalidOperationException>(() =>
+        {
+            using (var tx = Env.WriteTransaction())
+            {
+                tx.LowLevelTransaction.AfterCommitWhenNewTransactionsPrevented += transaction =>
+                {
+                    transaction.Commit();
+                };
+
+                tx.Commit();
+            }
+        });
+
+        Assert.Equal("Cannot commit already committed transaction.", ex.Message);
+    }
+
+    [Fact]
+    public void MustNotAllowToCreateWriteTransactionDuringAfterCommitWhenNewTransactionsPrevented()
+    {
+        var ex = Assert.Throws<InvalidOperationException>(() =>
+        {
+            using (var tx = Env.WriteTransaction())
+            {
+                tx.LowLevelTransaction.AfterCommitWhenNewTransactionsPrevented += transaction =>
+                {
+                    using (Env.WriteTransaction())
+                    {
+
+                    }
+                };
+
+                tx.Commit();
+            }
+        });
+        
+        Assert.Contains("A write transaction is already opened", ex.Message);
+    }
+}


### PR DESCRIPTION
- Moved the transaction counter update before other actions - that shouldn't matter since any error thrown there causes the catastrophic error and prevents from creating new transaction
- Also renaming `AfterCommitWhenNewReadTransactionsPrevented` to `AfterCommitWhenNewTransactionsPrevented` since it's not just about read transactions

### Issue link

https://issues.hibernatingrhinos.com/issue/RDBCL-1977
https://issues.hibernatingrhinos.com/issue/RavenDB-16869

### Additional description

Enhancements potentially could help to narrow down the issue

### Type of change

- Debugging enhancements
- Possible improved behavior when additional operations hook up to `AfterCommitWhenNewReadTransactionsPrevented`

### How risky is the change?

- Low +

### Backward compatibility

- Non breaking change

### Is it platform specific issue?

- No

### Documentation update

- No documentation update is needed 

### Testing 

- Cannot reproduce the original issue with committing 2 transactions with the same ID

### Is there any existing behavior change of other features due to this change?

- No

### UI work

- No UI work is needed
