### PR TITLE
RavenDB-18727 - Sharding - Revisions - Handlers

### DIFF
--- a/src/Raven.Server/Documents/Commands/Revisions/GetResolvedRevisionsCommand.cs
+++ b/src/Raven.Server/Documents/Commands/Revisions/GetResolvedRevisionsCommand.cs
@@ -1,0 +1,66 @@
+﻿using System;
+using System.Net.Http;
+using System.Text;
+using Raven.Client.Http;
+using Raven.Server.Json;
+using Sparrow.Extensions;
+using Sparrow.Json;
+
+namespace Raven.Server.Documents.Commands.Revisions
+{
+    public class GetResolvedRevisionsCommand : RavenCommand<ResolvedRevisions>
+    {
+        private readonly DateTime? _since;
+        private readonly int? _take;
+
+        public GetResolvedRevisionsCommand(DateTime? since, int? take = null)
+        {
+            _since = since;
+            _take = take;
+        }
+        
+        public override HttpRequestMessage CreateRequest(JsonOperationContext ctx, ServerNode node, out string url)
+        {
+            var request = new HttpRequestMessage
+            {
+                Method = HttpMethod.Get
+            };
+
+            var pathBuilder = new StringBuilder(node.Url)
+                .Append("/databases/")
+                .Append(node.Database)
+                .Append("/revisions/resolved");
+
+            if (_since.HasValue && _take.HasValue)
+            {
+                pathBuilder.Append("?since=").Append(_since.Value.GetDefaultRavenFormat());
+                pathBuilder.Append("&take=").Append(_take.Value);
+            }
+            else if (_take.HasValue) 
+                pathBuilder.Append("?take=").Append(_take.Value);
+            else if (_since.HasValue)
+                pathBuilder.Append("?since=").Append(_since.Value.GetDefaultRavenFormat());
+
+            url = pathBuilder.ToString();
+            return request;
+        }
+
+        public override void SetResponse(JsonOperationContext context, BlittableJsonReaderObject response, bool fromCache)
+        {
+            if (response == null)
+            {
+                Result = null;
+                return;
+            }
+            
+            Result = JsonDeserializationServer.ResolvedRevisions(response);
+        }
+
+        public override bool IsReadRequest => true;
+    }
+
+    public class ResolvedRevisions
+    {
+        public BlittableJsonReaderArray Results { get; set; }
+    }
+}

--- a/src/Raven.Server/Documents/Commands/Revisions/GetRevisionsDebugCommand.cs
+++ b/src/Raven.Server/Documents/Commands/Revisions/GetRevisionsDebugCommand.cs
@@ -7,13 +7,13 @@ namespace Raven.Server.Documents.Commands.Revisions
 {
     public class GetRevisionsDebugCommand : RavenCommand<BlittableJsonReaderObject>
     {
-        private readonly long? _etag;
+        private readonly long? _start;
         private readonly int? _pageSize;
 
-        public GetRevisionsDebugCommand(string nodeTag, long? etag, int? pageSize)
+        public GetRevisionsDebugCommand(string nodeTag, long? start, int? pageSize)
         {
             SelectedNodeTag = nodeTag;
-            _etag = etag;
+            _start = start;
             _pageSize = pageSize;
         }
 
@@ -29,15 +29,15 @@ namespace Raven.Server.Documents.Commands.Revisions
                 .Append(node.Database)
                 .Append("/debug/documents/get-revisions");
 
-            if (_etag.HasValue && _pageSize.HasValue)
+            if (_start.HasValue && _pageSize.HasValue)
             {
-                pathBuilder.Append("?etag=").Append(_etag.Value);
+                pathBuilder.Append("?start=").Append(_start.Value);
                 pathBuilder.Append("&pageSize=").Append(_pageSize.Value);
             }
             else if (_pageSize.HasValue)
                 pathBuilder.Append("?pageSize=").Append(_pageSize.Value);
-            else if (_etag.HasValue)
-                pathBuilder.Append("?etag=").Append(_etag.Value);
+            else if (_start.HasValue)
+                pathBuilder.Append("?start=").Append(_start.Value);
 
             url = pathBuilder.ToString();
             return request;

--- a/src/Raven.Server/Documents/Commands/Revisions/GetRevisionsDebugCommand.cs
+++ b/src/Raven.Server/Documents/Commands/Revisions/GetRevisionsDebugCommand.cs
@@ -1,0 +1,59 @@
+﻿using System.Net.Http;
+using System.Text;
+using Raven.Client.Http;
+using Sparrow.Json;
+
+namespace Raven.Server.Documents.Commands.Revisions
+{
+    public class GetRevisionsDebugCommand : RavenCommand<BlittableJsonReaderObject>
+    {
+        private readonly long? _etag;
+        private readonly int? _pageSize;
+
+        public GetRevisionsDebugCommand(string nodeTag, long? etag, int? pageSize)
+        {
+            SelectedNodeTag = nodeTag;
+            _etag = etag;
+            _pageSize = pageSize;
+        }
+
+        public override HttpRequestMessage CreateRequest(JsonOperationContext ctx, ServerNode node, out string url)
+        {
+            var request = new HttpRequestMessage
+            {
+                Method = HttpMethod.Get
+            };
+
+            var pathBuilder = new StringBuilder(node.Url)
+                .Append("/databases/")
+                .Append(node.Database)
+                .Append("/debug/documents/get-revisions");
+
+            if (_etag.HasValue && _pageSize.HasValue)
+            {
+                pathBuilder.Append("?etag=").Append(_etag.Value);
+                pathBuilder.Append("&pageSize=").Append(_pageSize.Value);
+            }
+            else if (_pageSize.HasValue)
+                pathBuilder.Append("?pageSize=").Append(_pageSize.Value);
+            else if (_etag.HasValue)
+                pathBuilder.Append("?etag=").Append(_etag.Value);
+
+            url = pathBuilder.ToString();
+            return request;
+        }
+
+        public override void SetResponse(JsonOperationContext context, BlittableJsonReaderObject response, bool fromCache)
+        {
+            if (response == null)
+            {
+                Result = null;
+                return;
+            }
+
+            Result = response;
+        }
+
+        public override bool IsReadRequest => true;
+    }
+}

--- a/src/Raven.Server/Documents/Handlers/Debugging/RevisionsHandler.cs
+++ b/src/Raven.Server/Documents/Handlers/Debugging/RevisionsHandler.cs
@@ -1,7 +1,6 @@
 ﻿using System.Threading.Tasks;
+using Raven.Server.Documents.Handlers.Processors.Revisions;
 using Raven.Server.Routing;
-using Raven.Server.ServerWide.Context;
-using Sparrow.Json;
 
 namespace Raven.Server.Documents.Handlers.Debugging
 {
@@ -10,47 +9,8 @@ namespace Raven.Server.Documents.Handlers.Debugging
         [RavenAction("/databases/*/debug/documents/get-revisions", "GET", AuthorizationStatus.ValidUser, EndpointType.Read)]
         public async Task GetRevisions()
         {
-            var etag = GetLongQueryString("etag", false) ?? 0;
-            var pageSize = GetPageSize();
-
-            using (ContextPool.AllocateOperationContext(out DocumentsOperationContext context))
-            using (context.OpenReadTransaction())
-            await using (var writer = new AsyncBlittableJsonTextWriter(context, ResponseBodyStream()))
-            {
-                writer.WriteStartObject();
-                writer.WritePropertyName("Revisions");
-                writer.WriteStartArray();
-
-                var first = true;
-                foreach (var revision in Database.DocumentsStorage.RevisionsStorage.GetRevisionsFrom(context, etag, pageSize))
-                {
-                    if (first == false)
-                        writer.WriteComma();
-                    first = false;
-
-                    writer.WriteStartObject();
-
-                    writer.WritePropertyName(nameof(Document.Id));
-                    writer.WriteString(revision.Id);
-                    writer.WriteComma();
-
-                    writer.WritePropertyName(nameof(Document.Etag));
-                    writer.WriteInteger(revision.Etag);
-                    writer.WriteComma();
-
-                    writer.WritePropertyName(nameof(Document.LastModified));
-                    writer.WriteDateTime(revision.LastModified, true);
-                    writer.WriteComma();
-
-                    writer.WritePropertyName(nameof(Document.ChangeVector));
-                    writer.WriteString(revision.ChangeVector);
-
-                    writer.WriteEndObject();
-                }
-
-                writer.WriteEndArray();
-                writer.WriteEndObject();
-            }
+            using (var processor = new RevisionsHandlerProcessorForGetRevisionsDebug(this))
+                await processor.ExecuteAsync();
         }
     }
 }

--- a/src/Raven.Server/Documents/Handlers/Processors/Revisions/AbstractRevisionsHandlerProcessorForGetResolvedRevisions.cs
+++ b/src/Raven.Server/Documents/Handlers/Processors/Revisions/AbstractRevisionsHandlerProcessorForGetResolvedRevisions.cs
@@ -1,0 +1,32 @@
+﻿using System;
+using System.Threading;
+using System.Threading.Tasks;
+using JetBrains.Annotations;
+using Sparrow.Json;
+
+namespace Raven.Server.Documents.Handlers.Processors.Revisions
+{
+    internal abstract class AbstractRevisionsHandlerProcessorForGetResolvedRevisions<TRequestHandler, TOperationContext> : AbstractDatabaseHandlerProcessor<TRequestHandler, TOperationContext>
+        where TOperationContext : JsonOperationContext
+        where TRequestHandler : AbstractDatabaseRequestHandler<TOperationContext>
+    {
+        protected AbstractRevisionsHandlerProcessorForGetResolvedRevisions([NotNull] TRequestHandler requestHandler) : base(requestHandler)
+        {
+        }
+
+        protected abstract ValueTask GetResolvedRevisionsAndWriteAsync(TOperationContext context, DateTime since, int take, CancellationToken token);
+        
+        public override async ValueTask ExecuteAsync()
+        {
+            var since = RequestHandler.GetStringQueryString("since", required: false);
+            var take = RequestHandler.GetIntValueQueryString("take", required: false) ?? 1024;
+            var date = Convert.ToDateTime(since).ToUniversalTime();
+
+            using (ContextPool.AllocateOperationContext(out TOperationContext context))
+            using (var token = RequestHandler.CreateOperationToken())
+            {
+                await GetResolvedRevisionsAndWriteAsync(context, since: date, take, token.Token);
+            }
+        }
+    }
+}

--- a/src/Raven.Server/Documents/Handlers/Processors/Revisions/AbstractRevisionsHandlerProcessorForGetRevisionsDebug.cs
+++ b/src/Raven.Server/Documents/Handlers/Processors/Revisions/AbstractRevisionsHandlerProcessorForGetRevisionsDebug.cs
@@ -1,0 +1,19 @@
+﻿using JetBrains.Annotations;
+using Sparrow.Json;
+
+namespace Raven.Server.Documents.Handlers.Processors.Revisions
+{
+    internal abstract class AbstractRevisionsHandlerProcessorForGetRevisionsDebug<TRequestHandler, TOperationContext> : AbstractHandlerProxyReadProcessor<BlittableJsonReaderObject ,TRequestHandler, TOperationContext>
+        where TOperationContext : JsonOperationContext
+        where TRequestHandler : AbstractDatabaseRequestHandler<TOperationContext>
+    {
+        protected AbstractRevisionsHandlerProcessorForGetRevisionsDebug([NotNull] TRequestHandler requestHandler) : base(requestHandler)
+        {
+        }
+
+        protected (long Start, int PageSize) GetParameters()
+        {
+            return (RequestHandler.GetLongQueryString("etag", false) ?? 0, RequestHandler.GetPageSize());
+        }
+    }
+}

--- a/src/Raven.Server/Documents/Handlers/Processors/Revisions/AbstractRevisionsHandlerProcessorForGetRevisionsDebug.cs
+++ b/src/Raven.Server/Documents/Handlers/Processors/Revisions/AbstractRevisionsHandlerProcessorForGetRevisionsDebug.cs
@@ -1,4 +1,6 @@
 ﻿using JetBrains.Annotations;
+using Raven.Client.Http;
+using Raven.Server.Documents.Commands.Revisions;
 using Sparrow.Json;
 
 namespace Raven.Server.Documents.Handlers.Processors.Revisions
@@ -13,7 +15,13 @@ namespace Raven.Server.Documents.Handlers.Processors.Revisions
 
         protected (long Start, int PageSize) GetParameters()
         {
-            return (RequestHandler.GetLongQueryString("etag", false) ?? 0, RequestHandler.GetPageSize());
+            return (RequestHandler.GetLongQueryString("start", false) ?? 0, RequestHandler.GetPageSize());
+        }
+
+        protected override RavenCommand<BlittableJsonReaderObject> CreateCommandForNode(string nodeTag)
+        {
+            var (start, pageSize) = GetParameters();
+            return new GetRevisionsDebugCommand(nodeTag, start, pageSize);
         }
     }
 }

--- a/src/Raven.Server/Documents/Handlers/Processors/Revisions/RevisionsHandlerProcessorForGetResolvedRevisions.cs
+++ b/src/Raven.Server/Documents/Handlers/Processors/Revisions/RevisionsHandlerProcessorForGetResolvedRevisions.cs
@@ -1,0 +1,32 @@
+﻿using System;
+using System.Threading;
+using System.Threading.Tasks;
+using JetBrains.Annotations;
+using Raven.Server.Documents.Commands.Revisions;
+using Raven.Server.Json;
+using Raven.Server.ServerWide.Context;
+using Sparrow.Json;
+
+namespace Raven.Server.Documents.Handlers.Processors.Revisions
+{
+    internal class RevisionsHandlerProcessorForGetResolvedRevisions : AbstractRevisionsHandlerProcessorForGetResolvedRevisions<DatabaseRequestHandler, DocumentsOperationContext>
+    {
+        public RevisionsHandlerProcessorForGetResolvedRevisions([NotNull] DatabaseRequestHandler requestHandler) : base(requestHandler)
+        {
+        }
+
+        protected override async ValueTask GetResolvedRevisionsAndWriteAsync(DocumentsOperationContext context, DateTime since, int take, CancellationToken token)
+        {
+            using (context.OpenReadTransaction())
+            await using (var writer = new AsyncBlittableJsonTextWriter(context, RequestHandler.ResponseBodyStream()))
+            {
+                var revisions = RequestHandler.Database.DocumentsStorage.RevisionsStorage.GetResolvedDocumentsSince(context, since, take);
+
+                writer.WriteStartObject();
+                writer.WritePropertyName(nameof(ResolvedRevisions.Results));
+                await writer.WriteDocumentsAsync(context, revisions, metadataOnly: false, token);
+                writer.WriteEndObject();
+            }
+        }
+    }
+}

--- a/src/Raven.Server/Documents/Handlers/Processors/Revisions/RevisionsHandlerProcessorForGetRevisionsDebug.cs
+++ b/src/Raven.Server/Documents/Handlers/Processors/Revisions/RevisionsHandlerProcessorForGetRevisionsDebug.cs
@@ -1,5 +1,4 @@
-﻿using System;
-using System.Threading.Tasks;
+﻿using System.Threading.Tasks;
 using JetBrains.Annotations;
 using Raven.Server.ServerWide;
 using Raven.Server.ServerWide.Context;
@@ -13,11 +12,12 @@ namespace Raven.Server.Documents.Handlers.Processors.Revisions
         public RevisionsHandlerProcessorForGetRevisionsDebug([NotNull] DatabaseRequestHandler requestHandler) : base(requestHandler)
         {
         }
-
+        
         protected override bool SupportsCurrentNode => true;
+
         protected override async ValueTask HandleCurrentNodeAsync()
         {
-            var (etag, pageSize) = GetParameters();
+            var (start, pageSize) = GetParameters();
 
             using (ContextPool.AllocateOperationContext(out DocumentsOperationContext context))
             using (context.OpenReadTransaction())
@@ -28,7 +28,7 @@ namespace Raven.Server.Documents.Handlers.Processors.Revisions
                 writer.WriteStartArray();
 
                 var first = true;
-                foreach (var revision in RequestHandler.Database.DocumentsStorage.RevisionsStorage.GetRevisionsFrom(context, etag, pageSize))
+                foreach (var revision in RequestHandler.Database.DocumentsStorage.RevisionsStorage.GetRevisionsFrom(context, start, pageSize))
                 {
                     if (first == false)
                         writer.WriteComma();
@@ -59,9 +59,9 @@ namespace Raven.Server.Documents.Handlers.Processors.Revisions
             }
         }
 
-        protected override Task HandleRemoteNodeAsync(ProxyCommand<BlittableJsonReaderObject> command, OperationCancelToken token)
+        protected override async Task HandleRemoteNodeAsync(ProxyCommand<BlittableJsonReaderObject> command, OperationCancelToken token)
         {
-            throw new NotImplementedException();
+            await RequestHandler.ExecuteRemoteAsync(command, token.Token);
         }
     }
 }

--- a/src/Raven.Server/Documents/Handlers/Processors/Revisions/RevisionsHandlerProcessorForGetRevisionsDebug.cs
+++ b/src/Raven.Server/Documents/Handlers/Processors/Revisions/RevisionsHandlerProcessorForGetRevisionsDebug.cs
@@ -1,0 +1,67 @@
+﻿using System;
+using System.Threading.Tasks;
+using JetBrains.Annotations;
+using Raven.Server.ServerWide;
+using Raven.Server.ServerWide.Context;
+using Raven.Server.Web.Http;
+using Sparrow.Json;
+
+namespace Raven.Server.Documents.Handlers.Processors.Revisions
+{
+    internal class RevisionsHandlerProcessorForGetRevisionsDebug : AbstractRevisionsHandlerProcessorForGetRevisionsDebug<DatabaseRequestHandler, DocumentsOperationContext>
+    {
+        public RevisionsHandlerProcessorForGetRevisionsDebug([NotNull] DatabaseRequestHandler requestHandler) : base(requestHandler)
+        {
+        }
+
+        protected override bool SupportsCurrentNode => true;
+        protected override async ValueTask HandleCurrentNodeAsync()
+        {
+            var (etag, pageSize) = GetParameters();
+
+            using (ContextPool.AllocateOperationContext(out DocumentsOperationContext context))
+            using (context.OpenReadTransaction())
+            await using (var writer = new AsyncBlittableJsonTextWriter(context, RequestHandler.ResponseBodyStream()))
+            {
+                writer.WriteStartObject();
+                writer.WritePropertyName("Revisions");
+                writer.WriteStartArray();
+
+                var first = true;
+                foreach (var revision in RequestHandler.Database.DocumentsStorage.RevisionsStorage.GetRevisionsFrom(context, etag, pageSize))
+                {
+                    if (first == false)
+                        writer.WriteComma();
+                    first = false;
+
+                    writer.WriteStartObject();
+
+                    writer.WritePropertyName(nameof(Document.Id));
+                    writer.WriteString(revision.Id);
+                    writer.WriteComma();
+
+                    writer.WritePropertyName(nameof(Document.Etag));
+                    writer.WriteInteger(revision.Etag);
+                    writer.WriteComma();
+
+                    writer.WritePropertyName(nameof(Document.LastModified));
+                    writer.WriteDateTime(revision.LastModified, true);
+                    writer.WriteComma();
+
+                    writer.WritePropertyName(nameof(Document.ChangeVector));
+                    writer.WriteString(revision.ChangeVector);
+
+                    writer.WriteEndObject();
+                }
+
+                writer.WriteEndArray();
+                writer.WriteEndObject();
+            }
+        }
+
+        protected override Task HandleRemoteNodeAsync(ProxyCommand<BlittableJsonReaderObject> command, OperationCancelToken token)
+        {
+            throw new NotImplementedException();
+        }
+    }
+}

--- a/src/Raven.Server/Documents/Revisions/RevisionsStorage.cs
+++ b/src/Raven.Server/Documents/Revisions/RevisionsStorage.cs
@@ -1683,7 +1683,7 @@ namespace Raven.Server.Documents.Revisions
                 var document = TableValueToRevision(context, ref tvr.Reader);
                 yield return document;
 
-                if (take-- <= 0)
+                if (--take <= 0)
                     yield break;
             }
         }

--- a/src/Raven.Server/Documents/Sharding/Handlers/Processors/Revisions/ShardedRevisionsHandlerProcessorForGetResolvedRevisions.cs
+++ b/src/Raven.Server/Documents/Sharding/Handlers/Processors/Revisions/ShardedRevisionsHandlerProcessorForGetResolvedRevisions.cs
@@ -1,0 +1,74 @@
+﻿using System;
+using System.Collections.Generic;
+using System.Threading;
+using System.Threading.Tasks;
+using JetBrains.Annotations;
+using Microsoft.AspNetCore.Http;
+using Raven.Client.Http;
+using Raven.Server.Documents.Commands.Revisions;
+using Raven.Server.Documents.Handlers.Processors.Revisions;
+using Raven.Server.Documents.Sharding.Operations;
+using Raven.Server.ServerWide.Context;
+using Sparrow.Json;
+
+namespace Raven.Server.Documents.Sharding.Handlers.Processors.Revisions
+{
+    internal class ShardedRevisionsHandlerProcessorForGetResolvedRevisions : AbstractRevisionsHandlerProcessorForGetResolvedRevisions<ShardedDatabaseRequestHandler, TransactionOperationContext>
+    {
+        public ShardedRevisionsHandlerProcessorForGetResolvedRevisions([NotNull] ShardedDatabaseRequestHandler requestHandler) : base(requestHandler)
+        {
+        }
+
+        protected override async ValueTask GetResolvedRevisionsAndWriteAsync(TransactionOperationContext context, DateTime since, int take, CancellationToken token)
+        {
+            var op = new ShardedGetResolvedRevisionsOperation(context, RequestHandler.HttpContext, since, take);
+            var revisions = await RequestHandler.ShardExecutor.ExecuteParallelForAllAsync(op, token);
+
+            using (context.OpenReadTransaction())
+            await using (var writer = new AsyncBlittableJsonTextWriter(context, RequestHandler.ResponseBodyStream()))
+            {
+                writer.WriteStartObject();
+                await writer.WriteArrayAsync(nameof(ResolvedRevisions.Results), revisions);
+                writer.WriteEndObject();
+            }
+        }
+    }
+
+    internal readonly struct ShardedGetResolvedRevisionsOperation : IShardedOperation<ResolvedRevisions, List<BlittableJsonReaderObject>>
+    {
+        private readonly JsonOperationContext _context;
+        private readonly HttpContext _httpContext;
+        private readonly DateTime _since;
+        private readonly int _take;
+
+        public ShardedGetResolvedRevisionsOperation(JsonOperationContext context, HttpContext httpContext, DateTime since, int take)
+        {
+            _context = context;
+            _httpContext = httpContext;
+            _since = since;
+            _take = take;
+        }
+
+        public HttpRequest HttpRequest => _httpContext.Request;
+
+        public List<BlittableJsonReaderObject> Combine(Memory<ResolvedRevisions> results)
+        {
+            var combined = new List<BlittableJsonReaderObject>();
+
+            foreach (var revisions in results.Span)
+            {
+                if(revisions == null)
+                    continue;
+                
+                foreach (BlittableJsonReaderObject revision in revisions.Results)
+                {
+                    combined.Add(revision.Clone(_context));
+                }
+            }
+
+            return combined;
+        }
+
+        public RavenCommand<ResolvedRevisions> CreateCommandForShard(int shardNumber) => new GetResolvedRevisionsCommand(_since, _take);
+    }
+}

--- a/src/Raven.Server/Documents/Sharding/Handlers/Processors/Revisions/ShardedRevisionsHandlerProcessorForGetRevisionsDebug.cs
+++ b/src/Raven.Server/Documents/Sharding/Handlers/Processors/Revisions/ShardedRevisionsHandlerProcessorForGetRevisionsDebug.cs
@@ -1,0 +1,38 @@
+﻿using System;
+using System.Threading.Tasks;
+using JetBrains.Annotations;
+using Raven.Client.Http;
+using Raven.Server.Documents.Commands.Revisions;
+using Raven.Server.Documents.Handlers.Processors.Revisions;
+using Raven.Server.ServerWide;
+using Raven.Server.ServerWide.Context;
+using Raven.Server.Web.Http;
+using Sparrow.Json;
+
+namespace Raven.Server.Documents.Sharding.Handlers.Processors.Revisions
+{
+    internal class ShardedRevisionsHandlerProcessorForGetRevisionsDebug : AbstractRevisionsHandlerProcessorForGetRevisionsDebug<ShardedDatabaseRequestHandler, TransactionOperationContext>
+    {
+        public ShardedRevisionsHandlerProcessorForGetRevisionsDebug([NotNull] ShardedDatabaseRequestHandler requestHandler) : base(requestHandler)
+        {
+        }
+
+        protected override bool SupportsCurrentNode => false;
+        protected override ValueTask HandleCurrentNodeAsync()
+        {
+            throw new NotImplementedException();
+        }
+
+        protected override Task HandleRemoteNodeAsync(ProxyCommand<BlittableJsonReaderObject> command, OperationCancelToken token)
+        {
+            var shardNumber = GetShardNumber();
+            return RequestHandler.ShardExecutor.ExecuteSingleShardAsync(command, shardNumber, token.Token);
+        }
+
+        protected override RavenCommand<BlittableJsonReaderObject> CreateCommandForNode(string nodeTag)
+        {
+            var (etag, pageSize) = GetParameters();
+            return new GetRevisionsDebugCommand(nodeTag, etag, pageSize);
+        }
+    }
+}

--- a/src/Raven.Server/Documents/Sharding/Handlers/Processors/Revisions/ShardedRevisionsHandlerProcessorForGetRevisionsDebug.cs
+++ b/src/Raven.Server/Documents/Sharding/Handlers/Processors/Revisions/ShardedRevisionsHandlerProcessorForGetRevisionsDebug.cs
@@ -18,21 +18,16 @@ namespace Raven.Server.Documents.Sharding.Handlers.Processors.Revisions
         }
 
         protected override bool SupportsCurrentNode => false;
+
         protected override ValueTask HandleCurrentNodeAsync()
         {
-            throw new NotImplementedException();
+            throw new NotSupportedException();
         }
 
         protected override Task HandleRemoteNodeAsync(ProxyCommand<BlittableJsonReaderObject> command, OperationCancelToken token)
         {
             var shardNumber = GetShardNumber();
             return RequestHandler.ShardExecutor.ExecuteSingleShardAsync(command, shardNumber, token.Token);
-        }
-
-        protected override RavenCommand<BlittableJsonReaderObject> CreateCommandForNode(string nodeTag)
-        {
-            var (etag, pageSize) = GetParameters();
-            return new GetRevisionsDebugCommand(nodeTag, etag, pageSize);
         }
     }
 }

--- a/src/Raven.Server/Documents/Sharding/Handlers/ShardedRevisionsHandler.cs
+++ b/src/Raven.Server/Documents/Sharding/Handlers/ShardedRevisionsHandler.cs
@@ -58,5 +58,12 @@ namespace Raven.Server.Documents.Sharding.Handlers
             using (var processor = new ShardedRevisionsHandlerProcessorForRevertRevisions(this))
                 await processor.ExecuteAsync();
         }
+
+        [RavenShardedAction("/databases/*/revisions/resolved", "GET")]
+        public async Task GetResolvedConflictsSince()
+        {
+            using (var processor = new ShardedRevisionsHandlerProcessorForGetResolvedRevisions(this))
+                await processor.ExecuteAsync();
+        }
     }
 }

--- a/src/Raven.Server/Documents/Sharding/Handlers/ShardedRevisionsHandler.cs
+++ b/src/Raven.Server/Documents/Sharding/Handlers/ShardedRevisionsHandler.cs
@@ -65,5 +65,12 @@ namespace Raven.Server.Documents.Sharding.Handlers
             using (var processor = new ShardedRevisionsHandlerProcessorForGetResolvedRevisions(this))
                 await processor.ExecuteAsync();
         }
+
+        [RavenShardedAction("/databases/*/debug/documents/get-revisions", "GET")]
+        public async Task GetRevisions()
+        {
+            using (var processor = new ShardedRevisionsHandlerProcessorForGetRevisionsDebug(this))
+                await processor.ExecuteAsync();
+        }
     }
 }

--- a/src/Raven.Server/Json/JsonDeserializationServer.cs
+++ b/src/Raven.Server/Json/JsonDeserializationServer.cs
@@ -27,6 +27,7 @@ using Raven.Server.Commercial;
 using Raven.Server.Documents.Commands;
 using Raven.Server.Documents.Commands.ETL;
 using Raven.Server.Documents.Commands.Indexes;
+using Raven.Server.Documents.Commands.Revisions;
 using Raven.Server.Documents.ETL.Providers.ElasticSearch.Test;
 using Raven.Server.Documents.ETL.Providers.OLAP.Test;
 using Raven.Server.Documents.ETL.Providers.Raven.Test;
@@ -235,6 +236,8 @@ namespace Raven.Server.Json
         public static readonly Func<BlittableJsonReaderObject, GetIndexErrorsCountCommand.IndexErrorsCount> IndexErrorsCount = GenerateJsonDeserializationRoutine<GetIndexErrorsCountCommand.IndexErrorsCount>();
 
         public static readonly Func<BlittableJsonReaderObject, LastChangeVectorForCollectionResult> LastChangeVectorForCollectionResult = GenerateJsonDeserializationRoutine<LastChangeVectorForCollectionResult>();
+
+        public static readonly Func<BlittableJsonReaderObject, ResolvedRevisions> ResolvedRevisions = GenerateJsonDeserializationRoutine<ResolvedRevisions>();
 
         public static readonly Func<BlittableJsonReaderObject, GetConflictsPreviewResult> GetConflictResults = GenerateJsonDeserializationRoutine<GetConflictsPreviewResult>();
 


### PR DESCRIPTION
### Issue link

https://issues.hibernatingrhinos.com/issue/RavenDB-18727

`GET /databases/*/revisions/resolved`: Test for sharding skipped until external replication is done

`GET /databases/*/debug/documents/get-revisions` : Made into proxy processor. Tested manually