### PR TITLE
RavenDB-17513 - faster generation of subscription ids

### DIFF
--- a/src/Raven.Server/ServerWide/Commands/Subscriptions/PutSubscriptionCommand.cs
+++ b/src/Raven.Server/ServerWide/Commands/Subscriptions/PutSubscriptionCommand.cs
@@ -1,5 +1,4 @@
 ﻿using System;
-using System.Collections.Generic;
 using Raven.Client;
 using Raven.Client.Documents.Subscriptions;
 using Raven.Client.Exceptions.Documents.Subscriptions;
@@ -14,7 +13,6 @@ using Voron;
 using Voron.Data.Tables;
 using Raven.Server.Documents.Replication;
 using Raven.Server.Rachis;
-using Voron.Impl.Paging;
 
 namespace Raven.Server.ServerWide.Commands.Subscriptions
 {
@@ -111,43 +109,6 @@ namespace Raven.Server.ServerWide.Commands.Subscriptions
                     tryToSetName = false;
                 }
             }
-        }
-
-        public long FindFreeId(Dictionary<string, long> minimumSubscriptionIdPerDatabase, long subscriptionId, TransactionOperationContext context)
-        {
-            if (minimumSubscriptionIdPerDatabase.TryGetValue(DatabaseName, out var minimumSubscriptionId) == false)
-            {
-                minimumSubscriptionId = int.MaxValue;
-
-                foreach (var keyValue in ClusterStateMachine.ReadValuesStartingWith(context,
-                    SubscriptionState.SubscriptionPrefix(DatabaseName)))
-                {
-                    if (keyValue.Value.TryGet(nameof(SubscriptionState.SubscriptionId), out long id) == false)
-                        continue;
-
-                    if (id < minimumSubscriptionId)
-                        minimumSubscriptionId = id;
-                }
-
-                minimumSubscriptionIdPerDatabase[DatabaseName] = minimumSubscriptionId;
-            }
-
-            if (SubscriptionId.HasValue)
-            {
-                if (SubscriptionId.Value < minimumSubscriptionId)
-                    minimumSubscriptionIdPerDatabase[DatabaseName] = minimumSubscriptionId;
-
-                return SubscriptionId.Value;
-            }
-
-            if (subscriptionId >= minimumSubscriptionId)
-            {
-                subscriptionId = --minimumSubscriptionId;
-            }
-
-            minimumSubscriptionIdPerDatabase[DatabaseName] = subscriptionId;
-
-            return subscriptionId;
         }
 
         private void AssertValidChangeVector()

--- a/test/SlowTests/Issues/RavenDB-17513.cs
+++ b/test/SlowTests/Issues/RavenDB-17513.cs
@@ -35,7 +35,9 @@ namespace SlowTests.Issues
                 }, store2.Smuggler);
                 await operation.WaitForCompletionAsync(TimeSpan.FromSeconds(30));
 
-                WaitForUserToContinueTheTest(store2);
+                var newSubscriptions = await store2.Subscriptions.GetSubscriptionsAsync(0, 1024);
+                var subscriptionIdsDistinctCount = newSubscriptions.Select(x => x.SubscriptionId).Distinct().Count();
+                Assert.Equal(newSubscriptions.Count, subscriptionIdsDistinctCount);
             }
         }
     }

--- a/test/SlowTests/Issues/RavenDB-17513.cs
+++ b/test/SlowTests/Issues/RavenDB-17513.cs
@@ -1,0 +1,42 @@
+﻿using System;
+using System.Linq;
+using System.Threading.Tasks;
+using FastTests;
+using FastTests.Client;
+using Raven.Client.Documents.Indexes;
+using Raven.Client.Documents.Smuggler;
+using Xunit;
+using Xunit.Abstractions;
+
+namespace SlowTests.Issues
+{
+    public class RavenDB_17513 : RavenTestBase
+    {
+        public RavenDB_17513(ITestOutputHelper output) : base(output)
+        {
+        }
+
+        [Fact]
+        public async Task Can_Import_Subscriptions()
+        {
+            using (var store1 = GetDocumentStore())
+            using (var store2 = GetDocumentStore())
+            {
+                for (var i = 0; i < 1024; i++)
+                {
+                    await store1.Subscriptions.CreateAsync<Query.Order>(
+                        order => order.Lines.Any(x => x.Discount > 10)
+                    );
+                }
+
+                var operation = await store1.Smuggler.ExportAsync(new DatabaseSmugglerExportOptions
+                {
+                    OperateOnTypes = DatabaseItemType.Subscriptions
+                }, store2.Smuggler);
+                await operation.WaitForCompletionAsync(TimeSpan.FromSeconds(30));
+
+                WaitForUserToContinueTheTest(store2);
+            }
+        }
+    }
+}


### PR DESCRIPTION
### Issue link

https://issues.hibernatingrhinos.com/issue/RavenDB-17513

### Additional description

Improved the id generation of subscription ids.
If we had more subscriptions, it would take more time to restore them during database import/restore.
(restoring 1024 subscriptions would take ~30 seconds)

### Type of change

- Bug fix

### How risky is the change?

- Low 

### Testing 

- Tests have been added that prove the fix is effective or that the feature works