### PR TITLE
RavenDB-17187 - Incoming replication from External Replication is not visible in the Ongoing Task Stats

### DIFF
--- a/src/Raven.Client/Documents/Replication/Messages/ReplicationLatestEtagRequest.cs
+++ b/src/Raven.Client/Documents/Replication/Messages/ReplicationLatestEtagRequest.cs
@@ -2,7 +2,6 @@
 
 namespace Raven.Client.Documents.Replication.Messages
 {
-    //TODO stav: move replicationType to LatestEtagRequest
     public class ReplicationLatestEtagRequest
     {
         public string SourceDatabaseName { get; set; }
@@ -14,7 +13,14 @@ namespace Raven.Client.Documents.Replication.Messages
         public string SourceTag { get; set; }
 
         public string SourceMachineName { get; set; }
-        
+
+        public ReplicationType ReplicationsType { get; set; }
+
+        public enum ReplicationType
+        {
+            External,
+            Internal
+        }
     }
 
     public class ReplicationInitialRequest
@@ -30,13 +36,5 @@ namespace Raven.Client.Documents.Replication.Messages
         public string SourceUrl { get; set; }
 
         public string DatabaseGroupId { get; set; }
-
-        public ReplicationType ReplicationsType { get; set; }
-
-        public enum ReplicationType
-        {
-            External,
-            Internal
-        }
     }
 }

--- a/src/Raven.Client/Documents/Replication/Messages/ReplicationLatestEtagRequest.cs
+++ b/src/Raven.Client/Documents/Replication/Messages/ReplicationLatestEtagRequest.cs
@@ -2,6 +2,7 @@
 
 namespace Raven.Client.Documents.Replication.Messages
 {
+    //TODO stav: move replicationType to LatestEtagRequest
     public class ReplicationLatestEtagRequest
     {
         public string SourceDatabaseName { get; set; }

--- a/src/Raven.Client/Documents/Replication/Messages/ReplicationLatestEtagRequest.cs
+++ b/src/Raven.Client/Documents/Replication/Messages/ReplicationLatestEtagRequest.cs
@@ -18,6 +18,7 @@ namespace Raven.Client.Documents.Replication.Messages
 
         public enum ReplicationType
         {
+            //No None here for legacy reasons. External should be default.
             External,
             Internal
         }

--- a/src/Raven.Client/Documents/Replication/Messages/ReplicationLatestEtagRequest.cs
+++ b/src/Raven.Client/Documents/Replication/Messages/ReplicationLatestEtagRequest.cs
@@ -29,5 +29,13 @@ namespace Raven.Client.Documents.Replication.Messages
         public string SourceUrl { get; set; }
 
         public string DatabaseGroupId { get; set; }
+
+        public ReplicationType ReplicationsType { get; set; }
+
+        public enum ReplicationType
+        {
+            External,
+            Internal
+        }
     }
 }

--- a/src/Raven.Client/Documents/Replication/Messages/ReplicationLatestEtagRequest.cs
+++ b/src/Raven.Client/Documents/Replication/Messages/ReplicationLatestEtagRequest.cs
@@ -18,7 +18,7 @@ namespace Raven.Client.Documents.Replication.Messages
 
         public enum ReplicationType
         {
-            //No None here for legacy reasons. External should be default.
+            // External here as the default value to handle older servers, which aren't sending this field.
             External,
             Internal
         }

--- a/src/Raven.Server/Documents/Replication/IncomingReplicationHandler.cs
+++ b/src/Raven.Server/Documents/Replication/IncomingReplicationHandler.cs
@@ -892,6 +892,13 @@ namespace Raven.Server.Documents.Replication
                 _lastReplicationStats.TryDequeue(out stats);
         }
 
+        public LiveReplicationPerformanceCollector.ReplicationPerformanceType GetReplicationPerformanceType()
+        {
+            return ReplicationType == ReplicationInitialRequest.ReplicationType.Internal
+                ? LiveReplicationPerformanceCollector.ReplicationPerformanceType.IncomingInternal
+                : LiveReplicationPerformanceCollector.ReplicationPerformanceType.IncomingExternal;
+        }
+
         public bool IsDisposed => _disposeOnce.Disposed;
 
         public void Dispose()

--- a/src/Raven.Server/Documents/Replication/IncomingReplicationHandler.cs
+++ b/src/Raven.Server/Documents/Replication/IncomingReplicationHandler.cs
@@ -78,14 +78,14 @@ namespace Raven.Server.Documents.Replication
 
         private readonly DisposeOnce<SingleAttempt> _disposeOnce;
 
-        public readonly ReplicationInitialRequest.ReplicationType ReplicationType;
+        public readonly ReplicationLatestEtagRequest.ReplicationType ReplicationType;
 
         public IncomingReplicationHandler(
             TcpConnectionOptions options,
             ReplicationLatestEtagRequest replicatedLastEtag,
             ReplicationLoader parent,
             JsonOperationContext.MemoryBuffer bufferToCopy,
-            ReplicationInitialRequest.ReplicationType replicationType,
+            ReplicationLatestEtagRequest.ReplicationType replicationType,
             ReplicationLoader.PullReplicationParams pullReplicationParams = null)
         {
             if (pullReplicationParams?.AllowedPaths != null && pullReplicationParams.AllowedPaths.Length > 0)
@@ -894,7 +894,7 @@ namespace Raven.Server.Documents.Replication
 
         public LiveReplicationPerformanceCollector.ReplicationPerformanceType GetReplicationPerformanceType()
         {
-            return ReplicationType == ReplicationInitialRequest.ReplicationType.Internal
+            return ReplicationType == ReplicationLatestEtagRequest.ReplicationType.Internal
                 ? LiveReplicationPerformanceCollector.ReplicationPerformanceType.IncomingInternal
                 : LiveReplicationPerformanceCollector.ReplicationPerformanceType.IncomingExternal;
         }

--- a/src/Raven.Server/Documents/Replication/IncomingReplicationHandler.cs
+++ b/src/Raven.Server/Documents/Replication/IncomingReplicationHandler.cs
@@ -78,11 +78,14 @@ namespace Raven.Server.Documents.Replication
 
         private readonly DisposeOnce<SingleAttempt> _disposeOnce;
 
+        public readonly ReplicationInitialRequest.ReplicationType ReplicationType;
+
         public IncomingReplicationHandler(
             TcpConnectionOptions options,
             ReplicationLatestEtagRequest replicatedLastEtag,
             ReplicationLoader parent,
             JsonOperationContext.MemoryBuffer bufferToCopy,
+            ReplicationInitialRequest.ReplicationType replicationType,
             ReplicationLoader.PullReplicationParams pullReplicationParams = null)
         {
             if (pullReplicationParams?.AllowedPaths != null && pullReplicationParams.AllowedPaths.Length > 0)
@@ -102,7 +105,9 @@ namespace Raven.Server.Documents.Replication
             SupportedFeatures = TcpConnectionHeaderMessage.GetSupportedFeaturesFor(options.Operation, options.ProtocolVersion);
             ConnectionInfo.RemoteIp = ((IPEndPoint)_tcpClient.Client.RemoteEndPoint).Address.ToString();
             _parent = parent;
-            
+
+            ReplicationType = replicationType;
+
             _incomingPullReplicationParams = new ReplicationLoader.PullReplicationParams
             {
                 AllowedPaths = pullReplicationParams?.AllowedPaths,

--- a/src/Raven.Server/Documents/Replication/LiveReplicationPerformanceCollector.cs
+++ b/src/Raven.Server/Documents/Replication/LiveReplicationPerformanceCollector.cs
@@ -3,7 +3,10 @@ using System.Collections.Concurrent;
 using System.Collections.Generic;
 using System.Linq;
 using System.Threading.Tasks;
+using Microsoft.CodeAnalysis.CSharp.Syntax;
+using Raven.Client.Documents.Operations.Replication;
 using Raven.Client.Documents.Replication;
+using Raven.Client.Documents.Replication.Messages;
 using Raven.Server.Utils;
 using Raven.Server.Utils.Stats;
 using Sparrow.Json;
@@ -84,19 +87,29 @@ namespace Raven.Server.Documents.Replication
             foreach (var handler in Database.ReplicationLoader.IncomingHandlers)
             {
                 var stats = handler.GetReplicationPerformance();
-                if (stats.Length > 0)
-                    yield return handler.PullReplication
-                        ? IncomingPerformanceStats.ForPullReplication(handler.ConnectionInfo.SourceDatabaseId, handler.SourceFormatted, stats)
-                        : IncomingPerformanceStats.ForPushReplication(handler.ConnectionInfo.SourceDatabaseId, handler.SourceFormatted, stats);
+
+                if (stats.Length == 0)
+                {
+                    stats = new IncomingReplicationPerformanceStats[] { new IncomingReplicationPerformanceStats() };
+                }
+                
+                yield return handler.PullReplication
+                    ? IncomingPerformanceStats.ForPullReplication(handler.ConnectionInfo.SourceDatabaseId, handler.SourceFormatted, stats)
+                    : IncomingPerformanceStats.ForPushReplication(handler.ConnectionInfo.SourceDatabaseId, handler.ReplicationType, handler.SourceFormatted, stats);
             }
 
             foreach (var handler in Database.ReplicationLoader.OutgoingHandlers)
             {
                 var stats = handler.GetReplicationPerformance();
-                if (stats.Length > 0)
-                    yield return handler.IsPullReplicationAsHub
-                        ? OutgoingPerformanceStats.ForPullReplication(handler.DestinationDbId, handler.DestinationFormatted, stats)
-                        : OutgoingPerformanceStats.ForPushReplication(handler.DestinationDbId, handler.DestinationFormatted, stats);
+
+                if (stats.Length == 0)
+                {
+                    stats = new OutgoingReplicationPerformanceStats[] { new OutgoingReplicationPerformanceStats() };
+                }
+
+                yield return handler.IsPullReplicationAsHub
+                    ? OutgoingPerformanceStats.ForPullReplication(handler.DestinationDbId, handler.DestinationFormatted, stats)
+                    : OutgoingPerformanceStats.ForPushReplication(handler.DestinationDbId, handler.ReplicationType, handler.DestinationFormatted, stats);
             }
         }
 
@@ -128,7 +141,7 @@ namespace Raven.Server.Documents.Replication
                     var stats = itemsToSend.Select(item => item.ToReplicationPerformanceLiveStatsWithDetails()).ToArray();
                     results.Add(handler.PullReplication
                         ? IncomingPerformanceStats.ForPullReplication(handler.ConnectionInfo.SourceDatabaseId, handler.SourceFormatted, stats)
-                        : IncomingPerformanceStats.ForPushReplication(handler.ConnectionInfo.SourceDatabaseId, handler.SourceFormatted, stats));
+                        : IncomingPerformanceStats.ForPushReplication(handler.ConnectionInfo.SourceDatabaseId, handler.ReplicationType, handler.SourceFormatted, stats));
                 }
             }
 
@@ -156,13 +169,16 @@ namespace Raven.Server.Documents.Replication
                     var stats = itemsToSend.Select(item => item.ToReplicationPerformanceLiveStatsWithDetails()).ToArray();
                     results.Add(handler.IsPullReplicationAsHub
                         ? OutgoingPerformanceStats.ForPullReplication(handler.DestinationDbId, handler.DestinationFormatted, stats)
-                        : OutgoingPerformanceStats.ForPushReplication(handler.DestinationDbId, handler.DestinationFormatted, stats));
+                        : OutgoingPerformanceStats.ForPushReplication(handler.DestinationDbId, handler.ReplicationType, handler.DestinationFormatted, stats));
                 }
             }
 
             foreach (var outgoingError in _outgoingErrors)
             {
-                results.Add(OutgoingPerformanceStats.ForPushReplication(outgoingError.Key.Database, outgoingError.Value.DestinationFormatted, outgoingError.Value.GetReplicationPerformance()));
+                var type = outgoingError.Key is InternalReplication
+                    ? ReplicationInitialRequest.ReplicationType.Internal
+                    : ReplicationInitialRequest.ReplicationType.External;
+                results.Add(OutgoingPerformanceStats.ForPushReplication(outgoingError.Key.Database, type, outgoingError.Value.DestinationFormatted, outgoingError.Value.GetReplicationPerformance()));
                 _outgoingErrors.TryRemove(outgoingError.Key, out _);
             }
 
@@ -261,9 +277,10 @@ namespace Raven.Server.Documents.Replication
                 return new OutgoingPerformanceStats(id, description, ReplicationPerformanceType.OutgoingPull, performance);
             }
 
-            public static OutgoingPerformanceStats ForPushReplication(string id, string description, OutgoingReplicationPerformanceStats[] performance)
+            public static OutgoingPerformanceStats ForPushReplication(string id, ReplicationInitialRequest.ReplicationType replicationType, string description, OutgoingReplicationPerformanceStats[] performance)
             {
-                return new OutgoingPerformanceStats(id, description, ReplicationPerformanceType.OutgoingPush, performance);
+                return new OutgoingPerformanceStats(id, description, 
+                    replicationType == ReplicationInitialRequest.ReplicationType.Internal? ReplicationPerformanceType.OutgoingInternal : ReplicationPerformanceType.OutgoingPush, performance);
             }
         }
 
@@ -279,9 +296,10 @@ namespace Raven.Server.Documents.Replication
                 return new IncomingPerformanceStats(id, description, ReplicationPerformanceType.IncomingPull, performance);
             }
 
-            public static IncomingPerformanceStats ForPushReplication(string id, string description, IncomingReplicationPerformanceStats[] performance)
+            public static IncomingPerformanceStats ForPushReplication(string id, ReplicationInitialRequest.ReplicationType replicationType, string description, IncomingReplicationPerformanceStats[] performance)
             {
-                return new IncomingPerformanceStats(id, description, ReplicationPerformanceType.IncomingPush, performance);
+                return new IncomingPerformanceStats(id, description, 
+                    replicationType == ReplicationInitialRequest.ReplicationType.Internal? ReplicationPerformanceType.IncomingInternal : ReplicationPerformanceType.IncomingPush, performance);
             }
         }
 
@@ -335,7 +353,9 @@ namespace Raven.Server.Documents.Replication
             IncomingPush,
             IncomingPull,
             OutgoingPush,
-            OutgoingPull
+            OutgoingPull,
+            IncomingInternal,
+            OutgoingInternal
         }
 
         public interface IReplicationPerformanceStats

--- a/src/Raven.Server/Documents/Replication/LiveReplicationPerformanceCollector.cs
+++ b/src/Raven.Server/Documents/Replication/LiveReplicationPerformanceCollector.cs
@@ -280,7 +280,7 @@ namespace Raven.Server.Documents.Replication
             public static OutgoingPerformanceStats ForPushReplication(string id, ReplicationInitialRequest.ReplicationType replicationType, string description, OutgoingReplicationPerformanceStats[] performance)
             {
                 return new OutgoingPerformanceStats(id, description, 
-                    replicationType == ReplicationInitialRequest.ReplicationType.Internal? ReplicationPerformanceType.OutgoingInternal : ReplicationPerformanceType.OutgoingPush, performance);
+                    replicationType == ReplicationInitialRequest.ReplicationType.Internal? ReplicationPerformanceType.OutgoingInternal : ReplicationPerformanceType.OutgoingExternal, performance);
             }
         }
 
@@ -299,7 +299,7 @@ namespace Raven.Server.Documents.Replication
             public static IncomingPerformanceStats ForPushReplication(string id, ReplicationInitialRequest.ReplicationType replicationType, string description, IncomingReplicationPerformanceStats[] performance)
             {
                 return new IncomingPerformanceStats(id, description, 
-                    replicationType == ReplicationInitialRequest.ReplicationType.Internal? ReplicationPerformanceType.IncomingInternal : ReplicationPerformanceType.IncomingPush, performance);
+                    replicationType == ReplicationInitialRequest.ReplicationType.Internal? ReplicationPerformanceType.IncomingInternal : ReplicationPerformanceType.IncomingExternal, performance);
             }
         }
 
@@ -350,9 +350,9 @@ namespace Raven.Server.Documents.Replication
 
         public enum ReplicationPerformanceType
         {
-            IncomingPush,
+            IncomingExternal,
+            OutgoingExternal,
             IncomingPull,
-            OutgoingPush,
             OutgoingPull,
             IncomingInternal,
             OutgoingInternal

--- a/src/Raven.Server/Documents/Replication/OutgoingReplicationHandler.cs
+++ b/src/Raven.Server/Documents/Replication/OutgoingReplicationHandler.cs
@@ -82,6 +82,9 @@ namespace Raven.Server.Documents.Replication
         public readonly ReplicationNode Destination;
         private readonly bool _external;
 
+        public ReplicationInitialRequest.ReplicationType ReplicationType =>
+            _external ? ReplicationInitialRequest.ReplicationType.External : ReplicationInitialRequest.ReplicationType.Internal;
+
         private readonly ConcurrentQueue<OutgoingReplicationStatsAggregator> _lastReplicationStats = new ConcurrentQueue<OutgoingReplicationStatsAggregator>();
         private OutgoingReplicationStatsAggregator _lastStats;
         private readonly TcpConnectionInfo _connectionInfo;
@@ -278,6 +281,7 @@ namespace Raven.Server.Documents.Replication
             var request = new DynamicJsonValue
             {
                 ["Type"] = nameof(ReplicationInitialRequest),
+                [nameof(ReplicationInitialRequest.ReplicationsType)] = ReplicationType
             };
 
             if (Destination is PullReplicationAsSink destination)

--- a/src/Raven.Server/Documents/Replication/ReplicationLoader.cs
+++ b/src/Raven.Server/Documents/Replication/ReplicationLoader.cs
@@ -634,10 +634,10 @@ namespace Raven.Server.Documents.Replication
                     throw new Exception(exceptionSchema.Message);
 
                 getLatestEtagMessage = JsonDeserializationServer.ReplicationLatestEtagRequest(readerObject);
-                if (_log.IsInfoEnabled)//TODO stav: add replicationsType to the logger too?
+                if (_log.IsInfoEnabled)
                 {
                     _log.Info(
-                        $"GetLastEtag: {getLatestEtagMessage.SourceTag}({getLatestEtagMessage.SourceMachineName}) / {getLatestEtagMessage.SourceDatabaseName} ({getLatestEtagMessage.SourceDatabaseId}) - {getLatestEtagMessage.SourceUrl}");
+                        $"GetLastEtag: {getLatestEtagMessage.SourceTag}({getLatestEtagMessage.SourceMachineName}) / {getLatestEtagMessage.SourceDatabaseName} ({getLatestEtagMessage.SourceDatabaseId}) - {getLatestEtagMessage.SourceUrl}. Type: {getLatestEtagMessage.ReplicationsType}");
                 }
             }
 

--- a/src/Raven.Studio/typescript/viewmodels/database/status/ongoingTasksStats.ts
+++ b/src/Raven.Studio/typescript/viewmodels/database/status/ongoingTasksStats.ts
@@ -1222,7 +1222,9 @@ class ongoingTasksStats extends viewModelBase {
                 context.save();
 
                 // Draw perf items
-                this.drawStripes(context, [perfWithCache.Details], x1, stripesYStart, yOffset, extentFunc, perfWithCache, trackName);
+                if (perfWithCache.Details) {
+                    this.drawStripes(context, [perfWithCache.Details], x1, stripesYStart, yOffset, extentFunc, perfWithCache, trackName);
+                }
 
                 // Draw a separating line between adjacent perf items if needed
                 if (perfIdx >= 1 && perfCompleted === perf.Started) {
@@ -1235,7 +1237,7 @@ class ongoingTasksStats extends viewModelBase {
                 // Save to compare with the start time of the next item...
                 perfCompleted = perf.Completed;
 
-                if (!perf.Completed) {
+                if (!perf.Completed && perf.Details) {
                     this.findInProgressAction([perf.Details], extentFunc, x1, stripesYStart, yOffset);
                 }
             }
@@ -1540,12 +1542,16 @@ class ongoingTasksStats extends viewModelBase {
     
     private getTaskTypeDescription(type: ongoingTaskStatType): string {
         switch (type) {
-            case "IncomingPush":
+            case "IncomingExternal":
                 return "Incoming External Replication";
+            case "IncomingInternal":
+                return "Incoming Internal Replication";
             case "IncomingPull":
                 return "Incoming Pull Replication";
-            case "OutgoingPush":
+            case "OutgoingExternal":
                 return "Outgoing External Replication";
+            case "OutgoingInternal":
+                return "Outgoing Internal Replication";
             case "OutgoingPull":
                 return "Outgoing Pull Replication";
             case "Raven":
@@ -1816,7 +1822,8 @@ class ongoingTasksStats extends viewModelBase {
 
         if (currentDatum !== context.item) {
             const type = context.rootStats.Type;
-            const isReplication = type === "OutgoingPull" || type === "OutgoingPush" || type === "IncomingPull" || type === "IncomingPush";
+            const isReplication = type === "OutgoingPull" || type === "OutgoingExternal" || type === "OutgoingInternal" ||
+                                  type === "IncomingPull" || type === "IncomingExternal" || type === "IncomingInternal";
             const isEtl = type === "Raven" || type === "Sql" || type === "Olap";
             const isSubscription = type === "SubscriptionConnection" || type === "SubscriptionBatch" || type === "AggregatedBatchesInfo";
             const isRootItem = context.rootStats.Details === context.item;
@@ -1831,17 +1838,19 @@ class ongoingTasksStats extends viewModelBase {
             
             if (isRootItem) {
                 switch (type) {
-                    case "IncomingPush":
+                    case "IncomingExternal":
+                    case "IncomingInternal":
                     case "IncomingPull": {
                         const elementWithData = context.rootStats as any as Raven.Client.Documents.Replication.IncomingReplicationPerformanceStats;
                         tooltipHtml += `<div class="tooltip-li">Received last Etag: <div class="value">${elementWithData.ReceivedLastEtag} </div></div>`;
                         tooltipHtml += `<div class="tooltip-li">Network input count: <div class="value">${elementWithData.Network.InputCount.toLocaleString()} </div></div>`;
                         tooltipHtml += `<div class="tooltip-li">Documents read count: <div class="value">${elementWithData.Network.DocumentReadCount.toLocaleString()} </div></div>`;
                         tooltipHtml += `<div class="tooltip-li">Attachments read count: <div class="value">${elementWithData.Network.AttachmentReadCount.toLocaleString()} </div></div>`;
-                        tooltipHtml += `Counters read count: ${elementWithData.Network.CounterReadCount}<br/>`;
+                        tooltipHtml += `<div class="tooltip-li">Counters read count: <div class="value">${elementWithData.Network.CounterReadCount.toLocaleString()} </div></div>`;
                     }
                         break;
-                    case "OutgoingPush":
+                    case "OutgoingExternal":
+                    case "OutgoingInternal":
                     case "OutgoingPull": {
                         const elementWithData = context.rootStats as any as Raven.Client.Documents.Replication.OutgoingReplicationPerformanceStats;
                         tooltipHtml += `<div class="tooltip-li">Sent last Etag: <div class="value">${elementWithData.SendLastEtag}</div></div>`;

--- a/test/SlowTests/Server/Replication/ExternalReplicationTests.cs
+++ b/test/SlowTests/Server/Replication/ExternalReplicationTests.cs
@@ -5,6 +5,7 @@ using System.Threading;
 using System.Threading.Tasks;
 using FastTests.Server.Replication;
 using Raven.Client.Documents;
+using Raven.Client.Documents.Conventions;
 using Raven.Client.Documents.Operations;
 using Raven.Client.Documents.Operations.ConnectionStrings;
 using Raven.Client.Documents.Operations.ETL;
@@ -54,6 +55,57 @@ namespace SlowTests.Server.Replication
                 // SlowTests uses the regular old value of 3000mSec. But if called from StressTests - needs more timeout
                 Assert.True(WaitForDocument(store2, "foo/bar", timeout), store2.Identifier);
                 Assert.True(WaitForDocument(store3, "foo/bar", timeout), store3.Identifier);
+            }
+        }
+
+        [Fact]
+        public async Task RavenDB_17187_2()
+        {
+            var database = GetDatabaseName();
+            var cluster = await CreateRaftCluster(3);
+            await CreateDatabaseInCluster(database, 3, cluster.Leader.WebUrl);
+            
+            var externalServer = GetNewServer(new ServerCreationOptions() {NodeTag = "Server1"});
+
+            using (var externalStore = GetDocumentStore(new Options() {Server = externalServer}))
+            using (var store1 = new DocumentStore()
+            {
+                Urls = new [] {cluster.Nodes[0].WebUrl},
+                Database = database
+            }.Initialize())
+            using (var store2 = new DocumentStore()
+            {
+                Urls = new[] { cluster.Nodes[1].WebUrl },
+                Database = database,
+            }.Initialize())
+            using (var store3 = new DocumentStore()
+            {
+                Urls = new[] { cluster.Nodes[2].WebUrl },
+                Database = database
+            }.Initialize())
+            {
+                await Task.Delay(2000);
+                await SetupReplicationAsync(externalStore, store1);
+
+                using (var s1 = store1.OpenSession(database))
+                {
+                    s1.Store(new User(), "foo/bar");
+                    s1.SaveChanges();
+                }
+                using (var s2 = store2.OpenSession(database))
+                {
+                    s2.Store(new User(), "foo/bar/store2");
+                    s2.SaveChanges();
+                }
+                using (var s3 = store3.OpenSession(database))
+                {
+                    s3.Store(new User(), "foo/bar/store3");
+                    s3.SaveChanges();
+                }
+                
+                Assert.True(WaitForDocument(store2, "foo/bar", 10000, database), store2.Identifier);
+                Assert.True(WaitForDocument(store3, "foo/bar", 10000, database), store3.Identifier);
+                WaitForUserToContinueTheTest(store1);
             }
         }
 


### PR DESCRIPTION
### Issue link

https://issues.hibernatingrhinos.com/issue/RavenDB-17187

### Additional description

Incoming replication was missing from Ongoing Task Stats because a stats instance was only sent under the condition that an item has been passed through the replication. Now Performance Collector returns an empty stats instance if handler has no stats.
In addition, all internal replications were shown as external due to having no differentiation between external and internal Push Replications. Added ReplicationType to the handshake so both incoming and outgoing handlers will know whether they are internal or external, and are sent to the Performance Collector accordingly. 

### Type of change

- Bug fix

### How risky is the change?

- Low 

### Backward compatibility

- Non breaking change - has been checked manually with a 4.2 server replicating to this issue's server (checking that ReplicationType can be missing from the handshake) 

### Is it platform specific issue?

- No

### Documentation update

- No documentation update is needed 

### Testing 

- Tests have been added that prove the fix is effective or that the feature works

### Is there any existing behavior change of other features due to this change?

- No

### UI work

- It requires further work in the Studio - https://issues.hibernatingrhinos.com/issue/RavenDB-17607
