### PR TITLE
RavenDB-17795 - Verify for filtered replication that we skip documents properly when prevent deletion is enabled

### DIFF
--- a/src/Raven.Server/Documents/Replication/ReplicationDocumentSender.cs
+++ b/src/Raven.Server/Documents/Replication/ReplicationDocumentSender.cs
@@ -607,9 +607,9 @@ namespace Raven.Server.Documents.Replication
             if (ValidatorSaysToSkip(_pathsToSend) || ValidatorSaysToSkip(_destinationAcceptablePaths))
                 return true;
 
-            if (_shouldSkipSendingTombstones)
+            if (_shouldSkipSendingTombstones && ReplicationLoader.IsOfTypePreventDeletions(item))
             {
-                return ReplicationLoader.IsOfTypePreventDeletions(item);
+                return true;
             }
 
             switch (item)


### PR DESCRIPTION
### Issue link

https://issues.hibernatingrhinos.com/issue/RavenDB-17795

### Type of change

- Bug fix

### How risky is the change?

- Low

### Backward compatibility

- Not relevant

### Is it platform specific issue?

- No

### Documentation update

- No documentation update is needed 

### Testing 

- Tests have been added that prove the fix is effective or that the feature works

### Is there any existing behavior change of other features due to this change?

- No

### UI work

- No UI work is needed
