### PR TITLE
RavenDB-18422 Use @sql-keys (as was originally intended), avoid setti…

### DIFF
--- a/src/Raven.Server/SqlMigration/Model/SqlMigrationDocument.cs
+++ b/src/Raven.Server/SqlMigration/Model/SqlMigrationDocument.cs
@@ -25,8 +25,7 @@ namespace Raven.Server.SqlMigration.Model
             Object[Constants.Documents.Metadata.Key] = new DynamicJsonValue
             {
                 [Constants.Documents.Metadata.Collection] = collectionName,
-                [Constants.Documents.Metadata.Id] = id,
-                ["Sql-Keys-Columns"] = SpecialColumnsValues
+                ["@sql-keys"] = SpecialColumnsValues
             };
             Collection = collectionName;
         }


### PR DESCRIPTION
…ng @id property on metadata of documents about to be written.

### Issue link

https://issues.hibernatingrhinos.com/issue/RavenDB-18422 

### Additional description

The issue was that I added `@id` property, which is forbidden.
Using `@sql-keys` metadata property now

### Type of change

- Regression bug fix

### How risky is the change?

- Low 

### Backward compatibility

- Ensured. Please explain how has it been implemented?

### Is it platform specific issue?

- No

### Documentation update

- No documentation update is needed 

### Testing 

- It has been verified by manual testing
- Existing tests pass

### Is there any existing behavior change of other features due to this change?

- No

### UI work

- No UI work is needed
