### PR TITLE
RavenDB-13669 Check actual client-cert before redirecting to error page

### DIFF
--- a/src/Raven.Server/Web/System/StudioHandler.cs
+++ b/src/Raven.Server/Web/System/StudioHandler.cs
@@ -156,9 +156,9 @@ namespace Raven.Server.Web.System
             var feature = HttpContext.Features.Get<IHttpAuthenticationFeature>() as RavenServer.AuthenticateConnection;
             var authStatus = feature?.Status;
             
-            if (authStatus is RavenServer.AuthenticationStatus.ClusterAdmin or
-                RavenServer.AuthenticationStatus.Operator or 
-                RavenServer.AuthenticationStatus.Allowed)
+            if (authStatus == RavenServer.AuthenticationStatus.ClusterAdmin ||
+                authStatus == RavenServer.AuthenticationStatus.Operator ||
+                authStatus == RavenServer.AuthenticationStatus.Allowed)
             {
                 HttpContext.Response.Headers["Location"] = "/studio/index.html";
                 HttpContext.Response.StatusCode = (int)HttpStatusCode.Redirect;


### PR DESCRIPTION
### Issue link
https://issues.hibernatingrhinos.com/issue/RavenDB-13669

### Additional description
Check authentication status before redirecting to the error page

### Type of change
- Bug fix

### How risky is the change?
- Low 

### Backward compatibility
- Non breaking change

### Is it platform specific issue?
- No

### Documentation update
- No documentation update is needed 

### Testing 
- It has been verified by manual testing

### Is there any existing behavior change of other features due to this change?
- No

### UI work
- No UI work is needed
