### PR TITLE
RavenDB-16336 : Calculate size of included items for Subscription Stats

### DIFF
--- a/src/Raven.Server/Documents/Subscriptions/Stats/SubscriptionBatchPerformanceStats.cs
+++ b/src/Raven.Server/Documents/Subscriptions/Stats/SubscriptionBatchPerformanceStats.cs
@@ -5,9 +5,8 @@
 // -----------------------------------------------------------------------
 
 using System;
-using Raven.Server.Documents.Subscriptions.Stats;
 
-namespace Raven.Server.Documents.Subscriptions
+namespace Raven.Server.Documents.Subscriptions.Stats
 {
     public class SubscriptionBatchPerformanceStats
     {
@@ -21,8 +20,11 @@ namespace Raven.Server.Documents.Subscriptions
         public long SizeOfIncludedDocumentsInBytes { get; set; }
         
         public long NumberOfIncludedCounters { get; set; }
+        public long SizeOfIncludedCountersInBytes { get; set; }
+
         public long NumberOfIncludedTimeSeriesEntries { get; set; }
-        
+        public long SizeOfIncludedTimeSeriesInBytes { get; set; }
+
         public DateTime Started { get; set; }
         public DateTime? Completed { get; set; }
         

--- a/src/Raven.Server/Documents/Subscriptions/Stats/SubscriptionBatchRunStats.cs
+++ b/src/Raven.Server/Documents/Subscriptions/Stats/SubscriptionBatchRunStats.cs
@@ -21,8 +21,11 @@ namespace Raven.Server.Documents.Subscriptions.Stats
         public long SizeOfIncludedDocumentsInBytes { get; set; }
                 
         public long NumberOfIncludedCounters { get; set; }
+        public long SizeOfIncludedCountersInBytes { get; set; }
+
         public long NumberOfIncludedTimeSeriesEntries { get; set; }
-        
+        public long SizeOfIncludedTimeSeriesInBytes { get; set; }
+
         public string Exception { get; set; }
     }
 }

--- a/src/Raven.Server/Documents/Subscriptions/Stats/SubscriptionBatchStatsAggregator.cs
+++ b/src/Raven.Server/Documents/Subscriptions/Stats/SubscriptionBatchStatsAggregator.cs
@@ -55,7 +55,10 @@ namespace Raven.Server.Documents.Subscriptions.Stats
                 SizeOfIncludedDocumentsInBytes = Stats.SizeOfIncludedDocumentsInBytes,
                 
                 NumberOfIncludedCounters = Stats.NumberOfIncludedCounters,
+                SizeOfIncludedCountersInBytes = Stats.SizeOfIncludedCountersInBytes,
+
                 NumberOfIncludedTimeSeriesEntries = Stats.NumberOfIncludedTimeSeriesEntries,
+                SizeOfIncludedTimeSeriesInBytes = Stats.SizeOfIncludedTimeSeriesInBytes,
                 
                 Exception = Stats.Exception,
                 

--- a/src/Raven.Server/Documents/Subscriptions/Stats/SubscriptionBatchStatsScope.cs
+++ b/src/Raven.Server/Documents/Subscriptions/Stats/SubscriptionBatchStatsScope.cs
@@ -44,16 +44,18 @@ namespace Raven.Server.Documents.Subscriptions.Stats
             _stats.SizeOfIncludedDocumentsInBytes += includedDocumentsSize;
         }
         
-        public void RecordIncludedCountersInfo(long includedCountersCount)
+        public void RecordIncludedCountersInfo(long includedCountersCount, long includedCountersSize)
         {
             _stats.NumberOfIncludedCounters += includedCountersCount;
+            _stats.SizeOfIncludedCountersInBytes += includedCountersSize;
         }
         
-        public void RecordIncludedTimeSeriesInfo(long includedTimeSeriesEntriesCount)
+        public void RecordIncludedTimeSeriesInfo(long includedTimeSeriesEntriesCount, long includedTimeSeriesSize)
         {
             _stats.NumberOfIncludedTimeSeriesEntries += includedTimeSeriesEntriesCount;
+            _stats.SizeOfIncludedTimeSeriesInBytes += includedTimeSeriesSize;
         }
-        
+
         public void RecordException(string exceptionMsg)
         {
             _stats.Exception = exceptionMsg;

--- a/src/Raven.Server/Json/BlittableJsonTextWriterExtensions.cs
+++ b/src/Raven.Server/Json/BlittableJsonTextWriterExtensions.cs
@@ -1781,8 +1781,9 @@ namespace Raven.Server.Json
             writer.WriteEndObject();
         }
 
-        public static void WriteTimeSeries(this AsyncBlittableJsonTextWriter writer, Dictionary<string, Dictionary<string, List<TimeSeriesRangeResult>>> timeSeries)
+        public static int WriteTimeSeries(this AsyncBlittableJsonTextWriter writer, Dictionary<string, Dictionary<string, List<TimeSeriesRangeResult>>> timeSeries)
         {
+            int size = 0;
             writer.WriteStartObject();
 
             var first = true;
@@ -1794,11 +1795,13 @@ namespace Raven.Server.Json
                 first = false;
 
                 writer.WritePropertyName(kvp.Key);
-
-                TimeSeriesHandler.WriteTimeSeriesRangeResults(context: null, writer, documentId: null, kvp.Value);
+                size += kvp.Key.Length;
+                size += TimeSeriesHandler.WriteTimeSeriesRangeResults(context: null, writer, documentId: null, kvp.Value);
             }
 
             writer.WriteEndObject();
+
+            return size;
         }
 
         private static void WriteDocumentMetadata(this AbstractBlittableJsonTextWriter writer, JsonOperationContext context,

--- a/src/Raven.Studio/typescript/common/liveSubscriptionStatsWebSocketClient.ts
+++ b/src/Raven.Studio/typescript/common/liveSubscriptionStatsWebSocketClient.ts
@@ -195,7 +195,7 @@ class liveSubscriptionStatsWebSocketClient extends abstractWebSocketClient<resul
         withCache.Type = "SubscriptionConnection";
     }
 
-    static fillBatchCache(perf: Raven.Server.Documents.Subscriptions.SubscriptionBatchPerformanceStats) {
+    static fillBatchCache(perf: Raven.Server.Documents.Subscriptions.Stats.SubscriptionBatchPerformanceStats) {
         const withCache = perf as SubscriptionBatchPerformanceStatsWithCache;
         withCache.CompletedAsDate = perf.Completed ? liveSubscriptionStatsWebSocketClient.isoParser.parse(perf.Completed) : undefined;
         withCache.StartedAsDate = liveSubscriptionStatsWebSocketClient.isoParser.parse(perf.Started);

--- a/src/Raven.Studio/typescript/viewmodels/database/status/ongoingTasksStats.ts
+++ b/src/Raven.Studio/typescript/viewmodels/database/status/ongoingTasksStats.ts
@@ -1888,11 +1888,10 @@ class ongoingTasksStats extends viewModelBase {
                     case "SubscriptionBatch": {
                         const elementWithData = context.rootStats as SubscriptionBatchPerformanceStatsWithCache;
                        
-                        tooltipHtml += `<div class="tooltip-li">Documents sent in batch: <div class="value">${elementWithData.NumberOfDocuments.toLocaleString()} </div></div>`;
-                        tooltipHtml += `<div class="tooltip-li">Documents size: <div class="value">${generalUtils.formatBytesToSize(elementWithData.SizeOfDocumentsInBytes)} </div></div>`;
-                        tooltipHtml += `<div class="tooltip-li">Included Documents: <div class="value">${elementWithData.NumberOfIncludedDocuments.toLocaleString()} </div></div>`;
-                        tooltipHtml += `<div class="tooltip-li">Included Counters: <div class="value">${elementWithData.NumberOfIncludedCounters.toLocaleString()} </div></div>`;
-                        tooltipHtml += `<div class="tooltip-li">Included Time Series entries: <div class="value">${elementWithData.NumberOfIncludedTimeSeriesEntries.toLocaleString()} </div></div>`;
+                        tooltipHtml += `<div class="tooltip-li">Documents sent in batch: <div class="value">${elementWithData.NumberOfDocuments.toLocaleString()} (size: ${generalUtils.formatBytesToSize(elementWithData.SizeOfDocumentsInBytes)})</div></div>`;
+                        tooltipHtml += `<div class="tooltip-li">Included Documents: <div class="value">${elementWithData.NumberOfIncludedDocuments.toLocaleString()} (size: ${generalUtils.formatBytesToSize(elementWithData.SizeOfIncludedDocumentsInBytes)})</div></div>`;
+                        tooltipHtml += `<div class="tooltip-li">Included Counters: <div class="value">${elementWithData.NumberOfIncludedCounters.toLocaleString()} (size: ${generalUtils.formatBytesToSize(elementWithData.SizeOfIncludedCountersInBytes)})</div></div>`;
+                        tooltipHtml += `<div class="tooltip-li">Included Time Series entries: <div class="value">${elementWithData.NumberOfIncludedTimeSeriesEntries.toLocaleString()} (size: ${generalUtils.formatBytesToSize(elementWithData.SizeOfIncludedTimeSeriesInBytes)})</div></div>`;
 
                         if (elementWithData.Exception) {
                             tooltipHtml += `<div class="tooltip-li">Message: <div class="value">${elementWithData.Exception} </div></div>`;

--- a/src/Raven.Studio/typings/_studio/dto.d.ts
+++ b/src/Raven.Studio/typings/_studio/dto.d.ts
@@ -398,7 +398,7 @@ interface SubscriptionConnectionPerformanceStatsWithCache extends Raven.Server.D
     HasErrors: boolean;
 }
 
-interface SubscriptionBatchPerformanceStatsWithCache extends Raven.Server.Documents.Subscriptions.SubscriptionBatchPerformanceStats {
+interface SubscriptionBatchPerformanceStatsWithCache extends Raven.Server.Documents.Subscriptions.Stats.SubscriptionBatchPerformanceStats {
     StartedAsDate: Date;
     CompletedAsDate: Date;
     Type: subscriptionType;

--- a/src/Sparrow/Json/AbstractBlittableJsonTextWriter.cs
+++ b/src/Sparrow/Json/AbstractBlittableJsonTextWriter.cs
@@ -192,11 +192,13 @@ namespace Sparrow.Json
         }
 
         [MethodImpl(MethodImplOptions.AggressiveInlining)]
-        public void WriteDateTime(DateTime value, bool isUtc)
+        public int WriteDateTime(DateTime value, bool isUtc)
         {
             int size = value.GetDefaultRavenFormat(_auxiliarBuffer, _auxiliarBufferLength, isUtc);
 
             WriteRawStringWhichMustBeWithoutEscapeChars(_auxiliarBuffer, size);
+
+            return size;
         }
 
         public void WriteString(string str, bool skipEscaping = false)

--- a/test/SlowTests/Issues/RavenDB_16336.cs
+++ b/test/SlowTests/Issues/RavenDB_16336.cs
@@ -1,0 +1,136 @@
+﻿using System;
+using System.Threading.Tasks;
+using FastTests;
+using Orders;
+using Raven.Client.Documents;
+using Raven.Client.Documents.Operations.TimeSeries;
+using Raven.Client.Documents.Subscriptions;
+using Raven.Server.Documents.Subscriptions.Stats;
+using Sparrow.Server;
+using Xunit;
+using Xunit.Abstractions;
+
+namespace SlowTests.Issues
+{
+    public class RavenDB_16336 : RavenTestBase
+    {
+        public RavenDB_16336(ITestOutputHelper output) : base(output)
+        {
+        }
+
+        [Fact]
+        public async Task SubscriptionBatchStats_ShouldIncludeSizeOfIncludedTimeSeriesAndCounters()
+        {
+            using (var store = GetDocumentStore())
+            {
+                const string id = "products/1";
+                const string counter1 = "Likes";
+                const string counter2 = "Dislikes";
+                const string timeSeries = "HeartRate";
+
+                int expectedTimeSeriesSize = 0;
+                using (var session = store.OpenSession())
+                using (store.GetRequestExecutor().ContextPool.AllocateOperationContext(out var ctx))
+                {
+                    var product = new Product();
+                    session.Store(product, id);
+
+                    session.CountersFor(product).Increment(counter1, 3);
+                    session.CountersFor(product).Increment(counter2, 5);
+
+                    var baseline = new DateTime(2021, 1, 1);
+                    var tsf = session.TimeSeriesFor(product, timeSeries);
+
+                    for (int i = 0; i < TimeSpan.FromHours(2).TotalMinutes; i++)
+                    {
+                        var dateTime = baseline.AddMinutes(i);
+                        tsf.Append(dateTime, i);
+                        if (i < 20)
+                            // we're only taking the last 100 entries
+                            continue;
+                        
+                        expectedTimeSeriesSize += Sparrow.Extensions.RavenDateTimeExtensions.GetDefaultRavenFormat(dateTime, ctx, out _, isUtc: true); // entry.Timestamp
+                        expectedTimeSeriesSize += sizeof(double); // entry.Values
+                        expectedTimeSeriesSize += 1; // entry.IsRollup
+                    }
+
+                    session.SaveChanges();
+
+                    expectedTimeSeriesSize += id.Length; // doc id
+                    expectedTimeSeriesSize += timeSeries.Length; // series name
+                    var from = baseline.AddMinutes(20);
+                    expectedTimeSeriesSize += Sparrow.Extensions.RavenDateTimeExtensions.GetDefaultRavenFormat(from, ctx, out _, isUtc: true); // range.From
+                }
+
+                var expectedCountersSize = counter1.Length
+                                           + id.Length
+                                           + sizeof(long) // Etag
+                                           + sizeof(long) // Value
+
+                                           + counter2.Length
+                                           + id.Length
+                                           + sizeof(long) // Etag
+                                           + sizeof(long) // Value
+
+                                           + id.Length + counter1.Length + counter2.Length; // CountersToGetByDocId property 
+
+                var db = await GetDocumentDatabaseInstanceFor(store);
+
+                SubscriptionBatchPerformanceStats stats = null;
+                var mre = new AsyncManualResetEvent();
+                db.SubscriptionStorage.OnEndBatch += (s, aggregator) =>
+                {
+                    stats = aggregator.ToBatchPerformanceStats();
+                    mre.Set();
+                };
+                var name = store.Subscriptions.Create(new SubscriptionCreationOptions<Product>
+                {
+                    Includes = builder => builder
+                        .IncludeCounter(counter1)
+                        .IncludeCounter(counter2)
+                        .IncludeTimeSeries(timeSeries, TimeSeriesRangeType.Last, 100)
+                });
+
+                await AssertSubscription(store, name, mre);
+
+                Assert.NotNull(stats);
+                Assert.Equal(expectedCountersSize, stats.SizeOfIncludedCountersInBytes);
+                Assert.Equal(expectedTimeSeriesSize, stats.SizeOfIncludedTimeSeriesInBytes);
+            }
+        }
+
+        private static async Task AssertSubscription(DocumentStore store, string name, AsyncManualResetEvent mre)
+        {
+            var baseline = new DateTime(2021, 1, 1);
+            using (var sub = store.Subscriptions.GetSubscriptionWorker<Product>(name))
+            {
+                var r = sub.Run(batch =>
+                {
+                    Assert.NotEmpty(batch.Items);
+                    using (var s = batch.OpenSession())
+                    {
+                        foreach (var item in batch.Items)
+                        {
+                            var product = s.Load<Product>(item.Id);
+                            Assert.Same(product, item.Result);
+
+                            var likesValue = s.CountersFor(product).Get("Likes");
+                            Assert.Equal(3, likesValue);
+
+                            var dislikesValue = s.CountersFor(product).Get("Dislikes");
+                            Assert.Equal(5, dislikesValue);
+
+                            var ts = s.TimeSeriesFor(product, "HeartRate").Get(from: baseline.AddMinutes(20));
+                            Assert.Equal(100, ts.Length);
+                        }
+
+                        Assert.Equal(0, s.Advanced.NumberOfRequests);
+                    }
+                });
+                Assert.True(await mre.WaitAsync(TimeSpan.FromSeconds(30)));
+                await sub.DisposeAsync();
+                await r; // no error
+            }
+        }
+    }
+}


### PR DESCRIPTION
### Issue link

https://issues.hibernatingrhinos.com/issue/RavenDB-16336

### Additional description

- Add `SizeOfIncludedCountersInBytes` and `SizeOfIncludedTimeSeriesInBytes` to `SubscriptionBatchPerformanceStats`

### How risky is the change?

- Low 

### Testing 

- Tests have been added that prove the fix is effective or that the feature works