### PR TITLE
RavenDB-18872: IndexEntryWriter internal growable auxiliary buffers

### DIFF
--- a/bench/Voron.Benchmark/Corax/AndOrBenchmark.cs
+++ b/bench/Voron.Benchmark/Corax/AndOrBenchmark.cs
@@ -115,8 +115,7 @@ namespace Voron.Benchmark.Corax
             Slice.From(bsc, "Family", ByteStringType.Immutable, out var familySlice);
             Slice.From(bsc, "Age", ByteStringType.Immutable, out var ageSlice);
             Slice.From(bsc, "Type", ByteStringType.Immutable, out var typeSlice);
-
-            Span<byte> buffer = new byte[256];
+            
             var fields = new IndexFieldsMapping(bsc)
                 .AddBinding(0, nameSlice)
                 .AddBinding(1, familySlice)
@@ -126,38 +125,41 @@ namespace Voron.Benchmark.Corax
             using (var writer = new IndexWriter(env, fields))
             {
                 {
-                    var entryWriter = new IndexEntryWriter(buffer, fields);
+                    var entryWriter = new IndexEntryWriter(bsc, fields);
                     entryWriter.Write(0, Encoding.UTF8.GetBytes("Arava"));
                     entryWriter.Write(1, Encoding.UTF8.GetBytes("Eini"));
                     entryWriter.Write(2, Encoding.UTF8.GetBytes(12L.ToString()), 12L, 12D);
                     entryWriter.Write(3, Encoding.UTF8.GetBytes("Dog"));
-                    entryWriter.Finish(out var entry);
-
-                    writer.Index("dogs/arava", entry);
+                    using (var _ = entryWriter.Finish(out var entry))
+                    {
+                        writer.Index("dogs/arava", entry.ToSpan());
+                    }
                 }
 
                 {
-                    var entryWriter = new IndexEntryWriter(buffer, fields);
+                    var entryWriter = new IndexEntryWriter(bsc, fields);
                     entryWriter.Write(0, Encoding.UTF8.GetBytes("Phoebe"));
                     entryWriter.Write(1, Encoding.UTF8.GetBytes("Eini"));
                     entryWriter.Write(2, Encoding.UTF8.GetBytes(7.ToString()), 7L, 7D);
                     entryWriter.Write(3, Encoding.UTF8.GetBytes("Dog"));
-                    entryWriter.Finish(out var entry);
-
-                    writer.Index("dogs/phoebe", entry);
+                    using (var _ = entryWriter.Finish(out var entry))
+                    {
+                        writer.Index("dogs/phoebe", entry.ToSpan());
+                    }
                 }
 
                 for (int i = 0; i < 10_000; i++)
                 {
-                    var entryWriter = new IndexEntryWriter(buffer, fields);
+                    var entryWriter = new IndexEntryWriter(bsc, fields);
                     entryWriter.Write(0, Encoding.UTF8.GetBytes("Dog #" + i));
                     entryWriter.Write(1, Encoding.UTF8.GetBytes("families/" + (i % 1024)));
                     var age = i % 17;
                     entryWriter.Write(2, Encoding.UTF8.GetBytes(age.ToString()), age, age);
                     entryWriter.Write(3, Encoding.UTF8.GetBytes("Dog"));
-                    entryWriter.Finish(out var entry);
-
-                    writer.Index("dogs/" + i, entry);
+                    using (var _ = entryWriter.Finish(out var entry))
+                    {
+                        writer.Index("dogs/" + i, entry.ToSpan());
+                    }
                 }
 
                 writer.Commit();

--- a/bench/Voron.Benchmark/Corax/InBenchmark.cs
+++ b/bench/Voron.Benchmark/Corax/InBenchmark.cs
@@ -126,38 +126,41 @@ namespace Voron.Benchmark.Corax
             using (var writer = new IndexWriter(env, fields))
             {
                 {
-                    var entryWriter = new IndexEntryWriter(buffer, fields);
+                    var entryWriter = new IndexEntryWriter(bsc, fields);
                     entryWriter.Write(0, Encoding.UTF8.GetBytes("Arava"));
                     entryWriter.Write(1, Encoding.UTF8.GetBytes("Eini"));
                     entryWriter.Write(2, Encoding.UTF8.GetBytes(12L.ToString()), 12L, 12D);
                     entryWriter.Write(3, Encoding.UTF8.GetBytes("Dog"));
-                    entryWriter.Finish(out var entry);
-
-                    writer.Index("dogs/arava", entry);
+                    using (var _ = entryWriter.Finish(out var entry))
+                    {
+                        writer.Index("dogs/arava", entry.ToSpan());
+                    }
                 }
 
                 {
-                    var entryWriter = new IndexEntryWriter(buffer, fields);
+                    var entryWriter = new IndexEntryWriter(bsc, fields);
                     entryWriter.Write(0, Encoding.UTF8.GetBytes("Phoebe"));
                     entryWriter.Write(1, Encoding.UTF8.GetBytes("Eini"));
                     entryWriter.Write(2, Encoding.UTF8.GetBytes(7.ToString()), 7L, 7D);
                     entryWriter.Write(3, Encoding.UTF8.GetBytes("Dog"));
-                    entryWriter.Finish(out var entry);
-
-                    writer.Index("dogs/phoebe", entry);
+                    using (var _ = entryWriter.Finish(out var entry))
+                    {
+                        writer.Index("dogs/phoebe", entry.ToSpan());
+                    }
                 }
 
                 for (int i = 0; i < 10_000; i++)
                 {
-                    var entryWriter = new IndexEntryWriter(buffer, fields);
+                    var entryWriter = new IndexEntryWriter(bsc, fields);
                     entryWriter.Write(0, Encoding.UTF8.GetBytes("Dog #" + i));
                     entryWriter.Write(1, Encoding.UTF8.GetBytes("families/" + (i % 1024)));
                     var age = i % 17;
                     entryWriter.Write(2, Encoding.UTF8.GetBytes(age.ToString()), age, age);
                     entryWriter.Write(3, Encoding.UTF8.GetBytes("Dog"));
-                    entryWriter.Finish(out var entry);
-
-                    writer.Index("dogs/" + i, entry);
+                    using (var _ = entryWriter.Finish(out var entry))
+                    {
+                        writer.Index("dogs/" + i, entry.ToSpan());
+                    }
                 }
 
                 writer.Commit();

--- a/bench/Voron.Benchmark/Corax/StartWithBenchmark.cs
+++ b/bench/Voron.Benchmark/Corax/StartWithBenchmark.cs
@@ -118,7 +118,6 @@ namespace Voron.Benchmark.Corax
             Slice.From(bsc, "Age", ByteStringType.Immutable, out var ageSlice);
             Slice.From(bsc, "Type", ByteStringType.Immutable, out var typeSlice);
 
-            Span<byte> buffer = new byte[256];
             var fields = new IndexFieldsMapping(bsc)
                 .AddBinding(0, nameSlice)
                 .AddBinding(1, familySlice)
@@ -127,38 +126,41 @@ namespace Voron.Benchmark.Corax
             using (var writer = new IndexWriter(env, fields))
             {
                 {
-                    var entryWriter = new IndexEntryWriter(buffer, fields);
+                    var entryWriter = new IndexEntryWriter(bsc, fields);
                     entryWriter.Write(0, Encoding.UTF8.GetBytes("Arava"));
                     entryWriter.Write(1, Encoding.UTF8.GetBytes("Eini"));
                     entryWriter.Write(2, Encoding.UTF8.GetBytes(12L.ToString()), 12L, 12D);
                     entryWriter.Write(3, Encoding.UTF8.GetBytes("Dog"));
-                    entryWriter.Finish(out var entry);
-
-                    writer.Index("dogs/arava", entry);
+                    using (var _ = entryWriter.Finish(out var entry))
+                    {
+                        writer.Index("dogs/arava", entry.ToSpan());
+                    };
                 }
 
                 {
-                    var entryWriter = new IndexEntryWriter(buffer, fields);
+                    var entryWriter = new IndexEntryWriter(bsc, fields);
                     entryWriter.Write(0, Encoding.UTF8.GetBytes("Phoebe"));
                     entryWriter.Write(1, Encoding.UTF8.GetBytes("Eini"));
                     entryWriter.Write(2, Encoding.UTF8.GetBytes(7.ToString()), 7L, 7D);
                     entryWriter.Write(3, Encoding.UTF8.GetBytes("Dog"));
-                    entryWriter.Finish(out var entry);
-
-                    writer.Index("dogs/phoebe", entry);
+                    using (var _ = entryWriter.Finish(out var entry))
+                    {
+                        writer.Index("dogs/phoebe", entry.ToSpan());
+                    }
                 }
 
                 for (int i = 0; i < 10_000; i++)
                 {
-                    var entryWriter = new IndexEntryWriter(buffer, fields);
+                    var entryWriter = new IndexEntryWriter(bsc, fields);
                     entryWriter.Write(0, Encoding.UTF8.GetBytes("Dog #" + i));
                     entryWriter.Write(1, Encoding.UTF8.GetBytes("families/" + (i % 1024)));
                     var age = i % 15;
                     entryWriter.Write(2, Encoding.UTF8.GetBytes(age.ToString()), age, age);
                     entryWriter.Write(3, Encoding.UTF8.GetBytes("Dog"));
-                    entryWriter.Finish(out var entry);
-
-                    writer.Index("dogs/" + i, entry);
+                    using (var _ = entryWriter.Finish(out var entry))
+                    {
+                        writer.Index("dogs/" + i, entry.ToSpan());
+                    }
                 }
 
                 writer.Commit();

--- a/src/Corax/IndexEntry/IndexEntryReader.cs
+++ b/src/Corax/IndexEntry/IndexEntryReader.cs
@@ -317,14 +317,12 @@ public unsafe readonly ref struct IndexEntryReader
 
             if (type.HasFlag(IndexEntryFieldType.HasNulls))
             {
-                fixed (byte* nullTablePtr = _buffer)
-                {
-                    if (PtrBitVector.GetBitInPointer(nullTablePtr + spanTableOffset, elementIdx) == true)
-                        goto HasNull;
+                byte* nullTablePtr = (byte*)Unsafe.AsPointer(ref MemoryMarshal.GetReference(_buffer));
+                if (PtrBitVector.GetBitInPointer(nullTablePtr + spanTableOffset, elementIdx) == true)
+                    goto HasNull;
 
-                    int nullBitStreamSize = totalElements / (sizeof(byte) * 8) + (totalElements % (sizeof(byte) * 8) == 0 ? 0 : 1);
-                    spanTableOffset += nullBitStreamSize; // Point after the null table.
-                }
+                int nullBitStreamSize = totalElements / (sizeof(byte) * 8) + (totalElements % (sizeof(byte) * 8) == 0 ? 0 : 1);
+                spanTableOffset += nullBitStreamSize; // Point after the null table.                             
             }
 
             // Skip over the number of entries and jump to the string location.
@@ -342,11 +340,9 @@ public unsafe readonly ref struct IndexEntryReader
             if (type.HasFlag(IndexEntryFieldType.HasNulls))
             {
                 var spanTableOffset = Unsafe.ReadUnaligned<int>(ref _buffer[intOffset]);
-                fixed (byte* nullTablePtr = _buffer)
-                {
-                    if (PtrBitVector.GetBitInPointer(nullTablePtr + spanTableOffset, elementIdx))
-                        goto HasNull;
-                }
+                byte* nullTablePtr = (byte*)Unsafe.AsPointer(ref MemoryMarshal.GetReference(_buffer));
+                if (PtrBitVector.GetBitInPointer(nullTablePtr + spanTableOffset, elementIdx) == true)
+                    goto HasNull;
             }
 
             stringLength = VariableSizeEncoding.Read<int>(_buffer, out int readOffset, intOffset);
@@ -358,11 +354,9 @@ public unsafe readonly ref struct IndexEntryReader
             if (type.HasFlag(IndexEntryFieldType.HasNulls))
             {
                 var spanTableOffset = Unsafe.ReadUnaligned<int>(ref _buffer[intOffset]);
-                fixed (byte* nullTablePtr = _buffer)
-                {
-                    if (PtrBitVector.GetBitInPointer(nullTablePtr + spanTableOffset, elementIdx))
-                        goto HasNull;
-                }
+                byte* nullTablePtr = (byte*)Unsafe.AsPointer(ref MemoryMarshal.GetReference(_buffer));
+                if (PtrBitVector.GetBitInPointer(nullTablePtr + spanTableOffset, elementIdx) == true)
+                    goto HasNull;
             }
 
             VariableSizeEncoding.Read<long>(_buffer, out int length, intOffset); // Skip

--- a/src/Corax/IndexEntry/IndexEntryReader.cs
+++ b/src/Corax/IndexEntry/IndexEntryReader.cs
@@ -317,8 +317,7 @@ public unsafe readonly ref struct IndexEntryReader
 
             if (type.HasFlag(IndexEntryFieldType.HasNulls))
             {
-                byte* nullTablePtr = (byte*)Unsafe.AsPointer(ref MemoryMarshal.GetReference(_buffer));
-                if (PtrBitVector.GetBitInPointer(nullTablePtr + spanTableOffset, elementIdx) == true)
+                if (PtrBitVector.GetBitInSpan(_buffer.Slice(spanTableOffset), elementIdx) == true)
                     goto HasNull;
 
                 int nullBitStreamSize = totalElements / (sizeof(byte) * 8) + (totalElements % (sizeof(byte) * 8) == 0 ? 0 : 1);
@@ -340,8 +339,7 @@ public unsafe readonly ref struct IndexEntryReader
             if (type.HasFlag(IndexEntryFieldType.HasNulls))
             {
                 var spanTableOffset = Unsafe.ReadUnaligned<int>(ref _buffer[intOffset]);
-                byte* nullTablePtr = (byte*)Unsafe.AsPointer(ref MemoryMarshal.GetReference(_buffer));
-                if (PtrBitVector.GetBitInPointer(nullTablePtr + spanTableOffset, elementIdx) == true)
+                if (PtrBitVector.GetBitInSpan(_buffer.Slice(spanTableOffset), elementIdx) == true)
                     goto HasNull;
             }
 
@@ -353,9 +351,8 @@ public unsafe readonly ref struct IndexEntryReader
         {
             if (type.HasFlag(IndexEntryFieldType.HasNulls))
             {
-                var spanTableOffset = Unsafe.ReadUnaligned<int>(ref _buffer[intOffset]);
-                byte* nullTablePtr = (byte*)Unsafe.AsPointer(ref MemoryMarshal.GetReference(_buffer));
-                if (PtrBitVector.GetBitInPointer(nullTablePtr + spanTableOffset, elementIdx) == true)
+                var spanTableOffset = Unsafe.ReadUnaligned<int>(ref _buffer[intOffset]); 
+                if (PtrBitVector.GetBitInSpan(_buffer.Slice(spanTableOffset), elementIdx) == true)
                     goto HasNull;
             }
 

--- a/src/Corax/IndexEntry/IndexEntryReader.cs
+++ b/src/Corax/IndexEntry/IndexEntryReader.cs
@@ -1,12 +1,10 @@
 using System;
-using System.Collections.Generic;
 using System.Linq;
 using System.Runtime.CompilerServices;
 using System.Runtime.InteropServices;
 using Sparrow;
 using Sparrow.Binary;
 using Sparrow.Server.Compression;
-using Voron;
 
 namespace Corax;
 
@@ -20,18 +18,23 @@ namespace Corax;
  *  tuple<long, double, string>: <length:variable_size><string_table_ptr:sizeof(int)><long_ptr:variable_size><double[X]:sizeof(double)>
  *                               <strings[X]:sequence><string_length_table[X]:var_int>
  */
-public unsafe readonly ref struct IndexEntryReader
+public unsafe ref struct IndexEntryReader
 {
     private const int Invalid = unchecked((int)0xFFFF_FFFF);
     private readonly Span<byte> _buffer;
+    private int _lastFieldAccessed;
+    private int _lastFieldAccessedOffset;
+    private bool _lastFieldAccessedIsTyped;
 
     public int Length => (int)MemoryMarshal.Read<uint>(_buffer);
 
     public IndexEntryReader(Span<byte> buffer)
     {
         _buffer = buffer;
+        _lastFieldAccessed = -1;
+        Unsafe.SkipInit(out _lastFieldAccessedOffset);
+        Unsafe.SkipInit(out _lastFieldAccessedIsTyped);
     }
-
 
     /// <summary>
     /// Read unmanaged field entry from buffer.
@@ -42,7 +45,6 @@ public unsafe readonly ref struct IndexEntryReader
         var (intOffset, isTyped) = GetMetadataFieldLocation(_buffer, field);
         if (intOffset == Invalid || isTyped == false)
             goto Fail;
-
 
         type = Unsafe.ReadUnaligned<IndexEntryFieldType>(ref _buffer[intOffset]);
         if (type == IndexEntryFieldType.Null)
@@ -351,7 +353,7 @@ public unsafe readonly ref struct IndexEntryReader
         {
             if (type.HasFlag(IndexEntryFieldType.HasNulls))
             {
-                var spanTableOffset = Unsafe.ReadUnaligned<int>(ref _buffer[intOffset]); 
+                var spanTableOffset = Unsafe.ReadUnaligned<int>(ref _buffer[intOffset]);
                 if (PtrBitVector.GetBitInSpan(_buffer.Slice(spanTableOffset), elementIdx) == true)
                     goto HasNull;
             }
@@ -426,8 +428,8 @@ public unsafe readonly ref struct IndexEntryReader
         // setup costs for handling multiple elements are usually much higher than to access the first element, where
         // data layout is optimized for. 
         if (type.HasFlag(IndexEntryFieldType.Tuple) == false)
-            goto Fail;        
-        
+            goto Fail;
+
         if (type.HasFlag(IndexEntryFieldType.HasNulls))
         {
             if (type.HasFlag(IndexEntryFieldType.List))
@@ -436,15 +438,15 @@ public unsafe readonly ref struct IndexEntryReader
                 type = IndexEntryFieldType.HasNulls;
             goto NullOrEmpty;
         }
-        
-        if( type.HasFlag(IndexEntryFieldType.Empty))
+
+        if (type.HasFlag(IndexEntryFieldType.Empty))
         {
             if (type.HasFlag(IndexEntryFieldType.List))
                 type = IndexEntryFieldType.Empty | IndexEntryFieldType.List;
             else
                 type = IndexEntryFieldType.Empty;
             goto NullOrEmpty;
-        }            
+        }
 
         longValue = VariableSizeEncoding.Read<long>(_buffer, out int length, intOffset); // Read
         intOffset += length;
@@ -473,21 +475,31 @@ public unsafe readonly ref struct IndexEntryReader
         return true;
     }
 
+    private static ReadOnlySpan<byte> TableEncodingLookupTable => new byte[] { 0, 1, 2, 0, 4 };
+
+    private (int offset, bool isTyped) GetMetadataFieldLocation(Span<byte> buffer, int field)
+    {
+        if (field == _lastFieldAccessed)
+        {
+            return (_lastFieldAccessedOffset, _lastFieldAccessedIsTyped);
+        }
+        else
+        {
+            (_lastFieldAccessedOffset, _lastFieldAccessedIsTyped) = GetMetadataFieldLocationUnlikely(buffer, field);
+            _lastFieldAccessed = field;
+            return (_lastFieldAccessedOffset, _lastFieldAccessedIsTyped);
+        }
+    }
+
     [MethodImpl(MethodImplOptions.AggressiveInlining)]
-    private static (int offset, bool isTyped) GetMetadataFieldLocation(Span<byte> buffer, int field)
+    private static (int offset, bool isTyped) GetMetadataFieldLocationUnlikely(Span<byte> buffer, int field)
     {
         ref var header = ref MemoryMarshal.AsRef<IndexEntryHeader>(buffer);
 
         ushort knownFieldsCount = (ushort)(header.KnownFieldCount >> 2);
         IndexEntryTableEncoding encoding = (IndexEntryTableEncoding)(header.KnownFieldCount & 0b11);
-        int encodeSize = encoding switch
-        {
-            IndexEntryTableEncoding.OneByte => 1,
-            IndexEntryTableEncoding.TwoBytes => 2,
-            IndexEntryTableEncoding.FourBytes => 4,
-            _ => throw new InvalidOperationException()
-        };
 
+        int encodeSize = TableEncodingLookupTable[(int)encoding];    
         int locationOffset = buffer.Length - (knownFieldsCount * encodeSize) + field * encodeSize;
 
         int offset;
@@ -498,22 +510,20 @@ public unsafe readonly ref struct IndexEntryReader
             offset = Unsafe.ReadUnaligned<byte>(ref buffer[locationOffset]);
             if (offset == 0xFF)
                 goto Fail;
-            isTyped = (offset & 0x80) != 0;
-            offset &= ~0x80;
+            isTyped = (offset & Constants.IndexWriter.ByteKnownFieldMask) != 0;
+            offset &= ~Constants.IndexWriter.ByteKnownFieldMask;
             goto End;
         }
-
-        if (encoding == IndexEntryTableEncoding.TwoBytes)
+        else if (encoding == IndexEntryTableEncoding.TwoBytes)
         {
             offset = Unsafe.ReadUnaligned<ushort>(ref buffer[locationOffset]);
             if (offset == 0xFFFF)
                 goto Fail;
-            isTyped = (offset & 0x8000) != 0;
-            offset &= ~0x8000;
+            isTyped = (offset & Constants.IndexWriter.ShortKnownFieldMask) != 0;
+            offset &= ~Constants.IndexWriter.ShortKnownFieldMask;
             goto End;
         }
-
-        if (encoding == IndexEntryTableEncoding.FourBytes)
+        else if (encoding == IndexEntryTableEncoding.FourBytes)
         {
             offset = (int)Unsafe.ReadUnaligned<uint>(ref buffer[locationOffset]);
             if (offset == unchecked((int)0xFFFF_FFFF))

--- a/src/Corax/IndexEntry/IndexEntryTableEncoding.cs
+++ b/src/Corax/IndexEntry/IndexEntryTableEncoding.cs
@@ -1,5 +1,8 @@
 ﻿namespace Corax;
 
+
+// PERF: This entries are used in a lookup table at the IndexEntryReader. Any modification of these values
+//       would require the modification of the table. 
 public enum IndexEntryTableEncoding : byte
 {
     None = 0b00, // shouldn't be used ever

--- a/src/Corax/IndexEntry/IndexEntryWriter.cs
+++ b/src/Corax/IndexEntry/IndexEntryWriter.cs
@@ -7,14 +7,16 @@ using Corax.Utils;
 using Corax.Utils.Spatial;
 using Sparrow;
 using Sparrow.Binary;
+using Sparrow.Server;
 using Sparrow.Server.Compression;
 using Voron;
+using Voron.Impl;
 
 namespace Corax;
 
 // The rationale to use ref structs is not allowing to copy those around so easily. They should be cheap to construct
 // and cheaper to use. 
-public unsafe ref partial struct IndexEntryWriter
+public unsafe partial struct IndexEntryWriter : IDisposable
 {
     private static int Invalid = unchecked(~0);
 
@@ -22,14 +24,20 @@ public unsafe ref partial struct IndexEntryWriter
 
     private readonly IndexFieldsMapping _knownFields;
 
+    private readonly ByteStringContext _context;
+    private ByteStringContext<ByteStringMemoryCache>.InternalScope _bufferScope;
+    private ByteString _rawBuffer;
+
     // The usable part of the buffer, the metadata space will be removed from the usable space.
-    private readonly Span<byte> _buffer;
+    private Span<byte> Buffer => new Span<byte>(_rawBuffer.Ptr, _rawBuffer.Length - KnownFieldMetadataSize);
 
     // Temporary location for the pointers, these will eventually be encoded based on how big they are.
     // <256 bytes we could use a single byte
     // <65546 bytes we could use a single ushort
     // for the rest we will use a uint.
-    private readonly Span<int> _knownFieldsLocations;
+    private Span<int> KnownFieldsLocations => new Span<int>(_rawBuffer.Ptr + _rawBuffer.Length - KnownFieldMetadataSize, _knownFields.Count);
+
+    private int KnownFieldMetadataSize => _knownFields.Count * sizeof(uint);
 
     [MethodImpl(MethodImplOptions.AggressiveInlining)]
     public bool IsEmpty() => Unsafe.SizeOf<IndexEntryHeader>() == _dataIndex;
@@ -41,24 +49,39 @@ public unsafe ref partial struct IndexEntryWriter
     // so we wont even try to make the process more complex just to deal with them efficienly.
     private int _dynamicFieldIndex;
 
-    public IndexEntryWriter(Span<byte> buffer, IndexFieldsMapping knownFields)
+    public IndexEntryWriter(LowLevelTransaction llt, IndexFieldsMapping knownFields) 
+        : this(llt.Allocator, knownFields)
     {
-        // TODO: For now we will assume that the max size of an index entry is 32Kb, revisit this...
-        _knownFields = knownFields;
-        int knownFieldMetadataSize = _knownFields.Count * sizeof(uint);
-        _knownFieldsLocations = MemoryMarshal.Cast<byte, int>(buffer[^knownFieldMetadataSize..]);
-        _knownFieldsLocations.Fill(Invalid); // We prepare the table in order to avoid tracking the writes. 
+    }
 
-        _buffer = buffer[..^knownFieldMetadataSize];
+    public IndexEntryWriter(ByteStringContext context, IndexFieldsMapping knownFields) 
+    {
+        _context = context;
+        _knownFields = knownFields;
+
+        _bufferScope = _context.Allocate(16 * Sparrow.Global.Constants.Size.Kilobyte, out _rawBuffer);
+
         _dynamicFieldIndex = 0;
         _dataIndex = Unsafe.SizeOf<IndexEntryHeader>();
+
+        // We prepare the table in order to avoid tracking the writes. 
+        new Span<int>(_rawBuffer.Ptr + _rawBuffer.Length - KnownFieldMetadataSize, _knownFields.Count).Fill(Invalid);
+    }
+
+    public void Reset()
+    {
+        _dynamicFieldIndex = 0;
+        _dataIndex = Unsafe.SizeOf<IndexEntryHeader>();
+
+        KnownFieldsLocations.Fill(Invalid); // We prepare the table in order to avoid tracking the writes. 
     }
 
     public void WriteNull(int field)
     {
         // Write known field.
-        _knownFieldsLocations[field] = _dataIndex | Constants.IndexWriter.IntKnownFieldMask;
-        Unsafe.WriteUnaligned(ref _buffer[_dataIndex], IndexEntryFieldType.Null);
+        KnownFieldsLocations[field] = _dataIndex | Constants.IndexWriter.IntKnownFieldMask;
+
+        Unsafe.WriteUnaligned(ref Buffer[_dataIndex], IndexEntryFieldType.Null);
         _dataIndex += sizeof(IndexEntryFieldType);
     }
 
@@ -68,23 +91,24 @@ public unsafe ref partial struct IndexEntryWriter
     public void Write(int field, ReadOnlySpan<byte> value)
     {
         Debug.Assert(field < _knownFields.Count);
-        Debug.Assert(_knownFieldsLocations[field] == Invalid);
+        Debug.Assert(KnownFieldsLocations[field] == Invalid);
 
         // Write known field.
-        ref int fieldLocation = ref _knownFieldsLocations[field];
+        ref int fieldLocation = ref KnownFieldsLocations[field];                
         fieldLocation = _dataIndex;
 
+        var buffer = Buffer;
         if (value.Length == 0)
         {
             fieldLocation |= Constants.IndexWriter.IntKnownFieldMask;
-            Unsafe.WriteUnaligned(ref _buffer[_dataIndex], IndexEntryFieldType.Empty);
+            Unsafe.WriteUnaligned(ref buffer[_dataIndex], IndexEntryFieldType.Empty);
             _dataIndex += sizeof(IndexEntryFieldType);
             return;
         }
         
-        int length = VariableSizeEncoding.Write(_buffer, value.Length, _dataIndex);
+        int length = VariableSizeEncoding.Write(buffer, value.Length, _dataIndex);
         _dataIndex += length;
-        value.CopyTo(_buffer.Slice(_dataIndex, value.Length));
+        value.CopyTo(buffer.Slice(_dataIndex, value.Length));
         _dataIndex += value.Length;
     }
 
@@ -96,43 +120,42 @@ public unsafe ref partial struct IndexEntryWriter
         //STRUCT
         //<type><size_of_binary><binary>
         Debug.Assert(field < _knownFields.Count);
-        Debug.Assert(_knownFieldsLocations[field] == Invalid);
+        Debug.Assert(KnownFieldsLocations[field] == Invalid);
 
         int dataLocation = _dataIndex;
 
         // Write known field.
-        ref int fieldLocation = ref _knownFieldsLocations[field];
+        ref int fieldLocation = ref KnownFieldsLocations[field];
         fieldLocation = dataLocation | Constants.IndexWriter.IntKnownFieldMask;
 
+        var buffer = Buffer;
+
         // Write the list metadata information. 
-        fixed (byte* bufferPtr = _buffer)
+        ref var indexEntryField = ref Unsafe.AsRef<IndexEntryFieldType>(Unsafe.AsPointer(ref buffer[dataLocation]));
+        indexEntryField = IndexEntryFieldType.Raw;
+        dataLocation += sizeof(IndexEntryFieldType);
+
+        if (binaryValue.Length == 0)
         {
-            ref var indexEntryField = ref Unsafe.AsRef<IndexEntryFieldType>(bufferPtr + dataLocation);
-            indexEntryField = IndexEntryFieldType.Raw;
-            dataLocation += sizeof(IndexEntryFieldType);
-
-            if (binaryValue.Length == 0)
-            {
-                // Signal that we will have to deal with the empties.
-                indexEntryField |= IndexEntryFieldType.Empty;
-            }
-            else
-            {
-                dataLocation += VariableSizeEncoding.Write(_buffer, binaryValue.Length, dataLocation);
-
-                binaryValue.CopyTo(_buffer.Slice(dataLocation));
-                dataLocation += binaryValue.Length;
-            }
-
-            _dataIndex = dataLocation;
+            // Signal that we will have to deal with the empties.
+            indexEntryField |= IndexEntryFieldType.Empty;
         }
+        else
+        {
+            dataLocation += VariableSizeEncoding.Write(buffer, binaryValue.Length, dataLocation);
+
+            binaryValue.CopyTo(buffer.Slice(dataLocation));
+            dataLocation += binaryValue.Length;
+        }
+
+        _dataIndex = dataLocation;
     }
 
 
     public void WriteSpatial(int field, CoraxSpatialPointEntry entry)
     {
         Debug.Assert(field < _knownFields.Count);
-        Debug.Assert(_knownFieldsLocations[field] == Invalid);
+        Debug.Assert(KnownFieldsLocations[field] == Invalid);
 
         if (entry.Geohash.Length == 0)
             return;
@@ -140,30 +163,29 @@ public unsafe ref partial struct IndexEntryWriter
         int dataLocation = _dataIndex;
 
         // Write known field pointer.
-        ref int fieldLocation = ref _knownFieldsLocations[field];
+        ref int fieldLocation = ref KnownFieldsLocations[field];
         fieldLocation = dataLocation | Constants.IndexWriter.IntKnownFieldMask;
 
+        var buffer = Buffer;
+
         // Write the spatial point information. 
-        fixed (byte* bufferPtr = _buffer)
-        {
-            ref var indexEntryField = ref Unsafe.AsRef<IndexEntryFieldType>(bufferPtr + dataLocation);
-            indexEntryField = IndexEntryFieldType.SpatialPoint;
-            dataLocation += sizeof(IndexEntryFieldType);
+        ref var indexEntryField = ref Unsafe.AsRef<IndexEntryFieldType>(Unsafe.AsPointer(ref buffer[dataLocation]));
+        indexEntryField = IndexEntryFieldType.SpatialPoint;
+        dataLocation += sizeof(IndexEntryFieldType);
 
-            Unsafe.WriteUnaligned(ref _buffer[dataLocation], entry.Latitude);
-            dataLocation += sizeof(double);
-            Unsafe.WriteUnaligned(ref _buffer[dataLocation], entry.Longitude);
-            dataLocation += sizeof(double);
+        Unsafe.WriteUnaligned(ref buffer[dataLocation], entry.Latitude);
+        dataLocation += sizeof(double);
+        Unsafe.WriteUnaligned(ref buffer[dataLocation], entry.Longitude);
+        dataLocation += sizeof(double);
 
-            // Copy the actual string data.
-            dataLocation += VariableSizeEncoding.Write(_buffer, (byte)entry.Geohash.Length, dataLocation);
+        // Copy the actual string data.
+        dataLocation += VariableSizeEncoding.Write(buffer, (byte)entry.Geohash.Length, dataLocation);
 
-            int geohashLength = entry.Geohash.Length;
-            Span<byte> encodedGeohash = Encodings.Utf8.GetBytes(entry.Geohash);
-            encodedGeohash.CopyTo(_buffer.Slice(dataLocation, geohashLength));
+        int geohashLength = entry.Geohash.Length;
+        Span<byte> encodedGeohash = Encodings.Utf8.GetBytes(entry.Geohash);
+        encodedGeohash.CopyTo(buffer.Slice(dataLocation, geohashLength));
 
-            _dataIndex = dataLocation + geohashLength;
-        }
+        _dataIndex = dataLocation + geohashLength;
     }
 
     public void WriteSpatial(int field, ReadOnlySpan<CoraxSpatialPointEntry> entries, int geohashLevel = SpatialUtils.DefaultGeohashLevel)
@@ -171,7 +193,7 @@ public unsafe ref partial struct IndexEntryWriter
         //<type:byte><extended_type:byte><amount_of_items:int><geohashLevel:int><geohash_ptr:int>
         //<longitudes_ptr:int><latitudes_list:double[]><longtitudes_list:double[]><geohashes_list:bytes[]>
         Debug.Assert(field < _knownFields.Count);
-        Debug.Assert(_knownFieldsLocations[field] == Invalid);
+        Debug.Assert(KnownFieldsLocations[field] == Invalid);
 
         if (entries.Length == 0)
             return;
@@ -179,153 +201,146 @@ public unsafe ref partial struct IndexEntryWriter
         int dataLocation = _dataIndex;
 
         // Write known field pointer.
-        ref int fieldLocation = ref _knownFieldsLocations[field];
+        ref int fieldLocation = ref KnownFieldsLocations[field];
         fieldLocation = dataLocation | Constants.IndexWriter.IntKnownFieldMask;
 
+        var buffer = Buffer;
+
         // Write the spatial point list. 
-        fixed (byte* bufferPtr = _buffer)
+        ref var indexEntryField = ref Unsafe.AsRef<IndexEntryFieldType>(Unsafe.AsPointer(ref buffer[dataLocation]));
+        indexEntryField = IndexEntryFieldType.SpatialPointList;
+        dataLocation += sizeof(IndexEntryFieldType);
+
+        dataLocation += VariableSizeEncoding.Write(buffer, entries.Length, dataLocation); // Size of list.
+
+        dataLocation += VariableSizeEncoding.Write(buffer, geohashLevel, dataLocation); // geohash lvl
+
+        ref int geohashPtrTableLocation = ref Unsafe.AsRef<int>(Unsafe.AsPointer(ref buffer[dataLocation]));
+        dataLocation += sizeof(int);
+
+        ref int longitudesPtrLocation = ref Unsafe.AsRef<int>(Unsafe.AsPointer(ref buffer[dataLocation]));
+        dataLocation += sizeof(int);
+
+        var latitudesList = MemoryMarshal.Cast<byte, double>(buffer.Slice(dataLocation, entries.Length * sizeof(double)));
+        for (int i = 0; i < entries.Length; ++i)
+            latitudesList[i] = entries[i].Latitude;
+        dataLocation += entries.Length * sizeof(double);
+
+        longitudesPtrLocation = dataLocation;
+        var longitudesList = MemoryMarshal.Cast<byte, double>(buffer.Slice(dataLocation, entries.Length * sizeof(double)));
+        for (int i = 0; i < entries.Length; ++i)
+            longitudesList[i] = entries[i].Longitude;
+        dataLocation += entries.Length * sizeof(double);
+
+        geohashPtrTableLocation = dataLocation;
+        for (int i = 0; i < entries.Length; ++i)
         {
-            ref var indexEntryField = ref Unsafe.AsRef<IndexEntryFieldType>(bufferPtr + dataLocation);
-
-            indexEntryField = IndexEntryFieldType.SpatialPointList;
-            dataLocation += sizeof(IndexEntryFieldType);
-
-            dataLocation += VariableSizeEncoding.Write(_buffer, entries.Length, dataLocation); // Size of list.
-
-            dataLocation += VariableSizeEncoding.Write(_buffer, geohashLevel, dataLocation); // geohash lvl
-
-            ref int geohashPtrTableLocation = ref Unsafe.AsRef<int>( bufferPtr + dataLocation);
-            dataLocation += sizeof(int);
-
-            ref int longitudesPtrLocation = ref Unsafe.AsRef<int>(bufferPtr + dataLocation);
-            dataLocation += sizeof(int);
-
-            var latitudesList = MemoryMarshal.Cast<byte, double>(_buffer.Slice(dataLocation, entries.Length * sizeof(double)));
-            for (int i = 0; i < entries.Length; ++i)
-                latitudesList[i] = entries[i].Latitude;
-            dataLocation += entries.Length * sizeof(double);
-
-            longitudesPtrLocation = dataLocation;
-            var longitudesList = MemoryMarshal.Cast<byte, double>(_buffer.Slice(dataLocation, entries.Length * sizeof(double)));
-            for (int i = 0; i < entries.Length; ++i)
-                longitudesList[i] = entries[i].Longitude;
-            dataLocation += entries.Length * sizeof(double);
-
-            geohashPtrTableLocation = dataLocation;
-            for (int i = 0; i < entries.Length; ++i)
-            {
-                Encodings.Utf8.GetBytes(entries[i].Geohash).CopyTo(_buffer[dataLocation..]);
-                dataLocation += geohashLevel;
-            }
-
-            _dataIndex = dataLocation;
+            Encodings.Utf8.GetBytes(entries[i].Geohash).CopyTo(buffer[dataLocation..]);
+            dataLocation += geohashLevel;
         }
+
+        _dataIndex = dataLocation;
     }
 
     public void Write(int field, ReadOnlySpan<byte> value, long longValue, double doubleValue)
     {
         Debug.Assert(field < _knownFields.Count);
-        Debug.Assert(_knownFieldsLocations[field] == Invalid);
+        Debug.Assert(KnownFieldsLocations[field] == Invalid);
 
         int dataLocation = _dataIndex;
 
         // Write known field pointer.
-        ref int fieldLocation = ref _knownFieldsLocations[field];
+        ref int fieldLocation = ref KnownFieldsLocations[field];
         fieldLocation = dataLocation | Constants.IndexWriter.IntKnownFieldMask;
 
+        var buffer = Buffer;
+
         // Write the tuple information. 
-        fixed (byte* bufferPtr = _buffer)
+        ref var indexEntryField = ref Unsafe.AsRef<IndexEntryFieldType>(Unsafe.AsPointer(ref buffer[dataLocation]));
+        indexEntryField = IndexEntryFieldType.Tuple;
+        dataLocation += sizeof(IndexEntryFieldType);
+
+        dataLocation += VariableSizeEncoding.Write(buffer, longValue, dataLocation);
+        Unsafe.WriteUnaligned(ref buffer[dataLocation], doubleValue);
+        dataLocation += sizeof(double);
+        dataLocation += VariableSizeEncoding.Write(buffer, value.Length, dataLocation);
+
+        // Copy the actual string data. 
+        if (value.Length != 0)
         {
-            ref var indexEntryField = ref Unsafe.AsRef<IndexEntryFieldType>(bufferPtr + dataLocation);
-
-            indexEntryField = IndexEntryFieldType.Tuple;
-            dataLocation += sizeof(IndexEntryFieldType);
-
-            dataLocation += VariableSizeEncoding.Write(_buffer, longValue, dataLocation);
-            Unsafe.WriteUnaligned(ref _buffer[dataLocation], doubleValue);
-            dataLocation += sizeof(double);
-            dataLocation += VariableSizeEncoding.Write(_buffer, value.Length, dataLocation);
-
-            // Copy the actual string data. 
-            if (value.Length != 0)
-            {
-                value.CopyTo(_buffer.Slice(dataLocation, value.Length));
-                dataLocation += value.Length;
-            }
-            else
-            {
-                // Signal that we will have to deal with the empties.
-                indexEntryField |= IndexEntryFieldType.Empty;
-            }
-
-            _dataIndex = dataLocation;
+            value.CopyTo(buffer.Slice(dataLocation, value.Length));
+            dataLocation += value.Length;
         }
+        else
+        {
+            // Signal that we will have to deal with the empties.
+            indexEntryField |= IndexEntryFieldType.Empty;
+        }
+
+        _dataIndex = dataLocation;
     }
 
-    public void Write<TEnumerator>(int field, TEnumerator values, IndexEntryFieldType type = IndexEntryFieldType.Null)
+    public void Write<TEnumerator>(int field, TEnumerator values, IndexEntryFieldType type = IndexEntryFieldType.Null) 
         where TEnumerator : IReadOnlySpanIndexer
     {
         Debug.Assert(field < _knownFields.Count);
-        Debug.Assert(_knownFieldsLocations[field] == Invalid);
+        Debug.Assert(KnownFieldsLocations[field] == Invalid);
 
         int dataLocation = _dataIndex;
 
         // Write known field pointer.
-        ref int fieldLocation = ref _knownFieldsLocations[field];
+        ref int fieldLocation = ref KnownFieldsLocations[field];
         fieldLocation = dataLocation | Constants.IndexWriter.IntKnownFieldMask;
 
+        var buffer = Buffer;
+
         // Write the list metadata information. 
-        fixed (byte* bufferPtr = _buffer)
+        ref var indexEntryField = ref Unsafe.AsRef<IndexEntryFieldType>(Unsafe.AsPointer(ref buffer[dataLocation]));
+        indexEntryField = IndexEntryFieldType.List | type;
+        dataLocation += sizeof(IndexEntryFieldType);
+
+        // Size of list.
+        dataLocation += VariableSizeEncoding.Write(buffer, values.Length, dataLocation);
+
+        // Prepare the location to store the pointer where the table of the strings will be (after writing the strings).
+        ref int stringPtrTableLocation = ref Unsafe.AsRef<int>(Unsafe.AsPointer(ref buffer[dataLocation]));
+        dataLocation += sizeof(int);
+
+        // Copy the actual string data. 
+        if (values.Length == 0)
         {
-            ref var indexEntryField = ref Unsafe.AsRef<IndexEntryFieldType>(bufferPtr + dataLocation);
+            // Write the pointer to the location.
+            stringPtrTableLocation = Invalid;
 
-            indexEntryField = IndexEntryFieldType.List | type;
-            dataLocation += sizeof(IndexEntryFieldType);
-
-            // Size of list.
-            dataLocation += VariableSizeEncoding.Write(_buffer, values.Length, dataLocation);
-
-            // Prepare the location to store the pointer where the table of the strings will be (after writing the strings).
-            ref int stringPtrTableLocation = ref Unsafe.AsRef<int>(bufferPtr + dataLocation);
-            dataLocation += sizeof(int);
-
-            // Copy the actual string data. 
-            if (values.Length == 0)
-            {
-                // Write the pointer to the location.
-                stringPtrTableLocation = Invalid;
-
-                // Signal that we will have to deal with the empties.
-                indexEntryField |= IndexEntryFieldType.Empty;
-                goto Done;
-            }
-
-            int[] stringLengths = ArrayPool<int>.Shared.Rent(values.Length);
-
-            // We start to write the strings in a place we know where it is from implicit positioning...
-            // 4b 
-            for (int i = 0; i < values.Length; i++)
-            {
-                var value = values[i];
-                value.CopyTo(_buffer[dataLocation..]);
-                dataLocation += value.Length;
-                stringLengths[i] = value.Length;
-            }
-
-            // Write the pointer to the location
-            stringPtrTableLocation = dataLocation;
-            dataLocation = WriteNullsTableIfRequired(values, dataLocation, ref indexEntryField);
-            dataLocation += VariableSizeEncoding.WriteMany<int>(_buffer, stringLengths[0..values.Length], dataLocation);
-
-            ArrayPool<int>.Shared.Return(stringLengths);
-
-            Done:
-            _dataIndex = dataLocation;
+            // Signal that we will have to deal with the empties.
+            indexEntryField |= IndexEntryFieldType.Empty;
+            goto Done;
         }
+
+        int[] stringLengths = ArrayPool<int>.Shared.Rent(values.Length);
+
+        // We start to write the strings in a place we know where it is from implicit positioning...
+        // 4b 
+        for (int i = 0; i < values.Length; i++)
+        {
+            var value = values[i];
+            value.CopyTo(buffer[dataLocation..]);
+            dataLocation += value.Length;
+            stringLengths[i] = value.Length;
+        }
+
+        // Write the pointer to the location
+        stringPtrTableLocation = dataLocation;
+        dataLocation = WriteNullsTableIfRequired(values, dataLocation, ref indexEntryField);
+        dataLocation += VariableSizeEncoding.WriteMany<int>(buffer, stringLengths[0..values.Length], dataLocation);
+
+        ArrayPool<int>.Shared.Return(stringLengths);
+
+        Done:
+        _dataIndex = dataLocation;
     }
 
-
-    private readonly int WriteNullsTableIfRequired<TEnumerator>(TEnumerator values, int dataLocation, ref IndexEntryFieldType indexEntryFieldLocation)
+    private int WriteNullsTableIfRequired<TEnumerator>(TEnumerator values, int dataLocation, ref IndexEntryFieldType indexEntryFieldLocation)
         where TEnumerator : IReadOnlySpanIndexer
     {
         // We will include null values if there are nulls to be stored.           
@@ -345,7 +360,7 @@ public unsafe ref partial struct IndexEntryWriter
         {
             // Copy the null stream.
             new ReadOnlySpan<byte>(nullStream, nullBitStreamSize)
-                .CopyTo(_buffer.Slice(dataLocation, nullBitStreamSize));
+                .CopyTo(Buffer.Slice(dataLocation, nullBitStreamSize));
 
             dataLocation += nullBitStreamSize;
 
@@ -359,86 +374,86 @@ public unsafe ref partial struct IndexEntryWriter
     public unsafe void Write(int field, IReadOnlySpanIndexer values, ReadOnlySpan<long> longValues, ReadOnlySpan<double> doubleValues)
     {
         Debug.Assert(field < _knownFields.Count);
-        Debug.Assert(_knownFieldsLocations[field] == Invalid);
-
+        Debug.Assert(KnownFieldsLocations[field] == Invalid);        
+        
         if (values.Length != longValues.Length || values.Length != doubleValues.Length)
             throw new ArgumentException("The lengths of the values and longValues and doubleValues must be the same.");
 
         int dataLocation = _dataIndex;
 
         // Write known field pointer.
-        ref int fieldLocation = ref _knownFieldsLocations[field];
+        ref int fieldLocation = ref KnownFieldsLocations[field];
         fieldLocation = dataLocation | Constants.IndexWriter.IntKnownFieldMask;
 
+        var buffer = Buffer;
+
         // Write the list metadata information. 
-        fixed (byte* bufferPtr = _buffer)
+        ref var indexEntryField = ref Unsafe.AsRef<IndexEntryFieldType>(Unsafe.AsPointer(ref buffer[dataLocation]));
+        indexEntryField = IndexEntryFieldType.TupleList;
+        dataLocation += sizeof(IndexEntryFieldType);       
+
+        dataLocation += VariableSizeEncoding.Write(buffer, values.Length, dataLocation); // Size of list.
+
+        // Prepare the location to store the pointer where the table of the strings will be (after writing the strings).
+        ref int stringPtrTableLocation = ref Unsafe.AsRef<int>(Unsafe.AsPointer(ref buffer[dataLocation]));
+        dataLocation += sizeof(int);
+
+        // Prepare the location to store the pointer where the long values are going to be stored.
+        ref int longPtrLocation = ref Unsafe.AsRef<int>(Unsafe.AsPointer(ref buffer[dataLocation]));
+        dataLocation += sizeof(int);
+        
+        if (values.Length == 0)
         {
-            ref var indexEntryField = ref Unsafe.AsRef<IndexEntryFieldType>(bufferPtr + dataLocation);
-
-            indexEntryField = IndexEntryFieldType.TupleList;
-            dataLocation += sizeof(IndexEntryFieldType);
-
-            dataLocation += VariableSizeEncoding.Write(_buffer, values.Length, dataLocation); // Size of list.
-
-            // Prepare the location to store the pointer where the table of the strings will be (after writing the strings).
-            ref int stringPtrTableLocation = ref Unsafe.AsRef<int>(bufferPtr + dataLocation);
-            dataLocation += sizeof(int);
-
-            // Prepare the location to store the pointer where the long values are going to be stored.
-            ref int longPtrLocation = ref Unsafe.AsRef<int>(bufferPtr + dataLocation);
-            dataLocation += sizeof(int);
-
-            if (values.Length == 0)
-            {
-                // Write the pointer to the location.
-                stringPtrTableLocation = Invalid;
-                longPtrLocation = Invalid;
-
-                // Signal that we will have to deal with the empties.
-                indexEntryField |= IndexEntryFieldType.Empty;
-
-                goto Done;
-            }
-
-            var doubleValuesList = MemoryMarshal.Cast<byte, double>(_buffer.Slice(dataLocation, values.Length * sizeof(double)));
-            doubleValues.CopyTo(doubleValuesList);
-            dataLocation += doubleValuesList.Length * sizeof(double);
-
-            // We start to write the strings in a place we know where it is from implicit positioning...
-            // 4b + 4b + len(values) * 8b
-            int[] stringLengths = ArrayPool<int>.Shared.Rent(values.Length);
-            for (int i = 0; i < values.Length; i++)
-            {
-                var value = values[i];
-                value.CopyTo(_buffer.Slice(dataLocation, value.Length));
-                dataLocation += value.Length;
-
-                stringLengths[i] = value.Length;
-            }
-
             // Write the pointer to the location.
-            stringPtrTableLocation = dataLocation;
-            dataLocation = WriteNullsTableIfRequired(values, dataLocation, ref indexEntryField);
-            dataLocation += VariableSizeEncoding.WriteMany<int>(_buffer, stringLengths[..values.Length], dataLocation);
+            stringPtrTableLocation = Invalid;
+            longPtrLocation = Invalid;
 
-            // Write the long values
-            longPtrLocation = dataLocation;
-            dataLocation += VariableSizeEncoding.WriteMany(_buffer, longValues, pos: dataLocation);
+            // Signal that we will have to deal with the empties.
+            indexEntryField |= IndexEntryFieldType.Empty;
 
-            ArrayPool<int>.Shared.Return(stringLengths);
-
-            Done:
-            _dataIndex = dataLocation;
+            goto Done;
         }
+
+        var doubleValuesList = MemoryMarshal.Cast<byte, double>(buffer.Slice(dataLocation, values.Length * sizeof(double)));
+        doubleValues.CopyTo(doubleValuesList);
+        dataLocation += doubleValuesList.Length * sizeof(double);
+
+        // We start to write the strings in a place we know where it is from implicit positioning...
+        // 4b + 4b + len(values) * 8b
+        int[] stringLengths = ArrayPool<int>.Shared.Rent(values.Length);
+        for (int i = 0; i < values.Length; i++)
+        {
+            var value = values[i];
+            value.CopyTo(buffer.Slice(dataLocation, value.Length));
+            dataLocation += value.Length;
+
+            stringLengths[i] = value.Length;
+        }
+
+        // Write the pointer to the location.
+        stringPtrTableLocation = dataLocation;
+        dataLocation = WriteNullsTableIfRequired(values, dataLocation, ref indexEntryField);
+        dataLocation += VariableSizeEncoding.WriteMany<int>(buffer, stringLengths[..values.Length], dataLocation);
+
+        // Write the long values
+        longPtrLocation = dataLocation;
+        dataLocation += VariableSizeEncoding.WriteMany(buffer, longValues, pos: dataLocation);
+
+        ArrayPool<int>.Shared.Return(stringLengths);
+        
+        Done:
+        _dataIndex = dataLocation;
     }
 
-    public int Finish(out Span<byte> output)
+    public ByteStringContext<ByteStringMemoryCache>.InternalScope Finish(out ByteString output)
     {
+        var knownFieldsLocations = KnownFieldsLocations;
+
         // We need to know how big the metadata table is going to be.
         int maxOffset = 0;
-        for (int i = 0; i < _knownFieldsLocations.Length; i++)
+        for (int i = 0; i < knownFieldsLocations.Length; i++)
         {
-            int offset = _knownFieldsLocations[i];
+            int offset = knownFieldsLocations[i];
             if (offset != Invalid)
                 maxOffset = Math.Max(offset & LocationMask, maxOffset);
         }
@@ -450,13 +465,15 @@ public unsafe ref partial struct IndexEntryWriter
         else if (maxOffset > sbyte.MaxValue - 1)
             encodeSize = IndexEntryTableEncoding.TwoBytes;
 
+        var buffer = Buffer;
+
         // The size of the known fields metadata section
         int metadataSection = (int)encodeSize * _knownFields.Count;
         // The size of the unknown/dynamic fields metadata section            
         int dynamicMetadataSection = _dynamicFieldIndex * sizeof(uint);
-        int dynamicMetadataSectionOffset = _buffer.Length - dynamicMetadataSection - 1;
+        int dynamicMetadataSectionOffset = buffer.Length - dynamicMetadataSection - 1;
 
-        ref var header = ref MemoryMarshal.AsRef<IndexEntryHeader>(_buffer);
+        ref var header = ref MemoryMarshal.AsRef<IndexEntryHeader>(buffer);
         header.Length = (uint)(_dataIndex + dynamicMetadataSection + metadataSection + 1);
 
         // The known field count is encoded as xxxxxxyy where:
@@ -466,14 +483,14 @@ public unsafe ref partial struct IndexEntryWriter
         header.DynamicTable = (uint)_dataIndex;
 
         // The dynamic metadata fields count. 
-        Unsafe.WriteUnaligned(ref _buffer[_dataIndex], (byte)_dynamicFieldIndex);
+        Unsafe.WriteUnaligned(ref buffer[_dataIndex], (byte)_dynamicFieldIndex);
         _dataIndex += sizeof(byte);
 
         if (dynamicMetadataSection != 0)
         {
             // From the offset to the end... move the data toward the closest position
-            var metadataTable = _buffer[dynamicMetadataSectionOffset..];
-            metadataTable.CopyTo(_buffer[_dataIndex..]);
+            var metadataTable = buffer[dynamicMetadataSectionOffset..];
+            metadataTable.CopyTo(buffer[_dataIndex..]);
 
             // Move the pointer to the end of the copied section.
             _dataIndex += dynamicMetadataSection;
@@ -482,20 +499,22 @@ public unsafe ref partial struct IndexEntryWriter
         switch (encodeSize)
         {
             case IndexEntryTableEncoding.OneByte:
-                _dataIndex += WriteMetadataTable<byte>(_buffer, _dataIndex, _knownFieldsLocations);
+                _dataIndex += WriteMetadataTable<byte>(buffer, _dataIndex, knownFieldsLocations);
                 break;
             case IndexEntryTableEncoding.TwoBytes:
-                _dataIndex += WriteMetadataTable<ushort>(_buffer, _dataIndex, _knownFieldsLocations);
+                _dataIndex += WriteMetadataTable<ushort>(buffer, _dataIndex, knownFieldsLocations);
                 break;
             case IndexEntryTableEncoding.FourBytes:
-                _dataIndex += WriteMetadataTable<uint>(_buffer, _dataIndex, _knownFieldsLocations);
+                _dataIndex += WriteMetadataTable<uint>(buffer, _dataIndex, knownFieldsLocations);
                 break;
             default:
                 throw new ArgumentException($"'{encodeSize}' is not a valid {nameof(IndexEntryTableEncoding)}.");
         }
 
-        output = _buffer.Slice(0, _dataIndex);
-        return _dataIndex;
+        // Create the actual output memory buffer that we are going to be using. 
+        var scope = _context.Allocate(_dataIndex, out output);
+        buffer.Slice(0, _dataIndex).CopyTo(output.ToSpan());
+        return scope;
     }
 
     private static int WriteMetadataTable<T>(Span<byte> buffer, int dataIndex, Span<int> locations) where T : unmanaged
@@ -531,5 +550,10 @@ public unsafe ref partial struct IndexEntryWriter
         }
 
         return count * offset;
+    }
+
+    public void Dispose()
+    {
+        _bufferScope.Dispose();
     }
 }

--- a/src/Corax/IndexEntry/IndexEntryWriter.cs
+++ b/src/Corax/IndexEntry/IndexEntryWriter.cs
@@ -584,7 +584,7 @@ public unsafe partial struct IndexEntryWriter : IDisposable
 
             if (isTyped)
             {
-                location |= Unsafe.SizeOf<T>() switch
+                location |= offset switch
                 {
                     sizeof(int) => Constants.IndexWriter.IntKnownFieldMask,
                     sizeof(short) => Constants.IndexWriter.ShortKnownFieldMask,

--- a/src/Corax/IndexWriter.cs
+++ b/src/Corax/IndexWriter.cs
@@ -708,6 +708,9 @@ namespace Corax
 
             for (int fieldId = 0; fieldId < _fieldsMapping.Count; ++fieldId)
             {
+                if (_buffer[fieldId].Count == 0)
+                    continue; 
+
                 InsertTextualField(fieldsTree, fieldId, workingBuffer);
                 InsertNumericFieldLongs(fieldsTree, fieldId, workingBuffer);
                 InsertNumericFieldDoubles(fieldsTree, fieldId, workingBuffer);

--- a/src/Raven.Server/Documents/Indexes/Persistence/Corax/AnonymousCoraxDocumentConverter.cs
+++ b/src/Raven.Server/Documents/Indexes/Persistence/Corax/AnonymousCoraxDocumentConverter.cs
@@ -46,7 +46,6 @@ public class AnonymousCoraxDocumentConverter : CoraxDocumentConverterBase
 
         // We prepare for the next entry.
         ref var entryWriter = ref GetEntriesWriter();
-        entryWriter.Reset();
 
         foreach (var property in accessor.GetPropertiesInOrder(documentToProcess))
         {

--- a/src/Raven.Server/Documents/Indexes/Persistence/Corax/AnonymousCoraxDocumentConverter.cs
+++ b/src/Raven.Server/Documents/Indexes/Persistence/Corax/AnonymousCoraxDocumentConverter.cs
@@ -9,6 +9,7 @@ using Sparrow.Json;
 using Sparrow.Json.Parsing;
 using Raven.Server.Utils;
 using Constants = Raven.Client.Constants;
+using Sparrow.Server;
 
 namespace Raven.Server.Documents.Indexes.Persistence.Corax;
 
@@ -23,8 +24,10 @@ public class AnonymousCoraxDocumentConverter : CoraxDocumentConverterBase
         _isMultiMap = index.IsMultiMap;
     }
 
-    public override Span<byte> SetDocumentFields(LazyStringValue key, LazyStringValue sourceDocumentId, object doc, JsonOperationContext indexContext,
-        out LazyStringValue id, Span<byte> writerBuffer)
+    public override ByteStringContext<ByteStringMemoryCache>.InternalScope SetDocumentFields(
+        LazyStringValue key, LazyStringValue sourceDocumentId,
+        object doc, JsonOperationContext indexContext, out LazyStringValue id,
+        out ByteString output)
     {
         var knownFields = GetKnownFieldsForWriter();
         var boostedValue = doc as BoostedValue;
@@ -41,7 +44,7 @@ public class AnonymousCoraxDocumentConverter : CoraxDocumentConverterBase
         // todo maciej
         // We need to discuss how we will handle this.  
         // https://github.com/ravendb/ravendb/pull/13730#discussion_r820661488
-        var entryWriter = new IndexEntryWriter(writerBuffer, knownFields);
+        var entryWriter = new IndexEntryWriter(_allocator, knownFields);
 
         var scope = new SingleEntryWriterScope(_allocator);
         var storedValue = _storeValue ? new DynamicJsonValue() : null;
@@ -74,12 +77,13 @@ public class AnonymousCoraxDocumentConverter : CoraxDocumentConverterBase
         }
 
         if (entryWriter.IsEmpty() == true)
-            return Span<byte>.Empty;
+        {
+            output = default;
+            return default;
+        }            
         
         id = key ?? (sourceDocumentId ?? throw new InvalidParameterException("Cannot find any identifier of the document."));
         scope.Write(0, id.AsSpan(), ref entryWriter);
-        entryWriter.Finish(out var output);
-
-        return output;
+        return entryWriter.Finish(out output);
     }
 }

--- a/src/Raven.Server/Documents/Indexes/Persistence/Corax/CoraxDocumentConverter.cs
+++ b/src/Raven.Server/Documents/Indexes/Persistence/Corax/CoraxDocumentConverter.cs
@@ -30,11 +30,14 @@ public class CoraxDocumentConverter : CoraxDocumentConverterBase
         out ByteString output)
     {
         var document = (Document)doc;
-        var entryWriter = new IndexEntryWriter(_allocator, GetKnownFieldsForWriter());
         id = document.LowerId ?? key;
 
         var scope = new SingleEntryWriterScope(_allocator);
-        
+
+        // We prepare for the next entry.
+        ref var entryWriter = ref GetEntriesWriter();
+        entryWriter.Reset();
+
         object value;
         foreach (var indexField in _fields.Values)
         {

--- a/src/Raven.Server/Documents/Indexes/Persistence/Corax/CoraxDocumentConverter.cs
+++ b/src/Raven.Server/Documents/Indexes/Persistence/Corax/CoraxDocumentConverter.cs
@@ -6,6 +6,7 @@ using Raven.Server.Documents.Indexes.Persistence.Corax.WriterScopes;
 using Raven.Server.Documents.Indexes.Static;
 using Raven.Server.Json;
 using Sparrow.Json;
+using Sparrow.Server;
 using Constants = Raven.Client.Constants;
 
 namespace Raven.Server.Documents.Indexes.Persistence.Corax;
@@ -23,11 +24,13 @@ public class CoraxDocumentConverter : CoraxDocumentConverterBase
     {
     }
 
-    public override Span<byte> SetDocumentFields(LazyStringValue key, LazyStringValue sourceDocumentId, object doc, JsonOperationContext indexContext,
-        out LazyStringValue id, Span<byte> writerBuffer)
+    public override ByteStringContext<ByteStringMemoryCache>.InternalScope SetDocumentFields(
+        LazyStringValue key, LazyStringValue sourceDocumentId,
+        object doc, JsonOperationContext indexContext, out LazyStringValue id,
+        out ByteString output)
     {
         var document = (Document)doc;
-        var entryWriter = new IndexEntryWriter(writerBuffer, GetKnownFieldsForWriter());
+        var entryWriter = new IndexEntryWriter(_allocator, GetKnownFieldsForWriter());
         id = document.LowerId ?? key;
 
         var scope = new SingleEntryWriterScope(_allocator);
@@ -68,7 +71,6 @@ public class CoraxDocumentConverter : CoraxDocumentConverterBase
             }
         }
 
-
         if (key != null)
         {
             Debug.Assert(document.LowerId == null || (key == document.LowerId));
@@ -89,7 +91,6 @@ public class CoraxDocumentConverter : CoraxDocumentConverterBase
             }
         }
 
-        entryWriter.Finish(out var output);
-        return output;
+        return entryWriter.Finish(out output);
     }
 }

--- a/src/Raven.Server/Documents/Indexes/Persistence/Corax/CoraxDocumentConverter.cs
+++ b/src/Raven.Server/Documents/Indexes/Persistence/Corax/CoraxDocumentConverter.cs
@@ -36,7 +36,6 @@ public class CoraxDocumentConverter : CoraxDocumentConverterBase
 
         // We prepare for the next entry.
         ref var entryWriter = ref GetEntriesWriter();
-        entryWriter.Reset();
 
         object value;
         foreach (var indexField in _fields.Values)

--- a/src/Raven.Server/Documents/Indexes/Persistence/Corax/CoraxDocumentConverterBase.cs
+++ b/src/Raven.Server/Documents/Indexes/Persistence/Corax/CoraxDocumentConverterBase.cs
@@ -60,8 +60,10 @@ public abstract class CoraxDocumentConverterBase : ConverterBase
     public List<CoraxSpatialPointEntry> CoraxSpatialPointEntryListForEnumerableScope;
     
     
-    public abstract Span<byte> SetDocumentFields(LazyStringValue key, LazyStringValue sourceDocumentId, object doc, JsonOperationContext indexContext,
-        out LazyStringValue id, Span<byte> writerBuffer);
+    public abstract ByteStringContext<ByteStringMemoryCache>.InternalScope SetDocumentFields(
+        LazyStringValue key, LazyStringValue sourceDocumentId,
+        object doc, JsonOperationContext indexContext, out LazyStringValue id,
+        out ByteString output);
 
     protected CoraxDocumentConverterBase(Index index, bool storeValue, bool indexImplicitNull, bool indexEmptyEntries, int numberOfBaseFields, string keyFieldName,
         string storeValueFieldName, ICollection<IndexField> fields = null) : base(index, storeValue, indexImplicitNull, indexEmptyEntries, numberOfBaseFields,

--- a/src/Raven.Server/Documents/Indexes/Persistence/Corax/CoraxDocumentConverterBase.cs
+++ b/src/Raven.Server/Documents/Indexes/Persistence/Corax/CoraxDocumentConverterBase.cs
@@ -134,7 +134,7 @@ public abstract class CoraxDocumentConverterBase : ConverterBase
 
     protected ref IndexEntryWriter GetEntriesWriter()
     {
-        if (!_indexEntryWriterInitialized)
+        if (_indexEntryWriterInitialized == false)
         {
             _indexEntryWriter = new IndexEntryWriter(_allocator, GetKnownFieldsForWriter());
             _indexEntryWriterInitialized = true;

--- a/src/Raven.Server/Documents/Indexes/Persistence/Corax/JintCoraxDocumentConverter.cs
+++ b/src/Raven.Server/Documents/Indexes/Persistence/Corax/JintCoraxDocumentConverter.cs
@@ -57,7 +57,6 @@ public class JintCoraxDocumentConverter : JintCoraxDocumentConverterBase
 
         // We prepare for the next entry.
         ref var entryWriter = ref GetEntriesWriter();
-        entryWriter.Reset();
 
         scope.Write(0, id.AsSpan(), ref entryWriter);
         int idX = 1;

--- a/src/Raven.Server/Documents/Indexes/Persistence/Corax/JintCoraxDocumentConverter.cs
+++ b/src/Raven.Server/Documents/Indexes/Persistence/Corax/JintCoraxDocumentConverter.cs
@@ -47,16 +47,17 @@ public class JintCoraxDocumentConverter : JintCoraxDocumentConverterBase
             return default;
         }
 
-        var entryWriter = new CoraxLib.IndexEntryWriter(_allocator, GetKnownFieldsForWriter());
-
         id = key ?? (sourceDocumentId ?? throw new InvalidDataException("Cannot find any identifier of the document."));
         var scope = new SingleEntryWriterScope(_allocator);
-
 
         if (TryGetBoostedValue(documentToProcess, out var boostedValue, out var documentBoost))
         {
             throw new NotSupportedException("Document boosting is not available in Corax.");
         }
+
+        // We prepare for the next entry.
+        ref var entryWriter = ref GetEntriesWriter();
+        entryWriter.Reset();
 
         scope.Write(0, id.AsSpan(), ref entryWriter);
         int idX = 1;

--- a/src/Sparrow.Server/Collections/Persistent/BinaryTree.cs
+++ b/src/Sparrow.Server/Collections/Persistent/BinaryTree.cs
@@ -137,6 +137,53 @@ namespace Sparrow.Server.Collections.Persistent
             //Console.WriteLine($",{u.Value}");
         }
 
+        public void Add<KeyReader>(ref KeyReader key, T value)
+            where KeyReader : IBitReader
+        {
+            Span<Node> nodes = Nodes;
+
+            ref Node u = ref nodes[0];
+
+            while (key.Length != 0)
+            {
+                Bit b = key.Read();
+                if (b.IsSet)
+                {
+                    if (u.RightChild == Invalid)
+                    {
+                        ref Node newNode = ref nodes[FreeNodes];
+                        newNode._leftChild = Invalid;
+                        newNode._rightChild = Invalid;
+
+                        u.RightChild = FreeNodes;
+                        FreeNodes++;
+                    }
+                    //Console.Write("R");
+                    u = ref nodes[u.RightChild];
+                }
+                else
+                {
+                    if (u.LeftChild == Invalid)
+                    {
+                        ref Node newNode = ref nodes[FreeNodes];
+                        newNode._leftChild = Invalid;
+                        newNode._rightChild = Invalid;
+
+                        u.LeftChild = FreeNodes;
+                        FreeNodes++;
+                    }
+
+                    //Console.Write("L");
+                    u = ref nodes[u.LeftChild];
+                }
+            }
+
+            u.Value = value;
+            u.HasValue = true;
+
+            //Console.WriteLine($",{u.Value}");
+        }
+
         public bool Find(ref BitReader key, out T value)
         {
             Span<Node> nodes = Nodes;

--- a/src/Sparrow.Server/Compression/Encoder3Gram.cs
+++ b/src/Sparrow.Server/Compression/Encoder3Gram.cs
@@ -408,12 +408,12 @@ namespace Sparrow.Server.Compression
 
                 entry.Code = symbolCodeList[i].Code;
 
-                int codeValue = BinaryPrimitives.ReverseEndianness(entry.Code.Value << (sizeof(int) * 8 - entry.Code.Length));
-                var codeValueSpan = MemoryMarshal.Cast<int, byte>(MemoryMarshal.CreateSpan(ref codeValue, 1));
-                var reader = new BitReader(codeValueSpan, entry.Code.Length);
+                uint codeValue = (uint)entry.Code.Value << (sizeof(int) * 8 - entry.Code.Length);
+                
                 maxBitSequenceLength = Math.Max(maxBitSequenceLength, entry.Code.Length);
                 minBitSequenceLength = Math.Min(minBitSequenceLength, entry.Code.Length);
 
+                var reader = new TypedBitReader<uint>(codeValue, entry.Code.Length);
                 tree.Add(ref reader, (short)i);
             }
 

--- a/src/Sparrow/Binary/PtrBitVector.cs
+++ b/src/Sparrow/Binary/PtrBitVector.cs
@@ -42,7 +42,15 @@ namespace Sparrow.Binary
         {
             uint word = ByteForBit(idx);
             byte mask = BitInByte(idx);
-            return (*((byte*)ptr + word) & mask) != 0 ;
+            return (*((byte*)ptr + word) & mask) != 0;
+        }
+
+        [MethodImpl(MethodImplOptions.AggressiveInlining)]
+        public static bool GetBitInSpan(Span<byte> ptr, int idx)
+        {
+            uint word = ByteForBit(idx);
+            byte mask = BitInByte(idx);
+            return (ptr[(int)word]& mask) != 0;
         }
 
         [MethodImpl(MethodImplOptions.AggressiveInlining)]
@@ -52,6 +60,17 @@ namespace Sparrow.Binary
             byte mask = BitInByte(idx);
 
             byte* bytePtr = (byte*)ptr;
+            bool currentValue = (bytePtr[word] & mask) != 0;
+            if (currentValue != value)
+                bytePtr[word] ^= mask;
+        }
+
+        [MethodImpl(MethodImplOptions.AggressiveInlining)]
+        public static void SetBitInSpan(Span<byte> bytePtr, int idx, bool value)
+        {
+            int word = (int)ByteForBit(idx);
+            byte mask = BitInByte(idx);
+
             bool currentValue = (bytePtr[word] & mask) != 0;
             if (currentValue != value)
                 bytePtr[word] ^= mask;

--- a/src/Voron/Data/CompactTrees/CompactTree.cs
+++ b/src/Voron/Data/CompactTrees/CompactTree.cs
@@ -27,7 +27,7 @@ namespace Voron.Data.CompactTrees
 
         // TODO: Improve interactions with caller code. It is good enough for now but we can encapsulate behavior better to improve readability. 
         private IteratorCursorState _internalCursor = new() { _stk = new CursorState[8], _pos = -1, _len = 0 };
-
+        
         // TODO: We will never rewrite a dictionary, only create new ones. Therefore, we can effectively cache them until removing them. 
         private readonly Dictionary<long, PersistentDictionary> _dictionaries = new(); 
         
@@ -1176,7 +1176,7 @@ namespace Voron.Data.CompactTrees
             return encodedKey;
         }
 
-        private EncodedKey SearchPageAndPushNext(in EncodedKey key, ref IteratorCursorState cstate)
+        private EncodedKey SearchPageAndPushNext(EncodedKey key, ref IteratorCursorState cstate)
         {
             SearchInCurrentPage(key, ref cstate._stk[cstate._pos]);
 
@@ -1432,7 +1432,7 @@ namespace Voron.Data.CompactTrees
             state.LastSearchPosition = ~mid;
         }
 
-        private EncodedKey FuzzySearchPageAndPushNext(in EncodedKey key, ref IteratorCursorState cstate)
+        private EncodedKey FuzzySearchPageAndPushNext(EncodedKey key, ref IteratorCursorState cstate)
         {
             FuzzySearchInCurrentPage(key, ref cstate._stk[cstate._pos]);
 

--- a/test/FastTests/Corax/BoostingQuery.cs
+++ b/test/FastTests/Corax/BoostingQuery.cs
@@ -399,7 +399,6 @@ namespace FastTests.Corax
             {
                 using var __ = CreateIndexEntry(ref entryWriter, entry, out var data);
                 indexWriter.Index(entry.Id, data.ToSpan());
-                entryWriter.Reset();
             }
             indexWriter.Commit();
         }

--- a/test/FastTests/Corax/BoostingQuery.cs
+++ b/test/FastTests/Corax/BoostingQuery.cs
@@ -392,28 +392,25 @@ namespace FastTests.Corax
             using var bsc = new ByteStringContext(SharedMultipleUseFlag.None);
             var knownFields = CreateKnownFields(bsc);
 
-            const int bufferSize = 4096;
-            using var _ = bsc.Allocate(bufferSize, out ByteString buffer);
+            using var indexWriter = new IndexWriter(Env, knownFields);
+            var entryWriter = new IndexEntryWriter(bsc, knownFields);
 
+            foreach (var entry in longList)
             {
-                using var indexWriter = new IndexWriter(Env, knownFields);
-                foreach (var entry in longList)
-                {
-                    var entryWriter = new IndexEntryWriter(buffer.ToSpan(), knownFields);
-                    var data = CreateIndexEntry(ref entryWriter, entry);
-                    indexWriter.Index(entry.Id, data);
-                }
-                indexWriter.Commit();
+                using var __ = CreateIndexEntry(ref entryWriter, entry, out var data);
+                indexWriter.Index(entry.Id, data.ToSpan());
+                entryWriter.Reset();
             }
+            indexWriter.Commit();
         }
 
-        private Span<byte> CreateIndexEntry(ref IndexEntryWriter entryWriter, IndexSingleNumericalEntry<long, long> entry)
+        private ByteStringContext<ByteStringMemoryCache>.InternalScope CreateIndexEntry(
+            ref IndexEntryWriter entryWriter, IndexSingleNumericalEntry<long, long> entry, out ByteString output)
         {
             entryWriter.Write(IndexId, Encoding.UTF8.GetBytes(entry.Id));
             entryWriter.Write(Content1, Encoding.UTF8.GetBytes(entry.Content1.ToString()), entry.Content1, Convert.ToDouble(entry.Content1));
             entryWriter.Write(Content2, Encoding.UTF8.GetBytes(entry.Content2.ToString()), entry.Content2, Convert.ToDouble(entry.Content2));
-            entryWriter.Finish(out var output);
-            return output;
+            return entryWriter.Finish(out output);
         }
 
         private IndexFieldsMapping CreateKnownFields(ByteStringContext bsc)

--- a/test/FastTests/Corax/CoraxQueries.cs
+++ b/test/FastTests/Corax/CoraxQueries.cs
@@ -228,7 +228,6 @@ namespace FastTests.Corax
             {
                 using var __ = CreateIndexEntry(ref entryWriter, entry, out var data);
                 indexWriter.Index(entry.Id, data.ToSpan());
-                entryWriter.Reset();
             }
 
             indexWriter.Commit();

--- a/test/FastTests/Corax/DeleteTest.cs
+++ b/test/FastTests/Corax/DeleteTest.cs
@@ -336,7 +336,6 @@ namespace FastTests.Corax
             {
                 using var __ = CreateIndexEntry(ref entryWriter, entry, out var data);
                 indexWriter.Index(entry.Id, data.ToSpan());
-                entryWriter.Reset();
             }
 
             indexWriter.Commit();

--- a/test/FastTests/Corax/IndexSearcher.cs
+++ b/test/FastTests/Corax/IndexSearcher.cs
@@ -109,7 +109,6 @@ namespace FastTests.Corax
             {
                 using var __ = CreateIndexEntry(ref entryWriter, entry, out var data);
                 entry.IndexEntryId = indexWriter.Index(entry.Id, data.ToSpan());
-                entryWriter.Reset();
             }
 
             indexWriter.Commit();
@@ -822,7 +821,6 @@ namespace FastTests.Corax
             {
                 using var __ = CreateIndexEntry(ref entryWriter, entry, out var data);
                 indexWriter.Index(entry.Id, data.ToSpan());
-                entryWriter.Reset();
             }
 
             indexWriter.Commit();
@@ -958,7 +956,6 @@ namespace FastTests.Corax
                 {
                     using var __ = CreateIndexEntryDouble(ref entryWriter, entry, out var data);
                     indexWriter.Index(entry.Id, data.ToSpan());
-                    entryWriter.Reset();
                 }
 
                 indexWriter.Commit();

--- a/test/FastTests/Corax/OrderByMultiSorting.cs
+++ b/test/FastTests/Corax/OrderByMultiSorting.cs
@@ -172,7 +172,6 @@ namespace FastTests.Corax
                     using (var _ = CreateIndexEntry(ref entryWriter, entry, out var data))
                     {
                         indexWriter.Index(entry.Id, data.ToSpan());
-                        entryWriter.Reset();
                     }
                 }
                 indexWriter.Commit();

--- a/test/FastTests/Corax/OrderByMultiSorting.cs
+++ b/test/FastTests/Corax/OrderByMultiSorting.cs
@@ -163,28 +163,29 @@ namespace FastTests.Corax
             using var bsc = new ByteStringContext(SharedMultipleUseFlag.None);
             var knownFields = CreateKnownFields(bsc);
 
-            const int bufferSize = 4096;
-            using var _ = bsc.Allocate(bufferSize, out ByteString buffer);
-
             {
                 using var indexWriter = new IndexWriter(Env, knownFields);
+                var entryWriter = new IndexEntryWriter(bsc, knownFields);
+
                 foreach (var entry in longList)
                 {
-                    var entryWriter = new IndexEntryWriter(buffer.ToSpan(), knownFields);
-                    var data = CreateIndexEntry(ref entryWriter, entry);
-                    indexWriter.Index(entry.Id, data);
+                    using (var _ = CreateIndexEntry(ref entryWriter, entry, out var data))
+                    {
+                        indexWriter.Index(entry.Id, data.ToSpan());
+                        entryWriter.Reset();
+                    }
                 }
                 indexWriter.Commit();
             }
         }
 
-        private Span<byte> CreateIndexEntry(ref IndexEntryWriter entryWriter, IndexSingleNumericalEntry<long, long> entry)
+        private ByteStringContext<ByteStringMemoryCache>.InternalScope CreateIndexEntry(
+            ref IndexEntryWriter entryWriter, IndexSingleNumericalEntry<long, long> entry, out ByteString output)
         {
             entryWriter.Write(IndexId, Encoding.UTF8.GetBytes(entry.Id));
             entryWriter.Write(Content1, Encoding.UTF8.GetBytes(entry.Content1.ToString()), entry.Content1, Convert.ToDouble(entry.Content1));
             entryWriter.Write(Content2, Encoding.UTF8.GetBytes(entry.Content2.ToString()), entry.Content2, Convert.ToDouble(entry.Content2));
-            entryWriter.Finish(out var output);
-            return output;
+            return entryWriter.Finish(out output);
         }
 
         private IndexFieldsMapping CreateKnownFields(ByteStringContext bsc)

--- a/test/FastTests/Corax/OrderBySorting.cs
+++ b/test/FastTests/Corax/OrderBySorting.cs
@@ -86,7 +86,6 @@ namespace FastTests.Corax
                     using (var _ = CreateIndexEntry(ref entryWriter, entry, out var data))
                     {
                         indexWriter.Index(entry.Id, data.ToSpan());
-                        entryWriter.Reset();
                     }
                 }
                 indexWriter.Commit();

--- a/test/FastTests/Corax/RawCoraxFlag.cs
+++ b/test/FastTests/Corax/RawCoraxFlag.cs
@@ -52,7 +52,6 @@ public class RawCoraxFlag : StorageTest
 
                 using var _ = entry.Finish(out var output);                
                 writer.Index(id, output.ToSpan());
-                entry.Reset();
             }
 
             writer.Commit();

--- a/test/FastTests/Corax/Suggestions.cs
+++ b/test/FastTests/Corax/Suggestions.cs
@@ -190,7 +190,6 @@ namespace FastTests.Corax
             {
                 using var __ = CreateIndexEntry(ref entryWriter, entry, out var data);
                 indexWriter.Index(entry.Id, data.ToSpan());
-                entryWriter.Reset();
             }
 
             indexWriter.Commit();

--- a/test/FastTests/Corax/Suggestions.cs
+++ b/test/FastTests/Corax/Suggestions.cs
@@ -166,7 +166,8 @@ namespace FastTests.Corax
             ;
         }
 
-        private static Span<byte> CreateIndexEntry(ref IndexEntryWriter entryWriter, IndexEntryValues value)
+        private static ByteStringContext<ByteStringMemoryCache>.InternalScope CreateIndexEntry(
+            ref IndexEntryWriter entryWriter, IndexEntryValues value, out ByteString output)
         {
             Span<byte> PrepareString(string value)
             {
@@ -177,27 +178,22 @@ namespace FastTests.Corax
 
             entryWriter.Write(IndexId, PrepareString(value.Id));
             entryWriter.Write(ContentId, PrepareString(value.Content));
-
-            entryWriter.Finish(out var output);
-            return output;
+            return entryWriter.Finish(out output);
         }
 
         private void IndexEntries(ByteStringContext bsc, IEnumerable<IndexEntryValues> list, IndexFieldsMapping mapping)
         {
-            const int bufferSize = 4096;
-            using var _ = bsc.Allocate(bufferSize, out ByteString buffer);
+            using var indexWriter = new IndexWriter(Env, mapping);
+            var entryWriter = new IndexEntryWriter(bsc, mapping);
 
+            foreach (var entry in list)
             {
-                using var indexWriter = new IndexWriter(Env, mapping);
-                foreach (var entry in list)
-                {
-                    var entryWriter = new IndexEntryWriter(buffer.ToSpan(), mapping);
-                    var data = CreateIndexEntry(ref entryWriter, entry);
-                    indexWriter.Index(entry.Id, data);
-                }
-
-                indexWriter.Commit();
+                using var __ = CreateIndexEntry(ref entryWriter, entry, out var data);
+                indexWriter.Index(entry.Id, data.ToSpan());
+                entryWriter.Reset();
             }
+
+            indexWriter.Commit();
         }
 
         private class IndexEntryValues

--- a/test/FastTests/Sparrow/Bits.cs
+++ b/test/FastTests/Sparrow/Bits.cs
@@ -1,4 +1,8 @@
-﻿using Sparrow.Binary;
+﻿using System;
+using System.Buffers.Binary;
+using System.Runtime.InteropServices;
+using Sparrow.Binary;
+using Sparrow.Server.Binary;
 using Xunit;
 using Xunit.Abstractions;
 
@@ -162,6 +166,77 @@ namespace FastTests.Sparrow
             Assert.Equal(0, Bits.TrailingZeroesInBytes((uint)number));
             Assert.Equal(0, Bits.TrailingZeroesInBytes(number));
             Assert.Equal(0, Bits.TrailingZeroesInBytes((ulong)number));
+        }
+
+
+        [Fact]
+        public void BitReaderEquivalence()
+        {
+            for (int i = 0; i <= 255; i++)
+            {
+                byte value = (byte)i;
+
+                byte valueForSpan = BinaryPrimitives.ReverseEndianness(value);
+                var valueSpan = MemoryMarshal.CreateSpan(ref valueForSpan, 1);
+
+                for (int bits = 1; bits <= sizeof(byte) * 8; bits++)
+                {
+                    var reader = new BitReader(valueSpan, bits);
+                    var reader2 = new TypedBitReader<byte>(value, bits);
+
+                    Assert.Equal(reader.Read(), reader2.Read());
+                }
+            }
+
+            var rnd = new Random(1337);
+            for (int i = ushort.MinValue; i < ushort.MaxValue; i++)
+            {
+                short usvalue = (short)rnd.Next();
+
+                ushort valueForSpan = (ushort)BinaryPrimitives.ReverseEndianness(usvalue);
+                var valueSpan = MemoryMarshal.Cast<ushort, byte>(MemoryMarshal.CreateSpan(ref valueForSpan, 1));
+
+                for (int bits = 1; bits <= sizeof(ushort) * 8; bits++)
+                {
+                    var reader = new BitReader(valueSpan, bits);
+                    var reader2 = new TypedBitReader<short>(usvalue, bits);
+
+                    Assert.Equal(reader.Read(), reader2.Read());
+                }
+            }
+
+            for (int i = 0; i < 50000; i++)
+            {
+                uint usvalue = (uint)rnd.Next();
+
+                uint valueForSpan = (uint)BinaryPrimitives.ReverseEndianness(usvalue);
+                var valueSpan = MemoryMarshal.Cast<uint, byte>(MemoryMarshal.CreateSpan(ref valueForSpan, 1));
+
+                for (int bits = 1; bits <= sizeof(uint) * 8; bits++)
+                {
+                    var reader = new BitReader(valueSpan, bits);
+                    var reader2 = new TypedBitReader<uint>(usvalue, bits);
+
+                    Assert.Equal(reader.Read(), reader2.Read());
+                }
+            }
+
+            //for (int i = 0; i <= 100000; i++)
+            //{
+            //    int uivalue = (int)rnd.Next();
+
+            //    uint valueForSpan = (uint)BinaryPrimitives.ReverseEndianness(uivalue << (sizeof(uint) * 8 - uivalue));
+            //    var valueSpan = MemoryMarshal.Cast<uint, byte>(MemoryMarshal.CreateSpan(ref valueForSpan, 1));
+
+            //    for (int bits = 1; bits <= sizeof(byte) * 8; bits++)
+            //    {
+            //        var reader = new BitReader(valueSpan, bits);
+            //        var reader2 = new TypedBitReader<uint>(valueForSpan, bits);
+
+            //        Assert.Equal(reader.Read(), reader2.Read());
+            //    }
+            //}
+
         }
     }
 }

--- a/test/Tryouts/Program.cs
+++ b/test/Tryouts/Program.cs
@@ -2,6 +2,7 @@ using System;
 using System.Diagnostics;
 using Tests.Infrastructure;
 using FastTests.Voron.Sets;
+using FastTests.Corax;
 
 namespace Tryouts;
 
@@ -14,7 +15,8 @@ public static class Program
 
     public static void Main(string[] args)
     {
-        Console.WriteLine(Process.GetCurrentProcess().Id);
+        Console.WriteLine(Process.GetCurrentProcess().Id);        
+
         for (int i = 0; i < 100; i++)
         {
             Console.WriteLine($"Starting to run {i}");
@@ -22,7 +24,9 @@ public static class Program
             {
                 using (var testOutputHelper = new ConsoleTestOutputHelper())
                 {
-                    new SetTests(testOutputHelper).CanDeleteAndInsertInRandomOrder(73014, 35);
+                    new IndexSearcherTest(testOutputHelper).SimpleAndOrForBiggerSet(201, 128);
+
+                    //new SetTests(testOutputHelper).CanDeleteAndInsertInRandomOrder(73014, 35);
                     //new SetAddRemoval(testOutputHelper).AdditionsAndRemovalWork();
 
                     int minFailure = int.MaxValue;


### PR DESCRIPTION
In the beginning the underlying assumption for the usage of `IndexEntryWriter` was that the caller would provide a big enough buffer to write the object in. That assumption is incorrect, because the caller most likely will not be able to know that beforehand; therefore, now `IndexEntryWriter` will handle internally its' own auxiliary buffer and return the serialized object in a brand new memory segment and provide the caller of `.Finish(out output)` the ability to return that memory when no longer needed. 