### PR TITLE
RavenDB-17955 - Debug Info Package takes a very long time to generate

### DIFF
--- a/src/Raven.Server/Documents/Handlers/Debugging/ServerWideDebugInfoPackageHandler.cs
+++ b/src/Raven.Server/Documents/Handlers/Debugging/ServerWideDebugInfoPackageHandler.cs
@@ -316,7 +316,7 @@ namespace Raven.Server.Documents.Handlers.Debugging
                 debugInfoDict[route.Path] = sw.Elapsed;
             }
 
-            await DebugInfoPackageUtils.WriteExtraDebugInfoAsZipEntryAsync(debugInfoDict, archive, databaseName);
+            await DebugInfoPackageUtils.WriteDebugInfoTimesAsZipEntryAsync(debugInfoDict, archive, databaseName);
         }
 
         internal static async Task InvokeAndWriteToArchive(ZipArchive archive, JsonOperationContext jsonOperationContext, LocalEndpointClient localEndpointClient,

--- a/src/Raven.Server/ServerWide/DebugInfoPackageUtils.cs
+++ b/src/Raven.Server/ServerWide/DebugInfoPackageUtils.cs
@@ -76,19 +76,19 @@ namespace Raven.Server.ServerWide
             }
         }
 
-        public static async Task WriteExtraDebugInfoAsZipEntryAsync(Dictionary<string, TimeSpan> debugInfoTimeSpans, ZipArchive archive, string databaseName)
+        public static async Task WriteDebugInfoTimesAsZipEntryAsync(Dictionary<string, TimeSpan> debugInfoTimeSpans, ZipArchive archive, string databaseName)
         {
-            var entryName = databaseName == null ? "DebugInfo-ServerWide" : $"DebugInfo-ServerWide-{databaseName}";
+            var entryName = databaseName == null ? "server-wide-requestTimes" : $"{databaseName}-requestTimes";
             var entry = archive.CreateEntry($"{entryName}.txt");
             entry.ExternalAttributes = ((int)(FilePermissions.S_IRUSR | FilePermissions.S_IWUSR)) << 16;
 
-            var sorted = debugInfoTimeSpans.OrderBy(o => o.Value);
+            var sorted = debugInfoTimeSpans.OrderByDescending(o => o.Value);
             await using (var entryStream = entry.Open())
             await using (var sw = new StreamWriter(entryStream))
             {
                 foreach (var timeInfo in sorted)
                 {
-                    await sw.WriteLineAsync(timeInfo.Key + ", " + timeInfo.Value);
+                    await sw.WriteLineAsync(timeInfo.Value + ", " + timeInfo.Key);
                 }
                 await sw.FlushAsync();
             }

--- a/test/SlowTests/Authentication/AuthenticationDebugPackageInfoTests.cs
+++ b/test/SlowTests/Authentication/AuthenticationDebugPackageInfoTests.cs
@@ -275,7 +275,7 @@ namespace SlowTests.Authentication
             foreach (var e in debugEntries)
                 Assert.True(archiveEntries.Contains(e), $"{e} is missing from the debug package");
             foreach (var e in archiveEntries)
-                Assert.True(debugEntries.Contains(e), $"{e} should not be in the debug package");
+                Assert.True(debugEntries.Contains(e) || e.Contains("requestTimes"), $"{e} should not be in the debug package");
         }
 
         private string GetFileNameWithoutExtension(RouteInformation route, string prefixFolder)


### PR DESCRIPTION
### Issue link

https://issues.hibernatingrhinos.com/issue/RavenDB-17955

### Additional description

We failed to reproduce the bug; for now, we added more information for the debug info package (the execution time of each endpoint).


### Type of change

- Bug fix

### How risky is the change?

- Low 

### Backward compatibility

- Not relevant

### Is it platform specific issue?

- No

### Documentation update

- No documentation update is needed 

### Testing 

- It has been verified by manual testing

### Is there any existing behavior change of other features due to this change?

- No

### UI work

- No UI work is needed
