### PR TITLE
RavenDB-17967 Setup: Selecting 0.0.0.0 as IP address of a node should…

### DIFF
--- a/src/Raven.Studio/typescript/models/wizard/nodeInfo.ts
+++ b/src/Raven.Studio/typescript/models/wizard/nodeInfo.ts
@@ -142,8 +142,8 @@ class nodeInfo {
         
         this.externalIpAddress.extend({
             required: {   
-                onlyIf: () => this.ipsContainHostName() && !this.externalIpAddress(),                
-                message: "This field is required when an address contains Hostname"
+                onlyIf: () => (this.ipsContainHostName() || this.ipContainBindAll()) && !this.externalIpAddress(),
+                message: "This field is required when an address contains Hostname or 0.0.0.0"
             },
             validIpWithoutPort: true
         });


### PR DESCRIPTION
… require mandatory external IP address

### Issue link

https://issues.hibernatingrhinos.com/issue/RavenDB-17967 

### Additional description

external ip is required with bind set to 0.0.0.0


### Type of change

- Bug fix

### How risky is the change?

- Low 

### Backward compatibility

- Non breaking change
