### PR TITLE
RavenDB-17856 Making absolutely sure that we will try to create an Elasticsearch index if it doesn't exist. Erroring on a failure to cleanup indexes.

### DIFF
--- a/src/Raven.Server/Documents/ETL/Providers/Elasticsearch/ElasticSearchEtl.cs
+++ b/src/Raven.Server/Documents/ETL/Providers/Elasticsearch/ElasticSearchEtl.cs
@@ -204,27 +204,28 @@ namespace Raven.Server.Documents.ETL.Providers.ElasticSearch
 
         private void EnsureIndexExistsAndValidateIfNeeded(string indexName, ElasticSearchIndexWithRecords index)
         {
-            if (_existingIndexes.Contains(indexName) == false && _client.Indices.Exists(new IndexExistsRequest(Indices.Index(indexName))).Exists == false)
-            {
-                CreateDefaultIndex(indexName, index);
-
-                _existingIndexes.Add(indexName);
-            }
-            else
+            if (_existingIndexes.Contains(indexName) == false)
             {
                 var indexResponse = _client.Indices.Get(new GetIndexDescriptor(Indices.Index(indexName)));
 
-                var mappingsProperties = indexResponse.Indices[indexName].Mappings.Properties;
+                if (indexResponse.Indices.TryGetValue(indexName, out var state))
+                {
+                    var mappingsProperties = state.Mappings.Properties;
 
-                if (mappingsProperties.TryGetValue(new PropertyName(index.DocumentIdProperty), out var propertyDefinition) == false)
-                    throw new ElasticSearchLoadException(
-                        $"The index '{indexName}' doesn't contain the mapping for '{index.DocumentIdProperty}' property. " +
-                        "This property is meant to store RavenDB document ID so it needs to be defined as a non-analyzed field, with type 'keyword' to avoid having full-text-search on it.");
+                    if (mappingsProperties.TryGetValue(new PropertyName(index.DocumentIdProperty), out var propertyDefinition) == false)
+                        throw new ElasticSearchLoadException(
+                            $"The index '{indexName}' doesn't contain the mapping for '{index.DocumentIdProperty}' property. " +
+                            "This property is meant to store RavenDB document ID so it needs to be defined as a non-analyzed field, with type 'keyword' to avoid having full-text-search on it.");
 
-                if (propertyDefinition.Type == null || propertyDefinition.Type.Equals("keyword", StringComparison.OrdinalIgnoreCase) == false)
-                    throw new ElasticSearchLoadException(
-                        $"The index '{indexName}' has invalid mapping for '{index.DocumentIdProperty}' property. " +
-                        "This property is meant to store RavenDB document ID so it needs to be defined as a non-analyzed field, with type 'keyword' to avoid having full-text-search on it.");
+                    if (propertyDefinition.Type == null || propertyDefinition.Type.Equals("keyword", StringComparison.OrdinalIgnoreCase) == false)
+                        throw new ElasticSearchLoadException(
+                            $"The index '{indexName}' has invalid mapping for '{index.DocumentIdProperty}' property. " +
+                            "This property is meant to store RavenDB document ID so it needs to be defined as a non-analyzed field, with type 'keyword' to avoid having full-text-search on it.");
+                }
+                else
+                {
+                    CreateDefaultIndex(indexName, index);
+                }
 
                 _existingIndexes.Add(indexName);
             }

--- a/test/SlowTests/Server/Documents/ETL/Elasticsearch/ElasticSearchEtlTestBase.cs
+++ b/test/SlowTests/Server/Documents/ETL/Elasticsearch/ElasticSearchEtlTestBase.cs
@@ -94,6 +94,9 @@ namespace SlowTests.Server.Documents.ETL.ElasticSearch
         protected void CleanupIndexes(ElasticClient client)
         {
             var response = client.Indices.Delete(Indices.All);
+
+            if (response.IsValid == false)
+                throw new InvalidOperationException($"Failed to cleanup indexes: {response.ServerError}", response.OriginalException);
         }
 
         protected void AssertEtlDone(ManualResetEventSlim etlDone, TimeSpan timeout, string databaseName, ElasticSearchEtlConfiguration config)


### PR DESCRIPTION
### Issue link

https://issues.hibernatingrhinos.com/issue/RavenDB-17856

### Additional description

Making the ES index creation more robust so we won't end up with NRE on validating existing index definition. I believe the root cause was related to something deleted the index behind our back - not sure how that could happen. Anyway now we'll create and index definition if the response doesn't contain info about a given index.

### Type of change

- Bug fix

### How risky is the change?

- Low 


### Backward compatibility


- Not relevant

### Is it platform specific issue?
- No

### Documentation update

- No documentation update is needed 

### Testing 

- Existing tests on CI will verify the fix

### Is there any existing behavior change of other features due to this change?

- No

### UI work

- No UI work is needed
