### PR TITLE
RavenDB-18269 Always show the Replace License button in the about page

### DIFF
--- a/src/Raven.Studio/wwwroot/App/views/shell/about.html
+++ b/src/Raven.Studio/wwwroot/App/views/shell/about.html
@@ -216,7 +216,6 @@
                     <!-- ko if: registered() -->
                     <button class="btn btn-primary flex-grow"
                             data-bind="click: register, 
-                                       visible: accessManager.canReplaceLicense,
                                        enable: isReplaceLicenseEnabled,
                                        attr: { title: replaceTooltip }">
                             <i class="icon-replace"></i><span>REPLACE LICENSE</span>


### PR DESCRIPTION
### Issue link
https://issues.hibernatingrhinos.com/issue/RavenDB-18269

### Additional description
Always show the REPLACE LICENSE btn 
Disable with tooltip for non-admin access

### Type of change
- Bug fix

### How risky is the change?
- Low 

### Backward compatibility
- Non breaking change

### Is it platform specific issue?
- No

### Documentation update
- No documentation update is needed 

### Testing 
- It has been verified by manual testing

### Is there any existing behavior change of other features due to this change?
- No

### UI work
- No UI work is needed
