### PR TITLE
RavenDB-18092 Instead of throwing exception on LoadLicenseLimits call (e.g. it can thow EarlyOutOfMemory) let's return null.

### DIFF
--- a/src/Raven.Server/ServerWide/ServerStore.cs
+++ b/src/Raven.Server/ServerWide/ServerStore.cs
@@ -2593,14 +2593,24 @@ namespace Raven.Server.ServerWide
 
         public LicenseLimits LoadLicenseLimits()
         {
-            using (ContextPool.AllocateOperationContext(out TransactionOperationContext context))
-            using (context.OpenReadTransaction())
+            try
             {
-                var licenseLimitsBlittable = Cluster.Read(context, LicenseLimitsStorageKey);
-                if (licenseLimitsBlittable == null)
-                    return null;
+                using (ContextPool.AllocateOperationContext(out TransactionOperationContext context))
+                using (context.OpenReadTransaction())
+                {
+                    var licenseLimitsBlittable = Cluster.Read(context, LicenseLimitsStorageKey);
+                    if (licenseLimitsBlittable == null)
+                        return null;
 
-                return JsonDeserializationServer.LicenseLimits(licenseLimitsBlittable);
+                    return JsonDeserializationServer.LicenseLimits(licenseLimitsBlittable);
+                }
+            }
+            catch (Exception e)
+            {
+                if (Logger.IsOperationsEnabled)
+                    Logger.Operations("Failed to load license limits", e);
+
+                return null;
             }
         }
 


### PR DESCRIPTION
All of the callers take into account that it can return null. This will fix the problem with undisposed indexes since this method is called during IndexStore.Dispose() before disposing indexes.

### Issue link

(e.g. it can thow EarlyOutOfMemory) let's return null

### Additional description

In low memory conditions we got EarlyOutOfMemoryException throw from the following line called during `IndexStore.Dispose()`:
https://github.com/ravendb/ravendb/blob/68d7ed202fa2a885a235e848ceaeaeae46af9946/src/Raven.Server/Documents/Indexes/IndexStore.cs#L202

which make that we failed to dispose indexes. That resulted in AccessDenied error on next attempt to open a database and its indexes.

### Type of change

- Bug fix

### How risky is the change?

- Low 

### Backward compatibility

- Not relevant

### Is it platform specific issue?

- No

### Documentation update

- No documentation update is needed 

### Testing 

- Manual testing and code verification

### Is there any existing behavior change of other features due to this change?

- I don't think so. We might get a transient error here (e.g. EOOM), then we'll run with default limits but next attempts to get the limit are supposed to manage to get the configured limits.

### UI work

- No UI work is needed
