### PR TITLE
RavenDB-17311

### DIFF
--- a/src/Raven.Server/ServerWide/Commands/RemoveNodeFromDatabaseCommand.cs
+++ b/src/Raven.Server/ServerWide/Commands/RemoveNodeFromDatabaseCommand.cs
@@ -23,6 +23,8 @@ namespace Raven.Server.ServerWide.Commands
         {
             DeletionInProgressStatus deletionStatus = DeletionInProgressStatus.No;
             record.DeletionInProgress?.TryGetValue(NodeTag, out deletionStatus);
+            if (deletionStatus == DeletionInProgressStatus.No)
+                return null;
 
             record.Topology.RemoveFromTopology(NodeTag);
             record.DeletionInProgress?.Remove(NodeTag);

--- a/test/SlowTests/Issues/RavenDB-17096.cs
+++ b/test/SlowTests/Issues/RavenDB-17096.cs
@@ -1,11 +1,17 @@
 ﻿using System;
 using System.Collections.Generic;
+using System.Diagnostics;
 using System.Linq;
+using System.Threading;
 using System.Threading.Tasks;
 using FastTests.Server.Replication;
+using Raven.Client.Documents;
 using Raven.Client.Documents.Operations.ConnectionStrings;
 using Raven.Client.Documents.Operations.ETL;
+using Raven.Client.Documents.Operations.OngoingTasks;
 using Raven.Client.ServerWide.Operations;
+using Raven.Server.Documents;
+using Raven.Server.Documents.ETL;
 using Raven.Tests.Core.Utils.Entities;
 using Xunit;
 using Xunit.Abstractions;
@@ -18,11 +24,12 @@ namespace SlowTests.Issues
         {
         }
 
+
         [Fact]
         public async Task EtlFromReAddedNodeShouldWork()
         {
+            const string mentorTag = "A";
             var (nodes, leader) = await CreateRaftCluster(3, watcherCluster: true);
-
             using (var src = GetDocumentStore(new Options
             {
                 Server = leader,
@@ -41,7 +48,7 @@ namespace SlowTests.Issues
                     Name = connectionStringName,
                     ConnectionStringName = connectionStringName,
                     LoadRequestTimeoutInSec = 10,
-                    MentorNode = "A",
+                    MentorNode = mentorTag,
                     Transforms = new List<Transformation>
                     {
                         new Transformation
@@ -62,7 +69,7 @@ namespace SlowTests.Issues
                 var result = await src.Maintenance.SendAsync(new PutConnectionStringOperation<RavenConnectionString>(connectionString));
                 Assert.NotNull(result.RaftCommandIndex);
 
-                await src.Maintenance.SendAsync(new AddEtlOperation<RavenConnectionString>(config));
+                var addEtl = await src.Maintenance.SendAsync(new AddEtlOperation<RavenConnectionString>(config));
                 using (var session = src.OpenSession())
                 {
                     session.Advanced.WaitForReplicationAfterSaveChanges(replicas: 2);
@@ -90,14 +97,25 @@ namespace SlowTests.Issues
                     {
                         Name = "John Dire"
                     }, "users/1");
+
                     session.SaveChanges();
                 }
 
                 Assert.True(WaitForDocument<User>(dest, "users/1", u => u.Name == "John Dire", 30_000));
 
-                var deletion = await src.Maintenance.Server.SendAsync(new DeleteDatabasesOperation(src.Database, hardDelete: true, fromNode: "A",
+                var deletion = await src.Maintenance.Server.SendAsync(new DeleteDatabasesOperation(src.Database, hardDelete: true, fromNode: mentorTag,
                     timeToWaitForConfirmation: TimeSpan.FromSeconds(30)));
-                await WaitForRaftIndexToBeAppliedInCluster(deletion.RaftCommandIndex, TimeSpan.FromSeconds(30));
+
+                await WaitForRaftIndexToBeAppliedInCluster(deletion.RaftCommandIndex + 1, TimeSpan.FromSeconds(30));
+                await RavenDB_7912.WaitForDatabaseToBeDeleted(leader, src.Database, TimeSpan.FromSeconds(15), CancellationToken.None);
+                await WaitAndAssertForValueAsync(() => GetMembersCount(src), 2);
+
+                var newResponsibleTag = WaitForNewResponsibleNode(src, addEtl.TaskId, mentorTag);
+                Assert.NotNull(newResponsibleTag);
+
+                var newResponsible = nodes.Single(s => s.ServerStore.NodeTag == newResponsibleTag);
+                var db = await newResponsible.ServerStore.DatabasesLandlord.TryGetOrCreateResourceStore(src.Database).ConfigureAwait(false);
+                var etlDone = WaitForEtl(db, (s, statistics) => statistics.LoadSuccesses > 0);
 
                 using (var session = src.OpenSession())
                 {
@@ -111,10 +129,10 @@ namespace SlowTests.Issues
                 }
 
                 Assert.True(WaitForDocument<User>(dest, "users/2", u => u.Name == "John Doe", 30_000));
+                Assert.True(etlDone.Wait(TimeSpan.FromSeconds(10)));
 
-                var addResult = await src.Maintenance.Server.SendAsync(new AddDatabaseNodeOperation(src.Database, node: "A"));
+                var addResult = await src.Maintenance.Server.SendAsync(new AddDatabaseNodeOperation(src.Database, node: mentorTag));
                 await WaitForRaftIndexToBeAppliedInCluster(addResult.RaftCommandIndex, TimeSpan.FromSeconds(30));
-
                 await WaitAndAssertForValueAsync(() => GetMembersCount(src), 3);
 
                 using (var session = src.OpenSession())
@@ -130,6 +148,35 @@ namespace SlowTests.Issues
 
                 Assert.True(WaitForDocument<User>(dest, "marker", u => u.Name == "John Doe", 30_000));
             }
+        }
+
+        private static string WaitForNewResponsibleNode(IDocumentStore store, long taskId, string oldTag, int timeout = 10_000)
+        {
+            var sw = Stopwatch.StartNew();
+            while (true)
+            {
+                if (sw.ElapsedMilliseconds > timeout)
+                    return null;
+
+                var taskInfo = store.Maintenance.Send(new GetOngoingTaskInfoOperation(taskId, OngoingTaskType.RavenEtl));
+                if (taskInfo.ResponsibleNode.NodeTag != oldTag)
+                    return taskInfo.ResponsibleNode.NodeTag;
+
+                Thread.Sleep(100);
+            }
+        }
+
+        private static ManualResetEventSlim WaitForEtl(DocumentDatabase database, Func<string, EtlProcessStatistics, bool> predicate)
+        {
+            var mre = new ManualResetEventSlim();
+
+            database.EtlLoader.BatchCompleted += x =>
+            {
+                if (predicate($"{x.ConfigurationName}/{x.TransformationName}", x.Statistics))
+                    mre.Set();
+            };
+
+            return mre;
         }
     }
 }

--- a/test/SlowTests/Issues/RavenDB-17311.cs
+++ b/test/SlowTests/Issues/RavenDB-17311.cs
@@ -1,0 +1,108 @@
+﻿using System;
+using System.Collections.Generic;
+using System.Linq;
+using System.Threading.Tasks;
+using FastTests.Server.Replication;
+using Raven.Client.Documents;
+using Raven.Client.Documents.Operations.ConnectionStrings;
+using Raven.Client.Documents.Operations.ETL;
+using Raven.Client.ServerWide.Operations;
+using Raven.Tests.Core.Utils.Entities;
+using Xunit;
+using Xunit.Abstractions;
+
+namespace SlowTests.Issues
+{
+    public class RavenDB_17311 : ReplicationTestBase
+    {
+        public RavenDB_17311(ITestOutputHelper output) : base(output)
+        {
+        }
+
+        [Fact]
+        public async Task CanRemoveAndReAddNodeToDbWhileUpdatingEtlProcessState()
+        {
+            const string mentor = "A";
+            var (nodes, leader) = await CreateRaftCluster(3, watcherCluster: true);
+
+            using (var src = GetDocumentStore(new Options
+            {
+                Server = leader,
+                ReplicationFactor = 3
+            }))
+            using (var dest = GetDocumentStore(new Options
+            {
+                Server = leader,
+                ReplicationFactor = 3
+            }))
+            {
+                var urls = nodes.Select(n => n.WebUrl).ToArray();
+                await AddEtl(src, dest.Database, urls, mentor);
+
+                using (var session = src.OpenSession())
+                {
+                    session.Advanced.WaitForReplicationAfterSaveChanges(replicas: 2);
+                    session.Store(new User()
+                    {
+                        Name = "Joe Doe"
+                    }, "users/1");
+                    session.SaveChanges();
+                }
+
+                var deletion = await src.Maintenance.Server.SendAsync(new DeleteDatabasesOperation(src.Database, hardDelete: true, fromNode: mentor,
+                    timeToWaitForConfirmation: TimeSpan.FromSeconds(30)));
+                await WaitForRaftIndexToBeAppliedInCluster(deletion.RaftCommandIndex, TimeSpan.FromSeconds(30));
+
+                using (var session = src.OpenSession())
+                {
+                    session.Advanced.WaitForReplicationAfterSaveChanges(replicas: 1);
+
+                    session.Store(new User()
+                    {
+                        Name = "John Doe"
+                    }, "users/2");
+                    session.SaveChanges();
+                }
+
+                Assert.True(WaitForDocument<User>(dest, "users/2", u => u.Name == "John Doe", 30_000));
+
+                var addResult = await src.Maintenance.Server.SendAsync(new AddDatabaseNodeOperation(src.Database, node: mentor));
+                await WaitForRaftIndexToBeAppliedInCluster(addResult.RaftCommandIndex, TimeSpan.FromSeconds(30));
+
+                await WaitAndAssertForValueAsync(() => GetMembersCount(src), 3);
+            }
+        }
+
+        internal static async Task<AddEtlOperationResult> AddEtl(IDocumentStore source, string destination, string[] urls, string mentor)
+        {
+            var connectionStringName = $"RavenEtl_From{source.Database}_To{destination}";
+            var config = new RavenEtlConfiguration()
+            {
+                Name = connectionStringName,
+                ConnectionStringName = connectionStringName,
+                LoadRequestTimeoutInSec = 10,
+                MentorNode = mentor,
+                Transforms = new List<Transformation>
+                {
+                    new Transformation
+                    {
+                        Name = $"ETL : {connectionStringName}",
+                        ApplyToAllDocuments = true,
+                        IsEmptyScript = true
+                    }
+                }
+            };
+            var connectionString = new RavenConnectionString
+            {
+                Name = connectionStringName,
+                Database = destination,
+                TopologyDiscoveryUrls = urls,
+            };
+
+            var result = await source.Maintenance.SendAsync(new PutConnectionStringOperation<RavenConnectionString>(connectionString));
+            Assert.NotNull(result.RaftCommandIndex);
+
+            return await source.Maintenance.SendAsync(new AddEtlOperation<RavenConnectionString>(config));
+        }
+    }
+}

--- a/test/SlowTests/Issues/RavenDB_7912.cs
+++ b/test/SlowTests/Issues/RavenDB_7912.cs
@@ -62,7 +62,7 @@ namespace SlowTests.Issues
             }
         }
 
-        private static async Task<bool> WaitForDatabaseToBeDeleted(RavenServer server, string databaseName, TimeSpan timeout, CancellationToken token)
+        internal static async Task<bool> WaitForDatabaseToBeDeleted(RavenServer server, string databaseName, TimeSpan timeout, CancellationToken token)
         {
             using (var store = new DocumentStore
             {


### PR DESCRIPTION
### Issue link

https://issues.hibernatingrhinos.com/issue/RavenDB-17311

### Additional description

- Fixed flaky test `EtlFromReAddedNodeShouldWork`
- The reason the test was failing is because in some runs we had a race between removing node from database + updating Etl process state  + re-adding the node to database that resulted in an invalid topology with replication factor of 3 but only 2 nodes in it
- The node that we removed from the database was removed from topology *twice* by `RemoveNodeFromDatabaseCommand` - once when reaching `HandleClusterDatabaseChanged()` on `DeleteDatabaseCommand` and another time on `UpdateEtlProcessStateCommand` :
https://github.com/ravendb/ravendb/blob/v4.2/src/Raven.Server/Documents/DatabasesLandlord.cs#L111 
- In these failures, re-adding the node (even after waiting on `WaitForRaftIndexToBeAppliedInCluster` with the delete command index before re adding) happened in between the first and second `RemoveNodeFromDatabaseCommand`, which resulted in an invalid topology and the node not being re-added
- fixed this issue simply by returning when `deletionStatus == DeletionInProgressStatus.No` in `RemoveNodeFromDatabaseCommand`, and added a test 

### Type of change

- Bug fix

### How risky is the change?

- Moderate 


### Testing 

- Tests have been added that prove the fix is effective or that the feature works