### PR TITLE
RavenDB-17692: Handle OperationCanceledException in Changes API

### DIFF
--- a/src/Raven.Client/Documents/Changes/DatabaseChanges.cs
+++ b/src/Raven.Client/Documents/Changes/DatabaseChanges.cs
@@ -525,9 +525,9 @@ namespace Raven.Client.Documents.Changes
 
                     await ProcessChanges().ConfigureAwait(false);
                 }
-                catch (OperationCanceledException e)
+                catch (OperationCanceledException) when (_cts.Token.IsCancellationRequested)
                 {
-                    NotifyAboutError(e);
+                    // disposing
                     return;
                 }
                 catch (ChangeProcessingException)

--- a/src/Raven.Client/Documents/Changes/DatabaseChanges.cs
+++ b/src/Raven.Client/Documents/Changes/DatabaseChanges.cs
@@ -372,7 +372,15 @@ namespace Raven.Client.Documents.Changes
                 // nothing we can do here
             }
 
-            ConnectionStatusChanged?.Invoke(this, EventArgs.Empty);
+            try
+            {
+                ConnectionStatusChanged?.Invoke(this, EventArgs.Empty);
+            }
+            catch
+            {
+               // we are disposing
+            }
+
             ConnectionStatusChanged -= OnConnectionStatusChanged;
 
             _onDispose?.Invoke();

--- a/src/Raven.Client/Documents/Changes/DatabaseChanges.cs
+++ b/src/Raven.Client/Documents/Changes/DatabaseChanges.cs
@@ -573,6 +573,7 @@ namespace Raven.Client.Documents.Changes
                     {
                         // we couldn't reconnect
                         NotifyAboutError(e);
+                        _tcs.TrySetException(e);
                         throw;
                     }
                 }


### PR DESCRIPTION
### Issue link

https://issues.hibernatingrhinos.com/issue/RavenDB-17692

### Additional description

Try to maintain the Changes API connection, if we got `OperationCanceledException` from other source than Changes API `_cts`


### Type of change

- Bug fix


### How risky is the change?

- Low 


### Backward compatibility


- Not relevant

### Is it platform specific issue?

- No

### Documentation update

- No documentation update is needed 

### Testing 


- It has been verified by manual testing

### Is there any existing behavior change of other features due to this change?

- No

### UI work

- No UI work is needed
