### PR TITLE
RavenDB-17688 Docker ServerUrl override

### DIFF
--- a/docker/ravendb-nanoserver/run-raven.ps1
+++ b/docker/ravendb-nanoserver/run-raven.ps1
@@ -2,7 +2,9 @@ $ErrorActionPreference = 'Stop'
 
 $COMMAND=".\Raven.Server.exe"
 $hostname = & "hostname.exe"
-$env:RAVEN_ServerUrl = "http://$($hostname):8080"
+if ([string]::IsNullOrEmpty($env:RAVEN_ServerUrl) -eq $True) {
+    $env:RAVEN_ServerUrl = "http://$($hostname):8080"
+}
 
 if ([string]::IsNullOrEmpty($env:RAVEN_SETTINGS) -eq $False) {
     Set-Content -Path "settings.json" -Value "$env:RAVEN_SETTINGS"

--- a/docker/ravendb-ubuntu/run-raven.sh
+++ b/docker/ravendb-ubuntu/run-raven.sh
@@ -1,6 +1,6 @@
 #!/bin/bash
 COMMAND="./Raven.Server"
-export RAVEN_ServerUrl="http://$(hostname):8080"
+[ -z "$RAVEN_ServerUrl" ] && export RAVEN_ServerUrl="http://$(hostname):8080"
 
 if [ ! -z "$RAVEN_SETTINGS" ]; then
     echo "$RAVEN_SETTINGS" > settings.json


### PR DESCRIPTION
### Issue link

ravendb/ravendb#13254

### Additional description

Enable Docker user's to change the IP/Port Raven internally listens on.

### Type of change

- Optimization

### How risky is the change?

- Low 

### Backward compatibility

- None. If someone was using the setting (like it's the case [here](https://github.com/ravendb/ravendb/blob/v5.3/docker/compose/linux-cluster/docker-compose.yml#L13)) it did not have an effect and now it will.

### Is it platform specific issue?

- Yes. Docker (Windows & Linux)

### Documentation update

- No documentation update is needed: docs already says it's possible but it wasn't.

### Testing 

NONE done.

### Is there any existing behavior change of other features due to this change?

- No

### UI work

- No UI work is needed
