### PR TITLE
RavenDB-14791 - Confirmation count on certificate replacement is wrong

### DIFF
--- a/src/Raven.Server/RavenServer.cs
+++ b/src/Raven.Server/RavenServer.cs
@@ -1076,8 +1076,7 @@ namespace Raven.Server
                     var nodesInCluster = ServerStore.GetClusterTopology(context).AllNodes;
                     var confirmedNodes = confirmedNodesBlittable.Items.Select(n => n.ToString()).ToHashSet();
 
-                    if ((confirmedNodes.Contains("*") && confirmations < nodesInCluster.Count) || 
-                        (confirmedNodes.Contains("*") == false && ServerStore.DidAllNodesConfirm(nodesInCluster, confirmedNodes) == false))
+                    if (confirmations < nodesInCluster.Count && ServerStore.DidAllNodesConfirm(nodesInCluster, confirmedNodes) == false)
                     {
                         // we are already in the process of updating the certificate, so we need
                         // to nudge all the nodes in the cluster to check the replacement state.
@@ -1096,8 +1095,7 @@ namespace Raven.Server
                     }
 
                     var replacedNodes = replacedNodesBlittable.Items.Select(n => n.ToString()).ToHashSet();
-                    if ((replacedNodes.Contains("*") && replaced < nodesInCluster.Count) || 
-                        (replacedNodes.Contains("*") == false && ServerStore.DidAllNodesConfirm(nodesInCluster, replacedNodes) == false))
+                    if (replaced < nodesInCluster.Count && ServerStore.DidAllNodesConfirm(nodesInCluster, replacedNodes) == false)
                     {
                         // This is for the case where all nodes confirmed they received the replacement cert but
                         // not all nodes have made the actual change yet.

--- a/src/Raven.Server/ServerWide/CertificateReplacement.cs
+++ b/src/Raven.Server/ServerWide/CertificateReplacement.cs
@@ -1,4 +1,6 @@
-﻿namespace Raven.Server.ServerWide
+﻿using System.Collections.Generic;
+
+namespace Raven.Server.ServerWide
 {
     public class CertificateReplacement
     {
@@ -8,6 +10,10 @@
         public int Confirmations;
         public int Replaced;
         public bool ReplaceImmediately;
+        // Hold the list of the nodes that confirmed/replaced. Nodes working with legacy will have '*' as their tag
+        // If there is a legacy node in the cluster, will revert to old behavior - use 'confirmations'/'replaced' count to check if everyone confirmed.
+        public HashSet<string> ConfirmedNodes;
+        public HashSet<string> ReplacedNodes;
 
         public const string CertReplaceAlertTitle = "Server Certificate Replacement";
         public const string CertificateReplacementDoc = "server/cert";

--- a/src/Raven.Server/ServerWide/CertificateReplacement.cs
+++ b/src/Raven.Server/ServerWide/CertificateReplacement.cs
@@ -10,8 +10,6 @@ namespace Raven.Server.ServerWide
         public int Confirmations;
         public int Replaced;
         public bool ReplaceImmediately;
-        // Hold the list of the nodes that confirmed/replaced. Nodes working with legacy will have '*' as their tag
-        // If there is a legacy node in the cluster, will revert to old behavior - use 'confirmations'/'replaced' count to check if everyone confirmed.
         public HashSet<string> ConfirmedNodes;
         public HashSet<string> ReplacedNodes;
 

--- a/src/Raven.Server/ServerWide/ClusterStateMachine.cs
+++ b/src/Raven.Server/ServerWide/ClusterStateMachine.cs
@@ -880,7 +880,8 @@ namespace Raven.Server.ServerWide
                     certInstallation.TryGet(nameof(CertificateReplacement.Confirmations), out int confirmations);
 
                     var newConfirmed = confirmedNodesBlittable.Items.Select(n => n.ToString()).ToHashSet();
-                    newConfirmed.Add(string.IsNullOrEmpty(nodeTag) ? "*" : nodeTag);
+                    if(string.IsNullOrEmpty(nodeTag) == false)
+                        newConfirmed.Add(nodeTag);
                     confirmations++;
                     
                     certInstallation.Modifications = new DynamicJsonValue(certInstallation)
@@ -1030,7 +1031,8 @@ namespace Raven.Server.ServerWide
                     }
 
                     var newReplaced = replacedNodesBlittable.Items.Select(n => n.ToString()).ToHashSet();
-                    newReplaced.Add(string.IsNullOrEmpty(nodeTag) ? "*" : nodeTag);
+                    if(string.IsNullOrEmpty(nodeTag) == false)
+                        newReplaced.Add(nodeTag);
                     replaced++;
                     
                     certInstallation.Modifications = new DynamicJsonValue(certInstallation)

--- a/src/Raven.Server/ServerWide/Commands/InstallUpdatedServerCertificateCommand.cs
+++ b/src/Raven.Server/ServerWide/Commands/InstallUpdatedServerCertificateCommand.cs
@@ -40,15 +40,17 @@ namespace Raven.Server.ServerWide.Commands
     public class ConfirmReceiptServerCertificateCommand : CommandBase
     {
         public string Thumbprint { get; set; }
+        public string NodeTag { get; set; }
 
         public ConfirmReceiptServerCertificateCommand()
         {
             // for deserialization
         }
 
-        public ConfirmReceiptServerCertificateCommand(string thumbprint) : base(RaftIdGenerator.DontCareId)
+        public ConfirmReceiptServerCertificateCommand(string thumbprint, string nodeTag) : base(RaftIdGenerator.DontCareId)
         {
             Thumbprint = thumbprint;
+            NodeTag = nodeTag;
         }
 
         public override void VerifyCanExecuteCommand(ServerStore store, TransactionOperationContext context, bool isClusterAdmin)
@@ -60,6 +62,7 @@ namespace Raven.Server.ServerWide.Commands
         {
             var json = base.ToJson(context);
             json[nameof(Thumbprint)] = Thumbprint;
+            json[nameof(NodeTag)] = NodeTag;
             return json;
         }
     }
@@ -81,16 +84,18 @@ namespace Raven.Server.ServerWide.Commands
     {
         public string Thumbprint { get; set; }
         public string OldThumbprint { get; set; }
+        public string NodeTag { get; set; }
 
         public ConfirmServerCertificateReplacedCommand()
         {
             // for deserialization
         }
 
-        public ConfirmServerCertificateReplacedCommand(string thumbprint, string oldThumbprint) : base(RaftIdGenerator.DontCareId)
+        public ConfirmServerCertificateReplacedCommand(string thumbprint, string oldThumbprint, string nodeTag) : base(RaftIdGenerator.DontCareId)
         {
             Thumbprint = thumbprint;
             OldThumbprint = oldThumbprint;
+            NodeTag = nodeTag;
         }
 
         public override void VerifyCanExecuteCommand(ServerStore store, TransactionOperationContext context, bool isClusterAdmin)
@@ -103,6 +108,7 @@ namespace Raven.Server.ServerWide.Commands
             var json = base.ToJson(context);
             json[nameof(Thumbprint)] = Thumbprint;
             json[nameof(OldThumbprint)] = OldThumbprint;
+            json[nameof(NodeTag)] = NodeTag;
             return json;
         }
     }

--- a/test/SlowTests/Authentication/SetupCommands.cs
+++ b/test/SlowTests/Authentication/SetupCommands.cs
@@ -21,7 +21,7 @@ namespace SlowTests.Authentication
 {
     public partial class AuthenticationLetsEncryptTests
     {
-        private class ClaimDomainCommand : RavenCommand<ClaimDomainResult>
+        internal class ClaimDomainCommand : RavenCommand<ClaimDomainResult>
         {
             private readonly BlittableJsonReaderObject _payload;
 
@@ -83,7 +83,7 @@ namespace SlowTests.Authentication
             public string RaftUniqueRequestId { get; } = RaftIdGenerator.NewId();
         }
 
-        private class SetupLetsEncryptCommand : RavenCommand<byte[]>, IRaftCommand
+        internal class SetupLetsEncryptCommand : RavenCommand<byte[]>, IRaftCommand
         {
             private readonly BlittableJsonReaderObject _payload;
 

--- a/test/SlowTests/Cluster/ClusterOperationTests.cs
+++ b/test/SlowTests/Cluster/ClusterOperationTests.cs
@@ -2,30 +2,38 @@
 using System.Collections.Concurrent;
 using System.Collections.Generic;
 using System.Diagnostics;
+using System.IO;
 using System.Linq;
+using System.Net;
 using System.Net.Http;
+using System.Net.Sockets;
+using System.Security.Cryptography.X509Certificates;
 using System.Threading;
 using System.Threading.Tasks;
 using FastTests;
+using Newtonsoft.Json;
 using Raven.Client.Documents;
 using Raven.Client.Documents.Changes;
-using Raven.Client.Documents.Commands;
 using Raven.Client.Documents.Conventions;
+using Raven.Client.Documents.Operations.Identities;
 using Raven.Client.Exceptions;
+using Raven.Client.Extensions;
 using Raven.Client.Http;
 using Raven.Client.ServerWide;
 using Raven.Client.ServerWide.Commands;
 using Raven.Client.ServerWide.Operations;
 using Raven.Server;
+using Raven.Server.Commercial;
 using Raven.Server.Config;
-using Tests.Infrastructure;
-using Raven.Tests.Core.Utils.Entities;
-using Sparrow.Json;
-using Xunit;
-using Raven.Client.Documents.Operations.Identities;
-using Raven.Client.Extensions;
+using Raven.Server.Config.Settings;
+using Raven.Server.ServerWide;
+using Raven.Server.ServerWide.Commands;
 using Raven.Server.Utils;
-using Sparrow.Server;
+using Raven.Tests.Core.Utils.Entities;
+using SlowTests.Authentication;
+using Sparrow.Json;
+using Tests.Infrastructure;
+using Xunit;
 using Xunit.Abstractions;
 
 namespace SlowTests.Cluster
@@ -437,6 +445,206 @@ namespace SlowTests.Cluster
             await store.Maintenance.Server.SendAsync(new ReorderDatabaseMembersOperation(db, record.Topology.Members));
             record = await store.Maintenance.Server.SendAsync(new GetDatabaseRecordOperation(db));
             Assert.True(copy.All(record.Topology.Members.Contains));
+        }
+
+        [Fact]
+        public async Task EnsureCertificateReplacementDoesntOverConfirm_RavenDB_14791()
+        {
+            DebuggerAttachedTimeout.DisableLongTimespan = true;
+            var clusterSize = 5;
+            var (leader, nodes, serverCert) = await CreateLetsEncryptCluster(clusterSize);
+            Assert.Equal(serverCert.Thumbprint, nodes[0].Certificate.Certificate.Thumbprint);
+            var databaseName = GetDatabaseName();
+            
+            var options = new Options
+            {
+                Server = nodes[0],
+                ReplicationFactor = clusterSize,
+                ClientCertificate = serverCert,
+                AdminCertificate = serverCert,
+                ModifyDatabaseName = _ => databaseName,
+                RunInMemory = true,
+            };
+            using (var store = GetDocumentStore(options))
+            {
+                string originalServerCert = nodes[0].Certificate.Certificate.Thumbprint;
+
+                var requestExecutor = store.GetRequestExecutor(store.Database);
+                
+                //bring one of the other nodes down
+                var serverToBringDown = Servers.First(x => x.ServerStore.IsLeader() == false);
+                var (_, _, nodeDown) = await DisposeServerAndWaitForFinishOfDisposalAsync(serverToBringDown);
+                
+                //trigger cert refresh
+                await requestExecutor.HttpClient.PostAsync(Uri.EscapeUriString($"{nodes[0].WebUrl}/admin/certificates/letsencrypt/force-renew"), null);
+                
+                await WaitAndAssertForValueAsync(async () =>
+                {
+                    //simulate original problem where InstallUpdatedServerCertificateCommand happened lots of times and confirmations over-counted
+                    foreach (var node in nodes)
+                    {
+                        if (node.ServerStore.NodeTag == nodeDown)
+                            continue;
+                        await node.ServerStore.InstallUpdatedCertificateValueChanged(0, nameof(InstallUpdatedServerCertificateCommand));
+                    }
+
+                    var res = await WaitForValueAsync( async () =>
+                    {
+                        var response = await requestExecutor.HttpClient.GetAsync(Uri.EscapeUriString($"{nodes[0].WebUrl}/admin/certificates/replacement/status"));
+                        var rawResponse = response.Content.ReadAsStringAsync().Result;
+                        var cert = JsonConvert.DeserializeObject<CertificateReplacement>(rawResponse);
+                        
+                        return cert?.Confirmations >= clusterSize;
+                    }, true, 3000, 500);
+                    return res;
+                }, true, 40_000, 4000);
+
+                var response = await requestExecutor.HttpClient.GetAsync(Uri.EscapeUriString($"{nodes[0].WebUrl}/admin/certificates/replacement/status"));
+                var rawResponse = response.Content.ReadAsStringAsync().Result;
+                var cert = JsonConvert.DeserializeObject<CertificateReplacement>(rawResponse);
+                var allActiveNodes = nodes[0].ServerStore.GetClusterTopology().AllNodes.Select(x => x.Key).ToHashSet();
+                allActiveNodes.Remove(nodeDown);
+                Assert.True(cert?.ConfirmedNodes.SetEquals(allActiveNodes));
+                Assert.True(cert?.ReplacedNodes.Count() < clusterSize);
+
+                foreach (var node in nodes)
+                {
+                    if (node.ServerStore.NodeTag == nodeDown)
+                        continue;
+                    
+                    //all nodes should have old cert
+                    Assert.Equal(originalServerCert, node.Certificate.Certificate.Thumbprint);
+                }
+
+            }
+        }
+
+        public async Task<(RavenServer Leader, List<RavenServer> Nodes, X509Certificate2 Cert)> CreateLetsEncryptCluster(int clutserSize)
+        {
+            var settingPath = Path.Combine(NewDataPath(forceCreateDir: true), "settings.json");
+            var defaultSettingsPath = new PathSetting("settings.default.json").FullPath;
+            File.Copy(defaultSettingsPath, settingPath, true);
+
+            UseNewLocalServer(customConfigPath: settingPath);
+            
+            var acmeStaging = "https://acme-staging-v02.api.letsencrypt.org/";
+
+            Server.Configuration.Core.AcmeUrl = acmeStaging;
+            Server.ServerStore.Configuration.Core.SetupMode = SetupMode.Initial;
+
+            var domain = "RavenClusterTest" + Environment.MachineName.Replace("-", "");
+            string email;
+            string rootDomain;
+
+            Server.ServerStore.EnsureNotPassive();
+            var license = Server.ServerStore.LoadLicense();
+
+            using (var store = GetDocumentStore())
+            using (var commands = store.Commands())
+            using (Server.ServerStore.ContextPool.AllocateOperationContext(out JsonOperationContext context))
+            {
+                var command = new AuthenticationLetsEncryptTests.ClaimDomainCommand(store.Conventions, context, new ClaimDomainInfo
+                {
+                    Domain = domain,
+                    License = license
+                });
+
+                await commands.RequestExecutor.ExecuteAsync(command, commands.Context);
+
+                Assert.True(command.Result.RootDomains.Length > 0);
+                rootDomain = command.Result.RootDomains[0];
+                email = command.Result.Email;
+            }
+
+            var nodeSetupInfos = new Dictionary<string, SetupInfo.NodeInfo>();
+            char nodeTag = 'A';
+            for (int i = 1; i <= clutserSize; i++)
+            {
+                var tcpListener = new TcpListener(IPAddress.Loopback, 0);
+                tcpListener.Start();
+                var port = ((IPEndPoint)tcpListener.LocalEndpoint).Port;
+                tcpListener.Stop();
+                var setupNodeInfo = new SetupInfo.NodeInfo
+                {
+                    Port = port, 
+                    Addresses = new List<string> {$"127.0.0.{i}"}
+                };
+                nodeSetupInfos.Add(nodeTag.ToString() ,setupNodeInfo);
+                nodeTag++;
+            }
+            
+            var setupInfo = new SetupInfo
+            {
+                Domain = domain,
+                RootDomain = rootDomain,
+                ModifyLocalServer = false,
+                RegisterClientCert = false,
+                Password = null,
+                Certificate = null,
+                LocalNodeTag = "A",
+                License = license,
+                Email = email,
+                NodeSetupInfos = nodeSetupInfos
+            };
+
+            X509Certificate2 serverCert = default;
+            byte[] serverCertBytes;
+            BlittableJsonReaderObject settingsJsonObject;
+            var customSettings = new List<IDictionary<string, string>>();
+
+            using (var store = GetDocumentStore())
+            using (var commands = store.Commands())
+            using (Server.ServerStore.ContextPool.AllocateOperationContext(out JsonOperationContext context))
+            {
+                var command = new AuthenticationLetsEncryptTests.SetupLetsEncryptCommand(store.Conventions, context, setupInfo);
+
+                await commands.RequestExecutor.ExecuteAsync(command, commands.Context);
+
+                Assert.True(command.Result.Length > 0);
+
+                var zipBytes = command.Result;
+
+                foreach(var node in setupInfo.NodeSetupInfos)
+                {
+                    try
+                    {
+                        var tag = node.Key;
+                        settingsJsonObject = SetupManager.ExtractCertificatesAndSettingsJsonFromZip(zipBytes, tag, context, out serverCertBytes, out serverCert, out _, out _, out _, out _);
+                    }
+                    catch (Exception e)
+                    {
+                        throw new InvalidOperationException("Unable to extract setup information from the zip file.", e);
+                    }
+
+                    settingsJsonObject.TryGet(RavenConfiguration.GetKey(x => x.Security.CertificatePassword), out string certPassword);
+                    settingsJsonObject.TryGet(RavenConfiguration.GetKey(x => x.Security.CertificateLetsEncryptEmail), out string letsEncryptEmail);
+                    settingsJsonObject.TryGet(RavenConfiguration.GetKey(x => x.Core.PublicServerUrl), out string publicServerUrl);
+                    settingsJsonObject.TryGet(RavenConfiguration.GetKey(x => x.Core.ServerUrls), out string serverUrl);
+                    settingsJsonObject.TryGet(RavenConfiguration.GetKey(x => x.Core.SetupMode), out SetupMode setupMode);
+                    settingsJsonObject.TryGet(RavenConfiguration.GetKey(x => x.Core.ExternalIp), out string externalIp);
+
+                    var tempFileName = GetTempFileName();
+                    await File.WriteAllBytesAsync(tempFileName, serverCertBytes);
+                    
+                    var settings = new Dictionary<string, string>
+                    {
+                        [RavenConfiguration.GetKey(x => x.Security.CertificatePath)] = tempFileName,
+                        [RavenConfiguration.GetKey(x => x.Security.CertificateLetsEncryptEmail)] = letsEncryptEmail,
+                        [RavenConfiguration.GetKey(x => x.Security.CertificatePassword)] = certPassword,
+                        [RavenConfiguration.GetKey(x => x.Core.PublicServerUrl)] = publicServerUrl,
+                        [RavenConfiguration.GetKey(x => x.Core.ServerUrls)] = serverUrl,
+                        [RavenConfiguration.GetKey(x => x.Core.SetupMode)] = setupMode.ToString(),
+                        [RavenConfiguration.GetKey(x => x.Core.ExternalIp)] = externalIp,
+                        [RavenConfiguration.GetKey(x => x.Core.AcmeUrl)] = acmeStaging
+                    };
+                    customSettings.Add(settings);
+                }
+            }
+
+            Server.Dispose();
+            
+            var cluster = await CreateRaftClusterInternalAsync(clutserSize, customSettingsList: customSettings, leaderIndex: 0, useSsl: true);
+            return (cluster.Leader, cluster.Nodes, serverCert);
         }
     }
 }

--- a/test/Tests.Infrastructure/ClusterTestBase.cs
+++ b/test/Tests.Infrastructure/ClusterTestBase.cs
@@ -20,6 +20,7 @@ using Raven.Client.ServerWide.Commands;
 using Raven.Client.ServerWide.Operations;
 using Raven.Client.Util;
 using Raven.Server;
+using Raven.Server.Commercial;
 using Raven.Server.Config;
 using Raven.Server.Documents;
 using Raven.Server.Documents.Replication;
@@ -716,19 +717,21 @@ namespace Tests.Infrastructure
                 {
                     customSettings = customSettingsList[i];
                 }
-
-                string serverUrl;
+                
+                customSettings.TryGetValue(RavenConfiguration.GetKey(x => x.Core.ServerUrls), out string serverUrl);
 
                 if (useSsl)
                 {
-                    serverUrl = UseFiddlerUrl("https://127.0.0.1:0");
-                    certificates = SetupServerAuthentication(customSettings, serverUrl);
+                    serverUrl ??= UseFiddlerUrl("https://127.0.0.1:0");
+                    if(customSettings.TryGetValue(RavenConfiguration.GetKey(x => x.Core.SetupMode), out var setupMode) == false || setupMode != nameof(SetupMode.LetsEncrypt))
+                        certificates = SetupServerAuthentication(customSettings, serverUrl);
                 }
                 else
                 {
-                    serverUrl = UseFiddlerUrl("http://127.0.0.1:0");
+                    serverUrl ??= UseFiddlerUrl("http://127.0.0.1:0");
                     customSettings[RavenConfiguration.GetKey(x => x.Core.ServerUrls)] = serverUrl;
                 }
+
                 var co = new ServerCreationOptions
                 {
                     CustomSettings = customSettings,
@@ -737,9 +740,12 @@ namespace Tests.Infrastructure
                     NodeTag = allowedNodeTags[i]
                 };
                 var server = GetNewServer(co, caller);
+                
                 var port = Convert.ToInt32(server.ServerStore.GetNodeHttpServerUrl().Split(':')[2]);
                 var prefix = useSsl ? "https" : "http";
-                serverUrl = UseFiddlerUrl($"{prefix}://127.0.0.1:{port}");
+                var ip = serverUrl.Split(':')[1].Replace("//", "");
+                serverUrl = UseFiddlerUrl($"{prefix}://{ip}:{port}");
+                
                 Servers.Add(server);
                 clusterNodes.Add(server);
 


### PR DESCRIPTION
### Issue link

https://issues.hibernatingrhinos.com/issue/RavenDB-14791

### Additional description

Added `ConfirmedNodes` and `ReplacedNodes` lists and using them now to check if all nodes confirmed during the process of certificate replacement. This is to prevent over-counting confirmations in cases where confirmation commands happen multiple times per node.
In addition, added prevention of sending confirmation and replacement commands to nodes that are already in the list.
In case of mixed cluster, where one of the nodes has an older version, if the confirmations commands are sent too many times, confirmations will over count and old bug is preserved.

### Type of change

- Bug fix

### How risky is the change?

- Moderate

### Backward compatibility

- Ensured. Written above.

### Documentation update

- No documentation update is needed 

### Testing 

- Tests have been added that prove the fix is effective or that the feature works
- It has been verified by manual testing - mixed cluster case

### Is there any existing behavior change of other features due to this change?

- No

### UI work

- No UI work is needed
