### PR TITLE
RavenDB-17834 GetRevisionsCommand should convert _before parameter to…

### DIFF
--- a/src/Raven.Client/Documents/Commands/GetRevisionsCommand.cs
+++ b/src/Raven.Client/Documents/Commands/GetRevisionsCommand.cs
@@ -23,7 +23,7 @@ namespace Raven.Client.Documents.Commands
         public GetRevisionsCommand(string id, DateTime before)
         {
             _id = id ?? throw new ArgumentNullException(nameof(id));
-            _before = before;
+            _before = before.ToUniversalTime();
         }
 
         public GetRevisionsCommand(string id, int? start, int? pageSize, bool metadataOnly = false)


### PR DESCRIPTION
… UTC time when sending it to the server

### Issue link

https://issues.hibernatingrhinos.com/issue/RavenDB-17834

### Additional description
convert _before parameter to UTC time when sending it to the server at GetRevisionsCommand 

_Please delete below the options that are not relevant_

### Type of change

- Bug fix

### How risky is the change?

- Low 

### Backward compatibility

- Not relevant

### Is it platform specific issue?

- No

### Documentation update

- No documentation update is needed 

### Testing 

- Not relevant

### Is there any existing behavior change of other features due to this change?

- No

### UI work

- No UI work is needed
