### PR TITLE
RavenDB-17849 Avoid race-condition when waiting for errors in tests.

### DIFF
--- a/test/FastTests/Client/Indexing/IndexExtensionFromClient.cs
+++ b/test/FastTests/Client/Indexing/IndexExtensionFromClient.cs
@@ -592,8 +592,8 @@ namespace My.Crazy.Namespace
 
                 using (var session = store.OpenSession())
                 {
-                    var indexErrors = store.Maintenance.Send(new GetIndexErrorsOperation(new[] { index.IndexName }));
-                    Assert.Equal(0, indexErrors[0].Errors.Length);
+                    var indexErrors = WaitForIndexingErrors(store, errorsShouldExists: false);
+                    Assert.Null(indexErrors);
 
                     var person = session.Query<Person, PeopleIndex11>()
                         .Single(p => p.Friends.Contains("ayende"));
@@ -631,8 +631,8 @@ namespace My.Crazy.Namespace
 
                 using (var session = store.OpenSession())
                 {
-                    var indexErrors = store.Maintenance.Send(new GetIndexErrorsOperation(new[] { index.IndexName }));
-                    Assert.Equal(0, indexErrors[0].Errors.Length);
+                    var indexErrors = WaitForIndexingErrors(store, errorsShouldExists: false);
+                    Assert.Null(indexErrors);
 
                     var combined = session.Query<PeopleIndex12.Result, PeopleIndex12>()
                         .Select(p => p.Combined)
@@ -675,12 +675,11 @@ namespace My.Crazy.Namespace
 
                 using (var session = store.OpenSession())
                 {
-                    var indexErrors = store.Maintenance.Send(new GetIndexErrorsOperation(new[] { index.IndexName }));
-                    Assert.Equal(0, indexErrors[0].Errors.Length);
+                    var indexErrors = WaitForIndexingErrors(store, errorsShouldExists: false);
+                    Assert.Null(indexErrors);
 
                     var person = session.Query<Person, PeopleIndex13>().Single();
                     Assert.Equal("aviv", person.Name);
-
                 }
             }
         }
@@ -721,8 +720,8 @@ namespace My.Crazy.Namespace
 
                 using (var session = store.OpenSession())
                 {
-                    var indexErrors = store.Maintenance.Send(new GetIndexErrorsOperation(new[] { index.IndexName }));
-                    Assert.Equal(0, indexErrors[0].Errors.Length);
+                    var indexErrors = WaitForIndexingErrors(store, errorsShouldExists: false);
+                    Assert.Null(indexErrors);
 
                     var person = session.Query<Person, PeopleIndex14>().Single();
 
@@ -767,8 +766,8 @@ namespace My.Crazy.Namespace
 
                 using (var session = store.OpenSession())
                 {
-                    var indexErrors = store.Maintenance.Send(new GetIndexErrorsOperation(new[] { index.IndexName }));
-                    Assert.Equal(0, indexErrors[0].Errors.Length);
+                    var indexErrors = WaitForIndexingErrors(store, errorsShouldExists: false);
+                    Assert.Null(indexErrors);
 
                     var person = session.Query<Person, PeopleIndex15>().Single();
 

--- a/test/FastTests/Client/Indexing/IndexesFromClient.cs
+++ b/test/FastTests/Client/Indexing/IndexesFromClient.cs
@@ -207,8 +207,7 @@ namespace FastTests.Client.Indexing
                 batchStats.Errors[1].Timestamp = nowNext;
 
                 index._indexStorage.UpdateStats(SystemTime.UtcNow, batchStats);
-
-                var errors = await store.Maintenance.SendAsync(new GetIndexErrorsOperation(new[] { index.Name }));
+                var errors = WaitForIndexingErrors(store, new[] { index.Name });
                 var error = errors[0];
                 Assert.Equal(index.Name, error.Name);
                 Assert.Equal(2, error.Errors.Length);
@@ -222,10 +221,10 @@ namespace FastTests.Client.Indexing
                 Assert.True(error.Errors[1].Error.Contains("Could not create analyzer:"));
                 Assert.Equal(nowNext, error.Errors[1].Timestamp);
 
-                errors = await store.Maintenance.SendAsync(new GetIndexErrorsOperation());
+                errors = WaitForIndexingErrors(store);
                 Assert.Equal(1, errors.Length);
 
-                errors = await store.Maintenance.SendAsync(new GetIndexErrorsOperation(new[] { index.Name }));
+                errors = WaitForIndexingErrors(store, new[] { index.Name });
                 Assert.Equal(1, errors.Length);
 
                 var stats = await store.Maintenance.SendAsync(new GetIndexStatisticsOperation(index.Name));

--- a/test/FastTests/Client/Indexing/StaticIndexesFromClient.cs
+++ b/test/FastTests/Client/Indexing/StaticIndexesFromClient.cs
@@ -206,9 +206,7 @@ namespace FastTests.Client.Indexing
 
                 WaitForIndexing(store);
 
-                var errors = store.Maintenance.Send(new GetIndexErrorsOperation());
-
-                Assert.Equal(0, errors[0].Errors.Length);
+                Assert.Null(WaitForIndexingErrors(store, errorsShouldExists: false));
             }
         }
     }

--- a/test/SlowTests/Bugs/GuidValueInIndexing.cs
+++ b/test/SlowTests/Bugs/GuidValueInIndexing.cs
@@ -31,8 +31,8 @@ namespace SlowTests.Bugs
 
                 WaitForIndexing(store);
 
-                var stats = store.Maintenance.Send(new GetIndexErrorsOperation(new[] { "Test" }));
-                Assert.Empty(stats[0].Errors);
+                var stats = WaitForIndexingErrors(store, errorsShouldExists: false);
+                Assert.Null(stats);
 
             }
         }

--- a/test/SlowTests/Issues/RavenDB-11402.cs
+++ b/test/SlowTests/Issues/RavenDB-11402.cs
@@ -48,9 +48,8 @@ namespace SlowTests.Issues
                         .ProjectInto<TestIndex.Result>()
                         .ToList();
 
-                    var errors = documentStore.Maintenance.Send(new GetIndexErrorsOperation(new[] { index.IndexName }));
-
-                    Assert.Equal(0, errors[0].Errors.Length);
+                    var errors = WaitForIndexingErrors(documentStore, errorsShouldExists: false);
+                    Assert.Null(errors);
                     Assert.Equal(1, results.Count);
                 }
             }

--- a/test/SlowTests/Issues/RavenDB-12780.cs
+++ b/test/SlowTests/Issues/RavenDB-12780.cs
@@ -37,8 +37,8 @@ namespace SlowTests.Issues
 
                 WaitForIndexing(store);
 
-                var stats = store.Maintenance.Send(new GetIndexErrorsOperation(new[] { "IdIndex" }));
-                Assert.Empty(stats[0].Errors);
+                var stats = WaitForIndexingErrors(store, errorsShouldExists: false);
+                Assert.Null(stats);
             }
         }
 
@@ -54,12 +54,9 @@ namespace SlowTests.Issues
                     session.Store(new User());
                     session.SaveChanges();
                 }
-
-                WaitForIndexing(store);
-                WaitForUserToContinueTheTest((store));
-
-                var stats = store.Maintenance.Send(new GetIndexErrorsOperation(new[] { "MetadataIndex" }));
-                Assert.Empty(stats[0].Errors);
+                
+                var stats = WaitForIndexingErrors(store, errorsShouldExists: false);
+                Assert.Null(stats);
             }
         }
 
@@ -77,9 +74,9 @@ namespace SlowTests.Issues
                 }
 
                 WaitForIndexing(store);
-
-                var stats = store.Maintenance.Send(new GetIndexErrorsOperation(new[] { "AsJsonIndex" }));
-                Assert.Empty(stats[0].Errors);
+                
+                var stats = WaitForIndexingErrors(store, errorsShouldExists: false);
+                Assert.Null(stats);
             }
         }
 
@@ -97,15 +94,17 @@ namespace SlowTests.Issues
                     Name = "Index"
                 }));
 
+                
+                
                 using (var session = store.OpenSession())
                 {
                     session.Store(new User());
                     session.SaveChanges();
                 }
+                
+                
 
-                WaitForIndexingErrors(store);
-
-                var stats = store.Maintenance.Send(new GetIndexErrorsOperation(new[] { "Index" }));
+                var stats = WaitForIndexingErrors(store);
                 Assert.NotEmpty(stats[0].Errors);
                 Assert.True(stats[0].Errors[0].Error.Contains("Id may only be called with a document"));
             }
@@ -131,9 +130,8 @@ namespace SlowTests.Issues
                     session.SaveChanges();
                 }
 
-                WaitForIndexingErrors(store);
 
-                var stats = store.Maintenance.Send(new GetIndexErrorsOperation(new[] { "Index" }));
+                var stats = WaitForIndexingErrors(store);
                 Assert.NotEmpty(stats[0].Errors);
                 Assert.True(stats[0].Errors[0].Error.Contains("MetadataFor may only be called with a document"));
             }
@@ -158,10 +156,8 @@ namespace SlowTests.Issues
                     session.Store(new User());
                     session.SaveChanges();
                 }
-
-                WaitForIndexingErrors(store);
-
-                var stats = store.Maintenance.Send(new GetIndexErrorsOperation(new[] { "Index" }));
+                
+                var stats = WaitForIndexingErrors(store);
                 Assert.NotEmpty(stats[0].Errors);
                 Assert.True(stats[0].Errors[0].Error.Contains("AsJson may only be called with a document"));
             }

--- a/test/SlowTests/Issues/RavenDB-12785.cs
+++ b/test/SlowTests/Issues/RavenDB-12785.cs
@@ -37,8 +37,8 @@ if(collection == 'ShoppingCarts')
 
                 using (var session = store.OpenAsyncSession())
                 {
-                    var errors = await store.Maintenance.SendAsync(new GetIndexErrorsOperation(new[] { "Events/ShoppingCart" }));
-                    Assert.Empty(errors[0].Errors);
+                    var errors = WaitForIndexingErrors(store, new[] { "Events/ShoppingCart" }, errorsShouldExists: false);
+                    Assert.Null(errors);
                     var count = await session.Advanced.AsyncRawQuery<object>("from ShoppingCarts").CountAsync();
                     Assert.Equal(1, count);
                 }

--- a/test/SlowTests/Issues/RavenDB-12847.cs
+++ b/test/SlowTests/Issues/RavenDB-12847.cs
@@ -56,8 +56,7 @@ namespace SlowTests.Issues
 
                 WaitForIndexing(store);
 
-                var errors = store.Maintenance.Send(new GetIndexErrorsOperation());
-                Assert.Equal(0, errors[0].Errors.Length);
+                Assert.Null(WaitForIndexingErrors(store, errorsShouldExists: false));
             }
         }
 

--- a/test/SlowTests/Issues/RavenDB-13269.cs
+++ b/test/SlowTests/Issues/RavenDB-13269.cs
@@ -99,9 +99,8 @@ namespace SlowTests.Issues
                 }}));
 
                 WaitForIndexing(store);
-
-                var stats = store.Maintenance.Send(new GetIndexErrorsOperation(new[] { "test1", "test2", "test3", "test4" }));
-                Assert.Empty(stats.SelectMany(x => x.Errors));
+                var stats = WaitForIndexingErrors(store, new[] { "test1", "test2", "test3", "test4" }, errorsShouldExists: false);
+                Assert.Null(stats);
 
                 using (var session = store.OpenSession())
                 {

--- a/test/SlowTests/Issues/RavenDB-14576.cs
+++ b/test/SlowTests/Issues/RavenDB-14576.cs
@@ -41,8 +41,7 @@ namespace SlowTests.Issues
                 new JavascriptIndex().Execute(store);
                 WaitForIndexing(store, timeout: TimeSpan.FromSeconds(5), allowErrors: true);
 
-                var indexErrors = store.Maintenance.Send(new GetIndexErrorsOperation());
-                Assert.Empty(indexErrors.First().Errors);
+                Assert.Null(WaitForIndexingErrors(store, errorsShouldExists: false));
             }
         }
 

--- a/test/SlowTests/Issues/RavenDB-16889.cs
+++ b/test/SlowTests/Issues/RavenDB-16889.cs
@@ -123,13 +123,15 @@ namespace SlowTests.Issues
 
             WaitForIndexing(store);
             
-            var errors = store.Maintenance.Send(new GetIndexErrorsOperation(new[] { index.IndexName }))
+            var errors = WaitForIndexingErrors(store, new []{index.IndexName}, errorsShouldExists: false)?
                 .SelectMany(e => e.Errors)
                 .Select(e => e.Error)
                 .ToArray();
-            var errorsString = string.Join("\n", errors);
-
-            Assert.DoesNotContain("Failed to execute mapping function", errorsString);
+            if (errors is not null)
+            {
+                var errorsString = string.Join("\n", errors);
+                Assert.DoesNotContain("Failed to execute mapping function", errorsString);
+            }
 
             using (var session = store.OpenSession())
             {

--- a/test/SlowTests/Issues/RavenDB-4904.cs
+++ b/test/SlowTests/Issues/RavenDB-4904.cs
@@ -4,6 +4,7 @@
 //  </copyright>
 // -----------------------------------------------------------------------
 
+using System;
 using System.Linq;
 using System.Threading;
 using FastTests;
@@ -31,11 +32,11 @@ namespace SlowTests.Issues
                 using (var commands = store.Commands())
                 {
                     commands.Put("companies/1", null, new { Name = "HR" }, null);
-                    Assert.Equal(0, store.Maintenance.Send(new GetIndexErrorsOperation(new[] { IndexName }))[0].Errors.Length);
+                    Assert.Null(WaitForIndexingErrors(store, new[] { IndexName }, errorsShouldExists: false));
 
                     store.Maintenance.Send(new PutIndexesOperation(new[] { new IndexDefinition { Name = IndexName, Maps = { "from doc in docs let x = 0 select new { Total = 3/x };" } }}));
                     WaitForIndexing(store);
-                    Assert.Equal(1, store.Maintenance.Send(new GetIndexErrorsOperation(new[] { IndexName }))[0].Errors.Length);
+                    Assert.Equal(1, WaitForIndexingErrors(store, new[] { IndexName })[0].Errors.Length);
 
                     //store.DatabaseCommands.PutSideBySideIndexes(new[]
                     //{
@@ -47,8 +48,7 @@ namespace SlowTests.Issues
                     //});
 
                     SpinWait.SpinUntil(() => store.Maintenance.Send(new GetStatisticsOperation()).Indexes.Length == 2);
-                    Assert.Equal(0, store.Maintenance.Send(new GetIndexErrorsOperation()).Where(x => x.Name == IndexName).Sum(x => x.Errors.Length));
-                    Assert.Equal(0, store.Maintenance.Send(new GetIndexErrorsOperation()).Where(x => x.Name != IndexName).Sum(x => x.Errors.Length));
+                    Assert.Null(WaitForIndexingErrors(store, errorsShouldExists: false));
                 }
             }
         }
@@ -61,11 +61,11 @@ namespace SlowTests.Issues
                 using (var commands = store.Commands())
                 {
                     commands.Put("companies/1", null, new { Name = "HR" }, null);
-                    Assert.Equal(0, store.Maintenance.Send(new GetIndexErrorsOperation(new[] { IndexName }))[0].Errors.Length);
+                    Assert.Null(WaitForIndexingErrors(store, new []{ IndexName }, errorsShouldExists: false));
 
                     store.Maintenance.Send(new PutIndexesOperation(new[] { new IndexDefinition { Name = IndexName, Maps = { "from doc in docs let x = 0 select new { Total = 3/x };" } }}));
                     WaitForIndexing(store);
-                    Assert.Equal(1, store.Maintenance.Send(new GetIndexErrorsOperation(new[] { IndexName }))[0].Errors.Length);
+                    Assert.Equal(1, WaitForIndexingErrors(store, new[] { IndexName })[0].Errors.Length);
 
                     //store.DatabaseCommands.PutSideBySideIndexes(new[]
                     //{
@@ -77,8 +77,9 @@ namespace SlowTests.Issues
                     //});
 
                     SpinWait.SpinUntil(() => store.Maintenance.Send(new GetStatisticsOperation()).Indexes.Length == 2);
-                    Assert.Equal(1, store.Maintenance.Send(new GetIndexErrorsOperation()).Where(x => x.Name == IndexName).Sum(x => x.Errors.Length));
-                    Assert.Equal(0, store.Maintenance.Send(new GetIndexErrorsOperation()).Where(x => x.Name != IndexName).Sum(x => x.Errors.Length));
+                    var errors = WaitForIndexingErrors(store);
+                    Assert.Equal(1, errors.Where(x => x.Name == IndexName).Sum(x => x.Errors.Length));
+                    Assert.Equal(0, errors.Where(x => x.Name != IndexName).Sum(x => x.Errors.Length));
                 }
             }
         }
@@ -91,12 +92,11 @@ namespace SlowTests.Issues
                 using (var commands = store.Commands())
                 {
                     commands.Put("companies/1", null, new { Name = "HR" }, null);
-                    Assert.Equal(0, store.Maintenance.Send(new GetIndexErrorsOperation(new[] { IndexName }))[0].Errors.Length);
-
+                    Assert.Null(WaitForIndexingErrors(store, new []{IndexName}, errorsShouldExists: false));
                     store.Maintenance.Send(new PutIndexesOperation(new[] { new IndexDefinition { Name = IndexName,
                         Maps = { "from doc in docs select new { Total = 3/1 };" }} }));
                     WaitForIndexing(store);
-                    Assert.Equal(0, store.Maintenance.Send(new GetIndexErrorsOperation(new[] { IndexName }))[0].Errors.Length);
+                    Assert.Null(WaitForIndexingErrors(store, errorsShouldExists: false));
 
                     //store.DatabaseCommands.PutSideBySideIndexes(new[]
                     //{
@@ -108,8 +108,9 @@ namespace SlowTests.Issues
                     //});
 
                     SpinWait.SpinUntil(() => store.Maintenance.Send(new GetStatisticsOperation()).Indexes.Length == 2);
-                    Assert.Equal(1, store.Maintenance.Send(new GetIndexErrorsOperation()).Where(x => x.Name == IndexName).Sum(x => x.Errors.Length));
-                    Assert.Equal(0, store.Maintenance.Send(new GetIndexErrorsOperation()).Where(x => x.Name != IndexName).Sum(x => x.Errors.Length));
+                    var errors = WaitForIndexingErrors(store);
+                    Assert.Equal(1, errors.Where(x => x.Name == IndexName).Sum(x => x.Errors.Length));
+                    Assert.Equal(0, errors.Where(x => x.Name != IndexName).Sum(x => x.Errors.Length));
                 }
             }
         }

--- a/test/SlowTests/Issues/RavenDB-6064.cs
+++ b/test/SlowTests/Issues/RavenDB-6064.cs
@@ -68,8 +68,7 @@ namespace SlowTests.Issues
 
                 using (var s = store.OpenSession())
                 {
-                    var errors = store.Maintenance.Send(new GetIndexErrorsOperation())[0];
-                    Assert.Empty(errors.Errors);
+                    Assert.Null(WaitForIndexingErrors(store, errorsShouldExists: false));
                     var collection = s.Query<User, User_Index>().ToList();
                     Assert.NotEmpty(collection);
                 }

--- a/test/SlowTests/Issues/RavenDB14196.cs
+++ b/test/SlowTests/Issues/RavenDB14196.cs
@@ -29,9 +29,7 @@ namespace SlowTests.Issues
                 WaitForIndexing(store);
                 WaitForUserToContinueTheTest(store);
 
-                var indexErrors = store.Maintenance.Send(new GetIndexErrorsOperation());
-                var errors = indexErrors.SelectMany(e => e.Errors).Select(e => e.Error);
-                Assert.Empty(errors);
+                Assert.Null(WaitForIndexingErrors(store, errorsShouldExists: false));
             }
         }
     }

--- a/test/SlowTests/Issues/RavenDB_10052.cs
+++ b/test/SlowTests/Issues/RavenDB_10052.cs
@@ -224,7 +224,7 @@ namespace SlowTests.Issues
 
         private static void AssertIndexHasNoErrors(IDocumentStore store, string indexName)
         {
-            Assert.Equal(0, store.Maintenance.Send(new GetIndexErrorsOperation(new[] { indexName }))[0].Errors.Length);
+            Assert.Null(WaitForIndexingErrors(store, new []{ indexName }, errorsShouldExists: false));
         }
 
         private class User

--- a/test/SlowTests/Issues/RavenDB_10982.cs
+++ b/test/SlowTests/Issues/RavenDB_10982.cs
@@ -1,10 +1,13 @@
-﻿using System.Collections.Generic;
+﻿using System;
+using System.Collections.Generic;
 using System.Linq;
 using System.Threading;
 using FastTests;
 using Orders;
 using Raven.Client.Documents.Indexes;
+using Raven.Client.Documents.Linq;
 using Raven.Client.Documents.Operations.Indexes;
+using Raven.Server.Monitoring.Snmp.Objects.Database;
 using Xunit;
 using Xunit.Abstractions;
 
@@ -54,18 +57,7 @@ namespace SlowTests.Issues
 
                     Assert.Equal(0, results.Count);
 
-                    IndexErrors[] errors = null;
-
-                    for (int i = 0; i < 100; i++)
-                    {
-                        errors = store.Maintenance.Send(new GetIndexErrorsOperation(new[] { index.IndexName }));
-
-                        if (errors.Length > 0 && errors[0].Errors.Length > 0)
-                            break;
-
-                        Thread.Sleep(50);
-                    }
-                    
+                    IndexErrors[] errors = WaitForIndexingErrors(store, new[] { index.IndexName });
                     Assert.Equal(1, errors[0].Errors.Length);
                 }
             }

--- a/test/SlowTests/Issues/RavenDB_11683.cs
+++ b/test/SlowTests/Issues/RavenDB_11683.cs
@@ -38,9 +38,7 @@ order by count() desc
 select r.ClaimPayment.ServiceLinePayments[].ClaimAdjustments[].ReasonCode, r.ClaimPayment.ClaimStatusCode, count()")
                         .WaitForNonStaleResults().ToList();
 
-                    var indexErrors = store.Maintenance.Send(new GetIndexErrorsOperation());
-
-                    Assert.Empty(indexErrors[0].Errors);
+                    Assert.Null(WaitForIndexingErrors(store, errorsShouldExists: false));
                 }
             }
         }

--- a/test/SlowTests/Issues/RavenDB_12293.cs
+++ b/test/SlowTests/Issues/RavenDB_12293.cs
@@ -48,9 +48,7 @@ namespace SlowTests.Issues
                     var count = session.Query<SearchIndex.Result, SearchIndex>().Count();
                 }
 
-                var stats = store.Maintenance.Send(new GetIndexErrorsOperation());
-
-                Assert.Empty(stats.First().Errors);
+                Assert.Null(WaitForIndexingErrors(store, errorsShouldExists: false));
             }
         }
 

--- a/test/SlowTests/Issues/RavenDB_16962.cs
+++ b/test/SlowTests/Issues/RavenDB_16962.cs
@@ -37,12 +37,15 @@ namespace SlowTests.Issues
 
                 WaitForIndexing(store);
 
-                var errors = store.Maintenance.Send(new GetIndexErrorsOperation(new[] { index.IndexName }))
+                var errors = WaitForIndexingErrors(store, new[] { index.IndexName }, errorsShouldExists: false)?
                     .SelectMany(e => e.Errors)
                     .Select(e => e.Error)
                     .ToArray();
-                var errorsString = string.Join("\n", errors);
-                Assert.DoesNotContain("Failed to execute mapping function", errorsString);
+                if (errors is not null)
+                {
+                    var errorsString = string.Join("\n", errors);
+                    Assert.DoesNotContain("Failed to execute mapping function", errorsString);
+                }
 
                 using (var session = store.OpenSession())
                 {
@@ -79,12 +82,15 @@ namespace SlowTests.Issues
 
                 WaitForIndexing(store);
 
-                var errors = store.Maintenance.Send(new GetIndexErrorsOperation(new[] { index.IndexName }))
+                var errors = WaitForIndexingErrors(store, new[] { index.IndexName }, errorsShouldExists: false)?
                     .SelectMany(e => e.Errors)
                     .Select(e => e.Error)
                     .ToArray();
-                var errorsString = string.Join("\n", errors);
-                Assert.DoesNotContain("Failed to execute mapping function", errorsString);
+                if (errors is not null)
+                {
+                    var errorsString = string.Join("\n", errors);
+                    Assert.DoesNotContain("Failed to execute mapping function", errorsString);
+                }
 
                 using (var session = store.OpenSession())
                 {

--- a/test/SlowTests/Issues/RavenDB_5489.cs
+++ b/test/SlowTests/Issues/RavenDB_5489.cs
@@ -70,8 +70,7 @@ namespace SlowTests.Issues
 
                 result = SpinWait.SpinUntil(() => store.Maintenance.Send(new GetIndexErrorsOperation())[0].Errors.Length != 0 , TimeSpan.FromSeconds(5));
                 Assert.True(result);
-
-                var errors = store.Maintenance.Send(new GetIndexErrorsOperation(new[] { new Users_ByName().IndexName }));
+                var errors = WaitForIndexingErrors(store, new[] { new Users_ByName().IndexName });
                 Assert.Equal(1, errors[0].Errors.Length);
                 Assert.Contains("Simulated corruption", errors[0].Errors[0].Error);
             }

--- a/test/SlowTests/Issues/RavenDB_9645.cs
+++ b/test/SlowTests/Issues/RavenDB_9645.cs
@@ -58,10 +58,7 @@ namespace SlowTests.Issues
 
                 WaitForIndexing(store);
 
-                var errors = store.Maintenance.Send(new GetIndexErrorsOperation());
-
-                var anyError = errors.Any(x => x.Errors.Any());
-                Assert.False(anyError);
+                Assert.Null(WaitForIndexingErrors(store, errorsShouldExists: false));
 
                 using (var session = store.OpenSession())
                 {

--- a/test/SlowTests/Server/Documents/Indexing/MapReduce/RavenDB_12932.cs
+++ b/test/SlowTests/Server/Documents/Indexing/MapReduce/RavenDB_12932.cs
@@ -347,7 +347,7 @@ namespace SlowTests.Server.Documents.Indexing.MapReduce
 
                 WaitForIndexing(store);
 
-                var errors = store.Maintenance.Send(new GetIndexErrorsOperation(new[] {index.IndexName}));
+                var errors = WaitForIndexingErrors(store, new[] {index.IndexName});
 
                 Assert.Equal(1, errors.Length);
 

--- a/test/SlowTests/Tests/Indexes/DynamicEnumerableIndexesTests.cs
+++ b/test/SlowTests/Tests/Indexes/DynamicEnumerableIndexesTests.cs
@@ -239,15 +239,18 @@ namespace SlowTests.Tests.Indexes
 
                 WaitForIndexing(store);
                 
-                var errors = store.Maintenance.Send(new GetIndexErrorsOperation(new[] { index.IndexName }))
+                var errors = WaitForIndexingErrors(store, new[] { index.IndexName }, errorsShouldExists: false)?
                     .SelectMany(e => e.Errors)
                     .Select(e => e.Error)
                     .ToArray();
-                var errorsString = string.Join("\n", errors);
+                if (errors is not null)
+                {
+                    var errorsString = string.Join("\n", errors);
+                    Assert.DoesNotContain("Failed to execute mapping function", errorsString);
+                }
 
                 using (var session = store.OpenSession())
                 {
-                    Assert.DoesNotContain("Failed to execute mapping function", errorsString);
                     var query = session.Query<Result, T>().Select(x => x.Path).ToList();
                     switch (typeof(T))
                     {

--- a/test/SlowTests/Voron/Bugs/RavenDB_6971.cs
+++ b/test/SlowTests/Voron/Bugs/RavenDB_6971.cs
@@ -39,9 +39,7 @@ namespace SlowTests.Voron.Bugs
 
                 WaitForIndexing(store);
 
-                var errors = store.Maintenance.ForDatabase(store.Database).Send(new GetIndexErrorsOperation());
-
-                Assert.Empty(errors.SelectMany(x => x.Errors));
+                Assert.Null(WaitForIndexingErrors(store, errorsShouldExists: false));
             }
         }
 

--- a/test/StressTests/Issues/RavenDB_12151.cs
+++ b/test/StressTests/Issues/RavenDB_12151.cs
@@ -205,7 +205,7 @@ namespace StressTests.Issues
                 {
                 }
 
-                var errors = store.Maintenance.Send(new GetIndexErrorsOperation());
+                var errors = WaitForIndexingErrors(store, errorsShouldExists: false);
                 if (errors != null)
                 {
                     foreach (var error in errors)

--- a/test/Tests.Infrastructure/RavenTestBase.cs
+++ b/test/Tests.Infrastructure/RavenTestBase.cs
@@ -606,11 +606,18 @@ namespace FastTests
             throw new TimeoutException("The indexes stayed stale for more than " + timeout.Value + ", stats at " + file);
         }
 
-        public static IndexErrors[] WaitForIndexingErrors(IDocumentStore store, string[] indexNames = null, TimeSpan? timeout = null)
+        public static IndexErrors[] WaitForIndexingErrors(IDocumentStore store, string[] indexNames = null, TimeSpan? timeout = null, bool? errorsShouldExists = null)
         {
-            timeout ??= (Debugger.IsAttached
-                          ? TimeSpan.FromMinutes(15)
-                          : TimeSpan.FromMinutes(1));
+            if (errorsShouldExists is null)
+            {
+                timeout ??= Debugger.IsAttached ? TimeSpan.FromMinutes(15) : TimeSpan.FromMinutes(1);
+            }
+            else
+            {
+                timeout ??= errorsShouldExists is true 
+                    ? TimeSpan.FromSeconds(5)
+                    : TimeSpan.FromSeconds(1);
+            }
 
             var toWait = new HashSet<string>(indexNames ?? Array.Empty<string>(), StringComparer.OrdinalIgnoreCase);
 
@@ -636,7 +643,10 @@ namespace FastTests
             if (toWait.Count != 0)
                 msg += $" Still waiting for following indexes: {string.Join(",", toWait)}";
 
-            throw new TimeoutException(msg);
+            if (errorsShouldExists is null)
+                throw new TimeoutException(msg);
+            
+            return null;
         }
 
         public static int WaitForEntriesCount(IDocumentStore store, string indexName, int minEntriesCount, string databaseName = null, TimeSpan? timeout = null, bool throwOnTimeout = true)


### PR DESCRIPTION
### Issue link

https://issues.hibernatingrhinos.com/issue/RavenDB-17849 

### Additional description

There is a race condition when trying to read errors. When the lock is on we return the empty list immediately. 


https://github.com/ravendb/ravendb/blob/dddd4496e11d5915c6a0b98b95b7c34d541e9ca2/src/Raven.Server/Documents/Indexes/Index.cs#L1896-L1919

https://github.com/ravendb/ravendb/blob/dddd4496e11d5915c6a0b98b95b7c34d541e9ca2/src/Raven.Server/Documents/Indexes/Index.cs#L3205-L3210


### Type of change

- Regression bug fix


### How risky is the change?
- Not relevant

### Backward compatibility


- Not relevant

### Is it platform specific issue?

- No

### Documentation update

- No documentation update is needed 

### Testing 

- Tests have been added that prove the fix is effective or that the feature works


### Is there any existing behavior change of other features due to this change?

- No

### UI work

- No UI work is needed
