### PR TITLE
RavenDB-18464 Analyze terms before comparison in UnaryMatch and DateOnly&TimeOnly support

### DIFF
--- a/src/Corax/IndexEntryBuilder.cs
+++ b/src/Corax/IndexEntryBuilder.cs
@@ -36,6 +36,8 @@ namespace Corax
         Raw = 1 << 4,
         Invalid = 1 << 6,
         
+        
+        TupleList = List | Tuple,
         RawList = List | Raw
     }
 
@@ -276,7 +278,7 @@ namespace Corax
             _knownFieldsLocations[field] = dataLocation | unchecked((int)0x80000000);
 
             // Write the list metadata information. 
-            dataLocation += VariableSizeEncoding.Write(_buffer, (byte)(IndexEntryFieldType.List | IndexEntryFieldType.Tuple), dataLocation);
+            dataLocation += VariableSizeEncoding.Write(_buffer, (byte)(IndexEntryFieldType.TupleList), dataLocation);
             dataLocation += VariableSizeEncoding.Write(_buffer, values.Length, dataLocation); // Size of list.
 
             // Prepare the location to store the pointer where the table of the strings will be (after writing the strings).

--- a/src/Corax/IndexSearcher/IndexSearcher.UnaryMatches.cs
+++ b/src/Corax/IndexSearcher/IndexSearcher.UnaryMatches.cs
@@ -53,12 +53,12 @@ public partial class IndexSearcher
     {
         return @operation switch
         {
-            UnaryMatchOperation.GreaterThan => UnaryMatch.Create(UnaryMatch<TInner, TValueType>.YieldGreaterThan(set, this, fieldId, term, take)),
-            UnaryMatchOperation.GreaterThanOrEqual => UnaryMatch.Create(UnaryMatch<TInner, TValueType>.YieldGreaterThanOrEqualMatch(set, this, fieldId, term, take)),
-            UnaryMatchOperation.LessThan => UnaryMatch.Create(UnaryMatch<TInner, TValueType>.YieldLessThan(set, this, fieldId, term, take)),
-            UnaryMatchOperation.LessThanOrEqual => UnaryMatch.Create(UnaryMatch<TInner, TValueType>.YieldLessThanOrEqualMatch(set, this, fieldId, term, take)),
-            UnaryMatchOperation.Equals => UnaryMatch.Create(UnaryMatch<TInner, TValueType>.YieldEqualsMatch(set, this, fieldId, term, take)),
-            UnaryMatchOperation.NotEquals => UnaryMatch.Create(UnaryMatch<TInner, TValueType>.YieldNotEqualsMatch(set, this, fieldId, term, take)),
+            UnaryMatchOperation.GreaterThan => UnaryMatch.Create(UnaryMatch<TInner, TValueType>.YieldGreaterThan(set, this, fieldId, term, take: take)),
+            UnaryMatchOperation.GreaterThanOrEqual => UnaryMatch.Create(UnaryMatch<TInner, TValueType>.YieldGreaterThanOrEqualMatch(set, this, fieldId, term, take: take)),
+            UnaryMatchOperation.LessThan => UnaryMatch.Create(UnaryMatch<TInner, TValueType>.YieldLessThan(set, this, fieldId, term, take: take)),
+            UnaryMatchOperation.LessThanOrEqual => UnaryMatch.Create(UnaryMatch<TInner, TValueType>.YieldLessThanOrEqualMatch(set, this, fieldId, term, take: take)),
+            UnaryMatchOperation.Equals => UnaryMatch.Create(UnaryMatch<TInner, TValueType>.YieldEqualsMatch(set, this, fieldId, term, take: take)),
+            UnaryMatchOperation.NotEquals => UnaryMatch.Create(UnaryMatch<TInner, TValueType>.YieldNotEqualsMatch(set, this, fieldId, term, true, take)),
             _ => throw new ArgumentOutOfRangeException(nameof(operation), @operation, $"Wrong {nameof(UnaryQuery)} was called. Check other overloads.")
         };
     }

--- a/src/Corax/IndexSearcher/IndexSearcher.cs
+++ b/src/Corax/IndexSearcher/IndexSearcher.cs
@@ -129,15 +129,16 @@ public sealed unsafe partial class IndexSearcher : IDisposable
 
         var analyzer = binding.Analyzer!;
         analyzer.GetOutputBuffersSize(originalTerm.Length, out int outputSize, out int tokenSize);
-        Debug.Assert(outputSize < 1024 * 1024);
-        Debug.Assert(Unsafe.SizeOf<Token>() * tokenSize < 1024 * 1024);
+        
+        Debug.Assert(outputSize < 1024 * 1024, "Term size is too big for analyzer.");
+        Debug.Assert(Unsafe.SizeOf<Token>() * tokenSize < 1024 * 1024, "Analyzer wants to create too much tokens.");
         
         Span<byte> encoded = new byte[outputSize];
         Token* tokensPtr = stackalloc Token[tokenSize];
         var tokens = new Span<Token>(tokensPtr, tokenSize);
         
         analyzer.Execute(originalTerm, ref encoded, ref tokens);
-        Debug.Assert(tokens.Length == 1);
+        Debug.Assert(tokens.Length == 1, $"{nameof(ApplyAnalyzer)} should create only 1 token as a result.");
 
         return encoded;
     }

--- a/src/Corax/Queries/UnaryMatch.Between.cs
+++ b/src/Corax/Queries/UnaryMatch.Between.cs
@@ -128,7 +128,7 @@ namespace Corax.Queries
                     in inner, UnaryMatchOperation.Between, 
                     searcher, fieldId, value1, value2, 
                     &FillFuncBetweenSequence, &AndWith, 
-                    inner.Count, inner.Confidence.Min(QueryCountConfidence.Normal), take);
+                    inner.Count, inner.Confidence.Min(QueryCountConfidence.Normal), false, take);
             }
             else if (typeof(TValueType) == typeof(long))
             {
@@ -145,7 +145,7 @@ namespace Corax.Queries
                     in inner, UnaryMatchOperation.Between, 
                     searcher, fieldId, value1, value2, 
                     &FillFuncBetweenNumerical, &AndWith, 
-                    inner.Count, inner.Confidence.Min(QueryCountConfidence.Normal), take);
+                    inner.Count, inner.Confidence.Min(QueryCountConfidence.Normal), false, take);
             }
             else
             {
@@ -161,7 +161,7 @@ namespace Corax.Queries
                     in inner, UnaryMatchOperation.NotBetween, 
                     searcher, fieldId, value1, value2, 
                     &FillFuncBetweenNumerical, &AndWith, 
-                    inner.Count, inner.Confidence.Min(QueryCountConfidence.Normal), take);
+                    inner.Count, inner.Confidence.Min(QueryCountConfidence.Normal), false, take);
             }
         }
 
@@ -284,7 +284,7 @@ namespace Corax.Queries
                     in inner, UnaryMatchOperation.NotBetween, 
                     searcher, fieldId, value1, value2, 
                     &FillFuncNotBetweenSequence, &AndWith, 
-                    inner.Count, inner.Confidence.Min(QueryCountConfidence.Normal), take);
+                    inner.Count, inner.Confidence.Min(QueryCountConfidence.Normal), true, take);
             }
             else if (typeof(TValueType) == typeof(long))
             {
@@ -301,7 +301,7 @@ namespace Corax.Queries
                     in inner, UnaryMatchOperation.NotBetween, 
                     searcher, fieldId, value1, value2, 
                     &FillFuncNotBetweenNumerical, &AndWith, 
-                    inner.Count, inner.Confidence.Min(QueryCountConfidence.Normal), take);
+                    inner.Count, inner.Confidence.Min(QueryCountConfidence.Normal), true, take);
             }
             else
             {
@@ -317,7 +317,7 @@ namespace Corax.Queries
                     in inner, UnaryMatchOperation.NotBetween, 
                     searcher, fieldId, value1, value2, 
                     &FillFuncNotBetweenNumerical, &AndWith, 
-                    inner.Count, inner.Confidence.Min(QueryCountConfidence.Normal), take);
+                    inner.Count, inner.Confidence.Min(QueryCountConfidence.Normal), true, take);
             }
         }
     }

--- a/src/Corax/Queries/UnaryMatch.Ordinal.cs
+++ b/src/Corax/Queries/UnaryMatch.Ordinal.cs
@@ -63,26 +63,25 @@ namespace Corax.Queries
                     if (type is IndexEntryFieldType.Tuple or IndexEntryFieldType.None)
                     {
                         var read = reader.Read(match._fieldId, out var resultX);
-                        if (read && comparer.Compare(currentType, resultX))
+                        var analyzedTerm = match._searcher.ApplyAnalyzer(resultX, match._fieldId);
+                        if (read && comparer.Compare(currentType, analyzedTerm))
                         {
                             // We found a match.
                             isMatch = true;
                         }
                     }
-                    else if (type is IndexEntryFieldType.List)
+                    else if (type is IndexEntryFieldType.List or IndexEntryFieldType.TupleList)
                     {
                         var iterator = reader.ReadMany(match._fieldId);
-                        var unacceptableItem = false;
                         while (iterator.ReadNext())
                         {
-                            if (comparer.Compare(currentType, iterator.Sequence) == false)
+                            var analyzedTerm = match._searcher.ApplyAnalyzer(iterator.Sequence, match._fieldId);
+                            if (comparer.Compare(currentType, analyzedTerm))
                             {
-                                unacceptableItem = true;
+                                isMatch = true;
                                 break;
                             }
                         }
-
-                        isMatch = unacceptableItem == false;
                     }
 
                     if (isMatch)
@@ -132,20 +131,17 @@ namespace Corax.Queries
                             if (read)
                                 isMatch = comparer.Compare((long)(object)currentType, resultX);
                         }
-                        else if (type is IndexEntryFieldType.List)
+                        else if (type is IndexEntryFieldType.List or IndexEntryFieldType.TupleList)
                         {
                             var iterator = reader.ReadMany(match._fieldId);
-                            var unacceptableItem = false;
                             while (iterator.ReadNext())
                             {
-                                if (comparer.Compare((long)(object)currentType, iterator.Long) == false)
+                                if (comparer.Compare((long)(object)currentType, iterator.Long))
                                 {
-                                    unacceptableItem = true;
+                                    isMatch = true;
                                     break;
                                 }
                             }
-
-                            isMatch = unacceptableItem == false;
                         }
                     }
                     else if (typeof(TValueType) == typeof(double))
@@ -156,20 +152,17 @@ namespace Corax.Queries
                             if (read)
                                 isMatch = comparer.Compare((double)(object)currentType, resultX);
                         }
-                        else if (type is IndexEntryFieldType.List)
+                        else if (type is IndexEntryFieldType.List or IndexEntryFieldType.TupleList)
                         {
                             var iterator = reader.ReadMany(match._fieldId);
-                            var unacceptableItem = false;
                             while (iterator.ReadNext())
                             {
-                                if (comparer.Compare((double)(object)currentType, iterator.Double) == false)
+                                if (comparer.Compare((double)(object)currentType, iterator.Double))
                                 {
-                                    unacceptableItem = true;
+                                    isMatch = true;
                                     break;
                                 }
                             }
-
-                            isMatch = unacceptableItem == false;
                         }
                     }
 

--- a/src/Corax/Queries/UnaryMatch.cs
+++ b/src/Corax/Queries/UnaryMatch.cs
@@ -33,7 +33,8 @@ namespace Corax.Queries
         private readonly TValueType _value;
         private readonly TValueType _valueAux;
         private readonly int _take;
-
+        private readonly bool _distinct;
+        
         private long _totalResults;
         private long _current;
         private QueryCountConfidence _confidence;
@@ -52,7 +53,9 @@ namespace Corax.Queries
             delegate*<ref UnaryMatch<TInner, TValueType>, Span<long>, int> fillFunc,
             delegate*<ref UnaryMatch<TInner, TValueType>, Span<long>, int, int> andWithFunc,
             long totalResults,
-            QueryCountConfidence confidence, int take = -1)
+            QueryCountConfidence confidence, 
+            bool distinct = false,
+            int take = -1)
         {
             _totalResults = totalResults;
             _current = QueryMatch.Start;
@@ -67,6 +70,7 @@ namespace Corax.Queries
             _value = value;
             _valueAux = default;
             _confidence = confidence;
+            _distinct = distinct;
             _take = take <= 0 ? int.MaxValue : take;
         }
 
@@ -79,7 +83,9 @@ namespace Corax.Queries
             delegate*<ref UnaryMatch<TInner, TValueType>, Span<long>, int> fillFunc,
             delegate*<ref UnaryMatch<TInner, TValueType>, Span<long>, int, int> andWith,
             long totalResults,
-            QueryCountConfidence confidence, int take = -1)
+            QueryCountConfidence confidence, 
+            bool distinct = false,
+            int take = -1)
         {
             _totalResults = totalResults;
             _current = QueryMatch.Start;
@@ -94,6 +100,7 @@ namespace Corax.Queries
             _value = value1;
             _valueAux = value2;
             _confidence = confidence;
+            _distinct = distinct;
             _take = take <= 0 ? int.MaxValue : take;
         }
 

--- a/src/Raven.Server/Documents/Indexes/Persistence/Corax/CoraxDocumentConverterBase.cs
+++ b/src/Raven.Server/Documents/Indexes/Persistence/Corax/CoraxDocumentConverterBase.cs
@@ -12,6 +12,7 @@ using Raven.Server.Documents.Indexes.Persistence.Corax.WriterScopes;
 using Raven.Server.Documents.Indexes.Static;
 using Raven.Server.Exceptions;
 using Raven.Server.Utils;
+using Sparrow;
 using Sparrow.Extensions;
 using Sparrow.Json;
 using Sparrow.Json.Parsing;
@@ -203,7 +204,17 @@ public abstract class CoraxDocumentConverterBase : ConverterBase
                 }
 
                 return;
-
+            
+            case ValueType.DateOnly:
+                var dateOnly = ((DateOnly)value).ToString(DefaultFormat.DateOnlyFormatToWrite, CultureInfo.InvariantCulture);
+                scope.Write(field.Id, dateOnly, ref entryWriter);
+                return;
+            
+            case ValueType.TimeOnly:
+                var timeOnly = ((TimeOnly)value).ToString(DefaultFormat.TimeOnlyFormatToWrite, CultureInfo.InvariantCulture);
+                scope.Write(field.Id, timeOnly, ref entryWriter);
+                return;
+            
             case ValueType.Convertible:
                 var iConvertible = (IConvertible)value;
                 @long = iConvertible.ToInt64(CultureInfo.InvariantCulture);

--- a/test/FastTests/Corax/IndexSearcher.cs
+++ b/test/FastTests/Corax/IndexSearcher.cs
@@ -2017,7 +2017,7 @@ namespace FastTests.Corax
             using var searcher = new IndexSearcher(Env);
             {
                 var notOne = searcher.UnaryQuery(searcher.AllEntries(), ContentIndex, one, UnaryMatchOperation.NotEquals);
-                var notTwo = searcher.UnaryQuery(searcher.AllEntries(), ContentIndex, two, UnaryMatchOperation.NotEquals);
+              //  var notTwo = searcher.UnaryQuery(searcher.AllEntries(), ContentIndex, two, UnaryMatchOperation.NotEquals);
                 Span<long> ids = stackalloc long[32];
                 var expected = entries.Count(x => x.Content.Contains("1") == false);
                 var result = notOne.Fill(ids);

--- a/test/SlowTests/Bugs/DateRanges.cs
+++ b/test/SlowTests/Bugs/DateRanges.cs
@@ -22,7 +22,7 @@ namespace SlowTests.Bugs
         }
 
         [Theory]
-        [RavenData(SearchEngineMode = RavenSearchEngineMode.Lucene)]
+        [RavenData(SearchEngineMode = RavenSearchEngineMode.All)]
         public void CanQueryByDate(Options options)
         {
             using (var store = GetDocumentStore(options))

--- a/test/SlowTests/Issues/RavenDB-10229.cs
+++ b/test/SlowTests/Issues/RavenDB-10229.cs
@@ -4,6 +4,7 @@ using System.Linq;
 using FastTests;
 using Raven.Client.Documents;
 using Raven.Client.Documents.Indexes;
+using Tests.Infrastructure;
 using Xunit;
 using Xunit.Abstractions;
 
@@ -15,10 +16,11 @@ namespace SlowTests.Issues
         {
         }
 
-        [Fact]
-        public void CanQueryDateTime()
+        [RavenTheory(RavenTestCategory.Querying)]
+        [RavenData(SearchEngineMode = RavenSearchEngineMode.All)]
+        public void CanQueryDateTime(Options options)
         {
-            using (var store = GetDocumentStore())
+            using (var store = GetDocumentStore(options))
             {
                 store.ExecuteIndex(new DateIndex());
 
@@ -48,10 +50,11 @@ namespace SlowTests.Issues
             }
         }
 
-        [Fact]
-        public void CanIndexDateTimeArrayProperly1()
+        [RavenTheory(RavenTestCategory.Querying)]
+        [RavenData(SearchEngineMode = RavenSearchEngineMode.All)]
+        public void CanIndexDateTimeArrayProperly1(Options options)
         {
-            using (var store = GetDocumentStore())
+            using (var store = GetDocumentStore(options))
             {
                 store.ExecuteIndex(new LastAccessIndex());
 
@@ -105,10 +108,11 @@ namespace SlowTests.Issues
             }
         }
 
-        [Fact]
-        public void CanIndexDateTimeArrayProperly2()
+        [RavenTheory(RavenTestCategory.Querying)]
+        [RavenData(SearchEngineMode = RavenSearchEngineMode.All)]
+        public void CanIndexDateTimeArrayProperly2(Options options)
         {
-            using (var store = GetDocumentStore())
+            using (var store = GetDocumentStore(options))
             {
                 store.ExecuteIndex(new LastAccessPerName());
 
@@ -159,10 +163,11 @@ namespace SlowTests.Issues
             }
         }
 
-        [Fact]
-        public void CanIndexGuidArrayProperly1()
+        [RavenTheory(RavenTestCategory.Querying)]
+        [RavenData(SearchEngineMode = RavenSearchEngineMode.All)]
+        public void CanIndexGuidArrayProperly1(Options options)
         {
-            using (var store = GetDocumentStore())
+            using (var store = GetDocumentStore(options))
             {
                 store.ExecuteIndex(new DummyIndex());
 
@@ -196,10 +201,11 @@ namespace SlowTests.Issues
             }
         }
 
-        [Fact]
-        public void CanIndexGuidArrayProperly2()
+        [RavenTheory(RavenTestCategory.Querying)]
+        [RavenData(SearchEngineMode = RavenSearchEngineMode.All)]
+        public void CanIndexGuidArrayProperly2(Options options)
         {
-            using (var store = GetDocumentStore())
+            using (var store = GetDocumentStore(options))
             {
                 store.ExecuteIndex(new DummyGuidList());
 
@@ -238,10 +244,11 @@ namespace SlowTests.Issues
             }
         }
 
-        [Fact]
-        public void CanIndexNumericArrayProperly()
+        [RavenTheory(RavenTestCategory.Querying)]
+        [RavenData(SearchEngineMode = RavenSearchEngineMode.Lucene)]
+        public void CanIndexNumericArrayProperly(Options options)
         {
-            using (var store = GetDocumentStore())
+            using (var store = GetDocumentStore(options))
             {
                 store.ExecuteIndex(new DummyIndexCount());
 
@@ -280,7 +287,6 @@ namespace SlowTests.Issues
                     var list = session.Query<DummyIndexCount.Result, DummyIndexCount>()
                         .Where(x => x.IntCount.Any(d => d == 2))
                         .ToList();
-
                     Assert.Equal(1, list.Count);
                     Assert.Equal(newGuid, list[0].Guid);
                     Assert.Equal(new int[] { 2 }, list[0].IntCount);

--- a/test/SlowTests/Issues/RavenDB-17250.cs
+++ b/test/SlowTests/Issues/RavenDB-17250.cs
@@ -8,6 +8,7 @@ using Raven.Client.Documents;
 using Raven.Client.Documents.Indexes;
 using Raven.Client.Documents.Operations;
 using Raven.Client.Documents.Operations.Indexes;
+using Tests.Infrastructure;
 using Xunit;
 using Xunit.Abstractions;
 
@@ -23,10 +24,11 @@ public class RavenDB_17250 : RavenTestBase
     {
     }
  
-    [Fact]
-    public void DateAndTimeOnlyTestInIndex()
+    [RavenTheory(RavenTestCategory.Indexes | RavenTestCategory.Querying)]
+    [RavenData(SearchEngineMode = RavenSearchEngineMode.All)]
+    public void DateAndTimeOnlyTestInIndex(Options options)
     {
-        using var store = GetDocumentStore();
+        using var store = GetDocumentStore(options);
         CreateDatabaseData(store);
         CreateIndex<DateAndTimeOnlyIndex>(store);
         {
@@ -43,10 +45,11 @@ public class RavenDB_17250 : RavenTestBase
         }
     }
 
-    [Fact]
-    public void IndexWithLetQueries()
+    [RavenTheory(RavenTestCategory.Indexes | RavenTestCategory.Querying)]
+    [RavenData(SearchEngineMode = RavenSearchEngineMode.All)]
+    public void IndexWithLetQueries(Options options)
     {
-        using var store = GetDocumentStore();
+        using var store = GetDocumentStore(options);
         CreateDatabaseData(store);
         CreateIndex<MapReduceWithLetAndNullableItems>(store);
         using var session = store.OpenSession();
@@ -62,13 +65,14 @@ public class RavenDB_17250 : RavenTestBase
         });
     }
 
-    [Fact]
-    public void UsingFilter()
+    [RavenTheory(RavenTestCategory.Indexes | RavenTestCategory.Querying)]
+    [RavenData(SearchEngineMode = RavenSearchEngineMode.All)]
+    public void UsingFilter(Options options)
     {
         var dateOnly = default(DateOnly).AddDays(300);
         var timeOnly = new TimeOnly(0, 0, 0, 234).AddMinutes(300);
 
-        using var store = GetDocumentStore();
+        using var store = GetDocumentStore(options);
         CreateDatabaseData(store);
         using var session = store.OpenSession();
         var result = session
@@ -83,10 +87,11 @@ public class RavenDB_17250 : RavenTestBase
         Assert.Equal(timeOnly, result.TimeOnly);
     }
 
-    [Fact]
-    public void DateTimeToDateOnlyWithLet()
+    [RavenTheory(RavenTestCategory.Indexes | RavenTestCategory.Querying)]
+    [RavenData(SearchEngineMode = RavenSearchEngineMode.All)]
+    public void DateTimeToDateOnlyWithLet(Options options)
     {
-        using var store = GetDocumentStore();
+        using var store = GetDocumentStore(options);
         CreateDatabaseData(store);
         CreateIndex<IndexWithDateTimeAndDateOnly>(store);
         
@@ -104,10 +109,11 @@ public class RavenDB_17250 : RavenTestBase
         });
     }
 
-    [Fact]
-    public void TransformDateInJsPatch()
+    [RavenTheory(RavenTestCategory.Indexes | RavenTestCategory.Querying)]
+    [RavenData(SearchEngineMode = RavenSearchEngineMode.All)]
+    public void TransformDateInJsPatch(Options options)
     {
-        using var store = GetDocumentStore();
+        using var store = GetDocumentStore(options);
         var @do = new DateOnly(2022, 2, 21);
         var to = new TimeOnly(21, 11, 00);
         var entity = new DateAndTimeOnly() {DateOnly = @do, TimeOnly = to};
@@ -134,10 +140,11 @@ from DateAndTimeOnlies update { this.DateOnly = modifyDateInJs(this.DateOnly, 1)
     }
 
 
-    [Fact]
-    public void PatchDateOnlyAndTimeOnly()
+    [RavenTheory(RavenTestCategory.Indexes | RavenTestCategory.Querying)]
+    [RavenData(SearchEngineMode = RavenSearchEngineMode.All)]
+    public void PatchDateOnlyAndTimeOnly(Options options)
     {
-        using var store = GetDocumentStore();
+        using var store = GetDocumentStore(options);
         var @do = new DateOnly(2022, 2, 21);
         var to = new TimeOnly(21, 11, 00);
         string id;
@@ -179,10 +186,11 @@ from DateAndTimeOnlies update { this.DateOnly = modifyDateInJs(this.DateOnly, 1)
     }
 
 
-    [Fact]
-    public void DateAndTimeOnlyInQuery()
+    [RavenTheory(RavenTestCategory.Indexes | RavenTestCategory.Querying)]
+    [RavenData(SearchEngineMode = RavenSearchEngineMode.All)]
+    public void DateAndTimeOnlyInQuery(Options options)
     {
-        using var store = GetDocumentStore();
+        using var store = GetDocumentStore(options);
 
         var data = CreateDatabaseData(store);
         Indexes.WaitForIndexing(store);
@@ -207,10 +215,11 @@ from DateAndTimeOnlies update { this.DateOnly = modifyDateInJs(this.DateOnly, 1)
         }
     }
 
-    [Fact]
-    public void QueriesAsString()
+    [RavenTheory(RavenTestCategory.Indexes | RavenTestCategory.Querying)]
+    [RavenData(SearchEngineMode = RavenSearchEngineMode.All)]
+    public void QueriesAsString(Options options)
     {
-        using var store = GetDocumentStore();
+        using var store = GetDocumentStore(options);
         var data = CreateDatabaseData(store);
 
         {
@@ -263,10 +272,11 @@ from DateAndTimeOnlies update { this.DateOnly = modifyDateInJs(this.DateOnly, 1)
         }
     }
 
-    [Fact]
-    public void QueriesAsTicks()
+    [RavenTheory(RavenTestCategory.Indexes | RavenTestCategory.Querying)]
+    [RavenData(SearchEngineMode = RavenSearchEngineMode.All)]
+    public void QueriesAsTicks(Options options)
     {
-        using var store = GetDocumentStore();
+        using var store = GetDocumentStore(options);
         var data = CreateDatabaseData(store);
         CreateIndex<DateAndTimeOnlyIndex>(store);
 
@@ -320,10 +330,11 @@ from DateAndTimeOnlies update { this.DateOnly = modifyDateInJs(this.DateOnly, 1)
         }
     }
 
-    [Fact]
-    public void MinMaxValueInProjections()
+    [RavenTheory(RavenTestCategory.Indexes | RavenTestCategory.Querying)]
+    [RavenData(SearchEngineMode = RavenSearchEngineMode.All)]
+    public void MinMaxValueInProjections(Options options)
     {
-        using var store = GetDocumentStore();
+        using var store = GetDocumentStore(options);
         {
             using var session = store.OpenSession();
             session.Store(new ProjectionTestWithDefaultValues {Min = DateOnly.MaxValue, Max = DateOnly.MinValue, Time = DateTime.Today}
@@ -347,10 +358,11 @@ from DateAndTimeOnlies update { this.DateOnly = modifyDateInJs(this.DateOnly, 1)
         public DateTime? Time { get; set; }
     }
 
-    [Fact]
-    public void ProjectionJobsWithDateTimeDateOnly()
+    [RavenTheory(RavenTestCategory.Indexes | RavenTestCategory.Querying)]
+    [RavenData(SearchEngineMode = RavenSearchEngineMode.All)]
+    public void ProjectionJobsWithDateTimeDateOnly(Options options)
     {
-        using var store = GetDocumentStore();
+        using var store = GetDocumentStore(options);
         {
             using var s = store.OpenSession();
             s.Store(new DateAndTimeOnly() {TimeOnly = TimeOnly.MaxValue, DateOnly = new DateOnly(1947, 12, 21)});

--- a/test/SlowTests/Issues/RavenDB-18399.cs
+++ b/test/SlowTests/Issues/RavenDB-18399.cs
@@ -8,6 +8,7 @@ using Raven.Client.Documents;
 using Raven.Client.Documents.Indexes;
 using Raven.Client.Documents.Operations;
 using Raven.Client.Documents.Operations.Indexes;
+using Tests.Infrastructure;
 using Xunit;
 using Xunit.Abstractions;
 
@@ -21,10 +22,11 @@ public class RavenDB_18399 : RavenTestBase
     {
     }
 
-    [Fact]
-    public void DateAndTimeOnlyTestInIndex()
+    [RavenTheory(RavenTestCategory.Indexes | RavenTestCategory.Querying)]
+    [RavenData(SearchEngineMode = RavenSearchEngineMode.All)]
+    public void DateAndTimeOnlyTestInIndex(Options options)
     {
-        using var store = GetDocumentStore();
+        using var store = GetDocumentStore(options);
         CreateDatabaseData(store);
         CreateIndex<DateAndTimeOnlyIndex>(store);
         {
@@ -41,10 +43,11 @@ public class RavenDB_18399 : RavenTestBase
         }
     }
 
-    [Fact]
-    public void IndexWithLetQueries()
+    [RavenTheory(RavenTestCategory.Indexes | RavenTestCategory.Querying)]
+    [RavenData(SearchEngineMode = RavenSearchEngineMode.All)]
+    public void IndexWithLetQueries(Options options)
     {
-        using var store = GetDocumentStore();
+        using var store = GetDocumentStore(options);
         CreateDatabaseData(store);
         CreateIndex<MapReduceWithLetAndNullableItems>(store);
         using var session = store.OpenSession();
@@ -60,13 +63,14 @@ public class RavenDB_18399 : RavenTestBase
         });
     }
 
-    [Fact]
-    public void UsingFilter()
+    [RavenTheory(RavenTestCategory.Indexes | RavenTestCategory.Querying)]
+    [RavenData(SearchEngineMode = RavenSearchEngineMode.All)]
+    public void UsingFilter(Options options)
     {
         var dateOnly = default(DateOnly).AddDays(300);
         var timeOnly = new TimeOnly(0, 0, 0, 234).AddMinutes(300);
 
-        using var store = GetDocumentStore();
+        using var store = GetDocumentStore(options);
         CreateDatabaseData(store);
         using var session = store.OpenSession();
         var result = session
@@ -81,10 +85,11 @@ public class RavenDB_18399 : RavenTestBase
         Assert.Equal(timeOnly, result.TimeOnly);
     }
 
-    [Fact]
-    public void DateTimeToDateOnlyWithLet()
+    [RavenTheory(RavenTestCategory.Indexes | RavenTestCategory.Querying)]
+    [RavenData(SearchEngineMode = RavenSearchEngineMode.All)]
+    public void DateTimeToDateOnlyWithLet(Options options)
     {
-        using var store = GetDocumentStore();
+        using var store = GetDocumentStore(options);
         CreateDatabaseData(store);
         CreateIndex<IndexWithDateTimeAndDateOnly>(store);
         
@@ -102,10 +107,11 @@ public class RavenDB_18399 : RavenTestBase
         });
     }
 
-    [Fact]
-    public void TransformDateInJsPatch()
+    [RavenTheory(RavenTestCategory.Indexes | RavenTestCategory.Querying)]
+    [RavenData(SearchEngineMode = RavenSearchEngineMode.All)]
+    public void TransformDateInJsPatch(Options options)
     {
-        using var store = GetDocumentStore();
+        using var store = GetDocumentStore(options);
         var @do = new DateOnly(2022, 2, 21);
         var to = new TimeOnly(21, 11, 00);
         var entity = new DateAndTimeOnly() {DateOnly = @do, TimeOnly = to};
@@ -134,10 +140,11 @@ from DateAndTimeOnlies where DateOnly != null update { this.DateOnly = modifyDat
     }
 
 
-    [Fact]
-    public void PatchDateOnlyAndTimeOnly()
+    [RavenTheory(RavenTestCategory.Indexes | RavenTestCategory.Querying)]
+    [RavenData(SearchEngineMode = RavenSearchEngineMode.All)]
+    public void PatchDateOnlyAndTimeOnly(Options options)
     {
-        using var store = GetDocumentStore();
+        using var store = GetDocumentStore(options);
         var @do = new DateOnly(2022, 2, 21);
         var to = new TimeOnly(21, 11, 00);
         string id;
@@ -179,10 +186,11 @@ from DateAndTimeOnlies where DateOnly != null update { this.DateOnly = modifyDat
     }
 
 
-    [Fact]
-    public void DateAndTimeOnlyInQuery()
+    [RavenTheory(RavenTestCategory.Indexes | RavenTestCategory.Querying)]
+    [RavenData(SearchEngineMode = RavenSearchEngineMode.All)]
+    public void DateAndTimeOnlyInQuery(Options options)
     {
-        using var store = GetDocumentStore();
+        using var store = GetDocumentStore(options);
 
         var data = CreateDatabaseData(store);
         Indexes.WaitForIndexing(store);
@@ -215,10 +223,11 @@ from DateAndTimeOnlies where DateOnly != null update { this.DateOnly = modifyDat
         }
     }
 
-    [Fact]
-    public void QueriesAsString()
+    [RavenTheory(RavenTestCategory.Indexes | RavenTestCategory.Querying)]
+    [RavenData(SearchEngineMode = RavenSearchEngineMode.All)]
+    public void QueriesAsString(Options options)
     {
-        using var store = GetDocumentStore();
+        using var store = GetDocumentStore(options);
         var data = CreateDatabaseData(store);
 
         {
@@ -271,10 +280,11 @@ from DateAndTimeOnlies where DateOnly != null update { this.DateOnly = modifyDat
         }
     }
 
-    [Fact]
-    public void QueriesAsTicks()
+    [RavenTheory(RavenTestCategory.Indexes | RavenTestCategory.Querying)]
+    [RavenData(SearchEngineMode = RavenSearchEngineMode.All)]
+    public void QueriesAsTicks(Options options)
     {
-        using var store = GetDocumentStore();
+        using var store = GetDocumentStore(options);
         var data = CreateDatabaseData(store);
         CreateIndex<DateAndTimeOnlyIndex>(store);
 
@@ -328,10 +338,11 @@ from DateAndTimeOnlies where DateOnly != null update { this.DateOnly = modifyDat
         }
     }
 
-    [Fact]
-    public void MinMaxValueInProjections()
+    [RavenTheory(RavenTestCategory.Indexes | RavenTestCategory.Querying)]
+    [RavenData(SearchEngineMode = RavenSearchEngineMode.All)]
+    public void MinMaxValueInProjections(Options options)
     {
-        using var store = GetDocumentStore();
+        using var store = GetDocumentStore(options);
         {
             using var session = store.OpenSession();
             session.Store(new ProjectionTestWithDefaultValues {Min = DateOnly.MaxValue, Max = DateOnly.MinValue, Time = DateTime.Today}
@@ -356,10 +367,11 @@ from DateAndTimeOnlies where DateOnly != null update { this.DateOnly = modifyDat
         public DateTime? Time { get; set; }
     }
 
-    [Fact]
-    public void ProjectionJobsWithDateTimeDateOnly()
+    [RavenTheory(RavenTestCategory.Indexes | RavenTestCategory.Querying)]
+    [RavenData(SearchEngineMode = RavenSearchEngineMode.All)]
+    public void ProjectionJobsWithDateTimeDateOnly(Options options)
     {
-        using var store = GetDocumentStore();
+        using var store = GetDocumentStore(options);
         {
             using var s = store.OpenSession();
             s.Store(new DateAndTimeOnly() {TimeOnly = TimeOnly.MaxValue, DateOnly = new DateOnly(1947, 12, 21)});

--- a/test/SlowTests/Issues/RavenDB-1847.cs
+++ b/test/SlowTests/Issues/RavenDB-1847.cs
@@ -3,6 +3,7 @@ using System.Collections.Generic;
 using System.Linq;
 using FastTests;
 using Raven.Client.Documents.Indexes;
+using Tests.Infrastructure;
 using Xunit;
 using Xunit.Abstractions;
 
@@ -14,10 +15,11 @@ namespace SlowTests.Issues
         {
         }
 
-        [Fact]
-        public void CanIndexAndQuery()
+        [RavenTheory(RavenTestCategory.Indexes | RavenTestCategory.Querying)]
+        [RavenData(SearchEngineMode = RavenSearchEngineMode.All)]
+        public void CanIndexAndQuery(Options options)
         {
-            using (var store = GetDocumentStore())
+            using (var store = GetDocumentStore(options))
             {
                 new TestObjectIndex().Execute(store);
 

--- a/test/SlowTests/Issues/RavenDB_11794.cs
+++ b/test/SlowTests/Issues/RavenDB_11794.cs
@@ -3,6 +3,7 @@ using System.Linq;
 using FastTests;
 using Orders;
 using Sparrow.Extensions;
+using Tests.Infrastructure;
 using Xunit;
 using Xunit.Abstractions;
 
@@ -14,10 +15,11 @@ namespace SlowTests.Issues
         {
         }
 
-        [Fact]
-        public void CanUseLastModifiedInAutoIndex()
+        [RavenTheory(RavenTestCategory.Indexes | RavenTestCategory.Querying)]
+        [RavenData(SearchEngineMode = RavenSearchEngineMode.Corax)]
+        public void CanUseLastModifiedInAutoIndex(Options options)
         {
-            using (var store = GetDocumentStore())
+            using (var store = GetDocumentStore(options))
             {
                 var now1 = DateTime.UtcNow;
 

--- a/test/SlowTests/Issues/RavenDB_17626.cs
+++ b/test/SlowTests/Issues/RavenDB_17626.cs
@@ -4,6 +4,7 @@ using System.Linq;
 using FastTests;
 using Raven.Client.Documents;
 using Raven.Client.Documents.Indexes;
+using Tests.Infrastructure;
 using Xunit;
 using Xunit.Abstractions;
 
@@ -15,10 +16,11 @@ public class RavenDB_17626 : RavenTestBase
     {
     }
 
-    [Fact]
-    public void EnumerableInSelectManyWillBeCastedProperly()
+    [RavenTheory(RavenTestCategory.Indexes | RavenTestCategory.Querying)]
+    [RavenData(SearchEngineMode = RavenSearchEngineMode.All)]
+    public void EnumerableInSelectManyWillBeCastedProperly(Options options)
     {
-        using (var store = GetDocumentStore())
+        using (var store = GetDocumentStore(options))
         {
             store.ExecuteIndex(new Index());
             var date = DateTime.UtcNow;

--- a/test/SlowTests/MailingList/SkippedResults.cs
+++ b/test/SlowTests/MailingList/SkippedResults.cs
@@ -5,6 +5,7 @@ using FastTests;
 using Raven.Client.Documents.Indexes;
 using Raven.Client.Documents.Linq;
 using Raven.Client.Documents.Session;
+using Tests.Infrastructure;
 using Xunit;
 using Xunit.Abstractions;
 
@@ -16,10 +17,11 @@ namespace SlowTests.MailingList
         {
         }
 
-        [Fact]
-        public void Can_page_when_using_nested_property_index()
+        [RavenTheory(RavenTestCategory.Querying)]
+        [RavenData(SearchEngineMode = RavenSearchEngineMode.All)]
+        public void Can_page_when_using_nested_property_index(Options options)
         {
-            using (var store = GetDocumentStore())
+            using (var store = GetDocumentStore(options))
             {
                 using (var session = store.OpenSession())
                 {


### PR DESCRIPTION
### Issue link

https://issues.hibernatingrhinos.com/issue/RavenDB-18464

### Additional description

UnaryMatch operates on the values taken from the entry (not parsed), while the searched value comes already parsed. Therefore, without using the transformation, the results may be incorrect.

### Type of change

- Bug fix
- New feature


### How risky is the change?

- Not relevant

### Backward compatibility

- Not relevant

### Is it platform specific issue?

- No

### Documentation update

- No documentation update is needed 

### Testing 

- Tests have been added that prove the fix is effective or that the feature works

### Is there any existing behavior change of other features due to this change?

- No

### UI work

- No UI work is needed
