### PR TITLE
RavenDB-17580 : pass cancellation token to TimeSeries retriever when invoked from ScriptRunner

### DIFF
--- a/src/Raven.Server/Documents/Patch/ScriptRunner.cs
+++ b/src/Raven.Server/Documents/Patch/ScriptRunner.cs
@@ -1861,6 +1861,7 @@ namespace Raven.Server.Documents.Patch
                     _loadScope = null;
                     _docsCtx = null;
                     _jsonCtx = null;
+                    _token = default;
                     Array.Clear(_args, 0, _args.Length);
                 }
             }

--- a/src/Raven.Server/Documents/Patch/ScriptRunnerCache.cs
+++ b/src/Raven.Server/Documents/Patch/ScriptRunnerCache.cs
@@ -69,7 +69,6 @@ namespace Raven.Server.Documents.Patch
             public abstract override int GetHashCode();
         }
 
-
         public ScriptRunner.ReturnRun GetScriptRunner(Key key, bool readOnly, out ScriptRunner.SingleRun patchRun)
         {
             if (key == null)
@@ -82,7 +81,6 @@ namespace Raven.Server.Documents.Patch
             patchRun.ReadOnly = readOnly;
             return returnRun;
         }
-
 
         private ScriptRunner GetScriptRunner(Key script)
         {

--- a/src/Raven.Server/Documents/Queries/Results/QueryResultRetrieverBase.cs
+++ b/src/Raven.Server/Documents/Queries/Results/QueryResultRetrieverBase.cs
@@ -856,7 +856,7 @@ namespace Raven.Server.Documents.Queries.Results
 
             var key = new QueryKey(query.DeclaredFunctions);
             using (_database.Scripts.GetScriptRunner(key, readOnly: true, patchRun: out var run))
-            using (var result = run.Run(_context, _context as DocumentsOperationContext, methodName, args, timings))
+            using (var result = run.Run(_context, _context as DocumentsOperationContext, methodName, args, timings, token))
             {
                 _includeDocumentsCommand?.AddRange(run.Includes, documentId);
                 _includeRevisionsCommand?.AddRange(run.IncludeRevisionsChangeVectors);


### PR DESCRIPTION
### Issue link
https://issues.hibernatingrhinos.com/issue/RavenDB-17580

### Type of change

- Bug fix

### How risky is the change?

- Low 

### Documentation update

- No documentation update is needed 

### Testing 

- It has been verified by manual testing

### UI work

- No UI work is needed
