### PR TITLE
RavenDB-18026 Remove Identities from Stats View

### DIFF
--- a/src/Raven.Studio/typescript/viewmodels/database/status/statistics.ts
+++ b/src/Raven.Studio/typescript/viewmodels/database/status/statistics.ts
@@ -7,16 +7,12 @@ import indexStalenessReasons = require("viewmodels/database/indexes/indexStalene
 import getStorageReportCommand = require("commands/database/debug/getStorageReportCommand");
 import statsModel = require("models/database/stats/statistics");
 import popoverUtils = require("common/popoverUtils");
-import getIdentitiesCommand = require("commands/database/identities/getIdentitiesCommand");
-
-type identityItem = { Prefix: string, Value: number };
 
 class statistics extends viewModelBase {
 
     view = require("views/database/status/statistics.html");
 
     stats = ko.observable<statsModel>();
-    identities = ko.observableArray<identityItem>([]);
     rawJsonUrl: KnockoutComputed<string>;
 
     private refreshStatsObservable = ko.observable<number>();
@@ -112,25 +108,12 @@ class statistics extends viewModelBase {
         const dbDataLocationTask = new getStorageReportCommand(db)
             .execute();
         
-        const identitiesTask = new getIdentitiesCommand(db)
-            .execute();
-        
-        return $.when<any>(dbStatsTask, indexesStatsTask, dbDataLocationTask, identitiesTask)
+        return $.when<any>(dbStatsTask, indexesStatsTask, dbDataLocationTask)
             .done(([dbStats]: [Raven.Client.Documents.Operations.DetailedDatabaseStatistics],
                    [indexesStats]: [Raven.Client.Documents.Indexes.IndexStats[]],
-                   [dbLocation]: [storageReportDto],
-                   [identities]: [dictionary<number>]) => {
+                   [dbLocation]: [storageReportDto]) => {
                 this.processStatsResults(dbStats, indexesStats);
                 this.dataLocation(dbLocation.BasePath);
-                
-                const mappedIdentities = _.map(identities, (value, key): identityItem => {
-                    return {
-                        Prefix: key,
-                        Value: value
-                    };
-                });
-                
-                this.identities(_.sortBy(mappedIdentities, x => x.Prefix.toLocaleLowerCase()));
             });
     }
 

--- a/src/Raven.Studio/wwwroot/App/views/database/status/statistics.html
+++ b/src/Raven.Studio/wwwroot/App/views/database/status/statistics.html
@@ -219,27 +219,4 @@
             </div>
         </div>
     </div>
-    <hr />
-    <div class="identities">
-        <div class="flex-horizontal">
-            <h2 class="flex-end on-base-background">Identities</h2>
-            <small class="js-identities-header identities-header has-info-icon flex-end"><i class="icon-info text-info"></i></small>
-        </div>
-        <div class="row" data-bind="visible: identities().length === 0">
-            <div class="col-sm-8 col-sm-offset-2 col-lg-6 col-lg-offset-3">
-                <i class="icon-xl icon-empty-set text-muted"></i>
-                <h2 class="text-center text-muted">No identities have been defined for this database.</h2>
-            </div>
-        </div>
-        <div class="row row-sm flex-row" data-bind="visible: identities().length">
-            <div class="col-sm-6 col-lg-4 col-xl-3 flex-vertical">
-                <div class="stats-list margin-bottom flex-grow" data-bind="foreach: identities">
-                    <div class="stats-item">
-                        <div class="name" data-bind="text: Prefix, attr: { title: Prefix }"></div>
-                        <div class="value" data-bind="text: Value"></div>
-                    </div>
-                </div>
-            </div>
-        </div>
-    </div>
 </section>


### PR DESCRIPTION
### Issue link
https://issues.hibernatingrhinos.com/issue/RavenDB-.18026

### Additional description
Remove identities from the Stats view since we now have a dedicated view

### Type of change
- Bug fix

### How risky is the change?
- Low 

### Backward compatibility
- Non breaking change

### Is it platform specific issue?
- No

### Documentation update
- No documentation update is needed 

### Testing 
- It has been verified by manual testing

### Is there any existing behavior change of other features due to this change?
- No

### UI work
- No UI work is needed
