### PR TITLE
RavenDB-18199 Fixing failing test on Linux due to line endings

### DIFF
--- a/test/SlowTests/Sharding/Issues/RavenDB_18199.cs
+++ b/test/SlowTests/Sharding/Issues/RavenDB_18199.cs
@@ -113,7 +113,7 @@ namespace SlowTests.Core.Utils.Entities
 		public object LastName { get; set; } 
 		public object Name { get; set; } 
 	}
-}", commandResult);
+}", RavenTestHelper.NormalizeNewLines(commandResult));
                 }
             }
         }

--- a/test/Tests.Infrastructure/RavenTestHelper.cs
+++ b/test/Tests.Infrastructure/RavenTestHelper.cs
@@ -160,14 +160,14 @@ namespace FastTests
 
         public static void AssertEqualRespectingNewLines(string expected, string actual)
         {
-            var converted = ConvertRespectingNewLines(expected);
+            var converted = NormalizeNewLines(expected);
 
             Assert.Equal(converted, actual);
         }
 
         public static void AssertStartsWithRespectingNewLines(string expected, string actual)
         {
-            var converted = ConvertRespectingNewLines(expected);
+            var converted = NormalizeNewLines(expected);
 
             Assert.StartsWith(converted, actual);
         }
@@ -211,7 +211,7 @@ namespace FastTests
             }
         }
 
-        private static string ConvertRespectingNewLines(string toConvert)
+        internal static string NormalizeNewLines(string toConvert)
         {
             if (string.IsNullOrEmpty(toConvert))
                 return toConvert;


### PR DESCRIPTION
### Issue link

https://issues.hibernatingrhinos.com/issue/RavenDB-18199

### Additional description

It fixes test failures on Linux due to inconsistency in line endings

### Type of change

- Test fix

### How risky is the change?

- Low 

### Backward compatibility

- Not relevant

### Is it platform specific issue?

- No

### Documentation update

- No documentation update is needed 

### Testing 

- Existing tests will verify it

### Is there any existing behavior change of other features due to this change?

- No

### UI work

- No UI work is needed
