### PR TITLE
DatabaseChanges connection completion source task not faulted upon error state

### DIFF
--- a/src/Raven.Client/Documents/Changes/DatabaseChanges.cs
+++ b/src/Raven.Client/Documents/Changes/DatabaseChanges.cs
@@ -528,6 +528,9 @@ namespace Raven.Client.Documents.Changes
                 catch (OperationCanceledException e)
                 {
                     NotifyAboutError(e);
+                    if (wasConnected)
+                        ConnectionStatusChanged?.Invoke(this, EventArgs.Empty);
+                    _tcs.TrySetCanceled();
                     return;
                 }
                 catch (ChangeProcessingException)
@@ -565,6 +568,7 @@ namespace Raven.Client.Documents.Changes
                     {
                         // we couldn't reconnect
                         NotifyAboutError(e);
+                        _tcs.TrySetException(e);
                         throw;
                     }
                 }


### PR DESCRIPTION
When using the `EnsureConnectionNow` method the task may not reflect the error state of the `DoWork` method.
If an exception occurs (other than the `ChangeProcessingException` then the `_tsc` task completion source is not always updated. This can result in the _tsc task to remain in a non error state, while no more reconnection attempts will be made.

### Issue link

https://github.com/ravendb/ravendb/discussions/13048

### Additional description

Normally errors are reported through the OnError of an Rx subscription on the changes. However if an exception occurs before a subscription is made then this error is lost. By setting this error on the `_tcs`, as is done in several other places, you will be able to use the task status to determine whether or not the subscription is in an error state.


### Type of change

- Bug fix

### How risky is the change?

- Low 

### Backward compatibility

- Non breaking change


### Is it platform specific issue?

- No

### Documentation update

- No documentation update is needed 


### Is there any existing behavior change of other features due to this change?

- No

### UI work

- No UI work is needed
