### PR TITLE
RavenDB-18760 - Failing InterversionTests on 5.3 and 5.4 branches

### DIFF
--- a/src/Raven.Server/Documents/Handlers/BatchHandler.cs
+++ b/src/Raven.Server/Documents/Handlers/BatchHandler.cs
@@ -617,7 +617,7 @@ namespace Raven.Server.Documents.Handlers
                         {
                             count++;
                             var changeVector = $"{ChangeVectorParser.RaftTag}:{count}-{Database.DatabaseGroupId}";
-                            if (options.DisableAtomicDocumentWrites == false)
+                            if (options.DisableAtomicDocumentWrites == false && Database.ClusterTransactionId != null)
                             {
                                 changeVector += $",{ChangeVectorParser.TrxnTag}:{command.Index}-{Database.ClusterTransactionId}";
                             }


### PR DESCRIPTION
### Issue link

https://issues.hibernatingrhinos.com/issue/RavenDB-18760/Failing-InterversionTests-on-53-and-54-branches

### Additional description

Fixed tests:
* **_InterversionTests.MixedClusterTests.UpgradeDirectlyFrom41X(initialVersions: ["4.1.7", "4.1.7", "4.1.7"])_**
* **_InterversionTests.MixedClusterTests.UpgradeToLatest_**

### Type of change

- Bug fix

### How risky is the change?

- Low 

### Backward compatibility

- Non breaking change

### Is it platform specific issue?

- No

### Documentation update

- No documentation update is needed 

### Testing 

- It has been verified by manual testing

### Is there any existing behavior change of other features due to this change?

- No

### UI work

- No UI work is needed
