### PR TITLE
RavenDB-17903 - Can't operate new bulk insert on one node database if…

### DIFF
--- a/src/Raven.Client/Http/NodeSelector.cs
+++ b/src/Raven.Client/Http/NodeSelector.cs
@@ -1,5 +1,6 @@
 using System;
 using System.Collections.Generic;
+using System.Diagnostics;
 using System.Threading;
 using Raven.Client.Exceptions;
 using Raven.Client.Exceptions.Database;
@@ -66,6 +67,8 @@ namespace Raven.Client.Http
             var state = _state;
             var stateFailures = state.Failures;
             var serverNodes = state.Nodes;
+
+            Debug.Assert(serverNodes.Count == stateFailures.Length, $"Expected equals {serverNodes.Count}, but got {stateFailures.Length}");
             
             if (serverNodes.Count == 1 && serverNodes[0].ClusterTag == nodeTag) // If this is a cluster with 1 node return it without checking it's failure.
                 return (0, serverNodes[0]);
@@ -74,8 +77,7 @@ namespace Raven.Client.Http
             {
                 if (serverNodes[i].ClusterTag == nodeTag)
                 {
-                    if (i>= stateFailures.Length || // if the node doesn't have an element in stateFailure array, it's considered to have 0 failures
-                                    stateFailures[i] == 0)
+                    if (stateFailures[i] == 0)
                         return (i, serverNodes[i]);
 
                     throw new RequestedNodeUnavailableException($"Requested node {nodeTag} currently unavailable, please try again later.");

--- a/src/Raven.Client/Http/NodeSelector.cs
+++ b/src/Raven.Client/Http/NodeSelector.cs
@@ -77,6 +77,8 @@ namespace Raven.Client.Http
             {
                 if (serverNodes[i].ClusterTag == nodeTag)
                 {
+                    Debug.Assert(string.IsNullOrEmpty(serverNodes[i].Url) == false, $"Expected serverNodes Url not null or empty but got: \'{serverNodes[i].Url}\'");
+
                     if (stateFailures[i] == 0)
                         return (i, serverNodes[i]);
 

--- a/src/Raven.Client/Http/NodeSelector.cs
+++ b/src/Raven.Client/Http/NodeSelector.cs
@@ -66,12 +66,16 @@ namespace Raven.Client.Http
             var state = _state;
             var stateFailures = state.Failures;
             var serverNodes = state.Nodes;
-            var len = Math.Min(serverNodes.Count, stateFailures.Length);
-            for (var i = 0; i < len; i++)
+            
+            if (serverNodes.Count == 1 && serverNodes[0].ClusterTag == nodeTag) // If this is a cluster with 1 node return it without checking it's failure.
+                return (0, serverNodes[0]);
+
+            for (var i = 0; i < serverNodes.Count; i++)
             {
                 if (serverNodes[i].ClusterTag == nodeTag)
                 {
-                    if (stateFailures[i] == 0 && string.IsNullOrEmpty(serverNodes[i].Url) == false)
+                    if (i>= stateFailures.Length || // if the node doesn't have an element in stateFailure array, it's considered to have 0 failures
+                                    stateFailures[i] == 0)
                         return (i, serverNodes[i]);
 
                     throw new RequestedNodeUnavailableException($"Requested node {nodeTag} currently unavailable, please try again later.");

--- a/test/SlowTests/Issues/RavenDB-17903.cs
+++ b/test/SlowTests/Issues/RavenDB-17903.cs
@@ -1,10 +1,17 @@
 ﻿using System;
 using System.Collections.Generic;
+using System.Diagnostics;
 using System.Linq;
 using System.Text;
+using System.Threading;
 using System.Threading.Tasks;
 using FastTests;
+using FastTests.Graph;
+using Raven.Client.Documents;
+using Raven.Client.Documents.Operations;
+using Raven.Client.ServerWide;
 using Raven.Client.ServerWide.Operations;
+using Raven.Server;
 using Raven.Server.Config;
 using Tests.Infrastructure;
 using Xunit;
@@ -19,7 +26,7 @@ namespace SlowTests.Issues
         }
 
         [Fact]
-        public async Task BulkInsertFailover_TestCase1()
+        public async Task Bulk_Insert_1NodeRestart_TestCase1()
         {
             using var server = GetNewServer(new ServerCreationOptions { RunInMemory = false, });
             using var store = GetDocumentStore(new Options { RunInMemory = false, Server = server });
@@ -54,7 +61,7 @@ namespace SlowTests.Issues
         }
 
         [Fact]
-        public async Task BulkInsertFailover_TestCase2()
+        public async Task Bulk_Insert_1NodeRestart_TestCase2()
         {
             (var nodes, var leader) = await CreateRaftCluster(2, shouldRunInMemory: false);
 
@@ -92,9 +99,192 @@ namespace SlowTests.Issues
             }
         }
 
+        [Fact]
+        public async Task Bulk_Insert_2NodesDown_1NodeRestart()
+        {
+            (var nodes, var leader) = await CreateRaftCluster(2, shouldRunInMemory: false);
+
+            using var store = GetDocumentStore(new Options { RunInMemory = false, Server = leader, ReplicationFactor = 2 });
+
+            var record = await store.Maintenance.Server.SendAsync(new GetDatabaseRecordOperation(store.Database));
+            var databaseNodeTag = record.Topology.AllNodes.First();
+            var nodeToRestart = nodes.First(n => n.ServerStore.NodeTag == databaseNodeTag);
+            var nodeToKill = nodes.First(n => n.ServerStore.NodeTag != databaseNodeTag);
+
+            await using (var bulk = store.BulkInsert())
+            {
+                await bulk.StoreAsync(new TestObj(), $"testObjs/0");
+            }
+
+            var result = await DisposeServerAndWaitForFinishOfDisposalAsync(nodeToRestart);
+            await DisposeServerAndWaitForFinishOfDisposalAsync(nodeToKill);
+
+            await Assert.ThrowsAnyAsync<Exception>(async () =>
+            {
+                await using (var bulk = store.BulkInsert())
+                {
+                    await bulk.StoreAsync(new TestObj(), $"testObjs/0");
+                }
+            });
+
+            using var newServer = GetNewServer(new ServerCreationOptions
+            {
+                DeletePrevious = false,
+                RunInMemory = false,
+                DataDirectory = result.DataDirectory,
+                CustomSettings = new Dictionary<string, string> { [RavenConfiguration.GetKey(x => x.Core.ServerUrls)] = result.Url }
+            });
+
+            await using (var bulk = store.BulkInsert())
+            {
+                await bulk.StoreAsync(new TestObj(), $"testObjs/0");
+            }
+        }
+
+        [Fact]
+        public async Task BulkInsertFailoverTest()
+        {
+            (var nodes, var leader) = await CreateRaftCluster(2, shouldRunInMemory: false);
+
+            using var store2 = GetDocumentStore(new Options
+            {
+                RunInMemory = false,
+                Server = leader, 
+                ReplicationFactor = 2,
+            });
+
+            await using (var bulk = store2.BulkInsert())
+            {
+                await bulk.StoreAsync(new TestObj(), $"testObjs/0");
+            }
+
+            var storeNodes = store2.GetRequestExecutor(store2.Database).Topology.Nodes;
+            var responsibleNodeUrl = storeNodes[0].Url;
+            var responsibleNode = nodes.Single(n => n.ServerStore.GetNodeHttpServerUrl() == responsibleNodeUrl);
+
+            await DisposeServerAndWaitForFinishOfDisposalAsync(responsibleNode);
+
+            // Check topology didn't changed
+            var responsibleNodeUrlAfterDispose = store2.GetRequestExecutor(store2.Database).Topology.Nodes[0].Url;
+            Assert.Equal(responsibleNodeUrl, responsibleNodeUrlAfterDispose);
+
+            // If passes - failover succeeded
+            await using (var bulk = store2.BulkInsert())
+            {
+                await bulk.StoreAsync(new TestObj(), $"testObjs/1");
+            }
+        }
+
         class TestObj
         {
             public string Id { get; set; }
+        }
+
+        [Fact]
+        public async Task Should_Create_New_Bulk_Insert_If_Previously_Failed_On_Unavailable_Server_1()
+        {
+            using var server = GetNewServer(new ServerCreationOptions { RunInMemory = false, });
+            using var store = GetDocumentStore(new Options { Server = server, RunInMemory = false });
+
+            var result = await DisposeServerAndWaitForFinishOfDisposalAsync(server);
+
+            await Assert.ThrowsAnyAsync<Exception>(async () =>
+            {
+                await using (var bulk = store.BulkInsert())
+                {
+                    await bulk.StoreAsync(new User(), "user/1");
+                }
+            });
+
+            using var newServer = GetNewServer(new ServerCreationOptions
+            {
+                DeletePrevious = false,
+                RunInMemory = false,
+                DataDirectory = result.DataDirectory,
+                CustomSettings = new Dictionary<string, string>
+                {
+                    [RavenConfiguration.GetKey(x => x.Core.ServerUrls)] = result.Url
+                }
+            });
+
+            await using (var bulk = store.BulkInsert())
+            {
+                await bulk.StoreAsync(new User(), "user/1");
+            }
+        }
+
+        [Fact]
+        public async Task Should_Create_New_Bulk_Insert_If_Previously_Failed_On_Unavailable_Server_2()
+        {
+            (var nodes, var leader) = await CreateRaftCluster(2, shouldRunInMemory: false);
+
+            using var store = GetDocumentStore(new Options { RunInMemory = false, Server = leader, ReplicationFactor = 1 });
+
+            var record = await store.Maintenance.Server.SendAsync(new GetDatabaseRecordOperation(store.Database));
+            var databaseNodeTag = record.Topology.AllNodes.First();
+            var nodeToRestart = nodes.First(n => n.ServerStore.NodeTag == databaseNodeTag);
+
+            var result = await DisposeServerAndWaitForFinishOfDisposalAsync(nodeToRestart);
+
+            await Assert.ThrowsAnyAsync<Exception>(async () =>
+            {
+                await using (var bulk = store.BulkInsert())
+                {
+                    await bulk.StoreAsync(new User(), "user/1");
+                }
+            });
+
+            using var newServer = GetNewServer(new ServerCreationOptions
+            {
+                DeletePrevious = false,
+                RunInMemory = false,
+                DataDirectory = result.DataDirectory,
+                CustomSettings = new Dictionary<string, string> { [RavenConfiguration.GetKey(x => x.Core.ServerUrls)] = result.Url }
+            });
+
+            await using (var bulk = store.BulkInsert())
+            {
+                await bulk.StoreAsync(new User(), "user/1");
+            }
+        }
+
+        [Fact]
+        public async Task Should_Not_Throw_Node_Unavailable()
+        {
+            using var server = GetNewServer(new ServerCreationOptions { RunInMemory = false, });
+            using var store = GetDocumentStore(new Options { RunInMemory = false, Server = server });
+
+            using (var session = store.OpenSession())
+            {
+                session.Store(new User { Name = "Omer" });
+            }
+
+            var result = await DisposeServerAndWaitForFinishOfDisposalAsync(server);
+
+            await Assert.ThrowsAnyAsync<Exception>(async () =>
+            {
+                Operation deleteOperation = await store
+                    .Operations
+                    .SendAsync(new DeleteByQueryOperation("from Users"))
+                    .ConfigureAwait(false);
+
+                await deleteOperation.WaitForCompletionAsync().ConfigureAwait(false);
+            });
+
+            using var newServer = GetNewServer(new ServerCreationOptions
+            {
+                DeletePrevious = false,
+                RunInMemory = false,
+                DataDirectory = result.DataDirectory,
+                CustomSettings = new Dictionary<string, string> { [RavenConfiguration.GetKey(x => x.Core.ServerUrls)] = result.Url }
+            });
+
+            Operation deleteOperation = await store
+                .Operations
+                .SendAsync(new DeleteByQueryOperation("from Users"))
+                .ConfigureAwait(false);
+
+            await deleteOperation.WaitForCompletionAsync().ConfigureAwait(false);
         }
     }
 }

--- a/test/SlowTests/Issues/RavenDB-17903.cs
+++ b/test/SlowTests/Issues/RavenDB-17903.cs
@@ -1,0 +1,100 @@
+﻿using System;
+using System.Collections.Generic;
+using System.Linq;
+using System.Text;
+using System.Threading.Tasks;
+using FastTests;
+using Raven.Client.ServerWide.Operations;
+using Raven.Server.Config;
+using Tests.Infrastructure;
+using Xunit;
+using Xunit.Abstractions;
+
+namespace SlowTests.Issues
+{
+    public class RavenDB_17903 : ClusterTestBase
+    {
+        public RavenDB_17903(ITestOutputHelper output) : base(output)
+        {
+        }
+
+        [Fact]
+        public async Task BulkInsertFailover_TestCase1()
+        {
+            using var server = GetNewServer(new ServerCreationOptions { RunInMemory = false, });
+            using var store = GetDocumentStore(new Options { RunInMemory = false, Server = server });
+
+            await using (var bulk = store.BulkInsert())
+            {
+                await bulk.StoreAsync(new TestObj(), $"testObjs/0");
+            }
+            
+            var result = await DisposeServerAndWaitForFinishOfDisposalAsync(server);
+
+            await Assert.ThrowsAnyAsync<Exception>(async () =>
+            {
+                await using (var bulk = store.BulkInsert())
+                {
+                    await bulk.StoreAsync(new TestObj(), $"testObjs/0");
+                }
+            });
+
+            using var newServer = GetNewServer(new ServerCreationOptions
+            {
+                DeletePrevious = false,
+                RunInMemory = false,
+                DataDirectory = result.DataDirectory,
+                CustomSettings = new Dictionary<string, string> { [RavenConfiguration.GetKey(x => x.Core.ServerUrls)] = result.Url }
+            });
+
+            await using (var bulk = store.BulkInsert())
+            {
+                await bulk.StoreAsync(new TestObj(), $"testObjs/0");
+            }
+        }
+
+        [Fact]
+        public async Task BulkInsertFailover_TestCase2()
+        {
+            (var nodes, var leader) = await CreateRaftCluster(2, shouldRunInMemory: false);
+
+            using var store = GetDocumentStore(new Options { RunInMemory = false, Server = leader, ReplicationFactor = 1 });
+
+            var record = await store.Maintenance.Server.SendAsync(new GetDatabaseRecordOperation(store.Database));
+            var databaseNodeTag = record.Topology.AllNodes.First();
+            var nodeToRestart = nodes.First(n => n.ServerStore.NodeTag == databaseNodeTag);
+
+            await using (var bulk = store.BulkInsert())
+            {
+                await bulk.StoreAsync(new TestObj(), $"testObjs/0");
+            }
+            var result = await DisposeServerAndWaitForFinishOfDisposalAsync(nodeToRestart);
+
+            await Assert.ThrowsAnyAsync<Exception>(async () =>
+            {
+                await using (var bulk = store.BulkInsert())
+                {
+                    await bulk.StoreAsync(new TestObj(), $"testObjs/0");
+                }
+            });
+
+            using var newServer = GetNewServer(new ServerCreationOptions
+            {
+                DeletePrevious = false,
+                RunInMemory = false,
+                DataDirectory = result.DataDirectory,
+                CustomSettings = new Dictionary<string, string> { [RavenConfiguration.GetKey(x => x.Core.ServerUrls)] = result.Url }
+            });
+
+            await using (var bulk = store.BulkInsert())
+            {
+                await bulk.StoreAsync(new TestObj(), $"testObjs/0");
+            }
+        }
+
+        class TestObj
+        {
+            public string Id { get; set; }
+        }
+    }
+}


### PR DESCRIPTION
### Issue link

https://issues.hibernatingrhinos.com/issue/RavenDB-17903/Cant-operate-new-bulk-insert-on-one-node-database-if-previously-failed-on-server-unabailable

### Additional description

Can't operate new bulk insert on one node database if previously failed on server unabailable.

### Type of change

- Bug fix

### How risky is the change?

- Low 

### Backward compatibility

- Not relevant

### Is it platform specific issue?

- No

### Documentation update

- No documentation update is needed 

### Testing 

- Tests have been added that prove the fix is effective or that the feature works

### Is there any existing behavior change of other features due to this change?

- No

### UI work

- No UI work is needed
