### PR TITLE
RavenDB-17948 async should return `Task` instead of `void`

### DIFF
--- a/src/Raven.Server/Documents/Handlers/Debugging/ServerWideDebugInfoPackageHandler.cs
+++ b/src/Raven.Server/Documents/Handlers/Debugging/ServerWideDebugInfoPackageHandler.cs
@@ -72,7 +72,7 @@ namespace Raven.Server.Documents.Handlers.Debugging
                         await WriteServerInfo(archive, jsonOperationContext, localEndpointClient);
                         foreach (var databaseName in requestHeader.DatabaseNames)
                         {
-                            WriteDatabaseRecord(archive, databaseName, jsonOperationContext, transactionOperationContext);
+                            await WriteDatabaseRecord(archive, databaseName, jsonOperationContext, transactionOperationContext);
                             await WriteDatabaseInfo(archive, jsonOperationContext, localEndpointClient, databaseName);
                         }
 
@@ -251,7 +251,7 @@ namespace Raven.Server.Documents.Handlers.Debugging
                             rawRecord.Topology.RelevantFor(ServerStore.NodeTag) == false)
                             continue;
                         
-                        WriteDatabaseRecord(archive, databaseName, jsonOperationContext, transactionOperationContext, token);
+                        await WriteDatabaseRecord(archive, databaseName, jsonOperationContext, transactionOperationContext, token);
 
                         if (rawRecord.IsDisabled ||
                             rawRecord.DatabaseState == DatabaseStateStatus.RestoreInProgress ||
@@ -351,7 +351,7 @@ namespace Raven.Server.Documents.Handlers.Debugging
             }
         }
 
-        private async void WriteDatabaseRecord(ZipArchive archive, string databaseName, JsonOperationContext jsonOperationContext, TransactionOperationContext transactionCtx, CancellationToken token = default)
+        private async Task WriteDatabaseRecord(ZipArchive archive, string databaseName, JsonOperationContext jsonOperationContext, TransactionOperationContext transactionCtx, CancellationToken token = default)
         {
             var entryName = DebugInfoPackageUtils.GetOutputPathFromRouteInformation("/database-record", databaseName, "json");
             try


### PR DESCRIPTION
### Issue link

https://issues.hibernatingrhinos.com/issue/RavenDB-17948

### Type of change

- Bug fix

### How risky is the change?

- Low 

### Backward compatibility

- Not relevant

### Is it platform specific issue?

- No

### Documentation update

- No documentation update is needed 

### Testing 

- It has been verified by manual testing

### Is there any existing behavior change of other features due to this change?

- No

### UI work

- No UI work is needed
