### PR TITLE
RavenDB-17592 Adding `Expires` to compare exchange atomic guard

### DIFF
--- a/src/Raven.Server/ServerWide/ClusterStateMachine.cs
+++ b/src/Raven.Server/ServerWide/ClusterStateMachine.cs
@@ -3005,7 +3005,7 @@ namespace Raven.Server.ServerWide
             return compareExchangeValue;
         }
 
-        private static unsafe long ReadCompareExchangeOrTombstoneIndex(TableValueReader reader)
+        public static unsafe long ReadCompareExchangeOrTombstoneIndex(TableValueReader reader)
         {
             var index = *(long*)reader.Read((int)CompareExchangeTable.Index, out var size);
             Debug.Assert(size == sizeof(long));

--- a/src/Raven.Server/ServerWide/ClusterStateMachine.cs
+++ b/src/Raven.Server/ServerWide/ClusterStateMachine.cs
@@ -2792,6 +2792,12 @@ namespace Raven.Server.ServerWide
         {
             var items = context.Transaction.InnerTransaction.OpenTable(CompareExchangeSchema, CompareExchange);
 
+            return GetCompareExchangeValue(context, key, items);
+        }
+
+        public static (long Index, BlittableJsonReaderObject Value) GetCompareExchangeValue<TTransaction>(TransactionOperationContext<TTransaction> context, Slice key, Table items)
+            where TTransaction : RavenTransaction
+        {
             if (items.ReadByKey(key, out var reader))
             {
                 var index = ReadCompareExchangeOrTombstoneIndex(reader);
@@ -2991,7 +2997,8 @@ namespace Raven.Server.ServerWide
             return new CompareExchangeKey(storageKey, dbPrefix.Length + 1);
         }
 
-        private static unsafe BlittableJsonReaderObject ReadCompareExchangeValue(TransactionOperationContext context, TableValueReader reader)
+        private static unsafe BlittableJsonReaderObject ReadCompareExchangeValue<TTransaction>(TransactionOperationContext<TTransaction> context, TableValueReader reader)
+            where TTransaction : RavenTransaction
         {
             BlittableJsonReaderObject compareExchangeValue = new BlittableJsonReaderObject(reader.Read((int)CompareExchangeTable.Value, out var size), size, context);
             Transaction.DebugDisposeReaderAfterTransaction(context.Transaction.InnerTransaction, compareExchangeValue);

--- a/src/Raven.Server/ServerWide/Commands/ClusterTransactionCommand.cs
+++ b/src/Raven.Server/ServerWide/Commands/ClusterTransactionCommand.cs
@@ -30,8 +30,8 @@ namespace Raven.Server.ServerWide.Commands
         public string ClusterTransactionId;
 
         public long DatabaseCommandsCount;
-        //We take the current ticks in advance to ensure consist results of the command execution on all nodes
-        public long CommandCreationTicks;
+        //We take the current ticks in advance to ensure consistent results of the command execution on all nodes
+        public long CommandCreationTicks = long.MinValue;
 
         public class ClusterTransactionDataCommand
         {

--- a/src/Raven.Server/ServerWide/Commands/CompareExchangeCommands.cs
+++ b/src/Raven.Server/ServerWide/Commands/CompareExchangeCommands.cs
@@ -219,7 +219,7 @@ namespace Raven.Server.ServerWide.Commands
             throw new RachisApplyException("Unable to convert result type: " + result?.GetType()?.FullName + ", " + result);
         }
 
-        protected bool TryGetExpires(BlittableJsonReaderObject value, string storageKey, out long ticks)
+        protected bool TryGetExpires(BlittableJsonReaderObject value, out long ticks)
         {
             try
             {
@@ -227,8 +227,7 @@ namespace Raven.Server.ServerWide.Commands
             }
             catch (Exception e)
             {
-                (var database, var key) = CompareExchangeKey.SplitStorageKey(storageKey);
-                throw new RachisApplyException($"Could not apply command {GetType().Name} - failed to get `Expires` for compare exchange key:{key} database:{database}.", e);
+                throw new RachisApplyException($"Could not apply command {GetType().Name} - failed to get `Expires` for compare exchange key:{Key} database:{Database}.", e);
             }
         }
     }
@@ -336,7 +335,7 @@ namespace Raven.Server.ServerWide.Commands
         {
             if (key.Length > MaxNumberOfCompareExchangeKeyBytes || Encoding.GetByteCount(key) > MaxNumberOfCompareExchangeKeyBytes)
                 ThrowCompareExchangeKeyTooBig(key);
-            if (TryGetExpires(value, ActualKey, out long ticks))
+            if (TryGetExpires(value, out long ticks))
                 ExpirationTicks = ticks;
 
             Value = value;
@@ -431,7 +430,7 @@ namespace Raven.Server.ServerWide.Commands
 
             using (value)
             {
-                if (CompareExchangeExpirationStorage.TryGetExpires(value, out var ticks) && ticks < CurrentTicks)
+                if (TryGetExpires(value, out var ticks) && ticks < CurrentTicks)
                     return true;
                 return currentIndex == index;
             }

--- a/src/Raven.Server/ServerWide/CompareExchangeExpirationStorage.cs
+++ b/src/Raven.Server/ServerWide/CompareExchangeExpirationStorage.cs
@@ -89,7 +89,9 @@ namespace Raven.Server.ServerWide
             if (metadataReader.TryGet(Constants.Documents.Metadata.Expires, out LazyStringValue expirationDate) == false)
                 return false;
 
-            var date = DateTime.ParseExact(expirationDate, DefaultFormat.DateTimeFormatsToRead, CultureInfo.InvariantCulture, DateTimeStyles.RoundtripKind);
+            if (DateTime.TryParseExact(expirationDate, DefaultFormat.DateTimeFormatsToRead, CultureInfo.InvariantCulture, DateTimeStyles.RoundtripKind, out var date) == false)
+                throw new FormatException($"{Constants.Documents.Metadata.Expires} should contain date but has {expirationDate}': {value}");
+
             ticks = date.ToUniversalTime().Ticks;
             return true;
         }

--- a/src/Raven.Server/ServerWide/CompareExchangeExpirationStorage.cs
+++ b/src/Raven.Server/ServerWide/CompareExchangeExpirationStorage.cs
@@ -80,40 +80,18 @@ namespace Raven.Server.ServerWide
             }
         }
 
-        public static bool HasExpiredMetadata(BlittableJsonReaderObject value, out long ticks, Slice keySlice, string storageKey = null)
+        public static bool TryGetExpires(BlittableJsonReaderObject value, out long ticks)
         {
             ticks = default;
-            if (value.TryGetMember(Constants.Documents.Metadata.Key, out var metadata) == false || metadata == null)
+            if (value.TryGetMember(Constants.Documents.Metadata.Key, out var metadata) == false || metadata is not BlittableJsonReaderObject metadataReader)
+                return false;
+        
+            if (metadataReader.TryGet(Constants.Documents.Metadata.Expires, out LazyStringValue expirationDate) == false)
                 return false;
 
-            if (metadata is BlittableJsonReaderObject bjro && bjro.TryGet(Constants.Documents.Metadata.Expires, out object obj))
-            {
-                if (obj is LazyStringValue expirationDate)
-                {
-                    if (DateTime.TryParseExact(expirationDate, DefaultFormat.DateTimeFormatsToRead, CultureInfo.InvariantCulture, DateTimeStyles.RoundtripKind,
-                            out DateTime date) == false)
-                    {
-                        storageKey ??= keySlice.ToString();
-
-                        var inner = new InvalidOperationException(
-                            $"The expiration date format for compare exchange '{CompareExchangeKey.SplitStorageKey(storageKey).Key}' is not valid: '{expirationDate}'. Use the following format: {DateTime.UtcNow:O}");
-                        throw new RachisApplyException("Could not apply command.", inner);
-                    }
-
-                    var expiry = date.ToUniversalTime();
-                    ticks = expiry.Ticks;
-                    return true;
-                }
-                else
-                {
-                    storageKey ??= keySlice.ToString();
-                    var inner = new InvalidOperationException(
-                        $"The type of {Constants.Documents.Metadata.Expires} metadata for compare exchange '{CompareExchangeKey.SplitStorageKey(storageKey).Key}' is not valid. Use the following type: {nameof(DateTime)}");
-                    throw new RachisApplyException("Could not apply command.", inner);
-                }
-            }
-
-            return false;
+            var date = DateTime.ParseExact(expirationDate, DefaultFormat.DateTimeFormatsToRead, CultureInfo.InvariantCulture, DateTimeStyles.RoundtripKind);
+            ticks = date.ToUniversalTime().Ticks;
+            return true;
         }
 
         public static unsafe bool DeleteExpiredCompareExchange(ClusterOperationContext context, Table items, long ticks, long take = long.MaxValue)
@@ -140,7 +118,7 @@ namespace Raven.Server.ServerWide
                 var storeValue = reader.Read((int)ClusterStateMachine.CompareExchangeTable.Value, out var size);
                 using var result = new BlittableJsonReaderObject(storeValue, size, context);
 
-                if (HasExpiredMetadata(result, out long currentTicks, keySlice, storageKey: null) == false)
+                if (TryGetExpires(result, out long currentTicks) == false)
                     continue;
 
                 if (currentTicks > expiredTicks)

--- a/test/RachisTests/DatabaseCluster/AtomicClusterReadWriteTests.cs
+++ b/test/RachisTests/DatabaseCluster/AtomicClusterReadWriteTests.cs
@@ -6,15 +6,19 @@ using System.Linq;
 using System.Threading;
 using System.Threading.Tasks;
 using FastTests.Server.Replication;
+using Raven.Client;
 using Raven.Client.Documents;
 using Raven.Client.Documents.Conventions;
 using Raven.Client.Documents.Operations.Backups;
 using Raven.Client.Documents.Operations.CompareExchange;
+using Raven.Client.Documents.Operations.Expiration;
 using Raven.Client.Documents.Session;
 using Raven.Client.Documents.Smuggler;
 using Raven.Client.Exceptions;
 using Raven.Client.Util;
 using Raven.Server;
+using Raven.Server.Config;
+using Sparrow.Extensions;
 using Sparrow.Server;
 using Xunit;
 using Xunit.Abstractions;
@@ -461,6 +465,83 @@ namespace RachisTests.DatabaseCluster
             }
 
             await task;
+        }
+
+        [Fact]
+        public async Task ClusterWideTransaction_WhenSetExpirationAndExport_ShouldDeleteTheCompareExchangeAsWell()
+        {
+            var customSettings = new Dictionary<string, string> {[RavenConfiguration.GetKey(x => x.Cluster.CompareExchangeExpiredCleanupInterval)] = "1"};
+            using var server = GetNewServer(new ServerCreationOptions {CustomSettings = customSettings,});
+
+            using var source = GetDocumentStore();
+            using var dest = GetDocumentStore(new Options {Server = server});
+            await dest.Maintenance.SendAsync(new ConfigureExpirationOperation(new ExpirationConfiguration
+            {
+                Disabled = false,
+                DeleteFrequencyInSec = 1
+            }));
+            
+            const string id = "testObjs/0";
+            using (var session = source.OpenAsyncSession(new SessionOptions {TransactionMode = TransactionMode.ClusterWide}))
+            {
+                var entity = new TestObj();
+                await session.StoreAsync(entity, id);
+            
+                var expires = SystemTime.UtcNow.AddMinutes(-5);
+                session.Advanced.GetMetadataFor(entity)[Constants.Documents.Metadata.Expires] = expires.GetDefaultRavenFormat(isUtc: true);
+                await session.SaveChangesAsync();    
+            }
+
+            var operation = await source.Smuggler.ExportAsync(new DatabaseSmugglerExportOptions(), dest.Smuggler);
+            await operation.WaitForCompletionAsync(TimeSpan.FromMinutes(1));
+            
+            await AssertWaitForNullAsync(async () =>
+            {
+                using var session = dest.OpenAsyncSession(new SessionOptions { TransactionMode = TransactionMode.ClusterWide });
+                return await session.LoadAsync<TestObj>(id);
+            });
+
+            await AssertWaitForTrueAsync(async () =>
+            {
+                var compareExchangeValues = await dest.Operations.SendAsync(new GetCompareExchangeValuesOperation<object>(""));
+                return compareExchangeValues.Any() == false;
+            });
+        }
+
+        [Fact]
+        public async Task ClusterWideTransaction_WhenSetExpiration_ShouldDeleteTheCompareExchangeAsWell()
+        {
+            var customSettings = new Dictionary<string, string> {[RavenConfiguration.GetKey(x => x.Cluster.CompareExchangeExpiredCleanupInterval)] = "1"};
+            using var server = GetNewServer(new ServerCreationOptions {CustomSettings = customSettings,});
+            using var store = GetDocumentStore(new Options{Server = server});
+            await store.Maintenance.SendAsync(new ConfigureExpirationOperation(new ExpirationConfiguration
+            {
+                Disabled = false,
+                DeleteFrequencyInSec = 10
+            }));
+            
+            const string id = "testObjs/0";
+            using (var session = store.OpenAsyncSession(new SessionOptions {TransactionMode = TransactionMode.ClusterWide}))
+            {
+                var entity = new TestObj();
+                await session.StoreAsync(entity, id);
+            
+                var expires = SystemTime.UtcNow.AddMinutes(-5);
+                session.Advanced.GetMetadataFor(entity)[Constants.Documents.Metadata.Expires] = expires.GetDefaultRavenFormat(isUtc: true);;
+                await session.SaveChangesAsync();    
+            }
+
+            await AssertWaitForNullAsync(async () =>
+            {
+                using var session = store.OpenAsyncSession(new SessionOptions { TransactionMode = TransactionMode.ClusterWide });
+                return await session.LoadAsync<TestObj>(id);
+            });
+
+            await AssertWaitForTrueAsync(async () =>
+            {
+                var compareExchangeValues = await store.Operations.SendAsync(new GetCompareExchangeValuesOperation<object>(""));
+                return compareExchangeValues.Any() == false;
+            });
         }
 
         private static IDisposable LocalGetDocumentStores(List<RavenServer> nodes, string database, out IDocumentStore[] stores)


### PR DESCRIPTION
### Issue link

https://issues.hibernatingrhinos.com/issue/RavenDB-17592 

### Additional description

We keep the implementation simple by simply adding an `Expires` property to the compare exchange with the value from the document.
There is no guarantee that the document and its compare exchange will be deleted at the same time.

### Type of change
- Bug fix

### How risky is the change?
- Moderate 


### Backward compatibility
- Fix undesired behaviour

### Is it platform specific issue?
- No

### Documentation update
- This change requires a documentation update.

### Testing 
- Tests have been added that prove the fix is effective or that the feature works

### Is there any existing behavior change of other features due to this change?
- No

### UI work
- No UI work is needed
