### PR TITLE
RavenDB-17886 Traffic watch view flickerling, lagging and constantly …

### DIFF
--- a/src/Raven.Studio/typescript/viewmodels/manage/trafficWatch.ts
+++ b/src/Raven.Studio/typescript/viewmodels/manage/trafficWatch.ts
@@ -183,13 +183,6 @@ class trafficWatch extends viewModelBase {
         }
     }
     
-    attached() {
-        super.attached();
-        
-        awesomeMultiselect.build($("#visibleTypesSelectorHttp"), this.getOptions(this.filteredTypeDataHttp));
-        awesomeMultiselect.build($("#visibleTypesSelectorTcp"), this.getOptions(this.filteredTypeDataTcp));
-    }
-    
     private getOptions(filteredTypeData: typeData[]): (opts: any) => void {
         return (opts: any) => {
             opts.enableHTML = true;
@@ -397,6 +390,9 @@ class trafficWatch extends viewModelBase {
 
     compositionComplete() {
         super.compositionComplete();
+
+        awesomeMultiselect.build($("#visibleTypesSelectorHttp"), this.getOptions(this.filteredTypeDataHttp));
+        awesomeMultiselect.build($("#visibleTypesSelectorTcp"), this.getOptions(this.filteredTypeDataTcp));
 
         $('.traffic-watch [data-toggle="tooltip"]').tooltip({
             html: true


### PR DESCRIPTION
…connecting

### Issue link
https://issues.hibernatingrhinos.com/issue/RavenDB-17886

### Additional description

For some reason the `attached` method is called over and over again
Moving the 'attached' content into the `compositionComplete` is a current working solution

### Type of change
- Bug fix

### How risky is the change?
- Low 

### Backward compatibility
- Non breaking change

### Is it platform specific issue?
- No

### Documentation update
- No documentation update is needed 

### Testing 
- It has been verified by manual testing

### Is there any existing behavior change of other features due to this change?
- No

- No UI work is needed
