### PR TITLE
RavenDB-18956 Fixing unexpected error in indexing thread which effectively was TaskCanceledException

### DIFF
--- a/src/Raven.Server/Documents/Indexes/Index.cs
+++ b/src/Raven.Server/Documents/Indexes/Index.cs
@@ -18,6 +18,7 @@ using Raven.Client.Documents.Operations;
 using Raven.Client.Documents.Queries;
 using Raven.Client.Exceptions.Database;
 using Raven.Client.Exceptions.Documents.Indexes;
+using Raven.Client.Extensions;
 using Raven.Client.ServerWide.Operations;
 using Raven.Client.Util;
 using Raven.Server.Config.Categories;
@@ -2089,6 +2090,11 @@ namespace Raven.Server.Documents.Indexes
                     Task.Delay((int)timeLeft, _indexingProcessCancellationTokenSource.Token).Wait();
             }
             catch (OperationCanceledException)
+            {
+                // index was deleted or database was shutdown
+                return;
+            }
+            catch (AggregateException ae) when (ae.ExtractSingleInnerException() is OperationCanceledException)
             {
                 // index was deleted or database was shutdown
                 return;


### PR DESCRIPTION
### Issue link

https://issues.hibernatingrhinos.com/issue/RavenDB-18956/Unexpected-error-in-indexing-thread-TaskCanceledException

### Additional description

We don't want to consider it as unexpected / critical error

### Type of change

- Bug fix

### How risky is the change?

- Low 

### Backward compatibility

- Not relevant

### Is it platform specific issue?

- No

### Documentation update

- No documentation update is needed 

### Testing 

- It has been verified by manual testing

### Is there any existing behavior change of other features due to this change?

- No

### UI work

- No UI work is needed
