### PR TITLE
RavenDB-17574 - fix exception during query

### DIFF
--- a/test/SlowTests/Issues/RavenDB-17574.cs
+++ b/test/SlowTests/Issues/RavenDB-17574.cs
@@ -1,0 +1,38 @@
+﻿using System.Linq;
+using FastTests;
+using FastTests.Client;
+using Raven.Client.Documents;
+using Xunit;
+using Xunit.Abstractions;
+
+namespace SlowTests.Issues
+{
+    public class RavenDB_17574 : RavenTestBase
+    {
+        public RavenDB_17574(ITestOutputHelper output) : base(output)
+        {
+        }
+
+        [Fact]
+        public void document_query_with_projection_and_orderby_score_afterwards()
+        {
+            using (var store = GetDocumentStore())
+            {
+                using (var session = store.OpenSession())
+                {
+                    var query =
+                        session.Advanced.DocumentQuery<Query.Order>()
+                            .ToQueryable()
+                            .Select(x => new
+                            {
+                                x.Freight,
+                                x.Company
+                            })
+                            .OrderByScoreDescending();
+
+                    Assert.Equal("from 'Orders' order by score() desc select Freight, Company", query.ToString());
+                }
+            }
+        }
+    }
+}


### PR DESCRIPTION
### Issue link

https://issues.hibernatingrhinos.com/issue/RavenDB-17574

### Additional description

Fix query builder when using a projection before `OrderBy` (of any type)

_Please delete below the options that are not relevant_

### Type of change

- Bug fix

### How risky is the change?

- Low 

### Testing 

- Tests have been added that prove the fix is effective or that the feature works