### PR TITLE
RavenDB-17822 stabilize EditRollingIndexMultipleTimesWhileDocumentsModified

### DIFF
--- a/src/Raven.Server/Documents/Indexes/Index.cs
+++ b/src/Raven.Server/Documents/Indexes/Index.cs
@@ -3809,7 +3809,11 @@ namespace Raven.Server.Documents.Indexes
                 return null;
             }
 
-            return new DisposableAction(() => _executingIndexing.Release());
+            return new DisposableAction(() =>
+            {
+                DocumentDatabase.IndexStore.ForTestingPurposes?.BeforeIndexThreadExit?.Invoke(this);
+                _executingIndexing.Release();
+            });
         }
 
         internal static readonly TimeSpan DefaultWaitForNonStaleResultsTimeout = TimeSpan.FromSeconds(15); // this matches default timeout from client

--- a/src/Raven.Server/Documents/Indexes/IndexStore.cs
+++ b/src/Raven.Server/Documents/Indexes/IndexStore.cs
@@ -2538,6 +2538,8 @@ namespace Raven.Server.Documents.Indexes
             internal Action<Index> BeforeRollingIndexFinished;
             internal Action<Index> OnRollingIndexStart;
             internal Action<Index> BeforeRollingIndexStart;
+
+            internal Action<Index> BeforeIndexThreadExit;
             public TestingStuff(IndexStore parent)
             {
                 _parent = parent;

--- a/test/SlowTests/Rolling/RollingIndexesClusterTests.cs
+++ b/test/SlowTests/Rolling/RollingIndexesClusterTests.cs
@@ -1,6 +1,7 @@
 ﻿using System;
 using System.Collections.Concurrent;
 using System.Collections.Generic;
+using System.Diagnostics;
 using System.IO;
 using System.Linq;
 using System.Text;
@@ -21,6 +22,7 @@ using Raven.Server;
 using Raven.Server.ServerWide.Commands.Indexes;
 using Raven.Server.ServerWide.Context;
 using Raven.Server.Utils;
+using Sparrow.Collections;
 using Tests.Infrastructure;
 using Xunit;
 using Xunit.Abstractions;
@@ -231,7 +233,7 @@ namespace SlowTests.Rolling
 
                 await VerifyHistory(cluster, store);
 
-                var count = 0L;
+                var runningIndexes = new ConcurrentSet<Index>();
                 var violation = new StringBuilder();
                 var mre = new ManualResetEventSlim();
                 foreach (var server in Servers)
@@ -246,15 +248,33 @@ namespace SlowTests.Rolling
                         if (index.Name != "ReplacementOf/MyRollingIndex")
                             return;
 
-                        var inc = Interlocked.Increment(ref count);
+                        if (runningIndexes.TryAdd(index) == false)
+                        {
+                            violation.AppendLine($"{index} already exists");
+                        }
+
+                        var inc = runningIndexes.Count;
                         if (inc > 1)
+                        {
                             violation.AppendLine($"{index} started concurrently (count: {inc})");
+                        }
                     };
                     indexStore.ForTestingPurposesOnly().BeforeRollingIndexFinished = index =>
                     {
-                        var dec = Interlocked.Decrement(ref count);
+                        if (runningIndexes.TryRemove(index) == false)
+                        {
+                            violation.AppendLine($"{index} isn't found");
+                        }
+
+                        var dec = runningIndexes.Count;
                         if (dec != 0)
                             violation.AppendLine($"finishing {index} must be zero but is {dec} @ {server.ServerStore.NodeTag}");
+                    };
+
+                    indexStore.ForTestingPurposesOnly().BeforeIndexThreadExit = index =>
+                    {
+                        if (index.IndexingProcessCancellationToken.IsCancellationRequested)
+                            runningIndexes.TryRemove(index);
                     };
                 }
 


### PR DESCRIPTION

### Issue link

https://issues.hibernatingrhinos.com/issue/RavenDB-17822

### Additional description

Take into account different exit path of an index thread

### Type of change

- Test fix

### How risky is the change?

- Low 

### Backward compatibility

- Not relevant

### Is it platform specific issue?

- No

### Documentation update

- No documentation update is needed 

### Testing 

- It has been verified by manual testing
- run the above test in a loop isn't failing anymore (was failing after ~15 runs)

### Is there any existing behavior change of other features due to this change?

- No

### UI work

- No UI work is needed
