### PR TITLE
RavenDB-17828 Initial name for cloned index

### DIFF
--- a/src/Raven.Studio/typescript/viewmodels/database/indexes/editIndex.ts
+++ b/src/Raven.Studio/typescript/viewmodels/database/indexes/editIndex.ts
@@ -818,7 +818,7 @@ class editIndex extends viewModelBase {
 
     cloneIndex() {
         this.isEditingExistingIndex(false);
-        this.editedIndex().name(null);
+        this.editedIndex().name(`CloneOf/${this.editedIndex().name()}`);
         this.editedIndex().reduceOutputCollectionName(null);
         this.editedIndex().patternForReferencesToReduceOutputCollection(null);
         this.editedIndex().collectionNameForReferenceDocuments(null);


### PR DESCRIPTION
### Issue link
https://issues.hibernatingrhinos.com/issue/RavenDB-17828

### Additional description
Initial name for cloned index, i.e.:
`CloneOf/Orders/Totals`

### Type of change
- Bug fix

### How risky is the change?
- Low 

### Backward compatibility
- Non breaking change

### Is it platform specific issue?
- No

### Documentation update
- No documentation update is needed 

### Testing 
- It has been verified by manual testing

### Is there any existing behavior change of other features due to this change?
- No

### UI work
- No UI work is needed
