### PR TITLE
RavenDB-18852 Support range queries using the index instead of scan

### DIFF
--- a/bench/Micro.Benchmark/Micro.Benchmark.csproj
+++ b/bench/Micro.Benchmark/Micro.Benchmark.csproj
@@ -4,6 +4,8 @@
     <RuntimeFrameworkVersion>6.0.6</RuntimeFrameworkVersion>
     <AllowUnsafeBlocks>true</AllowUnsafeBlocks>
     <AssemblyName>Micro.Benchmark</AssemblyName>
+    <EnablePreviewFeatures>True</EnablePreviewFeatures>
+
     <OutputType>Exe</OutputType>
     <PackageId>Micro.Benchmark</PackageId>
     <RuntimeIdentifiers>win7-x64;win8-x64;win10-x64;ubuntu.14.04-x64</RuntimeIdentifiers>

--- a/bench/SubscriptionFailover.Benchmark/SubscriptionFailover.Benchmark.csproj
+++ b/bench/SubscriptionFailover.Benchmark/SubscriptionFailover.Benchmark.csproj
@@ -3,6 +3,7 @@
     <OutputType>Exe</OutputType>
     <TargetFramework>net6.0</TargetFramework>
     <RuntimeFrameworkVersion>6.0.6</RuntimeFrameworkVersion>
+    <EnablePreviewFeatures>True</EnablePreviewFeatures>
     <CodeAnalysisRuleSet>..\..\RavenDB.ruleset</CodeAnalysisRuleSet>
   </PropertyGroup>
   <ItemGroup>

--- a/bench/Voron.Benchmark/Voron.Benchmark.csproj
+++ b/bench/Voron.Benchmark/Voron.Benchmark.csproj
@@ -4,6 +4,8 @@
     <RuntimeFrameworkVersion>6.0.6</RuntimeFrameworkVersion>
     <AllowUnsafeBlocks>true</AllowUnsafeBlocks>
     <AssemblyName>Voron.Benchmark</AssemblyName>
+    <EnablePreviewFeatures>True</EnablePreviewFeatures>
+
     <OutputType>Exe</OutputType>
     <PackageId>Voron.Benchmark</PackageId>
     <RuntimeIdentifiers>win7-x64;win8-x64;win10-x64;ubuntu.14.04-x64</RuntimeIdentifiers>

--- a/src/Corax/Analyzers/Analyzer.cs
+++ b/src/Corax/Analyzers/Analyzer.cs
@@ -102,10 +102,12 @@ namespace Corax
             }
 
             int result = transformer.Transform(source, tokens, ref outputBufferSpace, ref outputTokenSpace);
+            output = output.Slice(0, outputBufferSpace.Length);
+            outputTokens = outputTokens.Slice(0, outputTokenSpace.Length);
 
             if (transformer.RequiresBufferSpace)
             {
-                outputBufferSpace.CopyTo(output);
+                outputBufferSpace.CopyTo(output);                
                 BufferPool.Return(sourceTempBufferHolder);
             }
 
@@ -113,10 +115,7 @@ namespace Corax
             {
                 outputTokenSpace.CopyTo(outputTokens);
                 TokensPool.Return(tokensTempBufferHolder);
-            }
-
-            output = output.Slice(0, outputBufferSpace.Length);
-            outputTokens = outputTokens.Slice(0, outputTokenSpace.Length);
+            }                      
 
             return result;
         }
@@ -143,10 +142,12 @@ namespace Corax
             }
 
             int result = transformer.Transform(source, tokens, ref outputBufferSpace, ref outputTokenSpace);
+            output = output.Slice(0, outputBufferSpace.Length);
+            outputTokens = outputTokens.Slice(0, outputTokenSpace.Length);
 
             if (transformer.RequiresBufferSpace)
             {
-                outputBufferSpace.CopyTo(output);
+                outputBufferSpace.CopyTo(output);                
                 BufferPool.Return(sourceTempBufferHolder);
             }
 
@@ -155,9 +156,6 @@ namespace Corax
                 outputTokenSpace.CopyTo(outputTokens);
                 TokensPool.Return(tokensTempBufferHolder);
             }
-
-            output = output.Slice(0, outputBufferSpace.Length);
-            outputTokens = outputTokens.Slice(0, outputTokenSpace.Length);
 
             return result;
         }

--- a/src/Corax/Analyzers/Analyzer.cs
+++ b/src/Corax/Analyzers/Analyzer.cs
@@ -316,7 +316,7 @@ namespace Corax
 
             static void RunUtf8WithConversion(Analyzer analyzer, ReadOnlySpan<byte> source, ref Span<byte> output, ref Span<Token> tokens)
             {
-                var buffer = BufferPool.Rent(source.Length * 5);
+                var buffer = BufferPool.Rent(source.Length * 10);
                 
                 Span<char> charBuffer = MemoryMarshal.Cast<byte, char>(buffer.AsSpan());
                 int characters = Encoding.UTF8.GetChars(source, charBuffer);
@@ -472,9 +472,12 @@ namespace Corax
         [MethodImpl(MethodImplOptions.AggressiveInlining)]
         public void Execute(ReadOnlySpan<byte> source, ref Span<byte> output, ref Span<Token> tokens)
         {
-            Debug.Assert(output.Length >= (int)(_sourceBufferMultiplier * source.Length));
-            Debug.Assert(tokens.Length >= (int)(_tokenBufferMultiplier * source.Length));
-            
+            if (output.Length < (int)(_sourceBufferMultiplier * source.Length))
+                throw new ArgumentException("Buffer is too small");
+            if (tokens.Length < (int)(_tokenBufferMultiplier * source.Length))
+                throw new ArgumentException("Buffer is too small");
+
+                    
             _funcUtf8(this, source, ref output, ref tokens);
         }
 

--- a/src/Corax/Corax.csproj
+++ b/src/Corax/Corax.csproj
@@ -6,6 +6,8 @@
     <TargetFramework>net6.0</TargetFramework>
     <RuntimeFrameworkVersion>6.0.6</RuntimeFrameworkVersion>
     <AllowUnsafeBlocks>true</AllowUnsafeBlocks>
+    <EnablePreviewFeatures>True</EnablePreviewFeatures>
+
     <AssemblyName>Corax</AssemblyName>
     <PackageId>Corax</PackageId>
     <PackageTags>storage;acid;corax;ravendb;nosql</PackageTags>

--- a/src/Corax/IndexEntry/IndexEntryWriter.cs
+++ b/src/Corax/IndexEntry/IndexEntryWriter.cs
@@ -399,6 +399,8 @@ public unsafe ref partial struct IndexEntryWriter
         longPtrLocation = dataLocation;
         dataLocation += VariableSizeEncoding.WriteMany(_buffer, longValues, pos: dataLocation);
 
+        ArrayPool<int>.Shared.Return(stringLengths);
+        
         Done:
         _dataIndex = dataLocation;
     }

--- a/src/Corax/IndexFieldsMapping.cs
+++ b/src/Corax/IndexFieldsMapping.cs
@@ -30,11 +30,37 @@ public class IndexFieldsMapping : IEnumerable<IndexFieldBinding>
         _fieldsList = new List<IndexFieldBinding>();
     }
 
+    
+    private const int I64Postfix = 875972909; //"-I64"
+    private const int DblPostfix = 1818379309; //"-Dbl"
+
+    public ByteStringContext<ByteStringMemoryCache>.InternalScope GetFieldNameForLongs(Slice fieldName, out Slice fieldNameForLongs)
+    {
+        return GetFieldNameWithPostfix(fieldName, I64Postfix, out fieldNameForLongs);
+    }
+    
+    public ByteStringContext<ByteStringMemoryCache>.InternalScope GetFieldNameForDoubles(Slice fieldName, out Slice fieldNameForDoubles)
+    {
+        return GetFieldNameWithPostfix(fieldName, DblPostfix, out fieldNameForDoubles);
+    }
+
+    private unsafe ByteStringContext<ByteStringMemoryCache>.InternalScope GetFieldNameWithPostfix(Slice fieldName, int postfix, out Slice fieldWithPostfix)
+    {
+        var scope = _context.Allocate(fieldName.Size + sizeof(int), out ByteString output);
+        fieldName.Content.CopyTo(output.Ptr);
+        *(int*)(output.Ptr + fieldName.Size) = postfix;
+        fieldWithPostfix = new Slice(SliceOptions.Key, output);
+        return scope;
+    }
+
     public IndexFieldsMapping AddBinding(int fieldId, Slice fieldName, Analyzer analyzer = null, bool hasSuggestion = false, FieldIndexingMode fieldIndexingMode = FieldIndexingMode.Normal, bool hasSpatial = false)
     {
         if (!_fieldsById.TryGetValue(fieldId, out var storedAnalyzer))
         {
-            var binding = new IndexFieldBinding(fieldId, fieldName, analyzer, hasSuggestion, fieldIndexingMode, hasSpatial);
+            GetFieldNameForDoubles(fieldName, out var fieldNameDouble);
+            GetFieldNameForLongs(fieldName, out var fieldNameLong);
+            var binding = new IndexFieldBinding(fieldId, fieldName,  fieldNameLong,fieldNameDouble, 
+                analyzer, hasSuggestion, fieldIndexingMode, hasSpatial);
             _fields[fieldName] = binding;
             _fieldsById[fieldId] = binding;
             _fieldsList.Add(binding);
@@ -131,6 +157,8 @@ public class IndexFieldBinding
 {
     public readonly int FieldId;
     public readonly Slice FieldName;
+    public readonly Slice FieldNameLong;
+    public readonly Slice FieldNameDouble;
     public Corax.Analyzer Analyzer;
     public readonly bool HasSuggestions;
     public readonly bool HasSpatial;
@@ -139,10 +167,15 @@ public class IndexFieldBinding
     private FieldIndexingMode? _silentlyChangedIndexingMode;
     private string _fieldName;
 
-    public IndexFieldBinding(int fieldId, Slice fieldName, Analyzer analyzer = null, bool hasSuggestions = false, FieldIndexingMode fieldIndexingMode = FieldIndexingMode.Normal, bool hasSpatial = false)
+    public IndexFieldBinding(int fieldId, Slice fieldName, Slice fieldNameLong,Slice fieldNameDouble,
+        Analyzer analyzer = null, bool hasSuggestions = false, 
+        FieldIndexingMode fieldIndexingMode = FieldIndexingMode.Normal, 
+        bool hasSpatial = false)
     {
         FieldId = fieldId;
         FieldName = fieldName;
+        FieldNameDouble = fieldNameDouble;
+        FieldNameLong = fieldNameLong;
         Analyzer = analyzer;
         HasSuggestions = hasSuggestions;
         _fieldIndexingMode = fieldIndexingMode;
@@ -153,7 +186,7 @@ public class IndexFieldBinding
     {
         get
         {
-            return _fieldName ?? (_fieldName = FieldName.ToString());
+            return _fieldName ??= FieldName.ToString();
         }
     }
     

--- a/src/Corax/IndexFieldsMapping.cs
+++ b/src/Corax/IndexFieldsMapping.cs
@@ -31,24 +31,24 @@ public class IndexFieldsMapping : IEnumerable<IndexFieldBinding>
     }
 
     
-    private const int I64Postfix = 875972909; //"-I64"
-    private const int DblPostfix = 1818379309; //"-Dbl"
+    private const short LongSuffix = 19501; //"-L"
+    private const short DoubleSuffix = 17453; //"-D"
 
     public ByteStringContext<ByteStringMemoryCache>.InternalScope GetFieldNameForLongs(Slice fieldName, out Slice fieldNameForLongs)
     {
-        return GetFieldNameWithPostfix(fieldName, I64Postfix, out fieldNameForLongs);
+        return GetFieldNameWithPostfix(fieldName, LongSuffix, out fieldNameForLongs);
     }
     
     public ByteStringContext<ByteStringMemoryCache>.InternalScope GetFieldNameForDoubles(Slice fieldName, out Slice fieldNameForDoubles)
     {
-        return GetFieldNameWithPostfix(fieldName, DblPostfix, out fieldNameForDoubles);
+        return GetFieldNameWithPostfix(fieldName, DoubleSuffix, out fieldNameForDoubles);
     }
 
-    private unsafe ByteStringContext<ByteStringMemoryCache>.InternalScope GetFieldNameWithPostfix(Slice fieldName, int postfix, out Slice fieldWithPostfix)
+    private unsafe ByteStringContext<ByteStringMemoryCache>.InternalScope GetFieldNameWithPostfix(Slice fieldName, short postfix, out Slice fieldWithPostfix)
     {
-        var scope = _context.Allocate(fieldName.Size + sizeof(int), out ByteString output);
+        var scope = _context.Allocate(fieldName.Size + sizeof(short), out ByteString output);
         fieldName.Content.CopyTo(output.Ptr);
-        *(int*)(output.Ptr + fieldName.Size) = postfix;
+        *(short*)(output.Ptr + fieldName.Size) = postfix;
         fieldWithPostfix = new Slice(SliceOptions.Key, output);
         return scope;
     }

--- a/src/Corax/IndexSearcher/IndexSearcher.MultiTermMatches.cs
+++ b/src/Corax/IndexSearcher/IndexSearcher.MultiTermMatches.cs
@@ -28,6 +28,12 @@ public partial class IndexSearcher
     }
     
     [MethodImpl(MethodImplOptions.AggressiveInlining)]
+    public MultiTermMatch BetweenQuery(Slice field, Slice fieldLongs, double low, double high, bool isNegated = false, int fieldId = Constants.IndexSearcher.NonAnalyzer)
+    {
+        return RangeBuilder<NullScoreFunction, Range.Inclusive, Range.Inclusive>(field, fieldLongs, low, high, default, isNegated);
+    }
+    
+    [MethodImpl(MethodImplOptions.AggressiveInlining)]
     public MultiTermMatch GreaterThanQuery(Slice field, Slice value, bool isNegated = false, int fieldId = Constants.IndexSearcher.NonAnalyzer)
     {
         return RangeBuilder<NullScoreFunction, Range.Exclusive, Range.Inclusive>(field, value, Slices.AfterAllKeys, default, isNegated);
@@ -386,7 +392,7 @@ public partial class IndexSearcher
         };
     }
 
-    private unsafe MultiTermMatch RangeBuilder<TScoreFunction, TLow, THigh>(Slice fieldName, Slice fieldLong, long low, long high, TScoreFunction scoreFunction, bool isNegated)
+    private MultiTermMatch RangeBuilder<TScoreFunction, TLow, THigh>(Slice fieldName, Slice fieldLong, long low, long high, TScoreFunction scoreFunction, bool isNegated)
         where TScoreFunction : IQueryScoreFunction
         where TLow : struct, Range.Marker
         where THigh : struct, Range.Marker
@@ -400,8 +406,39 @@ public partial class IndexSearcher
 
         return (isNegated, scoreFunction) switch
         {
-            (false, NullScoreFunction) => MultiTermMatch.Create(new MultiTermMatch<TermNumericRangeProvider<TLow, THigh>>(_transaction.Allocator,
-                new TermNumericRangeProvider<TLow, THigh>(this, set, terms, fieldName, low, high))),
+            (false, NullScoreFunction) => MultiTermMatch.Create(new MultiTermMatch<TermNumericRangeProvider<TLow, THigh, long>>(_transaction.Allocator,
+                new TermNumericRangeProvider<TLow, THigh, long>(this, set, terms, fieldName, low, high))),
+
+            _ => throw new NotSupportedException()
+            // (true, NullScoreFunction) => MultiTermMatch.Create(new MultiTermMatch<NotStartWithTermProvider>(_transaction.Allocator,
+            //     new NotStartWithTermProvider(this, _transaction.Allocator, terms, fieldName, fieldId, slicedTerm))),
+            //
+            // (false, _) => MultiTermMatch.Create(
+            //     MultiTermBoostingMatch<StartWithTermProvider>.Create(
+            //         this, new StartWithTermProvider(this, _transaction.Allocator, terms, fieldName, fieldId, slicedTerm), scoreFunction)),
+            //
+            // (true, _) => MultiTermMatch.Create(
+            //     MultiTermBoostingMatch<NotStartWithTermProvider>.Create(
+            //         this, new NotStartWithTermProvider(this, _transaction.Allocator, terms, fieldName, fieldId, slicedTerm), scoreFunction))
+        };
+    }
+    
+    private MultiTermMatch RangeBuilder<TScoreFunction, TLow, THigh>(Slice fieldName, Slice fieldLong, double low, double high, TScoreFunction scoreFunction, bool isNegated)
+        where TScoreFunction : IQueryScoreFunction
+        where TLow : struct, Range.Marker
+        where THigh : struct, Range.Marker
+    {
+        var fields = _transaction.ReadTree(Constants.IndexWriter.FieldsSlice);
+        var terms = fields?.CompactTreeFor(fieldName);
+        if (terms == null)
+            return MultiTermMatch.CreateEmpty(_transaction.Allocator);
+
+        var set = fields?.FixedTreeForDouble(fieldLong, sizeof(long));
+
+        return (isNegated, scoreFunction) switch
+        {
+            (false, NullScoreFunction) => MultiTermMatch.Create(new MultiTermMatch<TermNumericRangeProvider<TLow, THigh, double>>(_transaction.Allocator,
+                new TermNumericRangeProvider<TLow, THigh, double>(this, set, terms, fieldName, low, high))),
 
             _ => throw new NotSupportedException()
             // (true, NullScoreFunction) => MultiTermMatch.Create(new MultiTermMatch<NotStartWithTermProvider>(_transaction.Allocator,

--- a/src/Corax/IndexWriter.cs
+++ b/src/Corax/IndexWriter.cs
@@ -57,7 +57,7 @@ namespace Corax
         private readonly Dictionary<long, List<long>>[] _bufferLongs;
         private readonly Dictionary<double, List<long>>[] _bufferDoubles;
 
-        private readonly List<long> _entriesToDelete = new List<long>();
+        private readonly HashSet<long> _entriesToDelete = new();
 
 
         private readonly long _postingListContainerId, _entriesContainerId;
@@ -217,7 +217,7 @@ namespace Corax
                 return;
 
             term.Add(entryId);
-        }        
+        }
 
         [SkipLocalsInit]
         private unsafe void InsertToken(ByteStringContext context, ref IndexEntryReader entryReader, long entryId,
@@ -275,7 +275,7 @@ namespace Corax
                         ExactInsert(valueInEntry.Slice(0, i));
 
                     break;
-                
+
                 case IndexEntryFieldType.TupleListWithNulls:
                 case IndexEntryFieldType.ListWithNulls:
                 case IndexEntryFieldType.List:
@@ -297,13 +297,13 @@ namespace Corax
 
                     break;
                 case IndexEntryFieldType.Raw:
-                case IndexEntryFieldType.RawList:                
+                case IndexEntryFieldType.RawList:
                 case IndexEntryFieldType.Invalid:
                     break;
                 default:
                     if (entryReader.Read(fieldId, out var value) == false)
                         break;
-                    
+
                     Insert(value);
                     break;
             }
@@ -336,12 +336,19 @@ namespace Corax
 
                     if (token.Offset + token.Length > wordsBuffer.Length)
                         throw new InvalidDataException(
-                            $"Got tokens with: OFFSET {token.Offset}  | LENGTH: {token.Length}. Buffer is {Encodings.Utf8.GetString(wordsBuffer)}");
-                    
+                            $"\nGot token with: \n\tOFFSET {token.Offset}\n\tLENGTH: {token.Length}.\n" +
+                            $"Total amount of tokens: {tokens.Length}" +
+                            $"\nBuffer contains '{Encodings.Utf8.GetString(wordsBuffer)}' and total length is {wordsBuffer.Length}" +
+                            $"\nBuffer from ArrayPool: \n\tbyte buffer is {_encodingBufferHandler.Length} \n\ttokens buffer is {_tokensBufferHandler.Length}" +
+                            $"\nOriginal span cointains '{Encodings.Utf8.GetString(value)}' with total length {value.Length}" +
+                            $"\nField " +
+                            $"\n\tid: {binding.FieldId}" +
+                            $"\n\tname: {binding.FieldName}");
+
                     var word = wordsBuffer.Slice(token.Offset, (int)token.Length);
                     ExactInsert(word);
                 }
-            }            
+            }
 
             void NumericInsert(long lVal, double dVal)
             {
@@ -384,7 +391,8 @@ namespace Corax
             }
         }
 
-        private static unsafe ByteStringContext<ByteStringMemoryCache>.InternalScope CreateNormalizedTerm(ByteStringContext context, ReadOnlySpan<byte> value, out Slice slice)
+        private static unsafe ByteStringContext<ByteStringMemoryCache>.InternalScope CreateNormalizedTerm(ByteStringContext context, ReadOnlySpan<byte> value,
+            out Slice slice)
         {
             ulong hash = 0;
             int length = value.Length;
@@ -406,7 +414,7 @@ namespace Corax
             }
         }
 
-        private unsafe void DeleteCommit(Span<byte> tmpBuf, Tree fieldsTree)
+        private unsafe void DeleteCommit(Span<byte> workingBuffer, Tree fieldsTree)
         {
             if (_entriesToDelete.Count == 0)
                 return;
@@ -414,9 +422,7 @@ namespace Corax
             Page lastVisitedPage = default;
             var llt = Transaction.LowLevelTransaction;
             List<long> temporaryStorageForIds = null;
-            Span<byte> tempWordsSpace = stackalloc byte[_fieldsMapping.MaximumOutputSize];
-            Span<Token> tempTokenSpace = stackalloc Token[_fieldsMapping.MaximumTokenSize];
-            
+
             foreach (var entryToDelete in _entriesToDelete)
             {
                 var entryReader = IndexSearcher.GetReaderFor(Transaction, ref lastVisitedPage, entryToDelete);
@@ -426,45 +432,92 @@ namespace Corax
                         continue;
 
                     var fieldType = entryReader.GetFieldType(binding.FieldId, out var intOffset);
-                    if (fieldType.HasFlag(IndexEntryFieldType.List))
+                    switch (fieldType)
                     {
-                        if (fieldType.HasFlag(IndexEntryFieldType.SpatialPoint))
-                        {
-                            var iterator = entryReader.ReadManySpatialPoint(binding.FieldId);
+                        case IndexEntryFieldType.Empty:
+                        case IndexEntryFieldType.Null:
+                            var fieldName = fieldType == IndexEntryFieldType.Null ? Constants.NullValueSlice : Constants.EmptyStringSlice;
+                            DeleteIdFromExactTerm(binding.FieldId, binding.FieldName, workingBuffer, fieldName.AsReadOnlySpan());
+                            break;
+
+                        case IndexEntryFieldType.TupleList:
+                            if (entryReader.TryReadMany(binding.FieldId, out var iterator) == false)
+                                break;
+
                             while (iterator.ReadNext())
                             {
-                                for (int i = 1; i <= iterator.Count; ++i)
-                                    DeleteIdFromTerm(iterator.Geohash.Slice(0, i), tmpBuf, binding, tempWordsSpace, tempTokenSpace);
+                                DeleteIdFromExactTerm(binding.FieldId, binding.FieldName, workingBuffer, iterator.Sequence);
                             }
-                        }
-                        else
-                        {
-                            var it = entryReader.ReadMany(binding.FieldId);
-                            while (it.ReadNext())
+
+                            break;
+
+                        case IndexEntryFieldType.Tuple:
+                            if (entryReader.Read(binding.FieldId, out Span<byte> valueInEntry) == false)
+                                break;
+                            DeleteIdFromExactTerm(binding.FieldId, binding.FieldName, workingBuffer, valueInEntry);
+                            break;
+
+                        case IndexEntryFieldType.SpatialPointList:
+                            if (entryReader.TryReadManySpatialPoint(binding.FieldId, out var spatialIterator) == false)
+                                break;
+
+                            while (spatialIterator.ReadNext())
                             {
-                                if (it.IsNull)
-                                    DeleteIdFromTerm(Constants.NullValueSlice.AsSpan(), tmpBuf, binding, tempWordsSpace, tempTokenSpace);
-                                else
-                                    DeleteIdFromTerm(it.Sequence, tmpBuf, binding, tempWordsSpace, tempTokenSpace);
+                                for (int i = 1; i <= spatialIterator.Geohash.Length; ++i)
+                                    DeleteIdFromExactTerm(binding.FieldId, binding.FieldName, workingBuffer, spatialIterator.Geohash.Slice(0, i));
                             }
-                        }
-                    }
-                    else
-                    {
-                        entryReader.Read(binding.FieldId, out var termValue);
-                        DeleteIdFromTerm(termValue, tmpBuf, binding, tempWordsSpace, tempTokenSpace);
+
+                            break;
+
+                        case IndexEntryFieldType.SpatialPoint:
+                            if (entryReader.Read(binding.FieldId, out valueInEntry) == false)
+                                break;
+
+                            for (int i = 1; i <= valueInEntry.Length; ++i)
+                                DeleteIdFromExactTerm(binding.FieldId, binding.FieldName, workingBuffer, valueInEntry.Slice(0, i));
+
+                            break;
+
+                        case IndexEntryFieldType.TupleListWithNulls:
+                        case IndexEntryFieldType.ListWithNulls:
+                        case IndexEntryFieldType.List:
+                            if (entryReader.TryReadMany(binding.FieldId, out iterator) == false)
+                                break;
+
+                            while (iterator.ReadNext())
+                            {
+                                if ((fieldType & IndexEntryFieldType.HasNulls) != 0 && (iterator.IsEmpty || iterator.IsNull))
+                                {
+                                    var fieldValue = iterator.IsNull ? Constants.NullValueSlice : Constants.EmptyStringSlice;
+                                    DeleteIdFromExactTerm(binding.FieldId, binding.FieldName, workingBuffer, fieldValue.AsReadOnlySpan());
+                                }
+                                else
+                                {
+                                    DeleteIdFromTerm(iterator.Sequence, workingBuffer, binding);
+                                }
+                            }
+
+                            break;
+                        case IndexEntryFieldType.Raw:
+                        case IndexEntryFieldType.RawList:
+                        case IndexEntryFieldType.Invalid:
+                            break;
+                        default:
+                            if (entryReader.Read(binding.FieldId, out var value) == false)
+                                break;
+
+                            DeleteIdFromTerm(value, workingBuffer, binding);
+                            break;
                     }
                 }
-                
+
                 Container.Delete(llt, _entriesContainerId, entryToDelete); // delete raw index entry
                 llt.RootObjects.Increment(Constants.IndexWriter.NumberOfEntriesSlice, -1); // update number of entries
                 temporaryStorageForIds?.Clear();
-                
-                
-                var numberOfEntries = llt.RootObjects.ReadInt64(Constants.IndexWriter.NumberOfEntriesSlice) ?? 0;
-                Debug.Assert(numberOfEntries >= 0);
 
-                void DeleteIdFromTerm(ReadOnlySpan<byte> termValue, Span<byte> tmpBuf, IndexFieldBinding binding, Span<byte> wordSpace, Span<Token> tokenSpace)
+                Debug.Assert((llt.RootObjects.ReadInt64(Constants.IndexWriter.NumberOfEntriesSlice) ?? 0) >= 0);
+
+                void DeleteIdFromTerm(ReadOnlySpan<byte> termValue, Span<byte> tmpBuf, IndexFieldBinding binding)
                 {
                     if (binding.IsAnalyzed == false)
                     {
@@ -483,6 +536,9 @@ namespace Corax
                             UnlikelyGrowBuffer(outputSize, tokenSize);
                     }
 
+                    var wordSpace = _encodingBufferHandler.AsSpan();
+                    var tokenSpace = _tokensBufferHandler.AsSpan();
+
                     analyzer.Execute(termValue, ref wordSpace, ref tokenSpace);
 
                     for (int i = 0; i < tokenSpace.Length; i++)
@@ -496,67 +552,74 @@ namespace Corax
                             RemoveSuggestions(binding, termValue);
                     }
                 }
-            }
-            
-            void DeleteIdFromExactTerm(long id, Slice fieldName, Span<byte> tmpBuffer, ReadOnlySpan<byte> termValue)
-            {
-                // We need to normalize the term in case we have a term bigger than MaxTermLength.
-                using var _ = CreateNormalizedTerm(Transaction.Allocator, termValue, out Slice termSlice);
-                termValue = termSlice.AsReadOnlySpan();
 
-                var fieldTree = fieldsTree.CompactTreeFor(fieldName);
-                if (termValue.Length == 0 || fieldTree.TryGetValue(termSlice.AsReadOnlySpan(), out var containerId) == false)
-                    return;
 
-                if ((containerId & (long)TermIdMask.Set) != 0)
+                void DeleteIdFromExactTerm(long id, Slice fieldName, Span<byte> tmpBuffer, ReadOnlySpan<byte> termValue)
                 {
-                    var setId = containerId & ~0b11;
-                    var setStateSpan = Container.GetMutable(llt, setId);
-                    ref var setState = ref MemoryMarshal.AsRef<SetState>(setStateSpan);
-                    var set = new Set(llt, fieldName, in setState);
-                    set.Remove(id);
-                    setState = set.State;
-
-                    if (setState.NumberOfEntries == 0)
+                    if (termValue.Length == 0)
                     {
-                        //If we get rid off all terms we have to remove container. Probably we can do this in a better way
-                        fieldTree.TryRemove(termValue, out var __);
-                        Container.Delete(llt, _postingListContainerId, setId);
-                    }
-                }
-                else if ((containerId & (long)TermIdMask.Small) != 0)
-                {
-                    var smallSetId = containerId & ~0b11;
-                    var buffer = Container.GetMutable(llt, smallSetId);
-
-                    //Fetch all the ids from the set into temporaryStorageForIds
-                    var itemsCount = ZigZagEncoding.Decode<int>(buffer, out var len);
-                    temporaryStorageForIds ??= new List<long>(itemsCount);
-                    temporaryStorageForIds.Clear();
-                    
-                    long pos = len;
-                    var currentId = 0L;
-
-                    while (pos < buffer.Length)
-                    {
-                        var delta = ZigZagEncoding.Decode<long>(buffer, out len, (int)pos);
-                        pos += len;
-                        currentId += delta;
-                        if (currentId == id)
-                            continue;
-                        temporaryStorageForIds.Add(currentId);
+                        Debugger.Launch();
+                        Debugger.Break();
                     }
 
-                    // Due to encoding we have to encode new set again so we remove previous small set from container.
-                    Container.Delete(llt, _postingListContainerId, smallSetId);
-                    fieldTree.TryRemove(termValue, out var __); // term also disappears from the field tree
+                    // We need to normalize the term in case we have a term bigger than MaxTermLength.
+                    using var _ = CreateNormalizedTerm(Transaction.Allocator, termValue, out Slice termSlice);
+                    termValue = termSlice.AsReadOnlySpan();
 
-                    if(AddNewTerm(temporaryStorageForIds, tmpBuffer, out var termId))
-                        fieldTree.Add(termValue, termId);
-                }
-                else
-                {
-                    fieldTree.TryRemove(termValue, out var _);
+                    var fieldTree = fieldsTree.CompactTreeFor(fieldName);
+                    if (termValue.Length == 0 || fieldTree.TryGetValue(termSlice.AsReadOnlySpan(), out var containerId) == false)
+                        return;
+
+                    if ((containerId & (long)TermIdMask.Set) != 0)
+                    {
+                        var setId = containerId & ~0b11;
+                        var setStateSpan = Container.GetMutable(llt, setId);
+                        ref var setState = ref MemoryMarshal.AsRef<SetState>(setStateSpan);
+                        var set = new Set(llt, fieldName, in setState);
+                        set.Remove(id);
+                        setState = set.State;
+
+                        if (setState.NumberOfEntries == 0)
+                        {
+                            //If we get rid off all terms we have to remove container. Probably we can do this in a better way
+                            fieldTree.TryRemove(termValue, out var __);
+                            Container.Delete(llt, _postingListContainerId, setId);
+                        }
+                    }
+                    else if ((containerId & (long)TermIdMask.Small) != 0)
+                    {
+                        var smallSetId = containerId & ~0b11;
+                        var buffer = Container.GetMutable(llt, smallSetId);
+
+                        //Fetch all the ids from the set into temporaryStorageForIds
+                        var itemsCount = ZigZagEncoding.Decode<int>(buffer, out var len);
+                        temporaryStorageForIds ??= new List<long>(itemsCount);
+                        temporaryStorageForIds.Clear();
+
+                        long pos = len;
+                        var currentId = 0L;
+
+                        while (pos < buffer.Length)
+                        {
+                            var delta = ZigZagEncoding.Decode<long>(buffer, out len, (int)pos);
+                            pos += len;
+                            currentId += delta;
+                            if (currentId == id)
+                                continue;
+                            temporaryStorageForIds.Add(currentId);
+                        }
+
+                        // Due to encoding we have to encode new set again so we remove previous small set from container.
+                        Container.Delete(llt, _postingListContainerId, smallSetId);
+                        fieldTree.TryRemove(termValue, out var __); // term also disappears from the field tree
+
+                        if (AddNewTerm(temporaryStorageForIds, tmpBuffer, out var termId))
+                            fieldTree.Add(termValue, termId);
+                    }
+                    else
+                    {
+                        fieldTree.TryRemove(termValue, out var _);
+                    }
                 }
             }
         }
@@ -610,38 +673,40 @@ namespace Corax
             {
                 _entriesToDelete.Add(idInTree);
             }
-            
+
             return true;
         }
 
         private void UnlikelyGrowBuffer(int newBufferSize, int newTokenSize)
         {
             if (newBufferSize > _encodingBufferHandler.Length)
-            { 
+            {
                 Analyzer.BufferPool.Return(_encodingBufferHandler);
+                _encodingBufferHandler = null;
                 _encodingBufferHandler = Analyzer.BufferPool.Rent(newBufferSize);
             }
 
             if (newTokenSize > _tokensBufferHandler.Length)
             {
                 Analyzer.TokensPool.Return(_tokensBufferHandler);
+                _tokensBufferHandler = null;
                 _tokensBufferHandler = Analyzer.TokensPool.Rent(newTokenSize);
             }
         }
 
         public void Commit()
         {
-            using var _ = Transaction.Allocator.Allocate(Container.MaxSizeInsideContainerPage, out Span<byte> tmpBuf);
+            using var _ = Transaction.Allocator.Allocate(Container.MaxSizeInsideContainerPage, out Span<byte> workingBuffer);
             Tree fieldsTree = Transaction.CreateTree(Constants.IndexWriter.FieldsSlice);
 
             if (_fieldsMapping.Count != 0)
-                DeleteCommit(tmpBuf, fieldsTree);
+                DeleteCommit(workingBuffer, fieldsTree);
 
             for (int fieldId = 0; fieldId < _fieldsMapping.Count; ++fieldId)
             {
-                InsertTextualField(fieldsTree, fieldId, tmpBuf);
-                InsertNumericFieldLongs(fieldsTree, fieldId, tmpBuf);
-                InsertNumericFieldDoubles(fieldsTree, fieldId, tmpBuf);
+                InsertTextualField(fieldsTree, fieldId, workingBuffer);
+                InsertNumericFieldLongs(fieldsTree, fieldId, workingBuffer);
+                InsertNumericFieldDoubles(fieldsTree, fieldId, workingBuffer);
             }
 
             // Check if we have suggestions to deal with. 
@@ -685,14 +750,13 @@ namespace Corax
                 var entries = _buffer[fieldId][term];
                 if (fieldTree.TryGetValue(termsSpan, out var existing, out var encodedKey) == false)
                 {
-                    if(AddNewTerm(entries,  tmpBuf, out  termId))
+                    if (AddNewTerm(entries, tmpBuf, out termId))
                         fieldTree.Add(termsSpan, termId, encodedKey);
                     continue;
                 }
 
-                if(AddEntriesToTerm(tmpBuf, existing, llt, entries, out  termId))
+                if (AddEntriesToTerm(tmpBuf, existing, llt, entries, out termId))
                     fieldTree.Add(termsSpan, termId, encodedKey);
-
             }
         }
 
@@ -728,7 +792,7 @@ namespace Corax
                     }
 
                     Container.Delete(llt, _postingListContainerId, id);
-                    return AddNewTerm(entries, tmpBuf, out  termId);
+                    return AddNewTerm(entries, tmpBuf, out termId);
                 }
                 // single
                 
@@ -740,7 +804,7 @@ namespace Corax
                 }
 
                 entries.Add(existing);
-                return AddNewTerm(entries, tmpBuf, out  termId);
+                return AddNewTerm(entries, tmpBuf, out termId);
             }
         }
 
@@ -807,7 +871,7 @@ namespace Corax
             // common for unique values (guid, date, etc)
             if (entries.Count == 1)
             {
-                termId = entries[0] | (long)TermIdMask.Single;
+                termId = entries[0] | (long)TermIdMask.Single;                
                 return true;
             }
 
@@ -831,20 +895,21 @@ namespace Corax
                 }
 
                 // too big, convert to a set
-                var setId = Container.Allocate(llt, _postingListContainerId, sizeof(SetState), out var setSpace);
+                long setId = Container.Allocate(llt, _postingListContainerId, sizeof(SetState), out var setSpace);
                 ref var setState = ref MemoryMarshal.AsRef<SetState>(setSpace);
                 Set.Create(llt, ref setState);
                 var set = new Set(llt, Slices.Empty, setState);
                 entries.Sort();
                 set.Add(entries);
                 setState = set.State;
-                termId = setId | (long)TermIdMask.Set;
+                termId = setId | (long)TermIdMask.Set;                
                 return true;
             }
 
             var containerId = Container.Allocate(llt, _postingListContainerId, pos, out var space);
             tmpBuf.Slice(0, pos).CopyTo(space);
-            termId  = containerId | (long)TermIdMask.Small;
+
+            termId = containerId | (long)TermIdMask.Small;
             return true;
         }
 

--- a/src/Corax/IndexWriter.cs
+++ b/src/Corax/IndexWriter.cs
@@ -349,6 +349,17 @@ namespace Corax
                 }
             }            
 
+            void NumericInsert(long lVal, double dVal)
+            {
+                if (fieldDoubles.TryGetValue(dVal, out var doublesTerms) == false)
+                    fieldDoubles[dVal] = doublesTerms = new List<long>();
+                if(fieldLongs.TryGetValue(lVal, out var longsTerms) == false)
+                    fieldLongs[lVal] = longsTerms = new List<long>();
+
+                AddMaybeAvoidDuplicate(doublesTerms, entryId);
+                AddMaybeAvoidDuplicate(longsTerms, entryId);
+            }
+            
             void ExactInsert(ReadOnlySpan<byte> value)
             {
                 ByteStringContext<ByteStringMemoryCache>.InternalScope? scope;
@@ -398,17 +409,6 @@ namespace Corax
             else
             {
                 return Slice.From(context, value, ByteStringType.Mutable, out slice);
-            }
-            
-            void NumericInsert(long lVal, double dVal)
-            {
-                if (fieldDoubles.TryGetValue(dVal, out var doublesTerms) == false)
-                    fieldDoubles[dVal] = doublesTerms = new List<long>();
-                if(fieldLongs.TryGetValue(lVal, out var longsTerms) == false)
-                    fieldLongs[lVal] = longsTerms = new List<long>();
-
-                AddMaybeAvoidDuplicate(doublesTerms, entryId);
-                AddMaybeAvoidDuplicate(longsTerms, entryId);
             }
         }
 

--- a/src/Corax/IndexWriter.cs
+++ b/src/Corax/IndexWriter.cs
@@ -64,10 +64,7 @@ namespace Corax
 
         private const string SuggestionsTreePrefix = "__Suggestion_";
         private Dictionary<int, Dictionary<Slice, int>> _suggestionsAccumulator;
-
-        //Let persist maximum calculated size of word locally.
-        private readonly int[] _maxTermLengthProceedPerAnalyzer;
-
+        
 #pragma warning disable CS0169
         private Queue<long> _lastEntries; // keep last 256 items
 #pragma warning restore CS0169
@@ -94,8 +91,6 @@ namespace Corax
                 _bufferDoubles[i] = new Dictionary<double, List<long>>();
                 _bufferLongs[i] = new Dictionary<long, List<long>>();
             }
-
-            _maxTermLengthProceedPerAnalyzer = ArrayPool<int>.Shared.Rent(fieldsMapping.Count);
         }
 
         public IndexWriter([NotNull] StorageEnvironment environment, IndexFieldsMapping fieldsMapping) : this(fieldsMapping)
@@ -324,15 +319,13 @@ namespace Corax
             void AnalyzeInsert(Span<byte> wordsBuffer, Span<Token> tokens, ReadOnlySpan<byte> value)
             {
                 var analyzer = binding.Analyzer;
-                if (value.Length > _maxTermLengthProceedPerAnalyzer[binding.FieldId])
+                if (value.Length > _encodingBufferHandler.Length)
                 {
                     analyzer.GetOutputBuffersSize(value.Length, out var outputSize, out var tokenSize);
-                    if (wordsBuffer.Length < outputSize || tokens.Length < tokenSize)
+                    if (outputSize > _encodingBufferHandler.Length || tokenSize >  _tokensBufferHandler.Length)
                     {
                         UnlikelyGrowBuffer(ref wordsBuffer, ref tokens, outputSize, tokenSize);
                     }
-
-                    _maxTermLengthProceedPerAnalyzer[binding.FieldId] = value.Length;
                 }
 
                 analyzer.Execute(value, ref wordsBuffer, ref tokens);
@@ -482,12 +475,11 @@ namespace Corax
                     }
 
                     var analyzer = binding.Analyzer;
-                    if (termValue.Length > _maxTermLengthProceedPerAnalyzer[binding.FieldId])
+                    if (termValue.Length > _encodingBufferHandler.Length)
                     {
                         analyzer.GetOutputBuffersSize(termValue.Length, out int outputSize, out int tokenSize);
-                        if (outputSize > wordSpace.Length)
+                        if (outputSize > _encodingBufferHandler.Length || tokenSize > _tokensBufferHandler.Length)
                             UnlikelyGrowBuffer(ref wordSpace, ref tokenSpace, outputSize, tokenSize);
-                        _maxTermLengthProceedPerAnalyzer[binding.FieldId] = termValue.Length;
                     }
 
                     analyzer.Execute(termValue, ref wordSpace, ref tokenSpace);
@@ -862,8 +854,6 @@ namespace Corax
             _jsonOperationContext?.Dispose();
             if (_ownsTransaction)
                 Transaction?.Dispose();
-
-            ArrayPool<int>.Shared.Return(_maxTermLengthProceedPerAnalyzer);
 
             if (_encodingBufferHandler != null)
                 Analyzer.BufferPool.Return(_encodingBufferHandler);

--- a/src/Corax/Queries/TermProviders/TermProvider.Range.cs
+++ b/src/Corax/Queries/TermProviders/TermProvider.Range.cs
@@ -1,0 +1,113 @@
+﻿using System;
+using System.Collections.Generic;
+using System.Diagnostics;
+using System.Linq;
+using System.Runtime.CompilerServices;
+using System.Text;
+using System.Threading.Tasks;
+using Sparrow.Server;
+using Voron;
+using Voron.Data.CompactTrees;
+
+namespace Corax.Queries
+{
+    public static class Range
+    {
+        public interface Marker { }
+        public struct Exclusive : Marker { }
+        public struct Inclusive : Marker { }
+    }
+
+    [DebuggerDisplay("{DebugView,nq}")]
+    public struct TermRangeProvider<TLow, THigh> : ITermProvider
+        where TLow : struct, Range.Marker
+        where THigh  : struct, Range.Marker
+    {
+        private readonly IndexSearcher _searcher;
+        private readonly Slice _fieldName;
+        private readonly Slice _low, _high;
+        private readonly CompactTree _tree;
+        private CompactTree.Iterator _iterator;
+        private bool _skipLowCheck;
+        private readonly bool _skipHighCheck;
+
+        public TermRangeProvider(IndexSearcher searcher, CompactTree tree, Slice fieldName, 
+            Slice low, Slice high)
+        {
+            _searcher = searcher;
+            _fieldName = fieldName;
+            _iterator = tree.Iterate();
+            _low = low;
+            _high = high;
+            _tree = tree;
+            _skipLowCheck = false;
+            _skipHighCheck = high.Options == SliceOptions.AfterAllKeys;
+            Reset();
+        }
+
+        public void Reset()
+        {
+            if (_low.Options != SliceOptions.BeforeAllKeys)
+            {
+                _iterator.Seek(_low);
+                _skipLowCheck = typeof(TLow) == typeof(Range.Exclusive);
+            }
+            else
+            {
+                _iterator.Reset();
+            }
+        }
+
+        [MethodImpl(MethodImplOptions.AggressiveInlining)]
+        public bool Next(out TermMatch term) => Next(out term, out _);
+
+        public bool Next(out TermMatch term, out Slice termSlice)
+        {
+            if (_iterator.MoveNext(out termSlice, out var _) == false)
+            {
+                term = TermMatch.CreateEmpty();
+                return false;
+            }
+
+            if (typeof(TLow) == typeof(Range.Exclusive))
+            {
+                if (_skipLowCheck)
+                {
+                    _skipLowCheck = false;
+                    if (_low.AsSpan().SequenceEqual(termSlice.AsSpan()))
+                    {
+                        return Next(out term, out termSlice);
+                    }
+                }
+            }
+
+            if (_skipHighCheck == false)
+            {
+                int cmp = _high.AsSpan().SequenceCompareTo(termSlice.AsSpan());
+                if (typeof(THigh) == typeof(Range.Exclusive) && cmp <= 0 || 
+                    typeof(THigh) == typeof(Range.Inclusive) && cmp < 0)
+                {
+                    term = TermMatch.CreateEmpty();
+                    return false;
+                }
+
+            }
+            
+            term = _searcher.TermQuery(_tree, termSlice);
+            return true;
+        }
+
+        public QueryInspectionNode Inspect()
+        {
+            return new QueryInspectionNode($"{GetType().Name}",
+                            parameters: new Dictionary<string, string>()
+                            {
+                                { "Field", _fieldName.ToString() },
+                                { "Low", _low.ToString()},
+                                { "High", _high.ToString()}
+                            });
+        }
+
+        public string DebugView => Inspect().ToString();
+    }
+}

--- a/src/Corax/Queries/TermProviders/TermProvider.Range.cs
+++ b/src/Corax/Queries/TermProviders/TermProvider.Range.cs
@@ -1,4 +1,6 @@
 ﻿using System;
+using System.Buffers;
+using System.Buffers.Text;
 using System.Collections.Generic;
 using System.Diagnostics;
 using System.Linq;
@@ -8,6 +10,7 @@ using System.Threading.Tasks;
 using Sparrow.Server;
 using Voron;
 using Voron.Data.CompactTrees;
+using Voron.Data.Fixed;
 
 namespace Corax.Queries
 {
@@ -95,6 +98,115 @@ namespace Corax.Queries
             
             term = _searcher.TermQuery(_tree, termSlice);
             return true;
+        }
+
+        public QueryInspectionNode Inspect()
+        {
+            return new QueryInspectionNode($"{GetType().Name}",
+                            parameters: new Dictionary<string, string>()
+                            {
+                                { "Field", _fieldName.ToString() },
+                                { "Low", _low.ToString()},
+                                { "High", _high.ToString()}
+                            });
+        }
+
+        public string DebugView => Inspect().ToString();
+    }
+    
+     [DebuggerDisplay("{DebugView,nq}")]
+    public unsafe struct TermNumericRangeProvider<TLow, THigh> : ITermProvider
+        where TLow : struct, Range.Marker
+        where THigh  : struct, Range.Marker
+    {
+        private readonly IndexSearcher _searcher;
+        private readonly Slice _fieldName;
+        private readonly long _low, _high;
+        private readonly CompactTree _tree;
+        private readonly FixedSizeTree _set;
+        private readonly FixedSizeTree.IFixedSizeIterator _iterator;
+        private bool _first;
+
+        private const int TermBufferSize = 32;
+        private fixed byte _termsBuffer[TermBufferSize];
+        private ByteStringContext<ByteStringMemoryCache>.ExternalScope _prevTermScope;
+
+        public TermNumericRangeProvider(IndexSearcher searcher, FixedSizeTree set,
+            CompactTree tree, Slice fieldName, long low, long high)
+        {
+            _searcher = searcher;
+            _fieldName = fieldName;
+            _iterator = set.Iterate();
+            _low = low;
+            _high = high;
+            _set = set;
+            _tree = tree;
+            _prevTermScope = default;
+            _first = true;
+        }
+
+        public void Reset()
+        {
+            _first = true;
+        }
+
+        [MethodImpl(MethodImplOptions.AggressiveInlining)]
+        public bool Next(out TermMatch term) => Next(out term, out _);
+
+        public bool Next(out TermMatch term, out Slice termSlice)
+        {
+            bool wasFirst = false;
+            bool hasNext;
+            if (_first)
+            {
+                hasNext = _iterator.Seek(_low);
+                _first = false;
+                wasFirst = true;
+            }
+            else
+            {
+                hasNext = _iterator.MoveNext();
+            }
+
+            if (hasNext == false)
+                goto Empty;
+            
+            long curVal = _iterator.CurrentKey;
+            if (typeof(TLow) == typeof(Range.Exclusive))
+            {
+                if (wasFirst && curVal == _low)
+                {
+                    return Next(out term, out termSlice);
+                }
+            }     
+
+
+            var cmp = _high - curVal;
+            if (typeof(THigh) == typeof(Range.Exclusive) && cmp <= 0 || 
+                typeof(THigh) == typeof(Range.Inclusive) && cmp < 0)
+            {
+                goto Empty;
+            }
+
+            _prevTermScope.Dispose();
+            
+            fixed (byte* p = _termsBuffer)
+            {
+                if (Utf8Formatter.TryFormat(curVal, new Span<byte>(p, TermBufferSize), out int termLen) == false)
+                {
+                    throw new InvalidOperationException("Cannot format long value " + curVal);
+                }
+
+                _prevTermScope = Slice.External(_set.Llt.Allocator, p, termLen, ByteStringType.Immutable, out termSlice);
+
+                term = _searcher.TermQuery(_tree, termSlice);
+                return true;
+            }
+
+            Empty:
+            termSlice = Slices.Empty;
+            term = TermMatch.CreateEmpty();
+            return false;
         }
 
         public QueryInspectionNode Inspect()

--- a/src/Corax/Queries/TermProviders/TermProvider.Range.cs
+++ b/src/Corax/Queries/TermProviders/TermProvider.Range.cs
@@ -182,9 +182,9 @@ namespace Corax.Queries
             }     
 
 
-            var cmp = _high - curVal;
-            if (typeof(THigh) == typeof(Range.Exclusive) && cmp <= TVal.Zero || 
-                typeof(THigh) == typeof(Range.Inclusive) && cmp < TVal.Zero)
+            var cmp = _high.CompareTo(curVal);
+            if (typeof(THigh) == typeof(Range.Exclusive) && cmp <= 0 || 
+                typeof(THigh) == typeof(Range.Inclusive) && cmp < 0)
             {
                 goto Empty;
             }

--- a/src/Corax/Queries/TermProviders/TermProvider.StartWith.cs
+++ b/src/Corax/Queries/TermProviders/TermProvider.StartWith.cs
@@ -57,6 +57,6 @@ namespace Corax.Queries
                             });
         }
 
-        string DebugView => Inspect().ToString();
+        public string DebugView => Inspect().ToString();
     }
 }

--- a/src/Corax/Queries/UnaryMatch.Ordinal.cs
+++ b/src/Corax/Queries/UnaryMatch.Ordinal.cs
@@ -947,7 +947,7 @@ namespace Corax.Queries
                 return new UnaryMatch<TInner, TValueType>(
                     in inner, UnaryMatchOperation.GreaterThan,
                     searcher, fieldId, value,
-                    mode == UnaryMatchOperationMode.Any ? &FillFuncNumericalAny<GreaterThanMatchComparer> : &FillFuncSequenceAll<GreaterThanMatchComparer>, &AndWith,
+                    mode == UnaryMatchOperationMode.Any ? &FillFuncNumericalAny<GreaterThanMatchComparer> : &FillFuncNumericalAll<GreaterThanMatchComparer>, &AndWith,
                     inner.Count, inner.Confidence.Min(QueryCountConfidence.Normal), mode, take: take);
             }
         }

--- a/src/Corax/Queries/UnaryMatch.Ordinal.cs
+++ b/src/Corax/Queries/UnaryMatch.Ordinal.cs
@@ -947,7 +947,7 @@ namespace Corax.Queries
                 return new UnaryMatch<TInner, TValueType>(
                     in inner, UnaryMatchOperation.GreaterThan,
                     searcher, fieldId, value,
-                    mode == UnaryMatchOperationMode.Any ? &FillFuncNumericalAny<GreaterThanMatchComparer> : &FillFuncNumericalAny<GreaterThanMatchComparer>, &AndWith,
+                    mode == UnaryMatchOperationMode.Any ? &FillFuncNumericalAny<GreaterThanMatchComparer> : &FillFuncSequenceAll<GreaterThanMatchComparer>, &AndWith,
                     inner.Count, inner.Confidence.Min(QueryCountConfidence.Normal), mode, take: take);
             }
         }

--- a/src/Raven.Server/Documents/Indexes/Persistence/Corax/CoraxDocumentConverterBase.cs
+++ b/src/Raven.Server/Documents/Indexes/Persistence/Corax/CoraxDocumentConverterBase.cs
@@ -63,7 +63,8 @@ public abstract class CoraxDocumentConverterBase : ConverterBase
         keyFieldName, storeValueFieldName, fields)
     {
         _allocator = new ByteStringContext(SharedMultipleUseFlag.None);
-        _knownFields = GetKnownFields();
+        _knownFields = GetKnownFields(_allocator, index);
+        _knownFields.UpdateAnalyzersInBindings( CoraxIndexingHelpers.CreateCoraxAnalyzers(_allocator, index, index.Definition));
         Scope = new();
     }
 
@@ -94,10 +95,7 @@ public abstract class CoraxDocumentConverterBase : ConverterBase
         return knownFields;
     }
 
-    public IndexFieldsMapping GetKnownFields()
-    {
-        return _knownFields ?? GetKnownFields(_allocator, _index);
-    }
+    public IndexFieldsMapping GetKnownFields() => _knownFields;
 
     protected void InsertRegularField(IndexField field, object value, JsonOperationContext indexContext, ref IndexEntryWriter entryWriter,
         IWriterScope scope, bool nestedArray = false)

--- a/src/Raven.Server/Documents/Indexes/Persistence/Corax/CoraxIndexPersistence.cs
+++ b/src/Raven.Server/Documents/Indexes/Persistence/Corax/CoraxIndexPersistence.cs
@@ -41,9 +41,9 @@ public class CoraxIndexPersistence : IndexPersistenceBase
                         _converter = new JintCoraxDocumentConverter((MapIndex)index);
                         break;
                     case IndexSourceType.TimeSeries:
-                        throw new NotSupportedException($"Currently, {nameof(TimeSeries)} are not supported by Corax");
+                        throw new NotSupportedException($"Currently, {nameof(TimeSeries)} is not supported by Corax");
                     case IndexSourceType.Counters:
-                        throw new NotSupportedException($"Currently, {nameof(IndexSourceType.Counters)} are not supported by Corax");
+                        throw new NotSupportedException($"Currently, {nameof(IndexSourceType.Counters)} is not supported by Corax");
                 }
                 break;
             case IndexType.JavaScriptMapReduce:

--- a/src/Raven.Server/Documents/Indexes/Persistence/Corax/CoraxSuggestionIndexReader.cs
+++ b/src/Raven.Server/Documents/Indexes/Persistence/Corax/CoraxSuggestionIndexReader.cs
@@ -29,7 +29,7 @@ public class CoraxSuggestionReader : SuggestionIndexReaderBase
 
     public CoraxSuggestionReader(Index index, Logger logger, IndexFieldBinding binding, Transaction readTransaction) : base(index, logger)
     {
-        _fieldMappings = CoraxDocumentConverter.GetKnownFields(readTransaction.Allocator, index);
+        _fieldMappings = CoraxDocumentConverterBase.GetKnownFields(readTransaction.Allocator, index);
         _fieldMappings.UpdateAnalyzersInBindings(CoraxIndexingHelpers.CreateCoraxAnalyzers(readTransaction.Allocator, index, index.Definition, true));
         _binding = binding;
         _indexSearcher = new IndexSearcher(readTransaction, _fieldMappings);

--- a/src/Raven.Server/Raven.Server.csproj
+++ b/src/Raven.Server/Raven.Server.csproj
@@ -5,6 +5,8 @@
     <TargetFramework>net6.0</TargetFramework>
     <RuntimeFrameworkVersion>6.0.6</RuntimeFrameworkVersion>
     <AllowUnsafeBlocks>true</AllowUnsafeBlocks>
+    <EnablePreviewFeatures>True</EnablePreviewFeatures>
+
     <AssemblyName>Raven.Server</AssemblyName>
     <OutputType>Exe</OutputType>
     <PackageId>Raven.Server</PackageId>

--- a/src/Voron/Data/Fixed/FixedSizeIterators.cs
+++ b/src/Voron/Data/Fixed/FixedSizeIterators.cs
@@ -114,7 +114,7 @@ namespace Voron.Data.Fixed
                 {
                     if (_pos >= _header->NumberOfEntries)
                         throw new InvalidOperationException("Invalid position, cannot read past end of tree");
-                    return FixedSizeTreePage<TVal>.GetEntry(_dataStart, (int)_pos, _fst._entrySize)->Key;
+                    return FixedSizeTreePage<TVal>.GetEntry(_dataStart, (int)_pos, _fst._entrySize)->GetKey<TVal>();
                 }
             }
 

--- a/src/Voron/Data/Fixed/FixedSizeIterators.cs
+++ b/src/Voron/Data/Fixed/FixedSizeIterators.cs
@@ -27,6 +27,7 @@ namespace Voron.Data.Fixed
 
         public class NullIterator : IFixedSizeIterator
         {
+            public readonly static NullIterator Instance = new NullIterator();
             public bool SeekToLast()
             {
                 return false;
@@ -75,9 +76,9 @@ namespace Voron.Data.Fixed
             private readonly FixedSizeTree _fst;
             private readonly ByteStringContext _allocator;
             private long _pos;
-            private FixedSizeTreeHeader.Embedded* _header;
-            private byte* _dataStart;
-            private int _changesAtStart;
+            private readonly FixedSizeTreeHeader.Embedded* _header;
+            private readonly byte* _dataStart;
+            private readonly int _changesAtStart;
 
             public EmbeddedIterator(FixedSizeTree fst)
             {

--- a/src/Voron/Data/Fixed/FixedSizeTree.cs
+++ b/src/Voron/Data/Fixed/FixedSizeTree.cs
@@ -221,8 +221,7 @@ namespace Voron.Data.Fixed
                 throw new InvalidOperationException($"The value size must be of size '{_valSize}' but was of size '{val.Size}'.");
 
             bool isNew;
-            byte* ptr;
-            using (DirectAdd(key, out isNew, out ptr))
+            using (DirectAdd(key, out isNew, out byte* ptr))
             {
                 if (val.HasValue && val.Size != 0)
                     val.CopyTo(ptr);
@@ -233,8 +232,15 @@ namespace Voron.Data.Fixed
 
         public bool Add(long key, byte[] val)
         {
-            Slice str;
-            using (Slice.From(_tx.Allocator, val, ByteStringType.Immutable, out str))
+            using (Slice.From(_tx.Allocator, val, ByteStringType.Immutable, out Slice str))
+            {
+                return Add(key, str);
+            }
+        }
+        
+        public bool Add(long key, long val)
+        {
+            using (Slice.From(_tx.Allocator, (byte*)&val, sizeof(long), ByteStringType.Immutable, out Slice str))
             {
                 return Add(key, str);
             }
@@ -1533,7 +1539,7 @@ namespace Voron.Data.Fixed
             switch (Type)
             {
                 case null:
-                    return new NullIterator();
+                    return NullIterator.Instance;
                 case RootObjectType.EmbeddedFixedSizeTree:
                     return new EmbeddedIterator(this);
                 case RootObjectType.FixedSizeTree:

--- a/src/Voron/Data/Fixed/FixedSizeTree.cs
+++ b/src/Voron/Data/Fixed/FixedSizeTree.cs
@@ -505,7 +505,7 @@ namespace Voron.Data.Fixed
                 }
 
                 var entry = parentPage.GetEntry(0);
-                entry->Key = TVal.MinValue;
+                entry->SetKey(TVal.MinValue);
                 entry->PageNumber = page.PageNumber;
             }
 
@@ -574,7 +574,7 @@ namespace Voron.Data.Fixed
                     newPage.NumberOfEntries++;
                     page.NumberOfEntries--;
 
-                    AddSeparatorToParentPage(parentPage, parentPage.LastSearchPosition + 1, entry->Key,
+                    AddSeparatorToParentPage(parentPage, parentPage.LastSearchPosition + 1, entry->GetKey<TVal>(),
                         newPage.PageNumber);
 
                     return newPage; // this is where the new entry needs to go
@@ -626,8 +626,8 @@ namespace Voron.Data.Fixed
             }
             parentPage.NumberOfEntries++;
 
-            var newEntry = (FixedSizeTreeEntry<TVal>*)newEntryPos;
-            newEntry->Key = key;
+            var newEntry = (FixedSizeTreeEntry*)newEntryPos;
+            newEntry->SetKey(key);
             newEntry->PageNumber = pageNum;
         }
 
@@ -774,7 +774,7 @@ namespace Voron.Data.Fixed
             while (low <= high)
             {
                 position = (low + high) >> 1;
-                var curKey = FixedSizeTreePage<TVal>.GetEntry(p, position, size)->Key;
+                var curKey = FixedSizeTreePage<TVal>.GetEntry(p, position, size)->GetKey<TVal>();
                 lastMatch = val.CompareTo(curKey);
                 if (lastMatch == 0)
                     break;

--- a/src/Voron/Data/Fixed/FixedSizeTreeEntry.cs
+++ b/src/Voron/Data/Fixed/FixedSizeTreeEntry.cs
@@ -1,14 +1,37 @@
 ﻿using System;
+using System.Runtime.CompilerServices;
 using System.Runtime.InteropServices;
 
 namespace Voron.Data.Fixed
 {
     [StructLayout(LayoutKind.Explicit, Pack = 1)]
-    public unsafe struct FixedSizeTreeEntry<TVal>
-        where TVal : unmanaged, IBinaryNumber<TVal> 
+    public unsafe struct FixedSizeTreeEntry
     {
         [FieldOffset(0)]
-        public TVal Key;
+        private long _key;
+
+        [MethodImpl(MethodImplOptions.AggressiveInlining)]
+        public TVal GetKey<TVal>()
+            where TVal : unmanaged, IBinaryNumber<TVal>
+        {
+            if (typeof(TVal) == typeof(long))
+                return (TVal)(object)_key;
+            if (typeof(TVal) == typeof(double))
+                return (TVal)(object)BitConverter.Int64BitsToDouble(_key);
+            throw new NotSupportedException("Unknown type: " + typeof(TVal));
+        }
+
+        [MethodImpl(MethodImplOptions.AggressiveInlining)]
+        public void SetKey<TVal>(TVal value)
+            where TVal : unmanaged, IBinaryNumber<TVal>
+        {
+            if (typeof(TVal) == typeof(long))
+                _key = (long)(object)value;
+            else if (typeof(TVal) == typeof(double))
+                _key = BitConverter.DoubleToInt64Bits((double)(object)value);
+            else
+                throw new NotSupportedException("Unknown type: " + typeof(TVal));
+        }
 
         [FieldOffset(8)]
         public byte* Value;

--- a/src/Voron/Data/Fixed/FixedSizeTreeEntry.cs
+++ b/src/Voron/Data/Fixed/FixedSizeTreeEntry.cs
@@ -1,12 +1,14 @@
-﻿using System.Runtime.InteropServices;
+﻿using System;
+using System.Runtime.InteropServices;
 
 namespace Voron.Data.Fixed
 {
     [StructLayout(LayoutKind.Explicit, Pack = 1)]
-    public unsafe struct FixedSizeTreeEntry
+    public unsafe struct FixedSizeTreeEntry<TVal>
+        where TVal : unmanaged, IBinaryNumber<TVal> 
     {
         [FieldOffset(0)]
-        public long Key;
+        public TVal Key;
 
         [FieldOffset(8)]
         public byte* Value;

--- a/src/Voron/Data/Fixed/FixedSizeTreePage.cs
+++ b/src/Voron/Data/Fixed/FixedSizeTreePage.cs
@@ -128,26 +128,26 @@ namespace Voron.Data.Fixed
         [MethodImpl(MethodImplOptions.AggressiveInlining)]
         public void SetKey(TVal key, int position)
         {
-            GetEntry(position)->Key = key;
+            GetEntry(position)->SetKey(key);
         }
 
         [MethodImpl(MethodImplOptions.AggressiveInlining)]
         public TVal GetKey(int position)
         {
-            return GetEntry(Pointer + StartPosition, position, _entrySize)->Key;
+            return GetEntry(Pointer + StartPosition, position, _entrySize)->GetKey<TVal>();
         }
 
         [MethodImpl(MethodImplOptions.AggressiveInlining)]
-        internal FixedSizeTreeEntry<TVal>* GetEntry(int position)
+        internal FixedSizeTreeEntry* GetEntry(int position)
         {
             Debug.Assert(position >= 0 && ((position == 0 && NumberOfEntries == 0) || position < NumberOfEntries) ,$"FixedSizeTreePage: Requested an out of range entry {position} from [0-{NumberOfEntries-1}]");
             return GetEntry(Pointer + StartPosition, position, _entrySize);
         }
 
         [MethodImpl(MethodImplOptions.AggressiveInlining)]
-        public static FixedSizeTreeEntry<TVal>* GetEntry(byte* p, int position, int size)
+        public static FixedSizeTreeEntry* GetEntry(byte* p, int position, int size)
         {
-            return (FixedSizeTreeEntry<TVal>*)(p + position * size);
+            return (FixedSizeTreeEntry*)(p + position * size);
         }
 
         public void ResetStartPosition()

--- a/src/Voron/Debugging/DebugStuff.cs
+++ b/src/Voron/Debugging/DebugStuff.cs
@@ -5,6 +5,7 @@ using System.IO;
 using System.Linq;
 using System.Text;
 using System.Threading.Tasks;
+using Sparrow;
 using Sparrow.Platform;
 using Voron.Data;
 using Voron.Data.BTrees;
@@ -137,7 +138,8 @@ namespace Voron.Debugging
 }";
 
         [Conditional("DEBUG")]
-        public static void RenderAndShow_FixedSizeTree(LowLevelTransaction tx, FixedSizeTree fst)
+        public static void RenderAndShow_FixedSizeTree<TVal>(LowLevelTransaction tx, FixedSizeTree<TVal> fst) 
+            where TVal : unmanaged, IBinaryNumber<TVal>, IMinMaxValue<TVal>
         {
             var name = fst.Name;
             var tree = fst.Parent;
@@ -147,7 +149,8 @@ namespace Voron.Debugging
             });
         }
 
-        private static unsafe Task DumpFixedSizeTreeToStreamAsync(LowLevelTransaction tx, FixedSizeTree fst, TextWriter writer, Slice name, Tree tree)
+        private static unsafe Task DumpFixedSizeTreeToStreamAsync<TVal>(LowLevelTransaction tx, FixedSizeTree<TVal> fst, TextWriter writer, Slice name, Tree tree)
+            where TVal : unmanaged, IBinaryNumber<TVal>, IMinMaxValue<TVal>
         {
             var ptr = tree.DirectRead(name);
             if (ptr == null)
@@ -164,7 +167,8 @@ namespace Voron.Debugging
             return RenderLargeFixedSizeTreeAsync(large, tx, fst, writer);
         }
 
-        private static async Task RenderLargeFixedSizeTreeAsync(FixedSizeTreeSafe.LargeFixedSizeTreeSafe tree, LowLevelTransaction tx, FixedSizeTree fst, TextWriter writer)
+        private static async Task RenderLargeFixedSizeTreeAsync<TVal>(FixedSizeTreeSafe.LargeFixedSizeTreeSafe tree, LowLevelTransaction tx, FixedSizeTree<TVal> fst, TextWriter writer)
+            where TVal : unmanaged, IBinaryNumber<TVal>, IMinMaxValue<TVal>
         {
             await writer.WriteLineAsync(string.Format("<p>Number of entries: {0:#,#;;0}, val size: {1:#,#;;0}.</p>", tree.NumberOfEntries, tree.ValueSize));
             await writer.WriteLineAsync("<div class='css-treeview'><ul>");
@@ -249,7 +253,8 @@ namespace Voron.Debugging
 
         }
 
-        private static async Task RenderFixedSizeTreePageAsync(LowLevelTransaction tx, FixedSizeTreePage page, TextWriter sw, FixedSizeTreeSafe.LargeFixedSizeTreeSafe tree, string text, bool open)
+        private static async Task RenderFixedSizeTreePageAsync<TVal>(LowLevelTransaction tx, FixedSizeTreePage<TVal> page, TextWriter sw, FixedSizeTreeSafe.LargeFixedSizeTreeSafe tree, string text, bool open)
+            where TVal : unmanaged, IBinaryNumber<TVal>, IMinMaxValue<TVal>
         {
             await sw.WriteLineAsync(
                 string.Format("<ul><li><input type='checkbox' id='page-{0}' {3} /><label for='page-{0}'>{4}: Page {0:#,#;;0} - {1} - {2:#,#;;0} entries</label><ul>",
@@ -277,7 +282,7 @@ namespace Voron.Debugging
                     }
 
                     var fstPage = tx.GetPage(pageNum);
-                    await RenderFixedSizeTreePageAsync(tx, CreateFixedSizeTreePage(fstPage, tree), sw, tree, s, false);
+                    await RenderFixedSizeTreePageAsync(tx, CreateFixedSizeTreePage<TVal>(fstPage, tree), sw, tree, s, false);
                 }
             }
 
@@ -338,7 +343,8 @@ namespace Voron.Debugging
             sw.WriteLine("</ul></li></ul>");
         }
 
-        private static unsafe long GetFixedSizeTreeKey(FixedSizeTreePage page, FixedSizeTreeSafe.LargeFixedSizeTreeSafe tree, int i)
+        private static unsafe long GetFixedSizeTreeKey<TVal>(FixedSizeTreePage<TVal> page, FixedSizeTreeSafe.LargeFixedSizeTreeSafe tree, int i)
+            where TVal : unmanaged, IBinaryNumber<TVal>, IMinMaxValue<TVal>
         {
             if (page.IsLeaf)
                 return *(long*)(page.Pointer + page.StartPosition + (((sizeof(long) + tree.ValueSize)) * i));
@@ -346,14 +352,16 @@ namespace Voron.Debugging
             return *(long*)(page.Pointer + page.StartPosition + (((sizeof(long) + sizeof(long))) * i));
         }
 
-        private static unsafe long GetFixedSizeTreePageNumber(FixedSizeTreePage page, int i)
+        private static unsafe long GetFixedSizeTreePageNumber<TVal>(FixedSizeTreePage<TVal> page, int i)
+            where TVal : unmanaged, IBinaryNumber<TVal>, IMinMaxValue<TVal>
         {
             return *(long*)(page.Pointer + page.StartPosition + (((sizeof(long) + sizeof(long))) * i) + sizeof(long));
         }
 
-        private static unsafe FixedSizeTreePage CreateFixedSizeTreePage(Page page, FixedSizeTreeSafe.LargeFixedSizeTreeSafe tree)
+        private static unsafe FixedSizeTreePage<TVal> CreateFixedSizeTreePage<TVal>(Page page, FixedSizeTreeSafe.LargeFixedSizeTreeSafe tree)
+            where TVal : unmanaged, IBinaryNumber<TVal>, IMinMaxValue<TVal>
         {
-            return new FixedSizeTreePage(page.Pointer, tree.ValueSize + sizeof(long), Constants.Storage.PageSize);
+            return new FixedSizeTreePage<TVal>(page.Pointer, tree.ValueSize + sizeof(long), Constants.Storage.PageSize);
         }
 
  

--- a/src/Voron/Debugging/StorageReportGenerator.cs
+++ b/src/Voron/Debugging/StorageReportGenerator.cs
@@ -561,7 +561,7 @@ namespace Voron.Debugging
                 {
                     if ((page.Flags & PageFlags.FixedSizeTreePage) == PageFlags.FixedSizeTreePage)
                     {
-                        var fstp = new FixedSizeTreePage(page.Pointer, -1, Constants.Storage.PageSize);
+                        var fstp = new FixedSizeTreePage<long>(page.Pointer, -1, Constants.Storage.PageSize);
                         var sizeUsed = Constants.FixedSizeTree.PageHeaderSize +
                             fstp.NumberOfEntries * (fstp.IsLeaf ? fstp.ValueSize + sizeof(long) : FixedSizeTree.BranchEntrySize);
                         densities.Add((double)sizeUsed / Constants.Storage.PageSize);
@@ -586,7 +586,7 @@ namespace Voron.Debugging
             foreach (var pageNumber in allPages)
             {
                 var page = tree.Llt.GetPage(pageNumber);
-                var fstp = new FixedSizeTreePage(page.Pointer, tree.ValueSize + sizeof(long), Constants.Storage.PageSize);
+                var fstp = new FixedSizeTreePage<long>(page.Pointer, tree.ValueSize + sizeof(long), Constants.Storage.PageSize);
                 var sizeUsed = Constants.FixedSizeTree.PageHeaderSize +
                                fstp.NumberOfEntries * (fstp.IsLeaf ? fstp.ValueSize + sizeof(long) : FixedSizeTree.BranchEntrySize);
                 densities.Add((double)sizeUsed / Constants.Storage.PageSize);

--- a/src/Voron/Voron.csproj
+++ b/src/Voron/Voron.csproj
@@ -3,6 +3,8 @@
     <Description>Voron - Low level storage engine</Description>
     <Authors>Hibernating Rhinos</Authors>
     <TargetFramework>net6.0</TargetFramework>
+    <LangVersion>preview</LangVersion>
+    <EnablePreviewFeatures>True</EnablePreviewFeatures>
     <RuntimeFrameworkVersion>6.0.6</RuntimeFrameworkVersion>
     <AllowUnsafeBlocks>true</AllowUnsafeBlocks>
     <AssemblyName>Voron</AssemblyName>
@@ -30,6 +32,7 @@
   </ItemGroup>
   <ItemGroup>
     <PackageReference Include="System.Memory" Version="4.5.5" />
+    <PackageReference Include="System.Runtime.Experimental" Version="6.0.2" />
   </ItemGroup>
   <ItemGroup>
     <ProjectReference Include="..\Sparrow.Server\Sparrow.Server.csproj" />

--- a/test/BenchmarkTests/BenchmarkTests.csproj
+++ b/test/BenchmarkTests/BenchmarkTests.csproj
@@ -6,6 +6,7 @@
     <AssemblyName>BenchmarkTests</AssemblyName>
     <PackageId>BenchmarkTests</PackageId>
     <GenerateRuntimeConfigurationFiles>true</GenerateRuntimeConfigurationFiles>
+    <EnablePreviewFeatures>True</EnablePreviewFeatures>
     <CodeAnalysisRuleSet>..\..\RavenDB.ruleset</CodeAnalysisRuleSet>
     <CopyLocalLockFileAssemblies>true</CopyLocalLockFileAssemblies>
   </PropertyGroup>

--- a/test/EmbeddedTests/EmbeddedTests.csproj
+++ b/test/EmbeddedTests/EmbeddedTests.csproj
@@ -5,6 +5,7 @@
     <AssemblyName>EmbeddedTests</AssemblyName>
     <PackageId>EmbeddedTests</PackageId>
     <GenerateRuntimeConfigurationFiles>true</GenerateRuntimeConfigurationFiles>
+    <EnablePreviewFeatures>True</EnablePreviewFeatures>
     <CodeAnalysisRuleSet>..\..\RavenDB.ruleset</CodeAnalysisRuleSet>
     <CopyLocalLockFileAssemblies>true</CopyLocalLockFileAssemblies>
   </PropertyGroup>

--- a/test/FastTests/Corax/CoraxQueries.cs
+++ b/test/FastTests/Corax/CoraxQueries.cs
@@ -133,6 +133,29 @@ namespace FastTests.Corax
                 Assert.Equal(expectedList[i], outputList[i]);
         }
         
+             
+        [Fact]
+        public void BetweenQueryNumericDouble()
+        {
+            PrepareData();
+            IndexEntries();
+            using var ctx = new ByteStringContext(SharedMultipleUseFlag.None);
+            using var searcher = new IndexSearcher(Env);
+            Slice.From(ctx, "Content", out var field);
+            Slice.From(ctx, "Content-Dbl", out var fieldLong);
+
+
+            var match1 = searcher.BetweenQuery(field, fieldLong, 95.2, 213.2);
+            var expectedList = _entries.Where(x => x.LongValue is >= 95 and <= 213).Select(x => x.Id).ToList();
+            expectedList.Sort();
+            var outputList = FetchFromCorax(ref match1);
+            outputList.Sort();
+            Assert.Equal(expectedList.Count, outputList.Count);
+            for (int i = 0; i < expectedList.Count; ++i) 
+                Assert.Equal(expectedList[i], outputList[i]);
+        }
+
+        
         [Fact]
         public void UnaryMatchWithNumerical()
         {

--- a/test/FastTests/Corax/CoraxQueries.cs
+++ b/test/FastTests/Corax/CoraxQueries.cs
@@ -120,7 +120,7 @@ namespace FastTests.Corax
             using var ctx = new ByteStringContext(SharedMultipleUseFlag.None);
             using var searcher = new IndexSearcher(Env);
             Slice.From(ctx, "Content", out var field);
-            Slice.From(ctx, "Content-I64", out var fieldLong);
+            Slice.From(ctx, "Content-L", out var fieldLong);
 
 
             var match1 = searcher.BetweenQuery(field, fieldLong, 95, 212);
@@ -142,7 +142,7 @@ namespace FastTests.Corax
             using var ctx = new ByteStringContext(SharedMultipleUseFlag.None);
             using var searcher = new IndexSearcher(Env);
             Slice.From(ctx, "Content", out var field);
-            Slice.From(ctx, "Content-Dbl", out var fieldLong);
+            Slice.From(ctx, "Content-D", out var fieldLong);
 
 
             var match1 = searcher.BetweenQuery(field, fieldLong, 95.2, 213.2);

--- a/test/FastTests/Corax/CoraxQueries.cs
+++ b/test/FastTests/Corax/CoraxQueries.cs
@@ -113,6 +113,27 @@ namespace FastTests.Corax
         }
         
         [Fact]
+        public void BetweenQueryNumeric()
+        {
+            PrepareData();
+            IndexEntries();
+            using var ctx = new ByteStringContext(SharedMultipleUseFlag.None);
+            using var searcher = new IndexSearcher(Env);
+            Slice.From(ctx, "Content", out var field);
+            Slice.From(ctx, "Content-I64", out var fieldLong);
+
+
+            var match1 = searcher.BetweenQuery(field, fieldLong, 95, 212);
+            var expectedList = _entries.Where(x => x.LongValue is >= 95 and <= 212).Select(x => x.Id).ToList();
+            expectedList.Sort();
+            var outputList = FetchFromCorax(ref match1);
+            outputList.Sort();
+            Assert.Equal(expectedList.Count, outputList.Count);
+            for (int i = 0; i < expectedList.Count; ++i) 
+                Assert.Equal(expectedList[i], outputList[i]);
+        }
+        
+        [Fact]
         public void UnaryMatchWithNumerical()
         {
             PrepareData();

--- a/test/FastTests/Corax/CoraxQueries.cs
+++ b/test/FastTests/Corax/CoraxQueries.cs
@@ -24,6 +24,25 @@ namespace FastTests.Corax
         }
 
         [Fact]
+        public void GreaterThanQuery()
+        {
+            PrepareData();
+            IndexEntries();
+            using var ctx = new ByteStringContext(SharedMultipleUseFlag.None);
+            using var searcher = new IndexSearcher(Env);
+            Slice.From(ctx, "Content", out var fieldName);
+            Slice.From(ctx, "3", out var three);
+            var match1 = searcher.GreaterThanQuery(fieldName, three);
+            var expectedList = GetExpectedResult("3");
+            expectedList.Sort();
+            var outputList = FetchFromCorax(ref match1);
+            outputList.Sort();
+            Assert.Equal(expectedList.Count, outputList.Count);
+            for (int i = 0; i < expectedList.Count; ++i)
+                Assert.Equal(expectedList[i], outputList[i]);
+        }
+
+        [Fact]
         public void UnaryMatchWithSequential()
         {
             PrepareData();
@@ -55,6 +74,42 @@ namespace FastTests.Corax
             var ids = new long[16];
             int read = match1.Fill(ids);
             Assert.Equal(0, read);
+        }
+        
+        [Fact]
+        public void LexicographicalLessThanQuery()
+        {
+            PrepareData(1);
+            IndexEntries();
+            using var ctx = new ByteStringContext(SharedMultipleUseFlag.None);
+            using var searcher = new IndexSearcher(Env);
+            Slice.From(ctx, "0", out var id);
+            Slice.From(ctx, "Content", out var field);
+            var match1 = searcher.LessThanQuery(field, id);
+            var ids = new long[16];
+            int read = match1.Fill(ids);
+            Assert.Equal(0, read);
+        }
+        
+        [Fact]
+        public void BetweenQuery()
+        {
+            PrepareData();
+            IndexEntries();
+            using var ctx = new ByteStringContext(SharedMultipleUseFlag.None);
+            using var searcher = new IndexSearcher(Env);
+            Slice.From(ctx, "991", out var low);
+            Slice.From(ctx, "995", out var high);
+            Slice.From(ctx, "Content", out var field);
+
+            var match1 = searcher.BetweenQuery(field, low, high);
+            var expectedList = _entries.Where(x => x.LongValue is >= 991 and <= 995).Select(x => x.Id).ToList();
+            expectedList.Sort();
+            var outputList = FetchFromCorax(ref match1);
+            outputList.Sort();
+            Assert.Equal(expectedList.Count, outputList.Count);
+            for (int i = 0; i < expectedList.Count; ++i) 
+                Assert.Equal(expectedList[i], outputList[i]);
         }
         
         [Fact]
@@ -100,7 +155,8 @@ namespace FastTests.Corax
             Assert.True(first.SequenceEqual(second));
         }
 
-        private List<string> FetchFromCorax(ref BinaryMatch match)
+        private List<string> FetchFromCorax<TMatch>(ref TMatch match)
+            where TMatch : IQueryMatch
         {
             using var indexSearcher = new IndexSearcher(Env);
             List<string> list = new();

--- a/test/FastTests/Corax/CoraxQueries.cs
+++ b/test/FastTests/Corax/CoraxQueries.cs
@@ -146,7 +146,7 @@ namespace FastTests.Corax
 
 
             var match1 = searcher.BetweenQuery(field, fieldLong, 95.2, 213.2);
-            var expectedList = _entries.Where(x => x.LongValue is >= 95 and <= 213).Select(x => x.Id).ToList();
+            var expectedList = _entries.Where(x => (double)x.LongValue is >= 95.2 and <= 213.2).Select(x => x.Id).ToList();
             expectedList.Sort();
             var outputList = FetchFromCorax(ref match1);
             outputList.Sort();

--- a/test/FastTests/FastTests.csproj
+++ b/test/FastTests/FastTests.csproj
@@ -5,6 +5,8 @@
     <AllowUnsafeBlocks>true</AllowUnsafeBlocks>
     <AssemblyName>FastTests</AssemblyName>
     <PackageId>FastTests</PackageId>
+    <EnablePreviewFeatures>True</EnablePreviewFeatures>
+
     <GenerateRuntimeConfigurationFiles>true</GenerateRuntimeConfigurationFiles>
     <CodeAnalysisRuleSet>..\..\RavenDB.ruleset</CodeAnalysisRuleSet>
     <CopyLocalLockFileAssemblies>true</CopyLocalLockFileAssemblies>

--- a/test/FastTests/Voron/Bugs/RavenDB_9225.cs
+++ b/test/FastTests/Voron/Bugs/RavenDB_9225.cs
@@ -61,8 +61,6 @@ namespace FastTests.Voron.Bugs
         [Fact]
         public unsafe void FixedSizeTree_DeletingFromMiddle()
         {
-            FixedSizeTreeHeader.Large* header;
-            FixedSizeTreePage page;
             ushort valSize = 1008;
             var buffer = new byte[valSize];
             using (var tx = Env.WriteTransaction())
@@ -71,6 +69,8 @@ namespace FastTests.Voron.Bugs
                 var fst = tx.FixedTreeFor(t, valSize);
 
                 long i = 0;
+                FixedSizeTreeHeader.Large* header;
+                FixedSizeTreePage<long> page;
                 while (true)
                 {
                     fst.Add(++i, buffer);

--- a/test/FastTests/Voron/Bugs/RavenDB_9225.cs
+++ b/test/FastTests/Voron/Bugs/RavenDB_9225.cs
@@ -93,8 +93,8 @@ namespace FastTests.Voron.Bugs
                 page = fst.GetReadOnlyPage(page.GetEntry(page.NumberOfEntries - 1)->PageNumber);
                 page = fst.GetReadOnlyPage(page.GetEntry(0)->PageNumber);
 
-                var min = page.GetEntry(0)->Key;
-                var max = page.GetEntry(page.NumberOfEntries - 1)->Key;
+                var min = page.GetEntry(0)->GetKey<long>();
+                var max = page.GetEntry(page.NumberOfEntries - 1)->GetKey<long>();
 
                 for (i = min; i < max; i++)
                     fst.Delete(i);

--- a/test/InterversionTests/InterversionTests.csproj
+++ b/test/InterversionTests/InterversionTests.csproj
@@ -7,6 +7,7 @@
     <PackageId>InterversionTests</PackageId>
     <GenerateRuntimeConfigurationFiles>true</GenerateRuntimeConfigurationFiles>
     <CodeAnalysisRuleSet>..\..\RavenDB.ruleset</CodeAnalysisRuleSet>
+    <EnablePreviewFeatures>True</EnablePreviewFeatures>
     <CopyLocalLockFileAssemblies>true</CopyLocalLockFileAssemblies>
   </PropertyGroup>
   <ItemGroup Condition="'$(OS)' == 'Windows_NT'">

--- a/test/LicenseTests/LicenseTests.csproj
+++ b/test/LicenseTests/LicenseTests.csproj
@@ -4,6 +4,7 @@
     <RuntimeFrameworkVersion>6.0.6</RuntimeFrameworkVersion>
     <AssemblyName>LicenseTests</AssemblyName>
     <PackageId>LicenseTests</PackageId>
+    <EnablePreviewFeatures>True</EnablePreviewFeatures>
     <CodeAnalysisRuleSet>..\..\RavenDB.ruleset</CodeAnalysisRuleSet>
   </PropertyGroup>
   <ItemGroup Condition="'$(OS)' == 'Windows_NT'">

--- a/test/RachisTests/RachisTests.csproj
+++ b/test/RachisTests/RachisTests.csproj
@@ -6,6 +6,7 @@
     <AssemblyName>RachisTests</AssemblyName>
     <PackageId>RachisTests</PackageId>
     <GenerateRuntimeConfigurationFiles>true</GenerateRuntimeConfigurationFiles>
+    <EnablePreviewFeatures>True</EnablePreviewFeatures>
     <CodeAnalysisRuleSet>..\..\RavenDB.ruleset</CodeAnalysisRuleSet>
   </PropertyGroup>
   <ItemGroup Condition="'$(OS)' == 'Windows_NT'">

--- a/test/SlowTests/SlowTests.csproj
+++ b/test/SlowTests/SlowTests.csproj
@@ -7,6 +7,7 @@
     <PackageId>SlowTests</PackageId>
     <GenerateRuntimeConfigurationFiles>true</GenerateRuntimeConfigurationFiles>
     <CodeAnalysisRuleSet>..\..\RavenDB.ruleset</CodeAnalysisRuleSet>
+    <EnablePreviewFeatures>True</EnablePreviewFeatures>
     <CopyLocalLockFileAssemblies>true</CopyLocalLockFileAssemblies>
   </PropertyGroup>
   <ItemGroup Condition="'$(OS)' == 'Windows_NT'">

--- a/test/StressTests/StressTests.csproj
+++ b/test/StressTests/StressTests.csproj
@@ -7,6 +7,7 @@
     <PackageId>StressTests</PackageId>
     <GenerateRuntimeConfigurationFiles>true</GenerateRuntimeConfigurationFiles>
     <CodeAnalysisRuleSet>..\..\RavenDB.ruleset</CodeAnalysisRuleSet>
+    <EnablePreviewFeatures>True</EnablePreviewFeatures>
     <CopyLocalLockFileAssemblies>true</CopyLocalLockFileAssemblies>
   </PropertyGroup>
   <ItemGroup Condition="'$(OS)' == 'Windows_NT'">

--- a/test/Tests.Infrastructure/Tests.Infrastructure.csproj
+++ b/test/Tests.Infrastructure/Tests.Infrastructure.csproj
@@ -5,6 +5,8 @@
     <AssemblyName>Tests.Infrastructure</AssemblyName>
     <PackageId>Tests.Infrastructure</PackageId>
     <CodeAnalysisRuleSet>..\..\RavenDB.ruleset</CodeAnalysisRuleSet>
+    <EnablePreviewFeatures>True</EnablePreviewFeatures>
+
     <AllowUnsafeBlocks>true</AllowUnsafeBlocks>
   </PropertyGroup>
   <ItemGroup Condition="'$(OS)' == 'Windows_NT'">

--- a/test/Tryouts/Tryouts.csproj
+++ b/test/Tryouts/Tryouts.csproj
@@ -6,6 +6,7 @@
     <AssemblyName>Tryouts</AssemblyName>
     <OutputType>Exe</OutputType>
     <PackageId>Tryouts</PackageId>
+    <EnablePreviewFeatures>True</EnablePreviewFeatures>
     <CodeAnalysisRuleSet>..\..\RavenDB.ruleset</CodeAnalysisRuleSet>
     <LangVersion>latest</LangVersion>
     <DefineConstants>$(DefineConstants);IsAnyOS</DefineConstants>

--- a/tools/TypingsGenerator/TypingsGenerator.csproj
+++ b/tools/TypingsGenerator/TypingsGenerator.csproj
@@ -5,6 +5,8 @@
     <AssemblyName>TypingsGenerator</AssemblyName>
     <OutputType>Exe</OutputType>
     <PackageId>TypingsGenerator</PackageId>
+    <EnablePreviewFeatures>True</EnablePreviewFeatures>
+
     <GenerateAssemblyConfigurationAttribute>false</GenerateAssemblyConfigurationAttribute>
     <GenerateAssemblyCompanyAttribute>false</GenerateAssemblyCompanyAttribute>
     <GenerateAssemblyProductAttribute>false</GenerateAssemblyProductAttribute>

--- a/tools/Voron.Dictionary.Generator/Voron.Dictionary.Generator.csproj
+++ b/tools/Voron.Dictionary.Generator/Voron.Dictionary.Generator.csproj
@@ -6,6 +6,8 @@
     <ImplicitUsings>enable</ImplicitUsings>
     <Nullable>enable</Nullable>
     <AllowUnsafeBlocks>True</AllowUnsafeBlocks>
+    <EnablePreviewFeatures>True</EnablePreviewFeatures>
+
   </PropertyGroup>
 
   <ItemGroup>

--- a/tools/Voron.Recovery/Voron.Recovery.csproj
+++ b/tools/Voron.Recovery/Voron.Recovery.csproj
@@ -7,6 +7,8 @@
     <AllowUnsafeBlocks>true</AllowUnsafeBlocks>
     <AssemblyName>Voron.Recovery</AssemblyName>
     <OutputType>Exe</OutputType>
+    <EnablePreviewFeatures>True</EnablePreviewFeatures>
+
     <PackageId>Voron.Recovery</PackageId>
     <RuntimeIdentifiers>win7-x64;win8-x64;win10-x64;ubuntu.14.04-x64</RuntimeIdentifiers>
     <GenerateAssemblyConfigurationAttribute>false</GenerateAssemblyConfigurationAttribute>

--- a/tools/rvn/rvn.csproj
+++ b/tools/rvn/rvn.csproj
@@ -2,6 +2,8 @@
   <PropertyGroup>
     <Description>rvn is a CLI utility for RavenDB</Description>
     <Authors>Hibernating Rhinos</Authors>
+    <EnablePreviewFeatures>True</EnablePreviewFeatures>
+
     <OutputType>Exe</OutputType>
     <TargetFramework>net6.0</TargetFramework>
     <RuntimeFrameworkVersion>6.0.6</RuntimeFrameworkVersion>


### PR DESCRIPTION
### Issue link

https://issues.hibernatingrhinos.com/issue/RavenDB-18852 

### Additional description

This PR adds support for running range queries by using `MultiTermProvider`.
We scan through the index and do efficient range queries to provide the relevant terms.

I provided only the base infrastructure, still need to wire it in all the right places. 

Also added support for storing `FixedSizeTree` where the key is a `double`. 

### Type of change

- New feature

### How risky is the change?

- Not relevant

### Backward compatibility

- Not relevant

### Is it platform specific issue?

- No

### Documentation update

- No documentation update is needed 

### Testing 

- Tests have been added that prove the fix is effective or that the feature works


### Is there any existing behavior change of other features due to this change?

Need to wire that to the Corax queries execution

### UI work

- No UI work is needed
