### PR TITLE
RavenDB-17543 Compound sorting fix in static indexes.

### DIFF
--- a/src/Raven.Server/Documents/Indexes/Static/DynamicArray.cs
+++ b/src/Raven.Server/Documents/Indexes/Static/DynamicArray.cs
@@ -3,6 +3,7 @@ using System.Collections;
 using System.Collections.Generic;
 using System.Dynamic;
 using System.Linq;
+using Raven.Client.Exceptions;
 using Raven.Server.Utils;
 using Sparrow.Json;
 
@@ -371,11 +372,34 @@ namespace Raven.Server.Documents.Indexes.Static
             return new DynamicArray(_inner.Cast<DynamicGrouping>().OrderByDescending(comparable));
         }
 
+        private IOrderedEnumerable<object> CreateOrderedEnumerable<TKey>(Func<object, TKey> keySelector, IComparer<TKey> comparer, bool descending, int depth)
+        {
+            if (_inner is not DynamicArray && _inner is IOrderedEnumerable<object> orderedEnumerable)
+            {
+                return descending
+                    ? new DynamicArray(Enumerable.ThenByDescending(orderedEnumerable, keySelector, comparer))
+                    : new DynamicArray(Enumerable.ThenBy(orderedEnumerable, keySelector, comparer));
+            }
+            
+            if (_inner is not DynamicArray dynamicArray)
+            {
+                return descending
+                    ? new DynamicArray(Enumerable.OrderByDescending(_inner, keySelector, comparer))
+                    : new DynamicArray(Enumerable.OrderBy(_inner, keySelector, comparer));
+            }
+
+            if (depth == 0)
+            {
+                throw new InvalidQueryException($"Cannot create {nameof(IOrderedEnumerable<object>)} because your query is too complex. Please rewrite your ordering query.");
+            }
+
+            return dynamicArray.CreateOrderedEnumerable(keySelector, comparer, descending, depth - 1);
+        }
+        
+        
         public IOrderedEnumerable<object> CreateOrderedEnumerable<TKey>(Func<object, TKey> keySelector, IComparer<TKey> comparer, bool descending)
         {
-            return descending ?
-                new DynamicArray(_inner.OrderByDescending(keySelector, comparer)) :
-                new DynamicArray(_inner.OrderBy(keySelector, comparer));
+            return CreateOrderedEnumerable(keySelector, comparer, descending, 32);
         }
 
         public IEnumerable<dynamic> ThenBy(Func<dynamic, dynamic> comparable)

--- a/test/SlowTests/Issues/RavenDB_17543.cs
+++ b/test/SlowTests/Issues/RavenDB_17543.cs
@@ -1,0 +1,88 @@
+﻿using System.Linq;
+using System.Threading.Tasks;
+using FastTests;
+using Raven.Client.Documents.Indexes;
+using Xunit;
+using Xunit.Abstractions;
+
+
+namespace SlowTests.Issues
+{
+    public class RavenDB_17543 : RavenTestBase
+    {
+        public RavenDB_17543(ITestOutputHelper output) : base(output)
+        {
+        }
+
+        [Fact]
+        public Task CanCompoundOrderingInMapReduceResult()
+        {
+            using var store = GetDocumentStore();
+            using (var session = store.OpenSession())
+            {
+                session.Store(new TestDoc(){Id = "a",Group = "dummy",Value1 = 10,Value2 = 30});
+                session.Store(new TestDoc(){Id = "b",Group = "dummy",Value1 = 10,Value2 = 40});
+                session.Store(new TestDoc(){Id = "c",Group = "dummy",Value1 = 20,Value2 = 30});
+                session.Store(new TestDoc(){Id = "d",Group = "dummy",Value1 = 20,Value2 = 40});
+                session.SaveChanges();
+            }
+
+            new TestIndexOrderByThenBy().Execute(store);
+            WaitForIndexing(store);
+            using (var session = store.OpenSession())
+            {
+                var ravenQueryable = session.Query<Result, TestIndexOrderByThenBy>().ToList();
+
+                var single = ravenQueryable.Single();
+                
+                Assert.True(single.AscAsc.OrderBy(doc => doc.Value1).ThenBy(doc => doc.Value2).SequenceEqual(single.AscAsc));
+                Assert.True(single.AscDesc.OrderBy(doc => doc.Value1).ThenByDescending(doc => doc.Value2).SequenceEqual(single.AscDesc));
+                Assert.True(single.DescAsc.OrderByDescending(doc => doc.Value1).ThenBy(doc => doc.Value2).SequenceEqual(single.DescAsc));
+                Assert.True(single.DescDesc.OrderByDescending(doc => doc.Value1).ThenByDescending(doc => doc.Value2).SequenceEqual(single.DescDesc));
+
+            }
+
+            return null;
+        }
+        
+        private class TestDoc
+        {
+            public string Id { get; set; }
+            public string Group { get; set; }
+            public int Value1 { get; set; }
+            public int Value2 { get; set; }
+
+            public override string ToString()
+            {
+                return $"Id: {Id}, Group: {Group}, Value1: {Value1}, Value2: {Value2}";
+            }
+        }
+    
+        private class Result
+        {
+            public string Group { get; set; }
+            public TestDoc[] AscAsc { get; set; }
+            public TestDoc[] AscDesc { get; set; }
+            public TestDoc[] DescAsc { get; set; }
+            public TestDoc[] DescDesc { get; set; }
+        }
+
+        private class TestIndexOrderByThenBy : AbstractIndexCreationTask<TestDoc, Result>
+        {
+            public TestIndexOrderByThenBy()
+            {
+                Map = docs => docs.Select(doc => new Result { Group = doc.Group, DescAsc = new[] { doc }, DescDesc = new[] { doc }, AscAsc = new[] { doc }, AscDesc = new[] { doc }  });
+                Reduce = results => results
+                    .GroupBy(result => new { result.Group })
+                    .Select(result => new Result()
+                    {
+                        Group = result.Key.Group,
+                        AscAsc = result.SelectMany(result1 => result1.AscAsc).OrderBy(doc => doc.Value1).ThenBy(doc => doc.Value2).ToArray(),
+                        AscDesc = result.SelectMany(result1 => result1.AscAsc).OrderBy(doc => doc.Value1).ThenByDescending(doc => doc.Value2).ToArray(),
+                        DescAsc = result.SelectMany(result1 => result1.AscAsc).OrderByDescending(doc => doc.Value1).ThenBy(doc => doc.Value2).ToArray(),
+                        DescDesc = result.SelectMany(result1 => result1.AscAsc).OrderByDescending(doc => doc.Value1).ThenByDescending(doc => doc.Value2).ToArray()
+                    });
+            }
+        }
+    }
+}

--- a/test/SlowTests/MailingList/IndexCompilation.cs
+++ b/test/SlowTests/MailingList/IndexCompilation.cs
@@ -45,9 +45,9 @@ namespace SlowTests.MailingList
                     Lines = new List<OrderLine>
                     {
                         new OrderLine {Quantity = 7, Discount = 4},
-                        new OrderLine {Quantity = 50, Discount = 4},
-                        new OrderLine {Quantity = 20, Discount = 4},
-                        new OrderLine {Quantity = 3, Discount = 4},
+                        new OrderLine {Quantity = 50, Discount = 3},
+                        new OrderLine {Quantity = 20, Discount = 3},
+                        new OrderLine {Quantity = 3, Discount = 5},
                         new OrderLine {Quantity = 7, Discount = 4}
                     }
                 };
@@ -83,10 +83,10 @@ namespace SlowTests.MailingList
                     Lines = new List<OrderLine>
                     {
                         new OrderLine {Quantity = 7, Discount = 4},
-                        new OrderLine {Quantity = 50, Discount = 4},
-                        new OrderLine {Quantity = 20, Discount = 4},
+                        new OrderLine {Quantity = 50, Discount = 3},
+                        new OrderLine {Quantity = 20, Discount = 3},
                         new OrderLine {Quantity = 3, Discount = 4},
-                        new OrderLine {Quantity = 7, Discount = 4}
+                        new OrderLine {Quantity = 7, Discount = 5}
                     }
                 };
 


### PR DESCRIPTION
### Issue link

https://issues.hibernatingrhinos.com/issue/RavenDB-17543

### Additional description


If we call ThenBy / ThenByDescending on IOrderedEnumerable implementation with Enumerable it gonna move us into CeateOrderedEnumerable - so we need to call Enumerable.(Then etc)  with inner only when _inner is enumerable or go deeper in the chain and find the right one.
 
### Type of change

- Bug fix


### How risky is the change?

- High


### Backward compatibility

- Not relevant

### Is it platform specific issue?

- No

### Documentation update

- No documentation update is needed 

### Testing 

- Tests have been added that prove the fix is effective or that the feature works
- Old tests of this functionality weren't deterministic so I changed them.

### Is there any existing behavior change of other features due to this change?

- Yes, static index builder.

### UI work

- No UI work is needed
