### PR TITLE
RavenDB-17994 before doing validation of private key of the cert to avoid issues with bouncy castle not supporting encryption algorithm used we should export it

### DIFF
--- a/src/Raven.Server/Commercial/SetupManager.cs
+++ b/src/Raven.Server/Commercial/SetupManager.cs
@@ -1252,7 +1252,7 @@ namespace Raven.Server.Commercial
             settingsJsonObject.TryGet(RavenConfiguration.GetKey(x => x.Core.SetupMode), out SetupMode setupMode);
             settingsJsonObject.TryGet(RavenConfiguration.GetKey(x => x.Security.CertificatePath), out string certificateFileName);
 
-            serverStore.Server.Certificate = SecretProtection.ValidateCertificateAndCreateCertificateHolder("Setup", serverCert, serverCertBytes, certPassword, serverStore);
+            serverStore.Server.Certificate = SecretProtection.ValidateCertificateAndCreateCertificateHolder("Setup", serverCert, certPassword, serverStore);
 
             if (continueSetupInfo.NodeTag.Equals(firstNodeTag))
             {
@@ -1450,7 +1450,7 @@ namespace Raven.Server.Commercial
                             }
 
                             serverStore.Server.Certificate =
-                                SecretProtection.ValidateCertificateAndCreateCertificateHolder("Setup", serverCert, serverCertBytes, setupInfo.Password, serverStore);
+                                SecretProtection.ValidateCertificateAndCreateCertificateHolder("Setup", serverCert, setupInfo.Password, serverStore);
 
                             serverStore.HasFixedPort = setupInfo.NodeSetupInfos[localNodeTag].Port != 0;
 

--- a/src/Raven.Server/RavenServer.cs
+++ b/src/Raven.Server/RavenServer.cs
@@ -1318,8 +1318,7 @@ namespace Raven.Server
             var cert = await SetupManager.RefreshLetsEncryptTask(setupInfo, ServerStore, ServerStore.ServerShutdown);
             var certBytes = Convert.FromBase64String(setupInfo.Certificate);
 
-            SecretProtection.ValidateCertificateAndCreateCertificateHolder("Let's Encrypt Refresh", cert, certBytes,
-                setupInfo.Password, ServerStore);
+            SecretProtection.ValidateCertificateAndCreateCertificateHolder("Let's Encrypt Refresh", cert, setupInfo.Password, ServerStore);
 
             return certBytes;
         }
@@ -2263,10 +2262,10 @@ namespace Raven.Server
 
         public (IPAddress[] Addresses, int Port) ListenEndpoints { get; private set; }
 
-        internal void SetCertificate(X509Certificate2 certificate, byte[] rawBytes, string password)
+        internal void SetCertificate(X509Certificate2 certificate, string password)
         {
             var certificateHolder = Certificate;
-            var newCertHolder = SecretProtection.ValidateCertificateAndCreateCertificateHolder("Auto Update", certificate, rawBytes, password, ServerStore);
+            var newCertHolder = SecretProtection.ValidateCertificateAndCreateCertificateHolder("Auto Update", certificate, password, ServerStore);
             if (Interlocked.CompareExchange(ref Certificate, newCertHolder, certificateHolder) == certificateHolder)
             {
                 _httpsConnectionMiddleware.SetCertificate(certificate);

--- a/src/Raven.Server/ServerWide/SecretProtection.cs
+++ b/src/Raven.Server/ServerWide/SecretProtection.cs
@@ -581,14 +581,17 @@ namespace Raven.Server.ServerWide
         public static RavenServer.CertificateHolder ValidateCertificateAndCreateCertificateHolder(string source, X509Certificate2 loadedCertificate, string password, ServerStore serverStore)
         {
             // make sure that we are using supported encryption format by bouncy castle
-            var rawData = loadedCertificate.Export(X509ContentType.Pfx, password);
+            var rawData = loadedCertificate.Export(X509ContentType.Pfx);
 
             ValidateExpiration(source, loadedCertificate, serverStore);
 
-            ValidatePrivateKey(source, password, rawData, out var privateKey);
+            ValidatePrivateKey(source, certificatePassword: null, rawData, out var privateKey);
 
             ValidateKeyUsages(source, loadedCertificate);
             
+            if (string.IsNullOrEmpty(password) == false)
+                rawData = loadedCertificate.Export(X509ContentType.Pfx, password);
+
             AddCertificateChainToTheUserCertificateAuthorityStoreAndCleanExpiredCerts(loadedCertificate, rawData, password);
 
             return new RavenServer.CertificateHolder
@@ -678,11 +681,11 @@ namespace Raven.Server.ServerWide
                 var loadedCertificate = new X509Certificate2(rawData, password, X509KeyStorageFlags.Exportable | X509KeyStorageFlags.MachineKeySet);
 
                 // make sure that we are using supported encryption format by bouncy castle
-                rawData = loadedCertificate.Export(X509ContentType.Pfx, password);
+                rawData = loadedCertificate.Export(X509ContentType.Pfx);
 
                 ValidateExpiration(path, loadedCertificate, serverStore);
 
-                ValidatePrivateKey(path, password, rawData, out var privateKey);
+                ValidatePrivateKey(path, certificatePassword: null, rawData, out var privateKey);
 
                 ValidateKeyUsages(path, loadedCertificate);
 

--- a/src/Raven.Server/ServerWide/ServerStore.cs
+++ b/src/Raven.Server/ServerWide/ServerStore.cs
@@ -1458,7 +1458,7 @@ namespace Raven.Server.ServerWide
                     if (Logger.IsOperationsEnabled)
                         Logger.Operations($"Replacing the certificate used by the server to: {newClusterCertificate.Thumbprint} ({newClusterCertificate.SubjectName.Name})");
 
-                    Server.SetCertificate(newClusterCertificate, bytesToSave, Configuration.Security.CertificatePassword);
+                    Server.SetCertificate(newClusterCertificate, Configuration.Security.CertificatePassword);
 
                     NotificationCenter.Dismiss(AlertRaised.GetKey(AlertType.Certificates_ReplaceError, null));
                     NotificationCenter.Dismiss(AlertRaised.GetKey(AlertType.Certificates_ReplacePending, null));


### PR DESCRIPTION
### Issue link

https://issues.hibernatingrhinos.com/issue/RavenDB-17994

### Type of change

- Bug fix

### How risky is the change?

- High

### Backward compatibility

- Non breaking change

### Is it platform specific issue?

- No

### Documentation update

- No documentation update is needed 

### Testing 

- It has been verified by manual testing

### Is there any existing behavior change of other features due to this change?

- No

### UI work

- No UI work is needed
