### PR TITLE
RavenDB-18815 Added validation to ensure that ETL script is not empty when it's not allowed

### DIFF
--- a/src/Raven.Client/Documents/Operations/ETL/Transformation.cs
+++ b/src/Raven.Client/Documents/Operations/ETL/Transformation.cs
@@ -410,6 +410,12 @@ namespace Raven.Client.Documents.Operations.ETL
                 IsEmptyScript = true;
             }
 
+            if (IsEmptyScript)
+            {
+                if (type != EtlType.Raven)
+                    errors.Add($"Script '{Name}' must not be empty");
+            }
+
             return errors.Count == 0;
         }
 

--- a/src/Raven.Studio/typescript/models/database/tasks/ongoingTaskQueueEtlTransformationModel.ts
+++ b/src/Raven.Studio/typescript/models/database/tasks/ongoingTaskQueueEtlTransformationModel.ts
@@ -85,6 +85,7 @@ class ongoingTaskQueueEtlTransformationModel {
         });
         
         this.script.extend({
+            required: true,
             aceValidation: true
         });
 

--- a/src/Raven.Studio/wwwroot/App/views/database/tasks/editKafkaEtlTask.html
+++ b/src/Raven.Studio/wwwroot/App/views/database/tasks/editKafkaEtlTask.html
@@ -214,7 +214,7 @@
                                        data-bind="textInput: name, disable: $root.enableTestArea() || !isNew()" />
                             </div>
                         </div>
-                        <label><strong>Script:</strong> <small>(leave empty to send documents without any modifications)</small></label>
+                        <label><strong>Script:</strong></label>
                         <span class="pull-right"><a href="#" data-bind="click: $root.syntaxHelp"><small>Syntax <i class="icon-help"></i></small></a></span>
                         <div data-bind="validationElement: script">
                             <pre class="form-control editor"

--- a/src/Raven.Studio/wwwroot/App/views/database/tasks/editRabbitMqEtlTask.html
+++ b/src/Raven.Studio/wwwroot/App/views/database/tasks/editRabbitMqEtlTask.html
@@ -216,12 +216,11 @@
                                        data-bind="textInput: name, disable: $root.enableTestArea() || !isNew()" />
                             </div>
                         </div>
-                        <label><strong>Script:</strong> <small>(leave empty to send documents without any modifications)</small></label>
+                        <label><strong>Script:</strong></label>
                         <span class="pull-right"><a href="#" data-bind="click: $root.syntaxHelp"><small>Syntax <i class="icon-help"></i></small></a></span>
                         <div data-bind="validationElement: script">
                             <pre class="form-control editor"
                                  data-bind="aceEditor: { code: script, fontSize: '14px', lang: 'ace/mode/javascript' }, validationOptions: { errorsAsTitle: false }, validationElement: script" style="height: 250px;"></pre>
-
                             <div data-bind="validationOptions: { errorsAsTitle: false }, validationElement: script">
                                 <div class="help-block" data-bind="validationMessage: script"></div>
                             </div>
@@ -365,14 +364,14 @@
                 <div data-bind="foreach: testResults">
                     <div class="result-item margin-bottom">
                         <div class="header margin-bottom">
-                            <span>Queue Name:</span>
-                            <strong data-bind="text: QueueName"></strong>
+                            <span>Exchange Name:</span>
+                            <strong data-bind="text: QueueName || 'Default'"></strong>
                         </div>
                         <div data-bind="foreach: Messages" class="test-output">
                             <div class="header margin-bottom">
                                 <span>Message body:</span>
                                 <pre data-bind="text: Body" class="margin-top"></pre>
-                                <div>
+                                <div class="margin-top-sm" >
                                     <span>Routing Key:</span>
                                     <strong data-bind="text: RoutingKey || '(empty)'"></strong>
                                 </div>

--- a/src/Raven.Studio/wwwroot/App/views/database/tasks/transformationScriptSyntax.html
+++ b/src/Raven.Studio/wwwroot/App/views/database/tasks/transformationScriptSyntax.html
@@ -52,19 +52,14 @@
                <div class="margin-bottom">
                    <pre class="copy-area"><a href="#" class="copy-button-hidden" title="Copy code sample" data-bind="click: copySample"><i class="icon-copy"></i></a><span data-bind="html: rabbitMqEtlSampleHtml"></span></pre>
                </div>
-               <table class="table table-striped">
+               <table class="table table-striped table-condensed margin-top-lg">
                    <thead>
-                   <tr>
-                       <th>LoadTo Option</th>
-                       <th>Target Exchange</th>
-                       <th>Routing Key</th>
-                   </tr>
                    </thead>
                    <tbody>
                    <tr>
-                       <td><code>loadToUsers({ Name: 'Bob' }, 'admin')</code></td>
-                       <td>Users</td>
-                       <td>admin</td>
+                       <th><strong><em>loadTo</em> Option</strong></th>
+                       <th><strong>Target Exchange</strong></th>
+                       <th><strong>Routing Key</strong></th>
                    </tr>
                    <tr>
                        <td><code>loadToUsers({ Name: 'Bob')</code></td>
@@ -72,9 +67,30 @@
                        <td class="text-muted">empty (default)</td>
                    </tr>
                    <tr>
-                       <td><code>loadToUsers({ Name: 'Bob' }, { Source: ..., Type: .... })</code></td>
+                       <td><code>loadToUsers({ Name: 'Bob' }, 'admin')</code></td>
+                       <td>Users</td>
+                       <td>admin</td>
+                   </tr>
+                   <tr>
+                       <td>
+                           <code>loadToUsers({ Name: 'Bob' }, {<br />
+                               <span class="margin-left-lg">Id: ...,</span><br />
+                               <span class="margin-left-lg">PartitionKey: ...,</span><br />
+                               <span class="margin-left-lg">Source: ...,</span><br />
+                               <span class="margin-left-lg">Type: ...</span><br /> })
+                           </code>
+                       </td>
                        <td>Users</td>
                        <td class="text-muted">empty (default)</td>
+                   </tr>
+                   <tr>
+                       <td>
+                           <code>loadToUsers({ Name: 'Bob' }, 'admin', {<br />
+                               <span class="margin-left-lg">Type: ...,</span><br /> })
+                           </code>
+                       </td>
+                       <td>Users</td>
+                       <td>admin</td>
                    </tr>
                    <tr>
                        <td><code>loadTo('', { Name: 'Bob' }, 'users-queue')</code></td>

--- a/test/SlowTests/Server/Documents/ETL/Queue/KafkaEtlTests.cs
+++ b/test/SlowTests/Server/Documents/ETL/Queue/KafkaEtlTests.cs
@@ -219,6 +219,32 @@ public class KafkaEtlTests : KafkaEtlTestBase
     }
 
     [Fact]
+    public void Error_if_script_is_empty()
+    {
+        var config = new QueueEtlConfiguration
+        {
+            Name = "test",
+            ConnectionStringName = "test",
+            BrokerType = QueueBrokerType.Kafka,
+            Transforms = { new Transformation { Name = "test", Collections = { "Orders" }, Script = @"" } }
+        };
+
+        config.Initialize(new QueueConnectionString
+        {
+            Name = "Foo",
+            BrokerType = QueueBrokerType.Kafka,
+            KafkaConnectionSettings = new KafkaConnectionSettings() { ConnectionOptions = new Dictionary<string, string> { }, BootstrapServers = "localhost:29092" }
+        });
+
+        List<string> errors;
+        config.Validate(out errors);
+
+        Assert.Equal(1, errors.Count);
+
+        Assert.Equal("Script 'test' must not be empty", errors[0]);
+    }
+
+    [Fact]
     public async Task CanTestScript()
     {
         using (var store = GetDocumentStore())

--- a/test/SlowTests/Server/Documents/ETL/Queue/RabbitMqEtlTests.cs
+++ b/test/SlowTests/Server/Documents/ETL/Queue/RabbitMqEtlTests.cs
@@ -383,6 +383,33 @@ public class RabbitMqEtlTests : RabbitMqEtlTestBase
     }
 
     [Fact]
+    public void Error_if_script_is_empty()
+    {
+        var config = new QueueEtlConfiguration
+        {
+            Name = "test",
+            ConnectionStringName = "test",
+            BrokerType = QueueBrokerType.RabbitMq,
+            Transforms = { new Transformation { Name = "test", Collections = { "Orders" }, Script = @"" } }
+        };
+
+        config.Initialize(new QueueConnectionString
+        {
+            Name = "Foo",
+            BrokerType = QueueBrokerType.RabbitMq,
+            RabbitMqConnectionSettings =
+                new RabbitMqConnectionSettings() { ConnectionString = "amqp://guest:guest@localhost:5672/" }
+        });
+
+        List<string> errors;
+        config.Validate(out errors);
+
+        Assert.Equal(1, errors.Count);
+
+        Assert.Equal("Script 'test' must not be empty", errors[0]);
+    }
+
+    [Fact]
     public async Task CanTestScript()
     {
         using (var store = GetDocumentStore())

--- a/test/SlowTests/Server/Documents/ETL/SQL/RavenDB_9626.cs
+++ b/test/SlowTests/Server/Documents/ETL/SQL/RavenDB_9626.cs
@@ -48,5 +48,39 @@ namespace SlowTests.Server.Documents.ETL.SQL
                          "If you are using the SQL replication script from RavenDB 3.x version then please use `loadTo<TableName>()` instead.", errors[0]);
 
         }
+
+        [Fact]
+        public void Error_if_script_is_empty()
+        {
+            var config = new SqlEtlConfiguration
+            {
+                Name = "test",
+                ConnectionStringName = "test",
+                Transforms =
+                {
+                    new Transformation
+                    {
+                        Name = "test",
+                        Collections = {"Users"},
+                        Script = @""
+                    }
+                },
+                SqlTables =
+                {
+                    new SqlEtlTable {TableName = "Orders", DocumentIdColumn = "Id", InsertOnlyMode = false},
+                    new SqlEtlTable {TableName = "OrderLines", DocumentIdColumn = "OrderId", InsertOnlyMode = false},
+                }
+            };
+
+            config.Initialize(new SqlConnectionString { ConnectionString = @"Data Source=localhost\sqlexpress" });
+
+            List<string> errors;
+            config.Validate(out errors);
+
+            Assert.Equal(1, errors.Count);
+
+            Assert.Equal("Script 'test' must not be empty", errors[0]);
+
+        }
     }
 }

--- a/test/SlowTests/Smuggler/BackupDatabaseRecordTests.cs
+++ b/test/SlowTests/Smuggler/BackupDatabaseRecordTests.cs
@@ -165,7 +165,7 @@ namespace SlowTests.Smuggler
                         Name = "sql",
                         ParameterizeDeletes = false,
                         MentorNode = "A",
-                        Transforms = new List<Transformation>{new() {Script = "",Collections = new List<string>{"Orders"},Name ="testScript"}}
+                        Transforms = new List<Transformation>{new() {Script = "loadToOrders(this)", Collections = new List<string>{"Orders"},Name ="testScript"}}
                     }));
                     await store1.Maintenance.SendAsync(new UpdatePeriodicBackupOperation(config));
 
@@ -369,7 +369,7 @@ namespace SlowTests.Smuggler
                         Name = "sql",
                         ParameterizeDeletes = false,
                         MentorNode = "A",
-                        Transforms = new List<Transformation>{new() {Script = "",Collections = new List<string>{"Orders"},Name ="testScript"}}
+                        Transforms = new List<Transformation>{new() {Script = "loadToOrders(this)", Collections = new List<string>{"Orders"},Name ="testScript"}}
                     }));
                     var migrate = new Migrator(new DatabasesMigrationConfiguration
                     {
@@ -816,7 +816,7 @@ namespace SlowTests.Smuggler
                         ConnectionStringName = "scon1",
                         Name = "setl1",
                         AllowEtlOnNonEncryptedChannel = true,
-                        Transforms = new List<Transformation>{new() {Script = "",Collections = new List<string>{"Orders"},Name ="testScript"}},
+                        Transforms = new List<Transformation>{new() {Script = "loadToOrders(this)", Collections = new List<string>{"Orders"},Name ="testScript"}},
                         SqlTables =
                         {
                             new SqlEtlTable {TableName = "Orders", DocumentIdColumn = "Id"},
@@ -829,7 +829,7 @@ namespace SlowTests.Smuggler
                         ConnectionStringName = "scon2",
                         Name = "setl2",
                         AllowEtlOnNonEncryptedChannel = true,
-                        Transforms = new List<Transformation>{new() {Script = "",Collections = new List<string>{"Orders"},Name ="testScript"}},
+                        Transforms = new List<Transformation>{new() {Script = "loadToOrders(this)", Collections = new List<string>{"Orders"},Name ="testScript"}},
                         SqlTables =
                         {
                             new SqlEtlTable {TableName = "Orders", DocumentIdColumn = "Id"},
@@ -842,7 +842,7 @@ namespace SlowTests.Smuggler
                         ConnectionStringName = "scon3",
                         Name = "setl1",
                         AllowEtlOnNonEncryptedChannel = true,
-                        Transforms = new List<Transformation>{new() {Script = "",Collections = new List<string>{"Orders"},Name ="testScript"}},
+                        Transforms = new List<Transformation>{new() {Script = "loadToOrders(this)", Collections = new List<string>{"Orders"},Name ="testScript"}},
                         SqlTables =
                         {
                             new SqlEtlTable {TableName = "Orders", DocumentIdColumn = "Id"},
@@ -855,7 +855,7 @@ namespace SlowTests.Smuggler
                         ConnectionStringName = "scon4",
                         Name = "setl4",
                         AllowEtlOnNonEncryptedChannel = true,
-                        Transforms = new List<Transformation>{new() {Script = "",Collections = new List<string>{"Orders"},Name ="testScript"}},
+                        Transforms = new List<Transformation>{new() {Script = "loadToOrders(this)", Collections = new List<string>{"Orders"},Name ="testScript"}},
                         SqlTables =
                         {
                             new SqlEtlTable {TableName = "Orders", DocumentIdColumn = "Id"},
@@ -1109,7 +1109,7 @@ namespace SlowTests.Smuggler
                         Name = "sql",
                         ParameterizeDeletes = false,
                     MentorNode = "A",
-                    Transforms = new List<Transformation>{new() {Script = "",Collections = new List<string>{"Orders"},Name ="testScript"}}
+                    Transforms = new List<Transformation>{new() {Script = "loadToOrders(this)",Collections = new List<string>{"Orders"},Name ="testScript"}}
                     }));
 
                     using (var session = store.OpenAsyncSession())


### PR DESCRIPTION

### Issue link

https://issues.hibernatingrhinos.com/issue/RavenDB-18815

### Additional description

Added missing validation

### Type of change

- Bug fix

### How risky is the change?

- Low 

### Backward compatibility

- Not relevant

### Is it platform specific issue?

- No

### Documentation update

- No documentation update is needed 

### Testing 

- Tests have been added that prove the fix is effective or that the feature works

### Is there any existing behavior change of other features due to this change?

- No

### UI work

- No UI work is needed
