### PR TITLE
RavenDB-17754 Fixing flushing boundaries when writing encrypted data

### DIFF
--- a/src/Sparrow/Json/AbstractBlittableJsonTextWriter.cs
+++ b/src/Sparrow/Json/AbstractBlittableJsonTextWriter.cs
@@ -695,6 +695,7 @@ namespace Sparrow.Json
             try
             {
                 FlushInternal();
+                _stream.Flush();
             }
             catch (ObjectDisposedException)
             {

--- a/src/Sparrow/Json/AsyncBlittableJsonTextWriter.cs
+++ b/src/Sparrow/Json/AsyncBlittableJsonTextWriter.cs
@@ -47,7 +47,8 @@ namespace Sparrow.Json
         {
             DisposeInternal();
 
-            await FlushAsync().ConfigureAwait(false);
+            if (await FlushAsync().ConfigureAwait(false) > 0)
+                await _outputStream.FlushAsync().ConfigureAwait(false);
 
             _context.ReturnMemoryStream((MemoryStream)_stream);
         }


### PR DESCRIPTION
### Issue link

https://issues.hibernatingrhinos.com/issue/RavenDB-17754 

### Additional description

Our encrypted stream relies on the framework to only call `Flush` on well defined points, however, that isn't guaranteed. 
We now check that we flush from the encrypted stream to the underlying stream at 4KB increments always (except at the end).
This is required so we'll be able to properly read the data afterward.

### Type of change

- Regression bug fix

### How risky is the change?

- Low 

### Backward compatibility

- Ensured. Please explain how has it been implemented?

### Is it platform specific issue?

- No

### Documentation update

- No documentation update is needed 

### Testing 

- It has been verified by manual testing

And there are now tests passing

### Is there any existing behavior change of other features due to this change?

- No

### UI work

- No UI work is needed
