### PR TITLE
RavenDB-14303 Cluster observer should ignore idle indexes on the prom…

### DIFF
--- a/src/Raven.Server/Documents/Indexes/IndexStore.cs
+++ b/src/Raven.Server/Documents/Indexes/IndexStore.cs
@@ -773,7 +773,7 @@ namespace Raven.Server.Documents.Indexes
 
             _indexes.Add(index);
 
-            if (_serverStore.ForTestingPurposes?.stopIndex == true)
+            if (_serverStore.ForTestingPurposes?.StopIndex == true)
                 return;
 
             if (_documentDatabase.Configuration.Indexing.Disabled == false && _run)

--- a/src/Raven.Server/Documents/Indexes/IndexStore.cs
+++ b/src/Raven.Server/Documents/Indexes/IndexStore.cs
@@ -773,6 +773,9 @@ namespace Raven.Server.Documents.Indexes
 
             _indexes.Add(index);
 
+            if (_serverStore.ForTestingPurposes?.stopIndex == true)
+                return;
+
             if (_documentDatabase.Configuration.Indexing.Disabled == false && _run)
                 index.Start();
 

--- a/src/Raven.Server/ServerWide/Maintenance/ClusterObserver.cs
+++ b/src/Raven.Server/ServerWide/Maintenance/ClusterObserver.cs
@@ -1,7 +1,6 @@
 ﻿using System;
 using System.Collections.Concurrent;
 using System.Collections.Generic;
-using System.Diagnostics;
 using System.Linq;
 using System.Text;
 using System.Threading;
@@ -15,7 +14,6 @@ using Raven.Client.ServerWide;
 using Raven.Client.Util;
 using Raven.Server.Config;
 using Raven.Server.Config.Settings;
-using Raven.Server.Documents.Indexes;
 using Raven.Server.Json;
 using Raven.Server.NotificationCenter.Notifications;
 using Raven.Server.Rachis;
@@ -1499,6 +1497,9 @@ namespace Raven.Server.ServerWide.Maintenance
                 // the promotable don't have them. 
 
                 if (mentorIndex.Value.IsSideBySide)
+                    continue;
+
+                if (mentorIndex.Value.State == IndexState.Idle)
                     continue;
 
                 if (mentor.TryGetValue(Constants.Documents.Indexing.SideBySideIndexNamePrefix + mentorIndex.Key, out var mentorIndexStats) == false)

--- a/src/Raven.Server/ServerWide/ServerStore.cs
+++ b/src/Raven.Server/ServerWide/ServerStore.cs
@@ -3137,7 +3137,7 @@ namespace Raven.Server.ServerWide
         internal class TestingStuff
         {
             internal Action BeforePutLicenseCommandHandledInOnValueChanged;
-            internal bool stopIndex;
+            internal bool StopIndex;
         }
     }
 }

--- a/src/Raven.Server/ServerWide/ServerStore.cs
+++ b/src/Raven.Server/ServerWide/ServerStore.cs
@@ -3137,6 +3137,7 @@ namespace Raven.Server.ServerWide
         internal class TestingStuff
         {
             internal Action BeforePutLicenseCommandHandledInOnValueChanged;
+            internal bool stopIndex;
         }
     }
 }

--- a/test/SlowTests/RavenDB-14303.cs
+++ b/test/SlowTests/RavenDB-14303.cs
@@ -26,17 +26,18 @@ namespace SlowTests
             var (_, leader) = await CreateRaftCluster(clusterSize);
             var replicationFactor = 2;
             var databaseName = GetDatabaseName();
-            using (var store = new DocumentStore()
+            using (var store = GetDocumentStore(new Options
             {
-                Urls = new[] { leader.WebUrl },
-                Database = databaseName
-            }.Initialize())
+                Server = leader,
+                ReplicationFactor = 2,
+
+            }))
             {
                 var doc = new DatabaseRecord(databaseName);
                 var createRes = await store.Maintenance.Server.SendAsync(new CreateDatabaseOperation(doc, replicationFactor));
 
                 var dbServer = Servers.First(s => createRes.NodesAddedTo.Contains(s.WebUrl));
-                await dbServer.ServerStore.Cluster.WaitForIndexNotification(createRes.RaftCommandIndex);
+
                 Random rnd = new Random();
                 for (int i = 0; i < 100; i++)
                 {

--- a/test/SlowTests/RavenDB-14303.cs
+++ b/test/SlowTests/RavenDB-14303.cs
@@ -1,0 +1,97 @@
+﻿using System;
+using System.Linq;
+using System.Threading.Tasks;
+using Raven.Client.Documents;
+using Raven.Client.Documents.Indexes;
+using Raven.Client.ServerWide;
+using Raven.Client.ServerWide.Operations;
+using Raven.Server.Documents.Indexes;
+using Raven.Server.Documents.Indexes.MapReduce.Auto;
+using Raven.Server.ServerWide;
+using Raven.Server.ServerWide.Commands.Indexes;
+using Raven.Tests.Core.Utils.Entities;
+using Tests.Infrastructure;
+using Xunit;
+using Xunit.Abstractions;
+
+namespace SlowTests
+{
+    public class RavenDB_14303 : ClusterTestBase
+    {
+
+        [Fact]
+        public async Task IgnoreIdleIndexOnPromotable()
+        {
+            var clusterSize = 3;
+            var (_, leader) = await CreateRaftCluster(clusterSize);
+            var replicationFactor = 2;
+            var databaseName = GetDatabaseName();
+            using (var store = new DocumentStore()
+            {
+                Urls = new[] { leader.WebUrl },
+                Database = databaseName
+            }.Initialize())
+            {
+                var doc = new DatabaseRecord(databaseName);
+                var createRes = await store.Maintenance.Server.SendAsync(new CreateDatabaseOperation(doc, replicationFactor));
+
+                var dbServer = Servers.First(s => createRes.NodesAddedTo.Contains(s.WebUrl));
+                await dbServer.ServerStore.Cluster.WaitForIndexNotification(createRes.RaftCommandIndex);
+                Random rnd = new Random();
+                for (int i = 0; i < 100; i++)
+                {
+                    using (var session = store.OpenAsyncSession())
+                    {
+                        await session.StoreAsync(new User { Name = "Toli" , Count = i, Age = rnd.Next(1,100)}, "users/" + i);
+                        await session.SaveChangesAsync();
+                    }
+                }
+
+                var count = new AutoIndexField
+                {
+                    Name = "Count",
+                };
+
+                var age = new AutoIndexField
+                {
+                    Name = "Age",
+                };
+
+                var sum = new AutoIndexField
+                {
+                    Name = "Sum",
+                };
+
+                var db = await dbServer.ServerStore.DatabasesLandlord.TryGetOrCreateResourceStore(databaseName);
+                var index = await db.IndexStore.CreateIndex(new AutoMapReduceIndexDefinition("Users", new[] { count, sum }, new[] { age }), Guid.NewGuid().ToString());
+
+                await leader.ServerStore.Engine.PutAsync(new SetIndexStateCommand(index.Name, IndexState.Idle, db.Name, Guid.NewGuid().ToString()));
+                dbServer = Servers.First(s => !createRes.NodesAddedTo.Contains(s.WebUrl));
+                dbServer.ServerStore.ForTestingPurposes = new ServerStore.TestingStuff {stopIndex = true};
+
+                await store.Maintenance.Server.SendAsync(new AddDatabaseNodeOperation(databaseName));
+                WaitForUserToContinueTheTest(store);
+                var res = await WaitForValueAsync(async () =>
+                {
+                    var membersCount = await GetMembersCount(store, db.Name);
+                    return membersCount == 3;
+                }, true, 5000);
+                Assert.True(res);
+            }
+        }
+        private static async Task<int> GetMembersCount(IDocumentStore store, string databaseName)
+        {
+            var res = await store.Maintenance.Server.SendAsync(new GetDatabaseRecordOperation(databaseName));
+            if (res == null)
+            {
+                return -1;
+            }
+            return res.Topology.Members.Count;
+        }
+
+
+        public RavenDB_14303(ITestOutputHelper output) : base(output)
+        {
+        }
+    }
+}


### PR DESCRIPTION
…otable

### Issue link

https://issues.hibernatingrhinos.com/issue/RavenDB-14303

### Additional description
Ignoring idle indexes on promotable node

### Type of change

- Bug fix

### How risky is the change?

- Low 

### Backward compatibility

- Non breaking change

### Is it platform specific issue?

- No

### Documentation update

- No documentation update is needed 

### Testing 

- Tests have been added that prove the fix is effective or that the feature works

### Is there any existing behavior change of other features due to this change?

- No

### UI work

- No UI work is needed
