### PR TITLE
RavenDB-19008 - Use the correct event when collecting the allocations

### DIFF
--- a/src/Raven.Server/Web/System/AdminAllocationDebugHandler.cs
+++ b/src/Raven.Server/Web/System/AdminAllocationDebugHandler.cs
@@ -80,7 +80,7 @@ namespace Raven.Server.Web.System
             {
                 switch (eventData.EventName)
                 {
-                    case "GCAllocationTick_V3":
+                    case "GCAllocationTick_V4":
                         var type = (string)eventData.Payload[5];
                         if (_allocations.TryGetValue(type, out var info) == false)
                         {

--- a/src/Raven.Server/Web/System/AdminAllocationDebugHandler.cs
+++ b/src/Raven.Server/Web/System/AdminAllocationDebugHandler.cs
@@ -12,6 +12,8 @@ namespace Raven.Server.Web.System
 {
     public sealed class AdminAllocationDebugHandler : RequestHandler
     {
+        public const string AllocationEventName = "GCAllocationTick_V4";
+
         [RavenAction("/admin/debug/memory/allocations", "GET", AuthorizationStatus.Operator,
             // intentionally not calling it debug endpoint because it isn't valid for us
             // to do so in debug package (since we force a wait)
@@ -80,7 +82,7 @@ namespace Raven.Server.Web.System
             {
                 switch (eventData.EventName)
                 {
-                    case "GCAllocationTick_V4":
+                    case AllocationEventName:
                         var type = (string)eventData.Payload[5];
                         if (_allocations.TryGetValue(type, out var info) == false)
                         {

--- a/test/FastTests/Server/DebugMemoryTests.cs
+++ b/test/FastTests/Server/DebugMemoryTests.cs
@@ -1,0 +1,20 @@
+﻿using System;
+using Raven.Server.Web.System;
+using Xunit;
+using Xunit.Abstractions;
+
+namespace FastTests.Server;
+
+public class DebugMemoryTests : NoDisposalNeeded
+{
+    public DebugMemoryTests(ITestOutputHelper output) : base(output)
+    {
+    }
+
+    [Fact]
+    public void Allocation_Debug_Event()
+    {
+        Assert.True(Environment.Version.Major == 6 && AdminAllocationDebugHandler.AllocationEventName == "GCAllocationTick_V4",
+            "Check if GCAllocationTick event was updated: https://github.com/dotnet/runtime/blob/main/src/coreclr/gc/gcevents.h");
+    }
+}


### PR DESCRIPTION
### Issue link

https://issues.hibernatingrhinos.com/issue/RavenDB-19008

### Additional description

Change the event name, this was probably changed when the dotnet version was upgraded

### Type of change

- Bug fix

### How risky is the change?

- Low 

### Testing 

- It has been verified by manual testing
