### PR TITLE
RavenDB-16003 close subscription worker faster

### DIFF
--- a/src/Raven.Client/Documents/Subscriptions/SubscriptionWorker.cs
+++ b/src/Raven.Client/Documents/Subscriptions/SubscriptionWorker.cs
@@ -649,7 +649,7 @@ namespace Raven.Client.Documents.Subscriptions
                         }
                         if (ShouldTryToReconnect(ex))
                         {
-                            await TimeoutManager.WaitFor(_options.TimeToWaitBeforeConnectionRetry).ConfigureAwait(false);
+                            await TimeoutManager.WaitFor(_options.TimeToWaitBeforeConnectionRetry, _processingCts.Token).ConfigureAwait(false);
 
                             if (_redirectNode == null)
                             {


### PR DESCRIPTION
### Issue link

https://issues.hibernatingrhinos.com/issue/RavenDB-16003

### Additional description

When the test is over but the subscription failed and was trying to reconnect we would wait 3 seconds before disposing the store, because we were stuck at waiting at `TimeToWaitBeforeConnectionRetry`

The 3 second wait is due to the code in the document store dispose:
```
foreach (var subscription in _subscriptions)
{
    tasks.Add(subscription.DisposeAsync());
}

try
{
    Task.WaitAll(tasks.ToArray(), TimeSpan.FromSeconds(3));
}
catch (AggregateException ae)
{
    throw new InvalidOperationException("Failed to dispose active data subscriptions", ae.ExtractSingleInnerException());
}
```

### Type of change

- Optimization

### How risky is the change?

- Low 

### Backward compatibility

- Not relevant

### Is it platform specific issue?

- No

### Documentation update

- No documentation update is needed 

### Testing 

- It has been verified by manual testing - some subscription tests now completed faster 

### Is there any existing behavior change of other features due to this change?

- No

### UI work

- No UI work is needed
