### PR TITLE
RavenDB-17657  Cannot export the Server IO Stats

### DIFF
--- a/src/Raven.Studio/typescript/models/database/status/ioStatsGraph.ts
+++ b/src/Raven.Studio/typescript/models/database/status/ioStatsGraph.ts
@@ -1439,7 +1439,7 @@ class ioStatsGraph {
         if (this.isImport()) {
             exportFileName = this.importFileName().substring(0, this.importFileName().lastIndexOf('.'));
         } else {
-            exportFileName = `IOStats-of-${this.statsNameProvider()}-${moment().format("YYYY-MM-DD-HH-mm")}`;
+            exportFileName = `IOStats-for-${this.statsNameProvider()}-${moment().format("YYYY-MM-DD-HH-mm")}`;
         }
 
         const keysToIgnore: Array<keyof IOMetricsRecentStatsWithCache> = ["StartedAsDate", "CompletedAsDate"];

--- a/src/Raven.Studio/typescript/viewmodels/database/status/ioStats.ts
+++ b/src/Raven.Studio/typescript/viewmodels/database/status/ioStats.ts
@@ -9,7 +9,7 @@ class ioStats extends viewModelBase {
         super();
         
         this.graph = new ioStatsGraph(
-            () => this.activeDatabase().name,
+            () => `database-${this.activeDatabase().name}`,
             ["Documents", "Index", "Configuration"],
             true,
             (onUpdate, cutOff) => new dbLiveIOStatsWebSocketClient(this.activeDatabase(), onUpdate, cutOff));

--- a/src/Raven.Studio/typescript/viewmodels/manage/serverWideIoStats.ts
+++ b/src/Raven.Studio/typescript/viewmodels/manage/serverWideIoStats.ts
@@ -9,7 +9,7 @@ class serverWideIoStats extends viewModelBase {
         super();
         
         this.graph = new ioStatsGraph(
-            () => this.activeDatabase().name,
+            () => "Server",
             ["System"],
             false,
             (onUpdate, cutOff) => new serverWideLiveIOStatsWebSocketClient(onUpdate, cutOff));


### PR DESCRIPTION
### Issue link
https://issues.hibernatingrhinos.com/issue/RavenDB-17657

### Additional description
Fix the exported file name per server and per database

### Type of change
- Bug fix

### How risky is the change?
- Low 

### Backward compatibility
- Non breaking change

### Is it platform specific issue?
- No

### Documentation update
- No documentation update is needed 

### Testing 
- It has been verified by manual testing

### Is there any existing behavior change of other features due to this change?
- No

### UI work
- No UI work is needed
