### PR TITLE
RavenDB-16783 : fix flaky test

### DIFF
--- a/test/SlowTests/Server/Documents/ETL/Raven/RavenDB_13288.cs
+++ b/test/SlowTests/Server/Documents/ETL/Raven/RavenDB_13288.cs
@@ -97,6 +97,8 @@ namespace SlowTests.Server.Documents.ETL.Raven
 
                         session.CountersFor("users/1").Increment("likes");
 
+                        session.Advanced.WaitForReplicationAfterSaveChanges();
+
                         session.SaveChanges();
                     }
                 }


### PR DESCRIPTION
### Issue link

https://issues.hibernatingrhinos.com/issue/RavenDB-16783

### Additional description

wait for document and counter to replicate to node B before incrementing counter on node B
