### PR TITLE
RavenDB-17815 default index deploymenet mode should be `Parallel`

### DIFF
--- a/test/Tests.Infrastructure/RavenTestBase.cs
+++ b/test/Tests.Infrastructure/RavenTestBase.cs
@@ -345,9 +345,6 @@ namespace FastTests
                             [RavenConfiguration.GetKey(x => x.Core.RunInMemory)] = runInMemory.ToString(),
                             [RavenConfiguration.GetKey(x => x.Core.ThrowIfAnyIndexCannotBeOpened)] = "true",
                             [RavenConfiguration.GetKey(x => x.Indexing.MinNumberOfMapAttemptsAfterWhichBatchWillBeCanceledIfRunningLowOnMemory)] = int.MaxValue.ToString(),
-                            // TODO: remove this after testing
-                            [RavenConfiguration.GetKey(x => x.Indexing.AutoIndexDeploymentMode)] = IndexDeploymentMode.Rolling.ToString(),
-                            [RavenConfiguration.GetKey(x => x.Indexing.StaticIndexDeploymentMode)] = IndexDeploymentMode.Rolling.ToString(),
                         }
                     };
 


### PR DESCRIPTION
### Issue link

https://issues.hibernatingrhinos.com/issue/RavenDB-17815

### Additional description

The default in our tests for index deployment was set to `Rolling`, so basically each index was deployed as rolling.

When deployment mode is set to `Rolling` the cluster is responsible to roll the index, which incur some delay in comparison to the `Parallel` mode.

The reason we had this time increase is that https://github.com/ravendb/ravendb/pull/13316 ensures we roll based on the cluster decision and not upon local document change.

### Type of change

- test fix

### How risky is the change?

- Low 

### Backward compatibility

- Not relevant

### Is it platform specific issue?

- No

### Documentation update

- No documentation update is needed 

### Testing 

- It has been verified by manual testing

### Is there any existing behavior change of other features due to this change?

- No

### UI work

- No UI work is needed
