### PR TITLE
RavenDB-18011 SSL error while using replication with TCP compression

### DIFF
--- a/src/Sparrow/Utils/ZstdStream.cs
+++ b/src/Sparrow/Utils/ZstdStream.cs
@@ -161,6 +161,10 @@ namespace Sparrow.Utils
             {
                 var (outputBytes, inputBytes, _) = CompressStep(buffer, ZstdLib.ZSTD_EndDirective.ZSTD_e_continue);
                 buffer = buffer.Slice(inputBytes);
+                
+                if (outputBytes == 0)
+                    continue;
+                
                 _inner.Write(_tempBuffer, 0, outputBytes);
             }
         }
@@ -184,6 +188,10 @@ namespace Sparrow.Utils
             {
                 var (outputBytes, inputBytes, _) = CompressStep(buffer.Span, ZstdLib.ZSTD_EndDirective.ZSTD_e_continue);
                 buffer = buffer.Slice(inputBytes);
+                
+                if (outputBytes == 0)
+                    continue;
+
                 await _inner.WriteAsync(_tempBuffer, 0, outputBytes, cancellationToken).ConfigureAwait(false);
             }
         }


### PR DESCRIPTION
### Issue link

https://issues.hibernatingrhinos.com/issue/RavenDB-18011 

### Additional description

Don't write to ssl stream when zlib output is empty. 


### Type of change

- Bug fix

### How risky is the change?

- Moderate 

### Backward compatibility

- Non breaking change


### Is it platform specific issue?

- No

### Documentation update

- No documentation update is needed 

### Testing 

- Tests have been added that prove the fix is effective or that the feature works
 - Internal classes added to the test class (e.g. entity or index definition classes) have the lowest possible access modifier (preferable `private`) 
- It has been verified by manual testing

### Is there any existing behavior change of other features due to this change?

- No

### UI work

- No UI work is needed
