### PR TITLE
RavenDB-17128 : ConcurrencyException enhancements 

### DIFF
--- a/src/Raven.Client/Exceptions/ClusterTransactionConcurrencyException.cs
+++ b/src/Raven.Client/Exceptions/ClusterTransactionConcurrencyException.cs
@@ -39,16 +39,16 @@ namespace Raven.Client.Exceptions
         }
 
         /// <summary>
-        /// Cluster Concurrency violations info.
+        /// Concurrency violations info.
         /// </summary>
-        public Conflict[] ConcurrencyViolations;
+        public Conflict[] ConcurrencyViolations { get; set; }
 
         public class Conflict
         {
-            public ConflictType Type;
-            public string Id;
-            public string Expected;
-            public string Actual;
+            public ConflictType Type { get; set; }
+            public string Id { get; set; }
+            public string Expected { get; set; }
+            public string Actual { get; set; }
 
             public DynamicJsonValue ToJson()
             {

--- a/src/Raven.Client/Exceptions/ClusterTransactionConcurrencyException.cs
+++ b/src/Raven.Client/Exceptions/ClusterTransactionConcurrencyException.cs
@@ -47,8 +47,8 @@ namespace Raven.Client.Exceptions
         {
             public ConflictType Type { get; set; }
             public string Id { get; set; }
-            public string Expected { get; set; }
-            public string Actual { get; set; }
+            public long Expected { get; set; }
+            public long Actual { get; set; }
 
             public DynamicJsonValue ToJson()
             {

--- a/src/Raven.Client/Exceptions/ClusterTransactionConcurrencyException.cs
+++ b/src/Raven.Client/Exceptions/ClusterTransactionConcurrencyException.cs
@@ -1,0 +1,71 @@
+//-----------------------------------------------------------------------
+// <copyright file="ClusterTransactionConcurrencyException .cs" company="Hibernating Rhinos LTD">
+//     Copyright (c) Hibernating Rhinos LTD. All rights reserved.
+// </copyright>
+//-----------------------------------------------------------------------
+
+using System;
+using Sparrow.Json.Parsing;
+
+namespace Raven.Client.Exceptions
+{
+    /// <summary>
+    /// This exception is raised when a concurrency conflict is encountered
+    /// </summary>
+    public class ClusterTransactionConcurrencyException : ConcurrencyException
+    {
+        /// <summary>
+        /// Initializes a new instance of the <see cref="ClusterTransactionConcurrencyException "/> class.
+        /// </summary>
+        public ClusterTransactionConcurrencyException()
+        {
+        }
+
+        /// <summary>
+        /// Initializes a new instance of the <see cref="ClusterTransactionConcurrencyException "/> class.
+        /// </summary>
+        /// <param name="message">The message.</param>
+        public ClusterTransactionConcurrencyException(string message) : base(message)
+        {
+        }
+
+        /// <summary>
+        /// Initializes a new instance of the <see cref="ClusterTransactionConcurrencyException "/> class.
+        /// </summary>
+        /// <param name="message">The message.</param>
+        /// <param name="inner">The inner.</param>
+        public ClusterTransactionConcurrencyException(string message, Exception inner) : base(message, inner)
+        {
+        }
+
+        /// <summary>
+        /// Cluster Concurrency violations info.
+        /// </summary>
+        public Conflict[] ConcurrencyViolations;
+
+        public class Conflict
+        {
+            public ConflictType Type;
+            public string Id;
+            public string Expected;
+            public string Actual;
+
+            public DynamicJsonValue ToJson()
+            {
+                return new DynamicJsonValue()
+                {
+                    [nameof(Type)] = Type,
+                    [nameof(Id)] = Id,
+                    [nameof(Expected)] = Expected,
+                    [nameof(Actual)] = Actual
+                };
+            }
+        }
+
+        public enum ConflictType
+        {
+            Document,
+            CompareExchange
+        }
+    }
+}

--- a/src/Raven.Client/Exceptions/ClusterTransactionConcurrencyException.cs
+++ b/src/Raven.Client/Exceptions/ClusterTransactionConcurrencyException.cs
@@ -41,11 +41,11 @@ namespace Raven.Client.Exceptions
         /// <summary>
         /// Concurrency violations info.
         /// </summary>
-        public Conflict[] ConcurrencyViolations { get; set; }
+        public ConcurrencyViolation[] ConcurrencyViolations { get; set; }
 
-        public class Conflict
+        public class ConcurrencyViolation
         {
-            public ConflictType Type { get; set; }
+            public ViolationOnType Type { get; set; }
             public string Id { get; set; }
             public long Expected { get; set; }
             public long Actual { get; set; }
@@ -62,7 +62,7 @@ namespace Raven.Client.Exceptions
             }
         }
 
-        public enum ConflictType
+        public enum ViolationOnType
         {
             Document,
             CompareExchange

--- a/src/Raven.Client/Exceptions/ConcurrencyException.cs
+++ b/src/Raven.Client/Exceptions/ConcurrencyException.cs
@@ -62,6 +62,6 @@ namespace Raven.Client.Exceptions
         /// <summary>
         /// The Document Id.
         /// </summary>
-        public string Id;
+        public string Id { get; set; }
     }
 }

--- a/src/Raven.Client/Exceptions/ConcurrencyException.cs
+++ b/src/Raven.Client/Exceptions/ConcurrencyException.cs
@@ -5,6 +5,7 @@
 //-----------------------------------------------------------------------
 
 using System;
+using Sparrow.Json.Parsing;
 
 namespace Raven.Client.Exceptions
 {
@@ -40,21 +41,51 @@ namespace Raven.Client.Exceptions
         /// <summary>
         /// Expected Etag.
         /// </summary>
-        public long ExpectedETag { get; set; }
+        public long ExpectedETag;
 
         /// <summary>
         /// Actual Etag.
         /// </summary>
-        public long ActualETag { get; set; }
+        public long ActualETag;
 
         /// <summary>
         /// Expected Change Vector.
         /// </summary>
-        public string ExpectedChangeVector { get; set; }
+        public string ExpectedChangeVector;
 
         /// <summary>
         /// Actual Change Vector.
         /// </summary>
-        public string ActualChangeVector { get; set; }
+        public string ActualChangeVector;
+
+        /// <summary>
+        /// Cluster Transaction conflicts info.
+        /// </summary>
+        public Conflict[] ClusterTransactionConflicts;
+
+        public class Conflict
+        {
+            public ConflictType Type;
+            public string Id;
+            public string Expected;
+            public string Actual;
+
+            public DynamicJsonValue ToJson()
+            {
+                return new DynamicJsonValue()
+                {
+                    [nameof(Type)] = Type,
+                    [nameof(Id)] = Id,
+                    [nameof(Expected)] = Expected,
+                    [nameof(Actual)] = Actual
+                };
+            }
+        }
+
+        public enum ConflictType
+        {
+            Document,
+            CompareExchange
+        }
     }
 }

--- a/src/Raven.Client/Exceptions/ConcurrencyException.cs
+++ b/src/Raven.Client/Exceptions/ConcurrencyException.cs
@@ -41,27 +41,34 @@ namespace Raven.Client.Exceptions
         /// <summary>
         /// Expected Etag.
         /// </summary>
-        public long ExpectedETag;
+        [Obsolete("Not used and will be removed and the next major version")]
+        public long ExpectedETag { get; set; }
 
         /// <summary>
         /// Actual Etag.
         /// </summary>
-        public long ActualETag;
+        [Obsolete("Not used and will be removed and the next major version")]
+        public long ActualETag { get; set; }
 
         /// <summary>
         /// Expected Change Vector.
         /// </summary>
-        public string ExpectedChangeVector;
+        public string ExpectedChangeVector { get; set; }
 
         /// <summary>
         /// Actual Change Vector.
         /// </summary>
-        public string ActualChangeVector;
+        public string ActualChangeVector { get; set; }
 
         /// <summary>
-        /// Cluster Transaction conflicts info.
+        /// The Document Id.
         /// </summary>
-        public Conflict[] ClusterTransactionConflicts;
+        public string Id;
+
+        /// <summary>
+        /// Cluster Concurrency violations info.
+        /// </summary>
+        public Conflict[] ClusterConcurrencyViolations;
 
         public class Conflict
         {

--- a/src/Raven.Client/Exceptions/ConcurrencyException.cs
+++ b/src/Raven.Client/Exceptions/ConcurrencyException.cs
@@ -5,7 +5,6 @@
 //-----------------------------------------------------------------------
 
 using System;
-using Sparrow.Json.Parsing;
 
 namespace Raven.Client.Exceptions
 {
@@ -64,35 +63,5 @@ namespace Raven.Client.Exceptions
         /// The Document Id.
         /// </summary>
         public string Id;
-
-        /// <summary>
-        /// Cluster Concurrency violations info.
-        /// </summary>
-        public Conflict[] ClusterConcurrencyViolations;
-
-        public class Conflict
-        {
-            public ConflictType Type;
-            public string Id;
-            public string Expected;
-            public string Actual;
-
-            public DynamicJsonValue ToJson()
-            {
-                return new DynamicJsonValue()
-                {
-                    [nameof(Type)] = Type,
-                    [nameof(Id)] = Id,
-                    [nameof(Expected)] = Expected,
-                    [nameof(Actual)] = Actual
-                };
-            }
-        }
-
-        public enum ConflictType
-        {
-            Document,
-            CompareExchange
-        }
     }
 }

--- a/src/Raven.Client/Exceptions/ExceptionDispatcher.cs
+++ b/src/Raven.Client/Exceptions/ExceptionDispatcher.cs
@@ -125,51 +125,58 @@ namespace Raven.Client.Exceptions
             if (schema.Type.Contains(nameof(DocumentConflictException))) // temporary!
                 throw DocumentConflictException.From(json);
 
-            string expectedCv, actualCv;
+            string expectedCv, actualCv, docId;
             if (schema.Type.Contains(nameof(ClusterTransactionConcurrencyException)))
             {
-                var clusterTransactionConcurrencyException = new ClusterTransactionConcurrencyException(schema.Message);
+                var ctxConcurrencyException = new ClusterTransactionConcurrencyException(schema.Message);
 
-                json.TryGet(nameof(ClusterTransactionConcurrencyException.Id), out clusterTransactionConcurrencyException.Id);
+                if (json.TryGet(nameof(ClusterTransactionConcurrencyException.Id), out docId))
+                    ctxConcurrencyException.Id = docId;
 
                 if (json.TryGet(nameof(ClusterTransactionConcurrencyException.ExpectedChangeVector), out expectedCv))
-                    clusterTransactionConcurrencyException.ExpectedChangeVector = expectedCv;
+                    ctxConcurrencyException.ExpectedChangeVector = expectedCv;
 
                 if (json.TryGet(nameof(ClusterTransactionConcurrencyException.ActualChangeVector), out actualCv))
-                    clusterTransactionConcurrencyException.ActualChangeVector = actualCv;
+                    ctxConcurrencyException.ActualChangeVector = actualCv;
 
                 if (json.TryGet(nameof(ClusterTransactionConcurrencyException.ConcurrencyViolations), out BlittableJsonReaderArray violations) == false)
-                    throw clusterTransactionConcurrencyException;
+                    throw ctxConcurrencyException;
 
-                clusterTransactionConcurrencyException.ConcurrencyViolations = new ClusterTransactionConcurrencyException.Conflict[violations.Length];
+                ctxConcurrencyException.ConcurrencyViolations = new ClusterTransactionConcurrencyException.Conflict[violations.Length];
 
                 for (var i = 0; i < violations.Length; i++)
                 {
                     if (!(violations[i] is BlittableJsonReaderObject conflict))
                         continue;
 
-                    var current = clusterTransactionConcurrencyException.ConcurrencyViolations[i] = new ClusterTransactionConcurrencyException.Conflict();
+                    var current = ctxConcurrencyException.ConcurrencyViolations[i] = new ClusterTransactionConcurrencyException.Conflict();
 
-                    conflict.TryGet(nameof(ClusterTransactionConcurrencyException.Conflict.Id), out current.Id);
-                    conflict.TryGet(nameof(ClusterTransactionConcurrencyException.Conflict.Type), out current.Type);
-                    conflict.TryGet(nameof(ClusterTransactionConcurrencyException.Conflict.Expected), out current.Expected);
-                    conflict.TryGet(nameof(ClusterTransactionConcurrencyException.Conflict.Actual), out current.Actual);
+                    if (conflict.TryGet(nameof(ClusterTransactionConcurrencyException.Conflict.Id), out string id))
+                        current.Id = id;
+
+                    if (conflict.TryGet(nameof(ClusterTransactionConcurrencyException.Conflict.Type), out ClusterTransactionConcurrencyException.ConflictType type))
+                        current.Type = type;
+
+                    if (conflict.TryGet(nameof(ClusterTransactionConcurrencyException.Conflict.Expected), out string expected))
+                        current.Expected = expected;
+
+                    if (conflict.TryGet(nameof(ClusterTransactionConcurrencyException.Conflict.Actual), out string actual))
+                        current.Actual = actual;
                 }
 
-                throw clusterTransactionConcurrencyException;
+                throw ctxConcurrencyException;
             }
 
             var concurrencyException = new ConcurrencyException(schema.Message);
-            json.TryGet(nameof(ConcurrencyException.Id), out concurrencyException.Id);
 
+            if (json.TryGet(nameof(ConcurrencyException.Id), out docId))
+                concurrencyException.Id = docId;
             if (json.TryGet(nameof(ConcurrencyException.ExpectedChangeVector), out expectedCv))
                 concurrencyException.ExpectedChangeVector = expectedCv;
-
             if (json.TryGet(nameof(ConcurrencyException.ActualChangeVector), out actualCv))
                 concurrencyException.ActualChangeVector = actualCv;
 
             throw concurrencyException;
-
         }
 
         public static Type GetType(string typeAsString)

--- a/src/Raven.Client/Exceptions/ExceptionDispatcher.cs
+++ b/src/Raven.Client/Exceptions/ExceptionDispatcher.cs
@@ -142,25 +142,25 @@ namespace Raven.Client.Exceptions
                 if (json.TryGet(nameof(ClusterTransactionConcurrencyException.ConcurrencyViolations), out BlittableJsonReaderArray violations) == false)
                     throw ctxConcurrencyException;
 
-                ctxConcurrencyException.ConcurrencyViolations = new ClusterTransactionConcurrencyException.Conflict[violations.Length];
+                ctxConcurrencyException.ConcurrencyViolations = new ClusterTransactionConcurrencyException.ConcurrencyViolation[violations.Length];
 
                 for (var i = 0; i < violations.Length; i++)
                 {
-                    if (!(violations[i] is BlittableJsonReaderObject conflict))
+                    if (!(violations[i] is BlittableJsonReaderObject violation))
                         continue;
 
-                    var current = ctxConcurrencyException.ConcurrencyViolations[i] = new ClusterTransactionConcurrencyException.Conflict();
+                    var current = ctxConcurrencyException.ConcurrencyViolations[i] = new ClusterTransactionConcurrencyException.ConcurrencyViolation();
 
-                    if (conflict.TryGet(nameof(ClusterTransactionConcurrencyException.Conflict.Id), out string id))
+                    if (violation.TryGet(nameof(ClusterTransactionConcurrencyException.ConcurrencyViolation.Id), out string id))
                         current.Id = id;
 
-                    if (conflict.TryGet(nameof(ClusterTransactionConcurrencyException.Conflict.Type), out ClusterTransactionConcurrencyException.ConflictType type))
+                    if (violation.TryGet(nameof(ClusterTransactionConcurrencyException.ConcurrencyViolation.Type), out ClusterTransactionConcurrencyException.ViolationOnType type))
                         current.Type = type;
 
-                    if (conflict.TryGet(nameof(ClusterTransactionConcurrencyException.Conflict.Expected), out long expected))
+                    if (violation.TryGet(nameof(ClusterTransactionConcurrencyException.ConcurrencyViolation.Expected), out long expected))
                         current.Expected = expected;
 
-                    if (conflict.TryGet(nameof(ClusterTransactionConcurrencyException.Conflict.Actual), out long actual))
+                    if (violation.TryGet(nameof(ClusterTransactionConcurrencyException.ConcurrencyViolation.Actual), out long actual))
                         current.Actual = actual;
                 }
 

--- a/src/Raven.Client/Exceptions/ExceptionDispatcher.cs
+++ b/src/Raven.Client/Exceptions/ExceptionDispatcher.cs
@@ -157,10 +157,10 @@ namespace Raven.Client.Exceptions
                     if (conflict.TryGet(nameof(ClusterTransactionConcurrencyException.Conflict.Type), out ClusterTransactionConcurrencyException.ConflictType type))
                         current.Type = type;
 
-                    if (conflict.TryGet(nameof(ClusterTransactionConcurrencyException.Conflict.Expected), out string expected))
+                    if (conflict.TryGet(nameof(ClusterTransactionConcurrencyException.Conflict.Expected), out long expected))
                         current.Expected = expected;
 
-                    if (conflict.TryGet(nameof(ClusterTransactionConcurrencyException.Conflict.Actual), out string actual))
+                    if (conflict.TryGet(nameof(ClusterTransactionConcurrencyException.Conflict.Actual), out long actual))
                         current.Actual = actual;
                 }
 

--- a/src/Raven.Server/Documents/AttachmentsStorage.cs
+++ b/src/Raven.Server/Documents/AttachmentsStorage.cs
@@ -952,6 +952,7 @@ namespace Raven.Server.Documents
             throw new ConcurrencyException(
                 $"Attachment {name} of '{documentId}' has change vector {oldChangeVector}, but Put was called with {(expectedChangeVector.Length == 0 ? "expecting new document" : "change vector " + expectedChangeVector)}. Optimistic concurrency violation, transaction will be aborted.")
             {
+                Id = documentId,
                 ActualChangeVector = oldChangeVector,
                 ExpectedChangeVector = expectedChangeVector
             };
@@ -962,6 +963,7 @@ namespace Raven.Server.Documents
             throw new ConcurrencyException(
                 $"Attachment {name} of '{documentId}' does not exist, but Put was called with change vector '{expectedChangeVector}'. Optimistic concurrency violation, transaction will be aborted.")
             {
+                Id = documentId,
                 ExpectedChangeVector = expectedChangeVector
             };
         }
@@ -1051,7 +1053,11 @@ namespace Raven.Server.Documents
                     if (expectedChangeVector != null)
                         throw new ConcurrencyException($"Document {documentId} does not exist, " +
                                                        $"but delete was called with change vector '{expectedChangeVector}' to remove attachment {name}. " +
-                                                       "Optimistic concurrency violation, transaction will be aborted.");
+                                                       "Optimistic concurrency violation, transaction will be aborted.")
+                        {
+                            Id = documentId,
+                            ExpectedChangeVector = expectedChangeVector
+                        };
 
                     // this basically mean that we tried to delete attachment whose document doesn't exist.
                     return;
@@ -1186,7 +1192,10 @@ namespace Raven.Server.Documents
                 if (expectedChangeVector != null)
                     throw new ConcurrencyException($"Attachment {name} with key '{key}' does not exist, " +
                                                    $"but delete was called with change vector '{expectedChangeVector}'. " +
-                                                   "Optimistic concurrency violation, transaction will be aborted.");
+                                                   "Optimistic concurrency violation, transaction will be aborted.")
+                    {
+                        ExpectedChangeVector = expectedChangeVector
+                    };
 
                 // This basically means that we tried to delete attachment that doesn't exist.
                 long attachmentEtag;

--- a/src/Raven.Server/Documents/ConflictsStorage.cs
+++ b/src/Raven.Server/Documents/ConflictsStorage.cs
@@ -780,7 +780,11 @@ namespace Raven.Server.Documents
 
             if (HasHigherChangeVector(context, lowerId, expectedChangeVector))
             {
-                throw new ConcurrencyException($"Failed to resolve document conflict with change vector = {expectedChangeVector}, because we have a newer change vector.");
+                throw new ConcurrencyException($"Failed to resolve document conflict with change vector = {expectedChangeVector}, because we have a newer change vector.")
+                {
+                    Id = lowerId.ToString(),
+                    ExpectedChangeVector = expectedChangeVector
+                };
             }
         }
 

--- a/src/Raven.Server/Documents/DocumentPutAction.cs
+++ b/src/Raven.Server/Documents/DocumentPutAction.cs
@@ -15,7 +15,6 @@ using System.Linq;
 using Raven.Client.Exceptions;
 using Raven.Client.Exceptions.Documents;
 using Raven.Client.ServerWide;
-using Raven.Server.Documents.Replication;
 using Sparrow.Server;
 using static Raven.Server.Documents.DocumentsStorage;
 using Constants = Raven.Client.Constants;

--- a/src/Raven.Server/Documents/DocumentPutAction.cs
+++ b/src/Raven.Server/Documents/DocumentPutAction.cs
@@ -87,7 +87,10 @@ namespace Raven.Server.Documents
                     {
                         throw new ConcurrencyException(
                             $"Cannot PUT document '{id}' because its change vector's cluster transaction index is set to {indexFromChangeVector} " +
-                            $"but the compare exchange guard ('{ClusterTransactionCommand.GetAtomicGuardKey(id)}') is set to {indexFromCluster}");
+                            $"but the compare exchange guard ('{ClusterTransactionCommand.GetAtomicGuardKey(id)}') is set to {indexFromCluster}")
+                        {
+                            Id = id
+                        };
                     }
                 }
             }
@@ -722,6 +725,7 @@ namespace Raven.Server.Documents
             throw new ConcurrencyException(
                 $"Document {id} does not exist, but Put was called with change vector: {expectedChangeVector}. Optimistic concurrency violation, transaction will be aborted.")
             {
+                Id = id,
                 ExpectedChangeVector = expectedChangeVector
             };
         }
@@ -736,6 +740,7 @@ namespace Raven.Server.Documents
             throw new ConcurrencyException(
                 $"Document {id} has change vector {oldChangeVector}, but Put was called with {(expectedChangeVector.Length == 0 ? "expecting new document" : "change vector " + expectedChangeVector)}. Optimistic concurrency violation, transaction will be aborted.")
             {
+                Id = id,
                 ActualChangeVector = oldChangeVector,
                 ExpectedChangeVector = expectedChangeVector
             };

--- a/src/Raven.Server/Documents/DocumentsStorage.cs
+++ b/src/Raven.Server/Documents/DocumentsStorage.cs
@@ -1610,7 +1610,11 @@ namespace Raven.Server.Documents
             {
                 if (expectedChangeVector != null)
                     throw new ConcurrencyException($"Document {local.Tombstone.LowerId} does not exist, but delete was called with change vector '{expectedChangeVector}'. " +
-                                                   "Optimistic concurrency violation, transaction will be aborted.");
+                                                   "Optimistic concurrency violation, transaction will be aborted.")
+                    {
+                        Id = local.Tombstone.LowerId,
+                        ExpectedChangeVector = expectedChangeVector
+                    };
                 if (collectionName == null)
                 {
                     collectionName = ExtractCollectionName(context, local.Tombstone.Collection);

--- a/src/Raven.Server/Documents/Handlers/BatchHandler.cs
+++ b/src/Raven.Server/Documents/Handlers/BatchHandler.cs
@@ -231,7 +231,7 @@ namespace Raven.Server.Documents.Handlers
                 HttpContext.Response.StatusCode = (int)HttpStatusCode.Conflict;
                 throw new ClusterTransactionConcurrencyException($"Failed to execute cluster transaction due to the following issues: {string.Join(Environment.NewLine, errors.Select(e => e.Message))}")
                 {
-                    ConcurrencyViolations = errors.Select(e => e.Conflict).ToArray()
+                    ConcurrencyViolations = errors.Select(e => e.Violation).ToArray()
                 };
             }
 

--- a/src/Raven.Server/Documents/Handlers/BatchHandler.cs
+++ b/src/Raven.Server/Documents/Handlers/BatchHandler.cs
@@ -231,7 +231,7 @@ namespace Raven.Server.Documents.Handlers
                 HttpContext.Response.StatusCode = (int)HttpStatusCode.Conflict;
                 throw new ConcurrencyException($"Failed to execute cluster transaction due to the following issues: {string.Join(Environment.NewLine, errors.Select(e => e.Message))}")
                 {
-                    ClusterTransactionConflicts = errors.Select(e => e.Conflict).ToArray()
+                    ClusterConcurrencyViolations = errors.Select(e => e.Conflict).ToArray()
                 };
             }
 

--- a/src/Raven.Server/Documents/Handlers/BatchHandler.cs
+++ b/src/Raven.Server/Documents/Handlers/BatchHandler.cs
@@ -229,9 +229,9 @@ namespace Raven.Server.Documents.Handlers
             if (result.Result is List<ClusterTransactionCommand.ClusterTransactionErrorInfo> errors)
             {
                 HttpContext.Response.StatusCode = (int)HttpStatusCode.Conflict;
-                throw new ConcurrencyException($"Failed to execute cluster transaction due to the following issues: {string.Join(Environment.NewLine, errors.Select(e => e.Message))}")
+                throw new ClusterTransactionConcurrencyException($"Failed to execute cluster transaction due to the following issues: {string.Join(Environment.NewLine, errors.Select(e => e.Message))}")
                 {
-                    ClusterConcurrencyViolations = errors.Select(e => e.Conflict).ToArray()
+                    ConcurrencyViolations = errors.Select(e => e.Conflict).ToArray()
                 };
             }
 

--- a/src/Raven.Server/Documents/Patch/PatchDocumentCommand.cs
+++ b/src/Raven.Server/Documents/Patch/PatchDocumentCommand.cs
@@ -80,6 +80,7 @@ namespace Raven.Server.Documents.Patch
 
                     throw new ConcurrencyException($"Could not patch document '{id}' because non current change vector was used")
                     {
+                        Id = id,
                         ActualChangeVector = null,
                         ExpectedChangeVector = expectedChangeVector
                     };
@@ -97,6 +98,7 @@ namespace Raven.Server.Documents.Patch
 
                     throw new ConcurrencyException($"Could not patch document '{id}' because non current change vector was used")
                     {
+                        Id = id,
                         ActualChangeVector = originalDocument.ChangeVector,
                         ExpectedChangeVector = expectedChangeVector
                     };

--- a/src/Raven.Server/RavenServerStartup.cs
+++ b/src/Raven.Server/RavenServerStartup.cs
@@ -323,13 +323,12 @@ namespace Raven.Server
 
             if (exception is ConcurrencyException concurrencyException)
             {
+                djv[nameof(ConcurrencyException.Id)] = concurrencyException.Id;
                 djv[nameof(ConcurrencyException.ExpectedChangeVector)] = concurrencyException.ExpectedChangeVector;
                 djv[nameof(ConcurrencyException.ActualChangeVector)] = concurrencyException.ActualChangeVector;
-                djv[nameof(ConcurrencyException.ExpectedETag)] = concurrencyException.ExpectedETag;
-                djv[nameof(ConcurrencyException.ActualETag)] = concurrencyException.ActualETag;
-    
-                if (concurrencyException.ClusterTransactionConflicts != null)
-                    djv[nameof(ConcurrencyException.ClusterTransactionConflicts)] = new DynamicJsonArray(concurrencyException.ClusterTransactionConflicts.Select(c => c.ToJson()));
+
+                if (concurrencyException.ClusterConcurrencyViolations != null)
+                    djv[nameof(ConcurrencyException.ClusterConcurrencyViolations)] = new DynamicJsonArray(concurrencyException.ClusterConcurrencyViolations.Select(c => c.ToJson()));
             }
         }
 

--- a/src/Raven.Server/RavenServerStartup.cs
+++ b/src/Raven.Server/RavenServerStartup.cs
@@ -1,6 +1,7 @@
 using System;
 using System.Collections.Generic;
 using System.Diagnostics;
+using System.Linq;
 using System.Net;
 using System.Threading;
 using System.Threading.Tasks;
@@ -318,6 +319,17 @@ namespace Raven.Server
             {
                 djv[nameof(DocumentConflictException.DocId)] = documentConflictException.DocId;
                 djv[nameof(DocumentConflictException.LargestEtag)] = documentConflictException.LargestEtag;
+            }
+
+            if (exception is ConcurrencyException concurrencyException)
+            {
+                djv[nameof(ConcurrencyException.ExpectedChangeVector)] = concurrencyException.ExpectedChangeVector;
+                djv[nameof(ConcurrencyException.ActualChangeVector)] = concurrencyException.ActualChangeVector;
+                djv[nameof(ConcurrencyException.ExpectedETag)] = concurrencyException.ExpectedETag;
+                djv[nameof(ConcurrencyException.ActualETag)] = concurrencyException.ActualETag;
+    
+                if (concurrencyException.ClusterTransactionConflicts != null)
+                    djv[nameof(ConcurrencyException.ClusterTransactionConflicts)] = new DynamicJsonArray(concurrencyException.ClusterTransactionConflicts.Select(c => c.ToJson()));
             }
         }
 

--- a/src/Raven.Server/RavenServerStartup.cs
+++ b/src/Raven.Server/RavenServerStartup.cs
@@ -326,10 +326,10 @@ namespace Raven.Server
                 djv[nameof(ConcurrencyException.Id)] = concurrencyException.Id;
                 djv[nameof(ConcurrencyException.ExpectedChangeVector)] = concurrencyException.ExpectedChangeVector;
                 djv[nameof(ConcurrencyException.ActualChangeVector)] = concurrencyException.ActualChangeVector;
-
-                if (concurrencyException.ClusterConcurrencyViolations != null)
-                    djv[nameof(ConcurrencyException.ClusterConcurrencyViolations)] = new DynamicJsonArray(concurrencyException.ClusterConcurrencyViolations.Select(c => c.ToJson()));
             }
+
+            if (exception is ClusterTransactionConcurrencyException { ConcurrencyViolations: { } } ctxConcurrencyException)
+                djv[nameof(ClusterTransactionConcurrencyException.ConcurrencyViolations)] = new DynamicJsonArray(ctxConcurrencyException.ConcurrencyViolations.Select(c => c.ToJson()));
         }
 
         private static void MaybeSetExceptionStatusCode(HttpContext httpContext, ServerStore serverStore, Exception exception)

--- a/src/Raven.Server/ServerWide/ClusterStateMachine.cs
+++ b/src/Raven.Server/ServerWide/ClusterStateMachine.cs
@@ -876,7 +876,7 @@ namespace Raven.Server.ServerWide
             }
         }
 
-        private List<string> ExecuteClusterTransaction(ClusterOperationContext context, BlittableJsonReaderObject cmd, long index)
+        private List<ClusterTransactionCommand.ClusterTransactionErrorInfo> ExecuteClusterTransaction(ClusterOperationContext context, BlittableJsonReaderObject cmd, long index)
         {
             ClusterTransactionCommand clusterTransaction = null;
             Exception exception = null;

--- a/src/Raven.Server/ServerWide/Commands/ClusterTransactionCommand.cs
+++ b/src/Raven.Server/ServerWide/Commands/ClusterTransactionCommand.cs
@@ -240,8 +240,8 @@ namespace Raven.Server.ServerWide.Commands
                 Conflict = new Conflict
                 {
                     Id = clusterCommand.Id, 
-                    Actual = actualIndex.ToString(), 
-                    Expected = clusterCommand.Index.ToString(), 
+                    Actual = actualIndex, 
+                    Expected = clusterCommand.Index, 
                     Type = type
                 }
             };
@@ -568,10 +568,10 @@ namespace Raven.Server.ServerWide.Commands
             if (conflict.TryGet(nameof(Conflict.Type), out ConflictType type))
                 current.Type = type;
 
-            if (conflict.TryGet(nameof(Conflict.Expected), out string expected))
+            if (conflict.TryGet(nameof(Conflict.Expected), out long expected))
                 current.Expected = expected;
 
-            if (conflict.TryGet(nameof(Conflict.Actual), out string actual))
+            if (conflict.TryGet(nameof(Conflict.Actual), out long actual))
                 current.Actual = actual;
 
             return errorInfo;

--- a/src/Raven.Server/ServerWide/Commands/ClusterTransactionCommand.cs
+++ b/src/Raven.Server/ServerWide/Commands/ClusterTransactionCommand.cs
@@ -2,11 +2,10 @@
 using System.Collections.Generic;
 using System.Linq;
 using System.Text;
-using Raven.Client;
 using Raven.Client.Documents.Commands.Batches;
+using Raven.Client.Exceptions;
 using Raven.Client.ServerWide;
 using Raven.Server.Documents.Handlers;
-using Raven.Server.Documents.Replication;
 using Raven.Server.Json;
 using Raven.Server.Rachis;
 using Raven.Server.ServerWide.Context;
@@ -66,6 +65,21 @@ namespace Raven.Server.ServerWide.Commands
                     [nameof(ChangeVector)] = ChangeVector,
                     [nameof(Document)] = Document?.Clone(context),
                     [nameof(Error)] = Error
+                };
+            }
+        }
+
+        public class ClusterTransactionErrorInfo : IDynamicJsonValueConvertible
+        {
+            public string Message;
+            public ConcurrencyException.Conflict Conflict;
+            
+            public DynamicJsonValue ToJson()
+            {
+                return new DynamicJsonValue
+                {
+                    [nameof(Message)] = Message,
+                    [nameof(Conflict)] = Conflict.ToJson()
                 };
             }
         }
@@ -154,7 +168,7 @@ namespace Raven.Server.ServerWide.Commands
                 throw new RachisApplyException($"Document id {command.Id} cannot end with '|' or '{identityPartsSeparator}' as part of cluster transaction");
         }
 
-        public List<string> ExecuteCompareExchangeCommands(DatabaseTopology dbTopology, ClusterOperationContext context, long index, Table items)
+        public List<ClusterTransactionErrorInfo> ExecuteCompareExchangeCommands(DatabaseTopology dbTopology, ClusterOperationContext context, long index, Table items)
         {
             if (Options?.DisableAtomicDocumentWrites == false)
                 EnsureAtomicDocumentWrites(dbTopology, context, items, index);
@@ -163,7 +177,7 @@ namespace Raven.Server.ServerWide.Commands
                 return null;
 
             var toExecute = new List<CompareExchangeCommandBase>(ClusterCommands.Count);
-            var errors = new List<string>();
+            var errors = new List<ClusterTransactionErrorInfo>();
             foreach (var clusterCommand in ClusterCommands)
             {
                 long current;
@@ -173,12 +187,7 @@ namespace Raven.Server.ServerWide.Commands
                         var put = new AddOrUpdateCompareExchangeCommand(DatabaseName, clusterCommand.Id, clusterCommand.Document, clusterCommand.Index, context, null);
                         if (put.Validate(context, items, clusterCommand.Index, out current) == false)
                         {
-                            if(clusterCommand.Error != null)
-                            {
-                                errors.Add(clusterCommand.Error);
-                            }
-                            errors.Add(
-                                $"Concurrency check failed for putting the key '{clusterCommand.Id}'. Requested index: {clusterCommand.Index}, actual index: {current}");
+                            errors.Add(GenerateErrorInfo(clusterCommand, current));
                             continue;
                         }
                         toExecute.Add(put);
@@ -187,11 +196,7 @@ namespace Raven.Server.ServerWide.Commands
                         var delete = new RemoveCompareExchangeCommand(DatabaseName, clusterCommand.Id, clusterCommand.Index, context, null);
                         if (delete.Validate(context, items, clusterCommand.Index, out current) == false)
                         {
-                            if (clusterCommand.Error != null)
-                            {
-                                errors.Add(clusterCommand.Error);
-                            }
-                            errors.Add($"Concurrency check failed for deleting the key '{clusterCommand.Id}'. Requested index: {clusterCommand.Index}, actual index: {current}");
+                            errors.Add(GenerateErrorInfo(clusterCommand, current, delete: true));
                             continue;
                         }
                         toExecute.Add(delete);
@@ -199,7 +204,7 @@ namespace Raven.Server.ServerWide.Commands
                     default:
                         throw new RachisApplyException(
                             $"Invalid cluster command detected: {clusterCommand.Type}! Only " +
-                            $"CompareExchangePUT and CompareExchangeDELETE are supported.");
+                            "CompareExchangePUT and CompareExchangeDELETE are supported.");
                 }
             }
 
@@ -214,6 +219,32 @@ namespace Raven.Server.ServerWide.Commands
             }
 
             return null;
+        }
+
+        private static ClusterTransactionErrorInfo GenerateErrorInfo(ClusterTransactionDataCommand clusterCommand, long actualIndex, bool delete = false)
+        {
+            var msg = $"Concurrency check failed for {(delete ? "deleting" : "putting")} the key '{clusterCommand.Id}'. " +
+                      $"Requested index: {clusterCommand.Index}, actual index: {actualIndex}";
+
+            var type = ConcurrencyException.ConflictType.CompareExchange;
+
+            if (clusterCommand.Error != null)
+            {
+                msg = $"{clusterCommand.Error}{Environment.NewLine}{msg}";
+                type = ConcurrencyException.ConflictType.Document;
+            }
+
+            return new ClusterTransactionErrorInfo
+            {
+                Message = msg,
+                Conflict = new ConcurrencyException.Conflict
+                {
+                    Id = clusterCommand.Id, 
+                    Actual = actualIndex.ToString(), 
+                    Expected = clusterCommand.Index.ToString(), 
+                    Type = type
+                }
+            };
         }
 
         private void EnsureAtomicDocumentWrites(DatabaseTopology dbTopology, ClusterOperationContext context, Table items, long index)

--- a/src/Raven.Server/ServerWide/Commands/ClusterTransactionCommand.cs
+++ b/src/Raven.Server/ServerWide/Commands/ClusterTransactionCommand.cs
@@ -3,7 +3,6 @@ using System.Collections.Generic;
 using System.Linq;
 using System.Text;
 using Raven.Client.Documents.Commands.Batches;
-using Raven.Client.Exceptions;
 using Raven.Client.ServerWide;
 using Raven.Server.Documents.Handlers;
 using Raven.Server.Json;
@@ -17,6 +16,7 @@ using Sparrow.Json.Parsing;
 using Sparrow.Server;
 using Voron;
 using Voron.Data.Tables;
+using static Raven.Client.Exceptions.ClusterTransactionConcurrencyException;
 
 namespace Raven.Server.ServerWide.Commands
 {
@@ -72,7 +72,7 @@ namespace Raven.Server.ServerWide.Commands
         public class ClusterTransactionErrorInfo : IDynamicJsonValueConvertible
         {
             public string Message;
-            public ConcurrencyException.Conflict Conflict;
+            public Conflict Conflict;
             
             public DynamicJsonValue ToJson()
             {
@@ -226,18 +226,18 @@ namespace Raven.Server.ServerWide.Commands
             var msg = $"Concurrency check failed for {(delete ? "deleting" : "putting")} the key '{clusterCommand.Id}'. " +
                       $"Requested index: {clusterCommand.Index}, actual index: {actualIndex}";
 
-            var type = ConcurrencyException.ConflictType.CompareExchange;
+            var type = ConflictType.CompareExchange;
 
             if (clusterCommand.Error != null)
             {
                 msg = $"{clusterCommand.Error}{Environment.NewLine}{msg}";
-                type = ConcurrencyException.ConflictType.Document;
+                type = ConflictType.Document;
             }
 
             return new ClusterTransactionErrorInfo
             {
                 Message = msg,
-                Conflict = new ConcurrencyException.Conflict
+                Conflict = new Conflict
                 {
                     Id = clusterCommand.Id, 
                     Actual = actualIndex.ToString(), 

--- a/src/Raven.Server/Smuggler/Documents/DatabaseDestination.cs
+++ b/src/Raven.Server/Smuggler/Documents/DatabaseDestination.cs
@@ -643,7 +643,7 @@ namespace Raven.Server.Smuggler.Documents
                 if (clusterTransactionResult.Result is List<ClusterTransactionCommand.ClusterTransactionErrorInfo> errors)
                     throw new ConcurrencyException($"Failed to execute cluster transaction due to the following issues: {string.Join(Environment.NewLine, errors.Select(e => e.Message))}")
                     {
-                        ClusterTransactionConflicts = errors.Select(e => e.Conflict).ToArray()
+                        ClusterConcurrencyViolations = errors.Select(e => e.Conflict).ToArray()
                     };
                 
                 await _database.ServerStore.Cluster.WaitForIndexNotification(clusterTransactionResult.Index);

--- a/src/Raven.Server/Smuggler/Documents/DatabaseDestination.cs
+++ b/src/Raven.Server/Smuggler/Documents/DatabaseDestination.cs
@@ -643,7 +643,7 @@ namespace Raven.Server.Smuggler.Documents
                 if (clusterTransactionResult.Result is List<ClusterTransactionCommand.ClusterTransactionErrorInfo> errors)
                     throw new ClusterTransactionConcurrencyException($"Failed to execute cluster transaction due to the following issues: {string.Join(Environment.NewLine, errors.Select(e => e.Message))}")
                     {
-                        ConcurrencyViolations = errors.Select(e => e.Conflict).ToArray()
+                        ConcurrencyViolations = errors.Select(e => e.Violation).ToArray()
                     };
                 
                 await _database.ServerStore.Cluster.WaitForIndexNotification(clusterTransactionResult.Index);

--- a/src/Raven.Server/Smuggler/Documents/DatabaseDestination.cs
+++ b/src/Raven.Server/Smuggler/Documents/DatabaseDestination.cs
@@ -641,9 +641,9 @@ namespace Raven.Server.Smuggler.Documents
                 _documentContextHolder.Reset();
 
                 if (clusterTransactionResult.Result is List<ClusterTransactionCommand.ClusterTransactionErrorInfo> errors)
-                    throw new ConcurrencyException($"Failed to execute cluster transaction due to the following issues: {string.Join(Environment.NewLine, errors.Select(e => e.Message))}")
+                    throw new ClusterTransactionConcurrencyException($"Failed to execute cluster transaction due to the following issues: {string.Join(Environment.NewLine, errors.Select(e => e.Message))}")
                     {
-                        ClusterConcurrencyViolations = errors.Select(e => e.Conflict).ToArray()
+                        ConcurrencyViolations = errors.Select(e => e.Conflict).ToArray()
                     };
                 
                 await _database.ServerStore.Cluster.WaitForIndexNotification(clusterTransactionResult.Index);

--- a/test/RachisTests/DatabaseCluster/AtomicClusterReadWriteTests.cs
+++ b/test/RachisTests/DatabaseCluster/AtomicClusterReadWriteTests.cs
@@ -109,7 +109,7 @@ namespace RachisTests.DatabaseCluster
             Assert.Equal(2, exceptions.Count);
             foreach (var exception in exceptions)
             {
-                Assert.IsType<ConcurrencyException>(exception);
+                Assert.IsType<ClusterTransactionConcurrencyException>(exception);
             }
         }
 

--- a/test/SlowTests/Issues/RavenDB-16614.cs
+++ b/test/SlowTests/Issues/RavenDB-16614.cs
@@ -177,7 +177,7 @@ namespace SlowTests.Issues
                 }
 
                 arava.Name += "-modified";
-                var err = await Assert.ThrowsAsync<ConcurrencyException>(() => session.SaveChangesAsync());
+                var err = await Assert.ThrowsAsync<ClusterTransactionConcurrencyException>(() => session.SaveChangesAsync());
                 Assert.Contains("Failed to execute cluster transaction due to the following issues: " +
                     "Guard compare exchange value 'rvn-atomic/users/arava' index does not match ", err.Message);
             }
@@ -291,7 +291,7 @@ namespace SlowTests.Issues
                     await conflictedSession.SaveChangesAsync();
                 }
 
-                await Assert.ThrowsAsync<ConcurrencyException>(() => session.SaveChangesAsync());
+                await Assert.ThrowsAsync<ClusterTransactionConcurrencyException>(() => session.SaveChangesAsync());
             }
         }
 
@@ -323,7 +323,7 @@ namespace SlowTests.Issues
                     await conflictedSession.SaveChangesAsync();
                 }
 
-                await Assert.ThrowsAsync<ConcurrencyException>(() => session.SaveChangesAsync());
+                await Assert.ThrowsAsync<ClusterTransactionConcurrencyException>(() => session.SaveChangesAsync());
             }
         }
     }

--- a/test/SlowTests/Issues/RavenDB-17128.cs
+++ b/test/SlowTests/Issues/RavenDB-17128.cs
@@ -6,6 +6,7 @@ using Raven.Client.Exceptions;
 using Sparrow.Json.Parsing;
 using Xunit;
 using Xunit.Abstractions;
+using static Raven.Client.Exceptions.ClusterTransactionConcurrencyException.ConflictType;
 
 namespace SlowTests.Issues
 {
@@ -40,20 +41,20 @@ namespace SlowTests.Issues
                     session.Advanced.ClusterTransaction
                         .CreateCompareExchangeValue("emails/info@ravendb.net", new object());
 
-                    var ex = await Assert.ThrowsAsync<ConcurrencyException>(async () => await session.SaveChangesAsync());
+                    var ex = await Assert.ThrowsAsync<ClusterTransactionConcurrencyException>(async () => await session.SaveChangesAsync());
                     
-                    Assert.NotNull(ex.ClusterConcurrencyViolations);
-                    Assert.Equal(2, ex.ClusterConcurrencyViolations.Length);
+                    Assert.NotNull(ex.ConcurrencyViolations);
+                    Assert.Equal(2, ex.ConcurrencyViolations.Length);
 
-                    Assert.Equal(ConcurrencyException.ConflictType.CompareExchange, ex.ClusterConcurrencyViolations[0].Type);
-                    Assert.Equal("usernames/ravendb", ex.ClusterConcurrencyViolations[0].Id);
-                    Assert.NotNull(ex.ClusterConcurrencyViolations[0].Expected);
-                    Assert.NotNull(ex.ClusterConcurrencyViolations[0].Actual);
+                    Assert.Equal(CompareExchange, ex.ConcurrencyViolations[0].Type);
+                    Assert.Equal("usernames/ravendb", ex.ConcurrencyViolations[0].Id);
+                    Assert.NotNull(ex.ConcurrencyViolations[0].Expected);
+                    Assert.NotNull(ex.ConcurrencyViolations[0].Actual);
 
-                    Assert.Equal(ConcurrencyException.ConflictType.CompareExchange, ex.ClusterConcurrencyViolations[1].Type);
-                    Assert.Equal("emails/info@ravendb.net", ex.ClusterConcurrencyViolations[1].Id);
-                    Assert.NotNull(ex.ClusterConcurrencyViolations[1].Expected);
-                    Assert.NotNull(ex.ClusterConcurrencyViolations[1].Actual);
+                    Assert.Equal(CompareExchange, ex.ConcurrencyViolations[1].Type);
+                    Assert.Equal("emails/info@ravendb.net", ex.ConcurrencyViolations[1].Id);
+                    Assert.NotNull(ex.ConcurrencyViolations[1].Expected);
+                    Assert.NotNull(ex.ConcurrencyViolations[1].Actual);
                 }
             }
         }
@@ -88,19 +89,19 @@ namespace SlowTests.Issues
                     o1.Value = 13;
                     o2.Value = 23;
 
-                    var ex = Assert.Throws<ConcurrencyException>(() => session.SaveChanges());
-                    Assert.NotNull(ex.ClusterConcurrencyViolations);
-                    Assert.Equal(2, ex.ClusterConcurrencyViolations.Length);
+                    var ex = Assert.Throws<ClusterTransactionConcurrencyException>(() => session.SaveChanges());
+                    Assert.NotNull(ex.ConcurrencyViolations);
+                    Assert.Equal(2, ex.ConcurrencyViolations.Length);
 
-                    Assert.Equal(ConcurrencyException.ConflictType.Document, ex.ClusterConcurrencyViolations[0].Type);
-                    Assert.Equal("rvn-atomic/objects/1", ex.ClusterConcurrencyViolations[0].Id);
-                    Assert.NotNull(ex.ClusterConcurrencyViolations[0].Expected);
-                    Assert.NotNull(ex.ClusterConcurrencyViolations[0].Actual);
+                    Assert.Equal(ClusterTransactionConcurrencyException.ConflictType.Document, ex.ConcurrencyViolations[0].Type);
+                    Assert.Equal("rvn-atomic/objects/1", ex.ConcurrencyViolations[0].Id);
+                    Assert.NotNull(ex.ConcurrencyViolations[0].Expected);
+                    Assert.NotNull(ex.ConcurrencyViolations[0].Actual);
 
-                    Assert.Equal(ConcurrencyException.ConflictType.Document, ex.ClusterConcurrencyViolations[1].Type);
-                    Assert.Equal("rvn-atomic/objects/2", ex.ClusterConcurrencyViolations[1].Id);
-                    Assert.NotNull(ex.ClusterConcurrencyViolations[1].Expected);
-                    Assert.NotNull(ex.ClusterConcurrencyViolations[1].Actual);
+                    Assert.Equal(ClusterTransactionConcurrencyException.ConflictType.Document, ex.ConcurrencyViolations[1].Type);
+                    Assert.Equal("rvn-atomic/objects/2", ex.ConcurrencyViolations[1].Id);
+                    Assert.NotNull(ex.ConcurrencyViolations[1].Expected);
+                    Assert.NotNull(ex.ConcurrencyViolations[1].Actual);
                 }
             }
         }

--- a/test/SlowTests/Issues/RavenDB-17128.cs
+++ b/test/SlowTests/Issues/RavenDB-17128.cs
@@ -6,7 +6,7 @@ using Raven.Client.Exceptions;
 using Sparrow.Json.Parsing;
 using Xunit;
 using Xunit.Abstractions;
-using static Raven.Client.Exceptions.ClusterTransactionConcurrencyException.ConflictType;
+using static Raven.Client.Exceptions.ClusterTransactionConcurrencyException.ViolationOnType;
 
 namespace SlowTests.Issues
 {
@@ -93,12 +93,12 @@ namespace SlowTests.Issues
                     Assert.NotNull(ex.ConcurrencyViolations);
                     Assert.Equal(2, ex.ConcurrencyViolations.Length);
 
-                    Assert.Equal(ClusterTransactionConcurrencyException.ConflictType.Document, ex.ConcurrencyViolations[0].Type);
+                    Assert.Equal(ClusterTransactionConcurrencyException.ViolationOnType.Document, ex.ConcurrencyViolations[0].Type);
                     Assert.Equal("rvn-atomic/objects/1", ex.ConcurrencyViolations[0].Id);
                     Assert.True(ex.ConcurrencyViolations[0].Expected > 0);
                     Assert.True(ex.ConcurrencyViolations[0].Actual > 0);
 
-                    Assert.Equal(ClusterTransactionConcurrencyException.ConflictType.Document, ex.ConcurrencyViolations[1].Type);
+                    Assert.Equal(ClusterTransactionConcurrencyException.ViolationOnType.Document, ex.ConcurrencyViolations[1].Type);
                     Assert.Equal("rvn-atomic/objects/2", ex.ConcurrencyViolations[1].Id);
                     Assert.True(ex.ConcurrencyViolations[1].Expected > 0);
                     Assert.True(ex.ConcurrencyViolations[1].Actual > 0);

--- a/test/SlowTests/Issues/RavenDB-17128.cs
+++ b/test/SlowTests/Issues/RavenDB-17128.cs
@@ -48,13 +48,13 @@ namespace SlowTests.Issues
 
                     Assert.Equal(CompareExchange, ex.ConcurrencyViolations[0].Type);
                     Assert.Equal("usernames/ravendb", ex.ConcurrencyViolations[0].Id);
-                    Assert.NotNull(ex.ConcurrencyViolations[0].Expected);
-                    Assert.NotNull(ex.ConcurrencyViolations[0].Actual);
+                    Assert.Equal(0 ,ex.ConcurrencyViolations[0].Expected);
+                    Assert.True(ex.ConcurrencyViolations[0].Actual > 0);
 
                     Assert.Equal(CompareExchange, ex.ConcurrencyViolations[1].Type);
                     Assert.Equal("emails/info@ravendb.net", ex.ConcurrencyViolations[1].Id);
-                    Assert.NotNull(ex.ConcurrencyViolations[1].Expected);
-                    Assert.NotNull(ex.ConcurrencyViolations[1].Actual);
+                    Assert.Equal(0, ex.ConcurrencyViolations[1].Expected);
+                    Assert.True(ex.ConcurrencyViolations[1].Actual > 0);
                 }
             }
         }
@@ -95,13 +95,13 @@ namespace SlowTests.Issues
 
                     Assert.Equal(ClusterTransactionConcurrencyException.ConflictType.Document, ex.ConcurrencyViolations[0].Type);
                     Assert.Equal("rvn-atomic/objects/1", ex.ConcurrencyViolations[0].Id);
-                    Assert.NotNull(ex.ConcurrencyViolations[0].Expected);
-                    Assert.NotNull(ex.ConcurrencyViolations[0].Actual);
+                    Assert.True(ex.ConcurrencyViolations[0].Expected > 0);
+                    Assert.True(ex.ConcurrencyViolations[0].Actual > 0);
 
                     Assert.Equal(ClusterTransactionConcurrencyException.ConflictType.Document, ex.ConcurrencyViolations[1].Type);
                     Assert.Equal("rvn-atomic/objects/2", ex.ConcurrencyViolations[1].Id);
-                    Assert.NotNull(ex.ConcurrencyViolations[1].Expected);
-                    Assert.NotNull(ex.ConcurrencyViolations[1].Actual);
+                    Assert.True(ex.ConcurrencyViolations[1].Expected > 0);
+                    Assert.True(ex.ConcurrencyViolations[1].Actual > 0);
                 }
             }
         }

--- a/test/SlowTests/Issues/RavenDB-17128.cs
+++ b/test/SlowTests/Issues/RavenDB-17128.cs
@@ -1,0 +1,184 @@
+﻿using System.Threading.Tasks;
+using FastTests.Server.Replication;
+using Raven.Client.Documents.Commands;
+using Raven.Client.Documents.Session;
+using Raven.Client.Exceptions;
+using Sparrow.Json.Parsing;
+using Xunit;
+using Xunit.Abstractions;
+
+namespace SlowTests.Issues
+{
+    public class RavenDB_17128 : ReplicationTestBase
+    {
+        public RavenDB_17128(ITestOutputHelper output) : base(output)
+        {
+        }
+
+
+        [Fact]
+        public async Task ConcurrencyExceptionShouldIncludeConflictsInfo_CompareExchangeClusterWide()
+        {
+            using (var store = GetDocumentStore())
+            {
+                using (var session = store.OpenAsyncSession(new SessionOptions { TransactionMode = TransactionMode.ClusterWide }))
+                {
+                    session.Advanced.ClusterTransaction
+                        .CreateCompareExchangeValue("usernames/ravendb", new object());
+
+                    session.Advanced.ClusterTransaction
+                        .CreateCompareExchangeValue("emails/info@ravendb.net", new object());
+
+                    await session.SaveChangesAsync();
+                }
+
+                using (var session = store.OpenAsyncSession(new SessionOptions { TransactionMode = TransactionMode.ClusterWide }))
+                {
+                    session.Advanced.ClusterTransaction
+                        .CreateCompareExchangeValue("usernames/ravendb", new object());
+
+                    session.Advanced.ClusterTransaction
+                        .CreateCompareExchangeValue("emails/info@ravendb.net", new object());
+
+                    var ex = await Assert.ThrowsAsync<ConcurrencyException>(async () => await session.SaveChangesAsync());
+                    
+                    Assert.NotNull(ex.ClusterTransactionConflicts);
+                    Assert.Equal(2, ex.ClusterTransactionConflicts.Length);
+
+                    Assert.Equal(ConcurrencyException.ConflictType.CompareExchange, ex.ClusterTransactionConflicts[0].Type);
+                    Assert.Equal("usernames/ravendb", ex.ClusterTransactionConflicts[0].Id);
+                    Assert.NotNull(ex.ClusterTransactionConflicts[0].Expected);
+                    Assert.NotNull(ex.ClusterTransactionConflicts[0].Actual);
+
+                    Assert.Equal(ConcurrencyException.ConflictType.CompareExchange, ex.ClusterTransactionConflicts[1].Type);
+                    Assert.Equal("emails/info@ravendb.net", ex.ClusterTransactionConflicts[1].Id);
+                    Assert.NotNull(ex.ClusterTransactionConflicts[1].Expected);
+                    Assert.NotNull(ex.ClusterTransactionConflicts[1].Actual);
+                }
+            }
+        }
+
+        [Fact]
+        public void ConcurrencyExceptionShouldIncludeConflictsInfo_DocumentsClusterWide()
+        {
+            using (var store = GetDocumentStore())
+            {
+                using (var session = store.OpenSession(new SessionOptions { TransactionMode = TransactionMode.ClusterWide }))
+                {
+                    session.Store(new Document { Value = 1 }, "objects/1");
+                    session.Store(new Document { Value = 2 }, "objects/2");
+
+                    session.SaveChanges();
+                }
+
+                using (var session = store.OpenSession(new SessionOptions { TransactionMode = TransactionMode.ClusterWide }))
+                using (var session2 = store.OpenSession(new SessionOptions { TransactionMode = TransactionMode.ClusterWide }))
+                {
+                    var o1 = session.Load<Document>("objects/1");
+                    var o2 = session.Load<Document>("objects/2");
+
+                    var o12 = session2.Load<Document>("objects/1");
+                    var o22 = session2.Load<Document>("objects/2");
+
+                    o12.Value = 12;
+                    o22.Value = 22;
+
+                    session2.SaveChanges();
+
+                    o1.Value = 13;
+                    o2.Value = 23;
+
+                    var ex = Assert.Throws<ConcurrencyException>(() => session.SaveChanges());
+                    Assert.NotNull(ex.ClusterTransactionConflicts);
+                    Assert.Equal(2, ex.ClusterTransactionConflicts.Length);
+
+                    Assert.Equal(ConcurrencyException.ConflictType.Document, ex.ClusterTransactionConflicts[0].Type);
+                    Assert.Equal("rvn-atomic/objects/1", ex.ClusterTransactionConflicts[0].Id);
+                    Assert.NotNull(ex.ClusterTransactionConflicts[0].Expected);
+                    Assert.NotNull(ex.ClusterTransactionConflicts[0].Actual);
+
+                    Assert.Equal(ConcurrencyException.ConflictType.Document, ex.ClusterTransactionConflicts[1].Type);
+                    Assert.Equal("rvn-atomic/objects/2", ex.ClusterTransactionConflicts[1].Id);
+                    Assert.NotNull(ex.ClusterTransactionConflicts[1].Expected);
+                    Assert.NotNull(ex.ClusterTransactionConflicts[1].Actual);
+                }
+            }
+        }
+
+        [Fact]
+        public void ConcurrencyExceptionShouldIncludeConflictsInfo_DocumentsSingleNode()
+        {
+            using (var store = GetDocumentStore())
+            {
+                using (var session = store.OpenSession(new SessionOptions { TransactionMode = TransactionMode.ClusterWide }))
+                {
+                    session.Store(new Document { Value = 1 }, "objects/1");
+                    session.Store(new Document { Value = 2 }, "objects/2");
+
+                    session.SaveChanges();
+                }
+
+                using (var session = store.OpenSession())
+                using (var session2 = store.OpenSession())
+                {
+                    session.Advanced.UseOptimisticConcurrency = true;
+                    session2.Advanced.UseOptimisticConcurrency = true;
+
+                    var o1 = session.Load<Document>("objects/1");
+                    var o2 = session.Load<Document>("objects/2");
+
+                    var o12 = session2.Load<Document>("objects/1");
+                    var o22 = session2.Load<Document>("objects/2");
+
+                    o12.Value = 12;
+                    o22.Value = 22;
+
+                    session2.SaveChanges();
+
+                    o1.Value = 13;
+                    o2.Value = 23;
+
+                    var ex = Assert.Throws<ConcurrencyException>(() => session.SaveChanges());
+
+                    Assert.NotNull(ex.ExpectedChangeVector);
+                    Assert.NotNull(ex.ActualChangeVector);
+                }
+            }
+        }
+
+        [Fact]
+        public void ConcurrencyExceptionShouldIncludeConflictsInfo_DocumentPut()
+        {
+            using (var store = GetDocumentStore())
+            {
+                using (var session = store.OpenSession(new SessionOptions { TransactionMode = TransactionMode.ClusterWide }))
+                {
+                    session.Store(new Document { Value = 1 }, "objects/1");
+                    session.SaveChanges();
+                }
+
+                using (var session = store.OpenSession())
+                {
+                    var doc = session.Load<Document>("objects/1");
+                    var cv = session.Advanced.GetChangeVectorFor(doc);
+                    var djv = new DynamicJsonValue
+                    {
+                        ["Name"] = "ayende"
+                    };
+                    var re = store.GetRequestExecutor();
+                    using (re.ContextPool.AllocateOperationContext(out var ctx))
+                    using (var blittable = ctx.ReadObject(djv, "new/1"))
+                    {
+                        var ex = Assert.Throws<ConcurrencyException>(() => re.Execute(new PutDocumentCommand("new/1", cv, blittable), ctx));
+                        Assert.Equal(cv, ex.ExpectedChangeVector);
+                    }
+                }
+            }
+        }
+
+        private class Document
+        {
+            public int Value;
+        }
+    }
+}

--- a/test/SlowTests/Issues/RavenDB-17128.cs
+++ b/test/SlowTests/Issues/RavenDB-17128.cs
@@ -42,18 +42,18 @@ namespace SlowTests.Issues
 
                     var ex = await Assert.ThrowsAsync<ConcurrencyException>(async () => await session.SaveChangesAsync());
                     
-                    Assert.NotNull(ex.ClusterTransactionConflicts);
-                    Assert.Equal(2, ex.ClusterTransactionConflicts.Length);
+                    Assert.NotNull(ex.ClusterConcurrencyViolations);
+                    Assert.Equal(2, ex.ClusterConcurrencyViolations.Length);
 
-                    Assert.Equal(ConcurrencyException.ConflictType.CompareExchange, ex.ClusterTransactionConflicts[0].Type);
-                    Assert.Equal("usernames/ravendb", ex.ClusterTransactionConflicts[0].Id);
-                    Assert.NotNull(ex.ClusterTransactionConflicts[0].Expected);
-                    Assert.NotNull(ex.ClusterTransactionConflicts[0].Actual);
+                    Assert.Equal(ConcurrencyException.ConflictType.CompareExchange, ex.ClusterConcurrencyViolations[0].Type);
+                    Assert.Equal("usernames/ravendb", ex.ClusterConcurrencyViolations[0].Id);
+                    Assert.NotNull(ex.ClusterConcurrencyViolations[0].Expected);
+                    Assert.NotNull(ex.ClusterConcurrencyViolations[0].Actual);
 
-                    Assert.Equal(ConcurrencyException.ConflictType.CompareExchange, ex.ClusterTransactionConflicts[1].Type);
-                    Assert.Equal("emails/info@ravendb.net", ex.ClusterTransactionConflicts[1].Id);
-                    Assert.NotNull(ex.ClusterTransactionConflicts[1].Expected);
-                    Assert.NotNull(ex.ClusterTransactionConflicts[1].Actual);
+                    Assert.Equal(ConcurrencyException.ConflictType.CompareExchange, ex.ClusterConcurrencyViolations[1].Type);
+                    Assert.Equal("emails/info@ravendb.net", ex.ClusterConcurrencyViolations[1].Id);
+                    Assert.NotNull(ex.ClusterConcurrencyViolations[1].Expected);
+                    Assert.NotNull(ex.ClusterConcurrencyViolations[1].Actual);
                 }
             }
         }
@@ -89,18 +89,18 @@ namespace SlowTests.Issues
                     o2.Value = 23;
 
                     var ex = Assert.Throws<ConcurrencyException>(() => session.SaveChanges());
-                    Assert.NotNull(ex.ClusterTransactionConflicts);
-                    Assert.Equal(2, ex.ClusterTransactionConflicts.Length);
+                    Assert.NotNull(ex.ClusterConcurrencyViolations);
+                    Assert.Equal(2, ex.ClusterConcurrencyViolations.Length);
 
-                    Assert.Equal(ConcurrencyException.ConflictType.Document, ex.ClusterTransactionConflicts[0].Type);
-                    Assert.Equal("rvn-atomic/objects/1", ex.ClusterTransactionConflicts[0].Id);
-                    Assert.NotNull(ex.ClusterTransactionConflicts[0].Expected);
-                    Assert.NotNull(ex.ClusterTransactionConflicts[0].Actual);
+                    Assert.Equal(ConcurrencyException.ConflictType.Document, ex.ClusterConcurrencyViolations[0].Type);
+                    Assert.Equal("rvn-atomic/objects/1", ex.ClusterConcurrencyViolations[0].Id);
+                    Assert.NotNull(ex.ClusterConcurrencyViolations[0].Expected);
+                    Assert.NotNull(ex.ClusterConcurrencyViolations[0].Actual);
 
-                    Assert.Equal(ConcurrencyException.ConflictType.Document, ex.ClusterTransactionConflicts[1].Type);
-                    Assert.Equal("rvn-atomic/objects/2", ex.ClusterTransactionConflicts[1].Id);
-                    Assert.NotNull(ex.ClusterTransactionConflicts[1].Expected);
-                    Assert.NotNull(ex.ClusterTransactionConflicts[1].Actual);
+                    Assert.Equal(ConcurrencyException.ConflictType.Document, ex.ClusterConcurrencyViolations[1].Type);
+                    Assert.Equal("rvn-atomic/objects/2", ex.ClusterConcurrencyViolations[1].Id);
+                    Assert.NotNull(ex.ClusterConcurrencyViolations[1].Expected);
+                    Assert.NotNull(ex.ClusterConcurrencyViolations[1].Actual);
                 }
             }
         }


### PR DESCRIPTION
### Issue link

https://issues.hibernatingrhinos.com/issue/RavenDB-17128

### Additional description
- add cluster transaction conflicts information to `ConcurrencyException`
- include the additional data of `ConcurrencyException` (the new `ClusterTransactionConflicts` field and the existing `Expected/Actual-Etag/ChangeVector` fields) in `RavenServerStartup.MaybeAddAdditionalExceptionData` and in `ExceptionDispatcher`

### Type of change

- Bug fix
- New feature

### How risky is the change?

- Low 

### Testing 

- Tests have been added that prove the fix is effective or that the feature works
