### PR TITLE
RavenDB-18649 Corax as Experimental feature only / Allowing to set search engine per index 

### DIFF
--- a/src/Raven.Client/Constants.cs
+++ b/src/Raven.Client/Constants.cs
@@ -146,6 +146,11 @@ namespace Raven.Client
             {
             }
 
+            internal class Indexes
+            {
+                internal const string IndexingStaticSearchEngineType = "Indexing.Static.SearchEngineType";
+            }
+            
             public const string ClientId = "Configuration/Client";
 
             public const string StudioId = "Configuration/Studio";

--- a/src/Raven.Client/Documents/Indexes/AbstractIndexCreationTask.cs
+++ b/src/Raven.Client/Documents/Indexes/AbstractIndexCreationTask.cs
@@ -132,6 +132,12 @@ namespace Raven.Client.Documents.Indexes
         public IndexLockMode? LockMode { get; set; }
 
         public IndexDeploymentMode? DeploymentMode { get; set; }
+        
+        /// <summary>
+        ///  Set search engine for index.
+        ///<para>Default value: null means that the configuration from the database will be used.</para>
+        /// </summary>
+        public SearchEngineType? SearchEngineType { get; set; }
 
         /// <summary>
         /// Index state
@@ -219,6 +225,11 @@ namespace Raven.Client.Documents.Indexes
 
                 if (DeploymentMode.HasValue)
                     indexDefinition.DeploymentMode = DeploymentMode.Value;
+
+                if (SearchEngineType.HasValue)
+                {
+                    indexDefinition.Configuration[Constants.Configuration.Indexes.IndexingStaticSearchEngineType] = SearchEngineType.Value.ToString();
+                }
 
                 return store.Maintenance.ForDatabase(database).SendAsync(new PutIndexesOperation(indexDefinition), token);
             }

--- a/src/Raven.Server/Config/Categories/IndexingConfiguration.cs
+++ b/src/Raven.Server/Config/Categories/IndexingConfiguration.cs
@@ -388,7 +388,7 @@ namespace Raven.Server.Config.Categories
         [Description("Search engine for static indexes")]
         [DefaultValue(SearchEngineType.Lucene)]
         [IndexUpdateType(IndexUpdateType.Reset)]
-        [ConfigurationEntry("Indexing.Static.SearchEngineType", ConfigurationEntryScope.ServerWideOrPerDatabaseOrPerIndex)]
+        [ConfigurationEntry(Constants.Configuration.Indexes.IndexingStaticSearchEngineType, ConfigurationEntryScope.ServerWideOrPerDatabaseOrPerIndex)]
         public SearchEngineType StaticIndexingEngineType { get; protected set; }
         
         public Lazy<AnalyzerFactory> DefaultAnalyzerType { get; private set; }

--- a/src/Raven.Server/Documents/Handlers/Admin/AdminIndexHandler.cs
+++ b/src/Raven.Server/Documents/Handlers/Admin/AdminIndexHandler.cs
@@ -11,6 +11,7 @@ using Raven.Client.Documents.Operations;
 using Raven.Client.Documents.Smuggler;
 using Raven.Client.Exceptions.Documents.Indexes;
 using Raven.Client.Exceptions.Security;
+using Raven.Server.Config;
 using Raven.Server.Json;
 using Raven.Server.Routing;
 using Raven.Server.ServerWide.Context;
@@ -18,6 +19,7 @@ using Raven.Server.Smuggler.Documents;
 using Raven.Server.Smuggler.Documents.Data;
 using Raven.Server.Smuggler.Migration;
 using Raven.Server.TrafficWatch;
+using Raven.Server.Utils.Features;
 using Sparrow.Json;
 using Sparrow.Json.Parsing;
 using Sparrow.Logging;
@@ -82,6 +84,14 @@ namespace Raven.Server.Documents.Handlers.Admin
 
                     indexDefinition.Type = indexDefinition.DetectStaticIndexType();
 
+                    if (indexDefinition.Configuration.TryGetValue(Constants.Configuration.Indexes.IndexingStaticSearchEngineType, out var searchEngine))
+                    {
+                        if (searchEngine.Equals(SearchEngineType.Corax.ToString(), StringComparison.InvariantCultureIgnoreCase))
+                        {
+                            RavenConfiguration.AssertCanUseCoraxFeature(Server.Configuration);
+                        }
+                    }
+                    
                     // C# index using a non-admin endpoint
                     if (indexDefinition.Type.IsJavaScript() == false && validatedAsAdmin == false)
                     {

--- a/src/Raven.Server/Documents/Indexes/Index.cs
+++ b/src/Raven.Server/Documents/Indexes/Index.cs
@@ -20,6 +20,7 @@ using Raven.Client.Exceptions.Database;
 using Raven.Client.Exceptions.Documents.Indexes;
 using Raven.Client.ServerWide.Operations;
 using Raven.Client.Util;
+using Raven.Server.Config;
 using Raven.Server.Config.Categories;
 using Raven.Server.Config.Settings;
 using Raven.Server.Documents.Handlers.Admin;
@@ -817,6 +818,7 @@ namespace Raven.Server.Documents.Indexes
                     SearchEngineType = SearchEngineType.Lucene;
                     break;
                 case SearchEngineType.Corax:
+                    RavenConfiguration.AssertCanUseCoraxFeature(DocumentDatabase.ServerStore.Configuration);
                     IndexPersistence = new CoraxIndexPersistence(this);
                     SearchEngineType = SearchEngineType.Corax;
                     break;

--- a/src/Raven.Server/Utils/Features/Feature.cs
+++ b/src/Raven.Server/Utils/Features/Feature.cs
@@ -8,5 +8,8 @@ public enum Feature
     GraphApi,
 
     [Description("PostgreSQL")]
-    PostgreSql
+    PostgreSql,
+    
+    [Description("Corax")]
+    Corax
 }

--- a/src/Raven.Server/Utils/Features/FeatureGuardian.cs
+++ b/src/Raven.Server/Utils/Features/FeatureGuardian.cs
@@ -20,6 +20,7 @@ public class FeatureGuardian
     {
         switch (feature)
         {
+            case Feature.Corax:
             case Feature.GraphApi:
             case Feature.PostgreSql:
                 AssertExperimental(feature, getExceptionMessage);
@@ -31,6 +32,7 @@ public class FeatureGuardian
     {
         switch (feature)
         {
+            case Feature.Corax:
             case Feature.GraphApi:
             case Feature.PostgreSql:
                 return _configuration.Core.FeaturesAvailability == FeaturesAvailability.Experimental;

--- a/test/FastTests/Issues/RavenDB-11791.cs
+++ b/test/FastTests/Issues/RavenDB-11791.cs
@@ -28,7 +28,7 @@ namespace FastTests.Issues
         }
         
         [RavenTheory(RavenTestCategory.Indexes)]
-        [RavenData(SearchEngineMode = RavenSearchEngineMode.All)]
+        [RavenData(SearchEngineMode = RavenSearchEngineMode.Corax)]
         public void Test(Options options)
         {
             using (var store = GetDocumentStore(options))

--- a/test/SlowTests/Corax/CanUseCoraxOnlyAsExperimental.cs
+++ b/test/SlowTests/Corax/CanUseCoraxOnlyAsExperimental.cs
@@ -1,0 +1,226 @@
+﻿using System.Collections.Generic;
+using System.Linq;
+using System.Threading.Tasks;
+using FastTests;
+using Raven.Client.Documents;
+using Raven.Client.Documents.Indexes;
+using Raven.Client.Documents.Operations.Indexes;
+using Raven.Client.Exceptions;
+using Raven.Server.Config;
+using Raven.Server.Documents.Indexes.Sorting;
+using Raven.Server.Utils;
+using Raven.Server.Utils.Features;
+using Tests.Infrastructure;
+using Xunit;
+using Xunit.Abstractions;
+
+namespace SlowTests.Corax;
+
+public class CanUseCoraxOnlyAsExperimental : RavenTestBase
+{
+    public CanUseCoraxOnlyAsExperimental(ITestOutputHelper output) : base(output)
+    {
+    }
+
+    private IDocumentStore GetDocumentStoreWithCustomExperimentalFlag(RavenTestParameters config, bool isExperimental = true)
+    {
+        if (isExperimental)
+        {
+            return GetDocumentStore(new Options()
+            {
+                ModifyDatabaseRecord = record =>
+                {
+                    record.Settings[RavenConfiguration.GetKey(x => x.Indexing.AutoIndexingEngineType)] = config.SearchEngine.ToString();
+                    record.Settings[RavenConfiguration.GetKey(x => x.Indexing.StaticIndexingEngineType)] = config.SearchEngine.ToString();
+                },
+            });
+        }
+
+
+        var server = GetNewServer(new ServerCreationOptions
+        {
+            CustomSettings = new Dictionary<string, string> {[RavenConfiguration.GetKey(x => x.Core.FeaturesAvailability)] = FeaturesAvailability.Stable.ToString()}
+        });
+
+
+        return GetDocumentStore(new Options()
+        {
+            ModifyDatabaseRecord = record =>
+            {
+                record.Settings[RavenConfiguration.GetKey(x => x.Indexing.AutoIndexingEngineType)] = config.SearchEngine.ToString();
+                record.Settings[RavenConfiguration.GetKey(x => x.Indexing.StaticIndexingEngineType)] = config.SearchEngine.ToString();
+            },
+            Server = server,
+        });
+    }
+
+    [RavenTheory(RavenTestCategory.Indexes)]
+    [RavenExplicitData(SearchEngineMode = RavenSearchEngineMode.Corax)]
+    public void CannotUseCoraxWhenExperimentalFlagIsOff(RavenTestParameters config)
+    {
+        var e = Assert.Throws<RavenException>(() =>
+        {
+            using (var store = GetDocumentStoreWithCustomExperimentalFlag(config, isExperimental: false))
+            {
+                new TestIndexWithSearchEngine(SearchEngineType.Corax).Execute(store);
+                return store;
+            }
+        });
+        Assert.True(e.Message.Contains("To use Corax search engine you have set FeaturesAvailability as Experimental."));
+    }
+
+    [RavenTheory(RavenTestCategory.Indexes)]
+    [RavenExplicitData(SearchEngineMode = RavenSearchEngineMode.Lucene)]
+    public void CannotCreateCoraxIndexOnLuceneDatabaseWhenExperimentalIsOff(RavenTestParameters config)
+    {
+        using var store = GetDocumentStoreWithCustomExperimentalFlag(config, false);
+        var e = Assert.Throws<RavenException>(() =>
+        {
+            new TestIndexWithSearchEngine(SearchEngineType.Corax).Execute(store);
+        });
+        Assert.True(e.Message.Contains("To use Corax search engine you have set FeaturesAvailability as Experimental."));
+    }
+
+    [RavenTheory(RavenTestCategory.Indexes)]
+    [RavenExplicitData(SearchEngineMode = RavenSearchEngineMode.Lucene)]
+    public async Task CanCreateCoraxIndexOnLuceneDatabase(RavenTestParameters config)
+    {
+        using var store = GetDocumentStoreWithCustomExperimentalFlag(config, true);
+        var indexObject = new TestIndexWithSearchEngine(SearchEngineType.Corax);
+        indexObject.Execute(store);
+        Indexes.WaitForIndexing(store);
+        var database = await GetDatabase(store.Database);
+        var index = database.IndexStore.GetIndex(indexObject.IndexName);
+        Assert.Equal(index.SearchEngineType, SearchEngineType.Corax);
+        Assert.False(index.IsInvalidIndex());
+    }
+
+    [RavenTheory(RavenTestCategory.Indexes)]
+    [RavenExplicitData(SearchEngineMode = RavenSearchEngineMode.Corax)]
+    public async Task LuceneIndexOnCoraxDatabase(RavenTestParameters config)
+    {
+        using var store = GetDocumentStoreWithCustomExperimentalFlag(config);
+        var indexObject = new TestIndexWithSearchEngine(SearchEngineType.Lucene);
+        indexObject.Execute(store);
+        Indexes.WaitForIndexing(store);
+        var database = await GetDatabase(store.Database);
+        var index = database.IndexStore.GetIndex(indexObject.IndexName);
+        Assert.Equal(index.SearchEngineType, SearchEngineType.Lucene);
+        Assert.False(index.IsInvalidIndex());
+    }
+    
+    [RavenTheory(RavenTestCategory.Indexes)]
+    [RavenExplicitData(SearchEngineMode = RavenSearchEngineMode.All)]
+    public async Task CreateDefaultIndex(RavenTestParameters config)
+    {
+        using var store = GetDocumentStoreWithCustomExperimentalFlag(config);
+        var indexObject = new TestIndexWithSearchEngine(null);
+        indexObject.Execute(store);
+        Indexes.WaitForIndexing(store);
+        var database = await GetDatabase(store.Database);
+        var index = database.IndexStore.GetIndex(indexObject.IndexName);
+        Assert.Equal(index.SearchEngineType, config.SearchEngine is RavenSearchEngineMode.Corax ? SearchEngineType.Corax : SearchEngineType.Lucene);
+        Assert.False(index.IsInvalidIndex());
+    }
+    
+    [RavenTheory(RavenTestCategory.Indexes)]
+    [RavenExplicitData(SearchEngineMode = RavenSearchEngineMode.Lucene)]
+    public async Task CannotOpenExperimentalIndexOnStable(RavenTestParameters config)
+    {
+        var serverPath = NewDataPath();
+        var databasePath = NewDataPath();
+
+        IOExtensions.DeleteDirectory(serverPath);
+        IOExtensions.DeleteDirectory(databasePath);
+
+        var dbName = GetDatabaseName();
+        var indexObject = new TestIndexWithSearchEngine(SearchEngineType.Corax);
+
+        using (var server = GetNewServer(new ServerCreationOptions
+               {
+                   DataDirectory = serverPath,
+                   RunInMemory = false,
+                   CustomSettings = new Dictionary<string, string>
+                   {
+                       [RavenConfiguration.GetKey(x => x.Core.FeaturesAvailability)] = FeaturesAvailability.Experimental.ToString()
+                   },
+               }))
+        using (var store = GetDocumentStore(new Options
+               {
+                   ModifyDatabaseName = _ => dbName,
+                   Path = databasePath,
+                   RunInMemory = false,
+                   Server = server,
+                   DeleteDatabaseOnDispose = false,
+                   ModifyDatabaseRecord = record =>
+                   {
+                       record.Settings[RavenConfiguration.GetKey(x => x.Indexing.AutoIndexingEngineType)] = config.SearchEngine.ToString();
+                       record.Settings[RavenConfiguration.GetKey(x => x.Indexing.StaticIndexingEngineType)] = config.SearchEngine.ToString();
+                       record.Settings[RavenConfiguration.GetKey(x => x.Core.ThrowIfAnyIndexCannotBeOpened)] = "false";
+                   }
+               }))
+        {
+            using (var session = store.OpenSession())
+            {
+                session.Store(new Test("Maciej"));
+                session.SaveChanges();
+            }
+
+            indexObject.Execute(store);
+            Indexes.WaitForIndexing(store);
+            var indexErrors1 = store.Maintenance.Send(new GetIndexErrorsOperation(new[] {indexObject.IndexName}));
+            Assert.Equal(indexErrors1[0].Name, indexObject.IndexName);
+            Assert.Empty(indexErrors1[0].Errors);
+
+            server.ServerStore.DatabasesLandlord.UnloadDirectly(store.Database);
+        }
+        SorterCompilationCache.Instance.RemoveServerWideItem(dbName);
+
+        using (var server = GetNewServer(
+                   new ServerCreationOptions 
+                   {
+                       DataDirectory = serverPath,
+                       RunInMemory = false,
+                       DeletePrevious = false,
+                       CustomSettings = new Dictionary<string, string> 
+                       {
+                           [RavenConfiguration.GetKey(x => x.Core.FeaturesAvailability)] = FeaturesAvailability.Stable.ToString()
+                           
+                       },
+                    }))
+        using (var store = GetDocumentStore(new Options
+                    {
+                        ModifyDatabaseName = _ => dbName,
+                        Path = databasePath,
+                        RunInMemory = false,
+                        Server = server,
+                        CreateDatabase = false,
+                        ModifyDatabaseRecord = record =>
+                        {
+                            record.Settings[RavenConfiguration.GetKey(x => x.Indexing.AutoIndexingEngineType)] = config.SearchEngine.ToString();
+                            record.Settings[RavenConfiguration.GetKey(x => x.Indexing.StaticIndexingEngineType)] = config.SearchEngine.ToString();
+                            record.Settings[RavenConfiguration.GetKey(x => x.Core.ThrowIfAnyIndexCannotBeOpened)] = "false";
+                        }
+                    }))
+        {
+            var indexErrors1 = store.Maintenance.Send(new GetIndexErrorsOperation(new[] {indexObject.IndexName}));
+            Assert.NotEmpty(indexErrors1);
+            Assert.Equal(indexErrors1[0].Name, indexObject.IndexName);
+            Assert.True(indexErrors1[0].Errors[0].Error.Contains("To use Corax search engine you have set FeaturesAvailability as Experimental."));
+        }
+    }
+
+    private record Test(string Name);
+
+    private class TestIndexWithSearchEngine : AbstractIndexCreationTask<Test>
+    {
+        public TestIndexWithSearchEngine(SearchEngineType? type)
+        {
+            Map = tests => from test in tests
+                select new {NewItem = test.Name};
+
+            if (type.HasValue)
+                SearchEngineType = type;
+        }
+    }
+}


### PR DESCRIPTION
### Issue link

https://issues.hibernatingrhinos.com/issue/RavenDB-18649 

### Additional description

`Experimental` mode is required for Corax.

### Type of change

- New feature

### How risky is the change?

- Not relevant

### Backward compatibility


- Not relevant

### Is it platform specific issue?

- No

### Documentation update

- No documentation update is needed 

### Testing 

- Tests have been added that prove the fix is effective or that the feature works


### Is there any existing behavior change of other features due to this change?

- No

### UI work

- No UI work is needed
