### PR TITLE
RavenDB-17881 : fix flaky test 

### DIFF
--- a/test/SlowTests/Server/Replication/PullReplicationTests.cs
+++ b/test/SlowTests/Server/Replication/PullReplicationTests.cs
@@ -309,7 +309,9 @@ namespace SlowTests.Server.Replication
 
                 pullDefinition.Disabled = true;
                 pullDefinition.TaskId = saveResult.TaskId;
-                await hub.Maintenance.ForDatabase(hub.Database).SendAsync(new PutPullReplicationAsHubOperation(pullDefinition));
+                var updateResult = await hub.Maintenance.ForDatabase(hub.Database).SendAsync(new PutPullReplicationAsHubOperation(pullDefinition));
+
+                await Server.ServerStore.Cluster.WaitForIndexNotification(updateResult.RaftCommandIndex);
 
                 using (var main = hub.OpenSession())
                 {


### PR DESCRIPTION
### Issue link

https://issues.hibernatingrhinos.com/issue/RavenDB-17881

### Additional description

wait for replication to be dropped on sink store before storing a new document on hub.
this is in order to avoid a situation where `ReplicationLoader.HandleDatabaseRecordChange()` finishes after the new document has already been replicated
 
