### PR TITLE
RavenDB-17586 distinguish between new subscription and a modified one

### DIFF
--- a/src/Raven.Server/Documents/Subscriptions/SubscriptionStorage.cs
+++ b/src/Raven.Server/Documents/Subscriptions/SubscriptionStorage.cs
@@ -645,7 +645,8 @@ namespace Raven.Server.Documents.Subscriptions
                         continue;
                     }
                     
-                    if (subscriptionState.LastClientConnectionTime == null)
+                    if (subscriptionState.LastClientConnectionTime == null && 
+                        subscriptionState.ChangeVectorForNextBatchStartingPoint != subscriptionConnectionsState.LastChangeVectorSent)
                     {
                         DropSubscriptionConnections(subscriptionStateKvp.Key, new SubscriptionClosedException($"The subscription {subscriptionName} was modified, connection must be restarted", canReconnect: true));
                         continue;


### PR DESCRIPTION
### Issue link

https://issues.hibernatingrhinos.com/issue/RavenDB-17586

### Additional description

Under high rate of subscription creation we might close a subscription that wasn't even started, which would cause a delay due to a retry of the worker

### Type of change

- Bug fix

### How risky is the change?

- Low 

### Backward compatibility

- Not relevant

### Is it platform specific issue?

- No

### Documentation update

- No documentation update is needed 

### Testing 

- It has been verified by manual testing - relevant tests complete faster

### Is there any existing behavior change of other features due to this change?

- No

### UI work

- No UI work is needed
