### PR TITLE
RavenDB-14436: make sure to use the _reasonableTimeout for backup in …

### DIFF
--- a/test/Tests.Infrastructure/RavenTestBase.Backup.cs
+++ b/test/Tests.Infrastructure/RavenTestBase.Backup.cs
@@ -22,7 +22,7 @@ namespace FastTests
         public class BackupTestBase
         {
             private readonly RavenTestBase _parent;
-            private readonly int _reasonableTimeout = Debugger.IsAttached ? 60000 : 15000;
+            private readonly int _reasonableTimeout = Debugger.IsAttached ? 60000 : 30000;
 
             public BackupTestBase(RavenTestBase parent)
             {


### PR DESCRIPTION
…debug when debugger is not attached

### Issue link

https://issues.hibernatingrhinos.com/issue/RavenDB-14436

### Additional description

the increased timeout for backup was working only when debugger was attached

### Type of change

- Bug fix


### How risky is the change?

- Low 


### Backward compatibility

- Not relevant

### Is it platform specific issue?


- No

### Documentation update

- No documentation update is needed 

### Testing 

- It has been verified by manual testing

### Is there any existing behavior change of other features due to this change?

- No

### UI work

- No UI work is needed
