### PR TITLE
RavenDB-17782 added more info to tests

### DIFF
--- a/src/Raven.Client/Documents/Session/Operations/Lazy/LazyRevisionOperation.cs
+++ b/src/Raven.Client/Documents/Session/Operations/Lazy/LazyRevisionOperation.cs
@@ -1,4 +1,5 @@
 ﻿using System;
+using System.IO;
 using System.Net.Http;
 using System.Text;
 using Raven.Client.Documents.Commands;
@@ -44,7 +45,8 @@ namespace Raven.Client.Documents.Session.Operations.Lazy
         {
             if(response.Result is null) return;
             BlittableJsonReaderObject responseAsBlittableReaderObject = (BlittableJsonReaderObject)response.Result;
-            responseAsBlittableReaderObject.TryGet("Results", out BlittableJsonReaderArray blittableJsonReaderArray);
+            if (responseAsBlittableReaderObject.TryGet("Results", out BlittableJsonReaderArray blittableJsonReaderArray) == false)
+                throw new InvalidDataException("Response is invalid");
 
             _getRevisionOperation.SetResult(new BlittableArrayResult {Results = blittableJsonReaderArray});
             switch (_mode)

--- a/test/FastTests/Server/Documents/Revisions/RevisionsTests.cs
+++ b/test/FastTests/Server/Documents/Revisions/RevisionsTests.cs
@@ -163,14 +163,27 @@ namespace FastTests.Server.Documents.Revisions
                 }
                 using (var session = store.OpenSession())
                 {
-                    var revision                 =  session.Advanced.Revisions.Get<User>("users/1", DateTime.Now);
-                    var revisionLazily  =  session.Advanced.Revisions.Lazily.Get<User>("users/1",DateTime.UtcNow);
-                    var revisionLazily2  =  session.Advanced.Revisions.Lazily.Get<User>("users/2",DateTime.UtcNow);
+                    var time = DateTime.UtcNow;
+                    var info = $"{time:hh.mm.ss.fffffff} : ";
+
+                    var revision =  session.Advanced.Revisions.GetFor<User>("users/1");
+                    info += $"revision == null : {revision == null}, ";
+                    Assert.False(revision == null, info);
+
+                    info += $"revsion name = {revision.First().Name}, ";
+                    var revisionByTime =  session.Advanced.Revisions.Get<User>("users/1", time);
+                    info += $"revisionByTime == null : {revisionByTime == null}, ";
+                    Assert.False(revisionByTime == null, info);
+
+                    info += $"revisionByTime name = {revisionByTime.Name}, ";
+                    var revisionLazily  =  session.Advanced.Revisions.Lazily.Get<User>("users/1", time);
+                    info += $"revisionLazily == null : {revisionLazily == null}, ";
+                    Assert.False(revisionLazily == null, info);
                     var revisionLazilyResult =  revisionLazily.Value;
                     
-                    Assert.Equal(revision.Id, revisionLazilyResult.Id);
-                    Assert.Equal(revision.Name, revisionLazilyResult.Name);
-                    Assert.Equal(2, session.Advanced.NumberOfRequests);
+                    Assert.Equal(revisionByTime.Id, revisionLazilyResult.Id);
+                    Assert.Equal(revisionByTime.Name, revisionLazilyResult.Name);
+                    Assert.Equal(3, session.Advanced.NumberOfRequests);
                 }
             }
         }
@@ -382,17 +395,30 @@ namespace FastTests.Server.Documents.Revisions
                     Assert.Equal(1, session.Advanced.NumberOfRequests);
                 }
 
-                var dateTime = DateTime.Now;
+                var dateTime = DateTime.UtcNow;
                 using (var session = store.OpenAsyncSession())
                 {
+                    var info = $"{dateTime:hh.mm.ss.fffffff} : ";
+
                     var revision = await session.Advanced.Revisions.GetAsync<User>("users/1", dateTime);
-                    var revisionLazily = session.Advanced.Revisions.Lazily.GetAsync<User>("users/1",dateTime);
-                    var revisionLazily2 = session.Advanced.Revisions.Lazily.GetAsync<User>("users/2",dateTime);
+                    info += $"revision == null : {revision == null}, ";
+                    Assert.False(revision == null, info);
+
+                    info += $"revsion name = {revision.Name}, ";
+                    var revisionByTime = await session.Advanced.Revisions.GetAsync<User>("users/1", dateTime);
+                    info += $"revisionByTime == null : {revisionByTime == null}, ";
+                    Assert.False(revisionByTime == null, info);
+
+                    info += $"revisionByTime name = {revisionByTime.Name}, ";
+                    var revisionLazily = session.Advanced.Revisions.Lazily.GetAsync<User>("users/1", dateTime);
+                    info += $"revisionLazily == null : {revisionLazily == null}, ";
+                    Assert.False(revisionLazily == null, info);
                     var revisionLazilyResult = await revisionLazily.Value;
+                    var revisionLazily2 = session.Advanced.Revisions.Lazily.GetAsync<User>("users/2",dateTime);
                     
                     Assert.Equal(revision.Id, revisionLazilyResult.Id);
                     Assert.Equal(revision.Name, revisionLazilyResult.Name);
-                    Assert.Equal(2, session.Advanced.NumberOfRequests);
+                    Assert.Equal(3, session.Advanced.NumberOfRequests);
                 }
             }
         }


### PR DESCRIPTION
### Issue link

https://issues.hibernatingrhinos.com/issue/RavenDB-17782
https://issues.hibernatingrhinos.com/issue/RavenDB-17783
### Additional description

added exception if a response to lazy revision operation is invalid
Can't reproduce failing tests. added more info to tests.
need to wait for tests to fail again

_Please delete below the options that are not relevant_

### Type of change

- Bug fix

### How risky is the change?

- Low 

### Backward compatibility

- Not relevant

### Is it platform specific issue?
- No

### Documentation update

- No documentation update is needed 

### Testing 

- Not relevant


### Is there any existing behavior change of other features due to this change?

- No

### UI work

- No UI work is needed
