### PR TITLE
RavenDB-17687 Adding default value of QueryInspectionNode to avoid calling null delegate.

### DIFF
--- a/src/Corax/Queries/BinaryMatch.cs
+++ b/src/Corax/Queries/BinaryMatch.cs
@@ -112,7 +112,7 @@ namespace Corax.Queries
 
         public QueryInspectionNode Inspect()
         {
-            return _inspectFunc(ref this);
+            return _inspectFunc is null ? QueryInspectionNode.NotInitializedInspectionNode(nameof(BinaryMatch)) : _inspectFunc(ref this);
         }
 
         string DebugView => Inspect().ToString();

--- a/src/Corax/Queries/BoostingMatch.cs
+++ b/src/Corax/Queries/BoostingMatch.cs
@@ -188,7 +188,7 @@ namespace Corax.Queries
 
         public QueryInspectionNode Inspect()
         {
-            return _inspectFunc(ref this);
+            return _inspectFunc is null ? QueryInspectionNode.NotInitializedInspectionNode(nameof(BoostingMatch)) : _inspectFunc(ref this);
         }
 
         string DebugView => Inspect().ToString();

--- a/src/Corax/Queries/MultiTermBoostingMatch.cs
+++ b/src/Corax/Queries/MultiTermBoostingMatch.cs
@@ -227,7 +227,7 @@ namespace Corax.Queries
 
         public QueryInspectionNode Inspect()
         {
-            return _inspectFunc(ref this);
+            return _inspectFunc is null ? QueryInspectionNode.NotInitializedInspectionNode(nameof(MultiTermBoostingMatch<TTermProvider>)) : _inspectFunc(ref this);
         }
 
         string DebugView => Inspect().ToString();

--- a/src/Corax/Queries/QueryInspectionNode.cs
+++ b/src/Corax/Queries/QueryInspectionNode.cs
@@ -16,6 +16,8 @@ namespace Corax.Queries
             Children = children ?? new List<QueryInspectionNode>();
         }
 
+        public static QueryInspectionNode NotInitializedInspectionNode(string nameOperation) => new($"Not initialized: {nameOperation}");
+
         public override string ToString()
         {
             return ToString(this, 0);

--- a/src/Corax/Queries/TermMatch.cs
+++ b/src/Corax/Queries/TermMatch.cs
@@ -454,7 +454,7 @@ namespace Corax.Queries
 
         public QueryInspectionNode Inspect()
         {
-            return _inspectFunc(ref this);
+            return _inspectFunc is null ? QueryInspectionNode.NotInitializedInspectionNode(nameof(TermMatch)) : _inspectFunc(ref this);
         }
 
         string DebugView => Inspect().ToString();


### PR DESCRIPTION
### Issue link

https://issues.hibernatingrhinos.com/issue/RavenDB-17687

### Additional description

Visual Studio will try to evaluate DebugVisualiser before we even initialize our node so we want to avoid calling null delegate.

### Type of change

- Bug fix


### How risky is the change?

- Low 

### Backward compatibility

- Not relevant

### Is it platform specific issue?

- No

### Documentation update

- No documentation update is needed 

### Testing 

- It has been verified by manual testing

### Is there any existing behavior change of other features due to this change?

- No

### UI work

- No UI work is needed
