### PR TITLE
RavenDB-18405 Edit Database Settings: Allow to set time values to -1

### DIFF
--- a/src/Raven.Studio/typescript/models/database/settings/databaseSettingsModels.ts
+++ b/src/Raven.Studio/typescript/models/database/settings/databaseSettingsModels.ts
@@ -300,7 +300,7 @@ export abstract class numberEntry extends databaseEntry<number | null> {
 
         const numberValue = this.customizedDatabaseValue();
         
-        if (numberValue >= 0) {
+        if (numberValue) {
             return numberValue >= this.minValue() ? numberValue.toString() : null;
         } else {
             return null;
@@ -393,14 +393,13 @@ export class sizeEntry extends numberEntry {
 
 export class timeEntry extends numberEntry {
     timeUnit = ko.observable<string>();
-    specialTimeEntry = "Indexing.MapTimeoutInSec"; // Not nullable and default value is -1
 
     initCustomizedValue(value: string) {
         const timeValue = value ? parseInt(value) : null;
         this.customizedDatabaseValue(timeValue);
 
         this.timeUnit(this.data.Metadata.TimeUnit);
-        this.minValue(this.keyName() === this.specialTimeEntry ? -1 : this.data.Metadata.MinValue || 0);
+        this.minValue(this.data.Metadata.MinValue || -1);
     }
 
     getTemplateType(): settingsTemplateType {
@@ -412,7 +411,7 @@ export class timeEntry extends numberEntry {
 
         this.customizedDatabaseValue.extend({
             digit: {
-                onlyIf: () => this.keyName() !== this.specialTimeEntry || this.customizedDatabaseValue() !== -1
+                onlyIf: () => this.customizedDatabaseValue() !== -1
             }
         });
     }


### PR DESCRIPTION
### Issue link
https://issues.hibernatingrhinos.com/issue/RavenDB-18405

### Additional description
Database Settings view: Allow to set time values to -1

### Type of change
- Bug fix

### How risky is the change?
- Low 

### Backward compatibility
- Non breaking change

### Is it platform specific issue?
- No

### Documentation update
- No documentation update is needed 

### Testing 
- It has been verified by manual testing

### Is there any existing behavior change of other features due to this change?
- No

### UI work
- No UI work is needed
