### PR TITLE
RavenDB-18163 - creating a revision manually fails when revisions are enabled for any collection

### DIFF
--- a/src/Raven.Server/Documents/DocumentFlags.cs
+++ b/src/Raven.Server/Documents/DocumentFlags.cs
@@ -51,7 +51,8 @@ namespace Raven.Server.Documents
         ByEnforceRevisionConfiguration = 0x1000,
         ResolveTimeSeriesConflict = 0x2000,
         ByTimeSeriesUpdate = 0x4000,
-        LegacyDeleteMarker = 0x8000
+        LegacyDeleteMarker = 0x8000,
+        ForceRevisionCreation = 0x10000
     }
 
     public static class EnumExtensions

--- a/src/Raven.Server/Documents/Handlers/BatchHandler.cs
+++ b/src/Raven.Server/Documents/Handlers/BatchHandler.cs
@@ -805,7 +805,7 @@ namespace Raven.Server.Documents.Handlers
                                     Database.DocumentsStorage.RevisionsStorage.Put(context, existingDocument.Id,
                                                                                    existingDocument.Data.Clone(context),
                                                                                    existingDocument.Flags |= DocumentFlags.HasRevisions,
-                                                                                   nonPersistentFlags: NonPersistentDocumentFlags.None,
+                                                                                   nonPersistentFlags: NonPersistentDocumentFlags.ForceRevisionCreation,
                                                                                    existingDocument.ChangeVector,
                                                                                    existingDocument.LastModified.Ticks);
                                     flags |= DocumentFlags.HasRevisions;

--- a/src/Raven.Server/Documents/Handlers/BatchHandler.cs
+++ b/src/Raven.Server/Documents/Handlers/BatchHandler.cs
@@ -1092,7 +1092,7 @@ namespace Raven.Server.Documents.Handlers
                             revisionCreated = Database.DocumentsStorage.RevisionsStorage.Put(context, existingDoc.Id,
                                                                                          clonedDocData,
                                                                                          existingDoc.Flags,
-                                                                                         nonPersistentFlags: NonPersistentDocumentFlags.None,
+                                                                                         nonPersistentFlags: NonPersistentDocumentFlags.ForceRevisionCreation,
                                                                                          existingDoc.ChangeVector,
                                                                                          existingDoc.LastModified.Ticks);
                             if (revisionCreated)

--- a/src/Raven.Server/Documents/Revisions/RevisionsStorage.cs
+++ b/src/Raven.Server/Documents/Revisions/RevisionsStorage.cs
@@ -399,7 +399,8 @@ namespace Raven.Server.Documents.Revisions
                 configuration = GetRevisionsConfiguration(collectionName.Name);
 
             if (configuration.Disabled &&
-                nonPersistentFlags.Contain(NonPersistentDocumentFlags.FromReplication) == false)
+                nonPersistentFlags.Contain(NonPersistentDocumentFlags.FromReplication) == false &&
+                flags.Contain(DocumentFlags.HasRevisions) == false)
                 return false;
 
             using (DocumentIdWorker.GetLowerIdSliceAndStorageKey(context, id, out Slice lowerId, out Slice idSlice))

--- a/src/Raven.Server/Documents/Revisions/RevisionsStorage.cs
+++ b/src/Raven.Server/Documents/Revisions/RevisionsStorage.cs
@@ -400,7 +400,7 @@ namespace Raven.Server.Documents.Revisions
 
             if (configuration.Disabled &&
                 nonPersistentFlags.Contain(NonPersistentDocumentFlags.FromReplication) == false &&
-                flags.Contain(DocumentFlags.HasRevisions) == false)
+                nonPersistentFlags.Contain(NonPersistentDocumentFlags.ForceRevisionCreation) == false)
                 return false;
 
             using (DocumentIdWorker.GetLowerIdSliceAndStorageKey(context, id, out Slice lowerId, out Slice idSlice))

--- a/test/SlowTests/Issues/RavenDB-18163.cs
+++ b/test/SlowTests/Issues/RavenDB-18163.cs
@@ -58,6 +58,15 @@ namespace SlowTests.Issues
                     revisionsCount = session.Advanced.Revisions.GetFor<Company>(company.Id).Count;
                     Assert.Equal(1, revisionsCount);
                 }
+
+                using (var session = store.OpenSession())
+                {
+                    // Assert that HasRevisions flag was created on both documents
+                    var company = session.Load<Company>(companyId);
+                    var metadata = session.Advanced.GetMetadataFor(company);
+                    metadata.TryGetValue("@flags", out var flagsContent);
+                    Assert.Equal("HasRevisions", flagsContent);
+                }
             }
         }
 
@@ -107,6 +116,15 @@ namespace SlowTests.Issues
 
                     var revisionsCount = session.Advanced.Revisions.GetFor<Company>(company.Id).Count;
                     Assert.Equal(1, revisionsCount);
+                }
+
+                using (var session = store.OpenSession())
+                {
+                    // Assert that HasRevisions flag was created on both documents
+                    var company = session.Load<Company>(companyId);
+                    var metadata = session.Advanced.GetMetadataFor(company);
+                    metadata.TryGetValue("@flags", out var flagsContent);
+                    Assert.Equal("HasRevisions", flagsContent);
                 }
             }
         }

--- a/test/SlowTests/Issues/RavenDB_18163.cs
+++ b/test/SlowTests/Issues/RavenDB_18163.cs
@@ -1,0 +1,84 @@
+﻿using System;
+using System.Collections.Generic;
+using System.Diagnostics;
+using System.Linq;
+using System.Threading;
+using System.Threading.Tasks;
+using FastTests;
+using Raven.Client;
+using Raven.Client.Documents;
+using Raven.Client.Documents.Operations.ConnectionStrings;
+using Raven.Client.Documents.Operations.ETL;
+using Raven.Client.Documents.Operations.Revisions;
+using Raven.Client.Documents.Queries.Timings;
+using Raven.Server;
+using Raven.Server.Documents;
+using Raven.Server.Documents.TimeSeries;
+using Raven.Server.ServerWide.Context;
+using Raven.Tests.Core.Utils.Entities;
+using Raven.Server.Config;
+using Sparrow.Json;
+using Sparrow.Json.Parsing;
+using Tests.Infrastructure;
+using Xunit;
+using Xunit.Abstractions;
+
+namespace SlowTests.Issues
+{
+    public class RavenDB_18163 : RavenTestBase
+    {
+        public RavenDB_18163(ITestOutputHelper output) : base(output)
+        {
+        }
+
+        [Fact]
+        public async Task CreatingARevisionManuallyAfterEnablingRevisionsForAnyCollection()
+        { 
+            var store = GetDocumentStore();
+
+            // Define revision settings on Orders collection
+            var configuration = new RevisionsConfiguration
+            {
+                Collections = new Dictionary<string, RevisionsCollectionConfiguration>
+                {
+                    {
+                        "Orders", new RevisionsCollectionConfiguration
+                        {
+                            PurgeOnDelete = true,
+                            MinimumRevisionsToKeep = 5
+                        }
+                    }
+                }
+            };
+            var result = await store.Maintenance.SendAsync(new ConfigureRevisionsOperation(configuration));
+
+            string companyId;
+            using (var session = store.OpenSession())
+            {
+                var company = new Company { Name = "HR" };
+                session.Store(company);
+                companyId = company.Id;
+                session.SaveChanges();
+            }
+
+            using (var session = store.OpenSession())
+            {
+                var company = session.Load<Company>(companyId);
+
+                var revisionsCount = session.Advanced.Revisions.GetFor<Company>(company.Id).Count;
+                Assert.Equal(0, revisionsCount);
+
+                // Force revisions on a Company document
+                session.Advanced.Revisions.ForceRevisionCreationFor<Company>(company);
+                session.SaveChanges();
+
+                revisionsCount = session.Advanced.Revisions.GetFor<Company>(company.Id).Count;
+                Assert.Equal(1, revisionsCount); //=> this fails - should be 1 - but it is 0
+            }
+
+            store.Dispose();
+        }
+
+    }
+
+}


### PR DESCRIPTION
### Issue link

https://issues.hibernatingrhinos.com/issue/RavenDB-18163

### Additional description

Fixing creating a revision manually fails when revisions are enabled for any collection

### Type of change

- Bug fix

### How risky is the change?

- Low

### Backward compatibility

- Not relevant

### Is it platform specific issue?

- No

### Documentation update

- No documentation update is needed 

### Testing 

- Tests have been added that prove the fix is effective or that the feature works

### Is there any existing behavior change of other features due to this change?

- No

### UI work

- No UI work is needed
