### PR TITLE
RavenDB-14753 - Counters are not being deleted from storage when we are changing casing but they are deleted from document metadata

### DIFF
--- a/src/Sparrow/Json/BlittableJsonReaderObject.cs
+++ b/src/Sparrow/Json/BlittableJsonReaderObject.cs
@@ -736,24 +736,24 @@ namespace Sparrow.Json
             throw new ArgumentOutOfRangeException("index", indexValue, "Unexpected index argument value: " + indexValue);
         }
 
-        public int GetPropertyIndex(string name)
+        public int GetPropertyIndex(string name, bool ignoreCase = false)
         {
             AssertContextNotDisposed();
 
-            return GetPropertyIndex(new StringSegment(name));
+            return GetPropertyIndex(new StringSegment(name), ignoreCase);
         }
 
         [MethodImpl(MethodImplOptions.AggressiveInlining)]
-        public int GetPropertyIndex(StringSegment name)
+        public int GetPropertyIndex(StringSegment name, bool ignoreCase = false)
         {
             AssertContextNotDisposed();
 
             var comparer = _context.GetLazyStringForFieldWithCaching(name);
-            return GetPropertyIndex(comparer);
+            return GetPropertyIndex(comparer, ignoreCase);
         }
 
         [MethodImpl(MethodImplOptions.AggressiveInlining)]
-        public int GetPropertyIndex(LazyStringValue comparer)
+        public int GetPropertyIndex(LazyStringValue comparer, bool ignoreCase = false)
         {
             AssertContextNotDisposed();
 
@@ -777,7 +777,7 @@ namespace Sparrow.Json
 
                 var propertyId = ReadNumber(propertyIntPtr + currentOffsetSize, currentPropertyIdSize);
 
-                var cmpResult = ComparePropertyName(propertyId, comparer);
+                var cmpResult = ComparePropertyName(propertyId, comparer, ignoreCase);
                 if (cmpResult == 0)
                 {
                     return mid;
@@ -807,7 +807,7 @@ namespace Sparrow.Json
         /// <param name="ignoreCase">Indicates if the comparassion should be case insensitive</param>
         /// <returns></returns>
         [MethodImpl(MethodImplOptions.AggressiveInlining)]
-        private int ComparePropertyName(int propertyId, LazyStringValue comparer)
+        private int ComparePropertyName(int propertyId, LazyStringValue comparer, bool ignoreCase = false)
         {
             AssertContextNotDisposed();
 
@@ -823,6 +823,9 @@ namespace Sparrow.Json
             var size = ReadVariableSizeInt((int)position, out byte propertyNameLengthDataLength);
 
             // Return result of comparison between property name and received comparer
+            if (ignoreCase)
+                return LazyStringValue.CompareToOrdinalIgnoreCase(propertyNameRelativePosition + propertyNameLengthDataLength, size, comparer.Buffer, comparer.Size);
+
             return comparer.Compare(propertyNameRelativePosition + propertyNameLengthDataLength, size);
         }
 

--- a/src/Sparrow/Json/LazyStringValue.cs
+++ b/src/Sparrow/Json/LazyStringValue.cs
@@ -84,6 +84,58 @@ namespace Sparrow.Json
             }
         }
 
+        public bool EqualsOrdinalIgnoreCase(LazyStringValue other)
+        {
+            return CompareToOrdinalIgnoreCase(this.Buffer, Size, other.Buffer, other.Size) == 0;
+        }
+
+
+        public static int CompareToOrdinalIgnoreCase(byte* strA, int strALen, byte* strB, int strBLen)
+        {
+            int length = Math.Min(strALen, strBLen);
+            {
+                byte* a = strA;
+                byte* b = strB;
+
+                while (length != 0 && (*a <= 0x7F) && (*b <= 0x7F))
+                {
+                    int charA = *a;
+                    int charB = *b;
+
+                    if (charA == charB)
+                    {
+                        a++;
+                        b++;
+                        length--;
+                        continue;
+                    }
+
+                    // uppercase both chars - notice that we need just one compare per char
+                    if ((uint)(charA - 'a') <= 'z' - 'a')
+                        charA -= 0x20;
+                    if ((uint)(charB - 'a') <= 'z' - 'a')
+                        charB -= 0x20;
+
+                    // Return the (case-insensitive) difference between them.
+                    if (charA != charB)
+                        return charA - charB;
+
+                    // Next char
+                    a++;
+                    b++;
+                    length--;
+                }
+
+                if (length == 0)
+                    return strALen - strBLen;
+
+                return string.Compare(
+                    Encoding.UTF8.GetString(strA, strALen),
+                    Encoding.UTF8.GetString(strB, strBLen),
+                    StringComparison.OrdinalIgnoreCase);
+            }
+        }
+
         public Span<byte> AsSpan()
         {
             return new Span<byte>(_buffer, _size);

--- a/test/SlowTests/Issues/RavenDB_14753.cs
+++ b/test/SlowTests/Issues/RavenDB_14753.cs
@@ -1,0 +1,66 @@
+﻿using System.Linq;
+using System.Threading.Tasks;
+using FastTests;
+using Raven.Server.ServerWide.Context;
+using Raven.Tests.Core.Utils.Entities;
+using Xunit;
+using Xunit.Abstractions;
+
+namespace SlowTests.Issues
+{
+    public class RavenDB_14753 : RavenTestBase
+    {
+        public RavenDB_14753(ITestOutputHelper output) : base(output)
+        {
+        }
+
+        [Fact]
+        public async Task CountersShouldBeCaseInsensitive()
+        {
+            using (var store = GetDocumentStore())
+            {
+                using (var session = store.OpenSession())
+                {
+                    var company = new Company
+                    {
+                        Name = "HR"
+                    };
+
+                    session.Store(company, "companies/1");
+                    session.CountersFor(company).Increment("Likes", 999);
+
+                    session.SaveChanges();
+                }
+
+                using (var session = store.OpenSession())
+                {
+                    var company = session.Load<Company>("companies/1");
+                    session.CountersFor(company).Delete("lIkEs");
+
+                    session.SaveChanges();
+                }
+
+                using (var session = store.OpenSession())
+                {
+                    var company = session.Load<Company>("companies/1");
+                    var counters = session.CountersFor(company).GetAll();
+
+                    Assert.Equal(0, counters.Count);
+                }
+
+                var database = await GetDocumentDatabaseInstanceFor(store);
+                var countersStorage = database.DocumentsStorage.CountersStorage;
+
+                using (database.DocumentsStorage.ContextPool.AllocateOperationContext(out DocumentsOperationContext context))
+                using (context.OpenReadTransaction())
+                {
+                    var values = countersStorage
+                        .GetCounterValues(context, "companies/1", "Likes")
+                        .ToList();
+
+                    Assert.Equal(0, values.Count);
+                }
+            }
+        }
+    }
+}


### PR DESCRIPTION

### Issue link

https://issues.hibernatingrhinos.com/issue/RavenDB-14753


### Type of change

- Bug fix

### How risky is the change?

- Low 

### Backward compatibility

- Non breaking change


### Is it platform specific issue?

- No

### Documentation update

- No documentation update is needed 

### Testing 

- Tests have been added that prove the fix is effective or that the feature works

### Is there any existing behavior change of other features due to this change?

- No

### UI work

- No UI work is needed
