### PR TITLE
RavenDB-16928 Allow to retry SQL db deletion when disposing SQL ETL t…

### DIFF
--- a/test/SlowTests/Server/Documents/ETL/SQL/SqlEtlTests.cs
+++ b/test/SlowTests/Server/Documents/ETL/SQL/SqlEtlTests.cs
@@ -1168,7 +1168,7 @@ CREATE TABLE [dbo].[Orders]
                             using (var session = store.OpenSession())
                             {
 
-                                for (int i = 0; i < 10; i++)
+                                for (int i = 0; i < 6; i++)
                                 {
                                     var order = new Orders.Order();
                                     session.Store(order);


### PR DESCRIPTION
### Issue link

https://issues.hibernatingrhinos.com/issue/RavenDB-16928

### Additional description

Fix for occasional SQL ETL tests failures due to inability to drop a database

### Type of change

- Test fix

### How risky is the change?

- Low 

### Backward compatibility

- Not relevant

### Is it platform specific issue?

- No

### Documentation update

- No documentation update is needed 

### Testing 

- Existing tests will verify the fix

### Is there any existing behavior change of other features due to this change?

- No

### UI work

- No UI work is needed
