### PR TITLE
RavenDB-18497 Corax - support for corax analyzers inside Search | allocation optimization inside Search

### DIFF
--- a/src/Corax/IndexSearcher/IndexSearcher.MultiTermMatches.cs
+++ b/src/Corax/IndexSearcher/IndexSearcher.MultiTermMatches.cs
@@ -7,11 +7,19 @@ using Corax.Queries;
 using Corax.Utils;
 using Sparrow;
 using Voron;
+using Sparrow.Server;
+using Voron.Data.CompactTrees;
 
 namespace Corax;
 
 public partial class IndexSearcher
 {
+    [MethodImpl(MethodImplOptions.AggressiveInlining)]
+    public MultiTermMatch StartWithQuery(Slice field, Slice startWith, bool isNegated = false, int fieldId = Constants.IndexSearcher.NonAnalyzer)
+    {
+        return MultiTermMatchBuilder<NullScoreFunction, StartWithTermProvider>(field, startWith, default, isNegated, fieldId);
+    }
+    
     [MethodImpl(MethodImplOptions.AggressiveInlining)]
     public MultiTermMatch StartWithQuery(string field, string startWith, bool isNegated = false, int fieldId = Constants.IndexSearcher.NonAnalyzer)
     {
@@ -20,6 +28,14 @@ public partial class IndexSearcher
 
     [MethodImpl(MethodImplOptions.AggressiveInlining)]
     public MultiTermMatch StartWithQuery<TScoreFunction>(string field, string startWith, TScoreFunction scoreFunction, bool isNegated = false,
+        int fieldId = Constants.IndexSearcher.NonAnalyzer)
+        where TScoreFunction : IQueryScoreFunction
+    {
+        return MultiTermMatchBuilder<TScoreFunction, StartWithTermProvider>(field, startWith, scoreFunction, isNegated, fieldId);
+    }
+    
+    [MethodImpl(MethodImplOptions.AggressiveInlining)]
+    public MultiTermMatch StartWithQuery<TScoreFunction>(Slice field, Slice startWith, TScoreFunction scoreFunction, bool isNegated = false,
         int fieldId = Constants.IndexSearcher.NonAnalyzer)
         where TScoreFunction : IQueryScoreFunction
     {
@@ -40,6 +56,21 @@ public partial class IndexSearcher
     {
         return MultiTermMatchBuilder<TScoreFunction, EndsWithTermProvider>(field, endsWith, scoreFunction, isNegated, fieldId);
     }
+    
+    [MethodImpl(MethodImplOptions.AggressiveInlining)]
+    public MultiTermMatch EndsWithQuery(Slice field, Slice endsWith, bool isNegated = false,
+        int fieldId = Constants.IndexSearcher.NonAnalyzer)
+    {
+        return MultiTermMatchBuilder<NullScoreFunction, EndsWithTermProvider>(field, endsWith, default, isNegated, fieldId);
+    }
+
+    [MethodImpl(MethodImplOptions.AggressiveInlining)]
+    public MultiTermMatch EndsWithQuery<TScoreFunction>(Slice field, Slice endsWith, TScoreFunction scoreFunction, bool isNegated = false,
+        int fieldId = Constants.IndexSearcher.NonAnalyzer)
+        where TScoreFunction : IQueryScoreFunction
+    {
+        return MultiTermMatchBuilder<TScoreFunction, EndsWithTermProvider>(field, endsWith, scoreFunction, isNegated, fieldId);
+    }
 
     [MethodImpl(MethodImplOptions.AggressiveInlining)]
     public MultiTermMatch ContainsQuery<TScoreFunction>(string field, string containsTerm, TScoreFunction scoreFunction, bool isNegated = false,
@@ -55,9 +86,37 @@ public partial class IndexSearcher
     {
         return MultiTermMatchBuilder<NullScoreFunction, ContainsTermProvider>(field, containsTerm, default, isNegated, fieldId);
     }
+    
+    [MethodImpl(MethodImplOptions.AggressiveInlining)]
+    public MultiTermMatch ContainsQuery<TScoreFunction>(Slice field, Slice containsTerm, TScoreFunction scoreFunction, bool isNegated = false,
+        int fieldId = Constants.IndexSearcher.NonAnalyzer)
+        where TScoreFunction : IQueryScoreFunction
+    {
+        return MultiTermMatchBuilder<TScoreFunction, ContainsTermProvider>(field, containsTerm, scoreFunction, isNegated, fieldId);
+    }
+
+    [MethodImpl(MethodImplOptions.AggressiveInlining)]
+    public MultiTermMatch ContainsQuery(Slice field, Slice containsTerm, bool isNegated = false,
+        int fieldId = Constants.IndexSearcher.NonAnalyzer)
+    {
+        return MultiTermMatchBuilder<NullScoreFunction, ContainsTermProvider>(field, containsTerm, default, isNegated, fieldId);
+    }
 
     [MethodImpl(MethodImplOptions.AggressiveInlining)]
     public MultiTermMatch ExistsQuery(string field)
+    {
+        return ExistsQuery(field, default(NullScoreFunction));
+    }
+
+    [MethodImpl(MethodImplOptions.AggressiveInlining)]
+    public MultiTermMatch ExistsQuery<TScoreFunction>(Slice field, TScoreFunction scoreFunction)
+        where TScoreFunction : IQueryScoreFunction
+    {
+        return MultiTermMatchBuilder<TScoreFunction, ExistsTermProvider>(field, default, scoreFunction, false, Constants.IndexSearcher.NonAnalyzer);
+    }
+    
+    [MethodImpl(MethodImplOptions.AggressiveInlining)]
+    public MultiTermMatch ExistsQuery(Slice field)
     {
         return ExistsQuery(field, default(NullScoreFunction));
     }
@@ -262,36 +321,56 @@ public partial class IndexSearcher
                 this, new InTermProvider(this, field, notInTerms, fieldId), scoreFunction)));
     }
 
+
+    private MultiTermMatch MultiTermMatchBuilder<TScoreFunction, TTermProvider>(Slice fieldName, Slice term, TScoreFunction scoreFunction, bool isNegated, int fieldId)
+        where TScoreFunction : IQueryScoreFunction
+        where TTermProvider : ITermProvider
+    {
+        var fields = _transaction.ReadTree(Constants.IndexWriter.FieldsSlice);
+        var terms = fields?.CompactTreeFor(fieldName);
+        if (terms == null)
+            return MultiTermMatch.CreateEmpty(_transaction.Allocator);
+
+        return MultiTermMatchBuilderBase<TScoreFunction, TTermProvider>(fieldName, terms, term, scoreFunction, isNegated, fieldId);
+
+    }
+    
     private MultiTermMatch MultiTermMatchBuilder<TScoreFunction, TTermProvider>(string field, string term, TScoreFunction scoreFunction, bool isNegated, int fieldId)
         where TScoreFunction : IQueryScoreFunction
         where TTermProvider : ITermProvider
     {
         var fields = _transaction.ReadTree(Constants.IndexWriter.FieldsSlice);
+        using var _ = Slice.From(Allocator, field, ByteStringType.Immutable, out var fieldName);
+
         var terms = fields?.CompactTreeFor(field);
         if (terms == null)
-        {
-            // If either the term or the field does not exist the request will be empty. 
             return MultiTermMatch.CreateEmpty(_transaction.Allocator);
-        }
-
         var slicedTerm = EncodeAndApplyAnalyzer(term, fieldId);
+        
+        return MultiTermMatchBuilderBase<TScoreFunction, TTermProvider>(fieldName, terms, slicedTerm, scoreFunction, isNegated, fieldId);
+    }
+
+    private MultiTermMatch MultiTermMatchBuilderBase<TScoreFunction, TTermProvider>(Slice fieldName, CompactTree terms, Slice slicedTerm, TScoreFunction scoreFunction, bool isNegated, int fieldId)
+        where TScoreFunction : IQueryScoreFunction
+        where TTermProvider : ITermProvider
+    {
         if (typeof(TTermProvider) == typeof(StartWithTermProvider))
         {
             return (isNegated, scoreFunction) switch
             {
                 (false, NullScoreFunction) => MultiTermMatch.Create(new MultiTermMatch<StartWithTermProvider>(_transaction.Allocator,
-                    new StartWithTermProvider(this, _transaction.Allocator, terms, field, fieldId, slicedTerm))),
+                    new StartWithTermProvider(this, _transaction.Allocator, terms, fieldName, fieldId, slicedTerm))),
 
                 (true, NullScoreFunction) => MultiTermMatch.Create(new MultiTermMatch<NotStartWithTermProvider>(_transaction.Allocator,
-                    new NotStartWithTermProvider(this, _transaction.Allocator, terms, field, fieldId, slicedTerm))),
+                    new NotStartWithTermProvider(this, _transaction.Allocator, terms, fieldName, fieldId, slicedTerm))),
 
                 (false, _) => MultiTermMatch.Create(
                     MultiTermBoostingMatch<StartWithTermProvider>.Create(
-                        this, new StartWithTermProvider(this, _transaction.Allocator, terms, field, fieldId, slicedTerm), scoreFunction)),
+                        this, new StartWithTermProvider(this, _transaction.Allocator, terms, fieldName, fieldId, slicedTerm), scoreFunction)),
 
                 (true, _) => MultiTermMatch.Create(
                     MultiTermBoostingMatch<NotStartWithTermProvider>.Create(
-                        this, new NotStartWithTermProvider(this, _transaction.Allocator, terms, field, fieldId, slicedTerm), scoreFunction))
+                        this, new NotStartWithTermProvider(this, _transaction.Allocator, terms, fieldName, fieldId, slicedTerm), scoreFunction))
             };
         }
 
@@ -300,18 +379,18 @@ public partial class IndexSearcher
             return (isNegated, scoreFunction) switch
             {
                 (false, NullScoreFunction) => MultiTermMatch.Create(new MultiTermMatch<EndsWithTermProvider>(_transaction.Allocator,
-                    new EndsWithTermProvider(this, _transaction.Allocator, terms, field, fieldId, slicedTerm))),
+                    new EndsWithTermProvider(this, _transaction.Allocator, terms, fieldName, fieldId, slicedTerm))),
 
                 (true, NullScoreFunction) => MultiTermMatch.Create(new MultiTermMatch<NotEndsWithTermProvider>(_transaction.Allocator,
-                    new NotEndsWithTermProvider(this, _transaction.Allocator, terms, field, fieldId, slicedTerm))),
+                    new NotEndsWithTermProvider(this, _transaction.Allocator, terms, fieldName, fieldId, slicedTerm))),
 
                 (false, _) => MultiTermMatch.Create(
                     MultiTermBoostingMatch<EndsWithTermProvider>.Create(
-                        this, new EndsWithTermProvider(this, _transaction.Allocator, terms, field, fieldId, slicedTerm), scoreFunction)),
+                        this, new EndsWithTermProvider(this, _transaction.Allocator, terms, fieldName, fieldId, slicedTerm), scoreFunction)),
 
                 (true, _) => MultiTermMatch.Create(
                     MultiTermBoostingMatch<NotEndsWithTermProvider>.Create(
-                        this, new NotEndsWithTermProvider(this, _transaction.Allocator, terms, field, fieldId, slicedTerm), scoreFunction))
+                        this, new NotEndsWithTermProvider(this, _transaction.Allocator, terms, fieldName, fieldId, slicedTerm), scoreFunction))
             };
         }
 
@@ -320,18 +399,18 @@ public partial class IndexSearcher
             return (isNegated, scoreFunction) switch
             {
                 (false, NullScoreFunction) => MultiTermMatch.Create(new MultiTermMatch<ContainsTermProvider>(_transaction.Allocator,
-                    new ContainsTermProvider(this, _transaction.Allocator, terms, field, fieldId, slicedTerm))),
+                    new ContainsTermProvider(this, _transaction.Allocator, terms, fieldName, fieldId, slicedTerm))),
 
                 (true, NullScoreFunction) => MultiTermMatch.Create(new MultiTermMatch<NotContainsTermProvider>(_transaction.Allocator,
-                    new NotContainsTermProvider(this, _transaction.Allocator, terms, field, fieldId, slicedTerm))),
+                    new NotContainsTermProvider(this, _transaction.Allocator, terms, fieldName, fieldId, slicedTerm))),
 
                 (false, _) => MultiTermMatch.Create(
                     MultiTermBoostingMatch<ContainsTermProvider>.Create(
-                        this, new ContainsTermProvider(this, _transaction.Allocator, terms, field, fieldId, slicedTerm), scoreFunction)),
+                        this, new ContainsTermProvider(this, _transaction.Allocator, terms, fieldName, fieldId, slicedTerm), scoreFunction)),
 
                 (true, _) => MultiTermMatch.Create(
                     MultiTermBoostingMatch<NotContainsTermProvider>.Create(
-                        this, new NotContainsTermProvider(this, _transaction.Allocator, terms, field, fieldId, slicedTerm), scoreFunction))
+                        this, new NotContainsTermProvider(this, _transaction.Allocator, terms, fieldName, fieldId, slicedTerm), scoreFunction))
             };
         }
 
@@ -339,11 +418,11 @@ public partial class IndexSearcher
         {
             if (typeof(TScoreFunction) == typeof(NullScoreFunction))
                 return MultiTermMatch.Create(new MultiTermMatch<ExistsTermProvider>(_transaction.Allocator,
-                    new ExistsTermProvider(this, _transaction.Allocator, terms, field)));
+                    new ExistsTermProvider(this, _transaction.Allocator, terms, fieldName)));
 
             return MultiTermMatch.Create(
                 MultiTermBoostingMatch<ExistsTermProvider>.Create(
-                    this, new ExistsTermProvider(this, _transaction.Allocator, terms, field), scoreFunction));
+                    this, new ExistsTermProvider(this, _transaction.Allocator, terms, fieldName), scoreFunction));
         }
 
         return MultiTermMatch.CreateEmpty(_transaction.Allocator);

--- a/src/Corax/IndexSearcher/IndexSearcher.Search.cs
+++ b/src/Corax/IndexSearcher/IndexSearcher.Search.cs
@@ -57,6 +57,7 @@ public partial class IndexSearcher
 
 
         wildcardAnalyzer.Execute(term, ref encodedWildcard, ref tokensWildcard);
+        using var _ = Slice.From(Allocator, field, ByteStringType.Immutable, out var fieldName);
         IQueryMatch match = null;
         foreach (var tokenWildcard in tokensWildcard)
         {
@@ -112,7 +113,7 @@ public partial class IndexSearcher
                 case Constants.Search.SearchMatchOptions.TermMatch:
                     IQueryMatch exactMatch = isNegated
                         ? UnaryQuery(AllEntries(), analyzerId, encodedString, UnaryMatchOperation.NotEquals)
-                        : TermQuery(field, encodedString.ToString());
+                        : TermQuery(field, encodedString);
 
                     if (match is null)
                     {
@@ -127,35 +128,35 @@ public partial class IndexSearcher
                 case Constants.Search.SearchMatchOptions.StartsWith:
                     if (match is null)
                     {
-                        match = StartWithQuery(field, encodedString.ToString(), isNegated);
+                        match = StartWithQuery(fieldName, encodedString, isNegated);
                         return;
                     }
 
                     match = @operator is Constants.Search.Operator.Or
-                        ? Or(match, StartWithQuery(field, encodedString.ToString(), isNegated))
-                        : And(match, StartWithQuery(field, encodedString.ToString(), isNegated));
+                        ? Or(match, StartWithQuery(fieldName, encodedString, isNegated))
+                        : And(match, StartWithQuery(fieldName, encodedString, isNegated));
                     break;
                 case Constants.Search.SearchMatchOptions.EndsWith:
                     if (match is null)
                     {
-                        match = EndsWithQuery(field, encodedString.ToString(), isNegated);
+                        match = EndsWithQuery(fieldName, encodedString, isNegated);
                         return;
                     }
 
                     match = @operator is Constants.Search.Operator.Or
-                        ? Or(match, EndsWithQuery(field, encodedString.ToString(), isNegated))
-                        : And(match, EndsWithQuery(field, encodedString.ToString(), isNegated));
+                        ? Or(match, EndsWithQuery(fieldName, encodedString, isNegated))
+                        : And(match, EndsWithQuery(fieldName, encodedString, isNegated));
                     break;
                 case Constants.Search.SearchMatchOptions.Contains:
                     if (match is null)
                     {
-                        match = ContainsQuery(field, encodedString.ToString(), isNegated);
+                        match = ContainsQuery(fieldName, encodedString, isNegated);
                         return;
                     }
 
                     match = @operator is Constants.Search.Operator.Or
-                        ? Or(match, ContainsQuery(field, encodedString.ToString(), isNegated))
-                        : And(match, ContainsQuery(field, encodedString.ToString(), isNegated));
+                        ? Or(match, ContainsQuery(fieldName, encodedString, isNegated))
+                        : And(match, ContainsQuery(fieldName, encodedString, isNegated));
                     break;
                 default:
                     throw new InvalidExpressionException("Unknown flag inside Search match.");

--- a/src/Corax/IndexSearcher/IndexSearcher.Search.cs
+++ b/src/Corax/IndexSearcher/IndexSearcher.Search.cs
@@ -83,19 +83,22 @@ public partial class IndexSearcher
                 if (mode != Constants.Search.SearchMatchOptions.TermMatch)
                 {
                     if (mode is Constants.Search.SearchMatchOptions.Contains && termForTree.Length <= 2)
-                        throw new InvalidDataException("");
+                        throw new InvalidDataException(
+                            "You are looking for an empty term. Search doesn't support it. If you want to find empty strings, you have to write an equal inside WHERE clause.");
                     else if (termForTree.Length == 1)
-                        throw new InvalidDataException();
+                        throw new InvalidDataException("You are looking for all matches. To retrieve all matches you have to write `true` in WHERE clause.");
                 }
-                
+
                 termForTree = mode switch
                 {
                     Constants.Search.SearchMatchOptions.StartsWith => termForTree.Slice(1),
                     Constants.Search.SearchMatchOptions.EndsWith => termForTree.Slice(0, termForTree.Length - 1),
-                    Constants.Search.SearchMatchOptions.Contains => termForTree.Slice(1, termForTree.Length - 2)
+                    Constants.Search.SearchMatchOptions.Contains => termForTree.Slice(1, termForTree.Length - 2),
+                    Constants.Search.SearchMatchOptions.TermMatch => termForTree,
+                    _ => throw new InvalidExpressionException("Unknown flag inside Search match.")
                 };
             }
-            
+
             Slice.From(_transaction.Allocator, termForTree, ByteStringType.Immutable, out var encodedString);
             BuildExpression(mode, encodedString);
         }

--- a/src/Corax/IndexSearcher/IndexSearcher.cs
+++ b/src/Corax/IndexSearcher/IndexSearcher.cs
@@ -157,8 +157,9 @@ public sealed unsafe partial class IndexSearcher : IDisposable
     
     public bool TryGetTermsOfField(string field, out ExistsTermProvider existsTermProvider)
     {
+        using var _ = Slice.From(Allocator, field, ByteStringType.Immutable, out var fieldName);
         var fields = _transaction.ReadTree(Constants.IndexWriter.FieldsSlice);
-        var terms = fields?.CompactTreeFor(field);
+        var terms = fields?.CompactTreeFor(fieldName);
         
         if (terms == null)
         {
@@ -166,7 +167,7 @@ public sealed unsafe partial class IndexSearcher : IDisposable
             return false;
         }
         
-        existsTermProvider = new ExistsTermProvider(this, _transaction.Allocator, terms, field);
+        existsTermProvider = new ExistsTermProvider(this, _transaction.Allocator, terms, fieldName);
         return true;
     }
 

--- a/src/Corax/Queries/TermProviders/TermProvider.Contains.cs
+++ b/src/Corax/Queries/TermProviders/TermProvider.Contains.cs
@@ -10,15 +10,15 @@ namespace Corax.Queries
     {
         private readonly CompactTree _tree;
         private readonly IndexSearcher _searcher;
-        private readonly string _field;
+        private readonly Slice _fieldName;
         private readonly Slice _term;
 
         private CompactTree.Iterator _iterator;
-        public ContainsTermProvider(IndexSearcher searcher, ByteStringContext context, CompactTree tree, string field, int fieldId, Slice term)
+        public ContainsTermProvider(IndexSearcher searcher, ByteStringContext context, CompactTree tree, Slice fieldName, int fieldId, Slice term)
         {
             _tree = tree;
             _searcher = searcher;
-            _field = field;
+            _fieldName = fieldName;
             _iterator = tree.Iterate();
             _iterator.Reset();
             _term = term;
@@ -38,7 +38,7 @@ namespace Corax.Queries
                 if (!termSlice.Contains(contains))
                     continue;
 
-                term = _searcher.TermQuery(_field, termSlice);
+                term = _searcher.TermQuery(_tree, termSlice);
                 return true;
             }
 
@@ -51,7 +51,7 @@ namespace Corax.Queries
             return new QueryInspectionNode($"{nameof(ContainsTermProvider)}",
                             parameters: new Dictionary<string, string>()
                             {
-                                { "Field", _field },
+                                { "Field", _fieldName.ToString() },
                                 { "Term", _term.ToString()}
                             });
         }

--- a/src/Corax/Queries/TermProviders/TermProvider.EndsWith.cs
+++ b/src/Corax/Queries/TermProviders/TermProvider.EndsWith.cs
@@ -9,15 +9,15 @@ namespace Corax.Queries
     {
         private readonly CompactTree _tree;
         private readonly IndexSearcher _searcher;
-        private readonly string _field;
+        private readonly Slice _fieldName;
         private readonly Slice _endsWith;
-
+        
         private CompactTree.Iterator _iterator;
-        public EndsWithTermProvider(IndexSearcher searcher, ByteStringContext context, CompactTree tree, string field, int fieldId, Slice endsWith)
+        public EndsWithTermProvider(IndexSearcher searcher, ByteStringContext context, CompactTree tree, Slice fieldName, int fieldId, Slice endsWith)
         {
             _tree = tree;
             _searcher = searcher;
-            _field = field;
+            _fieldName = fieldName;
             _iterator = tree.Iterate();
             _iterator.Reset();
             _endsWith = endsWith;
@@ -37,7 +37,7 @@ namespace Corax.Queries
                 if (termSlice.EndsWith(suffix) == false)
                     continue;
 
-                term = _searcher.TermQuery(_field, termSlice);
+                term = _searcher.TermQuery(_tree, termSlice);
                 return true;
             }
 
@@ -50,7 +50,7 @@ namespace Corax.Queries
             return new QueryInspectionNode($"{nameof(EndsWithTermProvider)}",
                 parameters: new Dictionary<string, string>()
                 {
-                    { "Field", _field },
+                    { "Field", _fieldName.ToString() },
                     { "Suffix", _endsWith.ToString()}
                 });
         }

--- a/src/Corax/Queries/TermProviders/TermProvider.Exists.cs
+++ b/src/Corax/Queries/TermProviders/TermProvider.Exists.cs
@@ -11,14 +11,14 @@ namespace Corax.Queries
     {
         private readonly CompactTree _tree;
         private readonly IndexSearcher _searcher;
-        private readonly string _field;
+        private readonly Slice _fieldName;
         private CompactTree.Iterator _iterator;
 
-        public ExistsTermProvider(IndexSearcher searcher, ByteStringContext context, CompactTree tree, string field)
+        public ExistsTermProvider(IndexSearcher searcher, ByteStringContext context, CompactTree tree, Slice fieldName)
         {
             _tree = tree;
             _searcher = searcher;
-            _field = field;
+            _fieldName = fieldName;
             _iterator = tree.Iterate();
             _iterator.Reset();
         }
@@ -33,7 +33,7 @@ namespace Corax.Queries
         {
             while (_iterator.MoveNext(out Slice termSlice, out var _))
             {
-                term = _searcher.TermQuery(_field, termSlice);
+                term = _searcher.TermQuery(_tree, termSlice);
                 return true;
             }
 
@@ -66,7 +66,7 @@ namespace Corax.Queries
             return new QueryInspectionNode($"{nameof(ExistsTermProvider)}",
                             parameters: new Dictionary<string, string>()
                             {
-                                { "Field", _field }
+                                { "Field", _fieldName.ToString() }
                             });
         }
     }

--- a/src/Corax/Queries/TermProviders/TermProvider.NotContains.cs
+++ b/src/Corax/Queries/TermProviders/TermProvider.NotContains.cs
@@ -10,16 +10,16 @@ namespace Corax.Queries
     {
         private readonly CompactTree _tree;
         private readonly IndexSearcher _searcher;
-        private readonly string _field;
+        private readonly Slice _fieldName;
         private readonly Slice _term;
 
         private CompactTree.Iterator _iterator;
 
-        public NotContainsTermProvider(IndexSearcher searcher, ByteStringContext context, CompactTree tree, string field, int fieldId, Slice term)
+        public NotContainsTermProvider(IndexSearcher searcher, ByteStringContext context, CompactTree tree, Slice fieldName, int fieldId, Slice term)
         {
             _tree = tree;
             _searcher = searcher;
-            _field = field;
+            _fieldName = fieldName;
             _iterator = tree.Iterate();
             _iterator.Reset();
             _term = term;
@@ -39,7 +39,7 @@ namespace Corax.Queries
                 if (termSlice.Contains(contains))
                     continue;
 
-                term = _searcher.TermQuery(_field, termSlice);
+                term = _searcher.TermQuery(_tree, termSlice);
                 return true;
             }
 
@@ -52,7 +52,7 @@ namespace Corax.Queries
             return new QueryInspectionNode($"{nameof(NotContainsTermProvider)}",
                             parameters: new Dictionary<string, string>()
                             {
-                                { "Field", _field },
+                                { "Field", _fieldName.ToString() },
                                 { "Term", _term.ToString()}
                             });
         }

--- a/src/Corax/Queries/TermProviders/TermProvider.NotEndsWith.cs
+++ b/src/Corax/Queries/TermProviders/TermProvider.NotEndsWith.cs
@@ -15,16 +15,18 @@ namespace Corax.Queries
     {
         private readonly IndexSearcher _searcher;
         private readonly CompactTree.Iterator _iterator;
-        private readonly string _field;
+        private readonly Slice _fieldName;
         private readonly Slice _endsWith;
+        private readonly CompactTree _tree;
 
-        public NotEndsWithTermProvider(IndexSearcher searcher, ByteStringContext context, CompactTree tree, string field, int fieldId, Slice endsWith)
+        public NotEndsWithTermProvider(IndexSearcher searcher, ByteStringContext context, CompactTree tree, Slice fieldName, int fieldId, Slice endsWith)
         {
             _searcher = searcher;
-            _field = field;
+            _fieldName = fieldName;
             _iterator = tree.Iterate();
             _iterator.Reset();
             _endsWith = endsWith;
+            _tree = tree;
         }
 
         public void Reset()
@@ -41,7 +43,7 @@ namespace Corax.Queries
                 if (termSlice.EndsWith(_endsWith))
                     continue;
 
-                term = _searcher.TermQuery(_field, termSlice);
+                term = _searcher.TermQuery(_tree, termSlice);
                 return true;
             }
 
@@ -54,7 +56,7 @@ namespace Corax.Queries
             return new QueryInspectionNode($"{nameof(NotEndsWithTermProvider)}",
                 parameters: new Dictionary<string, string>()
                 {
-                    { "Field", _field },
+                    { "Field", _fieldName.ToString() },
                     { "Terms", _endsWith.ToString()}
                 });
         }

--- a/src/Corax/Queries/TermProviders/TermProvider.NotStartsWith.cs
+++ b/src/Corax/Queries/TermProviders/TermProvider.NotStartsWith.cs
@@ -1,9 +1,5 @@
-﻿using System;
-using System.Collections.Generic;
+﻿using System.Collections.Generic;
 using System.Diagnostics;
-using System.Linq;
-using System.Text;
-using System.Threading.Tasks;
 using Sparrow.Server;
 using Voron;
 using Voron.Data.CompactTrees;
@@ -15,21 +11,22 @@ namespace Corax.Queries
     {
         private readonly IndexSearcher _searcher;
         private readonly CompactTree.Iterator _iterator;
-        private readonly string _field;
+        private readonly Slice _fieldName;
         private readonly Slice _startWith;
+        private readonly CompactTree _tree;
 
-        public NotStartWithTermProvider(IndexSearcher searcher, ByteStringContext context, CompactTree tree, string field, int fieldId, Slice startWith)
+        public NotStartWithTermProvider(IndexSearcher searcher, ByteStringContext context, CompactTree tree, Slice fieldName, int fieldId, Slice startWith)
         {
             _searcher = searcher;
-            _field = field;
+            _fieldName = fieldName;
             _iterator = tree.Iterate();
             _iterator.Reset();
             _startWith = startWith;
+            _tree = tree;
         }
 
         public void Reset()
         {
-
             _iterator.Reset();
         }
 
@@ -41,7 +38,7 @@ namespace Corax.Queries
                 if (termSlice.StartWith(_startWith))
                     continue;
 
-                term = _searcher.TermQuery(_field, termSlice);
+                term = _searcher.TermQuery(_tree, termSlice);
                 return true;
             }
             
@@ -54,7 +51,7 @@ namespace Corax.Queries
             return new QueryInspectionNode($"{nameof(NotStartWithTermProvider)}",
                             parameters: new Dictionary<string, string>()
                             {
-                                { "Field", _field },
+                                { "Field", _fieldName.ToString() },
                                 { "Terms", _startWith.ToString()}
                             });
         }

--- a/src/Corax/Queries/TermProviders/TermProvider.StartWith.cs
+++ b/src/Corax/Queries/TermProviders/TermProvider.StartWith.cs
@@ -16,16 +16,17 @@ namespace Corax.Queries
     {
         private readonly IndexSearcher _searcher;
         private readonly CompactTree.Iterator _iterator;
-        private readonly string _field;
+        private readonly Slice _fieldName;
         private readonly Slice _startWith;
-
-        public StartWithTermProvider(IndexSearcher searcher, ByteStringContext context, CompactTree tree, string field, int fieldId, Slice startWith)
+        private readonly CompactTree _tree;
+        public StartWithTermProvider(IndexSearcher searcher, ByteStringContext context, CompactTree tree, Slice fieldName, int fieldId, Slice startWith)
         {
             _searcher = searcher;
-            _field = field;
+            _fieldName = fieldName;
             _iterator = tree.Iterate();
             _startWith = startWith;
-
+            _tree = tree;
+            
             _iterator.Seek(_startWith);
         }
 
@@ -42,7 +43,7 @@ namespace Corax.Queries
                 return false;
             }
 
-            term = _searcher.TermQuery(_field, termSlice);
+            term = _searcher.TermQuery(_tree, termSlice);
             return true;
         }
 
@@ -51,7 +52,7 @@ namespace Corax.Queries
             return new QueryInspectionNode($"{nameof(StartWithTermProvider)}",
                             parameters: new Dictionary<string, string>()
                             {
-                                { "Field", _field },
+                                { "Field", _fieldName.ToString() },
                                 { "Terms", _startWith.ToString()}
                             });
         }

--- a/src/Raven.Server/Documents/Indexes/Persistence/Corax/CoraxQueryBuilder.cs
+++ b/src/Raven.Server/Documents/Indexes/Persistence/Corax/CoraxQueryBuilder.cs
@@ -637,6 +637,12 @@ public static class CoraxQueryBuilder
             else
                 QueryBuilderHelper.ThrowInvalidOperatorInSearch(metadata, parameters, fieldExpression);
         }
+
+
+        if (indexMapping.TryGetByFieldId(fieldId, out var binding) && binding.Analyzer is not LuceneAnalyzerAdapter )
+        {
+            return indexSearcher.SearchQuery(fieldName, valueAsString, scoreFunction, @operator, fieldId, isNegated, true);
+        }
         
         return indexSearcher.SearchQuery(fieldName, valueAsString, scoreFunction, @operator, fieldId, isNegated);
     }

--- a/test/SlowTests/Issues/RavenDB-15739.cs
+++ b/test/SlowTests/Issues/RavenDB-15739.cs
@@ -16,7 +16,7 @@ namespace SlowTests.Issues
         }
 
         [RavenTheory(RavenTestCategory.Querying)]
-        [RavenData(SearchEngineMode = RavenSearchEngineMode.Lucene)]
+        [RavenData(SearchEngineMode = RavenSearchEngineMode.All)]
         public async Task Search_On_Id(Options options)
         {
             using (var store = GetDocumentStore(options))


### PR DESCRIPTION
### Issue link

https://issues.hibernatingrhinos.com/issue/RavenDB-18497

### Additional description

RavenStandard analyzer is cutting wildcards automatically, so in another case, we have to cut them manually.

### Type of change

- Bug fix

### How risky is the change?

- Low 


### Backward compatibility

- Not relevant

### Is it platform specific issue?

- No

### Documentation update

- No documentation update is needed 

### Testing 

- Tests have been added that prove the fix is effective or that the feature works


### Is there any existing behavior change of other features due to this change?

- No

### UI work

- No UI work is needed
