### PR TITLE
RavenDB-17862: don't fail subscription worker if MaxErroneousPeriod was spent in Registering SubscriptionConnection

### DIFF
--- a/src/Raven.Client/Documents/Subscriptions/SubscriptionWorkerOptions.cs
+++ b/src/Raven.Client/Documents/Subscriptions/SubscriptionWorkerOptions.cs
@@ -61,6 +61,7 @@ namespace Raven.Client.Documents.Subscriptions
             public string CurrentTag;
             public string RedirectedTag;
             public Dictionary<string, string> Reasons;
+            public long? RegisterConnectionDurationInTicks;
         }
 
         public MessageType Type { get; set; }

--- a/src/Raven.Client/Exceptions/Documents/Subscriptions/SubscriptionDoesNotBelongToNodeException.cs
+++ b/src/Raven.Client/Exceptions/Documents/Subscriptions/SubscriptionDoesNotBelongToNodeException.cs
@@ -7,6 +7,7 @@ namespace Raven.Client.Exceptions.Documents.Subscriptions
     {
         public string AppropriateNode;
         internal long Index;
+        internal long? RegisterConnectionDurationInTicks;
         public readonly Dictionary<string, string> Reasons = new Dictionary<string, string>();
 
         public SubscriptionDoesNotBelongToNodeException(string message) : base(message)

--- a/src/Raven.Server/Documents/DocumentDatabase.cs
+++ b/src/Raven.Server/Documents/DocumentDatabase.cs
@@ -65,7 +65,7 @@ namespace Raven.Server.Documents
         private readonly Action<string> _addToInitLog;
         private readonly Logger _logger;
         private readonly DisposeOnce<SingleAttempt> _disposeOnce;
-        private TestingStuff _forTestingPurposes;
+        internal TestingStuff _forTestingPurposes;
 
         private readonly CancellationTokenSource _databaseShutdown = new CancellationTokenSource();
 
@@ -1784,6 +1784,22 @@ namespace Raven.Server.Documents
                 ActionToCallDuringDocumentDatabaseInternalDispose = action;
 
                 return new DisposableAction(() => ActionToCallDuringDocumentDatabaseInternalDispose = null);
+            }
+
+            internal Action Subscription_ActionToCallDuringWaitForChangedDocuments;
+            internal Action<long> Subscription_ActionToCallAfterRegisterSubscriptionConnection;
+
+            internal IDisposable CallDuringWaitForChangedDocuments(Action action)
+            {
+                Subscription_ActionToCallDuringWaitForChangedDocuments = action;
+
+                return new DisposableAction(() => Subscription_ActionToCallDuringWaitForChangedDocuments = null);
+            }
+            internal IDisposable CallAfterRegisterSubscriptionConnection(Action<long> action)
+            {
+                Subscription_ActionToCallAfterRegisterSubscriptionConnection = action;
+
+                return new DisposableAction(() => Subscription_ActionToCallAfterRegisterSubscriptionConnection = null);
             }
         }
     }

--- a/src/Raven.Server/Documents/Subscriptions/SubscriptionStorage.cs
+++ b/src/Raven.Server/Documents/Subscriptions/SubscriptionStorage.cs
@@ -131,7 +131,7 @@ namespace Raven.Server.Documents.Subscriptions
             return _db.WhoseTaskIsIt(topology, subscription, subscription);
         }
 
-        public async Task<SubscriptionState> AssertSubscriptionConnectionDetails(long id, string name, CancellationToken token)
+        public async Task<SubscriptionState> AssertSubscriptionConnectionDetails(long id, string name, long? registerConnectionDurationInTicks, CancellationToken token)
         {
             await _serverStore.WaitForCommitIndexChange(RachisConsensus.CommitIndexModification.GreaterOrEqual, id, token);
 
@@ -188,7 +188,10 @@ namespace Raven.Server.Documents.Subscriptions
                     throw new SubscriptionDoesNotBelongToNodeException(
                         $"Subscription with id {id} and name {name} can't be processed on current node ({_serverStore.NodeTag}), because it belongs to {whoseTaskIsIt}",
                         whoseTaskIsIt,
-                        databaseTopologyAvailabilityExplanation, id);
+                        databaseTopologyAvailabilityExplanation, id)
+                    {
+                        RegisterConnectionDurationInTicks = registerConnectionDurationInTicks
+                    };
                 }
                 if (subscription.Disabled)
                     throw new SubscriptionClosedException($"The subscription with id {id} and name {name} is disabled and cannot be used until enabled");

--- a/src/Raven.Server/Documents/TcpHandlers/SubscriptionConnection.cs
+++ b/src/Raven.Server/Documents/TcpHandlers/SubscriptionConnection.cs
@@ -139,7 +139,7 @@ namespace Raven.Server.Documents.TcpHandlers
             }
 
             // first, validate details and make sure subscription exists
-            SubscriptionState = await TcpConnection.DocumentDatabase.SubscriptionStorage.AssertSubscriptionConnectionDetails(SubscriptionId, _options.SubscriptionName, CancellationTokenSource.Token);
+            SubscriptionState = await TcpConnection.DocumentDatabase.SubscriptionStorage.AssertSubscriptionConnectionDetails(SubscriptionId, _options.SubscriptionName, registerConnectionDurationInTicks: null, CancellationTokenSource.Token);
 
             if (_supportedFeatures.Subscription.Includes == false)
             {
@@ -154,6 +154,7 @@ namespace Raven.Server.Documents.TcpHandlers
             bool shouldRetry;
 
             var random = new Random();
+            var registerConnectionDuration = Stopwatch.StartNew();
 
             do
             {
@@ -166,7 +167,7 @@ namespace Raven.Server.Documents.TcpHandlers
                 }
                 catch (TimeoutException)
                 {
-                    if (timeout == InitialConnectionTimeout && _logger.IsInfoEnabled)
+                    if (_logger.IsInfoEnabled)
                     {
                         _logger.Info(
                             $"Subscription Id {SubscriptionId} from IP {TcpConnection.TcpClient.Client.RemoteEndPoint} starts to wait until previous connection from {_connectionState.Connection?.TcpConnection.TcpClient.Client.RemoteEndPoint} is released");
@@ -178,10 +179,13 @@ namespace Raven.Server.Documents.TcpHandlers
                 }
             } while (shouldRetry);
 
+            registerConnectionDuration.Stop();
             try
             {
+                TcpConnection.DocumentDatabase._forTestingPurposes?.Subscription_ActionToCallAfterRegisterSubscriptionConnection?.Invoke(registerConnectionDuration.ElapsedTicks);
+
                 // refresh subscription data (change vector may have been updated, because in the meanwhile, another subscription could have just completed a batch)
-                SubscriptionState = await TcpConnection.DocumentDatabase.SubscriptionStorage.AssertSubscriptionConnectionDetails(SubscriptionId, _options.SubscriptionName, CancellationTokenSource.Token);
+                SubscriptionState = await TcpConnection.DocumentDatabase.SubscriptionStorage.AssertSubscriptionConnectionDetails(SubscriptionId, _options.SubscriptionName, registerConnectionDuration.ElapsedTicks, CancellationTokenSource.Token);
 
                 Subscription = ParseSubscriptionQuery(SubscriptionState.Query);
 
@@ -398,6 +402,7 @@ namespace Raven.Server.Documents.TcpHandlers
                         {
                             [nameof(SubscriptionConnectionServerMessage.SubscriptionRedirectData.RedirectedTag)] = subscriptionDoesNotBelongException.AppropriateNode,
                             [nameof(SubscriptionConnectionServerMessage.SubscriptionRedirectData.CurrentTag)] = connection.TcpConnection.DocumentDatabase.ServerStore.NodeTag,
+                            [nameof(SubscriptionConnectionServerMessage.SubscriptionRedirectData.RegisterConnectionDurationInTicks)] = subscriptionDoesNotBelongException.RegisterConnectionDurationInTicks,
                             [nameof(SubscriptionConnectionServerMessage.SubscriptionRedirectData.Reasons)] =
                                 new DynamicJsonArray(subscriptionDoesNotBelongException.Reasons.Select(item => new DynamicJsonValue
                                 {
@@ -868,6 +873,8 @@ namespace Raven.Server.Documents.TcpHandlers
             {
                 var hasMoreDocsTask = _waitForMoreDocuments.WaitAsync();
                 var resultingTask = await Task.WhenAny(hasMoreDocsTask, pendingReply, TimeoutManager.WaitFor(TimeSpan.FromMilliseconds(WaitForChangedDocumentsTimeoutInMs))).ConfigureAwait(false);
+
+                TcpConnection.DocumentDatabase._forTestingPurposes?.Subscription_ActionToCallDuringWaitForChangedDocuments?.Invoke();
 
                 if (CancellationTokenSource.IsCancellationRequested)
                     return false;

--- a/test/SlowTests/Client/Subscriptions/SubscriptionsBasic.cs
+++ b/test/SlowTests/Client/Subscriptions/SubscriptionsBasic.cs
@@ -9,6 +9,7 @@ using FastTests.Client.Subscriptions;
 using Raven.Client.Documents.Operations.Backups;
 using Raven.Client.Documents.Smuggler;
 using Raven.Client.Documents.Subscriptions;
+using Raven.Client.Exceptions.Documents.Subscriptions;
 using Raven.Client.Extensions;
 using Raven.Server.Documents.Replication;
 using Raven.Server.Documents.Subscriptions;
@@ -404,6 +405,108 @@ namespace SlowTests.Client.Subscriptions
                var status= WaitForValue(() => t.Status, TaskStatus.RanToCompletion);
                 Assert.Equal(TaskStatus.RanToCompletion, status);
                 Assert.True(t.IsCompletedSuccessfully, "t.IsCompletedSuccessfully");
+            }
+        }
+
+        [Fact]
+        public async Task Worker_should_consider_RegisterSubscriptionConnection_time_on_calculation_of_LastConnectionFailure()
+        {
+            DoNotReuseServer();
+            var maxErroneousPeriod = TimeSpan.FromSeconds(1);
+            using (var store = GetDocumentStore())
+            {
+                var id1 = store.Subscriptions.Create(new SubscriptionCreationOptions<Company>());
+                var workerOptions1 = new SubscriptionWorkerOptions(id1) { Strategy = SubscriptionOpeningStrategy.WaitForFree, MaxErroneousPeriod = maxErroneousPeriod };
+
+                var worker1Ack = new AsyncManualResetEvent();
+                var worker1Retry = new AsyncManualResetEvent();
+                using var worker1 = store.Subscriptions.GetSubscriptionWorker<Company>(workerOptions1, store.Database);
+                worker1.AfterAcknowledgment += _ =>
+                {
+                    worker1Ack.Set();
+                    return Task.CompletedTask;
+                };
+                worker1.OnSubscriptionConnectionRetry += exception =>
+                {
+                    worker1Retry.Set();
+                };
+                var t1 = worker1.Run(x => { });
+
+                using (var session = store.OpenSession())
+                {
+                    session.Store(new Company());
+                    session.SaveChanges();
+                }
+                await worker1Ack.WaitAsync(_reasonableWaitTime);
+
+                var worker2Ack = new AsyncManualResetEvent();
+                var worker2Retry = new ManualResetEvent(false);
+                using var worker2 = store.Subscriptions.GetSubscriptionWorker<Company>(workerOptions1, store.Database);
+                worker2.OnSubscriptionConnectionRetry += exception =>
+                {
+                    worker2Retry.Set();
+                };
+                worker2.AfterAcknowledgment += _ =>
+                {
+                    worker2Ack.Set();
+                    return Task.CompletedTask;
+                };
+
+                var t2 = worker2.Run(x => { });
+
+                var db = await GetDocumentDatabaseInstanceFor(store);
+                var testingStuff = db.ForTestingPurposesOnly();
+
+                var worker1Interrupt = new AsyncManualResetEvent();
+                using (testingStuff.CallDuringWaitForChangedDocuments(() =>
+                       {
+                           worker1Interrupt.Set();
+                           throw new SubscriptionDoesNotBelongToNodeException($"DROPPED BY TEST") { AppropriateNode = null };
+                       }))
+                {
+                    await worker1Interrupt.WaitAsync(_reasonableWaitTime);
+                }
+
+                await worker1Retry.WaitAsync(_reasonableWaitTime);
+                using (var session = store.OpenSession())
+                {
+                    session.Store(new Company());
+                    session.SaveChanges();
+                }
+
+                await worker2Ack.WaitAsync(_reasonableWaitTime);
+                await Task.Delay(maxErroneousPeriod * 2);
+
+                var worker1AfterRegisterSubscriptionConnection = new AsyncManualResetEvent();
+                worker1Interrupt.Reset(true);
+                var failed = false;
+                using (testingStuff.CallAfterRegisterSubscriptionConnection(time =>
+                       {
+                           if (worker2Retry.WaitOne(_reasonableWaitTime) == false)
+                           {
+                               failed = true;
+                           }
+                           worker1Retry.Reset(true);
+                           worker1AfterRegisterSubscriptionConnection.Set();
+                           throw new SubscriptionDoesNotBelongToNodeException($"DROPPED BY TEST") { AppropriateNode = null, RegisterConnectionDurationInTicks = time };
+                       }))
+                {
+                    using (testingStuff.CallDuringWaitForChangedDocuments(() =>
+                           {
+                               worker1Interrupt.Set();
+                               throw new SubscriptionDoesNotBelongToNodeException($"DROPPED BY TEST") { AppropriateNode = null };
+                           }))
+                    {
+                       Assert.True(await worker1Interrupt.WaitAsync(_reasonableWaitTime));
+                    }
+
+                    await worker1AfterRegisterSubscriptionConnection.WaitAsync(_reasonableWaitTime);
+                }
+                Assert.False(failed, "failed");
+
+                Assert.True(await worker1Retry.WaitAsync(_reasonableWaitTime));
+                Assert.False(t1.IsFaulted);
+                Assert.False(t2.IsFaulted);
             }
         }
     }


### PR DESCRIPTION
### Issue link

https://issues.hibernatingrhinos.com/issue/RavenDB-17862

### Additional description

don't fail subscription worker if MaxErroneousPeriod was spent in Registering SubscriptionConnection

_Please delete below the options that are not relevant_

### Type of change

- Bug fix


### How risky is the change?

- Low 


### Backward compatibility


- Not relevant

### Is it platform specific issue?


- No

### Documentation update

- No documentation update is needed 

### Testing 

- Tests have been added that prove the fix is effective or that the feature works
 - Internal classes added to the test class (e.g. entity or index definition classes) have the lowest possible access modifier (preferable `private`) 
- It has been verified by manual testing

### Is there any existing behavior change of other features due to this change?

- No

### UI work

- No UI work is needed
