### PR TITLE
RavenDB-18420: Reschedule Backup Timer If DocumentDatabase Failed To Load

### DIFF
--- a/src/Raven.Server/Documents/DatabasesLandlord.cs
+++ b/src/Raven.Server/Documents/DatabasesLandlord.cs
@@ -39,13 +39,14 @@ namespace Raven.Server.Documents
         private readonly ConcurrentDictionary<string, Timer> _wakeupTimers = new ConcurrentDictionary<string, Timer>();
 
         public readonly ResourceCache<DocumentDatabase> DatabasesCache = new ResourceCache<DocumentDatabase>();
-        private readonly TimeSpan _concurrentDatabaseLoadTimeout;
         private readonly Logger _logger;
-        private readonly SemaphoreSlim _databaseSemaphore;
         private readonly ServerStore _serverStore;
 
         // used in ServerWideBackupStress
         internal bool SkipShouldContinueDisposeCheck = false;
+        internal SemaphoreSlim _databaseSemaphore;
+        internal TimeSpan _concurrentDatabaseLoadTimeout;
+        internal int _dueTimeOnRetry = 60_000;
 
         public DatabasesLandlord(ServerStore serverStore)
         {
@@ -79,6 +80,7 @@ namespace Raven.Server.Documents
             internal int? HoldDocumentDatabaseCreation = null;
             internal bool PreventedRehabOfIdleDatabase = false;
             internal Action<DocumentDatabase> OnBeforeDocumentDatabaseInitialization;
+            internal ManualResetEventSlim RescheduleDatabaseWakeupMre = null;
         }
 
         private async Task HandleClusterDatabaseChanged(string databaseName, long index, string type, ClusterDatabaseChangeType changeType)
@@ -1039,7 +1041,20 @@ namespace Raven.Server.Documents
                     if (_serverStore.ServerShutdown.IsCancellationRequested)
                         return;
 
-                    TryGetOrCreateResourceStore(name, wakeup);
+                    _ = TryGetOrCreateResourceStore(name, wakeup).ContinueWith(t =>
+                          {
+                              var ex = t.Exception.ExtractSingleInnerException();
+                              if (ex is DatabaseConcurrentLoadTimeoutException e)
+                              {
+                                  // database failed to load, retry after 1 min
+                                  ForTestingPurposes?.RescheduleDatabaseWakeupMre?.Set();
+
+                                  if (_logger.IsInfoEnabled)
+                                      _logger.Info($"Failed to start database '{name}' on timer, will retry the wakeup in '{_dueTimeOnRetry}' ms", e);
+
+                                  RescheduleDatabaseWakeup(name, milliseconds: _dueTimeOnRetry, wakeup);
+                              }
+                          }, TaskContinuationOptions.OnlyOnFaulted);
                 }
             }
             catch

--- a/test/StressTests/Issues/RavenDB_18420.cs
+++ b/test/StressTests/Issues/RavenDB_18420.cs
@@ -1,0 +1,91 @@
+﻿using System;
+using System.Collections.Generic;
+using System.Threading;
+using System.Threading.Tasks;
+using FastTests;
+using Raven.Client.Documents.Operations.Backups;
+using Raven.Client.ServerWide.Operations.Configuration;
+using Raven.Server.Config;
+using Xunit;
+using Xunit.Abstractions;
+
+namespace StressTests.Issues;
+
+public class RavenDB_18420 : RavenTestBase
+{
+    public RavenDB_18420(ITestOutputHelper output) : base(output)
+    {
+
+    }
+    [Fact]
+    public async Task ShouldRescheduleBackupTimerIfDocumentDatabaseFailedToLoad()
+    {
+        var db2 = GetDatabaseName();
+        using var server = GetNewServer(new ServerCreationOptions
+        {
+            CustomSettings = new Dictionary<string, string>
+            {
+                [RavenConfiguration.GetKey(x => x.Databases.MaxIdleTime)] = "10",
+                [RavenConfiguration.GetKey(x => x.Databases.FrequencyToCheckForIdle)] = "3",
+                [RavenConfiguration.GetKey(x => x.Core.RunInMemory)] = "false",
+            }
+        });
+        server.ServerStore.DatabasesLandlord.SkipShouldContinueDisposeCheck = true;
+        try
+        {
+            var backupPath = NewDataPath(forceCreateDir: true);
+            using (var store = GetDocumentStore(new Options { Server = server, RunInMemory = false }))
+            {
+                Assert.Equal(1, WaitForValue(() => server.ServerStore.IdleDatabases.Count, 1, timeout: 60000, interval: 1000));
+                var putConfiguration = new ServerWideBackupConfiguration
+                {
+                    FullBackupFrequency = "*/1 * * * *",
+                    Disabled = true,
+                    LocalSettings = new LocalSettings { FolderPath = backupPath }
+                };
+
+                var result = await store.Maintenance.Server.SendAsync(new PutServerWideBackupConfigurationOperation(putConfiguration));
+                var serverWideConfiguration = await store.Maintenance.Server.SendAsync(new GetServerWideBackupConfigurationOperation(result.Name));
+                // update the backup configuration
+                putConfiguration.Name = serverWideConfiguration.Name;
+                putConfiguration.TaskId = serverWideConfiguration.TaskId;
+                putConfiguration.Disabled = false;
+
+                var old_databaseSemaphore = server.ServerStore.DatabasesLandlord._databaseSemaphore;
+                var old_concurrentDatabaseLoadTimeout = server.ServerStore.DatabasesLandlord._concurrentDatabaseLoadTimeout;
+                var old_dueTimeOnRetry = server.ServerStore.DatabasesLandlord._dueTimeOnRetry;
+                server.ServerStore.DatabasesLandlord._databaseSemaphore = new SemaphoreSlim(0);
+                server.ServerStore.DatabasesLandlord._concurrentDatabaseLoadTimeout = TimeSpan.Zero;
+                server.ServerStore.DatabasesLandlord._dueTimeOnRetry = 5000;
+
+                var mre = server.ServerStore.DatabasesLandlord.ForTestingPurposesOnly().RescheduleDatabaseWakeupMre = new ManualResetEventSlim();
+
+                // enable backup
+                await store.Maintenance.Server.SendAsync(new PutServerWideBackupConfigurationOperation(putConfiguration));
+
+                Assert.True(mre.Wait(TimeSpan.FromSeconds(65)));
+                server.ServerStore.DatabasesLandlord._databaseSemaphore = old_databaseSemaphore;
+                server.ServerStore.DatabasesLandlord._concurrentDatabaseLoadTimeout = old_concurrentDatabaseLoadTimeout;
+                server.ServerStore.DatabasesLandlord._dueTimeOnRetry = old_dueTimeOnRetry;
+
+                // db should wake up after dueTimeOnRetry is hit
+                Assert.Equal(0, WaitForValue(() => server.ServerStore.IdleDatabases.Count, 0, interval: 333));
+
+                PeriodicBackupStatus status = null;
+                var val = await WaitForValueAsync(async () =>
+                {
+                    var operation = new GetPeriodicBackupStatusOperation(putConfiguration.TaskId);
+                    status = (await store.Maintenance.SendAsync(operation)).Status;
+                    return status?.LastOperationId != null;
+                }, true, interval: 1000);
+                Assert.True(val);
+                Assert.NotNull(status);
+                Assert.NotNull(status.LastFullBackup);
+            }
+        }
+        finally
+        {
+            server.ServerStore.DatabasesLandlord.SkipShouldContinueDisposeCheck = false;
+        }
+    }
+}


### PR DESCRIPTION
### Issue link

https://issues.hibernatingrhinos.com/issue/RavenDB-18420

### Type of change

- Bug fix

### How risky is the change?

- Low 
### Backward compatibility

- Not relevant

### Testing 

- Tests have been added that prove the fix is effective or that the feature works
 - Internal classes added to the test class (e.g. entity or index definition classes) have the lowest possible access modifier (preferable `private`) 
- It has been verified by manual testing

### Is there any existing behavior change of other features due to this change?
- No
