### PR TITLE
RavenDB-18409 : add schema upgrader to version 6

### DIFF
--- a/src/Raven.Server/Documents/ConflictsStorage.cs
+++ b/src/Raven.Server/Documents/ConflictsStorage.cs
@@ -21,109 +21,18 @@ using Sparrow.Server;
 using Sparrow.Server.Utils;
 using Voron.Util;
 using static Raven.Server.Documents.DocumentsStorage;
+using static Raven.Server.Documents.Schemas.Conflicts;
 
 namespace Raven.Server.Documents
 {
     public unsafe class ConflictsStorage
     {
-        private static readonly Slice ChangeVectorSlice;
-        private static readonly Slice IdAndChangeVectorSlice;
-        public static readonly Slice AllConflictedDocsEtagsSlice;
-        private static readonly Slice ConflictedCollectionSlice;
-        public static readonly Slice ConflictsSlice;
-        private static readonly Slice ConflictsIdSlice;
-        private static readonly Slice ConflictsBucketAndEtagSlice;
-
-        public static readonly TableSchema ConflictsSchema = new TableSchema()
-        {
-            TableType = (byte)TableType.Conflicts
-        };
+        public static readonly TableSchema ConflictsSchema = Current;
+        public long ConflictsCount;
 
         private readonly DocumentDatabase _documentDatabase;
         private readonly DocumentsStorage _documentsStorage;
         private readonly Logger _logger;
-
-        public long ConflictsCount;
-
-        public enum ConflictsTable
-        {
-            LowerId = 0,
-            RecordSeparator = 1,
-            ChangeVector = 2,
-            Id = 3,
-            Data = 4,
-            Etag = 5,
-            Collection = 6,
-            LastModified = 7,
-            Flags = 8
-        }
-
-        static ConflictsStorage()
-        {
-            using (StorageEnvironment.GetStaticContext(out var ctx))
-            {
-                Slice.From(ctx, "ChangeVector", ByteStringType.Immutable, out ChangeVectorSlice);
-                Slice.From(ctx, "ConflictsId", ByteStringType.Immutable, out ConflictsIdSlice);
-                Slice.From(ctx, "IdAndChangeVector", ByteStringType.Immutable, out IdAndChangeVectorSlice);
-                Slice.From(ctx, "AllConflictedDocsEtags", ByteStringType.Immutable, out AllConflictedDocsEtagsSlice);
-                Slice.From(ctx, "ConflictedCollection", ByteStringType.Immutable, out ConflictedCollectionSlice);
-                Slice.From(ctx, "Conflicts", ByteStringType.Immutable, out ConflictsSlice);
-                Slice.From(ctx, "ConflictsBucketAndEtag", ByteStringType.Immutable, out ConflictsBucketAndEtagSlice);
-            }
-            /*
-             The structure of conflicts table starts with the following fields:
-             [ Conflicted Doc Id | Separator | Change Vector | ... the rest of fields ... ]
-             PK of the conflicts table will be 'Change Vector' field, because when dealing with conflicts,
-              the change vectors will always be different, hence the uniqueness of the ID. (inserts/updates will not overwrite)
-
-            Additional index is set to have composite ID of 'Conflicted Doc Id' and 'Change Vector' so we will be able to iterate
-            on conflicts by conflicted doc id (using 'starts with')
-
-            We need a separator in order to delete all conflicts all "users/1" without deleting "users/11" conflicts.
-             */
-
-            ConflictsSchema.DefineKey(new TableSchema.IndexDef
-            {
-                StartIndex = (int)ConflictsTable.ChangeVector,
-                Count = 1,
-                IsGlobal = false,
-                Name = ChangeVectorSlice
-            });
-            // required to get conflicts by ID
-            ConflictsSchema.DefineIndex(new TableSchema.IndexDef
-            {
-                StartIndex = (int)ConflictsTable.LowerId,
-                Count = 3,
-                IsGlobal = false,
-                Name = IdAndChangeVectorSlice
-            });
-            ConflictsSchema.DefineIndex(new TableSchema.IndexDef
-            {
-                StartIndex = (int)ConflictsTable.LowerId,
-                Count = 1,
-                IsGlobal = true,
-                Name = ConflictsIdSlice
-            });
-            ConflictsSchema.DefineFixedSizeIndex(new TableSchema.FixedSizeKeyIndexDef
-            {
-                StartIndex = (int)ConflictsTable.Etag,
-                IsGlobal = true,
-                Name = AllConflictedDocsEtagsSlice
-            });
-            ConflictsSchema.DefineIndex(new TableSchema.IndexDef
-            {
-                StartIndex = (int)ConflictsTable.Collection,
-                Count = 1,
-                IsGlobal = true,
-                Name = ConflictedCollectionSlice
-            });
-            ConflictsSchema.DefineIndex(new TableSchema.DynamicKeyIndexDef
-            {
-                GenerateKey = GenerateBucketAndEtagIndexKeyForConflicts,
-                IsGlobal = true,
-                Name = ConflictsBucketAndEtagSlice
-            });
-        }
 
         public ConflictsStorage(DocumentDatabase documentDatabase, Transaction tx)
         {
@@ -894,7 +803,7 @@ namespace Raven.Server.Documents
         }
 
         [StorageIndexEntryKeyGenerator]
-        private static ByteStringContext.Scope GenerateBucketAndEtagIndexKeyForConflicts(ByteStringContext context, ref TableValueReader tvr, out Slice slice)
+        internal static ByteStringContext.Scope GenerateBucketAndEtagIndexKeyForConflicts(ByteStringContext context, ref TableValueReader tvr, out Slice slice)
         {
             return GenerateBucketAndEtagIndexKey(context, idIndex: (int)ConflictsTable.LowerId, etagIndex: (int)ConflictsTable.Etag, ref tvr, out slice);
         }

--- a/src/Raven.Server/Documents/DocumentPutAction.cs
+++ b/src/Raven.Server/Documents/DocumentPutAction.cs
@@ -20,6 +20,7 @@ using static Raven.Server.Documents.DocumentsStorage;
 using Constants = Raven.Client.Constants;
 using Raven.Server.ServerWide;
 using Raven.Server.ServerWide.Commands;
+using static Raven.Server.Documents.Schemas.Documents;
 
 namespace Raven.Server.Documents
 {

--- a/src/Raven.Server/Documents/ETL/EtlLoader.cs
+++ b/src/Raven.Server/Documents/ETL/EtlLoader.cs
@@ -763,7 +763,7 @@ namespace Raven.Server.Documents.ETL
                 if (typeof(T) == typeof(RavenConnectionString))
                 {
                     if (RavenEtl.ShouldTrackAttachmentTombstones(transform))
-                        AddOrUpdate(lastProcessedTombstones, AttachmentsStorage.AttachmentsTombstones, etag);
+                        AddOrUpdate(lastProcessedTombstones, Schemas.Attachments.AttachmentsTombstones, etag);
                 }
             }
         }

--- a/src/Raven.Server/Documents/Revisions/RevisionsStorage.cs
+++ b/src/Raven.Server/Documents/Revisions/RevisionsStorage.cs
@@ -118,17 +118,17 @@ namespace Raven.Server.Documents.Revisions
                 // note that calling the Create() method multiple times is a noop
                 RevisionsSchema.Create(tx, tableName, 16);
                 tx.LowLevelTransaction.OnDispose += _ =>
-                 {
-                     if (tx.LowLevelTransaction.Committed == false)
-                         return;
+                {
+                    if (tx.LowLevelTransaction.Committed == false) 
+                        return;
 
-                     // not sure if we can _rely_ on the tx write lock here, so let's be safe and create
-                     // a new instance, just in case
-                     _tableCreated = new HashSet<string>(_tableCreated, StringComparer.OrdinalIgnoreCase)
-                     {
+                    // not sure if we can _rely_ on the tx write lock here, so let's be safe and create
+                    // a new instance, just in case
+                    _tableCreated = new HashSet<string>(_tableCreated, StringComparer.OrdinalIgnoreCase)
+                    {
                          collection.Name
-                     };
-                 };
+                    };
+                };
             }
 
             var revisionsSchema = _documentsStorage.DocumentPut.DocumentsCompression.CompressRevisions ?

--- a/src/Raven.Server/Documents/Schemas/Attachments.cs
+++ b/src/Raven.Server/Documents/Schemas/Attachments.cs
@@ -1,0 +1,84 @@
+﻿using Sparrow.Server;
+using Voron;
+using Voron.Data.Tables;
+
+namespace Raven.Server.Documents.Schemas
+{
+    public static class Attachments
+    {
+        public static TableSchema Current => AttachmentsSchemaBase60;
+
+        internal static readonly TableSchema AttachmentsSchemaBase = new TableSchema();
+        internal static readonly TableSchema AttachmentsSchemaBase60 = new TableSchema();
+
+        internal static readonly Slice AttachmentsSlice;
+        internal static readonly Slice AttachmentsMetadataSlice;
+        internal static readonly Slice AttachmentsEtagSlice;
+        internal static readonly Slice AttachmentsHashSlice;
+        internal static readonly Slice AttachmentsTombstonesSlice;
+        internal static readonly Slice AttachmentsBucketAndEtagSlice;
+        internal static readonly string AttachmentsTombstones = "Attachments.Tombstones";
+
+        internal enum AttachmentsTable
+        {
+            /* AND is a record separator.
+             * We are you using the record separator in order to avoid loading another files that has the same key prefix,
+                e.g. fitz(record-separator)profile.png and fitz0(record-separator)profile.png, without the record separator we would have to load also fitz0 and filter it. */
+            LowerDocumentIdAndLowerNameAndTypeAndHashAndContentType = 0,
+            Etag = 1,
+            Name = 2, // format of lazy string key is detailed in GetLowerIdSliceAndStorageKey
+            ContentType = 3, // format of lazy string key is detailed in GetLowerIdSliceAndStorageKey
+            Hash = 4, // base64 hash
+            TransactionMarker = 5,
+            ChangeVector = 6
+        }
+
+        static Attachments()
+        {
+            using (StorageEnvironment.GetStaticContext(out var ctx))
+            {
+                Slice.From(ctx, "Attachments", ByteStringType.Immutable, out AttachmentsSlice);
+                Slice.From(ctx, "AttachmentsMetadata", ByteStringType.Immutable, out AttachmentsMetadataSlice);
+                Slice.From(ctx, "AttachmentsEtag", ByteStringType.Immutable, out AttachmentsEtagSlice);
+                Slice.From(ctx, "AttachmentsHash", ByteStringType.Immutable, out AttachmentsHashSlice);
+                Slice.From(ctx, "AttachmentsBucketAndEtag", ByteStringType.Immutable, out AttachmentsBucketAndEtagSlice);
+                Slice.From(ctx, AttachmentsTombstones, ByteStringType.Immutable, out AttachmentsTombstonesSlice);
+            }
+
+            DefineIndexesForAttachmentsSchema(AttachmentsSchemaBase);
+            DefineIndexesForAttachmentsSchemaBase60();
+
+            void DefineIndexesForAttachmentsSchema(TableSchema schema)
+            {
+                schema.DefineKey(new TableSchema.IndexDef
+                {
+                    StartIndex = (int)AttachmentsTable.LowerDocumentIdAndLowerNameAndTypeAndHashAndContentType,
+                    Count = 1
+                });
+                schema.DefineFixedSizeIndex(new TableSchema.FixedSizeKeyIndexDef
+                {
+                    StartIndex = (int)AttachmentsTable.Etag,
+                    Name = AttachmentsEtagSlice
+                });
+                schema.DefineIndex(new TableSchema.IndexDef
+                {
+                    StartIndex = (int)AttachmentsTable.Hash,
+                    Count = 1,
+                    Name = AttachmentsHashSlice
+                });
+            }
+
+            void DefineIndexesForAttachmentsSchemaBase60()
+            {
+                DefineIndexesForAttachmentsSchema(AttachmentsSchemaBase60);
+
+                AttachmentsSchemaBase60.DefineIndex(new TableSchema.DynamicKeyIndexDef
+                {
+                    GenerateKey = AttachmentsStorage.GenerateBucketAndEtagIndexKeyForAttachments,
+                    IsGlobal = true,
+                    Name = AttachmentsBucketAndEtagSlice
+                });
+            }
+        }
+    }
+}

--- a/src/Raven.Server/Documents/Schemas/Collections.cs
+++ b/src/Raven.Server/Documents/Schemas/Collections.cs
@@ -1,0 +1,41 @@
+﻿using Sparrow.Server;
+using Voron;
+using Voron.Data.Tables;
+
+namespace Raven.Server.Documents.Schemas
+{
+    public static class Collections
+    {
+        public static TableSchema Current => CollectionsSchemaBase;
+
+        internal static readonly TableSchema CollectionsSchemaBase = new TableSchema();
+
+        internal static readonly Slice CollectionsSlice;
+
+        public enum CollectionsTable
+        {
+            Name = 0
+        }
+
+        static Collections()
+        {
+            using (StorageEnvironment.GetStaticContext(out var ctx))
+            {
+                Slice.From(ctx, "Collections", ByteStringType.Immutable, out CollectionsSlice);
+            }
+
+            /*
+            Collection schema is:
+            full name
+            collections are never deleted from the collections table
+            */
+
+            CollectionsSchemaBase.DefineKey(new TableSchema.IndexDef
+            {
+                StartIndex = (int)CollectionsTable.Name,
+                Count = 1,
+                IsGlobal = false
+            });
+        }
+    }
+}

--- a/src/Raven.Server/Documents/Schemas/Conflicts.cs
+++ b/src/Raven.Server/Documents/Schemas/Conflicts.cs
@@ -1,0 +1,121 @@
+﻿using Sparrow.Server;
+using Voron;
+using Voron.Data.Tables;
+
+namespace Raven.Server.Documents.Schemas
+{
+    public static class Conflicts
+    {
+        public static TableSchema Current => ConflictsSchemaBase60;
+
+        internal static readonly TableSchema ConflictsSchemaBase = new TableSchema()
+        {
+            TableType = (byte)TableType.Conflicts
+        };
+        internal static readonly TableSchema ConflictsSchemaBase60 = new TableSchema()
+        {
+            TableType = (byte)TableType.Conflicts
+        };
+
+        internal static readonly Slice ChangeVectorSlice;
+        internal static readonly Slice IdAndChangeVectorSlice;
+        internal static readonly Slice AllConflictedDocsEtagsSlice;
+        internal static readonly Slice ConflictedCollectionSlice;
+        internal static readonly Slice ConflictsSlice;
+        internal static readonly Slice ConflictsIdSlice;
+        internal static readonly Slice ConflictsBucketAndEtagSlice;
+
+        public enum ConflictsTable
+        {
+            LowerId = 0,
+            RecordSeparator = 1,
+            ChangeVector = 2,
+            Id = 3,
+            Data = 4,
+            Etag = 5,
+            Collection = 6,
+            LastModified = 7,
+            Flags = 8
+        }
+
+        static Conflicts()
+        {
+            using (StorageEnvironment.GetStaticContext(out var ctx))
+            {
+                Slice.From(ctx, "ChangeVector", ByteStringType.Immutable, out ChangeVectorSlice);
+                Slice.From(ctx, "ConflictsId", ByteStringType.Immutable, out ConflictsIdSlice);
+                Slice.From(ctx, "IdAndChangeVector", ByteStringType.Immutable, out IdAndChangeVectorSlice);
+                Slice.From(ctx, "AllConflictedDocsEtags", ByteStringType.Immutable, out AllConflictedDocsEtagsSlice);
+                Slice.From(ctx, "ConflictedCollection", ByteStringType.Immutable, out ConflictedCollectionSlice);
+                Slice.From(ctx, "Conflicts", ByteStringType.Immutable, out ConflictsSlice);
+                Slice.From(ctx, "ConflictsBucketAndEtag", ByteStringType.Immutable, out ConflictsBucketAndEtagSlice);
+            }
+
+            DefineIndexesForConflictsSchema(ConflictsSchemaBase);
+            DefineIndexesForConflictsSchemaBase60();
+
+            void DefineIndexesForConflictsSchema(TableSchema schema)
+            {
+                /*
+ The structure of conflicts table starts with the following fields:
+ [ Conflicted Doc Id | Separator | Change Vector | ... the rest of fields ... ]
+ PK of the conflicts table will be 'Change Vector' field, because when dealing with conflicts,
+  the change vectors will always be different, hence the uniqueness of the ID. (inserts/updates will not overwrite)
+
+Additional index is set to have composite ID of 'Conflicted Doc Id' and 'Change Vector' so we will be able to iterate
+on conflicts by conflicted doc id (using 'starts with')
+
+We need a separator in order to delete all conflicts all "users/1" without deleting "users/11" conflicts.
+ */
+
+                schema.DefineKey(new TableSchema.IndexDef
+                {
+                    StartIndex = (int)ConflictsTable.ChangeVector,
+                    Count = 1,
+                    IsGlobal = false,
+                    Name = ChangeVectorSlice
+                });
+                // required to get conflicts by ID
+                schema.DefineIndex(new TableSchema.IndexDef
+                {
+                    StartIndex = (int)ConflictsTable.LowerId,
+                    Count = 3,
+                    IsGlobal = false,
+                    Name = IdAndChangeVectorSlice
+                });
+                schema.DefineIndex(new TableSchema.IndexDef
+                {
+                    StartIndex = (int)ConflictsTable.LowerId,
+                    Count = 1,
+                    IsGlobal = true,
+                    Name = ConflictsIdSlice
+                });
+                schema.DefineFixedSizeIndex(new TableSchema.FixedSizeKeyIndexDef
+                {
+                    StartIndex = (int)ConflictsTable.Etag,
+                    IsGlobal = true,
+                    Name = AllConflictedDocsEtagsSlice
+                });
+                schema.DefineIndex(new TableSchema.IndexDef
+                {
+                    StartIndex = (int)ConflictsTable.Collection,
+                    Count = 1,
+                    IsGlobal = true,
+                    Name = ConflictedCollectionSlice
+                });
+            }
+
+            void DefineIndexesForConflictsSchemaBase60()
+            {
+                DefineIndexesForConflictsSchema(ConflictsSchemaBase60);
+
+                ConflictsSchemaBase60.DefineIndex(new TableSchema.DynamicKeyIndexDef
+                {
+                    GenerateKey = ConflictsStorage.GenerateBucketAndEtagIndexKeyForConflicts,
+                    IsGlobal = true,
+                    Name = ConflictsBucketAndEtagSlice
+                });
+            }
+        }
+    }
+}

--- a/src/Raven.Server/Documents/Schemas/CounterTombstones.cs
+++ b/src/Raven.Server/Documents/Schemas/CounterTombstones.cs
@@ -1,0 +1,57 @@
+﻿using Sparrow.Server;
+using Voron;
+using Voron.Data.Tables;
+
+namespace Raven.Server.Documents.Schemas
+{
+    public static class CounterTombstones
+    {
+        public static TableSchema Current => CounterTombstonesSchemaBase;
+
+        internal static readonly TableSchema CounterTombstonesSchemaBase = new TableSchema();
+
+        internal static readonly Slice CounterTombstoneKey;
+        internal static readonly Slice AllCounterTombstonesEtagSlice;
+        internal static readonly Slice CollectionCounterTombstonesEtagsSlice;
+
+        internal enum CounterTombstonesTable
+        {
+            // lower document id, record separator, lower counter name
+            CounterTombstoneKey = 0,
+
+            Etag = 1,
+            ChangeVector = 2
+        }
+
+        static CounterTombstones()
+        {
+            using (StorageEnvironment.GetStaticContext(out var ctx))
+            {
+                Slice.From(ctx, "CounterTombstoneKey", ByteStringType.Immutable, out CounterTombstoneKey);
+                Slice.From(ctx, "AllCounterTombstonesEtagSlice", ByteStringType.Immutable, out AllCounterTombstonesEtagSlice);
+                Slice.From(ctx, "CollectionCounterTombstonesEtagsSlice", ByteStringType.Immutable, out CollectionCounterTombstonesEtagsSlice);
+            }
+
+            CounterTombstonesSchemaBase.DefineKey(new TableSchema.IndexDef
+            {
+                StartIndex = (int)CounterTombstonesTable.CounterTombstoneKey,
+                Count = 1,
+                Name = CounterTombstoneKey,
+                IsGlobal = true
+            });
+
+            CounterTombstonesSchemaBase.DefineFixedSizeIndex(new TableSchema.FixedSizeKeyIndexDef
+            {
+                StartIndex = (int)CounterTombstonesTable.Etag,
+                Name = AllCounterTombstonesEtagSlice,
+                IsGlobal = true
+            });
+
+            CounterTombstonesSchemaBase.DefineFixedSizeIndex(new TableSchema.FixedSizeKeyIndexDef
+            {
+                StartIndex = (int)CounterTombstonesTable.Etag,
+                Name = CollectionCounterTombstonesEtagsSlice
+            });
+        }
+    }
+}

--- a/src/Raven.Server/Documents/Schemas/Counters.cs
+++ b/src/Raven.Server/Documents/Schemas/Counters.cs
@@ -1,0 +1,90 @@
+﻿using Sparrow.Server;
+using Voron;
+using Voron.Data.Tables;
+
+namespace Raven.Server.Documents.Schemas
+{
+    public static class Counters
+    {
+        public static TableSchema Current => CountersSchemaBase60;
+
+        internal static readonly TableSchema CountersSchemaBase = new TableSchema
+        {
+            TableType = (byte)TableType.Counters
+        };
+
+        internal static readonly TableSchema CountersSchemaBase60 = new TableSchema
+        {
+            TableType = (byte)TableType.Counters
+        };
+
+        internal static readonly Slice AllCountersEtagSlice;
+        internal static readonly Slice CollectionCountersEtagsSlice;
+        internal static readonly Slice CounterKeysSlice;
+        internal static readonly Slice CountersBucketAndEtagSlice;
+
+        internal enum CountersTable
+        {
+            // Format of this is:
+            // lower document id, record separator, prefix
+            CounterKey = 0,
+
+            Etag = 1,
+            ChangeVector = 2,
+            Data = 3,
+            Collection = 4,
+            TransactionMarker = 5
+        }
+
+        static Counters()
+        {
+            using (StorageEnvironment.GetStaticContext(out var ctx))
+            {
+                Slice.From(ctx, "AllCounterGroupsEtags", ByteStringType.Immutable, out AllCountersEtagSlice);
+                Slice.From(ctx, "CollectionCounterGroupsEtags", ByteStringType.Immutable, out CollectionCountersEtagsSlice);
+                Slice.From(ctx, "CounterGroupKeys", ByteStringType.Immutable, out CounterKeysSlice);
+                Slice.From(ctx, "CountersBucketAndEtag", ByteStringType.Immutable, out CountersBucketAndEtagSlice);
+            }
+
+            DefineIndexesForCountersSchema(CountersSchemaBase);
+            DefineIndexesForCountersSchemaBase60();
+
+            void DefineIndexesForCountersSchema(TableSchema schema)
+            {
+                schema.DefineKey(new TableSchema.IndexDef
+                {
+                    StartIndex = (int)CountersTable.CounterKey,
+                    Count = 1,
+                    Name = CounterKeysSlice,
+                    IsGlobal = true,
+                });
+
+                schema.DefineFixedSizeIndex(new TableSchema.FixedSizeKeyIndexDef
+                {
+                    StartIndex = (int)CountersTable.Etag,
+                    Name = AllCountersEtagSlice,
+                    IsGlobal = true
+                });
+
+                schema.DefineFixedSizeIndex(new TableSchema.FixedSizeKeyIndexDef
+                {
+                    StartIndex = (int)CountersTable.Etag,
+                    Name = CollectionCountersEtagsSlice
+                });
+
+            }
+
+            void DefineIndexesForCountersSchemaBase60()
+            {
+                DefineIndexesForCountersSchema(CountersSchemaBase60);
+
+                CountersSchemaBase60.DefineIndex(new TableSchema.DynamicKeyIndexDef
+                {
+                    GenerateKey = CountersStorage.GenerateBucketAndEtagIndexKeyForCounters,
+                    IsGlobal = true,
+                    Name = CountersBucketAndEtagSlice
+                });
+            }
+        }
+    }
+}

--- a/src/Raven.Server/Documents/Schemas/DeletedRanges.cs
+++ b/src/Raven.Server/Documents/Schemas/DeletedRanges.cs
@@ -1,0 +1,86 @@
+﻿using Raven.Server.Documents.TimeSeries;
+using Sparrow.Server;
+using Voron;
+using Voron.Data.Tables;
+
+namespace Raven.Server.Documents.Schemas
+{
+    public static class DeletedRanges
+    {
+        public static TableSchema Current => DeleteRangesSchemaBase60;
+
+        internal static readonly TableSchema DeleteRangesSchemaBase = new TableSchema();
+        internal static readonly TableSchema DeleteRangesSchemaBase60 = new TableSchema();
+
+        internal static readonly Slice PendingDeletionSegments;
+        internal static readonly Slice DeletedRangesKey;
+        internal static readonly Slice AllDeletedRangesEtagSlice;
+        internal static readonly Slice CollectionDeletedRangesEtagsSlice;
+        internal static readonly Slice DeletedRangesBucketAndEtagSlice;
+
+        internal enum DeletedRangeTable
+        {
+            // lower document id, record separator, lower time series name, record separator, change vector hash
+            RangeKey = 0,
+
+            Etag = 1,
+            ChangeVector = 2,
+            Collection = 3,
+            TransactionMarker = 4,
+            From = 5,
+            To = 6
+        }
+
+        static DeletedRanges()
+        {
+            using (StorageEnvironment.GetStaticContext(out var ctx))
+            {
+                Slice.From(ctx, "PendingDeletionSegments", ByteStringType.Immutable, out PendingDeletionSegments);
+                Slice.From(ctx, "DeletedRangesKey", ByteStringType.Immutable, out DeletedRangesKey);
+                Slice.From(ctx, "AllDeletedRangesEtag", ByteStringType.Immutable, out AllDeletedRangesEtagSlice);
+                Slice.From(ctx, "CollectionDeletedRangesEtags", ByteStringType.Immutable, out CollectionDeletedRangesEtagsSlice);
+                Slice.From(ctx, "DeletedRangesBucketAndEtag", ByteStringType.Immutable, out DeletedRangesBucketAndEtagSlice);
+            }
+
+            DefineIndexesForDeletedRangesSchema(DeleteRangesSchemaBase);
+            DefineIndexesForDeletedRangesSchemaBase60();
+
+            void DefineIndexesForDeletedRangesSchema(TableSchema schema)
+            {
+                schema.DefineKey(new TableSchema.IndexDef
+                {
+                    StartIndex = (int)DeletedRangeTable.RangeKey,
+                    Count = 1,
+                    Name = DeletedRangesKey,
+                    IsGlobal = true
+                });
+
+                schema.DefineFixedSizeIndex(new TableSchema.FixedSizeKeyIndexDef
+                {
+                    StartIndex = (int)DeletedRangeTable.Etag,
+                    Name = AllDeletedRangesEtagSlice,
+                    IsGlobal = true
+                });
+
+                schema.DefineFixedSizeIndex(new TableSchema.FixedSizeKeyIndexDef
+                {
+                    StartIndex = (int)DeletedRangeTable.Etag,
+                    Name = CollectionDeletedRangesEtagsSlice
+                });
+
+            }
+
+            void DefineIndexesForDeletedRangesSchemaBase60()
+            {
+                DefineIndexesForDeletedRangesSchema(DeleteRangesSchemaBase60);
+
+                DeleteRangesSchemaBase60.DefineIndex(new TableSchema.DynamicKeyIndexDef
+                {
+                    GenerateKey = TimeSeriesStorage.GenerateBucketAndEtagIndexKeyForDeletedRanges,
+                    IsGlobal = true,
+                    Name = DeletedRangesBucketAndEtagSlice
+                });
+            }
+        }
+    }
+}

--- a/src/Raven.Server/Documents/Schemas/Documents.cs
+++ b/src/Raven.Server/Documents/Schemas/Documents.cs
@@ -1,0 +1,119 @@
+﻿using Sparrow.Server;
+using Voron;
+using Voron.Data.Tables;
+
+namespace Raven.Server.Documents.Schemas
+{
+    public static class Documents
+    {
+        public static TableSchema Current => DocsSchemaBase60;
+        public static TableSchema CurrentCompressed => CompressedDocsSchemaBase60;
+
+
+        internal static readonly Slice DocsSlice;
+        public static readonly Slice CollectionEtagsSlice;
+        internal static readonly Slice AllDocsEtagsSlice;
+        internal static readonly Slice DocsBucketAndEtagSlice;
+
+        internal static readonly TableSchema DocsSchemaBase60 = new TableSchema
+        {
+            TableType = (byte)TableType.Documents
+        };
+
+        internal static readonly TableSchema CompressedDocsSchemaBase60 = new TableSchema
+        {
+            TableType = (byte)TableType.Documents
+        };
+
+        internal static readonly TableSchema DocsSchemaBase = new TableSchema
+        {
+            TableType = (byte)TableType.Documents
+        };
+
+        internal static readonly TableSchema CompressedDocsSchemaBase = new TableSchema
+        {
+            TableType = (byte)TableType.Documents
+        };
+
+
+        public enum DocumentsTable
+        {
+            LowerId = 0,
+            Etag = 1,
+            Id = 2, // format of lazy string id is detailed in GetLowerIdSliceAndStorageKey
+            Data = 3,
+            ChangeVector = 4,
+            LastModified = 5,
+            Flags = 6,
+            TransactionMarker = 7
+        }
+
+        static Documents()
+        {
+            using (StorageEnvironment.GetStaticContext(out var ctx))
+            {
+                Slice.From(ctx, "Docs", ByteStringType.Immutable, out DocsSlice);
+                Slice.From(ctx, "CollectionEtags", ByteStringType.Immutable, out CollectionEtagsSlice);
+                Slice.From(ctx, "AllDocsEtags", ByteStringType.Immutable, out AllDocsEtagsSlice);
+                Slice.From(ctx, "DocsBucketAndEtag", ByteStringType.Immutable, out DocsBucketAndEtagSlice);
+            }
+
+            DefineIndexesForDocsSchemaBase(DocsSchemaBase);
+            DefineIndexesForDocsSchemaBase(CompressedDocsSchemaBase);
+
+            DocsSchemaBase.CompressValues(DocsSchemaBase.FixedSizeIndexes[CollectionEtagsSlice], compress: false);
+            CompressedDocsSchemaBase.CompressValues(CompressedDocsSchemaBase.FixedSizeIndexes[CollectionEtagsSlice], compress: true);
+
+            DefineIndexesForDocsSchemaBase60(DocsSchemaBase60);
+            DefineIndexesForDocsSchemaBase60(CompressedDocsSchemaBase60);
+
+            DocsSchemaBase60.CompressValues(DocsSchemaBase.FixedSizeIndexes[CollectionEtagsSlice], compress: false);
+            CompressedDocsSchemaBase60.CompressValues(CompressedDocsSchemaBase.FixedSizeIndexes[CollectionEtagsSlice], compress: true);
+
+            void DefineIndexesForDocsSchemaBase(TableSchema docsSchema)
+            {
+                docsSchema.DefineKey(new TableSchema.IndexDef
+                {
+                    StartIndex = (int)DocumentsTable.LowerId, 
+                    Count = 1, 
+                    IsGlobal = true, 
+                    Name = DocsSlice
+                });
+                docsSchema.DefineFixedSizeIndex(new TableSchema.FixedSizeKeyIndexDef
+                {
+                    StartIndex = (int)DocumentsTable.Etag, 
+                    IsGlobal = false, 
+                    Name = CollectionEtagsSlice
+                });
+                docsSchema.DefineFixedSizeIndex(new TableSchema.FixedSizeKeyIndexDef
+                {
+                    StartIndex = (int)DocumentsTable.Etag, 
+                    IsGlobal = true, 
+                    Name = AllDocsEtagsSlice
+                });
+            }
+            void DefineIndexesForDocsSchemaBase60(TableSchema docsSchema)
+            {
+                DefineIndexesForDocsSchemaBase(docsSchema);
+
+                docsSchema.DefineIndex(new TableSchema.DynamicKeyIndexDef
+                {
+                    GenerateKey = DocumentsStorage.GenerateBucketAndEtagIndexKeyForDocuments,
+                    IsGlobal = true,
+                    Name = DocsBucketAndEtagSlice
+                });
+            }
+        }
+    }
+
+    public enum TableType : byte
+    {
+        None = 0,
+        Documents = 1,
+        Revisions = 2,
+        Conflicts = 3,
+        LegacyCounter = 4,
+        Counters = 5,
+        TimeSeries = 6
+    }
+}

--- a/src/Raven.Server/Documents/Schemas/Revisions.cs
+++ b/src/Raven.Server/Documents/Schemas/Revisions.cs
@@ -1,0 +1,157 @@
+﻿using Raven.Server.Documents.Revisions;
+using Sparrow.Server;
+using Voron;
+using Voron.Data.Tables;
+
+namespace Raven.Server.Documents.Schemas
+{
+    public static class Revisions
+    {
+        public static TableSchema Current => RevisionsSchemaBase60;
+
+        public static TableSchema CurrentCompressed => CompressedRevisionsSchemaBase60;
+
+        internal static readonly TableSchema RevisionsSchemaBase = new TableSchema()
+        {
+            TableType = (byte)TableType.Revisions,
+        };
+
+        internal static readonly TableSchema CompressedRevisionsSchemaBase = new TableSchema()
+        {
+            TableType = (byte)TableType.Revisions,
+        };
+
+        internal static readonly TableSchema RevisionsSchemaBase60 = new TableSchema()
+        {
+            TableType = (byte)TableType.Revisions,
+        };
+
+        internal static readonly TableSchema CompressedRevisionsSchemaBase60 = new TableSchema()
+        {
+            TableType = (byte)TableType.Revisions,
+        };
+
+        internal static readonly Slice IdAndEtagSlice;
+        internal static readonly Slice DeleteRevisionEtagSlice;
+        internal static readonly Slice AllRevisionsEtagsSlice;
+        internal static readonly Slice CollectionRevisionsEtagsSlice;
+        internal static readonly Slice RevisionsCountSlice;
+        internal static readonly Slice RevisionsTombstonesSlice;
+        internal static readonly Slice RevisionsPrefix;
+        internal static Slice ResolvedFlagByEtagSlice;
+        internal static readonly Slice RevisionsBucketAndEtagSlice;
+        internal static readonly string RevisionsTombstones = "Revisions.Tombstones";
+
+        public enum RevisionsTable
+        {
+            /* ChangeVector is the table's key as it's unique and will avoid conflicts (by replication) */
+            ChangeVector = 0,
+            LowerId = 1,
+            /* We are you using the record separator in order to avoid loading another documents that has the same ID prefix,
+                e.g. fitz(record-separator)01234567 and fitz0(record-separator)01234567, without the record separator we would have to load also fitz0 and filter it. */
+            RecordSeparator = 2,
+            Etag = 3, // etag to keep the insertion order
+            Id = 4,
+            Document = 5,
+            Flags = 6,
+            DeletedEtag = 7,
+            LastModified = 8,
+            TransactionMarker = 9,
+
+            // Field for finding the resolved conflicts
+            Resolved = 10,
+
+            SwappedLastModified = 11,
+        }
+
+        static Revisions()
+        {
+            using (StorageEnvironment.GetStaticContext(out var ctx))
+            {
+                Slice.From(ctx, "RevisionsChangeVector", ByteStringType.Immutable, out var changeVectorSlice);
+                Slice.From(ctx, "RevisionsIdAndEtag", ByteStringType.Immutable, out IdAndEtagSlice);
+                Slice.From(ctx, "DeleteRevisionEtag", ByteStringType.Immutable, out DeleteRevisionEtagSlice);
+                Slice.From(ctx, "AllRevisionsEtags", ByteStringType.Immutable, out AllRevisionsEtagsSlice);
+                Slice.From(ctx, "CollectionRevisionsEtags", ByteStringType.Immutable, out CollectionRevisionsEtagsSlice);
+                Slice.From(ctx, "RevisionsCount", ByteStringType.Immutable, out RevisionsCountSlice);
+                Slice.From(ctx, "RevisionsBucketAndEtag", ByteStringType.Immutable, out RevisionsBucketAndEtagSlice);
+                Slice.From(ctx, nameof(ResolvedFlagByEtagSlice), ByteStringType.Immutable, out ResolvedFlagByEtagSlice);
+                Slice.From(ctx, RevisionsTombstones, ByteStringType.Immutable, out RevisionsTombstonesSlice);
+                Slice.From(ctx, CollectionName.GetTablePrefix(CollectionTableType.Revisions), ByteStringType.Immutable, out RevisionsPrefix);
+
+
+                DefineIndexesForRevisionsSchema(RevisionsSchemaBase, changeVectorSlice);
+                DefineIndexesForRevisionsSchema(CompressedRevisionsSchemaBase, changeVectorSlice);
+
+                DefineIndexesForRevisionsSchemaBase60(RevisionsSchemaBase60, changeVectorSlice);
+                DefineIndexesForRevisionsSchemaBase60(CompressedRevisionsSchemaBase60, changeVectorSlice);
+
+                RevisionsSchemaBase.CompressValues(
+                    RevisionsSchemaBase.FixedSizeIndexes[CollectionRevisionsEtagsSlice], compress: false);
+                CompressedRevisionsSchemaBase.CompressValues(
+                    CompressedRevisionsSchemaBase.FixedSizeIndexes[CollectionRevisionsEtagsSlice], compress: true);
+
+                RevisionsSchemaBase60.CompressValues(
+                    RevisionsSchemaBase60.FixedSizeIndexes[CollectionRevisionsEtagsSlice], compress: false);
+                CompressedRevisionsSchemaBase60.CompressValues(
+                    CompressedRevisionsSchemaBase60.FixedSizeIndexes[CollectionRevisionsEtagsSlice], compress: true);
+
+            }
+        }
+
+        private static void DefineIndexesForRevisionsSchema(TableSchema revisionsSchema, Slice changeVectorSlice)
+        {
+            revisionsSchema.DefineKey(new TableSchema.IndexDef
+            {
+                StartIndex = (int)RevisionsTable.ChangeVector,
+                Count = 1,
+                Name = changeVectorSlice,
+                IsGlobal = true
+            });
+            revisionsSchema.DefineIndex(new TableSchema.IndexDef
+            {
+                StartIndex = (int)RevisionsTable.LowerId,
+                Count = 3,
+                Name = IdAndEtagSlice,
+                IsGlobal = true
+            });
+            revisionsSchema.DefineFixedSizeIndex(new TableSchema.FixedSizeKeyIndexDef
+            {
+                StartIndex = (int)RevisionsTable.Etag,
+                Name = AllRevisionsEtagsSlice,
+                IsGlobal = true
+            });
+            revisionsSchema.DefineFixedSizeIndex(new TableSchema.FixedSizeKeyIndexDef
+            {
+                StartIndex = (int)RevisionsTable.Etag,
+                Name = CollectionRevisionsEtagsSlice
+            });
+            revisionsSchema.DefineIndex(new TableSchema.IndexDef
+            {
+                StartIndex = (int)RevisionsTable.DeletedEtag,
+                Count = 1,
+                Name = DeleteRevisionEtagSlice,
+                IsGlobal = true
+            });
+            revisionsSchema.DefineIndex(new TableSchema.IndexDef
+            {
+                StartIndex = (int)RevisionsTable.Resolved,
+                Count = 2,
+                Name = ResolvedFlagByEtagSlice,
+                IsGlobal = true
+            });
+        }
+
+        private static void DefineIndexesForRevisionsSchemaBase60(TableSchema schema, Slice changeVectorSlice)
+        {
+            DefineIndexesForRevisionsSchema(schema, changeVectorSlice);
+
+            schema.DefineIndex(new TableSchema.DynamicKeyIndexDef
+            {
+                GenerateKey = RevisionsStorage.GenerateBucketAndEtagIndexKeyForRevisions,
+                IsGlobal = true,
+                Name = RevisionsBucketAndEtagSlice
+            });
+        }
+    }
+}

--- a/src/Raven.Server/Documents/Schemas/TimeSeries.cs
+++ b/src/Raven.Server/Documents/Schemas/TimeSeries.cs
@@ -1,0 +1,90 @@
+﻿using Raven.Server.Documents.TimeSeries;
+using Sparrow.Server;
+using Voron;
+using Voron.Data.Tables;
+
+namespace Raven.Server.Documents.Schemas
+{
+    public static class TimeSeries
+    {
+        public static TableSchema Current => TimeSeriesSchemaBase60;
+
+        internal static readonly TableSchema TimeSeriesSchemaBase = new TableSchema
+        {
+            TableType = (byte)TableType.TimeSeries
+        };
+
+        internal static readonly TableSchema TimeSeriesSchemaBase60 = new TableSchema
+        {
+            TableType = (byte)TableType.TimeSeries
+        };
+
+        internal static readonly Slice AllTimeSeriesEtagSlice;
+        internal static readonly Slice CollectionTimeSeriesEtagsSlice;
+        internal static readonly Slice TimeSeriesKeysSlice;
+        internal static readonly Slice TimeSeriesBucketAndEtagSlice;
+
+        internal enum TimeSeriesTable
+        {
+            // Format of this is:
+            // lower document id, record separator, lower time series name, record separator, segment start
+            TimeSeriesKey = 0,
+
+            Etag = 1,
+            ChangeVector = 2,
+            Segment = 3,
+            Collection = 4,
+            TransactionMarker = 5
+        }
+
+        static TimeSeries()
+        {
+            using (StorageEnvironment.GetStaticContext(out var ctx))
+            {
+                Slice.From(ctx, "AllTimeSeriesEtag", ByteStringType.Immutable, out AllTimeSeriesEtagSlice);
+                Slice.From(ctx, "CollectionTimeSeriesEtags", ByteStringType.Immutable, out CollectionTimeSeriesEtagsSlice);
+                Slice.From(ctx, "TimeSeriesKeys", ByteStringType.Immutable, out TimeSeriesKeysSlice);
+                Slice.From(ctx, "TimeSeriesBucketAndEtag", ByteStringType.Immutable, out TimeSeriesBucketAndEtagSlice);
+            }
+
+            DefineIndexesForTimeSeriesSchema(TimeSeriesSchemaBase);
+            DefineIndexesForTimeSeriesSchemaBase60();
+
+            void DefineIndexesForTimeSeriesSchema(TableSchema schema)
+            {
+                schema.DefineKey(new TableSchema.IndexDef
+                {
+                    StartIndex = (int)TimeSeriesTable.TimeSeriesKey,
+                    Count = 1,
+                    Name = TimeSeriesKeysSlice,
+                    IsGlobal = true
+                });
+
+                schema.DefineFixedSizeIndex(new TableSchema.FixedSizeKeyIndexDef
+                {
+                    StartIndex = (int)TimeSeriesTable.Etag,
+                    Name = AllTimeSeriesEtagSlice,
+                    IsGlobal = true
+                });
+
+                schema.DefineFixedSizeIndex(new TableSchema.FixedSizeKeyIndexDef
+                {
+                    StartIndex = (int)TimeSeriesTable.Etag,
+                    Name = CollectionTimeSeriesEtagsSlice
+                });
+            }
+
+            void DefineIndexesForTimeSeriesSchemaBase60()
+            {
+                DefineIndexesForTimeSeriesSchema(TimeSeriesSchemaBase60);
+
+                TimeSeriesSchemaBase60.DefineIndex(new TableSchema.DynamicKeyIndexDef
+                {
+                    GenerateKey = TimeSeriesStorage.GenerateBucketAndEtagIndexKeyForTimeSeries,
+                    IsGlobal = true,
+                    Name = TimeSeriesBucketAndEtagSlice
+                });
+            }
+        }
+    }
+}

--- a/src/Raven.Server/Documents/Schemas/Tombstones.cs
+++ b/src/Raven.Server/Documents/Schemas/Tombstones.cs
@@ -1,0 +1,89 @@
+﻿using Sparrow.Server;
+using Voron;
+using Voron.Data.Tables;
+
+namespace Raven.Server.Documents.Schemas
+{
+    public static class Tombstones
+    {
+        public static TableSchema Current => TombstonesSchemaBase60;
+
+        internal static readonly TableSchema TombstonesSchemaBase = new TableSchema();
+        internal static readonly TableSchema TombstonesSchemaBase60 = new TableSchema();
+
+        internal static readonly Slice TombstonesSlice;
+        internal static readonly Slice AllTombstonesEtagsSlice;
+        internal static readonly Slice TombstonesPrefix;
+        internal static readonly Slice DeletedEtagsSlice;
+        internal static readonly Slice TombstonesBucketAndEtagSlice;
+
+        internal enum TombstoneTable
+        {
+            LowerId = 0,
+            Etag = 1,
+            DeletedEtag = 2,
+            TransactionMarker = 3,
+            Type = 4,
+            Collection = 5,
+            Flags = 6,
+            ChangeVector = 7,
+            LastModified = 8
+        }
+
+        static Tombstones()
+        {
+            using (StorageEnvironment.GetStaticContext(out var ctx))
+            {
+                Slice.From(ctx, "AllTombstonesEtags", ByteStringType.Immutable, out AllTombstonesEtagsSlice);
+                Slice.From(ctx, "TombstonesBucketAndEtag", ByteStringType.Immutable, out TombstonesBucketAndEtagSlice);
+                Slice.From(ctx, "Tombstones", ByteStringType.Immutable, out TombstonesSlice);
+                Slice.From(ctx, CollectionName.GetTablePrefix(CollectionTableType.Tombstones), ByteStringType.Immutable, out TombstonesPrefix);
+                Slice.From(ctx, "DeletedEtags", ByteStringType.Immutable, out DeletedEtagsSlice);
+            }
+
+            DefineIndexesForTombstonesSchema(TombstonesSchemaBase);
+            DefineIndexesForTombstonesSchemaBase60();
+
+            void DefineIndexesForTombstonesSchema(TableSchema schema)
+            {
+                schema.DefineKey(new TableSchema.IndexDef
+                {
+                    StartIndex = (int)TombstoneTable.LowerId,
+                    Count = 1,
+                    IsGlobal = true,
+                    Name = TombstonesSlice
+                });
+                schema.DefineFixedSizeIndex(new TableSchema.FixedSizeKeyIndexDef
+                {
+                    StartIndex = (int)TombstoneTable.Etag,
+                    IsGlobal = false,
+                    Name = Documents.CollectionEtagsSlice
+                });
+                schema.DefineFixedSizeIndex(new TableSchema.FixedSizeKeyIndexDef
+                {
+                    StartIndex = (int)TombstoneTable.Etag,
+                    IsGlobal = true,
+                    Name = AllTombstonesEtagsSlice
+                });
+                schema.DefineFixedSizeIndex(new TableSchema.FixedSizeKeyIndexDef
+                {
+                    StartIndex = (int)TombstoneTable.DeletedEtag,
+                    IsGlobal = false,
+                    Name = DeletedEtagsSlice
+                });
+            }
+
+            void DefineIndexesForTombstonesSchemaBase60()
+            {
+                DefineIndexesForTombstonesSchema(TombstonesSchemaBase60);
+
+                TombstonesSchemaBase60.DefineIndex(new TableSchema.DynamicKeyIndexDef
+                {
+                    GenerateKey = DocumentsStorage.GenerateBucketAndEtagIndexKeyForTombstones,
+                    IsGlobal = true,
+                    Name = TombstonesBucketAndEtagSlice
+                });
+            }
+        }
+    }
+}

--- a/src/Raven.Server/Documents/TimeSeries/TimeSeriesReader.cs
+++ b/src/Raven.Server/Documents/TimeSeries/TimeSeriesReader.cs
@@ -13,6 +13,7 @@ using Sparrow.Json;
 using Sparrow.Json.Parsing;
 using Voron;
 using Voron.Data.Tables;
+using static Raven.Server.Documents.Schemas.TimeSeries;
 
 namespace Raven.Server.Documents.TimeSeries
 {
@@ -572,7 +573,7 @@ namespace Raven.Server.Documents.TimeSeries
 
         internal bool NextSegment(out long baselineMilliseconds)
         {
-            byte* key = _tvr.Read((int)TimeSeriesStorage.TimeSeriesTable.TimeSeriesKey, out int keySize);
+            byte* key = _tvr.Read((int)TimeSeriesTable.TimeSeriesKey, out int keySize);
             using (Slice.From(_context.Allocator, key, keySize - sizeof(long), out var prefix))
             using (Slice.From(_context.Allocator, key, keySize, out var current))
             {
@@ -595,13 +596,13 @@ namespace Raven.Server.Documents.TimeSeries
         private void InitializeSegment(out long baselineMilliseconds, out TimeSeriesValuesSegment readOnlySegment)
         {
             baselineMilliseconds = ReadBaseline();
-            var segmentReadOnlyBuffer = _tvr.Read((int)TimeSeriesStorage.TimeSeriesTable.Segment, out int size);
+            var segmentReadOnlyBuffer = _tvr.Read((int)TimeSeriesTable.Segment, out int size);
             readOnlySegment = new TimeSeriesValuesSegment(segmentReadOnlyBuffer, size);
         }
 
         private long ReadBaseline()
         {
-            var key = _tvr.Read((int)TimeSeriesStorage.TimeSeriesTable.TimeSeriesKey, out int keySize);
+            var key = _tvr.Read((int)TimeSeriesTable.TimeSeriesKey, out int keySize);
             return Bits.SwapBytes(*(long*)(key + keySize - sizeof(long)));
         }
 
@@ -612,13 +613,13 @@ namespace Raven.Server.Documents.TimeSeries
 
         internal string GetCurrentSegmentChangeVector()
         {
-            return DocumentsStorage.TableValueToChangeVector(_context, (int)TimeSeriesStorage.TimeSeriesTable.ChangeVector, ref _tvr);
+            return DocumentsStorage.TableValueToChangeVector(_context, (int)TimeSeriesTable.ChangeVector, ref _tvr);
         }
 
         internal (long Etag, string ChangeVector, DateTime Baseline) GetSegmentInfo()
         {
             var changeVector = GetCurrentSegmentChangeVector();
-            var etag = DocumentsStorage.TableValueToEtag((int)TimeSeriesStorage.TimeSeriesTable.Etag, ref _tvr);
+            var etag = DocumentsStorage.TableValueToEtag((int)TimeSeriesTable.Etag, ref _tvr);
             var baseline = new DateTime(ReadBaseline() * 10_000);
 
             return (etag, changeVector, baseline);

--- a/src/Raven.Server/Documents/TimeSeries/TimeSeriesStorage.cs
+++ b/src/Raven.Server/Documents/TimeSeries/TimeSeriesStorage.cs
@@ -51,7 +51,7 @@ namespace Raven.Server.Documents.TimeSeries
             TableType = (byte)TableType.TimeSeries
         };
 
-        private static readonly TableSchema DeleteRangesSchema = new TableSchema();
+        internal static readonly TableSchema DeleteRangesSchema = new TableSchema();
 
         private readonly DocumentDatabase _documentDatabase;
         private readonly DocumentsStorage _documentsStorage;
@@ -73,7 +73,6 @@ namespace Raven.Server.Documents.TimeSeries
                 Slice.From(ctx, "CollectionDeletedRangesEtags", ByteStringType.Immutable, out CollectionDeletedRangesEtagsSlice);
                 Slice.From(ctx, "TimeSeriesBucketAndEtag", ByteStringType.Immutable, out TimeSeriesBucketAndEtagSlice);
                 Slice.From(ctx, "DeletedRangesBucketAndEtag", ByteStringType.Immutable, out DeletedRangesBucketAndEtagSlice);
-
             }
 
             TimeSeriesSchema.DefineKey(new TableSchema.IndexDef

--- a/src/Raven.Server/Storage/Schema/SchemaUpgrader.cs
+++ b/src/Raven.Server/Storage/Schema/SchemaUpgrader.cs
@@ -16,7 +16,7 @@ namespace Raven.Server.Storage.Schema
 
             public const int ConfigurationVersion = 50_000;
 
-            public const int DocumentsVersion = 50_002;
+            public const int DocumentsVersion = 60_000;
 
             public const int IndexVersion = 50_000;
         }

--- a/src/Raven.Server/Storage/Schema/Updates/Documents/40011/From40010.cs
+++ b/src/Raven.Server/Storage/Schema/Updates/Documents/40011/From40010.cs
@@ -3,10 +3,13 @@ using Raven.Server.Json;
 using Raven.Server.ServerWide.Context;
 using Voron;
 using Voron.Data.Tables;
-using static Raven.Server.Documents.AttachmentsStorage;
-using static Raven.Server.Documents.ConflictsStorage;
 using static Raven.Server.Documents.DocumentsStorage;
-using static Raven.Server.Documents.Revisions.RevisionsStorage;
+using static Raven.Server.Documents.Schemas.Attachments;
+using static Raven.Server.Documents.Schemas.Collections;
+using static Raven.Server.Documents.Schemas.Conflicts;
+using static Raven.Server.Documents.Schemas.Documents;
+using static Raven.Server.Documents.Schemas.Revisions;
+using static Raven.Server.Documents.Schemas.Tombstones;
 
 namespace Raven.Server.Storage.Schema.Updates.Documents
 {
@@ -21,10 +24,10 @@ namespace Raven.Server.Storage.Schema.Updates.Documents
             // Update collections
             using (step.DocumentsStorage.ContextPool.AllocateOperationContext(out DocumentsOperationContext context))
             {
-                var readTable = step.ReadTx.OpenTable(CollectionsSchema, CollectionsSlice);
+                var readTable = step.ReadTx.OpenTable(CollectionsSchemaBase, CollectionsSlice);
                 if (readTable != null)
                 {
-                    var writeTable = step.WriteTx.OpenTable(CollectionsSchema, CollectionsSlice);
+                    var writeTable = step.WriteTx.OpenTable(CollectionsSchemaBase, CollectionsSlice);
                     foreach (var read in readTable.SeekByPrimaryKey(Slices.BeforeAllKeys, 0))
                     {
                         using (TableValueReaderUtil.CloneTableValueReader(context, read))
@@ -63,14 +66,14 @@ namespace Raven.Server.Storage.Schema.Updates.Documents
                         tableName = collectionName.GetTableName(CollectionTableType.Tombstones);
                     }
 
-                    var readTable = step.ReadTx.OpenTable(TombstonesSchema, tableName);
+                    var readTable = step.ReadTx.OpenTable(TombstonesSchemaBase, tableName);
                     if (readTable == null)
                         continue;
 
-                    var writeTable = step.WriteTx.OpenTable(TombstonesSchema, tableName);
+                    var writeTable = step.WriteTx.OpenTable(TombstonesSchemaBase, tableName);
                     // We seek by an index instead the PK because 
                     // we weed to ensure that we aren't accessing an IsGlobal key
-                    foreach (var read in readTable.SeekForwardFrom(TombstonesSchema.FixedSizeIndexes[CollectionEtagsSlice], 0, 0))
+                    foreach (var read in readTable.SeekForwardFrom(TombstonesSchemaBase.FixedSizeIndexes[CollectionEtagsSlice], 0, 0))
                     {
                         // We copy the memory of the read so AssertNoReferenceToOldData won't throw.
                         // This is done instead of moving AssertNoReferenceToOldData to assert later 
@@ -108,10 +111,10 @@ namespace Raven.Server.Storage.Schema.Updates.Documents
             // Update conflicts' collection value
             using (step.DocumentsStorage.ContextPool.AllocateOperationContext(out DocumentsOperationContext context))
             {
-                var readTable = step.ReadTx.OpenTable(ConflictsSchema, ConflictsSlice);
+                var readTable = step.ReadTx.OpenTable(ConflictsSchemaBase, ConflictsSlice);
                 if (readTable != null)
                 {
-                    var writeTable = step.WriteTx.OpenTable(ConflictsSchema, ConflictsSlice);
+                    var writeTable = step.WriteTx.OpenTable(ConflictsSchemaBase, ConflictsSlice);
                     foreach (var read in readTable.SeekByPrimaryKey(Slices.BeforeAllKeys, 0))
                     {
                         using (TableValueReaderUtil.CloneTableValueReader(context, read))

--- a/src/Raven.Server/Storage/Schema/Updates/Documents/40012/From40011.cs
+++ b/src/Raven.Server/Storage/Schema/Updates/Documents/40012/From40011.cs
@@ -5,6 +5,7 @@ using Raven.Server.ServerWide.Context;
 using Voron.Data.Tables;
 using static Raven.Server.Documents.Revisions.RevisionsStorage;
 using static Raven.Server.Documents.DocumentsStorage;
+using static Raven.Server.Documents.Schemas.Revisions;
 
 namespace Raven.Server.Storage.Schema.Updates.Documents
 {
@@ -33,12 +34,12 @@ namespace Raven.Server.Storage.Schema.Updates.Documents
                 {
                     var collectionName = new CollectionName(collection);
                     var tableName = collectionName.GetTableName(CollectionTableType.Revisions);
-                    var readTable = step.ReadTx.OpenTable(RevisionsSchema, tableName);
+                    var readTable = step.ReadTx.OpenTable(RevisionsSchemaBase, tableName);
                     if (readTable == null)
                         continue;
                     
-                    var writeTable = step.DocumentsStorage.RevisionsStorage.EnsureRevisionTableCreated(step.WriteTx, collectionName);
-                    foreach (var read in readTable.SeekForwardFrom(RevisionsSchema.FixedSizeIndexes[CollectionRevisionsEtagsSlice], 0, 0))
+                    var writeTable = step.DocumentsStorage.RevisionsStorage.EnsureRevisionTableCreated(step.WriteTx, collectionName, RevisionsSchemaBase);
+                    foreach (var read in readTable.SeekForwardFrom(RevisionsSchemaBase.FixedSizeIndexes[CollectionRevisionsEtagsSlice], 0, 0))
                     {
                         using (TableValueReaderUtil.CloneTableValueReader(context, read))
                         using (writeTable.Allocate(out TableValueBuilder write))

--- a/src/Raven.Server/Storage/Schema/Updates/Documents/40015/From40014.cs
+++ b/src/Raven.Server/Storage/Schema/Updates/Documents/40015/From40014.cs
@@ -5,7 +5,7 @@ using Raven.Server.ServerWide.Context;
 using Sparrow.Binary;
 using Voron.Data.Tables;
 using static Raven.Server.Documents.DocumentsStorage;
-using static Raven.Server.Documents.Revisions.RevisionsStorage;
+using static Raven.Server.Documents.Schemas.Revisions;
 
 namespace Raven.Server.Storage.Schema.Updates.Documents
 {
@@ -26,12 +26,12 @@ namespace Raven.Server.Storage.Schema.Updates.Documents
                 {
                     var collectionName = new CollectionName(collection);
                     var tableName = collectionName.GetTableName(CollectionTableType.Revisions);
-                    var readTable = step.ReadTx.OpenTable(RevisionsSchema, tableName);
+                    var readTable = step.ReadTx.OpenTable(RevisionsSchemaBase, tableName);
                     if (readTable == null)
                         continue;
 
-                    var writeTable = step.DocumentsStorage.RevisionsStorage.EnsureRevisionTableCreated(step.WriteTx, collectionName);
-                    foreach (var read in readTable.SeekForwardFrom(RevisionsSchema.FixedSizeIndexes[CollectionRevisionsEtagsSlice], 0, 0))
+                    var writeTable = step.DocumentsStorage.RevisionsStorage.EnsureRevisionTableCreated(step.WriteTx, collectionName, RevisionsSchemaBase);
+                    foreach (var read in readTable.SeekForwardFrom(RevisionsSchemaBase.FixedSizeIndexes[CollectionRevisionsEtagsSlice], 0, 0))
                     {
                         using (TableValueReaderUtil.CloneTableValueReader(context, read))
                         using (writeTable.Allocate(out TableValueBuilder write))

--- a/src/Raven.Server/Storage/Schema/Updates/Documents/60000/From50002.cs
+++ b/src/Raven.Server/Storage/Schema/Updates/Documents/60000/From50002.cs
@@ -1,0 +1,141 @@
+﻿using System.Collections.Generic;
+using System.Linq;
+using Raven.Server.Documents;
+using Raven.Server.Documents.Revisions;
+using Raven.Server.Documents.TimeSeries;
+using Raven.Server.ServerWide.Context;
+using Sparrow.Server;
+using Voron;
+using Voron.Data;
+using Voron.Data.Fixed;
+using Voron.Data.Tables;
+
+namespace Raven.Server.Storage.Schema.Updates.Documents
+{
+    public class From50002 : ISchemaUpdate
+    {
+        public int From => 50_002;
+
+        public int To => 60_000;
+        
+        public SchemaUpgrader.StorageType StorageType => SchemaUpgrader.StorageType.Documents;
+
+        internal static int NumberOfItemsToMigrateInSingleTransaction = 10_000;
+        internal static int MaxSizeToMigrateInSingleTransaction = 64 * 1024 * 1024;
+
+        internal static readonly Slice CountersBucketAndEtagSlice;
+        internal static readonly Slice TombstonesBucketAndEtagSlice;
+
+        private static readonly Slice DocsBucketAndEtagSlice;
+        private static readonly Slice ConflictsBucketAndEtagSlice;
+        private static readonly Slice RevisionsBucketAndEtagSlice;
+        private static readonly Slice AttachmentsBucketAndEtagSlice;
+        private static readonly Slice AttachmentsEtagSlice;
+        private static readonly Slice TimeSeriesBucketAndEtagSlice;
+        private static readonly Slice DeletedRangesBucketAndEtagSlice;
+        private static readonly Slice AllConflictedDocsEtagsSlice;
+        private static readonly Slice AllRevisionsEtagsSlice;
+        private const string AttachmentsMetadata = "AttachmentsMetadata";
+
+
+        static From50002()
+        {
+            using (StorageEnvironment.GetStaticContext(out var ctx))
+            {
+                Slice.From(ctx, "CountersBucketAndEtag", ByteStringType.Immutable, out CountersBucketAndEtagSlice);
+                Slice.From(ctx, "DocsBucketAndEtag", ByteStringType.Immutable, out DocsBucketAndEtagSlice);
+                Slice.From(ctx, "TombstonesBucketAndEtag", ByteStringType.Immutable, out TombstonesBucketAndEtagSlice);
+                Slice.From(ctx, "ConflictsBucketAndEtag", ByteStringType.Immutable, out ConflictsBucketAndEtagSlice);
+                Slice.From(ctx, "AllConflictedDocsEtags", ByteStringType.Immutable, out AllConflictedDocsEtagsSlice);
+                Slice.From(ctx, "RevisionsBucketAndEtag", ByteStringType.Immutable, out RevisionsBucketAndEtagSlice);
+                Slice.From(ctx, "AllRevisionsEtags", ByteStringType.Immutable, out AllRevisionsEtagsSlice);
+                Slice.From(ctx, "AttachmentsBucketAndEtag", ByteStringType.Immutable, out AttachmentsBucketAndEtagSlice);
+                Slice.From(ctx, "AttachmentsEtag", ByteStringType.Immutable, out AttachmentsEtagSlice);
+                Slice.From(ctx, "TimeSeriesBucketAndEtag", ByteStringType.Immutable, out TimeSeriesBucketAndEtagSlice);
+                Slice.From(ctx, "DeletedRangesBucketAndEtag", ByteStringType.Immutable, out DeletedRangesBucketAndEtagSlice);
+            }
+        }
+
+        public bool Update(UpdateStep step)
+        {
+            InsertIndexValuesFor(step, DocumentsStorage.DocsSchema, DocsBucketAndEtagSlice);
+            InsertIndexValuesFor(step, DocumentsStorage.TombstonesSchema, TombstonesBucketAndEtagSlice);
+            InsertIndexValuesFor(step, RevisionsStorage.CompressedRevisionsSchema, RevisionsBucketAndEtagSlice);
+            InsertIndexValuesFor(step, CountersStorage.CountersSchema, CountersBucketAndEtagSlice);
+            InsertIndexValuesFor(step, TimeSeriesStorage.TimeSeriesSchema, TimeSeriesBucketAndEtagSlice);
+            InsertIndexValuesFor(step, TimeSeriesStorage.DeleteRangesSchema, DeletedRangesBucketAndEtagSlice);
+
+            InsertIndexValuesFor(step, ConflictsStorage.ConflictsSchema, ConflictsBucketAndEtagSlice,
+                fixedSizeIndex: ConflictsStorage.ConflictsSchema.FixedSizeIndexes[AllConflictedDocsEtagsSlice]);
+
+            InsertIndexValuesFor(step, AttachmentsStorage.AttachmentsSchema, AttachmentsBucketAndEtagSlice,
+                tableName: AttachmentsMetadata,
+                fixedSizeIndex: AttachmentsStorage.AttachmentsSchema.FixedSizeIndexes[AttachmentsEtagSlice]);
+
+            return true;
+        }
+
+
+        public static void InsertIndexValuesFor(UpdateStep step, TableSchema schema, Slice indexName, string tableName = null, TableSchema.FixedSizeKeyIndexDef fixedSizeIndex = null)
+        {
+            var indexTree = step.WriteTx.ReadTree(indexName, RootObjectType.VariableSizeTree, isIndexTree: true);
+            if (indexTree != null)
+                return; // already processed by another schema-upgrade
+
+            indexTree = step.WriteTx.CreateTree(indexName, isIndexTree: true);
+            var indexDef = schema.DynamicKeyIndexes[indexName];
+            
+            bool done = false;
+            long skip = 0;
+
+            while (done == false)
+            {
+                var table = tableName == null
+                    ? new Table(schema, step.ReadTx)
+                    : step.ReadTx.OpenTable(schema, tableName);
+
+                var processedInCurrentTx = 0;
+
+                using (step.DocumentsStorage.ContextPool.AllocateOperationContext(out DocumentsOperationContext context))
+                {
+                    context.TransactionMarkerOffset = (short)step.WriteTx.LowLevelTransaction.Id;
+
+                    var commit = false;
+
+                    var enumerable = fixedSizeIndex == null
+                        ? table.SeekByPrimaryKey(Slices.BeforeAllKeys, skip: skip)
+                        : table.SeekForwardFrom(fixedSizeIndex, 0, skip);
+
+                    foreach (var tvh in enumerable)
+                    {
+                        if (processedInCurrentTx >= NumberOfItemsToMigrateInSingleTransaction ||
+                            context.AllocatedMemory >= MaxSizeToMigrateInSingleTransaction)
+                        {
+                            commit = true;
+                            skip += processedInCurrentTx;
+                            break;
+                        }
+
+                        var value = tvh.Reader;
+                        using (indexDef.GetValue(step.WriteTx.Allocator, ref value, out Slice val))
+                        {
+                            var index = new FixedSizeTree(step.WriteTx.LowLevelTransaction, indexTree, val, 0, isIndexTree: true);
+                            index.Add(value.Id);
+                        }
+
+                        processedInCurrentTx++;
+                    }
+
+                    if (commit)
+                    {
+                        step.Commit(context);
+                        step.RenewTransactions();
+                        continue;
+                    }
+
+                    done = true;
+                }
+            }
+        }
+    }
+}

--- a/src/Voron/Data/Tables/Table.cs
+++ b/src/Voron/Data/Tables/Table.cs
@@ -1412,6 +1412,9 @@ namespace Voron.Data.Tables
         {
             var pk = _schema.Key;
             var tree = GetTree(pk);
+            if (tree == null)
+                yield break;
+
             using (var it = tree.Iterate(true))
             {
                 if (it.Seek(value) == false)

--- a/test/FastTests/Issues/RavenDB-14525.cs
+++ b/test/FastTests/Issues/RavenDB-14525.cs
@@ -45,7 +45,7 @@ namespace FastTests.Issues
                 using (documentDatabase.DocumentsStorage.ContextPool.AllocateOperationContext(out DocumentsOperationContext context))
                 using (context.OpenReadTransaction())
                 {
-                    var collections = context.Transaction.InnerTransaction.OpenTable(DocumentsStorage.CollectionsSchema, DocumentsStorage.CollectionsSlice);
+                    var collections = context.Transaction.InnerTransaction.OpenTable(DocumentsStorage.CollectionsSchema, Raven.Server.Documents.Schemas.Collections.CollectionsSlice);
                     Assert.Equal(1, collections.NumberOfEntries);
                 }
             }

--- a/test/SlowTests/Issues/RavenDB-13468.cs
+++ b/test/SlowTests/Issues/RavenDB-13468.cs
@@ -92,8 +92,6 @@ namespace SlowTests.Issues
 
                         }
                     }
-                    WaitForUserToContinueTheTest(store);
-
                 }
 
             }

--- a/test/SlowTests/Issues/RavenDB-8451.cs
+++ b/test/SlowTests/Issues/RavenDB-8451.cs
@@ -16,6 +16,7 @@ using Voron;
 using Voron.Recovery;
 using Xunit;
 using Xunit.Abstractions;
+using static Raven.Server.Documents.Schemas.Attachments;
 
 namespace SlowTests.Issues
 {
@@ -141,9 +142,9 @@ namespace SlowTests.Issues
                         using (documentDatabase.DocumentsStorage.ContextPool.AllocateOperationContext(out DocumentsOperationContext context))
                         using (context.OpenReadTransaction())
                         {
-                            var table = context.Transaction.InnerTransaction.OpenTable(AttachmentsStorage.AttachmentsSchema, AttachmentsStorage.AttachmentsMetadataSlice);
+                            var table = context.Transaction.InnerTransaction.OpenTable(AttachmentsStorage.AttachmentsSchema, AttachmentsMetadataSlice);
                             var count = table.NumberOfEntries;
-                            var tree = context.Transaction.InnerTransaction.CreateTree(AttachmentsStorage.AttachmentsSlice);
+                            var tree = context.Transaction.InnerTransaction.CreateTree(AttachmentsSlice);
                             var streamsCount = tree.State.NumberOfEntries;
                             msg.AppendLine($"count={count}, streamsCount={streamsCount}");
 

--- a/tools/Voron.Recovery/Recovery.cs
+++ b/tools/Voron.Recovery/Recovery.cs
@@ -36,6 +36,7 @@ using Voron.Data.Tables;
 using Voron.Exceptions;
 using Voron.Impl.Paging;
 using static System.String;
+using static Raven.Server.Documents.Schemas.Counters;
 using static Voron.Data.BTrees.Tree;
 using Constants = Voron.Global.Constants;
 
@@ -1448,7 +1449,7 @@ namespace Voron.Recovery
                 {
                     if (_logger.IsInfoEnabled)
                     {
-                        using (var key = DocumentsStorage.TableValueToString(context, (int)CountersStorage.CountersTable.CounterKey, ref tvr))
+                        using (var key = DocumentsStorage.TableValueToString(context, (int)CountersTable.CounterKey, ref tvr))
                         {
                             _logger.Info(
                                 $"Found counter-group item (key = '{key}') with counter-data document that is missing '{CountersStorage.Values}' property.");


### PR DESCRIPTION
### Issue link

https://issues.hibernatingrhinos.com/issue/RavenDB-18409

### Additional description

- added schema upgrade from 52 to 60, which will insert index-values to the new 'BucketAndEtag' index that was added to  database related table schemas
- moved all database related table-schemas to dedicated static classes and spited the schemas to 2 versions (`base` and `base60`), with `Current` property pointing to the latest version
-  schema upgraders will use a specific table-schema version,  all other places will use the `Current` property
- these changes fix the NREs that we had in schema-upgrade related tests
- still missing new tests for this, created separate ticket : https://issues.hibernatingrhinos.com/issue/RavenDB-18448

### Type of change

- Bug fix
- New feature

### How risky is the change?

- Moderate 

### Backward compatibility

- Not relevant

### Is it platform specific issue?

- No

### Documentation update

- No documentation update is needed 

### Testing 

- It has been verified by manual testing

### Is there any existing behavior change of other features due to this change?

- No

### UI work

- No UI work is needed
