### PR TITLE
RavenDB-17665: Avoid the usage of stackalloc on primitives. 

### DIFF
--- a/src/Corax/Queries/BinaryMatch.Boolean.cs
+++ b/src/Corax/Queries/BinaryMatch.Boolean.cs
@@ -1,5 +1,6 @@
 ﻿using System;
 using System.Collections.Generic;
+using System.Diagnostics;
 using System.Linq;
 using System.Runtime.CompilerServices;
 using System.Runtime.InteropServices;
@@ -59,7 +60,9 @@ namespace Corax.Queries
             [SkipLocalsInit]
             static int AndWith(ref BinaryMatch<TInner, TOuter> match, Span<long> matches)
             {
-                Span<long> orMatches = stackalloc long[matches.Length];
+                var bufferHolder = QueryContext.MatchesPool.Rent(sizeof(long) * matches.Length);
+                var orMatches = MemoryMarshal.Cast<byte, long>(bufferHolder).Slice(0, matches.Length);
+
                 var count = FillFunc(ref match, orMatches);
 
                 var matchesPtr = (long*)Unsafe.AsPointer(ref MemoryMarshal.GetReference(matches));
@@ -67,7 +70,11 @@ namespace Corax.Queries
 
                 var orMatchesPtr = (long*)Unsafe.AsPointer(ref MemoryMarshal.GetReference(orMatches));
 
-                return MergeHelper.And(matchesPtr, matchesSize, matchesPtr, matchesSize, orMatchesPtr, count);
+                var result = MergeHelper.And(matchesPtr, matchesSize, matchesPtr, matchesSize, orMatchesPtr, count);
+                
+                QueryContext.MatchesPool.Return(bufferHolder);
+
+                return result;
             }
 
             [SkipLocalsInit]
@@ -75,6 +82,17 @@ namespace Corax.Queries
             {
                 ref var inner = ref match._inner;
                 ref var outer = ref match._outer;
+
+                if (matches.Length == 1)
+                {
+                    // Special case when matches is a single element (no OR is possible under this conditions)
+                    // PERF: For performance reason if this branch is been triggered repeteadly ensure the 
+                    //       calling code to avoid this happening. 
+                    var count = inner.Fill(matches);
+                    if (count == 0)
+                        count = outer.Fill(matches);
+                    return count;
+                }
 
                 var bufferHolder = QueryContext.MatchesPool.Rent(sizeof(long) * matches.Length);
                 var longBuffer = MemoryMarshal.Cast<byte, long>(bufferHolder);

--- a/src/Corax/Queries/BinaryMatch.cs
+++ b/src/Corax/Queries/BinaryMatch.cs
@@ -1,5 +1,6 @@
 using System;
 using System.Runtime.CompilerServices;
+using System.Runtime.InteropServices;
 
 namespace Corax.Queries
 {
@@ -64,9 +65,10 @@ namespace Corax.Queries
             if (innerBoosting == true && outerBoosting == true)
             {
                 _inner.Score(matches, scores);
-                
-                // TODO: We are not going to use stackalloc here.
-                Span<float> outerScores = stackalloc float[scores.Length];
+
+                var bufferHolder = QueryContext.MatchesPool.Rent(sizeof(float) * scores.Length);
+                var outerScores = MemoryMarshal.Cast<byte, float>(bufferHolder).Slice(0, scores.Length);
+
                 outerScores.Fill(1); // We will fill the scores with 1.0
 
                 // We get the score for the outer chain.
@@ -75,6 +77,9 @@ namespace Corax.Queries
                 // We multiply the scores from the outer chain with the current scores and return.
                 for(int i = 0; i < scores.Length; i++)
                     scores[i] *= outerScores[i];
+
+                QueryContext.MatchesPool.Return(bufferHolder);
+
                 return;
             }
 

--- a/src/Corax/Queries/SortingMatch.cs
+++ b/src/Corax/Queries/SortingMatch.cs
@@ -104,11 +104,13 @@ namespace Corax.Queries
 
             int take = _take <= 0 ? matches.Length : Math.Min(matches.Length, _take);
 
-            var matchesKeysHolder = QueryContext.MatchesPool.Rent(2 * sizeof(float) * matches.Length);            
-            var allScoresValues = MemoryMarshal.Cast<byte, float>(matchesKeysHolder);            
+            int floatArraySize = 2 * sizeof(float) * matches.Length;
+            int matchesArraySize = sizeof(long) * matches.Length;
+            var bufferHolder = QueryContext.MatchesPool.Rent(floatArraySize + matchesArraySize);
+            var allScoresValues = MemoryMarshal.Cast<byte, float>(bufferHolder.AsSpan().Slice(0, floatArraySize));
 
             // PERF: We want to avoid to share cache lines, that's why the second array will move toward the end of the array. 
-            var matchesScores = allScoresValues[0..matches.Length];
+            var matchesScores = allScoresValues[..matches.Length];
             var bScores = allScoresValues[^matches.Length..];           
 
             TotalResults += totalMatches;
@@ -124,9 +126,8 @@ namespace Corax.Queries
             var sorter = new Sorter<float, long, NumericDescendingComparer>();
             sorter.Sort(matchesScores[0..totalMatches], matches[0..totalMatches]);
 
+            Span<long> bValues = MemoryMarshal.Cast<byte, long>(bufferHolder.AsSpan().Slice(floatArraySize, matchesArraySize));
             var searcher = _searcher;
-            var bValuesHolder = QueryContext.MatchesPool.Rent(sizeof(long) * matches.Length);
-            var bValues = MemoryMarshal.Cast<byte, long>(bValuesHolder);
             while (true)
             {
                 // We get a new batch
@@ -161,8 +162,6 @@ namespace Corax.Queries
 
                 int aIdx = aTotalMatches;
                 bIdx = 0;
-                kIdx = 0;
-
                 while (aIdx > 0 && aIdx >= aTotalMatches / 8)
                 {
                     // If the 'bigger' of what we had is 'bigger than'
@@ -189,7 +188,6 @@ namespace Corax.Queries
 
                     if (result)
                     {
-
                         matches[kIdx] = matches[aIdx];
                         aIdx++;
                     }
@@ -222,11 +220,11 @@ namespace Corax.Queries
                     bIdx++;
                 }
 
-            End:
+                End:
                 totalMatches = kIdx;
             }
-            
-            QueryContext.MatchesPool.Return(matchesKeysHolder);
+
+            QueryContext.MatchesPool.Return(bufferHolder);
             return totalMatches;
         }
 
@@ -243,13 +241,19 @@ namespace Corax.Queries
             int totalMatches = _inner.Fill(matches);
             if (totalMatches == 0)
                 return 0;
+            
+            int matchesArraySize = sizeof(long) * matches.Length;
+            int itemArraySize = 2 * Unsafe.SizeOf<MatchComparer<TComparer, W>.Item>() * matches.Length;
+            var bufferHolder = QueryContext.MatchesPool.Rent(itemArraySize + matchesArraySize);
 
-            var matchesKeysHolder = QueryContext.MatchesPool.Rent(2 * Unsafe.SizeOf<MatchComparer<TComparer, W>.Item>() * matches.Length);
-            var itemKeys = MemoryMarshal.Cast<byte, MatchComparer<TComparer, W>.Item>(matchesKeysHolder);
+            var itemKeys = MemoryMarshal.Cast<byte, MatchComparer<TComparer, W>.Item>(bufferHolder.AsSpan().Slice(0, itemArraySize));
+            Debug.Assert(itemKeys.Length == 2 * matches.Length);
 
             // PERF: We want to avoid to share cache lines, that's why the second array will move toward the end of the array. 
-            var matchesKeys = itemKeys[0..matches.Length];            
-            var bKeys = itemKeys[^matches.Length..]; 
+            var matchesKeys = itemKeys.Slice(0, matches.Length);
+            Debug.Assert(matchesKeys.Length == matches.Length);
+            var bKeys = itemKeys.Slice(matches.Length, matches.Length);
+            Debug.Assert(bKeys.Length == matches.Length);
 
             int take = _take <= 0 ? matches.Length : Math.Min(matches.Length, _take);
 
@@ -268,7 +272,8 @@ namespace Corax.Queries
             var sorter = new Sorter<MatchComparer<TComparer, W>.Item, long, MatchComparer<TComparer, W>>(comparer);
             sorter.Sort(matchesKeys[0..totalMatches], matches);
 
-            Span<long> bValues = stackalloc long[matches.Length];                        
+            Span<long> bValues = MemoryMarshal.Cast<byte, long>(bufferHolder.AsSpan().Slice(itemArraySize, matchesArraySize));
+            Debug.Assert(bValues.Length == matches.Length);
             while (true)
             {
                 // We get a new batch
@@ -278,7 +283,7 @@ namespace Corax.Queries
                 // When we don't have any new batch, we are done.
                 if (bTotalMatches == 0)
                 {
-                    QueryContext.MatchesPool.Return(matchesKeysHolder);
+                    QueryContext.MatchesPool.Return(bufferHolder);
                     return totalMatches;
                 }
 

--- a/src/Corax/Queries/UnaryMatch.Ordinal.cs
+++ b/src/Corax/Queries/UnaryMatch.Ordinal.cs
@@ -40,10 +40,11 @@ namespace Corax.Queries
 
             var comparer = default(TComparer);
             var currentMatches = matches;
-            int totalResults = 0;
-            int results = 0;
+            int totalResults = 0;            
             int storeIdx = 0;
             int maxUnusedMatchesSlots = matches.Length >= 64 ? matches.Length / 8 : 1;
+
+            int results;
             do
             {
                 var freeMemory = currentMatches.Slice(storeIdx);
@@ -65,10 +66,10 @@ namespace Corax.Queries
                     }
                 }
 
-            } while (results >= totalResults + maxUnusedMatchesSlots);
+            } 
+            while (results >= totalResults + maxUnusedMatchesSlots);
 
-            matches = currentMatches.Slice(0,storeIdx);
-            return totalResults;
+            return storeIdx;
         }
 
         [SkipLocalsInit]


### PR DESCRIPTION
The reason why we want to avoid it is because primitives can call other primitives which in turn could consume more stack doing stack allocations. Therefore, we can end up in a situation where we stack overflow because of big queries. 