### PR TITLE
RavenDB-18489 When node is red, the graph edge is connected to a gree…

### DIFF
--- a/src/Raven.Studio/typescript/models/database/cluster/clusterGraph.ts
+++ b/src/Raven.Studio/typescript/models/database/cluster/clusterGraph.ts
@@ -255,8 +255,8 @@ class clusterGraph {
     }
 
     private updateEdges(selection: d3.Selection<clusterGraphEdge<clusterNodeWithLayout>>, leaderTag: string) {
-        const leaderDistance = 52;
-        const nonLeaderDistance = 45;
+        const leaderDistance = clusterGraph.circleRadius + 3;
+        const nonLeaderDistance = clusterGraph.circleRadius + 7;
 
         selection
             .select(".edge-line")


### PR DESCRIPTION
…n node ball in a weird way

### Issue link

https://issues.hibernatingrhinos.com/issue/RavenDB-18489 

### Additional description

Minor width fix

### Type of change

- Bug fix

### How risky is the change?

- Low 


### Backward compatibility

- Non breaking change
