### PR TITLE
RavenDB-18621 : Reset should Not be mandatory when saving an ETL task

### DIFF
--- a/src/Raven.Server/Documents/Handlers/Processors/OngoingTasks/AbstractOngoingTasksHandlerProcessorForAddEtl.cs
+++ b/src/Raven.Server/Documents/Handlers/Processors/OngoingTasks/AbstractOngoingTasksHandlerProcessorForAddEtl.cs
@@ -32,7 +32,7 @@ namespace Raven.Server.Documents.Handlers.Processors.OngoingTasks
         protected override async ValueTask OnAfterUpdateConfiguration(TransactionOperationContext _, BlittableJsonReaderObject configuration, string raftRequestId)
         {
             // Reset scripts if needed
-            var scriptsToReset = RequestHandler.GetStringValuesQueryString("reset");
+            var scriptsToReset = RequestHandler.GetStringValuesQueryString("reset", required: false);
             configuration.TryGet(nameof(RavenEtlConfiguration.Name), out string etlConfigurationName);
 
             using (RequestHandler.ServerStore.ContextPool.AllocateOperationContext(out TransactionOperationContext ctx))


### PR DESCRIPTION
### Issue link

https://issues.hibernatingrhinos.com/issue/RavenDB-18621

### Additional description

AbstractOngoingTasksHandlerProcessorForAddEtl - "reset" query parameter should not be mandatory
bug was introduced in https://github.com/ravendb/ravendb/pull/14132

### Type of change

- Bug fix

### How risky is the change?

- Low 

### Backward compatibility

- Not relevant

### Is it platform specific issue?

- No

### Documentation update

- No documentation update is needed 

### Testing 

- It has been verified by manual testing

### Is there any existing behavior change of other features due to this change?

- No

### UI work

- No UI work is needed
