### PR TITLE
RavenDB-17122 Forcing flush of the bulk insert's request stream when doing the initial write.

### DIFF
--- a/test/FastTests/Client/BulkInserts.cs
+++ b/test/FastTests/Client/BulkInserts.cs
@@ -34,16 +34,12 @@ namespace FastTests.Client
             X509Certificate2 adminCertificate = null;
             if (useSsl)
             {
-                Console.WriteLine($"DEBUG: {DateTime.UtcNow} Starting to setup SSL for {nameof(Simple_Bulk_Insert)} test");
                 var certificates = SetupServerAuthentication();
                 adminCertificate = RegisterClientCertificate(certificates.ServerCertificate.Value, certificates.ClientCertificate1.Value, new Dictionary<string, DatabaseAccess>(), SecurityClearance.ClusterAdmin);
                 clientCertificate = RegisterClientCertificate(certificates.ServerCertificate.Value, certificates.ClientCertificate2.Value, new Dictionary<string, DatabaseAccess>
                 {
                     [dbName] = DatabaseAccess.ReadWrite
                 });
-
-                Console.WriteLine($"DEBUG: {DateTime.UtcNow} SSL setup for {nameof(Simple_Bulk_Insert)} test completed");
-
             }
 
             using (var store = GetDocumentStore(new Options

--- a/test/Tests.Infrastructure/TestBase.cs
+++ b/test/Tests.Infrastructure/TestBase.cs
@@ -220,8 +220,6 @@ namespace FastTests
 
                 if (File.Exists(serverCertificatePath) == false)
                 {
-                    Console.WriteLine($"DEBUG: {DateTime.UtcNow} Generating cert file: {serverCertificatePath} (caller: {caller})");
-
                     try
                     {
                         certBytes = CertificateUtils.CreateSelfSignedTestCertificate(Environment.MachineName, "RavenTestsServer", log);
@@ -237,8 +235,6 @@ namespace FastTests
                     try
                     {
                         File.WriteAllBytes(serverCertificatePath, certBytes);
-
-                        Console.WriteLine($"DEBUG: {DateTime.UtcNow} Certificate {serverCertificatePath} generated successfully");
                     }
                     catch (Exception e)
                     {


### PR DESCRIPTION
It seems to help somehow for intermittent failures when using secured connection.

### Issue link

https://issues.hibernatingrhinos.com/issue/RavenDB-17122

### Additional description

0. This is separate PR for 5.2 version since the code is slightly different between 4.2 and 5.2. PR for 4.2 is here: https://github.com/ravendb/ravendb/pull/13775

1. This is the result of trials and errors approach in fixing the occasional failures of `Simple_Bulk_Insert_With_Ssl()` test. It tries to introduce the minimal amount of changes to fix or reduce the number of failures of that test.

More details here:  https://issues.hibernatingrhinos.com/issue/RavenDB-17122#focus=Comments-67-287768.0-0

2. I have moved `FlushIfNeeded()` method _after_ we write a document to make sure we're flushing it as well if needed. Note: on 4.2 it was okay.


### Type of change

- Bug fix

### How risky is the change?

- Low 

### Backward compatibility

- Not relevant

### Is it platform specific issue?

- No

### Documentation update

- No documentation update is needed 

### Testing 

- It has been verified by running multiple builds on Jenkins

### Is there any existing behavior change of other features due to this change?

- No

### UI work

- No UI work is needed
