### PR TITLE
RavenDB-7070 add Nito.AsyncEx.Coordination to Raven.Client to fix pub…

### DIFF
--- a/src/Raven.Client/Raven.Client.csproj
+++ b/src/Raven.Client/Raven.Client.csproj
@@ -93,6 +93,7 @@
     <PackageReference Include="System.Runtime.InteropServices.RuntimeInformation" Version="4.3.0" />
     <PackageReference Include="System.Security.Cryptography.Cng" Version="5.0.0" />
     <PackageReference Include="System.Threading.Tasks.Extensions" Version="4.5.4" />
+    <PackageReference Include="Nito.AsyncEx.Coordination" Version="5.1.2" />
   </ItemGroup>
   <ItemGroup Condition="$(TargetFramework) == 'netstandard2.0'">
     <PackageReference Include="Microsoft.Bcl.HashCode" Version="1.1.1" />


### PR DESCRIPTION
Since we embed Sparrow.dll in Client nuget package we need to include its dependencies in Raven.Client.csproj. Add missing package references to Raven.Client.csproj: Nito.AsyncEx.Coordination.
