### PR TITLE
RavenDB-17661 - allow deleting from the revisions bin when revisions are disabled

### DIFF
--- a/src/Raven.Server/Documents/Handlers/Admin/AdminRevisionsHandler.cs
+++ b/src/Raven.Server/Documents/Handlers/Admin/AdminRevisionsHandler.cs
@@ -18,10 +18,6 @@ namespace Raven.Server.Documents.Handlers.Admin
         [RavenAction("/databases/*/admin/revisions", "DELETE", AuthorizationStatus.DatabaseAdmin)]
         public async Task DeleteRevisionsFor()
         {
-            var revisionsStorage = Database.DocumentsStorage.RevisionsStorage;
-            if (revisionsStorage.Configuration == null)
-                throw new RevisionsDisabledException();
-
             using (Database.DocumentsStorage.ContextPool.AllocateOperationContext(out JsonOperationContext context))
             {
                 var json = await context.ReadForMemoryAsync(RequestBodyStream(), "admin/revisions/delete");

--- a/test/SlowTests/Issues/RavenDB-17661.cs
+++ b/test/SlowTests/Issues/RavenDB-17661.cs
@@ -1,6 +1,8 @@
 ﻿using System.Threading.Tasks;
 using FastTests;
+using FastTests.Server.Documents.Revisions;
 using Raven.Client.Documents.Commands;
+using Raven.Server.Documents.Handlers.Admin;
 using Sparrow.Json;
 using Xunit;
 using Xunit.Abstractions;
@@ -24,6 +26,19 @@ namespace SlowTests.Issues
                     await store.GetRequestExecutor().ExecuteAsync(command, context);
                     Assert.Equal(0, command.Result.Results.Length);
                 }
+            }
+        }
+
+        [Fact]
+        public async Task Can_Delete_From_Revisions_Bin_When_Revisions_Are_Disabled()
+        {
+            using (var store = GetDocumentStore())
+            {
+                const string id = "user";
+                await store.Maintenance.SendAsync(new RevisionsTests.DeleteRevisionsOperation(new AdminRevisionsHandler.Parameters
+                {
+                    DocumentIds = new[] { "non-existing-id" }
+                }));
             }
         }
     }


### PR DESCRIPTION
### Issue link

https://issues.hibernatingrhinos.com/issue/RavenDB-17661

### Additional description

Allow deleting from the revisions bin when revisions are disabled

### Type of change

- Bug fix

### How risky is the change?

- Low 

### Testing 

- Tests have been added that prove the fix is effective or that the feature works
