### PR TITLE
RavenDB-18157 added indexer to DynamicArray

### DIFF
--- a/src/Raven.Server/Documents/Indexes/Static/DynamicArray.cs
+++ b/src/Raven.Server/Documents/Indexes/Static/DynamicArray.cs
@@ -105,6 +105,11 @@ namespace Raven.Server.Documents.Indexes.Static
             return base.TryConvert(binder, out result);
         }
 
+        public dynamic this[int i]
+        {
+            get { return ElementAt(i); }
+        }
+
         IEnumerator<object> IEnumerable<object>.GetEnumerator()
         {
             return GetEnumerator();
@@ -380,7 +385,7 @@ namespace Raven.Server.Documents.Indexes.Static
                     ? new DynamicArray(Enumerable.ThenByDescending(orderedEnumerable, keySelector, comparer))
                     : new DynamicArray(Enumerable.ThenBy(orderedEnumerable, keySelector, comparer));
             }
-            
+
             if (_inner is not DynamicArray dynamicArray)
             {
                 return descending
@@ -395,8 +400,8 @@ namespace Raven.Server.Documents.Indexes.Static
 
             return dynamicArray.CreateOrderedEnumerable(keySelector, comparer, descending, depth - 1);
         }
-        
-        
+
+
         public IOrderedEnumerable<object> CreateOrderedEnumerable<TKey>(Func<object, TKey> keySelector, IComparer<TKey> comparer, bool descending)
         {
             return CreateOrderedEnumerable(keySelector, comparer, descending, 32);

--- a/test/FastTests/Issues/RavenDB_18157.cs
+++ b/test/FastTests/Issues/RavenDB_18157.cs
@@ -1,0 +1,29 @@
+﻿using System.Linq;
+using Raven.Server.Documents.Indexes.Static;
+using Xunit;
+using Xunit.Abstractions;
+
+namespace FastTests.Issues;
+
+public class RavenDB_18157 : RavenTestBase
+{
+    public RavenDB_18157(ITestOutputHelper output) : base(output)
+    {
+    }
+
+    [Fact]
+    public void Can_Use_Indexer_In_DynamicArray()
+    {
+        var dynamicArray = new DynamicArray(Enumerable.Range(0, 5));
+
+        var element = dynamicArray[1]; // does not work
+
+        Assert.Equal(1, element);
+
+        dynamic d = dynamicArray;
+
+        element = d[1]; // works;
+
+        Assert.Equal(1, element);
+    }
+}


### PR DESCRIPTION
### Issue link

https://issues.hibernatingrhinos.com/issue/RavenDB-18157

### Additional description

When used directly e.g. in Indexing Extensions, element cannot be accessed by indexer. It works when dealing with dynamic because 'TryGetIndex' is implemented.

### Type of change

- New feature

### How risky is the change?

- Low 

### Backward compatibility

- Non breaking change

### Is it platform specific issue?

- No

### Documentation update

- No documentation update is needed 

### Testing 

- Tests have been added that prove the fix is effective or that the feature works

### Is there any existing behavior change of other features due to this change?

- No

### UI work

- No UI work is needed
