### PR TITLE
RavenDB-18820 Keep all indexing data locally to avoid sharing data between indexes

### DIFF
--- a/src/Corax/Analyzers/Analyzer.cs
+++ b/src/Corax/Analyzers/Analyzer.cs
@@ -16,7 +16,6 @@ namespace Corax
         public static readonly ArrayPool<Token> TokensPool = ArrayPool<Token>.Create();
         public readonly int DefaultOutputSize;
         public readonly int DefaultTokenSize;
-        public int MaxCurrentLengthForSingleTerm;
         
         private readonly delegate*<Analyzer, ReadOnlySpan<byte>, ref Span<byte>, ref Span<Token>, void> _funcUtf8;
         private readonly delegate*<Analyzer, ReadOnlySpan<char>, ref Span<char>, ref Span<Token>, void> _funcUtf16;
@@ -66,7 +65,6 @@ namespace Corax
             _tokenBufferMultiplier = tokenBufferMultiplier;
             
             GetOutputBuffersSize(Constants.Analyzers.DefaultBufferForAnalyzers, out DefaultOutputSize, out DefaultTokenSize);
-            MaxCurrentLengthForSingleTerm = Constants.Analyzers.DefaultBufferForAnalyzers;
         }
 
         public void GetOutputBuffersSize(int inputSize, out int outputSize, out int tokenSize )

--- a/src/Corax/IndexWriter.cs
+++ b/src/Corax/IndexWriter.cs
@@ -342,7 +342,7 @@ namespace Corax
             void ExactInsert(ReadOnlySpan<byte> value)
             {
                 if (value.Length >= MaxTermLength)
-                    throw new InvalidDataException($"Term must be less than 1024 bytes in size. Actual length was {value.Length}");
+                    throw new InvalidDataException($"Term must be less than {MaxTermLength} bytes in size. Actual length was {value.Length}");
 
                 Slice slice;
                 if (value.Length == 0)

--- a/src/Corax/IndexWriter.cs
+++ b/src/Corax/IndexWriter.cs
@@ -62,6 +62,9 @@ namespace Corax
         private const string SuggestionsTreePrefix = "__Suggestion_";
         private Dictionary<int, Dictionary<Slice, int>> _suggestionsAccumulator;
 
+        //Let persist maximum calculated size of word locally.
+        private readonly int[] _maxTermLengthProceedPerAnalyzer;
+
 #pragma warning disable CS0169
         private Queue<long> _lastEntries; // keep last 256 items
 #pragma warning restore CS0169
@@ -82,8 +85,10 @@ namespace Corax
             _buffer = new Dictionary<Slice, List<long>>[bufferSize];
             for (int i = 0; i < bufferSize; ++i)
                 _buffer[i] = new Dictionary<Slice, List<long>>(SliceComparer.Instance);
+
+            _maxTermLengthProceedPerAnalyzer = ArrayPool<int>.Shared.Rent(fieldsMapping.Count);
         }
-        
+
         public IndexWriter([NotNull] StorageEnvironment environment, IndexFieldsMapping fieldsMapping) : this(fieldsMapping)
         {
             _environment = environment;
@@ -307,25 +312,38 @@ namespace Corax
 
             void AnalyzeInsert(Span<byte> wordsBuffer, Span<Token> tokens, ReadOnlySpan<byte> value)
             {
-                ref var analyzer = ref binding.Analyzer;
-                if (value.Length > analyzer.MaxCurrentLengthForSingleTerm)
+                var analyzer = binding.Analyzer;
+                if (value.Length > _maxTermLengthProceedPerAnalyzer[binding.FieldId])
                 {
                     analyzer.GetOutputBuffersSize(value.Length, out var outputSize, out var tokenSize);
                     if (wordsBuffer.Length < outputSize || tokens.Length < tokenSize)
+                    {
                         UnlikelyGrowBuffer(ref wordsBuffer, ref tokens, outputSize, tokenSize);
-                    analyzer.MaxCurrentLengthForSingleTerm = value.Length;
+                    }
+
+                    _maxTermLengthProceedPerAnalyzer[binding.FieldId] = value.Length;
                 }
 
                 analyzer.Execute(value, ref wordsBuffer, ref tokens);
                 for (int i = 0; i < tokens.Length; i++)
                 {
                     ref var token = ref tokens[i];
-                    ExactInsert(wordsBuffer.Slice(token.Offset, (int)token.Length));
+
+                    if (token.Offset + token.Length > wordsBuffer.Length)
+                        throw new InvalidDataException(
+                            $"Got tokens with: OFFSET {token.Offset}  | LENGTH: {token.Length}. Buffer is {Encodings.Utf8.GetString(wordsBuffer)}");
+                    
+                    var word = wordsBuffer.Slice(token.Offset, (int)token.Length);
+                    ExactInsert(word);
                 }
             }
 
+
             void ExactInsert(ReadOnlySpan<byte> value)
             {
+                if (value.Length >= MaxTermLength)
+                    throw new InvalidDataException($"Term must be less than 1024 bytes in size. Actual length was {value.Length}");
+
                 Slice slice;
                 if (value.Length == 0)
                 {
@@ -417,14 +435,14 @@ namespace Corax
                     }
 
                     var analyzer = binding.Analyzer;
-                    if (termValue.Length > analyzer.MaxCurrentLengthForSingleTerm)
+                    if (termValue.Length > _maxTermLengthProceedPerAnalyzer[binding.FieldId])
                     {
                         analyzer.GetOutputBuffersSize(termValue.Length, out int outputSize, out int tokenSize);
                         if (outputSize > wordSpace.Length)
                             UnlikelyGrowBuffer(ref wordSpace, ref tokenSpace, outputSize, tokenSize);
-                        analyzer.MaxCurrentLengthForSingleTerm = termValue.Length;
+                        _maxTermLengthProceedPerAnalyzer[binding.FieldId] = termValue.Length;
                     }
-                    
+
                     analyzer.Execute(termValue, ref wordSpace, ref tokenSpace);
 
                     for (int i = 0; i < tokenSpace.Length; i++)
@@ -514,17 +532,21 @@ namespace Corax
 
         private void UnlikelyGrowBuffer(ref Span<byte> buffer, ref Span<Token> tokens, int newBufferSize, int newTokenSize)
         {
-            Debug.Assert(buffer.Length <= newBufferSize);
-            Analyzer.BufferPool.Return(_encodingBufferHandler);
-            Analyzer.TokensPool.Return(_tokensBufferHandler);
+            if (newBufferSize > buffer.Length)
+            {
+                Analyzer.BufferPool.Return(_encodingBufferHandler);
+                _encodingBufferHandler = Analyzer.BufferPool.Rent(newBufferSize);
+                buffer = _encodingBufferHandler.AsSpan();
+            }
 
-            _encodingBufferHandler = Analyzer.BufferPool.Rent(newBufferSize);
-            _tokensBufferHandler = Analyzer.TokensPool.Rent(newTokenSize);
-
-            buffer = _encodingBufferHandler.AsSpan();
-            tokens = _tokensBufferHandler.AsSpan();
+            if (newTokenSize > tokens.Length)
+            {
+                Analyzer.TokensPool.Return(_tokensBufferHandler);
+                _tokensBufferHandler = Analyzer.TokensPool.Rent(newTokenSize);
+                tokens = _tokensBufferHandler.AsSpan();
+            }
         }
-        
+
         public void Commit()
         {
             using var _ = Transaction.Allocator.Allocate(Container.MaxSizeInsideContainerPage, out Span<byte> tmpBuf);
@@ -623,6 +645,9 @@ namespace Corax
         private unsafe void AddNewTerm(List<long> entries, CompactTree fieldTree, ReadOnlySpan<byte> termsSpan, Span<byte> tmpBuf, CompactTree.EncodedKey encodedKey,
             bool validEncodedKey = true)
         {
+            if (entries.Count == 0)
+                return;
+            
             // common for unique values (guid, date, etc)
             if (entries.Count == 1)
             {
@@ -684,6 +709,8 @@ namespace Corax
             _jsonOperationContext?.Dispose();
             if (_ownsTransaction)
                 Transaction?.Dispose();
+
+            ArrayPool<int>.Shared.Return(_maxTermLengthProceedPerAnalyzer);
 
             if (_encodingBufferHandler != null)
                 Analyzer.BufferPool.Return(_encodingBufferHandler);

--- a/src/Corax/Queries/MemoizationMatch.Provider.cs
+++ b/src/Corax/Queries/MemoizationMatch.Provider.cs
@@ -6,7 +6,7 @@ using static Voron.Global.Constants;
 namespace Corax.Queries
 {
 
-    public unsafe class MemoizationMatchProvider<TInner> : IMemoizationMatchSource
+    public unsafe struct MemoizationMatchProvider<TInner> : IMemoizationMatchSource
              where TInner : IQueryMatch
     {
         private int _replayCounter;
@@ -82,8 +82,7 @@ namespace Corax.Queries
                 count += read;
             }
 
-        End:
-
+            End:
             // The problem is that multiple Fill calls do not ensure that we will get a sequence of ordered
             // values, therefore we must ensure that we get a 'sorted' sequence ensuring those happen.
             if (iterations > 1 && count > 1)

--- a/src/Raven.Server/Documents/Indexes/Persistence/Corax/CoraxBooleanQuery.cs
+++ b/src/Raven.Server/Documents/Indexes/Persistence/Corax/CoraxBooleanQuery.cs
@@ -43,13 +43,15 @@ public readonly struct CoraxBooleanItem : IQueryMatch
         Unsafe.SkipInit(out BetweenRight);
 
         if (operation is UnaryMatchOperation.Equals or UnaryMatchOperation.NotEquals)
+        {
             TermAsString = QueryBuilderHelper.CoraxGetValueAsString(term);
+            Count = searcher.TermAmount(name, TermAsString);
+        }
         else
+        {
             Unsafe.SkipInit(out TermAsString);
-
-        Count = operation is UnaryMatchOperation.Equals or UnaryMatchOperation.NotEquals
-            ? searcher.TermAmount(name, TermAsString)
-            : searcher.GetEntriesAmountInField(name);
+            Count = searcher.GetEntriesAmountInField(name);
+        }
     }
 
     public CoraxBooleanItem(IndexSearcher searcher, string name, int fieldId, object term1, object term2, UnaryMatchOperation operation, UnaryMatchOperation left,

--- a/src/Raven.Server/Documents/Indexes/Persistence/IndexOperationBase.cs
+++ b/src/Raven.Server/Documents/Indexes/Persistence/IndexOperationBase.cs
@@ -2,6 +2,7 @@
 using System.Runtime.CompilerServices;
 using Lucene.Net.Analysis;
 using Lucene.Net.Search;
+using Raven.Server.Documents.Indexes.Persistence.Corax;
 using Raven.Server.Documents.Queries;
 using Raven.Server.Documents.Queries.AST;
 using Raven.Server.Documents.Queries.Results;
@@ -19,6 +20,7 @@ namespace Raven.Server.Documents.Indexes.Persistence;
 public abstract class IndexOperationBase : IDisposable
 {
     protected readonly string _indexName;
+    private const int DefaultBufferSizeForCorax = 4 * 1024;
 
     protected readonly Logger _logger;
     internal Index _index;
@@ -119,22 +121,25 @@ public abstract class IndexOperationBase : IDisposable
         
         if (numberOfEntries == 0)
             return 16;
-
-        if (pageSize <= 0)
-            return (int)numberOfEntries;
-        
-        if (numberOfEntries > int.MaxValue)
-            return int.MaxValue;
         
         //If we have a binary operation, we need to pass a buffer large enough to hold all the individual results.
         //We need to do this to get correct results and since we don't know how much results subqueries will have  we must create a buffer big enough to get all items from index
         if (query.Metadata.OrderBy is not null || query.Metadata.IsDistinct || isBoolean)
+        {
+            if (numberOfEntries > int.MaxValue)
+                return int.MaxValue;
+            
             return (int)numberOfEntries;
-
-        var result = Math.Min(numberOfEntries, pageSize);
-        return (int)(result <= 0 ? 2 << 4 : result);
+        }
+        
+        if (pageSize <= 0 && numberOfEntries < int.MaxValue)
+            return (int)numberOfEntries;
+        
+        return numberOfEntries > int.MaxValue 
+            ? int.MaxValue 
+            : DefaultBufferSizeForCorax;
     }
-
+    
     protected QueryFilter GetQueryFilter(Index index, IndexQueryServerSide query, DocumentsOperationContext documentsContext, Reference<int> skippedResults,
         Reference<int> scannedDocuments, IQueryResultRetriever retriever, QueryTimingsScope queryTimings)
     {


### PR DESCRIPTION
….

### Issue link

https://issues.hibernatingrhinos.com/issue/RavenDB-18820
### Additional description

Since we are sharing analyzer instances between indexes, we need to avoid writing index data into analyzer class.

### Type of change

- Bug fix


### How risky is the change?

- Low 
- Moderate 
- High
- Not relevant

### Backward compatibility


- Not relevant

### Is it platform specific issue?

- No

### Documentation update

- No documentation update is needed 

### Testing 

- It has been verified by manual testing

### Is there any existing behavior change of other features due to this change?

- No

### UI work

- No UI work is needed
