### PR TITLE
RavenDB-17590

### DIFF
--- a/test/BenchmarkTests/Indexing/Index.cs
+++ b/test/BenchmarkTests/Indexing/Index.cs
@@ -215,7 +215,7 @@ namespace BenchmarkTests.Indexing
                 }
             }
 
-            WaitForIndexing(store, ReIndexDatabaseName, timeout: 2 * DefaultTestOperationTimeout);
+            WaitForIndexing(store, ReIndexDatabaseName, timeout: 3 * DefaultTestOperationTimeout);
 
             await store.Maintenance.ForDatabase(ReIndexDatabaseName).SendAsync(new StopIndexingOperation());
 

--- a/test/BenchmarkTests/Indexing/Index.cs
+++ b/test/BenchmarkTests/Indexing/Index.cs
@@ -215,7 +215,7 @@ namespace BenchmarkTests.Indexing
                 }
             }
 
-            WaitForIndexing(store, ReIndexDatabaseName, timeout: DefaultTestOperationTimeout);
+            WaitForIndexing(store, ReIndexDatabaseName, timeout: 2 * DefaultTestOperationTimeout);
 
             await store.Maintenance.ForDatabase(ReIndexDatabaseName).SendAsync(new StopIndexingOperation());
 


### PR DESCRIPTION
### Issue link

https://issues.hibernatingrhinos.com/issue/RavenDB-17590
### Additional description

Benchmark tests need more time to initialize when using encryption
