### PR TITLE
RavenDB-18610 Missing the node type icon in the Cluster Topology Graph

### DIFF
--- a/src/Raven.Studio/typescript/common/helpers/view/icomoonHelpers.ts
+++ b/src/Raven.Studio/typescript/common/helpers/view/icomoonHelpers.ts
@@ -39,7 +39,12 @@ class icomoonHelpers {
         "connection-lost": 0xf120,
         "empty-set": 0xf121,
         "disabled": 0xf122,
-        "conflicts": 0xf123
+        "conflicts": 0xf123,
+        "waiting": 0xf124,
+        "cluster-member": 0xf125,
+        "cluster-promotable": 0xf126,
+        "cluster-watcher": 0xf127
+        
     } as const;
     
     static getCodePointForCanvas(iconName: keyof typeof icomoonHelpers.fixedCodepoints): string {

--- a/src/Raven.Studio/typescript/models/database/cluster/clusterGraph.ts
+++ b/src/Raven.Studio/typescript/models/database/cluster/clusterGraph.ts
@@ -224,11 +224,13 @@ class clusterGraph {
 
             switch (node.type()) {
                 case "Member":
-                    return "&#xe9ca;";
+                    return icomoonHelpers.getCodePointForCanvas("cluster-member");
                 case "Promotable":
-                    return "&#xe9cc;";
+                    return icomoonHelpers.getCodePointForCanvas("cluster-promotable");
                 case "Watcher":
-                    return leaderTag ? "&#xe9cd;" : "&#xe9a9;";
+                    return leaderTag 
+                        ? icomoonHelpers.getCodePointForCanvas("cluster-watcher")
+                        : icomoonHelpers.getCodePointForCanvas("waiting")
             }
             return "";
         };

--- a/src/Raven.Studio/webpack.config.js
+++ b/src/Raven.Studio/webpack.config.js
@@ -161,7 +161,11 @@ module.exports = (env, args) => {
                                     "connection-lost": 0xf120,
                                     "empty-set": 0xf121,
                                     "disabled": 0xf122,
-                                    "conflicts": 0xf123
+                                    "conflicts": 0xf123,
+                                    "waiting": 0xf124,
+                                    "cluster-member": 0xf125,
+                                    "cluster-promotable": 0xf126,
+                                    "cluster-watcher": 0xf127
                                 },
                                 cssTemplate: path.resolve(__dirname, "wwwroot/Content/css/fonts/icomoon.template.css.hbs")
                             }

--- a/src/Raven.Studio/wwwroot/Content/css/checkbox-toggle.less
+++ b/src/Raven.Studio/wwwroot/Content/css/checkbox-toggle.less
@@ -3,7 +3,7 @@
 // --------------------------------------------------
 
 @font-family-icon: 'icomoon';
-@fa-var-check: "\f116";
+@fa-var-check: "\f11B";
 @check-icon: @fa-var-check;
 
 .checkbox input[type="checkbox"]:focus + label::before, .checkbox input[type="radio"]:focus + label::before, .toggle input[type="checkbox"]:focus + label::before {


### PR DESCRIPTION
### Issue link

https://issues.hibernatingrhinos.com/issue/RavenDB-18610 

### Additional description

Fixed icons

