### PR TITLE
RavenDB-17878 Resend the entire report if previous message was a timeout

### DIFF
--- a/src/Raven.Server/ServerWide/Maintenance/ClusterMaintenanceSupervisor.cs
+++ b/src/Raven.Server/ServerWide/Maintenance/ClusterMaintenanceSupervisor.cs
@@ -34,6 +34,66 @@ namespace Raven.Server.ServerWide.Maintenance
         internal readonly ClusterConfiguration Config;
         private readonly ServerStore _server;
 
+        internal TestingStuff ForTestingPurposes;
+
+        internal TestingStuff ForTestingPurposesOnly()
+        {
+            if (ForTestingPurposes != null)
+                return ForTestingPurposes;
+
+            return ForTestingPurposes = new TestingStuff();
+        }
+
+        internal class TestingStuff
+        {
+            internal Action<ClusterNode> NoChangeFoundAction;
+            internal Action<ClusterNode> BeforeReportBuildAction;
+            internal Action<ClusterNode> AfterSettingReportAction;
+
+            private TriggerState _currentState;
+            private ClusterNode _currentClusterNode;
+
+            internal void SetTriggerTimeoutAfterNoChangeAction(string tag)
+            {
+                AfterSettingReportAction = BeforeReportBuildAction = NoChangeFoundAction = (node) =>
+                {
+                    if (node.ClusterTag != tag)
+                        return;
+
+                    if (_currentClusterNode != node)
+                    {
+                        _currentClusterNode = node;
+                        _currentState = TriggerState.None;
+                    }
+
+                    switch (_currentState)
+                    {
+                        case TriggerState.None:
+                            _currentState = TriggerState.Ready;
+                            break;
+                        case TriggerState.Ready:
+                            _currentState = TriggerState.Armed;
+                            break;
+                        case TriggerState.Armed:
+                            node.OnTimeout();
+                            _currentState = TriggerState.Fired;
+                            break;
+                        case TriggerState.Fired:
+                            break;
+                        default:
+                            throw new ArgumentOutOfRangeException();
+                    }
+                };
+            }
+            private enum TriggerState
+            {
+                None,
+                Ready,
+                Armed,
+                Fired
+            }
+        }
+
         public ClusterMaintenanceSupervisor(ServerStore server, string leaderClusterTag, long term)
         {
             _leaderClusterTag = leaderClusterTag;
@@ -254,14 +314,18 @@ namespace Raven.Server.ServerWide.Maintenance
                                     break;
                                 }
 
+                                _parent.ForTestingPurposes?.BeforeReportBuildAction(this);
+
                                 var nodeReport = BuildReport(rawReport, connection.SupportedFeatures);
                                 timeoutEvent.Defer(_parent._leaderClusterTag);
+
 
                                 UpdateNodeReportIfNeeded(nodeReport, unchangedReports);
                                 unchangedReports.Clear();
 
                                 ReceivedReport = _lastSuccessfulReceivedReport = nodeReport;
 
+                                _parent.ForTestingPurposes?.AfterSettingReportAction(this);
                             }
                         }
                     }
@@ -286,18 +350,12 @@ namespace Raven.Server.ServerWide.Maintenance
 
             private void UpdateNodeReportIfNeeded(ClusterNodeStatusReport nodeReport, List<DatabaseStatusReport> unchangedReports)
             {
-                // we take the last received and not the last successful.
-                // we don't want to reuse by miskate a successful report when we recieve an 'unchanged' error.
-                var lastReport = ReceivedReport;
-                if (lastReport.Status != ClusterNodeStatusReport.ReportStatus.Ok)
-                {
-                    return;
-                }
-
                 foreach (var dbReport in nodeReport.Report)
                 {
                     if (dbReport.Value.Status == DatabaseStatus.NoChange)
                     {
+                        _parent.ForTestingPurposes?.NoChangeFoundAction(this);
+                        
                         unchangedReports.Add(dbReport.Value);
                     }
                 }
@@ -305,22 +363,31 @@ namespace Raven.Server.ServerWide.Maintenance
                 if (unchangedReports.Count == 0)
                     return;
 
+                // we take the last received and not the last successful.
+                // we don't want to reuse by mistake a successful report when we receive an 'unchanged' error.
+                var lastReport = ReceivedReport;
+                if (lastReport.Status != ClusterNodeStatusReport.ReportStatus.Ok)
+                {
+                    throw new InvalidOperationException(
+                        $"We have databases with '{DatabaseStatus.NoChange}' status, but our last report from this node is '{lastReport.Status}'");
+                }
+
                 foreach (var dbReport in unchangedReports)
                 {
                     var dbName = dbReport.Name;
                     if (lastReport.Report.TryGetValue(dbName, out var previous) == false)
                     {
-                        // new db, shouldn't really be the case, but not much we can do, we'll
-                        // show it to the user as is
-                        continue;
+                        throw new InvalidOperationException(
+                            $"We got '{DatabaseStatus.NoChange}' for the database '{dbReport}', but it is missing in the last good report");
                     }
+
                     previous.LastSentEtag = dbReport.LastSentEtag;
                     previous.UpTime = dbReport.UpTime;
                     nodeReport.Report[dbName] = previous;
                 }
             }
 
-            private void OnTimeout()
+            internal void OnTimeout()
             {
                 if (_token.IsCancellationRequested)
                     return;

--- a/test/RachisTests/DatabaseCluster/ClusterDatabaseMaintenance.cs
+++ b/test/RachisTests/DatabaseCluster/ClusterDatabaseMaintenance.cs
@@ -5,6 +5,7 @@ using System.Linq;
 using System.Threading;
 using System.Threading.Tasks;
 using FastTests;
+using FastTests.Server.Basic;
 using FastTests.Server.Replication;
 using FastTests.Utils;
 using Raven.Client.Documents;
@@ -24,6 +25,7 @@ using Raven.Server.Rachis;
 using Raven.Server.ServerWide;
 using Raven.Server.ServerWide.Commands;
 using Raven.Server.ServerWide.Context;
+using Raven.Server.ServerWide.Maintenance;
 using Raven.Server.Utils;
 using Tests.Infrastructure;
 using Xunit;
@@ -209,6 +211,45 @@ namespace RachisTests.DatabaseCluster
                 val = await WaitForValueAsync(async () => await GetMembersCount(store), 3);
                 Assert.Equal(3, val);
 
+            }
+        }
+
+        [Fact]
+        public async Task DontMoveToRehabOnNoChangeAfterTimeout()
+        {
+            var clusterSize = 3;
+            DebuggerAttachedTimeout.DisableLongTimespan = true;
+            
+            DefaultClusterSettings[RavenConfiguration.GetKey(x => x.Cluster.MaxChangeVectorDistance)] = "1";
+            DefaultClusterSettings[RavenConfiguration.GetKey(x => x.Cluster.SupervisorSamplePeriod)] = "50";
+            DefaultClusterSettings[RavenConfiguration.GetKey(x => x.Cluster.OnErrorDelayTime)] = "15";
+            DefaultClusterSettings[RavenConfiguration.GetKey(x => x.Cluster.WorkerSamplePeriod)] = "25";
+
+            var cluster = await CreateRaftCluster(clusterSize, watcherCluster: true);
+            using (var store = GetDocumentStore(new Options
+                   {
+                       ReplicationFactor = 3, 
+                       Server = cluster.Leader,
+                   }))
+            {
+                using (var session = store.OpenAsyncSession())
+                {
+                    session.Advanced.WaitForReplicationAfterSaveChanges(replicas: 2);
+                    await session.StoreAsync(new User(), "users/1");
+                    await session.StoreAsync(new User(), "users/2");
+                    await session.SaveChangesAsync();
+
+                    var q = await session.Query<User>().Where(u => u.Name == "foo").ToListAsync();
+                }
+
+                WaitForIndexingInTheCluster(store);
+
+                cluster.Leader.ServerStore.ClusterMaintenanceSupervisor.ForTestingPurposesOnly().SetTriggerTimeoutAfterNoChangeAction("B");
+
+                await Task.Delay(2 * 1000); // twice the StabilizationTime
+
+                var members = await GetMembersCount(store);
+                Assert.Equal(3, members);
             }
         }
 


### PR DESCRIPTION
### Issue link

https://issues.hibernatingrhinos.com/issue/RavenDB-17878

### Additional description

If the cluster maintenance supervisor got a timeout and afterwards got a report with `NoChange` in it. It would set the default values and never recover until the database had some change.

In this case the database change vector was set to `null` so the cluster observer moved the node into rehab because of "lagging behind".

The fix is, that if we recognize such case, we throw and get a full report next time.

### Type of change

- Bug fix

### How risky is the change?

- Low - Moderate 


### Backward compatibility

- Not relevant

### Is it platform specific issue?

- No

### Documentation update

- No documentation update is needed 

### Testing 

- Tests have been added that prove the fix is effective or that the feature works
 - Internal classes added to the test class (e.g. entity or index definition classes) have the lowest possible access modifier 

### Is there any existing behavior change of other features due to this change?

- No

### UI work

- No UI work is needed
