### PR TITLE
RavenDB-17568 avoid rolling an index when documents been modified

### DIFF
--- a/src/Raven.Server/Documents/Indexes/Index.cs
+++ b/src/Raven.Server/Documents/Indexes/Index.cs
@@ -1418,7 +1418,7 @@ namespace Raven.Server.Documents.Indexes
 
                             _mre.Reset();
 
-                            Thread.Sleep(500); // replace will be re-tried
+                            _indexingProcessCancellationTokenSource.Token.WaitHandle.WaitOne(TimeSpan.FromMilliseconds(500)); // replace will be re-tried
                         }
 
                         DocumentDatabase.IndexStore.ForTestingPurposes?.OnRollingIndexStart?.Invoke(this);

--- a/src/Raven.Server/Documents/Indexes/IndexStore.cs
+++ b/src/Raven.Server/Documents/Indexes/IndexStore.cs
@@ -2535,6 +2535,7 @@ namespace Raven.Server.Documents.Indexes
             internal Action<string> AfterIndexCreation;
 
             internal Action<Index> OnRollingIndexFinished;
+            internal Action<Index> BeforeRollingIndexFinished;
             internal Action<Index> OnRollingIndexStart;
             internal Action<Index> BeforeRollingIndexStart;
             public TestingStuff(IndexStore parent)

--- a/src/Raven.Server/Utils/ThrottledManualResetEventSlim.cs
+++ b/src/Raven.Server/Utils/ThrottledManualResetEventSlim.cs
@@ -1,5 +1,4 @@
 ﻿using System;
-using System.Diagnostics;
 using System.Runtime.CompilerServices;
 using System.Threading;
 using System.Threading.Tasks;
@@ -193,7 +192,6 @@ namespace Raven.Server.Utils
 
             if (_setCalled.Lower())
             {
-                Debugger.Break();
                 _mre.Set();
             }
 

--- a/test/SlowTests/Rolling/RollingIndexesClusterTests.cs
+++ b/test/SlowTests/Rolling/RollingIndexesClusterTests.cs
@@ -3,6 +3,7 @@ using System.Collections.Concurrent;
 using System.Collections.Generic;
 using System.IO;
 using System.Linq;
+using System.Text;
 using System.Threading;
 using System.Threading.Tasks;
 using Orders;
@@ -66,6 +67,170 @@ namespace SlowTests.Rolling
                 await AssertWaitForValueAsync(() => Task.FromResult(count), 3L);
 
                 await VerifyHistory(cluster, store);
+            }
+        }
+
+        [Fact]
+        public async Task DeployRollingIndexWhileDocumentsModified()
+        {
+            DebuggerAttachedTimeout.DisableLongTimespan = true;
+            var cluster = await CreateRaftCluster(3, watcherCluster: true);
+            using (var store = GetDocumentStoreForRollingIndexes(
+                       new Options
+                       {
+                           Server = cluster.Leader, 
+                           ReplicationFactor = 3,
+                       }))
+            {
+                await CreateData(store);
+
+                
+                var count = 0L;
+                var violation = new StringBuilder();
+
+                foreach (var server in Servers)
+                {
+                    var database = await server.ServerStore.DatabasesLandlord.TryGetOrCreateResourceStore(store.Database);
+                    var indexStore = database.IndexStore;
+                    indexStore.ForTestingPurposesOnly().OnRollingIndexStart = index =>
+                    {
+                        var inc = Interlocked.Increment(ref count);
+                        if (inc > 1)
+                            violation.AppendLine($"{index} started concurrently (count: {inc})");
+                    };
+                    indexStore.ForTestingPurposesOnly().BeforeRollingIndexFinished = index =>
+                    {
+                        var dec = Interlocked.Decrement(ref count);
+                        if (dec != 0)
+                            violation.AppendLine($"finishing {index} must be zero but is {dec}");
+                    };
+                }
+
+                using (var cts = new CancellationTokenSource(TimeSpan.FromSeconds(10)))
+                {
+                    var t = ContinuouslyModifyDocuments(store, cts.Token);
+                    try
+                    {
+                        await store.ExecuteIndexAsync(new MyRollingIndex());
+
+                        WaitForIndexingInTheCluster(store, store.Database);
+
+                        var v = violation.ToString();
+                        Assert.True(string.IsNullOrEmpty(v), v);
+
+                        await VerifyHistory(cluster, store);
+                    }
+                    finally
+                    {
+                        try
+                        {
+                            cts.Cancel();
+                            await t;
+                        }
+                        catch
+                        {
+                            // ignore
+                        }
+                    }
+                }
+            }
+        }
+
+        [Fact]
+        public async Task EditRollingIndexWhileDocumentsModified()
+        {
+            DebuggerAttachedTimeout.DisableLongTimespan = true;
+            var cluster = await CreateRaftCluster(3, watcherCluster: true);
+            using (var store = GetDocumentStoreForRollingIndexes(
+                       new Options
+                       {
+                           Server = cluster.Leader, 
+                           ReplicationFactor = 3,
+                       }))
+            {
+                await CreateData(store);
+
+                await store.ExecuteIndexAsync(new MyRollingIndex());
+
+                WaitForIndexingInTheCluster(store, store.Database);
+
+                await VerifyHistory(cluster, store);
+
+                var count = 0L;
+                var violation = new StringBuilder();
+
+                foreach (var server in Servers)
+                {
+                    var database = await server.ServerStore.DatabasesLandlord.TryGetOrCreateResourceStore(store.Database);
+                    var indexStore = database.IndexStore;
+                    indexStore.ForTestingPurposesOnly().OnRollingIndexStart = index =>
+                    {
+                        if (index.Name != "ReplacementOf/MyRollingIndex")
+                            return;
+
+                        var inc = Interlocked.Increment(ref count);
+                        if (inc > 1)
+                            violation.AppendLine($"{index} started concurrently (count: {inc})");
+                    };
+                    indexStore.ForTestingPurposesOnly().BeforeRollingIndexFinished = index =>
+                    {
+                        var dec = Interlocked.Decrement(ref count);
+                        if (dec != 0)
+                            violation.AppendLine($"finishing {index} must be zero but is {dec}");
+                    };
+                }
+
+                using (var cts = new CancellationTokenSource(TimeSpan.FromSeconds(10)))
+                {
+                    var t = ContinuouslyModifyDocuments(store, cts.Token);
+                    try
+                    {
+                        await store.ExecuteIndexAsync(new MyEditedRollingIndex());
+
+                        WaitForIndexingInTheCluster(store, store.Database);
+
+                        var v = violation.ToString();
+                        Assert.True(string.IsNullOrEmpty(v), v);
+
+                        await VerifyHistory(cluster, store);
+                    }
+                    finally
+                    {
+                        try
+                        {
+                            cts.Cancel();
+                            await t;
+                        }
+                        catch
+                        {
+                            // ignore
+                        }
+                    }
+                }
+            }
+        }
+
+        private async Task ContinuouslyModifyDocuments(IDocumentStore store, CancellationToken token)
+        {
+            while (token.IsCancellationRequested == false)
+            {
+                try
+                {
+                    using (var session = store.OpenAsyncSession())
+                    {
+                        var o = await session.LoadAsync<Order>("orders/830-A");
+                        o.RequireAt = DateTime.UtcNow;
+                        await session.SaveChangesAsync(token);
+                    }
+                }
+                catch (OperationCanceledException)
+                {
+                    return;
+                }
+                catch
+                {
+                    await Task.Delay(500, token);
+                }
             }
         }
 


### PR DESCRIPTION
### Issue link

https://issues.hibernatingrhinos.com/issue/RavenDB-17568

### Additional description

Fix an issue when index was rolling out upon document change that would trigger the `_mre`

### Type of change

- Bug fix

### How risky is the change?

- Low 

### Backward compatibility

- Not relevant

### Is it platform specific issue?

- No

### Documentation update

- No documentation update is needed 

### Testing 

- Tests have been added that prove the fix is effective or that the feature works
- It has been verified by manual testing

### Is there any existing behavior change of other features due to this change?

- No

### UI work

- No UI work is needed
