### PR TITLE
RavenDB-18919 Ignoring exceptions in StorageSpaceMonitor if a database is shutting down

### DIFF
--- a/src/Raven.Server/Storage/StorageSpaceMonitor.cs
+++ b/src/Raven.Server/Storage/StorageSpaceMonitor.cs
@@ -74,6 +74,14 @@ namespace Raven.Server.Storage
                     {
                         storageEnvironment.Cleanup(tryCleanupRecycledJournals: true);
                     }
+                    catch (ObjectDisposedException)
+                    {
+                        // db is shutting down
+                    }
+                    catch (OperationCanceledException)
+                    {
+                        // db is shutting down
+                    }
                     catch (Exception e)
                     {
                         if (_logger.IsOperationsEnabled)


### PR DESCRIPTION

### Issue link

https://issues.hibernatingrhinos.com/issue/RavenDB-18919/ObjectDisposedException-Failed-to-cleanup-storage-environment-after-detecting-low-disk-space

### Additional description

Those are expected errors if a db is being shut down so we should not log them

### Type of change

- Bug fix

### How risky is the change?

- Low 

### Backward compatibility

- Not relevant

### Is it platform specific issue?

- No

### Documentation update

- No documentation update is needed 

### Testing 

- It has been verified by manual testing

### Is there any existing behavior change of other features due to this change?

- No

### UI work

- No UI work is needed
