### PR TITLE
RavenDB-17239 stabilize rachis tests 

### DIFF
--- a/src/Raven.Server/Rachis/Follower.cs
+++ b/src/Raven.Server/Rachis/Follower.cs
@@ -966,6 +966,34 @@ namespace Raven.Server.Rachis
                         return true;
                     }
 
+                    using (context.OpenReadTransaction())
+                    {
+                        var term = _engine.GetTermFor(context, negotiation.PrevLogIndex);
+                        if (term != negotiation.PrevLogTerm)
+                        {
+                            // divergence at the first leader entry
+                            var lastCommittedIndex = _engine.GetLastCommitIndex(context);
+                            if (lastCommittedIndex + 1 == negotiation.PrevLogIndex)
+                            {
+                                if (_engine.Log.IsInfoEnabled)
+                                {
+                                    _engine.Log.Info($"{ToString()}: found divergence at the first leader entry");
+                                }
+
+                                connection.Send(context, new LogLengthNegotiationResponse
+                                {
+                                    Status = LogLengthNegotiationResponse.ResponseStatus.Acceptable,
+                                    Message = $"agreed on our last committed index {lastCommittedIndex}",
+                                    CurrentTerm = _term,
+                                    LastLogIndex = lastCommittedIndex,
+                                });
+
+                                // leader's first entry is the next we need 
+                                return false;
+                            }
+                        }
+                    }
+
                     // the leader already truncated the suggested index
                     // Let's try to negotiate from that index upto our last appended index
                     maxIndex = lastIndex;

--- a/test/RachisTests/ElectionTests.cs
+++ b/test/RachisTests/ElectionTests.cs
@@ -1,6 +1,7 @@
 ﻿using System;
 using System.Collections.Generic;
 using System.Diagnostics;
+using System.IO;
 using System.Linq;
 using System.Threading;
 using System.Threading.Tasks;
@@ -297,9 +298,10 @@ namespace RachisTests
             await IssueCommandsAndWaitForCommit(10, "test", 1);
             var currentTerm = firstLeader.CurrentTerm;
 
-            var t = Task.Run(() => IssueCommandsWithoutWaitingForCommits(firstLeader, 100, "test"));
+            var t = IssueCommandsWithoutWaitingForCommits(firstLeader, 100, "test");
             Disconnect(follower.Url, firstLeader.Url);
-            await t;
+
+            await Assert.ThrowsAsync<NotLeadingException>(() => Task.WhenAll(t));
 
             Assert.True(await firstLeader.WaitForState(RachisState.Candidate, CancellationToken.None).WaitWithoutExceptionAsync(timeToWait),$"{firstLeader.CurrentState}");
             follower.FoundAboutHigherTerm(currentTerm + 1," why not, should work!");

--- a/test/RachisTests/ElectionTests.cs
+++ b/test/RachisTests/ElectionTests.cs
@@ -79,7 +79,86 @@ namespace RachisTests
             }
         }
 
-         [Fact]
+        [Fact]
+        public async Task CanElectOnDivergence3()
+        {
+            var firstLeader = await CreateNetworkAndGetLeader(3);
+            var followers = GetFollowers();
+
+            var randFollower = followers.First();
+            DisconnectBiDirectionalFromNode(randFollower);
+
+            var leaderTerm = firstLeader.CurrentTerm;
+            await IssueCommandsAndWaitForCommit(10, "foo", 123);
+
+            ReconnectBiDirectionalFromNode(randFollower);
+            DisconnectBiDirectionalFromNode(firstLeader);
+
+            for (int i = 0; i < 10; i++)
+            {
+                firstLeader.AppendToLog(new TestCommand { Name = "bar", Value = 1 }, leaderTerm);
+            }
+
+            await firstLeader.WaitForState(RachisState.Candidate, CancellationToken.None);
+
+            var newLeader = WaitForAnyToBecomeLeader(followers);
+
+            var lastIndex = -1L;
+
+            using (firstLeader.ContextPool.AllocateOperationContext(out ClusterOperationContext context))
+            using (context.OpenReadTransaction())
+            {
+                lastIndex = firstLeader.GetLastCommitIndex(context);
+            }
+
+            await IssueCommandsAndWaitForCommit(10, "baz", 123);
+            var nonLeader = followers.Single(x => x != newLeader);
+            DisconnectBiDirectionalFromNode(nonLeader);
+
+            using (newLeader.ContextPool.AllocateOperationContext(out ClusterOperationContext ctx))
+            using (var tx = ctx.OpenWriteTransaction())
+            {
+                newLeader.TruncateLogBefore(ctx, lastIndex);
+                tx.Commit();
+            }
+
+            ReconnectBiDirectionalFromNode(firstLeader);
+
+            using (newLeader.ContextPool.AllocateOperationContext(out ClusterOperationContext context))
+            using (context.OpenReadTransaction())
+            {
+                lastIndex = newLeader.GetLastCommitIndex(context);
+            }
+
+            var condition = await firstLeader.WaitForCommitIndexChange(RachisConsensus.CommitIndexModification.GreaterOrEqual, lastIndex)
+                    .WaitWithoutExceptionAsync(5000);
+
+            using (firstLeader.ContextPool.AllocateOperationContext(out ClusterOperationContext context))
+            using (context.OpenReadTransaction())
+            {
+                var commitIndex = firstLeader.GetLastCommitIndex(context);
+                Assert.True(condition, $"Last commit is {commitIndex} wanted {lastIndex}");
+            }
+
+            ReconnectBiDirectionalFromNode(nonLeader);
+
+            lastIndex = await IssueCommandsAndWaitForCommit(10, "foo", 357);
+
+            foreach (var r in RachisConsensuses)
+            {
+                condition = await r.WaitForCommitIndexChange(RachisConsensus.CommitIndexModification.GreaterOrEqual, lastIndex)
+                        .WaitWithoutExceptionAsync(5000);
+
+                using (r.ContextPool.AllocateOperationContext(out ClusterOperationContext context))
+                using (context.OpenReadTransaction())
+                {
+                    var commitIndex = r.GetLastCommitIndex(context);
+                    Assert.True(condition, $"Last commit is {commitIndex} wanted {lastIndex}");
+                }
+            }
+        }
+
+        [Fact]
         public async Task CanElectOnDivergence2()
         {
             var firstLeader = await CreateNetworkAndGetLeader(3);

--- a/test/Tests.Infrastructure/RachisConsensusTestBase.cs
+++ b/test/Tests.Infrastructure/RachisConsensusTestBase.cs
@@ -328,7 +328,7 @@ namespace Tests.Infrastructure
             return waitingList;
         }
 
-        protected async Task<Task> ActionWithLeader(Func<RachisConsensus<CountingStateMachine>, Task> action)
+        protected async Task ActionWithLeader(Func<RachisConsensus<CountingStateMachine>, Task> action)
         {
             var retires = 5;
             Exception lastException;
@@ -342,7 +342,8 @@ namespace Tests.Infrastructure
                         var tasks = RachisConsensuses.Select(x => x.WaitForState(RachisState.Leader, cts.Token));
                         await Task.WhenAny(tasks);
                         var leader = RachisConsensuses.Single(x => x.CurrentState == RachisState.Leader);
-                        return action(leader);
+                        await action(leader);
+                        return;
                     }
                 }
                 catch (Exception e)

--- a/test/Tests.Infrastructure/RavenTestHelper.cs
+++ b/test/Tests.Infrastructure/RavenTestHelper.cs
@@ -52,6 +52,24 @@ namespace FastTests
             return newDataDir;
         }
 
+        public static void AssertTrue(bool condition, Func<string> messageOnFailure)
+        {
+            string failureMessage = null;
+            if (condition == false)
+            {
+                try
+                {
+                    failureMessage = messageOnFailure();
+                }
+                catch (Exception e)
+                {
+                    failureMessage = e.ToString();
+                }
+            }
+
+            Xunit.Assert.True(condition, failureMessage);
+        }
+
         public static void DeletePaths(ConcurrentSet<string> pathsToDelete, ExceptionAggregator exceptionAggregator)
         {
             var localPathsToDelete = pathsToDelete.ToArray();


### PR DESCRIPTION
### Issue link

https://issues.hibernatingrhinos.com/issue/RavenDB-17239
https://issues.hibernatingrhinos.com/issue/RavenDB-17014
https://issues.hibernatingrhinos.com/issue/RavenDB-18635

### Additional description

- Make the test `RavenDB_13228` more stable, by injecting an entry to old leader and not rely on async task to do that before we disconnect the it. (RavenDB-17239)
- avoid returning `Task<Task>` since they aren't properly waited in the tests.
- Introduce `RavenTestHelper.AssertTrue` which will evaluate the message only upon failure.
- Handle a negotiation edge case that cause infinite negotiation loop (RavenDB-18635)
This happened when leader has a truncated log while the follower has a different appended term for the leader's first entry.

### Type of change

- Test fix
- Bug fix

### How risky is the change?

- Low 


### Backward compatibility

- Not relevant

### Is it platform specific issue?

- No

### Documentation update

- No documentation update is needed 

### Testing 

- Current test more stable when run locally
- New tests were added

### Is there any existing behavior change of other features due to this change?

- No

### UI work

- No UI work is needed
