### PR TITLE
RavenDB-15552 Awaiting a task in the test instead of waiting for it. hat caused FastTests hangs when running with maxParallelThreads - 1 and maxRunningTests - 1

### DIFF
--- a/test/FastTests/Server/Documents/Revisions/RevisionsTests.cs
+++ b/test/FastTests/Server/Documents/Revisions/RevisionsTests.cs
@@ -1701,12 +1701,12 @@ namespace FastTests.Server.Documents.Revisions
         }
 
         [Fact]
-        public void CanGetRevisionsCountFor()
+        public async Task CanGetRevisionsCountFor()
         {
             var company = new Company {Name = "Company Name"};
             using (var store = GetDocumentStore())
             {
-                RevisionsHelper.SetupRevisions(Server.ServerStore, store.Database).Wait();
+                await RevisionsHelper.SetupRevisions(Server.ServerStore, store.Database);
 
                 using (var session = store.OpenSession())
                 {


### PR DESCRIPTION
### Issue link

https://issues.hibernatingrhinos.com/issue/RavenDB-15552

### Additional description

Fixing deadlock in FastTests. The test was added in https://github.com/ravendb/ravendb/pull/11671

### Type of change

- Test fix
