### PR TITLE
RavenDB-17858 Include the actual subscription connection exception in the message shown to the user

### DIFF
--- a/src/Raven.Client/Documents/Subscriptions/SubscriptionWorker.cs
+++ b/src/Raven.Client/Documents/Subscriptions/SubscriptionWorker.cs
@@ -333,9 +333,16 @@ namespace Raven.Client.Documents.Subscriptions
                 if (connectionStatus.Exception.Contains(nameof(DatabaseDoesNotExistException)))
                     DatabaseDoesNotExistException.ThrowWithMessage(_dbName, connectionStatus.Message);
             }
+
             if (connectionStatus.Type != SubscriptionConnectionServerMessage.MessageType.ConnectionStatus)
-                throw new Exception("Server returned illegal type message when expecting connection status, was: " +
-                                    connectionStatus.Type);
+            {
+                var message = "Server returned illegal type message when expecting connection status, was: " + connectionStatus.Type;
+
+                if (connectionStatus.Type == SubscriptionConnectionServerMessage.MessageType.Error)
+                    message += $". Exception: {connectionStatus.Exception}";
+
+                throw new Exception(message);
+            }
 
             switch (connectionStatus.Status)
             {

--- a/src/Raven.Client/Documents/Subscriptions/SubscriptionWorker.cs
+++ b/src/Raven.Client/Documents/Subscriptions/SubscriptionWorker.cs
@@ -341,7 +341,7 @@ namespace Raven.Client.Documents.Subscriptions
                 if (connectionStatus.Type == SubscriptionConnectionServerMessage.MessageType.Error)
                     message += $". Exception: {connectionStatus.Exception}";
 
-                throw new Exception(message);
+                throw new SubscriptionMessageTypeException(message);
             }
 
             switch (connectionStatus.Status)

--- a/src/Raven.Client/Exceptions/Documents/Subscriptions/SubscriptionMessageTypeException.cs
+++ b/src/Raven.Client/Exceptions/Documents/Subscriptions/SubscriptionMessageTypeException.cs
@@ -1,0 +1,14 @@
+﻿using System;
+
+namespace Raven.Client.Exceptions.Documents.Subscriptions;
+
+public class SubscriptionMessageTypeException : SubscriptionException
+{
+    public SubscriptionMessageTypeException(string message) : base(message)
+    {
+    }
+
+    public SubscriptionMessageTypeException(string message, Exception inner) : base(message, inner)
+    {
+    }
+}


### PR DESCRIPTION
### Issue link

https://issues.hibernatingrhinos.com/issue/RavenDB-17858

### Additional description

Showing better error to the user

### Type of change

- Usability

### How risky is the change?

- Low 
### Backward compatibility

- Not relevant

### Is it platform specific issue?

- No

### Documentation update

- No documentation update is needed 

### Testing 

- Not relevant

### Is there any existing behavior change of other features due to this change?

- No

### UI work

- No UI work is needed
