### PR TITLE
RavenDB-18951 - Fix Bulk_Insert_2NodesDown_1NodeRestart/Should_Throw_…

### DIFF
--- a/src/Raven.Client/Documents/Subscriptions/SubscriptionWorker.cs
+++ b/src/Raven.Client/Documents/Subscriptions/SubscriptionWorker.cs
@@ -735,7 +735,7 @@ namespace Raven.Client.Documents.Subscriptions
                                 var nextNodeIndex = (_forcedTopologyUpdateAttempts++) % curTopology.Count;
                                 try
                                 {
-                                    (_, _redirectNode) = await reqEx.GetRequestedNode(curTopology[nextNodeIndex].ClusterTag, true).ConfigureAwait(false);
+                                    (_, _redirectNode) = await reqEx.GetRequestedNode(curTopology[nextNodeIndex].ClusterTag, throwIfContainsFailures: true).ConfigureAwait(false);
                                     if (_logger.IsInfoEnabled)
                                         _logger.Info($"Subscription '{_options.SubscriptionName}'. Will modify redirect node from null to {_redirectNode.ClusterTag}", ex);
                                 }

--- a/src/Raven.Client/Documents/Subscriptions/SubscriptionWorker.cs
+++ b/src/Raven.Client/Documents/Subscriptions/SubscriptionWorker.cs
@@ -735,7 +735,7 @@ namespace Raven.Client.Documents.Subscriptions
                                 var nextNodeIndex = (_forcedTopologyUpdateAttempts++) % curTopology.Count;
                                 try
                                 {
-                                    (_, _redirectNode) = await reqEx.GetRequestedNode(curTopology[nextNodeIndex].ClusterTag).ConfigureAwait(false);
+                                    (_, _redirectNode) = await reqEx.GetRequestedNode(curTopology[nextNodeIndex].ClusterTag, true).ConfigureAwait(false);
                                     if (_logger.IsInfoEnabled)
                                         _logger.Info($"Subscription '{_options.SubscriptionName}'. Will modify redirect node from null to {_redirectNode.ClusterTag}", ex);
                                 }

--- a/src/Raven.Client/Http/NodeSelector.cs
+++ b/src/Raven.Client/Http/NodeSelector.cs
@@ -92,7 +92,7 @@ namespace Raven.Client.Http
             throw new RequestedNodeUnavailableException($"Could not find requested node {nodeTag}.");
         }
 
-        public bool NodeIsAvailable(int index)
+        internal bool NodeIsAvailable(int index)
         {
             return _state.Failures[index] == 0;
         }

--- a/src/Raven.Client/Http/NodeSelector.cs
+++ b/src/Raven.Client/Http/NodeSelector.cs
@@ -17,6 +17,7 @@ namespace Raven.Client.Http
             public readonly int[] FastestRecords;
             public int Fastest;
             public int SpeedTestMode;
+            public int CurrentNodeIndex;
 
             public NodeSelectorState(Topology topology)
             {
@@ -24,6 +25,7 @@ namespace Raven.Client.Http
                 Nodes = topology.Nodes;
                 Failures = new int[topology.Nodes.Count];
                 FastestRecords = new int[topology.Nodes.Count];
+                CurrentNodeIndex = 0;
             }
         }        
 
@@ -129,7 +131,9 @@ namespace Raven.Client.Http
             if (state.Nodes.Count == 0)
                 throw new DatabaseDoesNotExistException("There are no nodes in the topology at all");
 
-            return (0, state.Nodes[0]);
+            int index = state.CurrentNodeIndex;
+            state.CurrentNodeIndex = (state.CurrentNodeIndex+1)%state.Nodes.Count;
+            return (index, state.Nodes[index]);
         }
 
         public (int Index, ServerNode Node) GetNodeBySessionId(int sessionId)

--- a/src/Raven.Client/Http/NodeSelector.cs
+++ b/src/Raven.Client/Http/NodeSelector.cs
@@ -74,10 +74,7 @@ namespace Raven.Client.Http
         internal (int Index, ServerNode Node) GetRequestedNode(string nodeTag)
         {
             var state = _state;
-            var stateFailures = state.Failures;
             var serverNodes = state.Nodes;
-
-            Debug.Assert(serverNodes.Count == stateFailures.Length, $"Expected equals {serverNodes.Count}, but got {stateFailures.Length}");
 
             for (var i = 0; i < serverNodes.Count; i++)
             {
@@ -93,6 +90,11 @@ namespace Raven.Client.Http
                 throw new DatabaseDoesNotExistException("There are no nodes in the topology.");
 
             throw new RequestedNodeUnavailableException($"Could not find requested node {nodeTag}.");
+        }
+
+        public bool NodeIsAvailable(int index)
+        {
+            return _state.Failures[index] == 0;
         }
 
         public (int Index, ServerNode Node) GetPreferredNode()

--- a/src/Raven.Client/Http/RequestExecutor.cs
+++ b/src/Raven.Client/Http/RequestExecutor.cs
@@ -2133,11 +2133,16 @@ namespace Raven.Client.Http
             }
         }
 
-        public async Task<(int Index, ServerNode Node)> GetRequestedNode(string nodeTag)
+        public async Task<(int Index, ServerNode Node)> GetRequestedNode(string nodeTag, bool checkIfAvailable = false)
         {
             await EnsureNodeSelector().ConfigureAwait(false);
+            (var index, var node) = _nodeSelector.GetRequestedNode(nodeTag);
+            if (checkIfAvailable && !_nodeSelector.NodeIsAvailable(index))
+            {
+                throw new RequestedNodeUnavailableException($"Requested node {nodeTag} currently unavailable, please try again later.");
+            }
 
-            return _nodeSelector.GetRequestedNode(nodeTag);
+            return (index, node);
         }
 
         public async Task<(int Index, ServerNode Node)> GetPreferredNode()

--- a/src/Raven.Client/Http/RequestExecutor.cs
+++ b/src/Raven.Client/Http/RequestExecutor.cs
@@ -2133,11 +2133,16 @@ namespace Raven.Client.Http
             }
         }
 
-        public async Task<(int Index, ServerNode Node)> GetRequestedNode(string nodeTag, bool checkIfAvailable = false)
+        public async Task<(int Index, ServerNode Node)> GetRequestedNode(string nodeTag)
         {
             await EnsureNodeSelector().ConfigureAwait(false);
-            (var index, var node) = _nodeSelector.GetRequestedNode(nodeTag);
-            if (checkIfAvailable && !_nodeSelector.NodeIsAvailable(index))
+            return _nodeSelector.GetRequestedNode(nodeTag);
+        }
+
+        internal async Task<(int Index, ServerNode Node)> GetRequestedNode(string nodeTag, bool throwIfContainsFailures)
+        {
+            (var index, var node) = await GetRequestedNode(nodeTag).ConfigureAwait(false);
+            if (throwIfContainsFailures && _nodeSelector.NodeIsAvailable(index) == false)
             {
                 throw new RequestedNodeUnavailableException($"Requested node {nodeTag} currently unavailable, please try again later.");
             }


### PR DESCRIPTION
…AllTopologyNodesDownException failures.

### Issue link

https://issues.hibernatingrhinos.com/issue/RavenDB-18951/SlowTestsIssuesRavenDB17903BulkInsert2NodesDown1NodeRestart
https://issues.hibernatingrhinos.com/issue/RavenDB-18952/SlowTestsIssuesRavenDB17903ShouldThrowAllTopologyNodesDownException

### Additional description

Fix Bulk_Insert_2NodesDown_1NodeRestart/Should_Throw_AllTopologyNodesDownException failures.

### Type of change

- Bug fix

### How risky is the change?

- Low 

### Backward compatibility

- Not relevant

### Is it platform specific issue?

- No

### Documentation update

- No documentation update is needed 

### Testing 

- Tests have been added that prove the fix is effective or that the feature works

### Is there any existing behavior change of other features due to this change?

- No

### UI work

- No UI work is needed
