### PR TITLE
Raven db 15427 Test fix and collecting info for further test failure invastigation

### DIFF
--- a/test/SlowTests/SparrowTests/LoggingSourceTests.cs
+++ b/test/SlowTests/SparrowTests/LoggingSourceTests.cs
@@ -97,15 +97,23 @@ namespace SlowTests.SparrowTests
                 Assert.All(toCheckLogFiles, toCheck =>
                 {
                     (string fileName, bool shouldExist) = toCheck;
-                    fileName = $"{fileName}{(compressing ? ".gz" : string.Empty)}";
-                    var fileInfo = new FileInfo(fileName);
+                    var found = Directory.GetFiles(path, Path.GetFileName(fileName) + '*');
                     if (shouldExist)
                     {
-                        Assert.True(fileInfo.Exists, $"The log file \"{fileInfo.Name}\" should be exist");
+                        Assert.True(found.Any(), $"The log file \"{fileName}\" should be exist");
                     }
                     else
                     {
-                        Assert.False(fileInfo.Exists, $"The log file \"{fileInfo.Name}\" last modified {fileInfo.LastWriteTime} should not be exist. retentionTime({retentionTime})");
+                        Assert.False(found.Any(), CreateErrorMessage());
+                        string CreateErrorMessage()
+                        {
+                            var messages = found.Select(f =>
+                            {
+                                var fileInfo = new FileInfo(found.First());
+                                return fileInfo.Exists ? $"\"{fileInfo.Name}\" last modified {fileInfo.LastWriteTime}" : string.Empty;
+                            });
+                            return $"The log files {string.Join(", ", messages)} should not be exist. retentionTime({retentionTime})";
+                        }
                     }
                 });
             }

--- a/test/SlowTests/SparrowTests/LoggingSourceTests.cs
+++ b/test/SlowTests/SparrowTests/LoggingSourceTests.cs
@@ -354,8 +354,6 @@ namespace SlowTests.SparrowTests
                 return Math.Abs(size - retentionSize) <= threshold;
             }, true, 10_000, 1_000);
 
-            loggingSource.EndLogging();
-
             string errorMessage = isRetentionPolicyApplied 
                 ? string.Empty
                 : $"{TempInfoToInvestigate(loggingSource, path)}. " +
@@ -363,6 +361,8 @@ namespace SlowTests.SparrowTests
                   Environment.NewLine + 
                   FileNamesWithSize(afterEndFiles);
 
+            loggingSource.EndLogging();
+            
             Assert.True(isRetentionPolicyApplied, errorMessage);
         }
 


### PR DESCRIPTION
### Issue link
https://issues.hibernatingrhinos.com/issue/RavenDB-15427

### Additional description
Include uncompressed files in exist file check
and the end of logging moved to after the collecting error data to get correct information.

### Type of change
- Test fix

### How risky is the change?
- Low 

### Backward compatibility
- Not relevant

### Is it platform specific issue?
- No

### Documentation update
- No documentation update is needed 

### Testing 
Not relevant

### Is there any existing behavior change of other features due to this change?
- No

### UI work
- No UI work is needed
