### PR TITLE
RavenDB-18613 - Remove ClusterWideTransaction_WhenRestoreFromIncrementalBackupAfterStoreAndDelete_ShouldDeleteInTheDestination test log if we cant reproduce the bug in 2 weeks

### DIFF
--- a/test/RachisTests/DatabaseCluster/AtomicClusterReadWriteTests.cs
+++ b/test/RachisTests/DatabaseCluster/AtomicClusterReadWriteTests.cs
@@ -286,9 +286,6 @@ namespace RachisTests.DatabaseCluster
             var (nodes, leader) = await CreateRaftCluster(3);
             using var documentStore = GetDocumentStore(new Options { Server = leader, ReplicationFactor = nodes.Count });
 
-            using var socket = new DummyWebSocket();
-            var _ = LoggingSource.Instance.Register(socket, new LoggingSource.WebSocketContext(), CancellationToken.None);
-
             var notDelete = $"TestObjs/{count}";
             using (var source = GetDocumentStore())
             {
@@ -333,14 +330,7 @@ namespace RachisTests.DatabaseCluster
                 return await session.LoadAsync<TestObj>(notDelete);
             });
 
-            var r = await WaitForSingleAsync(async () => await documentStore.Operations.SendAsync(new GetCompareExchangeValuesOperation<TestObj>("")),timeout: 15_000);
-            if (r.Count != 1)
-            {
-                // temp loggin to solve issue RavenDB-17890.
-                var logs = await socket.CloseAndGetLogsAsync();
-                Assert.True(false, $"Count is {r.Count} ,logs={logs}");
-            }
-
+            var r = await AssertWaitForSingleAsync(async () => await documentStore.Operations.SendAsync(new GetCompareExchangeValuesOperation<TestObj>("")));
             Assert.EndsWith(notDelete, r.Single().Key, StringComparison.OrdinalIgnoreCase);
         }
 


### PR DESCRIPTION
### Issue link

https://issues.hibernatingrhinos.com/issue/RavenDB-18666

### Additional description

Remove ClusterWideTransaction_WhenRestoreFromIncrementalBackupAfterStoreAndDelete_ShouldDeleteInTheDestination test log because we couldn't reproduce the bug in 2 weeks.

### Type of change

- Bug fix

### How risky is the change?

- Low 

### Backward compatibility

- Not relevant

### Is it platform specific issue?

- No

### Documentation update

- No documentation update is needed 

### Testing 

- Tests have been added that prove the fix is effective or that the feature works

### Is there any existing behavior change of other features due to this change?

- No

### UI work

- No UI work is needed
