### PR TITLE
RavenDB-17260 Let's use the default paths when running in cluster even when running in-memory (we still create some temp files in that mode)

### DIFF
--- a/test/Tests.Infrastructure/RavenTestBase.cs
+++ b/test/Tests.Infrastructure/RavenTestBase.cs
@@ -287,7 +287,14 @@ namespace FastTests
                     }
                     else if (pathToUse == null)
                     {
-                        pathToUse = NewDataPath(name);
+                        if (options.ReplicationFactor > 1)
+                        {
+                            // the folders will be assigned automatically - when running in cluster it's better to put files in directories under dedicated server / node dir
+                        }
+                        else
+                        {
+                            pathToUse = NewDataPath(name);
+                        }
                     }
                     else
                     {


### PR DESCRIPTION
### Issue link

https://issues.hibernatingrhinos.com/issue/RavenDB-17260

### Additional description

I believe that not providing the path explicitly is better when running in a cluster to avoid potential problems with using the same directory for different in-memory storage environments.  See my comment in the issue: https://issues.hibernatingrhinos.com/issue/RavenDB-17260

### Type of change

- Test fix

### How risky is the change?

- Moderate - this test might reveal some issues with other tests

### Backward compatibility

- Not relevant

### Is it platform specific issue?
- No

### Documentation update

- No documentation update is needed 

### Testing 

- Running full test suit on CI will verify that

### Is there any existing behavior change of other features due to this change?

- No

### UI work

- No UI work is needed
