### PR TITLE
RavenDB-18307 - Error getting a report by the ClusterObserver

### DIFF
--- a/src/Raven.Server/ServerWide/Maintenance/ClusterMaintenanceSupervisor.cs
+++ b/src/Raven.Server/ServerWide/Maintenance/ClusterMaintenanceSupervisor.cs
@@ -277,8 +277,9 @@ namespace Raven.Server.ServerWide.Maintenance
                         var stream = connection.Stream;
                         using (tcpClient)
                         using (_cts.Token.Register(tcpClient.Dispose))
-                        using (_contextPool.AllocateOperationContext(out JsonOperationContext context))
-                        using (context.GetMemoryBuffer(out var readBuffer))
+                        using (_contextPool.AllocateOperationContext(out JsonOperationContext contextForParsing))
+                        using (_contextPool.AllocateOperationContext(out JsonOperationContext contextForBuffer))
+                        using (contextForBuffer.GetMemoryBuffer(out var readBuffer))
                         using (var timeoutEvent = new TimeoutEvent(receiveFromWorkerTimeout, $"Timeout event for: {_name}", singleShot: false))
                         {
                             timeoutEvent.Start(OnTimeout);
@@ -286,14 +287,14 @@ namespace Raven.Server.ServerWide.Maintenance
 
                             while (_token.IsCancellationRequested == false)
                             {
-                                context.Reset();
-                                context.Renew();
+                                contextForParsing.Reset();
+                                contextForParsing.Renew();
                                 BlittableJsonReaderObject rawReport;
                                 try
                                 {
                                     // even if there is a timeout event, we will keep waiting on the same connection until the TCP timeout occurs.
 
-                                    rawReport = context.Sync.ParseToMemory(stream, _readStatusUpdateDebugString, BlittableJsonDocumentBuilder.UsageMode.None, readBuffer);
+                                    rawReport = contextForParsing.Sync.ParseToMemory(stream, _readStatusUpdateDebugString, BlittableJsonDocumentBuilder.UsageMode.None, readBuffer);
                                     timeoutEvent.Defer(_parent._leaderClusterTag);
                                 }
                                 catch (Exception e)

--- a/test/SlowTests/Cluster/ClusterMaintenanceTest.cs
+++ b/test/SlowTests/Cluster/ClusterMaintenanceTest.cs
@@ -77,7 +77,7 @@ namespace SlowTests.Cluster
                     }
                 });
 
-                for (int i = 0; i < 100; i++)
+                for (int i = 0; i < 25; i++)
                 {
                     if (task.IsFaulted)
                         await task;
@@ -86,7 +86,6 @@ namespace SlowTests.Cluster
                     {
                         var name = GetDatabaseName(new string('a', i));
                         await store.Maintenance.Server.SendAsync(new CreateDatabaseOperation(new DatabaseRecord(name), 2));
-                        await store.Maintenance.ForDatabase(name).SendAsync(new CreateSampleDataOperation());
                     }
                     catch (ConcurrencyException)
                     {

--- a/test/SlowTests/Cluster/ClusterMaintenanceTest.cs
+++ b/test/SlowTests/Cluster/ClusterMaintenanceTest.cs
@@ -7,14 +7,12 @@ using System.Runtime.CompilerServices;
 using System.Text;
 using System.Threading;
 using System.Threading.Tasks;
-using FastTests.Server.Replication;
 using Raven.Client.Exceptions;
 using Raven.Client.ServerWide;
 using Raven.Client.ServerWide.Operations;
 using Raven.Server;
 using Raven.Server.Config;
 using Tests.Infrastructure;
-using Xunit;
 using Xunit.Abstractions;
 
 namespace SlowTests.Cluster
@@ -79,7 +77,7 @@ namespace SlowTests.Cluster
                     }
                 });
 
-                for (int i = 0; i < 25; i++)
+                for (int i = 0; i < 100; i++)
                 {
                     if (task.IsFaulted)
                         await task;
@@ -88,7 +86,7 @@ namespace SlowTests.Cluster
                     {
                         var name = GetDatabaseName(new string('a', i));
                         await store.Maintenance.Server.SendAsync(new CreateDatabaseOperation(new DatabaseRecord(name), 2));
-                        //     await store.Maintenance.ForDatabase(name).SendAsync(new CreateSampleDataOperation());
+                        await store.Maintenance.ForDatabase(name).SendAsync(new CreateSampleDataOperation());
                     }
                     catch (ConcurrencyException)
                     {
@@ -98,8 +96,6 @@ namespace SlowTests.Cluster
 
                 client.Dispose();
                 await task;
-
-                WaitForUserToContinueTheTest(store);
             }
         }
 


### PR DESCRIPTION
### Issue link

https://issues.hibernatingrhinos.com/issue/RavenDB-18307

### Additional description

Use the same buffer while we keep receiving the report from the same stream.

### Type of change

- Bug fix

### How risky is the change?

- Low 

### Testing 

- Tests have been added that prove the fix is effective or that the feature works