### PR TITLE
RavenDB-17169 fix QueryFromMultipleTimeSeries_ShouldReturnSameResult_…

### DIFF
--- a/test/SlowTests/Client/TimeSeries/Query/QueryFromMultipleTimeSeries.cs
+++ b/test/SlowTests/Client/TimeSeries/Query/QueryFromMultipleTimeSeries.cs
@@ -816,6 +816,10 @@ select out()
                 var database = await GetDocumentDatabaseInstanceFor(store);
 
                 var now = DateTime.UtcNow;
+                var nowSeconds = now.Second;
+                now = now.AddSeconds(-nowSeconds);
+                database.Time.UtcDateTime = () => DateTime.UtcNow.AddSeconds(-nowSeconds);
+
                 var baseline = now.AddDays(-12);
                 var total = TimeSpan.FromDays(12).TotalMinutes;
 


### PR DESCRIPTION
…ForRawAndRollup2 test

### Issue link

https://issues.hibernatingrhinos.com/issue/RavenDB-17169

### Additional description
When we start the test approximately a second before the next rollup, we can get to the time to have an extra rollup.
The fix is to start with 0 seconds

### Type of change

- Test fix

### How risky is the change?

- Not relevant

### Backward compatibility


- Not relevant

### Is it platform specific issue?

- No

### Documentation update

- No documentation update is needed 

### Testing 


- Not relevant

### Is there any existing behavior change of other features due to this change?

- No

### UI work

- No UI work is needed
