### PR TITLE
RavenDB-18337 - add the tcp listener only when it was successfully started

### DIFF
--- a/src/Raven.Server/RavenServer.cs
+++ b/src/Raven.Server/RavenServer.cs
@@ -1783,7 +1783,7 @@ namespace Raven.Server
                         Logger.Info($"RavenDB TCP is configured to use {string.Join(", ", Configuration.Core.TcpServerUrls)} and bind to {ipAddress} at {port}");
 
                     var listener = new TcpListener(ipAddress, status.Port != 0 ? status.Port : port);
-                    status.Listeners.Add(listener);
+
                     try
                     {
                         listener.Start();
@@ -1804,6 +1804,8 @@ namespace Raven.Server
                             Logger.Operations(msg, ex);
                         continue;
                     }
+
+                    status.Listeners.Add(listener);
 
                     successfullyBoundToAtLeastOne = true;
                     var listenerLocalEndpoint = (IPEndPoint)listener.LocalEndpoint;


### PR DESCRIPTION
### Issue link

https://issues.hibernatingrhinos.com/issue/RavenDB-18337

### Additional description

Add the TCP listener only when it was successfully started.
If it's not the only TCP connection, we'll try to connect to it (after `Start()` failed)

### Type of change

- Bug fix

### How risky is the change?

- Low 

### Testing 

- It has been verified by manual testing
