### PR TITLE
RavenDB-18414 AddOrPatch / Patch session API adds needless $type valu…

### DIFF
--- a/src/Raven.Client/Documents/Session/InMemoryDocumentSessionOperations.Patch.cs
+++ b/src/Raven.Client/Documents/Session/InMemoryDocumentSessionOperations.Patch.cs
@@ -304,7 +304,7 @@ namespace Raven.Client.Documents.Session
             return true;
         }
 
-        private static readonly CreateSerializerOptions SerializerOptions = new CreateSerializerOptions {TypeNameHandling = TypeNameHandling.Objects};
+        private static readonly CreateSerializerOptions SerializerOptions = new CreateSerializerOptions {TypeNameHandling = TypeNameHandling.Auto};
 
         private object AddTypeNameToValueIfNeeded(Type propertyType, object value)
         {
@@ -326,7 +326,7 @@ namespace Raven.Client.Documents.Session
                 writer.WriteStartObject();
                 writer.WritePropertyName("Value");
 
-                serializer.Serialize(writer, value);
+                serializer.Serialize(writer, value, propertyType);
 
                 writer.WriteEndObject();
 

--- a/src/Raven.Client/Json/Serialization/IJsonSerializer.cs
+++ b/src/Raven.Client/Json/Serialization/IJsonSerializer.cs
@@ -6,6 +6,8 @@ namespace Raven.Client.Json.Serialization
     {
         void Serialize(IJsonWriter writer, object value);
 
+        void Serialize(IJsonWriter writer, object value, Type objectType);
+
         object Deserialize(IJsonReader reader, Type type);
 
         T Deserialize<T>(IJsonReader reader);

--- a/src/Raven.Client/Json/Serialization/NewtonsoftJson/Internal/NewtonsoftJsonJsonSerializer.cs
+++ b/src/Raven.Client/Json/Serialization/NewtonsoftJson/Internal/NewtonsoftJsonJsonSerializer.cs
@@ -15,6 +15,11 @@ namespace Raven.Client.Json.Serialization.NewtonsoftJson.Internal
             return Deserialize<T>((BlittableJsonReader)reader);
         }
 
+        void IJsonSerializer.Serialize(IJsonWriter writer, object value, Type objectType)
+        {
+            Serialize((BlittableJsonWriter)writer, value, objectType);
+        }
+        
         void IJsonSerializer.Serialize(IJsonWriter writer, object value)
         {
             Serialize((BlittableJsonWriter)writer, value);
@@ -32,6 +37,9 @@ namespace Raven.Client.Json.Serialization.NewtonsoftJson.Internal
                     break;
                 case TypeNameHandling.Objects:
                     jsonSerializer.TypeNameHandling = Newtonsoft.Json.TypeNameHandling.Objects;
+                    break;
+                case TypeNameHandling.Auto:
+                    jsonSerializer.TypeNameHandling = Newtonsoft.Json.TypeNameHandling.Auto;
                     break;
             }
         }

--- a/src/Raven.Client/Json/Serialization/TypeNameHandling.cs
+++ b/src/Raven.Client/Json/Serialization/TypeNameHandling.cs
@@ -3,6 +3,7 @@
     public enum TypeNameHandling
     {
         None,
-        Objects
+        Objects,
+        Auto
     }
 }

--- a/test/SlowTests/Issues/RavenDB_18414.cs
+++ b/test/SlowTests/Issues/RavenDB_18414.cs
@@ -1,0 +1,96 @@
+using System;
+using System.Collections.Generic;
+using FastTests;
+using Sparrow.Json;
+using Xunit;
+using Xunit.Abstractions;
+
+namespace SlowTests.MailingList;
+
+public class RavenDB_18414 : RavenTestBase
+{
+    public RavenDB_18414(ITestOutputHelper output) : base(output)
+    {
+    }
+
+    [Fact]
+    public void WillNotAddTypeToNestedObjectsOfSameClass()
+    {
+        using var store = GetDocumentStore();
+
+
+        using (var session = store.OpenSession())
+        {
+            var test = new TestingEntity()
+            {
+                MyValues = new Dictionary<string, string> { { "", "" } },
+                MyCollection =
+                {
+                    new TestingItemEntity { MyName = "bbbb" } 
+                }
+            };
+
+
+            session.Store(test, "items/test");
+
+            session.SaveChanges();
+
+        }
+
+        using (var session = store.OpenSession())
+        {
+            var newCollection = new List<TestingItemEntity> { new TestingItemEntity { MyName = "abba" } };
+
+
+            session.Advanced.Patch<TestingEntity, ICollection<TestingItemEntity>>("items/test", x => x.MyCollection, newCollection);
+
+            session.SaveChanges();
+        }
+        
+        using (var session = store.OpenSession())
+        {
+            var obj = session.Load<BlittableJsonReaderObject>("items/test");
+            Assert.DoesNotContain("$type", obj.ToString());
+        }
+    }
+
+    private abstract class BaseStorageEntity
+
+    {
+        public string Id { get; set; }
+
+        public Guid CreatedBy { get; set; }
+
+        public Guid ModifiedBy { get; set; }
+
+        public DateTime CreatedDate { get; set; } = DateTime.UtcNow;
+
+        public DateTime ModifiedDate { get; set; } = DateTime.UtcNow;
+
+        public bool IsDeactivated { get; set; }
+
+        public DateTime? DeactivatedDate { get; set; }
+    }
+
+
+    private interface IMyRepo
+
+    {
+        void Test();
+    }
+
+    private class TestingEntity : BaseStorageEntity
+
+    {
+        public Dictionary<string, string> MyValues { get; set; }
+
+        public ICollection<TestingItemEntity> MyCollection { get; set; } = new List<TestingItemEntity>();
+    }
+
+
+    private class TestingItemEntity
+
+    {
+        public string MyName { get; set; }
+    }
+}


### PR DESCRIPTION
…e to instances

### Issue link

https://issues.hibernatingrhinos.com/issue/RavenDB-18414 

### Additional description

This is done because of [RavenDB-12248](https://issues.hibernatingrhinos.com/issue/RavenDB-12248), but was too eager and added for everything. 
This PR changes the behavior so it will only be applied if the type and the instance aren't the same. 

### Type of change

- Bug fix

### How risky is the change?

- Moderate 

### Backward compatibility

I added an enum value and an interface method.
Users who implemented the `IJsonSerializer` would have to handle that. I think that this is acceptable since those are fairly rare and the change is minimal (can call the current `Serialize` directly).

### Is it platform specific issue?

- No

### Documentation update

- No documentation update is needed 

### Testing 

- Tests have been added that prove the fix is effective or that the feature works


### UI work

- No UI work is needed
