### PR TITLE
RavenDB-17754 Resume flushing the underlying stream on backups in .NE…

### DIFF
--- a/src/Sparrow/Json/AbstractBlittableJsonTextWriter.cs
+++ b/src/Sparrow/Json/AbstractBlittableJsonTextWriter.cs
@@ -696,6 +696,7 @@ namespace Sparrow.Json
             try
             {
                 FlushInternal();
+                _stream.Flush();
             }
             catch (ObjectDisposedException)
             {

--- a/src/Sparrow/Json/AsyncBlittableJsonTextWriter.cs
+++ b/src/Sparrow/Json/AsyncBlittableJsonTextWriter.cs
@@ -47,7 +47,8 @@ namespace Sparrow.Json
         {
             DisposeInternal();
 
-            await FlushAsync().ConfigureAwait(false);
+            if (await FlushAsync().ConfigureAwait(false) > 0)
+                await _stream.FlushAsync().ConfigureAwait(false);
 
             _context.ReturnMemoryStream((MemoryStream)_stream);
         }


### PR DESCRIPTION
…T 6.0

### Issue link

https://issues.hibernatingrhinos.com/issue/RavenDB-17754

### Additional description

Tests are passing locally, created this commit to see if the situation is the same on CI

### Type of change

- Regression bug fix

### How risky is the change?

- Moderate 

### Backward compatibility

- Ensured. Please explain how has it been implemented?



### Is it platform specific issue?

- No

### Documentation update

- No documentation update is needed 

### Testing 


- It has been verified by manual testing

### Is there any existing behavior change of other features due to this change?

- No

### UI work

- No UI work is needed
