### PR TITLE
RavenDB-18191 Allow to see exact map-reduce result which caused a reduce error

### DIFF
--- a/src/Raven.Server/Documents/Indexes/IndexingRunStats.cs
+++ b/src/Raven.Server/Documents/Indexes/IndexingRunStats.cs
@@ -62,9 +62,9 @@ namespace Raven.Server.Documents.Indexes
             AddError(key, message, "MapReference");
         }
 
-        public void AddReduceError(string message)
+        public void AddReduceError(string message, string reduceKey)
         {
-            AddError(null, message, "Reduce");
+            AddError(reduceKey, message, "Reduce");
 
             NumberOfKeptReduceErrors++;
         }

--- a/src/Raven.Server/Documents/Indexes/IndexingStatsAggregator.cs
+++ b/src/Raven.Server/Documents/Indexes/IndexingStatsAggregator.cs
@@ -178,9 +178,9 @@ namespace Raven.Server.Documents.Indexes
             _stats.AddMapReferenceError(key, message);
         }
 
-        public void AddReduceError(string message)
+        public void AddReduceError(string message, string reduceKey = null)
         {
-            _stats.AddReduceError(message);
+            _stats.AddReduceError(message, reduceKey);
         }
 
         public void RecordMapAttempt()

--- a/src/Raven.Server/Documents/Indexes/MapReduce/Auto/ReduceMapResultsOfAutoIndex.cs
+++ b/src/Raven.Server/Documents/Indexes/MapReduce/Auto/ReduceMapResultsOfAutoIndex.cs
@@ -14,10 +14,13 @@ namespace Raven.Server.Documents.Indexes.MapReduce.Auto
 {
     public unsafe class ReduceMapResultsOfAutoIndex : ReduceMapResultsBase<AutoMapReduceIndexDefinition>
     {
+        private BlittableJsonReaderObject _currentlyProcessedResult;
         public ReduceMapResultsOfAutoIndex(Index index, AutoMapReduceIndexDefinition indexDefinition, IndexStorage indexStorage, MetricCounters metrics, MapReduceIndexingContext mapReduceContext)
             : base(index, indexDefinition, indexStorage, metrics, mapReduceContext)
         {
         }
+
+        protected override BlittableJsonReaderObject CurrentlyProcessedResult => _currentlyProcessedResult;
 
         protected override AggregationResult AggregateOn(List<BlittableJsonReaderObject> aggregationBatch, TransactionOperationContext indexContext, IndexingStatsScope stats, CancellationToken token)
         {
@@ -26,6 +29,8 @@ namespace Raven.Server.Documents.Indexes.MapReduce.Auto
             foreach (var obj in aggregationBatch)
             {
                 token.ThrowIfCancellationRequested();
+
+                _currentlyProcessedResult = obj;
 
                 var aggregatedResult = new Dictionary<string, PropertyResult>();
 

--- a/src/Raven.Server/Documents/Indexes/MapReduce/Auto/ReduceMapResultsOfAutoIndex.cs
+++ b/src/Raven.Server/Documents/Indexes/MapReduce/Auto/ReduceMapResultsOfAutoIndex.cs
@@ -22,7 +22,7 @@ namespace Raven.Server.Documents.Indexes.MapReduce.Auto
 
         protected override BlittableJsonReaderObject CurrentlyProcessedResult => _currentlyProcessedResult;
 
-        protected override AggregationResult AggregateOn(List<BlittableJsonReaderObject> aggregationBatch, TransactionOperationContext indexContext, IndexingStatsScope stats, CancellationToken token)
+        protected override AggregationResult AggregateOnImpl(List<BlittableJsonReaderObject> aggregationBatch, TransactionOperationContext indexContext, IndexingStatsScope stats, CancellationToken token)
         {
             var aggregatedResultsByReduceKey = new Dictionary<BlittableJsonReaderObject, Dictionary<string, PropertyResult>>(ReduceKeyComparer.Instance);
 

--- a/src/Raven.Server/Documents/Indexes/MapReduce/ReduceMapResultsBase.cs
+++ b/src/Raven.Server/Documents/Indexes/MapReduce/ReduceMapResultsBase.cs
@@ -633,7 +633,7 @@ namespace Raven.Server.Documents.Indexes.MapReduce
             }
             catch
             {
-                OnErrorResult = CurrentlyProcessedResult.Clone(indexContext);
+                OnErrorResult = CurrentlyProcessedResult?.Clone(indexContext);
                 throw;
             }
         }

--- a/src/Raven.Server/Documents/Indexes/MapReduce/Static/ReduceMapResultsOfStaticIndex.cs
+++ b/src/Raven.Server/Documents/Indexes/MapReduce/Static/ReduceMapResultsOfStaticIndex.cs
@@ -25,7 +25,9 @@ namespace Raven.Server.Documents.Indexes.MapReduce.Static
             _reducingFunc = reducingFunc;
             _indexType = index.Type;
         }
-        
+
+        protected override BlittableJsonReaderObject CurrentlyProcessedResult => _blittableToDynamicWrapper.Current;
+
         protected override AggregationResult AggregateOn(List<BlittableJsonReaderObject> aggregationBatch, TransactionOperationContext indexContext, IndexingStatsScope stats, CancellationToken token)
         {
             _blittableToDynamicWrapper.InitializeForEnumeration(aggregationBatch);
@@ -67,6 +69,8 @@ namespace Raven.Server.Documents.Indexes.MapReduce.Static
             {
                 return GetEnumerator();
             }
+
+            public BlittableJsonReaderObject Current => _enumerator.Current?.BlittableJson;
 
             private class Enumerator : IEnumerator<DynamicBlittableJson>
             {

--- a/src/Raven.Server/Documents/Indexes/MapReduce/Static/ReduceMapResultsOfStaticIndex.cs
+++ b/src/Raven.Server/Documents/Indexes/MapReduce/Static/ReduceMapResultsOfStaticIndex.cs
@@ -28,7 +28,7 @@ namespace Raven.Server.Documents.Indexes.MapReduce.Static
 
         protected override BlittableJsonReaderObject CurrentlyProcessedResult => _blittableToDynamicWrapper.Current;
 
-        protected override AggregationResult AggregateOn(List<BlittableJsonReaderObject> aggregationBatch, TransactionOperationContext indexContext, IndexingStatsScope stats, CancellationToken token)
+        protected override AggregationResult AggregateOnImpl(List<BlittableJsonReaderObject> aggregationBatch, TransactionOperationContext indexContext, IndexingStatsScope stats, CancellationToken token)
         {
             _blittableToDynamicWrapper.InitializeForEnumeration(aggregationBatch);
             

--- a/test/SlowTests/Issues/RavenDB_18331.cs
+++ b/test/SlowTests/Issues/RavenDB_18331.cs
@@ -1,0 +1,116 @@
+﻿using System;
+using System.Collections.Generic;
+using System.Linq;
+using System.Threading;
+using FastTests;
+using Raven.Client;
+using Raven.Client.Documents.Indexes;
+using Raven.Server.Documents;
+using Raven.Server.Documents.Indexes;
+using Raven.Server.Documents.Indexes.MapReduce.Exceptions;
+using Raven.Server.Documents.Indexes.MapReduce.Static;
+using Raven.Server.ServerWide.Context;
+using Sparrow.Json.Parsing;
+using Xunit;
+using Xunit.Abstractions;
+
+namespace SlowTests.Issues;
+
+public class RavenDB_18331 : RavenLowLevelTestBase
+{
+    public RavenDB_18331(ITestOutputHelper output) : base(output)
+    {
+    }
+
+    [Fact]
+    public void ErrorShouldIncludeTheActualItemAndReduceKey()
+    {
+        var numberOfDocs = 100;
+
+        using (var database = CreateDocumentDatabase())
+        {
+            using (var index = MapReduceIndex.CreateNew<MapReduceIndex>(new IndexDefinition()
+            {
+                Name = "Users_DivideByZero",
+                Maps = { @"from order in docs.Orders
+from line in order.Lines
+select new { Product = line.Product, FakeValue = 0 }" },
+                Reduce = @"from result in mapResults
+group result by result.Product into g
+select new
+{
+    Product = g.Key,
+    FakeValue = (long) (128 / g.Sum(x=> x.Total) - g.Sum(x=> x.Count))
+}",
+            }, database))
+            {
+                using (var context = DocumentsOperationContext.ShortTermSingleUse(database))
+                {
+                    for (int i = 0; i < numberOfDocs; i++)
+                    {
+                        var order = CreateOrder();
+                        PutOrder(database, order, context, i);
+                    }
+
+                    var stats = new IndexingRunStats();
+                    var scope = new IndexingStatsScope(stats);
+
+                    var cts = new CancellationTokenSource(TimeSpan.FromSeconds(60));
+
+                    try
+                    {
+                        index.DoIndexingWork(scope, cts.Token);
+                    }
+                    catch (ExcessiveNumberOfReduceErrorsException)
+                    {
+                        // expected
+                    }
+
+                    List<IndexingError> indexingErrors = stats.Errors;
+
+                    Assert.Equal(1, indexingErrors.Count);
+                    Assert.Contains(@"current item to reduce: {""Product"":""Milk"",""FakeValue"":0}", indexingErrors.First().Error);
+                    Assert.Equal(@"Reduce key: { 'Product' : Milk }", indexingErrors.First().Document);
+                }
+            }
+        }
+    }
+
+    private static DynamicJsonValue CreateOrder()
+    {
+        return new DynamicJsonValue
+        {
+            ["RefNumber"] = "123",
+            ["Lines"] = new DynamicJsonArray
+            {
+                new DynamicJsonValue
+                {
+                    ["Product"] = "Milk",
+                    ["Price"] = 1
+                },
+                new DynamicJsonValue
+                {
+                    ["Product"] = "Bread",
+                    ["Price"] = 1
+                }
+            },
+            [Constants.Documents.Metadata.Key] = new DynamicJsonValue
+            {
+                [Constants.Documents.Metadata.Collection] = "Orders"
+            }
+        };
+    }
+
+    private static void PutOrder(DocumentDatabase database, DynamicJsonValue dynamicOrder, DocumentsOperationContext context, int number)
+    {
+        using (var tx = context.OpenWriteTransaction())
+        {
+            using (var doc = CreateDocument(context, $"orders/{number}", dynamicOrder))
+            {
+                database.DocumentsStorage.Put(context, $"orders/{number}", null, doc);
+            }
+
+            tx.Commit();
+        }
+    }
+}


### PR DESCRIPTION
### Issue link

https://issues.hibernatingrhinos.com/issue/RavenDB-18191
https://issues.hibernatingrhinos.com/issue/RavenDB-18331

### Additional description

1) When throwing reduce error try to get the currently processed item. If we won't get it the fallback to a sample item from the aggregation batch.

2) Adding reduce key value as `Document` property of index error so it will be show in the studio

### Type of change

- Error enhancement

### How risky is the change?

- Low 

### Backward compatibility

- Not relevant

### Is it platform specific issue?

- No

### Documentation update

- No documentation update is needed 

### Testing 

- Unit test added

### Is there any existing behavior change of other features due to this change?

- No

### UI work

- No UI work is needed
