### PR TITLE
RavenDB-18411 Fix duplicate document compression entries

### DIFF
--- a/src/Raven.Server/Config/Categories/ClusterConfiguration.cs
+++ b/src/Raven.Server/Config/Categories/ClusterConfiguration.cs
@@ -123,10 +123,10 @@ namespace Raven.Server.Config.Categories
         [ConfigurationEntry("Cluster.DisableAtomicDocumentWrites", ConfigurationEntryScope.ServerWideOrPerDatabase)]
         public bool DisableAtomicDocumentWrites { get; set; }
 
-        [Description("EXPERT: The maximum allowed size allowed for a signle raft command")]
+        [Description("EXPERT: The maximum allowed size allowed for a single raft command (in megabytes)")]
         [DefaultValue(128)]
         [SizeUnit(SizeUnit.Megabytes)]
-        [ConfigurationEntry("Cluster.MaxSizeOfSingleRaftCommandInMB", ConfigurationEntryScope.ServerWideOnly)]
+        [ConfigurationEntry("Cluster.MaxSizeOfSingleRaftCommandInMb", ConfigurationEntryScope.ServerWideOnly)]
         public Size? MaxSizeOfSingleRaftCommand { get; set; }
     }
 }

--- a/src/Raven.Server/Config/Categories/ClusterConfiguration.cs
+++ b/src/Raven.Server/Config/Categories/ClusterConfiguration.cs
@@ -122,5 +122,11 @@ namespace Raven.Server.Config.Categories
         [DefaultValue(false)]
         [ConfigurationEntry("Cluster.DisableAtomicDocumentWrites", ConfigurationEntryScope.ServerWideOrPerDatabase)]
         public bool DisableAtomicDocumentWrites { get; set; }
+
+        [Description("EXPERT: The maximum allowed size allowed for a signle raft command")]
+        [DefaultValue(128)]
+        [SizeUnit(SizeUnit.Megabytes)]
+        [ConfigurationEntry("Cluster.MaxSizeOfSingleRaftCommandInMB", ConfigurationEntryScope.ServerWideOnly)]
+        public Size? MaxSizeOfSingleRaftCommand { get; set; }
     }
 }

--- a/src/Raven.Server/Rachis/RachisConsensus.cs
+++ b/src/Raven.Server/Rachis/RachisConsensus.cs
@@ -1389,7 +1389,7 @@ namespace Raven.Server.Rachis
         {
             var type = RachisLogHistory.GetTypeFromCommand(cmd);
             throw new ArgumentOutOfRangeException(
-                $"The command '{type}' size of {new Size(cmd.Size, SizeUnit.Bytes)} exceed the max allowed size.");
+                $"The command '{type}' size of {new Size(cmd.Size, SizeUnit.Bytes)} exceed the max allowed size ({new Size(MaxSizeOfSingleRaftCommandInBytes.Value, SizeUnit.Bytes)}).");
         }
 
         public unsafe void ClearLogEntriesAndSetLastTruncate(ClusterOperationContext context, long index, long term)

--- a/src/Raven.Server/Rachis/RachisConsensus.cs
+++ b/src/Raven.Server/Rachis/RachisConsensus.cs
@@ -1389,7 +1389,8 @@ namespace Raven.Server.Rachis
         {
             var type = RachisLogHistory.GetTypeFromCommand(cmd);
             throw new ArgumentOutOfRangeException(
-                $"The command '{type}' size of {new Size(cmd.Size, SizeUnit.Bytes)} exceed the max allowed size ({new Size(MaxSizeOfSingleRaftCommandInBytes.Value, SizeUnit.Bytes)}).");
+                $"The command '{type}' size of {new Size(cmd.Size, SizeUnit.Bytes)} exceed the max allowed size ({new Size(MaxSizeOfSingleRaftCommandInBytes.Value, SizeUnit.Bytes)})." +
+                $" If it is expected you can modify the setting '{RavenConfiguration.GetKey(x => x.Cluster.MaxSizeOfSingleRaftCommand)}'");
         }
 
         public unsafe void ClearLogEntriesAndSetLastTruncate(ClusterOperationContext context, long index, long term)

--- a/src/Raven.Server/Rachis/RachisLogHistory.cs
+++ b/src/Raven.Server/Rachis/RachisLogHistory.cs
@@ -113,7 +113,7 @@ namespace Raven.Server.Rachis
             return null;
         }
 
-        public string GetTypeFromCommand(BlittableJsonReaderObject cmd)
+        public static string GetTypeFromCommand(BlittableJsonReaderObject cmd)
         {
             if (cmd.TryGet("Type", out string type) == false)
             {

--- a/src/Raven.Server/ServerWide/Commands/EditDocumentsCompressionCommand.cs
+++ b/src/Raven.Server/ServerWide/Commands/EditDocumentsCompressionCommand.cs
@@ -26,9 +26,9 @@ namespace Raven.Server.ServerWide.Commands
         
         public EditDocumentsCompressionCommand(DocumentsCompressionConfiguration configuration, string databaseName, string uniqueRequestId) : base(databaseName, uniqueRequestId)
         {
-            if (configuration?.Collections != null)
+            if (configuration?.Collections.Length > 0)
             {
-                configuration.Collections = configuration.Collections?.ToHashSet(StringComparer.OrdinalIgnoreCase).ToArray();
+                configuration.Collections = configuration.Collections.ToHashSet(StringComparer.OrdinalIgnoreCase).ToArray();
             }
 
             Configuration = configuration;

--- a/src/Raven.Server/ServerWide/Commands/EditDocumentsCompressionCommand.cs
+++ b/src/Raven.Server/ServerWide/Commands/EditDocumentsCompressionCommand.cs
@@ -1,4 +1,6 @@
-﻿using Raven.Client.ServerWide;
+﻿using System;
+using System.Linq;
+using Raven.Client.ServerWide;
 using Raven.Server.Utils;
 using Sparrow.Json.Parsing;
 
@@ -24,6 +26,11 @@ namespace Raven.Server.ServerWide.Commands
         
         public EditDocumentsCompressionCommand(DocumentsCompressionConfiguration configuration, string databaseName, string uniqueRequestId) : base(databaseName, uniqueRequestId)
         {
+            if (configuration?.Collections != null)
+            {
+                configuration.Collections = configuration.Collections?.ToHashSet(StringComparer.OrdinalIgnoreCase).ToArray();
+            }
+
             Configuration = configuration;
         }
 

--- a/src/Raven.Server/Smuggler/Documents/DatabaseDestination.cs
+++ b/src/Raven.Server/Smuggler/Documents/DatabaseDestination.cs
@@ -1016,7 +1016,7 @@ namespace Raven.Server.Smuggler.Documents
                 {
                     if (currentDatabaseRecord?.DocumentsCompression?.Collections?.Length > 0 || currentDatabaseRecord?.DocumentsCompression?.CompressAllCollections == true)
                     {
-                        var collectionsToAdd = new List<string>();
+                        var collectionsToAdd = new HashSet<string>(StringComparer.OrdinalIgnoreCase);
 
                         foreach (var collection in currentDatabaseRecord.DocumentsCompression.Collections)
                         {

--- a/test/SlowTests/Cluster/ClusterTransactionTests.cs
+++ b/test/SlowTests/Cluster/ClusterTransactionTests.cs
@@ -87,7 +87,7 @@ namespace SlowTests.Cluster
                     session.Advanced.ClusterTransaction.CreateCompareExchangeValue("usernames/ayende", new byte[256 * 1024]);
                     await session.StoreAsync(user3, "foo/bar");
                     var ex = await Assert.ThrowsAsync<RavenException>(() => session.SaveChangesAsync());
-                    Assert.Contains("The command 'ClusterTransactionCommand' size of 1.5 MBytes exceed the max allowed size.", ex.Message);
+                    Assert.Contains("The command 'ClusterTransactionCommand' size of 1.5 MBytes exceed the max allowed size", ex.Message);
                 }
 
                 using (var session = leaderStore.OpenAsyncSession(new SessionOptions

--- a/test/SlowTests/Cluster/ClusterTransactionTests.cs
+++ b/test/SlowTests/Cluster/ClusterTransactionTests.cs
@@ -57,6 +57,57 @@ namespace SlowTests.Cluster
         }
 
         [Fact]
+        public async Task ThrowOnTooLargeClusterTransactionRequest()
+        {
+            var (_, leader) = await CreateRaftCluster(3, customSettings: new Dictionary<string, string>
+            {
+                [RavenConfiguration.GetKey(x => x.Cluster.MaxSizeOfSingleRaftCommand)] = "1"
+            });
+            using (var leaderStore = GetDocumentStore(new Options
+                   {
+                       Server = leader,
+                       ReplicationFactor = 3,
+                       
+                   }))
+            {
+                var user1 = new User()
+                {
+                    Name = "Karmel"
+                };
+                var user3 = new User()
+                {
+                    Name = "Indych"
+                };
+
+                using (var session = leaderStore.OpenAsyncSession(new SessionOptions
+                       {
+                           TransactionMode = TransactionMode.ClusterWide
+                       }))
+                {
+                    session.Advanced.ClusterTransaction.CreateCompareExchangeValue("usernames/ayende", new byte[256 * 1024]);
+                    await session.StoreAsync(user3, "foo/bar");
+                    var ex = await Assert.ThrowsAsync<RavenException>(() => session.SaveChangesAsync());
+                    Assert.Contains("The command 'ClusterTransactionCommand' size of 1.5 MBytes exceed the max allowed size.", ex.Message);
+                }
+
+                using (var session = leaderStore.OpenAsyncSession(new SessionOptions
+                       {
+                           TransactionMode = TransactionMode.ClusterWide
+                       }))
+                {
+                    session.Advanced.ClusterTransaction.CreateCompareExchangeValue("usernames/ayende", user1);
+                    await session.StoreAsync(user3, "foo/bar");
+                    await session.SaveChangesAsync();
+
+                    var user = (await session.Advanced.ClusterTransaction.GetCompareExchangeValueAsync<User>("usernames/ayende")).Value;
+                    Assert.Equal(user1.Name, user.Name);
+                    user = await session.LoadAsync<User>("foo/bar");
+                    Assert.Equal(user3.Name, user.Name);
+                }
+            }
+        }
+
+        [Fact]
         public async Task CanCreateClusterTransactionRequest()
         {
             var (_, leader) = await CreateRaftCluster(3);


### PR DESCRIPTION
### Issue link

https://issues.hibernatingrhinos.com/issue/RavenDB-18411

### Additional description

We had here 2 issues.
1. re-importing compression configuration would double the collection size so after ~20 re-imports we would end up with ~500MB of a database record.
2. Such huge database record would cause us to try and allocate more memory then arena can support, which would result in blocking the leader send this and any further commands.

We fixed (1) by using a hashset, and we will prevent inserting large command to the leader in the first place, since it is unexpected and probably a bug.

### Type of change

- Bug fix

### How risky is the change?

- Low 

### Backward compatibility 

Existing machines suffering from this issue will need the followers to request the full snapshot from the leader.
We can do that via the JS admin console by `server.ServerStore.RequestSnapshot()` after we demote the relevant node to a watcher.

### Is it platform specific issue?

- No

### Documentation update

- Worth mention that the cluster transaction are by default limited to a single transaction of 128MB, which can be modified if need by changing the `Cluster.MaxSizeOfSingleRaftCommandInMb` setting

### Testing 

- Tests have been added that prove the fix is effective or that the feature works

### Is there any existing behavior change of other features due to this change?

- No

### UI work

- No UI work is needed
