### PR TITLE
Added ResolveTypeFromClrTypeName convention

### DIFF
--- a/src/Raven.Client/Documents/Conventions/DocumentConventions.cs
+++ b/src/Raven.Client/Documents/Conventions/DocumentConventions.cs
@@ -193,6 +193,7 @@ namespace Raven.Client.Documents.Conventions
                 return null;
             };
             FindClrTypeName = ReflectionUtil.GetFullNameWithoutVersionInformation;
+            ResolveTypeFromClrTypeName = Type.GetType;
 
             TransformTypeCollectionNameToDocumentIdPrefix = DefaultTransformCollectionNameToDocumentIdPrefix;
             FindCollectionName = DefaultGetCollectionName;
@@ -254,6 +255,7 @@ namespace Raven.Client.Documents.Conventions
 
         private Func<Type, string> _findClrTypeName;
         private Func<string, BlittableJsonReaderObject, string> _findClrType;
+        private Func<string, Type> _resolveTypeFromClrTypeName;
         private bool _useOptimisticConcurrency;
         private bool _throwIfQueryPageSizeIsNotSet;
         private bool _addIdFieldToDynamicObjects;
@@ -587,6 +589,19 @@ namespace Raven.Client.Documents.Conventions
             {
                 AssertNotFrozen();
                 _findClrTypeName = value;
+            }
+        }
+
+        /// <summary>
+        ///     Gets or sets the function to resolve the clr type from a clr type name.
+        /// </summary>
+        public Func<string, Type> ResolveTypeFromClrTypeName
+        {
+            get => _resolveTypeFromClrTypeName;
+            set
+            {
+                AssertNotFrozen();
+                _resolveTypeFromClrTypeName = value;
             }
         }
 

--- a/src/Raven.Client/Json/Serialization/NewtonsoftJson/Internal/BlittableJsonConverter.cs
+++ b/src/Raven.Client/Json/Serialization/NewtonsoftJson/Internal/BlittableJsonConverter.cs
@@ -26,7 +26,7 @@ namespace Raven.Client.Json.Serialization.NewtonsoftJson.Internal
                 var documentTypeAsString = Conventions.Conventions.GetClrType(id, json);
                 if (documentTypeAsString != null)
                 {
-                    var documentType = Type.GetType(documentTypeAsString);
+                    var documentType = Conventions.Conventions.ResolveTypeFromClrTypeName(documentTypeAsString);
                     if (documentType != null && type.IsAssignableFrom(documentType))
                     {
                         entity = Conventions.DeserializeEntityFromBlittable(documentType, json);

--- a/src/Raven.Client/Json/Serialization/NewtonsoftJson/Internal/SessionBlittableJsonConverter.cs
+++ b/src/Raven.Client/Json/Serialization/NewtonsoftJson/Internal/SessionBlittableJsonConverter.cs
@@ -50,7 +50,7 @@ namespace Raven.Client.Json.Serialization.NewtonsoftJson.Internal
                     var documentTypeAsString = _session.Conventions.GetClrType(id, json);
                     if (documentTypeAsString != null)
                     {
-                        var documentType = Type.GetType(documentTypeAsString);
+                        var documentType = _session.Conventions.ResolveTypeFromClrTypeName(documentTypeAsString);
                         if (documentType != null && type.IsAssignableFrom(documentType))
                         {
                             entity = _session.Conventions.Serialization.DeserializeEntityFromBlittable(documentType, json);


### PR DESCRIPTION
### Issue link

Issue is not created, but is discussed on https://github.com/ravendb/ravendb/discussions/14119

### Additional description

This PR add a new convention that allow customise the type resolver. Using search on my IDE, I found that `Type.GetType()` is called in these files:

https://github.com/ravendb/ravendb/blob/f773b7da6e8afccad88549ee528fd1165878baa1/src/Raven.Client/Json/Serialization/NewtonsoftJson/Internal/BlittableJsonConverter.cs#L29

https://github.com/ravendb/ravendb/blob/f773b7da6e8afccad88549ee528fd1165878baa1/src/Raven.Client/Json/Serialization/NewtonsoftJson/Internal/SessionBlittableJsonConverter.cs#L53

https://github.com/ravendb/ravendb/blob/b187304ca44c5518c4137cfe205f837e2c57cac4/src/Raven.Client/Exceptions/ExceptionDispatcher.cs#L184

https://github.com/ravendb/ravendb/blob/b187304ca44c5518c4137cfe205f837e2c57cac4/src/Raven.Client/Json/Serialization/NewtonsoftJson/Internal/BlittableJsonConverterBase.cs#L229

In this PR I only modified the first two because the others two are static methods and I'm don't know how to access conventions on these methods and I'm not sure if I should do it.

### Type of change

- New feature

### How risky is the change?

- Low 

### Backward compatibility

- Ensured. Please explain how has it been implemented?

Because the default convention is calling `Type.GetType()`, so if the convention is not applied, remains the old behaviour.

### Is it platform specific issue?

- No

### Documentation update

- This change requires a documentation update. Please mark the issue on YouTrack using `Documentation Required` tag.

### Testing 

- It has been verified by manual testing

### Is there any existing behavior change of other features due to this change?

- No

### UI work

- No UI work is needed
