### PR TITLE
RavenDB-17633: Rearrange the backup timer if the backup got active by other node and then got active by current node while running

### DIFF
--- a/src/Raven.Server/Documents/PeriodicBackup/PeriodicBackup.cs
+++ b/src/Raven.Server/Documents/PeriodicBackup/PeriodicBackup.cs
@@ -60,21 +60,18 @@ namespace Raven.Server.Documents.PeriodicBackup
             return new DisposableAction(() => _updateBackupTaskSemaphore.Release());
         }
 
-        public void DisableFutureBackups(bool cancelRunningBackup)
+        public void DisableFutureBackups()
         {
             using (UpdateBackupTask())
             {
-                CancelFutureTasks(cancelRunningBackup);
+                CancelFutureTasks();
             }
         }
 
-        private void CancelFutureTasks(bool cancelRunningBackup = true)
+        private void CancelFutureTasks()
         {
             _backupTimer?.Dispose();
             _backupTimer = null;
-
-            if (cancelRunningBackup == false)
-                return;
 
             try
             {

--- a/test/SlowTests/Server/Documents/PeriodicBackup/PeriodicBackupSlowTests.cs
+++ b/test/SlowTests/Server/Documents/PeriodicBackup/PeriodicBackupSlowTests.cs
@@ -1767,9 +1767,6 @@ namespace SlowTests.Server.Documents.PeriodicBackup
 
                     responsibleDatabase.PeriodicBackupRunner.ForTestingPurposesOnly().SimulateActiveByOtherNodeStatus_UpdateConfigurations = true;
                     responsibleDatabase.PeriodicBackupRunner.UpdateConfigurations(record1);
-                    var pb = responsibleDatabase.PeriodicBackupRunner.PeriodicBackups.FirstOrDefault();
-                    Assert.NotNull(pb);
-                    Assert.False(pb.HasScheduledBackup(), "ActiveByOtherNode didn't remove the backup timer.");
                     responsibleDatabase.PeriodicBackupRunner.ForTestingPurposesOnly().SimulateActiveByOtherNodeStatus_UpdateConfigurations = false;
                     responsibleDatabase.PeriodicBackupRunner.ForTestingPurposesOnly().SimulateActiveByCurrentNode_UpdateConfigurations = true;
                     responsibleDatabase.PeriodicBackupRunner.UpdateConfigurations(record1);

--- a/test/SlowTests/Server/Documents/PeriodicBackup/PeriodicBackupSlowTests.cs
+++ b/test/SlowTests/Server/Documents/PeriodicBackup/PeriodicBackupSlowTests.cs
@@ -1729,6 +1729,84 @@ namespace SlowTests.Server.Documents.PeriodicBackup
             }
         }
 
+        [Fact, Trait("Category", "Smuggler")]
+        public async Task ShouldRearrangeTheBackupTimer_IfItGot_ActiveByOtherNode_Then_ActiveByCurrentNode_WhileRunning()
+        {
+            var backupPath = NewDataPath(suffix: "BackupFolder");
+            using (var server = GetNewServer())
+            using (var store = GetDocumentStore(new Options
+            {
+                Server = server
+            }))
+            {
+                const string documentId = "Users/1";
+                using (var session = store.OpenAsyncSession())
+                {
+                    await session.StoreAsync(new User { Name = "Grisha" }, documentId);
+                    await session.SaveChangesAsync();
+                }
+
+                var config = Backup.CreateBackupConfiguration(backupPath);
+
+                var documentDatabase = await server.ServerStore.DatabasesLandlord.TryGetOrCreateResourceStore(store.Database).ConfigureAwait(false);
+                Assert.NotNull(documentDatabase);
+                var tcs = new TaskCompletionSource<object>();
+                documentDatabase.PeriodicBackupRunner.ForTestingPurposesOnly().OnBackupTaskRunHoldBackupExecution = tcs;
+                try
+                {
+                    var backupTaskId = await Backup.UpdateConfigAndRunBackupAsync(server, config, store, opStatus: OperationStatus.InProgress);
+                    var record1 = await store.Maintenance.Server.SendAsync(new GetDatabaseRecordOperation(store.Database));
+                    var backups1 = record1.PeriodicBackups;
+                    Assert.Equal(1, backups1.Count);
+
+                    var taskId = backups1.First().TaskId;
+                    var responsibleDatabase = await server.ServerStore.DatabasesLandlord.TryGetOrCreateResourceStore(store.Database).ConfigureAwait(false);
+                    Assert.NotNull(responsibleDatabase);
+                    var tag = responsibleDatabase.PeriodicBackupRunner.WhoseTaskIsIt(taskId);
+                    Assert.Equal(server.ServerStore.NodeTag, tag);
+
+                    responsibleDatabase.PeriodicBackupRunner.ForTestingPurposesOnly().SimulateActiveByOtherNodeStatus_UpdateConfigurations = true;
+                    responsibleDatabase.PeriodicBackupRunner.UpdateConfigurations(record1);
+                    var pb = responsibleDatabase.PeriodicBackupRunner.PeriodicBackups.FirstOrDefault();
+                    Assert.NotNull(pb);
+                    Assert.False(pb.HasScheduledBackup(), "ActiveByOtherNode didn't remove the backup timer.");
+                    responsibleDatabase.PeriodicBackupRunner.ForTestingPurposesOnly().SimulateActiveByOtherNodeStatus_UpdateConfigurations = false;
+                    responsibleDatabase.PeriodicBackupRunner.ForTestingPurposesOnly().SimulateActiveByCurrentNode_UpdateConfigurations = true;
+                    responsibleDatabase.PeriodicBackupRunner.UpdateConfigurations(record1);
+                    tcs.SetResult(null);
+
+                    responsibleDatabase.PeriodicBackupRunner._forTestingPurposes = null;
+                    var getPeriodicBackupStatus = new GetPeriodicBackupStatusOperation(taskId);
+                    PeriodicBackupStatus status = null;
+                    var val = WaitForValue(() =>
+                    {
+                        status = store.Maintenance.Send(getPeriodicBackupStatus).Status;
+                        return status?.LastFullBackup != null;
+                    }, true, timeout: 66666, interval: 444);
+                    Assert.NotNull(status);
+                    Assert.Null(status.Error);
+                    Assert.True(val, "Failed to complete the backup in time");
+
+                    var pb2 = responsibleDatabase.PeriodicBackupRunner.PeriodicBackups.FirstOrDefault();
+                    Assert.NotNull(pb2);
+                    Assert.True(pb2.HasScheduledBackup(), "Completed backup didn't schedule next one.");
+                }
+                finally
+                {
+                    try
+                    {
+                        tcs.TrySetResult(null);
+                    }
+                    catch
+                    {
+                        // ignored
+                    }
+
+                    documentDatabase.PeriodicBackupRunner.ForTestingPurposesOnly().OnBackupTaskRunHoldBackupExecution = null;
+                }
+            }
+        }
+
         private static string GetBackupPath(IDocumentStore store, long backTaskId, bool incremental = true)
         {
             var status = store.Maintenance.Send(new GetPeriodicBackupStatusOperation(backTaskId)).Status;


### PR DESCRIPTION

### Issue link

https://issues.hibernatingrhinos.com/issue/RavenDB-17633
### Additional description

Currently if task state is `ActiveByCurrentNode` and is being processed we always assume the timer will rearrange when the backup finish, but if it got `ActiveByOtherNode` while running the backup timer is disposed, then when the backup finish it check if there is an active timer, but it there isn't so we end up without scheduling next backup, this PR is handling this edge case by always scheduling the timer (to next backup occurrence) if the task status got `ActiveByCurrentNode` while running and it doesn't have a timer.

### Type of change

- Bug fix

### How risky is the change?

- Low 

### Backward compatibility

- Not relevant

### Is it platform specific issue?

- No

### Documentation update

- No documentation update is needed 

### Testing 

- Tests have been added that prove the fix is effective or that the feature works
 - Internal classes added to the test class
- It has been verified by manual testing

### Is there any existing behavior change of other features due to this change?

- No

### UI work

- No UI work is needed
