### PR TITLE
RavenDB-18599 Menu item Recent should be All Documents

### DIFF
--- a/src/Raven.Studio/typescript/common/shell/menu/items/documents.ts
+++ b/src/Raven.Studio/typescript/common/shell/menu/items/documents.ts
@@ -8,7 +8,7 @@ export = getDocumentsMenuItem;
 function getDocumentsMenuItem(appUrls: computedAppUrls) {
     let documentsItems = [
         new leafMenuItem({
-            title: "List of documents",
+            title: "All Documents",
             nav: false,
             route: "databases/documents",
             moduleId: require("viewmodels/database/documents/documents"),

--- a/src/Raven.Studio/wwwroot/App/views/shell.html
+++ b/src/Raven.Studio/wwwroot/App/views/shell.html
@@ -179,8 +179,8 @@
         <li>
             <!-- ko with: $root.collectionsTracker.getAllDocumentsCollection() -->
             <a data-bind="click: $parent.menu.navigate.bind($parent.menu), attr: { href: $root.urlForCollection($data) }, css: { 'active': $parent.item.isOpen($parent.menu.activeItem, $data) }">
-                <i class="icon-recent"></i>
-                <span>Recent</span>
+                <i class="icon-documents"></i>
+                <span>All Documents</span>
                 <div class="collection-count" data-bind="attr: {title: documentCount().toLocaleString()}, css: { 'bounce': hasBounceClass }">
                     <div class="value label label-default" data-bind="text: countPrefix"></div>
                     <div data-bind="attr: { class: sizeClass }"></div>


### PR DESCRIPTION
### Issue link
https://issues.hibernatingrhinos.com/issue/RavenDB-18599

### Additional description
Recent => All Documents

### Type of change
- Bug fix

### How risky is the change?
- Low 

### Backward compatibility
- Non breaking change

### Is it platform specific issue?
- No

### Documentation update
- This change requires a documentation update !!

### Testing 
- It has been verified by manual testing

### Is there any existing behavior change of other features due to this change?
- No

### UI work
- No UI work is needed
