### PR TITLE
Revert "Revert "RavenDB-17308 Using mmap() instead of posix_memalign when allocating 4KB aligned memory for the encryption buffers and journal reader recovery.

### DIFF
--- a/test/FastTests/Sparrow/EncryptionTests.cs
+++ b/test/FastTests/Sparrow/EncryptionTests.cs
@@ -11,6 +11,7 @@ using Sparrow;
 using Sparrow.Platform;
 using Sparrow.Server;
 using Sparrow.Utils;
+using Tests.Infrastructure;
 using Voron;
 using Voron.Data;
 using Voron.Impl.Paging;
@@ -26,7 +27,7 @@ namespace FastTests.Sparrow
         {
         }
 
-        [Fact]
+        [MultiplatformFact(RavenPlatform.Windows | RavenPlatform.Linux)]
         public unsafe void WriteAndReadPageUsingCryptoPager()
         {
             using (var options = StorageEnvironmentOptions.ForPath(DataDir))
@@ -110,7 +111,7 @@ namespace FastTests.Sparrow
             }
         }
 
-        [Fact]
+        [MultiplatformFact(RavenPlatform.Windows | RavenPlatform.Linux)]
         public unsafe void StreamsTempFile_With_Encryption_ShouldNotThrow_When_NotAllStreamsWereRead()
         {
             using (var options = StorageEnvironmentOptions.ForPath(DataDir))
@@ -151,7 +152,7 @@ namespace FastTests.Sparrow
             }
         }
 
-        [Fact]
+        [MultiplatformFact(RavenPlatform.Windows | RavenPlatform.Linux)]
         public unsafe void StreamsTempFile_With_Encryption_ShouldThrow_When_SeekAndWrite_AreMixed_Without_ExecutingReset()
         {
             using (var options = StorageEnvironmentOptions.ForPath(DataDir))
@@ -189,7 +190,7 @@ namespace FastTests.Sparrow
             }
         }
 
-        [Fact]
+        [MultiplatformFact(RavenPlatform.Windows | RavenPlatform.Linux)]
         public unsafe void RavenDB_15975()
         {
             using (var options = StorageEnvironmentOptions.ForPath(DataDir))

--- a/test/FastTests/Voron/EncryptionBufferPool.cs
+++ b/test/FastTests/Voron/EncryptionBufferPool.cs
@@ -5,6 +5,7 @@ using System.Threading;
 using Sparrow;
 using Sparrow.LowMemory;
 using Sparrow.Utils;
+using Tests.Infrastructure;
 using Voron.Impl;
 using Xunit;
 using Xunit.Abstractions;
@@ -17,7 +18,7 @@ namespace FastTests.Voron
         {
         }
 
-        [Fact]
+        [MultiplatformFact(RavenPlatform.Windows | RavenPlatform.Linux)]
         public void dont_pool_buffers_larger_than_8Mb()
         {
             var encryptionBuffersPool = new EncryptionBuffersPool();
@@ -56,7 +57,7 @@ namespace FastTests.Voron
             ClearMemory(encryptionBuffersPool);
         }
 
-        [Theory]
+        [MultiplatformTheory(RavenPlatform.Windows | RavenPlatform.Linux)]
         [InlineData(LowMemorySeverity.Low)]
         [InlineData(LowMemorySeverity.ExtremelyLow)]
         public void clear_all_buffers_from_current_generation_on_low_memory(LowMemorySeverity lowMemorySeverity)
@@ -105,7 +106,7 @@ namespace FastTests.Voron
             ClearMemory(encryptionBuffersPool);
         }
 
-        [Fact]
+        [MultiplatformFact(RavenPlatform.Windows | RavenPlatform.Linux)]
         public void clear_all_buffers_on_extremely_low_memory()
         {
             var encryptionBuffersPool = new EncryptionBuffersPool();
@@ -136,7 +137,7 @@ namespace FastTests.Voron
             ClearMemory(encryptionBuffersPool);
         }
 
-        [Fact]
+        [MultiplatformFact(RavenPlatform.Windows | RavenPlatform.Linux)]
         public void can_save_buffers_after_low_memory()
         {
             var encryptionBuffersPool = new EncryptionBuffersPool();
@@ -170,7 +171,7 @@ namespace FastTests.Voron
             ClearMemory(encryptionBuffersPool);
         }
 
-        [Fact]
+        [MultiplatformFact(RavenPlatform.Windows | RavenPlatform.Linux)]
         public void clear_buffers_only_when_in_extremely_low_memory()
         {
             var encryptionBuffersPool = new EncryptionBuffersPool();
@@ -190,7 +191,7 @@ namespace FastTests.Voron
             ClearMemory(encryptionBuffersPool);
         }
 
-        [Fact]
+        [MultiplatformFact(RavenPlatform.Windows | RavenPlatform.Linux)]
         public void properly_calculate_thread_total_allocations_when_we_cant_put_buffer_in_pool()
         {
             var encryptionBuffersPool = new EncryptionBuffersPool(registerLowMemory: false, registerCleanup: false);


### PR DESCRIPTION
 This way we avoid the memory fragmentation. Note that providing NULL as the first argument to mmap() makes that the returned address is page-aligned.""

This reverts commit f773b7da6e8afccad88549ee528fd1165878baa1.

### Issue link

https://issues.hibernatingrhinos.com/issue/RavenDB-17308

### Additional description

This PR applies the fix https://github.com/ravendb/ravendb/pull/13148 to 5.3 branch which got reverted in https://github.com/ravendb/ravendb/commit/f773b7da6e8afccad88549ee528fd1165878baa1 and wasn't applied during 5.2 to 5.3 merge.

### Type of change

- Bug fix

### How risky is the change?

- Low (it is in 5.2 version already)

### Backward compatibility

- Not relevant

### Is it platform specific issue?

- No

### Documentation update

- No documentation update is needed 

### Testing 

- Verified in 5.2 version

### Is there any existing behavior change of other features due to this change?

- No

### UI work

- No UI work is needed
