### PR TITLE
HRINT-2716 New symbol to run test in alphabetic order

### DIFF
--- a/test/Tests.Infrastructure/CommonTestsAssemblyInfo.cs
+++ b/test/Tests.Infrastructure/CommonTestsAssemblyInfo.cs
@@ -1,9 +1,21 @@
 ﻿using Xunit;
 
-#if TESTING
+#if ALPHABETIC_TEST_RUN
 
 [assembly: TestCaseOrderer("Tests.Infrastructure.AlphabeticTestsOrderer", "Tests.Infrastructure")]
 [assembly: TestCollectionOrderer("Tests.Infrastructure.AlphabeticTestsOrderer", "Tests.Infrastructure")]
+
+#endif
+
+#if TESTING
+
+    #if !ALPHABETIC_TEST_RUN
+
+    [assembly: TestCaseOrderer("Tests.Infrastructure.AlphabeticTestsOrderer", "Tests.Infrastructure")]
+    [assembly: TestCollectionOrderer("Tests.Infrastructure.AlphabeticTestsOrderer", "Tests.Infrastructure")]
+
+    #endif
+
 [assembly: TestFramework("Tests.Infrastructure.XunitExtensions.PerformanceTestFramework", "Tests.Infrastructure")]
 
 #endif


### PR DESCRIPTION
### Issue link

https://issues.hibernatingrhinos.com/issue/HRINT-2716

### Additional description

Added new symbol that allows to run test in alphabetic order.

### Type of change

- Optimization

### How risky is the change?

- Low

### Backward compatibility

- Not relevant

### Is it platform specific issue?

- No

### Documentation update

- No documentation update is needed 

### Testing 

- It has been verified by manual testing

### Is there any existing behavior change of other features due to this change?

- No

### UI work

- No UI work is needed
