### PR TITLE
RavenDB-18422 Use @sql-keys (as was originally intended), avoid setti…

### DIFF
--- a/src/Raven.Server/SqlMigration/Model/SqlMigrationDocument.cs
+++ b/src/Raven.Server/SqlMigration/Model/SqlMigrationDocument.cs
@@ -25,8 +25,7 @@ namespace Raven.Server.SqlMigration.Model
             Object[Constants.Documents.Metadata.Key] = new DynamicJsonValue
             {
                 [Constants.Documents.Metadata.Collection] = collectionName,
-                [Constants.Documents.Metadata.Id] = id,
-                ["Sql-Keys-Columns"] = SpecialColumnsValues
+                ["@sql-keys"] = SpecialColumnsValues
             };
             Collection = collectionName;
         }


### PR DESCRIPTION
…ng @id property on metadata of documents about to be written.

Backport of https://github.com/ravendb/ravendb/pull/14073 to 5.2