### PR TITLE
RavenDB-17010 - cloning only the relevant fields that needs to be cloned

### DIFF
--- a/src/Raven.Server/Smuggler/Documents/SmugglerPatcher.cs
+++ b/src/Raven.Server/Smuggler/Documents/SmugglerPatcher.cs
@@ -1,5 +1,4 @@
 ﻿using System;
-
 using Raven.Client.Documents.Smuggler;
 using Raven.Server.Documents;
 using Raven.Server.Documents.Patch;
@@ -49,13 +48,7 @@ namespace Raven.Server.Smuggler.Documents
                 if (!(translatedResult is BlittableJsonReaderObject bjro))
                     return null;
 
-                var cloned = document.Clone(ctx);
-                using (cloned.Data)
-                {
-                    cloned.Data = bjro;
-                }
-
-                return cloned;
+                return document.CloneWith(ctx, bjro);
             }
         }
 


### PR DESCRIPTION
### Issue link

https://issues.hibernatingrhinos.com/issue/RavenDB-17010

### Additional description

- Cloning only the relevant fields that needs to be cloned. The data was cloned and disposed afterwards.
- The reason for the rising memory usage is due to fragmentation.
We cloned the `document data`, then the document id and then the lower document id.
We then disposed of the `document data` which caused the fragmentation.

### Type of change

- Bug fix

### How risky is the change?

- Low 

### Testing 

- It has been verified by manual testing