### PR TITLE
RavenDB-17835 Adding null check in query cache.

### DIFF
--- a/src/Raven.Server/Documents/Queries/LuceneQueryHelper.cs
+++ b/src/Raven.Server/Documents/Queries/LuceneQueryHelper.cs
@@ -358,7 +358,7 @@ This edge-case has a very slim chance of happening, but still we should not igno
 
         private static Query MaybeCacheQuery(Index index, Query query)
         {
-            if (index.Configuration.QueryClauseCacheDisabled)
+            if (index is null || index.Configuration.QueryClauseCacheDisabled)
                 return query;
             return new CachingQuery(query, index, query.ToString());
         }

--- a/test/SlowTests/Issues/RavenDB_17835.cs
+++ b/test/SlowTests/Issues/RavenDB_17835.cs
@@ -1,0 +1,53 @@
+﻿using System.Collections.Generic;
+using System.Linq;
+using System.Text;
+using FastTests;
+using Xunit;
+using Xunit.Abstractions;
+
+namespace SlowTests.Issues;
+
+public class RavenDB_17835 : RavenTestBase
+{
+    public RavenDB_17835(ITestOutputHelper output) : base(output)
+    {
+    }
+
+    [Fact]
+    public void CachingLayerDoesntThrowNREOnSpecificMethod()
+    {
+        const int terms = 29;
+        using var luceneStore = GetDocumentStore();
+        List<Result> results;
+        {
+            using var luceneSession = luceneStore.BulkInsert();
+            results = Enumerable.Range(0, 29).Select(i => new Result() { Age = i % terms, Height = i }).ToList();
+            results.ForEach((x) =>
+            {
+                luceneSession.Store(x);
+            });
+        }
+
+        {
+            var rawQuery = new StringBuilder();
+            rawQuery.Append("from Results where boost(Age == 0, 0)");
+            for (int i = 1; i < terms; ++i)
+                rawQuery.Append($" or boost(Age == {i},{i})");
+            rawQuery.Append(" order by score()");
+
+            Assertion(rawQuery.ToString());
+        }
+
+        void Assertion(string rawQuery)
+        {
+            using var luceneSession = luceneStore.OpenSession();
+            var luceneResult = luceneSession.Advanced.RawQuery<Result>(rawQuery.ToString()).ToList();
+        }
+    }
+
+    private class Result
+    {
+        public int Age { get; set; }
+        public int Height { get; set; }
+    }
+}


### PR DESCRIPTION
### Issue link

https://issues.hibernatingrhinos.com/issue/RavenDB-17835

### Additional description

When building a query with a method like Boosting we are not passing an index instance and get NRE when trying to read options from it in the cache layer.

https://github.com/ravendb/ravendb/blob/611a8edbd80356c82e2438aec76ada4c337fafee/src/Raven.Server/Documents/Queries/QueryBuilder.cs#L924


### Type of change

- Regression bug fix


### How risky is the change?

- Low 

### Backward compatibility

- Not relevant

### Is it platform specific issue?

- No

### Documentation update

- No documentation update is needed 

### Testing 

- Tests have been added that prove the fix is effective or that the feature works


### Is there any existing behavior change of other features due to this change?
- No

### UI work

- No UI work is needed
