### PR TITLE
RavenDB-18590 handle a race that disconnected leader can commit a NOOP command without having a consensus

### DIFF
--- a/src/Raven.Server/Rachis/Elector.cs
+++ b/src/Raven.Server/Rachis/Elector.cs
@@ -43,6 +43,8 @@ namespace Raven.Server.Rachis
                 {
                     while (_engine.IsDisposed == false)
                     {
+                        _engine.ForTestingPurposes?.LeaderLock?.HangThreadIfLocked();
+
                         using (_engine.ContextPool.AllocateOperationContext(out ClusterOperationContext context))
                         {
                             var rv = _connection.Read<RequestVote>(context);

--- a/src/Raven.Server/Rachis/Follower.cs
+++ b/src/Raven.Server/Rachis/Follower.cs
@@ -1093,6 +1093,8 @@ namespace Raven.Server.Rachis
                 {
                     try
                     {
+                        _engine.ForTestingPurposes?.LeaderLock?.HangThreadIfLocked();
+
                         using (_engine.ContextPool.AllocateOperationContext(out ClusterOperationContext context))
                         {
                             NegotiateWithLeader(context, (LogLengthNegotiation)obj);

--- a/src/Raven.Server/Rachis/Remote/RemoteConnection.cs
+++ b/src/Raven.Server/Rachis/Remote/RemoteConnection.cs
@@ -384,6 +384,17 @@ namespace Raven.Server.Rachis.Remote
 
         private void DisposeInternal()
         {
+            try
+            {
+                //  we dispose here the stream explicitly to avoid waiting indefinitely on the stream.Read method
+                // which will prevent us continue the dispose, since the Read is wrapped with _disposerLock.EnsureNotDisposed()
+                _stream?.Dispose();
+            }
+            catch
+            {
+                // don't care
+            }
+
             using (_disposerLock.StartDisposing())
             {
                 RemoteConnectionsList.TryRemove(_info);


### PR DESCRIPTION
### Issue link

https://issues.hibernatingrhinos.com/issue/RavenDB-18590

### Additional description

The following sequance should occur to hit this bug:
- Leader was elected but didn't take office yet.
- A _different_ leader was elected so the previous one was disposed.
- While we under the dispose lock, the leader thread continued to the `RefreshAmassadors` method and returned due to a taken lock.
- Our log shouldn't be updated by the new leader yet.

Combine of those events resulted in having number of voter to be 0 and though the majority that is require is 0 as well!
In that case we were committing the noop command although we are no longer the leader.

This issue is basically since day 1, not sure why it suddenly start to appear with a high frequency. 

The fix is to validate the term under lock & to throw if we are disposing.

### Type of change

- Bug fix

### How risky is the change?

- Low 

### Backward compatibility

- Not relevant

### Is it platform specific issue?

- No

### Documentation update

- No documentation update is needed 

### Testing 

- Tests have been added that prove the fix is effective or that the feature works
 - Internal classes added to the test class 

### Is there any existing behavior change of other features due to this change?

- No

### UI work

- No UI work is needed
