### PR TITLE
RavenDB-17904 Fixing Postgres integration: Unable to cast object of t…

### DIFF
--- a/src/Raven.Server/Integrations/PostgreSQL/Types/PgTimestampTz.cs
+++ b/src/Raven.Server/Integrations/PostgreSQL/Types/PgTimestampTz.cs
@@ -14,12 +14,21 @@ namespace Raven.Server.Integrations.PostgreSQL.Types
 
         public override ReadOnlyMemory<byte> ToBytes(object value, PgFormat formatCode)
         {
-            if (formatCode == PgFormat.Text)
+            switch (value)
             {
-                return Encoding.UTF8.GetBytes(((DateTime)value).ToString("yyyy-MM-dd HH:mm:ss.fffffffzz"));
-            }
+                case DateTime dateTimeValue:
+                    if (formatCode == PgFormat.Text)
+                        return Encoding.UTF8.GetBytes(dateTimeValue.ToString("yyyy-MM-dd HH:mm:ss.fffffffzz"));
 
-            return BitConverter.GetBytes(IPAddress.HostToNetworkOrder(GetTimestampTz((DateTime)value)));
+                    return BitConverter.GetBytes(IPAddress.HostToNetworkOrder(GetTimestampTz(dateTimeValue)));
+                case DateTimeOffset dateTimeOffsetValue:
+                    if (formatCode == PgFormat.Text)
+                        return Encoding.UTF8.GetBytes(dateTimeOffsetValue.ToString("yyyy-MM-dd HH:mm:ss.fffffffzz"));
+
+                    return BitConverter.GetBytes(IPAddress.HostToNetworkOrder(GetTimestampTz(dateTimeOffsetValue)));
+                default:
+                    throw new ArgumentOutOfRangeException(nameof(value), $"Unable to convert {value} to {nameof(PgTimestampTz)} type");
+            }
         }
 
         public override object FromBytes(byte[] buffer, PgFormat formatCode)

--- a/test/SlowTests/Server/Integrations/PostgreSQL/RavenDB_17904.cs
+++ b/test/SlowTests/Server/Integrations/PostgreSQL/RavenDB_17904.cs
@@ -1,0 +1,54 @@
+﻿using System;
+using System.Threading.Tasks;
+using Orders;
+using Raven.Client.Documents;
+using Xunit;
+using Xunit.Abstractions;
+
+namespace SlowTests.Server.Integrations.PostgreSQL;
+
+public class RavenDB_17904 : PostgreSqlIntegrationTestBase
+{
+    public RavenDB_17904(ITestOutputHelper output) : base(output)
+    {
+    }
+
+    [Fact]
+    public async Task CanCovertDateTimeOffsetCorrectlyInPostgres()
+    {
+        const string query = "from Calculations";
+
+        DoNotReuseServer(EnablePostgresSqlSettings);
+
+        using (var store = GetDocumentStore())
+        {
+            using (var session = store.OpenSession())
+            {
+                session.Store(new Calculation
+                {
+                    CreatedAt = DateTimeOffset.Now
+                });
+
+                session.SaveChanges();
+            }
+
+            using (var session = store.OpenAsyncSession())
+            {
+                var employees = await session
+                    .Query<Calculation>()
+                    .ToListAsync();
+
+                var result = await Act(store, query, Server);
+
+                Assert.NotNull(result);
+                Assert.NotEmpty(result.Rows);
+                Assert.Equal(employees.Count, result.Rows.Count);
+            }
+        }
+    }
+
+    private class Calculation
+    {
+        public DateTimeOffset CreatedAt { get; set; }
+    }
+}


### PR DESCRIPTION
…ype 'System.DateTimeOffset' to type 'System.DateTime'.

### Issue link

https://issues.hibernatingrhinos.com/issue/RavenDB-17904

### Additional description

Fixing missing support of conversion DateTimeOffset to PgTimestampTz

### Type of change

- Bug fix

### How risky is the change?

- Low 

### Backward compatibility

- Not relevant

### Is it platform specific issue?

- No

### Documentation update

- No documentation update is needed 

### Testing 

- Tests have been added that prove the fix is effective or that the feature works


### Is there any existing behavior change of other features due to this change?

- No

### UI work

- No UI work is needed
