### PR TITLE
RavenDB-17823 Additional info for failing test

### DIFF
--- a/test/RachisTests/DatabaseCluster/AtomicClusterReadWriteTests.cs
+++ b/test/RachisTests/DatabaseCluster/AtomicClusterReadWriteTests.cs
@@ -239,11 +239,31 @@ namespace RachisTests.DatabaseCluster
                 await documentStore.Smuggler.ImportIncrementalAsync(new DatabaseSmugglerImportOptions(), Directory.GetDirectories(backupPath).First());
             }
 
-            await AssertClusterWaitForNotNull(nodes, documentStore.Database, async s =>
+            // await AssertClusterWaitForNotNull(nodes, documentStore.Database, async s =>
+            // {
+            //     using var session = s.OpenAsyncSession();
+            //     return await session.LoadAsync<TestObj>(notDelete);
+            // });
+            
+            //Additional information for investigating RavenDB-17823 
             {
-                using var session = s.OpenAsyncSession();
-                return await session.LoadAsync<TestObj>(notDelete);
-            });
+                var waitResults = await ClusterWaitForNotNull(nodes, documentStore.Database, async s =>
+                {
+                    using var session = s.OpenAsyncSession();
+                    return await session.LoadAsync<TestObj>(notDelete);
+                });
+                var nullCount = waitResults.Count(r => r == null);
+                if (nullCount != 0)
+                {
+                    var results = await ClusterWaitFor(nodes, documentStore.Database, async s =>
+                    {
+                        using var session = s.OpenAsyncSession();
+                        return (await session.LoadAsync<TestObj>(notDelete), await session.Query<TestObj>().CountAsync());
+                    });
+
+                    Assert.True(false, string.Join("\n", results.Select((r => $"is notDelete null:{r.Item1 == null}, actual count {r.Item2}, expected {count}"))));
+                }
+            }
 
             await AssertWaitForCountAsync(async () => await documentStore.Operations.SendAsync(new GetCompareExchangeValuesOperation<TestObj>("")), count + 1);
         }

--- a/test/Tests.Infrastructure/ClusterTestBase.cs
+++ b/test/Tests.Infrastructure/ClusterTestBase.cs
@@ -579,6 +579,15 @@ namespace Tests.Infrastructure
         {
             return await ClusterWaitFor(nodes, database, s => AssertWaitForNotNullAsync(() => act(s), timeout, interval));
         }
+        public async Task<T[]> ClusterWaitForNotNull<T>(
+            List<RavenServer> nodes,
+            string database,
+            Func<IDocumentStore, Task<T>> act,
+            int timeout = 15000,
+            int interval = 100) where T : class
+        {
+            return await ClusterWaitFor(nodes, database, s => WaitForNotNullAsync(() => act(s), timeout, interval));
+        }
 
         public async Task<T[]> AssertClusterWaitForValue<T>(
             List<RavenServer> nodes,


### PR DESCRIPTION
### Issue link

https://issues.hibernatingrhinos.com/issue/RavenDB-17823

### Additional description
The test didn't fail locally.
Just additional information for the next failure.

_Please delete below the options that are not relevant_

### Type of change
- Additional info on test failure

### How risky is the change?
- Not relevant

### Backward compatibility
- Not relevant

### Is it platform specific issue?
- No

### Documentation update
- No documentation update is needed 

### Testing 
- Not relevant

### Is there any existing behavior change of other features due to this change?
- No

### UI work
- No UI work is needed
