### PR TITLE
RavenDB-18490 Searching with the usage of multiple phrases must not add +"?" to Lucene query so we'll get correct results

### DIFF
--- a/src/Raven.Server/Documents/Queries/QueryBuilder.cs
+++ b/src/Raven.Server/Documents/Queries/QueryBuilder.cs
@@ -1030,8 +1030,12 @@ namespace Raven.Server.Documents.Queries
                         case ' ':
                             if(quoted)
                                 continue;
-                            
-                            yield return YieldValue(valueAsString, lastWordStart, i - lastWordStart, escapePositions);
+
+                            if (lastWordStart != i)
+                            {
+                                yield return YieldValue(valueAsString, lastWordStart, i - lastWordStart, escapePositions);
+                            }
+
                             lastWordStart = i + 1; // skipping
                             break;
                     }

--- a/test/SlowTests/Issues/RavenDB_18490.cs
+++ b/test/SlowTests/Issues/RavenDB_18490.cs
@@ -1,0 +1,108 @@
+﻿using System.Collections.Generic;
+using System.Linq;
+using FastTests;
+using Raven.Client.Documents;
+using Raven.Client.Documents.Indexes;
+using Raven.Client.Documents.Queries;
+using Xunit;
+using Xunit.Abstractions;
+
+namespace SlowTests.Issues;
+
+public class RavenDB_18490 : RavenTestBase
+{
+    public RavenDB_18490(ITestOutputHelper output) : base(output)
+    {
+    }
+
+    [Fact]
+    public void CanProvideMultiplePhrasesToSearchQuery()
+    {
+        using (var store = GetDocumentStore())
+        {
+            using (var session = store.OpenSession())
+            {
+                new CompanyCandidateSearchIndex().Execute(store);
+
+                CompanyCandidateDocument entity = new CompanyCandidateDocument
+                {
+                    Id = "candidates/1",
+                    FifoId = 1,
+                    ProfileTitle = "Software Engineer",
+                    CurrentRole = new JobExperience { RoleTitle = "Software Engineer" },
+                    Specialties = { "Developing", "Matching" },
+                    PreferredNextRoleNames = { "Team Lead" },
+                    ActiveRoles = new List<JobExperience>
+                    {
+                        new JobExperience { RoleTitle = ".NET Framework Architect" },
+                        new JobExperience { RoleTitle = "Developer of Software" },
+                        new JobExperience { RoleTitle = "SQL Developer" },
+                        new JobExperience { RoleTitle = "Should Match" }
+                    },
+                    MarketStatus = CandidateMarketStatus.InTheMarket
+                };
+                session.Store(entity);
+
+                session.SaveChanges();
+
+                Indexes.WaitForIndexing(store);
+
+                var results = session.Query<CompanyCandidateSearchIndex.Result, CompanyCandidateSearchIndex>()
+                    .Search(c => c.TextQuery, "\"Software Engineer\"", @operator: SearchOperator.And)
+                    .Search(c => c.TextQuery, "\".NET Framework\"", options: SearchOptions.And, @operator: SearchOperator.And)
+                    .OfType<CompanyCandidateDocument>()
+                    .ToArray();
+
+                Assert.Equal(1, results.Length);
+
+                results = session.Query<CompanyCandidateSearchIndex.Result, CompanyCandidateSearchIndex>()
+                    .Search(c => c.TextQuery, "\"Software Engineer\" \".NET Framework\"", @operator: SearchOperator.And)
+                    .OfType<CompanyCandidateDocument>()
+                    .ToArray();
+
+                Assert.Equal(1, results.Length);
+            }
+        }
+    }
+
+    private class CompanyCandidateSearchIndex : AbstractIndexCreationTask<CompanyCandidateDocument>
+    {
+        public class Result
+        {
+            public object[] TextQuery { get; set; }
+        }
+
+        public CompanyCandidateSearchIndex()
+        {
+            Map = documents => from doc in documents
+                               select new Result()
+                               {
+                                   TextQuery = new object[] { doc.ProfileTitle, doc.ActiveRoles.Select(x => new { x.RoleTitle }) }
+                               };
+
+            Index(nameof(Result.TextQuery), FieldIndexing.Search);
+        }
+    }
+
+    private enum CandidateMarketStatus
+    {
+        InTheMarket
+    }
+
+    private class JobExperience
+    {
+        public string RoleTitle { get; set; }
+    }
+
+    private class CompanyCandidateDocument
+    {
+        public string Id { get; set; }
+        public int FifoId { get; set; }
+        public string ProfileTitle { get; set; }
+        public JobExperience CurrentRole { get; set; }
+        public List<string> Specialties { get; set; } = new();
+        public List<string> PreferredNextRoleNames { get; set; } = new();
+        public List<JobExperience> ActiveRoles { get; set; } = new();
+        public CandidateMarketStatus MarketStatus { get; set; }
+    }
+}


### PR DESCRIPTION
### Issue link

https://issues.hibernatingrhinos.com/issue/RavenDB-18490

### Additional description

Fixes the search with multiple phrases

### Type of change

- Bug fix

### How risky is the change?

- Moderate 

### Backward compatibility

- Non breaking change. This is a bug. It returned wrong results. 

### Is it platform specific issue?

- No

### Documentation update

- No documentation update is needed 

### Testing 

- Tests have been added that prove the fix is effective or that the feature works
 - Internal classes added to the test class (e.g. entity or index definition classes) have the lowest possible access modifier (preferable `private`) 

### Is there any existing behavior change of other features due to this change?

- No

### UI work

- No UI work is needed
