### PR TITLE
RavenDB-18090 Add ElasticSearch ETL to the Tasks Panel in the Cluster…

### DIFF
--- a/src/Raven.Server/Dashboard/DatabasesInfoRetriever.cs
+++ b/src/Raven.Server/Dashboard/DatabasesInfoRetriever.cs
@@ -11,6 +11,7 @@ using Raven.Client.Documents.Operations.Backups;
 using Raven.Client.Documents.Operations.ETL;
 using Raven.Client.Documents.Operations.ETL.OLAP;
 using Raven.Client.Documents.Operations.ETL.SQL;
+using Raven.Client.Documents.Operations.ETL.ElasticSearch;
 using Raven.Client.Documents.Operations.Replication;
 using Raven.Client.Documents.Subscriptions;
 using Raven.Client.Json.Serialization;
@@ -295,6 +296,10 @@ namespace Raven.Server.Dashboard
             var sqlEtlCount = database.EtlLoader.SqlDestinations.Count;
             long sqlEtlCountOnNode = GetTaskCountOnNode<SqlEtlConfiguration>(database, dbRecord, serverStore, database.EtlLoader.SqlDestinations,
                 task => EtlLoader.GetProcessState(task.Transforms, database, task.Name));
+            
+            var elasticSearchEtlCount = database.EtlLoader.ElasticSearchDestinations.Count;
+            long elasticSearchEtlCountOnNode = GetTaskCountOnNode<ElasticSearchEtlConfiguration>(database, dbRecord, serverStore, database.EtlLoader.ElasticSearchDestinations,
+                task => EtlLoader.GetProcessState(task.Transforms, database,task.Name));
 
             var olapEtlCount = database.EtlLoader.OlapDestinations.Count;
             long olapEtlCountOnNode = GetTaskCountOnNode<OlapEtlConfiguration>(database, dbRecord, serverStore, database.EtlLoader.OlapDestinations,
@@ -310,7 +315,7 @@ namespace Raven.Server.Dashboard
             long subscriptionCountOnNode = GetSubscriptionCountOnNode(database, dbRecord, serverStore, context);
 
             ongoingTasksCount = extRepCount + replicationHubCount + replicationSinkCount +
-                                ravenEtlCount + sqlEtlCount + olapEtlCount + periodicBackupCount + subscriptionCount;
+                                ravenEtlCount + sqlEtlCount + elasticSearchEtlCount + olapEtlCount + periodicBackupCount + subscriptionCount;
             
             return new DatabaseOngoingTasksInfoItem()
             {
@@ -320,6 +325,7 @@ namespace Raven.Server.Dashboard
                 ReplicationSinkCount = replicationSinkCountOnNode,
                 RavenEtlCount = ravenEtlCountOnNode,
                 SqlEtlCount = sqlEtlCountOnNode,
+                ElasticSearchEtlCount = elasticSearchEtlCountOnNode,
                 OlapEtlCount = olapEtlCountOnNode,
                 PeriodicBackupCount = periodicBackupCountOnNode,
                 SubscriptionCount = subscriptionCountOnNode

--- a/src/Raven.Server/Dashboard/DatabasesOngoingTasksInfo.cs
+++ b/src/Raven.Server/Dashboard/DatabasesOngoingTasksInfo.cs
@@ -56,7 +56,7 @@ namespace Raven.Server.Dashboard
 
         public long SqlEtlCount { get; set; }
         
-        // public long ElasticSearchEtlCount { get; set; }  // TODO: RavenDB-18090
+        public long ElasticSearchEtlCount { get; set; }
         
         public long OlapEtlCount { get; set; }
 
@@ -74,6 +74,7 @@ namespace Raven.Server.Dashboard
                 [nameof(ReplicationSinkCount)] = ReplicationSinkCount,
                 [nameof(RavenEtlCount)] = RavenEtlCount,
                 [nameof(SqlEtlCount)] = SqlEtlCount,
+                [nameof(ElasticSearchEtlCount)] = ElasticSearchEtlCount,
                 [nameof(OlapEtlCount)] = OlapEtlCount,
                 [nameof(PeriodicBackupCount)] = PeriodicBackupCount,
                 [nameof(SubscriptionCount)] = SubscriptionCount

--- a/src/Raven.Studio/typescript/viewmodels/resources/widgets/ongoingTasksWidget.ts
+++ b/src/Raven.Studio/typescript/viewmodels/resources/widgets/ongoingTasksWidget.ts
@@ -62,6 +62,7 @@ class ongoingTaskItem {
             case "RavenEtlCount": return "RavenDB ETL";
             case "OlapEtlCount": return "OLAP ETL";
             case "SqlEtlCount": return "SQL ETL";
+            case "ElasticSearchEtlCount": return "Elasticsearch ETL";
             case "PeriodicBackupCount": return "Backup";
             case "SubscriptionCount": return "Subscription";
         }
@@ -95,6 +96,7 @@ class ongoingTasksWidget extends websocketBasedWidget<Raven.Server.Dashboard.Clu
             new ongoingTaskItem("RavenEtlCount", 0, "ravendb-etl", "icon-ravendb-etl"),
             new ongoingTaskItem("OlapEtlCount", 0, "olap-etl", "icon-olap-etl"),
             new ongoingTaskItem("SqlEtlCount", 0, "sql-etl", "icon-sql-etl"),
+            new ongoingTaskItem("ElasticSearchEtlCount", 0, "elastic-etl", "icon-elastic-search-etl"),
             new ongoingTaskItem("PeriodicBackupCount", 0, "periodic-backup", "icon-backups"),
             new ongoingTaskItem("SubscriptionCount", 0, "subscription", "icon-subscription")
         ]);

--- a/src/Raven.Studio/wwwroot/Content/css/pages/cluster-dashboard.less
+++ b/src/Raven.Studio/wwwroot/Content/css/pages/cluster-dashboard.less
@@ -658,6 +658,10 @@
                 color: @sql-etl-color;
             }
 
+            &.elastic-etl .task-name i {
+                color: @elastic-etl-color;
+            }
+
             &.periodic-backup .task-name i {
                 color: @backup-color;
             }


### PR DESCRIPTION
… Dashboard

### Issue link
https://issues.hibernatingrhinos.com/issue/RavenDB-18090

### Additional description
Add ElasticSearch info to Tasks Panel in Cluster Dashboard

### Type of change
- Bug fix

### How risky is the change?
- Low 

### Backward compatibility
- Non breaking change

### Is it platform specific issue?
- No

### Documentation update
- This change requires a documentation update. 

### Testing 
- It has been verified by manual testing

### Is there any existing behavior change of other features due to this change?
- No

### UI work
- No UI work is needed
