### PR TITLE
RavenDB-18594 Applying boosting on the whole document once and not on each field individually.

### DIFF
--- a/src/Raven.Server/Documents/Indexes/Persistence/Lucene/Documents/AnonymousLuceneDocumentConverter.cs
+++ b/src/Raven.Server/Documents/Indexes/Persistence/Lucene/Documents/AnonymousLuceneDocumentConverter.cs
@@ -55,8 +55,18 @@ namespace Raven.Server.Documents.Indexes.Persistence.Lucene.Documents
                 newFields++;
             }
 
-            var boostedValue = document as BoostedValue;
-            var documentToProcess = boostedValue == null ? document : boostedValue.Value;
+            var boostedValue = document  as BoostedValue;
+            object documentToProcess;
+            if (boostedValue != null)
+            {
+                documentToProcess = boostedValue.Value;
+                Document.Boost = boostedValue.Boost;
+            }
+            else
+            {
+                documentToProcess = document;
+                Document.Boost = LuceneDefaultBoost;
+            }
 
             IPropertyAccessor accessor;
 
@@ -92,7 +102,6 @@ namespace Raven.Server.Documents.Indexes.Persistence.Lucene.Documents
                     for (int idx = fields.Count - 1; numberOfCreatedFields > 0; numberOfCreatedFields--, idx--)
                     {
                         var luceneField = fields[idx];
-                        luceneField.Boost = boostedValue.Boost;
                         luceneField.OmitNorms = false;
                     }
                 }

--- a/src/Raven.Server/Documents/Indexes/Persistence/Lucene/Documents/JintLuceneDocumentConverter.cs
+++ b/src/Raven.Server/Documents/Indexes/Persistence/Lucene/Documents/JintLuceneDocumentConverter.cs
@@ -79,6 +79,12 @@ namespace Raven.Server.Documents.Indexes.Persistence.Lucene.Documents
                     throw new InvalidOperationException($"Invalid boosted value. Expected object but got '{boostedValue.Type}' with value '{boostedValue}'.");
 
                 documentToProcess = boostedValue.AsObject();
+
+                Document.Boost = documentBoost.Value;
+            }
+            else
+            {
+                Document.Boost = LuceneDefaultBoost;
             }
 
             foreach (var (property, propertyDescriptor) in documentToProcess.GetOwnProperties())
@@ -213,7 +219,6 @@ namespace Raven.Server.Documents.Indexes.Persistence.Lucene.Documents
                 for (int idx = fields.Count - 1; numberOfCreatedFields > 0; numberOfCreatedFields--, idx--)
                 {
                     var luceneField = fields[idx];
-                    luceneField.Boost = boost.Value;
                     luceneField.OmitNorms = false;
                 }
             }

--- a/src/Raven.Server/Documents/Indexes/Persistence/Lucene/Documents/LuceneDocumentConverterBase.cs
+++ b/src/Raven.Server/Documents/Indexes/Persistence/Lucene/Documents/LuceneDocumentConverterBase.cs
@@ -31,6 +31,8 @@ namespace Raven.Server.Documents.Indexes.Persistence.Lucene.Documents
 
     public abstract class LuceneDocumentConverterBase : IDisposable
     {
+        protected const float LuceneDefaultBoost = 1f;
+        
         public struct DefaultDocumentLuceneWrapper : ILuceneDocumentWrapper
         {
             private readonly LuceneDocument _doc;

--- a/test/SlowTests/Issues/RavenDB-18594.cs
+++ b/test/SlowTests/Issues/RavenDB-18594.cs
@@ -17,95 +17,11 @@ public class RavenDB_18594 : RavenTestBase
     }
     
     [Fact]
-    public void ShouldApplyBoostingToDocumentInsteadOfIndividualFields()
+    public void ShouldApplyBoostingToDocumentInsteadOfIndividualFieldsInStaticIndex()
     {
         using var store = GetDocumentStore();
         {
-            using var s = store.OpenSession();
-             s.Store(new UserDocument
-                {
-                    Id = "Doc1",
-                    FifoId = 1,
-                    CvRankingBoostFactor = 2,
-                    ProfileTitle = "Developer",
-                    CurrentRole = new ActiveRoles { FromDate = new DateTime(2012, 1, 1), ToDate = new DateTime(2020, 1, 1), Specialties = new List<string> { "Developer" } },
-                    ActiveRoles = new List<ActiveRoles>
-                    {
-                        new ActiveRoles
-                        {
-                            FromDate = new DateTime(2015, 1, 1),
-                            ToDate = new DateTime(2020, 1, 1),
-                            Specialties = new List<string> { "Engineer" }
-                        },
-                        new ActiveRoles
-                        {
-                            FromDate = new DateTime(2015, 1, 1),
-                            ToDate = new DateTime(2020, 1, 1),
-                            Specialties = new List<string> { "Coder" }
-                        },
-                        new ActiveRoles
-                        {
-                            FromDate = new DateTime(2015, 1, 1),
-                            ToDate = new DateTime(2020, 1, 1),
-                            Specialties = new List<string> { "Analyst" }
-                        },
-                        new ActiveRoles
-                        {
-                            FromDate = new DateTime(2015, 1, 1),
-                            ToDate = new DateTime(2020, 1, 1),
-                            Specialties = new List<string> { "Tester" }
-                        },
-                        new ActiveRoles
-                        {
-                            FromDate = new DateTime(2015, 1, 1),
-                            ToDate = new DateTime(2020, 1, 1),
-                            Specialties = new List<string> { "Dev" }
-                        }
-                    }
-                });
-                s.Store(new UserDocument
-                {
-                    Id = "Doc2",
-                    FifoId = 2,
-                    CvRankingBoostFactor = 2,
-                    ProfileTitle = "Engineer",
-                    CurrentRole = new ActiveRoles { FromDate = new DateTime(2132, 1, 1), ToDate = new DateTime(2020, 1, 1), Specialties = new List<string> { "Developer" } },
-                    ActiveRoles = new List<ActiveRoles>
-                    {
-                        new ActiveRoles
-                        {
-                            FromDate = new DateTime(2015, 1, 1),
-                            ToDate = new DateTime(2020, 1, 1),
-                            Specialties = new List<string> { "Developer" }
-                        },
-                        new ActiveRoles
-                        {
-                            FromDate = new DateTime(2015, 1, 1),
-                            ToDate = new DateTime(2020, 1, 1),
-                            Specialties = new List<string> { "Coder" }
-                        },
-                        new ActiveRoles
-                        {
-                            FromDate = new DateTime(2015, 1, 1),
-                            ToDate = new DateTime(2020, 1, 1),
-                            Specialties = new List<string> { "Analyst" }
-                        },
-                        new ActiveRoles
-                        {
-                            FromDate = new DateTime(2015, 1, 1),
-                            ToDate = new DateTime(2020, 1, 1),
-                            Specialties = new List<string> { "Tester" }
-                        },
-                        new ActiveRoles
-                            {
-                                FromDate = new DateTime(2015, 1, 1),
-                                ToDate = new DateTime(2020, 1, 1),
-                                Specialties = new List<string> { "Dev" }
-                            }
-                        }
-                    });
-
-            s.SaveChanges();
+            InsertUsers(store);
         }
 
         new SearchIndex().Execute(store);
@@ -116,7 +32,6 @@ public class RavenDB_18594 : RavenTestBase
             const string term = "Engineer";
                
             var query = s.Query<SearchIndex.ReduceResult, SearchIndex>().Search(r => r.ProfileTitle, term, boost: 10).Search(r => r.PreviousRolesSpecialties, term, boost: 5, SearchOptions.Or).OrderByScore();
- 
 
             var docQuery = query.As<UserDocument>().ToDocumentQuery().IncludeExplanations(out var _);
             var queryResults = docQuery.GetQueryResult();
@@ -129,6 +44,75 @@ public class RavenDB_18594 : RavenTestBase
         }
     }
     
+    [Fact]
+    public void ShouldApplyBoostingToDocumentInsteadOfIndividualFieldsInStaticJavaScriptIndex()
+    {
+        using var store = GetDocumentStore();
+        {
+            InsertUsers(store);
+        }
+
+        new SearchJavaScriptIndex().Execute(store);
+        Indexes.WaitForIndexing(store);
+        
+        WaitForUserToContinueTheTest(store);
+
+        {
+            using var s = store.OpenSession();
+            const string term = "Engineer";
+               
+            var query = s.Query<SearchJavaScriptIndex.ReduceResult, SearchJavaScriptIndex>().Search(r => r.ProfileTitle, term, boost: 10).Search(r => r.PreviousRolesSpecialties, term, boost: 5, SearchOptions.Or).OrderByScore();
+
+            var docQuery = query.As<UserDocument>().ToDocumentQuery().IncludeExplanations(out var _);
+            var queryResults = docQuery.GetQueryResult();
+            var explanations = queryResults.Explanations;
+            var results = query.As<UserDocument>().ToArray();
+            Assert.Equal(2, results.Length);
+            Assert.Equal(2, results.First().FifoId);
+            Assert.Equal(1, results.Last().FifoId);
+            Assert.Contains("0.875 = fieldNorm(field=PreviousRolesSpecialties, doc=0)", explanations["Doc1"][0]);
+        }
+    }
+
+    private static void InsertUsers(DocumentStore store)
+    {
+        using var s = store.OpenSession();
+        s.Store(new UserDocument
+        {
+            Id = "Doc1",
+            FifoId = 1,
+            CvRankingBoostFactor = 2,
+            ProfileTitle = "Developer",
+            CurrentRole = new ActiveRoles {FromDate = new DateTime(2012, 1, 1), ToDate = new DateTime(2020, 1, 1), Specialties = new List<string> {"Developer"}},
+            ActiveRoles = new List<ActiveRoles>
+            {
+                new ActiveRoles {FromDate = new DateTime(2015, 1, 1), ToDate = new DateTime(2020, 1, 1), Specialties = new List<string> {"Engineer"}},
+                new ActiveRoles {FromDate = new DateTime(2015, 1, 1), ToDate = new DateTime(2020, 1, 1), Specialties = new List<string> {"Coder"}},
+                new ActiveRoles {FromDate = new DateTime(2015, 1, 1), ToDate = new DateTime(2020, 1, 1), Specialties = new List<string> {"Analyst"}},
+                new ActiveRoles {FromDate = new DateTime(2015, 1, 1), ToDate = new DateTime(2020, 1, 1), Specialties = new List<string> {"Tester"}},
+                new ActiveRoles {FromDate = new DateTime(2015, 1, 1), ToDate = new DateTime(2020, 1, 1), Specialties = new List<string> {"Dev"}}
+            }
+        });
+        s.Store(new UserDocument
+        {
+            Id = "Doc2",
+            FifoId = 2,
+            CvRankingBoostFactor = 2,
+            ProfileTitle = "Engineer",
+            CurrentRole = new ActiveRoles {FromDate = new DateTime(2132, 1, 1), ToDate = new DateTime(2020, 1, 1), Specialties = new List<string> {"Developer"}},
+            ActiveRoles = new List<ActiveRoles>
+            {
+                new ActiveRoles {FromDate = new DateTime(2015, 1, 1), ToDate = new DateTime(2020, 1, 1), Specialties = new List<string> {"Developer"}},
+                new ActiveRoles {FromDate = new DateTime(2015, 1, 1), ToDate = new DateTime(2020, 1, 1), Specialties = new List<string> {"Coder"}},
+                new ActiveRoles {FromDate = new DateTime(2015, 1, 1), ToDate = new DateTime(2020, 1, 1), Specialties = new List<string> {"Analyst"}},
+                new ActiveRoles {FromDate = new DateTime(2015, 1, 1), ToDate = new DateTime(2020, 1, 1), Specialties = new List<string> {"Tester"}},
+                new ActiveRoles {FromDate = new DateTime(2015, 1, 1), ToDate = new DateTime(2020, 1, 1), Specialties = new List<string> {"Dev"}}
+            }
+        });
+
+        s.SaveChanges();
+    }
+
     private class UserDocument
     {
         public List<ActiveRoles> ActiveRoles { get; set; }
@@ -153,7 +137,6 @@ public class RavenDB_18594 : RavenTestBase
     
     private class SearchIndex : AbstractIndexCreationTask<UserDocument, SearchIndex.ReduceResult>
     {
-
         public class ReduceResult
         {
             public string ProfileTitle { get; set; }
@@ -172,6 +155,43 @@ public class RavenDB_18594 : RavenTestBase
                     ProfileTitle = doc.ProfileTitle
                     
                 }.Boost(doc.CvRankingBoostFactor);
+            
+            Index(x => x.PreviousRolesSpecialties, FieldIndexing.Search);
+            Index(x => x.ProfileTitle, FieldIndexing.Search);
+
+            Analyze(x => x.PreviousRolesSpecialties, "StandardAnalyzer");
+            Analyze(x => x.ProfileTitle, "StandardAnalyzer");
+        }
+    }
+    
+    private class SearchJavaScriptIndex : AbstractJavaScriptIndexCreationTask
+    {
+        public class ReduceResult
+        {
+            public string ProfileTitle { get; set; }
+            public List<string> PreviousRolesSpecialties { get; set; }
+
+            public int FifoId { get; set; }
+        }
+
+        public SearchJavaScriptIndex()
+        {
+            Maps = new HashSet<string>
+            {
+                @"map('UserDocuments', function (doc) { 
+                    return boost({ 
+                                    PreviousRolesSpecialties: doc.ActiveRoles.filter(r4 => r4 != doc.CurrentRole).map(r => r.Specialties).flat(), 
+                                    FifoId: doc.FifoId, 
+                                    ProfileTitle: doc.ProfileTitle
+                                },
+                                doc.CvRankingBoostFactor) })"
+            };
+
+            Fields = new Dictionary<string, IndexFieldOptions>()
+            {
+                {"PreviousRolesSpecialties", new IndexFieldOptions {Indexing = FieldIndexing.Search, Analyzer = "StandardAnalyzer"}},
+                {"ProfileTitle", new IndexFieldOptions {Indexing = FieldIndexing.Search, Analyzer = "StandardAnalyzer"}},
+            };
         }
     
     }

--- a/test/SlowTests/Issues/RavenDB-18594.cs
+++ b/test/SlowTests/Issues/RavenDB-18594.cs
@@ -1,0 +1,179 @@
+﻿using System;
+using System.Collections.Generic;
+using System.Linq;
+using FastTests;
+using Raven.Client.Documents;
+using Raven.Client.Documents.Indexes;
+using Raven.Client.Documents.Linq.Indexing;
+using Xunit;
+using Xunit.Abstractions;
+
+namespace SlowTests.Issues;
+
+public class RavenDB_18594 : RavenTestBase
+{
+    public RavenDB_18594(ITestOutputHelper output) : base(output)
+    {
+    }
+    
+    [Fact]
+    public void ShouldApplyBoostingToDocumentInsteadOfIndividualFields()
+    {
+        using var store = GetDocumentStore();
+        {
+            using var s = store.OpenSession();
+             s.Store(new UserDocument
+                {
+                    Id = "Doc1",
+                    FifoId = 1,
+                    CvRankingBoostFactor = 2,
+                    ProfileTitle = "Developer",
+                    CurrentRole = new ActiveRoles { FromDate = new DateTime(2012, 1, 1), ToDate = new DateTime(2020, 1, 1), Specialties = new List<string> { "Developer" } },
+                    ActiveRoles = new List<ActiveRoles>
+                    {
+                        new ActiveRoles
+                        {
+                            FromDate = new DateTime(2015, 1, 1),
+                            ToDate = new DateTime(2020, 1, 1),
+                            Specialties = new List<string> { "Engineer" }
+                        },
+                        new ActiveRoles
+                        {
+                            FromDate = new DateTime(2015, 1, 1),
+                            ToDate = new DateTime(2020, 1, 1),
+                            Specialties = new List<string> { "Coder" }
+                        },
+                        new ActiveRoles
+                        {
+                            FromDate = new DateTime(2015, 1, 1),
+                            ToDate = new DateTime(2020, 1, 1),
+                            Specialties = new List<string> { "Analyst" }
+                        },
+                        new ActiveRoles
+                        {
+                            FromDate = new DateTime(2015, 1, 1),
+                            ToDate = new DateTime(2020, 1, 1),
+                            Specialties = new List<string> { "Tester" }
+                        },
+                        new ActiveRoles
+                        {
+                            FromDate = new DateTime(2015, 1, 1),
+                            ToDate = new DateTime(2020, 1, 1),
+                            Specialties = new List<string> { "Dev" }
+                        }
+                    }
+                });
+                s.Store(new UserDocument
+                {
+                    Id = "Doc2",
+                    FifoId = 2,
+                    CvRankingBoostFactor = 2,
+                    ProfileTitle = "Engineer",
+                    CurrentRole = new ActiveRoles { FromDate = new DateTime(2132, 1, 1), ToDate = new DateTime(2020, 1, 1), Specialties = new List<string> { "Developer" } },
+                    ActiveRoles = new List<ActiveRoles>
+                    {
+                        new ActiveRoles
+                        {
+                            FromDate = new DateTime(2015, 1, 1),
+                            ToDate = new DateTime(2020, 1, 1),
+                            Specialties = new List<string> { "Developer" }
+                        },
+                        new ActiveRoles
+                        {
+                            FromDate = new DateTime(2015, 1, 1),
+                            ToDate = new DateTime(2020, 1, 1),
+                            Specialties = new List<string> { "Coder" }
+                        },
+                        new ActiveRoles
+                        {
+                            FromDate = new DateTime(2015, 1, 1),
+                            ToDate = new DateTime(2020, 1, 1),
+                            Specialties = new List<string> { "Analyst" }
+                        },
+                        new ActiveRoles
+                        {
+                            FromDate = new DateTime(2015, 1, 1),
+                            ToDate = new DateTime(2020, 1, 1),
+                            Specialties = new List<string> { "Tester" }
+                        },
+                        new ActiveRoles
+                            {
+                                FromDate = new DateTime(2015, 1, 1),
+                                ToDate = new DateTime(2020, 1, 1),
+                                Specialties = new List<string> { "Dev" }
+                            }
+                        }
+                    });
+
+            s.SaveChanges();
+        }
+
+        new SearchIndex().Execute(store);
+        Indexes.WaitForIndexing(store);
+
+        {
+            using var s = store.OpenSession();
+            const string term = "Engineer";
+               
+            var query = s.Query<SearchIndex.ReduceResult, SearchIndex>().Search(r => r.ProfileTitle, term, boost: 10).Search(r => r.PreviousRolesSpecialties, term, boost: 5, SearchOptions.Or).OrderByScore();
+ 
+
+            var docQuery = query.As<UserDocument>().ToDocumentQuery().IncludeExplanations(out var _);
+            var queryResults = docQuery.GetQueryResult();
+            var explanations = queryResults.Explanations;
+            var results = query.As<UserDocument>().ToArray();
+            Assert.Equal(2, results.Length);
+            Assert.Equal(2, results.First().FifoId);
+            Assert.Equal(1, results.Last().FifoId);
+            Assert.Contains("0.875 = fieldNorm(field=PreviousRolesSpecialties, doc=0)", explanations["Doc1"][0]);
+        }
+    }
+    
+    private class UserDocument
+    {
+        public List<ActiveRoles> ActiveRoles { get; set; }
+        
+        public ActiveRoles CurrentRole { get; set; }
+        
+        public int CvRankingBoostFactor { get; set; }
+        
+        public int FifoId { get; set; }
+        
+        public string ProfileTitle { get; set; }
+        
+        public string Id { get; set; }
+    }
+    
+    private class ActiveRoles
+    {
+        public DateTimeOffset FromDate { get; set; }
+        public List<string> Specialties { get; set; }
+        public object ToDate { get; set; }
+    }
+    
+    private class SearchIndex : AbstractIndexCreationTask<UserDocument, SearchIndex.ReduceResult>
+    {
+
+        public class ReduceResult
+        {
+            public string ProfileTitle { get; set; }
+            public List<string> PreviousRolesSpecialties { get; set; }
+
+            public int FifoId { get; set; }
+        }
+
+        public SearchIndex()
+        {
+            Map = docs => from doc in docs
+                select new ReduceResult()
+                {
+                    PreviousRolesSpecialties = doc.ActiveRoles.Where(r4 => r4 != doc.CurrentRole).SelectMany(r => r.Specialties).ToList(),
+                    FifoId = doc.FifoId,
+                    ProfileTitle = doc.ProfileTitle
+                    
+                }.Boost(doc.CvRankingBoostFactor);
+        }
+    
+    }
+
+}


### PR DESCRIPTION
### Issue link
https://issues.hibernatingrhinos.com/issue/RavenDB-18594 

### Additional description

The problem was that if we had boosting applied on the whole indexing result e.g. `from u in docs.Users select new { ... }.Boost(5)` then we applied the boosting value to each field of the result instead of setting it to Lucene's document instance.

That in turns caused the `fieldNorms` to have very high values and affected the final scoring of query results:

https://github.com/ravendb/lucenenet/blob/60d42a72ed5d20645c1244217dd2b5ea59241420/src/Lucene.Net/Search/Similarity.cs#L441-L444

In result we got results in different order than in version 3.5.

### Type of change

- Regression bug fix (Introduced in 4.0. It was working as expected in 3.5)


### How risky is the change?


- Moderate


### Backward compatibility


- Non breaking change


### Is it platform specific issue?

- No

### Documentation update

- No documentation update is needed 

### Testing 

- Tests have been added that prove the fix is effective or that the feature works

### Is there any existing behavior change of other features due to this change?

- Yes
  - Boosting - now the boosting on entire document works correctly

### UI work

- No UI work is needed
