### PR TITLE
RavenDB-18804 - Add the request size to the traffic watch

### DIFF
--- a/src/Raven.Client/Documents/Changes/ChangeNotification.cs
+++ b/src/Raven.Client/Documents/Changes/ChangeNotification.cs
@@ -394,6 +394,7 @@ namespace Raven.Client.Documents.Changes
         public int ResponseStatusCode { get; set; }
         public string RequestUri { get; set; }
         public string AbsoluteUri { get; set; }
+        public long RequestSizeInBytes { get; set; }
         public long ResponseSizeInBytes { get; set; }
         public TrafficWatchChangeType Type { get; set; }
 
@@ -406,6 +407,7 @@ namespace Raven.Client.Documents.Changes
             json[nameof(ResponseStatusCode)] = ResponseStatusCode;
             json[nameof(RequestUri)] = RequestUri;
             json[nameof(AbsoluteUri)] = AbsoluteUri;
+            json[nameof(RequestSizeInBytes)] = RequestSizeInBytes;
             json[nameof(ResponseSizeInBytes)] = ResponseSizeInBytes;
             json[nameof(Type)] = Type;
             return json;

--- a/src/Raven.Server/RavenServerStartup.cs
+++ b/src/Raven.Server/RavenServerStartup.cs
@@ -30,6 +30,7 @@ using Raven.Server.Routing;
 using Raven.Server.ServerWide;
 using Raven.Server.TrafficWatch;
 using Raven.Server.Web;
+using Sparrow;
 using Sparrow.Json;
 using Sparrow.Json.Parsing;
 using Sparrow.Logging;
@@ -300,7 +301,8 @@ namespace Raven.Server
                 Type = twTuple.Type,
                 ClientIP = context.Connection.RemoteIpAddress?.ToString(),
                 CertificateThumbprint = context.Connection.ClientCertificate?.Thumbprint,
-                ResponseSizeInBytes = ((StreamWithTimeout)context.Items["ResponseStream"])?.TotalWritten ?? 0
+                RequestSizeInBytes = ((StreamWithTimeout)context.Items["RequestStream"])?.TotalRead ?? 0,
+                ResponseSizeInBytes = ((StreamWithTimeout)context.Items["ResponseStream"])?.TotalWritten ?? 0,
             };
 
             TrafficWatchManager.DispatchMessage(twn);

--- a/src/Raven.Server/Web/RequestHandler.cs
+++ b/src/Raven.Server/Web/RequestHandler.cs
@@ -96,6 +96,11 @@ namespace Raven.Server.Web
                 return _requestBodyStream;
             _requestBodyStream = new StreamWithTimeout(GetDecompressedStream(HttpContext.Request.Body, HttpContext.Request.Headers));
 
+            if (TrafficWatchManager.HasRegisteredClients)
+            {
+                HttpContext.Items["RequestStream"] = _requestBodyStream;
+            }
+
             _context.HttpContext.Response.RegisterForDispose(_requestBodyStream);
 
             return _requestBodyStream;


### PR DESCRIPTION
### Issue link

https://issues.hibernatingrhinos.com/issue/RavenDB-18804/Add-the-request-size-to-the-traffic-watch

### Additional description

Add the request size to the traffic watch

### Type of change

- New feature

### How risky is the change?

- Low 

### Documentation update

- This change requires a documentation update. Please mark the issue on YouTrack using `Documentation Required` tag.

### Testing 

- It has been verified by manual testing

### UI work

- It requires further work in the Studio

