### PR TITLE
RavenDB-18369: Implementation of AndNot as support structure for negatives

### DIFF
--- a/src/Corax/IndexSearcher/IndexSearcher.BinaryMatches.cs
+++ b/src/Corax/IndexSearcher/IndexSearcher.BinaryMatches.cs
@@ -69,4 +69,32 @@ public partial class IndexSearcher
 
         return BinaryMatch.Create(BinaryMatch<TInner, TOuter>.YieldOr(in set1, in set2));
     }
+
+    [MethodImpl(MethodImplOptions.AggressiveInlining)]
+    public AndNotMatch AndNot<TInner, TOuter>(in TInner set1, in TOuter set2)
+        where TInner : IQueryMatch
+        where TOuter : IQueryMatch
+    {
+
+        // If any of the generic types is not known to be a struct (calling from interface) the code executed will
+        // do all the work to figure out what to emit. The cost is in instantiation not on execution.                         
+        if (set1.GetType() == typeof(TermMatch) && set2.GetType() == typeof(TermMatch))
+        {
+            return AndNotMatch.Create(AndNotMatch<TermMatch, TermMatch>.Create(this, (TermMatch)(object)set1, (TermMatch)(object)set2));
+        }
+        else if (set1.GetType() == typeof(BinaryMatch) && set2.GetType() == typeof(TermMatch))
+        {
+            return AndNotMatch.Create(AndNotMatch<BinaryMatch, TermMatch>.Create(this, (BinaryMatch)(object)set1, (TermMatch)(object)set2));
+        }
+        else if (set1.GetType() == typeof(TermMatch) && set2.GetType() == typeof(BinaryMatch))
+        {
+            return AndNotMatch.Create(AndNotMatch<TermMatch, BinaryMatch>.Create(this, (TermMatch)(object)set1, (BinaryMatch)(object)set2));
+        }
+        else if (set1.GetType() == typeof(BinaryMatch) && set2.GetType() == typeof(BinaryMatch))
+        {
+            return AndNotMatch.Create(AndNotMatch<BinaryMatch, BinaryMatch>.Create(this, (BinaryMatch)(object)set1, (BinaryMatch)(object)set2));
+        }
+
+        return AndNotMatch.Create(AndNotMatch<TInner, TOuter>.Create(this, in set1, in set2));
+    }
 }

--- a/src/Corax/IndexSearcher/IndexSearcher.Memoization.cs
+++ b/src/Corax/IndexSearcher/IndexSearcher.Memoization.cs
@@ -1,0 +1,12 @@
+﻿using Corax.Queries;
+
+namespace Corax;
+
+partial class IndexSearcher
+{
+    public MemoizationMatchProvider<TInner> Memoize<TInner>(TInner inner)
+        where TInner : IQueryMatch
+    {
+        return new MemoizationMatchProvider<TInner>(inner);
+    }
+}

--- a/src/Corax/IndexSearcher/IndexSearcher.MultiTermMatches.cs
+++ b/src/Corax/IndexSearcher/IndexSearcher.MultiTermMatches.cs
@@ -160,8 +160,7 @@ public partial class IndexSearcher
                 this, new InTermProvider(this, field, inTerms, fieldId), scoreFunction));
     }
 
-    private MultiTermMatch MultiTermMatchBuilder<TScoreFunction, TTermProvider>(string field, string term, TScoreFunction scoreFunction, bool isNegated,
-        int fieldId)
+    private MultiTermMatch MultiTermMatchBuilder<TScoreFunction, TTermProvider>(string field, string term, TScoreFunction scoreFunction, bool isNegated, int fieldId)
         where TScoreFunction : IQueryScoreFunction
         where TTermProvider : ITermProvider
     {

--- a/src/Corax/IndexSearcher/IndexSearcher.Search.cs
+++ b/src/Corax/IndexSearcher/IndexSearcher.Search.cs
@@ -44,7 +44,7 @@ public partial class IndexSearcher
         wildcardAnalyzer.GetOutputBuffersSize(term.Length, out var wildcardSize, out var wildcardTokenSize);
 
         var tokenStructSize = Unsafe.SizeOf<Token>();
-        var buffer = QueryContext.MatchesPool.Rent(outputSize + wildcardSize + tokenStructSize * (tokenSize + wildcardTokenSize));
+        var buffer = QueryContext.MatchesRawPool.Rent(outputSize + wildcardSize + tokenStructSize * (tokenSize + wildcardTokenSize));
         Span<byte> encodeBufferOriginal = buffer.AsSpan().Slice(0, outputSize);
         Span<Token> tokensBufferOriginal = MemoryMarshal.Cast<byte, Token>(buffer.AsSpan().Slice(outputSize, tokenSize * tokenStructSize));
 
@@ -80,7 +80,7 @@ public partial class IndexSearcher
                 BuildExpression(mode, encodedString);
         }
 
-        QueryContext.MatchesPool.Return(buffer);
+        QueryContext.MatchesRawPool.Return(buffer);
 
         return typeof(TScoreFunction) == typeof(NullScoreFunction)
             ? match

--- a/src/Corax/Queries/AndNotMatch.Erasure.cs
+++ b/src/Corax/Queries/AndNotMatch.Erasure.cs
@@ -1,0 +1,129 @@
+﻿using System;
+using System.Diagnostics;
+using System.Runtime.CompilerServices;
+
+namespace Corax.Queries
+{
+    [DebuggerDisplay("{DebugView,nq}")]
+    public unsafe struct AndNotMatch : IQueryMatch
+    {
+        private readonly FunctionTable _functionTable;
+        private IQueryMatch _inner;
+
+        internal AndNotMatch(IQueryMatch match, FunctionTable functionTable)
+        {
+            _inner = match;
+            _functionTable = functionTable;
+        }
+
+        public bool IsBoosting => _inner.IsBoosting;
+
+        public long Count => _functionTable.CountFunc(ref this);
+
+        public QueryCountConfidence Confidence => _inner.Confidence;
+
+        [MethodImpl(MethodImplOptions.AggressiveInlining)]
+        public int Fill(Span<long> buffer)
+        {
+            return _functionTable.FillFunc(ref this, buffer);
+        }
+
+        [MethodImpl(MethodImplOptions.AggressiveInlining)]
+        public int AndWith(Span<long> buffer, int matches)
+        {
+            return _functionTable.AndWithFunc(ref this, buffer, matches);
+        }
+
+        [MethodImpl(MethodImplOptions.AggressiveInlining)]
+        public void Score(Span<long> matches, Span<float> scores)
+        {
+            _inner.Score(matches, scores);
+        }
+
+        public QueryInspectionNode Inspect()
+        {
+            return _inner.Inspect();
+        }
+
+        internal class FunctionTable
+        {
+            public readonly delegate*<ref AndNotMatch, Span<long>, int> FillFunc;
+            public readonly delegate*<ref AndNotMatch, Span<long>, int, int> AndWithFunc;
+            public readonly delegate*<ref AndNotMatch, Span<long>, Span<float>, void> ScoreFunc;
+            public readonly delegate*<ref AndNotMatch, long> CountFunc;
+
+            public FunctionTable(
+                delegate*<ref AndNotMatch, Span<long>, int> fillFunc,
+                delegate*<ref AndNotMatch, Span<long>, int, int> andWithFunc,
+                delegate*<ref AndNotMatch, Span<long>, Span<float>, void> scoreFunc,
+                delegate*<ref AndNotMatch, long> countFunc)
+            {
+                FillFunc = fillFunc;
+                AndWithFunc = andWithFunc;
+                ScoreFunc = scoreFunc;
+                CountFunc = countFunc;
+            }
+        }
+
+        private static class StaticFunctionCache<TInner, TOuter>
+            where TInner : IQueryMatch
+            where TOuter : IQueryMatch
+        {
+            public static readonly FunctionTable FunctionTable;
+
+            static StaticFunctionCache()
+            {
+                static long CountFunc(ref AndNotMatch match)
+                {
+                    return ((AndNotMatch<TInner, TOuter>)match._inner).Count;
+                }
+
+                [MethodImpl(MethodImplOptions.AggressiveInlining)]
+                static int FillFunc(ref AndNotMatch match, Span<long> matches)
+                {
+                    if (match._inner is AndNotMatch<TInner, TOuter> inner)
+                    {
+                        var result = inner.Fill(matches);
+                        match._inner = inner;
+                        return result;
+                    }
+                    return 0;
+                }
+
+                [MethodImpl(MethodImplOptions.AggressiveInlining)]
+                static int AndWithFunc(ref AndNotMatch match, Span<long> buffer, int matches)
+                {
+                    if (match._inner is AndNotMatch<TInner, TOuter> inner)
+                    {
+                        var result = inner.AndWith(buffer, matches);
+                        match._inner = inner;
+                        return result;
+                    }
+                    return 0;
+                }
+
+                [MethodImpl(MethodImplOptions.AggressiveInlining)]
+                static void ScoreFunc(ref AndNotMatch match, Span<long> matches, Span<float> scores)
+                {
+                    if (match._inner is AndNotMatch<TInner, TOuter> inner)
+                    {
+                        inner.Score(matches, scores);
+                        match._inner = inner;
+                    }
+                }
+
+                FunctionTable = new FunctionTable(&FillFunc, &AndWithFunc, &ScoreFunc, &CountFunc);
+            }
+        }
+
+        [MethodImpl(MethodImplOptions.AggressiveInlining)]
+        public static AndNotMatch Create<TInner, TOuter>(in AndNotMatch<TInner, TOuter> query)
+            where TInner : IQueryMatch
+            where TOuter : IQueryMatch
+        {
+            return new AndNotMatch(query, StaticFunctionCache<TInner, TOuter>.FunctionTable);
+        }
+
+        string DebugView => Inspect().ToString();
+    }
+}

--- a/src/Corax/Queries/AndNotMatch.cs
+++ b/src/Corax/Queries/AndNotMatch.cs
@@ -1,4 +1,4 @@
-﻿using System;
+using System;
 using System.Collections.Generic;
 using System.Diagnostics;
 using System.Runtime.CompilerServices;
@@ -17,18 +17,16 @@ namespace Corax.Queries
         private TOuter _outer;
 
         private long _totalResults;
-        private long _current;
-        private QueryCountConfidence _confidence;
+        private QueryCountConfidence _confidence;        
 
         public bool IsBoosting => _inner.IsBoosting || _outer.IsBoosting;
         public long Count => _totalResults;
-        public long Current => _current;
 
         private readonly ByteStringContext _context;
+        internal bool _isAndWithBuffer;
+        internal long* _buffer;
         internal int _bufferSize;
-        internal int _bufferIdx;
-        internal long* _documentBuffer;
-        internal bool _requiresSort;
+        internal int _bufferIdx;              
         internal IDisposable _bufferHandler;
 
         public QueryCountConfidence Confidence => _confidence;
@@ -38,7 +36,6 @@ namespace Corax.Queries
             long totalResults, QueryCountConfidence confidence)
         {
             _totalResults = totalResults;
-            _current = QueryMatch.Start;
 
             _inner = inner;
             _outer = outer;
@@ -49,21 +46,21 @@ namespace Corax.Queries
             int bufferSize = 4 * Math.Min(Math.Max(Size.Kilobyte, (int)outer.Count), 16 * Size.Kilobyte);
             _bufferHandler = _context.Allocate(bufferSize * sizeof(long), out var buffer);
             _bufferSize = bufferSize;
-            _documentBuffer = (long*)buffer.Ptr;
+            _buffer = (long*)buffer.Ptr;
             _bufferIdx = -1;
-            _requiresSort = false;
+            _isAndWithBuffer = false;
         }
 
         [MethodImpl(MethodImplOptions.AggressiveInlining)]
         public int Fill(Span<long> matches)
         {
-            if (_current == QueryMatch.Invalid)
-                return 0;
+            if (_isAndWithBuffer)
+                throw new InvalidOperationException($"We cannot execute `{nameof(Fill)}` after initiating a `{nameof(AndWith)}` operation.");
 
             // Check if this is the second time we enter or not. 
             if (_bufferIdx == -1)
             {                
-                var bufferState = new Span<long>(_documentBuffer, _bufferSize);
+                var bufferState = new Span<long>(_buffer, _bufferSize);
                 int iterations = 0;
 
                 int count = 0;
@@ -81,7 +78,7 @@ namespace Corax.Queries
                     if (bufferUsedItems > _bufferSize * 3 / 4)
                     {
                         UnlikelyGrowBuffer(bufferUsedItems);
-                        bufferState = new Span<long>(_documentBuffer, _bufferSize).Slice(count);
+                        bufferState = new Span<long>(_buffer, _bufferSize).Slice(count);
                     }
 
                     // Every time this is called we will store in a growable temporary buffer all the matches to be used in the AndNot later.
@@ -96,7 +93,7 @@ namespace Corax.Queries
                 if (iterations > 1 && count > 1)
                 {
                     // We need to sort and remove duplicates.
-                    var bufferBasePtr = _documentBuffer;
+                    var bufferBasePtr = _buffer;
                     count = SortAndRemoveDuplicates(bufferBasePtr, count);
                 }
 
@@ -139,7 +136,7 @@ namespace Corax.Queries
                 if (totalResults == 0)
                     return 0;
                 
-                Span<long> outerBuffer = new Span<long>(_documentBuffer, _bufferIdx);
+                Span<long> outerBuffer = new Span<long>(_buffer, _bufferIdx);
                 Span<long> innerBuffer = matches.Slice(0, totalResults);
 
                 totalResults = MergeHelper.AndNot(innerBuffer, innerBuffer, outerBuffer);
@@ -191,18 +188,113 @@ namespace Corax.Queries
             var bufferHandler = _context.Allocate(size * sizeof(long), out var buffer);
 
             // Ensure we copy the content and then switch the buffers. 
-            new Span<long>(_documentBuffer, currentlyUsed).CopyTo(new Span<long>(buffer.Ptr, size));
+            new Span<long>(_buffer, currentlyUsed).CopyTo(new Span<long>(buffer.Ptr, size));
             _bufferHandler.Dispose();
 
             _bufferSize = size;
-            _documentBuffer = (long*)buffer.Ptr;
+            _buffer = (long*)buffer.Ptr;
             _bufferHandler = bufferHandler;
+        }
+
+
+        [MethodImpl(MethodImplOptions.NoInlining)]
+        private (IDisposable, ByteString) UnlikelyGrowBuffer(ByteString buffer, int currentlyUsed)
+        {
+            // Calculate the new size. 
+            int currentSizeInBytes = buffer.Length;
+            int sizeInBytes;
+            if (currentSizeInBytes > 16 * Size.Megabyte)
+            {
+                sizeInBytes = (int)(currentSizeInBytes * 1.5);
+            }
+            else
+            {
+                sizeInBytes = currentSizeInBytes * 2;
+            }
+
+            // Allocate the new buffer based on the size the original buffer had in bytes.
+            var newBufferHandler = _context.Allocate(sizeInBytes, out var newBuffer);
+            
+            // Ensure we copy the content and then switch the buffers. 
+            new Span<long>(buffer.Ptr, currentlyUsed).CopyTo(new Span<long>(newBuffer.Ptr, newBuffer.Length));
+
+            return (newBufferHandler, newBuffer);
         }
 
         [MethodImpl(MethodImplOptions.AggressiveInlining)]
         public int AndWith(Span<long> buffer, int matches)
         {
-            throw new NotSupportedException($"{nameof(AndNotMatch<TInner, TOuter>)} does not support the operation of {nameof(AndWith)}.");
+            // This is not an AndWith memoized buffer, therefore we need to acquire a buffer to store the results
+            // before continuing.             
+            if (!_isAndWithBuffer)
+            {
+                int bufferSizeInItems = 4 * Math.Min(Math.Max(Size.Kilobyte, (int)_inner.Count), 16 * Size.Kilobyte);
+                
+                IDisposable scope = _context.Allocate(bufferSizeInItems * sizeof(long), out ByteString currentMatchesBuffer);
+                var currentMatches = MemoryMarshal.Cast<byte, long>(currentMatchesBuffer.ToSpan());
+
+                int totalResults = 0;
+
+                // Now it is time to run the other part of the algorithm, which is getting the Inner data until we fill the buffer.
+                bool isDone = false;
+                while (!isDone)
+                {
+                    int iterations = 0;
+
+                    var resultsSpan = currentMatches;
+                    while (resultsSpan.Length > 0)
+                    {
+                        // RavenDB-17750: We have to fill everything possible UNTIL there are no more matches availables.
+                        var read = Fill(resultsSpan);
+                        if (read == 0)
+                        {
+                            isDone = true;
+                            break;
+                        }
+
+                        // We havent finished and probably we will need to expand the temporary buffer.
+                        int bufferUsedItems = totalResults + read;
+                        if (bufferUsedItems > bufferSizeInItems * 15 / 16)
+                        {                            
+                            (var newBufferHandler, currentMatchesBuffer) = UnlikelyGrowBuffer(currentMatchesBuffer, bufferUsedItems);
+                            scope.Dispose();
+                            scope = newBufferHandler;
+
+                            resultsSpan = MemoryMarshal.Cast<byte, long>(currentMatchesBuffer.ToSpan());
+                            bufferSizeInItems = resultsSpan.Length;
+                            resultsSpan = resultsSpan.Slice(totalResults);                            
+                        }
+
+                        totalResults += read;
+                        iterations++;
+
+                        resultsSpan = resultsSpan.Slice(read);
+                    }
+
+                    // Again multiple Fill calls do not ensure that we will get a sequence of ordered
+                    // values, therefore we must ensure that we get a 'sorted' sequence ensuring those happen.
+                    if (iterations > 1 && totalResults > 0)
+                    {
+                        // We need to sort and remove duplicates.
+                        var bufferBasePtr = (long*)currentMatchesBuffer.Ptr;
+                        totalResults = SortAndRemoveDuplicates(bufferBasePtr, totalResults);
+                    }
+                }
+
+                // Now we signal that this is now indeed an AndWith memoized buffer, no Fill allowed from now on.                
+                _isAndWithBuffer = true;
+                _bufferHandler.Dispose();
+                _bufferHandler = scope;
+                _buffer = (long*)currentMatchesBuffer.Ptr;
+                _bufferSize = currentMatchesBuffer.Size;
+                _bufferIdx = totalResults;                
+            }
+
+            // If we dont have any result, no need to do anything. And with nothing will mean that there is nothing.
+            if (_bufferSize == 0)
+                return 0;
+
+            return MergeHelper.And(buffer, buffer.Slice(0, matches), new Span<long>(_buffer, _bufferIdx));
         }
 
 

--- a/src/Corax/Queries/AndNotMatch.cs
+++ b/src/Corax/Queries/AndNotMatch.cs
@@ -1,0 +1,243 @@
+﻿using System;
+using System.Collections.Generic;
+using System.Diagnostics;
+using System.Runtime.CompilerServices;
+using System.Runtime.InteropServices;
+using Sparrow.Server;
+using static Voron.Global.Constants;
+
+namespace Corax.Queries
+{
+    [DebuggerDisplay("{DebugView,nq}")]
+    public unsafe partial struct AndNotMatch<TInner, TOuter> : IQueryMatch
+    where TInner : IQueryMatch
+    where TOuter : IQueryMatch
+    {
+        private TInner _inner;
+        private TOuter _outer;
+
+        private long _totalResults;
+        private long _current;
+        private QueryCountConfidence _confidence;
+
+        public bool IsBoosting => _inner.IsBoosting || _outer.IsBoosting;
+        public long Count => _totalResults;
+        public long Current => _current;
+
+        private readonly ByteStringContext _context;
+        internal int _bufferSize;
+        internal int _bufferIdx;
+        internal long* _documentBuffer;
+        internal bool _requiresSort;
+        internal IDisposable _bufferHandler;
+
+        public QueryCountConfidence Confidence => _confidence;
+
+        private AndNotMatch(ByteStringContext context, 
+            in TInner inner, in TOuter outer,
+            long totalResults, QueryCountConfidence confidence)
+        {
+            _totalResults = totalResults;
+            _current = QueryMatch.Start;
+
+            _inner = inner;
+            _outer = outer;
+            _confidence = confidence;
+
+            _context = context;
+
+            int bufferSize = 4 * Math.Min(Math.Max(Size.Kilobyte, (int)outer.Count), 16 * Size.Kilobyte);
+            _bufferHandler = _context.Allocate(bufferSize * sizeof(long), out var buffer);
+            _bufferSize = bufferSize;
+            _documentBuffer = (long*)buffer.Ptr;
+            _bufferIdx = -1;
+            _requiresSort = false;
+        }
+
+        [MethodImpl(MethodImplOptions.AggressiveInlining)]
+        public int Fill(Span<long> matches)
+        {
+            if (_current == QueryMatch.Invalid)
+                return 0;
+
+            // Check if this is the second time we enter or not. 
+            if (_bufferIdx == -1)
+            {                
+                var bufferState = new Span<long>(_documentBuffer, _bufferSize);
+                int iterations = 0;
+
+                int count = 0;
+                while (true)
+                {
+                    var read = _outer.Fill(bufferState);
+                    if (read == 0)
+                        goto End;
+
+                    // We will use multiple rounds to get the whole buffer.
+                    iterations++;
+
+                    // We havent finished and probably we will need to expand the temporary buffer.
+                    int bufferUsedItems = count + read;
+                    if (bufferUsedItems > _bufferSize * 3 / 4)
+                    {
+                        UnlikelyGrowBuffer(bufferUsedItems);
+                        bufferState = new Span<long>(_documentBuffer, _bufferSize).Slice(count);
+                    }
+
+                    // Every time this is called we will store in a growable temporary buffer all the matches to be used in the AndNot later.
+                    bufferState = bufferState.Slice(read);
+                    count += read;
+                }                
+
+                End:
+
+                // The problem is that multiple Fill calls do not ensure that we will get a sequence of ordered
+                // values, therefore we must ensure that we get a 'sorted' sequence ensuring those happen.
+                if (iterations > 1 && count > 1)
+                {
+                    // We need to sort and remove duplicates.
+                    var bufferBasePtr = _documentBuffer;
+                    count = SortAndRemoveDuplicates(bufferBasePtr, count);
+                }
+
+                _bufferIdx = count;
+            }
+
+            // The outer is empty, so item in inner will be returned. 
+            if (_bufferIdx == 0)
+                return _inner.Fill(matches);
+
+            // Now it is time to run the other part of the algorithm, which is getting the Inner data until we fill the buffer.
+            while (true)
+            {
+                int totalResults = 0;
+                int iterations = 0;
+
+                var resultsSpan = matches;
+                while (resultsSpan.Length > 0)
+                {
+                    // RavenDB-17750: We have to fill everything possible UNTIL there are no more matches availables.
+                    var results = _inner.Fill(resultsSpan);
+                    if (results == 0)
+                        break;
+
+                    totalResults += results;
+                    iterations++;
+
+                    resultsSpan = resultsSpan.Slice(results);
+                }
+
+                // Again multiple Fill calls do not ensure that we will get a sequence of ordered
+                // values, therefore we must ensure that we get a 'sorted' sequence ensuring those happen.
+                if (iterations > 1)
+                {
+                    // We need to sort and remove duplicates.
+                    var bufferBasePtr = (long*)Unsafe.AsPointer(ref MemoryMarshal.GetReference(matches));
+                    totalResults = SortAndRemoveDuplicates(bufferBasePtr, totalResults);
+                }
+
+                if (totalResults == 0)
+                    return 0;
+                
+                Span<long> outerBuffer = new Span<long>(_documentBuffer, _bufferIdx);
+                Span<long> innerBuffer = matches.Slice(0, totalResults);
+
+                totalResults = MergeHelper.AndNot(innerBuffer, innerBuffer, outerBuffer);
+                if (totalResults != 0)
+                    return totalResults;
+            }
+        }
+
+        private static int SortAndRemoveDuplicates(long* bufferBasePtr, int count)
+        {
+            MemoryExtensions.Sort(new Span<long>(bufferBasePtr, count));
+
+            // We need to fill in the gaps left by removing deduplication process.
+            // If there are no duplicated the writes at the architecture level will execute
+            // way faster than if there are.
+
+            var outputBufferPtr = bufferBasePtr;
+
+            var bufferPtr = bufferBasePtr;
+            var bufferEndPtr = bufferBasePtr + count - 1;
+            while (bufferPtr < bufferEndPtr)
+            {
+                outputBufferPtr += bufferPtr[1] != bufferPtr[0] ? 1 : 0;
+                *outputBufferPtr = bufferPtr[1];
+
+                bufferPtr++;
+            }
+
+            count = (int)(outputBufferPtr - bufferBasePtr + 1);
+            return count;
+        }
+
+        [MethodImpl(MethodImplOptions.NoInlining)]
+        private void UnlikelyGrowBuffer(int currentlyUsed)
+        {
+            // Calculate the new size. 
+            int currentLength = _bufferSize;
+            int size;
+            if (currentLength > 16 * Size.Megabyte)
+            {
+                size = (int)(currentLength * 1.5);
+            }
+            else
+            {
+                size = currentLength * 2;
+            }
+
+            // Allocate the new buffer
+            var bufferHandler = _context.Allocate(size * sizeof(long), out var buffer);
+
+            // Ensure we copy the content and then switch the buffers. 
+            new Span<long>(_documentBuffer, currentlyUsed).CopyTo(new Span<long>(buffer.Ptr, size));
+            _bufferHandler.Dispose();
+
+            _bufferSize = size;
+            _documentBuffer = (long*)buffer.Ptr;
+            _bufferHandler = bufferHandler;
+        }
+
+        [MethodImpl(MethodImplOptions.AggressiveInlining)]
+        public int AndWith(Span<long> buffer, int matches)
+        {
+            throw new NotSupportedException($"{nameof(AndNotMatch<TInner, TOuter>)} does not support the operation of {nameof(AndWith)}.");
+        }
+
+
+        [MethodImpl(MethodImplOptions.AggressiveInlining)]
+        public void Score(Span<long> matches, Span<float> scores)
+        {
+            _inner.Score(matches, scores);
+        }
+
+        public QueryInspectionNode Inspect()
+        {
+            return new QueryInspectionNode($"{nameof(BinaryMatch)} [AndNot]",
+                children: new List<QueryInspectionNode> { _inner.Inspect(), _outer.Inspect() },
+                parameters: new Dictionary<string, string>()
+                {
+                    { nameof(IsBoosting), IsBoosting.ToString() },
+                    { nameof(Count), $"{Count} [{Confidence}]" }
+                });
+        }
+
+        string DebugView => Inspect().ToString();
+
+
+        public static AndNotMatch<TInner, TOuter> Create(IndexSearcher searcher, in TInner inner, in TOuter outer)
+        {
+            // Estimate Confidence values.
+            QueryCountConfidence confidence;
+            if (inner.Count < outer.Count / 2)
+                confidence = inner.Confidence;
+            else if (outer.Count < inner.Count / 2)
+                confidence = outer.Confidence;
+            else
+                confidence = inner.Confidence.Min(outer.Confidence);
+
+            return new AndNotMatch<TInner, TOuter>(searcher.Allocator, in inner, in outer, inner.Count, confidence);
+        }
+    }
+}

--- a/src/Corax/Queries/AndNotMatch.cs
+++ b/src/Corax/Queries/AndNotMatch.cs
@@ -1,8 +1,9 @@
-using System;
+﻿using System;
 using System.Collections.Generic;
 using System.Diagnostics;
 using System.Runtime.CompilerServices;
 using System.Runtime.InteropServices;
+using Corax.Utils;
 using Sparrow.Server;
 using static Voron.Global.Constants;
 
@@ -94,7 +95,7 @@ namespace Corax.Queries
                 {
                     // We need to sort and remove duplicates.
                     var bufferBasePtr = _buffer;
-                    count = SortAndRemoveDuplicates(bufferBasePtr, count);
+                    count = Sorting.SortAndRemoveDuplicates(bufferBasePtr, count);
                 }
 
                 _bufferIdx = count;
@@ -130,7 +131,7 @@ namespace Corax.Queries
                 {
                     // We need to sort and remove duplicates.
                     var bufferBasePtr = (long*)Unsafe.AsPointer(ref MemoryMarshal.GetReference(matches));
-                    totalResults = SortAndRemoveDuplicates(bufferBasePtr, totalResults);
+                    totalResults = Sorting.SortAndRemoveDuplicates(bufferBasePtr, totalResults);
                 }
 
                 if (totalResults == 0)
@@ -145,29 +146,7 @@ namespace Corax.Queries
             }
         }
 
-        private static int SortAndRemoveDuplicates(long* bufferBasePtr, int count)
-        {
-            MemoryExtensions.Sort(new Span<long>(bufferBasePtr, count));
-
-            // We need to fill in the gaps left by removing deduplication process.
-            // If there are no duplicated the writes at the architecture level will execute
-            // way faster than if there are.
-
-            var outputBufferPtr = bufferBasePtr;
-
-            var bufferPtr = bufferBasePtr;
-            var bufferEndPtr = bufferBasePtr + count - 1;
-            while (bufferPtr < bufferEndPtr)
-            {
-                outputBufferPtr += bufferPtr[1] != bufferPtr[0] ? 1 : 0;
-                *outputBufferPtr = bufferPtr[1];
-
-                bufferPtr++;
-            }
-
-            count = (int)(outputBufferPtr - bufferBasePtr + 1);
-            return count;
-        }
+        
 
         [MethodImpl(MethodImplOptions.NoInlining)]
         private void UnlikelyGrowBuffer(int currentlyUsed)
@@ -277,7 +256,7 @@ namespace Corax.Queries
                     {
                         // We need to sort and remove duplicates.
                         var bufferBasePtr = (long*)currentMatchesBuffer.Ptr;
-                        totalResults = SortAndRemoveDuplicates(bufferBasePtr, totalResults);
+                        totalResults = Sorting.SortAndRemoveDuplicates(bufferBasePtr, totalResults);
                     }
                 }
 

--- a/src/Corax/Queries/BinaryMatch.cs
+++ b/src/Corax/Queries/BinaryMatch.cs
@@ -75,7 +75,7 @@ namespace Corax.Queries
             {
                 _inner.Score(matches, scores);
 
-                var bufferHolder = QueryContext.MatchesPool.Rent(sizeof(float) * scores.Length);
+                var bufferHolder = QueryContext.MatchesRawPool.Rent(sizeof(float) * scores.Length);
                 var outerScores = MemoryMarshal.Cast<byte, float>(bufferHolder).Slice(0, scores.Length);
 
                 outerScores.Fill(1); // We will fill the scores with 1.0
@@ -87,7 +87,7 @@ namespace Corax.Queries
                 for(int i = 0; i < scores.Length; i++)
                     scores[i] *= outerScores[i];
 
-                QueryContext.MatchesPool.Return(bufferHolder);
+                QueryContext.MatchesRawPool.Return(bufferHolder);
 
                 return;
             }

--- a/src/Corax/Queries/IMemoizationMatchSource.cs
+++ b/src/Corax/Queries/IMemoizationMatchSource.cs
@@ -1,0 +1,9 @@
+﻿using System;
+
+namespace Corax.Queries
+{
+    public interface IMemoizationMatchSource : IDisposable
+    {
+        MemoizationMatch Replay();
+    }
+}

--- a/src/Corax/Queries/MemoizationMatch.Erasure.cs
+++ b/src/Corax/Queries/MemoizationMatch.Erasure.cs
@@ -1,0 +1,116 @@
+﻿using System;
+using System.Collections.Generic;
+using System.Diagnostics;
+using System.Linq;
+using System.Runtime.CompilerServices;
+using System.Text;
+using System.Threading.Tasks;
+
+namespace Corax.Queries
+{
+    [DebuggerDisplay("{DebugView,nq}")]
+    public unsafe struct MemoizationMatch : IQueryMatch
+    {
+        private readonly FunctionTable _functionTable;
+        private IQueryMatch _inner;
+
+        internal MemoizationMatch(IQueryMatch match, FunctionTable functionTable)
+        {
+            _inner = match;
+            _functionTable = functionTable;
+        }
+
+        public bool IsBoosting => _inner.IsBoosting;
+
+        public long Count => _functionTable.CountFunc(ref this);
+
+        public QueryCountConfidence Confidence => _inner.Confidence;
+
+        [MethodImpl(MethodImplOptions.AggressiveInlining)]
+        public int Fill(Span<long> buffer)
+        {
+            return _functionTable.FillFunc(ref this, buffer);
+        }
+
+        [MethodImpl(MethodImplOptions.AggressiveInlining)]
+        public int AndWith(Span<long> buffer, int matches)
+        {
+            return _functionTable.AndWithFunc(ref this, buffer, matches);
+        }
+
+        internal class FunctionTable
+        {
+            public readonly delegate*<ref MemoizationMatch, Span<long>, int> FillFunc;
+            public readonly delegate*<ref MemoizationMatch, Span<long>, int, int> AndWithFunc;
+            public readonly delegate*<ref MemoizationMatch, long> CountFunc;
+
+            public FunctionTable(
+                delegate*<ref MemoizationMatch, Span<long>, int> fillFunc,
+                delegate*<ref MemoizationMatch, Span<long>, int, int> andWithFunc,
+                delegate*<ref MemoizationMatch, long> countFunc)
+            {
+                FillFunc = fillFunc;
+                AndWithFunc = andWithFunc;
+                CountFunc = countFunc;
+            }
+        }
+
+        private static class StaticFunctionCache<TInner>
+            where TInner : IQueryMatch
+        {
+            public static readonly FunctionTable FunctionTable;
+
+            static StaticFunctionCache()
+            {
+                static long CountFunc(ref MemoizationMatch match)
+                {
+                    return ((MemoizationMatch<TInner>)match._inner).Count;
+                }
+
+                [MethodImpl(MethodImplOptions.AggressiveInlining)]
+                static int FillFunc(ref MemoizationMatch match, Span<long> matches)
+                {
+                    if (match._inner is MemoizationMatch<TInner> inner)
+                    {
+                        var result = inner.Fill(matches);
+                        match._inner = inner;
+                        return result;
+                    }
+                    return 0;
+                }
+
+                [MethodImpl(MethodImplOptions.AggressiveInlining)]
+                static int AndWithFunc(ref MemoizationMatch match, Span<long> buffer, int matches)
+                {
+                    if (match._inner is MemoizationMatch<TInner> inner)
+                    {
+                        var result = inner.AndWith(buffer, matches);
+                        match._inner = inner;
+                        return result;
+                    }
+                    return 0;
+                }
+
+                FunctionTable = new FunctionTable(&FillFunc, &AndWithFunc, &CountFunc);
+            }
+        }
+
+        [MethodImpl(MethodImplOptions.AggressiveInlining)]
+        public static MemoizationMatch Create<TInner>(in MemoizationMatch<TInner> query)
+            where TInner : IQueryMatch
+        {
+            return new MemoizationMatch(query, StaticFunctionCache<TInner>.FunctionTable);
+        }
+
+        [MethodImpl(MethodImplOptions.AggressiveInlining)]
+        public void Score(Span<long> matches, Span<float> scores)
+        {
+            _inner.Score(matches, scores);
+        }
+
+        public QueryInspectionNode Inspect()
+        {
+            return _inner.Inspect();
+        }
+    }
+}

--- a/src/Corax/Queries/MemoizationMatch.Provider.cs
+++ b/src/Corax/Queries/MemoizationMatch.Provider.cs
@@ -1,0 +1,131 @@
+﻿using System;
+using System.Runtime.CompilerServices;
+using Corax.Utils;
+using static Voron.Global.Constants;
+
+namespace Corax.Queries
+{
+
+    public unsafe struct MemoizationMatchProvider<TInner> : IMemoizationMatchSource
+             where TInner : IQueryMatch
+    {
+        private TInner _inner;
+        public bool IsBoosting => _inner.IsBoosting;
+        public long Count => _inner.Count;
+        public QueryCountConfidence Confidence => _inner.Confidence;
+
+        public int BufferSize => _buffer == null ? 0 : _buffer.Length;
+
+        internal long[] _buffer;
+        internal int _bufferEndIdx;
+
+        public MemoizationMatchProvider(in TInner inner)
+        {
+            _inner = inner;
+
+            _buffer = null;
+            _bufferEndIdx = -1;
+        }
+
+        public MemoizationMatch Replay()
+        {
+            return MemoizationMatch.Create(new MemoizationMatch<TInner>(this));
+        }
+
+        public Span<long> FillAndRetrieve()
+        {
+            if (_bufferEndIdx < 0)
+                InitializeInner();
+
+            if (_bufferEndIdx == 0)
+                return Span<long>.Empty;
+
+            return _buffer.AsSpan(0, _bufferEndIdx);
+        }
+
+        private void InitializeInner()
+        {
+            // We rent a buffer size. 
+            int bufferSize = 4 * Math.Min(Math.Max(Size.Kilobyte, (int)_inner.Count), 16 * Size.Kilobyte);
+            _buffer = QueryContext.MatchesPool.Rent(bufferSize);
+
+            var bufferState = _buffer.AsSpan();
+            int iterations = 0;
+
+            int count = 0;
+            while (true)
+            {
+                var read = _inner.Fill(bufferState);
+                if (read == 0)
+                    goto End;
+
+                // We will use multiple rounds to get the whole buffer.
+                iterations++;
+
+                // We havent finished and probably we will need to expand the temporary buffer.
+                int bufferUsedItems = count + read;
+                if (bufferUsedItems > _buffer.Length * 3 / 4)
+                {
+                    UnlikelyGrowBuffer(bufferUsedItems);
+                    bufferState = _buffer.AsSpan().Slice(count);
+                }
+
+                // Every time this is called we will store in a growable temporary buffer all the matches to be used in the AndNot later.
+                bufferState = bufferState.Slice(read);
+                count += read;
+            }
+
+        End:
+
+            // The problem is that multiple Fill calls do not ensure that we will get a sequence of ordered
+            // values, therefore we must ensure that we get a 'sorted' sequence ensuring those happen.
+            if (iterations > 1 && count > 1)
+            {
+                // We need to sort and remove duplicates.
+                count = Sorting.SortAndRemoveDuplicates(_buffer.AsSpan(0, count));
+            }
+
+            _bufferEndIdx = count;
+        }
+
+        [MethodImpl(MethodImplOptions.NoInlining)]
+        private void UnlikelyGrowBuffer(int currentlyUsed)
+        {
+            // Calculate the new size. 
+            int currentLength = _buffer.Length;
+            int size;
+            if (currentLength > 16 * Size.Megabyte)
+            {
+                size = (int)(currentLength * 1.5);
+            }
+            else
+            {
+                size = currentLength * 2;
+            }
+
+            // Allocate the new buffer
+            var newBuffer = QueryContext.MatchesPool.Rent(size);
+
+            // Ensure we copy the content and then switch the buffers. 
+            _buffer.AsSpan(0, currentlyUsed).CopyTo(newBuffer.AsSpan(0, size));
+
+            QueryContext.MatchesPool.Return(_buffer);
+            _buffer = newBuffer;
+        }
+
+        public void Score(Span<long> matches, Span<float> scores)
+        {
+            _inner.Score(matches, scores);
+        }
+
+        public QueryInspectionNode Inspect()
+        {
+            return _inner.Inspect();
+        }
+
+        public void Dispose()
+        {
+            QueryContext.MatchesPool.Return(_buffer);
+        }
+    }
+}

--- a/src/Corax/Queries/MemoizationMatch.cs
+++ b/src/Corax/Queries/MemoizationMatch.cs
@@ -1,0 +1,67 @@
+﻿using System;
+using System.Collections.Generic;
+
+namespace Corax.Queries
+{    
+    public unsafe struct MemoizationMatch<TInner> : IQueryMatch
+        where TInner : IQueryMatch
+    {
+        private MemoizationMatchProvider<TInner> _inner;
+        private int _bufferCurrentIdx;
+
+        public bool IsBoosting => _inner.IsBoosting;
+        public long Count => _inner.Count;
+        public QueryCountConfidence Confidence => _inner.Confidence;
+
+
+        internal MemoizationMatch(in MemoizationMatchProvider<TInner> inner)
+        {
+            _inner = inner;
+            _bufferCurrentIdx = 0;
+        }
+             
+        public int Fill(Span<long> matches)
+        {
+            // If it has never be initialized, acquire all the data from inner. 
+            // PERF: In case we need to improve performance, we can initialize lazily on demand. 
+            var memoizedMatches = _inner.FillAndRetrieve().Slice(_bufferCurrentIdx);
+
+            int toRead = Math.Min(matches.Length, memoizedMatches.Length);
+            if (toRead == 0)
+                return 0;
+
+            // Copy the current memoized matches to the output. 
+            memoizedMatches.Slice(0, toRead).CopyTo(matches);
+
+            // Move the pointer so we dont read them again. 
+            _bufferCurrentIdx += toRead;
+            return toRead;
+        }
+
+        public int AndWith(Span<long> buffer, int matches)
+        {
+            var memoizedMatches = _inner.FillAndRetrieve();
+            if (memoizedMatches.Length == 0)
+                return 0;
+
+            return MergeHelper.And(buffer, buffer.Slice(0, matches), memoizedMatches);
+        }
+
+        public void Score(Span<long> matches, Span<float> scores)
+        {
+            _inner.Score(matches, scores);
+        }
+
+        public QueryInspectionNode Inspect()
+        {
+            return new QueryInspectionNode($"{nameof(MemoizationMatch)} [Memoization]",
+                children: new List<QueryInspectionNode> { _inner.Inspect() },
+                parameters: new Dictionary<string, string>()
+                {
+                    { "BufferSize", _inner.BufferSize.ToString() },
+                    { nameof(IsBoosting), IsBoosting.ToString() },
+                    { nameof(Count), $"{Count} [{Confidence}]" }
+                });
+        }
+    }
+}

--- a/src/Corax/Queries/MultiTermBoostingMatch.cs
+++ b/src/Corax/Queries/MultiTermBoostingMatch.cs
@@ -76,7 +76,7 @@ namespace Corax.Queries
 
             int count = 0;
             var bufferState = buffer;
-            bool requiresSort = false;           
+            bool requiresSort = false;
 
             long docsCount = _currentTerm.Count;
             while (bufferState.Length > 0)

--- a/src/Corax/Queries/MultiTermMatch.cs
+++ b/src/Corax/Queries/MultiTermMatch.cs
@@ -114,7 +114,7 @@ namespace Corax.Queries
             // the statistics guarrant those approaches, etc. Currently we apply memoization but without any limit to 
             // size of the result and it's subsequent usage of memory. 
 
-            var bufferHolder = QueryContext.MatchesPool.Rent(3 * sizeof(long) * buffer.Length);
+            var bufferHolder = QueryContext.MatchesRawPool.Rent(3 * sizeof(long) * buffer.Length);
             var longBuffer = MemoryMarshal.Cast<byte, long>(bufferHolder);
 
             // PERF: We want to avoid to share cache lines, that's why the third array will move toward the end of the array. 
@@ -153,7 +153,7 @@ namespace Corax.Queries
             
             results[0..totalSize].CopyTo(buffer);
 
-            QueryContext.MatchesPool.Return(bufferHolder);
+            QueryContext.MatchesRawPool.Return(bufferHolder);
             return totalSize;
         }
 

--- a/src/Corax/Queries/QueryContext.cs
+++ b/src/Corax/Queries/QueryContext.cs
@@ -9,6 +9,8 @@ namespace Corax.Queries
 {
     public static class QueryContext
     {
-        public static readonly ArrayPool<byte> MatchesPool = ArrayPool<byte>.Create();
+        public static readonly ArrayPool<byte> MatchesRawPool = ArrayPool<byte>.Create();
+
+        public static readonly ArrayPool<long> MatchesPool = ArrayPool<long>.Create();
     }
 }

--- a/src/Corax/Queries/SortingMatch.cs
+++ b/src/Corax/Queries/SortingMatch.cs
@@ -107,7 +107,7 @@ namespace Corax.Queries
 
             int floatArraySize = 2 * sizeof(float) * matches.Length;
             int matchesArraySize = sizeof(long) * matches.Length;
-            var bufferHolder = QueryContext.MatchesPool.Rent(floatArraySize + matchesArraySize);
+            var bufferHolder = QueryContext.MatchesRawPool.Rent(floatArraySize + matchesArraySize);
             var allScoresValues = MemoryMarshal.Cast<byte, float>(bufferHolder.AsSpan().Slice(0, floatArraySize));
 
             // PERF: We want to avoid to share cache lines, that's why the second array will move toward the end of the array. 
@@ -225,7 +225,7 @@ namespace Corax.Queries
                 totalMatches = kIdx;
             }
 
-            QueryContext.MatchesPool.Return(bufferHolder);
+            QueryContext.MatchesRawPool.Return(bufferHolder);
             return totalMatches;
         }
 
@@ -245,7 +245,7 @@ namespace Corax.Queries
             
             int matchesArraySize = sizeof(long) * matches.Length;
             int itemArraySize = 2 * Unsafe.SizeOf<MatchComparer<TComparer, W>.Item>() * matches.Length;
-            var bufferHolder = QueryContext.MatchesPool.Rent(itemArraySize + matchesArraySize);
+            var bufferHolder = QueryContext.MatchesRawPool.Rent(itemArraySize + matchesArraySize);
 
             var itemKeys = MemoryMarshal.Cast<byte, MatchComparer<TComparer, W>.Item>(bufferHolder.AsSpan().Slice(0, itemArraySize));
             Debug.Assert(itemKeys.Length == 2 * matches.Length);
@@ -284,7 +284,7 @@ namespace Corax.Queries
                 // When we don't have any new batch, we are done.
                 if (bTotalMatches == 0)
                 {
-                    QueryContext.MatchesPool.Return(bufferHolder);
+                    QueryContext.MatchesRawPool.Return(bufferHolder);
                     return totalMatches;
                 }
 

--- a/src/Corax/Queries/SortingMultiMatch.cs
+++ b/src/Corax/Queries/SortingMultiMatch.cs
@@ -290,7 +290,7 @@ namespace Corax.Queries
             int floatArraySize = 2 * sizeof(float) * matches.Length;
             int matchesArraySize = sizeof(long) * matches.Length;
             int itemArraySize = 2 * Unsafe.SizeOf<MultiMatchComparer<TComparer1, W>.Item>() * matches.Length;
-            var bufferHolder = QueryContext.MatchesPool.Rent(itemArraySize + matchesArraySize + floatArraySize);
+            var bufferHolder = QueryContext.MatchesRawPool.Rent(itemArraySize + matchesArraySize + floatArraySize);
 
             var matchesKeysSpan = MemoryMarshal.Cast<byte, MultiMatchComparer<TComparer1, W>.Item>(bufferHolder.AsSpan().Slice(0, itemArraySize));
             Debug.Assert(matchesKeysSpan.Length == 2 * matches.Length);
@@ -342,7 +342,7 @@ namespace Corax.Queries
                 // When we don't have any new batch, we are done.
                 if (bTotalMatches == 0)
                 {
-                    QueryContext.MatchesPool.Return(bufferHolder);
+                    QueryContext.MatchesRawPool.Return(bufferHolder);
                     return totalMatches;
                 }
 
@@ -459,7 +459,7 @@ namespace Corax.Queries
 
             End:
                 totalMatches = kIdx;
-                QueryContext.MatchesPool.Return(bufferHolder);
+                QueryContext.MatchesRawPool.Return(bufferHolder);
             }
         }
 

--- a/src/Corax/Queries/SuggestionTermProvider.cs
+++ b/src/Corax/Queries/SuggestionTermProvider.cs
@@ -108,12 +108,12 @@ namespace Corax.Queries
                 int minSize = word.Length + (2 * _maxSize * sizeof(int)) + _maxSize * sizeof(float);
                 if ( _storage == null )
                 {
-                    _storage = QueryContext.MatchesPool.Rent(minSize);
+                    _storage = QueryContext.MatchesRawPool.Rent(minSize);
                 }                    
                 else if ( _storage.Length < minSize )
                 {
-                    QueryContext.MatchesPool.Return(_storage);
-                    _storage = QueryContext.MatchesPool.Rent(minSize);
+                    QueryContext.MatchesRawPool.Return(_storage);
+                    _storage = QueryContext.MatchesRawPool.Rent(minSize);
                 }
 
                 word.CopyTo(Word);
@@ -161,7 +161,7 @@ namespace Corax.Queries
             public void Dispose()
             {
                 if (_storage != null)
-                    QueryContext.MatchesPool.Return(_storage);
+                    QueryContext.MatchesRawPool.Return(_storage);
             }
         }
 

--- a/src/Corax/Queries/TermMatch.cs
+++ b/src/Corax/Queries/TermMatch.cs
@@ -296,7 +296,7 @@ namespace Corax.Queries
                 long* inputEndPtr = inputStartPtr + matches;
                 
                 // The size of this array is fixed to improve cache locality.
-                var bufferHolder = QueryContext.MatchesPool.Rent(sizeof(long) * BlockSize);
+                var bufferHolder = QueryContext.MatchesRawPool.Rent(sizeof(long) * BlockSize);
                 var blockMatches = MemoryMarshal.Cast<byte, long>(bufferHolder).Slice(0, BlockSize);
                 Debug.Assert(blockMatches.Length == BlockSize);
                 

--- a/src/Corax/Queries/UnaryMatch.Ordinal.cs
+++ b/src/Corax/Queries/UnaryMatch.Ordinal.cs
@@ -18,7 +18,7 @@ namespace Corax.Queries
         [SkipLocalsInit]
         private static int AndWith(ref UnaryMatch<TInner, TValueType> match, Span<long> buffer, int matches)
         {
-            var bufferHolder = QueryContext.MatchesPool.Rent(sizeof(long) * buffer.Length);
+            var bufferHolder = QueryContext.MatchesRawPool.Rent(sizeof(long) * buffer.Length);
             var innerBuffer = MemoryMarshal.Cast<byte, long>(bufferHolder).Slice(0, buffer.Length);
             Debug.Assert(innerBuffer.Length == buffer.Length);
 
@@ -28,7 +28,7 @@ namespace Corax.Queries
             var baseMatchesPtr = (long*)Unsafe.AsPointer(ref MemoryMarshal.GetReference(innerBuffer));
             var result = MergeHelper.And(matchesPtr, buffer.Length, matchesPtr, matches, baseMatchesPtr, count);
 
-            QueryContext.MatchesPool.Return(bufferHolder);
+            QueryContext.MatchesRawPool.Return(bufferHolder);
             return result;
         }
 

--- a/src/Corax/Utils/Sorting.cs
+++ b/src/Corax/Utils/Sorting.cs
@@ -1,0 +1,44 @@
+﻿using System;
+using System.Collections.Generic;
+using System.Linq;
+using System.Runtime.CompilerServices;
+using System.Runtime.InteropServices;
+using System.Text;
+using System.Threading.Tasks;
+
+namespace Corax.Utils
+{
+    internal static class Sorting
+    {
+        internal unsafe static int SortAndRemoveDuplicates(long* bufferBasePtr, int count)
+        {
+            MemoryExtensions.Sort(new Span<long>(bufferBasePtr, count));
+
+            // We need to fill in the gaps left by removing deduplication process.
+            // If there are no duplicated the writes at the architecture level will execute
+            // way faster than if there are.
+
+            var outputBufferPtr = bufferBasePtr;
+
+            var bufferPtr = bufferBasePtr;
+            var bufferEndPtr = bufferBasePtr + count - 1;
+            while (bufferPtr < bufferEndPtr)
+            {
+                outputBufferPtr += bufferPtr[1] != bufferPtr[0] ? 1 : 0;
+                *outputBufferPtr = bufferPtr[1];
+
+                bufferPtr++;
+            }
+
+            count = (int)(outputBufferPtr - bufferBasePtr + 1);
+            return count;
+        }
+
+        [MethodImpl(MethodImplOptions.AggressiveInlining)]
+        internal unsafe static int SortAndRemoveDuplicates(Span<long> buffer)
+        {
+            var bufferBasePtr = (long*)Unsafe.AsPointer(ref MemoryMarshal.GetReference(buffer));
+            return SortAndRemoveDuplicates(bufferBasePtr, buffer.Length);
+        }
+    }
+}

--- a/test/FastTests/Corax/CoraxQueries.cs
+++ b/test/FastTests/Corax/CoraxQueries.cs
@@ -2,7 +2,6 @@
 using System.Collections.Generic;
 using System.Linq;
 using System.Text;
-using System.Threading.Tasks;
 using Corax.Queries;
 using Corax;
 using FastTests.Voron;

--- a/test/FastTests/Corax/IndexSearcher.cs
+++ b/test/FastTests/Corax/IndexSearcher.cs
@@ -1529,13 +1529,37 @@ namespace FastTests.Corax
                 {
                     read = andNotMatch.Fill(ids);
 
-                    for ( int i = 0; i < read; i++)
+                    for (int i = 0; i < read; i++)
                     {
                         var id = searcher.GetIdentityFor(ids[i]);
                         Assert.False(id.StartsWith("entry/00"));
                         entriesLookup.Add(id);
                     }
-                    
+
+                }
+                while (read != 0);
+
+                Assert.Equal(total - startWith, entriesLookup.Count);
+            }
+
+            {
+                var andNotMatch = searcher.AndNot(searcher.AllEntries(), searcher.StartWithQuery("Content", "00"));
+                var andMatch = searcher.And(searcher.AllEntries(), andNotMatch);
+
+                Span<long> ids = stackalloc long[4096];
+
+                var entriesLookup = new HashSet<string>();
+                int read;
+                do
+                {
+                    read = andMatch.Fill(ids);
+
+                    for (int i = 0; i < read; i++)
+                    {
+                        var id = searcher.GetIdentityFor(ids[i]);
+                        Assert.False(id.StartsWith("entry/00"));
+                        entriesLookup.Add(id);
+                    }
                 }
                 while (read != 0);
 

--- a/test/FastTests/Corax/IndexSearcher.cs
+++ b/test/FastTests/Corax/IndexSearcher.cs
@@ -12,9 +12,11 @@ using Raven.Client.Documents.Linq;
 using Sparrow;
 using Sparrow.Server;
 using Sparrow.Threading;
+using Tests.Infrastructure;
 using Voron;
 using Xunit;
 using Xunit.Abstractions;
+using VoronConstants = Voron.Global.Constants;
 
 namespace FastTests.Corax
 {
@@ -516,7 +518,7 @@ namespace FastTests.Corax
                 Assert.Equal(3, match.Fill(ids));
                 Assert.Equal(0, match.Fill(ids));
             }
-        }
+        }        
 
         [Theory]
         [InlineData(new object[] { 300, 128 })]
@@ -1420,7 +1422,128 @@ namespace FastTests.Corax
             }        
         }
 
-        [Fact]
+        [RavenFact(RavenTestCategory.Corax)]
+        public void SimpleAndNot()
+        {
+            var entry1 = new IndexSingleEntry { Id = "entry/1", Content = "Testing" };
+            var entry2 = new IndexSingleEntry { Id = "entry/2", Content = "Running" };
+            var entry3 = new IndexSingleEntry { Id = "entry/3", Content = "Runner" };
+
+            using var bsc = new ByteStringContext(SharedMultipleUseFlag.None);
+            IndexEntries(bsc, new[] { entry1, entry2, entry3 }, CreateKnownFields(bsc));
+
+            using var ctx = new ByteStringContext(SharedMultipleUseFlag.None);
+            Slice.From(ctx, "Id", ByteStringType.Immutable, out Slice idSlice);
+            Slice.From(ctx, "Content", ByteStringType.Immutable, out Slice contentSlice);
+
+            using var searcher = new IndexSearcher(Env);
+
+            {
+                var andNotMatch = searcher.AndNot(searcher.AllEntries(), searcher.StartWithQuery("Content", "Run"));
+
+                Span<long> ids = stackalloc long[256];
+                Assert.Equal(1, andNotMatch.Fill(ids));
+            }
+
+            {
+                var andNotMatch = searcher.AndNot(searcher.AllEntries(), searcher.AllEntries());
+
+                Span<long> ids = stackalloc long[256];
+                Assert.Equal(0, andNotMatch.Fill(ids));
+            }
+
+            {
+                var andNotMatch = searcher.AndNot(searcher.AllEntries(), searcher.StartWithQuery("Content", "J"));
+
+                Span<long> ids = stackalloc long[256];
+                Assert.Equal(3, andNotMatch.Fill(ids));
+            }
+        }
+
+        [RavenFact(RavenTestCategory.Corax)]
+        public void BigAndNot()
+        {
+            int total = 100000;
+
+            int startWith = 0;
+            var entries = new List<IndexSingleEntry>();
+            for (int i = 0; i < total; i++)
+            {
+                var content = i.ToString("000000");
+                entries.Add(new IndexSingleEntry { Id = $"entry/{content}", Content = content });
+                if (content.StartsWith("00"))
+                    startWith++;
+            }
+                
+
+            using var bsc = new ByteStringContext(SharedMultipleUseFlag.None);
+            IndexEntries(bsc, entries, CreateKnownFields(bsc));
+
+            using var ctx = new ByteStringContext(SharedMultipleUseFlag.None);
+            Slice.From(ctx, "Id", ByteStringType.Immutable, out Slice idSlice);
+            Slice.From(ctx, "Content", ByteStringType.Immutable, out Slice contentSlice);
+
+            using var searcher = new IndexSearcher(Env);
+
+            {
+                var andNotMatch = searcher.AndNot(searcher.AllEntries(), searcher.AllEntries());
+
+                Span<long> ids = stackalloc long[4096];
+
+                int counter = 0;
+                int read;
+                do
+                {
+                    read = andNotMatch.Fill(ids);
+                    counter += read;
+                }
+                while (read != 0);
+
+                Assert.Equal(0, counter);
+            }
+
+            {
+                var andNotMatch = searcher.AndNot(searcher.AllEntries(), searcher.StartWithQuery("Content", "J"));
+
+                Span<long> ids = stackalloc long[4096];
+                int counter = 0;
+                int read;
+                do
+                {
+                    read = andNotMatch.Fill(ids);
+                    counter += read;
+                }
+                while (read != 0);
+
+                Assert.Equal(entries.Count, counter);
+            }
+
+            {
+                var andNotMatch = searcher.AndNot(searcher.AllEntries(), searcher.StartWithQuery("Content", "00"));
+
+                Span<long> ids = stackalloc long[4096];
+
+                var entriesLookup = new HashSet<string>();
+                int read;
+                do
+                {
+                    read = andNotMatch.Fill(ids);
+
+                    for ( int i = 0; i < read; i++)
+                    {
+                        var id = searcher.GetIdentityFor(ids[i]);
+                        Assert.False(id.StartsWith("entry/00"));
+                        entriesLookup.Add(id);
+                    }
+                    
+                }
+                while (read != 0);
+
+                Assert.Equal(total - startWith, entriesLookup.Count);
+            }
+        }
+
+        [RavenFact(RavenTestCategory.Corax)]
         public void NotEqualWithList()
         {
             var entries = new List<IndexEntry>();


### PR DESCRIPTION
The basis of `AndNot` is that allows us to negate whatever inclusive query we have available.