### PR TITLE
RavenDB-18083 There is no need to opend write transaction when writing an attachment to temp file.

### DIFF
--- a/src/Raven.Server/Documents/Handlers/BulkInsertHandler.cs
+++ b/src/Raven.Server/Documents/Handlers/BulkInsertHandler.cs
@@ -229,7 +229,6 @@ namespace Raven.Server.Documents.Handlers
             }
 
             using (Database.DocumentsStorage.ContextPool.AllocateOperationContext(out DocumentsOperationContext ctx))
-            using (ctx.OpenWriteTransaction())
             {
                 attachmentStream.Hash = await AttachmentsStorageHelper.CopyStreamToFileAndCalculateHash(ctx, stream, attachmentStream.Stream, Database.DatabaseShutdown);
                 await attachmentStream.Stream.FlushAsync();


### PR DESCRIPTION
This also made that we have incorrectly detected an active write tx lock owner and threw in ThrowOnFlushLockEnterWhileWriteTransactionLockIsTaken(). The problem was that we had async call uside so a thread statring the transaction could be used to call SyncEnv() meanwhile.

### Issue link

The issue was detected in https://issues.hibernatingrhinos.com/issue/RavenDB-18083

### Additional description

This fixes not necessary write tx lock acquirement - which can take long for big attachments. This also fixes the problem with occasionally failing bulk insert attachment tests due to recently added debug check - the problem was async call inside using with the transaction

### Type of change

- Bug fix

### How risky is the change?

- Low 

### Backward compatibility

- Not relevant

### Is it platform specific issue?

- No

### Documentation update

- No documentation update is needed 

### Testing 

- Existing tests will verify that

### Is there any existing behavior change of other features due to this change?

- No

### UI work

- No UI work is needed
