### PR TITLE
RavenDB-16488  Cluster dashboard - Storage widget - Scaled settings

### DIFF
--- a/src/Raven.Studio/typescript/models/resources/widgets/mountPointUsage.ts
+++ b/src/Raven.Studio/typescript/models/resources/widgets/mountPointUsage.ts
@@ -11,6 +11,7 @@ class mountPointUsage {
     ravendbToUsedSpacePercentage: KnockoutComputed<number>;
 
     mountPointLabel: KnockoutComputed<string>;
+    scaleFactor = ko.observable<number>();
 
     constructor() {
         this.mountPointLabel = ko.pureComputed(() => {

--- a/src/Raven.Studio/typescript/viewmodels/resources/widgets/settings/storageWidgetSettings.ts
+++ b/src/Raven.Studio/typescript/viewmodels/resources/widgets/settings/storageWidgetSettings.ts
@@ -1,14 +1,14 @@
 import dialogViewModelBase = require("viewmodels/dialogViewModelBase");
-import storageKeyProvider = require("common/storage/storageKeyProvider");
+import dialog = require("plugins/dialog");
 
 class storageWidgetSettings extends dialogViewModelBase {
 
-    static localStorageName = storageKeyProvider.storageKeyFor("storageWidgetScaleSettings");
     scaleDriveSize = ko.observable<boolean>();
 
-    activate() {
-        const savedSettings: boolean = localStorage.getObject(storageWidgetSettings.localStorageName);
-        this.scaleDriveSize(savedSettings);
+    constructor(scaleToSize: boolean) {
+        super();
+        
+        this.scaleDriveSize(scaleToSize);
     }
 
     compositionComplete() {
@@ -18,8 +18,7 @@ class storageWidgetSettings extends dialogViewModelBase {
     }
 
     saveSettings() {
-        localStorage.setObject(storageWidgetSettings.localStorageName, this.scaleDriveSize());
-        this.close();
+        dialog.close(this, this.scaleDriveSize());
     }
 }
 

--- a/src/Raven.Studio/typescript/viewmodels/resources/widgets/settings/storageWidgetSettings.ts
+++ b/src/Raven.Studio/typescript/viewmodels/resources/widgets/settings/storageWidgetSettings.ts
@@ -1,0 +1,26 @@
+import dialogViewModelBase = require("viewmodels/dialogViewModelBase");
+import storageKeyProvider = require("common/storage/storageKeyProvider");
+
+class storageWidgetSettings extends dialogViewModelBase {
+
+    static localStorageName = storageKeyProvider.storageKeyFor("storageWidgetScaleSettings");
+    scaleDriveSize = ko.observable<boolean>();
+
+    activate() {
+        const savedSettings: boolean = localStorage.getObject(storageWidgetSettings.localStorageName);
+        this.scaleDriveSize(savedSettings);
+    }
+
+    compositionComplete() {
+        super.compositionComplete();
+
+        $('.storage-widget-settings [data-toggle="tooltip"]').tooltip();
+    }
+
+    saveSettings() {
+        localStorage.setObject(storageWidgetSettings.localStorageName, this.scaleDriveSize());
+        this.close();
+    }
+}
+
+export = storageWidgetSettings;

--- a/src/Raven.Studio/typescript/viewmodels/resources/widgets/widget.ts
+++ b/src/Raven.Studio/typescript/viewmodels/resources/widgets/widget.ts
@@ -110,6 +110,10 @@ abstract class widget<TConfig = unknown, TState = unknown> {
     restoreConfiguration(config: TConfig) {
         // empty by default
     }
+
+    openWidgetSettings(): void {
+        // empty by default
+    }
     
     dispose() {
         if (this.syncUpdateTaskId > 0) {

--- a/src/Raven.Studio/typescript/viewmodels/resources/widgets/widget.ts
+++ b/src/Raven.Studio/typescript/viewmodels/resources/widgets/widget.ts
@@ -110,10 +110,6 @@ abstract class widget<TConfig = unknown, TState = unknown> {
     restoreConfiguration(config: TConfig) {
         // empty by default
     }
-
-    openWidgetSettings(): void {
-        // empty by default
-    }
     
     dispose() {
         if (this.syncUpdateTaskId > 0) {

--- a/src/Raven.Studio/wwwroot/App/views/resources/widgets/settings/storageWidgetSettings.html
+++ b/src/Raven.Studio/wwwroot/App/views/resources/widgets/settings/storageWidgetSettings.html
@@ -1,0 +1,37 @@
+<div class="modal-dialog storage-widget-settings" role="document">
+    <div class="modal-content" tabindex="-1">
+        <div class="modal-header">
+            <div class="flex-horizontal">
+                <div class="flex-grow">
+                    <h3>Storage Widget Settings</h3>
+                </div>
+                <div>
+                    <button type="button" class="close" data-bind="click: close" aria-hidden="true">
+                        <i class="icon-cancel"></i>
+                    </button>
+                </div>
+            </div>
+        </div>
+        <div class="modal-body">
+            <div class="flex-form">
+                <div class="form-group">
+                    <label class="control-label">&nbsp;</label>
+                    <div class="toggle">
+                        <div data-placement="right" data-toggle="tooltip" title="Toggle on to show scaled size" data-animation="true">
+                            <input id="scaleToggle" type="checkbox" data-bind="checked: scaleDriveSize">
+                            <label for="scaleToggle">Scale drive size</label>
+                        </div>
+                    </div>
+                </div>
+            </div>
+        </div>
+        <div class="modal-footer">
+            <div class="text-right">
+                <button type="button" class=" btn btn-default" data-bind="click: close"><i class="icon-cancel"></i><span>Cancel</span></button>
+                <button data-bind="click: saveSettings" type="button" class="btn btn-primary">
+                    <i class="icon-save"></i><span>Save</span>
+                </button>
+            </div>
+        </div>
+    </div>
+</div>

--- a/src/Raven.Studio/wwwroot/App/views/resources/widgets/storageWidget.html
+++ b/src/Raven.Studio/wwwroot/App/views/resources/widgets/storageWidget.html
@@ -1,6 +1,9 @@
 <div>
     <div class="cluster-dashboard-item-header">
         <h3> <i class="icon-storage"></i> <span>Storage</span></h3>
+        <button class="btn btn-default btn-sm" data-bind="click: openWidgetSettings" title="Open widget settings">
+            <i class="icon-settings"></i>
+        </button>
         <button class="btn btn-warning btn-sm" data-bind="click: remove" title="Remove widget from board">
             <i class="icon-trash"></i>
         </button>
@@ -21,17 +24,17 @@
                         <div class="details-list" data-bind="foreach: mountPoints">
                             <div class="mount" data-bind="text: mountPointLabel, visible: $parent.mountPoints().length > 1"></div>
                             <div class="storage-legend">
-                                <div class="storage-ravendb" data-toggle="tooltip" data-placement="top" title="RavenDB" 
+                                <div class="storage-ravendb" data-toggle="tooltip" data-placement="top" title="Used by RavenDB"
                                      data-bind="text: $root.sizeFormatter(ravenSize())"></div>
-                                <div class="storage-used" data-toggle="tooltip" data-placement="top" title="Storage Used"
+                                <div class="storage-used" data-toggle="tooltip" data-placement="top" title="Storage used"
                                     data-bind="text: $root.sizeFormatter(usedSpace())"></div>
                                 <div class="storage-free" data-toggle="tooltip" data-placement="top" title="Free"
                                     data-bind="text: $root.sizeFormatter(freeSpace())"></div>
                                 <div class="flex-grow"></div>
-                                <div class="storage-total" data-toggle="tooltip" data-placement="top" title="Storage Available"
+                                <div class="storage-total" data-toggle="tooltip" data-placement="top" title="Total storage available"
                                     data-bind="text: $root.sizeFormatter(totalCapacity())"></div>
                             </div>
-                            <div class="storage-chart">
+                            <div class="storage-chart" data-bind="style: { width: scaleFactor() + '%' }">
                                 <div class="storage-used" data-bind="style: { width: usedSpacePercentage() + '%' }">
                                     <div class="storage-ravendb" data-bind="style: { width: ravendbToUsedSpacePercentage() + '%' }"></div>
                                 </div>

--- a/src/Raven.Studio/wwwroot/Content/css/pages/cluster-dashboard.less
+++ b/src/Raven.Studio/wwwroot/Content/css/pages/cluster-dashboard.less
@@ -432,7 +432,6 @@
 
                     .storage-chart {
                         display: flex;
-                        width: 100%;
                         height: @gutter-xxs;
                         box-shadow: 0 0 0 1px @hr-border inset;
                         font-size: 11px;


### PR DESCRIPTION
### Issue link
https://issues.hibernatingrhinos.com/issue/RavenDB-16488

### Additional description
* Add Settings btn to widget
* Allow to scale/unscale

### Type of change
- New feature

### How risky is the change?
- Low 

### Backward compatibility
- Non breaking change

### Is it platform specific issue?
- No

### Documentation update
- This change requires a documentation update. 

### Testing 
- It has been verified by manual testing

### Is there any existing behavior change of other features due to this change?
- No

### UI work
- No UI work is needed
