### PR TITLE
HRINT-2770 publish macos-arm64 builds

### DIFF
--- a/build.ps1
+++ b/build.ps1
@@ -104,7 +104,7 @@ if ([string]::IsNullOrEmpty($Target) -eq $false) {
     } 
 
     if ($MacOs) {
-        $Target = @( "macos" );
+        $Target = @( "macos-x64" );
     }
 
     if ($Rpi) {

--- a/scripts/target.ps1
+++ b/scripts/target.ps1
@@ -27,7 +27,7 @@ $TARGET_SPECS = (
         "Runtime"   = "osx-x64";
         "PkgType"   = "tar.bz2";
         "IsUnix"    = $True;
-        "TargetId" = "macos";
+        "TargetId" = "macos-x64";
         "NativeBinExtension" = "dylib";
     },
     @{

--- a/scripts/target.ps1
+++ b/scripts/target.ps1
@@ -62,6 +62,10 @@ function GetBuildTargets( $targets ) {
         return $TARGET_SPECS;
     }
 
+    if ($targets.Contains("macos")) {
+        $targets += "macos-x64"
+    }
+
     $result = @( );
 
     foreach ($spec in $TARGET_SPECS) {

--- a/scripts/upload.ps1
+++ b/scripts/upload.ps1
@@ -4,17 +4,19 @@ $CATEGORIES = @(
 
     @('RavenDB-[0-9]\.[0-9]\.[0-9]+(-[a-zA-Z]+-([0-9-]+))?-windows-x64.Tools', "RavenDB Tools for Windows x64"),
     @('RavenDB-[0-9]\.[0-9]\.[0-9]+(-[a-zA-Z]+-([0-9-]+))?-windows-x86.Tools', "RavenDB Tools for Windows x86"),
-    @('RavenDB-[0-9]\.[0-9]\.[0-9]+(-[a-zA-Z]+-([0-9-]+))?-macos-x64.Tools', "RavenDB Tools for macOS"),
+    @('RavenDB-[0-9]\.[0-9]\.[0-9]+(-[a-zA-Z]+-([0-9-]+))?-macos-x64.Tools', "RavenDB Tools for macOS x64"),
+    @('RavenDB-[0-9]\.[0-9]\.[0-9]+(-[a-zA-Z]+-([0-9-]+))?-macos-arm64.Tools', "RavenDB Tools for macOS arm64"),
     @('RavenDB-[0-9]\.[0-9]\.[0-9]+(-[a-zA-Z]+-([0-9-]+))?-raspberry-pi.Tools', "RavenDB Tools for Raspberry Pi"),
     @('RavenDB-[0-9]\.[0-9]\.[0-9]+(-[a-zA-Z]+-([0-9-]+))?-linux-x64.Tools', "RavenDB Tools for Linux x64"),
-    @('RavenDB-[0-9]\.[0-9]\.[0-9]+(-[a-zA-Z]+-([0-9-]+))?-linux-arm64.Tools', "RavenDB Tools for Linux ARM64"),
+    @('RavenDB-[0-9]\.[0-9]\.[0-9]+(-[a-zA-Z]+-([0-9-]+))?-linux-arm64.Tools', "RavenDB Tools for Linux arm64"),
 
     @('RavenDB-[0-9]\.[0-9]\.[0-9]+(-[a-zA-Z]+-([0-9-]+))?-windows-x64', "RavenDB for Windows x64"),
     @('RavenDB-[0-9]\.[0-9]\.[0-9]+(-[a-zA-Z]+-([0-9-]+))?-windows-x86', "RavenDB for Windows x86"),
-    @('RavenDB-[0-9]\.[0-9]\.[0-9]+(-[a-zA-Z]+-([0-9-]+))?-macos-x64', "RavenDB for macOS"),
+    @('RavenDB-[0-9]\.[0-9]\.[0-9]+(-[a-zA-Z]+-([0-9-]+))?-macos-x64', "RavenDB for macOS x64"),
+    @('RavenDB-[0-9]\.[0-9]\.[0-9]+(-[a-zA-Z]+-([0-9-]+))?-macos-arm64', "RavenDB for macOS arm64"),
     @('RavenDB-[0-9]\.[0-9]\.[0-9]+(-[a-zA-Z]+-([0-9-]+))?-raspberry-pi', "RavenDB for Raspberry Pi"),
     @('RavenDB-[0-9]\.[0-9]\.[0-9]+(-[a-zA-Z]+-([0-9-]+))?-linux-x64', "RavenDB for Linux x64"),
-    @('RavenDB-[0-9]\.[0-9]\.[0-9]+(-[a-zA-Z]+-([0-9-]+))?-linux-arm64', "RavenDB for Linux ARM64")
+    @('RavenDB-[0-9]\.[0-9]\.[0-9]+(-[a-zA-Z]+-([0-9-]+))?-linux-arm64', "RavenDB for Linux arm64")
 )
 
 function Get-UploadCategory ( $filename ) {


### PR DESCRIPTION
### Issue link

https://issues.hibernatingrhinos.com/issue/HRINT-2770

### Additional description

Add macOS arm64 publishing and adjust Linux arm build naming.

### Type of change

- Publish scripts

### How risky is the change?

- Moderate

### Backward compatibility

- Ensured - older platform strings are still supported by the publishing mechanism

### Is it platform specific issue?

- Yes - macOS

### Documentation update

- No documentation update is needed 

### Testing 

- Tests have been added that prove the fix is effective or that the feature works
- It has been verified by manual testing TODO

### Is there any existing behavior change of other features due to this change?

- No

### UI work

- No UI work is needed
