### PR TITLE
RavenDB-18413 Timings aren't filled after ToQueryable

### DIFF
--- a/src/Raven.Client/Documents/Queries/Timings/QueryTimings.cs
+++ b/src/Raven.Client/Documents/Queries/Timings/QueryTimings.cs
@@ -10,6 +10,8 @@ namespace Raven.Client.Documents.Queries.Timings
 
         public IDictionary<string, QueryTimings> Timings { get; set; }
 
+        internal bool ShouldBeIncluded { get; set; }
+
         public void FillFromBlittableJson(BlittableJsonReaderObject json)
         {
             var timings = DocumentConventions.Default.Serialization.DefaultConverter.FromBlittable<QueryTimings>(json, "query/timings");

--- a/src/Raven.Client/Documents/Session/AbstractDocumentQuery.Timings.cs
+++ b/src/Raven.Client/Documents/Session/AbstractDocumentQuery.Timings.cs
@@ -4,19 +4,14 @@ namespace Raven.Client.Documents.Session
 {
     public abstract partial class AbstractDocumentQuery<T, TSelf>
     {
-        protected QueryTimings QueryTimings;
+        protected QueryTimings QueryTimings = new QueryTimings();
 
         protected FlagHolder ShouldIncludeTimings = new FlagHolder { Value = false };
 
         public void IncludeTimings(out QueryTimings timings)
         {
-            if (QueryTimings == null)
-            {
-                QueryTimings = new QueryTimings();
-            }
-            timings = QueryTimings;
-
             ShouldIncludeTimings.Value = true;
+            timings = QueryTimings;
         }
     }
 

--- a/src/Raven.Client/Documents/Session/AbstractDocumentQuery.Timings.cs
+++ b/src/Raven.Client/Documents/Session/AbstractDocumentQuery.Timings.cs
@@ -6,15 +6,22 @@ namespace Raven.Client.Documents.Session
     {
         protected QueryTimings QueryTimings;
 
+        protected FlagHolder ShouldIncludeTimings = new FlagHolder { Value = false };
+
         public void IncludeTimings(out QueryTimings timings)
         {
-            if (QueryTimings != null)
+            if (QueryTimings == null)
             {
-                timings = QueryTimings;
-                return;
+                QueryTimings = new QueryTimings();
             }
+            timings = QueryTimings;
 
-            QueryTimings = timings = new QueryTimings();
+            ShouldIncludeTimings.Value = true;
         }
+    }
+
+    public class FlagHolder
+    {
+        public bool Value { get; set; }
     }
 }

--- a/src/Raven.Client/Documents/Session/AbstractDocumentQuery.Timings.cs
+++ b/src/Raven.Client/Documents/Session/AbstractDocumentQuery.Timings.cs
@@ -6,17 +6,10 @@ namespace Raven.Client.Documents.Session
     {
         protected QueryTimings QueryTimings = new QueryTimings();
 
-        protected FlagHolder ShouldIncludeTimings = new FlagHolder { Value = false };
-
         public void IncludeTimings(out QueryTimings timings)
         {
-            ShouldIncludeTimings.Value = true;
+            QueryTimings.ShouldBeIncluded = true;
             timings = QueryTimings;
         }
-    }
-
-    public class FlagHolder
-    {
-        public bool Value { get; set; }
     }
 }

--- a/src/Raven.Client/Documents/Session/AbstractDocumentQuery.cs
+++ b/src/Raven.Client/Documents/Session/AbstractDocumentQuery.cs
@@ -1250,7 +1250,7 @@ Use session.Query<T>() instead of session.Advanced.DocumentQuery<T>. The session
             if (DocumentIncludes.Count == 0 &&
                 HighlightingTokens.Count == 0 &&
                 ExplanationToken == null &&
-                !ShouldIncludeTimings.Value &&
+                QueryTimings.ShouldBeIncluded == false &&
                 CounterIncludesTokens == null &&
                 RevisionsIncludesTokens == null &&
                 TimeSeriesIncludesTokens == null &&
@@ -1286,7 +1286,7 @@ Use session.Query<T>() instead of session.Advanced.DocumentQuery<T>. The session
                 ExplanationToken.WriteTo(queryText);
             }
 
-            if (ShouldIncludeTimings.Value)
+            if (QueryTimings.ShouldBeIncluded)
             {
                 if (first == false)
                     queryText.Append(",");

--- a/src/Raven.Client/Documents/Session/AbstractDocumentQuery.cs
+++ b/src/Raven.Client/Documents/Session/AbstractDocumentQuery.cs
@@ -1250,7 +1250,7 @@ Use session.Query<T>() instead of session.Advanced.DocumentQuery<T>. The session
             if (DocumentIncludes.Count == 0 &&
                 HighlightingTokens.Count == 0 &&
                 ExplanationToken == null &&
-                QueryTimings == null &&
+                !ShouldIncludeTimings.Value &&
                 CounterIncludesTokens == null &&
                 RevisionsIncludesTokens == null &&
                 TimeSeriesIncludesTokens == null &&
@@ -1286,7 +1286,7 @@ Use session.Query<T>() instead of session.Advanced.DocumentQuery<T>. The session
                 ExplanationToken.WriteTo(queryText);
             }
 
-            if (QueryTimings != null)
+            if (ShouldIncludeTimings.Value)
             {
                 if (first == false)
                     queryText.Append(",");

--- a/src/Raven.Client/Documents/Session/DocumentQuery.cs
+++ b/src/Raven.Client/Documents/Session/DocumentQuery.cs
@@ -1198,7 +1198,6 @@ namespace Raven.Client.Documents.Session
                 DisableCaching = DisableCaching,
                 ProjectionBehavior = queryData?.ProjectionBehavior ?? ProjectionBehavior,
                 QueryTimings = QueryTimings,
-                ShouldIncludeTimings = ShouldIncludeTimings,
                 Explanations = Explanations,
                 ExplanationToken = ExplanationToken,
                 IsIntersect = IsIntersect,

--- a/src/Raven.Client/Documents/Session/DocumentQuery.cs
+++ b/src/Raven.Client/Documents/Session/DocumentQuery.cs
@@ -1213,6 +1213,7 @@ namespace Raven.Client.Documents.Session
 
             var queryStatistics = new QueryStatistics();
             var highlightings = new LinqQueryHighlightings();
+            IncludeTimings(out _);
 
             var ravenQueryInspector = new RavenQueryInspector<T>();
             var ravenQueryProvider = new RavenQueryProvider<T>(

--- a/src/Raven.Client/Documents/Session/DocumentQuery.cs
+++ b/src/Raven.Client/Documents/Session/DocumentQuery.cs
@@ -1214,7 +1214,6 @@ namespace Raven.Client.Documents.Session
 
             var queryStatistics = new QueryStatistics();
             var highlightings = new LinqQueryHighlightings();
-            QueryTimings = new QueryTimings();
 
             var ravenQueryInspector = new RavenQueryInspector<T>();
             var ravenQueryProvider = new RavenQueryProvider<T>(

--- a/src/Raven.Client/Documents/Session/DocumentQuery.cs
+++ b/src/Raven.Client/Documents/Session/DocumentQuery.cs
@@ -1198,6 +1198,7 @@ namespace Raven.Client.Documents.Session
                 DisableCaching = DisableCaching,
                 ProjectionBehavior = queryData?.ProjectionBehavior ?? ProjectionBehavior,
                 QueryTimings = QueryTimings,
+                ShouldIncludeTimings = ShouldIncludeTimings,
                 Explanations = Explanations,
                 ExplanationToken = ExplanationToken,
                 IsIntersect = IsIntersect,
@@ -1213,7 +1214,7 @@ namespace Raven.Client.Documents.Session
 
             var queryStatistics = new QueryStatistics();
             var highlightings = new LinqQueryHighlightings();
-            IncludeTimings(out _);
+            QueryTimings = new QueryTimings();
 
             var ravenQueryInspector = new RavenQueryInspector<T>();
             var ravenQueryProvider = new RavenQueryProvider<T>(

--- a/test/SlowTests/Issues/RavenDB-18413.cs
+++ b/test/SlowTests/Issues/RavenDB-18413.cs
@@ -1,0 +1,52 @@
+﻿using System;
+using System.Collections.Generic;
+using System.Diagnostics;
+using System.Linq;
+using System.Threading;
+using System.Threading.Tasks;
+using FastTests;
+using Raven.Client;
+using Raven.Client.Documents;
+using Raven.Client.Documents.Operations.ConnectionStrings;
+using Raven.Client.Documents.Operations.ETL;
+using Raven.Client.Documents.Queries.Timings;
+using Raven.Server;
+using Raven.Server.Documents;
+using Raven.Server.Documents.TimeSeries;
+using Raven.Server.ServerWide.Context;
+using Raven.Tests.Core.Utils.Entities;
+using Raven.Server.Config;
+using Sparrow.Json;
+using Sparrow.Json.Parsing;
+using Tests.Infrastructure;
+using Xunit;
+using Xunit.Abstractions;
+
+namespace SlowTests.Issues
+{
+    public class RavenDB_18413 : RavenTestBase
+    {
+        public RavenDB_18413(ITestOutputHelper output) : base(output)
+        {
+        }
+
+        [Fact]
+        public async Task ToQueryableTimings()
+        {
+            using (var store = GetDocumentStore())
+            {
+                using (var newSession = store.OpenSession())
+                {
+                    QueryTimings timings = null;
+                    newSession.Advanced.DocumentQuery<User>()
+                        .ToQueryable()
+                        .Customize(x => x.Timings(out timings)).ToList();
+
+                    Assert.NotNull(timings.Timings);
+                }
+            }
+        }
+
+    }
+
+}

--- a/test/SlowTests/Issues/RavenDB-18413.cs
+++ b/test/SlowTests/Issues/RavenDB-18413.cs
@@ -31,7 +31,7 @@ namespace SlowTests.Issues
         }
 
         [Fact]
-        public async Task ToQueryableTimings()
+        public void ToQueryableTimings()
         {
             using (var store = GetDocumentStore())
             {
@@ -48,7 +48,7 @@ namespace SlowTests.Issues
         }
 
         [Fact]
-        public async Task ToQueryableTimingsOutTimings()
+        public void ToQueryableTimingsOutTimings()
         {
             using (var store = GetDocumentStore())
             {

--- a/test/SlowTests/Issues/RavenDB-18413.cs
+++ b/test/SlowTests/Issues/RavenDB-18413.cs
@@ -47,6 +47,25 @@ namespace SlowTests.Issues
             }
         }
 
+        [Fact]
+        public async Task ToQueryableTimingsOutTimings()
+        {
+            using (var store = GetDocumentStore())
+            {
+                using (var newSession = store.OpenSession())
+                {
+                    QueryTimings timings = null;
+                    newSession.Advanced.DocumentQuery<User>()
+                        .Timings(out var timings2)
+                        .ToQueryable()
+                        .Customize(x => x.Timings(out timings)).ToList();
+
+                    Assert.NotNull(timings.Timings);
+                    Assert.Same(timings, timings2);
+                }
+            }
+        }
+
     }
 
 }


### PR DESCRIPTION
### Issue link

https://issues.hibernatingrhinos.com/issue/RavenDB-18413

### Additional description

Fixing timings aren't filled after ToQueryable

### Type of change

- Bug fix

### How risky is the change?

- Low

### Backward compatibility

- Not relevant

### Is it platform specific issue?

- No

### Documentation update

- No documentation update is needed 

### Testing 

- Tests have been added that prove the fix is effective or that the feature works

### Is there any existing behavior change of other features due to this change?

- No

### UI work

- No UI work is needed
