### PR TITLE
RavenDB-18959 Corax - Indexing performance improvements

### DIFF
--- a/src/Corax/IndexSearcher/IndexSearcher.cs
+++ b/src/Corax/IndexSearcher/IndexSearcher.cs
@@ -21,6 +21,7 @@ public sealed unsafe partial class IndexSearcher : IDisposable
     private readonly Transaction _transaction;
     private readonly IndexFieldsMapping _fieldMapping;
     private Page _lastPage = default;
+    private long? _numberOfEntries;
 
     /// <summary>
     /// When true no SIMD instruction will be used. Useful for checking that optimized algorithms behave in the same
@@ -30,7 +31,7 @@ public sealed unsafe partial class IndexSearcher : IDisposable
 
     public bool IsAccelerated => Avx2.IsSupported && !ForceNonAccelerated;
 
-    public long NumberOfEntries => _metadataTree?.ReadInt64(Constants.IndexWriter.NumberOfEntriesSlice) ?? 0;
+    public long NumberOfEntries => _numberOfEntries ??= _metadataTree?.ReadInt64(Constants.IndexWriter.NumberOfEntriesSlice) ?? 0;
 
     internal ByteStringContext Allocator => _transaction.Allocator;
 

--- a/src/Raven.Server/Documents/Indexes/Persistence/Corax/AnonymousCoraxDocumentConverter.cs
+++ b/src/Raven.Server/Documents/Indexes/Persistence/Corax/AnonymousCoraxDocumentConverter.cs
@@ -1,4 +1,5 @@
 using System;
+using System.Collections.Generic;
 using Amazon.SimpleNotificationService.Model;
 using Corax;
 using Raven.Client.Documents.Indexes;
@@ -45,21 +46,19 @@ public class AnonymousCoraxDocumentConverter : CoraxDocumentConverterBase
         var scope = new SingleEntryWriterScope(_allocator);
         var storedValue = _storeValue ? new DynamicJsonValue() : null;
 
-
         foreach (var property in accessor.GetPropertiesInOrder(documentToProcess))
         {
             var value = property.Value;
 
             IndexField field;
-            if (knownFields.TryGetByFieldName(property.Key, out var binding))
+            try
             {
                 field = _fields[property.Key];
-                field.Id = binding.FieldId;
             }
-            else
+            catch (KeyNotFoundException e)
             {
-                throw new InvalidOperationException($"Field '{property.Key}' is not defined. Available fields: {string.Join(", ", _fields.Keys)}.");
-            }            
+                throw new InvalidOperationException($"Field '{property.Key}' is not defined. Available fields: {string.Join(", ", _fields.Keys)}.", e);
+            }
 
             if (storedValue is not null)
             {

--- a/src/Raven.Server/Documents/Indexes/Persistence/Lucene/LuceneAnalyzerAdapter.cs
+++ b/src/Raven.Server/Documents/Indexes/Persistence/Lucene/LuceneAnalyzerAdapter.cs
@@ -20,14 +20,14 @@ namespace Raven.Server.Documents.Indexes.Persistence.Corax
         private readonly LuceneAnalyzer _analyzer;
 
         private LuceneAnalyzerAdapter(LuceneAnalyzer analyzer,
-            delegate*<Analyzer, ReadOnlySpan<byte>, ref Span<byte>, ref Span<Token>, void> functionUtf8,
+            delegate*<Analyzer, ReadOnlySpan<byte>, ref Span<byte>, ref Span<Token>, ref byte[], void> functionUtf8,
             delegate*<Analyzer, ReadOnlySpan<char>, ref Span<char>, ref Span<Token>, void> functionUtf16) : 
             base(functionUtf8, functionUtf16, default(NullTokenizer), NoTransformers)
         {
             _analyzer = analyzer;
         }
 
-        internal static void Run(Analyzer adapter, ReadOnlySpan<byte> source, ref Span<byte> output, ref Span<Token> tokens)
+        internal static void Run(Analyzer adapter, ReadOnlySpan<byte> source, ref Span<byte> output, ref Span<Token> tokens, ref byte[] buffer)
         {
             var @this = (LuceneAnalyzerAdapter)adapter;
             var analyzer = @this._analyzer;


### PR DESCRIPTION
### Issue link

https://issues.hibernatingrhinos.com/issue/RavenDB-18959

### Additional description

This PR contains three changes:
1. Do not update `NumberOfEntries` per each document inserted/removed.
     Currently, we're updating it at the end of a batch.
2. Do not `TryGetBindingByName`
      We changed the way of setting ID per Field a couple of weeks ago. Such a clause is no longer needed because it is already made on a higher level.
3. Do not rent a buffer for UTF8 per term.
     We can easily create a local buffer for that in IndexWriter. Also left the implementation for Querying where we do not try to cache it.  In such a case, we return it immediately. 

### Type of change

- Optimization

### How risky is the change?

- Low 


### Backward compatibility

- Not relevant

### Is it platform specific issue?

- No

### Documentation update

- No documentation update is needed 

### Testing 

- Tests have been added that prove the fix is effective or that the feature works

### Is there any existing behavior change of other features due to this change?

- No

### UI work

- No UI work is needed
