### PR TITLE
RavenDB-17963 Adding retry arrtibute to SQL ETL tests so we won't faili immediately on connection errors

### DIFF
--- a/test/SlowTests/Server/Documents/ETL/SQL/SqlEtlTests.cs
+++ b/test/SlowTests/Server/Documents/ETL/SQL/SqlEtlTests.cs
@@ -31,6 +31,7 @@ using Raven.Tests.Core.Utils.Entities;
 using SlowTests.Server.Documents.Migration;
 using Sparrow.Server;
 using Tests.Infrastructure.ConnectionString;
+using xRetry;
 using Xunit;
 using Xunit.Abstractions;
 
@@ -65,7 +66,7 @@ for (var i = 0; i < this.OrderLines.length; i++) {
 loadToOrders(orderData);
 ";
 
-        [Fact]
+        [RetryFact(delayBetweenRetriesMs: 1000)]
         public async Task ReplicateMultipleBatches()
         {
             using (var store = GetDocumentStore())
@@ -156,7 +157,7 @@ DROP DATABASE [SqlReplication-{dbName}]";
             }
         }
 
-        [Fact]
+        [RetryFact(delayBetweenRetriesMs: 1000)]
         public async Task SimpleTransformation()
         {
             using (var store = GetDocumentStore())
@@ -202,7 +203,7 @@ DROP DATABASE [SqlReplication-{dbName}]";
 
 
 
-        [Fact]
+        [RetryFact(delayBetweenRetriesMs: 1000)]
         public async Task ShouldHandleCaseMismatchBetweenTableDefinitionAndLoadTo()
         {
             using (var store = GetDocumentStore())
@@ -256,7 +257,7 @@ loadToOrDerS(orderData); // note 'OrDerS' here vs 'Orders' defined in the config
             }
         }
 
-        [Fact]
+        [RetryFact(delayBetweenRetriesMs: 1000)]
         public async Task NullPropagation()
         {
             using (var store = GetDocumentStore())
@@ -305,7 +306,7 @@ loadToOrders(orderData);");
             }
         }
 
-        [Fact]
+        [RetryFact(delayBetweenRetriesMs: 1000)]
         public async Task NullPropagation_WithExplicitNull()
         {
             using (var store = GetDocumentStore())
@@ -355,7 +356,7 @@ loadToOrders(orderData);");
             }
         }
 
-        [Fact]
+        [RetryFact(delayBetweenRetriesMs: 1000)]
         public async Task RavenDB_3341()
         {
             using (var store = GetDocumentStore())
@@ -407,7 +408,7 @@ loadToOrders(orderData);");
             }
         }
 
-        [Fact]
+        [RetryFact(delayBetweenRetriesMs: 1000)]
         public async Task CanUpdateToBeNoItemsInChildTable()
         {
             using (var store = GetDocumentStore())
@@ -452,7 +453,7 @@ loadToOrders(orderData);");
             }
         }
 
-        [Fact]
+        [RetryFact(delayBetweenRetriesMs: 1000)]
         public async Task CanDelete()
         {
             using (var store = GetDocumentStore())
@@ -493,7 +494,7 @@ loadToOrders(orderData);");
             }
         }
 
-        [Fact]
+        [RetryFact(delayBetweenRetriesMs: 1000)]
         public async Task RavenDB_3172()
         {
             using (var store = GetDocumentStore())
@@ -538,7 +539,7 @@ loadToOrders(orderData);");
             }
         }
 
-        [Fact]
+        [RetryFact(delayBetweenRetriesMs: 1000)]
         public async Task WillLog()
         {
             using (var client = new ClientWebSocket())
@@ -762,7 +763,7 @@ var nameArr = this.StepName.split('.'); loadToOrders({});");
             }
         }
 
-        [Fact]
+        [RetryFact(delayBetweenRetriesMs: 1000)]
         public async Task LoadingSingleAttachment()
         {
             using (var store = GetDocumentStore())
@@ -831,7 +832,7 @@ loadToOrders(orderData);
             }
         }
 
-        [Fact]
+        [RetryFact(delayBetweenRetriesMs: 1000)]
         public async Task Should_error_if_attachment_doesnt_exist()
         {
             using (var store = GetDocumentStore())
@@ -904,7 +905,7 @@ loadToOrders(orderData);
             }
         }
 
-        [Fact]
+        [RetryFact(delayBetweenRetriesMs: 1000)]
         public async Task LoadingMultipleAttachments()
         {
             using (var store = GetDocumentStore())
@@ -979,7 +980,7 @@ for (var i = 0; i < attachments.length; i++)
             }
         }
 
-        [Fact]
+        [RetryFact(delayBetweenRetriesMs: 1000)]
         public async Task CanSkipSettingFieldIfAttachmentDoesntExist()
         {
             using (var store = GetDocumentStore())
@@ -1036,7 +1037,7 @@ loadToOrders(orderData);
             }
         }
 
-        [Fact]
+        [RetryFact(delayBetweenRetriesMs: 1000)]
         public async Task LoadingFromMultipleCollections()
         {
             using (var store = GetDocumentStore())
@@ -1083,7 +1084,7 @@ loadToOrders(orderData);
             }
         }
 
-        [Fact]
+        [RetryFact(delayBetweenRetriesMs: 1000)]
         public async Task CanUseVarcharAndNVarcharFunctions()
         {
             using (var store = GetDocumentStore())
@@ -1153,7 +1154,7 @@ loadToUsers(
             }
         }
 
-        [Fact]
+        [RetryFact(delayBetweenRetriesMs: 1000)]
         public void Should_stop_batch_if_size_limit_exceeded_RavenDB_12800()
         {
             using (var store = GetDocumentStore(new Options { ModifyDatabaseRecord = x => x.Settings[RavenConfiguration.GetKey(c => c.Etl.MaxBatchSize)] = "5" }))

--- a/test/Tests.Infrastructure/Tests.Infrastructure.csproj
+++ b/test/Tests.Infrastructure/Tests.Infrastructure.csproj
@@ -18,6 +18,7 @@
   </ItemGroup>
   <ItemGroup>
     <PackageReference Include="MongoDB.Driver" Version="2.11.6" />
+    <PackageReference Include="xRetry" Version="1.8.0" />
     <PackageReference Include="xunit" Version="2.4.1" />
     <PackageReference Include="xunit.runner.utility" Version="2.4.1" />
     <PackageReference Include="XunitLogger" Version="4.0.991" />


### PR DESCRIPTION
### Issue link

https://issues.hibernatingrhinos.com/issue/RavenDB-17963
https://issues.hibernatingrhinos.com/issue/RavenDB-18064

### Additional description

Retrying on SQL ETL tests so we won't fail on occasional connection errors

### Type of change

- Test fix

### How risky is the change?

- Low 

### Backward compatibility

- Not relevant

### Is it platform specific issue?

- No

### Documentation update

- No documentation update is needed 

### Testing 

- Existing tests will verify that

### Is there any existing behavior change of other features due to this change?

- No

### UI work

- No UI work is needed
