### PR TITLE
RavenDB-7829 Use HSTS to remember that the studio is running with HTTPS

### DIFF
--- a/src/Raven.Server/Config/Categories/SecurityConfiguration.cs
+++ b/src/Raven.Server/Config/Categories/SecurityConfiguration.cs
@@ -17,6 +17,11 @@ namespace Raven.Server.Config.Categories
         [DefaultValue(false)]
         [ConfigurationEntry("Security.DisableHttpsRedirection", ConfigurationEntryScope.ServerWideOnly)]
         public bool DisableHttpsRedirection { get; set; }
+        
+        [Description("Disable HTTP Strict Transport Security")]
+        [DefaultValue(false)]
+        [ConfigurationEntry("Security.DisableHsts", ConfigurationEntryScope.ServerWideOnly)]
+        public bool DisableHsts { get; set; }
 
         [Description("The path to a folder where RavenDB will store the access audit logs")]
         [DefaultValue(null)]

--- a/src/Raven.Server/Web/System/StudioHandler.cs
+++ b/src/Raven.Server/Web/System/StudioHandler.cs
@@ -167,6 +167,7 @@ namespace Raven.Server.Web.System
             
             var error = GetStringQueryString("err");
             HttpContext.Response.Headers["Content-Type"] = "text/html; charset=utf-8";
+            SetupSecurityHeaders();
             return HttpContext.Response.WriteAsync(HtmlUtil.RenderStudioAuthErrorPage(error));
         }
 
@@ -290,6 +291,8 @@ namespace Raven.Server.Web.System
                 }
             }
 
+            SetupSecurityHeaders();
+            
             HttpContext.Response.Headers["Raven-Static-Served-From"] = "Cache";
             if (await ServeFromCache(serverRelativeFileName))
                 return;
@@ -322,6 +325,13 @@ namespace Raven.Server.Web.System
             HttpContext.Response.Headers["Content-Type"] = "text/plain; charset=utf-8";
 
             await HttpContext.Response.WriteAsync(message);
+        }
+
+        private void SetupSecurityHeaders()
+        {
+            HttpContext.Response.Headers["X-Frame-Options"] = "DENY";
+            HttpContext.Response.Headers["X-XSS-Protection"] = "1; mode=block";
+            HttpContext.Response.Headers["X-Content-Type-Options"] = "nosniff";
         }
 
         private async Task LoadFilesIntoCache()


### PR DESCRIPTION
### Issue link

https://issues.hibernatingrhinos.com/issue/RavenDB-7829

### Additional description

Added HSTS header

### Type of change

- New feature


### How risky is the change?

- Moderate 

### Backward compatibility

- Non breaking change

### UI work

- No UI work is needed
