### PR TITLE
RavenDB-18603 - QueriesShouldFailoverIfIndexIsCompacting test fails

### DIFF
--- a/test/SlowTests/Issues/RavenDB-18554.cs
+++ b/test/SlowTests/Issues/RavenDB-18554.cs
@@ -36,32 +36,10 @@ namespace SlowTests.Issues
         }
 
 
-        [Theory]
-        [InlineData(true)]
-        [InlineData(false)]
-        public async Task QueriesShouldFailoverIfDatabaseIsCompacting(bool cluster = false)
+        [Fact]
+        public async Task QueriesShouldFailoverIfDatabaseIsCompactingSingleNode()
         {
-            Options storeOptions;
-            RavenServer leader = null;
-            List<RavenServer> nodes = null;
-            if (cluster)
-            {
-                (nodes, leader) = await CreateRaftCluster(2);
-                Assert.Equal(nodes.Count, 2);
-                storeOptions = new Options
-                {
-                    Server = leader, 
-                    ReplicationFactor = nodes.Count, 
-                    RunInMemory = false, 
-                    ModifyDocumentStore = (store) => store.Conventions.DisableTopologyUpdates = true
-                };
-                
-            }
-            else
-            {
-                storeOptions = new Options {RunInMemory = false};
-            }
-
+            var storeOptions = new Options {RunInMemory = false};
             using (var store = GetDocumentStore(storeOptions))
             {
                 // Prepare Server For Test
@@ -70,8 +48,6 @@ namespace SlowTests.Issues
                 using (var session = store.OpenAsyncSession())
                 {
                     await session.StoreAsync(c);
-                    if(cluster)
-                        session.Advanced.WaitForReplicationAfterSaveChanges(replicas: 1);
                     await session.SaveChangesAsync();
                     categoryId = c.Id;
                 }
@@ -84,33 +60,16 @@ namespace SlowTests.Issues
                 CompactSettings settings = new CompactSettings {DatabaseName = store.Database, Documents = true, Indexes = new[]{ index.IndexName } };
 
                 Exception exception = null;
-                List<Categoroies_Details.Entity> l = null;
+
                 var d = () =>
                 {
                     try
                     {
-                        if (cluster)
-                        {
-                            using (var store2 = new DocumentStore() // DisableTopologyUpdates is false, for letting failover work (failover updates the topology)
-                            {
-                                       Urls = (from node in nodes select node.WebUrl).ToArray<string>(),
-                                Database = store.Database,
-                                   }.Initialize())
-                            using (var session = store2.OpenSession())
-                            {
-                                l = session.Query<Categoroies_Details.Entity, Categoroies_Details>()
-                                    .ProjectInto<Categoroies_Details.Entity>()
-                                    .ToList();
-                            }
-                        }
-                        else
-                        {
-                            using (var session = store.OpenSession())
-                            {
-                                l = session.Query<Categoroies_Details.Entity, Categoroies_Details>()
-                                    .ProjectInto<Categoroies_Details.Entity>()
-                                    .ToList();
-                            }
+                        using (var session = store.OpenSession()) 
+                        { 
+                            var l = session.Query<Categoroies_Details.Entity, Categoroies_Details>()
+                                .ProjectInto<Categoroies_Details.Entity>()
+                                .ToList();
                         }
                     }
                     catch (Exception e)
@@ -119,63 +78,96 @@ namespace SlowTests.Issues
                     }
                 };
 
-                if (cluster)
-                {
-                    var responsibleNodeUrl = store.GetRequestExecutor(store.Database).Topology.Nodes[0].Url;
-                    var responsibleNode = nodes.Single(n => n.ServerStore.GetNodeHttpServerUrl() == responsibleNodeUrl);
-                    var database = await GetDatabase(responsibleNode, store.Database);
-                    database.ForTestingPurposesOnly().CompactionAfterDatabaseUnload = d;
-                }
-                else
-                {
-                    var database = await GetDatabase(store.Database);
-                    database.ForTestingPurposesOnly().CompactionAfterDatabaseUnload = d;
-                }
+                var database = await GetDatabase(store.Database);
+                database.ForTestingPurposesOnly().CompactionAfterDatabaseUnload = d;
 
                 var operation = store.Maintenance.Server.Send(new CompactDatabaseOperation(settings));
                 operation.WaitForCompletion();
 
-                if (cluster == false)
-                {
-                    Assert.NotNull(exception);
-                    Assert.True(exception is DatabaseDisabledException);
-                }
-                else
-                {
-                    Assert.Null(exception); // Failover
-                    Assert.NotNull(l);
-                    Assert.Equal(1, l.Count);
-                    Assert.Equal(categoryId, l[0].Id);
-                    Assert.Equal(Categoroies_Details.GenDetails(c), l[0].Details);
-                }
+                Assert.NotNull(exception);
+                Assert.True(exception is DatabaseDisabledException);
             }
         }
 
-        [Theory]
-        [InlineData(true)]
-        [InlineData(false)]
-        public async Task QueriesShouldFailoverIfIndexIsCompacting(bool cluster = false)
+        [Fact]
+        public async Task QueriesShouldFailoverIfDatabaseIsCompactingCluster()
         {
-            Options storeOptions;
-            RavenServer leader = null;
-            List<RavenServer> nodes = null;
-            if (cluster)
+            var (nodes, leader) = await CreateRaftCluster(2);
+            Assert.Equal(nodes.Count, 2);
+            var storeOptions = new Options
             {
-                (nodes, leader) = await CreateRaftCluster(2);
-                Assert.Equal(nodes.Count, 2);
-                storeOptions = new Options
-                {
-                    Server = leader,
-                    ReplicationFactor = nodes.Count,
-                    RunInMemory = false,
-                    ModifyDocumentStore = (store) => store.Conventions.DisableTopologyUpdates = true
-                };
-            }
-            else
-            {
-                storeOptions = new Options { RunInMemory = false };
-            }
+                Server = leader,
+                ReplicationFactor = nodes.Count,
+                RunInMemory = false,
+                ModifyDocumentStore = (store) => store.Conventions.DisableTopologyUpdates = true
+            };
 
+
+            using (var store = GetDocumentStore(storeOptions))
+            {
+                // Prepare Server For Test
+                string categoryId;
+                Category c = new Category { Name = $"n0", Description = $"d0" };
+                using (var session = store.OpenAsyncSession())
+                {
+                    await session.StoreAsync(c);
+                    session.Advanced.WaitForReplicationAfterSaveChanges(replicas: 1);
+                    await session.SaveChangesAsync();
+                    categoryId = c.Id;
+                }
+
+                var index = new Categoroies_Details();
+                index.Execute(store);
+                Indexes.WaitForIndexing(store);
+
+                // Test
+                CompactSettings settings = new CompactSettings { DatabaseName = store.Database, Documents = true, Indexes = new[] { index.IndexName } };
+
+                Exception exception = null;
+                List<Categoroies_Details.Entity> l = null;
+                var d = () =>
+                {
+                    try
+                    {
+                        using (var store2 = new DocumentStore() // DisableTopologyUpdates is false, for letting failover work (failover updates the topology)
+                               {
+                                   Urls = (from node in nodes select node.WebUrl).ToArray<string>(),
+                                   Database = store.Database,
+                               }.Initialize())
+                        using (var session = store2.OpenSession())
+                        {
+                            l = session.Query<Categoroies_Details.Entity, Categoroies_Details>()
+                                .ProjectInto<Categoroies_Details.Entity>()
+                                .ToList();
+                        }
+                    }
+                    catch (Exception e)
+                    {
+                        exception = e;
+                    }
+                };
+
+                var responsibleNodeUrl = store.GetRequestExecutor(store.Database).Topology.Nodes[0].Url;
+                var responsibleNode = nodes.Single(n => n.ServerStore.GetNodeHttpServerUrl() == responsibleNodeUrl);
+                var database = await GetDatabase(responsibleNode, store.Database);
+                database.ForTestingPurposesOnly().CompactionAfterDatabaseUnload = d;
+
+                var operation = store.Maintenance.Server.Send(new CompactDatabaseOperation(settings));
+                operation.WaitForCompletion();
+
+                // Check if failover succeeded
+                Assert.Null(exception);
+                Assert.NotNull(l);
+                Assert.Equal(1, l.Count);
+                Assert.Equal(categoryId, l[0].Id);
+                Assert.Equal(Categoroies_Details.GenDetails(c), l[0].Details);
+            }
+        }
+
+        [Fact]
+        public async Task QueriesShouldFailoverIfIndexIsCompactingSingleNode()
+        {
+            var storeOptions = new Options { RunInMemory = false };
             using (var store = GetDocumentStore(storeOptions))
             {
                 // Prepare Server For Test
@@ -184,8 +176,69 @@ namespace SlowTests.Issues
                 using (var session = store.OpenAsyncSession())
                 {
                     await session.StoreAsync(c);
-                    if (cluster)
-                        session.Advanced.WaitForReplicationAfterSaveChanges(replicas: 1); //Wait for replication
+                    await session.SaveChangesAsync();
+                    categoryId = c.Id;
+                }
+
+                // Wait for indexing in first node
+                var index = new Categoroies_Details();
+                index.Execute(store);
+                Indexes.WaitForIndexing(store);
+
+                // Test
+                CompactSettings settings = new CompactSettings {DatabaseName = store.Database, Documents = true, Indexes = new[] { index.IndexName } };
+
+                Exception exception = null;
+                var d = () =>
+                {
+                    try
+                    {
+                        using (var session = store.OpenSession())
+                        {
+                            var l = session.Query<Categoroies_Details.Entity, Categoroies_Details>()
+                                                .ProjectInto<Categoroies_Details.Entity>()
+                                                .ToList();
+                        }
+                    }
+                    catch (Exception e)
+                    {
+                        exception = e;
+                    }
+                };
+
+                var database = await GetDatabase(store.Database);
+                database.IndexStore.ForTestingPurposesOnly().IndexCompaction = d;
+
+                var operation = await store.Maintenance.Server.SendAsync(new CompactDatabaseOperation(settings));
+                await operation.WaitForCompletionAsync();
+
+                Assert.NotNull(exception);
+                Assert.True(exception is IndexCompactionInProgressException);
+            }
+        }
+
+        [Fact]
+        public async Task QueriesShouldFailoverIfIndexIsCompactingClaster()
+        {
+            var (nodes, leader) = await CreateRaftCluster(2);
+            Assert.Equal(nodes.Count, 2);
+            var storeOptions = new Options
+            {
+                Server = leader,
+                ReplicationFactor = nodes.Count,
+                RunInMemory = false,
+                ModifyDocumentStore = (store) => store.Conventions.DisableTopologyUpdates = true
+            };
+
+            using (var store = GetDocumentStore(storeOptions))
+            {
+                // Prepare Server For Test
+                string categoryId;
+                Category c = new Category { Name = $"n0", Description = $"d0" };
+                using (var session = store.OpenAsyncSession())
+                {
+                    await session.StoreAsync(c);
+                    session.Advanced.WaitForReplicationAfterSaveChanges(replicas: 1); //Wait for replication
                     await session.SaveChangesAsync();
                     categoryId = c.Id;
                 }
@@ -196,22 +249,20 @@ namespace SlowTests.Issues
                 Indexes.WaitForIndexing(store);
 
                 // Wait for indexing in second node (if it's cluster test)
-                if (cluster)
+                using (var storeReversedTopology = new DocumentStore()
+                       {
+                           Urls = (from node in nodes select node.WebUrl).Reverse().ToArray<string>(),
+                           Database = store.Database,
+                           Conventions = new DocumentConventions() {DisableTopologyUpdates = true}
+                       }.Initialize())
                 {
-                    var storeReversedTopology = new DocumentStore()
-                    {
-                        Urls = (from node in nodes select node.WebUrl).Reverse().ToArray<string>(),
-                        Database = store.Database,
-                        Conventions = new DocumentConventions() {DisableTopologyUpdates = true}
-                    }.Initialize();
-
                     var index2 = new Categoroies_Details();
                     index2.Execute(storeReversedTopology);
                     Indexes.WaitForIndexing(storeReversedTopology);
                 }
 
                 // Test
-                CompactSettings settings = new CompactSettings {DatabaseName = store.Database, Documents = true, Indexes = new[] { index.IndexName } };
+                CompactSettings settings = new CompactSettings { DatabaseName = store.Database, Documents = true, Indexes = new[] { index.IndexName } };
 
                 Exception exception = null;
                 List<Categoroies_Details.Entity> l = null;
@@ -219,28 +270,16 @@ namespace SlowTests.Issues
                 {
                     try
                     {
-                        if (cluster)
+                        using (var store2 = new DocumentStore() // DisableTopologyUpdates is false, for letting failover work (failover updates the topology)
+                               {
+                                   Urls = (from node in nodes select node.WebUrl).ToArray<string>(),
+                                   Database = store.Database,
+                               }.Initialize())
+                        using (var session = store2.OpenSession())
                         {
-                            using (var store2 = new DocumentStore() // DisableTopologyUpdates is false, for letting failover work (failover updates the topology)
-                                   {
-                                       Urls = (from node in nodes select node.WebUrl).ToArray<string>(), 
-                                       Database = store.Database,
-                                   }.Initialize())
-                            using (var session = store2.OpenSession())
-                            {
-                                l = session.Query<Categoroies_Details.Entity, Categoroies_Details>()
-                                    .ProjectInto<Categoroies_Details.Entity>()
-                                    .ToList();
-                            }
-                        }
-                        else
-                        {
-                            using (var session = store.OpenSession())
-                            {
-                                l = session.Query<Categoroies_Details.Entity, Categoroies_Details>()
-                                    .ProjectInto<Categoroies_Details.Entity>()
-                                    .ToList();
-                            }
+                            l = session.Query<Categoroies_Details.Entity, Categoroies_Details>()
+                                .ProjectInto<Categoroies_Details.Entity>()
+                                .ToList();
                         }
                     }
                     catch (Exception e)
@@ -249,35 +288,20 @@ namespace SlowTests.Issues
                     }
                 };
 
-                if (cluster)
-                {
-                    var responsibleNodeUrl = store.GetRequestExecutor(store.Database).Topology.Nodes[0].Url;
-                    var responsibleNode = nodes.Single(n => n.ServerStore.GetNodeHttpServerUrl() == responsibleNodeUrl);
-                    var database = await GetDatabase(responsibleNode, store.Database);
-                    database.IndexStore.ForTestingPurposesOnly().IndexCompaction = d;
-                }
-                else
-                {
-                    var database = await GetDatabase(store.Database);
-                    database.IndexStore.ForTestingPurposesOnly().IndexCompaction = d;
-                }
+                var responsibleNodeUrl = store.GetRequestExecutor(store.Database).Topology.Nodes[0].Url;
+                var responsibleNode = nodes.Single(n => n.ServerStore.GetNodeHttpServerUrl() == responsibleNodeUrl);
+                var database = await GetDatabase(responsibleNode, store.Database);
+                database.IndexStore.ForTestingPurposesOnly().IndexCompaction = d;
 
                 var operation = await store.Maintenance.Server.SendAsync(new CompactDatabaseOperation(settings));
                 await operation.WaitForCompletionAsync();
 
-                if (cluster == false)
-                {
-                    Assert.NotNull(exception);
-                    Assert.True(exception is IndexCompactionInProgressException);
-                }
-                else
-                {
-                    Assert.Null(exception); // Failover
-                    Assert.NotNull(l);
-                    Assert.Equal(1, l.Count);
-                    Assert.Equal(categoryId, l[0].Id);
-                    Assert.Equal(Categoroies_Details.GenDetails(c), l[0].Details);
-                }
+                // Check if failover succeeded
+                Assert.Null(exception);
+                Assert.NotNull(l);
+                Assert.Equal(1, l.Count);
+                Assert.Equal(categoryId, l[0].Id);
+                Assert.Equal(Categoroies_Details.GenDetails(c), l[0].Details);
             }
         }
 


### PR DESCRIPTION
### Issue link

https://issues.hibernatingrhinos.com/issue/RavenDB-18603

### Additional description

Fixing SlowTests.Issues.RavenDB_18554.SlowTests.Issues.RavenDB_18554.QueriesShouldFailoverIfIndexIsCompacting(cluster: True) failure.

### Type of change

- Bug fix

### How risky is the change?

- Low 

### Backward compatibility

- Not relevant

### Is it platform specific issue?

- No

### Documentation update

- No documentation update is needed 

### Testing 

- Tests have been added that prove the fix is effective or that the feature works

### Is there any existing behavior change of other features due to this change?

- No

### UI work

- No UI work is needed
