### PR TITLE
RavenDB-18859 - Infinite loop when having a popular document in LoadDocument

### DIFF
--- a/src/Raven.Server/Documents/Indexes/Index.cs
+++ b/src/Raven.Server/Documents/Indexes/Index.cs
@@ -4250,7 +4250,7 @@ namespace Raven.Server.Documents.Indexes
 
             if (parameters.Sw.Elapsed > maxTimeForDocumentTransactionToRemainOpen)
             {
-                if (parameters.QueryContext.Documents.ShouldRenewTransactionsToAllowFlushing())
+                if (parameters.QueryContext.Documents.ShouldRenewTransactionsToAllowFlushing() || _forTestingPurposes is { ShouldRenewTransaction: true })
                     return CanContinueBatchResult.RenewTransaction;
 
                 // if we haven't had writes in the meantime, there is no point
@@ -5055,6 +5055,8 @@ namespace Raven.Server.Documents.Indexes
         internal class TestingStuff
         {
             internal Action ActionToCallInFinallyOfExecuteIndexing;
+
+            internal bool ShouldRenewTransaction;
 
             internal IDisposable CallDuringFinallyOfExecuteIndexing(Action action)
             {

--- a/src/Raven.Server/Documents/Indexes/Workers/HandleReferencesBase.ReferencesState.cs
+++ b/src/Raven.Server/Documents/Indexes/Workers/HandleReferencesBase.ReferencesState.cs
@@ -37,16 +37,14 @@ namespace Raven.Server.Documents.Indexes.Workers
                 dictionary.Clear();
             }
 
-            public void Set(ActionType actionType, string collection, Reference reference, string itemId, long lastIndexedParentEtag, TransactionOperationContext indexContext)
+            public void Set(ActionType actionType, string collection, ReferenceState referenceState, TransactionOperationContext indexContext)
             {
                 var dictionary = GetDictionary(actionType);
-                var referencedItemId = (string)reference.Key;
-                var referenceEtag = reference.Etag;
 
                 indexContext.Transaction.InnerTransaction.LowLevelTransaction.AfterCommitWhenNewTransactionsPrevented += _ =>
                 {
                     // we update this only after the transaction was committed
-                    dictionary[collection] = new ReferenceState(referencedItemId, referenceEtag, itemId, lastIndexedParentEtag);
+                    dictionary[collection] = referenceState;
 
 #if DEBUG
                     if (_setCollections.Add((actionType, collection)) == false)


### PR DESCRIPTION
### Issue link

https://issues.hibernatingrhinos.com/issue/RavenDB-18859

### Additional description

Add an infinite loop when having a popular document in LoadDocument

### Type of change

- Bug fix

### How risky is the change?

- Low 

### Is it platform specific issue?

- No

### Testing 

- Tests have been added that prove the fix is effective or that the feature works
