### PR TITLE
RavenDB-17875 - Out of memory on 5.3 / x86 builds

### DIFF
--- a/src/Sparrow/Utils/ReadWriteCompressedStream.cs
+++ b/src/Sparrow/Utils/ReadWriteCompressedStream.cs
@@ -41,7 +41,7 @@ namespace Sparrow.Utils
                 alreadyOnBuffer.Valid = alreadyOnBuffer.Used = 0; // consume all the data from the buffer
             }
 
-            _inner = inner ?? throw new ArgumentNullException(nameof(inner));
+            _inner = innerInput ?? throw new ArgumentNullException(nameof(inner));
             _input = ZstdStream.Decompress(inner);
             _output = ZstdStream.Compress(inner);
             _dispose = new DisposeOnce<SingleAttempt>(DisposeInternal);

--- a/src/Sparrow/Utils/ZstdLib.cs
+++ b/src/Sparrow/Utils/ZstdLib.cs
@@ -190,6 +190,7 @@ namespace Sparrow.Utils
 
                 if (PlatformDetails.Is32Bits)
                 {
+                    // set windowLog size to 256KB 
                     var rc = ZSTD_CCtx_setParameter(cctx, ZSTD_cParameter.ZSTD_c_windowLog, 16);
                     AssertZstdSuccess(rc);
                 }

--- a/src/Sparrow/Utils/ZstdStream.cs
+++ b/src/Sparrow/Utils/ZstdStream.cs
@@ -57,7 +57,7 @@ namespace Sparrow.Utils
                 {
                     var output = new ZstdLib.ZSTD_outBuffer {Source = pBuffer, Position = UIntPtr.Zero, Size = (UIntPtr)buffer.Length};
                     var input = new ZstdLib.ZSTD_inBuffer {Source = pOutput, Position = UIntPtr.Zero, Size = (UIntPtr)_decompressionInput.Length};
-                    var v = ZstdLib.ZSTD_decompressStream(_compressContext.Streaming, &output, &input);
+                    var v = ZstdLib.ZSTD_decompressStream(_compressContext.Decompression, &output, &input);
                     ZstdLib.AssertZstdSuccess(v);
                     _compressedBytesCount += (long)input.Position;
                     _uncompressedBytesCount += (long)output.Position;

--- a/test/RachisTests/DatabaseCluster/ClusterDatabaseMaintenance.cs
+++ b/test/RachisTests/DatabaseCluster/ClusterDatabaseMaintenance.cs
@@ -311,20 +311,10 @@ namespace RachisTests.DatabaseCluster
             }
         }
 
-        [Fact32Bit]
-        public async Task ReshuffleAfterPromotionX86()
+        [Fact]
+        public async Task ReshuffleAfterPromotion()
         {
-            await ReshuffleAfterPromotion(10);
-        }
-        
-        [Fact64Bit]
-        public async Task ReshuffleAfterPromotionX64()
-        {
-            await ReshuffleAfterPromotion(25);
-        }
-        
-        private async Task ReshuffleAfterPromotion(int numberOfDatabases)
-        {
+            var numberOfDatabases = 25;
             var clusterSize = 3;
             var settings = new Dictionary<string, string>()
             {


### PR DESCRIPTION
### Issue link

https://issues.hibernatingrhinos.com/issue/RavenDB-17875

### Additional description

https://github.com/ravendb/ravendb/pull/13568#pullrequestreview-867098794
The solution was to set a lower value for `Window_Size` in the case of 32 bit (256KB). 

** This PR includes, in addition, the fix for https://issues.hibernatingrhinos.com/issue/RavenDB-17884

### Type of change

- Bug fix

### How risky is the change?

- Low 

### Backward compatibility

- Non breaking change

### Is it platform specific issue?

- No

### Documentation update

- No documentation update is needed 

### Testing 

- It has been verified by manual testing

### Is there any existing behavior change of other features due to this change?

- No

### UI work

- No UI work is needed
