### PR TITLE
RavenDB-18399 Support for Nullable DateOnly&TimeOnly for conventers and MapReduce.

### DIFF
--- a/src/Raven.Client/Documents/Indexes/ExpressionStringBuilder.cs
+++ b/src/Raven.Client/Documents/Indexes/ExpressionStringBuilder.cs
@@ -1326,9 +1326,18 @@ namespace Raven.Client.Documents.Indexes
             }
             var exprType = node.Expression != null ? node.Member.DeclaringType : node.Type;
 #if FEATURE_DATEONLY_TIMEONLY_SUPPORT
-            if (node.Type == typeof(TimeOnly) || node.Type == typeof(DateOnly))
+            if (_isProjectionPart && (node.Type == typeof(TimeOnly) || node.Type == typeof(DateOnly) || node.Type == typeof(TimeOnly?) || node.Type == typeof(DateOnly?)))
             {
-                Out($"As{node.Type.Name}(");
+                if (Nullable.GetUnderlyingType(node.Type) is Type underlyingType)
+                {
+                    Out($"As{underlyingType.Name}(");
+                }
+                else
+                {
+                    Out($"As{node.Type.Name}(");
+                }
+
+                
                 OutMember(node.Expression, node.Member, exprType);
                 Out(")");
                 return node;
@@ -1384,7 +1393,7 @@ namespace Raven.Client.Documents.Indexes
                 Out("new");
             }
             else
-            {
+            { 
                 Visit(node.NewExpression);
                 if (TypeExistsOnServer(node.Type) == false)
                 {
@@ -1722,10 +1731,13 @@ namespace Raven.Client.Documents.Indexes
 
                     var oldAvoidDuplicateParameters = _avoidDuplicatedParameters;
                     var oldIsSelectMany = _isSelectMany;
-
+                    var oldIsProjectionPart = _isProjectionPart;
                     _isSelectMany = node.Method.Name == "SelectMany";
                     if (node.Method.Name == "Select" || _isSelectMany)
+                    {
                         _avoidDuplicatedParameters = true;
+                        _isProjectionPart = true;
+                    }
 
                     if (node.Arguments[num2].NodeType == ExpressionType.MemberAccess)
                     {
@@ -1747,6 +1759,7 @@ namespace Raven.Client.Documents.Indexes
 
                     _isSelectMany = oldIsSelectMany;
                     _avoidDuplicatedParameters = oldAvoidDuplicateParameters;
+                    _isProjectionPart = oldIsProjectionPart;
                 }
                 finally
                 {
@@ -2178,6 +2191,7 @@ namespace Raven.Client.Documents.Indexes
         private bool _insideWellKnownType;
         private bool _avoidDuplicatedParameters;
         private bool _isSelectMany;
+        private bool _isProjectionPart;
         private readonly HashSet<Type> _loadDocumentTypes = new HashSet<Type>();
 
         /// <summary>

--- a/src/Raven.Client/Json/Serialization/IJsonWriter.cs
+++ b/src/Raven.Client/Json/Serialization/IJsonWriter.cs
@@ -65,7 +65,16 @@ namespace Raven.Client.Json.Serialization
         void WriteValue(DateTimeOffset dto);
 
         void WriteValue(DateTimeOffset? value);
+        
+#if FEATURE_DATEONLY_TIMEONLY_SUPPORT
+        void WriteValue(TimeOnly to);
 
+        void WriteValue(TimeOnly? to);
+        
+        void WriteValue(DateOnly @do);
+
+        void WriteValue(DateOnly? @do);
+#endif
         void WriteValue(decimal value);
 
         void WriteValue(decimal? value);

--- a/src/Raven.Client/Json/Serialization/NewtonsoftJson/Internal/BlittableJsonWriter.cs
+++ b/src/Raven.Client/Json/Serialization/NewtonsoftJson/Internal/BlittableJsonWriter.cs
@@ -267,6 +267,14 @@ namespace Raven.Client.Json.Serialization.NewtonsoftJson.Internal
                 case TimeSpan ts:
                     WriteValue(ts);
                     break;
+#if FEATURE_DATEONLY_TIMEONLY_SUPPORT
+                case TimeOnly to:
+                    WriteValue(to);
+                    break;
+                case DateOnly @do:
+                    WriteValue(@do);
+                    break;
+#endif
                 case IDictionary<string, string> dics:
                     WriteDictionary(dics);
                     break;
@@ -441,6 +449,36 @@ namespace Raven.Client.Json.Serialization.NewtonsoftJson.Internal
             _manualBlittableJsonDocumentBuilder.WriteValue(value);
         }
 
+#if FEATURE_DATEONLY_TIMEONLY_SUPPORT
+        public void WriteValue(TimeOnly to)
+        {
+            var value = to.ToString(DefaultFormat.TimeOnlyFormatToWrite);
+            _manualBlittableJsonDocumentBuilder.WriteValue(value);
+        }
+        
+        public void WriteValue(DateOnly @do)
+        {
+            var value = @do.ToString(DefaultFormat.DateOnlyFormatToWrite);
+            _manualBlittableJsonDocumentBuilder.WriteValue(value);
+        }
+        
+        public void WriteValue(TimeOnly? to)
+        {
+            if (to != null)
+                _manualBlittableJsonDocumentBuilder.WriteValue(to.Value.ToString(DefaultFormat.TimeOnlyFormatToWrite));
+            else
+                _manualBlittableJsonDocumentBuilder.WriteValueNull();
+        }
+        
+        public void WriteValue(DateOnly? @do)
+        {
+            if (@do != null)
+                _manualBlittableJsonDocumentBuilder.WriteValue(@do.Value.ToString(DefaultFormat.DateOnlyFormatToWrite));
+            else
+                _manualBlittableJsonDocumentBuilder.WriteValueNull();
+        }
+#endif
+
         public override void WriteValue(int? value)
         {
             if (value != null)
@@ -526,7 +564,7 @@ namespace Raven.Client.Json.Serialization.NewtonsoftJson.Internal
             else
                 _manualBlittableJsonDocumentBuilder.WriteValueNull();
         }
-
+        
         protected override void Dispose(bool disposing)
         {
             _manualBlittableJsonDocumentBuilder.Dispose();

--- a/src/Raven.Server/Documents/Indexes/MapReduce/ReduceKeyProcessor.cs
+++ b/src/Raven.Server/Documents/Indexes/MapReduce/ReduceKeyProcessor.cs
@@ -250,7 +250,11 @@ namespace Raven.Server.Documents.Indexes.MapReduce
                 ticks = dateTimeOffset.Ticks;
             if (value is TimeSpan timeSpan)
                 ticks = timeSpan.Ticks;
-
+            if (value is DateOnly @do)
+                ticks = @do.DayNumber * TimeSpan.TicksPerDay;
+            if (value is TimeOnly to)
+                ticks = to.Ticks;
+                    
             if (ticks.HasValue)
             {
                 var t = ticks.Value;

--- a/src/Raven.Server/Documents/Indexes/MapReduce/Static/MapReduceIndex.cs
+++ b/src/Raven.Server/Documents/Indexes/MapReduce/Static/MapReduceIndex.cs
@@ -670,6 +670,14 @@ namespace Raven.Server.Documents.Indexes.MapReduce.Static
                                 writer.WriteValue(val);
                                 break;
 
+                            case TimeOnly val:
+                                writer.WriteValue(val);
+                                break;
+                            
+                            case DateOnly val:
+                                writer.WriteValue(val);
+                                break;
+                            
                             case BlittableJsonReaderObject val:
                                 var propertyDetails = new BlittableJsonReaderObject.PropertyDetails();
 

--- a/src/Raven.Server/Documents/Indexes/Static/StaticIndexBase.cs
+++ b/src/Raven.Server/Documents/Indexes/Static/StaticIndexBase.cs
@@ -468,7 +468,7 @@ namespace Raven.Server.Documents.Indexes.Static
             {
                 return dtO;
             }
-
+            
             if (field is null)
             {
                 return DynamicNullObject.ExplicitNull;

--- a/src/Raven.Server/Utils/TypeConverter.cs
+++ b/src/Raven.Server/Utils/TypeConverter.cs
@@ -213,7 +213,8 @@ namespace Raven.Server.Utils
                 type == typeof(string) || type == typeof(bool) || type == typeof(int) || type == typeof(long) ||
                 type == typeof(double) || type == typeof(decimal) || type == typeof(float) || type == typeof(short) ||
                 type == typeof(byte) ||
-                type == typeof(DateTime) || type == typeof(DateTimeOffset) || type == typeof(TimeSpan))
+                type == typeof(DateTime) || type == typeof(DateTimeOffset) || type == typeof(TimeSpan) ||
+                type == typeof(DateOnly) || type == typeof(TimeOnly))
                 return BlittableSupportedReturnType.Same;
 
             if (value is JsValue)

--- a/src/Sparrow/Json/Parsing/ObjectJsonParser.cs
+++ b/src/Sparrow/Json/Parsing/ObjectJsonParser.cs
@@ -516,7 +516,26 @@ namespace Sparrow.Json.Parsing
                     _state.CurrentTokenType = JsonParserToken.String;
                     return true;
                 }
+                
+#if FEATURE_DATEONLY_TIMEONLY_SUPPORT
+                if (current is TimeOnly timeOnly)
+                {
+                    var s = timeOnly.ToString(DefaultFormat.TimeOnlyFormatToWrite);
 
+                    SetStringBuffer(s);
+                    _state.CurrentTokenType = JsonParserToken.String;
+                    return true;
+                }
+                
+                if (current is DateOnly dateOnly)
+                {
+                    var s = dateOnly.ToString(DefaultFormat.DateOnlyFormatToWrite);
+
+                    SetStringBuffer(s);
+                    _state.CurrentTokenType = JsonParserToken.String;
+                    return true;
+                }
+#endif
                 if (current is decimal d2)
                 {
                     var d = (decimal)current;

--- a/test/SlowTests/Issues/RavenDB-18404.cs
+++ b/test/SlowTests/Issues/RavenDB-18404.cs
@@ -1,0 +1,94 @@
+﻿using System;
+using System.Linq;
+using FastTests;
+using Raven.Client.Documents.Indexes;
+using Raven.Client.Documents.Operations.Indexes;
+using Xunit;
+using Xunit.Abstractions;
+
+namespace SlowTests.Issues;
+
+public class RavenDB_18404 : RavenTestBase
+{
+    public RavenDB_18404(ITestOutputHelper output) : base(output)
+    {
+    }
+
+    [Fact]
+    public void NullableDateOnlyWithMapReduce()
+    {
+        using var store = GetDocumentStore();
+        {
+            using var s = store.OpenSession();
+            s.Store(new BussinessCustomer
+            {
+                Id = "bus1",
+              
+            });
+            s.Store(new IndividualCustomer
+            {
+                Id = "cus1",
+                BirthDate = new DateOnly(2022, 9, 10)
+            });
+            s.Store(new Contract
+            {
+                Id = "con1",
+               
+            });
+            s.SaveChanges();
+        }
+
+        var index = new Core_Customers_CustomerProfile();
+        index.Execute(store);
+        Indexes.WaitForIndexing(store);
+        WaitForUserToContinueTheTest(store);
+        var indexErrors = store.Maintenance.Send(new GetIndexErrorsOperation(new[] { index.IndexName }));
+        Assert.Equal(0, indexErrors[0].Errors.Length);
+    }
+    
+    record BussinessCustomer
+    {
+        public string Id { get; init; }
+    }
+
+    record IndividualCustomer
+    {
+        public string Id { get; init; }
+        public DateOnly BirthDate { get; init; }
+    }
+
+    record Contract
+    {
+        public string Id { get; init; }
+    }
+
+    public record CustomerProfileResult
+    {
+        public string Id { get; init; }
+    }
+
+    public record IndividualCustomerProfileResult : CustomerProfileResult
+    {
+        public DateOnly BirthDate { get; init; }
+    }
+
+    public record Result : IndividualCustomerProfileResult
+    {
+        public new DateOnly? BirthDate { get; init; }
+    }
+    
+    private class Core_Customers_CustomerProfile : AbstractMultiMapIndexCreationTask<Result>
+    {
+        public Core_Customers_CustomerProfile()
+        {
+            AddMap<IndividualCustomer>(customers =>
+                from customer in customers
+                select new Result {Id = customer.Id, BirthDate = customer.BirthDate,});
+            Reduce = results =>
+                from result in results
+                group result by result.Id
+                into g
+                select new Result {Id = g.Key, BirthDate = g.Select(x => x.BirthDate).First(x => x != null),};
+        }
+    }
+}


### PR DESCRIPTION
### Issue link

https://issues.hibernatingrhinos.com/issue/RavenDB-18403
https://issues.hibernatingrhinos.com/issue/RavenDB-18404

### Additional description


This PR includes two significant changes for DateOnly and TimeOnly support.

The first change is support for DateOnly and TimeOnly conventions for MapReduce.

The second is a change to the index rewriter. As agreed before, we automatically detected the type in static indexes, and if we encountered a TimeOnly or DateOnly we added AsDateOnly( term ) or AsTimeOnly (term ), which allowed us to build an index containing Ticks. Now we make sure that we only specify this in the SELECT clause.

### Type of change

- Bug fix


### How risky is the change?

- Moderate 

### Backward compatibility
- Not relevant

### Is it platform specific issue?

- No

### Documentation update

- No documentation update is needed 

### Testing 

- Tests have been added that prove the fix is effective or that the feature works

### Is there any existing behavior change of other features due to this change?

- No

### UI work

- No UI work is needed
