### PR TITLE
RavenDB-18418 Open dialog + Show spinner while loading stack trace

### DIFF
--- a/src/Raven.Studio/typescript/viewmodels/manage/debugAdvancedThreadsRuntime.ts
+++ b/src/Raven.Studio/typescript/viewmodels/manage/debugAdvancedThreadsRuntime.ts
@@ -98,7 +98,6 @@ class debugAdvancedThreadsRuntime extends viewModelBase {
                 return [
                     new actionColumn<Raven.Server.Dashboard.ThreadInfo>(grid, (x) => this.showStackTrace(x), "Stack",
                                 () => `<i title="Click to view Stack Trace" class="icon-thread-stack-trace"></i>`, "55px"),
-                                // TODO replace above icon with RavenDB-174430
                     new textColumn<Raven.Server.Dashboard.ThreadInfo>(grid, x => x.Name, "Name", "20%", {
                         sortable: "string"
                     }),
@@ -162,9 +161,10 @@ class debugAdvancedThreadsRuntime extends viewModelBase {
             .done(() => this.gridController().reset(true))
             .always(() => this.spinners.refresh(false));
     }
+
     private showStackTrace(thread: Raven.Server.Dashboard.ThreadInfo) {
         app.showBootstrapDialog(new threadStackTrace(thread.Id, thread.Name));
-}
+    }
 }
 
 export = debugAdvancedThreadsRuntime;

--- a/src/Raven.Studio/typescript/viewmodels/manage/threadStackTrace.ts
+++ b/src/Raven.Studio/typescript/viewmodels/manage/threadStackTrace.ts
@@ -30,12 +30,10 @@ class threadStackTrace extends dialogViewModelBase {
     compositionComplete() {
         super.compositionComplete();
         this.dialogContainer = document.getElementById("threadStackTraceDialog");
+        
+        this.loadStackTrace(this.threadId());
     }
     
-    activate() {
-        return this.loadStackTrace(this.threadId());
-    }
-
     private loadStackTrace(threadId: number): JQueryPromise<threadStackTraceResponseDto> {
         this.spinners.loading(true);
         

--- a/src/Raven.Studio/wwwroot/App/views/manage/threadStackTrace.html
+++ b/src/Raven.Studio/wwwroot/App/views/manage/threadStackTrace.html
@@ -33,9 +33,12 @@
                     </div>
                 </div>
                 <div class="panel padding">
-                    <div class="padding padding-xs text-center text-warning bg-warning margin-top margin-top-lg margin-bottom margin-left margin-left-lg margin-right margin-right-lg" 
-                         data-bind="visible: !isThreadAlive()">
+                    <div class="padding padding-xs text-center text-warning bg-warning margin-top margin-top-lg margin-bottom margin-left margin-left-lg margin-right margin-right-lg"
+                         data-bind="visible: !isThreadAlive() && !spinners.loading()">
                         <i class="icon-warning"></i><span>Thread is no longer alive</span>
+                    </div>
+                    <div class="text-center padding" data-bind="visible: spinners.loading(), css: { 'btn-spinner': spinners.loading }">
+                        <span>Loading</span>
                     </div>
                     <div class="padding" data-bind="css: { panel: stackTrace().length }, visible: isThreadAlive">
                         <div class="text-nowrap stack-trace">


### PR DESCRIPTION
### Issue link
https://issues.hibernatingrhinos.com/issue/RavenDB-18418

### Additional description
Open dialog immediately + show spinner when loading

### Type of change
- Bug fix

### How risky is the change?
- Low 

### Backward compatibility
- Non breaking change

### Is it platform specific issue?
- No

### Documentation update
- No documentation update is needed 

### Testing 
- It has been verified by manual testing

### Is there any existing behavior change of other features due to this change?
- No

### UI work
- No UI work is needed
