### PR TITLE
RavenDB-17971 when we are compacting the database it is being locked with DatabaseDisabledException - we should ignore it and not count those as faulty databases in SNMP

### DIFF
--- a/src/Raven.Server/Monitoring/Snmp/Objects/Database/5.1/DatabaseFaultedCount.cs
+++ b/src/Raven.Server/Monitoring/Snmp/Objects/Database/5.1/DatabaseFaultedCount.cs
@@ -1,4 +1,7 @@
+using System;
 using Lextm.SharpSnmpLib;
+using Raven.Client.Exceptions.Database;
+using Raven.Client.Extensions;
 using Raven.Server.ServerWide;
 
 namespace Raven.Server.Monitoring.Snmp.Objects.Database
@@ -25,8 +28,14 @@ namespace Raven.Server.Monitoring.Snmp.Objects.Database
                 if (databaseTask == null)
                     continue;
 
-                if (databaseTask.IsFaulted)
-                    count++;
+                if (databaseTask.IsFaulted == false) 
+                    continue;
+                
+                var e = databaseTask.Exception?.ExtractSingleInnerException();
+                if (e is DatabaseDisabledException)
+                    continue;
+
+                count++;
             }
 
             return count;


### PR DESCRIPTION
### Issue link

https://issues.hibernatingrhinos.com/issue/RavenDB-17971

### Type of change

- Bug fix

### How risky is the change?

- Low 

### Backward compatibility

- Non breaking change

### Is it platform specific issue?

- No

### Documentation update

- No documentation update is needed 

### Testing 

- It has been verified by manual testing

### Is there any existing behavior change of other features due to this change?

- No

### UI work

- No UI work is needed
