### PR TITLE
RavenDB-17699 Accept NoCache flag from the session for lazy operation…

### DIFF
--- a/src/Raven.Client/Documents/Commands/MultiGet/MultiGetCommand.cs
+++ b/src/Raven.Client/Documents/Commands/MultiGet/MultiGetCommand.cs
@@ -26,11 +26,13 @@ namespace Raven.Client.Documents.Commands.MultiGet
 
         internal bool AggressivelyCached;
 
-        public MultiGetCommand(RequestExecutor requestExecutor, List<GetRequest> commands)  :this(requestExecutor, commands, null)
+        public MultiGetCommand(RequestExecutor requestExecutor, List<GetRequest> commands)
+            : this(requestExecutor, commands, null)
         {
-            
+
         }
-        public MultiGetCommand(RequestExecutor requestExecutor, List<GetRequest> commands, SessionInfo sessionInfo)
+
+        internal MultiGetCommand(RequestExecutor requestExecutor, List<GetRequest> commands, SessionInfo sessionInfo)
         {
             _requestExecutor = requestExecutor ?? throw new ArgumentNullException(nameof(requestExecutor));
             _httpCache = _requestExecutor.Cache ?? throw new ArgumentNullException(nameof(_requestExecutor.Cache));
@@ -44,7 +46,7 @@ namespace Raven.Client.Documents.Commands.MultiGet
             _baseUrl = $"{node.Url}/databases/{node.Database}";
             url = $"{_baseUrl}/multi_get";
 
-            if (_sessionInfo?.NoCaching != true &&
+            if ((_sessionInfo == null || _sessionInfo.NoCaching == false) &&
                 MaybeReadAllFromCache(ctx, _requestExecutor.AggressiveCaching.Value))
             {
                 AggressivelyCached = true;
@@ -353,7 +355,7 @@ namespace Raven.Client.Documents.Commands.MultiGet
             {
                 _size = size;
                 Values = ArrayPool<(HttpCache.ReleaseCacheItem, BlittableJsonReaderObject)>.Shared.Rent(size);
-    }
+            }
 
             public void Dispose()
             {

--- a/src/Raven.Client/Documents/Commands/MultiGet/MultiGetCommand.cs
+++ b/src/Raven.Client/Documents/Commands/MultiGet/MultiGetCommand.cs
@@ -4,6 +4,7 @@ using System.Collections.Generic;
 using System.IO;
 using System.Net;
 using System.Net.Http;
+using Raven.Client.Documents.Session;
 using Raven.Client.Extensions;
 using Raven.Client.Http;
 using Raven.Client.Json;
@@ -18,17 +19,23 @@ namespace Raven.Client.Documents.Commands.MultiGet
         private readonly RequestExecutor _requestExecutor;
         private readonly HttpCache _httpCache;
         private readonly List<GetRequest> _commands;
+        private readonly SessionInfo _sessionInfo;
 
         private string _baseUrl;
         private Cached _cached;
 
         internal bool AggressivelyCached;
 
-        public MultiGetCommand(RequestExecutor requestExecutor, List<GetRequest> commands)
+        public MultiGetCommand(RequestExecutor requestExecutor, List<GetRequest> commands)  :this(requestExecutor, commands, null)
+        {
+            
+        }
+        public MultiGetCommand(RequestExecutor requestExecutor, List<GetRequest> commands, SessionInfo sessionInfo)
         {
             _requestExecutor = requestExecutor ?? throw new ArgumentNullException(nameof(requestExecutor));
             _httpCache = _requestExecutor.Cache ?? throw new ArgumentNullException(nameof(_requestExecutor.Cache));
             _commands = commands ?? throw new ArgumentNullException(nameof(commands));
+            _sessionInfo = sessionInfo;
             ResponseType = RavenCommandResponseType.Raw;
         }
 
@@ -37,7 +44,8 @@ namespace Raven.Client.Documents.Commands.MultiGet
             _baseUrl = $"{node.Url}/databases/{node.Database}";
             url = $"{_baseUrl}/multi_get";
 
-            if (MaybeReadAllFromCache(ctx, _requestExecutor.AggressiveCaching.Value))
+            if (_sessionInfo?.NoCaching != true &&
+                MaybeReadAllFromCache(ctx, _requestExecutor.AggressiveCaching.Value))
             {
                 AggressivelyCached = true;
                 return null;// aggressively cached

--- a/src/Raven.Client/Documents/Session/Operations/MultiGetOperation.cs
+++ b/src/Raven.Client/Documents/Session/Operations/MultiGetOperation.cs
@@ -15,7 +15,7 @@ namespace Raven.Client.Documents.Session.Operations
 
         public MultiGetCommand CreateRequest(List<GetRequest> requests)
         {
-            return new MultiGetCommand(_session.RequestExecutor, requests);
+            return new MultiGetCommand(_session.RequestExecutor, requests, _session.SessionInfo);
         }
 
         public void SetResult(BlittableArrayResult result)


### PR DESCRIPTION
…s (previously would apply only at the multi get request)

### Issue link

https://issues.hibernatingrhinos.com/issue/RavenDB-17699

### Additional description

The sessions' `NoCache` flag was ignored by lazy requests, only handled at the container request level.
We now consider that scenario as well for lazy requests.


### Type of change

- Bug fix

### How risky is the change?

- Low 

### Backward compatibility

- Non breaking change

### Is it platform specific issue?

- No

### Documentation update

- No documentation update is needed 

