### PR TITLE
RavenDB-18199 fix ShardedDocumentHandler when not passing ids

### DIFF
--- a/src/Raven.Server/Documents/Handlers/BatchHandler.cs
+++ b/src/Raven.Server/Documents/Handlers/BatchHandler.cs
@@ -57,12 +57,12 @@ namespace Raven.Server.Documents.Handlers
                     if (contentType == null ||
                         contentType.StartsWith("application/json", StringComparison.OrdinalIgnoreCase))
                     {
-                        await commandBuilder.BuildCommandsAsync(context, RequestBodyStream());
+                        await commandBuilder.BuildCommandsAsync(context, RequestBodyStream(), Database.IdentityPartsSeparator);
                     }
                     else if (contentType.StartsWith("multipart/mixed", StringComparison.OrdinalIgnoreCase) ||
                              contentType.StartsWith("multipart/form-data", StringComparison.OrdinalIgnoreCase))
                     {
-                        await commandBuilder.ParseMultipart(context, RequestBodyStream(), HttpContext.Request.ContentType);
+                        await commandBuilder.ParseMultipart(context, RequestBodyStream(), HttpContext.Request.ContentType, Database.IdentityPartsSeparator);
                     }
                     else
                         ThrowNotSupportedType(contentType);
@@ -76,7 +76,7 @@ namespace Raven.Server.Documents.Handlers
                         AddStringToHttpContext(log, TrafficWatchChangeType.BulkDocs);
                     }
                 }
-                
+
                 using (var command = await commandBuilder.GetCommand(context))
                 {
                     if (command.IsClusterTransaction)

--- a/src/Raven.Server/Documents/Handlers/BatchRequestParser.cs
+++ b/src/Raven.Server/Documents/Handlers/BatchRequestParser.cs
@@ -247,7 +247,7 @@ namespace Raven.Server.Documents.Handlers
                 return ReadSingleCommand(ctx, stream, state, parser, buffer, modifier, token);
             }
 
-            public async Task BuildCommandsAsync(JsonOperationContext context, Stream stream, char separator = '/')
+            public async Task BuildCommandsAsync(JsonOperationContext context, Stream stream, char separator)
             {
                 var state = new JsonParserState();
                 using (context.GetMemoryBuffer(out JsonOperationContext.MemoryBuffer buffer))
@@ -358,7 +358,7 @@ namespace Raven.Server.Documents.Handlers
                 return commandData.Type == CommandType.PUT && string.IsNullOrEmpty(commandData.Id) == false && commandData.Id[^1] == '|';
             }
 
-            public async Task ParseMultipart(JsonOperationContext context, Stream stream, string contentType)
+            public async Task ParseMultipart(JsonOperationContext context, Stream stream, string contentType, char separator)
             {
                 var boundary = MultipartRequestHelper.GetBoundary(
                     MediaTypeHeaderValue.Parse(contentType),
@@ -373,7 +373,7 @@ namespace Raven.Server.Documents.Handlers
                     var bodyStream = Handler.GetBodyStream(section);
                     if (i == 0)
                     {
-                        await BuildCommandsAsync(context, bodyStream);
+                        await BuildCommandsAsync(context, bodyStream, separator);
                         continue;
                     }
 

--- a/src/Raven.Server/Documents/Sharding/Handlers/ShardedBatchHandler.cs
+++ b/src/Raven.Server/Documents/Sharding/Handlers/ShardedBatchHandler.cs
@@ -41,12 +41,12 @@ namespace Raven.Server.Documents.Sharding.Handlers
                 if (contentType == null ||
                     contentType.StartsWith("application/json", StringComparison.OrdinalIgnoreCase))
                 {
-                    await commandBuilder.BuildCommandsAsync(context, RequestBodyStream());
+                    await commandBuilder.BuildCommandsAsync(context, RequestBodyStream(), ShardedContext.IdentitySeparator);
                 }
                 else if (contentType.StartsWith("multipart/mixed", StringComparison.OrdinalIgnoreCase) ||
                          contentType.StartsWith("multipart/form-data", StringComparison.OrdinalIgnoreCase))
                 {
-                    await commandBuilder.ParseMultipart(context, RequestBodyStream(), HttpContext.Request.ContentType);
+                    await commandBuilder.ParseMultipart(context, RequestBodyStream(), HttpContext.Request.ContentType, ShardedContext.IdentitySeparator);
                 }
                 else
                     BatchHandler.ThrowNotSupportedType(contentType);

--- a/src/Raven.Server/Documents/Sharding/Operations/IShardedOperation.cs
+++ b/src/Raven.Server/Documents/Sharding/Operations/IShardedOperation.cs
@@ -39,8 +39,6 @@ namespace Raven.Server.Documents.Sharding.Operations
 
     public interface IShardedOperation : IShardedOperation<object>
     {
-        new RavenCommand CreateCommandForShard(int shard);
-
         object IShardedOperation<object, object>.Combine(Memory<object> results) => null;
 
         object IShardedOperation<object, object>.CombineCommands(Memory<RavenCommand<object>> commands, Memory<object> results) => null;

--- a/src/Raven.Server/Documents/Sharding/Operations/IShardedOperation.cs
+++ b/src/Raven.Server/Documents/Sharding/Operations/IShardedOperation.cs
@@ -36,4 +36,15 @@ namespace Raven.Server.Documents.Sharding.Operations
         CombinedStreamResult IShardedOperation<StreamResult, CombinedStreamResult>.Combine(Memory<StreamResult> results) =>
             new CombinedStreamResult { Results = results };
     }
+
+    public interface IShardedOperation : IShardedOperation<object>
+    {
+        new RavenCommand CreateCommandForShard(int shard);
+
+        object IShardedOperation<object, object>.Combine(Memory<object> results) => null;
+
+        object IShardedOperation<object, object>.CombineCommands(Memory<RavenCommand<object>> commands, Memory<object> results) => null;
+
+        RavenCommand<object> IShardedOperation<object, object>.CreateCommandForShard(int shard) => CreateCommandForShard(shard);
+    }
 }

--- a/src/Raven.Server/Documents/Sharding/ShardedContext.Streaming.cs
+++ b/src/Raven.Server/Documents/Sharding/ShardedContext.Streaming.cs
@@ -157,6 +157,14 @@ namespace Raven.Server.Documents.Sharding
                     pagingContinuation);
             }
 
+            public async IAsyncEnumerable<Document> GetDocumentsAsync(CombinedReadContinuationState documents, ShardedPagingContinuation pagingContinuation, string resultPropertyName = "Results")
+            {
+                await foreach (var result in PagedShardedDocumentsByLastModified(documents, resultPropertyName, pagingContinuation))
+                {
+                    yield return result.Item;
+                }
+            }
+
             private class YieldStreamArray<T, TInner> : AsyncDocumentSession.AbstractYieldStream<T> where T : ShardStreamItem<TInner>
             {
                 private readonly Func<BlittableJsonReaderObject, TInner> _converter;

--- a/src/Raven.Server/Web/Studio/Sharding/Processors/ShardedStudioCollectionsHandlerProcessorForPreviewCollection.cs
+++ b/src/Raven.Server/Web/Studio/Sharding/Processors/ShardedStudioCollectionsHandlerProcessorForPreviewCollection.cs
@@ -91,13 +91,8 @@ public class ShardedStudioCollectionsHandlerProcessorForPreviewCollection : Abst
         return false;
     }
 
-    protected override async IAsyncEnumerable<Document> GetDocumentsAsync()
-    {
-        await foreach (var doc in _requestHandler.ShardedContext.Streaming.PagedShardedDocumentsByLastModified(_combinedReadState, nameof(PreviewCollectionResult.Results), _continuationToken))
-        {
-            yield return doc.Item;
-        }
-    }
+    protected override IAsyncEnumerable<Document> GetDocumentsAsync() =>
+        RequestHandler.ShardedContext.Streaming.GetDocumentsAsync(_combinedReadState, _continuationToken);
 
     protected override async ValueTask<List<string>> GetAvailableColumnsAsync()
     {

--- a/test/FastTests/Sharding/BasicSharding.cs
+++ b/test/FastTests/Sharding/BasicSharding.cs
@@ -1,4 +1,5 @@
-﻿using Raven.Client.Documents;
+﻿using System.Threading.Tasks;
+using Raven.Client.Documents;
 using Raven.Client.Documents.Commands;
 using Raven.Client.Documents.Operations;
 using Raven.Client.Exceptions;
@@ -67,6 +68,21 @@ namespace FastTests.Sharding
                     var u = s.Load<User>("users/1");
                     Assert.NotNull(u);
                     Assert.Equal("Oren", u.Name);
+                }
+            }
+        }
+
+        [RavenFact(RavenTestCategory.ClientApi | RavenTestCategory.Sharding)]
+        public async Task CanPutAndGetItem2()
+        {
+            using (var store = Sharding.GetDocumentStore())
+            {
+                PutEntity(store, new DynamicJsonValue {["Name"] = "Oren",}, "users/1");
+
+                using (var s = store.Commands())
+                {
+                    var documents = await s.GetAsync(start: 0, pageSize: 100);
+                    Assert.Equal(1, documents.Count());
                 }
             }
         }


### PR DESCRIPTION
### Issue link

https://issues.hibernatingrhinos.com/issue/RavenDB-18199

### Additional description

Support return document from the document handler when no ids are specified.

### Type of change

- Bug fix

### How risky is the change?

- Low 

### Backward compatibility

- Not relevant

### Is it platform specific issue?

- No

### Documentation update

- No documentation update is needed 

### Testing 

- Tests have been added that prove the fix is effective or that the feature works
- 
### Is there any existing behavior change of other features due to this change?

- No

### UI work

- No UI work is needed
