### PR TITLE
RavenDB-18028 Return the cluster-wide index enable/disable option the UI

### DIFF
--- a/src/Raven.Studio/wwwroot/App/views/database/indexes/indexes.html
+++ b/src/Raven.Studio/wwwroot/App/views/database/indexes/indexes.html
@@ -42,26 +42,22 @@
                                         <span class="sr-only">Toggle Dropdown</span>
                                     </button>
                                     <ul class="dropdown-menu">
-
-
-<!-- TODO return when issue RavenDB-16345 is done -->
-<!--                                        <li class="margin-left margin-top margin-top-sm" data-bind="visible: isCluster">-->
-<!--                                            <label><strong>Cluster Wide</strong></label>-->
-<!--                                        </li>-->
-<!--                                        <li data-bind="click: _.partial(enableSelectedIndexes, true), visible: isCluster">-->
-<!--                                            <a href="#" title="Enable indexing on ALL cluster nodes">-->
-<!--                                                <i class="icon-play"></i>-->
-<!--                                                <span>Enable</span>-->
-<!--                                            </a>-->
-<!--                                        </li>-->
-<!--                                        <li data-bind="click: _.partial(disableSelectedIndexes, true), visible: isCluster">-->
-<!--                                            <a href="#" title="Disable indexing on All cluster nodes">-->
-<!--                                                <i class="icon-cancel"></i>-->
-<!--                                                <span>Disable</span>-->
-<!--                                            </a>-->
-<!--                                        </li>-->
-<!--                                        <li class="divider" data-bind="visible: isCluster"></li>-->
-                                        
+                                        <li class="margin-left margin-top margin-top-sm" data-bind="visible: isCluster">
+                                            <label><strong>Cluster Wide</strong></label>
+                                        </li>
+                                        <li data-bind="click: _.partial(enableSelectedIndexes, true), visible: isCluster">
+                                            <a href="#" title="Enable indexing on ALL cluster nodes">
+                                                <i class="icon-play"></i>
+                                                <span>Enable</span>
+                                            </a>
+                                        </li>
+                                        <li data-bind="click: _.partial(disableSelectedIndexes, true), visible: isCluster">
+                                            <a href="#" title="Disable indexing on All cluster nodes">
+                                                <i class="icon-cancel"></i>
+                                                <span>Disable</span>
+                                            </a>
+                                        </li>
+                                        <li class="divider" data-bind="visible: isCluster"></li>
                                         <li class="margin-left margin-top margin-top-sm" data-bind="visible: isCluster">
                                             <label><strong>Local Node</strong></label>
                                         </li>
@@ -246,30 +242,24 @@
                             <span class="caret"></span>
                         </button>
                         <ul class="dropdown-menu">
-                            
-<!-- TODO return when issue RavenDB-16345 is done -->                          
-<!--                            <li data-bind="visible: canBeEnabled() && $root.isCluster()">-->
-<!--                                <a href="#" data-bind="click: _.partial($root.enableIndex, $data, true)" title="Enable indexing on ALL cluster nodes">-->
-<!--                                    <i class="icon-play"></i>-->
-<!--                                    <span>Enable indexing - Cluster wide</span>-->
-<!--                                </a>-->
-<!--                            </li>-->
-                            
+                            <li data-bind="visible: canBeEnabled() && $root.isCluster()">
+                                <a href="#" data-bind="click: _.partial($root.enableIndex, $data, true)" title="Enable indexing on ALL cluster nodes">
+                                    <i class="icon-play"></i>
+                                    <span>Enable indexing - Cluster wide</span>
+                                </a>
+                            </li>
                             <li data-bind="visible: canBeEnabled()">
                                 <a href="#" data-bind="click: _.partial($root.enableIndex, $data, false), attr: { title: 'Enable indexing on node ' + $root.localNodeTag() }">
                                     <i class="icon-play"></i>
                                     <span data-bind="text: $root.isCluster() ? 'Enable indexing - Local node' : 'Enable indexing'"></span>
                                 </a>
                             </li>
-                            
-<!-- TODO return when issue RavenDB-16345 is done -->
-<!--                            <li data-bind="visible: canBeDisabled() && $root.isCluster()">-->
-<!--                                <a href="#" data-bind="click: _.partial($root.disableIndex, $data, true)" title="Disable indexing on ALL cluster nodes">-->
-<!--                                    <i class="icon-cancel"></i>-->
-<!--                                    <span>Disable indexing - Cluster wide</span>-->
-<!--                                </a>-->
-<!--                            </li>-->
-                            
+                            <li data-bind="visible: canBeDisabled() && $root.isCluster()">
+                                <a href="#" data-bind="click: _.partial($root.disableIndex, $data, true)" title="Disable indexing on ALL cluster nodes">
+                                    <i class="icon-cancel"></i>
+                                    <span>Disable indexing - Cluster wide</span>
+                                </a>
+                            </li>
                             <li data-bind="visible: canBeDisabled()">
                                 <a href="#" data-bind="click: _.partial($root.disableIndex, $data, false), attr: { title: 'Disable indexing on node ' + $root.localNodeTag() }">
                                     <i class="icon-cancel"></i>


### PR DESCRIPTION
### Issue link
https://issues.hibernatingrhinos.com/issue/RavenDB-18028

### Additional description
Return the cluster-wide index enable/disable option the UI dropdown

### Type of change
- Bug fix

### How risky is the change?
- Low 

### Backward compatibility
- Non breaking change

### Is it platform specific issue?
- No

### Documentation update
- No documentation update is needed 

### Testing 
- It has been verified by manual testing

### Is there any existing behavior change of other features due to this change?
- No

### UI work
- No UI work is needed
