### PR TITLE
RavenDB-18458  Provide option to delete existing-expired certificate …

### DIFF
--- a/src/Raven.Studio/typescript/models/auth/certificateModel.ts
+++ b/src/Raven.Studio/typescript/models/auth/certificateModel.ts
@@ -59,8 +59,12 @@ class certificateModel {
         validityPeriod: this.validityPeriod
     });
     
-    private constructor(mode: certificateMode) {
+    private constructor(mode: certificateMode,
+                        name?: string, clearance?: Raven.Client.ServerWide.Operations.Certificates.SecurityClearance, thumbprint?: string) {
         this.mode(mode);
+        this.name(name);
+        this.securityClearance(clearance);
+        this.thumbprint(thumbprint);
 
         _.bindAll(this, "setClearanceMode", "changeValidityPeriodUnits");
         
@@ -198,8 +202,8 @@ class certificateModel {
         return new certificateModel("generate");
     }
 
-    static reGenerate() {
-        return new certificateModel("reGenerate");
+    static regenerate(name: string, clearance: Raven.Client.ServerWide.Operations.Certificates.SecurityClearance, thumbprint: string) {
+        return new certificateModel("regenerate", name, clearance, thumbprint);
     }
     
     static upload() {

--- a/src/Raven.Studio/typescript/models/auth/certificateModel.ts
+++ b/src/Raven.Studio/typescript/models/auth/certificateModel.ts
@@ -50,6 +50,8 @@ class certificateModel {
 
     securityClearanceLabel: KnockoutComputed<string>;
     canEditClearance: KnockoutComputed<boolean>;
+
+    deleteExpired = ko.observable<boolean>(false);
     
     validationGroup: KnockoutValidationGroup = ko.validatedObservable({
         name: this.name,
@@ -194,6 +196,10 @@ class certificateModel {
     
     static generate() {
         return new certificateModel("generate");
+    }
+
+    static reGenerate() {
+        return new certificateModel("reGenerate");
     }
     
     static upload() {

--- a/src/Raven.Studio/typescript/models/auth/certificateModel.ts
+++ b/src/Raven.Studio/typescript/models/auth/certificateModel.ts
@@ -204,6 +204,13 @@ class certificateModel {
         newItem.name(itemToRegenerate.Name);
         newItem.thumbprint(itemToRegenerate.Thumbprint);
         newItem.securityClearance(itemToRegenerate.SecurityClearance);
+
+        for (let dbItem in itemToRegenerate.Permissions) {
+            const permission = new certificatePermissionModel();
+            permission.databaseName(dbItem);
+            permission.accessLevel(itemToRegenerate.Permissions[dbItem]);
+            newItem.permissions.push(permission);
+        }
         
         return newItem;
     }

--- a/src/Raven.Studio/typescript/models/auth/certificateModel.ts
+++ b/src/Raven.Studio/typescript/models/auth/certificateModel.ts
@@ -59,12 +59,8 @@ class certificateModel {
         validityPeriod: this.validityPeriod
     });
     
-    private constructor(mode: certificateMode,
-                        name?: string, clearance?: Raven.Client.ServerWide.Operations.Certificates.SecurityClearance, thumbprint?: string) {
+    private constructor(mode: certificateMode) {
         this.mode(mode);
-        this.name(name);
-        this.securityClearance(clearance);
-        this.thumbprint(thumbprint);
 
         _.bindAll(this, "setClearanceMode", "changeValidityPeriodUnits");
         
@@ -202,8 +198,14 @@ class certificateModel {
         return new certificateModel("generate");
     }
 
-    static regenerate(name: string, clearance: Raven.Client.ServerWide.Operations.Certificates.SecurityClearance, thumbprint: string) {
-        return new certificateModel("regenerate", name, clearance, thumbprint);
+    static regenerate(itemToRegenerate: unifiedCertificateDefinition) {
+        const newItem = new certificateModel("regenerate");
+        
+        newItem.name(itemToRegenerate.Name);
+        newItem.thumbprint(itemToRegenerate.Thumbprint);
+        newItem.securityClearance(itemToRegenerate.SecurityClearance);
+        
+        return newItem;
     }
     
     static upload() {

--- a/src/Raven.Studio/typescript/viewmodels/manage/certificates.ts
+++ b/src/Raven.Studio/typescript/viewmodels/manage/certificates.ts
@@ -410,7 +410,7 @@ class certificates extends viewModelBase {
 
     enterRegenerateCertificateMode(itemToRegenerate: unifiedCertificateDefinition) {
         eventsCollector.default.reportEvent("certificates", "re-generate");
-        this.model(certificateModel.regenerate(itemToRegenerate.Name, itemToRegenerate.SecurityClearance, itemToRegenerate.Thumbprint));
+        this.model(certificateModel.regenerate(itemToRegenerate));
 
         for (let dbItem in itemToRegenerate.Permissions) {
             const permission = new certificatePermissionModel();
@@ -446,6 +446,7 @@ class certificates extends viewModelBase {
 
     save() {
         const model = this.model();
+        const thumbprint = model.thumbprint();
         
         if (!this.isValid(model.validationGroup)) {
             return;
@@ -453,7 +454,7 @@ class certificates extends viewModelBase {
 
         const maybeWarnTask = $.Deferred<void>();
         
-        if (this.model().mode() !== "replace" && model.securityClearance() === "ValidUser" && model.permissions().length === 0) {
+        if (model.mode() !== "replace" && model.securityClearance() === "ValidUser" && model.permissions().length === 0) {
             this.confirmationMessage("Did you forget about assigning database privileges?",
             "Leaving the database privileges section empty is going to prevent users from accessing the database.",
                 {
@@ -489,7 +490,7 @@ class certificates extends viewModelBase {
                                 notificationCenter.instance.monitorOperation(null, operationId)
                                     .done(() => {
                                         if (model.deleteExpired()) {
-                                            this.deleteCertificate(this.model().thumbprint());
+                                            this.deleteCertificate(thumbprint);
                                         }
                                         messagePublisher.reportSuccess("Client certificate was generated and downloaded successfully.");
                                     })

--- a/src/Raven.Studio/typescript/viewmodels/manage/certificates.ts
+++ b/src/Raven.Studio/typescript/viewmodels/manage/certificates.ts
@@ -411,13 +411,6 @@ class certificates extends viewModelBase {
     enterRegenerateCertificateMode(itemToRegenerate: unifiedCertificateDefinition) {
         eventsCollector.default.reportEvent("certificates", "re-generate");
         this.model(certificateModel.regenerate(itemToRegenerate));
-
-        for (let dbItem in itemToRegenerate.Permissions) {
-            const permission = new certificatePermissionModel();
-            permission.databaseName(dbItem);
-            permission.accessLevel(itemToRegenerate.Permissions[dbItem]);
-            this.model().permissions.push(permission);
-        }
     }
     
     enterUploadCertificateMode() {

--- a/src/Raven.Studio/typings/_studio/dto.d.ts
+++ b/src/Raven.Studio/typings/_studio/dto.d.ts
@@ -514,7 +514,7 @@ interface queryCompleterProviders {
 type rqlQueryType = "Select" | "Update";
 
 type autoCompleteCompleter = (editor: AceAjax.Editor, session: AceAjax.IEditSession, pos: AceAjax.Position, prefix: string, callback: (errors: any[], wordlist: autoCompleteWordList[]) => void) => void;
-type certificateMode = "generate" | "reGenerate" | "upload" | "editExisting" | "replace";
+type certificateMode = "generate" | "regenerate" | "upload" | "editExisting" | "replace";
 
 type dbCreationMode = "newDatabase" | "restore" | "legacyMigration";
 

--- a/src/Raven.Studio/typings/_studio/dto.d.ts
+++ b/src/Raven.Studio/typings/_studio/dto.d.ts
@@ -514,7 +514,7 @@ interface queryCompleterProviders {
 type rqlQueryType = "Select" | "Update";
 
 type autoCompleteCompleter = (editor: AceAjax.Editor, session: AceAjax.IEditSession, pos: AceAjax.Position, prefix: string, callback: (errors: any[], wordlist: autoCompleteWordList[]) => void) => void;
-type certificateMode = "generate" | "upload" | "editExisting" | "replace";
+type certificateMode = "generate" | "reGenerate" | "upload" | "editExisting" | "replace";
 
 type dbCreationMode = "newDatabase" | "restore" | "legacyMigration";
 

--- a/src/Raven.Studio/wwwroot/App/views/manage/certificates.html
+++ b/src/Raven.Studio/wwwroot/App/views/manage/certificates.html
@@ -209,7 +209,7 @@
                                     <button class="btn btn-default" data-bind="click: _.partial($root.enterEditCertificateMode, $data), visible: $root.canEdit($data)() && !isExpired" title="Edit certificate">
                                         <i class="icon-edit"></i>
                                     </button>
-                                    <button class="btn btn-danger" data-bind="click: _.partial($root.deleteCertificate, $data), visible: $root.canDelete(SecurityClearance, $data)" title="Remove certificate">
+                                    <button class="btn btn-danger" data-bind="click: _.partial($root.deleteCertificateConfirm, $data), visible: $root.canDelete(SecurityClearance, $data)" title="Remove certificate">
                                         <i class="icon-trash"></i>
                                     </button>
                                 </div>
@@ -270,6 +270,7 @@
                         <div class="flex-horizontal margin-bottom">
                             <div class="flex-grow">
                                 <h3 data-bind="visible: mode() === 'generate'">Generate client certificate</h3>
+                                <h3 data-bind="visible: mode() === 'reGenerate'">Regenerate expired client certificate</h3>
                                 <h3 data-bind="visible: mode() === 'upload'">Upload client certificate</h3>
                                 <h3 data-bind="visible: mode() === 'editExisting'">Edit permissions</h3>
                                 <h3 data-bind="visible: mode() === 'replace'">Replace server certificates (cluster-wide)</h3>
@@ -390,7 +391,7 @@
                                 </div>
                             </div>
                             <div data-bind="visible: mode() !== 'replace'">
-                                <hr />
+                                <hr class="margin-top-lg" />
                                 <h4>Database Permissions</h4>
                                 <div class="flex-horizontal margin-bottom margin-bottom-sm" data-bind="visible: $root.showDatabasesSelector">
                                     <div class="flex-grow" data-bind="validationOptions: { insertMessages: false }, validationElement: $root.newPermissionDatabaseName">
@@ -450,6 +451,13 @@
                                     </div>
                                 </div>
                             </div>
+                            <hr class="margin-top-lg" />
+                            <div class="toggle margin-left-sm" data-bind="visible: mode() === 'reGenerate'">
+                                <input id="deleteExpired" type="checkbox" class="styled" data-bind="checked: deleteExpired" />
+                                <label for="deleteExpired" data-placement="bottom" data-toggle="tooltip" data-animation="true" title="The expired certificate will be deleted upon clicking 'Generate'">
+                                    <span>Delete expired certificate</span>&nbsp;<small>(<code data-bind="text: thumbprint()"></code>)</small>
+                                </label>
+                            </div>
                             <div class="flex-horizontal margin-top">
                                 <div class="flex-separator"></div>
                                 <div>
@@ -458,9 +466,9 @@
                                         <span>Cancel</span>
                                     </button>
                                     <button class="btn btn-success" type="submit" data-placement="bottom" data-toggle="tooltip" title="The generated certificate will be downloaded in your browser" data-animation="true"
-                                            data-bind="visible: mode() === 'generate', disable: $root.spinners.processing, css: { 'btn-spinner' : $root.spinners.processing }">
+                                            data-bind="visible: mode() === 'generate' || mode() === 'reGenerate', disable: $root.spinners.processing, css: { 'btn-spinner' : $root.spinners.processing }">
                                         <i class="icon-magic-wand"></i>
-                                        <span>Generate</span>
+                                        <span data-bind="text: deleteExpired() ? 'Generate & Delete expired' : 'Generate'">Generate</span>
                                     </button>
                                     <button class="btn btn-success" type="submit"
                                             data-bind="visible: mode() === 'editExisting', disable: $root.spinners.processing, css: { 'btn-spinner' : $root.spinners.processing }">

--- a/src/Raven.Studio/wwwroot/App/views/manage/certificates.html
+++ b/src/Raven.Studio/wwwroot/App/views/manage/certificates.html
@@ -468,7 +468,7 @@
                                     <button class="btn btn-success" type="submit" data-placement="bottom" data-toggle="tooltip" title="The generated certificate will be downloaded in your browser" data-animation="true"
                                             data-bind="visible: mode() === 'generate' || mode() === 'reGenerate', disable: $root.spinners.processing, css: { 'btn-spinner' : $root.spinners.processing }">
                                         <i class="icon-magic-wand"></i>
-                                        <span data-bind="text: deleteExpired() ? 'Generate & Delete expired' : 'Generate'">Generate</span>
+                                        <span>Generate</span>
                                     </button>
                                     <button class="btn btn-success" type="submit"
                                             data-bind="visible: mode() === 'editExisting', disable: $root.spinners.processing, css: { 'btn-spinner' : $root.spinners.processing }">

--- a/src/Raven.Studio/wwwroot/App/views/manage/certificates.html
+++ b/src/Raven.Studio/wwwroot/App/views/manage/certificates.html
@@ -270,7 +270,7 @@
                         <div class="flex-horizontal margin-bottom">
                             <div class="flex-grow">
                                 <h3 data-bind="visible: mode() === 'generate'">Generate client certificate</h3>
-                                <h3 data-bind="visible: mode() === 'reGenerate'">Regenerate expired client certificate</h3>
+                                <h3 data-bind="visible: mode() === 'regenerate'">Regenerate expired client certificate</h3>
                                 <h3 data-bind="visible: mode() === 'upload'">Upload client certificate</h3>
                                 <h3 data-bind="visible: mode() === 'editExisting'">Edit permissions</h3>
                                 <h3 data-bind="visible: mode() === 'replace'">Replace server certificates (cluster-wide)</h3>
@@ -334,13 +334,13 @@
                                     <p class="help-block" data-bind="validationMessage: $root.importedFileName"></p>
                                 </div>
                             </div>
-                            <div class="form-group" data-bind="visible: mode() === 'upload' || mode() === 'generate' || mode() === 'replace'">
+                            <div class="form-group" data-bind="visible: mode() === 'upload' || mode() === 'generate' || mode() === 'regenerate' || mode() === 'replace'">
                                 <label class="control-label">
                                     Certificate Passphrase
                                 </label>
                                 <input class="form-control" type="password" data-bind="textInput: certificatePassphrase">
                             </div>
-                            <div class="form-group" data-bind="visible: mode() === 'upload' || mode() === 'generate', validationElement: validityPeriod">
+                            <div class="form-group" data-bind="visible: mode() === 'upload' || mode() === 'generate' || mode() === 'regenerate', validationElement: validityPeriod">
                                 <label class="control-label">
                                     Expire in
                                 </label>
@@ -452,7 +452,7 @@
                                 </div>
                             </div>
                             <hr class="margin-top-lg" />
-                            <div class="toggle margin-left-sm" data-bind="visible: mode() === 'reGenerate'">
+                            <div class="toggle margin-left-sm" data-bind="visible: mode() === 'regenerate'">
                                 <input id="deleteExpired" type="checkbox" class="styled" data-bind="checked: deleteExpired" />
                                 <label for="deleteExpired" data-placement="bottom" data-toggle="tooltip" data-animation="true" title="The expired certificate will be deleted upon clicking 'Generate'">
                                     <span>Delete expired certificate</span>&nbsp;<small>(<code data-bind="text: thumbprint()"></code>)</small>
@@ -466,7 +466,7 @@
                                         <span>Cancel</span>
                                     </button>
                                     <button class="btn btn-success" type="submit" data-placement="bottom" data-toggle="tooltip" title="The generated certificate will be downloaded in your browser" data-animation="true"
-                                            data-bind="visible: mode() === 'generate' || mode() === 'reGenerate', disable: $root.spinners.processing, css: { 'btn-spinner' : $root.spinners.processing }">
+                                            data-bind="visible: mode() === 'generate' || mode() === 'regenerate', disable: $root.spinners.processing, css: { 'btn-spinner' : $root.spinners.processing }">
                                         <i class="icon-magic-wand"></i>
                                         <span>Generate</span>
                                     </button>

--- a/src/Raven.Studio/wwwroot/App/views/manage/certificates.html
+++ b/src/Raven.Studio/wwwroot/App/views/manage/certificates.html
@@ -203,7 +203,7 @@
                             <div class="flex-grow"></div>
                             <div class="flex-horizontal">
                                 <div class="actions">
-                                    <button class="btn btn-default" data-bind="click: _.partial($root.enterReGenerateCertificateMode, $data), visible: $root.canEdit($data)() && isExpired" title="Re-generate certificate">
+                                    <button class="btn btn-default" data-bind="click: _.partial($root.enterRegenerateCertificateMode, $data), visible: $root.canEdit($data)() && isExpired" title="Re-generate certificate">
                                         <i class="icon-magic-wand"></i>
                                     </button>
                                     <button class="btn btn-default" data-bind="click: _.partial($root.enterEditCertificateMode, $data), visible: $root.canEdit($data)() && !isExpired" title="Edit certificate">


### PR DESCRIPTION
…when re-generating

### Issue link
https://issues.hibernatingrhinos.com/issue/RavenDB-18458

### Additional description
Add toggle to delete the expired cert when re-generating

### Type of change
- Task

### How risky is the change?
- Low 

### Backward compatibility
- Non breaking change

### Is it platform specific issue?
- No

### Documentation update
- This change requires a documentation update. 

### Testing 
- It has been verified by manual testing

### Is there any existing behavior change of other features due to this change?
- No

### UI work
- No UI work is needed
