### PR TITLE
RavenDB-18081 - StressTests.Client.TimeSeries.TimeSeriesStress.RapidR…

### DIFF
--- a/src/Raven.Server/Documents/TimeSeries/TimeSeriesStorage.cs
+++ b/src/Raven.Server/Documents/TimeSeries/TimeSeriesStorage.cs
@@ -454,7 +454,8 @@ namespace Raven.Server.Documents.TimeSeries
                                 RemoveTimeSeriesNameFromMetadata(context, slicer.DocId, slicer.Name);
                             }
 
-                            return true;
+                            changeVector = holder.ChangeVector;
+                            return end < to;
                         }
 
                         var segmentChanged = false;
@@ -709,7 +710,7 @@ namespace Raven.Server.Documents.TimeSeries
             // if this segment isn't overlap with any other we can put it directly
             using (var holder = new TimeSeriesSegmentHolder(this, context, documentId, name, collectionName, fromReplicationChangeVector: changeVector, timeStamp: baseline))
             {
-                if (holder.LoadCurrentSegment())
+                if (holder.LoadClosestSegment())
                 {
                     // if we got here it means that `IsOverlapping` is false
                     // but a segment with matching ranges exists 


### PR DESCRIPTION
…etention

### Issue link

https://issues.hibernatingrhinos.com/issue/RavenDB-18081

### Additional description

Following @efratshenhar changes on https://github.com/ravendb/ravendb/pull/13674 - I updated the returned change vector in `DeleteTimestampRange` method for `AppendDeadSegment` path (previously it was `null` because we wrote empty change vector there). In addition, we should also use the new method `LoadClosestSegment` in `TryPutSegmentDirectly`.

### Type of change

- Bug fix

### How risky is the change?

- Low 

### Backward compatibility

- Non breaking change


### Is it platform specific issue?

- No

### Documentation update

- No documentation update is needed 

### Testing 

- It has been verified by manual testing

### Is there any existing behavior change of other features due to this change?

- No

### UI work

- No UI work is needed
