### PR TITLE
RavenDB-18221 Sharding - Database Settings View - return the folder-p…

### DIFF
--- a/src/Raven.Studio/typescript/models/database/settings/databaseSettingsModels.ts
+++ b/src/Raven.Studio/typescript/models/database/settings/databaseSettingsModels.ts
@@ -259,11 +259,9 @@ export class pathEntry extends databaseEntry<string> {
         super(data);
         _.bindAll(this, "pathHasChanged");
 
-        shardingTodo("Danielle");
-        // TODO: waiting for ep:  "/databases/*/admin/studio-tasks/folder-path-options" RavenDB-18222
-        // this.customizedDatabaseValue.throttle(300).subscribe((newPathValue) => {
-        //     this.getFolderPathOptions(newPathValue);
-        // });
+        this.customizedDatabaseValue.throttle(300).subscribe((newPathValue) => {
+            this.getFolderPathOptions(newPathValue);
+        });
     }
 
     initCustomizedValue(value: string) {


### PR DESCRIPTION
### Issue link
https://issues.hibernatingrhinos.com/issue/RavenDB-18221

### Additional description
Use the folder-path-options since the ep is now implemented

### Type of change
- New feature

### How risky is the change?
- Low 

### Backward compatibility
- Non breaking change

### Is it platform specific issue?
- No

### Documentation update
- No documentation update is needed 

### Testing 
- It has been verified by manual testing

### Is there any existing behavior change of other features due to this change?
- No

### UI work
- No UI work is needed
