### PR TITLE
RavenDB-17537 Error when querying Auto-Index with quotes

### DIFF
--- a/src/Raven.Studio/typescript/common/queryUtil.ts
+++ b/src/Raven.Studio/typescript/common/queryUtil.ts
@@ -32,6 +32,16 @@ class queryUtil {
         }
         return "'" + name + "'";
     }
+    
+    static escapeIndexName(indexName: string): string {
+        indexName = indexName.replace(/"/g, '\\"');
+        
+        if (indexName.toLocaleLowerCase().startsWith(queryUtil.AutoPrefix) && indexName.includes("'")) {
+            return `"${indexName}"`;
+        }
+
+        return `'${indexName}'`;
+    }
 
     private static readonly RQL_TOKEN_REGEX = /(?=([^{]*{[^}{]*})*[^}]*$)(?=([^']*'[^']*')*[^']*$)(?=([^"]*"[^"]*")*[^"]*$)(SELECT|WHERE|ORDER BY|LOAD|UPDATE|INCLUDE)(\s+|{)/gi;
 

--- a/src/Raven.Studio/typescript/models/database/query/queryCriteria.ts
+++ b/src/Raven.Studio/typescript/models/database/query/queryCriteria.ts
@@ -67,15 +67,22 @@ class queryCriteria {
             hash: genUtils.hashCode(name + (queryText || "")) } as storedQueryDto;
     }
 
-    setSelectedIndex(indexName: string) {
+    setSelectedIndex(indexName: string): void {
         let rql = "from ";
-        if (indexName.startsWith(queryUtil.DynamicPrefix)) {
+
+        if (indexName.toLocaleLowerCase().startsWith(queryUtil.AutoPrefix) && indexName.includes("'")) {
+            rql += `index "${indexName}"`;
+
+        } else  if (indexName.startsWith(queryUtil.DynamicPrefix)) {
             rql += indexName.substring(queryUtil.DynamicPrefix.length);
+
         } else if (indexName === queryUtil.AllDocs) {
             rql += "@all_docs";
+
         } else {
             rql += "index '" + indexName + "'";
         }
+
         this.queryText(rql);
     }
 

--- a/src/Raven.Studio/typescript/models/database/query/queryCriteria.ts
+++ b/src/Raven.Studio/typescript/models/database/query/queryCriteria.ts
@@ -70,19 +70,14 @@ class queryCriteria {
     setSelectedIndex(indexName: string): void {
         let rql = "from ";
 
-        indexName = indexName.replace(/"/g, '\\"');
-        
-        if (indexName.toLocaleLowerCase().startsWith(queryUtil.AutoPrefix) && indexName.includes("'")) {
-            rql += `index "${indexName}"`;
-
-        } else  if (indexName.startsWith(queryUtil.DynamicPrefix)) {
+        if (indexName.startsWith(queryUtil.DynamicPrefix)) {
             rql += indexName.substring(queryUtil.DynamicPrefix.length);
 
         } else if (indexName === queryUtil.AllDocs) {
             rql += "@all_docs";
 
         } else {
-            rql += "index '" + indexName + "'";
+            rql += `index ${queryUtil.escapeIndexName(indexName)}`;
         }
 
         this.queryText(rql);

--- a/src/Raven.Studio/typescript/models/database/query/queryCriteria.ts
+++ b/src/Raven.Studio/typescript/models/database/query/queryCriteria.ts
@@ -70,6 +70,8 @@ class queryCriteria {
     setSelectedIndex(indexName: string): void {
         let rql = "from ";
 
+        indexName = indexName.replace(/"/g, '\\"');
+        
         if (indexName.toLocaleLowerCase().startsWith(queryUtil.AutoPrefix) && indexName.includes("'")) {
             rql += `index "${indexName}"`;
 


### PR DESCRIPTION
### Issue link
https://issues.hibernatingrhinos.com/issue/RavenDB-17537

### Additional description
Added double quotes to auto-index name when name has single quotes inside

### Type of change
- Bug fix

### How risky is the change?
- Low 

### Backward compatibility
- Non breaking change
- 
### Is it platform specific issue?
- No

### Documentation update
- No documentation update is needed 

### Testing 
- It has been verified by manual testing

### Is there any existing behavior change of other features due to this change?
- No

### UI work
- No UI work is needed
