### PR TITLE
RavenDB-18068 do not fail to load database if we failed to delete DatabaseInfoCache

### DIFF
--- a/src/Raven.Server/Documents/DatabaseInfoCache.cs
+++ b/src/Raven.Server/Documents/DatabaseInfoCache.cs
@@ -106,7 +106,7 @@ namespace Raven.Server.Documents
         /// </summary>
         /// <param name="ctx">A context allocated outside the method with an open write transaction</param>
         /// <param name="databaseName">The database name as a slice</param>
-        public void DeleteInternal(TransactionOperationContext ctx, Slice databaseName)
+        private void DeleteInternal(TransactionOperationContext ctx, Slice databaseName)
         {
             if (Logger.IsInfoEnabled)
                 Logger.Info($"Deleting database info for '{databaseName}'.");
@@ -117,7 +117,7 @@ namespace Raven.Server.Documents
         public void Delete(string databaseName)
         {
             using (_contextPool.AllocateOperationContext(out TransactionOperationContext ctx))
-            using (var tx = ctx.OpenWriteTransaction())
+            using (var tx = ctx.OpenWriteTransaction(TimeSpan.FromSeconds(5)))
             using (Slice.From(ctx.Allocator, databaseName.ToLowerInvariant(), out Slice key))
             {
                 DeleteInternal(ctx, key);


### PR DESCRIPTION
### Issue link

https://issues.hibernatingrhinos.com/issue/RavenDB-18068

### Additional description

The database info cache is used only by Studio to display information of database without the need to load it. If we fail to delete it during the database load (due to timeout in opening tx to server store) we should just ignore it and continue the process. We are doing the same when database is being disposed.

### Type of change

- Bug fix

### How risky is the change?

- Low 

### Backward compatibility

- Non breaking change

### Is it platform specific issue?

- No

### Documentation update

- No documentation update is needed 

### Testing 

- It has been verified by manual testing

### Is there any existing behavior change of other features due to this change?

- Yes. If we failed to delete it and then during database dispose we failed to insert new one, Studio might show stale information. Considering this a low and acceptable. We should prefer loading database instead of failing it because of this reason.

### UI work

- No UI work is needed
