### PR TITLE
RavenDB-18609: prevent idling the database when there is subscription with active connection

### DIFF
--- a/src/Raven.Client/Exceptions/Documents/Subscriptions/SubscriptionClosedException.cs
+++ b/src/Raven.Client/Exceptions/Documents/Subscriptions/SubscriptionClosedException.cs
@@ -24,5 +24,9 @@ namespace Raven.Client.Exceptions.Documents.Subscriptions
         public SubscriptionClosedException(string message, Exception inner) : base(message, inner)
         {
         }
+        public SubscriptionClosedException(string message, bool canReconnect, Exception inner) : base(message, inner)
+        {
+            CanReconnect = canReconnect;
+        }
     }
 }

--- a/src/Raven.Server/Documents/Subscriptions/SubscriptionStorage.cs
+++ b/src/Raven.Server/Documents/Subscriptions/SubscriptionStorage.cs
@@ -454,6 +454,24 @@ namespace Raven.Server.Documents.Subscriptions
             }
         }
 
+        public int GetNumberOfRunningSubscriptions()
+        {
+            using (_db.ServerStore.ContextPool.AllocateOperationContext(out TransactionOperationContext context))
+            using (context.OpenReadTransaction())
+            {
+                var c = 0;
+                foreach ((_, SubscriptionConnectionsState value) in _subscriptions)
+                {
+                    if (value.IsSubscriptionActive() == false)
+                        continue;
+
+                    c++;
+                }
+
+                return c;
+            }
+        }
+
         public SubscriptionGeneralDataAndStats GetSubscription(TransactionOperationContext context, long? id, string name, bool history)
         {
             SubscriptionGeneralDataAndStats subscription;

--- a/src/Raven.Server/Documents/TcpHandlers/SubscriptionConnection.cs
+++ b/src/Raven.Server/Documents/TcpHandlers/SubscriptionConnection.cs
@@ -1079,7 +1079,7 @@ namespace Raven.Server.Documents.TcpHandlers
             }
             catch (Exception ex)
             {
-                throw new SubscriptionClosedException($"Cannot contact client anymore, closing subscription ({Options?.SubscriptionName})", ex);
+                throw new SubscriptionClosedException($"Cannot contact client anymore, closing subscription ({Options?.SubscriptionName})", canReconnect: ex is OperationCanceledException, ex);
             }
 
             TcpConnection.RegisterBytesSent(Heartbeat.Length);

--- a/src/Raven.Server/ServerWide/ServerStore.cs
+++ b/src/Raven.Server/ServerWide/ServerStore.cs
@@ -2550,6 +2550,21 @@ namespace Raven.Server.ServerWide
                     statistics.Explanations.Add($"Cannot unload database because number of Changes API connections ({numberOfChangesApiConnections}) is greater than 0");
                 }
             }
+            using (database.ServerStore.ContextPool.AllocateOperationContext(out TransactionOperationContext context))
+            using (context.OpenReadTransaction())
+            {
+                var numberOfSubscriptionConnections = database.SubscriptionStorage.GetAllRunningSubscriptions(context, false, 0, int.MaxValue).ToList().Count;
+                if (statistics != null)
+                    statistics.NumberOfSubscriptionConnections = numberOfSubscriptionConnections;
+
+                if (numberOfSubscriptionConnections > 0)
+                {
+                    if (statistics == null)
+                        return false;
+
+                    statistics.Explanations.Add($"Cannot unload database because number of Subscriptions connections ({numberOfSubscriptionConnections}) is greater than 0");
+                }
+            }
 
             var hasActiveOperations = database.Operations.HasActive;
             if (statistics != null)

--- a/src/Raven.Server/ServerWide/ServerStore.cs
+++ b/src/Raven.Server/ServerWide/ServerStore.cs
@@ -2550,20 +2550,17 @@ namespace Raven.Server.ServerWide
                     statistics.Explanations.Add($"Cannot unload database because number of Changes API connections ({numberOfChangesApiConnections}) is greater than 0");
                 }
             }
-            using (database.ServerStore.ContextPool.AllocateOperationContext(out TransactionOperationContext context))
-            using (context.OpenReadTransaction())
+
+            var numberOfSubscriptionConnections = database.SubscriptionStorage.GetNumberOfRunningSubscriptions();
+            if (statistics != null)
+                statistics.NumberOfSubscriptionConnections = numberOfSubscriptionConnections;
+
+            if (numberOfSubscriptionConnections > 0)
             {
-                var numberOfSubscriptionConnections = database.SubscriptionStorage.GetAllRunningSubscriptions(context, false, 0, int.MaxValue).ToList().Count;
-                if (statistics != null)
-                    statistics.NumberOfSubscriptionConnections = numberOfSubscriptionConnections;
+                if (statistics == null)
+                    return false;
 
-                if (numberOfSubscriptionConnections > 0)
-                {
-                    if (statistics == null)
-                        return false;
-
-                    statistics.Explanations.Add($"Cannot unload database because number of Subscriptions connections ({numberOfSubscriptionConnections}) is greater than 0");
-                }
+                statistics.Explanations.Add($"Cannot unload database because number of Subscriptions connections ({numberOfSubscriptionConnections}) is greater than 0");
             }
 
             var hasActiveOperations = database.Operations.HasActive;

--- a/src/Raven.Server/Web/System/DatabasesDebugHandler.cs
+++ b/src/Raven.Server/Web/System/DatabasesDebugHandler.cs
@@ -74,6 +74,8 @@ namespace Raven.Server.Web.System
 
             public int NumberOfChangesApiConnections { get; set; }
 
+            public int NumberOfSubscriptionConnections { get; set; }
+
             public bool HasActiveOperations { get; set; }
 
             public List<string> Explanations { get; set; }


### PR DESCRIPTION
### Issue link

https://issues.hibernatingrhinos.com/issue/RavenDB-18609

### Additional description

Don't idle the database when there is a subscription with active connection


### Type of change

- Bug fix
- New feature
- Optimization

### How risky is the change?

- Low 


### Backward compatibility


- Not relevant

### Is it platform specific issue?


- No

### Documentation update

- No documentation update is needed 

### Testing 

- Tests have been added that prove the fix is effective or that the feature works



### Is there any existing behavior change of other features due to this change?


- No

### UI work


- No UI work is needed
