### PR TITLE
RavenDB-18059 Adding additional infot the exception message to verify if that's the real problem

### DIFF
--- a/src/Voron/Impl/Journal/WriteAheadJournal.cs
+++ b/src/Voron/Impl/Journal/WriteAheadJournal.cs
@@ -1524,11 +1524,16 @@ namespace Voron.Impl.Journal
             private void ThrowOnFlushLockEnterWhileWriteTransactionLockIsTaken()
             {
                 var currentWriteTransactionHolder = _waj._env._currentWriteTransactionHolder;
+                var currentTxLockCount = _waj._env._transactionWriter.CurrentCount;
+
                 if (currentWriteTransactionHolder != null &&
                     currentWriteTransactionHolder == NativeMemory.CurrentThreadStats)
                 {
                     throw new InvalidOperationException("The flushing lock must be taken before acquiring the write transaction lock. " +
-                                                        "This check is supposed to prevent potential deadlock and guarantee the same order of taking those two locks.");
+                                                        "This check is supposed to prevent potential deadlock and guarantee the same order of taking those two locks." +
+                                                        $"(Thread holding the write tx lock - Name: '{currentWriteTransactionHolder.Name}', Id: {currentWriteTransactionHolder.ManagedThreadId}. " +
+                                                        $"Current thread - Id: {Thread.CurrentThread.ManagedThreadId}. " +
+                                                        $"Current tx lock count: {currentTxLockCount})");
                 }
             }
 

--- a/src/Voron/StorageEnvironment.cs
+++ b/src/Voron/StorageEnvironment.cs
@@ -82,7 +82,7 @@ namespace Voron
             new LowLevelTransaction.WriteTransactionPool();
 
         private readonly WriteAheadJournal _journal;
-        private readonly SemaphoreSlim _transactionWriter = new SemaphoreSlim(1, 1);
+        internal readonly SemaphoreSlim _transactionWriter = new SemaphoreSlim(1, 1);
         internal NativeMemory.ThreadStats _currentWriteTransactionHolder;
         private readonly AsyncManualResetEvent _writeTransactionRunning = new AsyncManualResetEvent();
         internal readonly ThreadHoppingReaderWriterLock FlushInProgressLock = new ThreadHoppingReaderWriterLock();


### PR DESCRIPTION
### Issue link

https://issues.hibernatingrhinos.com/issue/RavenDB-18059

### Additional description

Adding more details after we got `System.InvalidOperationException: The flushing lock must be taken before acquiring the write transaction lock. This check is supposed to prevent potential deadlock and guarantee the same order of taking those two locks.` exception when running tests in debug on CI.

### Type of change

- Additional info for investigation 

### How risky is the change?

- Low 

### Backward compatibility


- Not relevant

### Is it platform specific issue?

- No

### Documentation update

- No documentation update is needed 

### Testing 

- Not relevant

### Is there any existing behavior change of other features due to this change?

- No

### UI work

- No UI work is needed
