### PR TITLE
RavenDB-17711 Bad date parsing for"yyyy'-'MM'-'dd'T'HH':'mm':'ss'.'fff"

### DIFF
--- a/src/Sparrow/Json/LazyStringParser.cs
+++ b/src/Sparrow/Json/LazyStringParser.cs
@@ -407,6 +407,7 @@ namespace Sparrow.Json
                         goto Failed;
                     if (TryParseNumber3(buffer, 20, out fractions) == false)
                         goto Failed;
+                    fractions *= 10000;
                     goto Finished_DT;
                 case 28://"yyyy'-'MM'-'dd'T'HH':'mm':'ss.fffffff'Z'"
                     if (buffer[27] != 'Z')
@@ -518,6 +519,7 @@ namespace Sparrow.Json
                         goto Failed;
                     if (TryParseNumber3(buffer, 20, out fractions) == false)
                         goto Failed;
+                    fractions *= 10000;
                     goto Finished_DT;
                 case 28://"yyyy'-'MM'-'dd'T'HH':'mm':'ss.fffffff'Z'"
                     if (buffer[27] != 'Z')

--- a/test/SlowTests/Issues/RavenDB-17711.cs
+++ b/test/SlowTests/Issues/RavenDB-17711.cs
@@ -1,0 +1,70 @@
+﻿using System;
+using System.Globalization;
+using System.Linq;
+using FastTests;
+using Raven.Client.Documents.Indexes;
+using Xunit;
+using Xunit.Abstractions;
+
+namespace SlowTests.Issues
+{
+    public class RavenDB_17711 : RavenTestBase
+    {
+        public RavenDB_17711(ITestOutputHelper output) : base(output)
+        {
+        }
+
+        private class Task
+        {
+            public object At;
+        }
+        
+        [Fact]
+        public void ThreeDigitsFractionalDateParsingShouldWorkProperly_AutoIndex()
+        {
+            using var store = GetDocumentStore();
+
+            using (var s = store.OpenSession())
+            {
+                s.Store(new Task{At = "2021-12-14T11:22:28.322Z"});
+                s.SaveChanges();
+            }
+
+            using (var s = store.OpenSession())
+            {
+                object date = new DateTime(2021, 12, 14, 11, 22, 28, 322, DateTimeKind.Utc);
+
+                Assert.True(s.Query<Task>().Any(t => t.At == date));
+            }
+        }
+
+        private class Index : AbstractIndexCreationTask<Task>
+        {
+            public Index()
+            {
+                Map = tasks => from t in tasks select new { t.At };
+            }
+        }
+          
+        [Fact]
+        public void ThreeDigitsFractionalDateParsingShouldWorkProperly_StaticIndex()
+        {
+            using var store = GetDocumentStore();
+
+            using (var s = store.OpenSession())
+            {
+                s.Store(new Task{At = "2021-12-14T11:22:28.322Z"});
+                s.SaveChanges();
+            }
+            new Index().Execute(store);
+            WaitForIndexing(store);
+
+            using (var s = store.OpenSession())
+            {
+                object date = new DateTime(2021, 12, 14, 11, 22, 28, 322, DateTimeKind.Utc);
+
+                Assert.True(s.Query<Task, Index>().Any(t => t.At == date));
+            }
+        }
+    }
+}


### PR DESCRIPTION
### Issue link

https://issues.hibernatingrhinos.com/issue/RavenDB-17711

### Additional description

When parsing fractional date with 3 digits, we threated this as a 7 digits fraction.

### Type of change

- Bug fix

### How risky is the change?

- Low 

### Backward compatibility

- Not relevant

This change behavior for a specific use case, but I doubt that there is anyone that relies on this.

### Is it platform specific issue?

- No

### Documentation update

- No documentation update is needed 

### Testing 

- Tests have been added that prove the fix is effective or that the feature works


### Is there any existing behavior change of other features due to this change?

- No

### UI work

- No UI work is needed
