### PR TITLE
RavenDB-18061 added WriteStreamAsync to AsyncBlittableJsonTextWriter and removed WriteStream from AbstractBlittableJsonTextWriter

### DIFF
--- a/src/Raven.Server/Smuggler/Documents/StreamDestination.cs
+++ b/src/Raven.Server/Smuggler/Documents/StreamDestination.cs
@@ -1211,7 +1211,7 @@ namespace Raven.Server.Smuggler.Documents
 
                 Writer.WriteEndObject();
 
-                Writer.WriteStream(stream);
+                await Writer.WriteStreamAsync(stream);
 
                 await Writer.MaybeFlushAsync();
             }

--- a/src/Sparrow/Json/AbstractBlittableJsonTextWriter.cs
+++ b/src/Sparrow/Json/AbstractBlittableJsonTextWriter.cs
@@ -63,13 +63,13 @@ namespace Sparrow.Json
             EscapeCharacters[(byte)'"'] = (byte)'"';
         }
 
-        private readonly JsonOperationContext.MemoryBuffer _pinnedBuffer;
+        private protected readonly JsonOperationContext.MemoryBuffer _pinnedBuffer;
         private readonly byte* _buffer;
 
         private readonly byte* _auxiliarBuffer;
         private readonly int _auxiliarBufferLength;
 
-        private int _pos;
+        private protected int _pos;
         private readonly JsonOperationContext.MemoryBuffer.ReturnBuffer _returnBuffer;
         private readonly JsonOperationContext.MemoryBuffer.ReturnBuffer _returnAuxiliarBuffer;
 
@@ -722,20 +722,6 @@ namespace Sparrow.Json
             EnsureBuffer(2);
             _buffer[_pos++] = (byte)'\r';
             _buffer[_pos++] = (byte)'\n';
-        }
-
-        public void WriteStream(Stream stream)
-        {
-            FlushInternal();
-
-            while (true)
-            {
-                _pos = stream.Read(_pinnedBuffer.Memory.Memory.Span);
-                if (_pos == 0)
-                    break;
-
-                FlushInternal();
-            }
         }
 
         public void WriteMemoryChunk(IntPtr ptr, int size)

--- a/src/Sparrow/Json/AsyncBlittableJsonTextWriter.cs
+++ b/src/Sparrow/Json/AsyncBlittableJsonTextWriter.cs
@@ -15,6 +15,20 @@ namespace Sparrow.Json
             _outputStream = stream ?? throw new ArgumentNullException(nameof(stream));
         }
 
+        public async ValueTask WriteStreamAsync(Stream stream, CancellationToken token = default)
+        {
+            await FlushAsync(token).ConfigureAwait(false);
+
+            while (true)
+            {
+                _pos = await stream.ReadAsync(_pinnedBuffer.Memory.Memory, token).ConfigureAwait(false);
+                if (_pos == 0)
+                    break;
+
+                await FlushAsync(token).ConfigureAwait(false);
+            }
+        }
+
         [MethodImpl(MethodImplOptions.AggressiveInlining)]
         public ValueTask<int> MaybeFlushAsync(CancellationToken token = default)
         {


### PR DESCRIPTION
### Issue link

https://issues.hibernatingrhinos.com/issue/RavenDB-18061

### Type of change

- Optimization

### How risky is the change?

- Low 

### Backward compatibility

- Not relevant

### Is it platform specific issue?

- No

### Documentation update

- No documentation update is needed 

### Testing 

- Tests have been added that prove the fix is effective or that the feature works
- It has been verified by manual testing

### Is there any existing behavior change of other features due to this change?

- No

### UI work

- No UI work is needed
