### PR TITLE
RavenDB-18654 Added handler to test patch by query in sharded db

### DIFF
--- a/src/Raven.Server/Documents/Commands/Queries/PatchByQueryTestCommand.cs
+++ b/src/Raven.Server/Documents/Commands/Queries/PatchByQueryTestCommand.cs
@@ -1,0 +1,65 @@
+﻿using System;
+using System.Collections.Generic;
+using System.Net.Http;
+using Raven.Client.Documents.Conventions;
+using Raven.Client.Documents.Operations;
+using Raven.Client.Http;
+using Raven.Client.Json;
+using Raven.Client.Util;
+using Raven.Server.Documents.Queries;
+using Raven.Server.Json;
+using Sparrow.Json;
+using Sparrow.Json.Parsing;
+
+namespace Raven.Server.Documents.Commands.Queries;
+
+public class PatchByQueryTestCommand : RavenCommand<PatchByQueryTestCommand.Response>
+{
+    private readonly string _id;
+    private readonly IndexQueryServerSide _query;
+
+    public class Response : PatchResult
+    {
+        public List<string> Output { get; set; }
+
+        public BlittableJsonReaderObject DebugActions { get; set; }
+    }
+
+    public PatchByQueryTestCommand(string id, IndexQueryServerSide query)
+    {
+        _id = id ?? throw new ArgumentNullException(nameof(id));
+        _query = query ?? throw new ArgumentNullException(nameof(query));
+    }
+
+    public override bool IsReadRequest => true;
+
+    public override HttpRequestMessage CreateRequest(JsonOperationContext ctx, ServerNode node, out string url)
+    {
+        url = $"{node.Url}/databases/{node.Database}/queries/test?id={Uri.EscapeDataString(_id)}";
+
+        return new HttpRequestMessage
+        {
+            Method = HttpMethods.Patch,
+            Content = new BlittableJsonContent(async stream =>
+            {
+                await using (var writer = new AsyncBlittableJsonTextWriter(ctx, stream))
+                {
+                    writer.WriteStartObject();
+
+                    writer.WritePropertyName("Query");
+                    writer.WriteIndexQuery(ctx, _query);
+
+                    writer.WriteEndObject();
+                }
+            })
+        };
+    }
+
+    public override void SetResponse(JsonOperationContext context, BlittableJsonReaderObject response, bool fromCache)
+    {
+        if (response == null)
+            ThrowInvalidResponse();
+
+        Result = DocumentConventions.DefaultForServer.Serialization.DefaultConverter.FromBlittable<Response>(response);
+    }
+}

--- a/src/Raven.Server/Documents/Handlers/Processors/Queries/AbstractQueriesHandlerProcessor.cs
+++ b/src/Raven.Server/Documents/Handlers/Processors/Queries/AbstractQueriesHandlerProcessor.cs
@@ -30,7 +30,7 @@ internal abstract class AbstractQueriesHandlerProcessor<TRequestHandler, TOperat
         _queryMetadataCache = queryMetadataCache;
     }
 
-    public async ValueTask<IndexQueryServerSide> GetIndexQueryAsync(JsonOperationContext context, HttpMethod method, RequestTimeTracker tracker, bool addSpatialProperties)
+    public async ValueTask<IndexQueryServerSide> GetIndexQueryAsync(JsonOperationContext context, HttpMethod method, RequestTimeTracker tracker, bool addSpatialProperties = false)
     {
         if (method == HttpMethod.Get)
             return await ReadIndexQueryAsync(context, tracker, addSpatialProperties);

--- a/src/Raven.Server/Documents/Handlers/Processors/Queries/AbstractQueriesHandlerProcessorForPatchTest.cs
+++ b/src/Raven.Server/Documents/Handlers/Processors/Queries/AbstractQueriesHandlerProcessorForPatchTest.cs
@@ -1,0 +1,34 @@
+﻿using System.Net.Http;
+using System.Threading.Tasks;
+using JetBrains.Annotations;
+using Raven.Server.Documents.Queries;
+using Raven.Server.TrafficWatch;
+using Sparrow.Json;
+
+namespace Raven.Server.Documents.Handlers.Processors.Queries;
+
+internal abstract class AbstractQueriesHandlerProcessorForPatchTest<TRequestHandler, TOperationContext> : AbstractQueriesHandlerProcessor<TRequestHandler, TOperationContext>
+    where TOperationContext : JsonOperationContext
+    where TRequestHandler : AbstractDatabaseRequestHandler<TOperationContext>
+{
+    protected AbstractQueriesHandlerProcessorForPatchTest([NotNull] TRequestHandler requestHandler, QueryMetadataCache queryMetadataCache) : base(requestHandler, queryMetadataCache)
+    {
+    }
+
+    protected abstract ValueTask HandleDocumentPatchTestAsync(IndexQueryServerSide query, string docId, TOperationContext context);
+
+    public override async ValueTask ExecuteAsync()
+    {
+        using (ContextPool.AllocateOperationContext(out TOperationContext context))
+        {
+            var docId = RequestHandler.GetQueryStringValueAndAssertIfSingleAndNotEmpty("id");
+
+            var query = await GetIndexQueryAsync(context, HttpMethod.Patch, null);
+
+            if (TrafficWatchManager.HasRegisteredClients)
+                RequestHandler.TrafficWatchQuery(query);
+
+            await HandleDocumentPatchTestAsync(query, docId, context);
+        }
+    }
+}

--- a/src/Raven.Server/Documents/Handlers/Processors/Queries/DatabaseQueriesHandlerProcessorForPatchTest.cs
+++ b/src/Raven.Server/Documents/Handlers/Processors/Queries/DatabaseQueriesHandlerProcessorForPatchTest.cs
@@ -1,0 +1,102 @@
+﻿using System;
+using System.Net;
+using System.Threading.Tasks;
+using JetBrains.Annotations;
+using Raven.Client.Documents.Operations;
+using Raven.Server.Documents.Patch;
+using Raven.Server.Documents.Queries;
+using Raven.Server.ServerWide.Context;
+using Sparrow.Json;
+using Sparrow.Json.Parsing;
+using PatchRequest = Raven.Server.Documents.Patch.PatchRequest;
+
+namespace Raven.Server.Documents.Handlers.Processors.Queries;
+
+internal class DatabaseQueriesHandlerProcessorForPatchTest : AbstractQueriesHandlerProcessorForPatchTest<QueriesHandler, DocumentsOperationContext>
+{
+
+    public DatabaseQueriesHandlerProcessorForPatchTest([NotNull] QueriesHandler requestHandler) : base(requestHandler, requestHandler.Database.QueryMetadataCache)
+    {
+    }
+
+    protected override async ValueTask HandleDocumentPatchTestAsync(IndexQueryServerSide query, string docId, DocumentsOperationContext context)
+    {
+        var patch = new PatchRequest(query.Metadata.GetUpdateBody(query.QueryParameters), PatchRequestType.Patch, query.Metadata.DeclaredFunctions);
+
+        var command = new PatchDocumentCommand(context, docId,
+            expectedChangeVector: null,
+            skipPatchIfChangeVectorMismatch: false,
+            patch: (patch, query.QueryParameters),
+            patchIfMissing: (null, null),
+            identityPartsSeparator: context.DocumentDatabase.IdentityPartsSeparator,
+            createIfMissing: null,
+            debugMode: true,
+            isTest: true,
+            collectResultsNeeded: true,
+            returnDocument: false
+        );
+
+        using (context.OpenWriteTransaction())
+        {
+            command.Execute(context, null);
+        }
+
+        switch (command.PatchResult.Status)
+        {
+            case PatchStatus.DocumentDoesNotExist:
+                HttpContext.Response.StatusCode = (int)HttpStatusCode.NotFound;
+                return;
+
+
+            case PatchStatus.Created:
+                HttpContext.Response.StatusCode = (int)HttpStatusCode.Created;
+                break;
+
+            case PatchStatus.Skipped:
+                HttpContext.Response.StatusCode = (int)HttpStatusCode.NotModified;
+                return;
+
+
+            case PatchStatus.Patched:
+            case PatchStatus.NotModified:
+                HttpContext.Response.StatusCode = (int)HttpStatusCode.OK;
+                break;
+
+            default:
+                throw new ArgumentOutOfRangeException();
+        }
+
+        await WritePatchResultToResponseAsync(context, command);
+    }
+
+    private async ValueTask WritePatchResultToResponseAsync(DocumentsOperationContext context, PatchDocumentCommand command)
+    {
+        await using (var writer = new AsyncBlittableJsonTextWriter(context, RequestHandler.ResponseBodyStream()))
+        {
+            writer.WriteStartObject();
+
+            writer.WritePropertyName(nameof(command.PatchResult.Status));
+            writer.WriteString(command.PatchResult.Status.ToString());
+            writer.WriteComma();
+
+            writer.WritePropertyName(nameof(command.PatchResult.ModifiedDocument));
+            writer.WriteObject(command.PatchResult.ModifiedDocument);
+
+            writer.WriteComma();
+            writer.WritePropertyName(nameof(command.PatchResult.OriginalDocument));
+            writer.WriteObject(command.PatchResult.OriginalDocument);
+
+            writer.WriteComma();
+
+            writer.WritePropertyName(nameof(command.PatchResult.Debug));
+
+            context.Write(writer, new DynamicJsonValue
+            {
+                ["Output"] = new DynamicJsonArray(command.DebugOutput),
+                ["Actions"] = command.DebugActions
+            });
+
+            writer.WriteEndObject();
+        }
+    }
+}

--- a/src/Raven.Server/Documents/Sharding/Handlers/Processors/Queries/ShardedQueriesHandlerProcessorForDelete.cs
+++ b/src/Raven.Server/Documents/Sharding/Handlers/Processors/Queries/ShardedQueriesHandlerProcessorForDelete.cs
@@ -1,16 +1,12 @@
 ﻿using System;
 using System.Net.Http;
-using System.Threading.Tasks;
 using JetBrains.Annotations;
 using Raven.Client.Documents.Conventions;
 using Raven.Client.Documents.Operations;
 using Raven.Client.Documents.Queries;
 using Raven.Client.Http;
-using Raven.Server.Documents.Handlers.Processors.Queries;
 using Raven.Server.Documents.Operations;
 using Raven.Server.Documents.Queries;
-using Raven.Server.ServerWide;
-using Raven.Server.ServerWide.Context;
 using Sparrow.Json;
 
 namespace Raven.Server.Documents.Sharding.Handlers.Processors.Queries;

--- a/src/Raven.Server/Documents/Sharding/Handlers/Processors/Queries/ShardedQueriesHandlerProcessorForPatchTest.cs
+++ b/src/Raven.Server/Documents/Sharding/Handlers/Processors/Queries/ShardedQueriesHandlerProcessorForPatchTest.cs
@@ -1,0 +1,31 @@
+﻿using System.Threading.Tasks;
+using JetBrains.Annotations;
+using Raven.Client.Documents.Conventions;
+using Raven.Client.Documents.Operations;
+using Raven.Server.Documents.Commands.Queries;
+using Raven.Server.Documents.Handlers.Processors.Queries;
+using Raven.Server.Documents.Queries;
+using Raven.Server.ServerWide.Context;
+using Raven.Server.Web.Http;
+
+namespace Raven.Server.Documents.Sharding.Handlers.Processors.Queries;
+
+internal class ShardedQueriesHandlerProcessorForPatchTest : AbstractQueriesHandlerProcessorForPatchTest<ShardedQueriesHandler, TransactionOperationContext>
+{
+    public ShardedQueriesHandlerProcessorForPatchTest([NotNull] ShardedQueriesHandler requestHandler) : base(requestHandler, requestHandler.DatabaseContext.QueryMetadataCache)
+    {
+    }
+
+    protected override async ValueTask HandleDocumentPatchTestAsync(IndexQueryServerSide query, string docId, TransactionOperationContext context)
+    {
+        var command = new PatchByQueryTestCommand(docId, query);
+
+        int shardNumber = RequestHandler.DatabaseContext.GetShardNumber(context, docId);
+
+        using (var token = RequestHandler.CreateOperationToken())
+        {
+            var proxyCommand = new ProxyCommand<PatchByQueryTestCommand.Response>(command, HttpContext.Response);
+            await RequestHandler.ShardExecutor.ExecuteSingleShardAsync(proxyCommand, shardNumber, token.Token);
+        }
+    }
+}

--- a/src/Raven.Server/Documents/Sharding/Handlers/ShardedQueriesHandler.cs
+++ b/src/Raven.Server/Documents/Sharding/Handlers/ShardedQueriesHandler.cs
@@ -38,6 +38,13 @@ namespace Raven.Server.Documents.Sharding.Handlers
                 await processor.ExecuteAsync();
         }
 
+        [RavenShardedAction("/databases/*/queries/test", "PATCH")]
+        public async Task PatchTest()
+        {
+            using (var processor = new ShardedQueriesHandlerProcessorForPatchTest(this))
+                await processor.ExecuteAsync();
+        }
+
         [RavenShardedAction("/databases/*/queries", "DELETE")]
         public async Task Delete()
         {


### PR DESCRIPTION
### Issue link

https://issues.hibernatingrhinos.com/issue/RavenDB-18654

### Additional description

Ability to test patch by query scripts in a sharded db.

### Type of change

- Feature

### How risky is the change?

- Low 

### Backward compatibility

- Not relevant

### Is it platform specific issue?

- No

### Documentation update

- No documentation update is needed 

### Testing 

- It has been verified by manual testing via Studio

### Is there any existing behavior change of other features due to this change?

- No

### UI work

- No UI work is needed
