### PR TITLE
RavenDB-18677 Ensure no replication from multiple nodes to rehab

### DIFF
--- a/src/Raven.Client/ServerWide/DatabaseTopology.cs
+++ b/src/Raven.Client/ServerWide/DatabaseTopology.cs
@@ -1,5 +1,6 @@
 ﻿using System;
 using System.Collections.Generic;
+using System.Diagnostics;
 using System.Linq;
 using Newtonsoft.Json;
 using Raven.Client.Documents.Operations.Replication;
@@ -213,9 +214,23 @@ namespace Raven.Client.ServerWide
             if (Promotables.Contains(myTag)) // if we are a promotable we can't have any destinations
                 return destinations;
 
-            var nodes = Members.Concat(Rehabs);
+            if (Rehabs.Contains(myTag)) // if I'm rehab my only destination is my mentor
+            {
+                var myUrl = clusterTopology.GetUrlFromTag(myTag);
+                var repNode = WhoseTaskIsIt(state, new PromotableTask(myTag, myUrl, databaseName));
+                var repNodeUrl = clusterTopology.GetUrlFromTag(repNode);
 
-            foreach (var node in nodes)
+                destinations.Add(new InternalReplication
+                {
+                    NodeTag = repNode,
+                    Url = repNodeUrl,
+                    Database = databaseName
+                });
+
+                return destinations;
+            }
+
+            foreach (var node in Members)
             {
                 if (node == myTag) // skip me
                     continue;
@@ -231,11 +246,24 @@ namespace Raven.Client.ServerWide
 
                 var url = clusterTopology.GetUrlFromTag(promotable);
                 PredefinedMentors.TryGetValue(promotable, out var mentor);
-                if (WhoseTaskIsIt(state, new PromotableTask(promotable, url, databaseName, mentor), null) == myTag)
+                if (WhoseTaskIsIt(state, new PromotableTask(promotable, url, databaseName, mentor)) == myTag)
                 {
                     list.Add(url);
                 }
             }
+
+            foreach (var rehab in Rehabs)
+            {
+                if (deletionInProgress != null && deletionInProgress.ContainsKey(rehab))
+                    continue;
+
+                var url = clusterTopology.GetUrlFromTag(rehab);
+                if (WhoseTaskIsIt(state, new PromotableTask(rehab, url, databaseName)) == myTag)
+                {
+                    list.Add(url);
+                }
+            }
+
             // remove nodes that are not in the raft cluster topology
             list.RemoveAll(url => clusterTopology.TryGetNodeTagByUrl(url).HasUrl == false);
 
@@ -402,7 +430,7 @@ namespace Raven.Client.ServerWide
         public string WhoseTaskIsIt(
             RachisState state,
             IDatabaseTask task,
-            Func<string> getLastResponsibleNode)
+            Func<string> getLastResponsibleNode = null)
         {
             if (state == RachisState.Candidate || state == RachisState.Passive)
                 return null;

--- a/src/Raven.Server/Documents/DatabasesLandlord.cs
+++ b/src/Raven.Server/Documents/DatabasesLandlord.cs
@@ -81,6 +81,7 @@ namespace Raven.Server.Documents
         {
             internal Action<ServerStore> BeforeHandleClusterDatabaseChanged;
             internal Action<(DocumentDatabase Database, string caller)> AfterDatabaseCreation;
+            internal Action<CancellationToken> DelayIncomingReplication;
             internal int? HoldDocumentDatabaseCreation = null;
             internal bool PreventedRehabOfIdleDatabase = false;
             internal Action<DocumentDatabase> OnBeforeDocumentDatabaseInitialization;

--- a/src/Raven.Server/Documents/Replication/IncomingReplicationHandler.cs
+++ b/src/Raven.Server/Documents/Replication/IncomingReplicationHandler.cs
@@ -540,6 +540,8 @@ namespace Raven.Server.Documents.Replication
                         ReadAttachmentStreamsFromSource(attachmentStreamCount, documentsContext, dataForReplicationCommand, reader, networkStats);
                     }
 
+                    _parent._server.DatabasesLandlord.ForTestingPurposes?.DelayIncomingReplication?.Invoke(_cts.Token);
+
                     if (_allowedPathsValidator != null || _preventIncomingSinkDeletions)
                     {
                         // if the other side sends us any information that we shouldn't get from them,

--- a/src/Raven.Server/Documents/Replication/ReplicationLoader.cs
+++ b/src/Raven.Server/Documents/Replication/ReplicationLoader.cs
@@ -1294,10 +1294,12 @@ namespace Raven.Server.Documents.Replication
                     NodeTag = _clusterTopology.TryGetNodeTagByUrl(r).NodeTag,
                     Url = r,
                     Database = Database.Name
-                });
+                }).ToList();
 
                 DropOutgoingConnections(removed, instancesToDispose);
+                DropIncomingConnections(removed, instancesToDispose);
             }
+
             if (internalConnections.AddedDestinations.Count > 0)
             {
                 var added = internalConnections.AddedDestinations.Select(r => new InternalReplication


### PR DESCRIPTION
### Issue link

https://issues.hibernatingrhinos.com/issue/RavenDB-18677

### Additional description

Members & Rehabs were treat as equals when we decided to whom we should replicate.
When in fact Rehab should have been treated more like the Promotables. 
So there will be a single node that will replicate to the Rehab.

One distinguish between Rehab & Promotable in that regard is that Rehab node will try to replicate any new document that    he may contain to his mentor.

### Type of change

- Bug fix

### How risky is the change?

- Low 

### Backward compatibility

- Not relevant

### Is it platform specific issue?

- No

### Documentation update

- No documentation update is needed 

### Testing 

- Tests have been added that prove the fix is effective or that the feature works

### Is there any existing behavior change of other features due to this change?

- No

### UI work

- No UI work is needed
