### PR TITLE
RavenDB-16626 - changed old RachisApplyExceptions to appropriate subscription exceptions and added missing db deletion check

### DIFF
--- a/src/Raven.Client/Documents/Subscriptions/SubscriptionWorker.cs
+++ b/src/Raven.Client/Documents/Subscriptions/SubscriptionWorker.cs
@@ -340,8 +340,8 @@ namespace Raven.Client.Documents.Subscriptions
 
                 if (connectionStatus.Type == SubscriptionConnectionServerMessage.MessageType.Error)
                     message += $". Exception: {connectionStatus.Exception}";
-
-                throw new Exception(message);
+                
+                throw new SubscriptionMessageTypeException(message);
             }
 
             switch (connectionStatus.Status)

--- a/src/Raven.Client/Documents/Subscriptions/SubscriptionWorker.cs
+++ b/src/Raven.Client/Documents/Subscriptions/SubscriptionWorker.cs
@@ -772,6 +772,10 @@ namespace Raven.Client.Documents.Subscriptions
 
                     _processingCts.Cancel();
                     return false;
+
+                case SubscriptionMessageTypeException _:
+                    goto default;
+
                 case SubscriptionInUseException _:
                 case SubscriptionDoesNotExistException _:
                 case SubscriptionInvalidStateException _:

--- a/src/Raven.Client/Exceptions/Documents/Subscriptions/SubscriptionMessageTypeException.cs
+++ b/src/Raven.Client/Exceptions/Documents/Subscriptions/SubscriptionMessageTypeException.cs
@@ -1,0 +1,15 @@
+﻿using System;
+
+namespace Raven.Client.Exceptions.Documents.Subscriptions
+{
+    public class SubscriptionMessageTypeException : SubscriptionException
+    {
+        public SubscriptionMessageTypeException(string message) : base(message)
+        {
+        }
+
+        public SubscriptionMessageTypeException(string message, Exception inner) : base(message, inner)
+        {
+        }
+    }
+}

--- a/src/Raven.Server/ServerWide/Commands/Subscriptions/ToggleSubscriptionStateCommand.cs
+++ b/src/Raven.Server/ServerWide/Commands/Subscriptions/ToggleSubscriptionStateCommand.cs
@@ -1,6 +1,7 @@
 using System;
 using JetBrains.Annotations;
 using Raven.Client.Documents.Subscriptions;
+using Raven.Client.Exceptions.Documents.Subscriptions;
 using Raven.Client.Json.Converters;
 using Raven.Client.ServerWide;
 using Raven.Server.Rachis;
@@ -51,7 +52,7 @@ namespace Raven.Server.ServerWide.Commands.Subscriptions
             {
                 if (items.ReadByKey(valueNameLowered, out var tvr) == false)
                 {
-                    throw new RachisApplyException($"Cannot find subscription {index}");
+                    throw new SubscriptionDoesNotExistException($"Cannot find subscription {index}");
                 }
 
                 var ptr = tvr.Read(2, out int size);

--- a/src/Raven.Server/ServerWide/Commands/Subscriptions/UpdateSubscriptionClientConnectionTime.cs
+++ b/src/Raven.Server/ServerWide/Commands/Subscriptions/UpdateSubscriptionClientConnectionTime.cs
@@ -1,5 +1,7 @@
 ﻿using System;
 using Raven.Client.Documents.Subscriptions;
+using Raven.Client.Exceptions.Database;
+using Raven.Client.Exceptions.Documents.Subscriptions;
 using Raven.Client.ServerWide;
 using Raven.Server.Rachis;
 using Sparrow.Json;
@@ -28,14 +30,21 @@ namespace Raven.Server.ServerWide.Commands.Subscriptions
         {
             var itemId = GetItemId();
             if (existingValue == null)
-                throw new RachisApplyException($"Subscription with id {itemId} does not exist");
+                throw new SubscriptionDoesNotExistException($"Subscription with id {itemId} does not exist");
 
             var subscription = JsonDeserializationCluster.SubscriptionState(existingValue);
 
             var topology = record.Topology;
             var lastResponsibleNode = AcknowledgeSubscriptionBatchCommand.GetLastResponsibleNode(HasHighlyAvailableTasks, topology, NodeTag);
-            if (topology.WhoseTaskIsIt(RachisState.Follower, subscription, lastResponsibleNode) != NodeTag)
-                throw new RachisApplyException($"Can't update subscription with name {itemId} by node {NodeTag}, because it's not it's task to update this subscription");
+            var appropriateNode = topology.WhoseTaskIsIt(RachisState.Follower, subscription, lastResponsibleNode);
+
+            if (appropriateNode == null && record.DeletionInProgress.ContainsKey(NodeTag))
+                throw new DatabaseDoesNotExistException(
+                    $"Stopping subscription '{SubscriptionName}' on node {NodeTag}, because database '{DatabaseName}' is being deleted.");
+
+            if (appropriateNode != NodeTag)
+                throw new SubscriptionDoesNotBelongToNodeException(
+                    $"Can't update subscription with name {itemId} by node {NodeTag}, because it's not its task to update this subscription");
 
             subscription.LastClientConnectionTime = LastClientConnectionTime;
             subscription.NodeTag = NodeTag;


### PR DESCRIPTION
### Issue link

https://issues.hibernatingrhinos.com/issue/RavenDB-16626

### Additional description

The test failed on a 'RachisApplyException' in 'UpdateSubscriptionClientConnectionTime' which sent a type of Error back to the client and eventually reached `SubscriptionMessageTypeException`, which in turn returned false in 'ShouldTryToReconnect' since it inherits from 'RavenException'. While the previous 'Exception' returned a true.
Changed the simple exception back to `SubscriptionMessageTypeException` .
SubscriptionDoesNotExist and DatabaseDoesNotExist are expected exceptions that return Type of 'ConnectionStatus' when reported back to the client (in `AssertConnectionState`). Therefore they don't pass through `SubscriptionMessageTypeException` in `AssertConnectionState`, Unlike `RachisApplyException` that returned a Type of 'Error' which was unexpected. 
Replaced all `RachisApplyException` to their appropriate Subscription exceptions.
Also added a missing db-being-deleted check.

### Type of change

- Bug fix

### Backward compatibility

- old client and new server: will throw an 'Exception' in client in case of a 'RachisApplyException' and will not reconnect - as desired.
- new client and old server: will throw a `SubscriptionMessageTypeException` in client in case of a 'RachisApplyException' which may be triggered on db deletion or nonexistent subscription. In either case will not reconnect - as desired (EDIT: will reconnect). (Exception type may not be the one the client is expecting)

### Testing 

- It has been verified by manual testing
