### PR TITLE
RavenDB-17231 : Unexpected failures during `EmptyQueue` should cause re-election

### DIFF
--- a/src/Raven.Server/Rachis/Leader.cs
+++ b/src/Raven.Server/Rachis/Leader.cs
@@ -38,7 +38,7 @@ namespace Raven.Server.Rachis
         public delegate object ConvertResultFromLeader(JsonOperationContext ctx, object result);
 
         private TaskCompletionSource<object> _newEntriesArrived = new TaskCompletionSource<object>(TaskCreationOptions.RunContinuationsAsynchronously);
-        private readonly TaskCompletionSource<Exception> _errorOccurred = new TaskCompletionSource<Exception>(TaskCreationOptions.RunContinuationsAsynchronously);
+        private readonly TaskCompletionSource<object> _errorOccurred = new TaskCompletionSource<object>(TaskCreationOptions.RunContinuationsAsynchronously);
 
         private readonly ConcurrentDictionary<long, CommandState> _entries = new ConcurrentDictionary<long, CommandState>();
 
@@ -332,7 +332,8 @@ namespace Raven.Server.Rachis
                             _running.Lower();
                             return;
                         case 4: // an error occurred during EmptyQueue()
-                            throw _errorOccurred.Task.Result;
+                            _errorOccurred.Task.Wait();
+                            break;
                     }
 
                     EnsureThatWeHaveLeadership(VotersMajority);
@@ -797,7 +798,7 @@ namespace Raven.Server.Rachis
                         tcs.TrySetException(e);
                     }
 
-                    _errorOccurred.TrySetResult(e);
+                    _errorOccurred.TrySetException(e);
                 }
             }
         }

--- a/test/SlowTests/Issues/RavenDB_17231.cs
+++ b/test/SlowTests/Issues/RavenDB_17231.cs
@@ -1,0 +1,70 @@
+﻿using System;
+using System.Linq;
+using System.Threading;
+using System.Threading.Tasks;
+using Raven.Client.Documents;
+using Raven.Client.Documents.Operations.ConnectionStrings;
+using Raven.Client.Documents.Operations.ETL;
+using Raven.Client.ServerWide;
+using Sparrow.Server.Exceptions;
+using Tests.Infrastructure;
+using Xunit;
+using Xunit.Abstractions;
+
+namespace SlowTests.Issues
+{
+    public class RavenDB_17231 : ClusterTestBase
+    {
+        public RavenDB_17231(ITestOutputHelper output) : base(output)
+        {
+        }
+
+        [Fact]
+        public async Task FailuresDuringEmptyQueueShouldCauseReelection()
+        {
+            var (nodes, leader) = await CreateRaftCluster(3);
+            var dbName = GetDatabaseName();
+            var db = await CreateDatabaseInCluster(dbName, 2, leader.WebUrl);
+
+            var cmdCount = 0;
+            leader.ServerStore.Engine.BeforeAppendToRaftLog += (context, cmd) =>
+            {
+                if (++cmdCount > 10)
+                {
+                    throw new DiskFullException("no more space");
+                }
+            };
+
+            var followers = nodes.Where(s => s != leader).ToList();
+            var leaderSteppedDown = leader.ServerStore.Engine.WaitForLeaveState(RachisState.Leader, CancellationToken.None);
+            var newLeaderElected = Task.WhenAny(followers.Select(s => s.ServerStore.WaitForState(RachisState.Leader, CancellationToken.None)));
+            var putConnectionStrings = Task.Run(async () =>
+            {
+                using (var store = new DocumentStore
+                {
+                    Database = dbName,
+                    Urls = db.Servers.Select(s => s.WebUrl).ToArray()
+                }.Initialize())
+                {
+                    var urls = nodes.Select(s => s.WebUrl).ToArray();
+                    for (int i = 0; i < 20; i++)
+                    {
+                        var cs = new RavenConnectionString
+                        {
+                            Database = $"db/{i}",
+                            Name = $"cs/{i}",
+                            TopologyDiscoveryUrls = urls
+                        };
+
+                        await store.Maintenance.SendAsync(new PutConnectionStringOperation<RavenConnectionString>(cs));
+                    }
+                }
+            });
+
+            Assert.True(leaderSteppedDown.Wait(TimeSpan.FromSeconds(15)));
+            Assert.True(newLeaderElected.Wait(TimeSpan.FromSeconds(15)));
+
+            await putConnectionStrings;
+        }
+    }
+}


### PR DESCRIPTION
### Issue link

https://issues.hibernatingrhinos.com/issue/RavenDB-17231

### Additional description

- failures when leader tries to append to raft log (e.g. no more disk space in system folder - no new cluster commands can be performed) did not cause the leader to step down and he remained stable
- added an `errorOccurred` handle to `Leader.cs` and set it upon a failure during `EmptyQueue`
- leader will now step down and record the error message when `errorOccurred` is set

### Type of change

- Bug fix

### How risky is the change?

- Low 

### Backward compatibility

- Not relevant

### Is it platform specific issue?

- No

### Documentation update

- No documentation update is needed 

### Testing 

- Tests have been added that prove the fix is effective or that the feature works
- It has been verified by manual testing

### Is there any existing behavior change of other features due to this change?

- No

### UI work

- No UI work is needed
