### PR TITLE
RavenDB-17580 fix various issues in streaming

### DIFF
--- a/src/Raven.Server/Documents/CollectionRunner.cs
+++ b/src/Raven.Server/Documents/CollectionRunner.cs
@@ -1,6 +1,7 @@
 ﻿using System;
 using System.Collections.Generic;
 using System.Diagnostics;
+using System.Threading;
 using System.Threading.Tasks;
 using Raven.Client;
 using Raven.Client.Documents.Operations;
@@ -87,7 +88,7 @@ namespace Raven.Server.Documents
 
                     using (context.OpenReadTransaction())
                     {
-                        foreach (var document in GetDocuments(context, collectionName, startEtag, startAfterId, alreadySeenIdsCount, OperationBatchSize, isAllDocs, DocumentFields.Id, out bool isStartsWithOrIdQuery))
+                        foreach (var document in GetDocuments(context, collectionName, startEtag, startAfterId, alreadySeenIdsCount, OperationBatchSize, isAllDocs, DocumentFields.Id, out bool isStartsWithOrIdQuery, token.Token))
                         {
                             using (document)
                             {
@@ -159,7 +160,7 @@ namespace Raven.Server.Documents
             };
         }
 
-        protected IEnumerable<Document> GetDocuments(DocumentsOperationContext context, string collectionName, long startEtag, string startAfterId, Reference<long> alreadySeenIdsCount, int batchSize, bool isAllDocs, DocumentFields fields, out bool isStartsWithOrIdQuery)
+        protected IEnumerable<Document> GetDocuments(DocumentsOperationContext context, string collectionName, long startEtag, string startAfterId, Reference<long> alreadySeenIdsCount, int batchSize, bool isAllDocs, DocumentFields fields, out bool isStartsWithOrIdQuery, CancellationToken token)
         {
             if (_collectionQuery != null && _collectionQuery.Metadata.WhereFields.Count > 0)
             {
@@ -169,7 +170,7 @@ namespace Raven.Server.Documents
                 isStartsWithOrIdQuery = true;
 
                 return new CollectionQueryEnumerable(Database, Database.DocumentsStorage, new FieldsToFetch(_operationQuery, null),
-                    collectionName, _operationQuery, null, context, null, null, null, new Reference<int>())
+                    collectionName, _operationQuery, null, context, null, null, null, new Reference<int>(), token)
                 {
                     Fields = fields,
                     StartAfterId = startAfterId,

--- a/src/Raven.Server/Documents/Indexes/Persistence/Lucene/IndexQueryingScope.cs
+++ b/src/Raven.Server/Documents/Indexes/Persistence/Lucene/IndexQueryingScope.cs
@@ -1,6 +1,6 @@
 using System;
 using System.Collections.Generic;
-
+using System.Threading;
 using Lucene.Net.Search;
 using Lucene.Net.Store;
 using Raven.Client;
@@ -49,7 +49,7 @@ namespace Raven.Server.Documents.Indexes.Persistence.Lucene
         {
         }
 
-        public void RecordAlreadyPagedItemsInPreviousPage(TopDocs search)
+        public void RecordAlreadyPagedItemsInPreviousPage(TopDocs search, CancellationToken token)
         {
             if (_query.Start == 0)
                 return;
@@ -94,7 +94,7 @@ namespace Raven.Server.Documents.Indexes.Persistence.Lucene
             for (; _alreadyScannedForDuplicates < _query.Start; _alreadyScannedForDuplicates++)
             {
                 var scoreDoc = search.ScoreDocs[_alreadyScannedForDuplicates];
-                var document = _retriever.Get(_searcher.Doc(scoreDoc.Doc, _state), scoreDoc, _state);
+                var document = _retriever.Get(_searcher.Doc(scoreDoc.Doc, _state), scoreDoc, _state, token);
 
                 if (document.Data.Count > 0) // we don't consider empty projections to be relevant for distinct operations
                     _alreadySeenProjections.Add(document.DataHash);

--- a/src/Raven.Server/Documents/Indexes/Persistence/Lucene/IndexReadOperation.cs
+++ b/src/Raven.Server/Documents/Indexes/Persistence/Lucene/IndexReadOperation.cs
@@ -137,7 +137,7 @@ namespace Raven.Server.Documents.Indexes.Persistence.Lucene
 
                     totalResults.Value = search.TotalHits;
 
-                    scope.RecordAlreadyPagedItemsInPreviousPage(search);
+                    scope.RecordAlreadyPagedItemsInPreviousPage(search, token);
 
                     for (; position < search.ScoreDocs.Length && pageSize > 0; position++)
                     {
@@ -155,7 +155,7 @@ namespace Raven.Server.Documents.Indexes.Persistence.Lucene
                             continue;
                         }
 
-                        var result = retriever.Get(document, scoreDoc, _state);
+                        var result = retriever.Get(document, scoreDoc, _state, token);
                         if (scope.TryIncludeInResults(result) == false)
                         {
                             result?.Dispose();
@@ -403,7 +403,7 @@ namespace Raven.Server.Documents.Indexes.Persistence.Lucene
                         continue;
                     }
 
-                    var result = retriever.Get(document, new ScoreDoc(indexResult.LuceneId, indexResult.Score), _state);
+                    var result = retriever.Get(document, new ScoreDoc(indexResult.LuceneId, indexResult.Score), _state, token);
                     if (scope.TryIncludeInResults(result) == false)
                     {
                         result?.Dispose();
@@ -786,7 +786,7 @@ namespace Raven.Server.Documents.Indexes.Persistence.Lucene
 
                 yield return new QueryResult
                 {
-                    Result = retriever.Get(doc, hit, _state)
+                    Result = retriever.Get(doc, hit, _state, token)
                 };
             }
         }

--- a/src/Raven.Server/Documents/Patch/ScriptRunner.cs
+++ b/src/Raven.Server/Documents/Patch/ScriptRunner.cs
@@ -1368,7 +1368,8 @@ namespace Raven.Server.Documents.Patch
 
                 var queryParams = ((Document)tsFunctionArgs[^1]).Data;
 
-                var retriever = new TimeSeriesRetriever(_docsCtx, queryParams, null);
+                //TODO: properly pass cancellation token
+                var retriever = new TimeSeriesRetriever(_docsCtx, queryParams, null, token: default);
 
                 var streamableResults = retriever.InvokeTimeSeriesFunction(func, docId, tsFunctionArgs, out var type);
                 var result = retriever.MaterializeResults(streamableResults, type, addProjectionToResult: false, fromStudio: false);

--- a/src/Raven.Server/Documents/Queries/Dynamic/CollectionQueryRunner.cs
+++ b/src/Raven.Server/Documents/Queries/Dynamic/CollectionQueryRunner.cs
@@ -113,7 +113,7 @@ namespace Raven.Server.Documents.Queries.Dynamic
             throw new NotSupportedException("Collection query is handled directly by documents storage so suggestions aren't supported");
         }
 
-        private async ValueTask ExecuteCollectionQueryAsync(QueryResultServerSide<Document> resultToFill, IndexQueryServerSide query, string collection, QueryOperationContext context, bool pulseReadingTransaction, CancellationToken cancellationToken)
+        private async ValueTask ExecuteCollectionQueryAsync(QueryResultServerSide<Document> resultToFill, IndexQueryServerSide query, string collection, QueryOperationContext context, bool pulseReadingTransaction, CancellationToken token)
         {
             using (var queryScope = query.Timings?.For(nameof(QueryTimingsScope.Names.Query)))
             {
@@ -145,7 +145,7 @@ namespace Raven.Server.Documents.Queries.Dynamic
 
                 if (pulseReadingTransaction == false)
                 {
-                    var documents = new CollectionQueryEnumerable(Database, Database.DocumentsStorage, fieldsToFetch, collection, query, queryScope, context.Documents, includeDocumentsCommand, includeRevisionsCommand: includeRevisionsCommand, includeCompareExchangeValuesCommand, totalResults);
+                    var documents = new CollectionQueryEnumerable(Database, Database.DocumentsStorage, fieldsToFetch, collection, query, queryScope, context.Documents, includeDocumentsCommand, includeRevisionsCommand: includeRevisionsCommand, includeCompareExchangeValuesCommand: includeCompareExchangeValuesCommand, totalResults: totalResults, token);
                     
                     documents.SkippedResults = skippedResults;
                     enumerator = documents.GetEnumerator();
@@ -157,7 +157,7 @@ namespace Raven.Server.Documents.Queries.Dynamic
                         {
                             query.Start = state.Start;
                             query.PageSize = state.Take;
-                            var documents = new CollectionQueryEnumerable(Database, Database.DocumentsStorage, fieldsToFetch, collection, query, queryScope, context.Documents, includeDocumentsCommand, includeRevisionsCommand, includeCompareExchangeValuesCommand, totalResults);
+                            var documents = new CollectionQueryEnumerable(Database, Database.DocumentsStorage, fieldsToFetch, collection, query, queryScope, context.Documents, includeDocumentsCommand, includeRevisionsCommand, includeCompareExchangeValuesCommand, totalResults, token);
 
                             return documents;
                         },
@@ -202,9 +202,9 @@ namespace Raven.Server.Documents.Queries.Dynamic
                         {
                             var document = enumerator.Current;
 
-                            cancellationToken.ThrowIfCancellationRequested();
+                            token.ThrowIfCancellationRequested();
 
-                            await resultToFill.AddResultAsync(document, cancellationToken);
+                            await resultToFill.AddResultAsync(document, token);
 
                             using (gatherScope?.Start())
                             {
@@ -226,7 +226,7 @@ namespace Raven.Server.Documents.Queries.Dynamic
                     if (resultToFill.SupportsExceptionHandling == false)
                         throw;
 
-                    await resultToFill.HandleExceptionAsync(e, cancellationToken);
+                    await resultToFill.HandleExceptionAsync(e, token);
                 }
 
                 using (fillScope?.Start())

--- a/src/Raven.Server/Documents/Queries/GraphQueryRunner.cs
+++ b/src/Raven.Server/Documents/Queries/GraphQueryRunner.cs
@@ -168,7 +168,7 @@ namespace Raven.Server.Documents.Queries
                             if (match.Empty)
                                 continue;
 
-                            var result = resultRetriever.ProjectFromMatch(match, queryContext.Documents);
+                            var result = resultRetriever.ProjectFromMatch(match, queryContext.Documents, token.Token);
                             // ReSharper disable once PossibleNullReferenceException
                             if (q.IsDistinct && alreadySeenProjections.Add(result.DataHash) == false)
                                 continue;

--- a/src/Raven.Server/Documents/Queries/IndexQueryServerSide.cs
+++ b/src/Raven.Server/Documents/Queries/IndexQueryServerSide.cs
@@ -2,6 +2,7 @@
 using System.Collections.Generic;
 using System.IO;
 using System.Text;
+using System.Threading;
 using System.Threading.Tasks;
 using Microsoft.AspNetCore.Http;
 using Raven.Client;
@@ -34,6 +35,9 @@ namespace Raven.Server.Documents.Queries
 
         [JsonDeserializationIgnore]
         public SpatialDistanceFieldComparatorSource.SpatialDistanceFieldComparator Distances;
+
+        [JsonDeserializationIgnore]
+        public CancellationToken Token;
 
         public new int Start
         {

--- a/src/Raven.Server/Documents/Queries/IndexQueryServerSide.cs
+++ b/src/Raven.Server/Documents/Queries/IndexQueryServerSide.cs
@@ -36,9 +36,6 @@ namespace Raven.Server.Documents.Queries
         [JsonDeserializationIgnore]
         public SpatialDistanceFieldComparatorSource.SpatialDistanceFieldComparator Distances;
 
-        [JsonDeserializationIgnore]
-        public CancellationToken Token;
-
         public new int Start
         {
 #pragma warning disable 618

--- a/src/Raven.Server/Documents/Queries/QueryRunner.cs
+++ b/src/Raven.Server/Documents/Queries/QueryRunner.cs
@@ -456,8 +456,6 @@ namespace Raven.Server.Documents.Queries
 
             _currentlyRunningQueries.TryAdd(executingQueryInfo);
             
-            query.Token = token.Token;
-
             return new QueryMarker(this, executingQueryInfo);
         }
 

--- a/src/Raven.Server/Documents/Queries/QueryRunner.cs
+++ b/src/Raven.Server/Documents/Queries/QueryRunner.cs
@@ -455,6 +455,8 @@ namespace Raven.Server.Documents.Queries
             var executingQueryInfo = new ExecutingQueryInfo(queryStartTime, name, query, queryId, isStreaming, token);
 
             _currentlyRunningQueries.TryAdd(executingQueryInfo);
+            
+            query.Token = token.Token;
 
             return new QueryMarker(this, executingQueryInfo);
         }

--- a/src/Raven.Server/Documents/Queries/Results/GraphQueryResultRetriever.cs
+++ b/src/Raven.Server/Documents/Queries/Results/GraphQueryResultRetriever.cs
@@ -1,6 +1,7 @@
 ﻿using System;
 using System.Collections.Generic;
 using System.Linq;
+using System.Threading;
 using Lucene.Net.Store;
 using Raven.Client;
 using Raven.Client.Documents.Queries;
@@ -45,7 +46,7 @@ namespace Raven.Server.Documents.Queries.Results
             throw new InvalidQueryException($"Invalid projection behavior '{_query.ProjectionBehavior}'.Only default projection behavior can be used for graph queries.", _query.Query, _query.QueryParameters);
         }
 
-        public override Document Get(Lucene.Net.Documents.Document input, Lucene.Net.Search.ScoreDoc scoreDoc, IState state)
+        public override Document Get(Lucene.Net.Documents.Document input, Lucene.Net.Search.ScoreDoc scoreDoc, IState state, CancellationToken token)
         {
             throw new NotSupportedException("Graph Queries do not deal with Lucene indexes.");
         }
@@ -69,7 +70,7 @@ namespace Raven.Server.Documents.Queries.Results
             throw new NotSupportedException("Graph Queries do not deal with Counters.");
         }
 
-        internal Document ProjectFromMatch(Match match, JsonOperationContext context)
+        internal Document ProjectFromMatch(Match match, JsonOperationContext context, CancellationToken token)
         {
             var result = new DynamicJsonValue();
             result[Constants.Documents.Metadata.Key] = new DynamicJsonValue
@@ -122,7 +123,7 @@ namespace Raven.Server.Documents.Queries.Results
                     }
 
                     key = fieldToFetch.ProjectedName ?? (fieldToFetch.ProjectedName ?? fieldToFetch.Name.Value);
-                    fieldVal = GetFunctionValue(fieldToFetch, null, args);
+                    fieldVal = GetFunctionValue(fieldToFetch, null, args, token);
 
                     var immediateResult = AddProjectionToResult(item, OneScore, FieldsToFetch, result, key, fieldVal);
                     if (immediateResult != null)
@@ -136,7 +137,7 @@ namespace Raven.Server.Documents.Queries.Results
                     {
                         case Document d:
                             {
-                                if (TryGetValue(fieldToFetch, d, null, null, null, null, out key, out fieldVal) == false)
+                                if (TryGetValue(fieldToFetch, d, null, null, null, null, out key, out fieldVal, token) == false)
                                     continue;
                                 d.EnsureMetadata();
                                 var immediateResult = AddProjectionToResult(d, OneScore, FieldsToFetch, result, key, fieldVal);
@@ -147,7 +148,7 @@ namespace Raven.Server.Documents.Queries.Results
                         case BlittableJsonReaderObject bjro:
                             {
                                 var doc = new Document { Data = bjro };
-                                if (TryGetValue(fieldToFetch, doc, null, null, null, null, out key, out fieldVal) == false)
+                                if (TryGetValue(fieldToFetch, doc, null, null, null, null, out key, out fieldVal, token) == false)
                                     continue;
                                 doc.EnsureMetadata();
                                 var immediateResult = AddProjectionToResult(doc, OneScore, FieldsToFetch, result, key, fieldVal);
@@ -169,7 +170,7 @@ namespace Raven.Server.Documents.Queries.Results
 
                                 var doc = new Document { Data = matchJson };
 
-                                if (TryGetValue(fieldToFetch, doc, null, null, null, null, out key, out fieldVal) == false)
+                                if (TryGetValue(fieldToFetch, doc, null, null, null, null, out key, out fieldVal, token) == false)
                                     continue;
                                 doc.EnsureMetadata();
                                 if (ReferenceEquals(doc, fieldVal))

--- a/src/Raven.Server/Documents/Queries/Results/IQueryResultRetriever.cs
+++ b/src/Raven.Server/Documents/Queries/Results/IQueryResultRetriever.cs
@@ -1,4 +1,5 @@
-﻿using Lucene.Net.Search;
+﻿using System.Threading;
+using Lucene.Net.Search;
 using Lucene.Net.Store;
 using Raven.Server.Documents.Indexes.Static.Spatial;
 
@@ -6,7 +7,7 @@ namespace Raven.Server.Documents.Queries.Results
 {
     public interface IQueryResultRetriever
     {
-        Document Get(Lucene.Net.Documents.Document input, ScoreDoc lucene, IState state);
+        Document Get(Lucene.Net.Documents.Document input, ScoreDoc lucene, IState state, CancellationToken token);
 
         bool TryGetKey(Lucene.Net.Documents.Document document, IState state, out string key);
     }

--- a/src/Raven.Server/Documents/Queries/Results/MapQueryResultRetriever.cs
+++ b/src/Raven.Server/Documents/Queries/Results/MapQueryResultRetriever.cs
@@ -1,4 +1,5 @@
 ﻿using System;
+using System.Threading;
 using Lucene.Net.Store;
 using Raven.Client;
 using Raven.Server.Documents.Includes;
@@ -20,7 +21,7 @@ namespace Raven.Server.Documents.Queries.Results
             _context = context;
         }
 
-        public override Document Get(Lucene.Net.Documents.Document input, Lucene.Net.Search.ScoreDoc scoreDoc, IState state)
+        public override Document Get(Lucene.Net.Documents.Document input, Lucene.Net.Search.ScoreDoc scoreDoc, IState state, CancellationToken token)
         {
             using (RetrieverScope?.Start())
             {
@@ -28,7 +29,7 @@ namespace Raven.Server.Documents.Queries.Results
                     throw new InvalidOperationException($"Could not extract '{Constants.Documents.Indexing.Fields.DocumentIdFieldName}' from index.");
 
                 if (FieldsToFetch.IsProjection)
-                    return GetProjection(input, scoreDoc, id, state);
+                    return GetProjection(input, scoreDoc, id, state, token);
 
                 using (_storageScope = _storageScope?.Start() ?? RetrieverScope?.For(nameof(QueryTimingsScope.Names.Storage)))
                 {

--- a/src/Raven.Server/Documents/Queries/Results/MapReduceQueryResultRetriever.cs
+++ b/src/Raven.Server/Documents/Queries/Results/MapReduceQueryResultRetriever.cs
@@ -1,4 +1,5 @@
 ﻿using System;
+using System.Threading;
 using Lucene.Net.Search;
 using Lucene.Net.Store;
 using Raven.Client;
@@ -92,10 +93,10 @@ namespace Raven.Server.Documents.Queries.Results
             };
         }
 
-        public override Document Get(Lucene.Net.Documents.Document input, ScoreDoc scoreDoc, IState state)
+        public override Document Get(Lucene.Net.Documents.Document input, ScoreDoc scoreDoc, IState state, CancellationToken token)
         {
             if (FieldsToFetch.IsProjection)
-                return GetProjection(input, scoreDoc, null, state);
+                return GetProjection(input, scoreDoc, null, state, token);
 
             using (_storageScope = _storageScope?.Start() ?? RetrieverScope?.For(nameof(QueryTimingsScope.Names.Storage)))
             {

--- a/src/Raven.Server/Documents/Queries/Results/QueryResultRetrieverBase.cs
+++ b/src/Raven.Server/Documents/Queries/Results/QueryResultRetrieverBase.cs
@@ -1,6 +1,7 @@
 ﻿using System;
 using System.Collections.Generic;
 using System.Linq;
+using System.Threading;
 using Jint.Native;
 using Jint.Native.Object;
 using Jint.Runtime;
@@ -102,7 +103,7 @@ namespace Raven.Server.Documents.Queries.Results
             }
         }
 
-        public abstract Document Get(Lucene.Net.Documents.Document input, Lucene.Net.Search.ScoreDoc scoreDoc, IState state);
+        public abstract Document Get(Lucene.Net.Documents.Document input, Lucene.Net.Search.ScoreDoc scoreDoc, IState state, CancellationToken token);
 
         public abstract bool TryGetKey(Lucene.Net.Documents.Document document, IState state, out string key);
 
@@ -114,7 +115,7 @@ namespace Raven.Server.Documents.Queries.Results
 
         protected abstract DynamicJsonValue GetCounterRaw(string docId, string name);
 
-        protected Document GetProjection(Lucene.Net.Documents.Document input, Lucene.Net.Search.ScoreDoc scoreDoc, string lowerId, IState state)
+        protected Document GetProjection(Lucene.Net.Documents.Document input, Lucene.Net.Search.ScoreDoc scoreDoc, string lowerId, IState state, CancellationToken token)
         {
             using (_projectionScope = _projectionScope?.Start() ?? RetrieverScope?.For(nameof(QueryTimingsScope.Names.Projection)))
             {
@@ -135,7 +136,7 @@ namespace Raven.Server.Documents.Queries.Results
                         return null;
                     }
 
-                    return GetProjectionFromDocumentInternal(doc, input, scoreDoc, FieldsToFetch, _context, state);
+                    return GetProjectionFromDocumentInternal(doc, input, scoreDoc, FieldsToFetch, _context, state, token);
                 }
 
                 var result = new DynamicJsonValue();
@@ -200,7 +201,7 @@ namespace Raven.Server.Documents.Queries.Results
                         }
                     }
 
-                    if (TryGetValue(fieldToFetch, doc, input, state, FieldsToFetch.IndexFields, FieldsToFetch.AnyDynamicIndexFields, out var key, out var fieldVal))
+                    if (TryGetValue(fieldToFetch, doc, input, state, FieldsToFetch.IndexFields, FieldsToFetch.AnyDynamicIndexFields, out var key, out var fieldVal, token))
                     {
                         if (FieldsToFetch.SingleBodyOrMethodWithNoAlias)
                         {
@@ -245,22 +246,22 @@ namespace Raven.Server.Documents.Queries.Results
             }
         }
 
-        public Document GetProjectionFromDocument(Document doc, Lucene.Net.Documents.Document luceneDoc, Lucene.Net.Search.ScoreDoc scoreDoc, FieldsToFetch fieldsToFetch, JsonOperationContext context, IState state)
+        public Document GetProjectionFromDocument(Document doc, Lucene.Net.Documents.Document luceneDoc, Lucene.Net.Search.ScoreDoc scoreDoc, FieldsToFetch fieldsToFetch, JsonOperationContext context, IState state, CancellationToken token)
         {
             using (RetrieverScope?.Start())
             using (_projectionScope = _projectionScope?.Start() ?? RetrieverScope?.For(nameof(QueryTimingsScope.Names.Projection)))
             {
-                return GetProjectionFromDocumentInternal(doc, luceneDoc, scoreDoc, fieldsToFetch, context, state);
+                return GetProjectionFromDocumentInternal(doc, luceneDoc, scoreDoc, fieldsToFetch, context, state, token);
             }
         }
 
-        private Document GetProjectionFromDocumentInternal(Document doc, Lucene.Net.Documents.Document luceneDoc, Lucene.Net.Search.ScoreDoc scoreDoc, FieldsToFetch fieldsToFetch, JsonOperationContext context, IState state)
+        private Document GetProjectionFromDocumentInternal(Document doc, Lucene.Net.Documents.Document luceneDoc, Lucene.Net.Search.ScoreDoc scoreDoc, FieldsToFetch fieldsToFetch, JsonOperationContext context, IState state, CancellationToken token)
         {
             var result = new DynamicJsonValue();
 
             foreach (var fieldToFetch in fieldsToFetch.Fields.Values)
             {
-                if (TryGetValue(fieldToFetch, doc, luceneDoc, state, fieldsToFetch.IndexFields, fieldsToFetch.AnyDynamicIndexFields, out var key, out var fieldVal) == false)
+                if (TryGetValue(fieldToFetch, doc, luceneDoc, state, fieldsToFetch.IndexFields, fieldsToFetch.AnyDynamicIndexFields, out var key, out var fieldVal, token) == false)
                 {
                     if (FieldsToFetch.Projection.MustExtractFromDocument)
                     {
@@ -524,7 +525,7 @@ namespace Raven.Server.Documents.Queries.Results
             throw new NotSupportedException("Cannot convert binary values");
         }
 
-        protected bool TryGetValue(FieldsToFetch.FieldToFetch fieldToFetch, Document document, Lucene.Net.Documents.Document luceneDoc, IState state, Dictionary<string, IndexField> indexFields, bool? anyDynamicIndexFields, out string key, out object value)
+        protected bool TryGetValue(FieldsToFetch.FieldToFetch fieldToFetch, Document document, Lucene.Net.Documents.Document luceneDoc, IState state, Dictionary<string, IndexField> indexFields, bool? anyDynamicIndexFields, out string key, out object value, CancellationToken token)
         {
             key = fieldToFetch.ProjectedName ?? fieldToFetch.Name.Value;
 
@@ -538,13 +539,13 @@ namespace Raven.Server.Documents.Queries.Results
                 var args = new object[fieldToFetch.QueryField.FunctionArgs.Length + 1];
                 for (int i = 0; i < fieldToFetch.FunctionArgs.Length; i++)
                 {
-                    TryGetValue(fieldToFetch.FunctionArgs[i], document, luceneDoc, state, indexFields, anyDynamicIndexFields, out _, out args[i]);
+                    TryGetValue(fieldToFetch.FunctionArgs[i], document, luceneDoc, state, indexFields, anyDynamicIndexFields, out _, out args[i], token);
                     if (ReferenceEquals(args[i], document))
                     {
                         args[i] = Tuple.Create(document, luceneDoc, state, indexFields, anyDynamicIndexFields, FieldsToFetch.Projection);
                     }
                 }
-                value = GetFunctionValue(fieldToFetch, document.Id, args);
+                value = GetFunctionValue(fieldToFetch, document.Id, args, token);
                 return true;
             }
 
@@ -749,7 +750,7 @@ namespace Raven.Server.Documents.Queries.Results
             return false;
         }
 
-        protected object GetFunctionValue(FieldsToFetch.FieldToFetch fieldToFetch, string documentId, object[] args)
+        protected object GetFunctionValue(FieldsToFetch.FieldToFetch fieldToFetch, string documentId, object[] args, CancellationToken token)
         {
             using (_functionScope = _functionScope?.Start() ?? _projectionScope?.For(nameof(QueryTimingsScope.Names.JavaScript)))
             {
@@ -759,7 +760,8 @@ namespace Raven.Server.Documents.Queries.Results
                     _query.Metadata.Query,
                     documentId,
                     args,
-                    _functionScope);
+                    _functionScope,
+                    token);
 
                 return value;
             }
@@ -833,12 +835,12 @@ namespace Raven.Server.Documents.Queries.Results
             }
         }
 
-        private object InvokeFunction(string methodName, Query query, string documentId, object[] args, QueryTimingsScope timings)
+        private object InvokeFunction(string methodName, Query query, string documentId, object[] args, QueryTimingsScope timings, CancellationToken token)
         {
             if (TryGetTimeSeriesFunction(methodName, query, out var func))
             {
-                _timeSeriesRetriever ??= new TimeSeriesRetriever(_includeDocumentsCommand.Context, _query.QueryParameters, _loadedDocuments);
-                var result = _timeSeriesRetriever.InvokeTimeSeriesFunction(func, documentId, args, out var type, _query.Token);
+                _timeSeriesRetriever ??= new TimeSeriesRetriever(_includeDocumentsCommand.Context, _query.QueryParameters, _loadedDocuments, token);
+                var result = _timeSeriesRetriever.InvokeTimeSeriesFunction(func, documentId, args, out var type);
                 if (_query.IsStream)
                     return _timeSeriesRetriever.PrepareForStreaming(result, FieldsToFetch.SingleBodyOrMethodWithNoAlias, _query.AddTimeSeriesNames);
                 return _timeSeriesRetriever.MaterializeResults(result, type, FieldsToFetch.SingleBodyOrMethodWithNoAlias, _query.AddTimeSeriesNames);

--- a/src/Raven.Server/Documents/Queries/Results/QueryResultRetrieverBase.cs
+++ b/src/Raven.Server/Documents/Queries/Results/QueryResultRetrieverBase.cs
@@ -838,7 +838,7 @@ namespace Raven.Server.Documents.Queries.Results
             if (TryGetTimeSeriesFunction(methodName, query, out var func))
             {
                 _timeSeriesRetriever ??= new TimeSeriesRetriever(_includeDocumentsCommand.Context, _query.QueryParameters, _loadedDocuments);
-                var result = _timeSeriesRetriever.InvokeTimeSeriesFunction(func, documentId, args, out var type);
+                var result = _timeSeriesRetriever.InvokeTimeSeriesFunction(func, documentId, args, out var type, _query.Token);
                 if (_query.IsStream)
                     return _timeSeriesRetriever.PrepareForStreaming(result, FieldsToFetch.SingleBodyOrMethodWithNoAlias, _query.AddTimeSeriesNames);
                 return _timeSeriesRetriever.MaterializeResults(result, type, FieldsToFetch.SingleBodyOrMethodWithNoAlias, _query.AddTimeSeriesNames);

--- a/src/Raven.Server/Documents/Queries/Results/TimeSeries/TimeSeriesRetriever.cs
+++ b/src/Raven.Server/Documents/Queries/Results/TimeSeries/TimeSeriesRetriever.cs
@@ -32,6 +32,7 @@ namespace Raven.Server.Documents.Queries.Results.TimeSeries
         private readonly DocumentsOperationContext _context;
 
         private Dictionary<string, Document> _loadedDocuments;
+        private readonly CancellationToken _token;
 
         private Dictionary<LazyStringValue, object> _bucketByTag;
 
@@ -59,11 +60,13 @@ namespace Raven.Server.Documents.Queries.Results.TimeSeries
             [AggregationType.Average] = null
         };
 
-        public TimeSeriesRetriever(DocumentsOperationContext context, BlittableJsonReaderObject queryParameters, Dictionary<string, Document> loadedDocuments)
+        public TimeSeriesRetriever(DocumentsOperationContext context, BlittableJsonReaderObject queryParameters, Dictionary<string, Document> loadedDocuments,
+            CancellationToken token)
         {
             _context = context;
             _queryParameters = queryParameters;
             _loadedDocuments = loadedDocuments;
+            _token = token;
 
             _valuesDictionary = new Dictionary<ValueExpression, object>();
             _argumentValuesDictionary = new Dictionary<FieldExpression, object>();
@@ -76,7 +79,7 @@ namespace Raven.Server.Documents.Queries.Results.TimeSeries
             Aggregated
         }
 
-        public IEnumerable<DynamicJsonValue> InvokeTimeSeriesFunction(DeclaredFunction declaredFunction, string documentId, object[] args, out ResultType resultType, CancellationToken token = default)
+        public IEnumerable<DynamicJsonValue> InvokeTimeSeriesFunction(DeclaredFunction declaredFunction, string documentId, object[] args, out ResultType resultType)
         {
             var timeSeriesFunction = declaredFunction.TimeSeries;
             
@@ -109,8 +112,8 @@ namespace Raven.Server.Documents.Queries.Results.TimeSeries
             }
 
             ITimeSeriesReader reader = groupByTimePeriod == null
-                ? new TimeSeriesReader(_context, documentId, _source, from, to, offset, token)
-                : new TimeSeriesMultiReader(_context, documentId, _source, _collection, from, to, offset, rangeSpec.ToTimeValue(), token);
+                ? new TimeSeriesReader(_context, documentId, _source, from, to, offset, _token)
+                : new TimeSeriesMultiReader(_context, documentId, _source, _collection, from, to, offset, rangeSpec.ToTimeValue(), _token);
 
             _scale = GetScale(declaredFunction, timeSeriesFunction.Scale);
 

--- a/src/Raven.Server/Documents/Queries/Results/TimeSeries/TimeSeriesRetriever.cs
+++ b/src/Raven.Server/Documents/Queries/Results/TimeSeries/TimeSeriesRetriever.cs
@@ -3,6 +3,7 @@ using System.Collections;
 using System.Collections.Generic;
 using System.Globalization;
 using System.Linq;
+using System.Threading;
 using Lucene.Net.Store;
 using Raven.Client;
 using Raven.Client.Documents.Queries.TimeSeries;
@@ -75,7 +76,7 @@ namespace Raven.Server.Documents.Queries.Results.TimeSeries
             Aggregated
         }
 
-        public IEnumerable<DynamicJsonValue> InvokeTimeSeriesFunction(DeclaredFunction declaredFunction, string documentId, object[] args, out ResultType resultType)
+        public IEnumerable<DynamicJsonValue> InvokeTimeSeriesFunction(DeclaredFunction declaredFunction, string documentId, object[] args, out ResultType resultType, CancellationToken token = default)
         {
             var timeSeriesFunction = declaredFunction.TimeSeries;
             
@@ -107,9 +108,9 @@ namespace Raven.Server.Documents.Queries.Results.TimeSeries
                 rangeSpec.InitializeFullRange(from, to);
             }
 
-            var reader = groupByTimePeriod == null
-                ? new TimeSeriesReader(_context, documentId, _source, from, to, offset)
-                : new TimeSeriesMultiReader(_context, documentId, _source, _collection, from, to, offset, rangeSpec.ToTimeValue()) as ITimeSeriesReader;
+            ITimeSeriesReader reader = groupByTimePeriod == null
+                ? new TimeSeriesReader(_context, documentId, _source, from, to, offset, token)
+                : new TimeSeriesMultiReader(_context, documentId, _source, _collection, from, to, offset, rangeSpec.ToTimeValue(), token);
 
             _scale = GetScale(declaredFunction, timeSeriesFunction.Scale);
 

--- a/src/Raven.Server/Documents/TimeSeries/TimeSeriesReader.cs
+++ b/src/Raven.Server/Documents/TimeSeries/TimeSeriesReader.cs
@@ -457,7 +457,7 @@ namespace Raven.Server.Documents.TimeSeries
         public bool IsRaw => _reader.IsRaw;
 
         public TimeSeriesMultiReader(DocumentsOperationContext context, string documentId,
-            string source, string collection, DateTime from, DateTime to, TimeSpan? offset, TimeValue groupBy, CancellationToken token = default)
+            string source, string collection, DateTime from, DateTime to, TimeSpan? offset, TimeValue groupBy, CancellationToken token)
         {
             if (string.IsNullOrEmpty(source))
                 throw new ArgumentNullException(nameof(source));

--- a/src/Sparrow/Json/AbstractBlittableJsonTextWriter.cs
+++ b/src/Sparrow/Json/AbstractBlittableJsonTextWriter.cs
@@ -695,6 +695,7 @@ namespace Sparrow.Json
             try
             {
                 FlushInternal();
+                _stream.Flush(); // flush the underlying stream as well
             }
             catch (ObjectDisposedException)
             {

--- a/src/Sparrow/Json/AsyncBlittableJsonTextWriter.cs
+++ b/src/Sparrow/Json/AsyncBlittableJsonTextWriter.cs
@@ -47,6 +47,8 @@ namespace Sparrow.Json
         {
             DisposeInternal();
             await FlushAsync().ConfigureAwait(false);
+            await _outputStream.FlushAsync().ConfigureAwait(false); // flush the output stream underlying stream as well
+            
             _context.ReturnMemoryStream((MemoryStream)_stream);
         }
 

--- a/src/Sparrow/Json/AsyncBlittableJsonTextWriter.cs
+++ b/src/Sparrow/Json/AsyncBlittableJsonTextWriter.cs
@@ -46,9 +46,9 @@ namespace Sparrow.Json
         public async ValueTask DisposeAsync()
         {
             DisposeInternal();
-            await FlushAsync().ConfigureAwait(false);
-            await _outputStream.FlushAsync().ConfigureAwait(false); // flush the output stream underlying stream as well
-            
+            if (await FlushAsync().ConfigureAwait(false) > 0)
+                await _outputStream.FlushAsync().ConfigureAwait(false); // flush the output stream underlying stream as well
+
             _context.ReturnMemoryStream((MemoryStream)_stream);
         }
 


### PR DESCRIPTION
### Issue link

https://issues.hibernatingrhinos.com/issue/RavenDB-17580

### Additional description

This PR fix multiple issues:
1. Add the ability to cancel time-series stream/query, we pass a token to the time-series reader and throw if needed.
2. The `UnmanagedJsonParserHelper.ReadAsync` had and edge case of throwing when reading a single separator from stream at the beginning of the `MoveNextAsync`, the sync version `UnmanagedJsonParserHelper.Read` is correct.
3. `AsyncBlittableJsonTextWriter` didn't flush to the output stream upon disposal

### Type of change

- Bug fix

### How risky is the change?

- Moderate 

### Backward compatibility

- Not relevant

### Is it platform specific issue?

- No

### Documentation update

- No documentation update is needed 

### Testing 

- It has been verified by manual testing

I've tried to write some tests to it, but it was hard to simulate the exact conditions for the above issues.
It constantly throw when streaming from remote, but locally it has never failed.

### Is there any existing behavior change of other features due to this change?

- No

### UI work

- No UI work is needed
