### PR TITLE
RavenDB-18379 - Allow to pin on going tasks to a mentor node

### DIFF
--- a/src/Raven.Client/Documents/Operations/Backups/PeriodicBackupConfiguration.cs
+++ b/src/Raven.Client/Documents/Operations/Backups/PeriodicBackupConfiguration.cs
@@ -17,6 +17,7 @@ namespace Raven.Client.Documents.Operations.Backups
         public long TaskId { get; set; }
         public bool Disabled { get; set; }
         public string MentorNode { get; set; }
+        public bool PinToMentorNode { get; set; }
         public RetentionPolicy RetentionPolicy { get; set; }
 
         /// <summary>
@@ -60,6 +61,11 @@ namespace Raven.Client.Documents.Operations.Backups
             return true;
         }
 
+        public bool IsPinnedToMentorNode()
+        {
+            return PinToMentorNode;
+        }
+
         public bool HasBackupFrequencyChanged(PeriodicBackupConfiguration other)
         {
             if (other == null)
@@ -81,6 +87,7 @@ namespace Raven.Client.Documents.Operations.Backups
             json[nameof(TaskId)] = TaskId;
             json[nameof(Disabled)] = Disabled;
             json[nameof(MentorNode)] = MentorNode;
+            json[nameof(PinToMentorNode)] = PinToMentorNode;
             json[nameof(FullBackupFrequency)] = FullBackupFrequency;
             json[nameof(IncrementalBackupFrequency)] = IncrementalBackupFrequency;
             json[nameof(RetentionPolicy)] = RetentionPolicy?.ToJson();

--- a/src/Raven.Client/Documents/Operations/ETL/EtlConfiguration.cs
+++ b/src/Raven.Client/Documents/Operations/ETL/EtlConfiguration.cs
@@ -121,6 +121,7 @@ namespace Raven.Client.Documents.Operations.ETL
                 [nameof(TaskId)] = TaskId,
                 [nameof(ConnectionStringName)] = ConnectionStringName,
                 [nameof(MentorNode)] = MentorNode,
+                [nameof(PinToMentorNode)] = PinToMentorNode,
                 [nameof(AllowEtlOnNonEncryptedChannel)] = AllowEtlOnNonEncryptedChannel,
                 [nameof(Transforms)] = new DynamicJsonArray(Transforms.Select(x => x.ToJson()))
             };

--- a/src/Raven.Client/Documents/Operations/ETL/EtlConfiguration.cs
+++ b/src/Raven.Client/Documents/Operations/ETL/EtlConfiguration.cs
@@ -121,7 +121,6 @@ namespace Raven.Client.Documents.Operations.ETL
                 [nameof(TaskId)] = TaskId,
                 [nameof(ConnectionStringName)] = ConnectionStringName,
                 [nameof(MentorNode)] = MentorNode,
-                [nameof(PinToMentorNode)] = PinToMentorNode,
                 [nameof(AllowEtlOnNonEncryptedChannel)] = AllowEtlOnNonEncryptedChannel,
                 [nameof(Transforms)] = new DynamicJsonArray(Transforms.Select(x => x.ToJson()))
             };

--- a/src/Raven.Client/Documents/Operations/ETL/EtlConfiguration.cs
+++ b/src/Raven.Client/Documents/Operations/ETL/EtlConfiguration.cs
@@ -19,6 +19,8 @@ namespace Raven.Client.Documents.Operations.ETL
         public string Name { get; set; }
 
         public string MentorNode { get; set; }
+        
+        public bool PinToMentorNode { get; set; }
 
         public abstract string GetDestination();
 
@@ -101,6 +103,11 @@ namespace Raven.Client.Documents.Operations.ETL
             return false;
         }
 
+        public bool IsPinnedToMentorNode()
+        {
+            return PinToMentorNode;
+        }
+
         public override string ToString()
         {
             return Name;
@@ -114,6 +121,7 @@ namespace Raven.Client.Documents.Operations.ETL
                 [nameof(TaskId)] = TaskId,
                 [nameof(ConnectionStringName)] = ConnectionStringName,
                 [nameof(MentorNode)] = MentorNode,
+                [nameof(PinToMentorNode)] = PinToMentorNode,
                 [nameof(AllowEtlOnNonEncryptedChannel)] = AllowEtlOnNonEncryptedChannel,
                 [nameof(Transforms)] = new DynamicJsonArray(Transforms.Select(x => x.ToJson()))
             };

--- a/src/Raven.Client/Documents/Operations/OngoingTasks/GetTaskInfoResult.cs
+++ b/src/Raven.Client/Documents/Operations/OngoingTasks/GetTaskInfoResult.cs
@@ -47,8 +47,8 @@ namespace Raven.Client.Documents.Operations.OngoingTasks
         public OngoingTaskConnectionStatus TaskConnectionStatus { get; set; }
         public string TaskName { get; set; }
         public string Error { get; set; }
-
         public string MentorNode { get; set; }
+        public bool PinToMentorNode { get; set; }
 
         public virtual DynamicJsonValue ToJson()
         {
@@ -61,6 +61,7 @@ namespace Raven.Client.Documents.Operations.OngoingTasks
                 [nameof(TaskConnectionStatus)] = TaskConnectionStatus,
                 [nameof(TaskName)] = TaskName,
                 [nameof(MentorNode)] = MentorNode,
+                [nameof(PinToMentorNode)] = PinToMentorNode,
                 [nameof(Error)] = Error
             };
         }

--- a/src/Raven.Client/Documents/Operations/OngoingTasks/GetTaskInfoResult.cs
+++ b/src/Raven.Client/Documents/Operations/OngoingTasks/GetTaskInfoResult.cs
@@ -60,6 +60,8 @@ namespace Raven.Client.Documents.Operations.OngoingTasks
                 [nameof(TaskState)] = TaskState,
                 [nameof(TaskConnectionStatus)] = TaskConnectionStatus,
                 [nameof(TaskName)] = TaskName,
+                [nameof(MentorNode)] = MentorNode,
+                [nameof(PinToMentorNode)] = PinToMentorNode,
                 [nameof(Error)] = Error
             };
         }
@@ -87,6 +89,7 @@ namespace Raven.Client.Documents.Operations.OngoingTasks
             json[nameof(SubscriptionName)] = SubscriptionName;
             json[nameof(SubscriptionId)] = SubscriptionId;
             json[nameof(MentorNode)] = MentorNode;
+            json[nameof(PinToMentorNode)] = PinToMentorNode;
             json[nameof(ChangeVectorForNextBatchStartingPoint)] = ChangeVectorForNextBatchStartingPoint;
             json[nameof(LastBatchAckTime)] = LastBatchAckTime;
             json[nameof(Disabled)] = Disabled;
@@ -181,6 +184,8 @@ namespace Raven.Client.Documents.Operations.OngoingTasks
             json[nameof(AccessName)] = AccessName;
             json[nameof(AllowedHubToSinkPaths)] = AllowedHubToSinkPaths;
             json[nameof(AllowedSinkToHubPaths)] = AllowedSinkToHubPaths;
+            json[nameof(MentorNode)] = MentorNode;
+            json[nameof(PinToMentorNode)] = PinToMentorNode;
             return json;
         }
     }

--- a/src/Raven.Client/Documents/Operations/OngoingTasks/GetTaskInfoResult.cs
+++ b/src/Raven.Client/Documents/Operations/OngoingTasks/GetTaskInfoResult.cs
@@ -60,8 +60,6 @@ namespace Raven.Client.Documents.Operations.OngoingTasks
                 [nameof(TaskState)] = TaskState,
                 [nameof(TaskConnectionStatus)] = TaskConnectionStatus,
                 [nameof(TaskName)] = TaskName,
-                [nameof(MentorNode)] = MentorNode,
-                [nameof(PinToMentorNode)] = PinToMentorNode,
                 [nameof(Error)] = Error
             };
         }

--- a/src/Raven.Client/Documents/Operations/Replication/ExternalReplicationBase.cs
+++ b/src/Raven.Client/Documents/Operations/Replication/ExternalReplicationBase.cs
@@ -28,6 +28,7 @@ namespace Raven.Client.Documents.Operations.Replication
         public string Name { get; set; }
         public string ConnectionStringName { get; set; }
         public string MentorNode { get; set; }
+        public bool PinToMentorNode { get; set; }
 
         [JsonDeserializationIgnore]
         internal RavenConnectionString ConnectionString; // this is in memory only
@@ -73,6 +74,7 @@ namespace Raven.Client.Documents.Operations.Replication
             json[nameof(TaskId)] = TaskId;
             json[nameof(Name)] = Name;
             json[nameof(MentorNode)] = MentorNode;
+            json[nameof(PinToMentorNode)] = PinToMentorNode;
             json[nameof(ConnectionStringName)] = ConnectionStringName;
             return json;
         }
@@ -139,6 +141,11 @@ namespace Raven.Client.Documents.Operations.Replication
         public bool IsResourceIntensive()
         {
             return false;
+        }
+
+        public bool IsPinnedToMentorNode()
+        {
+            return PinToMentorNode;
         }
     }
 }

--- a/src/Raven.Client/Documents/Operations/Replication/IExternalReplication.cs
+++ b/src/Raven.Client/Documents/Operations/Replication/IExternalReplication.cs
@@ -12,6 +12,8 @@ namespace Raven.Client.Documents.Operations.Replication
         string Name { get; set; }
 
         string MentorNode { get; set; }
+        
+        bool PinToMentorNode { get; set; }
 
         TimeSpan DelayReplicationFor { get; set; }
 

--- a/src/Raven.Client/Documents/Operations/Replication/PullReplicationDefinition.cs
+++ b/src/Raven.Client/Documents/Operations/Replication/PullReplicationDefinition.cs
@@ -16,6 +16,8 @@ namespace Raven.Client.Documents.Operations.Replication
 
         public string MentorNode;
 
+        public bool PinToMentorNode;
+        
         public PullReplicationMode Mode = PullReplicationMode.HubToSink;
 
         public string Name;
@@ -46,6 +48,7 @@ namespace Raven.Client.Documents.Operations.Replication
                 [nameof(TaskId)] = TaskId,
                 [nameof(Disabled)] = Disabled,
                 [nameof(MentorNode)] = MentorNode,
+                [nameof(PinToMentorNode)] = PinToMentorNode,
                 [nameof(DelayReplicationFor)] = DelayReplicationFor,
                 [nameof(Mode)] = Mode,
                 [nameof(WithFiltering)] = WithFiltering,
@@ -78,6 +81,7 @@ namespace Raven.Client.Documents.Operations.Replication
                 Name = request.PullReplicationSinkTaskName,
                 DelayReplicationFor = DelayReplicationFor,
                 MentorNode = MentorNode,
+                PinToMentorNode = PinToMentorNode,
                 TaskId = taskId
             };
         }

--- a/src/Raven.Client/Documents/Operations/Replication/PutPullReplicationAsHubOperation.cs
+++ b/src/Raven.Client/Documents/Operations/Replication/PutPullReplicationAsHubOperation.cs
@@ -20,6 +20,7 @@ namespace Raven.Client.Documents.Operations.Replication
             {
                 throw new ArgumentException($"'{nameof(name)}' must have value");
             }
+
             _pullReplicationDefinition = new PullReplicationDefinition(name);
         }
 

--- a/src/Raven.Client/Documents/Subscriptions/SubscriptionCriteria.cs
+++ b/src/Raven.Client/Documents/Subscriptions/SubscriptionCriteria.cs
@@ -18,6 +18,7 @@ namespace Raven.Client.Documents.Subscriptions
         public string ChangeVector { get; set; }
         public string MentorNode { get; set; }
         public bool Disabled { get; set; }
+        public bool PinToMentorNode { get; set; }
     }
 
     public class SubscriptionCreationOptions<T>
@@ -29,6 +30,8 @@ namespace Raven.Client.Documents.Subscriptions
         public Action<ISubscriptionIncludeBuilder<T>> Includes { get; set; }
         public string ChangeVector { get; set; }
         public string MentorNode { get; set; }
+        public bool PinToMentorNode { get; set; }
+
 
         public SubscriptionCreationOptions ToSubscriptionCreationOptions(DocumentConventions conventions)
         {
@@ -37,6 +40,7 @@ namespace Raven.Client.Documents.Subscriptions
                 Name = Name,
                 ChangeVector = ChangeVector,
                 MentorNode = MentorNode,
+                PinToMentorNode = PinToMentorNode,
                 Disabled = Disabled
             };
             return DocumentSubscriptions.CreateSubscriptionOptionsFromGeneric(conventions, 

--- a/src/Raven.Client/Documents/Subscriptions/SubscriptionState.cs
+++ b/src/Raven.Client/Documents/Subscriptions/SubscriptionState.cs
@@ -18,6 +18,7 @@ namespace Raven.Client.Documents.Subscriptions
         public long SubscriptionId { get; set; }
         public string SubscriptionName { get; set; }
         public string MentorNode { get; set; }
+        public bool PinToMentorNode { get; set; }
         public string NodeTag { get; set; }
         public DateTime? LastBatchAckTime { get; set; }  // Last time server made some progress with the subscriptions docs  
         public DateTime? LastClientConnectionTime { get; set; } // Last time any client has connected to server (connection dead or alive)
@@ -48,6 +49,11 @@ namespace Raven.Client.Documents.Subscriptions
             return false;
         }
 
+        public bool IsPinnedToMentorNode()
+        {
+            return PinToMentorNode;
+        }
+
         public virtual DynamicJsonValue ToJson()
         {
             return new DynamicJsonValue
@@ -57,6 +63,7 @@ namespace Raven.Client.Documents.Subscriptions
                 [nameof(SubscriptionId)] = SubscriptionId,
                 [nameof(SubscriptionName)] = SubscriptionName,
                 [nameof(MentorNode)] = MentorNode,
+                [nameof(PinToMentorNode)] = PinToMentorNode,
                 [nameof(NodeTag)] = NodeTag,
                 [nameof(LastBatchAckTime)] = LastBatchAckTime,
                 [nameof(LastClientConnectionTime)] = LastClientConnectionTime,

--- a/src/Raven.Client/ServerWide/DatabaseTopology.cs
+++ b/src/Raven.Client/ServerWide/DatabaseTopology.cs
@@ -29,12 +29,14 @@ namespace Raven.Client.ServerWide
         ulong GetTaskKey();
 
         string GetMentorNode();
-
+        
         string GetDefaultTaskName();
 
         string GetTaskName();
 
         bool IsResourceIntensive();
+
+        bool IsPinnedToMentorNode();
     }
 
     public interface IDatabaseTaskStatus
@@ -102,6 +104,11 @@ namespace Raven.Client.ServerWide
         }
 
         public bool IsResourceIntensive()
+        {
+            return false;
+        }
+
+        public bool IsPinnedToMentorNode()
         {
             return false;
         }
@@ -411,6 +418,9 @@ namespace Raven.Client.ServerWide
             if (mentorNode != null)
             {
                 if (Members.Contains(mentorNode))
+                    return mentorNode;
+                
+                if (AllNodes.Contains(mentorNode) && task.IsPinnedToMentorNode())
                     return mentorNode;
             }
 

--- a/src/Raven.Client/ServerWide/Operations/OngoingTasks/ServerWideExternalReplication.cs
+++ b/src/Raven.Client/ServerWide/Operations/OngoingTasks/ServerWideExternalReplication.cs
@@ -17,6 +17,8 @@ namespace Raven.Client.ServerWide.Operations.OngoingTasks
         public string Name { get; set; }
 
         public string MentorNode { get; set; }
+        
+        public bool PinToMentorNode { get; set; }
 
         public TimeSpan DelayReplicationFor { get; set; }
 
@@ -37,6 +39,7 @@ namespace Raven.Client.ServerWide.Operations.OngoingTasks
                 [nameof(TaskId)] = TaskId,
                 [nameof(Name)] = Name,
                 [nameof(MentorNode)] = MentorNode,
+                [nameof(PinToMentorNode)] = PinToMentorNode,
                 [nameof(DelayReplicationFor)] = DelayReplicationFor,
                 [nameof(TopologyDiscoveryUrls)] = TopologyDiscoveryUrls,
                 [nameof(ExcludedDatabases)] = ExcludedDatabases

--- a/src/Raven.Server/Documents/Subscriptions/SubscriptionStorage.cs
+++ b/src/Raven.Server/Documents/Subscriptions/SubscriptionStorage.cs
@@ -74,6 +74,7 @@ namespace Raven.Server.Documents.Subscriptions
                 InitialChangeVector = options.ChangeVector,
                 SubscriptionName = options.Name,
                 SubscriptionId = subscriptionId,
+                PinToMentorNode = options.PinToMentorNode,
                 Disabled = disabled ?? false
             };
 
@@ -484,6 +485,7 @@ namespace Raven.Server.Documents.Subscriptions
                 SubscriptionId = @base.SubscriptionId;
                 SubscriptionName = @base.SubscriptionName;
                 MentorNode = @base.MentorNode;
+                PinToMentorNode = @base.PinToMentorNode;
                 NodeTag = @base.NodeTag;
                 LastBatchAckTime = @base.LastBatchAckTime;
                 LastClientConnectionTime = @base.LastClientConnectionTime;

--- a/src/Raven.Server/ServerWide/Commands/Subscriptions/PutSubscriptionCommand.cs
+++ b/src/Raven.Server/ServerWide/Commands/Subscriptions/PutSubscriptionCommand.cs
@@ -25,6 +25,7 @@ namespace Raven.Server.ServerWide.Commands.Subscriptions
         public string SubscriptionName;
         public bool Disabled;
         public string MentorNode;
+        public bool PinToMentorNode;
 
         // for serialization
         private PutSubscriptionCommand() { }
@@ -102,6 +103,7 @@ namespace Raven.Server.ServerWide.Commands.Subscriptions
                         LastBatchAckTime = null,
                         Disabled = Disabled,
                         MentorNode = MentorNode,
+                        PinToMentorNode = PinToMentorNode,
                         LastClientConnectionTime = null
                     }.ToJson(), SubscriptionName))
                     {
@@ -165,6 +167,7 @@ namespace Raven.Server.ServerWide.Commands.Subscriptions
             json[nameof(SubscriptionId)] = SubscriptionId;
             json[nameof(Disabled)] = Disabled;
             json[nameof(MentorNode)] = MentorNode;
+            json[nameof(PinToMentorNode)] = PinToMentorNode;
         }
     }
 }

--- a/src/Raven.Server/Web/System/OngoingTasksHandler.cs
+++ b/src/Raven.Server/Web/System/OngoingTasksHandler.cs
@@ -1042,6 +1042,7 @@ namespace Raven.Server.Web.System
                                 TaskId = sqlEtl.TaskId,
                                 TaskName = sqlEtl.Name,
                                 Configuration = sqlEtl,
+                                MentorNode = sqlEtl.MentorNode,
                                 TaskState = GetEtlTaskState(sqlEtl),
                                 TaskConnectionStatus = GetEtlTaskConnectionStatus(record, sqlEtl, out var sqlNode, out var sqlEtlError),
                                 ResponsibleNode = new NodeId
@@ -1069,6 +1070,7 @@ namespace Raven.Server.Web.System
                             {
                                 TaskId = olapEtl.TaskId,
                                 TaskName = olapEtl.Name,
+                                MentorNode = olapEtl.MentorNode,
                                 Configuration = olapEtl,
                                 TaskState = GetEtlTaskState(olapEtl),
                                 TaskConnectionStatus = GetEtlTaskConnectionStatus(record, olapEtl, out var olapNode, out var olapEtlError),
@@ -1101,6 +1103,7 @@ namespace Raven.Server.Web.System
                                 TaskName = ravenEtl.Name,
                                 Configuration = ravenEtl,
                                 TaskState = GetEtlTaskState(ravenEtl),
+                                MentorNode = ravenEtl.MentorNode,
                                 DestinationUrl = process?.Url,
                                 TaskConnectionStatus = GetEtlTaskConnectionStatus(record, ravenEtl, out var node, out var ravenEtlError),
                                 ResponsibleNode = new NodeId

--- a/src/Raven.Server/Web/System/OngoingTasksHandler.cs
+++ b/src/Raven.Server/Web/System/OngoingTasksHandler.cs
@@ -157,6 +157,7 @@ namespace Raven.Server.Web.System
                 DestinationUrl = res.Url,
                 TopologyDiscoveryUrls = connection?.TopologyDiscoveryUrls,
                 MentorNode = sinkReplication.MentorNode,
+                PinToMentorNode = sinkReplication.PinToMentorNode,
                 TaskConnectionStatus = res.Status,
                 AccessName = sinkReplication.AccessName,
                 AllowedHubToSinkPaths = sinkReplication.AllowedHubToSinkPaths,
@@ -204,6 +205,7 @@ namespace Raven.Server.Web.System
                 DestinationDatabase = ex.Database,
                 DestinationUrl = connectionResult.Url,
                 MentorNode = ex.MentorNode,
+                PinToMentorNode = ex.PinToMentorNode,
                 TaskConnectionStatus = connectionResult.Status,
                 DelayReplicationFor = ex.DelayReplicationFor
             };
@@ -1039,6 +1041,7 @@ namespace Raven.Server.Web.System
                                 TaskId = sqlEtl.TaskId,
                                 TaskName = sqlEtl.Name,
                                 MentorNode = sqlEtl.MentorNode,
+                                PinToMentorNode = sqlEtl.PinToMentorNode,
                                 Configuration = sqlEtl,
                                 TaskState = GetEtlTaskState(sqlEtl),
                                 TaskConnectionStatus = GetEtlTaskConnectionStatus(record, sqlEtl, out var sqlNode, out var sqlEtlError),
@@ -1068,6 +1071,7 @@ namespace Raven.Server.Web.System
                                 TaskId = olapEtl.TaskId,
                                 TaskName = olapEtl.Name,
                                 MentorNode = olapEtl.MentorNode,
+                                PinToMentorNode = olapEtl.PinToMentorNode,
                                 Configuration = olapEtl,
                                 TaskState = GetEtlTaskState(olapEtl),
                                 TaskConnectionStatus = GetEtlTaskConnectionStatus(record, olapEtl, out var olapNode, out var olapEtlError),
@@ -1101,6 +1105,7 @@ namespace Raven.Server.Web.System
                                 Configuration = ravenEtl,
                                 TaskState = GetEtlTaskState(ravenEtl),
                                 MentorNode = ravenEtl.MentorNode,
+                                PinToMentorNode = ravenEtl.PinToMentorNode,
                                 DestinationUrl = process?.Url,
                                 TaskConnectionStatus = GetEtlTaskConnectionStatus(record, ravenEtl, out var node, out var ravenEtlError),
                                 ResponsibleNode = new NodeId
@@ -1142,6 +1147,7 @@ namespace Raven.Server.Web.System
                                 Disabled = subscriptionState.Disabled,
                                 LastClientConnectionTime = subscriptionState.LastClientConnectionTime,
                                 MentorNode = subscriptionState.MentorNode,
+                                PinToMentorNode = subscriptionState.PinToMentorNode,
                                 ResponsibleNode = new NodeId
                                 {
                                     NodeTag = tag,

--- a/src/Raven.Server/Web/System/OngoingTasksHandler.cs
+++ b/src/Raven.Server/Web/System/OngoingTasksHandler.cs
@@ -1041,8 +1041,6 @@ namespace Raven.Server.Web.System
                             {
                                 TaskId = sqlEtl.TaskId,
                                 TaskName = sqlEtl.Name,
-                                MentorNode = sqlEtl.MentorNode,
-                                PinToMentorNode = sqlEtl.PinToMentorNode,
                                 Configuration = sqlEtl,
                                 TaskState = GetEtlTaskState(sqlEtl),
                                 TaskConnectionStatus = GetEtlTaskConnectionStatus(record, sqlEtl, out var sqlNode, out var sqlEtlError),
@@ -1071,8 +1069,6 @@ namespace Raven.Server.Web.System
                             {
                                 TaskId = olapEtl.TaskId,
                                 TaskName = olapEtl.Name,
-                                MentorNode = olapEtl.MentorNode,
-                                PinToMentorNode = olapEtl.PinToMentorNode,
                                 Configuration = olapEtl,
                                 TaskState = GetEtlTaskState(olapEtl),
                                 TaskConnectionStatus = GetEtlTaskConnectionStatus(record, olapEtl, out var olapNode, out var olapEtlError),
@@ -1105,8 +1101,6 @@ namespace Raven.Server.Web.System
                                 TaskName = ravenEtl.Name,
                                 Configuration = ravenEtl,
                                 TaskState = GetEtlTaskState(ravenEtl),
-                                MentorNode = ravenEtl.MentorNode,
-                                PinToMentorNode = ravenEtl.PinToMentorNode,
                                 DestinationUrl = process?.Url,
                                 TaskConnectionStatus = GetEtlTaskConnectionStatus(record, ravenEtl, out var node, out var ravenEtlError),
                                 ResponsibleNode = new NodeId

--- a/src/Raven.Server/Web/System/OngoingTasksHandler.cs
+++ b/src/Raven.Server/Web/System/OngoingTasksHandler.cs
@@ -294,6 +294,7 @@ namespace Raven.Server.Web.System
                 DestinationUrl = res.Url,
                 TopologyDiscoveryUrls = connection?.TopologyDiscoveryUrls,
                 MentorNode = watcher.MentorNode,
+                PinToMentorNode = watcher.PinToMentorNode,
                 TaskConnectionStatus = res.Status,
                 DelayReplicationFor = watcher.DelayReplicationFor
             };
@@ -573,6 +574,7 @@ namespace Raven.Server.Web.System
                 TaskName = backupConfiguration.Name,
                 TaskState = backupConfiguration.Disabled ? OngoingTaskState.Disabled : OngoingTaskState.Enabled,
                 MentorNode = backupConfiguration.MentorNode,
+                PinToMentorNode = backupConfiguration.PinToMentorNode,
                 LastExecutingNodeTag = backupStatus.NodeTag,
                 LastFullBackup = backupStatus.LastFullBackup,
                 LastIncrementalBackup = backupStatus.LastIncrementalBackup,

--- a/src/Raven.Server/Web/System/OngoingTasksHandler.cs
+++ b/src/Raven.Server/Web/System/OngoingTasksHandler.cs
@@ -824,6 +824,7 @@ namespace Raven.Server.Web.System
                         TaskName = ravenEtl.Name,
                         TaskState = taskState,
                         MentorNode = ravenEtl.MentorNode,
+                        PinToMentorNode = ravenEtl.PinToMentorNode,
                         ResponsibleNode = new NodeId
                         {
                             NodeTag = tag,

--- a/src/Raven.Server/Web/System/TcpConnectionInfoHandler.cs
+++ b/src/Raven.Server/Web/System/TcpConnectionInfoHandler.cs
@@ -204,6 +204,11 @@ namespace Raven.Server.Web.System
             {
                 return false;
             }
+
+            public bool IsPinnedToMentorNode()
+            {
+                return false;
+            }
         }
     }
 }

--- a/src/Raven.Server/Web/System/TcpConnectionInfoHandler.cs
+++ b/src/Raven.Server/Web/System/TcpConnectionInfoHandler.cs
@@ -1,6 +1,7 @@
 ﻿using System;
 using System.Collections.Generic;
 using System.Diagnostics;
+using System.Linq;
 using System.Threading.Tasks;
 using Microsoft.AspNetCore.Http;
 using Microsoft.AspNetCore.Http.Features.Authentication;
@@ -156,7 +157,6 @@ namespace Raven.Server.Web.System
 
         private List<string> GetResponsibleNodes(DatabaseTopology topology, string databaseGroupId, string mentorNode, bool pinToMentorNode)
         {
-            var list = new List<string>();
             // we distribute connections to have load balancing when many sinks are connected.
             // this is the hub cluster, so we make the decision which node will do the pull replication only once and only here,
             // for that we create a dummy IDatabaseTask.
@@ -167,19 +167,19 @@ namespace Raven.Server.Web.System
                 DatabaseGroupId = databaseGroupId
             };
 
+            if (pinToMentorNode)
+            {
+                if (topology.AllNodes.Contains(mentorNode))
+                    return new List<string> {mentorNode};
+            }
+
+            var list = new List<string>();
             while (topology.Members.Count > 0)
             {
                 var next = topology.WhoseTaskIsIt(ServerStore.CurrentRachisState, mentorNodeTask, null);
-                if (next.Equals(mentorNode) && pinToMentorNode)
-                {
-                    // if it's pinned to the mentor node than the list will always contain one node (only if the node exists in the topology)
-                    list.Add(next);
-                    return list;
-                }
                 list.Add(next);
                 topology.Members.Remove(next);
             }
-
             return list;
         }
 

--- a/src/Raven.Server/Web/System/TcpConnectionInfoHandler.cs
+++ b/src/Raven.Server/Web/System/TcpConnectionInfoHandler.cs
@@ -47,7 +47,7 @@ namespace Raven.Server.Web.System
                     throw new InvalidOperationException($"The pull replication '{remoteTask}' is disabled.");
 
                 var topology = ServerStore.Cluster.ReadDatabaseTopology(context, database);
-                nodes = GetResponsibleNodes(topology, databaseGroupId, pullReplication.MentorNode);
+                nodes = GetResponsibleNodes(topology, databaseGroupId, pullReplication.MentorNode, pullReplication.PinToMentorNode);
             }
 
             using (ServerStore.ContextPool.AllocateOperationContext(out JsonOperationContext context))
@@ -153,7 +153,7 @@ namespace Raven.Server.Web.System
             }
         }
 
-        private List<string> GetResponsibleNodes(DatabaseTopology topology, string databaseGroupId, string mentorNode)
+        private List<string> GetResponsibleNodes(DatabaseTopology topology, string databaseGroupId, string mentorNode, bool pinToMentorNode)
         {
             var list = new List<string>();
             // we distribute connections to have load balancing when many sinks are connected.
@@ -162,6 +162,7 @@ namespace Raven.Server.Web.System
             var mentorNodeTask = new PullNodeTask
             {
                 Mentor = mentorNode,
+                PinToMentorNode = pinToMentorNode,
                 DatabaseGroupId = databaseGroupId
             };
 
@@ -179,6 +180,7 @@ namespace Raven.Server.Web.System
         {
             public string Mentor;
             public string DatabaseGroupId;
+            public bool PinToMentorNode;
 
             public ulong GetTaskKey()
             {
@@ -207,7 +209,7 @@ namespace Raven.Server.Web.System
 
             public bool IsPinnedToMentorNode()
             {
-                return false;
+                return PinToMentorNode;
             }
         }
     }

--- a/src/Raven.Server/Web/System/TcpConnectionInfoHandler.cs
+++ b/src/Raven.Server/Web/System/TcpConnectionInfoHandler.cs
@@ -1,5 +1,6 @@
 ﻿using System;
 using System.Collections.Generic;
+using System.Diagnostics;
 using System.Threading.Tasks;
 using Microsoft.AspNetCore.Http;
 using Microsoft.AspNetCore.Http.Features.Authentication;
@@ -169,6 +170,12 @@ namespace Raven.Server.Web.System
             while (topology.Members.Count > 0)
             {
                 var next = topology.WhoseTaskIsIt(ServerStore.CurrentRachisState, mentorNodeTask, null);
+                if (next.Equals(mentorNode) && pinToMentorNode)
+                {
+                    // if it's pinned to the mentor node than the list will always contain one node (only if the node exists in the topology)
+                    list.Add(next);
+                    return list;
+                }
                 list.Add(next);
                 topology.Members.Remove(next);
             }

--- a/src/Raven.Studio/typescript/models/database/tasks/ongoingTaskEditModel.ts
+++ b/src/Raven.Studio/typescript/models/database/tasks/ongoingTaskEditModel.ts
@@ -3,7 +3,9 @@
 import ongoingTaskModel = require("models/database/tasks/ongoingTaskModel");
 
 abstract class ongoingTaskEditModel extends ongoingTaskModel {
+    
     manualChooseMentor = ko.observable<boolean>(false);
+    pinMentorNode = ko.observable<boolean>(false);
     
     nodeTag: string = null;
 
@@ -19,6 +21,10 @@ abstract class ongoingTaskEditModel extends ongoingTaskModel {
                 onlyIf: () => this.manualChooseMentor()
             }
         });
+    }
+
+    togglePinMentorNode() {
+        this.pinMentorNode.toggle();
     }
 }
 

--- a/src/Raven.Studio/typescript/models/database/tasks/ongoingTaskOlapEtlEditModel.ts
+++ b/src/Raven.Studio/typescript/models/database/tasks/ongoingTaskOlapEtlEditModel.ts
@@ -38,6 +38,7 @@ class ongoingTaskOlapEtlEditModel extends ongoingTaskEditModel {
             this.taskState,
             this.connectionStringName,
             this.mentorNode,
+            this.pinMentorNode,
             this.manualChooseMentor,
             this.customPartition,
             this.customPartitionEnabled,
@@ -88,6 +89,7 @@ class ongoingTaskOlapEtlEditModel extends ongoingTaskEditModel {
         if (configuration) {
             this.connectionStringName(configuration.ConnectionStringName);
             this.manualChooseMentor(!!configuration.MentorNode);
+            this.pinMentorNode(configuration.PinToMentorNode);
             
             this.customPartition(configuration.CustomPartitionValue);
             this.customPartitionEnabled(!!configuration.CustomPartitionValue);
@@ -117,10 +119,10 @@ class ongoingTaskOlapEtlEditModel extends ongoingTaskEditModel {
             AllowEtlOnNonEncryptedChannel: true,
             Disabled: this.taskState() === "Disabled",
             MentorNode: this.manualChooseMentor() ? this.mentorNode() : undefined,
+            PinToMentorNode: this.pinMentorNode(),
             Transforms: this.transformationScripts().map(x => x.toDto()),
             CustomPartitionValue: this.customPartitionEnabled() ? this.customPartition() : null,
             RunFrequency: this.runFrequency(),
-            PinToMentorNode: false,
             OlapTables: this.olapTables().map(x => x.toDto()),
             Format: undefined
         };

--- a/src/Raven.Studio/typescript/models/database/tasks/ongoingTaskOlapEtlEditModel.ts
+++ b/src/Raven.Studio/typescript/models/database/tasks/ongoingTaskOlapEtlEditModel.ts
@@ -90,6 +90,7 @@ class ongoingTaskOlapEtlEditModel extends ongoingTaskEditModel {
             this.connectionStringName(configuration.ConnectionStringName);
             this.manualChooseMentor(!!configuration.MentorNode);
             this.pinMentorNode(configuration.PinToMentorNode);
+            this.mentorNode(configuration.MentorNode);
             
             this.customPartition(configuration.CustomPartitionValue);
             this.customPartitionEnabled(!!configuration.CustomPartitionValue);

--- a/src/Raven.Studio/typescript/models/database/tasks/ongoingTaskOlapEtlEditModel.ts
+++ b/src/Raven.Studio/typescript/models/database/tasks/ongoingTaskOlapEtlEditModel.ts
@@ -120,6 +120,7 @@ class ongoingTaskOlapEtlEditModel extends ongoingTaskEditModel {
             Transforms: this.transformationScripts().map(x => x.toDto()),
             CustomPartitionValue: this.customPartitionEnabled() ? this.customPartition() : null,
             RunFrequency: this.runFrequency(),
+            PinToMentorNode: false,
             OlapTables: this.olapTables().map(x => x.toDto()),
             Format: undefined
         };

--- a/src/Raven.Studio/typescript/models/database/tasks/ongoingTaskRavenEtlEditModel.ts
+++ b/src/Raven.Studio/typescript/models/database/tasks/ongoingTaskRavenEtlEditModel.ts
@@ -97,6 +97,7 @@ class ongoingTaskRavenEtlEditModel extends ongoingTaskEditModel {
             this.transformationScripts(dto.Configuration.Transforms.map(x => new ongoingTaskRavenEtlTransformationModel(x, false, false)));
             this.manualChooseMentor(!!dto.Configuration.MentorNode);
             this.pinMentorNode(dto.Configuration.PinToMentorNode);
+            this.mentorNode(dto.Configuration.MentorNode);
             this.loadRequestTimeout(dto.Configuration.LoadRequestTimeoutInSec);
         }
     }

--- a/src/Raven.Studio/typescript/models/database/tasks/ongoingTaskRavenEtlEditModel.ts
+++ b/src/Raven.Studio/typescript/models/database/tasks/ongoingTaskRavenEtlEditModel.ts
@@ -50,6 +50,7 @@ class ongoingTaskRavenEtlEditModel extends ongoingTaskEditModel {
                 this.taskName,
                 this.taskState,
                 this.mentorNode,
+                this.pinMentorNode,
                 this.manualChooseMentor,
                 this.connectionStringName,
                 this.allowEtlOnNonEncryptedChannel,
@@ -95,6 +96,7 @@ class ongoingTaskRavenEtlEditModel extends ongoingTaskEditModel {
             this.connectionStringName(dto.Configuration.ConnectionStringName);
             this.transformationScripts(dto.Configuration.Transforms.map(x => new ongoingTaskRavenEtlTransformationModel(x, false, false)));
             this.manualChooseMentor(!!dto.Configuration.MentorNode);
+            this.pinMentorNode(dto.Configuration.PinToMentorNode);
             this.loadRequestTimeout(dto.Configuration.LoadRequestTimeoutInSec);
         }
     }
@@ -108,8 +110,8 @@ class ongoingTaskRavenEtlEditModel extends ongoingTaskEditModel {
             Transforms: this.transformationScripts().map(x => x.toDto()),
             EtlType: "Raven",
             MentorNode: this.manualChooseMentor() ? this.mentorNode() : undefined,
+            PinToMentorNode: this.pinMentorNode(),
             TaskId: this.taskId,
-            PinToMentorNode: false,
             LoadRequestTimeoutInSec: this.loadRequestTimeout() || null,
         };
     }

--- a/src/Raven.Studio/typescript/models/database/tasks/ongoingTaskRavenEtlEditModel.ts
+++ b/src/Raven.Studio/typescript/models/database/tasks/ongoingTaskRavenEtlEditModel.ts
@@ -109,6 +109,7 @@ class ongoingTaskRavenEtlEditModel extends ongoingTaskEditModel {
             EtlType: "Raven",
             MentorNode: this.manualChooseMentor() ? this.mentorNode() : undefined,
             TaskId: this.taskId,
+            PinToMentorNode: false,
             LoadRequestTimeoutInSec: this.loadRequestTimeout() || null,
         };
     }

--- a/src/Raven.Studio/typescript/models/database/tasks/ongoingTaskReplicationEditModel.ts
+++ b/src/Raven.Studio/typescript/models/database/tasks/ongoingTaskReplicationEditModel.ts
@@ -35,6 +35,7 @@ class ongoingTaskReplicationEditModel extends ongoingTaskEditModel {
 
         this.connectionStringName(dto.ConnectionStringName); 
         this.manualChooseMentor(!!dto.MentorNode);
+        this.pinMentorNode(dto.PinToMentorNode);
 
         const delayTime = generalUtils.timeSpanToSeconds(dto.DelayReplicationFor);
         this.showDelayReplication(dto.DelayReplicationFor != null && delayTime !== 0);
@@ -45,11 +46,11 @@ class ongoingTaskReplicationEditModel extends ongoingTaskEditModel {
         return {
             Name: this.taskName(),
             MentorNode: this.manualChooseMentor() ? this.mentorNode() : undefined,
+            PinToMentorNode: this.pinMentorNode(),
             ConnectionStringName: this.connectionStringName(),
             TaskId: taskId,
             DelayReplicationFor: this.showDelayReplication() ? generalUtils.formatAsTimeSpan(this.delayReplicationTime() * 1000) : null,
             Url: undefined,
-            PinToMentorNode: false,
             Disabled: this.taskState() === "Disabled",
             Database: undefined
         };

--- a/src/Raven.Studio/typescript/models/database/tasks/ongoingTaskReplicationEditModel.ts
+++ b/src/Raven.Studio/typescript/models/database/tasks/ongoingTaskReplicationEditModel.ts
@@ -49,6 +49,7 @@ class ongoingTaskReplicationEditModel extends ongoingTaskEditModel {
             TaskId: taskId,
             DelayReplicationFor: this.showDelayReplication() ? generalUtils.formatAsTimeSpan(this.delayReplicationTime() * 1000) : null,
             Url: undefined,
+            PinToMentorNode: false,
             Disabled: this.taskState() === "Disabled",
             Database: undefined
         };

--- a/src/Raven.Studio/typescript/models/database/tasks/ongoingTaskReplicationHubEditModel.ts
+++ b/src/Raven.Studio/typescript/models/database/tasks/ongoingTaskReplicationHubEditModel.ts
@@ -13,6 +13,7 @@ class ongoingTaskReplicationHubEditModel {
     responsibleNode = ko.observable<Raven.Client.ServerWide.Operations.NodeId>();
     
     manualChooseMentor = ko.observable<boolean>();
+    pinMentorNode = ko.observable<boolean>(false);
     mentorNode = ko.observable<string>();
     nodeTag: string = null;
     
@@ -68,6 +69,7 @@ class ongoingTaskReplicationHubEditModel {
         this.disabled(dto.Disabled);
 
         this.manualChooseMentor(!!dto.MentorNode);
+        this.pinMentorNode(dto.PinToMentorNode);
         this.mentorNode(dto.MentorNode);
 
         const delayTime = generalUtils.timeSpanToSeconds(dto.DelayReplicationFor);
@@ -85,6 +87,7 @@ class ongoingTaskReplicationHubEditModel {
         return {
             Name: this.taskName(),
             MentorNode: this.manualChooseMentor() ? this.mentorNode() : undefined,
+            PinToMentorNode: this.pinMentorNode(),
             TaskId: taskId,
             DelayReplicationFor: this.showDelayReplication() ? generalUtils.formatAsTimeSpan(this.delayReplicationTime() * 1000) : null,
             Mode: this.replicationMode(),
@@ -150,6 +153,10 @@ class ongoingTaskReplicationHubEditModel {
             WithFiltering: false,
             Mode: "HubToSink"
         } as Raven.Client.Documents.Operations.Replication.PullReplicationDefinition);
+    }
+
+    togglePinMentorNode() {
+        this.pinMentorNode.toggle();
     }
 }
 

--- a/src/Raven.Studio/typescript/models/database/tasks/ongoingTaskReplicationSinkEditModel.ts
+++ b/src/Raven.Studio/typescript/models/database/tasks/ongoingTaskReplicationSinkEditModel.ts
@@ -46,6 +46,7 @@ class ongoingTaskReplicationSinkEditModel extends ongoingTaskEditModel {
 
         this.connectionStringName(dto.ConnectionStringName);
         this.manualChooseMentor(!!dto.MentorNode);
+        this.pinMentorNode(dto.PinToMentorNode);
         this.hubName(dto.HubDefinitionName);
 
         this.allowReplicationFromHubToSink(dto.Mode.includes("HubToSink"));
@@ -71,6 +72,7 @@ class ongoingTaskReplicationSinkEditModel extends ongoingTaskEditModel {
             TaskId: taskId,
             Name: this.taskName(),
             MentorNode: this.manualChooseMentor() ? this.mentorNode() : undefined,
+            PinToMentorNode: this.pinMentorNode(),
             ConnectionStringName: this.connectionStringName(),
             HubName: this.hubName(),
             Mode: this.replicationMode(),

--- a/src/Raven.Studio/typescript/models/database/tasks/ongoingTaskSqlEtlEditModel.ts
+++ b/src/Raven.Studio/typescript/models/database/tasks/ongoingTaskSqlEtlEditModel.ts
@@ -36,6 +36,7 @@ class ongoingTaskSqlEtlEditModel extends ongoingTaskEditModel {
             this.taskState,
             this.connectionStringName,
             this.mentorNode,
+            this.pinMentorNode,
             this.manualChooseMentor,
             this.parameterizedDeletes,
             this.forceRecompileQuery,
@@ -99,6 +100,7 @@ class ongoingTaskSqlEtlEditModel extends ongoingTaskEditModel {
             this.commandTimeout(dto.Configuration.CommandTimeout);
             
             this.manualChooseMentor(!!dto.Configuration.MentorNode);
+            this.pinMentorNode(dto.Configuration.PinToMentorNode);
             
             this.transformationScripts(dto.Configuration.Transforms.map(x => new ongoingTaskSqlEtlTransformationModel(x, false, false)));
             this.sqlTables(dto.Configuration.SqlTables.map(x => new ongoingTaskSqlEtlTableModel(x, false)));
@@ -113,13 +115,13 @@ class ongoingTaskSqlEtlEditModel extends ongoingTaskEditModel {
             ConnectionStringName: this.connectionStringName(),
             AllowEtlOnNonEncryptedChannel: this.allowEtlOnNonEncryptedChannel(),
             Disabled: this.taskState() === "Disabled",
-            MentorNode: this.manualChooseMentor() ? this.mentorNode() : undefined, 
+            MentorNode: this.manualChooseMentor() ? this.mentorNode() : undefined,
+            PinToMentorNode: this.pinMentorNode(),
             FactoryName: "System.Data.SqlClient",
             ForceQueryRecompile: this.forceRecompileQuery(),
             ParameterizeDeletes: this.parameterizedDeletes(),
             CommandTimeout: this.commandTimeout() || null,
             QuoteTables: this.tableQuotation(),
-            PinToMentorNode: false,
             Transforms: this.transformationScripts().map(x => x.toDto()),
             SqlTables: this.sqlTables().map(x => x.toDto())
         

--- a/src/Raven.Studio/typescript/models/database/tasks/ongoingTaskSqlEtlEditModel.ts
+++ b/src/Raven.Studio/typescript/models/database/tasks/ongoingTaskSqlEtlEditModel.ts
@@ -119,6 +119,7 @@ class ongoingTaskSqlEtlEditModel extends ongoingTaskEditModel {
             ParameterizeDeletes: this.parameterizedDeletes(),
             CommandTimeout: this.commandTimeout() || null,
             QuoteTables: this.tableQuotation(),
+            PinToMentorNode: false,
             Transforms: this.transformationScripts().map(x => x.toDto()),
             SqlTables: this.sqlTables().map(x => x.toDto())
         

--- a/src/Raven.Studio/typescript/models/database/tasks/ongoingTaskSqlEtlEditModel.ts
+++ b/src/Raven.Studio/typescript/models/database/tasks/ongoingTaskSqlEtlEditModel.ts
@@ -101,6 +101,7 @@ class ongoingTaskSqlEtlEditModel extends ongoingTaskEditModel {
             
             this.manualChooseMentor(!!dto.Configuration.MentorNode);
             this.pinMentorNode(dto.Configuration.PinToMentorNode);
+            this.mentorNode(dto.Configuration.MentorNode);
             
             this.transformationScripts(dto.Configuration.Transforms.map(x => new ongoingTaskSqlEtlTransformationModel(x, false, false)));
             this.sqlTables(dto.Configuration.SqlTables.map(x => new ongoingTaskSqlEtlTableModel(x, false)));

--- a/src/Raven.Studio/typescript/models/database/tasks/ongoingTaskSubscriptionEditModel.ts
+++ b/src/Raven.Studio/typescript/models/database/tasks/ongoingTaskSubscriptionEditModel.ts
@@ -33,6 +33,7 @@ class ongoingTaskSubscriptionEditModel extends ongoingTaskEditModel {
             this.taskState,
             this.mentorNode,
             this.manualChooseMentor,
+            this.pinMentorNode,
             this.query,
             this.startingPointType,
             this.startingChangeVector,
@@ -67,6 +68,7 @@ class ongoingTaskSubscriptionEditModel extends ongoingTaskEditModel {
             TaskId: dtoEditModel.SubscriptionId,
             TaskName: dtoEditModel.SubscriptionName,
             MentorNode: dtoEditModel.MentorNode,
+            PinToMentorNode: dtoEditModel.PinToMentorNode,
             TaskState: state,
             TaskType: 'Subscription',
             Error: null
@@ -75,6 +77,7 @@ class ongoingTaskSubscriptionEditModel extends ongoingTaskEditModel {
         super.update(dtoListModel);
         
         this.manualChooseMentor(!!dto.MentorNode);
+        this.pinMentorNode(dto.PinToMentorNode);
 
         this.query(dto.Query);
         this.changeVectorForNextBatchStartingPoint(dto.ChangeVectorForNextBatchStartingPoint);
@@ -112,6 +115,7 @@ class ongoingTaskSubscriptionEditModel extends ongoingTaskEditModel {
             Name: this.taskName(),
             Query: this.query() || null,
             MentorNode: this.manualChooseMentor() ? this.mentorNode() : undefined,
+            PinToMentorNode: this.pinMentorNode(),
             ChangeVector: this.serializeChangeVector(),
             Disabled: this.taskState() === "Disabled"
         }
@@ -158,6 +162,7 @@ class ongoingTaskSubscriptionEditModel extends ongoingTaskEditModel {
                 LastClientConnectionTime: null,
                 LastBatchAckTime: null,
                 MentorNode: null,
+                PinToMentorNode: false,
                 NodeTag: null
             });
     }

--- a/src/Raven.Studio/typescript/models/database/tasks/periodicBackup/backupConfiguration.ts
+++ b/src/Raven.Studio/typescript/models/database/tasks/periodicBackup/backupConfiguration.ts
@@ -30,6 +30,8 @@ abstract class backupConfiguration {
     snapshot = ko.observable<snapshot>();
     
     mentorNode = ko.observable<string>();
+    //pinMentorNode = ko.observable<boolean>(); // todo new..??
+    
     encryptionSettings = ko.observable<encryptionSettings>();
     
     localSettings = ko.observable<localSettings>();
@@ -66,7 +68,9 @@ abstract class backupConfiguration {
         this.glacierSettings(!dto.GlacierSettings ? glacierSettings.empty(serverLimits.AllowedAwsRegions, "Backup") : new glacierSettings(dto.GlacierSettings, serverLimits.AllowedAwsRegions, "Backup"));
         this.ftpSettings(!dto.FtpSettings ? ftpSettings.empty("Backup") : new ftpSettings(dto.FtpSettings, "Backup"));
         this.isServerWide(isServerWide);
+        
         this.mentorNode(dto.MentorNode);
+        //this.pinMentorNode(dto.PinToMentorNode);
 
         const folderPath = this.localSettings().folderPath();
         if (folderPath) {
@@ -199,9 +203,9 @@ abstract class backupConfiguration {
             GoogleCloudSettings: null,
             FtpSettings: null,
             MentorNode: null,
+            PinToMentorNode: false,
             BackupEncryptionSettings: null,
             SnapshotSettings: null,
-            PinToMentorNode: false,
             RetentionPolicy: null,
         }
     }

--- a/src/Raven.Studio/typescript/models/database/tasks/periodicBackup/backupConfiguration.ts
+++ b/src/Raven.Studio/typescript/models/database/tasks/periodicBackup/backupConfiguration.ts
@@ -30,7 +30,6 @@ abstract class backupConfiguration {
     snapshot = ko.observable<snapshot>();
     
     mentorNode = ko.observable<string>();
-    //pinMentorNode = ko.observable<boolean>(); // todo new..??
     
     encryptionSettings = ko.observable<encryptionSettings>();
     
@@ -70,7 +69,6 @@ abstract class backupConfiguration {
         this.isServerWide(isServerWide);
         
         this.mentorNode(dto.MentorNode);
-        //this.pinMentorNode(dto.PinToMentorNode);
 
         const folderPath = this.localSettings().folderPath();
         if (folderPath) {

--- a/src/Raven.Studio/typescript/models/database/tasks/periodicBackup/backupConfiguration.ts
+++ b/src/Raven.Studio/typescript/models/database/tasks/periodicBackup/backupConfiguration.ts
@@ -201,6 +201,7 @@ abstract class backupConfiguration {
             MentorNode: null,
             BackupEncryptionSettings: null,
             SnapshotSettings: null,
+            PinToMentorNode: false,
             RetentionPolicy: null,
         }
     }

--- a/src/Raven.Studio/typescript/models/database/tasks/periodicBackup/periodicBackupConfiguration.ts
+++ b/src/Raven.Studio/typescript/models/database/tasks/periodicBackup/periodicBackupConfiguration.ts
@@ -15,6 +15,7 @@ class periodicBackupConfiguration extends backupConfiguration {
     stateText: KnockoutComputed<string>;
 
     manualChooseMentor = ko.observable<boolean>(false);
+    pinMentorNode = ko.observable<boolean>(false);
 
     fullBackupEnabled = ko.observable<boolean>(false);
     fullBackupFrequency = ko.observable<string>();
@@ -42,6 +43,7 @@ class periodicBackupConfiguration extends backupConfiguration {
         this.incrementalBackupFrequency(dto.IncrementalBackupFrequency || periodicBackupConfiguration.defaultIncrementalBackupFrequency);
         
         this.manualChooseMentor(!!dto.MentorNode);
+        this.pinMentorNode(dto.PinToMentorNode);
         
         this.retentionPolicy(!dto.RetentionPolicy ? retentionPolicy.empty() : new retentionPolicy(dto.RetentionPolicy));
        
@@ -76,6 +78,7 @@ class periodicBackupConfiguration extends backupConfiguration {
             this.incrementalBackupEnabled,
             this.manualChooseMentor,
             this.mentorNode,
+            this.pinMentorNode,
             this.snapshot().compressionLevel,
             this.retentionPolicy().dirtyFlag().isDirty,
             this.encryptionSettings().dirtyFlag().isDirty,
@@ -147,6 +150,7 @@ class periodicBackupConfiguration extends backupConfiguration {
             Name: this.name(),
             Disabled: this.disabled(),
             MentorNode: this.manualChooseMentor() ? this.mentorNode() : undefined,
+            PinToMentorNode: this.pinMentorNode(),
             FullBackupFrequency: this.fullBackupEnabled() ? this.fullBackupFrequency() : null,
             IncrementalBackupFrequency: this.incrementalBackupEnabled() ? this.incrementalBackupFrequency() : null,
             RetentionPolicy: this.retentionPolicy().toDto(),
@@ -157,7 +161,6 @@ class periodicBackupConfiguration extends backupConfiguration {
             S3Settings: this.s3Settings().toDto(),
             GlacierSettings: this.glacierSettings().toDto(),
             AzureSettings: this.azureSettings().toDto(),
-            PinToMentorNode: false,
             GoogleCloudSettings: this.googleCloudSettings().toDto(),
             FtpSettings: this.ftpSettings().toDto()
         };
@@ -177,6 +180,10 @@ class periodicBackupConfiguration extends backupConfiguration {
 
     setState(state: Raven.Client.Documents.Operations.OngoingTasks.OngoingTaskState): void {
         this.disabled(state === "Disabled");
+    }
+
+    togglePinMentorNode() {
+        this.pinMentorNode.toggle();
     }
 }
 

--- a/src/Raven.Studio/typescript/models/database/tasks/periodicBackup/periodicBackupConfiguration.ts
+++ b/src/Raven.Studio/typescript/models/database/tasks/periodicBackup/periodicBackupConfiguration.ts
@@ -157,6 +157,7 @@ class periodicBackupConfiguration extends backupConfiguration {
             S3Settings: this.s3Settings().toDto(),
             GlacierSettings: this.glacierSettings().toDto(),
             AzureSettings: this.azureSettings().toDto(),
+            PinToMentorNode: false,
             GoogleCloudSettings: this.googleCloudSettings().toDto(),
             FtpSettings: this.ftpSettings().toDto()
         };

--- a/src/Raven.Studio/typescript/models/database/tasks/serverWide/serverWideConfigurationModel.ts
+++ b/src/Raven.Studio/typescript/models/database/tasks/serverWide/serverWideConfigurationModel.ts
@@ -9,15 +9,18 @@ abstract class serverWideConfigurationModel {
     stateText: KnockoutComputed<string>;
     
     mentorNode = ko.observable<string>();
+    pinMentorNode = ko.observable<boolean>(false);
     manualChooseMentor = ko.observable<boolean>(false);
     
     excludeInfo = ko.observable<serverWideExcludeModel>();
 
-    constructor(taskId: number, taskName: string, disabled: boolean, mentorNode: string, excludedDatabases: string[]) {
+    constructor(taskId: number, taskName: string, disabled: boolean, mentorNode: string, pinMentorNode: boolean, excludedDatabases: string[]) {
         this.taskId(taskId);
         this.taskName(taskName);
         
         this.mentorNode(mentorNode);
+        this.pinMentorNode(pinMentorNode);
+        
         this.disabled(disabled);
 
         this.manualChooseMentor(!!mentorNode);
@@ -37,6 +40,10 @@ abstract class serverWideConfigurationModel {
 
             return "Enabled";
         });
+    }
+
+    togglePinMentorNode() {
+        this.pinMentorNode.toggle();
     }
 }
 

--- a/src/Raven.Studio/typescript/models/database/tasks/serverWide/serverWideExternalReplicationEditModel.ts
+++ b/src/Raven.Studio/typescript/models/database/tasks/serverWide/serverWideExternalReplicationEditModel.ts
@@ -15,7 +15,7 @@ class serverWideExternalReplicationEditModel extends serverWideConfigurationMode
     validationGroup: KnockoutValidationGroup;
 
     constructor(dto: Raven.Client.ServerWide.Operations.OngoingTasks.ServerWideExternalReplication) {
-        super(dto.TaskId, dto.Name, dto.Disabled, dto.MentorNode, dto.ExcludedDatabases);
+        super(dto.TaskId, dto.Name, dto.Disabled, dto.MentorNode, dto.PinToMentorNode, dto.ExcludedDatabases);
 
         const delayTime = generalUtils.timeSpanToSeconds(dto.DelayReplicationFor);
         this.showDelayTime(dto.DelayReplicationFor != null && delayTime !== 0);
@@ -47,6 +47,7 @@ class serverWideExternalReplicationEditModel extends serverWideConfigurationMode
             this.showDelayTime,
             this.manualChooseMentor,
             this.mentorNode,
+            this.pinMentorNode,
             this.excludeInfo().dirtyFlag().isDirty,
             this.connectionString().dirtyFlag().isDirty
         ], false, jsonUtil.newLineNormalizingHashFunction);
@@ -79,6 +80,7 @@ class serverWideExternalReplicationEditModel extends serverWideConfigurationMode
             TopologyDiscoveryUrls: this.connectionString().topologyDiscoveryUrls().map(x => x.discoveryUrlName()),
             ExcludedDatabases: this.excludeInfo().toDto(),
             MentorNode: this.manualChooseMentor() ? this.mentorNode() : undefined,
+            PinToMentorNode: this.pinMentorNode(),
             Disabled: this.disabled()
         };
     }
@@ -91,6 +93,7 @@ class serverWideExternalReplicationEditModel extends serverWideConfigurationMode
             TopologyDiscoveryUrls: [],
             ExcludedDatabases: [],
             MentorNode: null,
+            PinToMentorNode: false,
             Disabled: false,
         });
     }

--- a/src/Raven.Studio/typescript/models/database/tasks/tasksCommonContent.ts
+++ b/src/Raven.Studio/typescript/models/database/tasks/tasksCommonContent.ts
@@ -1,10 +1,4 @@
 ﻿class tasksCommonContent {
-    
-    static readonly responsibleNodeInfo =
-        `<ul class="margin-top margin-top-xs no-padding-left margin-left">
-            <li><small>The <strong>preferred node</strong> that will handle this task.</small></li>
-            <li><small>When this node is down, the cluster selects another node from the Database Group to handle the task.</small></li>
-         </ul>`;
         
     static readonly generalBackupInfo =
         "Differences between Backup and Snapshot:" +

--- a/src/Raven.Studio/typescript/viewmodels/database/tasks/editExternalReplicationTask.ts
+++ b/src/Raven.Studio/typescript/viewmodels/database/tasks/editExternalReplicationTask.ts
@@ -10,8 +10,6 @@ import getConnectionStringsCommand = require("commands/database/settings/getConn
 import getPossibleMentorsCommand = require("commands/database/tasks/getPossibleMentorsCommand");
 import connectionStringRavenEtlModel = require("models/database/settings/connectionStringRavenEtlModel");
 import jsonUtil = require("common/jsonUtil");
-import popoverUtils = require("common/popoverUtils");
-import tasksCommonContent = require("models/database/tasks/tasksCommonContent");
 import discoveryUrl = require("models/database/settings/discoveryUrl");
 
 class editExternalReplicationTask extends viewModelBase {
@@ -128,6 +126,7 @@ class editExternalReplicationTask extends viewModelBase {
             model.taskName,
             model.taskState,
             model.manualChooseMentor,
+            model.pinMentorNode,
             model.mentorNode,
             model.connectionStringName,
             model.delayReplicationTime,
@@ -142,11 +141,6 @@ class editExternalReplicationTask extends viewModelBase {
         document.getElementById('taskName').focus();
         
         $('.edit-replication-task [data-toggle="tooltip"]').tooltip();
-
-        popoverUtils.longWithHover($(".responsible-node"),
-            {
-                content: tasksCommonContent.responsibleNodeInfo
-            });
     }
 
     saveExternalReplication() {

--- a/src/Raven.Studio/typescript/viewmodels/database/tasks/editOlapEtlTask.ts
+++ b/src/Raven.Studio/typescript/viewmodels/database/tasks/editOlapEtlTask.ts
@@ -17,7 +17,6 @@ import aceEditorBindingHandler = require("common/bindingHelpers/aceEditorBinding
 import getPossibleMentorsCommand = require("commands/database/tasks/getPossibleMentorsCommand");
 import jsonUtil = require("common/jsonUtil");
 import popoverUtils = require("common/popoverUtils");
-import tasksCommonContent = require("models/database/tasks/tasksCommonContent");
 import backupSettings = require("models/database/tasks/periodicBackup/backupSettings");
 import testPeriodicBackupCredentialsCommand = require("commands/serverWide/testPeriodicBackupCredentialsCommand");
 import getPeriodicBackupConfigCommand = require("commands/database/tasks/getPeriodicBackupConfigCommand");
@@ -315,11 +314,6 @@ class editOlapEtlTask extends viewModelBase {
         super.compositionComplete();
 
         $('.edit-raven-olap-task [data-toggle="tooltip"]').tooltip();
-
-        popoverUtils.longWithHover($(".responsible-node"),
-            {
-                content: tasksCommonContent.responsibleNodeInfo
-            });
 
         popoverUtils.longWithHover($(".keep-files-on-disk"),
             {

--- a/src/Raven.Studio/typescript/viewmodels/database/tasks/editPeriodicBackupTask.ts
+++ b/src/Raven.Studio/typescript/viewmodels/database/tasks/editPeriodicBackupTask.ts
@@ -137,11 +137,6 @@ class editPeriodicBackupTask extends viewModelBase {
             {
                 content: tasksCommonContent.backupAgeInfo
             });
-
-        popoverUtils.longWithHover($(".responsible-node"),
-            {
-                content: tasksCommonContent.responsibleNodeInfo
-            });
     }
 
     onSubmit() {

--- a/src/Raven.Studio/typescript/viewmodels/database/tasks/editRavenEtlTask.ts
+++ b/src/Raven.Studio/typescript/viewmodels/database/tasks/editRavenEtlTask.ts
@@ -23,8 +23,6 @@ import documentMetadata = require("models/database/documents/documentMetadata");
 import getDocumentWithMetadataCommand = require("commands/database/documents/getDocumentWithMetadataCommand");
 import document = require("models/database/documents/document");
 import testRavenEtlCommand = require("commands/database/tasks/testRavenEtlCommand");
-import popoverUtils = require("common/popoverUtils");
-import tasksCommonContent = require("models/database/tasks/tasksCommonContent");
 import discoveryUrl = require("models/database/settings/discoveryUrl");
 
 type resultItem = {
@@ -249,11 +247,6 @@ class editRavenEtlTask extends viewModelBase {
         super.compositionComplete();
 
         $('.edit-raven-etl-task [data-toggle="tooltip"]').tooltip();
-
-        popoverUtils.longWithHover($(".responsible-node"),
-            {
-                content: tasksCommonContent.responsibleNodeInfo
-            });
     }
 
     private getAllConnectionStrings() {

--- a/src/Raven.Studio/typescript/viewmodels/database/tasks/editReplicationHubTask.ts
+++ b/src/Raven.Studio/typescript/viewmodels/database/tasks/editReplicationHubTask.ts
@@ -144,11 +144,6 @@ class editReplicationHubTask extends viewModelBase {
                         "</li>" +
                     "</ul>"
             });
-
-        popoverUtils.longWithHover($(".responsible-node"),
-            {
-                content: tasksCommonContent.responsibleNodeInfo
-            });
     }
     
     private loadPossibleMentors() {

--- a/src/Raven.Studio/typescript/viewmodels/database/tasks/editReplicationHubTask.ts
+++ b/src/Raven.Studio/typescript/viewmodels/database/tasks/editReplicationHubTask.ts
@@ -25,7 +25,6 @@ import deleteReplicationHubAccessConfigCommand = require("commands/database/task
 import genUtils = require("common/generalUtils");
 import certificateUtils = require("common/certificateUtils");
 import viewHelpers = require("common/helpers/view/viewHelpers");
-import tasksCommonContent = require("models/database/tasks/tasksCommonContent");
 import accessManager = require("common/shell/accessManager");
 
 class editReplicationHubTask extends viewModelBase {
@@ -189,6 +188,7 @@ class editReplicationHubTask extends viewModelBase {
             model.disabled,
             model.manualChooseMentor,
             model.mentorNode,
+            model.pinMentorNode,
             model.delayReplicationTime,
             model.showDelayReplication,
             model.preventDeletions,

--- a/src/Raven.Studio/typescript/viewmodels/database/tasks/editReplicationSinkTask.ts
+++ b/src/Raven.Studio/typescript/viewmodels/database/tasks/editReplicationSinkTask.ts
@@ -19,7 +19,6 @@ import popoverUtils = require("common/popoverUtils");
 import prefixPathModel = require("models/database/tasks/prefixPathModel");
 import endpoints = require("endpoints");
 import getCertificatesCommand = require("commands/auth/getCertificatesCommand");
-import tasksCommonContent = require("models/database/tasks/tasksCommonContent");
 import accessManager = require("common/shell/accessManager");
 
 class editReplicationSinkTask extends viewModelBase {
@@ -156,6 +155,7 @@ class editReplicationSinkTask extends viewModelBase {
                 model.taskName,
                 model.taskState,
                 model.manualChooseMentor,
+                model.pinMentorNode,
                 model.mentorNode,
                 model.connectionStringName,
                 this.createNewConnectionString,

--- a/src/Raven.Studio/typescript/viewmodels/database/tasks/editReplicationSinkTask.ts
+++ b/src/Raven.Studio/typescript/viewmodels/database/tasks/editReplicationSinkTask.ts
@@ -234,11 +234,6 @@ class editReplicationSinkTask extends viewModelBase {
                     "<li><small>Only public keys are downloaded.</small></li>" +
                     "</ul>"
             });
-
-        popoverUtils.longWithHover($(".responsible-node"),
-            {
-                content: tasksCommonContent.responsibleNodeInfo
-            });
     }
 
     saveTask() {

--- a/src/Raven.Studio/typescript/viewmodels/database/tasks/editSqlEtlTask.ts
+++ b/src/Raven.Studio/typescript/viewmodels/database/tasks/editSqlEtlTask.ts
@@ -24,8 +24,6 @@ import documentMetadata = require("models/database/documents/documentMetadata");
 import getDocumentsMetadataByIDPrefixCommand = require("commands/database/documents/getDocumentsMetadataByIDPrefixCommand");
 import testSqlReplicationCommand = require("commands/database/tasks/testSqlReplicationCommand");
 import getDocumentWithMetadataCommand = require("commands/database/documents/getDocumentWithMetadataCommand");
-import popoverUtils = require("common/popoverUtils");
-import tasksCommonContent = require("models/database/tasks/tasksCommonContent");
 
 class sqlTaskTestMode {
     
@@ -274,11 +272,6 @@ class editSqlEtlTask extends viewModelBase {
         super.compositionComplete();
 
         $('.edit-raven-sql-task [data-toggle="tooltip"]').tooltip();
-
-        popoverUtils.longWithHover($(".responsible-node"),
-            {
-                content: tasksCommonContent.responsibleNodeInfo
-            });
     }
     
     /***************************************************/

--- a/src/Raven.Studio/typescript/viewmodels/database/tasks/editSubscriptionTask.ts
+++ b/src/Raven.Studio/typescript/viewmodels/database/tasks/editSubscriptionTask.ts
@@ -20,8 +20,6 @@ import subscriptionRqlSyntax = require("viewmodels/database/tasks/subscriptionRq
 import getPossibleMentorsCommand = require("commands/database/tasks/getPossibleMentorsCommand");
 import eventsCollector = require("common/eventsCollector");
 import generalUtils = require("common/generalUtils");
-import popoverUtils = require("common/popoverUtils");
-import tasksCommonContent = require("models/database/tasks/tasksCommonContent");
 
 type testTabName = "results" | perCollectionIncludes;
 type fetcherType = (skip: number, take: number) => JQueryPromise<pagedResult<documentObject>>;
@@ -125,11 +123,6 @@ class editSubscriptionTask extends viewModelBase {
         super.compositionComplete();
 
         $('.edit-subscription-task [data-toggle="tooltip"]').tooltip();
-
-        popoverUtils.longWithHover($(".responsible-node"),
-            {
-                content: tasksCommonContent.responsibleNodeInfo
-            });
         
         document.getElementById('taskName').focus(); 
     }

--- a/src/Raven.Studio/typescript/viewmodels/manage/editServerWideBackup.ts
+++ b/src/Raven.Studio/typescript/viewmodels/manage/editServerWideBackup.ts
@@ -159,11 +159,6 @@ class editServerWideBackup extends viewModelBase {
             {
                 content: tasksCommonContent.serverwideSnapshotEncryptionInfo
             });
-
-        popoverUtils.longWithHover($(".responsible-node"),
-            {
-                content: tasksCommonContent.responsibleNodeInfo
-            });
     }
 
     saveBackupSettings() {

--- a/src/Raven.Studio/typescript/viewmodels/manage/editServerWideExternalReplication.ts
+++ b/src/Raven.Studio/typescript/viewmodels/manage/editServerWideExternalReplication.ts
@@ -82,11 +82,6 @@ class editServerWideExternalReplication extends viewModelBase {
         super.compositionComplete();
         
         $('.edit-server-wide-replication [data-toggle="tooltip"]').tooltip();
-
-        popoverUtils.longWithHover($(".responsible-node"),
-            {
-                content: tasksCommonContent.responsibleNodeInfo
-            });
     }
    
     private initObservables() {

--- a/src/Raven.Studio/typescript/viewmodels/manage/editServerWideExternalReplication.ts
+++ b/src/Raven.Studio/typescript/viewmodels/manage/editServerWideExternalReplication.ts
@@ -8,8 +8,6 @@ import saveServerWideExternalReplicationCommand = require("commands/serverWide/t
 import connectionStringRavenEtlModel = require("models/database/settings/connectionStringRavenEtlModel");
 import generalUtils = require("common/generalUtils");
 import clusterTopologyManager = require("common/shell/clusterTopologyManager");
-import popoverUtils = require("common/popoverUtils");
-import tasksCommonContent = require("models/database/tasks/tasksCommonContent");
 import discoveryUrl = require("models/database/settings/discoveryUrl");
 
 class editServerWideExternalReplication extends viewModelBase {

--- a/src/Raven.Studio/wwwroot/App/views/database/tasks/editExternalReplicationTask.html
+++ b/src/Raven.Studio/wwwroot/App/views/database/tasks/editExternalReplicationTask.html
@@ -1,4 +1,4 @@
-<div class="content-margin edit-replication-task">
+<div class="content-margin edit-replication-task edit-ongoing-task">
     <form class="flex-form" data-bind="submit: saveExternalReplication">
         <div class="row flex-row absolute-fill">
             <div class="col-xs-12 col-lg-6 flex-vertical">
@@ -34,7 +34,7 @@
                         </div>
                         <div class="form-group">
                             <label class="control-label">&nbsp;</label>
-                            <div class="toggle" data-placement="right" data-toggle="tooltip" title="Set a delay time for the task" data-animation="true">
+                            <div class="toggle" data-placement="right" data-toggle="tooltip" title="Toggle on to set a delay time for the task" data-animation="true">
                                 <input id="setDelayTime" type="checkbox" data-bind="checked: showDelayReplication">
                                 <label for="setDelayTime">Set Replication Delay Time</label>
                             </div>
@@ -61,25 +61,32 @@
                         </div>
                         <div class="form-group">
                             <label class="control-label">&nbsp;</label>
-                            <div class="toggle responsible-node">
+                            <div class="toggle" data-placement="right" data-toggle="tooltip" title="Toggle on to set a responsible node for the task" data-animation="true">
                                 <input id="responsibleNode" type="checkbox" data-bind="checked: manualChooseMentor">
-                                <label for="responsibleNode">Set preferred responsible node</label>
+                                <label for="responsibleNode">Set responsible node</label>
                             </div>
                         </div>
                         <div data-bind="validationElement: mentorNode, collapse: manualChooseMentor">
-                            <div class="form-group">
+                            <div class="form-group" data-bind="css: { 'margin-bottom-xs': mentorNode() }">
                                 <div>
                                     <label class="control-label">Responsible Node</label>
                                 </div>
                                 <div class="flex-grow">
                                     <button class="btn btn-block dropdown-toggle text-left" data-toggle="dropdown">
-                                        <span data-bind="text: mentorNode() ? 'Node ' + mentorNode() : 'Select preferred responsible node'"></span>
+                                        <span data-bind="text: mentorNode() ? 'Node ' + mentorNode() : 'Select responsible node'"></span>
                                         <span class="caret"></span>
                                     </button>
                                     <ul class="dropdown-menu" data-bind="foreach: $root.possibleMentors">
                                         <li><a href="#" data-bind="text: 'Node ' + $data, click: $parent.mentorNode.bind($parent.mentorNode, $data)"></a></li>
                                     </ul>
                                     <span class="help-block" data-bind="validationMessage: mentorNode"></span>
+                                </div>
+                                <div data-bind="compose: 'partial/pinResponsibleNodeButtonsScript.html'"></div>
+                            </div>
+                            <div data-bind="visible: mentorNode">
+                                <div class="form-group small">
+                                    <label class="control-label">&nbsp;</label>
+                                    <div class="flex-grow" data-bind="compose: 'partial/pinResponsibleNodeTextScript.html'"></div>
                                 </div>
                             </div>
                         </div>

--- a/src/Raven.Studio/wwwroot/App/views/database/tasks/editOlapEtlTask.html
+++ b/src/Raven.Studio/wwwroot/App/views/database/tasks/editOlapEtlTask.html
@@ -1,4 +1,4 @@
-<div class="content-margin edit-raven-olap-task" data-bind="css: { 'test-mode': enableTestArea }">
+<div class="content-margin edit-raven-olap-task edit-ongoing-task" data-bind="css: { 'test-mode': enableTestArea }">
     <div class="row flex-row absolute-fill">
         <div class="col-xs-12 col-lg-6 flex-vertical">
             <form class="flex-form" data-bind="submit: saveOlapEtl" autocomplete="off" novalidate>
@@ -36,25 +36,32 @@
                             </div>
                             <div class="form-group">
                                 <label class="control-label">&nbsp;</label>
-                                <div class="toggle responsible-node">
+                                <div class="toggle" data-placement="right" data-toggle="tooltip" title="Toggle on to set a responsible node for the task" data-animation="true">
                                     <input id="responsibleNode" type="checkbox" data-bind="checked: manualChooseMentor" />
-                                    <label for="responsibleNode">Set preferred responsible node</label>
+                                    <label for="responsibleNode">Set responsible node</label>
                                 </div>
                             </div>
                             <div data-bind="validationElement: mentorNode, collapse: manualChooseMentor">
-                                <div class="form-group">
+                                <div class="form-group" data-bind="css: { 'margin-bottom-xs': mentorNode() }">
                                     <div>
                                         <label class="control-label">Responsible Node</label>
                                     </div>
                                     <div class="flex-grow">
                                         <button class="btn btn-block dropdown-toggle text-left" type="button" data-toggle="dropdown">
-                                            <span data-bind="text: mentorNode() ? 'Node ' + mentorNode() : 'Select preferred responsible node'"></span>
+                                            <span data-bind="text: mentorNode() ? 'Node ' + mentorNode() : 'Select responsible node'"></span>
                                             <span class="caret"></span>
                                         </button>
                                         <ul class="dropdown-menu" data-bind="foreach: $root.possibleMentors">
                                             <li><a href="#" data-bind="text: 'Node ' + $data, click: $parent.mentorNode.bind($parent.mentorNode, $data)"></a></li>
                                         </ul>
                                         <span class="help-block" data-bind="validationMessage: mentorNode"></span>
+                                    </div>
+                                    <div data-bind="compose: 'partial/pinResponsibleNodeButtonsScript.html'"></div>
+                                </div>
+                                <div data-bind="visible: mentorNode">
+                                    <div class="form-group small">
+                                        <label class="control-label">&nbsp;</label>
+                                        <div class="flex-grow" data-bind="compose: 'partial/pinResponsibleNodeTextScript.html'"></div>
                                     </div>
                                 </div>
                             </div>

--- a/src/Raven.Studio/wwwroot/App/views/database/tasks/editPeriodicBackupTask.html
+++ b/src/Raven.Studio/wwwroot/App/views/database/tasks/editPeriodicBackupTask.html
@@ -1,4 +1,4 @@
-<form class="content-margin edit-backup" data-bind="with: configuration" autocomplete="off">
+<form class="content-margin edit-backup edit-ongoing-task" data-bind="with: configuration" autocomplete="off">
     <div class="toolbar" data-bind="with: $root">
         <button data-bind="click: onSubmit, enable: dirtyFlag().isDirty" type="submit" class="btn btn-primary">
             <i class="icon-save"></i><span data-bind="text: configuration().backupOperation === 'manual' ? 'Backup Now' : 'Save'"></span>
@@ -67,20 +67,20 @@
                 <div class="row margin-bottom">
                     <div class="col-sm-4 col-sm-offset-4 col-lg-offset-2">
                         <div class="toggle">
-                            <div class="responsible-node">
+                            <div class="toggle" data-placement="right" data-toggle="tooltip" title="Toggle on to set a responsible node for the task" data-animation="true">
                                 <input id="responsibleNode" type="checkbox" data-bind="checked: manualChooseMentor">
-                                <label for="responsibleNode">Set preferred responsible node</label>
+                                <label for="responsibleNode">Set responsible node</label>
                             </div>
                         </div>
                     </div>
                 </div>
                 <div data-bind="validationElement: mentorNode, collapse: manualChooseMentor">
-                    <div class="row margin-bottom">
+                    <div class="row" data-bind="css: { 'margin-bottom-xs': mentorNode() }">
                         <label class="control-label col-sm-4 col-lg-2">Responsible Node</label>
-                        <div class="col-sm-4">
+                        <div class="col-sm-4 flex-horizontal">
                             <div class="dropdown btn-block">
                                 <button class="btn btn-block dropdown-toggle text-left" data-toggle="dropdown">
-                                    <span data-bind="text: mentorNode() ? 'Node ' + mentorNode() : 'Select preferred responsible node'"></span>
+                                    <span data-bind="text: mentorNode() ? 'Node ' + mentorNode() : 'Select responsible node'"></span>
                                     <span class="caret"></span>
                                 </button>
                                 <ul class="dropdown-menu" data-bind="foreach: $root.possibleMentors">
@@ -88,6 +88,12 @@
                                 </ul>
                                 <span class="help-block" data-bind="validationMessage: mentorNode"></span>
                             </div>
+                            <span data-bind="compose: 'partial/pinResponsibleNodeButtonsScript.html'"></span>
+                        </div>
+                    </div>
+                    <div class="row margin-bottom small">
+                        <div class="col-sm-offset-4 col-lg-offset-2 col-sm-4" data-bind="visible: mentorNode">
+                            <div data-bind="compose: 'partial/pinResponsibleNodeTextScript.html'"></div>
                         </div>
                     </div>
                 </div>

--- a/src/Raven.Studio/wwwroot/App/views/database/tasks/editRavenEtlTask.html
+++ b/src/Raven.Studio/wwwroot/App/views/database/tasks/editRavenEtlTask.html
@@ -1,4 +1,4 @@
-<div class="content-margin edit-raven-etl-task" data-bind="css: { 'test-mode': enableTestArea }">
+<div class="content-margin edit-raven-etl-task edit-ongoing-task" data-bind="css: { 'test-mode': enableTestArea }">
     <div class="row flex-row absolute-fill">
         <div class="col-xs-12 col-lg-6 flex-vertical">
             <form class="flex-form" data-bind="submit: saveRavenEtl" autocomplete="off">
@@ -50,25 +50,32 @@
                         </div>
                         <div class="form-group">
                             <label class="control-label">&nbsp;</label>
-                            <div class="toggle responsible-node">
+                            <div class="toggle" data-placement="right" data-toggle="tooltip" title="Toggle on to set a responsible node for the task" data-animation="true">
                                 <input id="responsibleNode" type="checkbox" data-bind="checked: manualChooseMentor">
-                                <label for="responsibleNode">Set preferred responsible node</label>
+                                <label for="responsibleNode">Set responsible node</label>
                             </div>
                         </div>
                         <div data-bind="validationElement: mentorNode, collapse: manualChooseMentor">
-                            <div class="form-group">
+                            <div class="form-group" data-bind="css: { 'margin-bottom-xs': mentorNode() }">
                                 <div>
                                     <label class="control-label">Responsible Node</label>
                                 </div>
                                 <div class="flex-grow">
                                     <button class="btn btn-block dropdown-toggle text-left" data-toggle="dropdown">
-                                        <span data-bind="text: mentorNode() ? 'Node ' + mentorNode() : 'Select preferred responsible node'"></span>
+                                        <span data-bind="text: mentorNode() ? 'Node ' + mentorNode() : 'Select responsible node'"></span>
                                         <span class="caret"></span>
                                     </button>
                                     <ul class="dropdown-menu" data-bind="foreach: $root.possibleMentors">
                                         <li><a href="#" data-bind="text: 'Node ' + $data, click: $parent.mentorNode.bind($parent.mentorNode, $data)"></a></li>
                                     </ul>
                                     <span class="help-block" data-bind="validationMessage: mentorNode"></span>
+                                </div>
+                                <div data-bind="compose: 'partial/pinResponsibleNodeButtonsScript.html'"></div>
+                            </div>
+                            <div data-bind="visible: mentorNode">
+                                <div class="form-group small">
+                                    <label class="control-label">&nbsp;</label>
+                                    <div class="flex-grow" data-bind="compose: 'partial/pinResponsibleNodeTextScript.html'"></div>
                                 </div>
                             </div>
                         </div>

--- a/src/Raven.Studio/wwwroot/App/views/database/tasks/editReplicationHubTask.html
+++ b/src/Raven.Studio/wwwroot/App/views/database/tasks/editReplicationHubTask.html
@@ -1,4 +1,4 @@
-<div class="content-margin edit-pull-replication-hub-task">
+<div class="content-margin edit-pull-replication-hub-task edit-ongoing-task">
     <form class="flex-form" autocomplete="off">
         <div class="row flex-row absolute-fill" data-bind="with: editedHubTask">
             <div class="col-xs-12 col-lg-6">
@@ -57,25 +57,32 @@
                             </div>
                             <div class="form-group margin-bottom margin-bottom-xs">
                                 <label class="control-label">&nbsp;</label>
-                                <div class="toggle responsible-node">
+                                <div class="toggle" data-placement="right" data-toggle="tooltip" title="Toggle on to set a responsible node for the task" data-animation="true">
                                     <input id="responsibleNode" type="checkbox" data-bind="checked: manualChooseMentor" />
-                                    <label for="responsibleNode">Set preferred responsible node</label>
+                                    <label for="responsibleNode">Set responsible node</label>
                                 </div>
                             </div>
                             <div data-bind="validationElement: mentorNode, collapse: manualChooseMentor">
-                                <div class="form-group">
+                                <div class="form-group" data-bind="css: { 'margin-bottom-xs': mentorNode() }">
                                     <div>
                                         <label class="control-label">Responsible Node</label>
                                     </div>
                                     <div class="flex-grow">
                                         <button class="btn btn-block dropdown-toggle text-left" data-toggle="dropdown">
-                                            <span data-bind="text: mentorNode() ? 'Node ' + mentorNode() : 'Select preferred responsible node'"></span>
+                                            <span data-bind="text: mentorNode() ? 'Node ' + mentorNode() : 'Select responsible node'"></span>
                                             <span class="caret"></span>
                                         </button>
                                         <ul class="dropdown-menu" data-bind="foreach: $root.possibleMentors">
                                             <li><a href="#" data-bind="text: 'Node ' + $data, click: $parent.mentorNode.bind($parent.mentorNode, $data)"></a></li>
                                         </ul>
                                         <span class="help-block" data-bind="validationMessage: mentorNode"></span>
+                                    </div>
+                                    <div data-bind="compose: 'partial/pinResponsibleNodeButtonsScript.html'"></div>
+                                </div>
+                                <div data-bind="visible: mentorNode">
+                                    <div class="form-group small">
+                                        <label class="control-label">&nbsp;</label>
+                                        <div class="flex-grow" data-bind="compose: 'partial/pinResponsibleNodeTextScript.html'"></div>
                                     </div>
                                 </div>
                             </div>

--- a/src/Raven.Studio/wwwroot/App/views/database/tasks/editReplicationSinkTask.html
+++ b/src/Raven.Studio/wwwroot/App/views/database/tasks/editReplicationSinkTask.html
@@ -1,4 +1,4 @@
-<div class="content-margin edit-pull-replication-sink-task">
+<div class="content-margin edit-pull-replication-sink-task edit-ongoing-task">
     <form class="flex-form" data-bind="submit: saveTask" autocomplete="off">
         <div class="row flex-row absolute-fill">
             <div class="col-xs-12 col-lg-6 flex-vertical">
@@ -53,25 +53,32 @@
                         </div>
                         <div class="form-group margin-bottom margin-bottom-xs">
                             <label class="control-label">&nbsp;</label>
-                            <div class="toggle responsible-node">
+                            <div class="toggle" data-placement="right" data-toggle="tooltip" title="Toggle on to set a responsible node for the task" data-animation="true">
                                 <input id="manualMentorNode" type="checkbox" data-bind="checked: manualChooseMentor" />
-                                <label for="manualMentorNode">Set preferred responsible node</label>
+                                <label for="manualMentorNode">Set responsible node</label>
                             </div>
                         </div>
                         <div data-bind="validationElement: mentorNode, collapse: manualChooseMentor">
-                            <div class="form-group">
+                            <div class="form-group" data-bind="css: { 'margin-bottom-xs': mentorNode() }">
                                 <div>
                                     <label class="control-label">Responsible Node</label>
                                 </div>
                                 <div class="flex-grow">
                                     <button class="btn btn-block dropdown-toggle text-left" data-toggle="dropdown">
-                                        <span data-bind="text: mentorNode() ? 'Node ' + mentorNode() : 'Select preferred responsible node'"></span>
+                                        <span data-bind="text: mentorNode() ? 'Node ' + mentorNode() : 'Select responsible node'"></span>
                                         <span class="caret"></span>
                                     </button>
                                     <ul class="dropdown-menu" data-bind="foreach: $root.possibleMentors">
                                         <li><a href="#" data-bind="text: 'Node ' + $data, click: $parent.mentorNode.bind($parent.mentorNode, $data)"></a></li>
                                     </ul>
                                     <span class="help-block" data-bind="validationMessage: mentorNode"></span>
+                                </div>
+                                <div data-bind="compose: 'partial/pinResponsibleNodeButtonsScript.html'"></div>
+                            </div>
+                            <div data-bind="visible: mentorNode">
+                                <div class="form-group small">
+                                    <label class="control-label">&nbsp;</label>
+                                    <div class="flex-grow" data-bind="compose: 'partial/pinResponsibleNodeTextScript.html'"></div>
                                 </div>
                             </div>
                         </div>

--- a/src/Raven.Studio/wwwroot/App/views/database/tasks/editSqlEtlTask.html
+++ b/src/Raven.Studio/wwwroot/App/views/database/tasks/editSqlEtlTask.html
@@ -1,4 +1,4 @@
-<div class="content-margin edit-raven-sql-task" data-bind="css: { 'test-mode': enableTestArea }">
+<div class="content-margin edit-raven-sql-task edit-ongoing-task" data-bind="css: { 'test-mode': enableTestArea }">
     <div class="row flex-row absolute-fill">
         <div class="col-xs-12 col-lg-6 flex-vertical">
             <form class="flex-form" data-bind="submit: saveSqlEtl" autocomplete="off">
@@ -52,25 +52,32 @@
                             </div>
                             <div class="form-group">
                                 <label class="control-label">&nbsp;</label>
-                                <div class="toggle responsible-node">
+                                <div class="toggle" data-placement="right" data-toggle="tooltip" title="Toggle on to set a responsible node for the task" data-animation="true">
                                     <input id="responsibleNode" type="checkbox" data-bind="checked: manualChooseMentor">
-                                    <label for="responsibleNode">Set preferred responsible node</label>
+                                    <label for="responsibleNode">Set responsible node</label>
                                 </div>
                             </div>
                             <div data-bind="validationElement: mentorNode, collapse: manualChooseMentor"> 
-                                <div class="form-group">
+                                <div class="form-group" data-bind="css: { 'margin-bottom-xs': mentorNode() }">
                                     <div>
                                         <label class="control-label">Responsible Node</label>
                                     </div>
                                     <div class="flex-grow"> 
                                         <button class="btn btn-block dropdown-toggle text-left" type="button" data-toggle="dropdown">
-                                            <span data-bind="text: mentorNode() ? 'Node ' + mentorNode() : 'Select preferred responsible node'"></span>
+                                            <span data-bind="text: mentorNode() ? 'Node ' + mentorNode() : 'Select responsible node'"></span>
                                             <span class="caret"></span>
                                         </button>
                                         <ul class="dropdown-menu" data-bind="foreach: $root.possibleMentors">
                                             <li><a href="#" data-bind="text: 'Node ' + $data, click: $parent.mentorNode.bind($parent.mentorNode, $data)"></a></li>
                                         </ul>
                                         <span class="help-block" data-bind="validationMessage: mentorNode"></span>
+                                    </div>
+                                    <div data-bind="compose: 'partial/pinResponsibleNodeButtonsScript.html'"></div>
+                                </div>
+                                <div data-bind="visible: mentorNode">
+                                    <div class="form-group small">
+                                        <label class="control-label">&nbsp;</label>
+                                        <div class="flex-grow" data-bind="compose: 'partial/pinResponsibleNodeTextScript.html'"></div>
                                     </div>
                                 </div>
                             </div>

--- a/src/Raven.Studio/wwwroot/App/views/database/tasks/editSubscriptionTask.html
+++ b/src/Raven.Studio/wwwroot/App/views/database/tasks/editSubscriptionTask.html
@@ -1,4 +1,4 @@
-    <div class="edit-subscription flex-vertical absolute-fill content-margin edit-subscription-task">
+    <div class="edit-subscription flex-vertical absolute-fill content-margin edit-subscription-task edit-ongoing-task">
         <div class="row flex-row flex-grow flex-stretch-items">
             <div class="col-sm-12 col-lg-6 flex-vertical">
                 <form data-bind="submit: saveSubscription">
@@ -62,7 +62,7 @@
                         </div>
                         <div class="panel padding flex-form">
                             <div class="form-group">
-                                <div class="toggle">
+                                <div class="toggle" data-placement="right" data-toggle="tooltip" title="Toggle on to set starting point from which documents will be sent" data-animation="true">
                                     <input id="use-starting-point" type="checkbox" data-bind="checked: setStartingPoint">
                                     <label for="use-starting-point">Use a defined starting point</label>
                                 </div>
@@ -101,25 +101,32 @@
                                 </div>
                             </div>
                             <div class="form-group">
-                                <div class="toggle responsible-node">
+                                <div class="toggle" data-placement="right" data-toggle="tooltip" title="Toggle on to set a responsible node for the task" data-animation="true">
                                     <input id="responsibleNode" type="checkbox" data-bind="checked: manualChooseMentor">
-                                    <label for="responsibleNode">Set preferred responsible node</label>
+                                    <label for="responsibleNode">Set responsible node</label>
                                 </div>
                             </div>
                             <div data-bind="validationElement: mentorNode, collapse: manualChooseMentor">
-                                <div class="for-group">
+                                <div class="form-group" data-bind="css: { 'margin-bottom-xs': mentorNode() }">
                                     <div>
                                         <label class="control-label">Responsible Node</label>
                                     </div>
                                     <div class="flex-grow">
                                         <button class="btn btn-block dropdown-toggle text-left" data-toggle="dropdown">
-                                            <span data-bind="text: mentorNode() ? 'Node ' + mentorNode() : 'Select preferred responsible node'"></span>
+                                            <span data-bind="text: mentorNode() ? 'Node ' + mentorNode() : 'Select responsible node'"></span>
                                             <span class="caret"></span>
                                         </button>
                                         <ul class="dropdown-menu" data-bind="foreach: $root.possibleMentors">
                                             <li><a href="#" data-bind="text: 'Node ' + $data, click: $parent.mentorNode.bind($parent.mentorNode, $data)"></a></li>
                                         </ul>
                                         <span class="help-block" data-bind="validationMessage: mentorNode"></span>
+                                    </div>
+                                    <div data-bind="compose: 'partial/pinResponsibleNodeButtonsScript.html'"></div>
+                                </div>
+                                <div data-bind="visible: mentorNode">
+                                    <div class="form-group small">
+                                        <label class="control-label">&nbsp;</label>
+                                        <div class="flex-grow" data-bind="compose: 'partial/pinResponsibleNodeTextScript.html'"></div>
                                     </div>
                                 </div>
                             </div>

--- a/src/Raven.Studio/wwwroot/App/views/manage/editServerWideBackup.html
+++ b/src/Raven.Studio/wwwroot/App/views/manage/editServerWideBackup.html
@@ -1,4 +1,4 @@
-<form class="content-margin edit-backup" data-bind="with: editedTask" autocomplete="off">
+<form class="content-margin edit-backup edit-ongoing-task" data-bind="with: editedTask" autocomplete="off">
     <div class="toolbar" data-bind="with: $root">
         <button type="submit" class="btn btn-primary"
                 data-bind="click: saveBackupSettings, disable: spinners.save() || !dirtyFlag().isDirty(), css: { 'btn-spinner': spinners.save }">
@@ -67,20 +67,20 @@
             <div class="row margin-bottom margin-bottom-sm">
                 <div class="col-sm-offset-4 col-lg-offset-2 col-sm-4">
                     <div class="toggle">
-                        <div class="responsible-node">
+                        <div class="toggle" data-placement="right" data-toggle="tooltip" title="Toggle on to set a responsible node for the task" data-animation="true">
                             <input id="responsibleNode" type="checkbox" data-bind="checked: manualChooseMentor">
-                            <label for="responsibleNode">Set preferred responsible node</label>
+                            <label for="responsibleNode">Set responsible node</label>
                         </div>
                     </div>
                 </div>
             </div>
             <div data-bind="validationElement: mentorNode, collapse: manualChooseMentor">
-                <div class="row margin-bottom">
+                <div class="row" data-bind="css: { 'margin-bottom-xs': mentorNode() }">
                     <label class="control-label col-sm-4 col-lg-2">Responsible Node</label>
-                    <div class="col-sm-4">
-                        <div class="dropdown btn-block margin-bottom margin-bottom-sm">
+                    <div class="col-sm-4 flex-horizontal">
+                        <div class="dropdown btn-block">
                             <button class="btn btn-block dropdown-toggle text-left" data-toggle="dropdown">
-                                <span data-bind="text: mentorNode() ? 'Node ' + mentorNode() : 'Select preferred responsible node'"></span>
+                                <span data-bind="text: mentorNode() ? 'Node ' + mentorNode() : 'Select responsible node'"></span>
                                 <span class="caret"></span>
                             </button>
                             <ul class="dropdown-menu" data-bind="foreach: $root.possibleMentors">
@@ -88,6 +88,12 @@
                             </ul>
                             <span class="help-block" data-bind="validationMessage: mentorNode"></span>
                         </div>
+                        <span data-bind="compose: 'partial/pinResponsibleNodeButtonsScript.html'"></span>
+                    </div>
+                </div>
+                <div class="row margin-bottom small">
+                    <div class="col-sm-offset-4 col-lg-offset-2 col-sm-4" data-bind="visible: mentorNode">
+                        <div data-bind="compose: 'partial/pinResponsibleNodeTextScript.html'"></div>
                     </div>
                 </div>
             </div>

--- a/src/Raven.Studio/wwwroot/App/views/manage/editServerWideExternalReplication.html
+++ b/src/Raven.Studio/wwwroot/App/views/manage/editServerWideExternalReplication.html
@@ -1,4 +1,4 @@
-<div class="content-margin edit-server-wide-replication">
+<div class="content-margin edit-server-wide-replication edit-ongoing-task">
     <form class="flex-form" data-bind="submit: saveServerWideExternalReplication" autocomplete="off">
         <div class="row flex-row absolute-fill">
             <div class="col-xs-12 col-lg-6 flex-vertical">
@@ -61,20 +61,20 @@
                         </div>
                         <div class="form-group">
                             <label class="control-label">&nbsp;</label>
-                            <div class="toggle responsible-node">
+                            <div class="toggle" data-placement="right" data-toggle="tooltip" title="Toggle on to set a responsible node for the task" data-animation="true">
                                 <input id="responsibleNode" type="checkbox" data-bind="checked: manualChooseMentor">
-                                <label for="responsibleNode">Set preferred responsible node</label>
+                                <label for="responsibleNode">Set responsible node</label>
                             </div>
                         </div>
                         <div data-bind="collapse: manualChooseMentor">
-                            <div class="form-group">
+                            <div class="form-group" data-bind="css: { 'margin-bottom-xs': mentorNode() }">
                                 <div>
                                     <label class="control-label">Responsible Node</label>
                                 </div>
                                 <div class="flex-grow" data-bind="validationElement: mentorNode">
                                     <div class="dropdown btn-block margin-bottom">
                                         <button class="btn btn-block dropdown-toggle text-left" data-toggle="dropdown">
-                                            <span data-bind="text: mentorNode() ? 'Node ' + mentorNode() : 'Select preferred responsible node'"></span>
+                                            <span data-bind="text: mentorNode() ? 'Node ' + mentorNode() : 'Select responsible node'"></span>
                                             <span class="caret"></span>
                                         </button>
                                         <ul class="dropdown-menu" data-bind="foreach: $root.possibleMentors">
@@ -82,6 +82,13 @@
                                         </ul>
                                         <span class="help-block" data-bind="validationMessage: mentorNode"></span>
                                     </div>
+                                </div>
+                                <div data-bind="compose: 'partial/pinResponsibleNodeButtonsScript.html'"></div>
+                            </div>
+                            <div data-bind="visible: mentorNode">
+                                <div class="form-group small">
+                                    <label class="control-label">&nbsp;</label>
+                                    <div class="flex-grow" data-bind="compose: 'partial/pinResponsibleNodeTextScript.html'"></div>
                                 </div>
                             </div>
                         </div>

--- a/src/Raven.Studio/wwwroot/App/views/partial/pinResponsibleNodeButtonsScript.html
+++ b/src/Raven.Studio/wwwroot/App/views/partial/pinResponsibleNodeButtonsScript.html
@@ -1,0 +1,10 @@
+<button class="input-group-addon btn btn-default toggle" data-placement="top" data-toggle="tooltip"
+        title="Click to Pin the selected node as the responsible node" data-animation="true"
+        data-bind="visible: !pinMentorNode(), click: togglePinMentorNode, disable: !mentorNode()">
+    <i class="icon-pin"></i>
+</button>
+<button class="input-group-addon btn btn-default toggle" data-placement="top" data-toggle="tooltip"
+        title="Click to Unpin the selected node" data-animation="true"
+        data-bind="visible: pinMentorNode, click: togglePinMentorNode, disable: !mentorNode()">
+    <i class="icon-pinned"></i>
+</button>

--- a/src/Raven.Studio/wwwroot/App/views/partial/pinResponsibleNodeTextScript.html
+++ b/src/Raven.Studio/wwwroot/App/views/partial/pinResponsibleNodeTextScript.html
@@ -1,0 +1,10 @@
+<div class="text-info bg-info flex-horizontal padding padding-xs">
+    <span class="flex-start"><i class="icon-info"></i></span>
+    <span class="margin-left margin-left-sm" data-bind="visible: !pinMentorNode()">
+            The selected node will be the Preferred Node to handle the task.<br />
+            When this node is down, the cluster selects another node from the Database Group to handle the task.</span>
+    <span class="margin-left margin-left-sm" data-bind="visible: pinMentorNode">
+            The selected node is now Pinned to handle this task.<br />
+            When this node is down, the task will Not execute as no other node will be selected to handle the task.<br />
+            In case the node is removed from the Database Group, a failover will occur as the cluster will select another node to handle the task.</span>
+</div>

--- a/src/Raven.Studio/wwwroot/Content/css/pages/ongoing-tasks.less
+++ b/src/Raven.Studio/wwwroot/Content/css/pages/ongoing-tasks.less
@@ -138,3 +138,15 @@
         color: @backup-color;
     }
 }
+
+.edit-ongoing-task {
+    
+    .icon-pinned {
+        color: @brand-primary;
+        top: -1px;
+    }
+
+    .icon-pin {
+        top: -1px;
+    }
+}

--- a/test/FastTests/Client/Indexing/IndexExtensionFromClient.cs
+++ b/test/FastTests/Client/Indexing/IndexExtensionFromClient.cs
@@ -75,7 +75,7 @@ namespace My.Crazy.Namespace
                 Assert.Equal(1, additionalSources.Count);
                 Assert.Equal(getRealCountry, additionalSources["Helper"]);
 
-                //WaitForUserToContinueTheTest(store);
+                WaitForUserToContinueTheTest(store);
 
                 async Task<Dictionary<string, string>> GetAdditionalSources()
                 {

--- a/test/FastTests/Client/Indexing/IndexExtensionFromClient.cs
+++ b/test/FastTests/Client/Indexing/IndexExtensionFromClient.cs
@@ -75,7 +75,7 @@ namespace My.Crazy.Namespace
                 Assert.Equal(1, additionalSources.Count);
                 Assert.Equal(getRealCountry, additionalSources["Helper"]);
 
-                WaitForUserToContinueTheTest(store);
+                //WaitForUserToContinueTheTest(store);
 
                 async Task<Dictionary<string, string>> GetAdditionalSources()
                 {

--- a/test/FastTests/Client/Indexing/JavaScriptIndexTests.cs
+++ b/test/FastTests/Client/Indexing/JavaScriptIndexTests.cs
@@ -197,7 +197,7 @@ namespace FastTests.Client.Indexing
                     });
                     session.SaveChanges();
                     Indexes.WaitForIndexing(store);
-                    //WaitForUserToContinueTheTest(store);
+                    WaitForUserToContinueTheTest(store);
                     var result = session.Query<FanoutByNumbersWithReduce.Result>("FanoutByNumbersWithReduce")
                         .Where(x => x.Sum == 33)
                         .Single();
@@ -222,7 +222,7 @@ namespace FastTests.Client.Indexing
                     });
                     session.SaveChanges();
                     Indexes.WaitForIndexing(store);
-                    //WaitForUserToContinueTheTest(store);
+                    WaitForUserToContinueTheTest(store);
                     session.Query<User>("UsersByNameAndAnalyzedName").ProjectInto<UsersByNameAndAnalyzedName.Result>().Search(x => x.AnalyzedName, "Brendan")
                         .Single();
                 }
@@ -383,7 +383,7 @@ namespace FastTests.Client.Indexing
                 });
                 session.SaveChanges();
                 Indexes.WaitForIndexing(store);
-                //WaitForUserToContinueTheTest(store);
+                WaitForUserToContinueTheTest(store);
                 session.Query<Location>(indexName).Spatial("Location", criteria => criteria.WithinRadius(kalab, 32.56829122491778, 34.953954053921734)).Single(x => x.Description == "Dor beach");
             }
         }

--- a/test/FastTests/Client/Indexing/JavaScriptIndexTests.cs
+++ b/test/FastTests/Client/Indexing/JavaScriptIndexTests.cs
@@ -197,7 +197,7 @@ namespace FastTests.Client.Indexing
                     });
                     session.SaveChanges();
                     Indexes.WaitForIndexing(store);
-                    WaitForUserToContinueTheTest(store);
+                    //WaitForUserToContinueTheTest(store);
                     var result = session.Query<FanoutByNumbersWithReduce.Result>("FanoutByNumbersWithReduce")
                         .Where(x => x.Sum == 33)
                         .Single();
@@ -222,7 +222,7 @@ namespace FastTests.Client.Indexing
                     });
                     session.SaveChanges();
                     Indexes.WaitForIndexing(store);
-                    WaitForUserToContinueTheTest(store);
+                    //WaitForUserToContinueTheTest(store);
                     session.Query<User>("UsersByNameAndAnalyzedName").ProjectInto<UsersByNameAndAnalyzedName.Result>().Search(x => x.AnalyzedName, "Brendan")
                         .Single();
                 }
@@ -383,7 +383,7 @@ namespace FastTests.Client.Indexing
                 });
                 session.SaveChanges();
                 Indexes.WaitForIndexing(store);
-                WaitForUserToContinueTheTest(store);
+                //WaitForUserToContinueTheTest(store);
                 session.Query<Location>(indexName).Spatial("Location", criteria => criteria.WithinRadius(kalab, 32.56829122491778, 34.953954053921734)).Single(x => x.Description == "Dor beach");
             }
         }

--- a/test/FastTests/Client/Indexing/TimeSeries/BasicTimeSeriesIndexes.cs
+++ b/test/FastTests/Client/Indexing/TimeSeries/BasicTimeSeriesIndexes.cs
@@ -566,7 +566,7 @@ namespace FastTests.Client.Indexing.TimeSeries
                 terms = store.Maintenance.Send(new GetTermsOperation(indexName, "HeartBeat", null));
                 Assert.Equal(0, terms.Length);
 
-                //WaitForUserToContinueTheTest(store);
+                WaitForUserToContinueTheTest(store);
             }
         }
 
@@ -787,7 +787,7 @@ namespace FastTests.Client.Indexing.TimeSeries
 
                 Indexes.WaitForIndexing(store);
 
-                //WaitForUserToContinueTheTest(store);
+                WaitForUserToContinueTheTest(store);
 
                 var terms = store.Maintenance.Send(new GetTermsOperation(indexName, "User", null));
                 Assert.Equal(1, terms.Length);

--- a/test/FastTests/Client/Indexing/TimeSeries/BasicTimeSeriesIndexes.cs
+++ b/test/FastTests/Client/Indexing/TimeSeries/BasicTimeSeriesIndexes.cs
@@ -566,7 +566,7 @@ namespace FastTests.Client.Indexing.TimeSeries
                 terms = store.Maintenance.Send(new GetTermsOperation(indexName, "HeartBeat", null));
                 Assert.Equal(0, terms.Length);
 
-                WaitForUserToContinueTheTest(store);
+                //WaitForUserToContinueTheTest(store);
             }
         }
 
@@ -787,7 +787,7 @@ namespace FastTests.Client.Indexing.TimeSeries
 
                 Indexes.WaitForIndexing(store);
 
-                WaitForUserToContinueTheTest(store);
+                //WaitForUserToContinueTheTest(store);
 
                 var terms = store.Maintenance.Send(new GetTermsOperation(indexName, "User", null));
                 Assert.Equal(1, terms.Length);

--- a/test/FastTests/Client/Subscriptions/SubscriptionsBasic.cs
+++ b/test/FastTests/Client/Subscriptions/SubscriptionsBasic.cs
@@ -1111,7 +1111,7 @@ namespace FastTests.Client.Subscriptions
                 Projection = x => new { RavenQuery.Load<B>(x.BId).SomeProp }
             });
 
-            WaitForUserToContinueTheTest(store);
+            //WaitForUserToContinueTheTest(store);
 
             await using (var sub = store.Subscriptions.GetSubscriptionWorker<ProjectionObject>(name))
             {

--- a/test/FastTests/Client/Subscriptions/SubscriptionsBasic.cs
+++ b/test/FastTests/Client/Subscriptions/SubscriptionsBasic.cs
@@ -1111,7 +1111,7 @@ namespace FastTests.Client.Subscriptions
                 Projection = x => new { RavenQuery.Load<B>(x.BId).SomeProp }
             });
 
-            //WaitForUserToContinueTheTest(store);
+            WaitForUserToContinueTheTest(store);
 
             await using (var sub = store.Subscriptions.GetSubscriptionWorker<ProjectionObject>(name))
             {

--- a/test/FastTests/Server/Replication/ReplicationTestBase.cs
+++ b/test/FastTests/Server/Replication/ReplicationTestBase.cs
@@ -225,7 +225,7 @@ namespace FastTests.Server.Replication
             }
         }
 
-        protected static async Task<ModifyOngoingTaskResult> AddWatcherToReplicationTopology<T>(
+        protected internal static async Task<ModifyOngoingTaskResult> AddWatcherToReplicationTopology<T>(
             IDocumentStore store,
             T watcher,
             string[] urls = null) where T : ExternalReplicationBase
@@ -391,7 +391,7 @@ namespace FastTests.Server.Replication
             }
         }
 
-        protected static async Task<OngoingTasksHandler> InstantiateOutgoingTaskHandler(string name, RavenServer server)
+        protected internal static async Task<OngoingTasksHandler> InstantiateOutgoingTaskHandler(string name, RavenServer server)
         {
             Assert.True(server.ServerStore.DatabasesLandlord.DatabasesCache.TryGetValue(name, out var db));
             var database = await db;

--- a/test/FastTests/Server/Replication/ReplicationTestBase.cs
+++ b/test/FastTests/Server/Replication/ReplicationTestBase.cs
@@ -225,7 +225,7 @@ namespace FastTests.Server.Replication
             }
         }
 
-        protected internal static async Task<ModifyOngoingTaskResult> AddWatcherToReplicationTopology<T>(
+        protected static async Task<ModifyOngoingTaskResult> AddWatcherToReplicationTopology<T>(
             IDocumentStore store,
             T watcher,
             string[] urls = null) where T : ExternalReplicationBase
@@ -391,7 +391,7 @@ namespace FastTests.Server.Replication
             }
         }
 
-        protected internal static async Task<OngoingTasksHandler> InstantiateOutgoingTaskHandler(string name, RavenServer server)
+        protected static async Task<OngoingTasksHandler> InstantiateOutgoingTaskHandler(string name, RavenServer server)
         {
             Assert.True(server.ServerStore.DatabasesLandlord.DatabasesCache.TryGetValue(name, out var db));
             var database = await db;

--- a/test/SlowTests/Server/Documents/ETL/EtlTestBase.cs
+++ b/test/SlowTests/Server/Documents/ETL/EtlTestBase.cs
@@ -47,12 +47,12 @@ namespace SlowTests.Server.Documents.ETL
             return addResult;
         }
 
-        protected AddEtlOperationResult AddEtl(DocumentStore src, DocumentStore dst, string collection, string script, bool applyToAllDocuments = false, bool disabled = false, string mentor = null)
+        protected AddEtlOperationResult AddEtl(DocumentStore src, DocumentStore dst, string collection, string script, bool applyToAllDocuments = false, bool disabled = false, string mentor = null, bool pinToMentorNode = false)
         {
-            return AddEtl(src, dst, new[] { collection }, script, applyToAllDocuments, disabled, mentor);
+            return AddEtl(src, dst, new[] { collection }, script, applyToAllDocuments, disabled, mentor, pinToMentorNode);
         }
 
-        protected AddEtlOperationResult AddEtl(DocumentStore src, DocumentStore dst, IEnumerable<string> collections, string script, bool applyToAllDocuments = false, bool disabled = false, string mentor = null)
+        protected AddEtlOperationResult AddEtl(DocumentStore src, DocumentStore dst, IEnumerable<string> collections, string script, bool applyToAllDocuments = false, bool disabled = false, string mentor = null, bool pinToMentorNode = false)
         {
             var connectionStringName = $"{src.Database}@{src.Urls.First()} to {dst.Database}@{dst.Urls.First()}";
 
@@ -72,6 +72,8 @@ namespace SlowTests.Server.Documents.ETL
                         }
                     },
                 MentorNode = mentor,
+                PinToMentorNode = pinToMentorNode
+                
             },
                 new RavenConnectionString
                 {

--- a/test/SlowTests/Server/Documents/ETL/PinOnGoingTaskToMentorNode.cs
+++ b/test/SlowTests/Server/Documents/ETL/PinOnGoingTaskToMentorNode.cs
@@ -1,0 +1,328 @@
+﻿using System;
+using System.Collections.Generic;
+using System.Linq;
+using System.Threading;
+using System.Threading.Tasks;
+using Raven.Client.Documents;
+using Raven.Client.Documents.Operations.Backups;
+using Raven.Client.Documents.Operations.ConnectionStrings;
+using Raven.Client.Documents.Operations.ETL;
+using Raven.Client.Documents.Operations.OngoingTasks;
+using Raven.Client.Documents.Operations.Replication;
+using Raven.Client.Documents.Subscriptions;
+using Raven.Client.ServerWide;
+using Raven.Client.ServerWide.Operations;
+using Raven.Server.Config;
+using Raven.Tests.Core.Utils.Entities;
+using Tests.Infrastructure;
+using Xunit;
+using Xunit.Abstractions;
+
+namespace SlowTests.Server.Documents.ETL;
+
+public class PinOnGoingTaskToMentorNode : ClusterTestBase
+{
+    public PinOnGoingTaskToMentorNode(ITestOutputHelper output) : base(output)
+    {
+    }
+
+    [Fact]
+    public async Task ETL_Task_Should_Be_Pinned_To_Mentor_Node()
+    {
+        const string srcDb = "ETL-src";
+        const string dstDb = "ETL-dst";
+        
+        var srcRaft = await CreateRaftCluster(3);
+        var leader = srcRaft.Leader;
+
+        var srcNodes = await CreateDatabaseInCluster(srcDb, 3, leader.WebUrl);
+        var destNodes = await CreateDatabaseInCluster(dstDb, 2, leader.WebUrl);
+
+        var mentorNode = srcNodes.Servers.First(s => s != leader);
+        var mentorTag = mentorNode.ServerStore.NodeTag;
+        using (var src = new DocumentStore
+               {
+                   Urls = srcNodes.Servers.Select(s => s.WebUrl).ToArray(),
+                   Database = srcDb,
+               }.Initialize())
+
+        using (var dest = new DocumentStore
+               {
+                   Urls = new[]
+                   {
+                       destNodes.Servers.First(u => u != mentorNode).WebUrl
+                   },
+                   Database = dstDb,
+               }.Initialize())
+        {
+            const string name = "PinToMentorNode";
+            var urls =  destNodes.Servers.Select(u => u.WebUrl);
+            var config = new RavenEtlConfiguration
+            {
+                Name = name,
+                ConnectionStringName = name,
+                MentorNode = mentorTag,
+                PinToMentorNode = true,
+                Transforms =
+                {
+                    new Transformation
+                    {
+                        Name = $"ETL : {name}",
+                        Collections = new List<string>(new[] {"Users"}),
+                        Script = null,
+                        ApplyToAllDocuments = false,
+                        Disabled = false
+                    }
+                },
+                LoadRequestTimeoutInSec = 30,
+            };
+
+            var connectionString = new RavenConnectionString
+            {
+                Name = name,
+                Database = dest.Database,
+                TopologyDiscoveryUrls = urls.ToArray(),
+            };
+            
+            var result = src.Maintenance.Send(new PutConnectionStringOperation<RavenConnectionString>(connectionString));
+            Assert.NotNull(result.RaftCommandIndex);
+
+            src.Maintenance.Send(new AddEtlOperation<RavenConnectionString>(config));
+            
+            var ongoingTask = src.Maintenance.Send(new GetOngoingTaskInfoOperation(name, OngoingTaskType.RavenEtl));
+
+            var responsibleNodeNodeTag = ongoingTask.ResponsibleNode.NodeTag;
+            var originalTaskNodeServer = srcNodes.Servers.Single(s => s.ServerStore.NodeTag == responsibleNodeNodeTag);
+
+            using (var session = src.OpenSession())
+            {
+                session.Store(new User()
+                {
+                    Name = "Joe Doe"
+                }, "users/1");
+
+                session.SaveChanges();
+            }
+            
+            Assert.True(WaitForDocument<User>(dest, "users/1", u => u.Name == "Joe Doe", 30_000));
+
+
+            var originalResult = await DisposeServerAndWaitForFinishOfDisposalAsync(originalTaskNodeServer);
+
+            using (var session = src.OpenSession())
+            {
+                session.Store(new User()
+                {
+                    Name = "Joe Doe2"
+                }, "users/2");
+
+                session.SaveChanges();
+            }
+            
+            Assert.False(WaitForDocument<User>(dest, "users/2", u => u.Name == "Joe Doe2", 10_000));
+
+            var revivedServer =GetNewServer(new ServerCreationOptions
+            {
+                CustomSettings = new Dictionary<string, string>
+                {
+                    {RavenConfiguration.GetKey(x => x.Core.ServerUrls), originalResult.Url}
+                },
+                RunInMemory = false,
+                DeletePrevious = false,
+                DataDirectory = originalResult.DataDirectory
+            });
+
+            var waitForNotPassive = revivedServer.ServerStore.Engine.WaitForLeaveState(RachisState.Passive,CancellationToken.None);
+            Assert.True(waitForNotPassive.Wait(TimeSpan.FromSeconds(10_000)));
+            using (var session = src.OpenSession())
+            {
+                session.Store(new User()
+                    {
+                        Name = "Joe Doe3"
+                    },
+                    "users/3");
+
+                session.SaveChanges();
+            }
+
+            Assert.True(WaitForDocument<User>(dest, "users/3", u => u.Name == "Joe Doe3", 10_000));
+            Assert.True(WaitForDocument<User>(dest, "users/2", u => u.Name == "Joe Doe2", 10_000));
+        
+        }
+    }
+
+    [Fact]
+    public async Task ETL_Should_Fail_Over_When_Removing_Mentor_Node_And_Pin_To_MentorNode()
+    {
+        const string srcDb = "ETL-src";
+        const string dstDb = "ETL-dst";
+        
+        var srcRaft = await CreateRaftCluster(5);
+        var leader = srcRaft.Leader;
+
+        var srcNodes = await CreateDatabaseInCluster(srcDb, 5, leader.WebUrl);
+        var destNodes = await CreateDatabaseInCluster(dstDb, 3, leader.WebUrl);
+
+        var mentorNode = srcNodes.Servers.First(s => s != leader);
+        var mentorTag = mentorNode.ServerStore.NodeTag;
+
+        using (var src = new DocumentStore
+               {
+                   Urls = new [] {leader.WebUrl},
+                   Database = srcDb,
+               }.Initialize())
+
+        using (var dest = new DocumentStore
+               {
+                   Urls =  new [] {destNodes.Servers.First(u => u != mentorNode).WebUrl},
+                   Database = dstDb,
+               }.Initialize())
+        {
+            const string name = "PinToMentorNode";
+            var urls =  destNodes.Servers.Select(u => u.WebUrl);
+            var config = new RavenEtlConfiguration
+            {
+                Name = name,
+                ConnectionStringName = name,
+                MentorNode = mentorTag,
+                PinToMentorNode = true,
+                Transforms =
+                {
+                    new Transformation
+                    {
+                        Name = $"ETL : {name}",
+                        Collections = new List<string>(new[] {"Users"}),
+                        Script = null,
+                        ApplyToAllDocuments = false,
+                        Disabled = false
+                    }
+                },
+                LoadRequestTimeoutInSec = 30,
+            };
+
+            var connectionString = new RavenConnectionString
+            {
+                Name = name,
+                Database = dest.Database,
+                TopologyDiscoveryUrls = urls.ToArray(),
+            };
+            
+            var result = src.Maintenance.Send(new PutConnectionStringOperation<RavenConnectionString>(connectionString));
+            Assert.NotNull(result.RaftCommandIndex);
+
+            src.Maintenance.Send(new AddEtlOperation<RavenConnectionString>(config));
+            
+            var ongoingTask = src.Maintenance.Send(new GetOngoingTaskInfoOperation(name, OngoingTaskType.RavenEtl));
+            var responsibleNodeNodeTag = ongoingTask.ResponsibleNode.NodeTag;
+            
+            using (var session = src.OpenSession())
+            {
+                session.Store(new User()
+                {
+                    Name = "Joe Doe"
+                }, "users/1");
+
+                session.SaveChanges();
+            }
+            
+            Assert.True(WaitForDocument<User>(dest, "users/1", u => u.Name == "Joe Doe", 30_000));
+            
+            await ActionWithLeader(l =>
+            {
+                l.ServerStore.RemoveFromClusterAsync(responsibleNodeNodeTag);
+            });
+            
+            var waitForPassive = mentorNode.ServerStore.Engine.WaitForState(RachisState.Passive,CancellationToken.None);
+            Assert.True(waitForPassive.Wait(TimeSpan.FromSeconds(10_000)));
+            
+            var val = await WaitForValueAsync(async () =>
+                {
+                    var dbRecord = await src.Maintenance.Server.SendAsync(new GetDatabaseRecordOperation(srcDb));
+                    return dbRecord.Topology.Members.Count;
+                }, 4);
+            Assert.Equal(4, val);
+
+            using (var session = src.OpenSession())
+            {
+                session.Store(new User()
+                {
+                    Name = "Joe Doe2"
+                }, "users/2");
+
+                session.SaveChanges();
+            }
+
+            await WaitForValueAsync(async () =>
+            {
+                ongoingTask = await src.Maintenance.SendAsync(new GetOngoingTaskInfoOperation(name, OngoingTaskType.RavenEtl));
+                return ongoingTask.ResponsibleNode.NodeTag != responsibleNodeNodeTag;
+            }, true);
+
+            Assert.True(WaitForDocument<User>(dest, "users/2", u => u.Name == "Joe Doe2", 10_000));
+        }
+    }
+    
+    [Fact]
+    public async Task Can_Set_Pin_To_Node_Property_Subscription()
+    {
+        var store = GetDocumentStore();
+
+        var subscriptionName = await store.Subscriptions.CreateAsync<User>(options: new SubscriptionCreationOptions
+        {
+            MentorNode = "A",
+            PinToMentorNode = true
+        }).ConfigureAwait(false);
+    
+        var state = await store.Subscriptions.GetSubscriptionStateAsync(subscriptionName, store.Database);
+        Assert.True(state.PinToMentorNode);
+    }
+    
+    [Fact]
+    public async Task Can_Set_Pin_To_Node_Backup()
+    {
+        var store = GetDocumentStore();
+        var backupPath = NewDataPath();
+        var updateBackupResult = await store.Maintenance.SendAsync(new UpdatePeriodicBackupOperation(new PeriodicBackupConfiguration
+        {
+            BackupType = BackupType.Backup,
+            LocalSettings = new LocalSettings
+            {
+                FolderPath = backupPath
+            },
+            PinToMentorNode = true,
+            FullBackupFrequency = "* * * * *",
+        }));
+
+        var res = await store.Maintenance.SendAsync(new GetOngoingTaskInfoOperation(updateBackupResult.TaskId, OngoingTaskType.Backup));
+        Assert.True(res.PinToMentorNode);
+    }
+    
+    [Fact]
+    public async Task Can_Set_Pin_To_Node_ExternalReplication()
+    {
+        var dbName = GetDatabaseName();
+        var watcher = new ExternalReplication(dbName, "Connection")
+        {
+            PinToMentorNode = true,
+            Name = "MyExternalReplication"
+        };
+
+        using (var store = GetDocumentStore())
+        {
+            var replicationOperation = new UpdateExternalReplicationOperation(watcher);
+            var replicationResult = await store.Maintenance.SendAsync(replicationOperation);
+            var res = await store.Maintenance.SendAsync(new GetOngoingTaskInfoOperation(replicationResult.TaskId, OngoingTaskType.Replication));
+            Assert.True(res.PinToMentorNode);
+        }
+    }
+    
+    private static AddEtlOperationResult AddEtl<T>(IDocumentStore src, EtlConfiguration<T> configuration, T connectionString) where T : ConnectionString
+    {
+        var putResult = src.Maintenance.Send(new PutConnectionStringOperation<T>(connectionString));
+        Assert.NotNull(putResult.RaftCommandIndex);
+
+        var addResult = src.Maintenance.Send(new AddEtlOperation<T>(configuration));
+        return addResult;
+    }
+
+}

--- a/test/SlowTests/Server/Documents/ETL/PinOnGoingTaskToMentorNode.cs
+++ b/test/SlowTests/Server/Documents/ETL/PinOnGoingTaskToMentorNode.cs
@@ -14,8 +14,10 @@ using Raven.Client.Documents.Operations.Replication;
 using Raven.Client.Documents.Subscriptions;
 using Raven.Client.ServerWide;
 using Raven.Client.ServerWide.Operations;
+using Raven.Client.ServerWide.Operations.OngoingTasks;
 using Raven.Server.Config;
 using Raven.Tests.Core.Utils.Entities;
+using SlowTests.Server.Documents.Replication;
 using Xunit;
 using Xunit.Abstractions;
 
@@ -503,6 +505,43 @@ public class PinOnGoingTaskToMentorNode : ReplicationTestBase
                 Assert.Equal(1, await WaitForValueAsync(async () => await GetMembersCount(hubStore, hubStore.Database), 1));
                 Assert.Equal(3, await WaitForValueAsync(async () => await GetMembersCount(sinkStore, sinkStore.Database), 3));
             }
+        }
+    }
+    
+    [Fact]
+    public async Task Can_Set_Pin_To_Node_Server_Wide_External_Replication()
+    {
+        using (var store = GetDocumentStore())
+        {
+            var putConfiguration = new ServerWideExternalReplication
+            {
+                Disabled = true,
+                TopologyDiscoveryUrls = new[] { store.Urls.First() },
+                DelayReplicationFor = TimeSpan.FromMinutes(3),
+                MentorNode = "A",
+                PinToMentorNode = true
+            };
+
+            var result = await store.Maintenance.Server.SendAsync(new PutServerWideExternalReplicationOperation(putConfiguration));
+            var serverWideConfiguration = await store.Maintenance.Server.SendAsync(new GetServerWideExternalReplicationOperation(result.Name));
+            Assert.NotNull(serverWideConfiguration);
+
+            ServerWideReplication.ValidateServerWideConfiguration(serverWideConfiguration, putConfiguration);
+
+            // the configuration is applied to existing databases
+            var record1 = await store.Maintenance.Server.SendAsync(new GetDatabaseRecordOperation(store.Database));
+            var externalReplications1 = record1.ExternalReplications;
+            Assert.Equal(1, externalReplications1.Count);
+            ServerWideReplication.ValidateConfiguration(serverWideConfiguration, externalReplications1.First(), store.Database);
+
+            // the configuration is applied to new databases
+            var newDbName = store.Database + "-testDatabase";
+            await store.Maintenance.Server.SendAsync(new CreateDatabaseOperation(new DatabaseRecord(newDbName)));
+            var externalReplications = record1.ExternalReplications;
+            Assert.Equal(1, externalReplications.Count);
+            var record2 = await store.Maintenance.Server.SendAsync(new GetDatabaseRecordOperation(newDbName));
+            ServerWideReplication.ValidateConfiguration(serverWideConfiguration, record2.ExternalReplications.First(), newDbName);
+            Assert.True(record2.ExternalReplications.First().PinToMentorNode);
         }
     }
     

--- a/test/SlowTests/Server/Documents/ETL/PinOnGoingTaskToMentorNode.cs
+++ b/test/SlowTests/Server/Documents/ETL/PinOnGoingTaskToMentorNode.cs
@@ -1,6 +1,7 @@
 ﻿using System;
 using System.Collections.Generic;
 using System.Linq;
+using System.Security.Cryptography.X509Certificates;
 using System.Threading;
 using System.Threading.Tasks;
 using FastTests.Server.Replication;
@@ -14,7 +15,6 @@ using Raven.Client.Documents.Subscriptions;
 using Raven.Client.ServerWide;
 using Raven.Client.ServerWide.Operations;
 using Raven.Server.Config;
-using Raven.Server.Utils;
 using Raven.Tests.Core.Utils.Entities;
 using Xunit;
 using Xunit.Abstractions;
@@ -28,7 +28,7 @@ public class PinOnGoingTaskToMentorNode : ReplicationTestBase
     }
 
     [Fact]
-    public async Task ETL_Task_Should_Be_Pinned_To_Mentor_Node()
+    public async Task Can_Set_Pin_To_Mentor_Node_Etl()
     {
         const string srcDb = "ETL-src";
         const string dstDb = "ETL-dst";
@@ -153,7 +153,7 @@ public class PinOnGoingTaskToMentorNode : ReplicationTestBase
     }
 
     [Fact]
-    public async Task ETL_Should_Fail_Over_When_Removing_Mentor_Node_And_Pin_To_MentorNode()
+    public async Task Can_Fail_Over_When_Removing_Mentor_Node_Etl()
     {
         const string srcDb = "ETL-src";
         const string dstDb = "ETL-dst";
@@ -330,24 +330,28 @@ public class PinOnGoingTaskToMentorNode : ReplicationTestBase
         var hubMentorNode = mentorNodes[0];
         var sinkMentorNode = mentorNodes[1];
 
-
-
         using (var hubStore = GetDocumentStore(new Options
                {
-                   Server = hubLeader, ReplicationFactor = 3, AdminCertificate = adminHubClusterCert, ClientCertificate = adminHubClusterCert,
+                   Server = hubLeader,
+                   ReplicationFactor = 3,
+                   AdminCertificate = adminHubClusterCert,
+                   ClientCertificate = adminHubClusterCert,
                }))
         {
             
             using (var sinkStore = GetDocumentStore(new Options
                    {
-                       Server = sinkMentorNode, ReplicationFactor = 3, AdminCertificate = adminHubClusterCert, ClientCertificate = adminHubClusterCert,
+                       Server = sinkMentorNode,
+                       ReplicationFactor = 3,
+                       AdminCertificate = adminHubClusterCert,
+                       ClientCertificate = adminHubClusterCert,
                    }))
-            {
-                    await hubStore.Maintenance.SendAsync(new PutPullReplicationAsHubOperation(new PullReplicationDefinition
+            { 
+                await hubStore.Maintenance.SendAsync(new PutPullReplicationAsHubOperation(new PullReplicationDefinition
             {
                 MentorNode = hubMentorNode.ServerStore.NodeTag,
                 PinToMentorNode = true,
-                Name = "HUB",
+                Name = hubStore.Database + "HUB",
             }));
 
             await sinkStore.Maintenance.SendAsync(new PutConnectionStringOperation<RavenConnectionString>(new RavenConnectionString
@@ -360,9 +364,10 @@ public class PinOnGoingTaskToMentorNode : ReplicationTestBase
             await sinkStore.Maintenance.SendAsync(new UpdatePullReplicationAsSinkOperation(new PullReplicationAsSink
             {
                 ConnectionStringName = hubStore.Database + "ConStr",
-                HubName = "HUB",
+                HubName =  hubStore.Database + "HUB",
             }));
-            
+            WaitForUserToContinueTheTest(hubStore,true,hubStore.Database,adminHubClusterCert);
+
             using (var hubSession = hubStore.OpenSession())
             {
                 hubSession.Store(new User
@@ -393,19 +398,114 @@ public class PinOnGoingTaskToMentorNode : ReplicationTestBase
                 RunInMemory = true,
                 DataDirectory = disposedServer.DataDirectory
             });
+            var waitForNotPassive = revivedServer.ServerStore.Engine.WaitForLeaveState(RachisState.Passive, CancellationToken.None);
+            Assert.True(waitForNotPassive.Wait(TimeSpan.FromSeconds(20_000)));
             Assert.True(WaitForDocument<User>(sinkStore, "users/2", u => u.Name == "Arava2",30_000)); 
-            // Assert.Equal(3, await WaitForValueAsync(async () => await GetMembersCount(hubStore, hubStore.Database), 3));
-            // Assert.Equal(3, await WaitForValueAsync(async () => await GetMembersCount(sinkStore, sinkStore.Database), 3));
-         
-            Console.WriteLine("IGal");
-            // sinkStore.Dispose();
-            // hubStore.Dispose();
-
+            Assert.Equal(3, await WaitForValueAsync(async () => await GetMembersCount(hubStore, hubStore.Database), 3));
+            Assert.Equal(3, await WaitForValueAsync(async () => await GetMembersCount(sinkStore, sinkStore.Database), 3));
             }
         }
-
     }
-         
+   
+    [Fact]
+    public async Task Can_Set_Pin_To_Node_Pull_Replication_As_Sink()
+    {
+        const int clusterSize = 3;
+    
+        var (hubNodes, hubLeader, hubCertificatesHolder) = await CreateRaftClusterWithSsl(clusterSize, watcherCluster: true, shouldRunInMemory: true);
+        var adminHubClusterCert = hubCertificatesHolder.ServerCertificate.Value;
+        
+        var mentorNodes = hubNodes.Where(s => s.ServerStore.NodeTag != hubLeader.ServerStore.NodeTag).ToList();
+       
+        var hubMentorNode = mentorNodes[0];
+        var sinkMentorNode = mentorNodes[1];
+        using (var hubStore = GetDocumentStore(new Options
+               {
+                   Server = hubMentorNode,
+                   ReplicationFactor = 1,
+                   AdminCertificate = adminHubClusterCert,
+                   ClientCertificate = adminHubClusterCert,
+               }))
+        {
+            using (var sinkStore = GetDocumentStore(new Options
+                   {
+                       Server = hubLeader,
+                       ReplicationFactor = 3,
+                       AdminCertificate = adminHubClusterCert,
+                       ClientCertificate = adminHubClusterCert,
+                   }))
+            {
+    
+                using (var hubSession = hubStore.OpenAsyncSession())
+                {
+                    await hubSession.StoreAsync(new {Type = "Eggs"}, "menus/breakfast");
+                    await hubSession.StoreAsync(new {Name = "Bird Seed Milkshake"}, "recipes/bird-seed-milkshake");
+                    await hubSession.StoreAsync(new {Name = "3 USD"}, "prices/eastus/2");
+                    await hubSession.StoreAsync(new {Name = "3 EUR"}, "prices/eu/1");
+                    await hubSession.SaveChangesAsync();
+                }
+    
+                using (var sinkSession = sinkStore.OpenAsyncSession())
+                {
+                    await sinkSession.StoreAsync(new {Name = "Candy"}, "orders/bert/3");
+                    await sinkSession.SaveChangesAsync();
+                }
+    
+                await hubStore.Maintenance.SendAsync(new PutPullReplicationAsHubOperation(new PullReplicationDefinition
+                {
+                    Name = "Franchises",
+                    Mode = PullReplicationMode.HubToSink | PullReplicationMode.SinkToHub,
+                    WithFiltering = true,
+                }));
+    
+                await hubStore.Maintenance.SendAsync(new RegisterReplicationHubAccessOperation("Franchises",
+                    new ReplicationHubAccess
+                    {
+                        Name = "Franchises",
+                        CertificateBase64 = Convert.ToBase64String(hubCertificatesHolder.ClientCertificate1.Value.Export(X509ContentType.Cert)),
+                        AllowedSinkToHubPaths = new[] {"orders/*","users/*"},
+                        AllowedHubToSinkPaths = new[] {"menus/*", "prices/eastus/*", "recipes/*"}
+                    }));
+    
+                await sinkStore.Maintenance.SendAsync(new PutConnectionStringOperation<RavenConnectionString>(new RavenConnectionString
+                {
+                    Database = hubStore.Database, Name = "HopperConStr", TopologyDiscoveryUrls = hubStore.Urls
+                }));
+                await sinkStore.Maintenance.SendAsync(new UpdatePullReplicationAsSinkOperation(new PullReplicationAsSink
+                {
+                    ConnectionStringName = "HopperConStr",
+                    PinToMentorNode = true,
+                    MentorNode = sinkMentorNode.ServerStore.NodeTag,
+                    CertificateWithPrivateKey = Convert.ToBase64String(hubCertificatesHolder.ClientCertificate1.Value.Export(X509ContentType.Pfx)),
+                    HubName = "Franchises",
+                    Mode = PullReplicationMode.HubToSink | PullReplicationMode.SinkToHub
+                }));
+    
+                var disposedServer = await DisposeServerAndWaitForFinishOfDisposalAsync(sinkMentorNode);
+                using (var sinkSession = sinkStore.OpenAsyncSession())
+                {
+                    await sinkSession.StoreAsync(new User {Name = "Arava",}, "users/1");
+                    await sinkSession.SaveChangesAsync();
+                }
+                var revivedServer = GetNewServer(new ServerCreationOptions
+                {
+                    CustomSettings = new Dictionary<string, string>
+                    {
+                        {RavenConfiguration.GetKey(x => x.Core.ServerUrls), disposedServer.Url},
+                        {RavenConfiguration.GetKey(x => x.Security.CertificatePath), hubCertificatesHolder.ServerCertificatePath}
+                    },
+                    RunInMemory = true,
+                    DataDirectory = disposedServer.DataDirectory
+                });
+                var waitForNotPassive = revivedServer.ServerStore.Engine.WaitForLeaveState(RachisState.Passive, CancellationToken.None);
+                Assert.True(waitForNotPassive.Wait(TimeSpan.FromSeconds(20_000)));
+                Assert.True(WaitForDocument<User>(hubStore, "users/1", u => u.Name == "Arava", 30_000));
+                Assert.Equal(1, await WaitForValueAsync(async () => await GetMembersCount(hubStore, hubStore.Database), 1));
+                Assert.Equal(3, await WaitForValueAsync(async () => await GetMembersCount(sinkStore, sinkStore.Database), 3));
+            }
+        }
+    }
+    
     private static AddEtlOperationResult AddEtl<T>(IDocumentStore src, EtlConfiguration<T> configuration, T connectionString) where T : ConnectionString
     {
         var putResult = src.Maintenance.Send(new PutConnectionStringOperation<T>(connectionString));
@@ -414,5 +514,4 @@ public class PinOnGoingTaskToMentorNode : ReplicationTestBase
         var addResult = src.Maintenance.Send(new AddEtlOperation<T>(configuration));
         return addResult;
     }
-
 }

--- a/test/SlowTests/Server/Documents/ETL/PinOnGoingTaskToMentorNode.cs
+++ b/test/SlowTests/Server/Documents/ETL/PinOnGoingTaskToMentorNode.cs
@@ -3,6 +3,7 @@ using System.Collections.Generic;
 using System.Linq;
 using System.Threading;
 using System.Threading.Tasks;
+using FastTests.Server.Replication;
 using Raven.Client.Documents;
 using Raven.Client.Documents.Operations.Backups;
 using Raven.Client.Documents.Operations.ConnectionStrings;
@@ -13,14 +14,14 @@ using Raven.Client.Documents.Subscriptions;
 using Raven.Client.ServerWide;
 using Raven.Client.ServerWide.Operations;
 using Raven.Server.Config;
+using Raven.Server.Utils;
 using Raven.Tests.Core.Utils.Entities;
-using Tests.Infrastructure;
 using Xunit;
 using Xunit.Abstractions;
 
 namespace SlowTests.Server.Documents.ETL;
 
-public class PinOnGoingTaskToMentorNode : ClusterTestBase
+public class PinOnGoingTaskToMentorNode : ReplicationTestBase
 {
     public PinOnGoingTaskToMentorNode(ITestOutputHelper output) : base(output)
     {
@@ -315,7 +316,96 @@ public class PinOnGoingTaskToMentorNode : ClusterTestBase
             Assert.True(res.PinToMentorNode);
         }
     }
-    
+
+    [Fact]
+    public async Task Can_Set_Pin_To_Node_Pull_Replication_As_Hub()
+    {
+        const int clusterSize = 3;
+
+        var (hubNodes, hubLeader, hubCertificatesHolder) = await CreateRaftClusterWithSsl(clusterSize, watcherCluster: true, shouldRunInMemory: true);
+        var adminHubClusterCert = hubCertificatesHolder.ServerCertificate.Value;
+        
+        var mentorNodes = hubNodes.Where(s => s.ServerStore.NodeTag != hubLeader.ServerStore.NodeTag).ToList();
+       
+        var hubMentorNode = mentorNodes[0];
+        var sinkMentorNode = mentorNodes[1];
+
+
+
+        using (var hubStore = GetDocumentStore(new Options
+               {
+                   Server = hubLeader, ReplicationFactor = 3, AdminCertificate = adminHubClusterCert, ClientCertificate = adminHubClusterCert,
+               }))
+        {
+            
+            using (var sinkStore = GetDocumentStore(new Options
+                   {
+                       Server = sinkMentorNode, ReplicationFactor = 3, AdminCertificate = adminHubClusterCert, ClientCertificate = adminHubClusterCert,
+                   }))
+            {
+                    await hubStore.Maintenance.SendAsync(new PutPullReplicationAsHubOperation(new PullReplicationDefinition
+            {
+                MentorNode = hubMentorNode.ServerStore.NodeTag,
+                PinToMentorNode = true,
+                Name = "HUB",
+            }));
+
+            await sinkStore.Maintenance.SendAsync(new PutConnectionStringOperation<RavenConnectionString>(new RavenConnectionString
+            {
+                Database = hubStore.Database,
+                Name = hubStore.Database + "ConStr",
+                TopologyDiscoveryUrls = hubNodes.Select(u => u.WebUrl).ToArray()
+            }));
+
+            await sinkStore.Maintenance.SendAsync(new UpdatePullReplicationAsSinkOperation(new PullReplicationAsSink
+            {
+                ConnectionStringName = hubStore.Database + "ConStr",
+                HubName = "HUB",
+            }));
+            
+            using (var hubSession = hubStore.OpenSession())
+            {
+                hubSession.Store(new User
+                {
+                    Name = "Arava",
+                }, "users/1");
+                hubSession.SaveChanges();
+            }
+
+            Assert.True(WaitForDocument<User>(sinkStore, "users/1", u => u.Name == "Arava",30_000));
+            var disposedServer = await DisposeServerAndWaitForFinishOfDisposalAsync(hubMentorNode);
+            using (var hubSession = hubStore.OpenSession())
+            {
+                hubSession.Store(new User
+                {
+                    Name = "Arava2",
+                }, "users/2");
+                hubSession.SaveChanges();
+            }
+            Assert.False(WaitForDocument<User>(sinkStore, "users/2", u => u.Name == "Arava2",30_000));
+            var revivedServer = GetNewServer(new ServerCreationOptions
+            {
+                CustomSettings = new Dictionary<string, string>
+                {
+                    {RavenConfiguration.GetKey(x => x.Core.ServerUrls), disposedServer.Url},
+                    {RavenConfiguration.GetKey(x => x.Security.CertificatePath), hubCertificatesHolder.ServerCertificatePath}
+                },
+                RunInMemory = true,
+                DataDirectory = disposedServer.DataDirectory
+            });
+            Assert.True(WaitForDocument<User>(sinkStore, "users/2", u => u.Name == "Arava2",30_000)); 
+            // Assert.Equal(3, await WaitForValueAsync(async () => await GetMembersCount(hubStore, hubStore.Database), 3));
+            // Assert.Equal(3, await WaitForValueAsync(async () => await GetMembersCount(sinkStore, sinkStore.Database), 3));
+         
+            Console.WriteLine("IGal");
+            // sinkStore.Dispose();
+            // hubStore.Dispose();
+
+            }
+        }
+
+    }
+         
     private static AddEtlOperationResult AddEtl<T>(IDocumentStore src, EtlConfiguration<T> configuration, T connectionString) where T : ConnectionString
     {
         var putResult = src.Maintenance.Send(new PutConnectionStringOperation<T>(connectionString));

--- a/test/SlowTests/Server/Documents/Replication/ServerWideReplication.cs
+++ b/test/SlowTests/Server/Documents/Replication/ServerWideReplication.cs
@@ -706,20 +706,22 @@ namespace SlowTests.Server.Documents.Replication
             }
         }
 
-        private static void ValidateServerWideConfiguration(ServerWideExternalReplication serverWideConfiguration, ServerWideExternalReplication putConfiguration)
+        internal static void ValidateServerWideConfiguration(ServerWideExternalReplication serverWideConfiguration, ServerWideExternalReplication putConfiguration)
         {
             Assert.Equal(serverWideConfiguration.Name, putConfiguration.Name ?? putConfiguration.GetDefaultTaskName());
             Assert.Equal(serverWideConfiguration.Disabled, putConfiguration.Disabled);
             Assert.Equal(serverWideConfiguration.MentorNode, putConfiguration.MentorNode);
+            Assert.Equal(serverWideConfiguration.PinToMentorNode, putConfiguration.PinToMentorNode);
             Assert.Equal(serverWideConfiguration.DelayReplicationFor, putConfiguration.DelayReplicationFor);
             Assert.True(putConfiguration.TopologyDiscoveryUrls.SequenceEqual(serverWideConfiguration.TopologyDiscoveryUrls));
         }
 
-        private static void ValidateConfiguration(ServerWideExternalReplication serverWideConfiguration, ExternalReplication externalReplication, string databaseName)
+        internal static void ValidateConfiguration(ServerWideExternalReplication serverWideConfiguration, ExternalReplication externalReplication, string databaseName)
         {
             Assert.Equal(PutServerWideExternalReplicationCommand.GetTaskName(serverWideConfiguration.Name), externalReplication.Name);
             Assert.Equal(serverWideConfiguration.Disabled, externalReplication.Disabled);
             Assert.Equal(serverWideConfiguration.MentorNode, externalReplication.MentorNode);
+            Assert.Equal(serverWideConfiguration.PinToMentorNode, externalReplication.PinToMentorNode);
             Assert.Equal(serverWideConfiguration.DelayReplicationFor, externalReplication.DelayReplicationFor);
             Assert.Equal(databaseName, externalReplication.Database);
             Assert.Equal(PutServerWideExternalReplicationCommand.GetRavenConnectionStringName(serverWideConfiguration.Name), externalReplication.ConnectionStringName);


### PR DESCRIPTION
### Issue link

https://issues.hibernatingrhinos.com/issue/RavenDB-18379

### Additional description

`PullReplicationAsHub` is not implementing `IDatabaseTask`, Compare to `PullReplicationAsSink` which inherited form `ExternalReplicationBase` and implementing `IDatabaseTask`.
Currently, it's unsupported.


### Type of change

- New feature

### How risky is the change?

- Low 

### Backward compatibility

- Not relevant

### Is it platform specific issue?

- No

### Documentation update

- This change requires a documentation update. Please mark the issue on YouTrack using `Documentation Required` tag.

### Testing 

- Tests have been added that prove the fix is effective or that the feature works

### Is there any existing behavior change of other features due to this change?

- Yes

### UI work

- It requires further work in the Studio

