### PR TITLE
RavenDB-17671 marked Graph API methods in Client API as obsolete

### DIFF
--- a/src/Raven.Client/Constants.cs
+++ b/src/Raven.Client/Constants.cs
@@ -453,5 +453,14 @@ namespace Raven.Client
                 public const string DestinationDocumentChangeVector = null;
             }
         }
+
+        internal class Obsolete
+        {
+            private Obsolete()
+            {
+            }
+
+            public const string GraphApi = "Graph API will be removed in next major version of the product.";
+        }
     }
 }

--- a/src/Raven.Client/Documents/Session/AsyncDocumentQuery.cs
+++ b/src/Raven.Client/Documents/Session/AsyncDocumentQuery.cs
@@ -24,7 +24,12 @@ namespace Raven.Client.Documents.Session
     /// A query against a Raven index
     /// </summary>
     public partial class AsyncDocumentQuery<T> : AbstractDocumentQuery<T, AsyncDocumentQuery<T>>, IAbstractDocumentQueryImpl<T>,
-        IAsyncRawDocumentQuery<T>, IAsyncGraphQuery<T>, IDocumentQueryGenerator, IAsyncDocumentQuery<T>
+        IAsyncRawDocumentQuery<T>,
+#pragma warning disable CS0618
+        IAsyncGraphQuery<T>,
+#pragma warning restore CS0618
+        IDocumentQueryGenerator,
+        IAsyncDocumentQuery<T>
     {
         /// <summary>
         /// Initializes a new instance of the <see cref="AsyncDocumentQuery{T}"/> class.
@@ -58,6 +63,7 @@ namespace Raven.Client.Documents.Session
             }
         }
 
+#pragma warning disable CS0618
         IAsyncGraphQuery<T> IQueryBase<T, IAsyncGraphQuery<T>>.Statistics(out QueryStatistics stats)
         {
             Statistics(out stats);
@@ -87,6 +93,7 @@ namespace Raven.Client.Documents.Session
             AddParameter(name, value);
             return this;
         }
+#pragma warning restore CS0618
 
         /// <inheritdoc />
         IAsyncDocumentQuery<T> IQueryBase<T, IAsyncDocumentQuery<T>>.Take(int count)
@@ -102,6 +109,7 @@ namespace Raven.Client.Documents.Session
             return this;
         }
 
+#pragma warning disable CS0618
         IAsyncGraphQuery<T> IQueryBase<T, IAsyncGraphQuery<T>>.Timings(out QueryTimings timings)
         {
             Timings(out timings);
@@ -113,6 +121,7 @@ namespace Raven.Client.Documents.Session
             Skip(count);
             return this;
         }
+#pragma warning restore CS0618
 
         /// <inheritdoc />
         IAsyncDocumentQuery<T> IQueryBase<T, IAsyncDocumentQuery<T>>.Skip(int count)
@@ -162,7 +171,7 @@ namespace Raven.Client.Documents.Session
             WhereEquals(GetMemberQueryPath(propertySelector.Body), value, exact);
             return this;
         }
-        
+
         /// <inheritdoc />
         IAsyncDocumentQuery<T> IFilterDocumentQueryBase<T, IAsyncDocumentQuery<T>>.WhereEquals<TValue>(Expression<Func<T, TValue>> propertySelector, MethodCall value, bool exact)
         {
@@ -386,7 +395,7 @@ namespace Raven.Client.Documents.Session
             AndAlso();
             return this;
         }
-        
+
         /// <inheritdoc />
         IAsyncDocumentQuery<T> IFilterDocumentQueryBase<T, IAsyncDocumentQuery<T>>.AndAlso(bool wrapPreviousQueryClauses)
         {
@@ -561,6 +570,7 @@ namespace Raven.Client.Documents.Session
             return this;
         }
 
+#pragma warning disable CS0618
         IAsyncGraphQuery<T> IQueryBase<T, IAsyncGraphQuery<T>>.AfterStreamExecuted(Action<BlittableJsonReaderObject> action)
         {
             AfterStreamExecuted(action);
@@ -572,6 +582,7 @@ namespace Raven.Client.Documents.Session
             BeforeQueryExecuted(beforeQueryExecuted);
             return this;
         }
+#pragma warning restore CS0618
 
         /// <inheritdoc />
         IAsyncDocumentQuery<T> IQueryBase<T, IAsyncDocumentQuery<T>>.BeforeQueryExecuted(Action<IndexQuery> beforeQueryExecuted)
@@ -727,11 +738,13 @@ namespace Raven.Client.Documents.Session
             return this;
         }
 
+#pragma warning disable CS0618
         IAsyncGraphQuery<T> IQueryBase<T, IAsyncGraphQuery<T>>.AfterQueryExecuted(Action<QueryResult> action)
         {
             AfterQueryExecuted(action);
             return this;
         }
+#pragma warning restore CS0618
 
         IAsyncDocumentQuery<T> IQueryBase<T, IAsyncDocumentQuery<T>>.AfterStreamExecuted(Action<BlittableJsonReaderObject> action)
         {
@@ -857,6 +870,7 @@ namespace Raven.Client.Documents.Session
             return this;
         }
 
+#pragma warning disable CS0618
         IAsyncGraphQuery<T> IQueryBase<T, IAsyncGraphQuery<T>>.NoCaching()
         {
             NoCaching();
@@ -868,6 +882,7 @@ namespace Raven.Client.Documents.Session
             NoTracking();
             return this;
         }
+#pragma warning restore CS0618
 
         /// <inheritdoc />
         IAsyncDocumentQuery<T> IQueryBase<T, IAsyncDocumentQuery<T>>.NoTracking()
@@ -1197,6 +1212,7 @@ namespace Raven.Client.Documents.Session
             return CreateDocumentQueryInternal<TResult>();
         }
 
+#pragma warning disable CS0618
         public IAsyncGraphQuery<T> With<TOther>(string alias, string rawQuery)
         {
             return WithInternal(alias, (AsyncDocumentQuery<TOther>)AsyncSession.Advanced.AsyncRawQuery<TOther>(rawQuery));
@@ -1220,6 +1236,7 @@ namespace Raven.Client.Documents.Session
             var docQuery = (AsyncDocumentQuery<TOther>)queryFactory(new AsyncDocumentQueryBuilder(AsyncSession, $"w{WithTokens.Count}p"));
             return WithInternal(alias, docQuery);
         }
+#pragma warning restore CS0618
 
         private class AsyncDocumentQueryBuilder : IAsyncDocumentQueryBuilder
         {
@@ -1247,6 +1264,7 @@ namespace Raven.Client.Documents.Session
             }
         }
 
+#pragma warning disable CS0618
         private IAsyncGraphQuery<T> WithInternal<TOther>(string alias, AsyncDocumentQuery<TOther> docQuery)
         {
             if (docQuery.SelectTokens?.Count > 0)
@@ -1272,5 +1290,6 @@ namespace Raven.Client.Documents.Session
 
             return this;
         }
+#pragma warning restore CS0618
     }
 }

--- a/src/Raven.Client/Documents/Session/AsyncDocumentSession.cs
+++ b/src/Raven.Client/Documents/Session/AsyncDocumentSession.cs
@@ -68,12 +68,14 @@ namespace Raven.Client.Documents.Session
             }
         }
 
+#pragma warning disable CS0618
         public IAsyncGraphQuery<T> AsyncGraphQuery<T>(string query)
         {
             var documentQuery = new AsyncDocumentQuery<T>(this, null, null, false);
             documentQuery.GraphQuery(query);
             return documentQuery;
         }
+#pragma warning restore CS0618
 
         /// <summary>
         /// Get the accessor for advanced operations

--- a/src/Raven.Client/Documents/Session/DocumentQuery.cs
+++ b/src/Raven.Client/Documents/Session/DocumentQuery.cs
@@ -21,7 +21,14 @@ namespace Raven.Client.Documents.Session
     /// <summary>
     /// A query against a Raven index
     /// </summary>
-    public partial class DocumentQuery<T> : AbstractDocumentQuery<T, DocumentQuery<T>>, IDocumentQuery<T>, IRawDocumentQuery<T>, IGraphQuery<T>, IDocumentQueryGenerator, IAbstractDocumentQueryImpl<T>
+    public partial class DocumentQuery<T> : AbstractDocumentQuery<T, DocumentQuery<T>>,
+        IDocumentQuery<T>,
+        IRawDocumentQuery<T>,
+#pragma warning disable CS0618
+        IGraphQuery<T>,
+#pragma warning restore CS0618
+        IDocumentQueryGenerator,
+        IAbstractDocumentQueryImpl<T>
     {
         /// <summary>
         /// Initializes a new instance of the <see cref="DocumentQuery{T}"/> class.
@@ -122,6 +129,7 @@ namespace Raven.Client.Documents.Session
             return CreateDocumentQueryInternal<TProjection>(queryData);
         }
 
+#pragma warning disable CS0618
         IGraphQuery<T> IQueryBase<T, IGraphQuery<T>>.UsingDefaultOperator(QueryOperator queryOperator)
         {
             UsingDefaultOperator(queryOperator);
@@ -139,6 +147,7 @@ namespace Raven.Client.Documents.Session
             AddParameter(name, value);
             return this;
         }
+#pragma warning restore CS0618
 
         /// <inheritdoc />
         IDocumentQuery<T> IQueryBase<T, IDocumentQuery<T>>.WaitForNonStaleResults(TimeSpan? waitTimeout)
@@ -197,6 +206,7 @@ namespace Raven.Client.Documents.Session
             return this;
         }
 
+#pragma warning disable CS0618
         IGraphQuery<T> IQueryBase<T, IGraphQuery<T>>.AfterStreamExecuted(Action<BlittableJsonReaderObject> action)
         {
             AfterStreamExecuted(action);
@@ -208,6 +218,7 @@ namespace Raven.Client.Documents.Session
             BeforeQueryExecuted(beforeQueryExecuted);
             return this;
         }
+#pragma warning restore CS0618
 
         IRawDocumentQuery<T> IQueryBase<T, IRawDocumentQuery<T>>.AfterQueryExecuted(Action<QueryResult> action)
         {
@@ -215,11 +226,13 @@ namespace Raven.Client.Documents.Session
             return this;
         }
 
+#pragma warning disable CS0618
         IGraphQuery<T> IQueryBase<T, IGraphQuery<T>>.AfterQueryExecuted(Action<QueryResult> action)
         {
             AfterQueryExecuted(action);
             return this;
         }
+#pragma warning restore CS0618
 
         IDocumentQuery<T> IQueryBase<T, IDocumentQuery<T>>.AfterStreamExecuted(Action<BlittableJsonReaderObject> action)
         {
@@ -316,6 +329,7 @@ namespace Raven.Client.Documents.Session
             return this;
         }
 
+#pragma warning disable CS0618
         IGraphQuery<T> IQueryBase<T, IGraphQuery<T>>.Skip(int count)
         {
             Skip(count);
@@ -333,6 +347,7 @@ namespace Raven.Client.Documents.Session
             Take(count);
             return this;
         }
+#pragma warning restore CS0618
 
         /// <inheritdoc />
         IDocumentQuery<T> IQueryBase<T, IDocumentQuery<T>>.Statistics(out QueryStatistics stats)
@@ -362,6 +377,7 @@ namespace Raven.Client.Documents.Session
             return this;
         }
 
+#pragma warning disable CS0618
         IGraphQuery<T> IQueryBase<T, IGraphQuery<T>>.NoCaching()
         {
             NoCaching();
@@ -379,6 +395,7 @@ namespace Raven.Client.Documents.Session
             Timings(out timings);
             return this;
         }
+#pragma warning restore CS0618
 
         /// <inheritdoc />
         IDocumentQuery<T> IQueryBase<T, IDocumentQuery<T>>.NoTracking()
@@ -732,14 +749,14 @@ namespace Raven.Client.Documents.Session
             WhereRegex(fieldName, pattern);
             return this;
         }
-        
+
         /// <inheritdoc />
         IDocumentQuery<T> IFilterDocumentQueryBase<T, IDocumentQuery<T>>.AndAlso()
         {
             AndAlso();
             return this;
         }
-        
+
         /// <inheritdoc />
         IDocumentQuery<T> IFilterDocumentQueryBase<T, IDocumentQuery<T>>.AndAlso(bool wrapPreviousQueryClauses)
         {
@@ -927,6 +944,7 @@ namespace Raven.Client.Documents.Session
             return this;
         }
 
+#pragma warning disable CS0618
         public IGraphQuery<T> WithEdges(string alias, string edgeSelector, string query)
         {
             WithTokens.AddLast(new WithEdgesToken(alias, edgeSelector, query));
@@ -950,6 +968,7 @@ namespace Raven.Client.Documents.Session
             var docQuery = (DocumentQuery<TOther>)queryFactory(new DocumentQueryBuilder(Session, $"w{WithTokens.Count}p"));
             return WithInternal(alias, docQuery);
         }
+#pragma warning restore CS0618
 
         private class DocumentQueryBuilder : IDocumentQueryBuilder
         {
@@ -977,6 +996,7 @@ namespace Raven.Client.Documents.Session
             }
         }
 
+#pragma warning disable CS0618
         private IGraphQuery<T> WithInternal<TOther>(string alias, DocumentQuery<TOther> docQuery)
         {
             if (docQuery.SelectTokens?.Count > 0)
@@ -1002,6 +1022,7 @@ namespace Raven.Client.Documents.Session
 
             return this;
         }
+#pragma warning restore CS0618
 
         /// <inheritdoc />
         T IDocumentQueryBase<T>.First()
@@ -1177,7 +1198,7 @@ namespace Raven.Client.Documents.Session
                 WhereTokens = new LinkedList<QueryToken>(WhereTokens),
                 OrderByTokens = new LinkedList<QueryToken>(OrderByTokens),
                 GroupByTokens = new LinkedList<QueryToken>(GroupByTokens),
-                FilterTokens =  new LinkedList<QueryToken>(FilterTokens),
+                FilterTokens = new LinkedList<QueryToken>(FilterTokens),
                 QueryParameters = new Parameters(QueryParameters),
                 FilterModeStack = new Stack<bool>(FilterModeStack),
                 Start = Start,

--- a/src/Raven.Client/Documents/Session/DocumentSession.GraphQuery.cs
+++ b/src/Raven.Client/Documents/Session/DocumentSession.GraphQuery.cs
@@ -2,11 +2,13 @@
 {
     public partial class DocumentSession
     {
+#pragma warning disable CS0618
         public IGraphQuery<T> GraphQuery<T>(string query)
         {
             var documentQuery = new DocumentQuery<T>(this, null, null, false);
             documentQuery.GraphQuery(query);
             return documentQuery;
         }
+#pragma warning restore CS0618
     }
 }

--- a/src/Raven.Client/Documents/Session/IAdvancedSessionOperations.cs
+++ b/src/Raven.Client/Documents/Session/IAdvancedSessionOperations.cs
@@ -4,6 +4,7 @@
 // </copyright>
 //-----------------------------------------------------------------------
 
+using System;
 using Raven.Client.Documents.Session.Operations.Lazy;
 
 namespace Raven.Client.Documents.Session
@@ -54,6 +55,7 @@ namespace Raven.Client.Documents.Session
         /// Issue a graph query based on the raw match query provided
         /// </summary>
         /// <typeparam name="T">The query result type</typeparam>
+        [Obsolete(Constants.Obsolete.GraphApi)]
         IGraphQuery<T> GraphQuery<T>(string query);
     }
 }

--- a/src/Raven.Client/Documents/Session/IAsyncAdvancedSessionOperations.cs
+++ b/src/Raven.Client/Documents/Session/IAsyncAdvancedSessionOperations.cs
@@ -4,6 +4,7 @@
 // </copyright>
 //-----------------------------------------------------------------------
 
+using System;
 using System.Threading;
 using System.Threading.Tasks;
 using Raven.Client.Documents.Session.Operations.Lazy;
@@ -57,6 +58,7 @@ namespace Raven.Client.Documents.Session
         /// Issue a graph query based on the raw match query provided
         /// </summary>
         /// <typeparam name="T">The query result type</typeparam>
+        [Obsolete(Constants.Obsolete.GraphApi)]
         IAsyncGraphQuery<T> AsyncGraphQuery<T>(string query);
     }
 }

--- a/src/Raven.Client/Documents/Session/IAsyncDocumentQuery.cs
+++ b/src/Raven.Client/Documents/Session/IAsyncDocumentQuery.cs
@@ -83,16 +83,21 @@ namespace Raven.Client.Documents.Session
         Task<Dictionary<string, FacetResult>> ExecuteAggregationAsync(CancellationToken token = default);
     }
 
+    [Obsolete(Constants.Obsolete.GraphApi)]
     public interface IAsyncGraphQuery<T> :
         IQueryBase<T, IAsyncGraphQuery<T>>,
         IAsyncDocumentQueryBase<T>
     {
+        [Obsolete(Constants.Obsolete.GraphApi)]
         IAsyncGraphQuery<T> With<TOther>(string alias, IRavenQueryable<TOther> query);
 
+        [Obsolete(Constants.Obsolete.GraphApi)]
         IAsyncGraphQuery<T> With<TOther>(string alias, string rawQuery);
 
+        [Obsolete(Constants.Obsolete.GraphApi)]
         IAsyncGraphQuery<T> With<TOther>(string alias, Func<IAsyncDocumentQueryBuilder, IAsyncDocumentQuery<TOther>> queryFactory);
 
+        [Obsolete(Constants.Obsolete.GraphApi)]
         IAsyncGraphQuery<T> WithEdges(string alias, string edgeSelector, string query);
     }
 

--- a/src/Raven.Client/Documents/Session/IDocumentQuery.cs
+++ b/src/Raven.Client/Documents/Session/IDocumentQuery.cs
@@ -88,16 +88,21 @@ namespace Raven.Client.Documents.Session
         Dictionary<string, FacetResult> ExecuteAggregation();
     }
 
+    [Obsolete(Constants.Obsolete.GraphApi)]
     public interface IGraphQuery<T> :
         IQueryBase<T, IGraphQuery<T>>,
         IDocumentQueryBase<T>
     {
+        [Obsolete(Constants.Obsolete.GraphApi)]
         IGraphQuery<T> With<TOther>(string alias, IRavenQueryable<TOther> query);
 
+        [Obsolete(Constants.Obsolete.GraphApi)]
         IGraphQuery<T> With<TOther>(string alias, string rawQuery);
 
+        [Obsolete(Constants.Obsolete.GraphApi)]
         IGraphQuery<T> With<TOther>(string alias, Func<IDocumentQueryBuilder, IDocumentQuery<TOther>> queryFactory);
 
+        [Obsolete(Constants.Obsolete.GraphApi)]
         IGraphQuery<T> WithEdges(string alias, string edgeSelector, string query);
     }
 

--- a/test/FastTests/Graph/ClientGraphQueries.cs
+++ b/test/FastTests/Graph/ClientGraphQueries.cs
@@ -26,7 +26,9 @@ namespace FastTests.Graph
                     session.Store(bar, barId);
                     session.Store(new Foo {Name = "Foozy", Bars = new List<string> {barId}});
                     session.SaveChanges();
+#pragma warning disable CS0618
                     FooBar res = session.Advanced.GraphQuery<FooBar>("match (Foo)-[Bars as _]->(Bars as Bar)").With("Foo", session.Query<Foo>()).Single();
+#pragma warning restore CS0618
                     Assert.Equal(res.Foo.Name, "Foozy");
                     Assert.Equal(res.Bar.Name, "Barvazon");
                 }
@@ -54,11 +56,13 @@ namespace FastTests.Graph
                         new[] {"Fi", "Foozy", "Fah", "Fah", "Foozy"},
                     })
                     {
+#pragma warning disable CS0618
                         var res = session.Advanced.GraphQuery<FooBar>("match (Foo)-[Bars as _]->(Bars as Bar)")
                             .With("Foo", builder => builder.DocumentQuery<Foo>().WhereIn(x => x.Name, names))
                             .With("Bar", session.Query<Bar>().Where(x => x.Age >= 18))
                             .WaitForNonStaleResults()
                             .ToList();
+#pragma warning restore CS0618
 
                         Assert.Single(res);
                         Assert.Equal(res[0].Foo.Name, "Foozy");
@@ -77,11 +81,13 @@ namespace FastTests.Graph
 
                 using (var session = store.OpenSession())
                 {
+#pragma warning disable CS0618
                     var query = session.Advanced.GraphQuery<FooBar>("match (Foo)-[Bars as _]->(Bars as Bar)")
                         .With("Foo", builder => builder.DocumentQuery<Foo>().WhereIn(x => x.Name, names).WaitForNonStaleResults(TimeSpan.FromMinutes(3)))
                         .With("Bar", session.Query<Bar>().Customize(x => x.WaitForNonStaleResults(TimeSpan.FromMinutes(5))).Where(x => x.Age >= 18))
                         .WaitForNonStaleResults()
                         .GetIndexQuery();
+#pragma warning restore CS0618
 
                     Assert.True(query.WaitForNonStaleResults);
                     Assert.Equal(TimeSpan.FromMinutes(5), query.WaitForNonStaleResultsTimeout);
@@ -89,11 +95,13 @@ namespace FastTests.Graph
 
                 using (var session = store.OpenAsyncSession())
                 {
+#pragma warning disable CS0618
                     var query = session.Advanced.AsyncGraphQuery<FooBar>("match (Foo)-[Bars as _]->(Bars as Bar)")
                         .With("Foo", builder => builder.AsyncDocumentQuery<Foo>().WhereIn(x => x.Name, names).WaitForNonStaleResults(TimeSpan.FromMinutes(3)))
                         .With("Bar", session.Query<Bar>().Customize(x => x.WaitForNonStaleResults(TimeSpan.FromMinutes(5))).Where(x => x.Age >= 18))
                         .WaitForNonStaleResults()
                         .GetIndexQuery();
+#pragma warning restore CS0618
 
                     Assert.True(query.WaitForNonStaleResults);
                     Assert.Equal(TimeSpan.FromMinutes(5), query.WaitForNonStaleResultsTimeout);
@@ -151,6 +159,7 @@ namespace FastTests.Graph
                     var from = now.AddDays(-345);
 
                     session.SaveChanges();
+#pragma warning disable CS0618
                     var res = session.Advanced.GraphQuery<FriendsTuple>("match (F1)-[L1]->(F2)")
                         .With("F1", session.Query<Friend>())
                         .With("F2", session.Query<Friend>())
@@ -160,6 +169,7 @@ namespace FastTests.Graph
                         .OrderByDescending(x => x.F1.Age)
                         .Select(x => x.F1)
                         .ToList();
+#pragma warning restore CS0618
 
                     Assert.Equal(res.Count, 4);
                     Assert.Equal(res[0].Name, "F4");

--- a/test/FastTests/Issues/RavenDB-13499.cs
+++ b/test/FastTests/Issues/RavenDB-13499.cs
@@ -24,13 +24,15 @@ namespace FastTests.Issues
                 
                 using (var session = store.OpenSession())
                 {
+#pragma warning disable CS0618
                     var results1 = session.Advanced
-                            .GraphQuery<JObject>("match (Person as f)-[Relationships as r select TargetId]->(Person as t)")
-                            .ToArray();
+                        .GraphQuery<JObject>("match (Person as f)-[Relationships as r select TargetId]->(Person as t)")
+                        .ToArray();
 
                     var results2 = session.Advanced
-                            .GraphQuery<JObject>("match (Person as f)-[Relationships as r select r.TargetId]->(Person as t)")
-                            .ToArray();
+                        .GraphQuery<JObject>("match (Person as f)-[Relationships as r select r.TargetId]->(Person as t)")
+                        .ToArray();
+#pragma warning restore CS0618
 
                     Assert.Equal(results1, results2);
                 }

--- a/test/SlowTests/Issues/RavenDB_4708_Conventions.cs
+++ b/test/SlowTests/Issues/RavenDB_4708_Conventions.cs
@@ -51,7 +51,9 @@ namespace SlowTests.Issues
             suspectedMethods = suspectedMethods.Where(x =>
                 x.ReturnType != typeof(IRavenQueryable<Employee>) &&
                 x.ReturnType != typeof(IAsyncDocumentQuery<Employee>) && 
+#pragma warning disable CS0618
                 x.ReturnType != typeof(IAsyncGraphQuery<Employee>) &&
+#pragma warning restore CS0618
                 x.ReturnType != typeof(IAsyncGroupByDocumentQuery<Employee>) &&
                 x.ReturnType != typeof(IAsyncAggregationDocumentQuery<Employee>))
                 .ToList();


### PR DESCRIPTION
### Issue link

https://issues.hibernatingrhinos.com/issue/RavenDB-17671

### How risky is the change?

- Low 

### Backward compatibility

- Not relevant

### Is it platform specific issue?

- No

### Documentation update

- No documentation update is needed 


### Is there any existing behavior change of other features due to this change?

- No

### UI work

- No UI work is needed
