### PR TITLE
RavenDB-17555  Ongoing Tasks Stats: Add Labels

### DIFF
--- a/src/Raven.Studio/typescript/viewmodels/database/indexes/indexPerformance.ts
+++ b/src/Raven.Studio/typescript/viewmodels/database/indexes/indexPerformance.ts
@@ -1053,18 +1053,18 @@ class indexPerformance extends viewModelBase {
             context.fillRect(currentX, yStart, dx, indexPerformance.trackHeight);
 
             if (yOffset !== 0) { // track is opened
-                if (dx >= 0.8) { // don't show tooltip for very small items
+                if (dx >= 0.8) { // don't show tooltip & text for very small items
                     this.hitTest.registerTrackItem(currentX, yStart, dx, indexPerformance.trackHeight, op);
-                }
-       
-                if (dx > 30) {
-                    context.fillStyle = this.colors.stripeTextColor;
-                    const text = op.Name.startsWith("Collection_") ? `${op.Name.substr("Collection_".length)} (Collection)` : op.Name;
-                    const textWidth = context.measureText(text).width;
-                    const truncatedText = graphHelper.truncText(text, textWidth, dx - 4);
-                    if (truncatedText) {
-                        context.font = "12px Lato";
-                        context.fillText(truncatedText, currentX + 2, yStart + 13, dx - 4);
+
+                    if (dx > 30) {
+                        context.fillStyle = this.colors.stripeTextColor;
+                        const text = op.Name.startsWith("Collection_") ? `${op.Name.substr("Collection_".length)} (Collection)` : op.Name;
+                        const textWidth = context.measureText(text).width;
+                        const truncatedText = graphHelper.truncText(text, textWidth, dx - 4);
+                        if (truncatedText) {
+                            context.font = "12px Lato";
+                            context.fillText(truncatedText, currentX + 2, yStart + 13, dx - 4);
+                        }
                     }
                 }
             } else { // track is closed

--- a/src/Raven.Studio/typescript/viewmodels/database/status/ongoingTasksStats.ts
+++ b/src/Raven.Studio/typescript/viewmodels/database/status/ongoingTasksStats.ts
@@ -1661,10 +1661,13 @@ class ongoingTasksStats extends viewModelBase {
             // Register items:
             // 1. Track is open
             if (yOffset !== 0) {
-                if (dx >= 0.8) { // Don't show tooltip for very small items
-                    this.hitTest.registerTrackItem(currentX, yStart, dx, ongoingTasksStats.trackHeight, perfItemWithCache, op);
+                if (dx >= 0.8) { // Don't show tooltip & text for small items
+                    this.hitTest.registerTrackItem(currentX, yStart, dx, ongoingTasksStats.trackHeight, perfItemWithCache, op); 
+                    
+                    if (dx > 30) {
+                        this.drawTextOnStripe(context, op.Name, dx, currentX, yStart);
+                    }
                 }
-                this.drawTextOnStripe(context, op.Name, dx, currentX, yStart);
             }
             // 2. Track is closed
             else if (isRootOperation) { // register only on root item
@@ -1715,10 +1718,13 @@ class ongoingTasksStats extends viewModelBase {
         
         // Track is open
         if (yOffset !== 0) {
-            if (dx >= 0.8) { // Don't show tooltip for very small items
+            if (dx >= 0.8) { // Don't show tooltip & text for very small items
                 this.hitTest.registerSubscriptionConnectionItem(xStart, yStart, dx, ongoingTasksStats.trackHeight, this.mapItemToRegister(perfItemWithCache, operationDuration));
+                
+                if (dx > 30) {
+                    this.drawTextOnStripe(context, "ClientConnection", dx, xStart, yStart);
+                }
             }
-            this.drawTextOnStripe(context, "ClientConnection", dx, xStart, yStart);
         }
         // Track is closed
         else if (dx >= 0.8) {
@@ -2288,14 +2294,12 @@ class ongoingTasksStats extends viewModelBase {
     }
     
     private drawTextOnStripe(context: CanvasRenderingContext2D, text: string, dx: number, xStart: number, yStart: number): void {
-        if (dx > 30) {
-            context.fillStyle = this.colors.stripeTextColor;
-            const textWidth = context.measureText(text).width;
-            const truncatedText = graphHelper.truncText(text, textWidth, dx - 4);
-            if (truncatedText) {
-                context.font = "12px Lato";
-                context.fillText(truncatedText, xStart + 2, yStart + 13, dx - 4);
-            }
+        context.fillStyle = this.colors.stripeTextColor;
+        const textWidth = context.measureText(text).width;
+        const truncatedText = graphHelper.truncText(text, textWidth, dx - 4);
+        if (truncatedText) {
+            context.font = "12px Lato";
+            context.fillText(truncatedText, xStart + 2, yStart + 13, dx - 4);
         }
     }
 }

--- a/src/Raven.Studio/typescript/viewmodels/database/status/ongoingTasksStats.ts
+++ b/src/Raven.Studio/typescript/viewmodels/database/status/ongoingTasksStats.ts
@@ -394,6 +394,7 @@ class ongoingTasksStats extends viewModelBase {
         collectionNameTextColor: undefined as string,
         itemWithError: undefined as string,
         progressStripes: undefined as string,
+        stripeTextColor: undefined as string,
 
         tracks: {
             "Replication": undefined as string,
@@ -954,7 +955,7 @@ class ongoingTasksStats extends viewModelBase {
                 this.subscriptionToWorkers.set(subscriptionName, new Set<string>(workerIds));
             }
             
-            const numberOfWorkers = subscription.size;
+            const numberOfWorkers = subscription ? subscription.size : 1;
             const height = ongoingTasksStats.openedSubscriptionTrackHeight + ((numberOfWorkers - 1) * ongoingTasksStats.openedSubscriptionWorkerTrackHeight);
             
             trackInfos.push({
@@ -1663,6 +1664,7 @@ class ongoingTasksStats extends viewModelBase {
                 if (dx >= 0.8) { // Don't show tooltip for very small items
                     this.hitTest.registerTrackItem(currentX, yStart, dx, ongoingTasksStats.trackHeight, perfItemWithCache, op);
                 }
+                this.drawTextOnStripe(context, op.Name, dx, currentX, yStart);
             }
             // 2. Track is closed
             else if (isRootOperation) { // register only on root item
@@ -1716,6 +1718,7 @@ class ongoingTasksStats extends viewModelBase {
             if (dx >= 0.8) { // Don't show tooltip for very small items
                 this.hitTest.registerSubscriptionConnectionItem(xStart, yStart, dx, ongoingTasksStats.trackHeight, this.mapItemToRegister(perfItemWithCache, operationDuration));
             }
+            this.drawTextOnStripe(context, "ClientConnection", dx, xStart, yStart);
         }
         // Track is closed
         else if (dx >= 0.8) {
@@ -2282,6 +2285,18 @@ class ongoingTasksStats extends viewModelBase {
         this.brushContainer.call(this.brush);
 
         this.onBrush();
+    }
+    
+    private drawTextOnStripe(context: CanvasRenderingContext2D, text: string, dx: number, xStart: number, yStart: number): void {
+        if (dx > 30) {
+            context.fillStyle = this.colors.stripeTextColor;
+            const textWidth = context.measureText(text).width;
+            const truncatedText = graphHelper.truncText(text, textWidth, dx - 4);
+            if (truncatedText) {
+                context.font = "12px Lato";
+                context.fillText(truncatedText, xStart + 2, yStart + 13, dx - 4);
+            }
+        }
     }
 }
 

--- a/src/Raven.Studio/wwwroot/App/views/database/status/ongoingTasksStats.html
+++ b/src/Raven.Studio/wwwroot/App/views/database/status/ongoingTasksStats.html
@@ -14,6 +14,7 @@
         <div class="collectionNameTextColor"></div>
         <div class="itemWithError"></div>
         <div class="progressStripes"></div>
+        <div class="stripeTextColor"></div>
         
         <div class="tracks">
             <div class="replication" data-property="Replication"></div>

--- a/src/Raven.Studio/wwwroot/Content/css/pages/metrics.less
+++ b/src/Raven.Studio/wwwroot/Content/css/pages/metrics.less
@@ -89,6 +89,9 @@ rect.pane {
         .progressStripes {
             color: fadeout(@gray-lighter, 90%);
         }
+        .stripeTextColor {
+            color: lighten(@gray-lighter, 10%);
+        }
         
         .tracks {
             .replication {


### PR DESCRIPTION
### Issue link
https://issues.hibernatingrhinos.com/issue/RavenDB-17555

### Additional description
Add labels on the stripes in the Ongoing Tasks Stats graph

### Type of change
- Task/Usability

### How risky is the change?
- Low 

### Backward compatibility
- Non-breaking change

### Is it a platform-specific issue?
- No

### Documentation update
- No documentation update is needed 

### Testing 
- It has been verified by manual testing

### Is there any existing behavior change of other features due to this change?
- No

### UI work
- No UI work is needed
