### PR TITLE
RavenDB-18142: CSV filename was not UrlEncoded

### DIFF
--- a/src/Raven.Server/Documents/Handlers/StreamCsvResultWriter.cs
+++ b/src/Raven.Server/Documents/Handlers/StreamCsvResultWriter.cs
@@ -34,7 +34,7 @@ namespace Raven.Server.Documents.Handlers
 
         protected StreamCsvResultWriter(HttpResponse response, Stream stream, string[] properties = null, string csvFileNamePrefix = "export")
         {
-            var encodedCsvFileName = WebUtility.UrlEncode($"{csvFileNamePrefix}_{SystemTime.UtcNow.ToString("yyyyMMdd_HHmm", CultureInfo.InvariantCulture)}.csv");
+            var encodedCsvFileName = Uri.EscapeDataString($"{csvFileNamePrefix}_{SystemTime.UtcNow.ToString("yyyyMMdd_HHmm", CultureInfo.InvariantCulture)}.csv");
 
             response.Headers["Content-Disposition"] = $"attachment; filename=\"{encodedCsvFileName}\"; filename*=UTF-8''{encodedCsvFileName}";
             response.Headers["Content-Type"] = "text/csv";

--- a/src/Raven.Server/Documents/Handlers/StreamCsvResultWriter.cs
+++ b/src/Raven.Server/Documents/Handlers/StreamCsvResultWriter.cs
@@ -3,6 +3,7 @@ using System.Collections.Generic;
 using System.Globalization;
 using System.IO;
 using System.Linq;
+using System.Net;
 using System.Text;
 using System.Threading;
 using System.Threading.Tasks;
@@ -33,9 +34,9 @@ namespace Raven.Server.Documents.Handlers
 
         protected StreamCsvResultWriter(HttpResponse response, Stream stream, string[] properties = null, string csvFileNamePrefix = "export")
         {
-            var csvFileName = $"{csvFileNamePrefix}_{SystemTime.UtcNow.ToString("yyyyMMdd_HHmm", CultureInfo.InvariantCulture)}.csv";
+            var encodedCsvFileName = WebUtility.UrlEncode($"{csvFileNamePrefix}_{SystemTime.UtcNow.ToString("yyyyMMdd_HHmm", CultureInfo.InvariantCulture)}.csv");
 
-            response.Headers["Content-Disposition"] = $"attachment; filename=\"{csvFileName}\"; filename*=UTF-8''{csvFileName}";
+            response.Headers["Content-Disposition"] = $"attachment; filename=\"{encodedCsvFileName}\"; filename*=UTF-8''{encodedCsvFileName}";
             response.Headers["Content-Type"] = "text/csv";
 
             _writer = new StreamWriter(stream, Encoding.UTF8);


### PR DESCRIPTION
RavenDB creats an automatic filename for csv exports of queries. That filename contains the name of the database and collection (like 'DBName_CollectionName_collection_20220303_1512.csv'). That filename is used in the 'Content-Disposition'-Header to suggest the filename to the browser.

However this filename doesn't get encoded (URL encoding, RFC 3986). This will fail if the collection name contains that requires to be encoded.

The fix is to always encode the filename in the HTTP response header.

```
EXCEPTION: System.InvalidOperationException: Invalid non-ASCII or control character in header: 0x00FC
   at Microsoft.AspNetCore.Server.Kestrel.Core.Internal.Http.HttpHeaders.ThrowInvalidHeaderCharacter(Char ch)
   at Microsoft.AspNetCore.Server.Kestrel.Core.Internal.Http.HttpHeaders.ValidateHeaderValueCharacters(String headerName, StringValues headerValues, Func`2 encodingSelector)
   at Microsoft.AspNetCore.Server.Kestrel.Core.Internal.Http.HttpResponseHeaders.SetValueFast(String key, StringValues value)
   at Microsoft.AspNetCore.Server.Kestrel.Core.Internal.Http.HttpHeaders.Microsoft.AspNetCore.Http.IHeaderDictionary.set_Item(String key, StringValues value)
   at Raven.Server.Documents.Handlers.StreamCsvResultWriter`1..ctor(HttpResponse response, Stream stream, String[] properties, String csvFileNamePrefix) in C:\Builds\RavenDB-Stable-5.3\53004\src\Raven.Server\Documents\Handlers\StreamCsvResultWriter.cs:line 38
   at Raven.Server.Documents.Handlers.StreamCsvDocumentQueryResultWriter..ctor(HttpResponse response, Stream stream, DocumentsOperationContext context, String[] properties, String csvFileName) in C:\Builds\RavenDB-Stable-5.3\53004\src\Raven.Server\Documents\Handlers\StreamCsvDocumentQueryResultWriter.cs:line 35
   at Raven.Server.Documents.Handlers.Streaming.StreamingHandler.GetQueryResultWriter(String format, HttpResponse response, DocumentsOperationContext context, Stream responseBodyStream, String[] propertiesArray, String fileNamePrefix) in C:\Builds\RavenDB-Stable-5.3\53004\src\Raven.Server\Documents\Handlers\Streaming\StreamingHandler.cs:line 310
   at Raven.Server.Documents.Handlers.Streaming.StreamingHandler.StreamQueryPost() in C:\Builds\RavenDB-Stable-5.3\53004\src\Raven.Server\Documents\Handlers\Streaming\StreamingHandler.cs:line 280
   at Raven.Server.Routing.RequestRouter.HandlePath(RequestHandlerContext reqCtx) in C:\Builds\RavenDB-Stable-5.3\53004\src\Raven.Server\Routing\RequestRouter.cs:line 352
   at Raven.Server.RavenServerStartup.RequestHandler(HttpContext context) in C:\Builds\RavenDB-Stable-5.3\53004\src\Raven.Server\RavenServerStartup.cs:line 175
```

### Type of change

- Bug fix

### How risky is the change?

- Low 

### Backward compatibility

- Ensured. 

It didn't work before anyway.

### Is it platform specific issue?

- No

### Is there any existing behavior change of other features due to this change?

- No

### UI work

- No UI work is needed
