### PR TITLE
RavenDB-17626 Cast IEnumerable<T> into IEnumerable<dynamic> inside SelectMany

### DIFF
--- a/src/Raven.Server/Documents/Indexes/Static/Roslyn/Rewriters/DynamicLambdaExpressionsRewriter.cs
+++ b/src/Raven.Server/Documents/Indexes/Static/Roslyn/Rewriters/DynamicLambdaExpressionsRewriter.cs
@@ -162,7 +162,6 @@ namespace Raven.Server.Documents.Indexes.Static.Roslyn.Rewriters
                 return node;
 
             var parentInvocation = GetInvocationParent(node);
-
             if (currentInvocation.ArgumentList.Arguments.Count > 0 && currentInvocation.ArgumentList.Arguments[0].Expression == node)
             {
                 if (node is SimpleLambdaExpressionSyntax)
@@ -172,7 +171,7 @@ namespace Raven.Server.Documents.Indexes.Static.Roslyn.Rewriters
                         case "ToDictionary":
                             return Visit(SyntaxFactory.ParseExpression($"(Func<KeyValuePair<dynamic, dynamic>, IEnumerable<KeyValuePair<dynamic, dynamic>>>)({node})"));
                         default:
-                            return Visit(SyntaxFactory.ParseExpression($"(Func<dynamic, IEnumerable<dynamic>>)({node})"));
+                            return Visit(SyntaxFactory.ParseExpression($"(Func<dynamic, IEnumerable<dynamic>>)({ModifyLambdaForDynamicEnumerable(node)})"));
                     }
                 }
                 else
@@ -201,6 +200,24 @@ namespace Raven.Server.Documents.Indexes.Static.Roslyn.Rewriters
             return node;
         }
 
+        private static SyntaxNode ModifyLambdaForDynamicEnumerable(LambdaExpressionSyntax node)
+        {
+            var lambda = node as SimpleLambdaExpressionSyntax;
+            if (lambda == null)
+                throw new InvalidOperationException($"Invalid lambda expression: {node}");
+
+            var alreadyCasted = GetAsCastExpression(lambda.Body);
+
+            if (alreadyCasted != null)
+            {
+                return SyntaxFactory.ParseExpression($"{lambda.WithBody(lambda.Body)}");
+            }
+
+            var cast = SyntaxFactory.ParseExpression($"Enumerable.Cast<dynamic>({lambda.Body})");
+
+            return SyntaxFactory.ParseExpression($"{lambda.WithBody(cast)}");
+        }
+        
         private static SyntaxNode ModifyLambdaForSelect(LambdaExpressionSyntax node, InvocationExpressionSyntax currentInvocation)
         {
             var parentMethod = GetParentMethod(currentInvocation);

--- a/test/SlowTests/Issues/RavenDB_17626.cs
+++ b/test/SlowTests/Issues/RavenDB_17626.cs
@@ -1,0 +1,75 @@
+﻿using System;
+using System.Collections.Generic;
+using System.Linq;
+using FastTests;
+using Raven.Client.Documents;
+using Raven.Client.Documents.Indexes;
+using Xunit;
+using Xunit.Abstractions;
+
+namespace SlowTests.Issues;
+
+public class RavenDB_17626 : RavenTestBase
+{
+    public RavenDB_17626(ITestOutputHelper output) : base(output)
+    {
+    }
+
+    [Fact]
+    public void EnumerableInSelectManyWillBeCastedProperly()
+    {
+        using (var store = GetDocumentStore())
+        {
+            store.ExecuteIndex(new Index());
+            var date = DateTime.UtcNow;
+            using (var session = store.OpenSession())
+            {
+                session.Store(new Product { Dates = new List<Date> { new Date { DateTime = date },new Date { DateTime = date.AddDays(1) } } });
+                session.SaveChanges();
+            }
+
+            WaitForIndexing(store);
+            using (var session = store.OpenSession())
+            {
+                var result = session.Query<Index.Result, Index>()
+                    .Where(x => x.Dates.Any(d => d == date))
+                    .ProjectInto<Index.Result>()
+                    .ToList();
+                Assert.Equal(1, result.Count);
+                Assert.Equal(date, result[0].Dates.First());
+            }
+        }
+    }
+
+    private class Product
+    {
+        public List<Date> Dates { get; set; }
+    }
+
+    private class Date
+    {
+        public DateTime DateTime { get; set; }
+    }
+    
+    private class Index : AbstractIndexCreationTask<Product, Index.Result>
+    {
+        public Index()
+        {
+            Map = products => from product in products
+                let productByDate = from date in product.Dates
+                    select new { Dates = new List<DateTime> { date.DateTime } }
+                select new Result { Dates = productByDate.SelectMany(x => x.Dates).ToList(), };
+            
+            Store("Dates", FieldStorage.Yes);
+        }
+
+        public class Result
+        {
+            public List<DateTime> Dates
+            {
+                get;
+                set;
+            }
+        }
+    }
+}


### PR DESCRIPTION
### Issue link

https://issues.hibernatingrhinos.com/issue/RavenDB-17626

### Additional description

Cast IEnumerable<T> into IEnumerable<dynamic> inside SelectMany



### Type of change

- Bug fix


### How risky is the change?


- High

### Backward compatibility


- Not relevant

### Is it platform specific issue?

- No

### Documentation update

- No documentation update is needed 

### Testing 

- Tests have been added that prove the fix is effective or that the feature works


### Is there any existing behavior change of other features due to this change?

- Yes: static indexes

### UI work

- No UI work is needed
