### PR TITLE
RavenDB-16358 - Aggressive cache not used for lazily loaded documents after first cache timeout

### DIFF
--- a/src/Raven.Client/Documents/Commands/MultiGet/MultiGetCommand.cs
+++ b/src/Raven.Client/Documents/Commands/MultiGet/MultiGetCommand.cs
@@ -36,7 +36,7 @@ namespace Raven.Client.Documents.Commands.MultiGet
         {
             _baseUrl = $"{node.Url}/databases/{node.Database}";
             url = $"{_baseUrl}/multi_get";
-            
+
             if (MaybeReadAllFromCache(ctx, _requestExecutor.AggressiveCaching.Value))
             {
                 AggressivelyCached = true;
@@ -167,41 +167,41 @@ namespace Raven.Client.Documents.Commands.MultiGet
 
         public override void SetResponseRaw(HttpResponseMessage response, Stream stream, JsonOperationContext context)
         {
-            var state = new JsonParserState();
-            using (var parser = new UnmanagedJsonParser(context, state, "multi_get/response"))
+                var state = new JsonParserState();
+                using (var parser = new UnmanagedJsonParser(context, state, "multi_get/response"))
             using (context.GetMemoryBuffer(out var buffer))
-            using (var peepingTomStream = new PeepingTomStream(stream, context))
+                using (var peepingTomStream = new PeepingTomStream(stream, context))
             using (_cached)
-            {
-                if (UnmanagedJsonParserHelper.Read(peepingTomStream, parser, state, buffer) == false)
-                    ThrowInvalidJsonResponse(peepingTomStream);
-
-                if (state.CurrentTokenType != JsonParserToken.StartObject) 
-                    ThrowInvalidJsonResponse(peepingTomStream);
-
-                var property = UnmanagedJsonParserHelper.ReadString(context, peepingTomStream, parser, state, buffer);
-                if (property != nameof(BlittableArrayResult.Results))
-                    ThrowInvalidJsonResponse(peepingTomStream);
-
-                var i = 0;
-                Result = new List<GetResponse>(_commands.Count);
-                foreach (var getResponse in ReadResponses(context, peepingTomStream, parser, state, buffer))
                 {
-                    var command = _commands[i];
+                    if (UnmanagedJsonParserHelper.Read(peepingTomStream, parser, state, buffer) == false)
+                        ThrowInvalidJsonResponse(peepingTomStream);
 
-                    MaybeSetCache(getResponse, command);
+                    if (state.CurrentTokenType != JsonParserToken.StartObject)
+                        ThrowInvalidJsonResponse(peepingTomStream);
+
+                    var property = UnmanagedJsonParserHelper.ReadString(context, peepingTomStream, parser, state, buffer);
+                    if (property != nameof(BlittableArrayResult.Results))
+                        ThrowInvalidJsonResponse(peepingTomStream);
+
+                    var i = 0;
+                Result = new List<GetResponse>(_commands.Count);
+                    foreach (var getResponse in ReadResponses(context, peepingTomStream, parser, state, buffer))
+                    {
+                        var command = _commands[i];
+
+                        MaybeSetCache(getResponse, command, context);
                     Result.Add(_cached != null && getResponse.StatusCode == HttpStatusCode.NotModified ? new GetResponse { Result = _cached.Values[i].Cached?.Clone(context), StatusCode = HttpStatusCode.NotModified } : getResponse);
 
-                    i++;
+                        i++;
+                    }
+
+                    if (UnmanagedJsonParserHelper.Read(peepingTomStream, parser, state, buffer) == false)
+                        ThrowInvalidJsonResponse(peepingTomStream);
+
+                    if (state.CurrentTokenType != JsonParserToken.EndObject)
+                        ThrowInvalidJsonResponse(peepingTomStream);
                 }
-
-                if (UnmanagedJsonParserHelper.Read(peepingTomStream, parser, state, buffer) == false)
-                    ThrowInvalidJsonResponse(peepingTomStream);
-
-                if (state.CurrentTokenType != JsonParserToken.EndObject)
-                    ThrowInvalidJsonResponse(peepingTomStream);
             }
-        }
 
         private static IEnumerable<GetResponse> ReadResponses(JsonOperationContext context, PeepingTomStream peepingTomStream, UnmanagedJsonParser parser, JsonParserState state, JsonOperationContext.MemoryBuffer buffer)
         {
@@ -239,7 +239,7 @@ namespace Raven.Client.Documents.Commands.MultiGet
 
                 if (state.CurrentTokenType != JsonParserToken.String)
                     ThrowInvalidJsonResponse(peepingTomStream);
-                
+
                 var property = context.AllocateStringValue(null, state.StringBuffer, state.StringSize).ToString();
                 switch (property)
                 {
@@ -297,12 +297,21 @@ namespace Raven.Client.Documents.Commands.MultiGet
             return getResponse;
         }
 
-        private void MaybeSetCache(GetResponse getResponse, GetRequest command)
+        private void MaybeSetCache(GetResponse getResponse, GetRequest command, JsonOperationContext context)
         {
-            if (getResponse.StatusCode == HttpStatusCode.NotModified)
-                return;
-
             var cacheKey = GetCacheKey(command, out string _);
+
+            if (getResponse.StatusCode == HttpStatusCode.NotModified)
+            {
+                // if not modified - update age
+                using var cachedItem = _httpCache.Get(context, cacheKey, out var cv, out var cached);
+                if (cachedItem.Item != null)
+                {
+                    cachedItem.Item.UpdateLastServerUpdate();
+                }
+                return;
+            }
+            
 
             var result = getResponse.Result as BlittableJsonReaderObject;
             if (result == null)
@@ -332,7 +341,7 @@ namespace Raven.Client.Documents.Commands.MultiGet
             if (_cached != null)
             {
                 _cached.Dispose();
-                _cached = null;
+            _cached = null;
 
                 // The client sends the commands.
                 // Some of which could be saved in cache with a response 
@@ -343,7 +352,7 @@ namespace Raven.Client.Documents.Commands.MultiGet
                 foreach (var command in _commands)
                 {
                     command.Headers.Remove(Constants.Headers.IfNoneMatch);
-                }
+        }
             } 
         }
 
@@ -356,7 +365,7 @@ namespace Raven.Client.Documents.Commands.MultiGet
             {
                 _size = size;
                 Values = ArrayPool<(HttpCache.ReleaseCacheItem, BlittableJsonReaderObject)>.Shared.Rent(size);
-            }
+    }
 
             public void Dispose()
             {
@@ -365,7 +374,7 @@ namespace Raven.Client.Documents.Commands.MultiGet
                 for (int i = 0; i < _size; i++)
                 {
                     Values[i].Release.Dispose();
-                }
+}
                 ArrayPool<(HttpCache.ReleaseCacheItem, BlittableJsonReaderObject)>.Shared.Return(Values);
                 Values = null;
             }

--- a/src/Raven.Client/Http/HttpCache.cs
+++ b/src/Raven.Client/Http/HttpCache.cs
@@ -63,6 +63,11 @@ namespace Raven.Client.Http
                 this.LastServerUpdate = SystemTime.UtcNow;
             }
 
+            public void UpdateLastServerUpdate()
+            {
+                this.LastServerUpdate = SystemTime.UtcNow;
+            }
+
             public bool AddRef()
             {
                 // May return false if the memory has been already released.

--- a/src/Raven.Client/Http/HttpCache.cs
+++ b/src/Raven.Client/Http/HttpCache.cs
@@ -63,11 +63,6 @@ namespace Raven.Client.Http
                 this.LastServerUpdate = SystemTime.UtcNow;
             }
 
-            public void UpdateLastServerUpdate()
-            {
-                this.LastServerUpdate = SystemTime.UtcNow;
-            }
-
             public bool AddRef()
             {
                 // May return false if the memory has been already released.

--- a/test/SlowTests/Issues/RavenDB_16358.cs
+++ b/test/SlowTests/Issues/RavenDB_16358.cs
@@ -1,23 +1,8 @@
 ﻿using System;
-using System.Collections.Generic;
-using System.Diagnostics;
-using System.Linq;
 using System.Threading;
 using System.Threading.Tasks;
 using FastTests;
-using Raven.Client;
 using Raven.Client.Documents;
-using Raven.Client.Documents.Operations.ConnectionStrings;
-using Raven.Client.Documents.Operations.ETL;
-using Raven.Server;
-using Raven.Server.Documents;
-using Raven.Server.Documents.TimeSeries;
-using Raven.Server.ServerWide.Context;
-using Raven.Tests.Core.Utils.Entities;
-using Raven.Server.Config;
-using Sparrow.Json;
-using Sparrow.Json.Parsing;
-using Tests.Infrastructure;
 using Xunit;
 using Xunit.Abstractions;
 
@@ -49,7 +34,7 @@ namespace SlowTests.Issues
 
             Assert.Equal(requests, requestExecutor.NumberOfServerRequests);
 
-            await Task.Delay(3000); // cache timed out
+            await Task.Delay(500); // cache timed out
 
             await LoadDataAsync(store);
 
@@ -65,7 +50,7 @@ namespace SlowTests.Issues
         private async Task LoadDataAsync(IDocumentStore store)
         {
             using (var session = store.OpenAsyncSession())
-            using (session.Advanced.DocumentStore.AggressivelyCacheFor(TimeSpan.FromSeconds(2)))
+            using (session.Advanced.DocumentStore.AggressivelyCacheFor(TimeSpan.FromMilliseconds(300)))
             {
                 var docLazy = session.Advanced.Lazily.LoadAsync<Doc>("doc-1");
                 var doc = await docLazy.Value;
@@ -92,7 +77,7 @@ namespace SlowTests.Issues
 
             Assert.Equal(requests, requestExecutor.NumberOfServerRequests);
 
-            Thread.Sleep(3000); // cache timed out
+            Thread.Sleep(500); // cache timed out
 
             LoadData(store); 
 
@@ -108,20 +93,16 @@ namespace SlowTests.Issues
         private void LoadData(IDocumentStore store)
         {
             using (var session = store.OpenSession())
-            using (session.Advanced.DocumentStore.AggressivelyCacheFor(TimeSpan.FromSeconds(2)))
+            using (session.Advanced.DocumentStore.AggressivelyCacheFor(TimeSpan.FromMilliseconds(300)))
             {
                 var docLazy = session.Advanced.Lazily.Load<Doc>("doc-1");
                 var doc = docLazy.Value;
             }
         }
 
-        public class Doc
+        private class Doc
         {
             public string Id { get; set; }
         }
-
-
-
     }
-
 }

--- a/test/SlowTests/Issues/RavenDB_16358.cs
+++ b/test/SlowTests/Issues/RavenDB_16358.cs
@@ -1,0 +1,127 @@
+﻿using System;
+using System.Collections.Generic;
+using System.Diagnostics;
+using System.Linq;
+using System.Threading;
+using System.Threading.Tasks;
+using FastTests;
+using Raven.Client;
+using Raven.Client.Documents;
+using Raven.Client.Documents.Operations.ConnectionStrings;
+using Raven.Client.Documents.Operations.ETL;
+using Raven.Server;
+using Raven.Server.Documents;
+using Raven.Server.Documents.TimeSeries;
+using Raven.Server.ServerWide.Context;
+using Raven.Tests.Core.Utils.Entities;
+using Raven.Server.Config;
+using Sparrow.Json;
+using Sparrow.Json.Parsing;
+using Tests.Infrastructure;
+using Xunit;
+using Xunit.Abstractions;
+
+namespace SlowTests.Issues
+{
+    public class RavenDB_16358 : RavenTestBase
+    {
+        public RavenDB_16358(ITestOutputHelper output) : base(output)
+        {
+        }
+
+        [Fact]
+        public async Task AggressiveCacheWithTimeoutTestAsync()
+        {
+            using var store = GetDocumentStore();
+
+            var requestExecutor = store.GetRequestExecutor();
+            using (var session = store.OpenSession())
+            {
+                session.Store(new Doc { Id = "doc-1" });
+                session.SaveChanges();
+            }
+
+            await LoadDataAsync(store);
+
+            var requests = requestExecutor.NumberOfServerRequests;
+
+            await LoadDataAsync(store); //got 'Not modified' from server - update httpCacheItem age to 0
+
+            Assert.Equal(requests, requestExecutor.NumberOfServerRequests);
+
+            await Task.Delay(3000); // cache timed out
+
+            await LoadDataAsync(store);
+
+            // additional request expected after cache timed out
+            Assert.Equal(requests + 1, requestExecutor.NumberOfServerRequests);
+
+            await LoadDataAsync(store);
+
+            // this should be aggressively cached without sending a request
+            Assert.Equal(requests + 1, requestExecutor.NumberOfServerRequests);
+        }
+
+        private async Task LoadDataAsync(IDocumentStore store)
+        {
+            using (var session = store.OpenAsyncSession())
+            using (session.Advanced.DocumentStore.AggressivelyCacheFor(TimeSpan.FromSeconds(2)))
+            {
+                var docLazy = session.Advanced.Lazily.LoadAsync<Doc>("doc-1");
+                var doc = await docLazy.Value;
+            }
+        }
+
+        [Fact]
+        public void AggressiveCacheWithTimeoutTest()
+        {
+            using var store = GetDocumentStore();
+
+            var requestExecutor = store.GetRequestExecutor();
+            using (var session = store.OpenSession())
+            {
+                session.Store(new Doc { Id = "doc-1" });
+                session.SaveChanges();
+            }
+
+            LoadData(store);
+
+            var requests = requestExecutor.NumberOfServerRequests;
+
+            LoadData(store); //got 'Not modified' from server - update httpCacheItem age to 0
+
+            Assert.Equal(requests, requestExecutor.NumberOfServerRequests);
+
+            Thread.Sleep(3000); // cache timed out
+
+            LoadData(store); 
+
+            // additional request expected after cache timed out
+            Assert.Equal(requests + 1, requestExecutor.NumberOfServerRequests);
+
+            LoadData(store);
+
+            // this should be aggressively cached without sending a  request
+            Assert.Equal(requests + 1, requestExecutor.NumberOfServerRequests);
+        }
+
+        private void LoadData(IDocumentStore store)
+        {
+            using (var session = store.OpenSession())
+            using (session.Advanced.DocumentStore.AggressivelyCacheFor(TimeSpan.FromSeconds(2)))
+            {
+                var docLazy = session.Advanced.Lazily.Load<Doc>("doc-1");
+                var doc = docLazy.Value;
+            }
+        }
+
+        public class Doc
+        {
+            public string Id { get; set; }
+        }
+
+
+
+    }
+
+}


### PR DESCRIPTION
### Issue link

https://issues.hibernatingrhinos.com/issue/RavenDB-16358

### Additional description

Fixing aggressive cache not used for lazily loaded documents after first cache timeout.

### Type of change

- Bug fix

### How risky is the change?

- Low 

### Backward compatibility

- Not relevant

### Is it platform specific issue?

- No

### Documentation update

- No documentation update is needed 

### Testing 

- Tests have been added that prove the fix is effective or that the feature works

### Is there any existing behavior change of other features due to this change?

- No

### UI work

- No UI work is needed
