### PR TITLE
RavenDB-17711

### DIFF
--- a/src/Raven.Client/Json/Serialization/NewtonsoftJson/Internal/Converters/ParametersConverter.cs
+++ b/src/Raven.Client/Json/Serialization/NewtonsoftJson/Internal/Converters/ParametersConverter.cs
@@ -131,7 +131,7 @@ namespace Raven.Client.Json.Serialization.NewtonsoftJson.Internal.Converters
                 {
                     fixed (char* pBuffer = s)
                     {
-                        var r = LazyStringParser.TryParseDateTime(pBuffer, s.Length, out var dt, out var dto);
+                        var r = LazyStringParser.TryParseDateTime(pBuffer, s.Length, out var dt, out var dto, properlyParseThreeDigitsMilliseconds: true);
                         switch (r)
                         {
                             case LazyStringParser.Result.Failed:

--- a/src/Raven.Server/Documents/BlittableMetadataModifier.cs
+++ b/src/Raven.Server/Documents/BlittableMetadataModifier.cs
@@ -80,7 +80,7 @@ namespace Raven.Server.Documents
         {
             var str = CreateLazyStringValueFromParserState(jsonParserState);
 
-            var result = LazyStringParser.TryParseDateTime(str.Buffer, str.Size, out DateTime dt, out DateTimeOffset _);
+            var result = LazyStringParser.TryParseDateTime(str.Buffer, str.Size, out DateTime dt, out DateTimeOffset _, properlyParseThreeDigitsMilliseconds: true);
             if (result != LazyStringParser.Result.DateTime)
                 ThrowInvalidLastModifiedProperty(state, str, reader);
 

--- a/src/Raven.Server/Documents/ETL/Providers/OLAP/ParquetTransformedItems.cs
+++ b/src/Raven.Server/Documents/ETL/Providers/OLAP/ParquetTransformedItems.cs
@@ -730,7 +730,7 @@ namespace Raven.Server.Documents.ETL.Providers.OLAP
         {
             fixed (char* c = str)
             {
-                var result = LazyStringParser.TryParseDateTime(c, str.Length, out var dt, out dto);
+                var result = LazyStringParser.TryParseDateTime(c, str.Length, out var dt, out dto, properlyParseThreeDigitsMilliseconds: true);
                 switch (result)
                 {
                     case LazyStringParser.Result.DateTime:

--- a/src/Raven.Server/Documents/Handlers/TimeSeriesHandler.cs
+++ b/src/Raven.Server/Documents/Handlers/TimeSeriesHandler.cs
@@ -369,7 +369,7 @@ namespace Raven.Server.Documents.Handlers
         {
             fixed (char* c = dateStr)
             {
-                var result = LazyStringParser.TryParseDateTime(c, dateStr.Length, out var dt, out _);
+                var result = LazyStringParser.TryParseDateTime(c, dateStr.Length, out var dt, out _, properlyParseThreeDigitsMilliseconds: true);
                 if (result != LazyStringParser.Result.DateTime)
                     ThrowInvalidDateTime(name, dateStr);
 

--- a/src/Raven.Server/Documents/Indexes/IndexDefinitionBase.cs
+++ b/src/Raven.Server/Documents/Indexes/IndexDefinitionBase.cs
@@ -137,10 +137,12 @@ namespace Raven.Server.Documents.Indexes
 
             public const long ReduceKeyProcessorHashDoubleFix = 52_001; // RavenDB-17572
 
+            public const long ProperlyParseThreeDigitsMillisecondsDates = 52_002; // RavenDB-17711
+
             /// <summary>
             /// Remember to bump this
             /// </summary>
-            public const long CurrentVersion = ReduceKeyProcessorHashDoubleFix;
+            public const long CurrentVersion = ProperlyParseThreeDigitsMillisecondsDates;
         }
     }
 

--- a/src/Raven.Server/Documents/Patch/ScriptRunner.cs
+++ b/src/Raven.Server/Documents/Patch/ScriptRunner.cs
@@ -162,7 +162,7 @@ namespace Raven.Server.Documents.Patch
             var s = arg.AsString();
             fixed (char* pValue = s)
             {
-                var result = LazyStringParser.TryParseDateTime(pValue, s.Length, out DateTime dt, out _);
+                var result = LazyStringParser.TryParseDateTime(pValue, s.Length, out DateTime dt, out _, properlyParseThreeDigitsMilliseconds: true);
                 if (result != LazyStringParser.Result.DateTime)
                     ThrowInvalidDateArgument();
 
@@ -1668,7 +1668,7 @@ namespace Raven.Server.Documents.Patch
                     var s = args[0].AsString();
                     fixed (char* pValue = s)
                     {
-                        var result = LazyStringParser.TryParseDateTime(pValue, s.Length, out DateTime dt, out _);
+                        var result = LazyStringParser.TryParseDateTime(pValue, s.Length, out DateTime dt, out _, properlyParseThreeDigitsMilliseconds: true);
                         switch (result)
                         {
                             case LazyStringParser.Result.DateTime:

--- a/src/Raven.Server/Documents/Queries/LuceneQueryHelper.cs
+++ b/src/Raven.Server/Documents/Queries/LuceneQueryHelper.cs
@@ -252,7 +252,7 @@ namespace Raven.Server.Documents.Queries
 
                         fixed (char* pValue = value)
                         {
-                            var result = LazyStringParser.TryParseDateTime(pValue, value.Length, out DateTime _, out DateTimeOffset _);
+                            var result = LazyStringParser.TryParseDateTime(pValue, value.Length, out DateTime _, out DateTimeOffset _, properlyParseThreeDigitsMilliseconds: true);
                             switch (result)
                             {
                                 case LazyStringParser.Result.DateTime:

--- a/src/Raven.Server/Documents/Queries/QueryBuilder.cs
+++ b/src/Raven.Server/Documents/Queries/QueryBuilder.cs
@@ -522,7 +522,7 @@ namespace Raven.Server.Documents.Queries
             if (exact || index == null || valueFirst == null || valueSecond == null || index.Definition.Version < IndexDefinitionBase.IndexVersion.TimeTicks)
                 return false;
 
-            if (index.IndexFieldsPersistence.HasTimeValues(fieldName) && TryGetTime(valueFirst, out ticksFirst) && TryGetTime(valueSecond, out ticksSecond))
+            if (index.IndexFieldsPersistence.HasTimeValues(fieldName) && TryGetTime(index,valueFirst, out ticksFirst) && TryGetTime(index,valueSecond, out ticksSecond))
                 return true;
 
             return false;
@@ -535,13 +535,13 @@ namespace Raven.Server.Documents.Queries
             if (exact || index == null || value == null || index.Definition.Version < IndexDefinitionBase.IndexVersion.TimeTicks)
                 return false;
 
-            if (index.IndexFieldsPersistence.HasTimeValues(fieldName) && TryGetTime(value, out ticks))
+            if (index.IndexFieldsPersistence.HasTimeValues(fieldName) && TryGetTime(index, value, out ticks))
                 return true;
 
             return false;
         }
 
-        private unsafe static bool TryGetTime(object value, out long ticks)
+        private unsafe static bool TryGetTime(Index index, object value, out long ticks)
         {
             ticks = -1;
             DateTime dt = default;
@@ -551,16 +551,16 @@ namespace Raven.Server.Documents.Queries
             switch (value)
             {
                 case LazyStringValue lsv:
-                    result = LazyStringParser.TryParseDateTime(lsv.Buffer, lsv.Size, out dt, out dto);
+                    result = LazyStringParser.TryParseDateTime(lsv.Buffer, lsv.Size, out dt, out dto, index.Definition.Version >= IndexDefinitionBase.IndexVersion.ProperlyParseThreeDigitsMillisecondsDates);
                     break;
                 case string valueAsString:
                     fixed (char* buffer = valueAsString)
-                        result = LazyStringParser.TryParseDateTime(buffer, valueAsString.Length, out dt, out dto);
+                        result = LazyStringParser.TryParseDateTime(buffer, valueAsString.Length, out dt, out dto, index.Definition.Version >= IndexDefinitionBase.IndexVersion.ProperlyParseThreeDigitsMillisecondsDates);
                     break;
                 default:
                     var otherAsString = value.ToString();
                     fixed (char* buffer = otherAsString)
-                        result = LazyStringParser.TryParseDateTime(buffer, otherAsString.Length, out dt, out dto);
+                        result = LazyStringParser.TryParseDateTime(buffer, otherAsString.Length, out dt, out dto, index.Definition.Version >= IndexDefinitionBase.IndexVersion.ProperlyParseThreeDigitsMillisecondsDates);
                     break;
             }
 

--- a/src/Raven.Server/Utils/TypeConverter.cs
+++ b/src/Raven.Server/Utils/TypeConverter.cs
@@ -531,7 +531,7 @@ namespace Raven.Server.Utils
             var buffer = value.Buffer;
             var size = value.Size;
 
-            var result = LazyStringParser.TryParseDateTime(buffer, size, out DateTime dt, out DateTimeOffset dto);
+            var result = LazyStringParser.TryParseDateTime(buffer, size, out DateTime dt, out DateTimeOffset dto, properlyParseThreeDigitsMilliseconds: true);
             if (result == LazyStringParser.Result.DateTime)
                 return dt;
             if (result == LazyStringParser.Result.DateTimeOffset)
@@ -568,7 +568,7 @@ namespace Raven.Server.Utils
 
             fixed (char* str = value)
             {
-                var result = LazyStringParser.TryParseDateTime(str, value.Length, out DateTime dt, out DateTimeOffset dto);
+                var result = LazyStringParser.TryParseDateTime(str, value.Length, out DateTime dt, out DateTimeOffset dto,properlyParseThreeDigitsMilliseconds: true);
                 if (result == LazyStringParser.Result.DateTime)
                     output = dt;
                 if (result == LazyStringParser.Result.DateTimeOffset)

--- a/src/Sparrow/Json/LazyStringParser.cs
+++ b/src/Sparrow/Json/LazyStringParser.cs
@@ -345,7 +345,7 @@ namespace Sparrow.Json
         }
 
         [MethodImpl(MethodImplOptions.AggressiveInlining)]
-        public static Result TryParseDateTime(char* buffer, int len, out DateTime dt, out DateTimeOffset dto)
+        public static Result TryParseDateTime(char* buffer, int len, out DateTime dt, out DateTimeOffset dto, bool properlyParseThreeDigitsMilliseconds)
         {
             // PERF: We want this part of the code to be embedded into the caller code instead. 
             if (len < 19 || len > 33)
@@ -355,7 +355,7 @@ namespace Sparrow.Json
                 buffer[13] != ':' || buffer[16] != ':' || buffer[16] != ':')
                 goto Failed;
 
-            return TryParseDateTimeInternal(buffer, len, out dt, out dto);
+            return TryParseDateTimeInternal(buffer, len, out dt, out dto, properlyParseThreeDigitsMilliseconds);
 
             Failed:
             dt = default(DateTime);
@@ -363,7 +363,7 @@ namespace Sparrow.Json
             return Result.Failed;
         }
 
-        public static Result TryParseDateTimeInternal(char* buffer, int len, out DateTime dt, out DateTimeOffset dto)
+        public static Result TryParseDateTimeInternal(char* buffer, int len, out DateTime dt, out DateTimeOffset dto, bool properlyParseThreeDigitsMilliseconds)
         {
             if (TryParseNumber4(buffer, 0, out int year) == false)
                 goto Failed;
@@ -407,6 +407,8 @@ namespace Sparrow.Json
                         goto Failed;
                     if (TryParseNumber3(buffer, 20, out fractions) == false)
                         goto Failed;
+                    if (properlyParseThreeDigitsMilliseconds)
+                        fractions *= 10000;
                     goto Finished_DT;
                 case 25://"yyyy'-'MM'-'dd'T'HH':'mm':'ss'+'dd':'dd'",
                     if (buffer[22] != ':' || (buffer[19] != '+' && buffer[19] != '-'))
@@ -473,7 +475,7 @@ namespace Sparrow.Json
         }
 
         [MethodImpl(MethodImplOptions.AggressiveInlining)]
-        public static Result TryParseDateTime(byte* buffer, int len, out DateTime dt, out DateTimeOffset dto)
+        public static Result TryParseDateTime(byte* buffer, int len, out DateTime dt, out DateTimeOffset dto, bool properlyParseThreeDigitsMilliseconds)
         {
             // PERF: We want this part of the code to be embedded into the caller code instead. 
             if (len < 19 || len > 33)
@@ -483,7 +485,7 @@ namespace Sparrow.Json
                 buffer[13] != ':' || buffer[16] != ':' || buffer[16] != ':')
                 goto Failed;
 
-            return TryParseDateTimeInternal(buffer, len, out dt, out dto);
+            return TryParseDateTimeInternal(buffer, len, out dt, out dto, properlyParseThreeDigitsMilliseconds);
 
             Failed:
             dt = default(DateTime);
@@ -491,7 +493,7 @@ namespace Sparrow.Json
             return Result.Failed;
         }
 
-        private static Result TryParseDateTimeInternal(byte* buffer, int len, out DateTime dt, out DateTimeOffset dto)
+        private static Result TryParseDateTimeInternal(byte* buffer, int len, out DateTime dt, out DateTimeOffset dto, bool properlyParseThreeDigitsMilliseconds)
         {
             if (TryParseNumber4(buffer, 0, out int year) == false)
                 goto Failed;
@@ -535,6 +537,8 @@ namespace Sparrow.Json
                         goto Failed;
                     if (TryParseNumber3(buffer, 20, out fractions) == false)
                         goto Failed;
+                    if (properlyParseThreeDigitsMilliseconds)
+                        fractions *= 10000;
                     goto Finished_DT;
                 case 25://"yyyy'-'MM'-'dd'T'HH':'mm':'ss'+'dd':'dd'",
                     if (buffer[22] != ':' || (buffer[19] != '+' && buffer[19] != '-'))

--- a/test/FastTests/Utils/TimeParsing.cs
+++ b/test/FastTests/Utils/TimeParsing.cs
@@ -29,7 +29,7 @@ namespace FastTests.Utils
                 DateTime time;
                 DateTimeOffset dto;
                 Assert.Equal(LazyStringParser.Result.DateTime,
-                    LazyStringParser.TryParseDateTime(buffer, bytes.Length, out time, out dto));
+                    LazyStringParser.TryParseDateTime(buffer, bytes.Length, out time, out dto, properlyParseThreeDigitsMilliseconds: true));
                 Assert.Equal(expected, time);
             }
         }
@@ -87,7 +87,7 @@ namespace FastTests.Utils
                 DateTime time;
                 DateTimeOffset dto;
                 Assert.Equal(LazyStringParser.Result.DateTimeOffset,
-                    LazyStringParser.TryParseDateTime(buffer, bytes.Length, out time, out dto));
+                    LazyStringParser.TryParseDateTime(buffer, bytes.Length, out time, out dto, properlyParseThreeDigitsMilliseconds: true));
                 Assert.Equal(expected, dto);
             }
         }
@@ -107,7 +107,7 @@ namespace FastTests.Utils
                 DateTime time;
                 DateTimeOffset dto;
                 Assert.Equal(LazyStringParser.Result.Failed,
-                    LazyStringParser.TryParseDateTime(buffer, bytes.Length, out time, out dto));
+                    LazyStringParser.TryParseDateTime(buffer, bytes.Length, out time, out dto, properlyParseThreeDigitsMilliseconds: true));
             }
         }
     }

--- a/test/SlowTests/Issues/RavenDB-17711.cs
+++ b/test/SlowTests/Issues/RavenDB-17711.cs
@@ -1,0 +1,70 @@
+﻿using System;
+using System.Globalization;
+using System.Linq;
+using FastTests;
+using Raven.Client.Documents.Indexes;
+using Xunit;
+using Xunit.Abstractions;
+
+namespace SlowTests.Issues
+{
+    public class RavenDB_17711 : RavenTestBase
+    {
+        public RavenDB_17711(ITestOutputHelper output) : base(output)
+        {
+        }
+
+        private class Task
+        {
+            public object At;
+        }
+        
+        [Fact]
+        public void ThreeDigitsFractionalDateParsingShouldWorkProperly_AutoIndex()
+        {
+            using var store = GetDocumentStore();
+
+            using (var s = store.OpenSession())
+            {
+                s.Store(new Task{At = "2021-12-14T11:22:28.322Z"});
+                s.SaveChanges();
+            }
+
+            using (var s = store.OpenSession())
+            {
+                object date = new DateTime(2021, 12, 14, 11, 22, 28, 322, DateTimeKind.Utc);
+
+                Assert.True(s.Query<Task>().Any(t => t.At == date));
+            }
+        }
+
+        private class Index : AbstractIndexCreationTask<Task>
+        {
+            public Index()
+            {
+                Map = tasks => from t in tasks select new { t.At };
+            }
+        }
+          
+        [Fact]
+        public void ThreeDigitsFractionalDateParsingShouldWorkProperly_StaticIndex()
+        {
+            using var store = GetDocumentStore();
+
+            using (var s = store.OpenSession())
+            {
+                s.Store(new Task{At = "2021-12-14T11:22:28.322Z"});
+                s.SaveChanges();
+            }
+            new Index().Execute(store);
+            WaitForIndexing(store);
+
+            using (var s = store.OpenSession())
+            {
+                object date = new DateTime(2021, 12, 14, 11, 22, 28, 322, DateTimeKind.Utc);
+
+                Assert.True(s.Query<Task, Index>().Any(t => t.At == date));
+            }
+        }
+    }
+}


### PR DESCRIPTION
- Bad date parsing for"yyyy'-'MM'-'dd'T'HH':'mm':'ss'.'fff"
- Making sure that we properly handle index versioning for dates with 3 milliseconds digits, old indexes will retain the old format, while new ones will handle such dates properly.

### Issue link

https://issues.hibernatingrhinos.com/issue/RavenDB-17711

### Additional description

See details here: https://github.com/ravendb/ravendb/pull/13287

This is almost the same as the 4.2 version, but here we have to deal with versioning concerns, since the value _would_ work, but with wrong values.