### PR TITLE
RavenDB-18422 Expose the SQL PK values to the migration script

### DIFF
--- a/src/Raven.Server/SqlMigration/GenericDatabaseMigrator.cs
+++ b/src/Raven.Server/SqlMigration/GenericDatabaseMigrator.cs
@@ -56,9 +56,10 @@ namespace Raven.Server.SqlMigration
                         foreach (var doc in EnumerateTable(queryToUse, collectionToImport.ColumnsMapping, specialColumns,
                             collectionToImport.AttachmentNameMapping, enumerationConnection, rowsLimit: 1, queryParameters: queryParameters))
                         {
-                            doc.SetCollection(collectionToImport.Name);
                             
-                            var id = GenerateDocumentId(doc.Collection, GetColumns(doc.SpecialColumnsValues, tableSchema.PrimaryKeyColumns));
+                            var id = GenerateDocumentId(collectionToImport.Name, GetColumns(doc.SpecialColumnsValues, tableSchema.PrimaryKeyColumns));
+
+                            doc.SetCollectionAndId(collectionToImport.Name, id);
 
                             FillDocumentFields(doc.Object, doc.SpecialColumnsValues, references, "", doc.Attachments);
 
@@ -134,9 +135,9 @@ namespace Raven.Server.SqlMigration
                                         onProgress.Invoke(result.Progress);
                                     }
                                     
-                                    doc.SetCollection(collectionToImport.Name);
+                                    var id = GenerateDocumentId(collectionToImport.Name, GetColumns(doc.SpecialColumnsValues, tableSchema.PrimaryKeyColumns));
 
-                                    var id = GenerateDocumentId(doc.Collection, GetColumns(doc.SpecialColumnsValues, tableSchema.PrimaryKeyColumns));
+                                    doc.SetCollectionAndId(collectionToImport.Name, id);
 
                                     FillDocumentFields(doc.Object, doc.SpecialColumnsValues, references, "", doc.Attachments);
 

--- a/src/Raven.Server/SqlMigration/Model/SqlMigrationDocument.cs
+++ b/src/Raven.Server/SqlMigration/Model/SqlMigrationDocument.cs
@@ -20,11 +20,13 @@ namespace Raven.Server.SqlMigration.Model
             Object = new DynamicJsonValue();
         }
 
-        public void SetCollection(string collectionName)
+        public void SetCollectionAndId(string collectionName, string id)
         {
             Object[Constants.Documents.Metadata.Key] = new DynamicJsonValue
             {
-                [Constants.Documents.Metadata.Collection] = collectionName
+                [Constants.Documents.Metadata.Collection] = collectionName,
+                [Constants.Documents.Metadata.Id] = id,
+                ["@sql-keys"] = SpecialColumnsValues
             };
             Collection = collectionName;
         }


### PR DESCRIPTION
`id(this)` as a way to get the future document key for this document.
`@metadata.@sql-keys` element that allows access to the other columns that we remove from the document on migration.

### Issue link

https://issues.hibernatingrhinos.com/issue/RavenDB-18422 

### Additional description

Users can now make direct access of both the future document key and the FK / PK keys that we use for the generating those links. 

### Type of change

- Bug fix

### How risky is the change?

- Low 

### Backward compatibility

- Non breaking change

### Is it platform specific issue?

- No

### Documentation update

- This change requires a documentation update. Please mark the issue on YouTrack using `Documentation Required` tag.

### Testing 


- It has been verified by manual testing

### Is there any existing behavior change of other features due to this change?

- No

### UI work

- No UI work is needed
