### PR TITLE
RavenDB-18059 Fixing the race condition between the backup and JournalApplicator.UpdateDatabaseStateAfterSync()

### DIFF
--- a/src/Voron/Impl/Backup/FullBackup.cs
+++ b/src/Voron/Impl/Backup/FullBackup.cs
@@ -98,8 +98,8 @@ namespace Voron.Impl.Backup
                 long allocatedPages;
                 var writePersistentContext = new TransactionPersistentContext(true);
                 var readPersistentContext = new TransactionPersistentContext(true);
-                using (var txw = env.NewLowLevelTransaction(writePersistentContext, TransactionFlags.ReadWrite)) // so no new journal files will be created
                 using (env.Journal.Applicator.TakeFlushingLock()) // prevent from running JournalApplicator.UpdateDatabaseStateAfterSync() concurrently
+                using (var txw = env.NewLowLevelTransaction(writePersistentContext, TransactionFlags.ReadWrite)) // so no new journal files will be created
                 {
                     txr = env.NewLowLevelTransaction(readPersistentContext, TransactionFlags.Read);// now have snapshot view
                     allocatedPages = dataPager.NumberOfAllocatedPages;

--- a/src/Voron/Impl/FileHeaders/HeaderAccessor.cs
+++ b/src/Voron/Impl/FileHeaders/HeaderAccessor.cs
@@ -264,7 +264,7 @@ namespace Voron.Impl.FileHeaders
             return header->Hash == CalculateFileHeaderHash(header);
         }
 
-        public void CopyHeaders(CompressionLevel compressionLevel, ZipArchive package, DataCopier copier, StorageEnvironmentOptions envOptions, string basePath)
+        public JournalInfo CopyHeaders(CompressionLevel compressionLevel, ZipArchive package, DataCopier copier, StorageEnvironmentOptions envOptions, string basePath)
         {
             _locker.EnterReadLock(); //race between reading the headers while modifying them
             try
@@ -289,6 +289,8 @@ namespace Voron.Impl.FileHeaders
 
                 if (!success)
                     throw new InvalidDataException($"Failed to read both file headers (headers.one & headers.two) from path: {basePath}, possible corruption.");
+
+                return _theHeader->Journal;
             }
             finally
             {

--- a/src/Voron/StorageEnvironment.cs
+++ b/src/Voron/StorageEnvironment.cs
@@ -83,7 +83,7 @@ namespace Voron
 
         private readonly WriteAheadJournal _journal;
         private readonly SemaphoreSlim _transactionWriter = new SemaphoreSlim(1, 1);
-        private NativeMemory.ThreadStats _currentWriteTransactionHolder;
+        internal NativeMemory.ThreadStats _currentWriteTransactionHolder;
         private readonly AsyncManualResetEvent _writeTransactionRunning = new AsyncManualResetEvent();
         internal readonly ThreadHoppingReaderWriterLock FlushInProgressLock = new ThreadHoppingReaderWriterLock();
         private readonly ReaderWriterLockSlim _txCreation = new ReaderWriterLockSlim();

--- a/src/Voron/StorageEnvironment.cs
+++ b/src/Voron/StorageEnvironment.cs
@@ -1438,6 +1438,21 @@ namespace Voron
         {
             throw new InvalidOperationException("Simulation of db creation failure");
         }
+
+        internal TestingStuff _forTestingPurposes;
+
+        internal TestingStuff ForTestingPurposesOnly()
+        {
+            if (_forTestingPurposes != null)
+                return _forTestingPurposes;
+
+            return _forTestingPurposes = new TestingStuff();
+        }
+
+        internal class TestingStuff
+        {
+            internal Action ActionToCallDuringFullBackupRighAfterCopyHeaders;
+        }
     }
     
     public class StorageEnvironmentWithType

--- a/test/SlowTests/Issues/RavenDB_18059.cs
+++ b/test/SlowTests/Issues/RavenDB_18059.cs
@@ -1,0 +1,95 @@
+﻿using System;
+using System.IO;
+using System.Threading;
+using FastTests.Voron;
+using Voron;
+using Voron.Global;
+using Voron.Impl.Backup;
+using Voron.Impl.Journal;
+using Voron.Util.Settings;
+using Xunit;
+using Xunit.Abstractions;
+
+namespace SlowTests.Issues;
+
+public class RavenDB_18059 : StorageTest
+{
+    public RavenDB_18059(ITestOutputHelper output) : base(output)
+    {
+    }
+
+    protected override void Configure(StorageEnvironmentOptions options)
+    {
+        options.MaxLogFileSize = 1000 * Constants.Storage.PageSize;
+        options.ManualFlushing = true;
+        options.ManualSyncing = true;
+    }
+
+    [Fact]
+    public void RaceConditionBetweenFullBackupAndUpdateDatabaseStateAfterSync()
+    {
+        RequireFileBasedPager();
+        var random = new Random(2);
+        var buffer = new byte[8192];
+        random.NextBytes(buffer);
+
+        using (var tx = Env.WriteTransaction())
+        {
+            var tree = tx.CreateTree("foo");
+            for (int i = 0; i < 5000; i++)
+            {
+                tree.Add("items/" + i, new MemoryStream(buffer));
+            }
+
+            tx.Commit();
+        }
+
+        Assert.True(Env.Journal.Files.Count > 1);
+
+        Env.FlushLogToDataFile(); // force writing data to the data file
+
+        var voronDataDir = new VoronPathSetting(DataDir);
+
+        Env.ForTestingPurposesOnly().ActionToCallDuringFullBackupRighAfterCopyHeaders += () =>
+        {
+            // here we remove 0000000000000000000.journal file while during backup we'll try to backup it
+
+            Thread syncOperation = new Thread(() =>
+            {
+                using (var operation = new WriteAheadJournal.JournalApplicator.SyncOperation(Env.Journal.Applicator))
+                {
+                    var syncResult = operation.SyncDataFile();
+
+                    Assert.True(syncResult);
+                }
+            });
+
+            syncOperation.Start();
+
+            Assert.False(syncOperation.Join(TimeSpan.FromSeconds(5)));
+        };
+
+        BackupMethods.Full.ToFile(Env, voronDataDir.Combine("voron-test.backup"));
+
+        BackupMethods.Full.Restore(voronDataDir.Combine("voron-test.backup"), voronDataDir.Combine("backup-test.data"));
+
+        var options = StorageEnvironmentOptions.ForPath(Path.Combine(DataDir, "backup-test.data"));
+        options.MaxLogFileSize = Env.Options.MaxLogFileSize;
+
+        using (var env = new StorageEnvironment(options))
+        {
+            using (var tx = env.ReadTransaction())
+            {
+                var tree = tx.CreateTree("foo");
+                for (int i = 0; i < 5000; i++)
+                {
+                    var readResult = tree.Read("items/" + i);
+                    Assert.NotNull(readResult);
+                    var memoryStream = new MemoryStream();
+                    readResult.Reader.CopyTo(memoryStream);
+                    Assert.Equal(memoryStream.ToArray(), buffer);
+                }
+            }
+        }
+    }
+}


### PR DESCRIPTION
The problem was during UpdateDatabaseStateAfterSync() we could delete unused journals that were still required for backup based on the info from the headers.

### Issue link

https://issues.hibernatingrhinos.com/issue/RavenDB-18059

### Additional description

The issue was discovered by occasionally failing backup test (RavenDB-17964). First attempt to fix it in https://github.com/ravendb/ravendb/pull/13652 solved the problem partially (`The process cannot access the file '...\headers.one` was fixed) but we still had the problem with the following error during backup:

`Voron.Exceptions.InvalidJournalException: No such journal '...\Journals\0000000000000000001.journal'.`

Also during the investigation I got another problem:

```
System.InvalidOperationException: Errno: 32='The process cannot access the file because it is being used by another process.
' (rc=0) - 'Attempted to open journal file - Path: C:\workspace\ravendb-5.2\test\Tryouts\bin\Release\net6.0\Databases\can_backup_and_restore_snapshot_with_compression_54.0-110\Journals\0000000000000000002.journal Size :262144'. FailCode=FailOpenFile.
   at Sparrow.Server.Platform.PalHelper.ThrowLastError(FailCodes rc, Int32 lastError, String msg) in C:\workspace\ravendb-5.2\src\Sparrow.Server\Platform\PalHelper.cs:line 38
   at Voron.Impl.Journal.JournalWriter..ctor(StorageEnvironmentOptions options, VoronPathSetting filename, Int64 size, JournalMode mode) in C:\workspace\ravendb-5.2\src\Voron\Impl\Journal\JournalWriter.cs:line 49
   at Voron.StorageEnvironmentOptions.DirectoryStorageEnvironmentOptions.<>c__DisplayClass19_0.<CreateJournalWriter>b__1() in C:\workspace\ravendb-5.2\src\Voron\StorageEnvironmentOptions.cs:line 510
   at System.Lazy`1.ViaFactory(LazyThreadSafetyMode mode)
   at System.Lazy`1.ExecutionAndPublication(LazyHelper executionAndPublication, Boolean useDefaultConstructor)
   at System.Lazy`1.CreateValue()
   at Sparrow.Utils.LazyWithExceptionRetry`1.get_Value() in C:\workspace\ravendb-5.2\src\Sparrow\Utils\LazyWithExceptionRetry.cs:line 40
   at Voron.StorageEnvironmentOptions.DirectoryStorageEnvironmentOptions.CreateJournalWriter(Int64 journalNumber, Int64 journalSize) in C:\workspace\ravendb-5.2\src\Voron\StorageEnvironmentOptions.cs:line 516
   at Voron.Impl.Backup.FullBackup.Backup(StorageEnvironment env, CompressionLevel compressionLevel, AbstractPager dataPager, ZipArchive package, String basePath, DataCopier copier, Action`1 infoNotify, CancellationToken cancellationToken)
   at Voron.Impl.Backup.FullBackup.ToFile(IEnumerable`1 envs, ZipArchive archive, CompressionLevel compressionLevel, Action`1 infoNotify, CancellationToken cancellationToken) in C:\workspace\ravendb-5.2\src\Voron\Impl\Backup\FullBackup.cs:line 73

```

after the fix we no longer experience that as well.

NOTE: From now on we'll be taking additional lock when doing snapshot backup. But it's going to last very short so it's not an issue (note that we were already take the write tx lock).

### Type of change

- Bug fix

### How risky is the change?

- Moderate

### Backward compatibility


- Not relevant

### Is it platform specific issue?

- No

### Documentation update

- No documentation update is needed 

### Testing 

- Tests have been added that prove the fix is effective or that the feature works
- It has been verified by manual testing

### Is there any existing behavior change of other features due to this change?

- No

### UI work

- No UI work is needed
