### PR TITLE
RavenDB-17742 - SlowTests.Voron.Storage.StorageReportGenerationTests.…

### DIFF
--- a/test/SlowTests/Voron/Storage/StorageReportGenerationTests.cs
+++ b/test/SlowTests/Voron/Storage/StorageReportGenerationTests.cs
@@ -439,7 +439,7 @@ namespace SlowTests.Voron.Storage
                 var streamsSizeInMb = new Size(treeReport.Streams.Streams[0].AllocatedSpaceInBytes, SizeUnit.Bytes).GetValue(SizeUnit.Megabytes);
                 var fullStreamsSizeInMb = new Size(fullTreeReport.Streams.AllocatedSpaceInBytes, SizeUnit.Bytes).GetValue(SizeUnit.Megabytes);
                 
-                Assert.Equal(streamsSizeInMb,fullStreamsSizeInMb);
+                Assert.True(streamsSizeInMb == fullStreamsSizeInMb || streamsSizeInMb + 1 == fullStreamsSizeInMb || streamsSizeInMb - 1 == fullStreamsSizeInMb);
             }
         }
 


### PR DESCRIPTION
…TreeReportContainsPartialInfoAboutStreams(numberOfStreams: 5, seed: 897061618)

### Issue link

https://issues.hibernatingrhinos.com/issue/RavenDB-17742

### Additional description

Changed the assertion condition in the test  

### Type of change

- Bug fix

### How risky is the change?

- Low 

### Backward compatibility

- Non breaking change

### Is it platform specific issue?

- No

### Documentation update

- No documentation update is needed 

### Testing 

- It has been verified by manual testing

### Is there any existing behavior change of other features due to this change?

- No

### UI work

- No UI work is needed
