### PR TITLE
RavenDB-17689 Invalid load document results when we are projecting a …

### DIFF
--- a/src/Raven.Server/Documents/Document.cs
+++ b/src/Raven.Server/Documents/Document.cs
@@ -27,6 +27,7 @@ namespace Raven.Server.Documents
         public DocumentFlags Flags;
         public NonPersistentDocumentFlags NonPersistentFlags;
         public short TransactionMarker;
+        public bool IgnoreDispose;
 
         public unsafe ulong DataHash
         {
@@ -88,6 +89,14 @@ namespace Raven.Server.Documents
 
         public Document Clone(DocumentsOperationContext context)
         {
+            var newData = Data.Clone(context);
+            return CloneWith(context, newData);
+        }
+
+        public Document CloneWith(JsonOperationContext context, BlittableJsonReaderObject newData)
+        {
+            var newId = context.GetLazyString(Id);
+            var newLowerId = context.GetLazyString(LowerId);
             return new Document
             {
                 Etag = Etag,
@@ -99,10 +108,9 @@ namespace Raven.Server.Documents
                 Flags = Flags,
                 NonPersistentFlags = NonPersistentFlags,
                 TransactionMarker = TransactionMarker,
-
-                Id = context.GetLazyString(Id),
-                LowerId = context.GetLazyString(LowerId),
-                Data = Data.Clone(context),
+                Id = newId,
+                LowerId = newLowerId,
+                Data = newData,
             };
         }
 

--- a/test/SlowTests/Issues/RavenDB-17689.cs
+++ b/test/SlowTests/Issues/RavenDB-17689.cs
@@ -1,0 +1,78 @@
+﻿using System;
+using System.Collections.Generic;
+using System.Linq;
+using System.Text;
+using System.Threading.Tasks;
+using FastTests;
+using Xunit;
+using Xunit.Abstractions;
+
+namespace SlowTests.Issues
+{
+    public class RavenDB_17689 : RavenTestBase
+    {
+        public RavenDB_17689(ITestOutputHelper output) : base(output)
+        {
+        }
+
+        private class Employee
+        {
+            public Employee(string FirstName, string Manager)
+            {
+                this.FirstName = FirstName;
+                this.Manager = Manager;
+            }
+
+            public string FirstName { get; }
+            public string Manager { get; }
+
+        }
+
+        private class Projection
+        {
+            public Projection(string e, string r)
+            {
+                this.e = e;
+                this.r = r;
+            }
+
+            public string e { get; }
+            public string r { get; }
+
+        }
+
+        [Fact]
+        public void CanQueryOnProjectionsThatWeAlsoReturn()
+        {
+            using var store = GetDocumentStore();
+
+            using(var session = store.OpenSession())
+            {
+                session.Store(new Employee("Smith", "emps/jane"));
+                session.Store(new Employee("Jane", null), "emps/jane");
+                session.Store(new Employee("Sandra", "emps/jane"));
+                session.SaveChanges();
+            }
+
+            using (var session = store.OpenSession())
+            {
+                var emps = session.Advanced.RawQuery<Projection>(@"
+from Employees  as e
+load e.Manager as r
+select e.FirstName as e, r.FirstName as r")
+                    .ToList();
+                WaitForUserToContinueTheTest(store);
+                Assert.Equal(3, emps.Count);
+                int notNull = 0;
+                foreach (var emp in emps)
+                {
+                    if (emp.r != null)
+                        notNull++;
+                }
+                Assert.Equal(2, notNull);
+
+
+            }
+        }
+    }
+}


### PR DESCRIPTION
…document as well as loading it.

Create a new instance of document if this is required. Will avoid adding clone / allocations to the query code path unless this is actually in use.

### Issue link

https://issues.hibernatingrhinos.com/issue/RavenDB-17689 

See discussion at https://github.com/ravendb/ravendb/pull/13256