### PR TITLE
RavenDB-18575 - Changing aseertion. ModifyLocalServer is not mandatory.

### DIFF
--- a/test/SlowTests/Tools/SetupSecuredClusterUsingRvn.cs
+++ b/test/SlowTests/Tools/SetupSecuredClusterUsingRvn.cs
@@ -62,7 +62,7 @@ public class SetupSecuredClusterUsingRvn : ClusterTestBase
             }
         };
         
-        Debug.Assert(setupInfo.ModifyLocalServer, nameof(setupInfo.ModifyLocalServer) + " == true");
+        Debug.Assert(setupInfo.ModifyLocalServer == false, nameof(setupInfo.ModifyLocalServer) + " != false");
 
 
         var zipBytes = await OwnCertificateSetupUtils.Setup(setupInfo, new SetupProgressAndResult(tuple =>
@@ -236,7 +236,7 @@ public class SetupSecuredClusterUsingRvn : ClusterTestBase
             }
         };
         
-        Debug.Assert(setupInfo.ModifyLocalServer, nameof(setupInfo.ModifyLocalServer) + " == true");
+        Debug.Assert(setupInfo.ModifyLocalServer == false, nameof(setupInfo.ModifyLocalServer) + " != false");
 
 
         var zipBytes = await OwnCertificateSetupUtils.Setup(setupInfo, new SetupProgressAndResult(tuple =>
@@ -340,7 +340,7 @@ public class SetupSecuredClusterUsingRvn : ClusterTestBase
                 {"A", new SetupInfo.NodeInfo {Port = 443, TcpPort = 38879, Addresses = new List<string> {"127.0.0.1"}}},
             }
         };
-        Debug.Assert(setupInfo.ModifyLocalServer, nameof(setupInfo.ModifyLocalServer) + " == true");
+        Debug.Assert(setupInfo.ModifyLocalServer == false, nameof(setupInfo.ModifyLocalServer) + " != false");
 
         var zipBytes = await LetsEncryptSetupUtils.Setup(setupInfo, new SetupProgressAndResult(tuple =>
             {
@@ -474,7 +474,7 @@ public class SetupSecuredClusterUsingRvn : ClusterTestBase
                 {"C", new SetupInfo.NodeInfo {Port = 446, TcpPort = 38888, Addresses = new List<string> {"127.0.0.1"}}}
             }
         };
-        Debug.Assert(setupInfo.ModifyLocalServer, nameof(setupInfo.ModifyLocalServer) + " == true");
+        Debug.Assert(setupInfo.ModifyLocalServer == false, nameof(setupInfo.ModifyLocalServer) + " != false");
 
         var zipBytes = await LetsEncryptSetupUtils.Setup(setupInfo, new SetupProgressAndResult(tuple =>
             {


### PR DESCRIPTION
### Issue link

https://issues.hibernatingrhinos.com/issue/RavenDB-18575

### Type of change

- Bug fix

### How risky is the change?

- Low 

### Backward compatibility


- Not relevant

### Is it platform specific issue?

- No

### Documentation update

- No documentation update is needed 

### Testing 

- Tests have been added that prove the fix is effective or that the feature works

### Is there any existing behavior change of other features due to this change?

- No
- 
### UI work

- No UI work is needed
