### PR TITLE
RavenDB-17777 Fix the order of the duplicate configurations

### DIFF
--- a/src/Raven.Server/Config/Categories/SecurityConfiguration.cs
+++ b/src/Raven.Server/Config/Categories/SecurityConfiguration.cs
@@ -31,8 +31,8 @@ namespace Raven.Server.Config.Categories
         [Description("How far back we should retain audit log entries")]
         [DefaultValue(365 * 24)]
         [TimeUnit(TimeUnit.Hours)]
-        [ConfigurationEntry("Security.AuditLog.RetentionTimeInHrs", ConfigurationEntryScope.ServerWideOnly)]
         [ConfigurationEntry("Security.AuditLog.RetentionTimeInHours", ConfigurationEntryScope.ServerWideOnly)]
+        [ConfigurationEntry("Security.AuditLog.RetentionTimeInHrs", ConfigurationEntryScope.ServerWideOnly)]
         public TimeSetting AuditLogRetentionTime { get; set; }
 
         [Description("The maximum size of the audit log after which the old files will be deleted")]

--- a/src/Raven.Server/Config/Categories/StorageConfiguration.cs
+++ b/src/Raven.Server/Config/Categories/StorageConfiguration.cs
@@ -55,8 +55,8 @@ namespace Raven.Server.Config.Categories
         [Description("Time to sync after flash in seconds")]
         [DefaultValue(30)]
         [TimeUnit(TimeUnit.Seconds)]
-        [ConfigurationEntry("Storage.TimeToSyncAfterFlashInSec", ConfigurationEntryScope.ServerWideOrPerDatabase)]
         [ConfigurationEntry("Storage.TimeToSyncAfterFlushInSec", ConfigurationEntryScope.ServerWideOrPerDatabase)]
+        [ConfigurationEntry("Storage.TimeToSyncAfterFlashInSec", ConfigurationEntryScope.ServerWideOrPerDatabase)]
         public TimeSetting TimeToSyncAfterFlush { get; set; }
 
         [Description("Number of concurrent syncs per physical drive")]
@@ -116,21 +116,21 @@ namespace Raven.Server.Config.Categories
 
         [Description("EXPERT: A command or executable to run when creating/opening a directory (storage environment). RavenDB will execute: command [user-arg-1] ... [user-arg-n] <environment-type> <database-name> <data-dir-path> <temp-dir-path> <journal-dir-path>")]
         [DefaultValue(null)]
-        [ConfigurationEntry("Storage.OnCreateDirectory.Exec", ConfigurationEntryScope.ServerWideOrPerDatabase)]
         [ConfigurationEntry("Storage.OnDirectoryInitialize.Exec", ConfigurationEntryScope.ServerWideOrPerDatabase)]
+        [ConfigurationEntry("Storage.OnCreateDirectory.Exec", ConfigurationEntryScope.ServerWideOrPerDatabase)]
         public string OnDirectoryInitializeExec { get; set; }
 
         [Description("EXPERT: The optional user arguments for the 'Storage.OnDirectoryInitialize.Exec' command or executable. The arguments must be escaped for the command line.")]
         [DefaultValue(null)]
-        [ConfigurationEntry("Storage.OnCreateDirectory.Exec.Arguments", ConfigurationEntryScope.ServerWideOrPerDatabase, isSecured: true)]
         [ConfigurationEntry("Storage.OnDirectoryInitialize.Exec.Arguments", ConfigurationEntryScope.ServerWideOrPerDatabase, isSecured: true)]
+        [ConfigurationEntry("Storage.OnCreateDirectory.Exec.Arguments", ConfigurationEntryScope.ServerWideOrPerDatabase, isSecured: true)]
         public string OnDirectoryInitializeExecArguments { get; set; }
 
         [Description("EXPERT: The number of seconds to wait for the OnDirectoryInitialize executable to exit. Default: 30 seconds")]
         [DefaultValue(30)]
         [TimeUnit(TimeUnit.Seconds)]
-        [ConfigurationEntry("Storage.OnCreateDirectory.Exec.TimeoutInSec", ConfigurationEntryScope.ServerWideOrPerDatabase)]
         [ConfigurationEntry("Storage.OnDirectoryInitialize.Exec.TimeoutInSec", ConfigurationEntryScope.ServerWideOrPerDatabase)]
+        [ConfigurationEntry("Storage.OnCreateDirectory.Exec.TimeoutInSec", ConfigurationEntryScope.ServerWideOrPerDatabase)]
         public TimeSetting OnDirectoryInitializeExecTimeout { get; set; }
 
         [Description("EXPERT: Allows to load a database regardless journal errors that can be thrown during the recovery operation on startup. Since journals are mandatory to properly start a database, the usage of this option is dangerous")]


### PR DESCRIPTION
### Issue link
https://issues.hibernatingrhinos.com/issue/RavenDB-17777

### Additional description
Fix the order for the 'duplicated' configuration entries
Both are still available for usage 
The difference is that in the Studio Database Settings view you see the first one.

### Type of change
- Bug fix

### How risky is the change?
- Low 

### Backward compatibility
- Non breaking change

### Is it platform specific issue?
- No

### Documentation update
- This change requires a documentation update. 

### Testing 
- It has been verified by manual testing

### Is there any existing behavior change of other features due to this change?
- No

### UI work
- No UI work is needed
