### PR TITLE
RavenDB-18676 - add a log only in case of low memory

### DIFF
--- a/src/Sparrow/LowMemory/LowMemoryNotification.cs
+++ b/src/Sparrow/LowMemory/LowMemoryNotification.cs
@@ -50,7 +50,7 @@ namespace Sparrow.LowMemory
             {
                 try
                 {
-                    if (_logger.IsOperationsEnabled)
+                    if (isLowMemory && _logger.IsOperationsEnabled)
                     {
                         _logger.Operations($"Running {_lowMemoryHandlers.Count} low memory handlers with severity: {lowMemorySeverity}. " +
                                            $"Commit charge: {memoryInfo.CurrentCommitCharge} / {memoryInfo.TotalCommittableMemory}, " +


### PR DESCRIPTION
### Issue link

https://issues.hibernatingrhinos.com/issue/RavenDB-18676

### Additional description

Add the log entry only if we are in low memory state

