### PR TITLE
RavenDB-18886 Handling non-existent server wide task deletion

### DIFF
--- a/src/Raven.Server/ServerWide/ClusterStateMachine.cs
+++ b/src/Raven.Server/ServerWide/ClusterStateMachine.cs
@@ -3975,10 +3975,10 @@ namespace Raven.Server.ServerWide
         private void DeleteServerWideBackupConfigurationFromAllDatabases(DeleteServerWideTaskCommand.DeleteConfiguration deleteConfiguration, ClusterOperationContext context, string type, long index)
         {
             if (deleteConfiguration == null)
-                throw new RachisInvalidOperationException($"No configuration was supplied to {type}");
+                throw new RachisInvalidOperationException($"No configuration was supplied to {type}: raftIndex {index}");
             
             if (string.IsNullOrWhiteSpace(deleteConfiguration.TaskName))
-                throw new RachisInvalidOperationException($"Task name to delete cannot be null or white space for command type: {type}");
+                throw new RachisInvalidOperationException($"Task name to delete cannot be null or white space for command type {type} : raftIndex {index}");
 
             var items = context.Transaction.InnerTransaction.OpenTable(ItemsSchema, Items);
 

--- a/src/Raven.Server/ServerWide/ClusterStateMachine.cs
+++ b/src/Raven.Server/ServerWide/ClusterStateMachine.cs
@@ -3974,6 +3974,9 @@ namespace Raven.Server.ServerWide
 
         private void DeleteServerWideBackupConfigurationFromAllDatabases(DeleteServerWideTaskCommand.DeleteConfiguration deleteConfiguration, ClusterOperationContext context, string type, long index)
         {
+            if (deleteConfiguration == null)
+                throw new RachisInvalidOperationException($"No configuration was supplied to {type}");
+            
             if (string.IsNullOrWhiteSpace(deleteConfiguration.TaskName))
                 throw new RachisInvalidOperationException($"Task name to delete cannot be null or white space for command type: {type}");
 

--- a/src/Raven.Server/ServerWide/Commands/DeleteServerWideTaskCommand.cs
+++ b/src/Raven.Server/ServerWide/Commands/DeleteServerWideTaskCommand.cs
@@ -42,11 +42,15 @@ namespace Raven.Server.ServerWide.Commands
         public override BlittableJsonReaderObject GetUpdatedValue(JsonOperationContext context, BlittableJsonReaderObject previousValue, long index)
         {
             if (previousValue == null)
-                throw new RachisInvalidOperationException($"There are no server wide tasks so nothing to delete: configuration {context.ReadObject(Value.ToJson(), "")}");
+                throw new RachisInvalidOperationException(
+                    "There are no server wide tasks so nothing to delete: " +
+                           $"raftIndex {index}, configuration {context.ReadObject(Value.ToJson(), "")}");
 
             var propertyIndex = previousValue.GetPropertyIndex(Value.TaskName);
             if (propertyIndex == -1)
-                throw new RachisInvalidOperationException($"The server wide task to delete doesn't exist: previousValue {previousValue}, configuration {context.ReadObject(Value.ToJson(), "")}");
+                throw new RachisInvalidOperationException(
+                    "The server wide task to delete doesn't exist: " +
+                           $"raftIndex {index}, previousValue {previousValue}, configuration {context.ReadObject(Value.ToJson(), "")}");
 
             if (previousValue.Modifications == null)
                 previousValue.Modifications = new DynamicJsonValue();

--- a/src/Raven.Server/ServerWide/Commands/DeleteServerWideTaskCommand.cs
+++ b/src/Raven.Server/ServerWide/Commands/DeleteServerWideTaskCommand.cs
@@ -1,6 +1,7 @@
 ﻿using System;
 using System.Collections.Generic;
 using Raven.Client.Documents.Operations.OngoingTasks;
+using Raven.Server.Rachis;
 using Raven.Server.ServerWide.Context;
 using Sparrow.Json;
 using Sparrow.Json.Parsing;
@@ -41,11 +42,11 @@ namespace Raven.Server.ServerWide.Commands
         public override BlittableJsonReaderObject GetUpdatedValue(JsonOperationContext context, BlittableJsonReaderObject previousValue, long index)
         {
             if (previousValue == null)
-                return null;
+                throw new RachisInvalidOperationException($"There are no server wide tasks so nothing to delete: configuration {context.ReadObject(Value.ToJson(), "")}");
 
             var propertyIndex = previousValue.GetPropertyIndex(Value.TaskName);
             if (propertyIndex == -1)
-                return null;
+                throw new RachisInvalidOperationException($"The server wide task to delete doesn't exist: previousValue {previousValue}, configuration {context.ReadObject(Value.ToJson(), "")}");
 
             if (previousValue.Modifications == null)
                 previousValue.Modifications = new DynamicJsonValue();

--- a/test/SlowTests/Server/Documents/PeriodicBackup/ServerWideBackup.cs
+++ b/test/SlowTests/Server/Documents/PeriodicBackup/ServerWideBackup.cs
@@ -385,6 +385,33 @@ namespace SlowTests.Server.Documents.PeriodicBackup
         }
 
         [Fact, Trait("Category", "Smuggler")]
+        public async Task DeleteServerWideBackup_WhenDoesntExit_ShouldBeHandledProperly()
+        {
+            var server = GetNewServer();
+            using var store = GetDocumentStore(new Options{Server = server});
+
+            const string nonExistentTaskName = "NonExistentTask";
+            await Assert.ThrowsAnyAsync<RavenException>(async () =>
+                await store.Maintenance.Server.SendAsync(new DeleteServerWideTaskOperation(nonExistentTaskName, OngoingTaskType.Backup)));
+            
+            const string existentTaskName = "ExistentTaskName";
+            var putConfiguration = new ServerWideBackupConfiguration
+            {
+                Name = existentTaskName,
+                Disabled = true,
+                FullBackupFrequency = "0 2 * * 0",
+                IncrementalBackupFrequency = "0 2 * * 1",
+            };
+            await store.Maintenance.Server.SendAsync(new PutServerWideBackupConfigurationOperation(putConfiguration));
+            
+            await Assert.ThrowsAnyAsync<RavenException>(async () =>
+                await store.Maintenance.Server.SendAsync(new DeleteServerWideTaskOperation(nonExistentTaskName, OngoingTaskType.Backup)));
+            
+            //Just a raft command to check the cluster state machine is not stuck
+            await store.Maintenance.Server.SendAsync(new DeleteServerWideTaskOperation(existentTaskName, OngoingTaskType.Backup));
+        }
+        
+        [Fact, Trait("Category", "Smuggler")]
         public async Task CanDeleteServerWideBackup()
         {
             using (var store = GetDocumentStore())


### PR DESCRIPTION
### Issue link
https://issues.hibernatingrhinos.com/issue/RavenDB-18886

### Additional description
Checking that the task to delete exit and throw an appropriate exception if not.

### Type of change
- Bug fix

### How risky is the change?
- Low 

### Backward compatibility
- Not relevant

### Is it platform specific issue?
- No

### Documentation update
- No documentation update is needed 

### Testing 
- Tests have been added that prove the fix is effective or that the feature works

### Is there any existing behavior change of other features due to this change?
- No

### UI work
- No UI work is needed
