### PR TITLE
RavenDB-18563 - Handle System.Threading.ThreadStateException: Unable to set thread priority

### DIFF
--- a/src/Raven.Server/Documents/ETL/EtlProcess.cs
+++ b/src/Raven.Server/Documents/ETL/EtlProcess.cs
@@ -619,7 +619,7 @@ namespace Raven.Server.Documents.ETL
                 {
                     // This has lower priority than request processing, so we let the OS
                     // schedule this appropriately
-                    Thread.CurrentThread.Priority = ThreadPriority.BelowNormal;
+                    ThreadHelper.TrySetThreadPriority(ThreadPriority.BelowNormal, threadName, Logger);
                     NativeMemory.EnsureRegistered();
                     Run();
                 }

--- a/src/Raven.Server/Documents/Indexes/Index.cs
+++ b/src/Raven.Server/Documents/Indexes/Index.cs
@@ -1900,7 +1900,7 @@ namespace Raven.Server.Documents.Indexes
             if (currentPriority == newPriority)
                 return;
 
-            Thread.CurrentThread.Priority = newPriority;
+            ThreadHelper.TrySetThreadPriority(newPriority, IndexingThreadName, _logger);
         }
 
         private void PersistIndexDefinition()

--- a/src/Raven.Server/Documents/Indexes/Index.cs
+++ b/src/Raven.Server/Documents/Indexes/Index.cs
@@ -1896,7 +1896,7 @@ namespace Raven.Server.Documents.Indexes
                     throw new NotSupportedException($"Unknown priority: {priority}");
             }
 
-            var currentPriority = Thread.CurrentThread.Priority;
+            var currentPriority = ThreadHelper.GetThreadPriority();
             if (currentPriority == newPriority)
                 return;
 

--- a/src/Raven.Server/Documents/TransactionOperationsMerger.cs
+++ b/src/Raven.Server/Documents/TransactionOperationsMerger.cs
@@ -299,17 +299,7 @@ namespace Raven.Server.Documents
 
         private void MergeOperationThreadProc()
         {
-            try
-            {
-                Thread.CurrentThread.Priority = ThreadPriority.AboveNormal;
-            }
-            catch (Exception e)
-            {
-                if (_log.IsInfoEnabled)
-                {
-                    _log.Info("Unable to elevate the transaction merger thread for " + _parent.Name, e);
-                }
-            }
+            ThreadHelper.TrySetThreadPriority(ThreadPriority.AboveNormal, TransactionMergerThreadName, _log);
 
             var oomTimer = new Stopwatch();// this is allocated here to avoid OOM when using it
 

--- a/src/Raven.Server/Rachis/Elector.cs
+++ b/src/Raven.Server/Rachis/Elector.cs
@@ -37,17 +37,7 @@ namespace Raven.Server.Rachis
         {
             try
             {
-                try
-                {
-                    Thread.CurrentThread.Priority = ThreadPriority.AboveNormal;
-                }
-                catch (Exception e)
-                {
-                    if (_engine.Log.IsInfoEnabled)
-                    {
-                        _engine.Log.Info("Elector was unable to set the thread priority, will continue with the same priority", e);
-                    }
-                }
+                ThreadHelper.TrySetThreadPriority(ThreadPriority.AboveNormal, ToString(), _engine.Log);
 
                 using (this)
                 {

--- a/src/Raven.Server/Rachis/Follower.cs
+++ b/src/Raven.Server/Rachis/Follower.cs
@@ -1087,17 +1087,7 @@ namespace Raven.Server.Rachis
         {
             try
             {
-                try
-                {
-                    Thread.CurrentThread.Priority = ThreadPriority.AboveNormal;
-                }
-                catch (Exception e)
-                {
-                    if (_engine.Log.IsInfoEnabled)
-                    {
-                        _engine.Log.Info($"{_debugName} was unable to set the thread priority, will continue with the same priority", e);
-                    }
-                }
+                ThreadHelper.TrySetThreadPriority(ThreadPriority.AboveNormal, _debugName, _engine.Log);
 
                 using (this)
                 {

--- a/src/Raven.Server/Rachis/FollowerAmbassador.cs
+++ b/src/Raven.Server/Rachis/FollowerAmbassador.cs
@@ -157,17 +157,7 @@ namespace Raven.Server.Rachis
 
             try
             {
-                try
-                {
-                    Thread.CurrentThread.Priority = ThreadPriority.AboveNormal;
-                }
-                catch (Exception e)
-                {
-                    if (_engine.Log.IsInfoEnabled)
-                    {
-                        _engine.Log.Info($"{ToString()} was unable to set the thread priority, will continue with the same priority", e);
-                    }
-                }
+                ThreadHelper.TrySetThreadPriority(ThreadPriority.AboveNormal, ToString(), _engine.Log);
 
                 var connectionBroken = false;
                 var obtainConnectionFailure = false;

--- a/src/Raven.Server/ServerWide/ServerStore.cs
+++ b/src/Raven.Server/ServerWide/ServerStore.cs
@@ -927,11 +927,12 @@ namespace Raven.Server.ServerWide
             _clusterMaintenanceSetupTask = PoolOfThreads.GlobalRavenThreadPool.LongRunning(x =>
                 ClusterMaintenanceSetupTask(), null, "Cluster Maintenance Setup Task");
 
+            const string threadName = "Update Topology Change Notification Task";
             _updateTopologyChangeNotification = PoolOfThreads.GlobalRavenThreadPool.LongRunning(x =>
             {
-                Thread.CurrentThread.Priority = ThreadPriority.BelowNormal;
+                ThreadHelper.TrySetThreadPriority(ThreadPriority.BelowNormal, threadName, Logger);
                 UpdateTopologyChangeNotification();
-            }, null, "Update Topology Change Notification Task");
+            }, null, threadName);
         }
 
         private void OnStateChanged(object sender, RachisConsensus.StateTransition state)

--- a/src/Raven.Server/Utils/PoolOfThreads.cs
+++ b/src/Raven.Server/Utils/PoolOfThreads.cs
@@ -270,21 +270,21 @@ namespace Raven.Server.Utils
 
             private static bool ResetThreadPriority()
             {
-                try
+                if (Thread.CurrentThread.Priority != ThreadPriority.Normal)
                 {
-                    if (Thread.CurrentThread.Priority != ThreadPriority.Normal)
-                        Thread.CurrentThread.Priority = ThreadPriority.Normal;
-                    return true;
-                }
-                catch (Exception e)
-                {
-                    // if we can't reset it, better just kill it
-                    if (_log.IsInfoEnabled)
+                    if (ThreadHelper.TrySetThreadPriority(ThreadPriority.Normal, null, _log) == false)
                     {
-                        _log.Info($"Unable to set this thread priority to normal, since we don't want its priority of {Thread.CurrentThread.Priority}, we'll let it exit", e);
+                        // if we can't reset it, better just kill it
+                        if (_log.IsInfoEnabled)
+                        {
+                            _log.Info($"Unable to set this thread priority to normal, since we don't want its priority of {Thread.CurrentThread.Priority}, we'll let it exit");
+                        }
+
+                        return false;
                     }
-                    return false;
                 }
+
+                return true;
             }
 
             private void InitializeProcessThreads()

--- a/src/Raven.Server/Utils/PoolOfThreads.cs
+++ b/src/Raven.Server/Utils/PoolOfThreads.cs
@@ -270,14 +270,15 @@ namespace Raven.Server.Utils
 
             private static bool ResetThreadPriority()
             {
-                if (Thread.CurrentThread.Priority != ThreadPriority.Normal)
+                var currentPriority = ThreadHelper.GetThreadPriority();
+                if (currentPriority != ThreadPriority.Normal)
                 {
                     if (ThreadHelper.TrySetThreadPriority(ThreadPriority.Normal, null, _log) == false)
                     {
                         // if we can't reset it, better just kill it
                         if (_log.IsInfoEnabled)
                         {
-                            _log.Info($"Unable to set this thread priority to normal, since we don't want its priority of {Thread.CurrentThread.Priority}, we'll let it exit");
+                            _log.Info($"Unable to set this thread priority to normal, since we don't want its priority of {currentPriority}, we'll let it exit");
                         }
 
                         return false;

--- a/src/Raven.Server/Utils/ThreadHelper.cs
+++ b/src/Raven.Server/Utils/ThreadHelper.cs
@@ -22,4 +22,16 @@ public static class ThreadHelper
             return false;
         }
     }
+
+    public static ThreadPriority GetThreadPriority()
+    {
+        try
+        {
+            return Thread.CurrentThread.Priority;
+        }
+        catch
+        {
+            return ThreadPriority.Normal;
+        }
+    }
 }

--- a/src/Raven.Server/Utils/ThreadHelper.cs
+++ b/src/Raven.Server/Utils/ThreadHelper.cs
@@ -1,0 +1,25 @@
+﻿using System;
+using System.Threading;
+using Sparrow.Logging;
+
+namespace Raven.Server.Utils;
+
+public static class ThreadHelper
+{
+    public static bool TrySetThreadPriority(ThreadPriority priority, string threadName, Logger logger)
+    {
+        try
+        {
+            Thread.CurrentThread.Priority = priority;
+            return true;
+        }
+        catch (Exception e)
+        {
+            if (logger.IsInfoEnabled && threadName != null)
+            {
+                logger.Info($"`{threadName}` was unable to set the thread priority to {priority}, will continue with the same priority", e);
+            }
+            return false;
+        }
+    }
+}

--- a/src/Raven.Server/Web/System/OngoingTasksHandler.cs
+++ b/src/Raven.Server/Web/System/OngoingTasksHandler.cs
@@ -463,6 +463,7 @@ namespace Raven.Server.Web.System
                     };
 
                     var backupTask = new BackupTask(Database, backupParameters, backupConfiguration, Logger);
+                    var threadName = $"Backup thread {backupName} for database '{Database.Name}'";
 
                     var t = Database.Operations.AddOperation(
                         null,
@@ -475,7 +476,7 @@ namespace Raven.Server.Web.System
                             {
                                 try
                                 {
-                                    Thread.CurrentThread.Priority = ThreadPriority.BelowNormal;
+                                    ThreadHelper.TrySetThreadPriority(ThreadPriority.BelowNormal, threadName, Logger);
                                     NativeMemory.EnsureRegistered();
 
                                     using (Database.PreventFromUnloadingByIdleOperations())
@@ -501,7 +502,7 @@ namespace Raven.Server.Web.System
                                 {
                                     ServerStore.ConcurrentBackupsCounter.FinishBackup(backupName, backupStatus: null, sw.Elapsed, Logger);
                                 }
-                            }, null, $"Backup thread {backupName} for database '{Database.Name}'");
+                            }, null, threadName);
                             return tcs.Task;
                         },
                         id: operationId, token: cancelToken);


### PR DESCRIPTION
### Issue link

https://issues.hibernatingrhinos.com/issue/RavenDB-18563

### Additional description

Avoid throwing when we fail to update the thread priority

### Type of change

- Bug fix

### How risky is the change?

- Low 

### Testing 

- It has been verified by manual testing
