### PR TITLE
RavenDB-18659 : Timeseries stream could not parse start/end

### DIFF
--- a/src/Raven.Client/Documents/Session/Operations/StreamOperation.cs
+++ b/src/Raven.Client/Documents/Session/Operations/StreamOperation.cs
@@ -58,17 +58,17 @@ namespace Raven.Client.Documents.Session.Operations
         {
             var sb = new StringBuilder("streams/timeseries?");
 
-            sb.Append("docId=").Append(Uri.EscapeDataString(_docId)).Append("&");
-            sb.Append("name=").Append(Uri.EscapeDataString(_name)).Append("&");
+            sb.Append("docId=").Append(Uri.EscapeDataString(_docId)).Append('&');
+            sb.Append("name=").Append(Uri.EscapeDataString(_name)).Append('&');
 
             if (_from.HasValue)
-                sb.Append("from=").Append(_from.Value.GetDefaultRavenFormat()).Append("&");
+                sb.Append("from=").Append(_from.Value.EnsureUtc().GetDefaultRavenFormat()).Append('&');
 
             if (_to.HasValue)
-                sb.Append("to=").Append(_to.Value.GetDefaultRavenFormat()).Append("&");
+                sb.Append("to=").Append(_to.Value.EnsureUtc().GetDefaultRavenFormat()).Append('&');
 
             if (_offset.HasValue)
-                sb.Append("offset=").Append(_offset).Append("&");
+                sb.Append("offset=").Append(_offset).Append('&');
 
             return new StreamCommand(sb.ToString());
         }

--- a/src/Raven.Client/Documents/Session/Operations/StreamOperation.cs
+++ b/src/Raven.Client/Documents/Session/Operations/StreamOperation.cs
@@ -14,6 +14,7 @@ using Raven.Client.Util;
 using Sparrow;
 using Sparrow.Json;
 using Sparrow.Json.Parsing;
+using static Sparrow.Extensions.RavenDateTimeExtensions;
 
 namespace Raven.Client.Documents.Session.Operations
 {
@@ -61,10 +62,10 @@ namespace Raven.Client.Documents.Session.Operations
             sb.Append("name=").Append(Uri.EscapeDataString(_name)).Append("&");
 
             if (_from.HasValue)
-                sb.Append("from=").Append(_from).Append("&");
+                sb.Append("from=").Append(_from.Value.GetDefaultRavenFormat()).Append("&");
 
             if (_to.HasValue)
-                sb.Append("to=").Append(_to).Append("&");
+                sb.Append("to=").Append(_to.Value.GetDefaultRavenFormat()).Append("&");
 
             if (_offset.HasValue)
                 sb.Append("offset=").Append(_offset).Append("&");

--- a/test/SlowTests/Issues/RavenDB-18659.cs
+++ b/test/SlowTests/Issues/RavenDB-18659.cs
@@ -1,0 +1,54 @@
+﻿using System;
+using FastTests;
+using SlowTests.Core.Utils.Entities;
+using Sparrow;
+using Xunit;
+using Xunit.Abstractions;
+
+namespace SlowTests.Issues
+{
+    public class RavenDB_18659 : RavenTestBase
+    {
+        public RavenDB_18659(ITestOutputHelper output) : base(output)
+        {
+        }
+
+        [Fact]
+        public void CanStreamTimeSeriesWithFromAndTo()
+        {
+            using (var store = GetDocumentStore())
+            {
+                var baseline = DateTime.UtcNow.EnsureMilliseconds();
+                using (var session = store.OpenSession())
+                {
+
+                    session.Store(new User(), "karmel");
+                    var ts = session.TimeSeriesFor("karmel", "heartrate");
+                    for (int i = 0; i < 10; i++)
+                    {
+                        ts.Append(baseline.AddMinutes(i), i, "stream");
+                    }
+                    session.SaveChanges();
+                }
+
+                using (var session = store.OpenSession())
+                {
+                    var ts = session.TimeSeriesFor("karmel", "heartrate");
+
+                    using (var it = ts.Stream(baseline.AddMinutes(1), baseline.AddMinutes(9)))
+                    {
+                        var i = 1;
+                        while (it.MoveNext())
+                        {
+                            var entry = it.Current;
+                            Assert.Equal(baseline.AddMinutes(i), entry.Timestamp);
+                            Assert.Equal(i, entry.Value);
+                            Assert.Equal("stream", entry.Tag);
+                            i++;
+                        }
+                    }
+                }
+            }
+        }
+    }
+}

--- a/test/SlowTests/Issues/RavenDB-18659.cs
+++ b/test/SlowTests/Issues/RavenDB-18659.cs
@@ -21,7 +21,6 @@ namespace SlowTests.Issues
                 var baseline = DateTime.UtcNow.EnsureMilliseconds();
                 using (var session = store.OpenSession())
                 {
-
                     session.Store(new User(), "karmel");
                     var ts = session.TimeSeriesFor("karmel", "heartrate");
                     for (int i = 0; i < 10; i++)


### PR DESCRIPTION
### Issue link

https://issues.hibernatingrhinos.com/issue/RavenDB-18659

### Additional description

- use `GetDefaultRavenFormat` on `from` and `to` dates in `TimeSeriesStreamOperation`

### Type of change

- Bug fix

### How risky is the change?

- Low 

### Backward compatibility

- Not relevant

### Is it platform specific issue?

- No

### Documentation update

- No documentation update is needed 

### Testing 

- Tests have been added that prove the fix is effective or that the feature works

### Is there any existing behavior change of other features due to this change?

- No

### UI work

- No UI work is needed
