### PR TITLE
RavenDB-13106 abstract and reorganize replication

### DIFF
--- a/src/Raven.Server/Dashboard/DatabasesInfoRetriever.cs
+++ b/src/Raven.Server/Dashboard/DatabasesInfoRetriever.cs
@@ -12,6 +12,8 @@ using Raven.Client.ServerWide.Operations;
 using Raven.Client.Util;
 using Raven.Server.Config.Categories;
 using Raven.Server.Documents;
+using Raven.Server.Documents.Replication;
+using Raven.Server.Documents.Replication.Outgoing;
 using Raven.Server.Json;
 using Raven.Server.ServerWide;
 using Raven.Server.ServerWide.Context;
@@ -256,7 +258,7 @@ namespace Raven.Server.Dashboard
             var olapEtlCount = database.EtlLoader.OlapDestinations.Count;
             var sqlEtlCount = database.EtlLoader.SqlDestinations.Count;
             var ravenEtlCount = database.EtlLoader.RavenDestinations.Count;
-            var hubCount = database.ReplicationLoader.OutgoingHandlers.Count(x => x.IsPullReplicationAsHub);
+            var hubCount = database.ReplicationLoader.OutgoingHandlers.Count(x => x is OutgoingPullReplicationHandler);
             var sinkCount = dbRecord.SinkPullReplications.Count;
             var extRepCount = dbRecord.ExternalReplications.Count;
             

--- a/src/Raven.Server/Documents/DocumentsTransaction.cs
+++ b/src/Raven.Server/Documents/DocumentsTransaction.cs
@@ -2,6 +2,7 @@
 using System.Collections.Generic;
 using Raven.Client.Documents.Changes;
 using Raven.Server.Documents.Replication;
+using Raven.Server.Documents.Replication.Incoming;
 using Raven.Server.ServerWide;
 using Raven.Server.ServerWide.Context;
 using Sparrow;

--- a/src/Raven.Server/Documents/Handlers/ReplicationHandler.cs
+++ b/src/Raven.Server/Documents/Handlers/ReplicationHandler.cs
@@ -9,6 +9,8 @@ using Raven.Client.Documents.Commands;
 using Raven.Client.Documents.Replication;
 using Raven.Client.ServerWide;
 using Raven.Server.Documents.Replication;
+using Raven.Server.Documents.Replication.Outgoing;
+using Raven.Server.Documents.Replication.Stats;
 using Raven.Server.Routing;
 using Raven.Server.ServerWide.Context;
 using Raven.Server.Utils;

--- a/src/Raven.Server/Documents/ReplayTxCommandHelper.cs
+++ b/src/Raven.Server/Documents/ReplayTxCommandHelper.cs
@@ -13,6 +13,8 @@ using Raven.Server.Documents.Handlers.Admin;
 using Raven.Server.Documents.Indexes.MapReduce.OutputToCollection;
 using Raven.Server.Documents.Patch;
 using Raven.Server.Documents.Replication;
+using Raven.Server.Documents.Replication.Incoming;
+using Raven.Server.Documents.Replication.Outgoing;
 using Raven.Server.Documents.Revisions;
 using Raven.Server.Documents.TimeSeries;
 using Raven.Server.Documents.TransactionCommands;
@@ -223,11 +225,14 @@ namespace Raven.Server.Documents
                 case nameof(ExpiredDocumentsCleaner.DeleteExpiredDocumentsCommand):
                     return jsonSerializer.Deserialize<DeleteExpiredDocumentsCommandDto>(reader);
 
-                case nameof(OutgoingReplicationHandler.UpdateSiblingCurrentEtag):
-                    return jsonSerializer.Deserialize<UpdateSiblingCurrentEtagDto>(reader);
+                case nameof(OutgoingInternalReplicationHandler.UpdateSiblingCurrentEtag):
+                    return jsonSerializer.Deserialize<OutgoingInternalReplicationHandler.UpdateSiblingCurrentEtagDto>(reader);
 
                 case nameof(IncomingReplicationHandler.MergedUpdateDatabaseChangeVectorCommand):
-                    return jsonSerializer.Deserialize<MergedUpdateDatabaseChangeVectorCommandDto>(reader);
+                    return jsonSerializer.Deserialize<IncomingReplicationHandler.MergedUpdateDatabaseChangeVectorCommandDto>(reader);
+
+                case nameof(IncomingPullReplicationHandler.MergedUpdateDatabaseChangeVectorForHubCommand):
+                    return jsonSerializer.Deserialize<IncomingPullReplicationHandler.MergedUpdateDatabaseChangeVectorForHubCommandDto>(reader);
 
                 case nameof(AdminRevisionsHandler.DeleteRevisionsCommand):
                     return jsonSerializer.Deserialize<DeleteRevisionsCommandDto>(reader);

--- a/src/Raven.Server/Documents/Replication/Incoming/IncomingPullReplicationHandler.cs
+++ b/src/Raven.Server/Documents/Replication/Incoming/IncomingPullReplicationHandler.cs
@@ -1,0 +1,310 @@
+﻿using System;
+using System.Collections.Generic;
+using System.Linq;
+using Raven.Client;
+using Raven.Client.Documents.Operations.Replication;
+using Raven.Client.Documents.Replication.Messages;
+using Raven.Server.Documents.Replication.ReplicationItems;
+using Raven.Server.Documents.TcpHandlers;
+using Raven.Server.ServerWide.Context;
+using Sparrow.Json;
+using Sparrow.Json.Parsing;
+using Sparrow.Server;
+using Voron;
+
+namespace Raven.Server.Documents.Replication.Incoming
+{
+    public class IncomingPullReplicationHandler : IncomingReplicationHandler
+    {
+        public readonly ReplicationLoader.PullReplicationParams _incomingPullReplicationParams;
+
+        private readonly bool _preventIncomingSinkDeletions;
+
+        private AllowedPathsValidator _allowedPathsValidator;
+
+        public string CertificateThumbprint;
+        public IncomingPullReplicationHandler(TcpConnectionOptions options, ReplicationLatestEtagRequest replicatedLastEtag, ReplicationLoader parent, JsonOperationContext.MemoryBuffer bufferToCopy, ReplicationLatestEtagRequest.ReplicationType replicationType, ReplicationLoader.PullReplicationParams pullReplicationParams) : 
+            base(options, replicatedLastEtag, parent, bufferToCopy, replicationType)
+        {
+            if (pullReplicationParams?.AllowedPaths != null && pullReplicationParams.AllowedPaths.Length > 0)
+                _allowedPathsValidator = new AllowedPathsValidator(pullReplicationParams.AllowedPaths);
+
+            _incomingPullReplicationParams = new ReplicationLoader.PullReplicationParams
+            {
+                AllowedPaths = pullReplicationParams?.AllowedPaths,
+                Mode = pullReplicationParams?.Mode ?? PullReplicationMode.None,
+                Name = pullReplicationParams?.Name,
+                PreventDeletionsMode = pullReplicationParams?.PreventDeletionsMode,
+                Type = ReplicationLoader.PullReplicationParams.ConnectionType.Incoming
+            };
+
+            _preventIncomingSinkDeletions = _incomingPullReplicationParams.PreventDeletionsMode?.HasFlag(PreventDeletionsMode.PreventSinkToHubDeletions) == true &&
+                                            _incomingPullReplicationParams.Mode == PullReplicationMode.SinkToHub;
+
+
+            CertificateThumbprint = options.Certificate?.Thumbprint;
+
+            AfterItemsReadFromStream = ValidateIncomingReplicationItemsPaths;
+        }
+
+        private void ValidateIncomingReplicationItemsPaths(DataForReplicationCommand dataForReplicationCommand)
+        {
+            if (_allowedPathsValidator == null && _preventIncomingSinkDeletions == false)
+                return;
+
+            HashSet<Slice> expectedAttachmentStreams = null;
+
+            foreach (var item in dataForReplicationCommand.ReplicatedItems)
+            {
+                if (_allowedPathsValidator != null)
+                {
+                    if (_allowedPathsValidator.ShouldAllow(item) == false)
+                    {
+                        throw new InvalidOperationException("Attempted to replicate " + _allowedPathsValidator.GetItemInformation(item) +
+                                                            ", which is not allowed, according to the allowed paths policy. Replication aborted");
+                    }
+
+                    switch (item)
+                    {
+                        case AttachmentReplicationItem a:
+                            expectedAttachmentStreams ??= new HashSet<Slice>(SliceComparer.Instance);
+                            expectedAttachmentStreams.Add(a.Key);
+                            break;
+                    }
+                }
+
+                if (_preventIncomingSinkDeletions)
+                {
+                    if (ReplicationLoader.IsOfTypePreventDeletions(item))
+                    {
+                        using (var infoHelper = new DocumentInfoHelper())
+                        {
+                            throw new InvalidOperationException(
+                                $"This hub does not allow for tombstone replication via pull replication '{_incomingPullReplicationParams.Name}'." +
+                                $" Replication of item '{infoHelper.GetItemInformation(item)}' has been aborted for sink connection: '{this.ConnectionInfo.ToString()}'.");
+                        }
+                    }
+                }
+            }
+
+            if (dataForReplicationCommand.ReplicatedAttachmentStreams != null)
+            {
+                foreach (var kvp in dataForReplicationCommand.ReplicatedAttachmentStreams)
+                {
+                    if (expectedAttachmentStreams == null || expectedAttachmentStreams.Contains(kvp.Key))
+                    {
+                        throw new InvalidOperationException("Attempted to attachment with hash: " + kvp.Key +
+                                                            ", but without a matching attachment key.");
+                    }
+                }
+            }
+        }
+
+        protected override void DisposeInternal()
+        {
+            try
+            {
+                _allowedPathsValidator?.Dispose();
+            }
+            catch
+            {
+                // ignore
+            }
+            base.DisposeInternal();
+        }
+
+        public override string FromToString => base.FromToString +
+                                               $"{(_incomingPullReplicationParams?.Name == null ? null : $"(pull definition: {_incomingPullReplicationParams?.Name})")}";
+
+        protected override TransactionOperationsMerger.MergedTransactionCommand GetMergeDocumentsCommand(DataForReplicationCommand data, long lastDocumentEtag)
+        {
+            return new MergedDocumentForPullReplicationCommand(data, lastDocumentEtag, _incomingPullReplicationParams);
+        }
+
+        protected override TransactionOperationsMerger.MergedTransactionCommand GetUpdateChangeVectorCommand(string changeVector, long lastDocumentEtag, string sourceDatabaseId, AsyncManualResetEvent trigger)
+        {
+            return new MergedUpdateDatabaseChangeVectorForHubCommand(changeVector, lastDocumentEtag, ConnectionInfo.SourceDatabaseId, trigger, _incomingPullReplicationParams);
+        }
+
+        internal class MergedDocumentForPullReplicationCommand : MergedDocumentReplicationCommand
+        {
+            private readonly bool _isHub;
+            private readonly bool _isSink;
+            private readonly PreventDeletionsMode? _preventDeletionsMode;
+
+            public MergedDocumentForPullReplicationCommand(DataForReplicationCommand replicationInfo, long lastEtag,
+                ReplicationLoader.PullReplicationParams pullReplicationParams) : base(replicationInfo, lastEtag)
+            {
+                _isHub = pullReplicationParams.Mode == PullReplicationMode.SinkToHub;
+                _isSink = pullReplicationParams.Mode == PullReplicationMode.HubToSink;
+                _preventDeletionsMode = pullReplicationParams.PreventDeletionsMode;
+            }
+
+            protected override string PreProcessItem(DocumentsOperationContext context, ReplicationBatchItem item)
+            {
+                HandleExpiredDocuments(context, item);
+
+                if (_isSink) 
+                    ReplaceKnownSinkEntries(context, ref item.ChangeVector);
+
+                var changeVectorToMerge = item.ChangeVector;
+
+                if (_isHub) 
+                    changeVectorToMerge = ReplaceUnknownEntriesWithSinkTag(context, ref item.ChangeVector);
+
+                return changeVectorToMerge;
+            }
+
+            protected override Slice HandleRevisionTombstone(DocumentsOperationContext context, LazyStringValue id, List<IDisposable> toDispose)
+            {
+                Slice idSlice;
+                var currentId = id.ToString();
+                ReplaceKnownSinkEntries(context, ref currentId);
+                toDispose.Add(Slice.From(context.Allocator, currentId, out idSlice));
+
+                return idSlice;
+            }
+
+            public void HandleExpiredDocuments(DocumentsOperationContext ctx, ReplicationBatchItem item)
+            {
+                if (_isSink)
+                    return;
+
+                if (_preventDeletionsMode?.HasFlag(PreventDeletionsMode.PreventSinkToHubDeletions) == false)
+                    return;
+
+                if (item is DocumentReplicationItem doc)
+                {
+                    if (doc.Data == null)
+                        return;
+
+                    RemoveExpiresFromSinkBatchItem(doc, ctx);
+                }
+            }
+
+
+            private static string ReplaceUnknownEntriesWithSinkTag(DocumentsOperationContext context, ref string changeVector)
+            {
+                var globalDbIds = context.LastDatabaseChangeVector?.ToChangeVectorList()?.Select(x => x.DbId).ToList();
+                var incoming = changeVector.ToChangeVectorList();
+                var knownEntries = new List<ChangeVectorEntry>();
+                var newIncoming = new List<ChangeVectorEntry>();
+
+                foreach (var entry in incoming)
+                {
+                    if (globalDbIds?.Contains(entry.DbId) == true)
+                    {
+                        newIncoming.Add(entry);
+                        knownEntries.Add(entry);
+                    }
+                    else
+                    {
+                        newIncoming.Add(new ChangeVectorEntry
+                        {
+                            DbId = entry.DbId,
+                            Etag = entry.Etag,
+                            NodeTag = ChangeVectorParser.SinkInt
+                        });
+
+                        context.DbIdsToIgnore ??= new HashSet<string>();
+                        context.DbIdsToIgnore.Add(entry.DbId);
+                    }
+                }
+
+                changeVector = newIncoming.SerializeVector();
+
+                return knownEntries.Count > 0 ? 
+                    knownEntries.SerializeVector() : 
+                    null;
+            }
+
+            private static void ReplaceKnownSinkEntries(DocumentsOperationContext context, ref string changeVector)
+            {
+                if (changeVector.Contains("SINK", StringComparison.OrdinalIgnoreCase) == false)
+                    return;
+
+                var global = context.LastDatabaseChangeVector?.ToChangeVectorList();
+                var incoming = changeVector.ToChangeVectorList();
+                var newIncoming = new List<ChangeVectorEntry>();
+
+                foreach (var entry in incoming)
+                {
+                    if (entry.NodeTag == ChangeVectorParser.SinkInt)
+                    {
+                        var found = global?.Find(x => x.DbId == entry.DbId) ?? default;
+                        if (found.Etag > 0)
+                        {
+                            newIncoming.Add(new ChangeVectorEntry
+                            {
+                                DbId = entry.DbId,
+                                Etag = entry.Etag,
+                                NodeTag = found.NodeTag
+                            });
+                            continue;
+                        }
+                    }
+
+                    newIncoming.Add(entry);
+                }
+
+                changeVector = newIncoming.SerializeVector();
+            }
+
+            private static void RemoveExpiresFromSinkBatchItem(DocumentReplicationItem doc, JsonOperationContext context)
+            {
+                if (doc.Data.TryGet(Constants.Documents.Metadata.Key, out BlittableJsonReaderObject metadata) == false)
+                    return;
+
+                if (metadata.TryGet(Constants.Documents.Metadata.Expires, out string _) == false)
+                    return;
+
+                metadata.Modifications ??= new DynamicJsonValue(metadata);
+                metadata.Modifications.Remove(Constants.Documents.Metadata.Expires);
+                using (var old = doc.Data)
+                {
+                    doc.Data = context.ReadObject(doc.Data, doc.Id, BlittableJsonDocumentBuilder.UsageMode.ToDisk);
+                }
+            }
+        }
+
+        internal class MergedUpdateDatabaseChangeVectorForHubCommand : MergedUpdateDatabaseChangeVectorCommand
+        {
+            private readonly ReplicationLoader.PullReplicationParams _pullReplicationParams;
+
+            public MergedUpdateDatabaseChangeVectorForHubCommand(string changeVector, long lastDocumentEtag, string sourceDatabaseId, AsyncManualResetEvent trigger,
+                ReplicationLoader.PullReplicationParams pullReplicationParams) : base(changeVector, lastDocumentEtag, sourceDatabaseId, trigger)
+            {
+                _pullReplicationParams = pullReplicationParams;
+            }
+            protected override bool TryUpdateChangeVector(DocumentsOperationContext context)
+            {
+                if (_pullReplicationParams.Mode == PullReplicationMode.SinkToHub)
+                    return false;
+
+                return base.TryUpdateChangeVector(context);
+            }
+
+            public override TransactionOperationsMerger.IReplayableCommandDto<TransactionOperationsMerger.MergedTransactionCommand> ToDto(JsonOperationContext context)
+            {
+                return new MergedUpdateDatabaseChangeVectorForHubCommandDto
+                {
+                    BaseDto = (MergedUpdateDatabaseChangeVectorCommandDto)base.ToDto(context),
+                    PullReplicationParams = _pullReplicationParams
+                };
+            }
+        }
+
+        internal class MergedUpdateDatabaseChangeVectorForHubCommandDto : TransactionOperationsMerger.IReplayableCommandDto<MergedUpdateDatabaseChangeVectorForHubCommand>
+        {
+            public MergedUpdateDatabaseChangeVectorCommandDto BaseDto;
+            public ReplicationLoader.PullReplicationParams PullReplicationParams;
+            public MergedUpdateDatabaseChangeVectorForHubCommand ToCommand(DocumentsOperationContext context, DocumentDatabase database)
+            {
+                var command = new MergedUpdateDatabaseChangeVectorForHubCommand(BaseDto.ChangeVector, BaseDto.LastDocumentEtag, BaseDto.SourceDatabaseId,
+                    new AsyncManualResetEvent(), PullReplicationParams);
+                return command;
+            }
+        }
+    }
+
+}

--- a/src/Raven.Server/Documents/Replication/Outgoing/OutgoingExternalReplicationHandler.cs
+++ b/src/Raven.Server/Documents/Replication/Outgoing/OutgoingExternalReplicationHandler.cs
@@ -1,0 +1,54 @@
+﻿using System.IO;
+using Raven.Client.Documents.Operations.Replication;
+using Raven.Client.Documents.Replication;
+using Raven.Client.Extensions;
+using Raven.Client.ServerWide.Commands;
+using Raven.Client.Util;
+using Raven.Server.Documents.Replication.Senders;
+using Raven.Server.ServerWide.Commands;
+using Sparrow.Logging;
+
+namespace Raven.Server.Documents.Replication.Outgoing
+{
+    public class OutgoingExternalReplicationHandler : OutgoingReplicationHandlerBase
+    {
+        private long? _taskId;
+
+        public OutgoingExternalReplicationHandler(ReplicationLoader parent, DocumentDatabase database, ReplicationNode node, TcpConnectionInfo connectionInfo) : 
+            base(parent, database, node, connectionInfo)
+        {
+            if (node is ExternalReplication externalReplication)
+            {
+                _taskId = externalReplication.TaskId;
+                DocumentsSend += (_) => UpdateExternalReplicationInfo();
+            }
+        }
+
+        public override ReplicationDocumentSenderBase CreateDocumentSender(Stream stream, Logger logger)
+        {
+            return new ExternalReplicationDocumentSender(stream, this, logger);
+        }
+
+        private void UpdateExternalReplicationInfo()
+        {
+            if (_taskId == null)
+                return;
+
+            var command = new UpdateExternalReplicationStateCommand(_database.Name, RaftIdGenerator.NewId())
+            {
+                ExternalReplicationState = new ExternalReplicationState
+                {
+                    TaskId = _taskId.Value,
+                    NodeTag = _parent._server.NodeTag,
+                    LastSentEtag = _lastSentDocumentEtag,
+                    SourceChangeVector = LastSentChangeVectorDuringHeartbeat,
+                    DestinationChangeVector = LastAcceptedChangeVector
+                }
+            };
+
+            // we don't wait to see if the command was applied on purpose
+            _parent._server.SendToLeaderAsync(command)
+                .IgnoreUnobservedExceptions();
+        }
+    }
+}

--- a/src/Raven.Server/Documents/Replication/Outgoing/OutgoingInternalReplicationHandler.cs
+++ b/src/Raven.Server/Documents/Replication/Outgoing/OutgoingInternalReplicationHandler.cs
@@ -1,0 +1,166 @@
+﻿using System;
+using System.Collections.Generic;
+using System.IO;
+using Raven.Client.Documents.Replication;
+using Raven.Client.Extensions;
+using Raven.Client.ServerWide.Commands;
+using Raven.Server.Documents.Replication.Senders;
+using Raven.Server.ServerWide.Context;
+using Raven.Server.Utils;
+using Sparrow.Json;
+using Sparrow.Logging;
+using Sparrow.Server;
+
+namespace Raven.Server.Documents.Replication.Outgoing
+{
+    public class OutgoingInternalReplicationHandler : OutgoingReplicationHandlerBase
+    {
+        private long _lastDestinationEtag;
+
+        public OutgoingInternalReplicationHandler(ReplicationLoader parent, DocumentDatabase database, ReplicationNode node,
+            TcpConnectionInfo connectionInfo) :
+            base(parent, database, node, connectionInfo)
+        {
+        }
+
+        public override ReplicationDocumentSenderBase CreateDocumentSender(Stream stream, Logger logger)
+        {
+            return new InternalReplicationDocumentSender(stream, this, logger);
+        }
+
+        protected override void UpdateDestinationChangeVectorHeartbeat(ReplicationMessageReply replicationBatchReply)
+        {
+            UpdateSibling(replicationBatchReply);
+            base.UpdateDestinationChangeVectorHeartbeat(replicationBatchReply);
+        }
+
+        public void UpdateSibling(ReplicationMessageReply replicationBatchReply)
+        {
+            var update = new UpdateSiblingCurrentEtag(replicationBatchReply, _waitForChanges);
+            if (update.InitAndValidate(_lastDestinationEtag))
+            {
+                using (_database.DocumentsStorage.ContextPool.AllocateOperationContext(out DocumentsOperationContext ctx))
+                using (ctx.OpenReadTransaction())
+                {
+                    if (update.DryRun(ctx))
+                    {
+                        // we intentionally not waiting here, there is nothing that depends on the timing on this, since this
+                        // is purely advisory. We just want to have the information up to date at some point, and we won't
+                        // miss anything much if this isn't there.
+                        _database.TxMerger.Enqueue(update).IgnoreUnobservedExceptions();
+                    }
+                }
+            }
+
+            _lastDestinationEtag = replicationBatchReply.CurrentEtag;
+        }
+
+        internal class UpdateSiblingCurrentEtag : TransactionOperationsMerger.MergedTransactionCommand
+        {
+            private readonly ReplicationMessageReply _replicationBatchReply;
+            private readonly AsyncManualResetEvent _trigger;
+            private string _dbId;
+
+            public UpdateSiblingCurrentEtag(ReplicationMessageReply replicationBatchReply, AsyncManualResetEvent trigger)
+            {
+                _replicationBatchReply = replicationBatchReply;
+                _trigger = trigger;
+            }
+
+            public bool InitAndValidate(long lastReceivedEtag)
+            {
+                if (false == Init())
+                {
+                    return false;
+                }
+
+                return _replicationBatchReply.CurrentEtag >= lastReceivedEtag;
+            }
+
+            internal bool Init()
+            {
+                if (Guid.TryParse(_replicationBatchReply.DatabaseId, out Guid dbGuid) == false)
+                    return false;
+
+                if (_replicationBatchReply.CurrentEtag == 0)
+                    return false;
+
+                _dbId = dbGuid.ToBase64Unpadded();
+
+                return true;
+            }
+
+            internal bool DryRun(DocumentsOperationContext context)
+            {
+                var changeVector = DocumentsStorage.GetDatabaseChangeVector(context);
+
+                var status = ChangeVectorUtils.GetConflictStatus(_replicationBatchReply.DatabaseChangeVector,
+                    changeVector);
+
+                if (status != ConflictStatus.AlreadyMerged)
+                    return false;
+
+                var result = ChangeVectorUtils.TryUpdateChangeVector(_replicationBatchReply.NodeTag, _dbId, _replicationBatchReply.CurrentEtag, changeVector);
+                return result.IsValid;
+            }
+
+            protected override long ExecuteCmd(DocumentsOperationContext context)
+            {
+                if (string.IsNullOrEmpty(context.LastDatabaseChangeVector))
+                    context.LastDatabaseChangeVector = DocumentsStorage.GetDatabaseChangeVector(context);
+
+                var status = ChangeVectorUtils.GetConflictStatus(_replicationBatchReply.DatabaseChangeVector,
+                    context.LastDatabaseChangeVector);
+
+                if (status != ConflictStatus.AlreadyMerged)
+                    return 0;
+
+                var result = ChangeVectorUtils.TryUpdateChangeVector(_replicationBatchReply.NodeTag, _dbId, _replicationBatchReply.CurrentEtag,
+                    context.LastDatabaseChangeVector);
+                if (result.IsValid)
+                {
+                    if (context.LastReplicationEtagFrom == null)
+                        context.LastReplicationEtagFrom = new Dictionary<string, long>();
+
+                    if (context.LastReplicationEtagFrom.ContainsKey(_replicationBatchReply.DatabaseId) == false)
+                    {
+                        context.LastReplicationEtagFrom[_replicationBatchReply.DatabaseId] = _replicationBatchReply.CurrentEtag;
+                    }
+
+                    context.LastDatabaseChangeVector = result.ChangeVector;
+
+                    context.Transaction.InnerTransaction.LowLevelTransaction.OnDispose += _ =>
+                    {
+                        try
+                        {
+                            _trigger.Set();
+                        }
+                        catch
+                        {
+                            //
+                        }
+                    };
+                }
+
+                return result.IsValid ? 1 : 0;
+            }
+
+            public override TransactionOperationsMerger.IReplayableCommandDto<TransactionOperationsMerger.MergedTransactionCommand> ToDto(JsonOperationContext context)
+            {
+                return new UpdateSiblingCurrentEtagDto { ReplicationBatchReply = _replicationBatchReply };
+            }
+        }
+
+        internal class UpdateSiblingCurrentEtagDto : TransactionOperationsMerger.IReplayableCommandDto<UpdateSiblingCurrentEtag>
+        {
+            public ReplicationMessageReply ReplicationBatchReply;
+
+            public UpdateSiblingCurrentEtag ToCommand(DocumentsOperationContext context, DocumentDatabase database)
+            {
+                var command = new UpdateSiblingCurrentEtag(ReplicationBatchReply, new AsyncManualResetEvent());
+                command.Init();
+                return command;
+            }
+        }
+    }
+}

--- a/src/Raven.Server/Documents/Replication/Outgoing/OutgoingPullReplicationHandler.cs
+++ b/src/Raven.Server/Documents/Replication/Outgoing/OutgoingPullReplicationHandler.cs
@@ -1,0 +1,68 @@
+﻿using System.IO;
+using Raven.Client.Documents.Operations.Replication;
+using Raven.Client.Documents.Replication;
+using Raven.Client.ServerWide.Commands;
+using Raven.Server.Documents.Replication.Senders;
+using Sparrow.Logging;
+
+namespace Raven.Server.Documents.Replication.Outgoing
+{
+    public abstract class OutgoingPullReplicationHandler : OutgoingReplicationHandlerBase
+    {
+        public string[] PathsToSend;
+        private string[] _destinationAcceptablePaths;
+        public ReplicationLoader.PullReplicationParams OutgoingPullReplicationParams;
+
+        public string CertificateThumbprint;
+
+        protected OutgoingPullReplicationHandler(ReplicationLoader parent, DocumentDatabase database, ReplicationNode node, TcpConnectionInfo connectionInfo) : 
+            base(parent, database, node, connectionInfo)
+        {
+        }
+
+        public override ReplicationDocumentSenderBase CreateDocumentSender(Stream stream, Logger logger)
+        {
+            return new FilteredReplicationDocumentSender(stream, this, logger, PathsToSend, _destinationAcceptablePaths);
+        }
+
+        protected override void ProcessHandshakeResponse((ReplicationMessageReply.ReplyType ReplyType, ReplicationMessageReply Reply) response)
+        {
+            base.ProcessHandshakeResponse(response);
+            // this is used when the other side lets us know what paths it is going to accept from us
+            // it supplements (but does not extend) what we are willing to send out 
+            _destinationAcceptablePaths = response.Reply.AcceptablePaths;
+        }
+    }
+
+    public class OutgoingPullReplicationHandlerAsHub : OutgoingPullReplicationHandler
+    {
+        // In case this is an outgoing pull replication from the hub
+        // we need to associate this instance to the replication definition.
+        public string PullReplicationDefinitionName;
+
+        public OutgoingPullReplicationHandlerAsHub(ReplicationLoader parent, DocumentDatabase database, ExternalReplication node, TcpConnectionInfo connectionInfo) : 
+            base(parent, database, node, connectionInfo)
+        {
+        }
+        public override string FromToString => $"{base.FromToString} (pull definition: {PullReplicationDefinitionName})";
+    }
+
+    public class OutgoingPullReplicationHandlerAsSink : OutgoingPullReplicationHandler
+    {
+        public OutgoingPullReplicationHandlerAsSink(ReplicationLoader parent, DocumentDatabase database, PullReplicationAsSink node, TcpConnectionInfo connectionInfo) : 
+            base(parent, database, node, connectionInfo)
+        {
+            CertificateThumbprint = _parent.GetCertificateForReplication(node, out _)?.Thumbprint;
+        }
+
+        protected override void ProcessHandshakeResponse((ReplicationMessageReply.ReplyType ReplyType, ReplicationMessageReply Reply) response)
+        {
+            base.ProcessHandshakeResponse(response);
+            OutgoingPullReplicationParams = new ReplicationLoader.PullReplicationParams
+            {
+                PreventDeletionsMode = response.Reply.PreventDeletionsMode,
+                Type = ReplicationLoader.PullReplicationParams.ConnectionType.Outgoing
+            };
+        }
+    }
+}

--- a/src/Raven.Server/Documents/Replication/ReplicationItems/AttachmentReplicationItem.cs
+++ b/src/Raven.Server/Documents/Replication/ReplicationItems/AttachmentReplicationItem.cs
@@ -1,6 +1,7 @@
 ﻿using System;
 using System.IO;
 using Raven.Client.Util;
+using Raven.Server.Documents.Replication.Stats;
 using Raven.Server.ServerWide.Context;
 using Sparrow;
 using Sparrow.Json;

--- a/src/Raven.Server/Documents/Replication/ReplicationItems/AttachmentTombstoneReplicationItem.cs
+++ b/src/Raven.Server/Documents/Replication/ReplicationItems/AttachmentTombstoneReplicationItem.cs
@@ -1,5 +1,6 @@
 ﻿using System.IO;
 using Raven.Client.Util;
+using Raven.Server.Documents.Replication.Stats;
 using Raven.Server.ServerWide.Context;
 using Sparrow;
 using Sparrow.Json;

--- a/src/Raven.Server/Documents/Replication/ReplicationItems/CounterReplicationItem.cs
+++ b/src/Raven.Server/Documents/Replication/ReplicationItems/CounterReplicationItem.cs
@@ -1,5 +1,6 @@
 ﻿using System.Diagnostics;
 using System.IO;
+using Raven.Server.Documents.Replication.Stats;
 using Raven.Server.ServerWide.Context;
 using Sparrow;
 using Sparrow.Json;

--- a/src/Raven.Server/Documents/Replication/ReplicationItems/DocumentReplicationItem.cs
+++ b/src/Raven.Server/Documents/Replication/ReplicationItems/DocumentReplicationItem.cs
@@ -1,5 +1,6 @@
 ﻿using System;
 using System.IO;
+using Raven.Server.Documents.Replication.Stats;
 using Raven.Server.ServerWide.Context;
 using Sparrow;
 using Sparrow.Json;

--- a/src/Raven.Server/Documents/Replication/ReplicationItems/ReplicationBatchItem.cs
+++ b/src/Raven.Server/Documents/Replication/ReplicationItems/ReplicationBatchItem.cs
@@ -3,6 +3,8 @@ using System.Collections.Generic;
 using System.IO;
 using System.Runtime.CompilerServices;
 using System.Text;
+using Raven.Server.Documents.Replication.Incoming;
+using Raven.Server.Documents.Replication.Stats;
 using Raven.Server.ServerWide;
 using Raven.Server.ServerWide.Context;
 using Sparrow;

--- a/src/Raven.Server/Documents/Replication/ReplicationItems/RevisionTombstoneReplicationItem.cs
+++ b/src/Raven.Server/Documents/Replication/ReplicationItems/RevisionTombstoneReplicationItem.cs
@@ -1,5 +1,6 @@
 ﻿using System.Diagnostics;
 using System.IO;
+using Raven.Server.Documents.Replication.Stats;
 using Raven.Server.ServerWide.Context;
 using Sparrow;
 using Sparrow.Json;

--- a/src/Raven.Server/Documents/Replication/ReplicationItems/TimeSeriesReplicationItem.cs
+++ b/src/Raven.Server/Documents/Replication/ReplicationItems/TimeSeriesReplicationItem.cs
@@ -2,6 +2,7 @@
 using System.Diagnostics;
 using System.IO;
 using Raven.Client.Util;
+using Raven.Server.Documents.Replication.Stats;
 using Raven.Server.Documents.TimeSeries;
 using Raven.Server.ServerWide.Context;
 using Sparrow;

--- a/src/Raven.Server/Documents/Replication/ReplicationMessageReply.cs
+++ b/src/Raven.Server/Documents/Replication/ReplicationMessageReply.cs
@@ -2,9 +2,9 @@
 
 namespace Raven.Server.Documents.Replication
 {
-    internal class ReplicationMessageReply
+    public class ReplicationMessageReply
     {
-        internal enum ReplyType
+        public enum ReplyType
         {
             None,
             Ok,

--- a/src/Raven.Server/Documents/Replication/Senders/ExternalReplicationDocumentSender.cs
+++ b/src/Raven.Server/Documents/Replication/Senders/ExternalReplicationDocumentSender.cs
@@ -1,0 +1,25 @@
+﻿using System;
+using System.Diagnostics;
+using System.IO;
+using Raven.Client.Documents.Operations.Replication;
+using Raven.Server.Documents.Replication.Outgoing;
+using Sparrow.Logging;
+
+namespace Raven.Server.Documents.Replication.Senders
+{
+    public class ExternalReplicationDocumentSender : ReplicationDocumentSenderBase
+    {
+        public ExternalReplicationDocumentSender(Stream stream, OutgoingReplicationHandlerBase parent, Logger log) : base(stream, parent, log)
+        {
+        }
+
+        protected override TimeSpan GetDelayReplication()
+        {
+            if (_parent.Destination is ExternalReplication external == false)
+                return TimeSpan.Zero;
+
+            _parent._parent._server.LicenseManager.AssertCanDelayReplication(external.DelayReplicationFor);
+            return external.DelayReplicationFor;
+        }
+    }
+}

--- a/src/Raven.Server/Documents/Replication/Senders/FilteredReplicationDocumentSender.cs
+++ b/src/Raven.Server/Documents/Replication/Senders/FilteredReplicationDocumentSender.cs
@@ -1,0 +1,67 @@
+﻿using System.IO;
+using Raven.Client.Documents.Operations.Replication;
+using Raven.Server.Documents.Replication.Outgoing;
+using Raven.Server.Documents.Replication.ReplicationItems;
+using Raven.Server.Documents.Replication.Stats;
+using Sparrow.Logging;
+
+namespace Raven.Server.Documents.Replication.Senders
+{
+    public class FilteredReplicationDocumentSender : ExternalReplicationDocumentSender
+    {
+        private readonly AllowedPathsValidator _pathsToSend, _destinationAcceptablePaths;
+        private readonly bool _shouldSkipSendingTombstones;
+
+        public FilteredReplicationDocumentSender(Stream stream, OutgoingPullReplicationHandler parent, Logger log, string[] pathsToSend, string[] destinationAcceptablePaths) : base(stream, parent, log)
+        {
+            if (pathsToSend != null && pathsToSend.Length > 0)
+                _pathsToSend = new AllowedPathsValidator(pathsToSend);
+            if (destinationAcceptablePaths != null && destinationAcceptablePaths.Length > 0)
+                _destinationAcceptablePaths = new AllowedPathsValidator(destinationAcceptablePaths);
+            
+            _shouldSkipSendingTombstones = _parent.Destination is PullReplicationAsSink sink && sink.Mode == PullReplicationMode.SinkToHub && 
+                                           _parent is OutgoingPullReplicationHandler pull &&
+                                           pull.OutgoingPullReplicationParams?.PreventDeletionsMode?.HasFlag(PreventDeletionsMode.PreventSinkToHubDeletions) == true &&
+                                           _parent._database.ForTestingPurposes?.ForceSendTombstones == false;
+        }
+
+        protected override bool ShouldSkip(ReplicationBatchItem item, OutgoingReplicationStatsScope stats, SkippedReplicationItemsInfo skippedReplicationItemsInfo)
+        {
+            if (ValidatorSaysToSkip(_pathsToSend) || ValidatorSaysToSkip(_destinationAcceptablePaths))
+                return true;
+
+            if (_shouldSkipSendingTombstones && ReplicationLoader.IsOfTypePreventDeletions(item))
+                return true;
+
+            return base.ShouldSkip(item, stats, skippedReplicationItemsInfo);
+
+            
+            bool ValidatorSaysToSkip(AllowedPathsValidator validator)
+            {
+                if (validator == null)
+                    return false;
+
+                if (validator.ShouldAllow(item))
+                    return false;
+
+                stats.RecordArtificialDocumentSkip();
+                skippedReplicationItemsInfo.Update(item);
+
+                if (Log.IsInfoEnabled)
+                {
+                    string key = validator.GetItemInformation(item);
+                    Log.Info($"Will skip sending {key} ({item.Type}) because it was not allowed according to the incoming .");
+                }
+
+                return true;
+            }
+        }
+
+        public override void Dispose()
+        {
+            _pathsToSend?.Dispose();
+            _destinationAcceptablePaths?.Dispose();
+            base.Dispose();
+        }
+    }
+}

--- a/src/Raven.Server/Documents/Replication/Senders/InternalReplicationDocumentSender.cs
+++ b/src/Raven.Server/Documents/Replication/Senders/InternalReplicationDocumentSender.cs
@@ -1,0 +1,13 @@
+﻿using System.IO;
+using Raven.Server.Documents.Replication.Outgoing;
+using Sparrow.Logging;
+
+namespace Raven.Server.Documents.Replication.Senders
+{
+    public class InternalReplicationDocumentSender : ReplicationDocumentSenderBase
+    {
+        public InternalReplicationDocumentSender(Stream stream, OutgoingReplicationHandlerBase parent, Logger log) : base(stream, parent, log)
+        {
+        }
+    }
+}

--- a/src/Raven.Server/Documents/Replication/Senders/MergedReplicationBatchEnumerator.cs
+++ b/src/Raven.Server/Documents/Replication/Senders/MergedReplicationBatchEnumerator.cs
@@ -1,0 +1,122 @@
+﻿using System;
+using System.Collections;
+using System.Collections.Generic;
+using System.Runtime.CompilerServices;
+using Raven.Server.Documents.Replication.ReplicationItems;
+using Raven.Server.Documents.Replication.Stats;
+
+namespace Raven.Server.Documents.Replication.Senders
+{
+    public class MergedReplicationBatchEnumerator : IEnumerator<ReplicationBatchItem>
+    {
+        private readonly List<IEnumerator<ReplicationBatchItem>> _workEnumerators = new List<IEnumerator<ReplicationBatchItem>>();
+        private ReplicationBatchItem _currentItem;
+        private readonly OutgoingReplicationStatsScope _documentRead;
+        private readonly OutgoingReplicationStatsScope _attachmentRead;
+        private readonly OutgoingReplicationStatsScope _tombstoneRead;
+        private readonly OutgoingReplicationStatsScope _countersRead;
+        private readonly OutgoingReplicationStatsScope _timeSeriesRead;
+
+        public MergedReplicationBatchEnumerator(
+            OutgoingReplicationStatsScope documentRead,
+            OutgoingReplicationStatsScope attachmentRead,
+            OutgoingReplicationStatsScope tombstoneRead,
+            OutgoingReplicationStatsScope counterRead,
+            OutgoingReplicationStatsScope timeSeriesRead
+        )
+        {
+            _documentRead = documentRead;
+            _attachmentRead = attachmentRead;
+            _tombstoneRead = tombstoneRead;
+            _countersRead = counterRead;
+            _timeSeriesRead = timeSeriesRead;
+        }
+
+        public void AddEnumerator(ReplicationBatchItem.ReplicationItemType type, IEnumerator<ReplicationBatchItem> enumerator)
+        {
+            if (enumerator == null)
+                return;
+
+            if (enumerator.MoveNext())
+            {
+                using (GetStatsFor(type).Start())
+                {
+                    _workEnumerators.Add(enumerator);
+                }
+            }
+        }
+
+        [MethodImpl(MethodImplOptions.AggressiveInlining)]
+        private OutgoingReplicationStatsScope GetStatsFor(ReplicationBatchItem.ReplicationItemType type)
+        {
+            switch (type)
+            {
+                case ReplicationBatchItem.ReplicationItemType.Document:
+                    return _documentRead;
+
+                case ReplicationBatchItem.ReplicationItemType.Attachment:
+                    return _attachmentRead;
+
+                case ReplicationBatchItem.ReplicationItemType.CounterGroup:
+                    return _countersRead;
+
+                case ReplicationBatchItem.ReplicationItemType.DocumentTombstone:
+                case ReplicationBatchItem.ReplicationItemType.AttachmentTombstone:
+                case ReplicationBatchItem.ReplicationItemType.RevisionTombstone:
+                    return _tombstoneRead;
+
+                case ReplicationBatchItem.ReplicationItemType.TimeSeriesSegment:
+                case ReplicationBatchItem.ReplicationItemType.DeletedTimeSeriesRange:
+                    return _timeSeriesRead;
+
+                default:
+                    throw new ArgumentOutOfRangeException();
+            }
+        }
+
+        public bool MoveNext()
+        {
+            if (_workEnumerators.Count == 0)
+                return false;
+
+            var current = _workEnumerators[0];
+            for (var index = 1; index < _workEnumerators.Count; index++)
+            {
+                if (_workEnumerators[index].Current.Etag < current.Current.Etag)
+                {
+                    current = _workEnumerators[index];
+                }
+            }
+
+            _currentItem = current.Current;
+            using (GetStatsFor(_currentItem.Type).Start())
+            {
+                if (current.MoveNext() == false)
+                {
+                    _workEnumerators.Remove(current);
+                }
+
+                return true;
+            }
+        }
+
+        public void Reset()
+        {
+            throw new NotSupportedException();
+        }
+
+        public ReplicationBatchItem Current => _currentItem;
+
+        object IEnumerator.Current => Current;
+
+        public void Dispose()
+        {
+            foreach (var workEnumerator in _workEnumerators)
+            {
+                workEnumerator.Dispose();
+            }
+
+            _workEnumerators.Clear();
+        }
+    }
+}

--- a/src/Raven.Server/Documents/Replication/Stats/IncomingConnectionInfo.cs
+++ b/src/Raven.Server/Documents/Replication/Stats/IncomingConnectionInfo.cs
@@ -2,7 +2,7 @@
 using Raven.Client.Documents.Replication.Messages;
 using Sparrow.Json.Parsing;
 
-namespace Raven.Server.Documents.Replication
+namespace Raven.Server.Documents.Replication.Stats
 {
     public class IncomingConnectionInfo : IEquatable<IncomingConnectionInfo>
     {

--- a/src/Raven.Server/Documents/Replication/Stats/IncomingReplicationStatsAggregator.cs
+++ b/src/Raven.Server/Documents/Replication/Stats/IncomingReplicationStatsAggregator.cs
@@ -4,7 +4,7 @@ using System.Linq;
 using Raven.Client.Documents.Replication;
 using Raven.Server.Utils.Stats;
 
-namespace Raven.Server.Documents.Replication
+namespace Raven.Server.Documents.Replication.Stats
 {
     public class IncomingReplicationStatsAggregator : StatsAggregator<IncomingReplicationRunStats, IncomingReplicationStatsScope>
     {

--- a/src/Raven.Server/Documents/Replication/Stats/LiveReplicationPulsesCollector.cs
+++ b/src/Raven.Server/Documents/Replication/Stats/LiveReplicationPulsesCollector.cs
@@ -1,9 +1,11 @@
 ﻿using System;
 using Raven.Client.Documents.Replication;
+using Raven.Server.Documents.Replication.Incoming;
+using Raven.Server.Documents.Replication.Outgoing;
 using Sparrow.Json.Parsing;
 using Sparrow.Server.Collections;
 
-namespace Raven.Server.Documents.Replication
+namespace Raven.Server.Documents.Replication.Stats
 {
     public interface ILiveReplicationCollector : IDisposable
     {
@@ -33,12 +35,12 @@ namespace Raven.Server.Documents.Replication
                 OutgoingHandlerAdded(handler);
         }
 
-        private void OutgoingHandlerRemoved(OutgoingReplicationHandler handler)
+        private void OutgoingHandlerRemoved(OutgoingReplicationHandlerBase handler)
         {
             handler.HandleReplicationPulse -= HandleReplicationPulse;
         }
 
-        private void OutgoingHandlerAdded(OutgoingReplicationHandler handler)
+        private void OutgoingHandlerAdded(OutgoingReplicationHandlerBase handler)
         {
             handler.HandleReplicationPulse += HandleReplicationPulse;
         }

--- a/src/Raven.Server/Documents/Replication/Stats/OutgoingReplicationStatsAggregator.cs
+++ b/src/Raven.Server/Documents/Replication/Stats/OutgoingReplicationStatsAggregator.cs
@@ -5,7 +5,7 @@ using Raven.Client.Documents.Replication;
 using Raven.Server.Utils.Stats;
 using Sparrow;
 
-namespace Raven.Server.Documents.Replication
+namespace Raven.Server.Documents.Replication.Stats
 {
     public class OutgoingReplicationStatsAggregator : StatsAggregator<OutgoingReplicationRunStats, OutgoingReplicationStatsScope>
     {

--- a/src/Raven.Server/Documents/Replication/Stats/ReplicationRunStatsBase.cs
+++ b/src/Raven.Server/Documents/Replication/Stats/ReplicationRunStatsBase.cs
@@ -3,7 +3,7 @@ using System.Collections.Generic;
 using Raven.Client.Documents.Replication;
 using Raven.Client.Util;
 
-namespace Raven.Server.Documents.Replication
+namespace Raven.Server.Documents.Replication.Stats
 {
     public abstract class ReplicationRunStatsBase
     {

--- a/src/Raven.Server/Web/System/OngoingTasksHandler.cs
+++ b/src/Raven.Server/Web/System/OngoingTasksHandler.cs
@@ -32,6 +32,8 @@ using Raven.Server.Documents.ETL.Providers.ElasticSearch;
 using Raven.Server.Documents.ETL.Providers.Raven;
 using Raven.Server.Documents.PeriodicBackup;
 using Raven.Server.Documents.Replication;
+using Raven.Server.Documents.Replication.Incoming;
+using Raven.Server.Documents.Replication.Outgoing;
 using Raven.Server.Json;
 using Raven.Server.NotificationCenter.Notifications;
 using Raven.Server.NotificationCenter.Notifications.Details;
@@ -133,7 +135,8 @@ namespace Raven.Server.Web.System
             {
                 foreach (var incoming in handlers)
                 {
-                    if (incoming._incomingPullReplicationParams?.Name == sinkReplication.HubName)
+                    if (incoming is IncomingPullReplicationHandler pullHandler && 
+                        pullHandler._incomingPullReplicationParams?.Name == sinkReplication.HubName)
                     {
                         handler = incoming;
                         res = (incoming.ConnectionInfo.SourceUrl, OngoingTaskConnectionStatus.Active);
@@ -181,7 +184,7 @@ namespace Raven.Server.Web.System
 
         private IEnumerable<OngoingTask> CollectPullReplicationAsHubTasks(ClusterTopology clusterTopology)
         {
-            var pullReplicationHandlers = Database.ReplicationLoader.OutgoingHandlers.Where(n => n.IsPullReplicationAsHub).ToList();
+            var pullReplicationHandlers = Database.ReplicationLoader.OutgoingHandlers.Where(n => n is OutgoingPullReplicationHandler).ToList();
             foreach (var handler in pullReplicationHandlers)
             {
                 var ex = handler.Destination as ExternalReplication;

--- a/test/RachisTests/DatabaseCluster/ReplicationTests.cs
+++ b/test/RachisTests/DatabaseCluster/ReplicationTests.cs
@@ -19,6 +19,7 @@ using Raven.Client.ServerWide.Operations.Certificates;
 using Raven.Server;
 using Raven.Server.Documents;
 using Raven.Server.Documents.Replication;
+using Raven.Server.Documents.Replication.Outgoing;
 using Raven.Server.ServerWide.Context;
 using Raven.Tests.Core.Utils.Entities;
 using Sparrow.Json;
@@ -1087,7 +1088,7 @@ namespace RachisTests.DatabaseCluster
             using (var store2 = GetDocumentStore())
             {
                 var database = await GetDocumentDatabaseInstanceFor(store1);
-                var handlers = new HashSet<OutgoingReplicationHandler>();
+                var handlers = new HashSet<OutgoingReplicationHandlerBase>();
 
                 database.ReplicationLoader.OutgoingReplicationAdded += handler =>
                 {

--- a/test/SlowTests/Issues/RavenDB_15538.cs
+++ b/test/SlowTests/Issues/RavenDB_15538.cs
@@ -17,6 +17,8 @@ using Raven.Server.Config;
 using Raven.Server.Documents;
 using Raven.Server.Documents.Replication;
 using Raven.Server.Documents.Replication.ReplicationItems;
+using Raven.Server.Documents.Replication.Senders;
+using Raven.Server.Documents.Replication.Stats;
 using Raven.Server.ServerWide.Context;
 using Sparrow.Json;
 using Xunit;
@@ -139,8 +141,7 @@ namespace SlowTests.Issues
                         using (context1.OpenReadTransaction())
                         {
                             Assert.NotNull(database);
-
-                            firstReplicationOrder.AddRange(ReplicationDocumentSender.GetReplicationItems(database, context1, etag, new ReplicationDocumentSender.ReplicationStats
+                            firstReplicationOrder.AddRange(ReplicationDocumentSenderBase.GetReplicationItems(database, context1, etag, new ReplicationDocumentSenderBase.ReplicationStats
                             {
                                 DocumentRead = new OutgoingReplicationStatsScope(new OutgoingReplicationRunStats()),
                                 AttachmentRead = new OutgoingReplicationStatsScope(new OutgoingReplicationRunStats())
@@ -162,7 +163,7 @@ namespace SlowTests.Issues
                         Assert.True(WaitForValue(() => AssertReplication(firstDestination, firstDestination.Database, stats), true, reasonableWaitTime, 333));
                         using (context1.OpenReadTransaction())
                         {
-                            firstReplicationOrder.AddRange(ReplicationDocumentSender.GetReplicationItems(database, context1, etag, new ReplicationDocumentSender.ReplicationStats
+                            firstReplicationOrder.AddRange(ReplicationDocumentSenderBase.GetReplicationItems(database, context1, etag, new ReplicationDocumentSenderBase.ReplicationStats
                             {
                                 DocumentRead = new OutgoingReplicationStatsScope(new OutgoingReplicationRunStats()),
                                 AttachmentRead = new OutgoingReplicationStatsScope(new OutgoingReplicationRunStats())
@@ -176,7 +177,7 @@ namespace SlowTests.Issues
                         using var disposable3 = database2.DocumentsStorage.ContextPool.AllocateOperationContext(out DocumentsOperationContext context);
                         using (context.OpenReadTransaction())
                         {
-                            secondReplicationOrder.AddRange(ReplicationDocumentSender.GetReplicationItems(database2, context, 0, new ReplicationDocumentSender.ReplicationStats
+                            secondReplicationOrder.AddRange(ReplicationDocumentSenderBase.GetReplicationItems(database2, context, 0, new ReplicationDocumentSenderBase.ReplicationStats
                             {
                                 DocumentRead = new OutgoingReplicationStatsScope(new OutgoingReplicationRunStats()),
                                 AttachmentRead = new OutgoingReplicationStatsScope(new OutgoingReplicationRunStats())

--- a/test/SlowTests/Server/Replication/ExternalReplicationTests.cs
+++ b/test/SlowTests/Server/Replication/ExternalReplicationTests.cs
@@ -8,6 +8,7 @@ using Raven.Client.Documents.Operations.ETL;
 using Raven.Client.Documents.Operations.Replication;
 using Raven.Client.Documents.Replication;
 using Raven.Server.Documents.Replication;
+using Raven.Server.Documents.Replication.Stats;
 using Raven.Server.Utils.Stats;
 using Raven.Tests.Core.Utils.Entities;
 using Xunit;

--- a/test/SlowTests/Server/Replication/PullReplicationTests.cs
+++ b/test/SlowTests/Server/Replication/PullReplicationTests.cs
@@ -360,6 +360,8 @@ namespace SlowTests.Server.Replication
         [Fact]
         public async Task FailoverOnHubNodeFail()
         {
+            DebuggerAttachedTimeout.DisableLongTimespan = true;
+
             var clusterSize = 3;
             var (_, hub) = await CreateRaftCluster(clusterSize);
             var (minionNodes, minion) = await CreateRaftCluster(clusterSize);

--- a/test/Tests.Infrastructure/ClusterTestBase.cs
+++ b/test/Tests.Infrastructure/ClusterTestBase.cs
@@ -23,6 +23,7 @@ using Raven.Server;
 using Raven.Server.Config;
 using Raven.Server.Documents;
 using Raven.Server.Documents.Replication;
+using Raven.Server.Documents.Replication.Stats;
 using Raven.Server.Rachis;
 using Raven.Server.ServerWide;
 using Raven.Server.ServerWide.Context;

--- a/tools/TypingsGenerator/Program.cs
+++ b/tools/TypingsGenerator/Program.cs
@@ -75,6 +75,7 @@ using Raven.Server.Documents.PeriodicBackup.Restore;
 using Raven.Server.Documents.Queries;
 using Raven.Server.Documents.Queries.Dynamic;
 using Raven.Server.Documents.Replication;
+using Raven.Server.Documents.Replication.Stats;
 using Raven.Server.Documents.Revisions;
 using Raven.Server.Documents.Studio;
 using Raven.Server.Documents.Subscriptions;


### PR DESCRIPTION
### Issue link

https://issues.hibernatingrhinos.com/issue/RavenDB-13106

### Additional description

We want to reuse most of the replication code for resharding connection and in order to do so we need to abstract current code.

### Type of change

- Optimization

### How risky is the change?

- High

### Backward compatibility

- Not relevant

### Is it platform specific issue?

- No

### Documentation update

- No documentation update is needed 

### Testing 

Current tests should cover it all

### Is there any existing behavior change of other features due to this change?

- No

### UI work

- No UI work is needed
