### PR TITLE
RavenDB-17804 Fixing slow facet queries

### DIFF
--- a/src/Raven.Server/Documents/Indexes/Persistence/Lucene/IndexFacetedReadOperation.cs
+++ b/src/Raven.Server/Documents/Indexes/Persistence/Lucene/IndexFacetedReadOperation.cs
@@ -323,13 +323,14 @@ namespace Raven.Server.Documents.Indexes.Persistence.Lucene
                 var doubles = FieldCache_Fields.DEFAULT.GetDoubles(indexReader, name, state);
 
                 var val = kvp.Value;
-                double min = value.Min ?? double.MaxValue, max = value.Max ?? double.MinValue, sum = value.Sum ?? 0;
+                double min = value.Min ?? double.MaxValue, max = value.Max ?? double.MinValue, sum = value.Sum ?? 0, avg = value.Average ?? 0;
                 int[] array = docsInQuery.Array;
                 for (var index = 0; index < docsInQuery.Count; index++)
                 {
                     var doc = array[index];
                     var currentVal = doubles[doc - docBase];
                     sum += currentVal;
+                    avg += currentVal;
                     min = Math.Min(min, currentVal);
                     max = Math.Max(max, currentVal);
                 }
@@ -341,7 +342,7 @@ namespace Raven.Server.Documents.Indexes.Persistence.Lucene
 
                 if (val.Average)
                 {
-                    value.Average = sum; // actual average handled later
+                    value.Average = avg;
                 }
 
                 if (val.Max)

--- a/test/Tests.Infrastructure/AmazonS3FactAttribute.cs
+++ b/test/Tests.Infrastructure/AmazonS3FactAttribute.cs
@@ -12,7 +12,7 @@ namespace Tests.Infrastructure
 
         private static readonly S3Settings _s3Settings;
 
-        public static S3Settings S3Settings => new S3Settings(_s3Settings);
+        public static S3Settings S3Settings => _s3Settings == null ? null : new S3Settings(_s3Settings);
 
         private static readonly string ParsingError;
 


### PR DESCRIPTION
### Issue link

https://issues.hibernatingrhinos.com/issue/RavenDB-17804

### Additional description

* Optimize facet queries by avoiding allocating (and abandoning) arrays for facet terms that don't have intersection with the query.
* Do fast checks to see if the intersection of the terms and the query is even relevant 
* Avoid property lookups at the hot path


### Type of change

- Optimization

### How risky is the change?

- Low 

### Backward compatibility

- Non breaking change

### Is it platform specific issue?

- No

### Documentation update

- No documentation update is needed 

### Testing 

- It has been verified by manual testing

