### PR TITLE
RavenDB-15978 avoid mixing `Wait()` with `async`

### DIFF
--- a/test/SlowTests/Client/Attachments/AttachmentsReplication.cs
+++ b/test/SlowTests/Client/Attachments/AttachmentsReplication.cs
@@ -1560,7 +1560,11 @@ namespace SlowTests.Client.Attachments
                     EnsureNoReplicationLoop(cluster.Nodes[2], databaseName)
                 };
 
-                tasks.ForEach(t => Assert.True(t.Wait(TimeSpan.FromMinutes(1))));
+                await Task.WhenAll(tasks);
+                foreach (var task in tasks)
+                {
+                    await task;
+                }
 
                 var result = await store.Maintenance.Server.SendAsync(new DeleteDatabasesOperation(databaseName, hardDelete: true, fromNode: toRemove, timeToWaitForConfirmation: TimeSpan.FromSeconds(60)));
                 await mainServer.ServerStore.Cluster.WaitForIndexNotification(result.RaftCommandIndex + 1);
@@ -1585,7 +1589,11 @@ namespace SlowTests.Client.Attachments
                     EnsureNoReplicationLoop(cluster.Nodes[2], databaseName)
                 };
 
-                tasks.ForEach(t => Assert.True(t.Wait(TimeSpan.FromMinutes(1))));
+                await Task.WhenAll(tasks);
+                foreach (var task in tasks)
+                {
+                    await task;
+                }
             }
         }
 


### PR DESCRIPTION
### Issue link

https://issues.hibernatingrhinos.com/issue/RavenDB-15978

### Additional description

Failure of this tests seem to correlate with the last changes done to by this commit `https://github.com/ravendb/ravendb/pull/13941/commits/6c2808dfe547b510fcd47096e9bf0661fabb8045`

specifically converting this code
```
await Task.WhenAll(tasks);
tasks.ForEach(t => t.Wait());
```
to this:
```
tasks.ForEach(t => Assert.True(t.Wait(TimeSpan.FromMinutes(1))));
```

But I was unable to repro this locally probably due to not enough TP pressure / different parallelism config

### Type of change

- Test fix

### How risky is the change?

- Low 

### Backward compatibility

- Not relevant

### Is it platform specific issue?

- No

### Documentation update

- No documentation update is needed 

### Testing 

- Was unable to repro that locally

### Is there any existing behavior change of other features due to this change?

- No

### UI work

- No UI work is needed
