### PR TITLE
RavenDB-18455 - Error when trying to import a RavenFS file dump

### DIFF
--- a/Raven.Abstractions/Smuggler/SmugglerFilesApiBase.cs
+++ b/Raven.Abstractions/Smuggler/SmugglerFilesApiBase.cs
@@ -296,7 +296,7 @@ namespace Raven.Abstractions.Smuggler
             if (exceptionHappened != null)
                 throw exceptionHappened;
 
-            Operations.ShowProgress("Done with reading documents, total: {0}, lastEtag: {1}", totalCount, lastEtag);
+            Operations.ShowProgress("Done with reading files, total: {0}, lastEtag: {1}", totalCount, lastEtag);
             return lastEtag;
         }
 
@@ -445,7 +445,7 @@ namespace Raven.Abstractions.Smuggler
             if (exceptionHappened != null)
                 throw exceptionHappened;
 
-            Operations.ShowProgress("Done with reading documents, total: {0}, lastEtag: {1}", totalCount, lastEtag);
+            Operations.ShowProgress("Done with reading files, total: {0}, lastEtag: {1}", totalCount, lastEtag);
             return lastEtag;
         }
 
@@ -978,7 +978,7 @@ namespace Raven.Abstractions.Smuggler
             if (exceptionHappened != null)
                 throw exceptionHappened;
 
-            Operations.ShowProgress("Done with reading documents, total: {0}, lastEtag: {1}", totalFiles, lastEtag);
+            Operations.ShowProgress("Done with reading files, total: {0}, lastEtag: {1}", totalFiles, lastEtag);
             return lastEtag;
         }
     }

--- a/Raven.Abstractions/Util/PositionWrapperStream.cs
+++ b/Raven.Abstractions/Util/PositionWrapperStream.cs
@@ -13,7 +13,7 @@ namespace Raven.Abstractions.Util
         private readonly Stream wrapped;
         private readonly bool leaveOpen;
 
-        private int pos = 0;
+        private long pos = 0;
 
         public PositionWrapperStream(Stream wrapped, bool leaveOpen)
         {


### PR DESCRIPTION
### Issue link

https://issues.hibernatingrhinos.com/issue/RavenDB-18455

### Additional description

Fix an overflow in the `PositionWrapperStream`

### Type of change

- Bug fix
- 
### How risky is the change?

- Low 

### Testing 

- It has been verified by manual testing
