### PR TITLE
RavenDB-13106 Subscriptions with resharding

### DIFF
--- a/src/Raven.Client/Documents/Subscriptions/AbstractSubscriptionWorker.cs
+++ b/src/Raven.Client/Documents/Subscriptions/AbstractSubscriptionWorker.cs
@@ -561,7 +561,7 @@ namespace Raven.Client.Documents.Subscriptions
 
                 _processingCts.Token.ThrowIfCancellationRequested();
 
-                var lastReceivedChangeVector = batch.Initialize(incomingBatch);
+                batch.Initialize(incomingBatch);
 
                 notifiedSubscriber = Task.Run(async () => // the 2'nd thread
                 {
@@ -592,7 +592,7 @@ namespace Raven.Client.Documents.Subscriptions
                     {
                         if (tcpStreamCopy != null) //possibly prevent ObjectDisposedException
                         {
-                            await SendAckAsync(lastReceivedChangeVector, tcpStreamCopy, context, _processingCts.Token).ConfigureAwait(false);
+                            await SendAckAsync(batch.LastSentChangeVectorInBatch, tcpStreamCopy, context, _processingCts.Token).ConfigureAwait(false);
                         }
                     }
                     catch (ObjectDisposedException)

--- a/src/Raven.Client/Documents/Subscriptions/SubscriptionState.cs
+++ b/src/Raven.Client/Documents/Subscriptions/SubscriptionState.cs
@@ -16,16 +16,21 @@ namespace Raven.Client.Documents.Subscriptions
     public class SubscriptionState : IDatabaseTask, IDatabaseTaskStatus
     {
         public string Query { get; set; }
-        public string ChangeVectorForNextBatchStartingPoint { get; set; }
-        public Dictionary<string, string> ChangeVectorForNextBatchStartingPointPerShard { get; set; }
         public long SubscriptionId { get; set; }
         public string SubscriptionName { get; set; }
         public string MentorNode { get; set; }
-        public string NodeTag { get; set; }
         public DateTime? LastBatchAckTime { get; set; }  // Last time server made some progress with the subscriptions docs  
         public DateTime? LastClientConnectionTime { get; set; } // Last time any client has connected to server (connection dead or alive)
-        
         public bool Disabled { get; set; }
+
+        // for non-sharded
+        public string NodeTag { get; set; }
+        public string ChangeVectorForNextBatchStartingPoint { get; set; }
+
+        // for sharded
+        public Dictionary<string, string> ChangeVectorForNextBatchStartingPointPerShard { get; set; }
+        public Dictionary<string, string> NodeTagPerShard { get; set; }
+        public Dictionary<long, string> IgnoreBucketLesserChangeVector { get; set; }
 
         public ulong GetTaskKey()
         {
@@ -65,7 +70,9 @@ namespace Raven.Client.Documents.Subscriptions
                 [nameof(LastBatchAckTime)] = LastBatchAckTime,
                 [nameof(LastClientConnectionTime)] = LastClientConnectionTime,
                 [nameof(Disabled)] = Disabled,
-                [nameof(ChangeVectorForNextBatchStartingPointPerShard)] = ChangeVectorForNextBatchStartingPointPerShard?.ToJson()
+                [nameof(ChangeVectorForNextBatchStartingPointPerShard)] = ChangeVectorForNextBatchStartingPointPerShard?.ToJson(),
+                [nameof(IgnoreBucketLesserChangeVector)] = IgnoreBucketLesserChangeVector?.ToJsonWithPrimitiveKey(),
+                [nameof(NodeTagPerShard)] = NodeTagPerShard?.ToJson(),
             };
 
             return djv;

--- a/src/Raven.Client/Documents/Subscriptions/SubscriptionState.cs
+++ b/src/Raven.Client/Documents/Subscriptions/SubscriptionState.cs
@@ -13,6 +13,23 @@ using Sparrow.Json.Parsing;
 
 namespace Raven.Client.Documents.Subscriptions
 {
+    public class SubscriptionShardingState : IDynamicJson
+    {
+        public Dictionary<string, string> ChangeVectorForNextBatchStartingPointPerShard { get; set; }
+        public Dictionary<string, string> NodeTagPerShard { get; set; }
+        public Dictionary<long, string> IgnoreBucketLesserChangeVector { get; set; }
+        
+        public DynamicJsonValue ToJson()
+        {
+            return new DynamicJsonValue
+            {
+                [nameof(ChangeVectorForNextBatchStartingPointPerShard)] = ChangeVectorForNextBatchStartingPointPerShard?.ToJson(),
+                [nameof(IgnoreBucketLesserChangeVector)] = IgnoreBucketLesserChangeVector?.ToJsonWithPrimitiveKey(),
+                [nameof(NodeTagPerShard)] = NodeTagPerShard?.ToJson(),
+            };
+        }
+    }
+
     public class SubscriptionState : IDatabaseTask, IDatabaseTaskStatus
     {
         public string Query { get; set; }
@@ -27,10 +44,7 @@ namespace Raven.Client.Documents.Subscriptions
         public string NodeTag { get; set; }
         public string ChangeVectorForNextBatchStartingPoint { get; set; }
 
-        // for sharded
-        public Dictionary<string, string> ChangeVectorForNextBatchStartingPointPerShard { get; set; }
-        public Dictionary<string, string> NodeTagPerShard { get; set; }
-        public Dictionary<long, string> IgnoreBucketLesserChangeVector { get; set; }
+        public SubscriptionShardingState SubscriptionShardingState { get; set; }
 
         public ulong GetTaskKey()
         {
@@ -70,10 +84,15 @@ namespace Raven.Client.Documents.Subscriptions
                 [nameof(LastBatchAckTime)] = LastBatchAckTime,
                 [nameof(LastClientConnectionTime)] = LastClientConnectionTime,
                 [nameof(Disabled)] = Disabled,
-                [nameof(ChangeVectorForNextBatchStartingPointPerShard)] = ChangeVectorForNextBatchStartingPointPerShard?.ToJson(),
+                /*[nameof(ChangeVectorForNextBatchStartingPointPerShard)] = ChangeVectorForNextBatchStartingPointPerShard?.ToJson(),
                 [nameof(IgnoreBucketLesserChangeVector)] = IgnoreBucketLesserChangeVector?.ToJsonWithPrimitiveKey(),
-                [nameof(NodeTagPerShard)] = NodeTagPerShard?.ToJson(),
+                [nameof(NodeTagPerShard)] = NodeTagPerShard?.ToJson(),*/
             };
+
+            if (SubscriptionShardingState != null)
+            {
+                djv[nameof(SubscriptionShardingState)] = SubscriptionShardingState.ToJson();
+            }
 
             return djv;
         }

--- a/src/Raven.Client/Extensions/JsonSerializationExtensions.cs
+++ b/src/Raven.Client/Extensions/JsonSerializationExtensions.cs
@@ -1,4 +1,5 @@
-﻿using System.Collections.Generic;
+﻿using System;
+using System.Collections.Generic;
 using Sparrow;
 using Sparrow.Json;
 using Sparrow.Json.Parsing;
@@ -7,6 +8,25 @@ namespace Raven.Client.Extensions
 {
     internal static class JsonSerializationExtensions
     {
+        public static DynamicJsonValue ToJsonWithPrimitiveKey<TKey, TValue>(this Dictionary<TKey, TValue> dic)
+        {
+            var jsonMap = new DynamicJsonValue();
+            if (dic == null) //precaution, prevent NRE
+                return null;
+
+            if (typeof(TKey).IsPrimitive || typeof(TKey) == typeof(string))
+            {
+                foreach (var kvp in dic)
+                {
+                    jsonMap[kvp.Key.ToString()] = kvp.Value;
+                }
+
+                return jsonMap;
+            }
+
+            throw new ArgumentException($"Key type expected to primitive but was {typeof(TKey).FullName}");
+        }
+
         public static DynamicJsonValue ToJson<TValue>(this Dictionary<string, TValue> dic)     
         {
             var jsonMap = new DynamicJsonValue();

--- a/src/Raven.Server/Documents/Document.cs
+++ b/src/Raven.Server/Documents/Document.cs
@@ -141,7 +141,7 @@ namespace Raven.Server.Documents
 
         public override string ToString()
         {
-            return Id;
+            return $"id:{Id}, cv:{ChangeVector}";
         }
     }
 

--- a/src/Raven.Server/Documents/Handlers/Processors/Subscriptions/AbstractSubscriptionsHandlerProcessorForGetSubscription.cs
+++ b/src/Raven.Server/Documents/Handlers/Processors/Subscriptions/AbstractSubscriptionsHandlerProcessorForGetSubscription.cs
@@ -61,7 +61,7 @@ namespace Raven.Server.Documents.Handlers.Processors.Subscriptions
                 [nameof(SubscriptionState.SubscriptionId)] = state.SubscriptionId,
                 [nameof(SubscriptionState.SubscriptionName)] = state.SubscriptionName,
                 [nameof(SubscriptionState.ChangeVectorForNextBatchStartingPoint)] = state.ChangeVectorForNextBatchStartingPoint,
-                [nameof(SubscriptionState.ChangeVectorForNextBatchStartingPointPerShard)] = state.ChangeVectorForNextBatchStartingPointPerShard?.ToJson(),
+                [nameof(SubscriptionState.SubscriptionShardingState)] = state.SubscriptionShardingState?.ToJson(),
                 [nameof(SubscriptionState.Query)] = state.Query,
                 [nameof(SubscriptionState.Disabled)] = state.Disabled,
                 [nameof(SubscriptionState.LastClientConnectionTime)] = state.LastClientConnectionTime,
@@ -77,7 +77,6 @@ namespace Raven.Server.Documents.Handlers.Processors.Subscriptions
                     ["State"] = new DynamicJsonValue()
                     {
                         ["LatestChangeVectorClientACKnowledged"] = r.SubscriptionState.ChangeVectorForNextBatchStartingPoint,
-                        ["LatestChangeVectorsClientACKnowledged"] = r.SubscriptionState.ChangeVectorForNextBatchStartingPointPerShard?.ToJson(),
                         ["Query"] = r.SubscriptionState.Query
                     },
                     ["Connection"] = GetSubscriptionConnectionJson(r)
@@ -87,7 +86,6 @@ namespace Raven.Server.Documents.Handlers.Processors.Subscriptions
                     ["State"] = new DynamicJsonValue()
                     {
                         ["LatestChangeVectorClientACKnowledged"] = r.SubscriptionState.ChangeVectorForNextBatchStartingPoint,
-                        ["LatestChangeVectorsClientACKnowledged"] = r.SubscriptionState.ChangeVectorForNextBatchStartingPointPerShard?.ToJson(),
                         ["Query"] = r.SubscriptionState.Query
                     },
                     ["Connection"] = GetSubscriptionConnectionJson(r)

--- a/src/Raven.Server/Documents/Replication/Incoming/IncomingMigrationReplicationHandler.cs
+++ b/src/Raven.Server/Documents/Replication/Incoming/IncomingMigrationReplicationHandler.cs
@@ -40,8 +40,12 @@ namespace Raven.Server.Documents.Replication.Incoming
 
             protected override ChangeVector PreProcessItem(DocumentsOperationContext context, ReplicationBatchItem item)
             {
-                var changeVector = context.GetChangeVector(item.ChangeVector);
                 var order = context.DocumentDatabase.DocumentsStorage.GetNewChangeVector(context).ChangeVector;
+
+                var changeVector = context.GetChangeVector(item.ChangeVector);
+                if (changeVector.Order.Contains(_shardedDatabase.ShardedDatabaseId))
+                    return order;
+
                 var migratedChangeVector = context.GetChangeVector(changeVector.Version, order);
                 migratedChangeVector = migratedChangeVector.UpdateOrder(MigrationTag, _shardedDatabase.ShardedDatabaseId, _movingBucket.MigrationIndex, context);
                 item.ChangeVector = migratedChangeVector.AsString();

--- a/src/Raven.Server/Documents/Replication/Senders/MigrationReplicationDocumentSender.cs
+++ b/src/Raven.Server/Documents/Replication/Senders/MigrationReplicationDocumentSender.cs
@@ -61,12 +61,6 @@ namespace Raven.Server.Documents.Replication.Senders
                 while (mergedInEnumerator.MoveNext())
                 {
                     yield return mergedInEnumerator.Current;
-                    /*var item = mergedInEnumerator.Current;
-                    var result = ChangeVectorUtils.TryUpdateChangeVector(MigrationTag, migrationId, Destination.MigrationIndex, item.ChangeVector);
-                    Debug.Assert(result.IsValid,$"Failed to update the change vector {item.ChangeVector} with '{MigrationTag}:{Destination.MigrationIndex}-{migrationId}'");
-
-                    item.ChangeVector = result.ChangeVector;
-                    yield return item;*/
                 }
             }
         }

--- a/src/Raven.Server/Documents/Sharding/ShardedDatabaseContext.Subscriptions.cs
+++ b/src/Raven.Server/Documents/Sharding/ShardedDatabaseContext.Subscriptions.cs
@@ -87,7 +87,8 @@ public partial class ShardedDatabaseContext
                     DevelopmentHelper.ShardingToDo(DevelopmentHelper.TeamMember.Karmel, DevelopmentHelper.Severity.Normal, "create subscription WhosTaskIsIt");
                     DevelopmentHelper.ShardingToDo(DevelopmentHelper.TeamMember.Karmel, DevelopmentHelper.Severity.Normal, "Need to handle NodeTag, currently is isn't used for sharded because it is shared");
 
-                    var whoseTaskIsIt = databaseRecord.TopologyForSubscriptions().WhoseTaskIsIt(_serverStore.Engine.CurrentState, subscriptionState);
+                    var topology = databaseRecord.Sharding.Orchestrator.Topology;
+                    var whoseTaskIsIt = _serverStore.WhoseTaskIsIt(topology, subscriptionState, subscriptionState);
                     if (whoseTaskIsIt != _serverStore.NodeTag)
                     {
                         subscriptionConnectionsState.DropSubscription(

--- a/src/Raven.Server/Documents/Sharding/Subscriptions/ShardedDocumentsDatabaseSubscriptionProcessor.cs
+++ b/src/Raven.Server/Documents/Sharding/Subscriptions/ShardedDocumentsDatabaseSubscriptionProcessor.cs
@@ -1,4 +1,5 @@
 ﻿using System;
+using System.Threading.Tasks;
 using Raven.Client.ServerWide.Sharding;
 using Raven.Server.Documents.Subscriptions;
 using Raven.Server.Documents.Subscriptions.SubscriptionProcessor;

--- a/src/Raven.Server/Documents/Sharding/Subscriptions/ShardedSubscriptionBatch.cs
+++ b/src/Raven.Server/Documents/Sharding/Subscriptions/ShardedSubscriptionBatch.cs
@@ -12,7 +12,6 @@ public class ShardedSubscriptionBatch : SubscriptionBatchBase<BlittableJsonReade
 {
     public TaskCompletionSource SendBatchToClientTcs;
     public TaskCompletionSource ConfirmFromShardSubscriptionConnectionTcs;
-    public string LastSentChangeVectorInBatch;
     public string ShardName;
     public IDisposable ReturnContext;
 
@@ -35,15 +34,16 @@ public class ShardedSubscriptionBatch : SubscriptionBatchBase<BlittableJsonReade
 
     protected override void EnsureDocumentId(BlittableJsonReaderObject item, string id) => throw new SubscriberErrorException($"Missing id property for {item}");
 
-    internal override string Initialize(BatchFromServer batch)
+    internal override void Initialize(BatchFromServer batch)
     {
         SendBatchToClientTcs = new TaskCompletionSource(TaskCreationOptions.RunContinuationsAsynchronously);
         ConfirmFromShardSubscriptionConnectionTcs = new TaskCompletionSource(TaskCreationOptions.RunContinuationsAsynchronously);
-        LastSentChangeVectorInBatch = null;
         
         ReturnContext = batch.ReturnContext;
         batch.ReturnContext = null; // move the release responsibility to the OrchestratedSubscriptionProcessor
 
-        return base.Initialize(batch);
+        base.Initialize(batch);
+
+        LastSentChangeVectorInBatch = null;
     }
 }

--- a/src/Raven.Server/Documents/Sharding/Subscriptions/ShardedSubscriptionWorker.cs
+++ b/src/Raven.Server/Documents/Sharding/Subscriptions/ShardedSubscriptionWorker.cs
@@ -59,6 +59,7 @@ namespace Raven.Server.Documents.Sharding.Subscriptions
                 _state.Batches.Add(batch);
 
                 _state.NotifyHasMoreDocs();
+
                 await using (_processingCts.Token.Register(batch.SetCancel))
                 {
                     // wait for ShardedSubscriptionConnection to redirect the batch to client worker

--- a/src/Raven.Server/Documents/Sharding/Subscriptions/SubscriptionConnectionsStateOrchestrator.cs
+++ b/src/Raven.Server/Documents/Sharding/Subscriptions/SubscriptionConnectionsStateOrchestrator.cs
@@ -85,13 +85,14 @@ public class SubscriptionConnectionsStateOrchestrator : SubscriptionConnectionsS
         options.Strategy = SubscriptionOpeningStrategy.TakeOver;
         options.WorkerId += $"/{ShardHelper.GetShardNumber(shard)}";
         options.TimeToWaitBeforeConnectionRetry = TimeSpan.FromMilliseconds(250); // failover faster
-
+        
         // we want to limit the batch of each shard, to not hold too much memory if there are other batches while batch is proceed
         options.MaxDocsPerBatch = Math.Max(Math.Min(_options.MaxDocsPerBatch / _databaseContext.ShardCount, _options.MaxDocsPerBatch), 1);
 
         DevelopmentHelper.ShardingToDo(DevelopmentHelper.TeamMember.Karmel, DevelopmentHelper.Severity.Normal, "need to ensure the sharded workers has the same sub definition. by sending my raft index?");
         var shardWorker = new ShardedSubscriptionWorker(options, shard, re, this);
         shardWorker.Run(shardWorker.TryPublishBatchAsync, CancellationTokenSource.Token);
+        
         return shardWorker;
     }
 

--- a/src/Raven.Server/Documents/Subscriptions/SubscriptionConnectionsStateForShard.cs
+++ b/src/Raven.Server/Documents/Subscriptions/SubscriptionConnectionsStateForShard.cs
@@ -17,8 +17,8 @@ public class SubscriptionConnectionsStateForShard : SubscriptionConnectionsState
 
     protected override void SetLastChangeVectorSent(SubscriptionConnection connection)
     {
-        if (connection.SubscriptionState.ChangeVectorForNextBatchStartingPointPerShard == null ||
-            connection.SubscriptionState.ChangeVectorForNextBatchStartingPointPerShard.TryGetValue(DocumentDatabase.Name, out string cv) == false)
+        if (connection.SubscriptionState.SubscriptionShardingState.ChangeVectorForNextBatchStartingPointPerShard == null ||
+            connection.SubscriptionState.SubscriptionShardingState.ChangeVectorForNextBatchStartingPointPerShard.TryGetValue(DocumentDatabase.Name, out string cv) == false)
         {
             LastChangeVectorSent = null;
         }

--- a/src/Raven.Server/Documents/Subscriptions/SubscriptionConnectionsStateForShard.cs
+++ b/src/Raven.Server/Documents/Subscriptions/SubscriptionConnectionsStateForShard.cs
@@ -30,7 +30,7 @@ public class SubscriptionConnectionsStateForShard : SubscriptionConnectionsState
 
     public override Task UpdateClientConnectionTime()
     {
-        // the orchastartor will update the client connection time
+        // the orchestrator will update the client connection time
         return Task.CompletedTask;
     }
 

--- a/src/Raven.Server/Documents/Subscriptions/SubscriptionProcessor/DatabaseSubscriptionProcessor.cs
+++ b/src/Raven.Server/Documents/Subscriptions/SubscriptionProcessor/DatabaseSubscriptionProcessor.cs
@@ -1,4 +1,5 @@
-﻿using System;
+﻿
+using System;
 using System.Collections.Generic;
 using Jint.Native;
 using Jint.Native.Object;

--- a/src/Raven.Server/Documents/Subscriptions/SubscriptionProcessor/DocumentsDatabaseSubscriptionProcessor.cs
+++ b/src/Raven.Server/Documents/Subscriptions/SubscriptionProcessor/DocumentsDatabaseSubscriptionProcessor.cs
@@ -122,7 +122,14 @@ namespace Raven.Server.Documents.Subscriptions.SubscriptionProcessor
             {
                 var conflictStatus = ChangeVectorUtils.GetConflictStatus(
                     remoteAsString: item.ChangeVector,
+                    localAsString: SubscriptionConnectionsState.PreviouslyRecordedChangeVector);
+
+                /*
+                var conflictStatus = ChangeVectorUtils.GetConflictStatus(
+                    remoteAsString: item.ChangeVector,
                     localAsString: SubscriptionState.ChangeVectorForNextBatchStartingPoint);
+                    */
+
 
                 if (conflictStatus == ConflictStatus.AlreadyMerged)
                 {

--- a/src/Raven.Server/Documents/Subscriptions/SubscriptionProcessor/DocumentsDatabaseSubscriptionProcessor.cs
+++ b/src/Raven.Server/Documents/Subscriptions/SubscriptionProcessor/DocumentsDatabaseSubscriptionProcessor.cs
@@ -122,14 +122,7 @@ namespace Raven.Server.Documents.Subscriptions.SubscriptionProcessor
             {
                 var conflictStatus = ChangeVectorUtils.GetConflictStatus(
                     remoteAsString: item.ChangeVector,
-                    localAsString: SubscriptionConnectionsState.PreviouslyRecordedChangeVector);
-
-                /*
-                var conflictStatus = ChangeVectorUtils.GetConflictStatus(
-                    remoteAsString: item.ChangeVector,
                     localAsString: SubscriptionState.ChangeVectorForNextBatchStartingPoint);
-                    */
-
 
                 if (conflictStatus == ConflictStatus.AlreadyMerged)
                 {

--- a/src/Raven.Server/Documents/Subscriptions/SubscriptionProcessor/OrchestratedSubscriptionProcessor.cs
+++ b/src/Raven.Server/Documents/Subscriptions/SubscriptionProcessor/OrchestratedSubscriptionProcessor.cs
@@ -129,7 +129,7 @@ public class OrchestratedSubscriptionProcessor : SubscriptionProcessor
                 {
                     // document from old shard, which hasn't been moved yet
                     // check whether it was put into the resend queue before we start the resharding
-                    if (_subscriptionState.IgnoreBucketLesserChangeVector.TryGetValue(migration.MigrationIndex, out var skipChangeVector))
+                    if (_subscriptionState.SubscriptionShardingState.IgnoreBucketLesserChangeVector.TryGetValue(migration.MigrationIndex, out var skipChangeVector))
                     {
                         var status = ChangeVectorUtils.GetConflictStatus(changeVector.Version, skipChangeVector);
                         if (status == ConflictStatus.Update)
@@ -159,7 +159,7 @@ public class OrchestratedSubscriptionProcessor : SubscriptionProcessor
 
             if (moveIndex > 0)
             {
-                if (_subscriptionState.IgnoreBucketLesserChangeVector.TryGetValue(moveIndex, out var skipChangeVector))
+                if (_subscriptionState.SubscriptionShardingState.IgnoreBucketLesserChangeVector.TryGetValue(moveIndex, out var skipChangeVector))
                 {
                     var status = ChangeVectorUtils.GetConflictStatus(changeVector.Version, skipChangeVector, _exclude);
                     if (status == ConflictStatus.AlreadyMerged)

--- a/src/Raven.Server/Documents/Subscriptions/SubscriptionProcessor/OrchestratedSubscriptionProcessor.cs
+++ b/src/Raven.Server/Documents/Subscriptions/SubscriptionProcessor/OrchestratedSubscriptionProcessor.cs
@@ -1,9 +1,16 @@
 ﻿using System;
 using System.Collections.Generic;
 using System.Threading.Tasks;
+using Raven.Client.Documents.Subscriptions;
+using Raven.Client.ServerWide.Sharding;
 using Raven.Server.Documents.Sharding;
 using Raven.Server.Documents.Sharding.Subscriptions;
 using Raven.Server.ServerWide;
+using Raven.Server.ServerWide.Context;
+using Raven.Server.Utils;
+using Sparrow.Json;
+using Sparrow.Server;
+using Sparrow.Threading;
 using Sparrow.Utils;
 
 namespace Raven.Server.Documents.Subscriptions.SubscriptionProcessor;
@@ -15,7 +22,7 @@ public class OrchestratedSubscriptionProcessor : SubscriptionProcessor
 
     public ShardedSubscriptionBatch CurrentBatch;
 
-    public OrchestratedSubscriptionProcessor(ServerStore server, ShardedDatabaseContext databaseContext, SubscriptionConnectionBase connection) : base(server, connection)
+    public OrchestratedSubscriptionProcessor(ServerStore server, ShardedDatabaseContext databaseContext, OrchestratedSubscriptionConnection connection) : base(server, connection)
     {
         _databaseContext = databaseContext;
     }
@@ -25,7 +32,7 @@ public class OrchestratedSubscriptionProcessor : SubscriptionProcessor
         base.InitializeProcessor();
         _state = _databaseContext.Subscriptions.SubscriptionsConnectionsState[Connection.SubscriptionId];
     }
-        
+
     // should never hit this
     public override Task<long> RecordBatch(string lastChangeVectorSentInThisBatch) => throw new NotImplementedException();
 
@@ -43,25 +50,128 @@ public class OrchestratedSubscriptionProcessor : SubscriptionProcessor
     {
         if (_state.Batches.TryTake(out CurrentBatch, TimeSpan.Zero) == false)
             yield break;
-
+        
         using (CurrentBatch.ReturnContext)
+        using (Server.ContextPool.AllocateOperationContext(out TransactionOperationContext context))
         {
+            var migrationFilter = new SubscriptionBatchMigrationHelper();
+            migrationFilter.Init(Server, _databaseContext.DatabaseName, Connection.SubscriptionId, ShardHelper.GetShardNumber(CurrentBatch.ShardName));
+
             foreach (var batchItem in CurrentBatch.Items)
             {
                 Connection.CancellationTokenSource.Token.ThrowIfCancellationRequested();
 
                 if (batchItem.ExceptionMessage != null)
                     yield return (null, new Exception(batchItem.ExceptionMessage));
-
-                var document = new Document
+                
+                using (var document = new Document
+                       {
+                           ChangeVector = batchItem.ChangeVector, 
+                           Id = ClusterContext.GetLazyString(batchItem.Id)
+                       })
                 {
-                    Data = batchItem.RawResult.Clone(ClusterContext),
-                    ChangeVector = batchItem.ChangeVector,
-                    Id = ClusterContext.GetLazyString(batchItem.Id)
-                };
+                    var changeVector = context.GetChangeVector(document.ChangeVector);
+                    var shouldSkip = migrationFilter.ShouldSkip(context.Allocator, document.Id, changeVector, out var reason);
+                    if (shouldSkip == false)
+                    {
+                        document.Data = batchItem.RawResult.Clone(ClusterContext);
+                    }
 
-                yield return (document, null);
+                    if (Connection._logger.IsInfoEnabled)
+                    {
+                        Connection._logger.Info(reason);
+                    }
+
+                    yield return (document, null);
+                }
             }
+        }
+    }
+
+    private class SubscriptionBatchMigrationHelper
+    {
+        private string _moveId;
+        private SubscriptionState _subscriptionState;
+        private int _currentShard;
+        private List<ShardBucketRange> _ranges;
+        private Dictionary<int, ShardBucketMigration> _activeMigration;
+        private HashSet<string> _exclude;
+
+        public void Init(ServerStore server, string database, long subId, int shardNumber)
+        {
+            _currentShard = shardNumber;
+
+            using (server.ContextPool.AllocateOperationContext(out TransactionOperationContext context))
+            using (context.OpenReadTransaction())
+            {
+                var raw = server.Cluster.ReadRawDatabaseRecord(context, database).Sharding;
+                _moveId = raw.ShardedDatabaseId;
+                _ranges = raw.ShardBucketRanges;
+                _subscriptionState = server.Cluster.Subscriptions.ReadSubscriptionStateById(context, database, subId);
+                _activeMigration = raw.BucketMigrations;
+            }
+
+            _exclude = new HashSet<string>(capacity: 1) { _moveId };
+        }
+
+        public bool ShouldSkip(ByteStringContext context, LazyStringValue id, ChangeVector changeVector, out string reason)
+        {
+            // changeVector = new ChangeVector(changeVector).Order.AsString();
+
+            var bucket = ShardHelper.GetBucket(context, id);
+            var actualShard = ShardHelper.GetShardNumber(_ranges, bucket);
+            var moveIndex = ChangeVectorUtils.GetEtagById(changeVector.Order, _moveId);
+            reason = null;
+
+            if (_activeMigration.TryGetValue(bucket, out var migration))
+            {
+                if (_currentShard != migration.DestinationShard && moveIndex == 0)
+                {
+                    // document from old shard, which hasn't been moved yet
+                    // check whether it was put into the resend queue before we start the resharding
+                    if (_subscriptionState.IgnoreBucketLesserChangeVector.TryGetValue(migration.MigrationIndex, out var skipChangeVector))
+                    {
+                        var status = ChangeVectorUtils.GetConflictStatus(changeVector.Version, skipChangeVector);
+                        if (status == ConflictStatus.Update)
+                        {
+                            reason =
+                                $"Got '{id}' (change-vector: '{changeVector}') from shard '{_currentShard}', but it will be sent by its new owner shard '{migration.DestinationShard}', (marked change vector: {skipChangeVector}, status: {status})";
+                            return true;
+                        }
+
+                        if (status == ConflictStatus.AlreadyMerged)
+                        {
+                            reason = $"'{id}' (change-vector: '{changeVector}') from shard '{_currentShard}' was already processed, (skip: '{skipChangeVector}', status: '{status}')";
+                            return true;
+                        }
+                    }
+                }
+            }
+            else
+            {
+                if (actualShard != _currentShard)
+                {
+                    // not the owner
+                    reason = $"Not the owner of '{id}' (change-vector: '{changeVector}') (expected shard: '{_currentShard}', actual shard: '{actualShard}')";
+                    return true;
+                }
+            }
+
+            if (moveIndex > 0)
+            {
+                if (_subscriptionState.IgnoreBucketLesserChangeVector.TryGetValue(moveIndex, out var skipChangeVector))
+                {
+                    var status = ChangeVectorUtils.GetConflictStatus(changeVector.Version, skipChangeVector, _exclude);
+                    if (status == ConflictStatus.AlreadyMerged)
+                    {
+                        reason = $"'{id}' (change-vector: '{changeVector}') was already processed, (skip: '{skipChangeVector}', status: '{status}')";
+                        return true;
+                    }
+                }
+            }
+
+            reason = $"allow '{id}' (change-vector: '{changeVector}'";
+            return false;
         }
     }
 }

--- a/src/Raven.Server/Documents/Subscriptions/SubscriptionProcessor/OrchestratedSubscriptionProcessor.cs
+++ b/src/Raven.Server/Documents/Subscriptions/SubscriptionProcessor/OrchestratedSubscriptionProcessor.cs
@@ -116,12 +116,9 @@ public class OrchestratedSubscriptionProcessor : SubscriptionProcessor
 
         public bool ShouldSkip(ByteStringContext context, LazyStringValue id, ChangeVector changeVector, out string reason)
         {
-            // changeVector = new ChangeVector(changeVector).Order.AsString();
-
             var bucket = ShardHelper.GetBucket(context, id);
             var actualShard = ShardHelper.GetShardNumber(_ranges, bucket);
             var moveIndex = ChangeVectorUtils.GetEtagById(changeVector.Order, _moveId);
-            reason = null;
 
             if (_activeMigration.TryGetValue(bucket, out var migration))
             {

--- a/src/Raven.Server/Documents/Subscriptions/SubscriptionProcessor/RevisionsDatabaseSubscriptionProcessor.cs
+++ b/src/Raven.Server/Documents/Subscriptions/SubscriptionProcessor/RevisionsDatabaseSubscriptionProcessor.cs
@@ -105,12 +105,7 @@ namespace Raven.Server.Documents.Subscriptions.SubscriptionProcessor
             {
                 var conflictStatus = ChangeVectorUtils.GetConflictStatus(
                     remoteAsString: item.Current.ChangeVector,
-                    localAsString: SubscriptionConnectionsState.PreviouslyRecordedChangeVector);
-
-                /*var conflictStatus = ChangeVectorUtils.GetConflictStatus(
-                    remoteAsString: item.Current.ChangeVector,
                     localAsString: SubscriptionState.ChangeVectorForNextBatchStartingPoint);
-                    */
 
                 if (conflictStatus == ConflictStatus.AlreadyMerged)
                 {

--- a/src/Raven.Server/Documents/Subscriptions/SubscriptionProcessor/RevisionsDatabaseSubscriptionProcessor.cs
+++ b/src/Raven.Server/Documents/Subscriptions/SubscriptionProcessor/RevisionsDatabaseSubscriptionProcessor.cs
@@ -105,7 +105,12 @@ namespace Raven.Server.Documents.Subscriptions.SubscriptionProcessor
             {
                 var conflictStatus = ChangeVectorUtils.GetConflictStatus(
                     remoteAsString: item.Current.ChangeVector,
+                    localAsString: SubscriptionConnectionsState.PreviouslyRecordedChangeVector);
+
+                /*var conflictStatus = ChangeVectorUtils.GetConflictStatus(
+                    remoteAsString: item.Current.ChangeVector,
                     localAsString: SubscriptionState.ChangeVectorForNextBatchStartingPoint);
+                    */
 
                 if (conflictStatus == ConflictStatus.AlreadyMerged)
                 {

--- a/src/Raven.Server/Documents/Subscriptions/SubscriptionProcessor/SubscriptionProcessor.cs
+++ b/src/Raven.Server/Documents/Subscriptions/SubscriptionProcessor/SubscriptionProcessor.cs
@@ -26,8 +26,8 @@ public abstract class SubscriptionProcessor : IDisposable
 
     public static SubscriptionProcessor Create(SubscriptionConnectionBase connection)
     {
-        if (connection is OrchestratedSubscriptionConnection)
-            return new OrchestratedSubscriptionProcessor(connection.TcpConnection.DatabaseContext.ServerStore, connection.TcpConnection.DatabaseContext, connection);
+        if (connection is OrchestratedSubscriptionConnection orchestratedSubscription)
+            return new OrchestratedSubscriptionProcessor(connection.TcpConnection.DatabaseContext.ServerStore, connection.TcpConnection.DatabaseContext, orchestratedSubscription);
 
         if (connection is SubscriptionConnectionForShard sharded)
             return CreateForSharded(sharded);

--- a/src/Raven.Server/Documents/Subscriptions/SubscriptionStorage.cs
+++ b/src/Raven.Server/Documents/Subscriptions/SubscriptionStorage.cs
@@ -417,7 +417,7 @@ namespace Raven.Server.Documents.Subscriptions
                 LastBatchAckTime = @base.LastBatchAckTime;
                 LastClientConnectionTime = @base.LastClientConnectionTime;
                 Disabled = @base.Disabled;
-                ChangeVectorForNextBatchStartingPointPerShard = @base.ChangeVectorForNextBatchStartingPointPerShard;
+                SubscriptionShardingState = @base.SubscriptionShardingState;
             }
         }
 

--- a/src/Raven.Server/Documents/TcpHandlers/SubscriptionConnection.cs
+++ b/src/Raven.Server/Documents/TcpHandlers/SubscriptionConnection.cs
@@ -13,6 +13,7 @@ using System.Threading.Tasks;
 using Esprima;
 using Raven.Client.Documents.Subscriptions;
 using Raven.Client.Exceptions;
+using Raven.Client.ServerWide;
 using Raven.Server.Documents.Queries;
 using Raven.Server.Documents.Queries.AST;
 using Raven.Server.Documents.Queries.TimeSeries;
@@ -373,7 +374,7 @@ namespace Raven.Server.Documents.TcpHandlers
             };
         }
 
-        protected override async Task OnClientAckAsync()
+        protected override async Task OnClientAckAsync(string clientReplyChangeVector)
         {
             await Processor.AcknowledgeBatch(CurrentBatchId);
             await SendConfirmAsync(TcpConnection.DocumentDatabase.Time.GetUtcNow());
@@ -418,7 +419,7 @@ namespace Raven.Server.Documents.TcpHandlers
             //merge with this node's local etag
         }
 
-        protected override async Task UpdateStateAfterBatchSentAsync(string lastChangeVectorSentInThisBatch)
+        protected override async Task UpdateStateAfterBatchSentAsync(IChangeVectorOperationContext context, string lastChangeVectorSentInThisBatch)
         {
             //Entire unsent batch could contain docs that have to be skipped, but we still want to update the etag in the cv
             LastSentChangeVectorInThisConnection = lastChangeVectorSentInThisBatch;
@@ -441,6 +442,8 @@ namespace Raven.Server.Documents.TcpHandlers
                 SubscriptionType = "subscription"
             };
         }
+
+        protected override string WhosTaskIsIt(DatabaseTopology topology, SubscriptionState subscriptionState) => _serverStore.WhoseTaskIsIt(topology, subscriptionState, subscriptionState);
 
         protected override StatusMessageDetails GetStatusMessageDetails()
         {

--- a/src/Raven.Server/Documents/TcpHandlers/SubscriptionConnectionForShard.cs
+++ b/src/Raven.Server/Documents/TcpHandlers/SubscriptionConnectionForShard.cs
@@ -78,7 +78,7 @@ public class SubscriptionConnectionForShard : SubscriptionConnection
     protected override string WhosTaskIsIt(DatabaseTopology topology, SubscriptionState subscriptionState) => 
         topology.WhoseTaskIsIt(_serverStore.Engine.CurrentState, subscriptionState, () =>
         {
-            subscriptionState.NodeTagPerShard.TryGetValue(ShardName, out var tag);
+            subscriptionState.SubscriptionShardingState.NodeTagPerShard.TryGetValue(ShardName, out var tag);
             return tag;
         });
 }

--- a/src/Raven.Server/ServerWide/Commands/Sharding/PutShardedSubscriptionCommand.cs
+++ b/src/Raven.Server/ServerWide/Commands/Sharding/PutShardedSubscriptionCommand.cs
@@ -27,7 +27,7 @@ public class PutShardedSubscriptionCommand : PutSubscriptionCommand
         if (InitialChangeVector == nameof(Constants.Documents.SubscriptionChangeVectorSpecialStates.DoNotChange))
         {
             // use current change vectors saved in state
-            InitialChangeVectorPerShard = existingSubscriptionState.ChangeVectorForNextBatchStartingPointPerShard;
+            InitialChangeVectorPerShard = existingSubscriptionState.SubscriptionShardingState.ChangeVectorForNextBatchStartingPointPerShard;
             return;
         }
 
@@ -35,7 +35,7 @@ public class PutShardedSubscriptionCommand : PutSubscriptionCommand
             return;
 
         // start from LastDocument (the CVs were validated in handler)
-        InitialChangeVectorPerShard = existingSubscriptionState.ChangeVectorForNextBatchStartingPointPerShard;
+        InitialChangeVectorPerShard = existingSubscriptionState.SubscriptionShardingState.ChangeVectorForNextBatchStartingPointPerShard;
         // remove the old state from storage
         RemoveSubscriptionStateFromStorage(context, subscriptionId);
     }
@@ -56,7 +56,10 @@ public class PutShardedSubscriptionCommand : PutSubscriptionCommand
             Disabled = Disabled,
             MentorNode = MentorNode,
             LastClientConnectionTime = null,
-            ChangeVectorForNextBatchStartingPointPerShard = InitialChangeVectorPerShard
+            SubscriptionShardingState = new SubscriptionShardingState
+            {
+                ChangeVectorForNextBatchStartingPointPerShard = InitialChangeVectorPerShard
+            }
         }.ToJson();
     }
 

--- a/src/Raven.Server/ServerWide/Commands/Sharding/StartBucketMigrationCommand.cs
+++ b/src/Raven.Server/ServerWide/Commands/Sharding/StartBucketMigrationCommand.cs
@@ -70,10 +70,10 @@ namespace Raven.Server.ServerWide.Commands.Sharding
             foreach (var (key, state) in ClusterStateMachine.ReadValuesStartingWith(context, SubscriptionState.SubscriptionPrefix(DatabaseName)))
             {
                 var subscriptionState = JsonDeserializationClient.SubscriptionState(state);
-                if (subscriptionState.ChangeVectorForNextBatchStartingPointPerShard.TryGetValue(database, out var changeVector) == false)
+                if (subscriptionState.SubscriptionShardingState.ChangeVectorForNextBatchStartingPointPerShard.TryGetValue(database, out var changeVector) == false)
                     return;
 
-                subscriptionState.IgnoreBucketLesserChangeVector[index] = changeVector;
+                subscriptionState.SubscriptionShardingState.IgnoreBucketLesserChangeVector[index] = changeVector;
 
                 using (state)
                 using (Slice.From(context.Allocator, subscriptionState.SubscriptionName, out Slice valueName))

--- a/src/Raven.Server/ServerWide/Commands/Subscriptions/AcknowledgeSubscriptionBatchCommand.cs
+++ b/src/Raven.Server/ServerWide/Commands/Subscriptions/AcknowledgeSubscriptionBatchCommand.cs
@@ -94,7 +94,7 @@ namespace Raven.Server.ServerWide.Commands.Subscriptions
             }
             else
             {
-                subscription.NodeTagPerShard[ShardName] = NodeTag;
+                subscription.SubscriptionShardingState.NodeTagPerShard[ShardName] = NodeTag;
             }
 
             subscription.LastBatchAckTime = LastTimeServerMadeProgressWithDocuments;

--- a/src/Raven.Server/ServerWide/Commands/Subscriptions/PutSubscriptionCommand.cs
+++ b/src/Raven.Server/ServerWide/Commands/Subscriptions/PutSubscriptionCommand.cs
@@ -132,7 +132,7 @@ namespace Raven.Server.ServerWide.Commands.Subscriptions
         protected void RemoveSubscriptionStateFromStorage(ClusterOperationContext context, long subscriptionId)
         {
             var subscriptionStateTable = context.Transaction.InnerTransaction.OpenTable(ClusterStateMachine.SubscriptionStateSchema, ClusterStateMachine.SubscriptionState);
-            using (SubscriptionConnectionsState.GetDatabaseAndSubscriptionPrefix(context, DatabaseName, subscriptionId, out var prefix))
+            using (SubscriptionConnectionsStateBase.GetDatabaseAndSubscriptionPrefix(context, DatabaseName, subscriptionId, out var prefix))
             {
                 using var _ = Slice.External(context.Allocator, prefix, out var prefixSlice);
                 subscriptionStateTable.DeleteByPrimaryKeyPrefix(prefixSlice);

--- a/src/Raven.Server/ServerWide/Commands/Subscriptions/RecordBatchSubscriptionDocumentsCommand.cs
+++ b/src/Raven.Server/ServerWide/Commands/Subscriptions/RecordBatchSubscriptionDocumentsCommand.cs
@@ -124,9 +124,9 @@ namespace Raven.Server.ServerWide.Commands.Subscriptions
                     }
                     else
                     {
-                        subscriptionState.ChangeVectorForNextBatchStartingPointPerShard.TryGetValue(ShardName, out string current);
-                        subscriptionState.ChangeVectorForNextBatchStartingPointPerShard[ShardName] = ChangeVectorUtils.MergeVectors(current, CurrentChangeVector);
-                        subscriptionState.NodeTagPerShard[ShardName] = NodeTag;
+                        subscriptionState.SubscriptionShardingState.ChangeVectorForNextBatchStartingPointPerShard.TryGetValue(ShardName, out string current);
+                        subscriptionState.SubscriptionShardingState.ChangeVectorForNextBatchStartingPointPerShard[ShardName] = ChangeVectorUtils.MergeVectors(current, CurrentChangeVector);
+                        subscriptionState.SubscriptionShardingState.NodeTagPerShard[ShardName] = NodeTag;
                     }
 
                     using (var obj = context.ReadObject(subscriptionState.ToJson(), "subscription"))
@@ -189,7 +189,7 @@ namespace Raven.Server.ServerWide.Commands.Subscriptions
                 return;
             }
 
-            state.ChangeVectorForNextBatchStartingPointPerShard.TryGetValue(ShardName, out string cvInStorage);
+            state.SubscriptionShardingState.ChangeVectorForNextBatchStartingPointPerShard.TryGetValue(ShardName, out string cvInStorage);
             if (cvInStorage != PreviouslyRecordedChangeVector)
             {
                 throw new SubscriptionChangeVectorUpdateConcurrencyException($"Can't record sharded subscription with name '{subscriptionName}' due to inconsistency in change vector progress. Probably there was an admin intervention that changed the change vector value. Stored value: {cvInStorage}, received value: {PreviouslyRecordedChangeVector}.");

--- a/src/Raven.Server/ServerWide/Commands/Subscriptions/UpdateSubscriptionClientConnectionTime.cs
+++ b/src/Raven.Server/ServerWide/Commands/Subscriptions/UpdateSubscriptionClientConnectionTime.cs
@@ -16,6 +16,7 @@ namespace Raven.Server.ServerWide.Commands.Subscriptions
         public string NodeTag;
         public bool HasHighlyAvailableTasks;
         public DateTime LastClientConnectionTime;
+
         private UpdateSubscriptionClientConnectionTime()
         {
         }
@@ -35,10 +36,10 @@ namespace Raven.Server.ServerWide.Commands.Subscriptions
             var subscription = JsonDeserializationCluster.SubscriptionState(existingValue);
 
             DevelopmentHelper.ShardingToDo(DevelopmentHelper.TeamMember.Karmel, DevelopmentHelper.Severity.Normal, "create subscription WhosTaskIsIt");
-            DevelopmentHelper.ShardingToDo(DevelopmentHelper.TeamMember.Karmel, DevelopmentHelper.Severity.Normal, "Need to handle NodeTag, currently is isn't used for sharded because it is shared");
 
+            // for sharded the topology is the orchestrator and the node-tag here is the orchestrator's responsible node
             var topology = record.TopologyForSubscriptions();
-            var lastResponsibleNode = record.IsSharded ? null : AcknowledgeSubscriptionBatchCommand.GetLastResponsibleNode(HasHighlyAvailableTasks, topology, NodeTag);
+            var lastResponsibleNode = AcknowledgeSubscriptionBatchCommand.GetLastResponsibleNode(HasHighlyAvailableTasks, topology, NodeTag);
 
             var appropriateNode = topology.WhoseTaskIsIt(RachisState.Follower, subscription, lastResponsibleNode);
 

--- a/src/Raven.Server/ServerWide/Context/TransactionOperationContext.cs
+++ b/src/Raven.Server/ServerWide/Context/TransactionOperationContext.cs
@@ -222,14 +222,17 @@ namespace Raven.Server.ServerWide.Context
         public ChangeVector GetChangeVector(string version, string order)
         {
             ChangeVector allocatedChangeVector;
+            var versionChangeVector = GetChangeVector(version, throwOnRecursion: true);
+            var orderChangeVector = GetChangeVector(order, throwOnRecursion: true);
+
             if (_numberOfAllocatedChangeVectors < _allocatedChangeVectors.Count)
             {
                 allocatedChangeVector = _allocatedChangeVectors[_numberOfAllocatedChangeVectors++];
-                allocatedChangeVector.Renew(GetChangeVector(version), GetChangeVector(order));
+                allocatedChangeVector.Renew(versionChangeVector, orderChangeVector);
                 return allocatedChangeVector;
             }
 
-            allocatedChangeVector = new ChangeVector(new ChangeVector(version, this), new ChangeVector(order, this));
+            allocatedChangeVector = new ChangeVector(versionChangeVector, orderChangeVector);
             if (_numberOfAllocatedChangeVectors < _maxOfAllocatedChangeVectors)
             {
                 _allocatedChangeVectors.Add(allocatedChangeVector);

--- a/src/Raven.Server/ServerWide/ShardingStore.cs
+++ b/src/Raven.Server/ServerWide/ShardingStore.cs
@@ -15,30 +15,30 @@ namespace Raven.Server.ServerWide
         }
 
         
-        public Task<(long Index, object Result)> StartBucketMigration(string database, int bucket, int fromShard, int toShard)
+        public Task<(long Index, object Result)> StartBucketMigration(string database, int bucket, int fromShard, int toShard, string raftId)
         {
-            var cmd = new StartBucketMigrationCommand(bucket, fromShard, toShard, database, RaftIdGenerator.NewId());
+            var cmd = new StartBucketMigrationCommand(bucket, fromShard, toShard, database, raftId);
 
             return _server.SendToLeaderAsync(cmd);
         }
 
-        public Task<(long Index, object Result)> SourceMigrationCompleted(string database, int bucket, long migrationIndex, string lastChangeVector)
+        public Task<(long Index, object Result)> SourceMigrationCompleted(string database, int bucket, long migrationIndex, string lastChangeVector, string raftId)
         {
-            var cmd = new SourceMigrationSendCompletedCommand(bucket, migrationIndex, lastChangeVector, database, RaftIdGenerator.NewId());
+            var cmd = new SourceMigrationSendCompletedCommand(bucket, migrationIndex, lastChangeVector, database, raftId);
 
             return _server.SendToLeaderAsync(cmd);
         }
 
-        public Task<(long Index, object Result)> DestinationMigrationConfirm(string database, int bucket, long migrationIndex)
+        public Task<(long Index, object Result)> DestinationMigrationConfirm(string database, int bucket, long migrationIndex, string raftId)
         {
-            var cmd = new DestinationMigrationConfirmCommand(bucket, migrationIndex, _server.NodeTag, database, RaftIdGenerator.NewId());
+            var cmd = new DestinationMigrationConfirmCommand(bucket, migrationIndex, _server.NodeTag, database, raftId);
 
             return _server.SendToLeaderAsync(cmd);
         }
 
-        public Task<(long Index, object Result)> SourceMigrationCleanup(string database, int bucket, long migrationIndex)
+        public Task<(long Index, object Result)> SourceMigrationCleanup(string database, int bucket, long migrationIndex, string raftId)
         {
-            var cmd = new SourceMigrationCleanupCommand(bucket, migrationIndex, _server.NodeTag, database, RaftIdGenerator.NewId());
+            var cmd = new SourceMigrationCleanupCommand(bucket, migrationIndex, _server.NodeTag, database, raftId);
 
             return _server.SendToLeaderAsync(cmd);
         }

--- a/src/Raven.Server/Utils/ShardHelper.cs
+++ b/src/Raven.Server/Utils/ShardHelper.cs
@@ -203,6 +203,12 @@ namespace Raven.Server.Utils
             return ranges[^1].ShardNumber;
         }
 
+        public static int GetShardNumber(List<ShardBucketRange> ranges, string id)
+        {
+            var bucket = GetBucket(id);
+            return GetShardNumber(ranges, bucket);
+        }
+
         public static void MoveBucket(this DatabaseRecord record, int bucket, int toShard)
         {
             try

--- a/src/Raven.Server/Web/System/AdminDatabasesHandler.cs
+++ b/src/Raven.Server/Web/System/AdminDatabasesHandler.cs
@@ -445,7 +445,7 @@ namespace Raven.Server.Web.System
             {
                 databaseRecord.Sharding.Orchestrator ??= new OrchestratorConfiguration();
                 databaseRecord.Sharding.Orchestrator.Topology ??= new OrchestratorTopology();
-                databaseRecord.Sharding.Orchestrator.Topology.ReplicationFactor = Math.Min(replicationFactor, clusterTopology.AllNodes.Count);
+                SetReplicationFactor(databaseRecord.Sharding.Orchestrator.Topology, clusterTopology, replicationFactor);
 
                 foreach (var databaseTopology in databaseRecord.Sharding.Shards)
                     UpdateDatabaseTopology(databaseTopology, clusterTopology, replicationFactor, clusterTransactionId);
@@ -455,6 +455,12 @@ namespace Raven.Server.Web.System
                 databaseRecord.Topology ??= new DatabaseTopology();
                 UpdateDatabaseTopology(databaseRecord.Topology, clusterTopology, replicationFactor, clusterTransactionId);
             }
+        }
+
+        private static void SetReplicationFactor(DatabaseTopology databaseTopology, ClusterTopology clusterTopology, int replicationFactor)
+        {
+            databaseTopology.ReplicationFactor = Math.Max(databaseTopology.ReplicationFactor, replicationFactor);
+            databaseTopology.ReplicationFactor = Math.Min(databaseTopology.ReplicationFactor, clusterTopology.AllNodes.Count);
         }
 
         private static void UpdateDatabaseTopology(DatabaseTopology databaseTopology, ClusterTopology clusterTopology, int replicationFactor, string clusterTransactionId)
@@ -469,8 +475,8 @@ namespace Raven.Server.Web.System
 
                 replicationFactor = databaseTopology.Count;
             }
-
-            databaseTopology.ReplicationFactor = Math.Min(replicationFactor, clusterTopology.AllNodes.Count);
+            
+            SetReplicationFactor(databaseTopology, clusterTopology, replicationFactor);
 
             databaseTopology.ClusterTransactionIdBase64 ??= clusterTransactionId;
             databaseTopology.DatabaseTopologyIdBase64 ??= Guid.NewGuid().ToBase64Unpadded();

--- a/src/Raven.Server/Web/System/Processors/OngoingTasks/AbstractOngoingTasksHandlerProcessorForGetOngoingTasks.cs
+++ b/src/Raven.Server/Web/System/Processors/OngoingTasks/AbstractOngoingTasksHandlerProcessorForGetOngoingTasks.cs
@@ -515,7 +515,7 @@ internal abstract class AbstractOngoingTasksHandlerProcessorForGetOngoingTasks<T
             TaskId = subscriptionState.SubscriptionId,
             Query = subscriptionState.Query,
             ChangeVectorForNextBatchStartingPoint = subscriptionState.ChangeVectorForNextBatchStartingPoint,
-            ChangeVectorForNextBatchStartingPointPerShard = subscriptionState.SubscriptionShardingState.ChangeVectorForNextBatchStartingPointPerShard,
+            ChangeVectorForNextBatchStartingPointPerShard = subscriptionState.SubscriptionShardingState?.ChangeVectorForNextBatchStartingPointPerShard,
             SubscriptionId = subscriptionState.SubscriptionId,
             SubscriptionName = subscriptionState.SubscriptionName,
             LastBatchAckTime = subscriptionState.LastBatchAckTime,

--- a/src/Raven.Server/Web/System/Processors/OngoingTasks/AbstractOngoingTasksHandlerProcessorForGetOngoingTasks.cs
+++ b/src/Raven.Server/Web/System/Processors/OngoingTasks/AbstractOngoingTasksHandlerProcessorForGetOngoingTasks.cs
@@ -515,7 +515,7 @@ internal abstract class AbstractOngoingTasksHandlerProcessorForGetOngoingTasks<T
             TaskId = subscriptionState.SubscriptionId,
             Query = subscriptionState.Query,
             ChangeVectorForNextBatchStartingPoint = subscriptionState.ChangeVectorForNextBatchStartingPoint,
-            ChangeVectorForNextBatchStartingPointPerShard = subscriptionState.ChangeVectorForNextBatchStartingPointPerShard,
+            ChangeVectorForNextBatchStartingPointPerShard = subscriptionState.SubscriptionShardingState.ChangeVectorForNextBatchStartingPointPerShard,
             SubscriptionId = subscriptionState.SubscriptionId,
             SubscriptionName = subscriptionState.SubscriptionName,
             LastBatchAckTime = subscriptionState.LastBatchAckTime,

--- a/src/Raven.Studio/typescript/models/database/tasks/ongoingTaskSubscriptionEditModel.ts
+++ b/src/Raven.Studio/typescript/models/database/tasks/ongoingTaskSubscriptionEditModel.ts
@@ -163,7 +163,9 @@ class ongoingTaskSubscriptionEditModel extends ongoingTaskEditModel {
                 LastBatchAckTime: null,
                 MentorNode: null,
                 NodeTag: null,
-                ChangeVectorForNextBatchStartingPointPerShard: null
+                ChangeVectorForNextBatchStartingPointPerShard: null,
+                IgnoreBucketLesserChangeVector: null,
+                NodeTagPerShard: null
             });
     }
 }

--- a/test/SlowTests/Sharding/Cluster/ReshardingTests.cs
+++ b/test/SlowTests/Sharding/Cluster/ReshardingTests.cs
@@ -4,6 +4,7 @@ using FastTests.Sharding;
 using Orders;
 using Raven.Client.Documents.Smuggler;
 using Raven.Client.ServerWide.Operations;
+using Raven.Client.Util;
 using Raven.Server.Utils;
 using SlowTests.Core.Utils.Entities;
 using Tests.Infrastructure;
@@ -46,7 +47,7 @@ namespace SlowTests.Sharding.Cluster
                     Assert.NotNull(user);
                 }
 
-                var result = await Server.ServerStore.Sharding.StartBucketMigration(store.Database, bucket, location, newLocation);
+                var result = await Server.ServerStore.Sharding.StartBucketMigration(store.Database, bucket, location, newLocation, RaftIdGenerator.NewId());
 
                 var exists = WaitForDocument<User>(store, id, predicate: null, database: ShardHelper.ToShardName(store.Database, newLocation));
                 Assert.True(exists);
@@ -55,10 +56,10 @@ namespace SlowTests.Sharding.Cluster
                 {
                     var user = await session.LoadAsync<User>(id);
                     var changeVector = session.Advanced.GetChangeVectorFor(user);
-                    await Server.ServerStore.Sharding.SourceMigrationCompleted(store.Database, bucket, result.Index, changeVector);
+                    await Server.ServerStore.Sharding.SourceMigrationCompleted(store.Database, bucket, result.Index, changeVector, RaftIdGenerator.NewId());
                 }
 
-                result = await Server.ServerStore.Sharding.DestinationMigrationConfirm(store.Database, bucket, result.Index);
+                result = await Server.ServerStore.Sharding.DestinationMigrationConfirm(store.Database, bucket, result.Index, RaftIdGenerator.NewId());
                 await Server.ServerStore.Cluster.WaitForIndexNotification(result.Index);
 
                 // the document will be written to the new location
@@ -96,7 +97,7 @@ namespace SlowTests.Sharding.Cluster
                     Assert.NotNull(order);
                 }
 
-                var result = await Server.ServerStore.Sharding.StartBucketMigration(store.Database, bucket, location, newLocation);
+                var result = await Server.ServerStore.Sharding.StartBucketMigration(store.Database, bucket, location, newLocation, RaftIdGenerator.NewId());
 
                 var exists = WaitForDocument<Order>(store, id, predicate: null, database: ShardHelper.ToShardName(store.Database, newLocation));
                 Assert.True(exists);
@@ -105,10 +106,10 @@ namespace SlowTests.Sharding.Cluster
                 {
                     var order = await session.LoadAsync<Order>(id);
                     var changeVector = session.Advanced.GetChangeVectorFor(order);
-                    await Server.ServerStore.Sharding.SourceMigrationCompleted(store.Database, bucket, result.Index, changeVector);
+                    await Server.ServerStore.Sharding.SourceMigrationCompleted(store.Database, bucket, result.Index, changeVector, RaftIdGenerator.NewId());
                 }
 
-                result = await Server.ServerStore.Sharding.DestinationMigrationConfirm(store.Database, bucket, result.Index);
+                result = await Server.ServerStore.Sharding.DestinationMigrationConfirm(store.Database, bucket, result.Index, RaftIdGenerator.NewId());
                 await Server.ServerStore.Cluster.WaitForIndexNotification(result.Index);
 
                 // the document will be written to the new location

--- a/test/SlowTests/Sharding/Cluster/SubscriptionsWithReshardingTests.cs
+++ b/test/SlowTests/Sharding/Cluster/SubscriptionsWithReshardingTests.cs
@@ -4,8 +4,10 @@ using System.Diagnostics;
 using System.Linq;
 using System.Threading;
 using System.Threading.Tasks;
+using Raven.Client.Documents;
 using Raven.Client.Documents.Subscriptions;
 using Raven.Client.Exceptions.Documents.Subscriptions;
+using Raven.Server.Utils;
 using Raven.Tests.Core.Utils.Entities;
 using Tests.Infrastructure;
 using Xunit;
@@ -19,124 +21,14 @@ namespace SlowTests.Sharding.Cluster
         {
         }
 
-        [RavenFact(RavenTestCategory.Sharding | RavenTestCategory.Subscriptions, Skip = "fix after resharding")]
+        [RavenFact(RavenTestCategory.Sharding | RavenTestCategory.Subscriptions)]
         public async Task ContinueSubscriptionAfterResharding()
         {
             using var store = Sharding.GetDocumentStore();
-            var id = await store.Subscriptions.CreateAsync<User>();
-            
-            var users = new HashSet<string>(StringComparer.OrdinalIgnoreCase);
-
-            var mre = new ManualResetEvent(false);
-            await using (var subscription = store.Subscriptions.GetSubscriptionWorker<User>(new SubscriptionWorkerOptions(id)
-                         {
-                              MaxDocsPerBatch = 5
-                         }))
-            {
-                subscription.AfterAcknowledgment += batch =>
-                {
-                    mre.Set();
-                    return Task.CompletedTask;
-                };
-
-                var t = subscription.Run(batch =>
-                {
-                    foreach (var item in batch.Items)
-                    {
-                        if (users.Add(item.Id) == false)
-                        {
-                            throw new SubscriberErrorException($"Got same {item.Id} twice");
-                        }
-                    }
-                });
-
-                using (var session = store.OpenSession())
-                {
-                    session.Store(new User(),"foo$users/1-A");
-
-                    for (int i = 0; i < 20; i++)
-                    {
-                        session.Store(new User());
-                    }
-
-                    session.Store(new User(),"foo$users/8-A");
-
-                    session.SaveChanges();
-                }
-                
-                Assert.True(mre.WaitOne(TimeSpan.FromSeconds(5)));
-                mre.Reset();
-
-                await Sharding.Resharding.MoveShardForId(store, "users/1-A");
-
-                using (var session = store.OpenSession())
-                {
-                    session.Store(new User(),"bar$users/1-A");
-
-                    for (int i = 0; i < 20; i++)
-                    {
-                        session.Store(new User());
-                    }
-
-                    session.Store(new User(),"bar$users/8-A");
-
-                    session.SaveChanges();
-                }
-
-                Assert.True(mre.WaitOne(TimeSpan.FromSeconds(5)));
-                mre.Reset();
-
-                await Sharding.Resharding.MoveShardForId(store, "users/8-A");
-
-                using (var session = store.OpenSession())
-                {
-                    session.Store(new User(),"baz$users/1-A");
-
-                    for (int i = 0; i < 20; i++)
-                    {
-                        session.Store(new User());
-                    }
-
-                    session.Store(new User(),"baz$users/8-A");
-
-
-                    session.SaveChanges();
-                }
-
-                try
-                {
-                    await t.WaitAsync(TimeSpan.FromSeconds(5));
-                    Assert.True(false, "Worker completed without exception");
-                }
-                catch (TimeoutException)
-                {
-                   
-                }
-
-                var expected = new HashSet<string>();
-                for (int i = 1; i < 61; i++)
-                {
-                    var u = $"users/{i}-A";
-                    expected.Add(u);
-                }
-
-                expected.Add("foo$users/1-A");
-                expected.Add("bar$users/1-A");
-                expected.Add("baz$users/1-A");
-                expected.Add("foo$users/8-A");
-                expected.Add("bar$users/8-A");
-                expected.Add("baz$users/8-A");
-
-                foreach (var user in users)
-                {
-                    expected.Remove(user);
-                }
-                
-                Assert.True(expected.Count == 0, $"Missing {string.Join(Environment.NewLine, expected)}");
-            }
+            await SubscriptionWithResharding(store);
         }
 
-        [RavenFact(RavenTestCategory.Sharding | RavenTestCategory.Subscriptions, Skip = "fix after resharding")]
+        [RavenFact(RavenTestCategory.Sharding)]
         public async Task ContinueSubscriptionAfterReshardingInACluster()
         {
             var cluster = await CreateRaftCluster(5, watcherCluster: true);
@@ -146,15 +38,65 @@ namespace SlowTests.Sharding.Cluster
                 ReplicationFactor = 3,
             });
 
-            var id = await store.Subscriptions.CreateAsync<User>();
-            
-            var users = new Dictionary<string, HashSet<string>>(StringComparer.OrdinalIgnoreCase);
+            await SubscriptionWithResharding(store);
+        }
 
+        [RavenFact(RavenTestCategory.Sharding, Skip = "Need to handle resharding failover")]
+        public async Task ContinueSubscriptionAfterReshardingInAClusterWithFailover()
+        {
+            var cluster = await CreateRaftCluster(5, watcherCluster: true);
+            using var store = Sharding.GetDocumentStore(new Options
+            {
+                Server = cluster.Leader,
+                ReplicationFactor = 3,
+            });
+
+            using (var cts = new CancellationTokenSource())
+            {
+                var fail = Task.Run(async () =>
+                {
+                    try
+                    {
+                        while (cts.IsCancellationRequested == false)
+                        {
+                            var position = Random.Shared.Next(0, 5);
+                            var node = cluster.Nodes[position];
+                            if (node.ServerStore.IsLeader())
+                                continue;
+
+                            var result = await DisposeServerAndWaitForFinishOfDisposalAsync(node);
+                            await Task.Delay(TimeSpan.FromMilliseconds(1000), cts.Token);
+                            cluster.Nodes[position] = await ReviveNodeAsync(result);
+                            await Task.Delay(TimeSpan.FromMilliseconds(1000), cts.Token);
+                        }
+                    }
+                    catch (OperationCanceledException)
+                    {
+                        // shutdown
+                    }
+                });
+
+                try
+                {
+                    await SubscriptionWithResharding(store);
+                }
+                finally
+                {
+                   cts.Cancel();
+                   await fail;
+                }
+            }
+        }
+
+        private async Task SubscriptionWithResharding(IDocumentStore store)
+        {
+            var id = await store.Subscriptions.CreateAsync<User>();
+            var users = new Dictionary<string, HashSet<string>>(StringComparer.OrdinalIgnoreCase);
             var mre = new ManualResetEvent(false);
             await using (var subscription = store.Subscriptions.GetSubscriptionWorker<User>(new SubscriptionWorkerOptions(id)
                          {
-                              MaxDocsPerBatch = 5,
-                              TimeToWaitBeforeConnectionRetry = TimeSpan.FromMilliseconds(250)
+                             MaxDocsPerBatch = 5, 
+                             TimeToWaitBeforeConnectionRetry = TimeSpan.FromMilliseconds(250)
                          }))
             {
                 subscription.AfterAcknowledgment += batch =>
@@ -176,49 +118,69 @@ namespace SlowTests.Sharding.Cluster
                         }
                     }
                 });
-                
+
 
                 using (var session = store.OpenSession())
                 {
-                    session.Store(new User(),"foo$users/1-A");
-
-                    for (int i = 0; i < 20; i++)
-                    {
-                        session.Store(new User(),NextId);
-                    }
-
-                    session.Store(new User(),"foo$users/8-A");
-
-                    session.SaveChanges();
-                }
-                
-                Assert.True(mre.WaitOne(TimeSpan.FromSeconds(5)));
-                mre.Reset();
-
-                await WaitAndAssertForValueAsync(() => users["users/8-A"].Count, 1);
-                await WaitAndAssertForValueAsync(() => users["users/1-A"].Count, 1);
-
-                await Sharding.Resharding.MoveShardForId(store, "users/1-A");
-
-                using (var session = store.OpenSession())
-                {
-                    session.Store(new User(),"bar$users/1-A");
-                    session.Store(new User(),"users/1-A");
+                    session.Store(new User(), "foo$users/1-A");
 
                     for (int i = 0; i < 20; i++)
                     {
                         session.Store(new User(), NextId);
                     }
 
-                    session.Store(new User(),"bar$users/8-A");
-                    session.Store(new User(),"users/8-A");
+                    session.Store(new User(), "foo$users/8-A");
+
+                    session.SaveChanges();
+                }
+
+                try
+                {
+                    await t.WaitAsync(TimeSpan.FromSeconds(5));
+                    Assert.True(false, "Worker completed without exception");
+                }
+                catch (TimeoutException)
+                {
+                    // expected, means the worker is still alive  
+                }
+
+                mre.Reset();
+
+                await WaitAndAssertForValueAsync(() => users["users/8-A"].Count, 1);
+                await WaitAndAssertForValueAsync(() => users["users/1-A"].Count, 1);
+
+                await Sharding.Resharding.MoveShardForId(store, "users/1-A");
+                await Sharding.Resharding.MoveShardForId(store, "users/1-A");
+
+                try
+                {
+                    await t.WaitAsync(TimeSpan.FromSeconds(5));
+                    Assert.True(false, "Worker completed without exception");
+                }
+                catch (TimeoutException)
+                {
+                    // expected, means the worker is still alive  
+                }
+
+                using (var session = store.OpenSession())
+                {
+                    session.Store(new User(), "bar$users/1-A");
+                    session.Store(new User(), "users/1-A");
+
+                    for (int i = 0; i < 20; i++)
+                    {
+                        session.Store(new User(), NextId);
+                    }
+
+                    session.Store(new User(), "bar$users/8-A");
+                    session.Store(new User(), "users/8-A");
 
                     session.SaveChanges();
                 }
 
                 await WaitAndAssertForValueAsync(() => users["users/8-A"].Count, 2);
                 await WaitAndAssertForValueAsync(() => users["users/1-A"].Count, 2);
-
+                
                 Assert.True(mre.WaitOne(TimeSpan.FromSeconds(5)));
                 mre.Reset();
 
@@ -226,28 +188,24 @@ namespace SlowTests.Sharding.Cluster
 
                 using (var session = store.OpenSession())
                 {
-                    session.Store(new User(),"baz$users/1-A");
-                    session.Store(new User(),"users/1-A");
+                    session.Store(new User(), "baz$users/1-A");
+                    session.Store(new User(), "users/1-A");
 
                     for (int i = 0; i < 20; i++)
                     {
                         session.Store(new User(), NextId);
                     }
 
-                    session.Store(new User(),"baz$users/8-A");
-                    session.Store(new User(),"users/8-A");
+                    session.Store(new User(), "baz$users/8-A");
+                    session.Store(new User(), "users/8-A");
 
 
                     session.SaveChanges();
                 }
 
-                await Assert.ThrowsAsync<TimeoutException>(() => t.WaitAsync(TimeSpan.FromSeconds(5)));
-
-                Assert.Equal(3, users["users/1-A"].Count);
-                Assert.Equal(3, users["users/8-A"].Count);
-
-                var total = users.Sum(x => x.Value.Count);
-                Assert.Equal(70, total);
+                await WaitAndAssertForValueAsync(() => users["users/8-A"].Count, 3);
+                await WaitAndAssertForValueAsync(() => users["users/1-A"].Count, 3);
+                await WaitForValueAsync(() => users.Count, 66);
 
                 var expected = new HashSet<string>();
                 for (int i = 1; i < 61; i++)
@@ -267,8 +225,13 @@ namespace SlowTests.Sharding.Cluster
                 {
                     expected.Remove(user.Key);
                 }
+
+                var config = await Sharding.GetShardingConfigurationAsync(store);
+                Assert.True(expected.Count == 0,
+                    $"Missing {string.Join(Environment.NewLine, expected.Select(e => $"{e} (shard: {ShardHelper.GetShardNumber(config.BucketRanges, e)})"))}");
+
                 
-                Assert.True(expected.Count == 0, $"Missing {string.Join(Environment.NewLine, expected)}");
+                await Sharding.Subscriptions.AssertNoItemsInTheResendQueueAsync(store, id);
             }
         }
 

--- a/test/SlowTests/Sharding/Subscriptions/ShardedSubscriptionClusterTests.cs
+++ b/test/SlowTests/Sharding/Subscriptions/ShardedSubscriptionClusterTests.cs
@@ -25,7 +25,7 @@ namespace SlowTests.Sharding.Subscriptions
         {
         }
 
-        private readonly TimeSpan _reasonableWaitTime = Debugger.IsAttached ? TimeSpan.FromMinutes(15) : TimeSpan.FromSeconds(60);
+        private readonly TimeSpan _reasonableWaitTime = Debugger.IsAttached ? TimeSpan.FromMinutes(15) : TimeSpan.FromSeconds(3000);
 
         [Fact]
         public async Task CanRunShardedSubscriptionInCluster()
@@ -79,12 +79,12 @@ namespace SlowTests.Sharding.Subscriptions
         {
             int rf = 1;
             int clusterSize = 3;
-            var db = GetDatabaseName();
             var (nodes, leader) = await CreateRaftCluster(clusterSize, shouldRunInMemory: false);
+            var options = Sharding.GetOptionsForCluster(nodes, shards: 3, shardReplicationFactor: 1, orchestratorReplicationFactor: clusterSize);
+            options.Server = leader;
+            options.RunInMemory = false;
 
-            await ShardingCluster.CreateShardedDatabaseInCluster(db, rf, (nodes, leader));
-
-            using (var store = new DocumentStore { Database = db, Urls = new[] { leader.WebUrl } }.Initialize())
+            using (var store = Sharding.GetDocumentStore(options))
             {
                 var id = store.Subscriptions.Create<User>();
                 var subscriptions = await store.Subscriptions.GetSubscriptionsAsync(0, 5);
@@ -106,8 +106,8 @@ namespace SlowTests.Sharding.Subscriptions
                 }
 
                 // Wait for documents to replicate
-                Assert.True(ShardingCluster.WaitForShardedChangeVectorInCluster(nodes, store.Database, rf));
-
+                Assert.True(await ShardingCluster.WaitForShardedChangeVectorInClusterAsync(nodes, store.Database, rf));
+                
                 var disposed = new List<string>();
                 var hashset = new HashSet<string>();
                 var tagsToDispose = new HashSet<string>();
@@ -133,7 +133,7 @@ namespace SlowTests.Sharding.Subscriptions
                     nodesWithIds.Add(kvp.Key, internalDic);
                 }
 
-                Assert.True(tagsToDispose.Count == 3, "tagsToDispose.Count == 3");
+                Assert.True(tagsToDispose.Count == 3, $"{tagsToDispose.Count} != 3");
 
                 var c1 = rf;
                 while (c1-- != 0)
@@ -193,7 +193,7 @@ namespace SlowTests.Sharding.Subscriptions
                             mre2.Set();
                     });
 
-                    Assert.True(await mre.WaitAsync(_reasonableWaitTime));
+                    Assert.True(await mre.WaitAsync(_reasonableWaitTime),$"error: {t.Exception}");
 
                     Assert.All(expectedIds, s => Assert.Contains(s, results));
                     results.Clear();
@@ -201,26 +201,10 @@ namespace SlowTests.Sharding.Subscriptions
                     var dispsoedNode = nodes.FirstOrDefault(x => x.ServerStore.NodeTag == disposed.First());
                     Assert.NotNull(dispsoedNode);
 
-                    var settings = new Dictionary<string, string>(DefaultClusterSettings)
-                    {
-                        [RavenConfiguration.GetKey(x => x.Core.ServerUrls)] = dispsoedNode.WebUrl,
-                        [RavenConfiguration.GetKey(x => x.Cluster.ElectionTimeout)] = $"{dispsoedNode.Configuration.Cluster.ElectionTimeout.GetValue(TimeUnit.Milliseconds)}",
-                    };
-
-                    var dataDirectory = dispsoedNode.Configuration.Core.DataDirectory.FullPath;
-
-                    var node = base.GetNewServer(new ServerCreationOptions()
-                    {
-                        DeletePrevious = false,
-                        RunInMemory = false,
-                        CustomSettings = settings,
-                        DataDirectory = dataDirectory
-                    });
-
-                    Assert.True(node.ServerStore.Engine.CurrentState != RachisState.Passive, "node.ServerStore.Engine.CurrentState != RachisState.Passive");
-
+                    await ReviveNodeAsync((dispsoedNode.Configuration.Core.DataDirectory.FullPath, dispsoedNode.WebUrl, dispsoedNode.ServerStore.NodeTag));
+                    
                     // disposed node should reconnect and send docs
-                    Assert.True(await mre2.WaitAsync(_reasonableWaitTime));
+                    Assert.True(await mre2.WaitAsync(_reasonableWaitTime), $"error: {t.Exception}");
                     Assert.All(expectedIds2, s => Assert.Contains(s, results));
                 }
             }

--- a/test/SlowTests/Sharding/Subscriptions/ShardedSubscriptionSlowTests.cs
+++ b/test/SlowTests/Sharding/Subscriptions/ShardedSubscriptionSlowTests.cs
@@ -175,8 +175,8 @@ namespace SlowTests.Sharding.Subscriptions
 
         private async Task CheckSubscriptionNewQuery(IDocumentStore store, SubscriptionState state, string newQuery)
         {
-            var shards = await Sharding.GetShardsDocumentDatabaseInstancesFor(store);
-            foreach (var db in shards)
+            var shards = Sharding.GetShardsDocumentDatabaseInstancesFor(store);
+            await foreach (var db in shards)
             {
                 using (db.ServerStore.ContextPool.AllocateOperationContext(out TransactionOperationContext ctx))
                 using (ctx.OpenReadTransaction())
@@ -412,8 +412,8 @@ namespace SlowTests.Sharding.Subscriptions
 
                     var firstItemchangeVector = cvFirst.ToChangeVector();
                     var cvNew = new List<ChangeVectorEntry>();
-                    var shards = (await Sharding.GetShardsDocumentDatabaseInstancesFor(store)).ToList();
-                    foreach (var db in shards)
+
+                    await foreach (var db in Sharding.GetShardsDocumentDatabaseInstancesFor(store))
                     {
                         cvNew.Add(new ChangeVectorEntry()
                         {
@@ -436,7 +436,8 @@ namespace SlowTests.Sharding.Subscriptions
                     {
                         subscriptionState = Server.ServerStore.Cluster.Subscriptions.ReadSubscriptionStateByName(context, store.Database, subscriptionId);
                     }
-                    foreach (var db in shards)
+
+                    await foreach (var db in Sharding.GetShardsDocumentDatabaseInstancesFor(store))
                     {
                         var connectionState = db.SubscriptionStorage.PutSubscription(new SubscriptionCreationOptions()
                         {
@@ -620,7 +621,7 @@ namespace SlowTests.Sharding.Subscriptions
                     });
 
                     await AssertWaitForTrueAsync(() => Task.FromResult(con1Docs.Count + con2Docs.Count == 6), 6000);
-                    await AssertNoLeftovers(store, id);
+                    await Sharding.Subscriptions.AssertNoItemsInTheResendQueueAsync(store, id);
                 }
             }
         }
@@ -676,24 +677,8 @@ namespace SlowTests.Sharding.Subscriptions
                     amre.Set();
 
                     await AssertWaitForTrueAsync(() => Task.FromResult(con1Docs.Count == 6), 6000);
-                    await AssertNoLeftovers(store, id);
+                    await Sharding.Subscriptions.AssertNoItemsInTheResendQueueAsync(store, id);
                 }
-            }
-        }
-
-        private async Task AssertNoLeftovers(IDocumentStore store, string id)
-        {
-            var shards = await Sharding.GetShardsDocumentDatabaseInstancesFor(store);
-            foreach (var db in shards)
-            {
-                await AssertWaitForValueAsync(() =>
-                {
-                    using (Server.ServerStore.ContextPool.AllocateOperationContext(out TransactionOperationContext ctx))
-                    using (ctx.OpenReadTransaction())
-                    {
-                        return Task.FromResult(db.SubscriptionStorage.GetSubscriptionConnectionsState(ctx, id).GetNumberOfResendDocuments(SubscriptionType.Document));
-                    }
-                }, 0);
             }
         }
     }

--- a/test/Tests.Infrastructure/ClusterTestBase.cs
+++ b/test/Tests.Infrastructure/ClusterTestBase.cs
@@ -599,6 +599,27 @@ namespace Tests.Infrastructure
             return (dataDirectory, url, nodeTag);
         }
 
+        protected async Task<RavenServer> ReviveNodeAsync((string DataDirectory, string Url, string NodeTag) info, ServerCreationOptions options = default)
+        {
+            options ??= new ServerCreationOptions
+            {
+                RunInMemory = false,
+                DeletePrevious = false,
+                RegisterForDisposal = true,
+                CustomSettings = DefaultClusterSettings
+            };
+
+            options.CustomSettings ??= new Dictionary<string, string>();
+
+            options.DataDirectory = info.DataDirectory;
+            options.NodeTag = info.NodeTag;
+            options.CustomSettings[RavenConfiguration.GetKey(x => x.Core.ServerUrls)] = info.Url;
+
+            var server = GetNewServer(options);
+            await server.ServerStore.InitializationCompleted.WaitAsync();
+            return server;
+        }
+
         protected static async Task<(string DataDirectory, string Url, string NodeTag)> DisposeServerAndWaitForFinishOfDisposalAsync(RavenServer serverToDispose)
         {
             var dataDirectory = serverToDispose.Configuration.Core.DataDirectory.FullPath;

--- a/test/Tests.Infrastructure/TestBase.cs
+++ b/test/Tests.Infrastructure/TestBase.cs
@@ -275,6 +275,16 @@ namespace FastTests
                 return _globalServer;
             }
         }
+            
+        public List<RavenServer> GetServers()
+        {
+            if (Servers.Count > 0)
+            {
+                return Servers;
+            }
+
+            return new List<RavenServer> { Server };
+        }
 
         private static void CheckServerLeak()
         {

--- a/test/Tryouts/Program.cs
+++ b/test/Tryouts/Program.cs
@@ -9,7 +9,6 @@ using Raven.Server.Utils;
 using SlowTests.Cluster;
 using SlowTests.Issues;
 using SlowTests.Sharding.Cluster;
-using SlowTests.Sharding.Subscriptions;
 
 namespace Tryouts;
 
@@ -29,10 +28,10 @@ public static class Program
             try
             {
                 using (var testOutputHelper = new ConsoleTestOutputHelper())
-                using (var test = new ShardedSubscriptionClusterTests(testOutputHelper))
+                using (var test = new SubscriptionsWithReshardingTests(testOutputHelper))
                 {
                     DebuggerAttachedTimeout.DisableLongTimespan = true;
-                    await test.SubscriptionShouldTryConnectWithTimeoutIfShardUnavailable();
+                    await test.ContinueSubscriptionAfterResharding();
                 }
             }
             catch (Exception e)

--- a/test/Tryouts/Program.cs
+++ b/test/Tryouts/Program.cs
@@ -9,6 +9,7 @@ using Raven.Server.Utils;
 using SlowTests.Cluster;
 using SlowTests.Issues;
 using SlowTests.Sharding.Cluster;
+using SlowTests.Sharding.Subscriptions;
 
 namespace Tryouts;
 
@@ -28,10 +29,10 @@ public static class Program
             try
             {
                 using (var testOutputHelper = new ConsoleTestOutputHelper())
-                using (var test = new SubscriptionsWithReshardingTests(testOutputHelper))
+                using (var test = new ShardedSubscriptionClusterTests(testOutputHelper))
                 {
                     DebuggerAttachedTimeout.DisableLongTimespan = true;
-                    await test.ContinueSubscriptionAfterResharding();
+                    await test.SubscriptionShouldTryConnectWithTimeoutIfShardUnavailable();
                 }
             }
             catch (Exception e)


### PR DESCRIPTION
### Issue link

https://issues.hibernatingrhinos.com/issue/RavenDB-13106

### Additional description

Handle subscriptions while resharding. 
The idea is that upon resharding we will go over all of the existing subs for the database and mark the current processed change vector in a `Dictionary<long, string> IgnoreBucketLesserChangeVector`.

This will allow us to check migrated documents whether they already were processed by the subscription or not.

The change vector of a migrated document will look like `A:1 | B:10, MOVE:67` the left side the the document's version and the right side the order.

We will lookup the `IgnoreBucketLesserChangeVector` by the `MOVE` tag and compare the versions.

### Type of change

- New feature

### How risky is the change?

- Not relevant

### Backward compatibility

Don't know

### Is it platform specific issue?

- No

### Documentation update

- No documentation update is needed 

### Testing 

- Tests have been added that prove the fix is effective or that the feature works

### Is there any existing behavior change of other features due to this change?

- Yes. Please list the affected features/subsystems and provide appropriate explanation

### UI work

- No UI work is needed
