### PR TITLE
RavenDB-17493 NaN should be the initial values for StatefulTimestampValue

### DIFF
--- a/src/Raven.Server/Documents/TimeSeries/TimeSeriesValuesSegment.cs
+++ b/src/Raven.Server/Documents/TimeSeries/TimeSeriesValuesSegment.cs
@@ -182,6 +182,15 @@ namespace Raven.Server.Documents.TimeSeries
 
                 AddTimestamp(deltaFromStart, ref tempBitsBuffer, tempHeader);
 
+                if (NumberOfLiveEntries == 0 &&
+                    status == Live)
+                {
+                    for (int i = 0; i < vals.Length; i++)
+                    {
+                        prevs[i].Max = prevs[i].Min = prevs[i].First = double.NaN;
+                    }
+                }
+
                 for (int i = 0; i < vals.Length; i++)
                 {
                     AddValue(ref prevs[i], ref tempBitsBuffer, vals[i], status, aggregated.Length > 0 ? aggregated[i] : null);


### PR DESCRIPTION
### Issue link

https://issues.hibernatingrhinos.com/issue/RavenDB-17493

### Additional description

revert to the 5.2 behavior so the initial values of `StatefulTimestampValue` are `NaN`

### Type of change

- Bug fix
- Regression bug fix

### How risky is the change?

- Low 
Same behavior as 5.2

### Backward compatibility

- Not relevant

### Is it platform specific issue?

- No

### Documentation update

- No documentation update is needed 

### Testing 

- Existing test caught this issue (`RollupWithMoreThan5ValuesShouldHalt`)

### Is there any existing behavior change of other features due to this change?

- No

### UI work

- No UI work is needed
