### PR TITLE
RavenDB-17260 Deletion of in-memory replacement index must take into account that we there might be temp files of previous replacement in the same temp directory because we cannot restart in-memory environment and move its directory.

### DIFF
--- a/src/Raven.Server/Documents/Indexes/Index.cs
+++ b/src/Raven.Server/Documents/Indexes/Index.cs
@@ -3930,6 +3930,9 @@ namespace Raven.Server.Documents.Indexes
             if (_currentlyRunningQueriesLock.IsWriteLockHeld == false)
                 throw new InvalidOperationException("Expected to be called only via DrainRunningQueries");
 
+            if (Configuration.RunInMemory)
+                throw new InvalidOperationException("Cannot restart the environment of an index running in-memory");
+
             // here we ensure that we aren't currently running any indexing,
             // because we'll shut down the environment for this index, reads
             // are handled using the DrainRunningQueries portion

--- a/test/SlowTests/Issues/RavenDB_17260.cs
+++ b/test/SlowTests/Issues/RavenDB_17260.cs
@@ -1,0 +1,88 @@
+﻿using System;
+using System.IO;
+using System.Linq;
+using System.Threading.Tasks;
+using FastTests;
+using Orders;
+using Raven.Client;
+using Raven.Client.Documents.Indexes;
+using Raven.Client.Documents.Operations.Indexes;
+using Voron;
+using Xunit;
+using Xunit.Abstractions;
+
+namespace SlowTests.Issues;
+
+public class RavenDB_17260 : RavenTestBase
+{
+    public RavenDB_17260(ITestOutputHelper output) : base(output)
+    {
+    }
+
+    [Fact]
+    public async Task DeleteIndexInternalWillNotThrowAccessDeniedWhenDeletingInMemoryReplacementIndex()
+    {
+        using (var store = GetDocumentStore(new Options()
+        {
+            RunInMemory = true
+        }))
+        {
+            var indexToCreate = new Orders_ProfitByProductAndOrderedAt(referencesCollectionName: "Foo");
+            await indexToCreate.ExecuteAsync(store);
+
+            WaitForIndexing(store);
+
+            indexToCreate = new Orders_ProfitByProductAndOrderedAt(referencesCollectionName: "Bar");
+            await indexToCreate.ExecuteAsync(store);
+
+            WaitForIndexing(store);
+
+            store.Maintenance.Send(new StopIndexingOperation());
+
+            indexToCreate = new Orders_ProfitByProductAndOrderedAt(referencesCollectionName: "Baz");
+            await indexToCreate.ExecuteAsync(store);
+
+            var database = await GetDatabase(store.Database);
+
+            var index = database.IndexStore.GetIndex(Constants.Documents.Indexing.SideBySideIndexNamePrefix + indexToCreate.IndexName);
+            var options = index._environment.Options as StorageEnvironmentOptions.PureMemoryStorageEnvironmentOptions;
+
+
+            var replacementIndex = database.IndexStore.GetIndex(Constants.Documents.Indexing.SideBySideIndexNamePrefix + indexToCreate.IndexName);
+            var replacementIndexOptions = replacementIndex._environment.Options as StorageEnvironmentOptions.PureMemoryStorageEnvironmentOptions;
+
+            Assert.Equal(options.TempPath, replacementIndexOptions.TempPath);
+
+            database.IndexStore.DeleteIndexInternal(replacementIndex, false);
+        }
+    }
+
+    private class Orders_ProfitByProductAndOrderedAt : AbstractIndexCreationTask<Order, Orders_ProfitByProductAndOrderedAt.Result>
+    {
+        public class Result
+        {
+            public DateTime OrderedAt { get; set; }
+            public string Product { get; set; }
+            public decimal Profit { get; set; }
+        }
+
+        public Orders_ProfitByProductAndOrderedAt(string referencesCollectionName = null)
+        {
+            Map = orders => from order in orders
+                from line in order.Lines
+                select new { line.Product, order.OrderedAt, Profit = line.Quantity * line.PricePerUnit * (1 - line.Discount) };
+
+            Reduce = results => from r in results
+                group r by new { r.OrderedAt, r.Product }
+                into g
+                select new { g.Key.Product, g.Key.OrderedAt, Profit = g.Sum(r => r.Profit) };
+
+            OutputReduceToCollection = "Profits";
+
+            PatternForOutputReduceToCollectionReferences = x => $"reports/daily/{x.OrderedAt:yyyy-MM-dd}";
+
+            if (referencesCollectionName != null)
+                PatternReferencesCollectionName = referencesCollectionName;
+        }
+    }
+}


### PR DESCRIPTION
### Issue link

https://issues.hibernatingrhinos.com/issue/RavenDB-17260

### Additional description

The problem was that we were getting the following exceptions occasionally:

`System.IO.IOException : Failed to get Write access a file at ...\\Indexes\ReplacementOf_Orders_ProfitByProductAndOrderedAt\Temp\ravendb-15880-408-0000000000000000000.journal-787c72e3-132d-42b4-ae3d-d74957c14517`

The investigation revealed that the problem affected replacement indexes running in-memory. 

When handling the replacement of an in-memory index we cannot move its directory to original index dir (because on environment dispose all temp files are deleted):

https://github.com/ravendb/ravendb/blob/6be018ba6543d58bb9a8329f205073f78fdcdc77/src/Raven.Server/Documents/Indexes/IndexStore.cs#L1801

Hence when index is updated two times then 1st and 2nd replacements are put in the same dir so we cannot delete entire directory.

### Type of change

- Bug fix affecting in-memory indexes only

### How risky is the change?

- Low 

### Backward compatibility

- Not relevant

### Is it platform specific issue?

- No

### Documentation update

- No documentation update is needed 

### Testing 

- Tests have been added that prove the fix is effective or that the feature works
- It has been verified by manual testing

### Is there any existing behavior change of other features due to this change?

- No

### UI work

- No UI work is needed
