### PR TITLE
RavenDB-18092 Instead of throwing exception on LoadLicenseLimits call…

### DIFF
--- a/src/Raven.Server/Documents/Indexes/IndexStore.cs
+++ b/src/Raven.Server/Documents/Indexes/IndexStore.cs
@@ -194,11 +194,26 @@ namespace Raven.Server.Documents.Indexes
 
         private int GetNumberOfUtilizedCores()
         {
-            var licenseLimits = _documentDatabase.ServerStore.LoadLicenseLimits();
+            int defaultNumberOfCores = ProcessorInfo.ProcessorCount;
 
-            return licenseLimits != null && licenseLimits.NodeLicenseDetails.TryGetValue(_serverStore.NodeTag, out DetailsPerNode detailsPerNode)
-                ? detailsPerNode.UtilizedCores
-                : ProcessorInfo.ProcessorCount;
+            try
+            {
+                var licenseLimits = _documentDatabase.ServerStore.LoadLicenseLimits();
+
+                return licenseLimits != null && licenseLimits.NodeLicenseDetails.TryGetValue(_serverStore.NodeTag, out DetailsPerNode detailsPerNode)
+                    ? detailsPerNode.UtilizedCores
+                    : defaultNumberOfCores;
+            }
+            catch (Exception e)
+            {
+                if (e.IsOutOfMemory() == false)
+                {
+                    if (Logger.IsOperationsEnabled)
+                        Logger.Operations($"Failed to get number of utilized cores. Defaulting to {defaultNumberOfCores} cores", e);
+                }
+
+                return defaultNumberOfCores;
+            }
         }
 
         private void HandleSorters(DatabaseRecord record, long index)


### PR DESCRIPTION
… (e.g. it can thow EarlyOutOfMemory) let's return null. All of the callers take into account that it can return null. This will fix the problem with undisposed indexes since this method is called during IndexStore.Dispose() before disposing indexes.

### Issue link

https://issues.hibernatingrhinos.com/issue/RavenDB-18092

### Additional description

In low memory conditions we got EarlyOutOfMemoryException throw from the following line called during IndexStore.Dispose():

https://github.com/ravendb/ravendb/blob/68d7ed202fa2a885a235e848ceaeaeae46af9946/src/Raven.Server/Documents/Indexes/IndexStore.cs#L202

which make that we failed to dispose indexes. That resulted in AccessDenied error on next attempt to open a database and its indexes.

### Type of change

- Bug fix

### How risky is the change?

- Low 

### Backward compatibility

- Not relevant

### Is it platform specific issue?

- No

### Documentation update

- No documentation update is needed 

### Testing 

- Manual verification of the error handing in the code

### Is there any existing behavior change of other features due to this change?

- No

### UI work

- No UI work is needed
