### PR TITLE
RavenDB-14958 - fixed Database access isn't removed when deleting database and creating a new one with the same name

### DIFF
--- a/src/Raven.Client/Http/RequestExecutor.cs
+++ b/src/Raven.Client/Http/RequestExecutor.cs
@@ -287,7 +287,7 @@ namespace Raven.Client.Http
             return httpClientCache.GetOrAdd(name, new Lazy<HttpClient>(CreateClient)).Value;
         }
 
-        private void RemoveHttpClient()
+        internal void RemoveHttpClient()
         {
             var httpClientCache = GetHttpClientCache();
 

--- a/src/Raven.Server/ServerWide/ClusterStateMachine.cs
+++ b/src/Raven.Server/ServerWide/ClusterStateMachine.cs
@@ -1300,6 +1300,9 @@ namespace Raven.Server.ServerWide
             // delete all values linked to database record - for subscription, etl etc.
             CleanupDatabaseRelatedValues(context, items, databaseName, serverStore);
 
+            //remove the database from all certificate's permissions
+            DeleteDatabaseFromCertificatePermissions(context, databaseName);
+
             var transactionsCommands = context.Transaction.InnerTransaction.OpenTable(TransactionCommandsSchema, TransactionCommands);
             var commandsCountPerDatabase = context.Transaction.InnerTransaction.ReadTree(TransactionCommandsCountPerDatabase);
 
@@ -1646,6 +1649,45 @@ namespace Raven.Server.ServerWide
             finally
             {
                 NotifyValueChanged(context, type, index);
+            }
+        }
+
+        private static void DeleteDatabaseFromCertificatePermissions(TransactionOperationContext context, string database)
+        {
+            try
+            {
+                var certTable = context.Transaction.InnerTransaction.OpenTable(CertificatesSchema, CertificatesSlice);
+
+                foreach (var result in certTable.SeekByPrimaryKeyPrefix(Slices.Empty, Slices.Empty, 0))
+                {
+                    var blittable = GetCertificate(context, result.Value).Cert;
+
+                    if (blittable.TryGet(nameof(CertificateDefinition.Thumbprint), out string thumbprint) == false)
+                        throw new MissingFieldException($"Couldn't get '{nameof(CertificateDefinition.Thumbprint)}' from {nameof(CertificateDefinition)}");
+                    
+                    if (blittable.TryGet(nameof(CertificateDefinition.PublicKeyPinningHash), out string hash) == false)
+                        throw new MissingFieldException($"Couldn't get '{nameof(CertificateDefinition.PublicKeyPinningHash)}' from {nameof(CertificateDefinition)}");
+                    
+                    if (blittable.TryGet(nameof(CertificateDefinition.Permissions), out BlittableJsonReaderObject permissions) == false)
+                        throw new MissingFieldException($"Couldn't get '{nameof(CertificateDefinition.Permissions)}' from {nameof(CertificateDefinition)}");
+
+                    using (Slice.From(context.Allocator, thumbprint.ToLower(), out var thumbprintSlice))
+                    using (Slice.From(context.Allocator, hash, out var hashSlice))
+                    {
+                        int index = permissions.GetPropertyIndex(database);
+                        if (index > -1)
+                        {
+                            permissions.Modifications ??= new DynamicJsonValue();
+                            permissions.Modifications.Removals = new HashSet<int>() { index };
+                            var updated = context.ReadObject(blittable, "cert/updated");
+                            UpdateCertificate(certTable, thumbprintSlice, hashSlice, updated);
+                        }
+                    }
+                }
+            }
+            finally
+            {
+                //NotifyValueChanged(context, type, index); //TODO stav: is needed?
             }
         }
 


### PR DESCRIPTION
### Issue link

https://issues.hibernatingrhinos.com/issue/RavenDB-14958

### Additional description

Changed behavior so that upon deleting a database it is now removed from all certificate permissions. This prevents using an old certificate for a new database with the same name as the old one.

### How risky is the change?

- High (?)

### Backward compatibility

- Breaking change - Users might be relying on previous behavior when deleting a db?

### Is it platform specific issue?

- No

### Documentation update

- This behavior doesn't seem to be documented

### Testing 

- Tests have been added that prove the fix is effective or that the feature works

### Is there any existing behavior change of other features due to this change?

- No.

### UI work

- No UI work is needed
