### PR TITLE
Raven db 18862 Fix defference between total thread CPU usage to process CPU usage in Linux

### DIFF
--- a/src/Raven.Server/Dashboard/ThreadsInfo.cs
+++ b/src/Raven.Server/Dashboard/ThreadsInfo.cs
@@ -16,6 +16,8 @@ namespace Raven.Server.Dashboard
         public SortedSet<ThreadInfo> List { get; }
 
         public double CpuUsage { get; set; }
+        
+        public double ProcessCpuUsage { get; set; }
 
         public long ActiveCores { get; set; }
 
@@ -50,6 +52,7 @@ namespace Raven.Server.Dashboard
             {
                 [nameof(Date)] = Date,
                 [nameof(CpuUsage)] = CpuUsage,
+                [nameof(ProcessCpuUsage)] = ProcessCpuUsage,
                 [nameof(ActiveCores)] = ActiveCores,
                 [nameof(ThreadsCount)] = ThreadsCount,
                 [nameof(List)] = new DynamicJsonArray(List.Take(_take ?? int.MaxValue).Select(x => x.ToJson()))

--- a/src/Raven.Server/Utils/ThreadsUsage.cs
+++ b/src/Raven.Server/Utils/ThreadsUsage.cs
@@ -53,8 +53,8 @@ namespace Raven.Server.Utils
                 if (timeDiff == 0 || activeCores == 0)
                     return threadsInfo;
 
-                var cpuUsage = (processorTimeDiff * 100.0) / timeDiff / activeCores;
-                cpuUsage = Math.Min(cpuUsage, 100);
+                var processCpuUsage = (processorTimeDiff * 100.0) / timeDiff / activeCores;
+                processCpuUsage = Math.Min(processCpuUsage, 100);
 
                 var threadTimesInfo = new Dictionary<int, long>();
                 double totalCpuUsage = 0;
@@ -70,7 +70,7 @@ namespace Raven.Server.Utils
                         try
                         {
                             var threadTotalProcessorTime = thread.TotalProcessorTime;
-                            var threadCpuUsage = GetThreadCpuUsage(thread.Id, threadTotalProcessorTime, processorTimeDiff, cpuUsage, activeCores);
+                            var threadCpuUsage = GetThreadCpuUsage(thread.Id, threadTotalProcessorTime, processorTimeDiff, processCpuUsage);
                             threadTimesInfo[thread.Id] = threadTotalProcessorTime.Ticks;
                             if (threadCpuUsage == null)
                             {
@@ -131,6 +131,7 @@ namespace Raven.Server.Utils
 
                 _threadTimesInfo = threadTimesInfo;
                 threadsInfo.CpuUsage = Math.Min(totalCpuUsage, 100);
+                threadsInfo.ProcessCpuUsage = processCpuUsage;
                 return threadsInfo;
             }
         }
@@ -159,7 +160,7 @@ namespace Raven.Server.Utils
             }
         }
 
-        private double? GetThreadCpuUsage(int threadId, TimeSpan threadTotalProcessorTime, long processorTimeDiff, double cpuUsage, long activeCores)
+        private double? GetThreadCpuUsage(int threadId, TimeSpan threadTotalProcessorTime, long processorTimeDiff, double processCpuUsage)
         {
             if (_threadTimesInfo.TryGetValue(threadId, out var previousTotalProcessorTimeTicks) == false)
             {
@@ -174,16 +175,7 @@ namespace Raven.Server.Utils
                 return 0;
             }
 
-            var threadCpuUsage = threadTimeDiff * 1.0 / processorTimeDiff * cpuUsage;
-
-            if (PlatformDetails.RunningOnLinux)
-            {
-                // we need to divide the result by the number of cores since
-                // a .net thread is a process in linux
-                threadCpuUsage /= activeCores;
-            }
-
-            return threadCpuUsage;
+            return threadTimeDiff * 1.0 / processorTimeDiff * processCpuUsage;
         }
     }
 }


### PR DESCRIPTION
### Issue link
https://issues.hibernatingrhinos.com/issue/RavenDB-18862

### Additional description
The base calculation already contains the division by `activeCores` while we multiple it  by `processCpuUsage` (that equals to `(processorTimeDiff * 100.0) / timeDiff / activeCores`)

### Type of change
- Bug fix

### How risky is the change?
- Low 

### Backward compatibility
- Not relevant

### Is it platform specific issue?
- Yes. Linux.


### Documentation update
- No documentation update is needed 

### Testing 
- Tests have been added that prove the fix is effective or that the feature works

### Is there any existing behavior change of other features due to this change?
- No

### UI work
- No UI work is needed
