### PR TITLE
RavenDB-15437 - We still have counters & counters-snapshot in the metadata

### DIFF
--- a/src/Raven.Server/Documents/Revisions/RevisionsStorage.cs
+++ b/src/Raven.Server/Documents/Revisions/RevisionsStorage.cs
@@ -528,8 +528,6 @@ namespace Raven.Server.Documents.Revisions
             if (document.TryGet(Constants.Documents.Metadata.Key, out BlittableJsonReaderObject metadata) &&
                 metadata.TryGet(snapshotFlag, out BlittableJsonReaderObject bjro))
             {
-                bool isSnapshot = snapshotFlag == Constants.Documents.Metadata.RevisionCounters;
-
                 var names = bjro.GetPropertyNames();
 
                 metadata.Modifications = new DynamicJsonValue(metadata);
@@ -540,7 +538,7 @@ namespace Raven.Server.Documents.Revisions
                     arr.Add(name);
                 }
 
-                metadata.Modifications[flag] = arr; 
+                metadata.Modifications[flag] = arr;
                 document.Modifications ??= new DynamicJsonValue();
                 document.Modifications[Constants.Documents.Metadata.Key] = metadata;
 
@@ -755,7 +753,7 @@ namespace Raven.Server.Documents.Revisions
 
                 revisionEtag = TableValueToEtag((int)RevisionsTable.Etag, ref tvr);
 
-                if (table.IsOwned(tvr.Id) == false) 
+                if (table.IsOwned(tvr.Id) == false)
                 {
                     // We request to delete revision with the wrong collection
                     var revision = TableValueToRevision(context, ref tvr);
@@ -1540,7 +1538,7 @@ namespace Raven.Server.Documents.Revisions
                         InsertNewMetadataInfo(context, documentsStorage, document, collectionName);
 
                         var flag = document.Flags | DocumentFlags.Reverted;
-                        documentsStorage.Put(context, document.Id, null, document.Data, flags: flag.Strip(DocumentFlags.Revision | DocumentFlags.Conflicted | DocumentFlags.Resolved) );
+                        documentsStorage.Put(context, document.Id, null, document.Data, flags: flag.Strip(DocumentFlags.Revision | DocumentFlags.Conflicted | DocumentFlags.Resolved));
                     }
                     else
                     {

--- a/test/SlowTests/Issues/RavenDB_15437.cs
+++ b/test/SlowTests/Issues/RavenDB_15437.cs
@@ -1,0 +1,106 @@
+﻿using System.Threading;
+using System.Threading.Tasks;
+using FastTests.Server.Replication;
+using FastTests.Utils;
+using Raven.Client;
+using SlowTests.Core.Utils.Entities;
+using Sparrow.Json;
+using Xunit;
+using Xunit.Abstractions;
+
+namespace SlowTests.Issues
+{
+    public class RavenDB_15437 : ReplicationTestBase
+    {
+        public RavenDB_15437(ITestOutputHelper output) : base(output)
+        {
+        }
+
+        [Fact]
+        public async Task ShouldNotHaveCounterAndCountersSnapshotInMetadata()
+        {
+            using (var storeA = GetDocumentStore())
+            using (var storeB = GetDocumentStore())
+            {
+                await RevisionsHelper.SetupRevisions(Server.ServerStore, storeA.Database);
+
+                using (var session = storeA.OpenAsyncSession())
+                {
+                    await session.StoreAsync(new User
+                    {
+                        Name = "Rhino"
+                    }, "users/1");
+                    session.CountersFor("users/1").Increment("Likes", 100);
+                    await session.SaveChangesAsync();
+                }
+
+                await SetupReplicationAsync(storeA, storeB);
+                await EnsureReplicatingAsync(storeA, storeB);
+
+                var dbA = await GetDocumentDatabaseInstanceFor(storeA);
+                dbA.Configuration.Replication.MaxItemsCount = 1;
+                dbA.ReplicationLoader.DebugWaitAndRunReplicationOnce = new ManualResetEventSlim();
+
+                using (var session = storeA.OpenAsyncSession())
+                {
+                    var user = await session.LoadAsync<User>("users/1");
+
+                    // add revision to A
+                    session.CountersFor(user).Increment("Likes2", 200);
+                    await session.SaveChangesAsync();
+                }
+
+                using (var session = storeA.OpenAsyncSession())
+                {
+                    session.CountersFor("users/1").Increment("Downloads", 100);
+                    await session.SaveChangesAsync();
+                }
+
+                dbA.ReplicationLoader.DebugWaitAndRunReplicationOnce.Set();
+
+                using (var session = storeB.OpenAsyncSession())
+                {
+                    var user = await session.LoadAsync<User>("users/1");
+
+                    session.CountersFor(user).Increment("Likes3", 300);
+                    await session.SaveChangesAsync();
+                }
+
+                using (var session = storeB.OpenAsyncSession())
+                {
+                    var user = await session.LoadAsync<BlittableJsonReaderObject>("users/1");
+                    var metadata = session.Advanced.GetMetadataFor(user);
+                    Assert.True(metadata.Keys.Contains(Constants.Documents.Metadata.Counters));
+                    Assert.False(metadata.Keys.Contains(Constants.Documents.Metadata.RevisionCounters));
+                }
+
+                dbA.ReplicationLoader.DebugWaitAndRunReplicationOnce.Set();
+                dbA.ReplicationLoader.DebugWaitAndRunReplicationOnce = null;
+
+                await SetupReplicationAsync(storeA, storeB);
+                await EnsureReplicatingAsync(storeA, storeB);
+
+                await SetupReplicationAsync(storeB, storeA);
+                await EnsureReplicatingAsync(storeB, storeA);
+
+                using (var sessionA = storeA.OpenAsyncSession())
+                using (var sessionB = storeB.OpenAsyncSession())
+                {
+                    var countersA = await sessionA.CountersFor("users/1").GetAllAsync();
+                    var countersB = await sessionB.CountersFor("users/1").GetAllAsync();
+
+                    Assert.Equal(4, countersA.Count);
+                    Assert.Equal(4, countersB.Count);
+
+                    foreach (var counterA in countersA)
+                    {
+                        Assert.True(countersB.ContainsKey(counterA.Key));
+
+                        countersB.TryGetValue(counterA.Key, out var val);
+                        Assert.Equal(val, counterA.Value);
+                    }
+                }
+            }
+        }
+    }
+}


### PR DESCRIPTION

### Issue link

https://issues.hibernatingrhinos.com/issue/RavenDB-15437

### Additional description

If replication brake at a point that only the revision's documents replicate, we may receive both - '**_@counters_**' & '**_@counters-snapshot_**' keys in the document metadata. 

We encounter this issue only when trying to replace the Live document with the revision document (if the revision's change vector is greater than the Live change vector). 

### Type of change

- Bug fix

### How risky is the change?

- Low 

### Backward compatibility

- Non breaking change

### Is it platform specific issue?

- No

### Documentation update

- No documentation update is needed 

### Testing 

- Tests have been added that prove the fix is effective or that the feature works

### Is there any existing behavior change of other features due to this change?

- No

### UI work

- No UI work is needed
