### PR TITLE
RavenDB-17427 - Gather debug info: admin.proc.meminfo.json.error contains exception

### DIFF
--- a/src/Raven.Server/Documents/Handlers/Debugging/DatabaseDebugInfoPackageHandler.cs
+++ b/src/Raven.Server/Documents/Handlers/Debugging/DatabaseDebugInfoPackageHandler.cs
@@ -36,27 +36,7 @@ namespace Raven.Server.Documents.Handlers.Debugging
 
                         foreach (var route in routes)
                         {
-                            var entryName = DebugInfoPackageUtils.GetOutputPathFromRouteInformation(route, null);
-                            try
-                            {
-                                var entry = archive.CreateEntry(entryName);
-                                entry.ExternalAttributes = ((int)(FilePermissions.S_IRUSR | FilePermissions.S_IWUSR)) << 16;
-
-                                using (var entryStream = entry.Open())
-                                using (var writer = new BlittableJsonTextWriter(context, entryStream))
-                                {
-                                    using (var endpointOutput = await localEndpointClient.InvokeAndReadObjectAsync(route, context, endpointParameters))
-                                    {
-                                        context.Write(writer, endpointOutput);
-                                        writer.Flush();
-                                        await entryStream.FlushAsync();
-                                    }
-                                }
-                            }
-                            catch (Exception e)
-                            {
-                                DebugInfoPackageUtils.WriteExceptionAsZipEntry(e, archive, entryName.Replace(".json", string.Empty));
-                            }
+                            await ServerWideDebugInfoPackageHandler.InvokeAndWriteToArchive(archive, context, localEndpointClient, route, null, endpointParameters);
                         }
                     }
 

--- a/src/Raven.Server/Documents/Handlers/Debugging/ServerWideDebugInfoPackageHandler.cs
+++ b/src/Raven.Server/Documents/Handlers/Debugging/ServerWideDebugInfoPackageHandler.cs
@@ -341,13 +341,12 @@ namespace Raven.Server.Documents.Handlers.Debugging
             {
                 throw;
             }
-            catch (InvalidStartOfObjectException e)
-            {
-                //precaution, ideally this exception should never be thrown
-                throw new InvalidOperationException("Expected to find a blittable object as a result of debug endpoint, but found something else (see inner exception for details). This should be investigated as all RavenDB endpoints are supposed to return an object.", e);
-            }
             catch (Exception e)
             {
+                //precaution, ideally this exception should never be thrown
+                if (e is InvalidStartOfObjectException)
+                    e = new InvalidOperationException("Expected to find a blittable object as a result of debug endpoint, but found something else (see inner exception for details). This should be investigated as all RavenDB endpoints are supposed to return an object.", e);
+
                 DebugInfoPackageUtils.WriteExceptionAsZipEntry(e, archive, DebugInfoPackageUtils.GetOutputPathFromRouteInformation(route, path, null));
             }
         }

--- a/src/Raven.Server/ServerWide/DebugInfoPackageUtils.cs
+++ b/src/Raven.Server/ServerWide/DebugInfoPackageUtils.cs
@@ -15,10 +15,9 @@ namespace Raven.Server.ServerWide
     {
         public static readonly IReadOnlyList<RouteInformation> Routes = RouteScanner.DebugRoutes;
 
+        public static string GetOutputPathFromRouteInformation(RouteInformation route, string prefix, string extension) => GetOutputPathFromRouteInformation(route.Path, prefix, extension);
 
-        public static string GetOutputPathFromRouteInformation(RouteInformation route, string prefix) => GetOutputPathFromRouteInformation(route.Path, prefix);
-
-        public static string GetOutputPathFromRouteInformation(string path, string prefix)
+        public static string GetOutputPathFromRouteInformation(string path, string prefix, string extension)
         {
             if (path.StartsWith("/debug/"))
                 path = path.Replace("/debug/", string.Empty);
@@ -33,8 +32,10 @@ namespace Raven.Server.ServerWide
                 path = path.Substring(1);
 
             path = string.IsNullOrWhiteSpace(prefix) == false ?
-                $"{prefix}/{path}.json" : // .ZIP File Format Specification 4.4.17 file name: (Variable)
-                $"{path}.json";
+                $"{prefix}/{path}" : // .ZIP File Format Specification 4.4.17 file name: (Variable)
+                path;
+
+            path = string.IsNullOrWhiteSpace(extension) ? path : $"{path}.{extension}";
 
             return path;
         }

--- a/src/Raven.Server/ServerWide/LocalEndpointClient.cs
+++ b/src/Raven.Server/ServerWide/LocalEndpointClient.cs
@@ -90,21 +90,6 @@ namespace Raven.Server.ServerWide
             throw new HttpRequestException($"A call to endpoint <<{route.Method} {route.Path}>> has failed with status code {statusCode}");
         }
 
-        public async Task<BlittableJsonReaderObject> InvokeAndReadObjectAsync(RouteInformation route, JsonOperationContext context, Dictionary<string, Microsoft.Extensions.Primitives.StringValues> parameters = null)
-        {
-            var response = await InvokeAsync(route, parameters);
-
-            try
-            {
-                return context.ReadForMemory(response.Body, $"read/local endpoint/{route.Path}");
-            }
-            catch (InvalidStartOfObjectException e)
-            {
-                //precaution, ideally this exception should never be thrown
-                throw new InvalidOperationException("Expected to find a blittable object as a result of debug endpoint, but found something else (see inner exception for details). This should be investigated as all RavenDB endpoints are supposed to return an object.", e);
-            }
-        }
-
         private class LocalInvocationCustomHttpContext : HttpContext, IDisposable
         {
             public LocalInvocationCustomHttpContext(string method, string path)

--- a/test/SlowTests/Authentication/AuthenticationDebugPackageInfoTests.cs
+++ b/test/SlowTests/Authentication/AuthenticationDebugPackageInfoTests.cs
@@ -27,8 +27,10 @@ namespace SlowTests.Authentication
         [LinuxFact]
         public async Task WriteMeminfoAsTextFileInDebugPackage_RavenDB_17427()
         {
+            DoNotReuseServer();
             using (var store = GetDocumentStore())
             {
+                Server.ForTestingPurposesOnly().DebugPackage.RoutesToSkip = _routesToSkip;
                 var requestExecutor = store.GetRequestExecutor(store.Database);
                 await using var response = await requestExecutor.HttpClient.GetStreamAsync($"{store.Urls.First()}/admin/debug/info-package");
                 using var archive = new ZipArchive(response);


### PR DESCRIPTION
### Issue link

https://issues.hibernatingrhinos.com/issue/RavenDB-17427

### Additional description

Now creating the debug package entries according to the content type returning from the route in its response.
If there is a failure in the route itself, and hence no content type in the response, will make an error entry with the extension ".error" (instead of where we originally added ".error" on top of the extension. i.e - now will be "tasks.error" instead of "tasks.json.error")

### Type of change

- Bug fix

### How risky is the change?

- Low 

### Is it platform specific issue?

- Linux & OSX issue 

### Documentation update

- No documentation update is needed 

### Testing 

- Tests have been added that prove the fix is effective or that the feature works

### Is there any existing behavior change of other features due to this change?

- No

### UI work

- No UI work is needed
