### PR TITLE
RavenDB-17477 Fixing possible deadlock caused by calling ConcurrentEsEtlTests.Wait() in the constructor of the test

### DIFF
--- a/test/SlowTests/Server/Documents/ETL/Elasticsearch/ElasticSearchEtlTests.cs
+++ b/test/SlowTests/Server/Documents/ETL/Elasticsearch/ElasticSearchEtlTests.cs
@@ -893,13 +893,13 @@ loadToOrders(orderData);
             }
         }
 
-        [RequiresElasticSearchFact]
+        [Fact]
         public async Task ShouldImportTask()
         {
             using (var srcStore = GetDocumentStore())
             using (var dstStore = GetDocumentStore())
             {
-                SetupElasticEtl(srcStore, defaultScript, new List<string> { OrderIndexName, OrderLinesIndexName });
+                SetupElasticEtl(srcStore, defaultScript, new List<string> { OrderIndexName, OrderLinesIndexName }, nodes: new [] {"http://localhost:1234"});
 
                 var exportFile = GetTempFileName();
 

--- a/test/SlowTests/Server/Documents/ETL/Elasticsearch/RavenDB_17477.cs
+++ b/test/SlowTests/Server/Documents/ETL/Elasticsearch/RavenDB_17477.cs
@@ -14,7 +14,7 @@ namespace SlowTests.Server.Documents.ETL.ElasticSearch
         {
         }
 
-        [RequiresElasticSearchFact(Skip = "Suspicion that this test causes test hangs")]
+        [RequiresElasticSearchFact]
         public void ShouldErrorAndAlertOnInvalidIndexSetupInElastic()
         {
             using (var store = GetDocumentStore())


### PR DESCRIPTION
We were supposed to release the lock in the Dispose() of a test but the problem is that when a test is skipped then we called only the ctor and got the lock but the dispose isn't called in that case.

### Issue link

https://issues.hibernatingrhinos.com/issue/RavenDB-17477

### Additional description

Fixing potential deadlock in ES ETL tests

### Type of change

- Test fix

### How risky is the change?

- Not relevant

### Backward compatibility

- Not relevant

### Is it platform specific issue?

- No

### Documentation update

- No documentation update is needed 

### Testing 

- Tests have been added that prove the fix is effective or that the feature works
- It has been verified by manual testing

### Is there any existing behavior change of other features due to this change?

- No

### UI work

- No UI work is needed
