### PR TITLE
RavenDB-18277 - Sharding - Stats View Endpoints

### DIFF
--- a/src/Raven.Server/Documents/Handlers/Processors/Debugging/StorageHandlerProcessorForGetReport.cs
+++ b/src/Raven.Server/Documents/Handlers/Processors/Debugging/StorageHandlerProcessorForGetReport.cs
@@ -1,0 +1,78 @@
+﻿using System.Threading.Tasks;
+using JetBrains.Annotations;
+using Raven.Server.ServerWide.Context;
+using Raven.Server.Utils;
+using Sparrow.Json;
+using Sparrow.Json.Parsing;
+using Voron;
+using Voron.Debugging;
+
+namespace Raven.Server.Documents.Handlers.Processors.Debugging
+{
+    internal class StorageHandlerProcessorForGetReport : AbstractHandlerProcessor<DatabaseRequestHandler, DocumentsOperationContext>
+    {
+        public StorageHandlerProcessorForGetReport([NotNull] DatabaseRequestHandler requestHandler)
+            : base(requestHandler, requestHandler.ContextPool)
+        {
+        }
+
+        public override async ValueTask ExecuteAsync()
+        {
+            await GetStorageReport();
+        }
+
+        protected async ValueTask GetStorageReport()
+        {
+            using (ContextPool.AllocateOperationContext(out DocumentsOperationContext context))
+            {
+                await using (var writer = new AsyncBlittableJsonTextWriter(context, RequestHandler.ResponseBodyStream()))
+                {
+                    writer.WriteStartObject();
+
+                    writer.WritePropertyName("BasePath");
+                    writer.WriteString(RequestHandler.Database.Configuration.Core.DataDirectory.FullPath);
+                    writer.WriteComma();
+
+                    writer.WritePropertyName("Results");
+                    writer.WriteStartArray();
+                    var first = true;
+                    foreach (var env in RequestHandler.Database.GetAllStoragesEnvironment())
+                    {
+                        if (first == false)
+                            writer.WriteComma();
+
+                        first = false;
+
+                        writer.WriteStartObject();
+
+                        writer.WritePropertyName("Name");
+                        writer.WriteString(env.Name);
+                        writer.WriteComma();
+
+                        writer.WritePropertyName("Type");
+                        writer.WriteString(env.Type.ToString());
+                        writer.WriteComma();
+
+                        var djv = (DynamicJsonValue)TypeConverter.ToBlittableSupportedType(GetReport(env));
+                        writer.WritePropertyName("Report");
+                        writer.WriteObject(context.ReadObject(djv, env.Name));
+
+                        writer.WriteEndObject();
+                    }
+
+                    writer.WriteEndArray();
+
+                    writer.WriteEndObject();
+                }
+            }
+        }
+
+        private static StorageReport GetReport(StorageEnvironmentWithType environment)
+        {
+            using (var tx = environment.Environment.ReadTransaction())
+            {
+                return environment.Environment.GenerateReport(tx);
+            }
+        }
+    }
+}

--- a/src/Raven.Server/Documents/Handlers/Processors/Debugging/StorageHandlerProcessorForGetReport.cs
+++ b/src/Raven.Server/Documents/Handlers/Processors/Debugging/StorageHandlerProcessorForGetReport.cs
@@ -21,7 +21,7 @@ namespace Raven.Server.Documents.Handlers.Processors.Debugging
             await GetStorageReport();
         }
 
-        protected async ValueTask GetStorageReport()
+        private async ValueTask GetStorageReport()
         {
             using (ContextPool.AllocateOperationContext(out DocumentsOperationContext context))
             {

--- a/src/Raven.Studio/typescript/common/shell/menu/items/stats.ts
+++ b/src/Raven.Studio/typescript/common/shell/menu/items/stats.ts
@@ -8,6 +8,7 @@ function getStatsMenuItem(appUrls: computedAppUrls) {
         new leafMenuItem({
             route: 'databases/status',
             moduleId: require('viewmodels/database/status/statistics'),
+            shardingMode: "singleShardOnly",
             title: 'Stats',
             nav: true,
             css: 'icon-stats',

--- a/src/Raven.Studio/typescript/viewmodels/database/status/statistics.ts
+++ b/src/Raven.Studio/typescript/viewmodels/database/status/statistics.ts
@@ -1,4 +1,3 @@
-import viewModelBase = require("viewmodels/viewModelBase");
 import getDatabaseDetailedStatsCommand = require("commands/resources/getDatabaseDetailedStatsCommand");
 import getIndexesStatsCommand = require("commands/database/index/getIndexesStatsCommand");
 import appUrl = require("common/appUrl");
@@ -7,8 +6,10 @@ import indexStalenessReasons = require("viewmodels/database/indexes/indexStalene
 import getStorageReportCommand = require("commands/database/debug/getStorageReportCommand");
 import statsModel = require("models/database/stats/statistics");
 import popoverUtils = require("common/popoverUtils");
+import shardViewModelBase from "viewmodels/shardViewModelBase";
+import database = require("models/resources/database");
 
-class statistics extends viewModelBase {
+class statistics extends shardViewModelBase {
 
     view = require("views/database/status/statistics.html");
 
@@ -20,13 +21,13 @@ class statistics extends viewModelBase {
 
     dataLocation = ko.observable<string>();
 
-    constructor() {
-        super();
+    constructor(db: database) {
+        super(db);
         
         this.bindToCurrentInstance("showStaleReasons");
 
         this.rawJsonUrl = ko.pureComputed(() => {
-            const activeDatabase = this.activeDatabase();
+            const activeDatabase = this.db;
             return activeDatabase ? appUrl.forStatsRawData(activeDatabase) : null;
         });
     }
@@ -97,7 +98,7 @@ class statistics extends viewModelBase {
     }
    
     fetchStats(): JQueryPromise<Raven.Client.Documents.Operations.DatabaseStatistics> {
-        const db = this.activeDatabase();
+        const db = this.db;
 
         const dbStatsTask = new getDatabaseDetailedStatsCommand(db)
             .execute();
@@ -128,11 +129,11 @@ class statistics extends viewModelBase {
     }
     
     urlForIndexPerformance(indexName: string) {
-        return appUrl.forIndexPerformance(this.activeDatabase(), indexName);
+        return appUrl.forIndexPerformance(this.db, indexName);
     }
 
     showStaleReasons(indexName: string) {
-        const view = new indexStalenessReasons(this.activeDatabase(), indexName);
+        const view = new indexStalenessReasons(this.db, indexName);
         app.showBootstrapDialog(view);
     }
 


### PR DESCRIPTION
### Issue link

https://issues.hibernatingrhinos.com/issue/RavenDB-18277

### Additional description

Includes implementation for **GET** `/databases/*/debug/storage/report ` - only for **_Single Shard_** mode (as discussed with @Danielle9897  - in case of **_All Shards_** mode - we'll send from Studio as single shard)

### Type of change

- New feature

### How risky is the change?

- Not relevant

### Backward compatibility

- Not relevant

### Is it platform specific issue?

- No

### Documentation update

- No documentation update is needed 

### Testing 

- It has been verified by manual testing

### Is there any existing behavior change of other features due to this change?

- No

### UI work

- No UI work is needed
