### PR TITLE
RDoc-2008 - In the example of client config time-series the "collcetion" dictionary should be initiated first

### DIFF
--- a/src/Raven.Client/Documents/Operations/TimeSeries/TimeSeriesConfiguration.cs
+++ b/src/Raven.Client/Documents/Operations/TimeSeries/TimeSeriesConfiguration.cs
@@ -18,7 +18,12 @@ namespace Raven.Client.Documents.Operations.TimeSeries
 
         // collection -> timeseries -> names
         public Dictionary<string, Dictionary<string, string[]>> NamedValues { get; set; }
-        
+
+        public TimeSeriesConfiguration()
+        {
+            Collections = new Dictionary<string, TimeSeriesCollectionConfiguration>();
+        }
+
         internal void InitializeRollupAndRetention()
         {
             if (Collections == null || Collections.Count == 0) 


### PR DESCRIPTION
### Issue link

https://issues.hibernatingrhinos.com/issue/RDoc-2008
