### PR TITLE
RavenDB-18143 skipped FastTests.Server.Documents.DocCompression.Can_compact_from_no_compression_to_compressed on macOS

### DIFF
--- a/test/FastTests/Server/Documents/DocCompression.cs
+++ b/test/FastTests/Server/Documents/DocCompression.cs
@@ -41,7 +41,7 @@ namespace FastTests.Server.Documents
                 .Select(s => s[random.Next(s.Length)]).ToArray());
         }
 
-        [LicenseRequiredFact]
+        [MultiplatformFact(RavenPlatform.Windows | RavenPlatform.Linux, LicenseRequired = true)]
         public void Can_compact_from_no_compression_to_compressed()
         {
             var path = NewDataPath();
@@ -100,7 +100,7 @@ namespace FastTests.Server.Documents
                 Path = path,
                 RunInMemory = false,
                 ModifyDatabaseRecord = r => r.DocumentsCompression = new DocumentsCompressionConfiguration(true, "Orders")
-        });
+            });
 
             store.Maintenance.Send(new CreateSampleDataOperation());
 
@@ -142,18 +142,19 @@ namespace FastTests.Server.Documents
         public void Can_compact_db_with_compressed_collections()
         {
             var path = NewDataPath();
-            if(Directory.Exists(path))
+            if (Directory.Exists(path))
                 Directory.Delete(path, true);
             using var store = GetDocumentStore(new Options
             {
                 Path = path,
                 RunInMemory = false,
                 ModifyDatabaseRecord = record => record.DocumentsCompression = new DocumentsCompressionConfiguration(true, "Orders")
-        });
+            });
 
             store.Maintenance.Send(new CreateSampleDataOperation());
 
-            var op = store.Maintenance.Server.Send(new CompactDatabaseOperation(new CompactSettings{
+            var op = store.Maintenance.Server.Send(new CompactDatabaseOperation(new CompactSettings
+            {
                 DatabaseName = store.Database,
                 Documents = true,
             }));
@@ -184,7 +185,7 @@ namespace FastTests.Server.Documents
             using var store = GetDocumentStore(new Options
             {
                 ModifyDatabaseRecord = record => record.DocumentsCompression = new DocumentsCompressionConfiguration(true, "Users")
-        });
+            });
 
             var rnd = Enumerable.Range(1, 10)
                 .Select(i => RandomString(random, 16))
@@ -208,7 +209,7 @@ namespace FastTests.Server.Documents
             using var store = GetDocumentStore();
 
             var rnd = Enumerable.Range(1, 10)
-                .Select(i => new string((char)(65+i), 256))
+                .Select(i => new string((char)(65 + i), 256))
                 .ToList();
 
             using (var s = store.OpenSession())
@@ -218,7 +219,7 @@ namespace FastTests.Server.Documents
                     s.Store(new User
                     {
                         Items = Enumerable.Range(1, random.Next(1, 10))
-                            .Select(x=>rnd[x])
+                            .Select(x => rnd[x])
                             .ToList()
                     }, "users/" + i);
                 }
@@ -239,7 +240,7 @@ namespace FastTests.Server.Documents
                         Items = Enumerable.Range(1, random.Next(1, 10))
                             .Select(x => rnd[x])
                             .ToList()
-                    },"users/" +i);
+                    }, "users/" + i);
                 }
 
                 s.SaveChanges();
@@ -295,7 +296,7 @@ namespace FastTests.Server.Documents
             using var store = GetDocumentStore(new Options
             {
                 ModifyDatabaseRecord = record => record.DocumentsCompression = new DocumentsCompressionConfiguration(true, "Users")
-        });
+            });
 
             var rnd = Enumerable.Range(1, 10)
                 .Select(i => RandomString(random, 16))
@@ -339,7 +340,7 @@ namespace FastTests.Server.Documents
             using var store = GetDocumentStore(new Options
             {
                 ModifyDatabaseRecord = record => record.DocumentsCompression = new DocumentsCompressionConfiguration(true, "Users")
-        });
+            });
 
             var rnd = Enumerable.Range(1, 10)
                 .Select(i => RandomString(random, 16))
@@ -394,7 +395,7 @@ namespace FastTests.Server.Documents
                     s.Store(new User
                     {
                         Desc = string.Join("-", Enumerable.Range(1, random.Next(1, 64)).Select(xi => rnd[xi]))
-                    }, "users/" + i+900);
+                    }, "users/" + i + 900);
                 }
 
                 s.SaveChanges();

--- a/test/Tests.Infrastructure/LicenseRequiredFactAttribute.cs
+++ b/test/Tests.Infrastructure/LicenseRequiredFactAttribute.cs
@@ -5,24 +5,32 @@ namespace Tests.Infrastructure
 {
     public class LicenseRequiredFactAttribute : FactAttribute
     {
-        private static readonly bool ShouldSkip;
+        private static readonly bool HasLicense;
 
         internal static string SkipMessage = "Requires License to be set via 'RAVEN_LICENSE' environment variable.";
 
         static LicenseRequiredFactAttribute()
         {
-            ShouldSkip = string.IsNullOrWhiteSpace(Environment.GetEnvironmentVariable("RAVEN_LICENSE"));
+            HasLicense = string.IsNullOrWhiteSpace(Environment.GetEnvironmentVariable("RAVEN_LICENSE")) == false;
         }
 
         public override string Skip
         {
             get
             {
-                if (ShouldSkip)
+                if (ShouldSkip(licenseRequired: true))
                     return SkipMessage;
 
                 return null;
             }
+        }
+
+        internal static bool ShouldSkip(bool licenseRequired)
+        {
+            if (licenseRequired == false)
+                return false;
+
+            return HasLicense == false;
         }
     }
 }

--- a/test/Tests.Infrastructure/LicenseRequiredTheoryAttribute.cs
+++ b/test/Tests.Infrastructure/LicenseRequiredTheoryAttribute.cs
@@ -1,25 +1,15 @@
-﻿using System;
-using Xunit;
+﻿using Xunit;
 
 namespace Tests.Infrastructure
 {
     public class LicenseRequiredTheoryAttribute : TheoryAttribute
     {
-        private static readonly bool ShouldSkip;
-
-        internal static string SkipMessage = "Requires License to be set via 'RAVEN_LICENSE' environment variable.";
-
-        static LicenseRequiredTheoryAttribute()
-        {
-            ShouldSkip = string.IsNullOrWhiteSpace(Environment.GetEnvironmentVariable("RAVEN_LICENSE"));
-        }
-
         public override string Skip
         {
             get
             {
-                if (ShouldSkip)
-                    return SkipMessage;
+                if (LicenseRequiredFactAttribute.ShouldSkip(licenseRequired: true))
+                    return LicenseRequiredFactAttribute.SkipMessage;
 
                 return null;
             }

--- a/test/Tests.Infrastructure/MultiplatformFactAttribute.cs
+++ b/test/Tests.Infrastructure/MultiplatformFactAttribute.cs
@@ -57,6 +57,8 @@ public class MultiplatformFactAttribute : FactAttribute
         _architecture = architecture;
     }
 
+    public bool LicenseRequired { get; set; }
+
     public override string Skip
     {
         get
@@ -65,13 +67,16 @@ public class MultiplatformFactAttribute : FactAttribute
             if (skip != null)
                 return skip;
 
-            return ShouldSkip(_platform, _architecture);
+            return ShouldSkip(_platform, _architecture, LicenseRequired);
         }
         set => _skip = value;
     }
 
-    internal static string ShouldSkip(RavenPlatform platform, RavenArchitecture architecture)
+    internal static string ShouldSkip(RavenPlatform platform, RavenArchitecture architecture, bool licenseRequired)
     {
+        if (licenseRequired && LicenseRequiredFactAttribute.ShouldSkip(licenseRequired: true))
+            return LicenseRequiredFactAttribute.SkipMessage;
+
         var matchesPlatform = Match(platform);
         var matchesArchitecture = Match(architecture);
 

--- a/test/Tests.Infrastructure/MultiplatformTheoryAttribute.cs
+++ b/test/Tests.Infrastructure/MultiplatformTheoryAttribute.cs
@@ -25,6 +25,8 @@ public class MultiplatformTheoryAttribute : TheoryAttribute
         _architecture = architecture;
     }
 
+    public bool LicenseRequired { get; set; }
+
     public override string Skip
     {
         get
@@ -33,7 +35,7 @@ public class MultiplatformTheoryAttribute : TheoryAttribute
             if (skip != null)
                 return skip;
 
-            return MultiplatformFactAttribute.ShouldSkip(_platform, _architecture);
+            return MultiplatformFactAttribute.ShouldSkip(_platform, _architecture, LicenseRequired);
         }
         set => _skip = value;
     }

--- a/test/Tests.Infrastructure/NightlyBuildMultiplatformFactAttribute.cs
+++ b/test/Tests.Infrastructure/NightlyBuildMultiplatformFactAttribute.cs
@@ -21,6 +21,8 @@
             _architecture = architecture;
         }
 
+        public bool LicenseRequired { get; set; }
+
         public override string Skip
         {
             get
@@ -29,7 +31,7 @@
                 if (skip != null)
                     return skip;
 
-                return MultiplatformFactAttribute.ShouldSkip(_platform, _architecture);
+                return MultiplatformFactAttribute.ShouldSkip(_platform, _architecture, LicenseRequired);
             }
         }
     }

--- a/test/Tests.Infrastructure/NightlyBuildMultiplatformTheoryAttribute.cs
+++ b/test/Tests.Infrastructure/NightlyBuildMultiplatformTheoryAttribute.cs
@@ -21,6 +21,8 @@
             _architecture = architecture;
         }
 
+        public bool LicenseRequired { get; set; }
+
         public override string Skip
         {
             get
@@ -29,7 +31,7 @@
                 if (skip != null)
                     return skip;
 
-                return MultiplatformFactAttribute.ShouldSkip(_platform, _architecture);
+                return MultiplatformFactAttribute.ShouldSkip(_platform, _architecture, LicenseRequired);
             }
         }
     }


### PR DESCRIPTION
### Issue link

https://issues.hibernatingrhinos.com/issue/RavenDB-18143

### How risky is the change?

- Low 

### Backward compatibility

- Not relevant

### Is it platform specific issue?

- Yes. macOS

### Documentation update

- No documentation update is needed 

### Testing 

- It has been verified by manual testing

### Is there any existing behavior change of other features due to this change?

- No

### UI work

- No UI work is needed
