### PR TITLE
RavenDB-18517 fix revisions configuration selection logic

### DIFF
--- a/src/Raven.Server/Documents/DocumentsStorage.cs
+++ b/src/Raven.Server/Documents/DocumentsStorage.cs
@@ -1755,9 +1755,11 @@ namespace Raven.Server.Documents
                     }
                 }
 
-                if (((flags & DocumentFlags.HasRevisions) == DocumentFlags.HasRevisions) &&
-                    (revisionsStorage.Configuration == null) &&
-                    ((flags & DocumentFlags.Resolved) != DocumentFlags.Resolved))
+                if (flags.Contain(DocumentFlags.HasRevisions) &&
+                    revisionsStorage.Configuration == null &&
+                    (flags & DocumentFlags.Resolved) != DocumentFlags.Resolved &&
+                    flags.Contain(DocumentFlags.Resolved) == false &&
+                    nonPersistentFlags.Contain(NonPersistentDocumentFlags.FromReplication) == false)
                     revisionsStorage.DeleteRevisionsFor(context, id);
 
                 if (flags.Contain(DocumentFlags.HasRevisions) &&

--- a/test/SlowTests/Issues/RavenDB-16961.cs
+++ b/test/SlowTests/Issues/RavenDB-16961.cs
@@ -102,6 +102,7 @@ namespace SlowTests.Issues
                 }
 
                 await EnsureReplicatingAsync(store1, store2);
+                WaitForUserToContinueTheTest(store2);
 
                 var db = await Databases.GetDocumentDatabaseInstanceFor(store2, store2.Database);
                 var val2 = await WaitForValueAsync(() =>
@@ -112,9 +113,10 @@ namespace SlowTests.Issues
                             var rev = db.DocumentsStorage.RevisionsStorage.GetRevisions(ctx, "users/1", 0, 1);
                             return rev.Count;
                         }
-                    }, 1
+                    }, 4
                 );
-                Assert.Equal(1, val2);
+
+                Assert.Equal(4, val2);
                 await RevisionsHelper.SetupRevisions(store1, Server.ServerStore, new RevisionsConfiguration());
 
                 db = await Databases.GetDocumentDatabaseInstanceFor(store1, store1.Database);

--- a/test/SlowTests/Server/Replication/ReplicationBasicTestsSlow.cs
+++ b/test/SlowTests/Server/Replication/ReplicationBasicTestsSlow.cs
@@ -263,7 +263,7 @@ namespace SlowTests.Server.Replication
                     var stats1 = store1.Maintenance.Send(new GetStatisticsOperation());
                     var stats2 = store2.Maintenance.Send(new GetStatisticsOperation());
                     Assert.Equal(stats1.DatabaseChangeVector, stats2.DatabaseChangeVector);
-                    Assert.Equal(13, stats2.CountOfTombstones);
+                    Assert.Equal(2, stats2.CountOfTombstones);
                 }
             }
         }

--- a/test/SlowTests/Smuggler/SmugglerApiTests.cs
+++ b/test/SlowTests/Smuggler/SmugglerApiTests.cs
@@ -1643,7 +1643,7 @@ namespace SlowTests.Smuggler
         }
 
         [Fact]
-        public async Task Smugller_WhenContainRevisionWithoutConfiguration_ShouldExportImportRevisions()
+        public async Task Smuggler_WhenContainRevisionWithoutConfiguration_ShouldExportImportRevisions()
         {
             using var src = GetDocumentStore();
             using var dest = GetDocumentStore();


### PR DESCRIPTION
### Issue link

https://issues.hibernatingrhinos.com/issue/RavenDB-18517

### Additional description

The issue was the missing revisions upon replication to a destination without a revision configuration.

The root cause was, when no configuration was available we were selecting the Conflicts Revision configuration by default, regardless whether the document was conflicted/resolved or not.

The fix is to pick the Conflicts configuration only for conflicted/resolved documents.

### Type of change

- Bug fix
- 
### How risky is the change?

- Low 

### Backward compatibility

- Not relevant

### Is it platform specific issue?

- No

### Documentation update

Actually the docs reflect the behavior after this fix
 
### Testing 

- Tests have been added that prove the fix is effective or that the feature works
+ the Coverage of current tests 

### Is there any existing behavior change of other features due to this change?

- No

### UI work

- No UI work is needed
