### PR TITLE
RavenDB-17303 - Fixing paging of alphanumeric queries' null handling

### DIFF
--- a/src/Raven.Server/Documents/Queries/IndexQueryServerSide.cs
+++ b/src/Raven.Server/Documents/Queries/IndexQueryServerSide.cs
@@ -156,7 +156,7 @@ namespace Raven.Server.Documents.Queries
                     var start = (int)QueryBuilder.GetLongValue(result.Metadata.Query, result.Metadata, result.QueryParameters, result.Metadata.Query.Offset, 0);
                     result.Offset = start;
                     result.Start = result.Start != 0 || json.TryGet(nameof(Start), out int _)
-                        ? Math.Min(start, result.Start)
+                        ? Math.Max(start, result.Start)
                         : start;
                 }
 

--- a/src/Raven.Server/Documents/Queries/Sorting/AlphaNumeric/AlphaNumericFieldComparator.cs
+++ b/src/Raven.Server/Documents/Queries/Sorting/AlphaNumeric/AlphaNumericFieldComparator.cs
@@ -68,9 +68,9 @@ namespace Raven.Server.Documents.Queries.Sorting.AlphaNumeric
         public override int CompareBottom(int doc, IState state)
         {
             var str2 = _lookup[_order[doc]];
-            if (_bottom.IsNull)
-                return str2.IsNull ? 0 : -1;
-            if (str2.IsNull)
+            if (IsNull(_bottom))
+                return IsNull(str2) ? 0 : -1;
+            if (IsNull(str2))
                 return 1;
 
             return AlphanumComparer.Instance.Compare(_bottom, str2);

--- a/src/Raven.Server/Documents/Queries/Sorting/AlphaNumeric/AlphaNumericFieldComparator.cs
+++ b/src/Raven.Server/Documents/Queries/Sorting/AlphaNumeric/AlphaNumericFieldComparator.cs
@@ -1,5 +1,6 @@
 ﻿using System;
 using System.Collections.Generic;
+using System.Diagnostics;
 using System.Runtime.InteropServices;
 using System.Text;
 using Lucene.Net.Index;
@@ -281,16 +282,9 @@ namespace Raven.Server.Documents.Queries.Sorting.AlphaNumeric
 
             public int Compare(UnmanagedStringArray.UnmanagedString string1, UnmanagedStringArray.UnmanagedString string2)
             {
-                if (string1.IsNull)
-                {
-                    return 0;
-                }
-
-                if (string2.IsNull)
-                {
-                    return 0;
-                }
-
+                Debug.Assert(string1.IsNull == false);
+                Debug.Assert(string2.IsNull == false);
+                
                 var string1State = new AlphanumericStringComparisonState(string1);
                 var string2State = new AlphanumericStringComparisonState(string2);
 

--- a/test/SlowTests/Issues/RavenDB-17303.cs
+++ b/test/SlowTests/Issues/RavenDB-17303.cs
@@ -1,4 +1,6 @@
-﻿using System.Linq;
+﻿using System;
+using System.Linq;
+using System.Threading.Tasks;
 using FastTests;
 using Raven.Client.Documents;
 using Raven.Client.Documents.Indexes;
@@ -57,7 +59,94 @@ namespace SlowTests.Issues
                 WaitForUserToContinueTheTest(store);
                 Assert.Equal(new[]{null, "1BC", "02BC", "Me", "Pla"}, names);
             }
+        }
+        
+        [Fact]
+        public async Task PagingWithAlphaNumericSorting()
+        {
+            using (var store = GetDocumentStore())
+            {
+                int nullNameCount = 4;
+                using (var session = store.OpenAsyncSession())
+                {
+                    new GreatIndex().Execute(store);
+                    var document1 = new TestDocument { Document = new TestDocument2() { Name = "EGOR" }, SomeRandomDate = new DateTime(2021, 6, 14) };
+                    for (int i = 0; i < nullNameCount; i++)
+                    {
+                        await session.StoreAsync(document1);
+                        var document2 = new TestDocument { Document = new TestDocument2() { Name = null } };
+                        await session.StoreAsync(document2);
+                    }
 
+                    for (int i = 0; i < 2; i++)
+                    {
+
+                        var document3 = new TestDocument { Document = new TestDocument2() { Name = $"{i}_EGOR" } };
+                        await session.StoreAsync(document3);
+                    }
+                    await session.SaveChangesAsync();
+
+                }
+
+                WaitForIndexing(store);
+
+                WaitForUserToContinueTheTest(store);
+                using (var s = store.OpenAsyncSession())
+                {
+                    var pageSize = 2;
+                    var total = 0;
+                    while (total != nullNameCount - pageSize)
+                    {
+                        var res = await s.Advanced.AsyncRawQuery<TestResult>($@"from index 'GreatIndex' as u
+where u.RandomDate < ""2021-11-31""
+order by u.DocsName as alphanumeric
+select u.DocsName limit {total}, {pageSize}").ToListAsync();
+
+                        foreach (var p in res)
+                        {
+                            Assert.Null(p.DocsName);
+                        }
+
+                        total += pageSize;
+                    }
+
+                    Assert.Equal(nullNameCount - pageSize, total);
+                }
+            }
+        }
+        private class GreatIndex : AbstractIndexCreationTask<TestDocument>
+        {
+            public override string IndexName => "GreatIndex";
+
+            public GreatIndex()
+            {
+                Map = users => from user in users
+                    select new
+                    {
+                        RandomDate = user.SomeRandomDate,
+                        DocsName = user.Document.Name
+                    };
+                StoreAllFields(FieldStorage.Yes);
+            }
+        }
+
+        private class TestDocument
+        {
+            public string Id { get; set; }
+            public TestDocument2 Document{ get; set; }
+            public DateTime SomeRandomDate { get; set; }
+        }
+
+        private class TestDocument2
+        {
+            public string Id { get; set; }
+            public string Name { get; set; }
+        }
+
+        private class TestResult
+        {
+            public string Id { get; set; }
+            public string DocsName { get; set; }
         }
     }
 }


### PR DESCRIPTION
### Issue link

https://issues.hibernatingrhinos.com/issue/RavenDB-17303

### Additional description

Missed handling of nulls in alphanumeric sorting when running with limited queries. 


### Type of change

- Bug fix

### How risky is the change?

- Low 

### Backward compatibility

- Non breaking change

### Is it platform specific issue?

- No

### Documentation update

- No documentation update is needed 

### Testing 

- Tests have been added that prove the fix is effective or that the feature works

### UI work

- No UI work is needed
