### PR TITLE
RavenDB-18565  Patch & Query Views: refactor the disable-auto-indexes…

### DIFF
--- a/src/Raven.Studio/wwwroot/App/views/database/patch/patch.html
+++ b/src/Raven.Studio/wwwroot/App/views/database/patch/patch.html
@@ -408,7 +408,7 @@
         <div class="margin-left margin-left-sm">
             <div class="toggle">
                 <input id="disableAutoIndex" type="checkbox" data-bind="checked: disableAutoIndexCreation">
-                <label for="disableAutoIndex">Disable creating new Auto-Indexes</label>
+                <label for="disableAutoIndex">Don't create a new Auto-Index</label>
             </div>
             <div class="toggle">
                 <input id="maxOperations" class="styled" type="checkbox" data-bind="checked: defineMaxOperationsPerSecond">

--- a/src/Raven.Studio/wwwroot/App/views/database/query/query.html
+++ b/src/Raven.Studio/wwwroot/App/views/database/query/query.html
@@ -335,7 +335,7 @@
         </div>
         <div class="toggle margin-left">
             <input id="disableAutoIndex" type="checkbox" data-bind="checked: disableAutoIndexCreation">
-            <label for="disableAutoIndex">Disable creating new Auto-Indexes</label>
+            <label for="disableAutoIndex">Don't create a new Auto-Index</label>
         </div>
         <div class="toggle margin-left">
             <input id="storedFields" type="checkbox" data-bind="checked: criteria().showFields, disable: isCollectionQuery() || isGraphQuery()">

--- a/src/Raven.Studio/wwwroot/App/views/database/settings/studioConfiguration.html
+++ b/src/Raven.Studio/wwwroot/App/views/database/settings/studioConfiguration.html
@@ -24,7 +24,7 @@
                                 <label class="control-label">&nbsp;</label>
                                 <div class="toggle margin-top disable-auto-index" data-placement="right" data-toggle="tooltip" data-animation="true">
                                     <input id="disableAutoIndex" type="checkbox" data-bind="checked: model.disableAutoIndexCreation" />
-                                    <label for="disableAutoIndex">Disable auto-index creation</label>
+                                    <label for="disableAutoIndex">Disable creating new Auto-Indexes</label>
                                 </div>
                             </div>
                             <div class="form-group margin-top margin-top-lg">


### PR DESCRIPTION
… label

### Issue link
https://issues.hibernatingrhinos.com/issue/RavenDB-18565

### Additional description
Fix the the disable-auto-indexes label

### Type of change
- Bug fix

### How risky is the change?
- Low 

### Backward compatibility
- Non breaking change

### Is it platform specific issue?
- No

### Documentation update
- No documentation update is needed 

### Testing 
- It has been verified by manual testing

### Is there any existing behavior change of other features due to this change?
- No

### UI work
- No UI work is needed
