### PR TITLE
RavenDB-17533 create new command type & block ETL

### DIFF
--- a/src/Raven.Client/Documents/Commands/Batches/ICommandData.cs
+++ b/src/Raven.Client/Documents/Commands/Batches/ICommandData.cs
@@ -35,6 +35,7 @@ namespace Raven.Client.Documents.Commands.Batches
         ForceRevisionCreation, 
         Counters,
         TimeSeries,
+        TimeSeriesWithIncrements,
         TimeSeriesBulkInsert,
         TimeSeriesCopy,
 

--- a/src/Raven.Client/Documents/Commands/Batches/TimeSeriesBatchCommandData.cs
+++ b/src/Raven.Client/Documents/Commands/Batches/TimeSeriesBatchCommandData.cs
@@ -8,30 +8,27 @@ using Sparrow.Json.Parsing;
 
 namespace Raven.Client.Documents.Commands.Batches
 {
-    public class TimeSeriesBatchCommandData : ICommandData
+    public class IncrementalTimeSeriesBatchCommandData : TimeSeriesCommandData
     {
-        public TimeSeriesBatchCommandData(string documentId, string name, IList<TimeSeriesOperation.AppendOperation> appends, 
-            List<TimeSeriesOperation.DeleteOperation> deletes) : this(documentId, name, appends, deletes, null)
+        public IncrementalTimeSeriesBatchCommandData(string documentId, string name, IList<TimeSeriesOperation.IncrementOperation> increments) : base(documentId, name)
         {
+            if (increments != null)
+            {
+                foreach (var incrementOperation in increments)
+                {
+                    TimeSeries.Increment(incrementOperation);
+                }
+            }
         }
 
-        public TimeSeriesBatchCommandData(string documentId, string name, IList<TimeSeriesOperation.AppendOperation> appends,
-            List<TimeSeriesOperation.DeleteOperation> deletes, IList<TimeSeriesOperation.IncrementOperation> increments)
+        public override CommandType Type => CommandType.TimeSeriesWithIncrements;
+    }
+
+    public class TimeSeriesBatchCommandData : TimeSeriesCommandData
+    {
+        public TimeSeriesBatchCommandData(string documentId, string name, IList<TimeSeriesOperation.AppendOperation> appends, 
+            List<TimeSeriesOperation.DeleteOperation> deletes) : base(documentId, name)
         {
-            if (string.IsNullOrWhiteSpace(documentId))
-                throw new ArgumentNullException(nameof(documentId));
-
-            if (string.IsNullOrWhiteSpace(name))
-                throw new ArgumentNullException(nameof(name));
-
-            Id = documentId;
-            Name = name;
-
-            TimeSeries = new TimeSeriesOperation
-            {
-                Name = name
-            };
-
             if (appends != null)
             {
                 foreach (var appendOperation in appends)
@@ -47,14 +44,28 @@ namespace Raven.Client.Documents.Commands.Batches
                     TimeSeries.Delete(deleteOperation);
                 }
             }
+        }
 
-            if (increments != null)
+        public override CommandType Type => CommandType.TimeSeries;
+    }
+
+    public abstract class TimeSeriesCommandData : ICommandData
+    {
+        protected TimeSeriesCommandData(string documentId, string name)
+        {
+            if (string.IsNullOrWhiteSpace(documentId))
+                throw new ArgumentNullException(nameof(documentId));
+
+            if (string.IsNullOrWhiteSpace(name))
+                throw new ArgumentNullException(nameof(name));
+
+            Id = documentId;
+            Name = name;
+
+            TimeSeries = new TimeSeriesOperation
             {
-                foreach (var incrementOperation in increments)
-                {
-                    TimeSeries.Increment(incrementOperation);
-                }
-            }
+                Name = name
+            };
         }
 
         public string Id { get; set; }
@@ -63,9 +74,9 @@ namespace Raven.Client.Documents.Commands.Batches
 
         public string ChangeVector => null;
 
-        public CommandType Type => CommandType.TimeSeries;
+        public abstract CommandType Type { get; }
 
-        public TimeSeriesOperation TimeSeries { get; }
+        public TimeSeriesOperation TimeSeries { get; protected set; }
         
         public bool? FromEtl { get; set; }
 

--- a/src/Raven.Client/Documents/Session/InMemoryDocumentSessionOperations.cs
+++ b/src/Raven.Client/Documents/Session/InMemoryDocumentSessionOperations.cs
@@ -1371,6 +1371,7 @@ more responsive application.
                     commandType != CommandType.AttachmentMOVE &&
                     commandType != CommandType.Counters &&
                     commandType != CommandType.TimeSeries &&
+                    commandType != CommandType.TimeSeriesWithIncrements &&
                     commandType != CommandType.TimeSeriesCopy)
                     DeferredCommandsDictionary[(id, CommandType.ClientModifyDocumentCommand, null)] = command;
             }

--- a/src/Raven.Client/Documents/Session/Operations/BatchOperation.cs
+++ b/src/Raven.Client/Documents/Session/Operations/BatchOperation.cs
@@ -158,6 +158,7 @@ namespace Raven.Client.Documents.Session.Operations
                         HandleCounters(batchResult);
                         break;
                     case CommandType.TimeSeries:
+                    case CommandType.TimeSeriesWithIncrements:
                         //TODO: RavenDB-13474 add to time series cache
                         break;
                     case CommandType.TimeSeriesCopy:

--- a/src/Raven.Client/Documents/Session/SessionTimeSeriesBase.cs
+++ b/src/Raven.Client/Documents/Session/SessionTimeSeriesBase.cs
@@ -136,14 +136,14 @@ namespace Raven.Client.Documents.Session
                 Values = values is double[] doubleValues ? doubleValues : values.ToArray()
             };
 
-            if (Session.DeferredCommandsDictionary.TryGetValue((DocId, CommandType.TimeSeries, Name), out var command))
+            if (Session.DeferredCommandsDictionary.TryGetValue((DocId, CommandType.TimeSeriesWithIncrements, Name), out var command))
             {
-                var tsCmd = (TimeSeriesBatchCommandData)command;
+                var tsCmd = (IncrementalTimeSeriesBatchCommandData)command;
                 tsCmd.TimeSeries.Increment(op);
             }
             else
             {
-                Session.Defer(new TimeSeriesBatchCommandData(DocId, Name, appends: null, deletes: null, increments: new List<TimeSeriesOperation.IncrementOperation> { op }));
+                Session.Defer(new IncrementalTimeSeriesBatchCommandData(DocId, Name, increments: new List<TimeSeriesOperation.IncrementOperation> { op }));
             }
         }
 

--- a/src/Raven.Server/Documents/ETL/Providers/Raven/RavenEtlScriptRun.cs
+++ b/src/Raven.Server/Documents/ETL/Providers/Raven/RavenEtlScriptRun.cs
@@ -88,7 +88,7 @@ namespace Raven.Server.Documents.ETL.Providers.Raven
             {
                 foreach (var operation in timeSeriesOperations)
                 {
-                    commands.Add(new TimeSeriesBatchCommandData(id, operation.Name, operation.Appends, operation.Deletes, operation.Increments)
+                    commands.Add(new TimeSeriesBatchCommandData(id, operation.Name, operation.Appends, operation.Deletes)
                     {
                         FromEtl = true
                     });    
@@ -260,7 +260,7 @@ namespace Raven.Server.Documents.ETL.Providers.Raven
 
             if (timeSeriesOperations.TryGetValue(timeSeriesName, out var timeSeriesOperation) == false)
             {
-                timeSeriesOperation = new TimeSeriesBatchCommandData(documentId, timeSeriesName, appends: null, deletes: null, increments: null);
+                timeSeriesOperation = new TimeSeriesBatchCommandData(documentId, timeSeriesName, appends: null, deletes: null);
                 timeSeriesOperations.Add(timeSeriesName, timeSeriesOperation);
             }
 
@@ -307,7 +307,7 @@ namespace Raven.Server.Documents.ETL.Providers.Raven
                     {
                         foreach (var (_, operation) in timeSeriesOperations)
                         {
-                            commands.Add(new TimeSeriesBatchCommandData(put.Value.Id, operation.Name, operation.Appends, operation.Deletes, operation.Increments){FromEtl = true});
+                            commands.Add(new TimeSeriesBatchCommandData(put.Value.Id, operation.Name, operation.Appends, operation.Deletes){FromEtl = true});
                         }
                     }
                 }

--- a/src/Raven.Server/Documents/Handlers/BatchHandler.cs
+++ b/src/Raven.Server/Documents/Handlers/BatchHandler.cs
@@ -1000,6 +1000,7 @@ namespace Raven.Server.Documents.Handlers
                             break;
 
                         case CommandType.TimeSeries:
+                        case CommandType.TimeSeriesWithIncrements:
                             EtlGetDocIdFromPrefixIfNeeded(ref cmd.Id, cmd, lastPutResult);
                             var tsCmd = new TimeSeriesHandler.ExecuteTimeSeriesBatchCommand(Database, cmd.Id, cmd.TimeSeries, cmd.FromEtl);
 
@@ -1011,7 +1012,7 @@ namespace Raven.Server.Documents.Handlers
                             {
                                 [nameof(BatchRequestParser.CommandData.Id)] = cmd.Id,
                                 [nameof(BatchRequestParser.CommandData.ChangeVector)] = tsCmd.LastChangeVector,
-                                [nameof(BatchRequestParser.CommandData.Type)] = nameof(CommandType.TimeSeries),
+                                [nameof(BatchRequestParser.CommandData.Type)] = cmd.Type,
                                 //TODO: handle this
                                 //[nameof(Constants.Fields.CommandData.DocumentChangeVector)] = tsCmd.LastDocumentChangeVector
                             });

--- a/src/Raven.Server/Documents/Handlers/BatchRequestParser.cs
+++ b/src/Raven.Server/Documents/Handlers/BatchRequestParser.cs
@@ -1156,7 +1156,11 @@ namespace Raven.Server.Documents.Handlers
                     if (*(long*)state.StringBuffer == 8318823012450529091)
                         return CommandType.Counters;
                     break;
-
+                case 9:
+                    if (*(long*)state.StringBuffer == 7166459905131377482 &&
+                        state.StringBuffer[8] == (byte)'h')
+                        return CommandType.JsonPatch;
+                    break;
                 case 10:
                     if (*(long*)state.StringBuffer == 7598246930185808212 &&
                     *(short*)(state.StringBuffer + sizeof(long)) == 29541)
@@ -1225,10 +1229,12 @@ namespace Raven.Server.Documents.Handlers
                         state.StringBuffer[sizeof(long) + sizeof(long) + sizeof(int)] == (byte)'n')
                         return CommandType.ForceRevisionCreation;
                     break;
-                case 9:
-                    if (*(long*)state.StringBuffer == 7166459905131377482 &&
-                        state.StringBuffer[8] == (byte)'h')
-                        return CommandType.JsonPatch;
+
+                case 24:
+                    if (*(long*)state.StringBuffer == 7598246930185808212 &&
+                        *(long*)(state.StringBuffer + sizeof(long)) == 7946997866664784741 && 
+                        *(long*)(state.StringBuffer + sizeof(long) + sizeof(long)) == 8319395793566265955)
+                        return CommandType.TimeSeriesWithIncrements;
                     break;
             }
 

--- a/src/Raven.Server/NotificationCenter/EtlNotifications.cs
+++ b/src/Raven.Server/NotificationCenter/EtlNotifications.cs
@@ -90,6 +90,20 @@ namespace Raven.Server.NotificationCenter
             }
         }
 
+        public T GetAlert<T>(string processTag, string processName, AlertType etlAlertType) where T : INotificationDetails, new()
+        {
+            Debug.Assert(etlAlertType == AlertType.Etl_LoadError || etlAlertType == AlertType.Etl_TransformationError);
+
+            var key = $"{processTag}/{processName}";
+
+            var id = AlertRaised.GetKey(etlAlertType, key);
+
+            using (_notificationsStorage.Read(id, out NotificationTableValue ntv))
+            {
+                return GetDetails<T>(ntv);
+            }
+        }
+
         private PerformanceHint GetOrCreatePerformanceHint<T>(string processTag, string processName, PerformanceHintType etlHintType, string message, out T details) where T : INotificationDetails, new()
         {
             Debug.Assert(etlHintType == PerformanceHintType.SqlEtl_SlowSql);


### PR DESCRIPTION
### Issue link

https://issues.hibernatingrhinos.com/issue/RavenDB-17533

### Additional description

The main issue was that we treat the incremental time-series as a normal time-series, so the incrementing from new client to old server wasn't throwing an exception, but simple accept the operation and does nothing with it.

After adding the new type and adjust the client, ETL part was need to be taken care of, since it uses the client.
upon ETLing a time-series we were using always the `Append` which wouldn't work for ETLing to even a new 5.3 server since the name begin with `INC:` but it was an append operation, so I did quick & dirty fix, but we need to address it in a separate issue.

### Type of change

- Bug fix

### How risky is the change?

- Low 

### Backward compatibility

I think Not relevant

### Is it platform specific issue?

- No

### Documentation update

- No documentation update is needed 

### Testing 

- Tests have been added that prove the fix is effective or that the feature works
- It has been verified by manual testing

### Is there any existing behavior change of other features due to this change?

- No

### UI work

Maybe studio work required, since we change how we sent stuff via the command. (but not sure what the studio uses)
