### PR TITLE
RavenDB-17552 merge same timestamp with the same tag

### DIFF
--- a/src/Raven.Client/Documents/Session/TimeSeries/TimeSeriesEntry.cs
+++ b/src/Raven.Client/Documents/Session/TimeSeries/TimeSeriesEntry.cs
@@ -47,6 +47,11 @@ namespace Raven.Client.Documents.Session.TimeSeries
                 throw new InvalidOperationException("Entry has more than one value.");
             }
         }
+
+        public override string ToString()
+        {
+            return $"[{Timestamp}] {string.Join(", ", Values)} {Tag}";
+        }
     }
 
     public class TimeSeriesEntry<T> : TimeSeriesEntry, IPostJsonDeserialization where T : new()

--- a/src/Raven.Server/Documents/TimeSeries/TimeSeriesReader.cs
+++ b/src/Raven.Server/Documents/TimeSeries/TimeSeriesReader.cs
@@ -50,9 +50,11 @@ namespace Raven.Server.Documents.TimeSeries
         {
             dest.Status = Status;
 
+            // destination is shorter
             if (dest.Values.Length < Values.Length)
-                dest.Values = new double[Values.Length];
+                dest.Values = new double[Values.Length]; 
 
+            // destination is larger, so we need to forget values from the previous entry
             for (int i = Values.Length; i < dest.Values.Length; i++)
             {
                 dest.Values.Span[i] = 0;

--- a/src/Raven.Server/Documents/TimeSeries/TimeSeriesReader.cs
+++ b/src/Raven.Server/Documents/TimeSeries/TimeSeriesReader.cs
@@ -49,6 +49,15 @@ namespace Raven.Server.Documents.TimeSeries
         public void CopyTo(SingleResult dest)
         {
             dest.Status = Status;
+
+            if (dest.Values.Length < Values.Length)
+                dest.Values = new double[Values.Length];
+
+            for (int i = Values.Length; i < dest.Values.Length; i++)
+            {
+                dest.Values.Span[i] = 0;
+            }
+
             Values.CopyTo(dest.Values);
             dest.Tag = Tag?.CloneOnSameContext();
             dest.Type = Type;

--- a/src/Raven.Server/Documents/TimeSeries/TimeSeriesStorage.cs
+++ b/src/Raven.Server/Documents/TimeSeries/TimeSeriesStorage.cs
@@ -1450,7 +1450,11 @@ namespace Raven.Server.Documents.TimeSeries
 
                             if (FromReplication)
                                 throw new InvalidDataException(
-                                    $"Got an invalid segment from replication for '{Name}' time-series for document '{DocumentId}', segment contain duplicate timestamp and tag at '{_current.Timestamp:O}'");
+                                    $"Got an invalid segment from replication for '{Name}' time-series for document '{DocumentId}', segment contain duplicate timestamp and tag '{_current.Tag}' at '{_current.Timestamp:O}'");
+
+                            if (_next.Values.Length != _current.Values.Length)
+                                throw new InvalidDataException(
+                                    $"Entries for '{Name}' time-series for document '{DocumentId}' with tag '{_current.Tag}' at '{_current.Timestamp:O}' has different number of values ({_next.Values.Length} vs {_current.Values.Length})");
 
                             for (int i = 0; i < _next.Values.Length; i++)
                             {

--- a/test/SlowTests/Client/TimeSeries/IncrementalTimeSeriesTests.cs
+++ b/test/SlowTests/Client/TimeSeries/IncrementalTimeSeriesTests.cs
@@ -18,11 +18,11 @@ using Sparrow;
 using Xunit;
 using Xunit.Abstractions;
 
-namespace SlowTests.Client.TimeSeries.Issues
+namespace SlowTests.Client.TimeSeries
 {
-    public class RavenDB_15804 : ReplicationTestBase
+    public class IncrementalTimeSeriesTests : ReplicationTestBase
     {
-        public RavenDB_15804(ITestOutputHelper output) : base(output)
+        public IncrementalTimeSeriesTests(ITestOutputHelper output) : base(output)
         {
 
         }
@@ -245,7 +245,7 @@ namespace SlowTests.Client.TimeSeries.Issues
 
                     for (int i = 0; i < tsA.Length; i++)
                     {
-                        Assert.True(Equals(tsA[i], tsB[i]));
+                        Assert.True(Equals(tsA[i], tsB[i]), $"{tsA[i]} vs {tsB[i]}");
                     }
                 }
             }
@@ -303,24 +303,24 @@ namespace SlowTests.Client.TimeSeries.Issues
                     {
                         var incrementOperations = new List<SingleResult>();
 
-                        for (int i = 0; i < 50; i++)
+                        for (int i = 0; i < 25; i++)
                         {
                             var singleResult = new SingleResult
                             {
                                 Timestamp = baseline.EnsureUtc().EnsureMilliseconds(),
                                 Values = new double[] { 1 },
-                                Tag = context.GetLazyString("TC:INC-test-1-" + i.ToString("000"))
+                                Tag = context.GetLazyString("TC:INC-" + i.ToString("D22"))
                             };
                             incrementOperations.Add(singleResult);
                         }
 
-                        for (int i = 0; i < 90; i++)
+                        for (int i = 0; i < 45; i++)
                         {
                             var singleResult = new SingleResult
                             {
                                 Timestamp = baseline.AddMinutes(1).EnsureUtc().EnsureMilliseconds(),
                                 Values = new double[] { 1 },
-                                Tag = context.GetLazyString("TC:INC-test-1-" + i.ToString("000"))
+                                Tag = context.GetLazyString("TC:INC-" + i.ToString("D22"))
                             };
                             incrementOperations.Add(singleResult);
                         }
@@ -340,8 +340,8 @@ namespace SlowTests.Client.TimeSeries.Issues
                     var ts = session.IncrementalTimeSeriesFor("users/ayende", IncrementalTsName).Get();
 
                     Assert.Equal(2, ts.Length);
-                    Assert.Equal(50, ts[0].Value);
-                    Assert.Equal(90, ts[1].Value);
+                    Assert.Equal(25, ts[0].Value);
+                    Assert.Equal(45, ts[1].Value);
                 }
             }
         }
@@ -599,7 +599,7 @@ namespace SlowTests.Client.TimeSeries.Issues
                                 {
                                     Timestamp = baseline.EnsureUtc().EnsureMilliseconds(),
                                     Values = new double[] { i },
-                                    Tag = context.GetLazyString("TC:INC-" + i)
+                                    Tag = context.GetLazyString("TC:INC-" + i.ToString("D22"))
                                 };
                                 incrementOperations.Add(singleResult);
                             }
@@ -650,7 +650,7 @@ namespace SlowTests.Client.TimeSeries.Issues
                         {
                             Timestamp = baseline.EnsureUtc().EnsureMilliseconds(),
                             Values = new double[] { -100 },
-                            Tag = contextA.GetLazyString("TC:DEC-test")
+                            Tag = contextA.GetLazyString("TC:DEC-"+1.ToString("D22"))
                         };
                         incrementOperations.Add(singleResult);
 
@@ -675,7 +675,7 @@ namespace SlowTests.Client.TimeSeries.Issues
                         {
                             Timestamp = baseline.EnsureUtc().EnsureMilliseconds(),
                             Values = new double[] { -2 },
-                            Tag = contextB.GetLazyString("TC:DEC-test")
+                            Tag = contextB.GetLazyString("TC:DEC-"+1.ToString("D22"))
                         };
                         incrementOperations.Add(singleResult);
 
@@ -743,7 +743,7 @@ namespace SlowTests.Client.TimeSeries.Issues
                         {
                             Timestamp = baseline.EnsureUtc().EnsureMilliseconds(),
                             Values = new double[] { 100 },
-                            Tag = contextA.GetLazyString("TC:INC-test")
+                            Tag = contextA.GetLazyString("TC:INC-"+1.ToString("D22"))
                         };
                         incrementOperations.Add(singleResult);
 
@@ -768,7 +768,7 @@ namespace SlowTests.Client.TimeSeries.Issues
                         {
                             Timestamp = baseline.EnsureUtc().EnsureMilliseconds(),
                             Values = new double[] { 2 },
-                            Tag = contextB.GetLazyString("TC:INC-test")
+                            Tag = contextB.GetLazyString("TC:INC-"+1.ToString("D22"))
                         };
                         incrementOperations.Add(singleResult);
 
@@ -805,7 +805,7 @@ namespace SlowTests.Client.TimeSeries.Issues
             }
         }
 
-        [Fact]
+        [Fact(Skip = "RavenDB-17557")]
         public async Task ReplicationShouldNotCollapseWhenSegmentReachedCapacity()
         {
             var baseline = DateTime.Today;
@@ -837,8 +837,8 @@ namespace SlowTests.Client.TimeSeries.Issues
                             var singleResult = new SingleResult
                             {
                                 Timestamp = baseline.EnsureUtc().EnsureMilliseconds(),
-                                Values = new double[] { 1 },
-                                Tag = contextA.GetLazyString("TC:INC-test-1-" + i.ToString("000"))
+                                Values = new double[] { i },
+                                Tag = contextA.GetLazyString("TC:INC-" + i.ToString("D22"))
                             };
                             incrementOperations.Add(singleResult);
                         }
@@ -860,13 +860,13 @@ namespace SlowTests.Client.TimeSeries.Issues
                     {
                         var incrementOperations = new List<SingleResult>();
 
-                        for (int i = 0; i < 50; i++)
+                        for (int i = 50; i < 100; i++)
                         {
                             var singleResult = new SingleResult
                             {
                                 Timestamp = baseline.EnsureUtc().EnsureMilliseconds(),
-                                Values = new double[] { 1 },
-                                Tag = contextB.GetLazyString("TC:INC-test-2-" + i.ToString("000"))
+                                Values = new double[] { i },
+                                Tag = contextB.GetLazyString("TC:INC-" + i.ToString("D22"))
                             };
                             incrementOperations.Add(singleResult);
                         }
@@ -882,9 +882,9 @@ namespace SlowTests.Client.TimeSeries.Issues
                 }
 
                 await SetupReplicationAsync(storeA, storeB);
-                await SetupReplicationAsync(storeB, storeA);
-
                 await EnsureReplicatingAsync(storeA, storeB);
+
+                await SetupReplicationAsync(storeB, storeA);
                 await EnsureReplicatingAsync(storeB, storeA);
 
                 await EnsureNoReplicationLoop(Server, storeA.Database);
@@ -898,8 +898,7 @@ namespace SlowTests.Client.TimeSeries.Issues
 
                     Assert.Equal(tsA.Length, tsB.Length);
                     for (int i = 0; i < tsA.Length; i++)
-                        Assert.True(Equals(tsA[i], tsB[i]));
-
+                        Assert.True(Equals(tsA[i], tsB[i]),$"{tsA[i]} vs {tsB[i]}");
 
                     var dbA = await this.GetDocumentDatabaseInstanceFor(storeA);
                     var count = dbA.NotificationCenter.GetAlertCount();
@@ -949,7 +948,7 @@ namespace SlowTests.Client.TimeSeries.Issues
                             {
                                 Timestamp = baseline.EnsureUtc().EnsureMilliseconds(),
                                 Values = new double[] { 1 },
-                                Tag = context.GetLazyString("TC:INC-test-1-" + i.ToString("000"))
+                                Tag = context.GetLazyString("TC:INC-" + i.ToString("D22"))
                             };
                             incrementOperations.Add(singleResult);
                         }
@@ -998,7 +997,7 @@ namespace SlowTests.Client.TimeSeries.Issues
                         {
                             Timestamp = baseline.EnsureUtc().EnsureMilliseconds(),
                             Values = new double[] { 10 },
-                            Tag = context.GetLazyString("TC:INC-test-1-001")
+                            Tag = context.GetLazyString("TC:INC-"+1.ToString("D22"))
                         };
                         incrementOperations.Add(singleResult);
 
@@ -1008,7 +1007,7 @@ namespace SlowTests.Client.TimeSeries.Issues
                             {
                                 Timestamp = baseline.AddMinutes(1).EnsureUtc().EnsureMilliseconds(),
                                 Values = new double[] { 1 },
-                                Tag = context.GetLazyString("TC:INC-test-1-" + i.ToString("000"))
+                                Tag = context.GetLazyString("TC:INC-" + i.ToString("D22"))
                             };
                             incrementOperations.Add(singleResult);
                         }
@@ -1060,7 +1059,7 @@ namespace SlowTests.Client.TimeSeries.Issues
                             {
                                 Timestamp = baseline.EnsureUtc().EnsureMilliseconds(),
                                 Values = new double[] { 1, 1, 1 },
-                                Tag = context.GetLazyString("TC:INC-test-1-" + i.ToString("000"))
+                                Tag = context.GetLazyString("TC:INC-" + i.ToString("D22"))
                             };
                             incrementOperations.Add(singleResult);
                         }
@@ -1552,6 +1551,8 @@ namespace SlowTests.Client.TimeSeries.Issues
                 await SetupReplicationAsync(storeA, storeB);
                 await SetupReplicationAsync(storeB, storeA);
 
+                WaitForUserToContinueTheTest(storeB);
+
                 await EnsureReplicatingAsync(storeA, storeB);
                 await EnsureReplicatingAsync(storeB, storeA);
 
@@ -1640,6 +1641,65 @@ namespace SlowTests.Client.TimeSeries.Issues
             }
         }
 
+
+        [Fact]
+        public async Task IncrementalTimeSeriesQueryShouldWorkInACluster()
+        {
+            var cluster = await CreateRaftCluster(numberOfNodes: 3, watcherCluster: true);
+            using (var store = GetDocumentStore(new Options
+            {
+                Server = cluster.Leader,
+                ReplicationFactor = 3
+            }))
+            {
+                using (var session = store.OpenAsyncSession())
+                {
+                    await session.StoreAsync(new User {Name = "Oren"}, "products/77-A");
+                    await session.SaveChangesAsync();
+                }
+
+                await WaitForDocumentInClusterAsync<User>(cluster.Nodes, store.Database, "products/77-A", predicate: null, timeout: TimeSpan.FromSeconds(30));
+
+                for (int j = 0; j < 10; j++)
+                {
+                    using (var session = store.OpenAsyncSession())
+                    {
+                        for (int i = 0; i < 10; i++)
+                        {
+                            session.IncrementalTimeSeriesFor("products/77-A", $"INC:Views").Increment(1);
+                        }
+
+                        await session.SaveChangesAsync();
+                    }
+                }
+
+                WaitForUserToContinueTheTest(store);
+                var stores = GetDocumentStores(cluster.Nodes, store.Database, disableTopologyUpdates: true);
+                using (var sessionA = stores[0].OpenSession())
+                using (var sessionB = stores[1].OpenSession())
+                using (var sessionC = stores[2].OpenSession())
+                {
+                    await EnsureReplicatingAsync(stores[0], stores[1]);
+                    await EnsureReplicatingAsync(stores[1], stores[2]);
+                    await EnsureReplicatingAsync(stores[2], stores[0]);
+
+                    var tsA = sessionA.IncrementalTimeSeriesFor("products/77-A", $"INC:Views").Get();
+                    var tsB = sessionB.IncrementalTimeSeriesFor("products/77-A", $"INC:Views").Get();
+                    var tsC = sessionC.IncrementalTimeSeriesFor("products/77-A", $"INC:Views").Get();
+
+                    Assert.Equal(tsA.Length, tsB.Length);
+                    Assert.Equal(tsA.Length, tsC.Length);
+                    Assert.Equal(100, tsA.Sum(x => x.Value));
+
+                    for (int i = 0; i < tsA.Length; i++)
+                    {
+                        Assert.True(Equals(tsA[i], tsB[i]),$"{tsA[i]} vs {tsB[i]}");
+                        Assert.True(Equals(tsA[i], tsC[i]),$"{tsA[i]} vs {tsC[i]}");
+                    }
+                }
+            }
+        }
+
         [Fact]
         public async Task CanQueryDuplicateValues()
         {
@@ -1660,14 +1720,14 @@ namespace SlowTests.Client.TimeSeries.Issues
                     {
                         Timestamp = DateTime.Parse("2020-04-04T11:50:00"),
                         Values = new double[] {1},
-                        Tag = context.GetLazyString("TC:INC-test-1-" + 1.ToString("000"))
+                        Tag = context.GetLazyString("TC:INC-" + 1.ToString("D22"))
                     });
 
                     incrementOperations.Add(new SingleResult
                     {
                         Timestamp = DateTime.Parse("2020-04-04T11:50:00"),
                         Values = new double[] {3},
-                        Tag = context.GetLazyString("TC:INC-test-1-" + 2.ToString("000"))
+                        Tag = context.GetLazyString("TC:INC-" + 2.ToString("D22"))
                     });
 
 
@@ -1675,14 +1735,14 @@ namespace SlowTests.Client.TimeSeries.Issues
                     {
                         Timestamp = DateTime.Parse("2020-04-04T12:00:00"),
                         Values = new double[] {-4},
-                        Tag = context.GetLazyString("TC:INC-test-1-" + 1.ToString("000"))
+                        Tag = context.GetLazyString("TC:INC-" + 1.ToString("D22"))
                     });
 
                     incrementOperations.Add(new SingleResult
                     {
                         Timestamp = DateTime.Parse("2020-04-04T12:00:00"),
                         Values = new double[] {4},
-                        Tag = context.GetLazyString("TC:INC-test-1-" + 2.ToString("000"))
+                        Tag = context.GetLazyString("TC:INC-" + 2.ToString("D22"))
                     });
 
                     using (var tx = context.OpenWriteTransaction())
@@ -1762,14 +1822,14 @@ select timeseries(
                     {
                         Timestamp = DateTime.Parse("2020-04-04T11:50:00"),
                         Values = new double[] {1},
-                        Tag = context.GetLazyString("TC:INC-test-1-" + 1.ToString("000"))
+                        Tag = context.GetLazyString("TC:INC-" + 1.ToString("D22"))
                     });
 
                     incrementOperations.Add(new SingleResult
                     {
                         Timestamp = DateTime.Parse("2020-04-04T11:50:00"),
                         Values = new double[] {3},
-                        Tag = context.GetLazyString("TC:INC-test-1-" + 2.ToString("000"))
+                        Tag = context.GetLazyString("TC:INC-" + 2.ToString("D22"))
                     });
 
 
@@ -1777,21 +1837,21 @@ select timeseries(
                     {
                         Timestamp = DateTime.Parse("2020-04-04T12:00:00"),
                         Values = new double[] {-4},
-                        Tag = context.GetLazyString("TC:INC-test-1-" + 1.ToString("000"))
+                        Tag = context.GetLazyString("TC:INC-" + 1.ToString("D22"))
                     });
 
                     incrementOperations.Add(new SingleResult
                     {
                         Timestamp = DateTime.Parse("2020-04-04T12:00:00"),
                         Values = new double[] {4},
-                        Tag = context.GetLazyString("TC:INC-test-1-" + 2.ToString("000"))
+                        Tag = context.GetLazyString("TC:INC-" + 2.ToString("D22"))
                     });
 
                     incrementOperations.Add(new SingleResult
                     {
                         Timestamp = DateTime.Parse("2020-04-04T12:10:00"),
                         Values = new double[] {-4},
-                        Tag = context.GetLazyString("TC:DEC-test-1-" + 3.ToString("000"))
+                        Tag = context.GetLazyString("TC:DEC-" + 3.ToString("D22"))
                     });
 
                     using (var tx = context.OpenWriteTransaction())

--- a/test/Tests.Infrastructure/ClusterTestBase.cs
+++ b/test/Tests.Infrastructure/ClusterTestBase.cs
@@ -459,7 +459,7 @@ namespace Tests.Infrastructure
             return stores;
         }
 
-        private List<DocumentStore> GetDocumentStores(List<RavenServer> nodes, string database, bool disableTopologyUpdates, X509Certificate2 certificate = null)
+        public List<DocumentStore> GetDocumentStores(List<RavenServer> nodes, string database, bool disableTopologyUpdates, X509Certificate2 certificate = null)
         {
             var stores = new List<DocumentStore>();
             foreach (var node in nodes)


### PR DESCRIPTION
### Issue link

https://issues.hibernatingrhinos.com/issue/RavenDB-17552

### Additional description

Merge incoming incremental entries if they have same timestamp and tag.
It might happened if the client increment two different entries with less than a 1ms between them.

Also in this PR:
- rename to IncrementalTimeSeriesTests
- always throw when segment out of space and entries has the same timestamp (RavenDB-17557)

### Type of change

- Bug fix

### How risky is the change?

- Moderate 

### Backward compatibility

- Not relevant

### Is it platform specific issue?

- No

### Documentation update

- No documentation update is needed 

### Testing 

- Tests have been added that prove the fix is effective or that the feature works

### Is there any existing behavior change of other features due to this change?

- No

### UI work

- No UI work is needed
