### PR TITLE
RavenDB-18359 sign setup-as-service.ps1 in build scripts

### DIFF
--- a/scripts/copyAssets.ps1
+++ b/scripts/copyAssets.ps1
@@ -67,8 +67,8 @@ function CopyWindowsServiceScripts ( $projectDir, $targetDir, $packOpts ) {
     Copy-Item $uninstallServicePs1Path $uninstallServicePs1TargetPath
 
     if ($packOpts.VersionInfo.BuildType.ToLower() -ne 'custom') {
-        write-host "Signing $uninstallServicePs1TargetPath"
-        SignFile $projectDir $uninstallServicePs1TargetPath $packOpts.DryRunSign
+        write-host "Signing $startAsServicePs1TargetPath"
+        SignFile $projectDir $startAsServicePs1TargetPath $packOpts.DryRunSign
 
         write-host "Signing $uninstallServicePs1TargetPath"
         SignFile $projectDir $uninstallServicePs1TargetPath $packOpts.DryRunSign


### PR DESCRIPTION
### Issue link

https://issues.hibernatingrhinos.com/issue/RavenDB-18359

# Description

Sign the file!

### Type of change

- Bug fix

### How risky is the change?

- Low 

### Backward compatibility

- Non breaking change

### Is it platform specific issue?

- No

### Documentation update

- No documentation update is needed 

### Is there any existing behavior change of other features due to this change?

- No

### UI work

- No UI work is needed
