### PR TITLE
RavenDB-17806 fix for CanIncludeCountersInSubscriptions_EvenIfTheyDoN…

### DIFF
--- a/src/Raven.Server/Documents/TcpHandlers/SubscriptionConnection.cs
+++ b/src/Raven.Server/Documents/TcpHandlers/SubscriptionConnection.cs
@@ -959,12 +959,14 @@ namespace Raven.Server.Documents.TcpHandlers
                                 writer.WritePropertyName(docsContext.GetLazyStringForFieldWithCaching(IncludedCounterNamesSegment));
                                 writer.WriteIncludedCounterNames(includeCountersCommand.CountersToGetByDocId);
 
-                                var size = includeCountersCommand.CountersToGetByDocId.Sum(kvp => kvp.Key.Length + kvp.Value.Sum(name => name.Length)) //CountersToGetByDocId
-                                    + includeCountersCommand.Results.Sum(kvp => kvp.Value.Sum(counter => counter.CounterName.Length
-                                                                                                         + counter.DocumentId.Length
-                                                                                                         + sizeof(long) //Etag
-                                                                                                         + sizeof(long) //Total Value
-                                    ));
+                                var size = includeCountersCommand.CountersToGetByDocId.Sum(kvp =>
+                                               kvp.Key.Length + kvp.Value.Sum(name => name.Length)) //CountersToGetByDocId
+                                    + includeCountersCommand.Results.Sum(kvp =>
+                                        kvp.Value.Sum(counter => counter == null ? 0 : counter.CounterName.Length
+                                                                                         + counter.DocumentId.Length
+                                                                                         + sizeof(long) //Etag
+                                                                                         + sizeof(long) //Total Value
+                                   ));
                                 batchScope.RecordIncludedCountersInfo(includeCountersCommand.Results.Sum(x => x.Value.Count), size);
 
 


### PR DESCRIPTION
…otExist test

### Issue link

https://issues.hibernatingrhinos.com/issue/RavenDB-17806
https://issues.hibernatingrhinos.com/issue/RavenDB-17797

### Additional description

Added check for counter == null when calculation couner size.
for CanIncludeCountersInSubscriptions_EvenIfTheyDoNotExist  test

_Please delete below the options that are not relevant_

### Type of change

- Bug fix

### How risky is the change?

- Low 

### Backward compatibility

- Not relevant

### Is it platform specific issue?

- No

### Documentation update

- No documentation update is needed 

### Testing 

- Not relevant

### Is there any existing behavior change of other features due to this change?

- No

### UI work

- No UI work is needed
