### PR TITLE
RavenDB-18013: fix database deletion while deletion is in progress

### DIFF
--- a/src/Raven.Server/Documents/ResourceCache.cs
+++ b/src/Raven.Server/Documents/ResourceCache.cs
@@ -210,7 +210,7 @@ namespace Raven.Server.Documents
                 });
             }
 
-            if (current.IsFaulted && current.Exception?.InnerException?.Data.Contains(DatabasesLandlord.DoNotRemove) == false)
+            if (current.IsFaulted && DatabasesLandlord.IsLockedDatabase(current.Exception) == false)
             {
                 // some real exception occurred, but we still want to remove / unload the faulty database
                 resource = default; 

--- a/src/Raven.Server/Documents/ResourceCache.cs
+++ b/src/Raven.Server/Documents/ResourceCache.cs
@@ -210,7 +210,7 @@ namespace Raven.Server.Documents
                 });
             }
 
-            if (current.IsFaulted && current.Exception?.Data.Contains(DatabasesLandlord.DoNotRemove) == false)
+            if (current.IsFaulted && current.Exception?.InnerException?.Data.Contains(DatabasesLandlord.DoNotRemove) == false)
             {
                 // some real exception occurred, but we still want to remove / unload the faulty database
                 resource = default; 

--- a/src/Raven.Server/ServerWide/Maintenance/ClusterMaintenanceWorker.cs
+++ b/src/Raven.Server/ServerWide/Maintenance/ClusterMaintenanceWorker.cs
@@ -202,8 +202,7 @@ namespace Raven.Server.ServerWide.Maintenance
 
                 if (dbTask.IsFaulted)
                 {
-                    var extractSingleInnerException = dbTask.Exception.ExtractSingleInnerException();
-                    if (Equals(extractSingleInnerException.Data[DatabasesLandlord.DoNotRemove], true))
+                    if (DatabasesLandlord.IsLockedDatabase(dbTask.Exception))
                     {
                         report.Status = DatabaseStatus.Unloaded;
                         result[dbName] = report;

--- a/test/RachisTests/RavenDB_18013.cs
+++ b/test/RachisTests/RavenDB_18013.cs
@@ -1,0 +1,98 @@
+﻿using System;
+using System.Diagnostics;
+using System.Linq;
+using System.Threading;
+using System.Threading.Tasks;
+using Raven.Client.ServerWide.Operations;
+using Tests.Infrastructure;
+using Xunit;
+using Xunit.Abstractions;
+
+namespace RachisTests;
+
+public class RavenDB_18013 : ClusterTestBase
+{
+    public RavenDB_18013(ITestOutputHelper output) : base(output)
+    {
+    }
+    private readonly TimeSpan _reasonableWaitTime = Debugger.IsAttached ? TimeSpan.FromMinutes(15) : TimeSpan.FromSeconds(60);
+    [Fact]
+    public async Task ShouldHandleDatabaseDeleteWhileItsBeingDeleted()
+    {
+        var cluster = await CreateRaftCluster(3, shouldRunInMemory: false);
+
+        var deleteDatabaseCommandMre = new ManualResetEvent(false);
+        var deleteDatabaseCommandHasWaiterMre = new ManualResetEvent(false);
+        var removeNodeFromDatabaseCommandMre = new ManualResetEvent(false);
+        var documentDatabaseDisposeMre = new ManualResetEvent(false);
+        var documentDatabaseDisposeHasWaiterMre = new ManualResetEvent(false);
+
+        using var store = GetDocumentStore(new Options
+        {
+            Server = cluster.Leader,
+            ReplicationFactor = 3,
+            ModifyDocumentStore = s => s.Conventions.ReadBalanceBehavior = Raven.Client.Http.ReadBalanceBehavior.RoundRobin,
+            RunInMemory = false,
+            DeleteDatabaseOnDispose = false
+        });
+
+        CountdownEvent cde = new CountdownEvent(2);
+        var c = 0;
+        var server = cluster.Nodes.First();
+        server.ServerStore.DatabasesLandlord.ForTestingPurposesOnly().DeleteDatabaseWhileItBeingDeleted = new ManualResetEvent(false);
+        server.ServerStore.DatabasesLandlord.ForTestingPurposesOnly().InsideHandleClusterDatabaseChanged += type =>
+        {
+            if (type == "DeleteDatabaseCommand")
+            {
+                deleteDatabaseCommandHasWaiterMre.Set();
+                deleteDatabaseCommandMre.WaitOne(_reasonableWaitTime);
+            }
+            else if (type == "RemoveNodeFromDatabaseCommand")
+            {
+                cde.Signal();
+                removeNodeFromDatabaseCommandMre.WaitOne(_reasonableWaitTime);
+                removeNodeFromDatabaseCommandMre.Reset();
+                if (Interlocked.Increment(ref c) == 1)
+                {
+                    return;
+                }
+                else
+                {
+                    removeNodeFromDatabaseCommandMre.WaitOne(_reasonableWaitTime);
+                }
+            }
+        };
+        var documentDatabase = await server.ServerStore.DatabasesLandlord.TryGetOrCreateResourceStore(store.Database);
+        var testingStuff = documentDatabase.ForTestingPurposesOnly();
+
+        using (testingStuff.CallDuringDocumentDatabaseInternalDispose(() =>
+               {
+                   documentDatabaseDisposeHasWaiterMre.Set();
+                   documentDatabaseDisposeMre.WaitOne(_reasonableWaitTime);
+               }))
+        {
+
+            var t = store.Maintenance.Server.SendAsync(new DeleteDatabasesOperation(store.Database, true));
+
+            // wait for DeleteDatabaseCommand
+            deleteDatabaseCommandHasWaiterMre.WaitOne(_reasonableWaitTime);
+            // wait for RemoveNodeFromDatabaseCommands
+            cde.Wait(_reasonableWaitTime);
+            // advance DeleteDatabaseCommand
+            deleteDatabaseCommandMre.Set();
+            // wait for the thread to reach dispose of document database
+            documentDatabaseDisposeHasWaiterMre.WaitOne(_reasonableWaitTime);
+            // advance one of RemoveNodeFromDatabaseCommands
+            removeNodeFromDatabaseCommandMre.Set();
+            // we should handle deletion while deletion is in progress
+            server.ServerStore.DatabasesLandlord.ForTestingPurposesOnly().DeleteDatabaseWhileItBeingDeleted.WaitOne(_reasonableWaitTime);
+
+            // advance the document database dispose & RemoveNodeFromDatabaseCommands
+            documentDatabaseDisposeMre.Set();
+            removeNodeFromDatabaseCommandMre.Set();
+
+            // finish delete
+            await t;
+        }
+    }
+}


### PR DESCRIPTION
### Issue link

https://issues.hibernatingrhinos.com/issue/RavenDB-18013

### Additional description

Attempt to delete a database while deletion is in progress wasn't handled properly and caused attempt to delete the database folder, even if it still was being disposed.

### Type of change

- Bug fix


### How risky is the change?

- Low 


### Backward compatibility


- Not relevant

### Is it platform specific issue?


- No

### Documentation update

- No documentation update is needed 

### Testing 

- Tests have been added that prove the fix is effective or that the feature works
 - Internal classes added to the test class (e.g. entity or index definition classes) have the lowest possible access modifier (preferable `private`) 
- It has been verified by manual testing

### Is there any existing behavior change of other features due to this change?


- No

### UI work

- No UI work is needed
