### PR TITLE
RavenDB-17698 - fix etl failure when we failover to another node

### DIFF
--- a/src/Raven.Server/Documents/ETL/EtlProcess.cs
+++ b/src/Raven.Server/Documents/ETL/EtlProcess.cs
@@ -440,7 +440,7 @@ namespace Raven.Server.Documents.ETL
                 stats.NumberOfExtractedItems[EtlItemType.Document] > Database.Configuration.Etl.MaxNumberOfExtractedDocuments ||
                 stats.NumberOfExtractedItems.Sum(x => x.Value) > Database.Configuration.Etl.MaxNumberOfExtractedItems)
             {
-                var reason = $"Stopping the batch because it has already processed max number of items ({string.Join(',', stats.NumberOfExtractedItems.Select(x => $"{x.Key} - {x.Value}"))})";
+                var reason = $"Stopping the batch because it has already processed max number of items ({string.Join(',', stats.NumberOfExtractedItems.Select(x => $"{x.Key} - {x.Value:#,#;;0}"))})";
 
                 if (Logger.IsInfoEnabled)
                     Logger.Info($"[{Name}] {reason}");

--- a/src/Raven.Server/Documents/ETL/EtlProcess.cs
+++ b/src/Raven.Server/Documents/ETL/EtlProcess.cs
@@ -661,14 +661,10 @@ namespace Raven.Server.Documents.ETL
                                             transformations.AddRange(transformed);
                                     }
 
-                                    var successfulLoad = false;
-
-                                    if (transformations.Count > 0)
-                                        successfulLoad = Load(transformations, context, stats);
-
+                                    var noFailures = Load(transformations, context, stats);
                                     var lastProcessed = Math.Max(stats.LastLoadedEtag, stats.LastFilteredOutEtags.Values.Max());
 
-                                    if (lastProcessed > Statistics.LastProcessedEtag && successfulLoad)
+                                    if (lastProcessed > Statistics.LastProcessedEtag && noFailures)
                                     {
                                         didWork = true;
                                         Statistics.LastProcessedEtag = lastProcessed;

--- a/src/Raven.Server/Documents/ETL/EtlProcess.cs
+++ b/src/Raven.Server/Documents/ETL/EtlProcess.cs
@@ -268,6 +268,12 @@ namespace Raven.Server.Documents.ETL
                 {
                     stats.RecordLastExtractedEtag(item.Etag, item.Type);
 
+                    if (CanContinueBatch(stats, item, batchSize, context) == false)
+                    {
+                        batchStopped = true;
+                        break;
+                    }
+
                     if (AlreadyLoadedByDifferentNode(item, state))
                     {
                         stats.RecordChangeVector(item.ChangeVector);
@@ -293,12 +299,6 @@ namespace Raven.Server.Documents.ETL
 
                         try
                         {
-                            if (CanContinueBatch(stats, item, batchSize, context) == false)
-                            {
-                                batchStopped = true;
-                                break;
-                            }
-
                             transformer.Transform(item, stats);
 
                             Statistics.TransformationSuccess();

--- a/src/Raven.Server/Documents/ETL/EtlProcess.cs
+++ b/src/Raven.Server/Documents/ETL/EtlProcess.cs
@@ -268,6 +268,8 @@ namespace Raven.Server.Documents.ETL
                 {
                     stats.RecordLastExtractedEtag(item.Etag, item.Type);
 
+                    CancellationToken.ThrowIfCancellationRequested();
+
                     if (CanContinueBatch(stats, item, batchSize, context) == false)
                     {
                         batchStopped = true;
@@ -295,8 +297,6 @@ namespace Raven.Server.Documents.ETL
 
                     using (stats.For(EtlOperations.Transform))
                     {
-                        CancellationToken.ThrowIfCancellationRequested();
-
                         try
                         {
                             transformer.Transform(item, stats);

--- a/test/SlowTests/Issues/RavenDB-17698.cs
+++ b/test/SlowTests/Issues/RavenDB-17698.cs
@@ -1,0 +1,99 @@
+﻿using System;
+using System.Collections.Generic;
+using System.Linq;
+using System.Threading;
+using System.Threading.Tasks;
+using FastTests;
+using Raven.Client.Documents;
+using Raven.Client.Documents.Indexes;
+using Raven.Client.Documents.Operations.ConnectionStrings;
+using Raven.Client.Documents.Operations.ETL;
+using Raven.Client.Documents.Operations.ETL.SQL;
+using Raven.Client.Documents.Operations.Indexes;
+using Raven.Client.ServerWide;
+using Raven.Client.ServerWide.Operations;
+using SlowTests.Core.Utils.Entities;
+using Tests.Infrastructure;
+using Xunit;
+using Xunit.Abstractions;
+
+namespace SlowTests.Issues
+{
+    public class RavenDB_17698 : ClusterTestBase
+    {
+        public RavenDB_17698(ITestOutputHelper output) : base(output)
+        {
+        }
+
+        [Fact]
+        public async Task Can_fail_over_etl_task()
+        {
+            var (nodes, leader) = await CreateRaftCluster(3, customSettings:
+                new Dictionary<string, string>
+                {
+                    {"ETL.MaxNumberOfExtractedDocuments", "5"}
+                });
+            var database = GetDatabaseName();
+
+            await CreateDatabaseInClusterInner(new DatabaseRecord(database), 3, leader.WebUrl, null);
+
+            using (var destination = GetDocumentStore())
+            using (var source = new DocumentStore
+            {
+                Database = database,
+                Urls = new[] { leader.WebUrl }
+            }.Initialize())
+            {
+                string lastDocumentId = null;
+                using (var bulkInsert = source.BulkInsert())
+                {
+                    for (var i = 0; i < 10; i++)
+                    {
+                        lastDocumentId = i.ToString();
+                        await bulkInsert.StoreAsync(new User(), lastDocumentId);
+                    }
+                }
+
+                var putResult = await source.Maintenance.SendAsync(new PutConnectionStringOperation<RavenConnectionString>(new RavenConnectionString
+                {
+                    Name = "test",
+                    TopologyDiscoveryUrls = new[] { destination.Urls.First() },
+                    Database = destination.Database,
+                }));
+                Assert.NotNull(putResult.RaftCommandIndex);
+
+                var configuration = new RavenEtlConfiguration
+                {
+                    ConnectionStringName = "test",
+                    Name = "myConfiguration",
+                    Transforms = {
+                        new Transformation
+                        {
+                            Name = "allDocs",
+                            Collections = { "Users" }
+                        }
+                    },
+                    MentorNode = "A"
+                };
+
+                var addResult = await source.Maintenance.SendAsync(new AddEtlOperation<RavenConnectionString>(configuration));
+                Assert.NotNull(addResult.RaftCommandIndex);
+                Assert.True(WaitForDocument(destination, lastDocumentId));
+
+                configuration.MentorNode = "B";
+                var updateResult = await source.Maintenance.SendAsync(new UpdateEtlOperation<RavenConnectionString>(addResult.TaskId, configuration));
+                Assert.NotNull(updateResult.RaftCommandIndex);
+
+                using (var session = source.OpenAsyncSession())
+                {
+                    var user = new User();
+                    await session.StoreAsync(user);
+                    lastDocumentId = user.Id;
+                    await session.SaveChangesAsync();
+                }
+
+                Assert.True(WaitForDocument(destination, lastDocumentId));
+            }
+        }
+    }
+}

--- a/test/SlowTests/Server/Documents/ETL/RavenDB_11891.cs
+++ b/test/SlowTests/Server/Documents/ETL/RavenDB_11891.cs
@@ -196,7 +196,13 @@ function deleteDocumentsOfEmployeesBehavior(docId) {
 
 ");
 
-                var etlDone = WaitForEtl(src, (n, s) => s.LoadSuccesses > 0);
+                var last = 0;
+                var etlDone = WaitForEtl(src, (n, s) =>
+                {
+                    var check = s.LoadSuccesses > last;
+                    last = s.LoadSuccesses;
+                    return check;
+                });
 
                 using (var session = src.OpenSession())
                 {

--- a/test/SlowTests/Server/Documents/ETL/RavenDB_11897.cs
+++ b/test/SlowTests/Server/Documents/ETL/RavenDB_11897.cs
@@ -39,7 +39,13 @@ namespace SlowTests.Server.Documents.ETL
             {
                 AddEtl(src, dest, "Users", script: script);
 
-                var etlDone = WaitForEtl(src, (n, s) => s.LoadSuccesses > 0);
+                var last = 0;
+                var etlDone = WaitForEtl(src, (n, s) =>
+                {
+                    var check = s.LoadSuccesses > last;
+                    last = s.LoadSuccesses;
+                    return check;
+                });
 
                 using (var session = src.OpenSession())
                 {


### PR DESCRIPTION
### Issue link

https://issues.hibernatingrhinos.com/issue/RavenDB-17698

### Additional description

Save the last etag for a batch even if we skipped all documents

### Type of change

- Bug fix

### How risky is the change?

- Low 

### Testing 

- Tests have been added that prove the fix is effective or that the feature works
