### PR TITLE
RavenDB-18483 Corax - customizable between. 

### DIFF
--- a/src/Corax/Queries/UnaryMatch.Ordinal.cs
+++ b/src/Corax/Queries/UnaryMatch.Ordinal.cs
@@ -9,7 +9,7 @@ namespace Corax.Queries
 {
     unsafe partial struct UnaryMatch<TInner, TValueType>
     {
-        private interface IUnaryMatchComparer
+        public interface IUnaryMatchComparer
         {
             bool Compare(ReadOnlySpan<byte> sx, ReadOnlySpan<byte> sy);
             bool Compare<T>(T sx, T sy) where T : unmanaged;
@@ -317,7 +317,7 @@ namespace Corax.Queries
             }
         }
 
-        private struct GreaterThanMatchComparer : IUnaryMatchComparer
+        internal struct GreaterThanMatchComparer : IUnaryMatchComparer
         {
             [MethodImpl(MethodImplOptions.AggressiveInlining | MethodImplOptions.AggressiveOptimization)]
             public bool Compare(ReadOnlySpan<byte> sx, ReadOnlySpan<byte> sy)
@@ -337,7 +337,7 @@ namespace Corax.Queries
             }
         }
 
-        private struct GreaterThanOrEqualMatchComparer : IUnaryMatchComparer
+        internal struct GreaterThanOrEqualMatchComparer : IUnaryMatchComparer
         {
             [MethodImpl(MethodImplOptions.AggressiveInlining | MethodImplOptions.AggressiveOptimization)]
             public bool Compare(ReadOnlySpan<byte> sx, ReadOnlySpan<byte> sy)
@@ -357,7 +357,7 @@ namespace Corax.Queries
             }
         }
 
-        private struct LessThanMatchComparer : IUnaryMatchComparer
+        internal struct LessThanMatchComparer : IUnaryMatchComparer
         {
             [MethodImpl(MethodImplOptions.AggressiveInlining | MethodImplOptions.AggressiveOptimization)]
             public bool Compare(ReadOnlySpan<byte> sx, ReadOnlySpan<byte> sy)
@@ -377,7 +377,7 @@ namespace Corax.Queries
             }
         }
 
-        private struct LessThanOrEqualMatchComparer : IUnaryMatchComparer
+        internal struct LessThanOrEqualMatchComparer : IUnaryMatchComparer
         {
             [MethodImpl(MethodImplOptions.AggressiveInlining | MethodImplOptions.AggressiveOptimization)]
             public bool Compare(ReadOnlySpan<byte> sx, ReadOnlySpan<byte> sy)
@@ -397,7 +397,7 @@ namespace Corax.Queries
             }
         }
 
-        private struct NotEqualsMatchComparer : IUnaryMatchComparer
+        internal struct NotEqualsMatchComparer : IUnaryMatchComparer
         {
             [MethodImpl(MethodImplOptions.AggressiveInlining | MethodImplOptions.AggressiveOptimization)]
             public bool Compare(ReadOnlySpan<byte> sx, ReadOnlySpan<byte> sy)
@@ -417,7 +417,7 @@ namespace Corax.Queries
             }
         }
 
-        private struct EqualsMatchComparer : IUnaryMatchComparer
+        internal struct EqualsMatchComparer : IUnaryMatchComparer
         {
             [MethodImpl(MethodImplOptions.AggressiveInlining | MethodImplOptions.AggressiveOptimization)]
             public bool Compare(ReadOnlySpan<byte> sx, ReadOnlySpan<byte> sy)


### PR DESCRIPTION
### Issue link

https://issues.hibernatingrhinos.com/issue/RavenDB-18483

### Additional description

This PR will gives us possibility to rewrite query like: `x > CONST && x <= CONST2` into between.

### Type of change

- New feature
- Optimization

### How risky is the change?


- Not relevant

### Backward compatibility


- Not relevant

### Is it platform specific issue?


- No

### Documentation update

- No documentation update is needed 

### Testing 

- Tests have been added that prove the fix is effective or that the feature works


### Is there any existing behavior change of other features due to this change?

- No

### UI work

- No UI work is needed
