### PR TITLE
RavenDB-16935 - SlowTests.Server.Documents.TimeSeries.TimeSeriesTombs…

### DIFF
--- a/src/Raven.Server/Documents/TimeSeries/TimeSeriesSliceHolder.cs
+++ b/src/Raven.Server/Documents/TimeSeries/TimeSeriesSliceHolder.cs
@@ -47,12 +47,12 @@ namespace Raven.Server.Documents.TimeSeries
             Memory.Set(SegmentBuffer.Ptr, 0, TimeSeriesStorage.MaxSegmentSize);
         }
 
-        public TimeSeriesSliceHolder WithEtag(long etag)
+        public TimeSeriesSliceHolder WithChangeVectorHash(long hash)
         {
             if (TimeSeriesKeySlice.Content.HasValue == false)
                 _externalScopesToDispose.Add(Slice.External(_context.Allocator, TimeSeriesKeyBuffer.Ptr, TimeSeriesKeyBuffer.Length, out TimeSeriesKeySlice));
 
-            *(long*)(TimeSeriesKeyBuffer.Ptr + TimeSeriesKeyBuffer.Length - sizeof(long)) = Bits.SwapBytes(etag);
+            *(long*)(TimeSeriesKeyBuffer.Ptr + TimeSeriesKeyBuffer.Length - sizeof(long)) = Bits.SwapBytes(hash);
             return this;
         }
 

--- a/src/Raven.Server/Documents/TimeSeries/TimeSeriesStorage.cs
+++ b/src/Raven.Server/Documents/TimeSeries/TimeSeriesStorage.cs
@@ -312,6 +312,8 @@ namespace Raven.Server.Documents.TimeSeries
                     {
                         return null;
                     }
+
+                    // in case of a hash collision (Conflict) we overwrite the existing entry
                 }
 
                 using (table.Allocate(out var tvb))

--- a/src/Raven.Server/Documents/TimeSeries/TimeSeriesStorage.cs
+++ b/src/Raven.Server/Documents/TimeSeries/TimeSeriesStorage.cs
@@ -304,10 +304,9 @@ namespace Raven.Server.Documents.TimeSeries
 
             using (var sliceHolder = new TimeSeriesSliceHolder(context, documentId, name, collectionName.Name).WithChangeVectorHash(hash))
             {
-                if (table.SeekOneBackwardByPrimaryKeyPrefix(sliceHolder.TimeSeriesPrefixSlice, sliceHolder.TimeSeriesKeySlice, out var segmentValueReader) ||
-                    table.SeekOnePrimaryKeyWithPrefix(sliceHolder.TimeSeriesPrefixSlice, sliceHolder.TimeSeriesKeySlice, out segmentValueReader))
+                if (table.ReadByKey(sliceHolder.TimeSeriesKeySlice, out var tableValueReader))
                 {
-                    var item = CreateDeletedRangeItem(context, ref segmentValueReader);
+                    var item = CreateDeletedRangeItem(context, ref tableValueReader);
                     if (ChangeVectorUtils.GetConflictStatus(changeVector, item.ChangeVector) == ConflictStatus.AlreadyMerged)
                     {
                         return null;
@@ -339,7 +338,6 @@ namespace Raven.Server.Documents.TimeSeries
 
             if (InsertDeletedRange(context, deletionRangeRequest, remoteChangeVector) == null)
                 return null;
-
 
             var collection = deletionRangeRequest.Collection;
             var documentId = deletionRangeRequest.DocumentId;

--- a/test/SlowTests/Server/Documents/TimeSeries/TimeSeriesTombstoneCleaner.cs
+++ b/test/SlowTests/Server/Documents/TimeSeries/TimeSeriesTombstoneCleaner.cs
@@ -329,7 +329,6 @@ namespace SlowTests.Server.Documents.TimeSeries
                         var c2 = storage.DocumentsStorage.TimeSeriesStorage.GetNumberOfTimeSeriesDeletedRanges(context);
                         var c3 = storage.DocumentsStorage.TimeSeriesStorage.GetNumberOfTimeSeriesPendingDeletionSegments(context);
 
-
                         Assert.Equal(750, c2);
                         Assert.Equal(2, c3);
                     }

--- a/test/SlowTests/Server/Documents/TimeSeries/TimeSeriesTombstoneCleaner.cs
+++ b/test/SlowTests/Server/Documents/TimeSeries/TimeSeriesTombstoneCleaner.cs
@@ -170,7 +170,11 @@ namespace SlowTests.Server.Documents.TimeSeries
                     tsCount1 = storage.DocumentsStorage.TimeSeriesStorage.GetNumberOfTimeSeriesDeletedRanges(context);
                 }
 
-                var storage2 = await Server.ServerStore.DatabasesLandlord.TryGetOrCreateResourceStore(store1.Database);
+                var storage2 = await Server.ServerStore.DatabasesLandlord.TryGetOrCreateResourceStore(store2.Database);
+
+                cleaner = storage2.TombstoneCleaner;
+                await cleaner.ExecuteCleanup();
+
                 long tsCount2 = 0;
                 using (storage2.DocumentsStorage.ContextPool.AllocateOperationContext(out DocumentsOperationContext context))
                 using (context.OpenReadTransaction())


### PR DESCRIPTION
…toneCleaner.CleanTimeSeriesTombstonesInTheClusterWithOnlyFullBackup

### Issue link

https://issues.hibernatingrhinos.com/issue/RavenDB-16935

### Additional description

**Bug explanation:**

`TimeSeriesDeletedRanges` items were sent to all nodes in the cluster but a replication failure occurred and the items were sent again.
The items were already handled on all nodes the first time, but they were written again in the `DeleteRangesSchema` as new entries the second time (although no changes were actually made). The reason is the `RangeKey` was of the form: ‘**_document ID|TS name|local etag_**’ - we increment the `etag` at the very beginning, so each time a new `RangeKey` is created. 

**Solution proposed in the PR:**

We changed the `RangeKey` to ‘_**document ID|TS name|Hash(change vector)**_’.
By changing the `RangeKey` we managed to extract the relevant entry (if it exists) and compare the entry’s change vector and the remote change vector (the one from the replication). 
In case the `ConflictStatus` is `AlreadyMerged` - we can safely return and do nothing (this can only happen if we received the same range twice).
In case the `ConflictStatus` is `Update` - we can overwrite the existing entry with new values. 


### Type of change

- Bug fix

### How risky is the change?

- Low 

### Backward compatibility

- Non breaking change

### Is it platform specific issue?

- No

### Documentation update

- No documentation update is needed 

### Testing 

- It has been verified by manual testing

### Is there any existing behavior change of other features due to this change?

- No

### UI work

- No UI work is needed
