### PR TITLE
RavenDB-18812 do not failover when WaitForIndexes timeout

### DIFF
--- a/src/Raven.Client/Exceptions/ExceptionDispatcher.cs
+++ b/src/Raven.Client/Exceptions/ExceptionDispatcher.cs
@@ -63,6 +63,17 @@ namespace Raven.Client.Exceptions
             return exception;
         }
 
+        public static Exception Get(BlittableJsonReaderObject json, HttpStatusCode code, Exception inner = null)
+        {
+            var schema = GetExceptionSchema(code, json);
+
+            var exception = Get(schema, code, inner);
+
+            FillException(exception, json);
+
+            return exception;
+        }
+
         public static async Task Throw(JsonOperationContext context, HttpResponseMessage response, Action<StringBuilder> additionalErrorInfo = null)
         {
             if (response == null)
@@ -71,7 +82,7 @@ namespace Raven.Client.Exceptions
             using (var stream = await RequestExecutor.ReadAsStreamUncompressedAsync(response).ConfigureAwait(false))
             using (var json = await GetJson(context, response, stream).ConfigureAwait(false))
             {
-                var schema = GetExceptionSchema(response, json);
+                var schema = GetExceptionSchema(response.StatusCode, json);
 
                 if (response.StatusCode == HttpStatusCode.Conflict)
                 {
@@ -107,16 +118,23 @@ namespace Raven.Client.Exceptions
                 if (typeof(RavenException).IsAssignableFrom(type) == false)
                     throw new RavenException(schema.Error, exception);
 
-                if (type == typeof(IndexCompilationException))
-                {
-                    var indexCompilationException = (IndexCompilationException)exception;
-                    json.TryGet(nameof(IndexCompilationException.IndexDefinitionProperty), out indexCompilationException.IndexDefinitionProperty);
-                    json.TryGet(nameof(IndexCompilationException.ProblematicText), out indexCompilationException.ProblematicText);
-
-                    throw indexCompilationException;
-                }
+                FillException(exception, json);
 
                 throw exception;
+            }
+        }
+
+        private static void FillException(Exception exception, BlittableJsonReaderObject json)
+        {
+            switch (exception)
+            {
+                case IndexCompilationException indexCompilationException:
+                    json.TryGet(nameof(IndexCompilationException.IndexDefinitionProperty), out indexCompilationException.IndexDefinitionProperty);
+                    json.TryGet(nameof(IndexCompilationException.ProblematicText), out indexCompilationException.ProblematicText);
+                    break;
+                case RavenTimeoutException timeoutException:
+                    json.TryGet(nameof(RavenTimeoutException.FailImmediately), out timeoutException.FailImmediately);
+                    break;
             }
         }
 
@@ -184,7 +202,7 @@ namespace Raven.Client.Exceptions
             return Type.GetType(typeAsString, throwOnError: false);
         }
 
-        private static ExceptionSchema GetExceptionSchema(HttpResponseMessage response, BlittableJsonReaderObject json)
+        private static ExceptionSchema GetExceptionSchema(HttpStatusCode code, BlittableJsonReaderObject json)
         {
             ExceptionSchema schema;
             try
@@ -193,20 +211,20 @@ namespace Raven.Client.Exceptions
             }
             catch (Exception e)
             {
-                throw new InvalidOperationException($"Cannot deserialize the {response.StatusCode} response. JSON: {json}", e);
+                throw new InvalidOperationException($"Cannot deserialize the {code} response. JSON: {json}", e);
             }
 
             if (schema == null)
-                throw new BadResponseException($"After deserialization the {response.StatusCode} response is null. JSON: {json}");
+                throw new BadResponseException($"After deserialization the {code} response is null. JSON: {json}");
 
             if (schema.Message == null)
-                throw new BadResponseException($"After deserialization the {response.StatusCode} response property '{nameof(schema.Message)}' is null. JSON: {json}");
+                throw new BadResponseException($"After deserialization the {code} response property '{nameof(schema.Message)}' is null. JSON: {json}");
 
             if (schema.Error == null)
-                throw new BadResponseException($"After deserialization the {response.StatusCode} response property '{nameof(schema.Error)}' is null. JSON: {json}");
+                throw new BadResponseException($"After deserialization the {code} response property '{nameof(schema.Error)}' is null. JSON: {json}");
 
             if (schema.Type == null)
-                throw new BadResponseException($"After deserialization the {response.StatusCode} response property '{nameof(schema.Type)}' is null. JSON: {json}");
+                throw new BadResponseException($"After deserialization the {code} response property '{nameof(schema.Type)}' is null. JSON: {json}");
 
             return schema;
         }

--- a/src/Raven.Client/Exceptions/RavenTimeoutException.cs
+++ b/src/Raven.Client/Exceptions/RavenTimeoutException.cs
@@ -1,0 +1,22 @@
+﻿using System;
+
+namespace Raven.Client.Exceptions;
+
+public class RavenTimeoutException : RavenException
+{
+    public RavenTimeoutException()
+    {
+    }
+
+    public RavenTimeoutException(string message)
+        : base(message)
+    {
+    }
+
+    public RavenTimeoutException(string message, Exception inner)
+        : base(message, inner)
+    {
+    }
+
+    public bool FailImmediately;
+}

--- a/src/Raven.Client/Http/RequestExecutor.cs
+++ b/src/Raven.Client/Http/RequestExecutor.cs
@@ -915,7 +915,7 @@ namespace Raven.Client.Http
                 refreshTask = UpdateTopologyAsync(
                     new UpdateTopologyParameters(chosenNode)
                     {
-                        TimeoutInMs = 0, 
+                        TimeoutInMs = 0,
                         DebugTag = "refresh-topology-header"
                     });
             }
@@ -1056,7 +1056,7 @@ namespace Raven.Client.Http
             if (chosenNode.ShouldUpdateServerVersion())
             {
                 if (TryGetServerVersion(response, out var serverVersion))
-                    chosenNode.UpdateServerVersion(serverVersion);                    
+                    chosenNode.UpdateServerVersion(serverVersion);
             }
 
             LastServerVersion = chosenNode.LastServerVersion;
@@ -1442,7 +1442,7 @@ namespace Raven.Client.Http
                     var nextNode = ChooseNodeForRequest(command, sessionInfo);
 
                     await ExecuteAsync(nextNode.CurrentNode, nextNode.CurrentIndex, context, command, shouldRetry: true, sessionInfo: sessionInfo, token: token).ConfigureAwait(false);
-                    
+
                     if (nodeIndex.HasValue)
                         _nodeSelector.RestoreNodeIndex(nodeIndex.Value);
 
@@ -1489,10 +1489,13 @@ namespace Raven.Client.Http
         private async Task<bool> HandleServerDown<TResult>(string url, ServerNode chosenNode, int? nodeIndex, JsonOperationContext context, RavenCommand<TResult> command,
             HttpRequestMessage request, HttpResponseMessage response, Exception e, SessionInfo sessionInfo, bool shouldRetry, RequestContext requestContext = null, CancellationToken token = default)
         {
-            if (command.FailedNodes == null)
-                command.FailedNodes = new Dictionary<ServerNode, Exception>();
+            command.FailedNodes ??= new Dictionary<ServerNode, Exception>();
 
-            command.FailedNodes[chosenNode] = await ReadExceptionFromServer(context, request, response, e).ConfigureAwait(false);
+            var exception = await ReadExceptionFromServer(context, request, response, e).ConfigureAwait(false);
+            if (exception is RavenTimeoutException { FailImmediately: true })
+                throw exception;
+
+            command.FailedNodes[chosenNode] = exception;
 
             if (nodeIndex.HasValue == false)
             {
@@ -1803,7 +1806,7 @@ namespace Raven.Client.Http
                     ms.Position = 0;
                     using (var responseJson = await context.ReadForMemoryAsync(ms, "RequestExecutor/HandleServerDown/ReadResponseContent").ConfigureAwait(false))
                     {
-                        return ExceptionDispatcher.Get(JsonDeserializationClient.ExceptionSchema(responseJson), response.StatusCode, e);
+                        return ExceptionDispatcher.Get(responseJson, response.StatusCode, e);
                     }
                 }
                 catch

--- a/src/Raven.Server/RavenServerStartup.cs
+++ b/src/Raven.Server/RavenServerStartup.cs
@@ -306,7 +306,7 @@ namespace Raven.Server
             TrafficWatchManager.DispatchMessage(twn);
         }
 
-        private void MaybeAddAdditionalExceptionData(DynamicJsonValue djv, Exception exception)
+        private static void MaybeAddAdditionalExceptionData(DynamicJsonValue djv, Exception exception)
         {
             if (exception is IndexCompilationException indexCompilationException)
             {
@@ -326,6 +326,11 @@ namespace Raven.Server
                 djv[nameof(ConcurrencyException.Id)] = concurrencyException.Id;
                 djv[nameof(ConcurrencyException.ExpectedChangeVector)] = concurrencyException.ExpectedChangeVector;
                 djv[nameof(ConcurrencyException.ActualChangeVector)] = concurrencyException.ActualChangeVector;
+            }
+
+            if (exception is RavenTimeoutException timeoutException)
+            {
+                djv[nameof(RavenTimeoutException.FailImmediately)] = timeoutException.FailImmediately;
             }
 
             if (exception is ClusterTransactionConcurrencyException { ConcurrencyViolations: { } } ctxConcurrencyException)
@@ -372,7 +377,7 @@ namespace Raven.Server
                 exception is DatabaseConcurrentLoadTimeoutException ||
                 exception is NodeIsPassiveException ||
                 exception is ClientVersionMismatchException ||
-                exception is DatabaseSchemaErrorException || 
+                exception is DatabaseSchemaErrorException ||
                 exception is DatabaseIdleException
                 )
             {
@@ -399,7 +404,7 @@ namespace Raven.Server
                 return;
             }
 
-            if (exception is TimeoutException)
+            if (exception is TimeoutException or RavenTimeoutException)
             {
                 response.StatusCode = (int)HttpStatusCode.RequestTimeout;
                 return;

--- a/test/SlowTests/Issues/RavenDB-15497.cs
+++ b/test/SlowTests/Issues/RavenDB-15497.cs
@@ -1,17 +1,21 @@
 ﻿using System;
+using System.Collections.Generic;
 using System.Linq;
 using System.Threading.Tasks;
-using FastTests;
+using Raven.Client.Documents;
+using Raven.Client.Documents.Conventions;
 using Raven.Client.Documents.Indexes;
 using Raven.Client.Documents.Operations.Indexes;
 using Raven.Client.Exceptions;
+using Raven.Server;
 using Raven.Tests.Core.Utils.Entities;
+using Tests.Infrastructure;
 using Xunit;
 using Xunit.Abstractions;
 
 namespace SlowTests.Issues
 {
-    public class RavenDB_15497 : RavenTestBase
+    public class RavenDB_15497 : ClusterTestBase
     {
         public RavenDB_15497(ITestOutputHelper output) : base(output)
         {
@@ -48,8 +52,88 @@ namespace SlowTests.Issues
                     });
                     session.Advanced.WaitForIndexesAfterSaveChanges(timeout: TimeSpan.FromSeconds(3), throwOnTimeout: true);
 
-                    var error = Assert.Throws<RavenException>(() => session.SaveChanges());
-                    Assert.StartsWith("System.TimeoutException", error.Message);
+                    var error = Assert.Throws<RavenTimeoutException>(() => session.SaveChanges());
+                    Assert.StartsWith("Raven.Client.Exceptions.RavenTimeoutException", error.Message);
+                    Assert.Contains("could not verify that all indexes has caught up with the changes as of etag", error.Message);
+                    Assert.Contains("total paused indexes: 1", error.Message);
+                    Assert.DoesNotContain("total errored indexes", error.Message);
+                }
+            }
+        }
+
+        [Fact]
+        public async Task WaitForIndexesAfterSaveChangesCanExitWhenThrowOnTimeoutIsFalse_Cluster()
+        {
+            var databaseName = GetDatabaseName();
+            (List<RavenServer> _, RavenServer leader) = await CreateRaftCluster(3);
+            var (raftIndex, dbGroupNodes) = await CreateDatabaseInCluster(databaseName, 3, leader.WebUrl);
+            await Cluster.WaitForRaftIndexToBeAppliedInClusterAsync(raftIndex, TimeSpan.FromSeconds(30));
+
+            using (var store = new DocumentStore
+            {
+                Database = databaseName,
+                Urls = new[] { dbGroupNodes[0].WebUrl }
+            }.Initialize())
+            using (var store1 = new DocumentStore
+            {
+                Database = databaseName,
+                Urls = new[] { dbGroupNodes[0].WebUrl },
+                Conventions = new DocumentConventions
+                {
+                    DisableTopologyUpdates = true
+                }
+            }.Initialize())
+            using (var store2 = new DocumentStore
+            {
+                Database = databaseName,
+                Urls = new[] { dbGroupNodes[1].WebUrl },
+                Conventions = new DocumentConventions
+                {
+                    DisableTopologyUpdates = true
+                }
+            }.Initialize())
+            using (var store3 = new DocumentStore
+            {
+                Database = databaseName,
+                Urls = new[] { dbGroupNodes[2].WebUrl },
+                Conventions = new DocumentConventions
+                {
+                    DisableTopologyUpdates = true
+                }
+            }.Initialize())
+            {
+                var index = new Index();
+                await index.ExecuteAsync(store);
+
+                using (var session = store.OpenSession())
+                {
+                    session.Store(new User
+                    {
+                        Name = "user1",
+                        Count = 3
+                    });
+                    session.Advanced.WaitForIndexesAfterSaveChanges(timeout: TimeSpan.FromSeconds(10), throwOnTimeout: false);
+                    session.SaveChanges();
+                }
+
+                Indexes.WaitForIndexing(store1);
+                Indexes.WaitForIndexing(store2);
+                Indexes.WaitForIndexing(store3);
+
+                await store1.Maintenance.SendAsync(new StopIndexOperation(index.IndexName));
+                await store2.Maintenance.SendAsync(new StopIndexOperation(index.IndexName));
+                await store3.Maintenance.SendAsync(new StopIndexOperation(index.IndexName));
+
+                using (var session = store.OpenSession())
+                {
+                    session.Store(new User
+                    {
+                        Name = "user1"
+                    });
+                    session.Advanced.WaitForIndexesAfterSaveChanges(timeout: TimeSpan.FromSeconds(10), throwOnTimeout: true);
+
+                    var error = Assert.Throws<RavenTimeoutException>(() => session.SaveChanges());
+                    Assert.StartsWith("Raven.Client.Exceptions.RavenTimeoutException", error.Message);
                     Assert.Contains("could not verify that all indexes has caught up with the changes as of etag", error.Message);
                     Assert.Contains("total paused indexes: 1", error.Message);
                     Assert.DoesNotContain("total errored indexes", error.Message);

--- a/test/SlowTests/Issues/RavenDB-18688.cs
+++ b/test/SlowTests/Issues/RavenDB-18688.cs
@@ -45,8 +45,8 @@ namespace SlowTests.Issues
                             Name = "Grisha"
                         });
                     session.Advanced.WaitForIndexesAfterSaveChanges(timeout: TimeSpan.FromSeconds(5), indexes: new[] { index.IndexName });
-                    var error = await Assert.ThrowsAsync<RavenException>(async () => await session.SaveChangesAsync());
-                    Assert.StartsWith("System.TimeoutException", error.Message);
+                    var error = await Assert.ThrowsAsync<RavenTimeoutException>(async () => await session.SaveChangesAsync());
+                    Assert.StartsWith("Raven.Client.Exceptions.RavenTimeoutException", error.Message);
                     Assert.Contains("could not verify that all indexes has caught up with the changes as of etag", error.Message);
                     Assert.Contains("Total relevant indexes: 1, total stale indexes: 1", error.Message);
                     Assert.DoesNotContain("total paused indexes", error.Message);
@@ -88,8 +88,8 @@ namespace SlowTests.Issues
                             Count = 0
                         });
                     session.Advanced.WaitForIndexesAfterSaveChanges(timeout: TimeSpan.FromSeconds(5));
-                    var error = await Assert.ThrowsAsync<RavenException>(async () => await session.SaveChangesAsync());
-                    Assert.StartsWith("System.TimeoutException", error.Message);
+                    var error = await Assert.ThrowsAsync<RavenTimeoutException>(async () => await session.SaveChangesAsync());
+                    Assert.StartsWith("Raven.Client.Exceptions.RavenTimeoutException", error.Message);
                     Assert.Contains($"Total relevant indexes: 1, total stale indexes: 1, total errored indexes: 1 ({index.IndexName})", error.Message);
                     Assert.DoesNotContain("total paused indexes", error.Message);
                 }
@@ -102,8 +102,8 @@ namespace SlowTests.Issues
                             Count = 0
                         });
                     session.Advanced.WaitForIndexesAfterSaveChanges(timeout: TimeSpan.FromSeconds(5), indexes: new[] { index.IndexName });
-                    var error = await Assert.ThrowsAsync<RavenException>(async () => await session.SaveChangesAsync());
-                    Assert.StartsWith("System.TimeoutException", error.Message);
+                    var error = await Assert.ThrowsAsync<RavenTimeoutException>(async () => await session.SaveChangesAsync());
+                    Assert.StartsWith("Raven.Client.Exceptions.RavenTimeoutException", error.Message);
                     Assert.Contains($"Total relevant indexes: 1, total stale indexes: 1, total errored indexes: 1 ({index.IndexName})", error.Message);
                     Assert.DoesNotContain("total paused indexes", error.Message);
                 }
@@ -118,8 +118,8 @@ namespace SlowTests.Issues
                             Count = 0
                         });
                     session.Advanced.WaitForIndexesAfterSaveChanges(timeout: TimeSpan.FromSeconds(5));
-                    var error = await Assert.ThrowsAsync<RavenException>(async () => await session.SaveChangesAsync());
-                    Assert.StartsWith("System.TimeoutException", error.Message);
+                    var error = await Assert.ThrowsAsync<RavenTimeoutException>(async () => await session.SaveChangesAsync());
+                    Assert.StartsWith("Raven.Client.Exceptions.RavenTimeoutException", error.Message);
                     Assert.Contains($"Total relevant indexes: 2, total stale indexes: 1, total errored indexes: 1 ({index.IndexName})", error.Message);
                     Assert.DoesNotContain("total paused indexes", error.Message);
                 }

--- a/test/SlowTests/Issues/RavenDB_9723.cs
+++ b/test/SlowTests/Issues/RavenDB_9723.cs
@@ -42,7 +42,7 @@ namespace SlowTests.Issues
 
                     session.Advanced.WaitForIndexesAfterSaveChanges(timeout: TimeSpan.FromSeconds(1), throwOnTimeout: true);
 
-                    var ex = Assert.Throws<RavenException>(() => session.SaveChanges()); // expected since indexing is stopped
+                    var ex = Assert.Throws<RavenTimeoutException>(() => session.SaveChanges()); // expected since indexing is stopped
 
                     Assert.Contains("TimeoutException", ex.Message);
                 }


### PR DESCRIPTION
### Issue link

https://issues.hibernatingrhinos.com/issue/RavenDB-18812

### Additional description

Related PR: https://github.com/ravendb/ravendb/pull/14377#discussion_r896935306

### Type of change

- Bug fix

### How risky is the change?

- Moderate 

### Backward compatibility

- Ensured. We are still getting the HttpStatusCode.RequestTimeout, what changed is the type, so old client will throw RavenException (with TimeoutException in the message), new Client will throw RavenTimeoutException which inherits from RavenException.

### Is it platform specific issue?

- No

### Documentation update

- No documentation update is needed 

### Testing 

- Tests have been added that prove the fix is effective or that the feature works

### Is there any existing behavior change of other features due to this change?

- No

### UI work

- No UI work is needed
