### PR TITLE
RavenDB-17764 - fixed Batch acknowledged before the client processed the batch and ask for confirm

### DIFF
--- a/src/Raven.Server/Documents/Subscriptions/SubscriptionConnectionsState.cs
+++ b/src/Raven.Server/Documents/Subscriptions/SubscriptionConnectionsState.cs
@@ -197,21 +197,12 @@ namespace Raven.Server.Documents.Subscriptions
 
         public Task AcknowledgeBatch(SubscriptionConnection connection, long batchId, List<DocumentRecord> addDocumentsToResend)
         {
-            if (ClusterCommandsVersionManager.CurrentClusterMinimalVersion >= 53_000)
-            {
-                return connection.TcpConnection.DocumentDatabase.SubscriptionStorage.AcknowledgeBatchProcessed(
-                    SubscriptionId,
-                    SubscriptionName,
-                    connection.LastSentChangeVectorInThisConnection ?? nameof(Client.Constants.Documents.SubscriptionChangeVectorSpecialStates.DoNotChange),
-                    batchId,
-                    addDocumentsToResend);
-            }
-
-            return connection.TcpConnection.DocumentDatabase.SubscriptionStorage.LegacyAcknowledgeBatchProcessed(
+            return connection.TcpConnection.DocumentDatabase.SubscriptionStorage.AcknowledgeBatchProcessed(
                 SubscriptionId,
                 SubscriptionName,
                 connection.LastSentChangeVectorInThisConnection ?? nameof(Client.Constants.Documents.SubscriptionChangeVectorSpecialStates.DoNotChange),
-                LastChangeVectorSent);
+                batchId,
+                addDocumentsToResend);
         }
         
         public long GetLastEtagSent()

--- a/src/Raven.Server/Documents/TcpHandlers/SubscriptionConnection.cs
+++ b/src/Raven.Server/Documents/TcpHandlers/SubscriptionConnection.cs
@@ -806,7 +806,7 @@ namespace Raven.Server.Documents.TcpHandlers
                         await TcpConnection.DocumentDatabase.SubscriptionStorage.LegacyAcknowledgeBatchProcessed(
                             SubscriptionId,
                             Options.SubscriptionName,
-                            LastSentChangeVectorInThisConnection ?? nameof(Client.Constants.Documents.SubscriptionChangeVectorSpecialStates.DoNotChange),
+                            LastSentChangeVectorInThisConnection,
                             SubscriptionConnectionsState.LastChangeVectorSent);
 
                         //since we send the next batch by LastChangeVectorSent, in legacy will represent the last acked cv instead


### PR DESCRIPTION
### Issue link

https://issues.hibernatingrhinos.com/issue/RavenDB-17764

### Additional description

Removed legacy acknowledge from TrySendingBatch(). Should not happen there.
Added legacy acknowledge to ProcessSubscriptionAsync() for acking empty skipped documents to mark progress.

### Type of change

- Bug fix

### How risky is the change?

- Low 

### Backward compatibility

- Non breaking change

### Is it platform specific issue?

- No

### Documentation update

- No documentation update is needed 

### Testing 

- Tests have been added that prove the fix is effective or that the feature works

### Is there any existing behavior change of other features due to this change?

- No

### UI work

- No UI work is needed
