### PR TITLE
RavenDB-18229 Sharding - Edit Replication Hub View - No need for node…

### DIFF
--- a/src/Raven.Studio/typescript/commands/database/tasks/getReplicationHubTaskInfoCommand.ts
+++ b/src/Raven.Studio/typescript/commands/database/tasks/getReplicationHubTaskInfoCommand.ts
@@ -1,23 +1,17 @@
 import commandBase = require("commands/commandBase");
 import database = require("models/resources/database");
 import endpoints = require("endpoints");
-import clusterTopologyManager from "common/shell/clusterTopologyManager";
-import { shardingTodo } from "common/developmentHelper";
 
 class getReplicationHubTaskInfoCommand extends commandBase {
 
     constructor(private db: database, private taskId: number) {
-          super();
+        super();
     }
 
     execute(): JQueryPromise<Raven.Client.Documents.Operations.Replication.PullReplicationDefinitionAndCurrentConnections> {
         
-        shardingTodo("ANY", "Currently, the Hub GET is implemented only for Single-Shard-Only (while PUT is All-Shards-Only)");
-        const location = this.db.getFirstLocation(clusterTopologyManager.default.localNodeTag());
-        
         const args = {
-            key: this.taskId,
-            ...location
+            key: this.taskId
         };
         
         const url = endpoints.databases.ongoingTasks.tasksPullReplicationHub + this.urlEncodeArgs(args);
@@ -29,4 +23,4 @@ class getReplicationHubTaskInfoCommand extends commandBase {
     }
 }
 
-export = getReplicationHubTaskInfoCommand; 
+export = getReplicationHubTaskInfoCommand;


### PR DESCRIPTION
### Issue link

https://issues.hibernatingrhinos.com/issue/RavenDB-18229

### Additional description
No need to GET the hub task w/ nodeTag & shardNumber - using key only

### Type of change
- Bug fix

### How risky is the change?
- Low 

### Backward compatibility
- Non breaking change

### Is it platform specific issue?
- No

### Documentation update
- No documentation update is needed 

### Testing 
- It has been verified by manual testing

### Is there any existing behavior change of other features due to this change?
- No

### UI work
- No UI work is needed
