### PR TITLE
RavenDB-7070 Fixing not awaited tests that are run in parallel in StressTests. This caused occasional crashes due to unhandled exceptions.

### DIFF
--- a/test/StressTests/Issues/RavenDB-5763.cs
+++ b/test/StressTests/Issues/RavenDB-5763.cs
@@ -1,4 +1,5 @@
-﻿using System.Threading.Tasks;
+﻿using System;
+using System.Threading.Tasks;
 using FastTests;
 using SlowTests.Server.Replication;
 using Tests.Infrastructure;
@@ -16,11 +17,11 @@ namespace StressTests.Issues
         [Fact]
         public void Should_not_throw_timeout_and_out_of_memory()
         {
-            Parallel.For(0, 3, RavenTestHelper.DefaultParallelOptions, async _ =>
+            Parallel.For(0, 3, RavenTestHelper.DefaultParallelOptions, _ =>
             {
                 using (var store = new ReplicationTombstoneTests(Output))
                 {
-                    await store.Two_tombstones_should_replicate_in_master_master();
+                    store.Two_tombstones_should_replicate_in_master_master().Wait(TimeSpan.FromMinutes(10));
                 }
             });
         }

--- a/test/StressTests/Server/Replication/ExternalReplicationStressTests_NoDispose.cs
+++ b/test/StressTests/Server/Replication/ExternalReplicationStressTests_NoDispose.cs
@@ -25,11 +25,11 @@ namespace StressTests.Server.Replication
         {
             for (int i = 0; i < 10; i++)
             {
-                Parallel.For(0, 3, RavenTestHelper.DefaultParallelOptions, async _ =>
+                Parallel.For(0, 3, RavenTestHelper.DefaultParallelOptions, _ =>
                 {
                     using (var test = new ExternalReplicationTests(Output))
                     {
-                        await test.ExternalReplicationShouldWorkWithSmallTimeoutStress(20000);
+                        test.ExternalReplicationShouldWorkWithSmallTimeoutStress(20000).Wait(TimeSpan.FromMinutes(10));
                     }
                 });
             }


### PR DESCRIPTION
### Issue link

https://issues.hibernatingrhinos.com/issue/RavenDB-...

### Additional description

Fixes occasional crashes during StressTests: `The active test run was aborted. Reason: Test host process crashed : Unhandled exception. Unhandled exception. Raven.Client.Exceptions.RavenException: System.TimeoutException: Waited for 00:00:15 but the command was not applied in this time.`

### Type of change

- Test fix

### How risky is the change?

- Low 

### Backward compatibility

- Not relevant

### Is it platform specific issue?

- No

### Documentation update

- No documentation update is needed 

### Testing 

- Will be verified by existing tests

### Is there any existing behavior change of other features due to this change?

- No

### UI work

- No UI work is needed
