### PR TITLE
RavenDB-17606: Stop index references processing stage when there is memory pressure

### DIFF
--- a/src/Raven.Client/Documents/Indexes/ReduceRunDetails.cs
+++ b/src/Raven.Client/Documents/Indexes/ReduceRunDetails.cs
@@ -55,5 +55,13 @@
 
         public long AllocationBudget { get; set; }
 
+        public string BatchCompleteReason { get; set; }
+    }
+
+    public class CleanupRunDetails
+    {
+        public int DeleteSuccesses { get; set; }
+
+        public string BatchCompleteReason { get; set; }
     }
 }

--- a/src/Raven.Server/Documents/Indexes/Index.cs
+++ b/src/Raven.Server/Documents/Indexes/Index.cs
@@ -4383,7 +4383,22 @@ namespace Raven.Server.Documents.Indexes
                     parameters.QueryContext.Documents.DoNotReuse = true;
                     parameters.IndexingContext.DoNotReuse = true;
 
-                    if (parameters.Stats.MapAttempts >= Configuration.MinNumberOfMapAttemptsAfterWhichBatchWillBeCanceledIfRunningLowOnMemory)
+                    switch (parameters.WorkType)
+                    {
+                        case IndexingWorkType.Map:
+                            if (parameters.Stats.MapAttempts >= Configuration.MinNumberOfMapAttemptsAfterWhichBatchWillBeCanceledIfRunningLowOnMemory)
+                                canContinue = false;
+                            break;
+                        case IndexingWorkType.References:
+                            if (parameters.Count >= Configuration.MinNumberOfMapAttemptsAfterWhichBatchWillBeCanceledIfRunningLowOnMemory)
+                                canContinue = false;
+                            break;
+                        default:
+                            canContinue = false;
+                            break;
+                    }
+
+                    if (canContinue == false)
                     {
                         if (_logger.IsInfoEnabled)
                         {
@@ -4405,7 +4420,6 @@ namespace Raven.Server.Documents.Indexes
                             reason: "cannot budget additional memory");
 
                         parameters.Stats.RecordMapCompletedReason("Cannot budget additional memory for batch");
-                        canContinue = false;
                     }
                 }
 

--- a/src/Raven.Server/Documents/Indexes/IndexingRunStats.cs
+++ b/src/Raven.Server/Documents/Indexes/IndexingRunStats.cs
@@ -14,6 +14,7 @@ namespace Raven.Server.Documents.Indexes
         public int MapReferenceAttempts;
         public int MapSuccesses;
         public int MapReferenceSuccesses;
+        public int TombstoneDeleteSuccesses;
         public int MapErrors;
         public int MapReferenceErrors;
 
@@ -32,6 +33,8 @@ namespace Raven.Server.Documents.Indexes
         public MapRunDetails MapDetails;
 
         public ReferenceRunDetails ReferenceDetails;
+
+        public CleanupRunDetails CleanupDetails;
 
         public StorageCommitDetails CommitDetails;
 

--- a/src/Raven.Server/Documents/Indexes/Workers/CleanupDocuments.cs
+++ b/src/Raven.Server/Documents/Indexes/Workers/CleanupDocuments.cs
@@ -95,6 +95,7 @@ namespace Raven.Server.Documents.Indexes.Workers
                                     continue; // this can happen when we have '@all_docs'
 
                                 _index.HandleDelete(tombstone, collection, writeOperation, indexContext, collectionStats);
+                                stats.RecordTombstoneDeleteSuccess();
 
                                 var parameters = new CanContinueBatchParameters(stats, IndexingWorkType.Cleanup, queryContext, indexContext, writeOperation, lastEtag,
                                     lastCollectionEtag,

--- a/src/Raven.Server/Documents/Indexes/Workers/MapItems.cs
+++ b/src/Raven.Server/Documents/Indexes/Workers/MapItems.cs
@@ -81,7 +81,7 @@ namespace Raven.Server.Documents.Indexes.Workers
                                         if (etag > lastEtag)
                                             lastEtag = etag.Value;
 
-                                        collectionStats.RecordMapCompletedReason("No more documents to index");
+                                        collectionStats.RecordBatchCompletedReason(IndexingWorkType.Map, "No more documents to index");
                                         keepRunning = false;
                                         break;
                                     }


### PR DESCRIPTION
### Issue link

https://issues.hibernatingrhinos.com/issue/RavenDB-17606

### Additional description

The batch was not stopped because we were checking the map attempts, but map attempts is always 0 in references processing stage

### Type of change

- Bug fix

### How risky is the change?

- Low 

### Backward compatibility

- Not relevant

### Is it platform specific issue?

- No

### Documentation update

- No documentation update is needed 

### Testing 

- It has been verified by manual testing

### Is there any existing behavior change of other features due to this change?

- No

### UI work
- No UI work is needed
