### PR TITLE
RavenDB-19023 Fixing unobserved exception coming from SnmpDatabase if a database has been disabled meanwhile

### DIFF
--- a/src/Raven.Server/Monitoring/Snmp/SnmpDatabase.cs
+++ b/src/Raven.Server/Monitoring/Snmp/SnmpDatabase.cs
@@ -5,6 +5,7 @@ using System.Threading;
 using System.Threading.Tasks;
 using Lextm.SharpSnmpLib.Pipeline;
 using Raven.Client.Documents.Changes;
+using Raven.Client.Exceptions.Database;
 using Raven.Client.Util;
 using Raven.Server.Documents;
 using Raven.Server.Monitoring.Snmp.Objects.Database;
@@ -124,6 +125,10 @@ namespace Raven.Server.Monitoring.Snmp
                     await AddIndexesFromDatabase(database);
 
                     _attached = true;
+                }
+                catch (DatabaseDisabledException)
+                {
+                    // ignored
                 }
                 finally
                 {


### PR DESCRIPTION
### Issue link

https://issues.hibernatingrhinos.com/issue/RavenDB-19023/Unobserved-exception-coming-from-SnmpDatabase

### Type of change

- Bug fix

### How risky is the change?

- Low 

### Backward compatibility

- Not relevant

### Is it platform specific issue?

- No

### Documentation update

- No documentation update is needed 

### Testing 

- It has been verified by manual testing

### Is there any existing behavior change of other features due to this change?

- No

### UI work

- No UI work is needed
