### PR TITLE
RavenDB-17552 get incremental TS should populate the tag

### DIFF
--- a/src/Raven.Server/Documents/Handlers/TimeSeriesHandler.cs
+++ b/src/Raven.Server/Documents/Handlers/TimeSeriesHandler.cs
@@ -434,6 +434,7 @@ namespace Raven.Server.Documents.Handlers
                     {
                         Timestamp = singleResult.Timestamp,
                         Values = singleResult.Values.ToArray(),
+                        Tag = singleResult.Tag,
                         IsRollup = singleResult.Type == SingleResultType.RolledUp,
                         NodeValues = returnFullResults ? new Dictionary<string, double[]>(reader.GetDetails.Details) : null
                     };

--- a/test/SlowTests/Client/TimeSeries/IncrementalTimeSeriesTests.cs
+++ b/test/SlowTests/Client/TimeSeries/IncrementalTimeSeriesTests.cs
@@ -379,6 +379,32 @@ namespace SlowTests.Client.TimeSeries
         }
 
         [Fact]
+        public void GetTagForIncremental()
+        {
+            using (var store = GetDocumentStore())
+            {
+                var baseline = DateTime.Today;
+
+                using (var session = store.OpenSession())
+                {
+                    session.Store(new User { Name = "Oren" }, "users/ayende");
+                    var ts = session.IncrementalTimeSeriesFor("users/ayende", IncrementalTsName);
+                    ts.Increment(baseline, 4);
+                    session.SaveChanges();
+                }
+
+                using (var session = store.OpenSession())
+                {
+                    var ts = session.IncrementalTimeSeriesFor("users/ayende", IncrementalTsName).Get(baseline);
+
+                    Assert.Equal(1, ts.Length);
+                    Assert.Equal(4, ts[0].Value);
+                    Assert.StartsWith("TC:INC", ts[0].Tag);
+                }
+            }
+        }
+
+        [Fact]
         public void ShouldIncrementValueOnEditIncrementalEntry2()
         {
             using (var store = GetDocumentStore())


### PR DESCRIPTION
### Issue link

https://issues.hibernatingrhinos.com/issue/RavenDB-RavenDB-17552

### Additional description

Have identical behavior as for streaming

### Type of change

- Bug fix

### How risky is the change?

- Low 
### Backward compatibility

- Not relevant

### Is it platform specific issue?

- No

### Documentation update

Not sure if update of the docs required

### Testing 

- Tests have been added that prove the fix is effective or that the feature works

### Is there any existing behavior change of other features due to this change?

- No

### UI work

Not sure, since now we return an extra field
