### PR TITLE
RavenDB-16804 : ETL stats fixes

### DIFF
--- a/src/Raven.Server/Documents/ETL/Stats/EtlPerformanceStats.cs
+++ b/src/Raven.Server/Documents/ETL/Stats/EtlPerformanceStats.cs
@@ -41,7 +41,9 @@ namespace Raven.Server.Documents.ETL.Stats
 
         public Size BatchSize { get; set; }
 
-        public string BatchCompleteReason { get; set; }
+        public string BatchTransformationCompleteReason { get; set; }
+
+        public string BatchStopReason { get; set; }
 
         public int TransformationErrorCount { get; set; }
 

--- a/src/Raven.Server/Documents/ETL/Stats/EtlRunStats.cs
+++ b/src/Raven.Server/Documents/ETL/Stats/EtlRunStats.cs
@@ -55,7 +55,9 @@ namespace Raven.Server.Documents.ETL.Stats
 
         public int TransformationErrorCount;
 
-        public string BatchCompleteReason;
+        public string BatchTransformationCompleteReason;
+
+        public string BatchStopReason;
 
         public string ChangeVector;
 

--- a/src/Raven.Server/Documents/ETL/Stats/EtlStatsAggregator.cs
+++ b/src/Raven.Server/Documents/ETL/Stats/EtlStatsAggregator.cs
@@ -68,7 +68,8 @@ namespace Raven.Server.Documents.ETL.Stats
                 NumberOfTransformedTombstones = Stats.NumberOfTransformedTombstones,
                 TransformationErrorCount = Scope.TransformationErrorCount,
                 SuccessfullyLoaded = Stats.SuccessfullyLoaded,
-                BatchCompleteReason = Stats.BatchCompleteReason,
+                BatchTransformationCompleteReason = Stats.BatchTransformationCompleteReason,
+                BatchStopReason = Stats.BatchStopReason,
                 CurrentlyAllocated = new Size(Stats.CurrentlyAllocated.GetValue(SizeUnit.Bytes)),
                 BatchSize = new Size(Stats.BatchSize.GetValue(SizeUnit.Bytes)),
             };
@@ -108,7 +109,8 @@ namespace Raven.Server.Documents.ETL.Stats
                 NumberOfTransformedTombstones = Stats.NumberOfTransformedTombstones,
                 TransformationErrorCount = Scope.TransformationErrorCount,
                 SuccessfullyLoaded = Stats.SuccessfullyLoaded,
-                BatchCompleteReason = Stats.BatchCompleteReason
+                BatchTransformationCompleteReason = Stats.BatchTransformationCompleteReason,
+                BatchStopReason = Stats.BatchStopReason
             };
         }
 

--- a/src/Raven.Server/Documents/ETL/Stats/EtlStatsScope.cs
+++ b/src/Raven.Server/Documents/ETL/Stats/EtlStatsScope.cs
@@ -131,7 +131,9 @@ namespace Raven.Server.Documents.ETL.Stats
 
         public string ChangeVector => _stats.ChangeVector;
 
-        public string BatchCompleteReason => _stats.BatchCompleteReason;
+        public string BatchTransformationCompleteReason => _stats.BatchTransformationCompleteReason;
+
+        public string BatchStopReason => _stats.BatchStopReason;
 
         public Size BatchSize => _stats.BatchSize;
 
@@ -193,14 +195,19 @@ namespace Raven.Server.Documents.ETL.Stats
 
         public abstract TEtlPerformanceOperation ToPerformanceOperation(string name);
 
-        public void RecordBatchCompleteReason(string reason)
+        public void RecordBatchTransformationCompleteReason(string reason)
         {
-            _stats.BatchCompleteReason = reason;
+            _stats.BatchTransformationCompleteReason = reason;
         }
 
-        public bool HasBatchCompleteReason()
+        public bool HasBatchTransformationCompleteReason()
         {
-            return string.IsNullOrEmpty(_stats.BatchCompleteReason) == false;
+            return string.IsNullOrEmpty(_stats.BatchTransformationCompleteReason) == false;
+        }
+
+        public void RecordBatchStopReason(string reason)
+        {
+            _stats.BatchStopReason = reason;
         }
 
         public void RecordTransformationError()

--- a/test/SlowTests/Server/Documents/ETL/Raven/RavenDB_12800.cs
+++ b/test/SlowTests/Server/Documents/ETL/Raven/RavenDB_12800.cs
@@ -66,7 +66,7 @@ namespace SlowTests.Server.Documents.ETL.Raven
 
                 var stats = etlProcess.GetPerformanceStats();
 
-                Assert.Contains("Stopping the batch because maximum batch size limit was reached (5 MBytes)", stats.Select(x => x.BatchCompleteReason).ToList());
+                Assert.Contains("Stopping the batch because maximum batch size limit was reached (5 MBytes)", stats.Select(x => x.BatchTransformationCompleteReason).ToList());
             }
         }
     }

--- a/test/SlowTests/Server/Documents/ETL/RavenDB_12079.cs
+++ b/test/SlowTests/Server/Documents/ETL/RavenDB_12079.cs
@@ -63,7 +63,7 @@ namespace SlowTests.Server.Documents.ETL
 
                 var stats = etlProcess.GetPerformanceStats();
 
-                Assert.Contains("The batch was stopped after processing 64 items because of low memory", stats.Select(x => x.BatchCompleteReason));
+                Assert.Contains("The batch was stopped after processing 64 items because of low memory", stats.Select(x => x.BatchTransformationCompleteReason));
             }
         }
     }

--- a/test/SlowTests/Server/Documents/ETL/RavenDB_16804.cs
+++ b/test/SlowTests/Server/Documents/ETL/RavenDB_16804.cs
@@ -1,0 +1,68 @@
+﻿using System;
+using System.Linq;
+using System.Threading.Tasks;
+using Raven.Client.Documents.Operations.ETL;
+using Xunit;
+using Xunit.Abstractions;
+using User = SlowTests.Core.Utils.Entities.User;
+
+namespace SlowTests.Server.Documents.ETL
+{
+    public class RavenDB_16804 : EtlTestBase
+    {
+        public RavenDB_16804(ITestOutputHelper output) : base(output)
+        {
+        }
+
+
+        [Fact]
+        public async Task CanGetBatchStopReasonFromEtlPerformanceStats()
+        {
+            using (var src = GetDocumentStore())
+            using (var dst = GetDocumentStore())
+            {
+                var configuration = new RavenEtlConfiguration
+                {
+                    ConnectionStringName = "test",
+                    Name = "aaa",
+                    Transforms =
+                    {
+                        new Transformation
+                        {
+                            Name = "S1",
+                            Collections = {"Users"}
+                        }
+                    }
+                };
+
+                AddEtl(src, configuration, new RavenConnectionString
+                {
+                    Name = "test",
+                    TopologyDiscoveryUrls = dst.Urls,
+                    Database = dst.Database,
+                });
+
+                var etlDone = WaitForEtl(src, (_, statistics) => statistics.LoadSuccesses == 10);
+
+                using (var session = src.OpenAsyncSession())
+                {
+                    for (int i = 0; i < 10; i++)
+                    {
+                        await session.StoreAsync(new User());
+                    }
+
+                    await session.SaveChangesAsync();
+                }
+
+                Assert.True(etlDone.Wait(TimeSpan.FromSeconds(10)));
+
+                var database = await GetDocumentDatabaseInstanceFor(src);
+                var etlProcess = database.EtlLoader.Processes.First();
+                var performance = etlProcess.GetPerformanceStats();
+
+                Assert.Contains("Successfully finished loading all batch items", performance.Select(p => p.BatchStopReason));
+                Assert.Contains("No more items to process", performance.Select(p => p.BatchTransformationCompleteReason));
+            }
+        }
+    }
+}

--- a/test/SlowTests/Server/Documents/ETL/RavenDB_8866.cs
+++ b/test/SlowTests/Server/Documents/ETL/RavenDB_8866.cs
@@ -5,7 +5,6 @@ using System.Threading.Tasks;
 using Raven.Client.Documents.Operations.ETL;
 using Raven.Client.ServerWide.Operations;
 using Raven.Tests.Core.Utils.Entities;
-using SlowTests.Issues;
 using Xunit;
 using Xunit.Abstractions;
 using Index = SlowTests.Issues.Index;

--- a/test/SlowTests/Server/Documents/ETL/SQL/SqlEtlTests.cs
+++ b/test/SlowTests/Server/Documents/ETL/SQL/SqlEtlTests.cs
@@ -1274,7 +1274,7 @@ loadToOrders(orderData);
 
                             var stats = etlProcess.GetPerformanceStats();
 
-                            Assert.Contains("Stopping the batch because maximum batch size limit was reached (5 MBytes)", stats.Select(x => x.BatchCompleteReason).ToList());
+                            Assert.Contains("Stopping the batch because maximum batch size limit was reached (5 MBytes)", stats.Select(x => x.BatchTransformationCompleteReason).ToList());
                         }
                     }
                 }


### PR DESCRIPTION
### Issue link

https://issues.hibernatingrhinos.com/issue/RavenDB-16804

### Additional description

- Change from `BatchCompleteReason` to `BatchTransformationCompleteReason`
- Introduce `BatchStopReason`

### Type of change

- Bug fix

### How risky is the change?

- Low 

### Documentation update

- This change requires a documentation update

### Testing 

- Tests have been added that prove the fix is effective or that the feature works
- It has been verified by manual testing

### UI work

- It requires further work in the Studio