### PR TITLE
RavenDB-18725 Bump replication protocol to ensure replication to older versions

### DIFF
--- a/src/Raven.Client/ServerWide/Tcp/TcpConnectionHeader.cs
+++ b/src/Raven.Client/ServerWide/Tcp/TcpConnectionHeader.cs
@@ -73,7 +73,10 @@ namespace Raven.Client.ServerWide.Tcp
         public static readonly int ReplicationAttachmentMissing = 40_300;
         public static readonly int ReplicationAttachmentMissingVersion41 = 41_300;
         public static readonly int ReplicationWithPullOption = 42_300;
+        
         public static readonly int ReplicationWithTimeSeries = 50_000;
+        public static readonly int ReplicationWithDeduplicatedAttachments = 53_001;
+
         public static readonly int TcpConnectionsWithCompression = 53_000;
         public static readonly int SubscriptionBaseLine = 40;
         public static readonly int SubscriptionIncludes = 41_400;
@@ -83,7 +86,7 @@ namespace Raven.Client.ServerWide.Tcp
 
         public static readonly int ClusterTcpVersion = ClusterWithMultiTree;
         public static readonly int HeartbeatsTcpVersion = Heartbeats42000;
-        public static readonly int ReplicationTcpVersion = TcpConnectionsWithCompression;
+        public static readonly int ReplicationTcpVersion = ReplicationWithDeduplicatedAttachments;
         public static readonly int SubscriptionTcpVersion = TcpConnectionsWithCompression; 
         public static readonly int TestConnectionTcpVersion = TestConnectionBaseLine;
 
@@ -256,6 +259,7 @@ namespace Raven.Client.ServerWide.Tcp
                 public bool PullReplication;
                 public bool TimeSeries;
                 public bool IncrementalTimeSeries;
+                public bool DeduplicatedAttachments;
             }
         }
 
@@ -284,6 +288,7 @@ namespace Raven.Client.ServerWide.Tcp
                 },
                 [OperationTypes.Replication] = new List<int>
                 {
+                    ReplicationWithDeduplicatedAttachments,
                     TcpConnectionsWithCompression,
                     ReplicationWithTimeSeries,
                     ReplicationWithPullOption,
@@ -375,6 +380,21 @@ namespace Raven.Client.ServerWide.Tcp
                 },
                 [OperationTypes.Replication] = new Dictionary<int, SupportedFeatures>
                 {
+                    [ReplicationWithDeduplicatedAttachments] = new SupportedFeatures(ReplicationWithDeduplicatedAttachments)
+                    {
+                        DataCompression = true,
+                        Replication = new SupportedFeatures.ReplicationFeatures
+                        {
+                            DeduplicatedAttachments = true,
+                            MissingAttachments = true, 
+                            CountersBatch = true,
+                            PullReplication = true,
+                            TimeSeries = true,
+                            CaseInsensitiveCounters = true,
+                            ClusterTransaction = true,
+                            IncrementalTimeSeries = true
+                        }
+                    },
                     [TcpConnectionsWithCompression] = new SupportedFeatures(TcpConnectionsWithCompression)
                     {
                         DataCompression = true,

--- a/src/Raven.Server/Documents/Replication/ReplicationDocumentSender.cs
+++ b/src/Raven.Server/Documents/Replication/ReplicationDocumentSender.cs
@@ -674,7 +674,10 @@ namespace Raven.Server.Documents.Replication
                 // destination, so we need to send it again
                 return true;
             }
-                    
+
+            if (_parent.SupportedFeatures.Replication.DeduplicatedAttachments == false)
+                return true;
+
             // RavenDB does de-duplication of attachments on storage, but not over the wire
             // Here we implement the same idea, if (in the current connection), we already sent
             // an attachment, we will skip sending it to the other side since we _know_ it is 


### PR DESCRIPTION
### Issue link

https://issues.hibernatingrhinos.com/issue/RavenDB-18725 

### Additional description

We introduced de-duplication of attachment here https://github.com/ravendb/ravendb/pull/14121 and for 5.3 <-> 5.3 it is working as expected.

The issue is replication between 5.3 -> 5.2 when we are skipping to send the stream while the other side (5.2) is expecting to have it and getting an NRE because of it in this line https://github.com/ravendb/ravendb/blob/fe2dabb52081aaada1a25625a0e1ddb2f8e0120f/src/Raven.Server/Documents/Replication/IncomingReplicationHandler.cs#L1142.
 

### Type of change

- Bug fix

### How risky is the change?

- Low 

### Backward compatibility

- Ensured. Manually tested with 5.3 -> 5.2 replication

### Is it platform specific issue?

- No

### Documentation update

- No documentation update is needed 

### Testing 

- It has been verified by manual testing

### Is there any existing behavior change of other features due to this change?

- No

### UI work

- No UI work is needed
