### PR TITLE
RavenDB-17818 Let's filter out 404 (index_not_found_exception) response on cleaning indexex - since index doesn't exist that's okay anyway. Adding more Refresh() to ensure ES indexes are up to date.

### DIFF
--- a/test/SlowTests/Server/Documents/ETL/Elasticsearch/ElasticSearchEtlTestBase.cs
+++ b/test/SlowTests/Server/Documents/ETL/Elasticsearch/ElasticSearchEtlTestBase.cs
@@ -93,10 +93,19 @@ namespace SlowTests.Server.Documents.ETL.ElasticSearch
 
         protected void CleanupIndexes(ElasticClient client)
         {
+            client.Indices.Refresh();
+
             var response = client.Indices.Delete(Indices.All);
 
             if (response.IsValid == false)
+            {
+                if (response.ServerError?.Status == 404)
+                    return;
+
                 throw new InvalidOperationException($"Failed to cleanup indexes: {response.ServerError}", response.OriginalException);
+            }
+
+            client.Indices.Refresh();
         }
 
         protected void AssertEtlDone(ManualResetEventSlim etlDone, TimeSpan timeout, string databaseName, ElasticSearchEtlConfiguration config)

--- a/test/SlowTests/Server/Documents/ETL/Elasticsearch/ElasticSearchEtlTests.cs
+++ b/test/SlowTests/Server/Documents/ETL/Elasticsearch/ElasticSearchEtlTests.cs
@@ -145,7 +145,7 @@ loadToOrders(orderData);
 
                 var ordersCount = client.Count<object>(c => c.Index(OrderIndexName));
                 var orderLinesCount = client.Count<object>(c => c.Index(OrderLinesIndexName));
-
+                
                 Assert.Equal(numberOfOrders, ordersCount.Count);
                 Assert.Equal(numberOfOrders * numberOfLinesPerOrder, orderLinesCount.Count);
 
@@ -363,6 +363,8 @@ loadToOrders(orderData);
 
                 AssertEtlDone(etlDone, TimeSpan.FromMinutes(1), store.Database, config);
 
+                client.Indices.Refresh(OrderIndexName);
+
                 var orderResponse = client.Search<object>(d => d
                     .Index(OrderIndexName)
                     .Query(q => q
@@ -398,6 +400,8 @@ loadToOrders(orderData);
                 }
 
                 AssertEtlDone(etlDone, TimeSpan.FromMinutes(2), store.Database, config);
+
+                client.Indices.Refresh(OrderIndexName);
 
                 var orderResponse1 = client.Search<object>(d => d
                     .Index(OrderIndexName)


### PR DESCRIPTION
### Issue link

https://issues.hibernatingrhinos.com/issue/RavenDB-17818

### Additional description

Explicitly ignoring 404 - index not found response on delete indexes (not sure how that could happen but should be no-op for us since it's already deleted). 

### Type of change

- Test fix

### How risky is the change?

- Low 

### Backward compatibility

- Not relevant

### Is it platform specific issue?

- No

### Documentation update

- No documentation update is needed 

### Testing 

- It's gonna be verified by tests on CI

### Is there any existing behavior change of other features due to this change?

- No

### UI work

- No UI work is needed
