### PR TITLE
RavenDB-17621 - SlowTests.Voron.Storage.StorageReportGenerationTests.…

### DIFF
--- a/test/SlowTests/Voron/Storage/StorageReportGenerationTests.cs
+++ b/test/SlowTests/Voron/Storage/StorageReportGenerationTests.cs
@@ -432,9 +432,9 @@ namespace SlowTests.Voron.Storage
                 Assert.Equal(1, treeReport.Streams.Streams.Count);
                 Assert.Equal(StorageReportGenerator.SkippedStreamsDetailsName, treeReport?.Streams.Streams[0].Name);
 
-                var streamsSizeInMb = Math.Ceiling(treeReport.Streams.Streams[0].AllocatedSpaceInBytes * 0.000001);
-                var fullStreamsSizeInMb = Math.Ceiling(fullTreeReport.Streams.AllocatedSpaceInBytes * 0.000001);
-
+                var streamsSizeInMb = Math.Round(treeReport.Streams.Streams[0].AllocatedSpaceInBytes * 0.000001);
+                var fullStreamsSizeInMb = Math.Round(fullTreeReport.Streams.AllocatedSpaceInBytes * 0.000001);
+                
                 Assert.Equal(streamsSizeInMb, fullStreamsSizeInMb);
             }
         }


### PR DESCRIPTION
…TreeReportContainsPartialInfoAboutStreams(numberOfStreams: 1, seed: 1859588471)

### Issue link

https://issues.hibernatingrhinos.com/issue/RavenDB-17621

### Type of change

- Bug fix

### How risky is the change?

- Low 

### Backward compatibility

- Non breaking change

### Is it platform specific issue?

- No

### Documentation update

- No documentation update is needed 

### Testing 

- Tests have been added that prove the fix is effective or that the feature works


### Is there any existing behavior change of other features due to this change?

- No

### UI work

- No UI work is needed
