### PR TITLE
RavenDB-18364 - MultiGetCommand clear cache on failover and doesn't refill the cache while still relay on cache

### DIFF
--- a/src/Raven.Client/Documents/Commands/ConditionalGetDocumentsCommand.cs
+++ b/src/Raven.Client/Documents/Commands/ConditionalGetDocumentsCommand.cs
@@ -34,7 +34,7 @@ namespace Raven.Client.Documents.Commands
             {
                 Method = HttpMethod.Get
             };
-            request.Headers.Add("If-None-Match", '"' + _changeVector + '"');
+            request.Headers.Add(Constants.Headers.IfNoneMatch, '"' + _changeVector + '"');
             url = pathBuilder.ToString();
             return request;
         }

--- a/src/Raven.Client/Documents/Commands/HeadAttachmentCommand.cs
+++ b/src/Raven.Client/Documents/Commands/HeadAttachmentCommand.cs
@@ -38,7 +38,7 @@ namespace Raven.Client.Documents.Commands
             };
 
             if (_changeVector != null)
-                request.Headers.TryAddWithoutValidation("If-None-Match", _changeVector);
+                request.Headers.TryAddWithoutValidation(Constants.Headers.IfNoneMatch, _changeVector);
 
             return request;
         }

--- a/src/Raven.Client/Documents/Commands/HeadDocumentCommand.cs
+++ b/src/Raven.Client/Documents/Commands/HeadDocumentCommand.cs
@@ -32,7 +32,7 @@ namespace Raven.Client.Documents.Commands
             };
 
             if (_changeVector != null)
-                request.Headers.TryAddWithoutValidation("If-None-Match", _changeVector);
+                request.Headers.TryAddWithoutValidation(Constants.Headers.IfNoneMatch, _changeVector);
 
             return request;
         }

--- a/src/Raven.Client/Documents/Session/Operations/Lazy/LazyConditionalLoadOperation.cs
+++ b/src/Raven.Client/Documents/Session/Operations/Lazy/LazyConditionalLoadOperation.cs
@@ -30,7 +30,7 @@ namespace Raven.Client.Documents.Session.Operations.Lazy
                 Query = $"?id={Uri.EscapeDataString(_id)}"
             };
 
-            request.Headers.Add("If-None-Match", '"' + _changeVector + '"');
+            request.Headers.Add(Constants.Headers.IfNoneMatch, '"' + _changeVector + '"');
             return request;
         }
 

--- a/src/Raven.Client/Http/RequestExecutor.cs
+++ b/src/Raven.Client/Http/RequestExecutor.cs
@@ -1084,7 +1084,7 @@ namespace Raven.Client.Http
         private void SetRequestHeaders(SessionInfo sessionInfo, string cachedChangeVector, HttpRequestMessage request)
         {
             if (cachedChangeVector != null)
-                request.Headers.TryAddWithoutValidation("If-None-Match", $"\"{cachedChangeVector}\"");
+                request.Headers.TryAddWithoutValidation(Constants.Headers.IfNoneMatch, $"\"{cachedChangeVector}\"");
 
             if (_disableClientConfigurationUpdates == false)
                 request.Headers.TryAddWithoutValidation(Constants.Headers.ClientConfigurationEtag, $"\"{ClientConfigurationEtag.ToInvariantString()}\"");

--- a/src/Raven.Server/Documents/Handlers/AttachmentHandler.cs
+++ b/src/Raven.Server/Documents/Handlers/AttachmentHandler.cs
@@ -39,7 +39,7 @@ namespace Raven.Server.Documents.Handlers
                     return Task.CompletedTask;
                 }
 
-                var changeVector = GetStringFromHeaders("If-None-Match");
+                var changeVector = GetStringFromHeaders(Constants.Headers.IfNoneMatch);
                 if (changeVector == attachment.ChangeVector)
                 {
                     HttpContext.Response.StatusCode = (int)HttpStatusCode.NotModified;
@@ -224,7 +224,7 @@ namespace Raven.Server.Documents.Handlers
                     return;
                 }
 
-                var attachmentChangeVector = GetStringFromHeaders("If-None-Match");
+                var attachmentChangeVector = GetStringFromHeaders(Constants.Headers.IfNoneMatch);
                 if (attachmentChangeVector == attachment.ChangeVector)
                 {
                     HttpContext.Response.StatusCode = (int)HttpStatusCode.NotModified;

--- a/src/Raven.Server/Documents/Handlers/DocumentHandler.cs
+++ b/src/Raven.Server/Documents/Handlers/DocumentHandler.cs
@@ -51,7 +51,7 @@ namespace Raven.Server.Documents.Handlers
         public Task Head()
         {
             var id = GetQueryStringValueAndAssertIfSingleAndNotEmpty("id");
-            var changeVector = GetStringFromHeaders("If-None-Match");
+            var changeVector = GetStringFromHeaders(Constants.Headers.IfNoneMatch);
 
             using (ContextPool.AllocateOperationContext(out DocumentsOperationContext context))
             using (context.OpenReadTransaction())
@@ -159,7 +159,7 @@ namespace Raven.Server.Documents.Handlers
             // everything here operates on all docs
             var databaseChangeVector = DocumentsStorage.GetDatabaseChangeVector(context);
 
-            if (GetStringFromHeaders("If-None-Match") == databaseChangeVector)
+            if (GetStringFromHeaders(Constants.Headers.IfNoneMatch) == databaseChangeVector)
             {
                 HttpContext.Response.StatusCode = (int)HttpStatusCode.NotModified;
                 return;
@@ -235,7 +235,7 @@ namespace Raven.Server.Documents.Handlers
 
                     if (document == null && ids.Count == 1)
                     {
-                        HttpContext.Response.StatusCode = GetStringFromHeaders("If-None-Match") == HttpCache.NotFoundResponse
+                        HttpContext.Response.StatusCode = GetStringFromHeaders(Constants.Headers.IfNoneMatch) == HttpCache.NotFoundResponse
                         ?(int)HttpStatusCode.NotModified
                         :(int)HttpStatusCode.NotFound;
                         return;
@@ -254,7 +254,7 @@ namespace Raven.Server.Documents.Handlers
 
                 var actualEtag = ComputeHttpEtags.ComputeEtagForDocuments(documents, includes, includeCounters, includeTimeSeries, includeCompareExchangeValues);
 
-                var etag = GetStringFromHeaders("If-None-Match");
+                var etag = GetStringFromHeaders(Constants.Headers.IfNoneMatch);
                 if (etag == actualEtag)
                 {
                     HttpContext.Response.StatusCode = (int)HttpStatusCode.NotModified;

--- a/src/Raven.Server/Documents/Handlers/IndexHandler.cs
+++ b/src/Raven.Server/Documents/Handlers/IndexHandler.cs
@@ -830,7 +830,7 @@ namespace Raven.Server.Documents.Handlers
                 var name = GetIndexNameFromCollectionAndField(field) ?? GetQueryStringValueAndAssertIfSingleAndNotEmpty("name");
 
                 var fromValue = GetStringQueryString("fromValue", required: false);
-                var existingResultEtag = GetLongFromHeaders("If-None-Match");
+                var existingResultEtag = GetLongFromHeaders(Constants.Headers.IfNoneMatch);
 
                 var result = Database.QueryRunner.ExecuteGetTermsQuery(name, field, fromValue, existingResultEtag, GetPageSize(), context, token, out var index);
 

--- a/src/Raven.Server/Documents/Handlers/QueriesHandler.cs
+++ b/src/Raven.Server/Documents/Handlers/QueriesHandler.cs
@@ -89,7 +89,7 @@ namespace Raven.Server.Documents.Handlers
 
         private async Task FacetedQuery(IndexQueryServerSide indexQuery, QueryOperationContext queryContext, OperationCancelToken token)
         {
-            var existingResultEtag = GetLongFromHeaders("If-None-Match");
+            var existingResultEtag = GetLongFromHeaders(Constants.Headers.IfNoneMatch);
 
             var result = await Database.QueryRunner.ExecuteFacetedQuery(indexQuery, existingResultEtag, queryContext, token);
 
@@ -125,7 +125,7 @@ namespace Raven.Server.Documents.Handlers
             if (TrafficWatchManager.HasRegisteredClients)
                 TrafficWatchQuery(indexQuery);
 
-            var existingResultEtag = GetLongFromHeaders("If-None-Match");
+            var existingResultEtag = GetLongFromHeaders(Constants.Headers.IfNoneMatch);
 
             if (indexQuery.Metadata.HasFacet)
             {
@@ -211,7 +211,7 @@ namespace Raven.Server.Documents.Handlers
 
         private async Task SuggestQuery(IndexQueryServerSide indexQuery, QueryOperationContext queryContext, OperationCancelToken token)
         {
-            var existingResultEtag = GetLongFromHeaders("If-None-Match");
+            var existingResultEtag = GetLongFromHeaders(Constants.Headers.IfNoneMatch);
             var result = await Database.QueryRunner.ExecuteSuggestionQuery(indexQuery, queryContext, existingResultEtag, token);
             if (result.NotModified)
             {
@@ -597,7 +597,7 @@ namespace Raven.Server.Documents.Handlers
         private async Task IndexEntries(QueryOperationContext queryContext, OperationCancelToken token, RequestTimeTracker tracker, HttpMethod method, bool ignoreLimit)
         {
             var indexQuery = await GetIndexQuery(queryContext.Documents, method, tracker);
-            var existingResultEtag = GetLongFromHeaders("If-None-Match");
+            var existingResultEtag = GetLongFromHeaders(Constants.Headers.IfNoneMatch);
 
             var result = await Database.QueryRunner.ExecuteIndexEntriesQuery(indexQuery, queryContext, ignoreLimit, existingResultEtag, token);
 

--- a/src/Raven.Server/Documents/Handlers/RevisionsHandler.cs
+++ b/src/Raven.Server/Documents/Handlers/RevisionsHandler.cs
@@ -227,7 +227,7 @@ namespace Raven.Server.Documents.Handlers
 
             var actualEtag = ComputeHttpEtags.ComputeEtagForRevisions(revisions);
 
-            var etag = GetStringFromHeaders("If-None-Match");
+            var etag = GetStringFromHeaders(Constants.Headers.IfNoneMatch);
             if (etag == actualEtag)
             {
                 HttpContext.Response.StatusCode = (int)HttpStatusCode.NotModified;
@@ -340,7 +340,7 @@ namespace Raven.Server.Documents.Handlers
 
             var actualChangeVector = revisions.Length == 0 ? "" : revisions[0].ChangeVector;
 
-            if (GetStringFromHeaders("If-None-Match") == actualChangeVector)
+            if (GetStringFromHeaders(Constants.Headers.IfNoneMatch) == actualChangeVector)
             {
                 HttpContext.Response.StatusCode = (int)HttpStatusCode.NotModified;
                 return;
@@ -402,7 +402,7 @@ namespace Raven.Server.Documents.Handlers
                 revisionsStorage.GetLatestRevisionsBinEntryEtag(context, etag, out var actualChangeVector);
                 if (actualChangeVector != null)
                 {
-                    if (GetStringFromHeaders("If-None-Match") == actualChangeVector)
+                    if (GetStringFromHeaders(Constants.Headers.IfNoneMatch) == actualChangeVector)
                     {
                         HttpContext.Response.StatusCode = (int)HttpStatusCode.NotModified;
                         return;

--- a/src/Raven.Server/Documents/Handlers/TimeSeriesHandler.cs
+++ b/src/Raven.Server/Documents/Handlers/TimeSeriesHandler.cs
@@ -145,7 +145,7 @@ namespace Raven.Server.Documents.Handlers
 
                 var actualEtag = CombineHashesFromMultipleRanges(ranges);
 
-                var etag = GetStringFromHeaders("If-None-Match");
+                var etag = GetStringFromHeaders(Constants.Headers.IfNoneMatch);
                 if (etag == actualEtag)
                 {
                     HttpContext.Response.StatusCode = (int)HttpStatusCode.NotModified;
@@ -198,7 +198,7 @@ namespace Raven.Server.Documents.Handlers
                 var rangeResult = GetTimeSeriesRange(context, documentId, name, from, to, ref start, ref pageSize, includesCommand);
                 var hash = rangeResult?.Hash ?? string.Empty;
 
-                var etag = GetStringFromHeaders("If-None-Match");
+                var etag = GetStringFromHeaders(Constants.Headers.IfNoneMatch);
                 if (etag == hash)
                 {
                     HttpContext.Response.StatusCode = (int)HttpStatusCode.NotModified;

--- a/src/Raven.Server/Web/Studio/StudioCollectionFieldsHandler.cs
+++ b/src/Raven.Server/Web/Studio/StudioCollectionFieldsHandler.cs
@@ -8,6 +8,7 @@ using Raven.Server.Documents;
 using Raven.Server.Routing;
 using Raven.Server.ServerWide.Context;
 using Sparrow.Json;
+using Raven.Client;
 
 namespace Raven.Server.Web.Studio
 {
@@ -43,7 +44,7 @@ namespace Raven.Server.Web.Studio
                         etag = $"{changeVector}/{totalResults}";
                 }
 
-                if (etag != null && GetStringFromHeaders("If-None-Match") == etag)
+                if (etag != null && GetStringFromHeaders(Constants.Headers.IfNoneMatch) == etag)
                 {
                     HttpContext.Response.StatusCode = (int)HttpStatusCode.NotModified;
                     return;

--- a/src/Raven.Server/Web/Studio/StudioCollectionsHandler.cs
+++ b/src/Raven.Server/Web/Studio/StudioCollectionsHandler.cs
@@ -61,7 +61,7 @@ namespace Raven.Server.Web.Studio
                         etag = $"{changeVector}/{totalResults}";
                 }
 
-                if (etag != null && GetStringFromHeaders("If-None-Match") == etag)
+                if (etag != null && GetStringFromHeaders(Constants.Headers.IfNoneMatch) == etag)
                 {
                     HttpContext.Response.StatusCode = (int)HttpStatusCode.NotModified;
                     return;

--- a/test/SlowTests/Issues/RavenDB_18364.cs
+++ b/test/SlowTests/Issues/RavenDB_18364.cs
@@ -1,0 +1,83 @@
+﻿using System;
+using System.Collections.Concurrent;
+using System.Collections.Generic;
+using System.IO;
+using System.Linq;
+using System.Threading.Tasks;
+using FastTests;
+using Raven.Client.Documents;
+using Raven.Client.Documents.Changes;
+using Raven.Client.ServerWide.Operations;
+using Raven.Server.Config;
+using Raven.Tests.Core.Utils.Entities;
+using Tests.Infrastructure;
+using Xunit;
+using Xunit.Abstractions;
+
+namespace SlowTests.Issues
+{
+
+    public class RavenDB_18364 : ClusterTestBase
+    {
+        public RavenDB_18364(ITestOutputHelper output) : base(output)
+        {
+        }
+
+        //5.2
+        [Fact]
+        public async Task LazilyLoad_WhenCachedResultAndFailover_ShouldNotReturnReturnNull()
+        {
+            var (nodes, leader) = await CreateRaftCluster(2, watcherCluster: true);
+            var store = GetDocumentStore(new Options {Server = leader, ReplicationFactor = 2});
+
+            const string id = "testObjs/0";
+            using (var session = store.OpenAsyncSession())
+            {
+                var o = new TestObj();
+                o.LargeContent = "abcd";
+                await session.StoreAsync(o, id);
+                await session.SaveChangesAsync();
+            }
+
+            using (var session = store.OpenAsyncSession())
+            {
+                var lazilyLoaded0 = await session.LoadAsync<TestObj>(id);
+            }
+
+            var record = await store.Maintenance.Server.SendAsync(new GetDatabaseRecordOperation(store.Database));
+            var firstNode = record.Topology.Members.First();
+            var firstServer = nodes.Single(n => n.ServerStore.NodeTag == firstNode);
+
+            //WaitForUserToContinueTheTest(store);
+
+            await DisposeServerAndWaitForFinishOfDisposalAsync(firstServer);
+
+            using (var session = store.OpenAsyncSession())
+            {
+                var lazilyLoaded0 = session.Advanced.Lazily.LoadAsync<TestObj>(id);
+
+                var loaded0 = await lazilyLoaded0.Value;
+
+                // var lazilyLoaded1 = session.Advanced.Lazily.LoadAsync<TestObj>(id);
+                //
+                // var loaded1 = await lazilyLoaded0.Value;
+
+                //Assert.NotNull(loaded0);
+            }
+
+            using (var session = store.OpenAsyncSession())
+            {
+                var lazilyLoaded0 = session.Advanced.Lazily.LoadAsync<TestObj>(id);
+                var loaded0 = await lazilyLoaded0.Value;
+                //Assert.NotNull(loaded0);
+            }
+        }
+
+        public class TestObj
+        {
+            public string Id { get; set; }
+            public string LargeContent { get; set; }
+        }
+
+    }
+}

--- a/test/SlowTests/Issues/RavenDB_18364.cs
+++ b/test/SlowTests/Issues/RavenDB_18364.cs
@@ -48,28 +48,22 @@ namespace SlowTests.Issues
             var firstNode = record.Topology.Members.First();
             var firstServer = nodes.Single(n => n.ServerStore.NodeTag == firstNode);
 
-            //WaitForUserToContinueTheTest(store);
+            WaitForUserToContinueTheTest(store);
 
             await DisposeServerAndWaitForFinishOfDisposalAsync(firstServer);
 
             using (var session = store.OpenAsyncSession())
             {
                 var lazilyLoaded0 = session.Advanced.Lazily.LoadAsync<TestObj>(id);
-
                 var loaded0 = await lazilyLoaded0.Value;
-
-                // var lazilyLoaded1 = session.Advanced.Lazily.LoadAsync<TestObj>(id);
-                //
-                // var loaded1 = await lazilyLoaded0.Value;
-
-                //Assert.NotNull(loaded0);
+                Assert.NotNull(loaded0);
             }
 
             using (var session = store.OpenAsyncSession())
             {
                 var lazilyLoaded0 = session.Advanced.Lazily.LoadAsync<TestObj>(id);
                 var loaded0 = await lazilyLoaded0.Value;
-                //Assert.NotNull(loaded0);
+                Assert.NotNull(loaded0);
             }
         }
 

--- a/test/SlowTests/Issues/RavenDB_18364.cs
+++ b/test/SlowTests/Issues/RavenDB_18364.cs
@@ -48,8 +48,6 @@ namespace SlowTests.Issues
             var firstNode = record.Topology.Members.First();
             var firstServer = nodes.Single(n => n.ServerStore.NodeTag == firstNode);
 
-            WaitForUserToContinueTheTest(store);
-
             await DisposeServerAndWaitForFinishOfDisposalAsync(firstServer);
 
             using (var session = store.OpenAsyncSession())

--- a/test/SlowTests/Tests/Faceted/ConditionalGetHelper.cs
+++ b/test/SlowTests/Tests/Faceted/ConditionalGetHelper.cs
@@ -5,6 +5,7 @@ using Raven.Client.Documents;
 using Raven.Client.Extensions;
 using Raven.Client.Http;
 using Sparrow.Json;
+using Raven.Client;
 
 namespace SlowTests.Tests.Faceted
 {
@@ -76,7 +77,7 @@ namespace SlowTests.Tests.Faceted
                 };
 
                 if (_requestEtag != null)
-                    request.Headers.TryAddWithoutValidation("If-None-Match", _requestEtag);
+                    request.Headers.TryAddWithoutValidation(Constants.Headers.IfNoneMatch, _requestEtag);
 
                 if (_method == HttpMethod.Post)
                     request.Content = new StringContent(_payload);

--- a/test/SlowTests/Tests/MultiGet/MultiGetBasic.cs
+++ b/test/SlowTests/Tests/MultiGet/MultiGetBasic.cs
@@ -7,6 +7,7 @@ using Raven.Client.Documents.Commands.MultiGet;
 using Sparrow.Json;
 using Xunit;
 using Xunit.Abstractions;
+using Raven.Client;
 
 namespace SlowTests.Tests.MultiGet
 {
@@ -177,7 +178,7 @@ namespace SlowTests.Tests.MultiGet
                             Query = "?id=users/1-A",
                             Headers =
                             {
-                                {"If-None-Match", firstCommand.Result[0].Headers["ETag"]}
+                                {Constants.Headers.IfNoneMatch, firstCommand.Result[0].Headers["ETag"]}
                             }
                         },
                         new GetRequest
@@ -186,7 +187,7 @@ namespace SlowTests.Tests.MultiGet
                             Query = "?id=users/2-A",
                             Headers =
                             {
-                                {"If-None-Match", firstCommand.Result[1].Headers["ETag"]}
+                                {Constants.Headers.IfNoneMatch, firstCommand.Result[1].Headers["ETag"]}
                             }
                         }
                     });


### PR DESCRIPTION
### Issue link

https://issues.hibernatingrhinos.com/issue/RavenDB-18364

### Additional description

Fixing lazy load operation after shutting down 1 node in the cluster that you already loaded this doc from.

### Type of change

- Bug fix

### How risky is the change?

- Low

### Backward compatibility

- Not relevant

### Is it platform specific issue?

- No

### Documentation update

- No documentation update is needed 

### Testing 

- Tests have been added that prove the fix is effective or that the feature works

### Is there any existing behavior change of other features due to this change?

- No

### UI work

- No UI work is needed
