### PR TITLE
RavenDB-18351 Fix Local destination for OLAP connection string

### DIFF
--- a/src/Raven.Studio/typescript/viewmodels/database/settings/connectionStrings.ts
+++ b/src/Raven.Studio/typescript/viewmodels/database/settings/connectionStrings.ts
@@ -19,13 +19,15 @@ import testPeriodicBackupCredentialsCommand = require("commands/serverWide/testP
 class connectionStrings extends viewModelBase {
 
     view = require("views/database/settings/connectionStrings.html");
-    backupDestinationTestCredentialsView = require("views/partial/backupDestinationTestCredentialsResults.html");
+    
     connectionStringOlapView = require("views/database/settings/connectionStringOlap.html");
     connectionStringRavenView = require("views/database/settings/connectionStringRaven.html");
     connectionStringElasticView = require("views/database/settings/connectionStringElasticSearch.html");
     connectionStringSqlView = require("views/database/settings/connectionStringSql.html");
+
+    backupDestinationTestCredentialsView = require("views/partial/backupDestinationTestCredentialsResults.html");
     backupConfigurationView = require("views/partial/backupConfigurationScript.html");
-    
+    backupDestinationLocalView = require("views/partial/backupDestinationLocal.html");
 
     ravenEtlConnectionStringsNames = ko.observableArray<string>([]);
     sqlEtlConnectionStringsNames = ko.observableArray<string>([]);


### PR DESCRIPTION
### Issue link
https://issues.hibernatingrhinos.com/issue/RavenDB-18351

### Additional description
Added the missing HTML for the Local option

### Type of change
- Bug fix

### How risky is the change?
- Low 

### Backward compatibility
- Non breaking change

### Is it platform specific issue?
- No

### Documentation update
- No documentation update is needed 

### Testing 
- It has been verified by manual testing

### Is there any existing behavior change of other features due to this change?
- No

### UI work
- No UI work is needed
