### PR TITLE
RavenDB-18441 Upon Refresh: if document is viewed as 'collapsed' then…

### DIFF
--- a/src/Raven.Studio/typescript/viewmodels/database/documents/editDocument.ts
+++ b/src/Raven.Studio/typescript/viewmodels/database/documents/editDocument.ts
@@ -1082,7 +1082,7 @@ class editDocument extends viewModelBase {
 
                 this.displayDocumentChange(false);
                 
-                if (this.collapseDocsWhenOpening()) {
+                if (this.collapseDocsWhenOpening() || this.isDocumentCollapsed()) {
                     this.forceFold = true;
                 }
             });


### PR DESCRIPTION
… keep it collapsed, else keep it expanded

### Issue link
https://issues.hibernatingrhinos.com/issue/RavenDB-18441

### Additional description

The solution with this PR is:
Upon Refresh: If the document is viewed as 'collapsed' then keep it collapsed, else keep it expanded

### Type of change
- Bug fix

### How risky is the change?
- Low 

### Backward compatibility
- Non breaking change

### Is it platform specific issue?
- No

### Documentation update
- No documentation update is needed 

### Testing 
- It has been verified by manual testing

### Is there any existing behavior change of other features due to this change?
- No

### UI work
- No UI work is needed
