### PR TITLE
RavenDB-17731 - Missing ApplicationIdentifier in UpdateTopology

### DIFF
--- a/src/Raven.Client/Http/RequestExecutor.cs
+++ b/src/Raven.Client/Http/RequestExecutor.cs
@@ -981,7 +981,8 @@ namespace Raven.Client.Http
                     new UpdateTopologyParameters(chosenNode)
                     {
                         TimeoutInMs = 0, 
-                        DebugTag = "refresh-topology-header"
+                        DebugTag = "refresh-topology-header",
+                        ApplicationIdentifier = GlobalApplicationIdentifier
                     });
             }
 


### PR DESCRIPTION
### Issue link

https://issues.hibernatingrhinos.com/issue/RavenDB-17731

### Additional description

Add missing ApplicationIdentifier for update topology timer

### Type of change

- Bug fix

### How risky is the change?

- Low 

### Testing 

- It has been verified by manual testing
