### PR TITLE
RavenDB-18173 - Region seems to be ignored when using backup to S3

### DIFF
--- a/src/Raven.Server/Documents/PeriodicBackup/Aws/RavenAwsS3Client.cs
+++ b/src/Raven.Server/Documents/PeriodicBackup/Aws/RavenAwsS3Client.cs
@@ -63,6 +63,12 @@ namespace Raven.Server.Documents.PeriodicBackup.Aws
             }
             else
             {
+                if (string.IsNullOrWhiteSpace(s3Settings.AwsRegionName) == false)
+                {
+                    // region for custom server url isn't mandatory
+                    config.RegionEndpoint = RegionEndpoint.GetBySystemName(s3Settings.AwsRegionName);
+                }
+
                 _usingCustomServerUrl = true;
                 config.UseHttp = true;
                 config.ForcePathStyle = s3Settings.ForcePathStyle;
@@ -76,6 +82,7 @@ namespace Raven.Server.Documents.PeriodicBackup.Aws
                 credentials = new SessionAWSCredentials(s3Settings.AwsAccessKey, s3Settings.AwsSecretKey, s3Settings.AwsSessionToken);
 
             _client = new AmazonS3Client(credentials, config);
+
             _bucketName = s3Settings.BucketName;
             RemoteFolderName = s3Settings.RemoteFolderName;
             Region = s3Settings.AwsRegionName == null ? string.Empty : s3Settings.AwsRegionName.ToLower();

--- a/test/SlowTests/Server/Documents/PeriodicBackup/Aws.cs
+++ b/test/SlowTests/Server/Documents/PeriodicBackup/Aws.cs
@@ -155,6 +155,19 @@ namespace SlowTests.Server.Documents.PeriodicBackup
             }
         }
 
+        [AmazonS3Theory]
+        [InlineData(null)]
+        [InlineData("https://some-url.com")]
+        public void can_use_custom_region(string customUrl)
+        {
+            var settings = GetS3Settings();
+            settings.AwsRegionName = "fr-par";
+            settings.CustomServerUrl = customUrl;
+            using (new RavenAwsS3Client(settings, DefaultConfiguration))
+            {
+            }
+        }
+
         [AmazonGlacierTheory]
         [InlineData(EastRegion1)]
         [InlineData(WestRegion2)]


### PR DESCRIPTION
### Issue link

https://issues.hibernatingrhinos.com/issue/RavenDB-18173

### Additional description

Region is ignored when using backup to S3

### Type of change

- Bug fix

### How risky is the change?

- Low 

### Testing 

- It has been verified by manual testing