### PR TITLE
RavenDB-17547 Add button to refresh database stats in Studio

### DIFF
--- a/src/Raven.Studio/typescript/viewmodels/database/status/statistics.ts
+++ b/src/Raven.Studio/typescript/viewmodels/database/status/statistics.ts
@@ -121,6 +121,10 @@ class statistics extends viewModelBase {
         const view = new indexStalenessReasons(this.activeDatabase(), indexName);
         app.showBootstrapDialog(view);
     }
+
+    refreshStats() {
+        this.fetchStats();
+    }
 }
 
 export = statistics;

--- a/src/Raven.Studio/wwwroot/App/views/database/status/statistics.html
+++ b/src/Raven.Studio/wwwroot/App/views/database/status/statistics.html
@@ -1,6 +1,9 @@
 <section data-bind="if: stats" class="stats content-margin">
     <h2 class="on-base-background">General Database Stats
         <a target="_blank" href="#" title="Show raw output" data-bind="attr: { href: rawJsonUrl }"><i class="icon-link"></i></a>
+        <button class="btn btn-primary pull-right" data-bind="click: refreshStats" title="Click to refresh stats">
+            <i class="icon-refresh"></i><span>Refresh</span>
+        </button>
     </h2>
     <hr />
     <div id="storage-report" title="Base path for database data files">


### PR DESCRIPTION
### Issue link
https://issues.hibernatingrhinos.com/issue/RavenDB-17547

### Additional description
Added refresh button to stats view

### Type of change
- Task

### How risky is the change?
- Low 

### Backward compatibility
- Non breaking change

### Is it platform specific issue?
- No

### Documentation update
- No documentation update is needed 

### Testing 
- It has been verified by manual testing

### Is there any existing behavior change of other features due to this change?
- No

### UI work
- No UI work is needed
