### PR TITLE
RavenDB-18817 Corax - multiple items under same key - deletion support

### DIFF
--- a/src/Corax/IndexWriter.cs
+++ b/src/Corax/IndexWriter.cs
@@ -56,6 +56,7 @@ namespace Corax
 
         private readonly List<long> _entriesToDelete = new List<long>();
 
+
         private readonly long _postingListContainerId, _entriesContainerId;
 
         private const string SuggestionsTreePrefix = "__Suggestion_";
@@ -340,29 +341,16 @@ namespace Corax
             if (_entriesToDelete.Count == 0)
                 return;
 
-            Page page = default;
+            Page lastVisitedPage = default;
             var llt = Transaction.LowLevelTransaction;
+            List<long> temporaryStorageForIds = null;
+            Span<byte> tempWordsSpace = stackalloc byte[_fieldsMapping.MaximumOutputSize];
+            Span<Token> tempTokenSpace = stackalloc Token[_fieldsMapping.MaximumTokenSize];
 
-            List<long> ids = null;
-            int maxWordsSpaceLength = 0;
-            int maxTokensSpaceLength = 0;
-            foreach (var binding in _fieldsMapping)
+            
+            foreach (var entryToDelete in _entriesToDelete)
             {
-                if (binding.IsAnalyzed == false)
-                    continue;
-
-                binding.Analyzer.GetOutputBuffersSize(Analyzer.MaximumSingleTokenLength, out var tempOutputSize, out var tempTokenSize);
-                maxWordsSpaceLength = Math.Max(maxWordsSpaceLength, tempOutputSize);
-                maxTokensSpaceLength = Math.Max(maxTokensSpaceLength, tempTokenSize);
-            }
-
-            Span<byte> tempWordsSpace = stackalloc byte[maxWordsSpaceLength];
-            Span<Token> tempTokenSpace = stackalloc Token[maxTokensSpaceLength];
-
-            foreach (var id in _entriesToDelete)
-            {
-                var entryReader = IndexSearcher.GetReaderFor(Transaction, ref page, id);
-
+                var entryReader = IndexSearcher.GetReaderFor(Transaction, ref lastVisitedPage, entryToDelete);
                 foreach (var binding in _fieldsMapping) // todo maciej: this part needs to be rebuilt after implementing DynamicFields
                 {
                     if (binding.IsIndexed == false)
@@ -377,7 +365,7 @@ namespace Corax
                             while (iterator.ReadNext())
                             {
                                 for (int i = 1; i <= iterator.Count; ++i)
-                                    DeleteToken(iterator.Geohash.Slice(0, i), tmpBuf, binding, tempWordsSpace, tempTokenSpace);
+                                    DeleteIdFromTerm(iterator.Geohash.Slice(0, i), tmpBuf, binding, tempWordsSpace, tempTokenSpace);
                             }
                         }
                         else
@@ -386,30 +374,32 @@ namespace Corax
                             while (it.ReadNext())
                             {
                                 if (it.IsNull)
-                                    DeleteToken(Constants.NullValueSlice.AsSpan(), tmpBuf, binding, tempWordsSpace, tempTokenSpace);
+                                    DeleteIdFromTerm(Constants.NullValueSlice.AsSpan(), tmpBuf, binding, tempWordsSpace, tempTokenSpace);
                                 else
-                                    DeleteToken(it.Sequence, tmpBuf, binding, tempWordsSpace, tempTokenSpace);
+                                    DeleteIdFromTerm(it.Sequence, tmpBuf, binding, tempWordsSpace, tempTokenSpace);
                             }
                         }
                     }
                     else
                     {
                         entryReader.Read(binding.FieldId, out var termValue);
-                        DeleteToken(termValue, tmpBuf, binding, tempWordsSpace, tempTokenSpace);
+                        DeleteIdFromTerm(termValue, tmpBuf, binding, tempWordsSpace, tempTokenSpace);
                     }
                 }
-
-                ids?.Clear();
-                Container.Delete(llt, _entriesContainerId, id);
-                llt.RootObjects.Increment(Constants.IndexWriter.NumberOfEntriesSlice, -1);
+                
+                Container.Delete(llt, _entriesContainerId, entryToDelete); // delete raw index entry
+                llt.RootObjects.Increment(Constants.IndexWriter.NumberOfEntriesSlice, -1); // update number of entries
+                temporaryStorageForIds?.Clear();
+                
+                
                 var numberOfEntries = llt.RootObjects.ReadInt64(Constants.IndexWriter.NumberOfEntriesSlice) ?? 0;
                 Debug.Assert(numberOfEntries >= 0);
 
-                void DeleteToken(ReadOnlySpan<byte> termValue, Span<byte> tmpBuf, IndexFieldBinding binding, Span<byte> wordSpace, Span<Token> tokenSpace)
+                void DeleteIdFromTerm(ReadOnlySpan<byte> termValue, Span<byte> tmpBuf, IndexFieldBinding binding, Span<byte> wordSpace, Span<Token> tokenSpace)
                 {
                     if (binding.IsAnalyzed == false)
                     {
-                        DeleteField(id, binding.FieldName, tmpBuf, termValue);
+                        DeleteIdFromExactTerm(entryToDelete, binding.FieldName, tmpBuf, termValue);
                         if (binding.HasSuggestions)
                             RemoveSuggestions(binding, termValue);
 
@@ -424,15 +414,15 @@ namespace Corax
                         ref var token = ref tokenSpace[i];
 
                         var term = wordSpace.Slice(token.Offset, (int)token.Length);
-                        DeleteField(id, binding.FieldName, tmpBuf, term);
+                        DeleteIdFromExactTerm(entryToDelete, binding.FieldName, tmpBuf, term);
 
                         if (binding.HasSuggestions)
                             RemoveSuggestions(binding, termValue);
                     }
                 }
             }
-
-            void DeleteField(long id, Slice fieldName, Span<byte> tmpBuffer, ReadOnlySpan<byte> termValue)
+            
+            void DeleteIdFromExactTerm(long id, Slice fieldName, Span<byte> tmpBuffer, ReadOnlySpan<byte> termValue)
             {
                 var fieldTree = fieldsTree.CompactTreeFor(fieldName);
                 if (termValue.Length == 0 || fieldTree.TryGetValue(termValue, out var containerId) == false)
@@ -446,18 +436,24 @@ namespace Corax
                     var set = new Set(llt, fieldName, in setState);
                     set.Remove(id);
                     setState = set.State;
+
+                    if (setState.NumberOfEntries == 0)
+                    {
+                        //If we get rid off all terms we have to remove container. Probably we can do this in a better way
+                        fieldTree.TryRemove(termValue, out _);
+                        Container.Delete(llt, _postingListContainerId, setId);
+                    }
                 }
                 else if ((containerId & (long)TermIdMask.Small) != 0)
                 {
                     var smallSetId = containerId & ~0b11;
                     var buffer = Container.GetMutable(llt, smallSetId);
 
-                    //get first item into ids.
+                    //Fetch all the ids from the set into temporaryStorageForIds
                     var itemsCount = ZigZagEncoding.Decode<int>(buffer, out var len);
-                    ids ??= new List<long>(itemsCount);
-                    ids.Clear();
-
-
+                    temporaryStorageForIds ??= new List<long>(itemsCount);
+                    temporaryStorageForIds.Clear();
+                    
                     long pos = len;
                     var currentId = 0L;
 
@@ -468,14 +464,14 @@ namespace Corax
                         currentId += delta;
                         if (currentId == id)
                             continue;
-                        ids.Add(currentId);
+                        temporaryStorageForIds.Add(currentId);
                     }
 
+                    // Due to encoding we have to encode new set again so we remove previous small set from container.
                     Container.Delete(llt, _postingListContainerId, smallSetId);
-                    fieldTree.TryRemove(termValue, out _);
+                    fieldTree.TryRemove(termValue, out _); // term also disappears from the field tree
 
-
-                    AddNewTerm(ids, fieldTree, termValue, tmpBuffer, default, false);
+                    AddNewTerm(temporaryStorageForIds, fieldTree, termValue, tmpBuffer, default, false);
                 }
                 else
                 {
@@ -494,13 +490,42 @@ namespace Corax
             var entriesCount = Transaction.LowLevelTransaction.RootObjects.ReadInt64(Constants.IndexWriter.NumberOfEntriesSlice) ?? 0;
             Debug.Assert(entriesCount - _entriesToDelete.Count >= 0);
 
-            if (fieldTree.TryGetValue(term, out long id, out var _) == false)
+            if (fieldTree.TryGetValue(term, out long idInTree, out var _) == false)
                 return false;
 
-            if ((id & (long)TermIdMask.Set) != 0 || (id & (long)TermIdMask.Small) != 0)
-                throw new InvalidDataException($"Cannot delete {term} in {key} because it's not {nameof(TermIdMask.Single)}.");
 
-            _entriesToDelete.Add(id);
+            if ((idInTree & (long)TermIdMask.Set) != 0)
+            {
+                var id = idInTree & ~0b11;
+                var setSpace = Container.GetMutable(Transaction.LowLevelTransaction, id);
+                ref var setState = ref MemoryMarshal.AsRef<SetState>(setSpace);
+                var set = new Set(Transaction.LowLevelTransaction, Slices.Empty, setState);
+                using var iterator = set.Iterate();
+                while (iterator.MoveNext())
+                {
+                    _entriesToDelete.Add(iterator.Current);
+                }
+            }
+            else if ((idInTree & (long)TermIdMask.Small) != 0)
+            {
+                var id = idInTree & ~0b11;
+                var smallSet = Container.Get(Transaction.LowLevelTransaction, id).ToSpan();
+                // combine with existing value
+                var cur = 0L;
+                ZigZagEncoding.Decode<int>(smallSet, out var pos); // discard the first entry, the count
+                while (pos < smallSet.Length)
+                {
+                    var value = ZigZagEncoding.Decode<long>(smallSet, out var len, pos);
+                    pos += len;
+                    cur += value;
+                    _entriesToDelete.Add(cur);
+                }
+            }
+            else
+            {
+                _entriesToDelete.Add(idInTree);
+            }
+            
             return true;
         }
 
@@ -599,8 +624,7 @@ namespace Corax
 
         //Rationale behind passing in the validEncodedKey: because encodedKey could be out of date (due to deletion) so we have to generate it before we add the term.
         //We cannot make EncodedKey nullable either because it is a read-only ref struct
-        private unsafe void AddNewTerm(List<long> entries, CompactTree fieldTree, ReadOnlySpan<byte> termsSpan, Span<byte> tmpBuf, CompactTree.EncodedKey encodedKey,
-            bool validEncodedKey = true)
+        private unsafe void AddNewTerm(List<long> entries, CompactTree fieldTree, ReadOnlySpan<byte> termsSpan, Span<byte> tmpBuf, CompactTree.EncodedKey encodedKey, bool validEncodedKey = true)
         {
             // common for unique values (guid, date, etc)
             if (entries.Count == 1)

--- a/test/FastTests/Corax/DeleteTest.cs
+++ b/test/FastTests/Corax/DeleteTest.cs
@@ -1,14 +1,19 @@
 ﻿using System;
 using System.Collections.Generic;
 using System.Linq;
+using System.Runtime.InteropServices;
 using System.Text;
 using Corax;
+using Corax.Queries;
 using FastTests.Voron;
+using Sparrow;
 using Sparrow.Server;
 using Voron;
 using Xunit.Abstractions;
 using Xunit;
 using Sparrow.Threading;
+using Voron.Data.Containers;
+using Voron.Data.Sets;
 
 namespace FastTests.Corax
 {
@@ -63,7 +68,97 @@ namespace FastTests.Corax
             }
         }
 
+        [Fact]
+        public void MultipleEntriesUnderSameId()
+        {
+            for (int i = 0; i < 1000; ++i) 
+                PrepareData(DataType.Modulo);
+            IndexEntries(CreateKnownFields(_bsc));
+            var count = _longList.Count(p => p.Content == 9);
 
+            Span<long> ids = new long[(int)Math.Ceiling(1.5 * _longList.Count)];
+            {
+                using var indexSearcher = new IndexSearcher(Env, _analyzers);
+                var match = indexSearcher.TermQuery("Content", "9");
+                Assert.Equal(count, match.Fill(ids));
+            }
+
+            var previousIds = new List<long>();
+            {
+                using var indexSearcher = new IndexSearcher(Env, _analyzers);
+                var match = indexSearcher.TermQuery("Id", "list/9");
+                var read = match.Fill(ids);
+                previousIds.AddRange(ids.Slice(0, read).ToArray());
+            }
+            
+            using (var indexWriter = new IndexWriter(Env, _analyzers))
+            {
+                indexWriter.TryDeleteEntry("Id", "list/9");
+                indexWriter.Commit();
+            }
+            
+            {
+                using var indexSearcher = new IndexSearcher(Env, _analyzers);
+                var match = indexSearcher.TermQuery("Id", "list/9");
+                Assert.Equal(0, match.Fill(ids));
+            }
+
+            {
+                using var indexSearcher = new IndexSearcher(Env, _analyzers);
+
+                Span<byte> idAsBytes = Encodings.Utf8.GetBytes("list/9");
+                Span<byte> nine = Encodings.Utf8.GetBytes("9");
+                
+                var match = indexSearcher.TermQuery("Content", "9");
+                
+                
+                
+                // Count in the TermMatch is 100% accurate, isnt it?      
+                Assert.Equal(count - previousIds.Count, match.Count);
+                var read = match.Fill(ids);
+                Assert.NotEqual(0, read);
+                
+                //Lets check low level storage
+                using var writeTransaction = Env.WriteTransaction();
+                var llt = writeTransaction.LowLevelTransaction;
+                
+                var fields = indexSearcher.Transaction.ReadTree(Constants.IndexWriter.FieldsSlice);
+                var terms = fields?.CompactTreeFor("Content");
+                Assert.True(terms!.TryGetValue("9", out var containerId));
+                Assert.NotEqual(0, containerId & (long)TermIdMask.Set);
+                var setId = containerId & ~0b11;
+                var setStateSpan = Container.GetMutable(llt, setId);
+                ref var setState = ref MemoryMarshal.AsRef<SetState>(setStateSpan);
+                using var _ = Slice.From(llt.Allocator,"Content", ByteStringType.Immutable, out var fieldName);
+                var set = new Set(llt, fieldName, in setState);
+                setState = set.State;
+                Assert.Equal(count - previousIds.Count, setState.NumberOfEntries);
+
+                using var iterator = set.Iterate();
+                previousIds.Sort();
+                
+                // Look for "list/9" in the set
+                while (iterator.MoveNext())
+                {
+                    Assert.False(previousIds.BinarySearch(iterator.Current) >= 0);
+                }
+
+                Assert.Equal(read, match.Count);
+
+                for (int i = 0; i < read; i++)
+                {
+                    var entry = indexSearcher.GetReaderFor(ids[i]);
+                    Assert.True(entry.Read(0, out Span<byte> id));
+                    if (idAsBytes.SequenceEqual(id))
+                    {
+                        entry.Read(ContentId, out Span<byte> content);
+                       // Assert.False(nine.SequenceEqual(content));
+                    }
+                }
+            }
+
+        }
+        
         [Fact]
         public void CanDeleteOneElement()
         {
@@ -111,6 +206,9 @@ namespace FastTests.Corax
                     case DataType.Modulo:
                         _longList.Add(new IndexSingleNumericalEntry<long>{Id = $"list/{i}", Content = i % 33});
                         break;
+                    case DataType.Linear:
+                        _longList.Add(new IndexSingleNumericalEntry<long>{Id = $"list/{i}", Content = i });
+                        break;
                     default:
                         _longList.Add(new IndexSingleNumericalEntry<long> {Id = $"list/{i}", Content = 0});
                         break;
@@ -120,6 +218,7 @@ namespace FastTests.Corax
         private enum DataType
         {
             Default,
+            Linear,
             Modulo
         }
 


### PR DESCRIPTION
### Issue link

https://issues.hibernatingrhinos.com/issue/RavenDB-18817

### Additional description
Example of data:
```
[ID: test/1, Value: 5]
[ID: test/1, Value: 6]
```

### Type of change


- New feature


### How risky is the change?

- Low 


### Backward compatibility


- Not relevant

### Is it platform specific issue?

- No

### Documentation update

- No documentation update is needed 

### Testing 

- Tests have been added that prove the fix is effective or that the feature works


### Is there any existing behavior change of other features due to this change?

- No

### UI work

- No UI work is needed
