### PR TITLE
RavenDB-17301 : add WaitForDatabaseToBeDeleted in RemoveDatabaseNode

### DIFF
--- a/test/RachisTests/Cluster.cs
+++ b/test/RachisTests/Cluster.cs
@@ -1,6 +1,5 @@
 ﻿using System;
 using System.Collections.Generic;
-using System.Diagnostics;
 using System.Linq;
 using System.Threading.Tasks;
 using Raven.Client.Documents;
@@ -100,31 +99,6 @@ namespace RachisTests
                 using (context.OpenReadTransaction())
                 {
                     Assert.Null(leader.ServerStore.Cluster.ReadDatabase(context, databaseName));
-                }
-            }
-        }
-
-        private async Task<bool> WaitForDatabaseToBeDeleted(IDocumentStore store, string databaseName,TimeSpan timeout)
-        {
-            var pollingInterval = timeout.TotalSeconds<1? timeout:TimeSpan.FromSeconds(1);
-            var sw = Stopwatch.StartNew();
-            while (true)
-            {
-                var delayTask = Task.Delay(pollingInterval);
-                var dbTask = store.Maintenance.Server.SendAsync(new GetDatabaseRecordOperation(databaseName));
-                var doneTask = await Task.WhenAny(dbTask, delayTask);
-                if (doneTask == delayTask)
-                {
-                    if (sw.Elapsed > timeout)
-                    {
-                        return false;
-                    }
-                    continue;
-                }
-                var dbRecord = dbTask.Result;
-                if (dbRecord == null || dbRecord.DeletionInProgress == null || dbRecord.DeletionInProgress.Count == 0)
-                {
-                    return true;
                 }
             }
         }


### PR DESCRIPTION
### Issue link

https://issues.hibernatingrhinos.com/issue/RavenDB-17301

### Additional description

test `ClusterDatabaseMaintenance.HandleConflictShouldTakeUnusedDatabasesIntoAccount4` failed on asserting number of `UnusedDatabaseIds` in db-record after removing database node : https://github.com/ravendb/ravendb/blob/v5.2/test/Tests.Infrastructure/ClusterTestBase.cs#L211

we were waiting on `deleteCommand.Index + 1` before asserting `UnusedDatabaseIds` count, but `UnusedDatabaseIds`  is being set by a different command - `RemoveNodeFromDatabaseCommand` - and it's index might be greater than `deleteCommand.Index + 1`  (if some other command got in between) 

added `WaitForDatabaseToBeDeleted` before asserting `UnusedDatabaseIds` count