### PR TITLE
RavenDB-17654 Cluster View: Limit the maximum number of cores to use

### DIFF
--- a/src/Raven.Studio/typescript/viewmodels/manage/assignCores.ts
+++ b/src/Raven.Studio/typescript/viewmodels/manage/assignCores.ts
@@ -33,7 +33,8 @@ class assignCores extends dialogViewModelBase {
 
         this.maxUtilizedCores.extend({
             required: false,
-            min: 1
+            min: 1,
+            max: this.numberOfCores()
         });
     }
 


### PR DESCRIPTION
### Issue link
https://issues.hibernatingrhinos.com/issue/RavenDB-17654

### Additional description
Added validation on max number of cores that can be used

### Type of change
- Bug fix

### How risky is the change?
- Low 

### Backward compatibility
- Non breaking change

### Is it platform specific issue?
- No

### Documentation update
- No documentation update is needed 

### Testing 
- It has been verified by manual testing

### Is there any existing behavior change of other features due to this change?
- No

### UI work
- No UI work is needed
