### PR TITLE
RavenDB-17217 fix test and remove has revision flag from tombstone de…

### DIFF
--- a/src/Raven.Server/Documents/DocumentsStorage.cs
+++ b/src/Raven.Server/Documents/DocumentsStorage.cs
@@ -1498,11 +1498,18 @@ namespace Raven.Server.Documents
                 else
                 {
                     flags = localFlags | documentFlags;
+                    var revisionsStorage = DocumentDatabase.DocumentsStorage.RevisionsStorage;
 
+                    if (nonPersistentFlags.Contain(NonPersistentDocumentFlags.FromReplication) &&
+                        revisionsStorage.Configuration == null &&
+                        localFlags.Contain(DocumentFlags.HasRevisions) &&
+                        documentFlags.Contain(DocumentFlags.HasRevisions) == false)
+                    {
+                        flags = flags.Strip(DocumentFlags.HasRevisions);
+                    }
                     if (collectionName.IsHiLo == false &&
                         (flags & DocumentFlags.Artificial) != DocumentFlags.Artificial)
                     {
-                        var revisionsStorage = DocumentDatabase.DocumentsStorage.RevisionsStorage;
                         if (nonPersistentFlags.Contain(NonPersistentDocumentFlags.FromReplication) == false &&
                             (revisionsStorage.Configuration != null || flags.Contain(DocumentFlags.Resolved)))
                         {

--- a/src/Raven.Server/Documents/DocumentsStorage.cs
+++ b/src/Raven.Server/Documents/DocumentsStorage.cs
@@ -1501,11 +1501,11 @@ namespace Raven.Server.Documents
                     var revisionsStorage = DocumentDatabase.DocumentsStorage.RevisionsStorage;
 
                     if (nonPersistentFlags.Contain(NonPersistentDocumentFlags.FromReplication) &&
-                        revisionsStorage.Configuration == null &&
-                        localFlags.Contain(DocumentFlags.HasRevisions) &&
-                        documentFlags.Contain(DocumentFlags.HasRevisions) == false)
+                        localFlags.Contain(DocumentFlags.HasRevisions) != documentFlags.Contain(DocumentFlags.HasRevisions))
                     {
-                        flags = flags.Strip(DocumentFlags.HasRevisions);
+                        var (_, count) = revisionsStorage.GetRevisions(context, id, 0, 1);
+                        if (count == 0)
+                            flags = flags.Strip(DocumentFlags.HasRevisions);
                     }
                     if (collectionName.IsHiLo == false &&
                         (flags & DocumentFlags.Artificial) != DocumentFlags.Artificial)

--- a/src/Raven.Server/Documents/DocumentsStorage.cs
+++ b/src/Raven.Server/Documents/DocumentsStorage.cs
@@ -1503,7 +1503,7 @@ namespace Raven.Server.Documents
                     if (nonPersistentFlags.Contain(NonPersistentDocumentFlags.FromReplication) &&
                         localFlags.Contain(DocumentFlags.HasRevisions) != documentFlags.Contain(DocumentFlags.HasRevisions))
                     {
-                        var (_, count) = revisionsStorage.GetRevisions(context, id, 0, 1);
+                        var count = revisionsStorage.GetRevisionsCount(context, id);
                         if (count == 0)
                             flags = flags.Strip(DocumentFlags.HasRevisions);
                     }


### PR DESCRIPTION
…stination

### Issue link

https://issues.hibernatingrhinos.com/issue/RavenDB-17217

### Additional description

Added wait for the removal of has revision flag after enforcing revision configuration.
remove has revision flag at destination (external replication) after enforcing revision configuration at the source.

_Please delete below the options that are not relevant_

### Type of change

- Bug fix

### How risky is the change?

- Low 

### Backward compatibility

- Not relevant

### Is it platform specific issue?

- No

### Documentation update

- No documentation update is needed 

### Testing 

- Tests have been added that prove the fix is effective or that the feature works

### Is there any existing behavior change of other features due to this change?

- No

### UI work

- No UI work is needed
