### PR TITLE
Ravendb-18554 - Queries should failover if the index is compacting.

### DIFF
--- a/src/Raven.Client/Exceptions/Database/IndexCompactionInProgressException.cs
+++ b/src/Raven.Client/Exceptions/Database/IndexCompactionInProgressException.cs
@@ -1,0 +1,24 @@
+﻿using System;
+using System.Collections.Generic;
+using System.Linq;
+using System.Text;
+using System.Threading.Tasks;
+
+namespace Raven.Client.Exceptions.Database
+{
+    internal class IndexCompactionInProgressException : RavenException
+    {
+        public IndexCompactionInProgressException()
+        {
+        }
+
+        public IndexCompactionInProgressException(string message)
+            : base(message)
+        {
+        }
+
+        public IndexCompactionInProgressException(string message, Exception inner) : base(message, inner)
+        {
+        }
+    }
+}

--- a/src/Raven.Client/Exceptions/Documents/Indexes/IndexCompactionInProgressException.cs
+++ b/src/Raven.Client/Exceptions/Documents/Indexes/IndexCompactionInProgressException.cs
@@ -4,7 +4,7 @@ using System.Linq;
 using System.Text;
 using System.Threading.Tasks;
 
-namespace Raven.Client.Exceptions.Database
+namespace Raven.Client.Exceptions.Documents.Indexes
 {
     internal class IndexCompactionInProgressException : RavenException
     {

--- a/src/Raven.Server/Documents/CompactDatabaseTask.cs
+++ b/src/Raven.Server/Documents/CompactDatabaseTask.cs
@@ -70,7 +70,7 @@ namespace Raven.Server.Documents
                     },
                 new CatastrophicFailureNotification((endId, path, exception, stacktrace) => throw new InvalidOperationException($"Failed to compact database {_database} ({path}), StackTrace='{stacktrace}'", exception))))
                 {
-                    documentDatabase.ForTestingPurposes?.CompactionAfterDatabaseUnloadAction?.Invoke();
+                    documentDatabase.ForTestingPurposes?.CompactionAfterDatabaseUnload?.Invoke();
 
                     InitializeOptions(src, configuration, documentDatabase, encryptionKey);
                     DirectoryExecUtils.SubscribeToOnDirectoryInitializeExec(src, configuration.Storage, documentDatabase.Name, DirectoryExecUtils.EnvironmentType.Compaction, Logger);

--- a/src/Raven.Server/Documents/CompactDatabaseTask.cs
+++ b/src/Raven.Server/Documents/CompactDatabaseTask.cs
@@ -70,6 +70,8 @@ namespace Raven.Server.Documents
                     },
                 new CatastrophicFailureNotification((endId, path, exception, stacktrace) => throw new InvalidOperationException($"Failed to compact database {_database} ({path}), StackTrace='{stacktrace}'", exception))))
                 {
+                    documentDatabase.ForTestingPurposes?.CompactionAfterDatabaseUnloadAction?.Invoke();
+
                     InitializeOptions(src, configuration, documentDatabase, encryptionKey);
                     DirectoryExecUtils.SubscribeToOnDirectoryInitializeExec(src, configuration.Storage, documentDatabase.Name, DirectoryExecUtils.EnvironmentType.Compaction, Logger);
 

--- a/src/Raven.Server/Documents/DocumentDatabase.cs
+++ b/src/Raven.Server/Documents/DocumentDatabase.cs
@@ -1771,9 +1771,7 @@ namespace Raven.Server.Documents
 
             internal Action CollectionRunnerBeforeOpenReadTransaction;
 
-            internal Action CompactionAfterDatabaseUnloadAction;
-
-            internal Action IndexCompaction;
+            internal Action CompactionAfterDatabaseUnload;
 
             internal bool SkipDrainAllRequests = false;
 

--- a/src/Raven.Server/Documents/DocumentDatabase.cs
+++ b/src/Raven.Server/Documents/DocumentDatabase.cs
@@ -1771,6 +1771,10 @@ namespace Raven.Server.Documents
 
             internal Action CollectionRunnerBeforeOpenReadTransaction;
 
+            internal Action CompactionAfterDatabaseUnloadAction;
+
+            internal Action IndexCompaction;
+
             internal bool SkipDrainAllRequests = false;
 
             internal Action<string, string> DisposeLog;

--- a/src/Raven.Server/Documents/Indexes/Index.cs
+++ b/src/Raven.Server/Documents/Indexes/Index.cs
@@ -16,6 +16,7 @@ using Raven.Client.Documents.Indexes;
 using Raven.Client.Documents.Indexes.Spatial;
 using Raven.Client.Documents.Operations;
 using Raven.Client.Documents.Queries;
+using Raven.Client.Exceptions.Database;
 using Raven.Client.ServerWide.Operations;
 using Raven.Client.Util;
 using Raven.Server.Config.Categories;
@@ -3707,7 +3708,7 @@ namespace Raven.Server.Documents.Indexes
 
         private void ThrowCompactionInProgress()
         {
-            throw new InvalidOperationException($"Index '{Name}' is currently being compacted.");
+            throw new IndexCompactionInProgressException($"Index '{Name}' is currently being compacted."); // Shahar
         }
 
         private void AssertQueryDoesNotContainFieldsThatAreNotIndexed(QueryMetadata metadata)
@@ -4577,6 +4578,8 @@ namespace Raven.Server.Documents.Indexes
                 _isCompactionInProgress = true;
                 PathSetting compactPath = null;
                 PathSetting tempPath = null;
+
+                DocumentDatabase.ForTestingPurposes?.IndexCompaction?.Invoke();
 
                 try
                 {

--- a/src/Raven.Server/Documents/Indexes/Index.cs
+++ b/src/Raven.Server/Documents/Indexes/Index.cs
@@ -3708,7 +3708,7 @@ namespace Raven.Server.Documents.Indexes
 
         private void ThrowCompactionInProgress()
         {
-            throw new IndexCompactionInProgressException($"Index '{Name}' is currently being compacted."); // Shahar
+            throw new IndexCompactionInProgressException($"Index '{Name}' is currently being compacted.");
         }
 
         private void AssertQueryDoesNotContainFieldsThatAreNotIndexed(QueryMetadata metadata)
@@ -4579,14 +4579,14 @@ namespace Raven.Server.Documents.Indexes
                 PathSetting compactPath = null;
                 PathSetting tempPath = null;
 
-                DocumentDatabase.ForTestingPurposes?.IndexCompaction?.Invoke();
-
                 try
                 {
                     var storageEnvironmentOptions = _environment.Options;
 
                     using (RestartEnvironment(onBeforeEnvironmentDispose: Optimize))
                     {
+                        DocumentDatabase.IndexStore?.ForTestingPurposes?.IndexCompaction?.Invoke();
+
                         if (Type.IsMapReduce())
                         {
                             result.AddMessage($"Skipping data compaction of '{Name}' index because data compaction of map-reduce indexes isn't supported");

--- a/src/Raven.Server/Documents/Indexes/Index.cs
+++ b/src/Raven.Server/Documents/Indexes/Index.cs
@@ -17,6 +17,7 @@ using Raven.Client.Documents.Indexes.Spatial;
 using Raven.Client.Documents.Operations;
 using Raven.Client.Documents.Queries;
 using Raven.Client.Exceptions.Database;
+using Raven.Client.Exceptions.Documents.Indexes;
 using Raven.Client.ServerWide.Operations;
 using Raven.Client.Util;
 using Raven.Server.Config.Categories;

--- a/src/Raven.Server/Documents/Indexes/IndexStore.cs
+++ b/src/Raven.Server/Documents/Indexes/IndexStore.cs
@@ -2547,6 +2547,7 @@ namespace Raven.Server.Documents.Indexes
             internal Action DuringIndexReplacement_OnOldIndexDeletion;
             internal Action AfterIndexesOpen;
             internal Action<string> AfterIndexCreation;
+            internal Action IndexCompaction;
 
             internal Action<Index> OnRollingIndexFinished;
             internal Action<Index> BeforeRollingIndexFinished;

--- a/src/Raven.Server/RavenServerStartup.cs
+++ b/src/Raven.Server/RavenServerStartup.cs
@@ -418,6 +418,12 @@ namespace Raven.Server
                 return;
             }
 
+            if (exception is IndexCompactionInProgressException)
+            {
+                response.StatusCode = (int)HttpStatusCode.ServiceUnavailable;
+                return;
+            }
+
             response.StatusCode = (int)HttpStatusCode.InternalServerError;
         }
     }

--- a/test/SlowTests/Issues/RavenDB-18554.cs
+++ b/test/SlowTests/Issues/RavenDB-18554.cs
@@ -1,0 +1,163 @@
+﻿using System;
+using System.Collections.Generic;
+using System.Linq;
+using System.Text.RegularExpressions;
+using System.Threading;
+using System.Threading.Tasks;
+using FastTests;
+using FastTests.Client;
+using Orders;
+using Raven.Client.Documents;
+using Raven.Client.Documents.Indexes;
+using Raven.Client.Documents.Operations;
+using Raven.Client.Documents.Operations.Indexes;
+using Raven.Client.Documents.Session;
+using Raven.Client.ServerWide;
+using Raven.Client.ServerWide.Operations;
+using Raven.Server.Commercial;
+using Raven.Server.Documents.Indexes;
+using Xunit;
+using Xunit.Abstractions;
+
+namespace SlowTests.Issues
+{
+    public class RavenDB_18554 : RavenTestBase
+    {
+        public RavenDB_18554(ITestOutputHelper output) : base(output)
+        {
+        }
+
+        [Fact]
+        public async Task QueriesShouldFailoverIfIndexIsCompacting()
+        {
+            int n = 500;
+            int m = 5;
+
+            using (var store = GetDocumentStore(new Options { RunInMemory = false }))
+            {
+                // Prepare Server For Test
+                using (var session = store.OpenAsyncSession())
+                {
+                    for (int i = 0; i < n; i++)
+                    {
+                        Category c = new Category {Name = $"n{i}", Description = $"d{i}"};
+                        await session.StoreAsync(c);
+                    }
+                    await session.SaveChangesAsync();
+                }
+                var indexName = await CreateIndex(store);
+                string[] indexNames = {indexName};
+                CompactSettings settings = new CompactSettings {DatabaseName = "QueriesShouldFailoverIfIndexIsCompacting_1", Documents = true, Indexes = indexNames};
+
+                var cs = new CancellationTokenSource();
+                var t1 = Task.Run(async () =>
+                {
+                     for (int i = 0; i < m; i++)
+                     {
+                         if (cs.IsCancellationRequested)
+                             return;
+                         var operation = await store.Maintenance.Server.SendAsync(new CompactDatabaseOperation(settings), cs.Token);
+                         await operation.WaitForCompletionAsync();
+                     }
+                }, cs.Token);
+
+                for (int i = 0; i < m; i++)
+                {
+                    using (var session = store.OpenAsyncSession())
+                    {
+                        var curId = $"categories/{i + 1}-A";
+                        var l = await session.Query<Categoroies_Details.Entitiy, Categoroies_Details>()
+                            .Where(x => x.Id == curId)
+                            .ProjectInto<Categoroies_Details.Entitiy>()
+                            .ToListAsync();
+
+                        //Console.WriteLine("***" + (l.Count > 0 ? l[0] : "Empty List"));
+                    }
+                }
+
+                cs.Cancel();
+                await t1;
+                //WaitForUserToContinueTheTest(store);
+            }
+
+        }
+
+        async Task<string> CreateIndex(DocumentStore store)
+        {
+            //Create Index
+            var index = new Categoroies_Details();
+            index.Execute(store);
+
+            //Wait for indexing
+            using (var session = store.OpenAsyncSession())
+            {
+                await session.Query<Categoroies_Details.Entitiy, Categoroies_Details>()
+                    .Customize(c => c.WaitForNonStaleResults())
+                    .Where(x => x.Id == "categories/1-A")
+                    .Select(x => x.Id)
+                    .ToListAsync();
+            }
+            return index.IndexName;
+
+            // Wait for indexing
+            //var indexName = index.IndexName;
+            // DatabaseStatistics? stats = store.Maintenance.Send(new GetStatisticsOperation());
+            // while (stats.Indexes.Where(x => x.Name == indexName).Where(x => x.IsStale == false).ToList().Count > 0)
+            // {
+            //     await Task.Delay(100);
+            // }
+            //
+
+            // using (var session = store.OpenSession())
+            // {
+            //     QueryStatistics stats = null;
+            //     bool firstIteration = true;
+            //     do
+            //     {
+            //         if (firstIteration)
+            //         {
+            //             firstIteration = false;
+            //         }
+            //         else
+            //         {
+            //             await Task.Delay(100);
+            //         }
+            //         session.Query<Product>()
+            //             .Statistics(out stats)
+            //             .Where(x => x.Id == "aaa")
+            //             .ToList();
+            //     } while (stats!=null && stats.IsStale);
+            // }
+            //return indexName;
+        }
+
+        class Categoroies_Details : AbstractMultiMapIndexCreationTask<Categoroies_Details.Entitiy>
+        {
+            internal class Entitiy
+            {
+                public string Id { get; set; }
+                public string Details { get; set; }
+
+                public override string ToString()
+                {
+                    return $"Id=\"{Id}\", Details=\"{Details}\"";
+                }
+            }
+
+            public Categoroies_Details()
+            {
+                AddMap<Category>(
+                    categories =>
+                        from c in categories
+                        select new Entitiy
+                        {
+                            Id = c.Id,
+                            Details = $"Id=\"{c.Id}\", Name=\"{c.Name}\", Description=\"{c.Description}\""
+                        }
+                );
+                Store(x => x.Details, FieldStorage.Yes);
+            }
+        }
+    }
+}
+


### PR DESCRIPTION
### Issue link

https://issues.hibernatingrhinos.com/issue/RavenDB-18554

### Additional description

Fixing - Queries should failover if the index is compacting.

### Type of change

- Bug fix

### How risky is the change?

- Low 

### Backward compatibility

- Not relevant

### Is it platform specific issue?

- No

### Documentation update

- No documentation update is needed 

### Testing 

- Tests have been added that prove the fix is effective or that the feature works

### Is there any existing behavior change of other features due to this change?

- No

### UI work

- No UI work is needed
