### PR TITLE
RavenDB-17620 Fixing ocassionally failing test. The problem was the usage of wrong index instance (`replacementIndex` instead of `index`) and that we didn't call `WaitForIndexing(store)` inside `CallDuringFinallyOfExecuteIndexing()`

### DIFF
--- a/test/SlowTests/Issues/RavenDB_17237.cs
+++ b/test/SlowTests/Issues/RavenDB_17237.cs
@@ -63,16 +63,15 @@ namespace SlowTests.Issues
 
                 var replacementIndex = database.IndexStore.GetIndex(Constants.Documents.Indexing.SideBySideIndexNamePrefix + updatedIndexDef.IndexName);
 
-                using (replacementIndex.ForTestingPurposesOnly().CallDuringFinallyOfExecuteIndexing(() =>
+                using (index.ForTestingPurposesOnly().CallDuringFinallyOfExecuteIndexing(() =>
                 {
                     // stop the current index for a moment to ensure that a new thread will start - the one after renaming the replacement index
                     Thread.Sleep(2000);
                 }))
                 {
                     store.Maintenance.Send(new StartIndexingOperation());
+                    WaitForIndexing(store);
                 }
-
-                WaitForIndexing(store);
 
                 Assert.NotNull(replacementIndex._mre._timerTask);
                 Assert.False(replacementIndex._mre.Wait(100, CancellationToken.None));


### PR DESCRIPTION
### Issue link

https://issues.hibernatingrhinos.com/issue/RavenDB-17620

### Additional description

The test itself was faulty.

### Type of change

- Test fix

### How risky is the change?

- Low 

### Backward compatibility

- Not relevant

### Is it platform specific issue?

- No

### Documentation update

- No documentation update is needed 

### Testing 


- It has been verified by running the occasionally failing test in a loop

### Is there any existing behavior change of other features due to this change?

- No

### UI work

- No UI work is needed
