### PR TITLE
RavenDB-17276 Wait for nonstale results when querying to avoid race condition.

### DIFF
--- a/test/SlowTests/Tests/Linq/CanQueryAndIncludeRevisions.cs
+++ b/test/SlowTests/Tests/Linq/CanQueryAndIncludeRevisions.cs
@@ -18,7 +18,7 @@ namespace SlowTests.Tests.Linq
         public CanQueryAndIncludeRevisions(ITestOutputHelper output) : base(output)
         {
         }
-        
+
         [Fact]
         public void Query_IncludeAllQueryFunctionality()
         {
@@ -32,10 +32,7 @@ namespace SlowTests.Tests.Linq
 
                 using (var session = store.OpenSession())
                 {
-                    session.Store(new User
-                        {
-                            Name = "Omer",
-                        },
+                    session.Store(new User { Name = "Omer", },
                         id);
 
                     session.SaveChanges();
@@ -83,7 +80,7 @@ namespace SlowTests.Tests.Linq
                         .Include(builder => builder
                             .IncludeRevisions(x => x.ChangeVectors)
                             .IncludeRevisions(x => x.FirstRevision)
-                            .IncludeRevisions(x => x.SecondRevision));
+                            .IncludeRevisions(x => x.SecondRevision)).Customize(c => c.WaitForNonStaleResults());
 
 
                     var r = query.ToList();
@@ -98,10 +95,9 @@ namespace SlowTests.Tests.Linq
 
                     Assert.Equal(1, session.Advanced.NumberOfRequests);
                 }
-
             }
         }
-        
+
         [Fact]
         public async Task Query_IncludeAllQueryFunctionalityAsync()
         {
@@ -115,20 +111,17 @@ namespace SlowTests.Tests.Linq
 
                 using (var session = store.OpenAsyncSession())
                 {
-                    await session.StoreAsync(new User
-                        {
-                            Name = "Omer",
-                        },
+                    await session.StoreAsync(new User { Name = "Omer", },
                         id);
 
-                   await session.SaveChangesAsync();
+                    await session.SaveChangesAsync();
                 }
 
                 string changeVector;
                 var beforeDateTime = DateTime.UtcNow;
                 using (var session = store.OpenAsyncSession())
                 {
-                    var metadatas =await session.Advanced.Revisions.GetMetadataForAsync(id);
+                    var metadatas = await session.Advanced.Revisions.GetMetadataForAsync(id);
                     Assert.Equal(1, metadatas.Count);
 
                     changeVector = metadatas.First().GetString(Constants.Documents.Metadata.ChangeVector);
@@ -163,6 +156,7 @@ namespace SlowTests.Tests.Linq
                 using (var asyncSession = store.OpenAsyncSession())
                 {
                     var query = asyncSession.Query<User>()
+                        .Customize(x => x.WaitForNonStaleResults())
                         .Include(builder => builder
                             .IncludeRevisions(x => x.ChangeVectors)
                             .IncludeRevisions(x => x.FirstRevision)
@@ -181,7 +175,6 @@ namespace SlowTests.Tests.Linq
 
                     Assert.Equal(1, asyncSession.Advanced.NumberOfRequests);
                 }
-
             }
         }
 
@@ -195,21 +188,20 @@ namespace SlowTests.Tests.Linq
                 string changeVector;
                 using (var session = store.OpenSession())
                 {
-                    session.Store(new User {Name = "Omer",},
+                    session.Store(new User { Name = "Omer", },
                         id);
                     session.SaveChanges();
-                    
+
                     var metadatas = session.Advanced.Revisions.GetMetadataFor(id);
                     Assert.Equal(1, metadatas.Count);
-                    changeVector  = metadatas.First().GetString(Constants.Documents.Metadata.ChangeVector);
+                    changeVector = metadatas.First().GetString(Constants.Documents.Metadata.ChangeVector);
                     session.Advanced.Patch<User, string>(id, x => x.ChangeVector, changeVector);
                     session.SaveChanges();
-
                 }
 
                 using (var session = store.OpenSession())
                 {
-                    var query = session.Load<User>(id, builder => builder.IncludeRevisions(x=> x.ChangeVector));
+                    var query = session.Load<User>(id, builder => builder.IncludeRevisions(x => x.ChangeVector));
                     var revision = session.Advanced.Revisions.Get<User>(changeVector);
 
                     Assert.NotNull(revision);
@@ -217,8 +209,8 @@ namespace SlowTests.Tests.Linq
                 }
             }
         }
-        
-        [Fact]       
+
+        [Fact]
         public async Task Load_IncludeBuilder_IncludeRevisionByChangeVectorAsync()
         {
             using (var store = GetDocumentStore())
@@ -228,32 +220,29 @@ namespace SlowTests.Tests.Linq
                 string changeVector;
                 using (var session = store.OpenAsyncSession())
                 {
-                    await session.StoreAsync(new User
-                        {
-                            Name = "Omer",
-                        },
+                    await session.StoreAsync(new User { Name = "Omer", },
                         id);
-                   await session.SaveChangesAsync();
-                   
-                   var metadatas = await session.Advanced.Revisions.GetMetadataForAsync(id);
-                   Assert.Equal(1, metadatas.Count);
-                   changeVector = metadatas.First().GetString(Constants.Documents.Metadata.ChangeVector);
-                   session.Advanced.Patch<User, string>(id, x => x.ChangeVector, changeVector);
-                   
-                   await session.SaveChangesAsync();
+                    await session.SaveChangesAsync();
+
+                    var metadatas = await session.Advanced.Revisions.GetMetadataForAsync(id);
+                    Assert.Equal(1, metadatas.Count);
+                    changeVector = metadatas.First().GetString(Constants.Documents.Metadata.ChangeVector);
+                    session.Advanced.Patch<User, string>(id, x => x.ChangeVector, changeVector);
+
+                    await session.SaveChangesAsync();
                 }
 
                 using (var session = store.OpenAsyncSession())
                 {
-                    var query = await session.LoadAsync<User>(id, builder => builder.IncludeRevisions(x=> x.ChangeVector));
-                    var revision =await session.Advanced.Revisions.GetAsync<User>(changeVector);
-                    
-                    Assert.NotNull(revision); 
+                    var query = await session.LoadAsync<User>(id, builder => builder.IncludeRevisions(x => x.ChangeVector));
+                    var revision = await session.Advanced.Revisions.GetAsync<User>(changeVector);
+
+                    Assert.NotNull(revision);
                     Assert.Equal(1, session.Advanced.NumberOfRequests);
                 }
             }
         }
-    
+
         [Fact]
         public void Load_IncludeBuilder_IncludeRevisionByChangeVectors()
         {
@@ -266,43 +255,39 @@ namespace SlowTests.Tests.Linq
 
                 using (var session = store.OpenSession())
                 {
-                      session.Store(new User
-                          {
-                              Name = "Omer",
-                          },
+                    session.Store(new User { Name = "Omer", },
                         id);
 
-                     session.SaveChanges();
+                    session.SaveChanges();
                 }
 
                 string changeVector;
                 using (var session = store.OpenSession())
                 {
-                    var metadatas =  session.Advanced.Revisions.GetMetadataFor(id);
+                    var metadatas = session.Advanced.Revisions.GetMetadataFor(id);
                     Assert.Equal(1, metadatas.Count);
 
                     changeVector = metadatas.First().GetString(Constants.Documents.Metadata.ChangeVector);
                     session.SaveChanges();
                     cvList.Add(changeVector);
-                    
-                    metadatas =  session.Advanced.Revisions.GetMetadataFor(id);
+
+                    metadatas = session.Advanced.Revisions.GetMetadataFor(id);
                     changeVector = metadatas[0].GetString(Constants.Documents.Metadata.ChangeVector);
                     cvList.Add(changeVector);
-                    
+
                     session.SaveChanges();
-                    metadatas =  session.Advanced.Revisions.GetMetadataFor(id);
+                    metadatas = session.Advanced.Revisions.GetMetadataFor(id);
                     changeVector = metadatas[0].GetString(Constants.Documents.Metadata.ChangeVector);
-                    
+
                     cvList.Add(changeVector);
                     session.Advanced.Patch<User, List<string>>(id, x => x.ChangeVectors, cvList);
                     session.SaveChanges();
-                    
                 }
 
                 using (var session = store.OpenSession())
                 {
-                    var query = session.Load<User>(id, builder => builder.IncludeRevisions(x=> x.ChangeVectors));
-                    
+                    var query = session.Load<User>(id, builder => builder.IncludeRevisions(x => x.ChangeVectors));
+
                     var revision1 = session.Advanced.Revisions.Get<User>(cvList[0]);
                     var revision2 = session.Advanced.Revisions.Get<User>(cvList[1]);
                     var revision3 = session.Advanced.Revisions.Get<User>(cvList[2]);
@@ -311,7 +296,7 @@ namespace SlowTests.Tests.Linq
                 }
             }
         }
-        
+
         [Fact]
         public async Task Load_IncludeBuilder_IncludeRevisionByChangeVectorsAsync()
         {
@@ -319,67 +304,67 @@ namespace SlowTests.Tests.Linq
             {
                 const string id = "users/rhino";
                 var cvList = new List<string>();
-        
+
                 await RevisionsHelper.SetupRevisions(Server.ServerStore, store.Database);
-        
+
                 using (var session = store.OpenAsyncSession())
                 {
-                    await session.StoreAsync(new User {Name = "Omer",},
+                    await session.StoreAsync(new User { Name = "Omer", },
                         id);
-        
+
                     await session.SaveChangesAsync();
                 }
-        
+
                 string changeVector;
                 using (var session = store.OpenAsyncSession())
                 {
                     var metadatas = await session.Advanced.Revisions.GetMetadataForAsync(id);
                     Assert.Equal(1, metadatas.Count);
-        
+
                     changeVector = metadatas.First().GetString(Constants.Documents.Metadata.ChangeVector);
-        
+
                     session.Advanced.Patch<User, string>(id, x => x.FirstRevision, changeVector);
-        
+
                     await session.SaveChangesAsync();
-        
+
                     cvList.Add(changeVector);
-        
+
                     metadatas = await session.Advanced.Revisions.GetMetadataForAsync(id);
-        
+
                     changeVector = metadatas[0].GetString(Constants.Documents.Metadata.ChangeVector);
-        
+
                     cvList.Add(changeVector);
-        
+
                     session.Advanced.Patch<User, string>(id, x => x.SecondRevision, changeVector);
-        
+
                     await session.SaveChangesAsync();
-        
+
                     metadatas = await session.Advanced.Revisions.GetMetadataForAsync(id);
-        
+
                     changeVector = metadatas[0].GetString(Constants.Documents.Metadata.ChangeVector);
-        
+
                     cvList.Add(changeVector);
-        
+
                     session.Advanced.Patch<User, string>(id, x => x.ThirdRevision, changeVector);
-        
+
                     session.Advanced.Patch<User, List<string>>(id, x => x.ChangeVectors, cvList);
-                    
+
                     await session.SaveChangesAsync();
                 }
-        
+
                 using (var session = store.OpenAsyncSession())
                 {
-                    var query = await session.LoadAsync<User>(id, builder => builder.IncludeRevisions(x=> x.ChangeVectors));
-                    
+                    var query = await session.LoadAsync<User>(id, builder => builder.IncludeRevisions(x => x.ChangeVectors));
+
                     var revision1 = await session.Advanced.Revisions.GetAsync<User>(cvList[0]);
                     var revision2 = await session.Advanced.Revisions.GetAsync<User>(cvList[1]);
                     var revision3 = await session.Advanced.Revisions.GetAsync<User>(cvList[2]);
-        
+
                     Assert.Equal(1, session.Advanced.NumberOfRequests);
                 }
             }
         }
-        
+
         [Fact]
         public void Load_IncludeBuilder_IncludeRevisionsByProperty_ChangeVectorAndChangeVectors()
         {
@@ -393,7 +378,7 @@ namespace SlowTests.Tests.Linq
 
                 using (var session = store.OpenSession())
                 {
-                    session.Store(new User {Name = "Omer",},
+                    session.Store(new User { Name = "Omer", },
                         id);
 
                     session.SaveChanges();
@@ -437,17 +422,17 @@ namespace SlowTests.Tests.Linq
 
                 using (var session = store.OpenSession())
                 {
-                    var query =  session.Load<User>(id,builder => builder
-                                .IncludeRevisions(x => x.ChangeVectors)
-                                .IncludeRevisions(x => x.FirstRevision)
-                                .IncludeRevisions(x => x.SecondRevision));
+                    var query = session.Load<User>(id, builder => builder
+                        .IncludeRevisions(x => x.ChangeVectors)
+                        .IncludeRevisions(x => x.FirstRevision)
+                        .IncludeRevisions(x => x.SecondRevision));
 
-                    var revision1 =  session.Advanced.Revisions.Get<User>(cvList[0]);
-                    var revision2 =  session.Advanced.Revisions.Get<User>(cvList[1]);
-                    var revision3 =  session.Advanced.Revisions.Get<User>(cvList[2]);
-                    var revisions =  session.Advanced.Revisions.Get<User>(cvList);
+                    var revision1 = session.Advanced.Revisions.Get<User>(cvList[0]);
+                    var revision2 = session.Advanced.Revisions.Get<User>(cvList[1]);
+                    var revision3 = session.Advanced.Revisions.Get<User>(cvList[2]);
+                    var revisions = session.Advanced.Revisions.Get<User>(cvList);
 
-                    
+
                     Assert.NotNull(revision1);
                     Assert.NotNull(revision2);
                     Assert.NotNull(revision3);
@@ -457,7 +442,7 @@ namespace SlowTests.Tests.Linq
                 }
             }
         }
-        
+
         [Fact]
         public async Task Load_IncludeBuilder_IncludeRevisionsByProperty_ChangeVectorAndChangeVectorsAsync()
         {
@@ -471,10 +456,7 @@ namespace SlowTests.Tests.Linq
 
                 using (var session = store.OpenAsyncSession())
                 {
-                    await session.StoreAsync(new User
-                        {
-                            Name = "Omer",
-                        },
+                    await session.StoreAsync(new User { Name = "Omer", },
                         id);
 
                     await session.SaveChangesAsync();
@@ -518,24 +500,24 @@ namespace SlowTests.Tests.Linq
 
                 using (var session = store.OpenAsyncSession())
                 {
-                    var ex = await session.LoadAsync<User>(id,builder => builder
-                                .IncludeRevisions(x => x.ChangeVectors)
-                                .IncludeRevisions(x => x.FirstRevision)
-                                .IncludeRevisions(x => x.SecondRevision));
-                    
+                    var ex = await session.LoadAsync<User>(id, builder => builder
+                        .IncludeRevisions(x => x.ChangeVectors)
+                        .IncludeRevisions(x => x.FirstRevision)
+                        .IncludeRevisions(x => x.SecondRevision));
+
                     var revision1 = await session.Advanced.Revisions.GetAsync<User>(cvList[0]);
                     var revision2 = await session.Advanced.Revisions.GetAsync<User>(cvList[1]);
                     var revisions = await session.Advanced.Revisions.GetAsync<User>(cvList);
-                    
+
                     Assert.NotNull(revision1);
                     Assert.NotNull(revision2);
                     Assert.NotNull(revisions);
-                    
+
                     Assert.Equal(1, session.Advanced.NumberOfRequests);
                 }
             }
         }
-        
+
         [Fact]
         public void Load_IncludeBuilder_IncludeRevisionByDateTime_VerifyUtc()
         {
@@ -546,27 +528,25 @@ namespace SlowTests.Tests.Linq
                 RevisionsHelper.SetupRevisions(Server.ServerStore, store.Database).Wait();
                 using (var session = store.OpenSession())
                 {
-                    session.Store(new User
-                        {
-                            Name = "Omer",
-                        },
+                    session.Store(new User { Name = "Omer", },
                         id);
                     session.SaveChanges();
 
-                    var metadatas =  session.Advanced.Revisions.GetMetadataFor(id);
+                    var metadatas = session.Advanced.Revisions.GetMetadataFor(id);
                     Assert.Equal(1, metadatas.Count);
                     changeVector = metadatas.First().GetString(Constants.Documents.Metadata.ChangeVector);
                     session.Advanced.Patch<User, string>(id, x => x.ChangeVector, changeVector);
-                    session.Advanced.Patch<User, List<string>>(id, x => x.ChangeVectors, new List<string>{changeVector});
+                    session.Advanced.Patch<User, List<string>>(id, x => x.ChangeVectors, new List<string> { changeVector });
                 }
+
                 var dateTime = DateTime.Now.ToLocalTime();
                 using (var session = store.OpenSession())
                 {
                     var query = session.Load<User>(id, builder => builder
                         .IncludeRevisions(dateTime)
-                        .IncludeRevisions(x=>x.ChangeVector)
-                        .IncludeRevisions(x=>x.ChangeVectors));
-                    
+                        .IncludeRevisions(x => x.ChangeVector)
+                        .IncludeRevisions(x => x.ChangeVectors));
+
                     var revision = session.Advanced.Revisions.Get<User>(id, dateTime.ToUniversalTime());
                     var revision2 = session.Advanced.Revisions.Get<User>(changeVector);
                     Assert.NotNull(query);
@@ -576,7 +556,7 @@ namespace SlowTests.Tests.Linq
                 }
             }
         }
-        
+
         [Fact]
         public async Task Load_IncludeBuilder_IncludeRevisionByDateTime_VerifyUtcAsync()
         {
@@ -587,10 +567,7 @@ namespace SlowTests.Tests.Linq
                 await RevisionsHelper.SetupRevisions(Server.ServerStore, store.Database);
                 using (var session = store.OpenAsyncSession())
                 {
-                    await session.StoreAsync(new User
-                        {
-                            Name = "Omer",
-                        },
+                    await session.StoreAsync(new User { Name = "Omer", },
                         id);
                     await session.SaveChangesAsync();
 
@@ -599,13 +576,14 @@ namespace SlowTests.Tests.Linq
                     changeVector = metadatas.First().GetString(Constants.Documents.Metadata.ChangeVector);
                     session.Advanced.Patch<User, string>(id, x => x.ChangeVector, changeVector);
                 }
+
                 var dateTime = DateTime.Now.ToLocalTime();
                 using (var session = store.OpenAsyncSession())
                 {
                     var query = await session.LoadAsync<User>(id, builder => builder
                         .IncludeRevisions(dateTime)
-                        .IncludeRevisions(x=>x.ChangeVector));
-                    
+                        .IncludeRevisions(x => x.ChangeVector));
+
                     var revision = await session.Advanced.Revisions.GetAsync<User>(id, dateTime.ToUniversalTime());
                     var revision2 = await session.Advanced.Revisions.GetAsync<User>(changeVector);
                     Assert.NotNull(query);
@@ -615,7 +593,7 @@ namespace SlowTests.Tests.Linq
                 }
             }
         }
- 
+
         [Fact]
         public void Query_IncludeBuilder_IncludeRevisionBefore()
         {
@@ -626,38 +604,33 @@ namespace SlowTests.Tests.Linq
                 RevisionsHelper.SetupRevisions(Server.ServerStore, store.Database).Wait();
                 using (var session = store.OpenSession())
                 {
-                     session.Store(new User
-                        {
-                            Name = "Omer",
-                        },
+                    session.Store(new User { Name = "Omer", },
                         id);
-                     session.SaveChanges();
-                  
-                     var metadatas =  session.Advanced.Revisions.GetMetadataFor(id);
-                     Assert.Equal(1, metadatas.Count);
-                     changeVector = metadatas.First().GetString(Constants.Documents.Metadata.ChangeVector);
+                    session.SaveChanges();
+
+                    var metadatas = session.Advanced.Revisions.GetMetadataFor(id);
+                    Assert.Equal(1, metadatas.Count);
+                    changeVector = metadatas.First().GetString(Constants.Documents.Metadata.ChangeVector);
                 }
 
                 var beforeDateTime = DateTime.UtcNow;
                 using (var session = store.OpenSession())
                 {
-
-                   
                     var query = session.Query<User>()
-                            .Include(builder => builder
+                        .Customize(x => x.WaitForNonStaleResults())
+                        .Include(builder => builder
                             .IncludeRevisions(beforeDateTime));
                     var users = query.ToList();
-                    
-                    var revision =  session.Advanced.Revisions.Get<User>(changeVector);
-                    
+
+                    var revision = session.Advanced.Revisions.Get<User>(changeVector);
+
                     Assert.NotNull(users);
                     Assert.NotNull(revision);
                     Assert.Equal(1, session.Advanced.NumberOfRequests);
-         
                 }
             }
         }
-        
+
         [Fact]
         public async Task Query_IncludeBuilder_IncludeRevisionBeforeAsync()
         {
@@ -668,26 +641,24 @@ namespace SlowTests.Tests.Linq
                 await RevisionsHelper.SetupRevisions(Server.ServerStore, store.Database);
                 using (var session = store.OpenAsyncSession())
                 {
-                    await session.StoreAsync(new User
-                        {
-                            Name = "Omer",
-                        },
+                    await session.StoreAsync(new User { Name = "Omer", },
                         id);
-                   await session.SaveChangesAsync();
-                   
-                   var metadatas = await session.Advanced.Revisions.GetMetadataForAsync(id);
-                   Assert.Equal(1, metadatas.Count);
-                   changeVector = metadatas.First().GetString(Constants.Documents.Metadata.ChangeVector);
+                    await session.SaveChangesAsync();
+
+                    var metadatas = await session.Advanced.Revisions.GetMetadataForAsync(id);
+                    Assert.Equal(1, metadatas.Count);
+                    changeVector = metadatas.First().GetString(Constants.Documents.Metadata.ChangeVector);
                 }
 
                 var beforeDateTime = DateTime.UtcNow;
                 using (var asyncSession = store.OpenAsyncSession())
                 {
-                    var query =  asyncSession.Query<User>()
-                             .Include(builder => builder
+                    var query = asyncSession.Query<User>()
+                        .Customize(x => x.WaitForNonStaleResults())
+                        .Include(builder => builder
                             .IncludeRevisions(beforeDateTime));
                     var users = await query.ToListAsync();
-                    
+
                     var revision = await asyncSession.Advanced.Revisions.GetAsync<User>(changeVector);
                     Assert.NotNull(users);
                     Assert.NotNull(revision);
@@ -695,8 +666,8 @@ namespace SlowTests.Tests.Linq
                 }
             }
         }
-        
-        
+
+
         [Fact]
         public void Query_RawQueryChangeVectorInsidePropertyWithIndex()
         {
@@ -708,19 +679,16 @@ namespace SlowTests.Tests.Linq
 
                 using (var session = store.OpenSession())
                 {
-                     session.Store(new User
-                        {
-                            Name = "Omer",
-                        },
+                    session.Store(new User { Name = "Omer", },
                         id);
 
-                     session.SaveChanges();
+                    session.SaveChanges();
                 }
 
                 string changeVector;
                 using (var session = store.OpenSession())
                 {
-                    var metadatas =  session.Advanced.Revisions.GetMetadataFor(id);
+                    var metadatas = session.Advanced.Revisions.GetMetadataFor(id);
                     Assert.Equal(1, metadatas.Count);
 
                     changeVector = metadatas.First().GetString(Constants.Documents.Metadata.ChangeVector);
@@ -731,18 +699,19 @@ namespace SlowTests.Tests.Linq
 
                 using (var session = store.OpenSession())
                 {
-                    var query =  session.Advanced
+                    var query = session.Advanced
                         .RawQuery<User>("from Users where Name = 'Omer' include revisions($p0)")
                         .AddParameter("p0", "ChangeVector")
+                        .WaitForNonStaleResults()
                         .ToList();
 
-                    var revision =  session.Advanced.Revisions.Get<User>(changeVector);
+                    var revision = session.Advanced.Revisions.Get<User>(changeVector);
                     Assert.NotNull(revision);
                     Assert.Equal(1, session.Advanced.NumberOfRequests);
                 }
             }
         }
-        
+
         [Fact]
         public async Task Query_RawQueryChangeVectorInsidePropertyWithIndexAsync()
         {
@@ -754,10 +723,7 @@ namespace SlowTests.Tests.Linq
 
                 using (var session = store.OpenAsyncSession())
                 {
-                    await session.StoreAsync(new User
-                        {
-                            Name = "Omer",
-                        },
+                    await session.StoreAsync(new User { Name = "Omer", },
                         id);
 
                     await session.SaveChangesAsync();
@@ -777,10 +743,10 @@ namespace SlowTests.Tests.Linq
 
                 using (var session = store.OpenAsyncSession())
                 {
-              
                     var query = await session.Advanced
                         .AsyncRawQuery<User>("from Users where Name = 'Omer' include revisions($p0)")
                         .AddParameter("p0", "ChangeVector")
+                        .WaitForNonStaleResults()
                         .ToListAsync();
 
                     var revision = await session.Advanced.Revisions.GetAsync<User>(changeVector);
@@ -790,41 +756,39 @@ namespace SlowTests.Tests.Linq
                 }
             }
         }
-        
+
         [Fact]
         public void Query_RawQueryGetRevisionBeforeDateTime()
         {
             using (var store = GetDocumentStore())
             {
                 const string id = "users/rhino";
-                
+
                 RevisionsHelper.SetupRevisions(Server.ServerStore, store.Database).Wait();
 
                 string changeVector;
                 using (var session = store.OpenSession())
                 {
-                     session.Store(new User
-                        {
-                            Name = "Omer",
-                        },
+                    session.Store(new User { Name = "Omer", },
                         id);
 
-                     session.SaveChanges();
-                     var metadatas =  session.Advanced.Revisions.GetMetadataFor(id);
-                     Assert.Equal(1, metadatas.Count);
+                    session.SaveChanges();
+                    var metadatas = session.Advanced.Revisions.GetMetadataFor(id);
+                    Assert.Equal(1, metadatas.Count);
 
-                     changeVector = metadatas.First().GetString(Constants.Documents.Metadata.ChangeVector);
-                     
+                    changeVector = metadatas.First().GetString(Constants.Documents.Metadata.ChangeVector);
                 }
+
                 using (var session = store.OpenSession())
                 {
                     var getRevisionsBefore = DateTime.UtcNow;
-                    var query =  session.Advanced
+                    var query = session.Advanced
                         .RawQuery<User>("from Users include revisions($p0)")
                         .AddParameter("p0", getRevisionsBefore)
+                        .WaitForNonStaleResults()
                         .ToList();
 
-                    var revision =  session.Advanced.Revisions.Get<User>(changeVector);
+                    var revision = session.Advanced.Revisions.Get<User>(changeVector);
 
                     Assert.NotNull(query);
                     Assert.NotNull(revision);
@@ -832,22 +796,19 @@ namespace SlowTests.Tests.Linq
                 }
             }
         }
-        
+
         [Fact]
         public async Task Query_RawQueryGetRevisionBeforeDateTimeAsync()
         {
             using (var store = GetDocumentStore())
             {
                 const string id = "users/rhino";
-                
+
                 await RevisionsHelper.SetupRevisions(Server.ServerStore, store.Database);
                 string changeVector;
                 using (var session = store.OpenAsyncSession())
                 {
-                    await session.StoreAsync(new User
-                        {
-                            Name = "Omer",
-                        },
+                    await session.StoreAsync(new User { Name = "Omer", },
                         id);
 
                     await session.SaveChangesAsync();
@@ -855,13 +816,14 @@ namespace SlowTests.Tests.Linq
                     Assert.Equal(1, metadatas.Count);
                     changeVector = metadatas.First().GetString(Constants.Documents.Metadata.ChangeVector);
                 }
+
                 using (var session = store.OpenAsyncSession())
                 {
-
                     var getRevisionsBefore = DateTime.UtcNow;
                     var query = await session.Advanced
                         .AsyncRawQuery<User>("from Users include revisions($p0)")
                         .AddParameter("p0", getRevisionsBefore)
+                        .WaitForNonStaleResults()
                         .ToListAsync();
 
                     var revision = await session.Advanced.Revisions.GetAsync<User>(changeVector);
@@ -876,7 +838,6 @@ namespace SlowTests.Tests.Linq
         [Fact]
         public void Query_RawQuery_IncludeRevisions_Jint_StaticIndexQuery()
         {
-            
             using (var store = GetDocumentStore())
             {
                 new NameIndex().Execute(store);
@@ -888,19 +849,16 @@ namespace SlowTests.Tests.Linq
 
                 using (var session = store.OpenSession())
                 {
-                    session.Store(new User
-                        {
-                            Name = "Omer",
-                        },
+                    session.Store(new User { Name = "Omer", },
                         id);
 
                     session.SaveChanges();
-                    
                 }
+
                 string changeVector;
                 using (var session = store.OpenSession())
                 {
-                    var metadatas =  session.Advanced.Revisions.GetMetadataFor(id);
+                    var metadatas = session.Advanced.Revisions.GetMetadataFor(id);
                     Assert.Equal(1, metadatas.Count);
 
                     changeVector = metadatas.First().GetString(Constants.Documents.Metadata.ChangeVector);
@@ -911,7 +869,7 @@ namespace SlowTests.Tests.Linq
 
                 using (var session = store.OpenSession())
                 {
-                    var query =  session.Advanced
+                    var query = session.Advanced
                         .RawQuery<User>(
                             @"
 declare function Foo(i) {
@@ -922,8 +880,9 @@ from Users as u
 where Name != null 
 select Foo(u)"
                         )
+                        .WaitForNonStaleResults()
                         .ToList();
-                    
+
                     var revision = session.Advanced.Revisions.Get<User>(changeVector);
 
                     Assert.NotNull(revision);
@@ -931,7 +890,7 @@ select Foo(u)"
                 }
             }
         }
-        
+
         [Fact]
         public async Task Query_RawQuery_IncludeRevisions_Jint_StaticIndexQueryAsync()
         {
@@ -945,14 +904,12 @@ select Foo(u)"
 
                 using (var session = store.OpenAsyncSession())
                 {
-                    await session.StoreAsync(new User
-                        {
-                            Name = "Omer",
-                        },
+                    await session.StoreAsync(new User { Name = "Omer", },
                         id);
 
                     await session.SaveChangesAsync();
                 }
+
                 WaitForIndexing(store);
                 string changeVector;
                 using (var session = store.OpenAsyncSession())
@@ -979,15 +936,16 @@ from Users as u
 where Name != null 
 select Foo(u)"
                         )
+                        .WaitForNonStaleResults()
                         .ToListAsync();
-                    
+
                     var revision = await session.Advanced.Revisions.GetAsync<User>(changeVector);
                     Assert.NotNull(revision);
                     Assert.Equal(1, session.Advanced.NumberOfRequests);
                 }
             }
         }
-        
+
         [Fact]
         public void Query_RawQuery_IncludeRevisions_Jint_IndexQuery()
         {
@@ -999,10 +957,7 @@ select Foo(u)"
 
                 using (var session = store.OpenSession())
                 {
-                    session.Store(new User
-                        {
-                            Name = "Omer",
-                        },
+                    session.Store(new User { Name = "Omer", },
                         id);
 
                     session.SaveChanges();
@@ -1011,7 +966,7 @@ select Foo(u)"
                 string changeVector;
                 using (var session = store.OpenSession())
                 {
-                    var metadatas =  session.Advanced.Revisions.GetMetadataFor(id);
+                    var metadatas = session.Advanced.Revisions.GetMetadataFor(id);
                     Assert.Equal(1, metadatas.Count);
 
                     changeVector = metadatas.First().GetString(Constants.Documents.Metadata.ChangeVector);
@@ -1022,7 +977,7 @@ select Foo(u)"
 
                 using (var session = store.OpenSession())
                 {
-                    var query =  session.Advanced
+                    var query = session.Advanced
                         .RawQuery<User>(
                             @"
 declare function Foo(i) {
@@ -1033,15 +988,16 @@ from Users as u
 where Name != null 
 select Foo(u)"
                         )
+                        .WaitForNonStaleResults()
                         .ToList();
-                    
+
                     var revision = session.Advanced.Revisions.Get<User>(changeVector);
                     Assert.NotNull(revision);
                     Assert.Equal(1, session.Advanced.NumberOfRequests);
                 }
             }
         }
-        
+
         [Fact]
         public void Query_RawQuery_IncludeRevisions_beforeDateTime_Jint()
         {
@@ -1053,14 +1009,11 @@ select Foo(u)"
                 string changeVector;
                 using (var session = store.OpenSession())
                 {
-                    session.Store(new User
-                        {
-                            Name = "Omer",
-                        },
+                    session.Store(new User { Name = "Omer", },
                         id);
 
                     session.SaveChanges();
-                    var metadatas =  session.Advanced.Revisions.GetMetadataFor(id);
+                    var metadatas = session.Advanced.Revisions.GetMetadataFor(id);
                     Assert.Equal(1, metadatas.Count);
 
                     changeVector = metadatas.First().GetString(Constants.Documents.Metadata.ChangeVector);
@@ -1070,10 +1023,10 @@ select Foo(u)"
                 }
 
                 var getRevisionBefore = DateTime.UtcNow;
-                
+
                 using (var session = store.OpenSession())
                 {
-                    var query =  session.Advanced
+                    var query = session.Advanced
                         .RawQuery<User>(
                             @$"
 declare function Foo(i) {{
@@ -1084,15 +1037,16 @@ from Users as u
 where ID(u) = 'users/rhino' 
 select Foo(u)"
                         )
+                        .WaitForNonStaleResults()
                         .ToList();
-                    
-                    var revision =  session.Advanced.Revisions.Get<User>("users/rhino", getRevisionBefore);
+
+                    var revision = session.Advanced.Revisions.Get<User>("users/rhino", getRevisionBefore);
                     Assert.NotNull(revision);
                     Assert.Equal(1, session.Advanced.NumberOfRequests);
                 }
             }
         }
-        
+
         [Fact]
         public async Task Query_RawQuery_IncludeRevisions_beforeDateTime_JintAsync()
         {
@@ -1104,10 +1058,7 @@ select Foo(u)"
                 string changeVector;
                 using (var session = store.OpenAsyncSession())
                 {
-                    await session.StoreAsync(new User
-                        {
-                            Name = "Rhino",
-                        },
+                    await session.StoreAsync(new User { Name = "Rhino", },
                         id);
 
                     await session.SaveChangesAsync();
@@ -1121,10 +1072,10 @@ select Foo(u)"
                 }
 
                 var getRevisionBefore = DateTime.UtcNow;
-                
+
                 using (var session = store.OpenAsyncSession())
                 {
-                    var query =  await session.Advanced
+                    var query = await session.Advanced
                         .AsyncRawQuery<User>(
                             @$"
 declare function Foo(i) {{
@@ -1135,15 +1086,16 @@ from Users as u
 where ID(u) = 'users/Rhino' 
 select Foo(u)"
                         )
+                        .WaitForNonStaleResults()
                         .ToListAsync();
-                    
+
                     var revision = await session.Advanced.Revisions.GetAsync<User>("users/Rhino", getRevisionBefore);
                     Assert.NotNull(revision);
                     Assert.Equal(1, session.Advanced.NumberOfRequests);
                 }
             }
         }
-        
+
         [Fact]
         public void Query_RawQuery_IncludeRevisions_Jint()
         {
@@ -1155,30 +1107,27 @@ select Foo(u)"
 
                 using (var session = store.OpenSession())
                 {
-                     session.Store(new User
-                         {
-                             Name = "Rhino",
-                         },
+                    session.Store(new User { Name = "Rhino", },
                         id);
 
-                     session.SaveChanges();
+                    session.SaveChanges();
                 }
 
                 string changeVector;
                 using (var session = store.OpenSession())
                 {
-                    var metadatas =  session.Advanced.Revisions.GetMetadataFor(id);
+                    var metadatas = session.Advanced.Revisions.GetMetadataFor(id);
                     Assert.Equal(1, metadatas.Count);
 
                     changeVector = metadatas.First().GetString(Constants.Documents.Metadata.ChangeVector);
 
                     session.Advanced.Patch<User, string>(id, x => x.ChangeVector, changeVector);
-                     session.SaveChanges();
+                    session.SaveChanges();
                 }
 
                 using (var session = store.OpenSession())
                 {
-                    var query =  session.Advanced
+                    var query = session.Advanced
                         .RawQuery<User>(
                             @"
 declare function Foo(i) {
@@ -1189,15 +1138,16 @@ from Users as u
 where ID(u) = 'users/Rhino' 
 select Foo(u)"
                         )
+                        .WaitForNonStaleResults()
                         .ToList();
-                    
+
                     var revision = session.Advanced.Revisions.Get<User>(changeVector);
                     Assert.NotNull(revision);
                     Assert.Equal(1, session.Advanced.NumberOfRequests);
                 }
             }
         }
-        
+
         [Fact]
         public async Task Query_RawQuery_IncludeRevisions_JintAsync()
         {
@@ -1209,7 +1159,7 @@ select Foo(u)"
 
                 using (var session = store.OpenAsyncSession())
                 {
-                    await session.StoreAsync(new User {Name = "Rhino",},
+                    await session.StoreAsync(new User { Name = "Rhino", },
                         id);
 
                     await session.SaveChangesAsync();
@@ -1240,8 +1190,9 @@ from Users as u
 where ID(u) = 'users/Rhino' 
 select Foo(u)"
                         )
+                        .WaitForNonStaleResults()
                         .ToListAsync();
-                    
+
                     var revision = await session.Advanced.Revisions.GetAsync<User>(changeVector);
 
                     Assert.NotNull(revision);
@@ -1249,15 +1200,15 @@ select Foo(u)"
                 }
             }
         }
-        
+
         [Fact]
         public async Task Query_RawQuery_IncludeRevisionsArray_Jint()
         {
             using (var store = GetDocumentStore())
             {
-                await new NameIndex().ExecuteAsync(store);
+                new NameIndex().Execute(store);
                 WaitForIndexing(store);
-                
+
                 const string id = "users/Rhino";
                 var cvList = new List<string>();
 
@@ -1265,44 +1216,44 @@ select Foo(u)"
 
                 using (var session = store.OpenSession())
                 {
-                     session.Store(new User {Name = "Rhino",},
+                    session.Store(new User { Name = "Rhino", },
                         id);
 
-                     session.SaveChanges();
+                    session.SaveChanges();
                 }
 
                 string changeVector;
                 using (var session = store.OpenSession())
                 {
-                    var metadatas =  session.Advanced.Revisions.GetMetadataFor(id);
+                    var metadatas = session.Advanced.Revisions.GetMetadataFor(id);
                     Assert.Equal(1, metadatas.Count);
-                      
+
                     changeVector = metadatas.First().GetString(Constants.Documents.Metadata.ChangeVector);
-                    
+
                     session.Advanced.Patch<User, string>(id, x => x.FirstRevision, changeVector);
-                    
-                    session.SaveChanges(); 
+
+                    session.SaveChanges();
 
                     cvList.Add(changeVector);
-                    
-                    metadatas = session.Advanced.Revisions.GetMetadataFor(id);
-                    
-                    changeVector =  metadatas[0].GetString(Constants.Documents.Metadata.ChangeVector);
-                    
-                    cvList.Add(changeVector);
-                    
-                    session.Advanced.Patch<User, string>(id, x => x.SecondRevision, changeVector);
-                    
-                    session.SaveChanges(); 
-                    
+
                     metadatas = session.Advanced.Revisions.GetMetadataFor(id);
 
                     changeVector = metadatas[0].GetString(Constants.Documents.Metadata.ChangeVector);
-                    
+
                     cvList.Add(changeVector);
-                    
+
+                    session.Advanced.Patch<User, string>(id, x => x.SecondRevision, changeVector);
+
+                    session.SaveChanges();
+
+                    metadatas = session.Advanced.Revisions.GetMetadataFor(id);
+
+                    changeVector = metadatas[0].GetString(Constants.Documents.Metadata.ChangeVector);
+
+                    cvList.Add(changeVector);
+
                     session.Advanced.Patch<User, string>(id, x => x.ThirdRevision, changeVector);
-                    
+
                     session.SaveChanges();
                 }
 
@@ -1318,22 +1269,32 @@ declare function Foo(i) {
 from Index 'NameIndex' as u
 where u.Name = 'Rhino' 
 select Foo(u)"
-                        )
+                        ).WaitForNonStaleResults()
                         .ToList();
-                    
+
                     var revision1 = session.Advanced.Revisions.Get<User>(cvList[0]);
+                    if (session.Advanced.NumberOfRequests != 1)
+                        WaitForUserToContinueTheTest(store);
                     var revision2 = session.Advanced.Revisions.Get<User>(cvList[1]);
+                    if (session.Advanced.NumberOfRequests != 1)
+                        WaitForUserToContinueTheTest(store);
                     var revision3 = session.Advanced.Revisions.Get<User>(cvList[2]);
-                
+                    if (session.Advanced.NumberOfRequests != 1)
+                        WaitForUserToContinueTheTest(store);
+
+
                     Assert.NotNull(revision1);
                     Assert.NotNull(revision2);
                     Assert.NotNull(revision3);
-                    
+
+                    if (session.Advanced.NumberOfRequests != 1)
+                        WaitForUserToContinueTheTest(store);
+
                     Assert.Equal(1, session.Advanced.NumberOfRequests);
                 }
             }
         }
-        
+
         [Fact]
         public async Task Query_RawQuery_IncludeRevisionsArray_JintAsync()
         {
@@ -1346,7 +1307,7 @@ select Foo(u)"
 
                 using (var session = store.OpenAsyncSession())
                 {
-                    await session.StoreAsync(new User {Name = "Rhino",},
+                    await session.StoreAsync(new User { Name = "Rhino", },
                         id);
 
                     await session.SaveChangesAsync();
@@ -1357,33 +1318,33 @@ select Foo(u)"
                 {
                     var metadatas = await session.Advanced.Revisions.GetMetadataForAsync(id);
                     Assert.Equal(1, metadatas.Count);
-                      
+
                     changeVector = metadatas.First().GetString(Constants.Documents.Metadata.ChangeVector);
-                    
+
                     session.Advanced.Patch<User, string>(id, x => x.FirstRevision, changeVector);
-                    
+
                     await session.SaveChangesAsync();
 
                     cvList.Add(changeVector);
-                    
-                    metadatas = await session.Advanced.Revisions.GetMetadataForAsync(id);
-                    
-                    changeVector =  metadatas[0].GetString(Constants.Documents.Metadata.ChangeVector);
-                    
-                    cvList.Add(changeVector);
-                    
-                    session.Advanced.Patch<User, string>(id, x => x.SecondRevision, changeVector);
-                    
-                    await session.SaveChangesAsync(); 
-                    
+
                     metadatas = await session.Advanced.Revisions.GetMetadataForAsync(id);
 
                     changeVector = metadatas[0].GetString(Constants.Documents.Metadata.ChangeVector);
-                    
+
                     cvList.Add(changeVector);
-                    
+
+                    session.Advanced.Patch<User, string>(id, x => x.SecondRevision, changeVector);
+
+                    await session.SaveChangesAsync();
+
+                    metadatas = await session.Advanced.Revisions.GetMetadataForAsync(id);
+
+                    changeVector = metadatas[0].GetString(Constants.Documents.Metadata.ChangeVector);
+
+                    cvList.Add(changeVector);
+
                     session.Advanced.Patch<User, string>(id, x => x.ThirdRevision, changeVector);
-                    
+
                     await session.SaveChangesAsync();
                 }
 
@@ -1400,23 +1361,24 @@ from Users as u
 where ID(u) = 'users/Rhino' 
 select Foo(u)"
                         )
+                        .WaitForNonStaleResults()
                         .ToListAsync();
-                    
+
                     var revision1 = await session.Advanced.Revisions.GetAsync<User>(cvList[0]);
                     var revision2 = await session.Advanced.Revisions.GetAsync<User>(cvList[1]);
                     var revision3 = await session.Advanced.Revisions.GetAsync<User>(cvList[2]);
-                
+
                     Assert.NotNull(revision1);
                     Assert.NotNull(revision2);
                     Assert.NotNull(revision3);
-                    
+
                     Assert.Equal(1, session.Advanced.NumberOfRequests);
                 }
             }
         }
-        
+
         [Fact]
-        public void  Query_RawQuery_IncludeRevisionsWithoutAlias()
+        public void Query_RawQuery_IncludeRevisionsWithoutAlias()
         {
             using (var store = GetDocumentStore())
             {
@@ -1426,21 +1388,21 @@ select Foo(u)"
 
                 using (var session = store.OpenSession())
                 {
-                     session.Store(new User {Name = "Rhino",},
+                    session.Store(new User { Name = "Rhino", },
                         id);
 
-                     session.SaveChanges();
+                    session.SaveChanges();
                 }
 
                 string changeVector;
                 using (var session = store.OpenSession())
                 {
-                    var metadatas =  session.Advanced.Revisions.GetMetadataFor(id);
+                    var metadatas = session.Advanced.Revisions.GetMetadataFor(id);
                     Assert.Equal(1, metadatas.Count);
 
                     changeVector = metadatas.First().GetString(Constants.Documents.Metadata.ChangeVector);
 
-                    session.Advanced.Patch<User, string>(id, x => x.ChangeVector, changeVector); 
+                    session.Advanced.Patch<User, string>(id, x => x.ChangeVector, changeVector);
                     session.SaveChanges();
                 }
 
@@ -1449,6 +1411,7 @@ select Foo(u)"
                     var query = session.Advanced
                         .RawQuery<User>("from Users include revisions($p0)")
                         .AddParameter("p0", "ChangeVector")
+                        .WaitForNonStaleResults()
                         .ToList();
 
                     var revision = session.Advanced.Revisions.Get<User>(changeVector);
@@ -1458,7 +1421,7 @@ select Foo(u)"
                 }
             }
         }
-        
+
         [Fact]
         public async Task Query_RawQuery_IncludeRevisionsWithoutAliasAsync()
         {
@@ -1470,7 +1433,7 @@ select Foo(u)"
 
                 using (var session = store.OpenAsyncSession())
                 {
-                    await session.StoreAsync(new User {Name = "Rhino",},
+                    await session.StoreAsync(new User { Name = "Rhino", },
                         id);
 
                     await session.SaveChangesAsync();
@@ -1493,6 +1456,7 @@ select Foo(u)"
                     var query = await session.Advanced
                         .AsyncRawQuery<User>("from Users include revisions($p0)")
                         .AddParameter("p0", "ChangeVector")
+                        .WaitForNonStaleResults()
                         .ToListAsync();
 
                     var revision = await session.Advanced.Revisions.GetAsync<User>(changeVector);
@@ -1516,7 +1480,7 @@ select Foo(u)"
 
                 using (var session = store.OpenSession())
                 {
-                    session.Store(new User {Name = "Rhino",},
+                    session.Store(new User { Name = "Rhino", },
                         id);
 
                     session.SaveChanges();
@@ -1555,7 +1519,6 @@ select Foo(u)"
                     session.Advanced.Patch<User, string>(id, x => x.ThirdRevision, changeVector);
 
                     session.SaveChanges();
-
                 }
 
                 using (var session = store.OpenSession())
@@ -1565,6 +1528,7 @@ select Foo(u)"
                         .AddParameter("p0", "FirstRevision")
                         .AddParameter("p1", "SecondRevision")
                         .AddParameter("p2", "ThirdRevision")
+                        .WaitForNonStaleResults()
                         .ToList();
 
                     var revision1 = session.Advanced.Revisions.Get<User>(cvList[0]);
@@ -1579,104 +1543,97 @@ select Foo(u)"
                 }
             }
         }
-        
+
         [Fact]
         public void Query_RawQueryWithParameters_IncludeRevisions_Array_SecondOption()
         {
             using (var store = GetDocumentStore())
             {
                 var cvList = new List<string>();
-                
+
                 const string id = "users/Rhino";
-                
+
                 RevisionsHelper.SetupRevisions(Server.ServerStore, store.Database).Wait();
-                
+
                 using (var session = store.OpenSession())
                 {
-                     session.Store(new User
-                        {
-                            Name = "Rhino",
-                        },
+                    session.Store(new User { Name = "Rhino", },
                         id);
-                    
-                     session.SaveChanges();
+
+                    session.SaveChanges();
                 }
 
                 string changeVector;
                 using (var session = store.OpenSession())
                 {
-                    var metadatas =  session.Advanced.Revisions.GetMetadataFor(id);
+                    var metadatas = session.Advanced.Revisions.GetMetadataFor(id);
                     Assert.Equal(1, metadatas.Count);
-                      
+
                     changeVector = metadatas.First().GetString(Constants.Documents.Metadata.ChangeVector);
-                    
+
                     session.Advanced.Patch<User, string>(id, x => x.FirstRevision, changeVector);
-                    
+
                     session.SaveChanges();
-                    
+
                     cvList.Add(changeVector);
-                    
-                    metadatas = session.Advanced.Revisions.GetMetadataFor(id);
-                    
-                    changeVector =  metadatas[0].GetString(Constants.Documents.Metadata.ChangeVector);
-                    
-                    cvList.Add(changeVector);
-                    
-                    session.Advanced.Patch<User, string>(id, x => x.SecondRevision, changeVector);
-                    
-                    session.SaveChanges();
-                    
+
                     metadatas = session.Advanced.Revisions.GetMetadataFor(id);
 
                     changeVector = metadatas[0].GetString(Constants.Documents.Metadata.ChangeVector);
-                    
+
                     cvList.Add(changeVector);
-                    
-                    session.Advanced.Patch<User, string>(id, x => x.ThirdRevision, changeVector);
-                    
+
+                    session.Advanced.Patch<User, string>(id, x => x.SecondRevision, changeVector);
+
                     session.SaveChanges();
-                    
+
+                    metadatas = session.Advanced.Revisions.GetMetadataFor(id);
+
+                    changeVector = metadatas[0].GetString(Constants.Documents.Metadata.ChangeVector);
+
+                    cvList.Add(changeVector);
+
+                    session.Advanced.Patch<User, string>(id, x => x.ThirdRevision, changeVector);
+
+                    session.SaveChanges();
                 }
-                
+
                 using (var session = store.OpenSession())
                 {
-                     var query = session.Advanced
+                    var query = session.Advanced
                         .RawQuery<User>("from Users  include revisions(FirstRevision, SecondRevision, ThirdRevision)")
+                        .WaitForNonStaleResults()
                         .ToList();
-                
-                    var revision1 =  session.Advanced.Revisions.Get<User>(cvList[0]);
-                    var revision2 =  session.Advanced.Revisions.Get<User>(cvList[1]);
-                    var revision3 =  session.Advanced.Revisions.Get<User>(cvList[2]);
-                
+
+                    var revision1 = session.Advanced.Revisions.Get<User>(cvList[0]);
+                    var revision2 = session.Advanced.Revisions.Get<User>(cvList[1]);
+                    var revision3 = session.Advanced.Revisions.Get<User>(cvList[2]);
+
                     Assert.NotNull(revision1);
                     Assert.NotNull(revision2);
                     Assert.NotNull(revision3);
-                    
+
                     Assert.Equal(1, session.Advanced.NumberOfRequests);
                 }
-                
             }
         }
-        
+
         [Fact]
         public async Task Query_RawQueryWithParameters_IncludeRevisions_Array_SecondOptionAsync()
         {
             using (var store = GetDocumentStore())
             {
                 var cvList = new List<string>();
-                
+
                 const string id = "users/Rhino";
-                
+
                 await RevisionsHelper.SetupRevisions(Server.ServerStore, store.Database);
-                
+
                 using (var session = store.OpenAsyncSession())
                 {
-                    await session.StoreAsync(new User
-                        {
-                            Name = "Rhino",
-                        },
+                    await session.StoreAsync(new User { Name = "Rhino", },
                         id);
-                    
+
                     await session.SaveChangesAsync();
                 }
 
@@ -1685,54 +1642,52 @@ select Foo(u)"
                 {
                     var metadatas = await session.Advanced.Revisions.GetMetadataForAsync(id);
                     Assert.Equal(1, metadatas.Count);
-                      
+
                     changeVector = metadatas.First().GetString(Constants.Documents.Metadata.ChangeVector);
-                    
+
                     session.Advanced.Patch<User, string>(id, x => x.FirstRevision, changeVector);
-                    
-                    await session.SaveChangesAsync(); 
-                    
+
+                    await session.SaveChangesAsync();
+
                     cvList.Add(changeVector);
-                    
-                    metadatas = await session.Advanced.Revisions.GetMetadataForAsync(id);
-                    
-                    changeVector =  metadatas[0].GetString(Constants.Documents.Metadata.ChangeVector);
-                    
-                    cvList.Add(changeVector);
-                    
-                    session.Advanced.Patch<User, string>(id, x => x.SecondRevision, changeVector);
-                    
-                    await session.SaveChangesAsync(); 
-                    
+
                     metadatas = await session.Advanced.Revisions.GetMetadataForAsync(id);
 
                     changeVector = metadatas[0].GetString(Constants.Documents.Metadata.ChangeVector);
-                    
+
                     cvList.Add(changeVector);
-                    
-                    session.Advanced.Patch<User, string>(id, x => x.ThirdRevision, changeVector);
-                    
+
+                    session.Advanced.Patch<User, string>(id, x => x.SecondRevision, changeVector);
+
                     await session.SaveChangesAsync();
-                    
+
+                    metadatas = await session.Advanced.Revisions.GetMetadataForAsync(id);
+
+                    changeVector = metadatas[0].GetString(Constants.Documents.Metadata.ChangeVector);
+
+                    cvList.Add(changeVector);
+
+                    session.Advanced.Patch<User, string>(id, x => x.ThirdRevision, changeVector);
+
+                    await session.SaveChangesAsync();
                 }
-                
+
                 using (var session = store.OpenAsyncSession())
                 {
-                     var query = await session.Advanced
-                        .AsyncRawQuery<User>("from Users  include revisions(FirstRevision, SecondRevision, ThirdRevision)")
+                    var query = await session.Advanced
+                        .AsyncRawQuery<User>("from Users  include revisions(FirstRevision, SecondRevision, ThirdRevision)").WaitForNonStaleResults()
                         .ToListAsync();
-                
+
                     var revision1 = await session.Advanced.Revisions.GetAsync<User>(cvList[0]);
                     var revision2 = await session.Advanced.Revisions.GetAsync<User>(cvList[1]);
                     var revision3 = await session.Advanced.Revisions.GetAsync<User>(cvList[2]);
-                
+
                     Assert.NotNull(revision1);
                     Assert.NotNull(revision2);
                     Assert.NotNull(revision3);
-                    
+
                     Assert.Equal(1, session.Advanced.NumberOfRequests);
                 }
-                
             }
         }
 
@@ -1749,41 +1704,37 @@ select Foo(u)"
 
                 using (var session = store.OpenSession())
                 {
-                    session.Store(new User
-                        {
-                            Name = "Rhino",
-                        },
+                    session.Store(new User { Name = "Rhino", },
                         id);
-                    
+
                     session.SaveChanges();
                 }
 
                 using (var session = store.OpenSession())
                 {
-                    var error =  Assert.Throws<RavenException>(  () => session.Advanced
+                    var error = Assert.Throws<RavenException>(() => session.Advanced
                         .RawQuery<User>("from Users as u include revisions(u.FirstRevision, x.SecondRevision)")
                         .ToList());
-                        
+
                     Assert.Contains("System.InvalidOperationException: Alias is not supported `include revisions(..)`."
                         , error.Message);
                 }
-                
+
                 using (var session = store.OpenSession())
                 {
-                    var error =  Assert.Throws<RavenException>( () =>  session.Advanced
+                    var error = Assert.Throws<RavenException>(() => session.Advanced
                         .RawQuery<User>("from Users as u include revisions($p0, $p1, $p2)")
                         .AddParameter("p0", "u.FirstRevision")
                         .AddParameter("p1", "u.SecondRevision")
                         .AddParameter("p2", "x.ThirdRevision")
                         .ToList());
-                    
-                    Assert.Contains("System.InvalidOperationException: Alias is not supported `include revisions(..)`." 
+
+                    Assert.Contains("System.InvalidOperationException: Alias is not supported `include revisions(..)`."
                         , error.Message);
                 }
-                
             }
         }
-        
+
         [Fact]
         public async Task Query_RawQueryWithParameters_AliasSyntaxErrorAsync()
         {
@@ -1797,35 +1748,32 @@ select Foo(u)"
 
                 using (var session = store.OpenAsyncSession())
                 {
-                    await session.StoreAsync(new User
-                        {
-                            Name = "Rhino",
-                        },
+                    await session.StoreAsync(new User { Name = "Rhino", },
                         id);
-                    
+
                     await session.SaveChangesAsync();
                 }
 
                 using (var session = store.OpenSession())
                 {
-                    var error =  Assert.Throws<RavenException>(  () => session.Advanced
+                    var error = Assert.Throws<RavenException>(() => session.Advanced
                         .RawQuery<User>("from Users as u include revisions(u.FirstRevision, x.SecondRevision)")
                         .ToList());
-                        
+
                     Assert.Contains("System.InvalidOperationException: Alias is not supported `include revisions(..)`."
                         , error.Message);
                 }
-                
+
                 using (var session = store.OpenAsyncSession())
                 {
-                    var error = await Assert.ThrowsAsync<RavenException>( async () => await  session.Advanced
+                    var error = await Assert.ThrowsAsync<RavenException>(async () => await session.Advanced
                         .AsyncRawQuery<User>("from Users as u include revisions($p0, $p1, $p2)")
                         .AddParameter("p0", "u.FirstRevision")
                         .AddParameter("p1", "u.SecondRevision")
                         .AddParameter("p2", "x.ThirdRevision")
                         .ToListAsync());
-                    
-                    Assert.Contains("System.InvalidOperationException: Alias is not supported `include revisions(..)`." 
+
+                    Assert.Contains("System.InvalidOperationException: Alias is not supported `include revisions(..)`."
                         , error.Message);
                 }
             }
@@ -1840,18 +1788,14 @@ select Foo(u)"
             public string ThirdRevision { get; set; }
             public List<string> ChangeVectors { get; set; }
         }
-        
+
         private class NameIndex : AbstractIndexCreationTask<User>
         {
             public NameIndex()
             {
                 Map = users => from u in users
-                    select new
-                    {
-                        Name = u.Name,
-                    };
+                    select new { Name = u.Name, };
             }
         }
-
     }
 }


### PR DESCRIPTION
### Issue link

https://issues.hibernatingrhinos.com/issue/RavenDB-17276 

### Additional description

Race condition in tests.

### Type of change

- Test bug fix


### How risky is the change?


- Not relevant

### Backward compatibility


- Not relevant

### Is it platform specific issue?


- No

### Documentation update

- No documentation update is needed 

### Testing 

- It has been verified by manual testing

### Is there any existing behavior change of other features due to this change?

- No

### UI work

- No UI work is needed
