### PR TITLE
RavenDB-17766 When using custom S3 host, region shouldn't be mandatory

### DIFF
--- a/src/Raven.Studio/typescript/models/resources/creation/backupCredentials.ts
+++ b/src/Raven.Studio/typescript/models/resources/creation/backupCredentials.ts
@@ -91,7 +91,7 @@ export class amazonS3Credentials extends restoreSettings {
         let selectedRegion = _.trim(this.regionName()).toLowerCase();
         const foundRegion = amazonSettings.availableAwsRegionEndpointsStatic.find(x => amazonSettings.getDisplayRegionName(x).toLowerCase() === selectedRegion);        
         if (foundRegion) {
-            selectedRegion = foundRegion.value;            
+            selectedRegion = foundRegion.value;
         }
         
         return {
@@ -142,7 +142,14 @@ export class amazonS3Credentials extends restoreSettings {
     }
 
     isValid(): boolean {
-        return !!_.trim(this.accessKey()) && !!_.trim(this.secretKey()) && !!_.trim(this.regionName()) && !!_.trim(this.bucketName()) && (!this.useCustomS3Host() || !!_.trim(this.customServerUrl()));
+        const useCustomHost = this.useCustomS3Host();
+        const isRegionValid = useCustomHost || !!_.trim(this.regionName()) 
+        
+        return !!_.trim(this.accessKey()) &&
+               !!_.trim(this.secretKey()) &&
+               isRegionValid &&
+               !!_.trim(this.bucketName()) &&
+               (!useCustomHost || !!_.trim(this.customServerUrl()));
     }
 
     onCredentialsChange(onChange: () => void) {

--- a/src/Raven.Studio/wwwroot/App/views/resources/createDatabase.html
+++ b/src/Raven.Studio/wwwroot/App/views/resources/createDatabase.html
@@ -511,7 +511,7 @@
                </div>
                <div class="form-group row">
                    <div class="col-md-4">
-                       <label class="control-label">Aws Region Name<i class="required"></i></label>
+                       <label class="control-label">Aws Region Name<i class="required" data-bind="visible: !useCustomS3Host()"></i></label>
                    </div>
                    <div class="col-md-8">
                        <div class="dropdown btn-block">


### PR DESCRIPTION
### Issue link
https://issues.hibernatingrhinos.com/issue/RavenDB-17766

### Additional description
Make region not required when using custom S3 host (restore database from backup)

### Type of change
- Bug fix

### How risky is the change?
- Low 

### Backward compatibility
- Non breaking change

### Is it platform specific issue?
- No

### Documentation update
- No documentation update is needed 

### Testing 
- It has been verified by manual testing

### Is there any existing behavior change of other features due to this change?
- No

### UI work
- No UI work is needed
