### PR TITLE
RavenDB-18908 Support multiple result set in map-reduce visualize

### DIFF
--- a/src/Raven.Server/Documents/Indexes/Debugging/IndexDebugExtensions.cs
+++ b/src/Raven.Server/Documents/Indexes/Debugging/IndexDebugExtensions.cs
@@ -434,7 +434,15 @@ namespace Raven.Server.Documents.Indexes.Debugging
                     return context.ReadObject(new DynamicJsonValue(), "debug-reduce-result");
 
                 if (result.Count > 1)
-                    throw new InvalidOperationException("Cannot have multiple reduce results for a single reduce key");
+                {
+                    var dvj = new DynamicJsonValue
+                    {
+                        ["MergedResults"] = true,
+                        ["TotalNumberOfResults"] = result.Count,
+                        ["Results"] = new DynamicJsonArray(result.Select(x=>x.Result.Data))
+                    };
+                    return context.ReadObject(dvj, "merged-map-reduce");
+                }
 
                 return result[0].Result.Data;
             }


### PR DESCRIPTION
### Issue link

https://issues.hibernatingrhinos.com/issue/RavenDB-18908 

### Additional description

We can now show the map/reduce visualizer when we have multiple results from map/reduce.
Great for trouble shooting complex indexes

### Type of change

- Bug fix

### How risky is the change?

- Low 

Only impacts a debug endpoint in a rare case.

### Backward compatibility

- Non breaking change

Enables a previously blocked scenario

### Is it platform specific issue?

- No

### Testing 

- It has been verified by manual testing

### Is there any existing behavior change of other features due to this change?

- No

### UI work

- No UI work is needed


Studio already supports it :-)