### PR TITLE
RavenDB-17424 Make the NoQuery timespan configurable on index cleanup

### DIFF
--- a/src/Raven.Server/Config/Categories/IndexingConfiguration.cs
+++ b/src/Raven.Server/Config/Categories/IndexingConfiguration.cs
@@ -356,7 +356,7 @@ namespace Raven.Server.Config.Categories
         [DefaultValue(10)]
         [TimeUnit(TimeUnit.Minutes)]
         [IndexUpdateType(IndexUpdateType.Refresh)]
-        [ConfigurationEntry("Indexing.TimeSinceLastQueryAfterWhichDeepCleanupCanBeExecutedInMin", ConfigurationEntryScope.ServerWideOrPerDatabase)]
+        [ConfigurationEntry("Indexing.TimeSinceLastQueryAfterWhichDeepCleanupCanBeExecutedInMin", ConfigurationEntryScope.ServerWideOrPerDatabaseOrPerIndex)]
         public TimeSetting TimeSinceLastQueryAfterWhichDeepCleanupCanBeExecuted { get; set; }
 
         protected override void ValidateProperty(PropertyInfo property)

--- a/src/Raven.Studio/typescript/models/database/index/configurationItem.ts
+++ b/src/Raven.Studio/typescript/models/database/index/configurationItem.ts
@@ -29,6 +29,7 @@ class configurationItem {
         "Indexing.NumberOfLargeSegmentsToMergeInSingleBatch",
         "Indexing.ScratchSpaceLimitInMb",
         "Indexing.Throttling.TimeIntervalInMs",
+        "Indexing.TimeSinceLastQueryAfterWhichDeepCleanupCanBeExecutedInMin",
         "Indexing.TransactionSizeLimitInMb"
     ];
     

--- a/test/FastTests/Issues/RavenDB_16590.cs
+++ b/test/FastTests/Issues/RavenDB_16590.cs
@@ -68,6 +68,7 @@ namespace FastTests.Issues
                 "Indexing.NumberOfConcurrentStoppedBatchesIfRunningLowOnMemory",
                 "Indexing.NumberOfLargeSegmentsToMergeInSingleBatch",
                 "Indexing.ScratchSpaceLimitInMb",
+                "Indexing.TimeSinceLastQueryAfterWhichDeepCleanupCanBeExecutedInMin",
                 "Indexing.Throttling.TimeIntervalInMs",
                 "Indexing.TransactionSizeLimitInMb"
             };


### PR DESCRIPTION
### Issue link

https://issues.hibernatingrhinos.com/issue/RavenDB-17424

### Additional description

Adds the ability via configuration option to control after what time since last query we can perform deep clean

### Type of change

- New feature

### How risky is the change?

- Low 

### Backward compatibility

- Not relevant

### Is it platform specific issue?

- No

### UI work

- No UI work is needed
