### PR TITLE
RavenDB-18473 Let us ignore the creation of the attachment tombstone if it already exists.

### DIFF
--- a/src/Raven.Server/Documents/AttachmentsStorage.cs
+++ b/src/Raven.Server/Documents/AttachmentsStorage.cs
@@ -1274,6 +1274,10 @@ namespace Raven.Server.Documents
             var newEtag = _documentsStorage.GenerateNextEtag();
 
             var table = context.Transaction.InnerTransaction.OpenTable(TombstonesSchema, AttachmentsTombstonesSlice);
+
+            if (table.VerifyKeyExists(keySlice))
+                return; // attachments (and attachment tombstones) are immutable, we can safely ignore this
+
             using (table.Allocate(out TableValueBuilder tvb))
             using (Slice.From(context.Allocator, changeVector, out var cv))
             {

--- a/test/SlowTests/Issues/RavenDB_18473.cs
+++ b/test/SlowTests/Issues/RavenDB_18473.cs
@@ -1,0 +1,87 @@
+﻿using System;
+using System.IO;
+using System.Threading.Tasks;
+using FastTests;
+using FastTests.Server.Replication;
+using FastTests.Utils;
+using Raven.Client.Documents.Operations.Attachments;
+using Raven.Client.Documents.Smuggler;
+using Raven.Tests.Core.Utils.Entities;
+using Xunit;
+using Xunit.Abstractions;
+
+namespace SlowTests.Issues;
+
+public class RavenDB_18473 : ReplicationTestBase
+{
+    public RavenDB_18473(ITestOutputHelper output) : base(output)
+    {
+    }
+
+    [Fact]
+    public async Task MustNotThrowVoronConcurrencyErrorExceptionDuringReplication()
+    {
+        var file = GetTempFileName();
+        try
+        {
+            using (var store1 = GetDocumentStore())
+            using (var store2 = GetDocumentStore())
+            {
+                // Important: the issue reproduces only when RevisionsCollectionConfiguration.PurgeOnDelete is true
+                // that is the setup for "Users" collection. Let's verify that during the setup.
+
+                await RevisionsHelper.SetupRevisions(Server.ServerStore, store1.Database, x => Assert.True(x.Collections["Users"].PurgeOnDelete));
+                await RevisionsHelper.SetupRevisions(Server.ServerStore, store2.Database, x => Assert.True(x.Collections["Users"].PurgeOnDelete));
+
+                using (var session = store1.OpenSession())
+                {
+                    session.Store(new User { Name = "Foo" }, "users/1");
+                    session.SaveChanges();
+                }
+
+                await using (var profileStream = new MemoryStream(new byte[] { 1, 2, 3 }))
+                {
+                    store1.Operations.Send(new PutAttachmentOperation("users/1", "foo", profileStream, "image/png"));
+                }
+
+                using (var session = store1.OpenSession())
+                {
+                    var u = session.Load<User>("users/1");
+                    u.Name = "karmel";
+                    session.SaveChanges();
+                }
+
+                using (var session = store2.OpenSession())
+                {
+                    session.Store(new User { Name = "Foo" }, "users/1");
+                    session.SaveChanges();
+                }
+
+                await using (var profileStream = new MemoryStream(new byte[] { 1, 2, 3 }))
+                {
+                    store2.Operations.Send(new PutAttachmentOperation("users/1", "foo", profileStream, "image/png"));
+                }
+
+                using (var session = store1.OpenSession())
+                {
+                    session.Delete("users/1");
+                    session.SaveChanges();
+                }
+
+                await SetupReplicationAsync(store1, store2);
+                await EnsureReplicatingAsync(store1, store2);
+
+                using (var session = store2.OpenSession())
+                {
+                    var user = session.Load<User>("users/1");
+                    Assert.Null(user);
+                }
+            }
+        }
+        finally
+        {
+            File.Delete(file);
+        }
+    }
+
+}


### PR DESCRIPTION
This can happen during the replication when attachments are also involved. The added code is consistent with RevisionsStorage.CreateTombstone().

### Issue link

https://issues.hibernatingrhinos.com/issue/RavenDB-RavenDB-18473

### Additional description

The added test reproduced the following exception thrown during the replication on a destination instance:

```
Voron.dll!Voron.Data.BTrees.Tree.ThrowConcurrencyException() Line 441	C#
 	Voron.dll!Voron.Data.BTrees.Tree.DirectAdd(Voron.Slice key, int len, Voron.Data.BTrees.TreeNodeFlags nodeType, out byte* ptr) Line 341	C#
 	Voron.dll!Voron.Data.Tables.Table.InsertIndexValuesFor(long id, ref Voron.Data.Tables.TableValueReader value) Line 898	C#
 	Voron.dll!Voron.Data.Tables.Table.Insert(Voron.Data.Tables.TableValueBuilder builder) Line 639	C#
 	Raven.Server.dll!Raven.Server.Documents.AttachmentsStorage.CreateTombstone(Raven.Server.ServerWide.Context.DocumentsOperationContext context, Voron.Slice keySlice, long attachmentEtag, string changeVector, long lastModifiedTicks) Line 1274	C#
 	Raven.Server.dll!Raven.Server.Documents.AttachmentsStorage.DeleteInternal(Raven.Server.ServerWide.Context.DocumentsOperationContext context, Voron.Slice key, long etag, Voron.Slice hash, string changeVector, long lastModifiedTicks) Line 1244	C#
 	Raven.Server.dll!Raven.Server.Documents.AttachmentsStorage.DeleteAttachmentsOfDocumentInternal.AnonymousMethod__0(Voron.Data.Tables.Table.TableValueHolder before) Line 1288	C#
 	Voron.dll!Voron.Data.Tables.Table.DeleteByPrimaryKeyPrefix(Voron.Slice startSlice, System.Action<Voron.Data.Tables.Table.TableValueHolder> beforeDelete, System.Func<Voron.Data.Tables.Table.TableValueHolder, bool> shouldAbort) Line 1774	C#
 	Raven.Server.dll!Raven.Server.Documents.AttachmentsStorage.DeleteAttachmentsOfDocumentInternal(Raven.Server.ServerWide.Context.DocumentsOperationContext context, Voron.Slice prefixSlice, string changeVector, long lastModifiedTicks) Line 1282	C#
 	Raven.Server.dll!Raven.Server.Documents.AttachmentsStorage.DeleteRevisionAttachments(Raven.Server.ServerWide.Context.DocumentsOperationContext context, Raven.Server.Documents.Document revision, string changeVector, long lastModifiedTicks) Line 1299	C#
 	Raven.Server.dll!Raven.Server.Documents.Revisions.RevisionsStorage.DeleteRevisions(Raven.Server.ServerWide.Context.DocumentsOperationContext context, Voron.Data.Tables.Table table, Voron.Slice prefixSlice, Raven.Server.Documents.CollectionName collectionName, long numberOfRevisionsToDelete, System.TimeSpan? minimumTimeToKeep, string changeVector, long lastModifiedTicks) Line 776	C#
 	Raven.Server.dll!Raven.Server.Documents.Revisions.RevisionsStorage.Delete(Raven.Server.ServerWide.Context.DocumentsOperationContext context, Voron.Slice lowerId, Voron.Slice idSlice, string id, Raven.Server.Documents.CollectionName collectionName, Sparrow.Json.BlittableJsonReaderObject deleteRevisionDocument, string changeVector, long lastModifiedTicks, Raven.Server.Documents.NonPersistentDocumentFlags nonPersistentFlags, Raven.Server.Documents.DocumentFlags flags) Line 943	C#
 	Raven.Server.dll!Raven.Server.Documents.Revisions.RevisionsStorage.Delete(Raven.Server.ServerWide.Context.DocumentsOperationContext context, string id, Voron.Slice lowerId, Raven.Server.Documents.CollectionName collectionName, string changeVector, long lastModifiedTicks, Raven.Server.Documents.NonPersistentDocumentFlags nonPersistentFlags, Raven.Server.Documents.DocumentFlags flags) Line 894	C#
 	Raven.Server.dll!Raven.Server.Documents.DocumentsStorage.Delete(Raven.Server.ServerWide.Context.DocumentsOperationContext context, Voron.Slice lowerId, string id, Sparrow.Json.LazyStringValue expectedChangeVector, long? lastModifiedTicks, string changeVector, Raven.Server.Documents.CollectionName collectionName, Raven.Server.Documents.NonPersistentDocumentFlags nonPersistentFlags, Raven.Server.Documents.DocumentFlags documentFlags) Line 1753	C#
 	Raven.Server.dll!Raven.Server.Documents.Replication.ResolveConflictOnReplicationConfigurationChange.PutResolvedDocument(Raven.Server.ServerWide.Context.DocumentsOperationContext context, Raven.Server.Documents.DocumentConflict resolved, bool resolvedToLatest, Raven.Server.Documents.DocumentConflict incoming) Line 307	C#
 	Raven.Server.dll!Raven.Server.Documents.Replication.ConflictManager.HandleConflictForDocument(Raven.Server.ServerWide.Context.DocumentsOperationContext documentsContext, string id, string collection, long lastModifiedTicks, Sparrow.Json.BlittableJsonReaderObject doc, string changeVector, Raven.Server.Documents.DocumentFlags flags) Line 91	C#
 	Raven.Server.dll!Raven.Server.Documents.Replication.IncomingReplicationHandler.MergedDocumentReplicationCommand.ExecuteCmd(Raven.Server.ServerWide.Context.DocumentsOperationContext context) Line 1361	C#
 	Raven.Server.dll!Raven.Server.Documents.TransactionOperationsMerger.MergedTransactionCommand.Execute(Raven.Server.ServerWide.Context.DocumentsOperationContext context, Raven.Server.Documents.TransactionOperationsMerger.RecordingState recordingState) Line 104	C#
 	Raven.Server.dll!Raven.Server.Documents.TransactionOperationsMerger.ExecutePendingOperationsInTransaction(System.Collections.Generic.List<Raven.Server.Documents.TransactionOperationsMerger.MergedTransactionCommand> executedOps, Raven.Server.ServerWide.Context.DocumentsOperationContext context, System.Threading.Tasks.Task previousOperation, ref Sparrow.Server.Meters.PerformanceMetrics.DurationMeasurement meter) Line 910	C#
 	Raven.Server.dll!Raven.Server.Documents.TransactionOperationsMerger.MergeTransactionsOnce() Line 518	C#
 	Raven.Server.dll!Raven.Server.Documents.TransactionOperationsMerger.MergeOperationThreadProc() Line 346	C#
 	Raven.Server.dll!Raven.Server.Documents.TransactionOperationsMerger.Start.AnonymousMethod__20_0(object x) Line 76	C#
 	Raven.Server.dll!Raven.Server.Utils.PoolOfThreads.PooledThread.DoWork() Line 216	C#
 	Raven.Server.dll!Raven.Server.Utils.PoolOfThreads.PooledThread.Run() Line 186	C#
```

While during debugging it appeared that we're trying to create the same attachment tombstone twice. First, inside `SaveConflictedDocumentsAsRevisions()`:

https://github.com/ravendb/ravendb/blob/016785f4d3d96485af3e972f64ba3eaff05a7e7e/src/Raven.Server/Documents/Replication/ResolveConflictOnReplicationConfigurationChange.cs#L294

and then a few lines below because we resolved the conflict to the tombstone:

https://github.com/ravendb/ravendb/blob/016785f4d3d96485af3e972f64ba3eaff05a7e7e/src/Raven.Server/Documents/Replication/ResolveConflictOnReplicationConfigurationChange.cs#L307-L308

The proposed solution is to simply ignore an attempt to create a duplicated attachment tombstone. We already have the same code for creation of revision tombstones:

https://github.com/ravendb/ravendb/blob/016785f4d3d96485af3e972f64ba3eaff05a7e7e/src/Raven.Server/Documents/Revisions/RevisionsStorage.cs#L863-L870

### Type of change

- Bug fix

### How risky is the change?

- Moderate 

### Backward compatibility

- Not relevant

### Is it platform specific issue?

- No

### Documentation update

- No documentation update is needed 

### Testing 

- Tests have been added that prove the fix is effective or that the feature works

### Is there any existing behavior change of other features due to this change?

- No

### UI work

- No UI work is needed
