### PR TITLE
RavenDB-17661 - Allow to get revisions bin info even when revisions settings are disabled

### DIFF
--- a/src/Raven.Server/Documents/Handlers/RevisionsHandler.cs
+++ b/src/Raven.Server/Documents/Handlers/RevisionsHandler.cs
@@ -389,8 +389,6 @@ namespace Raven.Server.Documents.Handlers
         public async Task GetRevisionsBin()
         {
             var revisionsStorage = Database.DocumentsStorage.RevisionsStorage;
-            if (revisionsStorage.Configuration == null)
-                throw new RevisionsDisabledException();
 
             var sw = Stopwatch.StartNew();
             var etag = GetLongQueryString("etag", false) ?? long.MaxValue;

--- a/test/SlowTests/Issues/RavenDB-17661.cs
+++ b/test/SlowTests/Issues/RavenDB-17661.cs
@@ -1,0 +1,30 @@
+﻿using System.Threading.Tasks;
+using FastTests;
+using Raven.Client.Documents.Commands;
+using Sparrow.Json;
+using Xunit;
+using Xunit.Abstractions;
+
+namespace SlowTests.Issues
+{
+    public class RavenDB_17661 : RavenTestBase
+    {
+        public RavenDB_17661(ITestOutputHelper output) : base(output)
+        {
+        }
+
+        [Fact]
+        public async Task Can_Get_From_Revisions_Bin_When_Revisions_Are_Disabled()
+        {
+            using (var store = GetDocumentStore())
+            {
+                using (Server.ServerStore.ContextPool.AllocateOperationContext(out JsonOperationContext context))
+                {
+                    var command = new GetRevisionsBinEntryCommand(long.MaxValue, int.MaxValue);
+                    await store.GetRequestExecutor().ExecuteAsync(command, context);
+                    Assert.Equal(0, command.Result.Results.Length);
+                }
+            }
+        }
+    }
+}


### PR DESCRIPTION
### Issue link

https://issues.hibernatingrhinos.com/issue/RavenDB-17661

### Additional description

Allow to get revisions bin info even when revisions settings are disabled

### Type of change

- Bug fix

### How risky is the change?

- Low 
