### PR TITLE
RDBS-8983 Rolling index updates seems to be broken

### DIFF
--- a/src/Raven.Client/Documents/Indexes/ClusterState.cs
+++ b/src/Raven.Client/Documents/Indexes/ClusterState.cs
@@ -5,13 +5,16 @@
         public ClusterState()
         {
             LastStateIndex = 0;
+            LastRollingDeploymentIndex = 0;
         }
 
         public ClusterState(ClusterState clusterState)
         {
             LastStateIndex = clusterState.LastStateIndex;
+            LastRollingDeploymentIndex = clusterState.LastRollingDeploymentIndex;
         }
 
         public long LastStateIndex;
+        public long LastRollingDeploymentIndex;
     }
 }

--- a/src/Raven.Client/Documents/Indexes/RollingIndex.cs
+++ b/src/Raven.Client/Documents/Indexes/RollingIndex.cs
@@ -8,12 +8,13 @@ namespace Raven.Client.Documents.Indexes
     {
         public Dictionary<string, RollingIndexDeployment> ActiveDeployments = new Dictionary<string, RollingIndexDeployment>(StringComparer.OrdinalIgnoreCase);
 
-        public long RaftIndex;
+        public long RaftCommandIndex;
         public DynamicJsonValue ToJson()
         {
             return new DynamicJsonValue
             {
-                [nameof(ActiveDeployments)] = DynamicJsonValue.Convert(ActiveDeployments), 
+                [nameof(ActiveDeployments)] = DynamicJsonValue.Convert(ActiveDeployments),
+                [nameof(RaftCommandIndex)] = RaftCommandIndex
             };
         }
     }

--- a/src/Raven.Client/Documents/Indexes/RollingIndex.cs
+++ b/src/Raven.Client/Documents/Indexes/RollingIndex.cs
@@ -8,6 +8,7 @@ namespace Raven.Client.Documents.Indexes
     {
         public Dictionary<string, RollingIndexDeployment> ActiveDeployments = new Dictionary<string, RollingIndexDeployment>(StringComparer.OrdinalIgnoreCase);
 
+        public long RaftIndex;
         public DynamicJsonValue ToJson()
         {
             return new DynamicJsonValue

--- a/src/Raven.Client/ServerWide/DatabaseRecord.cs
+++ b/src/Raven.Client/ServerWide/DatabaseRecord.cs
@@ -48,6 +48,8 @@ namespace Raven.Client.ServerWide
 
         public long EtagForBackup;
 
+        public long EtagForRollingIndex;
+
         public Dictionary<string, DeletionInProgressStatus> DeletionInProgress;
 
         public Dictionary<string, RollingIndex> RollingIndexes;
@@ -193,6 +195,7 @@ namespace Raven.Client.ServerWide
                 definition.ReduceOutputIndex = version;
             }
 
+            definition.ClusterState.LastRollingDeploymentIndex = EtagForRollingIndex;
             Indexes[definition.Name] = definition;
             List<IndexHistoryEntry> history;
             if (IndexesHistory == null)
@@ -290,6 +293,7 @@ namespace Raven.Client.ServerWide
                 }
 
                 rollingIndex.ActiveDeployments[node] = deployment;
+                rollingIndex.RaftIndex = EtagForRollingIndex;
             }
         }
 

--- a/src/Raven.Server/Documents/Handlers/Debugging/ServerWideDebugInfoPackageHandler.cs
+++ b/src/Raven.Server/Documents/Handlers/Debugging/ServerWideDebugInfoPackageHandler.cs
@@ -54,7 +54,7 @@ namespace Raven.Server.Documents.Handlers.Debugging
             nameof(DatabaseRecord.LockMode),
             nameof(DatabaseRecord.DocumentsCompression),
             nameof(DatabaseRecord.Analyzers),
-            nameof(DatabaseRecord.TimeSeries),
+            nameof(DatabaseRecord.TimeSeries)
         };
 
         private Logger _logger = LoggingSource.Instance.GetLogger<ServerWideDebugInfoPackageHandler>("Server");

--- a/src/Raven.Server/Documents/Indexes/Auto/AutoIndexDefinitionBaseServerSide.cs
+++ b/src/Raven.Server/Documents/Indexes/Auto/AutoIndexDefinitionBaseServerSide.cs
@@ -9,7 +9,7 @@ namespace Raven.Server.Documents.Indexes.Auto
     public abstract class AutoIndexDefinitionBaseServerSide : IndexDefinitionBaseServerSide<AutoIndexField>
     {
         protected AutoIndexDefinitionBaseServerSide(string indexName, string collection, AutoIndexField[] fields, IndexDeploymentMode? deploymentMode, long? indexVersion = null)
-            : base(indexName, new [] { collection }, IndexLockMode.Unlock, IndexPriority.Normal, IndexState.Normal, fields, indexVersion ?? IndexVersion.CurrentVersion, deploymentMode, 0)
+            : base(indexName, new [] { collection }, IndexLockMode.Unlock, IndexPriority.Normal, IndexState.Normal, fields, indexVersion ?? IndexVersion.CurrentVersion, deploymentMode, clusterState: null)
         {
             if (string.IsNullOrEmpty(collection))
                 throw new ArgumentNullException(nameof(collection));

--- a/src/Raven.Server/Documents/Indexes/Errors/FaultyAutoIndexDefinition.cs
+++ b/src/Raven.Server/Documents/Indexes/Errors/FaultyAutoIndexDefinition.cs
@@ -12,7 +12,7 @@ namespace Raven.Server.Documents.Indexes.Errors
         public readonly AutoIndexDefinitionBaseServerSide Definition;
 
         public FaultyAutoIndexDefinition(string name, HashSet<string> collections, IndexLockMode lockMode, IndexPriority priority, IndexState state, IndexField[] mapFields, AutoIndexDefinitionBaseServerSide definition)
-            : base(name, collections, lockMode, priority, state, mapFields, definition.Version, definition.DeploymentMode, definition.ClusterState?.LastStateIndex)
+            : base(name, collections, lockMode, priority, state, mapFields, definition.Version, definition.DeploymentMode, definition.ClusterState)
         {
             Definition = definition;
         }

--- a/src/Raven.Server/Documents/Indexes/Errors/FaultyIndexDefinition.cs
+++ b/src/Raven.Server/Documents/Indexes/Errors/FaultyIndexDefinition.cs
@@ -11,7 +11,7 @@ namespace Raven.Server.Documents.Indexes.Errors
         private readonly IndexDefinition _definition;
 
         public FaultyIndexDefinition(string name, IEnumerable<string> collections, IndexLockMode lockMode, IndexPriority priority, IndexState state, IndexField[] mapFields, IndexDefinition definition)
-            : base(name, collections, lockMode, priority, state, mapFields, IndexVersion.CurrentVersion, definition.DeploymentMode, definition.ClusterState?.LastStateIndex)
+            : base(name, collections, lockMode, priority, state, mapFields, IndexVersion.CurrentVersion, definition.DeploymentMode, definition.ClusterState)
         {
             _definition = definition;
         }

--- a/src/Raven.Server/Documents/Indexes/Index.cs
+++ b/src/Raven.Server/Documents/Indexes/Index.cs
@@ -993,7 +993,7 @@ namespace Raven.Server.Documents.Indexes
             if (_rollingCompletionTask != null)
                 return;
 
-            if (DocumentDatabase.IndexStore.MaybeFinishRollingDeployment(Definition.Name) == false)
+            if (DocumentDatabase.IndexStore.MaybeFinishRollingDeployment(Definition.Name, Definition.ClusterState?.LastRollingDeploymentIndex) == false)
                 return;
 
             if (IsStaleInternal())

--- a/src/Raven.Server/Documents/Indexes/IndexDefinitionBaseServerSide.cs
+++ b/src/Raven.Server/Documents/Indexes/IndexDefinitionBaseServerSide.cs
@@ -161,7 +161,7 @@ namespace Raven.Server.Documents.Indexes
         private long _indexVersion;
         private int? _cachedHashCode;
 
-        protected IndexDefinitionBaseServerSide(string name, IEnumerable<string> collections, IndexLockMode lockMode, IndexPriority priority, IndexState state, T[] mapFields, long indexVersion, IndexDeploymentMode? deploymentMode, long? clusterIndexForState)
+        internal IndexDefinitionBaseServerSide(string name, IEnumerable<string> collections, IndexLockMode lockMode, IndexPriority priority, IndexState state, T[] mapFields, long indexVersion, IndexDeploymentMode? deploymentMode, ClusterState clusterState)
         {
             Name = name;
             DeploymentMode = deploymentMode ?? IndexDeploymentMode.Parallel;
@@ -189,7 +189,8 @@ namespace Raven.Server.Documents.Indexes
             Priority = priority;
             State = state;
             _indexVersion = indexVersion;
-            ClusterState.LastStateIndex = clusterIndexForState ?? 0;
+            ClusterState.LastStateIndex = clusterState?.LastStateIndex ?? 0;
+            ClusterState.LastRollingDeploymentIndex = clusterState?.LastRollingDeploymentIndex ?? 0;
         }
 
         static IndexDefinitionBaseServerSide()

--- a/src/Raven.Server/Documents/Indexes/IndexStore.cs
+++ b/src/Raven.Server/Documents/Indexes/IndexStore.cs
@@ -832,7 +832,7 @@ namespace Raven.Server.Documents.Indexes
             return _indexes.TryGetByName(replacementName, out _);
         }
 
-        public bool MaybeFinishRollingDeployment(string index)
+        public bool MaybeFinishRollingDeployment(string index, long? lastRollingDeploymentIndex)
         {
             var nodeTag = _serverStore.NodeTag;
 
@@ -848,11 +848,8 @@ namespace Raven.Server.Documents.Indexes
                 if (rollingIndexes.TryGetValue(index, out var rollingIndex) == false)
                     return false;
 
-                if (_indexes.TryGetByName(index, out Index currentIndex))
-                {
-                    if (rollingIndex.RaftIndex != currentIndex.Definition.ClusterState?.LastRollingDeploymentIndex)
-                        return false;
-                }
+                if (rollingIndex.RaftCommandIndex != lastRollingDeploymentIndex)
+                    return false;
 
                 if (rollingIndex.ActiveDeployments.TryGetValue(nodeTag, out var currentDeployment) == false)
                     return false;

--- a/src/Raven.Server/Documents/Indexes/Static/MapIndexDefinition.cs
+++ b/src/Raven.Server/Documents/Indexes/Static/MapIndexDefinition.cs
@@ -20,7 +20,7 @@ namespace Raven.Server.Documents.Indexes.Static
         public readonly IndexDefinition IndexDefinition;
 
         public MapIndexDefinition(IndexDefinition definition, IEnumerable<string> collections, string[] outputFields, bool hasDynamicFields, bool hasCompareExchange, long indexVersion)
-            : base(definition.Name, collections, definition.LockMode ?? IndexLockMode.Unlock, definition.Priority ?? IndexPriority.Normal, definition.State ??IndexState.Normal, GetFields(definition, outputFields), indexVersion, definition.DeploymentMode, definition.ClusterState?.LastStateIndex)
+            : base(definition.Name, collections, definition.LockMode ?? IndexLockMode.Unlock, definition.Priority ?? IndexPriority.Normal, definition.State ??IndexState.Normal, GetFields(definition, outputFields), indexVersion, definition.DeploymentMode, definition.ClusterState)
         {
             _hasDynamicFields = hasDynamicFields;
             _hasCompareExchange = hasCompareExchange;

--- a/src/Raven.Server/ServerWide/ClusterStateMachine.cs
+++ b/src/Raven.Server/ServerWide/ClusterStateMachine.cs
@@ -2349,7 +2349,6 @@ namespace Raven.Server.ServerWide
                     }
 
                     UpdateEtagForBackup(databaseRecord, type, index);
-                    UpdateEtagForRollingIndex(databaseRecord, type, index);
                     var updatedDatabaseBlittable = DocumentConventions.DefaultForServer.Serialization.DefaultConverter.ToBlittable(databaseRecord, context);
                     UpdateValue(index, items, valueNameLowered, valueName, updatedDatabaseBlittable);
                 }
@@ -2430,20 +2429,6 @@ namespace Raven.Server.ServerWide
                     break;
             }
         }
-
-        private void UpdateEtagForRollingIndex(DatabaseRecord databaseRecord, string type, long index)
-        {
-            switch (type)
-            {
-
-                case nameof(PutIndexCommand):
-                case nameof(PutAutoIndexCommand):
-                case nameof(PutRollingIndexCommand):
-                    databaseRecord.EtagForRollingIndex = index;
-                    break;
-            }
-        }
-
 
         private enum SnapshotEntryType
         {

--- a/src/Raven.Server/ServerWide/ClusterStateMachine.cs
+++ b/src/Raven.Server/ServerWide/ClusterStateMachine.cs
@@ -2349,6 +2349,7 @@ namespace Raven.Server.ServerWide
                     }
 
                     UpdateEtagForBackup(databaseRecord, type, index);
+                    UpdateEtagForRollingIndex(databaseRecord, type, index);
                     var updatedDatabaseBlittable = DocumentConventions.DefaultForServer.Serialization.DefaultConverter.ToBlittable(databaseRecord, context);
                     UpdateValue(index, items, valueNameLowered, valueName, updatedDatabaseBlittable);
                 }
@@ -2429,6 +2430,20 @@ namespace Raven.Server.ServerWide
                     break;
             }
         }
+
+        private void UpdateEtagForRollingIndex(DatabaseRecord databaseRecord, string type, long index)
+        {
+            switch (type)
+            {
+
+                case nameof(PutIndexCommand):
+                case nameof(PutAutoIndexCommand):
+                case nameof(PutRollingIndexCommand):
+                    databaseRecord.EtagForRollingIndex = index;
+                    break;
+            }
+        }
+
 
         private enum SnapshotEntryType
         {

--- a/test/SlowTests/Rolling/RollingIndexesClusterTests.cs
+++ b/test/SlowTests/Rolling/RollingIndexesClusterTests.cs
@@ -376,7 +376,7 @@ namespace SlowTests.Rolling
 
                             return Task.FromResult(deployment.Any(x => x.Value.State == RollingIndexState.Done));
                         }
-                    }, false);
+                    }, false, 5000);
                 }
                 finally
                 {


### PR DESCRIPTION
### Issue link

https://issues.hibernatingrhinos.com/issue/RDBS-8983

### Additional description

new rolling index set to done when the previous index finished
When we run MaybeFinishRollingDeployment from the current index we had a scenario that the replacement index was already initialized (InitializeRollingDeployment) but not in the index list (only happened at StartIndex), then we mark the index as done ( because we done with current index ) but didn't even start te index

_Please delete below the options that are not relevant_

### Type of change

- Bug fix

### How risky is the change?

- Low 

### Backward compatibility

- Non breaking change

### Is it platform specific issue?

- No

### Documentation update

- No documentation update is needed 

### Testing 

- Tests have been added that prove the fix is effective or that the feature works

### Is there any existing behavior change of other features due to this change?

- No

### UI work

- No UI work is needed
