### PR TITLE
RavenDB-17699 Bug with Conditional Gets - 2nd request gives different…

### DIFF
--- a/src/Raven.Client/Documents/Commands/MultiGet/MultiGetCommand.cs
+++ b/src/Raven.Client/Documents/Commands/MultiGet/MultiGetCommand.cs
@@ -120,6 +120,9 @@ namespace Raven.Client.Documents.Commands.MultiGet
             for (int i = 0; i < _commands.Count; i++)
             {
                 var command = _commands[i];
+                
+                if(command.Headers.ContainsKey(Constants.Headers.IfNoneMatch))
+                    continue; // command already explicitly handling setting this, let's not touch it.
 
                 var cacheKey = GetCacheKey(command, out _);
                 var cachedItem = _httpCache.Get(ctx, cacheKey, out var changeVector, out var cached);

--- a/test/SlowTests/Issues/RavenDB-17699.cs
+++ b/test/SlowTests/Issues/RavenDB-17699.cs
@@ -1,0 +1,43 @@
+﻿using System;
+using FastTests;
+using Xunit;
+using Xunit.Abstractions;
+
+namespace SlowTests.Issues
+{
+    public class RavenDB_17699 : RavenTestBase
+    {
+        public RavenDB_17699(ITestOutputHelper output) : base(output)
+        {
+        }
+
+        private record Item(string name);
+
+        [Fact]
+        public void MultipleConditionalGetQueries()
+        {
+            using var store = GetDocumentStore();
+
+            using (var s = store.OpenSession())
+            {
+                s.Store(new Item("Book"), "items/book");
+                s.SaveChanges();
+            }
+         
+
+            using (var s = store.OpenSession())
+            {
+                var bookLazy = s.Advanced.Lazily. ConditionalLoad<Item>("items/book", "bad-value");
+                s.Advanced.Eagerly.ExecuteAllPendingLazyOperations();
+                Assert.NotNull(bookLazy.Value.Entity);
+            }
+            
+            using (var s = store.OpenSession())
+            {
+                var bookLazy = s.Advanced.Lazily. ConditionalLoad<Item>("items/book", "bad-value");
+                s.Advanced.Eagerly.ExecuteAllPendingLazyOperations();
+                Assert.NotNull(bookLazy.Value.Entity);
+            }
+        }
+    }
+}


### PR DESCRIPTION
… result than the first.

### Issue link

https://issues.hibernatingrhinos.com/issue/RavenDB-17699

### Additional description

When using ConditionalLoad, we are getting the change vector externally.
If the HTTP cache has an ETag for the request, it overwrote it, which wasn't what we needed.
Changed the code to take into account that a request that explicitly set this value shouldn't overwrite it.

### Type of change

- Bug fix

### How risky is the change?

- Low 
- 
### Backward compatibility

- Non breaking change
- 
### Is it platform specific issue?

- No

### Documentation update

- No documentation update is needed 

### Testing 

- Tests have been added that prove the fix is effective or that the feature works


### Is there any existing behavior change of other features due to this change?

- No

### UI work

- No UI work is needed
