### PR TITLE
RavenDB-18496 : Encrypted database + big documents may cause a replication loop

### DIFF
--- a/src/Raven.Server/Documents/Replication/ReplicationDocumentSender.cs
+++ b/src/Raven.Server/Documents/Replication/ReplicationDocumentSender.cs
@@ -385,12 +385,6 @@ namespace Raven.Server.Documents.Replication
 
         private bool CanContinueBatch(ReplicationState state, ref long next)
         {
-            if (state.NumberOfItemsSent == 0)
-            {
-                // always send at least one item
-                return true;
-            }
-
             if (MissingAttachmentsInLastBatch)
             {
                 // we do have missing attachments but we haven't gathered yet any of the missing hashes
@@ -412,6 +406,12 @@ namespace Raven.Server.Documents.Replication
                         return false;
                     }
                 }
+            }
+
+            if (state.NumberOfItemsSent == 0)
+            {
+                // always send at least one item
+                return true;
             }
 
             // We want to limit batch sizes to reasonable limits.

--- a/src/Raven.Server/Documents/Replication/ReplicationDocumentSender.cs
+++ b/src/Raven.Server/Documents/Replication/ReplicationDocumentSender.cs
@@ -385,6 +385,12 @@ namespace Raven.Server.Documents.Replication
 
         private bool CanContinueBatch(ReplicationState state, ref long next)
         {
+            if (state.NumberOfItemsSent == 0)
+            {
+                // always send at least one item
+                return true;
+            }
+
             if (MissingAttachmentsInLastBatch)
             {
                 // we do have missing attachments but we haven't gathered yet any of the missing hashes

--- a/test/SlowTests/Issues/RavenDB_18496.cs
+++ b/test/SlowTests/Issues/RavenDB_18496.cs
@@ -1,0 +1,60 @@
+﻿using System;
+using System.Collections.Generic;
+using System.IO;
+using System.Linq;
+using System.Threading.Tasks;
+using FastTests.Graph;
+using FastTests.Server.Replication;
+using Raven.Client.Documents;
+using Raven.Client.Exceptions;
+using Raven.Client.Exceptions.Database;
+using Raven.Client.Exceptions.Security;
+using Raven.Client.ServerWide;
+using Raven.Client.ServerWide.Operations;
+using Raven.Client.ServerWide.Operations.Certificates;
+using Raven.Server;
+using Raven.Server.ServerWide.Context;
+using Raven.Server.Utils;
+using Sparrow;
+using Tests.Infrastructure;
+using Xunit;
+using Xunit.Abstractions;
+
+namespace SlowTests.Issues
+{
+    public class RavenDB_18496 : ReplicationTestBase
+    {
+        public RavenDB_18496(ITestOutputHelper output) : base(output)
+        {
+        }
+        
+
+        [Fact]
+        public async Task DeletingMasterKeyForExistedEncryptedDatabaseShouldFail_2()
+        {
+            EncryptedServer(out var certificates, out var databaseName);
+
+            using (var encryptedStore = GetDocumentStore(new Options
+                   {
+                       ModifyDatabaseName = _ => databaseName,
+                       ClientCertificate = certificates.ServerCertificate.Value,
+                       AdminCertificate = certificates.ServerCertificate.Value,
+                       Encrypted = true
+                   }))
+            using (var store2 = GetDocumentStore(new Options
+                   {
+                       ClientCertificate = certificates.ServerCertificate.Value
+                   }))
+            {
+                var db = await GetDocumentDatabaseInstanceFor(encryptedStore);
+                db.Configuration.Replication.MaxSizeToSend = new Size(16, SizeUnit.Kilobytes);
+
+                await SetupReplicationAsync(encryptedStore, store2);
+
+                await EnsureReplicatingAsync(encryptedStore, store2);
+
+                await EnsureNoReplicationLoop(Server, databaseName);
+            }
+        }
+    }
+}

--- a/test/SlowTests/Issues/RavenDB_18496.cs
+++ b/test/SlowTests/Issues/RavenDB_18496.cs
@@ -1,22 +1,6 @@
-﻿using System;
-using System.Collections.Generic;
-using System.IO;
-using System.Linq;
-using System.Threading.Tasks;
-using FastTests.Graph;
+﻿using System.Threading.Tasks;
 using FastTests.Server.Replication;
-using Raven.Client.Documents;
-using Raven.Client.Exceptions;
-using Raven.Client.Exceptions.Database;
-using Raven.Client.Exceptions.Security;
-using Raven.Client.ServerWide;
-using Raven.Client.ServerWide.Operations;
-using Raven.Client.ServerWide.Operations.Certificates;
-using Raven.Server;
-using Raven.Server.ServerWide.Context;
-using Raven.Server.Utils;
 using Sparrow;
-using Tests.Infrastructure;
 using Xunit;
 using Xunit.Abstractions;
 
@@ -41,10 +25,7 @@ namespace SlowTests.Issues
                        AdminCertificate = certificates.ServerCertificate.Value,
                        Encrypted = true
                    }))
-            using (var store2 = GetDocumentStore(new Options
-                   {
-                       ClientCertificate = certificates.ServerCertificate.Value
-                   }))
+            using (var store2 = GetDocumentStore(new Options { ClientCertificate = certificates.ServerCertificate.Value }))
             {
                 var db = await GetDocumentDatabaseInstanceFor(encryptedStore);
                 db.Configuration.Replication.MaxSizeToSend = new Size(16, SizeUnit.Kilobytes);

--- a/test/SlowTests/Issues/RavenDB_18496.cs
+++ b/test/SlowTests/Issues/RavenDB_18496.cs
@@ -1,5 +1,7 @@
-﻿using System.Threading.Tasks;
+﻿using System.Linq;
+using System.Threading.Tasks;
 using FastTests.Server.Replication;
+using Raven.Server.ServerWide.Context;
 using Sparrow;
 using Xunit;
 using Xunit.Abstractions;
@@ -14,7 +16,7 @@ namespace SlowTests.Issues
         
 
         [Fact]
-        public async Task DeletingMasterKeyForExistedEncryptedDatabaseShouldFail_2()
+        public async Task ReplicationShouldNotGetStuckWhenEncryptionBufferSizeIsGreaterThanMaxSizeToSend()
         {
             EncryptedServer(out var certificates, out var databaseName);
 
@@ -28,11 +30,38 @@ namespace SlowTests.Issues
             using (var store2 = GetDocumentStore(new Options { ClientCertificate = certificates.ServerCertificate.Value }))
             {
                 var db = await GetDocumentDatabaseInstanceFor(encryptedStore);
-                db.Configuration.Replication.MaxSizeToSend = new Size(16, SizeUnit.Kilobytes);
+                var maxSizeToSend = new Size(16, SizeUnit.Kilobytes);
+                db.Configuration.Replication.MaxSizeToSend = maxSizeToSend;
+
+                const string docId = "users/1";
+                using (var session = encryptedStore.OpenAsyncSession())
+                {
+                    var entity = new 
+                    {
+                        Data = Sparrow.Server.Sodium.GenerateRandomBuffer(20 * 1024)
+                    };
+
+                    await session.StoreAsync(entity, docId);
+                    await session.SaveChangesAsync();
+                }
+
+                using (db.DocumentsStorage.ContextPool.AllocateOperationContext(out DocumentsOperationContext ctx))
+                using (ctx.OpenReadTransaction())
+                {
+                    var doc = db.DocumentsStorage.GetDocumentsFrom(ctx, 0).SingleOrDefault();
+                    Assert.NotNull(doc);
+                    Assert.Equal(docId, doc.Id);
+
+                    long maxSize = maxSizeToSend.GetValue(SizeUnit.Bytes);
+                    long encryptionBufferSize = ctx.Transaction.InnerTransaction.LowLevelTransaction.TotalEncryptionBufferSize.GetValue(SizeUnit.Bytes);
+
+                    Assert.True(doc.Data.Size > maxSize);
+                    Assert.True(encryptionBufferSize > maxSize);
+                }
 
                 await SetupReplicationAsync(encryptedStore, store2);
 
-                await EnsureReplicatingAsync(encryptedStore, store2);
+                Assert.True(WaitForDocument(store2, docId));
 
                 await EnsureNoReplicationLoop(Server, databaseName);
             }


### PR DESCRIPTION
### Issue link

https://issues.hibernatingrhinos.com/issue/RavenDB-18496

### Additional description

fix a bug in `ReplicationDocumentSender.CanContinueBatch()` which might cause encrypted databases to get stuck in replication loop

### Type of change

- Bug fix

### How risky is the change?

- Low 

### Backward compatibility

- Not relevant

### Is it platform specific issue?

- No

### Documentation update

- No documentation update is needed 

### Testing 

- Tests have been added that prove the fix is effective or that the feature works

### Is there any existing behavior change of other features due to this change?

- No

### UI work

- No UI work is needed
