### PR TITLE
RavenDB-17478 PowerBI: "Field count mismatch when mapping column types" on some RQL queries

### DIFF
--- a/src/Raven.Server/Integrations/PostgreSQL/PgQuery.cs
+++ b/src/Raven.Server/Integrations/PostgreSQL/PgQuery.cs
@@ -57,7 +57,7 @@ namespace Raven.Server.Integrations.PostgreSQL
                 throw new PgErrorException(
                     PgErrorCodes.StatementTooComplex,
                     "Unhandled query (Are you using ; in your query? " +
-                    $"That is likely causing Power BI to split the query and results in partial queries): {Environment.NewLine}" +
+                    $"That is likely causing the postgres client to split the query and results in partial queries): {Environment.NewLine}" +
                     $"{queryText}");
             }
             catch (Exception e)

--- a/test/SlowTests/Server/Integrations/PostgreSQL/RavenDB_17478.cs
+++ b/test/SlowTests/Server/Integrations/PostgreSQL/RavenDB_17478.cs
@@ -1,0 +1,47 @@
+﻿using System;
+using System.Linq;
+using System.Threading.Tasks;
+using Npgsql;
+using Xunit;
+using Xunit.Abstractions;
+
+namespace SlowTests.Server.Integrations.PostgreSQL
+{
+    public class RavenDB_17478 : PostgreSqlIntegrationTestBase
+    {
+        public RavenDB_17478(ITestOutputHelper output) : base(output)
+        {
+        }
+
+        [Fact]
+        public async Task ShouldThrowException_WithFirstPartOfQuery_SplittedBySemicolons_WhenGivenQueryContainsSemicolons()
+        {
+            const string query =
+                @"declare function name(e) {
+                    if (!e)
+                        return null;
+                    return e.FirstName + "" "" + e.LastName;
+                }
+                from Employees as e
+                where id() in ('employees/2-A', 'employees/1-A'  )
+                load e.ReportsTo as boss
+                select { Name: name(e), Manager: name(boss) }";
+
+            var firstQueryPart = query.Split(";").First();
+
+            var expectedErrorMessage =
+                "54001: Unhandled query (Are you using ; in your query? " +
+                $"That is likely causing the postgres client to split the query and results in partial queries): {Environment.NewLine}" +
+                $"{firstQueryPart}";
+
+            DoNotReuseServer(EnablePostgresSqlSettings);
+
+            using (var store = GetDocumentStore())
+            {
+                var pgException = await Assert.ThrowsAsync<PostgresException>(async () => await Act(store, query, Server));
+
+                Assert.Equal(expectedErrorMessage, pgException.Message);
+            }
+        }
+    }
+}


### PR DESCRIPTION
### Issue link

https://issues.hibernatingrhinos.com/issue/RavenDB-17478

### Additional description

I added a unit test to see if the client received the correct error message. I also adjusted the error message.

### Type of change

- Error message improvement

### How risky is the change?

- Not relevant

### Backward compatibility

- Not relevant

### Is it platform specific issue?

- No

### Documentation update

- No documentation update is needed 

### Testing 

- It has been verified by manual testing

### Is there any existing behavior change of other features due to this change?

- No

### UI work

- No UI work is needed
