### PR TITLE
RavenDB-17789 Flaky performance hint test

### DIFF
--- a/test/SlowTests/Issues/RavenDB_10420.cs
+++ b/test/SlowTests/Issues/RavenDB_10420.cs
@@ -42,7 +42,8 @@ namespace SlowTests.Issues
                 }
 
                 var database = await GetDatabase(store.Database);
-                database.NotificationCenter.Paging.UpdatePaging(null);
+                var outcome = database.NotificationCenter.Paging.UpdatePagingInternal(null, out string reason);
+                Assert.True(outcome, reason);
 
                 int beforeBackupAlertCount;
                 using (database.NotificationCenter.GetStored(out var actions))

--- a/test/SlowTests/Issues/RavenDB_12646.cs
+++ b/test/SlowTests/Issues/RavenDB_12646.cs
@@ -40,7 +40,8 @@ namespace SlowTests.Issues
                 }
 
                 var database = await GetDatabase(store.Database);
-                database.NotificationCenter.Paging.UpdatePaging(null);
+                var outcome = database.NotificationCenter.Paging.UpdatePagingInternal(null, out string reason);
+                Assert.True(outcome, reason);
 
                 int beforeBackupAlertCount;
                 using (database.NotificationCenter.GetStored(out var actions))

--- a/test/SlowTests/Issues/RavenDB_15237.cs
+++ b/test/SlowTests/Issues/RavenDB_15237.cs
@@ -40,7 +40,8 @@ namespace SlowTests.Issues
                 }
 
                 var database = await GetDatabase(store.Database);
-                database.NotificationCenter.Paging.UpdatePaging(null);
+                var outcome = database.NotificationCenter.Paging.UpdatePagingInternal(null, out string reason);
+                Assert.True(outcome, reason);
 
                 int alertCount;
                 using (database.NotificationCenter.GetStored(out var actions))

--- a/test/SlowTests/Issues/RavenDB_17018.cs
+++ b/test/SlowTests/Issues/RavenDB_17018.cs
@@ -197,7 +197,10 @@ namespace SlowTests.Issues
                         .GetFor<Company>("companies/1", pageSize: 4);
                 }
                 var database = await GetDatabase(store.Database);
-                database.NotificationCenter.Paging.UpdatePaging(null);
+                
+                string reason;
+                var outcome = database.NotificationCenter.Paging.UpdatePagingInternal(null, out reason);
+                Assert.True(outcome, reason);
 
                 using (database.NotificationCenter.GetStored(out var actions))
                 {

--- a/test/SlowTests/Issues/RavenDB_17018.cs
+++ b/test/SlowTests/Issues/RavenDB_17018.cs
@@ -46,8 +46,9 @@ namespace SlowTests.Issues
                 }
 
                 var database = await GetDatabase(store.Database);
-                database.NotificationCenter.Paging.UpdatePaging(null);
-
+                var outcome = database.NotificationCenter.Paging.UpdatePagingInternal(null, out string reason);
+                Assert.True(outcome, reason);
+                
                 using (database.NotificationCenter.GetStored(out var actions))
                 {
                     var action = actions.First();
@@ -85,7 +86,10 @@ namespace SlowTests.Issues
                 }
 
                 var database = await GetDatabase(store.Database);
-                database.NotificationCenter.Paging.UpdatePaging(null);
+
+                var outcome = database.NotificationCenter.Paging.UpdatePagingInternal(null, out string reason);
+                Assert.True(outcome, reason);
+
 
                 using (database.NotificationCenter.GetStored(out var actions))
                 {
@@ -129,8 +133,10 @@ namespace SlowTests.Issues
                 }
 
                 var database = await GetDatabase(store.Database);
-                database.NotificationCenter.Paging.UpdatePaging(null);
-
+                
+                var outcome = database.NotificationCenter.Paging.UpdatePagingInternal(null, out string reason);
+                Assert.True(outcome, reason);
+                
                 using (database.NotificationCenter.GetStored(out var actions))
                 {
                     var action = actions.First();
@@ -241,7 +247,8 @@ namespace SlowTests.Issues
                 }
 
                 var database = await GetDatabase(store.Database);
-                database.NotificationCenter.Paging.UpdatePaging(null);
+                var outcome = database.NotificationCenter.Paging.UpdatePagingInternal(null, out string reason);
+                Assert.True(outcome, reason);
 
                 using (database.NotificationCenter.GetStored(out var actions))
                 {

--- a/test/SlowTests/Server/Documents/PeriodicBackup/EncryptedBackupTest.cs
+++ b/test/SlowTests/Server/Documents/PeriodicBackup/EncryptedBackupTest.cs
@@ -865,7 +865,8 @@ namespace SlowTests.Server.Documents.PeriodicBackup
                 }
 
                 var database = await GetDatabase(store.Database);
-                database.NotificationCenter.Paging.UpdatePaging(null);
+                var outcome = database.NotificationCenter.Paging.UpdatePagingInternal(null, out string reason);
+                Assert.True(outcome, reason);
 
                 int beforeBackupAlertCount;
                 using (database.NotificationCenter.GetStored(out var actions))


### PR DESCRIPTION


### Issue link

https://issues.hibernatingrhinos.com/issue/RavenDB-17789

### Additional description

`SlowTests.Issues.RavenDB_17018.ShouldStoreTotalDocumentsSizeInPerformanceHint_ForRevisions` is flaky test that can't be reproduced. Added a addionational check inside the test and modified `UpdatePaging` (added `UpdatePagingInternal`), to make it more informative on failure.

### Type of change

- Bug fix / Debug


### Is it platform specific issue?
- No

### Documentation update
- No documentation update is needed 

### Testing 

- It has been verified by manual testing

### Is there any existing behavior change of other features due to this change?

- No

