### PR TITLE
RavenDB-17906 - fixed WriteDatabaseRecord context usage

### DIFF
--- a/src/Raven.Server/Documents/Handlers/Debugging/ServerWideDebugInfoPackageHandler.cs
+++ b/src/Raven.Server/Documents/Handlers/Debugging/ServerWideDebugInfoPackageHandler.cs
@@ -389,10 +389,7 @@ namespace Raven.Server.Documents.Handlers.Debugging
                 }
             }
 
-            using (ServerStore.ContextPool.AllocateOperationContext(out JsonOperationContext jsonContext))
-            {
-                return jsonContext.ReadObject(djv, "databaserecord");
-            }
+            return context.ReadObject(djv, "databaserecord");
         }
 
         internal class NodeDebugInfoRequestHeader


### PR DESCRIPTION
### Issue link

https://issues.hibernatingrhinos.com/issue/RavenDB-17906

### Additional description

Problem was creating and disposing a one time context that held the database record before writing to stream. Put it on the outer `TransactionOperationContext` instead.

### Type of change

- Bug fix

### How risky is the change?

- Low 

### Backward compatibility

- Not relevant

### Is it platform specific issue?

- No
