### PR TITLE
RavenDB-16924 various raft snapshot fixes

### DIFF
--- a/src/Raven.Server/Rachis/AppendEntriesResponse.cs
+++ b/src/Raven.Server/Rachis/AppendEntriesResponse.cs
@@ -4,6 +4,8 @@
     {
         public long LastLogIndex { get; set; }
 
+        public long LastCommitIndex { get; set; }
+
         public long CurrentTerm { get; set; }
 
         public bool Success { get; set; } 
@@ -14,7 +16,7 @@
 
         public override string ToString()
         {
-            return $"Replying with {nameof(Success)}: {Success}, {nameof(Pending)}: {Pending}, {nameof(Message)}: {Message} ({CurrentTerm} / {LastLogIndex})";
+            return $"Replying with {nameof(Success)}: {Success}, {nameof(Pending)}: {Pending}, {nameof(Message)}: {Message} ({CurrentTerm} / {LastLogIndex}, commit:{LastCommitIndex})";
         }
     }
 }

--- a/src/Raven.Server/Rachis/Follower.cs
+++ b/src/Raven.Server/Rachis/Follower.cs
@@ -207,6 +207,7 @@ namespace Raven.Server.Rachis
                     {
                         CurrentTerm = _term,
                         LastLogIndex = lastAcknowledgedIndex,
+                        LastCommitIndex = lastCommit,
                         Success = true
                     });
 

--- a/src/Raven.Server/Rachis/Follower.cs
+++ b/src/Raven.Server/Rachis/Follower.cs
@@ -572,7 +572,8 @@ namespace Raven.Server.Rachis
 
                     _engine.SetLastCommitIndex(context, snapshot.LastIncludedIndex, snapshot.LastIncludedTerm);
                     _engine.ClearLogEntriesAndSetLastTruncate(context, snapshot.LastIncludedIndex, snapshot.LastIncludedTerm);
-                    onFullSnapshotInstalledTask = _engine.OnSnapshotInstalled(context, snapshot.LastIncludedIndex, token).Task;
+
+                    onFullSnapshotInstalledTask = _engine.OnSnapshotInstalled(context, snapshot.LastIncludedIndex, token);
                 }
                 else
                 {

--- a/src/Raven.Server/Rachis/Follower.cs
+++ b/src/Raven.Server/Rachis/Follower.cs
@@ -481,7 +481,7 @@ namespace Raven.Server.Rachis
             {
                 KeepAliveAndExecuteAction(() =>
                 {
-                    _engine.SnapshotInstalled(snapshot.LastIncludedIndex, requestFullSnapshot, cts.Token);
+                    _engine.AfterSnapshotInstalled(snapshot.LastIncludedIndex, requestFullSnapshot, cts.Token);
                 }, cts, "SnapshotInstalledAsync");
             }
 
@@ -543,6 +543,8 @@ namespace Raven.Server.Rachis
         {
             using (context.OpenWriteTransaction())
             {
+                _engine.OnSnapshotInstalledTask = null;
+
                 var lastTerm = _engine.GetTermFor(context, snapshot.LastIncludedIndex);
                 var lastCommitIndex = _engine.GetLastEntryIndex(context);
 
@@ -568,6 +570,7 @@ namespace Raven.Server.Rachis
 
                     _engine.SetLastCommitIndex(context, snapshot.LastIncludedIndex, snapshot.LastIncludedTerm);
                     _engine.ClearLogEntriesAndSetLastTruncate(context, snapshot.LastIncludedIndex, snapshot.LastIncludedTerm);
+                    _engine.OnSnapshotInstalled(context, snapshot.LastIncludedIndex, token);
                 }
                 else
                 {
@@ -580,7 +583,6 @@ namespace Raven.Server.Rachis
                         {
                             _engine.Log.Info($"{ToString()}: {message}");
                         }
-
                         throw new InvalidOperationException(message);
                     }
                 }

--- a/src/Raven.Server/Rachis/FollowerAmbassador.cs
+++ b/src/Raven.Server/Rachis/FollowerAmbassador.cs
@@ -867,13 +867,22 @@ namespace Raven.Server.Rachis
                         }
                         var midIndex = (llr.MinIndex + llr.MaxIndex) / 2;
                         var termFor = _engine.GetTermFor(context, midIndex);
+
+                        truncated |= termFor == null;
+
+                        if (truncated)
+                        {
+                            midIndex = _engine.GetFirstEntryIndex(context);
+                            termFor = _engine.GetTermForKnownExisting(context, midIndex);
+                        }
+
                         Debug.Assert(termFor != 0);
                         lln = new LogLengthNegotiation
                         {
                             Term = _term,
                             PrevLogIndex = midIndex,
                             PrevLogTerm = termFor ?? 0,
-                            Truncated = truncated || termFor == null
+                            Truncated = truncated
                         };
                         if (_engine.Log.IsInfoEnabled)
                         {

--- a/src/Raven.Server/Rachis/Leader.cs
+++ b/src/Raven.Server/Rachis/Leader.cs
@@ -6,6 +6,7 @@ using System.Linq;
 using System.Text;
 using System.Threading;
 using System.Threading.Tasks;
+using Raven.Client.Exceptions.Cluster;
 using Raven.Client.Extensions;
 using Raven.Client.Http;
 using Raven.Client.ServerWide;
@@ -107,13 +108,19 @@ namespace Raven.Server.Rachis
 
         private int _steppedDown;
 
-        public void StepDown()
+        public void StepDown(bool forceElection = true)
         {
             if (_voters.Count == 0)
                 throw new InvalidOperationException("Cannot step down when I'm the only voter in the cluster");
 
             if (Interlocked.CompareExchange(ref _steppedDown, 1, 0) == 1)
                 return;
+
+            if (forceElection == false)
+            {
+                _errorOccurred.TrySetException(new NotLeadingException("Was forced to step down"));
+                return;
+            }
 
             var nextLeader = _voters.Values.OrderByDescending(x => x.FollowerMatchIndex).ThenByDescending(x => x.LastReplyFromFollower).First();
             if (_engine.Log.IsInfoEnabled)
@@ -564,17 +571,17 @@ namespace Raven.Server.Rachis
 
             foreach (var voter in _voters.Values)
             {
-                lowestIndex = Math.Min(lowestIndex, voter.FollowerMatchIndex);
+                lowestIndex = Math.Min(lowestIndex, voter.FollowerLastCommitIndex);
             }
 
             foreach (var promotable in _promotables.Values)
             {
-                lowestIndex = Math.Min(lowestIndex, promotable.FollowerMatchIndex);
+                lowestIndex = Math.Min(lowestIndex, promotable.FollowerLastCommitIndex);
             }
 
             foreach (var nonVoter in _nonVoters.Values)
             {
-                lowestIndex = Math.Min(lowestIndex, nonVoter.FollowerMatchIndex);
+                lowestIndex = Math.Min(lowestIndex, nonVoter.FollowerLastCommitIndex);
             }
 
             return lowestIndex;

--- a/src/Raven.Server/Rachis/RachisConsensus.cs
+++ b/src/Raven.Server/Rachis/RachisConsensus.cs
@@ -91,14 +91,14 @@ namespace Raven.Server.Rachis
             return StateMachine.ShouldSnapshot(slice, type);
         }
 
-        public override void AfterSnapshotInstalled(long lastIncludedIndex, bool fullSnapshot, CancellationToken token)
+        public override void AfterSnapshotInstalled(long lastIncludedIndex, Task onFullSnapshotInstalledTask, CancellationToken token)
         {
-            StateMachine.AfterSnapshotInstalled(lastIncludedIndex, fullSnapshot, _serverStore, token);
+            StateMachine.AfterSnapshotInstalled(lastIncludedIndex, onFullSnapshotInstalledTask, token);
         }
 
-        public override void OnSnapshotInstalled(TransactionOperationContext context, long lastIncludedIndex, CancellationToken token)
+        public override TaskCompletionSource<Task> OnSnapshotInstalled(TransactionOperationContext context, long lastIncludedIndex, CancellationToken token)
         {
-            StateMachine.OnSnapshotInstalled(context, lastIncludedIndex, token);
+            return StateMachine.OnSnapshotInstalled(context, lastIncludedIndex, token);
         }
 
         public override Task<RachisConnection> ConnectToPeer(string url, string tag, X509Certificate2 certificate)
@@ -304,8 +304,6 @@ namespace Raven.Server.Rachis
         public Action<TransactionOperationContext> SwitchToSingleLeaderAction;
 
         public Action<TransactionOperationContext, CommandBase> BeforeAppendToRaftLog;
-
-        public Task OnSnapshotInstalledTask;
 
         private string _tag;
         private string _clusterId;
@@ -2133,8 +2131,8 @@ namespace Raven.Server.Rachis
 
         public abstract long Apply(TransactionOperationContext context, long uptoInclusive, Leader leader, Stopwatch duration);
 
-        public abstract void AfterSnapshotInstalled(long lastIncludedIndex, bool fullSnapshot, CancellationToken token);
-        public abstract void OnSnapshotInstalled(TransactionOperationContext context, long lastIncludedIndex, CancellationToken token);
+        public abstract void AfterSnapshotInstalled(long lastIncludedIndex, Task onFullSnapshotInstalledTask, CancellationToken token);
+        public abstract TaskCompletionSource<Task> OnSnapshotInstalled(TransactionOperationContext context, long lastIncludedIndex, CancellationToken token);
 
         private readonly AsyncManualResetEvent _leadershipTimeChanged = new AsyncManualResetEvent();
         private int _heartbeatWaitersCounter;

--- a/src/Raven.Server/Rachis/RachisConsensus.cs
+++ b/src/Raven.Server/Rachis/RachisConsensus.cs
@@ -305,7 +305,7 @@ namespace Raven.Server.Rachis
 
         public Action<TransactionOperationContext, CommandBase> BeforeAppendToRaftLog;
 
-        public TaskCompletionSource<Task> OnSnapshotInstalledTask;
+        public Task OnSnapshotInstalledTask;
 
         private string _tag;
         private string _clusterId;

--- a/src/Raven.Server/Rachis/RachisConsensus.cs
+++ b/src/Raven.Server/Rachis/RachisConsensus.cs
@@ -96,7 +96,7 @@ namespace Raven.Server.Rachis
             StateMachine.AfterSnapshotInstalled(lastIncludedIndex, onFullSnapshotInstalledTask, token);
         }
 
-        public override TaskCompletionSource<Task> OnSnapshotInstalled(TransactionOperationContext context, long lastIncludedIndex, CancellationToken token)
+        public override Task OnSnapshotInstalled(TransactionOperationContext context, long lastIncludedIndex, CancellationToken token)
         {
             return StateMachine.OnSnapshotInstalled(context, lastIncludedIndex, token);
         }
@@ -2132,7 +2132,7 @@ namespace Raven.Server.Rachis
         public abstract long Apply(TransactionOperationContext context, long uptoInclusive, Leader leader, Stopwatch duration);
 
         public abstract void AfterSnapshotInstalled(long lastIncludedIndex, Task onFullSnapshotInstalledTask, CancellationToken token);
-        public abstract TaskCompletionSource<Task> OnSnapshotInstalled(TransactionOperationContext context, long lastIncludedIndex, CancellationToken token);
+        public abstract Task OnSnapshotInstalled(TransactionOperationContext context, long lastIncludedIndex, CancellationToken token);
 
         private readonly AsyncManualResetEvent _leadershipTimeChanged = new AsyncManualResetEvent();
         private int _heartbeatWaitersCounter;

--- a/src/Raven.Server/Rachis/RachisStateMachine.cs
+++ b/src/Raven.Server/Rachis/RachisStateMachine.cs
@@ -8,6 +8,8 @@ using Raven.Server.ServerWide.Context;
 using Sparrow.Json;
 using Voron;
 using Voron.Data;
+using Voron.Impl;
+
 // ReSharper disable InconsistentNaming
 
 namespace Raven.Server.Rachis
@@ -86,7 +88,11 @@ namespace Raven.Server.Rachis
 
         public abstract Task<RachisConnection> ConnectToPeer(string url, string tag, X509Certificate2 certificate);
 
-        public virtual void OnSnapshotInstalled(long lastIncludedIndex, bool fullSnapshot, ServerStore serverStore, CancellationToken token)
+        public virtual void AfterSnapshotInstalled(long lastIncludedIndex, bool fullSnapshot, ServerStore serverStore, CancellationToken token)
+        {
+        }
+
+        public virtual void OnSnapshotInstalled(TransactionOperationContext context, long lastIncludedIndex, CancellationToken token)
         {
         }
     }

--- a/src/Raven.Server/Rachis/RachisStateMachine.cs
+++ b/src/Raven.Server/Rachis/RachisStateMachine.cs
@@ -92,11 +92,9 @@ namespace Raven.Server.Rachis
         {
         }
 
-        public virtual TaskCompletionSource<Task> OnSnapshotInstalled(TransactionOperationContext context, long lastIncludedIndex, CancellationToken token)
+        public virtual Task OnSnapshotInstalled(TransactionOperationContext context, long lastIncludedIndex, CancellationToken token)
         {
-            var tcs = new TaskCompletionSource<Task>(TaskCreationOptions.RunContinuationsAsynchronously);
-            tcs.TrySetResult(Task.CompletedTask);
-            return tcs;
+            return Task.CompletedTask;
         }
     }
 }

--- a/src/Raven.Server/Rachis/RachisStateMachine.cs
+++ b/src/Raven.Server/Rachis/RachisStateMachine.cs
@@ -88,12 +88,15 @@ namespace Raven.Server.Rachis
 
         public abstract Task<RachisConnection> ConnectToPeer(string url, string tag, X509Certificate2 certificate);
 
-        public virtual void AfterSnapshotInstalled(long lastIncludedIndex, bool fullSnapshot, ServerStore serverStore, CancellationToken token)
+        public virtual void AfterSnapshotInstalled(long lastIncludedIndex, Task onFullSnapshotInstalledTask, CancellationToken token)
         {
         }
 
-        public virtual void OnSnapshotInstalled(TransactionOperationContext context, long lastIncludedIndex, CancellationToken token)
+        public virtual TaskCompletionSource<Task> OnSnapshotInstalled(TransactionOperationContext context, long lastIncludedIndex, CancellationToken token)
         {
+            var tcs = new TaskCompletionSource<Task>(TaskCreationOptions.RunContinuationsAsynchronously);
+            tcs.TrySetResult(Task.CompletedTask);
+            return tcs;
         }
     }
 }

--- a/src/Raven.Server/Rachis/Remote/RemoteConnection.cs
+++ b/src/Raven.Server/Rachis/Remote/RemoteConnection.cs
@@ -367,6 +367,7 @@ namespace Raven.Server.Rachis.Remote
                 [nameof(AppendEntriesResponse.Message)] = aer.Message,
                 [nameof(AppendEntriesResponse.CurrentTerm)] = aer.CurrentTerm,
                 [nameof(AppendEntriesResponse.LastLogIndex)] = aer.LastLogIndex,
+                [nameof(AppendEntriesResponse.LastCommitIndex)] = aer.LastCommitIndex,
             };
 
             Send(context, msg);

--- a/src/Raven.Server/ServerWide/ServerStore.cs
+++ b/src/Raven.Server/ServerWide/ServerStore.cs
@@ -1285,13 +1285,14 @@ namespace Raven.Server.ServerWide
         {
             try
             {
+                string certThumbprint;
                 using (ContextPool.AllocateOperationContext(out TransactionOperationContext context))
                 using (context.OpenReadTransaction())
                 {
                     var cert = Cluster.GetItem(context, CertificateReplacement.CertificateReplacementDoc);
                     if (cert == null)
                         return;
-                    if (cert.TryGet(nameof(CertificateReplacement.Thumbprint), out string certThumbprint) == false)
+                    if (cert.TryGet(nameof(CertificateReplacement.Thumbprint), out certThumbprint) == false)
                         throw new InvalidOperationException($"Invalid 'server/cert' value, expected to get '{nameof(CertificateReplacement.Thumbprint)}' property");
 
                     if (cert.TryGet(nameof(CertificateReplacement.Certificate), out string base64Cert) == false)
@@ -1316,10 +1317,10 @@ namespace Raven.Server.ServerWide
                             NotificationSeverity.Error));
                         return;
                     }
-
-                    // we got it, now let us let the leader know about it
-                    await SendToLeaderAsync(new ConfirmReceiptServerCertificateCommand(certThumbprint));
                 }
+
+                // we got it, now let us let the leader know about it
+                await SendToLeaderAsync(new ConfirmReceiptServerCertificateCommand(certThumbprint));
             }
             catch (Exception e)
             {

--- a/src/Raven.Server/Web/System/DatabasesHandler.cs
+++ b/src/Raven.Server/Web/System/DatabasesHandler.cs
@@ -69,7 +69,7 @@ namespace Raven.Server.Web.System
                             return;
                         }
 
-                        WriteDatabaseInfo(databaseName, dbDoc.Item2, context, w);
+                        WriteDatabaseInfo(databaseName, dbDoc.Value, context, w);
                     });
                     writer.WriteEndObject();
                 }

--- a/test/InterversionTests/MixedClusterTests.cs
+++ b/test/InterversionTests/MixedClusterTests.cs
@@ -119,6 +119,20 @@ namespace InterversionTests
             var suit = new Version41X(this);
             await ExecuteUpgradeTest(initialVersions, upgradeTo, suit, suit, suit);
         }
+
+        [Fact]
+        public async Task UpgradeToLatest()
+        {
+            var latest = "4.2.119";
+            var initialVersions = new[] { latest, latest, latest };
+            var upgradeTo = new List<string>
+            {
+                "current"
+            };
+            var suit = new Version41X(this);
+            await ExecuteUpgradeTest(initialVersions, upgradeTo, suit, suit, suit);
+        }
+
         private async Task ExecuteUpgradeTest(
             string[] initialVersions,
             List<string> upgradeTo,

--- a/test/RachisTests/AddNodeToClusterTests.cs
+++ b/test/RachisTests/AddNodeToClusterTests.cs
@@ -771,6 +771,29 @@ namespace RachisTests
         }
 
         [Fact]
+        public async Task AddNodeToClusterWithoutError()
+        {
+            var (_, leader) = await CreateRaftCluster(1);
+
+            var server2 = GetNewServer();
+            var server2Url = server2.ServerStore.GetNodeHttpServerUrl();
+            Servers.Add(server2);
+
+            using (var requestExecutor = ClusterRequestExecutor.CreateForSingleNode(leader.WebUrl, null))
+            using (requestExecutor.ContextPool.AllocateOperationContext(out var ctx))
+            {
+                await requestExecutor.ExecuteAsync(new AddClusterNodeCommand(server2Url, watcher: true), ctx);
+                await server2.ServerStore.Engine.WaitForTopology(Leader.TopologyModification.NonVoter);
+            }
+
+            using (server2.ServerStore.ContextPool.AllocateOperationContext(out TransactionOperationContext ctx))
+            {
+                var logs = ctx.ReadObject(server2.ServerStore.Engine.InMemoryDebug.ToJson(),"watcher-logs").ToString();
+                Assert.False(logs.Contains("Exception"), logs);
+            }
+        }
+
+        [Fact]
         public async Task ResetServerShouldPreserveTopology()
         {
             var cluster = await CreateRaftCluster(3, shouldRunInMemory: false);

--- a/test/SlowTests/Cluster/ParallelClusterTransactionsTests.cs
+++ b/test/SlowTests/Cluster/ParallelClusterTransactionsTests.cs
@@ -1,0 +1,207 @@
+﻿using System;
+using System.Collections.Generic;
+using System.Linq;
+using System.Runtime.CompilerServices;
+using System.Threading;
+using System.Threading.Tasks;
+using FastTests.Server.Replication;
+using Raven.Client.Documents.Operations.CompareExchange;
+using Raven.Client.Documents.Session;
+using Raven.Server;
+using Raven.Server.Config;
+using Raven.Server.ServerWide.Context;
+using Raven.Server.Utils;
+using Raven.Tests.Core.Utils.Entities;
+using Xunit;
+using Xunit.Abstractions;
+
+namespace SlowTests.Cluster
+{
+    public class ParallelClusterTransactionsTests : ReplicationTestBase
+    {
+        public ParallelClusterTransactionsTests(ITestOutputHelper output) : base(output)
+        {
+        }
+
+        // the values are lower to make the cluster less stable
+        protected override RavenServer GetNewServer(ServerCreationOptions options = null, [CallerMemberName]string caller = null)
+        {
+            if (options == null)
+            {
+                options = new ServerCreationOptions();
+            }
+            if (options.CustomSettings == null)
+                options.CustomSettings = new Dictionary<string, string>();
+
+            options.CustomSettings[RavenConfiguration.GetKey(x => x.Cluster.OperationTimeout)] = "10";
+            options.CustomSettings[RavenConfiguration.GetKey(x => x.Cluster.StabilizationTime)] = "1";
+            options.CustomSettings[RavenConfiguration.GetKey(x => x.Cluster.TcpConnectionTimeout)] = "3000";
+            options.CustomSettings[RavenConfiguration.GetKey(x => x.Cluster.ElectionTimeout)] = "50";
+
+            return base.GetNewServer(options, caller);
+        }
+
+        [Fact]
+        public Task ParallelClusterTransactions() => ParallelClusterTransactions(3);
+
+
+        public async Task ParallelClusterTransactions(int numberOfNodes)
+        {
+            DebuggerAttachedTimeout.DisableLongTimespan = true;
+
+            var cluster = await CreateRaftCluster(numberOfNodes);
+            var db = GetDatabaseName();
+            using (GetDocumentStore(new Options
+            {
+                Server = cluster.Leader,
+                ReplicationFactor = numberOfNodes,
+                ModifyDatabaseName = _ => db
+            }))
+            {
+                var count = 0;
+                var tasks = new List<Task>();
+                var random = new Random();
+
+                for (int i = 0; i < 100; i++)
+                {
+                    var t = Task.Run(async () =>
+                    {
+                        var nodeNum = random.Next(0, numberOfNodes);
+                        using (var store = GetDocumentStore(new Options
+                        {
+                            Server = cluster.Nodes[nodeNum],
+                            CreateDatabase = false
+                        }))
+                        {
+                            for (int j = 0; j < 10; j++)
+                            {
+                                try
+                                {
+                                    await store.Operations.ForDatabase(db).SendAsync(new PutCompareExchangeValueOperation<User>($"usernames/{Interlocked.Increment(ref count)}", new User(), 0));
+
+                                    using (var session = store.OpenAsyncSession(db))
+                                    {
+                                        session.Advanced.SetTransactionMode(TransactionMode.ClusterWide);
+                                        session.Advanced.ClusterTransaction.CreateCompareExchangeValue($"usernames/{Interlocked.Increment(ref count)}", new User());
+                                        await session.StoreAsync(new User());
+                                        await session.SaveChangesAsync();
+                                    }
+                                }
+                                catch
+                                {
+                                    //
+                                }
+                            }
+                        }
+                    });
+                    tasks.Add(t);
+                }
+
+
+                var cts = new CancellationTokenSource();
+                var checkingTask = Task.Run(async () =>
+                {
+                    while (cts.IsCancellationRequested == false)
+                    {
+                        foreach (var n in cluster.Nodes)
+                        {
+                            var lastNodeNotifiedIndex = n.ServerStore.Cluster.LastNotifiedIndex;
+                            using (n.ServerStore.ContextPool.AllocateOperationContext(out TransactionOperationContext ctx))
+                            using (ctx.OpenReadTransaction())
+                            {
+                                var lastCommitIndex = n.ServerStore.Engine.GetLastCommitIndex(ctx);
+                                if (lastNodeNotifiedIndex > lastCommitIndex)
+                                {
+                                    var logs = CollectLogs(ctx, n);
+                                    throw new InvalidOperationException(
+                                        $"node {n.ServerStore.NodeTag} notified {lastNodeNotifiedIndex}, committed: {lastCommitIndex}{Environment.NewLine}{logs}");
+                                }
+                            }
+                        }
+
+                        try
+                        {
+                            await Task.Delay(150, cts.Token);
+                        }
+                        catch
+                        {
+                            // ignore
+                        }
+                    }
+                });
+                var destablizeTask = Task.Run(async () =>
+                {
+                    while (cts.IsCancellationRequested == false)
+                    {
+                        try
+                        {
+                            await ActionWithLeader(l => l.ServerStore.Engine.CurrentLeader.StepDown(forceElection: false));
+                            await Task.Delay(1000, cts.Token);
+                        }
+                        catch
+                        {
+                            // ignore
+                        }
+
+                    }
+                });
+
+                foreach (var task in tasks)
+                {
+                    try
+                    {
+                        await task;
+                    }
+                    catch
+                    {
+                        // ignore
+                    }
+
+                }
+
+                cts.Cancel();
+                await checkingTask;
+                await destablizeTask;
+
+                var maxTerm = cluster.Nodes.Select(x => x.ServerStore.Engine.CurrentTerm).Max();
+                long maxTermOld;
+                var attempts = 3 * numberOfNodes;
+                do
+                {
+                    maxTermOld = maxTerm;
+                    await Task.Delay(TimeSpan.FromSeconds(3) * numberOfNodes);
+                    maxTerm = cluster.Nodes.Select(x => x.ServerStore.Engine.CurrentTerm).Max();
+
+                    attempts--; // cluster couldn't stabilize
+                } while (maxTerm != maxTermOld && attempts > 0);
+
+                var compareExchangeCount = new HashSet<long>();
+                var maxLog = 0L;
+
+                foreach (var n in cluster.Nodes.Where(x => x.ServerStore.Engine.CurrentTerm >= maxTerm))
+                {
+                    using (n.ServerStore.ContextPool.AllocateOperationContext(out TransactionOperationContext ctx))
+                    using (ctx.OpenReadTransaction())
+                    {
+                        var currentLog = n.ServerStore.Engine.GetLastEntryIndex(ctx);
+                        if (maxLog < currentLog)
+                            maxLog = currentLog;
+                    }
+                }
+
+                foreach (var node in cluster.Nodes)
+                {
+                    await node.ServerStore.Cluster.WaitForIndexNotification(maxLog, TimeSpan.FromMinutes(1));
+
+                    using (node.ServerStore.ContextPool.AllocateOperationContext(out TransactionOperationContext ctx))
+                    using (ctx.OpenReadTransaction())
+                    {
+                        compareExchangeCount.Add(node.ServerStore.Cluster.GetNumberOfCompareExchange(ctx, db));
+                    }
+                }
+
+                Assert.Equal(1, compareExchangeCount.Count);
+            }
+        }
+    }
+}

--- a/test/StressTests/Cluster/ClusterStressTests.cs
+++ b/test/StressTests/Cluster/ClusterStressTests.cs
@@ -1,149 +1,23 @@
-﻿using System;
-using System.Collections.Generic;
-using System.Linq;
-using System.Runtime.CompilerServices;
-using System.Threading;
-using System.Threading.Tasks;
-using FastTests.Server.Replication;
-using Raven.Client.Documents.Operations.CompareExchange;
-using Raven.Client.Documents.Session;
-using Raven.Server;
-using Raven.Server.Config;
-using Raven.Server.ServerWide.Context;
-using Raven.Server.Utils;
-using Raven.Tests.Core.Utils.Entities;
+﻿using System.Threading.Tasks;
+using FastTests;
+using SlowTests.Cluster;
 using Xunit;
 using Xunit.Abstractions;
 
 namespace StressTests.Cluster
 {
-    public class ClusterStressTests : ReplicationTestBase
+    public class ClusterStressTests : NoDisposalNeeded
     {
         public ClusterStressTests(ITestOutputHelper output) : base(output)
         {
         }
 
-        // the values are lower to make the cluster less stable
-        protected override RavenServer GetNewServer(ServerCreationOptions options = null, [CallerMemberName]string caller = null)
-        {
-            if (options == null)
-            {
-                options = new ServerCreationOptions();
-            }
-            if (options.CustomSettings == null)
-                options.CustomSettings = new Dictionary<string, string>();
-
-            options.CustomSettings[RavenConfiguration.GetKey(x => x.Cluster.OperationTimeout)] = "10";
-            options.CustomSettings[RavenConfiguration.GetKey(x => x.Cluster.StabilizationTime)] = "1";
-            options.CustomSettings[RavenConfiguration.GetKey(x => x.Cluster.TcpConnectionTimeout)] = "3000";
-            options.CustomSettings[RavenConfiguration.GetKey(x => x.Cluster.ElectionTimeout)] = "50";
-
-            return base.GetNewServer(options, caller);
-        }
-
         [Fact]
         public async Task ParallelClusterTransactions()
         {
-            DebuggerAttachedTimeout.DisableLongTimespan = true;
-            var numberOfNodes = 7;
-            var cluster = await CreateRaftCluster(numberOfNodes);
-            var db = GetDatabaseName();
-            using (GetDocumentStore(new Options
+            using (var test = new ParallelClusterTransactionsTests(Output))
             {
-                Server = cluster.Leader,
-                ReplicationFactor = numberOfNodes,
-                ModifyDatabaseName = _ => db
-            }))
-            {
-                var count = 0;
-                var tasks = new List<Task>();
-                var random = new Random();
-
-                for (int i = 0; i < 100; i++)
-                {
-                    var t = Task.Run(async () =>
-                    {
-                        var nodeNum = random.Next(0, numberOfNodes);
-                        using (var store = GetDocumentStore(new Options
-                        {
-                            Server = cluster.Nodes[nodeNum],
-                            CreateDatabase = false
-                        }))
-                        {
-                            for (int j = 0; j < 10; j++)
-                            {
-                                try
-                                {
-                                    await store.Operations.ForDatabase(db).SendAsync(new PutCompareExchangeValueOperation<User>($"usernames/{Interlocked.Increment(ref count)}", new User(), 0));
-
-                                    using (var session = store.OpenAsyncSession(db))
-                                    {
-                                        session.Advanced.SetTransactionMode(TransactionMode.ClusterWide);
-                                        session.Advanced.ClusterTransaction.CreateCompareExchangeValue($"usernames/{Interlocked.Increment(ref count)}", new User());
-                                        await session.StoreAsync(new User());
-                                        await session.SaveChangesAsync();
-                                    }
-                                }
-                                catch
-                                {
-                                    //
-                                }
-                            }
-                        }
-                    });
-                    tasks.Add(t);
-                }
-
-                foreach (var task in tasks)
-                {
-                    try
-                    {
-                        await task;
-                    }
-                    catch
-                    {
-                        // ignore
-                    }
-                }
-
-                var maxTerm = cluster.Nodes.Select(x => x.ServerStore.Engine.CurrentTerm).Max();
-                long maxTermOld;
-                var attempts = 3 * numberOfNodes;
-                do
-                {
-                    maxTermOld = maxTerm;
-                    await Task.Delay(TimeSpan.FromSeconds(3) * numberOfNodes);
-                    maxTerm = cluster.Nodes.Select(x => x.ServerStore.Engine.CurrentTerm).Max();
-
-                    attempts--; // cluster couldn't stabilize
-                } while (maxTerm != maxTermOld && attempts > 0);
-
-                var compareExchangeCount = new HashSet<long>();
-                var maxLog = 0L;
-
-                foreach (var n in cluster.Nodes.Where(x => x.ServerStore.Engine.CurrentTerm >= maxTerm))
-                {
-                    using (n.ServerStore.ContextPool.AllocateOperationContext(out TransactionOperationContext ctx))
-                    using (ctx.OpenReadTransaction())
-                    {
-                        var currentLog = n.ServerStore.Engine.GetLastEntryIndex(ctx);
-                        if (maxLog < currentLog)
-                            maxLog = currentLog;
-                    }
-                }
-
-                foreach (var node in cluster.Nodes)
-                {
-                    await node.ServerStore.Cluster.WaitForIndexNotification(maxLog, TimeSpan.FromMinutes(1));
-
-                    using (node.ServerStore.ContextPool.AllocateOperationContext(out TransactionOperationContext ctx))
-                    using (ctx.OpenReadTransaction())
-                    {
-                        compareExchangeCount.Add(node.ServerStore.Cluster.GetNumberOfCompareExchange(ctx, db));
-                    }
-                }
-
-                Assert.Equal(1, compareExchangeCount.Count);
+                await test.ParallelClusterTransactions(7);
             }
         }
     }

--- a/test/Tests.Infrastructure/RavenTestBase.cs
+++ b/test/Tests.Infrastructure/RavenTestBase.cs
@@ -258,15 +258,20 @@ namespace FastTests
                 using (nodes[i].ServerStore.ContextPool.AllocateOperationContext(out TransactionOperationContext context))
                 using (context.OpenReadTransaction())
                 {
-                    message +=
-                        $"{Environment.NewLine}Log for server '{nodes[i].ServerStore.NodeTag}':" +
-                        $"{Environment.NewLine}Last notified Index '{nodes[i].ServerStore.Cluster.LastNotifiedIndex}':" +
-                        $"{Environment.NewLine}{context.ReadObject(nodes[i].ServerStore.GetLogDetails(context), "LogSummary/" + i)}" +
-                        $"{Environment.NewLine}{nodes[i].ServerStore.Engine.LogHistory.GetHistoryLogsAsString(context)}";
+                    message += CollectLogs(context, nodes[i]);
                 }
             }
 
             return message;
+        }
+
+        protected static string CollectLogs(TransactionOperationContext context, RavenServer server)
+        {
+            return 
+                $"{Environment.NewLine}Log for server '{server.ServerStore.NodeTag}':" +
+                $"{Environment.NewLine}Last notified Index '{server.ServerStore.Cluster.LastNotifiedIndex}':" +
+                $"{Environment.NewLine}{context.ReadObject(server.ServerStore.GetLogDetails(context, max: int.MaxValue), "LogSummary/" + server.ServerStore.NodeTag)}" +
+                $"{Environment.NewLine}{server.ServerStore.Engine.LogHistory.GetHistoryLogsAsString(context)}";
         }
 
         protected virtual DocumentStore GetDocumentStore(Options options = null, [CallerMemberName] string caller = null)


### PR DESCRIPTION
### Issue link

https://issues.hibernatingrhinos.com/issue/RavenDB-16924

### Additional description

from the additional debug info we got the following:
```
Last Notified Index : 7
Last Commit Index : 6
```
Which shouldn't happened because we should notify only on indexes that were committed.

Digging into that revealed several issues that are addressed here:

- When receiving a snapshot we notified after the snapshot was committed, but before the databases reacted to the new state.
- We truncated the raft log based on the appended entries instead of the committed ones, which might result in sending unnecessary full snapshots. 
- The negotiation itself had a few edge cases which lead to sending full snapshots

### Type of change

- Bug fix

### How risky is the change?

- Moderate - High

### Backward compatibility

- Interversion test was added.

### Is it platform specific issue?

- No

### Documentation update

- No documentation update is needed 

### Testing 

- Tests have been added that prove the fix is effective or that the feature works

### Is there any existing behavior change of other features due to this change?

- No

### UI work

- No UI work is needed
