### PR TITLE
RavenDB-18687 use ordinal comparer to sort fields to avoid issues with handling auto-indexes in mixed clusters, which could cause them to be reset on every database record change

### DIFF
--- a/src/Raven.Server/Documents/Indexes/AutoIndexNameFinder.cs
+++ b/src/Raven.Server/Documents/Indexes/AutoIndexNameFinder.cs
@@ -22,7 +22,7 @@ namespace Raven.Server.Documents.Indexes
             if (groupBy == null)
                 throw new ArgumentNullException(nameof(groupBy));
 
-            var reducedByFields = string.Join("And", groupBy.Select(GetName).OrderBy(x => x));
+            var reducedByFields = string.Join("And", groupBy.Select(GetName).OrderBy(x => x, StringComparer.Ordinal));
 
             return $"{FindName(collection, fields, isMapReduce: true)}ReducedBy{reducedByFields}";
         }
@@ -49,7 +49,7 @@ namespace Raven.Server.Documents.Indexes
                 return collectionOnly;
             }
             
-            var combinedFields = string.Join("And", fields.Select(GetName).OrderBy(x => x));
+            var combinedFields = string.Join("And", fields.Select(GetName).OrderBy(x => x, StringComparer.Ordinal));
 
             string formattableString = $"Auto/{collection}/By{combinedFields}";
             if (formattableString.Length > 256)


### PR DESCRIPTION
### Issue link

https://issues.hibernatingrhinos.com/issue/RavenDB-18687

### Type of change

- Bug fix

### How risky is the change?

- Low 

### Backward compatibility

- Breaking change. This can cause indexes with quoted names to be reset.

### Is it platform specific issue?

- No

### Documentation update

- No documentation update is needed 

### Testing 

- It has been verified by manual testing

### Is there any existing behavior change of other features due to this change?

- No

### UI work

- No UI work is needed
