### PR TITLE
RavenDB-18884 - Adding time property to debug endpoint results

### DIFF
--- a/src/Raven.Server/Documents/ETL/Handlers/EtlHandler.cs
+++ b/src/Raven.Server/Documents/ETL/Handlers/EtlHandler.cs
@@ -7,6 +7,7 @@ using Raven.Server.Documents.ETL.Stats;
 using Raven.Server.Json;
 using Raven.Server.Routing;
 using Raven.Server.ServerWide.Context;
+using Raven.Server.Utils;
 using Sparrow.Json;
 using Sparrow.Json.Parsing;
 
@@ -29,7 +30,7 @@ namespace Raven.Server.Documents.ETL.Handlers
 
             using (ContextPool.AllocateOperationContext(out JsonOperationContext context))
             {
-                await using (var writer = new AsyncBlittableJsonTextWriter(context, ResponseBodyStream()))
+                await using (var writer = new AsyncBlittableJsonTextWriterForDebug(context, ServerStore, ResponseBodyStream()))
                 {
                     writer.WriteStartObject();
                     writer.WriteArray(context, "Results", etlStats, (w, c, stats) => w.WriteObject(context.ReadObject(stats.ToJson(), "etl/stats")));
@@ -123,7 +124,7 @@ namespace Raven.Server.Documents.ETL.Handlers
         public async Task Progress()
         {
             using (ContextPool.AllocateOperationContext(out DocumentsOperationContext context))
-            await using (var writer = new AsyncBlittableJsonTextWriter(context, ResponseBodyStream()))
+            await using (var writer = new AsyncBlittableJsonTextWriterForDebug(context, ServerStore, ResponseBodyStream()))
             using (context.OpenReadTransaction())
             {
                 var performance = GetProcessesToReportOn().Select(x => new EtlTaskProgress

--- a/src/Raven.Server/Documents/ETL/Handlers/EtlHandler.cs
+++ b/src/Raven.Server/Documents/ETL/Handlers/EtlHandler.cs
@@ -30,7 +30,7 @@ namespace Raven.Server.Documents.ETL.Handlers
 
             using (ContextPool.AllocateOperationContext(out JsonOperationContext context))
             {
-                await using (var writer = new AsyncBlittableJsonTextWriterForDebug(HttpContext.Request, context, ServerStore, ResponseBodyStream()))
+                await using (var writer = new AsyncBlittableJsonTextWriterForDebug(context, ServerStore, ResponseBodyStream()))
                 {
                     writer.WriteStartObject();
                     writer.WriteArray(context, "Results", etlStats, (w, c, stats) => w.WriteObject(context.ReadObject(stats.ToJson(), "etl/stats")));
@@ -124,7 +124,7 @@ namespace Raven.Server.Documents.ETL.Handlers
         public async Task Progress()
         {
             using (ContextPool.AllocateOperationContext(out DocumentsOperationContext context))
-            await using (var writer = new AsyncBlittableJsonTextWriterForDebug(HttpContext.Request, context, ServerStore, ResponseBodyStream()))
+            await using (var writer = new AsyncBlittableJsonTextWriterForDebug(context, ServerStore, ResponseBodyStream()))
             using (context.OpenReadTransaction())
             {
                 var performance = GetProcessesToReportOn().Select(x => new EtlTaskProgress

--- a/src/Raven.Server/Documents/ETL/Handlers/EtlHandler.cs
+++ b/src/Raven.Server/Documents/ETL/Handlers/EtlHandler.cs
@@ -30,7 +30,7 @@ namespace Raven.Server.Documents.ETL.Handlers
 
             using (ContextPool.AllocateOperationContext(out JsonOperationContext context))
             {
-                await using (var writer = new AsyncBlittableJsonTextWriterForDebug(context, ServerStore, ResponseBodyStream()))
+                await using (var writer = new AsyncBlittableJsonTextWriterForDebug(HttpContext.Request, context, ServerStore, ResponseBodyStream()))
                 {
                     writer.WriteStartObject();
                     writer.WriteArray(context, "Results", etlStats, (w, c, stats) => w.WriteObject(context.ReadObject(stats.ToJson(), "etl/stats")));
@@ -124,7 +124,7 @@ namespace Raven.Server.Documents.ETL.Handlers
         public async Task Progress()
         {
             using (ContextPool.AllocateOperationContext(out DocumentsOperationContext context))
-            await using (var writer = new AsyncBlittableJsonTextWriterForDebug(context, ServerStore, ResponseBodyStream()))
+            await using (var writer = new AsyncBlittableJsonTextWriterForDebug(HttpContext.Request, context, ServerStore, ResponseBodyStream()))
             using (context.OpenReadTransaction())
             {
                 var performance = GetProcessesToReportOn().Select(x => new EtlTaskProgress

--- a/src/Raven.Server/Documents/Handlers/Admin/AdminConfigurationHandler.cs
+++ b/src/Raven.Server/Documents/Handlers/Admin/AdminConfigurationHandler.cs
@@ -13,6 +13,7 @@ using Raven.Server.Json;
 using Raven.Server.Routing;
 using Raven.Server.ServerWide;
 using Raven.Server.ServerWide.Context;
+using Raven.Server.Utils;
 using Sparrow.Json;
 using Sparrow.Json.Parsing;
 using ConfigurationEntryScope = Raven.Server.Config.Attributes.ConfigurationEntryScope;
@@ -68,7 +69,7 @@ namespace Raven.Server.Documents.Handlers.Admin
 
             using (ServerStore.ContextPool.AllocateOperationContext(out TransactionOperationContext context))
             {
-                await using (var writer = new AsyncBlittableJsonTextWriter(context, ResponseBodyStream()))
+                await using (var writer = new AsyncBlittableJsonTextWriterForDebug(context, ServerStore, ResponseBodyStream()))
                 {
                     context.Write(writer, settingsResult.ToJson());
                 }

--- a/src/Raven.Server/Documents/Handlers/Admin/AdminConfigurationHandler.cs
+++ b/src/Raven.Server/Documents/Handlers/Admin/AdminConfigurationHandler.cs
@@ -69,7 +69,7 @@ namespace Raven.Server.Documents.Handlers.Admin
 
             using (ServerStore.ContextPool.AllocateOperationContext(out TransactionOperationContext context))
             {
-                await using (var writer = new AsyncBlittableJsonTextWriterForDebug(HttpContext.Request, context, ServerStore, ResponseBodyStream()))
+                await using (var writer = new AsyncBlittableJsonTextWriterForDebug(context, ServerStore, ResponseBodyStream()))
                 {
                     context.Write(writer, settingsResult.ToJson());
                 }

--- a/src/Raven.Server/Documents/Handlers/Admin/AdminConfigurationHandler.cs
+++ b/src/Raven.Server/Documents/Handlers/Admin/AdminConfigurationHandler.cs
@@ -69,7 +69,7 @@ namespace Raven.Server.Documents.Handlers.Admin
 
             using (ServerStore.ContextPool.AllocateOperationContext(out TransactionOperationContext context))
             {
-                await using (var writer = new AsyncBlittableJsonTextWriterForDebug(context, ServerStore, ResponseBodyStream()))
+                await using (var writer = new AsyncBlittableJsonTextWriterForDebug(HttpContext.Request, context, ServerStore, ResponseBodyStream()))
                 {
                     context.Write(writer, settingsResult.ToJson());
                 }

--- a/src/Raven.Server/Documents/Handlers/Admin/AdminTombstoneHandler.cs
+++ b/src/Raven.Server/Documents/Handlers/Admin/AdminTombstoneHandler.cs
@@ -33,7 +33,7 @@ namespace Raven.Server.Documents.Handlers.Admin
 
             using (Database.DocumentsStorage.ContextPool.AllocateOperationContext(out JsonOperationContext context))
             {
-                await using (var writer = new AsyncBlittableJsonTextWriterForDebug(context, ServerStore, ResponseBodyStream()))
+                await using (var writer = new AsyncBlittableJsonTextWriterForDebug(HttpContext.Request, context, ServerStore, ResponseBodyStream()))
                 {
                     writer.WriteStartObject();
 

--- a/src/Raven.Server/Documents/Handlers/Admin/AdminTombstoneHandler.cs
+++ b/src/Raven.Server/Documents/Handlers/Admin/AdminTombstoneHandler.cs
@@ -33,7 +33,7 @@ namespace Raven.Server.Documents.Handlers.Admin
 
             using (Database.DocumentsStorage.ContextPool.AllocateOperationContext(out JsonOperationContext context))
             {
-                await using (var writer = new AsyncBlittableJsonTextWriterForDebug(HttpContext.Request, context, ServerStore, ResponseBodyStream()))
+                await using (var writer = new AsyncBlittableJsonTextWriterForDebug(context, ServerStore, ResponseBodyStream()))
                 {
                     writer.WriteStartObject();
 

--- a/src/Raven.Server/Documents/Handlers/Admin/AdminTombstoneHandler.cs
+++ b/src/Raven.Server/Documents/Handlers/Admin/AdminTombstoneHandler.cs
@@ -1,5 +1,6 @@
 ﻿using System.Threading.Tasks;
 using Raven.Server.Routing;
+using Raven.Server.Utils;
 using Sparrow.Json;
 
 namespace Raven.Server.Documents.Handlers.Admin
@@ -32,7 +33,7 @@ namespace Raven.Server.Documents.Handlers.Admin
 
             using (Database.DocumentsStorage.ContextPool.AllocateOperationContext(out JsonOperationContext context))
             {
-                await using (var writer = new AsyncBlittableJsonTextWriter(context, ResponseBodyStream()))
+                await using (var writer = new AsyncBlittableJsonTextWriterForDebug(context, ServerStore, ResponseBodyStream()))
                 {
                     writer.WriteStartObject();
 

--- a/src/Raven.Server/Documents/Handlers/Admin/RachisAdminHandler.cs
+++ b/src/Raven.Server/Documents/Handlers/Admin/RachisAdminHandler.cs
@@ -129,7 +129,7 @@ namespace Raven.Server.Documents.Handlers.Admin
             if (ServerStore.IsLeader())
             {
                 using (ServerStore.ContextPool.AllocateOperationContext(out TransactionOperationContext context))
-                await using (var writer = new AsyncBlittableJsonTextWriterForDebug(HttpContext.Request, context, ServerStore, ResponseBodyStream()))
+                await using (var writer = new AsyncBlittableJsonTextWriterForDebug(context, ServerStore, ResponseBodyStream()))
                 {
                     var res = ServerStore.Observer.ReadDecisionsForDatabase();
                     var json = new DynamicJsonValue
@@ -152,7 +152,7 @@ namespace Raven.Server.Documents.Handlers.Admin
         public async Task GetLogs()
         {
             using (ServerStore.Engine.ContextPool.AllocateOperationContext(out ClusterOperationContext context))
-            await using (var writer = new AsyncBlittableJsonTextWriterForDebug(HttpContext.Request, context, ServerStore, ResponseBodyStream()))
+            await using (var writer = new AsyncBlittableJsonTextWriterForDebug(context, ServerStore, ResponseBodyStream()))
             {
                 context.OpenReadTransaction();
                 context.Write(writer, ServerStore.GetLogDetails(context));
@@ -163,7 +163,7 @@ namespace Raven.Server.Documents.Handlers.Admin
         public async Task GetHistoryLogs()
         {
             using (ServerStore.Engine.ContextPool.AllocateOperationContext(out ClusterOperationContext context))
-            await using (var writer = new AsyncBlittableJsonTextWriterForDebug(HttpContext.Request, context, ServerStore, ResponseBodyStream()))
+            await using (var writer = new AsyncBlittableJsonTextWriterForDebug(context, ServerStore, ResponseBodyStream()))
             {
                 writer.WriteStartObject();
                 context.OpenReadTransaction();
@@ -222,7 +222,7 @@ namespace Raven.Server.Documents.Handlers.Admin
 
                 HttpContext.Response.StatusCode = (int)HttpStatusCode.OK;
 
-                await using (var writer = new AsyncBlittableJsonTextWriterForDebug(HttpContext.Request, context, ServerStore, ResponseBodyStream()))
+                await using (var writer = new AsyncBlittableJsonTextWriterForDebug(context, ServerStore, ResponseBodyStream()))
                 {
                     var loadLicenseLimits = ServerStore.LoadLicenseLimits();
                     var nodeLicenseDetails = loadLicenseLimits == null ?

--- a/src/Raven.Server/Documents/Handlers/Admin/RachisAdminHandler.cs
+++ b/src/Raven.Server/Documents/Handlers/Admin/RachisAdminHandler.cs
@@ -129,7 +129,7 @@ namespace Raven.Server.Documents.Handlers.Admin
             if (ServerStore.IsLeader())
             {
                 using (ServerStore.ContextPool.AllocateOperationContext(out TransactionOperationContext context))
-                await using (var writer = new AsyncBlittableJsonTextWriter(context, ResponseBodyStream()))
+                await using (var writer = new AsyncBlittableJsonTextWriterForDebug(context, ServerStore, ResponseBodyStream()))
                 {
                     var res = ServerStore.Observer.ReadDecisionsForDatabase();
                     var json = new DynamicJsonValue
@@ -152,7 +152,7 @@ namespace Raven.Server.Documents.Handlers.Admin
         public async Task GetLogs()
         {
             using (ServerStore.Engine.ContextPool.AllocateOperationContext(out ClusterOperationContext context))
-            await using (var writer = new AsyncBlittableJsonTextWriter(context, ResponseBodyStream()))
+            await using (var writer = new AsyncBlittableJsonTextWriterForDebug(context, ServerStore, ResponseBodyStream()))
             {
                 context.OpenReadTransaction();
                 context.Write(writer, ServerStore.GetLogDetails(context));
@@ -163,7 +163,7 @@ namespace Raven.Server.Documents.Handlers.Admin
         public async Task GetHistoryLogs()
         {
             using (ServerStore.Engine.ContextPool.AllocateOperationContext(out ClusterOperationContext context))
-            await using (var writer = new AsyncBlittableJsonTextWriter(context, ResponseBodyStream()))
+            await using (var writer = new AsyncBlittableJsonTextWriterForDebug(context, ServerStore, ResponseBodyStream()))
             {
                 writer.WriteStartObject();
                 context.OpenReadTransaction();
@@ -222,7 +222,7 @@ namespace Raven.Server.Documents.Handlers.Admin
 
                 HttpContext.Response.StatusCode = (int)HttpStatusCode.OK;
 
-                await using (var writer = new AsyncBlittableJsonTextWriter(context, ResponseBodyStream()))
+                await using (var writer = new AsyncBlittableJsonTextWriterForDebug(context, ServerStore, ResponseBodyStream()))
                 {
                     var loadLicenseLimits = ServerStore.LoadLicenseLimits();
                     var nodeLicenseDetails = loadLicenseLimits == null ?

--- a/src/Raven.Server/Documents/Handlers/Admin/RachisAdminHandler.cs
+++ b/src/Raven.Server/Documents/Handlers/Admin/RachisAdminHandler.cs
@@ -129,7 +129,7 @@ namespace Raven.Server.Documents.Handlers.Admin
             if (ServerStore.IsLeader())
             {
                 using (ServerStore.ContextPool.AllocateOperationContext(out TransactionOperationContext context))
-                await using (var writer = new AsyncBlittableJsonTextWriterForDebug(context, ServerStore, ResponseBodyStream()))
+                await using (var writer = new AsyncBlittableJsonTextWriterForDebug(HttpContext.Request, context, ServerStore, ResponseBodyStream()))
                 {
                     var res = ServerStore.Observer.ReadDecisionsForDatabase();
                     var json = new DynamicJsonValue
@@ -152,7 +152,7 @@ namespace Raven.Server.Documents.Handlers.Admin
         public async Task GetLogs()
         {
             using (ServerStore.Engine.ContextPool.AllocateOperationContext(out ClusterOperationContext context))
-            await using (var writer = new AsyncBlittableJsonTextWriterForDebug(context, ServerStore, ResponseBodyStream()))
+            await using (var writer = new AsyncBlittableJsonTextWriterForDebug(HttpContext.Request, context, ServerStore, ResponseBodyStream()))
             {
                 context.OpenReadTransaction();
                 context.Write(writer, ServerStore.GetLogDetails(context));
@@ -163,7 +163,7 @@ namespace Raven.Server.Documents.Handlers.Admin
         public async Task GetHistoryLogs()
         {
             using (ServerStore.Engine.ContextPool.AllocateOperationContext(out ClusterOperationContext context))
-            await using (var writer = new AsyncBlittableJsonTextWriterForDebug(context, ServerStore, ResponseBodyStream()))
+            await using (var writer = new AsyncBlittableJsonTextWriterForDebug(HttpContext.Request, context, ServerStore, ResponseBodyStream()))
             {
                 writer.WriteStartObject();
                 context.OpenReadTransaction();
@@ -222,7 +222,7 @@ namespace Raven.Server.Documents.Handlers.Admin
 
                 HttpContext.Response.StatusCode = (int)HttpStatusCode.OK;
 
-                await using (var writer = new AsyncBlittableJsonTextWriterForDebug(context, ServerStore, ResponseBodyStream()))
+                await using (var writer = new AsyncBlittableJsonTextWriterForDebug(HttpContext.Request, context, ServerStore, ResponseBodyStream()))
                 {
                     var loadLicenseLimits = ServerStore.LoadLicenseLimits();
                     var nodeLicenseDetails = loadLicenseLimits == null ?

--- a/src/Raven.Server/Documents/Handlers/Debugging/DocumentDebugHandler.cs
+++ b/src/Raven.Server/Documents/Handlers/Debugging/DocumentDebugHandler.cs
@@ -14,7 +14,7 @@ namespace Raven.Server.Documents.Handlers.Debugging
         public async Task HugeDocuments()
         {
             using (ContextPool.AllocateOperationContext(out DocumentsOperationContext context))
-            await using (var writer = new AsyncBlittableJsonTextWriterForDebug(context, ServerStore, ResponseBodyStream()))
+            await using (var writer = new AsyncBlittableJsonTextWriterForDebug(HttpContext.Request, context, ServerStore, ResponseBodyStream()))
             using (context.OpenReadTransaction())
             {
                 writer.WriteStartObject();

--- a/src/Raven.Server/Documents/Handlers/Debugging/DocumentDebugHandler.cs
+++ b/src/Raven.Server/Documents/Handlers/Debugging/DocumentDebugHandler.cs
@@ -14,7 +14,7 @@ namespace Raven.Server.Documents.Handlers.Debugging
         public async Task HugeDocuments()
         {
             using (ContextPool.AllocateOperationContext(out DocumentsOperationContext context))
-            await using (var writer = new AsyncBlittableJsonTextWriterForDebug(HttpContext.Request, context, ServerStore, ResponseBodyStream()))
+            await using (var writer = new AsyncBlittableJsonTextWriterForDebug(context, ServerStore, ResponseBodyStream()))
             using (context.OpenReadTransaction())
             {
                 writer.WriteStartObject();

--- a/src/Raven.Server/Documents/Handlers/Debugging/DocumentDebugHandler.cs
+++ b/src/Raven.Server/Documents/Handlers/Debugging/DocumentDebugHandler.cs
@@ -2,6 +2,7 @@
 using System.Threading.Tasks;
 using Raven.Server.Routing;
 using Raven.Server.ServerWide.Context;
+using Raven.Server.Utils;
 using Sparrow;
 using Sparrow.Json;
 
@@ -13,7 +14,7 @@ namespace Raven.Server.Documents.Handlers.Debugging
         public async Task HugeDocuments()
         {
             using (ContextPool.AllocateOperationContext(out DocumentsOperationContext context))
-            await using (var writer = new AsyncBlittableJsonTextWriter(context, ResponseBodyStream()))
+            await using (var writer = new AsyncBlittableJsonTextWriterForDebug(context, ServerStore, ResponseBodyStream()))
             using (context.OpenReadTransaction())
             {
                 writer.WriteStartObject();

--- a/src/Raven.Server/Documents/Handlers/Debugging/IdentityDebugHandler.cs
+++ b/src/Raven.Server/Documents/Handlers/Debugging/IdentityDebugHandler.cs
@@ -17,7 +17,7 @@ namespace Raven.Server.Documents.Handlers.Debugging
             using (Database.ServerStore.ContextPool.AllocateOperationContext(out TransactionOperationContext context))
             using (context.OpenReadTransaction())
             {
-                await using (var writer = new AsyncBlittableJsonTextWriterForDebug(HttpContext.Request, context, ServerStore, ResponseBodyStream()))
+                await using (var writer = new AsyncBlittableJsonTextWriter(context, ResponseBodyStream()))
                 {
                     writer.WriteStartObject();
 

--- a/src/Raven.Server/Documents/Handlers/Debugging/IdentityDebugHandler.cs
+++ b/src/Raven.Server/Documents/Handlers/Debugging/IdentityDebugHandler.cs
@@ -1,6 +1,7 @@
 ﻿using System.Threading.Tasks;
 using Raven.Server.Routing;
 using Raven.Server.ServerWide.Context;
+using Raven.Server.Utils;
 using Sparrow.Json;
 
 namespace Raven.Server.Documents.Handlers.Debugging
@@ -16,7 +17,7 @@ namespace Raven.Server.Documents.Handlers.Debugging
             using (Database.ServerStore.ContextPool.AllocateOperationContext(out TransactionOperationContext context))
             using (context.OpenReadTransaction())
             {
-                await using (var writer = new AsyncBlittableJsonTextWriter(context, ResponseBodyStream()))
+                await using (var writer = new AsyncBlittableJsonTextWriterForDebug(context, ServerStore, ResponseBodyStream()))
                 {
                     writer.WriteStartObject();
 

--- a/src/Raven.Server/Documents/Handlers/Debugging/IdentityDebugHandler.cs
+++ b/src/Raven.Server/Documents/Handlers/Debugging/IdentityDebugHandler.cs
@@ -17,7 +17,7 @@ namespace Raven.Server.Documents.Handlers.Debugging
             using (Database.ServerStore.ContextPool.AllocateOperationContext(out TransactionOperationContext context))
             using (context.OpenReadTransaction())
             {
-                await using (var writer = new AsyncBlittableJsonTextWriterForDebug(context, ServerStore, ResponseBodyStream()))
+                await using (var writer = new AsyncBlittableJsonTextWriterForDebug(HttpContext.Request, context, ServerStore, ResponseBodyStream()))
                 {
                     writer.WriteStartObject();
 

--- a/src/Raven.Server/Documents/Handlers/Debugging/MemoryDebugHandler.cs
+++ b/src/Raven.Server/Documents/Handlers/Debugging/MemoryDebugHandler.cs
@@ -39,7 +39,7 @@ namespace Raven.Server.Documents.Handlers.Debugging
                     [nameof(GCKind.FullBlocking)] = ToJson(GC.GetGCMemoryInfo(GCKind.FullBlocking)),
                 };
 
-                await using (var write = new AsyncBlittableJsonTextWriterForDebug(context, ServerStore, ResponseBodyStream()))
+                await using (var write = new AsyncBlittableJsonTextWriterForDebug(HttpContext.Request, context, ServerStore, ResponseBodyStream()))
                 {
                     context.Write(write, djv);
                 }
@@ -93,7 +93,7 @@ namespace Raven.Server.Documents.Handlers.Debugging
             {
                 var djv = LowMemLogInternal();
 
-                await using (var write = new AsyncBlittableJsonTextWriterForDebug(context, ServerStore, ResponseBodyStream()))
+                await using (var write = new AsyncBlittableJsonTextWriterForDebug(HttpContext.Request, context, ServerStore, ResponseBodyStream()))
                 {
                     context.Write(write, djv);
                 }
@@ -195,7 +195,7 @@ namespace Raven.Server.Documents.Handlers.Debugging
                         ["Details"] = rc.Json
                     };
 
-                    await using (var write = new AsyncBlittableJsonTextWriterForDebug(context, ServerStore, ResponseBodyStream()))
+                    await using (var write = new AsyncBlittableJsonTextWriterForDebug(HttpContext.Request, context, ServerStore, ResponseBodyStream()))
                     {
                         context.Write(write, djv);
                     }
@@ -236,7 +236,7 @@ namespace Raven.Server.Documents.Handlers.Debugging
                         ["Details"] = result.SmapsResults.ReturnResults()
                     };
 
-                    await using (var write = new AsyncBlittableJsonTextWriterForDebug(context, ServerStore, ResponseBodyStream()))
+                    await using (var write = new AsyncBlittableJsonTextWriterForDebug(HttpContext.Request, context, ServerStore, ResponseBodyStream()))
                     {
                         context.Write(write, djv);
                     }
@@ -259,7 +259,7 @@ namespace Raven.Server.Documents.Handlers.Debugging
 
             using (ServerStore.ContextPool.AllocateOperationContext(out JsonOperationContext context))
             {
-                await using (var writer = new AsyncBlittableJsonTextWriterForDebug(context, ServerStore, ResponseBodyStream()))
+                await using (var writer = new AsyncBlittableJsonTextWriterForDebug(HttpContext.Request, context, ServerStore, ResponseBodyStream()))
                 {
                     WriteMemoryStats(writer, context, includeThreads, includeMappings);
                 }
@@ -271,7 +271,7 @@ namespace Raven.Server.Documents.Handlers.Debugging
         {
             using (ServerStore.ContextPool.AllocateOperationContext(out JsonOperationContext context))
             {
-                await using (var write = new AsyncBlittableJsonTextWriterForDebug(context, ServerStore, ResponseBodyStream()))
+                await using (var write = new AsyncBlittableJsonTextWriterForDebug(HttpContext.Request, context, ServerStore, ResponseBodyStream()))
                 {
                     context.Write(write, EncryptionBuffersPool.Instance.GetStats().ToJson());
                 }

--- a/src/Raven.Server/Documents/Handlers/Debugging/MemoryDebugHandler.cs
+++ b/src/Raven.Server/Documents/Handlers/Debugging/MemoryDebugHandler.cs
@@ -39,7 +39,7 @@ namespace Raven.Server.Documents.Handlers.Debugging
                     [nameof(GCKind.FullBlocking)] = ToJson(GC.GetGCMemoryInfo(GCKind.FullBlocking)),
                 };
 
-                await using (var write = new AsyncBlittableJsonTextWriterForDebug(HttpContext.Request, context, ServerStore, ResponseBodyStream()))
+                await using (var write = new AsyncBlittableJsonTextWriterForDebug(context, ServerStore, ResponseBodyStream()))
                 {
                     context.Write(write, djv);
                 }
@@ -93,7 +93,7 @@ namespace Raven.Server.Documents.Handlers.Debugging
             {
                 var djv = LowMemLogInternal();
 
-                await using (var write = new AsyncBlittableJsonTextWriterForDebug(HttpContext.Request, context, ServerStore, ResponseBodyStream()))
+                await using (var write = new AsyncBlittableJsonTextWriterForDebug(context, ServerStore, ResponseBodyStream()))
                 {
                     context.Write(write, djv);
                 }
@@ -195,7 +195,7 @@ namespace Raven.Server.Documents.Handlers.Debugging
                         ["Details"] = rc.Json
                     };
 
-                    await using (var write = new AsyncBlittableJsonTextWriterForDebug(HttpContext.Request, context, ServerStore, ResponseBodyStream()))
+                    await using (var write = new AsyncBlittableJsonTextWriterForDebug(context, ServerStore, ResponseBodyStream()))
                     {
                         context.Write(write, djv);
                     }
@@ -236,7 +236,7 @@ namespace Raven.Server.Documents.Handlers.Debugging
                         ["Details"] = result.SmapsResults.ReturnResults()
                     };
 
-                    await using (var write = new AsyncBlittableJsonTextWriterForDebug(HttpContext.Request, context, ServerStore, ResponseBodyStream()))
+                    await using (var write = new AsyncBlittableJsonTextWriterForDebug(context, ServerStore, ResponseBodyStream()))
                     {
                         context.Write(write, djv);
                     }
@@ -259,7 +259,7 @@ namespace Raven.Server.Documents.Handlers.Debugging
 
             using (ServerStore.ContextPool.AllocateOperationContext(out JsonOperationContext context))
             {
-                await using (var writer = new AsyncBlittableJsonTextWriterForDebug(HttpContext.Request, context, ServerStore, ResponseBodyStream()))
+                await using (var writer = new AsyncBlittableJsonTextWriterForDebug(context, ServerStore, ResponseBodyStream()))
                 {
                     WriteMemoryStats(writer, context, includeThreads, includeMappings);
                 }
@@ -271,7 +271,7 @@ namespace Raven.Server.Documents.Handlers.Debugging
         {
             using (ServerStore.ContextPool.AllocateOperationContext(out JsonOperationContext context))
             {
-                await using (var write = new AsyncBlittableJsonTextWriterForDebug(HttpContext.Request, context, ServerStore, ResponseBodyStream()))
+                await using (var write = new AsyncBlittableJsonTextWriterForDebug(context, ServerStore, ResponseBodyStream()))
                 {
                     context.Write(write, EncryptionBuffersPool.Instance.GetStats().ToJson());
                 }

--- a/src/Raven.Server/Documents/Handlers/Debugging/MemoryDebugHandler.cs
+++ b/src/Raven.Server/Documents/Handlers/Debugging/MemoryDebugHandler.cs
@@ -6,7 +6,9 @@ using System.Diagnostics;
 using System.IO;
 using System.Linq;
 using System.Threading.Tasks;
+using MySqlX.XDevAPI;
 using Raven.Server.Routing;
+using Raven.Server.Utils;
 using Raven.Server.Web;
 using Sparrow;
 using Sparrow.Json;
@@ -37,7 +39,7 @@ namespace Raven.Server.Documents.Handlers.Debugging
                     [nameof(GCKind.FullBlocking)] = ToJson(GC.GetGCMemoryInfo(GCKind.FullBlocking)),
                 };
 
-                await using (var write = new AsyncBlittableJsonTextWriter(context, ResponseBodyStream()))
+                await using (var write = new AsyncBlittableJsonTextWriterForDebug(context, ServerStore, ResponseBodyStream()))
                 {
                     context.Write(write, djv);
                 }
@@ -91,7 +93,7 @@ namespace Raven.Server.Documents.Handlers.Debugging
             {
                 var djv = LowMemLogInternal();
 
-                await using (var write = new AsyncBlittableJsonTextWriter(context, ResponseBodyStream()))
+                await using (var write = new AsyncBlittableJsonTextWriterForDebug(context, ServerStore, ResponseBodyStream()))
                 {
                     context.Write(write, djv);
                 }
@@ -193,7 +195,7 @@ namespace Raven.Server.Documents.Handlers.Debugging
                         ["Details"] = rc.Json
                     };
 
-                    await using (var write = new AsyncBlittableJsonTextWriter(context, ResponseBodyStream()))
+                    await using (var write = new AsyncBlittableJsonTextWriterForDebug(context, ServerStore, ResponseBodyStream()))
                     {
                         context.Write(write, djv);
                     }
@@ -234,7 +236,7 @@ namespace Raven.Server.Documents.Handlers.Debugging
                         ["Details"] = result.SmapsResults.ReturnResults()
                     };
 
-                    await using (var write = new AsyncBlittableJsonTextWriter(context, ResponseBodyStream()))
+                    await using (var write = new AsyncBlittableJsonTextWriterForDebug(context, ServerStore, ResponseBodyStream()))
                     {
                         context.Write(write, djv);
                     }
@@ -257,7 +259,7 @@ namespace Raven.Server.Documents.Handlers.Debugging
 
             using (ServerStore.ContextPool.AllocateOperationContext(out JsonOperationContext context))
             {
-                await using (var writer = new AsyncBlittableJsonTextWriter(context, ResponseBodyStream()))
+                await using (var writer = new AsyncBlittableJsonTextWriterForDebug(context, ServerStore, ResponseBodyStream()))
                 {
                     WriteMemoryStats(writer, context, includeThreads, includeMappings);
                 }
@@ -269,7 +271,7 @@ namespace Raven.Server.Documents.Handlers.Debugging
         {
             using (ServerStore.ContextPool.AllocateOperationContext(out JsonOperationContext context))
             {
-                await using (var write = new AsyncBlittableJsonTextWriter(context, ResponseBodyStream()))
+                await using (var write = new AsyncBlittableJsonTextWriterForDebug(context, ServerStore, ResponseBodyStream()))
                 {
                     context.Write(write, EncryptionBuffersPool.Instance.GetStats().ToJson());
                 }

--- a/src/Raven.Server/Documents/Handlers/Debugging/NodeDebugHandler.cs
+++ b/src/Raven.Server/Documents/Handlers/Debugging/NodeDebugHandler.cs
@@ -26,7 +26,7 @@ namespace Raven.Server.Documents.Handlers.Debugging
         public async Task ListRemoteConnections()
         {
             using (ServerStore.ContextPool.AllocateOperationContext(out JsonOperationContext context))
-            await using (var write = new AsyncBlittableJsonTextWriterForDebug(context, ServerStore, ResponseBodyStream()))
+            await using (var write = new AsyncBlittableJsonTextWriterForDebug(HttpContext.Request, context, ServerStore, ResponseBodyStream()))
             {
                 context.Write(write,
                     new DynamicJsonValue
@@ -49,7 +49,7 @@ namespace Raven.Server.Documents.Handlers.Debugging
         public async Task ListRecentEngineLogs()
         {
             using (ServerStore.ContextPool.AllocateOperationContext(out JsonOperationContext context))
-            await using (var write = new AsyncBlittableJsonTextWriterForDebug(context, ServerStore, ResponseBodyStream()))
+            await using (var write = new AsyncBlittableJsonTextWriterForDebug(HttpContext.Request, context, ServerStore, ResponseBodyStream()))
             {
                 context.Write(write, ServerStore.Engine.InMemoryDebug.ToJson());
             }
@@ -59,7 +59,7 @@ namespace Raven.Server.Documents.Handlers.Debugging
         public async Task GetStateChangeHistory()
         {
             using (ServerStore.ContextPool.AllocateOperationContext(out JsonOperationContext context))
-            await using (var writer = new AsyncBlittableJsonTextWriterForDebug(context, ServerStore, ResponseBodyStream()))
+            await using (var writer = new AsyncBlittableJsonTextWriterForDebug(HttpContext.Request, context, ServerStore, ResponseBodyStream()))
             {
                 writer.WriteStartObject();
                 writer.WriteArray("States", ServerStore.Engine.PrevStates.Select(s => s.ToString()));
@@ -87,7 +87,7 @@ namespace Raven.Server.Documents.Handlers.Debugging
             }
 
             using (ServerStore.ContextPool.AllocateOperationContext(out JsonOperationContext context))
-            await using (var writer = new AsyncBlittableJsonTextWriterForDebug(context, ServerStore, ResponseBodyStream()))
+            await using (var writer = new AsyncBlittableJsonTextWriterForDebug(HttpContext.Request, context, ServerStore, ResponseBodyStream()))
             {
                 writer.WriteStartObject();
                 writer.WritePropertyName("Result");

--- a/src/Raven.Server/Documents/Handlers/Debugging/NodeDebugHandler.cs
+++ b/src/Raven.Server/Documents/Handlers/Debugging/NodeDebugHandler.cs
@@ -26,7 +26,7 @@ namespace Raven.Server.Documents.Handlers.Debugging
         public async Task ListRemoteConnections()
         {
             using (ServerStore.ContextPool.AllocateOperationContext(out JsonOperationContext context))
-            await using (var write = new AsyncBlittableJsonTextWriter(context, ResponseBodyStream()))
+            await using (var write = new AsyncBlittableJsonTextWriterForDebug(context, ServerStore, ResponseBodyStream()))
             {
                 context.Write(write,
                     new DynamicJsonValue
@@ -49,7 +49,7 @@ namespace Raven.Server.Documents.Handlers.Debugging
         public async Task ListRecentEngineLogs()
         {
             using (ServerStore.ContextPool.AllocateOperationContext(out JsonOperationContext context))
-            await using (var write = new AsyncBlittableJsonTextWriter(context, ResponseBodyStream()))
+            await using (var write = new AsyncBlittableJsonTextWriterForDebug(context, ServerStore, ResponseBodyStream()))
             {
                 context.Write(write, ServerStore.Engine.InMemoryDebug.ToJson());
             }
@@ -59,7 +59,7 @@ namespace Raven.Server.Documents.Handlers.Debugging
         public async Task GetStateChangeHistory()
         {
             using (ServerStore.ContextPool.AllocateOperationContext(out JsonOperationContext context))
-            await using (var writer = new AsyncBlittableJsonTextWriter(context, ResponseBodyStream()))
+            await using (var writer = new AsyncBlittableJsonTextWriterForDebug(context, ServerStore, ResponseBodyStream()))
             {
                 writer.WriteStartObject();
                 writer.WriteArray("States", ServerStore.Engine.PrevStates.Select(s => s.ToString()));
@@ -87,7 +87,7 @@ namespace Raven.Server.Documents.Handlers.Debugging
             }
 
             using (ServerStore.ContextPool.AllocateOperationContext(out JsonOperationContext context))
-            await using (var writer = new AsyncBlittableJsonTextWriter(context, ResponseBodyStream()))
+            await using (var writer = new AsyncBlittableJsonTextWriterForDebug(context, ServerStore, ResponseBodyStream()))
             {
                 writer.WriteStartObject();
                 writer.WritePropertyName("Result");

--- a/src/Raven.Server/Documents/Handlers/Debugging/NodeDebugHandler.cs
+++ b/src/Raven.Server/Documents/Handlers/Debugging/NodeDebugHandler.cs
@@ -26,7 +26,7 @@ namespace Raven.Server.Documents.Handlers.Debugging
         public async Task ListRemoteConnections()
         {
             using (ServerStore.ContextPool.AllocateOperationContext(out JsonOperationContext context))
-            await using (var write = new AsyncBlittableJsonTextWriterForDebug(HttpContext.Request, context, ServerStore, ResponseBodyStream()))
+            await using (var write = new AsyncBlittableJsonTextWriterForDebug(context, ServerStore, ResponseBodyStream()))
             {
                 context.Write(write,
                     new DynamicJsonValue
@@ -49,7 +49,7 @@ namespace Raven.Server.Documents.Handlers.Debugging
         public async Task ListRecentEngineLogs()
         {
             using (ServerStore.ContextPool.AllocateOperationContext(out JsonOperationContext context))
-            await using (var write = new AsyncBlittableJsonTextWriterForDebug(HttpContext.Request, context, ServerStore, ResponseBodyStream()))
+            await using (var write = new AsyncBlittableJsonTextWriterForDebug(context, ServerStore, ResponseBodyStream()))
             {
                 context.Write(write, ServerStore.Engine.InMemoryDebug.ToJson());
             }
@@ -59,7 +59,7 @@ namespace Raven.Server.Documents.Handlers.Debugging
         public async Task GetStateChangeHistory()
         {
             using (ServerStore.ContextPool.AllocateOperationContext(out JsonOperationContext context))
-            await using (var writer = new AsyncBlittableJsonTextWriterForDebug(HttpContext.Request, context, ServerStore, ResponseBodyStream()))
+            await using (var writer = new AsyncBlittableJsonTextWriterForDebug(context, ServerStore, ResponseBodyStream()))
             {
                 writer.WriteStartObject();
                 writer.WriteArray("States", ServerStore.Engine.PrevStates.Select(s => s.ToString()));
@@ -87,7 +87,7 @@ namespace Raven.Server.Documents.Handlers.Debugging
             }
 
             using (ServerStore.ContextPool.AllocateOperationContext(out JsonOperationContext context))
-            await using (var writer = new AsyncBlittableJsonTextWriterForDebug(HttpContext.Request, context, ServerStore, ResponseBodyStream()))
+            await using (var writer = new AsyncBlittableJsonTextWriterForDebug(context, ServerStore, ResponseBodyStream()))
             {
                 writer.WriteStartObject();
                 writer.WritePropertyName("Result");

--- a/src/Raven.Server/Documents/Handlers/Debugging/ProcStatsHandler.cs
+++ b/src/Raven.Server/Documents/Handlers/Debugging/ProcStatsHandler.cs
@@ -19,7 +19,7 @@ namespace Raven.Server.Documents.Handlers.Debugging
             {
                 var djv = CpuStatsInternal();
 
-                await using (var write = new AsyncBlittableJsonTextWriterForDebug(HttpContext.Request, context, ServerStore, ResponseBodyStream()))
+                await using (var write = new AsyncBlittableJsonTextWriterForDebug(context, ServerStore, ResponseBodyStream()))
                 {
                     context.Write(write, djv);
                 }
@@ -33,7 +33,7 @@ namespace Raven.Server.Documents.Handlers.Debugging
             {
                 var djv = ProcStatsInternal();
 
-                await using (var write = new AsyncBlittableJsonTextWriterForDebug(HttpContext.Request, context, ServerStore, ResponseBodyStream()))
+                await using (var write = new AsyncBlittableJsonTextWriterForDebug(context, ServerStore, ResponseBodyStream()))
                 {
                     context.Write(write, djv);
                 }

--- a/src/Raven.Server/Documents/Handlers/Debugging/ProcStatsHandler.cs
+++ b/src/Raven.Server/Documents/Handlers/Debugging/ProcStatsHandler.cs
@@ -19,7 +19,7 @@ namespace Raven.Server.Documents.Handlers.Debugging
             {
                 var djv = CpuStatsInternal();
 
-                await using (var write = new AsyncBlittableJsonTextWriterForDebug(context, ServerStore, ResponseBodyStream()))
+                await using (var write = new AsyncBlittableJsonTextWriterForDebug(HttpContext.Request, context, ServerStore, ResponseBodyStream()))
                 {
                     context.Write(write, djv);
                 }
@@ -33,7 +33,7 @@ namespace Raven.Server.Documents.Handlers.Debugging
             {
                 var djv = ProcStatsInternal();
 
-                await using (var write = new AsyncBlittableJsonTextWriterForDebug(context, ServerStore, ResponseBodyStream()))
+                await using (var write = new AsyncBlittableJsonTextWriterForDebug(HttpContext.Request, context, ServerStore, ResponseBodyStream()))
                 {
                     context.Write(write, djv);
                 }

--- a/src/Raven.Server/Documents/Handlers/Debugging/ProcStatsHandler.cs
+++ b/src/Raven.Server/Documents/Handlers/Debugging/ProcStatsHandler.cs
@@ -3,6 +3,7 @@ using System.Diagnostics;
 using System.Threading;
 using System.Threading.Tasks;
 using Raven.Server.Routing;
+using Raven.Server.Utils;
 using Raven.Server.Web;
 using Sparrow.Json;
 using Sparrow.Json.Parsing;
@@ -18,7 +19,7 @@ namespace Raven.Server.Documents.Handlers.Debugging
             {
                 var djv = CpuStatsInternal();
 
-                await using (var write = new AsyncBlittableJsonTextWriter(context, ResponseBodyStream()))
+                await using (var write = new AsyncBlittableJsonTextWriterForDebug(context, ServerStore, ResponseBodyStream()))
                 {
                     context.Write(write, djv);
                 }
@@ -32,7 +33,7 @@ namespace Raven.Server.Documents.Handlers.Debugging
             {
                 var djv = ProcStatsInternal();
 
-                await using (var write = new AsyncBlittableJsonTextWriter(context, ResponseBodyStream()))
+                await using (var write = new AsyncBlittableJsonTextWriterForDebug(context, ServerStore, ResponseBodyStream()))
                 {
                     context.Write(write, djv);
                 }

--- a/src/Raven.Server/Documents/Handlers/Debugging/QueriesDebugHandler.cs
+++ b/src/Raven.Server/Documents/Handlers/Debugging/QueriesDebugHandler.cs
@@ -36,7 +36,7 @@ namespace Raven.Server.Documents.Handlers.Debugging
         public async Task RunningQueries()
         {
             using (ContextPool.AllocateOperationContext(out DocumentsOperationContext context))
-            await using (var writer = new AsyncBlittableJsonTextWriterForDebug(HttpContext.Request, context, ServerStore, ResponseBodyStream()))
+            await using (var writer = new AsyncBlittableJsonTextWriterForDebug(context, ServerStore, ResponseBodyStream()))
             {
                 writer.WriteStartObject();
 
@@ -72,7 +72,7 @@ namespace Raven.Server.Documents.Handlers.Debugging
         public async Task QueriesCacheList()
         {
             using (ContextPool.AllocateOperationContext(out DocumentsOperationContext context))
-            await using (var writer = new AsyncBlittableJsonTextWriterForDebug(HttpContext.Request, context, ServerStore, ResponseBodyStream()))
+            await using (var writer = new AsyncBlittableJsonTextWriterForDebug(context, ServerStore, ResponseBodyStream()))
             {
                 var queryCache = Database.QueryMetadataCache.GetQueryCache();
 

--- a/src/Raven.Server/Documents/Handlers/Debugging/QueriesDebugHandler.cs
+++ b/src/Raven.Server/Documents/Handlers/Debugging/QueriesDebugHandler.cs
@@ -36,7 +36,7 @@ namespace Raven.Server.Documents.Handlers.Debugging
         public async Task RunningQueries()
         {
             using (ContextPool.AllocateOperationContext(out DocumentsOperationContext context))
-            await using (var writer = new AsyncBlittableJsonTextWriterForDebug(context, ServerStore, ResponseBodyStream()))
+            await using (var writer = new AsyncBlittableJsonTextWriterForDebug(HttpContext.Request, context, ServerStore, ResponseBodyStream()))
             {
                 writer.WriteStartObject();
 
@@ -72,7 +72,7 @@ namespace Raven.Server.Documents.Handlers.Debugging
         public async Task QueriesCacheList()
         {
             using (ContextPool.AllocateOperationContext(out DocumentsOperationContext context))
-            await using (var writer = new AsyncBlittableJsonTextWriterForDebug(context, ServerStore, ResponseBodyStream()))
+            await using (var writer = new AsyncBlittableJsonTextWriterForDebug(HttpContext.Request, context, ServerStore, ResponseBodyStream()))
             {
                 var queryCache = Database.QueryMetadataCache.GetQueryCache();
 

--- a/src/Raven.Server/Documents/Handlers/Debugging/QueriesDebugHandler.cs
+++ b/src/Raven.Server/Documents/Handlers/Debugging/QueriesDebugHandler.cs
@@ -4,6 +4,7 @@ using System.Net;
 using System.Threading.Tasks;
 using Raven.Server.Routing;
 using Raven.Server.ServerWide.Context;
+using Raven.Server.Utils;
 using Sparrow.Json;
 using Sparrow.Json.Parsing;
 
@@ -35,7 +36,7 @@ namespace Raven.Server.Documents.Handlers.Debugging
         public async Task RunningQueries()
         {
             using (ContextPool.AllocateOperationContext(out DocumentsOperationContext context))
-            await using (var writer = new AsyncBlittableJsonTextWriter(context, ResponseBodyStream()))
+            await using (var writer = new AsyncBlittableJsonTextWriterForDebug(context, ServerStore, ResponseBodyStream()))
             {
                 writer.WriteStartObject();
 
@@ -71,7 +72,7 @@ namespace Raven.Server.Documents.Handlers.Debugging
         public async Task QueriesCacheList()
         {
             using (ContextPool.AllocateOperationContext(out DocumentsOperationContext context))
-            await using (var writer = new AsyncBlittableJsonTextWriter(context, ResponseBodyStream()))
+            await using (var writer = new AsyncBlittableJsonTextWriterForDebug(context, ServerStore, ResponseBodyStream()))
             {
                 var queryCache = Database.QueryMetadataCache.GetQueryCache();
 

--- a/src/Raven.Server/Documents/Handlers/Debugging/ScriptRunnersDebugInfoHandler.cs
+++ b/src/Raven.Server/Documents/Handlers/Debugging/ScriptRunnersDebugInfoHandler.cs
@@ -1,5 +1,6 @@
 ﻿using System.Threading.Tasks;
 using Raven.Server.Routing;
+using Raven.Server.Utils;
 using Sparrow.Json;
 
 namespace Raven.Server.Documents.Handlers.Debugging
@@ -13,7 +14,7 @@ namespace Raven.Server.Documents.Handlers.Debugging
 
             using (Database.ServerStore.ContextPool.AllocateOperationContext(out JsonOperationContext context))
             {
-                await using (var writer = new AsyncBlittableJsonTextWriter(context, ResponseBodyStream()))
+                await using (var writer = new AsyncBlittableJsonTextWriterForDebug(context, ServerStore, ResponseBodyStream()))
                 {
                     writer.WriteStartObject();
                     writer.WritePropertyName("ScriptRunners");

--- a/src/Raven.Server/Documents/Handlers/Debugging/ScriptRunnersDebugInfoHandler.cs
+++ b/src/Raven.Server/Documents/Handlers/Debugging/ScriptRunnersDebugInfoHandler.cs
@@ -14,7 +14,7 @@ namespace Raven.Server.Documents.Handlers.Debugging
 
             using (Database.ServerStore.ContextPool.AllocateOperationContext(out JsonOperationContext context))
             {
-                await using (var writer = new AsyncBlittableJsonTextWriterForDebug(HttpContext.Request, context, ServerStore, ResponseBodyStream()))
+                await using (var writer = new AsyncBlittableJsonTextWriterForDebug(context, ServerStore, ResponseBodyStream()))
                 {
                     writer.WriteStartObject();
                     writer.WritePropertyName("ScriptRunners");

--- a/src/Raven.Server/Documents/Handlers/Debugging/ScriptRunnersDebugInfoHandler.cs
+++ b/src/Raven.Server/Documents/Handlers/Debugging/ScriptRunnersDebugInfoHandler.cs
@@ -14,7 +14,7 @@ namespace Raven.Server.Documents.Handlers.Debugging
 
             using (Database.ServerStore.ContextPool.AllocateOperationContext(out JsonOperationContext context))
             {
-                await using (var writer = new AsyncBlittableJsonTextWriterForDebug(context, ServerStore, ResponseBodyStream()))
+                await using (var writer = new AsyncBlittableJsonTextWriterForDebug(HttpContext.Request, context, ServerStore, ResponseBodyStream()))
                 {
                     writer.WriteStartObject();
                     writer.WritePropertyName("ScriptRunners");

--- a/src/Raven.Server/Documents/Handlers/Debugging/ServerInfoHandler.cs
+++ b/src/Raven.Server/Documents/Handlers/Debugging/ServerInfoHandler.cs
@@ -13,7 +13,7 @@ namespace Raven.Server.Documents.Handlers.Debugging
         public async Task ServerId()
         {
             using (ServerStore.ContextPool.AllocateOperationContext(out JsonOperationContext context))
-            await using (var writer = new AsyncBlittableJsonTextWriterForDebug(context, ServerStore, ResponseBodyStream()))
+            await using (var writer = new AsyncBlittableJsonTextWriterForDebug(HttpContext.Request, context, ServerStore, ResponseBodyStream()))
             {
                 context.Write(writer, new DynamicJsonValue
                 {

--- a/src/Raven.Server/Documents/Handlers/Debugging/ServerInfoHandler.cs
+++ b/src/Raven.Server/Documents/Handlers/Debugging/ServerInfoHandler.cs
@@ -13,7 +13,7 @@ namespace Raven.Server.Documents.Handlers.Debugging
         public async Task ServerId()
         {
             using (ServerStore.ContextPool.AllocateOperationContext(out JsonOperationContext context))
-            await using (var writer = new AsyncBlittableJsonTextWriterForDebug(HttpContext.Request, context, ServerStore, ResponseBodyStream()))
+            await using (var writer = new AsyncBlittableJsonTextWriterForDebug(context, ServerStore, ResponseBodyStream()))
             {
                 context.Write(writer, new DynamicJsonValue
                 {

--- a/src/Raven.Server/Documents/Handlers/Debugging/ServerInfoHandler.cs
+++ b/src/Raven.Server/Documents/Handlers/Debugging/ServerInfoHandler.cs
@@ -1,5 +1,6 @@
 using System.Threading.Tasks;
 using Raven.Server.Routing;
+using Raven.Server.Utils;
 using Raven.Server.Web;
 using Sparrow.Json;
 using Sparrow.Json.Parsing;
@@ -12,7 +13,7 @@ namespace Raven.Server.Documents.Handlers.Debugging
         public async Task ServerId()
         {
             using (ServerStore.ContextPool.AllocateOperationContext(out JsonOperationContext context))
-            await using (var writer = new AsyncBlittableJsonTextWriter(context, ResponseBodyStream()))
+            await using (var writer = new AsyncBlittableJsonTextWriterForDebug(context, ServerStore, ResponseBodyStream()))
             {
                 context.Write(writer, new DynamicJsonValue
                 {

--- a/src/Raven.Server/Documents/Handlers/Debugging/ServerTransactionDebugHandler.cs
+++ b/src/Raven.Server/Documents/Handlers/Debugging/ServerTransactionDebugHandler.cs
@@ -1,6 +1,7 @@
 ﻿using System.Collections.Generic;
 using System.Threading.Tasks;
 using Raven.Server.Routing;
+using Raven.Server.Utils;
 using Raven.Server.Web;
 using Sparrow.Json;
 using Sparrow.Json.Parsing;
@@ -23,7 +24,7 @@ namespace Raven.Server.Documents.Handlers.Debugging
             results.Add(txInfo);
 
             using (Server.ServerStore.ContextPool.AllocateOperationContext(out JsonOperationContext context))
-            await using (var writer = new AsyncBlittableJsonTextWriter(context, ResponseBodyStream()))
+            await using (var writer = new AsyncBlittableJsonTextWriterForDebug(context, ServerStore, ResponseBodyStream()))
             {
                 context.Write(writer, new DynamicJsonValue
                 {

--- a/src/Raven.Server/Documents/Handlers/Debugging/ServerTransactionDebugHandler.cs
+++ b/src/Raven.Server/Documents/Handlers/Debugging/ServerTransactionDebugHandler.cs
@@ -24,7 +24,7 @@ namespace Raven.Server.Documents.Handlers.Debugging
             results.Add(txInfo);
 
             using (Server.ServerStore.ContextPool.AllocateOperationContext(out JsonOperationContext context))
-            await using (var writer = new AsyncBlittableJsonTextWriterForDebug(context, ServerStore, ResponseBodyStream()))
+            await using (var writer = new AsyncBlittableJsonTextWriterForDebug(HttpContext.Request, context, ServerStore, ResponseBodyStream()))
             {
                 context.Write(writer, new DynamicJsonValue
                 {

--- a/src/Raven.Server/Documents/Handlers/Debugging/ServerTransactionDebugHandler.cs
+++ b/src/Raven.Server/Documents/Handlers/Debugging/ServerTransactionDebugHandler.cs
@@ -24,7 +24,7 @@ namespace Raven.Server.Documents.Handlers.Debugging
             results.Add(txInfo);
 
             using (Server.ServerStore.ContextPool.AllocateOperationContext(out JsonOperationContext context))
-            await using (var writer = new AsyncBlittableJsonTextWriterForDebug(HttpContext.Request, context, ServerStore, ResponseBodyStream()))
+            await using (var writer = new AsyncBlittableJsonTextWriterForDebug(context, ServerStore, ResponseBodyStream()))
             {
                 context.Write(writer, new DynamicJsonValue
                 {

--- a/src/Raven.Server/Documents/Handlers/Debugging/StorageHandler.cs
+++ b/src/Raven.Server/Documents/Handlers/Debugging/StorageHandler.cs
@@ -172,7 +172,7 @@ namespace Raven.Server.Documents.Handlers.Debugging
         {
             using (ContextPool.AllocateOperationContext(out DocumentsOperationContext context))
             {
-                await using (var writer = new AsyncBlittableJsonTextWriterForDebug(HttpContext.Request, context, ServerStore,  ResponseBodyStream()))
+                await using (var writer = new AsyncBlittableJsonTextWriterForDebug(context, ServerStore,  ResponseBodyStream()))
                 {
                     writer.WriteStartObject();
 
@@ -219,7 +219,7 @@ namespace Raven.Server.Documents.Handlers.Debugging
         {
             using (ContextPool.AllocateOperationContext(out DocumentsOperationContext context))
             {
-                await using (var writer = new AsyncBlittableJsonTextWriterForDebug(HttpContext.Request, context, ServerStore, ResponseBodyStream()))
+                await using (var writer = new AsyncBlittableJsonTextWriterForDebug(context, ServerStore, ResponseBodyStream()))
                 {
                     writer.WriteStartObject();
 

--- a/src/Raven.Server/Documents/Handlers/Debugging/StorageHandler.cs
+++ b/src/Raven.Server/Documents/Handlers/Debugging/StorageHandler.cs
@@ -172,7 +172,7 @@ namespace Raven.Server.Documents.Handlers.Debugging
         {
             using (ContextPool.AllocateOperationContext(out DocumentsOperationContext context))
             {
-                await using (var writer = new AsyncBlittableJsonTextWriter(context, ResponseBodyStream()))
+                await using (var writer = new AsyncBlittableJsonTextWriterForDebug(context, ServerStore, ResponseBodyStream()))
                 {
                     writer.WriteStartObject();
 
@@ -217,16 +217,14 @@ namespace Raven.Server.Documents.Handlers.Debugging
         [RavenAction("/databases/*/debug/storage/all-environments/report", "GET", AuthorizationStatus.ValidUser, EndpointType.Read, IsDebugInformationEndpoint = true)]
         public async Task AllEnvironmentsReport()
         {
-            var name = GetStringQueryString("database");
-
             using (ContextPool.AllocateOperationContext(out DocumentsOperationContext context))
             {
-                await using (var writer = new AsyncBlittableJsonTextWriter(context, ResponseBodyStream()))
+                await using (var writer = new AsyncBlittableJsonTextWriterForDebug(context, ServerStore, ResponseBodyStream()))
                 {
                     writer.WriteStartObject();
 
                     writer.WritePropertyName("DatabaseName");
-                    writer.WriteString(name);
+                    writer.WriteString(Database.Name);
                     writer.WriteComma();
 
                     writer.WritePropertyName("Environments");

--- a/src/Raven.Server/Documents/Handlers/Debugging/StorageHandler.cs
+++ b/src/Raven.Server/Documents/Handlers/Debugging/StorageHandler.cs
@@ -172,7 +172,7 @@ namespace Raven.Server.Documents.Handlers.Debugging
         {
             using (ContextPool.AllocateOperationContext(out DocumentsOperationContext context))
             {
-                await using (var writer = new AsyncBlittableJsonTextWriterForDebug(context, ServerStore, ResponseBodyStream()))
+                await using (var writer = new AsyncBlittableJsonTextWriterForDebug(HttpContext.Request, context, ServerStore,  ResponseBodyStream()))
                 {
                     writer.WriteStartObject();
 
@@ -219,7 +219,7 @@ namespace Raven.Server.Documents.Handlers.Debugging
         {
             using (ContextPool.AllocateOperationContext(out DocumentsOperationContext context))
             {
-                await using (var writer = new AsyncBlittableJsonTextWriterForDebug(context, ServerStore, ResponseBodyStream()))
+                await using (var writer = new AsyncBlittableJsonTextWriterForDebug(HttpContext.Request, context, ServerStore, ResponseBodyStream()))
                 {
                     writer.WriteStartObject();
 

--- a/src/Raven.Server/Documents/Handlers/Debugging/ThreadsHandler.cs
+++ b/src/Raven.Server/Documents/Handlers/Debugging/ThreadsHandler.cs
@@ -53,7 +53,7 @@ namespace Raven.Server.Documents.Handlers.Debugging
 
                 using (ServerStore.ContextPool.AllocateOperationContext(out TransactionOperationContext context))
                 {
-                    await using (var writer = new AsyncBlittableJsonTextWriter(context, ResponseBodyStream()))
+                    await using (var writer = new AsyncBlittableJsonTextWriterForDebug(context, ServerStore, ResponseBodyStream()))
                     {
                         context.Write(writer, DocumentConventions.DefaultForServer.Serialization.DefaultConverter.ToBlittable(result, context));
                     }
@@ -76,7 +76,7 @@ namespace Raven.Server.Documents.Handlers.Debugging
 
             using (ServerStore.ContextPool.AllocateOperationContext(out JsonOperationContext context))
             {
-                await using (var writer = new AsyncBlittableJsonTextWriter(context, ResponseBodyStream()))
+                await using (var writer = new AsyncBlittableJsonTextWriterForDebug(context, ServerStore, ResponseBodyStream()))
                 {
                     try
                     {

--- a/src/Raven.Server/Documents/Handlers/Debugging/ThreadsHandler.cs
+++ b/src/Raven.Server/Documents/Handlers/Debugging/ThreadsHandler.cs
@@ -53,7 +53,7 @@ namespace Raven.Server.Documents.Handlers.Debugging
 
                 using (ServerStore.ContextPool.AllocateOperationContext(out TransactionOperationContext context))
                 {
-                    await using (var writer = new AsyncBlittableJsonTextWriterForDebug(HttpContext.Request, context, ServerStore, ResponseBodyStream()))
+                    await using (var writer = new AsyncBlittableJsonTextWriterForDebug(context, ServerStore, ResponseBodyStream()))
                     {
                         context.Write(writer, DocumentConventions.DefaultForServer.Serialization.DefaultConverter.ToBlittable(result, context));
                     }
@@ -76,7 +76,7 @@ namespace Raven.Server.Documents.Handlers.Debugging
 
             using (ServerStore.ContextPool.AllocateOperationContext(out JsonOperationContext context))
             {
-                await using (var writer = new AsyncBlittableJsonTextWriterForDebug(HttpContext.Request, context, ServerStore, ResponseBodyStream()))
+                await using (var writer = new AsyncBlittableJsonTextWriterForDebug(context, ServerStore, ResponseBodyStream()))
                 {
                     try
                     {

--- a/src/Raven.Server/Documents/Handlers/Debugging/ThreadsHandler.cs
+++ b/src/Raven.Server/Documents/Handlers/Debugging/ThreadsHandler.cs
@@ -53,7 +53,7 @@ namespace Raven.Server.Documents.Handlers.Debugging
 
                 using (ServerStore.ContextPool.AllocateOperationContext(out TransactionOperationContext context))
                 {
-                    await using (var writer = new AsyncBlittableJsonTextWriterForDebug(context, ServerStore, ResponseBodyStream()))
+                    await using (var writer = new AsyncBlittableJsonTextWriterForDebug(HttpContext.Request, context, ServerStore, ResponseBodyStream()))
                     {
                         context.Write(writer, DocumentConventions.DefaultForServer.Serialization.DefaultConverter.ToBlittable(result, context));
                     }
@@ -76,7 +76,7 @@ namespace Raven.Server.Documents.Handlers.Debugging
 
             using (ServerStore.ContextPool.AllocateOperationContext(out JsonOperationContext context))
             {
-                await using (var writer = new AsyncBlittableJsonTextWriterForDebug(context, ServerStore, ResponseBodyStream()))
+                await using (var writer = new AsyncBlittableJsonTextWriterForDebug(HttpContext.Request, context, ServerStore, ResponseBodyStream()))
                 {
                     try
                     {

--- a/src/Raven.Server/Documents/Handlers/Debugging/TransactionDebugHandler.cs
+++ b/src/Raven.Server/Documents/Handlers/Debugging/TransactionDebugHandler.cs
@@ -38,7 +38,7 @@ namespace Raven.Server.Documents.Handlers.Debugging
             }
 
             using (ContextPool.AllocateOperationContext(out JsonOperationContext context))
-            await using (var writer = new AsyncBlittableJsonTextWriterForDebug(HttpContext.Request, context, ServerStore, ResponseBodyStream()))
+            await using (var writer = new AsyncBlittableJsonTextWriterForDebug(context, ServerStore, ResponseBodyStream()))
             {
                 context.Write(writer, new DynamicJsonValue
                 {
@@ -55,7 +55,7 @@ namespace Raven.Server.Documents.Handlers.Debugging
 
             using (ServerStore.ContextPool.AllocateOperationContext(out TransactionOperationContext context))
             using (context.OpenReadTransaction())
-            await using (var writer = new AsyncBlittableJsonTextWriterForDebug(HttpContext.Request, context, ServerStore, ResponseBodyStream()))
+            await using (var writer = new AsyncBlittableJsonTextWriterForDebug(context, ServerStore, ResponseBodyStream()))
             {
                 context.Write(writer, new DynamicJsonValue
                 {

--- a/src/Raven.Server/Documents/Handlers/Debugging/TransactionDebugHandler.cs
+++ b/src/Raven.Server/Documents/Handlers/Debugging/TransactionDebugHandler.cs
@@ -38,7 +38,7 @@ namespace Raven.Server.Documents.Handlers.Debugging
             }
 
             using (ContextPool.AllocateOperationContext(out JsonOperationContext context))
-            await using (var writer = new AsyncBlittableJsonTextWriterForDebug(context, ServerStore, ResponseBodyStream()))
+            await using (var writer = new AsyncBlittableJsonTextWriterForDebug(HttpContext.Request, context, ServerStore, ResponseBodyStream()))
             {
                 context.Write(writer, new DynamicJsonValue
                 {
@@ -55,7 +55,7 @@ namespace Raven.Server.Documents.Handlers.Debugging
 
             using (ServerStore.ContextPool.AllocateOperationContext(out TransactionOperationContext context))
             using (context.OpenReadTransaction())
-            await using (var writer = new AsyncBlittableJsonTextWriterForDebug(context, ServerStore, ResponseBodyStream()))
+            await using (var writer = new AsyncBlittableJsonTextWriterForDebug(HttpContext.Request, context, ServerStore, ResponseBodyStream()))
             {
                 context.Write(writer, new DynamicJsonValue
                 {

--- a/src/Raven.Server/Documents/Handlers/Debugging/TransactionDebugHandler.cs
+++ b/src/Raven.Server/Documents/Handlers/Debugging/TransactionDebugHandler.cs
@@ -5,6 +5,7 @@ using System.Threading.Tasks;
 using Raven.Server.Routing;
 using Raven.Server.ServerWide.Commands;
 using Raven.Server.ServerWide.Context;
+using Raven.Server.Utils;
 using Sparrow.Extensions;
 using Sparrow.Json;
 using Sparrow.Json.Parsing;
@@ -37,7 +38,7 @@ namespace Raven.Server.Documents.Handlers.Debugging
             }
 
             using (ContextPool.AllocateOperationContext(out JsonOperationContext context))
-            await using (var writer = new AsyncBlittableJsonTextWriter(context, ResponseBodyStream()))
+            await using (var writer = new AsyncBlittableJsonTextWriterForDebug(context, ServerStore, ResponseBodyStream()))
             {
                 context.Write(writer, new DynamicJsonValue
                 {
@@ -54,7 +55,7 @@ namespace Raven.Server.Documents.Handlers.Debugging
 
             using (ServerStore.ContextPool.AllocateOperationContext(out TransactionOperationContext context))
             using (context.OpenReadTransaction())
-            await using (var writer = new AsyncBlittableJsonTextWriter(context, ResponseBodyStream()))
+            await using (var writer = new AsyncBlittableJsonTextWriterForDebug(context, ServerStore, ResponseBodyStream()))
             {
                 context.Write(writer, new DynamicJsonValue
                 {

--- a/src/Raven.Server/Documents/Handlers/IndexHandler.cs
+++ b/src/Raven.Server/Documents/Handlers/IndexHandler.cs
@@ -339,7 +339,7 @@ namespace Raven.Server.Documents.Handlers
             var namesOnly = GetBoolValueQueryString("namesOnly", required: false) ?? false;
 
             using (ContextPool.AllocateOperationContext(out DocumentsOperationContext context))
-            await using (var writer = new AsyncBlittableJsonTextWriter(context, ResponseBodyStream()))
+            await using (var writer = new AsyncBlittableJsonTextWriterForDebug(context, ServerStore, ResponseBodyStream()))
             {
                 IndexDefinition[] indexDefinitions;
                 if (string.IsNullOrEmpty(name))
@@ -385,7 +385,7 @@ namespace Raven.Server.Documents.Handlers
             var name = GetStringQueryString("name", required: false);
 
             using (var context = QueryOperationContext.Allocate(Database, needsServerContext: true))
-            await using (var writer = new AsyncBlittableJsonTextWriter(context.Documents, ResponseBodyStream()))
+            await using (var writer = new AsyncBlittableJsonTextWriterForDebug(context.Documents, ServerStore, ResponseBodyStream()))
             {
                 IndexStats[] indexStats;
                 using (context.OpenReadTransaction())
@@ -785,7 +785,7 @@ namespace Raven.Server.Documents.Handlers
             }
 
             using (ContextPool.AllocateOperationContext(out DocumentsOperationContext context))
-            await using (var writer = new AsyncBlittableJsonTextWriter(context, ResponseBodyStream()))
+            await using (var writer = new AsyncBlittableJsonTextWriterForDebug(context, ServerStore, ResponseBodyStream()))
             {
                 writer.WriteStartObject();
                 writer.WriteArray(context, "Results", indexes, (w, c, index) =>

--- a/src/Raven.Server/Documents/Handlers/IndexHandler.cs
+++ b/src/Raven.Server/Documents/Handlers/IndexHandler.cs
@@ -339,7 +339,7 @@ namespace Raven.Server.Documents.Handlers
             var namesOnly = GetBoolValueQueryString("namesOnly", required: false) ?? false;
 
             using (ContextPool.AllocateOperationContext(out DocumentsOperationContext context))
-            await using (var writer = new AsyncBlittableJsonTextWriterForDebug(HttpContext.Request, context, ServerStore, ResponseBodyStream()))
+            await using (var writer = new AsyncBlittableJsonTextWriterForDebug(context, ServerStore, ResponseBodyStream()))
             {
                 IndexDefinition[] indexDefinitions;
                 if (string.IsNullOrEmpty(name))
@@ -385,7 +385,7 @@ namespace Raven.Server.Documents.Handlers
             var name = GetStringQueryString("name", required: false);
 
             using (var context = QueryOperationContext.Allocate(Database, needsServerContext: true))
-            await using (var writer = new AsyncBlittableJsonTextWriterForDebug(HttpContext.Request, context.Documents, ServerStore, ResponseBodyStream()))
+            await using (var writer = new AsyncBlittableJsonTextWriterForDebug(context.Documents, ServerStore, ResponseBodyStream()))
             {
                 IndexStats[] indexStats;
                 using (context.OpenReadTransaction())
@@ -785,7 +785,7 @@ namespace Raven.Server.Documents.Handlers
             }
 
             using (ContextPool.AllocateOperationContext(out DocumentsOperationContext context))
-            await using (var writer = new AsyncBlittableJsonTextWriterForDebug(HttpContext.Request, context, ServerStore, ResponseBodyStream()))
+            await using (var writer = new AsyncBlittableJsonTextWriterForDebug(context, ServerStore, ResponseBodyStream()))
             {
                 writer.WriteStartObject();
                 writer.WriteArray(context, "Results", indexes, (w, c, index) =>

--- a/src/Raven.Server/Documents/Handlers/IndexHandler.cs
+++ b/src/Raven.Server/Documents/Handlers/IndexHandler.cs
@@ -339,7 +339,7 @@ namespace Raven.Server.Documents.Handlers
             var namesOnly = GetBoolValueQueryString("namesOnly", required: false) ?? false;
 
             using (ContextPool.AllocateOperationContext(out DocumentsOperationContext context))
-            await using (var writer = new AsyncBlittableJsonTextWriterForDebug(context, ServerStore, ResponseBodyStream()))
+            await using (var writer = new AsyncBlittableJsonTextWriterForDebug(HttpContext.Request, context, ServerStore, ResponseBodyStream()))
             {
                 IndexDefinition[] indexDefinitions;
                 if (string.IsNullOrEmpty(name))
@@ -385,7 +385,7 @@ namespace Raven.Server.Documents.Handlers
             var name = GetStringQueryString("name", required: false);
 
             using (var context = QueryOperationContext.Allocate(Database, needsServerContext: true))
-            await using (var writer = new AsyncBlittableJsonTextWriterForDebug(context.Documents, ServerStore, ResponseBodyStream()))
+            await using (var writer = new AsyncBlittableJsonTextWriterForDebug(HttpContext.Request, context.Documents, ServerStore, ResponseBodyStream()))
             {
                 IndexStats[] indexStats;
                 using (context.OpenReadTransaction())
@@ -785,7 +785,7 @@ namespace Raven.Server.Documents.Handlers
             }
 
             using (ContextPool.AllocateOperationContext(out DocumentsOperationContext context))
-            await using (var writer = new AsyncBlittableJsonTextWriterForDebug(context, ServerStore, ResponseBodyStream()))
+            await using (var writer = new AsyncBlittableJsonTextWriterForDebug(HttpContext.Request, context, ServerStore, ResponseBodyStream()))
             {
                 writer.WriteStartObject();
                 writer.WriteArray(context, "Results", indexes, (w, c, index) =>

--- a/src/Raven.Server/Documents/Handlers/IoMetricsHandler.cs
+++ b/src/Raven.Server/Documents/Handlers/IoMetricsHandler.cs
@@ -16,7 +16,7 @@ namespace Raven.Server.Documents.Handlers
         public async Task IoMetrics()
         {
             using (ContextPool.AllocateOperationContext(out JsonOperationContext context))
-            await using (var writer = new AsyncBlittableJsonTextWriterForDebug(HttpContext.Request, context, ServerStore, ResponseBodyStream()))
+            await using (var writer = new AsyncBlittableJsonTextWriterForDebug(context, ServerStore, ResponseBodyStream()))
             {
                 var result = IoMetricsUtil.GetIoMetricsResponse(Database.GetAllStoragesEnvironment(), Database.GetAllPerformanceMetrics());
                 context.Write(writer, result.ToJson());

--- a/src/Raven.Server/Documents/Handlers/IoMetricsHandler.cs
+++ b/src/Raven.Server/Documents/Handlers/IoMetricsHandler.cs
@@ -4,6 +4,7 @@ using System.Linq;
 using System.Threading.Tasks;
 using Raven.Server.Routing;
 using Raven.Server.ServerWide.Context;
+using Raven.Server.Utils;
 using Raven.Server.Utils.IoMetrics;
 using Sparrow.Json;
 
@@ -15,7 +16,7 @@ namespace Raven.Server.Documents.Handlers
         public async Task IoMetrics()
         {
             using (ContextPool.AllocateOperationContext(out JsonOperationContext context))
-            await using (var writer = new AsyncBlittableJsonTextWriter(context, ResponseBodyStream()))
+            await using (var writer = new AsyncBlittableJsonTextWriterForDebug(context, ServerStore, ResponseBodyStream()))
             {
                 var result = IoMetricsUtil.GetIoMetricsResponse(Database.GetAllStoragesEnvironment(), Database.GetAllPerformanceMetrics());
                 context.Write(writer, result.ToJson());

--- a/src/Raven.Server/Documents/Handlers/IoMetricsHandler.cs
+++ b/src/Raven.Server/Documents/Handlers/IoMetricsHandler.cs
@@ -16,7 +16,7 @@ namespace Raven.Server.Documents.Handlers
         public async Task IoMetrics()
         {
             using (ContextPool.AllocateOperationContext(out JsonOperationContext context))
-            await using (var writer = new AsyncBlittableJsonTextWriterForDebug(context, ServerStore, ResponseBodyStream()))
+            await using (var writer = new AsyncBlittableJsonTextWriterForDebug(HttpContext.Request, context, ServerStore, ResponseBodyStream()))
             {
                 var result = IoMetricsUtil.GetIoMetricsResponse(Database.GetAllStoragesEnvironment(), Database.GetAllPerformanceMetrics());
                 context.Write(writer, result.ToJson());

--- a/src/Raven.Server/Documents/Handlers/PerformanceMetricsHandler.cs
+++ b/src/Raven.Server/Documents/Handlers/PerformanceMetricsHandler.cs
@@ -33,7 +33,7 @@ namespace Raven.Server.Documents.Handlers
         public async Task IoMetrics()
         {
             using (ContextPool.AllocateOperationContext(out JsonOperationContext context))
-            await using (var writer = new AsyncBlittableJsonTextWriterForDebug(context, ServerStore, ResponseBodyStream()))
+            await using (var writer = new AsyncBlittableJsonTextWriterForDebug(HttpContext.Request, context, ServerStore, ResponseBodyStream()))
             {
                 var result = GetPerformanceMetricsResponse(Database);
                 context.Write(writer, result.ToJson());

--- a/src/Raven.Server/Documents/Handlers/PerformanceMetricsHandler.cs
+++ b/src/Raven.Server/Documents/Handlers/PerformanceMetricsHandler.cs
@@ -33,7 +33,7 @@ namespace Raven.Server.Documents.Handlers
         public async Task IoMetrics()
         {
             using (ContextPool.AllocateOperationContext(out JsonOperationContext context))
-            await using (var writer = new AsyncBlittableJsonTextWriterForDebug(HttpContext.Request, context, ServerStore, ResponseBodyStream()))
+            await using (var writer = new AsyncBlittableJsonTextWriterForDebug(context, ServerStore, ResponseBodyStream()))
             {
                 var result = GetPerformanceMetricsResponse(Database);
                 context.Write(writer, result.ToJson());

--- a/src/Raven.Server/Documents/Handlers/PerformanceMetricsHandler.cs
+++ b/src/Raven.Server/Documents/Handlers/PerformanceMetricsHandler.cs
@@ -2,6 +2,7 @@
 using System.Linq;
 using System.Threading.Tasks;
 using Raven.Server.Routing;
+using Raven.Server.Utils;
 using Sparrow.Json;
 using Sparrow.Json.Parsing;
 using Sparrow.Server.Meters;
@@ -32,7 +33,7 @@ namespace Raven.Server.Documents.Handlers
         public async Task IoMetrics()
         {
             using (ContextPool.AllocateOperationContext(out JsonOperationContext context))
-            await using (var writer = new AsyncBlittableJsonTextWriter(context, ResponseBodyStream()))
+            await using (var writer = new AsyncBlittableJsonTextWriterForDebug(context, ServerStore, ResponseBodyStream()))
             {
                 var result = GetPerformanceMetricsResponse(Database);
                 context.Write(writer, result.ToJson());

--- a/src/Raven.Server/Documents/Handlers/ReplicationHandler.cs
+++ b/src/Raven.Server/Documents/Handlers/ReplicationHandler.cs
@@ -294,7 +294,7 @@ namespace Raven.Server.Documents.Handlers
         public async Task GetReplicationOutgoingFailureStats()
         {
             using (ContextPool.AllocateOperationContext(out DocumentsOperationContext context))
-            await using (var writer = new AsyncBlittableJsonTextWriter(context, ResponseBodyStream()))
+            await using (var writer = new AsyncBlittableJsonTextWriterForDebug(context, ServerStore, ResponseBodyStream()))
             {
                 var data = new DynamicJsonArray();
                 foreach (var item in Database.ReplicationLoader.OutgoingFailureInfo)
@@ -331,7 +331,7 @@ namespace Raven.Server.Documents.Handlers
         public async Task GetReplicationIncomingActivityTimes()
         {
             using (ContextPool.AllocateOperationContext(out DocumentsOperationContext context))
-            await using (var writer = new AsyncBlittableJsonTextWriter(context, ResponseBodyStream()))
+            await using (var writer = new AsyncBlittableJsonTextWriterForDebug(context, ServerStore, ResponseBodyStream()))
             {
                 var data = new DynamicJsonArray();
                 foreach (var item in Database.ReplicationLoader.IncomingLastActivityTime)
@@ -360,7 +360,7 @@ namespace Raven.Server.Documents.Handlers
         public async Task GetReplicationIncomingRejectionInfo()
         {
             using (ContextPool.AllocateOperationContext(out DocumentsOperationContext context))
-            await using (var writer = new AsyncBlittableJsonTextWriter(context, ResponseBodyStream()))
+            await using (var writer = new AsyncBlittableJsonTextWriterForDebug(context, ServerStore, ResponseBodyStream()))
             {
                 var stats = new DynamicJsonArray();
                 foreach (var statItem in Database.ReplicationLoader.IncomingRejectionStats)
@@ -393,7 +393,7 @@ namespace Raven.Server.Documents.Handlers
         public async Task GetReplicationReconnectionQueue()
         {
             using (ContextPool.AllocateOperationContext(out DocumentsOperationContext context))
-            await using (var writer = new AsyncBlittableJsonTextWriter(context, ResponseBodyStream()))
+            await using (var writer = new AsyncBlittableJsonTextWriterForDebug(context, ServerStore, ResponseBodyStream()))
             {
                 var data = new DynamicJsonArray();
                 foreach (var queueItem in Database.ReplicationLoader.ReconnectQueue)

--- a/src/Raven.Server/Documents/Handlers/ReplicationHandler.cs
+++ b/src/Raven.Server/Documents/Handlers/ReplicationHandler.cs
@@ -294,7 +294,7 @@ namespace Raven.Server.Documents.Handlers
         public async Task GetReplicationOutgoingFailureStats()
         {
             using (ContextPool.AllocateOperationContext(out DocumentsOperationContext context))
-            await using (var writer = new AsyncBlittableJsonTextWriterForDebug(context, ServerStore, ResponseBodyStream()))
+            await using (var writer = new AsyncBlittableJsonTextWriterForDebug(HttpContext.Request, context, ServerStore, ResponseBodyStream()))
             {
                 var data = new DynamicJsonArray();
                 foreach (var item in Database.ReplicationLoader.OutgoingFailureInfo)
@@ -331,7 +331,7 @@ namespace Raven.Server.Documents.Handlers
         public async Task GetReplicationIncomingActivityTimes()
         {
             using (ContextPool.AllocateOperationContext(out DocumentsOperationContext context))
-            await using (var writer = new AsyncBlittableJsonTextWriterForDebug(context, ServerStore, ResponseBodyStream()))
+            await using (var writer = new AsyncBlittableJsonTextWriterForDebug(HttpContext.Request, context, ServerStore, ResponseBodyStream()))
             {
                 var data = new DynamicJsonArray();
                 foreach (var item in Database.ReplicationLoader.IncomingLastActivityTime)
@@ -360,7 +360,7 @@ namespace Raven.Server.Documents.Handlers
         public async Task GetReplicationIncomingRejectionInfo()
         {
             using (ContextPool.AllocateOperationContext(out DocumentsOperationContext context))
-            await using (var writer = new AsyncBlittableJsonTextWriterForDebug(context, ServerStore, ResponseBodyStream()))
+            await using (var writer = new AsyncBlittableJsonTextWriterForDebug(HttpContext.Request, context, ServerStore, ResponseBodyStream()))
             {
                 var stats = new DynamicJsonArray();
                 foreach (var statItem in Database.ReplicationLoader.IncomingRejectionStats)
@@ -393,7 +393,7 @@ namespace Raven.Server.Documents.Handlers
         public async Task GetReplicationReconnectionQueue()
         {
             using (ContextPool.AllocateOperationContext(out DocumentsOperationContext context))
-            await using (var writer = new AsyncBlittableJsonTextWriterForDebug(context, ServerStore, ResponseBodyStream()))
+            await using (var writer = new AsyncBlittableJsonTextWriterForDebug(HttpContext.Request, context, ServerStore, ResponseBodyStream()))
             {
                 var data = new DynamicJsonArray();
                 foreach (var queueItem in Database.ReplicationLoader.ReconnectQueue)

--- a/src/Raven.Server/Documents/Handlers/ReplicationHandler.cs
+++ b/src/Raven.Server/Documents/Handlers/ReplicationHandler.cs
@@ -294,7 +294,7 @@ namespace Raven.Server.Documents.Handlers
         public async Task GetReplicationOutgoingFailureStats()
         {
             using (ContextPool.AllocateOperationContext(out DocumentsOperationContext context))
-            await using (var writer = new AsyncBlittableJsonTextWriterForDebug(HttpContext.Request, context, ServerStore, ResponseBodyStream()))
+            await using (var writer = new AsyncBlittableJsonTextWriterForDebug(context, ServerStore, ResponseBodyStream()))
             {
                 var data = new DynamicJsonArray();
                 foreach (var item in Database.ReplicationLoader.OutgoingFailureInfo)
@@ -331,7 +331,7 @@ namespace Raven.Server.Documents.Handlers
         public async Task GetReplicationIncomingActivityTimes()
         {
             using (ContextPool.AllocateOperationContext(out DocumentsOperationContext context))
-            await using (var writer = new AsyncBlittableJsonTextWriterForDebug(HttpContext.Request, context, ServerStore, ResponseBodyStream()))
+            await using (var writer = new AsyncBlittableJsonTextWriterForDebug(context, ServerStore, ResponseBodyStream()))
             {
                 var data = new DynamicJsonArray();
                 foreach (var item in Database.ReplicationLoader.IncomingLastActivityTime)
@@ -360,7 +360,7 @@ namespace Raven.Server.Documents.Handlers
         public async Task GetReplicationIncomingRejectionInfo()
         {
             using (ContextPool.AllocateOperationContext(out DocumentsOperationContext context))
-            await using (var writer = new AsyncBlittableJsonTextWriterForDebug(HttpContext.Request, context, ServerStore, ResponseBodyStream()))
+            await using (var writer = new AsyncBlittableJsonTextWriterForDebug(context, ServerStore, ResponseBodyStream()))
             {
                 var stats = new DynamicJsonArray();
                 foreach (var statItem in Database.ReplicationLoader.IncomingRejectionStats)
@@ -393,7 +393,7 @@ namespace Raven.Server.Documents.Handlers
         public async Task GetReplicationReconnectionQueue()
         {
             using (ContextPool.AllocateOperationContext(out DocumentsOperationContext context))
-            await using (var writer = new AsyncBlittableJsonTextWriterForDebug(HttpContext.Request, context, ServerStore, ResponseBodyStream()))
+            await using (var writer = new AsyncBlittableJsonTextWriterForDebug(context, ServerStore, ResponseBodyStream()))
             {
                 var data = new DynamicJsonArray();
                 foreach (var queueItem in Database.ReplicationLoader.ReconnectQueue)

--- a/src/Raven.Server/Documents/Handlers/StatsHandler.cs
+++ b/src/Raven.Server/Documents/Handlers/StatsHandler.cs
@@ -48,7 +48,7 @@ namespace Raven.Server.Documents.Handlers
 
                 FillDatabaseStatistics(stats, context);
 
-                await using (var writer = new AsyncBlittableJsonTextWriterForDebug(HttpContext.Request, context.Documents, ServerStore, ResponseBodyStream()))
+                await using (var writer = new AsyncBlittableJsonTextWriterForDebug(context.Documents, ServerStore, ResponseBodyStream()))
                     writer.WriteDatabaseStatistics(context.Documents, stats);
             }
         }

--- a/src/Raven.Server/Documents/Handlers/StatsHandler.cs
+++ b/src/Raven.Server/Documents/Handlers/StatsHandler.cs
@@ -48,7 +48,7 @@ namespace Raven.Server.Documents.Handlers
 
                 FillDatabaseStatistics(stats, context);
 
-                await using (var writer = new AsyncBlittableJsonTextWriterForDebug(context.Documents, ServerStore, ResponseBodyStream()))
+                await using (var writer = new AsyncBlittableJsonTextWriterForDebug(HttpContext.Request, context.Documents, ServerStore, ResponseBodyStream()))
                     writer.WriteDatabaseStatistics(context.Documents, stats);
             }
         }

--- a/src/Raven.Server/Documents/Handlers/StatsHandler.cs
+++ b/src/Raven.Server/Documents/Handlers/StatsHandler.cs
@@ -6,6 +6,7 @@ using Raven.Server.Documents.Indexes;
 using Raven.Server.Json;
 using Raven.Server.Routing;
 using Raven.Server.ServerWide.Context;
+using Raven.Server.Utils;
 using Sparrow.Json;
 using Sparrow.Json.Parsing;
 
@@ -47,7 +48,7 @@ namespace Raven.Server.Documents.Handlers
 
                 FillDatabaseStatistics(stats, context);
 
-                await using (var writer = new AsyncBlittableJsonTextWriter(context.Documents, ResponseBodyStream()))
+                await using (var writer = new AsyncBlittableJsonTextWriterForDebug(context.Documents, ServerStore, ResponseBodyStream()))
                     writer.WriteDatabaseStatistics(context.Documents, stats);
             }
         }

--- a/src/Raven.Server/Documents/Handlers/SubscriptionsHandler.cs
+++ b/src/Raven.Server/Documents/Handlers/SubscriptionsHandler.cs
@@ -281,7 +281,7 @@ namespace Raven.Server.Documents.Handlers
                     subscriptions = new[] { subscription };
                 }
 
-                await using (var writer = new AsyncBlittableJsonTextWriterForDebug(context, ServerStore, ResponseBodyStream()))
+                await using (var writer = new AsyncBlittableJsonTextWriterForDebug(HttpContext.Request, context, ServerStore, ResponseBodyStream()))
                 {
                     writer.WriteStartObject();
 

--- a/src/Raven.Server/Documents/Handlers/SubscriptionsHandler.cs
+++ b/src/Raven.Server/Documents/Handlers/SubscriptionsHandler.cs
@@ -17,6 +17,7 @@ using Raven.Server.Json;
 using Raven.Server.Routing;
 using Raven.Server.ServerWide.Context;
 using Raven.Server.TrafficWatch;
+using Raven.Server.Utils;
 using Sparrow.Json;
 using Sparrow.Json.Parsing;
 
@@ -280,7 +281,7 @@ namespace Raven.Server.Documents.Handlers
                     subscriptions = new[] { subscription };
                 }
 
-                await using (var writer = new AsyncBlittableJsonTextWriter(context, ResponseBodyStream()))
+                await using (var writer = new AsyncBlittableJsonTextWriterForDebug(context, ServerStore, ResponseBodyStream()))
                 {
                     writer.WriteStartObject();
 

--- a/src/Raven.Server/Documents/Handlers/SubscriptionsHandler.cs
+++ b/src/Raven.Server/Documents/Handlers/SubscriptionsHandler.cs
@@ -281,7 +281,7 @@ namespace Raven.Server.Documents.Handlers
                     subscriptions = new[] { subscription };
                 }
 
-                await using (var writer = new AsyncBlittableJsonTextWriterForDebug(HttpContext.Request, context, ServerStore, ResponseBodyStream()))
+                await using (var writer = new AsyncBlittableJsonTextWriterForDebug(context, ServerStore, ResponseBodyStream()))
                 {
                     writer.WriteStartObject();
 

--- a/src/Raven.Server/Documents/Handlers/TcpManagementHandler.cs
+++ b/src/Raven.Server/Documents/Handlers/TcpManagementHandler.cs
@@ -34,7 +34,7 @@ namespace Raven.Server.Documents.Handlers
                     .Skip(start)
                     .Take(pageSize);
 
-                await using (var writer = new AsyncBlittableJsonTextWriterForDebug(HttpContext.Request, context, ServerStore,  ResponseBodyStream()))
+                await using (var writer = new AsyncBlittableJsonTextWriterForDebug(context, ServerStore,  ResponseBodyStream()))
                 {
                     writer.WriteStartObject();
 

--- a/src/Raven.Server/Documents/Handlers/TcpManagementHandler.cs
+++ b/src/Raven.Server/Documents/Handlers/TcpManagementHandler.cs
@@ -5,6 +5,7 @@ using System.Threading.Tasks;
 using Raven.Client.ServerWide.Tcp;
 using Raven.Server.Routing;
 using Raven.Server.ServerWide.Context;
+using Raven.Server.Utils;
 using Sparrow.Json;
 
 namespace Raven.Server.Documents.Handlers
@@ -33,7 +34,7 @@ namespace Raven.Server.Documents.Handlers
                     .Skip(start)
                     .Take(pageSize);
 
-                await using (var writer = new AsyncBlittableJsonTextWriter(context, ResponseBodyStream()))
+                await using (var writer = new AsyncBlittableJsonTextWriterForDebug(context, ServerStore, ResponseBodyStream()))
                 {
                     writer.WriteStartObject();
 

--- a/src/Raven.Server/Documents/Handlers/TcpManagementHandler.cs
+++ b/src/Raven.Server/Documents/Handlers/TcpManagementHandler.cs
@@ -34,7 +34,7 @@ namespace Raven.Server.Documents.Handlers
                     .Skip(start)
                     .Take(pageSize);
 
-                await using (var writer = new AsyncBlittableJsonTextWriterForDebug(context, ServerStore, ResponseBodyStream()))
+                await using (var writer = new AsyncBlittableJsonTextWriterForDebug(HttpContext.Request, context, ServerStore,  ResponseBodyStream()))
                 {
                     writer.WriteStartObject();
 

--- a/src/Raven.Server/Utils/AsyncBlittableJsonTextWriterForDebug.cs
+++ b/src/Raven.Server/Utils/AsyncBlittableJsonTextWriterForDebug.cs
@@ -12,21 +12,19 @@ namespace Raven.Server.Utils
         private readonly ServerStore _serverStore;
         private bool _isFirst = true;
         private bool _isOnlyWrite;
-        private bool _isFromClientApi;
-        private bool _isFromStudio;
+        private bool _skipDebug;
 
         public AsyncBlittableJsonTextWriterForDebug(HttpRequest request, JsonOperationContext context, ServerStore serverStore, Stream stream) : base(context, stream)
         {
             _serverStore = serverStore;
-            _isFromClientApi = request.IsFromClientApi();
-            _isFromStudio = request.IsFromStudio();
+            _skipDebug = request.IsFromClientApi() || request.IsFromStudio();
         }
         
         public override void WriteStartObject()
         {
             base.WriteStartObject();
 
-            if (_isFirst && !_isFromStudio && !_isFromClientApi)
+            if (_isFirst && _skipDebug == false)
             {
                 _isFirst = false;
 
@@ -51,7 +49,7 @@ namespace Raven.Server.Utils
         {
             base.EnsureBuffer(len);
 
-            if (_isOnlyWrite && !_isFromStudio && !_isFromClientApi)
+            if (_isOnlyWrite && _skipDebug == false)
             {
                 _isOnlyWrite = false;
                 WriteComma();

--- a/src/Raven.Server/Utils/AsyncBlittableJsonTextWriterForDebug.cs
+++ b/src/Raven.Server/Utils/AsyncBlittableJsonTextWriterForDebug.cs
@@ -1,0 +1,61 @@
+﻿using System;
+using System.IO;
+using Raven.Server.ServerWide;
+using Sparrow.Json;
+
+namespace Raven.Server.Utils
+{
+    public class AsyncBlittableJsonTextWriterForDebug : AsyncBlittableJsonTextWriter
+    {
+        private readonly ServerStore _serverStore;
+        private bool _isFirst = true;
+        private bool _isOnlyWrite;
+
+        public AsyncBlittableJsonTextWriterForDebug(JsonOperationContext context, ServerStore serverStore, Stream stream) : base(context, stream)
+        {
+            _serverStore = serverStore;
+        }
+        
+        public override void WriteStartObject()
+        {
+            base.WriteStartObject();
+
+            if (_isFirst)
+            {
+                _isFirst = false;
+
+                WritePropertyName("@Metadata");
+                WriteStartObject();
+                WritePropertyName(nameof(DateTime));
+                WriteDateTime(DateTime.UtcNow, true);
+                WriteComma();
+                WritePropertyName(nameof(_serverStore.Server.WebUrl));
+                WriteString(_serverStore.Server.WebUrl);
+                WriteComma();
+                WritePropertyName(nameof(_serverStore.NodeTag));
+                WriteString(_serverStore.NodeTag);
+
+                WriteEndObject();
+
+                _isOnlyWrite = true;
+            }
+        }
+
+        protected override void EnsureBuffer(int len)
+        {
+            base.EnsureBuffer(len);
+
+            if (_isOnlyWrite)
+            {
+                _isOnlyWrite = false;
+                WriteComma();
+            }
+        }
+
+        public override void WriteEndObject()
+        {
+            _isOnlyWrite = false;
+            base.WriteEndObject();
+        }
+    }
+}

--- a/src/Raven.Server/Utils/AsyncBlittableJsonTextWriterForDebug.cs
+++ b/src/Raven.Server/Utils/AsyncBlittableJsonTextWriterForDebug.cs
@@ -1,6 +1,7 @@
 ﻿using System;
 using System.IO;
 using Microsoft.AspNetCore.Http;
+using Raven.Client;
 using Raven.Server.Extensions;
 using Raven.Server.ServerWide;
 using Sparrow.Json;
@@ -12,23 +13,21 @@ namespace Raven.Server.Utils
         private readonly ServerStore _serverStore;
         private bool _isFirst = true;
         private bool _isOnlyWrite;
-        private bool _skipDebug;
 
-        public AsyncBlittableJsonTextWriterForDebug(HttpRequest request, JsonOperationContext context, ServerStore serverStore, Stream stream) : base(context, stream)
+        public AsyncBlittableJsonTextWriterForDebug(JsonOperationContext context, ServerStore serverStore, Stream stream) : base(context, stream)
         {
             _serverStore = serverStore;
-            _skipDebug = request.IsFromClientApi() || request.IsFromStudio();
         }
         
         public override void WriteStartObject()
         {
             base.WriteStartObject();
 
-            if (_isFirst && _skipDebug == false)
+            if (_isFirst)
             {
                 _isFirst = false;
 
-                WritePropertyName("@Metadata");
+                WritePropertyName(Constants.Documents.Metadata.Key);
                 WriteStartObject();
                 WritePropertyName(nameof(DateTime));
                 WriteDateTime(DateTime.UtcNow, true);
@@ -49,7 +48,7 @@ namespace Raven.Server.Utils
         {
             base.EnsureBuffer(len);
 
-            if (_isOnlyWrite && _skipDebug == false)
+            if (_isOnlyWrite)
             {
                 _isOnlyWrite = false;
                 WriteComma();

--- a/src/Raven.Server/Web/Studio/LicenseHandler.cs
+++ b/src/Raven.Server/Web/Studio/LicenseHandler.cs
@@ -150,7 +150,7 @@ namespace Raven.Server.Web.Studio
                 }
 
                 using (ServerStore.ContextPool.AllocateOperationContext(out TransactionOperationContext context))
-                await using (var writer = new AsyncBlittableJsonTextWriterForDebug(context, ServerStore, ResponseBodyStream()))
+                await using (var writer = new AsyncBlittableJsonTextWriterForDebug(HttpContext.Request, context, ServerStore, ResponseBodyStream()))
                 {
                     context.Write(writer, result.ToJson());
                 }

--- a/src/Raven.Server/Web/Studio/LicenseHandler.cs
+++ b/src/Raven.Server/Web/Studio/LicenseHandler.cs
@@ -150,7 +150,7 @@ namespace Raven.Server.Web.Studio
                 }
 
                 using (ServerStore.ContextPool.AllocateOperationContext(out TransactionOperationContext context))
-                await using (var writer = new AsyncBlittableJsonTextWriterForDebug(HttpContext.Request, context, ServerStore, ResponseBodyStream()))
+                await using (var writer = new AsyncBlittableJsonTextWriterForDebug(context, ServerStore, ResponseBodyStream()))
                 {
                     context.Write(writer, result.ToJson());
                 }

--- a/src/Raven.Server/Web/Studio/LicenseHandler.cs
+++ b/src/Raven.Server/Web/Studio/LicenseHandler.cs
@@ -7,6 +7,7 @@ using Raven.Server.Config.Categories;
 using Raven.Server.Json;
 using Raven.Server.Routing;
 using Raven.Server.ServerWide.Context;
+using Raven.Server.Utils;
 using Sparrow.Json;
 using Sparrow.Json.Parsing;
 
@@ -149,7 +150,7 @@ namespace Raven.Server.Web.Studio
                 }
 
                 using (ServerStore.ContextPool.AllocateOperationContext(out TransactionOperationContext context))
-                await using (var writer = new AsyncBlittableJsonTextWriter(context, ResponseBodyStream()))
+                await using (var writer = new AsyncBlittableJsonTextWriterForDebug(context, ServerStore, ResponseBodyStream()))
                 {
                     context.Write(writer, result.ToJson());
                 }

--- a/src/Raven.Server/Web/System/AdminCpuCreditsHandler.cs
+++ b/src/Raven.Server/Web/System/AdminCpuCreditsHandler.cs
@@ -8,6 +8,7 @@ using System.Threading.Tasks;
 using Raven.Server.Json;
 using Raven.Server.Routing;
 using Raven.Server.ServerWide.Context;
+using Raven.Server.Utils;
 using Sparrow.Json;
 using Sparrow.Json.Parsing;
 
@@ -37,7 +38,7 @@ namespace Raven.Server.Web.System
         public async Task GetCpuCredits()
         {
             using (ServerStore.ContextPool.AllocateOperationContext(out TransactionOperationContext context))
-            await using (var writer = new AsyncBlittableJsonTextWriter(context, ResponseBodyStream()))
+            await using (var writer = new AsyncBlittableJsonTextWriterForDebug(context, ServerStore, ResponseBodyStream()))
             {
                 var json = Server.CpuCreditsBalance.ToJson();
                 writer.WriteObject(context.ReadObject(json, "cpu/credits"));

--- a/src/Raven.Server/Web/System/AdminCpuCreditsHandler.cs
+++ b/src/Raven.Server/Web/System/AdminCpuCreditsHandler.cs
@@ -38,7 +38,7 @@ namespace Raven.Server.Web.System
         public async Task GetCpuCredits()
         {
             using (ServerStore.ContextPool.AllocateOperationContext(out TransactionOperationContext context))
-            await using (var writer = new AsyncBlittableJsonTextWriterForDebug(context, ServerStore, ResponseBodyStream()))
+            await using (var writer = new AsyncBlittableJsonTextWriterForDebug(HttpContext.Request, context,ServerStore, ResponseBodyStream()))
             {
                 var json = Server.CpuCreditsBalance.ToJson();
                 writer.WriteObject(context.ReadObject(json, "cpu/credits"));

--- a/src/Raven.Server/Web/System/AdminCpuCreditsHandler.cs
+++ b/src/Raven.Server/Web/System/AdminCpuCreditsHandler.cs
@@ -38,7 +38,7 @@ namespace Raven.Server.Web.System
         public async Task GetCpuCredits()
         {
             using (ServerStore.ContextPool.AllocateOperationContext(out TransactionOperationContext context))
-            await using (var writer = new AsyncBlittableJsonTextWriterForDebug(HttpContext.Request, context,ServerStore, ResponseBodyStream()))
+            await using (var writer = new AsyncBlittableJsonTextWriterForDebug(context, ServerStore, ResponseBodyStream()))
             {
                 var json = Server.CpuCreditsBalance.ToJson();
                 writer.WriteObject(context.ReadObject(json, "cpu/credits"));

--- a/src/Raven.Server/Web/System/AdminIoMetricsHandler.cs
+++ b/src/Raven.Server/Web/System/AdminIoMetricsHandler.cs
@@ -5,6 +5,7 @@ using System.Threading.Tasks;
 using Raven.Server.Routing;
 using Raven.Server.ServerWide;
 using Raven.Server.ServerWide.Context;
+using Raven.Server.Utils;
 using Raven.Server.Utils.IoMetrics;
 using Sparrow.Json;
 using Voron;
@@ -17,7 +18,7 @@ namespace Raven.Server.Web.System
         public async Task IoMetrics()
         {
             using (ServerStore.ContextPool.AllocateOperationContext(out JsonOperationContext context))
-            await using (var writer = new AsyncBlittableJsonTextWriter(context, ResponseBodyStream()))
+            await using (var writer = new AsyncBlittableJsonTextWriterForDebug(context, ServerStore, ResponseBodyStream()))
             {
                 var result = IoMetricsUtil.GetIoMetricsResponse(GetSystemEnvironment(ServerStore), null);
                 context.Write(writer, result.ToJson());

--- a/src/Raven.Server/Web/System/AdminIoMetricsHandler.cs
+++ b/src/Raven.Server/Web/System/AdminIoMetricsHandler.cs
@@ -18,7 +18,7 @@ namespace Raven.Server.Web.System
         public async Task IoMetrics()
         {
             using (ServerStore.ContextPool.AllocateOperationContext(out JsonOperationContext context))
-            await using (var writer = new AsyncBlittableJsonTextWriterForDebug(context, ServerStore, ResponseBodyStream()))
+            await using (var writer = new AsyncBlittableJsonTextWriterForDebug(HttpContext.Request, context, ServerStore, ResponseBodyStream()))
             {
                 var result = IoMetricsUtil.GetIoMetricsResponse(GetSystemEnvironment(ServerStore), null);
                 context.Write(writer, result.ToJson());

--- a/src/Raven.Server/Web/System/AdminIoMetricsHandler.cs
+++ b/src/Raven.Server/Web/System/AdminIoMetricsHandler.cs
@@ -18,7 +18,7 @@ namespace Raven.Server.Web.System
         public async Task IoMetrics()
         {
             using (ServerStore.ContextPool.AllocateOperationContext(out JsonOperationContext context))
-            await using (var writer = new AsyncBlittableJsonTextWriterForDebug(HttpContext.Request, context, ServerStore, ResponseBodyStream()))
+            await using (var writer = new AsyncBlittableJsonTextWriterForDebug(context, ServerStore, ResponseBodyStream()))
             {
                 var result = IoMetricsUtil.GetIoMetricsResponse(GetSystemEnvironment(ServerStore), null);
                 context.Write(writer, result.ToJson());

--- a/src/Raven.Server/Web/System/AdminStatsHandler.cs
+++ b/src/Raven.Server/Web/System/AdminStatsHandler.cs
@@ -11,7 +11,7 @@ namespace Raven.Server.Web.System
         public async Task GetRootStats()
         {
             using (ServerStore.ContextPool.AllocateOperationContext(out JsonOperationContext context))
-            await using (var writer = new AsyncBlittableJsonTextWriterForDebug(HttpContext.Request, context, ServerStore, ResponseBodyStream()))
+            await using (var writer = new AsyncBlittableJsonTextWriterForDebug(context, ServerStore, ResponseBodyStream()))
             {
                 Server.Statistics.WriteTo(writer);
             }

--- a/src/Raven.Server/Web/System/AdminStatsHandler.cs
+++ b/src/Raven.Server/Web/System/AdminStatsHandler.cs
@@ -11,7 +11,7 @@ namespace Raven.Server.Web.System
         public async Task GetRootStats()
         {
             using (ServerStore.ContextPool.AllocateOperationContext(out JsonOperationContext context))
-            await using (var writer = new AsyncBlittableJsonTextWriterForDebug(context, ServerStore, ResponseBodyStream()))
+            await using (var writer = new AsyncBlittableJsonTextWriterForDebug(HttpContext.Request, context, ServerStore, ResponseBodyStream()))
             {
                 Server.Statistics.WriteTo(writer);
             }

--- a/src/Raven.Server/Web/System/AdminStatsHandler.cs
+++ b/src/Raven.Server/Web/System/AdminStatsHandler.cs
@@ -1,5 +1,6 @@
 ﻿using System.Threading.Tasks;
 using Raven.Server.Routing;
+using Raven.Server.Utils;
 using Sparrow.Json;
 
 namespace Raven.Server.Web.System
@@ -10,7 +11,7 @@ namespace Raven.Server.Web.System
         public async Task GetRootStats()
         {
             using (ServerStore.ContextPool.AllocateOperationContext(out JsonOperationContext context))
-            await using (var writer = new AsyncBlittableJsonTextWriter(context, ResponseBodyStream()))
+            await using (var writer = new AsyncBlittableJsonTextWriterForDebug(context, ServerStore, ResponseBodyStream()))
             {
                 Server.Statistics.WriteTo(writer);
             }

--- a/src/Raven.Server/Web/System/AdminStorageHandler.cs
+++ b/src/Raven.Server/Web/System/AdminStorageHandler.cs
@@ -16,7 +16,7 @@ namespace Raven.Server.Web.System
             var env = ServerStore._env;
 
             using (ServerStore.ContextPool.AllocateOperationContext(out JsonOperationContext context))
-            await using (var writer = new AsyncBlittableJsonTextWriterForDebug(context, ServerStore, ResponseBodyStream()))
+            await using (var writer = new AsyncBlittableJsonTextWriterForDebug(HttpContext.Request, context, ServerStore, ResponseBodyStream()))
             {
                 writer.WriteStartObject();
                 writer.WritePropertyName("Environment");

--- a/src/Raven.Server/Web/System/AdminStorageHandler.cs
+++ b/src/Raven.Server/Web/System/AdminStorageHandler.cs
@@ -16,7 +16,7 @@ namespace Raven.Server.Web.System
             var env = ServerStore._env;
 
             using (ServerStore.ContextPool.AllocateOperationContext(out JsonOperationContext context))
-            await using (var writer = new AsyncBlittableJsonTextWriter(context, ResponseBodyStream()))
+            await using (var writer = new AsyncBlittableJsonTextWriterForDebug(context, ServerStore, ResponseBodyStream()))
             {
                 writer.WriteStartObject();
                 writer.WritePropertyName("Environment");

--- a/src/Raven.Server/Web/System/AdminStorageHandler.cs
+++ b/src/Raven.Server/Web/System/AdminStorageHandler.cs
@@ -16,7 +16,7 @@ namespace Raven.Server.Web.System
             var env = ServerStore._env;
 
             using (ServerStore.ContextPool.AllocateOperationContext(out JsonOperationContext context))
-            await using (var writer = new AsyncBlittableJsonTextWriterForDebug(HttpContext.Request, context, ServerStore, ResponseBodyStream()))
+            await using (var writer = new AsyncBlittableJsonTextWriterForDebug(context, ServerStore, ResponseBodyStream()))
             {
                 writer.WriteStartObject();
                 writer.WritePropertyName("Environment");

--- a/src/Raven.Server/Web/System/AdminTcpConnectionDebugInfoHandler.cs
+++ b/src/Raven.Server/Web/System/AdminTcpConnectionDebugInfoHandler.cs
@@ -26,7 +26,7 @@ namespace Raven.Server.Web.System
             };
 
             using (ServerStore.ContextPool.AllocateOperationContext(out JsonOperationContext context))
-            await using (var writer = new AsyncBlittableJsonTextWriterForDebug(context, ServerStore, ResponseBodyStream()))
+            await using (var writer = new AsyncBlittableJsonTextWriterForDebug(HttpContext.Request, context, ServerStore, ResponseBodyStream()))
             {
                 context.Write(writer, djv);
             }
@@ -69,7 +69,7 @@ namespace Raven.Server.Web.System
             };
 
             using (ServerStore.ContextPool.AllocateOperationContext(out JsonOperationContext context))
-            await using (var writer = new AsyncBlittableJsonTextWriterForDebug(context, ServerStore, ResponseBodyStream()))
+            await using (var writer = new AsyncBlittableJsonTextWriterForDebug(HttpContext.Request, context, ServerStore, ResponseBodyStream()))
             {
                 context.Write(writer, djv);
             }

--- a/src/Raven.Server/Web/System/AdminTcpConnectionDebugInfoHandler.cs
+++ b/src/Raven.Server/Web/System/AdminTcpConnectionDebugInfoHandler.cs
@@ -3,6 +3,7 @@ using System.Linq;
 using System.Net.NetworkInformation;
 using System.Threading.Tasks;
 using Raven.Server.Routing;
+using Raven.Server.Utils;
 using Sparrow.Json;
 using Sparrow.Json.Parsing;
 using Sparrow.Server.Extensions;
@@ -25,7 +26,7 @@ namespace Raven.Server.Web.System
             };
 
             using (ServerStore.ContextPool.AllocateOperationContext(out JsonOperationContext context))
-            await using (var writer = new AsyncBlittableJsonTextWriter(context, ResponseBodyStream()))
+            await using (var writer = new AsyncBlittableJsonTextWriterForDebug(context, ServerStore, ResponseBodyStream()))
             {
                 context.Write(writer, djv);
             }
@@ -68,7 +69,7 @@ namespace Raven.Server.Web.System
             };
 
             using (ServerStore.ContextPool.AllocateOperationContext(out JsonOperationContext context))
-            await using (var writer = new AsyncBlittableJsonTextWriter(context, ResponseBodyStream()))
+            await using (var writer = new AsyncBlittableJsonTextWriterForDebug(context, ServerStore, ResponseBodyStream()))
             {
                 context.Write(writer, djv);
             }

--- a/src/Raven.Server/Web/System/AdminTcpConnectionDebugInfoHandler.cs
+++ b/src/Raven.Server/Web/System/AdminTcpConnectionDebugInfoHandler.cs
@@ -26,7 +26,7 @@ namespace Raven.Server.Web.System
             };
 
             using (ServerStore.ContextPool.AllocateOperationContext(out JsonOperationContext context))
-            await using (var writer = new AsyncBlittableJsonTextWriterForDebug(HttpContext.Request, context, ServerStore, ResponseBodyStream()))
+            await using (var writer = new AsyncBlittableJsonTextWriterForDebug(context, ServerStore, ResponseBodyStream()))
             {
                 context.Write(writer, djv);
             }
@@ -69,7 +69,7 @@ namespace Raven.Server.Web.System
             };
 
             using (ServerStore.ContextPool.AllocateOperationContext(out JsonOperationContext context))
-            await using (var writer = new AsyncBlittableJsonTextWriterForDebug(HttpContext.Request, context, ServerStore, ResponseBodyStream()))
+            await using (var writer = new AsyncBlittableJsonTextWriterForDebug(context, ServerStore, ResponseBodyStream()))
             {
                 context.Write(writer, djv);
             }

--- a/src/Raven.Server/Web/System/OngoingTasksHandler.cs
+++ b/src/Raven.Server/Web/System/OngoingTasksHandler.cs
@@ -51,7 +51,7 @@ namespace Raven.Server.Web.System
             var result = GetOngoingTasksInternal();
 
             using (ServerStore.ContextPool.AllocateOperationContext(out TransactionOperationContext context))
-            await using (var writer = new AsyncBlittableJsonTextWriterForDebug(context, ServerStore, ResponseBodyStream()))
+            await using (var writer = new AsyncBlittableJsonTextWriterForDebug(HttpContext.Request, context, ServerStore, ResponseBodyStream()))
             {
                 context.Write(writer, result.ToJson());
             }

--- a/src/Raven.Server/Web/System/OngoingTasksHandler.cs
+++ b/src/Raven.Server/Web/System/OngoingTasksHandler.cs
@@ -51,7 +51,7 @@ namespace Raven.Server.Web.System
             var result = GetOngoingTasksInternal();
 
             using (ServerStore.ContextPool.AllocateOperationContext(out TransactionOperationContext context))
-            await using (var writer = new AsyncBlittableJsonTextWriter(context, ResponseBodyStream()))
+            await using (var writer = new AsyncBlittableJsonTextWriterForDebug(context, ServerStore, ResponseBodyStream()))
             {
                 context.Write(writer, result.ToJson());
             }

--- a/src/Raven.Server/Web/System/OngoingTasksHandler.cs
+++ b/src/Raven.Server/Web/System/OngoingTasksHandler.cs
@@ -51,7 +51,7 @@ namespace Raven.Server.Web.System
             var result = GetOngoingTasksInternal();
 
             using (ServerStore.ContextPool.AllocateOperationContext(out TransactionOperationContext context))
-            await using (var writer = new AsyncBlittableJsonTextWriterForDebug(HttpContext.Request, context, ServerStore, ResponseBodyStream()))
+            await using (var writer = new AsyncBlittableJsonTextWriterForDebug(context, ServerStore, ResponseBodyStream()))
             {
                 context.Write(writer, result.ToJson());
             }

--- a/src/Sparrow/Json/AbstractBlittableJsonTextWriter.cs
+++ b/src/Sparrow/Json/AbstractBlittableJsonTextWriter.cs
@@ -462,7 +462,7 @@ namespace Sparrow.Json
         }
 
         [MethodImpl(MethodImplOptions.AggressiveInlining)]
-        public void WriteStartObject()
+        public virtual void WriteStartObject()
         {
             EnsureBuffer(1);
             _buffer[_pos++] = StartObject;
@@ -483,14 +483,14 @@ namespace Sparrow.Json
         }
 
         [MethodImpl(MethodImplOptions.AggressiveInlining)]
-        public void WriteEndObject()
+        public virtual void WriteEndObject()
         {
             EnsureBuffer(1);
             _buffer[_pos++] = EndObject;
         }
 
         [MethodImpl(MethodImplOptions.AggressiveInlining)]
-        private void EnsureBuffer(int len)
+        protected virtual void EnsureBuffer(int len)
         {
             if (len >= JsonOperationContext.MemoryBuffer.DefaultSize)
                 ThrowValueTooBigForBuffer(len);


### PR DESCRIPTION
### Issue link

https://issues.hibernatingrhinos.com/issue/RavenDB-18884/Adding-time-property-to-debug-endpoint-results

### Additional description

Adding time property to debug endpoint results

### Type of change

- New feature

### Backward compatibility

- Ensured. Only adding new fields.

### Testing 

- It has been verified by manual testing