### PR TITLE
RavenDB-17340 - Sending very large documents via bulk insert

### DIFF
--- a/src/Sparrow/Binary/Bits.cs
+++ b/src/Sparrow/Binary/Bits.cs
@@ -1,3 +1,4 @@
+using System;
 using System.Runtime.CompilerServices;
 
 namespace Sparrow.Binary
@@ -266,6 +267,9 @@ namespace Sparrow.Binary
             v |= v >> 8;
             v |= v >> 16;
             v++;
+
+            if (v < 0)
+                throw new ArgumentException($"Could not return next power of 2 because the resulting number exceeds return type int");
 
             return v;
         }

--- a/src/Sparrow/Binary/Bits.cs
+++ b/src/Sparrow/Binary/Bits.cs
@@ -5,6 +5,8 @@ namespace Sparrow.Binary
 {
     public static class Bits
     {
+        private const int GB = 1024 * 1024 * 1024;
+
         //https://stackoverflow.com/questions/2709430/count-number-of-bits-in-a-64-bit-long-big-integer
         public static long NumberOfSetBits(long i)
         {
@@ -260,6 +262,9 @@ namespace Sparrow.Binary
         [MethodImpl(MethodImplOptions.AggressiveInlining)]
         private static int PowerOf2Internal(int v)
         {
+            if (v > GB)
+                ThrowPowerOf2OverflowException(v);
+
             v--;
             v |= v >> 1;
             v |= v >> 2;
@@ -268,10 +273,12 @@ namespace Sparrow.Binary
             v |= v >> 16;
             v++;
 
-            if (v < 0)
-                throw new ArgumentException($"Could not return next power of 2 because the resulting number exceeds return type int");
-
             return v;
+        }
+
+        private static void ThrowPowerOf2OverflowException(int v)
+        {
+            throw new ArgumentException($"Could not return next power of 2 of {v} because the resulting number exceeds return type int");
         }
 
         [MethodImpl(MethodImplOptions.AggressiveInlining)]

--- a/src/Sparrow/Json/ArenaMemoryAllocator.cs
+++ b/src/Sparrow/Json/ArenaMemoryAllocator.cs
@@ -111,7 +111,10 @@ namespace Sparrow.Json
                 SizeInBytes = size
             };
 #else
-
+            if (size < 0)
+                throw new ArgumentOutOfRangeException(nameof(size), size,
+                    $"Size cannot be negative");
+            
             if (size > MaxArenaSize)
                 throw new ArgumentOutOfRangeException(nameof(size), size,
                     $"Requested size {size} while maximum size is {MaxArenaSize}");
@@ -209,7 +212,7 @@ namespace Sparrow.Json
             _used = 0;
         }
 
-        private int GetPreferredSize(int requestedSize)
+        private long GetPreferredSize(int requestedSize)
         {
             if (AvoidOverAllocation || PlatformDetails.Is32Bits)
                 return ApplyLimit(Bits.PowerOf2(requestedSize));
@@ -219,10 +222,10 @@ namespace Sparrow.Json
             // the idea is that a single allocation can server for multiple (increasing in size) calls
             return ApplyLimit(Math.Max(Bits.PowerOf2(requestedSize) * 3L, _initialSize));
 
-            int ApplyLimit(long size)
+            long ApplyLimit(long size)
             {
                 if (SingleAllocationSizeLimit == null)
-                    return (int)size;
+                    return size;
 
                 if (size > SingleAllocationSizeLimit.Value)
                 {
@@ -230,7 +233,7 @@ namespace Sparrow.Json
                     return sizeInMb * Constants.Size.Megabyte;
                 }
 
-                return (int)size;
+                return size;
             }
         }
 

--- a/src/Sparrow/Json/ArenaMemoryAllocator.cs
+++ b/src/Sparrow/Json/ArenaMemoryAllocator.cs
@@ -111,6 +111,11 @@ namespace Sparrow.Json
                 SizeInBytes = size
             };
 #else
+
+            if (size > MaxArenaSize)
+                throw new ArgumentOutOfRangeException(nameof(size), size,
+                    $"Requested size {size} while maximum size is {MaxArenaSize}");
+
             size = Bits.PowerOf2(Math.Max(sizeof(FreeSection), size));
 
             AllocatedMemoryData allocation;
@@ -167,7 +172,7 @@ namespace Sparrow.Json
 
         private void GrowArena(int requestedSize)
         {
-            if (requestedSize >= MaxArenaSize)
+            if (requestedSize > MaxArenaSize)
                 throw new ArgumentOutOfRangeException(nameof(requestedSize), requestedSize,
                     $"Requested arena resize to {requestedSize} while current size is {_allocated} and maximum size is {MaxArenaSize}");
 
@@ -212,12 +217,12 @@ namespace Sparrow.Json
             // we need the next allocation to cover at least the next expansion (also doubling)
             // so we'll allocate 3 times as much as was requested, or as much as we already have
             // the idea is that a single allocation can server for multiple (increasing in size) calls
-            return ApplyLimit(Math.Max(Bits.PowerOf2(requestedSize) * 3, _initialSize));
+            return ApplyLimit(Math.Max(Bits.PowerOf2(requestedSize) * 3L, _initialSize));
 
-            int ApplyLimit(int size)
+            int ApplyLimit(long size)
             {
                 if (SingleAllocationSizeLimit == null)
-                    return size;
+                    return (int)size;
 
                 if (size > SingleAllocationSizeLimit.Value)
                 {
@@ -225,7 +230,7 @@ namespace Sparrow.Json
                     return sizeInMb * Constants.Size.Megabyte;
                 }
 
-                return size;
+                return (int)size;
             }
         }
 

--- a/src/Sparrow/Json/BlittableWriter.cs
+++ b/src/Sparrow/Json/BlittableWriter.cs
@@ -453,6 +453,10 @@ namespace Sparrow.Json
 
             var escapePositionsMaxSize = JsonParserState.FindEscapePositionsMaxSize(str, out _);
             int size = Encodings.Utf8.GetMaxByteCount(str.Length) + escapePositionsMaxSize;
+            if (size > 8 * 1024 * 1024)
+            {
+                size = Encodings.Utf8.GetByteCount(str) + escapePositionsMaxSize;
+            }
 
             AllocatedMemoryData buffer = null;
             try

--- a/test/FastTests/Client/BulkInsert/BulkInserts.cs
+++ b/test/FastTests/Client/BulkInsert/BulkInserts.cs
@@ -20,6 +20,37 @@ namespace FastTests.Client.BulkInsert
         {
         }
 
+        [Theory]
+        [InlineData(6)]
+        [InlineData(100)]
+        [InlineData(600)]
+        public async Task SendingDocumentWithLargeFieldInBulkInsert(int sizeInMb)
+        {
+            var mb = 1024 * 1024;
+            var objSize = sizeInMb * mb;
+            var bigObj = new BigFieldObject()
+            {
+                textField = new string('*', objSize)
+            };
+
+            using (var store = GetDocumentStore())
+            {
+                await using (var bulkInsert = store.BulkInsert())
+                {
+                    await bulkInsert.StoreAsync(new BigFieldObject());
+                    await bulkInsert.StoreAsync(new BigFieldObject());
+                    await bulkInsert.StoreAsync(new BigFieldObject());
+                    await bulkInsert.StoreAsync(bigObj);
+                }
+            }
+        }
+
+        public class BigFieldObject
+        {
+            public string textField;
+        }
+
+
         [Fact]
         public void SimpleBulkInsertShouldWork()
         {

--- a/test/FastTests/Client/BulkInsert/BulkInserts.cs
+++ b/test/FastTests/Client/BulkInsert/BulkInserts.cs
@@ -20,37 +20,6 @@ namespace FastTests.Client.BulkInsert
         {
         }
 
-        [Theory]
-        [InlineData(6)]
-        [InlineData(100)]
-        [InlineData(600)]
-        public async Task SendingDocumentWithLargeFieldInBulkInsert(int sizeInMb)
-        {
-            var mb = 1024 * 1024;
-            var objSize = sizeInMb * mb;
-            var bigObj = new BigFieldObject()
-            {
-                textField = new string('*', objSize)
-            };
-
-            using (var store = GetDocumentStore())
-            {
-                await using (var bulkInsert = store.BulkInsert())
-                {
-                    await bulkInsert.StoreAsync(new BigFieldObject());
-                    await bulkInsert.StoreAsync(new BigFieldObject());
-                    await bulkInsert.StoreAsync(new BigFieldObject());
-                    await bulkInsert.StoreAsync(bigObj);
-                }
-            }
-        }
-
-        public class BigFieldObject
-        {
-            public string textField;
-        }
-
-
         [Fact]
         public void SimpleBulkInsertShouldWork()
         {

--- a/test/FastTests/Sparrow/Bits.cs
+++ b/test/FastTests/Sparrow/Bits.cs
@@ -97,7 +97,7 @@ namespace FastTests.Sparrow
         [Fact]
         public void Bits_NextPowerOf2()
         {
-            for (int i = 1; i < 31; i++)
+            for (int i = 1; i < 30; i++)
             {
                 int v = 1 << i;
                 Assert.Equal(v << 1, Bits.PowerOf2(v + 1));

--- a/test/StressTests/Issues/RavenDB_17340.cs
+++ b/test/StressTests/Issues/RavenDB_17340.cs
@@ -1,0 +1,56 @@
+﻿using System;
+using System.Collections.Generic;
+using System.Diagnostics;
+using System.Linq;
+using System.Text;
+using System.Threading.Tasks;
+using FastTests;
+using Orders;
+using Raven.Client.Documents;
+using Raven.Client.Documents.Indexes;
+using Raven.Client.Documents.Operations.Indexes;
+using Raven.Server.Config;
+using Tests.Infrastructure;
+using Xunit;
+using Xunit.Abstractions;
+
+namespace StressTests.Issues
+{
+    public class RavenDB_17340 : RavenTestBase
+    {
+        public RavenDB_17340(ITestOutputHelper output) : base(output)
+        {
+        }
+
+        [Theory]
+        [InlineData(6)]
+        [InlineData(100)]
+        [InlineData(600)]
+        public async Task SendingDocumentWithLargeFieldInBulkInsert(int sizeInMb)
+        {
+            var mb = 1024 * 1024;
+            var objSize = sizeInMb * mb;
+            var bigObj = new BigFieldObject()
+            {
+                textField = new string('*', objSize)
+            };
+
+            using (var store = GetDocumentStore())
+            {
+                await using (var bulkInsert = store.BulkInsert())
+                {
+                    await bulkInsert.StoreAsync(new BigFieldObject());
+                    await bulkInsert.StoreAsync(new BigFieldObject());
+                    await bulkInsert.StoreAsync(new BigFieldObject());
+                    await bulkInsert.StoreAsync(bigObj);
+                }
+            }
+        }
+
+        public class BigFieldObject
+        {
+            public string textField;
+        }
+
+    }
+}


### PR DESCRIPTION
### Issue link

https://issues.hibernatingrhinos.com/issue/RavenDB-17340

### Additional description

When an object sent in bulk insert has a very large text field, the requested size sent to GrowArena would be equal to MaxArenaSize, which would then throw. Changed so requested size is allowed to be equal to MaxArenaSize (1Gb).

After the change, the value sent to ApplyLimit was incorrect (not the actual max) since Bits.PowerOf2(requestedSize) * 3 caused an Int overflow and we would get a different value, which would not be chosen by Math.Max. Changed to long.
This problem does not happen in existing code since the condition 'requestedSize >= MaxArenaSize' ensured we would only get past this check when the requested size is less than 512MB - not enough to overflow Int.MaxValue. 

The size of the field was was calculated using GetMaxByteCount, which is fast but causes us to over allocate by a large margin when dealing with large sizes, which later caused us to reach MaxArenaSize.
Changed this so on dealing with max bytes of 8MB or more we use GetByteCount instead, which is slower but worth it to allocate proper sizes for big fields.

When experimenting with even larger sizes (>1GB), the 'Bits.PowerOf2(Math.Max(sizeof(FreeSection), size))' call would return a negative because of an int overflow. Added a check to prevent reaching this function if a size is bigger than MaxArenaSize (>1GB) as well as a check inside powerof2.

### Type of change

- Bug fix

### How risky is the change?

- Moderate 

### Backward compatibility

- Non breaking change

### Is it platform specific issue?

- No

### Documentation update

- No documentation update is needed 

### Testing 

- Tests have been added that prove the fix is effective or that the feature works

### Is there any existing behavior change of other features due to this change?

- No

### UI work

- No UI work is needed
