### PR TITLE
RavenDB-16345 Index is Paused after enabling the index Cluster Wide

### DIFF
--- a/src/Raven.Client/Documents/Indexes/AutoIndexDefinition.cs
+++ b/src/Raven.Client/Documents/Indexes/AutoIndexDefinition.cs
@@ -4,7 +4,7 @@ using Raven.Client.Extensions;
 
 namespace Raven.Client.Documents.Indexes
 {
-    public class AutoIndexDefinition
+    public class AutoIndexDefinition : IndexDefinitionBase
     {
         public AutoIndexDefinition()
         {
@@ -13,12 +13,6 @@ namespace Raven.Client.Documents.Indexes
         }
 
         public IndexType Type { get; set; }
-
-        public string Name { get; set; }
-
-        public IndexPriority? Priority { get; set; }
-
-        public IndexState? State { get; set; }
 
         public string Collection { get; set; }
 

--- a/src/Raven.Client/Documents/Indexes/ClusterState.cs
+++ b/src/Raven.Client/Documents/Indexes/ClusterState.cs
@@ -1,0 +1,17 @@
+﻿namespace Raven.Client.Documents.Indexes
+{
+    public class ClusterState
+    {
+        public ClusterState()
+        {
+            LastStateIndex = 0;
+        }
+
+        public ClusterState(ClusterState clusterState)
+        {
+            LastStateIndex = clusterState.LastStateIndex;
+        }
+
+        public long LastStateIndex;
+    }
+}

--- a/src/Raven.Client/Documents/Indexes/ClusterState.cs
+++ b/src/Raven.Client/Documents/Indexes/ClusterState.cs
@@ -1,6 +1,6 @@
 ﻿namespace Raven.Client.Documents.Indexes
 {
-    public class ClusterState
+    internal class ClusterState
     {
         public ClusterState()
         {

--- a/src/Raven.Client/Documents/Indexes/IndexDefinition.cs
+++ b/src/Raven.Client/Documents/Indexes/IndexDefinition.cs
@@ -16,7 +16,7 @@ namespace Raven.Client.Documents.Indexes
     /// <summary>
     /// A definition of a RavenIndex
     /// </summary>
-    public class IndexDefinition
+    public class IndexDefinition : IndexDefinitionBase
     {
         private static readonly Regex _newLineCharacters = new Regex("\r?\n", RegexOptions.Compiled);
 
@@ -24,21 +24,6 @@ namespace Raven.Client.Documents.Indexes
         {
             _configuration = new IndexConfiguration();
         }
-
-        /// <summary>
-        /// This is the means by which the outside world refers to this index definition
-        /// </summary>
-        public string Name { get; set; }
-
-        /// <summary>
-        /// Priority of an index
-        /// </summary>
-        public IndexPriority? Priority { get; set; }
-
-        /// <summary>
-        /// Index state
-        /// </summary>
-        public IndexState? State { get; set; }
 
         /// <summary>
         /// Index lock mode:
@@ -546,6 +531,7 @@ namespace Raven.Client.Documents.Indexes
             definition.PatternForOutputReduceToCollectionReferences = PatternForOutputReduceToCollectionReferences;
             definition.PatternReferencesCollectionName = PatternReferencesCollectionName;
             definition.DeploymentMode = DeploymentMode;
+            definition._clusterState = (_clusterState == null) ? null : new ClusterState(_clusterState);
 
             foreach (var kvp in _configuration)
                 definition.Configuration[kvp.Key] = kvp.Value;

--- a/src/Raven.Client/Documents/Indexes/IndexDefinition.cs
+++ b/src/Raven.Client/Documents/Indexes/IndexDefinition.cs
@@ -531,7 +531,7 @@ namespace Raven.Client.Documents.Indexes
             definition.PatternForOutputReduceToCollectionReferences = PatternForOutputReduceToCollectionReferences;
             definition.PatternReferencesCollectionName = PatternReferencesCollectionName;
             definition.DeploymentMode = DeploymentMode;
-            definition._clusterState = (_clusterState == null) ? null : new ClusterState(_clusterState);
+            definition.ClusterState = (ClusterState == null) ? null : new ClusterState(ClusterState);
 
             foreach (var kvp in _configuration)
                 definition.Configuration[kvp.Key] = kvp.Value;

--- a/src/Raven.Client/Documents/Indexes/IndexDefinitionBase.cs
+++ b/src/Raven.Client/Documents/Indexes/IndexDefinitionBase.cs
@@ -6,7 +6,7 @@ namespace Raven.Client.Documents.Indexes
     {
         protected IndexDefinitionBase()
         {
-            _clusterState = new ClusterState();
+            ClusterState = new ClusterState();
         }
 
         /// <summary>
@@ -24,7 +24,7 @@ namespace Raven.Client.Documents.Indexes
         /// </summary>
         public IndexState? State { get; set; }
 
-        [JsonDeserializationNoIgnore]
-        internal ClusterState _clusterState;
+        [ForceJsonSerialization]
+        internal ClusterState ClusterState;
     }
 }

--- a/src/Raven.Client/Documents/Indexes/IndexDefinitionBase.cs
+++ b/src/Raven.Client/Documents/Indexes/IndexDefinitionBase.cs
@@ -1,0 +1,30 @@
+﻿using Sparrow.Json;
+
+namespace Raven.Client.Documents.Indexes
+{
+    public abstract class IndexDefinitionBase
+    {
+        protected IndexDefinitionBase()
+        {
+            _clusterState = new ClusterState();
+        }
+
+        /// <summary>
+        /// This is the means by which the outside world refers to this index definition
+        /// </summary>
+        public string Name { get; set; }
+
+        /// <summary>
+        /// Priority of an index
+        /// </summary>
+        public IndexPriority? Priority { get; set; }
+
+        /// <summary>
+        /// Index state
+        /// </summary>
+        public IndexState? State { get; set; }
+
+        [JsonDeserializationNoIgnore]
+        internal ClusterState _clusterState;
+    }
+}

--- a/src/Raven.Client/Json/Serialization/NewtonsoftJson/DefaultRavenContractResolver.cs
+++ b/src/Raven.Client/Json/Serialization/NewtonsoftJson/DefaultRavenContractResolver.cs
@@ -196,7 +196,7 @@ namespace Raven.Client.Json.Serialization.NewtonsoftJson
             var fieldInfo = info as FieldInfo;
             if (fieldInfo != null)
             {
-                if ((fieldInfo.IsPublic == false) && (fieldInfo.IsDefined(typeof(JsonDeserializationNoIgnoreAttribute)) == false))
+                if ((fieldInfo.IsPublic == false) && (fieldInfo.IsDefined(typeof(ForceJsonSerializationAttribute)) == false))
                     return true;
 
 #if NETSTANDARD2_0

--- a/src/Raven.Client/Json/Serialization/NewtonsoftJson/DefaultRavenContractResolver.cs
+++ b/src/Raven.Client/Json/Serialization/NewtonsoftJson/DefaultRavenContractResolver.cs
@@ -196,7 +196,7 @@ namespace Raven.Client.Json.Serialization.NewtonsoftJson
             var fieldInfo = info as FieldInfo;
             if (fieldInfo != null)
             {
-                if (fieldInfo.IsPublic == false)
+                if ((fieldInfo.IsPublic == false) && (fieldInfo.IsDefined(typeof(JsonDeserializationNoIgnoreAttribute)) == false))
                     return true;
 
 #if NETSTANDARD2_0

--- a/src/Raven.Server/Documents/DocumentDatabase.cs
+++ b/src/Raven.Server/Documents/DocumentDatabase.cs
@@ -1050,7 +1050,7 @@ namespace Raven.Server.Documents
                     case StorageEnvironmentWithType.StorageEnvironmentType.Index:
                         yield return new FullBackup.StorageEnvironmentInformation
                         {
-                            Name = IndexDefinitionBase.GetIndexNameSafeForFileSystem(storageEnvironmentWithType.Name),
+                            Name = IndexDefinitionBaseServerSide.GetIndexNameSafeForFileSystem(storageEnvironmentWithType.Name),
                             Folder = Constants.Documents.PeriodicBackup.Folders.Indexes,
                             Env = storageEnvironmentWithType.Environment
                         };

--- a/src/Raven.Server/Documents/Handlers/IndexHandler.cs
+++ b/src/Raven.Server/Documents/Handlers/IndexHandler.cs
@@ -1036,7 +1036,7 @@ namespace Raven.Server.Documents.Handlers
                 if (indexDefinition.Type.IsJavaScript() == false)
                     throw new UnauthorizedAccessException("Testing indexes is only allowed for JavaScript indexes.");
 
-                var compiledIndex = new JavaScriptIndex(indexDefinition, Database.Configuration, IndexDefinitionBase.IndexVersion.CurrentVersion);
+                var compiledIndex = new JavaScriptIndex(indexDefinition, Database.Configuration, IndexDefinitionBaseServerSide.IndexVersion.CurrentVersion);
 
                 var inputSize = GetIntValueQueryString("inputSize", false) ?? DefaultInputSizeForTestingJavaScriptIndex;
                 var collections = new HashSet<string>(compiledIndex.Maps.Keys);

--- a/src/Raven.Server/Documents/Indexes/Auto/AutoIndexDefinitionBaseServerSide.cs
+++ b/src/Raven.Server/Documents/Indexes/Auto/AutoIndexDefinitionBaseServerSide.cs
@@ -6,10 +6,10 @@ using Sparrow.Json;
 
 namespace Raven.Server.Documents.Indexes.Auto
 {
-    public abstract class AutoIndexDefinitionBase : IndexDefinitionBase<AutoIndexField>
+    public abstract class AutoIndexDefinitionBaseServerSide : IndexDefinitionBaseServerSide<AutoIndexField>
     {
-        protected AutoIndexDefinitionBase(string indexName, string collection, AutoIndexField[] fields, IndexDeploymentMode? deploymentMode, long? indexVersion = null)
-            : base(indexName, new [] { collection }, IndexLockMode.Unlock, IndexPriority.Normal, IndexState.Normal, fields, indexVersion ?? IndexVersion.CurrentVersion, deploymentMode)
+        protected AutoIndexDefinitionBaseServerSide(string indexName, string collection, AutoIndexField[] fields, IndexDeploymentMode? deploymentMode, long? indexVersion = null)
+            : base(indexName, new [] { collection }, IndexLockMode.Unlock, IndexPriority.Normal, IndexState.Normal, fields, indexVersion ?? IndexVersion.CurrentVersion, deploymentMode, 0)
         {
             if (string.IsNullOrEmpty(collection))
                 throw new ArgumentNullException(nameof(collection));
@@ -60,7 +60,7 @@ namespace Raven.Server.Documents.Indexes.Auto
 
         protected internal abstract override IndexDefinition GetOrCreateIndexDefinitionInternal();
 
-        public abstract override IndexDefinitionCompareDifferences Compare(IndexDefinitionBase indexDefinition);
+        public abstract override IndexDefinitionCompareDifferences Compare(IndexDefinitionBaseServerSide indexDefinition);
 
         public abstract override IndexDefinitionCompareDifferences Compare(IndexDefinition indexDefinition);
 

--- a/src/Raven.Server/Documents/Indexes/Auto/AutoMapIndex.cs
+++ b/src/Raven.Server/Documents/Indexes/Auto/AutoMapIndex.cs
@@ -38,7 +38,7 @@ namespace Raven.Server.Documents.Indexes.Auto
             return new AutoIndexDocsEnumerator(items, stats);
         }
 
-        public override void Update(IndexDefinitionBase definition, IndexingConfiguration configuration)
+        public override void Update(IndexDefinitionBaseServerSide definition, IndexingConfiguration configuration)
         {
             SetLock(definition.LockMode);
             SetPriority(definition.Priority);

--- a/src/Raven.Server/Documents/Indexes/Auto/AutoMapIndexDefinition.cs
+++ b/src/Raven.Server/Documents/Indexes/Auto/AutoMapIndexDefinition.cs
@@ -10,7 +10,7 @@ using Voron;
 
 namespace Raven.Server.Documents.Indexes.Auto
 {
-    public class AutoMapIndexDefinition : AutoIndexDefinitionBase
+    public class AutoMapIndexDefinition : AutoIndexDefinitionBaseServerSide
     {
         public AutoMapIndexDefinition(string collection, AutoIndexField[] fields, IndexDeploymentMode? deploymentMode, long? indexVersion = null)
             : base(AutoIndexNameFinder.FindMapIndexName(collection, fields), collection, fields, deploymentMode, indexVersion)
@@ -63,7 +63,7 @@ namespace Raven.Server.Documents.Indexes.Auto
             return indexDefinition;
         }
 
-        public override IndexDefinitionCompareDifferences Compare(IndexDefinitionBase other)
+        public override IndexDefinitionCompareDifferences Compare(IndexDefinitionBaseServerSide other)
         {
             var otherDefinition = other as AutoMapIndexDefinition;
             if (otherDefinition == null)

--- a/src/Raven.Server/Documents/Indexes/Debugging/IndexDebugExtensions.cs
+++ b/src/Raven.Server/Documents/Indexes/Debugging/IndexDebugExtensions.cs
@@ -320,7 +320,7 @@ namespace Raven.Server.Documents.Indexes.Debugging
             };
         }
 
-        private static string GetTreeName(BlittableJsonReaderObject reduceEntry, IndexDefinitionBase indexDefinition, JsonOperationContext context)
+        private static string GetTreeName(BlittableJsonReaderObject reduceEntry, IndexDefinitionBaseServerSide indexDefinition, JsonOperationContext context)
         {
             Dictionary<string, CompiledIndexField> groupByFields;
 

--- a/src/Raven.Server/Documents/Indexes/Errors/FaultyAutoIndexDefinition.cs
+++ b/src/Raven.Server/Documents/Indexes/Errors/FaultyAutoIndexDefinition.cs
@@ -7,12 +7,12 @@ using Sparrow.Server.Json.Sync;
 
 namespace Raven.Server.Documents.Indexes.Errors
 {
-    public class FaultyAutoIndexDefinition : IndexDefinitionBase<IndexField>
+    public class FaultyAutoIndexDefinition : IndexDefinitionBaseServerSide<IndexField>
     {
-        public readonly AutoIndexDefinitionBase Definition;
+        public readonly AutoIndexDefinitionBaseServerSide Definition;
 
-        public FaultyAutoIndexDefinition(string name, HashSet<string> collections, IndexLockMode lockMode, IndexPriority priority, IndexState state, IndexField[] mapFields, AutoIndexDefinitionBase definition)
-            : base(name, collections, lockMode, priority, state, mapFields, definition.Version, definition.DeploymentMode)
+        public FaultyAutoIndexDefinition(string name, HashSet<string> collections, IndexLockMode lockMode, IndexPriority priority, IndexState state, IndexField[] mapFields, AutoIndexDefinitionBaseServerSide definition)
+            : base(name, collections, lockMode, priority, state, mapFields, definition.Version, definition.DeploymentMode, definition._clusterState?.LastStateIndex)
         {
             Definition = definition;
         }
@@ -42,7 +42,7 @@ namespace Raven.Server.Documents.Indexes.Errors
             return (hashCode * 397) ^ -1337;
         }
 
-        public override IndexDefinitionCompareDifferences Compare(IndexDefinitionBase indexDefinition)
+        public override IndexDefinitionCompareDifferences Compare(IndexDefinitionBaseServerSide indexDefinition)
         {
             return Definition.Compare(indexDefinition);
         }

--- a/src/Raven.Server/Documents/Indexes/Errors/FaultyAutoIndexDefinition.cs
+++ b/src/Raven.Server/Documents/Indexes/Errors/FaultyAutoIndexDefinition.cs
@@ -12,7 +12,7 @@ namespace Raven.Server.Documents.Indexes.Errors
         public readonly AutoIndexDefinitionBaseServerSide Definition;
 
         public FaultyAutoIndexDefinition(string name, HashSet<string> collections, IndexLockMode lockMode, IndexPriority priority, IndexState state, IndexField[] mapFields, AutoIndexDefinitionBaseServerSide definition)
-            : base(name, collections, lockMode, priority, state, mapFields, definition.Version, definition.DeploymentMode, definition._clusterState?.LastStateIndex)
+            : base(name, collections, lockMode, priority, state, mapFields, definition.Version, definition.DeploymentMode, definition.ClusterState?.LastStateIndex)
         {
             Definition = definition;
         }

--- a/src/Raven.Server/Documents/Indexes/Errors/FaultyInMemoryIndex.cs
+++ b/src/Raven.Server/Documents/Indexes/Errors/FaultyInMemoryIndex.cs
@@ -26,7 +26,7 @@ namespace Raven.Server.Documents.Indexes.Errors
 
         private readonly DateTime _createdAt;
 
-        public FaultyInMemoryIndex(Exception e, string name, IndexingConfiguration configuration, AutoIndexDefinitionBase definition)
+        public FaultyInMemoryIndex(Exception e, string name, IndexingConfiguration configuration, AutoIndexDefinitionBaseServerSide definition)
             : this(e, configuration, new FaultyAutoIndexDefinition(name, new HashSet<string> { "@FaultyIndexes" }, IndexLockMode.Unlock, IndexPriority.Normal, IndexState.Normal, new IndexField[0], definition))
         {
         }
@@ -36,7 +36,7 @@ namespace Raven.Server.Documents.Indexes.Errors
         {
         }
 
-        private FaultyInMemoryIndex(Exception e, IndexingConfiguration configuration, IndexDefinitionBase definition)
+        private FaultyInMemoryIndex(Exception e, IndexingConfiguration configuration, IndexDefinitionBaseServerSide definition)
             : base(IndexType.Faulty, IndexSourceType.None, definition)
         {
             _e = e;
@@ -70,7 +70,7 @@ namespace Raven.Server.Documents.Indexes.Errors
             throw new NotSupportedException($"Index {Name} is in-memory implementation of a faulty index", _e);
         }
 
-        public override void Update(IndexDefinitionBase definition, IndexingConfiguration configuration)
+        public override void Update(IndexDefinitionBaseServerSide definition, IndexingConfiguration configuration)
         {
             throw new NotSupportedException($"{Type} index does not support updating it's definition and configuration.");
         }

--- a/src/Raven.Server/Documents/Indexes/Errors/FaultyIndexDefinition.cs
+++ b/src/Raven.Server/Documents/Indexes/Errors/FaultyIndexDefinition.cs
@@ -6,12 +6,12 @@ using Sparrow.Server.Json.Sync;
 
 namespace Raven.Server.Documents.Indexes.Errors
 {
-    public class FaultyIndexDefinition : IndexDefinitionBase<IndexField>
+    public class FaultyIndexDefinition : IndexDefinitionBaseServerSide<IndexField>
     {
         private readonly IndexDefinition _definition;
 
         public FaultyIndexDefinition(string name, IEnumerable<string> collections, IndexLockMode lockMode, IndexPriority priority, IndexState state, IndexField[] mapFields, IndexDefinition definition)
-            : base(name, collections, lockMode, priority, state, mapFields, IndexVersion.CurrentVersion, definition.DeploymentMode)
+            : base(name, collections, lockMode, priority, state, mapFields, IndexVersion.CurrentVersion, definition.DeploymentMode, definition._clusterState?.LastStateIndex)
         {
             _definition = definition;
         }
@@ -43,7 +43,7 @@ namespace Raven.Server.Documents.Indexes.Errors
             return (hashCode * 397) ^ -1337;
         }
 
-        public override IndexDefinitionCompareDifferences Compare(IndexDefinitionBase indexDefinition)
+        public override IndexDefinitionCompareDifferences Compare(IndexDefinitionBaseServerSide indexDefinition)
         {
             return IndexDefinitionCompareDifferences.All;
         }

--- a/src/Raven.Server/Documents/Indexes/Errors/FaultyIndexDefinition.cs
+++ b/src/Raven.Server/Documents/Indexes/Errors/FaultyIndexDefinition.cs
@@ -11,7 +11,7 @@ namespace Raven.Server.Documents.Indexes.Errors
         private readonly IndexDefinition _definition;
 
         public FaultyIndexDefinition(string name, IEnumerable<string> collections, IndexLockMode lockMode, IndexPriority priority, IndexState state, IndexField[] mapFields, IndexDefinition definition)
-            : base(name, collections, lockMode, priority, state, mapFields, IndexVersion.CurrentVersion, definition.DeploymentMode, definition._clusterState?.LastStateIndex)
+            : base(name, collections, lockMode, priority, state, mapFields, IndexVersion.CurrentVersion, definition.DeploymentMode, definition.ClusterState?.LastStateIndex)
         {
             _definition = definition;
         }

--- a/src/Raven.Server/Documents/Indexes/Index.cs
+++ b/src/Raven.Server/Documents/Indexes/Index.cs
@@ -1123,7 +1123,7 @@ namespace Raven.Server.Documents.Indexes
 
                 _indexStorage.WriteDefinition(definition);
 
-                if (definition._clusterState?.LastStateIndex > (Definition._clusterState?.LastStateIndex ?? -1))
+                if (definition.ClusterState?.LastStateIndex > (Definition.ClusterState?.LastStateIndex ?? -1))
                 {
                     switch (definition.State)
                     {

--- a/src/Raven.Server/Documents/Indexes/IndexDefinitionBaseServerSide.cs
+++ b/src/Raven.Server/Documents/Indexes/IndexDefinitionBaseServerSide.cs
@@ -19,6 +19,11 @@ namespace Raven.Server.Documents.Indexes
 {
     public abstract class IndexDefinitionBaseServerSide
     {
+        protected IndexDefinitionBaseServerSide()
+        {
+            ClusterState = new ClusterState();
+        }
+
         public string Name { get; protected set; }
 
         public abstract long Version { get; }
@@ -31,7 +36,7 @@ namespace Raven.Server.Documents.Indexes
 
         public IndexState State { get; set; }
 
-        internal ClusterState _clusterState;
+        internal readonly ClusterState ClusterState;
 
         public IndexDeploymentMode DeploymentMode { get; set; }
 
@@ -164,7 +169,7 @@ namespace Raven.Server.Documents.Indexes
 
             MapFields = new Dictionary<string, IndexFieldBase>(StringComparer.Ordinal);
             IndexFields = new Dictionary<string, IndexField>(StringComparer.Ordinal);
-            _clusterState = new ClusterState();
+
             foreach (var field in mapFields)
             {
                 MapFields.Add(field.Name, field);
@@ -184,7 +189,7 @@ namespace Raven.Server.Documents.Indexes
             Priority = priority;
             State = state;
             _indexVersion = indexVersion;
-            _clusterState.LastStateIndex = clusterIndexForState ?? 0;
+            ClusterState.LastStateIndex = clusterIndexForState ?? 0;
         }
 
         static IndexDefinitionBaseServerSide()

--- a/src/Raven.Server/Documents/Indexes/IndexFieldsPersistence.cs
+++ b/src/Raven.Server/Documents/Indexes/IndexFieldsPersistence.cs
@@ -17,7 +17,7 @@ namespace Raven.Server.Documents.Indexes
         public IndexFieldsPersistence(Index index)
         {
             _index = index ?? throw new ArgumentNullException(nameof(index));
-            _supportsTimeFields = index.Definition.Version >= IndexDefinitionBase.IndexVersion.TimeTicks;
+            _supportsTimeFields = index.Definition.Version >= IndexDefinitionBaseServerSide.IndexVersion.TimeTicks;
         }
 
         internal void Initialize()

--- a/src/Raven.Server/Documents/Indexes/IndexStorage.cs
+++ b/src/Raven.Server/Documents/Indexes/IndexStorage.cs
@@ -158,7 +158,7 @@ namespace Raven.Server.Documents.Indexes
                     string persistedConfigurationValue = null;
                     if (result != null)
                         persistedConfigurationValue = result.Reader.ToStringValue();
-                    else if (_index.Definition.Version < IndexDefinitionBase.IndexVersion.Analyzers)
+                    else if (_index.Definition.Version < IndexDefinitionBaseServerSide.IndexVersion.Analyzers)
                         persistedConfigurationValue = defaultAnalyzer;
 
                     if (persistedConfigurationValue != null)
@@ -202,7 +202,7 @@ namespace Raven.Server.Documents.Indexes
             return _lastDatabaseEtagOnIndexCreation >= currentEtag;
         }
 
-        public void WriteDefinition(IndexDefinitionBase indexDefinition, TimeSpan? timeout = null)
+        public void WriteDefinition(IndexDefinitionBaseServerSide indexDefinition, TimeSpan? timeout = null)
         {
             using (_contextPool.AllocateOperationContext(out TransactionOperationContext context))
             using (var tx = context.OpenWriteTransaction(timeout))

--- a/src/Raven.Server/Documents/Indexes/IndexStore.cs
+++ b/src/Raven.Server/Documents/Indexes/IndexStore.cs
@@ -1171,7 +1171,7 @@ namespace Raven.Server.Documents.Indexes
             if (indexDef != null)
             {
                 differences = existingIndex.Definition.Compare(indexDef);
-                if (indexDef.ClusterState?.LastStateIndex > (existingIndex.Definition._clusterState?.LastStateIndex ?? -1))
+                if (indexDef.ClusterState?.LastStateIndex > (existingIndex.Definition.ClusterState?.LastStateIndex ?? -1))
                 {
                     differences |= IndexDefinitionCompareDifferences.State;
                 }
@@ -1815,8 +1815,7 @@ namespace Raven.Server.Documents.Indexes
                 if (indexDefinition.State != null && index.Definition.State != indexDefinition.State)
                     differences |= IndexDefinitionCompareDifferences.State;
 
-                index.Definition._clusterState ??= new ClusterState();
-                index.Definition._clusterState.LastStateIndex = (indexDefinition.ClusterState?.LastStateIndex ?? 0);
+                index.Definition.ClusterState.LastStateIndex = (indexDefinition.ClusterState?.LastStateIndex ?? 0);
 
                 if (differences != IndexDefinitionCompareDifferences.None)
                 {

--- a/src/Raven.Server/Documents/Indexes/IndexStore.cs
+++ b/src/Raven.Server/Documents/Indexes/IndexStore.cs
@@ -272,7 +272,7 @@ namespace Raven.Server.Documents.Indexes
             }
         }
 
-        private Index HandleAutoIndexChange(string name, AutoIndexDefinitionBase definition)
+        private Index HandleAutoIndexChange(string name, AutoIndexDefinitionBaseServerSide definition)
         {
             using (IndexLock(name))
             {
@@ -330,7 +330,7 @@ namespace Raven.Server.Documents.Indexes
             }
         }
 
-        internal static AutoIndexDefinitionBase CreateAutoDefinition(AutoIndexDefinition definition, IndexDeploymentMode indexDeployment)
+        internal static AutoIndexDefinitionBaseServerSide CreateAutoDefinition(AutoIndexDefinition definition, IndexDeploymentMode indexDeployment)
         {
             var mapFields = definition
                 .MapFields
@@ -346,7 +346,7 @@ namespace Raven.Server.Documents.Indexes
 
             if (definition.Type == IndexType.AutoMap)
             {
-                var result = new AutoMapIndexDefinition(definition.Collection, mapFields, indexDeployment, IndexDefinitionBase.IndexVersion.CurrentVersion);
+                var result = new AutoMapIndexDefinition(definition.Collection, mapFields, indexDeployment, IndexDefinitionBaseServerSide.IndexVersion.CurrentVersion);
 
                 if (definition.Priority.HasValue)
                     result.Priority = definition.Priority.Value;
@@ -369,7 +369,7 @@ namespace Raven.Server.Documents.Indexes
                     })
                     .ToArray();
 
-                var result = new AutoMapReduceIndexDefinition(definition.Collection, mapFields, groupByFields, indexDeployment, IndexDefinitionBase.IndexVersion.CurrentVersion);
+                var result = new AutoMapReduceIndexDefinition(definition.Collection, mapFields, groupByFields, indexDeployment, IndexDefinitionBaseServerSide.IndexVersion.CurrentVersion);
 
                 if (definition.Priority.HasValue)
                     result.Priority = definition.Priority.Value;
@@ -606,7 +606,7 @@ namespace Raven.Server.Documents.Indexes
                     return null;
                 }
 
-                UpdateStaticIndexDefinition(definition, currentIndex, currentDifferences);
+                UpdateIndexDefinition(definition, currentIndex, currentDifferences);
 
                 var prefixesOfDocumentsToDelete = new Dictionary<string, string>(StringComparer.OrdinalIgnoreCase);
 
@@ -960,7 +960,7 @@ namespace Raven.Server.Documents.Indexes
             return new IndexBatchScope(this, GetNumberOfUtilizedCores());
         }
 
-        public async Task<Index> CreateIndex(IndexDefinitionBase definition, string raftRequestId)
+        public async Task<Index> CreateIndex(IndexDefinitionBaseServerSide definition, string raftRequestId)
         {
             if (definition == null)
                 throw new ArgumentNullException(nameof(definition));
@@ -971,7 +971,7 @@ namespace Raven.Server.Documents.Indexes
             ValidateAutoIndex(definition);
             definition.DeploymentMode = _documentDatabase.Configuration.Indexing.AutoIndexDeploymentMode;
 
-            var command = PutAutoIndexCommand.Create((AutoIndexDefinitionBase)definition, _documentDatabase.Name, raftRequestId, _documentDatabase.Configuration.Indexing.AutoIndexDeploymentMode);
+            var command = PutAutoIndexCommand.Create((AutoIndexDefinitionBaseServerSide)definition, _documentDatabase.Name, raftRequestId, _documentDatabase.Configuration.Indexing.AutoIndexDeploymentMode);
 
             long index = 0;
             try
@@ -997,7 +997,7 @@ namespace Raven.Server.Documents.Indexes
             return GetIndex(definition.Name);
         }
 
-        private void ValidateAutoIndex(IndexDefinitionBase definition)
+        private void ValidateAutoIndex(IndexDefinitionBaseServerSide definition)
         {
             if (IsValidIndexName(definition.Name, false, out var errorMessage) == false)
             {
@@ -1014,11 +1014,11 @@ namespace Raven.Server.Documents.Indexes
 
             _serverStore.LicenseManager.AssertCanAddAdditionalAssembliesFromNuGet(definition);
 
-            var safeFileSystemIndexName = IndexDefinitionBase.GetIndexNameSafeForFileSystem(definition.Name);
+            var safeFileSystemIndexName = IndexDefinitionBaseServerSide.GetIndexNameSafeForFileSystem(definition.Name);
 
             var indexWithFileSystemNameCollision = GetIndexes().FirstOrDefault(x =>
                 x.Name.Equals(definition.Name, StringComparison.OrdinalIgnoreCase) == false &&
-                safeFileSystemIndexName.Equals(IndexDefinitionBase.GetIndexNameSafeForFileSystem(x.Name), StringComparison.OrdinalIgnoreCase));
+                safeFileSystemIndexName.Equals(IndexDefinitionBaseServerSide.GetIndexNameSafeForFileSystem(x.Name), StringComparison.OrdinalIgnoreCase));
 
             if (indexWithFileSystemNameCollision != null)
                 throw new IndexCreationException(
@@ -1027,7 +1027,7 @@ namespace Raven.Server.Documents.Indexes
             definition.RemoveDefaultValues();
             ValidateAnalyzers(definition);
 
-            var instance = IndexCompilationCache.GetIndexInstance(definition, _documentDatabase.Configuration, IndexDefinitionBase.IndexVersion.CurrentVersion); // pre-compile it and validate
+            var instance = IndexCompilationCache.GetIndexInstance(definition, _documentDatabase.Configuration, IndexDefinitionBaseServerSide.IndexVersion.CurrentVersion); // pre-compile it and validate
 
             if (definition.Type == IndexType.MapReduce)
             {
@@ -1081,7 +1081,7 @@ namespace Raven.Server.Documents.Indexes
 
         private void UpdateIndex(IndexDefinition definition, Index existingIndex, IndexDefinitionCompareDifferences indexDifferences)
         {
-            UpdateStaticIndexDefinition(definition, existingIndex, indexDifferences);
+            UpdateIndexDefinition(definition, existingIndex, indexDifferences);
 
             switch (definition.SourceType)
             {
@@ -1148,25 +1148,15 @@ namespace Raven.Server.Documents.Indexes
             }
         }
 
-        private static void UpdateStaticIndexDefinition(IndexDefinition definition, Index existingIndex, IndexDefinitionCompareDifferences indexDifferences)
+        private static void UpdateIndexDefinition(IndexDefinitionBase definition, Index existingIndex, IndexDefinitionCompareDifferences indexDifferences)
         {
-            if (definition.LockMode.HasValue && (indexDifferences & IndexDefinitionCompareDifferences.LockMode) != 0)
-                existingIndex.SetLock(definition.LockMode.Value);
-
+            if (definition is IndexDefinition def)
+            {
+                if (def.LockMode.HasValue && (indexDifferences & IndexDefinitionCompareDifferences.LockMode) != 0)
+                    existingIndex.SetLock(def.LockMode.Value);
+            }
             if (definition.Priority.HasValue && (indexDifferences & IndexDefinitionCompareDifferences.Priority) != 0)
                 existingIndex.SetPriority(definition.Priority.Value);
-
-            if (definition.State.HasValue && (indexDifferences & IndexDefinitionCompareDifferences.State) != 0)
-                existingIndex.SetState(definition.State.Value);
-        }
-
-        private static void UpdateAutoIndexDefinition(AutoIndexDefinition definition, Index existingIndex, IndexDefinitionCompareDifferences indexDifferences)
-        {
-            if (definition.Priority.HasValue && (indexDifferences & IndexDefinitionCompareDifferences.Priority) != 0)
-                existingIndex.SetPriority(definition.Priority.Value);
-
-            if (definition.State.HasValue && (indexDifferences & IndexDefinitionCompareDifferences.State) != 0)
-                existingIndex.SetState(definition.State.Value);
         }
 
         internal IndexCreationOptions GetIndexCreationOptions(object indexDefinition, Index existingIndex, out IndexDefinitionCompareDifferences differences)
@@ -1181,14 +1171,13 @@ namespace Raven.Server.Documents.Indexes
             if (indexDef != null)
             {
                 differences = existingIndex.Definition.Compare(indexDef);
-                //We need to check differences between old and new definition
-                //and also need to check differences between new index definition state to
-                //in memory index state ( can be different from current definition state).
-                if ((indexDef.State != null) && (existingIndex.State != indexDef.State))
+                if (indexDef._clusterState?.LastStateIndex > (existingIndex.Definition._clusterState?.LastStateIndex ?? -1))
+                {
                     differences |= IndexDefinitionCompareDifferences.State;
+                }
             }
 
-            var indexDefBase = indexDefinition as IndexDefinitionBase;
+            var indexDefBase = indexDefinition as IndexDefinitionBaseServerSide;
             if (indexDefBase != null)
                 differences = existingIndex.Definition.Compare(indexDefBase);
 
@@ -1377,7 +1366,7 @@ namespace Raven.Server.Documents.Indexes
             //if (index.Configuration.RunInMemory)
             //    return;
 
-            var name = IndexDefinitionBase.GetIndexNameSafeForFileSystem(index.Name);
+            var name = IndexDefinitionBaseServerSide.GetIndexNameSafeForFileSystem(index.Name);
 
             var indexPath = index.Configuration.StoragePath.Combine(name);
 
@@ -1703,14 +1692,14 @@ namespace Raven.Server.Documents.Indexes
                 var name = kvp.Key;
                 var definition = kvp.Value;
 
-                var safeName = IndexDefinitionBase.GetIndexNameSafeForFileSystem(definition.Name);
+                var safeName = IndexDefinitionBaseServerSide.GetIndexNameSafeForFileSystem(definition.Name);
                 var indexPath = path.Combine(safeName).FullPath;
                 if (Directory.Exists(indexPath))
                 {
                     var sp = Stopwatch.StartNew();
 
                     addToInitLog($"Initializing static index: `{name}`");
-                    OpenIndex(path, indexPath, exceptions, name, startIndex, staticIndexDefinition: definition, autoIndexDefinition: null);
+                    OpenIndex(path, indexPath, exceptions, name, startIndex, definition);
 
                     if (Logger.IsInfoEnabled)
                         Logger.Info($"Initialized static index: `{name}`, took: {sp.ElapsedMilliseconds:#,#;;0}ms");
@@ -1725,14 +1714,14 @@ namespace Raven.Server.Documents.Indexes
                 var name = kvp.Key;
                 var definition = kvp.Value;
 
-                var safeName = IndexDefinitionBase.GetIndexNameSafeForFileSystem(definition.Name);
+                var safeName = IndexDefinitionBaseServerSide.GetIndexNameSafeForFileSystem(definition.Name);
                 var indexPath = path.Combine(safeName).FullPath;
                 if (Directory.Exists(indexPath))
                 {
                     var sp = Stopwatch.StartNew();
 
                     addToInitLog($"Initializing auto index: `{name}`");
-                    OpenIndex(path, indexPath, exceptions, name, startIndex, staticIndexDefinition: null, autoIndexDefinition: definition);
+                    OpenIndex(path, indexPath, exceptions, name, startIndex, definition);
 
                     if (Logger.IsInfoEnabled)
                         Logger.Info($"Initialized auto index: `{name}`, took: {sp.ElapsedMilliseconds:#,#;;0}ms");
@@ -1785,11 +1774,11 @@ namespace Raven.Server.Documents.Indexes
             Debug.Assert(index is FaultyInMemoryIndex);
 
             var path = _documentDatabase.Configuration.Indexing.StoragePath;
-            var safeName = IndexDefinitionBase.GetIndexNameSafeForFileSystem(index.Name);
+            var safeName = IndexDefinitionBaseServerSide.GetIndexNameSafeForFileSystem(index.Name);
             var indexPath = path.Combine(safeName).FullPath;
             var exceptions = new List<Exception>();
 
-            OpenIndex(path, indexPath, exceptions, index.Name, startIndex: true, index.GetIndexDefinition(), null);
+            OpenIndex(path, indexPath, exceptions, index.Name, startIndex: true, index.GetIndexDefinition());
 
             if (exceptions.Count > 0)
             {
@@ -1805,7 +1794,7 @@ namespace Raven.Server.Documents.Indexes
                 });
         }
 
-        private void OpenIndex(PathSetting path, string indexPath, List<Exception> exceptions, string name, bool startIndex, IndexDefinition staticIndexDefinition, AutoIndexDefinition autoIndexDefinition)
+        private void OpenIndex(PathSetting path, string indexPath, List<Exception> exceptions, string name, bool startIndex, IndexDefinitionBase indexDefinition)
         {
             Index index = null;
 
@@ -1815,33 +1804,24 @@ namespace Raven.Server.Documents.Indexes
 
                 var differences = IndexDefinitionCompareDifferences.None;
 
-                if (staticIndexDefinition != null)
+                if (indexDefinition is IndexDefinition def)
                 {
-                    if (staticIndexDefinition.LockMode != null && index.Definition.LockMode != staticIndexDefinition.LockMode)
+                    if (def.LockMode != null && index.Definition.LockMode != def.LockMode)
                         differences |= IndexDefinitionCompareDifferences.LockMode;
-
-                    if (staticIndexDefinition.Priority != null && index.Definition.Priority != staticIndexDefinition.Priority)
-                        differences |= IndexDefinitionCompareDifferences.Priority;
-
-                    if (staticIndexDefinition.State != null && index.Definition.State != staticIndexDefinition.State)
-                        differences |= IndexDefinitionCompareDifferences.State;
                 }
-                else if (autoIndexDefinition != null)
-                {
-                    if (autoIndexDefinition.Priority != index.Definition.Priority)
-                        differences |= IndexDefinitionCompareDifferences.Priority;
+                if (indexDefinition.Priority != null && index.Definition.Priority != indexDefinition.Priority)
+                    differences |= IndexDefinitionCompareDifferences.Priority;
 
-                    if (autoIndexDefinition.State != index.Definition.State)
-                        differences |= IndexDefinitionCompareDifferences.State;
-                }
+                if (indexDefinition.State != null && index.Definition.State != indexDefinition.State)
+                    differences |= IndexDefinitionCompareDifferences.State;
+
+                index.Definition._clusterState ??= new ClusterState();
+                index.Definition._clusterState.LastStateIndex = (indexDefinition._clusterState?.LastStateIndex ?? 0);
 
                 if (differences != IndexDefinitionCompareDifferences.None)
                 {
                     // database record has different lock mode / priority / state setting than persisted locally
-                    if (staticIndexDefinition != null)
-                        UpdateStaticIndexDefinition(staticIndexDefinition, index, differences);
-                    else
-                        UpdateAutoIndexDefinition(autoIndexDefinition, index, differences);
+                    UpdateIndexDefinition(indexDefinition, index, differences);
                 }
 
                 if (index.State == IndexState.Error)
@@ -1880,9 +1860,9 @@ namespace Raven.Server.Documents.Indexes
 
                 var configuration = new FaultyInMemoryIndexConfiguration(path, _documentDatabase.Configuration);
 
-                var faultyIndex = autoIndexDefinition != null
-                    ? new FaultyInMemoryIndex(e, name, configuration, CreateAutoDefinition(autoIndexDefinition, IndexDeploymentMode.Parallel))
-                    : new FaultyInMemoryIndex(e, name, configuration, staticIndexDefinition);
+                var faultyIndex = (indexDefinition is AutoIndexDefinition)
+                    ? new FaultyInMemoryIndex(e, name, configuration, CreateAutoDefinition((AutoIndexDefinition)indexDefinition, IndexDeploymentMode.Parallel))
+                    : new FaultyInMemoryIndex(e, name, configuration, (IndexDefinition)indexDefinition);
 
                 var message = $"Could not open index at '{indexPath}'. Created in-memory, fake instance: {faultyIndex.Name}";
 
@@ -2007,7 +1987,7 @@ namespace Raven.Server.Documents.Indexes
                     if (indexesToRemove.Contains(indexToCheck.Name))
                         continue;
 
-                    var definitionToCheck = (AutoIndexDefinitionBase)indexToCheck.Definition;
+                    var definitionToCheck = (AutoIndexDefinitionBaseServerSide)indexToCheck.Definition;
 
                     var result = dynamicQueryToIndex.ConsiderUsageOfIndex(query, definitionToCheck);
 
@@ -2249,8 +2229,8 @@ namespace Raven.Server.Documents.Indexes
                         {
                             using (newIndex.DrainRunningQueries())
                             {
-                                var oldIndexDirectoryName = IndexDefinitionBase.GetIndexNameSafeForFileSystem(oldIndexName);
-                                var replacementIndexDirectoryName = IndexDefinitionBase.GetIndexNameSafeForFileSystem(replacementIndexName);
+                                var oldIndexDirectoryName = IndexDefinitionBaseServerSide.GetIndexNameSafeForFileSystem(oldIndexName);
+                                var replacementIndexDirectoryName = IndexDefinitionBaseServerSide.GetIndexNameSafeForFileSystem(replacementIndexName);
 
                                 using (newIndex.RestartEnvironment())
                                 {
@@ -2419,7 +2399,7 @@ namespace Raven.Server.Documents.Indexes
                 _defaultStaticDeploymentMode = store._documentDatabase.Configuration.Indexing.StaticIndexDeploymentMode;
             }
 
-            public void AddIndex(IndexDefinitionBase definition, string source, DateTime createdAt, string raftRequestId, int revisionsToKeep)
+            public void AddIndex(IndexDefinitionBaseServerSide definition, string source, DateTime createdAt, string raftRequestId, int revisionsToKeep)
             {
                 if (_command == null)
                     _command = new PutIndexesCommand(_store._documentDatabase.Name, source, createdAt, raftRequestId, revisionsToKeep, _defaultAutoDeploymentMode, _defaultStaticDeploymentMode);
@@ -2435,7 +2415,7 @@ namespace Raven.Server.Documents.Indexes
 
                 _store.ValidateAutoIndex(definition);
 
-                var autoDefinition = (AutoIndexDefinitionBase)definition;
+                var autoDefinition = (AutoIndexDefinitionBaseServerSide)definition;
                 var indexType = PutAutoIndexCommand.GetAutoIndexType(autoDefinition);
 
                 _command.Auto.Add(PutAutoIndexCommand.GetAutoIndexDefinition(autoDefinition, indexType));

--- a/src/Raven.Server/Documents/Indexes/IndexStore.cs
+++ b/src/Raven.Server/Documents/Indexes/IndexStore.cs
@@ -1171,7 +1171,7 @@ namespace Raven.Server.Documents.Indexes
             if (indexDef != null)
             {
                 differences = existingIndex.Definition.Compare(indexDef);
-                if (indexDef._clusterState?.LastStateIndex > (existingIndex.Definition._clusterState?.LastStateIndex ?? -1))
+                if (indexDef.ClusterState?.LastStateIndex > (existingIndex.Definition._clusterState?.LastStateIndex ?? -1))
                 {
                     differences |= IndexDefinitionCompareDifferences.State;
                 }
@@ -1816,7 +1816,7 @@ namespace Raven.Server.Documents.Indexes
                     differences |= IndexDefinitionCompareDifferences.State;
 
                 index.Definition._clusterState ??= new ClusterState();
-                index.Definition._clusterState.LastStateIndex = (indexDefinition._clusterState?.LastStateIndex ?? 0);
+                index.Definition._clusterState.LastStateIndex = (indexDefinition.ClusterState?.LastStateIndex ?? 0);
 
                 if (differences != IndexDefinitionCompareDifferences.None)
                 {

--- a/src/Raven.Server/Documents/Indexes/MapIndexBase.cs
+++ b/src/Raven.Server/Documents/Indexes/MapIndexBase.cs
@@ -12,7 +12,7 @@ using Raven.Server.ServerWide.Context;
 
 namespace Raven.Server.Documents.Indexes
 {
-    public abstract class MapIndexBase<T, TField> : Index<T, TField> where T : IndexDefinitionBase<TField> where TField : IndexFieldBase
+    public abstract class MapIndexBase<T, TField> : Index<T, TField> where T : IndexDefinitionBaseServerSide<TField> where TField : IndexFieldBase
     {
         private CollectionOfBloomFilters _filters;
         private IndexingStatsScope _statsInstance;

--- a/src/Raven.Server/Documents/Indexes/MapReduce/Auto/AutoMapReduceIndex.cs
+++ b/src/Raven.Server/Documents/Indexes/MapReduce/Auto/AutoMapReduceIndex.cs
@@ -77,7 +77,7 @@ namespace Raven.Server.Documents.Indexes.MapReduce.Auto
             return new AutoIndexDocsEnumerator(items, stats);
         }
 
-        public override void Update(IndexDefinitionBase definition, IndexingConfiguration configuration)
+        public override void Update(IndexDefinitionBaseServerSide definition, IndexingConfiguration configuration)
         {
             SetPriority(definition.Priority);
         }

--- a/src/Raven.Server/Documents/Indexes/MapReduce/Auto/AutoMapReduceIndexDefinition.cs
+++ b/src/Raven.Server/Documents/Indexes/MapReduce/Auto/AutoMapReduceIndexDefinition.cs
@@ -10,7 +10,7 @@ using Voron;
 
 namespace Raven.Server.Documents.Indexes.MapReduce.Auto
 {
-    public class AutoMapReduceIndexDefinition : AutoIndexDefinitionBase
+    public class AutoMapReduceIndexDefinition : AutoIndexDefinitionBaseServerSide
     {
         public readonly Dictionary<string, AutoIndexField> GroupByFields;
 
@@ -126,7 +126,7 @@ namespace Raven.Server.Documents.Indexes.MapReduce.Auto
             return (hashCode * 397) ^ GroupByFields.GetDictionaryHashCode();
         }
 
-        public override IndexDefinitionCompareDifferences Compare(IndexDefinitionBase other)
+        public override IndexDefinitionCompareDifferences Compare(IndexDefinitionBaseServerSide other)
         {
             var otherDefinition = other as AutoMapReduceIndexDefinition;
             if (otherDefinition == null)

--- a/src/Raven.Server/Documents/Indexes/MapReduce/MapReduceIndexBase.cs
+++ b/src/Raven.Server/Documents/Indexes/MapReduce/MapReduceIndexBase.cs
@@ -19,7 +19,7 @@ using Voron.Util;
 
 namespace Raven.Server.Documents.Indexes.MapReduce
 {
-    public abstract class MapReduceIndexBase<T, TField> : Index<T, TField> where T : IndexDefinitionBase<TField> where TField : IndexFieldBase
+    public abstract class MapReduceIndexBase<T, TField> : Index<T, TField> where T : IndexDefinitionBaseServerSide<TField> where TField : IndexFieldBase
     {
         internal const string MapPhaseTreeName = "MapPhaseTree";
         internal const string ReducePhaseTreeName = "ReducePhaseTree";

--- a/src/Raven.Server/Documents/Indexes/MapReduce/ReduceKeyProcessor.cs
+++ b/src/Raven.Server/Documents/Indexes/MapReduce/ReduceKeyProcessor.cs
@@ -223,7 +223,7 @@ namespace Raven.Server.Documents.Indexes.MapReduce
                         _singleValueHash = (ulong)dbl;
                         break;
                     case Mode.MultipleValues:
-                        if (_indexVersion < IndexDefinitionBase.IndexVersion.ReduceKeyProcessorHashDoubleFix)
+                        if (_indexVersion < IndexDefinitionBaseServerSide.IndexVersion.ReduceKeyProcessorHashDoubleFix)
                         {
                             // we keep the previous behavior for old indexes, because it will keep the reduce buckets
                             CopyToBuffer((byte*)&d, sizeof(double));

--- a/src/Raven.Server/Documents/Indexes/MapReduce/ReduceMapResultsBase.cs
+++ b/src/Raven.Server/Documents/Indexes/MapReduce/ReduceMapResultsBase.cs
@@ -26,7 +26,7 @@ using Constants = Voron.Global.Constants;
 
 namespace Raven.Server.Documents.Indexes.MapReduce
 {
-    public abstract unsafe class ReduceMapResultsBase<T> : IIndexingWork where T : IndexDefinitionBase
+    public abstract unsafe class ReduceMapResultsBase<T> : IIndexingWork where T : IndexDefinitionBaseServerSide
     {
         private static readonly TimeSpan MinReduceDurationToCalculateProcessMemoryUsage = TimeSpan.FromSeconds(3);
         internal static readonly Slice PageNumberSlice;

--- a/src/Raven.Server/Documents/Indexes/MapReduce/Static/MapReduceIndex.cs
+++ b/src/Raven.Server/Documents/Indexes/MapReduce/Static/MapReduceIndex.cs
@@ -282,11 +282,11 @@ namespace Raven.Server.Documents.Indexes.MapReduce.Static
         {
             TStaticIndex instance;
             if (typeof(TStaticIndex) == typeof(MapReduceIndex))
-                instance = (TStaticIndex)CreateIndexInstance<MapReduceIndex>(definition, documentDatabase.Configuration, IndexDefinitionBase.IndexVersion.CurrentVersion, (staticMapIndexDefinition, staticIndex) => new MapReduceIndex(staticMapIndexDefinition, staticIndex));
+                instance = (TStaticIndex)CreateIndexInstance<MapReduceIndex>(definition, documentDatabase.Configuration, IndexDefinitionBaseServerSide.IndexVersion.CurrentVersion, (staticMapIndexDefinition, staticIndex) => new MapReduceIndex(staticMapIndexDefinition, staticIndex));
             else if (typeof(TStaticIndex) == typeof(MapReduceTimeSeriesIndex))
-                instance = (TStaticIndex)(MapReduceIndex)CreateIndexInstance<MapReduceTimeSeriesIndex>(definition, documentDatabase.Configuration, IndexDefinitionBase.IndexVersion.CurrentVersion, (staticMapIndexDefinition, staticIndex) => new MapReduceTimeSeriesIndex(staticMapIndexDefinition, staticIndex));
+                instance = (TStaticIndex)(MapReduceIndex)CreateIndexInstance<MapReduceTimeSeriesIndex>(definition, documentDatabase.Configuration, IndexDefinitionBaseServerSide.IndexVersion.CurrentVersion, (staticMapIndexDefinition, staticIndex) => new MapReduceTimeSeriesIndex(staticMapIndexDefinition, staticIndex));
             else if (typeof(TStaticIndex) == typeof(MapReduceCountersIndex))
-                instance = (TStaticIndex)(MapReduceIndex)CreateIndexInstance<MapReduceCountersIndex>(definition, documentDatabase.Configuration, IndexDefinitionBase.IndexVersion.CurrentVersion, (staticMapIndexDefinition, staticIndex) => new MapReduceCountersIndex(staticMapIndexDefinition, staticIndex));
+                instance = (TStaticIndex)(MapReduceIndex)CreateIndexInstance<MapReduceCountersIndex>(definition, documentDatabase.Configuration, IndexDefinitionBaseServerSide.IndexVersion.CurrentVersion, (staticMapIndexDefinition, staticIndex) => new MapReduceCountersIndex(staticMapIndexDefinition, staticIndex));
             else
                 throw new NotSupportedException($"Not supported index type {typeof(TStaticIndex).Name}");
 

--- a/src/Raven.Server/Documents/Indexes/Persistence/Lucene/IndexFacetedReadOperation.cs
+++ b/src/Raven.Server/Documents/Indexes/Persistence/Lucene/IndexFacetedReadOperation.cs
@@ -34,7 +34,7 @@ namespace Raven.Server.Documents.Indexes.Persistence.Lucene
         private readonly IState _state;
 
         public IndexFacetedReadOperation(Index index,
-            IndexDefinitionBase indexDefinition,
+            IndexDefinitionBaseServerSide indexDefinition,
             LuceneVoronDirectory directory,
             IndexSearcherHolder searcherHolder,
             QueryBuilderFactories queryBuilderFactories,

--- a/src/Raven.Server/Documents/Indexes/Persistence/Lucene/IndexOperationBase.cs
+++ b/src/Raven.Server/Documents/Indexes/Persistence/Lucene/IndexOperationBase.cs
@@ -36,7 +36,7 @@ namespace Raven.Server.Documents.Indexes.Persistence.Lucene
             _logger = logger;
         }
 
-        protected static RavenPerFieldAnalyzerWrapper CreateAnalyzer(Index index, IndexDefinitionBase indexDefinition, bool forQuerying = false)
+        protected static RavenPerFieldAnalyzerWrapper CreateAnalyzer(Index index, IndexDefinitionBaseServerSide indexDefinition, bool forQuerying = false)
         {
             if (indexDefinition.IndexFields.ContainsKey(Constants.Documents.Indexing.Fields.AllFields))
                 throw new InvalidOperationException($"Detected '{Constants.Documents.Indexing.Fields.AllFields}'. This field should not be present here, because inheritance is done elsewhere.");

--- a/src/Raven.Server/Documents/Indexes/Static/Counters/MapCountersIndex.cs
+++ b/src/Raven.Server/Documents/Indexes/Static/Counters/MapCountersIndex.cs
@@ -203,7 +203,7 @@ namespace Raven.Server.Documents.Indexes.Static.Counters
 
         public static Index CreateNew(IndexDefinition definition, DocumentDatabase documentDatabase)
         {
-            var instance = CreateIndexInstance(definition, documentDatabase.Configuration, IndexDefinitionBase.IndexVersion.CurrentVersion);
+            var instance = CreateIndexInstance(definition, documentDatabase.Configuration, IndexDefinitionBaseServerSide.IndexVersion.CurrentVersion);
             instance.Initialize(documentDatabase,
                 new SingleIndexConfiguration(definition.Configuration, documentDatabase.Configuration),
                 documentDatabase.Configuration.PerformanceHints);

--- a/src/Raven.Server/Documents/Indexes/Static/CurrentIndexingScope.cs
+++ b/src/Raven.Server/Documents/Indexes/Static/CurrentIndexingScope.cs
@@ -54,11 +54,11 @@ namespace Raven.Server.Documents.Indexes.Static
 
         public readonly TransactionOperationContext IndexContext;
 
-        public readonly IndexDefinitionBase IndexDefinition;
+        public readonly IndexDefinitionBaseServerSide IndexDefinition;
 
         public LuceneDocumentConverter CreateFieldConverter;
 
-        public CurrentIndexingScope(Index index, DocumentsStorage documentsStorage, QueryOperationContext queryContext, IndexDefinitionBase indexDefinition, TransactionOperationContext indexContext, Func<string, SpatialField> getSpatialField, UnmanagedBuffersPoolWithLowMemoryHandling _unmanagedBuffersPool)
+        public CurrentIndexingScope(Index index, DocumentsStorage documentsStorage, QueryOperationContext queryContext, IndexDefinitionBaseServerSide indexDefinition, TransactionOperationContext indexContext, Func<string, SpatialField> getSpatialField, UnmanagedBuffersPoolWithLowMemoryHandling _unmanagedBuffersPool)
         {
             _documentsStorage = documentsStorage;
             QueryContext = queryContext;

--- a/src/Raven.Server/Documents/Indexes/Static/MapIndex.cs
+++ b/src/Raven.Server/Documents/Indexes/Static/MapIndex.cs
@@ -178,7 +178,7 @@ namespace Raven.Server.Documents.Indexes.Static
 
         public static Index CreateNew(IndexDefinition definition, DocumentDatabase documentDatabase)
         {
-            var instance = CreateIndexInstance(definition, documentDatabase.Configuration, IndexDefinitionBase.IndexVersion.CurrentVersion);
+            var instance = CreateIndexInstance(definition, documentDatabase.Configuration, IndexDefinitionBaseServerSide.IndexVersion.CurrentVersion);
             instance.Initialize(documentDatabase,
                 new SingleIndexConfiguration(definition.Configuration, documentDatabase.Configuration),
                 documentDatabase.Configuration.PerformanceHints);

--- a/src/Raven.Server/Documents/Indexes/Static/MapIndexDefinition.cs
+++ b/src/Raven.Server/Documents/Indexes/Static/MapIndexDefinition.cs
@@ -12,7 +12,7 @@ using Voron;
 
 namespace Raven.Server.Documents.Indexes.Static
 {
-    public class MapIndexDefinition : IndexDefinitionBase<IndexField>
+    public class MapIndexDefinition : IndexDefinitionBaseServerSide<IndexField>
     {
         private readonly bool _hasDynamicFields;
         private readonly bool _hasCompareExchange;
@@ -20,7 +20,7 @@ namespace Raven.Server.Documents.Indexes.Static
         public readonly IndexDefinition IndexDefinition;
 
         public MapIndexDefinition(IndexDefinition definition, IEnumerable<string> collections, string[] outputFields, bool hasDynamicFields, bool hasCompareExchange, long indexVersion)
-            : base(definition.Name, collections, definition.LockMode ?? IndexLockMode.Unlock, definition.Priority ?? IndexPriority.Normal, definition.State ??IndexState.Normal, GetFields(definition, outputFields), indexVersion, definition.DeploymentMode)
+            : base(definition.Name, collections, definition.LockMode ?? IndexLockMode.Unlock, definition.Priority ?? IndexPriority.Normal, definition.State ??IndexState.Normal, GetFields(definition, outputFields), indexVersion, definition.DeploymentMode, definition._clusterState?.LastStateIndex)
         {
             _hasDynamicFields = hasDynamicFields;
             _hasCompareExchange = hasCompareExchange;
@@ -99,7 +99,7 @@ namespace Raven.Server.Documents.Indexes.Static
             return definition;
         }
 
-        public override IndexDefinitionCompareDifferences Compare(IndexDefinitionBase indexDefinition)
+        public override IndexDefinitionCompareDifferences Compare(IndexDefinitionBaseServerSide indexDefinition)
         {
             return IndexDefinitionCompareDifferences.All;
         }

--- a/src/Raven.Server/Documents/Indexes/Static/MapIndexDefinition.cs
+++ b/src/Raven.Server/Documents/Indexes/Static/MapIndexDefinition.cs
@@ -20,7 +20,7 @@ namespace Raven.Server.Documents.Indexes.Static
         public readonly IndexDefinition IndexDefinition;
 
         public MapIndexDefinition(IndexDefinition definition, IEnumerable<string> collections, string[] outputFields, bool hasDynamicFields, bool hasCompareExchange, long indexVersion)
-            : base(definition.Name, collections, definition.LockMode ?? IndexLockMode.Unlock, definition.Priority ?? IndexPriority.Normal, definition.State ??IndexState.Normal, GetFields(definition, outputFields), indexVersion, definition.DeploymentMode, definition._clusterState?.LastStateIndex)
+            : base(definition.Name, collections, definition.LockMode ?? IndexLockMode.Unlock, definition.Priority ?? IndexPriority.Normal, definition.State ??IndexState.Normal, GetFields(definition, outputFields), indexVersion, definition.DeploymentMode, definition.ClusterState?.LastStateIndex)
         {
             _hasDynamicFields = hasDynamicFields;
             _hasCompareExchange = hasCompareExchange;

--- a/src/Raven.Server/Documents/Indexes/Static/TimeSeries/MapTimeSeriesIndex.cs
+++ b/src/Raven.Server/Documents/Indexes/Static/TimeSeries/MapTimeSeriesIndex.cs
@@ -225,7 +225,7 @@ namespace Raven.Server.Documents.Indexes.Static.TimeSeries
 
         public static Index CreateNew(IndexDefinition definition, DocumentDatabase documentDatabase)
         {
-            var instance = CreateIndexInstance(definition, documentDatabase.Configuration, IndexDefinitionBase.IndexVersion.CurrentVersion);
+            var instance = CreateIndexInstance(definition, documentDatabase.Configuration, IndexDefinitionBaseServerSide.IndexVersion.CurrentVersion);
             instance.Initialize(documentDatabase,
                 new SingleIndexConfiguration(definition.Configuration, documentDatabase.Configuration),
                 documentDatabase.Configuration.PerformanceHints);

--- a/src/Raven.Server/Documents/PeriodicBackup/Restore/RestoreBackupTaskBase.cs
+++ b/src/Raven.Server/Documents/PeriodicBackup/Restore/RestoreBackupTaskBase.cs
@@ -667,7 +667,7 @@ namespace Raven.Server.Documents.PeriodicBackup.Restore
                     {
                         case IndexType.AutoMap:
                         case IndexType.AutoMapReduce:
-                            var autoIndexDefinition = (AutoIndexDefinitionBase)indexAndType.IndexDefinition;
+                            var autoIndexDefinition = (AutoIndexDefinitionBaseServerSide)indexAndType.IndexDefinition;
                             databaseRecord.AutoIndexes[autoIndexDefinition.Name] =
                                 PutAutoIndexCommand.GetAutoIndexDefinition(autoIndexDefinition, indexAndType.Type);
                             break;

--- a/src/Raven.Server/Documents/Queries/Dynamic/DynamicQueryMapping.cs
+++ b/src/Raven.Server/Documents/Queries/Dynamic/DynamicQueryMapping.cs
@@ -26,7 +26,7 @@ namespace Raven.Server.Documents.Queries.Dynamic
 
         public List<Index> SupersededIndexes;
 
-        public AutoIndexDefinitionBase CreateAutoIndexDefinition()
+        public AutoIndexDefinitionBaseServerSide CreateAutoIndexDefinition()
         {
             if (IsGroupBy == false)
             {
@@ -115,7 +115,7 @@ namespace Raven.Server.Documents.Queries.Dynamic
                 }).ToArray(), deploymentMode: null);
         }
 
-        public void ExtendMappingBasedOn(AutoIndexDefinitionBase definitionOfExistingIndex)
+        public void ExtendMappingBasedOn(AutoIndexDefinitionBaseServerSide definitionOfExistingIndex)
         {
             Debug.Assert(definitionOfExistingIndex is AutoMapIndexDefinition || definitionOfExistingIndex is AutoMapReduceIndexDefinition, "Dynamic queries are handled only by auto indexes");
 
@@ -276,7 +276,7 @@ namespace Raven.Server.Documents.Queries.Dynamic
                 MapFields = new Dictionary<string, DynamicQueryMappingItem>(StringComparer.Ordinal)
             };
 
-            var definition = (AutoIndexDefinitionBase)index.Definition;
+            var definition = (AutoIndexDefinitionBaseServerSide)index.Definition;
 
             foreach (var field in definition.MapFields)
             {

--- a/src/Raven.Server/Documents/Queries/Dynamic/DynamicQueryRunner.cs
+++ b/src/Raven.Server/Documents/Queries/Dynamic/DynamicQueryRunner.cs
@@ -317,7 +317,7 @@ namespace Raven.Server.Documents.Queries.Dynamic
 
                         map.SupersededIndexes.Add(currentIndex);
 
-                        map.ExtendMappingBasedOn((AutoIndexDefinitionBase)currentIndex.Definition);
+                        map.ExtendMappingBasedOn((AutoIndexDefinitionBaseServerSide)currentIndex.Definition);
                     }
 
                     break;

--- a/src/Raven.Server/Documents/Queries/Dynamic/DynamicQueryToIndexMatcher.cs
+++ b/src/Raven.Server/Documents/Queries/Dynamic/DynamicQueryToIndexMatcher.cs
@@ -81,7 +81,7 @@ namespace Raven.Server.Documents.Queries.Dynamic
                 else if (index.Type != IndexType.AutoMap)
                     continue;
 
-                var auto = (AutoIndexDefinitionBase)index.Definition;
+                var auto = (AutoIndexDefinitionBaseServerSide)index.Definition;
 
                 var result = ConsiderUsageOfIndex(query, auto, explanations);
 
@@ -159,7 +159,7 @@ namespace Raven.Server.Documents.Queries.Dynamic
             return prioritizedResults[0];
         }
 
-        internal DynamicQueryMatchResult ConsiderUsageOfIndex(DynamicQueryMapping query, AutoIndexDefinitionBase definition, List<Explanation> explanations = null)
+        internal DynamicQueryMatchResult ConsiderUsageOfIndex(DynamicQueryMapping query, AutoIndexDefinitionBaseServerSide definition, List<Explanation> explanations = null)
         {
             var collection = query.ForCollection;
             var indexName = definition.Name;

--- a/src/Raven.Server/Documents/Queries/FieldsToFetch.cs
+++ b/src/Raven.Server/Documents/Queries/FieldsToFetch.cs
@@ -33,7 +33,7 @@ namespace Raven.Server.Documents.Queries
 
         public readonly ProjectionOptions Projection;
 
-        public FieldsToFetch(IndexQueryServerSide query, IndexDefinitionBase indexDefinition)
+        public FieldsToFetch(IndexQueryServerSide query, IndexDefinitionBaseServerSide indexDefinition)
         {
             Projection = new ProjectionOptions(query);
 
@@ -53,7 +53,7 @@ namespace Raven.Server.Documents.Queries
         }
 
         private static FieldToFetch GetFieldToFetch(
-            IndexDefinitionBase indexDefinition,
+            IndexDefinitionBaseServerSide indexDefinition,
             QueryMetadata metadata,
             ProjectionBehavior? projectionBehavior,
             SelectField selectField,
@@ -213,7 +213,7 @@ namespace Raven.Server.Documents.Queries
         private static Dictionary<string, FieldToFetch> GetFieldsToFetch(
             QueryMetadata metadata,
             ProjectionBehavior? projectionBehavior,
-            IndexDefinitionBase indexDefinition,
+            IndexDefinitionBaseServerSide indexDefinition,
             out bool anyExtractableFromIndex,
             out bool extractAllStoredFields,
             out bool singleFieldNoAlias,

--- a/src/Raven.Server/Documents/Queries/QueryBuilder.cs
+++ b/src/Raven.Server/Documents/Queries/QueryBuilder.cs
@@ -551,16 +551,16 @@ namespace Raven.Server.Documents.Queries
             switch (value)
             {
                 case LazyStringValue lsv:
-                    result = LazyStringParser.TryParseDateTime(lsv.Buffer, lsv.Size, out dt, out dto, index.Definition.Version >= IndexDefinitionBase.IndexVersion.ProperlyParseThreeDigitsMillisecondsDates);
+                    result = LazyStringParser.TryParseDateTime(lsv.Buffer, lsv.Size, out dt, out dto, index.Definition.Version >= IndexDefinitionBaseServerSide.IndexVersion.ProperlyParseThreeDigitsMillisecondsDates);
                     break;
                 case string valueAsString:
                     fixed (char* buffer = valueAsString)
-                        result = LazyStringParser.TryParseDateTime(buffer, valueAsString.Length, out dt, out dto, index.Definition.Version >= IndexDefinitionBase.IndexVersion.ProperlyParseThreeDigitsMillisecondsDates);
+                        result = LazyStringParser.TryParseDateTime(buffer, valueAsString.Length, out dt, out dto, index.Definition.Version >= IndexDefinitionBaseServerSide.IndexVersion.ProperlyParseThreeDigitsMillisecondsDates);
                     break;
                 default:
                     var otherAsString = value.ToString();
                     fixed (char* buffer = otherAsString)
-                        result = LazyStringParser.TryParseDateTime(buffer, otherAsString.Length, out dt, out dto, index.Definition.Version >= IndexDefinitionBase.IndexVersion.ProperlyParseThreeDigitsMillisecondsDates);
+                        result = LazyStringParser.TryParseDateTime(buffer, otherAsString.Length, out dt, out dto, index.Definition.Version >= IndexDefinitionBaseServerSide.IndexVersion.ProperlyParseThreeDigitsMillisecondsDates);
                     break;
             }
 

--- a/src/Raven.Server/Documents/Queries/QueryBuilder.cs
+++ b/src/Raven.Server/Documents/Queries/QueryBuilder.cs
@@ -519,7 +519,7 @@ namespace Raven.Server.Documents.Queries
             ticksFirst = -1;
             ticksSecond = -1;
 
-            if (exact || index == null || valueFirst == null || valueSecond == null || index.Definition.Version < IndexDefinitionBase.IndexVersion.TimeTicks)
+            if (exact || index == null || valueFirst == null || valueSecond == null || index.Definition.Version < IndexDefinitionBaseServerSide.IndexVersion.TimeTicks)
                 return false;
 
             if (index.IndexFieldsPersistence.HasTimeValues(fieldName) && TryGetTime(index,valueFirst, out ticksFirst) && TryGetTime(index,valueSecond, out ticksSecond))
@@ -532,7 +532,7 @@ namespace Raven.Server.Documents.Queries
         {
             ticks = -1;
 
-            if (exact || index == null || value == null || index.Definition.Version < IndexDefinitionBase.IndexVersion.TimeTicks)
+            if (exact || index == null || value == null || index.Definition.Version < IndexDefinitionBaseServerSide.IndexVersion.TimeTicks)
                 return false;
 
             if (index.IndexFieldsPersistence.HasTimeValues(fieldName) && TryGetTime(index, value, out ticks))

--- a/src/Raven.Server/Extensions/JsonSerializationExtensions.cs
+++ b/src/Raven.Server/Extensions/JsonSerializationExtensions.cs
@@ -26,9 +26,9 @@ namespace Raven.Server.Extensions
             result[nameof(IndexDefinition.Reduce)] = definition.Reduce;
             result[nameof(IndexDefinition.Type)] = definition.Type.ToString();
             result[nameof(IndexDefinition.Maps)] = new DynamicJsonArray(definition.Maps);
-            result[nameof(IndexDefinition._clusterState)] = new DynamicJsonValue()
+            result[nameof(IndexDefinition.ClusterState)] = new DynamicJsonValue()
             {
-                [nameof(IndexDefinition._clusterState.LastStateIndex)] = definition._clusterState?.LastStateIndex ?? 0
+                [nameof(IndexDefinition.ClusterState.LastStateIndex)] = definition.ClusterState?.LastStateIndex ?? 0
             };
 
             var fields = new DynamicJsonValue();

--- a/src/Raven.Server/Extensions/JsonSerializationExtensions.cs
+++ b/src/Raven.Server/Extensions/JsonSerializationExtensions.cs
@@ -26,6 +26,10 @@ namespace Raven.Server.Extensions
             result[nameof(IndexDefinition.Reduce)] = definition.Reduce;
             result[nameof(IndexDefinition.Type)] = definition.Type.ToString();
             result[nameof(IndexDefinition.Maps)] = new DynamicJsonArray(definition.Maps);
+            result[nameof(IndexDefinition._clusterState)] = new DynamicJsonValue()
+            {
+                [nameof(IndexDefinition._clusterState.LastStateIndex)] = definition._clusterState?.LastStateIndex ?? 0
+            };
 
             var fields = new DynamicJsonValue();
             foreach (var kvp in definition.Fields)

--- a/src/Raven.Server/ServerWide/Commands/Indexes/PutAutoIndexCommand.cs
+++ b/src/Raven.Server/ServerWide/Commands/Indexes/PutAutoIndexCommand.cs
@@ -53,14 +53,14 @@ namespace Raven.Server.ServerWide.Commands.Indexes
             json[nameof(DefaultStaticDeploymentMode)] = TypeConverter.ToBlittableSupportedType(DefaultStaticDeploymentMode);
         }
 
-        public static PutAutoIndexCommand Create(AutoIndexDefinitionBase definition, string databaseName, string raftRequestId, IndexDeploymentMode mode)
+        public static PutAutoIndexCommand Create(AutoIndexDefinitionBaseServerSide definition, string databaseName, string raftRequestId, IndexDeploymentMode mode)
         {
             var indexType = GetAutoIndexType(definition);
 
             return new PutAutoIndexCommand(GetAutoIndexDefinition(definition, indexType), databaseName, raftRequestId, mode, SystemTime.UtcNow);
         }
 
-        public static IndexType GetAutoIndexType(AutoIndexDefinitionBase definition)
+        public static IndexType GetAutoIndexType(AutoIndexDefinitionBaseServerSide definition)
         {
             var indexType = IndexType.None;
             if (definition is AutoMapIndexDefinition)
@@ -75,7 +75,7 @@ namespace Raven.Server.ServerWide.Commands.Indexes
             return indexType;
         }
 
-        public static AutoIndexDefinition GetAutoIndexDefinition(AutoIndexDefinitionBase definition, IndexType indexType)
+        public static AutoIndexDefinition GetAutoIndexDefinition(AutoIndexDefinitionBaseServerSide definition, IndexType indexType)
         {
             Debug.Assert(indexType == IndexType.AutoMap || indexType == IndexType.AutoMapReduce);
 

--- a/src/Raven.Server/ServerWide/Commands/Indexes/PutIndexCommand.cs
+++ b/src/Raven.Server/ServerWide/Commands/Indexes/PutIndexCommand.cs
@@ -27,7 +27,7 @@ namespace Raven.Server.ServerWide.Commands.Indexes
             : base(databaseName, uniqueRequestId)
         {
             Definition = definition;
-            Definition._clusterState ??= new ClusterState();
+            Definition.ClusterState ??= new ClusterState();
             Source = source;
             CreatedAt = createdAt;
             RevisionsToKeep = revisionsToKeep;

--- a/src/Raven.Server/ServerWide/Commands/Indexes/PutIndexCommand.cs
+++ b/src/Raven.Server/ServerWide/Commands/Indexes/PutIndexCommand.cs
@@ -3,8 +3,7 @@ using System.Collections.Generic;
 using System.Linq;
 using Raven.Client.Documents.Indexes;
 using Raven.Client.ServerWide;
-using Raven.Server.Config;
-using Raven.Server.Documents.Indexes;
+using Raven.Server.Extensions;
 using Raven.Server.Rachis;
 using Raven.Server.Utils;
 using Sparrow;
@@ -28,6 +27,7 @@ namespace Raven.Server.ServerWide.Commands.Indexes
             : base(databaseName, uniqueRequestId)
         {
             Definition = definition;
+            Definition._clusterState ??= new ClusterState();
             Source = source;
             CreatedAt = createdAt;
             RevisionsToKeep = revisionsToKeep;
@@ -62,7 +62,7 @@ namespace Raven.Server.ServerWide.Commands.Indexes
 
         public override void FillJson(DynamicJsonValue json)
         {
-            json[nameof(Definition)] = TypeConverter.ToBlittableSupportedType(Definition);
+            json[nameof(Definition)] = Definition.ToJson();
             json[nameof(Source)] = Source;
             json[nameof(CreatedAt)] = CreatedAt;
             json[nameof(RevisionsToKeep)] = RevisionsToKeep;

--- a/src/Raven.Server/ServerWide/Commands/Indexes/SetIndexStateCommand.cs
+++ b/src/Raven.Server/ServerWide/Commands/Indexes/SetIndexStateCommand.cs
@@ -32,10 +32,14 @@ namespace Raven.Server.ServerWide.Commands.Indexes
             if (record.AutoIndexes.TryGetValue(IndexName, out AutoIndexDefinition autoIndex))
             {
                 autoIndex.State = State;
+                autoIndex._clusterState ??= new ClusterState();
+                autoIndex._clusterState.LastStateIndex = etag;
             }
             else if (record.Indexes.TryGetValue(IndexName, out IndexDefinition indexDefinition))
             {
                 indexDefinition.State = State;
+                indexDefinition._clusterState ??= new ClusterState();
+                indexDefinition._clusterState.LastStateIndex = etag;
             }
 
         }

--- a/src/Raven.Server/ServerWide/Commands/Indexes/SetIndexStateCommand.cs
+++ b/src/Raven.Server/ServerWide/Commands/Indexes/SetIndexStateCommand.cs
@@ -32,14 +32,14 @@ namespace Raven.Server.ServerWide.Commands.Indexes
             if (record.AutoIndexes.TryGetValue(IndexName, out AutoIndexDefinition autoIndex))
             {
                 autoIndex.State = State;
-                autoIndex._clusterState ??= new ClusterState();
-                autoIndex._clusterState.LastStateIndex = etag;
+                autoIndex.ClusterState ??= new ClusterState();
+                autoIndex.ClusterState.LastStateIndex = etag;
             }
             else if (record.Indexes.TryGetValue(IndexName, out IndexDefinition indexDefinition))
             {
                 indexDefinition.State = State;
-                indexDefinition._clusterState ??= new ClusterState();
-                indexDefinition._clusterState.LastStateIndex = etag;
+                indexDefinition.ClusterState ??= new ClusterState();
+                indexDefinition.ClusterState.LastStateIndex = etag;
             }
 
         }

--- a/src/Raven.Server/Smuggler/Documents/Data/ISmugglerDestination.cs
+++ b/src/Raven.Server/Smuggler/Documents/Data/ISmugglerDestination.cs
@@ -73,7 +73,7 @@ namespace Raven.Server.Smuggler.Documents.Data
 
     public interface IIndexActions : IAsyncDisposable
     {
-        ValueTask WriteIndexAsync(IndexDefinitionBase indexDefinition, IndexType indexType);
+        ValueTask WriteIndexAsync(IndexDefinitionBaseServerSide indexDefinition, IndexType indexType);
 
         ValueTask WriteIndexAsync(IndexDefinition indexDefinition);
     }

--- a/src/Raven.Server/Smuggler/Documents/DatabaseDestination.cs
+++ b/src/Raven.Server/Smuggler/Documents/DatabaseDestination.cs
@@ -160,7 +160,7 @@ namespace Raven.Server.Smuggler.Documents
                     _batch = _database.IndexStore.CreateIndexBatch();
             }
 
-            public async ValueTask WriteIndexAsync(IndexDefinitionBase indexDefinition, IndexType indexType)
+            public async ValueTask WriteIndexAsync(IndexDefinitionBaseServerSide indexDefinition, IndexType indexType)
             {
                 if (_batch != null)
                 {

--- a/src/Raven.Server/Smuggler/Documents/StreamDestination.cs
+++ b/src/Raven.Server/Smuggler/Documents/StreamDestination.cs
@@ -740,7 +740,7 @@ namespace Raven.Server.Smuggler.Documents
                 _context = context;
             }
 
-            public async ValueTask WriteIndexAsync(IndexDefinitionBase indexDefinition, IndexType indexType)
+            public async ValueTask WriteIndexAsync(IndexDefinitionBaseServerSide indexDefinition, IndexType indexType)
             {
                 if (First == false)
                     Writer.WriteComma();

--- a/src/Raven.Server/Web/Studio/StudioIndexHandler.cs
+++ b/src/Raven.Server/Web/Studio/StudioIndexHandler.cs
@@ -74,7 +74,7 @@ namespace Raven.Server.Web.Studio
 
                     try
                     {
-                        var compiledIndex = IndexCompilationCache.GetIndexInstance(indexDefinition, Database.Configuration, IndexDefinitionBase.IndexVersion.CurrentVersion);
+                        var compiledIndex = IndexCompilationCache.GetIndexInstance(indexDefinition, Database.Configuration, IndexDefinitionBaseServerSide.IndexVersion.CurrentVersion);
 
                         var outputFields = compiledIndex.OutputFields;
 

--- a/src/Raven.Server/Web/System/AdminDatabasesHandler.cs
+++ b/src/Raven.Server/Web/System/AdminDatabasesHandler.cs
@@ -333,7 +333,7 @@ namespace Raven.Server.Web.System
                         {
                             case IndexType.AutoMap:
                             case IndexType.AutoMapReduce:
-                                var autoIndexDefinition = PutAutoIndexCommand.GetAutoIndexDefinition((AutoIndexDefinitionBase)definition, index.Type);
+                                var autoIndexDefinition = PutAutoIndexCommand.GetAutoIndexDefinition((AutoIndexDefinitionBaseServerSide)definition, index.Type);
                                 databaseRecord.AutoIndexes.Add(autoIndexDefinition.Name, autoIndexDefinition);
                                 break;
 

--- a/src/Sparrow/Json/ForceJsonSerializationAttribute.cs
+++ b/src/Sparrow/Json/ForceJsonSerializationAttribute.cs
@@ -6,7 +6,7 @@ namespace Sparrow.Json
     /// Instructs the <see cref="JsonDeserializationBase"/> to serialize nonPublic field .
     /// </summary>
     [AttributeUsage(AttributeTargets.Field | AttributeTargets.Property)]
-    internal sealed class JsonDeserializationNoIgnoreAttribute : Attribute
+    internal sealed class ForceJsonSerializationAttribute : Attribute
     {
     }
 }

--- a/src/Sparrow/Json/JsonDeserializationBase.cs
+++ b/src/Sparrow/Json/JsonDeserializationBase.cs
@@ -75,7 +75,7 @@ namespace Sparrow.Json
                 };
                 foreach (var fieldInfo in typeof(T).GetFields(BindingFlags.Public | BindingFlags.NonPublic | BindingFlags.Instance))
                 {
-                    if ((fieldInfo.IsPublic == false) && (fieldInfo.IsDefined(typeof(JsonDeserializationNoIgnoreAttribute)) == false))
+                    if ((fieldInfo.IsPublic == false) && (fieldInfo.IsDefined(typeof(ForceJsonSerializationAttribute)) == false))
                         continue;
 
                     if (fieldInfo.IsStatic || fieldInfo.IsDefined(typeof(JsonDeserializationIgnoreAttribute)))
@@ -92,7 +92,7 @@ namespace Sparrow.Json
                 foreach (var propertyInfo in typeof(T).GetProperties(BindingFlags.Static | BindingFlags.Public | BindingFlags.NonPublic | BindingFlags.Instance))
                 {
                     if ((propertyInfo.GetGetMethod(true)?.IsPublic == false) &&
-                        propertyInfo.IsDefined(typeof(JsonDeserializationNoIgnoreAttribute)) == false)
+                        propertyInfo.IsDefined(typeof(ForceJsonSerializationAttribute)) == false)
                         continue;
 
                     if (propertyInfo.CanWrite == false || propertyInfo.IsDefined(typeof(JsonDeserializationIgnoreAttribute)))

--- a/src/Sparrow/Json/JsonDeserializationBase.cs
+++ b/src/Sparrow/Json/JsonDeserializationBase.cs
@@ -73,8 +73,11 @@ namespace Sparrow.Json
                 {
                     assign
                 };
-                foreach (var fieldInfo in typeof(T).GetFields())
+                foreach (var fieldInfo in typeof(T).GetFields(BindingFlags.Public | BindingFlags.NonPublic | BindingFlags.Instance))
                 {
+                    if ((fieldInfo.IsPublic == false) && (fieldInfo.IsDefined(typeof(JsonDeserializationNoIgnoreAttribute)) == false))
+                        continue;
+
                     if (fieldInfo.IsStatic || fieldInfo.IsDefined(typeof(JsonDeserializationIgnoreAttribute)))
                         continue;
 
@@ -86,8 +89,12 @@ namespace Sparrow.Json
                     SetValue(fieldInfo.FieldType, access, fieldValue);
                 }
 
-                foreach (var propertyInfo in typeof(T).GetProperties())
+                foreach (var propertyInfo in typeof(T).GetProperties(BindingFlags.Static | BindingFlags.Public | BindingFlags.NonPublic | BindingFlags.Instance))
                 {
+                    if ((propertyInfo.GetGetMethod(true)?.IsPublic == false) &&
+                        propertyInfo.IsDefined(typeof(JsonDeserializationNoIgnoreAttribute)) == false)
+                        continue;
+
                     if (propertyInfo.CanWrite == false || propertyInfo.IsDefined(typeof(JsonDeserializationIgnoreAttribute)))
                         continue;
 

--- a/src/Sparrow/Json/JsonDeserializationNoIgnoreAttribute.cs
+++ b/src/Sparrow/Json/JsonDeserializationNoIgnoreAttribute.cs
@@ -1,0 +1,12 @@
+﻿using System;
+
+namespace Sparrow.Json
+{
+    /// <summary>
+    /// Instructs the <see cref="JsonDeserializationBase"/> to serialize nonPublic field .
+    /// </summary>
+    [AttributeUsage(AttributeTargets.Field | AttributeTargets.Property)]
+    internal sealed class JsonDeserializationNoIgnoreAttribute : Attribute
+    {
+    }
+}

--- a/test/FastTests/Client/Indexing/IndexesFromClient.cs
+++ b/test/FastTests/Client/Indexing/IndexesFromClient.cs
@@ -505,7 +505,7 @@ namespace FastTests.Client.Indexing
                     }, new HashSet<string>()
                     {
                         "Posts"
-                    }, new[] { "Title", "Desc" }, false, false, IndexDefinitionBase.IndexVersion.CurrentVersion), Guid.NewGuid().ToString());
+                    }, new[] { "Title", "Desc" }, false, false, IndexDefinitionBaseServerSide.IndexVersion.CurrentVersion), Guid.NewGuid().ToString());
 
                     WaitForIndexing(store);
 

--- a/test/FastTests/Server/Documents/Indexing/Auto/BasicAutoMapIndexing.cs
+++ b/test/FastTests/Server/Documents/Indexing/Auto/BasicAutoMapIndexing.cs
@@ -156,7 +156,7 @@ namespace FastTests.Server.Documents.Indexing.Auto
                 await database.IndexStore.CreateIndex(
                     def1, Guid.NewGuid().ToString());
             var path1 = Path.Combine(database.Configuration.Indexing.StoragePath.FullPath,
-                IndexDefinitionBase.GetIndexNameSafeForFileSystem(def1.Name));
+                IndexDefinitionBaseServerSide.GetIndexNameSafeForFileSystem(def1.Name));
 
             if (database.Configuration.Core.RunInMemory == false)
                 Assert.True(Directory.Exists(path1));
@@ -166,7 +166,7 @@ namespace FastTests.Server.Documents.Indexing.Auto
                 await database.IndexStore.CreateIndex(
                     def2, Guid.NewGuid().ToString());
             var path2 = Path.Combine(database.Configuration.Indexing.StoragePath.FullPath,
-                IndexDefinitionBase.GetIndexNameSafeForFileSystem(def2.Name));
+                IndexDefinitionBaseServerSide.GetIndexNameSafeForFileSystem(def2.Name));
 
             if (database.Configuration.Core.RunInMemory == false)
                 Assert.True(Directory.Exists(path2));
@@ -208,7 +208,7 @@ namespace FastTests.Server.Documents.Indexing.Auto
             var index1 = await database.IndexStore.CreateIndex(def1, Guid.NewGuid().ToString());
 
             var path1 = Path.Combine(database.Configuration.Indexing.StoragePath.FullPath,
-                IndexDefinitionBase.GetIndexNameSafeForFileSystem(def1.Name));
+                IndexDefinitionBaseServerSide.GetIndexNameSafeForFileSystem(def1.Name));
 
             if (database.Configuration.Core.RunInMemory == false)
                 Assert.True(Directory.Exists(path1));
@@ -216,7 +216,7 @@ namespace FastTests.Server.Documents.Indexing.Auto
             var def2 = new AutoMapIndexDefinition("Users", new[] { new AutoIndexField { Name = "Name2" } });
             var index2 = await database.IndexStore.CreateIndex(def2, Guid.NewGuid().ToString());
             var path2 = Path.Combine(database.Configuration.Indexing.StoragePath.FullPath,
-                IndexDefinitionBase.GetIndexNameSafeForFileSystem(def2.Name));
+                IndexDefinitionBaseServerSide.GetIndexNameSafeForFileSystem(def2.Name));
 
             if (database.Configuration.Core.RunInMemory == false)
                 Assert.True(Directory.Exists(path2));
@@ -225,7 +225,7 @@ namespace FastTests.Server.Documents.Indexing.Auto
             Assert.Equal(2, indexesAfterReset.Count());
 
             var index3 = database.IndexStore.ResetIndex(index1.Name);
-            var path3 = Path.Combine(database.Configuration.Indexing.StoragePath.FullPath, IndexDefinitionBase.GetIndexNameSafeForFileSystem(def1.Name));
+            var path3 = Path.Combine(database.Configuration.Indexing.StoragePath.FullPath, IndexDefinitionBaseServerSide.GetIndexNameSafeForFileSystem(def1.Name));
 
             if (database.Configuration.Core.RunInMemory == false)
                 Assert.True(Directory.Exists(path3));
@@ -235,7 +235,7 @@ namespace FastTests.Server.Documents.Indexing.Auto
             Assert.Equal(2, indexes.Count);
 
             var index4 = database.IndexStore.ResetIndex(index2.Name);
-            var path4 = Path.Combine(database.Configuration.Indexing.StoragePath.FullPath, IndexDefinitionBase.GetIndexNameSafeForFileSystem(def2.Name));
+            var path4 = Path.Combine(database.Configuration.Indexing.StoragePath.FullPath, IndexDefinitionBaseServerSide.GetIndexNameSafeForFileSystem(def2.Name));
 
             if (database.Configuration.Core.RunInMemory == false)
                 Assert.True(Directory.Exists(path4));
@@ -1322,7 +1322,7 @@ namespace FastTests.Server.Documents.Indexing.Auto
                 indexName = index.Name;
 
                 indexStoragePath = Path.Combine(database.Configuration.Indexing.StoragePath.FullPath,
-                    IndexDefinitionBase.GetIndexNameSafeForFileSystem(indexName));
+                    IndexDefinitionBaseServerSide.GetIndexNameSafeForFileSystem(indexName));
 
                 Server.ServerStore.DatabasesLandlord.UnloadDirectly(dbName);
 
@@ -1371,10 +1371,10 @@ namespace FastTests.Server.Documents.Indexing.Auto
 
                 var index = await database.IndexStore.CreateIndex(new AutoMapIndexDefinition("Users", new[] { name1 }), Guid.NewGuid().ToString());
                 Assert.NotNull(index);
-                var indexSafeName = IndexDefinitionBase.GetIndexNameSafeForFileSystem(index.Name);
+                var indexSafeName = IndexDefinitionBaseServerSide.GetIndexNameSafeForFileSystem(index.Name);
 
                 var indexStoragePath = Path.Combine(database.Configuration.Indexing.StoragePath.FullPath,
-                    IndexDefinitionBase.GetIndexNameSafeForFileSystem(index.Name));
+                    IndexDefinitionBaseServerSide.GetIndexNameSafeForFileSystem(index.Name));
 
 
                 Server.ServerStore.DatabasesLandlord.UnloadDirectly(dbName);
@@ -1396,7 +1396,7 @@ namespace FastTests.Server.Documents.Indexing.Auto
 
                 Assert.IsType<FaultyInMemoryIndex>(index);
                 Assert.Equal(IndexState.Error, index.State);
-                Assert.Equal(indexSafeName, IndexDefinitionBase.GetIndexNameSafeForFileSystem(index.Name));
+                Assert.Equal(indexSafeName, IndexDefinitionBaseServerSide.GetIndexNameSafeForFileSystem(index.Name));
 
                 await database.IndexStore.DeleteIndex(index.Name, Guid.NewGuid().ToString());
 

--- a/test/FastTests/Server/Documents/Indexing/BasicAnalyzers.cs
+++ b/test/FastTests/Server/Documents/Indexing/BasicAnalyzers.cs
@@ -250,7 +250,7 @@ namespace FastTests.Server.Documents.Indexing
         }
     }
 
-    internal class TestIndexDefinitions : IndexDefinitionBase
+    internal class TestIndexDefinitions : IndexDefinitionBaseServerSide
     {
         public override long Version => IndexVersion.CurrentVersion;
 
@@ -279,7 +279,7 @@ namespace FastTests.Server.Documents.Indexing
             throw new NotImplementedException();
         }
 
-        public override IndexDefinitionCompareDifferences Compare(IndexDefinitionBase indexDefinition)
+        public override IndexDefinitionCompareDifferences Compare(IndexDefinitionBaseServerSide indexDefinition)
         {
             throw new NotImplementedException();
         }

--- a/test/FastTests/Server/Documents/Indexing/MapReduce/ReduceKeyProcessorTests.cs
+++ b/test/FastTests/Server/Documents/Indexing/MapReduce/ReduceKeyProcessorTests.cs
@@ -24,7 +24,7 @@ namespace FastTests.Server.Documents.Indexing.MapReduce
             using (var context = JsonOperationContext.ShortTermSingleUse())
             using (var bsc = new ByteStringContext(SharedMultipleUseFlag.None))
             {
-                var sut = new ReduceKeyProcessor(9, bufferPool, IndexDefinitionBase.IndexVersion.CurrentVersion);
+                var sut = new ReduceKeyProcessor(9, bufferPool, IndexDefinitionBaseServerSide.IndexVersion.CurrentVersion);
 
                 sut.Reset();
 

--- a/test/SlowTests/Issues/RavenDB-15890.cs
+++ b/test/SlowTests/Issues/RavenDB-15890.cs
@@ -755,7 +755,12 @@ namespace SlowTests.Issues
                 await new SimpleIndex().ExecuteAsync(store);
 
                 documentDatabase = await leader.ServerStore.DatabasesLandlord.TryGetOrCreateResourceStore(database);
-
+                var res = WaitForValue(() =>
+                {
+                    var ind = documentDatabase.IndexStore.GetIndex(indexName);
+                    return ind != null;
+                }, true);
+                Assert.True(res);
                 documentDatabase.IndexStore.StopIndex(indexName);
                 Assert.Equal(IndexRunningStatus.Paused, documentDatabase.IndexStore.GetIndex(indexName).Status);
 

--- a/test/SlowTests/Issues/RavenDB_10925.cs
+++ b/test/SlowTests/Issues/RavenDB_10925.cs
@@ -124,7 +124,7 @@ namespace SlowTests.Issues
                 Assert.Contains(i0, indexes);
 
                 var merged = indexes.Single(x => x != i0);
-                var definition = (AutoIndexDefinitionBase)merged.Definition;
+                var definition = (AutoIndexDefinitionBaseServerSide)merged.Definition;
 
                 var nameField = (AutoIndexField)definition.MapFields["Name"];
                 Assert.Equal(AutoFieldIndexing.Default | AutoFieldIndexing.Exact | AutoFieldIndexing.Search | AutoFieldIndexing.Highlighting, nameField.Indexing);

--- a/test/SlowTests/Issues/RavenDB_13759.cs
+++ b/test/SlowTests/Issues/RavenDB_13759.cs
@@ -35,7 +35,7 @@ namespace SlowTests.Issues
                 var database = await GetDocumentDatabaseInstanceFor(store);
                 var indexInstance1 = database.IndexStore.GetIndex(index.IndexName);
 
-                Assert.Equal(IndexDefinitionBase.IndexVersion.CurrentVersion, indexInstance1.Definition.Version);
+                Assert.Equal(IndexDefinitionBaseServerSide.IndexVersion.CurrentVersion, indexInstance1.Definition.Version);
 
                 WaitForIndexing(store);
 
@@ -77,7 +77,7 @@ namespace SlowTests.Issues
                 var indexInstance2 = database.IndexStore.GetIndex(index.IndexName);
                 Assert.NotEqual(indexInstance1, indexInstance2);
 
-                Assert.Equal(IndexDefinitionBase.IndexVersion.CurrentVersion, indexInstance2.Definition.Version);
+                Assert.Equal(IndexDefinitionBaseServerSide.IndexVersion.CurrentVersion, indexInstance2.Definition.Version);
 
                 indexTimeFields = indexInstance2._indexStorage.ReadIndexTimeFields();
                 Assert.Equal(2, indexTimeFields.Count);
@@ -141,8 +141,8 @@ namespace SlowTests.Issues
                 var indexInstance1 = database.IndexStore.GetIndex(index.IndexName);
                 var indexInstance2 = database.IndexStore.GetIndex("Auto/Orders/ByOrderedAt");
 
-                Assert.Equal(IndexDefinitionBase.IndexVersion.BaseVersion, indexInstance1.Definition.Version);
-                Assert.Equal(IndexDefinitionBase.IndexVersion.BaseVersion, indexInstance2.Definition.Version);
+                Assert.Equal(IndexDefinitionBaseServerSide.IndexVersion.BaseVersion, indexInstance1.Definition.Version);
+                Assert.Equal(IndexDefinitionBaseServerSide.IndexVersion.BaseVersion, indexInstance2.Definition.Version);
 
                 var indexTimeFields = indexInstance1._indexStorage.ReadIndexTimeFields();
                 Assert.Equal(0, indexTimeFields.Count);
@@ -156,8 +156,8 @@ namespace SlowTests.Issues
                 indexInstance1 = database.IndexStore.GetIndex(index.IndexName);
                 indexInstance2 = database.IndexStore.GetIndex("Auto/Orders/ByOrderedAt");
 
-                Assert.Equal(IndexDefinitionBase.IndexVersion.BaseVersion, indexInstance1.Definition.Version);
-                Assert.Equal(IndexDefinitionBase.IndexVersion.BaseVersion, indexInstance2.Definition.Version);
+                Assert.Equal(IndexDefinitionBaseServerSide.IndexVersion.BaseVersion, indexInstance1.Definition.Version);
+                Assert.Equal(IndexDefinitionBaseServerSide.IndexVersion.BaseVersion, indexInstance2.Definition.Version);
 
                 store.Maintenance.Send(new ResetIndexOperation(index.IndexName));
                 store.Maintenance.Send(new ResetIndexOperation("Auto/Orders/ByOrderedAt"));
@@ -165,8 +165,8 @@ namespace SlowTests.Issues
                 indexInstance1 = database.IndexStore.GetIndex(index.IndexName);
                 indexInstance2 = database.IndexStore.GetIndex("Auto/Orders/ByOrderedAt");
 
-                Assert.Equal(IndexDefinitionBase.IndexVersion.CurrentVersion, indexInstance1.Definition.Version);
-                Assert.Equal(IndexDefinitionBase.IndexVersion.CurrentVersion, indexInstance2.Definition.Version);
+                Assert.Equal(IndexDefinitionBaseServerSide.IndexVersion.CurrentVersion, indexInstance1.Definition.Version);
+                Assert.Equal(IndexDefinitionBaseServerSide.IndexVersion.CurrentVersion, indexInstance2.Definition.Version);
             }
         }
 

--- a/test/SlowTests/Issues/RavenDB_6131.cs
+++ b/test/SlowTests/Issues/RavenDB_6131.cs
@@ -54,7 +54,7 @@ namespace SlowTests.Issues
                 Assert.Equal(path3, database.Configuration.Indexing.TempPath.FullPath);
 
                 var indexInstance = database.IndexStore.GetIndex(index.IndexName);
-                var safeName = IndexDefinitionBase.GetIndexNameSafeForFileSystem(indexInstance.Name);
+                var safeName = IndexDefinitionBaseServerSide.GetIndexNameSafeForFileSystem(indexInstance.Name);
                 var tempPath = Path.Combine(path3, safeName);
 
                 Assert.True(Directory.Exists(tempPath));
@@ -91,7 +91,7 @@ namespace SlowTests.Issues
                     Assert.Equal(Path.Combine(path3, "Databases", store.Database), database.Configuration.Indexing.TempPath.FullPath);
 
                     var indexInstance = database.IndexStore.GetIndex(index.IndexName);
-                    var safeName = IndexDefinitionBase.GetIndexNameSafeForFileSystem(indexInstance.Name);
+                    var safeName = IndexDefinitionBaseServerSide.GetIndexNameSafeForFileSystem(indexInstance.Name);
                     var tempPath = Path.Combine(path3, "Databases", store.Database, safeName);
 
                     Assert.True(Directory.Exists(tempPath));

--- a/test/SlowTests/Server/Documents/Indexing/Auto/RavenDB_9535.cs
+++ b/test/SlowTests/Server/Documents/Indexing/Auto/RavenDB_9535.cs
@@ -21,7 +21,7 @@ namespace SlowTests.Server.Documents.Indexing.Auto
             using (var bufferPool = new UnmanagedBuffersPoolWithLowMemoryHandling("RavenDB_9535"))
             using (var bsc = new ByteStringContext(SharedMultipleUseFlag.None))
             {
-                var sut = new ReduceKeyProcessor(1, bufferPool, IndexDefinitionBase.IndexVersion.CurrentVersion);
+                var sut = new ReduceKeyProcessor(1, bufferPool, IndexDefinitionBaseServerSide.IndexVersion.CurrentVersion);
 
                 try
                 {

--- a/test/SlowTests/Server/Documents/Indexing/MapReduce/RavenDB_12932.cs
+++ b/test/SlowTests/Server/Documents/Indexing/MapReduce/RavenDB_12932.cs
@@ -311,7 +311,7 @@ namespace SlowTests.Server.Documents.Indexing.MapReduce
 
                 var definition = MapIndexDefinition.Load(index._environment, out var version);
                 Assert.NotNull(definition.PatternForOutputReduceToCollectionReferences);
-                Assert.Equal(IndexDefinitionBase.IndexVersion.CurrentVersion, version);
+                Assert.Equal(IndexDefinitionBaseServerSide.IndexVersion.CurrentVersion, version);
 
                 Assert.Equal("CustomCollection", definition.PatternReferencesCollectionName);
 

--- a/test/SlowTests/Server/Documents/Queries/Dynamic/MapReduce/MatchingAutoMapReduceIndexesForDynamicQueries.cs
+++ b/test/SlowTests/Server/Documents/Queries/Dynamic/MapReduce/MatchingAutoMapReduceIndexesForDynamicQueries.cs
@@ -379,7 +379,7 @@ select Name, count()"));
             }
         }
 
-        protected void add_index(IndexDefinitionBase definition)
+        protected void add_index(IndexDefinitionBaseServerSide definition)
         {
             AsyncHelpers.RunSync(() => _documentDatabase.IndexStore.CreateIndex(definition, Guid.NewGuid().ToString()));
         }

--- a/test/SlowTests/Server/Documents/Queries/MatchingAutoMapReduceIndexesForDynamicQueriesSlow.cs
+++ b/test/SlowTests/Server/Documents/Queries/MatchingAutoMapReduceIndexesForDynamicQueriesSlow.cs
@@ -69,7 +69,7 @@ namespace SlowTests.Server.Documents.Queries
             Assert.Equal(DynamicQueryMatchType.Failure, result.MatchType);
         }
 
-        protected void add_index(IndexDefinitionBase definition)
+        protected void add_index(IndexDefinitionBaseServerSide definition)
         {
             AsyncHelpers.RunSync(() => _documentDatabase.IndexStore.CreateIndex(definition, Guid.NewGuid().ToString()));
         }


### PR DESCRIPTION
### Issue link

https://issues.hibernatingrhinos.com/issue/RavenDB-16345

### Additional description
This is a fix to the issue https://issues.hibernatingrhinos.com/issue/RavenDB-15890 - cluster wide disable index
* Change AutoIndexDefinitionBase to AutoIndexDefinitionBaseServerSide
* Change IndexDefinitionBase to IndexDefinitionBaseServerWide
* New indexDefinitionBase - abstract class for client index Definition
* Cluster State -  save the etag for the last index state change. we need this so we can know if we have a state change in definition.
  The problem was:
    - we have index definition state == normal
    - we changed the index in-memory state to disable 
    - we update index definition. the state doesn't changed in definition but when we compare it to the in-memory state we 
      think we need to change the state. 
    - with cluster state we can know if index definition state is new or not
* JsonDeserializationNoIgnoreAttribute - new attribute ,Do not ignore internal field or property 

_Please delete below the options that are not relevant_

### Type of change

- Bug fix

### How risky is the change?

-Moderate
 
### Backward compatibility

- Non breaking change

### Is it platform specific issue?

- No

### Documentation update

- No documentation update is needed 

### Testing 

- Tests have been added that prove the fix is effective or that the feature works

### Is there any existing behavior change of other features due to this change?

- No

### UI work

- No UI work is needed
