### PR TITLE
RavenDB-18056 limit the timeticks returned by oldest backup SNMP endp…

### DIFF
--- a/src/Raven.Server/Monitoring/Snmp/Objects/Database/5.2.X/1/DatabaseUpTime.cs
+++ b/src/Raven.Server/Monitoring/Snmp/Objects/Database/5.2.X/1/DatabaseUpTime.cs
@@ -13,7 +13,7 @@ namespace Raven.Server.Monitoring.Snmp.Objects.Database
 
         protected override TimeTicks GetData(DocumentDatabase database)
         {
-            return new TimeTicks(SystemTime.UtcNow - database.StartTime);
+            return SnmpValuesHelper.TimeSpanToTimeTicks(SystemTime.UtcNow - database.StartTime);
         }
     }
 }

--- a/src/Raven.Server/Monitoring/Snmp/Objects/Database/5.2.X/4/DatabaseIndexTimeSinceLastIndexing.cs
+++ b/src/Raven.Server/Monitoring/Snmp/Objects/Database/5.2.X/4/DatabaseIndexTimeSinceLastIndexing.cs
@@ -17,7 +17,7 @@ namespace Raven.Server.Monitoring.Snmp.Objects.Database
             var stats = index.GetStats();
 
             if (stats.LastIndexingTime.HasValue)
-                return new TimeTicks(SystemTime.UtcNow - stats.LastIndexingTime.Value);
+                return SnmpValuesHelper.TimeSpanToTimeTicks(SystemTime.UtcNow - stats.LastIndexingTime.Value);
 
             return null;
         }

--- a/src/Raven.Server/Monitoring/Snmp/Objects/Database/5.2.X/4/DatabaseIndexTimeSinceLastQuery.cs
+++ b/src/Raven.Server/Monitoring/Snmp/Objects/Database/5.2.X/4/DatabaseIndexTimeSinceLastQuery.cs
@@ -17,7 +17,7 @@ namespace Raven.Server.Monitoring.Snmp.Objects.Database
             var stats = index.GetStats();
 
             if (stats.LastQueryingTime.HasValue)
-                return new TimeTicks(SystemTime.UtcNow - stats.LastQueryingTime.Value);
+                return SnmpValuesHelper.TimeSpanToTimeTicks(SystemTime.UtcNow - stats.LastQueryingTime.Value);
 
             return null;
         }

--- a/src/Raven.Server/Monitoring/Snmp/Objects/Server/1.11/ServerCertificateExpirationLeft.cs
+++ b/src/Raven.Server/Monitoring/Snmp/Objects/Server/1.11/ServerCertificateExpirationLeft.cs
@@ -24,7 +24,7 @@ namespace Raven.Server.Monitoring.Snmp.Objects.Server
             var notAfter = holder.Certificate.NotAfter;
 
             var timeLeft = notAfter - SystemTime.UtcNow;
-            return new TimeTicks(timeLeft.TotalMilliseconds > 0 ? timeLeft : TimeSpan.Zero);
+            return SnmpValuesHelper.TimeSpanToTimeTicks(timeLeft.TotalMilliseconds > 0 ? timeLeft : TimeSpan.Zero);
         }
     }
 }

--- a/src/Raven.Server/Monitoring/Snmp/Objects/Server/1.9/ServerLicenseExpirationLeft.cs
+++ b/src/Raven.Server/Monitoring/Snmp/Objects/Server/1.9/ServerLicenseExpirationLeft.cs
@@ -22,7 +22,7 @@ namespace Raven.Server.Monitoring.Snmp.Objects.Server
                 return null;
 
             var timeLeft = status.Expiration.Value - SystemTime.UtcNow;
-            return new TimeTicks(timeLeft.TotalMilliseconds > 0 ? timeLeft : TimeSpan.Zero);
+            return SnmpValuesHelper.TimeSpanToTimeTicks(timeLeft.TotalMilliseconds > 0 ? timeLeft : TimeSpan.Zero);
         }
     }
 }

--- a/src/Raven.Server/Monitoring/Snmp/Objects/Server/ServerLastAuthorizedNonClusterAdminRequestTime.cs
+++ b/src/Raven.Server/Monitoring/Snmp/Objects/Server/ServerLastAuthorizedNonClusterAdminRequestTime.cs
@@ -17,9 +17,9 @@ namespace Raven.Server.Monitoring.Snmp.Objects.Server
         protected override TimeTicks GetData()
         {
             if (_statistics.LastAuthorizedNonClusterAdminRequestTime.HasValue)
-                return new TimeTicks(SystemTime.UtcNow - _statistics.LastAuthorizedNonClusterAdminRequestTime.Value);
+                return SnmpValuesHelper.TimeSpanToTimeTicks(SystemTime.UtcNow - _statistics.LastAuthorizedNonClusterAdminRequestTime.Value);
 
-            return new TimeTicks(uint.MaxValue);
+            return SnmpValuesHelper.TimeTicksMax;
         }
     }
 }

--- a/src/Raven.Server/Monitoring/Snmp/Objects/Server/ServerLastRequestTime.cs
+++ b/src/Raven.Server/Monitoring/Snmp/Objects/Server/ServerLastRequestTime.cs
@@ -17,7 +17,7 @@ namespace Raven.Server.Monitoring.Snmp.Objects.Server
         protected override TimeTicks GetData()
         {
             if (_statistics.LastRequestTime.HasValue)
-                return new TimeTicks(SystemTime.UtcNow - _statistics.LastRequestTime.Value);
+                return SnmpValuesHelper.TimeSpanToTimeTicks(SystemTime.UtcNow - _statistics.LastRequestTime.Value);
 
             return null;
         }

--- a/src/Raven.Server/Monitoring/Snmp/Objects/Server/ServerUpTime.cs
+++ b/src/Raven.Server/Monitoring/Snmp/Objects/Server/ServerUpTime.cs
@@ -15,7 +15,7 @@ namespace Raven.Server.Monitoring.Snmp.Objects.Server
 
         protected override TimeTicks GetData()
         {
-            return new TimeTicks(_statistics.UpTime);
+            return SnmpValuesHelper.TimeSpanToTimeTicks(_statistics.UpTime);
         }
     }
 
@@ -31,7 +31,7 @@ namespace Raven.Server.Monitoring.Snmp.Objects.Server
 
         protected override TimeTicks GetData()
         {
-            return new TimeTicks(_statistics.UpTime);
+            return SnmpValuesHelper.TimeSpanToTimeTicks(_statistics.UpTime);
         }
     }
 }

--- a/src/Raven.Server/Monitoring/Snmp/SnmpValuesHelper.cs
+++ b/src/Raven.Server/Monitoring/Snmp/SnmpValuesHelper.cs
@@ -5,14 +5,17 @@ namespace Raven.Server.Monitoring.Snmp
 {
     public static class SnmpValuesHelper
     {
-        public static TimeTicks TimeTicksMax => new TimeTicks(uint.MaxValue);
+        public static TimeTicks TimeTicksMax = new TimeTicks(uint.MaxValue);
 
         public static TimeTicks TimeTicksZero = new TimeTicks(0);
 
-        public static TimeSpan TimeSpanSnmpMax => TimeTicksMax.ToTimeSpan();
+        public static TimeSpan TimeSpanSnmpMax = TimeTicksMax.ToTimeSpan();
         
         public static TimeTicks TimeSpanToTimeTicks(TimeSpan timeSpan)
         {
+            if (timeSpan <= TimeSpan.Zero)
+                return TimeTicksZero;
+            
             if (timeSpan > TimeSpanSnmpMax)
                 return TimeTicksMax;
                     

--- a/src/Raven.Server/Monitoring/Snmp/SnmpValuesHelper.cs
+++ b/src/Raven.Server/Monitoring/Snmp/SnmpValuesHelper.cs
@@ -1,0 +1,23 @@
+﻿using System;
+using Lextm.SharpSnmpLib;
+
+namespace Raven.Server.Monitoring.Snmp
+{
+    public static class SnmpValuesHelper
+    {
+        public static TimeTicks TimeTicksMax => new TimeTicks(uint.MaxValue);
+
+        public static TimeTicks TimeTicksZero = new TimeTicks(0);
+
+        public static TimeSpan TimeSpanSnmpMax => TimeTicksMax.ToTimeSpan();
+        
+        public static TimeTicks TimeSpanToTimeTicks(TimeSpan timeSpan)
+        {
+            if (timeSpan > TimeSpanSnmpMax)
+                return TimeTicksMax;
+                    
+            return new TimeTicks(timeSpan);
+        }
+        
+    }
+}

--- a/test/SlowTests/Monitoring/TimeSinceOldestBackupTests.cs
+++ b/test/SlowTests/Monitoring/TimeSinceOldestBackupTests.cs
@@ -1,0 +1,124 @@
+﻿using System;
+using System.Collections.Generic;
+using System.Linq;
+using FastTests;
+using Lextm.SharpSnmpLib;
+using Raven.Client.Util;
+using Raven.Server.Monitoring.Snmp;
+using Raven.Server.Monitoring.Snmp.Objects.Database;
+using Xunit;
+using Xunit.Abstractions;
+
+namespace SlowTests.Monitoring
+{
+    public class TimeSinceOldestBackupTests : RavenTestBase
+    {
+        private readonly Dictionary<string, DateTime?> _backupDates;
+        private readonly SystemTime _time;
+
+        public TimeSinceOldestBackupTests(ITestOutputHelper output) : base(output)
+        {
+            _backupDates = new Dictionary<string, DateTime?>();
+            _time = new SystemTime();
+            _time.UtcDateTime = () => new DateTime(2022, 02, 15);
+        }
+
+        private void SetupDatabasesBackupTimes(DateTime?[] backupDates)
+        {
+            for (var i = 0; i < backupDates.Length; i++)
+            {
+                _backupDates.Add(i.ToString(), backupDates[i]);
+            }
+        }
+
+        private DateTime? GetLastBackupDate(string databaseName)
+        {
+            return _backupDates[databaseName];
+        }
+
+        [Fact]
+        public void GivenNeverBackedUpDb_ReturnsTimespanMax()
+        {
+            var backupTimes = new DateTime?[]
+            {
+                _time.GetUtcNow().Date, 
+                _time.GetUtcNow().Subtract(TimeSpan.FromDays(1)), 
+                _time.GetUtcNow(),
+                DateTime.MinValue, 
+            };
+            
+            SetupDatabasesBackupTimes(backupTimes);
+            
+            var result = 
+                DatabaseOldestBackup.GetTimeSinceOldestBackupInternal(_backupDates.Keys.ToList(), GetLastBackupDate, _time);
+            Assert.True(result > SnmpValuesHelper.TimeSpanSnmpMax);
+            Assert.Equal(SnmpValuesHelper.TimeTicksMax, SnmpValuesHelper.TimeSpanToTimeTicks(result));
+        } 
+        
+        [Fact]
+        public void GivenDbJustBackedUp_ReturnsZero()
+        {
+            var backupTimes = new DateTime?[]
+            {
+                _time.GetUtcNow(), 
+            };
+            
+            SetupDatabasesBackupTimes(backupTimes);
+            
+            var result = 
+                DatabaseOldestBackup.GetTimeSinceOldestBackupInternal(_backupDates.Keys.ToList(), GetLastBackupDate, _time);
+            Assert.Equal(TimeSpan.Zero, result);
+            Assert.Equal(new TimeTicks(0),
+                SnmpValuesHelper.TimeSpanToTimeTicks(result));
+            Assert.Equal(SnmpValuesHelper.TimeTicksZero, SnmpValuesHelper.TimeSpanToTimeTicks(result));
+        } 
+        
+        [Fact]
+        public void Given_NoDbs_ReturnsZero()
+        {
+            var backupTimes = new DateTime?[] {};
+            
+            SetupDatabasesBackupTimes(backupTimes);
+            
+            var result = 
+                DatabaseOldestBackup.GetTimeSinceOldestBackupInternal(_backupDates.Keys.ToList(), GetLastBackupDate, _time);
+            Assert.Equal(TimeSpan.Zero, result);
+            Assert.Equal(SnmpValuesHelper.TimeTicksZero, SnmpValuesHelper.TimeSpanToTimeTicks(result));
+        } 
+        
+        [Fact]
+        public void GivenAFewDatabases_ShouldProvideDurationSinceTheOldestDatabaseBackup()
+        {
+            var backupTimes = new DateTime?[]
+            {
+                _time.GetUtcNow().Date, 
+                _time.GetUtcNow().Subtract(TimeSpan.FromDays(1)), 
+                _time.GetUtcNow(),
+                null
+            };
+            
+            SetupDatabasesBackupTimes(backupTimes);
+            
+            var result = 
+                DatabaseOldestBackup.GetTimeSinceOldestBackupInternal(_backupDates.Keys.ToList(), GetLastBackupDate, _time);
+            Assert.Equal(_time.GetUtcNow() - backupTimes[1], result);
+        } 
+        
+        [Fact]
+        public void GivenDatabaseBackedUp_MoreThanMaxTimeTicksAgo_ReturnsTimespanMax()
+        {
+            var maxTimeTicksTimespan = SnmpValuesHelper.TimeTicksMax.ToTimeSpan();
+            var backupTimes = new DateTime?[]
+            {
+                _time.GetUtcNow().Subtract(maxTimeTicksTimespan).Subtract(TimeSpan.FromDays(1))
+            };
+            
+            SetupDatabasesBackupTimes(backupTimes);
+            
+            var result = 
+                DatabaseOldestBackup.GetTimeSinceOldestBackupInternal(_backupDates.Keys.ToList(), GetLastBackupDate, _time);
+            Assert.True(result > SnmpValuesHelper.TimeSpanSnmpMax);
+            Assert.Equal(SnmpValuesHelper.TimeTicksMax, SnmpValuesHelper.TimeSpanToTimeTicks(result));
+        } 
+    }
+}

--- a/test/SlowTests/Monitoring/TimeSinceOldestBackupTests.cs
+++ b/test/SlowTests/Monitoring/TimeSinceOldestBackupTests.cs
@@ -68,7 +68,7 @@ namespace SlowTests.Monitoring
             var result = 
                 DatabaseOldestBackup.GetTimeSinceOldestBackupInternal(_backupDates.Keys.ToList(), GetLastBackupDate, _time);
             Assert.Equal(TimeSpan.Zero, result);
-            Assert.Equal(new TimeTicks(0),
+            Assert.Equal(SnmpValuesHelper.TimeTicksZero,
                 SnmpValuesHelper.TimeSpanToTimeTicks(result));
             Assert.Equal(SnmpValuesHelper.TimeTicksZero, SnmpValuesHelper.TimeSpanToTimeTicks(result));
         } 


### PR DESCRIPTION
…oint; add tests

### Issue link

https://issues.hibernatingrhinos.com/issue/RavenDB-18056

### Additional description

PR changes the calculation of the oldest backup time from all databases. We did not limit the TimeSpan value passed to SNMP TimeTicks, which might resulted in overflows for databases that were never backed up. Added tests for the calculation logic.

### Type of change

- Bug fix

### How risky is the change?

- Moderate 

### Backward compatibility

- Not relevant

### Is it platform specific issue?

- No

### Documentation update

- No documentation update is needed 

### Testing 

- Tests have been added that prove the fix is effective or that the feature works

### Is there any existing behavior change of other features due to this change?

- No

### UI work

- No UI work is needed
