### PR TITLE
RavenDB-17725 Allow to abort queries from the studio

### DIFF
--- a/src/Raven.Server/Documents/Handlers/QueriesHandler.cs
+++ b/src/Raven.Server/Documents/Handlers/QueriesHandler.cs
@@ -200,13 +200,14 @@ namespace Raven.Server.Documents.Handlers
         private async Task<IndexQueryServerSide> GetIndexQuery(JsonOperationContext context, HttpMethod method, RequestTimeTracker tracker)
         {
             var addSpatialProperties = GetBoolValueQueryString("addSpatialProperties", required: false) ?? false;
+            var clientQueryId = GetStringQueryString("clientQueryId", required: false);
 
             if (method == HttpMethod.Get)
-                return await IndexQueryServerSide.CreateAsync(HttpContext, GetStart(), GetPageSize(), context, tracker, addSpatialProperties);
+                return await IndexQueryServerSide.CreateAsync(HttpContext, GetStart(), GetPageSize(), context, tracker, addSpatialProperties, clientQueryId);
 
             var json = await context.ReadForMemoryAsync(RequestBodyStream(), "index/query");
 
-            return IndexQueryServerSide.Create(HttpContext, json, Database.QueryMetadataCache, tracker, addSpatialProperties, Database);
+            return IndexQueryServerSide.Create(HttpContext, json, Database.QueryMetadataCache, tracker, addSpatialProperties, clientQueryId, Database);
         }
 
         private async Task SuggestQuery(IndexQueryServerSide indexQuery, QueryOperationContext queryContext, OperationCancelToken token)

--- a/src/Raven.Server/Documents/Queries/IndexQueryServerSide.cs
+++ b/src/Raven.Server/Documents/Queries/IndexQueryServerSide.cs
@@ -84,6 +84,7 @@ namespace Raven.Server.Documents.Queries
         public bool AddTimeSeriesNames;
 
         public bool IsStream;
+        public  string ClientQueryId;
 
         public IndexQueryServerSide(string query, BlittableJsonReaderObject queryParameters = null)
         {
@@ -104,6 +105,8 @@ namespace Raven.Server.Documents.Queries
             try
             {
                 result = JsonDeserializationServer.IndexQuery(json);
+                if (httpContext.Request.Query.TryGetValue("clientQueryId", out var v))
+                    result.ClientQueryId = v[0];
 
                 if (result.PageSize == 0 && json.TryGet(nameof(PageSize), out int _) == false)
                     result.PageSize = int.MaxValue;
@@ -202,6 +205,9 @@ namespace Raven.Server.Documents.Queries
                                     result.QueryParameters = await context.ReadForMemoryAsync(stream, "query parameters");
                                 }
                                 continue;
+                            case "clientQueryId":
+                                result.ClientQueryId = item.Value[0];
+                                break;
                             case "waitForNonStaleResults":
                                 result.WaitForNonStaleResults = bool.Parse(item.Value[0]);
                                 break;

--- a/src/Raven.Server/Documents/Queries/IndexQueryServerSide.cs
+++ b/src/Raven.Server/Documents/Queries/IndexQueryServerSide.cs
@@ -2,7 +2,6 @@
 using System.Collections.Generic;
 using System.IO;
 using System.Text;
-using System.Threading;
 using System.Threading.Tasks;
 using Microsoft.AspNetCore.Http;
 using Raven.Client;
@@ -84,7 +83,7 @@ namespace Raven.Server.Documents.Queries
         public bool AddTimeSeriesNames;
 
         public bool IsStream;
-        public  string ClientQueryId;
+        public string ClientQueryId;
 
         public IndexQueryServerSide(string query, BlittableJsonReaderObject queryParameters = null)
         {
@@ -98,6 +97,7 @@ namespace Raven.Server.Documents.Queries
             QueryMetadataCache cache,
             RequestTimeTracker tracker,
             bool addSpatialProperties = false,
+            string clientQueryId = null,
             DocumentDatabase database = null,
             QueryType queryType = QueryType.Select)
         {
@@ -105,8 +105,7 @@ namespace Raven.Server.Documents.Queries
             try
             {
                 result = JsonDeserializationServer.IndexQuery(json);
-                if (httpContext.Request.Query.TryGetValue("clientQueryId", out var v))
-                    result.ClientQueryId = v[0];
+                result.ClientQueryId = clientQueryId;
 
                 if (result.PageSize == 0 && json.TryGet(nameof(PageSize), out int _) == false)
                     result.PageSize = int.MaxValue;
@@ -173,7 +172,7 @@ namespace Raven.Server.Documents.Queries
             }
         }
 
-        public static async Task<IndexQueryServerSide> CreateAsync(HttpContext httpContext, int start, int pageSize, JsonOperationContext context, RequestTimeTracker tracker, bool addSpatialProperties = false, string overrideQuery = null)
+        public static async Task<IndexQueryServerSide> CreateAsync(HttpContext httpContext, int start, int pageSize, JsonOperationContext context, RequestTimeTracker tracker, bool addSpatialProperties = false, string clientQueryId = null, string overrideQuery = null)
         {
             IndexQueryServerSide result = null;
             try
@@ -188,7 +187,8 @@ namespace Raven.Server.Documents.Queries
                     Query = Uri.UnescapeDataString(actualQuery),
                     // all defaults which need to have custom value
                     Start = start,
-                    PageSize = pageSize
+                    PageSize = pageSize,
+                    ClientQueryId = clientQueryId
                 };
 
                 foreach (var item in httpContext.Request.Query)
@@ -205,9 +205,6 @@ namespace Raven.Server.Documents.Queries
                                     result.QueryParameters = await context.ReadForMemoryAsync(stream, "query parameters");
                                 }
                                 continue;
-                            case "clientQueryId":
-                                result.ClientQueryId = item.Value[0];
-                                break;
                             case "waitForNonStaleResults":
                                 result.WaitForNonStaleResults = bool.Parse(item.Value[0]);
                                 break;
@@ -229,7 +226,7 @@ namespace Raven.Server.Documents.Queries
                 }
 
                 result.Metadata = new QueryMetadata(result.Query, result.QueryParameters, 0, addSpatialProperties);
-                
+
                 if (result.Metadata.HasTimings)
                     result.Timings = new QueryTimingsScope(start: false);
 


### PR DESCRIPTION
### Issue link

https://issues.hibernatingrhinos.com/issue/RavenDB-17725

### Additional description

Allow the studio to create a unique id before sending a query, which can then be used to cancel it.

### Type of change

- New feature

### How risky is the change?

- Low 

### Backward compatibility

- Non breaking change

### UI work

- It requires further work in the Studio
