### PR TITLE
RavenDB-17754 Resume flushing the underlying stream on backups in .NET 6.0

### DIFF
--- a/src/Sparrow/Json/AbstractBlittableJsonTextWriter.cs
+++ b/src/Sparrow/Json/AbstractBlittableJsonTextWriter.cs
@@ -695,6 +695,7 @@ namespace Sparrow.Json
             try
             {
                 FlushInternal();
+                _stream.Flush(); // flush the underlying stream as well
             }
             catch (ObjectDisposedException)
             {

--- a/src/Sparrow/Json/AsyncBlittableJsonTextWriter.cs
+++ b/src/Sparrow/Json/AsyncBlittableJsonTextWriter.cs
@@ -46,8 +46,8 @@ namespace Sparrow.Json
         public async ValueTask DisposeAsync()
         {
             DisposeInternal();
-
-            await FlushAsync().ConfigureAwait(false);
+            if (await FlushAsync().ConfigureAwait(false) > 0)
+                await _outputStream.FlushAsync().ConfigureAwait(false); // flush the output stream underlying stream as well
 
             _context.ReturnMemoryStream((MemoryStream)_stream);
         }


### PR DESCRIPTION
Related PR: https://github.com/ravendb/ravendb/pull/13358