### PR TITLE
RavenDB-18001 : flaky test adjustments

### DIFF
--- a/test/SlowTests/Client/Counters/CountersReplication.cs
+++ b/test/SlowTests/Client/Counters/CountersReplication.cs
@@ -158,8 +158,9 @@ namespace SlowTests.Client.Counters
                 await SetupReplicationAsync(storeA, storeB);
                 await SetupReplicationAsync(storeB, storeA);
 
-                EnsureReplicating(storeA, storeB);
-                
+                await EnsureReplicatingAsync(storeA, storeB);
+                await EnsureReplicatingAsync(storeB, storeA);
+
                 using (var session = storeB.OpenAsyncSession())
                 {
                     var counters = await session.CountersFor("users/1").GetAllAsync();


### PR DESCRIPTION
### Issue link

https://issues.hibernatingrhinos.com/issue/RavenDB-18001

### Additional description

`CountersReplication.CounterConflictBetweenNewAndDeleted` : ensure that replication from B to A is finished before asserting `NoReplicationLoop`

### Type of change

- Bug fix
- Tests stabilization

### How risky is the change?

- Low 

### Backward compatibility

- Not relevant

### Is it platform specific issue?

- No

### Documentation update

- No documentation update is needed 

### Testing 

- It has been verified by manual testing

### Is there any existing behavior change of other features due to this change?

- No

### UI work

- No UI work is needed