### PR TITLE
RavenDB-18793 Disable patch button during query count calculation

### DIFF
--- a/src/Raven.Studio/typescript/viewmodels/database/patch/patch.ts
+++ b/src/Raven.Studio/typescript/viewmodels/database/patch/patch.ts
@@ -145,6 +145,7 @@ class patch extends viewModelBase {
 
     spinners = {
         save: ko.observable<boolean>(false),
+        countMatchingDocuments: ko.observable<boolean>(false)
     };
 
     jsCompleter = defaultAceCompleter.completer();
@@ -292,8 +293,13 @@ class patch extends viewModelBase {
 
     runPatch() {
         if (this.isValid(this.patchDocument().validationGroup)) {
+            this.spinners.countMatchingDocuments(true);
+            
             this.getMatchingDocumentsNumber()
-                .done((matchingDocs: number) => this.executePatch(matchingDocs));
+                .done((matchingDocs: number) => {
+                    this.spinners.countMatchingDocuments(false);
+                    this.executePatch(matchingDocs);
+                });
         }
     }
 

--- a/src/Raven.Studio/wwwroot/App/views/database/patch/patch.html
+++ b/src/Raven.Studio/wwwroot/App/views/database/patch/patch.html
@@ -42,11 +42,14 @@
                             </div>
                             <div class="patch-controls">
                                 <div class="flex-separator"></div>
-                                <button class="btn btn-primary btn-block btn-lg text-center" data-bind="click: runPatch" title="Execute patch">
-                                    <i class="icon-play2 icon-lg"></i><br />
-                                    <small class="kbd"><kbd>ctrl</kbd> <strong>+</strong> <kbd>enter</kbd></small>
-                                </button>
-                                <button class="btn btn-default btn-block text-center margin-top" data-bind="click: test.enterTestMode" title="Dry patch run. No data is modified.">
+                                <span class="has-disable-reason" data-bind="attr: { title: spinners.countMatchingDocuments() ? 'Calculating matching documents before patching' : 'Execute patch' }">
+                                    <button class="btn btn-primary btn-block btn-lg text-center"
+                                            data-bind="click: runPatch, css: { 'btn-spinner': spinners.countMatchingDocuments }, disable: spinners.countMatchingDocuments">
+                                        <i class="icon-play2 icon-lg"></i><br />
+                                        <small class="kbd"><kbd>ctrl</kbd> <strong>+</strong> <kbd>enter</kbd></small>
+                                    </button>
+                                </span>
+                                <button class="btn btn-default btn-block text-center margin-top-sm" data-bind="click: test.enterTestMode" title="Dry patch run. No data is modified.">
                                     <i class="icon-rocket"></i><span>Test</span>
                                 </button>
                             </div>


### PR DESCRIPTION
### Issue link
https://issues.hibernatingrhinos.com/issue/RavenDB-18793

### Additional description
Disable patch btn during query count calculation

### Type of change
- Bug fix

### How risky is the change?
- Low 

### Backward compatibility
- Non breaking change

### Is it platform specific issue?
- No

### Documentation update
- No documentation update is needed 

### Testing 
- It has been verified by manual testing

### Is there any existing behavior change of other features due to this change?
- No

### UI work
- No UI work is needed
