### PR TITLE
RavenDB-17595 Dump Index: Add access level

### DIFF
--- a/src/Raven.Studio/wwwroot/App/views/database/indexes/editIndex.html
+++ b/src/Raven.Studio/wwwroot/App/views/database/indexes/editIndex.html
@@ -22,9 +22,8 @@
                         <a data-bind="click: getCSharpCode, visible: isEditingExistingIndex" class="btn" title="Copy the index c# code"><i class="icon-code"></i><span>Copy C#</span></a>
                         <a data-bind="attr: { href: queryUrl }, visible: isEditingExistingIndex" class="btn" title="Query the index"><i class="icon-query"></i><span>Query</span></a>
                         <a data-bind="attr: { href: termsUrl }, visible: isEditingExistingIndex" class="btn" title="Navigate to index terms"><i class="icon-terms"></i><span>Terms</span></a>
-                        <!-- TODO replace the arrow-down icon when RavenDB-17594 is done -->
                         <a data-bind="click: openDumpDialog, visible: isEditingExistingIndex, requiredAccess: 'DatabaseAdmin'" href="#" class="btn" title="Dump the raw Lucene index files">
-                            <i class="icon-arrow-down"></i><span>Dump</span>
+                            <i class="icon-dump-index-files"></i><span>Dump</span>
                         </a>
                         <button class="btn btn-danger" 
                                 data-bind="visible: isEditingExistingIndex, click: deleteIndex, attr: { title: 'Delete index: ' + editedIndex().name() }, requiredAccess: 'DatabaseReadWrite'">
@@ -437,9 +436,8 @@
                     <div>
                         <a data-bind="attr: { href: queryUrl }, visible: isEditingExistingIndex" class="btn" title="Query the index"><i class="icon-query"></i><span>Query</span></a>
                         <a data-bind="attr: { href: termsUrl }, visible: isEditingExistingIndex" class="btn" title="Navigate to index terms"><i class="icon-terms"></i><span>Terms</span></a>
-                        <!-- TODO replace the arrow-down icon when RavenDB-17594 is done -->
                         <a data-bind="click: openDumpDialog, visible: isEditingExistingIndex, requiredAccess: 'DatabaseAdmin'" href="#" class="btn" title="Dump the raw Lucene index files">
-                            <i class="icon-arrow-down"></i><span>Dump</span>
+                            <i class="icon-dump-index-files"></i><span>Dump</span>
                         </a>
                         <button class="btn btn-danger" data-bind="visible: isEditingExistingIndex, click: deleteIndex, requiredAccess: 'DatabaseReadWrite'" title="Delete this index">
                             <i class="icon-trash"></i><span>Delete</span>
@@ -772,7 +770,6 @@
 <script type="text/html" id="index-history-dialog">
     <button class="btn btn-default dropdown-toggle" type="button" id="dropdownIndexHistory" data-toggle="dropdown"
             data-bind="click: indexHistoryButtonHandler, attr: { title: isEditingExistingIndex() ? 'View this index history' : 'View the history of the index you cloned from' }">
-        <!-- todo replace with new icon (icon-index-history) -->
         <i class="icon-index-history"></i><span>Index History</span>
         <span class="caret"></span>
     </button>

--- a/src/Raven.Studio/wwwroot/App/views/database/indexes/editIndex.html
+++ b/src/Raven.Studio/wwwroot/App/views/database/indexes/editIndex.html
@@ -23,8 +23,9 @@
                         <a data-bind="attr: { href: queryUrl }, visible: isEditingExistingIndex" class="btn" title="Query the index"><i class="icon-query"></i><span>Query</span></a>
                         <a data-bind="attr: { href: termsUrl }, visible: isEditingExistingIndex" class="btn" title="Navigate to index terms"><i class="icon-terms"></i><span>Terms</span></a>
                         <!-- TODO replace the arrow-down icon when RavenDB-17594 is done -->
-                        <!-- TODO add access level for DatabaseAdmin on v5.2 (RavenDB-17595) -->
-                        <a data-bind="click: openDumpDialog, visible: isEditingExistingIndex" href="#" class="btn" title="Dump the raw Lucene index files"><i class="icon-arrow-down"></i><span>Dump</span></a>
+                        <a data-bind="click: openDumpDialog, visible: isEditingExistingIndex, requiredAccess: 'DatabaseAdmin'" href="#" class="btn" title="Dump the raw Lucene index files">
+                            <i class="icon-arrow-down"></i><span>Dump</span>
+                        </a>
                         <button class="btn btn-danger" 
                                 data-bind="visible: isEditingExistingIndex, click: deleteIndex, attr: { title: 'Delete index: ' + editedIndex().name() }, requiredAccess: 'DatabaseReadWrite'">
                             <i class="icon-trash"></i><span>Delete</span>
@@ -437,9 +438,12 @@
                         <a data-bind="attr: { href: queryUrl }, visible: isEditingExistingIndex" class="btn" title="Query the index"><i class="icon-query"></i><span>Query</span></a>
                         <a data-bind="attr: { href: termsUrl }, visible: isEditingExistingIndex" class="btn" title="Navigate to index terms"><i class="icon-terms"></i><span>Terms</span></a>
                         <!-- TODO replace the arrow-down icon when RavenDB-17594 is done -->
-                        <!-- TODO add access level for DatabaseAdmin on v5.2 (RavenDB-17595) -->
-                        <a data-bind="click: openDumpDialog, visible: isEditingExistingIndex" href="#" class="btn" title="Dump the raw Lucene index files"><i class="icon-arrow-down"></i><span>Dump</span></a>
-                        <button class="btn btn-danger" data-bind="visible: isEditingExistingIndex, click: deleteIndex" title="Delete this index"><i class="icon-trash"></i><span>Delete</span></button>
+                        <a data-bind="click: openDumpDialog, visible: isEditingExistingIndex, requiredAccess: 'DatabaseAdmin'" href="#" class="btn" title="Dump the raw Lucene index files">
+                            <i class="icon-arrow-down"></i><span>Dump</span>
+                        </a>
+                        <button class="btn btn-danger" data-bind="visible: isEditingExistingIndex, click: deleteIndex, requiredAccess: 'DatabaseReadWrite'" title="Delete this index">
+                            <i class="icon-trash"></i><span>Delete</span>
+                        </button>
                     </div>
                 </div>
             </div>


### PR DESCRIPTION
### Issue link
https://issues.hibernatingrhinos.com/issue/RavenDB-17595.

### Additional description
Fix access level for 'dump index' and for 'delete auto index'

### Type of change
- Bug fix

### How risky is the change?
- Low 

### Backward compatibility
- Non breaking change

### Is it platform specific issue?
- No

### Documentation update
- No documentation update is needed 

### Testing 
- It has been verified by manual testing

### Is there any existing behavior change of other features due to this change?
- No

### UI work
- No UI work is needed
