### PR TITLE
RavenDB-18010 support sharded databases in the cluster observer

### DIFF
--- a/src/Raven.Client/ServerWide/Operations/AddDatabaseNodeOperation.cs
+++ b/src/Raven.Client/ServerWide/Operations/AddDatabaseNodeOperation.cs
@@ -20,6 +20,11 @@ namespace Raven.Client.ServerWide.Operations
             _node = node;
         }
 
+        internal AddDatabaseNodeOperation(string databaseName, int shard, string node = null) : this(databaseName, node)
+        {
+            _databaseName = $"{_databaseName}${shard}";
+        }
+
         public RavenCommand<DatabasePutResult> GetCommand(DocumentConventions conventions, JsonOperationContext context)
         {
             return new AddDatabaseNodeCommand(_databaseName, _node);

--- a/src/Raven.Client/ServerWide/Operations/AddDatabaseNodeOperation.cs
+++ b/src/Raven.Client/ServerWide/Operations/AddDatabaseNodeOperation.cs
@@ -22,7 +22,7 @@ namespace Raven.Client.ServerWide.Operations
 
         internal AddDatabaseNodeOperation(string databaseName, int shard, string node = null) : this(databaseName, node)
         {
-            _databaseName = $"{_databaseName}${shard}";
+            _databaseName = ClientShardHelper.ToShardName(databaseName, shard);
         }
 
         public RavenCommand<DatabasePutResult> GetCommand(DocumentConventions conventions, JsonOperationContext context)

--- a/src/Raven.Client/Util/ClientShardHelper.cs
+++ b/src/Raven.Client/Util/ClientShardHelper.cs
@@ -1,0 +1,25 @@
+﻿namespace Raven.Client.Util
+{
+    internal static class ClientShardHelper
+    {
+        public static string ToShardName(string database, int shard)
+        {
+            var name = ToDatabaseName(database);
+
+            int shardIndex = name.IndexOf('$');
+            if (shardIndex == -1)
+                return $"{name}${shard}";
+
+            return name;
+        }
+
+        public static string ToDatabaseName(string shardName)
+        {
+            int shardIndex = shardName.IndexOf('$');
+            if (shardIndex == -1)
+                return shardName;
+
+            return shardName.Substring(0, shardIndex);
+        }
+    }
+}

--- a/src/Raven.Server/ServerWide/RawDatabaseRecord.cs
+++ b/src/Raven.Server/ServerWide/RawDatabaseRecord.cs
@@ -222,6 +222,9 @@ namespace Raven.Server.ServerWide
 
         public bool IsSharded()
         {
+            if (_materializedRecord != null)
+                return _materializedRecord.IsSharded;
+
             _record.TryGet(nameof(DatabaseRecord.Shards), out BlittableJsonReaderArray array);
             return array != null && array.Length > 0;
         }

--- a/src/Raven.Server/Utils/ShardHelper.cs
+++ b/src/Raven.Server/Utils/ShardHelper.cs
@@ -1,6 +1,7 @@
 ﻿using System;
 using System.Collections.Generic;
 using Raven.Client.ServerWide;
+using Raven.Client.Util;
 using Raven.Server.Documents;
 using Raven.Server.ServerWide.Context;
 using Sparrow;
@@ -101,25 +102,9 @@ namespace Raven.Server.Utils
             return shardIndex;
         }
 
-        public static string ToDatabaseName(string shardName)
-        {
-            int shardIndex = shardName.IndexOf('$');
-            if (shardIndex == -1)
-                return shardName;
+        public static string ToDatabaseName(string shardName) => ClientShardHelper.ToDatabaseName(shardName);
 
-            return shardName.Substring(0, shardIndex);
-        }
-
-        public static string ToShardName(string database, int shard)
-        {
-            var name = ToDatabaseName(database);
-
-            int shardIndex = name.IndexOf('$');
-            if (shardIndex == -1)
-                return $"{name}${shard}";
-
-            return name;
-        }
+        public static string ToShardName(string database, int shard) => ClientShardHelper.ToShardName(database, shard);
 
         public static bool IsShardedName(string name)
         {

--- a/test/FastTests/Server/Documents/Indexing/Auto/BasicAutoMapIndexing.cs
+++ b/test/FastTests/Server/Documents/Indexing/Auto/BasicAutoMapIndexing.cs
@@ -996,7 +996,7 @@ namespace FastTests.Server.Documents.Indexing.Auto
                             }
                         }
                     };
-                    await Server.ServerStore.Observer.CleanUpUnusedAutoIndexes(state);
+                    await Server.ServerStore.Observer.CleanUpUnusedAutoIndexes(database.Name, state);
                 }
 
                 WaitForIndexDeletion(database, index0.Name);
@@ -1062,7 +1062,7 @@ namespace FastTests.Server.Documents.Indexing.Auto
                             }
                         }
                     };
-                    await Server.ServerStore.Observer.CleanUpUnusedAutoIndexes(state); // nothing should happen because difference between querying time between those two indexes is less than TimeToWaitBeforeMarkingAutoIndexAsIdle
+                    await Server.ServerStore.Observer.CleanUpUnusedAutoIndexes(database.Name, state); // nothing should happen because difference between querying time between those two indexes is less than TimeToWaitBeforeMarkingAutoIndexAsIdle
                 }
 
                 WaitForIndex(database, index1.Name, index => index.State == IndexState.Normal);
@@ -1122,7 +1122,7 @@ namespace FastTests.Server.Documents.Indexing.Auto
                             }
                         }
                     };
-                    await Server.ServerStore.Observer.CleanUpUnusedAutoIndexes(state); // this will mark index2 as idle, because the difference between two indexes and index last querying time is more than TimeToWaitBeforeMarkingAutoIndexAsIdle
+                    await Server.ServerStore.Observer.CleanUpUnusedAutoIndexes(database.Name, state); // this will mark index2 as idle, because the difference between two indexes and index last querying time is more than TimeToWaitBeforeMarkingAutoIndexAsIdle
                 }
 
                 WaitForIndex(database, index1.Name, index => index.State == IndexState.Normal);
@@ -1182,7 +1182,7 @@ namespace FastTests.Server.Documents.Indexing.Auto
                             }
                         }
                     };
-                    await Server.ServerStore.Observer.CleanUpUnusedAutoIndexes(state); // should not remove anything, age will be greater than 2x TimeToWaitBeforeMarkingAutoIndexAsIdle but less than TimeToWaitBeforeDeletingAutoIndexMarkedAsIdle
+                    await Server.ServerStore.Observer.CleanUpUnusedAutoIndexes(database.Name, state); // should not remove anything, age will be greater than 2x TimeToWaitBeforeMarkingAutoIndexAsIdle but less than TimeToWaitBeforeDeletingAutoIndexMarkedAsIdle
                 }
 
                 WaitForIndex(database, index1.Name, index => index.State == IndexState.Idle);
@@ -1242,7 +1242,7 @@ namespace FastTests.Server.Documents.Indexing.Auto
                             }
                         }
                     };
-                    await Server.ServerStore.Observer.CleanUpUnusedAutoIndexes(state); // this will delete indexes
+                    await Server.ServerStore.Observer.CleanUpUnusedAutoIndexes(database.Name, state); // this will delete indexes
                 }
 
                 WaitForIndexDeletion(database, index1.Name);

--- a/test/FastTests/Sharding/ShardedClusterTestBase.cs
+++ b/test/FastTests/Sharding/ShardedClusterTestBase.cs
@@ -3,7 +3,9 @@ using System.Collections.Generic;
 using System.Linq;
 using System.Security.Cryptography.X509Certificates;
 using System.Threading.Tasks;
+using Raven.Client.Documents;
 using Raven.Client.ServerWide;
+using Raven.Client.ServerWide.Operations;
 using Raven.Server;
 using Tests.Infrastructure;
 using Xunit;
@@ -48,6 +50,12 @@ namespace FastTests.Sharding
             }
 
             return topology;
+        }
+
+        public static async Task<DatabaseTopology[]> GetShards(DocumentStore store)
+        {
+            var record = await store.Maintenance.Server.SendAsync(new GetDatabaseRecordOperation(store.Database));
+            return record.Shards;
         }
     }
 }

--- a/test/SlowTests/Sharding/ShardedClusterObserverTests.cs
+++ b/test/SlowTests/Sharding/ShardedClusterObserverTests.cs
@@ -1,0 +1,72 @@
+﻿using System;
+using System.Collections.Generic;
+using System.Linq;
+using System.Text;
+using System.Threading.Tasks;
+using FastTests.Sharding;
+using Raven.Client.Documents;
+using Raven.Client.ServerWide;
+using Raven.Client.ServerWide.Operations;
+using Xunit;
+using Xunit.Abstractions;
+
+namespace SlowTests.Sharding
+{
+    public class ShardedClusterObserverTests : ShardedClusterTestBase
+    {
+        public ShardedClusterObserverTests(ITestOutputHelper output) : base(output)
+        {
+        }
+
+        [Fact]
+        public async Task CanMoveToRehab()
+        {
+            var database = GetDatabaseName();
+            var cluster = await CreateRaftCluster(3, watcherCluster: true, leaderIndex: 0);
+            await CreateShardedDatabaseInCluster(database, replicationFactor: 3, cluster, shards: 3);
+            await DisposeServerAndWaitForFinishOfDisposalAsync(cluster.Nodes[1]);
+
+            using (var store = GetDocumentStore(new Options
+                   {
+                       Server = cluster.Leader,
+                       CreateDatabase = false,
+                       ModifyDatabaseName = _ => database
+                   }))
+            {
+                await AssertWaitForValueAsync(async () =>
+                {
+                    var shards = await GetShards(store);
+                    return shards.Sum(s => s.Rehabs.Count);
+                }, 3);
+            }
+        }
+
+        [Fact]
+        public async Task CanAddNodeToShard()
+        {
+            var database = GetDatabaseName();
+            var cluster = await CreateRaftCluster(3, watcherCluster: true, leaderIndex: 0);
+            await CreateShardedDatabaseInCluster(database, replicationFactor: 1, cluster, shards: 3);
+
+            using (var store = GetDocumentStore(new Options
+                   {
+                       Server = cluster.Leader,
+                       CreateDatabase = false,
+                       ModifyDatabaseName = _ => database
+                   }))
+            {
+                for (int i = 0; i < 3; i++)
+                {
+                    var add = new AddDatabaseNodeOperation(database, shard: i);
+                    await store.Maintenance.Server.SendAsync(add);
+                }
+
+                await AssertWaitForValueAsync(async () =>
+                {
+                    var shards = await GetShards(store);
+                    return shards.Sum(s => s.Members.Count);
+                }, 6);
+            }
+        }
+    }
+}


### PR DESCRIPTION
### Issue link

https://issues.hibernatingrhinos.com/issue/RavenDB-18010

### Additional description

Cluster observer can handle now sharded database, and treat each shard as a separate database group.

But for things like clean idle auto indexes, compare exchange tombstone and clean cluster tx it takes into account every single node of the sharded database.

### Type of change

- New feature

### How risky is the change?

- Low 

### Backward compatibility

- Not relevant

### Is it platform specific issue?

- No

### Documentation update

- No documentation update is needed 

### Testing 

- Tests have been added that prove the fix is effective or that the feature works

### Is there any existing behavior change of other features due to this change?

- No

### UI work

- No UI work is needed
