### PR TITLE
RavenDB-17609 exposed OnBeforeRequest and OnSucceedRequest in IDocumentStore

### DIFF
--- a/src/Raven.Client/Documents/IDocumentStore.cs
+++ b/src/Raven.Client/Documents/IDocumentStore.cs
@@ -53,6 +53,10 @@ namespace Raven.Client.Documents
 
         event EventHandler<FailedRequestEventArgs> OnFailedRequest;
 
+        event EventHandler<BeforeRequestEventArgs> OnBeforeRequest;
+
+        event EventHandler<SucceedRequestEventArgs> OnSucceedRequest;
+
         event EventHandler<TopologyUpdatedEventArgs> OnTopologyUpdated;
 
         event EventHandler<SessionDisposingEventArgs> OnSessionDisposing;

--- a/test/FastTests/Client/RequestExecutorTests.cs
+++ b/test/FastTests/Client/RequestExecutorTests.cs
@@ -3,6 +3,7 @@ using System.Net.Http;
 using System.Text.RegularExpressions;
 using System.Threading;
 using System.Threading.Tasks;
+using Raven.Client.Documents;
 using Raven.Client.Documents.Commands;
 using Raven.Client.Documents.Conventions;
 using Raven.Tests.Core.Utils.Entities;
@@ -33,8 +34,10 @@ namespace FastTests.Client
             {
                 Server = leader,
                 ReplicationFactor = clusterSize,
-                ModifyDocumentStore = s =>
+                ModifyDocumentStore = str =>
                 {
+                    IDocumentStore s = str;
+
                     s.OnBeforeRequest += (sender, args) =>
                     {
                         if (urlRegex.IsMatch(args.Url) == false)


### PR DESCRIPTION
### Issue link

https://issues.hibernatingrhinos.com/issue/RavenDB-17609

### Type of change

- Bug fix

### How risky is the change?

- Low 

### Backward compatibility

- Non breaking change

### Is it platform specific issue?

- No

### Documentation update

- No documentation update is needed 

### Testing 

- Tests have been added that prove the fix is effective or that the feature works

### Is there any existing behavior change of other features due to this change?
- No

### UI work

- No UI work is needed
