### PR TITLE
RavenDB-17143 Add more time to test

### DIFF
--- a/test/SlowTests/Server/Replication/PullReplicationTests.cs
+++ b/test/SlowTests/Server/Replication/PullReplicationTests.cs
@@ -207,6 +207,7 @@ namespace SlowTests.Server.Replication
                     main.Store(new User(), "users/1");
                     main.SaveChanges();
                 }
+
                 await SetupPullReplicationAsync(definitionName, sink, hub);
                 Assert.True(WaitForDocument(sink, "users/1", timeout), sink.Identifier);
 
@@ -215,14 +216,12 @@ namespace SlowTests.Server.Replication
                     DelayReplicationFor = TimeSpan.FromDays(1),
                     TaskId = saveResult.TaskId
                 }));
-
                 using (var main = hub.OpenSession())
                 {
                     main.Store(new User(), "users/2");
                     main.SaveChanges();
                 }
                 Assert.False(WaitForDocument(sink, "users/2", timeout), sink.Identifier);
-
                 var res= await hub.Maintenance.ForDatabase(hub.Database).SendAsync(new PutPullReplicationAsHubOperation(new PullReplicationDefinition(definitionName)
                 {
                     TaskId = saveResult.TaskId
@@ -236,7 +235,7 @@ namespace SlowTests.Server.Replication
                 Assert.Equal(hubResult.Definition.DelayReplicationFor, new TimeSpan());
                 Assert.Equal(hubResult.Definition.Disabled, false);
 
-                Assert.True(WaitForDocument(sink, "users/2", timeout), sink.Identifier);
+                Assert.True(WaitForDocument(sink, "users/2", timeout * 2));
             }
         }
 


### PR DESCRIPTION
### Issue link

https://issues.hibernatingrhinos.com/issue/RavenDB-17143

### Additional description

The test was failing when we had the scenario we retry to connect after fail (when we had a delay on configuration) but still didn't get the new configuration. then we need to retry again and only then we get the document. 
added more time for wait to document

_Please delete below the options that are not relevant_

### Type of change

-Test fix

### How risky is the change?

- Low 

### Backward compatibility

- Not relevant

### Is it platform specific issue?

- No

### Documentation update

- No documentation update is needed 

### Testing 

- Tests have been added that prove the fix is effective or that the feature works

### Is there any existing behavior change of other features due to this change?

- No

### UI work

- No UI work is needed
