### PR TITLE
RavenDB-17641: Primitives support for search functionality. 

### DIFF
--- a/src/Corax/Queries/ITermProvider.cs
+++ b/src/Corax/Queries/ITermProvider.cs
@@ -4,6 +4,5 @@
     { 
         void Reset();
         bool Next(out TermMatch term);
-        bool Evaluate(long id);
     }    
 }

--- a/src/Corax/Queries/MultiTermMatch.cs
+++ b/src/Corax/Queries/MultiTermMatch.cs
@@ -34,7 +34,9 @@ namespace Corax.Queries
             _totalResults = totalResults;
             _confidence = confidence;
 
-            _inner.Next(out _currentTerm);
+            var result = _inner.Next(out _currentTerm);
+            if (result == false)
+                _current = QueryMatch.Invalid;
         }
 
         [SkipLocalsInit]

--- a/src/Corax/Queries/TermProvider.Contains.cs
+++ b/src/Corax/Queries/TermProvider.Contains.cs
@@ -1,0 +1,50 @@
+﻿using System;
+using Sparrow.Server;
+using Voron;
+using Voron.Data.CompactTrees;
+
+namespace Corax.Queries
+{
+    public unsafe struct ContainsTermProvider : ITermProvider
+    {
+        private readonly CompactTree _tree;
+        private readonly IndexSearcher _searcher;
+        private readonly string _field;
+        private readonly Slice _suffix;
+
+        private CompactTree.Iterator _iterator;
+
+        public ContainsTermProvider(IndexSearcher searcher, ByteStringContext context, CompactTree tree, string field, string suffix)
+        {
+            _tree = tree;
+            _searcher = searcher;
+            _field = field;
+            _iterator = tree.Iterate();
+            _iterator.Reset();
+
+            Slice.From(context, suffix, out _suffix);
+        }
+
+        public void Reset()
+        {            
+            _iterator = _tree.Iterate();
+            _iterator.Reset();
+        }
+
+        public bool Next(out TermMatch term)
+        {
+            var suffix = _suffix;
+            while (_iterator.MoveNext(out Slice termSlice, out var _))
+            {
+                if (!termSlice.Contains(suffix))
+                    continue;
+
+                term = _searcher.TermQuery(_field, termSlice.ToString());
+                return true;
+            }
+
+            term = TermMatch.CreateEmpty();
+            return false;
+        }
+    }
+}

--- a/src/Corax/Queries/TermProvider.In.cs
+++ b/src/Corax/Queries/TermProvider.In.cs
@@ -1,8 +1,5 @@
 ﻿using System;
 using System.Collections.Generic;
-using System.Linq;
-using System.Text;
-using System.Threading.Tasks;
 
 namespace Corax.Queries
 {
@@ -10,15 +7,13 @@ namespace Corax.Queries
     {
         private readonly IndexSearcher _searcher;
         private readonly string _field;
-        private readonly int _fieldId;
         private readonly List<string> _terms;
         private int _termIndex;
 
-        public InTermProvider(IndexSearcher searcher, string field, int fieldId, List<string> terms)
+        public InTermProvider(IndexSearcher searcher, string field, List<string> terms)
         {
             _searcher = searcher;
             _field = field;
-            _fieldId = fieldId;
             _terms = terms;
             _termIndex = -1;
         }
@@ -35,21 +30,6 @@ namespace Corax.Queries
             }
             term = _searcher.TermQuery(_field, _terms[_termIndex]);
             return true;
-        }
-
-        public bool Evaluate(long id)
-        {
-            var entry = _searcher.GetReaderFor(id);
-            var fieldType = entry.GetFieldType(_fieldId);
-            if (fieldType.HasFlag(IndexEntryFieldType.List))
-            {
-                // TODO: Federico fixme please
-            }
-            if (entry.Read(_fieldId, out var value) == false)
-                return false;
-
-            //TODO: fix me, allocations, O(N^2), etc
-            return _terms.Contains(Encoding.UTF8.GetString(value));
         }
     }
 }

--- a/src/Corax/Queries/TermProvider.StartWith.cs
+++ b/src/Corax/Queries/TermProvider.StartWith.cs
@@ -15,14 +15,11 @@ namespace Corax.Queries
         private readonly CompactTree.Iterator _iterator;
         private readonly string _field;
         private readonly Slice _startWith;
-        private readonly int _fieldId;
-
 
         public StartWithTermProvider(IndexSearcher searcher, ByteStringContext context, CompactTree tree, string field, int fieldId, string startWith)
         {
             _searcher = searcher;
             _field = field;
-            _fieldId = fieldId;
             _iterator = tree.Iterate();
             
             Slice.From(context, _searcher.EncodeTerm(startWith, fieldId), out _startWith);
@@ -42,11 +39,6 @@ namespace Corax.Queries
 
             term = _searcher.TermQuery(_field, termSlice.ToString());
             return true;
-        }
-
-        public bool Evaluate(long id)
-        {
-            throw new NotImplementedException();
         }
     }
 }

--- a/src/Voron/Data/CompactTrees/CompactTree.Iterator.cs
+++ b/src/Voron/Data/CompactTrees/CompactTree.Iterator.cs
@@ -11,6 +11,7 @@ namespace Voron.Data.CompactTrees
     {
         public interface IIterator
         {
+            void Reset();
             void Seek(ReadOnlySpan<byte> key);
             bool Skip(long count);
 
@@ -29,7 +30,7 @@ namespace Voron.Data.CompactTrees
             public Iterator(CompactTree tree)
             {
                 _tree = tree;
-                _cursor = new() { _stk = new CursorState[8], _pos = -1, _len = 0 };
+                _cursor = new() { _stk = new CursorState[8], _pos = -1, _len = 0 };                
             }
 
             public void Seek(string key)
@@ -44,6 +45,11 @@ namespace Voron.Data.CompactTrees
                 ref var state = ref _cursor._stk[_cursor._pos];
                 if (state.LastSearchPosition < 0)
                     state.LastSearchPosition = ~state.LastSearchPosition;
+            }
+
+            public void Reset()
+            {
+                _tree.PushPage(_tree._state.RootPage, ref _cursor);
             }
 
             public bool MoveNext(out Slice key, out long value)
@@ -114,8 +120,6 @@ namespace Voron.Data.CompactTrees
                 return true;
 
             }
-
-
         }
 
         public Iterator Iterate()

--- a/src/Voron/Slice.cs
+++ b/src/Voron/Slice.cs
@@ -106,6 +106,30 @@ namespace Voron
         }
 
         [MethodImpl(MethodImplOptions.AggressiveInlining)]
+        public bool Contains(Slice other)
+        {
+            var length = this.Size - other.Size;
+            if (length < 0)
+                return false;
+
+            // This is the last position with enough space to contain the other slice.             
+            var ptr = Content.Ptr;
+            var end = ptr + length;
+            
+            var otherSpan = new ReadOnlySpan<byte>(other.Content.Ptr, other.Size);
+            byte firstByte = otherSpan[0];
+            while (end >= ptr)
+            {
+                if (*end == firstByte && otherSpan.SequenceCompareTo(new ReadOnlySpan<byte>(end, otherSpan.Length)) == 0)
+                    return true;
+                end--;
+            }
+
+            return false;
+        }
+
+
+        [MethodImpl(MethodImplOptions.AggressiveInlining)]
         public static ByteStringContext.InternalScope From(ByteStringContext context, ReadOnlySpan<char> value, out Slice str)
         {
             return From(context, value, ByteStringType.Mutable, out str);

--- a/test/FastTests/Corax/BoostingQuery.cs
+++ b/test/FastTests/Corax/BoostingQuery.cs
@@ -241,7 +241,7 @@ namespace FastTests.Corax
             using var searcher = new IndexSearcher(Env);
             {                
                 var query = MultiTermBoostingMatch<InTermProvider>.Create(searcher, 
-                    new InTermProvider(searcher, "Content1", Content1, new List<string>() { "0", "1", "2", "3" }), 
+                    new InTermProvider(searcher, "Content1", new List<string>() { "0", "1", "2", "3" }), 
                     default(TermFrequencyScoreFunction));
                 var sortedMatch = searcher.OrderByScore(query);
 

--- a/test/FastTests/Corax/IndexSearcher.cs
+++ b/test/FastTests/Corax/IndexSearcher.cs
@@ -973,6 +973,53 @@ namespace FastTests.Corax
         }
 
         [Fact]
+        public void SimpleWildcardStatement()
+        {
+            var entry1 = new IndexSingleEntry { Id = "entry/1", Content = "Testing" };
+            var entry2 = new IndexSingleEntry { Id = "entry/2", Content = "Running" };
+            var entry3 = new IndexSingleEntry { Id = "entry/3", Content = "Runner" };
+
+            IndexEntries(new[] { entry1, entry2, entry3 });
+
+            using var bsc = new ByteStringContext(SharedMultipleUseFlag.None);
+            using var searcher = new IndexSearcher(Env);
+
+            Slice.From(bsc, "1", out var one);
+            Slice.From(bsc, "4", out var four);
+
+            {
+                var match = searcher.ContainsQuery("Content", "ing");
+
+                Span<long> ids = stackalloc long[16];
+                Assert.Equal(2, match.Fill(ids));
+                Assert.Equal(0, match.Fill(ids));
+            }
+
+            {
+                var match = searcher.ContainsQuery("Content", "Run");
+
+                Span<long> ids = stackalloc long[16];
+                Assert.Equal(2, match.Fill(ids));
+                Assert.Equal(0, match.Fill(ids));
+            }
+
+            {
+                var match = searcher.ContainsQuery("Content", "nn");
+
+                Span<long> ids = stackalloc long[16];
+                Assert.Equal(2, match.Fill(ids));
+                Assert.Equal(0, match.Fill(ids));
+            }
+
+            {
+                var match = searcher.ContainsQuery("Content", "run");
+
+                Span<long> ids = stackalloc long[16];
+                Assert.Equal(0, match.Fill(ids));
+            }
+        }
+
+        [Fact]
         public void SimpleBetweenCompareStatement()
         {
             var entry1 = new IndexSingleEntry { Id = "entry/1", Content = "3" };

--- a/test/FastTests/Voron/Slices.cs
+++ b/test/FastTests/Voron/Slices.cs
@@ -1,0 +1,42 @@
+﻿using System;
+using System.Collections.Generic;
+using System.Linq;
+using System.Text;
+using System.Threading.Tasks;
+using Sparrow.Server;
+using Sparrow.Threading;
+using Voron;
+using Xunit;
+using Xunit.Abstractions;
+
+namespace FastTests.Voron
+{
+    public class SliceTests : NoDisposalNeeded
+    {
+        public SliceTests(ITestOutputHelper output) : base(output)
+        {
+        }
+
+        [Fact]
+        public void BasicContains()
+        {
+            using ByteStringContext context = new ByteStringContext(SharedMultipleUseFlag.None);
+
+            Slice.From(context, "testing", out var original);
+            Slice.From(context, "ing", out var suffix);
+            Slice.From(context, "test", out var prefix);
+            Slice.From(context, "stin", out var middle);
+            Slice.From(context, "testing1", out var tooBig);
+            Slice.From(context, "a", out var noMatch);
+            Slice.From(context, "tw", out var multipleHits);
+
+            Assert.True(original.Contains(suffix));
+            Assert.True(original.Contains(prefix));
+            Assert.True(original.Contains(middle));
+            Assert.False(original.Contains(tooBig));
+            Assert.False(original.Contains(noMatch));
+            Assert.True(original.Contains(original));
+            Assert.False(original.Contains(multipleHits));
+        }
+    }
+}


### PR DESCRIPTION
Unless I am missing advanced functionality for the search feature, both prefix and suffix searches can be implemented through `Contains`. However, for performance in the case of prefix contains it is better to use the more efficient `StartWith` primitive. 