### PR TITLE
RavenDB-16966 avoid invalid context usage

### DIFF
--- a/src/Raven.Server/Documents/Handlers/Admin/RachisAdminHandler.cs
+++ b/src/Raven.Server/Documents/Handlers/Admin/RachisAdminHandler.cs
@@ -60,8 +60,6 @@ namespace Raven.Server.Documents.Handlers.Admin
                     command.VerifyCanExecuteCommand(ServerStore, context, isClusterAdmin);
 
                     var (etag, result) = await ServerStore.Engine.PutAsync(command);
-                    await ServerStore.Cluster.WaitForIndexNotification(etag);
-
                     HttpContext.Response.StatusCode = (int)HttpStatusCode.OK;
                     var ms = context.CheckoutMemoryStream();
                     try

--- a/src/Raven.Server/Documents/Handlers/Admin/RachisAdminHandler.cs
+++ b/src/Raven.Server/Documents/Handlers/Admin/RachisAdminHandler.cs
@@ -60,6 +60,8 @@ namespace Raven.Server.Documents.Handlers.Admin
                     command.VerifyCanExecuteCommand(ServerStore, context, isClusterAdmin);
 
                     var (etag, result) = await ServerStore.Engine.PutAsync(command);
+                    await ServerStore.Cluster.WaitForIndexNotification(etag);
+
                     HttpContext.Response.StatusCode = (int)HttpStatusCode.OK;
                     var ms = context.CheckoutMemoryStream();
                     try

--- a/src/Raven.Server/Rachis/Leader.cs
+++ b/src/Raven.Server/Rachis/Leader.cs
@@ -789,12 +789,28 @@ namespace Raven.Server.Rachis
 
         internal static ConvertResultAction GetConvertResult(CommandBase cmd)
         {
+            ConvertResultAction action;
             switch (cmd)
             {
                 case AddOrUpdateCompareExchangeBatchCommand batchCmpExchangeCommand:
-                    return new ConvertResultAction(batchCmpExchangeCommand.ContextToWriteResult, CompareExchangeCommandBase.ConvertResult);
+                    action = batchCmpExchangeCommand.ConvertResultAction;
+                    if (action != null)
+                        return action;
+
+                    action = new ConvertResultAction(batchCmpExchangeCommand.ContextToWriteResult, CompareExchangeCommandBase.ConvertResult);
+                    Interlocked.CompareExchange(ref batchCmpExchangeCommand.ConvertResultAction, action, null);
+                    return batchCmpExchangeCommand.ConvertResultAction;
+
                 case CompareExchangeCommandBase cmpExchange:
-                    return new ConvertResultAction(cmpExchange.ContextToWriteResult, CompareExchangeCommandBase.ConvertResult);
+
+                    action = cmpExchange.ConvertResultAction;
+                    if (action != null)
+                        return action;
+
+                    action = new ConvertResultAction(cmpExchange.ContextToWriteResult, CompareExchangeCommandBase.ConvertResult);
+                    Interlocked.CompareExchange(ref cmpExchange.ConvertResultAction, action, null);
+                    return cmpExchange.ConvertResultAction;
+
                 default:
                     return null;
             }

--- a/src/Raven.Server/Rachis/RachisConsensus.cs
+++ b/src/Raven.Server/Rachis/RachisConsensus.cs
@@ -937,7 +937,7 @@ namespace Raven.Server.Rachis
                 throw new NotLeadingException("Not a leader, cannot accept commands. " + _lastStateChangeReason);
 
             Validator.AssertPutCommandToLeader(cmd);
-            return leader.PutAsync(cmd, OperationTimeout);
+            return leader.PutAsync(cmd, cmd.Timeout ?? OperationTimeout);
         }
 
         public void SwitchToCandidateStateOnTimeout()

--- a/src/Raven.Server/ServerWide/Commands/AddOrUpdateCompareExchangeBatchCommand.cs
+++ b/src/Raven.Server/ServerWide/Commands/AddOrUpdateCompareExchangeBatchCommand.cs
@@ -1,4 +1,5 @@
 ﻿using System.Collections.Generic;
+using Raven.Server.Rachis;
 using Sparrow.Json;
 using Sparrow.Json.Parsing;
 
@@ -10,6 +11,9 @@ namespace Raven.Server.ServerWide.Commands
         public List<RemoveCompareExchangeCommand> RemoveCommands;
         [JsonDeserializationIgnore]
         public JsonOperationContext ContextToWriteResult;
+
+        [JsonDeserializationIgnore]
+        public Leader.ConvertResultAction ConvertResultAction;
 
         public AddOrUpdateCompareExchangeBatchCommand()
         {

--- a/src/Raven.Server/ServerWide/Commands/CommandBase.cs
+++ b/src/Raven.Server/ServerWide/Commands/CommandBase.cs
@@ -11,12 +11,19 @@ namespace Raven.Server.ServerWide.Commands
     {
         public virtual DynamicJsonValue ToJson(JsonOperationContext context)
         {
-            return new DynamicJsonValue
+            var json = new DynamicJsonValue
             {
                 ["Type"] = GetType().Name,
-                [nameof(UniqueRequestId)] = UniqueRequestId
+                [nameof(UniqueRequestId)] = UniqueRequestId,
             };
+
+            if (Timeout.HasValue)
+                json[nameof(Timeout)] = Timeout;
+
+            return json;
         }
+
+        public TimeSpan? Timeout;
 
         public long? RaftCommandIndex;
 

--- a/src/Raven.Server/ServerWide/Commands/CompareExchangeCommands.cs
+++ b/src/Raven.Server/ServerWide/Commands/CompareExchangeCommands.cs
@@ -27,6 +27,9 @@ namespace Raven.Server.ServerWide.Commands
         [JsonDeserializationIgnore]
         public JsonOperationContext ContextToWriteResult;
 
+        [JsonDeserializationIgnore]
+        public Leader.ConvertResultAction ConvertResultAction;
+
         public static string GetActualKey(string database, string key)
         {
             return (database + "/" + key).ToLowerInvariant();
@@ -160,7 +163,7 @@ namespace Raven.Server.ServerWide.Commands
 
         public override object FromRemote(object remoteResult)
         {
-            return JsonDeserializationCluster.CompareExchangeResult((BlittableJsonReaderObject)remoteResult);
+            return JsonDeserializationCluster.CompareExchangeResult(((BlittableJsonReaderObject)remoteResult).Clone(ContextToWriteResult));
         }
 
         public class CompareExchangeResult : IDynamicJsonValueConvertible

--- a/src/Raven.Server/ServerWide/ServerStore.cs
+++ b/src/Raven.Server/ServerWide/ServerStore.cs
@@ -2467,13 +2467,10 @@ namespace Raven.Server.ServerWide
             var response = await SendToLeaderAsyncInternal(cmd);
 
 #if DEBUG
-
-            if (Leader.GetConvertResult(cmd) == null && // if cmd specifies a convert, it explicitly handles this
-                response.Result.ContainsBlittableObject())
+            if (response.Result.ContainsBlittableObject())
             {
                 throw new InvalidOperationException($"{nameof(ServerStore)}::{nameof(SendToLeaderAsync)}({response.Result}) should not return command results with blittable json objects. This is not supposed to happen and should be reported.");
             }
-
 #endif
 
             return response;
@@ -2481,9 +2478,9 @@ namespace Raven.Server.ServerWide
 
         //this is needed for cases where Result or any of its fields are blittable json.
         //(for example, this is needed for use with AddOrUpdateCompareExchangeCommand, since it returns BlittableJsonReaderObject as result)
-        public Task<(long Index, object Result)> SendToLeaderAsync(TransactionOperationContext context, CommandBase cmd)
+        public Task<(long Index, object Result)> SendToLeaderAsync(JsonOperationContext context, CommandBase cmd)
         {
-            return SendToLeaderAsyncInternal(context, cmd);
+            return SendToLeaderAsyncInternal(cmd);
         }
 
         public DynamicJsonArray GetClusterErrors()
@@ -3138,6 +3135,7 @@ namespace Raven.Server.ServerWide
         {
             internal Action BeforePutLicenseCommandHandledInOnValueChanged;
             internal bool StopIndex;
+            internal Action<CompareExchangeCommandBase> ModifyCompareExchangeTimeout;
         }
     }
 }

--- a/src/Raven.Server/Smuggler/Documents/DatabaseDestination.cs
+++ b/src/Raven.Server/Smuggler/Documents/DatabaseDestination.cs
@@ -575,7 +575,7 @@ namespace Raven.Server.Smuggler.Documents
                 if (_compareExchangeAddOrUpdateCommands.Count > 0)
                 {
                     var compareExchangeAddOrUpdateCommands = _compareExchangeAddOrUpdateCommands;
-                    AsyncHelpers.RunSync(async () => await _database.ServerStore.SendToLeaderAsync(new AddOrUpdateCompareExchangeBatchCommand(_compareExchangeAddOrUpdateCommands, context, RaftIdGenerator.DontCareId)));
+                    AsyncHelpers.RunSync(async () => await _database.ServerStore.SendToLeaderAsync(context, new AddOrUpdateCompareExchangeBatchCommand(_compareExchangeAddOrUpdateCommands, context, RaftIdGenerator.DontCareId)));
                     foreach (var command in compareExchangeAddOrUpdateCommands)
                     {
                         command.Value.Dispose();
@@ -585,7 +585,7 @@ namespace Raven.Server.Smuggler.Documents
 
                 if (_compareExchangeRemoveCommands.Count > 0)
                 {
-                    AsyncHelpers.RunSync(async () => await _database.ServerStore.SendToLeaderAsync(new AddOrUpdateCompareExchangeBatchCommand(_compareExchangeRemoveCommands, context, RaftIdGenerator.DontCareId)));
+                    AsyncHelpers.RunSync(async () => await _database.ServerStore.SendToLeaderAsync(context, new AddOrUpdateCompareExchangeBatchCommand(_compareExchangeRemoveCommands, context, RaftIdGenerator.DontCareId)));
                     _compareExchangeRemoveCommands.Clear();
                 }
             }

--- a/src/Raven.Server/Web/System/CompareExchangeHandler.cs
+++ b/src/Raven.Server/Web/System/CompareExchangeHandler.cs
@@ -1,4 +1,5 @@
-﻿using System.Collections.Generic;
+﻿using System;
+using System.Collections.Generic;
 using System.Diagnostics;
 using System.Net;
 using System.Threading.Tasks;
@@ -137,6 +138,7 @@ namespace Raven.Server.Web.System
                 var command = new AddOrUpdateCompareExchangeCommand(Database.Name, key, updateJson, index, context, raftRequestId);
                 using (var writer = new BlittableJsonTextWriter(context, ResponseBodyStream()))
                 {
+                    ServerStore.ForTestingPurposes?.ModifyCompareExchangeTimeout?.Invoke(command);
                     (var raftIndex, var response) = await ServerStore.SendToLeaderAsync(context, command);
                     await ServerStore.Cluster.WaitForIndexNotification(raftIndex);
 

--- a/test/SlowTests/Issues/RavenDB_16966.cs
+++ b/test/SlowTests/Issues/RavenDB_16966.cs
@@ -1,0 +1,59 @@
+﻿using System;
+using System.Threading.Tasks;
+using FastTests.Server.Replication;
+using Raven.Client.Documents.Operations.CompareExchange;
+using Raven.Client.Exceptions;
+using Xunit;
+using Xunit.Abstractions;
+
+namespace SlowTests.Issues
+{
+    public class RavenDB_16966 : ReplicationTestBase
+    {
+        public RavenDB_16966(ITestOutputHelper output) : base(output)
+        {
+        }
+
+        [Fact]
+        public async Task AvoidContextDisposalForRaftBlittableResult()
+        {
+            var cluster = await CreateRaftCluster(3, watcherCluster: true);
+            var size = 100;
+            using var store = GetDocumentStore(new Options
+            {
+                Server = cluster.Leader,
+                ReplicationFactor = 3
+            });
+
+            foreach (var server in Servers)
+            {
+                server.ServerStore.ForTestingPurposesOnly().ModifyCompareExchangeTimeout = (cmd) => cmd.Timeout = TimeSpan.FromMilliseconds(1);
+            }
+
+            var tasks = new Task[size];
+            for (int i = 0; i < size; i++)
+            {
+                tasks[i] = store.Operations.SendAsync(new PutCompareExchangeValueOperation<string>("test/" + i, "Karmel/" + i, 0));
+            }
+
+
+            for (int i = 0; i < size; i++)
+            {
+                try
+                {
+                    await tasks[i];
+                }
+                catch (RavenException e) when (e.InnerException is TimeoutException)
+                {
+
+                }
+            }
+
+            for (int i = 0; i < size; i++)
+            {
+                var res = await AssertWaitForNotNullAsync(() => store.Operations.SendAsync(new GetCompareExchangeValueOperation<string>("test/" + i)));
+                Assert.Equal("Karmel/" + i, res.Value);
+            }
+        }
+    }
+}


### PR DESCRIPTION
### Issue link

https://issues.hibernatingrhinos.com/issue/RavenDB-16966

### Additional description

Compare exchange raft command are special because we return a `Blittable` as a result.
So the context to which we return the result must:
1. Not be disposed
2. Has no concurrent access 

When such command would timeout we might hit any of the above

One issue was that `ConvertResultAction` was creating a _new_ instance every time so effectively not blocking a concurrent access or disposal as initially intended to. (with the lock and the flag)

The second one was not cloning the result from the history to the `ContextToWriteResult`.

### Type of change

- Bug fix

### How risky is the change?

- Moderate 

### Backward compatibility

- Not relevant, `CommandBase` have an extra property but there shouldn't be a backward comp issue.

### Is it platform specific issue?

- No

### Documentation update

- No documentation update is needed 

### Testing 

- Tests have been added that prove the fix is effective or that the feature works
The issue is a race in few places, my test was failing every ~5 runs, now it doesn't fail.

### Is there any existing behavior change of other features due to this change?

- No

### UI work

- No UI work is needed
