### PR TITLE
RavenDB-18422 Avoid using @sql-keys in the metadata in favor of Sql-K…

### DIFF
--- a/src/Raven.Server/SqlMigration/Model/SqlMigrationDocument.cs
+++ b/src/Raven.Server/SqlMigration/Model/SqlMigrationDocument.cs
@@ -26,7 +26,7 @@ namespace Raven.Server.SqlMigration.Model
             {
                 [Constants.Documents.Metadata.Collection] = collectionName,
                 [Constants.Documents.Metadata.Id] = id,
-                ["@sql-keys"] = SpecialColumnsValues
+                ["Sql-Keys-Columns"] = SpecialColumnsValues
             };
             Collection = collectionName;
         }


### PR DESCRIPTION
…eys-Columns because @ metadata properties are reserved

### Issue link

https://issues.hibernatingrhinos.com/issue/RavenDB-18422 

### Additional description

The `@sql-keys` is using the reserved `@` metadata property. Changing this to a `Sql-Keys-Columns` metadata property.

### Type of change

- Regression bug fix

### How risky is the change?

- Low 

### Backward compatibility

- Ensured. Please explain how has it been implemented?

### Is it platform specific issue?

- No

### Documentation update

- This change requires a documentation update. Please mark the issue on YouTrack using `Documentation Required` tag.

### Testing 

- It has been verified by manual testing

### Is there any existing behavior change of other features due to this change?

- No

### UI work

- No UI work is needed
