### PR TITLE
RavenDB-19033 Fixing the implementation of DatabaseLandlord.UnloadAndLockDatabase() so it respects that the database can be already locked

### DIFF
--- a/test/RachisTests/DatabaseCluster/ClusterDatabaseMaintenance.cs
+++ b/test/RachisTests/DatabaseCluster/ClusterDatabaseMaintenance.cs
@@ -483,7 +483,7 @@ namespace RachisTests.DatabaseCluster
                         tcs.SetCanceled();
                 }))
                 {
-                    var t = preferred.ServerStore.DatabasesLandlord.DatabasesCache.Replace(databaseName, tcs.Task);
+                    var t = preferred.ServerStore.DatabasesLandlord.DatabasesCache.ForTestingPurposesOnly().Replace(databaseName, tcs.Task);
                     t.Result.Dispose();
 
                     Assert.True(await WaitForValueAsync(async () =>

--- a/test/SlowTests/Issues/RavenDB_19033.cs
+++ b/test/SlowTests/Issues/RavenDB_19033.cs
@@ -1,0 +1,98 @@
+﻿using System;
+using System.Collections.Generic;
+using System.Threading.Tasks;
+using FastTests;
+using Raven.Client.Exceptions.Database;
+using Raven.Client.Extensions;
+using Raven.Client.Util;
+using Raven.Server.Documents;
+using Sparrow.Threading;
+using Xunit;
+using Xunit.Abstractions;
+
+namespace SlowTests.Issues;
+
+public class RavenDB_19033 : NoDisposalNeeded
+{
+    public RavenDB_19033(ITestOutputHelper output) : base(output)
+    {
+    }
+
+    private class MyDb : IDisposable
+    {
+        public static List<MyDb> RunningDatabases = new List<MyDb>();
+
+        public MyDb(string name)
+        {
+        }
+
+        public void Run()
+        {
+            RunningDatabases.Add(this);
+        }
+
+        public void Dispose()
+        {
+            RunningDatabases.Remove(this);
+        }
+    }
+
+    [Fact]
+    public async Task UnloadAndLockDatabaseMustNotIgnoreDatabaseDisabledLock()
+    {
+        var dbsCache = new ResourceCache<MyDb>();
+
+        var dbName = "foo";
+
+        var task1 = new Task<MyDb>(() =>
+        {
+            var myDb = new MyDb(dbName);
+
+            myDb.Run();
+
+            return myDb;
+        }, TaskCreationOptions.RunContinuationsAsynchronously);
+
+        var database1 = dbsCache.GetOrAdd(dbName, task1);
+
+        if (database1 == task1)
+        {
+            task1.Start();
+            task1.Wait();
+        }
+
+        using (dbsCache.RemoveLockAndReturn(dbName, x => x.Dispose(), out _))
+        {
+            await Assert.ThrowsAsync<DatabaseDisabledException>(async () =>
+            {
+                using (await DatabasesLandlord.UnloadAndLockDatabaseImpl(dbsCache, dbName, x => x.Dispose(), "test"))
+                {
+
+                }
+            });
+
+            var task2 = new Task<MyDb>(() =>
+            {
+                var myDb = new MyDb(dbName);
+
+                myDb.Run();
+
+                return myDb;
+            }, TaskCreationOptions.RunContinuationsAsynchronously);
+
+            var database2 = dbsCache.GetOrAdd(dbName, task2); // might be run from different thread
+
+            if (database2 == task2)
+            {
+                Assert.False(true, "we should never be allowed to start a new database since the database disabled lock created by RemoveLockAndReturn() is still acquired");
+
+                task2.Start();
+                task2.Wait();
+            }
+        }
+
+        // delete database - there must be no running db instance
+
+        Assert.Empty(MyDb.RunningDatabases);
+    }
+}

--- a/test/StressTests/Rachis/DatabaseCluster/ClusterDatabaseMaintenanceStress.cs
+++ b/test/StressTests/Rachis/DatabaseCluster/ClusterDatabaseMaintenanceStress.cs
@@ -66,7 +66,7 @@ namespace StressTests.Rachis.DatabaseCluster
                         tcs.SetCanceled();
                 }))
                 {
-                    var t = preferred.ServerStore.DatabasesLandlord.DatabasesCache.Replace(databaseName, tcs.Task);
+                    var t = preferred.ServerStore.DatabasesLandlord.DatabasesCache.ForTestingPurposesOnly().Replace(databaseName, tcs.Task);
                     t.Result.Dispose();
 
                     Assert.True(await WaitForValueAsync(async () =>
@@ -132,7 +132,7 @@ namespace StressTests.Rachis.DatabaseCluster
                         tcs.SetCanceled();
                 }))
                 {
-                    var t = preferred.ServerStore.DatabasesLandlord.DatabasesCache.Replace(databaseName, tcs.Task);
+                    var t = preferred.ServerStore.DatabasesLandlord.DatabasesCache.ForTestingPurposesOnly().Replace(databaseName, tcs.Task);
                     t.Result.Dispose();
 
                     Assert.True(await WaitForValueAsync(async () =>


### PR DESCRIPTION
Then the DatabaseDisabledException is propagated to a caller but the internal state of ResourceCache remains unchanged.

### Issue link

https://issues.hibernatingrhinos.com/issue/RavenDB-19033/DatabaseLandlordUnloadAndLockDatabase-ignores-that-a-database-is-already-locked

### Additional description

This fixes possible race conditions between starting a new database and deleting it. In result we could get exceptions like below during database _creation_:

```
 System.IO.FileNotFoundException: Errno: 2='No such file or directory' (rc=2) - 'can't allocate more pages (rc=FailGetRealPath) for '/ravendb/data/Databases/db-3/Indexes/Orders_ByCompany/Raven.voron'.
```

The reason for that was that we allowed to create a new instance of a db while it was being deleted.

### Type of change

- Bug fix

### How risky is the change?

- Moderate 

### Backward compatibility

- Not relevant

### Is it platform specific issue?

- No

### Documentation update

- No documentation update is needed 

### Testing 

- It has been verified by manual testing

### Is there any existing behavior change of other features due to this change?

- No

### UI work

- No UI work is needed
