### PR TITLE
RavenDB-19010 - better error handling

### DIFF
--- a/src/Raven.Client/Exceptions/ExceptionDispatcher.cs
+++ b/src/Raven.Client/Exceptions/ExceptionDispatcher.cs
@@ -231,25 +231,28 @@ namespace Raven.Client.Exceptions
 
         private static async Task<BlittableJsonReaderObject> GetJson(JsonOperationContext context, HttpResponseMessage response, Stream stream)
         {
+            var memoryStream = new MemoryStream();
+
             BlittableJsonReaderObject json;
             try
             {
-                json = await context.ReadForMemoryAsync(stream, "error/response").ConfigureAwait(false);
+                // copying the error stream so we can read it as string if we fail to parse it
+                await stream.CopyToAsync(memoryStream).ConfigureAwait(false);
+                memoryStream.Position = 0;
+                json = await context.ReadForMemoryAsync(memoryStream, "error/response").ConfigureAwait(false);
             }
             catch (Exception e)
             {
-                string content = null;
-                if (stream.CanSeek)
-                {
-                    stream.Position = 0;
-                    using (var reader = new StreamReader(stream, Encoding.UTF8, detectEncodingFromByteOrderMarks: true, bufferSize: 4096, leaveOpen: true))
-                        content = await reader.ReadToEndAsync().ConfigureAwait(false);
-                }
-
-                if (content != null)
-                    content = $"Content: {content}";
+                string content = "Content: ";
+                memoryStream.Position = 0;
+                using (var reader = new StreamReader(memoryStream, Encoding.UTF8, detectEncodingFromByteOrderMarks: true, bufferSize: 4096, leaveOpen: true))
+                    content += await reader.ReadToEndAsync().ConfigureAwait(false);
 
                 throw new InvalidOperationException($"Cannot parse the '{response.StatusCode}' response. {content}", e);
+            }
+            finally
+            {
+                memoryStream.Dispose();
             }
 
             return json;


### PR DESCRIPTION
### Issue link

https://issues.hibernatingrhinos.com/issue/RavenDB-19010/Failed-to-read-the-error-message-after-an-exception

### Additional description

- Copy the stream before trying to parse it to a JSON.
- Log the error if we fail in the error handling

### Type of change

- Bug fix

### How risky is the change?

- Low 

### Testing 

- It has been verified by manual testing
