### PR TITLE
RavenDB-18961 Making sure that database dispose is not hanging forever if an operation task was not even started yet. Adding 30 seconds timeout in general to wait for an operation.

### DIFF
--- a/src/Raven.Server/Documents/Operations/Operations.cs
+++ b/src/Raven.Server/Documents/Operations/Operations.cs
@@ -246,7 +246,15 @@ namespace Raven.Server.Documents.Operations
                         if (active.Killable)
                             active.Token.Cancel();
 
-                        active.Task?.Wait();
+                        var task = active.Task;
+
+                        if (task == null)
+                            return;
+
+                        if (task.Status is TaskStatus.WaitingToRun)
+                            return; // execution has not even started yet
+
+                        task.Wait(TimeSpan.FromSeconds(30));
                     }
                     catch (Exception)
                     {


### PR DESCRIPTION
### Issue link

https://issues.hibernatingrhinos.com/issue/RavenDB-18961/Cannot-open-database-because-RavenDB-was-unable-create-file-lock-on

### Additional description

I saw that in the memory dump that the database disposal was hanging due to waiting for an operation task with status `WaitingToRun` (which for some reason was never started to be executed), Additionally adding 30 seconds timeout.

### Type of change

- Bug fix

### How risky is the change?

- Moderate 

### Backward compatibility

- Not relevant

### Is it platform specific issue?

- No

### Documentation update

- No documentation update is needed 

### Testing 

- It has been verified by manual testing

### Is there any existing behavior change of other features due to this change?

- No

### UI work

- No UI work is needed
