### PR TITLE
RavenDB-17861 Remove '@timeseries-snapshot' from metadata

### DIFF
--- a/src/Raven.Studio/typescript/models/database/documents/documentMetadata.ts
+++ b/src/Raven.Studio/typescript/models/database/documents/documentMetadata.ts
@@ -130,6 +130,7 @@ class documentMetadata {
                     property.toUpperCase() !== '@counters'.toUpperCase() &&
                     property.toUpperCase() !== '@counters-snapshot'.toUpperCase() &&
                     property.toUpperCase() !== '@timeseries'.toUpperCase() &&
+                    property.toUpperCase() !== '@timeseries-snapshot'.toUpperCase() &&
                     property.toUpperCase() !== 'toDto'.toUpperCase() &&
                     property.toUpperCase() !== '@change-vector'.toUpperCase()) {
                     this.nonStandardProps = this.nonStandardProps || [];
@@ -190,6 +191,7 @@ class documentMetadata {
         this.flags = "";
         this.counters([]);
         this.attachments([]);
+        this.timeSeries([]);
     }
 }
 


### PR DESCRIPTION
### Issue link
https://issues.hibernatingrhinos.com/issue/RavenDB-17861

### Additional description
Hide '@timeseries-smapshot' in the metadata editor view

### Type of change
- Bug fix

### How risky is the change?
- Low 

### Backward compatibility
- Non breaking change

### Is it platform specific issue?
- No

### Documentation update
- No documentation update is needed 

### Testing 
- It has been verified by manual testing

### Is there any existing behavior change of other features due to this change?
- No

### UI work
- No UI work is needed
