### PR TITLE
RavenDB-17424 added 'Indexing.TimeSinceLastQueryAfterWhichDeepCleanupCanBeExecutedInMin' configuration option

### DIFF
--- a/src/Raven.Server/Config/Categories/IndexingConfiguration.cs
+++ b/src/Raven.Server/Config/Categories/IndexingConfiguration.cs
@@ -241,6 +241,13 @@ namespace Raven.Server.Config.Categories
         [ConfigurationEntry("Indexing.SkipDatabaseIdValidationOnIndexOpening", ConfigurationEntryScope.ServerWideOrPerDatabase)]
         public bool SkipDatabaseIdValidationOnIndexOpening { get; set; }
 
+        [Description("Time since last query after which when cleanup is executed additional items will be released (e.g. readers).")]
+        [DefaultValue(10)]
+        [TimeUnit(TimeUnit.Minutes)]
+        [IndexUpdateType(IndexUpdateType.Refresh)]
+        [ConfigurationEntry("Indexing.TimeSinceLastQueryAfterWhichDeepCleanupCanBeExecutedInMin", ConfigurationEntryScope.ServerWideOrPerDatabase)]
+        public TimeSetting TimeSinceLastQueryAfterWhichDeepCleanupCanBeExecuted { get; set; }
+
         protected override void ValidateProperty(PropertyInfo property)
         {
             var updateTypeAttribute = property.GetCustomAttribute<IndexUpdateTypeAttribute>();

--- a/src/Raven.Server/Documents/Indexes/Index.cs
+++ b/src/Raven.Server/Documents/Indexes/Index.cs
@@ -1316,7 +1316,7 @@ namespace Raven.Server.Documents.Indexes
                                 // anytime soon
 
                                 var mode = IndexCleanup.Basic;
-                                if (NoQueryInLast10Minutes())
+                                if (NoQueryRecently())
                                     mode |= IndexCleanup.Readers;
 
                                 ReduceMemoryUsage(storageEnvironment, mode);
@@ -2428,11 +2428,11 @@ namespace Raven.Server.Documents.Indexes
             return _lastQueryingTime;
         }
 
-        public bool NoQueryInLast10Minutes()
+        public bool NoQueryRecently()
         {
             var last = _lastQueryingTime;
             return last.HasValue == false ||
-                   DocumentDatabase.Time.GetUtcNow() - last.Value > TimeSpan.FromMinutes(10);
+                   DocumentDatabase.Time.GetUtcNow() - last.Value > Configuration.TimeSinceLastQueryAfterWhichDeepCleanupCanBeExecuted.AsTimeSpan;
         }
 
         private void MarkQueried(DateTime time)

--- a/src/Raven.Server/Documents/Indexes/IndexStore.cs
+++ b/src/Raven.Server/Documents/Indexes/IndexStore.cs
@@ -1521,7 +1521,7 @@ namespace Raven.Server.Documents.Indexes
             foreach (var index in _indexes)
             {
                 var current = indexCleanupMode;
-                if (index.NoQueryInLast10Minutes())
+                if (index.NoQueryRecently())
                     current |= IndexCleanup.Readers;
 
                 index.Cleanup(current);


### PR DESCRIPTION
### Issue link

https://issues.hibernatingrhinos.com/issue/RavenDB-17424

### Additional description

Adds the ability via configuration option to control after what time since last query we can perform deep clean

### Type of change

- New feature

### How risky is the change?

- Low 

### Backward compatibility

- Not relevant

### Is it platform specific issue?

- No

### Documentation update

- This change requires a documentation update. Please mark the issue on YouTrack using `Documentation Required` tag.

### Testing 

- It has been verified by manual testing

### Is there any existing behavior change of other features due to this change?

- No

### UI work

- No UI work is needed
