### PR TITLE
RDBCL-2065 handle snapshot of multi-tree

### DIFF
--- a/src/Raven.Client/ServerWide/Tcp/TcpConnectionHeader.cs
+++ b/src/Raven.Client/ServerWide/Tcp/TcpConnectionHeader.cs
@@ -63,6 +63,7 @@ namespace Raven.Client.ServerWide.Tcp
         public static readonly int NoneBaseLine = -1;
         public static readonly int DropBaseLine = -2;
         public static readonly int ClusterBaseLine = 10;
+        public static readonly int ClusterWithMultiTree = 52_000;
         public static readonly int HeartbeatsBaseLine = 20;
         public static readonly int Heartbeats41200 = 41_200;
         public static readonly int Heartbeats42000 = 42_000;
@@ -77,7 +78,7 @@ namespace Raven.Client.ServerWide.Tcp
         public static readonly int SubscriptionTimeSeriesIncludes = 51_000;
         public static readonly int TestConnectionBaseLine = 50;
 
-        public static readonly int ClusterTcpVersion = ClusterBaseLine;
+        public static readonly int ClusterTcpVersion = ClusterWithMultiTree;
         public static readonly int HeartbeatsTcpVersion = Heartbeats42000;
         public static readonly int ReplicationTcpVersion = ReplicationWithTimeSeries;
         public static readonly int SubscriptionTcpVersion = SubscriptionTimeSeriesIncludes;
@@ -211,6 +212,7 @@ namespace Raven.Client.ServerWide.Tcp
             public class ClusterFeatures
             {
                 public bool BaseLine = true;
+                public bool MultiTree;
             }
 
             public class HeartbeatsFeatures
@@ -270,7 +272,8 @@ namespace Raven.Client.ServerWide.Tcp
                 },
                 [OperationTypes.Cluster] = new List<int>
                 {
-                    ClusterBaseLine
+                    ClusterWithMultiTree,
+                    ClusterBaseLine,
                 },
                 [OperationTypes.Heartbeats] = new List<int>
                 {
@@ -393,6 +396,13 @@ namespace Raven.Client.ServerWide.Tcp
                 },
                 [OperationTypes.Cluster] = new Dictionary<int, SupportedFeatures>
                 {
+                    [ClusterWithMultiTree] = new SupportedFeatures(ClusterWithMultiTree)
+                    {
+                        Cluster = new SupportedFeatures.ClusterFeatures
+                        {
+                            MultiTree = true
+                        }
+                    },
                     [ClusterBaseLine] = new SupportedFeatures(ClusterBaseLine)
                     {
                         Cluster = new SupportedFeatures.ClusterFeatures()

--- a/src/Raven.Server/Rachis/CandidateAmbassador.cs
+++ b/src/Raven.Server/Rachis/CandidateAmbassador.cs
@@ -5,6 +5,7 @@ using System.Threading;
 using System.Threading.Tasks;
 using Raven.Client.Http;
 using Raven.Client.ServerWide;
+using Raven.Client.ServerWide.Tcp;
 using Raven.Server.Rachis.Remote;
 using Raven.Server.ServerWide.Context;
 using Raven.Server.Utils;
@@ -108,6 +109,7 @@ namespace Raven.Server.Rachis
                     {
                         Stream stream;
                         Action disconnect;
+                        TcpConnectionHeaderMessage.SupportedFeatures.ClusterFeatures features;
                         try
                         {
                             var connectTask = _engine.ConnectToPeer(_url, _tag, _engine.ClusterCertificate);
@@ -119,6 +121,7 @@ namespace Raven.Server.Rachis
 
                             stream = connection.Stream;
                             disconnect = connection.Disconnect;
+                            features = connection.SupportedFeatures.Cluster;
                         }
                         catch (Exception e)
                         {
@@ -139,7 +142,7 @@ namespace Raven.Server.Rachis
 
                         Stopwatch sp;
                         _connection?.Dispose();
-                        _connection = new RemoteConnection(_tag, _engine.Tag, _candidate.ElectionTerm, stream, disconnect);
+                        _connection = new RemoteConnection(_tag, _engine.Tag, _candidate.ElectionTerm, stream, features, disconnect);
 
                         using (_engine.ContextPool.AllocateOperationContext(out ClusterOperationContext context))
                         {

--- a/src/Raven.Server/Rachis/Follower.cs
+++ b/src/Raven.Server/Rachis/Follower.cs
@@ -701,9 +701,9 @@ namespace Raven.Server.Rachis
                                 switch (flags)
                                 {
                                     case TreeFlags.None:
-                                    case TreeFlags.FixedSizeTrees:
-                                    case TreeFlags.LeafsCompressed:
 
+                                        // this is a very specific code to block receiving 'CompareExchangeByExpiration' which is a multi-value tree
+                                        // while here we expect a normal tree
                                         if (SliceComparer.Equals(valKey, CompareExchangeExpirationStorage.CompareExchangeByExpiration))
                                             throw new InvalidOperationException($"{valKey} is a multi-tree, please upgrade the leader node.");
 

--- a/src/Raven.Server/Rachis/Follower.cs
+++ b/src/Raven.Server/Rachis/Follower.cs
@@ -672,36 +672,76 @@ namespace Raven.Server.Rachis
                         return true;
                     case RootObjectType.VariableSizeTree:
                         size = reader.ReadInt32();
-                        reader.ReadExactly(size);
+                        reader.ReadExactly(size); 
 
                         Tree tree = null;
+                        Slice.From(context.Allocator, reader.Buffer, 0, size, ByteStringType.Immutable, out Slice treeName); // The Slice will be freed on context close
+
+                        entries = reader.ReadInt64();
+                        var flags = TreeFlags.FixedSizeTrees;
+
                         if (dryRun == false)
                         {
-                            Slice.From(context.Allocator, reader.Buffer, 0, size, ByteStringType.Immutable, out Slice treeName); // The Slice will be freed on context close
                             txw.DeleteTree(treeName);
                             tree = txw.CreateTree(treeName);
                         }
 
-                        entries = reader.ReadInt64();
+                        if (_connection.Features.MultiTree)
+                            flags = (TreeFlags)reader.ReadInt32();
+
                         for (long i = 0; i < entries; i++)
                         {
                             token.ThrowIfCancellationRequested();
+                            // read key
                             size = reader.ReadInt32();
                             reader.ReadExactly(size);
+
                             using (Slice.From(context.Allocator, reader.Buffer, 0, size, ByteStringType.Immutable, out Slice valKey))
                             {
-                                size = reader.ReadInt32();
-                                reader.ReadExactly(size);
-
-                                if (dryRun == false)
+                                switch (flags)
                                 {
-                                    using (tree.DirectAdd(valKey, size, out byte* ptr))
-                                    {
-                                        fixed (byte* pBuffer = reader.Buffer)
+                                    case TreeFlags.None:
+                                    case TreeFlags.FixedSizeTrees:
+                                    case TreeFlags.LeafsCompressed:
+
+                                        if (SliceComparer.Equals(valKey, CompareExchangeExpirationStorage.CompareExchangeByExpiration))
+                                            throw new InvalidOperationException($"{valKey} is a multi-tree, please upgrade the leader node.");
+
+                                        // read value
+                                        size = reader.ReadInt32();
+                                        reader.ReadExactly(size);
+
+                                        if (dryRun == false)
                                         {
-                                            Memory.Copy(ptr, pBuffer, size);
+                                            using (tree.DirectAdd(valKey, size, out byte* ptr))
+                                            {
+                                                fixed (byte* pBuffer = reader.Buffer)
+                                                {
+                                                    Memory.Copy(ptr, pBuffer, size);
+                                                }
+                                            }
                                         }
-                                    }
+                                        break;
+                                    case TreeFlags.MultiValueTrees:
+                                        var multiEntries = reader.ReadInt64();
+                                        for (int j = 0; j < multiEntries; j++)
+                                        {
+                                            token.ThrowIfCancellationRequested();
+
+                                            size = reader.ReadInt32();
+                                            reader.ReadExactly(size);
+
+                                            if (dryRun == false)
+                                            {
+                                                using (Slice.From(context.Allocator, reader.Buffer, 0, size, ByteStringType.Immutable, out Slice multiVal))
+                                                {
+                                                    tree.MultiAdd(valKey, multiVal);
+                                                }
+                                            }
+                                        }
+                                        break;
+                                    default:
+                                        throw new ArgumentOutOfRangeException($"Got unkonwn type '{type}'");
                                 }
                             }
                         }

--- a/src/Raven.Server/Rachis/FollowerAmbassador.cs
+++ b/src/Raven.Server/Rachis/FollowerAmbassador.cs
@@ -664,8 +664,6 @@ namespace Raven.Server.Rachis
                                                 switch (type)
                                                 {
                                                     case TreeFlags.None:
-                                                    case TreeFlags.FixedSizeTrees:
-                                                    case TreeFlags.LeafsCompressed:
                                                         var reader = treeIterator.CreateReaderForCurrent();
                                                         binaryWriter.Write(reader.Length);
                                                         copier.Copy(reader.Base, reader.Length);
@@ -679,7 +677,7 @@ namespace Raven.Server.Rachis
                                                             throw new NotSupportedException(
                                                                 $"The connection '{_connection}' doesn't support '{type}', please upgrade node '{_connection.Dest}'");
 
-                                                        var count = tree.MultiCount(currentTreeValueKey);
+                                                        long count = tree.MultiCount(currentTreeValueKey);
                                                         binaryWriter.Write(count);
                                                         totalSizeInBytes += sizeof(long);
 

--- a/src/Raven.Server/Rachis/FollowerAmbassador.cs
+++ b/src/Raven.Server/Rachis/FollowerAmbassador.cs
@@ -9,6 +9,7 @@ using System.Threading.Tasks;
 using Raven.Client.Exceptions;
 using Raven.Client.Http;
 using Raven.Client.ServerWide;
+using Raven.Client.ServerWide.Tcp;
 using Raven.Server.Rachis.Remote;
 using Raven.Server.ServerWide;
 using Raven.Server.ServerWide.Context;
@@ -20,6 +21,7 @@ using Sparrow.Server.Utils;
 using Sparrow.Threading;
 using Voron;
 using Voron.Data;
+using Voron.Data.BTrees;
 using Voron.Data.Tables;
 using Voron.Global;
 
@@ -149,8 +151,6 @@ namespace Raven.Server.Rachis
         /// it is responsible for talking to the remote follower and maintaining its state.
         /// This can never throw, and will run on its own thread.
         /// </summary>
-
-
         private unsafe void Run()
         {
             _engine.ForTestingPurposes?.BeforeNegotiatingWithFollower();
@@ -197,11 +197,11 @@ namespace Raven.Server.Rachis
                                         return;
 
                                     var connection = connectTask.Result;
-
                                     var stream = connection.Stream;
                                     var disconnect = connection.Disconnect;
-                                    var con = new RemoteConnection(_tag, _engine.Tag, _term, stream, disconnect);
+                                    var con = new RemoteConnection(_tag, _engine.Tag, _term, stream, connection.SupportedFeatures.Cluster, disconnect);
                                     Interlocked.Exchange(ref _connection, con);
+                                    
                                     ClusterTopology topology;
                                     using (context.OpenReadTransaction())
                                     {
@@ -639,9 +639,17 @@ namespace Raven.Server.Rachis
                             {
                                 case RootObjectType.VariableSizeTree:
                                     var tree = txr.ReadTree(currentTreeKey);
+                                    
                                     binaryWriter.Write(tree.State.NumberOfEntries);
                                     totalSizeInBytes += sizeof(long);
 
+                                    var type = tree.State.Flags;
+                                    if (_connection.Features.MultiTree)
+                                    {
+                                        binaryWriter.Write((int)type);
+                                        totalSizeInBytes += sizeof(int);
+                                    }
+                                    
                                     using (var treeIterator = tree.Iterate(false))
                                     {
                                         if (treeIterator.Seek(Slices.BeforeAllKeys))
@@ -651,11 +659,49 @@ namespace Raven.Server.Rachis
                                                 var currentTreeValueKey = treeIterator.CurrentKey;
                                                 binaryWriter.Write(currentTreeValueKey.Size);
                                                 copier.Copy(currentTreeValueKey.Content.Ptr, currentTreeValueKey.Size);
-                                                var reader = treeIterator.CreateReaderForCurrent();
-                                                binaryWriter.Write(reader.Length);
-                                                copier.Copy(reader.Base, reader.Length);
+                                                totalSizeInBytes += sizeof(int) + currentTreeValueKey.Size;
 
-                                                totalSizeInBytes += sizeof(long) + currentTreeValueKey.Size + reader.Length;
+                                                switch (type)
+                                                {
+                                                    case TreeFlags.None:
+                                                    case TreeFlags.FixedSizeTrees:
+                                                    case TreeFlags.LeafsCompressed:
+                                                        var reader = treeIterator.CreateReaderForCurrent();
+                                                        binaryWriter.Write(reader.Length);
+                                                        copier.Copy(reader.Base, reader.Length);
+
+                                                        totalSizeInBytes += sizeof(int) + reader.Length;
+                                                        break;
+
+                                                    case TreeFlags.MultiValueTrees:
+
+                                                        if (_connection.Features.MultiTree == false)
+                                                            throw new NotSupportedException(
+                                                                $"The connection '{_connection}' doesn't support '{type}', please upgrade node '{_connection.Dest}'");
+
+                                                        var count = tree.MultiCount(currentTreeValueKey);
+                                                        binaryWriter.Write(count);
+                                                        totalSizeInBytes += sizeof(long);
+
+                                                        using (var multiIt = tree.MultiRead(currentTreeValueKey))
+                                                        {
+                                                            if (multiIt.Seek(Slices.BeforeAllKeys))
+                                                            {
+                                                                do
+                                                                {
+                                                                    var val = multiIt.CurrentKey;
+                                                                    binaryWriter.Write(val.Size);
+                                                                    copier.Copy(val.Content.Ptr, val.Size);
+                                                                    totalSizeInBytes += val.Size + sizeof(int);
+
+                                                                } while (multiIt.MoveNext());
+                                                            }
+                                                        }
+
+                                                        break;
+                                                    default:
+                                                        throw new ArgumentOutOfRangeException($"Can't send snapshot of type {type}");
+                                                }
                                             } while (treeIterator.MoveNext());
                                         }
                                     }

--- a/src/Raven.Server/Rachis/Remote/RemoteConnection.cs
+++ b/src/Raven.Server/Rachis/Remote/RemoteConnection.cs
@@ -3,6 +3,7 @@ using System.Collections.Generic;
 using System.IO;
 using System.Runtime.CompilerServices;
 using System.Threading;
+using Raven.Client.ServerWide.Tcp;
 using Raven.Server.Rachis.Json.Sync;
 using Raven.Server.ServerWide;
 using Sparrow;
@@ -21,6 +22,7 @@ namespace Raven.Server.Rachis.Remote
         private string _destTag;
         private string _src;
         private readonly Stream _stream;
+        private readonly TcpConnectionHeaderMessage.SupportedFeatures.ClusterFeatures _features;
         private readonly JsonOperationContext.MemoryBuffer _buffer;
         private readonly JsonOperationContext _context;
         private readonly IDisposable _releaseBuffer;
@@ -32,17 +34,19 @@ namespace Raven.Server.Rachis.Remote
         public string Source => _src;
         public Stream Stream => _stream;
         public string Dest => _destTag;
+        public TcpConnectionHeaderMessage.SupportedFeatures.ClusterFeatures Features => _features;
 
-        public RemoteConnection(string src, long term, Stream stream, Action disconnect, [CallerMemberName] string caller = null)
-            : this(dest: "?", src, term, stream, disconnect, caller)
+        public RemoteConnection(string src, long term, Stream stream, TcpConnectionHeaderMessage.SupportedFeatures.ClusterFeatures features, Action disconnect, [CallerMemberName] string caller = null)
+            : this(dest: "?", src, term, stream,features, disconnect, caller)
         {
         }
 
-        public RemoteConnection(string dest, string src, long term, Stream stream, Action disconnect, [CallerMemberName] string caller = null)
+        public RemoteConnection(string dest, string src, long term, Stream stream, TcpConnectionHeaderMessage.SupportedFeatures.ClusterFeatures features, Action disconnect, [CallerMemberName] string caller = null)
         {
             _destTag = dest;
             _src = src;
             _stream = stream;
+            _features = features;
             _disconnect = disconnect;
             _context = JsonOperationContext.ShortTermSingleUse();
             _releaseBuffer = _context.GetMemoryBuffer(out _buffer);

--- a/src/Raven.Server/ServerWide/ServerStore.cs
+++ b/src/Raven.Server/ServerWide/ServerStore.cs
@@ -52,6 +52,7 @@ using Raven.Server.NotificationCenter.Notifications;
 using Raven.Server.NotificationCenter.Notifications.Details;
 using Raven.Server.NotificationCenter.Notifications.Server;
 using Raven.Server.Rachis;
+using Raven.Server.Rachis.Remote;
 using Raven.Server.ServerWide.BackgroundTasks;
 using Raven.Server.ServerWide.Commands;
 using Raven.Server.ServerWide.Commands.ConnectionStrings;
@@ -3044,7 +3045,10 @@ namespace Raven.Server.ServerWide
                     return;
                 }
 
-                _engine.AcceptNewConnection(tcp.Stream, disconnect, remoteEndpoint);
+                var features = TcpConnectionHeaderMessage.GetSupportedFeaturesFor(TcpConnectionHeaderMessage.OperationTypes.Cluster, tcp.ProtocolVersion);
+                var remoteConnection = new RemoteConnection(_engine.Tag, _engine.CurrentTerm, tcp.Stream, features.Cluster, disconnect);
+
+                _engine.AcceptNewConnection(remoteConnection, remoteEndpoint);
             }
             catch (IOException e)
             {

--- a/src/Raven.Server/Storage/Schema/SchemaUpgrader.cs
+++ b/src/Raven.Server/Storage/Schema/SchemaUpgrader.cs
@@ -12,7 +12,7 @@ namespace Raven.Server.Storage.Schema
     {
         internal class CurrentVersion
         {
-            public const int ServerVersion = 50_000;
+            public const int ServerVersion = 52_101;
 
             public const int ConfigurationVersion = 50_000;
 

--- a/src/Raven.Server/Storage/Schema/Updates/Server/52101/From50000.cs
+++ b/src/Raven.Server/Storage/Schema/Updates/Server/52101/From50000.cs
@@ -1,0 +1,77 @@
+﻿using System;
+using System.Collections.Generic;
+using System.Linq;
+using System.Text;
+using System.Threading.Tasks;
+using Raven.Server.ServerWide;
+using Raven.Server.ServerWide.Context;
+using Sparrow.Binary;
+using Sparrow.Json;
+using Voron;
+using Voron.Data.Tables;
+using Voron.Impl;
+
+namespace Raven.Server.Storage.Schema.Updates.Server
+{
+    internal class From50000 : ISchemaUpdate
+    {
+        public int From => 50_000;
+        public int To => 52_101;
+        public SchemaUpgrader.StorageType StorageType => SchemaUpgrader.StorageType.Server;
+        public bool Update(UpdateStep step)
+        {
+            step.WriteTx.DeleteTree(CompareExchangeExpirationStorage.CompareExchangeByExpiration);
+            step.WriteTx.CreateTree(CompareExchangeExpirationStorage.CompareExchangeByExpiration);
+
+            foreach (var (key,value) in GetAllCompareExchange(step.ReadTx))
+            {
+                if (CompareExchangeExpirationStorage.TryGetExpires(value, out var ticks))
+                {
+                    Put(step.WriteTx, key, ticks);
+                }
+            }
+
+            return true;
+        }
+        
+        public static IEnumerable<(Slice Key, BlittableJsonReaderObject Value)> GetAllCompareExchange(Transaction tx)
+        {
+            var table = tx.OpenTable(ClusterStateMachine.CompareExchangeSchema, ClusterStateMachine.CompareExchange);
+            using (var context = JsonOperationContext.ShortTermSingleUse())
+            {
+                foreach (var tvr in table.SeekForwardFrom(ClusterStateMachine.CompareExchangeSchema.Indexes[ClusterStateMachine.CompareExchangeIndex], Slices.BeforeAllKeys, 0))
+                {
+                    var key = ReadCompareExchangeKey(context, tvr.Result.Reader);
+                    var value = ReadCompareExchangeValue(context, tvr.Result.Reader);
+
+                    using (value)
+                    using (Slice.From(tx.Allocator, key, out var keySlice))
+                    {
+                        yield return (keySlice, value);
+                    }
+                }
+            }
+        }
+        
+        private static unsafe BlittableJsonReaderObject ReadCompareExchangeValue(JsonOperationContext context, TableValueReader reader)
+        {
+            return new BlittableJsonReaderObject(reader.Read((int)ClusterStateMachine.CompareExchangeTable.Value, out var size), size, context);
+        }
+
+        private static unsafe LazyStringValue ReadCompareExchangeKey(JsonOperationContext context, TableValueReader reader)
+        {
+            var ptr = reader.Read((int)ClusterStateMachine.CompareExchangeTable.Key, out var size);
+            return context.AllocateStringValue(null, ptr, size);
+        }
+
+        private static unsafe void Put(Transaction tx, Slice keySlice, long ticks)
+        {
+            var ticksBigEndian = Bits.SwapBytes(ticks);
+            using (Slice.External(tx.Allocator, (byte*)&ticksBigEndian, sizeof(long), out Slice ticksSlice))
+            {
+                var tree = tx.ReadTree(CompareExchangeExpirationStorage.CompareExchangeByExpiration);
+                tree.MultiAdd(ticksSlice, keySlice);
+            }
+        }
+    }
+}

--- a/test/Tests.Infrastructure/RachisConsensusTestBase.cs
+++ b/test/Tests.Infrastructure/RachisConsensusTestBase.cs
@@ -16,6 +16,7 @@ using Raven.Server;
 using Raven.Server.Config;
 using Raven.Server.Config.Settings;
 using Raven.Server.Rachis;
+using Raven.Server.Rachis.Remote;
 using Raven.Server.ServerWide;
 using Raven.Server.ServerWide.Commands;
 using Raven.Server.ServerWide.Context;
@@ -27,6 +28,7 @@ using Sparrow.Server.Platform;
 using Sparrow.Utils;
 using Voron;
 using Voron.Data;
+using Voron.Data.BTrees;
 using Xunit;
 using Xunit.Abstractions;
 using NativeMemory = Sparrow.Utils.NativeMemory;
@@ -219,7 +221,12 @@ namespace Tests.Infrastructure
                     try
                     {
                         var stream = tcpClient.GetStream();
-                        rachis.AcceptNewConnection(stream, () => tcpClient.Client.Disconnect(false), tcpClient.Client.RemoteEndPoint, hello =>
+                        var remoteConnection = new RemoteConnection(rachis.Tag, rachis.CurrentTerm, stream, features: new TcpConnectionHeaderMessage.SupportedFeatures.ClusterFeatures
+                        {
+                            MultiTree = true
+                        }, () => tcpClient.Client.Disconnect(false));
+
+                        rachis.AcceptNewConnection(remoteConnection, tcpClient.Client.RemoteEndPoint, hello =>
                         {
                             if (rachis.Url == null)
                                 return;
@@ -433,7 +440,8 @@ namespace Tests.Infrastructure
                     var conn = new RachisConnection
                     {
                         Stream = stream,
-                        SupportedFeatures = new TcpConnectionHeaderMessage.SupportedFeatures(TcpConnectionHeaderMessage.NoneBaseLine),
+                        SupportedFeatures = TcpConnectionHeaderMessage.GetSupportedFeaturesFor(
+                            TcpConnectionHeaderMessage.OperationTypes.Cluster, TcpConnectionHeaderMessage.ClusterWithMultiTree),
                         Disconnect = () =>
                         {
                             using (tcpClient)


### PR DESCRIPTION
### Issue link

https://issues.hibernatingrhinos.com/issue/RDBCL-2065

### Additional description

Snapshot of a `MultiValueTrees` was send from the leader as a `FixedSizeTrees` and treat on the follower read snapshot function also as a `FixedSizeTrees`.

This disrupt the structure of the compare exchange expiration when they grow beyond the max node size so they weren't embedded in the root tree any longer.

Schema upgrade is require to fix affected system env, by deleting and re-create the compare exchange expiration tree.
Since we have no way to know whether it is corrupted or not we simply delete it completely and iterate over all compare exchange values to check if we need to put it in the expiration tree.

### Type of change

- Bug fix

### How risky is the change?

- High

### Backward compatibility

- If no multi-tree in the snapshot (no entries) everything will work as before, 
- Fixed leader will refuse to send a snapshot with the multi-tree to a problematic follower.
- Fixed follower will refuse to get a snapshot from a bad leader if it contains compare exchange expiration tree. (maybe worth to block any full snapshot from a not upgraded leader?)

### Is it platform specific issue?

- No

### Documentation update

- No documentation update is needed 

### Testing 

- Tests have been added that prove the fix is effective or that the feature works
- It has been verified by manual testing
- More manual tests are required, especially for the schema upgrade

### Is there any existing behavior change of other features due to this change?

- No

### UI work

- No UI work is needed
