### PR TITLE
RavenDB-17596 handle zstd sos in deb build

### DIFF
--- a/scripts/linux/pkg/deb/assets/ravendb/debian/rules
+++ b/scripts/linux/pkg/deb/assets/ravendb/debian/rules
@@ -51,9 +51,11 @@ adjust_tarball_ravendb_dir:
 adjust_tarball_server_dir:
 	cp -v librvnpal.${RAVEN_SO_ARCH_SUFFIX}.so librvnpal.so
 	cp -v libsodium.${RAVEN_SO_ARCH_SUFFIX}.so libsodium.so
+	cp -v libzstd.${RAVEN_SO_ARCH_SUFFIX}.so libzstd.so
 
 	find . -maxdepth 1 -type f -name "librvnpal.*.so" ! -iname "*.${RAVEN_SO_ARCH_SUFFIX}.so" -exec rm -v {} \;
 	find . -maxdepth 1 -type f -name "libsodium.*.so" ! -iname "*.${RAVEN_SO_ARCH_SUFFIX}.so" -exec rm -v {} \;
+	find . -maxdepth 1 -type f -name "libzstd.*.so" ! -iname "*.${RAVEN_SO_ARCH_SUFFIX}.so" -exec rm -v {} \;
 
 	cp -rv $(ETC_ASSETS_DIR)/ravendb/settings.json settings.default.json
 	mkdir -p libmscordaccore


### PR DESCRIPTION
### Issue link

https://issues.hibernatingrhinos.com/issue/RavenDB-17596

### Additional description

We need to handle libzstd.so in the deb build pipeline and clear sos for not relevant platforms.

### Type of change

- Bug fix

### How risky is the change?

- Low 

### Backward compatibility

- Non breaking change

### Is it platform specific issue?

- Linux DEB packages

### Documentation update

- No documentation update is needed 

### Testing 

- It has been verified in CI

### Is there any existing behavior change of other features due to this change?

- No

### UI work

- No UI work is needed
