### PR TITLE
RavenDB-17253  Add SearchEngineType to Index List

### DIFF
--- a/src/Raven.Studio/typescript/models/database/index/index.ts
+++ b/src/Raven.Studio/typescript/models/database/index/index.ts
@@ -45,6 +45,7 @@ class index {
     typeForUI: KnockoutComputed<string>;
     
     sourceType = ko.observable<Raven.Client.Documents.Indexes.IndexSourceType>();
+    searchEngineType = ko.observable<Raven.Client.Documents.Indexes.SearchEngineType>();
 
     filteredOut = ko.observable<boolean>(false); //UI only property
     badgeClass: KnockoutComputed<string>;
@@ -106,6 +107,7 @@ class index {
         this.collectionNameForReferenceDocuments(dto.PatternReferencesCollectionName);
         this.type(dto.Type);
         this.sourceType(dto.SourceType);
+        this.searchEngineType(dto.SearchEngineType);
         this.state(dto.State);
         this.globalIndexingStatus = globalIndexingStatus;
         this.status(dto.Status); 

--- a/src/Raven.Studio/wwwroot/App/views/database/indexes/indexes.html
+++ b/src/Raven.Studio/wwwroot/App/views/database/indexes/indexes.html
@@ -208,10 +208,15 @@
                             <span data-bind="if: patternForReferencesToReduceOutputCollection"><i class="icon-reference-pattern"></i></span>
                     </div>
                     <div class="index-type">
-                        <span data-bind="text: typeForUI"></span>
+                        <span>Type:&nbsp;</span><strong data-bind="text: typeForUI"></strong>
                         <!--<span data-bind="visible: isTestIndex">&nbsp; <span class="label label-warning">TEST INDEX</span></span>-->
                         <span data-bind="visible: replacement" class="margin-left margin-left-sm"><span class="label label-warning">OLD</span></span>
                         <span data-bind="visible: parent" class="margin-left margin-left-sm"><span class="label label-warning">NEW</span></span>
+                    </div>
+                </div>
+                <div class="flex-horizontal clear-left index-info nospacing">
+                    <div class="index-type margin-left margin-left-lg">
+                        <span>Search Engine:&nbsp;</span><strong data-bind="text: searchEngineType"></strong>
                     </div>
                 </div>
             </div>


### PR DESCRIPTION
### Issue link
https://issues.hibernatingrhinos.com/issue/RavenDB-17253

### Additional description
Added search engine info to indexes list view

### Type of change
- New feature

### How risky is the change?
- Low 

### Backward compatibility
- Non breaking change

### Is it platform specific issue?
- No

### Documentation update
- No documentation update is needed 

### Testing 
- It has been verified by manual testing

### Is there any existing behavior change of other features due to this change?
- No

### UI work
- No UI work is needed
