### PR TITLE
RavenDB-18760 - Failing InterversionTests on 5.3 and 5.4 branches - f…

### DIFF
--- a/src/Raven.Server/Smuggler/Documents/Handlers/SmugglerHandler.cs
+++ b/src/Raven.Server/Smuggler/Documents/Handlers/SmugglerHandler.cs
@@ -740,7 +740,7 @@ namespace Raven.Server.Smuggler.Documents.Handlers
                 operateOnTypes != null && 
                 Enum.TryParse(typeof(DatabaseItemType), operateOnTypes, out _) == false)
             {
-                CheckClientVersion();
+                CheckClientVersion(operateOnTypes);
 
                 var itemsTypes = DatabaseItemType.None;
                 var types = operateOnTypes.Split(", ");
@@ -763,7 +763,7 @@ namespace Raven.Server.Smuggler.Documents.Handlers
                 operateOnDatabaseRecordTypes != null && 
                 Enum.TryParse(typeof(DatabaseRecordItemType), operateOnDatabaseRecordTypes, out _) == false)
             {
-                CheckClientVersion();
+                CheckClientVersion(operateOnDatabaseRecordTypes);
 
                 var databaseRecordItemsTypes = DatabaseRecordItemType.None;
                 var types = operateOnDatabaseRecordTypes.Split(", ");
@@ -792,11 +792,11 @@ namespace Raven.Server.Smuggler.Documents.Handlers
             }
         }
 
-        private void CheckClientVersion()
+        private void CheckClientVersion(string types)
         {
             if (RequestRouter.TryGetClientVersion(HttpContext, out var version) == false ||
                 (Version.TryParse(RavenVersionAttribute.Instance.AssemblyVersion, out var existingVersion) && version.CompareTo(existingVersion) <= 0))
-                throw new InvalidDataException("The value supplied in 'OperateOnTypes' and/or 'OperateOnDatabaseRecordTypes' is not parsable");
+                throw new InvalidDataException($"The value '{types}' supplied in 'OperateOnTypes' and/or 'OperateOnDatabaseRecordTypes' is not parsable");
         }
 
         [RavenAction("/databases/*/smuggler/import/csv", "POST", AuthorizationStatus.ValidUser, DisableOnCpuCreditsExhaustion = true)]

--- a/src/Raven.Server/Smuggler/Documents/Handlers/SmugglerHandler.cs
+++ b/src/Raven.Server/Smuggler/Documents/Handlers/SmugglerHandler.cs
@@ -24,7 +24,6 @@ using Raven.Client;
 using Raven.Client.Documents.Conventions;
 using Raven.Client.Documents.Operations;
 using Raven.Client.Documents.Smuggler;
-using Raven.Client.Exceptions;
 using Raven.Client.Exceptions.Security;
 using Raven.Client.Properties;
 using Raven.Client.Util;
@@ -795,11 +794,9 @@ namespace Raven.Server.Smuggler.Documents.Handlers
 
         private void CheckClientVersion()
         {
-            if (RequestRouter.TryGetClientVersion(HttpContext, out var version) == false)
-                throw new VersionNotFoundException("Could not find client version");
-
-            if (Version.TryParse(RavenVersionAttribute.Instance.AssemblyVersion, out var existingVersion) && version.CompareTo(existingVersion) <= 0)
-                throw new ClientVersionMismatchException($"Client version: {version.ToString(3)}, current version: {RavenVersionAttribute.Instance.AssemblyVersion}");
+            if (RequestRouter.TryGetClientVersion(HttpContext, out var version) == false ||
+                (Version.TryParse(RavenVersionAttribute.Instance.AssemblyVersion, out var existingVersion) && version.CompareTo(existingVersion) <= 0))
+                throw new InvalidDataException("The value supplied in 'OperateOnTypes' and/or 'OperateOnDatabaseRecordTypes' is not parsable");
         }
 
         [RavenAction("/databases/*/smuggler/import/csv", "POST", AuthorizationStatus.ValidUser, DisableOnCpuCreditsExhaustion = true)]

--- a/src/Raven.Server/Smuggler/Documents/Handlers/SmugglerHandler.cs
+++ b/src/Raven.Server/Smuggler/Documents/Handlers/SmugglerHandler.cs
@@ -740,7 +740,7 @@ namespace Raven.Server.Smuggler.Documents.Handlers
                 operateOnTypes != null && 
                 Enum.TryParse(typeof(DatabaseItemType), operateOnTypes, out _) == false)
             {
-                CheckClientVersion(operateOnTypes);
+                CheckClientVersion(operateOnTypes, nameof(DatabaseSmugglerOptions.OperateOnTypes));
 
                 var itemsTypes = DatabaseItemType.None;
                 var types = operateOnTypes.Split(", ");
@@ -763,7 +763,7 @@ namespace Raven.Server.Smuggler.Documents.Handlers
                 operateOnDatabaseRecordTypes != null && 
                 Enum.TryParse(typeof(DatabaseRecordItemType), operateOnDatabaseRecordTypes, out _) == false)
             {
-                CheckClientVersion(operateOnDatabaseRecordTypes);
+                CheckClientVersion(operateOnDatabaseRecordTypes, nameof(DatabaseSmugglerOptions.OperateOnDatabaseRecordTypes));
 
                 var databaseRecordItemsTypes = DatabaseRecordItemType.None;
                 var types = operateOnDatabaseRecordTypes.Split(", ");
@@ -792,11 +792,11 @@ namespace Raven.Server.Smuggler.Documents.Handlers
             }
         }
 
-        private void CheckClientVersion(string types)
+        private void CheckClientVersion(string value, string propertyName)
         {
             if (RequestRouter.TryGetClientVersion(HttpContext, out var version) == false ||
                 (Version.TryParse(RavenVersionAttribute.Instance.AssemblyVersion, out var existingVersion) && version.CompareTo(existingVersion) <= 0))
-                throw new InvalidDataException($"The value '{types}' supplied in 'OperateOnTypes' and/or 'OperateOnDatabaseRecordTypes' is not parsable");
+                throw new InvalidDataException($"The value '{value}' supplied in '{propertyName}' is not parsable");
         }
 
         [RavenAction("/databases/*/smuggler/import/csv", "POST", AuthorizationStatus.ValidUser, DisableOnCpuCreditsExhaustion = true)]


### PR DESCRIPTION
…ixing CanExportFromCurrentAndImportTo42

### Issue link

https://issues.hibernatingrhinos.com/issue/RavenDB-18760

### Additional description

Fix for CanExportFromCurrentAndImportTo42 test.

### Type of change

- Bug fix

### How risky is the change?

- Low 

### Backward compatibility

- Non breaking change

### Is it platform specific issue?

- No

### Documentation update

- No documentation update is needed 

### Testing 

- It has been verified by manual testing

### Is there any existing behavior change of other features due to this change?

- No

### UI work

- No UI work is needed
