### PR TITLE
RavenDB-18760 - Failing InterversionTests on 5.3 and 5.4 branches

### DIFF
--- a/test/InterversionTests/SmugglerTests.cs
+++ b/test/InterversionTests/SmugglerTests.cs
@@ -138,23 +138,6 @@ namespace InterversionTests
             //Import
             var importOptions = new DatabaseSmugglerImportOptions { SkipRevisionCreation = true };
 
-            // Operate on types that will remain relevant for v4.2 
-            importOptions.OperateOnTypes &= ~(DatabaseItemType.TimeSeries | DatabaseItemType.ReplicationHubCertificates);
-            importOptions.OperateOnDatabaseRecordTypes = DatabaseRecordItemType.Client |
-                                                         DatabaseRecordItemType.ConflictSolverConfig |
-                                                         DatabaseRecordItemType.Expiration |
-                                                         DatabaseRecordItemType.ExternalReplications |
-                                                         DatabaseRecordItemType.PeriodicBackups |
-                                                         DatabaseRecordItemType.RavenConnectionStrings |
-                                                         DatabaseRecordItemType.RavenEtls |
-                                                         DatabaseRecordItemType.Revisions |
-                                                         DatabaseRecordItemType.Settings |
-                                                         DatabaseRecordItemType.SqlConnectionStrings |
-                                                         DatabaseRecordItemType.Sorters |
-                                                         DatabaseRecordItemType.SqlEtls |
-                                                         DatabaseRecordItemType.HubPullReplications |
-                                                         DatabaseRecordItemType.SinkPullReplications;
-
             if (excludeOn == ExcludeOn.Import)
                 importOptions.OperateOnTypes &= ~(DatabaseItemType.Attachments | DatabaseItemType.RevisionDocuments | DatabaseItemType.CounterGroups);
             var importOperation = await store42.Smuggler.ImportAsync(importOptions, file);
@@ -341,7 +324,7 @@ namespace InterversionTests
         private static async Task<Operation> Migrate(DocumentStore @from, DocumentStore to, DatabaseItemType exclude = DatabaseItemType.None)
         {
             using var client = new HttpClient();
-            var url = Uri.EscapeDataString($"{to.Urls.First()}/admin/remote-server/build/version?serverUrl={@from.Urls.First()}");
+            var url = $"{to.Urls.First()}/admin/remote-server/build/version?serverUrl={@from.Urls.First()}";
             var rawVersionRespond = (await client.GetAsync(url)).Content.ReadAsStringAsync().Result;
             var versionRespond = JsonConvert.DeserializeObject<BuildInfo>(rawVersionRespond);
 

--- a/test/InterversionTests/SmugglerTests.cs
+++ b/test/InterversionTests/SmugglerTests.cs
@@ -130,14 +130,31 @@ namespace InterversionTests
             if (excludeOn == ExcludeOn.Export)
                 exportOptions.OperateOnTypes &= ~(DatabaseItemType.Attachments | DatabaseItemType.RevisionDocuments | DatabaseItemType.CounterGroups);
             var exportOperation = await storeCurrent.Smuggler.ExportAsync(exportOptions, file);
-            
+
             await exportOperation.WaitForCompletionAsync(_operationTimeout);
 
             DatabaseStatistics expected = await storeCurrent.Maintenance.SendAsync(new GetStatisticsOperation());
 
             //Import
             var importOptions = new DatabaseSmugglerImportOptions { SkipRevisionCreation = true };
-            importOptions.OperateOnTypes &= ~DatabaseItemType.TimeSeries;
+
+            // Operate on types that will remain relevant for v4.2 
+            importOptions.OperateOnTypes &= ~(DatabaseItemType.TimeSeries | DatabaseItemType.ReplicationHubCertificates);
+            importOptions.OperateOnDatabaseRecordTypes = DatabaseRecordItemType.Client |
+                                                         DatabaseRecordItemType.ConflictSolverConfig |
+                                                         DatabaseRecordItemType.Expiration |
+                                                         DatabaseRecordItemType.ExternalReplications |
+                                                         DatabaseRecordItemType.PeriodicBackups |
+                                                         DatabaseRecordItemType.RavenConnectionStrings |
+                                                         DatabaseRecordItemType.RavenEtls |
+                                                         DatabaseRecordItemType.Revisions |
+                                                         DatabaseRecordItemType.Settings |
+                                                         DatabaseRecordItemType.SqlConnectionStrings |
+                                                         DatabaseRecordItemType.Sorters |
+                                                         DatabaseRecordItemType.SqlEtls |
+                                                         DatabaseRecordItemType.HubPullReplications |
+                                                         DatabaseRecordItemType.SinkPullReplications;
+
             if (excludeOn == ExcludeOn.Import)
                 importOptions.OperateOnTypes &= ~(DatabaseItemType.Attachments | DatabaseItemType.RevisionDocuments | DatabaseItemType.CounterGroups);
             var importOperation = await store42.Smuggler.ImportAsync(importOptions, file);


### PR DESCRIPTION
### Issue link

https://issues.hibernatingrhinos.com/issue/RavenDB-18760

### Additional description

Fix for `InterversionTests.SmugglerTests.CanMigrateFrom42ToCurrent`

### Type of change

- Bug fix

### How risky is the change?

- Low 

### Backward compatibility

- Non breaking change

### Is it platform specific issue?

- No

### Documentation update

- No documentation update is needed 

### Testing 

- It has been verified by manual testing

### Is there any existing behavior change of other features due to this change?

- No

### UI work

- No UI work is needed
