### PR TITLE
RavenDB-18150: move backup logs to operations

### DIFF
--- a/src/Raven.Server/Documents/PeriodicBackup/PeriodicBackupRunner.cs
+++ b/src/Raven.Server/Documents/PeriodicBackup/PeriodicBackupRunner.cs
@@ -942,8 +942,8 @@ namespace Raven.Server.Documents.PeriodicBackup
 
                 if (taskState == TaskStatus.ActiveByCurrentNode)
                 {
-                    if (_logger.IsOperationsEnabled)
-                        _logger.Operations($"New backup task '{taskId}' state is '{taskState}', will arrange a new backup timer.");
+                    if (_logger.IsInfoEnabled)
+                        _logger.Info($"New backup task '{taskId}' state is '{taskState}', will arrange a new backup timer.");
 
                     var backupStatus = GetBackupStatus(taskId, inMemoryBackupStatus: null);
                     periodicBackup.UpdateTimer(GetNextBackupDetails(newConfiguration, backupStatus, _serverStore.NodeTag), lockTaken: false);
@@ -981,8 +981,8 @@ namespace Raven.Server.Documents.PeriodicBackup
                     // a backup is already running, the next one will be re-scheduled by the backup task if needed
                     if (existingBackupState.RunningTask != null)
                     {
-                        if (_logger.IsOperationsEnabled)
-                            _logger.Operations($"Backup task '{taskId}' state is '{taskState}', and currently are being executed since '{existingBackupState.StartTimeInUtc}'.");
+                        if (_logger.IsInfoEnabled)
+                            _logger.Info($"Backup task '{taskId}' state is '{taskState}', and currently are being executed since '{existingBackupState.StartTimeInUtc}'.");
 
                         return;
                     }
@@ -990,8 +990,8 @@ namespace Raven.Server.Documents.PeriodicBackup
                     // backup frequency hasn't changed, and we have a scheduled backup
                     if (previousConfiguration.HasBackupFrequencyChanged(newConfiguration) == false && existingBackupState.HasScheduledBackup())
                     {
-                        if (_logger.IsOperationsEnabled)
-                            _logger.Operations($"Backup task '{taskId}' state is '{taskState}', the task doesn't have frequency changes and has scheduled backup, will continue to execute by the current node '{_database.ServerStore.NodeTag}'.");
+                        if (_logger.IsInfoEnabled)
+                            _logger.Info($"Backup task '{taskId}' state is '{taskState}', the task doesn't have frequency changes and has scheduled backup, will continue to execute by the current node '{_database.ServerStore.NodeTag}'.");
 
                         return;
                     }


### PR DESCRIPTION
### Issue link

https://issues.hibernatingrhinos.com/issue/RavenDB-18150

### Additional description

Move to backup logs that were spamming few times in a second to operations mode.

### Type of change

- Bug fix


### How risky is the change?

- Low 

### Backward compatibility


- Not relevant

### Is it platform specific issue?


- No

### Documentation update

- No documentation update is needed 

### Testing 


- It has been verified by manual testing

### Is there any existing behavior change of other features due to this change?

- No

### UI work

- No UI work is needed
