### PR TITLE
RavenDB-17275 Fix stripes after clicking up/down sort buttons & when …

### DIFF
--- a/src/Raven.Studio/typescript/widgets/virtualGrid/virtualRow.ts
+++ b/src/Raven.Studio/typescript/widgets/virtualGrid/virtualRow.ts
@@ -88,15 +88,11 @@ class virtualRow {
             
             if (!this._disableStripes) {
                 // Update the "even" status. Used for striping the virtual rows.
-                const newEvenState = rowIndex % 2 === 0;
-                const hasChangedEven = this._even !== newEvenState;
-                if (hasChangedEven) {
-                    this._even = newEvenState;
-                    if (this._even) {
-                        this.element.addClass("even");
-                    } else {
-                        this.element.removeClass("even");
-                    }
+                this._even = rowIndex % 2 === 0;
+                if (this._even) {
+                    this.element.addClass("even");
+                } else {
+                    this.element.removeClass("even");
                 }
             }
 


### PR DESCRIPTION
…scrolling

### Issue link
https://issues.hibernatingrhinos.com/issue/RavenDB-17275

### Additional description
With this fix the stripes show correctly for both:
* Scrolling
* Clicking up/down buttons

### Type of change
- Bug fix

### How risky is the change?
- Low 

### Backward compatibility
- Non breaking change

### Is it platform specific issue?
- No

### Documentation update
- No documentation update is needed 

### Testing  
- It has been verified by manual testing

### Is there any existing behavior change of other features due to this change?
- No

### UI work
- No UI work is needed
