### PR TITLE
RavenDB-17262 allow to generate empty setup params json file

### DIFF
--- a/tools/rvn/InitSetupParams.cs
+++ b/tools/rvn/InitSetupParams.cs
@@ -39,41 +39,23 @@ public class InitSetupParams
 
     private static SetupInfo GenerateSetupInfoForOwnCert()
     {
-        return new SetupInfo()
-        {
-            Domain = "subdomain",
-            RootDomain = "example.com",
-            License = new License() { Id = Guid.Empty, Keys = new List<string>() { string.Empty }, Name = string.Empty },
-            NodeSetupInfos = new Dictionary<string, SetupInfo.NodeInfo>()
-            {
-                {
-                    "A",
-                    new SetupInfo.NodeInfo()
-                    {
-                        Addresses = new List<string>() { "https://0.0.0.0:0" },
-                        Port = 443,
-                        TcpPort = 38888,
-                        PublicServerUrl = "https://subdomain.example.com",
-                        PublicTcpServerUrl = "tcp://subdomain.example.com:38888"
-                    }
-                }
-            }
-        };
+        return GenerateTemplateSetupInfo("subdomain", "example.com");
     }
 
     private static SetupInfo GenerateSetupInfoForLetsEncrypt()
     {
+        var setupInfo = GenerateTemplateSetupInfo("your-domain", "development.run");
+        setupInfo.Email = string.Empty;
+        return setupInfo;
+    }
+
+    private static SetupInfo GenerateTemplateSetupInfo(string domain, string rootDomain)
+    {
         return new SetupInfo()
         {
-            Domain = "your-domain",
-            RootDomain = "development.run",
-            Email = string.Empty,
-            License = new License()
-            {
-                Id = new Guid(), 
-                Keys = new List<string>() { string.Empty }, 
-                Name = string.Empty
-            },
+            Domain = domain,
+            RootDomain = rootDomain,
+            License = new License() { Id = new Guid(), Keys = new List<string>() { string.Empty }, Name = string.Empty },
             NodeSetupInfos = new Dictionary<string, SetupInfo.NodeInfo>()
             {
                 {
@@ -83,8 +65,8 @@ public class InitSetupParams
                         Addresses = new List<string>() { "https://0.0.0.0:0" },
                         Port = 443,
                         TcpPort = 38888,
-                        PublicServerUrl = "https://your-domain.development.run",
-                        PublicTcpServerUrl = "tcp://your-domain.development.run:38888"
+                        PublicServerUrl = $"https://{domain}.{rootDomain}",
+                        PublicTcpServerUrl = $"tcp://{domain}.{rootDomain}:38888"
                     }
                 }
             }

--- a/tools/rvn/InitSetupParams.cs
+++ b/tools/rvn/InitSetupParams.cs
@@ -1,0 +1,93 @@
+﻿using System;
+using System.Collections.Generic;
+using System.IO;
+using System.Threading;
+using System.Threading.Tasks;
+using McMaster.Extensions.CommandLineUtils;
+using Newtonsoft.Json;
+using Raven.Server.Commercial;
+
+namespace rvn;
+
+public class InitSetupParams
+{
+    public static async Task RunAsync(string outputFilePath, string setupMode, CancellationToken token)
+    {
+        SetupInfo setupInfoLetsEncryptSkel = GenerateSetupInfo(setupMode);
+
+        var json = JsonConvert.SerializeObject(setupInfoLetsEncryptSkel, Formatting.Indented, new JsonSerializerSettings()
+        {
+            NullValueHandling = NullValueHandling.Ignore,
+            DefaultValueHandling = DefaultValueHandling.Ignore
+        });
+                    
+        await File.WriteAllTextAsync(outputFilePath!, json, token); 
+    }
+
+    private static SetupInfo GenerateSetupInfo(string mode)
+    {
+        switch (mode)
+        {
+            case CommandLineApp.LetsEncrypt:
+                return GenerateSetupInfoForLetsEncrypt();
+            case CommandLineApp.OwnCertificate:
+                return GenerateSetupInfoForOwnCert();
+            default:
+                throw new NotSupportedException();
+        }
+    }
+
+    private static SetupInfo GenerateSetupInfoForOwnCert()
+    {
+        return new SetupInfo()
+        {
+            Domain = "subdomain",
+            RootDomain = "example.com",
+            License = new License() { Id = Guid.Empty, Keys = new List<string>() { string.Empty }, Name = string.Empty },
+            NodeSetupInfos = new Dictionary<string, SetupInfo.NodeInfo>()
+            {
+                {
+                    "A",
+                    new SetupInfo.NodeInfo()
+                    {
+                        Addresses = new List<string>() { "https://0.0.0.0:0" },
+                        Port = 443,
+                        TcpPort = 38888,
+                        PublicServerUrl = "https://subdomain.example.com",
+                        PublicTcpServerUrl = "tcp://subdomain.example.com:38888"
+                    }
+                }
+            }
+        };
+    }
+
+    private static SetupInfo GenerateSetupInfoForLetsEncrypt()
+    {
+        return new SetupInfo()
+        {
+            Domain = "your-domain",
+            RootDomain = "development.run",
+            Email = string.Empty,
+            License = new License()
+            {
+                Id = new Guid(), 
+                Keys = new List<string>() { string.Empty }, 
+                Name = string.Empty
+            },
+            NodeSetupInfos = new Dictionary<string, SetupInfo.NodeInfo>()
+            {
+                {
+                    "A",
+                    new SetupInfo.NodeInfo()
+                    {
+                        Addresses = new List<string>() { "https://0.0.0.0:0" },
+                        Port = 443,
+                        TcpPort = 38888,
+                        PublicServerUrl = "https://your-domain.development.run",
+                        PublicTcpServerUrl = "tcp://your-domain.development.run:38888"
+                    }
+                }
+            }
+        };
+    }
+}


### PR DESCRIPTION
### Issue link

https://issues.hibernatingrhinos.com/issue/RavenDB-17262

### Additional description

The missing piece for generating empty setup.json file. Users would not know what to put there, so let's make it easier for them and init the "empty"/generic content to fill in. Similar thing to AWS CLI's `--generate-cli-skeleton` option.

This is what it generates when called with:
```
init-setup-params -o setup.json -m lets-encrypt
```

Content:
```
{
  "License": {
    "Name": "",
    "Keys": [
      ""
    ]
  },
  "Email": "",
  "Domain": "your-domain",
  "RootDomain": "development.run",
  "NodeSetupInfos": {
    "A": {
      "PublicServerUrl": "https://your-domain.development.run",
      "PublicTcpServerUrl": "tcp://your-domain.development.run:38888",
      "Port": 443,
      "TcpPort": 38888,
      "Addresses": [
        "https://0.0.0.0:0"
      ]
    }
  }
}
```

Swithches are optional and default to `-o setup.json` and `-m lets-encrypt`. 

### Type of change

- New feature

### How risky is the change?

- Moderate 

### Backward compatibility

- Non breaking change

### Is it platform specific issue?

- No

### Documentation update

- This change requires a documentation update.

### Testing 

- It has been verified by manual testing

### Is there any existing behavior change of other features due to this change?

- No

### UI work

- No UI work is needed
