### PR TITLE
5.2_RavenDB-18296: fix backup not ascii database name to AWS s3

### DIFF
--- a/src/Raven.Server/Documents/PeriodicBackup/Aws/RavenAwsS3Client.cs
+++ b/src/Raven.Server/Documents/PeriodicBackup/Aws/RavenAwsS3Client.cs
@@ -5,6 +5,7 @@ using System.Linq;
 using System.Net;
 using System.Threading;
 using System.Threading.Tasks;
+using System.Web;
 using Amazon;
 using Amazon.Runtime;
 using Amazon.S3;
@@ -368,7 +369,7 @@ namespace Raven.Server.Documents.PeriodicBackup.Aws
                 return;
 
             foreach (var kvp in metadata)
-                collection[kvp.Key] = kvp.Value;
+                collection[Uri.EscapeDataString(kvp.Key)] = Uri.EscapeDataString(kvp.Value);
         }
 
         private static IDictionary<string, string> ConvertMetadata(MetadataCollection collection)

--- a/test/SlowTests/Server/Documents/PeriodicBackup/Aws.cs
+++ b/test/SlowTests/Server/Documents/PeriodicBackup/Aws.cs
@@ -130,9 +130,9 @@ namespace SlowTests.Server.Documents.PeriodicBackup
                 else
                 {
                     key = $"{blobs[0]}";
-                    if (testBlobKeyAsFolder)
-                        key += "/";
                 }
+                if (testBlobKeyAsFolder)
+                    key += "/";
 
 
                 var sb = new StringBuilder();

--- a/test/SlowTests/Server/Documents/PeriodicBackup/Aws.cs
+++ b/test/SlowTests/Server/Documents/PeriodicBackup/Aws.cs
@@ -88,123 +88,80 @@ namespace SlowTests.Server.Documents.PeriodicBackup
         }
 
         [AmazonS3Theory]
-        [InlineData(5, false, UploadType.Regular)]
-        [InlineData(5, true, UploadType.Regular)]
-        [InlineData(11, false, UploadType.Chunked)]
-        [InlineData(11, true, UploadType.Chunked)]
+        [InlineData(5, false, UploadType.Regular, false)]
+        [InlineData(5, true, UploadType.Regular, false)]
+        [InlineData(11, false, UploadType.Chunked, false)]
+        [InlineData(11, true, UploadType.Chunked, false)]
+        [InlineData(5, false, UploadType.Regular, true)]
+        [InlineData(5, true, UploadType.Regular, true)]
+        [InlineData(11, false, UploadType.Chunked, true)]
+        [InlineData(11, true, UploadType.Chunked, true)]
         // ReSharper disable once InconsistentNaming
-        public async Task put_object_multipart(int sizeInMB, bool testBlobKeyAsFolder, UploadType uploadType)
+        public async Task put_object_multipart(int sizeInMB, bool testBlobKeyAsFolder, UploadType uploadType, bool noAsciiDbName)
         {
-            await PutObject(sizeInMB, testBlobKeyAsFolder, uploadType);
+            await PutObject(sizeInMB, testBlobKeyAsFolder, uploadType, noAsciiDbName);
         }
 
         // ReSharper disable once InconsistentNaming
-        private async Task PutObject(int sizeInMB, bool testBlobKeyAsFolder, UploadType uploadType)
+        private async Task PutObject(int sizeInMB, bool testBlobKeyAsFolder, UploadType uploadType, bool noAsciiDbName)
         {
             var settings = GetS3Settings();
             var blobs = GenerateBlobNames(settings, 1, out _);
             Assert.Equal(1, blobs.Count);
-            var key = $"{blobs[0]}";
-            if (testBlobKeyAsFolder)
-                key += "/";
-            
+            var key = "";
+
             var progress = new Progress();
             using (var client = new RavenAwsS3Client(settings, DefaultConfiguration, progress))
             {
                 client.MaxUploadPutObject = new Sparrow.Size(10, SizeUnit.Megabytes);
                 client.MinOnePartUploadSizeLimit = new Sparrow.Size(7, SizeUnit.Megabytes);
-            
+
+                var property1 = "property1";
+                var property2 = "property2";
                 var value1 = Guid.NewGuid().ToString();
                 var value2 = Guid.NewGuid().ToString();
-            
+                if (noAsciiDbName)
+                {
+                    string dateStr = DateTime.Now.ToString("yyyy-MM-dd-HH-mm-ss");
+                    key = $"{dateStr}.ravendb-żżżרייבן-A-backup/{dateStr}.ravendb-full-backup";
+                    property1 = "Description-żżרייבן";
+                    value1 = "ravendb-żżżרייבן-A-backup";
+                }
+                else
+                {
+                    key = $"{blobs[0]}";
+                    if (testBlobKeyAsFolder)
+                        key += "/";
+                }
+
+
                 var sb = new StringBuilder();
                 for (var i = 0; i < sizeInMB * 1024 * 1024; i++)
                 {
                     sb.Append("a");
                 }
-            
+
                 long streamLength;
                 using (var memoryStream = new MemoryStream(Encoding.UTF8.GetBytes(sb.ToString())))
                 {
                     streamLength = memoryStream.Length;
                     client.PutObject(key,
                         memoryStream,
-                        new Dictionary<string, string>
-                        {
-                                {"property1", value1},
-                                {"property2", value2}
-                        });
-                }
-            
-                var @object = await client.GetObjectAsync(key);
-                Assert.NotNull(@object);
-            
-                using (var reader = new StreamReader(@object.Data))
-                    Assert.Equal(sb.ToString(), reader.ReadToEnd());
-            
-                var property1 = @object.Metadata.Keys.Single(x => x.Contains("property1"));
-                var property2 = @object.Metadata.Keys.Single(x => x.Contains("property2"));
-            
-                Assert.Equal(value1, @object.Metadata[property1]);
-                Assert.Equal(value2, @object.Metadata[property2]);
-            
-                Assert.Equal(UploadState.Done, progress.UploadProgress.UploadState);
-                Assert.Equal(uploadType, progress.UploadProgress.UploadType);
-                Assert.Equal(streamLength, progress.UploadProgress.TotalInBytes);
-                Assert.Equal(streamLength, progress.UploadProgress.UploadedInBytes);
-            }
-        }
-
-        [AmazonS3Theory]
-        [InlineData(11, UploadType.Chunked)]
-        [InlineData(5, UploadType.Regular)]
-        [InlineData(11, UploadType.Chunked)]
-        [InlineData(11, UploadType.Chunked)]
-        public async Task put_object_not_ascii(int sizeInMB, UploadType uploadType)
-        {
-            var settings = GetS3Settings();
-            var blobs = GenerateBlobNames(settings, 1, out _);
-            Assert.Equal(1, blobs.Count);
-
-            string dateStr = DateTime.Now.ToString("yyyy-MM-dd-HH-mm-ss");
-            var key = $"{dateStr}.ravendb-żżżרייבן-A-backup/{dateStr}.ravendb-full-backup";
-            var property = "Description-żżרייבן";
-            var value = "ravendb-żżżרייבן-A-backup";
-
-            var metadata = new Dictionary<string, string> {{ property, value },};
-
-
-            var progress = new Progress();
-            using (var client = new RavenAwsS3Client(settings, DefaultConfiguration, progress))
-            {
-                client.MaxUploadPutObject = new Sparrow.Size(10, SizeUnit.Megabytes);
-                client.MinOnePartUploadSizeLimit = new Sparrow.Size(7, SizeUnit.Megabytes);
-
-                var sb = new StringBuilder();
-                for (var i = 0; i < sizeInMB * 1024 * 1024; i++)
-                {
-                    sb.Append("a");
-                }
-
-                long streamLength;
-                using (var memoryStream = new MemoryStream(Encoding.UTF8.GetBytes(sb.ToString())))
-                {
-                    streamLength = memoryStream.Length;
-                    client.PutObject(key, memoryStream, metadata);
+                        new Dictionary<string, string> {{property1, value1}, {property2, value2}});
                 }
 
                 var @object = await client.GetObjectAsync(key);
                 Assert.NotNull(@object);
 
                 using (var reader = new StreamReader(@object.Data))
-                {
                     Assert.Equal(sb.ToString(), reader.ReadToEnd());
-                }
 
-                Console.WriteLine(@object.Metadata.Keys);
-                var property1 = @object.Metadata.Keys.Single(x => x.Contains(Uri.EscapeDataString(property).ToLower()));
+                var property1check = @object.Metadata.Keys.Single(x => x.Contains(Uri.EscapeDataString(property1).ToLower()));
+                var property2check = @object.Metadata.Keys.Single(x => x.Contains(property2));
 
-                Assert.Equal(Uri.EscapeDataString(value), @object.Metadata[property1]);
+                Assert.Equal(Uri.EscapeDataString(value1), @object.Metadata[property1check]);
+                Assert.Equal(value2, @object.Metadata[property2check]);
+
                 Assert.Equal(UploadState.Done, progress.UploadProgress.UploadState);
                 Assert.Equal(uploadType, progress.UploadProgress.UploadType);
                 Assert.Equal(streamLength, progress.UploadProgress.TotalInBytes);

--- a/test/SlowTests/Server/Documents/PeriodicBackup/Restore/RestoreFromAwsS3.cs
+++ b/test/SlowTests/Server/Documents/PeriodicBackup/Restore/RestoreFromAwsS3.cs
@@ -1,4 +1,4 @@
-using System;
+﻿using System;
 using System.Threading.Tasks;
 using Raven.Client.Documents.Operations.Backups;
 using Raven.Client.Exceptions;
@@ -54,6 +54,8 @@ namespace SlowTests.Server.Documents.PeriodicBackup.Restore
         
         [AmazonS3Fact, Trait("Category", "Smuggler")]
         public async Task can_backup_and_restore() => await can_backup_and_restore_internal();
+        [AmazonS3Fact, Trait("Category", "Smuggler")]
+        public async Task can_backup_and_restore_no_ascii() => await can_backup_and_restore_internal("żżżרייבן");
         [AmazonS3Fact, Trait("Category", "Smuggler")]
         public async Task can_backup_and_restore_snapshot() => await can_backup_and_restore_snapshot_internal();
         [AmazonS3Fact, Trait("Category", "Smuggler")]

--- a/test/SlowTests/Server/Documents/PeriodicBackup/Restore/RestoreFromS3.cs
+++ b/test/SlowTests/Server/Documents/PeriodicBackup/Restore/RestoreFromS3.cs
@@ -27,12 +27,21 @@ namespace SlowTests.Server.Documents.PeriodicBackup.Restore
             _remoteFolderName = GetRemoteFolder(GetType().Name);
         }
 
-        protected async Task can_backup_and_restore_internal()
+        protected async Task can_backup_and_restore_internal(string dbName = null)
         {
             var s3Settings = GetS3Settings();
-
-            using (var store = GetDocumentStore())
+            Options options = null;
+            if (dbName != null)
             {
+                options = new Options()
+                {
+                    ModifyDatabaseName = s => s + dbName
+                };
+            }
+
+            using (var store = GetDocumentStore(options: options))
+            {
+                
                 using (var session = store.OpenAsyncSession())
                 {
                     await session.StoreAsync(new User { Name = "oren" }, "users/1");


### PR DESCRIPTION
### Issue link

https://issues.hibernatingrhinos.com/issue/RavenDB-18296

### Additional description

fix backup not ascii database name to AWS s3.

_Please delete below the options that are not relevant_

### Type of change

- Bug fix
 
### How risky is the change?

- Low 

### Backward compatibility

- Not relevant

### Is it platform specific issue?

- No

### Documentation update

- No documentation update is needed 

### Testing 

- Tests have been added that prove the fix is effective or that the feature works

### Is there any existing behavior change of other features due to this change?

- No

### UI work

- No UI work is needed
