### PR TITLE
RavenDB-17572: Fix wrong hashing of double value in reduce key processor

### DIFF
--- a/src/Raven.Server/Documents/Handlers/IndexHandler.cs
+++ b/src/Raven.Server/Documents/Handlers/IndexHandler.cs
@@ -1036,7 +1036,7 @@ namespace Raven.Server.Documents.Handlers
                 if (indexDefinition.Type.IsJavaScript() == false)
                     throw new UnauthorizedAccessException("Testing indexes is only allowed for JavaScript indexes.");
 
-                var compiledIndex = new JavaScriptIndex(indexDefinition, Database.Configuration);
+                var compiledIndex = new JavaScriptIndex(indexDefinition, Database.Configuration, IndexDefinitionBase.IndexVersion.CurrentVersion);
 
                 var inputSize = GetIntValueQueryString("inputSize", false) ?? DefaultInputSizeForTestingJavaScriptIndex;
                 var collections = new HashSet<string>(compiledIndex.Maps.Keys);

--- a/src/Raven.Server/Documents/Indexes/IndexDefinitionBase.cs
+++ b/src/Raven.Server/Documents/Indexes/IndexDefinitionBase.cs
@@ -135,10 +135,12 @@ namespace Raven.Server.Documents.Indexes
 
             public const long Analyzers = 52_000;
 
+            public const long ReduceKeyProcessorHashDoubleFix = 52_001; // RavenDB-17572
+
             /// <summary>
             /// Remember to bump this
             /// </summary>
-            public const long CurrentVersion = Analyzers;
+            public const long CurrentVersion = ReduceKeyProcessorHashDoubleFix;
         }
     }
 

--- a/src/Raven.Server/Documents/Indexes/IndexStore.cs
+++ b/src/Raven.Server/Documents/Indexes/IndexStore.cs
@@ -1022,7 +1022,7 @@ namespace Raven.Server.Documents.Indexes
             definition.RemoveDefaultValues();
             ValidateAnalyzers(definition);
 
-            var instance = IndexCompilationCache.GetIndexInstance(definition, _documentDatabase.Configuration); // pre-compile it and validate
+            var instance = IndexCompilationCache.GetIndexInstance(definition, _documentDatabase.Configuration, IndexDefinitionBase.IndexVersion.CurrentVersion); // pre-compile it and validate
 
             if (definition.Type == IndexType.MapReduce)
             {

--- a/src/Raven.Server/Documents/Indexes/MapReduce/Auto/AutoMapReduceIndex.cs
+++ b/src/Raven.Server/Documents/Indexes/MapReduce/Auto/AutoMapReduceIndex.cs
@@ -59,7 +59,7 @@ namespace Raven.Server.Documents.Indexes.MapReduce.Auto
         {
             base.OnInitialization();
 
-            _reduceKeyProcessor = new ReduceKeyProcessor(Definition.GroupByFields.Count, _unmanagedBuffersPool);
+            _reduceKeyProcessor = new ReduceKeyProcessor(Definition.GroupByFields.Count, _unmanagedBuffersPool, Definition.Version);
         }
 
         protected override IIndexingWork[] CreateIndexWorkExecutors()

--- a/src/Raven.Server/Documents/Indexes/MapReduce/Static/MapReduceIndex.cs
+++ b/src/Raven.Server/Documents/Indexes/MapReduce/Static/MapReduceIndex.cs
@@ -319,7 +319,7 @@ namespace Raven.Server.Documents.Indexes.MapReduce.Static
 
         private static MapReduceIndexDefinition CreateIndexDefinition(IndexDefinition definition, RavenConfiguration configuration, long indexVersion, out AbstractStaticIndexBase staticIndex)
         {
-            staticIndex = IndexCompilationCache.GetIndexInstance(definition, configuration);
+            staticIndex = IndexCompilationCache.GetIndexInstance(definition, configuration, indexVersion);
             return new MapReduceIndexDefinition(definition, staticIndex.Maps.Keys, staticIndex.OutputFields, staticIndex.GroupByFields, staticIndex.HasDynamicFields, staticIndex.CollectionsWithCompareExchangeReferences.Count > 0, indexVersion);
         }
 
@@ -480,7 +480,7 @@ namespace Raven.Server.Documents.Indexes.MapReduce.Static
                 _indexContext = indexContext;
                 _groupByFields = index.Definition.GroupByFields;
                 _isMultiMap = index.IsMultiMap;
-                _reduceKeyProcessor = new ReduceKeyProcessor(index.Definition.GroupByFields.Count, index._unmanagedBuffersPool);
+                _reduceKeyProcessor = new ReduceKeyProcessor(index.Definition.GroupByFields.Count, index._unmanagedBuffersPool, index.Definition.Version);
                 _compiledIndex = index._compiled;
             }
 

--- a/src/Raven.Server/Documents/Indexes/Static/AbstractCountersAndTimeSeriesJavaScriptIndex.cs
+++ b/src/Raven.Server/Documents/Indexes/Static/AbstractCountersAndTimeSeriesJavaScriptIndex.cs
@@ -14,8 +14,8 @@ namespace Raven.Server.Documents.Indexes.Static
     {
         private const string NameProperty = "name";
 
-        protected AbstractCountersAndTimeSeriesJavaScriptIndex(IndexDefinition definition, RavenConfiguration configuration, string mapPrefix, string allItems)
-            : base(definition, configuration, mappingFunctions => ModifyMappingFunctions(mappingFunctions, mapPrefix), GetMapCode(allItems))
+        protected AbstractCountersAndTimeSeriesJavaScriptIndex(IndexDefinition definition, RavenConfiguration configuration, string mapPrefix, string allItems, long indexVersion)
+            : base(definition, configuration, mappingFunctions => ModifyMappingFunctions(mappingFunctions, mapPrefix), GetMapCode(allItems), indexVersion)
         {
         }
 

--- a/src/Raven.Server/Documents/Indexes/Static/Counters/CountersJavaScriptIndex.cs
+++ b/src/Raven.Server/Documents/Indexes/Static/Counters/CountersJavaScriptIndex.cs
@@ -8,8 +8,8 @@ namespace Raven.Server.Documents.Indexes.Static.Counters
     {
         private const string MapPrefix = "counters.";
 
-        public CountersJavaScriptIndex(IndexDefinition definition, RavenConfiguration configuration)
-            : base(definition, configuration, MapPrefix, Constants.Counters.All)
+        public CountersJavaScriptIndex(IndexDefinition definition, RavenConfiguration configuration, long indexVersion)
+            : base(definition, configuration, MapPrefix, Constants.Counters.All, indexVersion)
         {
         }
     }

--- a/src/Raven.Server/Documents/Indexes/Static/Counters/MapCountersIndex.cs
+++ b/src/Raven.Server/Documents/Indexes/Static/Counters/MapCountersIndex.cs
@@ -225,7 +225,7 @@ namespace Raven.Server.Documents.Indexes.Static.Counters
 
         private static MapCountersIndex CreateIndexInstance(IndexDefinition definition, RavenConfiguration configuration, long indexVersion)
         {
-            var staticIndex = IndexCompilationCache.GetIndexInstance(definition, configuration);
+            var staticIndex = IndexCompilationCache.GetIndexInstance(definition, configuration, indexVersion);
 
             var staticMapIndexDefinition = new MapIndexDefinition(definition, staticIndex.Maps.Keys, staticIndex.OutputFields, staticIndex.HasDynamicFields, staticIndex.CollectionsWithCompareExchangeReferences.Count > 0, indexVersion);
             var instance = new MapCountersIndex(staticMapIndexDefinition, staticIndex);

--- a/src/Raven.Server/Documents/Indexes/Static/MapIndex.cs
+++ b/src/Raven.Server/Documents/Indexes/Static/MapIndex.cs
@@ -209,7 +209,7 @@ namespace Raven.Server.Documents.Indexes.Static
 
         private static MapIndex CreateIndexInstance(IndexDefinition definition, RavenConfiguration configuration, long indexVersion)
         {
-            var staticIndex = IndexCompilationCache.GetIndexInstance(definition, configuration);
+            var staticIndex = IndexCompilationCache.GetIndexInstance(definition, configuration, indexVersion);
 
             var staticMapIndexDefinition = new MapIndexDefinition(definition, staticIndex.Maps.Keys, staticIndex.OutputFields, staticIndex.HasDynamicFields, staticIndex.CollectionsWithCompareExchangeReferences.Count > 0, indexVersion);
             var instance = new MapIndex(staticMapIndexDefinition, staticIndex);

--- a/src/Raven.Server/Documents/Indexes/Static/TimeSeries/MapTimeSeriesIndex.cs
+++ b/src/Raven.Server/Documents/Indexes/Static/TimeSeries/MapTimeSeriesIndex.cs
@@ -247,7 +247,7 @@ namespace Raven.Server.Documents.Indexes.Static.TimeSeries
 
         private static MapTimeSeriesIndex CreateIndexInstance(IndexDefinition definition, RavenConfiguration configuration, long indexVersion)
         {
-            var staticIndex = IndexCompilationCache.GetIndexInstance(definition, configuration);
+            var staticIndex = IndexCompilationCache.GetIndexInstance(definition, configuration, indexVersion);
 
             var staticMapIndexDefinition = new MapIndexDefinition(definition, staticIndex.Maps.Keys, staticIndex.OutputFields, staticIndex.HasDynamicFields, staticIndex.CollectionsWithCompareExchangeReferences.Count > 0, indexVersion);
             var instance = new MapTimeSeriesIndex(staticMapIndexDefinition, staticIndex);

--- a/src/Raven.Server/Documents/Indexes/Static/TimeSeries/TimeSeriesJavaScriptIndex.cs
+++ b/src/Raven.Server/Documents/Indexes/Static/TimeSeries/TimeSeriesJavaScriptIndex.cs
@@ -8,8 +8,8 @@ namespace Raven.Server.Documents.Indexes.Static.TimeSeries
     {
         private const string MapPrefix = "timeSeries.";
 
-        public TimeSeriesJavaScriptIndex(IndexDefinition definition, RavenConfiguration configuration)
-            : base(definition, configuration, MapPrefix, Constants.TimeSeries.All)
+        public TimeSeriesJavaScriptIndex(IndexDefinition definition, RavenConfiguration configuration, long indexVersion)
+            : base(definition, configuration, MapPrefix, Constants.TimeSeries.All, indexVersion)
         {
         }
     }

--- a/src/Raven.Server/Web/Studio/StudioIndexHandler.cs
+++ b/src/Raven.Server/Web/Studio/StudioIndexHandler.cs
@@ -4,6 +4,7 @@ using System.Threading.Tasks;
 using Raven.Client.Documents.Indexes;
 using Raven.Client.Exceptions.Documents.Compilation;
 using Raven.Server.Documents;
+using Raven.Server.Documents.Indexes;
 using Raven.Server.Documents.Indexes.Static;
 using Raven.Server.Json;
 using Raven.Server.Routing;
@@ -73,7 +74,7 @@ namespace Raven.Server.Web.Studio
 
                     try
                     {
-                        var compiledIndex = IndexCompilationCache.GetIndexInstance(indexDefinition, Database.Configuration);
+                        var compiledIndex = IndexCompilationCache.GetIndexInstance(indexDefinition, Database.Configuration, IndexDefinitionBase.IndexVersion.CurrentVersion);
 
                         var outputFields = compiledIndex.OutputFields;
 

--- a/test/FastTests/Server/Documents/Indexing/MapReduce/ReduceKeyProcessorTests.cs
+++ b/test/FastTests/Server/Documents/Indexing/MapReduce/ReduceKeyProcessorTests.cs
@@ -1,4 +1,5 @@
 ﻿using Raven.Client.Util;
+using Raven.Server.Documents.Indexes;
 using Raven.Server.Documents.Indexes.MapReduce;
 using Raven.Server.ServerWide;
 using Sparrow.Server;
@@ -23,7 +24,7 @@ namespace FastTests.Server.Documents.Indexing.MapReduce
             using (var context = JsonOperationContext.ShortTermSingleUse())
             using (var bsc = new ByteStringContext(SharedMultipleUseFlag.None))
             {
-                var sut = new ReduceKeyProcessor(9, bufferPool);
+                var sut = new ReduceKeyProcessor(9, bufferPool, IndexDefinitionBase.IndexVersion.CurrentVersion);
 
                 sut.Reset();
 

--- a/test/SlowTests/Issues/RavenDB_17572.cs
+++ b/test/SlowTests/Issues/RavenDB_17572.cs
@@ -1,0 +1,119 @@
+﻿using System.Collections.Generic;
+using System.Dynamic;
+using System.Linq;
+using System.Net.Http;
+using System.Threading.Tasks;
+using FastTests;
+using Newtonsoft.Json;
+using Raven.Client.Documents.Indexes;
+using Xunit;
+using Xunit.Abstractions;
+
+namespace SlowTests.Issues
+{
+    public class RavenDB_17572 : RavenTestBase
+    {
+        public RavenDB_17572(ITestOutputHelper output) : base(output)
+        {
+        }
+
+        [Fact]
+        public async Task IndexWithGroupByOnDoubleShouldReturnDifferentHash()
+        {
+            using (var store = GetDocumentStore())
+            {
+                using (var session = store.OpenSession())
+                {
+                    session.Store(new Purchase
+                    {
+                        ItemType = "Tablet",
+                        Date = 322.0
+                    });
+                    session.Store(new Purchase
+                    {
+                        ItemType = "Tablet",
+                        Date = 123.0
+                    });
+                    session.SaveChanges();
+                }
+
+                new JavaScriptIndexWithGroupByOnDouble().Execute(store);
+                new IndexWithGroupByOnDouble().Execute(store);
+                WaitForIndexing(store);
+
+                var client = new HttpClient();
+                var jsRes = await client.PostAsync($"{store.Urls[0]}/databases/{store.Database}/queries?debug=entries&addTimeSeriesNames=true&addSpatialProperties=true&metadataOnly=false&ignoreLimit=true", new StringContent($"{{\"Query\":\"from index 'JavaScriptIndexWithGroupByOnDouble'\",\"Start\":0,\"PageSize\":101,\"QueryParameters\":{{}}}}"));
+                var jsonString1 = await jsRes.Content.ReadAsStringAsync();
+                dynamic resultsObj1 = JsonConvert.DeserializeObject<ExpandoObject>(jsonString1);
+
+                AssertQueryResults(resultsObj1);
+
+                var cSharpRes = await client.PostAsync($"{store.Urls[0]}/databases/{store.Database}/queries?debug=entries&addTimeSeriesNames=true&addSpatialProperties=true&metadataOnly=false&ignoreLimit=true", new StringContent($"{{\"Query\":\"from index 'IndexWithGroupByOnDouble'\",\"Start\":0,\"PageSize\":101,\"QueryParameters\":{{}}}}"));
+                var jsonString2 = await cSharpRes.Content.ReadAsStringAsync();
+                dynamic resultsObj2 = JsonConvert.DeserializeObject<ExpandoObject>(jsonString2);
+
+                AssertQueryResults(resultsObj2);
+            }
+        }
+
+        private static void AssertQueryResults(dynamic resultsObj)
+        {
+            Assert.NotNull(resultsObj);
+            Assert.Equal(2, resultsObj.TotalResults);
+            List<dynamic> results = resultsObj.Results;
+            Assert.Equal(2, results.Count);
+
+            string hash1 = (string)((IDictionary<string, object>)results.First())["hash(key())"];
+            string hash2 = (string)((IDictionary<string, object>)results.Last())["hash(key())"];
+            Assert.NotEqual(hash1, hash2);
+        }
+
+        private class Purchase
+        {
+            public string ItemType;
+            public double Date;
+        }
+
+        private class JavaScriptIndexWithGroupByOnDouble : AbstractIndexCreationTask
+        {
+            public override string IndexName => "JavaScriptIndexWithGroupByOnDouble";
+
+            public override IndexDefinition CreateIndexDefinition()
+            {
+                return new IndexDefinition
+                {
+                    Maps =
+                    {
+                        @"map(""Purchases"", (purchase) => {
+    return {
+        ItemType: purchase.ItemType,
+        Date: purchase.Date
+    };
+})"
+                    },
+                    Reduce = @"groupBy(x => ({
+    ItemType: x.ItemType,
+    Date: x.Date
+})).aggregate(g => {
+        return {
+                ItemType: x.ItemType,
+                Date: x.Date
+        };
+    })"
+                };
+            }
+        }
+
+        private class IndexWithGroupByOnDouble : AbstractIndexCreationTask<Purchase>
+        {
+            public override string IndexName => "IndexWithGroupByOnDouble";
+            public IndexWithGroupByOnDouble()
+            {
+                Map = docs => docs.Select(doc => new { ItemType = doc.ItemType, Date = (double)doc.Date });
+                Reduce = results => results
+                    .GroupBy(result => new { result.ItemType, result.Date })
+                    .Select(result => new { result.Key.ItemType, Date = (double)result.Key.Date });
+            }
+        }
+    }
+}

--- a/test/SlowTests/Server/Documents/Indexing/Auto/RavenDB_9535.cs
+++ b/test/SlowTests/Server/Documents/Indexing/Auto/RavenDB_9535.cs
@@ -1,4 +1,5 @@
 ﻿using FastTests;
+using Raven.Server.Documents.Indexes;
 using Raven.Server.Documents.Indexes.MapReduce;
 using Raven.Server.ServerWide;
 using Sparrow.Server;
@@ -20,7 +21,7 @@ namespace SlowTests.Server.Documents.Indexing.Auto
             using (var bufferPool = new UnmanagedBuffersPoolWithLowMemoryHandling("RavenDB_9535"))
             using (var bsc = new ByteStringContext(SharedMultipleUseFlag.None))
             {
-                var sut = new ReduceKeyProcessor(1, bufferPool);
+                var sut = new ReduceKeyProcessor(1, bufferPool, IndexDefinitionBase.IndexVersion.CurrentVersion);
 
                 try
                 {


### PR DESCRIPTION
### Issue link

https://issues.hibernatingrhinos.com/issue/RavenDB-17572

### Type of change

- Bug fix
- Optimization

### How risky is the change?

- Moderate 

### Backward compatibility

- Ensured. 
Added new index version, and apply the code fix only for new indexes

### Is it platform specific issue?

- No

### Documentation update

- No documentation update is needed 

### Testing 

- Tests have been added that prove the fix is effective or that the feature works
- It has been verified by manual testing

### Is there any existing behavior change of other features due to this change?

- No

### UI work

- No UI work is needed
