### PR TITLE
RavenDB-18466 Failure in updating the ETL process state results in looping and getting stuck 

### DIFF
--- a/src/Raven.Server/Documents/ETL/EtlProcess.cs
+++ b/src/Raven.Server/Documents/ETL/EtlProcess.cs
@@ -1252,11 +1252,11 @@ namespace Raven.Server.Documents.ETL
                 }
             }
 
-            result.Completed = (result.NumberOfDocumentsToProcess > 0
-                                && result.NumberOfDocumentTombstonesToProcess > 0
-                                && result.NumberOfCounterGroupsToProcess > 0
-                                && result.NumberOfTimeSeriesSegmentsToProcess > 0
-                                && result.NumberOfTimeSeriesDeletedRangesToProcess > 0) == false;
+            result.Completed = result.NumberOfDocumentsToProcess == 0
+                               && result.NumberOfDocumentTombstonesToProcess == 0
+                               && result.NumberOfCounterGroupsToProcess == 0
+                               && result.NumberOfTimeSeriesSegmentsToProcess == 0
+                               && result.NumberOfTimeSeriesDeletedRangesToProcess == 0;
 
             var performance = _lastStats?.ToPerformanceLiveStats();
 
@@ -1282,11 +1282,11 @@ namespace Raven.Server.Documents.ETL
                 if (result.NumberOfTimeSeriesDeletedRangesToProcess > 0)
                     result.NumberOfTimeSeriesDeletedRangesToProcess -= performance.NumberOfTransformedTombstones[EtlItemType.TimeSeries];
 
-                result.Completed = (result.NumberOfDocumentsToProcess > 0
-                                   && result.NumberOfDocumentTombstonesToProcess > 0
-                                   && result.NumberOfCounterGroupsToProcess > 0
-                                   && result.NumberOfTimeSeriesSegmentsToProcess > 0
-                                   && result.NumberOfTimeSeriesDeletedRangesToProcess > 0) == false;
+                result.Completed = result.NumberOfDocumentsToProcess == 0
+                                   && result.NumberOfDocumentTombstonesToProcess == 0
+                                   && result.NumberOfCounterGroupsToProcess == 0
+                                   && result.NumberOfTimeSeriesSegmentsToProcess == 0
+                                   && result.NumberOfTimeSeriesDeletedRangesToProcess == 0;
 
                 if (result.Completed && performance.Completed == null)
                 {

--- a/src/Raven.Server/Documents/ETL/EtlProcess.cs
+++ b/src/Raven.Server/Documents/ETL/EtlProcess.cs
@@ -703,7 +703,7 @@ namespace Raven.Server.Documents.ETL
 
                     var state = LastProcessState = GetProcessState(Database, Configuration.Name, Transformation.Name);
 
-                    var loadLastProcessedEtag = state.GetLastProcessedEtag(Database.DbBase64Id, _serverStore.NodeTag);
+                    var startEtag = state.GetLastProcessedEtag(Database.DbBase64Id, _serverStore.NodeTag);
 
                     using (Statistics.NewBatch())
                     using (Database.DocumentsStorage.ContextPool.AllocateOperationContext(out DocumentsOperationContext context))
@@ -723,7 +723,7 @@ namespace Raven.Server.Documents.ETL
                                 using (var scope = new DisposableScope())
                                 using (var merged = new ExtractedItemsEnumerator<TExtracted, TStatsScope, TEtlPerformanceOperation>(stats))
                                 {
-                                    var nextEtag = loadLastProcessedEtag + 1;
+                                    var nextEtag = startEtag + 1;
 
                                     Extract(context, merged, nextEtag, EtlItemType.Document, stats, scope);
 
@@ -737,13 +737,13 @@ namespace Raven.Server.Documents.ETL
 
                                     var noFailures = Load(transformations, context, stats);
 
-                                    var lastProcessed = Math.Max(stats.LastLoadedEtag, stats.LastFilteredOutEtags.Values.Max());
+                                    var lastProcessedInBatch = Math.Max(stats.LastLoadedEtag, stats.LastFilteredOutEtags.Values.Max());
 
-                                    if (lastProcessed > Statistics.LastProcessedEtag && noFailures)
+                                    if (lastProcessedInBatch > startEtag && noFailures)
                                     {
                                         didWork = true;
 
-                                        Statistics.LastProcessedEtag = lastProcessed;
+                                        Statistics.LastProcessedEtag = lastProcessedInBatch;
                                         Statistics.LastChangeVector = stats.ChangeVector;
                                         RecordSuccessfulBatch(stats);
 
@@ -777,15 +777,15 @@ namespace Raven.Server.Documents.ETL
                         try
                         {
                             UpdateEtlProcessState(state);
-                        }
-                        catch (OperationCanceledException)
-                        {
-                            return;
-                        }
-
-                        if (CancellationToken.IsCancellationRequested == false)
-                        {
                             Database.EtlLoader.OnBatchCompleted(ConfigurationName, TransformationName, Statistics);
+                        }
+                        catch (Exception e)
+                        {
+                            if (CancellationToken.IsCancellationRequested == false)
+                            {
+                                if (Logger.IsOperationsEnabled) 
+                                    Logger.Operations($"{Tag} Failed to update state of ETL process '{Name}'", e);
+                            }
                         }
 
                         continue;


### PR DESCRIPTION
### Issue link

https://issues.hibernatingrhinos.com/issue/RavenDB-18466

### Additional description

Exception during `UpdateEtlProcessState()` could result in looping the ETL process.

### Type of change

- Bug fix

### How risky is the change?

- Low 

### Backward compatibility

- Not relevant

### Is it platform specific issue?

- No

### Documentation update

- No documentation update is needed 

### Testing 

- It has been verified by manual testing

### Is there any existing behavior change of other features due to this change?

- No

### UI work

- No UI work is needed
