### PR TITLE
RavenDB-18664 - fixing NRE that resulted in a faulted WaitForTopologyUpdate task

### DIFF
--- a/src/Raven.Client/Http/DatabaseTopologyLocalCache.cs
+++ b/src/Raven.Client/Http/DatabaseTopologyLocalCache.cs
@@ -39,7 +39,7 @@ namespace Raven.Client.Http
         public static Task<Topology> TryLoadAsync(string databaseName, string topologyHash, DocumentConventions conventions, JsonOperationContext context)
         {
             if (conventions.DisableTopologyCache)
-                return null;
+                return Task.FromResult((Topology)null);
 
             var path = GetPath(databaseName, topologyHash, conventions);
             return TryLoadAsync(path, context);

--- a/test/SlowTests/Issues/RavenDB-18664.cs
+++ b/test/SlowTests/Issues/RavenDB-18664.cs
@@ -1,0 +1,54 @@
+﻿using System.Collections.Generic;
+using System.Linq;
+using FastTests;
+using Raven.Client.Documents.Linq;
+using Raven.Client.Documents.Session;
+using Xunit;
+using Xunit.Abstractions;
+
+namespace SlowTests.Issues
+{
+    public class RavenDB_18664 : RavenTestBase
+    {
+        public RavenDB_18664(ITestOutputHelper output) : base(output)
+        {
+        }
+
+        [Fact]
+        public void GivenADocument_WhenAnEmptyListIsPassedToCheckIfIdsExist_QueryShouldReturnZeroResults()
+        {
+            using (var store = GetDocumentStore())
+            {
+                using (var session = store.OpenSession())
+                {
+                    CreateTestDocument(session);
+                    session.SaveChanges();
+                }
+
+                var emptyList = new List<string>();
+
+                using (var session = store.OpenSession())
+                {
+                    var queryCount = session.Query<TestDocument>().Count(x => x.Id.In(emptyList));
+                    Assert.Equal(0, queryCount);
+                }
+            }
+        }
+
+        private static void CreateTestDocument(IDocumentSession session)
+        {
+            var testDoc = new TestDocument
+            {
+                Comment = "TestDoc1"
+            };
+
+            session.Store(testDoc);
+        }
+
+        private class TestDocument
+        {
+            public string Id { get; set; }
+            public string Comment { get; set; }
+        }
+    }
+}


### PR DESCRIPTION
### Issue link

https://issues.hibernatingrhinos.com/issue/RavenDB-18664

### Additional description

This can happen only when `DisableTopologyCache` is set to true

### Type of change

- Bug fix

### How risky is the change?

- Low 

### Testing 

- Tests have been added that prove the fix is effective or that the feature works
