### PR TITLE
RavenDB-17564 Making sure that errors on index open or index definition update are written to the log configured on the operations level

### DIFF
--- a/src/Raven.Server/Documents/Indexes/IndexStore.cs
+++ b/src/Raven.Server/Documents/Indexes/IndexStore.cs
@@ -367,11 +367,13 @@ namespace Raven.Server.Documents.Indexes
                     _documentDatabase.RachisLogIndexNotifications.NotifyListenersAbout(index, exception);
 
                     var indexName = name;
-                    if (Logger.IsInfoEnabled)
-                        Logger.Info($"Could not update static index {name}", exception);
+                    
 
                     if (exception is OperationCanceledException)
                         return;
+
+                    if (Logger.IsOperationsEnabled)
+                        Logger.Operations($"Could not update static index {name}", exception);
 
                     //If we don't have the index in memory this means that it is corrupted when trying to load it
                     //If we do have the index and it is not faulted this means that this is the replacement index that is faulty
@@ -1437,8 +1439,8 @@ namespace Raven.Server.Documents.Indexes
 
                 var message = $"Could not open index at '{indexPath}'. Created in-memory, fake instance: {fakeIndex.Name}";
 
-                if (Logger.IsInfoEnabled)
-                    Logger.Info(message, e);
+                if (Logger.IsOperationsEnabled)
+                    Logger.Operations(message, e);
 
                 _documentDatabase.NotificationCenter.Add(AlertRaised.Create(
                     _documentDatabase.Name,


### PR DESCRIPTION
### Issue link

https://issues.hibernatingrhinos.com/issue/RavenDB-17564

### Additional description

Fixing the logging level so we'll be able to see the actual exceptions in the logs once it's configured at Operations level (default)

### Type of change

- Bug fix

### How risky is the change?

- Low 

### Backward compatibility

- Not relevant

### Is it platform specific issue?

- No

### Documentation update

- No documentation update is needed 

### Testing 

- Not relevant

### Is there any existing behavior change of other features due to this change?

- No

### UI work

- No UI work is needed
