### PR TITLE
RavenDB-16969 : flaky tests adjustments

### DIFF
--- a/test/SlowTests/Issues/RavenDB-15588.cs
+++ b/test/SlowTests/Issues/RavenDB-15588.cs
@@ -217,7 +217,7 @@ namespace SlowTests.Issues
             return res.Topology.Rehabs.Count;
         }
 
-        private static async Task<(int MembersCount, int RehabsCount)> GetMembersAndRehabsCount(IDocumentStore store)
+        internal static async Task<(int MembersCount, int RehabsCount)> GetMembersAndRehabsCount(IDocumentStore store)
         {
             var dbRecord = await store.Maintenance.Server.SendAsync(new GetDatabaseRecordOperation(store.Database));
             var topology = dbRecord.Topology;

--- a/test/SlowTests/Issues/RavenDB-15625.cs
+++ b/test/SlowTests/Issues/RavenDB-15625.cs
@@ -93,17 +93,8 @@ namespace SlowTests.Issues
                 record.Topology.Rehabs.Add(Servers[2].ServerStore.NodeTag);
                 await store.Maintenance.Server.SendAsync(new UpdateDatabaseOperation(record, record.Etag));
 
-                var rehabs = await WaitForValueAsync(async () => await GetRehabCount(store, store.Database), 1);
-                Assert.Equal(1, rehabs);
-
-                var val = await WaitForValueAsync(async () => await GetMembersCount(store, database), 2);
-                Assert.Equal(2, val);
-
-                val = await WaitForValueAsync(async () => await GetMembersCount(store, store.Database), 3);
-                Assert.Equal(3, val);
-
-                rehabs = await WaitForValueAsync(async () => await GetRehabCount(store, store.Database), 0);
-                Assert.Equal(0, rehabs);
+                await WaitAndAssertForValueAsync(async () => await RavenDB_15588.GetMembersAndRehabsCount(store), expectedVal: (MembersCount: 2, RehabsCount: 1));
+                await WaitAndAssertForValueAsync(async () => await RavenDB_15588.GetMembersAndRehabsCount(store), expectedVal: (MembersCount: 3, RehabsCount: 0));
             }
         }
 
@@ -151,17 +142,8 @@ namespace SlowTests.Issues
                 record.Topology.Rehabs.Add(Servers[2].ServerStore.NodeTag);
                 await store.Maintenance.Server.SendAsync(new UpdateDatabaseOperation(record, record.Etag));
 
-                var rehabs = await WaitForValueAsync(async () => await GetRehabCount(store, store.Database), 1);
-                Assert.Equal(1, rehabs);
-
-                var val = await WaitForValueAsync(async () => await GetMembersCount(store, database), 2);
-                Assert.Equal(2, val);
-
-                val = await WaitForValueAsync(async () => await GetMembersCount(store, store.Database), 3);
-                Assert.Equal(3, val);
-
-                rehabs = await WaitForValueAsync(async () => await GetRehabCount(store, store.Database), 0);
-                Assert.Equal(0, rehabs);
+                await WaitAndAssertForValueAsync(async () => await RavenDB_15588.GetMembersAndRehabsCount(store), expectedVal: (MembersCount: 2, RehabsCount: 1));
+                await WaitAndAssertForValueAsync(async () => await RavenDB_15588.GetMembersAndRehabsCount(store), expectedVal: (MembersCount: 3, RehabsCount: 0));
             }
         }
 


### PR DESCRIPTION
### Issue link

https://issues.hibernatingrhinos.com/issue/RavenDB-16969
https://issues.hibernatingrhinos.com/issue/RavenDB-16873

### Additional description

assert members and rehabs count in a single operation, in order to avoid db-topology change in between 2 calls

