### PR TITLE
RavenDB-17579: PutServerWideBackupConfigurationCommand should wait on IndexNotification not apply of index

### DIFF
--- a/src/Raven.Server/ServerWide/ServerStore.cs
+++ b/src/Raven.Server/ServerWide/ServerStore.cs
@@ -2824,7 +2824,7 @@ namespace Raven.Server.ServerWide
 
             var result = await SendToLeaderAsync(command);
 
-            await WaitForCommitIndexChange(RachisConsensus.CommitIndexModification.GreaterOrEqual, result.Index);
+            await Cluster.WaitForIndexNotification(result.Index);
         }
 
         public DatabaseTopology LoadDatabaseTopology(string databaseName)

--- a/src/Raven.Server/Web/System/AdminDatabasesHandler.cs
+++ b/src/Raven.Server/Web/System/AdminDatabasesHandler.cs
@@ -456,7 +456,7 @@ namespace Raven.Server.Web.System
                 };
 
                 var res = await ServerStore.SendToLeaderAsync(reorder);
-                await ServerStore.WaitForCommitIndexChange(RachisConsensus.CommitIndexModification.GreaterOrEqual, res.Index);
+                await ServerStore.Cluster.WaitForIndexNotification(res.Index);
 
                 NoContentStatus();
             }

--- a/src/Raven.Server/Web/System/AdminServerWideHandler.cs
+++ b/src/Raven.Server/Web/System/AdminServerWideHandler.cs
@@ -94,7 +94,7 @@ namespace Raven.Server.Web.System
                 ServerStore.LicenseManager.AssertCanAddExternalReplication(configuration.DelayReplicationFor);
 
                 var (newIndex, _) = await ServerStore.PutServerWideExternalReplicationAsync(configuration, GetRaftRequestIdFromQuery());
-                await ServerStore.WaitForCommitIndexChange(RachisConsensus.CommitIndexModification.GreaterOrEqual, newIndex);
+                await ServerStore.Cluster.WaitForIndexNotification(newIndex);
 
                 await using (var writer = new AsyncBlittableJsonTextWriter(context, ResponseBodyStream()))
                 using (context.OpenReadTransaction())
@@ -185,7 +185,7 @@ namespace Raven.Server.Web.System
                     Disable = disable
                 };
                 var (newIndex, _) = await ServerStore.ToggleServerWideTaskStateAsync(configuration, GetRaftRequestIdFromQuery());
-                await ServerStore.WaitForCommitIndexChange(RachisConsensus.CommitIndexModification.GreaterOrEqual, newIndex);
+                await ServerStore.Cluster.WaitForIndexNotification(newIndex);
 
                 await using (var writer = new AsyncBlittableJsonTextWriter(context, ResponseBodyStream()))
                 {
@@ -212,7 +212,7 @@ namespace Raven.Server.Web.System
                 };
 
                 var (newIndex, _) = await ServerStore.DeleteServerWideTaskAsync(deleteConfiguration, GetRaftRequestIdFromQuery());
-                await ServerStore.WaitForCommitIndexChange(RachisConsensus.CommitIndexModification.GreaterOrEqual, newIndex);
+                await ServerStore.Cluster.WaitForIndexNotification(newIndex);
 
                 await using (var writer = new AsyncBlittableJsonTextWriter(context, ResponseBodyStream()))
                 using (context.OpenReadTransaction())

--- a/src/Raven.Server/Web/System/AdminServerWideHandler.cs
+++ b/src/Raven.Server/Web/System/AdminServerWideHandler.cs
@@ -62,7 +62,7 @@ namespace Raven.Server.Web.System
                 BackupConfigurationHelper.AssertDestinationAndRegionAreAllowed(configuration, ServerStore);
 
                 var (newIndex, _) = await ServerStore.PutServerWideBackupConfigurationAsync(configuration, GetRaftRequestIdFromQuery());
-                await ServerStore.WaitForCommitIndexChange(RachisConsensus.CommitIndexModification.GreaterOrEqual, newIndex);
+                await ServerStore.Cluster.WaitForIndexNotification(newIndex);
 
                 await using (var writer = new AsyncBlittableJsonTextWriter(context, ResponseBodyStream()))
                 using (context.OpenReadTransaction())


### PR DESCRIPTION


### Issue link

https://issues.hibernatingrhinos.com/issue/RavenDB-17579

### Additional description

We were waiting on `CommitIndexChange` which is set after `CSM.Apply()` finish, instead we should `WaitWaitForIndexNotification` which is set after the changes propagate 

### Type of change

- Bug fix


### How risky is the change?

- Low 


### Backward compatibility

- Not relevant

### Is it platform specific issue?

- No

### Documentation update

- No documentation update is needed 

### Testing 

- Tests have been added that prove the fix is effective or that the feature works
- It has been verified by manual testing

### Is there any existing behavior change of other features due to this change?


- No

### UI work


- No UI work is needed
