### PR TITLE
RavenDB-18467 tab is allowed character in headers

### DIFF
--- a/test/SlowTests/Client/Attachments/AttachmentsCrud.cs
+++ b/test/SlowTests/Client/Attachments/AttachmentsCrud.cs
@@ -223,7 +223,7 @@ namespace SlowTests.Client.Attachments
         }
 
         [Theory]
-        [InlineData("\t", null)]
+        [InlineData("\r\n", null)]
         [InlineData("\\", "\\")]
         [InlineData("/", "/")]
         [InlineData("5", "5")]

--- a/test/SlowTests/Client/Attachments/AttachmentsReplication.cs
+++ b/test/SlowTests/Client/Attachments/AttachmentsReplication.cs
@@ -178,7 +178,7 @@ namespace SlowTests.Client.Attachments
         }
 
         [Theory]
-        [InlineData("\t", null)]
+        [InlineData("\r\n", null)]
         [InlineData("\\", "\\")]
         [InlineData("/", "/")]
         [InlineData("5", "5")]


### PR DESCRIPTION
### Issue link

https://issues.hibernatingrhinos.com/issue/RavenDB-18467

### Additional description

Starting from .NET 6.0.4 the Headers are also accepting tabs. Which is inline with RFC. More info here: https://github.com/dotnet/aspnetcore/issues/41186

### Type of change

- Bug fix

### How risky is the change?

- Low 

### Backward compatibility

- Not relevant

### Is it platform specific issue?

- No

### Documentation update

- No documentation update is needed 

### Testing 

- Tests have been added that prove the fix is effective or that the feature works

### Is there any existing behavior change of other features due to this change?

- No

### UI work

- No UI work is needed
