### PR TITLE
RavenDB-17551 Paging is ignoring offset

### DIFF
--- a/src/Raven.Server/Documents/Queries/CollectionQueryEnumerable.cs
+++ b/src/Raven.Server/Documents/Queries/CollectionQueryEnumerable.cs
@@ -290,7 +290,7 @@ namespace Raven.Server.Documents.Queries
                 _initialized = true;
 
                 if (_query.Start == 0)
-                    return 0;
+                    return _query.Offset ?? 0;
 
                 if (_query.SkipDuplicateChecking)
                     return _query.Start;

--- a/test/SlowTests/Issues/RavenDB-17551.cs
+++ b/test/SlowTests/Issues/RavenDB-17551.cs
@@ -1,0 +1,38 @@
+﻿using System;
+using System.Collections.Generic;
+using System.Linq;
+using System.Text;
+using System.Threading.Tasks;
+using FastTests;
+using Xunit;
+using Xunit.Abstractions;
+
+namespace SlowTests.Issues
+{
+    public class RavenDB_17551 : RavenTestBase
+    {
+        public RavenDB_17551(ITestOutputHelper output) : base(output)
+        {
+        }
+
+        [Fact]
+        public void CanUseOffsetWithCollectionQuery()
+        {
+            using var store = GetDocumentStore();
+            using (var s = store.OpenSession())
+            {
+                for (int i = 0; i < 5; i++)
+                {
+                    s.Store(new { i = i }, "items/");
+                }
+                s.SaveChanges();
+            }
+
+            using(var session = store.OpenSession())
+            {
+                Assert.Equal(3, session.Query<object>().Take(3).Skip(2).ToList().Count);
+                Assert.Equal(2, session.Query<object>().Take(3).Skip(3).ToList().Count);
+            }
+        }
+    }
+}


### PR DESCRIPTION
### Issue link

https://issues.hibernatingrhinos.com/issue/RavenDB-17551

### Additional description

Will now consider offset when using collection queries.

### Type of change

- Bug fix

### How risky is the change?

- Low 

### Backward compatibility

- Non breaking change

### Is it platform specific issue?

- No

### Documentation update

- No documentation update is needed 

### Testing 

- Tests have been added that prove the fix is effective or that the feature works

### UI work

- No UI work is needed
