### PR TITLE
RavenDB-18957 Support for linq queries using a dictionary entity type

### DIFF
--- a/src/Raven.Client/Documents/Linq/LinqPathProvider.cs
+++ b/src/Raven.Client/Documents/Linq/LinqPathProvider.cs
@@ -82,23 +82,25 @@ namespace Raven.Client.Documents.Linq
                 {
                     var itemKey = GetValueFromExpression(callExpression.Arguments[0], callExpression.Method.GetParameters()[0].ParameterType).ToString();
 
-                    string parentPath;
-
                     if (callExpression.Object.NodeType == ExpressionType.Parameter)
                     {
-                        parentPath = itemKey;
+                        return new Result
+                        {
+                            MemberType = callExpression.Method.ReturnType,
+                            IsNestedPath = false,
+                            Path = itemKey
+                        };
                     }
                     else
                     {
                         var parent = GetPath(callExpression.Object);
-                        parentPath = $"{parent.Path}.{itemKey}";
+                        return new Result
+                        {
+                            MemberType = callExpression.Method.ReturnType,
+                            IsNestedPath = true,
+                            Path = parent.Path + "." + itemKey
+                        };
                     }
-                    return new Result
-                    {
-                        MemberType = callExpression.Method.ReturnType,
-                        IsNestedPath = true,
-                        Path = parentPath
-                    };
                 }
 
                 if (callExpression.Method.Name == "ToString" && callExpression.Method.ReturnType == typeof(string))

--- a/src/Raven.Client/Documents/Linq/LinqPathProvider.cs
+++ b/src/Raven.Client/Documents/Linq/LinqPathProvider.cs
@@ -82,7 +82,7 @@ namespace Raven.Client.Documents.Linq
                 {
                     var itemKey = GetValueFromExpression(callExpression.Arguments[0], callExpression.Method.GetParameters()[0].ParameterType).ToString();
 
-                    if (callExpression.Object.NodeType == ExpressionType.Parameter)
+                    if (callExpression.Object?.NodeType == ExpressionType.Parameter)
                     {
                         return new Result
                         {
@@ -91,16 +91,14 @@ namespace Raven.Client.Documents.Linq
                             Path = itemKey
                         };
                     }
-                    else
+
+                    var parent = GetPath(callExpression.Object);
+                    return new Result
                     {
-                        var parent = GetPath(callExpression.Object);
-                        return new Result
-                        {
-                            MemberType = callExpression.Method.ReturnType,
-                            IsNestedPath = true,
-                            Path = parent.Path + "." + itemKey
-                        };
-                    }
+                        MemberType = callExpression.Method.ReturnType,
+                        IsNestedPath = true,
+                        Path = parent.Path + "." + itemKey
+                    };
                 }
 
                 if (callExpression.Method.Name == "ToString" && callExpression.Method.ReturnType == typeof(string))

--- a/src/Raven.Client/Documents/Linq/LinqPathProvider.cs
+++ b/src/Raven.Client/Documents/Linq/LinqPathProvider.cs
@@ -80,15 +80,24 @@ namespace Raven.Client.Documents.Linq
 
                 if (callExpression.Method.Name == "get_Item")
                 {
-                    var parent = GetPath(callExpression.Object);
-
                     var itemKey = GetValueFromExpression(callExpression.Arguments[0], callExpression.Method.GetParameters()[0].ParameterType).ToString();
 
+                    string parentPath;
+
+                    if (callExpression.Object.NodeType == ExpressionType.Parameter)
+                    {
+                        parentPath = itemKey;
+                    }
+                    else
+                    {
+                        var parent = GetPath(callExpression.Object);
+                        parentPath = $"{parent.Path}.{itemKey}";
+                    }
                     return new Result
                     {
                         MemberType = callExpression.Method.ReturnType,
                         IsNestedPath = true,
-                        Path = parent.Path + "." + itemKey
+                        Path = parentPath
                     };
                 }
 

--- a/src/Raven.Client/Documents/Linq/RavenQueryProviderProcessor.cs
+++ b/src/Raven.Client/Documents/Linq/RavenQueryProviderProcessor.cs
@@ -510,6 +510,8 @@ namespace Raven.Client.Documents.Linq
             }
             if (node.NodeType == ExpressionType.Parameter)
                 return true;
+            if (node.NodeType == ExpressionType.Call && ((MethodCallExpression)node).Method.Name == "get_Item" && ((MethodCallExpression)node).Object.NodeType == ExpressionType.Parameter)
+                return true;
             if (node.NodeType != ExpressionType.MemberAccess)
                 return false;
             var memberExpression = ((MemberExpression)node);

--- a/src/Raven.Client/Documents/Linq/RavenQueryProviderProcessor.cs
+++ b/src/Raven.Client/Documents/Linq/RavenQueryProviderProcessor.cs
@@ -510,7 +510,7 @@ namespace Raven.Client.Documents.Linq
             }
             if (node.NodeType == ExpressionType.Parameter)
                 return true;
-            if (node.NodeType == ExpressionType.Call && ((MethodCallExpression)node).Method.Name == "get_Item" && ((MethodCallExpression)node).Object.NodeType == ExpressionType.Parameter)
+            if (node.NodeType == ExpressionType.Call && node is MethodCallExpression callExpressionNode && callExpressionNode.Method.Name == "get_Item" && callExpressionNode.Object?.NodeType == ExpressionType.Parameter)
                 return true;
             if (node.NodeType != ExpressionType.MemberAccess)
                 return false;

--- a/test/FastTests/Client/Query.cs
+++ b/test/FastTests/Client/Query.cs
@@ -216,6 +216,26 @@ namespace FastTests.Client
         }
 
         [Fact]
+        public void Query_Dictionary_Simple()
+        {
+            using (var store = GetDocumentStore())
+            {
+                using (var newSession = store.OpenSession())
+                {
+                    newSession.Store(new Dictionary<string, object?> { { "Name", "John" } }, "users/1");
+                    newSession.Store(new Dictionary<string, object?> { { "Name", "Jane" } }, "users/2");
+                    newSession.Store(new Dictionary<string, object?> { { "Name", "Tarzan" } }, "users/3");
+                    newSession.SaveChanges();
+
+                    var queryResult = newSession.Query<Dictionary<string,object?>>()
+                        .ToList();
+
+                    Assert.Equal(queryResult.Count, 3);
+                }
+            }
+        }
+
+        [Fact]
         public void Query_With_Where_Clause()
         {
             using (var store = GetDocumentStore())
@@ -245,7 +265,41 @@ namespace FastTests.Client
                 }
             }
         }
-        
+
+        [Fact]
+        public void Query_Dictionary_With_Where_Clause()
+        {
+            using (var store = GetDocumentStore())
+            {
+                using (var newSession = store.OpenSession())
+                {
+                    newSession.Store(new Dictionary<string, object?> { { "Name", "John" } }, "users/1");
+                    newSession.Store(new Dictionary<string, object?> { { "Name", "Jane" } }, "users/2");
+                    newSession.Store(new Dictionary<string, object?> { { "Name", "Tarzan" } }, "users/3");
+                    newSession.SaveChanges();
+
+                    var query = newSession.Query<Dictionary<string, object?>>()
+                        .Where(x => ((string)x["Name"]).StartsWith("J")).ToString();
+
+                    var queryResult = newSession.Query<Dictionary<string, object?>>()
+                        .Where(x => ((string)x["Name"]).StartsWith("J"))
+                        .ToList();
+
+                    var queryResult2 = newSession.Query<Dictionary<string, object?>>()
+                        .Where(x => ((string)x["Name"]).Equals("Tarzan"))
+                        .ToList();
+
+                    var queryResult3 = newSession.Query<Dictionary<string, object?>>()
+                        .Where(x => ((string)x["Name"]).EndsWith("n"))
+                        .ToList();
+
+                    Assert.Equal(queryResult.Count, 2);
+                    Assert.Equal(queryResult2.Count, 1);
+                    Assert.Equal(queryResult3.Count, 2);
+                }
+            }
+        }
+
         [Fact]
         public async Task QueryWithWhere_WhenUsingStringEquals_ShouldWork()
         {

--- a/test/FastTests/Client/Query.cs
+++ b/test/FastTests/Client/Query.cs
@@ -222,12 +222,12 @@ namespace FastTests.Client
             {
                 using (var newSession = store.OpenSession())
                 {
-                    newSession.Store(new Dictionary<string, object?> { { "Name", "John" } }, "users/1");
-                    newSession.Store(new Dictionary<string, object?> { { "Name", "Jane" } }, "users/2");
-                    newSession.Store(new Dictionary<string, object?> { { "Name", "Tarzan" } }, "users/3");
+                    newSession.Store(new Dictionary<string, object> { { "Name", "John" } }, "users/1");
+                    newSession.Store(new Dictionary<string, object> { { "Name", "Jane" } }, "users/2");
+                    newSession.Store(new Dictionary<string, object> { { "Name", "Tarzan" } }, "users/3");
                     newSession.SaveChanges();
 
-                    var queryResult = newSession.Query<Dictionary<string,object?>>()
+                    var queryResult = newSession.Query<Dictionary<string,object>>()
                         .ToList();
 
                     Assert.Equal(queryResult.Count, 3);
@@ -273,23 +273,20 @@ namespace FastTests.Client
             {
                 using (var newSession = store.OpenSession())
                 {
-                    newSession.Store(new Dictionary<string, object?> { { "Name", "John" } }, "users/1");
-                    newSession.Store(new Dictionary<string, object?> { { "Name", "Jane" } }, "users/2");
-                    newSession.Store(new Dictionary<string, object?> { { "Name", "Tarzan" } }, "users/3");
+                    newSession.Store(new Dictionary<string, object> { { "Name", "John" } }, "users/1");
+                    newSession.Store(new Dictionary<string, object> { { "Name", "Jane" } }, "users/2");
+                    newSession.Store(new Dictionary<string, object> { { "Name", "Tarzan" } }, "users/3");
                     newSession.SaveChanges();
-
-                    var query = newSession.Query<Dictionary<string, object?>>()
-                        .Where(x => ((string)x["Name"]).StartsWith("J")).ToString();
-
-                    var queryResult = newSession.Query<Dictionary<string, object?>>()
+                    
+                    var queryResult = newSession.Query<Dictionary<string, object>>()
                         .Where(x => ((string)x["Name"]).StartsWith("J"))
                         .ToList();
 
-                    var queryResult2 = newSession.Query<Dictionary<string, object?>>()
+                    var queryResult2 = newSession.Query<Dictionary<string, object>>()
                         .Where(x => ((string)x["Name"]).Equals("Tarzan"))
                         .ToList();
 
-                    var queryResult3 = newSession.Query<Dictionary<string, object?>>()
+                    var queryResult3 = newSession.Query<Dictionary<string, object>>()
                         .Where(x => ((string)x["Name"]).EndsWith("n"))
                         .ToList();
 
@@ -307,13 +304,13 @@ namespace FastTests.Client
             {
                 using (var newSession = store.OpenSession())
                 {
-                    newSession.Store(new Dictionary<string, object?> { { "Name", "Australia" } }, "continents/1");
-                    newSession.Store(new Dictionary<string, object?> { { "Name", "Europe" } }, "continents/2");
-                    newSession.Store(new Dictionary<string, object?> { { "Name", "America" } }, "continents/3");
+                    newSession.Store(new Dictionary<string, object> { { "Name", "Australia" } }, "continents/1");
+                    newSession.Store(new Dictionary<string, object> { { "Name", "Europe" } }, "continents/2");
+                    newSession.Store(new Dictionary<string, object> { { "Name", "America" } }, "continents/3");
                     newSession.SaveChanges();
 
-                    var queryResult = newSession.Query<Dictionary<string, object?>>()
-                        .Where(x => ((string?)x["Name"]) == "Australia").ToList();
+                    var queryResult = newSession.Query<Dictionary<string, object>>()
+                        .Where(x => ((string)x["Name"]) == "Australia").ToList();
 
                     Assert.Equal(queryResult.Count, 1);
                 }

--- a/test/FastTests/Client/Query.cs
+++ b/test/FastTests/Client/Query.cs
@@ -301,6 +301,26 @@ namespace FastTests.Client
         }
 
         [Fact]
+        public void Query_Dictionary_With_Where_Equality_Clause()
+        {
+            using (var store = GetDocumentStore())
+            {
+                using (var newSession = store.OpenSession())
+                {
+                    newSession.Store(new Dictionary<string, object?> { { "Name", "Australia" } }, "continents/1");
+                    newSession.Store(new Dictionary<string, object?> { { "Name", "Europe" } }, "continents/2");
+                    newSession.Store(new Dictionary<string, object?> { { "Name", "America" } }, "continents/3");
+                    newSession.SaveChanges();
+
+                    var queryResult = newSession.Query<Dictionary<string, object?>>()
+                        .Where(x => ((string?)x["Name"]) == "Australia").ToList();
+
+                    Assert.Equal(queryResult.Count, 1);
+                }
+            }
+        }
+
+        [Fact]
         public async Task QueryWithWhere_WhenUsingStringEquals_ShouldWork()
         {
             const string constStrToQuery = "Tarzan";


### PR DESCRIPTION
### Issue link

https://issues.hibernatingrhinos.com/issue/RavenDB-18957


### Type of change

- Bug fix


### How risky is the change?

- Moderate 


### Backward compatibility

- Not relevant

### Is it platform specific issue?

- No

### Documentation update

- No documentation update is needed 

### Testing 

- Tests have been added that prove the fix is effective or that the feature works


### Is there any existing behavior change of other features due to this change?

- It is touching LINQ translator, so maybe there is a case when this fix is affecting.

### UI work

- No UI work is needed
