### PR TITLE
RavenDB-17116: Don't remove subscription connections state from _subscriptions list on disconnect

### DIFF
--- a/src/Raven.Server/Documents/Subscriptions/SubscriptionConnectionsState.cs
+++ b/src/Raven.Server/Documents/Subscriptions/SubscriptionConnectionsState.cs
@@ -25,19 +25,17 @@ namespace Raven.Server.Documents.Subscriptions
 {
     public class SubscriptionConnectionsState : IDisposable
     {
-        private readonly string _subscriptionName;
         private readonly long _subscriptionId;
         private readonly SubscriptionStorage _subscriptionStorage;
-        private readonly DocumentsStorage _documentsStorage;
-        private readonly SubscriptionState _subscriptionState;
+        private readonly AsyncManualResetEvent _waitForMoreDocuments;
+        private DocumentsStorage _documentsStorage;
+        private SubscriptionState _subscriptionState;
         private ConcurrentSet<SubscriptionConnection> _connections;
-        public Task GetSubscriptionInUseAwaiter => Task.WhenAll(_connections.Select(c => c.SubscriptionConnectionTask));
-
+        private string _subscriptionName;
         private int _maxConcurrentConnections;
 
-        private AsyncManualResetEvent _waitForMoreDocuments;
-
-        public readonly string Query;
+        public string Query;
+        public Task GetSubscriptionInUseAwaiter => Task.WhenAll(_connections.Select(c => c.SubscriptionConnectionTask));
         public string SubscriptionName => _subscriptionName;
         public long SubscriptionId => _subscriptionId;
         public SubscriptionState SubscriptionState => _subscriptionState;
@@ -60,48 +58,36 @@ namespace Raven.Server.Documents.Subscriptions
         public string LastChangeVectorSent;
 
         public string PreviouslyRecordedChangeVector;
-        private readonly IDisposable _disposableNotificationsRegistration;
+        private IDisposable _disposableNotificationsRegistration;
 
-        // dummy state
-        private SubscriptionConnectionsState(DocumentsStorage storage, SubscriptionState state)
+        public SubscriptionConnectionsState(long subscriptionId, SubscriptionStorage storage)
         {
-            //the first connection to join creates this object and decides all details of the subscription
-            _subscriptionName = "dummy";
-            _subscriptionId = -0x42;
-            _documentsStorage = storage;
-            Query = state.Query;
-            
-            _subscriptionStorage = storage.DocumentDatabase.SubscriptionStorage;
-
-            CancellationTokenSource = CancellationTokenSource.CreateLinkedTokenSource(_documentsStorage.DocumentDatabase.DatabaseShutdown);
-            _waitForMoreDocuments = new AsyncManualResetEvent(CancellationTokenSource.Token);
-
+            _subscriptionId = subscriptionId;
+            _connections = new ConcurrentSet<SubscriptionConnection>();
+            _subscriptionStorage = storage;
+            _documentsStorage = storage._db.DocumentsStorage;
             _subscriptionActivelyWorkingLock = new SemaphoreSlim(1);
-            LastChangeVectorSent = state.ChangeVectorForNextBatchStartingPoint;
-            PreviouslyRecordedChangeVector = LastChangeVectorSent;
+            CancellationTokenSource = CancellationTokenSource.CreateLinkedTokenSource(storage._db.DatabaseShutdown);
+            _waitForMoreDocuments = new AsyncManualResetEvent(CancellationTokenSource.Token);
         }
 
-        public static SubscriptionConnectionsState CreateDummyState(DocumentsStorage storage, SubscriptionState state) => new (storage, state);
-
-        public SubscriptionConnectionsState(string subscriptionName, long subscriptionId, SubscriptionStorage storage, SubscriptionConnection connection)
+        public void Initialize(SubscriptionConnection connection, bool afterSubscribe = false)
         {
-            //the first connection to join creates this object and decides all details of the subscription
-            _subscriptionName = subscriptionName ?? subscriptionId.ToString();
-            _subscriptionId = subscriptionId;
+            _subscriptionName = connection.Options.SubscriptionName ?? _subscriptionId.ToString();
             _subscriptionState = connection.SubscriptionState;
-            _documentsStorage = connection.TcpConnection.DocumentDatabase.DocumentsStorage;
             Query = connection.SubscriptionState.Query;
-            _connections = new ConcurrentSet<SubscriptionConnection>();
-            
-            _subscriptionStorage = storage;
 
-            CancellationTokenSource = CancellationTokenSource.CreateLinkedTokenSource(_documentsStorage.DocumentDatabase.DatabaseShutdown);
-            _waitForMoreDocuments = new AsyncManualResetEvent(CancellationTokenSource.Token);
-            _disposableNotificationsRegistration = RegisterForNotificationOnNewDocuments(connection);
+            // update the subscription data only on new concurrent connection or regular connection
+            if (afterSubscribe && _connections.Count == 1)
+            {
+                using (var old = _disposableNotificationsRegistration)
+                {
+                    _disposableNotificationsRegistration = RegisterForNotificationOnNewDocuments(connection);
+                }
 
-            _subscriptionActivelyWorkingLock = new SemaphoreSlim(1);
-            LastChangeVectorSent = connection.SubscriptionState.ChangeVectorForNextBatchStartingPoint;
-            PreviouslyRecordedChangeVector = LastChangeVectorSent;
+                LastChangeVectorSent = connection.SubscriptionState.ChangeVectorForNextBatchStartingPoint;
+                PreviouslyRecordedChangeVector = LastChangeVectorSent;
+            }
         }
 
         public IEnumerable<DocumentRecord> GetDocumentsFromResend(ClusterOperationContext context, HashSet<long> activeBatches)
@@ -627,5 +613,26 @@ namespace Raven.Server.Documents.Subscriptions
             *(prefix.Ptr + position) = SpecialChars.RecordSeparator;
             position++;
         }
+
+        // dummy state
+        private SubscriptionConnectionsState(DocumentsStorage storage, SubscriptionState state)
+        {
+            //the first connection to join creates this object and decides all details of the subscription
+            _subscriptionName = "dummy";
+            _subscriptionId = -0x42;
+            _documentsStorage = storage;
+            Query = state.Query;
+
+            _subscriptionStorage = storage.DocumentDatabase.SubscriptionStorage;
+
+            CancellationTokenSource = CancellationTokenSource.CreateLinkedTokenSource(_documentsStorage.DocumentDatabase.DatabaseShutdown);
+            _waitForMoreDocuments = new AsyncManualResetEvent(CancellationTokenSource.Token);
+
+            _subscriptionActivelyWorkingLock = new SemaphoreSlim(1);
+            LastChangeVectorSent = state.ChangeVectorForNextBatchStartingPoint;
+            PreviouslyRecordedChangeVector = LastChangeVectorSent;
+        }
+
+        public static SubscriptionConnectionsState CreateDummyState(DocumentsStorage storage, SubscriptionState state) => new(storage, state);
     }
 }

--- a/src/Raven.Server/Documents/Subscriptions/SubscriptionConnectionsState.cs
+++ b/src/Raven.Server/Documents/Subscriptions/SubscriptionConnectionsState.cs
@@ -455,15 +455,6 @@ namespace Raven.Server.Documents.Subscriptions
                 });
         }
 
-        public void DropCancelledConnections()
-        {
-            foreach (var connection in _connections)
-            {
-                if(connection.CancellationTokenSource.IsCancellationRequested)
-                    DropSingleConnection(connection);
-            }
-        }
-
         public SubscriptionConnection MostRecentEndedConnection()
         {
             if (_recentConnections.TryPeek(out var recentConnection))

--- a/src/Raven.Server/Documents/Subscriptions/SubscriptionStorage.cs
+++ b/src/Raven.Server/Documents/Subscriptions/SubscriptionStorage.cs
@@ -33,7 +33,7 @@ namespace Raven.Server.Documents.Subscriptions
 {
     public class SubscriptionStorage : IDisposable, ILowMemoryHandler
     {
-        private readonly DocumentDatabase _db;
+        internal readonly DocumentDatabase _db;
         private readonly ServerStore _serverStore;
         
         private readonly ConcurrentDictionary<long, SubscriptionConnectionsState> _subscriptions = new ();
@@ -101,8 +101,8 @@ namespace Raven.Server.Documents.Subscriptions
 
         public SubscriptionConnectionsState OpenSubscription(SubscriptionConnection connection)
         {
-            var subscriptionState = _subscriptions.GetOrAdd(connection.SubscriptionId,
-                subscriptionId => new SubscriptionConnectionsState(connection.Options.SubscriptionName, subscriptionId ,this, connection));
+            var subscriptionState = _subscriptions.GetOrAdd(connection.SubscriptionId, subId => new SubscriptionConnectionsState(subId, this));
+            subscriptionState.Initialize(connection);
             return subscriptionState;
         }
 

--- a/src/Raven.Server/Documents/Subscriptions/SubscriptionStorage.cs
+++ b/src/Raven.Server/Documents/Subscriptions/SubscriptionStorage.cs
@@ -314,7 +314,7 @@ namespace Raven.Server.Documents.Subscriptions
 
         public bool DropSubscriptionConnections(long subscriptionId, SubscriptionException ex)
         {
-            if (_subscriptions.TryRemove(subscriptionId, out SubscriptionConnectionsState subscriptionConnectionsState) == false)
+            if (_subscriptions.TryGetValue(subscriptionId, out SubscriptionConnectionsState subscriptionConnectionsState) == false)
                 return false;
 
             foreach (var subscriptionConnection in subscriptionConnectionsState.GetConnections())
@@ -689,7 +689,10 @@ namespace Raven.Server.Documents.Subscriptions
 
                 if (recentConnection != null && recentConnection.Stats.LastMessageSentAt < oldestPossibleIdleSubscription)
                 {
-                    _subscriptions.Remove(kvp.Key, out _);
+                    if (_subscriptions.TryRemove(kvp.Key, out var subsState))
+                    {
+                        subsState.Dispose();
+                    }
                 }
             }
         }
@@ -701,7 +704,10 @@ namespace Raven.Server.Documents.Subscriptions
                 if (state.Value.IsSubscriptionActive())
                     continue;
 
-                _subscriptions.Remove(state.Key, out _);
+                if (_subscriptions.TryRemove(state.Key, out var subsState))
+                {
+                    subsState.Dispose();
+                }
             }
         }
 

--- a/src/Raven.Server/Documents/TcpHandlers/SubscriptionConnection.cs
+++ b/src/Raven.Server/Documents/TcpHandlers/SubscriptionConnection.cs
@@ -227,6 +227,9 @@ namespace Raven.Server.Documents.TcpHandlers
 
             Subscription = ParseSubscriptionQuery(SubscriptionState.Query);
 
+            // update the state if above data changed
+            _subscriptionConnectionsState.Initialize(this, afterSubscribe: true);
+
             await TcpConnection.DocumentDatabase.SubscriptionStorage.UpdateClientConnectionTime(SubscriptionState.SubscriptionId,
                 SubscriptionState.SubscriptionName, SubscriptionState.MentorNode);
 

--- a/src/Raven.Server/Documents/TcpHandlers/SubscriptionConnection.cs
+++ b/src/Raven.Server/Documents/TcpHandlers/SubscriptionConnection.cs
@@ -144,7 +144,6 @@ namespace Raven.Server.Documents.TcpHandlers
                 RecentSubscriptionStatuses.TryDequeue(out _);
             }
 
-          //  Console.WriteLine($"{_options.SubscriptionName}: " + message);
             RecentSubscriptionStatuses.Enqueue(message);
         }
 

--- a/src/Raven.Server/Documents/TcpHandlers/SubscriptionConnection.cs
+++ b/src/Raven.Server/Documents/TcpHandlers/SubscriptionConnection.cs
@@ -143,6 +143,8 @@ namespace Raven.Server.Documents.TcpHandlers
             {
                 RecentSubscriptionStatuses.TryDequeue(out _);
             }
+
+          //  Console.WriteLine($"{_options.SubscriptionName}: " + message);
             RecentSubscriptionStatuses.Enqueue(message);
         }
 
@@ -395,7 +397,6 @@ namespace Raven.Server.Documents.TcpHandlers
                         _logger.Info(
                             $"Finished processing subscription {SubscriptionId} / from client {TcpConnection.TcpClient.Client.RemoteEndPoint}");
                     }
-
                     disposeOnDisconnect?.Dispose();
                 }
             }

--- a/src/Raven.Server/Documents/TcpHandlers/TcpConnectionOptions.cs
+++ b/src/Raven.Server/Documents/TcpHandlers/TcpConnectionOptions.cs
@@ -184,11 +184,21 @@ namespace Raven.Server.Documents.TcpHandlers
 
         public DynamicJsonValue GetConnectionStats()
         {
+            string clientUri;
+            try
+            {
+                clientUri = TcpClient?.Client?.RemoteEndPoint?.ToString();
+            }
+            catch (ObjectDisposedException)
+            {
+                clientUri = "N/A";
+            }
+
             var stats = new DynamicJsonValue
             {
                 ["Id"] = Id,
                 ["Operation"] = Operation.ToString(),
-                ["ClientUri"] = TcpClient?.Client?.RemoteEndPoint?.ToString(),
+                ["ClientUri"] = clientUri,
                 ["ConnectedAt"] = _connectedAt,
                 ["Duration"] = (DateTime.UtcNow - _connectedAt).ToString(),
                 ["LastEtagReceived"] = _lastEtagReceived,

--- a/test/SlowTests/Client/Subscriptions/SubscriptionsBasic.cs
+++ b/test/SlowTests/Client/Subscriptions/SubscriptionsBasic.cs
@@ -20,13 +20,13 @@ using Raven.Client.Exceptions.Database;
 using Raven.Client.Exceptions.Documents.Subscriptions;
 using Raven.Client.Extensions;
 using Raven.Client.ServerWide.Operations;
+using Raven.Server.Documents;
 using Raven.Server.Documents.Replication;
 using Raven.Server.Documents.Subscriptions;
 using Raven.Server.ServerWide.Context;
 using Raven.Tests.Core.Utils.Entities;
 using Sparrow;
 using Sparrow.Server;
-using Tests.Infrastructure;
 using Xunit;
 using Xunit.Abstractions;
 
@@ -1258,6 +1258,93 @@ namespace SlowTests.Client.Subscriptions
                         holdAck.Set();
                     }
                 }
+            }
+        }
+
+        [Fact]
+        public async Task WaitingSubscriptionShouldBeRegisteredInSubscriptionConnections()
+        {
+            using (var store = GetDocumentStore())
+            {
+                var subsId = await store.Subscriptions.CreateAsync(new SubscriptionCreationOptions { Query = "from Users", Name = "Subscription0" });
+
+                List<Task> workerTasks = new List<Task>();
+                var finishedWorkersCde = new CountdownEvent(2);
+
+                var mre1 = new AsyncManualResetEvent();
+                var mreConnect1 = new AsyncManualResetEvent();
+                var mre2 = new AsyncManualResetEvent();
+                var mreConnect2 = new AsyncManualResetEvent();
+                using var subsWorker1 = store.Subscriptions.GetSubscriptionWorker(new SubscriptionWorkerOptions(subsId)
+                {
+                    Strategy = SubscriptionOpeningStrategy.WaitForFree
+                });
+                subsWorker1.OnEstablishedSubscriptionConnection += () =>
+                {
+                    mreConnect1.Set();
+                };
+                var t1 = subsWorker1.Run(_ => { mre1.Set(); }).ContinueWith(res =>
+                {
+                    finishedWorkersCde.Signal();
+                });
+
+                Assert.True(await mreConnect1.WaitAsync(_reasonableWaitTime));
+
+                using var subsWorker2 = store.Subscriptions.GetSubscriptionWorker(new SubscriptionWorkerOptions(subsId)
+                {
+                    Strategy = SubscriptionOpeningStrategy.WaitForFree
+                });
+                subsWorker2.OnEstablishedSubscriptionConnection += () =>
+                {
+                    mreConnect2.Set();
+                };
+                var t2 = subsWorker2.Run(_ => { mre2.Set(); }).ContinueWith(res =>
+                {
+                    finishedWorkersCde.Signal();
+                });
+
+                workerTasks.Add(t1);
+                workerTasks.Add(t2);
+                using (var session = store.OpenAsyncSession())
+                {
+                    await session.StoreAsync(new User());
+                    await session.SaveChangesAsync();
+                }
+                Assert.True(await mre1.WaitAsync(_reasonableWaitTime));
+
+                await AssertRunningSubscriptionAndDrop(store);
+
+                // waiting subscription connects
+                Assert.True(await mreConnect2.WaitAsync(_reasonableWaitTime));
+                using (var session = store.OpenAsyncSession())
+                {
+                    await session.StoreAsync(new User());
+                    await session.SaveChangesAsync();
+                }
+                // waiting subscription process document
+                Assert.True(await mre2.WaitAsync(_reasonableWaitTime));
+
+                await AssertRunningSubscriptionAndDrop(store);
+
+                // both workers should be disconnected
+                Assert.True(finishedWorkersCde.Wait(_reasonableWaitTime));
+                Assert.All(workerTasks, task => Assert.True(task.IsCompleted));
+            }
+        }
+
+        private async Task AssertRunningSubscriptionAndDrop(DocumentStore store)
+        {
+            DocumentDatabase db = await Server.ServerStore.DatabasesLandlord.TryGetOrCreateResourceStore(store.Database);
+            using (Server.ServerStore.ContextPool.AllocateOperationContext(out TransactionOperationContext context))
+            using (context.OpenReadTransaction())
+            {
+                var name = $"Subscription0";
+                var subscription = db
+                    .SubscriptionStorage
+                    .GetRunningSubscription(context, null, name, false);
+                Assert.NotNull(subscription);
+                db.SubscriptionStorage.DropSubscriptionConnections(subscription.SubscriptionId,
+                    new SubscriptionClosedException("Dropped by Test"));
             }
         }
 

--- a/test/StressTests/Rachis/SubscriptionFailoverWithWaitingChainsStress.cs
+++ b/test/StressTests/Rachis/SubscriptionFailoverWithWaitingChainsStress.cs
@@ -21,6 +21,7 @@ using Raven.Server.ServerWide.Context;
 using Raven.Server.ServerWide.Maintenance;
 using Raven.Tests.Core.Utils.Entities;
 using Sparrow.Collections;
+using Sparrow.Platform;
 using Tests.Infrastructure;
 using Xunit;
 using Xunit.Abstractions;
@@ -142,7 +143,7 @@ namespace StressTests.Rachis
 
                 foreach (var cde in cdeArray.GetArray())
                 {
-                    await KeepDroppingSubscriptionsAndWaitingForCDE(databaseName, SubscriptionsCount, cluster, cde, cts.Token);
+                    await KeepDroppingSubscriptionsAndWaitingForCDE(databaseName, SubscriptionsCount, cluster, cde, dBGroupSize, cts.Token);
                 }
 
                 foreach (var curNode in cluster.Nodes)
@@ -330,7 +331,7 @@ namespace StressTests.Rachis
                 {
                     for (var k = 0; k < DocsBatchSize; k++)
                     {
-                        var user = await session.LoadAsync<User>(ids[k]);
+                        var user = await session.LoadAsync<User>(ids[k], token);
                         user.Age++;
                     }
                     await session.SaveChangesAsync(token);
@@ -351,25 +352,24 @@ namespace StressTests.Rachis
             }
         }
 
-        private static async Task KeepDroppingSubscriptionsAndWaitingForCDE(string databaseName, int SubscriptionsCount, (List<Raven.Server.RavenServer> Nodes, Raven.Server.RavenServer Leader) cluster, CountdownEvent mainSubscribersCDE, CancellationToken token)
+        private static async Task KeepDroppingSubscriptionsAndWaitingForCDE(string databaseName, int SubscriptionsCount,
+            (List<RavenServer> Nodes, RavenServer Leader) cluster, CountdownEvent mainSubscribersCDE, int dBGroupSize, CancellationToken token)
         {
-            var mainTcs = new TaskCompletionSource<bool>();
-
-            var mainTI = ThreadPool.RegisterWaitForSingleObject(mainSubscribersCDE.WaitHandle, (x, timedOut) =>
+            Dictionary<string, List<string>> res = null;
+            var dropResult = await WaitForValueAsync(async () =>
             {
-                if (!timedOut)
-                    mainTcs.SetResult(true);
-            }, null, 10000, true);
+                res = await DropSubscriptions(databaseName, SubscriptionsCount, cluster, dBGroupSize, token);
 
-            for (int i = 0; i < 20; i++)
-            {
-                await DropSubscriptions(databaseName, SubscriptionsCount, cluster, token);
+                if (WaitHandle.WaitAny(new[] { mainSubscribersCDE.WaitHandle }, 1000) == WaitHandle.WaitTimeout)
+                {
+                    return false;
+                }
 
-                if (await mainTcs.Task.WaitWithoutExceptionAsync(1000))
-                    break;
-            }
+                return true;
+            }, true, timeout: PlatformDetails.Is32Bits ? 5 * 60_000 : 60_000);
 
-            mainTI.Unregister(mainSubscribersCDE.WaitHandle);
+            var msg = "Dropped subscriptions, didn't signal CDE.";
+            Assert.True(dropResult, res == null ? msg : $"{msg}{Environment.NewLine}{string.Join(Environment.NewLine, res.Select(x=> $"{x.Key}: {string.Join(",", x.Value)}"))}");
         }
 
         private async Task WaitForRehab(string dbName, int index, (List<Raven.Server.RavenServer> Nodes, Raven.Server.RavenServer Leader) cluster)
@@ -444,10 +444,14 @@ namespace StressTests.Rachis
             }
         }
 
-        private static async Task DropSubscriptions(string databaseName, int SubscriptionsCount, (List<RavenServer> Nodes, RavenServer Leader) cluster, CancellationToken token)
+        private static async Task<Dictionary<string, List<string>>> DropSubscriptions(string databaseName, int SubscriptionsCount, (List<RavenServer> Nodes, RavenServer Leader) cluster, int dBGroupSize,
+            CancellationToken token)
         {
+            var res = new Dictionary<string, List<string>>();
+
             foreach (var curNode in cluster.Nodes)
             {
+                res.Add(curNode.ServerStore.NodeTag, new List<string>());
                 DocumentDatabase db;
                 try
                 {
@@ -455,6 +459,9 @@ namespace StressTests.Rachis
                 }
                 catch (DatabaseNotRelevantException)
                 {
+                    if (dBGroupSize == cluster.Nodes.Count)
+                        throw;
+
                     continue;
                 }
 
@@ -463,17 +470,24 @@ namespace StressTests.Rachis
                     using (curNode.ServerStore.ContextPool.AllocateOperationContext(out TransactionOperationContext context))
                     using (context.OpenReadTransaction())
                     {
+                        var name = $"Subscription{k}";
                         var subscription = db
                             .SubscriptionStorage
-                            .GetRunningSubscription(context, null, "Subscription" + k, false);
+                            .GetRunningSubscription(context, null, name, false);
 
                         if (subscription == null)
+                        {
                             continue;
+                        }
+
+                        res[curNode.ServerStore.NodeTag].Add(name);
                         db.SubscriptionStorage.DropSubscriptionConnections(subscription.SubscriptionId,
                             new SubscriptionClosedException("Dropped by Test"));
                     }
                 }
             }
+
+            return res;
         }
 
         internal static async Task<SubscriptionStorage.SubscriptionGeneralDataAndStats> GetSubscription(string name, string database, List<RavenServer> nodes, CancellationToken token = default)


### PR DESCRIPTION
### Issue link

https://issues.hibernatingrhinos.com/issue/RavenDB-17116

### Additional description

With 5.3 code the subscription on disconnect was removing it self from _subscriptions dictionary, and if there was a waiting subscription (waiting to connect) it was getting connected but wasn't registered in _subscriptions dictionary, so there was subscription connection without being registered in _subscriptions dictionary.

### Type of change

- Regression bug fix

### How risky is the change?

- Low 

### Backward compatibility

- Not relevant

### Is it platform specific issue?

- No

### Documentation update

- No documentation update is needed 

### Testing 

- Tests have been added that prove the fix is effective or that the feature works
- It has been verified by manual testing

### Is there any existing behavior change of other features due to this change?

- No

### UI work

- No UI work is needed
