### PR TITLE
RavenDB-17545 Caching index metadata.

### DIFF
--- a/src/Raven.Client/Documents/Session/AsyncDocumentSession.Query.cs
+++ b/src/Raven.Client/Documents/Session/AsyncDocumentSession.Query.cs
@@ -9,8 +9,9 @@ namespace Raven.Client.Documents.Session
     {
         public IRavenQueryable<T> Query<T, TIndexCreator>() where TIndexCreator : AbstractCommonApiForIndexes, new()
         {
-            var indexCreator = new TIndexCreator();
-            return Query<T>(indexCreator.IndexName, null, indexCreator.IsMapReduce);
+            var index = IndexMetadataCache.GetIndexMetadataCacheItem<TIndexCreator>();
+            
+            return Query<T>(index.IndexName, null, index.IsMapReduce);
         }
 
         public IRavenQueryable<T> Query<T>(string indexName = null, string collectionName = null, bool isMapReduce = false)
@@ -52,8 +53,8 @@ namespace Raven.Client.Documents.Session
         /// <returns></returns>
         public IAsyncDocumentQuery<T> AsyncDocumentQuery<T, TIndexCreator>() where TIndexCreator : AbstractCommonApiForIndexes, new()
         {
-            var index = new TIndexCreator();
-
+            var index = IndexMetadataCache.GetIndexMetadataCacheItem<TIndexCreator>();
+            
             return AsyncDocumentQuery<T>(index.IndexName, null, index.IsMapReduce);
         }
 

--- a/src/Raven.Client/Documents/Session/DocumentSession.Query.cs
+++ b/src/Raven.Client/Documents/Session/DocumentSession.Query.cs
@@ -5,6 +5,7 @@
 //-----------------------------------------------------------------------
 
 using System;
+using System.Collections.Concurrent;
 using Raven.Client.Documents.Indexes;
 using Raven.Client.Documents.Linq;
 using Raven.Client.Documents.Queries.Highlighting;
@@ -16,6 +17,8 @@ namespace Raven.Client.Documents.Session
     /// </summary>
     public partial class DocumentSession
     {
+        
+        
         /// <summary>
         /// Queries the index specified by <typeparamref name="TIndexCreator"/> using lucene syntax.
         /// </summary>
@@ -24,7 +27,8 @@ namespace Raven.Client.Documents.Session
         /// <returns></returns>
         public IDocumentQuery<T> DocumentQuery<T, TIndexCreator>() where TIndexCreator : AbstractCommonApiForIndexes, new()
         {
-            var index = new TIndexCreator();
+            var index = IndexMetadataCache.GetIndexMetadataCacheItem<TIndexCreator>();
+            
             return DocumentQuery<T>(index.IndexName, null, index.IsMapReduce);
         }
 
@@ -102,8 +106,9 @@ namespace Raven.Client.Documents.Session
         /// <returns></returns>
         public IRavenQueryable<T> Query<T, TIndexCreator>() where TIndexCreator : AbstractCommonApiForIndexes, new()
         {
-            var indexCreator = new TIndexCreator();
-            return Query<T>(indexCreator.IndexName, null, indexCreator.IsMapReduce);
+            var index = IndexMetadataCache.GetIndexMetadataCacheItem<TIndexCreator>();
+            
+            return Query<T>(index.IndexName, null, index.IsMapReduce);
         }
 
         /// <summary>

--- a/src/Raven.Client/Documents/Session/IndexMetadataCache.cs
+++ b/src/Raven.Client/Documents/Session/IndexMetadataCache.cs
@@ -1,0 +1,35 @@
+﻿using System;
+using System.Collections.Concurrent;
+using Raven.Client.Documents.Indexes;
+
+namespace Raven.Client.Documents.Session
+{
+    internal static class IndexMetadataCache 
+    {
+        private static readonly ConcurrentDictionary<Type, IndexMetadataCacheItem> IndexMetadataCacheContainer = new();
+
+        internal static IndexMetadataCacheItem GetIndexMetadataCacheItem<TIndexCreator>() where TIndexCreator : AbstractCommonApiForIndexes, new()
+        {
+            if (IndexMetadataCacheContainer.TryGetValue(typeof(TIndexCreator), out var index) == false)
+            {
+                index = new IndexMetadataCacheItem(new TIndexCreator());
+                IndexMetadataCacheContainer.TryAdd(typeof(TIndexCreator), index);
+            }
+
+            return index;
+        }
+        
+        internal class IndexMetadataCacheItem
+        {
+            public readonly string IndexName;
+
+            public readonly bool IsMapReduce;
+            
+            public IndexMetadataCacheItem(AbstractCommonApiForIndexes indexCreator)
+            {
+                IndexName = indexCreator.IndexName;
+                IsMapReduce = indexCreator.IsMapReduce;
+            }
+        }
+    }
+}


### PR DESCRIPTION
### Issue link

https://issues.hibernatingrhinos.com/issue/RavenDB-17545

### Additional description

Caching index metadata to avoid the creation of index definition every time only to get two fields.

### Type of change


- Optimization

### How risky is the change?

- Moderate 


### Backward compatibility

- Not relevant

### Is it platform specific issue?


- No

### Documentation update

- No documentation update is needed 

### Testing 

- already existing tests in solution.


### Is there any existing behavior change of other features due to this change?

- No

### UI work

- No UI work is needed
