### PR TITLE
RavenDB-18003 Filter keyword in a projection fails

### DIFF
--- a/src/Raven.Server/Documents/Queries/Parser/QueryParser.cs
+++ b/src/Raven.Server/Documents/Queries/Parser/QueryParser.cs
@@ -1830,7 +1830,6 @@ Grouping by 'Tag' or Field is supported only as a second grouping-argument.";
             "AS",
             "SELECT",
             "WHERE",
-            "FILTER",
             "LOAD",
             "GROUP",
             "ORDER",
@@ -1838,7 +1837,6 @@ Grouping by 'Tag' or Field is supported only as a second grouping-argument.";
             "UPDATE",
             "OFFSET",
             "LIMIT",
-            "FILTER_LIMIT",
             "SCALE"
         };
 
@@ -1864,8 +1862,21 @@ Grouping by 'Tag' or Field is supported only as a second grouping-argument.";
                 return false;
             }
 
+            var oldPos = Scanner.Position;
             if (Field(out var token))
             {
+                if (required == false && // need to check that this is a real alias 
+                    token.FieldValue.Equals("FILTER", StringComparison.OrdinalIgnoreCase))
+                {
+                    // if the alias is 'filter' *and* the next term is *not* a keyword, we have a filter clause so not an alias 
+                    if (Scanner.TryPeek(AliasKeywords) == false)
+                    {
+                        Scanner.Reset(oldPos);
+                        alias = null;
+                        return false;
+                    }
+                }
+
                 alias = token.FieldValue;
                 return true;
             }

--- a/src/Raven.Server/Documents/Queries/Parser/QueryScanner.cs
+++ b/src/Raven.Server/Documents/Queries/Parser/QueryScanner.cs
@@ -225,6 +225,32 @@ namespace Raven.Server.Documents.Queries.Parser
             return true;
         }
 
+        public bool TryPeek(string[] matches, bool skipWhitespace = true)
+        {
+            if (SkipWhitespace(skipWhitespace) == false)
+                return false;
+
+            foreach (string match in matches)
+            {
+                if (match.Length + _pos > _q.Length)
+                    return false;
+
+                if (string.Compare(_q, _pos, match, 0, match.Length, StringComparison.OrdinalIgnoreCase) != 0)
+                    continue;
+
+                if (_pos + match.Length < _q.Length)
+                {
+                    if (char.IsLetterOrDigit(match[match.Length - 1]) &&
+                        char.IsLetterOrDigit(_q[_pos + match.Length]))
+                        continue;
+                }
+
+                return true;
+            }
+
+            return false;
+        }
+
         public bool TryScan(string match, bool skipWhitespace = true)
         {
             if (TryPeek(match, skipWhitespace) == false)


### PR DESCRIPTION
Reverted the FILTER introduction as a keyword, instead it is a contextual keyword to prevent backward compatibility issues.
The same applies to FILTER_LIMIT

### Issue link

https://issues.hibernatingrhinos.com/issue/RavenDB-18003


### Additional description

The introduction of the `FILTER` and `FILTER_LIMIT` caused a backward compatability issue for users using `filter` as an alias or a function name. 

### Type of change

- Regression bug fix

### How risky is the change?

- Moderate 

### Backward compatibility

- Non breaking change

Reverting breaking change

### Is it platform specific issue?


- No

### Documentation update

- No documentation update is needed 

### Testing 

- Tests have been added that prove the fix is effective or that the feature works

