### PR TITLE
RavenDB-17625 - Add support for escaping in JsonPatch

### DIFF
--- a/src/Raven.Server/Documents/TransactionCommands/JsonPatchCommand.cs
+++ b/src/Raven.Server/Documents/TransactionCommands/JsonPatchCommand.cs
@@ -334,18 +334,25 @@ namespace Raven.Server.Documents.TransactionCommands
                 {
                     if(paths[i].IsNullOrWhiteSpace())
                         throw new ArgumentException($"Invalid path {path}. Paths must be of format /*/*/*... ");
+                    paths[i] = EscapePathMember(paths[i]);
                 }
 
                 for (int i = 1; fromPaths != null && i < fromPaths.Length; i++)
                 {
                     if (fromPaths[i].IsNullOrWhiteSpace())
                         throw new ArgumentException($"Invalid 'from' path {path}. Paths must be of format /*/*/*... ");
+                    fromPaths[i] = EscapePathMember(fromPaths[i]);
                 }
 
                 commands.Add(new Command(type, paths, fromPaths, path, from, value));
             }
 
             return commands;
+        }
+
+        private static string EscapePathMember(string member)
+        {
+            return member.Replace("~0", "~").Replace("~1", "/");
         }
 
         public override TransactionOperationsMerger.IReplayableCommandDto<TransactionOperationsMerger.MergedTransactionCommand> ToDto(JsonOperationContext context)


### PR DESCRIPTION
### Issue link

https://issues.hibernatingrhinos.com/issue/RavenDB-17625

### Additional description

Added escaping for path members

### Type of change

- Bug fix

### How risky is the change?

- Low 

### Backward compatibility

- Non breaking change

### Is it platform specific issue?

- No

### Documentation update

- No documentation update is needed 

### Testing 

- Tests have been added that prove the fix is effective or that the feature works

### Is there any existing behavior change of other features due to this change?

- No

### UI work

- No UI work is needed
