### PR TITLE
RavenDB-18995 Downgrade TraceEvent

### DIFF
--- a/tools/Raven.Debug/GCDump/Graph.cs
+++ b/tools/Raven.Debug/GCDump/Graph.cs
@@ -125,7 +125,7 @@ namespace Graphs
         /// <summary>
         /// Same as NodeIndexLimit, just cast to an integer.  
         /// </summary>
-        public long NodeCount { get { return m_nodes.Count; } }
+        public int NodeCount { get { return m_nodes.Count; } }
         /// <summary>
         /// It is expected that users will want additional information associated with TYPES of the nodes of the graph.  They can
         /// do this by allocating an array of code:NodeTypeIndexLimit and then indexing this by code:NodeTypeIndex

--- a/tools/Raven.Debug/Raven.Debug.csproj
+++ b/tools/Raven.Debug/Raven.Debug.csproj
@@ -19,7 +19,7 @@
     <PackageReference Include="Microsoft.Bcl.AsyncInterfaces" Version="6.0.0" />
     <PackageReference Include="Microsoft.Diagnostics.Runtime" Version="1.1.142101" />
     <PackageReference Include="Microsoft.Diagnostics.NETCore.Client" Version="0.2.328102" />
-    <PackageReference Include="Microsoft.Diagnostics.Tracing.TraceEvent" Version="3.0.2" />
+    <PackageReference Include="Microsoft.Diagnostics.Tracing.TraceEvent" Version="2.0.64" />
     <PackageReference Include="Microsoft.Win32.Registry" Version="5.0.0" />
     <PackageReference Include="Newtonsoft.Json" Version="13.0.1" />
     <PackageReference Include="System.Collections.Immutable" Version="6.0.0" />


### PR DESCRIPTION
### Issue link

https://issues.hibernatingrhinos.com/issue/RavenDB-18995

### Additional description

The issue was caused because of the version of `Microsoft.Diagnostics.Traccing.TraceEvent` was upgraded from 2.0.64 to 3.0.2 (latest)

The `https://github.com/dotnet/diagnostics.git` is using 2.0.64 with a plan to upgrade that - https://github.com/dotnet/runtime/pull/71813

We will downgrade `Microsoft.Diagnostics.Traccing.TraceEvent` back and follow `https://github.com/dotnet/diagnostics.git` implementation when be done

### Type of change
- Bug fix

### How risky is the change?
- Low 

### Backward compatibility
- Non breaking change

### Is it platform specific issue?
- No

### Documentation update
- No documentation update is needed 

### Testing 
- It has been verified by manual testing

### Is there any existing behavior change of other features due to this change?
- No

### UI work
- No UI work is needed
