### PR TITLE
RavenDB-18293 disable TCP Compression on macOS if ZSTD cannot be loaded

### DIFF
--- a/src/Raven.Client/Documents/Conventions/DocumentConventions.cs
+++ b/src/Raven.Client/Documents/Conventions/DocumentConventions.cs
@@ -47,7 +47,7 @@ namespace Raven.Client.Documents.Conventions
             MaxContextSizeToKeep = new Size(PlatformDetails.Is32Bits == false ? 8 : 2, SizeUnit.Megabytes)
         };
 
-        private static readonly bool DefaultDisableTcpCompression;
+        private static readonly bool DefaultDisableTcpCompression = false;
 
         private static Dictionary<Type, string> CachedDefaultTypeCollectionNames = new Dictionary<Type, string>();
 

--- a/src/Raven.Client/Documents/Conventions/DocumentConventions.cs
+++ b/src/Raven.Client/Documents/Conventions/DocumentConventions.cs
@@ -6,6 +6,7 @@ using System.Linq;
 using System.Linq.Expressions;
 using System.Reflection;
 using System.Runtime.CompilerServices;
+using System.Runtime.InteropServices;
 using System.Text;
 using System.Threading.Tasks;
 using Microsoft.CSharp.RuntimeBinder;
@@ -21,6 +22,7 @@ using Raven.Client.Util;
 using Sparrow;
 using Sparrow.Json;
 using Sparrow.Platform;
+using Sparrow.Utils;
 using Size = Sparrow.Size;
 
 namespace Raven.Client.Documents.Conventions
@@ -45,7 +47,9 @@ namespace Raven.Client.Documents.Conventions
             MaxContextSizeToKeep = new Size(PlatformDetails.Is32Bits == false ? 8 : 2, SizeUnit.Megabytes)
         };
 
-        private static Dictionary<Type, string> _cachedDefaultTypeCollectionNames = new Dictionary<Type, string>();
+        private static readonly bool DefaultDisableTcpCompression;
+
+        private static Dictionary<Type, string> CachedDefaultTypeCollectionNames = new Dictionary<Type, string>();
 
         private readonly Dictionary<MemberInfo, CustomQueryTranslator> _customQueryTranslators = new Dictionary<MemberInfo, CustomQueryTranslator>();
 
@@ -147,6 +151,20 @@ namespace Raven.Client.Documents.Conventions
 
         static DocumentConventions()
         {
+#if NETCOREAPP3_1_OR_GREATER
+            if (RuntimeInformation.IsOSPlatform(OSPlatform.OSX))
+            {
+                try
+                {
+                    ZstdLib.GetMaxCompression(1);
+                }
+                catch
+                {
+                    DefaultDisableTcpCompression = true;
+                }
+            }
+#endif
+
             Default.Freeze();
             DefaultForServer.Freeze();
         }
@@ -208,6 +226,8 @@ namespace Raven.Client.Documents.Conventions
             _maxContextSizeToKeep = PlatformDetails.Is32Bits == false
                 ? new Size(1, SizeUnit.Megabytes)
                 : new Size(256, SizeUnit.Kilobytes);
+
+            _disableTcpCompression = DefaultDisableTcpCompression;
         }
 
         private bool _frozen;
@@ -838,7 +858,7 @@ namespace Raven.Client.Documents.Conventions
         /// </summary>
         public static string DefaultGetCollectionName(Type t)
         {
-            if (_cachedDefaultTypeCollectionNames.TryGetValue(t, out var result))
+            if (CachedDefaultTypeCollectionNames.TryGetValue(t, out var result))
                 return result;
 
             if (t.Name.Contains("<>"))
@@ -874,12 +894,12 @@ namespace Raven.Client.Documents.Conventions
                 result = Inflector.Pluralize(t.Name);
             }
 
-            var temp = new Dictionary<Type, string>(_cachedDefaultTypeCollectionNames)
+            var temp = new Dictionary<Type, string>(CachedDefaultTypeCollectionNames)
             {
                 [t] = result
             };
 
-            _cachedDefaultTypeCollectionNames = temp;
+            CachedDefaultTypeCollectionNames = temp;
             return result;
         }
 
@@ -1106,11 +1126,11 @@ namespace Raven.Client.Documents.Conventions
             // multiple capital letters, so probably something that we want to preserve caps on.
             return collectionName;
         }
-        
+
         public static string DefaultFindPropertyNameForIndex(Type indexedType, string indexedName, string path, string prop) => (path + prop).Replace("[].", "_").Replace(".", "_");
-        
+
         public static string DefaultFindPropertyNameForDynamicIndex(Type indexedType, string indexedName, string path, string prop) => path + prop;
-        
+
         private static IEnumerable<MemberInfo> GetPropertiesForType(Type type)
         {
             foreach (var propertyInfo in ReflectionUtil.GetPropertiesAndFieldsFor(type, BindingFlags.Public | BindingFlags.Instance | BindingFlags.NonPublic))

--- a/test/Tests.Infrastructure/Utils/TestOutcomeAnalyzer.cs
+++ b/test/Tests.Infrastructure/Utils/TestOutcomeAnalyzer.cs
@@ -18,7 +18,7 @@ namespace Tests.Infrastructure.Utils
             new Regex(@"Something is wrong, throwing to avoid hanging", RegexOptions.Compiled),
             new Regex(@"Waited for \S* but the command was not applied in this time.", RegexOptions.Compiled)
         };
-        
+
         private readonly Context _context;
 
         public TestOutcomeAnalyzer(Context context)
@@ -48,12 +48,13 @@ namespace Tests.Infrastructure.Utils
 
         public bool ShouldSaveDebugPackage()
         {
+            return false;
+
+            /*
             var exception = Exception;
 
             if (exception == null)
                 return false;
-
-            return false;
 
             if (NightlyBuildTheoryAttribute.IsNightlyBuild)
                 return true;
@@ -67,6 +68,7 @@ namespace Tests.Infrastructure.Utils
                 return false;
 
             return TimeoutExceptionMessageRegexes.Any(r => r.IsMatch(innerException.Message));
+            */
         }
     }
 }


### PR DESCRIPTION
### Issue link

https://issues.hibernatingrhinos.com/issue/RavenDB-18293

### Additional description

We do not have ZSTD for Apple Sillicon, so we are checking on macOS if we can load zstd, if not then tcp compression is disabled by default on that platform.

### Type of change

- Bug fix

### How risky is the change?

- Low 

### Backward compatibility

- Not relevant

### Is it platform specific issue?

- Yes. macOS

### Documentation update

- No documentation update is needed 

### Testing 

- It has been verified by manual testing

### Is there any existing behavior change of other features due to this change?

- No

### UI work

- No UI work is needed
