### PR TITLE
RavenDB-15213 - Tomstones_should_be_cleaned_properly_for_multiple_bac…

### DIFF
--- a/test/SlowTests/Issues/RavenDB_8369.cs
+++ b/test/SlowTests/Issues/RavenDB_8369.cs
@@ -1,4 +1,6 @@
-﻿using System.Linq;
+﻿using System;
+using System.Linq;
+using System.Threading;
 using System.Threading.Tasks;
 using FastTests.Server.Replication;
 using Raven.Client.Documents.Operations.Backups;
@@ -81,8 +83,12 @@ namespace SlowTests.Issues
                     session.Delete("foo/bar1");
                     session.SaveChanges();
                 }
-                var config1 = Backup.CreateBackupConfiguration(backupPath1, backupType: backupType, incrementalBackupFrequency: "* */6 * * *");
-                var config2 = Backup.CreateBackupConfiguration(backupPath2, backupType: backupType, incrementalBackupFrequency: "* */6 * * *");
+
+                int hour = (DateTime.Now.Hour + 1)%24;
+                var timeCronExpression = $"30 {hour} * * *"; // happen in the middle of the next hour - cause the periodic backups to happen in a 30 minutes at least 
+
+                var config1 = Backup.CreateBackupConfiguration(backupPath1, backupType: backupType, incrementalBackupFrequency: timeCronExpression);
+                var config2 = Backup.CreateBackupConfiguration(backupPath2, backupType: backupType, incrementalBackupFrequency: timeCronExpression);
                 var backupTaskId1 = await Backup.UpdateConfigAndRunBackupAsync(Server, config1, store, isFullBackup: false);
                 await Backup.UpdateConfigAndRunBackupAsync(Server, config2, store, isFullBackup: false);
 
@@ -105,6 +111,7 @@ namespace SlowTests.Issues
                 }
 
                 await Backup.RunBackupAsync(Server, backupTaskId1, store, isFullBackup: false);
+
                 await documentDatabase.TombstoneCleaner.ExecuteCleanup(1);
 
                 //since we ran only one of backup tasks, only tombstones with minimal last etag get cleaned


### PR DESCRIPTION
### Issue link

https://issues.hibernatingrhinos.com/issue/RavenDB-15213

### Additional description

Fixing SlowTests.Issues.RavenDB_8369.Tomstones_should_be_cleaned_properly_for_multiple_backup_tasks_for_snapshot failure.
Tombstones count in the end should be 1 but it's 0.

### Type of change

- Bug fix

### How risky is the change?

- Low 

### Backward compatibility

- Not relevant

### Is it platform specific issue?

- No

### Documentation update

- No documentation update is needed 

### Testing 

- Tests have been added that prove the fix is effective or that the feature works

### Is there any existing behavior change of other features due to this change?

- No

### UI work

- No UI work is needed
