### PR TITLE
RavenDB-17223 fix CanIndexRollups test

### DIFF
--- a/test/SlowTests/Client/TimeSeries/Issues/RavenDB-16060.cs
+++ b/test/SlowTests/Client/TimeSeries/Issues/RavenDB-16060.cs
@@ -6,7 +6,6 @@ using FastTests;
 using Raven.Client.Documents;
 using Raven.Client.Documents.Operations.TimeSeries;
 using Raven.Client.Documents.Session;
-using SlowTests.Client.TimeSeries.Query;
 using SlowTests.Core.Utils.Entities;
 using Sparrow;
 using Xunit;
@@ -524,7 +523,7 @@ namespace SlowTests.Client.TimeSeries.Issues
                 await database.TimeSeriesPolicyRunner.RunRollups();
                 await database.TimeSeriesPolicyRunner.DoRetention();
 
-                await QueryFromMultipleTimeSeries.VerifyPolicyExecution(store, config.Collections["Users"], 12, rawName: "StockPrices");
+                await TimeSeries.VerifyPolicyExecution(store, config.Collections["Users"], 12, rawName: "StockPrices");
 
                 using (var session = store.OpenSession())
                 {
@@ -600,7 +599,7 @@ namespace SlowTests.Client.TimeSeries.Issues
                 await database.TimeSeriesPolicyRunner.RunRollups();
                 await database.TimeSeriesPolicyRunner.DoRetention();
 
-                await QueryFromMultipleTimeSeries.VerifyPolicyExecution(store, config.Collections["Users"], 12, rawName: "StockPrices");
+                await TimeSeries.VerifyPolicyExecution(store, config.Collections["Users"], 12, rawName: "StockPrices");
 
                 using (var session = store.OpenSession())
                 {

--- a/test/SlowTests/Client/TimeSeries/Issues/RavenDB-16060.cs
+++ b/test/SlowTests/Client/TimeSeries/Issues/RavenDB-16060.cs
@@ -524,7 +524,7 @@ namespace SlowTests.Client.TimeSeries.Issues
                 await database.TimeSeriesPolicyRunner.RunRollups();
                 await database.TimeSeriesPolicyRunner.DoRetention();
 
-                await QueryFromMultipleTimeSeries.VerifyFullPolicyExecution(store, config.Collections["Users"], rawName: "StockPrices");
+                await QueryFromMultipleTimeSeries.VerifyPolicyExecution(store, config.Collections["Users"], 12, rawName: "StockPrices");
 
                 using (var session = store.OpenSession())
                 {
@@ -600,7 +600,7 @@ namespace SlowTests.Client.TimeSeries.Issues
                 await database.TimeSeriesPolicyRunner.RunRollups();
                 await database.TimeSeriesPolicyRunner.DoRetention();
 
-                await QueryFromMultipleTimeSeries.VerifyFullPolicyExecution(store, config.Collections["Users"], rawName: "StockPrices");
+                await QueryFromMultipleTimeSeries.VerifyPolicyExecution(store, config.Collections["Users"], 12, rawName: "StockPrices");
 
                 using (var session = store.OpenSession())
                 {

--- a/test/SlowTests/Client/TimeSeries/Operations/TimeSeriesOperations.cs
+++ b/test/SlowTests/Client/TimeSeries/Operations/TimeSeriesOperations.cs
@@ -1087,7 +1087,7 @@ namespace SlowTests.Client.TimeSeries.Operations
                 await database.TimeSeriesPolicyRunner.RunRollups();
                 await database.TimeSeriesPolicyRunner.DoRetention();
 
-                await QueryFromMultipleTimeSeries.VerifyFullPolicyExecution(store, config.Collections["Users"]);
+                await QueryFromMultipleTimeSeries.VerifyPolicyExecution(store, config.Collections["Users"], 12);
             }
         }
     }

--- a/test/SlowTests/Client/TimeSeries/Operations/TimeSeriesOperations.cs
+++ b/test/SlowTests/Client/TimeSeries/Operations/TimeSeriesOperations.cs
@@ -3,11 +3,9 @@ using System.Collections.Generic;
 using System.Linq;
 using System.Threading.Tasks;
 using FastTests;
-using Raven.Client.Documents;
 using Raven.Client.Documents.Operations.TimeSeries;
 using Raven.Client.Documents.Queries;
 using Raven.Client.Documents.Session;
-using Raven.Client.Documents.Session.TimeSeries;
 using Raven.Client.Exceptions.Documents;
 using Raven.Tests.Core.Utils.Entities;
 using SlowTests.Client.TimeSeries.Query;
@@ -1087,7 +1085,7 @@ namespace SlowTests.Client.TimeSeries.Operations
                 await database.TimeSeriesPolicyRunner.RunRollups();
                 await database.TimeSeriesPolicyRunner.DoRetention();
 
-                await QueryFromMultipleTimeSeries.VerifyPolicyExecution(store, config.Collections["Users"], 12);
+                await TimeSeries.VerifyPolicyExecution(store, config.Collections["Users"], 12);
             }
         }
     }

--- a/test/SlowTests/Client/TimeSeries/Policies/TimeSeriesConfigurationTests.cs
+++ b/test/SlowTests/Client/TimeSeries/Policies/TimeSeriesConfigurationTests.cs
@@ -9,14 +9,12 @@ using Raven.Client.Documents.Commands;
 using Raven.Client.Documents.Conventions;
 using Raven.Client.Documents.Operations.TimeSeries;
 using Raven.Client.Documents.Operations.TransactionsRecording;
-using Raven.Client.Documents.Session;
 using Raven.Client.Documents.Session.TimeSeries;
 using Raven.Client.Exceptions;
 using Raven.Client.ServerWide.Operations;
 using Raven.Server.NotificationCenter.Notifications;
 using Raven.Tests.Core.Utils.Entities;
 using SlowTests.Client.TimeSeries.Query;
-using SlowTests.Client.TimeSeries.Replication;
 using Sparrow;
 using Xunit;
 using Xunit.Abstractions;
@@ -1323,7 +1321,7 @@ namespace SlowTests.Client.TimeSeries.Policies
                 await database.TimeSeriesPolicyRunner.RunRollups();
                 await database.TimeSeriesPolicyRunner.DoRetention();
 
-                await QueryFromMultipleTimeSeries.VerifyFullPolicyExecution(store, config.Collections["Users"]);
+                await QueryFromMultipleTimeSeries.VerifyPolicyExecution(store, config.Collections["Users"], 12);
             }
         }
 
@@ -1451,7 +1449,7 @@ namespace SlowTests.Client.TimeSeries.Policies
                         ModifyDatabaseName = _ => store.Database
                     }))
                     {
-                        await QueryFromMultipleTimeSeries.VerifyFullPolicyExecution(nodeStore, config.Collections["Users"]);
+                        await QueryFromMultipleTimeSeries.VerifyPolicyExecution(nodeStore, config.Collections["Users"], 12);
                     }
                 }
             }

--- a/test/SlowTests/Client/TimeSeries/Policies/TimeSeriesConfigurationTests.cs
+++ b/test/SlowTests/Client/TimeSeries/Policies/TimeSeriesConfigurationTests.cs
@@ -14,7 +14,6 @@ using Raven.Client.Exceptions;
 using Raven.Client.ServerWide.Operations;
 using Raven.Server.NotificationCenter.Notifications;
 using Raven.Tests.Core.Utils.Entities;
-using SlowTests.Client.TimeSeries.Query;
 using Sparrow;
 using Xunit;
 using Xunit.Abstractions;
@@ -1321,7 +1320,7 @@ namespace SlowTests.Client.TimeSeries.Policies
                 await database.TimeSeriesPolicyRunner.RunRollups();
                 await database.TimeSeriesPolicyRunner.DoRetention();
 
-                await QueryFromMultipleTimeSeries.VerifyPolicyExecution(store, config.Collections["Users"], 12);
+                await TimeSeries.VerifyPolicyExecution(store, config.Collections["Users"], 12);
             }
         }
 
@@ -1449,7 +1448,7 @@ namespace SlowTests.Client.TimeSeries.Policies
                         ModifyDatabaseName = _ => store.Database
                     }))
                     {
-                        await QueryFromMultipleTimeSeries.VerifyPolicyExecution(nodeStore, config.Collections["Users"], 12);
+                        await TimeSeries.VerifyPolicyExecution(nodeStore, config.Collections["Users"], 12);
                     }
                 }
             }

--- a/test/SlowTests/Client/TimeSeries/Query/QueryFromMultipleTimeSeries.cs
+++ b/test/SlowTests/Client/TimeSeries/Query/QueryFromMultipleTimeSeries.cs
@@ -92,7 +92,7 @@ namespace SlowTests.Client.TimeSeries.Query
                 await database.TimeSeriesPolicyRunner.RunRollups();
                 await database.TimeSeriesPolicyRunner.DoRetention();
 
-                await VerifyPolicyExecution(store, config.Collections["Users"], 12);
+                await TimeSeries.VerifyPolicyExecution(store, config.Collections["Users"], 12);
 
                 using (var session = store.OpenSession())
                 {
@@ -174,7 +174,7 @@ select out()
                 await database.TimeSeriesPolicyRunner.RunRollups();
                 await database.TimeSeriesPolicyRunner.DoRetention();
 
-                await VerifyPolicyExecution(store, config.Collections["Users"], 12);
+                await TimeSeries.VerifyPolicyExecution(store, config.Collections["Users"], 12);
 
                 using (var session = store.OpenSession())
                 {
@@ -253,7 +253,7 @@ select timeseries(
                 await database.TimeSeriesPolicyRunner.RunRollups();
                 await database.TimeSeriesPolicyRunner.DoRetention();
 
-                await VerifyPolicyExecution(store, config.Collections["Users"], 12);
+                await TimeSeries.VerifyPolicyExecution(store, config.Collections["Users"], 12);
 
                 using (var session = store.OpenSession())
                 {
@@ -410,7 +410,7 @@ select out(u)
                 await database.TimeSeriesPolicyRunner.RunRollups();
                 await database.TimeSeriesPolicyRunner.DoRetention();
 
-                await VerifyPolicyExecution(store, config.Collections["Users"], 12);
+                await TimeSeries.VerifyPolicyExecution(store, config.Collections["Users"], 12);
 
                 using (var session = store.OpenSession())
                 {
@@ -579,7 +579,7 @@ select out(u)
                 await database.TimeSeriesPolicyRunner.RunRollups();
                 await database.TimeSeriesPolicyRunner.DoRetention();
             
-                await VerifyPolicyExecution(store, config.Collections["Users"], 12);
+                await TimeSeries.VerifyPolicyExecution(store, config.Collections["Users"], 12);
 
                 using (var session = store.OpenSession())
                 {
@@ -792,7 +792,7 @@ select out()
 
                 await store.Maintenance.SendAsync(new ConfigureTimeSeriesOperation(config));
                 await WaitForPolicyRunner(database);
-                await VerifyPolicyExecution(store, config.Collections["Users"], 12);
+                await TimeSeries.VerifyPolicyExecution(store, config.Collections["Users"], 12);
 
                 var raw = GetSum(store, now);
                 Assert.Equal(noPolicy, raw);
@@ -801,7 +801,7 @@ select out()
                 await store.Maintenance.SendAsync(new ConfigureTimeSeriesOperation(config));
 
                 await WaitForPolicyRunner(database);
-                await VerifyPolicyExecution(store, config.Collections["Users"], 12);
+                await TimeSeries.VerifyPolicyExecution(store, config.Collections["Users"], 12);
 
                 var rawAndRoll = GetSum(store, now);
                 Assert.Equal(raw, rawAndRoll);
@@ -860,7 +860,7 @@ select out()
 
                 await store.Maintenance.SendAsync(new ConfigureTimeSeriesOperation(config));
                 await WaitForPolicyRunner(database);
-                await VerifyPolicyExecution(store, config.Collections["Users"], 12);
+                await TimeSeries.VerifyPolicyExecution(store, config.Collections["Users"], 12);
 
                 var raw = GetSum(store, now);
                 Assert.Equal(noPolicy, raw);
@@ -868,7 +868,7 @@ select out()
                 config.Collections["Users"].RawPolicy = new RawTimeSeriesPolicy(TimeValue.FromDays(5));
                 await store.Maintenance.SendAsync(new ConfigureTimeSeriesOperation(config));
                 await WaitForPolicyRunner(database);
-                await VerifyPolicyExecution(store, config.Collections["Users"], 12);
+                await TimeSeries.VerifyPolicyExecution(store, config.Collections["Users"], 12);
 
                 var rawAndRoll = GetSum(store, now);
                 Assert.Equal(raw, rawAndRoll);
@@ -1015,7 +1015,7 @@ select out()
                 await database.TimeSeriesPolicyRunner.RunRollups();
                 await database.TimeSeriesPolicyRunner.DoRetention();
 
-                await VerifyPolicyExecution(store, config.Collections["Users"], 12);
+                await TimeSeries.VerifyPolicyExecution(store, config.Collections["Users"], 12);
 
                 using (var session = store.OpenSession())
                 {
@@ -1103,7 +1103,7 @@ select out()
                 await database.TimeSeriesPolicyRunner.RunRollups();
                 await database.TimeSeriesPolicyRunner.DoRetention();
 
-                await VerifyPolicyExecution(store, config.Collections["Users"], 12);
+                await TimeSeries.VerifyPolicyExecution(store, config.Collections["Users"], 12);
 
                 using (var session = store.OpenSession())
                 {
@@ -1181,7 +1181,7 @@ select out()
                 await database.TimeSeriesPolicyRunner.RunRollups();
                 await database.TimeSeriesPolicyRunner.DoRetention();
 
-                await VerifyPolicyExecution(store, config.Collections["Users"], 12);
+                await TimeSeries.VerifyPolicyExecution(store, config.Collections["Users"], 12);
 
                 using (var session = store.OpenSession())
                 {
@@ -1258,7 +1258,7 @@ select out()
                 await database.TimeSeriesPolicyRunner.RunRollups();
                 await database.TimeSeriesPolicyRunner.DoRetention();
 
-                await VerifyPolicyExecution(store, config.Collections["Users"], 12);
+                await TimeSeries.VerifyPolicyExecution(store, config.Collections["Users"], 12);
 
                 using (var session = store.OpenSession())
                 {
@@ -1372,7 +1372,7 @@ select out()
                 await database.TimeSeriesPolicyRunner.RunRollups();
                 await database.TimeSeriesPolicyRunner.DoRetention();
 
-                await VerifyPolicyExecution(store, config.Collections["Users"], 12);
+                await TimeSeries.VerifyPolicyExecution(store, config.Collections["Users"], 12);
 
 
                 using (var session = store.OpenSession())
@@ -1460,7 +1460,7 @@ select out()
                 await database.TimeSeriesPolicyRunner.RunRollups();
                 await database.TimeSeriesPolicyRunner.DoRetention();
 
-                await VerifyPolicyExecution(store, config.Collections["Users"], 12);
+                await TimeSeries.VerifyPolicyExecution(store, config.Collections["Users"], 12);
 
                 using (var session = store.OpenSession())
                 {
@@ -1547,7 +1547,7 @@ select out()
 
                 await store.Maintenance.SendAsync(new ConfigureTimeSeriesOperation(config));
                 await WaitForPolicyRunner(database);
-                await VerifyPolicyExecution(store, config.Collections["Users"], 12);
+                await TimeSeries.VerifyPolicyExecution(store, config.Collections["Users"], 12);
                 var raw = GetSum(store, now);
                 Assert.Equal(noPolicy, raw);
 
@@ -1555,7 +1555,7 @@ select out()
                 await store.Maintenance.SendAsync(new ConfigureTimeSeriesOperation(config));
                 
                 await WaitForPolicyRunner(database);
-                await VerifyPolicyExecution(store, config.Collections["Users"],12);
+                await TimeSeries.VerifyPolicyExecution(store, config.Collections["Users"],12);
 
                 var rawAndRoll = GetSum(store, now);
                 Assert.Equal(raw, rawAndRoll);

--- a/test/SlowTests/Client/TimeSeries/Query/QueryFromMultipleTimeSeries.cs
+++ b/test/SlowTests/Client/TimeSeries/Query/QueryFromMultipleTimeSeries.cs
@@ -92,7 +92,7 @@ namespace SlowTests.Client.TimeSeries.Query
                 await database.TimeSeriesPolicyRunner.RunRollups();
                 await database.TimeSeriesPolicyRunner.DoRetention();
 
-                await VerifyFullPolicyExecution(store, config.Collections["Users"]);
+                await VerifyPolicyExecution(store, config.Collections["Users"], 12);
 
                 using (var session = store.OpenSession())
                 {
@@ -174,7 +174,7 @@ select out()
                 await database.TimeSeriesPolicyRunner.RunRollups();
                 await database.TimeSeriesPolicyRunner.DoRetention();
 
-                await VerifyFullPolicyExecution(store, config.Collections["Users"]);
+                await VerifyPolicyExecution(store, config.Collections["Users"], 12);
 
                 using (var session = store.OpenSession())
                 {
@@ -253,7 +253,7 @@ select timeseries(
                 await database.TimeSeriesPolicyRunner.RunRollups();
                 await database.TimeSeriesPolicyRunner.DoRetention();
 
-                await VerifyFullPolicyExecution(store, config.Collections["Users"]);
+                await VerifyPolicyExecution(store, config.Collections["Users"], 12);
 
                 using (var session = store.OpenSession())
                 {
@@ -410,7 +410,7 @@ select out(u)
                 await database.TimeSeriesPolicyRunner.RunRollups();
                 await database.TimeSeriesPolicyRunner.DoRetention();
 
-                await VerifyFullPolicyExecution(store, config.Collections["Users"]);
+                await VerifyPolicyExecution(store, config.Collections["Users"], 12);
 
                 using (var session = store.OpenSession())
                 {
@@ -579,7 +579,7 @@ select out(u)
                 await database.TimeSeriesPolicyRunner.RunRollups();
                 await database.TimeSeriesPolicyRunner.DoRetention();
             
-                await VerifyFullPolicyExecution(store, config.Collections["Users"]);
+                await VerifyPolicyExecution(store, config.Collections["Users"], 12);
 
                 using (var session = store.OpenSession())
                 {
@@ -792,7 +792,7 @@ select out()
 
                 await store.Maintenance.SendAsync(new ConfigureTimeSeriesOperation(config));
                 await WaitForPolicyRunner(database);
-                await VerifyFullPolicyExecution(store, config.Collections["Users"]);
+                await VerifyPolicyExecution(store, config.Collections["Users"], 12);
 
                 var raw = GetSum(store, now);
                 Assert.Equal(noPolicy, raw);
@@ -801,7 +801,7 @@ select out()
                 await store.Maintenance.SendAsync(new ConfigureTimeSeriesOperation(config));
 
                 await WaitForPolicyRunner(database);
-                await VerifyFullPolicyExecution(store, config.Collections["Users"]);
+                await VerifyPolicyExecution(store, config.Collections["Users"], 12);
 
                 var rawAndRoll = GetSum(store, now);
                 Assert.Equal(raw, rawAndRoll);
@@ -860,7 +860,7 @@ select out()
 
                 await store.Maintenance.SendAsync(new ConfigureTimeSeriesOperation(config));
                 await WaitForPolicyRunner(database);
-                await VerifyFullPolicyExecution(store, config.Collections["Users"]);
+                await VerifyPolicyExecution(store, config.Collections["Users"], 12);
 
                 var raw = GetSum(store, now);
                 Assert.Equal(noPolicy, raw);
@@ -868,7 +868,7 @@ select out()
                 config.Collections["Users"].RawPolicy = new RawTimeSeriesPolicy(TimeValue.FromDays(5));
                 await store.Maintenance.SendAsync(new ConfigureTimeSeriesOperation(config));
                 await WaitForPolicyRunner(database);
-                await VerifyFullPolicyExecution(store, config.Collections["Users"]);
+                await VerifyPolicyExecution(store, config.Collections["Users"], 12);
 
                 var rawAndRoll = GetSum(store, now);
                 Assert.Equal(raw, rawAndRoll);
@@ -1015,7 +1015,7 @@ select out()
                 await database.TimeSeriesPolicyRunner.RunRollups();
                 await database.TimeSeriesPolicyRunner.DoRetention();
 
-                await VerifyFullPolicyExecution(store, config.Collections["Users"]);
+                await VerifyPolicyExecution(store, config.Collections["Users"], 12);
 
                 using (var session = store.OpenSession())
                 {
@@ -1103,7 +1103,7 @@ select out()
                 await database.TimeSeriesPolicyRunner.RunRollups();
                 await database.TimeSeriesPolicyRunner.DoRetention();
 
-                await VerifyFullPolicyExecution(store, config.Collections["Users"]);
+                await VerifyPolicyExecution(store, config.Collections["Users"], 12);
 
                 using (var session = store.OpenSession())
                 {
@@ -1181,7 +1181,7 @@ select out()
                 await database.TimeSeriesPolicyRunner.RunRollups();
                 await database.TimeSeriesPolicyRunner.DoRetention();
 
-                await VerifyFullPolicyExecution(store, config.Collections["Users"]);
+                await VerifyPolicyExecution(store, config.Collections["Users"], 12);
 
                 using (var session = store.OpenSession())
                 {
@@ -1258,7 +1258,7 @@ select out()
                 await database.TimeSeriesPolicyRunner.RunRollups();
                 await database.TimeSeriesPolicyRunner.DoRetention();
 
-                await VerifyFullPolicyExecution(store, config.Collections["Users"]);
+                await VerifyPolicyExecution(store, config.Collections["Users"], 12);
 
                 using (var session = store.OpenSession())
                 {
@@ -1372,7 +1372,7 @@ select out()
                 await database.TimeSeriesPolicyRunner.RunRollups();
                 await database.TimeSeriesPolicyRunner.DoRetention();
 
-                await VerifyFullPolicyExecution(store, config.Collections["Users"]);
+                await VerifyPolicyExecution(store, config.Collections["Users"], 12);
 
 
                 using (var session = store.OpenSession())
@@ -1460,7 +1460,7 @@ select out()
                 await database.TimeSeriesPolicyRunner.RunRollups();
                 await database.TimeSeriesPolicyRunner.DoRetention();
 
-                await VerifyFullPolicyExecution(store, config.Collections["Users"]);
+                await VerifyPolicyExecution(store, config.Collections["Users"], 12);
 
                 using (var session = store.OpenSession())
                 {
@@ -1547,7 +1547,7 @@ select out()
 
                 await store.Maintenance.SendAsync(new ConfigureTimeSeriesOperation(config));
                 await WaitForPolicyRunner(database);
-                await VerifyFullPolicyExecution(store, config.Collections["Users"]);
+                await VerifyPolicyExecution(store, config.Collections["Users"], 12);
                 var raw = GetSum(store, now);
                 Assert.Equal(noPolicy, raw);
 
@@ -1555,7 +1555,7 @@ select out()
                 await store.Maintenance.SendAsync(new ConfigureTimeSeriesOperation(config));
                 
                 await WaitForPolicyRunner(database);
-                await VerifyFullPolicyExecution(store, config.Collections["Users"]);
+                await VerifyPolicyExecution(store, config.Collections["Users"],12);
 
                 var rawAndRoll = GetSum(store, now);
                 Assert.Equal(raw, rawAndRoll);
@@ -1672,48 +1672,6 @@ select out()
                 var raw = GetSum(store, now);
                 Assert.Equal(noPolicy, raw);
             }
-        }
-
-        internal static async Task VerifyFullPolicyExecution(DocumentStore store, TimeSeriesCollectionConfiguration configuration, string rawName = "Heartrate")
-        {
-            var raw = configuration.RawPolicy;
-            configuration.ValidateAndInitialize();
-
-            await WaitForValueAsync(() =>
-            {
-                using (var session = store.OpenSession())
-                {
-                    var ts = session.TimeSeriesFor("users/karmel", rawName)
-                        .Get()?
-                        .ToList();
-
-                    Assert.NotNull(ts);
-                    if (raw != null)
-                        Assert.Equal(((TimeSpan)raw.RetentionTime).TotalMinutes, ts.Count);
-
-                    foreach (var policy in configuration.Policies)
-                    {
-                        ts = session.TimeSeriesFor("users/karmel", policy.GetTimeSeriesName(rawName))
-                            .Get()?
-                            .ToList();
-
-                        TimeValue retentionTime = policy.RetentionTime;
-                        if (retentionTime == TimeValue.MaxValue)
-                        {
-                            var seconds = TimeSpan.FromDays(12).TotalSeconds;
-                            var x = Math.Ceiling(seconds / policy.AggregationTime.Value);
-                            var max = Math.Max(x * policy.AggregationTime.Value, seconds);
-                            retentionTime = TimeSpan.FromSeconds(max);
-                        }
-
-                        Assert.NotNull(ts);
-                        var expected = ((TimeSpan)retentionTime).TotalMinutes / ((TimeSpan)policy.AggregationTime).TotalMinutes;
-                        if ((int)expected != ts.Count && Math.Ceiling(expected) != ts.Count)
-                            Assert.False(true,$"Expected {expected}, but got {ts.Count}");
-                    }
-                }
-                return true;
-            }, true);
         }
     }
 }

--- a/test/SlowTests/Client/TimeSeries/Session/TimeSeriesTypedSessionTests.cs
+++ b/test/SlowTests/Client/TimeSeries/Session/TimeSeriesTypedSessionTests.cs
@@ -656,7 +656,7 @@ select out(doc)
                 await database.TimeSeriesPolicyRunner.RunRollups();
                 await database.TimeSeriesPolicyRunner.DoRetention();
 
-                await QueryFromMultipleTimeSeries.VerifyFullPolicyExecution(store, config.Collections["Users"], rawName: "StockPrices");
+                await QueryFromMultipleTimeSeries.VerifyPolicyExecution(store, config.Collections["Users"], 12, rawName: "StockPrices");
 
                 using (var session = store.OpenSession())
                 {
@@ -784,7 +784,7 @@ select out()
                 await database.TimeSeriesPolicyRunner.RunRollups();
                 await database.TimeSeriesPolicyRunner.DoRetention();
 
-                await QueryFromMultipleTimeSeries.VerifyFullPolicyExecution(store, config.Collections["Users"], rawName: "StockPrices");
+                await QueryFromMultipleTimeSeries.VerifyPolicyExecution(store, config.Collections["Users"], 12, rawName: "StockPrices");
 
                 using (var session = store.OpenSession())
                 {

--- a/test/SlowTests/Client/TimeSeries/Session/TimeSeriesTypedSessionTests.cs
+++ b/test/SlowTests/Client/TimeSeries/Session/TimeSeriesTypedSessionTests.cs
@@ -13,7 +13,6 @@ using Raven.Server.Documents.TimeSeries;
 using Raven.Server.ServerWide.Context;
 using Raven.Tests.Core.Utils.Entities;
 using SlowTests.Client.TimeSeries.Policies;
-using SlowTests.Client.TimeSeries.Query;
 using Sparrow;
 using Xunit;
 using Xunit.Abstractions;
@@ -656,7 +655,7 @@ select out(doc)
                 await database.TimeSeriesPolicyRunner.RunRollups();
                 await database.TimeSeriesPolicyRunner.DoRetention();
 
-                await QueryFromMultipleTimeSeries.VerifyPolicyExecution(store, config.Collections["Users"], 12, rawName: "StockPrices");
+                await TimeSeries.VerifyPolicyExecution(store, config.Collections["Users"], 12, rawName: "StockPrices");
 
                 using (var session = store.OpenSession())
                 {
@@ -784,7 +783,7 @@ select out()
                 await database.TimeSeriesPolicyRunner.RunRollups();
                 await database.TimeSeriesPolicyRunner.DoRetention();
 
-                await QueryFromMultipleTimeSeries.VerifyPolicyExecution(store, config.Collections["Users"], 12, rawName: "StockPrices");
+                await TimeSeries.VerifyPolicyExecution(store, config.Collections["Users"], 12, rawName: "StockPrices");
 
                 using (var session = store.OpenSession())
                 {

--- a/test/SlowTests/Issues/RavenDB_14932.cs
+++ b/test/SlowTests/Issues/RavenDB_14932.cs
@@ -46,8 +46,12 @@ namespace SlowTests.Issues
                     PolicyCheckFrequency = TimeSpan.FromSeconds(1)
                 };
                 await store.Maintenance.SendAsync(new ConfigureTimeSeriesOperation(config));
-
+                var database = await GetDocumentDatabaseInstanceFor(store);
                 var now = DateTime.UtcNow;
+                var nowSeconds = now.Second;
+                now = now.AddSeconds(-nowSeconds);
+                database.Time.UtcDateTime = () => DateTime.UtcNow.AddSeconds(-nowSeconds);
+
                 var baseline = now.AddDays(-12);
                 var total = ((TimeSpan)TimeValue.FromDays(12)).TotalMinutes;
 
@@ -64,9 +68,11 @@ namespace SlowTests.Issues
                     session.SaveChanges();
                 }
 
-                var database = await GetDocumentDatabaseInstanceFor(store);
-                await database.TimeSeriesPolicyRunner.RunRollups();
-                await database.TimeSeriesPolicyRunner.DoRetention();
+                await WaitForPolicyRunner(database);
+                await VerifyPolicyExecution(store, config.Collections["Users"], 4, policies: new List<TimeSeriesPolicy> { p1 });
+                await VerifyPolicyExecution(store, config.Collections["Users"], 5, policies: new List<TimeSeriesPolicy> { p2 });
+                await VerifyPolicyExecution(store, config.Collections["Users"], 2, policies: new List<TimeSeriesPolicy> { p3 });
+                await VerifyPolicyExecution(store, config.Collections["Users"], 3, policies: new List<TimeSeriesPolicy> { p4 });
 
                 WaitForIndexing(store);
                 RavenTestHelper.AssertNoIndexErrors(store);
@@ -74,6 +80,7 @@ namespace SlowTests.Issues
                 using (var session = store.OpenSession())
                 {
                     var user = session.Load<User>("users/karmel");
+
                     var count = session
                         .TimeSeriesFor(user, "Heartrate")
                         .Get(DateTime.MinValue, DateTime.MaxValue)
@@ -102,7 +109,7 @@ namespace SlowTests.Issues
                     var results = session.Query<TimeSeriesIndex.Result, TimeSeriesIndex>()
                         .ToList();
 
-                    Assert.Equal(count, results.Count);
+                    Assert.True(count == results.Count, $"Test time = {now}");
                 }
             }
         }

--- a/test/SlowTests/Issues/RavenDB_14932.cs
+++ b/test/SlowTests/Issues/RavenDB_14932.cs
@@ -69,10 +69,10 @@ namespace SlowTests.Issues
                 }
 
                 await WaitForPolicyRunner(database);
-                await VerifyPolicyExecution(store, config.Collections["Users"], 4, policies: new List<TimeSeriesPolicy> { p1 });
-                await VerifyPolicyExecution(store, config.Collections["Users"], 5, policies: new List<TimeSeriesPolicy> { p2 });
-                await VerifyPolicyExecution(store, config.Collections["Users"], 2, policies: new List<TimeSeriesPolicy> { p3 });
-                await VerifyPolicyExecution(store, config.Collections["Users"], 3, policies: new List<TimeSeriesPolicy> { p4 });
+                await TimeSeries.VerifyPolicyExecution(store, config.Collections["Users"], 4, policies: new List<TimeSeriesPolicy> { p1 });
+                await TimeSeries.VerifyPolicyExecution(store, config.Collections["Users"], 5, policies: new List<TimeSeriesPolicy> { p2 });
+                await TimeSeries.VerifyPolicyExecution(store, config.Collections["Users"], 2, policies: new List<TimeSeriesPolicy> { p3 });
+                await TimeSeries.VerifyPolicyExecution(store, config.Collections["Users"], 3, policies: new List<TimeSeriesPolicy> { p4 });
 
                 WaitForIndexing(store);
                 RavenTestHelper.AssertNoIndexErrors(store);

--- a/test/Tests.Infrastructure/RavenTestBase.cs
+++ b/test/Tests.Infrastructure/RavenTestBase.cs
@@ -56,6 +56,8 @@ namespace FastTests
     {
         public static BackupTestBase Backup => BackupTestBase.Instance.Value;
 
+        public static TimeSeriesTestBase TimeSeries => TimeSeriesTestBase.Instance.Value;
+
         protected readonly ConcurrentSet<DocumentStore> CreatedStores = new ConcurrentSet<DocumentStore>();
 
         protected RavenTestBase(ITestOutputHelper output) : base(output)
@@ -1682,48 +1684,6 @@ namespace FastTests
                 Output?.WriteLine(sb.ToString());
                 Console.WriteLine(sb.ToString());
             }
-        }
-
-        internal static async Task VerifyPolicyExecution(DocumentStore store, TimeSeriesCollectionConfiguration configuration, int retentionNumberOfDays, string rawName = "Heartrate", List<TimeSeriesPolicy> policies = null)
-        {
-            var raw = configuration.RawPolicy;
-            configuration.ValidateAndInitialize();
-
-            await WaitForValueAsync(() =>
-            {
-                using (var session = store.OpenSession())
-                {
-                    var ts = session.TimeSeriesFor("users/karmel", rawName)
-                        .Get()?
-                        .ToList();
-
-                    Assert.NotNull(ts);
-                    if (raw != null)
-                        Assert.Equal(((TimeSpan)raw.RetentionTime).TotalMinutes, ts.Count);
-                    var policiesList = policies ?? configuration.Policies;
-                    foreach (var policy in policiesList)
-                    {
-                        ts = session.TimeSeriesFor("users/karmel", policy.GetTimeSeriesName(rawName))
-                            .Get()?
-                            .ToList();
-
-                        TimeValue retentionTime = policy.RetentionTime;
-                        if (retentionTime == TimeValue.MaxValue)
-                        {
-                            var seconds = TimeSpan.FromDays(retentionNumberOfDays).TotalSeconds;
-                            var x = Math.Ceiling(seconds / policy.AggregationTime.Value);
-                            var max = Math.Max(x * policy.AggregationTime.Value, seconds);
-                            retentionTime = TimeSpan.FromSeconds(max);
-                        }
-
-                        Assert.NotNull(ts);
-                        var expected = ((TimeSpan)retentionTime).TotalMinutes / ((TimeSpan)policy.AggregationTime).TotalMinutes;
-                        if ((int)expected != ts.Count && Math.Ceiling(expected) != ts.Count)
-                            Assert.False(true, $"Expected {expected}, but got {ts.Count}");
-                    }
-                }
-                return true;
-            }, true);
         }
     }
 }

--- a/test/Tests.Infrastructure/RavenTestBase.cs
+++ b/test/Tests.Infrastructure/RavenTestBase.cs
@@ -21,6 +21,7 @@ using Raven.Client.Documents.Indexes;
 using Raven.Client.Documents.Operations;
 using Raven.Client.Documents.Operations.Counters;
 using Raven.Client.Documents.Operations.Indexes;
+using Raven.Client.Documents.Operations.TimeSeries;
 using Raven.Client.Documents.Session;
 using Raven.Client.Documents.Smuggler;
 using Raven.Client.Exceptions;
@@ -37,6 +38,7 @@ using Raven.Server.Documents;
 using Raven.Server.Rachis;
 using Raven.Server.ServerWide.Context;
 using Raven.Server.Utils;
+using Sparrow;
 using Sparrow.Collections;
 using Sparrow.Json;
 using Sparrow.Json.Parsing;
@@ -1680,6 +1682,48 @@ namespace FastTests
                 Output?.WriteLine(sb.ToString());
                 Console.WriteLine(sb.ToString());
             }
+        }
+
+        internal static async Task VerifyPolicyExecution(DocumentStore store, TimeSeriesCollectionConfiguration configuration, int retentionNumberOfDays, string rawName = "Heartrate", List<TimeSeriesPolicy> policies = null)
+        {
+            var raw = configuration.RawPolicy;
+            configuration.ValidateAndInitialize();
+
+            await WaitForValueAsync(() =>
+            {
+                using (var session = store.OpenSession())
+                {
+                    var ts = session.TimeSeriesFor("users/karmel", rawName)
+                        .Get()?
+                        .ToList();
+
+                    Assert.NotNull(ts);
+                    if (raw != null)
+                        Assert.Equal(((TimeSpan)raw.RetentionTime).TotalMinutes, ts.Count);
+                    var policiesList = policies ?? configuration.Policies;
+                    foreach (var policy in policiesList)
+                    {
+                        ts = session.TimeSeriesFor("users/karmel", policy.GetTimeSeriesName(rawName))
+                            .Get()?
+                            .ToList();
+
+                        TimeValue retentionTime = policy.RetentionTime;
+                        if (retentionTime == TimeValue.MaxValue)
+                        {
+                            var seconds = TimeSpan.FromDays(retentionNumberOfDays).TotalSeconds;
+                            var x = Math.Ceiling(seconds / policy.AggregationTime.Value);
+                            var max = Math.Max(x * policy.AggregationTime.Value, seconds);
+                            retentionTime = TimeSpan.FromSeconds(max);
+                        }
+
+                        Assert.NotNull(ts);
+                        var expected = ((TimeSpan)retentionTime).TotalMinutes / ((TimeSpan)policy.AggregationTime).TotalMinutes;
+                        if ((int)expected != ts.Count && Math.Ceiling(expected) != ts.Count)
+                            Assert.False(true, $"Expected {expected}, but got {ts.Count}");
+                    }
+                }
+                return true;
+            }, true);
         }
     }
 }

--- a/test/Tests.Infrastructure/TimeSeriesTestBase.cs
+++ b/test/Tests.Infrastructure/TimeSeriesTestBase.cs
@@ -1,0 +1,62 @@
+﻿using System;
+using System.Collections.Generic;
+using System.Linq;
+using System.Text;
+using System.Threading.Tasks;
+using Raven.Client.Documents;
+using Raven.Client.Documents.Operations.TimeSeries;
+using Sparrow;
+using Xunit;
+
+namespace FastTests
+{
+    public abstract partial class RavenTestBase
+    {
+        public class TimeSeriesTestBase
+        {
+            internal static readonly Lazy<TimeSeriesTestBase> Instance = new Lazy<TimeSeriesTestBase>(() => new TimeSeriesTestBase());
+
+            internal async Task VerifyPolicyExecution(DocumentStore store, TimeSeriesCollectionConfiguration configuration, int retentionNumberOfDays, string rawName = "Heartrate", List<TimeSeriesPolicy> policies = null)
+            {
+                var raw = configuration.RawPolicy;
+                configuration.ValidateAndInitialize();
+
+                await WaitForValueAsync(() =>
+                {
+                    using (var session = store.OpenSession())
+                    {
+                        var ts = session.TimeSeriesFor("users/karmel", rawName)
+                            .Get()?
+                            .ToList();
+
+                        Assert.NotNull(ts);
+                        if (raw != null)
+                            Assert.Equal(((TimeSpan)raw.RetentionTime).TotalMinutes, ts.Count);
+                        var policiesList = policies ?? configuration.Policies;
+                        foreach (var policy in policiesList)
+                        {
+                            ts = session.TimeSeriesFor("users/karmel", policy.GetTimeSeriesName(rawName))
+                                .Get()?
+                                .ToList();
+
+                            TimeValue retentionTime = policy.RetentionTime;
+                            if (retentionTime == TimeValue.MaxValue)
+                            {
+                                var seconds = TimeSpan.FromDays(retentionNumberOfDays).TotalSeconds;
+                                var x = Math.Ceiling(seconds / policy.AggregationTime.Value);
+                                var max = Math.Max(x * policy.AggregationTime.Value, seconds);
+                                retentionTime = TimeSpan.FromSeconds(max);
+                            }
+
+                            Assert.NotNull(ts);
+                            var expected = ((TimeSpan)retentionTime).TotalMinutes / ((TimeSpan)policy.AggregationTime).TotalMinutes;
+                            if ((int)expected != ts.Count && Math.Ceiling(expected) != ts.Count)
+                                Assert.False(true, $"Expected {expected}, but got {ts.Count}");
+                        }
+                    }
+                    return true;
+                }, true);
+            }
+        }
+    }
+}


### PR DESCRIPTION
### Issue link

https://issues.hibernatingrhinos.com/issue/RavenDB-17223

### Additional description

add wait for rollup and retention in test .
Move VerifyPolicyExecution to TestBase

_Please delete below the options that are not relevant_

### Type of change

-Test fix

### How risky is the change?

- Not relevant

### Backward compatibility
- Not relevant
### Is it platform specific issue?

- No

### Documentation update

- No documentation update is needed 

### Testing 

- Not relevant

### Is there any existing behavior change of other features due to this change?

- No

### UI work

- No UI work is needed
