### PR TITLE
RavenDB-17636 Adding support for filter clause (which does a scan of …

### DIFF
--- a/src/Raven.Client/Documents/Queries/QueryResult.cs
+++ b/src/Raven.Client/Documents/Queries/QueryResult.cs
@@ -36,6 +36,13 @@ namespace Raven.Client.Documents.Queries
         /// Gets or sets the skipped results
         /// </summary>
         public int SkippedResults { get; set; }
+        
+        /// <summary>
+        /// The number of results (filtered or matches)
+        /// that were scanned by the query. This is relevant
+        /// only if you are using a filter clause in the query.
+        /// </summary>
+        public int? ScannedResults { get; set; }
 
         /// <summary>
         /// Highlighter results (if requested).
@@ -72,6 +79,7 @@ namespace Raven.Client.Documents.Queries
                 IncludedPaths = IncludedPaths,
                 IsStale = IsStale,
                 SkippedResults = SkippedResults,
+                ScannedResults = ScannedResults,
                 TotalResults = TotalResults,
                 LongTotalResults = LongTotalResults,
                 Highlightings = Highlightings?.ToDictionary(pair => pair.Key, x => new Dictionary<string, string[]>(x.Value)),

--- a/src/Raven.Client/Documents/Session/QueryStatistics.cs
+++ b/src/Raven.Client/Documents/Session/QueryStatistics.cs
@@ -39,6 +39,13 @@ namespace Raven.Client.Documents.Session
         /// Gets or sets the skipped results
         /// </summary>
         public int SkippedResults { get; set; }
+        
+        /// <summary>
+        /// The number of results (filtered or matches)
+        /// that were scanned by the query. This is relevant
+        /// only if you are using a filter clause in the query.
+        /// </summary>
+        public int? ScannedResults { get; set; }
 
         /// <summary>
         /// The time when the query results were unstale.
@@ -77,6 +84,7 @@ namespace Raven.Client.Documents.Session
             TotalResults = qr.TotalResults;
             LongTotalResults = qr.LongTotalResults;
             SkippedResults = qr.SkippedResults;
+            ScannedResults = qr.ScannedResults;
             Timestamp = qr.IndexTimestamp;
             IndexName = qr.IndexName;
             IndexTimestamp = qr.IndexTimestamp;

--- a/src/Raven.Server/Documents/CollectionRunner.cs
+++ b/src/Raven.Server/Documents/CollectionRunner.cs
@@ -170,11 +170,9 @@ namespace Raven.Server.Documents
                 isStartsWithOrIdQuery = true;
 
                 return new CollectionQueryEnumerable(Database, Database.DocumentsStorage, new FieldsToFetch(_operationQuery, null),
-                    collectionName, _operationQuery, null, context, null, null, null, new Reference<int>(), token)
+                    collectionName, _operationQuery, null, context, null, null, null, new Reference<int>(), new Reference<int>(), new Reference<long>(), token)
                 {
-                    Fields = fields,
-                    StartAfterId = startAfterId,
-                    AlreadySeenIdsCount = alreadySeenIdsCount
+                    Fields = fields, StartAfterId = startAfterId, AlreadySeenIdsCount = alreadySeenIdsCount
                 };
             }
 

--- a/src/Raven.Server/Documents/Indexes/Debugging/IndexDebugExtensions.cs
+++ b/src/Raven.Server/Documents/Indexes/Debugging/IndexDebugExtensions.cs
@@ -427,7 +427,7 @@ namespace Raven.Server.Documents.Indexes.Debugging
 
                 var retriever = new MapReduceQueryResultRetriever(null, null, null, null, context, fieldsToFetch, null, null, null);
                 var result = reader
-                     .Query(query, null, fieldsToFetch, new Reference<int>(), new Reference<int>(), retriever, ctx, null, CancellationToken.None)
+                     .Query(query, null, fieldsToFetch, new Reference<int>(), new Reference<int>(), new Reference<int>(), retriever, ctx, null, CancellationToken.None)
                     .ToList();
 
                 if (result.Count == 0)

--- a/src/Raven.Server/Documents/Indexes/Index.cs
+++ b/src/Raven.Server/Documents/Indexes/Index.cs
@@ -3096,8 +3096,9 @@ namespace Raven.Server.Documents.Indexes
                                     fillScope = includesScope.For(nameof(QueryTimingsScope.Names.Fill), start: false);
                                 }
 
-                                var totalResults = new Reference<int>();
-                                var skippedResults = new Reference<int>();
+                                Reference<int> totalResults = new Reference<int>();
+                                Reference<int> skippedResults = new Reference<int>();
+                                Reference<int> scannedResults = new Reference<int>();
                                 IncludeCountersCommand includeCountersCommand = null;
                                 IncludeTimeSeriesCommand includeTimeSeriesCommand = null;
                                 IncludeRevisionsCommand includeRevisionsCommand = new(DocumentDatabase,  queryContext.Documents, query.Metadata.RevisionIncludes);
@@ -3153,6 +3154,7 @@ namespace Raven.Server.Documents.Indexes
                                         fieldsToFetch,
                                         totalResults,
                                         skippedResults,
+                                        scannedResults,
                                         retriever,
                                         queryContext.Documents,
                                         GetOrAddSpatialField,
@@ -3166,6 +3168,7 @@ namespace Raven.Server.Documents.Indexes
                                         fieldsToFetch,
                                         totalResults,
                                         skippedResults,
+                                        scannedResults,
                                         retriever,
                                         queryContext.Documents,
                                         GetOrAddSpatialField,
@@ -3255,7 +3258,12 @@ namespace Raven.Server.Documents.Indexes
                                 resultToFill.TotalResults = Math.Max(totalResults.Value, resultToFill.Results.Count);
                                 resultToFill.LongTotalResults = resultToFill.TotalResults;
                                 resultToFill.SkippedResults = skippedResults.Value;
+                                resultToFill.ScannedResults = scannedResults.Value;
                                 resultToFill.IncludedPaths = query.Metadata.Includes;
+                                if (query.Metadata.FilterScript != null)
+                                {
+                                    resultToFill.ScannedResults = scannedResults.Value;
+                                }
                             }
                         }
 

--- a/src/Raven.Server/Documents/Indexes/Persistence/Lucene/IndexReadOperation.cs
+++ b/src/Raven.Server/Documents/Indexes/Persistence/Lucene/IndexReadOperation.cs
@@ -123,7 +123,7 @@ namespace Raven.Server.Documents.Indexes.Persistence.Lucene
             ScriptRunner.ReturnRun releaseFilterScriptRunner = default;
             if (query.Metadata.FilterScript != null)
             {
-                var key = new CollectionQueryEnumerable.FilterKey(query.Metadata.FilterScript, query.Metadata.DeclaredFunctions, query.Metadata.Query.From.Alias?.Value);
+                var key = new CollectionQueryEnumerable.FilterKey(query.Metadata);
                 releaseFilterScriptRunner = _index.DocumentDatabase.Scripts.GetScriptRunner(key, readOnly: true, patchRun: out filterScriptRun);
             }
             

--- a/src/Raven.Server/Documents/Indexes/Persistence/Lucene/IndexReadOperation.cs
+++ b/src/Raven.Server/Documents/Indexes/Persistence/Lucene/IndexReadOperation.cs
@@ -175,7 +175,8 @@ namespace Raven.Server.Documents.Indexes.Persistence.Lucene
                                 continue;
                             }
                             object self = filterScriptRun.Translate(documentsContext, doc);
-                            using (var result = filterScriptRun.Run(documentsContext, documentsContext, "execute", new[]{self, }))
+                            using(queryTimings.For(nameof(QueryTimingsScope.Names.JavaScript)))
+                            using (var result = filterScriptRun.Run(documentsContext, documentsContext, "execute", new[]{self, query.QueryParameters}, queryTimings))
                             {
                                 if (result.BooleanValue != true)
                                 {

--- a/src/Raven.Server/Documents/Indexes/Persistence/Lucene/IndexReadOperation.cs
+++ b/src/Raven.Server/Documents/Indexes/Persistence/Lucene/IndexReadOperation.cs
@@ -175,7 +175,7 @@ namespace Raven.Server.Documents.Indexes.Persistence.Lucene
                                 continue;
                             }
                             object self = filterScriptRun.Translate(documentsContext, doc);
-                            using(queryTimings.For(nameof(QueryTimingsScope.Names.JavaScript)))
+                            using(queryTimings?.For(nameof(QueryTimingsScope.Names.JavaScript)))
                             using (var result = filterScriptRun.Run(documentsContext, documentsContext, "execute", new[]{self, query.QueryParameters}, queryTimings))
                             {
                                 if (result.BooleanValue != true)

--- a/src/Raven.Server/Documents/Patch/PatchRequest.cs
+++ b/src/Raven.Server/Documents/Patch/PatchRequest.cs
@@ -72,7 +72,7 @@ namespace Raven.Server.Documents.Patch
             runner.AddScript(GenerateRootScript());
         }
 
-        private string GenerateRootScript()
+        protected virtual string GenerateRootScript()
         {
             switch (Type)
             {

--- a/src/Raven.Server/Documents/Queries/AST/JavascriptCodeQueryVisitor.cs
+++ b/src/Raven.Server/Documents/Queries/AST/JavascriptCodeQueryVisitor.cs
@@ -204,6 +204,9 @@ namespace Raven.Server.Documents.Queries.AST
         {
             if (expr.Value == ValueTokenType.String)
                 _sb.Append('"');
+
+            if (expr.Value == ValueTokenType.Parameter)
+                _sb.Append('$');
             
             _sb.Append(expr.Token.Value.Replace("\\", "\\\\"));
 

--- a/src/Raven.Server/Documents/Queries/AST/JavascriptCodeQueryVisitor.cs
+++ b/src/Raven.Server/Documents/Queries/AST/JavascriptCodeQueryVisitor.cs
@@ -11,7 +11,8 @@ namespace Raven.Server.Documents.Queries.AST
         private readonly StringBuilder _sb;
         private readonly HashSet<string> _knownAliases = new HashSet<string>();
         private static readonly string[] UnsupportedQueryMethodsInJavascript = {
-            "Search","Boost","Lucene","Exact","Count","Sum","Circle","Wkt","Point","Within","Contains","Disjoint","Intersects","MoreLikeThis"
+            "Search","Boost","Lucene","Exact","Count","Sum","Circle","Wkt","Point","Within","Contains","Disjoint","Intersects","MoreLikeThis",
+            "Spatial.Wkt", "Spatial.Point", "Spatial.Intersects", "Spatial.Contains", "Spatial.Disjoint", "Spatial.Sum"
         };
 
         public JavascriptCodeQueryVisitor(StringBuilder sb, Query q)
@@ -175,7 +176,7 @@ namespace Raven.Server.Documents.Queries.AST
             if (UnsupportedQueryMethodsInJavascript.Any(x=>
                 x.Equals(expr.Name.Value, StringComparison.OrdinalIgnoreCase)))
             {
-                throw new NotSupportedException($"'{expr.Name.Value}' query method is not supported by subscriptions");
+                throw new NotSupportedException($"'{expr.Name.Value}' query method is not supported for this type of query");
             }
             
             _sb.Append(expr.Name.Value);

--- a/src/Raven.Server/Documents/Queries/AST/JsonQueryVisitor.cs
+++ b/src/Raven.Server/Documents/Queries/AST/JsonQueryVisitor.cs
@@ -124,6 +124,12 @@ namespace Raven.Server.Documents.Queries.AST
             _writer.WritePropertyName("Where");
             base.VisitWhereClause(where);
         }
+        
+        public override void VisitFilterClause(QueryExpression filter)
+        {
+            _writer.WritePropertyName("Filter");
+            base.VisitWhereClause(filter);
+        }
 
         public override void VisitCompoundWhereExpression(BinaryExpression @where)
         {

--- a/src/Raven.Server/Documents/Queries/AST/Query.cs
+++ b/src/Raven.Server/Documents/Queries/AST/Query.cs
@@ -32,6 +32,7 @@ namespace Raven.Server.Documents.Queries.AST
         public string UpdateBody;
         public ValueExpression Offset;
         public ValueExpression Limit;
+        public ValueExpression ScanLimit;
 
         public bool TryAddFunction(DeclaredFunction func)
         {
@@ -85,7 +86,7 @@ namespace Raven.Server.Documents.Queries.AST
                 if (expr.Path.Compound.Count == 0 && expr.OrderBy == null && expr.Where == null)
                     return;
 
-                throw new InvalidQueryException($"Allias {alias} is already in use on a diffrent 'With' clause",
+                throw new InvalidQueryException($"Alias {alias} is already in use on a different 'With' clause",
                     QueryText);
             }
 

--- a/src/Raven.Server/Documents/Queries/AST/Query.cs
+++ b/src/Raven.Server/Documents/Queries/AST/Query.cs
@@ -17,6 +17,7 @@ namespace Raven.Server.Documents.Queries.AST
         public bool IsDistinct;
         public GraphQuery GraphQuery;
         public QueryExpression Where;
+        public QueryExpression Filter;
         public FromClause From;
         public List<(QueryExpression Expression, StringSegment? Alias)> Select;
         public List<(QueryExpression Expression, StringSegment? Alias)> Load;

--- a/src/Raven.Server/Documents/Queries/AST/QueryVisitor.cs
+++ b/src/Raven.Server/Documents/Queries/AST/QueryVisitor.cs
@@ -32,7 +32,12 @@ namespace Raven.Server.Documents.Queries.AST
             {
                 VisitWhereClause(q.Where);
             }
-
+            
+            if (q.Filter != null)
+            {
+                VisitFilterClause(q.Filter);
+            }
+            
             if (q.OrderBy != null)
             {
                 VisitOrderBy(q.OrderBy);
@@ -62,6 +67,11 @@ namespace Raven.Server.Documents.Queries.AST
             {
                 VisitInclude(q.Include);
             }
+        }
+
+        public virtual void VisitFilterClause(QueryExpression filter)
+        {
+            VisitExpression(filter);
         }
 
         public virtual void VisitMatchExpression(QueryExpression expr)

--- a/src/Raven.Server/Documents/Queries/AST/StringQueryVisitor.cs
+++ b/src/Raven.Server/Documents/Queries/AST/StringQueryVisitor.cs
@@ -123,6 +123,14 @@ namespace Raven.Server.Documents.Queries.AST
             base.VisitWhereClause(where);
             _sb.AppendLine();
         }
+        
+        public override void VisitFilterClause(QueryExpression where)
+        {
+            EnsureSpace();
+            _sb.Append("FILTER ");
+            base.VisitWhereClause(where);
+            _sb.AppendLine();
+        }
 
         public override void VisitNegatedExpression(NegatedExpression expr)
         {

--- a/src/Raven.Server/Documents/Queries/CollectionQueryEnumerable.cs
+++ b/src/Raven.Server/Documents/Queries/CollectionQueryEnumerable.cs
@@ -6,6 +6,7 @@ using System.Linq;
 using System.Threading;
 using Raven.Client.Exceptions;
 using Raven.Server.Documents.Includes;
+using Raven.Server.Documents.Patch;
 using Raven.Server.Documents.Queries.AST;
 using Raven.Server.Documents.Queries.Results;
 using Raven.Server.Documents.Queries.Timings;
@@ -74,6 +75,44 @@ namespace Raven.Server.Documents.Queries
             return GetEnumerator();
         }
 
+        public class FilterKey : ScriptRunnerCache.Key
+        {
+            private readonly QueryMetadata _queryMetadata;
+
+            public FilterKey(QueryMetadata queryMetadata)
+            {
+                _queryMetadata = queryMetadata;
+            }
+
+            public override void GenerateScript(ScriptRunner runner)
+            {
+                if (_queryMetadata.DeclaredFunctions != null)
+                {
+                    foreach (var function in _queryMetadata.DeclaredFunctions)
+                    {
+                        runner.AddScript(function.Value.FunctionText);
+                    }
+                }
+
+                runner.AddScript(_queryMetadata.FilterScript);
+            }
+
+            public override bool Equals(object obj)
+            {
+                if (obj is FilterKey fk)
+                {
+                    return _queryMetadata == fk._queryMetadata;
+                }
+
+                return false;
+            }
+
+            public override int GetHashCode()
+            {
+                return _queryMetadata.GetHashCode();
+            }
+        }
+
         private class Enumerator : IEnumerator<Document>
         {
             private readonly DocumentsStorage _documents;
@@ -83,6 +122,7 @@ namespace Raven.Server.Documents.Queries
             private readonly string _collection;
             private readonly bool _isAllDocsCollection;
             private readonly IndexQueryServerSide _query;
+            private readonly QueryTimingsScope _queryTimings;
             private readonly string _startAfterId;
             private readonly Reference<long> _alreadySeenIdsCount;
             private readonly DocumentFields _fields;
@@ -102,11 +142,12 @@ namespace Raven.Server.Documents.Queries
             private readonly string _startsWith;
             private readonly Reference<long> _skippedResults;
             private readonly CancellationToken _token;
+            private readonly ScriptRunner.SingleRun _filterScriptRun;
+            private ScriptRunner.ReturnRun _releaseFilterScriptRunner;
 
             public Enumerator(DocumentDatabase database, DocumentsStorage documents, FieldsToFetch fieldsToFetch, string collection, bool isAllDocsCollection,
                 IndexQueryServerSide query, QueryTimingsScope queryTimings, DocumentsOperationContext context, IncludeDocumentsCommand includeDocumentsCommand,
-                IncludeRevisionsCommand includeRevisionsCommand,
-                IncludeCompareExchangeValuesCommand includeCompareExchangeValuesCommand, Reference<int> totalResults, 
+                IncludeRevisionsCommand includeRevisionsCommand,IncludeCompareExchangeValuesCommand includeCompareExchangeValuesCommand, Reference<int> totalResults, 
                 string startAfterId, Reference<long> alreadySeenIdsCount, DocumentFields fields, Reference<long> skippedResults, CancellationToken token)
             {
                 _documents = documents;
@@ -114,6 +155,7 @@ namespace Raven.Server.Documents.Queries
                 _collection = collection;
                 _isAllDocsCollection = isAllDocsCollection;
                 _query = query;
+                _queryTimings = queryTimings;
                 _context = context;
                 _totalResults = totalResults;
                 _totalResults.Value = 0;
@@ -129,6 +171,12 @@ namespace Raven.Server.Documents.Queries
                 _resultsRetriever = new MapQueryResultRetriever(database, query, queryTimings, documents, context, fieldsToFetch, includeDocumentsCommand, includeCompareExchangeValuesCommand, includeRevisionsCommand);
 
                 (_ids, _startsWith) = ExtractIdsFromQuery(query, context);
+                
+                if (_query.Metadata.FilterScript != null)
+                {
+                    var key = new FilterKey(_query.Metadata);
+                    _releaseFilterScriptRunner = database.Scripts.GetScriptRunner(key, readOnly: true, patchRun: out _filterScriptRun);
+            	}
             }
 
             private (List<Slice>, string) ExtractIdsFromQuery(IndexQueryServerSide query, DocumentsOperationContext context)
@@ -178,6 +226,7 @@ namespace Raven.Server.Documents.Queries
                     {
                         if (hasNext == false)
                             return false;
+                        _skippedResults.Value++;
                         continue;
                     }
 
@@ -234,6 +283,17 @@ namespace Raven.Server.Documents.Queries
 
                 _innerCount++;
 
+                if (_filterScriptRun != null)
+                {
+                    object self = _filterScriptRun.Translate(_context, _inner.Current);
+                    using(_queryTimings?.For(nameof(QueryTimingsScope.Names.JavaScript)))
+                    using (var result = _filterScriptRun.Run(_context, _context, "execute", _inner.Current!.Id, new[]{self, _query.QueryParameters}, _queryTimings))
+                    {
+                        if (result.BooleanValue != true)
+                            return (true, null);
+                    }
+                }
+                
                 if (_fieldsToFetch.IsProjection)
                 {
                     var result = _resultsRetriever.GetProjectionFromDocument(_inner.Current, null, QueryResultRetrieverBase.ZeroScore, _fieldsToFetch, _context, null, _token);
@@ -424,6 +484,7 @@ namespace Raven.Server.Documents.Queries
                         id.Release(_context.Allocator);
                     }
                 }
+                _releaseFilterScriptRunner.Dispose();
             }
 
             private class RetrieveDocumentIdsVisitor : WhereExpressionVisitor

--- a/src/Raven.Server/Documents/Queries/Dynamic/CollectionQueryRunner.cs
+++ b/src/Raven.Server/Documents/Queries/Dynamic/CollectionQueryRunner.cs
@@ -141,13 +141,15 @@ namespace Raven.Server.Documents.Queries.Dynamic
 
                 var totalResults = new Reference<int>();
                 var skippedResults = new Reference<long>();
+                var scannedResults = new Reference<int>();
                 IEnumerator<Document> enumerator;
 
                 if (pulseReadingTransaction == false)
                 {
-                    var documents = new CollectionQueryEnumerable(Database, Database.DocumentsStorage, fieldsToFetch, collection, query, queryScope, context.Documents, includeDocumentsCommand, includeRevisionsCommand: includeRevisionsCommand, includeCompareExchangeValuesCommand: includeCompareExchangeValuesCommand, totalResults: totalResults, token);
-                    
-                    documents.SkippedResults = skippedResults;
+                    var documents = new CollectionQueryEnumerable(Database, Database.DocumentsStorage, fieldsToFetch, collection, query, queryScope, context.Documents,
+                        includeDocumentsCommand, includeRevisionsCommand: includeRevisionsCommand,
+                        includeCompareExchangeValuesCommand: includeCompareExchangeValuesCommand, totalResults: totalResults, scannedResults, skippedResults, token);
+
                     enumerator = documents.GetEnumerator();
                 }
                 else
@@ -157,7 +159,9 @@ namespace Raven.Server.Documents.Queries.Dynamic
                         {
                             query.Start = state.Start;
                             query.PageSize = state.Take;
-                            var documents = new CollectionQueryEnumerable(Database, Database.DocumentsStorage, fieldsToFetch, collection, query, queryScope, context.Documents, includeDocumentsCommand, includeRevisionsCommand, includeCompareExchangeValuesCommand, totalResults, token);
+                            var documents = new CollectionQueryEnumerable(Database, Database.DocumentsStorage, fieldsToFetch, collection, query, queryScope,
+                                context.Documents, includeDocumentsCommand, includeRevisionsCommand, includeCompareExchangeValuesCommand, totalResults, scannedResults,
+                                skippedResults, token);
 
                             return documents;
                         },
@@ -252,6 +256,7 @@ namespace Raven.Server.Documents.Queries.Dynamic
                 resultToFill.TotalResults = (totalResults.Value == 0 && resultToFill.Results.Count != 0) ? -1 : totalResults.Value;
                 resultToFill.LongTotalResults = resultToFill.TotalResults;
                 resultToFill.SkippedResults = Convert.ToInt32(skippedResults.Value);
+                resultToFill.ScannedResults = scannedResults.Value;
 
                 if (query.Offset != null || query.Limit != null)
                 {

--- a/src/Raven.Server/Documents/Queries/IndexQueryServerSide.cs
+++ b/src/Raven.Server/Documents/Queries/IndexQueryServerSide.cs
@@ -84,6 +84,7 @@ namespace Raven.Server.Documents.Queries
         public bool AddTimeSeriesNames;
 
         public bool IsStream;
+        public  string ClientQueryId;
 
         public IndexQueryServerSide(string query, BlittableJsonReaderObject queryParameters = null)
         {
@@ -104,6 +105,8 @@ namespace Raven.Server.Documents.Queries
             try
             {
                 result = JsonDeserializationServer.IndexQuery(json);
+                if (httpContext.Request.Query.TryGetValue("clientQueryId", out var v))
+                    result.ClientQueryId = v[0];
 
                 if (result.PageSize == 0 && json.TryGet(nameof(PageSize), out int _) == false)
                     result.PageSize = int.MaxValue;
@@ -202,6 +205,9 @@ namespace Raven.Server.Documents.Queries
                                     result.QueryParameters = await context.ReadForMemoryAsync(stream, "query parameters");
                                 }
                                 continue;
+                            case "clientQueryId":
+                                result.ClientQueryId = item.Value[0];
+                                break;
                             case "waitForNonStaleResults":
                                 result.WaitForNonStaleResults = bool.Parse(item.Value[0]);
                                 break;

--- a/src/Raven.Server/Documents/Queries/IndexQueryServerSide.cs
+++ b/src/Raven.Server/Documents/Queries/IndexQueryServerSide.cs
@@ -28,6 +28,9 @@ namespace Raven.Server.Documents.Queries
         public int? Limit;
 
         [JsonDeserializationIgnore]
+        public int? ScanLimit { get; set; }
+        
+        [JsonDeserializationIgnore]
         public QueryMetadata Metadata { get; private set; }
 
         [JsonDeserializationIgnore]
@@ -36,6 +39,7 @@ namespace Raven.Server.Documents.Queries
         [JsonDeserializationIgnore]
         public SpatialDistanceFieldComparatorSource.SpatialDistanceFieldComparator Distances;
 
+        
         public new int Start
         {
 #pragma warning disable 618
@@ -170,6 +174,18 @@ namespace Raven.Server.Documents.Queries
                     result.Limit = limit;
                     result.PageSize = Math.Min(limit, result.PageSize);
                 }
+                
+                if (result.Metadata.Query.Limit != null)
+                {
+                    var limit = (int)QueryBuilder.GetLongValue(result.Metadata.Query, result.Metadata, result.QueryParameters, result.Metadata.Query.Limit, int.MaxValue);
+                    result.Limit = limit;
+                    result.PageSize = Math.Min(limit, result.PageSize);
+                }
+                
+                if (result.Metadata.Query.ScanLimit != null)
+                {
+                    result.ScanLimit = (int)QueryBuilder.GetLongValue(result.Metadata.Query, result.Metadata, result.QueryParameters, result.Metadata.Query.ScanLimit, int.MaxValue);
+                }
             }
         }
 
@@ -246,6 +262,11 @@ namespace Raven.Server.Documents.Queries
                     result.Limit = pageSize;
                     result.PageSize = Math.Min(result.PageSize, pageSize);
                 }
+                
+                if (result.Metadata.Query.ScanLimit != null)
+                {
+                    result.ScanLimit = (int)QueryBuilder.GetLongValue(result.Metadata.Query, result.Metadata, result.QueryParameters, result.Metadata.Query.ScanLimit, int.MaxValue);
+                }
 
                 if (tracker != null)
                     tracker.Query = result.Query;
@@ -277,6 +298,9 @@ namespace Raven.Server.Documents.Queries
 
             if (indexQuery.Limit < 0)
                 throw new InvalidQueryException($"{nameof(Limit)} ({nameof(PageSize)}) cannot be negative, but was {indexQuery.Limit}.", indexQuery.Query, indexQuery.QueryParameters);
+
+            if (indexQuery.ScanLimit < 0)
+                throw new InvalidQueryException($"{nameof(ScanLimit)} cannot be negative, but was {indexQuery.ScanLimit}.", indexQuery.Query, indexQuery.QueryParameters);
 
             if (indexQuery.Start < 0)
                 throw new InvalidQueryException($"{nameof(Start)} cannot be negative, but was {indexQuery.Start}.", indexQuery.Query, indexQuery.QueryParameters);

--- a/src/Raven.Server/Documents/Queries/Parser/QueryParser.cs
+++ b/src/Raven.Server/Documents/Queries/Parser/QueryParser.cs
@@ -116,12 +116,6 @@ namespace Raven.Server.Documents.Queries.Parser
                     message = "Unable to parse WHERE clause";
                     return false;
                 }
-                
-                if (Scanner.TryScan("FILTER") && Expression(out query.Filter) == false)
-                {
-                    message = "Unable to parse FILTER clause";
-                    return false;
-                }
             }
             else
             {
@@ -175,6 +169,13 @@ namespace Raven.Server.Documents.Queries.Parser
 
             if (Scanner.TryScan("LOAD"))
                 query.Load = SelectClauseExpressions("LOAD", false);
+            
+                
+            if (Scanner.TryScan("FILTER") && Expression(out query.Filter) == false)
+            {
+                message = "Unable to parse FILTER clause";
+                return false;
+            }
 
             switch (queryType)
             {

--- a/src/Raven.Server/Documents/Queries/Parser/QueryParser.cs
+++ b/src/Raven.Server/Documents/Queries/Parser/QueryParser.cs
@@ -116,6 +116,12 @@ namespace Raven.Server.Documents.Queries.Parser
                     message = "Unable to parse WHERE clause";
                     return false;
                 }
+                
+                if (Scanner.TryScan("FILTER") && Expression(out query.Filter) == false)
+                {
+                    message = "Unable to parse FILTER clause";
+                    return false;
+                }
             }
             else
             {
@@ -1806,6 +1812,7 @@ Grouping by 'Tag' or Field is supported only as a second grouping-argument.";
             "AS",
             "SELECT",
             "WHERE",
+            "FILTER",
             "LOAD",
             "GROUP",
             "ORDER",

--- a/src/Raven.Server/Documents/Queries/QueryMetadata.cs
+++ b/src/Raven.Server/Documents/Queries/QueryMetadata.cs
@@ -71,6 +71,14 @@ namespace Raven.Server.Documents.Queries
             IsGraph = Query.GraphQuery != null;
             IsDistinct = Query.IsDistinct;
             IsGroupBy = Query.GroupBy != null;
+            
+            if (query.Filter != null)
+            {
+                var stringBuilder = new StringBuilder();
+                new JavascriptCodeQueryVisitor(stringBuilder, Query).VisitExpression(query.Filter);
+
+                FilterScript = stringBuilder.ToString();
+            }
 
             if (IsGraph == false)
             {
@@ -102,6 +110,8 @@ namespace Raven.Server.Documents.Queries
             CreatedAt = DateTime.UtcNow;
             LastQueriedAt = CreatedAt;
         }
+
+        public string FilterScript;
 
         public readonly bool AddSpatialProperties;
 

--- a/src/Raven.Server/Documents/Queries/QueryRunner.cs
+++ b/src/Raven.Server/Documents/Queries/QueryRunner.cs
@@ -187,6 +187,8 @@ namespace Raven.Server.Documents.Queries
         {
             if (query.Metadata.IsDynamic)
                 throw new InvalidQueryException("Facet query must be executed against static index.", query.Metadata.QueryText, query.QueryParameters);
+            if (query.Metadata.FilterScript != null)
+                throw new InvalidQueryException("Facet query does not support a filter clause.", query.Metadata.QueryText, query.QueryParameters);
 
             Exception lastException = null;
             for (var i = 0; i < NumberOfRetries; i++)

--- a/src/Raven.Server/Documents/Queries/Results/GraphQueryResultRetriever.cs
+++ b/src/Raven.Server/Documents/Queries/Results/GraphQueryResultRetriever.cs
@@ -56,7 +56,7 @@ namespace Raven.Server.Documents.Queries.Results
             throw new NotSupportedException("Graph Queries do not deal with Lucene indexes.");
         }
 
-        protected override Document DirectGet(Lucene.Net.Documents.Document input, string id, DocumentFields fields, IState state) => DocumentsStorage.Get(_context, id);
+        public override Document DirectGet(Lucene.Net.Documents.Document input, string id, DocumentFields fields, IState state) => DocumentsStorage.Get(_context, id);
 
         protected override Document LoadDocument(string id) => DocumentsStorage.Get(_context, id);
 

--- a/src/Raven.Server/Documents/Queries/Results/IQueryResultRetriever.cs
+++ b/src/Raven.Server/Documents/Queries/Results/IQueryResultRetriever.cs
@@ -11,5 +11,7 @@ namespace Raven.Server.Documents.Queries.Results
         (Document Document, List<Document> List) Get(Lucene.Net.Documents.Document input, ScoreDoc lucene, IState state, CancellationToken token);
 
         bool TryGetKey(Lucene.Net.Documents.Document document, IState state, out string key);
+        
+        Document DirectGet(Lucene.Net.Documents.Document input, string id, DocumentFields fields, IState state);
     }
 }

--- a/src/Raven.Server/Documents/Queries/Results/MapQueryResultRetriever.cs
+++ b/src/Raven.Server/Documents/Queries/Results/MapQueryResultRetriever.cs
@@ -48,7 +48,7 @@ namespace Raven.Server.Documents.Queries.Results
             return key != null;
         }
 
-        protected override Document DirectGet(Lucene.Net.Documents.Document input, string id, DocumentFields fields, IState state)
+        public override Document DirectGet(Lucene.Net.Documents.Document input, string id, DocumentFields fields, IState state)
         {
             return DocumentsStorage.Get(_context, id, fields);
         }

--- a/src/Raven.Server/Documents/Queries/Results/MapReduceQueryResultRetriever.cs
+++ b/src/Raven.Server/Documents/Queries/Results/MapReduceQueryResultRetriever.cs
@@ -77,7 +77,7 @@ namespace Raven.Server.Documents.Queries.Results
             return djv;
         }
 
-        protected override unsafe Document DirectGet(Lucene.Net.Documents.Document input, string id, DocumentFields fields, IState state)
+        public override unsafe Document DirectGet(Lucene.Net.Documents.Document input, string id, DocumentFields fields, IState state)
         {
             var storedValue = input.GetField(_storedValueFieldName).GetBinaryValue(state);
 

--- a/src/Raven.Server/Documents/Queries/Results/QueryResultRetrieverBase.cs
+++ b/src/Raven.Server/Documents/Queries/Results/QueryResultRetrieverBase.cs
@@ -109,7 +109,7 @@ namespace Raven.Server.Documents.Queries.Results
 
         public abstract bool TryGetKey(Lucene.Net.Documents.Document document, IState state, out string key);
 
-        protected abstract Document DirectGet(Lucene.Net.Documents.Document input, string id, DocumentFields fields, IState state);
+        public abstract Document DirectGet(Lucene.Net.Documents.Document input, string id, DocumentFields fields, IState state);
 
         protected abstract Document LoadDocument(string id);
 

--- a/src/Raven.Server/Json/BlittableJsonTextWriterExtensions.cs
+++ b/src/Raven.Server/Json/BlittableJsonTextWriterExtensions.cs
@@ -504,6 +504,13 @@ namespace Raven.Server.Json
                 writer.WriteComma();
             }
 
+            if (result.ScannedResults != null)
+            {
+                writer.WritePropertyName(nameof(result.ScannedResults));
+                writer.WriteInteger(result.ScannedResults.Value);
+                writer.WriteComma();
+            }
+
             writer.WritePropertyName(nameof(result.SkippedResults));
             writer.WriteInteger(result.SkippedResults);
             writer.WriteComma();

--- a/test/FastTests/Issues/RavenDB-17636.cs
+++ b/test/FastTests/Issues/RavenDB-17636.cs
@@ -1,0 +1,259 @@
+using System.Linq;
+using Raven.Client.Documents;
+using Xunit;
+using Xunit.Abstractions;
+
+namespace FastTests.Issues
+{
+    public class RavenDB_17636 : RavenTestBase
+    {
+        public RavenDB_17636(ITestOutputHelper output) : base(output)
+        {
+        }
+
+        private record Employee(string Name, string Manager, bool Active);
+
+        private record Projection(string Name, string ManagerName);
+
+        private record Summary(int Count, string Manager);
+
+        [Fact]
+        public void CanUseFilterWithCollectionQuery()
+        {
+            using var store = GetDocumentStore();
+
+            using (var s = store.OpenSession())
+            {
+                s.Store(new Employee("Jane", null, true), "emps/jane");
+                s.Store(new Employee("Mark", "emps/jane", false), "emps/mark");
+                s.Store(new Employee("Sandra", "emps/jane", true), "emps/sandra");
+                s.SaveChanges();
+            }
+
+            
+            // raw
+            using (var s = store.OpenSession())
+            {
+                var emp = s.Advanced.RawQuery<Employee>("from Employees filter Name = 'Jane'").SingleOrDefault();
+                Assert.Equal("Jane", emp.Name);
+            }
+            
+            // parameters
+            using (var s = store.OpenSession())
+            {
+                var emp = s.Advanced.RawQuery<Employee>("from Employees filter Name = $name")
+                    .AddParameter("name", "Jane")
+                    .SingleOrDefault();
+                Assert.Equal("Jane", emp.Name);
+            }
+            
+            // alias
+            using (var s = store.OpenSession())
+            {
+                var emp = s.Advanced.RawQuery<Employee>("from Employees as e filter e.Name = $name")
+                    .AddParameter("name", "Jane")
+                    .SingleOrDefault();
+                Assert.Equal("Jane", emp.Name);
+            }
+            
+            // using js function
+            using (var s = store.OpenSession())
+            {
+                var emp = s.Advanced.RawQuery<Employee>("declare function check(r) { return r.Name[0] == 'J'} from Employees as e filter check(e)")
+                    .AddParameter("name", "Jane")
+                    .SingleOrDefault();
+                Assert.Equal("Jane", emp.Name);
+                
+                // passing variable to function #1
+                emp = s.Advanced.RawQuery<Employee>("declare function check(r) { return r.Name[0] == $prefix} from Employees as e filter check(e)")
+                    .AddParameter("name", "Jane")
+                    .AddParameter("prefix", "J")
+                    .SingleOrDefault();
+                Assert.Equal("Jane", emp.Name);
+                
+                // passing variable to function #2
+                emp = s.Advanced.RawQuery<Employee>("declare function check(r, prefix) { return r.Name[0] == prefix} from Employees as e filter check(e, $prefix)")
+                    .AddParameter("name", "Jane")
+                    .AddParameter("prefix", "J")
+                    .SingleOrDefault();
+                Assert.Equal("Jane", emp.Name);
+            }
+            
+            
+            // with load
+            using (var s = store.OpenSession())
+            {
+                var emp = s.Advanced.RawQuery<Employee>("from Employees as e load e.Manager as m filter e.Name = $name and m.Name = $manager")
+                    .AddParameter("manager", "Jane")
+                    .AddParameter("name", "Sandra")
+                    .SingleOrDefault();
+                Assert.Equal("Sandra", emp.Name);
+                
+                // ensure we filter
+                emp = s.Advanced.RawQuery<Employee>("from Employees as e load e.Manager as m filter e.Name = $name and m.Name = $manager")
+                    .AddParameter("manager", "Mark")
+                    .AddParameter("name", "Sandra")
+                    .SingleOrDefault();
+
+                Assert.Null(emp);
+            }
+            
+            // with projections
+            using (var s = store.OpenSession())
+            {
+                var projection = s.Advanced.RawQuery<Projection>("from Employees as e load e.Manager as m filter e.Name = $name and m.Name = $manager select e.Name, m.Name as ManagerName")
+                    .AddParameter("manager", "Jane")
+                    .AddParameter("name", "Sandra")
+                    .SingleOrDefault();
+                Assert.Equal("Sandra", projection.Name);
+                Assert.Equal("Jane", projection.ManagerName);
+                
+                // projection via JS
+                projection = s.Advanced.RawQuery<Projection>("from Employees as e load e.Manager as m filter e.Name = $name and m.Name = $manager select { Name: e.Name, ManagerName: m.Name}")
+                    .AddParameter("manager", "Mark")
+                    .AddParameter("name", "Sandra")
+                    .SingleOrDefault();
+
+                Assert.Null(projection);
+            }
+        }
+
+        [Fact]
+        public void CanUseFilterQueryOnMapIndexes()
+        {
+            using var store = GetDocumentStore();
+
+            using (var s = store.OpenSession())
+            {
+                s.Store(new Employee("Jane", null, true), "emps/jane");
+                s.Store(new Employee("Mark", "emps/jane", false), "emps/mark");
+                s.Store(new Employee("Sandra", "emps/jane", true), "emps/sandra");
+                s.SaveChanges();
+                
+            }
+
+            // raw
+            using (var s = store.OpenSession())
+            {
+                var emp = s.Advanced.RawQuery<Employee>("from Employees where Active = true filter Name = 'Jane'").SingleOrDefault();
+                Assert.Equal("Jane", emp.Name);
+            }
+            
+            // parameters
+            using (var s = store.OpenSession())
+            {
+                var emp = s.Advanced.RawQuery<Employee>("from Employees where Active = $active filter Name = $name")
+                    .AddParameter("name", "Jane")
+                    .AddParameter("active", true)
+                    .SingleOrDefault();
+                Assert.Equal("Jane", emp.Name);
+            }
+            
+            // alias
+            using (var s = store.OpenSession())
+            {
+                var emp = s.Advanced.RawQuery<Employee>("from Employees as e where e.Active = true filter e.Name = $name")
+                    .AddParameter("name", "Jane")
+                    .SingleOrDefault();
+                Assert.Equal("Jane", emp.Name);
+            }
+            
+            // using js function
+            using (var s = store.OpenSession())
+            {
+                var emp = s.Advanced.RawQuery<Employee>("declare function check(r) { return r.Name[0] == 'J'} from Employees as e where e.Active = true filter check(e)")
+                    .AddParameter("name", "Jane")
+                    .SingleOrDefault();
+                WaitForUserToContinueTheTest(store);
+                Assert.Equal("Jane", emp.Name);
+                
+                // passing variable to function #1
+                emp = s.Advanced.RawQuery<Employee>("declare function check(r) { return r.Name[0] == $prefix} from Employees as e where e.Active = true filter check(e)")
+                    .AddParameter("name", "Jane")
+                    .AddParameter("prefix", "J")
+                    .SingleOrDefault();
+                Assert.Equal("Jane", emp.Name);
+                
+                // passing variable to function #2
+                emp = s.Advanced.RawQuery<Employee>("declare function check(r, prefix) { return r.Name[0] == prefix} from Employees as e where e.Active = true filter check(e, $prefix)")
+                    .AddParameter("name", "Jane")
+                    .AddParameter("prefix", "J")
+                    .SingleOrDefault();
+                Assert.Equal("Jane", emp.Name);
+            }
+            
+            
+            // with load
+            using (var s = store.OpenSession())
+            {
+                var emp = s.Advanced.RawQuery<Employee>("from Employees as e where e.Active = $active  load e.Manager as m filter e.Name = $name and m.Name = $manager")
+                    .AddParameter("manager", "Jane")
+                    .AddParameter("name", "Sandra")
+                    .AddParameter("active", true)
+                    .SingleOrDefault();
+                Assert.Equal("Sandra", emp.Name);
+                
+                // ensure we filter
+                emp = s.Advanced.RawQuery<Employee>("from Employees as e where e.Active = true load e.Manager as m filter e.Name = $name and m.Name = $manager")
+                    .AddParameter("manager", "Mark")
+                    .AddParameter("name", "Sandra")
+                    .SingleOrDefault();
+
+                Assert.Null(emp);
+            }
+            
+            // with projections
+            using (var s = store.OpenSession())
+            {
+                var projection = s.Advanced.RawQuery<Projection>("from Employees as e where e.Active = true load e.Manager as m filter e.Name = $name and m.Name = $manager select e.Name, m.Name as ManagerName")
+                    .AddParameter("manager", "Jane")
+                    .AddParameter("name", "Sandra")
+                    .SingleOrDefault();
+                Assert.Equal("Sandra", projection.Name);
+                Assert.Equal("Jane", projection.ManagerName);
+                
+                // projection via JS
+                projection = s.Advanced.RawQuery<Projection>("from Employees as e where e.Active = true load e.Manager as m filter e.Name = $name and m.Name = $manager select { Name: e.Name, ManagerName: m.Name}")
+                    .AddParameter("manager", "Mark")
+                    .AddParameter("name", "Sandra")
+                    .SingleOrDefault();
+
+                Assert.Null(projection);
+            }
+        }
+        
+         [Fact]
+        public void CanUseFilterQueryOnMapReduce()
+        {
+            using var store = GetDocumentStore();
+
+            using (var s = store.OpenSession())
+            {
+                s.Store(new Employee("Jane", null, true), "emps/jane");
+                s.Store(new Employee("Mark", "emps/jane", false), "emps/mark");
+                s.Store(new Employee("Sandra", "emps/jane", true), "emps/sandra");
+                s.SaveChanges();
+                
+            }
+
+            // raw
+            using (var s = store.OpenSession())
+            {
+                var summary = s.Advanced.RawQuery<Summary>("from Employees group by Manager filter Count == 2 select count(), Manager").SingleOrDefault();
+                Assert.Equal("emps/jane", summary.Manager);
+                Assert.Equal(2, summary.Count);
+            }
+            
+            // parameters
+            using (var s = store.OpenSession())
+            {
+                var summary = s.Advanced.RawQuery<Summary>("from Employees group by Manager filter Count == $count select count(), Manager")
+                    .AddParameter("count", 2)
+                    .SingleOrDefault();
+                Assert.Equal("emps/jane", summary.Manager);
+                Assert.Equal(2, summary.Count);
+            }
+        }
+        
+    }
+}

--- a/test/FastTests/Issues/RavenDB-17636.cs
+++ b/test/FastTests/Issues/RavenDB-17636.cs
@@ -43,8 +43,26 @@ namespace FastTests.Issues
                 Assert.Equal("Jane", emp.Name);
             }
             
-      
+            // scan results
+            using (var s = store.OpenSession())
+            {
+                var emp = s.Advanced.RawQuery<Employee>("from Employees filter Active = false")
+                    .Statistics(out var stats)
+                    .SingleOrDefault();
+                Assert.Equal("Mark", emp.Name);
+                Assert.Equal(3, stats.ScannedResults);
+            }
             
+            // scan limit
+            using (var s = store.OpenSession())
+            {
+                var emp = s.Advanced.RawQuery<Employee>("from Employees filter Active = true scan_limit 1")
+                    .Statistics(out var stats)
+                    .SingleOrDefault();
+                Assert.Equal("Jane", emp.Name);
+                Assert.Equal(1, stats.ScannedResults);
+            }
+
             // parameters
             using (var s = store.OpenSession())
             {
@@ -145,6 +163,26 @@ namespace FastTests.Issues
             {
                 var emp = s.Advanced.RawQuery<Employee>("from Employees where Active = true filter Name = 'Jane'").SingleOrDefault();
                 Assert.Equal("Jane", emp.Name);
+            }
+            
+            // scan results
+            using (var s = store.OpenSession())
+            {
+                var emp = s.Advanced.RawQuery<Employee>("from Employees order by Name filter Active = false")
+                    .Statistics(out var stats)
+                    .SingleOrDefault();
+                Assert.Equal("Mark", emp.Name);
+                Assert.Equal(4, stats.ScannedResults);
+            }
+            
+            // scan limit
+            using (var s = store.OpenSession())
+            {
+                var emp = s.Advanced.RawQuery<Employee>("from Employees order by Name desc filter Active = true scan_limit 1")
+                    .Statistics(out var stats)
+                    .SingleOrDefault();
+                Assert.Equal("Sandra", emp.Name);
+                Assert.Equal(1, stats.ScannedResults);
             }
             
             // parameters


### PR DESCRIPTION
…the result set) to collection queries

### Issue link

https://issues.hibernatingrhinos.com/issue/RavenDB-17636

### Additional description

Add the ability to run queries such as:

```
from Employees
filter FirstName == 'Anne' or Extension == 5467
```

The idea is that we can have a filter operation, evaluated at query time, without the need for issuing indexes, etc.
This is meant for exploratory queries or post query filtering in performance sensitive scenario.


### Type of change

- New feature

### How risky is the change?

- Low 

### Backward compatibility

- Potential breaking change.

We add `filter` as a keyword.

### Is it platform specific issue?

- No

### Documentation update

- This change requires a documentation update. Please mark the issue on YouTrack using `Documentation Required` tag.

### Testing 

TBD

### UI work

- It requires further work in the Studio

Would need to update the RQL parser