### PR TITLE
RavenDB-17587 Incremental time-series import should overwrite existing values

### DIFF
--- a/src/Raven.Server/Documents/Handlers/TimeSeriesHandler.cs
+++ b/src/Raven.Server/Documents/Handlers/TimeSeriesHandler.cs
@@ -1107,6 +1107,12 @@ namespace Raven.Server.Documents.Handlers
             }
         }
 
+        private static readonly TimeSeriesStorage.AppendOptions AppendOptionsForSmuggler = new TimeSeriesStorage.AppendOptions
+        {
+            VerifyName = false, 
+            FromSmuggler = true
+        };
+
         internal class SmugglerTimeSeriesBatchCommand : TransactionOperationsMerger.MergedTransactionCommand
         {
             private readonly DocumentDatabase _database;
@@ -1144,7 +1150,7 @@ namespace Raven.Server.Documents.Handlers
                         }
 
                         var values = item.Segment.YieldAllValues(context, context.Allocator, item.Baseline);
-                        tss.AppendTimestamp(context, docId, item.Collection, item.Name, values, verifyName: false);
+                        tss.AppendTimestamp(context, docId, item.Collection, item.Name, values, AppendOptionsForSmuggler);
                     }
 
                     changes += items.Count;

--- a/src/Raven.Server/Documents/Patch/ScriptRunner.cs
+++ b/src/Raven.Server/Documents/Patch/ScriptRunner.cs
@@ -422,6 +422,11 @@ namespace Raven.Server.Documents.Patch
                 return tsStats;
             }
 
+            private static readonly TimeSeriesStorage.AppendOptions AppendOptionsForScript = new TimeSeriesStorage.AppendOptions
+            {
+                AddNewNameToMetadata = false
+            };
+
             private JsValue AppendTimeSeries(JsValue document, JsValue name, JsValue[] args)
             {
                 AssertValidDatabaseContext("timeseries(doc, name).append");
@@ -500,7 +505,7 @@ namespace Raven.Server.Documents.Patch
                         CollectionName.GetCollectionName(doc),
                         timeSeries,
                         new[] { toAppend }, 
-                        addNewNameToMetadata: false);
+                        AppendOptionsForScript);
 
                     if (DebugMode)
                     {

--- a/src/Raven.Server/Documents/Replication/IncomingReplicationHandler.cs
+++ b/src/Raven.Server/Documents/Replication/IncomingReplicationHandler.cs
@@ -1236,9 +1236,15 @@ namespace Raven.Server.Documents.Replication
                                     context.LastDatabaseChangeVector = ChangeVectorUtils.MergeVectors(databaseChangeVector, segment.ChangeVector);
                                     continue;
                                 }
+                                
+                                var options = new TimeSeriesStorage.AppendOptions
+                                {
+                                    VerifyName = false,
+                                    ChangeVectorFromReplication = segment.ChangeVector
+                                };
 
                                 var values = segment.Segment.YieldAllValues(context, context.Allocator, baseline);
-                                var changeVector = tss.AppendTimestamp(context, docId, segment.Collection, segment.Name, values, segment.ChangeVector, verifyName: false);
+                                var changeVector = tss.AppendTimestamp(context, docId, segment.Collection, segment.Name, values, options);
                                 context.LastDatabaseChangeVector = ChangeVectorUtils.MergeVectors(changeVector, segment.ChangeVector);
 
                                 break;

--- a/src/Raven.Server/Documents/TimeSeries/TimeSeriesRollups.cs
+++ b/src/Raven.Server/Documents/TimeSeries/TimeSeriesRollups.cs
@@ -493,6 +493,11 @@ namespace Raven.Server.Documents.TimeSeries
                 return RolledUp;
             }
 
+            private readonly TimeSeriesStorage.AppendOptions _appendOptionsForRollups = new TimeSeriesStorage.AppendOptions
+            {
+                VerifyName = false
+            };
+
             private void RollupOne(DocumentsOperationContext context, Table table, RollupState item, TimeSeriesPolicy policy, TimeSeriesCollectionConfiguration config)
             {
                 var tss = context.DocumentDatabase.DocumentsStorage.TimeSeriesStorage;
@@ -589,7 +594,7 @@ namespace Raven.Server.Documents.TimeSeries
                 }
 
                 var before = context.LastDatabaseChangeVector;
-                var after = tss.AppendTimestamp(context, item.DocId, item.Collection, intoTimeSeries, values, verifyName: false);
+                var after = tss.AppendTimestamp(context, item.DocId, item.Collection, intoTimeSeries, values, _appendOptionsForRollups);
                 if (before != after)
                     RolledUp++;
                 MarkForNextPolicyAfterRollup(context, table, item, policy, tss, rollupEnd);

--- a/test/SlowTests/Server/Documents/ETL/ClusterEtlTimeSeriesTests.cs
+++ b/test/SlowTests/Server/Documents/ETL/ClusterEtlTimeSeriesTests.cs
@@ -91,7 +91,7 @@ namespace SlowTests.Server.Documents.ETL
                         Values = new Memory<double>(new []{value})
                     }, 
                 };
-                tsStorage.AppendTimestamp(context, tsOwnerId, "Users", timeSeriesName.ToLower(), toAppend, null, verifyName: false);
+                tsStorage.AppendTimestamp(context, tsOwnerId, "Users", timeSeriesName.ToLower(), toAppend, EtlTimeSeriesTests.AppendOptionsForEtlTest);
                 tr.Commit();
             }
 

--- a/test/SlowTests/Server/Documents/ETL/EtlTimeSeriesTests.cs
+++ b/test/SlowTests/Server/Documents/ETL/EtlTimeSeriesTests.cs
@@ -1828,7 +1828,7 @@ function loadTimeSeriesOfUsersBehavior(doc, ts)
                         Values = new Memory<double>(new []{value})
                     },
                 };
-                tsStorage.AppendTimestamp(context, documentId, "Users", timeSeriesName.ToLower(), toAppend, null, verifyName: false);
+                tsStorage.AppendTimestamp(context, documentId, "Users", timeSeriesName.ToLower(), toAppend, AppendOptionsForEtlTest);
                 tr.Commit();
             }
 
@@ -1888,7 +1888,7 @@ function loadTimeSeriesOfUsersBehavior(doc, ts)
                             Values = new Memory<double>(new []{value})
                         },
                     };
-                    tsStorage.AppendTimestamp(context, users[0].Id, "Users", timeSeriesName.ToLower(), toAppend, null, verifyName: false);
+                    tsStorage.AppendTimestamp(context, users[0].Id, "Users", timeSeriesName.ToLower(), toAppend, AppendOptionsForEtlTest);
                     tr.Commit();
                 }
 
@@ -2170,5 +2170,10 @@ loadToUsers({
                 return timeSeriesEntries?.FirstOrDefault();
             }, interval: 1000);
         }
+
+        public static TimeSeriesStorage.AppendOptions AppendOptionsForEtlTest = new TimeSeriesStorage.AppendOptions
+        {
+            VerifyName = false
+        };
     }
 }

--- a/test/Tests.Infrastructure/BackupTestBase.cs
+++ b/test/Tests.Infrastructure/BackupTestBase.cs
@@ -1,5 +1,7 @@
 ﻿using System;
 using System.Diagnostics;
+using System.IO;
+using System.Linq;
 using System.Text;
 using System.Threading.Tasks;
 using Raven.Client.Documents;
@@ -390,6 +392,24 @@ namespace FastTests
                     Assert.True(false, PrintBackupStatus(status));
                 }
             }
+        }
+        
+        public IDocumentStore RestoreAndGetStore(IDocumentStore store, string backupPath, TimeSpan? timeout = null)
+        {
+            var restoredDatabaseName = GetDatabaseName();
+
+            Backup.RestoreDatabase(store, new RestoreBackupConfiguration
+            {
+                BackupLocation = Directory.GetDirectories(backupPath).First(), 
+                DatabaseName = restoredDatabaseName
+            }, timeout);
+
+            return GetDocumentStore(new Options
+            {
+                ModifyDatabaseName = s => restoredDatabaseName, 
+                CreateDatabase = false, 
+                DeleteDatabaseOnDispose = true
+            });
         }
     }
 }


### PR DESCRIPTION
### Issue link

https://issues.hibernatingrhinos.com/issue/RavenDB-17587

### Additional description

Importing the same incremental time-series should not increment the values

### Type of change

- Bug fix

### How risky is the change?

- Low 

### Backward compatibility

- Not relevant

### Is it platform specific issue?

- No

### Documentation update

- No documentation update is needed 

### Testing 

- Tests have been added that prove the fix is effective or that the feature works

### Is there any existing behavior change of other features due to this change?

- No

### UI work

- No UI work is needed
