### PR TITLE
RavenDB-17772 - Duplicated items in output

### DIFF
--- a/src/Corax/Queries/BinaryMatch.Boolean.cs
+++ b/src/Corax/Queries/BinaryMatch.Boolean.cs
@@ -135,13 +135,13 @@ namespace Corax.Queries
 
                 // Execute the AndWith operation for each subpart of the query.               
                 matches.CopyTo(innerMatches);
-                inner.AndWith(innerMatches);
+                int innerSize = inner.AndWith(innerMatches);
 
                 matches.CopyTo(outerMatches);
-                outer.AndWith(outerMatches);
+                int outerSize = outer.AndWith(outerMatches);
                 
                 // Merge the hits from every side into the output buffer. 
-                var result = MergeHelper.Or(matches, innerMatches, outerMatches);                
+                var result = MergeHelper.Or(matches, innerMatches.Slice(0, innerSize), outerMatches.Slice(0, outerSize));                
                 QueryContext.MatchesPool.Return(bufferHolder);
 
                 return result;

--- a/test/FastTests/Corax/IndexSearcher.cs
+++ b/test/FastTests/Corax/IndexSearcher.cs
@@ -1403,18 +1403,15 @@ namespace FastTests.Corax
                 Span<long> ids = stackalloc long[256];
                 var orResult = searcher.Or(m4, searcher.Or(m3, searcher.Or(m2, searcher.Or(m1, m0))));
                 Assert.Equal(7, orResult.Fill(ids));
+                Assert.True(ids.Slice(0, 7).ToArray().ToList().Select(x => searcher.GetIdentityFor(x)).OrderBy(a => a).SequenceEqual(entries.OrderBy(z => z.Id).Select(e => e.Id)));
             }
 
             {
                 Span<long> ids = stackalloc long[256];
                 var startsWith = searcher.StartWithQuery("Id", "e");
-                Assert.Equal(7, startsWith.Fill(ids.Slice(7)));
+                Assert.Equal(7, startsWith.Fill(ids));
 
-                var orResArr = ids.Slice(0, 7).ToArray();
-                var stWthArr = ids.Slice(7, 7).ToArray();
-                Array.Sort(orResArr);
-                Array.Sort(stWthArr);
-                Assert.True(orResArr.SequenceEqual(stWthArr));
+                Assert.True(ids.Slice(0, 7).ToArray().ToList().Select(x => searcher.GetIdentityFor(x)).OrderBy(a => a).SequenceEqual(entries.OrderBy(z => z.Id).Select(e => e.Id)));
             }
 
             {
@@ -1431,6 +1428,7 @@ namespace FastTests.Corax
                 var idsOfResult = ids.Slice(14, amount).ToArray().Select(x => searcher.GetIdentityFor(x)).ToList();
                 Assert.Equal(idsOfResult.Count, idsOfResult.Distinct().Count());
                 Assert.Equal(7, amount);
+                Assert.True(idsOfResult.SequenceEqual(entries.OrderBy(z => z.Id).Select(e => e.Id)));
             }
         }
     }


### PR DESCRIPTION
### Issue link

https://issues.hibernatingrhinos.com/issue/RavenDB-17772 

### Additional description
The actual issue comes from not trimming the output list after the AndWith on the inner and outer.


### Type of change

- Bug fix


### How risky is the change?

- Low 


### Backward compatibility


- Not relevant

### Is it platform specific issue?

- No

### Documentation update

- No documentation update is needed 

### Testing 

- Tests have been added that prove the fix is effective or that the feature works

### Is there any existing behavior change of other features due to this change?

- No

### UI work

- No UI work is needed
