### PR TITLE
RavenDB-17762: Corrected implementation of Or and AndWith

### DIFF
--- a/src/Corax/Queries/MergeHelper.cs
+++ b/src/Corax/Queries/MergeHelper.cs
@@ -1,4 +1,5 @@
 using System;
+using System.Diagnostics;
 using System.Runtime.CompilerServices;
 using System.Runtime.InteropServices;
 using System.Runtime.Intrinsics;
@@ -181,6 +182,7 @@ namespace Corax.Queries
             var leftPtr = (long*)Unsafe.AsPointer(ref MemoryMarshal.GetReference(left));
             var rightPtr = (long*)Unsafe.AsPointer(ref MemoryMarshal.GetReference(right));
 
+            // TODO: Check there is no overlapping between dst and left and right.             
             return Or(dstPtr, dst.Length, leftPtr, left.Length, rightPtr, right.Length);
         }
 

--- a/src/Corax/Queries/MergeHelper.cs
+++ b/src/Corax/Queries/MergeHelper.cs
@@ -243,13 +243,13 @@ namespace Corax.Queries
             {
                 // We have items still available in the left arm                
                 values = leftEndPtr - leftPtr;
-                Unsafe.CopyBlockUnaligned(ref Unsafe.AsRef<byte>(dstPtr), ref Unsafe.AsRef<byte>(leftPtr), (uint)values * sizeof(long));
+                Unsafe.CopyBlockUnaligned(dstPtr, leftPtr, (uint)values * sizeof(long));
             }
             else if (rightPtr != rightEndPtr)
             {
                 // We have items still available in the left arm
                 values = rightEndPtr - rightPtr;
-                Unsafe.CopyBlockUnaligned(ref Unsafe.AsRef<byte>(dstPtr), ref Unsafe.AsRef<byte>(rightPtr), (uint)values * sizeof(long));
+                Unsafe.CopyBlockUnaligned(dstPtr, rightPtr, (uint)values * sizeof(long));
             }
 
             return (int)(dstPtr + values - dst);
@@ -300,13 +300,13 @@ namespace Corax.Queries
             {
                 // We have items still available in the left arm                
                 values = leftEndPtr - leftPtr;
-                Unsafe.CopyBlockUnaligned(ref Unsafe.AsRef<byte>(dstPtr), ref Unsafe.AsRef<byte>(leftPtr), (uint)values * sizeof(long));
+                Unsafe.CopyBlockUnaligned(dstPtr, leftPtr, (uint)values * sizeof(long));                
             }
             else if (rightPtr != rightEndPtr)
             {
                 // We have items still available in the left arm
                 values = rightEndPtr - rightPtr;
-                Unsafe.CopyBlockUnaligned(ref Unsafe.AsRef<byte>(dstPtr), ref Unsafe.AsRef<byte>(rightPtr), (uint)values * sizeof(long));
+                Unsafe.CopyBlockUnaligned(dstPtr, rightPtr, (uint)values * sizeof(long));
             }
 
             return (int)(dstPtr + values - dst);

--- a/src/Voron/Data/Sets/Set.cs
+++ b/src/Voron/Data/Sets/Set.cs
@@ -518,8 +518,11 @@ namespace Voron.Data.Sets
             }
 
             public bool? MaybeSeek(long from)
-            {
-                if (_it.IsInRange(from))
+            {                
+                // TODO: In case that we are in the right location but we have passed over,
+                //       we may be able to use a optimized Seek method instead which would
+                //       avoid getting the page and just start over in the current segment.
+                if (Current < from && _it.IsInRange(from)) 
                     return null;
                 return Seek(from);
             }


### PR DESCRIPTION
The current implementation has a few blind spots that become visible only under very narrow conditions requiring multiple batches sequences and deep queries. This version fixes those issues which in the process also showcase a Set Iterator issues with continuations which are the workhorse of Fill operations. 