### PR TITLE
RavenDB-18921 : avoid holding the read transaction in cluster observer log for too long

### DIFF
--- a/src/Raven.Server/ServerWide/Maintenance/ClusterObserver.cs
+++ b/src/Raven.Server/ServerWide/Maintenance/ClusterObserver.cs
@@ -10,6 +10,7 @@ using Raven.Client;
 using Raven.Client.Documents.Indexes;
 using Raven.Client.Documents.Operations.Backups;
 using Raven.Client.Exceptions;
+using Raven.Client.Extensions;
 using Raven.Client.Http;
 using Raven.Client.ServerWide;
 using Raven.Client.Util;
@@ -179,8 +180,7 @@ namespace Raven.Server.ServerWide.Maintenance
 
         private async Task AnalyzeLatestStats(
             Dictionary<string, ClusterNodeStatusReport> newStats,
-            Dictionary<string, ClusterNodeStatusReport> prevStats
-        )
+            Dictionary<string, ClusterNodeStatusReport> prevStats)
         {
             var currentLeader = _engine.CurrentLeader;
             if (currentLeader == null)
@@ -369,7 +369,7 @@ namespace Raven.Server.ServerWide.Maintenance
                     );
                     NotificationCenter.Add(alert);
                 }
-                catch (ConcurrencyException)
+                catch (Exception e) when (e.ExtractSingleInnerException() is ConcurrencyException)
                 {
                     // this is sort of expected, if the database was
                     // modified by someone else, we'll avoid changing

--- a/test/FastTests/Server/Documents/Indexing/Auto/BasicAutoMapIndexing.cs
+++ b/test/FastTests/Server/Documents/Indexing/Auto/BasicAutoMapIndexing.cs
@@ -998,7 +998,8 @@ namespace FastTests.Server.Documents.Indexing.Auto
                             }
                         }
                     };
-                    await Server.ServerStore.Observer.CleanUpUnusedAutoIndexes(state);
+
+                    await CleanupUnusedAutoIndexes(state);
                 }
 
                 WaitForIndexDeletion(database, index0.Name);
@@ -1064,7 +1065,9 @@ namespace FastTests.Server.Documents.Indexing.Auto
                             }
                         }
                     };
-                    await Server.ServerStore.Observer.CleanUpUnusedAutoIndexes(state); // nothing should happen because difference between querying time between those two indexes is less than TimeToWaitBeforeMarkingAutoIndexAsIdle
+
+                    // nothing should happen because difference between querying time between those two indexes is less than TimeToWaitBeforeMarkingAutoIndexAsIdle
+                    await CleanupUnusedAutoIndexes(state);
                 }
 
                 WaitForIndex(database, index1.Name, index => index.State == IndexState.Normal);
@@ -1124,7 +1127,9 @@ namespace FastTests.Server.Documents.Indexing.Auto
                             }
                         }
                     };
-                    await Server.ServerStore.Observer.CleanUpUnusedAutoIndexes(state); // this will mark index2 as idle, because the difference between two indexes and index last querying time is more than TimeToWaitBeforeMarkingAutoIndexAsIdle
+
+                    // this will mark index2 as idle, because the difference between two indexes and index last querying time is more than TimeToWaitBeforeMarkingAutoIndexAsIdle
+                    await CleanupUnusedAutoIndexes(state);
                 }
 
                 WaitForIndex(database, index1.Name, index => index.State == IndexState.Normal);
@@ -1184,7 +1189,9 @@ namespace FastTests.Server.Documents.Indexing.Auto
                             }
                         }
                     };
-                    await Server.ServerStore.Observer.CleanUpUnusedAutoIndexes(state); // should not remove anything, age will be greater than 2x TimeToWaitBeforeMarkingAutoIndexAsIdle but less than TimeToWaitBeforeDeletingAutoIndexMarkedAsIdle
+
+                    // should not remove anything, age will be greater than 2x TimeToWaitBeforeMarkingAutoIndexAsIdle but less than TimeToWaitBeforeDeletingAutoIndexMarkedAsIdle
+                    await CleanupUnusedAutoIndexes(state);
                 }
 
                 WaitForIndex(database, index1.Name, index => index.State == IndexState.Idle);
@@ -1244,11 +1251,22 @@ namespace FastTests.Server.Documents.Indexing.Auto
                             }
                         }
                     };
-                    await Server.ServerStore.Observer.CleanUpUnusedAutoIndexes(state); // this will delete indexes
+
+                    // this will delete indexes
+                    await CleanupUnusedAutoIndexes(state);
                 }
 
                 WaitForIndexDeletion(database, index1.Name);
                 WaitForIndexDeletion(database, index2.Name);
+            }
+        }
+
+        private async Task CleanupUnusedAutoIndexes(ClusterObserver.DatabaseObservationState state)
+        {
+            var indexCleanupCommands = Server.ServerStore.Observer.GetUnusedAutoIndexes(state);
+            foreach (var (cmd, _) in indexCleanupCommands)
+            {
+                await Server.ServerStore.Engine.PutAsync(cmd);
             }
         }
 


### PR DESCRIPTION
### Issue link

https://issues.hibernatingrhinos.com/issue/RavenDB-18921/Holding-the-read-transaction-in-the-cluster-observer-log-for-too-long

### Additional description

`ClusterObserver.AnalyzeLatestStats()` - only collect the commands to execute during the read transaction, and perform the execution after we close the read transaction

### Type of change

- Bug fix

### How risky is the change?

- Moderate 

### Backward compatibility

- Not relevant

### Is it platform specific issue?

- No

### Documentation update

- No documentation update is needed 

### Testing 

- existing tests were adjusted due to these changes  

### Is there any existing behavior change of other features due to this change?

- No

### UI work

- No UI work is needed
