### PR TITLE
HRINT-255 Powershell env

### DIFF
--- a/.github/workflows/conventions.yml
+++ b/.github/workflows/conventions.yml
@@ -13,7 +13,7 @@ jobs:
       - name: Parse Label
         run: |
           $label="${{ github.event.pull_request.base.ref }}".split("/")[-1]
-          echo "newLabel=$label" >> $GITHUB_ENV
+          echo "newLabel=$label" >> $env:GITHUB_ENV
       - name: Set Label
         env:
           githubOwner: ${{ github.event.pull_request.base.repo.owner.login }}


### PR DESCRIPTION
### Issue link

https://issues.hibernatingrhinos.com/issue/HRINT-255

### Additional description

Powershell env variables are called with `env:` prefix.