### PR TITLE
RavenDB-17473 Using Mono.Posix to call stat system call

### DIFF
--- a/src/Sparrow.Server/Sparrow.Server.csproj
+++ b/src/Sparrow.Server/Sparrow.Server.csproj
@@ -34,6 +34,7 @@
     </None>
   </ItemGroup>
   <ItemGroup>
+    <PackageReference Include="Mono.Posix.NETStandard" Version="1.0.0" />
     <PackageReference Include="Nito.AsyncEx.Coordination" Version="5.1.2" />
     <PackageReference Include="Raven.CodeAnalysis" Version="1.0.11">
       <PrivateAssets>All</PrivateAssets>

--- a/src/Sparrow.Server/Utils/DiskUtils.cs
+++ b/src/Sparrow.Server/Utils/DiskUtils.cs
@@ -241,11 +241,9 @@ namespace Sparrow.Server.Utils
 
         internal static IDiskStatsGetter GetOsDiskUsageCalculator(TimeSpan minInterval)
         {
-            //return PlatformDetails.RunningOnLinux == false 
-            //    ? new NotImplementedDiskStatsGetter() 
-            //    : new DiskStatsGetter(minInterval);
-
-            return new NotImplementedDiskStatsGetter();
+            return PlatformDetails.RunningOnLinux == false 
+                ? new NotImplementedDiskStatsGetter() 
+                : new DiskStatsGetter(minInterval);
         }
 
         private const uint FILE_READ_EA = 0x0008;


### PR DESCRIPTION
### Issue link

https://issues.hibernatingrhinos.com/issue/RavenDB-17473

### Additional description

There are some differences in getting the disk stat between the OS.
The c standard library wraps that.
The easiest solution is to wrap the c code functionality. 

### Type of change
- Bug fix

### How risky is the change?
- Moderate 

### Backward compatibility
- Not relevant

### Is it platform specific issue?
- Yes, Linux only

### Documentation update
- No documentation update is needed 

### Testing 
- It has been verified by manual testing

### Is there any existing behavior change of other features due to this change?
- No

### UI work
- No UI work is needed
