### PR TITLE
RavenDB-17882 Prevent from looping indefinitely and dispose PgServer when RavenServer is disposed.

### DIFF
--- a/src/Raven.Server/Integrations/PostgreSQL/Messages/MessageReader.cs
+++ b/src/Raven.Server/Integrations/PostgreSQL/Messages/MessageReader.cs
@@ -135,6 +135,14 @@ namespace Raven.Server.Integrations.PostgreSQL.Messages
             {
                 reader.AdvanceTo(read.Buffer.Start, read.Buffer.End);
                 read = await reader.ReadAsync(token);
+                
+                if (read.Buffer.Length < minSizeRequired && read.IsCompleted)
+                {
+                    // we aren't making progress and nothing else will be forthcoming
+
+                    throw new PgErrorException(PgErrorCodes.ProtocolViolation,
+                        $"Expected to read at least {minSizeRequired} but got {read.Buffer.Length} and the pipe is already closed");
+                }
             }
 
             return read;

--- a/src/Raven.Server/Integrations/PostgreSQL/PgServer.cs
+++ b/src/Raven.Server/Integrations/PostgreSQL/PgServer.cs
@@ -112,7 +112,7 @@ namespace Raven.Server.Integrations.PostgreSQL
             {
                 try
                 {
-                    task.Wait();
+                    task.Wait(TimeSpan.FromSeconds(3));
                 }
                 catch (OperationCanceledException)
                 {

--- a/src/Raven.Server/RavenServer.cs
+++ b/src/Raven.Server/RavenServer.cs
@@ -2660,6 +2660,7 @@ namespace Raven.Server
                 {
                     ea.Execute(() => CloseTcpListeners(_tcpListenerStatus.Listeners));
                 }
+                ea.Execute(() => PostgresServer?.Dispose());
 
                 ea.Execute(() => ServerStore?.Dispose());
                 ea.Execute(() =>


### PR DESCRIPTION
### Issue link

https://issues.hibernatingrhinos.com/issue/RavenDB-17882

### Additional description

It's related to `MustNotConnectToToSecuredServerWithoutProvidingValidCredentials` test that leaked the task. Found during investigation of https://issues.hibernatingrhinos.com/issue/RavenDB-17874 (not sure if that could be the reason of crashes during the tests).

### Type of change

- Bug fix

### How risky is the change?

- Moderate 

### Backward compatibility

- Not relevant

### Is it platform specific issue?

- No

### Documentation update

- No documentation update is needed 

### Testing 

- Existing tests verify that nothing is broken
- It has bee verified manually (VS - parallel stacks) that we no longer heave a leaked task after executing `MustNotConnectToToSecuredServerWithoutProvidingValidCredentials` test

### Is there any existing behavior change of other features due to this change?

- No

### UI work

- No UI work is needed
