### PR TITLE
RavenDB-12865 Handle SIGTERM and SIGINT in container for quick and safe Docker Compose shutdown

### DIFF
--- a/docker/ravendb-nanoserver/Dockerfile
+++ b/docker/ravendb-nanoserver/Dockerfile
@@ -28,4 +28,4 @@ WORKDIR C:/RavenDB/Server
 
 ADD settings.json https://ravendb-docker.s3.amazonaws.com/vcruntime140.dll .\
 
-CMD pwsh -File C:\RavenDB\run-raven.ps1
+CMD [ "pwsh.exe", "-File", "C:\\RavenDB\\run-raven.ps1" ]

--- a/docker/ravendb-ubuntu/Dockerfile.arm32v7
+++ b/docker/ravendb-ubuntu/Dockerfile.arm32v7
@@ -26,4 +26,4 @@ WORKDIR /opt/RavenDB/Server
 
 VOLUME /opt/RavenDB/Server/RavenData /opt/RavenDB/config
 
-CMD /opt/RavenDB/run-raven.sh
+CMD [ "/bin/bash", "/opt/RavenDB/run-raven.sh" ]

--- a/docker/ravendb-ubuntu/Dockerfile.arm64v8
+++ b/docker/ravendb-ubuntu/Dockerfile.arm64v8
@@ -26,4 +26,4 @@ WORKDIR /opt/RavenDB/Server
 
 VOLUME /opt/RavenDB/Server/RavenData /opt/RavenDB/config
 
-CMD /opt/RavenDB/run-raven.sh
+CMD [ "/bin/bash", "/opt/RavenDB/run-raven.sh" ]

--- a/docker/ravendb-ubuntu/Dockerfile.x64
+++ b/docker/ravendb-ubuntu/Dockerfile.x64
@@ -26,4 +26,4 @@ WORKDIR /opt/RavenDB/Server
 
 VOLUME /opt/RavenDB/Server/RavenData /opt/RavenDB/config
 
-CMD /opt/RavenDB/run-raven.sh
+CMD [ "/bin/bash", "/opt/RavenDB/run-raven.sh" ]

--- a/docker/ravendb-ubuntu/run-raven.sh
+++ b/docker/ravendb-ubuntu/run-raven.sh
@@ -10,9 +10,25 @@ if [ ! -z "$RAVEN_ARGS" ]; then
 	COMMAND="$COMMAND ${RAVEN_ARGS}"
 fi
 
+handle_term() {
+    if [ "$COMMANDPID" ]; then
+        kill -TERM "$COMMANDPID" 2>/dev/null
+    else
+        TERM_KILL_NEEDED="yes"
+    fi
+}
+
+unset COMMANDPID
+unset TERM_KILL_NEEDED
+trap 'handle_term' TERM INT
+
 [ -n "$RAVEN_DATABASE" ] && export RAVEN_Setup_Mode=None
 $COMMAND &
 COMMANDPID=$!
 
 [ -n "$RAVEN_DATABASE" ]  && source ./server-utils.sh && create-database
-wait $COMMANDPID
+
+[ "$TERM_KILL_NEEDED" ] && kill -TERM "$COMMANDPID" 2>/dev/null 
+wait $COMMANDPID 2>/dev/null
+trap - TERM INT
+wait $COMMANDPID 2>/dev/null


### PR DESCRIPTION
### Issue link

https://issues.hibernatingrhinos.com/issue/RavenDB-12865

### Additional description

This change allows for graceful exit when running within Docker, for example when using Docker Compose.  Before this change, it would take 10 seconds before Docker Compose force killed the container, now it takes 0.5 seconds for a graceful shutdown. Also, these three lines were not in the container log before this change:

```
Received graceful exit request...
Starting shut down...
Shutdown completed
```

Only Linux containers uses SIGTERM and SIGINT. Windows containers might [use a CTRL_SHUTDOWN_EVENT](https://github.com/moby/moby/issues/25982#issuecomment-361391154)?

For the Windows Dockerfile, only the unwrapping the extra shell layer, CMD exec, optimization was applied. Windows was already shutting down quickly. However, the Windows container also isn't printing out a `Received graceful exit request...` message even in `Information` level logs.

### Type of change

- Optimization

### How risky is the change?

- Low

### Backward compatibility

- Non breaking change

### Is it platform specific issue?

- Yes. Docker; Ubuntu (and partially Windows) containers

### Documentation update

- No documentation update is needed 

### Testing 

- It has been verified by manual testing

### Is there any existing behavior change of other features due to this change?

- No

### UI work

- No UI work is needed
