### PR TITLE
RavenDB-18299 Raw as field entry type inside Corax

### DIFF
--- a/src/Corax/IndexFieldsMapping.cs
+++ b/src/Corax/IndexFieldsMapping.cs
@@ -1,0 +1,127 @@
+﻿using System;
+using System.Collections;
+using System.Collections.Generic;
+using System.Diagnostics;
+using System.Runtime.InteropServices;
+using Sparrow.Server;
+using Voron;
+
+namespace Corax;
+
+public class IndexFieldsMapping : IEnumerable<IndexFieldBinding>
+{
+    public static readonly IndexFieldsMapping Instance = new IndexFieldsMapping(null);
+
+    private readonly ByteStringContext _context;
+    private readonly Dictionary<Slice, IndexFieldBinding> _fields;
+    private readonly Dictionary<int, IndexFieldBinding> _fieldsById;
+    private readonly List<IndexFieldBinding> _fieldsList;
+    public int Count => _fieldsById.Count;
+    public Analyzer DefaultAnalyzer;
+
+    public IndexFieldsMapping(ByteStringContext context)
+    {
+        _context = context;
+        _fields = new Dictionary<Slice, IndexFieldBinding>(SliceComparer.Instance);
+        _fieldsById = new Dictionary<int, IndexFieldBinding>();
+        _fieldsList = new List<IndexFieldBinding>();
+    }
+
+    public IndexFieldsMapping AddBinding(int fieldId, Slice fieldName, Analyzer analyzer = null, bool notApplyAnalyzer = false, bool hasSuggestion = false)
+    {
+        if (!_fieldsById.TryGetValue(fieldId, out var storedAnalyzer))
+        {
+            var binding = new IndexFieldBinding(fieldId, fieldName, analyzer, notApplyAnalyzer, hasSuggestion);
+            _fields[fieldName] = binding;
+            _fieldsById[fieldId] = binding;
+            _fieldsList.Add(binding);
+        }
+        else
+        {
+            Debug.Assert(analyzer == storedAnalyzer.Analyzer);
+        }
+
+        return this;
+    }
+
+    public void UpdateAnalyzersInBindings(IndexFieldsMapping analyzers)
+    {
+        foreach (var mapping in analyzers.GetEnumerator())
+        {
+            if (TryGetByFieldId(mapping.FieldId, out var binding) == true)
+            {
+                binding.Analyzer = mapping.Analyzer;
+            }
+        }
+
+        foreach (var ifb in CollectionsMarshal.AsSpan(_fieldsList))
+        {
+            if (ifb.NotApplyAnalyzer)
+                continue;
+
+            ifb.Analyzer ??= analyzers.DefaultAnalyzer;
+        }
+    }
+
+    public IndexFieldBinding GetByFieldId(int fieldId)
+    {
+        return _fieldsById[fieldId];
+    }
+
+    public bool TryGetByFieldId(int fieldId, out IndexFieldBinding binding)
+    {
+        return _fieldsById.TryGetValue(fieldId, out binding);
+    }
+
+    public IndexFieldBinding GetByFieldName(string fieldName)
+    {
+        // This method is a convenience method that should not be used in high performance sections of the code.
+        using var _ = Slice.From(_context, fieldName, out var str);
+        return _fields[str];
+    }
+
+    public bool TryGetByFieldName(string fieldName, out IndexFieldBinding binding)
+    {
+        // This method is a convenience method that should not be used in high performance sections of the code.
+        using var _ = Slice.From(_context, fieldName, out var str);
+        return _fields.TryGetValue(str, out binding);
+    }
+
+    public IndexFieldBinding GetByFieldName(Slice fieldName)
+    {
+        return _fields[fieldName];
+    }
+
+    public bool TryGetByFieldName(Slice fieldName, out IndexFieldBinding binding)
+    {
+        return _fields.TryGetValue(fieldName, out binding);
+    }
+
+    public IEnumerator<IndexFieldBinding> GetEnumerator()
+    {
+        return _fieldsList.GetEnumerator();
+    }
+
+    IEnumerator IEnumerable.GetEnumerator()
+    {
+        return _fieldsList.GetEnumerator();
+    }
+}
+
+public class IndexFieldBinding
+{
+    public readonly int FieldId;
+    public readonly Slice FieldName;
+    public Corax.Analyzer Analyzer;
+    public readonly bool NotApplyAnalyzer;
+    public readonly bool HasSuggestions;
+
+    public IndexFieldBinding(int fieldId, Slice fieldName, Analyzer analyzer = null, bool notApplyAnalyzer = false, bool hasSuggestions = false)
+    {
+        FieldId = fieldId;
+        FieldName = fieldName;
+        Analyzer = analyzer;
+        NotApplyAnalyzer = notApplyAnalyzer;
+        HasSuggestions = hasSuggestions;
+    }
+}

--- a/src/Corax/IndexWriter.cs
+++ b/src/Corax/IndexWriter.cs
@@ -30,126 +30,7 @@ namespace Corax
         Small = 1,
         Set = 2
     }
-
-
-    public class IndexFieldsMapping : IEnumerable<IndexFieldBinding>
-    {
-        public static readonly IndexFieldsMapping Instance = new IndexFieldsMapping(null);
-
-        private readonly ByteStringContext _context;
-        private readonly Dictionary<Slice, IndexFieldBinding> _fields;
-        private readonly Dictionary<int, IndexFieldBinding> _fieldsById;
-        private readonly List<IndexFieldBinding> _fieldsList;
-        public int Count => _fieldsById.Count;
-        public Analyzer DefaultAnalyzer;
-
-        public IndexFieldsMapping(ByteStringContext context)
-        {
-            _context = context;
-            _fields = new Dictionary<Slice, IndexFieldBinding>(SliceComparer.Instance);
-            _fieldsById = new Dictionary<int, IndexFieldBinding>();
-            _fieldsList = new List<IndexFieldBinding>();
-        }
-
-        public IndexFieldsMapping AddBinding(int fieldId, Slice fieldName, Analyzer analyzer = null, bool notApplyAnalyzer = false, bool hasSuggestion = false)
-        {
-            if (!_fieldsById.TryGetValue(fieldId, out var storedAnalyzer))
-            {
-                var binding = new IndexFieldBinding(fieldId, fieldName, analyzer, notApplyAnalyzer, hasSuggestion);
-                _fields[fieldName] = binding;
-                _fieldsById[fieldId] = binding;
-                _fieldsList.Add(binding);
-            }
-            else
-            {
-                Debug.Assert(analyzer == storedAnalyzer.Analyzer);
-            }
-
-            return this;
-        }
-
-        public void UpdateAnalyzersInBindings(IndexFieldsMapping analyzers)
-        {
-            foreach (var mapping in analyzers.GetEnumerator())
-            {
-                if (TryGetByFieldId(mapping.FieldId, out var binding) == true)
-                {
-                    binding.Analyzer = mapping.Analyzer;
-                }
-            }
-
-            foreach (var ifb in CollectionsMarshal.AsSpan(_fieldsList))
-            {
-                if (ifb.NotApplyAnalyzer)
-                    continue;
-
-                ifb.Analyzer ??= analyzers.DefaultAnalyzer;
-            }
-        }
-
-        public IndexFieldBinding GetByFieldId(int fieldId)
-        {
-            return _fieldsById[fieldId];
-        }
-
-        public bool TryGetByFieldId(int fieldId, out IndexFieldBinding binding)
-        {
-            return _fieldsById.TryGetValue(fieldId, out binding);
-        }
-
-        public IndexFieldBinding GetByFieldName(string fieldName)
-        {
-            // This method is a convenience method that should not be used in high performance sections of the code.
-            using var _ = Slice.From(_context, fieldName, out var str);
-            return _fields[str];
-        }
-
-        public bool TryGetByFieldName(string fieldName, out IndexFieldBinding binding)
-        {
-            // This method is a convenience method that should not be used in high performance sections of the code.
-            using var _ = Slice.From(_context, fieldName, out var str);
-            return _fields.TryGetValue(str, out binding);
-        }
-
-        public IndexFieldBinding GetByFieldName(Slice fieldName)
-        {
-            return _fields[fieldName];
-        }
-
-        public bool TryGetByFieldName(Slice fieldName, out IndexFieldBinding binding)
-        {
-            return _fields.TryGetValue(fieldName, out binding);
-        }
-
-        public IEnumerator<IndexFieldBinding> GetEnumerator()
-        {
-            return _fieldsList.GetEnumerator();
-        }
-
-        IEnumerator IEnumerable.GetEnumerator()
-        {
-            return _fieldsList.GetEnumerator();
-        }
-    }
-
-    public class IndexFieldBinding
-    {
-        public readonly int FieldId;
-        public readonly Slice FieldName;
-        public Corax.Analyzer Analyzer;
-        public readonly bool NotApplyAnalyzer;
-        public readonly bool HasSuggestions;
-
-        public IndexFieldBinding(int fieldId, Slice fieldName, Analyzer analyzer = null, bool notApplyAnalyzer = false, bool hasSuggestions = false)
-        {
-            FieldId = fieldId;
-            FieldName = fieldName;
-            Analyzer = analyzer;
-            NotApplyAnalyzer = notApplyAnalyzer;
-            HasSuggestions = hasSuggestions;
-        }
-    }
-
+    
     public class IndexWriter : IDisposable // single threaded, controlled by caller
     {
         public const int MaxTermLength = 1024;
@@ -304,15 +185,13 @@ namespace Corax
             else if (fieldType.HasFlag(IndexEntryFieldType.Tuple) ||
                      fieldType.HasFlag(IndexEntryFieldType.Invalid) == false)
             {
-                Span<byte> value;
-                if (fieldType.HasFlag(IndexEntryFieldType.Blittable))
+                if (fieldType.HasFlag(IndexEntryFieldType.Raw))
                 {
-                    entryReader.Read(tokenField, out Span<byte> _, out value);
+                    return;
                 }
-                else
-                {
-                    entryReader.Read(tokenField, out value);
-                }
+                
+                entryReader.Read(tokenField, out var value);
+                
                 var words = new Span<byte>(tempWordsSpace, bufferSize);
                 var tokens = new Span<Token>(tempTokenSpace, tokenSize);
                 analyzer.Execute(value, ref words, ref tokens);
@@ -433,13 +312,10 @@ namespace Corax
             }
             else if (fieldType.HasFlag(IndexEntryFieldType.Tuple) || fieldType.HasFlag(IndexEntryFieldType.Invalid) == false)
             {
-                Span<byte> value;
-                if (fieldType.HasFlag(IndexEntryFieldType.Blittable))
-                    entryReader.Read(tokenField, out Span<byte> _, out value, intOffset);
-                else
-                    entryReader.Read(tokenField, out value);
-
-
+                if (fieldType.HasFlag(IndexEntryFieldType.Raw))
+                    return;
+                
+                entryReader.Read(tokenField, out var value);
                 using var _ = Slice.From(context, value, ByteStringType.Mutable, out var slice);
                 if (field.TryGetValue(slice, out var term) == false)
                 {
@@ -529,11 +405,10 @@ namespace Corax
                     }
                     else
                     {
-                        Span<byte> termValue;
-                        if (fieldType.HasFlag(IndexEntryFieldType.Blittable))
-                            entryReader.Read(fieldId, out Span<byte> _, out termValue);
-                        else
-                            entryReader.Read(fieldId, out termValue);
+                        if (fieldType.HasFlag(IndexEntryFieldType.Raw))
+                            continue;
+                        
+                        entryReader.Read(fieldId, out var termValue);
 
                         if (analyzer is null)
                         {

--- a/src/Corax/Queries/UnaryMatch.Ordinal.cs
+++ b/src/Corax/Queries/UnaryMatch.Ordinal.cs
@@ -57,7 +57,7 @@ namespace Corax.Queries
                 for (int i = 0; i < results; i++)
                 {
                     var reader = searcher.GetReaderFor(freeMemory[i]);
-                    var type = reader.GetFieldType(match._fieldId);
+                    var type = reader.GetFieldType(match._fieldId, out var intOffset);
                     var isMatch = false;
 
                     if (type is IndexEntryFieldType.Tuple or IndexEntryFieldType.None)
@@ -121,7 +121,7 @@ namespace Corax.Queries
                 for (int i = 0; i < results; i++)
                 {
                     var reader = searcher.GetReaderFor(freeMemory[i]);
-                    var type = reader.GetFieldType(match._fieldId);
+                    var type = reader.GetFieldType(match._fieldId, out _);
 
                     bool isMatch = false;
                     if (typeof(TValueType) == typeof(long))

--- a/src/Raven.Server/Documents/Indexes/Persistence/Corax/WriterScopes/BlittableWriterScope.cs
+++ b/src/Raven.Server/Documents/Indexes/Persistence/Corax/WriterScopes/BlittableWriterScope.cs
@@ -28,7 +28,7 @@ public class BlittableWriterScope : IDisposable
             _currentIndex = (int)writeStream.Position;
         }
         
-        writer.Write(field, new Span<byte> (_reader.BasePointer, _reader.Size), _buffer.AsSpan(0, _currentIndex));
+        writer.WriteRaw(field, new Span<byte> (_reader.BasePointer, _reader.Size));
     }
 
     public void Dispose()

--- a/src/Raven.Server/Documents/Indexes/Persistence/Corax/WriterScopes/BlittableWriterScope.cs
+++ b/src/Raven.Server/Documents/Indexes/Persistence/Corax/WriterScopes/BlittableWriterScope.cs
@@ -1,0 +1,38 @@
+﻿using System;
+using System.Buffers;
+using System.IO;
+using Corax;
+using Sparrow.Json;
+
+namespace Raven.Server.Documents.Indexes.Persistence.Corax.WriterScopes;
+
+public class BlittableWriterScope : IDisposable
+{
+    private readonly byte[] _buffer;
+    private int _currentIndex;
+    private BlittableJsonReaderObject _reader;
+    
+    public BlittableWriterScope(BlittableJsonReaderObject reader)
+    {
+        _currentIndex = 0;
+        _reader = reader;
+        _buffer = ArrayPool<byte>.Shared.Rent(_reader.Size);
+    }
+    
+    public unsafe void Write(int field, ref IndexEntryWriter writer)
+    {
+        fixed (byte* ptr = _buffer)
+        {
+            using var writeStream = new UnmanagedMemoryStream(ptr, 0, _buffer.Length, FileAccess.Write);
+            _reader.WriteJsonToAsync(writeStream).AsTask().ConfigureAwait(false).GetAwaiter().GetResult();
+            _currentIndex = (int)writeStream.Position;
+        }
+        
+        writer.Write(field, new Span<byte> (_reader.BasePointer, _reader.Size), _buffer.AsSpan(0, _currentIndex));
+    }
+
+    public void Dispose()
+    {
+        ArrayPool<byte>.Shared.Return(_buffer);
+    }
+}

--- a/src/Raven.Server/Documents/Queries/Results/QueryResultRetrieverBase.cs
+++ b/src/Raven.Server/Documents/Queries/Results/QueryResultRetrieverBase.cs
@@ -522,7 +522,7 @@ namespace Raven.Server.Documents.Queries.Results
                 return false;
 
             var id = FieldsToFetch.IndexFields[fieldToFetch.Name.Value].Id;
-            var type = retrieverInput.CoraxEntry.GetFieldType(id);
+            var type = retrieverInput.CoraxEntry.GetFieldType(id, out _);
 
             //todo maciej: optimize this
             switch (type)

--- a/src/Sparrow/Json/BlittableJsonReaderObject.cs
+++ b/src/Sparrow/Json/BlittableJsonReaderObject.cs
@@ -48,7 +48,7 @@ namespace Sparrow.Json
 
             return _context.WriteAsync(stream, this, token);
         }
-
+        
         public BlittableJsonReaderObject(byte* mem, int size, JsonOperationContext context, UnmanagedWriteBuffer buffer = default(UnmanagedWriteBuffer))
             : this(mem, size, context)
         {
@@ -1319,7 +1319,7 @@ namespace Sparrow.Json
                 }
             }
         }
-
+        
         private static void ThrowInvalidTokenType()
         {
             throw new InvalidDataException("Token type not valid");

--- a/test/FastTests/Corax/BlittableCoraxFlag.cs
+++ b/test/FastTests/Corax/BlittableCoraxFlag.cs
@@ -1,0 +1,215 @@
+﻿using System;
+using System.Collections.Generic;
+using Corax;
+using FastTests.Voron;
+using Raven.Server.Documents.Indexes.Persistence.Corax;
+using Raven.Server.Documents.Indexes.Persistence.Corax.WriterScopes;
+using Raven.Server.Documents.Indexes.Persistence.Lucene.Analyzers;
+using Sparrow;
+using Sparrow.Json;
+using Sparrow.Json.Parsing;
+using Sparrow.Server;
+using Sparrow.Threading;
+using Voron;
+using Xunit;
+using Xunit.Abstractions;
+
+namespace FastTests.Corax;
+
+public class BlittableCoraxFlag : StorageTest
+{
+    private const int IndexId = 0, ContentId = 1;
+    private IndexFieldsMapping _analyzers;
+    private readonly ByteStringContext _bsc;
+    private DynamicJsonValue json1 = new() {["Address"] = new DynamicJsonValue() {["City"] = "Atlanta", ["ZipCode"] = 1254}, ["Friends"] = "yes"};
+    private DynamicJsonValue json2 = new() {["Address"] = new DynamicJsonValue() {["ZipCode"] = 1234, ["City"] = "New York"}, ["Friends"] = "no"};
+
+    public BlittableCoraxFlag(ITestOutputHelper output) : base(output)
+    {
+        _bsc = new ByteStringContext(SharedMultipleUseFlag.None);
+    }
+
+    [Fact]
+    public unsafe void CanStoreBlittableWithAnalyzers()
+    {
+        using var ctx = JsonOperationContext.ShortTermSingleUse();
+        _analyzers = CreateKnownFields(_bsc, true);
+        using var blittable1 = ctx.ReadObject(json1, "foo");
+        using var blittable2 = ctx.ReadObject(json2, "foo");
+        using(var writer = new IndexWriter(Env, _analyzers))
+        {
+            Span<byte> buffer = new byte[10 * 1024];
+            foreach (var (id, item) in new[] {("item/1", blittable1), ("item/2", blittable2)})
+            {
+                var entry = new IndexEntryWriter(buffer, _analyzers);
+                entry.Write(IndexId, Encodings.Utf8.GetBytes(id));
+                entry.Write(ContentId, new Span<byte>(item.BasePointer, item.Size), Encodings.Utf8.GetBytes(item.ToString()).AsSpan());
+                entry.Finish(out var output);
+                writer.Index(id, output, _analyzers);
+            }
+
+            writer.Commit();
+        }
+
+        Span<long> mem = stackalloc long[1024];
+        using (var searcher = new IndexSearcher(Env, _analyzers))
+        {
+            var match = searcher.SearchQuery("Content", "1254", Constants.Search.Operator.Or, false, 1);
+            Assert.Equal(1, match.Fill(mem));
+            var result = searcher.GetReaderFor(mem[0]);
+            result.Read(1, out Span<byte> blittableBinary, out Span<byte> blittableText);
+
+            fixed (byte* ptr = &blittableBinary.GetPinnableReference())
+            {
+                var reader = new BlittableJsonReaderObject(ptr, blittableBinary.Length, ctx);
+                Assert.Equal(blittable1.Size, reader.Size);
+                Assert.True(blittable1.Equals(reader));
+            }
+        }
+
+        //Delete part
+        using (var indexWriter = new IndexWriter(Env, _analyzers))
+        {
+            Assert.True(indexWriter.TryDeleteEntry("Id", "item/1"));
+            indexWriter.Commit();
+        }
+
+        {
+            using IndexSearcher searcher = new IndexSearcher(Env, _analyzers);
+            var match = searcher.AllEntries();
+            Assert.Equal(1, match.Fill(mem));
+            Assert.Equal("item/2", searcher.GetIdentityFor(mem[0]));
+        }
+        
+        
+    }
+
+    [Fact]
+    public unsafe void CanStoreBlittableWithoutAnalyzers()
+    {
+        using var ctx = JsonOperationContext.ShortTermSingleUse();
+        _analyzers = CreateKnownFields(_bsc, false);
+        using var blittable1 = ctx.ReadObject(json1, "foo");
+        using var blittable2 = ctx.ReadObject(json2, "foo");
+        {
+            Span<byte> buffer = new byte[10 * 1024];
+            using var writer = new IndexWriter(Env, _analyzers);
+            foreach (var (id, item) in new[] {("1", blittable1), ("2", blittable2)})
+            {
+                var entry = new IndexEntryWriter(buffer, _analyzers);
+                entry.Write(IndexId, Encodings.Utf8.GetBytes(id));
+                entry.Write(ContentId, new Span<byte>(item.BasePointer, item.Size), Encodings.Utf8.GetBytes(item.ToString()).AsSpan());
+                entry.Finish(out var output);
+                writer.Index(id, output, _analyzers);
+            }
+
+            writer.Commit();
+        }
+
+        Span<long> mem = stackalloc long[1024];
+        {
+            using var searcher = new IndexSearcher(Env, _analyzers);
+            var match = searcher.TermQuery("Content", blittable1.ToString(), ContentId);
+            Assert.Equal(1, match.Fill(mem));
+            var result = searcher.GetReaderFor(mem[0]);
+            result.Read(1, out Span<byte> blittableBinary, out Span<byte> blittableText);
+
+            fixed (byte* ptr = &blittableBinary.GetPinnableReference())
+            {
+                var reader = new BlittableJsonReaderObject(ptr, blittableBinary.Length, ctx);
+                Assert.Equal(blittable1.Size, reader.Size);
+                Assert.True(blittable1.Equals(reader));
+            }
+        }
+        
+        //Delete part
+        using (var indexWriter = new IndexWriter(Env, _analyzers))
+        {
+            Assert.True(indexWriter.TryDeleteEntry("Id", "1"));
+            indexWriter.Commit();
+        }
+
+        {
+            using var searcher = new IndexSearcher(Env, _analyzers);
+            var match = searcher.AllEntries();
+            Assert.Equal(1, match.Fill(mem));
+            Assert.Equal("2", searcher.GetIdentityFor(mem[0]));
+        }
+    }
+    
+    [Fact]
+    public unsafe void CanStoreBlittableWithWriterScope()
+    {
+        using var ctx = JsonOperationContext.ShortTermSingleUse();
+        _analyzers = CreateKnownFields(_bsc, true);
+        using var blittable1 = ctx.ReadObject(json1, "foo");
+        using var blittable2 = ctx.ReadObject(json2, "foo");
+        {
+            Span<byte> buffer = new byte[10 * 1024];
+            using var writer = new IndexWriter(Env, _analyzers);
+            foreach (var (id, item) in new[] {("1", blittable1), ("2", blittable2)})
+            {
+                var entry = new IndexEntryWriter(buffer, _analyzers);
+                entry.Write(IndexId, Encodings.Utf8.GetBytes(id));
+                using (var scope = new BlittableWriterScope(item))
+                {
+                    scope.Write(ContentId, ref entry);
+                }
+                entry.Finish(out var output);
+                writer.Index(id, output, _analyzers);
+            }
+
+            writer.Commit();
+        }
+
+        Span<long> mem = stackalloc long[1024];
+        {
+            using IndexSearcher searcher = new IndexSearcher(Env, _analyzers);
+            var match = searcher.SearchQuery("Content", "1254", Constants.Search.Operator.Or, false, ContentId);
+            Assert.Equal(1, match.Fill(mem));
+            var result = searcher.GetReaderFor(mem[0]);
+            result.Read(1, out Span<byte> blittableBinary, out Span<byte> blittableText);
+            var resStr = Encodings.Utf8.GetString(blittableText);
+            fixed (byte* ptr = &blittableBinary.GetPinnableReference())
+            {
+                var reader = new BlittableJsonReaderObject(ptr, blittableBinary.Length, ctx);
+                Assert.Equal(blittable1.Size, reader.Size);
+                Assert.True(blittable1.Equals(reader));
+            }
+        }
+        
+        //Delete part
+        using (var indexWriter = new IndexWriter(Env, _analyzers))
+        {
+            Assert.True(indexWriter.TryDeleteEntry("Id", "1"));
+            indexWriter.Commit();
+        }
+
+        {
+            using IndexSearcher searcher = new IndexSearcher(Env, _analyzers);
+            var match = searcher.AllEntries();
+            Assert.Equal(1, match.Fill(mem));
+            Assert.Equal("2", searcher.GetIdentityFor(mem[0]));
+        }
+    }
+
+    private static IndexFieldsMapping CreateKnownFields(ByteStringContext ctx, bool analyzers)
+    {
+        Slice.From(ctx, "Id", ByteStringType.Immutable, out Slice idSlice);
+        Slice.From(ctx, "Content", ByteStringType.Immutable, out Slice contentSlice);
+
+        return analyzers
+            ? new IndexFieldsMapping(ctx)
+                .AddBinding(IndexId, idSlice, Analyzer.DefaultAnalyzer)
+                .AddBinding(ContentId, contentSlice, LuceneAnalyzerAdapter.Create(new RavenStandardAnalyzer(Lucene.Net.Util.Version.LUCENE_30)))
+            : new IndexFieldsMapping(ctx)
+                .AddBinding(IndexId, idSlice)
+                .AddBinding(ContentId, contentSlice);
+    }
+
+    public override void Dispose()
+    {
+        _bsc.Dispose();
+        base.Dispose();
+    }
+}

--- a/test/FastTests/Corax/IndexEntryWriter.cs
+++ b/test/FastTests/Corax/IndexEntryWriter.cs
@@ -65,12 +65,12 @@ namespace FastTests.Corax
             reader.Read(0, out int intValue);
             Assert.Equal(1, intValue);
             
-            Assert.True(reader.GetFieldType(0).HasFlag(IndexEntryFieldType.Tuple));
-            Assert.False(reader.GetFieldType(0).HasFlag(IndexEntryFieldType.List));
-            Assert.True(reader.GetFieldType(1).HasFlag(IndexEntryFieldType.List));
-            Assert.False(reader.GetFieldType(1).HasFlag(IndexEntryFieldType.Tuple));
-            Assert.True(reader.GetFieldType(2).HasFlag(IndexEntryFieldType.None));
-            Assert.True(reader.GetFieldType(3).HasFlag(IndexEntryFieldType.None));
+            Assert.True(reader.GetFieldType(0, out var _).HasFlag(IndexEntryFieldType.Tuple));
+            Assert.False(reader.GetFieldType(0, out var _).HasFlag(IndexEntryFieldType.List));
+            Assert.True(reader.GetFieldType(1, out var _).HasFlag(IndexEntryFieldType.List));
+            Assert.False(reader.GetFieldType(1, out var _).HasFlag(IndexEntryFieldType.Tuple));
+            Assert.True(reader.GetFieldType(2, out var _).HasFlag(IndexEntryFieldType.None));
+            Assert.True(reader.GetFieldType(3, out var _).HasFlag(IndexEntryFieldType.None));
 
             reader.Read(0, out double doubleValue);
             Assert.True(doubleValue.AlmostEquals(1.001));


### PR DESCRIPTION
### Issue link

https://issues.hibernatingrhinos.com/issue/RavenDB-18299

### Additional description

Added RAW as IndexEntryType.


Struct:

`<Type><Length of binary><Binary>`

Having binary of blittable allows us to create blittable immediately for projections (this is extremely important for static indexes). 

### Type of change


- New feature


### How risky is the change?

- Not relevant

### Backward compatibility


- Not relevant

### Is it platform specific issue?

- No

### Documentation update

- No documentation update is needed 

### Testing 

- Tests have been added that prove the fix is effective or that the feature works


### Is there any existing behavior change of other features due to this change?


- No

### UI work

- No UI work is needed
