### PR TITLE
RavenDB-17707 - StressTests.Client.TimeSeries.Policies.TimeSeriesConf…

### DIFF
--- a/src/Raven.Server/Documents/Handlers/TimeSeriesHandler.cs
+++ b/src/Raven.Server/Documents/Handlers/TimeSeriesHandler.cs
@@ -979,7 +979,7 @@ namespace Raven.Server.Documents.Handlers
 
                     foreach (var item in items)
                     {
-                        using (var slicer = new TimeSeriesSliceHolder(context, docId, item.Name, collectionName.Name).WithBaseline(item.Baseline))
+                        using (var slicer = new TimeSeriesSliceHolder(context, docId, item.Name).WithBaseline(item.Baseline))
                         {
                             if (tss.TryAppendEntireSegmentFromSmuggler(context, slicer.TimeSeriesKeySlice, collectionName, item))
                             {

--- a/src/Raven.Server/Documents/Replication/IncomingReplicationHandler.cs
+++ b/src/Raven.Server/Documents/Replication/IncomingReplicationHandler.cs
@@ -1506,7 +1506,7 @@ namespace Raven.Server.Documents.Replication
 
             private static void UpdateTimeSeriesNameIfNeeded(DocumentsOperationContext context, LazyStringValue docId, TimeSeriesReplicationItem segment, TimeSeriesStorage tss)
             {
-                using (var slicer = new TimeSeriesSliceHolder(context, docId, segment.Name, collection: null))
+                using (var slicer = new TimeSeriesSliceHolder(context, docId, segment.Name))
                 {
                     var localName = tss.Stats.GetTimeSeriesNameOriginalCasing(context, slicer.StatsKey);
                     if (localName == null || localName.CompareTo(segment.Name) <= 0)

--- a/src/Raven.Server/Documents/TimeSeries/TimeSeriesReader.cs
+++ b/src/Raven.Server/Documents/TimeSeries/TimeSeriesReader.cs
@@ -123,7 +123,7 @@ namespace Raven.Server.Documents.TimeSeries
             if (_from > _to)
                 return false;
 
-            using (var holder = new TimeSeriesSliceHolder(_context, _documentId, _name, collection: null).WithBaseline(_from))
+            using (var holder = new TimeSeriesSliceHolder(_context, _documentId, _name).WithBaseline(_from))
             {
                 if (_table.SeekOneBackwardByPrimaryKeyPrefix(holder.TimeSeriesPrefixSlice, holder.TimeSeriesKeySlice, out _tvr) == false)
                 {
@@ -148,7 +148,7 @@ namespace Raven.Server.Documents.TimeSeries
 
             while (true)
             {
-                using (var holder = new TimeSeriesSliceHolder(_context, _documentId, _name, collection: null).WithBaseline(date))
+                using (var holder = new TimeSeriesSliceHolder(_context, _documentId, _name).WithBaseline(date))
                 {
                     if (_table.SeekOneBackwardByPrimaryKeyPrefix(holder.TimeSeriesPrefixSlice, holder.TimeSeriesKeySlice, out _tvr) == false)
                         return null;

--- a/src/Raven.Server/Documents/TimeSeries/TimeSeriesSliceHolder.cs
+++ b/src/Raven.Server/Documents/TimeSeries/TimeSeriesSliceHolder.cs
@@ -25,7 +25,7 @@ namespace Raven.Server.Documents.TimeSeries
         public Slice TimeSeriesKeySlice, TimeSeriesPrefixSlice, LowerTimeSeriesName, DocumentKeyPrefix, StatsKey, CollectionSlice, NameSlice;
         public DateTime CurrentBaseline;
 
-        public TimeSeriesSliceHolder(DocumentsOperationContext context, string documentId, string name, string collection)
+        public TimeSeriesSliceHolder(DocumentsOperationContext context, string documentId, string name, string collection = null)
         {
             _context = context;
             DocId = documentId;

--- a/src/Raven.Server/Documents/TimeSeries/TimeSeriesStats.cs
+++ b/src/Raven.Server/Documents/TimeSeries/TimeSeriesStats.cs
@@ -86,7 +86,7 @@ namespace Raven.Server.Documents.TimeSeries
             if (count == 0)
                 return;
 
-            using (var slicer = new TimeSeriesSliceHolder(context, docId, name, collection.Name))
+            using (var slicer = new TimeSeriesSliceHolder(context, docId, name))
             {
                 UpdateCountOfExistingStats(context, slicer, collection, count);
             }
@@ -295,7 +295,7 @@ namespace Raven.Server.Documents.TimeSeries
 
         public (long Count, DateTime Start, DateTime End) GetStats(DocumentsOperationContext context, string docId, string name)
         {
-            using (var slicer = new TimeSeriesSliceHolder(context, docId, name, collection: null))
+            using (var slicer = new TimeSeriesSliceHolder(context, docId, name))
             {
                 return GetStats(context, slicer);
             }
@@ -303,7 +303,7 @@ namespace Raven.Server.Documents.TimeSeries
 
         public string GetTimeSeriesNameOriginalCasing(DocumentsOperationContext context, string docId, string name)
         {
-            using (var slicer = new TimeSeriesSliceHolder(context, docId, name, collection: null))
+            using (var slicer = new TimeSeriesSliceHolder(context, docId, name))
             {
                 return GetTimeSeriesNameOriginalCasing(context, slicer.StatsKey);
             }

--- a/src/Raven.Server/Documents/TimeSeries/TimeSeriesStorage.cs
+++ b/src/Raven.Server/Documents/TimeSeries/TimeSeriesStorage.cs
@@ -334,7 +334,7 @@ namespace Raven.Server.Documents.TimeSeries
             var collectionName = _documentsStorage.ExtractCollectionName(context, collection);
             var table = GetOrCreateTimeSeriesTable(context.Transaction.InnerTransaction, collectionName);
 
-            using (var slicer = new TimeSeriesSliceHolder(context, documentId, name, collection))
+            using (var slicer = new TimeSeriesSliceHolder(context, documentId, name))
             {
                 var stats = Stats.GetStats(context, slicer);
                 if (stats == default || stats.Count == 0)
@@ -1804,7 +1804,7 @@ namespace Raven.Server.Documents.TimeSeries
 
         internal LazyStringValue GetTimeSeriesNameOriginalCasing(DocumentsOperationContext context, string documentId, string name)
         {
-            using (var slicer = new TimeSeriesSliceHolder(context, documentId, name, collection: null))
+            using (var slicer = new TimeSeriesSliceHolder(context, documentId, name))
             {
                 return Stats.GetTimeSeriesNameOriginalCasing(context, slicer.StatsKey);
             }
@@ -2244,7 +2244,7 @@ namespace Raven.Server.Documents.TimeSeries
                     Debug.Assert(noNaN, "Rollup has NaN");
                 }
 
-                using (var slicer = new TimeSeriesSliceHolder(context, docId, name, collectionName.Name).WithBaseline(baseline))
+                using (var slicer = new TimeSeriesSliceHolder(context, docId, name).WithBaseline(baseline))
                 {
                     Debug.Assert(tss.EnsureNoOverlap(context, slicer.TimeSeriesKeySlice, collectionName, segment, baseline), "Segment is overlapping another segment");
                 }


### PR DESCRIPTION
…igurationTestsStress.RapidRetentionAndRollupInACluster- revert changes

### Issue link

https://issues.hibernatingrhinos.com/issue/RavenDB-17707

### Additional description

Reverting PR changes 


### Type of change

- Bug fix

### How risky is the change?

- Not relevant

### Backward compatibility

- Not relevant

### Is it platform specific issue?

- No

### Documentation update

- No documentation update is needed 

### Testing 

- It has been verified by manual testing

### Is there any existing behavior change of other features due to this change?

- No

### UI work

- No UI work is needed
