### PR TITLE
RavenDB-18545 - Fix - Can't select a field that its name is equal to …

### DIFF
--- a/src/Raven.Client/Documents/Session/Tokens/GroupByKeyToken.cs
+++ b/src/Raven.Client/Documents/Session/Tokens/GroupByKeyToken.cs
@@ -27,7 +27,7 @@ namespace Raven.Client.Documents.Session.Tokens
 
             writer
                 .Append(" as ")
-                .Append(_projectedName);
+                .Append($"\'{_projectedName}\'");
         }
     }
 }

--- a/src/Raven.Client/Documents/Session/Tokens/GroupByKeyToken.cs
+++ b/src/Raven.Client/Documents/Session/Tokens/GroupByKeyToken.cs
@@ -26,8 +26,9 @@ namespace Raven.Client.Documents.Session.Tokens
                 return;
 
             writer
-                .Append(" as ")
-                .Append($"\'{_projectedName}\'");
+                .Append(" as '")
+                .Append(_projectedName)
+                .Append("'");
         }
     }
 }

--- a/src/Raven.Server/Documents/Queries/Parser/QueryParser.cs
+++ b/src/Raven.Server/Documents/Queries/Parser/QueryParser.cs
@@ -2392,28 +2392,8 @@ Grouping by 'Tag' or Field is supported only as a second grouping-argument.";
             return false;
         }
 
-        private static readonly string[] AsAliasKeyword = { "AS" };
-        enum AsState { NoAsAlias, IsAsAlias, AfterAsAlias };
-        private AsState tokenAsState = AsState.NoAsAlias;
-
         internal bool Field(out FieldExpression token)
         {
-            if (tokenAsState == AsState.NoAsAlias)
-            {
-                if (Scanner.CurrentTokenMatchesAnyOf(AsAliasKeyword))
-                {
-                    tokenAsState = AsState.IsAsAlias;
-                }
-            }
-            else if(tokenAsState == AsState.IsAsAlias)
-            {
-                tokenAsState = AsState.AfterAsAlias;
-            }
-            else if (tokenAsState == AsState.AfterAsAlias)
-            {
-                tokenAsState = AsState.NoAsAlias;
-            }
-
             var part = 0;
 
             var parts = new List<StringSegment>(1);
@@ -2439,13 +2419,10 @@ Grouping by 'Tag' or Field is supported only as a second grouping-argument.";
                 {
                     parts.Add(Scanner.Token);
                 }
-                //Shahar
                 if (part == 1)
                 {
-                    // need to ensure that this isn't a keyword (that isn't after 'AS' alias)
-                    // if the token is equal to some alias but it's placed after 'AS' - It's a field and no alias.
-                    if ( tokenAsState == AsState.NoAsAlias &&
-                         Scanner.CurrentTokenMatchesAnyOf(AliasKeywords))
+                    // need to ensure that this isn't a keyword
+                    if (Scanner.CurrentTokenMatchesAnyOf(AliasKeywords))
                     {
                         Scanner.GoBack();
                         token = null;

--- a/src/Raven.Server/Documents/Queries/Parser/QueryParser.cs
+++ b/src/Raven.Server/Documents/Queries/Parser/QueryParser.cs
@@ -2392,8 +2392,28 @@ Grouping by 'Tag' or Field is supported only as a second grouping-argument.";
             return false;
         }
 
+        private static readonly string[] AsAliasKeyword = { "AS" };
+        enum AsState { NoAsAlias, IsAsAlias, AfterAsAlias };
+        private AsState tokenAsState = AsState.NoAsAlias;
+
         internal bool Field(out FieldExpression token)
         {
+            if (tokenAsState == AsState.NoAsAlias)
+            {
+                if (Scanner.CurrentTokenMatchesAnyOf(AsAliasKeyword))
+                {
+                    tokenAsState = AsState.IsAsAlias;
+                }
+            }
+            else if(tokenAsState == AsState.IsAsAlias)
+            {
+                tokenAsState = AsState.AfterAsAlias;
+            }
+            else if (tokenAsState == AsState.AfterAsAlias)
+            {
+                tokenAsState = AsState.NoAsAlias;
+            }
+
             var part = 0;
 
             var parts = new List<StringSegment>(1);
@@ -2419,10 +2439,13 @@ Grouping by 'Tag' or Field is supported only as a second grouping-argument.";
                 {
                     parts.Add(Scanner.Token);
                 }
+                //Shahar
                 if (part == 1)
                 {
-                    // need to ensure that this isn't a keyword
-                    if (Scanner.CurrentTokenMatchesAnyOf(AliasKeywords))
+                    // need to ensure that this isn't a keyword (that isn't after 'AS' alias)
+                    // if the token is equal to some alias but it's placed after 'AS' - It's a field and no alias.
+                    if ( tokenAsState == AsState.NoAsAlias &&
+                         Scanner.CurrentTokenMatchesAnyOf(AliasKeywords))
                     {
                         Scanner.GoBack();
                         token = null;

--- a/test/SlowTests/Issues/RavenDB-18545.cs
+++ b/test/SlowTests/Issues/RavenDB-18545.cs
@@ -45,11 +45,11 @@ namespace SlowTests.Issues
             }
         }
 
-        class Job
+        private class Job
         {
             public string Id { get; set; }
             public string Name { get; set;  }
-            public String Group { get; set; }
+            public string Group { get; set; }
         }
     }
 

--- a/test/SlowTests/Issues/RavenDB-18545.cs
+++ b/test/SlowTests/Issues/RavenDB-18545.cs
@@ -1,0 +1,56 @@
+﻿using System;
+using System.Linq;
+using System.Threading;
+using System.Threading.Tasks;
+using FastTests;
+using Raven.Client.Documents;
+using Xunit;
+using Xunit.Abstractions;
+
+namespace SlowTests.Issues
+{
+    public class RavenDB_18545 : RavenTestBase
+    {
+        public RavenDB_18545(ITestOutputHelper output) : base(output)
+        {
+        }
+
+        [Fact]
+        public async Task QuotationForGroupInAlias()
+        {
+            using (var store = GetDocumentStore())
+            {
+                CancellationToken cancellationToken = CancellationToken.None;
+                using (var session = store.OpenAsyncSession())
+                {
+                    var job = new Job { Name = "HR Worker", Group = "HR" };
+                    await session.StoreAsync(job);
+                    string jobId = job.Id;
+                    await session.SaveChangesAsync();
+
+                    var q = session.Query<Job>()
+                        .GroupBy(j => j.Group)
+                        .Select(x => new {Group = x.Key});
+
+                    Assert.EndsWith("as \'Group\'", q.ToString());
+
+                    var l = (await q
+                                        .ToListAsync(cancellationToken))
+                                        .Select(x => x.Group).ToList();
+
+                    Assert.NotEmpty(l);
+                    Assert.Equal(1, l.Count);
+                    Assert.Equal(l[0], job.Group);
+                }
+            }
+        }
+
+        class Job
+        {
+            public string Id { get; set; }
+            public string Name { get; set;  }
+            public String Group { get; set; }
+        }
+    }
+
+}


### PR DESCRIPTION
### Issue link

https://issues.hibernatingrhinos.com/issue/RavenDB-18545

### Additional description

Fix - Can't select a field that its name is equal to some alias in Query.

### Type of change

- Bug fix

### How risky is the change?

- Low

### Backward compatibility

- Not relevant

### Is it platform specific issue?

- No

### Documentation update

- No documentation update is needed 

### Testing 

- Tests have been added that prove the fix is effective or that the feature works

### Is there any existing behavior change of other features due to this change?

- No

### UI work

- No UI work is needed
