### PR TITLE
RavenDB-18583 Revisions Settings: Do not mark fields with required er…

### DIFF
--- a/src/Raven.Studio/typescript/viewmodels/database/settings/revisions.ts
+++ b/src/Raven.Studio/typescript/viewmodels/database/settings/revisions.ts
@@ -289,8 +289,11 @@ class revisions extends viewModelBase {
 
     editItem(entry: revisionsConfigurationEntry) {
         this.currentBackingItem(entry);
+        
         const clone = revisionsConfigurationEntry.empty().copyFrom(entry);
         this.currentlyEditedItem(clone);
+
+        this.currentlyEditedItem().validationGroup.errors.showAllMessages(false);
     }
 
     deleteItem(entry: revisionsConfigurationEntry) {

--- a/src/Raven.Studio/wwwroot/App/views/database/settings/revisions.html
+++ b/src/Raven.Studio/wwwroot/App/views/database/settings/revisions.html
@@ -133,7 +133,7 @@
                             <div class="flex-horizontal">
                                 <small class="flex-start"><i class="icon-warning"></i></small>
                                 <small class="margin-left margin-left-sm" data-bind="html: limitWarningHtml()"></small>
-                    </div>
+                            </div>
                         </div>
                     </div>
                     <div class="toggle toggle-primary margin-top">


### PR DESCRIPTION
…ror by default

### Issue link
https://issues.hibernatingrhinos.com/issue/RavenDB-18583

### Additional description
Do not show the 'required error' upon opening the first time
Show error only upon clicking the 'OK' btn

### Type of change
- Bug fix
### How risky is the change?
- Low 

### Backward compatibility
- Non breaking change

### Is it platform specific issue?
- No

### Documentation update
- No documentation update is needed 

### Testing 
- It has been verified by manual testing

### Is there any existing behavior change of other features due to this change?
- No

### UI work
- No UI work is needed
