### PR TITLE
RavenDB-17787 : flaky tests

### DIFF
--- a/test/SlowTests/Issues/FilteredReplicationTests.cs
+++ b/test/SlowTests/Issues/FilteredReplicationTests.cs
@@ -408,9 +408,7 @@ namespace SlowTests.Issues
 
                 Assert.NotNull(await s.LoadAsync<object>("users/ayende/dogs/arava"));
                 Assert.NotNull(await s.LoadAsync<object>("users/ayende"));
-                Assert.NotNull(await s.Advanced.Revisions.GetAsync<object>("users/ayende", RavenTestHelper.UtcToday.AddDays(1)));
-
-                Assert.NotNull(await s.Advanced.Revisions.GetAsync<object>("users/ayende", RavenTestHelper.UtcToday.AddDays(1)));
+                Assert.NotNull(await s.Advanced.Revisions.GetAsync<object>("users/ayende", DateTime.UtcNow.AddDays(1)));
                 Assert.NotNull(await s.CountersFor("users/ayende").GetAsync("test"));
                 Assert.NotEmpty(await s.TimeSeriesFor<HeartRateMeasure>("users/ayende").GetAsync());
                 using (var attachment = await s.Advanced.Attachments.GetAsync("users/ayende", "test.bin"))
@@ -435,7 +433,7 @@ namespace SlowTests.Issues
 
                 Assert.NotNull(await s.LoadAsync<object>("users/ayende"));
 
-                Assert.NotNull(await s.Advanced.Revisions.GetAsync<object>("users/ayende", RavenTestHelper.UtcToday.AddDays(1)));
+                Assert.NotNull(await s.Advanced.Revisions.GetAsync<object>("users/ayende", DateTime.UtcNow.AddDays(1)));
                 Assert.NotNull(await s.CountersFor("users/ayende").GetAsync("test"));
                 Assert.NotEmpty(await s.TimeSeriesFor<HeartRateMeasure>("users/ayende").GetAsync());
                 using (var attachment = await s.Advanced.Attachments.GetAsync("users/ayende", "test.bin"))
@@ -560,9 +558,7 @@ namespace SlowTests.Issues
 
                 Assert.NotNull(await s.LoadAsync<object>("users/ayende/dogs/arava"));
                 Assert.NotNull(await s.LoadAsync<object>("users/ayende"));
-                Assert.NotNull(await s.Advanced.Revisions.GetAsync<object>("users/ayende", RavenTestHelper.UtcToday.AddDays(1)));
-
-                Assert.NotNull(await s.Advanced.Revisions.GetAsync<object>("users/ayende", RavenTestHelper.UtcToday.AddDays(1)));
+                Assert.NotNull(await s.Advanced.Revisions.GetAsync<object>("users/ayende", DateTime.UtcNow.AddDays(1)));
                 Assert.NotNull(await s.CountersFor("users/ayende").GetAsync("test"));
                 Assert.NotEmpty(await s.TimeSeriesFor<HeartRateMeasure>("users/ayende").GetAsync());
                 using (var attachment = await s.Advanced.Attachments.GetAsync("users/ayende", "test.bin"))
@@ -586,7 +582,7 @@ namespace SlowTests.Issues
 
                 Assert.NotNull(await s.LoadAsync<object>("users/ayende"));
 
-                Assert.NotNull(await s.Advanced.Revisions.GetAsync<object>("users/ayende", RavenTestHelper.UtcToday.AddDays(1)));
+                Assert.NotNull(await s.Advanced.Revisions.GetAsync<object>("users/ayende", DateTime.UtcNow.AddDays(1)));
                 Assert.NotNull(await s.CountersFor("users/ayende").GetAsync("test"));
                 Assert.NotEmpty(await s.TimeSeriesFor<HeartRateMeasure>("users/ayende").GetAsync());
                 using (var attachment = await s.Advanced.Attachments.GetAsync("users/ayende", "test.bin"))


### PR DESCRIPTION
### Issue link

https://issues.hibernatingrhinos.com/issue/RavenDB-17787

### Additional description

I think this might be another issue of local vs universal time
revision's last modified is kept in utc
`RavenTestHelper.UtcToday` gives you the local `DateTime.Today` in UTC kind,
and then we ask for revision before `RavenTestHelper.UtcToday.AddDays(1)` (next day at midnight)
but if local time < utc time then rvision's utc date might be later than the next day at midnight

changed from `RavenTestHelper.UtcToday` to `DateTime.UtcNow` in both
`Can_push_via_filtered_replication` and `Can_pull_via_filtered_replication`

