### PR TITLE
RavenDB-15840 - SlowTests.Client.TimeSeries.Policies.TimeSeriesConfig…

### DIFF
--- a/test/StressTests/Client/TimeSeries/Policies/TimeSeriesConfigurationTestsStress.cs
+++ b/test/StressTests/Client/TimeSeries/Policies/TimeSeriesConfigurationTestsStress.cs
@@ -76,6 +76,14 @@ namespace StressTests.Client.TimeSeries.Policies
                 await Task.Delay((TimeSpan)(p4.RetentionTime * 2));
                 // nothing should be left
 
+                using (var session = store.OpenSession())
+                {
+                    session.Store(new User { Name = "Karmel" }, "marker/2");
+                    session.SaveChanges();
+
+                    Assert.True(await WaitForDocumentInClusterAsync<User>(cluster.Nodes, store.Database, "marker/2", null, TimeSpan.FromSeconds(15)));
+                }
+
                 foreach (var node in cluster.Nodes)
                 {
                     using (var nodeStore = GetDocumentStore(new Options


### PR DESCRIPTION
…urationTests.RapidRetentionAndRollupInACluster

### Issue link

https://issues.hibernatingrhinos.com/issue/RavenDB-15840

### Additional description

Adding a check to ensure the replication ping-pong ends.
**_Note that it may not solve the issue - but it can help us narrow the causes._**


### Type of change

- Bug fix

### How risky is the change?

- Low 


### Backward compatibility

- Non breaking change


### Is it platform specific issue?

- No

### Documentation update

- No documentation update is needed 

### Testing 

- It has been verified by manual testing

### Is there any existing behavior change of other features due to this change?

- No

### UI work

- No UI work is needed
