### PR TITLE
RavenDB-17632 Corax - bump index version and pointer fix.

### DIFF
--- a/src/Corax/Queries/MergeHelper.cs
+++ b/src/Corax/Queries/MergeHelper.cs
@@ -221,8 +221,8 @@ namespace Corax.Queries
                 }
                 else if (leftValue > rightValue)
                 {
-                    Sse2.StoreNonTemporal((uint*)dstPtr, ((uint*)rightValue)[0]);
-                    Sse2.StoreNonTemporal(((uint*)dstPtr) + 1, ((uint*)rightValue)[1]);
+                    Sse2.StoreNonTemporal((uint*)dstPtr, ((uint*)rightPtr)[0]);
+                    Sse2.StoreNonTemporal(((uint*)dstPtr) + 1, ((uint*)rightPtr)[1]);
                     rightPtr++;
                 }
                 else

--- a/src/Raven.Server/Documents/Indexes/IndexDefinitionBase.cs
+++ b/src/Raven.Server/Documents/Indexes/IndexDefinitionBase.cs
@@ -142,7 +142,7 @@ namespace Raven.Server.Documents.Indexes
             /// <summary>
             /// Remember to bump this
             /// </summary>
-            public const long CurrentVersion = ReduceKeyProcessorHashDoubleFix;
+            public const long CurrentVersion = Corax;
         }
     }
 


### PR DESCRIPTION
### Issue link

https://issues.hibernatingrhinos.com/issue/RavenDB-17632

### Additional description

If the current version of indexes is lower than Corax (6_0) our mechanism will switch all Corax indexes into Lucene ones so Corax tests will use Lucene as the engine.




### Type of change

- Bug fix

### How risky is the change?


- Not relevant

### Backward compatibility

- Not relevant

### Is it platform specific issue?


- No

### Documentation update

- No documentation update is needed 

### Testing 

- Tests have been added that prove the fix is effective or that the feature works

### Is there any existing behavior change of other features due to this change?

- No

### UI work

- No UI work is needed
