### PR TITLE
RavenDB-17757 - Decoupling quantity of matches and buffers. 

### DIFF
--- a/src/Corax/Queries/AllEntriesMatch.cs
+++ b/src/Corax/Queries/AllEntriesMatch.cs
@@ -85,10 +85,10 @@ namespace Corax.Queries
         }
 
         [MethodImpl(MethodImplOptions.AggressiveInlining)]
-        public int AndWith(Span<long> prevMatches)
+        public int AndWith(Span<long> buffer, int matches)
         {
             // this match *everything*, so ands with everything 
-            return prevMatches.Length;
+            return matches;
         }
 
         [MethodImpl(MethodImplOptions.AggressiveInlining)]

--- a/src/Corax/Queries/BinaryMatch.Erasure.cs
+++ b/src/Corax/Queries/BinaryMatch.Erasure.cs
@@ -30,9 +30,9 @@ namespace Corax.Queries
         }
 
         [MethodImpl(MethodImplOptions.AggressiveInlining)]
-        public int AndWith(Span<long> buffer)
+        public int AndWith(Span<long> buffer, int matches)
         {
-            return _functionTable.AndWithFunc(ref this, buffer);
+            return _functionTable.AndWithFunc(ref this, buffer, matches);
         }
 
         [MethodImpl(MethodImplOptions.AggressiveInlining)]
@@ -49,13 +49,13 @@ namespace Corax.Queries
         internal class FunctionTable
         {
             public readonly delegate*<ref BinaryMatch, Span<long>, int> FillFunc;
-            public readonly delegate*<ref BinaryMatch, Span<long>, int> AndWithFunc;
+            public readonly delegate*<ref BinaryMatch, Span<long>, int, int> AndWithFunc;
             public readonly delegate*<ref BinaryMatch, Span<long>, Span<float>, void> ScoreFunc;
             public readonly delegate*<ref BinaryMatch, long> CountFunc;
 
             public FunctionTable(
                 delegate*<ref BinaryMatch, Span<long>, int> fillFunc,
-                delegate*<ref BinaryMatch, Span<long>, int> andWithFunc,
+                delegate*<ref BinaryMatch, Span<long>, int, int> andWithFunc,
                 delegate*<ref BinaryMatch, Span<long>, Span<float>, void> scoreFunc,
                 delegate*<ref BinaryMatch, long> countFunc)
             {
@@ -92,11 +92,11 @@ namespace Corax.Queries
                 }
 
                 [MethodImpl(MethodImplOptions.AggressiveInlining)]
-                static int AndWithFunc(ref BinaryMatch match, Span<long> matches)
+                static int AndWithFunc(ref BinaryMatch match, Span<long> buffer, int matches)
                 {
                     if (match._inner is BinaryMatch<TInner, TOuter> inner)
                     {
-                        var result = inner.AndWith(matches);
+                        var result = inner.AndWith(buffer, matches);
                         match._inner = inner;
                         return result;
                     }

--- a/src/Corax/Queries/BinaryMatch.cs
+++ b/src/Corax/Queries/BinaryMatch.cs
@@ -12,7 +12,7 @@ namespace Corax.Queries
         where TOuter : IQueryMatch
     {
         private readonly delegate*<ref BinaryMatch<TInner, TOuter>, Span<long>, int>  _fillFunc;
-        private readonly delegate*<ref BinaryMatch<TInner, TOuter>, Span<long>, int> _andWithFunc;
+        private readonly delegate*<ref BinaryMatch<TInner, TOuter>, Span<long>, int, int> _andWithFunc;
         private readonly delegate*<ref BinaryMatch<TInner, TOuter>, QueryInspectionNode> _inspectFunc;
 
         private TInner _inner;
@@ -30,7 +30,7 @@ namespace Corax.Queries
 
         private BinaryMatch(in TInner inner, in TOuter outer,
             delegate*<ref BinaryMatch<TInner, TOuter>, Span<long>, int> fillFunc,
-            delegate*<ref BinaryMatch<TInner, TOuter>, Span<long>, int> andWithFunc,
+            delegate*<ref BinaryMatch<TInner, TOuter>, Span<long>, int, int> andWithFunc,
             delegate*<ref BinaryMatch<TInner, TOuter>, QueryInspectionNode> inspectionFunc,
             long totalResults,
             QueryCountConfidence confidence)
@@ -54,9 +54,9 @@ namespace Corax.Queries
         }
 
         [MethodImpl(MethodImplOptions.AggressiveInlining)]
-        public int AndWith(Span<long> buffer)
+        public int AndWith(Span<long> buffer, int matches)
         {
-            return _andWithFunc(ref this, buffer);
+            return _andWithFunc(ref this, buffer, matches);
         }
 
         [MethodImpl(MethodImplOptions.AggressiveInlining)]

--- a/src/Corax/Queries/BoostingMatch.Erasure.cs
+++ b/src/Corax/Queries/BoostingMatch.Erasure.cs
@@ -30,9 +30,9 @@ namespace Corax.Queries
         }
 
         [MethodImpl(MethodImplOptions.AggressiveInlining)]
-        public int AndWith(Span<long> buffer)
+        public int AndWith(Span<long> buffer, int matches)
         {
-            return _functionTable.AndWithFunc(ref this, buffer);
+            return _functionTable.AndWithFunc(ref this, buffer, matches);
         }
 
         [MethodImpl(MethodImplOptions.AggressiveInlining)]
@@ -50,14 +50,14 @@ namespace Corax.Queries
         internal class FunctionTable
         {
             public readonly delegate*<ref BoostingMatch, Span<long>, int> FillFunc;
-            public readonly delegate*<ref BoostingMatch, Span<long>, int> AndWithFunc;
+            public readonly delegate*<ref BoostingMatch, Span<long>, int, int> AndWithFunc;
             public readonly delegate*<ref BoostingMatch, Span<long>, Span<float>, void> ScoreFunc;
             public readonly delegate*<ref BoostingMatch, long> CountFunc;
 
 
             public FunctionTable(
                 delegate*<ref BoostingMatch, Span<long>, int> fillFunc,
-                delegate*<ref BoostingMatch, Span<long>, int> andWithFunc,
+                delegate*<ref BoostingMatch, Span<long>, int, int> andWithFunc,
                 delegate*<ref BoostingMatch, Span<long>, Span<float>, void> scoreFunc,
                 delegate*<ref BoostingMatch, long> countFunc)
             {
@@ -94,11 +94,11 @@ namespace Corax.Queries
                 }
 
                 [MethodImpl(MethodImplOptions.AggressiveInlining)]
-                static int AndWithFunc(ref BoostingMatch match, Span<long> matches)
+                static int AndWithFunc(ref BoostingMatch match, Span<long> buffer, int matches)
                 {
                     if (match._inner is BoostingMatch<TInner, TQueryScoreFunction> inner)
                     {
-                        var result = inner.AndWith(matches);
+                        var result = inner.AndWith(buffer, matches);
                         match._inner = inner;
                         return result;
                     }

--- a/src/Corax/Queries/BoostingMatch.cs
+++ b/src/Corax/Queries/BoostingMatch.cs
@@ -88,9 +88,9 @@ namespace Corax.Queries
         public bool IsBoosting => true;
 
         [MethodImpl(MethodImplOptions.AggressiveInlining)]
-        public int AndWith(Span<long> prevMatches)
+        public int AndWith(Span<long> buffer, int matches)
         {            
-            var results = _inner.AndWith(prevMatches);
+            var results = _inner.AndWith(buffer, matches);
             if (results == 0)
                 return results;
 
@@ -102,7 +102,7 @@ namespace Corax.Queries
                 bufferSlice = new Span<long>(_buffer + _bufferIdx, _bufferSize - _bufferIdx);                
             }
 
-            prevMatches.Slice(0, results).CopyTo(bufferSlice);
+            buffer.Slice(0, results).CopyTo(bufferSlice);
             _bufferIdx += results;
 
             // We track the amount of times this is called in order to know if we need to sort the buffer when scoring.             

--- a/src/Corax/Queries/IQueryMatch.cs
+++ b/src/Corax/Queries/IQueryMatch.cs
@@ -53,7 +53,7 @@ namespace Corax.Queries
         // Guarantees: AndWith accepts sorted and returns sorted.
         //             May optimize for continued sorted.
         //             0 return means no more matches from the provided span, and may need to go to the next batch
-        int AndWith(Span<long> prevMatches);
+        int AndWith(Span<long> buffer, int matches);
 
         // Guarantees: The output of this for unscored sequences should be a no-op.
         // Requirements: The upmost call 

--- a/src/Corax/Queries/MultiTermBoostingMatch.cs
+++ b/src/Corax/Queries/MultiTermBoostingMatch.cs
@@ -178,7 +178,7 @@ namespace Corax.Queries
 
         [SkipLocalsInit]
         [MethodImpl(MethodImplOptions.AggressiveInlining)]
-        public int AndWith(Span<long> buffer)
+        public int AndWith(Span<long> buffer, int matches)
         {
             throw new NotSupportedException($"{nameof(AndWith)} is not supported for {nameof(MultiTermBoostingMatch<TTermProvider>)}");
         }

--- a/src/Corax/Queries/MultiTermMatch.Erasure.cs
+++ b/src/Corax/Queries/MultiTermMatch.Erasure.cs
@@ -33,9 +33,9 @@ namespace Corax.Queries
         }
 
         [MethodImpl(MethodImplOptions.AggressiveInlining)]
-        public int AndWith(Span<long> buffer)
+        public int AndWith(Span<long> buffer, int matches)
         {
-            return _functionTable.AndWithFunc(ref this, buffer);
+            return _functionTable.AndWithFunc(ref this, buffer, matches);
         }
 
         [MethodImpl(MethodImplOptions.AggressiveInlining)]
@@ -55,13 +55,13 @@ namespace Corax.Queries
         internal class FunctionTable
         {
             public readonly delegate*<ref MultiTermMatch, Span<long>, int> FillFunc;
-            public readonly delegate*<ref MultiTermMatch, Span<long>, int> AndWithFunc;
+            public readonly delegate*<ref MultiTermMatch, Span<long>, int, int> AndWithFunc;
             public readonly delegate*<ref MultiTermMatch, Span<long>, Span<float>, void> ScoreFunc;
             public readonly delegate*<ref MultiTermMatch, long> CountFunc;
 
             public FunctionTable(
                 delegate*<ref MultiTermMatch, Span<long>, int> fillFunc,
-                delegate*<ref MultiTermMatch, Span<long>, int> andWithFunc,
+                delegate*<ref MultiTermMatch, Span<long>, int, int> andWithFunc,
                 delegate*<ref MultiTermMatch, Span<long>, Span<float>, void> scoreFunc,
                 delegate*<ref MultiTermMatch, long> countFunc)
             {
@@ -94,11 +94,11 @@ namespace Corax.Queries
                     return 0;
                 }
 
-                static int AndWithFunc(ref MultiTermMatch match, Span<long> matches)
+                static int AndWithFunc(ref MultiTermMatch match, Span<long> buffer, int matches)
                 {
                     if (match._inner is TTermMatch inner)
                     {
-                        var result = inner.AndWith(matches);
+                        var result = inner.AndWith(buffer, matches);
                         match._inner = inner;
                         return result;
                     }

--- a/src/Corax/Queries/MultiTermMatch.cs
+++ b/src/Corax/Queries/MultiTermMatch.cs
@@ -104,7 +104,7 @@ namespace Corax.Queries
 
         [SkipLocalsInit]
         [MethodImpl(MethodImplOptions.AggressiveInlining)]
-        public int AndWith(Span<long> buffer)
+        public int AndWith(Span<long> buffer, int matches)
         {
             // We should consider the policy where it makes sense to actually implement something different to avoid
             // the N^2 check here. While could be interesting to do now we still dont know what are the conditions
@@ -123,15 +123,17 @@ namespace Corax.Queries
             Span<long> tmp2 = longBuffer.Slice(2 * buffer.Length, buffer.Length);
 
             _inner.Reset();
-            
+
+            var actualMatches = buffer.Slice(0, matches);
+
             int totalSize = 0;
 
             bool hasData = _inner.Next(out var current);
             long totalRead = current.Count;
             while (totalSize < buffer.Length && hasData)
-            {                
-                buffer.CopyTo(tmp);
-                var read = current.AndWith(tmp);
+            {
+                actualMatches.CopyTo(tmp);
+                var read = current.AndWith(tmp, matches);
                 if (read != 0)
                 {
                     results[0..totalSize].CopyTo(tmp2);

--- a/src/Corax/Queries/SortingMatch.Erasure.cs
+++ b/src/Corax/Queries/SortingMatch.Erasure.cs
@@ -35,7 +35,7 @@ namespace Corax.Queries
         }
 
         [MethodImpl(MethodImplOptions.AggressiveInlining)]
-        public int AndWith(Span<long> buffer)
+        public int AndWith(Span<long> buffer, int matches)
         {
             throw new NotSupportedException($"{nameof(SortingMatch)} does not support the operation of {nameof(AndWith)}.");
         }

--- a/src/Corax/Queries/SortingMatch.cs
+++ b/src/Corax/Queries/SortingMatch.cs
@@ -38,7 +38,7 @@ namespace Corax.Queries
 
         public bool IsBoosting => _inner.IsBoosting || _isScoreComparer;
 
-        public int AndWith(Span<long> prevMatches)
+        public int AndWith(Span<long> buffer, int matches)
         {
             throw new NotSupportedException($"{nameof(SortingMatch<TInner, TComparer>)} does not support the operation of {nameof(AndWith)}.");
         }

--- a/src/Corax/Queries/SortingMultiMatch.Erasure.cs
+++ b/src/Corax/Queries/SortingMultiMatch.Erasure.cs
@@ -37,7 +37,7 @@ namespace Corax.Queries
         }
 
         [MethodImpl(MethodImplOptions.AggressiveInlining)]
-        public int AndWith(Span<long> buffer)
+        public int AndWith(Span<long> buffer, int matches)
         {
             throw new NotSupportedException($"{nameof(SortingMatch)} does not support the operation of {nameof(AndWith)}.");
         }

--- a/src/Corax/Queries/SortingMultiMatch.cs
+++ b/src/Corax/Queries/SortingMultiMatch.cs
@@ -148,7 +148,7 @@ namespace Corax.Queries
             };
         }
 
-        public int AndWith(Span<long> prevMatches)
+        public int AndWith(Span<long> buffer, int matches)
         {
             throw new NotSupportedException($"SortingMultiMatch does not support the operation {nameof(AndWith)}.");
         }

--- a/src/Corax/Queries/UnaryMatch.Erasure.cs
+++ b/src/Corax/Queries/UnaryMatch.Erasure.cs
@@ -30,20 +30,20 @@ namespace Corax.Queries
         }
 
         [MethodImpl(MethodImplOptions.AggressiveInlining)]
-        public int AndWith(Span<long> buffer)
+        public int AndWith(Span<long> buffer, int matches)
         {
-            return _functionTable.AndWithFunc(ref this, buffer);
+            return _functionTable.AndWithFunc(ref this, buffer, matches);
         }
 
         internal class FunctionTable
         {
             public readonly delegate*<ref UnaryMatch, Span<long>, int> FillFunc;
-            public readonly delegate*<ref UnaryMatch, Span<long>, int> AndWithFunc;
+            public readonly delegate*<ref UnaryMatch, Span<long>, int, int> AndWithFunc;
             public readonly delegate*<ref UnaryMatch, long> CountFunc;
 
             public FunctionTable(
                 delegate*<ref UnaryMatch, Span<long>, int> fillFunc,
-                delegate*<ref UnaryMatch, Span<long>, int> andWithFunc,
+                delegate*<ref UnaryMatch, Span<long>, int, int> andWithFunc,
                 delegate*<ref UnaryMatch, long> countFunc)
             {
                 FillFunc = fillFunc;
@@ -77,11 +77,11 @@ namespace Corax.Queries
                 }
 
                 [MethodImpl(MethodImplOptions.AggressiveInlining)]
-                static int AndWithFunc(ref UnaryMatch match, Span<long> matches)
+                static int AndWithFunc(ref UnaryMatch match, Span<long> buffer, int matches)
                 {
                     if (match._inner is UnaryMatch<TInner, TValueType> inner)
                     {
-                        var result = inner.AndWith(matches);
+                        var result = inner.AndWith(buffer, matches);
                         match._inner = inner;
                         return result;
                     }

--- a/src/Corax/Queries/UnaryMatch.cs
+++ b/src/Corax/Queries/UnaryMatch.cs
@@ -23,7 +23,7 @@ namespace Corax.Queries
         where TInner : IQueryMatch
     {
         private readonly delegate*<ref UnaryMatch<TInner, TValueType>, Span<long>, int> _fillFunc;
-        private readonly delegate*<ref UnaryMatch<TInner, TValueType>, Span<long>, int> _andWithFunc;
+        private readonly delegate*<ref UnaryMatch<TInner, TValueType>, Span<long>, int, int> _andWithFunc;
 
         private TInner _inner;
         private UnaryMatchOperation _operation;
@@ -49,7 +49,7 @@ namespace Corax.Queries
             int fieldId,
             TValueType value,
             delegate*<ref UnaryMatch<TInner, TValueType>, Span<long>, int> fillFunc,
-            delegate*<ref UnaryMatch<TInner, TValueType>, Span<long>, int> andWithFunc,
+            delegate*<ref UnaryMatch<TInner, TValueType>, Span<long>, int, int> andWithFunc,
             long totalResults,
             QueryCountConfidence confidence, int take = -1)
         {
@@ -76,7 +76,7 @@ namespace Corax.Queries
             TValueType value1,
             TValueType value2,
             delegate*<ref UnaryMatch<TInner, TValueType>, Span<long>, int> fillFunc,
-            delegate*<ref UnaryMatch<TInner, TValueType>, Span<long>, int> andWith,
+            delegate*<ref UnaryMatch<TInner, TValueType>, Span<long>, int, int> andWith,
             long totalResults,
             QueryCountConfidence confidence, int take = -1)
         {
@@ -103,9 +103,9 @@ namespace Corax.Queries
         }
 
         [MethodImpl(MethodImplOptions.AggressiveInlining)]
-        public int AndWith(Span<long> buffer)
+        public int AndWith(Span<long> buffer, int matches)
         {
-            return _andWithFunc(ref this, buffer);
+            return _andWithFunc(ref this, buffer, matches);
         }
 
         [MethodImpl(MethodImplOptions.AggressiveInlining)]


### PR DESCRIPTION
In this PR we are decoupling the total matches found with the actual size of the buffer we are using to store those matches. The objective is to be able to deal with deep queries in an efficient way.

cc @ayende 