### PR TITLE
RavenDB-18311 Validate domain name does not start or end with '-'

### DIFF
--- a/src/Raven.Studio/typescript/models/wizard/domainInfo.ts
+++ b/src/Raven.Studio/typescript/models/wizard/domainInfo.ts
@@ -56,19 +56,16 @@ class domainInfo {
                                                         }
                                                     });
                              };
-        
-        const rg1 = /^[a-zA-Z0-9-]+$/;
-        const rg2 = /^(?!-)(?!.*-$)/;
 
         this.domain.extend({
             required: true,
             validation: [
                 {
-                    validator: (val: string) => rg1.test(val),
+                    validator: (val: string) => /^[a-zA-Z0-9-]+$/.test(val),
                     message: "Domain name can only contain A-Z, a-z, 0-9, '-'"
                 },
                 {
-                    validator: (val: string) => rg2.test(val),
+                    validator: (val: string) => !val.startsWith("-") && !val.endsWith("-"),
                     message: "Domain name cannot start or end with '-'"
                 },
                 {

--- a/src/Raven.Studio/typescript/models/wizard/domainInfo.ts
+++ b/src/Raven.Studio/typescript/models/wizard/domainInfo.ts
@@ -57,22 +57,31 @@ class domainInfo {
                                                     });
                              };
         
+        const rg1 = /^[a-zA-Z0-9-]+$/;
+        const rg2 = /^(?!-)(?!.*-$)/;
+
         this.domain.extend({
             required: true,
-            pattern: {
-                params: "^[a-zA-Z0-9-]+$",
-                message: "Domain name can only contain A-Z, a-z, 0-9, '-'"
-            },
-            validation: {
-                message: "Sorry, domain name is taken.",
-                async: true,
-                onlyIf: () => !!this.domain(),
-                validator: generalUtils.debounceAndFunnel(checkDomain)
-            }
+            validation: [
+                {
+                    validator: (val: string) => rg1.test(val),
+                    message: "Domain name can only contain A-Z, a-z, 0-9, '-'"
+                },
+                {
+                    validator: (val: string) => rg2.test(val),
+                    message: "Domain name cannot start or end with '-'"
+                },
+                {
+                    message: "Sorry, domain name is taken.",
+                    async: true,
+                    onlyIf: () => !!this.domain(),
+                    validator: generalUtils.debounceAndFunnel(checkDomain)
+                }
+            ]
         });
 
         this.rootDomain.extend({
-            required: true            
+            required: true
         });
         
         this.userEmail.extend({


### PR DESCRIPTION
### Issue link
https://issues.hibernatingrhinos.com/issue/RavenDB-18311

### Additional description
Added regex validation - domain name cannot start or end with a dash

### Type of change
- Bug fix

### How risky is the change?
- Low 

### Backward compatibility
- Non breaking change

### Is it platform specific issue?
- No

### Documentation update
- No documentation update is needed 

### Testing 
- It has been verified by manual testing

### Is there any existing behavior change of other features due to this change?
- No

### UI work
- No UI work is needed
