### PR TITLE
RavenDB-18332 FirstOrDefault in reduce may return null instead of dyn…

### DIFF
--- a/src/Raven.Server/Documents/Indexes/Static/Extensions/LinqOnDynamic.cs
+++ b/src/Raven.Server/Documents/Indexes/Static/Extensions/LinqOnDynamic.cs
@@ -8,11 +8,115 @@ using System;
 using System.Collections;
 using System.Collections.Generic;
 using System.Linq;
+using Raven.Server.Documents.Indexes.Static.Linq;
 
 namespace Raven.Server.Documents.Indexes.Static.Extensions
 {
     public static class LinqOnDynamic
     {
+        
+        [Obsolete("This method should never be used directly.")]
+        public static dynamic First(this IGrouping<dynamic, dynamic> self, Func<dynamic, bool> predicate)
+        {
+            return DynamicEnumerable.First(self, predicate);
+        }
+        
+        [Obsolete("This method should never be used directly.")]
+        public static dynamic FirstOrDefault(this IGrouping<dynamic, dynamic> self)
+        {
+            return DynamicEnumerable.FirstOrDefault(self);
+        }
+        
+        [Obsolete("This method should never be used directly.")]
+        public static dynamic FirstOrDefault(this IGrouping<dynamic, dynamic> self, Func<dynamic, bool> predicate)
+        {
+            return DynamicEnumerable.FirstOrDefault(self, predicate);
+        }
+        
+        [Obsolete("This method should never be used directly.")]
+        public static dynamic Last(this IGrouping<dynamic, dynamic> self)
+        {
+            return DynamicEnumerable.Last(self);
+        }
+        
+        [Obsolete("This method should never be used directly.")]
+        public static dynamic Last(this IGrouping<dynamic, dynamic> self, Func<dynamic, bool> predicate)
+        {
+            return DynamicEnumerable.Last(self, predicate);
+        }
+        
+        [Obsolete("This method should never be used directly.")]
+        public static dynamic LastOrDefault(this IGrouping<dynamic, dynamic> self)
+        {
+            return DynamicEnumerable.LastOrDefault(self);
+        }
+        
+        [Obsolete("This method should never be used directly.")]
+        public static dynamic LastOrDefault(this IGrouping<dynamic, dynamic> self, Func<dynamic, bool> predicate)
+        {
+            return DynamicEnumerable.LastOrDefault(self, predicate);
+        }
+        
+        [Obsolete("This method should never be used directly.")]
+        public static dynamic Single(this IGrouping<dynamic, dynamic> self)
+        {
+            return DynamicEnumerable.Single(self);
+        }
+        
+        [Obsolete("This method should never be used directly.")]
+        public static dynamic Single(this IGrouping<dynamic, dynamic> self, Func<dynamic, bool> predicate)
+        {
+            return DynamicEnumerable.Single(self, predicate);
+        }
+        
+        [Obsolete("This method should never be used directly.")]
+        public static dynamic SingleOrDefault(this IGrouping<dynamic, dynamic> self)
+        {
+            return DynamicEnumerable.SingleOrDefault(self);
+        }
+        
+        [Obsolete("This method should never be used directly.")]
+        public static dynamic SingleOrDefault(this IGrouping<dynamic, dynamic> self, Func<dynamic, bool> predicate)
+        {
+            return DynamicEnumerable.SingleOrDefault(self, predicate);
+        }
+        
+        [Obsolete("This method should never be used directly.")]
+        public static dynamic ElementAt(this IGrouping<dynamic, dynamic> self, int index)
+        {
+            return DynamicEnumerable.ElementAt(self, index);
+        }
+        
+        [Obsolete("This method should never be used directly.")]
+        public static dynamic ElementAtOrDefault(this IGrouping<dynamic, dynamic> self, int index)
+        {
+            return DynamicEnumerable.ElementAtOrDefault(self, index);
+        }
+        
+        [Obsolete("This method should never be used directly.")]
+        public static dynamic Min(this IGrouping<dynamic, dynamic> self)
+        {
+            return DynamicEnumerable.Min(self);
+        }
+        
+        [Obsolete("This method should never be used directly.")]
+        public static dynamic Min(this IGrouping<dynamic, dynamic> self, Func<dynamic, bool> predicate)
+        {
+            return DynamicEnumerable.Min(self, predicate);
+        }
+        
+        [Obsolete("This method should never be used directly.")]
+        public static dynamic Max(this IGrouping<dynamic, dynamic> self, Func<dynamic, bool> predicate)
+        {
+            return DynamicEnumerable.Max(self, predicate);
+        }
+        
+        [Obsolete("This method should never be used directly.")]
+        public static dynamic Max(this IGrouping<dynamic, dynamic> self)
+        {
+            return DynamicEnumerable.Max(self);
+        }
+        
         [Obsolete("This method should never be used directly.")]
         public static IEnumerable<IGrouping<dynamic, dynamic>> GroupBy(this IEnumerable<dynamic> source, Func<dynamic, dynamic> keySelector)
         {

--- a/test/SlowTests/Issues/RavenDB-18332.cs
+++ b/test/SlowTests/Issues/RavenDB-18332.cs
@@ -1,0 +1,75 @@
+﻿using System;
+using System.Linq;
+using System.Collections.Generic;
+using FastTests;
+using Orders;
+using Raven.Client.Documents.Indexes;
+using Raven.Client.Documents.Operations.Indexes;
+using Xunit;
+using Xunit.Abstractions;
+
+namespace SlowTests.Issues;
+
+public class RavenDB_18332 : RavenTestBase
+{
+    public RavenDB_18332(ITestOutputHelper output) : base(output)
+    {
+    }
+
+    private class User
+    {
+        public string Id, Name, CompanyId;
+    }
+
+    [Fact]
+    public void WillNotGetIndexErrorOnFirstOrDefaultWithNoValues()
+    {
+        var store = GetDocumentStore();
+        var indexDef = new IndexDefinition
+        {
+            Maps =
+            {
+                @"from u in docs.Users 
+                select new
+                {
+                    Name = (string)null,
+                    Id = u.CompanyId,
+                    Employees = 1
+                }",
+                @"from c in docs.Companies
+                select new
+                {
+                    c.Name,
+                    c.Id,
+                    Employees = 0
+                }"
+            },
+            Reduce = @"from r in results
+                group r by r.Id
+                into g
+                select new { Id = g.Key, g.FirstOrDefault(x => x.Name != null).Name, Employees = g.Sum(x => x.Employees) };",
+            Name = "MyIndex"
+        };
+        store.Maintenance.Send(new PutIndexesOperation(indexDef));
+
+        using (var s = store.OpenSession())
+        {
+            s.Store(new User
+            {
+                Name = "Oren",
+                CompanyId = "companies/1"
+            });
+            s.SaveChanges();
+        }
+        
+        WaitForIndexing(store);
+        
+        using (var s = store.OpenSession())
+        {
+            int count = s.Query<dynamic>("MyIndex").Count();
+            Assert.Equal(1, count);
+        }
+
+
+    }
+}


### PR DESCRIPTION
…amic null

### Issue link

https://issues.hibernatingrhinos.com/issue/RavenDB-18332

### Additional description

When creating an index manually (and not through the C#), we weren't routing the `FirstOrDefault` through the dynamic enumerable properly for `IGrouping` values.
This change allows us to handle this in a more graceful manner, avoid NRE if we cannot find a match by returning a `DynamicNull` value

### Type of change

- Bug fix

### How risky is the change?

- Moderate 

### Backward compatibility

- Non breaking change

### Is it platform specific issue?

- No

### Documentation update

- No documentation update is needed 

### Testing 

- Tests have been added that prove the fix is effective or that the feature works

