### PR TITLE
RavenDB-18683 limit the number of notifications that we show at first

### DIFF
--- a/src/Raven.Studio/typescript/common/notifications/notificationCenter.ts
+++ b/src/Raven.Studio/typescript/common/notifications/notificationCenter.ts
@@ -78,6 +78,10 @@ class notificationCenter {
 
     showNotifications = ko.observable<boolean>(false);
     pinNotifications = ko.observable<boolean>(false);
+    
+    isShowingAllNotifications = ko.observable<boolean>(false);
+    static readonly numberOfNotificationsToShow = 300;
+    
     includeInDom = ko.observable<boolean>(false); // to avoid RavenDB-10660
 
     globalNotifications = ko.observableArray<abstractNotification>();
@@ -88,6 +92,7 @@ class notificationCenter {
 
     allNotifications: KnockoutComputed<abstractNotification[]>;
     visibleNotifications: KnockoutComputed<abstractNotification[]>;
+    visibleNotificationsTrimmed: KnockoutComputed<abstractNotification[]>;
 
     totalItemsCount: KnockoutComputed<number>;
     successItemsCount: KnockoutComputed<number>;
@@ -189,6 +194,9 @@ class notificationCenter {
             return allNotifications.filter(x => x.severity() === severity);
         });
 
+        this.visibleNotificationsTrimmed = ko.pureComputed(() =>
+            this.visibleNotifications().slice(0, notificationCenter.numberOfNotificationsToShow));
+
         this.totalItemsCount = ko.pureComputed(() => this.allNotifications().length);
 
         const bySeverityCounter = (severity: Raven.Server.NotificationCenter.Notifications.NotificationSeverity) => {
@@ -223,6 +231,7 @@ class notificationCenter {
         this.showNotifications.subscribe((show: boolean) => {
             if (show) {
                 this.includeInDom(true);
+                this.isShowingAllNotifications(false);
                 window.addEventListener("click", this.hideHandler, true);
             } else {
                 window.removeEventListener("click", this.hideHandler, true);
@@ -395,6 +404,7 @@ class notificationCenter {
 
     dismissAll() {
         this.allNotifications().forEach(notification => this.dismiss(notification));
+        this.isShowingAllNotifications(false);
     }
 
     dismiss(notification: abstractNotification) {
@@ -498,6 +508,10 @@ class notificationCenter {
 
     filterBySeverity(severity: Raven.Server.NotificationCenter.Notifications.NotificationSeverity) {
         this.severityFilter(severity);
+    }
+
+    showAllNotifications() {
+        this.isShowingAllNotifications(true);
     }
 }
 

--- a/src/Raven.Studio/typescript/common/notifications/notificationCenter.ts
+++ b/src/Raven.Studio/typescript/common/notifications/notificationCenter.ts
@@ -91,6 +91,8 @@ class notificationCenter {
     databaseOperationsWatch = new notificationCenterOperationsWatch();
 
     allNotifications: KnockoutComputed<abstractNotification[]>;
+    notificationsToShow: KnockoutComputed<abstractNotification[]>;
+    
     visibleNotifications: KnockoutComputed<abstractNotification[]>;
     visibleNotificationsTrimmed: KnockoutComputed<abstractNotification[]>;
 
@@ -196,6 +198,9 @@ class notificationCenter {
 
         this.visibleNotificationsTrimmed = ko.pureComputed(() =>
             this.visibleNotifications().slice(0, notificationCenter.numberOfNotificationsToShow));
+
+        this.notificationsToShow = ko.pureComputed(() =>
+            this.isShowingAllNotifications() ? this.visibleNotifications() : this.visibleNotificationsTrimmed());
 
         this.totalItemsCount = ko.pureComputed(() => this.allNotifications().length);
 

--- a/src/Raven.Studio/wwwroot/App/views/notifications/notificationCenter.html
+++ b/src/Raven.Studio/wwwroot/App/views/notifications/notificationCenter.html
@@ -23,15 +23,8 @@
         <h2 class="text-center text-muted">No new notifications</h2>
     </div>
     <div class="notification-list scroll" data-bind="if: includeInDom">
-        <div data-bind="if: !isShowingAllNotifications()">
-            <!-- ko foreach: visibleNotificationsTrimmed-->
+        <div data-bind="foreach: notificationsToShow">
             <div data-bind="template: { name: type + '-template' }"></div>
-            <!-- /ko -->
-        </div>
-        <div data-bind="if: isShowingAllNotifications">
-            <!-- ko foreach: visibleNotifications-->
-            <div data-bind="template: { name: type + '-template' }"></div>
-            <!-- /ko -->
         </div>
         <div class="text-center" data-bind="visible: visibleNotifications().length > constructor.numberOfNotificationsToShow && !isShowingAllNotifications()">
             <button class="btn btn-danger margin-top-xs" data-bind="click: showAllNotifications">

--- a/src/Raven.Studio/wwwroot/App/views/notifications/notificationCenter.html
+++ b/src/Raven.Studio/wwwroot/App/views/notifications/notificationCenter.html
@@ -23,9 +23,21 @@
         <h2 class="text-center text-muted">No new notifications</h2>
     </div>
     <div class="notification-list scroll" data-bind="if: includeInDom">
-        <!-- ko foreach: visibleNotifications-->
-        <div data-bind="template: { name: type + '-template' }"></div>
-        <!-- /ko -->
+        <div data-bind="if: !isShowingAllNotifications()">
+            <!-- ko foreach: visibleNotificationsTrimmed-->
+            <div data-bind="template: { name: type + '-template' }"></div>
+            <!-- /ko -->
+        </div>
+        <div data-bind="if: isShowingAllNotifications">
+            <!-- ko foreach: visibleNotifications-->
+            <div data-bind="template: { name: type + '-template' }"></div>
+            <!-- /ko -->
+        </div>
+        <div class="text-center" data-bind="visible: visibleNotifications().length > constructor.numberOfNotificationsToShow && !isShowingAllNotifications()">
+            <button class="btn btn-danger margin-top-xs" data-bind="click: showAllNotifications">
+                Show all notifications
+            </button>
+        </div>
     </div>
 </div>
 


### PR DESCRIPTION
### Issue link
https://issues.hibernatingrhinos.com/issue/RavenDB-18683

### Additional description
Limit the number of notifications that are shown first to 300.
Show all notifications only if user clicks on 'show all'.

### Type of change
- Bug fix

### How risky is the change?
- Low 

### Backward compatibility
- Non breaking change

### Is it platform specific issue?
- No

### Documentation update
- No documentation update is needed 

### Testing 
- It has been verified by manual testing

### Is there any existing behavior change of other features due to this change?
- No

### UI work
- No UI work is needed
