### PR TITLE
RavenDB-18426 Allow to project `id()` from map index while projection…

### DIFF
--- a/src/Raven.Server/Documents/Queries/FieldsToFetch.cs
+++ b/src/Raven.Server/Documents/Queries/FieldsToFetch.cs
@@ -5,6 +5,8 @@ using Raven.Client;
 using Raven.Client.Documents.Indexes;
 using Raven.Client.Documents.Queries;
 using Raven.Server.Documents.Indexes;
+using Raven.Server.Documents.Indexes.MapReduce.Auto;
+using Raven.Server.Documents.Indexes.MapReduce.Static;
 using Raven.Server.Documents.Queries.AST;
 using Raven.Server.Documents.Queries.Results;
 using Sparrow;
@@ -151,7 +153,10 @@ namespace Raven.Server.Documents.Queries
                 if (selectFieldName == Constants.Documents.Indexing.Fields.DocumentIdFieldName)
                 {
                     anyExtractableFromIndex = maybeExtractFromIndex;
-                    return new FieldToFetch(selectFieldName, selectField, selectField.Alias, canExtractFromIndex: false, isDocumentId: true, isTimeSeries: false);
+                    
+                    return new FieldToFetch(selectFieldName, selectField, selectField.Alias, 
+                        canExtractFromIndex: indexDefinition is MapReduceIndexDefinition or AutoMapReduceIndexDefinition, 
+                        isDocumentId: true, isTimeSeries: false);
                 }
 
                 if (selectFieldName.Value[0] == '_')

--- a/test/SlowTests/Issues/RavenDB-18426.cs
+++ b/test/SlowTests/Issues/RavenDB-18426.cs
@@ -1,0 +1,96 @@
+using FastTests;
+using System.Linq;
+using Raven.Client.Documents;
+using Raven.Client.Documents.Indexes;
+using Raven.Client.Documents.Linq;
+using Raven.Client.Documents.Queries;
+using Raven.Server.Documents.Indexes.Static.Extensions;
+using Xunit;
+using Xunit.Abstractions;
+
+namespace SlowTests.Issues;
+
+public class RavenDB_18426 : RavenTestBase
+{
+    public RavenDB_18426(ITestOutputHelper output) : base(output)
+    {
+    }
+
+    [Fact]
+    public void ProjectionIdTest()
+    {
+        using (var store = GetDocumentStore())
+        {
+            new DocIndex().Execute(store);
+            new DocReduceIndex().Execute(store);
+            using (var session = store.OpenSession())
+            {
+                session.Store(new Doc { Id = "doc-1", IntVal = 1 });
+                session.SaveChanges();
+            }
+
+            Indexes.WaitForIndexing(store);
+
+            using (var session = store.OpenSession())
+            {
+                session.Query<DocView, DocIndex>()
+                    .Customize(x => x.Projection(ProjectionBehavior.FromIndexOrThrow))
+                    .ProjectInto<DocView>()
+                    .ToList(); // should not throw - map
+
+                session.Query<DocView, DocReduceIndex>()
+                    .Customize(x => x.Projection(ProjectionBehavior.FromIndexOrThrow))
+                    .ProjectInto<DocView>()
+                    .ToList(); // should not throw - map/reduce
+
+                
+            }
+        }
+    }
+
+    class Doc
+    {
+        public string Id { get; set; }
+        public int? IntVal { get; set; }
+    }
+
+    class DocView
+    {
+        public string Id { get; set; }
+    }
+
+    class DocIndex : AbstractIndexCreationTask<Doc>
+    {
+        public DocIndex()
+        {
+            Map = docs =>
+                from doc in docs
+                select new { Id = doc.Id, IntVal = doc.IntVal, };
+            StoreAllFields(FieldStorage.Yes);
+            Store(x => x.Id, FieldStorage.Yes);
+        }
+    }
+    
+     class DocReduceIndex : AbstractIndexCreationTask<Doc>
+    {
+        public DocReduceIndex()
+        {
+            Map = docs =>
+                from doc in docs
+                select new
+                {
+                    Id = doc.Id,
+                    IntVal = doc.IntVal,
+                };
+            Reduce = results =>
+                from result in results
+                group result by result.Id into g
+                select new
+                {
+                    Id = g.First().Id,
+                    IntVal = g.First().IntVal,
+                };
+            StoreAllFields(FieldStorage.Yes);
+        }
+    }
+}


### PR DESCRIPTION
… behavior is set to index only

### Issue link

https://issues.hibernatingrhinos.com/issue/RavenDB-18426 


### Type of change

- Bug fix

### How risky is the change?

- Low 

### Backward compatibility

- Ensured. Please explain how has it been implemented?

Enable previous invalid scenario

### Is it platform specific issue?


- No

### Documentation update

- No documentation update is needed 

### Testing 

- Tests have been added that prove the fix is effective or that the feature works

### Is there any existing behavior change of other features due to this change?

- No

### UI work

- No UI work is needed
