### PR TITLE
RavenDB-17719 fix double dispose of replication item

### DIFF
--- a/src/Raven.Server/Documents/Replication/IncomingReplicationHandler.cs
+++ b/src/Raven.Server/Documents/Replication/IncomingReplicationHandler.cs
@@ -1105,21 +1105,8 @@ namespace Raven.Server.Documents.Replication
                     HashSet<LazyStringValue> docCountersToRecreate = null;
                     var handledAttachmentStreams = new HashSet<Slice>(SliceComparer.Instance);
                     context.LastDatabaseChangeVector ??= DocumentsStorage.GetDatabaseChangeVector(context);
-
-                    var tx = context.Transaction.InnerTransaction.LowLevelTransaction;
-                    var replicationItems = _replicationInfo.ReplicatedItems;
-                    tx.OnDispose += _ =>
-                    {
-                        if (tx.Committed == false)
-                            return;
-
-                        for (int i = 0; i < replicationItems.Length; i++)
-                        {
-                            replicationItems[i].Dispose();
-                        }
-                    };
-
-                    foreach (var item in replicationItems)
+                    
+                    foreach (var item in _replicationInfo.ReplicatedItems)
                     {
                         if (lastTransactionMarker != item.TransactionMarker)
                         {


### PR DESCRIPTION
### Issue link

https://issues.hibernatingrhinos.com/issue/RavenDB-17719

### Additional description

This is regression fix that was introduce due to a merge of https://github.com/ravendb/ravendb/pull/13315 from 4.2.
In 5.2 and up we do not dispose the item in the command itself with the `using`, but the `_replicationInfo` is disposing those items once the command is completed.

### Type of change

- Regression bug fix

### How risky is the change?

- Low 

### Backward compatibility

- Not relevant

### Is it platform specific issue?

- No

### Documentation update

- No documentation update is needed 

### Testing 

- It has been verified by manual testing, 
`ClusterWideTransaction_WhenRestoreFromIncrementalBackupAfterStoreAndUpdate_ShouldCompleteImportWithNoException(2048)` was failing/hanging

### Is there any existing behavior change of other features due to this change?

- No

### UI work

- No UI work is needed
