### PR TITLE
RavenDB-19002 Fixing possible leak of DocumentDatabase instances by making sure that ResourceUsage<T>.TryRemove() removes the isntance that  we really want and pass via the parameter.

### DIFF
--- a/src/Raven.Server/Documents/DatabasesLandlord.cs
+++ b/src/Raven.Server/Documents/DatabasesLandlord.cs
@@ -583,7 +583,7 @@ namespace Raven.Server.Documents
 
                     if (database.IsFaulted || database.IsCanceled)
                     {
-                        DatabasesCache.TryRemove(databaseName, out database);
+                        DatabasesCache.TryRemove(databaseName, database);
                         LastRecentlyUsed.TryRemove(databaseName, out var _);
                         // and now we will try creating it again
                     }
@@ -956,12 +956,12 @@ namespace Raven.Server.Documents
 
                 return new DisposableAction(() =>
                 {
-                    DatabasesCache.TryRemove(dbName, out var _);
+                    DatabasesCache.TryRemove(dbName, tcs);
                 });
             }
             catch (Exception)
             {
-                DatabasesCache.TryRemove(dbName, out var _);
+                DatabasesCache.TryRemove(dbName, tcs);
                 throw;
             }
         }

--- a/test/RachisTests/DatabaseCluster/ClusterDatabaseMaintenance.cs
+++ b/test/RachisTests/DatabaseCluster/ClusterDatabaseMaintenance.cs
@@ -479,8 +479,7 @@ namespace RachisTests.DatabaseCluster
                 int val;
                 using (new DisposableAction(() =>
                 {
-                    preferred.ServerStore.DatabasesLandlord.DatabasesCache.TryRemove(databaseName, out var t);
-                    if (t == tcs.Task)
+                    if (preferred.ServerStore.DatabasesLandlord.DatabasesCache.TryRemove(databaseName, tcs.Task))
                         tcs.SetCanceled();
                 }))
                 {

--- a/test/SlowTests/Issues/RavenDB_19002.cs
+++ b/test/SlowTests/Issues/RavenDB_19002.cs
@@ -1,0 +1,123 @@
+﻿using System;
+using System.Collections.Generic;
+using System.Threading;
+using System.Threading.Tasks;
+using FastTests;
+using Raven.Server.Documents;
+using Sparrow.Threading;
+using Xunit;
+using Xunit.Abstractions;
+
+namespace SlowTests.Issues;
+
+public class RavenDB_19002 : NoDisposalNeeded
+{
+    public RavenDB_19002(ITestOutputHelper output) : base(output)
+    {
+    }
+
+    private class MyDb : IDisposable
+    {
+        public string Name { get; }
+
+        private readonly DisposeOnce<SingleAttempt> _disposeOnce;
+
+        public MyDb(string name)
+        {
+            Name = name;
+            _disposeOnce = new DisposeOnce<SingleAttempt>(() => { });
+        }
+
+        public bool IsDisposed => _disposeOnce.Disposed;
+
+        public void Dispose()
+        {
+            _disposeOnce.Dispose();
+        }
+    }
+
+    [Fact]
+    public void ResourceCacheMustNotAllowToLeakDatabaseInstance()
+    {
+        var dbsCache = new ResourceCache<MyDb>();
+
+        var dbName = "foo";
+
+        var createdDbs = new List<MyDb>();
+
+        var task1 = new Task<MyDb>(() =>
+        {
+            var myDb = new MyDb(dbName);
+
+            createdDbs.Add(myDb);
+
+            return myDb;
+        }, TaskCreationOptions.RunContinuationsAsynchronously);
+
+        var database1 = dbsCache.GetOrAdd(dbName, task1);
+
+        if (database1 == task1)
+        {
+            task1.Start();
+            task1.Wait();
+
+            dbsCache.ForTestingPurposesOnly().OnRemoveLockAndReturnDispose = cache =>
+            {
+                cache.ForTestingPurposesOnly().OnRemoveLockAndReturnDispose = null;
+
+                cache.TryGetValue(dbName, out var current);
+                cache.TryRemove(dbName, current); // might be run from different thread
+
+                var task2 = new Task<MyDb>(() =>
+                {
+                    var myDb = new MyDb(dbName);
+
+                    createdDbs.Add(myDb);
+
+                    return myDb;
+                }, TaskCreationOptions.RunContinuationsAsynchronously);
+
+                var database2 = dbsCache.GetOrAdd(dbName, task2); // might be run from different thread
+
+                if (database2 == task2)
+                {
+                    task2.Start();
+                    task2.Wait();
+                }
+            };
+
+            using (dbsCache.RemoveLockAndReturn(dbName, x => x.Dispose(), out _))
+            {
+
+            }
+        }
+
+        var task3 = new Task<MyDb>(() =>
+        {
+            var myDb = new MyDb(dbName);
+
+            createdDbs.Add(myDb);
+
+            return myDb;
+        }, TaskCreationOptions.RunContinuationsAsynchronously);
+
+        var database3 = dbsCache.GetOrAdd(dbName, task3);
+        if (database3 == task3)
+        {
+            task3.Start();
+            task3.Wait();
+        }
+
+        using (dbsCache.RemoveLockAndReturn(dbName, x => x.Dispose(), out var db))
+        {
+
+        }
+
+        Assert.Equal(2, createdDbs.Count);
+
+        foreach (var db in createdDbs)
+        {
+            Assert.True(db.IsDisposed);
+        }
+    }
+}

--- a/test/StressTests/Rachis/DatabaseCluster/ClusterDatabaseMaintenanceStress.cs
+++ b/test/StressTests/Rachis/DatabaseCluster/ClusterDatabaseMaintenanceStress.cs
@@ -62,8 +62,7 @@ namespace StressTests.Rachis.DatabaseCluster
                 int val;
                 using (new DisposableAction(() =>
                 {
-                    preferred.ServerStore.DatabasesLandlord.DatabasesCache.TryRemove(databaseName, out var t);
-                    if (t == tcs.Task)
+                    if (preferred.ServerStore.DatabasesLandlord.DatabasesCache.TryRemove(databaseName, tcs.Task))
                         tcs.SetCanceled();
                 }))
                 {
@@ -129,8 +128,7 @@ namespace StressTests.Rachis.DatabaseCluster
                 int val;
                 using (new DisposableAction(() =>
                 {
-                    preferred.ServerStore.DatabasesLandlord.DatabasesCache.TryRemove(databaseName, out var t);
-                    if (t == tcs.Task)
+                    if (preferred.ServerStore.DatabasesLandlord.DatabasesCache.TryRemove(databaseName, tcs.Task))
                         tcs.SetCanceled();
                 }))
                 {


### PR DESCRIPTION
Otherwise as demonstrated in the unit test we could remove the document database instance without disposing it so it was dangling forever. The reason was that we relied only on a key (database name) when calling TryRemove() so we could remove instance added meanwhile by someone else.

### Issue link

https://issues.hibernatingrhinos.com/issue/RavenDB-19002/Dangling-DocumentDatabase-instances-due-to-possible-race-with-the-usage-of-ResourceCacheT

### Additional description

Commit message contains all details

### Type of change

- Bug fix

### How risky is the change?

- Moderate 

### Backward compatibility

- Not relevant

### Is it platform specific issue?

- No

### Documentation update

- No documentation update is needed 

### Testing 

- Tests have been added that prove the fix is effective or that the feature works
 - Internal classes added to the test class (e.g. entity or index definition classes) have the lowest possible access modifier (preferable `private`) 
- It has been verified by manual testing

### Is there any existing behavior change of other features due to this change?

- No

### UI work

- No UI work is needed
