### PR TITLE
RavenDB-17851 - Assertion Failed in Counters_and_force_revisions

### DIFF
--- a/src/Raven.Server/Documents/DocumentsStorage.cs
+++ b/src/Raven.Server/Documents/DocumentsStorage.cs
@@ -1343,6 +1343,7 @@ namespace Raven.Server.Documents
                 Transaction.DebugDisposeReaderAfterTransaction(context.Transaction.InnerTransaction, document.Data);
                 DocumentPutAction.AssertMetadataWasFiltered(document.Data);
                 AttachmentsStorage.AssertAttachments(document.Data, document.Flags);
+                CountersStorage.AssertCounters(document.Data, document.Flags);
             }
 #endif
             return document;

--- a/src/Raven.Server/Documents/Revisions/RevisionsStorage.cs
+++ b/src/Raven.Server/Documents/Revisions/RevisionsStorage.cs
@@ -505,7 +505,7 @@ namespace Raven.Server.Documents.Revisions
                 }
 
                 nonPersistentFlags |= NonPersistentDocumentFlags.SkipRevisionCreation;
-                flags = flags.Strip(DocumentFlags.Revision | DocumentFlags.DeleteRevision);
+                flags = flags.Strip(DocumentFlags.Revision | DocumentFlags.DeleteRevision) | DocumentFlags.HasRevisions;
 
                 if (document == null)
                 {
@@ -530,7 +530,7 @@ namespace Raven.Server.Documents.Revisions
 
             var names = bjro.GetPropertyNames();
 
-            metadata.Modifications = new DynamicJsonValue(metadata);
+            metadata.Modifications ??= new DynamicJsonValue(metadata);
             metadata.Modifications.Remove(Constants.Documents.Metadata.RevisionCounters);
             var arr = new DynamicJsonArray();
             foreach (var name in names)

--- a/test/SlowTests/Issues/RavenDB_15076.cs
+++ b/test/SlowTests/Issues/RavenDB_15076.cs
@@ -1,0 +1,67 @@
+﻿using System.IO;
+using System.Text;
+using System.Threading.Tasks;
+using Raven.Client.Documents.Operations.ConnectionStrings;
+using Raven.Client.Documents.Operations.ETL;
+using Raven.Client.Documents.Operations.Replication;
+using Raven.Client.Documents.Session;
+using Tests.Infrastructure;
+using Xunit;
+using Xunit.Abstractions;
+
+namespace SlowTests.Issues
+{
+    internal class RavenDB_15076 : ClusterTestBase
+    {
+
+        public RavenDB_15076(ITestOutputHelper output) : base(output)
+        {
+        }
+
+        [Fact]
+        public async Task Counters_and_force_revisions()
+        {
+            using var storeA = GetDocumentStore();
+            using var storeB = GetDocumentStore();
+
+            using (var s = storeA.OpenAsyncSession())
+            {
+                await s.StoreAsync(new { Breed = "German Shepherd" }, "users/ayende/dogs/arava");
+                await s.StoreAsync(new { Color = "Gray/White" }, "users/pheobe");
+                await s.StoreAsync(new { Name = "Oren" }, "users/ayende");
+                s.CountersFor("users/ayende").Increment("test");
+                s.CountersFor("users/pheobe").Increment("test");
+                s.Advanced.Attachments.Store("users/ayende", "test.bin", new MemoryStream(Encoding.UTF8.GetBytes("hello")));
+                s.Advanced.Attachments.Store("users/pheobe", "test.bin", new MemoryStream(Encoding.UTF8.GetBytes("hello")));
+                s.Advanced.Revisions.ForceRevisionCreationFor("users/ayende", ForceRevisionStrategy.None);
+                s.Advanced.Revisions.ForceRevisionCreationFor("users/pheobe", ForceRevisionStrategy.None);
+                await s.SaveChangesAsync();
+            }
+
+            using (var s = storeA.OpenAsyncSession())
+            {
+                await s.StoreAsync(new { Color = "Gray/White 2" }, "users/pheobe");
+                await s.StoreAsync(new { Name = "Oren 2" }, "users/ayende");
+
+                s.Advanced.Revisions.ForceRevisionCreationFor("users/ayende");
+                s.Advanced.Revisions.ForceRevisionCreationFor("users/pheobe");
+                await s.SaveChangesAsync();
+            }
+
+            await storeA.Maintenance.SendAsync(new PutConnectionStringOperation<RavenConnectionString>(new RavenConnectionString
+            {
+                Database = storeB.Database,
+                Name = storeB.Database + "ConStr",
+                TopologyDiscoveryUrls = storeA.Urls
+            }));
+            await storeA.Maintenance.SendAsync(new UpdateExternalReplicationOperation(new ExternalReplication
+            {
+                ConnectionStringName = storeB.Database + "ConStr",
+                Name = "erpl"
+            }));
+
+            Assert.True(WaitForDocument(storeB, "users/ayende"));
+            Assert.True(WaitForDocument(storeB, "users/pheobe"));
+        }
+    }
+}


### PR DESCRIPTION
### *** Updates ***

- The base version has changed from v5.2 to v4.2.

- Few changes for https://issues.hibernatingrhinos.com/issue/RavenDB-15437 were added (see https://github.com/ravendb/ravendb/pull/13461#issuecomment-1013861608 for more details).

- The failing test [`Counters_and_force_revisions`] has been backported from v5.2 to v4.2

### Issue link

https://issues.hibernatingrhinos.com/issue/RavenDB-17851


### Additional description

Following the changes made on https://issues.hibernatingrhinos.com/issue/RavenDB-15437 [_We still have counters & counters-snapshot in the metadata_], we need to handle `DocumentFlags` properly (if the document has changed). 


### Type of change

- Bug fix

### How risky is the change?

- Low 

### Backward compatibility

- Non breaking change


### Is it platform specific issue?

- No

### Documentation update

- No documentation update is needed 

### Testing 

- Tests have been added that prove the fix is effective or that the feature works (tests in https://github.com/ravendb/ravendb/pull/13387 [`RavenDB_15437.cs`]

### Is there any existing behavior change of other features due to this change?

- No

### UI work

- No UI work is needed
