### PR TITLE
RavenDB-17478 "Field count mismatch when mapping column types" on some RQL queries

### DIFF
--- a/src/Raven.Server/Integrations/PostgreSQL/PgQuery.cs
+++ b/src/Raven.Server/Integrations/PostgreSQL/PgQuery.cs
@@ -51,7 +51,14 @@ namespace Raven.Server.Integrations.PostgreSQL
                     return powerBiQuery;
                 }
 
-                return new HardcodedQuery(queryText, parametersDataTypes);
+                if (HardcodedQuery.TryParse(queryText, parametersDataTypes, out var hardcodedQuery))
+                    return hardcodedQuery;
+
+                throw new PgErrorException(
+                    PgErrorCodes.StatementTooComplex,
+                    "Unhandled query (Are you using ; in your query? " +
+                    "That is likely causing Power BI to split the query and results in partial queries): " +
+                    $"{queryText}");
             }
             catch (Exception e)
             {

--- a/src/Raven.Server/Integrations/PostgreSQL/PgQuery.cs
+++ b/src/Raven.Server/Integrations/PostgreSQL/PgQuery.cs
@@ -57,7 +57,7 @@ namespace Raven.Server.Integrations.PostgreSQL
                 throw new PgErrorException(
                     PgErrorCodes.StatementTooComplex,
                     "Unhandled query (Are you using ; in your query? " +
-                    "That is likely causing Power BI to split the query and results in partial queries): " +
+                    $"That is likely causing Power BI to split the query and results in partial queries): {Environment.NewLine}" +
                     $"{queryText}");
             }
             catch (Exception e)


### PR DESCRIPTION
### Issue link

https://issues.hibernatingrhinos.com/issue/RavenDB-17478

### Additional description

I've added message for PowerBI user when user tries to use unsupported RQL query with semicolon.

### Type of change

- Error message improvement

### How risky is the change?

- Not relevant

### Backward compatibility

- Not relevant

### Is it platform specific issue?

- No

### Documentation update

- No documentation update is needed 

### Testing 

- It has been verified by manual testing

### Is there any existing behavior change of other features due to this change?

- No

### UI work

- No UI work is needed
