### PR TITLE
RavenDB-17122 - Avoid making a sync call to generate the ID in bulk i…

### DIFF
--- a/.github/workflows/compile.yml
+++ b/.github/workflows/compile.yml
@@ -1,7 +1,8 @@
 name: compile
 
 on:
-  pull_request
+  pull_request:
+  push:
 
 jobs:
   job1:

--- a/scripts/copyAssets.ps1
+++ b/scripts/copyAssets.ps1
@@ -67,8 +67,8 @@ function CopyWindowsServiceScripts ( $projectDir, $targetDir, $packOpts ) {
     Copy-Item $uninstallServicePs1Path $uninstallServicePs1TargetPath
 
     if ($packOpts.VersionInfo.BuildType.ToLower() -ne 'custom') {
-        write-host "Signing $uninstallServicePs1TargetPath"
-        SignFile $projectDir $uninstallServicePs1TargetPath $packOpts.DryRunSign
+        write-host "Signing $startAsServicePs1TargetPath"
+        SignFile $projectDir $startAsServicePs1TargetPath $packOpts.DryRunSign
 
         write-host "Signing $uninstallServicePs1TargetPath"
         SignFile $projectDir $uninstallServicePs1TargetPath $packOpts.DryRunSign

--- a/src/Raven.Server/RavenServer.cs
+++ b/src/Raven.Server/RavenServer.cs
@@ -1783,7 +1783,7 @@ namespace Raven.Server
                         Logger.Info($"RavenDB TCP is configured to use {string.Join(", ", Configuration.Core.TcpServerUrls)} and bind to {ipAddress} at {port}");
 
                     var listener = new TcpListener(ipAddress, status.Port != 0 ? status.Port : port);
-                    status.Listeners.Add(listener);
+
                     try
                     {
                         listener.Start();
@@ -1804,6 +1804,8 @@ namespace Raven.Server
                             Logger.Operations(msg, ex);
                         continue;
                     }
+
+                    status.Listeners.Add(listener);
 
                     successfullyBoundToAtLeastOne = true;
                     var listenerLocalEndpoint = (IPEndPoint)listener.LocalEndpoint;

--- a/src/Voron/Impl/Journal/WriteAheadJournal.cs
+++ b/src/Voron/Impl/Journal/WriteAheadJournal.cs
@@ -1524,11 +1524,16 @@ namespace Voron.Impl.Journal
             private void ThrowOnFlushLockEnterWhileWriteTransactionLockIsTaken()
             {
                 var currentWriteTransactionHolder = _waj._env._currentWriteTransactionHolder;
+                var currentTxLockCount = _waj._env._transactionWriter.CurrentCount;
+
                 if (currentWriteTransactionHolder != null &&
                     currentWriteTransactionHolder == NativeMemory.CurrentThreadStats)
                 {
                     throw new InvalidOperationException("The flushing lock must be taken before acquiring the write transaction lock. " +
-                                                        "This check is supposed to prevent potential deadlock and guarantee the same order of taking those two locks.");
+                                                        "This check is supposed to prevent potential deadlock and guarantee the same order of taking those two locks." +
+                                                        $"(Thread holding the write tx lock - Name: '{currentWriteTransactionHolder.Name}', Id: {currentWriteTransactionHolder.ManagedThreadId}. " +
+                                                        $"Current thread - Id: {Thread.CurrentThread.ManagedThreadId}. " +
+                                                        $"Current tx lock count: {currentTxLockCount})");
                 }
             }
 

--- a/src/Voron/StorageEnvironment.cs
+++ b/src/Voron/StorageEnvironment.cs
@@ -82,7 +82,7 @@ namespace Voron
             new LowLevelTransaction.WriteTransactionPool();
 
         private readonly WriteAheadJournal _journal;
-        private readonly SemaphoreSlim _transactionWriter = new SemaphoreSlim(1, 1);
+        internal readonly SemaphoreSlim _transactionWriter = new SemaphoreSlim(1, 1);
         internal NativeMemory.ThreadStats _currentWriteTransactionHolder;
         private readonly AsyncManualResetEvent _writeTransactionRunning = new AsyncManualResetEvent();
         internal readonly ThreadHoppingReaderWriterLock FlushInProgressLock = new ThreadHoppingReaderWriterLock();

--- a/test/FastTests/Client/BulkInserts.cs
+++ b/test/FastTests/Client/BulkInserts.cs
@@ -20,11 +20,8 @@ namespace FastTests.Client
 {
     public class BulkInserts : RavenTestBase
     {
-        private readonly ITestOutputHelper _testOutputHelper;
-
-        public BulkInserts(ITestOutputHelper output, ITestOutputHelper testOutputHelper) : base(output)
+        public BulkInserts(ITestOutputHelper output) : base(output)
         {
-            _testOutputHelper = testOutputHelper;
         }
 
         [Theory]
@@ -54,7 +51,7 @@ namespace FastTests.Client
             }))
             {
                 ThreadPool.GetAvailableThreads(out int workersThreads, out int completionPortThreads);
-                _testOutputHelper.WriteLine($"before - workerThreads: {workersThreads}, completionPortThreads: {completionPortThreads}");
+                Console.WriteLine($"before - workerThreads: {workersThreads}, completionPortThreads: {completionPortThreads}");
                 try
                 {
                     using (var bulkInsert = store.BulkInsert())
@@ -71,13 +68,12 @@ namespace FastTests.Client
                 catch (Exception e)
                 {
                     ThreadPool.GetAvailableThreads(out  workersThreads, out  completionPortThreads);
-                    _testOutputHelper.WriteLine($"after - workerThreads: {workersThreads}, completionPortThreads: {completionPortThreads}");
+                    Console.WriteLine($"after - workerThreads: {workersThreads}, completionPortThreads: {completionPortThreads}");
                     ThreadPool.GetMaxThreads(out workersThreads, out completionPortThreads);
-                    _testOutputHelper.WriteLine($"max values - workerThreads: {workersThreads}, completionPortThreads: {completionPortThreads}");
+                    Console.WriteLine($"max values - workerThreads: {workersThreads}, completionPortThreads: {completionPortThreads}");
                     ThreadPool.GetMinThreads(out workersThreads, out completionPortThreads);
-                    _testOutputHelper.WriteLine($"min values - workerThreads: {workersThreads}, completionPortThreads: {completionPortThreads}");
-                    
-                    _testOutputHelper.WriteLine($"ThreadCount: {ThreadPool.ThreadCount}, CompletedWorkItemCount: {ThreadPool.CompletedWorkItemCount}, PendingWorkItemCount: {ThreadPool.PendingWorkItemCount}");
+                    Console.WriteLine($"min values - workerThreads: {workersThreads}, completionPortThreads: {completionPortThreads}");
+                    Console.WriteLine($"ThreadCount: {ThreadPool.ThreadCount}, CompletedWorkItemCount: {ThreadPool.CompletedWorkItemCount}, PendingWorkItemCount: {ThreadPool.PendingWorkItemCount}");
                     throw;
                 }
                 using (var session = store.OpenSession())

--- a/test/FastTests/Client/BulkInserts.cs
+++ b/test/FastTests/Client/BulkInserts.cs
@@ -76,6 +76,8 @@ namespace FastTests.Client
                     _testOutputHelper.WriteLine($"max values - workerThreads: {workersThreads}, completionPortThreads: {completionPortThreads}");
                     ThreadPool.GetMinThreads(out workersThreads, out completionPortThreads);
                     _testOutputHelper.WriteLine($"min values - workerThreads: {workersThreads}, completionPortThreads: {completionPortThreads}");
+                    
+                    _testOutputHelper.WriteLine($"ThreadCount: {ThreadPool.ThreadCount}, CompletedWorkItemCount: {ThreadPool.CompletedWorkItemCount}, PendingWorkItemCount: {ThreadPool.PendingWorkItemCount}");
                     throw;
                 }
                 using (var session = store.OpenSession())

--- a/test/SlowTests/Client/BulkInserts.cs
+++ b/test/SlowTests/Client/BulkInserts.cs
@@ -1,4 +1,8 @@
-﻿using System.Threading.Tasks;
+﻿using System;
+using System.Diagnostics;
+using System.IO;
+using System.Threading.Tasks;
+using Raven.Debug.StackTrace;
 using Tests.Infrastructure;
 using Xunit;
 using Xunit.Abstractions;
@@ -14,9 +18,20 @@ namespace SlowTests.Client
         [Fact]
         public async Task Simple_Bulk_Insert_With_Ssl()
         {
+            using var p = Process.GetCurrentProcess();
             using (var x = new FastTests.Client.BulkInserts(Output))
             {
-                await x.Simple_Bulk_Insert(useSsl: true);
+                var task = x.Simple_Bulk_Insert(useSsl: true);
+
+                if (task.Wait(TimeSpan.FromSeconds(90)) == false)
+                {
+                    StringWriter outputWriter = new ();
+                    StackTracer.ShowStackTraceWithSnapshot(p.Id, outputWriter);
+                    Console.WriteLine("Stack Traces for Simple_Bulk_Insert_With_Ssl");
+                    Console.WriteLine(outputWriter.ToString());
+                }
+                
+                await task;
             }
         }
     }

--- a/test/SlowTests/Client/BulkInserts.cs
+++ b/test/SlowTests/Client/BulkInserts.cs
@@ -3,6 +3,7 @@ using System.Diagnostics;
 using System.IO;
 using System.Threading.Tasks;
 using Raven.Debug.StackTrace;
+using Raven.Server.Documents.Handlers.Debugging;
 using Tests.Infrastructure;
 using Xunit;
 using Xunit.Abstractions;
@@ -18,15 +19,15 @@ namespace SlowTests.Client
         [Fact]
         public async Task Simple_Bulk_Insert_With_Ssl()
         {
-            using var p = Process.GetCurrentProcess();
             using (var x = new FastTests.Client.BulkInserts(Output))
             {
                 var task = x.Simple_Bulk_Insert(useSsl: true);
 
                 if (task.Wait(TimeSpan.FromSeconds(90)) == false)
                 {
+                    Console.WriteLine("Timeout on test, will generate dump (hopefully)");
                     StringWriter outputWriter = new ();
-                    StackTracer.ShowStackTraceWithSnapshot(p.Id, outputWriter);
+                    ThreadsHandler.OutputResultToStream(outputWriter);
                     Console.WriteLine("Stack Traces for Simple_Bulk_Insert_With_Ssl");
                     Console.WriteLine(outputWriter.ToString());
                 }

--- a/test/Tryouts/Program.cs
+++ b/test/Tryouts/Program.cs
@@ -31,9 +31,9 @@ namespace Tryouts
                 try
                 {
                     using (var testOutputHelper = new ConsoleTestOutputHelper())
-                    using (var test = new ClusterDatabaseMaintenance(testOutputHelper))
+                    using (var test = new BulkInserts(testOutputHelper))
                     {
-                        await test.ReshuffleAfterPromotion();
+                        await test.Simple_Bulk_Insert(false);
                     }
                 }
                 catch (Exception e)


### PR DESCRIPTION
…nsert

### Issue link

https://issues.hibernatingrhinos.com/issue/RavenDB-17122

### Additional description

A sync call in an async context may stall for a long time, see:
https://ayende.com/blog/166913/mixing-sync-async-calls

### Type of change

- Bug fix
- 
### How risky is the change?

- Low 
- 
### Backward compatibility

- Non breaking change

### Is it platform specific issue?

- No

### Documentation update

- No documentation update is needed 

### Testing 

- Needs to be tested on CI

### Is there any existing behavior change of other features due to this change?

- No

### UI work

- No UI work is needed
