### PR TITLE
RavenDB-18640 Using cached value for extended memory info during CanContinueBatch because it was too expensive to calculate it each time

### DIFF
--- a/src/Raven.Server/Dashboard/Cluster/Notifications/MemoryUsageNotificationSender.cs
+++ b/src/Raven.Server/Dashboard/Cluster/Notifications/MemoryUsageNotificationSender.cs
@@ -32,7 +32,7 @@ namespace Raven.Server.Dashboard.Cluster.Notifications
 
         protected override AbstractClusterDashboardNotification CreateNotification()
         {
-            var memoryInfo = _server.MetricCacher.GetValue<MemoryInfoResult>(MetricCacher.Keys.Server.MemoryInfoExtended);
+            var memoryInfo = _server.MetricCacher.GetValue<MemoryInfoResult>(MetricCacher.Keys.Server.MemoryInfoExtended.RefreshRate15Seconds);
             long managedMemoryInBytes = AbstractLowMemoryMonitor.GetManagedMemoryInBytes();
             long totalUnmanagedAllocations = NativeMemory.TotalAllocatedMemory;
             var encryptionBuffers = EncryptionBuffersPool.Instance.GetStats();

--- a/src/Raven.Server/Dashboard/MachineResourcesNotificationSender.cs
+++ b/src/Raven.Server/Dashboard/MachineResourcesNotificationSender.cs
@@ -75,7 +75,7 @@ namespace Raven.Server.Dashboard
 
         internal static MachineResources GetMachineResources(MetricCacher metricCacher, LowMemoryMonitor lowMemoryMonitor, ICpuUsageCalculator cpuUsageCalculator)
         {
-            var memInfo = metricCacher.GetValue<MemoryInfoResult>(MetricCacher.Keys.Server.MemoryInfoExtended);
+            var memInfo = metricCacher.GetValue<MemoryInfoResult>(MetricCacher.Keys.Server.MemoryInfoExtended.RefreshRate15Seconds);
             var cpuInfo = metricCacher.GetValue(MetricCacher.Keys.Server.CpuUsage, cpuUsageCalculator.Calculate);
 
             var machineResources = new MachineResources

--- a/src/Raven.Server/Documents/ETL/EtlProcess.cs
+++ b/src/Raven.Server/Documents/ETL/EtlProcess.cs
@@ -533,7 +533,7 @@ namespace Raven.Server.Documents.ETL
             {
                 if (MemoryUsageGuard.TryIncreasingMemoryUsageForThread(_threadAllocations, ref _currentMaximumAllowedMemory,
                         totalAllocated,
-                        Database.DocumentsStorage.Environment.Options.RunningOn32Bits, Logger, out var memoryUsage) == false)
+                        Database.DocumentsStorage.Environment.Options.RunningOn32Bits, Database.ServerStore.Server.MetricCacher, Logger, out var memoryUsage) == false)
                 {
                     var reason = $"Stopping the batch because cannot budget additional memory. Current budget: {totalAllocated}.";
                     if (memoryUsage != null)

--- a/src/Raven.Server/Documents/Indexes/Index.cs
+++ b/src/Raven.Server/Documents/Indexes/Index.cs
@@ -4397,6 +4397,7 @@ namespace Raven.Server.Documents.Indexes
                     ref _currentMaximumAllowedMemory,
                     allocated,
                     _environment.Options.RunningOn32Bits,
+                    DocumentDatabase.ServerStore.Server.MetricCacher,
                     _logger,
                     out var memoryUsage) == false)
                 {

--- a/src/Raven.Server/Monitoring/Snmp/Objects/Server/1.6/ServerTotalMemory.cs
+++ b/src/Raven.Server/Monitoring/Snmp/Objects/Server/1.6/ServerTotalMemory.cs
@@ -17,7 +17,7 @@ namespace Raven.Server.Monitoring.Snmp.Objects.Server
 
         protected override Gauge32 GetData()
         {
-            return new Gauge32(_metricCacher.GetValue<MemoryInfoResult>(MetricCacher.Keys.Server.MemoryInfoExtended).WorkingSet.GetValue(SizeUnit.Megabytes));
+            return new Gauge32(_metricCacher.GetValue<MemoryInfoResult>(MetricCacher.Keys.Server.MemoryInfoExtended.RefreshRate15Seconds).WorkingSet.GetValue(SizeUnit.Megabytes));
         }
     }
 }

--- a/src/Raven.Server/Monitoring/Snmp/Objects/Server/1.6/ServerTotalSwapSize.cs
+++ b/src/Raven.Server/Monitoring/Snmp/Objects/Server/1.6/ServerTotalSwapSize.cs
@@ -21,7 +21,7 @@ namespace Raven.Server.Monitoring.Snmp.Objects.Server
         protected override Gauge32 GetData()
         {
             return new Gauge32(_metricCacher.GetValue<MemoryInfoResult>(
-                MetricCacher.Keys.Server.MemoryInfoExtended).TotalSwapSize.GetValue(SizeUnit.Megabytes));
+                MetricCacher.Keys.Server.MemoryInfoExtended.RefreshRate15Seconds).TotalSwapSize.GetValue(SizeUnit.Megabytes));
         }
     }
 }

--- a/src/Raven.Server/Monitoring/Snmp/Objects/Server/1.6/ServerTotalSwapUsage.cs
+++ b/src/Raven.Server/Monitoring/Snmp/Objects/Server/1.6/ServerTotalSwapUsage.cs
@@ -21,7 +21,7 @@ namespace Raven.Server.Monitoring.Snmp.Objects.Server
         protected override Gauge32 GetData()
         {
             return new Gauge32(_metricCacher.GetValue<MemoryInfoResult>(
-                MetricCacher.Keys.Server.MemoryInfoExtended).TotalSwapUsage.GetValue(SizeUnit.Megabytes));
+                MetricCacher.Keys.Server.MemoryInfoExtended.RefreshRate15Seconds).TotalSwapUsage.GetValue(SizeUnit.Megabytes));
         }
     }
 }

--- a/src/Raven.Server/Monitoring/Snmp/Objects/Server/1.6/ServerWorkingSetSwapUsage.cs
+++ b/src/Raven.Server/Monitoring/Snmp/Objects/Server/1.6/ServerWorkingSetSwapUsage.cs
@@ -21,7 +21,7 @@ namespace Raven.Server.Monitoring.Snmp.Objects.Server
         protected override Gauge32 GetData()
         {
             return new Gauge32(_metricCacher.GetValue<MemoryInfoResult>(
-                MetricCacher.Keys.Server.MemoryInfoExtended).WorkingSetSwapUsage.GetValue(SizeUnit.Megabytes));
+                MetricCacher.Keys.Server.MemoryInfoExtended.RefreshRate15Seconds).WorkingSetSwapUsage.GetValue(SizeUnit.Megabytes));
         }
     }
 }

--- a/src/Raven.Server/ServerWide/Memory/MemoryUsageGuard.cs
+++ b/src/Raven.Server/ServerWide/Memory/MemoryUsageGuard.cs
@@ -1,4 +1,5 @@
-﻿using Sparrow;
+﻿using Raven.Server.Utils;
+using Sparrow;
 using Sparrow.Logging;
 using Sparrow.LowMemory;
 using Sparrow.Utils;
@@ -11,6 +12,7 @@ namespace Raven.Server.ServerWide.Memory
             ref Size currentMaximumAllowedMemory,
             Size currentlyInUse,
             bool isRunningOn32Bits,
+            ServerMetricCacher metricCacher,
             Logger logger,
             out ProcessMemoryUsage currentUsage)
         {
@@ -21,7 +23,7 @@ namespace Raven.Server.ServerWide.Memory
             }
 
             // we run out our memory quota, so we need to see if we can increase it or break
-            var memoryInfo = MemoryInformation.GetMemoryInformationUsingOneTimeSmapsReader();
+            var memoryInfo = metricCacher.GetValue<MemoryInfoResult>(MetricCacher.Keys.Server.MemoryInfoExtended.RefreshRate5Seconds);
             currentUsage = GetProcessMemoryUsage(memoryInfo);
 
             var memoryAssumedFreeOrCheapToFree = memoryInfo.AvailableMemoryForProcessing;

--- a/src/Raven.Server/ServerWide/ServerMetricCacher.cs
+++ b/src/Raven.Server/ServerWide/ServerMetricCacher.cs
@@ -25,7 +25,8 @@ namespace Raven.Server.ServerWide
         {
             Register(MetricCacher.Keys.Server.CpuUsage, TimeSpan.FromSeconds(1), _server.CpuUsageCalculator.Calculate);
             Register(MetricCacher.Keys.Server.MemoryInfo, TimeSpan.FromSeconds(1), CalculateMemoryInfo);
-            Register(MetricCacher.Keys.Server.MemoryInfoExtended, TimeSpan.FromSeconds(15), CalculateMemoryInfoExtended);
+            Register(MetricCacher.Keys.Server.MemoryInfoExtended.RefreshRate15Seconds, TimeSpan.FromSeconds(15), CalculateMemoryInfoExtended);
+            Register(MetricCacher.Keys.Server.MemoryInfoExtended.RefreshRate5Seconds, TimeSpan.FromSeconds(5), CalculateMemoryInfoExtended);
             Register(MetricCacher.Keys.Server.DiskSpaceInfo, TimeSpan.FromSeconds(15), CalculateDiskSpaceInfo);
             Register(MetricCacher.Keys.Server.MemInfo, TimeSpan.FromSeconds(15), CalculateMemInfo);
             Register(MetricCacher.Keys.Server.GcAny, TimeSpan.FromSeconds(15), () => CalculateGcMemoryInfo(GCKind.Any));

--- a/src/Raven.Server/Utils/MetricCacher.cs
+++ b/src/Raven.Server/Utils/MetricCacher.cs
@@ -24,7 +24,12 @@ namespace Raven.Server.Utils
 
                 public const string MemoryInfo = "MemoryInfo";
 
-                public const string MemoryInfoExtended = "MemoryInfoExtended";
+                public class MemoryInfoExtended
+                {
+                    public const string RefreshRate15Seconds = "MemoryInfoExtended/RefreshRate15Seconds";
+
+                    public const string RefreshRate5Seconds = "MemoryInfoExtended/RefreshRate5Seconds";
+                }
 
                 public const string DiskSpaceInfo = "DiskSpaceInfo";
 

--- a/src/Raven.Server/Web/System/AdminMonitoringHandler.cs
+++ b/src/Raven.Server/Web/System/AdminMonitoringHandler.cs
@@ -148,7 +148,7 @@ namespace Raven.Server.Web.System
         private MemoryMetrics GetMemoryMetrics()
         {
             var result = new MemoryMetrics();
-            var memoryInfoResult = Server.MetricCacher.GetValue<MemoryInfoResult>(MetricCacher.Keys.Server.MemoryInfoExtended);
+            var memoryInfoResult = Server.MetricCacher.GetValue<MemoryInfoResult>(MetricCacher.Keys.Server.MemoryInfoExtended.RefreshRate15Seconds);
 
             result.InstalledMemoryInMb = memoryInfoResult.InstalledMemory.GetValue(SizeUnit.Megabytes);
             result.PhysicalMemoryInMb = memoryInfoResult.TotalPhysicalMemory.GetValue(SizeUnit.Megabytes);

--- a/test/Tests.Infrastructure/TestMetrics/TestResourcesAnalyzerMetricCacher.cs
+++ b/test/Tests.Infrastructure/TestMetrics/TestResourcesAnalyzerMetricCacher.cs
@@ -19,7 +19,7 @@ namespace Tests.Infrastructure.TestMetrics
 
             Register(Keys.Server.CpuUsage, _cacheRefreshRate, cpuUsageCalculator.Calculate);
             Register(Keys.Server.MemoryInfo, _cacheRefreshRate, CalculateMemoryInfo);
-            Register(Keys.Server.MemoryInfoExtended, _cacheRefreshRate, CalculateMemoryInfoExtended);
+            Register(Keys.Server.MemoryInfoExtended.RefreshRate15Seconds, _cacheRefreshRate, CalculateMemoryInfoExtended);
         }
 
         private static object CalculateMemoryInfo()
@@ -32,6 +32,6 @@ namespace Tests.Infrastructure.TestMetrics
             => GetValue<(double MachineCpuUsage, double ProcessCpuUsage, double? MachineIoWait)>(Keys.Server.CpuUsage);
 
         public MemoryInfoResult GetMemoryInfoExtended()
-            => GetValue<MemoryInfoResult>(Keys.Server.MemoryInfoExtended);
+            => GetValue<MemoryInfoResult>(Keys.Server.MemoryInfoExtended.RefreshRate15Seconds);
     }
 }


### PR DESCRIPTION
The value is going to be updated every 5 seconds. All indexes and ETLs will use the same cached value.

### Issue link

https://issues.hibernatingrhinos.com/issue/RavenDB-18640
https://github.com/ravendb/ravendb/discussions/14197

### Additional description

It fixes the performance of indexing if the allocation pattern resulted in often calls to `MemoryUsageGuard.TryIncreasingMemoryUsageForThread()` during `CanContinueBatch()` (more likely for map-reduce indexes). The solution is to cache the memory info for 5 seconds to avoid expensive reads by the smaps reader.

### Type of change

- Performance fix

### How risky is the change?

- Low 

### Backward compatibility

- Not relevant

### Is it platform specific issue?

- Partially - it mostly affected Linux systems due to more expensive reads by the smaps reader

### Documentation update

- No documentation update is needed 

### Testing 

- It has been verified by manual testing

### Is there any existing behavior change of other features due to this change?

- No

### UI work

- No UI work is needed
