### PR TITLE
RDBC-576 - Document store never recover, Fixed

### DIFF
--- a/src/Raven.Client/Http/NodeSelector.cs
+++ b/src/Raven.Client/Http/NodeSelector.cs
@@ -69,12 +69,11 @@ namespace Raven.Client.Http
             var len = Math.Min(serverNodes.Count, stateFailures.Length);
             for (var i = 0; i < len; i++)
             {
-                if (serverNodes[i].ClusterTag == nodeTag)
+                //In case of an error
+                //We want to reach the same node over and over  
+                if (serverNodes[i].ClusterTag == nodeTag && string.IsNullOrEmpty(serverNodes[i].Url) == false)
                 {
-                    if (stateFailures[i] == 0 && string.IsNullOrEmpty(serverNodes[i].Url) == false)
-                        return (i, serverNodes[i]);
-
-                    throw new RequestedNodeUnavailableException($"Requested node {nodeTag} currently unavailable, please try again later.");
+                    return (i, serverNodes[i]);
                 }
             }
 
@@ -97,6 +96,7 @@ namespace Raven.Client.Http
             var len = Math.Min(serverNodes.Count, stateFailures.Length);
             for (int i = 0; i < len; i++)
             {
+
                 if (stateFailures[i] == 0 && string.IsNullOrEmpty(serverNodes[i].Url) == false)
                 {
                     return (i, serverNodes[i]);

--- a/src/Raven.Client/Http/NodeSelector.cs
+++ b/src/Raven.Client/Http/NodeSelector.cs
@@ -66,14 +66,19 @@ namespace Raven.Client.Http
             var state = _state;
             var stateFailures = state.Failures;
             var serverNodes = state.Nodes;
-            var len = Math.Min(serverNodes.Count, stateFailures.Length);
-            for (var i = 0; i < len; i++)
+            var numOfServers = serverNodes.Count;
+            var len = Math.Min(numOfServers, stateFailures.Length);
+            for (var i = 0; i < len; i++) 
             {
-                //In case of an error
-                //We want to reach the same node over and over  
-                if (serverNodes[i].ClusterTag == nodeTag && string.IsNullOrEmpty(serverNodes[i].Url) == false)
+                if (serverNodes[i].ClusterTag == nodeTag)
                 {
-                    return (i, serverNodes[i]);
+                    if (numOfServers == 1)
+                        return (i, serverNodes[i]);
+                    
+                    if (stateFailures[i] == 0)
+                        return (i, serverNodes[i]);
+                
+                    throw new RequestedNodeUnavailableException($"Requested node {nodeTag} currently unavailable, please try again later.");
                 }
             }
 

--- a/test/SlowTests/Issues/RDBC_576.cs
+++ b/test/SlowTests/Issues/RDBC_576.cs
@@ -1,14 +1,25 @@
 using System;
 using System.Collections.Generic;
 using System.Linq;
+using System.Net.Http;
+using System.Text;
+using System.Threading;
 using System.Threading.Tasks;
+using NuGet.ContentModel;
 using Raven.Client.Documents;
+using Raven.Client.Documents.Conventions;
 using Raven.Client.Documents.Operations;
+using Raven.Client.Documents.Queries;
+using Raven.Client.Extensions;
+using Raven.Client.Http;
+using Raven.Client.Json;
+using Raven.Client.Json.Serialization;
 using Raven.Client.ServerWide;
 using Raven.Client.ServerWide.Operations;
 using Raven.Server.Config;
 using Raven.Tests.Core.Utils.Entities;
 using SlowTests.Bugs.Caching;
+using Sparrow.Json;
 using Tests.Infrastructure;
 using Xunit;
 using Xunit.Abstractions;
@@ -149,5 +160,157 @@ public class RDBC_576 : ClusterTestBase
 
         await deleteOperation.WaitForCompletionAsync().ConfigureAwait(false);
     }
+    
+    [Fact]
+    public async Task Should_Clear_Sate_Failures_Of_Given_Node()
+    {
+        var (nodes, leader) = await CreateRaftCluster(3, leaderIndex: 0);
+        var dbName = GetDatabaseName();
+        var db= await CreateDatabaseInCluster(dbName, 3, leader.WebUrl);
+        using (var store = new DocumentStore
+               {
+                   Urls = new[]
+                   {
+                       leader.WebUrl,
+                       nodes[1].WebUrl,
+                       nodes[2].WebUrl
+                   },
+                   Database = dbName
+               }.Initialize())
+        {
+            (string dataDirectory, string disposedServerUrl, _) = await DisposeServerAndWaitForFinishOfDisposalAsync(nodes[1]);
+
+            Operation deleteOperation = await store
+                .Operations
+                .SendAsync(new DeleteByQueryOperation("from Users"))
+                .ConfigureAwait(false);
+
+            await deleteOperation.WaitForCompletionAsync().ConfigureAwait(false);
+            
+            
+            using var newServer = GetNewServer(new ServerCreationOptions
+            {
+                DeletePrevious = false,
+                RunInMemory = false,
+                CustomSettings = new Dictionary<string, string>
+                {
+                    [RavenConfiguration.GetKey(x => x.Core.ServerUrls)] = disposedServerUrl, 
+                    [RavenConfiguration.GetKey(x => x.Core.DataDirectory)] = dataDirectory
+                },
+            });
+            
+            using (var session = store.OpenAsyncSession())
+            {
+                await session.StoreAsync(new User
+                    {
+                        Name = "Omer"
+                    },
+                    "Users/1");
+                await session.SaveChangesAsync();
+            }
+            var val = await WaitForValueAsync(async () => await GetMembersCount(store, dbName), 3, 60_000);
+            Assert.Equal(3, val);
+            
+            using (var store2 = new DocumentStore
+                   {
+                       Urls = new []{nodes[1].WebUrl},
+                       Database = dbName,
+                       Conventions = new DocumentConventions
+                       {
+                           DisableTopologyUpdates = true
+                       }
+                   }.Initialize())
+            {
+                await WaitForDocumentToReplicateAsync<User>(store2, "Users/1", 1000);
+            }
+       
+            var executor = store.GetRequestExecutor(dbName);
+            var command = new DeleteByQueryCommand(DocumentConventions.Default, new IndexQuery {Query = "from Users"});
+            using (executor.ContextPool.AllocateOperationContext(out JsonOperationContext ctx))
+            {
+                await executor.ExecuteAsync(new ServerNode
+                {
+                    Url = nodes[1].WebUrl,
+                    Database = dbName,
+                    ClusterTag = nodes[1].ServerStore.NodeTag,
+                },null, ctx, command);
+                var nodeTag = nodes[1].ServerStore.NodeTag;
+                var operation =  new Operation(executor, () => store.Changes(dbName, nodeTag), executor.Conventions, command.Result.OperationId, nodeTag);
+                var operationResult= await operation.WaitForCompletionAsync(TimeSpan.FromSeconds(60)).ConfigureAwait(false);
+                Assert.Equal(1, ((BulkOperationResult)operationResult).Total);
+            }
+        }
+    }
+    
+    private static async Task<int> GetMembersCount(IDocumentStore store, string databaseName)
+    {
+        var res = await store.Maintenance.Server.SendAsync(new GetDatabaseRecordOperation(databaseName));
+        if (res == null)
+        {
+            return -1;
+        }
+        return res.Topology.Members.Count;
+    }
+    
+    private class DeleteByQueryCommand : RavenCommand<OperationIdResult>
+    {
+        private readonly DocumentConventions _conventions;
+        private readonly IndexQuery _queryToDelete;
+        private readonly QueryOperationOptions _options;
+
+        public DeleteByQueryCommand(DocumentConventions conventions, IndexQuery queryToDelete, QueryOperationOptions options = null)
+        {
+            _conventions = conventions ?? throw new ArgumentNullException(nameof(conventions));
+            _queryToDelete = queryToDelete ?? throw new ArgumentNullException(nameof(queryToDelete));
+            _options = options ?? new QueryOperationOptions();
+        }
+
+        public override bool IsReadRequest { get; }
+
+        public override HttpRequestMessage CreateRequest(JsonOperationContext ctx, ServerNode node, out string url)
+        {
+            var path = new StringBuilder(node.Url)
+                .Append("/databases/")
+                .Append(node.Database)
+                .Append("/queries")
+                .Append("?allowStale=")
+                .Append(_options.AllowStale)
+                .Append("&maxOpsPerSec=")
+                .Append(_options.MaxOpsPerSecond)
+                .Append("&details=")
+                .Append(_options.RetrieveDetails);
+
+            if (_options.StaleTimeout != null)
+            {
+                path
+                    .Append("&staleTimeout=")
+                    .Append(_options.StaleTimeout.Value);
+            }
+
+            var request = new HttpRequestMessage
+            {
+                Method = HttpMethod.Delete,
+                Content = new BlittableJsonContent(async stream =>
+                {
+                    await using (var writer = new AsyncBlittableJsonTextWriter(ctx, stream))
+                    {
+                        writer.WriteIndexQuery(_conventions, ctx, _queryToDelete);
+                    }
+                })
+            };
+
+            url = path.ToString();
+            return request;
+        }
+        public override void SetResponse(JsonOperationContext context, BlittableJsonReaderObject response, bool fromCache)
+        {
+            if (response == null)
+                ThrowInvalidResponse();
+
+            Result = JsonDeserializationClient.OperationIdResult(response);
+        }
+
+    }
+    
 }
 

--- a/test/SlowTests/Issues/RDBC_576.cs
+++ b/test/SlowTests/Issues/RDBC_576.cs
@@ -1,0 +1,122 @@
+using System;
+using System.Collections.Generic;
+using System.Linq;
+using System.Threading.Tasks;
+using Raven.Client.Documents.Operations;
+using Raven.Client.ServerWide.Operations;
+using Raven.Server.Config;
+using Raven.Tests.Core.Utils.Entities;
+using Tests.Infrastructure;
+using Xunit;
+using Xunit.Abstractions;
+
+namespace FastTests.Issues;
+
+public class RDBC_576 : ClusterTestBase
+{
+    public RDBC_576(ITestOutputHelper output) : base(output)
+    {
+    }
+
+    [Fact]
+    public async Task Should_Create_New_Bulk_Insert_If_Previously_Failed_On_Unavailable_Server_1()
+    {
+        using var server = GetNewServer();
+        using var store = GetDocumentStore(new Options {Server = server});
+
+        var result = await DisposeServerAndWaitForFinishOfDisposalAsync(server);
+
+        await Assert.ThrowsAnyAsync<Exception>(async () =>
+        {
+            await using (var bulk = store.BulkInsert())
+            {
+                await bulk.StoreAsync(new User(), "user/1");
+            }
+        });
+
+        using var newServer = GetNewServer(new ServerCreationOptions
+        {
+            CustomSettings = new Dictionary<string, string>
+            {
+                [RavenConfiguration.GetKey(x => x.Core.ServerUrls)] = result.Url
+            }
+        });
+
+        await using (var bulk = store.BulkInsert())
+        {
+            await bulk.StoreAsync(new User(), "user/1");
+        }
+    }
+
+    [Fact]
+    public async Task Should_Create_New_Bulk_Insert_If_Previously_Failed_On_Unavailable_Server_2()
+    {
+        (var nodes, var leader) = await CreateRaftCluster(2, shouldRunInMemory: false);
+
+        using var store = GetDocumentStore(new Options {RunInMemory = false, Server = leader, ReplicationFactor = 1});
+
+        var record = await store.Maintenance.Server.SendAsync(new GetDatabaseRecordOperation(store.Database));
+        var databaseNodeTag = record.Topology.AllNodes.First();
+        var nodeToRestart = nodes.First(n => n.ServerStore.NodeTag == databaseNodeTag);
+
+        var result = await DisposeServerAndWaitForFinishOfDisposalAsync(nodeToRestart);
+
+        await Assert.ThrowsAnyAsync<Exception>(async () =>
+        {
+            await using (var bulk = store.BulkInsert())
+            {
+                await bulk.StoreAsync(new User(), "user/1");
+            }
+        });
+
+        using var newServer = GetNewServer(new ServerCreationOptions
+        {
+            DeletePrevious = false,
+            RunInMemory = false,
+            DataDirectory = result.DataDirectory,
+            CustomSettings = new Dictionary<string, string> {[RavenConfiguration.GetKey(x => x.Core.ServerUrls)] = result.Url}
+        });
+
+        await using (var bulk = store.BulkInsert())
+        {
+            await bulk.StoreAsync(new User(), "user/1");
+        }
+    }
+
+    [Fact]
+    public async Task Should_Not_Throw_Node_Unavailable()
+    {
+        using var server = GetNewServer(new ServerCreationOptions {RunInMemory = false,});
+        using var store = GetDocumentStore(new Options {RunInMemory = false, Server = server});
+
+        using (var session = store.OpenSession())
+        {
+            session.Store(new User {Name = "Omer"});
+        }
+
+        var result = await DisposeServerAndWaitForFinishOfDisposalAsync(server);
+
+        await Assert.ThrowsAnyAsync<Exception>(async () =>
+        {
+            Operation deleteOperation = await store
+                .Operations
+                .SendAsync(new DeleteByQueryOperation("from Users"))
+                .ConfigureAwait(false);
+
+            await deleteOperation.WaitForCompletionAsync().ConfigureAwait(false);
+        });
+
+        using var newServer = GetNewServer(new ServerCreationOptions
+        {
+            CustomSettings = new Dictionary<string, string> {[RavenConfiguration.GetKey(x => x.Core.ServerUrls)] = result.Url}
+        });
+
+        Operation deleteOperation = await store
+            .Operations
+            .SendAsync(new DeleteByQueryOperation("from Users"))
+            .ConfigureAwait(false);
+
+        await deleteOperation.WaitForCompletionAsync().ConfigureAwait(false);
+    }
+}
+

--- a/test/SlowTests/Issues/RDBC_576.cs
+++ b/test/SlowTests/Issues/RDBC_576.cs
@@ -2,70 +2,42 @@ using System;
 using System.Collections.Generic;
 using System.Linq;
 using System.Threading.Tasks;
+using Raven.Client.Documents;
 using Raven.Client.Documents.Operations;
+using Raven.Client.ServerWide;
 using Raven.Client.ServerWide.Operations;
 using Raven.Server.Config;
 using Raven.Tests.Core.Utils.Entities;
+using SlowTests.Bugs.Caching;
 using Tests.Infrastructure;
 using Xunit;
 using Xunit.Abstractions;
 
-namespace FastTests.Issues;
+namespace SlowTests.Issues;
 
 public class RDBC_576 : ClusterTestBase
 {
     public RDBC_576(ITestOutputHelper output) : base(output)
     {
     }
-
+    
     [Fact]
     public async Task Should_Create_New_Bulk_Insert_If_Previously_Failed_On_Unavailable_Server_1()
     {
-        using var server = GetNewServer();
-        using var store = GetDocumentStore(new Options {Server = server});
+        using var server = GetNewServer(new ServerCreationOptions {RunInMemory = false,});
+        using var store = GetDocumentStore(new Options {RunInMemory = false, Server = server});
 
+        await using (var bulk = store.BulkInsert())
+        {
+            await bulk.StoreAsync(new User(), "omer/1");
+        }
         var result = await DisposeServerAndWaitForFinishOfDisposalAsync(server);
 
         await Assert.ThrowsAnyAsync<Exception>(async () =>
         {
             await using (var bulk = store.BulkInsert())
             {
-                await bulk.StoreAsync(new User(), "user/1");
-            }
-        });
-
-        using var newServer = GetNewServer(new ServerCreationOptions
-        {
-            CustomSettings = new Dictionary<string, string>
-            {
-                [RavenConfiguration.GetKey(x => x.Core.ServerUrls)] = result.Url
-            }
-        });
-
-        await using (var bulk = store.BulkInsert())
-        {
-            await bulk.StoreAsync(new User(), "user/1");
-        }
-    }
-
-    [Fact]
-    public async Task Should_Create_New_Bulk_Insert_If_Previously_Failed_On_Unavailable_Server_2()
-    {
-        (var nodes, var leader) = await CreateRaftCluster(2, shouldRunInMemory: false);
-
-        using var store = GetDocumentStore(new Options {RunInMemory = false, Server = leader, ReplicationFactor = 1});
-
-        var record = await store.Maintenance.Server.SendAsync(new GetDatabaseRecordOperation(store.Database));
-        var databaseNodeTag = record.Topology.AllNodes.First();
-        var nodeToRestart = nodes.First(n => n.ServerStore.NodeTag == databaseNodeTag);
-
-        var result = await DisposeServerAndWaitForFinishOfDisposalAsync(nodeToRestart);
-
-        await Assert.ThrowsAnyAsync<Exception>(async () =>
-        {
-            await using (var bulk = store.BulkInsert())
-            {
-                await bulk.StoreAsync(new User(), "user/1");
+                await bulk.StoreAsync(new User(), "omer/2");
             }
         });
 
@@ -79,19 +51,72 @@ public class RDBC_576 : ClusterTestBase
 
         await using (var bulk = store.BulkInsert())
         {
-            await bulk.StoreAsync(new User(), "user/1");
+            await bulk.StoreAsync(new User(), "omer/2");
         }
     }
+    
+    [Fact]
+    public async Task Should_Create_New_Bulk_Insert_If_Previously_Failed_On_Unavailable_Server_2()
+    {
+        (var nodes, var leader) = await CreateRaftCluster(2, shouldRunInMemory: false);
 
+        using var store = GetDocumentStore(new Options {RunInMemory = false, Server = leader, ReplicationFactor = 1});
+
+        var record = await store.Maintenance.Server.SendAsync(new GetDatabaseRecordOperation(store.Database));
+        var databaseNodeTag = record.Topology.AllNodes.First();
+        var nodeToRestart = nodes.First(n => n.ServerStore.NodeTag == databaseNodeTag);
+
+        await using (var bulk = store.BulkInsert())
+        {
+            await bulk.StoreAsync(new User(), "omer/1");
+        }
+        
+        var result = await DisposeServerAndWaitForFinishOfDisposalAsync(nodeToRestart);
+
+        await Assert.ThrowsAnyAsync<Exception>(async () =>
+        {
+            await using (var bulk = store.BulkInsert())
+            {
+                await bulk.StoreAsync(new User(), "omer/2");
+            }
+        });
+
+        using var newServer = GetNewServer(new ServerCreationOptions
+        {
+            DeletePrevious = false,
+            RunInMemory = false,
+            DataDirectory = result.DataDirectory,
+            CustomSettings = new Dictionary<string, string> {[RavenConfiguration.GetKey(x => x.Core.ServerUrls)] = result.Url}
+        });
+
+        await using (var bulk = store.BulkInsert())
+        {
+            await bulk.StoreAsync(new User(), "omer/2");
+        }
+    }
+    
     [Fact]
     public async Task Should_Not_Throw_Node_Unavailable()
     {
-        using var server = GetNewServer(new ServerCreationOptions {RunInMemory = false,});
-        using var store = GetDocumentStore(new Options {RunInMemory = false, Server = server});
+        var path = NewDataPath();
+        var dbName = GetDatabaseName();
+        using var server = GetNewServer(new ServerCreationOptions
+        {
+            RunInMemory = false,
+            CustomSettings = new Dictionary<string, string>
+            {
+                [RavenConfiguration.GetKey(x => x.Core.DataDirectory)] = path 
+            },
+        });
 
+        using var store = new DocumentStore {Urls = new[] {server.WebUrl}, Database = dbName}.Initialize();
+        var dbRecord = new DatabaseRecord(dbName);
+        store.Maintenance.Server.Send(new CreateDatabaseOperation(dbRecord));
+        
         using (var session = store.OpenSession())
         {
             session.Store(new User {Name = "Omer"});
+            session.SaveChanges();
         }
 
         var result = await DisposeServerAndWaitForFinishOfDisposalAsync(server);
@@ -108,9 +133,15 @@ public class RDBC_576 : ClusterTestBase
 
         using var newServer = GetNewServer(new ServerCreationOptions
         {
-            CustomSettings = new Dictionary<string, string> {[RavenConfiguration.GetKey(x => x.Core.ServerUrls)] = result.Url}
+            DeletePrevious = false,
+            RunInMemory = false,
+            CustomSettings = new Dictionary<string, string>
+            {
+                [RavenConfiguration.GetKey(x => x.Core.ServerUrls)] = result.Url, 
+                [RavenConfiguration.GetKey(x => x.Core.DataDirectory)] = path
+            },
         });
-
+        
         Operation deleteOperation = await store
             .Operations
             .SendAsync(new DeleteByQueryOperation("from Users"))


### PR DESCRIPTION
### Issue link

https://issues.hibernatingrhinos.com/issue/RDBC-576

### Additional description

the scenario is- initially the server is down, the state aggregates errors and we can't recover since we don't clean the error.
After consulting Oren, We want to access the same node again and again.

_Please delete below the options that are not relevant_

### Type of change

- Bug fix


### How risky is the change?

- Low 


### Backward compatibility


- Not relevant

### Is it platform specific issue?

- No

### Documentation update

- No documentation update is needed 

### Testing 

- Tests have been added that prove the fix is effective or that the feature works


### Is there any existing behavior change of other features due to this change?

- No

### UI work

- No UI work is needed
