### PR TITLE
RavenDB-17993 show only refresh btn when database has error and fails…

### DIFF
--- a/src/Raven.Studio/wwwroot/App/views/resources/databases.html
+++ b/src/Raven.Studio/wwwroot/App/views/resources/databases.html
@@ -232,13 +232,14 @@
                             </span>
                             <div class="actions">
                                 <a class="btn btn-default" href="#" title="Manage the Database Group"
-                                   data-bind="css: { 'disabled': !canNavigateToDatabase() || isBeingDeleted() }, 
+                                   data-bind="css: { 'disabled': isBeingDeleted() }, visible: canNavigateToDatabase(),
                                               attr: { href: $root.createManageDbGroupUrlObsevable($data), target: $root.createIsLocalDatabaseObservable(name)() ? undefined : '_blank' }">
                                     <i class="icon-manage-dbgroup"></i>
                                     <span>Manage group</span>
                                 </a>
                                 <div class="btn-group">
-                                    <button class="btn btn-default" data-bind="click: $root.toggleDatabase, visible: $root.accessManager.canDisableEnableDatabase,
+                                    <button class="btn btn-default" data-bind="click: $root.toggleDatabase,
+                                                                    visible: $root.accessManager.canDisableEnableDatabase && canNavigateToDatabase(),
                                                                     css: { 'btn-spinner': inProgressAction },
                                                                     disable: isBeingDeleted() || inProgressAction()">
                                         <span data-bind="visible: inProgressAction(), text: inProgressAction()"></span>
@@ -289,14 +290,17 @@
                                     <i class="icon-refresh-stats"></i>
                                 </button>
                                 <div class="btn-group" data-bind="visible: $root.accessManager.canDelete">
-                                    <button class="btn" data-bind="click: $root.deleteDatabase, disable: isBeingDeleted() || lockMode() !== 'Unlock',
+                                    <button class="btn" data-bind="click: $root.deleteDatabase,
+                                                                   visible: canNavigateToDatabase,
+                                                                   disable: isBeingDeleted() || lockMode() !== 'Unlock',
                                                                    css: { 'btn-danger': lockMode() === 'Unlock', 'btn-default': lockMode() !== 'Unlock', 'btn-spinner': isBeingDeleted() || _.includes($root.spinners.localLockChanges(), name) },
                                                                    attr: { title: lockMode() === 'Unlock' ? 'Remove database' : 'Database cannot be deleted because of the set lock mode' }">
                                         <i class="icon-trash" data-bind="visible: lockMode() === 'Unlock'"></i>
                                         <i class="icon-trash-cutout icon-addon-cancel" data-bind="visible: lockMode() === 'PreventDeletesIgnore'"></i>
                                         <i class="icon-trash-cutout icon-addon-exclamation" data-bind="visible: lockMode() === 'PreventDeletesError'"></i>
                                     </button>
-                                    <button type="button" class="btn dropdown-toggle" data-toggle="dropdown" aria-haspopup="true" data-bind="css: { 'btn-danger': lockMode() === 'Unlock', 'btn-default': lockMode() !== 'Unlock' }">
+                                    <button type="button" class="btn dropdown-toggle" data-toggle="dropdown" aria-haspopup="true"
+                                            data-bind="css: { 'btn-danger': lockMode() === 'Unlock', 'btn-default': lockMode() !== 'Unlock' }, visible: canNavigateToDatabase">
                                         <span class="caret"></span>
                                         <span class="sr-only">Toggle Dropdown</span>
                                     </button>


### PR DESCRIPTION
… to load

### Issue link
https://issues.hibernatingrhinos.com/issue/RavenDB-17993

### Additional description
Show only the refresh btn when db has error and fails to load

### Type of change
- Bug fix

### How risky is the change?
- Low 

### Backward compatibility
- Non breaking change

### Is it platform specific issue?
- No

### Documentation update
- No documentation update is needed 

### Testing 
- It has been verified by manual testing

### Is there any existing behavior change of other features due to this change?
- No

### UI work
- No UI work is needed
