### PR TITLE
RavenDB-17995 : add some debug info to flaky test

### DIFF
--- a/src/Raven.Server/ServerWide/Maintenance/ClusterObserver.cs
+++ b/src/Raven.Server/ServerWide/Maintenance/ClusterObserver.cs
@@ -1,6 +1,7 @@
 ﻿using System;
 using System.Collections.Concurrent;
 using System.Collections.Generic;
+using System.Diagnostics;
 using System.Linq;
 using System.Text;
 using System.Threading;
@@ -140,6 +141,9 @@ namespace Raven.Server.ServerWide.Maintenance
                 }
                 catch (Exception e)
                 {
+                    Debug.Assert(e.InnerException is not KeyNotFoundException,
+                        $"Got a '{nameof(KeyNotFoundException)}' while analyzing maintenance stats on node {_nodeTag} : {e}");
+
                     LogMessage($"An error occurred while analyzing maintenance stats on node {_nodeTag}.", e);
                 }
                 finally

--- a/src/Raven.Server/ServerWide/Maintenance/ClusterObserver.cs
+++ b/src/Raven.Server/ServerWide/Maintenance/ClusterObserver.cs
@@ -1245,7 +1245,8 @@ namespace Raven.Server.ServerWide.Maintenance
 
                 LogMessage($"Mentor {mentorNode} hasn't sent all of the documents yet to {promotable} (time diff: {timeDiff}, sent etag: {lastSentEtag}/{mentorsEtag})", database: dbName);
 
-                if (msg.Equals(topology.DemotionReasons[promotable]) == false)
+                if (topology.DemotionReasons.TryGetValue(promotable, out var demotionReason) == false ||
+                    msg.Equals(demotionReason) == false)
                 {
                     topology.DemotionReasons[promotable] = msg;
                     topology.PromotablesStatus[promotable] = DatabasePromotionStatus.ChangeVectorNotMerged;

--- a/src/Raven.Server/ServerWide/Maintenance/ClusterObserver.cs
+++ b/src/Raven.Server/ServerWide/Maintenance/ClusterObserver.cs
@@ -106,7 +106,6 @@ namespace Raven.Server.ServerWide.Maintenance
             return (_decisionsLog.ToArray(), _iteration);
         }
 
-
         public void Run(CancellationToken token)
         {
             // we give some time to populate the stats.
@@ -1187,7 +1186,7 @@ namespace Raven.Server.ServerWide.Maintenance
             if (previous.TryGetValue(promotable, out var promotablePrevClusterStats) == false ||
                 promotablePrevClusterStats.Report.TryGetValue(dbName, out var promotablePrevDbStats) == false)
             {
-                LogMessage($"Can't previous stats for node {promotable}", database: dbName);
+                LogMessage($"Can't find previous stats for node {promotable}", database: dbName);
                 return (false, null);
             }
 
@@ -1255,14 +1254,14 @@ namespace Raven.Server.ServerWide.Maintenance
                 return (false, null);
             }
 
-            var indexesCatchedUp = CheckIndexProgress(
+            var indexesCaughtUp = CheckIndexProgress(
                 promotablePrevDbStats.LastEtag,
                 promotablePrevDbStats.LastIndexStats,
                 promotableDbStats.LastIndexStats,
                 mentorCurrDbStats.LastIndexStats,
                 out var reason);
 
-            if (indexesCatchedUp)
+            if (indexesCaughtUp)
             {
                 LogMessage($"We try to promote the database '{dbName}' on {promotable} to be a full member", database: dbName);
 

--- a/test/Tests.Infrastructure/RavenTestBase.cs
+++ b/test/Tests.Infrastructure/RavenTestBase.cs
@@ -728,7 +728,7 @@ namespace FastTests
             Assert.Equal(expectedVal, val);
         }
 
-        private static async Task<T> WaitForPredicateAsync<T>(Predicate<T> predicate, Func<Task<T>> act, int timeout = 15000, int interval = 100)
+        protected static async Task<T> WaitForPredicateAsync<T>(Predicate<T> predicate, Func<Task<T>> act, int timeout = 15000, int interval = 100)
         {
             if (Debugger.IsAttached)
                 timeout *= 100;


### PR DESCRIPTION
### Issue link

https://issues.hibernatingrhinos.com/issue/RavenDB-17995

### Additional description

- add debug info to flaky test `NotInRehabWithDisabledIndexes3`
- fix possible 'KeyNotFound' exception in `ClusterObserver.TryPromote`

### Type of change

- Bug fix
- Tests stabilization

### How risky is the change?

- Low 

### Backward compatibility

- Not relevant

### Is it platform specific issue?

- No

### Documentation update

- No documentation update is needed 

### Is there any existing behavior change of other features due to this change?

- No

### UI work

- No UI work is needed
