### PR TITLE
RavenDB-18005 Fix the auto-generated query syntax

### DIFF
--- a/src/Raven.Studio/typescript/common/queryUtil.ts
+++ b/src/Raven.Studio/typescript/common/queryUtil.ts
@@ -47,7 +47,7 @@ class queryUtil {
     static formatIndexQuery(indexName: string, fieldName: string, value: string) {
         const escapedFieldName = queryUtil.wrapWithSingleQuotes(fieldName);
         const escapedIndexName = queryUtil.escapeName(indexName);
-        return `from index ${escapedIndexName} where ${escapedFieldName} = '${value}' `;
+        return `from index ${escapedIndexName} where ${escapedFieldName} == '${value}' `;
     }
     
     static wrapWithSingleQuotes(input: string) {

--- a/src/Raven.Studio/typescript/common/queryUtil.ts
+++ b/src/Raven.Studio/typescript/common/queryUtil.ts
@@ -16,18 +16,18 @@ class queryUtil {
     static readonly MaxDateUTC = "9999-01-01T00:00:00.000Z";
 
     static formatRawTimeSeriesQuery(collectionName: string, documentId: string, timeSeriesName: string, startDate?: moment.Moment, endDate?: moment.Moment) {
-        const escapedCollectionName = queryUtil.wrapWithSingleQuotes(collectionName || "@all_docs");
+        const escapedCollectionName = queryUtil.escapeName(collectionName || "@all_docs");
         const escapedDocumentId = queryUtil.escapeName(documentId);
-        const escapedTimeSeriesName = queryUtil.wrapWithSingleQuotes(timeSeriesName);
+        const escapedTimeSeriesName = queryUtil.escapeName(timeSeriesName);
         const dates = queryUtil.formatDates(startDate, endDate);
         
         return `from ${escapedCollectionName}\r\nwhere id() == ${escapedDocumentId}\r\nselect timeseries(from ${escapedTimeSeriesName}${dates})`;
     }
 
     static formatGroupedTimeSeriesQuery(collectionName: string, documentId: string, timeSeriesName: string, group: string, startDate?: moment.Moment, endDate?: moment.Moment) {
-        const escapedCollectionName = queryUtil.wrapWithSingleQuotes(collectionName || "@all_docs");
+        const escapedCollectionName = queryUtil.escapeName(collectionName || "@all_docs");
         const escapedDocumentId = queryUtil.escapeName(documentId);
-        const escapedTimeSeriesName = queryUtil.wrapWithSingleQuotes(timeSeriesName);
+        const escapedTimeSeriesName = queryUtil.escapeName(timeSeriesName);
         const dates = queryUtil.formatDates(startDate, endDate);
 
         return `from ${escapedCollectionName}\r\nwhere id() == ${escapedDocumentId}\r\nselect timeseries(from ${escapedTimeSeriesName}${dates} group by ${group} select avg())`;
@@ -45,9 +45,10 @@ class queryUtil {
     }
     
     static formatIndexQuery(indexName: string, fieldName: string, value: string) {
-        const escapedFieldName = queryUtil.wrapWithSingleQuotes(fieldName);
+        const escapedFieldName = queryUtil.escapeName(fieldName);
         const escapedIndexName = queryUtil.escapeName(indexName);
-        return `from index ${escapedIndexName} where ${escapedFieldName} == '${value}' `;
+        const escapedValueName = queryUtil.escapeName(value);
+        return `from index ${escapedIndexName} where ${escapedFieldName} == ${escapedValueName}`;
     }
     
     static wrapWithSingleQuotes(input: string) {


### PR DESCRIPTION
### Issue link
https://issues.hibernatingrhinos.com/issue/RavenDB-18005

### Additional description
Fix the auto generated query syntax from `=` to `==` when clicking from Terms View

### Type of change
- Bug fix

### How risky is the change?
- Low 

### Backward compatibility
- Non breaking change

### Is it platform specific issue?
- No

### Documentation update
- No documentation update is needed 

### Testing 
- It has been verified by manual testing

### Is there any existing behavior change of other features due to this change?
- No

### UI work
- No UI work is needed
