### PR TITLE
RavenDB-18339 ConstructionInsideWholeSegment fails on MacOS

### DIFF
--- a/test/FastTests/Sparrow/ByteStringTests.cs
+++ b/test/FastTests/Sparrow/ByteStringTests.cs
@@ -49,8 +49,8 @@ namespace FastTests.Sparrow
                 context.Allocate(1, out var byteStringNextSegment);
 
                 long startLocation = (long)byteStringInFirstSegment._pointer;
-                Assert.InRange((long)byteStringWholeSegment._pointer, startLocation, startLocation + ByteStringContext.MinBlockSizeInBytes);
-                Assert.NotInRange((long)byteStringNextSegment._pointer, startLocation, startLocation + ByteStringContext.MinBlockSizeInBytes);
+                Assert.InRange((long)byteStringWholeSegment._pointer, startLocation, startLocation + ByteStringContext.MinBlockSizeInBytes -1);
+                Assert.NotInRange((long)byteStringNextSegment._pointer, startLocation, startLocation + ByteStringContext.MinBlockSizeInBytes -1);
             }
         }
 


### PR DESCRIPTION
### Issue link

https://issues.hibernatingrhinos.com/issue/RavenDB-18339 

### Additional description

Fixing valid range in test to avoid inclusive check where is should be exclusive.