### PR TITLE
RavenDB-18688 - Disabled indexes shouldn't count when using WaitForIndexesAfterSaveChanges

### DIFF
--- a/src/Raven.Server/Documents/Handlers/BatchHandler.cs
+++ b/src/Raven.Server/Documents/Handlers/BatchHandler.cs
@@ -4,7 +4,6 @@ using System.Diagnostics;
 using System.IO;
 using System.Linq;
 using System.Net;
-using System.Runtime.ExceptionServices;
 using System.Text;
 using System.Threading;
 using System.Threading.Tasks;
@@ -13,6 +12,7 @@ using Microsoft.Net.Http.Headers;
 using Raven.Client.Documents.Attachments;
 using Raven.Client.Documents.Changes;
 using Raven.Client.Documents.Commands.Batches;
+using Raven.Client.Documents.Indexes;
 using Raven.Client.Documents.Operations.Attachments;
 using Raven.Client.Documents.Operations.Counters;
 using Raven.Client.Documents.Session;
@@ -440,6 +440,9 @@ namespace Raven.Server.Documents.Handlers
             {
                 foreach (var index in database.IndexStore.GetIndexes())
                 {
+                    if (index.State is IndexState.Disabled or IndexState.Error)
+                        continue;
+
                     if (index.Collections.Contains(Constants.Documents.Collections.AllDocumentsCollection) ||
                         index.WorksOnAnyCollection(modifiedCollections))
                     {

--- a/src/Raven.Server/Documents/Handlers/BatchHandler.cs
+++ b/src/Raven.Server/Documents/Handlers/BatchHandler.cs
@@ -411,10 +411,6 @@ namespace Raven.Server.Documents.Handlers
                                 return;
 
                             ThrowTimeoutException(indexesToWait, i, sp, context, cutoffEtag);
-
-                            throw new TimeoutException(
-                                $"After waiting for {sp.Elapsed}, could not verify that {indexesToCheck.Count} " +
-                                $"indexes has caught up with the changes as of etag: {cutoffEtag}");
                         }
                     }
                 }

--- a/src/Raven.Server/Documents/Handlers/BatchHandler.cs
+++ b/src/Raven.Server/Documents/Handlers/BatchHandler.cs
@@ -13,6 +13,7 @@ using Raven.Client.Documents.Attachments;
 using Raven.Client.Documents.Changes;
 using Raven.Client.Documents.Commands.Batches;
 using Raven.Client.Documents.Indexes;
+using Raven.Client.Documents.Linq;
 using Raven.Client.Documents.Operations.Attachments;
 using Raven.Client.Documents.Operations.Counters;
 using Raven.Client.Documents.Session;
@@ -394,8 +395,9 @@ namespace Raven.Server.Documents.Handlers
                 using (var context = QueryOperationContext.Allocate(database, needsServerContext))
                 using (context.OpenReadTransaction())
                 {
-                    foreach (var waitForIndexItem in indexesToWait)
+                    for (var i = 0; i < indexesToWait.Count; i++)
                     {
+                        var waitForIndexItem = indexesToWait[i];
                         if (waitForIndexItem.Index.IsStale(context, cutoffEtag) == false)
                             continue;
 
@@ -408,6 +410,8 @@ namespace Raven.Server.Documents.Handlers
                             if (throwOnTimeout == false)
                                 return;
 
+                            ThrowTimeoutException(indexesToWait, i, sp, context, cutoffEtag);
+
                             throw new TimeoutException(
                                 $"After waiting for {sp.Elapsed}, could not verify that {indexesToCheck.Count} " +
                                 $"indexes has caught up with the changes as of etag: {cutoffEtag}");
@@ -418,6 +422,33 @@ namespace Raven.Server.Documents.Handlers
                 if (hadStaleIndexes == false)
                     return;
             }
+        }
+
+        private static void ThrowTimeoutException(List<WaitForIndexItem> indexesToWait, int i, Stopwatch sp, QueryOperationContext context, long cutoffEtag)
+        {
+            var staleIndexesCount = 0;
+            var erroredIndexes = new List<string>();
+
+            for (var j = i; j < indexesToWait.Count; j++)
+            {
+                var index = indexesToWait[j].Index;
+                
+                if (index.State == IndexState.Error)
+                    erroredIndexes.Add(index.Name);
+                
+                if (index.IsStale(context, cutoffEtag))
+                    staleIndexesCount++;
+            }
+
+            var errorMessage = $"After waiting for {sp.Elapsed}, could not verify that all indexes has caught up with the changes as of etag: {cutoffEtag:#,#;;0}. " +
+                               $"Total relevant indexes: {indexesToWait.Count}, total stale indexes: {staleIndexesCount}";
+
+            if (erroredIndexes.Count > 0)
+            {
+                errorMessage += $", total errored indexes: {erroredIndexes.Count} ({string.Join(", ", erroredIndexes)})";
+            }
+
+            throw new TimeoutException(errorMessage);
         }
 
         private static List<Index> GetImpactedIndexesToWaitForToBecomeNonStale(DocumentDatabase database, List<string> specifiedIndexesQueryString, HashSet<string> modifiedCollections)
@@ -440,7 +471,7 @@ namespace Raven.Server.Documents.Handlers
             {
                 foreach (var index in database.IndexStore.GetIndexes())
                 {
-                    if (index.State is IndexState.Disabled or IndexState.Error)
+                    if (index.State is IndexState.Disabled)
                         continue;
 
                     if (index.Collections.Contains(Constants.Documents.Collections.AllDocumentsCollection) ||

--- a/src/Raven.Server/Documents/Indexes/Index.cs
+++ b/src/Raven.Server/Documents/Indexes/Index.cs
@@ -1442,8 +1442,6 @@ namespace Raven.Server.Documents.Indexes
 
                     while (true)
                     {
-                        _forTestingPurposes?.BeforeStartingNewBatch?.Invoke();
-
                         lock (_disablingIndexLock)
                         {
                             if (_indexDisabled)
@@ -5057,7 +5055,6 @@ namespace Raven.Server.Documents.Indexes
         internal class TestingStuff
         {
             internal Action ActionToCallInFinallyOfExecuteIndexing;
-            internal Action BeforeStartingNewBatch;
 
             internal IDisposable CallDuringFinallyOfExecuteIndexing(Action action)
             {

--- a/src/Raven.Server/Documents/Indexes/Index.cs
+++ b/src/Raven.Server/Documents/Indexes/Index.cs
@@ -1442,6 +1442,8 @@ namespace Raven.Server.Documents.Indexes
 
                     while (true)
                     {
+                        _forTestingPurposes?.BeforeStartingNewBatch?.Invoke();
+
                         lock (_disablingIndexLock)
                         {
                             if (_indexDisabled)
@@ -5055,6 +5057,7 @@ namespace Raven.Server.Documents.Indexes
         internal class TestingStuff
         {
             internal Action ActionToCallInFinallyOfExecuteIndexing;
+            internal Action BeforeStartingNewBatch;
 
             internal IDisposable CallDuringFinallyOfExecuteIndexing(Action action)
             {

--- a/test/SlowTests/Issues/RavenDB-15497.cs
+++ b/test/SlowTests/Issues/RavenDB-15497.cs
@@ -1,8 +1,9 @@
 ﻿using System;
 using System.Linq;
+using System.Threading;
+using System.Threading.Tasks;
 using FastTests;
 using Raven.Client.Documents.Indexes;
-using Raven.Client.Documents.Operations.Indexes;
 using Raven.Client.Exceptions;
 using Raven.Tests.Core.Utils.Entities;
 using Xunit;
@@ -17,35 +18,39 @@ namespace SlowTests.Issues
         }
 
         [Fact]
-        public void WaitForIndexesAfterSaveChangesCanExitWhenThrowOnTimeoutIsFalse()
+        public async Task WaitForIndexesAfterSaveChangesCanExitWhenThrowOnTimeoutIsFalse()
         {
             using (var store = GetDocumentStore())
             {
                 var index = new Index();
-                index.Execute(store);
-                store.Maintenance.Send(new DisableIndexOperation(index.IndexName));
-
-                var indexStats = store.Maintenance.Send(new GetIndexStatisticsOperation(index.IndexName));
-                Assert.Equal(IndexState.Disabled, indexStats.State);
-                Assert.Equal(IndexRunningStatus.Disabled, indexStats.Status);
+                await index.ExecuteAsync(store);
 
                 using (var session = store.OpenSession())
                 {
                     session.Store(new User
                     {
-                        Name = "user1"
+                        Name = "user1",
+                        Count = 3
                     });
                     session.Advanced.WaitForIndexesAfterSaveChanges(timeout: TimeSpan.FromSeconds(3), throwOnTimeout: false);
                     session.SaveChanges();
                 }
 
+                Indexes.WaitForIndexing(store);
+
+                const int timeoutInMs = 2_000;
+                (await GetDatabase(store.Database)).IndexStore.GetIndex(index.IndexName).ForTestingPurposesOnly().BeforeStartingNewBatch = () =>
+                {
+                    Thread.Sleep(timeoutInMs + 100);
+                };
+
                 using (var session = store.OpenSession())
                 {
                     session.Store(new User
                     {
                         Name = "user1"
                     });
-                    session.Advanced.WaitForIndexesAfterSaveChanges(timeout: TimeSpan.FromSeconds(3), throwOnTimeout: true);
+                    session.Advanced.WaitForIndexesAfterSaveChanges(timeout: TimeSpan.FromMilliseconds(timeoutInMs), throwOnTimeout: true);
 
                     var error = Assert.Throws<RavenException>(() => session.SaveChanges());
                     Assert.StartsWith("System.TimeoutException", error.Message);

--- a/test/SlowTests/Issues/RavenDB-15497.cs
+++ b/test/SlowTests/Issues/RavenDB-15497.cs
@@ -54,7 +54,8 @@ namespace SlowTests.Issues
 
                     var error = Assert.Throws<RavenException>(() => session.SaveChanges());
                     Assert.StartsWith("System.TimeoutException", error.Message);
-                    Assert.Contains("could not verify that 1 indexes has caught up with the changes as of etag", error.Message);
+                    Assert.Contains("could not verify that all indexes has caught up with the changes as of etag", error.Message);
+                    Assert.DoesNotContain("total errored indexes", error.Message);
                 }
             }
         }

--- a/test/SlowTests/Issues/RavenDB-15497.cs
+++ b/test/SlowTests/Issues/RavenDB-15497.cs
@@ -1,9 +1,9 @@
 ﻿using System;
 using System.Linq;
-using System.Threading;
 using System.Threading.Tasks;
 using FastTests;
 using Raven.Client.Documents.Indexes;
+using Raven.Client.Documents.Operations.Indexes;
 using Raven.Client.Exceptions;
 using Raven.Tests.Core.Utils.Entities;
 using Xunit;
@@ -38,8 +38,7 @@ namespace SlowTests.Issues
 
                 Indexes.WaitForIndexing(store);
 
-                var database = await GetDatabase(store.Database);
-                database.IndexStore.StopIndex(index.IndexName);
+                await store.Maintenance.SendAsync(new StopIndexOperation(index.IndexName));
 
                 using (var session = store.OpenSession())
                 {

--- a/test/SlowTests/Issues/RavenDB-18688.cs
+++ b/test/SlowTests/Issues/RavenDB-18688.cs
@@ -1,0 +1,131 @@
+﻿using System;
+using System.Linq;
+using System.Threading.Tasks;
+using FastTests;
+using Raven.Client.Documents.Indexes;
+using Raven.Client.Documents.Operations.Indexes;
+using Raven.Client.Exceptions;
+using Raven.Tests.Core.Utils.Entities;
+using Xunit;
+using Xunit.Abstractions;
+
+namespace SlowTests.Issues
+{
+    public class RavenDB_18688 : RavenTestBase
+    {
+        public RavenDB_18688(ITestOutputHelper output) : base(output)
+        {
+        }
+
+        [Fact]
+        public async Task Doesnt_Throw_When_Index_Is_Disabled()
+        {
+            using (var store = GetDocumentStore())
+            {
+                var index = new Index();
+                await index.ExecuteAsync(store);
+                await store.Maintenance.SendAsync(new DisableIndexOperation(index.IndexName));
+
+                using (var session = store.OpenAsyncSession())
+                {
+                    await session.StoreAsync(
+                        new User
+                        {
+                            Name = "Grisha"
+                        });
+                    session.Advanced.WaitForIndexesAfterSaveChanges(timeout: TimeSpan.FromSeconds(5));
+                    await session.SaveChangesAsync();
+                }
+
+                using (var session = store.OpenAsyncSession())
+                {
+                    await session.StoreAsync(
+                        new User
+                        {
+                            Name = "Grisha"
+                        });
+                    session.Advanced.WaitForIndexesAfterSaveChanges(timeout: TimeSpan.FromSeconds(5), indexes: new[] { index.IndexName });
+                    var error = await Assert.ThrowsAsync<RavenException>(async () => await session.SaveChangesAsync());
+                    Assert.StartsWith("System.TimeoutException", error.Message);
+                    Assert.Contains("could not verify that 1 indexes has caught up with the changes as of etag", error.Message);
+                }
+            }
+        }
+
+        [Fact]
+        public async Task Doesnt_Throw_When_Index_Is_Errored()
+        {
+            using (var store = GetDocumentStore())
+            {
+                var index = new ErroredIndex();
+                await index.ExecuteAsync(store);
+
+                using (var session = store.OpenAsyncSession())
+                {
+                    await session.StoreAsync(
+                        new User
+                        {
+                            Count = 0
+                        });
+                    await session.SaveChangesAsync();
+                }
+
+                var state = await WaitForValueAsync(async () =>
+                {
+                    var indexStats = store.Maintenance.Send(new GetIndexStatisticsOperation(index.IndexName));
+                    return indexStats.State;
+                }, IndexState.Error);
+
+                Assert.Equal(IndexState.Error, state);
+
+                using (var session = store.OpenAsyncSession())
+                {
+                    await session.StoreAsync(
+                        new User
+                        {
+                            Count = 0
+                        });
+                    session.Advanced.WaitForIndexesAfterSaveChanges(timeout: TimeSpan.FromSeconds(5));
+                    await session.SaveChangesAsync();
+                }
+
+                using (var session = store.OpenAsyncSession())
+                {
+                    await session.StoreAsync(
+                        new User
+                        {
+                            Count = 0
+                        });
+                    session.Advanced.WaitForIndexesAfterSaveChanges(timeout: TimeSpan.FromSeconds(5), indexes: new[] { index.IndexName });
+                    var error = await Assert.ThrowsAsync<RavenException>(async () => await session.SaveChangesAsync());
+                    Assert.StartsWith("System.TimeoutException", error.Message);
+                    Assert.Contains("could not verify that 1 indexes has caught up with the changes as of etag", error.Message);
+                }
+            }
+        }
+
+        private class Index : AbstractIndexCreationTask<User>
+        {
+            public Index()
+            {
+                Map = users => from user in users
+                    select new
+                    {
+                        user.Name
+                    };
+            }
+        }
+
+        private class ErroredIndex : AbstractIndexCreationTask<User>
+        {
+            public ErroredIndex()
+            {
+                Map = users => from user in users
+                    select new
+                    {
+                        Count = 3 / user.Count
+                    };
+            }
+        }
+    }
+}

--- a/test/SlowTests/Issues/RavenDB-18688.cs
+++ b/test/SlowTests/Issues/RavenDB-18688.cs
@@ -49,6 +49,7 @@ namespace SlowTests.Issues
                     Assert.StartsWith("System.TimeoutException", error.Message);
                     Assert.Contains("could not verify that all indexes has caught up with the changes as of etag", error.Message);
                     Assert.Contains("Total relevant indexes: 1, total stale indexes: 1", error.Message);
+                    Assert.DoesNotContain("total paused indexes", error.Message);
                 }
             }
         }
@@ -90,6 +91,7 @@ namespace SlowTests.Issues
                     var error = await Assert.ThrowsAsync<RavenException>(async () => await session.SaveChangesAsync());
                     Assert.StartsWith("System.TimeoutException", error.Message);
                     Assert.Contains($"Total relevant indexes: 1, total stale indexes: 1, total errored indexes: 1 ({index.IndexName})", error.Message);
+                    Assert.DoesNotContain("total paused indexes", error.Message);
                 }
 
                 using (var session = store.OpenAsyncSession())
@@ -103,6 +105,7 @@ namespace SlowTests.Issues
                     var error = await Assert.ThrowsAsync<RavenException>(async () => await session.SaveChangesAsync());
                     Assert.StartsWith("System.TimeoutException", error.Message);
                     Assert.Contains($"Total relevant indexes: 1, total stale indexes: 1, total errored indexes: 1 ({index.IndexName})", error.Message);
+                    Assert.DoesNotContain("total paused indexes", error.Message);
                 }
 
                 await new Index().ExecuteAsync(store);
@@ -118,6 +121,7 @@ namespace SlowTests.Issues
                     var error = await Assert.ThrowsAsync<RavenException>(async () => await session.SaveChangesAsync());
                     Assert.StartsWith("System.TimeoutException", error.Message);
                     Assert.Contains($"Total relevant indexes: 2, total stale indexes: 1, total errored indexes: 1 ({index.IndexName})", error.Message);
+                    Assert.DoesNotContain("total paused indexes", error.Message);
                 }
             }
         }


### PR DESCRIPTION
### Issue link

https://issues.hibernatingrhinos.com/issue/RavenDB-18688

### Additional description

Disabled and Errored indexes shouldn't count when using `WaitForIndexesAfterSaveChanges`.
`WaitForIndexesAfterSaveChanges` with specific indexes will still wait for those kinds of indexes.

### Type of change

- Bug fix

### How risky is the change?

- Low 

### Backward compatibility

- Ensured

### Testing 

- Tests have been added that prove the fix is effective or that the feature works