### PR TITLE
RavenDB-15483 Revision configuration should create revision bin for d…

### DIFF
--- a/src/Raven.Server/Documents/DocumentsStorage.cs
+++ b/src/Raven.Server/Documents/DocumentsStorage.cs
@@ -1614,9 +1614,9 @@ namespace Raven.Server.Documents
                     ((flags & DocumentFlags.Resolved) != DocumentFlags.Resolved))
                     revisionsStorage.DeleteRevisionsFor(context, id);
 
-                if (((flags & DocumentFlags.HasRevisions) == DocumentFlags.HasRevisions) &&
-                    (revisionsStorage.Configuration != null) &&
-                    (nonPersistentFlags.Contain(NonPersistentDocumentFlags.FromReplication)))
+                if (flags.Contain(DocumentFlags.HasRevisions) &&
+                    revisionsStorage.Configuration != null &&
+                    nonPersistentFlags.Contain(NonPersistentDocumentFlags.FromReplication))
                     revisionsStorage.Delete(context, id, lowerId, collectionName, changeVector ?? local.Tombstone.ChangeVector,
                         modifiedTicks, nonPersistentFlags, documentFlags);
 

--- a/src/Raven.Server/Documents/DocumentsStorage.cs
+++ b/src/Raven.Server/Documents/DocumentsStorage.cs
@@ -1614,6 +1614,12 @@ namespace Raven.Server.Documents
                     ((flags & DocumentFlags.Resolved) != DocumentFlags.Resolved))
                     revisionsStorage.DeleteRevisionsFor(context, id);
 
+                if (((flags & DocumentFlags.HasRevisions) == DocumentFlags.HasRevisions) &&
+                    (revisionsStorage.Configuration != null) &&
+                    (nonPersistentFlags.Contain(NonPersistentDocumentFlags.FromReplication)))
+                    revisionsStorage.Delete(context, id, lowerId, collectionName, changeVector ?? local.Tombstone.ChangeVector,
+                        modifiedTicks, nonPersistentFlags, documentFlags);
+
                 table.Delete(doc.StorageId);
 
                 if ((flags & DocumentFlags.HasAttachments) == DocumentFlags.HasAttachments)

--- a/src/Raven.Server/Documents/Revisions/RevisionsStorage.cs
+++ b/src/Raven.Server/Documents/Revisions/RevisionsStorage.cs
@@ -823,7 +823,7 @@ namespace Raven.Server.Documents.Revisions
 
             Debug.Assert(changeVector != null, "Change vector must be set");
 
-            flags.Strip(DocumentFlags.HasAttachments);
+            flags = flags.Strip(DocumentFlags.HasAttachments);
             flags |= DocumentFlags.HasRevisions;
 
             var fromReplication = nonPersistentFlags.Contain(NonPersistentDocumentFlags.FromReplication);

--- a/test/SlowTests/Issues/RavenDB-15483.cs
+++ b/test/SlowTests/Issues/RavenDB-15483.cs
@@ -1,0 +1,297 @@
+﻿using System;
+using System.Linq;
+using System.Threading.Tasks;
+using FastTests.Server.Replication;
+using FastTests.Utils;
+using Raven.Client.Documents.Operations.Replication;
+using Raven.Server.ServerWide.Context;
+using Raven.Tests.Core.Utils.Entities;
+using Xunit;
+using Xunit.Abstractions;
+
+namespace SlowTests.Issues
+{
+    public class RavenDB_15483 : ReplicationTestBase
+    {
+        public RavenDB_15483(ITestOutputHelper output) : base(output)
+        {
+        }
+
+        [Fact]
+        public async Task ExternalReplicationWithRevisionsBin1()
+        {
+            using (var store1 = GetDocumentStore())
+
+            using (var store2 = GetDocumentStore())
+            {
+                await RevisionsHelper.SetupRevisions(Server.ServerStore, store2.Database, modifyConfiguration: configuration => configuration.Collections["Users"].PurgeOnDelete = false);
+
+                var externalTask = new ExternalReplication(store2.Database, "ExternalReplication");
+                await AddWatcherToReplicationTopology(store1, externalTask);
+
+                using (var s1 = store1.OpenSession())
+                {
+                    s1.Store(new User(){Name = "Toli"}, "foo/bar");
+                    s1.SaveChanges();
+                }
+
+                Assert.True(WaitForDocument(store2, "foo/bar"));
+                for (int i = 0; i < 4; i++)
+                {
+                    var name = "Toli" + i;
+                    using (var s1 = store1.OpenSession())
+                    {
+                        s1.Store(new User() { Name = name }, "foo/bar");
+                        s1.SaveChanges();
+                    }
+
+                    await WaitForValueAsync(async () =>
+                    {
+                        using (var s2 = store2.OpenAsyncSession())
+                        {
+                            var user = await s2.LoadAsync<User>("foo/bar");
+                            return name.Equals(user.Name, StringComparison.InvariantCultureIgnoreCase);
+                        }
+                    }, true);
+                }
+
+                using (var s1 = store1.OpenSession())
+                {
+                    s1.Delete("foo/bar");
+                    s1.SaveChanges();
+                }
+                await WaitForValueAsync(async () =>
+                {
+                    using (var s2 = store2.OpenAsyncSession())
+                    {
+                        var user = await s2.LoadAsync<User>("foo/bar");
+                        return user == null;
+                    }
+
+                }, true);
+                var database  =await Server.ServerStore.DatabasesLandlord.TryGetOrCreateResourceStore(store2.Database);
+                var revisionsStorage = database.DocumentsStorage.RevisionsStorage;
+                using (database.DocumentsStorage.ContextPool.AllocateOperationContext(out DocumentsOperationContext context))
+                using (context.OpenReadTransaction())
+                {
+                    var revisions = revisionsStorage.GetRevisionsBinEntries(context, long.MaxValue, 6).Count();
+                    Assert.Equal(1, revisions);
+                }
+
+                database = await Server.ServerStore.DatabasesLandlord.TryGetOrCreateResourceStore(store1.Database);
+                revisionsStorage = database.DocumentsStorage.RevisionsStorage;
+                using (database.DocumentsStorage.ContextPool.AllocateOperationContext(out DocumentsOperationContext context))
+                using (context.OpenReadTransaction())
+                {
+                    var revisions = revisionsStorage.GetRevisionsBinEntries(context, long.MaxValue, 6).Count();
+                    Assert.Equal(0, revisions);
+                }
+            }
+        }
+
+        [Fact]
+        public async Task ExternalReplicationWithRevisionsBin2()
+        {
+            using (var store1 = GetDocumentStore())
+
+            using (var store2 = GetDocumentStore())
+            {
+                await RevisionsHelper.SetupRevisions(Server.ServerStore, store1.Database, modifyConfiguration: configuration => configuration.Collections["Users"].PurgeOnDelete = false);
+
+                var externalTask = new ExternalReplication(store2.Database, "ExternalReplication");
+                await AddWatcherToReplicationTopology(store1, externalTask);
+
+                using (var s1 = store1.OpenSession())
+                {
+                    s1.Store(new User() { Name = "Toli" }, "foo/bar");
+                    s1.SaveChanges();
+                }
+
+                Assert.True(WaitForDocument(store2, "foo/bar"));
+                for (int i = 0; i < 4; i++)
+                {
+                    var name = "Toli" + i;
+                    using (var s1 = store1.OpenSession())
+                    {
+                        s1.Store(new User() { Name = name }, "foo/bar");
+                        s1.SaveChanges();
+                    }
+                }
+
+                using (var s1 = store1.OpenSession())
+                {
+                    s1.Delete("foo/bar");
+                    s1.SaveChanges();
+                }
+
+                await WaitForValueAsync(async () =>
+                {
+                    using (var s2 = store2.OpenAsyncSession())
+                    {
+                        var user = await s2.LoadAsync<User>("foo/bar");
+                        return user == null;
+                    }
+                }, true);
+                var database = await Server.ServerStore.DatabasesLandlord.TryGetOrCreateResourceStore(store1.Database);
+                var revisionsStorage = database.DocumentsStorage.RevisionsStorage;
+                using (database.DocumentsStorage.ContextPool.AllocateOperationContext(out DocumentsOperationContext context))
+                using (context.OpenReadTransaction())
+                {
+                    var revisions = revisionsStorage.GetRevisionsBinEntries(context, long.MaxValue, 2).Count();
+                    Assert.Equal(1, revisions);
+                }
+
+                database = await Server.ServerStore.DatabasesLandlord.TryGetOrCreateResourceStore(store2.Database);
+                revisionsStorage = database.DocumentsStorage.RevisionsStorage;
+                using (database.DocumentsStorage.ContextPool.AllocateOperationContext(out DocumentsOperationContext context))
+                using (context.OpenReadTransaction())
+                {
+                    var revisions = revisionsStorage.GetRevisionsBinEntries(context, long.MaxValue, 2).Count();
+                    Assert.Equal(1, revisions);
+                }
+            }
+        }
+
+        [Fact]
+        public async Task ExternalReplicationWithRevisionsBin3()
+        {
+            using (var store1 = GetDocumentStore())
+
+            using (var store2 = GetDocumentStore())
+            {
+                await RevisionsHelper.SetupRevisions(Server.ServerStore, store1.Database, modifyConfiguration: configuration => configuration.Collections["Users"].PurgeOnDelete = false);
+                await RevisionsHelper.SetupRevisions(Server.ServerStore, store2.Database, modifyConfiguration: configuration => configuration.Collections["Users"].PurgeOnDelete = false);
+
+                var externalTask = new ExternalReplication(store2.Database, "ExternalReplication");
+                await AddWatcherToReplicationTopology(store1, externalTask);
+
+                using (var s1 = store1.OpenSession())
+                {
+                    s1.Store(new User() { Name = "Toli" }, "foo/bar");
+                    s1.SaveChanges();
+                }
+
+                Assert.True(WaitForDocument(store2, "foo/bar"));
+                for (int i = 0; i < 4; i++)
+                {
+                    var name = "Toli" + i;
+                    using (var s1 = store1.OpenSession())
+                    {
+                        s1.Store(new User() { Name = name }, "foo/bar");
+                        s1.SaveChanges();
+                    }
+
+                    await WaitForValueAsync(async () =>
+                    {
+                        using (var s2 = store2.OpenAsyncSession())
+                        {
+                            var user = await s2.LoadAsync<User>("foo/bar");
+                            return name.Equals(user.Name, StringComparison.InvariantCultureIgnoreCase);
+                        }
+                    }, true);
+                }
+                using (var s1 = store1.OpenSession())
+                {
+                    s1.Delete("foo/bar");
+                    s1.SaveChanges();
+                }
+                await WaitForValueAsync(async () =>
+                {
+                    using (var s2 = store2.OpenAsyncSession())
+                    {
+                        var user = await s2.LoadAsync<User>("foo/bar");
+                        return user == null;
+                    }
+                }, true);
+                var database = await Server.ServerStore.DatabasesLandlord.TryGetOrCreateResourceStore(store2.Database);
+                var revisionsStorage = database.DocumentsStorage.RevisionsStorage;
+                using (database.DocumentsStorage.ContextPool.AllocateOperationContext(out DocumentsOperationContext context))
+                using (context.OpenReadTransaction())
+                {
+                    var revisions = revisionsStorage.GetRevisionsBinEntries(context, long.MaxValue, 6).Count();
+                    Assert.Equal(1, revisions);
+                }
+
+                database = await Server.ServerStore.DatabasesLandlord.TryGetOrCreateResourceStore(store1.Database);
+                revisionsStorage = database.DocumentsStorage.RevisionsStorage;
+                using (database.DocumentsStorage.ContextPool.AllocateOperationContext(out DocumentsOperationContext context))
+                using (context.OpenReadTransaction())
+                {
+                    var revisions = revisionsStorage.GetRevisionsBinEntries(context, long.MaxValue, 6).Count();
+                    Assert.Equal(1, revisions);
+                }
+            }
+        }
+
+        [Fact]
+        public async Task ExternalReplicationWithRevisionsBin4()
+        {
+            using (var store1 = GetDocumentStore())
+
+            using (var store2 = GetDocumentStore())
+            {
+                await RevisionsHelper.SetupRevisions(Server.ServerStore, store2.Database, modifyConfiguration: configuration => configuration.Collections["Users"].PurgeOnDelete = true);
+
+                var externalTask = new ExternalReplication(store2.Database, "ExternalReplication");
+                await AddWatcherToReplicationTopology(store1, externalTask);
+
+                using (var s1 = store1.OpenSession())
+                {
+                    s1.Store(new User() { Name = "Toli" }, "foo/bar");
+                    s1.SaveChanges();
+                }
+
+                Assert.True(WaitForDocument(store2, "foo/bar"));
+                for (int i = 0; i < 4; i++)
+                {
+                    var name = "Toli" + i;
+                    using (var s1 = store1.OpenSession())
+                    {
+                        s1.Store(new User() { Name = name }, "foo/bar");
+                        s1.SaveChanges();
+                    }
+
+                    await WaitForValueAsync(async () =>
+                    {
+                        using (var s2 = store2.OpenAsyncSession())
+                        {
+                            var user = await s2.LoadAsync<User>("foo/bar");
+                            return name.Equals(user.Name, StringComparison.InvariantCultureIgnoreCase);
+                        }
+                    }, true);
+                }
+
+                using (var s1 = store1.OpenSession())
+                {
+                    s1.Delete("foo/bar");
+                    s1.SaveChanges();
+                }
+                await WaitForValueAsync(async () =>
+                {
+                    using (var s2 = store2.OpenAsyncSession())
+                    {
+                        var user = await s2.LoadAsync<User>("foo/bar");
+                        return user == null;
+                    }
+                }, true);
+                var database = await Server.ServerStore.DatabasesLandlord.TryGetOrCreateResourceStore(store2.Database);
+                var revisionsStorage = database.DocumentsStorage.RevisionsStorage;
+                using (database.DocumentsStorage.ContextPool.AllocateOperationContext(out DocumentsOperationContext context))
+                using (context.OpenReadTransaction())
+                {
+                    var revisions = revisionsStorage.GetRevisionsBinEntries(context, long.MaxValue, 6).Count();
+                    Assert.Equal(0, revisions);
+                }
+
+                database = await Server.ServerStore.DatabasesLandlord.TryGetOrCreateResourceStore(store1.Database);
+                revisionsStorage = database.DocumentsStorage.RevisionsStorage;
+                using (database.DocumentsStorage.ContextPool.AllocateOperationContext(out DocumentsOperationContext context))
+                using (context.OpenReadTransaction())
+                {
+                    var revisions = revisionsStorage.GetRevisionsBinEntries(context, long.MaxValue, 6).Count();
+                    Assert.Equal(0, revisions);
+                }
+            }
+        }
+    }
+}


### PR DESCRIPTION
…ocuments deleted by replication

### Issue link

https://issues.hibernatingrhinos.com/issue/RavenDB-15483

### Additional description
When we have external replication and revision configuration only at the destination, we need to create revision bin for deleted documents

### Type of change

- Bug fix

### How risky is the change?

- Low 

### Backward compatibility
- Non breaking change

### Is it platform specific issue?

- No

### Documentation update

- No documentation update is needed 

### Testing 

- Tests have been added that prove the fix is effective or that the feature works

### Is there any existing behavior change of other features due to this change?

- No

### UI work

- No UI work is needed
