### PR TITLE
RavenDB-18944 [CoraxBooleanQuery-BetweenMatch] Convert long into double when opposite side is double.

### DIFF
--- a/src/Raven.Server/Documents/Indexes/Persistence/Corax/CoraxBooleanQuery.cs
+++ b/src/Raven.Server/Documents/Indexes/Persistence/Corax/CoraxBooleanQuery.cs
@@ -105,7 +105,10 @@ public readonly struct CoraxBooleanItem : IQueryMatch
                 (long l, long l2) => _indexSearcher.Between(_indexSearcher.ExistsQuery(Name), FieldId, l, l2, BetweenLeft, BetweenRight),
                 (double d, double d2) => _indexSearcher.Between(_indexSearcher.ExistsQuery(Name), FieldId, d, d2, BetweenLeft, BetweenRight),
                 (string s, string s2) => _indexSearcher.Between(_indexSearcher.ExistsQuery(Name), FieldId, s, s2, BetweenLeft, BetweenRight),
-                _ => throw new InvalidOperationException($"UnaryMatchOperation {Operation} is not supported for type {Term.GetType()}")
+                (long l, double d) => _indexSearcher.Between(_indexSearcher.ExistsQuery(Name), FieldId, Convert.ToDouble(l), d, BetweenLeft, BetweenRight),
+                (double d, long l) => _indexSearcher.Between(_indexSearcher.ExistsQuery(Name), FieldId, d, Convert.ToDouble(l), BetweenLeft, BetweenRight),
+
+                    _ => throw new InvalidOperationException($"UnaryMatchOperation {Operation} is not supported for type {Term.GetType()}")
             };
         }
 
@@ -222,6 +225,8 @@ public class CoraxBooleanQuery : IQueryMatch
                         query.BetweenRight),
                     (string s, string s2) => _indexSearcher.Between(baseMatch ?? _indexSearcher.ExistsQuery(query.Name), query.FieldId, s, s2, query.BetweenLeft,
                         query.BetweenRight),
+                    (long l, double d) => _indexSearcher.Between(baseMatch ?? _indexSearcher.ExistsQuery(query.Name),  query.FieldId, Convert.ToDouble(l), d, query.BetweenLeft, query.BetweenRight),
+                    (double d, long l) => _indexSearcher.Between(baseMatch ?? _indexSearcher.ExistsQuery(query.Name),  query.FieldId, d, Convert.ToDouble(l), query.BetweenLeft, query.BetweenRight),
                     _ => throw new InvalidOperationException($"UnaryMatchOperation {query.Operation} is not supported for type {query.Term.GetType()}")
                 };
             }

--- a/test/FastTests/Corax/QueriesFromRavenDb.cs
+++ b/test/FastTests/Corax/QueriesFromRavenDb.cs
@@ -1,0 +1,35 @@
+﻿using System.Linq;
+using Raven.Client.Documents.Linq;
+using Raven.Server.Documents.Indexes.Persistence.Corax;
+using Tests.Infrastructure;
+using Xunit;
+using Xunit.Abstractions;
+
+namespace FastTests.Corax;
+
+public class QueriesFromRavenDb : RavenTestBase
+{
+    public QueriesFromRavenDb(ITestOutputHelper output) : base(output)
+    {
+    }
+
+    [RavenTheory(RavenTestCategory.Indexes | RavenTestCategory.Querying)]
+    [RavenData(SearchEngineMode = RavenSearchEngineMode.Corax)]
+    public void CanMixValuesInQueryForBetween(Options options)
+    {
+        using var store = GetDocumentStore(options);
+        {
+            using var s = store.OpenSession();
+            s.Store(new DoubleItem(2));
+            s.SaveChanges();
+        }
+
+        {
+            using var s = store.OpenSession();
+            var q = s.Advanced.RawQuery<DoubleItem>("from DoubleItems where 'Value' < 3 and 'Value' > 1.5").ToList();
+            Assert.Equal(1, q.Count);
+        }
+    }
+
+    private record DoubleItem(double Value);
+}


### PR DESCRIPTION
…lder (CoraxBooleanQuery)

### Issue link

https://issues.hibernatingrhinos.com/issue/RavenDB-18944

### Additional description
--


### Type of change

- Bug fix

### How risky is the change?


- Not relevant

### Backward compatibility

- Not relevant

### Is it platform specific issue?

- No

### Documentation update

- No documentation update is needed 

### Testing 

- Tests have been added that prove the fix is effective or that the feature works


### Is there any existing behavior change of other features due to this change?

- No

### UI work

- No UI work is needed
