### PR TITLE
RavenDB-18638 - SlowTests.Sharding.ETL.ShardedEtlTests.SlowTests.Shar…

### DIFF
--- a/test/SlowTests/Sharding/ETL/ShardedEtlTests.cs
+++ b/test/SlowTests/Sharding/ETL/ShardedEtlTests.cs
@@ -908,8 +908,6 @@ person.addCounter(loadCounter('down'));
 
                     Assert.NotNull(ongoingTask);
                     Assert.Equal(name, ongoingTask.TaskName);
-                    Assert.Equal("A", ongoingTask.ResponsibleNode.NodeTag);
-                    Assert.Equal(OngoingTaskConnectionStatus.Active, ongoingTask.TaskConnectionStatus);
                 }
             }
         }

--- a/test/SlowTests/Sharding/ETL/ShardedEtlTests.cs
+++ b/test/SlowTests/Sharding/ETL/ShardedEtlTests.cs
@@ -902,12 +902,19 @@ person.addCounter(loadCounter('down'));
                     Database = "Northwind"
                 });
 
+                var ongoingTask = store.Maintenance.Send(new GetOngoingTaskInfoOperation(name, OngoingTaskType.RavenEtl));
+
+                Assert.NotNull(ongoingTask);
+                Assert.Equal(name, ongoingTask.TaskName);
+
                 for (int i = 0; i < 3; i++)
                 {
-                    var ongoingTask = store.Maintenance.Send(new GetOngoingTaskInfoOperation(name, OngoingTaskType.RavenEtl));
+                    var singleShardInfo = store.Maintenance.ForShard(i).Send(new GetOngoingTaskInfoOperation(name, OngoingTaskType.RavenEtl));
 
-                    Assert.NotNull(ongoingTask);
-                    Assert.Equal(name, ongoingTask.TaskName);
+                    Assert.NotNull(singleShardInfo);
+                    Assert.Equal(name, singleShardInfo.TaskName);
+                    Assert.Equal("A", singleShardInfo.ResponsibleNode.NodeTag);
+                    Assert.Equal(OngoingTaskConnectionStatus.Active, singleShardInfo.TaskConnectionStatus);
                 }
             }
         }


### PR DESCRIPTION
…ding.ETL.ShardedEtlTests.CanGetTaskInfo

### Issue link

https://issues.hibernatingrhinos.com/issue/RavenDB-18638

### Additional description

We have some missing values for sharding **_GetOngoingTaskInfo_** that will be implemented in the future

### Type of change

- Bug fix

### How risky is the change?

- Low 

### Backward compatibility

- Non breaking change

### Is it platform specific issue?

- No

### Documentation update

- No documentation update is needed 

### Testing 

- It has been verified by manual testing

### Is there any existing behavior change of other features due to this change?

- No

### UI work

- No UI work is needed
