### PR TITLE
RavenDB-18079 fix skipping beyond number of entries for embedded iterator

### DIFF
--- a/src/Voron/Data/Fixed/FixedSizeIterators.cs
+++ b/src/Voron/Data/Fixed/FixedSizeIterators.cs
@@ -164,6 +164,9 @@ namespace Voron.Data.Fixed
                 if (count != 0)
                     _pos += count;
 
+                if (_pos < 0)
+                    return false;
+
                 return _pos < _header->NumberOfEntries;
             }
 

--- a/test/SlowTests/Core/Commands/Documents.cs
+++ b/test/SlowTests/Core/Commands/Documents.cs
@@ -116,6 +116,38 @@ namespace SlowTests.Core.Commands
         }
 
         [Fact]
+        public async Task CanSkipBeyondCountForEmbeddedIterator()
+        {
+            using (var store = GetDocumentStore())
+            {
+                using (var commands = store.Commands())
+                {
+                    var putResult = await commands.PutAsync(
+                        "companies/1",
+                        null,
+                        new Company
+                        {
+                            Name = "testname",
+                            Phone = 1,
+                            Contacts = new List<Contact> { new Contact { }, new Contact { } },
+                            Address1 = "To be removed.",
+                            Address2 = "Address2"
+                        },
+                        new Dictionary<string, object>
+                        {
+                            {"SomeMetadataKey", "SomeMetadataValue"}
+                        });
+
+                    await commands.PutAsync("users/2", null, new User { Name = "testname2" }, null);
+                    
+                    var documents = await commands.GetAsync(10, 25);
+                    Assert.Equal(0, documents.Count());
+
+                }
+            }
+        }
+
+        [Fact]
         public async Task CanDeleteAndUpdateDocumentByIndex()
         {
             using (var store = GetDocumentStore())

--- a/test/SlowTests/Server/Documents/Patching/AdvancedPatching.cs
+++ b/test/SlowTests/Server/Documents/Patching/AdvancedPatching.cs
@@ -685,6 +685,32 @@ this.Value = another.Value;
         }
 
         [Fact]
+        public async Task CanSkipBeyondCountForLargeIterator()
+        {
+            using (var store = GetDocumentStore())
+            {
+                using (var session = store.OpenAsyncSession())
+                {
+                    await session.StoreAsync(new CustomType { Id = "Items/1", Value = 10, Comments = new List<string>(Enumerable.Range(0, 100).Select(i=>i.ToString()) )});
+                    await session.SaveChangesAsync();
+                }
+
+                await store.Operations.SendAsync(new PatchOperation("Items/1", null, new PatchRequest
+                {
+                    Script = @"this.Comments.map(function(comment){
+                                     put('Comments/' + comment, { 'Comment':comment });
+                                 })",
+                }));
+
+                using (var commands = store.Commands())
+                {
+                    var docs = await commands.GetAsync(101, 10);
+                    Assert.Equal(0, docs.Count());
+                }
+            }
+        }
+
+        [Fact]
         public async Task CreateDocumentWillNotThrowIfEmptyKeyProvided()
         {
             using (var store = GetDocumentStore())


### PR DESCRIPTION
### Issue link

https://issues.hibernatingrhinos.com/issue/RavenDB-18079

### Additional description

If we pass `start` parameter which is beyond the number of entries we would end up in AVE, because we do that by passing a negative value to the `Skip` of tree.

### Type of change

- Bug fix

### How risky is the change?

- Low 

### Backward compatibility

- Not relevant

### Is it platform specific issue?

- No

### Documentation update

- No documentation update is needed 

### Testing 

- Tests have been added that prove the fix is effective or that the feature works

### Is there any existing behavior change of other features due to this change?

- No

### UI work

- No UI work is needed
