### PR TITLE
RavenDB-17666 - export the escaped id correctly when using smuggler

### DIFF
--- a/src/Raven.Server/Smuggler/Documents/StreamDestination.cs
+++ b/src/Raven.Server/Smuggler/Documents/StreamDestination.cs
@@ -733,17 +733,23 @@ namespace Raven.Server.Smuggler.Documents
 
                 using (tombstone)
                 {
-                    _context.Write(Writer, new DynamicJsonValue
+                    unsafe
                     {
-                        ["Key"] = tombstone.LowerId,
-                        [nameof(Tombstone.Type)] = tombstone.Type.ToString(),
-                        [nameof(Tombstone.Collection)] = tombstone.Collection,
-                        [nameof(Tombstone.Flags)] = tombstone.Flags.ToString(),
-                        [nameof(Tombstone.ChangeVector)] = tombstone.ChangeVector,
-                        [nameof(Tombstone.DeletedEtag)] = tombstone.DeletedEtag,
-                        [nameof(Tombstone.Etag)] = tombstone.Etag,
-                        [nameof(Tombstone.LastModified)] = tombstone.LastModified,
-                    });
+                        using (var escapedId = _context.GetLazyString(tombstone.LowerId.Buffer, tombstone.LowerId.Size))
+                        {
+                            _context.Write(Writer, new DynamicJsonValue
+                            {
+                                ["Key"] = escapedId,
+                                [nameof(Tombstone.Type)] = tombstone.Type.ToString(),
+                                [nameof(Tombstone.Collection)] = tombstone.Collection,
+                                [nameof(Tombstone.Flags)] = tombstone.Flags.ToString(),
+                                [nameof(Tombstone.ChangeVector)] = tombstone.ChangeVector,
+                                [nameof(Tombstone.DeletedEtag)] = tombstone.DeletedEtag,
+                                [nameof(Tombstone.Etag)] = tombstone.Etag,
+                                [nameof(Tombstone.LastModified)] = tombstone.LastModified,
+                            });
+                        }
+                    }
                 }
             }
 

--- a/test/SlowTests/Server/Documents/PeriodicBackup/PeriodicBackupSlowTests.cs
+++ b/test/SlowTests/Server/Documents/PeriodicBackup/PeriodicBackupSlowTests.cs
@@ -1804,6 +1804,46 @@ namespace SlowTests.Server.Documents.PeriodicBackup
             }
         }
 
+        [Fact, Trait("Category", "Smuggler")]
+        public async Task can_restore_smuggler_with_escaped_quotes()
+        {
+            var backupPath = NewDataPath(suffix: "BackupFolder");
+            const string docId = "\"users/1\"";
+
+            using (var store = GetDocumentStore())
+            {
+                using (var session = store.OpenAsyncSession())
+                {
+                    await session.StoreAsync(new User { Name = "Grisha" }, docId);
+                    await session.SaveChangesAsync();
+                }
+
+                var config = Backup.CreateBackupConfiguration(backupPath);
+                var backupTaskId = await Backup.UpdateConfigAndRunBackupAsync(Server, config, store);
+
+                using (var session = store.OpenAsyncSession())
+                {
+                    session.Delete(docId);
+                    await session.SaveChangesAsync();
+                }
+
+                var lastEtag = store.Maintenance.Send(new GetStatisticsOperation()).LastDatabaseEtag;
+                await Backup.RunBackupAndReturnStatusAsync(Server, backupTaskId, store, isFullBackup: false, expectedEtag: lastEtag);
+            }
+
+            using (var store = GetDocumentStore())
+            {
+                var backupDirectory = Directory.GetDirectories(backupPath).First();
+
+                await store.Smuggler.ImportIncrementalAsync(new DatabaseSmugglerImportOptions(), backupDirectory);
+                using (var session = store.OpenAsyncSession())
+                {
+                    var user = await session.LoadAsync<User>(docId);
+                    Assert.Null(user);
+                }
+            }
+        }
+
         private static string GetBackupPath(IDocumentStore store, long backTaskId, bool incremental = true)
         {
             var status = store.Maintenance.Send(new GetPeriodicBackupStatusOperation(backTaskId)).Status;


### PR DESCRIPTION
### Issue link

https://issues.hibernatingrhinos.com/issue/RavenDB-17666

### Additional description

Export the escaped id correctly when using smuggler.
The `LowerId` isn't saved in the escaped format and we don't have an `Id` like we have for a `Document`.

### Type of change

- Bug fix

### How risky is the change?

- Low 

### Testing 

- Tests have been added that prove the fix is effective or that the feature works
