### PR TITLE
RavenDB-18656 - DocumentQuery RQL expression includes private members…

### DIFF
--- a/src/Raven.Client/Documents/LinqExtensions.cs
+++ b/src/Raven.Client/Documents/LinqExtensions.cs
@@ -189,7 +189,7 @@ namespace Raven.Client.Documents
             var results = queryable.Provider.CreateQuery<TResult>(ofType.Expression);
             var ravenQueryInspector = (RavenQueryInspector<TResult>)results;
 
-            var membersList = ReflectionUtil.GetPropertiesAndFieldsFor<TResult>(BindingFlags.Instance | BindingFlags.Public | BindingFlags.NonPublic).ToList();
+            var membersList = ReflectionUtil.GetPropertiesAndFieldsFor<TResult>(BindingFlags.Instance | BindingFlags.Public).ToList();
             ravenQueryInspector.FieldsToFetch(membersList.Select(x => x.Name));
             return (IRavenQueryable<TResult>)results;
         }

--- a/src/Raven.Client/Documents/Session/AsyncDocumentQuery.cs
+++ b/src/Raven.Client/Documents/Session/AsyncDocumentQuery.cs
@@ -624,7 +624,7 @@ namespace Raven.Client.Documents.Session
         /// <inheritdoc />
         public IAsyncDocumentQuery<TProjection> SelectFields<TProjection>(ProjectionBehavior projectionBehavior)
         {
-            var propertyInfos = ReflectionUtil.GetPropertiesAndFieldsFor<TProjection>(BindingFlags.Public | BindingFlags.NonPublic | BindingFlags.Instance).ToList();
+            var propertyInfos = ReflectionUtil.GetPropertiesAndFieldsFor<TProjection>(BindingFlags.Public | BindingFlags.Instance).ToList();
             var projections = propertyInfos.Select(x => x.Name).ToArray();
             var fields = propertyInfos.Select(p => p.Name).ToArray();
             return SelectFields<TProjection>(new QueryData(fields, projections)

--- a/src/Raven.Client/Documents/Session/DocumentQuery.cs
+++ b/src/Raven.Client/Documents/Session/DocumentQuery.cs
@@ -40,7 +40,7 @@ namespace Raven.Client.Documents.Session
         /// <inheritdoc />
         public IDocumentQuery<TProjection> SelectFields<TProjection>(ProjectionBehavior projectionBehavior)
         {
-            var propertyInfos = ReflectionUtil.GetPropertiesAndFieldsFor<TProjection>(BindingFlags.Public | BindingFlags.NonPublic | BindingFlags.Instance).ToList();
+            var propertyInfos = ReflectionUtil.GetPropertiesAndFieldsFor<TProjection>(BindingFlags.Public | BindingFlags.Instance).ToList();
             var projections = propertyInfos.Select(x => x.Name).ToArray();
             var fields = propertyInfos.Select(p => p.Name).ToArray();
             return SelectFields<TProjection>(new QueryData(fields, projections)

--- a/test/SlowTests/Issues/RavenDB-18656.cs
+++ b/test/SlowTests/Issues/RavenDB-18656.cs
@@ -1,0 +1,89 @@
+﻿using System;
+using System.Collections.Generic;
+using System.Linq;
+using System.Linq.Expressions;
+using System.Text;
+using System.Threading.Tasks;
+using FastTests;
+using Raven.Client.Documents;
+using Raven.Client.Documents.Indexes;
+using Xunit;
+using Xunit.Abstractions;
+
+namespace SlowTests.Issues
+{
+    public class RavenDB_18656 : RavenTestBase
+    {
+        public RavenDB_18656(ITestOutputHelper output) : base(output)
+        {
+        }
+
+        [Fact]
+        public async Task DocumentQueryRQLExpressionShouldNotIncludePrivateMembers()
+        {
+            using var store = GetDocumentStore();
+
+            using (var session = store.OpenSession())
+            {
+                session.Store(new Item(11, 22));
+                session.SaveChanges();
+            }
+
+            var index = new Item_Content();
+            await index.ExecuteAsync(store);
+            Indexes.WaitForIndexing(store);
+
+            using (var session = store.OpenSession())
+            {
+                var q = session.Query<Item, Item_Content>()
+                    .ProjectInto<Item>();
+                var expr = q.Expression.ToString();
+
+                Assert.DoesNotContain("privateContent", expr); // expression shouldn't contain privateContent & privateContent2
+            }
+        }
+
+
+
+        public class Item
+        {
+
+            public Item()
+            {
+            }
+
+            public Item(int a, int b)
+            {
+                privateContent = a;
+                privateContent2 = b;
+            }
+
+            private int? privateContent;
+            public int? Content
+            {
+                get => privateContent;
+                set => privateContent = value == int.MinValue ? null : value;
+            }
+
+            private int? privateContent2;
+        }
+
+
+        class Item_Content : AbstractIndexCreationTask<Item>
+        {
+            public Item_Content()
+            {
+                Map = (items) =>
+                    from item in items
+                    select new
+                    {
+                        item.Content
+                    };
+
+
+                Store("Content", FieldStorage.Yes);
+            }
+
+        }
+    }
+}


### PR DESCRIPTION
### Issue link

https://issues.hibernatingrhinos.com/issue/RavenDB-18656

### Additional description

Fixing- DocumentQuery RQL expression includes private members (properties and fields) of the projected class.

### Type of change

- Bug fix

### How risky is the change?

- Low 

### Backward compatibility

- Not relevant

### Is it platform specific issue?

- No

### Documentation update

- No documentation update is needed 

### Testing 

- Tests have been added that prove the fix is effective or that the feature works

### Is there any existing behavior change of other features due to this change?

- No

### UI work

- No UI work is needed
