### PR TITLE
Bump node-forge from 0.10.0 to 1.2.1 in /src/Raven.Studio

### DIFF
--- a/src/Raven.Studio/package-lock.json
+++ b/src/Raven.Studio/package-lock.json
@@ -6140,9 +6140,9 @@
             }
         },
         "node-forge": {
-            "version": "0.10.0",
-            "resolved": "https://registry.npmjs.org/node-forge/-/node-forge-0.10.0.tgz",
-            "integrity": "sha512-PPmu8eEeG9saEUvI97fm4OYxXVB6bFvyNTyiUOBichBpFG8A1Ljw3bY62+5oOjDEMHRnd0Y7HQ+x7uzxOzC6JA=="
+            "version": "1.2.1",
+            "resolved": "https://registry.npmjs.org/node-forge/-/node-forge-1.2.1.tgz",
+            "integrity": "sha512-Fcvtbb+zBcZXbTTVwqGA5W+MKBj56UjVRevvchv5XrcyXbmNdesfZL37nlcWOfpgHhgmxApw3tQbTr4CqNmX4w=="
         },
         "node-int64": {
             "version": "0.4.0",

--- a/src/Raven.Studio/package.json
+++ b/src/Raven.Studio/package.json
@@ -95,7 +95,7 @@
         "leaflet.markercluster": "^1.5.3",
         "lodash": "^4.17.15",
         "moment": "^2.21.0",
-        "node-forge": "^0.10.0",
+        "node-forge": "^1.2.1",
         "packery": "^2.1.2",
         "prismjs": "^1.13.0",
         "rbush": "^2.0.1",


### PR DESCRIPTION
Bump node-forge

See https://github.com/ravendb/ravendb/pull/13476