### PR TITLE
RavenDB-17577 Adding new configuration option Indexing.Static.RequireAdminToDeployJavaScriptIndexes

### DIFF
--- a/src/Raven.Server/Config/Categories/IndexingConfiguration.cs
+++ b/src/Raven.Server/Config/Categories/IndexingConfiguration.cs
@@ -359,6 +359,12 @@ namespace Raven.Server.Config.Categories
         [ConfigurationEntry("Indexing.TimeSinceLastQueryAfterWhichDeepCleanupCanBeExecutedInMin", ConfigurationEntryScope.ServerWideOrPerDatabaseOrPerIndex)]
         public TimeSetting TimeSinceLastQueryAfterWhichDeepCleanupCanBeExecuted { get; set; }
 
+        [Description("Require database admin clearance to deploy JavaScript indexes")]
+        [DefaultValue(false)]
+        [IndexUpdateType(IndexUpdateType.None)]
+        [ConfigurationEntry("Indexing.Static.RequireAdminToDeployJavaScriptIndexes", ConfigurationEntryScope.ServerWideOrPerDatabase)]
+        public bool RequireAdminToDeployJavaScriptIndexes { get; set; }
+
         protected override void ValidateProperty(PropertyInfo property)
         {
             base.ValidateProperty(property);

--- a/test/SlowTests/Issues/RavenDB_17577.cs
+++ b/test/SlowTests/Issues/RavenDB_17577.cs
@@ -1,0 +1,67 @@
+﻿using System.Collections.Generic;
+using FastTests;
+using Raven.Client.Documents;
+using Raven.Client.Documents.Indexes;
+using Raven.Client.Exceptions.Security;
+using Raven.Client.ServerWide.Operations.Certificates;
+using Raven.Server.Config;
+using Xunit;
+using Xunit.Abstractions;
+
+namespace SlowTests.Issues;
+
+public class RavenDB_17577 : RavenTestBase
+{
+    public RavenDB_17577(ITestOutputHelper output) : base(output)
+    {
+    }
+
+    [Fact]
+    public void WillRejectJsIndexDeploymentAsValidUserIfItIsRestrictedToAdminsOnly()
+    {
+        var certificates = SetupServerAuthentication(customSettings: new Dictionary<string, string>
+        {
+            { RavenConfiguration.GetKey(x => x.Indexing.RequireAdminToDeployJavaScriptIndexes), "true"}
+        });
+
+        var dbName = GetDatabaseName();
+        var adminCert = RegisterClientCertificate(certificates.ServerCertificate.Value, certificates.ClientCertificate1.Value, new Dictionary<string, DatabaseAccess>(), SecurityClearance.ClusterAdmin);
+        var userCert = RegisterClientCertificate(certificates.ServerCertificate.Value, certificates.ClientCertificate2.Value, new Dictionary<string, DatabaseAccess>
+        {
+            [dbName] = DatabaseAccess.ReadWrite
+        }, SecurityClearance.ValidUser);
+
+        using (var store = GetDocumentStore(new Options
+               {
+                   AdminCertificate = adminCert, 
+                   ClientCertificate = userCert, 
+                   ModifyDatabaseName = s => dbName,
+               }))
+        {
+            var index = new UsersByName();
+
+            Assert.Throws<AuthorizationException>(() => store.ExecuteIndex(index));
+
+            using (var storeWithAdminCert = new DocumentStore
+                   {
+                       Urls = store.Urls,
+                       Certificate = adminCert,
+                       Database = store.Database
+                   }.Initialize())
+            {
+                storeWithAdminCert.ExecuteIndex(index);
+            }
+        }
+    }
+
+    private class UsersByName : AbstractJavaScriptIndexCreationTask
+    {
+        public UsersByName()
+        {
+            Maps = new HashSet<string>
+            {
+                @"map('Users', function (u){ return { Name: u.Name, Count: 1};})",
+            };
+        }
+    }
+}


### PR DESCRIPTION
### Issue link

https://issues.hibernatingrhinos.com/issue/RavenDB-17577

### Additional description

Config option allowing to restrict deploying JavaScript indexes to admin users only

### Type of change

- New feature

### How risky is the change?

- Low 

### Backward compatibility

- Not relevant

### Is it platform specific issue?

- No

### Documentation update

- This change requires a documentation update. Please mark the issue on YouTrack using `Documentation Required` tag.

### Testing 

- Tests have been added that prove the fix is effective or that the feature works

### Is there any existing behavior change of other features due to this change?

- No

### UI work

- No UI work is needed
