### PR TITLE
RavenDB-17170 : fix flaky test

### DIFF
--- a/test/SlowTests/Server/Documents/ETL/EtlTestBase.cs
+++ b/test/SlowTests/Server/Documents/ETL/EtlTestBase.cs
@@ -8,7 +8,6 @@ using Raven.Client.Documents;
 using Raven.Client.Documents.Operations.ConnectionStrings;
 using Raven.Client.Documents.Operations.ETL;
 using Raven.Client.Documents.Operations.OngoingTasks;
-using Raven.Client.Util;
 using Raven.Server.Documents.ETL;
 using Raven.Server.NotificationCenter;
 using Sparrow.Json;

--- a/test/SlowTests/Server/Documents/ETL/EtlTimeSeriesTests.cs
+++ b/test/SlowTests/Server/Documents/ETL/EtlTimeSeriesTests.cs
@@ -1629,50 +1629,65 @@ function loadTimeSeriesOfUsersBehavior(doc, ts)
 
             var timeSeriesEntriesToAppend = timeSeriesEntries.ToList();
 
-            var (src, dest, _) = CreateSrcDestAndAddEtl(collections, script, collections.Length == 0, srcOptions: _options);
-
-            using (var session = src.OpenAsyncSession())
+            using (var src = GetDocumentStore(_options))
+            using (var dest = GetDocumentStore())
             {
-                var entity = new User { Name = "Joe Doe" };
-                await session.StoreAsync(entity, documentId);
-                await session.SaveChangesAsync();
-            }
-
-            random = new Random(0);
-            var j = 0;
-            while (timeSeriesEntriesToAppend.Count > 0)
-            {
-                using var session = src.OpenAsyncSession();
-
-                while (timeSeriesEntriesToAppend.Count > 0)
+                using (var session = src.OpenAsyncSession())
                 {
-                    int index = random.Next(0, timeSeriesEntriesToAppend.Count - 1);
-                    var entry = timeSeriesEntriesToAppend[index];
-                    session.TimeSeriesFor(documentId, timeSeriesName).Append(entry.Timestamp, entry.Values, entry.Tag);
-                    timeSeriesEntriesToAppend.RemoveAt(index);
-                    if (j++ % (toAppendCount / 10) == 0)
-                        break;
+                    var entity = new User { Name = "Joe Doe" };
+                    await session.StoreAsync(entity, documentId);
+                    await session.SaveChangesAsync();
                 }
 
-                await session.SaveChangesAsync();
-            }
+                random = new Random(0);
+                var j = 0;
+                while (timeSeriesEntriesToAppend.Count > 0)
+                {
+                    using var session = src.OpenAsyncSession();
 
-            TimeSeriesEntry[] actual = null;
-            await AssertWaitForValueAsync(async () =>
-            {
-                using IAsyncDocumentSession session = dest.OpenAsyncSession();
-                var result = await session.TimeSeriesFor(documentId, timeSeriesName).GetAsync(DateTime.MinValue, DateTime.MaxValue);
-                if (result == null)
-                    return 0;
-                actual = result.ToArray();
-                return actual.Count();
-            }, timeSeriesEntries.Length, interval: 1000);
+                    while (timeSeriesEntriesToAppend.Count > 0)
+                    {
+                        int index = random.Next(0, timeSeriesEntriesToAppend.Count - 1);
+                        var entry = timeSeriesEntriesToAppend[index];
+                        session.TimeSeriesFor(documentId, timeSeriesName).Append(entry.Timestamp, entry.Values, entry.Tag);
+                        timeSeriesEntriesToAppend.RemoveAt(index);
+                        if (j++ % (toAppendCount / 10) == 0)
+                            break;
+                    }
 
-            for (int i = 0; i < timeSeriesEntries.Length; i++)
-            {
-                Assert.Equal(timeSeriesEntries[i].Timestamp, actual[i].Timestamp);
-                Assert.Equal(timeSeriesEntries[i].Tag, actual[i].Tag);
-                Assert.Equal(timeSeriesEntries[i].Value, actual[i].Value);
+                    await session.SaveChangesAsync();
+                }
+
+                var db = await GetDocumentDatabaseInstanceFor(src);
+                long lastEtag;
+                using (db.DocumentsStorage.ContextPool.AllocateOperationContext(out DocumentsOperationContext context))
+                using (context.OpenReadTransaction())
+                {
+                    lastEtag = db.DocumentsStorage.TimeSeriesStorage.GetLastTimeSeriesEtag(context);
+                }
+
+                var etlDone = WaitForEtl(src, (_, statistics) => statistics.LastProcessedEtag >= lastEtag);
+                AddEtl(src, dest, collections, script, applyToAllDocuments : collections.Length == 0);
+                
+                Assert.True(etlDone.Wait(TimeSpan.FromSeconds(30)));
+
+                TimeSeriesEntry[] actual = null;
+                await AssertWaitForValueAsync(async () =>
+                {
+                    using IAsyncDocumentSession session = dest.OpenAsyncSession();
+                    var result = await session.TimeSeriesFor(documentId, timeSeriesName).GetAsync(DateTime.MinValue, DateTime.MaxValue);
+                    if (result == null)
+                        return 0;
+                    actual = result.ToArray();
+                    return actual.Count();
+                }, timeSeriesEntries.Length, interval: 1000);
+
+                for (int i = 0; i < timeSeriesEntries.Length; i++)
+                {
+                    Assert.Equal(timeSeriesEntries[i].Timestamp, actual[i].Timestamp);
+                    Assert.Equal(timeSeriesEntries[i].Tag, actual[i].Tag);
+                    Assert.Equal(timeSeriesEntries[i].Value, actual[i].Value);
+                }
             }
         }
 


### PR DESCRIPTION
### Issue link

https://issues.hibernatingrhinos.com/issue/RavenDB-17170

### Additional description
- Fix flaky test `RavenEtlWithTimeSeries_WhenStoreDocumentAndMultipleSegmentOfTimeSeriesInAnotherSession_ShouldDestBeAsSrc`
- The test was failing on asserting number of timeseries entries in destination (`expected: 131068, Actual: 117955`) so I'm guessing ETL didn't finish processing all these items within the default timeout (15 sec) 
-  Changed the test to wait for ETL to finish processing all items before asserting in destination 