### PR TITLE
RavenDB-17125 Report the Responsible Node for the Hub Task

### DIFF
--- a/src/Raven.Studio/wwwroot/App/views/database/tasks/ongoingTasks.html
+++ b/src/Raven.Studio/wwwroot/App/views/database/tasks/ongoingTasks.html
@@ -588,7 +588,8 @@
 </script>
 
 <script type="text/html" id="responsible-node-template">
-    <div data-bind="with: responsibleNode().NodeTag, visible: !usingNotPreferredNode()" title="Cluster node that is responsible for this task">
+    <div data-bind="with: responsibleNode().NodeTag, visible: !usingNotPreferredNode(),
+                    attr: { title: taskType() === 'PullReplicationAsHub' ? 'Hub node that is serving this Sink task' : 'Cluster node that is responsible for this task' }">
         <i class="icon-cluster-node"></i>
         <span data-bind="text: $data"></span>
     </div>


### PR DESCRIPTION
### Issue link
https://issues.hibernatingrhinos.com/issue/RavenDB-17125

### Additional description
Better explain the responsible node tooltip.
The current general statement about the responsible node for the task is not accurate for the connected Sinks showing under the Hub

### Type of change
- Bug fix

### How risky is the change?
- Low 

### Backward compatibility
- Non breaking change

### Is it platform specific issue?
- No

### Documentation update
- No documentation update is needed 

### Testing 

- It has been verified by manual testing

### Is there any existing behavior change of other features due to this change?
- No

### UI work
- No UI work is needed
