### PR TITLE
RavenDB-17640: Calculation of size when tokens have multibyte characters

### DIFF
--- a/src/Raven.Server/Documents/Indexes/Persistence/Corax/LuceneAnalyzerAdapter.cs
+++ b/src/Raven.Server/Documents/Indexes/Persistence/Corax/LuceneAnalyzerAdapter.cs
@@ -59,7 +59,7 @@ namespace Raven.Server.Documents.Indexes.Persistence.Corax
                     token.Type = TokenType.Word;
 
                     // Advance the current token output.
-                    currentOutputIdx += length;
+                    currentOutputIdx += outputLength;
                     currentTokenIdx++;
                 }
                 while (stream.IncrementToken());
@@ -71,8 +71,9 @@ namespace Raven.Server.Documents.Indexes.Persistence.Corax
 
         internal static void Run(Analyzer adapter, ReadOnlySpan<char> source, ref Span<char> output, ref Span<Token> tokens)
         {
-            // TODO: Currently we are not going to be supporting the use of UTF-16 in the Lucene Analyzer Adapter. All tests should
-            //       use ASCII values. 
+            // PERF: Currently we are not going to be supporting the use of UTF-16 in the Lucene Analyzer Adapter. 
+            //       A proper implementation of SpanTextReader for ReadOnlySpan<char> should be built in order to
+            //       avoid the GetBytes conversions required. 
             throw new NotImplementedException();
         }
 

--- a/test/FastTests/Server/Documents/Indexing/Corax/LuceneAnalyzerAdapter.cs
+++ b/test/FastTests/Server/Documents/Indexing/Corax/LuceneAnalyzerAdapter.cs
@@ -46,5 +46,25 @@ namespace FastTests.Server.Documents.Indexing.Corax
             Assert.Equal(4u, outputTokens[3].Length);
             Assert.Equal(TokenType.Word, outputTokens[3].Type);
         }
+
+        [Fact]
+        public void StandardAnalyzerWithSampleDataUtf8()
+        {
+            Span<byte> source = Encoding.UTF8.GetBytes("Toms Spezialitäten");
+            //Notice: Raven uses 29 version, not 30.
+            var analyzer = LuceneAnalyzerAdapter.Create(new RavenStandardAnalyzer(Version.LUCENE_29));
+
+            Span<byte> outputBuffer = new byte[512];
+            Span<Token> outputTokens = new Token[512];
+
+            analyzer.Execute(source, ref outputBuffer, ref outputTokens);
+
+            Assert.Equal(2, outputTokens.Length);
+            var firstWord = outputBuffer.Slice(outputTokens[0].Offset, (int)outputTokens[0].Length);
+            Assert.Equal("toms", System.Text.Encoding.Default.GetString(firstWord));
+            Assert.True(outputTokens[1].Offset + (int)outputTokens[1].Length <= outputBuffer.Length);
+            var secondWord = outputBuffer.Slice(outputTokens[1].Offset, (int)outputTokens[1].Length);
+            Assert.Equal("spezialitäten", System.Text.Encoding.Default.GetString(secondWord));
+        }
     }
 }


### PR DESCRIPTION
The origin of the issue was that we didnt adjust the size of the token in face of multibyte characters. 