### PR TITLE
RavenDB-17758 Fixing data corruption: Dictionary mismatch on Dic

### DIFF
--- a/src/Voron/Data/Tables/Table.cs
+++ b/src/Voron/Data/Tables/Table.cs
@@ -704,9 +704,6 @@ namespace Voron.Data.Tables
                 if (_compressionDictionaries.TryGetValue(id, out var current))
                     return current;
 
-                if (_compressionDictionaries.TryGetValue(id, out current))
-                    return current;
-
                 current = CreateCompressionDictionary(tx, id);
 
                 var result = _compressionDictionaries.GetOrAdd(id, current);

--- a/src/Voron/Data/Tables/Table.cs
+++ b/src/Voron/Data/Tables/Table.cs
@@ -751,6 +751,11 @@ namespace Voron.Data.Tables
 
                 }
             }
+
+            public void Remove(int id)
+            {
+                _compressionDictionaries.TryRemove(id, out _);
+            }
         }
 
 

--- a/src/Voron/Data/Tables/Table.cs
+++ b/src/Voron/Data/Tables/Table.cs
@@ -751,6 +751,8 @@ namespace Voron.Data.Tables
 
             public void Remove(int id)
             {
+                // Intentionally orphaning the dictionary here, we'll let the 
+                // GC's finalizer to clear it up, this is a *very* rare operation.
                 _compressionDictionaries.TryRemove(id, out _);
             }
         }

--- a/src/Voron/Data/Tables/TableValueCompressor.cs
+++ b/src/Voron/Data/Tables/TableValueCompressor.cs
@@ -229,9 +229,9 @@ namespace Voron.Data.Tables
                         }
 
                         tx.LowLevelTransaction.OnDispose += RecreateRecoveryDictionaries;
-                        tx.LowLevelTransaction.OnDispose += state =>
+                        tx.LowLevelTransaction.OnRollBack += state =>
                         {
-                            if (state is not LowLevelTransaction llt || llt.Committed)
+                            if (state is not LowLevelTransaction llt)
                                 return;
                             // ***************************************
                             // RavenDB-17758  - This is *important* - if we aren't committing the transaction, we *have*
@@ -239,7 +239,7 @@ namespace Voron.Data.Tables
                             // keep it, we can compress data with a dictionary that we rolled back, and end up with data
                             // corruption!!!
                             // ****************************************
-                            tx.LowLevelTransaction.Environment.CompressionDictionariesHolder.Remove(newId);
+                            llt.Environment.CompressionDictionariesHolder.Remove(newId);
                         };
                     }
                 }

--- a/src/Voron/Data/Tables/ZstdLib.cs
+++ b/src/Voron/Data/Tables/ZstdLib.cs
@@ -3,6 +3,7 @@ using System.Diagnostics;
 using System.IO;
 using System.Runtime.InteropServices;
 using Sparrow.Server;
+using Voron.Exceptions;
 
 namespace Voron.Data.Tables
 {
@@ -94,9 +95,10 @@ namespace Voron.Data.Tables
             string ptrToStringAnsi = Marshal.PtrToStringAnsi(ZSTD_getErrorName(v));
             if (dictionary != null)
             {
-                throw new InvalidOperationException(ptrToStringAnsi + " on " + dictionary);
+                throw new VoronErrorException(ptrToStringAnsi + " on " + dictionary);
             }
-            throw new InvalidOperationException(ptrToStringAnsi);
+
+            throw new VoronErrorException(ptrToStringAnsi);
         }
 
         private class CompressContext
@@ -229,7 +231,7 @@ namespace Voron.Data.Tables
 
             public override string ToString()
             {
-                return "Dic #" + Id 
+                return "Dictionary #" + Id 
 #if DEBUG
 					 + " - " + DictionaryHash
 #endif

--- a/src/Voron/Impl/LowLevelTransaction.cs
+++ b/src/Voron/Impl/LowLevelTransaction.cs
@@ -113,6 +113,13 @@ namespace Voron.Impl
             }
         }
         public event Action<IPagerLevelTransactionState> OnDispose;
+        
+        /// <summary>
+        /// This is called *under the write transaction lock* and will
+        /// allow us to clean up any in memory state that shouldn't be preserved
+        /// passed the transaction rollback
+        /// </summary>
+        public event Action<IPagerLevelTransactionState> OnRollBack;
         public event Action<LowLevelTransaction> AfterCommitWhenNewTransactionsPrevented;
 
         private readonly IFreeSpaceHandling _freeSpaceHandling;
@@ -1221,6 +1228,8 @@ namespace Voron.Impl
 
             if (Committed || RolledBack || Flags != (TransactionFlags.ReadWrite))
                 return;
+
+            OnRollBack?.Invoke(this);
 
             ValidateReadOnlyPages();
 

--- a/test/SlowTests/Issues/RavenDB-17758.cs
+++ b/test/SlowTests/Issues/RavenDB-17758.cs
@@ -1,0 +1,140 @@
+using System;
+using System.Text;
+using FastTests.Voron;
+using Sparrow.Binary;
+using Sparrow.Server;
+using Sparrow.Threading;
+using Voron;
+using Voron.Data.Tables;
+using Xunit;
+using Xunit.Abstractions;
+
+namespace SlowTests.Issues
+{
+    public class RavenDB_17758 : StorageTest
+    {
+        public RavenDB_17758(ITestOutputHelper output) : base(output)
+        {
+        }
+
+        public string LongRandomString()
+        {
+            var random = new Random();
+            var sb = new StringBuilder();
+            for (int j = 0; j < random.Next(20,400); j++)
+            {
+                var key = Guid.NewGuid().ToString();
+                sb.AppendLine(key);
+            }
+
+            return sb.ToString();
+        }
+
+        [Fact]
+        public void WillNotRememberOldDictionariesAfterRestart()
+        {
+            RequireFileBasedPager();
+
+            
+            using var allocator = new ByteStringContext(SharedMultipleUseFlag.None);
+            using var ____ = Slice.From(allocator, "PK", out var pk);
+            using var ___ = Slice.From(allocator, "Etags", out var etags);
+            using var __ = Slice.From(allocator, "Table", out var tbl);
+
+            var idx = new TableSchema.FixedSizeSchemaIndexDef { Name = etags, IsGlobal = false, StartIndex = 0 };
+            var schema = new TableSchema()
+                .DefineKey(new TableSchema.SchemaIndexDef
+                {
+                    Name = pk,
+                    IsGlobal = false,
+                    StartIndex = 0,
+                    Count = 1
+                })
+                .DefineFixedSizeIndex(idx)
+                .CompressValues(idx, true);
+
+            using (var wtx = Env.WriteTransaction())
+            {
+                schema.Create(wtx, tbl, null);
+                wtx.Commit();
+            }
+            
+            
+            using (var wtx = Env.WriteTransaction())
+            {
+                var table = wtx.OpenTable(schema, tbl);
+
+                using var _ = Slice.From(allocator,  LongRandomString(), out var val); 
+
+                for (long i = 0; i < 1024*4; i++)
+                {
+                    using (table.Allocate(out var builder))
+                    {
+                        builder.Add(Bits.SwapBytes(i));
+                        builder.Add(val);
+                        table.Insert(builder);
+                    }
+                }
+                
+                wtx.Commit();
+            }
+            
+            using (var wtx = Env.WriteTransaction())
+            {
+                var table = wtx.OpenTable(schema, tbl);
+
+                using var _ = Slice.From(allocator,  LongRandomString(), out var val);
+
+                for (long i = 20_000; i <  20_000 + 1024*4; i++)
+                {
+                    using (table.Allocate(out var builder))
+                    {
+                        builder.Add(Bits.SwapBytes(i));
+                        builder.Add(val);
+                        table.Insert(builder);
+                    }
+
+                    table.ReadLast(idx); // force to read the new dictionary
+                }
+                
+                // explicitly discard the change
+                //wtx.Commit();
+            }
+            
+            using (var wtx = Env.WriteTransaction())
+            {
+                var table = wtx.OpenTable(schema, tbl);
+
+                using var _ = Slice.From(allocator,  LongRandomString(), out var val);
+
+                for (long i = 20_000; i <  20_000 +  1020*4; i++)
+                {
+                    using (table.Allocate(out var builder))
+                    {
+                        builder.Add(Bits.SwapBytes(i));
+                        builder.Add(val);
+                        table.Insert(builder);
+                    }
+                }
+
+                wtx.Commit();
+            }
+            
+            RestartDatabase();
+            
+            using (var rtx = Env.ReadTransaction())
+            {
+                var table = rtx.OpenTable(schema, tbl);
+
+                using (var it = table.SeekForwardFrom(idx, 0, 0).GetEnumerator())
+                {
+                    while (it.MoveNext())
+                    {
+                        
+                    }
+                }
+            }
+
+        }
+    }
+}


### PR DESCRIPTION
### Issue link

https://issues.hibernatingrhinos.com/issue/RavenDB-17758

### Additional description

This scenario can happen when the following happens:

* We retrain a compression dictionary in a transaction, giving it the next available dictionary id.
* We *use* the new dictionary to *read* data in that same transaction
* The transaction is rolled back

* At some later time, a *new* transaction will occur which will train the dictionary again, however, the dictionary id generation will use the _same_ id as the dictionary that we discarded.
* We have a cache of compression dictionaries, and that cache already has an instance of the _old_ dictionary

For as long as the database is alive, that cached dictionary will be used. Upon restart, we'll reload the actual dictionary we trained from disk, which wouldn't match with the actual dictionary that was used, leading to data corruption.


This PR change the behavior of Voron so we'll not remember a compression dictionary if the transaction that created it has been rolled back.

### Type of change

- Bug fix

### How risky is the change?

- Not relevant

This fixes data corruption.

### Backward compatibility

- Ensured. Please explain how has it been implemented?

This is a change to the behavior only, doesn't change the persistent state.
Note that this also doesn't _fix_ any such issues, however. The data has already been compressed using the wrong dictionary. 

### Is it platform specific issue?

- No

### Documentation update

- No documentation update is needed 

### Testing 

- Tests have been added that prove the fix is effective or that the feature works

### Is there any existing behavior change of other features due to this change?

- No

### UI work

- No UI work is needed
