### PR TITLE
RavenDB-17702 remove empty change vector and fix TryPutSegmentDirectly

### DIFF
--- a/test/SlowTests/Issues/RavenDB-17702.cs
+++ b/test/SlowTests/Issues/RavenDB-17702.cs
@@ -1,0 +1,145 @@
+﻿using System;
+using System.Threading.Tasks;
+using FastTests.Server.Replication;
+using Raven.Server.ServerWide.Context;
+using Raven.Tests.Core.Utils.Entities;
+using Xunit;
+using Xunit.Abstractions;
+
+namespace SlowTests.Issues
+{
+    public class RavenDB_17702 : ReplicationTestBase
+    {
+        public RavenDB_17702(ITestOutputHelper output) : base(output)
+        {
+        }
+        [Fact]
+        public async Task InsertOldSegmentAfterDeletionProblem1()
+        {
+            var cluster = await CreateRaftCluster(3, watcherCluster: true);
+            using (var store = GetDocumentStore(new Options
+            {
+                Server = cluster.Leader,
+                ReplicationFactor = 3,
+            }))
+            {
+                var now = DateTime.UtcNow;
+                using (var session = store.OpenSession())
+                {
+                    session.Store(new User { Name = "Karmel" }, "users/1");
+                    session.SaveChanges();
+                }
+
+                for (int i = 0; i < 31; i += 30)
+                {
+                    var ts1 = now.AddDays(i);
+                    var ts2 = now.AddDays(i).AddSeconds(1);
+                    using (var session = store.OpenSession())
+                    {
+                        session.TimeSeriesFor("users/1", "Heartrate")
+                             .Append(ts1, 1);
+                        session.TimeSeriesFor("users/1", "Heartrate")
+                            .Append(ts2, 1);
+                        session.SaveChanges();
+                    }
+                    using (var session = store.OpenSession())
+                    {
+                        session.TimeSeriesFor("users/1", "Heartrate")
+                            .Delete(now.AddDays(i), now.AddDays(i).AddSeconds(1));
+                        session.SaveChanges();
+                    }
+                    foreach (var server in Servers)
+                    {
+                        var database = await server.ServerStore.DatabasesLandlord.TryGetOrCreateResourceStore(store.Database);
+                        var tss = database.DocumentsStorage.TimeSeriesStorage;
+                        var res = await WaitForValueAsync(() =>
+                        {
+                            using (database.DocumentsStorage.ContextPool.AllocateOperationContext(out DocumentsOperationContext ctx))
+                            using (ctx.OpenReadTransaction())
+                            {
+                                var id = $"users/1";
+                                var stats = tss.Stats.GetStats(ctx, id, "Heartrate");
+                                return stats.Count;
+                            }
+                        }, 0, 5000);
+                        Assert.Equal(0, res);
+
+                    }
+                }
+            }
+        }
+
+        [Fact]
+        public async Task InsertOldSegmentAfterDeletionProblem2()
+        {
+            using (var store1 = GetDocumentStore())
+            using (var store2 = GetDocumentStore())
+            {
+                var now = DateTime.UtcNow;
+                using (var session = store1.OpenSession())
+                {
+                    session.Store(new User { Name = "Karmel" }, "users/1");
+                    session.SaveChanges();
+                }
+                using (var session = store2.OpenSession())
+                {
+                    session.Store(new User { Name = "Karmel" }, "users/1");
+                    session.SaveChanges();
+                }
+                var ts1 = now;
+                var ts2 = now.AddDays(30);
+                using (var session = store1.OpenSession())
+                {
+                    session.TimeSeriesFor("users/1", "Heartrate")
+                        .Append(ts1, 1);
+                    session.TimeSeriesFor("users/1", "Heartrate")
+                        .Append(ts2, 1);
+                    session.SaveChanges();
+                }
+
+                using (var session = store1.OpenSession())
+                {
+                    session.TimeSeriesFor("users/1", "Heartrate")
+                        .Delete(now, now.AddDays(29));
+                    session.SaveChanges();
+                }
+
+
+                ts1 = now.AddSeconds(2);
+                ts2 = now.AddSeconds(3);
+                using (var session = store2.OpenSession())
+                {
+                    session.TimeSeriesFor("users/1", "Heartrate")
+                        .Append(ts1, 1);
+                    session.TimeSeriesFor("users/1", "Heartrate")
+                        .Append(ts2, 1);
+                    session.SaveChanges();
+                }
+                await SetupReplicationAsync(store2, store1);
+                await EnsureReplicatingAsync(store2, store1);
+
+                await SetupReplicationAsync(store1, store2);
+                var res = await WaitForValueAsync(() =>
+                {
+                    using (var session = store2.OpenSession())
+                    {
+                        var ts = session.TimeSeriesFor("users/1", "Heartrate")
+                            .Get(DateTime.MinValue, DateTime.MaxValue);
+
+                        return ts.Length;
+                    }
+                }, 1);
+                res = await WaitForValueAsync(() =>
+                {
+                    using (var session = store1.OpenSession())
+                    {
+                        var ts = session.TimeSeriesFor("users/1", "Heartrate")
+                            .Get(DateTime.MinValue, DateTime.MaxValue);
+
+                        return ts.Length;
+                    }
+                }, 1);
+            }
+        }
+    }
+}


### PR DESCRIPTION
### Issue link

https://issues.hibernatingrhinos.com/issue/RavenDB-17702

### Additional description

we had 2 problems in TryAppendEntireSegmentFromSmuggler:
1. we need to get true only if we have the same segment and not the closest segment
2. we need to sent change vector from incoming replication to append new segment

we had a problem with the change vector empty. like the scenario :
* cluster with 3 nodes
* node A responsible for rolling/retention
* Node A sends to Node B and C new segment X
* Node A sends to Node B and C delete segment X
* node B executes both requests. ( Now we have empty change vector duo to https://github.com/ravendb/ravendb/blob/ff6d261f9d159eb7c017660f351d86dece6e3246/src/Raven.Server/Documents/TimeSeries/TimeSeriesStorage.cs#L1004)
* node C executes the first request and send to Node B - B get the request and compare with empty change vector then insert the segment X again
* B sends the second request to C ( C don't need to send the delete to B)
In the end, we stay with X segment

In general empty change vector is a problem when we want to compare between two change vectors --> we always update
now, we get a new change vector for dead segment. 

_Please delete below the options that are not relevant_

### Type of change

- Bug fix

### How risky is the change?

- Low 

### Backward compatibility

- Non breaking change


### Is it platform specific issue?

- No

### Documentation update
- No documentation update is needed 

### Testing 

- Tests have been added that prove the fix is effective or that the feature works

### Is there any existing behavior change of other features due to this change?

- No

### UI work

- No UI work is needed
