### PR TITLE
RavenDB-16801 - StressTests.Client.TimeSeries.TimeSeriesStress.RapidR…

### DIFF
--- a/test/StressTests/Client/TimeSeries/TimeSeriesStress.cs
+++ b/test/StressTests/Client/TimeSeries/TimeSeriesStress.cs
@@ -18,6 +18,7 @@ using Raven.Tests.Core.Utils.Entities;
 using SlowTests.Client.TimeSeries.Patch;
 using SlowTests.Client.TimeSeries.Replication;
 using Sparrow;
+using Tests.Infrastructure;
 using Xunit;
 using Xunit.Abstractions;
 
@@ -29,7 +30,7 @@ namespace StressTests.Client.TimeSeries
         {
         }
 
-        [Fact]
+        [Fact64Bit]
         public async Task RapidRetention()
         {
             var cluster = await CreateRaftCluster(3);


### PR DESCRIPTION
…etention

### Issue link

https://issues.hibernatingrhinos.com/issue/RavenDB-16801

### Additional description

Changed test to run only for 64bit to avoid OOM exception.


### Type of change

- Bug fix

### How risky is the change?

- Low 

### Backward compatibility

- Non breaking change

### Is it platform specific issue?

- No

### Documentation update

- No documentation update is needed 

### Testing 

- It has been verified by manual testing

### Is there any existing behavior change of other features due to this change?

- No

### UI work

- No UI work is needed
