### PR TITLE
RavenDB-17937 - prevent putting ReplacementOf indexes in the database record

### DIFF
--- a/src/Raven.Server/ServerWide/ClusterStateMachine.cs
+++ b/src/Raven.Server/ServerWide/ClusterStateMachine.cs
@@ -11,6 +11,7 @@ using System.Security.Cryptography.X509Certificates;
 using System.Text;
 using System.Threading;
 using System.Threading.Tasks;
+using Raven.Client.Documents.Indexes;
 using Raven.Client.Documents.Operations.Backups;
 using Raven.Client.Documents.Operations.Configuration;
 using Raven.Client.Documents.Operations.Replication;
@@ -1408,6 +1409,8 @@ namespace Raven.Server.ServerWide
                         shouldSetClientConfigEtag = ShouldSetClientConfigEtag(newDatabaseRecord, oldDatabaseRecord?.Raw);
                     }
 
+                    VerifyIndexNames(newDatabaseRecord);
+
                     using (var databaseRecordAsJson = UpdateDatabaseRecordIfNeeded(databaseExists, shouldSetClientConfigEtag, index, addDatabaseCommand, newDatabaseRecord, context))
                     {
                         UpdateValue(index, items, valueNameLowered, valueName, databaseRecordAsJson);
@@ -1460,6 +1463,32 @@ namespace Raven.Server.ServerWide
                             }
                         }
 
+                    }
+
+                    void VerifyIndexNames(BlittableJsonReaderObject dbDoc)
+                    {
+                        if (dbDoc.TryGet(nameof(DatabaseRecord.Indexes), out BlittableJsonReaderObject obj) == false || obj == null)
+                            return;
+
+                        var propertyDetails = new BlittableJsonReaderObject.PropertyDetails();
+                        for (var i = 0; i < obj.Count; i++)
+                        {
+                            obj.GetPropertyByIndex(i, ref propertyDetails);
+
+                            if (propertyDetails.Value == null)
+                                continue;
+
+                            if (!(propertyDetails.Value is BlittableJsonReaderObject bjro))
+                                continue;
+                            
+                            if (bjro.TryGet(nameof(IndexDefinition.Name), out string indexName) == false || indexName == null)
+                                continue;
+
+                            if (indexName.StartsWith(Constants.Documents.Indexing.SideBySideIndexNamePrefix, StringComparison.OrdinalIgnoreCase))
+                            {
+                                throw new RachisInvalidOperationException($"Index name cannot start with {Constants.Documents.Indexing.SideBySideIndexNamePrefix} but got {indexName}");
+                            }
+                        }
                     }
                 }
             }

--- a/src/Raven.Server/Web/System/AdminDatabasesHandler.cs
+++ b/src/Raven.Server/Web/System/AdminDatabasesHandler.cs
@@ -360,7 +360,14 @@ namespace Raven.Server.Web.System
                             case IndexType.JavaScriptMap:
                             case IndexType.JavaScriptMapReduce:
                                 var indexDefinition = index.GetIndexDefinition();
-                                databaseRecord.Indexes.Add(indexDefinition.Name, indexDefinition);
+                                if (index.Name.StartsWith(Constants.Documents.Indexing.SideBySideIndexNamePrefix, StringComparison.OrdinalIgnoreCase))
+                                {
+                                    // the side by side index is the last version of this index
+                                    // and it's the one that should be stored in the database record
+                                    indexDefinition.Name = indexDefinition.Name[Constants.Documents.Indexing.SideBySideIndexNamePrefix.Length..];
+                                }
+
+                                databaseRecord.Indexes[indexDefinition.Name] = indexDefinition;
                                 break;
                             default:
                                 throw new NotSupportedException(index.Type.ToString());

--- a/src/Raven.Server/Web/System/AdminDatabasesHandler.cs
+++ b/src/Raven.Server/Web/System/AdminDatabasesHandler.cs
@@ -360,7 +360,7 @@ namespace Raven.Server.Web.System
                             case IndexType.JavaScriptMap:
                             case IndexType.JavaScriptMapReduce:
                                 var indexDefinition = index.GetIndexDefinition();
-                                if (index.Name.StartsWith(Constants.Documents.Indexing.SideBySideIndexNamePrefix, StringComparison.OrdinalIgnoreCase))
+                                if (indexDefinition.Name.StartsWith(Constants.Documents.Indexing.SideBySideIndexNamePrefix, StringComparison.OrdinalIgnoreCase))
                                 {
                                     // the side by side index is the last version of this index
                                     // and it's the one that should be stored in the database record

--- a/src/Raven.Server/Web/System/AdminDatabasesHandler.cs
+++ b/src/Raven.Server/Web/System/AdminDatabasesHandler.cs
@@ -334,6 +334,8 @@ namespace Raven.Server.Web.System
                 documentDatabase.Initialize(options);
 
                 var indexesPath = databaseConfiguration.Indexing.StoragePath.FullPath;
+                var sideBySideIndexes = new Dictionary<string, IndexDefinition>();
+
                 foreach (var indexPath in Directory.GetDirectories(indexesPath))
                 {
                     Index index = null;
@@ -365,9 +367,11 @@ namespace Raven.Server.Web.System
                                     // the side by side index is the last version of this index
                                     // and it's the one that should be stored in the database record
                                     indexDefinition.Name = indexDefinition.Name[Constants.Documents.Indexing.SideBySideIndexNamePrefix.Length..];
+                                    sideBySideIndexes.Add(indexDefinition.Name, indexDefinition);
+                                    continue;
                                 }
 
-                                databaseRecord.Indexes[indexDefinition.Name] = indexDefinition;
+                                databaseRecord.Indexes.Add(indexDefinition.Name, indexDefinition);
                                 break;
                             default:
                                 throw new NotSupportedException(index.Type.ToString());
@@ -382,6 +386,11 @@ namespace Raven.Server.Web.System
                     {
                         index?.Dispose();
                     }
+                }
+
+                foreach ((string key, IndexDefinition value) in sideBySideIndexes)
+                {
+                    databaseRecord.Indexes[key] = value;
                 }
             }
         }

--- a/test/SlowTests/Issues/RavenDB-17937.cs
+++ b/test/SlowTests/Issues/RavenDB-17937.cs
@@ -1,0 +1,104 @@
+﻿using System;
+using System.Linq;
+using System.Threading.Tasks;
+using FastTests;
+using FastTests.Client;
+using Raven.Client.Documents.Indexes;
+using Raven.Client.Documents.Operations.Indexes;
+using Raven.Client.ServerWide;
+using Raven.Client.ServerWide.Operations;
+using Raven.Server.Config;
+using Xunit;
+using Xunit.Abstractions;
+
+namespace SlowTests.Issues
+{
+    public class RavenDB_17937 : RavenTestBase
+    {
+        public RavenDB_17937(ITestOutputHelper output) : base(output)
+        {
+        }
+
+        [Fact]
+        public async Task Can_Add_Database_With_Side_By_Side_Indexes()
+        {
+            var path = NewDataPath();
+
+            using (var store = GetDocumentStore(new Options
+                   {
+                       RunInMemory = false,
+                       Path = path
+            }))
+            {
+                using (var session = store.OpenAsyncSession())
+                {
+                    await session.StoreAsync(new Query.Order());
+                    await session.SaveChangesAsync();
+                }
+
+                var index1 = new Index1();
+                await index1.ExecuteAsync(store);
+                WaitForIndexing(store);
+
+                await new Index2().ExecuteAsync(store);
+                WaitForIndexing(store, allowErrors: true, timeout: TimeSpan.FromSeconds(5));
+
+                var record = await store.Maintenance.Server.SendAsync(new GetDatabaseRecordOperation(store.Database));
+                Assert.Equal(1, record.Indexes.Count);
+                Assert.Equal(index1.IndexName, record.Indexes.First().Key);
+
+                var indexStats = await store.Maintenance.SendAsync(new GetIndexesStatisticsOperation());
+                Assert.Equal(2, indexStats.Length);
+
+                await store.Maintenance.Server.SendAsync(new DeleteDatabasesOperation(store.Database, hardDelete: false));
+
+                await store.Maintenance.Server.SendAsync(new CreateDatabaseOperation(new DatabaseRecord(store.Database)
+                {
+                    Settings =
+                    {
+                        {RavenConfiguration.GetKey(x => x.Core.RunInMemory), "false" },
+                        {RavenConfiguration.GetKey(x => x.Core.DataDirectory), path }
+                    }
+                }));
+
+                record = await store.Maintenance.Server.SendAsync(new GetDatabaseRecordOperation(store.Database));
+                Assert.Equal(index1.IndexName, record.Indexes.First().Key);
+                Assert.Equal("docs.Orders.Select(order => new {\r\n    order = order,\r\n    x = 0\r\n}).Select(this0 => new {\r\n    Count = 1 / this0.x\r\n})", record.Indexes.First().Value.Maps.First());
+
+                indexStats = await store.Maintenance.SendAsync(new GetIndexesStatisticsOperation());
+                Assert.Equal(2, indexStats.Length);
+            }
+        }
+
+        private class Index1 : AbstractIndexCreationTask<Query.Order>
+        {
+            public override string IndexName => "Index";
+
+            public Index1()
+            {
+                Map = orders =>
+                    from order in orders
+                    select new
+                    {
+                        Count = 1
+                    };
+            }
+        }
+
+        private class Index2 : AbstractIndexCreationTask<Query.Order>
+        {
+            public override string IndexName => "Index";
+
+            public Index2()
+            {
+                Map = orders =>
+                    from order in orders
+                    let x = 0
+                    select new
+                    {
+                        Count = 1 / x
+                    };
+            }
+        }
+    }
+}

--- a/test/SlowTests/Issues/RavenDB-17937.cs
+++ b/test/SlowTests/Issues/RavenDB-17937.cs
@@ -66,7 +66,7 @@ namespace SlowTests.Issues
 
                 record = await store.Maintenance.Server.SendAsync(new GetDatabaseRecordOperation(store.Database));
                 Assert.Equal(index1.IndexName, record.Indexes.First().Key);
-                Assert.Equal("docs.Orders.Select(order => new {\r\n    order = order,\r\n    x = 0\r\n}).Select(this0 => new {\r\n    Count = 1 / this0.x\r\n})", record.Indexes.First().Value.Maps.First());
+                Assert.Contains("Count = 1 / this0.x", record.Indexes.First().Value.Maps.First());
 
                 indexStats = await store.Maintenance.SendAsync(new GetIndexesStatisticsOperation());
                 Assert.Equal(2, indexStats.Length);

--- a/test/SlowTests/Issues/RavenDB-17937.cs
+++ b/test/SlowTests/Issues/RavenDB-17937.cs
@@ -1,10 +1,12 @@
 ﻿using System;
+using System.Collections.Generic;
 using System.Linq;
 using System.Threading.Tasks;
 using FastTests;
 using FastTests.Client;
 using Raven.Client.Documents.Indexes;
 using Raven.Client.Documents.Operations.Indexes;
+using Raven.Client.Exceptions;
 using Raven.Client.ServerWide;
 using Raven.Client.ServerWide.Operations;
 using Raven.Server.Config;
@@ -20,7 +22,7 @@ namespace SlowTests.Issues
         }
 
         [Fact]
-        public async Task Can_Add_Database_With_Side_By_Side_Indexes()
+        public async Task Can_Add_Database_Folder_With_Side_By_Side_Indexes()
         {
             var path = NewDataPath();
 
@@ -67,6 +69,37 @@ namespace SlowTests.Issues
 
                 indexStats = await store.Maintenance.SendAsync(new GetIndexesStatisticsOperation());
                 Assert.Equal(2, indexStats.Length);
+            }
+        }
+
+        [Fact]
+        public async Task Throw_If_Creating_A_Database_With_Side_By_Side_Indexes()
+        {
+            using (var store = GetDocumentStore())
+            {
+                var indexName = $"{Raven.Client.Constants.Documents.Indexing.SideBySideIndexNamePrefix}test";
+                var error = await Assert.ThrowsAsync<RavenException>(async () =>
+                {
+                    await store.Maintenance.Server.SendAsync(new CreateDatabaseOperation(new DatabaseRecord(GetDatabaseName())
+                    {
+                        Indexes = new Dictionary<string, IndexDefinition>
+                        {
+                            {
+                                indexName,
+                                new IndexDefinition
+                                {
+                                    Name = indexName,
+                                    Maps = new HashSet<string>
+                                    {
+                                        "docs.Orders.Select(order => new {\r\n    order = order,\r\n    x = 0\r\n}).Select(this0 => new {\r\n    Count = 1 / this0.x\r\n})"
+                                    }
+                                }
+                            }
+                        }
+                    }));
+                });
+
+                Assert.Contains("Index name cannot start with ReplacementOf/", error.Message);
             }
         }
 

--- a/test/SlowTests/Issues/RavenDB_10921.cs
+++ b/test/SlowTests/Issues/RavenDB_10921.cs
@@ -1,4 +1,5 @@
 ﻿using FastTests;
+using Raven.Client;
 using Raven.Client.Documents.Indexes;
 using Raven.Client.Documents.Operations.Indexes;
 using Raven.Client.Exceptions;
@@ -22,7 +23,7 @@ namespace SlowTests.Issues
                 {
                     store.Maintenance.Send(new PutIndexesOperation(new IndexDefinition()
                     {
-                        Name = "ReplacementOf/test",
+                        Name = $"{Constants.Documents.Indexing.SideBySideIndexNamePrefix}test",
                         Maps =
                     {
                         "from u in docs.Users select new { u.Age }"
@@ -30,7 +31,7 @@ namespace SlowTests.Issues
                     }));
                 });
 
-                Assert.Contains("Index name must not start with 'ReplacementOf/'. Provided index name: 'ReplacementOf/test'", ex.Message);
+                Assert.Contains($"Index name must not start with '{Constants.Documents.Indexing.SideBySideIndexNamePrefix}'. Provided index name: '{Constants.Documents.Indexing.SideBySideIndexNamePrefix}test'", ex.Message);
             }
         }
     }

--- a/test/SlowTests/Issues/RavenDB_12269.cs
+++ b/test/SlowTests/Issues/RavenDB_12269.cs
@@ -1,5 +1,6 @@
 ﻿using System.Threading.Tasks;
 using FastTests;
+using Raven.Client;
 using Raven.Client.Documents;
 using Raven.Client.Documents.Indexes;
 using Raven.Client.Documents.Operations.Indexes;
@@ -56,7 +57,7 @@ namespace SlowTests.Issues
                 }));
 
                 
-                var replacementIndex = db.IndexStore.GetIndex("ReplacementOf/Users_ByName");
+                var replacementIndex = db.IndexStore.GetIndex($"{Constants.Documents.Indexing.SideBySideIndexNamePrefix}Users_ByName");
 
                 // let's try to force calling storageEnvironment.Cleanup() inside ExecuteIndexing method
                 replacementIndex.LowMemory(LowMemorySeverity.ExtremelyLow);

--- a/test/SlowTests/Issues/RavenDB_15163.cs
+++ b/test/SlowTests/Issues/RavenDB_15163.cs
@@ -3,6 +3,7 @@ using System.IO;
 using System.Linq;
 using System.Threading;
 using FastTests;
+using Raven.Client;
 using Raven.Client.Documents.Indexes;
 using Raven.Client.Documents.Operations.Indexes;
 using Xunit;
@@ -39,7 +40,7 @@ namespace SlowTests.Issues
                     Name = "Users/ByName"
                 }));
 
-                var replacementIndexInstance = database.IndexStore.GetIndex("ReplacementOf/Users/ByName");
+                var replacementIndexInstance = database.IndexStore.GetIndex($"{Constants.Documents.Indexing.SideBySideIndexNamePrefix}Users/ByName");
 
                 var thrown = false;
 
@@ -56,7 +57,7 @@ namespace SlowTests.Issues
 
                 var cts = new CancellationTokenSource(TimeSpan.FromSeconds(30));
 
-                database.IndexStore.ReplaceIndexes("Users/ByName", "ReplacementOf/Users/ByName", cts.Token);
+                database.IndexStore.ReplaceIndexes("Users/ByName", $"{Constants.Documents.Indexing.SideBySideIndexNamePrefix}Users/ByName", cts.Token);
 
                 var indexes = database.IndexStore.GetIndexes().ToList();
 
@@ -71,7 +72,7 @@ namespace SlowTests.Issues
                     Name = "Users/ByName"
                 }));
 
-                replacementIndexInstance = database.IndexStore.GetIndex("ReplacementOf/Users/ByName");
+                replacementIndexInstance = database.IndexStore.GetIndex($"{Constants.Documents.Indexing.SideBySideIndexNamePrefix}Users/ByName");
 
                 database.IndexStore.ForTestingPurposesOnly().DuringIndexReplacement_OnOldIndexDeletion += () =>
                 {
@@ -83,7 +84,7 @@ namespace SlowTests.Issues
 
                 cts = new CancellationTokenSource(TimeSpan.FromSeconds(30));
 
-                Assert.Throws<IOException>(() => database.IndexStore.ReplaceIndexes("Users/ByName", "ReplacementOf/Users/ByName", cts.Token));
+                Assert.Throws<IOException>(() => database.IndexStore.ReplaceIndexes("Users/ByName", $"{Constants.Documents.Indexing.SideBySideIndexNamePrefix}Users/ByName", cts.Token));
 
                 indexes = database.IndexStore.GetIndexes().ToList();
 

--- a/test/SlowTests/Server/Documents/Indexing/MapReduce/OutputReduceToCollectionTests.cs
+++ b/test/SlowTests/Server/Documents/Indexing/MapReduce/OutputReduceToCollectionTests.cs
@@ -469,7 +469,7 @@ namespace SlowTests.Server.Documents.Indexing.MapReduce
                 var replacementIndex = (MapReduceIndex)db.IndexStore.GetIndexes().Single(x => x.Name.StartsWith(Constants.Documents.Indexing.SideBySideIndexNamePrefix));
                 var replacementIndexReduceOutputIndex = replacementIndex.Definition.ReduceOutputIndex.Value;
 
-                store.Maintenance.Send(new DeleteIndexOperation("ReplacementOf/DailyInvoicesIndex"));
+                store.Maintenance.Send(new DeleteIndexOperation($"{Constants.Documents.Indexing.SideBySideIndexNamePrefix}DailyInvoicesIndex"));
 
                 var indexes = db.IndexStore.GetIndexes().ToList();
 

--- a/test/Tests.Infrastructure/RavenTestBase.cs
+++ b/test/Tests.Infrastructure/RavenTestBase.cs
@@ -553,7 +553,7 @@ namespace FastTests
                 var indexes = databaseStatistics.Indexes
                     .Where(x => x.State != IndexState.Disabled);
 
-                var staleIndexesCount = indexes.Count(x => x.IsStale || x.Name.StartsWith("ReplacementOf/"));
+                var staleIndexesCount = indexes.Count(x => x.IsStale || x.Name.StartsWith(Constants.Documents.Indexing.SideBySideIndexNamePrefix));
                 if (staleIndexesCount == 0)
                     return;
 


### PR DESCRIPTION
### Issue link

https://issues.hibernatingrhinos.com/issue/RavenDB-17937

### Additional description

Prevent putting an index that starts with `ReplacementOf` in the database record.

### Type of change

- Bug fix

### How risky is the change?

- Low 

### Testing 

- Tests have been added that prove the fix is effective or that the feature works