### PR TITLE
RavenDB-18938 Track stack size inside LINQ and warn the user against potential StackoverflowException

### DIFF
--- a/src/Raven.Server/Config/Categories/PerformanceHintsConfiguration.cs
+++ b/src/Raven.Server/Config/Categories/PerformanceHintsConfiguration.cs
@@ -63,5 +63,10 @@ namespace Raven.Server.Config.Categories
         [DefaultValue(true)]
         [ConfigurationEntry("PerformanceHints.Indexing.AlertWhenSourceDocumentIncludedInOutput", ConfigurationEntryScope.ServerWideOrPerDatabase)]
         public bool AlertWhenSourceDocumentIncludedInOutput { get; set; }
+        
+        [Description("Maximum depth of recursion in LINQ Select clause.")]
+        [DefaultValue(32)]
+        [ConfigurationEntry("PerformanceHints.Indexing.MaxDepthOfRecursionInLinqSelect", ConfigurationEntryScope.ServerWideOrPerDatabase)]
+        public int MaxDepthOfRecursionInLinqSelect { get; set; }
     }
 }

--- a/src/Raven.Server/Documents/Indexes/MapReduce/Static/MapReduceIndex.cs
+++ b/src/Raven.Server/Documents/Indexes/MapReduce/Static/MapReduceIndex.cs
@@ -297,6 +297,9 @@ namespace Raven.Server.Documents.Indexes.MapReduce.Static
                 new SingleIndexConfiguration(definition.Configuration, documentDatabase.Configuration),
                 documentDatabase.Configuration.PerformanceHints);
 
+            var staticIndex = instance._compiled;
+            staticIndex.CheckDepthOfStackInOutputMap(definition, documentDatabase);
+            
             return instance;
         }
 

--- a/src/Raven.Server/Documents/Indexes/Static/IndexCompiler.cs
+++ b/src/Raven.Server/Documents/Indexes/Static/IndexCompiler.cs
@@ -507,19 +507,24 @@ namespace Raven.Server.Documents.Indexes.Static
                     RegisterPackage(dependency, userDefined: false, references);
             }
         }
-
+        
         private static MemberDeclarationSyntax CreateClass(string name, IndexDefinition definition)
         {
             var statements = new List<StatementSyntax>();
             var maps = definition.Maps.ToList();
             var fieldNamesValidator = new FieldNamesValidator();
             var methodDetector = new MethodDetectorRewriter();
+            var stackDepthRetriever = new StackDepthRetriever();
             var members = new SyntaxList<MemberDeclarationSyntax>();
-
+            var maxDepthInRecursiveLinqQuery = 0;
+            
             for (var i = 0; i < maps.Count; i++)
             {
                 var map = maps[i];
-                statements.AddRange(HandleMap(definition.SourceType, map, fieldNamesValidator, methodDetector, ref members));
+                statements.AddRange(HandleMap(definition.SourceType, map, fieldNamesValidator, methodDetector, stackDepthRetriever, ref members));
+
+                maxDepthInRecursiveLinqQuery = Math.Max(maxDepthInRecursiveLinqQuery, stackDepthRetriever.StackSize);
+                stackDepthRetriever.Clear();
             }
 
             if (string.IsNullOrWhiteSpace(definition.Reduce) == false)
@@ -543,6 +548,8 @@ namespace Raven.Server.Documents.Indexes.Static
 
             var methods = methodDetector.Methods;
 
+            statements.Add(RoslynHelper.This(nameof(AbstractStaticIndexBase.StackSizeInSelectClause)).Assign(SyntaxFactory.ParseExpression($"{maxDepthInRecursiveLinqQuery}")).AsExpressionStatement());
+            
             if (methods.HasCreateField)
                 statements.Add(RoslynHelper.This(nameof(AbstractStaticIndexBase.HasDynamicFields)).Assign(SyntaxFactory.LiteralExpression(SyntaxKind.TrueLiteralExpression)).AsExpressionStatement());
 
@@ -603,7 +610,7 @@ namespace Raven.Server.Documents.Indexes.Static
             return fields;
         }
 
-        private static List<StatementSyntax> HandleMap(IndexSourceType type, string map, FieldNamesValidator fieldNamesValidator, MethodDetectorRewriter methodsDetector,
+        private static List<StatementSyntax> HandleMap(IndexSourceType type, string map, FieldNamesValidator fieldNamesValidator, MethodDetectorRewriter methodsDetector, StackDepthRetriever stackDepthRetriever,
             ref SyntaxList<MemberDeclarationSyntax> members)
         {
             try
@@ -613,10 +620,11 @@ namespace Raven.Server.Documents.Indexes.Static
 
                 fieldNamesValidator.Validate(map, expression);
                 methodsDetector.Visit(expression);
-
+                stackDepthRetriever.Visit(expression);
                 var queryExpression = expression as QueryExpressionSyntax;
                 if (queryExpression != null)
                 {
+                    
                     switch (type)
                     {
                         case IndexSourceType.Documents:
@@ -850,11 +858,12 @@ namespace Raven.Server.Documents.Indexes.Static
             var rewrittenExpression = (CSharpSyntaxNode)mapRewriter.Visit(expression);
 
             StatementSyntax optimized = null;
-
+            bool? foundSourceDocumentInProjection;
             try
             {
                 var visitor = new RavenLinqOptimizer(fieldValidator);
                 optimized = visitor.Visit(new RavenLinqPrettifier().Visit(rewrittenExpression)) as StatementSyntax;
+                foundSourceDocumentInProjection = visitor.FoundSourceDocumentInProjection;
             }
             catch (NotSupportedException)
             {
@@ -888,6 +897,7 @@ namespace Raven.Server.Documents.Indexes.Static
             }
             else
             {
+                //This is unoptimized case. We will scan C# code is manner thisMAX.[...]...doc;
                 mapExpression = SyntaxFactory.SimpleLambdaExpression(SyntaxFactory.Parameter(SyntaxFactory.Identifier(identifier)), rewrittenExpression);
             }
 

--- a/src/Raven.Server/Documents/Indexes/Static/IndexCompiler.cs
+++ b/src/Raven.Server/Documents/Indexes/Static/IndexCompiler.cs
@@ -858,12 +858,10 @@ namespace Raven.Server.Documents.Indexes.Static
             var rewrittenExpression = (CSharpSyntaxNode)mapRewriter.Visit(expression);
 
             StatementSyntax optimized = null;
-            bool? foundSourceDocumentInProjection;
             try
             {
                 var visitor = new RavenLinqOptimizer(fieldValidator);
                 optimized = visitor.Visit(new RavenLinqPrettifier().Visit(rewrittenExpression)) as StatementSyntax;
-                foundSourceDocumentInProjection = visitor.FoundSourceDocumentInProjection;
             }
             catch (NotSupportedException)
             {

--- a/src/Raven.Server/Documents/Indexes/Static/MapIndex.cs
+++ b/src/Raven.Server/Documents/Indexes/Static/MapIndex.cs
@@ -9,6 +9,7 @@ using Raven.Server.Documents.Indexes.Configuration;
 using Raven.Server.Documents.Indexes.Persistence.Lucene;
 using Raven.Server.Documents.Indexes.Workers;
 using Raven.Server.Documents.Queries;
+using Raven.Server.NotificationCenter.Notifications;
 using Raven.Server.ServerWide.Context;
 using Voron;
 
@@ -179,25 +180,30 @@ namespace Raven.Server.Documents.Indexes.Static
         public static Index CreateNew(IndexDefinition definition, DocumentDatabase documentDatabase)
         {
             var instance = CreateIndexInstance(definition, documentDatabase.Configuration, IndexDefinitionBaseServerSide.IndexVersion.CurrentVersion);
+            
+            var staticIndex = instance._compiled;
+            staticIndex.CheckDepthOfStackInOutputMap(definition, documentDatabase);
+            
             instance.Initialize(documentDatabase,
                 new SingleIndexConfiguration(definition.Configuration, documentDatabase.Configuration),
                 documentDatabase.Configuration.PerformanceHints);
 
             return instance;
         }
+        
+        
 
         public static Index Open(StorageEnvironment environment, DocumentDatabase documentDatabase)
         {
             var definition = MapIndexDefinition.Load(environment, out var version);
             var instance = CreateIndexInstance(definition, documentDatabase.Configuration, version);
-
             instance.Initialize(environment, documentDatabase,
                 new SingleIndexConfiguration(definition.Configuration, documentDatabase.Configuration),
                 documentDatabase.Configuration.PerformanceHints);
 
             return instance;
         }
-
+        
         public static void Update(Index index, IndexDefinition definition, DocumentDatabase documentDatabase)
         {
             var staticMapIndex = (MapIndex)index;

--- a/src/Raven.Server/Documents/Indexes/Static/Roslyn/Rewriters/StackDepthRetriever.cs
+++ b/src/Raven.Server/Documents/Indexes/Static/Roslyn/Rewriters/StackDepthRetriever.cs
@@ -11,8 +11,18 @@ public class StackDepthRetriever : CSharpSyntaxRewriter
 
     private int _selectDepth;
 
-    public int StackSize => _letCounter + _selectDepth;
-    
+    public int StackSize
+    {
+        get
+        {
+            //Skip last select {}
+            if (_selectDepth > 0)
+                _selectDepth--;
+            
+            return _letCounter + _selectDepth;
+        }
+    }
+
     public void Clear()
     {
         _letCounter = 0;

--- a/src/Raven.Server/Documents/Indexes/Static/Roslyn/Rewriters/StackDepthRetriever.cs
+++ b/src/Raven.Server/Documents/Indexes/Static/Roslyn/Rewriters/StackDepthRetriever.cs
@@ -1,0 +1,46 @@
+﻿using Microsoft.CodeAnalysis;
+using Microsoft.CodeAnalysis.CSharp;
+using Microsoft.CodeAnalysis.CSharp.Syntax;
+
+
+namespace Raven.Server.Documents.Indexes.Static.Roslyn.Rewriters;
+
+public class StackDepthRetriever : CSharpSyntaxRewriter
+{
+    private int _letCounter;
+
+    private int _selectDepth;
+
+    public int StackSize => _letCounter + _selectDepth;
+    
+    public void Clear()
+    {
+        _letCounter = 0;
+        _selectDepth = 0;
+    }
+
+    public override SyntaxNode VisitInvocationExpression(InvocationExpressionSyntax node)
+    {
+        var memberAccess = node.Expression as MemberAccessExpressionSyntax;
+        if (memberAccess == null || node.ArgumentList.Arguments.Count < 1)
+            return base.VisitInvocationExpression(node);
+
+        switch (memberAccess.Name.Identifier.ValueText)
+        {
+            case "Select":
+            case "SelectMany":
+                _selectDepth++;
+            break;
+            default:
+                break;
+        }
+
+        return base.VisitInvocationExpression(node);
+    }
+
+    public override SyntaxNode VisitLetClause(LetClauseSyntax queryLetClause)
+    {
+        _letCounter++;
+        return base.VisitLetClause(queryLetClause);
+    }
+}

--- a/src/Raven.Server/Documents/Indexes/Static/StaticIndexBase.cs
+++ b/src/Raven.Server/Documents/Indexes/Static/StaticIndexBase.cs
@@ -234,7 +234,7 @@ namespace Raven.Server.Documents.Indexes.Static
             {
                 documentDatabase.NotificationCenter.Add(PerformanceHint.Create(
                     documentDatabase.Name,
-                    $"Index '{indexMetadata.Name}' contains a lot of `let` clauses.",
+                    $"Index '{indexMetadata.Name}' contains a lot of `let` clauses. Index contains {StackSizeInSelectClause} `let` clauses but we suggest not to exceed {performanceHintConfig.MaxDepthOfRecursionInLinqSelect}.",
                     $"Each of the let clause is nesting projections and could potentially leads to StackoverflowException.",
                     PerformanceHintType.Indexing,
                     NotificationSeverity.Info,

--- a/src/Raven.Server/Documents/Indexes/Static/StaticIndexBase.cs
+++ b/src/Raven.Server/Documents/Indexes/Static/StaticIndexBase.cs
@@ -230,8 +230,8 @@ namespace Raven.Server.Documents.Indexes.Static
             {
                 documentDatabase.NotificationCenter.Add(PerformanceHint.Create(
                     documentDatabase.Name,
-                    $"Index '{indexMetadata.Name}' contains a lot of `let` clause.",
-                    $"Each of let clause is nesting projections and could potentially leads to StackoverflowException.",
+                    $"Index '{indexMetadata.Name}' contains a lot of `let` clauses.",
+                    $"Each of the let clause is nesting projections and could potentially leads to StackoverflowException.",
                     PerformanceHintType.Indexing,
                     NotificationSeverity.Info,
                     nameof(IndexCompiler)));

--- a/src/Raven.Server/Documents/Indexes/Static/StaticIndexBase.cs
+++ b/src/Raven.Server/Documents/Indexes/Static/StaticIndexBase.cs
@@ -240,7 +240,8 @@ namespace Raven.Server.Documents.Indexes.Static
                     NotificationSeverity.Info,
                     nameof(IndexCompiler)));
                 
-                Log.Info($"Index '{indexMetadata.Name}' contains a lot of `let` clauses.");
+                if (Log.IsOperationsEnabled)
+                    Log.Operations($"Index '{indexMetadata.Name}' contains a lot of `let` clauses. Stack size is {StackSizeInSelectClause}.");
             }
         }
         

--- a/src/Raven.Server/Documents/Indexes/Static/StaticIndexBase.cs
+++ b/src/Raven.Server/Documents/Indexes/Static/StaticIndexBase.cs
@@ -12,6 +12,7 @@ using Raven.Server.Documents.Indexes.Persistence.Lucene.Documents;
 using Raven.Server.Documents.Indexes.Static.Spatial;
 using Raven.Server.NotificationCenter.Notifications;
 using Sparrow.Json;
+using Sparrow.Logging;
 using Spatial4n.Core.Shapes;
 
 namespace Raven.Server.Documents.Indexes.Static
@@ -179,6 +180,9 @@ namespace Raven.Server.Documents.Indexes.Static
 
         public readonly HashSet<string> CollectionsWithCompareExchangeReferences = new HashSet<string>(StringComparer.OrdinalIgnoreCase);
         
+        protected static Logger Log = LoggingSource.Instance.GetLogger<AbstractStaticIndexBase>("Server");
+
+        
         public int StackSizeInSelectClause { get; set; }
         
         public bool HasDynamicFields { get; set; }
@@ -235,6 +239,8 @@ namespace Raven.Server.Documents.Indexes.Static
                     PerformanceHintType.Indexing,
                     NotificationSeverity.Info,
                     nameof(IndexCompiler)));
+                
+                Log.Info($"Index '{indexMetadata.Name}' contains a lot of `let` clauses.");
             }
         }
         

--- a/test/SlowTests/Issues/RavenDB_18938.cs
+++ b/test/SlowTests/Issues/RavenDB_18938.cs
@@ -1,4 +1,5 @@
 ﻿using System;
+using System.Collections.Generic;
 using System.Linq;
 using System.Threading.Tasks;
 using FastTests;
@@ -44,31 +45,87 @@ public class RavenDB_18938 : RavenTestBase
             performanceHint = await notificationsQueue.TryDequeueAsync(TimeSpan.FromSeconds(5));
         } while (performanceHint.Item2["Type"].ToString() != NotificationType.PerformanceHint.ToString());
 
-        Assert.Equal($"Index '{index.IndexName}' contains a lot of `let` clauses.", performanceHint.Item2["Title"]);
-
+        Assert.Equal($"Index '{index.IndexName}' contains a lot of `let` clauses. Index contains 33 `let` clauses but we suggest not to exceed 32.", performanceHint.Item2["Title"]);
+        WaitForUserToContinueTheTest(store);
         do
         {
             performanceHint = await notificationsQueue.TryDequeueAsync(TimeSpan.FromSeconds(5));
         } while (performanceHint.Item2 != null && performanceHint.Item2["Type"].ToString() != NotificationType.PerformanceHint.ToString());
 
         if (performanceHint.Item2 != null)
-            Assert.NotEqual($"Index '{index.IndexName}' contains a lot of `let` clauses.", performanceHint.Item2["Title"]);
+            Assert.NotEqual($"Index '{index.IndexName}' contains a lot of `let` clauses. Index contains 33 `let` clauses but we suggest not to exceed 32.", performanceHint.Item2["Title"]);
     }
 
     [Fact]
     public Task QuerySyntax() => AssertPerformanceHint<QuerySyntaxIndex>();
 
     [Fact]
+    public Task QuerySyntaxReduce() => AssertPerformanceHint<QuerySyntaxMapReduceIndex>();
+    
+    [Fact]
     public Task MethodSyntax() => AssertPerformanceHint<MethodSyntaxIndex>();
     
     [Fact]
-    public Task BigStackTest() => AssertPerformanceHint<MaxStackTest>();
-    
+    public Task MethodSyntaxReduce() => AssertPerformanceHint<MethodSyntaxMapReduceIndex>();
+
     private class ExampleDocument
     {
         public string Name { get; set; }
     }
 
+    private class MethodSyntaxMapReduceIndex : AbstractIndexCreationTask<ExampleDocument>
+    {
+        public MethodSyntaxMapReduceIndex()
+        {
+            Map = documents => from doc in documents
+                select new
+                {
+                    Name = doc.Name,
+                    Count = 1
+                };
+
+            Reduce = results =>
+                from result in results
+                group result by result.Name
+                into g
+                let a0 = 0
+                let a1 = 1
+                let a2 = 2
+                let a3 = 3
+                let a4 = 4
+                let a5 = 5
+                let a6 = 6
+                let a7 = 7
+                let a8 = 8
+                let a9 = 9
+                let a10 = 10
+                let a11 = 11
+                let a12 = 12
+                let a13 = 13
+                let a14 = 14
+                let a15 = 15
+                let a16 = 16
+                let a17 = 17
+                let a18 = 18
+                let a19 = 19
+                let a20 = 20
+                let a21 = 21
+                let a22 = 22
+                let a23 = 23
+                let a24 = 24
+                let a25 = 25
+                let a26 = 26
+                let a27 = 27
+                let a28 = 28
+                let a29 = 29
+                let a30 = 30
+                let a31 = 31
+                let a32 = 32
+                
+                select new {Name = g.Key, Count = a0 + a1 + a2 + a3 + a4 + a5 + a6 + a7 + a8 + a9 + a10 + a11 + a12 + a13 + a14 + a15 + a16 + a17 + a18 + a19 + a20 + a21 + a22 + a23 + a24 + a25 + a26 + a27 + a28 + a29 + a30 + a31 +  a32};
+        }
+    }
+    
     private class MethodSyntaxIndex : AbstractIndexCreationTask<ExampleDocument>
     {
         public MethodSyntaxIndex()
@@ -147,147 +204,71 @@ public class RavenDB_18938 : RavenTestBase
         }
     }
     
-      private class MaxStackTest : AbstractIndexCreationTask<ExampleDocument>
+    private class QuerySyntaxMapReduceIndex : AbstractIndexCreationTask
     {
-        public MaxStackTest()
+        public QuerySyntaxMapReduceIndex()
         {
-            Map = documents => from doc in documents
-                    let a0 = 0
-                    let a1 = 1
-                    let a2 = 2
-                    let a3 = 3
-                    let a4 = 4
-                    let a5 = 5
-                    let a6 = 6
-                    let a7 = 7
-                    let a8 = 8
-                    let a9 = 9
-                    let a10 = 10
-                    let a11 = 11
-                    let a12 = 12
-                    let a13 = 13
-                    let a14 = 14
-                    let a15 = 15
-                    let a16 = 16
-                    let a17 = 17
-                    let a18 = 18
-                    let a19 = 19
-                    let a20 = 20
-                    let a21 = 21
-                    let a22 = 22
-                    let a23 = 23
-                    let a24 = 24
-                    let a25 = 25
-                    let a26 = 26
-                    let a27 = 27
-                    let a28 = 28
-                    let a29 = 29
-                    let a30 = 30
-                    let a31 = 31
-                    let a32 = 32
-                    let a33 = 33
-                    let a34 = 34
-                    let a35 = 35
-                    let a36 = 36
-                    let a37 = 37
-                    let a38 = 38
-                    let a39 = 39
-                    let a40 = 40
-                    let a41 = 41
-                    let a42 = 42
-                    let a43 = 43
-                    let a44 = 44
-                    let a45 = 45
-                    let a46 = 46
-                    let a47 = 47
-                    let a48 = 48
-                    let a49 = 49
-                    let a50 = 50
-                    let a51 = 51
-                    let a52 = 52
-                    let a53 = 53
-                    let a54 = 54
-                    let a55 = 55
-                    let a56 = 56
-                    let a57 = 57
-                    let a58 = 58
-                    let a59 = 59
-                    let a60 = 60
-                    let a61 = 61
-                    let a62 = 62
-                    let a63 = 63
-                    let a64 = 64
-                    select new {
-                        A0 = a0,
-                        A1 = a1,
-                        A2 = a2,
-                        A3 = a3,
-                        A4 = a4,
-                        A5 = a5,
-                        A6 = a6,
-                        A7 = a7,
-                        A8 = a8,
-                        A9 = a9,
-                        A10 = a10,
-                        A11 = a11,
-                        A12 = a12,
-                        A13 = a13,
-                        A14 = a14,
-                        A15 = a15,
-                        A16 = a16,
-                        A17 = a17,
-                        A18 = a18,
-                        A19 = a19,
-                        A20 = a20,
-                        A21 = a21,
-                        A22 = a22,
-                        A23 = a23,
-                        A24 = a24,
-                        A25 = a25,
-                        A26 = a26,
-                        A27 = a27,
-                        A28 = a28,
-                        A29 = a29,
-                        A30 = a30,
-                        A31 = a31,
-                        A32 = a32,
-                        A33 = a33,
-                        A34 = a34,
-                        A35 = a35,
-                        A36 = a36,
-                        A37 = a37,
-                        A38 = a38,
-                        A39 = a39,
-                        A40 = a40,
-                        A41 = a41,
-                        A42 = a42,
-                        A43 = a43,
-                        A44 = a44,
-                        A45 = a45,
-                        A46 = a46,
-                        A47 = a47,
-                        A48 = a48,
-                        A49 = a49,
-                        A50 = a50,
-                        A51 = a51,
-                        A52 = a52,
-                        A53 = a53,
-                        A54 = a54,
-                        A55 = a55,
-                        A56 = a56,
-                        A57 = a57,
-                        A58 = a58,
-                        A59 = a59,
-                        A60 = a60,
-                        A61 = a61,
-                        A62 = a62,
-                        A63 = a63,
-                        A64 = a64,
-                        Field = doc.Name
-                    };
+        }
+
+        public override IndexDefinition CreateIndexDefinition()
+        {
+            return new IndexDefinition()
+            {
+                Maps =
+                {
+                    @"from documentItself in docs.ExampleDocuments
+                    select new
+                    {
+                        Name = documentItself.Name,
+                        Count = 1
+                    };",
+                },
+                Reduce =
+                    @"from result in results
+                        group result by result.Name into g
+                        let a0 = 0
+                        let a1 = 1
+                        let a2 = 2
+                        let a3 = 3
+                        let a4 = 4
+                        let a5 = 5
+                        let a6 = 6
+                        let a7 = 7
+                        let a8 = 8
+                        let a9 = 9
+                        let a10 = 10
+                        let a11 = 11
+                        let a12 = 12
+                        let a13 = 13
+                        let a14 = 14
+                        let a15 = 15
+                        let a16 = 16
+                        let a17 = 17
+                        let a18 = 18
+                        let a19 = 19
+                        let a20 = 20
+                        let a21 = 21
+                        let a22 = 22
+                        let a23 = 23
+                        let a24 = 24
+                        let a25 = 25
+                        let a26 = 26
+                        let a27 = 27
+                        let a28 = 28
+                        let a29 = 29
+                        let a30 = 30
+                        let a31 = 31
+                        let a32 = 32
+                        select new 
+                        {
+                            Name = g.Key, 
+                            Count = a0 + a1 + a2 + a3 + a4 + a5 + a6 + a7 + a8 + a9 + a10 + a11 + a12 + a13 + a14 + a15 + a16 + a17 + a18 + a19 + a20 + a21 + a22 + a23 + a24 + a25 + a26 + a27 + a28 + a29 + a30 + a31 +  a32
+                        };"
+                
+            };
         }
     }
-    
+
     private class QuerySyntaxIndex : AbstractIndexCreationTask
     {
         public QuerySyntaxIndex()

--- a/test/SlowTests/Issues/RavenDB_18938.cs
+++ b/test/SlowTests/Issues/RavenDB_18938.cs
@@ -1,0 +1,378 @@
+﻿using System;
+using System.Linq;
+using System.Threading.Tasks;
+using FastTests;
+using Raven.Client.Documents.Indexes;
+using Raven.Server.NotificationCenter.Notifications;
+using Sparrow.Json.Parsing;
+using Sparrow.Server.Collections;
+using Xunit;
+using Xunit.Abstractions;
+
+namespace SlowTests.Issues;
+
+public class RavenDB_18938 : RavenTestBase
+{
+    public RavenDB_18938(ITestOutputHelper output) : base(output)
+    {
+    }
+
+    private async Task AssertPerformanceHint<TIndex>()
+        where TIndex : AbstractIndexCreationTask, new()
+    {
+        using var store = GetDocumentStore();
+        var db = await GetDatabase(store.Database);
+        var notificationsQueue = new AsyncQueue<DynamicJsonValue>();
+        using var _ = db.NotificationCenter.TrackActions(notificationsQueue, null);
+
+        {
+            using var session = store.OpenSession();
+            session.Store(new ExampleDocument() {Name = "Maciej"});
+            session.Store(new ExampleDocument() {Name = "Gracjan"});
+            session.Store(new ExampleDocument() {Name = "Marcin"});
+            session.SaveChanges();
+        }
+
+        var index = new TIndex();
+        await index.ExecuteAsync(store);
+        Indexes.WaitForIndexing(store);
+
+        Tuple<bool, DynamicJsonValue> performanceHint;
+
+        do
+        {
+            performanceHint = await notificationsQueue.TryDequeueAsync(TimeSpan.FromSeconds(5));
+        } while (performanceHint.Item2["Type"].ToString() != NotificationType.PerformanceHint.ToString());
+
+        Assert.Equal($"Index '{index.IndexName}' contains a lot of `let` clause.", performanceHint.Item2["Title"]);
+
+        do
+        {
+            performanceHint = await notificationsQueue.TryDequeueAsync(TimeSpan.FromSeconds(5));
+        } while (performanceHint.Item2 != null && performanceHint.Item2["Type"].ToString() != NotificationType.PerformanceHint.ToString());
+
+        if (performanceHint.Item2 != null)
+            Assert.NotEqual($"Index '{index.IndexName}' contains a lot of `let` clause.", performanceHint.Item2["Title"]);
+    }
+
+    [Fact]
+    public Task QuerySyntax() => AssertPerformanceHint<QuerySyntaxIndex>();
+
+    [Fact]
+    public Task MethodSyntax() => AssertPerformanceHint<MethodSyntaxIndex>();
+    
+    [Fact]
+    public Task BigStackTest() => AssertPerformanceHint<MaxStackTest>();
+    
+    private class ExampleDocument
+    {
+        public string Name { get; set; }
+    }
+
+    private class MethodSyntaxIndex : AbstractIndexCreationTask<ExampleDocument>
+    {
+        public MethodSyntaxIndex()
+        {
+            Map = documents => from doc in documents
+                let a0 = 0
+                let a1 = 1
+                let a2 = 2
+                let a3 = 3
+                let a4 = 4
+                let a5 = 5
+                let a6 = 6
+                let a7 = 7
+                let a8 = 8
+                let a9 = 9
+                let a10 = 10
+                let a11 = 11
+                let a12 = 12
+                let a13 = 13
+                let a14 = 14
+                let a15 = 15
+                let a16 = 16
+                let a17 = 17
+                let a18 = 18
+                let a19 = 19
+                let a20 = 20
+                let a21 = 21
+                let a22 = 22
+                let a23 = 23
+                let a24 = 24
+                let a25 = 25
+                let a26 = 26
+                let a27 = 27
+                let a28 = 28
+                let a29 = 29
+                let a30 = 30
+                let a31 = 31
+                let a32 = 32
+                select new
+                {
+                    A0 = a0,
+                    A1 = a1,
+                    A2 = a2,
+                    A3 = a3,
+                    A4 = a4,
+                    A5 = a5,
+                    A6 = a6,
+                    A7 = a7,
+                    A8 = a8,
+                    A9 = a9,
+                    A10 = a10,
+                    A11 = a11,
+                    A12 = a12,
+                    A13 = a13,
+                    A14 = a14,
+                    A15 = a15,
+                    A16 = a16,
+                    A17 = a17,
+                    A18 = a18,
+                    A19 = a19,
+                    A20 = a20,
+                    A21 = a21,
+                    A22 = a22,
+                    A23 = a23,
+                    A24 = a24,
+                    A25 = a25,
+                    A26 = a26,
+                    A27 = a27,
+                    A28 = a28,
+                    A29 = a29,
+                    A30 = a30,
+                    A31 = a31,
+                    A32 = a32,
+                    Field = doc.Name
+                };
+        }
+    }
+    
+      private class MaxStackTest : AbstractIndexCreationTask<ExampleDocument>
+    {
+        public MaxStackTest()
+        {
+            Map = documents => from doc in documents
+                    let a0 = 0
+                    let a1 = 1
+                    let a2 = 2
+                    let a3 = 3
+                    let a4 = 4
+                    let a5 = 5
+                    let a6 = 6
+                    let a7 = 7
+                    let a8 = 8
+                    let a9 = 9
+                    let a10 = 10
+                    let a11 = 11
+                    let a12 = 12
+                    let a13 = 13
+                    let a14 = 14
+                    let a15 = 15
+                    let a16 = 16
+                    let a17 = 17
+                    let a18 = 18
+                    let a19 = 19
+                    let a20 = 20
+                    let a21 = 21
+                    let a22 = 22
+                    let a23 = 23
+                    let a24 = 24
+                    let a25 = 25
+                    let a26 = 26
+                    let a27 = 27
+                    let a28 = 28
+                    let a29 = 29
+                    let a30 = 30
+                    let a31 = 31
+                    let a32 = 32
+                    let a33 = 33
+                    let a34 = 34
+                    let a35 = 35
+                    let a36 = 36
+                    let a37 = 37
+                    let a38 = 38
+                    let a39 = 39
+                    let a40 = 40
+                    let a41 = 41
+                    let a42 = 42
+                    let a43 = 43
+                    let a44 = 44
+                    let a45 = 45
+                    let a46 = 46
+                    let a47 = 47
+                    let a48 = 48
+                    let a49 = 49
+                    let a50 = 50
+                    let a51 = 51
+                    let a52 = 52
+                    let a53 = 53
+                    let a54 = 54
+                    let a55 = 55
+                    let a56 = 56
+                    let a57 = 57
+                    let a58 = 58
+                    let a59 = 59
+                    let a60 = 60
+                    let a61 = 61
+                    let a62 = 62
+                    let a63 = 63
+                    let a64 = 64
+                    select new {
+                        A0 = a0,
+                        A1 = a1,
+                        A2 = a2,
+                        A3 = a3,
+                        A4 = a4,
+                        A5 = a5,
+                        A6 = a6,
+                        A7 = a7,
+                        A8 = a8,
+                        A9 = a9,
+                        A10 = a10,
+                        A11 = a11,
+                        A12 = a12,
+                        A13 = a13,
+                        A14 = a14,
+                        A15 = a15,
+                        A16 = a16,
+                        A17 = a17,
+                        A18 = a18,
+                        A19 = a19,
+                        A20 = a20,
+                        A21 = a21,
+                        A22 = a22,
+                        A23 = a23,
+                        A24 = a24,
+                        A25 = a25,
+                        A26 = a26,
+                        A27 = a27,
+                        A28 = a28,
+                        A29 = a29,
+                        A30 = a30,
+                        A31 = a31,
+                        A32 = a32,
+                        A33 = a33,
+                        A34 = a34,
+                        A35 = a35,
+                        A36 = a36,
+                        A37 = a37,
+                        A38 = a38,
+                        A39 = a39,
+                        A40 = a40,
+                        A41 = a41,
+                        A42 = a42,
+                        A43 = a43,
+                        A44 = a44,
+                        A45 = a45,
+                        A46 = a46,
+                        A47 = a47,
+                        A48 = a48,
+                        A49 = a49,
+                        A50 = a50,
+                        A51 = a51,
+                        A52 = a52,
+                        A53 = a53,
+                        A54 = a54,
+                        A55 = a55,
+                        A56 = a56,
+                        A57 = a57,
+                        A58 = a58,
+                        A59 = a59,
+                        A60 = a60,
+                        A61 = a61,
+                        A62 = a62,
+                        A63 = a63,
+                        A64 = a64,
+                        Field = doc.Name
+                    };
+        }
+    }
+    
+    private class QuerySyntaxIndex : AbstractIndexCreationTask
+    {
+        public QuerySyntaxIndex()
+        {
+        }
+
+        public override IndexDefinition CreateIndexDefinition()
+        {
+            return new IndexDefinition()
+            {
+                Maps =
+                {
+                    @"from documentItself in docs.ExampleDocuments
+                let a0 = 0
+                let a1 = 1
+                let a2 = 2
+                let a3 = 3
+                let a4 = 4
+                let a5 = 5
+                let a6 = 6
+                let a7 = 7
+                let a8 = 8
+                let a9 = 9
+                let a10 = 10
+                let a11 = 11
+                let a12 = 12
+                let a13 = 13
+                let a14 = 14
+                let a15 = 15
+                let a16 = 16
+                let a17 = 17
+                let a18 = 18
+                let a19 = 19
+                let a20 = 20
+                let a21 = 21
+                let a22 = 22
+                let a23 = 23
+                let a24 = 24
+                let a25 = 25
+                let a26 = 26
+                let a27 = 27
+                let a28 = 28
+                let a29 = 29
+                let a30 = 30
+                let a31 = 31
+                let a32 = 32
+                select new
+                {
+                    A0 = a0,
+                    A1 = a1,
+                    A2 = a2,
+                    A3 = a3,
+                    A4 = a4,
+                    A5 = a5,
+                    A6 = a6,
+                    A7 = a7,
+                    A8 = a8,
+                    A9 = a9,
+                    A10 = a10,
+                    A11 = a11,
+                    A12 = a12,
+                    A13 = a13,
+                    A14 = a14,
+                    A15 = a15,
+                    A16 = a16,
+                    A17 = a17,
+                    A18 = a18,
+                    A19 = a19,
+                    A20 = a20,
+                    A21 = a21,
+                    A22 = a22,
+                    A23 = a23,
+                    A24 = a24,
+                    A25 = a25,
+                    A26 = a26,
+                    A27 = a27,
+                    A28 = a28,
+                    A29 = a29,
+                    A30 = a30,
+                    A31 = a31,
+                    A32 = a32,
+                    Field = documentItself.Name
+                };"
+                }
+            };
+        }
+    }
+}

--- a/test/SlowTests/Issues/RavenDB_18938.cs
+++ b/test/SlowTests/Issues/RavenDB_18938.cs
@@ -44,7 +44,7 @@ public class RavenDB_18938 : RavenTestBase
             performanceHint = await notificationsQueue.TryDequeueAsync(TimeSpan.FromSeconds(5));
         } while (performanceHint.Item2["Type"].ToString() != NotificationType.PerformanceHint.ToString());
 
-        Assert.Equal($"Index '{index.IndexName}' contains a lot of `let` clause.", performanceHint.Item2["Title"]);
+        Assert.Equal($"Index '{index.IndexName}' contains a lot of `let` clauses.", performanceHint.Item2["Title"]);
 
         do
         {
@@ -52,7 +52,7 @@ public class RavenDB_18938 : RavenTestBase
         } while (performanceHint.Item2 != null && performanceHint.Item2["Type"].ToString() != NotificationType.PerformanceHint.ToString());
 
         if (performanceHint.Item2 != null)
-            Assert.NotEqual($"Index '{index.IndexName}' contains a lot of `let` clause.", performanceHint.Item2["Title"]);
+            Assert.NotEqual($"Index '{index.IndexName}' contains a lot of `let` clauses.", performanceHint.Item2["Title"]);
     }
 
     [Fact]


### PR DESCRIPTION
### Issue link

https://issues.hibernatingrhinos.com/issue/RavenDB-18938 

### Additional description


### Type of change


- New feature


### How risky is the change?

- Low 


### Backward compatibility

- Not relevant

### Is it platform specific issue?

- No

### Documentation update

- This change requires a documentation update. Please mark the issue on YouTrack using `Documentation Required` tag.

### Testing 

- Tests have been added that prove the fix is effective or that the feature works


### Is there any existing behavior change of other features due to this change?

- No

### UI work

- No UI work is needed
