### PR TITLE
RavenDB-17243: Implement native support for nulls

### DIFF
--- a/src/Corax/Constants.cs
+++ b/src/Corax/Constants.cs
@@ -6,6 +6,19 @@ namespace Corax
 {
     public static class Constants
     {
+        public const string NullValue = "NULL_VALUE";
+        public const string EmptyValue = "EMPTY_VALUE";
+        public static readonly Slice NullValueSlice, EmptyValueSlice;
+
+        static Constants()
+        {
+            using (StorageEnvironment.GetStaticContext(out var ctx))
+            {
+                Slice.From(ctx, NullValue, ByteStringType.Immutable, out NullValueSlice);
+                Slice.From(ctx, EmptyValue, ByteStringType.Immutable, out EmptyValueSlice);
+            }
+        }
+
         public static class Boosting
         {
             public static float ScoreEpsilon = 1e-8F;

--- a/src/Corax/IndexEntryBuilder.cs
+++ b/src/Corax/IndexEntryBuilder.cs
@@ -118,12 +118,11 @@ namespace Corax
         }
 
         public void WriteNull(int field)
-        {
-            int dataLocation = _dataIndex;
-            
+        {           
             // Write known field.
-            _knownFieldsLocations[field] = dataLocation | unchecked((int)0x80000000);
-            Unsafe.WriteUnaligned(ref _buffer[dataLocation], IndexEntryFieldType.Null);
+            _knownFieldsLocations[field] = _dataIndex | unchecked((int)0x80000000);
+            Unsafe.WriteUnaligned(ref _buffer[_dataIndex], IndexEntryFieldType.Null);
+            _dataIndex += sizeof(IndexEntryFieldType);
         }
 
         public void Write(int field, ReadOnlySpan<byte> value)
@@ -167,7 +166,7 @@ namespace Corax
 
             binaryValue.CopyTo(_buffer.Slice(dataLocation));
             dataLocation += binaryValue.Length;
-            
+
             _dataIndex = dataLocation;
         }
 
@@ -831,7 +830,7 @@ namespace Corax
 
             if (isTyped)
             {
-                return (IndexEntryFieldType)_buffer[intOffset];
+                return Unsafe.ReadUnaligned<IndexEntryFieldType>(ref _buffer[intOffset]);                
             }
 
             return IndexEntryFieldType.Simple;

--- a/src/Corax/IndexSearcher/IndexSearcher.TermMatch.cs
+++ b/src/Corax/IndexSearcher/IndexSearcher.TermMatch.cs
@@ -20,14 +20,13 @@ public unsafe partial class IndexSearcher
             return TermMatch.CreateEmpty();
         }
 
-        var termSlice = EncodeAndApplyAnalyzer(term, fieldId);
+        var termSlice = term != Constants.NullValue ? EncodeAndApplyAnalyzer(term, fieldId) : Constants.NullValueSlice;
         return TermQuery(terms, termSlice, fieldId);
     }
 
     //This overload will die with current impl of InQuery
     internal TermMatch TermQuery(CompactTree tree, string term, int fieldId = Constants.IndexSearcher.NonAnalyzer)
     {
-
         return TermQuery(tree, EncodeAndApplyAnalyzer(term, fieldId), fieldId);
     }
 

--- a/src/Corax/IndexSearcher/IndexSearcher.UnaryMatches.cs
+++ b/src/Corax/IndexSearcher/IndexSearcher.UnaryMatches.cs
@@ -18,6 +18,11 @@ public partial class IndexSearcher
             var slice = EncodeAndApplyAnalyzer((string)(object)term, fieldId);
             return BuildUnaryMatch(in set, fieldId, slice, @operation, take);
         }
+        else if (typeof(TValueType) == typeof(Slice))
+        {
+            Slice.From(Allocator, ApplyAnalyzer((Slice)(object)term, fieldId), out var slice);
+            return BuildUnaryMatch(in set, fieldId, slice, @operation, take);
+        }
 
         return BuildUnaryMatch(in set, fieldId, term, @operation, take);
     }
@@ -35,6 +40,13 @@ public partial class IndexSearcher
 
             return BuildBetween(in set, fieldId, leftValueSlice, rightValueSlice, UnaryMatchOperation.GreaterThanOrEqual, UnaryMatchOperation.LessThanOrEqual, isNegated, take);
         }
+        else if (typeof(TValueType) == typeof(Slice))
+        {
+            Slice.From(Allocator, ApplyAnalyzer((Slice)(object)leftValue, fieldId), out var leftValueSlice);
+            Slice.From(Allocator, ApplyAnalyzer((Slice)(object)rightValue, fieldId), out var rightValueSlice);
+
+            return BuildBetween(in set, fieldId, leftValueSlice, rightValueSlice, UnaryMatchOperation.GreaterThanOrEqual, UnaryMatchOperation.LessThanOrEqual, isNegated, take);
+        }
 
         return BuildBetween(in set, fieldId, leftValue, rightValue, UnaryMatchOperation.GreaterThanOrEqual, UnaryMatchOperation.LessThanOrEqual, isNegated, take);
     }
@@ -48,6 +60,13 @@ public partial class IndexSearcher
         {
             var leftValueSlice = EncodeAndApplyAnalyzer((string)(object)leftValue, fieldId);
             var rightValueSlice = EncodeAndApplyAnalyzer((string)(object)rightValue, fieldId);
+
+            return BuildBetween(in set, fieldId, leftValueSlice, rightValueSlice, leftSide, rightSide, isNegated, take);
+        }
+        else if (typeof(TValueType) == typeof(Slice))
+        {
+            Slice.From(Allocator, ApplyAnalyzer((Slice)(object)leftValue, fieldId), out var leftValueSlice);
+            Slice.From(Allocator, ApplyAnalyzer((Slice)(object)rightValue, fieldId), out var rightValueSlice);
 
             return BuildBetween(in set, fieldId, leftValueSlice, rightValueSlice, leftSide, rightSide, isNegated, take);
         }

--- a/src/Corax/IndexSearcher/IndexSearcher.cs
+++ b/src/Corax/IndexSearcher/IndexSearcher.cs
@@ -103,6 +103,9 @@ public sealed unsafe partial class IndexSearcher : IDisposable
         if (term is null)
             return default;
 
+        if (term == Constants.NullValue)
+            return Constants.NullValueSlice;
+
         var encoded = Encoding.UTF8.GetBytes(term);
         Slice termSlice;
         if (fieldId == Constants.IndexSearcher.NonAnalyzer)

--- a/src/Corax/Queries/UnaryMatch.Between.cs
+++ b/src/Corax/Queries/UnaryMatch.Between.cs
@@ -134,7 +134,7 @@ namespace Corax.Queries
                     in inner, UnaryMatchOperation.Between, 
                     searcher, fieldId, value1, value2, 
                     &FillFuncBetweenSequence<TLeftSideComparer, TRightSideComparer>, &AndWith, 
-                    inner.Count, inner.Confidence.Min(QueryCountConfidence.Normal), false, take);
+                    inner.Count, inner.Confidence.Min(QueryCountConfidence.Normal), take: take);
             }
             else if (typeof(TValueType) == typeof(long))
             {
@@ -151,7 +151,7 @@ namespace Corax.Queries
                     in inner, UnaryMatchOperation.Between, 
                     searcher, fieldId, value1, value2, 
                     &FillFuncBetweenNumerical<TLeftSideComparer, TRightSideComparer>, &AndWith, 
-                    inner.Count, inner.Confidence.Min(QueryCountConfidence.Normal), false, take);
+                    inner.Count, inner.Confidence.Min(QueryCountConfidence.Normal), take: take);
             }
             else
             {
@@ -167,7 +167,7 @@ namespace Corax.Queries
                     in inner, UnaryMatchOperation.NotBetween, 
                     searcher, fieldId, value1, value2, 
                     &FillFuncBetweenNumerical<TLeftSideComparer, TRightSideComparer>, &AndWith, 
-                    inner.Count, inner.Confidence.Min(QueryCountConfidence.Normal), false, take);
+                    inner.Count, inner.Confidence.Min(QueryCountConfidence.Normal), take: take);
             }
         }
 
@@ -297,7 +297,7 @@ namespace Corax.Queries
                     in inner, UnaryMatchOperation.NotBetween, 
                     searcher, fieldId, value1, value2, 
                     &FillFuncNotBetweenSequence<TLeftSideComparer, TRightSideComparer>, &AndWith, 
-                    inner.Count, inner.Confidence.Min(QueryCountConfidence.Normal), true, take);
+                    inner.Count, inner.Confidence.Min(QueryCountConfidence.Normal), UnaryMatchOperationMode.All, take: take);
             }
             else if (typeof(TValueType) == typeof(long))
             {
@@ -314,7 +314,7 @@ namespace Corax.Queries
                     in inner, UnaryMatchOperation.NotBetween, 
                     searcher, fieldId, value1, value2, 
                     &FillFuncNotBetweenNumerical<TLeftSideComparer, TRightSideComparer>, &AndWith, 
-                    inner.Count, inner.Confidence.Min(QueryCountConfidence.Normal), true, take);
+                    inner.Count, inner.Confidence.Min(QueryCountConfidence.Normal), UnaryMatchOperationMode.All, take: take);
             }
             else
             {
@@ -330,7 +330,7 @@ namespace Corax.Queries
                     in inner, UnaryMatchOperation.NotBetween, 
                     searcher, fieldId, value1, value2, 
                     &FillFuncNotBetweenNumerical<TLeftSideComparer, TRightSideComparer>, &AndWith, 
-                    inner.Count, inner.Confidence.Min(QueryCountConfidence.Normal), true, take);
+                    inner.Count, inner.Confidence.Min(QueryCountConfidence.Normal), UnaryMatchOperationMode.All, take: take);
             }
         }
     }

--- a/src/Corax/Queries/UnaryMatch.Ordinal.cs
+++ b/src/Corax/Queries/UnaryMatch.Ordinal.cs
@@ -7,6 +7,7 @@ using Voron;
 
 namespace Corax.Queries
 {
+
     unsafe partial struct UnaryMatch<TInner, TValueType>
     {
         public interface IUnaryMatchComparer
@@ -32,10 +33,17 @@ namespace Corax.Queries
             return result;
         }
 
+
+
         [SkipLocalsInit]
-        private static int FillFuncSequence<TComparer>(ref UnaryMatch<TInner, TValueType> match, Span<long> matches)
+        private static int FillFuncSequenceAny<TComparer>(ref UnaryMatch<TInner, TValueType> match, Span<long> matches)
             where TComparer : struct, IUnaryMatchComparer
         {
+            // If we query unary, we want to find items where at least one element is valid for our conditions, so we look for the first match.
+            // For example: Terms [1,2,3] Q: 'where Term < 3'. We check '1 < 3' and thats it.
+            // Because the whole process is about comparing values, there is really no reason why we would call this when the condition is a null
+            // value, so if we want to compare against a null (which is pretty common) a more optimized version of FillFuncSequenceAny would be needed.
+
             var searcher = match._searcher;
             var currentType = ((Slice)(object)match._value).AsReadOnlySpan();
 
@@ -57,18 +65,19 @@ namespace Corax.Queries
                 for (int i = 0; i < results; i++)
                 {
                     var reader = searcher.GetReaderFor(freeMemory[i]);
-                    var type = reader.GetFieldType(match._fieldId, out var intOffset);
-                    var isMatch = false;
+                    var type = reader.GetFieldType(match._fieldId, out var _);
 
-                    if (type.HasFlag(IndexEntryFieldType.List) || type.HasFlag(IndexEntryFieldType.TupleList))
+                    var answer = match._distinct == false;
+                    var isMatch = match._distinct;
+
+                    // If we get a null, we just skip it. It will not match.
+                    if (type == IndexEntryFieldType.Null)
+                    {
+                        isMatch = answer;
+                    }                        
+                    else if (type.HasFlag(IndexEntryFieldType.List) || type.HasFlag(IndexEntryFieldType.TupleList))
                     {
                         var iterator = reader.ReadMany(match._fieldId);
-
-                        //If we query unary, we want to find items where at least one element is valid for our conditions, so we look for the first match.
-                        //For example: Terms [1,2,3] Q: 'where Term < 3'. We check '1 < 3' and thats it.
-                        //The only difference is with NotMatch. We have to look through the whole collection and check if there are elements that accept our condition.
-                        var answer = match._distinct == false;
-                        isMatch = match._distinct;
 
                         while (iterator.ReadNext())
                         {
@@ -85,15 +94,18 @@ namespace Corax.Queries
                     }
                     else if (type.HasFlag(IndexEntryFieldType.Tuple) || type.HasFlag(IndexEntryFieldType.Simple))
                     {
-                        var read = reader.Read(match._fieldId, out var resultX);
-                        var analyzedTerm = match._searcher.ApplyAnalyzer(resultX, match._fieldId);
-                        if (read && comparer.Compare(currentType, analyzedTerm))
+                        var read = reader.Read(match._fieldId, out var readType, out var resultX);
+                        if (read && readType != IndexEntryFieldType.Null)
                         {
-                            // We found a match.
-                            isMatch = true;
+                            var analyzedTerm = match._searcher.ApplyAnalyzer(resultX, match._fieldId);
+                            if (read && comparer.Compare(currentType, analyzedTerm) == answer)
+                            {
+                                // We found a match.
+                                isMatch = answer;
+                            }
                         }
                     }
-                    
+
                     if (isMatch)
                     {
                         currentMatches[storeIdx] = freeMemory[i];
@@ -107,7 +119,246 @@ namespace Corax.Queries
         }
 
         [SkipLocalsInit]
-        private static int FillFuncNumerical<TComparer>(ref UnaryMatch<TInner, TValueType> match, Span<long> matches)
+        private static int FillFuncSequenceAll<TComparer>(ref UnaryMatch<TInner, TValueType> match, Span<long> matches)
+            where TComparer : struct, IUnaryMatchComparer
+        {
+            // If we query unary, we want to find items where at all elements has valid conditions, so we look for all the matches.            
+            // The typical use of all is on distinct, we want to know if there are any element that matches the negative. 
+            // For example: Terms [1,2,3] Q: 'where Term != 3'. We check every item to ensure there is no match with 3 there.
+            // Because the whole process is about comparing values, there is really no reason why we would call this when the condition is a null
+            // value, so if we want to compare against a null (which is pretty common) a more optimized version of FillFuncSequenceAny would be needed.
+
+            var searcher = match._searcher;
+            var currentType = ((Slice)(object)match._value).AsReadOnlySpan();
+
+            var comparer = default(TComparer);
+            var currentMatches = matches;
+            int totalResults = 0;
+            int storeIdx = 0;
+            int maxUnusedMatchesSlots = matches.Length >= 64 ? matches.Length / 8 : 1;
+
+            int results;
+            do
+            {
+                var freeMemory = currentMatches.Slice(storeIdx);
+                results = match._inner.Fill(freeMemory);
+
+                if (results == 0)
+                    return totalResults;
+
+                var answer = match._distinct == false;
+                for (int i = 0; i < results; i++)
+                {
+                    var reader = searcher.GetReaderFor(freeMemory[i]);
+                    var type = reader.GetFieldType(match._fieldId, out var _);
+
+                    var isMatch = match._distinct;
+
+                    // If we get a null, we just skip it. It will not match.
+                    if (type != IndexEntryFieldType.Null)
+                    {
+                        if (type.HasFlag(IndexEntryFieldType.List) || type.HasFlag(IndexEntryFieldType.TupleList))
+                        {
+                            var iterator = reader.ReadMany(match._fieldId);
+
+                            while (iterator.ReadNext())
+                            {
+                                // Null here is complicated. When we are in the positive case, we know that the value is not null,
+                                // therefore finding a null in the case of the positive case would ensure that this is not a match.
+                                // However, when we are in the negative case (distict), we know for certain it is different to the
+                                // value and therefore we can continue to the next. 
+                                if (iterator.IsNull && !match._distinct)
+                                {
+                                    isMatch = answer;
+                                    break;
+                                }
+
+                                var analyzedTerm = match._searcher.ApplyAnalyzer(iterator.Sequence, match._fieldId);
+                                if (comparer.Compare(currentType, analyzedTerm) == answer)
+                                {
+                                    isMatch = answer;
+                                    break;
+                                }
+                            }
+                        }
+                        else if (type.HasFlag(IndexEntryFieldType.Tuple) || type.HasFlag(IndexEntryFieldType.Simple))
+                        {
+                            var read = reader.Read(match._fieldId, out var readType, out var resultX);
+
+                            // Null here is complicated. When we are in the positive case, we know that the value is not null,
+                            // therefore finding a null in the case of the positive case would ensure that this is not a match.
+                            // However, when we are in the negative case (distict), we know for certain it is different to the
+                            // value. 
+                            if (readType == IndexEntryFieldType.Null && !match._distinct)
+                            {
+                                isMatch = answer;
+                            }
+                            else
+                            {
+                                var analyzedTerm = match._searcher.ApplyAnalyzer(resultX, match._fieldId);
+                                if (read && comparer.Compare(currentType, analyzedTerm) == answer)
+                                {
+                                    // We found a match.
+                                    isMatch = answer;
+                                }
+                            }
+                        }
+                    }                        
+
+                    if (isMatch)
+                    {
+                        currentMatches[storeIdx] = freeMemory[i];
+                        storeIdx++;
+                        totalResults++;
+                    }
+                }
+            } while (results >= totalResults + maxUnusedMatchesSlots);
+
+            return storeIdx;
+        }
+
+
+        [SkipLocalsInit]
+        private static int FillFuncAllNull(ref UnaryMatch<TInner, TValueType> match, Span<long> matches)
+        {
+            // If we query unary, we want to find if all items are null (most likely wont have much positives on lists), but
+            // it can certainly be more common in tuples.
+            // Since null is an special case, many of the more general comparisons 
+
+            var searcher = match._searcher;
+            var currentMatches = matches;
+            int totalResults = 0;
+            int storeIdx = 0;
+            int maxUnusedMatchesSlots = matches.Length >= 64 ? matches.Length / 8 : 1;
+
+            int results;
+            do
+            {
+                var freeMemory = currentMatches.Slice(storeIdx);
+                results = match._inner.Fill(freeMemory);
+
+                if (results == 0)
+                    return totalResults;
+
+                var answer = match._distinct == false;
+                for (int i = 0; i < results; i++)
+                {
+                    var reader = searcher.GetReaderFor(freeMemory[i]);
+                    var type = reader.GetFieldType(match._fieldId, out var _);
+
+                    var isMatch = match._distinct;
+
+                    if (type != IndexEntryFieldType.Null)
+                    {
+                        if (type.HasFlag(IndexEntryFieldType.List) || type.HasFlag(IndexEntryFieldType.TupleList))
+                        {
+                            if (type.HasFlag(IndexEntryFieldType.HasNulls) && !type.HasFlag(IndexEntryFieldType.EmptyList))
+                            {
+                                var iterator = reader.ReadMany(match._fieldId);
+                                while (iterator.ReadNext())
+                                {
+                                    if (iterator.IsNull)
+                                    {
+                                        isMatch = answer;
+                                        break;
+                                    }
+                                }
+                            }
+                            else
+                            {
+                                isMatch = answer;
+                            }
+                        }
+                        else if (type.HasFlag(IndexEntryFieldType.Tuple) || type.HasFlag(IndexEntryFieldType.Simple))
+                        {
+                            var readType = reader.GetFieldType(match._fieldId, out var _);
+                            if (readType != IndexEntryFieldType.Null)
+                                isMatch = answer;
+                        }
+                    }
+
+                    if (isMatch)
+                    {
+                        currentMatches[storeIdx] = freeMemory[i];
+                        storeIdx++;
+                        totalResults++;
+                    }
+                }
+            } while (results >= totalResults + maxUnusedMatchesSlots);
+
+            return storeIdx;
+        }
+
+        [SkipLocalsInit]
+        private static int FillFuncAnyNull(ref UnaryMatch<TInner, TValueType> match, Span<long> matches)
+        {
+            // If we query unary, we want to find if all items are null (most likely wont have much positives on lists), but
+            // it can certainly be more common in tuples.
+            // Since null is an special case, many of the more general comparisons 
+
+            var searcher = match._searcher;
+            var currentMatches = matches;
+            int totalResults = 0;
+            int storeIdx = 0;
+            int maxUnusedMatchesSlots = matches.Length >= 64 ? matches.Length / 8 : 1;
+
+            int results;
+            do
+            {
+                var freeMemory = currentMatches.Slice(storeIdx);
+                results = match._inner.Fill(freeMemory);
+
+                if (results == 0)
+                    return totalResults;
+
+                var answer = match._distinct == false;
+                for (int i = 0; i < results; i++)
+                {
+                    var reader = searcher.GetReaderFor(freeMemory[i]);
+                    var type = reader.GetFieldType(match._fieldId, out var _);
+
+                    var isMatch = match._distinct;
+
+                    if (type == IndexEntryFieldType.Null)
+                    {
+                        isMatch = answer;
+                    }
+                    else if (type.HasFlag(IndexEntryFieldType.List) || type.HasFlag(IndexEntryFieldType.TupleList))
+                    {
+                        if (type.HasFlag(IndexEntryFieldType.HasNulls) && !type.HasFlag(IndexEntryFieldType.EmptyList))
+                        {
+                            var iterator = reader.ReadMany(match._fieldId);
+                            while (iterator.ReadNext())
+                            {
+                                if (iterator.IsNull)
+                                {
+                                    isMatch = answer;
+                                    break;
+                                }
+                            }
+                        }
+                    }
+                    else if (type.HasFlag(IndexEntryFieldType.Tuple) || type.HasFlag(IndexEntryFieldType.Simple))
+                    {
+                        var readType = reader.GetFieldType(match._fieldId, out var _);
+                        if (readType == IndexEntryFieldType.Null)
+                            isMatch = answer;
+                    }
+
+                    if (isMatch)
+                    {
+                        currentMatches[storeIdx] = freeMemory[i];
+                        storeIdx++;
+                        totalResults++;
+                    }
+                }
+            } while (results >= totalResults + maxUnusedMatchesSlots);
+
+            return storeIdx;
+        }
+
+        [SkipLocalsInit]
+        private static int FillFuncNumericalAny<TComparer>(ref UnaryMatch<TInner, TValueType> match, Span<long> matches)
             where TComparer : struct, IUnaryMatchComparer
         {
             var currentType = match._value;
@@ -127,27 +378,28 @@ namespace Corax.Queries
                 if (results == 0)
                     return totalResults;
 
+                var answer = match._distinct == false;
                 for (int i = 0; i < results; i++)
                 {
                     var reader = searcher.GetReaderFor(freeMemory[i]);
                     var type = reader.GetFieldType(match._fieldId, out _);
-
-                    bool isMatch = false;
+                    
+                    var isMatch = match._distinct;
+                    
                     if (typeof(TValueType) == typeof(long))
                     {
-                        if (type.HasFlag(IndexEntryFieldType.Tuple) || type.HasFlag(IndexEntryFieldType.Simple))
+                        if (type == IndexEntryFieldType.Null)
                         {
-                            var read = reader.Read<long>(match._fieldId, out var resultX);
-                            if (read)
-                                isMatch = comparer.Compare((long)(object)currentType, resultX);
+                            isMatch = answer;
                         }
                         else if (type.HasFlag(IndexEntryFieldType.List) || type.HasFlag(IndexEntryFieldType.TupleList))
                         {
                             var iterator = reader.ReadMany(match._fieldId);
-                            var answer = match._distinct == false;
-                            isMatch = match._distinct;
                             while (iterator.ReadNext())
                             {
+                                if (iterator.IsNull)
+                                    continue;
+
                                 if (comparer.Compare((long)(object)currentType, iterator.Long) == answer)
                                 {
                                     isMatch = answer;
@@ -155,26 +407,49 @@ namespace Corax.Queries
                                 }
                             }
                         }
+                        else if (type.HasFlag(IndexEntryFieldType.Tuple) || type.HasFlag(IndexEntryFieldType.Simple))
+                        {
+                            var read = reader.Read<long>(match._fieldId, out var readType, out var resultX);
+                            if (read && readType != IndexEntryFieldType.Null)
+                            {
+                                if (comparer.Compare((long)(object)currentType, resultX) == answer)
+                                {
+                                    // We found a match.
+                                    isMatch = answer;
+                                }
+                            }
+                        }
                     }
                     else if (typeof(TValueType) == typeof(double))
                     {
-                        if (type.HasFlag(IndexEntryFieldType.Tuple) || type.HasFlag(IndexEntryFieldType.Simple))
+                        if (type == IndexEntryFieldType.Null)
                         {
-                            var read = reader.Read<double>(match._fieldId, out var resultX);
-                            if (read)
-                                isMatch = comparer.Compare((double)(object)currentType, resultX);
+                            isMatch = answer;
                         }
                         else if (type.HasFlag(IndexEntryFieldType.List) || type.HasFlag(IndexEntryFieldType.TupleList))
                         {
                             var iterator = reader.ReadMany(match._fieldId);
-                            var answer = match._distinct == false;
-                            isMatch = match._distinct;
                             while (iterator.ReadNext())
                             {
-                                if (comparer.Compare((double)(object)currentType, iterator.Double) == answer)
+                                if (iterator.IsNull)
+                                    continue;
+
+                                if (comparer.Compare((double)(object)currentType, iterator.Long) == answer)
                                 {
                                     isMatch = answer;
                                     break;
+                                }
+                            }
+                        }
+                        else if (type.HasFlag(IndexEntryFieldType.Tuple) || type.HasFlag(IndexEntryFieldType.Simple))
+                        {
+                            var read = reader.Read<double>(match._fieldId, out var readType, out var resultX);
+                            if (read && readType != IndexEntryFieldType.Null)
+                            {
+                                if (comparer.Compare((double)(object)currentType, resultX) == answer)
+                                {
+                                    // We found a match.
+                                    isMatch = answer;
                                 }
                             }
                         }
@@ -194,49 +469,213 @@ namespace Corax.Queries
             return totalResults;
         }
 
-        public static UnaryMatch<TInner, TValueType> YieldGreaterThan(in TInner inner, IndexSearcher searcher, int fieldId, TValueType value, bool distinct = false,
+        [SkipLocalsInit]
+        private static int FillFuncNumericalAll<TComparer>(ref UnaryMatch<TInner, TValueType> match, Span<long> matches)
+            where TComparer : struct, IUnaryMatchComparer
+        {
+            var currentType = match._value;
+
+            var comparer = default(TComparer);
+            var searcher = match._searcher;
+            var currentMatches = matches;
+            int totalResults = 0;
+            int maxUnusedMatchesSlots = matches.Length >= 64 ? matches.Length / 8 : 1;
+            int storeIdx = 0;
+
+            int results;
+            do
+            {
+                var freeMemory = currentMatches.Slice(storeIdx);
+                results = match._inner.Fill(freeMemory);
+                if (results == 0)
+                    return totalResults;
+
+                var answer = match._distinct == false;
+                for (int i = 0; i < results; i++)
+                {
+                    var reader = searcher.GetReaderFor(freeMemory[i]);
+                    var type = reader.GetFieldType(match._fieldId, out _);
+
+                    var isMatch = match._distinct;
+
+                    if (typeof(TValueType) == typeof(long))
+                    {
+                        // If we get a null, we just skip it. It will not match.
+                        if (type != IndexEntryFieldType.Null)
+                        {
+                            if (type.HasFlag(IndexEntryFieldType.List) || type.HasFlag(IndexEntryFieldType.TupleList))
+                            {
+                                var iterator = reader.ReadMany(match._fieldId);
+
+                                while (iterator.ReadNext())
+                                {
+                                    // Null here is complicated. When we are in the positive case, we know that the value is not null,
+                                    // therefore finding a null in the case of the positive case would ensure that this is not a match.
+                                    // However, when we are in the negative case (distict), we know for certain it is different to the
+                                    // value and therefore we can continue to the next. 
+                                    if (iterator.IsNull && !match._distinct)
+                                    {
+                                        isMatch = answer;
+                                        break;
+                                    }
+
+                                    if (comparer.Compare((long)(object)currentType, iterator.Long) == answer)
+                                    {
+                                        isMatch = answer;
+                                        break;
+                                    }
+                                }
+                            }
+                        }
+                        else if (type.HasFlag(IndexEntryFieldType.Tuple) || type.HasFlag(IndexEntryFieldType.Simple))
+                        {
+                            var read = reader.Read<long>(match._fieldId, out var readType, out var resultX);
+
+                            // Null here is complicated. When we are in the positive case, we know that the value is not null,
+                            // therefore finding a null in the case of the positive case would ensure that this is not a match.
+                            // However, when we are in the negative case (distict), we know for certain it is different to the
+                            // value. 
+                            if (readType == IndexEntryFieldType.Null && !match._distinct)
+                            {
+                                isMatch = answer;
+                            }
+                            else
+                            {
+                                if (read && comparer.Compare((long)(object)currentType, resultX) == answer)
+                                {
+                                    // We found a match.
+                                    isMatch = answer;
+                                }
+                            }
+                        }
+                    }
+                    else if (typeof(TValueType) == typeof(double))
+                    {
+                        // If we get a null, we just skip it. It will not match.
+                        if (type != IndexEntryFieldType.Null)
+                        {
+                            if (type.HasFlag(IndexEntryFieldType.List) || type.HasFlag(IndexEntryFieldType.TupleList))
+                            {
+                                var iterator = reader.ReadMany(match._fieldId);
+
+                                while (iterator.ReadNext())
+                                {
+                                    // Null here is complicated. When we are in the positive case, we know that the value is not null,
+                                    // therefore finding a null in the case of the positive case would ensure that this is not a match.
+                                    // However, when we are in the negative case (distict), we know for certain it is different to the
+                                    // value and therefore we can continue to the next. 
+                                    if (iterator.IsNull && !match._distinct)
+                                    {
+                                        isMatch = answer;
+                                        break;
+                                    }
+
+                                    if (comparer.Compare((double)(object)currentType, iterator.Long) == answer)
+                                    {
+                                        isMatch = answer;
+                                        break;
+                                    }
+                                }
+                            }
+                        }
+                        else if (type.HasFlag(IndexEntryFieldType.Tuple) || type.HasFlag(IndexEntryFieldType.Simple))
+                        {
+                            var read = reader.Read<double>(match._fieldId, out var readType, out var resultX);
+
+                            // Null here is complicated. When we are in the positive case, we know that the value is not null,
+                            // therefore finding a null in the case of the positive case would ensure that this is not a match.
+                            // However, when we are in the negative case (distict), we know for certain it is different to the
+                            // value. 
+                            if (readType == IndexEntryFieldType.Null && !match._distinct)
+                            {
+                                isMatch = answer;
+                            }
+                            else
+                            {
+                                if (read && comparer.Compare((double)(object)currentType, resultX) == answer)
+                                {
+                                    // We found a match.
+                                    isMatch = answer;
+                                }
+                            }
+                        }
+                    }
+
+                    if (isMatch)
+                    {
+                        // We found a match.
+                        currentMatches[storeIdx] = freeMemory[i];
+                        storeIdx++;
+                        totalResults++;
+                    }
+                }
+            } while (results >= totalResults + maxUnusedMatchesSlots);
+
+            matches = currentMatches.Slice(0, storeIdx);
+            return totalResults;
+        }
+
+        public static UnaryMatch<TInner, TValueType> YieldIsNull(in TInner inner, IndexSearcher searcher, int fieldId, UnaryMatchOperationMode mode = UnaryMatchOperationMode.Any, int take = -1)
+        {
+            return new UnaryMatch<TInner, TValueType>(
+                in inner, UnaryMatchOperation.Equals,
+                searcher, fieldId, default(TValueType),
+                mode == UnaryMatchOperationMode.Any ? &FillFuncAnyNull : &FillFuncAllNull, &AndWith,
+                inner.Count, inner.Confidence.Min(QueryCountConfidence.Normal), mode, false, take: take);
+        }
+
+        public static UnaryMatch<TInner, TValueType> YieldIsNotNull(in TInner inner, IndexSearcher searcher, int fieldId, UnaryMatchOperationMode mode = UnaryMatchOperationMode.Any, int take = -1)
+        {
+            return new UnaryMatch<TInner, TValueType>(
+                in inner, UnaryMatchOperation.NotEquals,
+                searcher, fieldId, default(TValueType),
+                mode == UnaryMatchOperationMode.Any ? &FillFuncAnyNull : &FillFuncAllNull, &AndWith,
+                inner.Count, inner.Confidence.Min(QueryCountConfidence.Normal), mode, true, take: take);
+        }
+
+        public static UnaryMatch<TInner, TValueType> YieldGreaterThan(in TInner inner, IndexSearcher searcher, int fieldId, TValueType value, UnaryMatchOperationMode mode = UnaryMatchOperationMode.Any,
             int take = -1)
         {
             if (typeof(TValueType) == typeof(Slice))
-            {
+            {                
                 return new UnaryMatch<TInner, TValueType>(
                     in inner, UnaryMatchOperation.GreaterThan,
                     searcher, fieldId, value,
-                    &FillFuncSequence<GreaterThanMatchComparer>, &AndWith,
-                    inner.Count, inner.Confidence.Min(QueryCountConfidence.Normal), distinct, take);
+                    mode == UnaryMatchOperationMode.Any ? &FillFuncSequenceAny<GreaterThanMatchComparer> : &FillFuncSequenceAll<GreaterThanMatchComparer>, &AndWith,
+                    inner.Count, inner.Confidence.Min(QueryCountConfidence.Normal), mode, take: take);
             }
             else
             {
                 return new UnaryMatch<TInner, TValueType>(
                     in inner, UnaryMatchOperation.GreaterThan,
                     searcher, fieldId, value,
-                    &FillFuncNumerical<GreaterThanMatchComparer>, &AndWith,
-                    inner.Count, inner.Confidence.Min(QueryCountConfidence.Normal), distinct, take);
+                    mode == UnaryMatchOperationMode.Any ? &FillFuncNumericalAny<GreaterThanMatchComparer> : &FillFuncNumericalAny<GreaterThanMatchComparer>, &AndWith,
+                    inner.Count, inner.Confidence.Min(QueryCountConfidence.Normal), mode, take: take);
             }
         }
 
         public static UnaryMatch<TInner, TValueType> YieldGreaterThanOrEqualMatch(in TInner inner, IndexSearcher searcher, int fieldId, TValueType value,
-            bool distinct = false, int take = -1)
+            UnaryMatchOperationMode mode = UnaryMatchOperationMode.Any, int take = -1)
         {
             if (typeof(TValueType) == typeof(Slice))
             {
                 return new UnaryMatch<TInner, TValueType>(
                     in inner, UnaryMatchOperation.GreaterThanOrEqual,
                     searcher, fieldId, value,
-                    &FillFuncSequence<GreaterThanOrEqualMatchComparer>, &AndWith,
-                    inner.Count, inner.Confidence.Min(QueryCountConfidence.Normal), distinct, take);
+                    mode == UnaryMatchOperationMode.Any ? &FillFuncSequenceAny<GreaterThanOrEqualMatchComparer> : &FillFuncSequenceAll<GreaterThanOrEqualMatchComparer>, &AndWith,
+                    inner.Count, inner.Confidence.Min(QueryCountConfidence.Normal), mode, take: take);
             }
             else
             {
                 return new UnaryMatch<TInner, TValueType>(
                     in inner, UnaryMatchOperation.GreaterThanOrEqual,
                     searcher, fieldId, value,
-                    &FillFuncNumerical<GreaterThanOrEqualMatchComparer>, &AndWith,
-                    inner.Count, inner.Confidence.Min(QueryCountConfidence.Normal), distinct, take);
+                    mode == UnaryMatchOperationMode.Any ? &FillFuncNumericalAny<GreaterThanOrEqualMatchComparer> : &FillFuncNumericalAny<GreaterThanOrEqualMatchComparer>, &AndWith,
+                    inner.Count, inner.Confidence.Min(QueryCountConfidence.Normal), mode, take: take);
             }
         }
 
-        public static UnaryMatch<TInner, TValueType> YieldLessThan(in TInner inner, IndexSearcher searcher, int fieldId, TValueType value, bool distinct = false,
+        public static UnaryMatch<TInner, TValueType> YieldLessThan(in TInner inner, IndexSearcher searcher, int fieldId, TValueType value, UnaryMatchOperationMode mode = UnaryMatchOperationMode.Any,
             int take = -1)
         {
             if (typeof(TValueType) == typeof(Slice))
@@ -244,79 +683,79 @@ namespace Corax.Queries
                 return new UnaryMatch<TInner, TValueType>(
                     in inner, UnaryMatchOperation.LessThan,
                     searcher, fieldId, value,
-                    &FillFuncSequence<LessThanMatchComparer>, &AndWith,
-                    inner.Count, inner.Confidence.Min(QueryCountConfidence.Normal), distinct, take);
+                    mode == UnaryMatchOperationMode.Any ? &FillFuncSequenceAny<LessThanMatchComparer> : &FillFuncSequenceAll<LessThanMatchComparer>, &AndWith,
+                    inner.Count, inner.Confidence.Min(QueryCountConfidence.Normal), mode, take: take);
             }
             else
             {
                 return new UnaryMatch<TInner, TValueType>(
                     in inner, UnaryMatchOperation.LessThan,
                     searcher, fieldId, value,
-                    &FillFuncNumerical<LessThanMatchComparer>, &AndWith,
-                    inner.Count, inner.Confidence.Min(QueryCountConfidence.Normal), distinct, take);
+                    mode == UnaryMatchOperationMode.Any ? &FillFuncNumericalAny<LessThanMatchComparer> : &FillFuncNumericalAll<LessThanMatchComparer>, &AndWith,
+                    inner.Count, inner.Confidence.Min(QueryCountConfidence.Normal), mode, take: take);
             }
         }
 
         public static UnaryMatch<TInner, TValueType> YieldLessThanOrEqualMatch(in TInner inner, IndexSearcher searcher, int fieldId, TValueType value,
-            bool distinct = false, int take = -1)
+            UnaryMatchOperationMode mode = UnaryMatchOperationMode.Any, int take = -1)
         {
             if (typeof(TValueType) == typeof(Slice))
             {
                 return new UnaryMatch<TInner, TValueType>(
                     in inner, UnaryMatchOperation.LessThanOrEqual,
                     searcher, fieldId, value,
-                    &FillFuncSequence<LessThanOrEqualMatchComparer>, &AndWith,
-                    inner.Count, inner.Confidence.Min(QueryCountConfidence.Normal), distinct, take);
+                    mode == UnaryMatchOperationMode.Any ? &FillFuncSequenceAny<LessThanOrEqualMatchComparer> : &FillFuncSequenceAll<LessThanOrEqualMatchComparer>, &AndWith,
+                    inner.Count, inner.Confidence.Min(QueryCountConfidence.Normal), mode, take: take);
             }
             else
             {
                 return new UnaryMatch<TInner, TValueType>(
                     in inner, UnaryMatchOperation.LessThanOrEqual,
                     searcher, fieldId, value,
-                    &FillFuncNumerical<LessThanOrEqualMatchComparer>, &AndWith,
-                    inner.Count, inner.Confidence.Min(QueryCountConfidence.Normal), distinct, take);
+                    mode == UnaryMatchOperationMode.Any ? &FillFuncNumericalAny<LessThanOrEqualMatchComparer> : &FillFuncNumericalAny<LessThanOrEqualMatchComparer>, &AndWith,
+                    inner.Count, inner.Confidence.Min(QueryCountConfidence.Normal), mode, take: take);
             }
         }
 
-        public static UnaryMatch<TInner, TValueType> YieldNotEqualsMatch(in TInner inner, IndexSearcher searcher, int fieldId, TValueType value, bool distinct = true,
-            int take = -1)
+        public static UnaryMatch<TInner, TValueType> YieldNotEqualsMatch(in TInner inner, IndexSearcher searcher, int fieldId, TValueType value,
+            UnaryMatchOperationMode mode = UnaryMatchOperationMode.Any, int take = -1)
         {
             if (typeof(TValueType) == typeof(Slice))
             {
                 return new UnaryMatch<TInner, TValueType>(
                     in inner, UnaryMatchOperation.NotEquals,
                     searcher, fieldId, value,
-                    &FillFuncSequence<NotEqualsMatchComparer>, &AndWith,
-                    inner.Count, inner.Confidence.Min(QueryCountConfidence.Normal), distinct, take);
+                    mode == UnaryMatchOperationMode.Any ? &FillFuncSequenceAny<NotEqualsMatchComparer> : &FillFuncSequenceAll<NotEqualsMatchComparer>, &AndWith,
+                    inner.Count, inner.Confidence.Min(QueryCountConfidence.Normal), mode, true, take: take);
             }
             else
             {
                 return new UnaryMatch<TInner, TValueType>(
                     in inner, UnaryMatchOperation.NotEquals,
                     searcher, fieldId, value,
-                    &FillFuncNumerical<NotEqualsMatchComparer>, &AndWith,
-                    inner.Count, inner.Confidence.Min(QueryCountConfidence.Normal), distinct, take);
+                    mode == UnaryMatchOperationMode.Any ? &FillFuncNumericalAny<NotEqualsMatchComparer> : &FillFuncNumericalAny<NotEqualsMatchComparer>, &AndWith,
+                    inner.Count, inner.Confidence.Min(QueryCountConfidence.Normal), mode, true, take: take);
             }
         }
 
-        public static UnaryMatch<TInner, TValueType> YieldEqualsMatch(in TInner inner, IndexSearcher searcher, int fieldId, TValueType value, bool distinct = false,
-            int take = -1)
+        public static UnaryMatch<TInner, TValueType> YieldEqualsMatch(in TInner inner, IndexSearcher searcher, int fieldId, TValueType value,
+            UnaryMatchOperationMode mode = UnaryMatchOperationMode.Any, int take = -1)
         {
             if (typeof(TValueType) == typeof(Slice))
             {
                 return new UnaryMatch<TInner, TValueType>(
                     in inner, UnaryMatchOperation.Equals,
                     searcher, fieldId, value,
-                    &FillFuncSequence<EqualsMatchComparer>, &AndWith,
-                    inner.Count, inner.Confidence.Min(QueryCountConfidence.Normal), distinct, take);
+                    mode == UnaryMatchOperationMode.Any ? &FillFuncSequenceAny<EqualsMatchComparer> : &FillFuncSequenceAll<EqualsMatchComparer>, &AndWith,
+                    inner.Count, inner.Confidence.Min(QueryCountConfidence.Normal), mode, take: take);
             }
             else
             {
                 return new UnaryMatch<TInner, TValueType>(
                     in inner, UnaryMatchOperation.Equals,
                     searcher, fieldId, value,
-                    &FillFuncNumerical<EqualsMatchComparer>, &AndWith,
-                    inner.Count, inner.Confidence.Min(QueryCountConfidence.Normal), distinct, take);
+                    mode == UnaryMatchOperationMode.Any ? &FillFuncNumericalAny<EqualsMatchComparer> : &FillFuncNumericalAny<EqualsMatchComparer>, &AndWith,
+                    inner.Count, inner.Confidence.Min(QueryCountConfidence.Normal), mode, take: take);
             }
         }
 

--- a/src/Corax/Queries/UnaryMatch.Ordinal.cs
+++ b/src/Corax/Queries/UnaryMatch.Ordinal.cs
@@ -60,7 +60,7 @@ namespace Corax.Queries
                     var type = reader.GetFieldType(match._fieldId, out var intOffset);
                     var isMatch = false;
 
-                    if (type is IndexEntryFieldType.Tuple or IndexEntryFieldType.None)
+                    if (type.HasFlag(IndexEntryFieldType.Tuple) || type.HasFlag(IndexEntryFieldType.None))
                     {
                         var read = reader.Read(match._fieldId, out var resultX);
                         var analyzedTerm = match._searcher.ApplyAnalyzer(resultX, match._fieldId);
@@ -70,7 +70,7 @@ namespace Corax.Queries
                             isMatch = true;
                         }
                     }
-                    else if (type is IndexEntryFieldType.List or IndexEntryFieldType.TupleList)
+                    else if (type.HasFlag(IndexEntryFieldType.List) || type.HasFlag(IndexEntryFieldType.TupleList))
                     {
                         var iterator = reader.ReadMany(match._fieldId);
                         
@@ -132,13 +132,13 @@ namespace Corax.Queries
                     bool isMatch = false;
                     if (typeof(TValueType) == typeof(long))
                     {
-                        if (type is IndexEntryFieldType.Tuple or IndexEntryFieldType.None)
+                        if (type.HasFlag(IndexEntryFieldType.Tuple) || type.HasFlag(IndexEntryFieldType.None))
                         {
                             var read = reader.Read<long>(match._fieldId, out var resultX);
                             if (read)
                                 isMatch = comparer.Compare((long)(object)currentType, resultX);
                         }
-                        else if (type is IndexEntryFieldType.List or IndexEntryFieldType.TupleList)
+                        else if (type.HasFlag(IndexEntryFieldType.List) || type.HasFlag(IndexEntryFieldType.TupleList))
                         {
                             var iterator = reader.ReadMany(match._fieldId);
                             var answer = match._distinct == false;
@@ -155,13 +155,13 @@ namespace Corax.Queries
                     }
                     else if (typeof(TValueType) == typeof(double))
                     {
-                        if (type is IndexEntryFieldType.Tuple or IndexEntryFieldType.None)
+                        if (type.HasFlag(IndexEntryFieldType.Tuple) || type.HasFlag(IndexEntryFieldType.None))
                         {
                             var read = reader.Read<double>(match._fieldId, out var resultX);
                             if (read)
                                 isMatch = comparer.Compare((double)(object)currentType, resultX);
                         }
-                        else if (type is IndexEntryFieldType.List or IndexEntryFieldType.TupleList)
+                        else if (type.HasFlag(IndexEntryFieldType.List) || type.HasFlag(IndexEntryFieldType.TupleList))
                         {
                             var iterator = reader.ReadMany(match._fieldId);
                             var answer = match._distinct == false;

--- a/src/Corax/Queries/UnaryMatch.Ordinal.cs
+++ b/src/Corax/Queries/UnaryMatch.Ordinal.cs
@@ -60,7 +60,7 @@ namespace Corax.Queries
                     var type = reader.GetFieldType(match._fieldId, out var intOffset);
                     var isMatch = false;
 
-                    if (type.HasFlag(IndexEntryFieldType.Tuple) || type.HasFlag(IndexEntryFieldType.None))
+                    if (type.HasFlag(IndexEntryFieldType.Tuple) || type.HasFlag(IndexEntryFieldType.Simple))
                     {
                         var read = reader.Read(match._fieldId, out var resultX);
                         var analyzedTerm = match._searcher.ApplyAnalyzer(resultX, match._fieldId);
@@ -132,7 +132,7 @@ namespace Corax.Queries
                     bool isMatch = false;
                     if (typeof(TValueType) == typeof(long))
                     {
-                        if (type.HasFlag(IndexEntryFieldType.Tuple) || type.HasFlag(IndexEntryFieldType.None))
+                        if (type.HasFlag(IndexEntryFieldType.Tuple) || type.HasFlag(IndexEntryFieldType.Simple))
                         {
                             var read = reader.Read<long>(match._fieldId, out var resultX);
                             if (read)
@@ -155,7 +155,7 @@ namespace Corax.Queries
                     }
                     else if (typeof(TValueType) == typeof(double))
                     {
-                        if (type.HasFlag(IndexEntryFieldType.Tuple) || type.HasFlag(IndexEntryFieldType.None))
+                        if (type.HasFlag(IndexEntryFieldType.Tuple) || type.HasFlag(IndexEntryFieldType.Simple))
                         {
                             var read = reader.Read<double>(match._fieldId, out var resultX);
                             if (read)

--- a/src/Corax/Queries/UnaryMatch.Ordinal.cs
+++ b/src/Corax/Queries/UnaryMatch.Ordinal.cs
@@ -2,7 +2,7 @@ using System;
 using System.Diagnostics;
 using System.Runtime.CompilerServices;
 using System.Runtime.InteropServices;
-using System.Threading;
+using Sparrow;
 using Voron;
 
 namespace Corax.Queries
@@ -66,31 +66,45 @@ namespace Corax.Queries
                 {
                     var reader = searcher.GetReaderFor(freeMemory[i]);
                     var type = reader.GetFieldType(match._fieldId, out var _);
-
-                    var answer = match._distinct == false;
-                    var isMatch = match._distinct;
-
+                    if (type == IndexEntryFieldType.Invalid)
+                        continue;
+                    
                     // If we get a null, we just skip it. It will not match.
                     if (type == IndexEntryFieldType.Null)
                     {
-                        isMatch = answer;
+                        if (match._operation != UnaryMatchOperation.NotEquals)
+                        {
+                            // Found a null, item is not elegible.
+                            continue;
+                        }
                     }                        
                     else if (type.HasFlag(IndexEntryFieldType.List) || type.HasFlag(IndexEntryFieldType.TupleList))
                     {
                         var iterator = reader.ReadMany(match._fieldId);
 
+                        var isMatch = false;
                         while (iterator.ReadNext())
                         {
                             if (iterator.IsNull)
-                                continue;
+                            {
+                                if (match._operation != UnaryMatchOperation.NotEquals)
+                                {
+                                    // Found a null, item is not elegible.
+                                    continue;
+                                }
+                            }
 
                             var analyzedTerm = match._searcher.ApplyAnalyzer(iterator.Sequence, match._fieldId);
-                            if (comparer.Compare(currentType, analyzedTerm) == answer)
+                            
+                            // If there is any match, then it is a match
+                            if (comparer.Compare(currentType, analyzedTerm))
                             {
-                                isMatch = answer;
+                                isMatch = true;
                                 break;
                             }
                         }
+                        if (!isMatch)
+                            continue; // No match, item is not elegible.
                     }
                     else if (type.HasFlag(IndexEntryFieldType.Tuple) || type.HasFlag(IndexEntryFieldType.Simple))
                     {
@@ -98,20 +112,22 @@ namespace Corax.Queries
                         if (read && readType != IndexEntryFieldType.Null)
                         {
                             var analyzedTerm = match._searcher.ApplyAnalyzer(resultX, match._fieldId);
-                            if (read && comparer.Compare(currentType, analyzedTerm) == answer)
+                            if (!read || !comparer.Compare(currentType, analyzedTerm))
+                                continue; // Cant read or no match, item is not elegible.
+                        }
+                        else
+                        {
+                            if (match._operation != UnaryMatchOperation.NotEquals)
                             {
-                                // We found a match.
-                                isMatch = answer;
+                                // Found a null, item is not elegible.
+                                continue;
                             }
                         }
                     }
 
-                    if (isMatch)
-                    {
-                        currentMatches[storeIdx] = freeMemory[i];
-                        storeIdx++;
-                        totalResults++;
-                    }
+                    currentMatches[storeIdx] = freeMemory[i];
+                    storeIdx++;
+                    totalResults++;
                 }
             } while (results >= totalResults + maxUnusedMatchesSlots);
 
@@ -146,76 +162,216 @@ namespace Corax.Queries
                 if (results == 0)
                     return totalResults;
 
-                var answer = match._distinct == false;
                 for (int i = 0; i < results; i++)
                 {
                     var reader = searcher.GetReaderFor(freeMemory[i]);
                     var type = reader.GetFieldType(match._fieldId, out var _);
-
-                    var isMatch = match._distinct;
-
+                    if (type == IndexEntryFieldType.Invalid)
+                        continue;
+                    
                     // If we get a null, we just skip it. It will not match.
-                    if (type != IndexEntryFieldType.Null)
+
+                    if (type == IndexEntryFieldType.Null)
                     {
-                        if (type.HasFlag(IndexEntryFieldType.List) || type.HasFlag(IndexEntryFieldType.TupleList))
+                        if (match._operation != UnaryMatchOperation.NotEquals)
                         {
-                            var iterator = reader.ReadMany(match._fieldId);
-
-                            while (iterator.ReadNext())
-                            {
-                                // Null here is complicated. When we are in the positive case, we know that the value is not null,
-                                // therefore finding a null in the case of the positive case would ensure that this is not a match.
-                                // However, when we are in the negative case (distict), we know for certain it is different to the
-                                // value and therefore we can continue to the next. 
-                                if (iterator.IsNull && !match._distinct)
-                                {
-                                    isMatch = answer;
-                                    break;
-                                }
-
-                                var analyzedTerm = match._searcher.ApplyAnalyzer(iterator.Sequence, match._fieldId);
-                                if (comparer.Compare(currentType, analyzedTerm) == answer)
-                                {
-                                    isMatch = answer;
-                                    break;
-                                }
-                            }
-                        }
-                        else if (type.HasFlag(IndexEntryFieldType.Tuple) || type.HasFlag(IndexEntryFieldType.Simple))
-                        {
-                            var read = reader.Read(match._fieldId, out var readType, out var resultX);
-
-                            // Null here is complicated. When we are in the positive case, we know that the value is not null,
-                            // therefore finding a null in the case of the positive case would ensure that this is not a match.
-                            // However, when we are in the negative case (distict), we know for certain it is different to the
-                            // value. 
-                            if (readType == IndexEntryFieldType.Null && !match._distinct)
-                            {
-                                isMatch = answer;
-                            }
-                            else
-                            {
-                                var analyzedTerm = match._searcher.ApplyAnalyzer(resultX, match._fieldId);
-                                if (read && comparer.Compare(currentType, analyzedTerm) == answer)
-                                {
-                                    // We found a match.
-                                    isMatch = answer;
-                                }
-                            }
+                            // Found a null, item is not elegible.
+                            continue;
                         }
                     }                        
-
-                    if (isMatch)
+                    else if (type.HasFlag(IndexEntryFieldType.List) || type.HasFlag(IndexEntryFieldType.TupleList))
                     {
-                        currentMatches[storeIdx] = freeMemory[i];
-                        storeIdx++;
-                        totalResults++;
+                        var iterator = reader.ReadMany(match._fieldId);
+
+                        bool isNotMatch = false;
+                        while (iterator.ReadNext())
+                        {
+                            if (iterator.IsNull && match._operation != UnaryMatchOperation.NotEquals)
+                            {
+                                isNotMatch = true;
+                                break;
+                            }
+
+                            var analyzedTerm = match._searcher.ApplyAnalyzer(iterator.Sequence, match._fieldId);
+                            if (!comparer.Compare(currentType, analyzedTerm))
+                            {
+                                isNotMatch = true;
+                                break;
+                            }
+                        }
+                        if (isNotMatch)
+                            continue; // Has nulls or not a match, item is not elegible.
                     }
+                    else if (type.HasFlag(IndexEntryFieldType.Tuple) || type.HasFlag(IndexEntryFieldType.Simple))
+                    {
+                        var read = reader.Read(match._fieldId, out var readType, out var resultX);
+                        if (readType == IndexEntryFieldType.Null)
+                        {
+                            if (match._operation != UnaryMatchOperation.NotEquals)
+                                continue; // item is not elegible.
+                        }
+                        else
+                        {
+                            var analyzedTerm = match._searcher.ApplyAnalyzer(resultX, match._fieldId);
+                            if (!read || !comparer.Compare(currentType, analyzedTerm))
+                                continue; // Cant read or no match, item is not elegible.
+                        }
+                    }
+                    else continue;
+
+                    currentMatches[storeIdx] = freeMemory[i];
+                    storeIdx++;
+                    totalResults++;
                 }
             } while (results >= totalResults + maxUnusedMatchesSlots);
 
             return storeIdx;
         }
+
+
+        [SkipLocalsInit]
+        private static int FillFuncAllNonNull(ref UnaryMatch<TInner, TValueType> match, Span<long> matches)
+        {
+            // If we query unary, we want to find if all items are null (most likely wont have much positives on lists), but
+            // it can certainly be more common in tuples.
+            // Since null is an special case, many of the more general comparisons 
+
+            var searcher = match._searcher;
+            var currentMatches = matches;
+            int totalResults = 0;
+            int storeIdx = 0;
+            int maxUnusedMatchesSlots = matches.Length >= 64 ? matches.Length / 8 : 1;
+
+            int results;
+            do
+            {
+                var freeMemory = currentMatches.Slice(storeIdx);
+                results = match._inner.Fill(freeMemory);
+
+                if (results == 0)
+                    return totalResults;
+
+                for (int i = 0; i < results; i++)
+                {
+                    var reader = searcher.GetReaderFor(freeMemory[i]);
+                    var type = reader.GetFieldType(match._fieldId, out var _);
+                    if (type == IndexEntryFieldType.Invalid)
+                        continue;
+                    
+                    if (type == IndexEntryFieldType.Null)
+                        continue; // It is null, item is not elegible.
+
+                    if (type.HasFlag(IndexEntryFieldType.List) || type.HasFlag(IndexEntryFieldType.TupleList))
+                    {
+                        if (type.HasFlag(IndexEntryFieldType.HasNulls) && !type.HasFlag(IndexEntryFieldType.EmptyList))
+                        {
+                            var iterator = reader.ReadMany(match._fieldId);
+
+                            var isNotMatch = false;
+                            while (iterator.ReadNext())
+                            {
+                                // If there is any null, then it is NOT a match
+                                if (@iterator.IsNull)
+                                {
+                                    isNotMatch = true;
+                                    break;
+                                }
+                            }
+                            if (isNotMatch)
+                                continue;
+                        }
+                    }
+                    else if (type.HasFlag(IndexEntryFieldType.Tuple) || type.HasFlag(IndexEntryFieldType.Simple))
+                    {
+                        var readType = reader.GetFieldType(match._fieldId, out var _);
+                        if (readType == IndexEntryFieldType.Null)
+                            continue;
+                    }
+                    else
+                    {
+                        // It is null
+                        continue;
+                    }
+
+                    currentMatches[storeIdx] = freeMemory[i];
+                    storeIdx++;
+                    totalResults++;
+                }
+            } while (results >= totalResults + maxUnusedMatchesSlots);
+
+            return storeIdx;
+        }
+
+        [SkipLocalsInit]
+        private static int FillFuncAnyNonNull(ref UnaryMatch<TInner, TValueType> match, Span<long> matches)
+        {
+            // If we query unary, we want to find if all items are null (most likely wont have much positives on lists), but
+            // it can certainly be more common in tuples.
+            // Since null is an special case, many of the more general comparisons 
+
+            var searcher = match._searcher;
+            var currentMatches = matches;
+            int totalResults = 0;
+            int storeIdx = 0;
+            int maxUnusedMatchesSlots = matches.Length >= 64 ? matches.Length / 8 : 1;
+
+            int results;
+            do
+            {
+                var freeMemory = currentMatches.Slice(storeIdx);
+                results = match._inner.Fill(freeMemory);
+
+                if (results == 0)
+                    return totalResults;
+
+                for (int i = 0; i < results; i++)
+                {
+                    var reader = searcher.GetReaderFor(freeMemory[i]);
+                    var type = reader.GetFieldType(match._fieldId, out var _);
+                    if (type == IndexEntryFieldType.Invalid)
+                        continue;
+                    
+                    if (type == IndexEntryFieldType.Null)
+                        continue; // It is null, item is not elegible.
+                    
+                    if (type.HasFlag(IndexEntryFieldType.List) || type.HasFlag(IndexEntryFieldType.TupleList))
+                    {
+                        if (type.HasFlag(IndexEntryFieldType.HasNulls) && !type.HasFlag(IndexEntryFieldType.EmptyList))
+                        {
+                            var iterator = reader.ReadMany(match._fieldId);
+
+                            bool isMatch = false;
+                            while (iterator.ReadNext())
+                            {
+                                // If there is any non null, then it is a match
+                                if (!@iterator.IsNull)
+                                {
+                                    isMatch = true;
+                                    break;
+                                }
+                            }
+                            if (!isMatch)
+                                continue; // It is not a match, item is not elegible.
+                        }
+                        else
+                            continue; // It has not nulls, item is not elegible.
+                    }
+                    else if (type.HasFlag(IndexEntryFieldType.Tuple) || type.HasFlag(IndexEntryFieldType.Simple))
+                    {
+                        var readType = reader.GetFieldType(match._fieldId, out var _);
+                        if (readType == IndexEntryFieldType.Null)
+                            continue; // It is null, item is not elegible.
+                    }
+                    
+                    currentMatches[storeIdx] = freeMemory[i];
+                    storeIdx++;
+                    totalResults++;
+                }
+            } while (results >= totalResults + maxUnusedMatchesSlots);
+
+            return storeIdx;
+        }
+
 
 
         [SkipLocalsInit]
@@ -240,14 +396,14 @@ namespace Corax.Queries
                 if (results == 0)
                     return totalResults;
 
-                var answer = match._distinct == false;
                 for (int i = 0; i < results; i++)
                 {
                     var reader = searcher.GetReaderFor(freeMemory[i]);
                     var type = reader.GetFieldType(match._fieldId, out var _);
-
-                    var isMatch = match._distinct;
-
+                    if (type == IndexEntryFieldType.Invalid)
+                        continue;
+                    
+                    // If it is not a null, then we need to check lots of things.
                     if (type != IndexEntryFieldType.Null)
                     {
                         if (type.HasFlag(IndexEntryFieldType.List) || type.HasFlag(IndexEntryFieldType.TupleList))
@@ -255,34 +411,38 @@ namespace Corax.Queries
                             if (type.HasFlag(IndexEntryFieldType.HasNulls) && !type.HasFlag(IndexEntryFieldType.EmptyList))
                             {
                                 var iterator = reader.ReadMany(match._fieldId);
+                                var isNotMatch = false;
                                 while (iterator.ReadNext())
                                 {
-                                    if (iterator.IsNull)
+                                    if (!@iterator.IsNull)
                                     {
-                                        isMatch = answer;
+                                        isNotMatch = true;
                                         break;
                                     }
                                 }
+
+                                if (isNotMatch)
+                                    continue; // It has some non nulls. item is not elegible.
                             }
                             else
                             {
-                                isMatch = answer;
+                                // Does not have nulls or it is an empty list... item is not elegible.
+                                continue;
                             }
                         }
                         else if (type.HasFlag(IndexEntryFieldType.Tuple) || type.HasFlag(IndexEntryFieldType.Simple))
                         {
                             var readType = reader.GetFieldType(match._fieldId, out var _);
                             if (readType != IndexEntryFieldType.Null)
-                                isMatch = answer;
+                                continue; // item is not elegible.
                         }
-                    }
+                        else
+                            continue;
+                    }                        
 
-                    if (isMatch)
-                    {
-                        currentMatches[storeIdx] = freeMemory[i];
-                        storeIdx++;
-                        totalResults++;
-                    }
+                    currentMatches[storeIdx] = freeMemory[i];
+                    storeIdx++;
+                    totalResults++;
                 }
             } while (results >= totalResults + maxUnusedMatchesSlots);
 
@@ -311,46 +471,50 @@ namespace Corax.Queries
                 if (results == 0)
                     return totalResults;
 
-                var answer = match._distinct == false;
                 for (int i = 0; i < results; i++)
                 {
                     var reader = searcher.GetReaderFor(freeMemory[i]);
                     var type = reader.GetFieldType(match._fieldId, out var _);
-
-                    var isMatch = match._distinct;
-
-                    if (type == IndexEntryFieldType.Null)
+                    if (type == IndexEntryFieldType.Invalid)
+                        continue;
+                    
+                    // If it is not a null, then we need to check lots of things.
+                    if (type != IndexEntryFieldType.Null)
                     {
-                        isMatch = answer;
-                    }
-                    else if (type.HasFlag(IndexEntryFieldType.List) || type.HasFlag(IndexEntryFieldType.TupleList))
-                    {
-                        if (type.HasFlag(IndexEntryFieldType.HasNulls) && !type.HasFlag(IndexEntryFieldType.EmptyList))
+                        if (type.HasFlag(IndexEntryFieldType.List) || type.HasFlag(IndexEntryFieldType.TupleList))
                         {
-                            var iterator = reader.ReadMany(match._fieldId);
-                            while (iterator.ReadNext())
+                            if (type.HasFlag(IndexEntryFieldType.HasNulls) && !type.HasFlag(IndexEntryFieldType.EmptyList))
                             {
-                                if (iterator.IsNull)
+                                var iterator = reader.ReadMany(match._fieldId);
+
+                                bool isMatch = false;
+                                while (iterator.ReadNext())
                                 {
-                                    isMatch = answer;
-                                    break;
+                                    if (iterator.IsNull)
+                                    {
+                                        isMatch = true;
+                                        break;
+                                    }
                                 }
+                                if (!isMatch)
+                                    continue; // It is not a match, item is not elegible.
                             }
+                            else
+                                continue; // It has not nulls, item is not elegible.
                         }
-                    }
-                    else if (type.HasFlag(IndexEntryFieldType.Tuple) || type.HasFlag(IndexEntryFieldType.Simple))
-                    {
-                        var readType = reader.GetFieldType(match._fieldId, out var _);
-                        if (readType == IndexEntryFieldType.Null)
-                            isMatch = answer;
+                        else if (type.HasFlag(IndexEntryFieldType.Tuple) || type.HasFlag(IndexEntryFieldType.Simple))
+                        {
+                            var readType = reader.GetFieldType(match._fieldId, out var _);
+                            if (readType != IndexEntryFieldType.Null)
+                                continue; // It has not nulls, item is not elegible.
+                        }
+                        else
+                            continue;
                     }
 
-                    if (isMatch)
-                    {
-                        currentMatches[storeIdx] = freeMemory[i];
-                        storeIdx++;
-                        totalResults++;
-                    }
+                    currentMatches[storeIdx] = freeMemory[i];
+                    storeIdx++;
+                    totalResults++;
                 }
             } while (results >= totalResults + maxUnusedMatchesSlots);
 
@@ -361,14 +525,12 @@ namespace Corax.Queries
         private static int FillFuncNumericalAny<TComparer>(ref UnaryMatch<TInner, TValueType> match, Span<long> matches)
             where TComparer : struct, IUnaryMatchComparer
         {
-            var currentType = match._value;
-
             var comparer = default(TComparer);
             var searcher = match._searcher;
             var currentMatches = matches;
             int totalResults = 0;
             int maxUnusedMatchesSlots = matches.Length >= 64 ? matches.Length / 8 : 1;
-            int storeIdx = 0;
+            int storeIdx = 0;            
 
             int results;
             do
@@ -378,94 +540,110 @@ namespace Corax.Queries
                 if (results == 0)
                     return totalResults;
 
-                var answer = match._distinct == false;
                 for (int i = 0; i < results; i++)
                 {
                     var reader = searcher.GetReaderFor(freeMemory[i]);
                     var type = reader.GetFieldType(match._fieldId, out _);
+                    if (type == IndexEntryFieldType.Invalid)
+                        continue;
                     
-                    var isMatch = match._distinct;
-                    
-                    if (typeof(TValueType) == typeof(long))
+                    if (TypesHelper.IsInteger<TValueType>())
                     {
+                        long currentType = CoherseValueTypeToLong(match._value);
                         if (type == IndexEntryFieldType.Null)
                         {
-                            isMatch = answer;
+                            if (match._operation != UnaryMatchOperation.NotEquals)
+                            {
+                                // Found a null, item is not elegible.
+                                continue;
+                            }
                         }
                         else if (type.HasFlag(IndexEntryFieldType.List) || type.HasFlag(IndexEntryFieldType.TupleList))
                         {
                             var iterator = reader.ReadMany(match._fieldId);
+
+                            bool isMatch = false;
                             while (iterator.ReadNext())
                             {
-                                if (iterator.IsNull)
-                                    continue;
+                                if (iterator.IsNull && match._operation != UnaryMatchOperation.NotEquals)
+                                    continue; // Item is null, we will try the next.
 
-                                if (comparer.Compare((long)(object)currentType, iterator.Long) == answer)
+                                if (comparer.Compare(currentType, iterator.Long))
                                 {
-                                    isMatch = answer;
+                                    isMatch = true;
                                     break;
                                 }
                             }
+                            if (!isMatch)
+                                continue; // Not a match, item is not elegible.
                         }
                         else if (type.HasFlag(IndexEntryFieldType.Tuple) || type.HasFlag(IndexEntryFieldType.Simple))
                         {
                             var read = reader.Read<long>(match._fieldId, out var readType, out var resultX);
-                            if (read && readType != IndexEntryFieldType.Null)
-                            {
-                                if (comparer.Compare((long)(object)currentType, resultX) == answer)
-                                {
-                                    // We found a match.
-                                    isMatch = answer;
-                                }
-                            }
+                            if (!read)
+                                continue; // Not a match, item is not elegible.
+
+                            if (readType == IndexEntryFieldType.Null && match._operation != UnaryMatchOperation.NotEquals)
+                                continue; // Not a match, item is not elegible
+
+                            if (!comparer.Compare(currentType, resultX))
+                                continue;
                         }
                     }
-                    else if (typeof(TValueType) == typeof(double))
+                    else if (TypesHelper.IsFloatingPoint<TValueType>())
                     {
+                        double currentType = CoherseValueTypeToDouble(match._value);
+                        
                         if (type == IndexEntryFieldType.Null)
                         {
-                            isMatch = answer;
+                            if (match._operation != UnaryMatchOperation.NotEquals)
+                            {
+                                // Found a null, item is not elegible.
+                                continue;
+                            }
                         }
                         else if (type.HasFlag(IndexEntryFieldType.List) || type.HasFlag(IndexEntryFieldType.TupleList))
                         {
                             var iterator = reader.ReadMany(match._fieldId);
+
+                            bool isMatch = false;
                             while (iterator.ReadNext())
                             {
-                                if (iterator.IsNull)
-                                    continue;
+                                if (iterator.IsNull && match._operation != UnaryMatchOperation.NotEquals)
+                                    continue; // Item is null, we will try the next.
 
-                                if (comparer.Compare((double)(object)currentType, iterator.Long) == answer)
+                                if (comparer.Compare(currentType, iterator.Double))
                                 {
-                                    isMatch = answer;
+                                    isMatch = true;
                                     break;
                                 }
                             }
+                            if (!isMatch)
+                                continue; // Not a match, item is not elegible.
                         }
                         else if (type.HasFlag(IndexEntryFieldType.Tuple) || type.HasFlag(IndexEntryFieldType.Simple))
                         {
                             var read = reader.Read<double>(match._fieldId, out var readType, out var resultX);
-                            if (read && readType != IndexEntryFieldType.Null)
-                            {
-                                if (comparer.Compare((double)(object)currentType, resultX) == answer)
-                                {
-                                    // We found a match.
-                                    isMatch = answer;
-                                }
-                            }
+                            if (!read)
+                                continue; // Not a match, item is not elegible.
+
+                            if (readType == IndexEntryFieldType.Null && match._operation != UnaryMatchOperation.NotEquals)
+                                continue; // Not a match, item is not elegible.
+
+                            if (!comparer.Compare(currentType, resultX))
+                                continue;
                         }
                     }
+                    else
+                        throw new NotSupportedException($"Type '{typeof(TValueType).Name} is not supported. Only double and float are supported.");
 
-                    if (isMatch)
-                    {
-                        // We found a match.
-                        currentMatches[storeIdx] = freeMemory[i];
-                        storeIdx++;
-                        totalResults++;
-                    }
+                    // We found a match.
+                    currentMatches[storeIdx] = freeMemory[i];
+                    storeIdx++;
+                    totalResults++;
                 }
             } while (results >= totalResults + maxUnusedMatchesSlots);
 
-            matches = currentMatches.Slice(0, storeIdx);
             return totalResults;
         }
 
@@ -473,8 +651,6 @@ namespace Corax.Queries
         private static int FillFuncNumericalAll<TComparer>(ref UnaryMatch<TInner, TValueType> match, Span<long> matches)
             where TComparer : struct, IUnaryMatchComparer
         {
-            var currentType = match._value;
-
             var comparer = default(TComparer);
             var searcher = match._searcher;
             var currentMatches = matches;
@@ -490,128 +666,105 @@ namespace Corax.Queries
                 if (results == 0)
                     return totalResults;
 
-                var answer = match._distinct == false;
                 for (int i = 0; i < results; i++)
                 {
                     var reader = searcher.GetReaderFor(freeMemory[i]);
                     var type = reader.GetFieldType(match._fieldId, out _);
-
-                    var isMatch = match._distinct;
-
-                    if (typeof(TValueType) == typeof(long))
+                    if (type == IndexEntryFieldType.Invalid)
+                        continue;
+                    
+                    if (type == IndexEntryFieldType.Null)
                     {
-                        // If we get a null, we just skip it. It will not match.
-                        if (type != IndexEntryFieldType.Null)
+                        if (match._operation != UnaryMatchOperation.NotEquals)
                         {
-                            if (type.HasFlag(IndexEntryFieldType.List) || type.HasFlag(IndexEntryFieldType.TupleList))
+                            // Found a null, item is not elegible.
+                            continue;
+                        }
+                    }
+                    else if (TypesHelper.IsInteger<TValueType>())
+                    {
+                        long currentType = CoherseValueTypeToLong(match._value);
+                        if (type.HasFlag(IndexEntryFieldType.List) || type.HasFlag(IndexEntryFieldType.TupleList))
+                        {
+                            var iterator = reader.ReadMany(match._fieldId);
+
+                            bool isNotMatch = false;
+                            while (iterator.ReadNext())
                             {
-                                var iterator = reader.ReadMany(match._fieldId);
-
-                                while (iterator.ReadNext())
+                                if (iterator.IsNull)
                                 {
-                                    // Null here is complicated. When we are in the positive case, we know that the value is not null,
-                                    // therefore finding a null in the case of the positive case would ensure that this is not a match.
-                                    // However, when we are in the negative case (distict), we know for certain it is different to the
-                                    // value and therefore we can continue to the next. 
-                                    if (iterator.IsNull && !match._distinct)
-                                    {
-                                        isMatch = answer;
-                                        break;
-                                    }
+                                    isNotMatch = true;
+                                    break;
+                                }
 
-                                    if (comparer.Compare((long)(object)currentType, iterator.Long) == answer)
-                                    {
-                                        isMatch = answer;
-                                        break;
-                                    }
+                                if (!comparer.Compare(currentType, iterator.Long))
+                                {
+                                    isNotMatch = true;
+                                    break;
                                 }
                             }
+                            if (isNotMatch)
+                                continue; // It is not a match, item is not elegible.
                         }
                         else if (type.HasFlag(IndexEntryFieldType.Tuple) || type.HasFlag(IndexEntryFieldType.Simple))
                         {
                             var read = reader.Read<long>(match._fieldId, out var readType, out var resultX);
-
-                            // Null here is complicated. When we are in the positive case, we know that the value is not null,
-                            // therefore finding a null in the case of the positive case would ensure that this is not a match.
-                            // However, when we are in the negative case (distict), we know for certain it is different to the
-                            // value. 
-                            if (readType == IndexEntryFieldType.Null && !match._distinct)
-                            {
-                                isMatch = answer;
-                            }
-                            else
-                            {
-                                if (read && comparer.Compare((long)(object)currentType, resultX) == answer)
-                                {
-                                    // We found a match.
-                                    isMatch = answer;
-                                }
-                            }
+                            if (!read || readType == IndexEntryFieldType.Null)
+                                continue; // It is null, item is not elegible.
+                                          // 
+                            if (!comparer.Compare(currentType, resultX))
+                                continue; // It is null or not a match, item is not elegible.   
                         }
+                        else
+                            continue;
                     }
-                    else if (typeof(TValueType) == typeof(double))
+                    else if (TypesHelper.IsFloatingPoint<TValueType>())
                     {
-                        // If we get a null, we just skip it. It will not match.
-                        if (type != IndexEntryFieldType.Null)
+                        double currentType = CoherseValueTypeToDouble(match._value);
+                        if (type.HasFlag(IndexEntryFieldType.List) || type.HasFlag(IndexEntryFieldType.TupleList))
                         {
-                            if (type.HasFlag(IndexEntryFieldType.List) || type.HasFlag(IndexEntryFieldType.TupleList))
+                            var iterator = reader.ReadMany(match._fieldId);
+
+                            bool isNotMatch = false;
+                            while (iterator.ReadNext())
                             {
-                                var iterator = reader.ReadMany(match._fieldId);
-
-                                while (iterator.ReadNext())
+                                if (iterator.IsNull)
                                 {
-                                    // Null here is complicated. When we are in the positive case, we know that the value is not null,
-                                    // therefore finding a null in the case of the positive case would ensure that this is not a match.
-                                    // However, when we are in the negative case (distict), we know for certain it is different to the
-                                    // value and therefore we can continue to the next. 
-                                    if (iterator.IsNull && !match._distinct)
-                                    {
-                                        isMatch = answer;
-                                        break;
-                                    }
+                                    isNotMatch = true;
+                                    break;
+                                }
 
-                                    if (comparer.Compare((double)(object)currentType, iterator.Long) == answer)
-                                    {
-                                        isMatch = answer;
-                                        break;
-                                    }
+                                if (!comparer.Compare(currentType, iterator.Double))
+                                {
+                                    isNotMatch = true;
+                                    break;
                                 }
                             }
+                            if (isNotMatch)
+                                continue; // It is not a match, item is not elegible.
                         }
                         else if (type.HasFlag(IndexEntryFieldType.Tuple) || type.HasFlag(IndexEntryFieldType.Simple))
                         {
                             var read = reader.Read<double>(match._fieldId, out var readType, out var resultX);
-
-                            // Null here is complicated. When we are in the positive case, we know that the value is not null,
-                            // therefore finding a null in the case of the positive case would ensure that this is not a match.
-                            // However, when we are in the negative case (distict), we know for certain it is different to the
-                            // value. 
-                            if (readType == IndexEntryFieldType.Null && !match._distinct)
-                            {
-                                isMatch = answer;
-                            }
-                            else
-                            {
-                                if (read && comparer.Compare((double)(object)currentType, resultX) == answer)
-                                {
-                                    // We found a match.
-                                    isMatch = answer;
-                                }
-                            }
+                            if (!read || readType == IndexEntryFieldType.Null)
+                                continue; // It is null, item is not elegible.
+                                          // 
+                            if (!comparer.Compare(currentType, resultX))
+                                continue; // It is null or not a match, item is not elegible.   
                         }
+                        else
+                            continue;
                     }
+                    else
+                        throw new NotSupportedException($"Type '{typeof(TValueType).Name} is not supported. Only double and float are supported.");
 
-                    if (isMatch)
-                    {
-                        // We found a match.
-                        currentMatches[storeIdx] = freeMemory[i];
-                        storeIdx++;
-                        totalResults++;
-                    }
+                    // We found a match.
+                    currentMatches[storeIdx] = freeMemory[i];
+                    storeIdx++;
+                    totalResults++;
                 }
             } while (results >= totalResults + maxUnusedMatchesSlots);
 
-            matches = currentMatches.Slice(0, storeIdx);
             return totalResults;
         }
 
@@ -621,7 +774,7 @@ namespace Corax.Queries
                 in inner, UnaryMatchOperation.Equals,
                 searcher, fieldId, default(TValueType),
                 mode == UnaryMatchOperationMode.Any ? &FillFuncAnyNull : &FillFuncAllNull, &AndWith,
-                inner.Count, inner.Confidence.Min(QueryCountConfidence.Normal), mode, false, take: take);
+                inner.Count, inner.Confidence.Min(QueryCountConfidence.Normal), mode, take: take);
         }
 
         public static UnaryMatch<TInner, TValueType> YieldIsNotNull(in TInner inner, IndexSearcher searcher, int fieldId, UnaryMatchOperationMode mode = UnaryMatchOperationMode.Any, int take = -1)
@@ -629,8 +782,8 @@ namespace Corax.Queries
             return new UnaryMatch<TInner, TValueType>(
                 in inner, UnaryMatchOperation.NotEquals,
                 searcher, fieldId, default(TValueType),
-                mode == UnaryMatchOperationMode.Any ? &FillFuncAnyNull : &FillFuncAllNull, &AndWith,
-                inner.Count, inner.Confidence.Min(QueryCountConfidence.Normal), mode, true, take: take);
+                mode == UnaryMatchOperationMode.Any ? &FillFuncAnyNonNull : &FillFuncAllNonNull, &AndWith,
+                inner.Count, inner.Confidence.Min(QueryCountConfidence.Normal), mode, take: take);
         }
 
         public static UnaryMatch<TInner, TValueType> YieldGreaterThan(in TInner inner, IndexSearcher searcher, int fieldId, TValueType value, UnaryMatchOperationMode mode = UnaryMatchOperationMode.Any,
@@ -726,15 +879,15 @@ namespace Corax.Queries
                     in inner, UnaryMatchOperation.NotEquals,
                     searcher, fieldId, value,
                     mode == UnaryMatchOperationMode.Any ? &FillFuncSequenceAny<NotEqualsMatchComparer> : &FillFuncSequenceAll<NotEqualsMatchComparer>, &AndWith,
-                    inner.Count, inner.Confidence.Min(QueryCountConfidence.Normal), mode, true, take: take);
+                    inner.Count, inner.Confidence.Min(QueryCountConfidence.Normal), mode, take: take);
             }
             else
-            {
+            {                
                 return new UnaryMatch<TInner, TValueType>(
                     in inner, UnaryMatchOperation.NotEquals,
                     searcher, fieldId, value,
                     mode == UnaryMatchOperationMode.Any ? &FillFuncNumericalAny<NotEqualsMatchComparer> : &FillFuncNumericalAny<NotEqualsMatchComparer>, &AndWith,
-                    inner.Count, inner.Confidence.Min(QueryCountConfidence.Normal), mode, true, take: take);
+                    inner.Count, inner.Confidence.Min(QueryCountConfidence.Normal), mode, take: take);
             }
         }
 
@@ -878,5 +1031,42 @@ namespace Corax.Queries
                 throw new NotSupportedException($"MatchComparer does not support type {nameof(T)}");
             }
         }
+
+
+        [MethodImpl(MethodImplOptions.AggressiveInlining)]
+        private static long CoherseValueTypeToLong(TValueType value)
+        {
+            if (typeof(TValueType) == typeof(long))
+                return (long)(object)value;
+            if (typeof(TValueType) == typeof(ulong))
+                return (long)(ulong)(object)value;
+            if (typeof(TValueType) == typeof(int))
+                return (long)(int)(object)value;
+            if (typeof(TValueType) == typeof(uint))
+                return (long)(uint)(object)value;
+            if (typeof(TValueType) == typeof(short))
+                return (long)(short)(object)value;
+            if (typeof(TValueType) == typeof(ushort))
+                return (long)(ushort)(object)value;
+            if (typeof(TValueType) == typeof(byte))
+                return (long)(byte)(object)value;
+            if (typeof(TValueType) == typeof(sbyte))
+                return (long)(sbyte)(object)value;
+
+            throw new NotSupportedException($"Type '{typeof(TValueType).Name} is not supported. Only long, ulong, int, uint, double and float are supported.");
+        }
+
+
+        [MethodImpl(MethodImplOptions.AggressiveInlining)]
+        private static double CoherseValueTypeToDouble(TValueType value)
+        {
+            if (typeof(TValueType) == typeof(double))
+                return (double)(object)value;
+            if (typeof(TValueType) == typeof(float))
+                return (double)(float)(object)value;
+
+            throw new NotSupportedException($"Type '{typeof(TValueType).Name} is not supported. Only long, ulong, int, uint, double and float are supported.");
+        }
+
     }
 }

--- a/src/Corax/Queries/UnaryMatch.cs
+++ b/src/Corax/Queries/UnaryMatch.cs
@@ -19,6 +19,12 @@ namespace Corax.Queries
         NotBetween
     }
 
+    public enum UnaryMatchOperationMode
+    {
+        Any,
+        All
+    }
+
     [DebuggerDisplay("{DebugView,nq}")]
     public unsafe partial struct UnaryMatch<TInner, TValueType> : IQueryMatch
         where TInner : IQueryMatch
@@ -33,6 +39,7 @@ namespace Corax.Queries
         private readonly TValueType _value;
         private readonly TValueType _valueAux;
         private readonly int _take;
+        private readonly UnaryMatchOperationMode _operationMode;
         private readonly bool _distinct;
         
         private long _totalResults;
@@ -53,7 +60,8 @@ namespace Corax.Queries
             delegate*<ref UnaryMatch<TInner, TValueType>, Span<long>, int> fillFunc,
             delegate*<ref UnaryMatch<TInner, TValueType>, Span<long>, int, int> andWithFunc,
             long totalResults,
-            QueryCountConfidence confidence, 
+            QueryCountConfidence confidence,
+            UnaryMatchOperationMode mode = UnaryMatchOperationMode.Any,
             bool distinct = false,
             int take = -1)
         {
@@ -70,6 +78,7 @@ namespace Corax.Queries
             _value = value;
             _valueAux = default;
             _confidence = confidence;
+            _operationMode = mode;
             _distinct = distinct;
             _take = take <= 0 ? int.MaxValue : take;
         }
@@ -83,7 +92,8 @@ namespace Corax.Queries
             delegate*<ref UnaryMatch<TInner, TValueType>, Span<long>, int> fillFunc,
             delegate*<ref UnaryMatch<TInner, TValueType>, Span<long>, int, int> andWith,
             long totalResults,
-            QueryCountConfidence confidence, 
+            QueryCountConfidence confidence,
+            UnaryMatchOperationMode mode = UnaryMatchOperationMode.Any,
             bool distinct = false,
             int take = -1)
         {
@@ -100,6 +110,7 @@ namespace Corax.Queries
             _value = value1;
             _valueAux = value2;
             _confidence = confidence;
+            _operationMode = mode;
             _distinct = distinct;
             _take = take <= 0 ? int.MaxValue : take;
         }

--- a/src/Corax/Queries/UnaryMatch.cs
+++ b/src/Corax/Queries/UnaryMatch.cs
@@ -40,7 +40,6 @@ namespace Corax.Queries
         private readonly TValueType _valueAux;
         private readonly int _take;
         private readonly UnaryMatchOperationMode _operationMode;
-        private readonly bool _distinct;
         
         private long _totalResults;
         private long _current;
@@ -62,7 +61,6 @@ namespace Corax.Queries
             long totalResults,
             QueryCountConfidence confidence,
             UnaryMatchOperationMode mode = UnaryMatchOperationMode.Any,
-            bool distinct = false,
             int take = -1)
         {
             _totalResults = totalResults;
@@ -79,7 +77,6 @@ namespace Corax.Queries
             _valueAux = default;
             _confidence = confidence;
             _operationMode = mode;
-            _distinct = distinct;
             _take = take <= 0 ? int.MaxValue : take;
         }
 
@@ -94,7 +91,6 @@ namespace Corax.Queries
             long totalResults,
             QueryCountConfidence confidence,
             UnaryMatchOperationMode mode = UnaryMatchOperationMode.Any,
-            bool distinct = false,
             int take = -1)
         {
             _totalResults = totalResults;
@@ -111,7 +107,6 @@ namespace Corax.Queries
             _valueAux = value2;
             _confidence = confidence;
             _operationMode = mode;
-            _distinct = distinct;
             _take = take <= 0 ? int.MaxValue : take;
         }
 
@@ -141,6 +136,7 @@ namespace Corax.Queries
                 {
                     { nameof(IsBoosting), IsBoosting.ToString() },
                     { nameof(Count), $"{Count} [{Confidence}]" },
+                    { "Operation", _operation.ToString() },
                     { "FieldId", $"{_fieldId}" },
                     { "Value", GetValue()},
                     { "AuxValue", GetAuxValue()}

--- a/src/Raven.Server/Documents/Indexes/Persistence/Corax/CoraxDocumentConverterBase.cs
+++ b/src/Raven.Server/Documents/Indexes/Persistence/Corax/CoraxDocumentConverterBase.cs
@@ -22,6 +22,7 @@ using Voron;
 using RavenConstants = Raven.Client.Constants;
 using CoraxConstants = Corax.Constants;
 using Encoding = System.Text.Encoding;
+using System.Diagnostics;
 
 namespace Raven.Server.Documents.Indexes.Persistence.Corax;
 
@@ -284,16 +285,16 @@ public abstract class CoraxDocumentConverterBase : ConverterBase
                 HandleObject((BlittableJsonReaderObject)value, field, indexContext, ref entryWriter, scope);
                 return;
 
-            case ValueType.DynamicNull:
+            case ValueType.DynamicNull:       
                 var dynamicNull = (DynamicNullObject)value;
                 if (dynamicNull.IsExplicitNull || _indexImplicitNull)
                 {
-                    scope.Write(field.Id, NullValue.Span, ref entryWriter);
+                    scope.WriteNull(field.Id, ref entryWriter);
                 }
                 return;
 
             case ValueType.Null:
-                scope.Write(field.Id, NullValue.Span, ref entryWriter);
+                scope.WriteNull(field.Id, ref entryWriter);
                 return;
             case ValueType.BoostedValue:
                 //todo maciej

--- a/src/Raven.Server/Documents/Indexes/Persistence/Corax/CoraxDocumentConverterBase.cs
+++ b/src/Raven.Server/Documents/Indexes/Persistence/Corax/CoraxDocumentConverterBase.cs
@@ -72,7 +72,7 @@ public abstract class CoraxDocumentConverterBase : ConverterBase
             ? RavenConstants.Documents.Indexing.Fields.ReduceKeyValueFieldName
             : RavenConstants.Documents.Indexing.Fields.DocumentIdFieldName, ByteStringType.Immutable, out var value);
 
-        knownFields = knownFields.AddBinding(0, value, null, hasSuggestion: false, fieldIndexingMode: FieldIndexingMode.Exact);
+        knownFields = knownFields.AddBinding(0, value, null, hasSuggestion: false, fieldIndexingMode: FieldIndexingMode.Normal);
         foreach (var field in index.Definition.IndexFields.Values)
         {
             Slice.From(allocator, field.Name, ByteStringType.Immutable, out value);

--- a/src/Raven.Server/Documents/Indexes/Persistence/Corax/CoraxQueryBuilder.cs
+++ b/src/Raven.Server/Documents/Indexes/Persistence/Corax/CoraxQueryBuilder.cs
@@ -171,11 +171,11 @@ public static class CoraxQueryBuilder
                         // This is TermMatch case
                         if (scoreFunction is not NullScoreFunction)
                             return indexSearcher.Boost(rawMatch, scoreFunction);
-                        
-                        
+
+
                         return rawMatch;
                     }
-                  
+
 
                     var match = valueType switch
                     {
@@ -192,8 +192,8 @@ public static class CoraxQueryBuilder
                     if (highlightingTerm != null && valueType is ValueTokenType.Double or ValueTokenType.Long)
                     {
                         highlightingTerm.Values = value.ToString();
-                    }                       
-                    
+                    }
+
                     if (match is null)
                         QueryBuilderHelper.ThrowUnhandledValueTokenType(valueType);
 
@@ -201,17 +201,24 @@ public static class CoraxQueryBuilder
 
                     IQueryMatch HandleStringUnaryMatch()
                     {
-                        var valueAsString = QueryBuilderHelper.CoraxGetValueAsString(value);
-                        if (highlightingTerm != null)
-                            highlightingTerm.Values = valueAsString;
-                                                
                         if (exact && metadata.IsDynamic)
                         {
                             fieldName = new QueryFieldName(AutoIndexField.GetExactAutoIndexFieldName(fieldName), fieldName.IsQuoted);
                             fieldId = QueryBuilderHelper.GetFieldId(fieldName, index, indexMapping, queryMapping, exact);
                         }
 
-                        return indexSearcher.UnaryQuery(indexSearcher.AllEntries(), fieldId, valueAsString, operation, take);
+                        if (value == null)
+                        {
+                            return indexSearcher.EqualsNull(indexSearcher.AllEntries(), fieldId, operation, take);
+                        }
+                        else
+                        {
+                            var valueAsString = QueryBuilderHelper.CoraxGetValueAsString(value);
+                            if (highlightingTerm != null)
+                                highlightingTerm.Values = valueAsString;
+                            
+                            return indexSearcher.UnaryQuery(indexSearcher.AllEntries(), fieldId, valueAsString, operation, take);
+                        }
                     }
                 }
             }

--- a/src/Raven.Server/Documents/Indexes/Persistence/Corax/WriterScopes/IWriterScope.cs
+++ b/src/Raven.Server/Documents/Indexes/Persistence/Corax/WriterScopes/IWriterScope.cs
@@ -7,6 +7,7 @@ namespace Raven.Server.Documents.Indexes.Persistence.Corax.WriterScopes
 {
     public interface IWriterScope
     {
+        public void WriteNull(int field, ref IndexEntryWriter entryWriter);
         public void Write(int field, ReadOnlySpan<byte> value, ref IndexEntryWriter entryWriter);
 
         public void Write(int field, ReadOnlySpan<byte> value, long longValue, double doubleValue, ref IndexEntryWriter entryWriter);

--- a/src/Raven.Server/Documents/Indexes/Persistence/Corax/WriterScopes/SingleEntryWriterScope.cs
+++ b/src/Raven.Server/Documents/Indexes/Persistence/Corax/WriterScopes/SingleEntryWriterScope.cs
@@ -16,6 +16,12 @@ namespace Raven.Server.Documents.Indexes.Persistence.Corax.WriterScopes
         {
             _allocator = allocator;
         }
+
+
+        public void WriteNull(int field, ref IndexEntryWriter entryWriter)
+        {
+            entryWriter.WriteNull(field);
+        }
         
         public void Write(int field, ReadOnlySpan<byte> value, ref IndexEntryWriter entryWriter)
         {
@@ -52,5 +58,6 @@ namespace Raven.Server.Documents.Indexes.Persistence.Corax.WriterScopes
             using var scope = new BlittableWriterScope(reader);
             scope.Write(field, ref entryWriter);
         }
+
     }
 }

--- a/src/Raven.Server/Documents/Queries/QueryBuilderHelper.cs
+++ b/src/Raven.Server/Documents/Queries/QueryBuilderHelper.cs
@@ -546,7 +546,7 @@ public static class QueryBuilderHelper
         string s => s,
         long l => l.ToString(CultureInfo.InvariantCulture),
         double d => d.ToString(CultureInfo.InvariantCulture),
-        null => Constants.Documents.Indexing.Fields.NullValue,
+        null => Corax.Constants.NullValue,
         _ => value?.ToString()
     };
 

--- a/src/Raven.Server/Documents/Queries/Results/QueryResultRetrieverBase.cs
+++ b/src/Raven.Server/Documents/Queries/Results/QueryResultRetrieverBase.cs
@@ -623,7 +623,7 @@ namespace Raven.Server.Documents.Queries.Results
                     fixed (byte* ptr = &blittableBinary.GetPinnableReference())
                         value = new BlittableJsonReaderObject(ptr, blittableBinary.Length, context);
                     break;
-                case IndexEntryFieldType.None:
+                case IndexEntryFieldType.Simple:
                     retrieverInput.CoraxEntry.Read(fieldId, out data);
                     if (data.Length is 10 or 12)
                     {

--- a/src/Sparrow/TypesHelper.cs
+++ b/src/Sparrow/TypesHelper.cs
@@ -1,0 +1,38 @@
+﻿using System;
+using System.Collections.Generic;
+using System.Linq;
+using System.Runtime.CompilerServices;
+using System.Text;
+using System.Threading.Tasks;
+
+namespace Sparrow
+{
+    public static class TypesHelper
+    {
+
+        [MethodImpl(MethodImplOptions.AggressiveInlining)]
+        public static bool IsNumerical<T>()
+        {
+            return typeof(T) == typeof(long) || typeof(T) == typeof(int)
+                || typeof(T) == typeof(short) || typeof(T) == typeof(byte)
+                || typeof(T) == typeof(ulong) || typeof(T) == typeof(uint)
+                || typeof(T) == typeof(ushort) || typeof(T) == typeof(sbyte)
+                || typeof(T) == typeof(float) || typeof(T) == typeof(double);
+        }
+
+        [MethodImpl(MethodImplOptions.AggressiveInlining)]
+        public static bool IsInteger<T>()
+        {
+            return typeof(T) == typeof(long) || typeof(T) == typeof(int)
+                || typeof(T) == typeof(short) || typeof(T) == typeof(byte)
+                || typeof(T) == typeof(ulong) || typeof(T) == typeof(uint)
+                || typeof(T) == typeof(ushort) || typeof(T) == typeof(sbyte);
+        }
+
+        [MethodImpl(MethodImplOptions.AggressiveInlining)]
+        public static bool IsFloatingPoint<T>()
+        {
+            return typeof(T) == typeof(float) || typeof(T) == typeof(double);
+        }
+    }
+}

--- a/test/FastTests/Corax/IndexSearcher.cs
+++ b/test/FastTests/Corax/IndexSearcher.cs
@@ -60,7 +60,7 @@ namespace FastTests.Corax
                 return _values[i] == null;
             }
 
-            public ReadOnlySpan<byte> this[int i] => Encoding.UTF8.GetBytes(_values[i]);
+            public ReadOnlySpan<byte> this[int i] => _values[i] != null ? Encoding.UTF8.GetBytes(_values[i]) : null;
         }
 
         private static Span<byte> CreateIndexEntry(ref IndexEntryWriter entryWriter, IndexEntry value)
@@ -2039,10 +2039,10 @@ namespace FastTests.Corax
                     Content = (i % 7) switch
                     {
                         0 => new string[] { "1" },
-                        1 => new string[] { "7" },
+                        1 => new string[] { null, "7" },
                         2 => new string[] { "2", "1" },
-                        3 => new string[] { "1", "2", "3" },
-                        4 => new string[] { "1", "2", "3", "5" },
+                        3 => new string[] { null, "1", "2", "3" },
+                        4 => new string[] { "1", "2", "3", "5", null },
                         5 => new string[] { "2", "5" },
                         6 => new string[] { "2", "5", "7" },
                         _ => throw new ArgumentOutOfRangeException()
@@ -2060,8 +2060,7 @@ namespace FastTests.Corax
 
             using var searcher = new IndexSearcher(Env);
             {
-                var notOne = searcher.UnaryQuery(searcher.AllEntries(), ContentIndex, one, UnaryMatchOperation.NotEquals);
-                //  var notTwo = searcher.UnaryQuery(searcher.AllEntries(), ContentIndex, two, UnaryMatchOperation.NotEquals);
+                var notOne = searcher.UnaryQuery(searcher.AllEntries(), ContentIndex, one, UnaryMatchOperation.NotEquals);               
                 Span<long> ids = stackalloc long[32];
                 var expected = entries.Count(x => x.Content.Contains("1") == false);
                 var result = notOne.Fill(ids);

--- a/test/SlowTests/Bugs/AccurateCount.cs
+++ b/test/SlowTests/Bugs/AccurateCount.cs
@@ -10,6 +10,7 @@ using Raven.Client.Documents.Indexes;
 using Raven.Client.Documents.Operations.Indexes;
 using Xunit;
 using Xunit.Abstractions;
+using Tests.Infrastructure;
 
 namespace SlowTests.Bugs
 {
@@ -19,16 +20,16 @@ namespace SlowTests.Bugs
         {
         }
 
-        [Fact] 
-        public void QueryableCountIsAccurate()
+        [RavenTheory(RavenTestCategory.Indexes)]
+        [RavenData(SearchEngineMode = RavenSearchEngineMode.All)]
+        public void QueryableCountIsAccurate(Options options)
         {
-            using(var store = GetDocumentStore())
+            using(var store = GetDocumentStore(options))
             {
                 store.Maintenance.Send(new PutIndexesOperation(new[] {
                                                 new IndexDefinition
                                                 {
-                                                    Maps = { "from user in docs.Users select new { user.Name }"}
-                                                    ,
+                                                    Maps = { "from user in docs.Users select new { user.Name }"},
                                                     Name = "Users"
                                                 }}));
 

--- a/test/SlowTests/Bugs/AdHocProjections.cs
+++ b/test/SlowTests/Bugs/AdHocProjections.cs
@@ -2,6 +2,7 @@
 using Xunit;
 using System.Linq;
 using Xunit.Abstractions;
+using Tests.Infrastructure;
 
 namespace SlowTests.Bugs
 {
@@ -11,10 +12,11 @@ namespace SlowTests.Bugs
         {
         }
 
-        [Fact]
-        public void Query_can_project_to_a_different_model()
+        [RavenTheory(RavenTestCategory.Querying)]
+        [RavenData(SearchEngineMode = RavenSearchEngineMode.All)]
+        public void Query_can_project_to_a_different_model(Options options)
         {
-            using (var documentStore = GetDocumentStore())
+            using (var documentStore = GetDocumentStore(options))
             {
                 using (var session = documentStore.OpenSession())
                 {

--- a/test/SlowTests/Bugs/AfterDeletingTheIndexStopsBeingStale.cs
+++ b/test/SlowTests/Bugs/AfterDeletingTheIndexStopsBeingStale.cs
@@ -9,6 +9,7 @@ using FastTests;
 using Xunit;
 using System.Linq;
 using Xunit.Abstractions;
+using Tests.Infrastructure;
 
 namespace SlowTests.Bugs
 {
@@ -18,10 +19,11 @@ namespace SlowTests.Bugs
         {
         }
 
-        [Fact]
-        public void Deletion()
+        [RavenTheory(RavenTestCategory.Indexes)]
+        [RavenData(SearchEngineMode = RavenSearchEngineMode.All)]
+        public void Deletion(Options options)
         {
-            using (var store = GetDocumentStore())
+            using (var store = GetDocumentStore(options))
             {
                 using (var session = store.OpenSession())
                 {

--- a/test/SlowTests/Bugs/Errors/CanIndexOnNull.cs
+++ b/test/SlowTests/Bugs/Errors/CanIndexOnNull.cs
@@ -5,6 +5,7 @@ using Raven.Client.Documents.Indexes;
 using Raven.Client.Documents.Operations.Indexes;
 using Xunit;
 using Xunit.Abstractions;
+using Tests.Infrastructure;
 
 namespace SlowTests.Bugs.Errors
 {
@@ -14,10 +15,11 @@ namespace SlowTests.Bugs.Errors
         {
         }
 
-        [Fact]
-        public async Task CanIndexOnMissingProps()
+        [RavenTheory(RavenTestCategory.Querying)]
+        [RavenData(SearchEngineMode = RavenSearchEngineMode.All)]
+        public async Task CanIndexOnMissingProps(Options options)
         {
-            using (var store = GetDocumentStore())
+            using (var store = GetDocumentStore(options))
             {
                 store.Maintenance.Send(new PutIndexesOperation(new[] {
                                                 new IndexDefinition

--- a/test/SlowTests/Bugs/Errors/QueryIssues.cs
+++ b/test/SlowTests/Bugs/Errors/QueryIssues.cs
@@ -15,8 +15,7 @@ namespace SlowTests.Bugs.Errors
         }
 
         [Theory]
-        [RavenData(SearchEngineMode = RavenSearchEngineMode.Lucene)]
-        [RavenData(SearchEngineMode = RavenSearchEngineMode.Corax, Skip = "RavenDB-17966")]
+        [RavenData(SearchEngineMode = RavenSearchEngineMode.All)]    
         public void PrestonThinksLoadStartingWithShouldBeCaseInsensitive(Options options)
         {
             using (var store = GetDocumentStore(options))

--- a/test/SlowTests/Bugs/Indexing/CanHaveAnIndexNameThatStartsWithDynamic.cs
+++ b/test/SlowTests/Bugs/Indexing/CanHaveAnIndexNameThatStartsWithDynamic.cs
@@ -1,9 +1,9 @@
 ﻿using System.Linq;
 using FastTests;
 using Raven.Client.Documents.Indexes;
-using Tests.Infrastructure;
 using Xunit;
 using Xunit.Abstractions;
+using Tests.Infrastructure;
 
 namespace SlowTests.Bugs.Indexing
 {
@@ -43,7 +43,7 @@ namespace SlowTests.Bugs.Indexing
             }
         }
 
-        [Theory]
+        [RavenTheory(RavenTestCategory.Indexes)]
         [RavenData(SearchEngineMode = RavenSearchEngineMode.All)]
         public void CanHaveAnIndexWithANameThatStartsWithTheWordDynamic(Options options)
         {

--- a/test/SlowTests/Bugs/Indexing/CanHaveEscapedSecialCharactersInDefinition.cs
+++ b/test/SlowTests/Bugs/Indexing/CanHaveEscapedSecialCharactersInDefinition.cs
@@ -10,6 +10,7 @@ using Raven.Client.Documents.Indexes;
 using Raven.Client.Documents.Operations.Indexes;
 using Xunit;
 using Xunit.Abstractions;
+using Tests.Infrastructure;
 
 namespace SlowTests.Bugs.Indexing
 {
@@ -21,10 +22,11 @@ namespace SlowTests.Bugs.Indexing
 
         private const string FooIndexName = "SomeFooIndexWithSpecialCharacters";
 
-        [Fact]
-        public void CanContainSecialCharactersInDefinition()
+        [RavenTheory(RavenTestCategory.Indexes)]
+        [RavenData(SearchEngineMode = RavenSearchEngineMode.All)]
+        public void CanContainSecialCharactersInDefinition(Options options)
         {
-            using (var documentStore = GetDocumentStore())
+            using (var documentStore = GetDocumentStore(options))
             {
                 new FooIndex().Execute(documentStore);
                 Assert.NotNull(documentStore.Maintenance.Send(new GetIndexOperation(FooIndexName)));

--- a/test/SlowTests/Bugs/Indexing/CanIndexWithCharLiteral.cs
+++ b/test/SlowTests/Bugs/Indexing/CanIndexWithCharLiteral.cs
@@ -5,6 +5,7 @@ using Raven.Client.Documents.Indexes;
 using Raven.Client.Documents.Operations.Indexes;
 using Xunit;
 using Xunit.Abstractions;
+using Tests.Infrastructure;
 
 namespace SlowTests.Bugs.Indexing
 {
@@ -14,10 +15,11 @@ namespace SlowTests.Bugs.Indexing
         {
         }
 
-        [Fact]
-        public void CanQueryDocumentsIndexWithCharLiteral()
+        [RavenTheory(RavenTestCategory.Indexes)]
+        [RavenData(SearchEngineMode = RavenSearchEngineMode.All)]
+        public void CanQueryDocumentsIndexWithCharLiteral(Options options)
         {
-            using (var store = GetDocumentStore())
+            using (var store = GetDocumentStore(options))
             {
                 store.Maintenance.Send(new PutIndexesOperation(new[] {new IndexDefinition
                 {
@@ -25,7 +27,7 @@ namespace SlowTests.Bugs.Indexing
                     Fields = { { "SortVersion", new IndexFieldOptions { Storage = FieldStorage.Yes } } },
                     Name = "test"
                 }}));
-
+                
                 using (var s = store.OpenSession())
                 {
                     var entity = new { Version = "1" };

--- a/test/SlowTests/Bugs/Indexing/ComplexLinq.cs
+++ b/test/SlowTests/Bugs/Indexing/ComplexLinq.cs
@@ -3,6 +3,7 @@ using FastTests;
 using Xunit;
 using System.Linq;
 using Xunit.Abstractions;
+using Tests.Infrastructure;
 
 namespace SlowTests.Bugs.Indexing
 {
@@ -12,10 +13,11 @@ namespace SlowTests.Bugs.Indexing
         {
         }
 
-        [Fact]
-        public void QueryOnNegation()
+        [RavenTheory(RavenTestCategory.Querying)]
+        [RavenData(SearchEngineMode = RavenSearchEngineMode.All)]
+        public void QueryOnNegation(Options options)
         {
-            using (var store = GetDocumentStore())
+            using (var store = GetDocumentStore(options))
             {
                 using (var session = store.OpenSession())
                 {

--- a/test/SlowTests/Bugs/Indexing/CreateIndexesOnRemoteServer.cs
+++ b/test/SlowTests/Bugs/Indexing/CreateIndexesOnRemoteServer.cs
@@ -6,6 +6,7 @@ using Raven.Client.ServerWide;
 using Raven.Client.ServerWide.Operations;
 using Xunit;
 using Xunit.Abstractions;
+using Tests.Infrastructure;
 
 namespace SlowTests.Bugs.Indexing
 {
@@ -15,8 +16,9 @@ namespace SlowTests.Bugs.Indexing
         {
         }
 
-        [Fact]
-        public void CanCreateIndex()
+        [RavenTheory(RavenTestCategory.Indexes)]
+        [RavenData(SearchEngineMode = RavenSearchEngineMode.All)]
+        public void CanCreateIndex(Options options)
         {
             DoNotReuseServer();
             const string name = "CreateIndexesOnRemoteServer_1";

--- a/test/SlowTests/Bugs/Indexing/DataContracts.cs
+++ b/test/SlowTests/Bugs/Indexing/DataContracts.cs
@@ -4,6 +4,7 @@ using FastTests;
 using Xunit;
 using System.Linq;
 using Xunit.Abstractions;
+using Tests.Infrastructure;
 
 namespace SlowTests.Bugs.Indexing
 {
@@ -13,10 +14,12 @@ namespace SlowTests.Bugs.Indexing
         {
         }
 
-        [Fact]
-        public void RespectsNameOnDataMemberAttribute()
+
+        [RavenTheory(RavenTestCategory.Indexes)]
+        [RavenData(SearchEngineMode = RavenSearchEngineMode.All)]
+        public void RespectsNameOnDataMemberAttribute(Options options)
         {
-            using (var store = GetDocumentStore())
+            using (var store = GetDocumentStore(options))
             {
                 using (var session = store.OpenSession())
                 {
@@ -36,10 +39,11 @@ namespace SlowTests.Bugs.Indexing
             }
         }
 
-        [Fact]
-        public void RespectsNameOnDataMemberAttributeWithNestedCollection()
+        [RavenTheory(RavenTestCategory.Indexes)]
+        [RavenData(SearchEngineMode = RavenSearchEngineMode.All)]
+        public void RespectsNameOnDataMemberAttributeWithNestedCollection(Options options)
         {
-            using (var store = GetDocumentStore())
+            using (var store = GetDocumentStore(options))
             {
                 using (var session = store.OpenSession())
                 {

--- a/test/SlowTests/Bugs/Indexing/FilterOnMissingProperty.cs
+++ b/test/SlowTests/Bugs/Indexing/FilterOnMissingProperty.cs
@@ -5,6 +5,7 @@ using Raven.Client.Documents.Indexes;
 using Raven.Client.Documents.Operations.Indexes;
 using Xunit;
 using Xunit.Abstractions;
+using Tests.Infrastructure;
 
 namespace SlowTests.Bugs.Indexing
 {
@@ -14,8 +15,9 @@ namespace SlowTests.Bugs.Indexing
         {
         }
 
-        [Fact]
-        public async Task CanFilter()
+        [RavenTheory(RavenTestCategory.Indexes)]
+        [RavenData(SearchEngineMode = RavenSearchEngineMode.All)]
+        public async Task CanFilter(Options options)
         {
             using (var store = GetDocumentStore())
             {

--- a/test/SlowTests/Bugs/Indexing/IndexBuilderShouldCastNull.cs
+++ b/test/SlowTests/Bugs/Indexing/IndexBuilderShouldCastNull.cs
@@ -16,8 +16,7 @@ namespace SlowTests.Bugs.Indexing
         }
 
         [Theory]
-        [RavenData(SearchEngineMode = RavenSearchEngineMode.Lucene)]
-        [RavenData(SearchEngineMode = RavenSearchEngineMode.Corax, Skip = "RavenDB-17966")]
+        [RavenData(SearchEngineMode = RavenSearchEngineMode.All)]
         public void ShouldCastNullToThePropertyType(Options options)
         {
             using (var store = GetDocumentStore(options))
@@ -27,8 +26,7 @@ namespace SlowTests.Bugs.Indexing
         }
 
         [Theory]
-        [RavenData(SearchEngineMode = RavenSearchEngineMode.Lucene)]
-        [RavenData(SearchEngineMode = RavenSearchEngineMode.Corax, Skip = "RavenDB-17966")]
+        [RavenData(SearchEngineMode = RavenSearchEngineMode.All)]
         public void ShouldWorkAlsoWithAnonymousResultTypeWhichRequiredExplicitlyCast(Options options)
         {
             using (var store = GetDocumentStore(options))

--- a/test/SlowTests/Bugs/Indexing/IndexingOnDictionary.cs
+++ b/test/SlowTests/Bugs/Indexing/IndexingOnDictionary.cs
@@ -9,6 +9,7 @@ using FastTests;
 using Xunit;
 using System.Linq;
 using Xunit.Abstractions;
+using Tests.Infrastructure;
 
 namespace SlowTests.Bugs.Indexing
 {
@@ -18,10 +19,11 @@ namespace SlowTests.Bugs.Indexing
         {
         }
 
-        [Fact]
-        public void CanIndexValuesForDictionary()
+        [RavenTheory(RavenTestCategory.Indexes)]
+        [RavenData(SearchEngineMode = RavenSearchEngineMode.All)]
+        public void CanIndexValuesForDictionary(Options options)
         {
-            using (var store = GetDocumentStore())
+            using (var store = GetDocumentStore(options))
             {
                 using (var s = store.OpenSession())
                 {
@@ -46,10 +48,11 @@ namespace SlowTests.Bugs.Indexing
             }
         }
 
-        [Fact]
-        public void CanIndexValuesForDictionaryAsPartOfDictionary()
+        [RavenTheory(RavenTestCategory.Indexes)]
+        [RavenData(SearchEngineMode = RavenSearchEngineMode.All)]
+        public void CanIndexValuesForDictionaryAsPartOfDictionary(Options options)
         {
-            using (var store = GetDocumentStore())
+            using (var store = GetDocumentStore(options))
             {
                 using (var s = store.OpenSession())
                 {
@@ -60,7 +63,7 @@ namespace SlowTests.Bugs.Indexing
                                                     {"Color", "Red"}
                                                 }
                     });
-
+                    
                     s.SaveChanges();
                 }
 
@@ -77,10 +80,11 @@ namespace SlowTests.Bugs.Indexing
             }
         }
 
-        [Fact]
-        public void CanIndexNestedValuesForDictionaryAsPartOfDictionary()
+        [RavenTheory(RavenTestCategory.Indexes)]
+        [RavenData(SearchEngineMode = RavenSearchEngineMode.All)]
+        public void CanIndexNestedValuesForDictionaryAsPartOfDictionary(Options options)
         {
-            using (var store = GetDocumentStore())
+            using (var store = GetDocumentStore(options))
             {
                 using (var s = store.OpenSession())
                 {
@@ -106,10 +110,11 @@ namespace SlowTests.Bugs.Indexing
             }
         }
 
-        [Fact]
-        public void CanIndexValuesForIDictionaryAsPartOfIDictionary()
+        [RavenTheory(RavenTestCategory.Indexes)]
+        [RavenData(SearchEngineMode = RavenSearchEngineMode.All)]
+        public void CanIndexValuesForIDictionaryAsPartOfIDictionary(Options options)
         {
-            using (var store = GetDocumentStore())
+            using (var store = GetDocumentStore(options))
             {
                 using (var s = store.OpenSession())
                 {
@@ -135,10 +140,11 @@ namespace SlowTests.Bugs.Indexing
             }
         }
 
-        [Fact]
-        public void CanIndexNestedValuesForIDictionaryAsPartOfIDictionary()
+        [RavenTheory(RavenTestCategory.Indexes)]
+        [RavenData(SearchEngineMode = RavenSearchEngineMode.All)]
+        public void CanIndexNestedValuesForIDictionaryAsPartOfIDictionary(Options options)
         {
-            using (var store = GetDocumentStore())
+            using (var store = GetDocumentStore(options))
             {
                 using (var s = store.OpenSession())
                 {
@@ -164,10 +170,11 @@ namespace SlowTests.Bugs.Indexing
             }
         }
 
-        [Fact]
-        public void CanIndexValuesForDictionaryWithNumberForIndex()
+        [RavenTheory(RavenTestCategory.Indexes)]
+        [RavenData(SearchEngineMode = RavenSearchEngineMode.All)]
+        public void CanIndexValuesForDictionaryWithNumberForIndex(Options options)
         {
-            using (var store = GetDocumentStore())
+            using (var store = GetDocumentStore(options))
             {
                 using (var s = store.OpenSession())
                 {

--- a/test/SlowTests/Bugs/Indexing/InvalidIndexes.cs
+++ b/test/SlowTests/Bugs/Indexing/InvalidIndexes.cs
@@ -4,6 +4,7 @@ using Raven.Client.Documents.Operations.Indexes;
 using Raven.Client.Exceptions.Documents.Compilation;
 using Xunit;
 using Xunit.Abstractions;
+using Tests.Infrastructure;
 
 namespace SlowTests.Bugs.Indexing
 {
@@ -13,10 +14,11 @@ namespace SlowTests.Bugs.Indexing
         {
         }
 
-        [Fact]
-        public void CannotCreateIndexesUsingDateTimeNow()
+        [RavenTheory(RavenTestCategory.Indexes)]
+        [RavenData(SearchEngineMode = RavenSearchEngineMode.All)]
+        public void CannotCreateIndexesUsingDateTimeNow(Options options)
         {
-            using (var store = GetDocumentStore())
+            using (var store = GetDocumentStore(options))
             {
                 var ioe = Assert.Throws<IndexCompilationException>(() =>
                     store.Maintenance.Send(new PutIndexesOperation(new IndexDefinition
@@ -32,8 +34,9 @@ namespace SlowTests.Bugs.Indexing
             }
         }
 
-        [Fact]
-        public void CannotCreateIndexWithOrderBy()
+        [RavenTheory(RavenTestCategory.Indexes)]
+        [RavenData(SearchEngineMode = RavenSearchEngineMode.All)]
+        public void CannotCreateIndexWithOrderBy(Options options)
         {
             using (var store = GetDocumentStore())
             {

--- a/test/SlowTests/Bugs/Indexing/MissingAnalyzer.cs
+++ b/test/SlowTests/Bugs/Indexing/MissingAnalyzer.cs
@@ -10,6 +10,7 @@ using Raven.Client.Documents.Operations.Indexes;
 using Raven.Client.Exceptions.Documents.Compilation;
 using Xunit;
 using Xunit.Abstractions;
+using Tests.Infrastructure;
 
 namespace SlowTests.Bugs.Indexing
 {
@@ -19,10 +20,11 @@ namespace SlowTests.Bugs.Indexing
         {
         }
 
-        [Fact]
-        public void Should_give_clear_error_when_starting()
+        [RavenTheory(RavenTestCategory.Indexes)]
+        [RavenData(SearchEngineMode = RavenSearchEngineMode.All)]
+        public void Should_give_clear_error_when_starting(Options options)
         {
-            using (var store = GetDocumentStore())
+            using (var store = GetDocumentStore(options))
             {
                 var e = Assert.Throws<IndexCompilationException>(() => store.Maintenance.Send(new PutIndexesOperation(new IndexDefinition
                 {

--- a/test/SlowTests/Bugs/Indexing/RemoteIndexingOnDictionary.cs
+++ b/test/SlowTests/Bugs/Indexing/RemoteIndexingOnDictionary.cs
@@ -3,6 +3,7 @@ using System.Linq;
 using FastTests;
 using Xunit;
 using Xunit.Abstractions;
+using Tests.Infrastructure;
 
 namespace SlowTests.Bugs.Indexing
 {
@@ -12,10 +13,11 @@ namespace SlowTests.Bugs.Indexing
         {
         }
 
-        [Fact]
-        public void CanIndexOnRangeForNestedValuesForDictionaryAsPartOfDictionary()
+        [RavenTheory(RavenTestCategory.Indexes)]
+        [RavenData(SearchEngineMode = RavenSearchEngineMode.All)]
+        public void CanIndexOnRangeForNestedValuesForDictionaryAsPartOfDictionary(Options options)
         {
-            using (var store = GetDocumentStore())
+            using (var store = GetDocumentStore(options))
             {
                 using (var s = store.OpenSession())
                 {

--- a/test/SlowTests/Bugs/Indexing/SetIndexPriority.cs
+++ b/test/SlowTests/Bugs/Indexing/SetIndexPriority.cs
@@ -34,7 +34,7 @@ namespace SlowTests.Bugs.Indexing
             }
         }
 
-        [Theory]
+        [RavenTheory(RavenTestCategory.Indexes)]
         [RavenData(SearchEngineMode = RavenSearchEngineMode.All)]
         public async Task changing_index_priority_needs_to_set_it_on_index_instance_as_well(Options options)
         {
@@ -54,9 +54,8 @@ namespace SlowTests.Bugs.Indexing
             }
         }
 
-        [Theory]
-        [RavenData(SearchEngineMode = RavenSearchEngineMode.Lucene)]
-        [RavenData(SearchEngineMode = RavenSearchEngineMode.Corax, Skip = "RavenDB-17966")]
+        [RavenTheory(RavenTestCategory.Indexes)]
+        [RavenData(SearchEngineMode = RavenSearchEngineMode.All)]
         public void set_auto_index_priority(Options options)
         {
             using (var store = GetDocumentStore(options))

--- a/test/SlowTests/Bugs/Indexing/ThrowingAnalyzer.cs
+++ b/test/SlowTests/Bugs/Indexing/ThrowingAnalyzer.cs
@@ -17,6 +17,7 @@ using Raven.Client.Documents.Operations;
 using Raven.Client.Documents.Operations.Indexes;
 using Raven.Client.Exceptions;
 using Xunit.Abstractions;
+using Tests.Infrastructure;
 
 namespace SlowTests.Bugs.Indexing
 {
@@ -37,12 +38,13 @@ namespace SlowTests.Bugs.Indexing
             public bool Active { get; set; }
         }
 
-        [Fact]
-        public async Task Should_give_clear_error()
+        [RavenTheory(RavenTestCategory.Indexes)]
+        [RavenData(SearchEngineMode = RavenSearchEngineMode.All)]
+        public async Task Should_give_clear_error(Options options)
         {
             var fieldOptions = new IndexFieldOptions { Analyzer = typeof(ThrowingAnalyzerImpl).AssemblyQualifiedName };
-
-            using (var store = GetDocumentStore())
+            
+            using (var store = GetDocumentStore(options))
             {
                 store.Maintenance.Send(new PutIndexesOperation(new[] {
                                                 new IndexDefinition
@@ -58,7 +60,7 @@ namespace SlowTests.Bugs.Indexing
                     session.SaveChanges();
                 }
 
-
+                
                 using (var session = store.OpenSession())
                 {
                     Assert.Throws<RavenException>(() =>
@@ -82,12 +84,13 @@ namespace SlowTests.Bugs.Indexing
             }
         }
 
-        [Fact]
-        public async Task Should_disable_index()
+        [RavenTheory(RavenTestCategory.Indexes)]
+        [RavenData(SearchEngineMode = RavenSearchEngineMode.All)]
+        public async Task Should_disable_index(Options options)
         {
             var fieldOptions = new IndexFieldOptions { Analyzer = typeof(ThrowingAnalyzerImpl).AssemblyQualifiedName };
 
-            using (var store = GetDocumentStore())
+            using (var store = GetDocumentStore(options))
             {
                 store.Maintenance.Send(new PutIndexesOperation(new[] {
                     new IndexDefinition

--- a/test/SlowTests/Bugs/Indexing/TransactionIndexByMrn.cs
+++ b/test/SlowTests/Bugs/Indexing/TransactionIndexByMrn.cs
@@ -27,7 +27,7 @@ namespace SlowTests.Bugs.Indexing
             }
         }
 
-        [Theory]
+        [RavenTheory(RavenTestCategory.Indexes)]
         [RavenData(SearchEngineMode = RavenSearchEngineMode.All)]
         public void CanCreateIndex(Options options)
         {

--- a/test/SlowTests/Bugs/Indexing/WillRemoveTypesThatNotExistsOnTheServer.cs
+++ b/test/SlowTests/Bugs/Indexing/WillRemoveTypesThatNotExistsOnTheServer.cs
@@ -13,7 +13,7 @@ namespace SlowTests.Bugs.Indexing
         {
         }
 
-        [Theory]
+        [RavenTheory(RavenTestCategory.Indexes)]
         [RavenData(SearchEngineMode = RavenSearchEngineMode.All)]
         public void CanQueryAStronglyTypedIndex(Options options)
         {

--- a/test/SlowTests/Bugs/Indexing/WiseShrek.cs
+++ b/test/SlowTests/Bugs/Indexing/WiseShrek.cs
@@ -6,6 +6,7 @@ using Raven.Client.Documents.Indexes;
 using Raven.Client.Documents.Operations.Indexes;
 using Xunit;
 using Xunit.Abstractions;
+using Tests.Infrastructure;
 
 namespace SlowTests.Bugs.Indexing
 {
@@ -65,10 +66,11 @@ namespace SlowTests.Bugs.Indexing
             //}
         }
 
-        [Fact]
-        public void UsingKeywordAnalyzing()
+        [RavenTheory(RavenTestCategory.Indexes)]
+        [RavenData(SearchEngineMode = RavenSearchEngineMode.All)]
+        public void UsingKeywordAnalyzing(Options options)
         {
-            using (var store = GetDocumentStore())
+            using (var store = GetDocumentStore(options))
             using (var session = store.OpenSession())
             {
                 var fieldOptions1 = new IndexFieldOptions { Indexing = FieldIndexing.Exact };

--- a/test/SlowTests/Bugs/Indexing/WithStartWith.cs
+++ b/test/SlowTests/Bugs/Indexing/WithStartWith.cs
@@ -4,6 +4,7 @@ using System.Linq;
 using Raven.Client.Documents.Indexes;
 using Raven.Client.Documents.Operations.Indexes;
 using Xunit.Abstractions;
+using Tests.Infrastructure;
 
 namespace SlowTests.Bugs.Indexing
 {
@@ -13,10 +14,11 @@ namespace SlowTests.Bugs.Indexing
         {
         }
 
-        [Fact]
-        public void CanQueryDocumentsFilteredByMap()
+        [RavenTheory(RavenTestCategory.Indexes)]
+        [RavenData(SearchEngineMode = RavenSearchEngineMode.All)]
+        public void CanQueryDocumentsFilteredByMap(Options options)
         {
-            using (var store = GetDocumentStore())
+            using (var store = GetDocumentStore(options))
             {
                 store.Maintenance.Send(new PutIndexesOperation(new[] {
                     new IndexDefinition

--- a/test/SlowTests/Bugs/Indexing/WithStringReverse.cs
+++ b/test/SlowTests/Bugs/Indexing/WithStringReverse.cs
@@ -7,6 +7,7 @@ using Raven.Client.Documents.Operations.Indexes;
 using Raven.Client.Documents.Session;
 using Xunit;
 using Xunit.Abstractions;
+using Tests.Infrastructure;
 
 namespace SlowTests.Bugs.Indexing
 {
@@ -32,10 +33,11 @@ namespace SlowTests.Bugs.Indexing
             public string ReverseName { get; set; }
         }
 
-        [Fact]
-        public async Task GivenSomeUsers_QueryWithAnIndex_ReturnsUsersWithNamesReversed()
+        [RavenTheory(RavenTestCategory.Indexes)]
+        [RavenData(SearchEngineMode = RavenSearchEngineMode.All)]
+        public async Task GivenSomeUsers_QueryWithAnIndex_ReturnsUsersWithNamesReversed(Options options)
         {
-            using (var store = GetDocumentStore())
+            using (var store = GetDocumentStore(options))
             {
                 store.Maintenance.Send(new PutIndexesOperation(new[] {
                     new IndexDefinition
@@ -73,10 +75,11 @@ namespace SlowTests.Bugs.Indexing
             }
         }
 
-        [Fact]
-        public async Task CanQueryInReverse()
+        [RavenTheory(RavenTestCategory.Indexes)]
+        [RavenData(SearchEngineMode = RavenSearchEngineMode.All)]
+        public async Task CanQueryInReverse(Options options)
         {
-            using (var store = GetDocumentStore())
+            using (var store = GetDocumentStore(options))
             {
                 store.Maintenance.Send(new PutIndexesOperation(new[] {
                     new IndexDefinition

--- a/test/SlowTests/Bugs/Iulian/CanReadEntityWithUrlId.cs
+++ b/test/SlowTests/Bugs/Iulian/CanReadEntityWithUrlId.cs
@@ -2,6 +2,7 @@
 using FastTests;
 using Xunit;
 using Xunit.Abstractions;
+using Tests.Infrastructure;
 
 namespace SlowTests.Bugs.Iulian
 {
@@ -17,13 +18,14 @@ namespace SlowTests.Bugs.Iulian
             public string Tag { get; set; }
         }
 
-        [Fact]
-        public void Can_Load_entities_with_id_containing_url()
+        [RavenTheory(RavenTestCategory.Querying)]
+        [RavenData(SearchEngineMode = RavenSearchEngineMode.All)]
+        public void Can_Load_entities_with_id_containing_url(Options options)
         {
             var id = @"mssage@msmq://local/Sample.AppService";
 
             DoNotReuseServer();
-            using (var store = GetDocumentStore())
+            using (var store = GetDocumentStore(options))
             {
                 using (var s = store.OpenSession())
                 {

--- a/test/SlowTests/Bugs/Iulian/GeneratesCorrectTemporaryIndex.cs
+++ b/test/SlowTests/Bugs/Iulian/GeneratesCorrectTemporaryIndex.cs
@@ -2,6 +2,7 @@
 using System.Linq;
 using Xunit;
 using Xunit.Abstractions;
+using Tests.Infrastructure;
 
 namespace SlowTests.Bugs.Iulian
 {
@@ -21,10 +22,11 @@ namespace SlowTests.Bugs.Iulian
             public Inner Inner { get; set; }
         }
 
-        [Fact]
-        public void Can_Generate_Correct_Temporary_Index()
+        [RavenTheory(RavenTestCategory.Querying)]
+        [RavenData(SearchEngineMode = RavenSearchEngineMode.All)]
+        public void Can_Generate_Correct_Temporary_Index(Options options)
         {
-            using (var store = GetDocumentStore())
+            using (var store = GetDocumentStore(options))
             {
                 using (var s = store.OpenSession())
                 {

--- a/test/SlowTests/Bugs/LiveProjections/LiveProjectionOnProducts.cs
+++ b/test/SlowTests/Bugs/LiveProjections/LiveProjectionOnProducts.cs
@@ -5,6 +5,7 @@ using Raven.Client.Documents;
 using Raven.Client.Documents.Indexes;
 using Xunit;
 using Xunit.Abstractions;
+using Tests.Infrastructure;
 
 namespace SlowTests.Bugs.LiveProjections
 {
@@ -14,12 +15,13 @@ namespace SlowTests.Bugs.LiveProjections
         {
         }
 
-        [Fact]
-        public void ComplexLiveProjection()
+        [RavenTheory(RavenTestCategory.Querying)]
+        [RavenData(SearchEngineMode = RavenSearchEngineMode.All)]
+        public void ComplexLiveProjection(Options options)
         {
-            using (var documentStore = GetDocumentStore())
+            using (var documentStore = GetDocumentStore(options))
             {
-                new ProductDetailsReport_ByProductId().Execute((IDocumentStore)documentStore);
+                new ProductDetailsReport_ByProductId().Execute(documentStore);
 
                 using (var session = documentStore.OpenSession())
                 {

--- a/test/SlowTests/Bugs/PoisonIndexes/PoisonIndex.cs
+++ b/test/SlowTests/Bugs/PoisonIndexes/PoisonIndex.cs
@@ -12,8 +12,8 @@ namespace SlowTests.Bugs.PoisonIndexes
         {
         }
 
-        [Theory]
-        [RavenData]
+        [RavenTheory(RavenTestCategory.Indexes)]
+        [RavenData(SearchEngineMode = RavenSearchEngineMode.All)]
         public void ShouldNotCauseFailures(Options options)
         {
             using (var store = GetDocumentStore(options))

--- a/test/SlowTests/Bugs/Queries/Boolean.cs
+++ b/test/SlowTests/Bugs/Queries/Boolean.cs
@@ -2,6 +2,7 @@
 using Xunit;
 using System.Linq;
 using Xunit.Abstractions;
+using Tests.Infrastructure;
 
 namespace SlowTests.Bugs.Queries
 {
@@ -11,10 +12,11 @@ namespace SlowTests.Bugs.Queries
         {
         }
 
-        [Fact]
-        public void CanQueryOnNegation()
+        [RavenTheory(RavenTestCategory.Querying)]
+        [RavenData(SearchEngineMode = RavenSearchEngineMode.All)]
+        public void CanQueryOnNegation(Options options)
         {
-            using(var store = GetDocumentStore())
+            using(var store = GetDocumentStore(options))
             {
                 using(var s = store.OpenSession())
                 {

--- a/test/SlowTests/Bugs/Queries/DynamicQueriesOnMetadata.cs
+++ b/test/SlowTests/Bugs/Queries/DynamicQueriesOnMetadata.cs
@@ -2,6 +2,7 @@
 using FastTests;
 using Xunit;
 using Xunit.Abstractions;
+using Tests.Infrastructure;
 
 namespace SlowTests.Bugs.Queries
 {
@@ -11,10 +12,11 @@ namespace SlowTests.Bugs.Queries
         {
         }
 
-        [Fact]
-        public void CanQueryOnMetadataUsingDynamicQueries()
+        [RavenTheory(RavenTestCategory.Querying)]
+        [RavenData(SearchEngineMode = RavenSearchEngineMode.All)]
+        public void CanQueryOnMetadataUsingDynamicQueries(Options options)
         {
-            using (var store = GetDocumentStore())
+            using (var store = GetDocumentStore(options))
             {
                 using (var s = store.OpenSession())
                 {

--- a/test/SlowTests/Bugs/Queries/Fetching.cs
+++ b/test/SlowTests/Bugs/Queries/Fetching.cs
@@ -14,8 +14,8 @@ namespace SlowTests.Bugs.Queries
         {
         }
 
-        [Theory]
-        [RavenData]
+        [RavenTheory(RavenTestCategory.Querying)]
+        [RavenData(SearchEngineMode = RavenSearchEngineMode.All)]
         public void CanFetchMultiplePropertiesFromCollection(Options options)
         {
             using (var store = GetDocumentStore(options))

--- a/test/SlowTests/Bugs/Queries/LuceneQueryCustomMetadata.cs
+++ b/test/SlowTests/Bugs/Queries/LuceneQueryCustomMetadata.cs
@@ -2,6 +2,7 @@
 using FastTests;
 using Xunit;
 using Xunit.Abstractions;
+using Tests.Infrastructure;
 
 namespace SlowTests.Bugs.Queries
 {
@@ -13,10 +14,11 @@ namespace SlowTests.Bugs.Queries
 
         private const string PropertyName = "MyCustomProperty";
 
-        [Fact]
-        public void SuccessTest1()
+        [RavenTheory(RavenTestCategory.Querying)]
+        [RavenData(SearchEngineMode = RavenSearchEngineMode.All)]
+        public void SuccessTest1(Options options)
         {
-            using (var documentStore = GetDocumentStore())
+            using (var documentStore = GetDocumentStore(options))
             {
                 dynamic expando = new ExpandoObject();
 
@@ -41,10 +43,11 @@ namespace SlowTests.Bugs.Queries
             }
         }
 
-        [Fact]
-        public void SuccessTest2()
+        [RavenTheory(RavenTestCategory.Querying)]
+        [RavenData(SearchEngineMode = RavenSearchEngineMode.All)]
+        public void SuccessTest2(Options options)
         {
-            using (var documentStore = GetDocumentStore())
+            using (var documentStore = GetDocumentStore(options))
             {
                 dynamic expando = new ExpandoObject();
 
@@ -71,10 +74,11 @@ namespace SlowTests.Bugs.Queries
             }
         }
 
-        [Fact]
-        public void FailureTest()
+        [RavenTheory(RavenTestCategory.Querying)]
+        [RavenData(SearchEngineMode = RavenSearchEngineMode.All)]
+        public void FailureTest(Options options)
         {
-            using (var documentStore = GetDocumentStore())
+            using (var documentStore = GetDocumentStore(options))
             {
                 dynamic expando = new ExpandoObject();
 

--- a/test/SlowTests/Bugs/Queries/NameStartsWith.cs
+++ b/test/SlowTests/Bugs/Queries/NameStartsWith.cs
@@ -13,7 +13,7 @@ namespace SlowTests.Bugs.Queries
         {
         }
 
-        [Theory]
+        [RavenTheory(RavenTestCategory.Querying)]
         [RavenData(SearchEngineMode = RavenSearchEngineMode.All)]
         public void can_search_for_mrs_shaba(Options options)
         {

--- a/test/SlowTests/Bugs/Queries/NameStartsWith.cs
+++ b/test/SlowTests/Bugs/Queries/NameStartsWith.cs
@@ -1,6 +1,7 @@
 ﻿using System.Linq;
 using FastTests;
 using Raven.Client.Documents.Indexes;
+using Tests.Infrastructure;
 using Xunit;
 using Xunit.Abstractions;
 
@@ -12,13 +13,14 @@ namespace SlowTests.Bugs.Queries
         {
         }
 
-        [Fact]
-        public void can_search_for_mrs_shaba()
+        [Theory]
+        [RavenData(SearchEngineMode = RavenSearchEngineMode.All)]
+        public void can_search_for_mrs_shaba(Options options)
         {
-            using (var documentStore = GetDocumentStore())
+            using (var documentStore = GetDocumentStore(options))
             {
                 new User_Entity().Execute(documentStore);
-
+                
                 using (var session = documentStore.OpenSession())
                 {
                     var user1 = new User { Id = @"user/111", Name = "King Shaba" };

--- a/test/SlowTests/Bugs/Queries/QueryByTypeOnly.cs
+++ b/test/SlowTests/Bugs/Queries/QueryByTypeOnly.cs
@@ -13,8 +13,8 @@ namespace SlowTests.Bugs.Queries
         {
         }
 
-        [Theory]
-        [RavenData(SearchEngineMode = RavenSearchEngineMode.Lucene)]
+        [RavenTheory(RavenTestCategory.Querying)]
+        [RavenData(SearchEngineMode = RavenSearchEngineMode.All)]
         public void QueryOnlyByType(Options options)
         {
             using (var store = GetDocumentStore(options))

--- a/test/SlowTests/Bugs/Queries/QueryByTypeOnly.cs
+++ b/test/SlowTests/Bugs/Queries/QueryByTypeOnly.cs
@@ -1,6 +1,7 @@
 ﻿using System.Linq;
 using FastTests;
 using Raven.Client.Documents.Linq;
+using Tests.Infrastructure;
 using Xunit;
 using Xunit.Abstractions;
 
@@ -12,10 +13,11 @@ namespace SlowTests.Bugs.Queries
         {
         }
 
-        [Fact]
-        public void QueryOnlyByType()
+        [Theory]
+        [RavenData(SearchEngineMode = RavenSearchEngineMode.Lucene)]
+        public void QueryOnlyByType(Options options)
         {
-            using (var store = GetDocumentStore())
+            using (var store = GetDocumentStore(options))
             {
                 using (var session = store.OpenSession())
                 {

--- a/test/SlowTests/Bugs/Queries/QueryProvider.cs
+++ b/test/SlowTests/Bugs/Queries/QueryProvider.cs
@@ -16,7 +16,7 @@ namespace SlowTests.Bugs.Queries
         {
         }
 
-        [Theory]
+        [RavenTheory(RavenTestCategory.Querying)]
         [RavenData(SearchEngineMode = RavenSearchEngineMode.All)]
         public void CanCreateQuery(Options options)
         {

--- a/test/SlowTests/Bugs/Queries/QueryWithPercentageSign.cs
+++ b/test/SlowTests/Bugs/Queries/QueryWithPercentageSign.cs
@@ -10,6 +10,7 @@ using Raven.Client.Documents.Indexes;
 using Raven.Client.Documents.Operations.Indexes;
 using Xunit;
 using Xunit.Abstractions;
+using Tests.Infrastructure;
 
 namespace SlowTests.Bugs.Queries
 {
@@ -19,10 +20,11 @@ namespace SlowTests.Bugs.Queries
         {
         }
 
-        [Fact]
-        public void CanQueryUsingPercentageSign()
+        [RavenTheory(RavenTestCategory.Querying)]
+        [RavenData(SearchEngineMode = RavenSearchEngineMode.All)]
+        public void CanQueryUsingPercentageSign(Options options)
         {
-            using (var store = GetDocumentStore())
+            using (var store = GetDocumentStore(options))
             {
                 store.Maintenance.Send(new PutIndexesOperation(new IndexDefinition
                 {

--- a/test/SlowTests/Bugs/Queries/QueryingByNegative.cs
+++ b/test/SlowTests/Bugs/Queries/QueryingByNegative.cs
@@ -10,6 +10,7 @@ using Raven.Client.Documents.Indexes;
 using Raven.Client.Documents.Operations.Indexes;
 using Xunit;
 using Xunit.Abstractions;
+using Tests.Infrastructure;
 
 namespace SlowTests.Bugs.Queries
 {
@@ -19,10 +20,12 @@ namespace SlowTests.Bugs.Queries
         {
         }
 
-        [Fact]
-        public void CanQueryByNullUsingLinq()
+
+        [RavenTheory(RavenTestCategory.Querying)]
+        [RavenData(SearchEngineMode = RavenSearchEngineMode.All)]
+        public void CanQueryByNullUsingLinq(Options options)
         {
-            using (var store = GetDocumentStore())
+            using (var store = GetDocumentStore(options))
             {
                 using (var session = store.OpenSession())
                 {

--- a/test/SlowTests/Bugs/Queries/QueryingByNull.cs
+++ b/test/SlowTests/Bugs/Queries/QueryingByNull.cs
@@ -21,7 +21,7 @@ namespace SlowTests.Bugs.Queries
         {
         }
 
-        [Theory]
+        [RavenTheory(RavenTestCategory.Querying)]
         [RavenData(SearchEngineMode = RavenSearchEngineMode.All)]
         public void CanQueryByNullUsingLinq(Options options)
         {

--- a/test/SlowTests/Bugs/Queries/QueryingByNull.cs
+++ b/test/SlowTests/Bugs/Queries/QueryingByNull.cs
@@ -22,7 +22,7 @@ namespace SlowTests.Bugs.Queries
         }
 
         [Theory]
-        [RavenData]
+        [RavenData(SearchEngineMode = RavenSearchEngineMode.All)]
         public void CanQueryByNullUsingLinq(Options options)
         {
             using (var store = GetDocumentStore(options))

--- a/test/SlowTests/Bugs/Queries/QueryingDateTime.cs
+++ b/test/SlowTests/Bugs/Queries/QueryingDateTime.cs
@@ -5,6 +5,7 @@ using FastTests;
 using Sparrow;
 using Xunit;
 using Xunit.Abstractions;
+using Tests.Infrastructure;
 
 namespace SlowTests.Bugs.Queries
 {
@@ -14,10 +15,11 @@ namespace SlowTests.Bugs.Queries
         {
         }
 
-        [Fact]
-        public void QueryingNonUtcTime()
+        [RavenTheory(RavenTestCategory.Querying)]
+        [RavenData(SearchEngineMode = RavenSearchEngineMode.All)]
+        public void QueryingNonUtcTime(Options options)
         {
-            using (var store = GetDocumentStore())
+            using (var store = GetDocumentStore(options))
             {
                 var dateTime1 = DateTime.ParseExact("2011-04-08T22:00:00.0000000+02:00", DefaultFormat.DateTimeFormatsToRead, CultureInfo.InvariantCulture, DateTimeStyles.RoundtripKind);
                 var dateTime2 = dateTime1.AddHours(-2);

--- a/test/SlowTests/Bugs/Queries/QueryingFromIndex.cs
+++ b/test/SlowTests/Bugs/Queries/QueryingFromIndex.cs
@@ -10,6 +10,7 @@ using Raven.Client.Documents.Indexes;
 using Raven.Client.Documents.Operations.Indexes;
 using Xunit;
 using Xunit.Abstractions;
+using Tests.Infrastructure;
 
 namespace SlowTests.Bugs.Queries
 {
@@ -19,10 +20,11 @@ namespace SlowTests.Bugs.Queries
         {
         }
 
-        [Fact]
-        public void LuceneQueryWithIndexIsCaseInsensitive()
+        [RavenTheory(RavenTestCategory.Querying)]
+        [RavenData(SearchEngineMode = RavenSearchEngineMode.All)]
+        public void LuceneQueryWithIndexIsCaseInsensitive(Options options)
         {
-            using (var store = GetDocumentStore())
+            using (var store = GetDocumentStore(options))
             {
                 var definition = new IndexDefinitionBuilder<Company>("CompanyByName")
                 {
@@ -56,10 +58,11 @@ namespace SlowTests.Bugs.Queries
             }
         }
 
-        [Fact]
-        public void LinqQueryWithIndexIsCaseInsensitive()
+        [Theory]
+        [RavenData(SearchEngineMode = RavenSearchEngineMode.All)]
+        public void LinqQueryWithIndexIsCaseInsensitive(Options options)
         {
-            using (var store = GetDocumentStore())
+            using (var store = GetDocumentStore(options))
             {
                 var definition = new IndexDefinitionBuilder<Company>("CompanyByName")
                 {

--- a/test/SlowTests/Bugs/Queries/QueryingOnEmptyString.cs
+++ b/test/SlowTests/Bugs/Queries/QueryingOnEmptyString.cs
@@ -3,6 +3,7 @@ using FastTests;
 using Raven.Client.Documents.Linq;
 using Xunit;
 using Xunit.Abstractions;
+using Tests.Infrastructure;
 
 namespace SlowTests.Bugs.Queries
 {
@@ -12,10 +13,11 @@ namespace SlowTests.Bugs.Queries
         {
         }
 
-        [Fact]
-        public void ShouldNotSelectAllDocs()
+        [RavenTheory(RavenTestCategory.Querying)]
+        [RavenData(SearchEngineMode = RavenSearchEngineMode.All)]
+        public void ShouldNotSelectAllDocs(Options options)
         {
-            using (var store = GetDocumentStore())
+            using (var store = GetDocumentStore(options))
             {
                 using (var session = store.OpenSession())
                 {
@@ -32,10 +34,11 @@ namespace SlowTests.Bugs.Queries
             }
         }
 
-        [Fact]
-        public void CanFindByemptyStringMatch()
+        [RavenTheory(RavenTestCategory.Querying)]
+        [RavenData(SearchEngineMode = RavenSearchEngineMode.All)]
+        public void CanFindByemptyStringMatch(Options options)
         {
-            using (var store = GetDocumentStore())
+            using (var store = GetDocumentStore(options))
             {
                 using (var session = store.OpenSession())
                 {

--- a/test/SlowTests/Bugs/Queries/QueryingOnEqualToNull.cs
+++ b/test/SlowTests/Bugs/Queries/QueryingOnEqualToNull.cs
@@ -9,6 +9,7 @@ using FastTests;
 using SlowTests.Core.Utils.Entities;
 using Xunit;
 using Xunit.Abstractions;
+using Tests.Infrastructure;
 
 namespace SlowTests.Bugs.Queries
 {
@@ -18,10 +19,11 @@ namespace SlowTests.Bugs.Queries
         {
         }
 
-        [Fact]
-        public void QueryingOnEqNull()
+        [RavenTheory(RavenTestCategory.Querying)]
+        [RavenData(SearchEngineMode = RavenSearchEngineMode.All)]
+        public void QueryingOnEqNull(Options options)
         {
-            using (var store = GetDocumentStore())
+            using (var store = GetDocumentStore(options))
             {
                 using (var s = store.OpenSession())
                 {
@@ -42,10 +44,11 @@ namespace SlowTests.Bugs.Queries
             }
         }
 
-        [Fact]
-        public void QueryingOnEqNotNull()
+        [Theory]
+        [RavenData(SearchEngineMode = RavenSearchEngineMode.All)]
+        public void QueryingOnEqNotNull(Options options)
         {
-            using (var store = GetDocumentStore())
+            using (var store = GetDocumentStore(options))
             {
                 using (var s = store.OpenSession())
                 {

--- a/test/SlowTests/Bugs/Queries/QueryingOnMetadata.cs
+++ b/test/SlowTests/Bugs/Queries/QueryingOnMetadata.cs
@@ -3,6 +3,7 @@ using FastTests;
 using Raven.Tests.Core.Utils.Entities;
 using Xunit;
 using Xunit.Abstractions;
+using Tests.Infrastructure;
 
 namespace SlowTests.Bugs.Queries
 {
@@ -12,10 +13,11 @@ namespace SlowTests.Bugs.Queries
         {
         }
 
-        [Fact]
-        public void CanQueryOnNullableProperty()
+        [RavenTheory(RavenTestCategory.Querying)]
+        [RavenData(SearchEngineMode = RavenSearchEngineMode.All)]
+        public void CanQueryOnNullableProperty(Options options)
         {
-            using (var store = GetDocumentStore())
+            using (var store = GetDocumentStore(options))
             {
                 using (var session = store.OpenSession())
                 {

--- a/test/SlowTests/Bugs/Queries/QueryingOnValueWithMinus.cs
+++ b/test/SlowTests/Bugs/Queries/QueryingOnValueWithMinus.cs
@@ -2,6 +2,7 @@
 using FastTests;
 using Xunit;
 using Xunit.Abstractions;
+using Tests.Infrastructure;
 
 namespace SlowTests.Bugs.Queries
 {
@@ -11,10 +12,11 @@ namespace SlowTests.Bugs.Queries
         {
         }
 
-        [Fact]
-        public void CanQueryOnValuesContainingMinus()
+        [RavenTheory(RavenTestCategory.Querying)]
+        [RavenData(SearchEngineMode = RavenSearchEngineMode.All)]
+        public void CanQueryOnValuesContainingMinus(Options options)
         {
-            using (var store = GetDocumentStore())
+            using (var store = GetDocumentStore(options))
             {
                 using (var session = store.OpenSession())
                 {

--- a/test/SlowTests/Bugs/Queries/QueryingOverTags.cs
+++ b/test/SlowTests/Bugs/Queries/QueryingOverTags.cs
@@ -2,6 +2,7 @@
 using FastTests;
 using Xunit;
 using Xunit.Abstractions;
+using Tests.Infrastructure;
 
 namespace SlowTests.Bugs.Queries
 {
@@ -11,14 +12,15 @@ namespace SlowTests.Bugs.Queries
         {
         }
 
-        [Fact]
-        public void Can_chain_wheres_when_querying_collection_with_any()
+        [RavenTheory(RavenTestCategory.Querying)]
+        [RavenData(SearchEngineMode = RavenSearchEngineMode.All)]
+        public void Can_chain_wheres_when_querying_collection_with_any(Options options)
         {
             var entity = new EntityWithTags
             {
                 Tags = new[] { "FOO", "BAR" }
             };
-            using (var documentStore = GetDocumentStore())
+            using (var documentStore = GetDocumentStore(options))
             {
                 using (var session = documentStore.OpenSession())
                 {

--- a/test/SlowTests/Bugs/Queries/QueryingWithDynamicRavenQueryInspector.cs
+++ b/test/SlowTests/Bugs/Queries/QueryingWithDynamicRavenQueryInspector.cs
@@ -3,6 +3,7 @@ using FastTests;
 using Raven.Client.Documents;
 using Xunit;
 using Xunit.Abstractions;
+using Tests.Infrastructure;
 
 namespace SlowTests.Bugs.Queries
 {
@@ -12,8 +13,10 @@ namespace SlowTests.Bugs.Queries
         {
         }
 
-        [Fact]
-        public void CanInitializeDynamicRavenQueryInspector()
+
+        [RavenTheory(RavenTestCategory.Querying)]
+        [RavenData(SearchEngineMode = RavenSearchEngineMode.All)]
+        public void CanInitializeDynamicRavenQueryInspector(Options options)
         {
             var blogOne = new Blog
             {
@@ -31,7 +34,7 @@ namespace SlowTests.Bugs.Queries
                 Category = "Rhinos"
             };
             
-            using (var store = GetDocumentStore())
+            using (var store = GetDocumentStore(options))
             {
                 using (var s = store.OpenSession())
                 {

--- a/test/SlowTests/Bugs/Queries/RangeQueries.cs
+++ b/test/SlowTests/Bugs/Queries/RangeQueries.cs
@@ -6,6 +6,7 @@ using Raven.Client.Documents.Indexes;
 using Raven.Client.Documents.Operations.Indexes;
 using Xunit;
 using Xunit.Abstractions;
+using Tests.Infrastructure;
 
 namespace SlowTests.Bugs.Queries
 {
@@ -15,10 +16,11 @@ namespace SlowTests.Bugs.Queries
         {
         }
 
-        [Fact]
-        public void LinqTranslateCorrectly()
+        [RavenTheory(RavenTestCategory.Querying)]
+        [RavenData(SearchEngineMode = RavenSearchEngineMode.All)]
+        public void LinqTranslateCorrectly(Options options)
         {
-            using (var store = GetDocumentStore())
+            using (var store = GetDocumentStore(options))
             {
                 using (var session = store.OpenSession())
                 {
@@ -34,10 +36,11 @@ namespace SlowTests.Bugs.Queries
             }
         }
 
-        [Fact]
-        public void LinqTranslateCorrectly_Reverse()
+        [RavenTheory(RavenTestCategory.Querying)]
+        [RavenData(SearchEngineMode = RavenSearchEngineMode.All)]
+        public void LinqTranslateCorrectly_Reverse(Options options)
         {
-            using (var store = GetDocumentStore())
+            using (var store = GetDocumentStore(options))
             {
                 using (var session = store.OpenSession())
                 {
@@ -53,10 +56,11 @@ namespace SlowTests.Bugs.Queries
             }
         }
 
-        [Fact]
-        public void LinqTranslateCorrectly_Reverse2()
+        [RavenTheory(RavenTestCategory.Querying)]
+        [RavenData(SearchEngineMode = RavenSearchEngineMode.All)]
+        public void LinqTranslateCorrectly_Reverse2(Options options)
         {
-            using (var store = GetDocumentStore())
+            using (var store = GetDocumentStore(options))
             {
                 using (var session = store.OpenSession())
                 {
@@ -72,10 +76,11 @@ namespace SlowTests.Bugs.Queries
             }
         }
 
-        [Fact]
-        public void LinqTranslateCorrectlyEquals()
+        [RavenTheory(RavenTestCategory.Querying)]
+        [RavenData(SearchEngineMode = RavenSearchEngineMode.All)]
+        public void LinqTranslateCorrectlyEquals(Options options)
         {
-            using (var store = GetDocumentStore())
+            using (var store = GetDocumentStore(options))
             {
                 using (var session = store.OpenSession())
                 {
@@ -91,10 +96,11 @@ namespace SlowTests.Bugs.Queries
             }
         }
 
-        [Fact]
-        public void CanQueryOnRangeEqualsInt()
+        [RavenTheory(RavenTestCategory.Querying)]
+        [RavenData(SearchEngineMode = RavenSearchEngineMode.All)]
+        public void CanQueryOnRangeEqualsInt(Options options)
         {
-            using (var store = GetDocumentStore())
+            using (var store = GetDocumentStore(options))
             {
                 using (var session = store.OpenSession())
                 {
@@ -112,10 +118,11 @@ namespace SlowTests.Bugs.Queries
             }
         }
 
-        [Fact]
-        public void CanQueryOnRangeEqualsLong()
+        [RavenTheory(RavenTestCategory.Querying)]
+        [RavenData(SearchEngineMode = RavenSearchEngineMode.All)]
+        public void CanQueryOnRangeEqualsLong(Options options)
         {
-            using (var store = GetDocumentStore())
+            using (var store = GetDocumentStore(options))
             {
                 using (var session = store.OpenSession())
                 {
@@ -134,10 +141,11 @@ namespace SlowTests.Bugs.Queries
             }
         }
 
-        [Fact]
-        public void CanQueryOnRangeInt()
+        [RavenTheory(RavenTestCategory.Querying)]
+        [RavenData(SearchEngineMode = RavenSearchEngineMode.All)]
+        public void CanQueryOnRangeInt(Options options)
         {
-            using (var store = GetDocumentStore())
+            using (var store = GetDocumentStore(options))
             {
                 using (var session = store.OpenSession())
                 {
@@ -155,10 +163,11 @@ namespace SlowTests.Bugs.Queries
             }
         }
 
-        [Fact]
-        public void CanQueryOnRangeLong()
+        [RavenTheory(RavenTestCategory.Querying)]
+        [RavenData(SearchEngineMode = RavenSearchEngineMode.All)]
+        public void CanQueryOnRangeLong(Options options)
         {
-            using (var store = GetDocumentStore())
+            using (var store = GetDocumentStore(options))
             {
                 using (var session = store.OpenSession())
                 {
@@ -177,10 +186,11 @@ namespace SlowTests.Bugs.Queries
             }
         }
 
-        [Fact]
-        public void CanQueryOnRangeDoubleAsPartOfIDictionary()
+        [RavenTheory(RavenTestCategory.Querying)]
+        [RavenData(SearchEngineMode = RavenSearchEngineMode.All)]
+        public void CanQueryOnRangeDoubleAsPartOfIDictionary(Options options)
         {
-            using (var store = GetDocumentStore())
+            using (var store = GetDocumentStore(options))
             {
                 store.Maintenance.Send(new PutIndexesOperation(new[] { new IndexDefinition
                 {

--- a/test/SlowTests/Bugs/Queries/StatsOnDynamicQueries.cs
+++ b/test/SlowTests/Bugs/Queries/StatsOnDynamicQueries.cs
@@ -3,6 +3,7 @@ using System.Linq;
 using Raven.Client.Documents.Session;
 using Xunit;
 using Xunit.Abstractions;
+using Tests.Infrastructure;
 
 namespace SlowTests.Bugs.Queries
 {
@@ -12,10 +13,11 @@ namespace SlowTests.Bugs.Queries
         {
         }
 
-        [Fact]
-        public void WillGiveStats()
+        [RavenTheory(RavenTestCategory.Querying)]
+        [RavenData(SearchEngineMode = RavenSearchEngineMode.All)]
+        public void WillGiveStats(Options options)
         {
-            using (var store = GetDocumentStore())
+            using (var store = GetDocumentStore(options))
             {
                 using (var session = store.OpenSession())
                 {
@@ -40,10 +42,11 @@ namespace SlowTests.Bugs.Queries
             }
         }
 
-        [Fact]
-        public void WillGiveStatsForLuceneQuery()
+        [RavenTheory(RavenTestCategory.Querying)]
+        [RavenData(SearchEngineMode = RavenSearchEngineMode.Lucene)]
+        public void WillGiveStatsForLuceneQuery(Options options)
         {
-            using (var store = GetDocumentStore())
+            using (var store = GetDocumentStore(options))
             {
                 using (var session = store.OpenSession())
                 {

--- a/test/SlowTests/Bugs/Queries/WithAs.cs
+++ b/test/SlowTests/Bugs/Queries/WithAs.cs
@@ -3,6 +3,7 @@ using Xunit;
 using System.Linq;
 using Raven.Client.Documents;
 using Xunit.Abstractions;
+using Tests.Infrastructure;
 
 namespace SlowTests.Bugs.Queries
 {
@@ -12,8 +13,9 @@ namespace SlowTests.Bugs.Queries
         {
         }
 
-        [Fact]
-        public void WillAutomaticallyGenerateSelect()
+        [RavenTheory(RavenTestCategory.Querying)]
+        [RavenData(SearchEngineMode = RavenSearchEngineMode.All)]
+        public void WillAutomaticallyGenerateSelect(Options options)
         {
             using(var store = GetDocumentStore())
             {

--- a/test/SlowTests/Corax/RavenDB-18377.cs
+++ b/test/SlowTests/Corax/RavenDB-18377.cs
@@ -53,9 +53,9 @@ public class RavenDB_18377 : RavenTestBase
         {
             //StaticIndex
             using var session = store.OpenSession();
-            var result = session.Query<Item, NestedArray>().Where(p => p.Data.Any(data => data < 10)).ToList();
+            var result = session.Query<Item, NestedArray>().Where(p => p.Data.Any(data => data > 10)).ToList();
             Assert.Empty(result);
-            result = session.Query<Item, NestedArray>().Where(p => p.Data.Any(data => data > 10)).ToList();
+            result = session.Query<Item, NestedArray>().Where(p => p.Data.Any(data => data < 10)).ToList();
             Assert.Single(result);
         }
         {

--- a/test/SlowTests/Corax/RavenDB-18377.cs
+++ b/test/SlowTests/Corax/RavenDB-18377.cs
@@ -80,7 +80,7 @@ public class RavenDB_18377 : RavenTestBase
         public NestedArray()
         {
             Map = docs => from doc in docs
-                select new Item {Name = doc.Name, Data = doc.Data.Select(i => i * 10).ToArray()};
+                select new Item {Name = doc.Name, Data = doc.Data.Select(i => i).ToArray()};
         }
     }
 }

--- a/test/SlowTests/Corax/RavenDB-18377.cs
+++ b/test/SlowTests/Corax/RavenDB-18377.cs
@@ -19,7 +19,7 @@ public class RavenDB_18377 : RavenTestBase
     }
 
     [RavenTheory(RavenTestCategory.Indexes)]
-    [RavenData(SearchEngineMode = RavenSearchEngineMode.Corax)]
+    [RavenData(SearchEngineMode = RavenSearchEngineMode.All)]
     public void EnumerableSavedAsValue(Options options)
     {
         using var store = GetDocumentStore(options);
@@ -38,7 +38,7 @@ public class RavenDB_18377 : RavenTestBase
 
 
     [RavenTheory(RavenTestCategory.Indexes)]
-    [RavenData(SearchEngineMode = RavenSearchEngineMode.Corax)]
+    [RavenData(SearchEngineMode = RavenSearchEngineMode.All)]
     public void ArrayInIndex(Options options)
     {
         using var store = GetDocumentStore(options);

--- a/test/SlowTests/Issues/RavenDB-18377.cs
+++ b/test/SlowTests/Issues/RavenDB-18377.cs
@@ -13,7 +13,7 @@ public class RavenDB_18377 : RavenTestBase
     }
 
     [RavenTheory(RavenTestCategory.Indexes)]
-    [RavenData(SearchEngineMode = RavenSearchEngineMode.Corax)]
+    [RavenData(SearchEngineMode = RavenSearchEngineMode.All)]
     public void CanQueryOnNestedEnumerable(Options options)
     {
         using var store = GetDocumentStore(options);

--- a/test/SlowTests/Issues/RavenDB_10052.cs
+++ b/test/SlowTests/Issues/RavenDB_10052.cs
@@ -58,7 +58,7 @@ namespace SlowTests.Issues
                 }
 
                 Indexes.WaitForIndexing(store);
-WaitForUserToContinueTheTest(store);
+                WaitForUserToContinueTheTest(store);
                 using (var session = store.OpenSession())
                 {
                     var list = session.Query<User, LastAccessPerUserDateTimeIndex>()
@@ -258,7 +258,7 @@ WaitForUserToContinueTheTest(store);
             public LastAccessPerUserDateTimeIndex()
             {
                 Map = users =>
-                    from user in users
+                    from user in users                    
                     select new Result
                     {
                         LastAccess = user.LoginsByDate.Last().Value


### PR DESCRIPTION
After some working around I was able to piggyback the null support in an space efficient way and with as less as possible disruption into the format. More complex format means that the decoding phase would be more costly to execute. Therefore, keeping the format as simple as possible was a requirement. 

Current implementation supports handling null at every property level (albeit some options are not implemented yet on this draft PR). 

cc @maciejaszyk check if there is something else that's required to use native nulls instead of null strings.