### PR TITLE
RavenDB-18300 Adding debug info to the exception message when a committed and flushed transaction was not found in ActiveTransactions

### DIFF
--- a/src/Voron/StorageEnvironment.cs
+++ b/src/Voron/StorageEnvironment.cs
@@ -753,7 +753,7 @@ namespace Voron
 
         private void ThrowCommittedAndFlushedTransactionNotFoundInActiveOnes(LowLevelTransaction llt)
         {
-            throw new InvalidOperationException($"The transaction with ID '{llt.Id}' got committed and flushed but it wasn't found in the {nameof(ActiveTransactions)}");
+            throw new InvalidOperationException($"The transaction with ID '{llt.Id}' got committed and flushed but it wasn't found in the {nameof(ActiveTransactions)}. (Debug details: tx id of {nameof(llt.ActiveTransactionNode)} - {llt.ActiveTransactionNode?.Value?.Id}");
         }
 
         internal void WriteTransactionStarted()


### PR DESCRIPTION
### Issue link

https://issues.hibernatingrhinos.com/issue/RavenDB-18300

### Additional description

Including important detail about the transaction which was not found in ActiveTransactions. 

### Type of change

- Exception message improvement

### How risky is the change?

- Low 

### Backward compatibility

- Not relevant

### Is it platform specific issue?

- No

### Documentation update

- No documentation update is needed 

### Testing 

- Not applicable 

### Is there any existing behavior change of other features due to this change?

- No

### UI work

- No UI work is needed
