### PR TITLE
RavenDB-18058 : flaky test adjustments

### DIFF
--- a/test/SlowTests/Server/Documents/ETL/Olap/S3Tests.cs
+++ b/test/SlowTests/Server/Documents/ETL/Olap/S3Tests.cs
@@ -411,7 +411,7 @@ loadToOrders(partitionBy(key), orderData);
             }
         }
 
-        private static string GetPerformanceStats(DocumentDatabase database)
+        internal static string GetPerformanceStats(DocumentDatabase database)
         {
             var process = database.EtlLoader.Processes.First();
             var stats = process?.GetLatestPerformanceStats().ToPerformanceStats();


### PR DESCRIPTION
### Issue link

https://issues.hibernatingrhinos.com/issue/RavenDB-18058

### Additional description

- increase timeout if running on 32 bits
- add performance stats to failure message

### Type of change

- Bug fix
- Test stabilization 

### How risky is the change?

- Low 

### Backward compatibility

- Not relevant

### Is it platform specific issue?

- No

### Documentation update

- No documentation update is needed 

### Testing 

- It has been verified by manual testing

### Is there any existing behavior change of other features due to this change?

- No

### UI work

- No UI work is needed
