### PR TITLE
RavenDB-18482 escape the backslash

### DIFF
--- a/src/Raven.Studio/typescript/common/queryUtil.spec.ts
+++ b/src/Raven.Studio/typescript/common/queryUtil.spec.ts
@@ -85,4 +85,26 @@ describe("queryUtil", function () {
                 .toBeFalse();
         });
     });
+
+    describe("escapeName", function () {
+        const act = (name: string) => queryUtil.escapeName(name);
+
+        it("adds quotes on simple names", () => {
+            const result = act("name");
+            expect(result)
+                .toEqual("'name'");
+        });
+
+        it("escapes single quotes", () => {
+            const result = act("it'squoted");
+            expect(result)
+                .toEqual("'it''squoted'");
+        });
+
+        it("escapes the escape char", () => {
+            const result = act("itcontains\\literal");
+            expect(result)
+                .toEqual("'itcontains\\\\literal'");
+        });
+    });
 });

--- a/src/Raven.Studio/typescript/common/queryUtil.ts
+++ b/src/Raven.Studio/typescript/common/queryUtil.ts
@@ -59,6 +59,9 @@ class queryUtil {
     }
 
     static escapeName(name: string) {
+        if (name.includes("\\")) {
+            name = name.replace(/\\/g, "\\\\");
+        }
         return queryUtil.wrapWithSingleQuotes(name);
     }
 


### PR DESCRIPTION
### Issue link

https://issues.hibernatingrhinos.com/issue/RavenDB-18482 .

### Additional description

The query generated by the Studio is invalid when the document id or timeseries id contains a \ character.
This prevents a plot to be shown, though the user can work around it by escaping it manually.
Note that there may be other cases / chars that need escaping, I am no authority on that. 
Also, the unit tests have been added and tested successfully, ~I had some trouble to launch the Studio with this change to verify that it actually works in the scenario from the issue.~

### Type of change

- Bug fix

### How risky is the change?

- Moderate 

### Backward compatibility

- Non breaking change

### Is it platform specific issue?

- No

### Documentation update

- No documentation update is needed 

### Testing 

- Tests have been added that prove the fix is effective or that the feature works
- It has also been verified by manual testing to fix the behaviour in the linked issue.

### Is there any existing behavior change of other features due to this change?

- No

### UI work

- No UI work is needed
