### PR TITLE
RavenDB-17947 : clean olap test from s3

### DIFF
--- a/test/SlowTests/Server/Documents/ETL/Olap/S3Tests.cs
+++ b/test/SlowTests/Server/Documents/ETL/Olap/S3Tests.cs
@@ -3,7 +3,6 @@ using System.Collections.Generic;
 using System.IO;
 using System.Linq;
 using System.Runtime.CompilerServices;
-using System.Text;
 using System.Threading;
 using System.Threading.Tasks;
 using Newtonsoft.Json;
@@ -979,7 +978,7 @@ for (var i = 0; i < this.Lines.length; i++){
             }
             finally
             {
-                await DeleteObjects(settings, prefix: $"{settings.RemoteFolderName}/{CollectionName}", delimiter: string.Empty, replaceSpecialChars: true);
+                await DeleteObjects(settings, prefix: $"{settings.RemoteFolderName}/{CollectionName}", delimiter: string.Empty);
             }
         }
 
@@ -1353,7 +1352,7 @@ loadToOrders(partitionBy(['year', orderDate.getFullYear()]),
             await DeleteObjects(s3Settings, prefix: $"{s3Settings.RemoteFolderName}/{additionalTable}", delimiter: string.Empty);
         }
 
-        private static async Task DeleteObjects(S3Settings s3Settings, string prefix, string delimiter, bool listFolder = false, bool replaceSpecialChars = false)
+        private static async Task DeleteObjects(S3Settings s3Settings, string prefix, string delimiter, bool listFolder = false)
         {
             if (s3Settings == null)
                 return;
@@ -1368,18 +1367,8 @@ loadToOrders(partitionBy(['year', orderDate.getFullYear()]),
 
                     if (listFolder == false)
                     {
-                        if (replaceSpecialChars == false)
-                        {
-                            var pathsToDelete = cloudObjects.FileInfoDetails.Select(x => x.FullPath).ToList();
-                            s3Client.DeleteMultipleObjects(pathsToDelete);
-                            return;
-                        }
-
-                        foreach (var path in cloudObjects.FileInfoDetails.Select(x => EnsureSafeName(x.FullPath)))
-                        {
-                            s3Client.DeleteObject(path);
-                        }
-
+                        var pathsToDelete = cloudObjects.FileInfoDetails.Select(x => x.FullPath).ToList();
+                        s3Client.DeleteMultipleObjects(pathsToDelete);
                         return;
                     }
 
@@ -1405,21 +1394,5 @@ loadToOrders(partitionBy(['year', orderDate.getFullYear()]),
             return files;
         }
 
-        private static string EnsureSafeName(string str)
-        {
-            var builder = new StringBuilder(str.Length);
-            foreach (char @char in str)
-            {
-                if (SpecialChars.Contains(@char))
-                {
-                    builder.AppendFormat("%{0:X2}", (int)@char);
-                    continue;
-                }
-
-                builder.Append(@char);
-            }
-
-            return builder.ToString();
-        }
     }
 }


### PR DESCRIPTION
### Issue link

https://issues.hibernatingrhinos.com/issue/RavenDB-17947

### Additional description

- OLAP test `CanHandleSpecialCharsInFolderPath` was not cleaned from S3 storage after it finished running.
- Probably been happing since we moved to using the official S3 client
- Removed code that replaced special chars in file path with their hex encoding, 
and verified that now the test data is deleted after each run

### Type of change

- Bug fix

### How risky is the change?

- Low 

### Backward compatibility

- Not relevant

### Is it platform specific issue?

- No

### Documentation update

- No documentation update is needed 

### Testing 

- It has been verified by manual testing

### Is there any existing behavior change of other features due to this change?

- No

### UI work

- No UI work is needed
