### PR TITLE
RavenDB-17689 Invalid load document results

### DIFF
--- a/src/Raven.Server/Documents/Document.cs
+++ b/src/Raven.Server/Documents/Document.cs
@@ -98,6 +98,14 @@ namespace Raven.Server.Documents
 
         public Document Clone(JsonOperationContext context)
         {
+            var newData = Data.Clone(context);
+            return CloneWith(context, newData);
+        }
+
+        public Document CloneWith(JsonOperationContext context, BlittableJsonReaderObject newData)
+        {
+            var newId = context.GetLazyString(Id);
+            var newLowerId = context.GetLazyString(LowerId);
             return new Document
             {
                 Etag = Etag,
@@ -109,10 +117,9 @@ namespace Raven.Server.Documents
                 Flags = Flags,
                 NonPersistentFlags = NonPersistentFlags,
                 TransactionMarker = TransactionMarker,
-
-                Id = context.GetLazyString(Id),
-                LowerId = context.GetLazyString(LowerId),
-                Data = Data.Clone(context),
+                Id = newId,
+                LowerId = newLowerId,
+                Data = newData,
             };
         }
 

--- a/src/Raven.Server/Documents/Queries/Results/QueryResultRetrieverBase.cs
+++ b/src/Raven.Server/Documents/Queries/Results/QueryResultRetrieverBase.cs
@@ -645,7 +645,8 @@ namespace Raven.Server.Documents.Queries.Results
 
             //_loadedDocuments.Clear(); - explicitly not clearing this, we want to cache this for the duration of the query
 
-            _loadedDocuments[document.Id ?? string.Empty] = document;
+            // we have to clone, because the `document` instance is updated on result
+            _loadedDocuments[document.Id ?? string.Empty] = document.Clone(_context); 
 
             document.IgnoreDispose = true; // so we can do multiple projections of the same value
 

--- a/test/SlowTests/Issues/RavenDB-17689.cs
+++ b/test/SlowTests/Issues/RavenDB-17689.cs
@@ -1,0 +1,55 @@
+﻿using System;
+using System.Collections.Generic;
+using System.Linq;
+using System.Text;
+using System.Threading.Tasks;
+using FastTests;
+using Xunit;
+using Xunit.Abstractions;
+
+namespace SlowTests.Issues
+{
+    public class RavenDB_17689 : RavenTestBase
+    {
+        public RavenDB_17689(ITestOutputHelper output) : base(output)
+        {
+        }
+
+        private record Employee(string FirstName, string Manager);
+        private record Projection(string e, string r);
+
+        [Fact]
+        public void CanQueryOnProjectionsThatWeAlsoReturn()
+        {
+            using var store = GetDocumentStore();
+
+            using(var session = store.OpenSession())
+            {
+                session.Store(new Employee("Smith", "emps/jane"));
+                session.Store(new Employee("Jane", null), "emps/jane");
+                session.Store(new Employee("Sandra", "emps/jane"));
+                session.SaveChanges();
+            }
+
+            using (var session = store.OpenSession())
+            {
+                var emps = session.Advanced.RawQuery<Projection>(@"
+from Employees  as e
+load e.Manager as r
+select e.FirstName as e, r.FirstName as r")
+                    .ToList();
+                WaitForUserToContinueTheTest(store);
+                Assert.Equal(3, emps.Count);
+                int notNull = 0;
+                foreach (var emp in emps)
+                {
+                    if (emp.r != null)
+                        notNull++;
+                }
+                Assert.Equal(2, notNull);
+
+
+            }
+        }
+    }
+}


### PR DESCRIPTION
### Issue link

https://issues.hibernatingrhinos.com/issue/RavenDB-17689

### Additional description

When we have a load document, we are updating a dictionary of loaded documents, and if the returned document is also in the result set (and has projection) we'll get the projected value, not the real document.

### Type of change

- Bug fix

### How risky is the change?

- Low 

### Backward compatibility

- Non breaking change

### Is it platform specific issue?

- No

### Documentation update

- No documentation update is needed 

### Testing 

- Tests have been added that prove the fix is effective or that the feature works
 
### Is there any existing behavior change of other features due to this change?

- No

### UI work

- No UI work is needed
