### PR TITLE
RavenDB-17960 - Making sure when changing to developer license we don't allow long term usage of server certificate

### DIFF
--- a/src/Raven.Server/Commercial/LicenseManager.cs
+++ b/src/Raven.Server/Commercial/LicenseManager.cs
@@ -908,18 +908,8 @@ namespace Raven.Server.Commercial
                 throw GenerateLicenseLimit(LimitType.Snmp, message);
             }
             
-            if (_serverStore.LicenseManager.LicenseStatus.Type != LicenseType.Developer && newLicenseStatus.Type == LicenseType.Developer)
-            {
-                if (_serverStore.Server.Certificate.Certificate.NotAfter > DateTime.UtcNow.AddMonths(4))
-                {
-                    var msg = "The server certificate expiration date is more than 4 months from now. " +
-                                   $"This is not allowed when trying to change the license form {_serverStore.LicenseManager.LicenseStatus.Type} to {LicenseType.Developer}. " +
-                                   "Use short term certificate before changing the license";
-                    
-                    throw new InvalidOperationException(msg);
-                }
-            }
-
+            SecretProtection.ValidateExpiration(nameof(LicenseManager), _serverStore, newLicenseStatus);
+            
             var encryptedDatabasesCount = 0;
             var externalReplicationCount = 0;
             var delayedExternalReplicationCount = 0;

--- a/src/Raven.Server/ServerWide/SecretProtection.cs
+++ b/src/Raven.Server/ServerWide/SecretProtection.cs
@@ -746,7 +746,7 @@ namespace Raven.Server.ServerWide
             if (certificateNotAfter > DateTime.UtcNow.AddMonths(MaxDeveloperCertificateValidityDurationInMonths))
             {
                 msg = $"The server certificate expiration date is more than {MaxDeveloperCertificateValidityDurationInMonths} months from now. " +
-                      $"This is not allowed when trying to change the license form {currentLicenseType} the {LicenseType.Developer} license. " +
+                      $"This is not allowed when trying to change the license from {currentLicenseType} the {LicenseType.Developer} license. " +
                       "Use short term certificate before changing the license";
                     
                 throw new InvalidOperationException(msg);

--- a/src/Raven.Server/ServerWide/SecretProtection.cs
+++ b/src/Raven.Server/ServerWide/SecretProtection.cs
@@ -730,10 +730,10 @@ namespace Raven.Server.ServerWide
 
             var certificateNotAfter = serverStore.Server.Certificate.Certificate.NotAfter;
             var certificateNotBefore = serverStore.Server.Certificate.Certificate.NotBefore;
-            var concat = certificateNotBefore.AddMonths(ServerCertificateUsageLimitation);
+            var certificateMaxDuration = certificateNotBefore.AddMonths(ServerCertificateUsageLimitation);
             string msg;
             
-            if (certificateNotAfter > concat)
+            if (certificateNotAfter > certificateMaxDuration)
             {
                 msg = $"The server certificate total duration is greater than {ServerCertificateUsageLimitation} months." +
                       $"This is not allowed when using {LicenseType.Developer} license." +


### PR DESCRIPTION
### Issue link

https://issues.hibernatingrhinos.com/issue/RavenDB-17960


### Type of change

- Bug fix

### How risky is the change?

- Low 

### Backward compatibility

- Not relevant

### Is it platform specific issue?

- No

### Documentation update

- No documentation update is needed 

### Testing 

- It has been verified by manual testing

### Is there any existing behavior change of other features due to this change?

- No

### UI work

- No UI work is needed
