### PR TITLE
RavenDB-17653  Cluster View: Disable the 'Step Down' option when ther…

### DIFF
--- a/src/Raven.Studio/typescript/viewmodels/manage/cluster.ts
+++ b/src/Raven.Studio/typescript/viewmodels/manage/cluster.ts
@@ -29,6 +29,7 @@ class cluster extends viewModelBase {
     canDeleteNodes: KnockoutComputed<boolean>;
     canAddNodes: KnockoutComputed<boolean>;
     canBootstrapCluster: KnockoutComputed<boolean>;
+    canStepDown: KnockoutComputed<boolean>;
     
     leaderUrl: KnockoutComputed<string>;
     utilizedCores: KnockoutComputed<number>;
@@ -79,7 +80,8 @@ class cluster extends viewModelBase {
         this.canDeleteNodes = ko.pureComputed(() => this.topology().leader() && this.topology().nodes().length > 1);
         this.canAddNodes = ko.pureComputed(() => !!this.topology().leader() || this.topology().nodeTag() === "?");
         this.canBootstrapCluster = ko.pureComputed(() => this.topology().nodeTag() === "?");
-
+        this.canStepDown = ko.pureComputed(() => this.topology().membersCount() >= 2);
+        
         this.leaderUrl = ko.pureComputed(() => {
             const topology = this.topology();
 

--- a/src/Raven.Studio/wwwroot/App/views/manage/cluster.html
+++ b/src/Raven.Studio/wwwroot/App/views/manage/cluster.html
@@ -75,19 +75,21 @@
                                         <span class="sr-only">Toggle Dropdown</span>
                                     </button>
                                     <ul class="dropdown-menu dropdown-menu-right">
-                                        <li data-bind="visible: $root.isClusterAdminOrClusterNode">
-                                            <a href="#" data-bind="click: _.partial($parent.assignCores, $data)">
+                                        <li data-bind="click: _.partial($parent.assignCores, $data), visible: $root.isClusterAdminOrClusterNode">
+                                            <a href="#">
                                                 <i class="icon-reassign-cores"></i>
                                                 <span>Reassign cores</span>
                                             </a>
                                         </li>
-                                        <li>
-                                            <a href="#" data-bind="click: _.partial($parent.stepDown, $data), visible: $root.topology().leader() === tag(), css: { 'btn-spinner': $root.spinners.stepdown }, disable: $root.spinners.stepdown">
-                                                <i class="icon-stepdown"></i> <span>Step down</span>
+                                        <li data-bind="click: _.partial($parent.stepDown, $data), visible: $root.topology().leader() === tag() && $root.canStepDown(),
+                                                       css: { 'disabled-area' : $root.spinners.stepdown() }">
+                                            <a href="#" data-bind="css: { 'btn-spinner': $root.spinners.stepdown }">
+                                                <i class="icon-stepdown"></i>
+                                                <span>Step down</span>
                                             </a>
                                         </li>
-                                        <li>
-                                            <a href="#" data-bind="click: _.partial($parent.forceTimeout, $data), css: { 'btn-spinner': $root.spinners.forceTimeout() }, disable: $root.spinners.forceTimeout()">
+                                        <li data-bind="click: _.partial($parent.forceTimeout, $data), css: { 'disabled-area' : $root.spinners.forceTimeout }">
+                                            <a href="#" data-bind="css: { 'btn-spinner': $root.spinners.forceTimeout }">
                                                 <i class="icon-waiting"></i>
                                                 <span>Force timeout</span>
                                             </a>


### PR DESCRIPTION
…e is only one voter (one member node)

### Issue link
https://issues.hibernatingrhinos.com/issue/RavenDB-17653

### Additional description
1. The disable on the `<a>` didn't work => now fixed
2. Hide the '`Step Down`' option when there are no other Member nodes

### Type of change
- Bug fix

### How risky is the change?
- Low 

### Backward compatibility
- Non breaking change

### Is it platform specific issue?
- No

### Documentation update
- No documentation update is needed 

### Testing 
- It has been verified by manual testing

### Is there any existing behavior change of other features due to this change?
- No

### UI work
- No UI work is needed
