### PR TITLE
RavenDB-17548  Dump index via Studio

### DIFF
--- a/src/Raven.Studio/typescript/commands/database/index/dumpIndexCommand.ts
+++ b/src/Raven.Studio/typescript/commands/database/index/dumpIndexCommand.ts
@@ -1,0 +1,25 @@
+import commandBase = require("commands/commandBase");
+import database = require("models/resources/database");
+import endpoints = require("endpoints");
+
+class dumpIndexCommand extends commandBase {
+
+    constructor(private indexName: string, private db: database, private dumpDirectoryPath: string) {
+        super();
+    }
+
+    execute(): JQueryPromise<void> {
+        const args = {
+            name: this.indexName,
+            path: this.dumpDirectoryPath
+        };
+        
+        const url = endpoints.databases.adminIndex.adminIndexesDump + this.urlEncodeArgs(args);
+        
+        return this.post(url, null, this.db)
+            .done(() => this.reportSuccess(`Created dump files for index ${this.indexName}`))
+            .fail((response: JQueryXHR) => this.reportError("Failed to dump index files", response.responseText));
+    }
+}
+
+export = dumpIndexCommand; 

--- a/src/Raven.Studio/typescript/viewmodels/database/indexes/dumpDialog.ts
+++ b/src/Raven.Studio/typescript/viewmodels/database/indexes/dumpDialog.ts
@@ -1,0 +1,76 @@
+import dialog = require("plugins/dialog");
+import dialogViewModelBase = require("viewmodels/dialogViewModelBase");
+import dumpIndexCommand = require("commands/database/index/dumpIndexCommand");
+import getFolderPathOptionsCommand = require("commands/resources/getFolderPathOptionsCommand");
+
+class dumpDialog extends dialogViewModelBase {
+
+    indexName = ko.observable<string>();
+    
+    directoryPath = ko.observable<string>();
+    directoryPathOptions = ko.observableArray<string>([]);
+    directoryPathHasFocus = ko.observable<boolean>(false);
+    
+    validationGroup: KnockoutValidationGroup;
+    
+    constructor(indexName: string) {
+        super();
+
+        this.indexName(indexName);
+
+        _.bindAll(this, "directoryPathChanged");
+        this.updateDirectoryPathOptions(this.directoryPath());
+
+        this.initObservables();
+        this.initValidation();
+    }
+
+    private initObservables(): void {
+        this.directoryPath.throttle(300).subscribe(newPathValue => {
+            this.updateDirectoryPathOptions(newPathValue);
+        });
+    }
+
+    private initValidation(): void {
+        this.directoryPath.extend({
+            required: true
+        });
+
+        this.validationGroup = ko.validatedObservable({
+            directoryPath: this.directoryPath
+        });
+    }
+
+    private updateDirectoryPathOptions(path: string): void {
+        getFolderPathOptionsCommand.forServerLocal(path, true)
+            .execute()
+            .done((result: Raven.Server.Web.Studio.FolderPathOptions) => {
+                if (this.directoryPath() !== path) {
+                    // the path has changed
+                    return;
+                }
+
+                this.directoryPathOptions(result.List);
+            });
+    }
+
+    directoryPathChanged(value: string): void {
+        this.directoryPath(value);
+        this.directoryPathHasFocus(true);
+    }
+    
+    dumpIndex() {
+        if (!this.isValid(this.validationGroup)) {
+            return;
+        }
+        
+        new dumpIndexCommand(this.indexName(), this.activeDatabase(), this.directoryPath())
+            .execute();
+    }
+
+    close() {
+        dialog.close(this);
+    }
+}
+
+export = dumpDialog; 

--- a/src/Raven.Studio/typescript/viewmodels/database/indexes/editIndex.ts
+++ b/src/Raven.Studio/typescript/viewmodels/database/indexes/editIndex.ts
@@ -33,6 +33,7 @@ import additionalSourceSyntax = require("viewmodels/database/indexes/additionalS
 import additionalAssemblySyntax = require("viewmodels/database/indexes/additionalAssemblySyntax");
 import fileImporter = require("common/fileImporter");
 import popoverUtils = require("common/popoverUtils");
+import dumpDialog = require("viewmodels/database/indexes/dumpDialog");
 
 class editIndex extends viewModelBase {
 
@@ -645,6 +646,11 @@ class editIndex extends viewModelBase {
         new getCSharpIndexDefinitionCommand(this.editedIndex().name(), this.activeDatabase())
             .execute()
             .done((data: string) => app.showBootstrapDialog(new showDataDialog("C# Index Definition", data, "csharp")));
+    }
+
+    openDumpDialog() {
+        eventsCollector.default.reportEvent("index", "dump-index");
+        app.showBootstrapDialog(new dumpDialog(this.editedIndex().name()));
     }
 
     formatIndex(mapIndex: number) {

--- a/src/Raven.Studio/wwwroot/App/views/common/notificationCenter/detailViewer/operations/dumpRawIndexDataDetails.html
+++ b/src/Raven.Studio/wwwroot/App/views/common/notificationCenter/detailViewer/operations/dumpRawIndexDataDetails.html
@@ -15,7 +15,7 @@
                 </div>
             </div>
         </div>
-        <div class="modal-body">
+        <div class="modal-body word-break">
             <p data-bind="html: op.message"></p>
             <div data-bind="if: operationFailed">
                 <h3 class="text-danger text-center">Operation failed!</h3>

--- a/src/Raven.Studio/wwwroot/App/views/database/indexes/dumpDialog.html
+++ b/src/Raven.Studio/wwwroot/App/views/database/indexes/dumpDialog.html
@@ -1,0 +1,42 @@
+<div class="modal-dialog modal-lg" role="document">
+    <div class="modal-content">
+        <div class="modal-header word-break">
+            <button type="button" class="close" data-bind="click: close" aria-hidden="true">
+                <i class="icon-cancel"></i>
+            </button>
+            <h3 class="modal-title">Dump Index</h3>
+            <h4 data-bind="text: indexName"></h4>
+        </div>
+        <div class="modal-body">
+            <form class="flex-form" data-bind="submit: dumpIndex" autocomplete="off">
+                <div class="form-group margin-top" data-bind="validationElement: directoryPath">
+                    <label class="control-label">Directory Path <i class="required"></i></label>
+                    <div class="flex-grow" data-bind="validationOptions: { insertMessages: false }">
+                        <div class="dropdown btn-block">
+                            <input type="text" class="form-control dropdown-toggle" data-toggle="dropdown" id="directoryPath"
+                                   placeholder="Enter folder path for dumping the raw index files" data-bind="textInput: directoryPath, hasFocus: directoryPathHasFocus" />
+                            <span class="caret dropdown-toggle" data-toggle="dropdown"></span>
+                            <ul class="dropdown-menu max-height" data-bind="foreach: directoryPathOptions, autoComplete: '#directoryPath'">
+                                <li data-bind="click: $parent.directoryPathChanged">
+                                    <a href="#" data-bind="text: $data"></a>
+                                </li>
+                            </ul>
+                        </div>
+                        <span class="help-block" data-bind="validationMessage: directoryPath"></span>
+                    </div>
+                </div>
+            </form>
+        </div>
+        <div class="modal-footer">
+            <div class="margin-top margin-top-lg margin-bottom">
+                <button class="btn btn-default" data-bind="click: close" title="Close this dialog">
+                    <i class="icon-cancel"></i><span>Close</span>
+                </button>
+                <button type="submit" class="btn btn-primary" data-bind="click: dumpIndex" title="Dump the raw Lucene index files">
+                    <!-- TODO replace icon when RavenDB-17594 is done-->
+                    <i class="icon-arrow-down"></i><span>Dump index files</span>
+                </button>
+            </div>
+        </div>
+    </div>
+</div>

--- a/src/Raven.Studio/wwwroot/App/views/database/indexes/dumpDialog.html
+++ b/src/Raven.Studio/wwwroot/App/views/database/indexes/dumpDialog.html
@@ -1,16 +1,19 @@
 <div class="modal-dialog modal-lg" role="document">
     <div class="modal-content">
-        <div class="modal-header word-break">
+        <div class="modal-header">
             <button type="button" class="close" data-bind="click: close" aria-hidden="true">
                 <i class="icon-cancel"></i>
             </button>
             <h3 class="modal-title">Dump Index</h3>
-            <h4 data-bind="text: indexName"></h4>
         </div>
         <div class="modal-body">
             <form class="flex-form" data-bind="submit: dumpIndex" autocomplete="off">
-                <div class="form-group margin-top" data-bind="validationElement: directoryPath">
-                    <label class="control-label">Directory Path <i class="required"></i></label>
+                <div class="form-group margin-top word-break">
+                    <label class="control-label">Index Name</label>
+                    <strong class="form-control-static" data-bind="text: indexName"></strong>
+                </div>
+                <div class="form-group margin-top margin-top-lg margin-bottom margin-bottom-lg" data-bind="validationElement: directoryPath">
+                    <label class="control-label">Directory Path<i class="required"></i></label>
                     <div class="flex-grow" data-bind="validationOptions: { insertMessages: false }">
                         <div class="dropdown btn-block">
                             <input type="text" class="form-control dropdown-toggle" data-toggle="dropdown" id="directoryPath"

--- a/src/Raven.Studio/wwwroot/App/views/database/indexes/editIndex.html
+++ b/src/Raven.Studio/wwwroot/App/views/database/indexes/editIndex.html
@@ -12,6 +12,9 @@
                         <a data-bind="click: getCSharpCode, visible: isEditingExistingIndex" class="btn" title="Copy the index c# code"><i class="icon-code"></i><span>Copy C#</span></a>
                         <a data-bind="attr: { href: queryUrl }, visible: isEditingExistingIndex" class="btn" title="Query the index"><i class="icon-query"></i><span>Query</span></a>
                         <a data-bind="attr: { href: termsUrl }, visible: isEditingExistingIndex" class="btn" title="Navigate to index terms"><i class="icon-terms"></i><span>Terms</span></a>
+                        <!-- TODO replace the arrow-down icon when RavenDB-17594 is done-->
+                        <!-- TODO add access level for DatabaseAdmin on v5.2 -->
+                        <a data-bind="click: openDumpDialog, visible: isEditingExistingIndex" href="#" class="btn" title="Dump the raw Lucene index files"><i class="icon-arrow-down"></i><span>Dump</span></a>
                         <button class="btn btn-danger" data-bind="visible: isEditingExistingIndex, click: deleteIndex, attr: { title: 'Delete index: ' + editedIndex().name() }"><i class="icon-trash"></i><span>Delete</span></button>
                     </div>
                 </div>

--- a/src/Raven.Studio/wwwroot/App/views/database/indexes/editIndex.html
+++ b/src/Raven.Studio/wwwroot/App/views/database/indexes/editIndex.html
@@ -12,8 +12,8 @@
                         <a data-bind="click: getCSharpCode, visible: isEditingExistingIndex" class="btn" title="Copy the index c# code"><i class="icon-code"></i><span>Copy C#</span></a>
                         <a data-bind="attr: { href: queryUrl }, visible: isEditingExistingIndex" class="btn" title="Query the index"><i class="icon-query"></i><span>Query</span></a>
                         <a data-bind="attr: { href: termsUrl }, visible: isEditingExistingIndex" class="btn" title="Navigate to index terms"><i class="icon-terms"></i><span>Terms</span></a>
-                        <!-- TODO replace the arrow-down icon when RavenDB-17594 is done-->
-                        <!-- TODO add access level for DatabaseAdmin on v5.2 -->
+                        <!-- TODO replace the arrow-down icon when RavenDB-17594 is done -->
+                        <!-- TODO add access level for DatabaseAdmin on v5.2 (RavenDB-17595) -->
                         <a data-bind="click: openDumpDialog, visible: isEditingExistingIndex" href="#" class="btn" title="Dump the raw Lucene index files"><i class="icon-arrow-down"></i><span>Dump</span></a>
                         <button class="btn btn-danger" data-bind="visible: isEditingExistingIndex, click: deleteIndex, attr: { title: 'Delete index: ' + editedIndex().name() }"><i class="icon-trash"></i><span>Delete</span></button>
                     </div>
@@ -396,6 +396,9 @@
                     <div class="btn-group">
                         <a data-bind="attr: { href: queryUrl }, visible: isEditingExistingIndex" class="btn" title="Query the index"><i class="icon-query"></i><span>Query</span></a>
                         <a data-bind="attr: { href: termsUrl }, visible: isEditingExistingIndex" class="btn" title="Navigate to index terms"><i class="icon-terms"></i><span>Terms</span></a>
+                        <!-- TODO replace the arrow-down icon when RavenDB-17594 is done -->
+                        <!-- TODO add access level for DatabaseAdmin on v5.2 (RavenDB-17595) -->
+                        <a data-bind="click: openDumpDialog, visible: isEditingExistingIndex" href="#" class="btn" title="Dump the raw Lucene index files"><i class="icon-arrow-down"></i><span>Dump</span></a>
                         <button class="btn btn-danger" data-bind="visible: isEditingExistingIndex, click: deleteIndex" title="Delete this index"><i class="icon-trash"></i><span>Delete</span></button>
                     </div>
                 </div>


### PR DESCRIPTION
### Issue link
https://issues.hibernatingrhinos.com/issue/RavenDB-17548

### Additional description
Add 'Dump' button in Edit Index View for dumping the raw Lucene index files

### Type of change
- Task

### How risky is the change?
- Low 

### Backward compatibility
- Non breaking change

### Is it platform specific issue?
- No

### Documentation update
- This change requires a documentation update. 

### Testing 
- It has been verified by manual testing

### Is there any existing behavior change of other features due to this change?
- No

### UI work
- Waiting for icon https://issues.hibernatingrhinos.com/issue/RavenDB-17594