### PR TITLE
RavenDB-18368 Cleanup and refactoring of internal sharding API

### DIFF
--- a/src/Raven.Client/ServerWide/Sharding/MigrationStatus.cs
+++ b/src/Raven.Client/ServerWide/Sharding/MigrationStatus.cs
@@ -1,0 +1,19 @@
+﻿namespace Raven.Client.ServerWide.Sharding;
+
+public enum MigrationStatus
+{
+    None,
+
+    // source is in progress of sending the bucket
+    Moving,
+
+    // the source has completed to send everything he has
+    // and the destinations member nodes start confirm having all docs
+    // at this stage writes will still go to the source shard
+    Moved,
+
+    // all member nodes confirmed receiving the bucket
+    // the mapping is updated so any traffic will go now to the destination
+    // the source will start the cleanup process
+    OwnershipTransferred
+}

--- a/src/Raven.Client/ServerWide/Sharding/ShardBucketMigration.cs
+++ b/src/Raven.Client/ServerWide/Sharding/ShardBucketMigration.cs
@@ -1,0 +1,49 @@
+﻿using System;
+using System.Collections.Generic;
+using Sparrow;
+
+namespace Raven.Client.ServerWide.Sharding;
+
+public class ShardBucketMigration : IDatabaseTask
+{
+    public MigrationStatus Status;
+    public int Bucket;
+    public int SourceShard;
+    public int DestinationShard;
+    public long MigrationIndex;
+    public long? ConfirmationIndex;
+    public string LastSourceChangeVector;
+
+    public List<string> ConfirmedDestinations = new List<string>();
+    public List<string> ConfirmedSourceCleanup = new List<string>();
+
+    public string MentorNode;
+    public override string ToString()
+    {
+        return $"Bucket '{Bucket}' is migrated from '{SourceShard}' to '{DestinationShard}' at status '{Status}'.{Environment.NewLine}" +
+               $"Migrations index '{MigrationIndex}', Last change vector from source '{LastSourceChangeVector}', " +
+               $"Propagated to {string.Join(", ", ConfirmedDestinations)} and confirmed at {ConfirmationIndex}, Cleaned up at {string.Join(", ", ConfirmedSourceCleanup)}";
+    }
+
+    private ulong? _hashCode;
+
+    public ulong GetTaskKey()
+    {
+        if (_hashCode.HasValue)
+            return _hashCode.Value;
+
+        var hash = Hashing.Combine((ulong)SourceShard, (ulong)DestinationShard);
+        hash = Hashing.Combine(hash, (ulong)Bucket);
+        _hashCode = Hashing.Combine(hash, (ulong)MigrationIndex);
+
+        return _hashCode.Value;
+    }
+
+    public string GetMentorNode() => MentorNode;
+
+    public string GetDefaultTaskName() => GetTaskName();
+
+    public string GetTaskName() => $"Bucket '{Bucket}' migration from '{SourceShard}' to '{DestinationShard}' @ {MigrationIndex}";
+
+    public bool IsResourceIntensive() => false;
+}

--- a/src/Raven.Client/ServerWide/Sharding/ShardBucketRange.cs
+++ b/src/Raven.Client/ServerWide/Sharding/ShardBucketRange.cs
@@ -1,0 +1,8 @@
+﻿namespace Raven.Client.ServerWide.Sharding;
+
+public class ShardBucketRange
+{
+    public int BucketRangeStart;
+
+    public int ShardNumber;
+}

--- a/src/Raven.Client/Util/ClientShardHelper.cs
+++ b/src/Raven.Client/Util/ClientShardHelper.cs
@@ -6,8 +6,8 @@
         {
             var name = ToDatabaseName(database);
 
-            int shardIndex = name.IndexOf('$');
-            if (shardIndex == -1)
+            int shardNumberPosition = name.IndexOf('$');
+            if (shardNumberPosition == -1)
                 return $"{name}${shardNumber}";
 
             return name;
@@ -15,11 +15,11 @@
 
         public static string ToDatabaseName(string shardName)
         {
-            int shardIndex = shardName.IndexOf('$');
-            if (shardIndex == -1)
+            int shardNumberPosition = shardName.IndexOf('$');
+            if (shardNumberPosition == -1)
                 return shardName;
 
-            return shardName.Substring(0, shardIndex);
+            return shardName.Substring(0, shardNumberPosition);
         }
     }
 }

--- a/src/Raven.Server/Documents/DatabasesLandlord.cs
+++ b/src/Raven.Server/Documents/DatabasesLandlord.cs
@@ -331,8 +331,7 @@ namespace Raven.Server.Documents
 
         public bool ShouldDeleteDatabase(TransactionOperationContext context, string dbName, RawDatabaseRecord rawRecord, bool fromReplication = false)
         {
-            var index = ShardHelper.TryGetShardIndex(dbName);
-            var tag = index == -1 ? _serverStore.NodeTag : $"{_serverStore.NodeTag}${index}";
+            var tag = ShardHelper.TryGetShardNumber(dbName, out var shardNumber) ? $"{_serverStore.NodeTag}${shardNumber}" : _serverStore.NodeTag;
 
             var deletionInProgress = DeletionInProgressStatus.No;
             var directDelete = rawRecord.DeletionInProgress?.TryGetValue(tag, out deletionInProgress) == true &&

--- a/src/Raven.Server/Documents/ETL/EtlLoader.cs
+++ b/src/Raven.Server/Documents/ETL/EtlLoader.cs
@@ -692,8 +692,7 @@ namespace Raven.Server.Documents.ETL
 
         public void HandleDatabaseValueChanged(DatabaseRecord record)
         {
-            var dbName = record.DatabaseName;
-            ShardHelper.TryGetShardIndexAndDatabaseName(ref dbName);
+            var dbName = ShardHelper.ToDatabaseName(record.DatabaseName);
 
             using (_serverStore.ContextPool.AllocateOperationContext(out TransactionOperationContext context))
             using (context.OpenReadTransaction())

--- a/src/Raven.Server/Documents/ETL/EtlProcess.cs
+++ b/src/Raven.Server/Documents/ETL/EtlProcess.cs
@@ -89,8 +89,7 @@ namespace Raven.Server.Documents.ETL
 
         public static EtlProcessState GetProcessState(DocumentDatabase database, string configurationName, string transformationName)
         {
-            var databaseName = database.Name;
-            ShardHelper.TryGetShardIndexAndDatabaseName(ref databaseName);
+            var databaseName = ShardHelper.ToDatabaseName(database.Name);
 
             using (database.ServerStore.ContextPool.AllocateOperationContext(out TransactionOperationContext context))
             using (context.OpenReadTransaction())

--- a/src/Raven.Server/Documents/Handlers/Debugging/ServerWideDebugInfoPackageHandler.cs
+++ b/src/Raven.Server/Documents/Handlers/Debugging/ServerWideDebugInfoPackageHandler.cs
@@ -57,8 +57,8 @@ namespace Raven.Server.Documents.Handlers.Debugging
             nameof(DatabaseRecord.TimeSeries),
 
             nameof(DatabaseRecord.Shards),
-            nameof(DatabaseRecord.ShardAllocations),
-            nameof(DatabaseRecord.BucketMigrations),
+            nameof(DatabaseRecord.ShardBucketRanges),
+            nameof(DatabaseRecord.ShardBucketMigrations),
             nameof(DatabaseRecord.MigrationCutOffIndex),
             nameof(DatabaseRecord.ShardedDatabaseId),
         };

--- a/src/Raven.Server/Documents/Indexes/IndexStore.cs
+++ b/src/Raven.Server/Documents/Indexes/IndexStore.cs
@@ -1003,8 +1003,8 @@ namespace Raven.Server.Documents.Indexes
             ValidateAutoIndex(definition);
             definition.DeploymentMode = _documentDatabase.Configuration.Indexing.AutoIndexDeploymentMode;
 
-            var name = _documentDatabase.Name;
-            ShardHelper.TryGetShardIndexAndDatabaseName(ref name);
+            var name = ShardHelper.ToDatabaseName(_documentDatabase.Name);
+
             var command = PutAutoIndexCommand.Create((AutoIndexDefinitionBaseServerSide)definition, name, raftRequestId, _documentDatabase.Configuration.Indexing.AutoIndexDeploymentMode);
 
             long index = 0;

--- a/src/Raven.Server/Documents/Replication/BucketMigrationReplication.cs
+++ b/src/Raven.Server/Documents/Replication/BucketMigrationReplication.cs
@@ -1,6 +1,7 @@
 ﻿using System;
 using Raven.Client.Documents.Replication;
 using Raven.Client.ServerWide;
+using Raven.Client.ServerWide.Sharding;
 using Sparrow;
 using Sparrow.Json.Parsing;
 
@@ -21,7 +22,7 @@ namespace Raven.Server.Documents.Replication
             MigrationIndex = migrationIndex;
         }
 
-        public bool ForBucketMigration(BucketMigration migration)
+        public bool ForBucketMigration(ShardBucketMigration migration)
         {
             if (migration.MigrationIndex != MigrationIndex)
                 return false;

--- a/src/Raven.Server/Documents/Replication/ReplicationLoader.cs
+++ b/src/Raven.Server/Documents/Replication/ReplicationLoader.cs
@@ -961,7 +961,8 @@ namespace Raven.Server.Documents.Replication
 
         private void HandleMigrationReplication(DatabaseRecord newRecord, List<IDisposable> instancesToDispose)
         {
-            var myShard = ShardHelper.TryGetShardIndex(newRecord.DatabaseName);
+            if (ShardHelper.TryGetShardNumber(newRecord.DatabaseName, out var myShard) == false)
+                return;
             
             // remove
             foreach (var handler in OutgoingHandlers)
@@ -969,7 +970,7 @@ namespace Raven.Server.Documents.Replication
                 if (handler is not OutgoingMigrationReplicationHandler migrationHandler)
                     continue;
 
-                if (newRecord.BucketMigrations.TryGetValue(migrationHandler.BucketMigrationNode.Bucket, out var migration) == false)
+                if (newRecord.ShardBucketMigrations.TryGetValue(migrationHandler.BucketMigrationNode.Bucket, out var migration) == false)
                 {
                     RegisterMigrationConnectionToDispose(instancesToDispose, migrationHandler);
                     continue;
@@ -996,7 +997,7 @@ namespace Raven.Server.Documents.Replication
             }
 
             // add
-            foreach (var migration in newRecord.BucketMigrations)
+            foreach (var migration in newRecord.ShardBucketMigrations)
             {
                 var process = migration.Value;
 

--- a/src/Raven.Server/Documents/ShardedDocumentDatabase.cs
+++ b/src/Raven.Server/Documents/ShardedDocumentDatabase.cs
@@ -19,7 +19,7 @@ public class ShardedDocumentDatabase : DocumentDatabase
     public ShardedDocumentDatabase(string name, RavenConfiguration configuration, ServerStore serverStore, Action<string> addToInitLog) : 
         base(name, configuration, serverStore, addToInitLog)
     {
-        ShardNumber = ShardHelper.TryGetShardIndex(name);
+        ShardNumber = ShardHelper.GetShardNumber(name);
         ShardedDatabaseName = ShardHelper.ToDatabaseName(name);
     }
 

--- a/src/Raven.Server/Documents/Sharding/Handlers/ShardedDocumentHandler.cs
+++ b/src/Raven.Server/Documents/Sharding/Handlers/ShardedDocumentHandler.cs
@@ -30,7 +30,7 @@ namespace Raven.Server.Documents.Sharding.Handlers
 
             using (ContextPool.AllocateOperationContext(out TransactionOperationContext context))
             {
-                var index = DatabaseContext.GetShardIndex(context, id);
+                var index = DatabaseContext.GetShardNumber(context, id);
 
                 var cmd = new ShardedHeadCommand(this, Headers.IfNoneMatch);
 
@@ -47,7 +47,7 @@ namespace Raven.Server.Documents.Sharding.Handlers
 
             using (ContextPool.AllocateOperationContext(out TransactionOperationContext context))
             {
-                var index = DatabaseContext.GetShardIndex(context, id);
+                var index = DatabaseContext.GetShardNumber(context, id);
 
                 var cmd = new ShardedCommand(this, Headers.None);
                 await DatabaseContext.RequestExecutors[index].ExecuteAsync(cmd, context);
@@ -73,7 +73,7 @@ namespace Raven.Server.Documents.Sharding.Handlers
                     id = clusterId;
                 }
                 
-                var index = DatabaseContext.GetShardIndex(context, id);
+                var index = DatabaseContext.GetShardNumber(context, id);
                 var cmd = new ShardedCommand(this, Headers.IfMatch, content: doc);
                 await DatabaseContext.RequestExecutors[index].ExecuteAsync(cmd, context);
                 HttpContext.Response.StatusCode = (int)cmd.StatusCode;
@@ -96,7 +96,7 @@ namespace Raven.Server.Documents.Sharding.Handlers
             {
                 var patch = await context.ReadForMemoryAsync(RequestBodyStream(), "ScriptedPatchRequest");
 
-                var index = DatabaseContext.GetShardIndex(context, id);
+                var index = DatabaseContext.GetShardNumber(context, id);
 
                 var cmd = new ShardedCommand(this, Headers.IfMatch, content: patch);
 
@@ -172,7 +172,7 @@ namespace Raven.Server.Documents.Sharding.Handlers
             
             using (ContextPool.AllocateOperationContext(out TransactionOperationContext context))
             {
-                var index = DatabaseContext.GetShardIndex(context, id);
+                var index = DatabaseContext.GetShardNumber(context, id);
 
                 var cmd = new ShardedCommand(this, Headers.IfMatch);
                 await DatabaseContext.RequestExecutors[index].ExecuteAsync(cmd, context);
@@ -190,7 +190,7 @@ namespace Raven.Server.Documents.Sharding.Handlers
 
             using (ContextPool.AllocateOperationContext(out TransactionOperationContext context))
             {
-                var index = DatabaseContext.GetShardIndex(context, id);
+                var index = DatabaseContext.GetShardNumber(context, id);
 
                 var cmd = new ShardedCommand(this, Headers.None);
                 await DatabaseContext.RequestExecutors[index].ExecuteAsync(cmd, context);

--- a/src/Raven.Server/Documents/Sharding/Handlers/ShardedHiLoHandler.cs
+++ b/src/Raven.Server/Documents/Sharding/Handlers/ShardedHiLoHandler.cs
@@ -39,10 +39,10 @@ namespace Raven.Server.Documents.Sharding.Handlers
         {
             var tag = GetQueryStringValueAndAssertIfSingleAndNotEmpty("tag");
             var hiloDocId = HiLoHandler.RavenHiloIdPrefix + tag;
-            var shardIndex = DatabaseContext.GetShardIndex(context, hiloDocId);
+            var shardNumber = DatabaseContext.GetShardNumber(context, hiloDocId);
 
             var cmd = new ShardedCommand(this, Headers.None);
-            await DatabaseContext.RequestExecutors[shardIndex].ExecuteAsync(cmd, context);
+            await DatabaseContext.RequestExecutors[shardNumber].ExecuteAsync(cmd, context);
             
             HttpContext.Response.StatusCode = (int)cmd.StatusCode;
             HttpContext.Response.Headers[Constants.Headers.Etag] = cmd.Response?.Headers?.ETag?.Tag;

--- a/src/Raven.Server/Documents/Sharding/Handlers/ShardedOngoingTasks.cs
+++ b/src/Raven.Server/Documents/Sharding/Handlers/ShardedOngoingTasks.cs
@@ -114,12 +114,11 @@ namespace Raven.Server.Documents.Sharding.Handlers
                             if (name == null)
                                 throw new ArgumentException($"ETL task {key} is sharded, you must specify a query string argument for 'name', but none was specified.");
 
-                            var index = ShardHelper.TryGetShardIndexAndDatabaseName(ref name);
-                            if (index == -1)
+                            if (ShardHelper.TryGetShardNumberAndDatabaseName(ref name, out var shardNumber) == false)
                                 throw new ArgumentException($"ETL task '{name}' is sharded, you must specify the shard index, for example : '{name}$0'");
 
                             var cmd = new ShardedCommand(this, Headers.None);
-                            await DatabaseContext.RequestExecutors[index].ExecuteAsync(cmd, context);
+                            await DatabaseContext.RequestExecutors[shardNumber].ExecuteAsync(cmd, context);
 
                             HttpContext.Response.StatusCode = (int)cmd.StatusCode;
                             HttpContext.Response.Headers[Constants.Headers.Etag] = cmd.Response?.Headers?.ETag?.Tag;

--- a/src/Raven.Server/ServerWide/Commands/DeleteDatabaseCommand.cs
+++ b/src/Raven.Server/ServerWide/Commands/DeleteDatabaseCommand.cs
@@ -79,20 +79,20 @@ namespace Raven.Server.ServerWide.Commands
         }
 
         
-        private DatabaseTopology RemoveDatabaseFromAllNodes(DatabaseRecord record, DatabaseTopology topology, string shardIndex, DeletionInProgressStatus deletionInProgressStatus)
+        private DatabaseTopology RemoveDatabaseFromAllNodes(DatabaseRecord record, DatabaseTopology topology, string shardNumber, DeletionInProgressStatus deletionInProgressStatus)
         {
             var allNodes = topology.AllNodes.Distinct();
 
             foreach (var node in allNodes)
             {
                 if (ClusterNodes.Contains(node))
-                    record.DeletionInProgress[node + shardIndex] = deletionInProgressStatus;
+                    record.DeletionInProgress[node + shardNumber] = deletionInProgressStatus;
             }
 
             return new DatabaseTopology {Stamp = record.Topology?.Stamp, ReplicationFactor = 0};
         }
 
-        private void RemoveDatabaseFromSingleNode(DatabaseRecord record, DatabaseTopology topology, string node, string shardIndex, DeletionInProgressStatus deletionInProgressStatus)
+        private void RemoveDatabaseFromSingleNode(DatabaseRecord record, DatabaseTopology topology, string node, string shardNumber, DeletionInProgressStatus deletionInProgressStatus)
         {
             if (topology.RelevantFor(node) == false)
             {
@@ -109,7 +109,7 @@ namespace Raven.Server.ServerWide.Commands
             }
 
             if (ClusterNodes.Contains(node))
-                record.DeletionInProgress[node + shardIndex] = deletionInProgressStatus;
+                record.DeletionInProgress[node + shardNumber] = deletionInProgressStatus;
         }
         public override void FillJson(DynamicJsonValue json)
         {

--- a/src/Raven.Server/ServerWide/Commands/ETL/UpdateEtlProcessStateCommand.cs
+++ b/src/Raven.Server/ServerWide/Commands/ETL/UpdateEtlProcessStateCommand.cs
@@ -53,8 +53,7 @@ namespace Raven.Server.ServerWide.Commands.ETL
 
         public override string GetItemId()
         {
-            var databaseName = DatabaseName;
-            ShardHelper.TryGetShardIndexAndDatabaseName(ref databaseName);
+            var databaseName = ShardHelper.ToDatabaseName(DatabaseName);
 
             return EtlProcessState.GenerateItemName(databaseName, ConfigurationName, TransformationName);
         }

--- a/src/Raven.Server/ServerWide/Commands/RemoveNodeFromDatabaseCommand.cs
+++ b/src/Raven.Server/ServerWide/Commands/RemoveNodeFromDatabaseCommand.cs
@@ -57,10 +57,10 @@ namespace Raven.Server.ServerWide.Commands
             }
         }
 
-        public string UpdateShardedDatabaseRecord(DatabaseRecord record, int shardIndex, long etag)
+        public string UpdateShardedDatabaseRecord(DatabaseRecord record, int shardNumber, long etag)
         {
-            record.Shards[shardIndex].RemoveFromTopology(NodeTag);
-            record.DeletionInProgress?.Remove($"{NodeTag}${shardIndex}");
+            record.Shards[shardNumber].RemoveFromTopology(NodeTag);
+            record.DeletionInProgress?.Remove($"{NodeTag}${shardNumber}");
 
             if (DatabaseId == null)
                 return null;

--- a/src/Raven.Server/ServerWide/Commands/Sharding/DestinationMigrationConfirmCommand.cs
+++ b/src/Raven.Server/ServerWide/Commands/Sharding/DestinationMigrationConfirmCommand.cs
@@ -1,6 +1,7 @@
 ﻿using System;
 using System.Linq;
 using Raven.Client.ServerWide;
+using Raven.Client.ServerWide.Sharding;
 using Raven.Server.Utils;
 using Sparrow.Json.Parsing;
 
@@ -23,7 +24,7 @@ namespace Raven.Server.ServerWide.Commands.Sharding
 
         public override void UpdateDatabaseRecord(DatabaseRecord record, long etag)
         {
-            if (record.BucketMigrations.TryGetValue(Bucket, out var migration) == false)
+            if (record.ShardBucketMigrations.TryGetValue(Bucket, out var migration) == false)
                 throw new InvalidOperationException($"Bucket '{Bucket}' not found in the migration buckets");
 
             if (migration.MigrationIndex != MigrationIndex)

--- a/src/Raven.Server/ServerWide/Commands/Sharding/SourceMigrationCleanupCommand.cs
+++ b/src/Raven.Server/ServerWide/Commands/Sharding/SourceMigrationCleanupCommand.cs
@@ -1,6 +1,7 @@
 ﻿using System;
 using System.Linq;
 using Raven.Client.ServerWide;
+using Raven.Client.ServerWide.Sharding;
 using Sparrow.Json.Parsing;
 
 namespace Raven.Server.ServerWide.Commands.Sharding
@@ -22,7 +23,7 @@ namespace Raven.Server.ServerWide.Commands.Sharding
 
         public override void UpdateDatabaseRecord(DatabaseRecord record, long etag)
         {
-            if (record.BucketMigrations.TryGetValue(Bucket, out var migration) == false)
+            if (record.ShardBucketMigrations.TryGetValue(Bucket, out var migration) == false)
                 throw new InvalidOperationException($"Bucket '{Bucket}' not found in the migration buckets");
 
             if (migration.MigrationIndex != MigrationIndex)
@@ -37,7 +38,7 @@ namespace Raven.Server.ServerWide.Commands.Sharding
             var shardTopology = record.Shards[migration.SourceShard];
             if (shardTopology.AllNodes.All(migration.ConfirmedSourceCleanup.Contains))
             {
-                record.BucketMigrations.Remove(Bucket);
+                record.ShardBucketMigrations.Remove(Bucket);
             }
         }
 

--- a/src/Raven.Server/ServerWide/Commands/Sharding/SourceMigrationSendCompletedCommand.cs
+++ b/src/Raven.Server/ServerWide/Commands/Sharding/SourceMigrationSendCompletedCommand.cs
@@ -1,5 +1,6 @@
 ﻿using System;
 using Raven.Client.ServerWide;
+using Raven.Client.ServerWide.Sharding;
 using Sparrow.Json.Parsing;
 
 namespace Raven.Server.ServerWide.Commands.Sharding
@@ -24,7 +25,7 @@ namespace Raven.Server.ServerWide.Commands.Sharding
 
         public override void UpdateDatabaseRecord(DatabaseRecord record, long etag)
         {
-            if (record.BucketMigrations.TryGetValue(Bucket, out var migration) == false)
+            if (record.ShardBucketMigrations.TryGetValue(Bucket, out var migration) == false)
                 throw new InvalidOperationException($"Bucket '{Bucket}' not found in the migration buckets");
 
             if (migration.MigrationIndex != MigrationIndex)

--- a/src/Raven.Server/ServerWide/Commands/Sharding/StartBucketMigrationCommand.cs
+++ b/src/Raven.Server/ServerWide/Commands/Sharding/StartBucketMigrationCommand.cs
@@ -1,6 +1,7 @@
 ﻿using System;
 using System.Linq;
 using Raven.Client.ServerWide;
+using Raven.Client.ServerWide.Sharding;
 using Raven.Server.Utils;
 using Sparrow.Json.Parsing;
 
@@ -25,9 +26,9 @@ namespace Raven.Server.ServerWide.Commands.Sharding
 
         public override void UpdateDatabaseRecord(DatabaseRecord record, long etag)
         {
-            if (record.BucketMigrations.Count > 0)
+            if (record.ShardBucketMigrations.Count > 0)
             {
-                foreach (var migration in record.BucketMigrations)
+                foreach (var migration in record.ShardBucketMigrations)
                 {
                     if (migration.Value.Status < MigrationStatus.OwnershipTransferred)
                         throw new InvalidOperationException(
@@ -38,7 +39,7 @@ namespace Raven.Server.ServerWide.Commands.Sharding
                 }
             }
 
-            record.BucketMigrations.Add(Bucket, new BucketMigration
+            record.ShardBucketMigrations.Add(Bucket, new ShardBucketMigration
             {
                 Bucket = Bucket,
                 DestinationShard = DestinationShard,

--- a/src/Raven.Server/ServerWide/Commands/Subscriptions/AcknowledgeSubscriptionBatchCommand.cs
+++ b/src/Raven.Server/ServerWide/Commands/Subscriptions/AcknowledgeSubscriptionBatchCommand.cs
@@ -53,7 +53,7 @@ namespace Raven.Server.ServerWide.Commands.Subscriptions
                 throw new SubscriptionDoesNotExistException($"Subscription with name '{subscriptionName}' does not exist");
 
             var subscription = JsonDeserializationCluster.SubscriptionState(existingValue);
-            var topology = ShardName == null ? record.Topology : record.Shards[ShardHelper.TryGetShardIndex(ShardName)];
+            var topology = ShardName == null ? record.Topology : record.Shards[ShardHelper.GetShardNumber(ShardName)];
             var lastResponsibleNode = GetLastResponsibleNode(HasHighlyAvailableTasks, topology, NodeTag);
             var appropriateNode = topology.WhoseTaskIsIt(RachisState.Follower, subscription, lastResponsibleNode);
             if (appropriateNode == null && record.DeletionInProgress.ContainsKey(NodeTag))

--- a/src/Raven.Server/ServerWide/Commands/Subscriptions/RecordBatchSubscriptionDocumentsCommand.cs
+++ b/src/Raven.Server/ServerWide/Commands/Subscriptions/RecordBatchSubscriptionDocumentsCommand.cs
@@ -86,7 +86,7 @@ namespace Raven.Server.ServerWide.Commands.Subscriptions
 
                 var subscriptionState = JsonDeserializationClient.SubscriptionState(existingValue);
 
-                var topology = string.IsNullOrEmpty(ShardName) ? record.Topology : record.Shards[ShardHelper.TryGetShardIndex(ShardName)];
+                var topology = string.IsNullOrEmpty(ShardName) ? record.Topology : record.Shards[ShardHelper.GetShardNumber(ShardName)];
                 var lastResponsibleNode = AcknowledgeSubscriptionBatchCommand.GetLastResponsibleNode(HasHighlyAvailableTasks, topology, NodeTag);
                 var appropriateNode = topology.WhoseTaskIsIt(RachisState.Follower, subscriptionState, lastResponsibleNode);
                 if (appropriateNode == null && record.DeletionInProgress.ContainsKey(NodeTag))

--- a/src/Raven.Server/ServerWide/Commands/Subscriptions/UpdateSubscriptionClientConnectionTime.cs
+++ b/src/Raven.Server/ServerWide/Commands/Subscriptions/UpdateSubscriptionClientConnectionTime.cs
@@ -34,7 +34,7 @@ namespace Raven.Server.ServerWide.Commands.Subscriptions
 
             var subscription = JsonDeserializationCluster.SubscriptionState(existingValue);
 
-            var topology = ShardName == null ? record.Topology : record.Shards[ShardHelper.TryGetShardIndex(ShardName)];
+            var topology = ShardName == null ? record.Topology : record.Shards[ShardHelper.GetShardNumber(ShardName)];
             var lastResponsibleNode = AcknowledgeSubscriptionBatchCommand.GetLastResponsibleNode(HasHighlyAvailableTasks, topology, NodeTag);
             var appropriateNode = topology.WhoseTaskIsIt(RachisState.Follower, subscription, lastResponsibleNode);
 

--- a/src/Raven.Server/ServerWide/Commands/UpdateTopologyCommand.cs
+++ b/src/Raven.Server/ServerWide/Commands/UpdateTopologyCommand.cs
@@ -21,8 +21,7 @@ namespace Raven.Server.ServerWide.Commands
         {
             At = at;
 
-            var shard = ShardHelper.TryGetShardIndexAndDatabaseName(ref DatabaseName);
-            if (shard != -1)
+            if (ShardHelper.TryGetShardNumberAndDatabaseName(ref DatabaseName, out var shard))
                 Shard = shard;
         }
 

--- a/src/Raven.Server/ServerWide/JsonDeserializationCluster.cs
+++ b/src/Raven.Server/ServerWide/JsonDeserializationCluster.cs
@@ -18,6 +18,7 @@ using Raven.Client.ServerWide;
 using Raven.Client.ServerWide.Operations.Configuration;
 using Raven.Client.ServerWide.Operations.Integrations.PostgreSQL;
 using Raven.Client.ServerWide.Operations.OngoingTasks;
+using Raven.Client.ServerWide.Sharding;
 using Raven.Server.Documents.Patch;
 using Raven.Server.Documents.Replication;
 using Raven.Server.Integrations.PostgreSQL.Commands;
@@ -57,7 +58,7 @@ namespace Raven.Server.ServerWide
 
         public static readonly Func<BlittableJsonReaderObject, DatabaseTopology> DatabaseTopology = GenerateJsonDeserializationRoutine<DatabaseTopology>();
       
-        public static readonly Func<BlittableJsonReaderObject, DatabaseRecord.ShardRangeAssignment> ShardRangeAssignment = GenerateJsonDeserializationRoutine<DatabaseRecord.ShardRangeAssignment>();
+        public static readonly Func<BlittableJsonReaderObject, ShardBucketRange> ShardRangeAssignment = GenerateJsonDeserializationRoutine<ShardBucketRange>();
 
         public static readonly Func<BlittableJsonReaderObject, RemoveNodeFromDatabaseCommand> RemoveNodeFromDatabaseCommand = GenerateJsonDeserializationRoutine<RemoveNodeFromDatabaseCommand>();
 
@@ -138,7 +139,7 @@ namespace Raven.Server.ServerWide
         public static Func<BlittableJsonReaderObject, SorterDefinition> SorterDefinition = GenerateJsonDeserializationRoutine<SorterDefinition>();
 
         public static Func<BlittableJsonReaderObject, PostgreSqlConfiguration> PostgreSqlConfiguration = GenerateJsonDeserializationRoutine<PostgreSqlConfiguration>();
-        public static Func<BlittableJsonReaderObject, BucketMigration> BucketMigration = GenerateJsonDeserializationRoutine<BucketMigration>();
+        public static Func<BlittableJsonReaderObject, ShardBucketMigration> BucketMigration = GenerateJsonDeserializationRoutine<ShardBucketMigration>();
 
         public static readonly Dictionary<string, Func<BlittableJsonReaderObject, CommandBase>> Commands = new Dictionary<string, Func<BlittableJsonReaderObject, CommandBase>>
         {

--- a/src/Raven.Server/ServerWide/Maintenance/ClusterObserver.cs
+++ b/src/Raven.Server/ServerWide/Maintenance/ClusterObserver.cs
@@ -1749,8 +1749,7 @@ namespace Raven.Server.ServerWide.Maintenance
 
             public void AddState(DatabaseObservationState state)
             {
-                var shard = ShardHelper.TryGetShardIndex(state.Name);
-                if (shard == -1)
+                if (ShardHelper.TryGetShardNumber(state.Name, out var shardNumber) == false)
                 {
                     // handle not sharded database
                     if (_isShardedState)
@@ -1761,9 +1760,9 @@ namespace Raven.Server.ServerWide.Maintenance
                 }
 
                 if (_isShardedState == false)
-                    throw new InvalidOperationException($"The database {state.Name} is sharded (shard: {shard}), but was initialized as a regular one.");
+                    throw new InvalidOperationException($"The database {state.Name} is sharded (shard: {shardNumber}), but was initialized as a regular one.");
 
-                States[shard] = state;
+                States[shardNumber] = state;
             }
 
             public readonly DatabaseObservationState[] States;

--- a/src/Raven.Server/ServerWide/RawDatabaseRecord.cs
+++ b/src/Raven.Server/ServerWide/RawDatabaseRecord.cs
@@ -19,6 +19,7 @@ using Raven.Client.Documents.Operations.TimeSeries;
 using Raven.Client.Documents.Queries.Sorting;
 using Raven.Client.Json.Serialization;
 using Raven.Client.ServerWide;
+using Raven.Client.ServerWide.Sharding;
 using Raven.Server.Json;
 using Sparrow.Json;
 using Sparrow.Json.Parsing;
@@ -144,19 +145,19 @@ namespace Raven.Server.ServerWide
             }
         }
 
-        private Dictionary<int, BucketMigration> _bucketMigrations;
+        private Dictionary<int, ShardBucketMigration> _bucketMigrations;
 
-        public Dictionary<int, BucketMigration> BucketMigrations
+        public Dictionary<int, ShardBucketMigration> BucketMigrations
         {
             get
             {
                 if (_materializedRecord != null)
-                    return _materializedRecord.BucketMigrations;
+                    return _materializedRecord.ShardBucketMigrations;
 
                 if (_bucketMigrations == null)
                 {
-                    _bucketMigrations = new Dictionary<int, BucketMigration>();
-                    if (_record.TryGet(nameof(DatabaseRecord.BucketMigrations), out BlittableJsonReaderObject obj) && obj != null)
+                    _bucketMigrations = new Dictionary<int, ShardBucketMigration>();
+                    if (_record.TryGet(nameof(DatabaseRecord.ShardBucketMigrations), out BlittableJsonReaderObject obj) && obj != null)
                     {
                         var propertyDetails = new BlittableJsonReaderObject.PropertyDetails();
                         for (var i = 0; i < obj.Count; i++)
@@ -221,29 +222,29 @@ namespace Raven.Server.ServerWide
             }
         }
         
-        private List<DatabaseRecord.ShardRangeAssignment> _shardAllocations;
+        private List<ShardBucketRange> _shardBucketRanges;
 
-        public List<DatabaseRecord.ShardRangeAssignment> ShardAllocations
+        public List<ShardBucketRange> ShardBucketRanges
         {
             get
             {
                 if (_materializedRecord != null)
-                    return _materializedRecord.ShardAllocations;
+                    return _materializedRecord.ShardBucketRanges;
 
-                if (_shardAllocations != null)
-                    return _shardAllocations;
+                if (_shardBucketRanges != null)
+                    return _shardBucketRanges;
 
-                if (_record.TryGet(nameof(DatabaseRecord.ShardAllocations), out BlittableJsonReaderArray array) == false || array == null)
+                if (_record.TryGet(nameof(DatabaseRecord.ShardBucketRanges), out BlittableJsonReaderArray array) == false || array == null)
                     return null;
 
-                _shardAllocations = new List<DatabaseRecord.ShardRangeAssignment>(array.Length);
+                _shardBucketRanges = new List<ShardBucketRange>(array.Length);
                 for (var index = 0; index < array.Length; index++)
                 {
                     var shardAllocation = (BlittableJsonReaderObject)array[index];
-                    _shardAllocations.Add(JsonDeserializationCluster.ShardRangeAssignment(shardAllocation));
+                    _shardBucketRanges.Add(JsonDeserializationCluster.ShardRangeAssignment(shardAllocation));
                 }
 
-                return _shardAllocations;
+                return _shardBucketRanges;
             }
         }
 
@@ -278,7 +279,7 @@ namespace Raven.Server.ServerWide
             {
                 [nameof(DatabaseRecord.DatabaseName)] = shardName,
                 [nameof(DatabaseRecord.Topology)] = shardedTopology,
-                [nameof(DatabaseRecord.ShardAllocations)] = null,
+                [nameof(DatabaseRecord.ShardBucketRanges)] = null,
                 [nameof(DatabaseRecord.Shards)] = null,
                 [nameof(DatabaseRecord.Settings)] = DynamicJsonValue.Convert(settings)
             };

--- a/src/Raven.Server/ServerWide/ServerStore.cs
+++ b/src/Raven.Server/ServerWide/ServerStore.cs
@@ -35,6 +35,7 @@ using Raven.Client.ServerWide.Commands;
 using Raven.Client.ServerWide.Operations.Configuration;
 using Raven.Client.ServerWide.Operations.Integrations.PostgreSQL;
 using Raven.Client.ServerWide.Operations.OngoingTasks;
+using Raven.Client.ServerWide.Sharding;
 using Raven.Client.ServerWide.Tcp;
 using Raven.Client.Util;
 using Raven.Server.Commercial;
@@ -852,18 +853,18 @@ namespace Raven.Server.ServerWide
                     }
                     else
                     {
-                        if (addDatabase.Record.ShardAllocations == null ||
-                            addDatabase.Record.ShardAllocations.Count == 0)
+                        if (addDatabase.Record.ShardBucketRanges == null ||
+                            addDatabase.Record.ShardBucketRanges.Count == 0)
                         {
-                            addDatabase.Record.ShardAllocations = new List<DatabaseRecord.ShardRangeAssignment>();
+                            addDatabase.Record.ShardBucketRanges = new List<ShardBucketRange>();
                             var start = 0;
                             var step = (1024*1024) / addDatabase.Record.Shards.Length;
                             for (int i = 0; i < addDatabase.Record.Shards.Length; i++)
                             {
-                                addDatabase.Record.ShardAllocations.Add(new DatabaseRecord.ShardRangeAssignment
+                                addDatabase.Record.ShardBucketRanges.Add(new ShardBucketRange
                                 {
-                                    Shard = i,
-                                    RangeStart = start
+                                    ShardNumber = i,
+                                    BucketRangeStart = start
                                 });
                                 start += step;
                             }

--- a/src/Raven.Server/Smuggler/Documents/MultiShardedDestination.cs
+++ b/src/Raven.Server/Smuggler/Documents/MultiShardedDestination.cs
@@ -167,15 +167,15 @@ namespace Raven.Server.Smuggler.Documents
             public async ValueTask WriteKeyValueAsync(string key, BlittableJsonReaderObject value)
             {
                 var bucket = ShardHelper.GetBucket(key);
-                var index = DatabaseContext.GetShardIndex(bucket);
-                await _actions[index].WriteKeyValueAsync(key, value);
+                var shardNumber = DatabaseContext.GetShardNumber(bucket);
+                await _actions[shardNumber].WriteKeyValueAsync(key, value);
             }
 
             public async ValueTask WriteTombstoneKeyAsync(string key)
             {
                 var bucket = ShardHelper.GetBucket(key);
-                var index = DatabaseContext.GetShardIndex(bucket);
-                await _actions[index].WriteTombstoneKeyAsync(key);
+                var shardNumber = DatabaseContext.GetShardNumber(bucket);
+                await _actions[shardNumber].WriteTombstoneKeyAsync(key);
             }
         }
 
@@ -198,22 +198,22 @@ namespace Raven.Server.Smuggler.Documents
             public async ValueTask WriteDocumentAsync(DocumentItem item, SmugglerProgressBase.CountsWithLastEtagAndAttachments progress)
             {
                 var bucket = ShardHelper.GetBucket(_allocator, item.Document.Id);
-                var index = DatabaseContext.GetShardIndex(bucket);
-                await _actions[index].WriteDocumentAsync(item, progress);
+                var shardNumber = DatabaseContext.GetShardNumber(bucket);
+                await _actions[shardNumber].WriteDocumentAsync(item, progress);
             }
 
             public async ValueTask WriteTombstoneAsync(Tombstone tombstone, SmugglerProgressBase.CountsWithLastEtag progress)
             {
                 var bucket = ShardHelper.GetBucket(_allocator, tombstone.LowerId);
-                var index = DatabaseContext.GetShardIndex(bucket);
-                await _actions[index].WriteTombstoneAsync(tombstone, progress);
+                var shardNumber = DatabaseContext.GetShardNumber(bucket);
+                await _actions[shardNumber].WriteTombstoneAsync(tombstone, progress);
             }
 
             public async ValueTask WriteConflictAsync(DocumentConflict conflict, SmugglerProgressBase.CountsWithLastEtag progress)
             {
                 var bucket = ShardHelper.GetBucket(_allocator, conflict.Id);
-                var index = DatabaseContext.GetShardIndex(bucket);
-                await _actions[index].WriteConflictAsync(conflict, progress);
+                var shardNumber = DatabaseContext.GetShardNumber(bucket);
+                await _actions[shardNumber].WriteConflictAsync(conflict, progress);
             }
 
             public ValueTask DeleteDocumentAsync(string id) => ValueTask.CompletedTask;
@@ -242,15 +242,15 @@ namespace Raven.Server.Smuggler.Documents
             public async ValueTask WriteCounterAsync(CounterGroupDetail counterDetail)
             {
                 var bucket = ShardHelper.GetBucket(_allocator, counterDetail.DocumentId);
-                var index = DatabaseContext.GetShardIndex(bucket);
-                await _actions[index].WriteCounterAsync(counterDetail);
+                var shardNumber = DatabaseContext.GetShardNumber(bucket);
+                await _actions[shardNumber].WriteCounterAsync(counterDetail);
             }
 
             public async ValueTask WriteLegacyCounterAsync(CounterDetail counterDetail)
             {
                 var bucket = ShardHelper.GetBucket(counterDetail.DocumentId);
-                var index = DatabaseContext.GetShardIndex(bucket);
-                await _actions[index].WriteLegacyCounterAsync(counterDetail);
+                var shardNumber = DatabaseContext.GetShardNumber(bucket);
+                await _actions[shardNumber].WriteLegacyCounterAsync(counterDetail);
             }
 
             public void RegisterForDisposal(IDisposable data)
@@ -267,8 +267,8 @@ namespace Raven.Server.Smuggler.Documents
             public async ValueTask WriteTimeSeriesAsync(TimeSeriesItem ts)
             {
                 var bucket = ShardHelper.GetBucket(ts.DocId);
-                var index = DatabaseContext.GetShardIndex(bucket);
-                await _actions[index].WriteTimeSeriesAsync(ts);
+                var shardNumber = DatabaseContext.GetShardNumber(bucket);
+                await _actions[shardNumber].WriteTimeSeriesAsync(ts);
             }
         }
 
@@ -281,8 +281,8 @@ namespace Raven.Server.Smuggler.Documents
             public async ValueTask WriteLegacyDeletions(string id)
             {
                 var bucket = ShardHelper.GetBucket(id);
-                var index = DatabaseContext.GetShardIndex(bucket);
-                await _actions[index].WriteLegacyDeletions(id);
+                var shardNumber = DatabaseContext.GetShardNumber(bucket);
+                await _actions[shardNumber].WriteLegacyDeletions(id);
             }
         }
     }

--- a/src/Raven.Server/Utils/ShardHelper.cs
+++ b/src/Raven.Server/Utils/ShardHelper.cs
@@ -1,8 +1,11 @@
 ﻿using System;
 using System.Collections.Generic;
+using System.Diagnostics;
 using Raven.Client.ServerWide;
+using Raven.Client.ServerWide.Sharding;
 using Raven.Client.Util;
 using Raven.Server.Documents;
+using Raven.Server.ServerWide;
 using Raven.Server.ServerWide.Context;
 using Sparrow;
 using Sparrow.Json;
@@ -23,34 +26,50 @@ namespace Raven.Server.Utils
         /// per TB of overall db size. That means that even for *very* large databases, the
         /// size of the shard is still going to be manageable.
         /// </summary>
-        public static int GetBucket(string key)
+        public static int GetBucket(string id)
         {
             using (var context = new ByteStringContext(SharedMultipleUseFlag.None))
-            using (DocumentIdWorker.GetLower(context, key, out var lowerId))
+            using (DocumentIdWorker.GetLower(context, id, out var lowerId))
             {
                 return GetBucketFromSlice(lowerId);
             }
         }
         
-        public static int GetBucket(LazyStringValue key)
+        public static int GetBucket(LazyStringValue id)
         {
             using (var context = new ByteStringContext(SharedMultipleUseFlag.None))
-                return GetBucket(context, key);
+                return GetBucket(context, id);
         }
 
-        public static int GetBucket(TransactionOperationContext context, string key)
+        public static int GetBucket(TransactionOperationContext context, string id)
         {
-            using (DocumentIdWorker.GetLowerIdSliceAndStorageKey(context, key, out var lowerId, out _))
+            using (DocumentIdWorker.GetLowerIdSliceAndStorageKey(context, id, out var lowerId, out _))
             {
                 return GetBucketFromSlice(lowerId);
             }
         }
 
-        public static int GetBucket(ByteStringContext context, LazyStringValue key)
+        public static int GetBucket<TTransaction>(TransactionOperationContext<TTransaction> context, string id) where TTransaction : RavenTransaction
         {
-            using (DocumentIdWorker.GetLower(context, key, out var lowerId))
+            using (DocumentIdWorker.GetLowerIdSliceAndStorageKey(context, id, out var lowerId, out _))
             {
                 return GetBucketFromSlice(lowerId);
+            }
+        }
+
+        public static int GetBucket(ByteStringContext context, LazyStringValue id)
+        {
+            using (DocumentIdWorker.GetLower(context, id, out var lowerId))
+            {
+                return GetBucketFromSlice(lowerId);
+            }
+        }
+
+        public static unsafe int GetBucket(TransactionOperationContext context, Slice id)
+        {
+            using (DocumentIdWorker.GetLower(context.Allocator, id.Content.Ptr, id.Size, out var loweredId))
+            {
+                return GetBucketFromSlice(loweredId);
             }
         }
 
@@ -81,31 +100,49 @@ namespace Raven.Server.Utils
             }
         }
 
-        public static int TryGetShardIndexAndDatabaseName(ref string name)
+        public static bool TryGetShardNumberAndDatabaseName(ref string shardedDatabaseName, out int shardNumber)
         {
-            int shardIndex = name.IndexOf('$');
-            if (shardIndex != -1)
+            shardNumber = shardedDatabaseName.IndexOf('$');
+
+            if (shardNumber != -1)
             {
-                var slice = name.AsSpan().Slice(shardIndex + 1);
-                name = name.Substring(0, shardIndex);
-                if (int.TryParse(slice, out shardIndex) == false)
-                    throw new ArgumentNullException(nameof(name), "Unable to parse sharded database name: " + name);
+                var slice = shardedDatabaseName.AsSpan().Slice(shardNumber + 1);
+                shardedDatabaseName = shardedDatabaseName.Substring(0, shardNumber);
+                if (int.TryParse(slice, out shardNumber) == false)
+                    throw new ArgumentException(nameof(shardedDatabaseName), "Unable to parse sharded database name: " + shardedDatabaseName);
+
+                return true;
             }
 
-            return shardIndex;
+            return false;
         }
 
-        public static int TryGetShardIndex(string name)
+        public static bool TryGetShardNumber(string shardedDatabaseName, out int shardNumber)
         {
-            int shardIndex = name.IndexOf('$');
-            if (shardIndex != -1)
+            shardNumber = GetShardNumber(shardedDatabaseName, throwIfShardNumberNotFound: false);
+            
+            if (shardNumber != -1)
+                return true;
+
+            return false;
+        }
+
+        public static int GetShardNumber(string shardedDatabaseName, bool throwIfShardNumberNotFound = true)
+        {
+            var shardNumber = shardedDatabaseName.IndexOf('$');
+            if (shardNumber != -1)
             {
-                var slice = name.AsSpan().Slice(shardIndex + 1);
-                if (int.TryParse(slice, out shardIndex) == false)
-                    throw new ArgumentNullException(nameof(name), "Unable to parse sharded database name: " + name);
+                var slice = shardedDatabaseName.AsSpan().Slice(shardNumber + 1);
+                if (int.TryParse(slice, out shardNumber) == false)
+                    throw new ArgumentException(nameof(shardedDatabaseName), "Unable to parse sharded database name: " + shardedDatabaseName);
+            }
+            else
+            {
+                if (throwIfShardNumberNotFound)
+                    throw new ArgumentException(nameof(shardedDatabaseName), "It is not sharded database name: " + shardedDatabaseName);
             }
 
-            return shardIndex;
+            return shardNumber;
         }
 
         public static string ToDatabaseName(string shardName) => ClientShardHelper.ToDatabaseName(shardName);
@@ -133,27 +170,15 @@ namespace Raven.Server.Utils
             }
         }
 
-        public static int GetShardForId(TransactionOperationContext context, List<DatabaseRecord.ShardRangeAssignment> shardAllocation, string docId)
-        {
-            var bucket = GetBucket(context, docId);
-            return GetShardIndex(shardAllocation, bucket);
-        }
-
-        public static int GetShardForId(TransactionOperationContext context, List<DatabaseRecord.ShardRangeAssignment> shardAllocation, LazyStringValue docId)
-        {
-            var bucket = GetBucket(context.Allocator, docId);
-            return GetShardIndex(shardAllocation, bucket);
-        }
-
-        public static int GetShardIndex(List<DatabaseRecord.ShardRangeAssignment> ranges, int bucket)
+        public static int GetShardNumber(List<ShardBucketRange> ranges, int bucket)
         {
             for (int i = 0; i < ranges.Count - 1; i++)
             {
-                if (bucket < ranges[i + 1].RangeStart)
-                    return ranges[i].Shard;
+                if (bucket < ranges[i + 1].BucketRangeStart)
+                    return ranges[i].ShardNumber;
             }
 
-            return ranges[^1].Shard;
+            return ranges[^1].ShardNumber;
         }
 
         public static void MoveBucket(this DatabaseRecord record, int bucket, int toShard)
@@ -165,102 +190,102 @@ namespace Raven.Server.Utils
 
                 if (bucket == 0)
                 {
-                    if (record.ShardAllocations[0].Shard == toShard)
+                    if (record.ShardBucketRanges[0].ShardNumber == toShard)
                         return; // same shard
 
-                    record.ShardAllocations[0].RangeStart++;
-                    record.ShardAllocations.Insert(0, new DatabaseRecord.ShardRangeAssignment { RangeStart = 0, Shard = toShard });
+                    record.ShardBucketRanges[0].BucketRangeStart++;
+                    record.ShardBucketRanges.Insert(0, new ShardBucketRange { BucketRangeStart = 0, ShardNumber = toShard });
                     return;
                 }
 
                 if (bucket == NumberOfBuckets - 1)
                 {
-                    if (record.ShardAllocations[^1].Shard == toShard)
+                    if (record.ShardBucketRanges[^1].ShardNumber == toShard)
                         return; // same shard
 
-                    record.ShardAllocations.Add(new DatabaseRecord.ShardRangeAssignment { RangeStart = bucket, Shard = toShard });
+                    record.ShardBucketRanges.Add(new ShardBucketRange { BucketRangeStart = bucket, ShardNumber = toShard });
                     return;
                 }
 
-                for (int i = 0; i < record.ShardAllocations.Count - 1; i++)
+                for (int i = 0; i < record.ShardBucketRanges.Count - 1; i++)
                 {
-                    var start = record.ShardAllocations[i].RangeStart;
-                    var end = record.ShardAllocations[i + 1].RangeStart - 1;
+                    var start = record.ShardBucketRanges[i].BucketRangeStart;
+                    var end = record.ShardBucketRanges[i + 1].BucketRangeStart - 1;
                     var size = end - start + 1;
 
                     if (bucket <= end)
                     {
-                        var currentShard = record.ShardAllocations[i].Shard;
+                        var currentShard = record.ShardBucketRanges[i].ShardNumber;
                         if (currentShard == toShard)
                             return; // same shard
 
                         if (size == 1)
                         {
-                            var next = record.ShardAllocations[i + 1].Shard;
-                            var prev = record.ShardAllocations[i - 1].Shard;
+                            var next = record.ShardBucketRanges[i + 1].ShardNumber;
+                            var prev = record.ShardBucketRanges[i - 1].ShardNumber;
 
                             if (next == toShard)
                             {
-                                record.ShardAllocations[i + 1].RangeStart--;
-                                record.ShardAllocations.RemoveAt(i);
+                                record.ShardBucketRanges[i + 1].BucketRangeStart--;
+                                record.ShardBucketRanges.RemoveAt(i);
                             }
 
                             if (prev == toShard)
                             {
-                                record.ShardAllocations.RemoveAt(i);
+                                record.ShardBucketRanges.RemoveAt(i);
                             }
 
                             if (next != toShard && prev != toShard)
-                                record.ShardAllocations[i].Shard = toShard;
+                                record.ShardBucketRanges[i].ShardNumber = toShard;
 
                             return;
                         }
 
                         if (bucket == start)
                         {
-                            record.ShardAllocations[i].RangeStart++;
+                            record.ShardBucketRanges[i].BucketRangeStart++;
 
-                            if (record.ShardAllocations[i - 1].Shard == toShard)
+                            if (record.ShardBucketRanges[i - 1].ShardNumber == toShard)
                                 return;
 
-                            record.ShardAllocations.Insert(i + 1, new DatabaseRecord.ShardRangeAssignment { RangeStart = bucket, Shard = toShard });
+                            record.ShardBucketRanges.Insert(i + 1, new ShardBucketRange { BucketRangeStart = bucket, ShardNumber = toShard });
                             return;
                         }
 
                         if (bucket == end)
                         {
-                            if (record.ShardAllocations[i + 1].Shard == toShard)
+                            if (record.ShardBucketRanges[i + 1].ShardNumber == toShard)
                             {
-                                record.ShardAllocations[i + 1].RangeStart--;
+                                record.ShardBucketRanges[i + 1].BucketRangeStart--;
                                 return;
                             }
 
-                            record.ShardAllocations.Insert(i + 1, new DatabaseRecord.ShardRangeAssignment { RangeStart = bucket, Shard = toShard });
+                            record.ShardBucketRanges.Insert(i + 1, new ShardBucketRange { BucketRangeStart = bucket, ShardNumber = toShard });
                             return;
                         }
 
                         // split
-                        record.ShardAllocations.Insert(i + 1, new DatabaseRecord.ShardRangeAssignment { RangeStart = bucket, Shard = toShard });
+                        record.ShardBucketRanges.Insert(i + 1, new ShardBucketRange { BucketRangeStart = bucket, ShardNumber = toShard });
 
-                        record.ShardAllocations.Insert(i + 2, new DatabaseRecord.ShardRangeAssignment { RangeStart = bucket + 1, Shard = currentShard });
+                        record.ShardBucketRanges.Insert(i + 2, new ShardBucketRange { BucketRangeStart = bucket + 1, ShardNumber = currentShard });
                         return;
                     }
                 }
 
-                var lastRange = record.ShardAllocations[^1];
-                if (bucket == lastRange.RangeStart)
+                var lastRange = record.ShardBucketRanges[^1];
+                if (bucket == lastRange.BucketRangeStart)
                 {
-                    if (toShard == record.ShardAllocations[^2].Shard)
+                    if (toShard == record.ShardBucketRanges[^2].ShardNumber)
                     {
-                        record.ShardAllocations[^1].RangeStart++;
+                        record.ShardBucketRanges[^1].BucketRangeStart++;
                         return;
                     }
                 }
 
                 // split last
-                record.ShardAllocations.Insert(record.ShardAllocations.Count, new DatabaseRecord.ShardRangeAssignment { RangeStart = bucket, Shard = toShard });
-                record.ShardAllocations.Insert(record.ShardAllocations.Count,
-                    new DatabaseRecord.ShardRangeAssignment { RangeStart = bucket + 1, Shard = lastRange.Shard });
+                record.ShardBucketRanges.Insert(record.ShardBucketRanges.Count, new ShardBucketRange { BucketRangeStart = bucket, ShardNumber = toShard });
+                record.ShardBucketRanges.Insert(record.ShardBucketRanges.Count,
+                    new ShardBucketRange { BucketRangeStart = bucket + 1, ShardNumber = lastRange.ShardNumber });
             }
             finally
             {
@@ -270,25 +295,25 @@ namespace Raven.Server.Utils
 
         private static void ValidateBucketsMapping(DatabaseRecord record)
         {
-            if (record.ShardAllocations[0].RangeStart != 0)
+            if (record.ShardBucketRanges[0].BucketRangeStart != 0)
                 throw new InvalidOperationException($"At database '{record.DatabaseName}', " +
-                                                    $"First mapping must start with zero, actual: {record.ShardAllocations[0].RangeStart}");
+                                                    $"First mapping must start with zero, actual: {record.ShardBucketRanges[0].BucketRangeStart}");
 
-            var lastShard = record.ShardAllocations[0].Shard;
+            var lastShard = record.ShardBucketRanges[0].ShardNumber;
             var lastStart = 0;
 
-            for (int i = 1; i < record.ShardAllocations.Count - 1; i++)
+            for (int i = 1; i < record.ShardBucketRanges.Count - 1; i++)
             {
-                var current = record.ShardAllocations[i];
-                if (current.RangeStart <= lastStart)
+                var current = record.ShardBucketRanges[i];
+                if (current.BucketRangeStart <= lastStart)
                     throw new InvalidOperationException($"At database '{record.DatabaseName}', " +
-                                                        $"Overlap detected between mapping '{i}' and '{i-1}' start: {current.RangeStart}, previous end: {lastStart}");
-                if (current.Shard == lastShard)                    
+                                                        $"Overlap detected between mapping '{i}' and '{i-1}' start: {current.BucketRangeStart}, previous end: {lastStart}");
+                if (current.ShardNumber == lastShard)                    
                     throw new InvalidOperationException($"At database '{record.DatabaseName}', " +
-                                                        $"Not merged shard continuous range detected between mapping '{i}' and '{i-1}' at shard: {current.Shard}");
+                                                        $"Not merged shard continuous range detected between mapping '{i}' and '{i-1}' at shard: {current.ShardNumber}");
 
-                lastStart = current.RangeStart;
-                lastShard = current.Shard;
+                lastStart = current.BucketRangeStart;
+                lastShard = current.ShardNumber;
             }
         }
     }

--- a/src/Raven.Server/Web/System/OngoingTasksHandler.cs
+++ b/src/Raven.Server/Web/System/OngoingTasksHandler.cs
@@ -1167,8 +1167,7 @@ namespace Raven.Server.Web.System
                             RavenEtlConfiguration ravenEtl;
                             if (sharded)
                             {
-                                var taskName = name;
-                                ShardHelper.TryGetShardIndexAndDatabaseName(ref taskName);
+                                var taskName = ShardHelper.ToDatabaseName(name);
                                 ravenEtl = record.RavenEtls.Find(x => x.Name.Equals(taskName, StringComparison.OrdinalIgnoreCase));
                             }
                             else

--- a/test/SlowTests/Sharding/Cluster/ReshardingTests.cs
+++ b/test/SlowTests/Sharding/Cluster/ReshardingTests.cs
@@ -26,7 +26,7 @@ namespace SlowTests.Sharding.Cluster
 
                 var id = "foo/bar";
                 var bucket = ShardHelper.GetBucket(id);
-                var location = ShardHelper.GetShardIndex(record.ShardAllocations, bucket);
+                var location = ShardHelper.GetShardNumber(record.ShardBucketRanges, bucket);
                 var newLocation = (location + 1) % record.Shards.Length;
                 using (var session = store.OpenAsyncSession())
                 {
@@ -84,7 +84,7 @@ namespace SlowTests.Sharding.Cluster
 
                 var id = "foo/bar";
                 var bucket = ShardHelper.GetBucket(id);
-                var location = ShardHelper.GetShardIndex(record.ShardAllocations, bucket);
+                var location = ShardHelper.GetShardNumber(record.ShardBucketRanges, bucket);
                 var newLocation = (location + 1) % record.Shards.Length;
                 using (var session = store.OpenAsyncSession())
                 {

--- a/test/SlowTests/Sharding/ETL/ShardedEtlFailoverTests.cs
+++ b/test/SlowTests/Sharding/ETL/ShardedEtlFailoverTests.cs
@@ -433,13 +433,13 @@ namespace SlowTests.Sharding.ETL
 
                 var dbRecord = src.Maintenance.Server.SendAsync(new GetDatabaseRecordOperation(src.Database)).Result;
                 var shardedCtx = new ShardedDatabaseContext(srcNodes.Servers[0].ServerStore, dbRecord);
-                var shardIndex = 0;
+                var shardNumber = 0;
                 using (Server.ServerStore.ContextPool.AllocateOperationContext(out TransactionOperationContext context))
                 {
-                    shardIndex = shardedCtx.GetShardIndex(context, id);
+                    shardNumber = shardedCtx.GetShardNumber(context, id);
                 }
 
-                var ongoingTask = src.Maintenance.Send(new GetOngoingTaskInfoOperation($"{name}${shardIndex}", OngoingTaskType.RavenEtl));
+                var ongoingTask = src.Maintenance.Send(new GetOngoingTaskInfoOperation($"{name}${shardNumber}", OngoingTaskType.RavenEtl));
 
                 var responsibleNodeNodeTag = ongoingTask.ResponsibleNode.NodeTag;
 
@@ -452,7 +452,7 @@ namespace SlowTests.Sharding.ETL
                 id = "users/5";
                 using (Server.ServerStore.ContextPool.AllocateOperationContext(out TransactionOperationContext context))
                 {
-                    Assert.Equal(shardIndex, shardedCtx.GetShardIndex(context, id));
+                    Assert.Equal(shardNumber, shardedCtx.GetShardNumber(context, id));
                 }
 
                 using (var session = src.OpenSession())

--- a/test/SlowTests/Sharding/ETL/ShardedEtlTests.cs
+++ b/test/SlowTests/Sharding/ETL/ShardedEtlTests.cs
@@ -167,8 +167,8 @@ loadToOrders(orderData);
                     for (int i = 0; i < ids.Length; i++)
                     {
                         var id = ids[i];
-                        var shardIndex = shardedCtx.GetShardIndex(context, id);
-                        Assert.Equal(i, shardIndex);
+                        var shardNumber = shardedCtx.GetShardNumber(context, id);
+                        Assert.Equal(i, shardNumber);
                     }
                 }
 
@@ -241,8 +241,8 @@ loadToOrders(orderData);
                     for (int i = 0; i < ids.Length; i++)
                     {
                         var id = ids[i];
-                        var shardIndex = shardedCtx.GetShardIndex(context, id);
-                        Assert.Equal(i, shardIndex);
+                        var shardNumber = shardedCtx.GetShardNumber(context, id);
+                        Assert.Equal(i, shardNumber);
                     }
                 }
 
@@ -1149,8 +1149,8 @@ person.addCounter(loadCounter('down'));
                     for (int i = 0; i < ids.Length; i++)
                     {
                         var id = ids[i];
-                        var shardIndex = shardedCtx.GetShardIndex(context, id);
-                        Assert.Equal(i, shardIndex);
+                        var shardNumber = shardedCtx.GetShardNumber(context, id);
+                        Assert.Equal(i, shardNumber);
                     }
                 }
 


### PR DESCRIPTION
### Issue link

https://issues.hibernatingrhinos.com/issue/RavenDB-18368

### Additional description

The following changes was made in the PR:

1. Created namespace `Raven.Client.ServerWide.Sharding`
2. Renamed `BucketMigration` to  `ShardBucketMigration` 
3. Renamed `ShardRangeAssignment` to `ShardBucketRange`
4. Renamed `ShardIndex`  to `ShardName` in method names and variables.
4. Got rid of "shard id" (it was wrong naming for shard bucked)
5. Made `ShardingHelper.TryGet....` method returning `bool` instead of `int`. Introduced dedicated methods `ShardingHelper.Get..` methods which return a given value or throw.
6. Got rid of static methods from `ShardedContext` to get the shard number (formerly shard index). We have `ShardHelper` for that purpose.
7. Shard bucket number can be taken only via `ShardHelper.GetBucket()` which has all necessary overloads.
8. Unified the naming conventions of method parameters for document identifiers - we use `id` (not `key`)


### Type of change

- Refactoring

### How risky is the change?

- Low 

### Backward compatibility

- Not relevant

### Is it platform specific issue?

- No

### Documentation update

- No documentation update is needed 

### Testing 

- Existing tests will verify the changes

### Is there any existing behavior change of other features due to this change?

- No

### UI work

- No UI work is needed
