### PR TITLE
RavenDB-18334 fixed SmugglerResult deserialization

### DIFF
--- a/src/Sparrow/Json/JsonDeserializationBase.cs
+++ b/src/Sparrow/Json/JsonDeserializationBase.cs
@@ -275,8 +275,12 @@ namespace Sparrow.Json
                     }
                 }
 
-                if (propertyType == typeof(List<string>) || propertyType == typeof(HashSet<string>))
+                var isReadOnlyListOfStrings = propertyType == typeof(IReadOnlyList<string>);
+                if (propertyType == typeof(List<string>) || propertyType == typeof(HashSet<string>) || isReadOnlyListOfStrings)
                 {
+                    if (isReadOnlyListOfStrings)
+                        propertyType = typeof(List<string>);
+
                     var method = typeof(JsonDeserializationBase).GetMethod(nameof(ToCollectionOfString), BindingFlags.NonPublic | BindingFlags.Static);
                     method = method.MakeGenericMethod(propertyType);
                     return Expression.Call(method, json, Expression.Constant(propertyName));

--- a/test/FastTests/Issues/RavenDB_18334.cs
+++ b/test/FastTests/Issues/RavenDB_18334.cs
@@ -1,0 +1,41 @@
+﻿using Raven.Client.Documents.Conventions;
+using Raven.Client.Documents.Smuggler;
+using Raven.Client.Json.Serialization;
+using Sparrow.Json;
+using Xunit;
+using Xunit.Abstractions;
+
+namespace FastTests.Issues;
+
+public class RavenDB_18334 : NoDisposalNeeded
+{
+    public RavenDB_18334(ITestOutputHelper output) : base(output)
+    {
+    }
+
+    [Fact]
+    public void Can_Build_Serializator_For_SmugglerResult()
+    {
+        using (var context = JsonOperationContext.ShortTermSingleUse())
+        {
+            var result = new SmugglerResult();
+            result.AddError("MessageA");
+            result.AddInfo("MessageB");
+            result.AddWarning("MessageC");
+            result.AddMessage("MessageD");
+
+            var djv = result.ToJson();
+
+            var json = context.ReadObject(djv, "smuggler/result");
+
+            var result2 = JsonDeserializationClient.SmugglerResult(json);
+
+            Assert.Equal(result.Messages, result2.Messages);
+
+            var result3 = DocumentConventions.Default.Serialization.DefaultConverter.FromBlittable<SmugglerResult>(json);
+
+            Assert.Equal(result.Messages, result3.Messages);
+        }
+        
+    }
+}


### PR DESCRIPTION
### Issue link

https://issues.hibernatingrhinos.com/issue/RavenDB-18334

### Additional description

1. Deserialization was not keeping order of messages (because of Set used)
2. Wrong handling for `IReadOnlyList<string>` in JsonDeserializaitionBase

### Type of change

- Bug fix

### How risky is the change?

- Low 

### Backward compatibility

- Non breaking change

### Is it platform specific issue?

- No

### Documentation update

- No documentation update is needed 

### Testing 

- Tests have been added that prove the fix is effective or that the feature works

### Is there any existing behavior change of other features due to this change?

- No

### UI work

- No UI work is needed
