### PR TITLE
RavenDB-18942 - add the unmanaged allocations made by Lucene to the stats

### DIFF
--- a/src/Raven.Server/Documents/Handlers/Debugging/MemoryDebugHandler.cs
+++ b/src/Raven.Server/Documents/Handlers/Debugging/MemoryDebugHandler.cs
@@ -283,6 +283,7 @@ namespace Raven.Server.Documents.Handlers.Debugging
             var memInfo = MemoryInformation.GetMemoryInformationUsingOneTimeSmapsReader();
             long managedMemoryInBytes = AbstractLowMemoryMonitor.GetManagedMemoryInBytes();
             long totalUnmanagedAllocations = NativeMemory.TotalAllocatedMemory;
+            long totalLuceneUnmanagedAllocations = NativeMemory.TotalAllocatedMemoryByLucene;
             var encryptionBuffers = EncryptionBuffersPool.Instance.GetStats();
             var dirtyMemoryState = MemoryInformation.GetDirtyMemoryState();
             var memoryUsageRecords = MemoryInformation.GetMemoryUsageRecords();
@@ -315,6 +316,7 @@ namespace Raven.Server.Documents.Handlers.Debugging
                 [nameof(MemoryInfo.WorkingSet)] = memInfo.WorkingSet.ToString(),
                 [nameof(MemoryInfo.ManagedAllocations)] = Size.Humane(managedMemoryInBytes),
                 [nameof(MemoryInfo.UnmanagedAllocations)] = Size.Humane(totalUnmanagedAllocations),
+                [nameof(MemoryInfo.LuceneUnmanagedAllocations)] = Size.Humane(totalLuceneUnmanagedAllocations),
                 [nameof(MemoryInfo.EncryptionBuffersInUse)] = Size.Humane(encryptionBuffers.CurrentlyInUseSize),
                 [nameof(MemoryInfo.EncryptionBuffersPool)] = Size.Humane(encryptionBuffers.TotalPoolSize),
                 [nameof(MemoryInfo.EncryptionLockedMemory)] = Size.Humane(Sodium.LockedBytes),
@@ -525,6 +527,7 @@ namespace Raven.Server.Documents.Handlers.Debugging
             public string Remarks { get; set; }
             public string ManagedAllocations { get; set; }
             public string UnmanagedAllocations { get; set; }
+            public string LuceneUnmanagedAllocations { get; set; }
             public string EncryptionBuffersInUse { get; set; }
             public string EncryptionBuffersPool { get; set; }
             public string EncryptionLockedMemory { get; set; }

--- a/src/Raven.Server/Program.cs
+++ b/src/Raven.Server/Program.cs
@@ -36,8 +36,8 @@ namespace Raven.Server
         {
             NativeMemory.GetCurrentUnmanagedThreadId = () => (ulong)Pal.rvn_get_current_thread_id();
 
-            Lucene.Net.Util.UnmanagedStringArray.Segment.AllocateMemory = NativeMemory.AllocateMemory;
-            Lucene.Net.Util.UnmanagedStringArray.Segment.FreeMemory = NativeMemory.Free;
+            Lucene.Net.Util.UnmanagedStringArray.Segment.AllocateMemory = NativeMemory.AllocateMemoryByLucene;
+            Lucene.Net.Util.UnmanagedStringArray.Segment.FreeMemory = NativeMemory.FreeMemoryByLucene;
 
             UseOnlyInvariantCultureInRavenDB();
 

--- a/src/Sparrow/Utils/MemoryUtils.cs
+++ b/src/Sparrow/Utils/MemoryUtils.cs
@@ -21,6 +21,7 @@ public static class MemoryUtils
             TryAppend(() => sb.Append("Dirty memory: ").Append(memoryInfo.TotalScratchDirtyMemory).Append(", "));
             TryAppend(() => sb.Append("Managed memory: ").Append(new Size(AbstractLowMemoryMonitor.GetManagedMemoryInBytes(), SizeUnit.Bytes)).Append(", "));
             TryAppend(() => sb.Append("Unmanaged allocations: ").Append(new Size(AbstractLowMemoryMonitor.GetUnmanagedAllocationsInBytes(), SizeUnit.Bytes)));
+            TryAppend(() => sb.Append("Lucene unmanaged allocations: ").Append(new Size(NativeMemory.TotalAllocatedMemoryByLucene, SizeUnit.Bytes)));
 
             try
             {

--- a/src/Sparrow/Utils/NativeMemory.cs
+++ b/src/Sparrow/Utils/NativeMemory.cs
@@ -3,7 +3,6 @@ using System.Collections.Concurrent;
 using System.Collections.Generic;
 using System.Diagnostics;
 using System.IO;
-using System.Linq;
 using System.Runtime.InteropServices;
 using System.Threading;
 using Sparrow.LowMemory;
@@ -38,8 +37,10 @@ namespace Sparrow.Utils
         }
 
         internal static long _totalAllocatedMemory;
+        internal static long _totalAllocatedMemoryByLucene;
 
         public static long TotalAllocatedMemory => _totalAllocatedMemory;
+        public static long TotalAllocatedMemoryByLucene => _totalAllocatedMemoryByLucene;
 
         public static ConcurrentDictionary<string, Lazy<FileMappingInfo>> FileMapping = new ConcurrentDictionary<string, Lazy<FileMappingInfo>>();
 
@@ -122,9 +123,22 @@ namespace Sparrow.Utils
             Free(ptr, size, ThreadAllocations.Value);
         }
 
+        public static void FreeMemoryByLucene(byte* ptr, long size)
+        {
+            Interlocked.Add(ref _totalAllocatedMemoryByLucene, -size);
+            Free(ptr, size, ThreadAllocations.Value);
+        }
+
         public static byte* AllocateMemory(long size)
         {
             ThreadStats _;
+            return AllocateMemory(size, out _);
+        }
+
+        public static byte* AllocateMemoryByLucene(long size)
+        {
+            ThreadStats _;
+            Interlocked.Add(ref _totalAllocatedMemoryByLucene, size);
             return AllocateMemory(size, out _);
         }
 


### PR DESCRIPTION
### Issue link

https://issues.hibernatingrhinos.com/issue/RavenDB-18942/Unmanaged-thread-allocations-mismatch

### Additional description

We use it in order by queries

### How risky is the change?

- Low 

### Testing 

- It has been verified by manual testing

### Is there any existing behavior change of other features due to this change?

- No
