### PR TITLE
RavenDB-17877 - fix documents that aren't saved to the same shard

### DIFF
--- a/src/Raven.Server/Documents/Sharding/ShardedContext.cs
+++ b/src/Raven.Server/Documents/Sharding/ShardedContext.cs
@@ -75,7 +75,7 @@ namespace Raven.Server.Documents.Sharding
                 if (ptr[i] != expected)
                     continue;
                 ptr += i + 1;
-                len -= i - 1;
+                len -= i + 1;
                 break;
             }
         }


### PR DESCRIPTION
### Issue link

https://issues.hibernatingrhinos.com/issue/RavenDB-17877

### Additional description

Fix documents aren't saved to the same shard

### Type of change

- Bug fix

### How risky is the change?

- Low 

### Testing 

- Tests have been added that prove the fix is effective or that the feature works
