### PR TITLE
RavenDB-18991 -  QueriesShouldFailoverIfIndexIsCompact…

### DIFF
--- a/test/SlowTests/Issues/RavenDB-18554.cs
+++ b/test/SlowTests/Issues/RavenDB-18554.cs
@@ -246,7 +246,7 @@ namespace SlowTests.Issues
 
                 // Wait for indexing in first node and second node
                 var index = new Categoroies_Details();
-                var result = await CreateIndex(store, index);
+                var result = await Cluster.CreateIndexInClusterAsync(store, index);
                 Assert.NotNull(result);
                 // wait for index creation on cluster
                 await Cluster.WaitForRaftIndexToBeAppliedInClusterAsync(result.RaftCommandIndex);

--- a/test/SlowTests/Issues/RavenDB-18554.cs
+++ b/test/SlowTests/Issues/RavenDB-18554.cs
@@ -246,7 +246,7 @@ namespace SlowTests.Issues
 
                 // Wait for indexing in first node and second node
                 var index = new Categoroies_Details();
-                var result = await Indexes.CreateIndex(store, index);
+                var result = await CreateIndex(store, index);
                 Assert.NotNull(result);
                 // wait for index creation on cluster
                 await Cluster.WaitForRaftIndexToBeAppliedInClusterAsync(result.RaftCommandIndex);

--- a/test/SlowTests/Issues/RavenDB-18554.cs
+++ b/test/SlowTests/Issues/RavenDB-18554.cs
@@ -246,10 +246,7 @@ namespace SlowTests.Issues
 
                 // Wait for indexing in first node and second node
                 var index = new Categoroies_Details();
-                var result = await Cluster.CreateIndexInClusterAsync(store, index);
-                Assert.NotNull(result);
-                // wait for index creation on cluster
-                await Cluster.WaitForRaftIndexToBeAppliedInClusterAsync(result.RaftCommandIndex);
+                await Cluster.CreateIndexInClusterAsync(store, index);
 
                 foreach (var n in nodes)
                 {

--- a/test/Tests.Infrastructure/ClusterTestBase.cs
+++ b/test/Tests.Infrastructure/ClusterTestBase.cs
@@ -12,8 +12,6 @@ using System.Threading.Tasks;
 using FastTests;
 using Raven.Client.Documents;
 using Raven.Client.Documents.Conventions;
-using Raven.Client.Documents.Indexes;
-using Raven.Client.Documents.Operations.Indexes;
 using Raven.Client.Documents.Session;
 using Raven.Client.Exceptions;
 using Raven.Client.Http;
@@ -65,13 +63,6 @@ namespace Tests.Infrastructure
             options.RunInMemory = false; 
 
             return base.GetDocumentStore(options, caller);
-        }
-
-        public async Task<PutIndexResult> CreateIndex(IDocumentStore store, AbstractIndexCreationTask index)
-        {
-            var results = await store.Maintenance.ForDatabase(store.Database).SendAsync(new PutIndexesOperation(index.CreateIndexDefinition()));
-            var filterredResults = results.Where(r => r.Index == index.IndexName).ToArray();
-            return filterredResults.Length == 1 ? filterredResults[0] : null;
         }
 
         protected void NoTimeouts()

--- a/test/Tests.Infrastructure/ClusterTestBase.cs
+++ b/test/Tests.Infrastructure/ClusterTestBase.cs
@@ -12,6 +12,8 @@ using System.Threading.Tasks;
 using FastTests;
 using Raven.Client.Documents;
 using Raven.Client.Documents.Conventions;
+using Raven.Client.Documents.Indexes;
+using Raven.Client.Documents.Operations.Indexes;
 using Raven.Client.Documents.Session;
 using Raven.Client.Exceptions;
 using Raven.Client.Http;
@@ -63,6 +65,13 @@ namespace Tests.Infrastructure
             options.RunInMemory = false; 
 
             return base.GetDocumentStore(options, caller);
+        }
+
+        public async Task<PutIndexResult> CreateIndex(IDocumentStore store, AbstractIndexCreationTask index)
+        {
+            var results = await store.Maintenance.ForDatabase(store.Database).SendAsync(new PutIndexesOperation(index.CreateIndexDefinition()));
+            var filterredResults = results.Where(r => r.Index == index.IndexName).ToArray();
+            return filterredResults.Length == 1 ? filterredResults[0] : null;
         }
 
         protected void NoTimeouts()

--- a/test/Tests.Infrastructure/RavenTestBase.Indexes.cs
+++ b/test/Tests.Infrastructure/RavenTestBase.Indexes.cs
@@ -30,13 +30,6 @@ public partial class RavenTestBase
         {
             _parent = parent ?? throw new ArgumentNullException(nameof(parent));
         }
-		
-		public async Task<PutIndexResult> CreateIndex(IDocumentStore store, AbstractIndexCreationTask index)
-        {
-            var results = await store.Maintenance.ForDatabase(store.Database).SendAsync(new PutIndexesOperation(index.CreateIndexDefinition()));
-            var filterredResults = results.Where(r => r.Index == index.IndexName).ToArray();
-            return filterredResults.Length == 1 ? filterredResults[0] : null;
-        }
 
 
         public void WaitForIndexing(IDocumentStore store, string dbName = null, TimeSpan? timeout = null, bool allowErrors = false, string nodeTag = null)

--- a/test/Tests.Infrastructure/RavenTestBase.Indexes.cs
+++ b/test/Tests.Infrastructure/RavenTestBase.Indexes.cs
@@ -4,7 +4,6 @@ using System.Diagnostics;
 using System.IO;
 using System.Linq;
 using System.Threading;
-using System.Threading.Tasks;
 using Raven.Client;
 using Raven.Client.Documents;
 using Raven.Client.Documents.Indexes;

--- a/test/Tests.Infrastructure/RavenTestBase.Indexes.cs
+++ b/test/Tests.Infrastructure/RavenTestBase.Indexes.cs
@@ -4,6 +4,7 @@ using System.Diagnostics;
 using System.IO;
 using System.Linq;
 using System.Threading;
+using System.Threading.Tasks;
 using Raven.Client;
 using Raven.Client.Documents;
 using Raven.Client.Documents.Indexes;
@@ -29,6 +30,14 @@ public partial class RavenTestBase
         {
             _parent = parent ?? throw new ArgumentNullException(nameof(parent));
         }
+		
+		public async Task<PutIndexResult> CreateIndex(IDocumentStore store, AbstractIndexCreationTask index)
+        {
+            var results = await store.Maintenance.ForDatabase(store.Database).SendAsync(new PutIndexesOperation(index.CreateIndexDefinition()));
+            var filterredResults = results.Where(r => r.Index == index.IndexName).ToArray();
+            return filterredResults.Length == 1 ? filterredResults[0] : null;
+        }
+
 
         public void WaitForIndexing(IDocumentStore store, string dbName = null, TimeSpan? timeout = null, bool allowErrors = false, string nodeTag = null)
         {


### PR DESCRIPTION
### Issue link

https://issues.hibernatingrhinos.com/issue/RavenDB-18991

### Additional description

Fixing QueriesShouldFailoverIfIndexIsCompactingClaster failure.

### Type of change

- Bug fix

### How risky is the change?

- Low 

### Backward compatibility

- Not relevant

### Is it platform specific issue?

- No

### Documentation update

- No documentation update is needed 

### Testing 

- Tests have been added that prove the fix is effective or that the feature works

### Is there any existing behavior change of other features due to this change?

- No

### UI work

- No UI work is needed
