### PR TITLE
RDBCL-1977 Fixing test compilation if someone doesn't have .net 6 sdk installed (VS 2022 took advantage of new c# feature that there is no need to add curly brackets after namespace)

### DIFF
--- a/test/SlowTests/Voron/Issues/RDBCL_1977.cs
+++ b/test/SlowTests/Voron/Issues/RDBCL_1977.cs
@@ -4,93 +4,94 @@ using Voron;
 using Xunit;
 using Xunit.Abstractions;
 
-namespace SlowTests.Voron.Issues;
-
-public class RDBCL_1977 : StorageTest
+namespace SlowTests.Voron.Issues
 {
-    public RDBCL_1977(ITestOutputHelper output) : base(output)
+    public class RDBCL_1977 : StorageTest
     {
-    }
-
-    protected override void Configure(StorageEnvironmentOptions options)
-    {
-        base.Configure(options);
-
-        options.ManualFlushing = true;
-    }
-
-    [Fact]
-    public void MustNotAllowToCreateWriteTransactionAfterCatastrophicError()
-    {
-        var exceptionDuringStage3OfCommit = Assert.Throws<InvalidOperationException>(() =>
+        public RDBCL_1977(ITestOutputHelper output) : base(output)
         {
-            using (var tx = Env.WriteTransaction())
-            {
-                tx.LowLevelTransaction.AfterCommitWhenNewTransactionsPrevented += transaction => throw new InvalidOperationException(
-                    "Intentional error during CommitStage3_DisposeTransactionResources should mark the env in the catastrophic error state");
-
-                tx.Commit();
-            }
-        });
-
-        // this should throw because of AssertNoCatastrophicFailure() assertion on write tx creation
-        var exceptionOnTxCreation = Assert.Throws<InvalidOperationException>(() =>
-        {
-            using (Env.WriteTransaction())
-            {
-
-            }
-        });
-
-        Assert.Equal(exceptionDuringStage3OfCommit.Message, exceptionOnTxCreation.Message);
-
-        Assert.Throws<InvalidOperationException>(() => Env.Options.AssertNoCatastrophicFailure());
-
-        // Read transaction can be still created 
-        using (Env.ReadTransaction())
-        {
-            
         }
-    }
 
-    [Fact]
-    public void MustNotAllowToCommitWriteTransactionDuringAfterCommitWhenNewTransactionsPrevented()
-    {
-        var ex = Assert.Throws<InvalidOperationException>(() =>
+        protected override void Configure(StorageEnvironmentOptions options)
         {
-            using (var tx = Env.WriteTransaction())
-            {
-                tx.LowLevelTransaction.AfterCommitWhenNewTransactionsPrevented += transaction =>
-                {
-                    transaction.Commit();
-                };
+            base.Configure(options);
 
-                tx.Commit();
+            options.ManualFlushing = true;
+        }
+
+        [Fact]
+        public void MustNotAllowToCreateWriteTransactionAfterCatastrophicError()
+        {
+            var exceptionDuringStage3OfCommit = Assert.Throws<InvalidOperationException>(() =>
+            {
+                using (var tx = Env.WriteTransaction())
+                {
+                    tx.LowLevelTransaction.AfterCommitWhenNewTransactionsPrevented += transaction => throw new InvalidOperationException(
+                        "Intentional error during CommitStage3_DisposeTransactionResources should mark the env in the catastrophic error state");
+
+                    tx.Commit();
+                }
+            });
+
+            // this should throw because of AssertNoCatastrophicFailure() assertion on write tx creation
+            var exceptionOnTxCreation = Assert.Throws<InvalidOperationException>(() =>
+            {
+                using (Env.WriteTransaction())
+                {
+
+                }
+            });
+
+            Assert.Equal(exceptionDuringStage3OfCommit.Message, exceptionOnTxCreation.Message);
+
+            Assert.Throws<InvalidOperationException>(() => Env.Options.AssertNoCatastrophicFailure());
+
+            // Read transaction can be still created 
+            using (Env.ReadTransaction())
+            {
+
             }
-        });
+        }
 
-        Assert.Equal("Cannot commit already committed transaction.", ex.Message);
-    }
-
-    [Fact]
-    public void MustNotAllowToCreateWriteTransactionDuringAfterCommitWhenNewTransactionsPrevented()
-    {
-        var ex = Assert.Throws<InvalidOperationException>(() =>
+        [Fact]
+        public void MustNotAllowToCommitWriteTransactionDuringAfterCommitWhenNewTransactionsPrevented()
         {
-            using (var tx = Env.WriteTransaction())
+            var ex = Assert.Throws<InvalidOperationException>(() =>
             {
-                tx.LowLevelTransaction.AfterCommitWhenNewTransactionsPrevented += transaction =>
+                using (var tx = Env.WriteTransaction())
                 {
-                    using (Env.WriteTransaction())
+                    tx.LowLevelTransaction.AfterCommitWhenNewTransactionsPrevented += transaction =>
                     {
+                        transaction.Commit();
+                    };
 
-                    }
-                };
+                    tx.Commit();
+                }
+            });
 
-                tx.Commit();
-            }
-        });
-        
-        Assert.Contains("A write transaction is already opened", ex.Message);
+            Assert.Equal("Cannot commit already committed transaction.", ex.Message);
+        }
+
+        [Fact]
+        public void MustNotAllowToCreateWriteTransactionDuringAfterCommitWhenNewTransactionsPrevented()
+        {
+            var ex = Assert.Throws<InvalidOperationException>(() =>
+            {
+                using (var tx = Env.WriteTransaction())
+                {
+                    tx.LowLevelTransaction.AfterCommitWhenNewTransactionsPrevented += transaction =>
+                    {
+                        using (Env.WriteTransaction())
+                        {
+
+                        }
+                    };
+
+                    tx.Commit();
+                }
+            });
+
+            Assert.Contains("A write transaction is already opened", ex.Message);
+        }
     }
 }


### PR DESCRIPTION
### Issue link

https://issues.hibernatingrhinos.com/issue/RDBCL-1977

### Additional description

Fixing test compilation if .net 6 sdk aren't installed

### Type of change

- Compilation fix

### How risky is the change?

- Low 

### Backward compatibility

- Not relevant

