### PR TITLE
RavenDB-18572 Don't show link after we navigated away from the delete…

### DIFF
--- a/src/Raven.Studio/typescript/viewmodels/database/documents/editDocument.ts
+++ b/src/Raven.Studio/typescript/viewmodels/database/documents/editDocument.ts
@@ -589,7 +589,9 @@ class editDocument extends viewModelBase {
         }
         
         if (change.Type === 'Delete') {
-            this.displayDocumentDeleted(true);
+            if (this.editedDocId() === change.Id) {
+                this.displayDocumentDeleted(true);
+            }
         } else {
             this.displayDocumentChange(true);
         }
@@ -1147,6 +1149,7 @@ class editDocument extends viewModelBase {
             viewModel.deletionTask.done(() => {
                 this.dirtyFlag().reset();
                 this.connectedDocuments.onDocumentDeleted();
+                this.displayDocumentDeleted(false);
             });
             app.showBootstrapDialog(viewModel, editDocument.editDocSelector);
         } 


### PR DESCRIPTION
…d document...

### Issue link
https://issues.hibernatingrhinos.com/issue/RavenDB-18572

### Additional description

Don't show the link after we already navigated away from the deleted document.
LInk is only relevant if document was deleted 'outside' of current tab.

### Type of change
- Bug fix

### How risky is the change?
- Low 

### Backward compatibility
- Non breaking change

### Is it platform specific issue?
- No

### Documentation update
- No documentation update is needed 

### Testing 
- It has been verified by manual testing

### Is there any existing behavior change of other features due to this change?
- No

### UI work
- No UI work is needed
