### PR TITLE
RavenDB-18075 Workaround for a codegen optimization issue which resulted in AVE during gc_heap::mark_object_simple

### DIFF
--- a/src/Raven.Server/Documents/Queries/Parser/QueryParser.cs
+++ b/src/Raven.Server/Documents/Queries/Parser/QueryParser.cs
@@ -388,7 +388,6 @@ namespace Raven.Server.Documents.Queries.Parser
             // Lines where Name = 'Chang' select Product
 
             isImplicit = false;
-            SynteticWithQuery prev = default;
             alias = default;
             field = null;
             var start = Scanner.Position;
@@ -462,7 +461,7 @@ namespace Raven.Server.Documents.Queries.Parser
                     if (gq.HasAlias(alias))
                         return true;
 
-                    if (_synteticWithQueries?.TryGetValue(alias, out prev) == true && !prev.IsEdge)
+                    if (_synteticWithQueries?.TryGetValue(alias, out SynteticWithQuery prev) == true && !prev.IsEdge)
                         return true;
 
                     AddWithQuery(collection, null, alias, null, isEdge, start, true);


### PR DESCRIPTION
### Issue link

https://issues.hibernatingrhinos.com/issue/RavenDB-18075

### Additional description

It fixes occasional crashes during tests run on CI. See the issue for details of AVE thrown under the covers. 

It has been diagnosed by MS team as a codegen optimization issue  here: https://github.com/dotnet/runtime/issues/65694#issuecomment-1084647597

### Type of change

- Bug fix

### How risky is the change?

- Low 

### Backward compatibility


- Not relevant

### Is it platform specific issue?

- No

### Documentation update

- No documentation update is needed 

### Testing 

- Will be verified by existing tests on CI

### Is there any existing behavior change of other features due to this change?

- No

### UI work

- No UI work is needed
