### PR TITLE
RavenDB-18691 Avoid checking if a dictionary exists. | Token insertion cleanup

### DIFF
--- a/bench/Voron.Benchmark/Corax/AndOrBenchmark.cs
+++ b/bench/Voron.Benchmark/Corax/AndOrBenchmark.cs
@@ -133,7 +133,7 @@ namespace Voron.Benchmark.Corax
                     entryWriter.Write(3, Encoding.UTF8.GetBytes("Dog"));
                     entryWriter.Finish(out var entry);
 
-                    writer.Index("dogs/arava", entry, fields);
+                    writer.Index("dogs/arava", entry);
                 }
 
                 {
@@ -144,7 +144,7 @@ namespace Voron.Benchmark.Corax
                     entryWriter.Write(3, Encoding.UTF8.GetBytes("Dog"));
                     entryWriter.Finish(out var entry);
 
-                    writer.Index("dogs/phoebe", entry, fields);
+                    writer.Index("dogs/phoebe", entry);
                 }
 
                 for (int i = 0; i < 10_000; i++)
@@ -157,7 +157,7 @@ namespace Voron.Benchmark.Corax
                     entryWriter.Write(3, Encoding.UTF8.GetBytes("Dog"));
                     entryWriter.Finish(out var entry);
 
-                    writer.Index("dogs/" + i, entry, fields);
+                    writer.Index("dogs/" + i, entry);
                 }
 
                 writer.Commit();

--- a/bench/Voron.Benchmark/Corax/AndOrBenchmark.cs
+++ b/bench/Voron.Benchmark/Corax/AndOrBenchmark.cs
@@ -110,22 +110,21 @@ namespace Voron.Benchmark.Corax
 
         private static void GenerateData(StorageEnvironment env)
         {
-            using (var writer = new IndexWriter(env))
+            using var bsc = new ByteStringContext(SharedMultipleUseFlag.None);
+            Slice.From(bsc, "Name", ByteStringType.Immutable, out var nameSlice);
+            Slice.From(bsc, "Family", ByteStringType.Immutable, out var familySlice);
+            Slice.From(bsc, "Age", ByteStringType.Immutable, out var ageSlice);
+            Slice.From(bsc, "Type", ByteStringType.Immutable, out var typeSlice);
+
+            Span<byte> buffer = new byte[256];
+            var fields = new IndexFieldsMapping(bsc)
+                .AddBinding(0, nameSlice)
+                .AddBinding(1, familySlice)
+                .AddBinding(2, ageSlice)
+                .AddBinding(3, typeSlice);
+            
+            using (var writer = new IndexWriter(env, fields))
             {
-                using var bsc = new ByteStringContext(SharedMultipleUseFlag.None);
-                Slice.From(bsc, "Name", ByteStringType.Immutable, out var nameSlice);
-                Slice.From(bsc, "Family", ByteStringType.Immutable, out var familySlice);
-                Slice.From(bsc, "Age", ByteStringType.Immutable, out var ageSlice);
-                Slice.From(bsc, "Type", ByteStringType.Immutable, out var typeSlice);
-
-                Span<byte> buffer = new byte[256];
-                var fields = new IndexFieldsMapping(bsc)
-                    .AddBinding(0, nameSlice)
-                    .AddBinding(1, familySlice)
-                    .AddBinding(2, ageSlice)
-                    .AddBinding(3, typeSlice);
-
-
                 {
                     var entryWriter = new IndexEntryWriter(buffer, fields);
                     entryWriter.Write(0, Encoding.UTF8.GetBytes("Arava"));

--- a/bench/Voron.Benchmark/Corax/InBenchmark.cs
+++ b/bench/Voron.Benchmark/Corax/InBenchmark.cs
@@ -111,21 +111,20 @@ namespace Voron.Benchmark.Corax
 
         private static void GenerateData(StorageEnvironment env)
         {
-            using (var writer = new IndexWriter(env))
+            using var bsc = new ByteStringContext(SharedMultipleUseFlag.None);
+            Slice.From(bsc, "Name", ByteStringType.Immutable, out var nameSlice);
+            Slice.From(bsc, "Family", ByteStringType.Immutable, out var familySlice);
+            Slice.From(bsc, "Age", ByteStringType.Immutable, out var ageSlice);
+            Slice.From(bsc, "Type", ByteStringType.Immutable, out var typeSlice);
+
+            Span<byte> buffer = new byte[256];
+            var fields = new IndexFieldsMapping(bsc)
+                .AddBinding(0, nameSlice)
+                .AddBinding(1, familySlice)
+                .AddBinding(2, ageSlice)
+                .AddBinding(3, typeSlice);
+            using (var writer = new IndexWriter(env, fields))
             {
-                using var bsc = new ByteStringContext(SharedMultipleUseFlag.None);
-                Slice.From(bsc, "Name", ByteStringType.Immutable, out var nameSlice);
-                Slice.From(bsc, "Family", ByteStringType.Immutable, out var familySlice);
-                Slice.From(bsc, "Age", ByteStringType.Immutable, out var ageSlice);
-                Slice.From(bsc, "Type", ByteStringType.Immutable, out var typeSlice);
-
-                Span<byte> buffer = new byte[256];
-                var fields = new IndexFieldsMapping(bsc)
-                                    .AddBinding(0, nameSlice)
-                                    .AddBinding(1, familySlice)
-                                    .AddBinding(2, ageSlice)
-                                    .AddBinding(3, typeSlice);
-
                 {
                     var entryWriter = new IndexEntryWriter(buffer, fields);
                     entryWriter.Write(0, Encoding.UTF8.GetBytes("Arava"));

--- a/bench/Voron.Benchmark/Corax/InBenchmark.cs
+++ b/bench/Voron.Benchmark/Corax/InBenchmark.cs
@@ -133,7 +133,7 @@ namespace Voron.Benchmark.Corax
                     entryWriter.Write(3, Encoding.UTF8.GetBytes("Dog"));
                     entryWriter.Finish(out var entry);
 
-                    writer.Index("dogs/arava", entry, fields);
+                    writer.Index("dogs/arava", entry);
                 }
 
                 {
@@ -144,7 +144,7 @@ namespace Voron.Benchmark.Corax
                     entryWriter.Write(3, Encoding.UTF8.GetBytes("Dog"));
                     entryWriter.Finish(out var entry);
 
-                    writer.Index("dogs/phoebe", entry, fields);
+                    writer.Index("dogs/phoebe", entry);
                 }
 
                 for (int i = 0; i < 10_000; i++)
@@ -157,7 +157,7 @@ namespace Voron.Benchmark.Corax
                     entryWriter.Write(3, Encoding.UTF8.GetBytes("Dog"));
                     entryWriter.Finish(out var entry);
 
-                    writer.Index("dogs/" + i, entry, fields);
+                    writer.Index("dogs/" + i, entry);
                 }
 
                 writer.Commit();

--- a/bench/Voron.Benchmark/Corax/OrderByBenchmark.cs
+++ b/bench/Voron.Benchmark/Corax/OrderByBenchmark.cs
@@ -138,7 +138,7 @@ namespace Voron.Benchmark.Corax
                     entryWriter.Write(3, Encoding.UTF8.GetBytes("Dog"));
                     entryWriter.Finish(out var entry);
 
-                    writer.Index("dogs/arava", entry, fields);
+                    writer.Index("dogs/arava", entry);
                 }
 
                 {
@@ -149,7 +149,7 @@ namespace Voron.Benchmark.Corax
                     entryWriter.Write(3, Encoding.UTF8.GetBytes("Dog"));
                     entryWriter.Finish(out var entry);
 
-                    writer.Index("dogs/phoebe", entry, fields);
+                    writer.Index("dogs/phoebe", entry);
                 }
 
                 for (int i = 0; i < 100_000; i++)
@@ -162,7 +162,7 @@ namespace Voron.Benchmark.Corax
                     entryWriter.Write(3, Encoding.UTF8.GetBytes("Dog"));
                     entryWriter.Finish(out var entry);
 
-                    writer.Index("dogs/" + i, entry, fields);
+                    writer.Index("dogs/" + i, entry);
                 }
 
                 writer.Commit();

--- a/bench/Voron.Benchmark/Corax/OrderByBenchmark.cs
+++ b/bench/Voron.Benchmark/Corax/OrderByBenchmark.cs
@@ -115,21 +115,21 @@ namespace Voron.Benchmark.Corax
 
         private static void GenerateData(StorageEnvironment env)
         {
-            using (var writer = new IndexWriter(env))
+            using var bsc = new ByteStringContext(SharedMultipleUseFlag.None);
+            Slice.From(bsc, "Name", ByteStringType.Immutable, out var nameSlice);
+            Slice.From(bsc, "Family", ByteStringType.Immutable, out var familySlice);
+            Slice.From(bsc, "Age", ByteStringType.Immutable, out var ageSlice);
+            Slice.From(bsc, "Type", ByteStringType.Immutable, out var typeSlice);
+
+            Span<byte> buffer = new byte[256];
+            var fields = new IndexFieldsMapping(bsc)
+                .AddBinding(0, nameSlice)
+                .AddBinding(1, familySlice)
+                .AddBinding(2, ageSlice)
+                .AddBinding(3, typeSlice);
+            
+            using (var writer = new IndexWriter(env, fields))
             {
-                using var bsc = new ByteStringContext(SharedMultipleUseFlag.None);
-                Slice.From(bsc, "Name", ByteStringType.Immutable, out var nameSlice);
-                Slice.From(bsc, "Family", ByteStringType.Immutable, out var familySlice);
-                Slice.From(bsc, "Age", ByteStringType.Immutable, out var ageSlice);
-                Slice.From(bsc, "Type", ByteStringType.Immutable, out var typeSlice);
-
-                Span<byte> buffer = new byte[256];
-                var fields = new IndexFieldsMapping(bsc)
-                                    .AddBinding(0, nameSlice)
-                                    .AddBinding(1, familySlice)
-                                    .AddBinding(2, ageSlice)
-                                    .AddBinding(3, typeSlice);
-
                 {
                     var entryWriter = new IndexEntryWriter(buffer, fields);
                     entryWriter.Write(0, Encoding.UTF8.GetBytes("Arava"));

--- a/bench/Voron.Benchmark/Corax/StartWithBenchmark.cs
+++ b/bench/Voron.Benchmark/Corax/StartWithBenchmark.cs
@@ -112,21 +112,20 @@ namespace Voron.Benchmark.Corax
 
         private static void GenerateData(StorageEnvironment env)
         {
-            using (var writer = new IndexWriter(env))
+            using var bsc = new ByteStringContext(SharedMultipleUseFlag.None);
+            Slice.From(bsc, "Name", ByteStringType.Immutable, out var nameSlice);
+            Slice.From(bsc, "Family", ByteStringType.Immutable, out var familySlice);
+            Slice.From(bsc, "Age", ByteStringType.Immutable, out var ageSlice);
+            Slice.From(bsc, "Type", ByteStringType.Immutable, out var typeSlice);
+
+            Span<byte> buffer = new byte[256];
+            var fields = new IndexFieldsMapping(bsc)
+                .AddBinding(0, nameSlice)
+                .AddBinding(1, familySlice)
+                .AddBinding(2, ageSlice)
+                .AddBinding(3, typeSlice);
+            using (var writer = new IndexWriter(env, fields))
             {
-                using var bsc = new ByteStringContext(SharedMultipleUseFlag.None);
-                Slice.From(bsc, "Name", ByteStringType.Immutable, out var nameSlice);
-                Slice.From(bsc, "Family", ByteStringType.Immutable, out var familySlice);
-                Slice.From(bsc, "Age", ByteStringType.Immutable, out var ageSlice);
-                Slice.From(bsc, "Type", ByteStringType.Immutable, out var typeSlice);
-
-                Span<byte> buffer = new byte[256];
-                var fields = new IndexFieldsMapping(bsc)
-                                    .AddBinding(0, nameSlice)
-                                    .AddBinding(1, familySlice)
-                                    .AddBinding(2, ageSlice)
-                                    .AddBinding(3, typeSlice);
-
                 {
                     var entryWriter = new IndexEntryWriter(buffer, fields);
                     entryWriter.Write(0, Encoding.UTF8.GetBytes("Arava"));

--- a/bench/Voron.Benchmark/Corax/StartWithBenchmark.cs
+++ b/bench/Voron.Benchmark/Corax/StartWithBenchmark.cs
@@ -134,7 +134,7 @@ namespace Voron.Benchmark.Corax
                     entryWriter.Write(3, Encoding.UTF8.GetBytes("Dog"));
                     entryWriter.Finish(out var entry);
 
-                    writer.Index("dogs/arava", entry, fields);
+                    writer.Index("dogs/arava", entry);
                 }
 
                 {
@@ -145,7 +145,7 @@ namespace Voron.Benchmark.Corax
                     entryWriter.Write(3, Encoding.UTF8.GetBytes("Dog"));
                     entryWriter.Finish(out var entry);
 
-                    writer.Index("dogs/phoebe", entry, fields);
+                    writer.Index("dogs/phoebe", entry);
                 }
 
                 for (int i = 0; i < 10_000; i++)
@@ -158,7 +158,7 @@ namespace Voron.Benchmark.Corax
                     entryWriter.Write(3, Encoding.UTF8.GetBytes("Dog"));
                     entryWriter.Finish(out var entry);
 
-                    writer.Index("dogs/" + i, entry, fields);
+                    writer.Index("dogs/" + i, entry);
                 }
 
                 writer.Commit();

--- a/src/Corax/Analyzers/Analyzer.cs
+++ b/src/Corax/Analyzers/Analyzer.cs
@@ -12,7 +12,7 @@ namespace Corax
     public unsafe class Analyzer : IDisposable
     {
         public static Analyzer DefaultAnalyzer = Create(default(KeywordTokenizer), default(ExactTransformer));
-        public const int MaximumSingleTokenLength = 512;
+        public const int MaximumSingleTokenLength = Voron.Global.Constants.CompactTree.MaximumKeySize;
         public static readonly ArrayPool<byte> BufferPool = ArrayPool<byte>.Create();
         public static readonly ArrayPool<Token> TokensPool = ArrayPool<Token>.Create();
         public readonly int MaximumOutputSize;

--- a/src/Corax/IndexEntry/IndexEntryFieldType.cs
+++ b/src/Corax/IndexEntry/IndexEntryFieldType.cs
@@ -17,6 +17,7 @@ public enum IndexEntryFieldType : ushort
     HasNulls = 1 << 14, // Helper for list writer.
     Invalid = 1 << 15,
     
+    ListWithNulls = List | HasNulls,
     SpatialPointList = List | SpatialPoint,
     TupleList = List | Tuple,
     RawList = List | Raw

--- a/src/Corax/IndexEntry/IndexEntryFieldType.cs
+++ b/src/Corax/IndexEntry/IndexEntryFieldType.cs
@@ -18,6 +18,7 @@ public enum IndexEntryFieldType : ushort
     Invalid = 1 << 15,
     
     ListWithNulls = List | HasNulls,
+    TupleListWithNulls = TupleList | HasNulls,
     SpatialPointList = List | SpatialPoint,
     TupleList = List | Tuple,
     RawList = List | Raw

--- a/src/Corax/IndexEntry/IndexEntryWriter.cs
+++ b/src/Corax/IndexEntry/IndexEntryWriter.cs
@@ -42,19 +42,10 @@ public unsafe ref partial struct IndexEntryWriter
     // so we wont even try to make the process more complex just to deal with them efficienly.
     private int _dynamicFieldIndex;
 
-    public IndexEntryWriter(Span<byte> buffer, IndexFieldsMapping knownFields = null)
+    public IndexEntryWriter(Span<byte> buffer, IndexFieldsMapping knownFields)
     {
         // TODO: For now we will assume that the max size of an index entry is 32Kb, revisit this...
-        if (knownFields == null)
-        {
-            _knownFields = IndexFieldsMapping.Instance;
-            Debug.Assert(_knownFields.Count == 0);
-        }
-        else
-        {
-            _knownFields = knownFields;
-        }
-
+        _knownFields = knownFields;
         int knownFieldMetadataSize = _knownFields.Count * sizeof(uint);
         _knownFieldsLocations = MemoryMarshal.Cast<byte, int>(buffer[^knownFieldMetadataSize..]);
         _knownFieldsLocations.Fill(Invalid); // We prepare the table in order to avoid tracking the writes. 

--- a/src/Corax/IndexFieldsMapping.cs
+++ b/src/Corax/IndexFieldsMapping.cs
@@ -10,8 +10,6 @@ namespace Corax;
 
 public class IndexFieldsMapping : IEnumerable<IndexFieldBinding>
 {
-    public static readonly IndexFieldsMapping Instance = new IndexFieldsMapping(null);
-
     private readonly ByteStringContext _context;
     private readonly Dictionary<Slice, IndexFieldBinding> _fields;
     private readonly Dictionary<int, IndexFieldBinding> _fieldsById;

--- a/src/Corax/IndexFieldsMapping.cs
+++ b/src/Corax/IndexFieldsMapping.cs
@@ -18,6 +18,11 @@ public class IndexFieldsMapping : IEnumerable<IndexFieldBinding>
     private readonly List<IndexFieldBinding> _fieldsList;
     public int Count => _fieldsById.Count;
     public Analyzer DefaultAnalyzer;
+    private int _maximumOutputSize;
+    public int MaximumOutputSize => _maximumOutputSize;
+    
+    private int _maximumTokenSize;
+    public int MaximumTokenSize => _maximumTokenSize;
 
     public IndexFieldsMapping(ByteStringContext context)
     {
@@ -61,8 +66,24 @@ public class IndexFieldsMapping : IEnumerable<IndexFieldBinding>
 
             ifb.Analyzer ??= analyzers.DefaultAnalyzer;
         }
+        
+        //We want also find maximum buffer for analyzers.
+        UpdateMaximumOutputAndTokenSize();
     }
 
+    internal void UpdateMaximumOutputAndTokenSize()
+    {
+        foreach (var analyzer in CollectionsMarshal.AsSpan(_fieldsList))
+        {
+            if (analyzer.Analyzer == null)
+                continue;
+            
+            _maximumOutputSize = Math.Max(_maximumOutputSize, analyzer.Analyzer.MaximumOutputSize);
+            _maximumTokenSize = Math.Max(_maximumTokenSize, analyzer.Analyzer.MaximumTokenSize);
+        }
+    }
+        
+    
     public IndexFieldBinding GetByFieldId(int fieldId)
     {
         return _fieldsById[fieldId];

--- a/src/Corax/IndexWriter.cs
+++ b/src/Corax/IndexWriter.cs
@@ -1,4 +1,5 @@
 using System;
+using System.Buffers;
 using System.Collections;
 using System.Collections.Generic;
 using System.Diagnostics;
@@ -44,15 +45,17 @@ namespace Corax
         private JsonOperationContext _jsonOperationContext;
         public readonly Transaction Transaction;
         private readonly TransactionPersistentContext _transactionPersistentContext;
-
+        
+        private readonly Token[] _tokensBufferHandler;
+        private readonly byte[] _encodingBufferHandler;
 
         // CPU bound - embarassingly parallel
         // 
         // private readonly ConcurrentDictionary<Slice, Dictionary<Slice, ConcurrentQueue<long>>> _bufferConcurrent =
         //     new ConcurrentDictionary<Slice, ConcurrentDictionary<Slice, ConcurrentQueue<long>>>(SliceComparer.Instance);
 
-        private readonly Dictionary<Slice, Dictionary<Slice, List<long>>> _buffer =
-            new Dictionary<Slice, Dictionary<Slice, List<long>>>(SliceComparer.Instance);
+        private readonly Dictionary<Slice, List<long>>[] _buffer; 
+      //     = new Dictionary<Slice, List<long>>(SliceComparer.Instance);
 
         private readonly List<long> _entriesToDelete = new List<long>();
 
@@ -68,7 +71,7 @@ namespace Corax
         // The reason why we want to have the transaction open for us is so that we avoid having
         // to explicitly provide the index writer with opening semantics and also every new
         // writer becomes essentially a unit of work which makes reusing assets tracking more explicit.
-        public IndexWriter([NotNull] StorageEnvironment environment, IndexFieldsMapping fieldsMapping = null)
+        public IndexWriter([NotNull] StorageEnvironment environment, IndexFieldsMapping fieldsMapping)
         {
             _environment = environment;
             _transactionPersistentContext = new TransactionPersistentContext(true);
@@ -78,10 +81,21 @@ namespace Corax
             _postingListContainerId = Transaction.OpenContainer(Constants.IndexWriter.PostingListsSlice);
             _entriesContainerId = Transaction.OpenContainer(Constants.IndexWriter.EntriesContainerSlice);
             _jsonOperationContext = JsonOperationContext.ShortTermSingleUse();
+            if (fieldsMapping != null)
+            {
+                fieldsMapping.UpdateMaximumOutputAndTokenSize();
+                _encodingBufferHandler = ArrayPool<byte>.Shared.Rent(fieldsMapping.MaximumOutputSize);
+                _tokensBufferHandler = ArrayPool<Token>.Shared.Rent(fieldsMapping.MaximumTokenSize);
+            }
             _fieldsMapping = fieldsMapping ?? IndexFieldsMapping.Instance;
+            
+            var bufferSize = fieldsMapping?.Count ?? 1024;
+            _buffer = new Dictionary<Slice, List<long>>[bufferSize];
+            for (int i = 0; i < bufferSize; ++i)
+                _buffer[i] = new Dictionary<Slice, List<long>>(SliceComparer.Instance);
         }
 
-        public IndexWriter([NotNull] Transaction tx, IndexFieldsMapping fieldsMapping = null)
+        public IndexWriter([NotNull] Transaction tx, IndexFieldsMapping fieldsMapping)
         {
             Transaction = tx;
 
@@ -89,9 +103,19 @@ namespace Corax
             _postingListContainerId = Transaction.OpenContainer(Constants.IndexWriter.PostingListsSlice);
             _entriesContainerId = Transaction.OpenContainer(Constants.IndexWriter.EntriesContainerSlice);
 
+            if (fieldsMapping != null)
+            {
+                _encodingBufferHandler = ArrayPool<byte>.Shared.Rent(fieldsMapping.MaximumOutputSize);
+                _tokensBufferHandler = ArrayPool<Token>.Shared.Rent(fieldsMapping.MaximumTokenSize);
+            }
+            
             _fieldsMapping = fieldsMapping ?? IndexFieldsMapping.Instance;
+            
+            var bufferSize = fieldsMapping?.Count ?? 1024;
+            _buffer = new Dictionary<Slice, List<long>>[bufferSize];
+            for (int i = 0; i < bufferSize; ++i)
+                _buffer[i] = new Dictionary<Slice, List<long>>(SliceComparer.Instance);
         }
-
 
         public long Index(string id, Span<byte> data, IndexFieldsMapping knownFields)
         {
@@ -121,21 +145,7 @@ namespace Corax
                 if (binding.FieldIndexingMode is FieldIndexingMode.No)
                     continue;
 
-                var key = binding.FieldName;
-                if (_buffer.TryGetValue(key, out var field) == false)
-                {
-                    //PERF: avoid creating dictionary
-                    _buffer[key] = field = new Dictionary<Slice, List<long>>(SliceComparer.Instance);
-                }
-
-                if (binding.IsAnalyzed)
-                {
-                    InsertAnalyzedToken(context, ref entryReader, field, entryId, binding);
-                }
-                else
-                {
-                    InsertToken(context, ref entryReader, field, entryId, binding);
-                }
+                InsertToken(context, ref entryReader, entryId, binding);
             }
 
             return entryId;
@@ -212,174 +222,109 @@ namespace Corax
 
             term.Add(entryId);
         }
-
+        
         [SkipLocalsInit]
-        private unsafe void InsertAnalyzedToken(ByteStringContext context, ref IndexEntryReader entryReader, Dictionary<Slice, List<long>> field, long entryId,
+        private unsafe void InsertToken(ByteStringContext context, ref IndexEntryReader entryReader, long entryId,
             IndexFieldBinding binding)
         {
-            Analyzer analyzer = binding.Analyzer;
-            analyzer.GetOutputBuffersSize(Analyzer.MaximumSingleTokenLength, out int bufferSize, out int tokenSize);
-
-            byte* tempWordsSpace = stackalloc byte[bufferSize];
-            Token* tempTokenSpace = stackalloc Token[tokenSize];
-
-            int tokenField = binding.FieldId;
-            var fieldType = entryReader.GetFieldType(tokenField, out var intOffset);
-            if (fieldType == IndexEntryFieldType.Null || fieldType.HasFlag(IndexEntryFieldType.Empty))
+            var field = _buffer[binding.FieldId];
+            int fieldId = binding.FieldId;
+            var fieldType = entryReader.GetFieldType(fieldId, out var _);
+            switch (fieldType)
             {
-                var fieldName = fieldType == IndexEntryFieldType.Null ? Constants.NullValueSlice : Constants.EmptyStringSlice;
-                if (field.TryGetValue(fieldName, out var term) == false)
-                    field[fieldName] = term = new List<long>();
+                case IndexEntryFieldType.Empty:
+                case IndexEntryFieldType.Null:
+                    var fieldName = fieldType == IndexEntryFieldType.Null ? Constants.NullValueSlice : Constants.EmptyStringSlice;
+                    Insert(fieldName.AsReadOnlySpan());
+                    break;
+                
+                case IndexEntryFieldType.TupleList:
+                    if (entryReader.TryReadMany(binding.FieldId, out var iterator) == false)
+                        break;
 
-                AddMaybeAvoidDuplicate(term, entryId);
-                return;
-            }
-            else if (fieldType.HasFlag(IndexEntryFieldType.Raw))
-            {
-            }
-            else if (fieldType.HasFlag(IndexEntryFieldType.List))
-            {
-                // TODO: For performance we can retrieve the whole thing and execute the analyzer many times in a loop for each token
-                //       that will ensure faster turnaround and more efficient execution. 
-                if (fieldType.HasFlag(IndexEntryFieldType.SpatialPoint))
-                {
-                    var iterator = entryReader.ReadManySpatialPoint(binding.FieldId);
                     while (iterator.ReadNext())
                     {
-                        for (int i = 1; i <= iterator.Geohash.Length; ++i)
-                            ProcessTerm(iterator.Geohash.Slice(0, i));
+                        ExactInsert(iterator.Sequence);
                     }
-                }
-                else
-                {
-                    var iterator = entryReader.ReadMany(tokenField);
+                    
+                    break;
+                
+                case IndexEntryFieldType.Tuple:
+                    if (entryReader.Read(binding.FieldId, out Span<byte> valueInEntry) == false)
+                        break;
+                    
+                    ExactInsert(valueInEntry);
+                    break;
+                
+                case IndexEntryFieldType.SpatialPointList:
+                    if (entryReader.TryReadManySpatialPoint(binding.FieldId, out var spatialIterator) == false)
+                        break;
+
+                    while (spatialIterator.ReadNext())
+                    {
+                        for (int i = 1; i <= spatialIterator.Geohash.Length; ++i)
+                            ExactInsert(spatialIterator.Geohash.Slice(0, i));
+                    }
+                    break;
+                
+                case IndexEntryFieldType.SpatialPoint:
+                    if (entryReader.Read(binding.FieldId, out valueInEntry) == false)
+                        break;
+                    
+                    for (int i = 1; i <= valueInEntry.Length; ++i)
+                        ExactInsert(valueInEntry.Slice(0, i));
+
+                    break;
+                
+                case IndexEntryFieldType.ListWithNulls:
+                case IndexEntryFieldType.List:
+                    if (entryReader.TryReadMany(binding.FieldId, out iterator) == false)
+                        break;
+
                     while (iterator.ReadNext())
-                    {                        
-                        // If null, we just add it and be done with it. 
-                        if (iterator.IsNull || iterator.IsEmpty)
+                    {
+                        if ((fieldType & IndexEntryFieldType.HasNulls) != 0 && (iterator.IsEmpty || iterator.IsNull))
                         {
-                            var fieldName = iterator.IsNull ? Constants.NullValueSlice : Constants.EmptyStringSlice;
-                            if (field.TryGetValue(fieldName, out var term) == false)
-                                field[fieldName] = term = new List<long>();
-
-                            AddMaybeAvoidDuplicate(term, entryId);
-                            continue;
+                            var fieldValue = iterator.IsNull ? Constants.NullValueSlice : Constants.EmptyStringSlice;
+                            Insert(fieldValue.AsReadOnlySpan());
                         }
-
-                        ProcessTerm(iterator.Sequence);
+                        else
+                        {
+                            Insert(iterator.Sequence);
+                        }
                     }
-                }
+                    break;
+                case IndexEntryFieldType.Invalid:
+                    break;
+                default:
+                    if (entryReader.Read(fieldId, out var value) == false)
+                        break;
+                    Insert(value);
+                    break;
             }
-            else
-            {                
-                if (entryReader.Read(binding.FieldId, out Span<byte> valueInEntry))
-                {                   
-                    if (valueInEntry.Length == 0)
-                    {
-                        var fieldName = Constants.EmptyStringSlice;
-                        if (field.TryGetValue(fieldName, out var term) == false)
-                            field[fieldName] = term = new List<long>();
-
-                        AddMaybeAvoidDuplicate(term, entryId);
-                    }
-                    else if (fieldType.HasFlag(IndexEntryFieldType.SpatialPoint))
-                    {
-                        for (int i = 1; i <= valueInEntry.Length; ++i)
-                            ProcessTerm(valueInEntry.Slice(0, i));
-                    }
-                    else if (fieldType.HasFlag(IndexEntryFieldType.Tuple) || fieldType.HasFlag(IndexEntryFieldType.Invalid) == false)
-                    {
-                        ProcessTerm(valueInEntry);
-                    }
-                }
-            }
-
-            void ProcessTerm(ReadOnlySpan<byte> value)
+            
+            void Insert(ReadOnlySpan<byte> value)
             {
-                var words = new Span<byte>(tempWordsSpace, bufferSize);
-                var tokens = new Span<Token>(tempTokenSpace, tokenSize);
-                analyzer.Execute(value, ref words, ref tokens);
-
+                if (binding.IsAnalyzed)
+                    AnalyzeInsert(_encodingBufferHandler.AsSpan(), _tokensBufferHandler.AsSpan(), value);
+                else
+                    ExactInsert(value);
+            }
+            
+            void AnalyzeInsert(Span<byte> wordsBuffer, Span<Token> tokens, ReadOnlySpan<byte> value)
+            {
+                binding.Analyzer.Execute(value, ref wordsBuffer, ref tokens);
                 for (int i = 0; i < tokens.Length; i++)
                 {
                     ref var token = ref tokens[i];
-
-                    using var _ = Slice.From(context, words.Slice(token.Offset, (int)token.Length), ByteStringType.Mutable, out var slice);
-                    if (field.TryGetValue(slice, out var term) == false)
-                    {
-                        var fieldName = slice.Clone(context);
-                        field[fieldName] = term = new List<long>();
-                    }
-
-                    AddMaybeAvoidDuplicate(term, entryId);
-
-                    if (binding.HasSuggestions)
-                        AddSuggestions(binding, slice);
+                    ExactInsert(wordsBuffer.Slice(token.Offset, (int)token.Length));
                 }
-            }
-        }
-
-        [SkipLocalsInit]
-        private void InsertToken(ByteStringContext context, ref IndexEntryReader entryReader, Dictionary<Slice, List<long>> field, long entryId,
-            IndexFieldBinding binding)
-        {
-            int fieldId = binding.FieldId;
-            var fieldType = entryReader.GetFieldType(fieldId, out var _);
-            if (fieldType == IndexEntryFieldType.Null || fieldType.HasFlag(IndexEntryFieldType.Empty))
-            {
-                InsertNullOrEmpty(field, entryId, fieldType);
-            }
-            else if (fieldType.HasFlag(IndexEntryFieldType.Raw))
-            {
-            }
-            else if (fieldType.HasFlag(IndexEntryFieldType.List))
-            {
-                // TODO: For performance we can retrieve the whole thing and execute the analyzer many times in a loop for each token
-                //       that will ensure faster turnaround and more efficient execution. 
-
-                if (fieldType.HasFlag(IndexEntryFieldType.SpatialPoint))
-                {
-                    var iterator = entryReader.ReadManySpatialPoint(binding.FieldId);
-                    while (iterator.ReadNext())
-                    {
-                        for (int i = 1; i <= iterator.Geohash.Length; ++i)
-                            ProcessTerm(iterator.Geohash.Slice(0, i));
-                    }
-                }
-                else
-                {
-                    var iterator = entryReader.ReadMany(fieldId);
-                    while (iterator.ReadNext())
-                    {
-                        if (iterator.IsNull || iterator.IsEmpty)
-                        {
-                            InsertNullOrEmpty(field, entryId, fieldType);
-                            continue;
-                        }
-
-                        ProcessTerm(iterator.Sequence);
-                    }
-                }
-            }
-            else
-            {
-                entryReader.Read(binding.FieldId, out Span<byte> valueInEntry);
-                if (fieldType.HasFlag(IndexEntryFieldType.SpatialPoint))
-                {
-                    for (int i = 1; i <= valueInEntry.Length; ++i)
-                        ProcessTerm(valueInEntry.Slice(0, i));
-                }
-                else if (fieldType.HasFlag(IndexEntryFieldType.Tuple) || fieldType.HasFlag(IndexEntryFieldType.Invalid) == false)
-                {
-                    Debug.Assert(!fieldType.HasFlag(IndexEntryFieldType.Empty));
-                    ProcessTerm(valueInEntry);
-                }
+                
             }
 
-
-            void ProcessTerm(ReadOnlySpan<byte> value)
+            void ExactInsert(ReadOnlySpan<byte> value)
             {
-                using var _ = Slice.From(context, value, ByteStringType.Immutable, out var slice);
+                using var _ = Slice.From(context, value, ByteStringType.Mutable, out var slice);
                 if (field.TryGetValue(slice, out var term) == false)
                 {
                     var fieldName = slice.Clone(context);
@@ -391,16 +336,8 @@ namespace Corax
                 if (binding.HasSuggestions)
                     AddSuggestions(binding, slice);
             }
-
-            void InsertNullOrEmpty(Dictionary<Slice, List<long>> field, long entryId, IndexEntryFieldType fieldType)
-            {
-                var fieldName = fieldType == IndexEntryFieldType.Null ? Constants.NullValueSlice : Constants.EmptyStringSlice;
-                if (field.TryGetValue(fieldName, out var term) == false)
-                    field[fieldName] = term = new List<long>();
-
-                AddMaybeAvoidDuplicate(term, entryId);
-            }
         }
+        
 
         private unsafe void DeleteCommit(Span<byte> tmpBuf, Tree fieldsTree)
         {
@@ -577,23 +514,18 @@ namespace Corax
             if (_fieldsMapping.Count != 0)
                 DeleteCommit(tmpBuf, fieldsTree);
 
-            foreach (var (field, terms) in _buffer)
+            for (int fieldId = 0; fieldId < _fieldsMapping.Count; ++fieldId)
             {
-                var fieldTree = fieldsTree.CompactTreeFor(field);
+                var fieldTree = fieldsTree.CompactTreeFor(_fieldsMapping.GetByFieldId(fieldId).FieldName);
                 var llt = Transaction.LowLevelTransaction;
-                var sortedTerms = terms.Keys.ToArray();
-                // CPU bounded - embarssingly parallel
+                var sortedTerms = _buffer[fieldId].Keys.ToArray();
                 Array.Sort(sortedTerms, SliceComparer.Instance);
+                
+                
                 foreach (var term in sortedTerms)
                 {
-                    var entries = terms[term];
                     ReadOnlySpan<byte> termsSpan = term.AsSpan();
-
-                    // TODO: For now if the term is null (termsSpan.Length == 0) we will not do anything... this happens
-                    //       because we are not explicitly handling the case of explicit NULL values (instead of unsetted). 
-                    if (termsSpan.Length == 0)
-                        continue;
-
+                    var entries = _buffer[fieldId][term];
                     if (fieldTree.TryGetValue(termsSpan, out var existing) == false)
                     {
                         AddNewTerm(entries, fieldTree, termsSpan, tmpBuf);
@@ -661,9 +593,10 @@ namespace Corax
                 }
             }
 
-
             if (_ownsTransaction)
+            {
                 Transaction.Commit();
+            }
         }
 
         private unsafe void AddNewTerm(List<long> entries, CompactTree fieldTree, ReadOnlySpan<byte> termsSpan, Span<byte> tmpBuf)
@@ -719,6 +652,11 @@ namespace Corax
             _jsonOperationContext?.Dispose();
             if (_ownsTransaction)
                 Transaction?.Dispose();
+            
+            if (_encodingBufferHandler != null)
+                ArrayPool<byte>.Shared.Return(_encodingBufferHandler);
+            if (_tokensBufferHandler != null)
+                ArrayPool<Token>.Shared.Return(_tokensBufferHandler);
         }
     }
 }

--- a/src/Corax/IndexWriter.cs
+++ b/src/Corax/IndexWriter.cs
@@ -216,12 +216,13 @@ namespace Corax
             var field = _buffer[binding.FieldId];
             int fieldId = binding.FieldId;
             var fieldType = entryReader.GetFieldType(fieldId, out var _);
+            var xd = fieldType;
             switch (fieldType)
             {
                 case IndexEntryFieldType.Empty:
                 case IndexEntryFieldType.Null:
                     var fieldName = fieldType == IndexEntryFieldType.Null ? Constants.NullValueSlice : Constants.EmptyStringSlice;
-                    Insert(fieldName.AsReadOnlySpan());
+                    ExactInsert(fieldName.AsReadOnlySpan());
                     break;
 
                 case IndexEntryFieldType.TupleList:
@@ -262,7 +263,8 @@ namespace Corax
                         ExactInsert(valueInEntry.Slice(0, i));
 
                     break;
-
+                
+                case IndexEntryFieldType.TupleListWithNulls:
                 case IndexEntryFieldType.ListWithNulls:
                 case IndexEntryFieldType.List:
                     if (entryReader.TryReadMany(binding.FieldId, out iterator) == false)
@@ -273,7 +275,7 @@ namespace Corax
                         if ((fieldType & IndexEntryFieldType.HasNulls) != 0 && (iterator.IsEmpty || iterator.IsNull))
                         {
                             var fieldValue = iterator.IsNull ? Constants.NullValueSlice : Constants.EmptyStringSlice;
-                            Insert(fieldValue.AsReadOnlySpan());
+                            ExactInsert(fieldValue.AsReadOnlySpan());
                         }
                         else
                         {
@@ -332,7 +334,6 @@ namespace Corax
                     AddSuggestions(binding, slice);
             }
         }
-
 
         private unsafe void DeleteCommit(Span<byte> tmpBuf, Tree fieldsTree)
         {

--- a/src/Corax/IndexWriter.cs
+++ b/src/Corax/IndexWriter.cs
@@ -597,6 +597,8 @@ namespace Corax
             }
         }
 
+        //Rationale behind passing in the validEncodedKey: because encodedKey could be out of date (due to deletion) so we have to generate it before we add the term.
+        //We cannot make EncodedKey nullable either because it is a read-only ref struct
         private unsafe void AddNewTerm(List<long> entries, CompactTree fieldTree, ReadOnlySpan<byte> termsSpan, Span<byte> tmpBuf, CompactTree.EncodedKey encodedKey,
             bool validEncodedKey = true)
         {

--- a/src/Raven.Server/Documents/Indexes/Persistence/Corax/CoraxIndexWriteOperation.cs
+++ b/src/Raven.Server/Documents/Indexes/Persistence/Corax/CoraxIndexWriteOperation.cs
@@ -71,7 +71,9 @@ namespace Raven.Server.Documents.Indexes.Persistence.Corax
                 return;
             
             using (Stats.AddStats.Start())
-                _indexWriter.Index(lowerId, data, _knownFields);
+            {
+                _indexWriter.Index(lowerId, data);
+            }
 
             stats.RecordIndexingOutput();
         }

--- a/src/Voron/Constants.cs
+++ b/src/Voron/Constants.cs
@@ -66,6 +66,8 @@ namespace Voron.Global
         {
             public const int PageHeaderSize = CompactPageHeader.SizeOf;
 
+            public const int MaximumKeySize = 1024;
+            
             static CompactTree()
             {
                 Constants.Assert(() => PageHeaderSize == sizeof(CompactPageHeader), () => $"{nameof(CompactPageHeader)} size has changed and not updated at Voron.Global.Constants.");

--- a/src/Voron/Data/CompactTrees/CompactTree.cs
+++ b/src/Voron/Data/CompactTrees/CompactTree.cs
@@ -715,6 +715,17 @@ namespace Voron.Data.CompactTrees
             }
         }
 
+
+        private void AssertValueAndKeySize(ReadOnlySpan<byte> key, long value)
+        {
+            if (value < 0)
+                throw new ArgumentOutOfRangeException(nameof(value), value, "Only positive values are allowed");
+            if (key.Length > Constants.CompactTree.MaximumKeySize)
+                throw new ArgumentOutOfRangeException(nameof(key), Encoding.UTF8.GetString(key),$"key must be less than {Constants.CompactTree.MaximumKeySize} bytes in size");
+            if(key.Length <= 0)
+                throw new ArgumentOutOfRangeException(nameof(key), Encoding.UTF8.GetString(key), "key must be at least 1 byte");
+        }
+        
         public void Add(string key, long value)
         {
             using var _ = Slice.From(_llt.Allocator, key, out var slice);
@@ -724,25 +735,15 @@ namespace Voron.Data.CompactTrees
 
         public void Add(ReadOnlySpan<byte> key, long value)
         {
-            if (value < 0)
-                throw new ArgumentOutOfRangeException(nameof(value), value, "Only positive values are allowed");
-            if (key.Length > 1024)
-                throw new ArgumentOutOfRangeException(nameof(key), Encoding.UTF8.GetString(key),"key must be less than 1024 bytes in size");
-            if(key.Length <= 0)
-                throw new ArgumentOutOfRangeException(nameof(key), Encoding.UTF8.GetString(key), "key must be at least 1 byte");
-
+            AssertValueAndKeySize(key, value);
+            
             var encodedKey = FindPageFor(key, ref _internalCursor);
             AddToPage(encodedKey, value);
         }
         
         public void Add(ReadOnlySpan<byte> key, long value, EncodedKey encodedKey)
         {
-            if (value < 0)
-                throw new ArgumentOutOfRangeException(nameof(value), value, "Only positive values are allowed");
-            if (key.Length > 1024)
-                throw new ArgumentOutOfRangeException(nameof(key), Encoding.UTF8.GetString(key),"key must be less than 1024 bytes in size");
-            if(key.Length <= 0)
-                throw new ArgumentOutOfRangeException(nameof(key), Encoding.UTF8.GetString(key), "key must be at least 1 byte");
+            AssertValueAndKeySize(key, value);
 
             AddToPage(encodedKey, value);
         }

--- a/test/FastTests/Corax/BoostingQuery.cs
+++ b/test/FastTests/Corax/BoostingQuery.cs
@@ -401,7 +401,7 @@ namespace FastTests.Corax
                 {
                     var entryWriter = new IndexEntryWriter(buffer.ToSpan(), knownFields);
                     var data = CreateIndexEntry(ref entryWriter, entry);
-                    indexWriter.Index(entry.Id, data, knownFields);
+                    indexWriter.Index(entry.Id, data);
                 }
                 indexWriter.Commit();
             }

--- a/test/FastTests/Corax/BoostingQuery.cs
+++ b/test/FastTests/Corax/BoostingQuery.cs
@@ -396,7 +396,7 @@ namespace FastTests.Corax
             using var _ = bsc.Allocate(bufferSize, out ByteString buffer);
 
             {
-                using var indexWriter = new IndexWriter(Env);
+                using var indexWriter = new IndexWriter(Env, knownFields);
                 foreach (var entry in longList)
                 {
                     var entryWriter = new IndexEntryWriter(buffer.ToSpan(), knownFields);

--- a/test/FastTests/Corax/CoraxQueries.cs
+++ b/test/FastTests/Corax/CoraxQueries.cs
@@ -131,7 +131,7 @@ namespace FastTests.Corax
                 {
                     var entryWriter = new IndexEntryWriter(buffer.ToSpan(), _knownFields);
                     var data = CreateIndexEntry(ref entryWriter, entry);
-                    indexWriter.Index(entry.Id, data, _knownFields);
+                    indexWriter.Index(entry.Id, data);
                 }
 
                 indexWriter.Commit();

--- a/test/FastTests/Corax/CoraxQueries.cs
+++ b/test/FastTests/Corax/CoraxQueries.cs
@@ -126,7 +126,7 @@ namespace FastTests.Corax
             using var _ = ctx.Allocate(bufferSize, out ByteString buffer);
 
             {
-                using var indexWriter = new IndexWriter(Env);
+                using var indexWriter = new IndexWriter(Env, _knownFields);
                 foreach (var entry in _entries)
                 {
                     var entryWriter = new IndexEntryWriter(buffer.ToSpan(), _knownFields);

--- a/test/FastTests/Corax/DeleteTest.cs
+++ b/test/FastTests/Corax/DeleteTest.cs
@@ -29,7 +29,7 @@ namespace FastTests.Corax
         public void CanDelete()
         {
             PrepareData();
-            IndexEntries();
+            IndexEntries(CreateKnownFields(_bsc));
 
             Span<long> ids = stackalloc long[1024];
             {
@@ -68,7 +68,7 @@ namespace FastTests.Corax
         public void CanDeleteOneElement()
         {
             PrepareData(DataType.Modulo);
-            IndexEntries();
+            IndexEntries(CreateKnownFields(_bsc));
             var count = _longList.Count(p => p.Content == 9);
             
             Span<long> ids = stackalloc long[1024];
@@ -123,13 +123,13 @@ namespace FastTests.Corax
             Modulo
         }
 
-        private void IndexEntries()
+        private void IndexEntries(IndexFieldsMapping knownFields)
         {
             const int bufferSize = 4096;
             using var _ = _bsc.Allocate(bufferSize, out ByteString buffer);
 
             {
-                using var indexWriter = new IndexWriter(Env);
+                using var indexWriter = new IndexWriter(Env, knownFields);
                 foreach (var entry in _longList)
                 {
                     var entryWriter = new IndexEntryWriter(buffer.ToSpan(), _analyzers);

--- a/test/FastTests/Corax/DeleteTest.cs
+++ b/test/FastTests/Corax/DeleteTest.cs
@@ -134,7 +134,7 @@ namespace FastTests.Corax
                 {
                     var entryWriter = new IndexEntryWriter(buffer.ToSpan(), _analyzers);
                     var data = CreateIndexEntry(ref entryWriter, entry);
-                    indexWriter.Index(entry.Id, data, _analyzers);
+                    indexWriter.Index(entry.Id, data);
                 }
 
                 indexWriter.Commit();

--- a/test/FastTests/Corax/IndexSearcher.cs
+++ b/test/FastTests/Corax/IndexSearcher.cs
@@ -914,7 +914,7 @@ namespace FastTests.Corax
             using var _ = bsc.Allocate(bufferSize, out ByteString buffer);
 
             {
-                using var indexWriter = new IndexWriter(Env);
+                using var indexWriter = new IndexWriter(Env, knownFields);
                 foreach (var entry in list)
                 {
                     var entryWriter = new IndexEntryWriter(buffer.ToSpan(), knownFields);

--- a/test/FastTests/Corax/IndexSearcher.cs
+++ b/test/FastTests/Corax/IndexSearcher.cs
@@ -109,7 +109,7 @@ namespace FastTests.Corax
                 {
                     var entryWriter = new IndexEntryWriter(buffer.ToSpan(), mapping);
                     var data = CreateIndexEntry(ref entryWriter, entry);
-                    indexWriter.Index(entry.Id, data, mapping);
+                    indexWriter.Index(entry.Id, data);
                 }
 
                 indexWriter.Commit();
@@ -781,7 +781,7 @@ namespace FastTests.Corax
                 {
                     var entryWriter = new IndexEntryWriter(buffer.ToSpan(), mapping);
                     var data = CreateIndexEntry(ref entryWriter, entry);
-                    indexWriter.Index(entry.Id, data, mapping);
+                    indexWriter.Index(entry.Id, data);
                 }
 
                 indexWriter.Commit();
@@ -919,7 +919,7 @@ namespace FastTests.Corax
                 {
                     var entryWriter = new IndexEntryWriter(buffer.ToSpan(), knownFields);
                     var data = CreateIndexEntryDouble(ref entryWriter, entry);
-                    indexWriter.Index(entry.Id, data, knownFields);
+                    indexWriter.Index(entry.Id, data);
                 }
 
                 indexWriter.Commit();

--- a/test/FastTests/Corax/OrderByMultiSorting.cs
+++ b/test/FastTests/Corax/OrderByMultiSorting.cs
@@ -167,7 +167,7 @@ namespace FastTests.Corax
             using var _ = bsc.Allocate(bufferSize, out ByteString buffer);
 
             {
-                using var indexWriter = new IndexWriter(Env);
+                using var indexWriter = new IndexWriter(Env, knownFields);
                 foreach (var entry in longList)
                 {
                     var entryWriter = new IndexEntryWriter(buffer.ToSpan(), knownFields);

--- a/test/FastTests/Corax/OrderByMultiSorting.cs
+++ b/test/FastTests/Corax/OrderByMultiSorting.cs
@@ -172,7 +172,7 @@ namespace FastTests.Corax
                 {
                     var entryWriter = new IndexEntryWriter(buffer.ToSpan(), knownFields);
                     var data = CreateIndexEntry(ref entryWriter, entry);
-                    indexWriter.Index(entry.Id, data, knownFields);
+                    indexWriter.Index(entry.Id, data);
                 }
                 indexWriter.Commit();
             }

--- a/test/FastTests/Corax/OrderBySorting.cs
+++ b/test/FastTests/Corax/OrderBySorting.cs
@@ -82,7 +82,7 @@ namespace FastTests.Corax
             using var _ = bsc.Allocate(bufferSize, out ByteString buffer);
 
             {
-                using var indexWriter = new IndexWriter(Env);
+                using var indexWriter = new IndexWriter(Env, knownFields);
                 foreach (var entry in longList)
                 {
                     var entryWriter = new IndexEntryWriter(buffer.ToSpan(), knownFields);

--- a/test/FastTests/Corax/OrderBySorting.cs
+++ b/test/FastTests/Corax/OrderBySorting.cs
@@ -87,7 +87,7 @@ namespace FastTests.Corax
                 {
                     var entryWriter = new IndexEntryWriter(buffer.ToSpan(), knownFields);
                     var data = CreateIndexEntry(ref entryWriter, entry);
-                    indexWriter.Index(entry.Id, data, knownFields);
+                    indexWriter.Index(entry.Id, data);
                 }
                 indexWriter.Commit();
             }

--- a/test/FastTests/Corax/RawCoraxFlag.cs
+++ b/test/FastTests/Corax/RawCoraxFlag.cs
@@ -44,7 +44,7 @@ public class RawCoraxFlag : StorageTest
                 entry.Write(IndexId, Encodings.Utf8.GetBytes(id));
                 entry.WriteRaw(ContentId, new Span<byte>(item.BasePointer, item.Size));
                 entry.Finish(out var output);
-                writer.Index(id, output, _analyzers);
+                writer.Index(id, output);
             }
 
             writer.Commit();
@@ -104,7 +104,7 @@ public class RawCoraxFlag : StorageTest
                 }
 
                 entry.Finish(out var output);
-                writer.Index(id, output, _analyzers);
+                writer.Index(id, output);
             }
 
             writer.Commit();

--- a/test/FastTests/Corax/SpatialTests.cs
+++ b/test/FastTests/Corax/SpatialTests.cs
@@ -61,7 +61,7 @@ public class SpatialTests : StorageTest
             var spatialEntry = new CoraxSpatialPointEntry(latitude, longitude, geohash);
             entry.WriteSpatial(CoordinatesIndex, spatialEntry);
             entry.Finish(out var preparedItem);
-            writer.Index(IdString, preparedItem, _fieldsMapping);
+            writer.Index(IdString, preparedItem);
             writer.Commit();
         }
 

--- a/test/FastTests/Corax/Suggestions.cs
+++ b/test/FastTests/Corax/Suggestions.cs
@@ -193,7 +193,7 @@ namespace FastTests.Corax
                 {
                     var entryWriter = new IndexEntryWriter(buffer.ToSpan(), mapping);
                     var data = CreateIndexEntry(ref entryWriter, entry);
-                    indexWriter.Index(entry.Id, data, mapping);
+                    indexWriter.Index(entry.Id, data);
                 }
 
                 indexWriter.Commit();


### PR DESCRIPTION
### Additional description
There is no need to dynamically check if we have a dictionary for a given field since we specify it in the constructor. 

### Type of change

- Optimization

### How risky is the change?


- Not relevant

### Backward compatibility

- Not relevant

### Is it platform specific issue?

- No

### Documentation update

- No documentation update is needed 

### Testing 

- Tests have been added that prove the fix is effective or that the feature works


### Is there any existing behavior change of other features due to this change?

- No

### UI work

- No UI work is needed
