### PR TITLE
RavenDB-18399 Nullable DateOnly / TimeOnly support

### DIFF
--- a/src/Raven.Client/Json/Serialization/NewtonsoftJson/Internal/Converters/DateOnlyConverter.cs
+++ b/src/Raven.Client/Json/Serialization/NewtonsoftJson/Internal/Converters/DateOnlyConverter.cs
@@ -13,11 +13,13 @@ namespace Raven.Client.Json.Serialization.NewtonsoftJson.Internal.Converters
         // More info available at: https://docs.microsoft.com/en-us/dotnet/standard/base-types/standard-date-and-time-format-strings#Roundtrip
 
         public static readonly DateOnlyConverter Instance = new();
+
         public override void WriteJson(JsonWriter writer, object value, JsonSerializer serializer)
         {
-            if (value is null)
+            if (value == null)
             {
-                throw new ArgumentNullException(nameof(value));
+                writer.WriteNull();
+                return;
             }
 
             var @do = (DateOnly)value;
@@ -27,11 +29,11 @@ namespace Raven.Client.Json.Serialization.NewtonsoftJson.Internal.Converters
         public override unsafe object ReadJson(JsonReader reader, Type objectType, object existingValue, JsonSerializer serializer)
         {
             if (reader.TokenType == JsonToken.Null)
-                return default(DateOnly);
+                return null;
 
             if (reader.TokenType == JsonToken.PropertyName)
                 return reader.ReadAsString();
-            
+
             if (reader.TokenType != JsonToken.String)
                 throw new InvalidOperationException("Expected string, Got " + reader.TokenType);
 
@@ -41,7 +43,8 @@ namespace Raven.Client.Json.Serialization.NewtonsoftJson.Internal.Converters
             {
                 if (LazyStringParser.TryParseDateOnly(buffer, value.Length, out var dateOnly) == false)
                 {
-                    if (LazyStringParser.TryParseDateTime(buffer, value.Length, out var dt, out var _, true) is LazyStringParser.Result.Failed or LazyStringParser.Result.DateTimeOffset)
+                    if (LazyStringParser.TryParseDateTime(buffer, value.Length, out var dt, out var _, true) is LazyStringParser.Result.Failed
+                        or LazyStringParser.Result.DateTimeOffset)
                     {
                         throw new InvalidOperationException("Expected DateOnly, Got " + value);
                     }
@@ -55,7 +58,7 @@ namespace Raven.Client.Json.Serialization.NewtonsoftJson.Internal.Converters
 
         public override bool CanConvert(Type objectType)
         {
-            return objectType == typeof(DateOnly);
+            return objectType == typeof(DateOnly) || objectType == typeof(DateOnly?);
         }
     }
 }

--- a/src/Raven.Client/Json/Serialization/NewtonsoftJson/Internal/Converters/TimeOnlyConverter.cs
+++ b/src/Raven.Client/Json/Serialization/NewtonsoftJson/Internal/Converters/TimeOnlyConverter.cs
@@ -16,9 +16,10 @@ internal sealed class TimeOnlyConverter : JsonConverter
 
     public override void WriteJson(JsonWriter writer, object value, JsonSerializer serializer)
     {
-        if (value is null)
+        if (value == null)
         {
-            throw new ArgumentNullException(nameof(value));
+            writer.WriteNull();
+            return;
         }
 
         var to = (TimeOnly)value;
@@ -28,7 +29,7 @@ internal sealed class TimeOnlyConverter : JsonConverter
     public override unsafe object ReadJson(JsonReader reader, Type objectType, object existingValue, JsonSerializer serializer)
     {
         if (reader.TokenType == JsonToken.Null)
-            return default(TimeOnly);
+            return null;
 
         if (reader.TokenType != JsonToken.String)
             throw new InvalidOperationException("Expected string, Got " + reader.TokenType);
@@ -48,7 +49,7 @@ internal sealed class TimeOnlyConverter : JsonConverter
 
     public override bool CanConvert(Type objectType)
     {
-        return objectType == typeof(TimeOnly);
+        return objectType == typeof(TimeOnly) || objectType == typeof(TimeOnly?);
     }
 }
 #endif


### PR DESCRIPTION
### Issue link

https://issues.hibernatingrhinos.com/issue/RavenDB-18399 

### Additional description

Support for nullable DateOnly / TimeOnly in Client. 

### Type of change

- Bug fix


### How risky is the change?

- Low 


### Backward compatibility

- Not relevant

### Is it platform specific issue?


- No

### Documentation update

- No documentation update is needed 

### Testing 

- Tests have been added that prove the fix is effective or that the feature works

### Is there any existing behavior change of other features due to this change?


- No

### UI work


- No UI work is needed
