### PR TITLE
RavenDB-17317 - Time series value does not update across all nodes

### DIFF
--- a/test/SlowTests/Issues/RavenDB_15240.cs
+++ b/test/SlowTests/Issues/RavenDB_15240.cs
@@ -43,7 +43,7 @@ namespace SlowTests.Issues
                 var state = tombstoneCleaner.GetState();
 
                 Assert.Equal(0, state["Companies"].Documents.Etag);
-                Assert.Equal(3, state["Companies"].TimeSeries.Etag);
+                Assert.Equal(2, state["Companies"].TimeSeries.Etag);
 
                 using (var session = store.OpenSession())
                 {
@@ -59,7 +59,7 @@ namespace SlowTests.Issues
                 state = tombstoneCleaner.GetState();
 
                 Assert.Equal(0, state["Companies"].Documents.Etag);
-                Assert.Equal(10, state["Companies"].TimeSeries.Etag);
+                Assert.Equal(8, state["Companies"].TimeSeries.Etag);
 
                 using (var session = store.OpenSession())
                 {
@@ -74,8 +74,8 @@ namespace SlowTests.Issues
 
                 state = tombstoneCleaner.GetState();
 
-                Assert.Equal(12, state["Companies"].Documents.Etag);
-                Assert.Equal(10, state["Companies"].TimeSeries.Etag);
+                Assert.Equal(10, state["Companies"].Documents.Etag);
+                Assert.Equal(8, state["Companies"].TimeSeries.Etag);
             }
         }
 

--- a/test/SlowTests/Issues/RavenDB_17317.cs
+++ b/test/SlowTests/Issues/RavenDB_17317.cs
@@ -1,0 +1,413 @@
+﻿using System;
+using System.Diagnostics;
+using System.Threading.Tasks;
+using FastTests.Server.Replication;
+using Raven.Client.Documents.Session;
+using Xunit;
+using Xunit.Abstractions;
+
+namespace SlowTests.Issues
+{
+    public class RavenDB_17317 : ReplicationTestBase
+    {
+        public RavenDB_17317(ITestOutputHelper output) : base(output)
+        {
+        }
+
+        [Fact]
+        public async Task CanReplicateEntireSegmentOnUpdate_TimeSeries()
+        {
+            var baseline = DateTime.UtcNow;
+
+            using (var storeA = GetDocumentStore())
+            using (var storeB = GetDocumentStore())
+            {
+                using (var session = storeA.OpenSession())
+                {
+                    session.Store(new User { Name = "user/1" }, "users/ayende");
+                    session.SaveChanges();
+                }
+
+                using (var session = storeB.OpenSession())
+                {
+                    session.Store(new User { Name = "user/1" }, "users/ayende");
+                    session.SaveChanges();
+                }
+
+                using (var session = storeA.OpenSession())
+                {
+                    var ts = session.TimeSeriesFor("users/ayende", "HeartRates");
+
+                    for (int j = 0; j < 10; j++)
+                        ts.Append(baseline.AddMinutes(j), 100);
+
+                    session.SaveChanges();
+                }
+
+                using (var session = storeB.OpenSession())
+                {
+                    var ts = session.TimeSeriesFor("users/ayende", "HeartRates");
+
+                    for (int j = 0; j < 10; j++)
+                        ts.Append(baseline.AddMinutes(j), 100);
+
+                    session.SaveChanges();
+                }
+
+                await SetupReplicationAsync(storeA, storeB);
+                await SetupReplicationAsync(storeB, storeA);
+
+                await EnsureReplicatingAsync(storeA, storeB);
+                await EnsureReplicatingAsync(storeB, storeA);
+
+                await EnsureNoReplicationLoop(Server, storeA.Database);
+                await EnsureNoReplicationLoop(Server, storeB.Database);
+
+                using (var session = storeA.OpenSession())
+                {
+                    var ts = session.TimeSeriesFor("users/ayende", "HeartRates");
+                    ts.Append(baseline, 50);
+                    session.SaveChanges();
+                }
+
+                await EnsureReplicatingAsync(storeA, storeB);
+                await EnsureReplicatingAsync(storeB, storeA);
+
+                await EnsureNoReplicationLoop(Server, storeA.Database);
+                await EnsureNoReplicationLoop(Server, storeB.Database);
+
+                using (var sessionA = storeA.OpenSession())
+                using (var sessionB = storeB.OpenSession())
+                {
+                    var tsA = sessionA.TimeSeriesFor("users/ayende", "HeartRates").Get();
+                    var tsB = sessionB.TimeSeriesFor("users/ayende", "HeartRates").Get();
+
+                    Assert.Equal(tsA.Length, tsB.Length);
+                    Assert.Equal(50, tsA[0].Value);
+                    Assert.Equal(50, tsB[0].Value);
+
+                    for (int i = 1; i < tsA.Length; i++)
+                    {
+                        Assert.Equal(100, tsA[i].Value);
+                        Assert.Equal(100, tsB[i].Value);
+                    }
+                }
+            }
+        }
+
+        [Fact]
+        public async Task CanReplicateEntireSegmentOnUpdate_TimeSeries2()
+        {
+            var baseline = DateTime.UtcNow;
+
+            using (var storeA = GetDocumentStore())
+            using (var storeB = GetDocumentStore())
+            {
+                using (var session = storeA.OpenSession())
+                {
+                    session.Store(new User { Name = "user/1" }, "users/ayende");
+                    session.SaveChanges();
+                }
+
+                using (var session = storeB.OpenSession())
+                {
+                    session.Store(new User { Name = "user/1" }, "users/ayende");
+                    session.SaveChanges();
+                }
+
+                using (var session = storeA.OpenSession())
+                {
+                    var ts = session.TimeSeriesFor("users/ayende", "HeartRates");
+
+                    for (int j = 0; j < 10; j++)
+                        ts.Append(baseline.AddMinutes(j), 100);
+
+                    session.SaveChanges();
+                }
+
+                using (var session = storeB.OpenSession())
+                {
+                    var ts = session.TimeSeriesFor("users/ayende", "HeartRates");
+
+                    for (int j = 0; j < 10; j++)
+                        ts.Append(baseline.AddMinutes(j), 100);
+
+                    session.SaveChanges();
+                }
+
+                await SetupReplicationAsync(storeA, storeB);
+                await SetupReplicationAsync(storeB, storeA);
+
+                await EnsureReplicatingAsync(storeA, storeB);
+                await EnsureReplicatingAsync(storeB, storeA);
+
+                await EnsureNoReplicationLoop(Server, storeA.Database);
+                await EnsureNoReplicationLoop(Server, storeB.Database);
+
+                using (var session = storeA.OpenSession())
+                {
+                    var ts = session.TimeSeriesFor("users/ayende", "HeartRates");
+                    ts.Append(baseline, 50);
+                    session.SaveChanges();
+                }
+
+                await EnsureReplicatingAsync(storeA, storeB);
+                await EnsureReplicatingAsync(storeB, storeA);
+
+                await EnsureNoReplicationLoop(Server, storeA.Database);
+                await EnsureNoReplicationLoop(Server, storeB.Database);
+
+                using (var sessionA = storeA.OpenSession())
+                using (var sessionB = storeB.OpenSession())
+                {
+                    var tsA = sessionA.TimeSeriesFor("users/ayende", "HeartRates").Get();
+                    var tsB = sessionB.TimeSeriesFor("users/ayende", "HeartRates").Get();
+
+                    Assert.Equal(tsA.Length, tsB.Length);
+                    Assert.Equal(50, tsA[0].Value);
+                    Assert.Equal(50, tsB[0].Value);
+
+                    for (int i = 1; i < tsA.Length; i++)
+                    {
+                        Assert.Equal(100, tsA[i].Value);
+                        Assert.Equal(100, tsB[i].Value);
+                    }
+                }
+
+                using (var session = storeB.OpenSession())
+                {
+                    var ts = session.TimeSeriesFor("users/ayende", "HeartRates");
+                    ts.Append(baseline, 15);
+                    session.SaveChanges();
+                }
+
+                await EnsureReplicatingAsync(storeA, storeB);
+                await EnsureReplicatingAsync(storeB, storeA);
+
+                await EnsureNoReplicationLoop(Server, storeA.Database);
+                await EnsureNoReplicationLoop(Server, storeB.Database);
+
+                using (var sessionA = storeA.OpenSession())
+                using (var sessionB = storeB.OpenSession())
+                {
+                    var tsA = sessionA.TimeSeriesFor("users/ayende", "HeartRates").Get();
+                    var tsB = sessionB.TimeSeriesFor("users/ayende", "HeartRates").Get();
+
+                    Assert.Equal(tsA.Length, tsB.Length);
+                    Assert.Equal(15, tsA[0].Value);
+                    Assert.Equal(15, tsB[0].Value);
+                }
+            }
+        }
+
+        [Fact]
+        public async Task CanUpdateExistingSegmentWithMoreValues()
+        {
+            var baseline = DateTime.UtcNow;
+
+            using (var storeA = GetDocumentStore())
+            using (var storeB = GetDocumentStore())
+            {
+                using (var session = storeA.OpenSession())
+                {
+                    session.Store(new User { Name = "user/1" }, "users/ayende");
+                    session.SaveChanges();
+                }
+
+                using (var session = storeB.OpenSession())
+                {
+                    session.Store(new User { Name = "user/1" }, "users/ayende");
+                    session.SaveChanges();
+                }
+
+                using (var session = storeA.OpenSession())
+                {
+                    var ts = session.TimeSeriesFor("users/ayende", "HeartRates");
+
+                    for (int j = 0; j < 10; j++)
+                        ts.Append(baseline.AddMinutes(j), 100);
+
+                    session.SaveChanges();
+                }
+
+                using (var session = storeB.OpenSession())
+                {
+                    var ts = session.TimeSeriesFor("users/ayende", "HeartRates");
+
+                    for (int j = 0; j < 10; j++)
+                        ts.Append(baseline.AddMinutes(j), 100);
+
+                    session.SaveChanges();
+                }
+
+                await SetupReplicationAsync(storeA, storeB);
+                await SetupReplicationAsync(storeB, storeA);
+
+                await EnsureReplicatingAsync(storeA, storeB);
+                await EnsureReplicatingAsync(storeB, storeA);
+
+                await EnsureNoReplicationLoop(Server, storeA.Database);
+                await EnsureNoReplicationLoop(Server, storeB.Database);
+
+                using (var session = storeA.OpenSession())
+                {
+                    var ts = session.TimeSeriesFor("users/ayende", "HeartRates");
+                    ts.Append(baseline.AddMinutes(10), 100);
+                    session.SaveChanges();
+                }
+
+                await EnsureReplicatingAsync(storeA, storeB);
+                await EnsureReplicatingAsync(storeB, storeA);
+
+                await EnsureNoReplicationLoop(Server, storeA.Database);
+                await EnsureNoReplicationLoop(Server, storeB.Database);
+
+                using (var sessionA = storeA.OpenSession())
+                using (var sessionB = storeB.OpenSession())
+                {
+                    var tsA = sessionA.TimeSeriesFor("users/ayende", "HeartRates").Get();
+                    var tsB = sessionB.TimeSeriesFor("users/ayende", "HeartRates").Get();
+
+                    Assert.Equal(tsA.Length, tsB.Length);
+                    Assert.Equal(11, tsA.Length);
+
+                    for (int i = 0; i < tsA.Length; i++)
+                    {
+                        Assert.Equal(100, tsA[i].Value);
+                        Assert.Equal(100, tsB[i].Value);
+                    }
+                }
+            }
+        }
+
+        [Fact]
+        public async Task CanDeleteEntireSegment()
+        {
+            var baseline = DateTime.UtcNow;
+
+            using (var storeA = GetDocumentStore())
+            using (var storeB = GetDocumentStore())
+            {
+                using (var session = storeA.OpenSession())
+                {
+                    session.Store(new User { Name = "user/1" }, "users/ayende");
+                    session.SaveChanges();
+                }
+
+                using (var session = storeB.OpenSession())
+                {
+                    session.Store(new User { Name = "user/1" }, "users/ayende");
+                    session.SaveChanges();
+                }
+
+                using (var session = storeA.OpenSession())
+                {
+                    var ts = session.TimeSeriesFor("users/ayende", "HeartRates");
+
+                    for (int j = 0; j < 10; j++)
+                        ts.Append(baseline.AddMinutes(j), 100);
+
+                    session.SaveChanges();
+                }
+
+                using (var session = storeB.OpenSession())
+                {
+                    var ts = session.TimeSeriesFor("users/ayende", "HeartRates");
+
+                    for (int j = 0; j < 10; j++)
+                        ts.Append(baseline.AddMinutes(j), 100);
+
+                    session.SaveChanges();
+                }
+
+                await SetupReplicationAsync(storeA, storeB);
+                await SetupReplicationAsync(storeB, storeA);
+
+                await EnsureReplicatingAsync(storeA, storeB);
+                await EnsureReplicatingAsync(storeB, storeA);
+
+                await EnsureNoReplicationLoop(Server, storeA.Database);
+                await EnsureNoReplicationLoop(Server, storeB.Database);
+
+                using (var session = storeA.OpenSession())
+                {
+                    var ts = session.TimeSeriesFor("users/ayende", "HeartRates");
+                    ts.Delete();
+                    session.SaveChanges();
+                }
+
+                await EnsureReplicatingAsync(storeA, storeB);
+                await EnsureReplicatingAsync(storeB, storeA);
+
+                await EnsureNoReplicationLoop(Server, storeA.Database);
+                await EnsureNoReplicationLoop(Server, storeB.Database);
+
+                using (var sessionA = storeA.OpenSession())
+                using (var sessionB = storeB.OpenSession())
+                {
+                    var tsA = sessionA.TimeSeriesFor("users/ayende", "HeartRates").Get();
+                    var tsB = sessionB.TimeSeriesFor("users/ayende", "HeartRates").Get();
+
+                    Assert.Null(tsA);
+                    Assert.Null(tsB);
+                }
+            }
+        }
+
+        [Fact]
+        public async Task ClusterNodesShouldHaveTheSameChangeVectorAfterTimeSeriesValueDelete()
+        {
+            DateTime baseline = DateTime.Today;
+            var cluster = await CreateRaftCluster(3);
+            var database = GetDatabaseName();
+            await CreateDatabaseInCluster(database, 3, cluster.Leader.WebUrl);
+
+            using (var store = GetDocumentStore(new Options
+            {
+                CreateDatabase = false,
+                Server = cluster.Leader,
+                ModifyDatabaseName = _ => database
+            }))
+            {
+                using (var session = store.OpenSession())
+                {
+                    session.Store(new User { Name = "EGR" }, "user/322");
+                    session.SaveChanges();
+                }
+
+                using (var session = store.OpenSession())
+                {
+                    var tsf = session.TimeSeriesFor("user/322", "raven");
+                    tsf.Append(baseline, new[] { (double)0 }, "watches/apple");
+                    tsf.Append(baseline.AddMinutes(1), new[] { (double)1 }, "watches/apple");
+                    session.SaveChanges();
+                }
+
+                using (var session = store.OpenSession())
+                {
+                    var user = session.Load<User>("user/322");
+                    var tsf = session.TimeSeriesFor(user, "raven");
+
+                    tsf.Delete(baseline.AddMinutes(0));
+                    session.SaveChanges();
+                }
+
+                using (var session = store.OpenSession())
+                {
+                    var markerId = $"marker/{Guid.NewGuid()}";
+                    session.Store(new User { Name = "Karmel" }, markerId);
+                    session.SaveChanges();
+                    Assert.True(await WaitForDocumentInClusterAsync<User>((DocumentSession)session, markerId, (u) => u.Id == markerId, Debugger.IsAttached ? TimeSpan.FromSeconds(60) : TimeSpan.FromSeconds(15)));
+                }
+
+                Assert.True(await WaitForChangeVectorInClusterAsync(cluster.Nodes, database));
+            }
+        }
+
+        private class User
+        {
+            public string Id;
+            public string Name;
+        }
+    }
+}

--- a/test/SlowTests/Server/Documents/TimeSeries/TimeSeriesTombstoneCleaner.cs
+++ b/test/SlowTests/Server/Documents/TimeSeries/TimeSeriesTombstoneCleaner.cs
@@ -318,8 +318,7 @@ namespace SlowTests.Server.Documents.TimeSeries
                     Assert.True(await WaitForDocumentInClusterAsync<User>(cluster.Nodes, store.Database, markerId, (u) => u.Id == markerId, Debugger.IsAttached ? TimeSpan.FromSeconds(60) : TimeSpan.FromSeconds(15)));
                 }
 
-                // TODO: RavenDB-16914
-                //  Assert.True(await WaitForChangeVectorInClusterAsync(cluster.Nodes, database));
+                Assert.True(await WaitForChangeVectorInClusterAsync(cluster.Nodes, database), "await WaitForChangeVectorInClusterAsync(cluster.Nodes, database)");
 
                 foreach (var server in cluster.Nodes)
                 {

--- a/test/Tryouts/Program.cs
+++ b/test/Tryouts/Program.cs
@@ -3,6 +3,7 @@ using System.Diagnostics;
 using System.Threading.Tasks;
 using FastTests.Blittable;
 using FastTests.Client;
+using SlowTests.Client.TimeSeries.Replication;
 using SlowTests.Issues;
 using SlowTests.MailingList;
 using SlowTests.Rolling;
@@ -28,9 +29,9 @@ namespace Tryouts
                 try
                 {
                     using (var testOutputHelper = new ConsoleTestOutputHelper())
-                    using (var test = new RollingIndexesClusterTests(testOutputHelper))
+                    using (var test = new TimeSeriesReplicationTests(testOutputHelper))
                     {
-                         await test.RemoveNodeFromDatabaseGroupWhileRollingDeployment();
+                         await test.PreferDeletedValues3();
                     }
                 }
                 catch (Exception e)


### PR DESCRIPTION
### Issue link

https://issues.hibernatingrhinos.com/issue/RavenDB-17317

### Additional description

_Moving changes from 5.3 to 5.2_ (https://github.com/ravendb/ravendb/pull/12982).

**This PR includes the following bug fixes/optimizations:**
1. Changes made to enable TS values' update (see example below).
2. Replication & import operations optimization:  instead of decompressing every single segment (and reading it), we put it directly (of course - only if it isn't overlapping any existing one). Original issue: https://issues.hibernatingrhinos.com/issue/RavenDB-14851.
3. Fix for RavenDB-16914 Different change vector on cluster nodes after time series value delete (https://issues.hibernatingrhinos.com/issue/RavenDB-16914).
4. Fix for RavenDB-17718 Assertion failed at `Trying to insert a new segment, but load one with overlapping ranges` (https://issues.hibernatingrhinos.com/issue/RavenDB-17718)

### Type of change

- Bug fix
- Optimization

### How risky is the change?

- Moderate

### Backward compatibility

- Not relevant

### Is it platform specific issue?

- No

### Documentation update

- No documentation update is needed 

### Testing 

- Tests have been added that prove the fix is effective or that the feature works
- It has been verified by manual testing

### Is there any existing behavior change of other features due to this change?

- Yes. Time Series & Incremental Time Series conflict resolving behavior:
** On replication Update:
*** before changes: instead of choosing the newest version without comparing each segment value -> we compare each value and choose the highest values (as in Conflict status flow).
*** after changes: accept the update.

For example:
- TS **"HeartRates"** on 3 nodes [A, B, C], with a single entry:
{Timestamp: 12:00:00, Value: 75, Tag: "watches/fitbit"}.
- Node B edits the existing entry's value to 4.

**"HeartRates"**

before the change:
```
Node A: {Timestamp: 12:00:00, Value: 75, Tag: "watches/fitbit"}
Node B: {Timestamp: 12:00:00, Value: 4, Tag: "watches/fitbit"}
Node C: {Timestamp: 12:00:00, Value: 75, Tag: "watches/fitbit"}
```

after the change:
```
Node A: {Timestamp: 12:00:00, Value: 4, Tag: "watches/fitbit"}
Node B: {Timestamp: 12:00:00, Value: 4, Tag: "watches/fitbit"}
Node C: {Timestamp: 12:00:00, Value: 4, Tag: "watches/fitbit"}
```

### UI work

- No UI work is needed
