### PR TITLE
RavenDB-18358 fix failing test

### DIFF
--- a/src/Raven.Server/Documents/ShardedTcpHandlers/ShardedSubscriptionConnection.cs
+++ b/src/Raven.Server/Documents/ShardedTcpHandlers/ShardedSubscriptionConnection.cs
@@ -93,7 +93,7 @@ namespace Raven.Server.Documents.ShardedTcpHandlers
             {
                 DatabaseName = $"for sharded database '{Database}' on '{_serverStore.NodeTag}'",
                 ClientType = $"'client worker' with IP '{TcpConnection.TcpClient.Client.RemoteEndPoint}'",
-                SubscriptionType = $"sharded subscription '{_options.SubscriptionName}', id '{SubscriptionId}'"
+                SubscriptionType = $"sharded subscription '{_options?.SubscriptionName}', id '{SubscriptionId}'"
             };
         }
 

--- a/src/Raven.Server/Documents/TcpHandlers/SubscriptionConnection.cs
+++ b/src/Raven.Server/Documents/TcpHandlers/SubscriptionConnection.cs
@@ -120,7 +120,6 @@ namespace Raven.Server.Documents.TcpHandlers
 
         private async Task InitAsync()
         {
-            await ParseSubscriptionOptionsAsync();
             var message = CreateStatusMessage(ConnectionStatus.Create);
             AddToStatusDescription(message);
             if (_logger.IsInfoEnabled)
@@ -264,6 +263,8 @@ namespace Raven.Server.Documents.TcpHandlers
 
                 try
                 {
+                    await ParseSubscriptionOptionsAsync();
+
                     if (TcpConnection.DocumentDatabase.SubscriptionStorage.TryEnterSemaphore() == false)
                     {
                         throw new SubscriptionClosedException(
@@ -1140,7 +1141,7 @@ namespace Raven.Server.Documents.TcpHandlers
             var message = GetDefault();
             message.DatabaseName = $"{message.DatabaseName} on '{_serverStore.NodeTag}'";
             message.ClientType = $"{message.ClientType} with IP '{TcpConnection.TcpClient.Client.RemoteEndPoint}'";
-            message.SubscriptionType = $"{message.SubscriptionType} '{_options.SubscriptionName}', id '{SubscriptionId}'";
+            message.SubscriptionType = $"{message.SubscriptionType} '{_options?.SubscriptionName}', id '{SubscriptionId}'";
 
             return message;
         }


### PR DESCRIPTION
### Issue link

https://issues.hibernatingrhinos.com/issue/RavenDB-18358

### Additional description

Try to parse the options to get the name, but still we can fail even earlier so we need to protect against `null` 

### Type of change

- Bug fix

### How risky is the change?

- Low 

### Backward compatibility

- Not relevant

### Is it platform specific issue?

- No

### Documentation update

- No documentation update is needed 

### Testing 

- Existing tests cover this

### Is there any existing behavior change of other features due to this change?

- No

### UI work

- No UI work is needed
