### PR TITLE
RavenDB-17885: flush subscription Heartbeat

### DIFF
--- a/src/Raven.Server/Documents/TcpHandlers/SubscriptionConnection.cs
+++ b/src/Raven.Server/Documents/TcpHandlers/SubscriptionConnection.cs
@@ -1062,6 +1062,7 @@ namespace Raven.Server.Documents.TcpHandlers
             try
             {
                 await TcpConnection.Stream.WriteAsync(Heartbeat, 0, Heartbeat.Length, CancellationTokenSource.Token);
+                await TcpConnection.Stream.FlushAsync();
 
                 if (_logger.IsInfoEnabled)
                 {


### PR DESCRIPTION
### Issue link

https://issues.hibernatingrhinos.com/issue/RavenDB-17885

### Additional description

When using `CompressionStream` the stream needs to be flushed manually after writing `Hearbeat `
_Please delete below the options that are not relevant_

### Type of change


- Regression bug fix


### How risky is the change?

- Low 


### Backward compatibility


- Not relevant

### Is it platform specific issue?


- No

### Documentation update

- No documentation update is needed 

### Testing 


- It has been verified by manual testing

### Is there any existing behavior change of other features due to this change?

- No

### UI work

- It requires further work in the Studio

