### PR TITLE
RavenDB-17310 - Tombstones_should_be_cleaned_only_after_backup_with_s…

### DIFF
--- a/test/SlowTests/Issues/RavenDB_8369.cs
+++ b/test/SlowTests/Issues/RavenDB_8369.cs
@@ -1,4 +1,5 @@
-﻿using System.Linq;
+﻿using System;
+using System.Linq;
 using System.Threading.Tasks;
 using FastTests.Server.Replication;
 using Raven.Client.Documents.Operations.Backups;
@@ -171,7 +172,9 @@ namespace SlowTests.Issues
             var backupPath = NewDataPath(suffix: "BackupFolder");
             using (var store = GetDocumentStore())
             {
-                var config = Backup.CreateBackupConfiguration(backupPath, backupType: backupType, incrementalBackupFrequency: "* */6 * * *");
+                int hour = (DateTime.Now.Hour + 1) % 24;
+                var timeCronExpression = $"30 {hour} * * *"; // happen in the middle of the next hour - cause the periodic backups to happen in a 30 minutes at least 
+                var config = Backup.CreateBackupConfiguration(backupPath, backupType: backupType, incrementalBackupFrequency: timeCronExpression);
                 var result = await store.Maintenance.SendAsync(new UpdatePeriodicBackupOperation(config));
 
                 using (var session = store.OpenSession())


### PR DESCRIPTION
### Issue link

https://issues.hibernatingrhinos.com/issue/RavenDB-17310

### Additional description

Fix SlowTests.Issues.RavenDB_8369.Tombstones_should_be_cleaned_only_after_backup_with_snapshot_backupwhen_delete_is_not_last_operation failure - Tombstones count in the end should be 1 but it's 0.

### Type of change

- Bug fix

### How risky is the change?

- Low 

### Backward compatibility

- Not relevant

### Is it platform specific issue?

- No

### Documentation update

- No documentation update is needed 

### Testing 

- Tests have been added that prove the fix is effective or that the feature works

### Is there any existing behavior change of other features due to this change?

- No

### UI work

- No UI work is needed
