### PR TITLE
RavenDB-17590 More time for map-reduce index benchmarks when running on encryption

### DIFF
--- a/test/BenchmarkTests/Indexing/Index.cs
+++ b/test/BenchmarkTests/Indexing/Index.cs
@@ -100,7 +100,7 @@ namespace BenchmarkTests.Indexing
 
                 new Simple_MapReduce_Index().Execute(store);
 
-                await WaitForIndexAsync(store, store.Database, new Simple_MapReduce_Index().IndexName, DefaultTestOperationTimeout);
+                await WaitForIndexAsync(store, store.Database, new Simple_MapReduce_Index().IndexName, 2 * DefaultTestOperationTimeout);
 
                 RavenTestHelper.AssertNoIndexErrors(store);
 
@@ -122,7 +122,7 @@ namespace BenchmarkTests.Indexing
 
                 await store.Maintenance.SendAsync(new StartIndexOperation(new Simple_MapReduce_Index().IndexName));
 
-                await WaitForIndexAsync(store, store.Database, new Simple_MapReduce_Index().IndexName, DefaultTestOperationTimeout);
+                await WaitForIndexAsync(store, store.Database, new Simple_MapReduce_Index().IndexName, 2 * DefaultTestOperationTimeout);
 
                 RavenTestHelper.AssertNoIndexErrors(store);
 


### PR DESCRIPTION

### Issue link

https://issues.hibernatingrhinos.com/issue/RavenDB-17590

### Additional description

Longer timeouts when waiting for indexes to complete so the encryption benchmark tests will be able to complete
