### PR TITLE
RavenDB-18143 skipped FastTests.Server.Documents.DocCompression.Can_compact_from_compression_to_not_compressed on macOS

### DIFF
--- a/test/FastTests/Server/Documents/DocCompression.cs
+++ b/test/FastTests/Server/Documents/DocCompression.cs
@@ -89,7 +89,7 @@ namespace FastTests.Server.Documents
             }
         }
 
-        [LicenseRequiredFact]
+        [MultiplatformFact(RavenPlatform.Windows | RavenPlatform.Linux, LicenseRequired = true)]
         public void Can_compact_from_compression_to_not_compressed()
         {
             var path = NewDataPath();


### PR DESCRIPTION
### Issue link

https://issues.hibernatingrhinos.com/issue/RavenDB-18143
