### PR TITLE
RavenDB-18465 : Add missing Elastic ETL handling to DeleteOngoingTaskAction

### DIFF
--- a/src/Raven.Server/Web/System/OngoingTasksHandler.cs
+++ b/src/Raven.Server/Web/System/OngoingTasksHandler.cs
@@ -1492,6 +1492,12 @@ namespace Raven.Server.Web.System
                             if (olapEtl != null)
                                 _deletingEtl = (olapEtl.Name, olapEtl.Transforms.Where(x => string.IsNullOrEmpty(x.Name) == false).Select(x => x.Name).ToList());
                             break;
+                        case OngoingTaskType.ElasticSearchEtl:
+                            var elasticEtls = rawRecord.ElasticSearchEtls;
+                            var elasticEtl = elasticEtls?.Find(x => x.TaskId == id);
+                            if (elasticEtl != null)
+                                _deletingEtl = (elasticEtl.Name, elasticEtl.Transforms.Where(x => string.IsNullOrEmpty(x.Name) == false).Select(x => x.Name).ToList());
+                            break;
                     }
                 }
             }

--- a/src/Raven.Server/Web/System/OngoingTasksHandler.cs
+++ b/src/Raven.Server/Web/System/OngoingTasksHandler.cs
@@ -1466,32 +1466,33 @@ namespace Raven.Server.Web.System
                 _database = database;
                 _context = context;
 
-                switch (type)
+                using (context.Transaction == null ? context.OpenReadTransaction() : null)
+                using (var rawRecord = _serverStore.Cluster.ReadRawDatabaseRecord(context, database.Name))
                 {
-                    case OngoingTaskType.RavenEtl:
-                    case OngoingTaskType.SqlEtl:
-                        using (context.Transaction == null ? context.OpenReadTransaction() : null)
-                        using (var rawRecord = _serverStore.Cluster.ReadRawDatabaseRecord(context, database.Name))
-                        {
-                            if (rawRecord == null)
-                                break;
+                    if (rawRecord == null)
+                        return;
 
-                            if (type == OngoingTaskType.RavenEtl)
-                            {
-                                var ravenEtls = rawRecord.RavenEtls;
-                                var ravenEtl = ravenEtls?.Find(x => x.TaskId == id);
-                                if (ravenEtl != null)
-                                    _deletingEtl = (ravenEtl.Name, ravenEtl.Transforms.Where(x => string.IsNullOrEmpty(x.Name) == false).Select(x => x.Name).ToList());
-                            }
-                            else
-                            {
-                                var sqlEtls = rawRecord.SqlEtls;
-                                var sqlEtl = sqlEtls?.Find(x => x.TaskId == id);
-                                if (sqlEtl != null)
-                                    _deletingEtl = (sqlEtl.Name, sqlEtl.Transforms.Where(x => string.IsNullOrEmpty(x.Name) == false).Select(x => x.Name).ToList());
-                            }
-                        }
-                        break;
+                    switch (type)
+                    {
+                        case OngoingTaskType.RavenEtl:
+                            var ravenEtls = rawRecord.RavenEtls;
+                            var ravenEtl = ravenEtls?.Find(x => x.TaskId == id);
+                            if (ravenEtl != null)
+                                _deletingEtl = (ravenEtl.Name, ravenEtl.Transforms.Where(x => string.IsNullOrEmpty(x.Name) == false).Select(x => x.Name).ToList());
+                            break;
+                        case OngoingTaskType.SqlEtl:
+                            var sqlEtls = rawRecord.SqlEtls;
+                            var sqlEtl = sqlEtls?.Find(x => x.TaskId == id);
+                            if (sqlEtl != null)
+                                _deletingEtl = (sqlEtl.Name, sqlEtl.Transforms.Where(x => string.IsNullOrEmpty(x.Name) == false).Select(x => x.Name).ToList());
+                            break;
+                        case OngoingTaskType.OlapEtl:
+                            var olapEtls = rawRecord.OlapEtls;
+                            var olapEtl = olapEtls?.Find(x => x.TaskId == id);
+                            if (olapEtl != null)
+                                _deletingEtl = (olapEtl.Name, olapEtl.Transforms.Where(x => string.IsNullOrEmpty(x.Name) == false).Select(x => x.Name).ToList());
+                            break;
+                    }
                 }
             }
 

--- a/test/SlowTests/Server/Documents/ETL/Olap/FailoverTests.cs
+++ b/test/SlowTests/Server/Documents/ETL/Olap/FailoverTests.cs
@@ -107,7 +107,7 @@ loadToOrders(partitionBy(key),
                 },
                 MentorNode = mentorTag
             };
-            var task = AddEtl(store,
+            var task = AddOlapEtl(store,
                 configuration,
                 new OlapConnectionString
                 {
@@ -174,7 +174,7 @@ loadToOrders(partitionBy(key),
             return mre;
         }
 
-        private static AddEtlOperationResult AddEtl(IDocumentStore src, OlapEtlConfiguration configuration, OlapConnectionString connectionString)
+        internal static AddEtlOperationResult AddOlapEtl(IDocumentStore src, OlapEtlConfiguration configuration, OlapConnectionString connectionString)
         {
             var putResult = src.Maintenance.Send(new PutConnectionStringOperation<OlapConnectionString>(connectionString));
             Assert.NotNull(putResult.RaftCommandIndex);

--- a/test/SlowTests/Server/Documents/ETL/Olap/LocalTests.cs
+++ b/test/SlowTests/Server/Documents/ETL/Olap/LocalTests.cs
@@ -27,8 +27,7 @@ namespace SlowTests.Server.Documents.ETL.Olap
     public class LocalTests : EtlTestBase
     {
         internal const string DefaultFrequency = "* * * * *"; // every minute
-        private const string AllFilesPattern = "*.*";
-
+        internal const string AllFilesPattern = "*.*";
 
         public LocalTests(ITestOutputHelper output) : base(output)
         {
@@ -2467,7 +2466,7 @@ loadToOrders(partitionBy(['year', orderDate.getFullYear()]),
             return scriptPath;
         }
 
-        private void SetupLocalOlapEtl(DocumentStore store, string script, string path, string name = "olap-test", string frequency = null, string transformationName = null)
+        internal static AddEtlOperationResult SetupLocalOlapEtl(DocumentStore store, string script, string path, string name = "olap-test", string frequency = null, string transformationName = null)
         {
             var connectionStringName = $"{store.Database} to local";
             var configuration = new OlapEtlConfiguration
@@ -2486,10 +2485,10 @@ loadToOrders(partitionBy(['year', orderDate.getFullYear()]),
                 }
             };
 
-            SetupLocalOlapEtl(store, configuration, path, connectionStringName);
+            return SetupLocalOlapEtl(store, configuration, path, connectionStringName);
         }
 
-        private void SetupLocalOlapEtl(DocumentStore store, OlapEtlConfiguration configuration, string path, string connectionStringName)
+        private static AddEtlOperationResult SetupLocalOlapEtl(DocumentStore store, OlapEtlConfiguration configuration, string path, string connectionStringName)
         {
             var connectionString = new OlapConnectionString
             {
@@ -2500,7 +2499,7 @@ loadToOrders(partitionBy(['year', orderDate.getFullYear()]),
                 }
             };
 
-            AddEtl(store, configuration, connectionString);
+            return FailoverTests.AddOlapEtl(store, configuration, connectionString);
         }
 
         private class User

--- a/test/SlowTests/Server/Documents/ETL/Olap/RavenDB_18465.cs
+++ b/test/SlowTests/Server/Documents/ETL/Olap/RavenDB_18465.cs
@@ -1,0 +1,111 @@
+﻿using System;
+using System.IO;
+using System.Threading.Tasks;
+using Raven.Client.Documents;
+using Raven.Client.Documents.Operations.ETL;
+using Raven.Client.Documents.Operations.OngoingTasks;
+using Raven.Server.ServerWide.Context;
+using Xunit;
+using Xunit.Abstractions;
+using Order = Tests.Infrastructure.Entities.Order;
+
+namespace SlowTests.Server.Documents.ETL.Olap
+{
+    public class RavenDB_18465 : EtlTestBase
+    {
+        public RavenDB_18465(ITestOutputHelper output) : base(output)
+        {
+        }
+
+        [Fact]
+        public async Task EtlProcessStateShouldBeDeletedAfterTaskRemoval()
+        {
+            const string script = @"
+var orderDate = new Date(this.OrderedAt);
+var year = orderDate.getFullYear();
+var month = orderDate.getMonth();
+var key = new Date(year, month);
+
+loadTo(""Orders"", partitionBy(key),
+    {
+        Company : this.Company,
+        ShipVia : this.ShipVia
+    });
+";
+            using (var store = GetDocumentStore())
+            {
+                await InsertData(store);
+
+                var etlDone = WaitForEtl(store, (n, statistics) => statistics.LoadSuccesses != 0);
+                var path = NewDataPath(forceCreateDir: true);
+
+                const string configurationName = "olap-test";
+                const string transformationName = "transformation-test";
+                var result = LocalTests.SetupLocalOlapEtl(store, script, path, name: configurationName, transformationName: transformationName);
+
+                Assert.True(etlDone.Wait(TimeSpan.FromMinutes(1)));
+
+                var files = Directory.GetFiles(path, searchPattern: LocalTests.AllFilesPattern, SearchOption.AllDirectories);
+                Assert.Equal(2, files.Length);
+
+                var key = EtlProcessState.GenerateItemName(store.Database, configurationName, transformationName).ToLowerInvariant();
+
+                using (Server.ServerStore.ContextPool.AllocateOperationContext(out TransactionOperationContext context))
+                using (context.OpenReadTransaction())
+                {
+                    var item = Server.ServerStore.Engine.StateMachine.GetItem(context, key);
+                    Assert.NotNull(item);
+                }
+
+                // delete task
+                store.Maintenance.Send(new DeleteOngoingTaskOperation(result.TaskId, OngoingTaskType.OlapEtl));
+                var ongoingTask = store.Maintenance.Send(new GetOngoingTaskInfoOperation(result.TaskId, OngoingTaskType.OlapEtl));
+                Assert.Null(ongoingTask);
+
+                using (Server.ServerStore.ContextPool.AllocateOperationContext(out TransactionOperationContext context))
+                using (context.OpenReadTransaction())
+                {
+                    var item = Server.ServerStore.Engine.StateMachine.GetItem(context, key);
+                    Assert.Null(item);
+                }
+            }
+        }
+
+        private async Task InsertData(IDocumentStore store)
+        {
+            var baseline = new DateTime(2020, 1, 1);
+
+            using (var session = store.OpenAsyncSession())
+            {
+                const int numberOfDaysInJanuary = 31;
+                const int numberOfDaysInFebruary = 28;
+
+                for (int i = 0; i < numberOfDaysInJanuary; i++)
+                {
+                    await session.StoreAsync(new Order
+                    {
+                        Id = $"orders/{i}",
+                        OrderedAt = baseline.AddDays(i),
+                        ShipVia = $"shippers/{i}",
+                        Company = $"companies/{i}"
+                    });
+                }
+
+                for (int i = 0; i < numberOfDaysInFebruary; i++)
+                {
+                    var next = i + numberOfDaysInJanuary;
+                    await session.StoreAsync(new Order
+                    {
+                        Id = $"orders/{next}",
+                        OrderedAt = baseline.AddMonths(1).AddDays(i),
+                        ShipVia = $"shippers/{next}",
+                        Company = $"companies/{next}"
+                    });
+                }
+
+                await session.SaveChangesAsync();
+            }
+        }
+    }
+
+}


### PR DESCRIPTION
### Issue link

https://issues.hibernatingrhinos.com/issue/RavenDB-18465

### Type of change

- Bug fix

### How risky is the change?

- Low 

### Backward compatibility

- Not relevant

### Is it platform specific issue?

- No

### Documentation update

- No documentation update is needed 


### Is there any existing behavior change of other features due to this change?

- No

### UI work

- No UI work is needed
