### PR TITLE
RavenDB-13110 - Sharding - external and pull replication integration

### DIFF
--- a/src/Raven.Server/Documents/Handlers/Processors/Replication/AbstractPullReplicationHandlerProcessorForDefineHub.cs
+++ b/src/Raven.Server/Documents/Handlers/Processors/Replication/AbstractPullReplicationHandlerProcessorForDefineHub.cs
@@ -26,13 +26,6 @@ namespace Raven.Server.Documents.Handlers.Processors.Replication
             responseJson[nameof(OngoingTask.TaskId)] = _pullReplication.TaskId == 0 ? index : _pullReplication.TaskId;
         }
 
-        protected override ValueTask AssertCanExecuteAsync()
-        {
-            RequestHandler.ServerStore.LicenseManager.AssertCanAddPullReplicationAsHub();
-
-            return base.AssertCanExecuteAsync();
-        }
-
         protected override Task<(long Index, object Result)> OnUpdateConfiguration(TransactionOperationContext context, BlittableJsonReaderObject configuration, string raftRequestId)
         {
             _pullReplication = JsonDeserializationClient.PullReplicationDefinition(configuration);

--- a/src/Raven.Server/Documents/Handlers/Processors/Replication/AbstractPullReplicationHandlerProcessorForRegisterHubAccess.cs
+++ b/src/Raven.Server/Documents/Handlers/Processors/Replication/AbstractPullReplicationHandlerProcessorForRegisterHubAccess.cs
@@ -23,13 +23,6 @@ namespace Raven.Server.Documents.Handlers.Processors.Replication
         {
         }
 
-        protected override ValueTask AssertCanExecuteAsync()
-        {
-            RequestHandler.ServerStore.LicenseManager.AssertCanAddPullReplicationAsHub();
-
-            return base.AssertCanExecuteAsync();
-        }
-
         protected override async ValueTask<BlittableJsonReaderObject> GetConfigurationAsync(TransactionOperationContext context, AsyncBlittableJsonTextWriter writer)
         {
             _hubTaskName = RequestHandler.GetStringQueryString("name", true);

--- a/src/Raven.Server/Documents/Handlers/Processors/Replication/AbstractPullReplicationHandlerProcessorForUpdatePullReplicationOnSinkNode.cs
+++ b/src/Raven.Server/Documents/Handlers/Processors/Replication/AbstractPullReplicationHandlerProcessorForUpdatePullReplicationOnSinkNode.cs
@@ -41,13 +41,6 @@ namespace Raven.Server.Documents.Handlers.Processors.Replication
             responseJson[nameof(ModifyOngoingTaskResult.TaskId)] = _pullReplication.TaskId == 0 ? index : _pullReplication.TaskId;
         }
 
-        protected override ValueTask AssertCanExecuteAsync()
-        {
-            RequestHandler.ServerStore.LicenseManager.AssertCanAddPullReplicationAsSink();
-
-            return base.AssertCanExecuteAsync();
-        }
-
         protected override Task<(long Index, object Result)> OnUpdateConfiguration(TransactionOperationContext context, BlittableJsonReaderObject configuration, string raftRequestId)
         {
             return RequestHandler.ServerStore.UpdatePullReplicationAsSink(RequestHandler.DatabaseName, configuration, raftRequestId, out _pullReplication);

--- a/src/Raven.Server/Documents/Handlers/Processors/Replication/PullReplicationHandlerProcessorForDefineHub.cs
+++ b/src/Raven.Server/Documents/Handlers/Processors/Replication/PullReplicationHandlerProcessorForDefineHub.cs
@@ -1,4 +1,5 @@
-﻿using JetBrains.Annotations;
+﻿using System.Threading.Tasks;
+using JetBrains.Annotations;
 using Raven.Server.ServerWide.Context;
 
 namespace Raven.Server.Documents.Handlers.Processors.Replication
@@ -7,6 +8,13 @@ namespace Raven.Server.Documents.Handlers.Processors.Replication
     {
         public PullReplicationHandlerProcessorForDefineHub([NotNull] DatabaseRequestHandler requestHandler) : base(requestHandler)
         {
+        }
+
+        protected override ValueTask AssertCanExecuteAsync()
+        {
+            RequestHandler.ServerStore.LicenseManager.AssertCanAddPullReplicationAsHub();
+
+            return base.AssertCanExecuteAsync();
         }
     }
 }

--- a/src/Raven.Server/Documents/Handlers/Processors/Replication/PullReplicationHandlerProcessorForRegisterHubAccess.cs
+++ b/src/Raven.Server/Documents/Handlers/Processors/Replication/PullReplicationHandlerProcessorForRegisterHubAccess.cs
@@ -1,4 +1,5 @@
-﻿using JetBrains.Annotations;
+﻿using System.Threading.Tasks;
+using JetBrains.Annotations;
 using Raven.Server.ServerWide.Context;
 
 namespace Raven.Server.Documents.Handlers.Processors.Replication
@@ -7,6 +8,13 @@ namespace Raven.Server.Documents.Handlers.Processors.Replication
     {
         public PullReplicationHandlerProcessorForRegisterHubAccess([NotNull] DatabaseRequestHandler requestHandler) : base(requestHandler)
         {
+        }
+
+        protected override ValueTask AssertCanExecuteAsync()
+        {
+            RequestHandler.ServerStore.LicenseManager.AssertCanAddPullReplicationAsHub();
+
+            return base.AssertCanExecuteAsync();
         }
     }
 }

--- a/src/Raven.Server/Documents/Handlers/Processors/Replication/PullReplicationHandlerProcessorForUpdatePullReplicationOnSinkNode.cs
+++ b/src/Raven.Server/Documents/Handlers/Processors/Replication/PullReplicationHandlerProcessorForUpdatePullReplicationOnSinkNode.cs
@@ -1,4 +1,5 @@
-﻿using JetBrains.Annotations;
+﻿using System.Threading.Tasks;
+using JetBrains.Annotations;
 using Raven.Client.Documents.Operations.OngoingTasks;
 using Raven.Client.Documents.Operations.Replication;
 using Raven.Server.ServerWide.Context;
@@ -10,6 +11,13 @@ namespace Raven.Server.Documents.Handlers.Processors.Replication
     {
         public PullReplicationHandlerProcessorForUpdatePullReplicationOnSinkNode([NotNull] DatabaseRequestHandler requestHandler) : base(requestHandler)
         {
+        }
+
+        protected override ValueTask AssertCanExecuteAsync()
+        {
+            RequestHandler.ServerStore.LicenseManager.AssertCanAddPullReplicationAsSink();
+
+            return base.AssertCanExecuteAsync();
         }
 
         protected override void FillResponsibleNode(TransactionOperationContext context, DynamicJsonValue responseJson, PullReplicationAsSink pullReplication)

--- a/src/Raven.Server/Documents/Replication/AbstractReplicationLoader.cs
+++ b/src/Raven.Server/Documents/Replication/AbstractReplicationLoader.cs
@@ -1,0 +1,472 @@
+﻿using System;
+using System.Collections.Concurrent;
+using System.Collections.Generic;
+using System.Security.Cryptography.X509Certificates;
+using System.Threading;
+using Raven.Client.Documents.Operations.ETL;
+using Raven.Client.Documents.Operations.Replication;
+using Raven.Client.Documents.Replication;
+using Raven.Client.Documents.Replication.Messages;
+using Raven.Client.Http;
+using Raven.Client.Json.Serialization;
+using Raven.Client.ServerWide;
+using Raven.Client.ServerWide.Commands;
+using Raven.Client.ServerWide.Tcp;
+using Raven.Server.Config;
+using Raven.Server.Documents.Replication.Outgoing;
+using Raven.Server.Documents.Replication.Stats;
+using Raven.Server.Documents.TcpHandlers;
+using Raven.Server.Json;
+using Raven.Server.NotificationCenter.Notifications;
+using Raven.Server.ServerWide;
+using Raven.Server.ServerWide.Context;
+using Raven.Server.Utils;
+using Sparrow.Collections;
+using Sparrow.Json;
+using Sparrow.Json.Parsing;
+using Sparrow.Json.Sync;
+using Sparrow.Logging;
+using Sparrow.Server.Json.Sync;
+
+namespace Raven.Server.Documents.Replication
+{
+    public abstract class AbstractReplicationLoader
+    {
+        private readonly ReaderWriterLockSlim _locker = new ReaderWriterLockSlim();
+        private long _reconnectInProgress;
+        private int _replicationStatsId;
+
+        internal readonly ServerStore _server;
+        private readonly string _databaseName;
+        protected readonly Logger _logger;
+        protected readonly ConcurrentDictionary<ReplicationNode, ConnectionShutdownInfo> _outgoingFailureInfo = new ConcurrentDictionary<ReplicationNode, ConnectionShutdownInfo>();
+        protected readonly ConcurrentSet<ConnectionShutdownInfo> _reconnectQueue = new ConcurrentSet<ConnectionShutdownInfo>();
+        protected readonly Timer _reconnectAttemptTimer;
+
+        internal readonly int MinimalHeartbeatInterval;
+        public IReadOnlyDictionary<ReplicationNode, ConnectionShutdownInfo> OutgoingFailureInfo => _outgoingFailureInfo;
+
+        protected AbstractReplicationLoader(ServerStore serverStore, string databaseName, RavenConfiguration configuration)
+        {
+            _databaseName = databaseName;
+            _server = serverStore;
+            _logger = LoggingSource.Instance.GetLogger(GetType().FullName, databaseName);
+
+            var config = configuration.Replication;
+            var reconnectTime = config.RetryReplicateAfter.AsTimeSpan;
+            _reconnectAttemptTimer = new Timer(state => ForceTryReconnectAll(),
+                null, reconnectTime, reconnectTime);
+            MinimalHeartbeatInterval = (int)config.ReplicationMinimalHeartbeat.AsTimeSpan.TotalMilliseconds;
+        }
+
+        protected void ForceTryReconnectAll()
+        {
+            if (_reconnectQueue.Count == 0)
+                return;
+
+            if (Interlocked.CompareExchange(ref _reconnectInProgress, 1, 0) == 1)
+                return;
+
+            try
+            {
+                DatabaseTopology topology;
+                Dictionary<string, RavenConnectionString> ravenConnectionStrings;
+
+                using (_server.ContextPool.AllocateOperationContext(out TransactionOperationContext ctx))
+                using (ctx.OpenReadTransaction())
+                {
+                    var raw = _server.Cluster.ReadRawDatabaseRecord(ctx, _databaseName);
+                    if (raw == null)
+                    {
+                        _reconnectQueue.Clear();
+                        return;
+                    }
+
+                    topology = raw.Topology;
+                    ravenConnectionStrings = raw.RavenConnectionStrings;
+                }
+
+                var cts = GetCancellationToken();
+                foreach (var failure in _reconnectQueue)
+                {
+                    if (cts.IsCancellationRequested)
+                        return;
+
+                    try
+                    {
+                        if (_reconnectQueue.TryRemove(failure) == false)
+                            continue;
+
+                        if (_outgoingFailureInfo.Values.Contains(failure) == false)
+                            continue; // this connection is no longer exists
+
+                        if (failure.RetryOn > DateTime.UtcNow)
+                        {
+                            _reconnectQueue.Add(failure);
+                            continue;
+                        }
+
+                        if (failure.Node is ExternalReplicationBase exNode &&
+                            IsMyTask(ravenConnectionStrings, topology, exNode) == false)
+                            // no longer my task
+                            continue;
+
+                        if (failure.Node is BucketMigrationReplication migration &&
+                            topology.WhoseTaskIsIt(RachisState.Follower, migration.ShardBucketMigration, getLastResponsibleNode: null) != _server.NodeTag)
+                            // no longer my task
+                            continue;
+
+                        AddAndStartOutgoingReplication(failure.Node);
+                    }
+                    catch (Exception e)
+                    {
+                        if (_logger.IsOperationsEnabled)
+                        {
+                            _logger.Operations($"Failed to start outgoing replication to {failure.Node}", e);
+                        }
+                    }
+                }
+            }
+            catch (Exception e)
+            {
+                if (_logger.IsOperationsEnabled)
+                {
+                    _logger.Operations("Unexpected exception during ForceTryReconnectAll", e);
+                }
+            }
+            finally
+            {
+                Interlocked.Exchange(ref _reconnectInProgress, 0);
+            }
+        }
+
+        internal virtual void AddAndStartOutgoingReplication(ReplicationNode node)
+        {
+            var info = GetConnectionInfo(node);
+
+            if (info == null)
+            {
+                // this means that we were unable to retrieve the tcp connection info and will try it again later
+                return;
+            }
+
+            if (_locker.TryEnterReadLock(0) == false)
+            {
+                // the db being disposed
+                return;
+            }
+
+            try
+            {
+                StartOutgoingReplication(info, node);
+            }
+            finally
+            {
+                _locker.ExitReadLock();
+            }
+        }
+
+        public int GetNextReplicationStatsId() => Interlocked.Increment(ref _replicationStatsId);
+
+        protected bool IsMyTask(Dictionary<string, RavenConnectionString> connectionStrings, DatabaseTopology topology, ExternalReplicationBase task)
+        {
+            if (ValidateConnectionString(connectionStrings, task, out _) == false)
+                return false;
+
+            var taskStatus = GetExternalReplicationState(_server, _databaseName, task.TaskId);
+            var whoseTaskIsIt = _server.WhoseTaskIsIt(topology, task, taskStatus);
+            return whoseTaskIsIt == _server.NodeTag;
+        }
+
+        protected bool ValidateConnectionString(Dictionary<string, RavenConnectionString> ravenConnectionStrings, ExternalReplicationBase externalReplication, out RavenConnectionString connectionString)
+        {
+            connectionString = null;
+            if (string.IsNullOrEmpty(externalReplication.ConnectionStringName))
+            {
+                var msg = $"The external replication {externalReplication.Name} to the database '{externalReplication.Database}' " +
+                          "has an empty connection string name.";
+
+                if (_logger.IsInfoEnabled)
+                {
+                    _logger.Info(msg);
+                }
+
+                _server.NotificationCenter.Add(AlertRaised.Create(
+                    _databaseName,
+                    "Connection string name is empty",
+                    msg,
+                    AlertType.Replication,
+                    NotificationSeverity.Error));
+                return false;
+            }
+
+            if (ravenConnectionStrings.TryGetValue(externalReplication.ConnectionStringName, out connectionString) == false)
+            {
+                var msg = $"Could not find connection string with name {externalReplication.ConnectionStringName} " +
+                          $"for the external replication task '{externalReplication.Name}' to '{externalReplication.Database}'.";
+
+                if (_logger.IsInfoEnabled)
+                {
+                    _logger.Info(msg);
+                }
+
+                _server.NotificationCenter.Add(AlertRaised.Create(
+                    _databaseName,
+                    "Connection string not found",
+                    msg,
+                    AlertType.Replication,
+                    NotificationSeverity.Error));
+
+                return false;
+            }
+            return true;
+        }
+
+        public static ExternalReplicationState GetExternalReplicationState(ServerStore server, string database, long taskId)
+        {
+            using (server.ContextPool.AllocateOperationContext(out TransactionOperationContext context))
+            using (context.OpenReadTransaction())
+            {
+                return GetExternalReplicationState(server, database, taskId, context);
+            }
+        }
+
+        protected static ExternalReplicationState GetExternalReplicationState(ServerStore server, string database, long taskId, TransactionOperationContext context)
+        {
+            var stateBlittable = server.Cluster.Read(context, ExternalReplicationState.GenerateItemName(database, taskId));
+
+            return stateBlittable != null ? JsonDeserializationCluster.ExternalReplicationState(stateBlittable) : new ExternalReplicationState();
+        }
+
+        protected TcpConnectionHeaderMessage.SupportedFeatures GetSupportedVersions(TcpConnectionOptions tcpConnectionOptions)
+        {
+            return TcpConnectionHeaderMessage.GetSupportedFeaturesFor(TcpConnectionHeaderMessage.OperationTypes.Replication, tcpConnectionOptions.ProtocolVersion);
+        }
+
+        protected ReplicationInitialRequest GetReplicationInitialRequest(TcpConnectionOptions tcpConnectionOptions,
+            TcpConnectionHeaderMessage.SupportedFeatures supportedVersions, JsonOperationContext.MemoryBuffer buffer)
+        {
+            ReplicationInitialRequest initialRequest = null;
+            if (supportedVersions.Replication.PullReplication)
+            {
+                using (tcpConnectionOptions.ContextPool.AllocateOperationContext(out JsonOperationContext context))
+                using (var readerObject = context.Sync.ParseToMemory(tcpConnectionOptions.Stream, "initial-replication-message",
+                           BlittableJsonDocumentBuilder.UsageMode.None, buffer))
+                {
+                    initialRequest = JsonDeserializationServer.ReplicationInitialRequest(readerObject);
+                }
+            }
+
+            return initialRequest;
+        }
+
+        protected ReplicationLatestEtagRequest IncomingInitialHandshake(TcpConnectionOptions tcpConnectionOptions, JsonOperationContext.MemoryBuffer buffer, ReplicationLoader.PullReplicationParams replParams = null)
+        {
+            ReplicationLatestEtagRequest getLatestEtagMessage;
+
+            using (tcpConnectionOptions.ContextPool.AllocateOperationContext(out JsonOperationContext context))
+            using (var readerObject = context.Sync.ParseToMemory(
+                tcpConnectionOptions.Stream,
+                "IncomingReplication/get-last-etag-message read",
+                BlittableJsonDocumentBuilder.UsageMode.None,
+                buffer))
+            {
+                var exceptionSchema = JsonDeserializationClient.ExceptionSchema(readerObject);
+                if (exceptionSchema.Type.Equals("Error"))
+                    throw new Exception(exceptionSchema.Message);
+
+                getLatestEtagMessage = JsonDeserializationServer.ReplicationLatestEtagRequest(readerObject);
+                if (_logger.IsInfoEnabled)
+                {
+                    _logger.Info(
+                        $"GetLastEtag: {getLatestEtagMessage.SourceTag}({getLatestEtagMessage.SourceMachineName}) / {getLatestEtagMessage.SourceDatabaseName} ({getLatestEtagMessage.SourceDatabaseId}) - {getLatestEtagMessage.SourceUrl}. Type: {getLatestEtagMessage.ReplicationsType}");
+                }
+            }
+
+            var connectionInfo = IncomingConnectionInfo.FromGetLatestEtag(getLatestEtagMessage);
+            try
+            {
+                AssertValidConnection(connectionInfo);
+            }
+            catch (Exception e)
+            {
+                if (_logger.IsInfoEnabled)
+                    _logger.Info($"Connection from [{connectionInfo}] is rejected.", e);
+
+                throw;
+            }
+
+            try
+            {
+                using (_server.ContextPool.AllocateOperationContext(out TransactionOperationContext context))
+                using (var writer = new BlittableJsonTextWriter(context, tcpConnectionOptions.Stream))
+                {
+                    DynamicJsonValue response = GetInitialRequestMessage(getLatestEtagMessage, replParams);
+                    context.Write(writer, response);
+                    writer.Flush();
+                }
+            }
+            catch (Exception)
+            {
+                try
+                {
+                    tcpConnectionOptions.Dispose();
+                }
+                catch (Exception)
+                {
+                    // do nothing
+                }
+
+                throw;
+            }
+
+            if (_logger.IsInfoEnabled)
+                _logger.Info(
+                    $"Initialized document replication connection from {connectionInfo.SourceDatabaseName} located at {connectionInfo.SourceUrl}");
+
+            return getLatestEtagMessage;
+        }
+
+        public X509Certificate2 GetCertificateForReplication(ReplicationNode node, out TcpConnectionHeaderMessage.AuthorizationInfo authorizationInfo)
+        {
+            switch (node)
+            {
+                case BucketMigrationReplication _:
+                case InternalReplication _:
+                case ExternalReplication _:
+                    authorizationInfo = null;
+                    return _server.Server.Certificate.Certificate;
+
+                case PullReplicationAsSink sink:
+                    authorizationInfo = new TcpConnectionHeaderMessage.AuthorizationInfo
+                    {
+                        AuthorizeAs = sink.Mode switch
+                        {
+                            PullReplicationMode.HubToSink => TcpConnectionHeaderMessage.AuthorizationInfo.AuthorizeMethod.PullReplication,
+                            PullReplicationMode.SinkToHub => TcpConnectionHeaderMessage.AuthorizationInfo.AuthorizeMethod.PushReplication,
+                            PullReplicationMode.None => throw new ArgumentOutOfRangeException(nameof(node), "Replication mode should be set to pull or push"),
+                            _ => throw new ArgumentOutOfRangeException("Unexpected replication mode: " + sink.Mode)
+                        },
+                        AuthorizationFor = sink.HubName
+                    };
+
+                    if (sink.CertificateWithPrivateKey == null)
+                        return _server.Server.Certificate.Certificate;
+
+                    var certBytes = Convert.FromBase64String(sink.CertificateWithPrivateKey);
+                    return new X509Certificate2(certBytes, sink.CertificatePassword, X509KeyStorageFlags.Exportable | X509KeyStorageFlags.MachineKeySet);
+
+                default:
+                    throw new ArgumentException($"Unknown node type {node.GetType().FullName}");
+            }
+        }
+
+        public void EnsureNotDeleted(string node)
+        {
+            using (_server.ContextPool.AllocateOperationContext(out TransactionOperationContext ctx))
+            using (ctx.OpenReadTransaction())
+            {
+                using (var rawRecord = _server.Cluster.ReadRawDatabaseRecord(ctx, _databaseName))
+                {
+                    if (rawRecord != null && rawRecord.DeletionInProgress.ContainsKey(node))
+                    {
+                        throw new OperationCanceledException($"The database '{_databaseName}' on node '{node}' is being deleted, so it will not handle replications.");
+                    }
+                }
+            }
+        }
+
+        protected virtual void AssertValidConnection(IncomingConnectionInfo connectionInfo)
+        {
+            if (_server.IsPassive())
+            {
+                throw new InvalidOperationException(
+                    $"Cannot accept the incoming replication connection from {connectionInfo.SourceUrl}, because this node is in passive state.");
+            }
+        }
+
+        protected virtual DynamicJsonValue GetInitialRequestMessage(ReplicationLatestEtagRequest replicationLatestEtagRequest,
+            ReplicationLoader.PullReplicationParams replParams = null)
+        {
+            return new DynamicJsonValue
+            {
+                [nameof(ReplicationMessageReply.Type)] = nameof(ReplicationMessageReply.ReplyType.Ok),
+                [nameof(ReplicationMessageReply.MessageType)] = ReplicationMessageType.Heartbeat,
+                [nameof(ReplicationMessageReply.NodeTag)] = _server.NodeTag,
+                [nameof(ReplicationMessageReply.AcceptablePaths)] = replParams?.AllowedPaths,
+                [nameof(ReplicationMessageReply.PreventDeletionsMode)] = replParams?.PreventDeletionsMode
+            };
+        }
+
+        public ClusterTopology GetClusterTopology()
+        {
+            using (_server.ContextPool.AllocateOperationContext(out TransactionOperationContext ctx))
+            using (ctx.OpenReadTransaction())
+            {
+                return _server.GetClusterTopology(ctx);
+            }
+        }
+
+        protected DatabaseTopology GetTopologyForShard(int shard)
+        {
+            using (_server.ContextPool.AllocateOperationContext(out TransactionOperationContext ctx))
+            using (ctx.OpenReadTransaction())
+            {
+                return _server.Cluster.ReadDatabaseTopologyForShard(ctx, ShardHelper.ToDatabaseName(_databaseName), shard);
+            }
+        }
+
+        protected abstract TcpConnectionInfo GetConnectionInfo(ReplicationNode node);
+
+        protected abstract void StartOutgoingReplication(TcpConnectionInfo info, ReplicationNode node);
+
+        protected abstract CancellationToken GetCancellationToken();
+
+        public class ConnectionShutdownInfo
+        {
+            private readonly TimeSpan _initialTimeout = TimeSpan.FromMilliseconds(1000);
+            private readonly int _retriesCount = 0;
+
+            public ConnectionShutdownInfo()
+            {
+                NextTimeout = _initialTimeout;
+                RetriesCount = _retriesCount;
+            }
+
+            public string DestinationDbId;
+
+            public long LastHeartbeatTicks;
+
+            public double MaxConnectionTimeout;
+
+            public readonly Queue<Exception> Errors = new Queue<Exception>();
+
+            public TimeSpan NextTimeout { get; set; }
+
+            public DateTime RetryOn { get; set; }
+
+            public ReplicationNode Node { get; set; }
+
+            public int RetriesCount { get; set; }
+
+            public void Reset()
+            {
+                NextTimeout = _initialTimeout;
+                RetriesCount = _retriesCount;
+                Errors.Clear();
+            }
+
+            public void OnError(Exception e)
+            {
+                Errors.Enqueue(e);
+                while (Errors.Count > 25)
+                    Errors.TryDequeue(out _);
+
+                RetriesCount++;
+                NextTimeout *= 2;
+                NextTimeout = TimeSpan.FromMilliseconds(Math.Min(NextTimeout.TotalMilliseconds, MaxConnectionTimeout));
+                RetryOn = DateTime.UtcNow + NextTimeout;
+            }
+        }
+    }
+}

--- a/src/Raven.Server/Documents/Replication/ConnectionShutdownInfo.cs
+++ b/src/Raven.Server/Documents/Replication/ConnectionShutdownInfo.cs
@@ -1,0 +1,53 @@
+﻿using System;
+using System.Collections.Generic;
+using Raven.Client.Documents.Replication;
+
+namespace Raven.Server.Documents.Replication
+{
+    public class ConnectionShutdownInfo
+    {
+        private readonly TimeSpan _initialTimeout = TimeSpan.FromMilliseconds(1000);
+        private readonly int _retriesCount = 0;
+
+        public ConnectionShutdownInfo()
+        {
+            NextTimeout = _initialTimeout;
+            RetriesCount = _retriesCount;
+        }
+
+        public string DestinationDbId;
+
+        public long LastHeartbeatTicks;
+
+        public double MaxConnectionTimeout;
+
+        public readonly Queue<Exception> Errors = new Queue<Exception>();
+
+        public TimeSpan NextTimeout { get; set; }
+
+        public DateTime RetryOn { get; set; }
+
+        public ReplicationNode Node { get; set; }
+
+        public int RetriesCount { get; set; }
+
+        public void Reset()
+        {
+            NextTimeout = _initialTimeout;
+            RetriesCount = _retriesCount;
+            Errors.Clear();
+        }
+
+        public void OnError(Exception e)
+        {
+            Errors.Enqueue(e);
+            while (Errors.Count > 25)
+                Errors.TryDequeue(out _);
+
+            RetriesCount++;
+            NextTimeout *= 2;
+            NextTimeout = TimeSpan.FromMilliseconds(Math.Min(NextTimeout.TotalMilliseconds, MaxConnectionTimeout));
+            RetryOn = DateTime.UtcNow + NextTimeout;
+        }
+    }
+}

--- a/src/Raven.Server/Documents/Replication/Incoming/AbstractIncomingReplicationHandler.cs
+++ b/src/Raven.Server/Documents/Replication/Incoming/AbstractIncomingReplicationHandler.cs
@@ -491,8 +491,6 @@ namespace Raven.Server.Documents.Replication.Incoming
                                 msgContext.Write(writer, msg);
                                 writer.Flush();
                             }
-
-                            HandleMissingAttachmentsIfNeeded();
                         }
                     }
 
@@ -590,8 +588,6 @@ namespace Raven.Server.Documents.Replication.Incoming
         protected abstract void HandleHeartbeatMessage(TOperationContext jsonOperationContext, BlittableJsonReaderObject blittableJsonReaderObject);
 
         public abstract LiveReplicationPerformanceCollector.ReplicationPerformanceType GetReplicationPerformanceType();
-
-        protected abstract void HandleMissingAttachmentsIfNeeded();
 
         public bool IsDisposed => _disposeOnce.Disposed;
 

--- a/src/Raven.Server/Documents/Replication/Incoming/AbstractIncomingReplicationHandler.cs
+++ b/src/Raven.Server/Documents/Replication/Incoming/AbstractIncomingReplicationHandler.cs
@@ -487,15 +487,14 @@ namespace Raven.Server.Documents.Replication.Incoming
                             while (task.Wait(Math.Min(3000, (int)(configuration.Replication.ActiveConnectionTimeout.AsTimeSpan.TotalMilliseconds * 2 / 3))) ==
                                    false)
                             {
-                                HandleMissingAttachmentsIfNeeded(ref task);
-
                                 // send heartbeats while batch is processed in TxMerger. We wait until merger finishes with this command without timeouts
                                 msgContext.Write(writer, msg);
                                 writer.Flush();
                             }
 
+                            HandleMissingAttachmentsIfNeeded();
+
                             HandleTaskCompleteIfNeeded();
-                            task = null;
                         }
                     }
 
@@ -596,7 +595,7 @@ namespace Raven.Server.Documents.Replication.Incoming
 
         public abstract LiveReplicationPerformanceCollector.ReplicationPerformanceType GetReplicationPerformanceType();
 
-        protected abstract void HandleMissingAttachmentsIfNeeded(ref Task task);
+        protected abstract void HandleMissingAttachmentsIfNeeded();
 
         public bool IsDisposed => _disposeOnce.Disposed;
 

--- a/src/Raven.Server/Documents/Replication/Incoming/AbstractIncomingReplicationHandler.cs
+++ b/src/Raven.Server/Documents/Replication/Incoming/AbstractIncomingReplicationHandler.cs
@@ -493,8 +493,6 @@ namespace Raven.Server.Documents.Replication.Incoming
                             }
 
                             HandleMissingAttachmentsIfNeeded();
-
-                            HandleTaskCompleteIfNeeded();
                         }
                     }
 
@@ -582,8 +580,6 @@ namespace Raven.Server.Documents.Replication.Incoming
         protected abstract void InvokeOnFailed(Exception exception);
 
         protected abstract Task HandleBatchAsync(TOperationContext context, IncomingReplicationHandler.DataForReplicationCommand batch, long lastEtag);
-
-        protected abstract void HandleTaskCompleteIfNeeded();
 
         protected abstract RavenConfiguration GetConfiguration();
 

--- a/src/Raven.Server/Documents/Replication/Incoming/IAbstractIncomingReplicationHandler.cs
+++ b/src/Raven.Server/Documents/Replication/Incoming/IAbstractIncomingReplicationHandler.cs
@@ -1,0 +1,16 @@
+﻿using System;
+using Raven.Client.Documents.Replication;
+using Raven.Server.Documents.Replication.Stats;
+
+namespace Raven.Server.Documents.Replication.Incoming
+{
+    public interface IAbstractIncomingReplicationHandler : IDisposable
+    {
+        public bool IsDisposed { get; }
+        public IncomingConnectionInfo ConnectionInfo { get; }
+        public string SourceFormatted { get; }
+        public long LastDocumentEtag { get; }
+        public IncomingReplicationPerformanceStats[] GetReplicationPerformance();
+        public LiveReplicationPerformanceCollector.ReplicationPerformanceType GetReplicationPerformanceType();
+    }
+}

--- a/src/Raven.Server/Documents/Replication/Incoming/IncomingReplicationAllocator.cs
+++ b/src/Raven.Server/Documents/Replication/Incoming/IncomingReplicationAllocator.cs
@@ -1,0 +1,109 @@
+﻿using System;
+using System.Collections.Generic;
+using System.Diagnostics;
+using Sparrow;
+using Sparrow.Platform;
+using Sparrow.Server;
+using Sparrow.Utils;
+
+namespace Raven.Server.Documents.Replication.Incoming
+{
+    public unsafe class IncomingReplicationAllocator : IDisposable
+    {
+        private readonly long _maxSizeForContextUseInBytes;
+        private readonly long _minSizeToAllocateNonContextUseInBytes;
+        public long TotalDocumentsSizeInBytes { get; private set; }
+
+        private List<Allocation> _nativeAllocationList;
+        private Allocation _currentAllocation;
+        private readonly ByteStringContext _allocator;
+
+        public IncomingReplicationAllocator(ByteStringContext allocator, Size? maxSizeToSend)
+        {
+            _allocator = allocator;
+            var maxSizeForContextUse = maxSizeToSend * 2 ?? new Size(128, SizeUnit.Megabytes);
+
+            _maxSizeForContextUseInBytes = maxSizeForContextUse.GetValue(SizeUnit.Bytes);
+            var minSizeToNonContextAllocationInMb = PlatformDetails.Is32Bits ? 4 : 16;
+            _minSizeToAllocateNonContextUseInBytes = new Size(minSizeToNonContextAllocationInMb, SizeUnit.Megabytes).GetValue(SizeUnit.Bytes);
+        }
+
+        public byte* AllocateMemory(int size)
+        {
+            TotalDocumentsSizeInBytes += size;
+            if (TotalDocumentsSizeInBytes <= _maxSizeForContextUseInBytes)
+            {
+                _allocator.Allocate(size, out var output);
+                return output.Ptr;
+            }
+
+            if (_currentAllocation == null || _currentAllocation.Free < size)
+            {
+                // first allocation or we don't have enough space on the currently allocated chunk
+
+                // there can be a document that is larger than the minimum
+                var sizeToAllocate = Math.Max(size, _minSizeToAllocateNonContextUseInBytes);
+
+                var allocation = new Allocation(sizeToAllocate);
+                if (_nativeAllocationList == null)
+                    _nativeAllocationList = new List<Allocation>();
+
+                _nativeAllocationList.Add(allocation);
+                _currentAllocation = allocation;
+            }
+
+            return _currentAllocation.GetMemory(size);
+        }
+
+        public void Dispose()
+        {
+            if (_nativeAllocationList == null)
+                return;
+
+            foreach (var allocation in _nativeAllocationList)
+            {
+                allocation.Dispose();
+            }
+        }
+
+        private class Allocation : IDisposable
+        {
+            private readonly byte* _ptr;
+            private readonly long _allocationSize;
+            private readonly NativeMemory.ThreadStats _threadStats;
+            private long _used;
+            public long Free => _allocationSize - _used;
+
+            public Allocation(long allocationSize)
+            {
+                _ptr = NativeMemory.AllocateMemory(allocationSize, out var threadStats);
+                _allocationSize = allocationSize;
+                _threadStats = threadStats;
+            }
+
+            public byte* GetMemory(long size)
+            {
+                ThrowOnPointerOutOfRange(size);
+
+                var mem = _ptr + _used;
+                _used += size;
+                return mem;
+            }
+
+            [Conditional("DEBUG")]
+            private void ThrowOnPointerOutOfRange(long size)
+            {
+                if (_used + size > _allocationSize)
+                    throw new InvalidOperationException(
+                        $"Not enough space to allocate the requested size: {new Size(size, SizeUnit.Bytes)}, " +
+                        $"used: {new Size(_used, SizeUnit.Bytes)}, " +
+                        $"total allocation size: {new Size(_allocationSize, SizeUnit.Bytes)}");
+            }
+
+            public void Dispose()
+            {
+                NativeMemory.Free(_ptr, _allocationSize, _threadStats);
+            }
+        }
+    }
+}

--- a/src/Raven.Server/Documents/Replication/Incoming/IncomingReplicationHandler.cs
+++ b/src/Raven.Server/Documents/Replication/Incoming/IncomingReplicationHandler.cs
@@ -271,7 +271,7 @@ namespace Raven.Server.Documents.Replication.Incoming
         }
 
 
-        protected override void HandleMissingAttachmentsIfNeeded(ref Task task)
+        protected override void HandleMissingAttachmentsIfNeeded()
         {
         }
 

--- a/src/Raven.Server/Documents/Replication/Incoming/IncomingReplicationHandler.cs
+++ b/src/Raven.Server/Documents/Replication/Incoming/IncomingReplicationHandler.cs
@@ -13,7 +13,6 @@ using Raven.Client.ServerWide.Tcp;
 using Raven.Server.Config;
 using Raven.Server.Documents.Handlers.Processors.TimeSeries;
 using Raven.Server.Documents.Replication.ReplicationItems;
-using Raven.Server.Documents.Replication.Stats;
 using Raven.Server.Documents.TcpHandlers;
 using Raven.Server.Documents.TimeSeries;
 using Raven.Server.Exceptions;
@@ -299,13 +298,6 @@ namespace Raven.Server.Documents.Replication.Incoming
             LastHeartbeatTicks = _database.Time.GetUtcNow().Ticks;
 
             return heartbeat;
-        }
-
-        public LiveReplicationPerformanceCollector.ReplicationPerformanceType GetReplicationPerformanceType()
-        {
-            return ReplicationType == ReplicationLatestEtagRequest.ReplicationType.Internal
-                ? LiveReplicationPerformanceCollector.ReplicationPerformanceType.IncomingInternal
-                : LiveReplicationPerformanceCollector.ReplicationPerformanceType.IncomingExternal;
         }
 
         protected override void InvokeOnAttachmentStreamsReceived(int attachmentStreamCount) => AttachmentStreamsReceived?.Invoke(this, attachmentStreamCount);

--- a/src/Raven.Server/Documents/Replication/Incoming/IncomingReplicationHandler.cs
+++ b/src/Raven.Server/Documents/Replication/Incoming/IncomingReplicationHandler.cs
@@ -270,11 +270,6 @@ namespace Raven.Server.Documents.Replication.Incoming
                 : LiveReplicationPerformanceCollector.ReplicationPerformanceType.IncomingExternal;
         }
 
-
-        protected override void HandleMissingAttachmentsIfNeeded()
-        {
-        }
-
         protected override Task HandleBatchAsync(DocumentsOperationContext context, DataForReplicationCommand batch, long lastEtag)
         {
             var replicationCommand = GetMergeDocumentsCommand(batch, lastEtag);
@@ -684,8 +679,7 @@ namespace Raven.Server.Documents.Replication.Incoming
             protected virtual void SaveSourceEtag(DocumentsOperationContext context)
             {
                 context.LastReplicationEtagFrom ??= new Dictionary<string, long>();
-                if (_replicationInfo.SourceDatabaseId != null)
-                    context.LastReplicationEtagFrom[_replicationInfo.SourceDatabaseId] = _lastEtag;
+                context.LastReplicationEtagFrom[_replicationInfo.SourceDatabaseId] = _lastEtag;
             }
 
             private static void UpdateTimeSeriesNameIfNeeded(DocumentsOperationContext context, LazyStringValue docId, TimeSeriesReplicationItem segment, TimeSeriesStorage tss)

--- a/src/Raven.Server/Documents/Replication/Incoming/IncomingReplicationHandler.cs
+++ b/src/Raven.Server/Documents/Replication/Incoming/IncomingReplicationHandler.cs
@@ -37,22 +37,18 @@ namespace Raven.Server.Documents.Replication.Incoming
         private readonly DocumentDatabase _database;
         private readonly ReplicationLoader _parent;
 
-        public long LastDocumentEtag => _lastDocumentEtag;
         public long LastHeartbeatTicks;
-        public readonly ReplicationLatestEtagRequest.ReplicationType ReplicationType;
 
         public event Action<IncomingReplicationHandler, Exception> Failed;
         public event Action<IncomingReplicationHandler> DocumentsReceived;
         public event Action<IncomingReplicationHandler, int> AttachmentStreamsReceived;
-
-        public string SourceFormatted => $"{ConnectionInfo.SourceUrl}/databases/{ConnectionInfo.SourceDatabaseName} ({ConnectionInfo.SourceDatabaseId})";
 
         public IncomingReplicationHandler(
             TcpConnectionOptions options,
             ReplicationLatestEtagRequest replicatedLastEtag,
             ReplicationLoader parent,
             JsonOperationContext.MemoryBuffer bufferToCopy,
-            ReplicationLatestEtagRequest.ReplicationType replicationType) : base(options, bufferToCopy, parent._server, parent.Database.Name, replicatedLastEtag,
+            ReplicationLatestEtagRequest.ReplicationType replicationType) : base(options, bufferToCopy, parent._server, parent.Database.Name, replicationType, replicatedLastEtag,
             options.DocumentDatabase.DatabaseShutdown, options.DocumentDatabase.DocumentsStorage.ContextPool)
         {
             _database = options.DocumentDatabase;
@@ -60,7 +56,6 @@ namespace Raven.Server.Documents.Replication.Incoming
             _parent = parent;
             _attachmentStreamsTempFile = _database.DocumentsStorage.AttachmentsStorage.GetTempFile("replication");
 
-            ReplicationType = replicationType;
             LastHeartbeatTicks = _database.Time.GetUtcNow().Ticks;
         }
 

--- a/src/Raven.Server/Documents/Replication/Incoming/IncomingReplicationHandler.cs
+++ b/src/Raven.Server/Documents/Replication/Incoming/IncomingReplicationHandler.cs
@@ -20,15 +20,12 @@ using Raven.Server.Exceptions;
 using Raven.Server.NotificationCenter.Notifications;
 using Raven.Server.ServerWide.Context;
 using Raven.Server.Utils;
-using Sparrow;
 using Sparrow.Json;
 using Sparrow.Json.Parsing;
 using Sparrow.Logging;
-using Sparrow.Platform;
 using Sparrow.Server;
 using Sparrow.Utils;
 using Voron;
-using Size = Sparrow.Size;
 
 namespace Raven.Server.Documents.Replication.Incoming
 {
@@ -99,7 +96,7 @@ namespace Raven.Server.Documents.Replication.Incoming
 
         protected virtual TransactionOperationsMerger.MergedTransactionCommand GetMergeDocumentsCommand(DataForReplicationCommand data, long lastDocumentEtag)
         {
-            return new MergedDocumentReplicationCommand(data, lastDocumentEtag, ReplicationType);
+            return new MergedDocumentReplicationCommand(data, lastDocumentEtag);
         }
 
         internal class MergedUpdateDatabaseChangeVectorCommand : TransactionOperationsMerger.MergedTransactionCommand
@@ -321,17 +318,11 @@ namespace Raven.Server.Documents.Replication.Incoming
         {
             private readonly long _lastEtag;
             private readonly DataForReplicationCommand _replicationInfo;
-            private readonly ReplicationLatestEtagRequest.ReplicationType _replicationType;
 
             public MergedDocumentReplicationCommand(DataForReplicationCommand replicationInfo, long lastEtag)
             {
                 _replicationInfo = replicationInfo;
                 _lastEtag = lastEtag;
-            }
-
-            public MergedDocumentReplicationCommand(DataForReplicationCommand replicationInfo, long lastEtag, ReplicationLatestEtagRequest.ReplicationType replicationType) : this(replicationInfo, lastEtag)
-            {
-                _replicationType = replicationType;
             }
 
             protected virtual ChangeVector PreProcessItem(DocumentsOperationContext context, ReplicationBatchItem item)
@@ -690,7 +681,7 @@ namespace Raven.Server.Documents.Replication.Incoming
             protected virtual void SaveSourceEtag(DocumentsOperationContext context)
             {
                 context.LastReplicationEtagFrom ??= new Dictionary<string, long>();
-                if (_replicationType != ReplicationLatestEtagRequest.ReplicationType.Sharded)
+                if (_replicationInfo.SourceDatabaseId != null)
                     context.LastReplicationEtagFrom[_replicationInfo.SourceDatabaseId] = _lastEtag;
             }
 
@@ -762,105 +753,6 @@ namespace Raven.Server.Documents.Replication.Incoming
                     SourceDatabaseId = _replicationInfo.SourceDatabaseId,
                     ReplicatedAttachmentStreams = replicatedAttachmentStreams
                 };
-            }
-        }
-    }
-
-    public unsafe class IncomingReplicationAllocator : IDisposable
-    {
-        private readonly long _maxSizeForContextUseInBytes;
-        private readonly long _minSizeToAllocateNonContextUseInBytes;
-        public long TotalDocumentsSizeInBytes { get; private set; }
-
-        private List<Allocation> _nativeAllocationList;
-        private Allocation _currentAllocation;
-        private readonly ByteStringContext _allocator;
-
-        public IncomingReplicationAllocator(ByteStringContext allocator, Size? maxSizeToSend)
-        {
-            _allocator = allocator;
-            var maxSizeForContextUse = maxSizeToSend * 2 ?? new Size(128, SizeUnit.Megabytes);
-
-            _maxSizeForContextUseInBytes = maxSizeForContextUse.GetValue(SizeUnit.Bytes);
-            var minSizeToNonContextAllocationInMb = PlatformDetails.Is32Bits ? 4 : 16;
-            _minSizeToAllocateNonContextUseInBytes = new Size(minSizeToNonContextAllocationInMb, SizeUnit.Megabytes).GetValue(SizeUnit.Bytes);
-        }
-
-        public byte* AllocateMemory(int size)
-        {
-            TotalDocumentsSizeInBytes += size;
-            if (TotalDocumentsSizeInBytes <= _maxSizeForContextUseInBytes)
-            {
-                _allocator.Allocate(size, out var output);
-                return output.Ptr;
-            }
-
-            if (_currentAllocation == null || _currentAllocation.Free < size)
-            {
-                // first allocation or we don't have enough space on the currently allocated chunk
-
-                // there can be a document that is larger than the minimum
-                var sizeToAllocate = Math.Max(size, _minSizeToAllocateNonContextUseInBytes);
-
-                var allocation = new Allocation(sizeToAllocate);
-                if (_nativeAllocationList == null)
-                    _nativeAllocationList = new List<Allocation>();
-
-                _nativeAllocationList.Add(allocation);
-                _currentAllocation = allocation;
-            }
-
-            return _currentAllocation.GetMemory(size);
-        }
-
-        public void Dispose()
-        {
-            if (_nativeAllocationList == null)
-                return;
-
-            foreach (var allocation in _nativeAllocationList)
-            {
-                allocation.Dispose();
-            }
-        }
-
-        private class Allocation : IDisposable
-        {
-            private readonly byte* _ptr;
-            private readonly long _allocationSize;
-            private readonly NativeMemory.ThreadStats _threadStats;
-            private long _used;
-            public long Free => _allocationSize - _used;
-
-            public Allocation(long allocationSize)
-            {
-                _ptr = NativeMemory.AllocateMemory(allocationSize, out var threadStats);
-                _allocationSize = allocationSize;
-                _threadStats = threadStats;
-            }
-
-            public byte* GetMemory(long size)
-            {
-                ThrowOnPointerOutOfRange(size);
-
-                var mem = _ptr + _used;
-                _used += size;
-                return mem;
-            }
-
-            [Conditional("DEBUG")]
-            private void ThrowOnPointerOutOfRange(long size)
-            {
-                if (_used + size > _allocationSize)
-                    throw new InvalidOperationException(
-                        $"Not enough space to allocate the requested size: {new Size(size, SizeUnit.Bytes)}, " +
-                        $"used: {new Size(_used, SizeUnit.Bytes)}, " +
-                        $"total allocation size: {new Size(_allocationSize, SizeUnit.Bytes)}");
-            }
-
-            public void Dispose()
-            {
-                NativeMemory.Free(_ptr, _allocationSize, _threadStats);
             }
         }
     }

--- a/src/Raven.Server/Documents/Replication/Incoming/IncomingReplicationHandler.cs
+++ b/src/Raven.Server/Documents/Replication/Incoming/IncomingReplicationHandler.cs
@@ -275,10 +275,6 @@ namespace Raven.Server.Documents.Replication.Incoming
         {
         }
 
-        protected override void HandleTaskCompleteIfNeeded()
-        {
-        }
-
         protected override Task HandleBatchAsync(DocumentsOperationContext context, DataForReplicationCommand batch, long lastEtag)
         {
             var replicationCommand = GetMergeDocumentsCommand(batch, lastEtag);

--- a/src/Raven.Server/Documents/Replication/InterruptibleRead.cs
+++ b/src/Raven.Server/Documents/Replication/InterruptibleRead.cs
@@ -5,6 +5,7 @@ using System.Threading;
 using System.Threading.Tasks;
 using Sparrow.Json;
 using Sparrow.Server;
+using Sparrow.Utils;
 
 namespace Raven.Server.Documents.Replication
 {
@@ -64,6 +65,8 @@ namespace Raven.Server.Documents.Replication
 
             if (interrupt != null)
             {
+                DevelopmentHelper.ShardingToDo(DevelopmentHelper.TeamMember.Shiran, DevelopmentHelper.Severity.Normal, "check if we can avoid the above 'if' (fails only for sharding)");
+
                 if (_previousWait.TryGetValue(interrupt, out Task<Task> task) == false)
                 {
                     _previousWait[interrupt] = task = Task.WhenAny(_prevCall, interrupt.WaitAsync());

--- a/src/Raven.Server/Documents/Replication/Outgoing/AbstractOutgoingReplicationHandler.cs
+++ b/src/Raven.Server/Documents/Replication/Outgoing/AbstractOutgoingReplicationHandler.cs
@@ -177,6 +177,7 @@ namespace Raven.Server.Documents.Replication.Outgoing
                     {
                         InitialHandshake();
                         _tcpConnectionOptions.DocumentDatabase?.RunningTcpConnections.Add(_tcpConnectionOptions);
+                        _tcpConnectionOptions.DatabaseContext?.RunningTcpConnections.Add(_tcpConnectionOptions);
                         Replicate();
                     }
                 }
@@ -353,7 +354,7 @@ namespace Raven.Server.Documents.Replication.Outgoing
             }
         }
 
-        internal ReplicationMessageReply HandleServerResponse(BlittableJsonReaderObject replicationBatchReplyMessage, bool allowNotify)
+        internal virtual ReplicationMessageReply HandleServerResponse(BlittableJsonReaderObject replicationBatchReplyMessage, bool allowNotify)
         {
             replicationBatchReplyMessage.BlittableValidation();
             var replicationBatchReply = JsonDeserializationServer.ReplicationMessageReply(replicationBatchReplyMessage);

--- a/src/Raven.Server/Documents/Replication/Outgoing/DatabaseOutgoingReplicationHandler.cs
+++ b/src/Raven.Server/Documents/Replication/Outgoing/DatabaseOutgoingReplicationHandler.cs
@@ -25,7 +25,7 @@ using Sparrow.Utils;
 
 namespace Raven.Server.Documents.Replication.Outgoing
 {
-    public abstract class DatabaseOutgoingReplicationHandlerBase : AbstractOutgoingReplicationHandler<DocumentsContextPool, DocumentsOperationContext>
+    public abstract class DatabaseOutgoingReplicationHandler : AbstractOutgoingReplicationHandler<DocumentsContextPool, DocumentsOperationContext>
     {
         public const string AlertTitle = "Replication";
 
@@ -34,15 +34,15 @@ namespace Raven.Server.Documents.Replication.Outgoing
         internal readonly ReplicationLoader _parent;
         internal DateTime _lastDocumentSentTime;
 
-        public event Action<DatabaseOutgoingReplicationHandlerBase, Exception> Failed;
+        public event Action<DatabaseOutgoingReplicationHandler, Exception> Failed;
 
-        public event Action<DatabaseOutgoingReplicationHandlerBase> SuccessfulTwoWaysCommunication;
+        public event Action<DatabaseOutgoingReplicationHandler> SuccessfulTwoWaysCommunication;
 
-        public event Action<DatabaseOutgoingReplicationHandlerBase> SuccessfulReplication;
+        public event Action<DatabaseOutgoingReplicationHandler> SuccessfulReplication;
 
-        public event Action<DatabaseOutgoingReplicationHandlerBase> DocumentsSend;
+        public event Action<DatabaseOutgoingReplicationHandler> DocumentsSend;
 
-        protected DatabaseOutgoingReplicationHandlerBase(ReplicationLoader parent, DocumentDatabase database, ReplicationNode node, TcpConnectionInfo connectionInfo)
+        protected DatabaseOutgoingReplicationHandler(ReplicationLoader parent, DocumentDatabase database, ReplicationNode node, TcpConnectionInfo connectionInfo)
         : base(connectionInfo, parent._server, database.Name, node, database.DatabaseShutdown, database.DocumentsStorage.ContextPool)
         {
             _parent = parent;
@@ -72,10 +72,10 @@ namespace Raven.Server.Documents.Replication.Outgoing
                 return true;
             if (obj.GetType() != GetType())
                 return false;
-            return Equals((DatabaseOutgoingReplicationHandlerBase)obj);
+            return Equals((DatabaseOutgoingReplicationHandler)obj);
         }
 
-        public bool Equals(DatabaseOutgoingReplicationHandlerBase other)
+        public bool Equals(DatabaseOutgoingReplicationHandler other)
         {
             return Destination.Equals(other.Destination);
         }

--- a/src/Raven.Server/Documents/Replication/Outgoing/DatabaseOutgoingReplicationHandlerBase.cs
+++ b/src/Raven.Server/Documents/Replication/Outgoing/DatabaseOutgoingReplicationHandlerBase.cs
@@ -1,7 +1,6 @@
 ﻿using System;
 using System.Diagnostics;
 using System.IO;
-using System.Linq;
 using System.Runtime.CompilerServices;
 using System.Security.Cryptography.X509Certificates;
 using System.Threading;
@@ -26,7 +25,7 @@ using Sparrow.Utils;
 
 namespace Raven.Server.Documents.Replication.Outgoing
 {
-    public abstract class OutgoingReplicationHandlerBase : AbstractOutgoingReplicationHandler<DocumentsContextPool, DocumentsOperationContext>, IReportOutgoingReplicationPerformance
+    public abstract class DatabaseOutgoingReplicationHandlerBase : AbstractOutgoingReplicationHandler<DocumentsContextPool, DocumentsOperationContext>
     {
         public const string AlertTitle = "Replication";
 
@@ -35,15 +34,15 @@ namespace Raven.Server.Documents.Replication.Outgoing
         internal readonly ReplicationLoader _parent;
         internal DateTime _lastDocumentSentTime;
 
-        public event Action<OutgoingReplicationHandlerBase, Exception> Failed;
+        public event Action<DatabaseOutgoingReplicationHandlerBase, Exception> Failed;
 
-        public event Action<OutgoingReplicationHandlerBase> SuccessfulTwoWaysCommunication;
+        public event Action<DatabaseOutgoingReplicationHandlerBase> SuccessfulTwoWaysCommunication;
 
-        public event Action<OutgoingReplicationHandlerBase> SuccessfulReplication;
+        public event Action<DatabaseOutgoingReplicationHandlerBase> SuccessfulReplication;
 
-        public event Action<OutgoingReplicationHandlerBase> DocumentsSend;
+        public event Action<DatabaseOutgoingReplicationHandlerBase> DocumentsSend;
 
-        protected OutgoingReplicationHandlerBase(ReplicationLoader parent, DocumentDatabase database, ReplicationNode node, TcpConnectionInfo connectionInfo)
+        protected DatabaseOutgoingReplicationHandlerBase(ReplicationLoader parent, DocumentDatabase database, ReplicationNode node, TcpConnectionInfo connectionInfo)
         : base(connectionInfo, parent._server, database.Name, node, database.DatabaseShutdown, database.DocumentsStorage.ContextPool)
         {
             _parent = parent;
@@ -73,10 +72,10 @@ namespace Raven.Server.Documents.Replication.Outgoing
                 return true;
             if (obj.GetType() != GetType())
                 return false;
-            return Equals((OutgoingReplicationHandlerBase)obj);
+            return Equals((DatabaseOutgoingReplicationHandlerBase)obj);
         }
 
-        public bool Equals(OutgoingReplicationHandlerBase other)
+        public bool Equals(DatabaseOutgoingReplicationHandlerBase other)
         {
             return Destination.Equals(other.Destination);
         }

--- a/src/Raven.Server/Documents/Replication/Outgoing/IAbstractOutgoingReplicationHandler.cs
+++ b/src/Raven.Server/Documents/Replication/Outgoing/IAbstractOutgoingReplicationHandler.cs
@@ -1,6 +1,5 @@
 ﻿using System;
 using Raven.Client.Documents.Replication;
-using Raven.Server.ServerWide;
 
 namespace Raven.Server.Documents.Replication.Outgoing
 {
@@ -11,7 +10,6 @@ namespace Raven.Server.Documents.Replication.Outgoing
         public string LastAcceptedChangeVector { get; set; }
         public ReplicationNode Destination { get; }
         public bool IsConnectionDisposed { get; }
-        public ServerStore Server { get; }
         public string GetNode();
         public void Start();
     }

--- a/src/Raven.Server/Documents/Replication/Outgoing/IAbstractOutgoingReplicationHandler.cs
+++ b/src/Raven.Server/Documents/Replication/Outgoing/IAbstractOutgoingReplicationHandler.cs
@@ -1,0 +1,18 @@
+﻿using System;
+using Raven.Client.Documents.Replication;
+using Raven.Server.ServerWide;
+
+namespace Raven.Server.Documents.Replication.Outgoing
+{
+    public interface IAbstractOutgoingReplicationHandler : IDisposable, IReportOutgoingReplicationPerformance
+    {
+        public ReplicationNode Node { get; }
+        public long LastSentDocumentEtag { get; }
+        public string LastAcceptedChangeVector { get; set; }
+        public ReplicationNode Destination { get; }
+        public bool IsConnectionDisposed { get; }
+        public ServerStore Server { get; }
+        public string GetNode();
+        public void Start();
+    }
+}

--- a/src/Raven.Server/Documents/Replication/Outgoing/OutgoingExternalReplicationHandler.cs
+++ b/src/Raven.Server/Documents/Replication/Outgoing/OutgoingExternalReplicationHandler.cs
@@ -10,7 +10,7 @@ using Sparrow.Logging;
 
 namespace Raven.Server.Documents.Replication.Outgoing
 {
-    public class OutgoingExternalReplicationHandler : DatabaseOutgoingReplicationHandlerBase
+    public class OutgoingExternalReplicationHandler : DatabaseOutgoingReplicationHandler
     {
         private long? _taskId;
 

--- a/src/Raven.Server/Documents/Replication/Outgoing/OutgoingExternalReplicationHandler.cs
+++ b/src/Raven.Server/Documents/Replication/Outgoing/OutgoingExternalReplicationHandler.cs
@@ -10,7 +10,7 @@ using Sparrow.Logging;
 
 namespace Raven.Server.Documents.Replication.Outgoing
 {
-    public class OutgoingExternalReplicationHandler : OutgoingReplicationHandlerBase
+    public class OutgoingExternalReplicationHandler : DatabaseOutgoingReplicationHandlerBase
     {
         private long? _taskId;
 

--- a/src/Raven.Server/Documents/Replication/Outgoing/OutgoingInternalReplicationHandler.cs
+++ b/src/Raven.Server/Documents/Replication/Outgoing/OutgoingInternalReplicationHandler.cs
@@ -13,7 +13,7 @@ using Sparrow.Server;
 
 namespace Raven.Server.Documents.Replication.Outgoing
 {
-    public class OutgoingInternalReplicationHandler : DatabaseOutgoingReplicationHandlerBase
+    public class OutgoingInternalReplicationHandler : DatabaseOutgoingReplicationHandler
     {
         private long _lastDestinationEtag;
 

--- a/src/Raven.Server/Documents/Replication/Outgoing/OutgoingInternalReplicationHandler.cs
+++ b/src/Raven.Server/Documents/Replication/Outgoing/OutgoingInternalReplicationHandler.cs
@@ -13,7 +13,7 @@ using Sparrow.Server;
 
 namespace Raven.Server.Documents.Replication.Outgoing
 {
-    public class OutgoingInternalReplicationHandler : OutgoingReplicationHandlerBase
+    public class OutgoingInternalReplicationHandler : DatabaseOutgoingReplicationHandlerBase
     {
         private long _lastDestinationEtag;
 

--- a/src/Raven.Server/Documents/Replication/Outgoing/OutgoingMigrationReplicationHandler.cs
+++ b/src/Raven.Server/Documents/Replication/Outgoing/OutgoingMigrationReplicationHandler.cs
@@ -6,7 +6,7 @@ using Sparrow.Logging;
 
 namespace Raven.Server.Documents.Replication.Outgoing
 {
-    public class OutgoingMigrationReplicationHandler : DatabaseOutgoingReplicationHandlerBase
+    public class OutgoingMigrationReplicationHandler : DatabaseOutgoingReplicationHandler
     {
         public readonly BucketMigrationReplication BucketMigrationNode;
         public OutgoingMigrationReplicationHandler(ReplicationLoader parent, DocumentDatabase database, BucketMigrationReplication node, TcpConnectionInfo connectionInfo) : base(parent, database, node, connectionInfo)

--- a/src/Raven.Server/Documents/Replication/Outgoing/OutgoingMigrationReplicationHandler.cs
+++ b/src/Raven.Server/Documents/Replication/Outgoing/OutgoingMigrationReplicationHandler.cs
@@ -6,7 +6,7 @@ using Sparrow.Logging;
 
 namespace Raven.Server.Documents.Replication.Outgoing
 {
-    public class OutgoingMigrationReplicationHandler : OutgoingReplicationHandlerBase
+    public class OutgoingMigrationReplicationHandler : DatabaseOutgoingReplicationHandlerBase
     {
         public readonly BucketMigrationReplication BucketMigrationNode;
         public OutgoingMigrationReplicationHandler(ReplicationLoader parent, DocumentDatabase database, BucketMigrationReplication node, TcpConnectionInfo connectionInfo) : base(parent, database, node, connectionInfo)

--- a/src/Raven.Server/Documents/Replication/Outgoing/OutgoingPullReplicationHandler.cs
+++ b/src/Raven.Server/Documents/Replication/Outgoing/OutgoingPullReplicationHandler.cs
@@ -9,7 +9,7 @@ using Sparrow.Logging;
 
 namespace Raven.Server.Documents.Replication.Outgoing
 {
-    public abstract class OutgoingPullReplicationHandler : DatabaseOutgoingReplicationHandlerBase
+    public abstract class OutgoingPullReplicationHandler : DatabaseOutgoingReplicationHandler
     {
         public string[] PathsToSend;
         private string[] _destinationAcceptablePaths;

--- a/src/Raven.Server/Documents/Replication/Outgoing/OutgoingPullReplicationHandler.cs
+++ b/src/Raven.Server/Documents/Replication/Outgoing/OutgoingPullReplicationHandler.cs
@@ -9,7 +9,7 @@ using Sparrow.Logging;
 
 namespace Raven.Server.Documents.Replication.Outgoing
 {
-    public abstract class OutgoingPullReplicationHandler : OutgoingReplicationHandlerBase
+    public abstract class OutgoingPullReplicationHandler : DatabaseOutgoingReplicationHandlerBase
     {
         public string[] PathsToSend;
         private string[] _destinationAcceptablePaths;

--- a/src/Raven.Server/Documents/Replication/Outgoing/OutgoingReplicationHandlerBase.cs
+++ b/src/Raven.Server/Documents/Replication/Outgoing/OutgoingReplicationHandlerBase.cs
@@ -43,8 +43,6 @@ namespace Raven.Server.Documents.Replication.Outgoing
 
         public event Action<OutgoingReplicationHandlerBase> DocumentsSend;
 
-        private OutgoingReplicationStatsAggregator _lastStats;
-
         protected OutgoingReplicationHandlerBase(ReplicationLoader parent, DocumentDatabase database, ReplicationNode node, TcpConnectionInfo connectionInfo)
         : base(connectionInfo, parent._server, database.Name, node, database.DatabaseShutdown, database.DocumentsStorage.ContextPool)
         {
@@ -83,15 +81,7 @@ namespace Raven.Server.Documents.Replication.Outgoing
             return Destination.Equals(other.Destination);
         }
 
-        public OutgoingReplicationPerformanceStats[] GetReplicationPerformance()
-        {
-            var lastStats = _lastStats;
-
-            return _lastReplicationStats
-                .Select(x => x == lastStats ? x.ToReplicationPerformanceLiveStatsWithDetails() : x.ToReplicationPerformanceStats())
-                .ToArray();
-        }
-
+    
         public LiveReplicationPerformanceCollector.ReplicationPerformanceType GetReplicationPerformanceType()
         {
             switch (this)
@@ -383,9 +373,6 @@ namespace Raven.Server.Documents.Replication.Outgoing
                 }
             }
         }
-
-        public ReplicationNode Node => Destination;
-        public string DestinationFormatted => $"{Destination.Url}/databases/{Destination.Database}";
 
         protected override long GetLastHeartbeatTicks() => _parent.Database.Time.GetUtcNow().Ticks;
 

--- a/src/Raven.Server/Documents/Replication/ReplicationLoader.cs
+++ b/src/Raven.Server/Documents/Replication/ReplicationLoader.cs
@@ -9,7 +9,6 @@ using System.Threading.Tasks;
 using Raven.Client;
 using Raven.Client.Documents.Commands;
 using Raven.Client.Documents.Conventions;
-using Raven.Client.Documents.Operations.ETL;
 using Raven.Client.Documents.Operations.OngoingTasks;
 using Raven.Client.Documents.Operations.Replication;
 using Raven.Client.Documents.Replication;
@@ -17,7 +16,6 @@ using Raven.Client.Documents.Replication.Messages;
 using Raven.Client.Exceptions.Database;
 using Raven.Client.Exceptions.Security;
 using Raven.Client.Http;
-using Raven.Client.Json.Serialization;
 using Raven.Client.ServerWide;
 using Raven.Client.ServerWide.Commands;
 using Raven.Client.ServerWide.Tcp;
@@ -29,7 +27,6 @@ using Raven.Server.Documents.Replication.ReplicationItems;
 using Raven.Server.Documents.Replication.Stats;
 using Raven.Server.Documents.TcpHandlers;
 using Raven.Server.Extensions;
-using Raven.Server.Json;
 using Raven.Server.NotificationCenter.Notifications;
 using Raven.Server.ServerWide;
 using Raven.Server.ServerWide.Commands;
@@ -38,16 +35,13 @@ using Raven.Server.Utils;
 using Sparrow.Collections;
 using Sparrow.Json;
 using Sparrow.Json.Parsing;
-using Sparrow.Json.Sync;
-using Sparrow.Logging;
-using Sparrow.Server.Json.Sync;
 using Sparrow.Server.Utils;
 using Sparrow.Threading;
 using Sparrow.Utils;
 
 namespace Raven.Server.Documents.Replication
 {
-    public class ReplicationLoader : IDisposable, ITombstoneAware
+    public class ReplicationLoader : AbstractReplicationLoader, IDisposable, ITombstoneAware
     {
         private readonly ReaderWriterLockSlim _locker = new ReaderWriterLockSlim();
 
@@ -64,16 +58,10 @@ namespace Raven.Server.Documents.Replication
         public DocumentDatabase Database;
         private SingleUseFlag _isInitialized = new SingleUseFlag();
 
-        private readonly Timer _reconnectAttemptTimer;
-        internal readonly int MinimalHeartbeatInterval;
-
         public ResolveConflictOnReplicationConfigurationChange ConflictResolver;
 
         private readonly ConcurrentSet<OutgoingReplicationHandlerBase> _outgoing =
             new ConcurrentSet<OutgoingReplicationHandlerBase>();
-
-        private readonly ConcurrentDictionary<ReplicationNode, ConnectionShutdownInfo> _outgoingFailureInfo =
-            new ConcurrentDictionary<ReplicationNode, ConnectionShutdownInfo>();
 
         private readonly ConcurrentDictionary<string, IncomingReplicationHandler> _incoming =
             new ConcurrentDictionary<string, IncomingReplicationHandler>();
@@ -84,9 +72,6 @@ namespace Raven.Server.Documents.Replication
         private readonly ConcurrentDictionary<IncomingConnectionInfo, ConcurrentQueue<IncomingConnectionRejectionInfo>>
             _incomingRejectionStats =
                 new ConcurrentDictionary<IncomingConnectionInfo, ConcurrentQueue<IncomingConnectionRejectionInfo>>();
-
-        private readonly ConcurrentSet<ConnectionShutdownInfo> _reconnectQueue =
-            new ConcurrentSet<ConnectionShutdownInfo>();
 
         private readonly ConcurrentBag<ReplicationNode> _internalDestinations = new ConcurrentBag<ReplicationNode>();
         private readonly HashSet<ExternalReplicationBase> _externalDestinations = new HashSet<ExternalReplicationBase>();
@@ -105,8 +90,6 @@ namespace Raven.Server.Documents.Replication
         {
             public long LastEtag;
         }
-
-        private int _replicationStatsId;
 
         private readonly ConcurrentDictionary<ReplicationNode, LastEtagPerDestination> _lastSendEtagPerDestination =
             new ConcurrentDictionary<ReplicationNode, LastEtagPerDestination>();
@@ -231,8 +214,6 @@ namespace Raven.Server.Documents.Replication
             }
         }
 
-        private readonly Logger _log;
-
         // PERF: _incoming locks if you do _incoming.Values. Using .Select
         // directly and fetching the Value avoids this problem.
         public IEnumerable<IncomingConnectionInfo> IncomingConnections => _incoming.Select(x => x.Value.ConnectionInfo);
@@ -247,27 +228,17 @@ namespace Raven.Server.Documents.Replication
         private readonly ConcurrentQueue<TaskCompletionSource<object>> _waitForReplicationTasks =
             new ConcurrentQueue<TaskCompletionSource<object>>();
 
-        internal readonly ServerStore _server;
-
         public List<ReplicationNode> Destinations => _destinations;
         private List<ReplicationNode> _destinations = new List<ReplicationNode>();
         private ClusterTopology _clusterTopology = new ClusterTopology();
         private int _numberOfSiblings;
         public ConflictSolver ConflictSolverConfig;
         private readonly CancellationToken _shutdownToken;
-        public ReplicationLoader(DocumentDatabase database, ServerStore server)
-        {
 
-            _server = server;
+        public ReplicationLoader(DocumentDatabase database, ServerStore server) : base(server, database.Name, database.Configuration)
+        {
             Database = database;
             _shutdownToken = database.DatabaseShutdown;
-
-            var config = Database.Configuration.Replication;
-            var reconnectTime = config.RetryReplicateAfter.AsTimeSpan;
-            _log = LoggingSource.Instance.GetLogger<ReplicationLoader>(Database.Name);
-            _reconnectAttemptTimer = new Timer(state => ForceTryReconnectAll(),
-                null, reconnectTime, reconnectTime);
-            MinimalHeartbeatInterval = (int)config.ReplicationMinimalHeartbeat.AsTimeSpan.TotalMilliseconds;
             database.TombstoneCleaner.Subscribe(this);
             server.Cluster.Changes.DatabaseChanged += DatabaseValueChanged;
         }
@@ -322,8 +293,8 @@ namespace Raven.Server.Documents.Replication
 
                     try
                     {
-                        if (_log.IsInfoEnabled)
-                            _log.Info($"Resetting {repl.ConnectionInfo} for {hub} on {certThumbprint} because replication configuration changed. Will be reconnected.");
+                        if (_logger.IsInfoEnabled)
+                            _logger.Info($"Resetting {repl.ConnectionInfo} for {hub} on {certThumbprint} because replication configuration changed. Will be reconnected.");
                         repl.Dispose();
                     }
                     catch
@@ -353,9 +324,6 @@ namespace Raven.Server.Documents.Replication
             }
         }
 
-        public IReadOnlyDictionary<ReplicationNode, ConnectionShutdownInfo> OutgoingFailureInfo
-            => _outgoingFailureInfo;
-
         public IReadOnlyDictionary<IncomingConnectionInfo, DateTime> IncomingLastActivityTime
             => _incomingLastActivityTime;
 
@@ -379,19 +347,8 @@ namespace Raven.Server.Documents.Replication
             X509Certificate2 certificate,
             JsonOperationContext.MemoryBuffer buffer)
         {
-            var supportedVersions =
-                TcpConnectionHeaderMessage.GetSupportedFeaturesFor(TcpConnectionHeaderMessage.OperationTypes.Replication, tcpConnectionOptions.ProtocolVersion);
-
-            ReplicationInitialRequest initialRequest = null;
-            if (supportedVersions.Replication.PullReplication)
-            {
-                using (tcpConnectionOptions.ContextPool.AllocateOperationContext(out JsonOperationContext context))
-                using (var readerObject = context.Sync.ParseToMemory(tcpConnectionOptions.Stream, "initial-replication-message",
-                    BlittableJsonDocumentBuilder.UsageMode.None, buffer))
-                {
-                    initialRequest = JsonDeserializationServer.ReplicationInitialRequest(readerObject);
-                }
-            }
+            var supportedVersions = GetSupportedVersions(tcpConnectionOptions);
+            var initialRequest = GetReplicationInitialRequest(tcpConnectionOptions, supportedVersions, buffer);
 
             string[] allowedPaths = default;
             string pullDefinitionName = null;
@@ -561,8 +518,8 @@ namespace Raven.Server.Documents.Replication
                         instance.Failed -= RetryPullReplication;
                         instance.DocumentsReceived -= OnIncomingReceiveSucceeded;
                         instance.AttachmentStreamsReceived -= OnAttachmentStreamsReceived;
-                        if (_log.IsInfoEnabled)
-                            _log.Info($"Pull replication Sink handler has thrown an unhandled exception. ({instance.FromToString})", e);
+                        if (_logger.IsInfoEnabled)
+                            _logger.Info($"Pull replication Sink handler has thrown an unhandled exception. ({instance.FromToString})", e);
                     }
 
                     // if the stream closed, it is our duty to reconnect
@@ -599,9 +556,9 @@ namespace Raven.Server.Documents.Replication
                 }
                 else
                 {
-                    if (_log.IsInfoEnabled)
+                    if (_logger.IsInfoEnabled)
                     {
-                        _log.Info("you can't add two identical connections.", new InvalidOperationException("you can't add two identical connections."));
+                        _logger.Info("you can't add two identical connections.", new InvalidOperationException("you can't add two identical connections."));
                     }
                     newIncoming.Dispose();
                 }
@@ -629,7 +586,7 @@ namespace Raven.Server.Documents.Replication
             JsonOperationContext.MemoryBuffer buffer,
             PullReplicationParams incomingPullParams)
         {
-            var getLatestEtagMessage = IncomingInitialHandshake(tcpConnectionOptions, incomingPullParams, buffer);
+            var getLatestEtagMessage = IncomingInitialHandshake(tcpConnectionOptions, buffer, incomingPullParams);
 
             IncomingReplicationHandler newIncoming;
 
@@ -667,189 +624,38 @@ namespace Raven.Server.Documents.Replication
             return newIncoming;
         }
 
-        private ReplicationLatestEtagRequest IncomingInitialHandshake(TcpConnectionOptions tcpConnectionOptions, PullReplicationParams replParams, JsonOperationContext.MemoryBuffer buffer)
-        {
-            ReplicationLatestEtagRequest getLatestEtagMessage;
-
-            using (tcpConnectionOptions.ContextPool.AllocateOperationContext(out JsonOperationContext context))
-            using (var readerObject = context.Sync.ParseToMemory(
-                tcpConnectionOptions.Stream,
-                "IncomingReplication/get-last-etag-message read",
-                BlittableJsonDocumentBuilder.UsageMode.None,
-                buffer))
-            {
-                var exceptionSchema = JsonDeserializationClient.ExceptionSchema(readerObject);
-                if (exceptionSchema.Type.Equals("Error"))
-                    throw new Exception(exceptionSchema.Message);
-
-                getLatestEtagMessage = JsonDeserializationServer.ReplicationLatestEtagRequest(readerObject);
-                if (_log.IsInfoEnabled)
-                {
-                    _log.Info(
-                        $"GetLastEtag: {getLatestEtagMessage.SourceTag}({getLatestEtagMessage.SourceMachineName}) / {getLatestEtagMessage.SourceDatabaseName} ({getLatestEtagMessage.SourceDatabaseId}) - {getLatestEtagMessage.SourceUrl}. Type: {getLatestEtagMessage.ReplicationsType}");
-                }
-            }
-
-            var connectionInfo = IncomingConnectionInfo.FromGetLatestEtag(getLatestEtagMessage);
-            try
-            {
-                AssertValidConnection(connectionInfo);
-            }
-            catch (Exception e)
-            {
-                if (_log.IsInfoEnabled)
-                    _log.Info($"Connection from [{connectionInfo}] is rejected.", e);
-
-                var incomingConnectionRejectionInfos = _incomingRejectionStats.GetOrAdd(connectionInfo,
-                    _ => new ConcurrentQueue<IncomingConnectionRejectionInfo>());
-                incomingConnectionRejectionInfos.Enqueue(new IncomingConnectionRejectionInfo { Reason = e.ToString() });
-
-                throw;
-            }
-
-            try
-            {
-                using (Database.DocumentsStorage.ContextPool.AllocateOperationContext(out DocumentsOperationContext documentsContext))
-                using (Database.ConfigurationStorage.ContextPool.AllocateOperationContext(out TransactionOperationContext configurationContext))
-                using (var writer = new BlittableJsonTextWriter(documentsContext, tcpConnectionOptions.Stream))
-                using (documentsContext.OpenReadTransaction())
-                using (configurationContext.OpenReadTransaction())
-                {
-                    string changeVector = null;
-                    long lastEtagFromSrc = 0;
-
-                    if (getLatestEtagMessage.ReplicationsType != ReplicationLatestEtagRequest.ReplicationType.Migration &&
-                        ShardHelper.IsShardedName(Database.Name) == false)
-                    {
-                        changeVector = DocumentsStorage.GetFullDatabaseChangeVector(documentsContext);
-
-                        lastEtagFromSrc = DocumentsStorage.GetLastReplicatedEtagFrom(
-                        documentsContext, getLatestEtagMessage.SourceDatabaseId);
-                        if (_log.IsInfoEnabled)
-                            _log.Info($"GetLastEtag response, last etag: {lastEtagFromSrc}");
-                    }
-
-                    var response = new DynamicJsonValue
-                    {
-                        [nameof(ReplicationMessageReply.Type)] = nameof(ReplicationMessageReply.ReplyType.Ok),
-                        [nameof(ReplicationMessageReply.MessageType)] = ReplicationMessageType.Heartbeat,
-                        [nameof(ReplicationMessageReply.LastEtagAccepted)] = lastEtagFromSrc,
-                        [nameof(ReplicationMessageReply.NodeTag)] = _server.NodeTag,
-                        [nameof(ReplicationMessageReply.DatabaseChangeVector)] = changeVector,
-                        [nameof(ReplicationMessageReply.AcceptablePaths)] = replParams?.AllowedPaths,
-                        [nameof(ReplicationMessageReply.PreventDeletionsMode)] = replParams?.PreventDeletionsMode
-                    };
-
-                    documentsContext.Write(writer, response);
-                    writer.Flush();
-                }
-            }
-            catch (Exception)
-            {
-                try
-                {
-                    tcpConnectionOptions.Dispose();
-                }
-                catch (Exception)
-                {
-                    // do nothing
-                }
-
-                throw;
-            }
-
-            if (_log.IsInfoEnabled)
-                _log.Info(
-                    $"Initialized document replication connection from {connectionInfo.SourceDatabaseName} located at {connectionInfo.SourceUrl}");
-
-            return getLatestEtagMessage;
-        }
-
-        private long _reconnectInProgress;
-
-        private void ForceTryReconnectAll()
-        {
-            if (_reconnectQueue.Count == 0)
-                return;
-
-            if (Interlocked.CompareExchange(ref _reconnectInProgress, 1, 0) == 1)
-                return;
-
-            try
-            {
-                DatabaseTopology topology;
-                Dictionary<string, RavenConnectionString> ravenConnectionStrings;
-
-                using (_server.ContextPool.AllocateOperationContext(out TransactionOperationContext ctx))
-                using (ctx.OpenReadTransaction())
-                {
-                    var raw = _server.Cluster.ReadRawDatabaseRecord(ctx, Database.Name);
-                    if (raw == null)
-                    {
-                        _reconnectQueue.Clear();
-                        return;
-                    }
-
-                    topology = raw.Topology;
-                    ravenConnectionStrings = raw.RavenConnectionStrings;
-                }
-
-                foreach (var failure in _reconnectQueue)
-                {
-                    if (Database.DatabaseShutdown.IsCancellationRequested)
-                        return;
-
-                    try
-                    {
-                        if (_reconnectQueue.TryRemove(failure) == false)
-                            continue;
-
-                        if (_outgoingFailureInfo.Values.Contains(failure) == false)
-                            continue; // this connection is no longer exists
-
-                        if (failure.RetryOn > DateTime.UtcNow)
-                        {
-                            _reconnectQueue.Add(failure);
-                            continue;
-                        }
-
-                        if (failure.Node is ExternalReplicationBase exNode &&
-                            IsMyTask(ravenConnectionStrings, topology, exNode) == false)
-                            // no longer my task
-                            continue;
-
-                        if (failure.Node is BucketMigrationReplication migration &&
-                            topology.WhoseTaskIsIt(RachisState.Follower, migration.ShardBucketMigration, getLastResponsibleNode: null) != _server.NodeTag)
-                            // no longer my task
-                            continue;
-
-                        AddAndStartOutgoingReplication(failure.Node);
-                    }
-                    catch (Exception e)
-                    {
-                        if (_log.IsOperationsEnabled)
-                        {
-                            _log.Operations($"Failed to start outgoing replication to {failure.Node}", e);
-                        }
-                    }
-                }
-            }
-            catch (Exception e)
-            {
-                if (_log.IsOperationsEnabled)
-                {
-                    _log.Operations("Unexpected exception during ForceTryReconnectAll", e);
-                }
-            }
-            finally
-            {
-                Interlocked.Exchange(ref _reconnectInProgress, 0);
-            }
-        }
-
         internal static readonly TimeSpan MaxInactiveTime = TimeSpan.FromSeconds(60);
 
-        private void AssertValidConnection(IncomingConnectionInfo connectionInfo)
+        protected override DynamicJsonValue GetInitialRequestMessage(ReplicationLatestEtagRequest getLatestEtagMessage, PullReplicationParams replParams = null)
+        {
+            using (Database.DocumentsStorage.ContextPool.AllocateOperationContext(out DocumentsOperationContext documentsContext))
+            using (Database.ConfigurationStorage.ContextPool.AllocateOperationContext(out TransactionOperationContext configurationContext))
+            using (documentsContext.OpenReadTransaction())
+            using (configurationContext.OpenReadTransaction())
+            {
+                string changeVector = null;
+                long lastEtagFromSrc = 0;
+
+                if (getLatestEtagMessage.ReplicationsType != ReplicationLatestEtagRequest.ReplicationType.Migration &&
+                    ShardHelper.IsShardedName(Database.Name) == false)
+                {
+                    changeVector = DocumentsStorage.GetFullDatabaseChangeVector(documentsContext);
+
+                    lastEtagFromSrc = DocumentsStorage.GetLastReplicatedEtagFrom(
+                        documentsContext, getLatestEtagMessage.SourceDatabaseId);
+                    if (_logger.IsInfoEnabled)
+                        _logger.Info($"GetLastEtag response, last etag: {lastEtagFromSrc}");
+                }
+
+                var response = base.GetInitialRequestMessage(getLatestEtagMessage, replParams);
+                response[nameof(ReplicationMessageReply.LastEtagAccepted)] = lastEtagFromSrc;
+                response[nameof(ReplicationMessageReply.DatabaseChangeVector)] = changeVector;
+
+                return response;
+            }
+        }
+
+        protected override void AssertValidConnection(IncomingConnectionInfo connectionInfo)
         {
             //precaution, should never happen..
             if (string.IsNullOrWhiteSpace(connectionInfo.SourceDatabaseId) ||
@@ -865,11 +671,7 @@ namespace Raven.Server.Documents.Replication
                     $"Cannot have replication with source and destination being the same database. They share the same db id ({connectionInfo} - {Database.DbId})");
             }
 
-            if (_server.IsPassive())
-            {
-                throw new InvalidOperationException(
-                    $"Cannot accept the incoming replication connection from {connectionInfo.SourceUrl}, because this node is in passive state.");
-            }
+            base.AssertValidConnection(connectionInfo);
 
             if (_incoming.TryGetValue(connectionInfo.SourceDatabaseId, out var value))
             {
@@ -878,22 +680,13 @@ namespace Raven.Server.Documents.Replication
                     throw new InvalidOperationException(
                         $"An active connection for this database already exists from {value.ConnectionInfo.SourceUrl} (last heartbeat: {lastHeartbeat}).");
 
-                if (_log.IsInfoEnabled)
-                    _log.Info($"Disconnecting existing connection from {value.FromToString} because we got a new connection from the same source db " +
+                if (_logger.IsInfoEnabled)
+                    _logger.Info($"Disconnecting existing connection from {value.FromToString} because we got a new connection from the same source db " +
                               $"(last heartbeat was at {lastHeartbeat}).");
 
                 IncomingReplicationRemoved?.Invoke(value);
 
                 value.Dispose();
-            }
-        }
-
-        public ClusterTopology GetClusterTopology()
-        {
-            using (_server.ContextPool.AllocateOperationContext(out TransactionOperationContext ctx))
-            using (ctx.OpenReadTransaction())
-            {
-                return _server.GetClusterTopology(ctx);
             }
         }
 
@@ -903,7 +696,7 @@ namespace Raven.Server.Documents.Replication
                 return;
 
             ConflictSolverConfig = record.ConflictSolverConfig;
-            ConflictResolver = new ResolveConflictOnReplicationConfigurationChange(this, _log);
+            ConflictResolver = new ResolveConflictOnReplicationConfigurationChange(this, _logger);
             Task.Run(() => ConflictResolver.RunConflictResolversOnce(record.ConflictSolverConfig, index));
             _isInitialized.Raise();
         }
@@ -950,9 +743,9 @@ namespace Raven.Server.Documents.Replication
             var conflictSolverChanged = ConflictSolverConfig?.ConflictResolutionChanged(newRecord.ConflictSolverConfig) ?? true;
             if (conflictSolverChanged)
             {
-                if (_log.IsInfoEnabled)
+                if (_logger.IsInfoEnabled)
                 {
-                    _log.Info("Conflict resolution was change.");
+                    _logger.Info("Conflict resolution was change.");
                 }
                 ConflictSolverConfig = newRecord.ConflictSolverConfig;
                 Task.Run(() => ConflictResolver.RunConflictResolversOnce(newRecord.ConflictSolverConfig, index));
@@ -1060,15 +853,6 @@ namespace Raven.Server.Documents.Replication
             }
         }
 
-        private DatabaseTopology GetTopologyForShard(int shard)
-        {
-            using (_server.ContextPool.AllocateOperationContext(out TransactionOperationContext ctx))
-            using (ctx.OpenReadTransaction())
-            {
-                return _server.Cluster.ReadDatabaseTopologyForShard(ctx, ShardHelper.ToDatabaseName(Database.Name), shard);
-            }
-        }
-
         private void HandleHubPullReplication(DatabaseRecord newRecord, List<IDisposable> instancesToDispose)
         {
             foreach (var instance in OutgoingHandlers)
@@ -1091,8 +875,8 @@ namespace Raven.Server.Documents.Replication
                     continue;
                 }
 
-                if (_log.IsInfoEnabled)
-                    _log.Info($"Stopping replication to {instance.Destination.FromString()}");
+                if (_logger.IsInfoEnabled)
+                    _logger.Info($"Stopping replication to {instance.Destination.FromString()}");
 
                 instance.Failed -= OnOutgoingSendingFailed;
                 instance.SuccessfulTwoWaysCommunication -= OnOutgoingSendingSucceeded;
@@ -1138,20 +922,20 @@ namespace Raven.Server.Documents.Replication
                     }
                     catch (Exception e)
                     {
-                        if (_log.IsInfoEnabled)
+                        if (_logger.IsInfoEnabled)
                         {
                             switch (instance)
                             {
                                 case OutgoingReplicationHandlerBase outHandler:
-                                    _log.Info($"Failed to dispose outgoing replication to {outHandler.DestinationFormatted}", e);
+                                    _logger.Info($"Failed to dispose outgoing replication to {outHandler.DestinationFormatted}", e);
                                     break;
 
                                 case IncomingReplicationHandler inHandler:
-                                    _log.Info($"Failed to dispose incoming replication to {inHandler.SourceFormatted}", e);
+                                    _logger.Info($"Failed to dispose incoming replication to {inHandler.SourceFormatted}", e);
                                     break;
 
                                 default:
-                                    _log.Info($"Failed to dispose an unknown type '{instance?.GetType()}", e);
+                                    _logger.Info($"Failed to dispose an unknown type '{instance?.GetType()}", e);
                                     break;
                             }
                         }
@@ -1242,8 +1026,8 @@ namespace Raven.Server.Documents.Replication
                     }
                     catch (Exception e)
                     {
-                        if (_log.IsOperationsEnabled)
-                            _log.Operations($"Failed to start the outgoing connections to {newDestinations.Count} new destinations", e);
+                        if (_logger.IsOperationsEnabled)
+                            _logger.Operations($"Failed to start the outgoing connections to {newDestinations.Count} new destinations", e);
                     }
                 });
             }
@@ -1303,46 +1087,7 @@ namespace Raven.Server.Documents.Replication
             return added.Where(configuration => IsMyTask(newRecord.RavenConnectionStrings, newRecord.Topology, configuration)).ToList();
         }
 
-        private bool IsMyTask(Dictionary<string, RavenConnectionString> connectionStrings, DatabaseTopology topology, ExternalReplicationBase task)
-        {
-            if (ValidateConnectionString(connectionStrings, task, out _) == false)
-                return false;
-
-            var taskStatus = GetExternalReplicationState(_server, Database.Name, task.TaskId);
-            var whoseTaskIsIt = Database.WhoseTaskIsIt(topology, task, taskStatus);
-            return whoseTaskIsIt == _server.NodeTag;
-        }
-
-        public static ExternalReplicationState GetExternalReplicationState(ServerStore server, string database, long taskId)
-        {
-            using (server.ContextPool.AllocateOperationContext(out TransactionOperationContext context))
-            using (context.OpenReadTransaction())
-            {
-                return GetExternalReplicationState(server, database, taskId, context);
-            }
-        }
-
-        private static ExternalReplicationState GetExternalReplicationState(ServerStore server, string database, long taskId, TransactionOperationContext context)
-        {
-            var stateBlittable = server.Cluster.Read(context, ExternalReplicationState.GenerateItemName(database, taskId));
-
-            return stateBlittable != null ? JsonDeserializationCluster.ExternalReplicationState(stateBlittable) : new ExternalReplicationState();
-        }
-
-        public void EnsureNotDeleted(string node)
-        {
-            using (_server.ContextPool.AllocateOperationContext(out TransactionOperationContext ctx))
-            using (ctx.OpenReadTransaction())
-            {
-                using (var rawRecord = _server.Cluster.ReadRawDatabaseRecord(ctx, Database.Name))
-                {
-                    if (rawRecord != null && rawRecord.DeletionInProgress.ContainsKey(node))
-                    {
-                        throw new OperationCanceledException($"The database '{Database.Name}' on node '{node}' is being deleted, so it will not handle replications.");
-                    }
-                }
-            }
-        }
+        protected override CancellationToken GetCancellationToken() => Database.DatabaseShutdown;
 
         public void CompleteDeletionIfNeeded(CancellationTokenSource cts)
         {
@@ -1377,59 +1122,15 @@ namespace Raven.Server.Documents.Replication
                             }
                             catch (Exception e)
                             {
-                                if (_log.IsOperationsEnabled)
+                                if (_logger.IsOperationsEnabled)
                                 {
-                                    _log.Operations("Unexpected error during database deletion from replication loader", e);
+                                    _logger.Operations("Unexpected error during database deletion from replication loader", e);
                                 }
                             }
                         }
                         , null);
                 }
             }
-        }
-
-        private bool ValidateConnectionString(Dictionary<string, RavenConnectionString> ravenConnectionStrings, ExternalReplicationBase externalReplication, out RavenConnectionString connectionString)
-        {
-            connectionString = null;
-            if (string.IsNullOrEmpty(externalReplication.ConnectionStringName))
-            {
-                var msg = $"The external replication {externalReplication.Name} to the database '{externalReplication.Database}' " +
-                          "has an empty connection string name.";
-
-                if (_log.IsInfoEnabled)
-                {
-                    _log.Info(msg);
-                }
-
-                _server.NotificationCenter.Add(AlertRaised.Create(
-                    Database.Name,
-                    "Connection string name is empty",
-                    msg,
-                    AlertType.Replication,
-                    NotificationSeverity.Error));
-                return false;
-            }
-
-            if (ravenConnectionStrings.TryGetValue(externalReplication.ConnectionStringName, out connectionString) == false)
-            {
-                var msg = $"Could not find connection string with name {externalReplication.ConnectionStringName} " +
-                          $"for the external replication task '{externalReplication.Name}' to '{externalReplication.Database}'.";
-
-                if (_log.IsInfoEnabled)
-                {
-                    _log.Info(msg);
-                }
-
-                _server.NotificationCenter.Add(AlertRaised.Create(
-                    Database.Name,
-                    "Connection string not found",
-                    msg,
-                    AlertType.Replication,
-                    NotificationSeverity.Error));
-
-                return false;
-            }
-            return true;
         }
 
         private void HandleInternalReplication(DatabaseRecord newRecord, List<IDisposable> instancesToDispose)
@@ -1469,8 +1170,8 @@ namespace Raven.Server.Documents.Replication
                     }
                     catch (Exception e)
                     {
-                        if (_log.IsOperationsEnabled)
-                            _log.Operations($"Failed to start the outgoing connections to {added.Count} new destinations", e);
+                        if (_logger.IsOperationsEnabled)
+                            _logger.Operations($"Failed to start the outgoing connections to {added.Count} new destinations", e);
                     }
                 });
             }
@@ -1483,21 +1184,21 @@ namespace Raven.Server.Documents.Replication
 
         private void StartOutgoingConnections(IReadOnlyCollection<ReplicationNode> connectionsToAdd)
         {
-            if (_log.IsInfoEnabled)
-                _log.Info($"Initializing {connectionsToAdd.Count:#,#} outgoing replications from {Database} on {_server.NodeTag}.");
+            if (_logger.IsInfoEnabled)
+                _logger.Info($"Initializing {connectionsToAdd.Count:#,#} outgoing replications from {Database} on {_server.NodeTag}.");
 
             foreach (var destination in connectionsToAdd)
             {
                 if (destination.Disabled)
                     continue;
 
-                if (_log.IsInfoEnabled)
-                    _log.Info("Initialized outgoing replication for " + destination.FromString());
+                if (_logger.IsInfoEnabled)
+                    _logger.Info("Initialized outgoing replication for " + destination.FromString());
                 AddAndStartOutgoingReplication(destination);
             }
 
-            if (_log.IsInfoEnabled)
-                _log.Info("Finished initialization of outgoing replications..");
+            if (_logger.IsInfoEnabled)
+                _logger.Info("Finished initialization of outgoing replications..");
         }
 
         private void DropOutgoingConnections(IEnumerable<ReplicationNode> connectionsToRemove, List<IDisposable> instancesToDispose)
@@ -1515,13 +1216,13 @@ namespace Raven.Server.Documents.Replication
             if (outgoingChanged.Count == 0)
                 return; // no connections to remove
 
-            if (_log.IsInfoEnabled)
-                _log.Info($"Dropping {outgoingChanged.Count:#,#} outgoing replications connections from {Database} on {_server.NodeTag}.");
+            if (_logger.IsInfoEnabled)
+                _logger.Info($"Dropping {outgoingChanged.Count:#,#} outgoing replications connections from {Database} on {_server.NodeTag}.");
 
             foreach (var instance in outgoingChanged)
             {
-                if (_log.IsInfoEnabled)
-                    _log.Info($"Stopping replication to {instance.Destination.FromString()}");
+                if (_logger.IsInfoEnabled)
+                    _logger.Info($"Stopping replication to {instance.Destination.FromString()}");
 
                 instance.Failed -= OnOutgoingSendingFailed;
                 instance.SuccessfulTwoWaysCommunication -= OnOutgoingSendingSucceeded;
@@ -1535,69 +1236,7 @@ namespace Raven.Server.Documents.Replication
             }
         }
 
-        internal void AddAndStartOutgoingReplication(ReplicationNode node)
-        {
-            var info = GetConnectionInfo(node);
-
-            if (info == null)
-            {
-                // this means that we were unable to retrieve the tcp connection info and will try it again later
-                return;
-            }
-
-            if (_locker.TryEnterReadLock(0) == false)
-            {
-                // the db being disposed
-                return;
-            }
-
-            try
-            {
-                if (Database == null)
-                    return;
-
-                OutgoingReplicationHandlerBase outgoingReplication;
-
-                switch (node)
-                {
-                    case PullReplicationAsSink sinkNode:
-                        outgoingReplication = new OutgoingPullReplicationHandlerAsSink(this, Database, sinkNode, info);
-                        break;
-                    case InternalReplication clusterNode:
-                        outgoingReplication = new OutgoingInternalReplicationHandler(this, Database, clusterNode, info);
-                        break;
-                    case ExternalReplication externalNode:
-                        outgoingReplication = new OutgoingExternalReplicationHandler(this, Database, externalNode, info);
-                        break;
-                    case BucketMigrationReplication migrationNode:
-                        outgoingReplication = new OutgoingMigrationReplicationHandler(this, Database, migrationNode, info);
-                        break;
-                    default:
-                        throw new ArgumentException($"Unknown node type {node.GetType().FullName}");
-                }
-
-                if (_outgoing.TryAdd(outgoingReplication) == false)
-                {
-                    outgoingReplication.Dispose();
-                    return;
-                }
-
-
-                outgoingReplication.Failed += OnOutgoingSendingFailed;
-                outgoingReplication.SuccessfulTwoWaysCommunication += OnOutgoingSendingSucceeded;
-                outgoingReplication.SuccessfulReplication += ResetReplicationFailuresInfo;
-
-                outgoingReplication.Start();
-
-                OutgoingReplicationAdded?.Invoke(outgoingReplication);
-            }
-            finally
-            {
-                _locker.ExitReadLock();
-            }
-        }
-
-        private TcpConnectionInfo GetConnectionInfo(ReplicationNode node)
+        protected override TcpConnectionInfo GetConnectionInfo(ReplicationNode node)
         {
             var shutdownInfo = _outgoingFailureInfo.GetOrAdd(node, new ConnectionShutdownInfo
             {
@@ -1641,16 +1280,16 @@ namespace Raven.Server.Documents.Replication
                     return null;
 
                 // will try to fetch it again later
-                if (_log.IsInfoEnabled)
+                if (_logger.IsInfoEnabled)
                 {
                     if (e is DatabaseIdleException)
                     {
                         // this is expected, so we don't mark it as error
-                        _log.Info($"The database is idle on the destination '{node.FromString()}', the connection will be retried later.");
+                        _logger.Info($"The database is idle on the destination '{node.FromString()}', the connection will be retried later.");
                     }
                     else
                     {
-                        _log.Info($"Failed to fetch tcp connection information for the destination '{node.FromString()}' , the connection will be retried later.", e);
+                        _logger.Info($"Failed to fetch tcp connection information for the destination '{node.FromString()}' , the connection will be retried later.", e);
                     }
                 }
 
@@ -1707,6 +1346,47 @@ namespace Raven.Server.Documents.Replication
             return null;
         }
 
+        protected override void StartOutgoingReplication(TcpConnectionInfo info, ReplicationNode node)
+        {
+            if (Database == null)
+                return;
+
+            OutgoingReplicationHandlerBase outgoingReplication;
+
+            switch (node)
+            {
+                case PullReplicationAsSink sinkNode:
+                    outgoingReplication = new OutgoingPullReplicationHandlerAsSink(this, Database, sinkNode, info);
+                    break;
+                case InternalReplication clusterNode:
+                    outgoingReplication = new OutgoingInternalReplicationHandler(this, Database, clusterNode, info);
+                    break;
+                case ExternalReplication externalNode:
+                    outgoingReplication = new OutgoingExternalReplicationHandler(this, Database, externalNode, info);
+                    break;
+                case BucketMigrationReplication migrationNode:
+                    outgoingReplication = new OutgoingMigrationReplicationHandler(this, Database, migrationNode, info);
+                    break;
+                default:
+                    throw new ArgumentException($"Unknown node type {node.GetType().FullName}");
+            }
+
+            if (_outgoing.TryAdd(outgoingReplication) == false)
+            {
+                outgoingReplication.Dispose();
+                return;
+            }
+
+
+            outgoingReplication.Failed += OnOutgoingSendingFailed;
+            outgoingReplication.SuccessfulTwoWaysCommunication += OnOutgoingSendingSucceeded;
+            outgoingReplication.SuccessfulReplication += ResetReplicationFailuresInfo;
+
+            outgoingReplication.Start();
+
+            OutgoingReplicationAdded?.Invoke(outgoingReplication);
+        }
+
         public ConcurrentDictionary<ReplicationNode, OutgoingReplicationFailureToConnectReporter> OutgoingConnectionsLastFailureToConnect =
             new ConcurrentDictionary<ReplicationNode, OutgoingReplicationFailureToConnectReporter>();
 
@@ -1731,8 +1411,8 @@ namespace Raven.Server.Documents.Replication
                     }
                     catch (Exception e)
                     {
-                        if (_log.IsInfoEnabled)
-                            _log.Info($"Failed to execute {nameof(GetRemoteTaskTopologyCommand)} for {pullReplicationAsSink.Name}", e);
+                        if (_logger.IsInfoEnabled)
+                            _logger.Info($"Failed to execute {nameof(GetRemoteTaskTopologyCommand)} for {pullReplicationAsSink.Name}", e);
 
                         // failed to connect, will retry later
                         throw;
@@ -1792,40 +1472,6 @@ namespace Raven.Server.Documents.Replication
             }
         }
 
-        public X509Certificate2 GetCertificateForReplication(ReplicationNode node, out TcpConnectionHeaderMessage.AuthorizationInfo authorizationInfo)
-        {
-            switch (node)
-            {
-                case BucketMigrationReplication _:
-                case InternalReplication _:
-                case ExternalReplication _:
-                    authorizationInfo = null;
-                    return _server.Server.Certificate.Certificate;
-
-                case PullReplicationAsSink sink:
-                    authorizationInfo = new TcpConnectionHeaderMessage.AuthorizationInfo
-                    {
-                        AuthorizeAs = sink.Mode switch
-                        {
-                            PullReplicationMode.HubToSink => TcpConnectionHeaderMessage.AuthorizationInfo.AuthorizeMethod.PullReplication,
-                            PullReplicationMode.SinkToHub => TcpConnectionHeaderMessage.AuthorizationInfo.AuthorizeMethod.PushReplication,
-                            PullReplicationMode.None => throw new ArgumentOutOfRangeException(nameof(node), "Replication mode should be set to pull or push"),
-                            _ => throw new ArgumentOutOfRangeException("Unexpected replication mode: " + sink.Mode)
-                        },
-                        AuthorizationFor = sink.HubName
-                    };
-
-                    if (sink.CertificateWithPrivateKey == null)
-                        return _server.Server.Certificate.Certificate;
-
-                    var certBytes = Convert.FromBase64String(sink.CertificateWithPrivateKey);
-                    return new X509Certificate2(certBytes, sink.CertificatePassword, X509KeyStorageFlags.Exportable | X509KeyStorageFlags.MachineKeySet);
-
-                default:
-                    throw new ArgumentException($"Unknown node type {node.GetType().FullName}");
-            }
-        }
-
         public (string Url, OngoingTaskConnectionStatus Status) GetExternalReplicationDestination(long taskId)
         {
             foreach (var outgoing in OutgoingConnections)
@@ -1868,8 +1514,8 @@ namespace Raven.Server.Documents.Replication
                 instance.DocumentsReceived -= OnIncomingReceiveSucceeded;
                 instance.AttachmentStreamsReceived -= OnAttachmentStreamsReceived;
 
-                if (_log.IsInfoEnabled)
-                    _log.Info($"Incoming replication handler has thrown an unhandled exception. ({instance.FromToString})", e);
+                if (_logger.IsInfoEnabled)
+                    _logger.Info($"Incoming replication handler has thrown an unhandled exception. ({instance.FromToString})", e);
             }
         }
 
@@ -1896,8 +1542,8 @@ namespace Raven.Server.Documents.Replication
                 failureInfo.DestinationDbId = instance.DestinationDbId;
                 failureInfo.LastHeartbeatTicks = instance.LastHeartbeatTicks;
 
-                if (_log.IsInfoEnabled)
-                    _log.Info($"Document replication connection ({instance.Node}) failed {failureInfo.RetriesCount} times, the connection will be retried on {failureInfo.RetryOn}.", e);
+                if (_logger.IsInfoEnabled)
+                    _logger.Info($"Document replication connection ({instance.Node}) failed {failureInfo.RetriesCount} times, the connection will be retried on {failureInfo.RetryOn}.", e);
 
                 _reconnectQueue.Add(failureInfo);
             }
@@ -1968,8 +1614,8 @@ namespace Raven.Server.Documents.Replication
 
                 ConflictResolver = null;
 
-                if (_log.IsInfoEnabled)
-                    _log.Info("Closing and disposing document replication connections.");
+                if (_logger.IsInfoEnabled)
+                    _logger.Info("Closing and disposing document replication connections.");
 
                 foreach (var incoming in _incoming)
                     ea.Execute(incoming.Value.Dispose);
@@ -2068,53 +1714,6 @@ namespace Raven.Server.Documents.Replication
             public DateTime When { get; } = DateTime.UtcNow;
         }
 
-        public class ConnectionShutdownInfo
-        {
-            private readonly TimeSpan _initialTimeout = TimeSpan.FromMilliseconds(1000);
-            private readonly int _retriesCount = 0;
-
-            public ConnectionShutdownInfo()
-            {
-                NextTimeout = _initialTimeout;
-                RetriesCount = _retriesCount;
-            }
-
-            public string DestinationDbId;
-
-            public long LastHeartbeatTicks;
-
-            public double MaxConnectionTimeout;
-
-            public readonly Queue<Exception> Errors = new Queue<Exception>();
-
-            public TimeSpan NextTimeout { get; set; }
-
-            public DateTime RetryOn { get; set; }
-
-            public ReplicationNode Node { get; set; }
-
-            public int RetriesCount { get; set; }
-
-            public void Reset()
-            {
-                NextTimeout = _initialTimeout;
-                RetriesCount = _retriesCount;
-                Errors.Clear();
-            }
-
-            public void OnError(Exception e)
-            {
-                Errors.Enqueue(e);
-                while (Errors.Count > 25)
-                    Errors.TryDequeue(out _);
-
-                RetriesCount++;
-                NextTimeout *= 2;
-                NextTimeout = TimeSpan.FromMilliseconds(Math.Min(NextTimeout.TotalMilliseconds, MaxConnectionTimeout));
-                RetryOn = DateTime.UtcNow + NextTimeout;
-            }
-        }
-
         public int GetSizeOfMajority()
         {
             return (_numberOfSiblings + 1) / 2 + 1;
@@ -2144,8 +1743,8 @@ namespace Raven.Server.Documents.Replication
                 }
                 catch (OperationCanceledException e)
                 {
-                    if (_log.IsInfoEnabled)
-                        _log.Info($"Get exception while trying to get write assurance on a database with {numberOfReplicasToWaitFor} servers. " +
+                    if (_logger.IsInfoEnabled)
+                        _logger.Info($"Get exception while trying to get write assurance on a database with {numberOfReplicasToWaitFor} servers. " +
                                   $"Written so far to {past} servers only. " +
                                   $"LastChangeVector is: {lastChangeVector}.", e);
                     return ReplicatedPastInternalDestinations(context, internalDestinations, lastChangeVector);
@@ -2193,11 +1792,6 @@ namespace Raven.Server.Documents.Replication
             }
 
             return count;
-        }
-
-        public int GetNextReplicationStatsId()
-        {
-            return Interlocked.Increment(ref _replicationStatsId);
         }
 
         public static bool IsOfTypePreventDeletions(ReplicationBatchItem item)

--- a/src/Raven.Server/Documents/Replication/Senders/ExternalReplicationDocumentSender.cs
+++ b/src/Raven.Server/Documents/Replication/Senders/ExternalReplicationDocumentSender.cs
@@ -9,7 +9,7 @@ namespace Raven.Server.Documents.Replication.Senders
 {
     public class ExternalReplicationDocumentSender : ReplicationDocumentSenderBase
     {
-        public ExternalReplicationDocumentSender(Stream stream, OutgoingReplicationHandlerBase parent, Logger log) : base(stream, parent, log)
+        public ExternalReplicationDocumentSender(Stream stream, DatabaseOutgoingReplicationHandlerBase parent, Logger log) : base(stream, parent, log)
         {
         }
 

--- a/src/Raven.Server/Documents/Replication/Senders/ExternalReplicationDocumentSender.cs
+++ b/src/Raven.Server/Documents/Replication/Senders/ExternalReplicationDocumentSender.cs
@@ -9,7 +9,7 @@ namespace Raven.Server.Documents.Replication.Senders
 {
     public class ExternalReplicationDocumentSender : ReplicationDocumentSenderBase
     {
-        public ExternalReplicationDocumentSender(Stream stream, DatabaseOutgoingReplicationHandlerBase parent, Logger log) : base(stream, parent, log)
+        public ExternalReplicationDocumentSender(Stream stream, DatabaseOutgoingReplicationHandler parent, Logger log) : base(stream, parent, log)
         {
         }
 

--- a/src/Raven.Server/Documents/Replication/Senders/InternalReplicationDocumentSender.cs
+++ b/src/Raven.Server/Documents/Replication/Senders/InternalReplicationDocumentSender.cs
@@ -6,7 +6,7 @@ namespace Raven.Server.Documents.Replication.Senders
 {
     public class InternalReplicationDocumentSender : ReplicationDocumentSenderBase
     {
-        public InternalReplicationDocumentSender(Stream stream, OutgoingReplicationHandlerBase parent, Logger log) : base(stream, parent, log)
+        public InternalReplicationDocumentSender(Stream stream, DatabaseOutgoingReplicationHandlerBase parent, Logger log) : base(stream, parent, log)
         {
         }
     }

--- a/src/Raven.Server/Documents/Replication/Senders/InternalReplicationDocumentSender.cs
+++ b/src/Raven.Server/Documents/Replication/Senders/InternalReplicationDocumentSender.cs
@@ -6,7 +6,7 @@ namespace Raven.Server.Documents.Replication.Senders
 {
     public class InternalReplicationDocumentSender : ReplicationDocumentSenderBase
     {
-        public InternalReplicationDocumentSender(Stream stream, DatabaseOutgoingReplicationHandlerBase parent, Logger log) : base(stream, parent, log)
+        public InternalReplicationDocumentSender(Stream stream, DatabaseOutgoingReplicationHandler parent, Logger log) : base(stream, parent, log)
         {
         }
     }

--- a/src/Raven.Server/Documents/Replication/Senders/ReplicationDocumentSenderBase.cs
+++ b/src/Raven.Server/Documents/Replication/Senders/ReplicationDocumentSenderBase.cs
@@ -35,7 +35,7 @@ namespace Raven.Server.Documents.Replication.Senders
         private readonly Dictionary<Slice, AttachmentReplicationItem> _replicaAttachmentStreams = new Dictionary<Slice, AttachmentReplicationItem>(SliceComparer.Instance);
         private readonly byte[] _tempBuffer = new byte[32 * 1024];
         private readonly Stream _stream;
-        internal readonly DatabaseOutgoingReplicationHandlerBase _parent;
+        internal readonly DatabaseOutgoingReplicationHandler _parent;
         private OutgoingReplicationStatsScope _statsInstance;
         protected readonly ReplicationStats _stats = new ReplicationStats();
         public bool MissingAttachmentsInLastBatch { get; private set; }
@@ -44,7 +44,7 @@ namespace Raven.Server.Documents.Replication.Senders
         private readonly int _numberOfAttachmentsTrackedForDeduplication;
         private readonly ByteStringContext _context; // required to clone the hashes 
 
-        protected ReplicationDocumentSenderBase(Stream stream, DatabaseOutgoingReplicationHandlerBase parent, Logger log)
+        protected ReplicationDocumentSenderBase(Stream stream, DatabaseOutgoingReplicationHandler parent, Logger log)
         {
             Log = log;
             _stream = stream;

--- a/src/Raven.Server/Documents/Replication/Senders/ReplicationDocumentSenderBase.cs
+++ b/src/Raven.Server/Documents/Replication/Senders/ReplicationDocumentSenderBase.cs
@@ -35,7 +35,7 @@ namespace Raven.Server.Documents.Replication.Senders
         private readonly Dictionary<Slice, AttachmentReplicationItem> _replicaAttachmentStreams = new Dictionary<Slice, AttachmentReplicationItem>(SliceComparer.Instance);
         private readonly byte[] _tempBuffer = new byte[32 * 1024];
         private readonly Stream _stream;
-        internal readonly OutgoingReplicationHandlerBase _parent;
+        internal readonly DatabaseOutgoingReplicationHandlerBase _parent;
         private OutgoingReplicationStatsScope _statsInstance;
         protected readonly ReplicationStats _stats = new ReplicationStats();
         public bool MissingAttachmentsInLastBatch { get; private set; }
@@ -44,7 +44,7 @@ namespace Raven.Server.Documents.Replication.Senders
         private readonly int _numberOfAttachmentsTrackedForDeduplication;
         private readonly ByteStringContext _context; // required to clone the hashes 
 
-        protected ReplicationDocumentSenderBase(Stream stream, OutgoingReplicationHandlerBase parent, Logger log)
+        protected ReplicationDocumentSenderBase(Stream stream, DatabaseOutgoingReplicationHandlerBase parent, Logger log)
         {
             Log = log;
             _stream = stream;

--- a/src/Raven.Server/Documents/Replication/Stats/LiveReplicationPerformanceCollector.cs
+++ b/src/Raven.Server/Documents/Replication/Stats/LiveReplicationPerformanceCollector.cs
@@ -19,8 +19,8 @@ namespace Raven.Server.Documents.Replication.Stats
         private readonly ConcurrentDictionary<string, ReplicationHandlerAndPerformanceStatsList<IncomingReplicationHandler, IncomingReplicationStatsAggregator>> _incoming =
             new ConcurrentDictionary<string, ReplicationHandlerAndPerformanceStatsList<IncomingReplicationHandler, IncomingReplicationStatsAggregator>>(StringComparer.OrdinalIgnoreCase);
 
-        private readonly ConcurrentDictionary<DatabaseOutgoingReplicationHandlerBase, ReplicationHandlerAndPerformanceStatsList<DatabaseOutgoingReplicationHandlerBase, OutgoingReplicationStatsAggregator>> _outgoing =
-            new ConcurrentDictionary<DatabaseOutgoingReplicationHandlerBase, ReplicationHandlerAndPerformanceStatsList<DatabaseOutgoingReplicationHandlerBase, OutgoingReplicationStatsAggregator>>();
+        private readonly ConcurrentDictionary<DatabaseOutgoingReplicationHandler, ReplicationHandlerAndPerformanceStatsList<DatabaseOutgoingReplicationHandler, OutgoingReplicationStatsAggregator>> _outgoing =
+            new ConcurrentDictionary<DatabaseOutgoingReplicationHandler, ReplicationHandlerAndPerformanceStatsList<DatabaseOutgoingReplicationHandler, OutgoingReplicationStatsAggregator>>();
 
         private readonly ConcurrentDictionary<ReplicationNode, OutgoingReplicationFailureToConnectReporter> _outgoingErrors = new ConcurrentDictionary<ReplicationNode, OutgoingReplicationFailureToConnectReporter>();
         private readonly ConcurrentDictionary<ReplicationNode, IncomingReplicationFailureToConnectReporter> _incomingErrors = new ConcurrentDictionary<ReplicationNode, IncomingReplicationFailureToConnectReporter>();
@@ -200,23 +200,23 @@ namespace Raven.Server.Documents.Replication.Stats
             writer.WriteEndObject();
         }
 
-        private void OutgoingHandlerRemoved(DatabaseOutgoingReplicationHandlerBase handler)
+        private void OutgoingHandlerRemoved(DatabaseOutgoingReplicationHandler handler)
         {
             if (_outgoing.TryRemove(handler, out var stats))
                 stats.Handler.DocumentsSend -= OutgoingDocumentsSend;
         }
 
-        private void OutgoingHandlerAdded(DatabaseOutgoingReplicationHandlerBase handler)
+        private void OutgoingHandlerAdded(DatabaseOutgoingReplicationHandler handler)
         {
             _outgoing.GetOrAdd(handler, key =>
             {
                 handler.DocumentsSend += OutgoingDocumentsSend;
 
-                return new ReplicationHandlerAndPerformanceStatsList<DatabaseOutgoingReplicationHandlerBase, OutgoingReplicationStatsAggregator>(handler);
+                return new ReplicationHandlerAndPerformanceStatsList<DatabaseOutgoingReplicationHandler, OutgoingReplicationStatsAggregator>(handler);
             });
         }
 
-        private void OutgoingDocumentsSend(DatabaseOutgoingReplicationHandlerBase handler)
+        private void OutgoingDocumentsSend(DatabaseOutgoingReplicationHandler handler)
         {
             if (_outgoing.TryGetValue(handler, out var stats) == false)
             {

--- a/src/Raven.Server/Documents/Replication/Stats/LiveReplicationPerformanceCollector.cs
+++ b/src/Raven.Server/Documents/Replication/Stats/LiveReplicationPerformanceCollector.cs
@@ -46,10 +46,10 @@ namespace Raven.Server.Documents.Replication.Stats
             Database.ReplicationLoader.IncomingReplicationConnectionErrored += IncomingReplicationConnectionFailed;
 
             foreach (var handler in Database.ReplicationLoader.IncomingHandlers)
-                IncomingHandlerAdded(handler);
+                IncomingHandlerAdded(handler as IncomingReplicationHandler);
 
             foreach (var handler in Database.ReplicationLoader.OutgoingHandlers)
-                OutgoingHandlerAdded(handler);
+                OutgoingHandlerAdded(handler as OutgoingReplicationHandlerBase);
 
             try
             {
@@ -107,9 +107,9 @@ namespace Raven.Server.Documents.Replication.Stats
                     stats = new OutgoingReplicationPerformanceStats[] { new OutgoingReplicationPerformanceStats() };
                 }
 
-                yield return handler is OutgoingPullReplicationHandler
-                    ? OutgoingPerformanceStats.ForPullReplication(handler.DestinationDbId, handler.DestinationFormatted, stats)
-                    : OutgoingPerformanceStats.ForPushReplication(handler.DestinationDbId, handler.GetReplicationPerformanceType(), handler.DestinationFormatted, stats);
+                yield return handler is OutgoingPullReplicationHandler outgoingPull
+                    ? OutgoingPerformanceStats.ForPullReplication(outgoingPull.DestinationDbId, outgoingPull.DestinationFormatted, stats)
+                    : handler is OutgoingReplicationHandlerBase outgoingHandler ? OutgoingPerformanceStats.ForPushReplication(outgoingHandler.DestinationDbId, outgoingHandler.GetReplicationPerformanceType(), outgoingHandler.DestinationFormatted, stats) : null;
             }
         }
 

--- a/src/Raven.Server/Documents/Replication/Stats/LiveReplicationPulsesCollector.cs
+++ b/src/Raven.Server/Documents/Replication/Stats/LiveReplicationPulsesCollector.cs
@@ -29,10 +29,10 @@ namespace Raven.Server.Documents.Replication.Stats
             _database.ReplicationLoader.OutgoingReplicationConnectionFailed += HandleReplicationPulse;
 
             foreach (var handler in _database.ReplicationLoader.IncomingHandlers)
-                IncomingHandlerAdded(handler);
+                IncomingHandlerAdded(handler as IncomingReplicationHandler);
 
             foreach (var handler in _database.ReplicationLoader.OutgoingHandlers)
-                OutgoingHandlerAdded(handler);
+                OutgoingHandlerAdded(handler as OutgoingReplicationHandlerBase);
         }
 
         private void OutgoingHandlerRemoved(OutgoingReplicationHandlerBase handler)

--- a/src/Raven.Server/Documents/Replication/Stats/LiveReplicationPulsesCollector.cs
+++ b/src/Raven.Server/Documents/Replication/Stats/LiveReplicationPulsesCollector.cs
@@ -32,15 +32,15 @@ namespace Raven.Server.Documents.Replication.Stats
                 IncomingHandlerAdded(handler as IncomingReplicationHandler);
 
             foreach (var handler in _database.ReplicationLoader.OutgoingHandlers)
-                OutgoingHandlerAdded(handler as OutgoingReplicationHandlerBase);
+                OutgoingHandlerAdded(handler as DatabaseOutgoingReplicationHandlerBase);
         }
 
-        private void OutgoingHandlerRemoved(OutgoingReplicationHandlerBase handler)
+        private void OutgoingHandlerRemoved(DatabaseOutgoingReplicationHandlerBase handler)
         {
             handler.HandleReplicationPulse -= HandleReplicationPulse;
         }
 
-        private void OutgoingHandlerAdded(OutgoingReplicationHandlerBase handler)
+        private void OutgoingHandlerAdded(DatabaseOutgoingReplicationHandlerBase handler)
         {
             handler.HandleReplicationPulse += HandleReplicationPulse;
         }

--- a/src/Raven.Server/Documents/Replication/Stats/LiveReplicationPulsesCollector.cs
+++ b/src/Raven.Server/Documents/Replication/Stats/LiveReplicationPulsesCollector.cs
@@ -32,15 +32,15 @@ namespace Raven.Server.Documents.Replication.Stats
                 IncomingHandlerAdded(handler as IncomingReplicationHandler);
 
             foreach (var handler in _database.ReplicationLoader.OutgoingHandlers)
-                OutgoingHandlerAdded(handler as DatabaseOutgoingReplicationHandlerBase);
+                OutgoingHandlerAdded(handler as DatabaseOutgoingReplicationHandler);
         }
 
-        private void OutgoingHandlerRemoved(DatabaseOutgoingReplicationHandlerBase handler)
+        private void OutgoingHandlerRemoved(DatabaseOutgoingReplicationHandler handler)
         {
             handler.HandleReplicationPulse -= HandleReplicationPulse;
         }
 
-        private void OutgoingHandlerAdded(DatabaseOutgoingReplicationHandlerBase handler)
+        private void OutgoingHandlerAdded(DatabaseOutgoingReplicationHandler handler)
         {
             handler.HandleReplicationPulse += HandleReplicationPulse;
         }

--- a/src/Raven.Server/Documents/Sharding/Handlers/Processors/Replication/ShardedPullReplicationHandlerProcessorForDefineHub.cs
+++ b/src/Raven.Server/Documents/Sharding/Handlers/Processors/Replication/ShardedPullReplicationHandlerProcessorForDefineHub.cs
@@ -1,4 +1,6 @@
-﻿using JetBrains.Annotations;
+﻿using System.Threading.Tasks;
+using JetBrains.Annotations;
+using Raven.Client.Exceptions.Sharding;
 using Raven.Server.Documents.Handlers.Processors.Replication;
 using Raven.Server.ServerWide.Context;
 
@@ -8,6 +10,11 @@ namespace Raven.Server.Documents.Sharding.Handlers.Processors.Replication
     {
         public ShardedPullReplicationHandlerProcessorForDefineHub([NotNull] ShardedDatabaseRequestHandler requestHandler) : base(requestHandler)
         {
+        }
+
+        protected override ValueTask AssertCanExecuteAsync()
+        {
+            throw new NotSupportedInShardingException("Update Pull Replication Definition Command is not supported in sharding");
         }
     }
 }

--- a/src/Raven.Server/Documents/Sharding/Handlers/Processors/Replication/ShardedPullReplicationHandlerProcessorForRegisterHubAccess.cs
+++ b/src/Raven.Server/Documents/Sharding/Handlers/Processors/Replication/ShardedPullReplicationHandlerProcessorForRegisterHubAccess.cs
@@ -1,4 +1,6 @@
-﻿using JetBrains.Annotations;
+﻿using System.Threading.Tasks;
+using JetBrains.Annotations;
+using Raven.Client.Exceptions.Sharding;
 using Raven.Server.Documents.Handlers.Processors.Replication;
 using Raven.Server.ServerWide.Context;
 
@@ -8,6 +10,11 @@ namespace Raven.Server.Documents.Sharding.Handlers.Processors.Replication
     {
         public ShardedPullReplicationHandlerProcessorForRegisterHubAccess([NotNull] ShardedDatabaseRequestHandler requestHandler) : base(requestHandler)
         {
+        }
+
+        protected override ValueTask AssertCanExecuteAsync()
+        {
+            throw new NotSupportedInShardingException("Register Hub Access Command is not supported in sharding");
         }
     }
 }

--- a/src/Raven.Server/Documents/Sharding/Handlers/Processors/Replication/ShardedPullReplicationHandlerProcessorForUpdatePullReplicationOnSinkNode.cs
+++ b/src/Raven.Server/Documents/Sharding/Handlers/Processors/Replication/ShardedPullReplicationHandlerProcessorForUpdatePullReplicationOnSinkNode.cs
@@ -1,5 +1,7 @@
-﻿using JetBrains.Annotations;
+﻿using System.Threading.Tasks;
+using JetBrains.Annotations;
 using Raven.Client.Documents.Operations.Replication;
+using Raven.Client.Exceptions.Sharding;
 using Raven.Server.Documents.Handlers.Processors.Replication;
 using Raven.Server.ServerWide.Context;
 using Sparrow.Json.Parsing;
@@ -11,6 +13,11 @@ namespace Raven.Server.Documents.Sharding.Handlers.Processors.Replication
     {
         public ShardedPullReplicationHandlerProcessorForUpdatePullReplicationOnSinkNode([NotNull] ShardedDatabaseRequestHandler requestHandler) : base(requestHandler)
         {
+        }
+
+        protected override ValueTask AssertCanExecuteAsync()
+        {
+            throw new NotSupportedInShardingException("Update Pull Replication On Sink Node Command is not supported in sharding");
         }
 
         protected override void FillResponsibleNode(TransactionOperationContext context, DynamicJsonValue responseJson, PullReplicationAsSink pullReplication)

--- a/src/Raven.Server/Documents/Sharding/Handlers/ShardedDatabaseRequestHandler.cs
+++ b/src/Raven.Server/Documents/Sharding/Handlers/ShardedDatabaseRequestHandler.cs
@@ -65,12 +65,16 @@ namespace Raven.Server.Documents.Sharding.Handlers
             
             var request = HttpContext.Request;
             var url = context.RouteMatch.Url;
-            var relativeIndex = url.IndexOf('/', 11); //start after "/databases/" and skip the database name
 
-            BaseShardUrl = url.Substring(relativeIndex);
-            RelativeShardUrl = BaseShardUrl + request.QueryString;
-            Method = new HttpMethod(request.Method);
+            if (string.IsNullOrEmpty(url) == false)
+            {
+                var relativeIndex = url.IndexOf('/', 11); //start after "/databases/" and skip the database name
+                BaseShardUrl = url.Substring(relativeIndex);
 
+                RelativeShardUrl = BaseShardUrl + request.QueryString;
+                Method = new HttpMethod(request.Method);
+            }
+            
             context.HttpContext.Response.OnStarting(() => CheckForChanges(context));
         }
 

--- a/src/Raven.Server/Documents/Sharding/Handlers/ShardedIncomingReplicationHandler.cs
+++ b/src/Raven.Server/Documents/Sharding/Handlers/ShardedIncomingReplicationHandler.cs
@@ -62,7 +62,7 @@ namespace Raven.Server.Documents.Sharding.Handlers
         protected override Task HandleBatchAsync(TransactionOperationContext context, IncomingReplicationHandler.DataForReplicationCommand dataForReplicationCommand, long lastEtag)
         {
             PrepareReplicationDataForShards(context, dataForReplicationCommand);
-            return _replicationQueue.SendToShardCompletion.WaitAsync();
+            return _replicationQueue.SendToShardCompletion.WaitAsync(_cts.Token);
         }
 
         protected override void HandleMissingAttachmentsIfNeeded(ref Task task)

--- a/src/Raven.Server/Documents/Sharding/Handlers/ShardedIncomingReplicationHandler.cs
+++ b/src/Raven.Server/Documents/Sharding/Handlers/ShardedIncomingReplicationHandler.cs
@@ -25,7 +25,7 @@ namespace Raven.Server.Documents.Sharding.Handlers
 
         public ShardedIncomingReplicationHandler(TcpConnectionOptions tcpConnectionOptions, ShardedDatabaseContext.ShardedReplicationContext parent,
             JsonOperationContext.MemoryBuffer buffer, ReplicationLatestEtagRequest replicatedLastEtag, ReplicationQueue replicationQueue)
-            : base(tcpConnectionOptions, buffer, parent.Server, parent.DatabaseName, replicatedLastEtag, parent.Context.DatabaseShutdown, parent.Server.ContextPool)
+            : base(tcpConnectionOptions, buffer, parent.Server, parent.DatabaseName, ReplicationLatestEtagRequest.ReplicationType.Sharded, replicatedLastEtag, parent.Context.DatabaseShutdown, parent.Server.ContextPool)
         {
             _parent = parent;
             _replicationQueue = replicationQueue;

--- a/src/Raven.Server/Documents/Sharding/Handlers/ShardedOutgoingReplicationHandler.cs
+++ b/src/Raven.Server/Documents/Sharding/Handlers/ShardedOutgoingReplicationHandler.cs
@@ -97,8 +97,16 @@ namespace Raven.Server.Documents.Sharding.Handlers
             catch (Exception e)
             {
                 batch?.BatchSent.TrySetException(e);
+                try
+                {
+                    _tcpConnectionOptions.Dispose();
+                }
+                catch
+                {
+                    // nothing we can do
+                }
+                
                 throw;
-                //TODO: is the connection still alive, need to abort?
             }
         }
 

--- a/src/Raven.Server/Documents/Sharding/Handlers/ShardedOutgoingReplicationHandler.cs
+++ b/src/Raven.Server/Documents/Sharding/Handlers/ShardedOutgoingReplicationHandler.cs
@@ -49,7 +49,7 @@ namespace Raven.Server.Documents.Sharding.Handlers
         {
             while (_cts.IsCancellationRequested == false)
             {
-                while (_replicationQueue.Items[_shardNumber].TryTake(out var items))
+                while (_replicationQueue.Items[_shardNumber].TryTake(out var items, 0, _cts.Token))
                 {
                     using (_parent.Server.ContextPool.AllocateOperationContext(out TransactionOperationContext context))
                     {

--- a/src/Raven.Server/Documents/Sharding/Handlers/ShardedOutgoingReplicationHandler.cs
+++ b/src/Raven.Server/Documents/Sharding/Handlers/ShardedOutgoingReplicationHandler.cs
@@ -27,9 +27,7 @@ namespace Raven.Server.Documents.Sharding.Handlers
         private readonly ReplicationQueue _replicationQueue;
 
         private readonly byte[] _tempBuffer = new byte[32 * 1024];
-        private OutgoingReplicationStatsAggregator _lastStats;
         private long _lastEtag;
-
 
         public ShardedOutgoingReplicationHandler(ShardedDatabaseContext.ShardedReplicationContext parent, ShardReplicationNode node, int shardNumber,
             TcpConnectionInfo connectionInfo, ReplicationQueue replicationQueue) :

--- a/src/Raven.Server/Documents/Sharding/ShardedDatabaseContext.ReplicationLoader.cs
+++ b/src/Raven.Server/Documents/Sharding/ShardedDatabaseContext.ReplicationLoader.cs
@@ -4,6 +4,7 @@ using System.Threading;
 using System.Threading.Tasks;
 using JetBrains.Annotations;
 using Raven.Client.Documents.Operations.Replication;
+using Raven.Client.Exceptions.Sharding;
 using Raven.Client.ServerWide.Tcp;
 using Raven.Server.Documents.Replication;
 using Raven.Server.Documents.Replication.ReplicationItems;
@@ -46,9 +47,9 @@ namespace Raven.Server.Documents.Sharding
                 switch (header.AuthorizeInfo?.AuthorizeAs)
                 {
                     case TcpConnectionHeaderMessage.AuthorizationInfo.AuthorizeMethod.PullReplication:
-                        throw new InvalidOperationException("Pull Replication is not supported for sharded database");
+                        throw new NotSupportedInShardingException("Pull Replication is not supported for sharded database");
                     case TcpConnectionHeaderMessage.AuthorizationInfo.AuthorizeMethod.PushReplication:
-                        throw new InvalidOperationException("Push Replication is not supported for sharded database");
+                        throw new NotSupportedInShardingException("Push Replication is not supported for sharded database");
 
                     case null:
                         return;

--- a/src/Raven.Server/Documents/Sharding/ShardedDatabaseContext.ReplicationLoader.cs
+++ b/src/Raven.Server/Documents/Sharding/ShardedDatabaseContext.ReplicationLoader.cs
@@ -1,6 +1,7 @@
 ﻿using System;
 using System.Collections.Generic;
 using System.Threading;
+using System.Threading.Tasks;
 using JetBrains.Annotations;
 using Raven.Client.Documents.Operations.Replication;
 using Raven.Client.ServerWide.Tcp;
@@ -94,6 +95,7 @@ namespace Raven.Server.Documents.Sharding
     {
         public List<ReplicationBatchItem> Items = new();
         public Dictionary<Slice, AttachmentReplicationItem> Attachments;
+        public TaskCompletionSource BatchSent;
     }
 
     public class ShardReplicationNode : ExternalReplication

--- a/src/Raven.Server/Documents/Sharding/ShardedDatabaseContext.ReplicationLoader.cs
+++ b/src/Raven.Server/Documents/Sharding/ShardedDatabaseContext.ReplicationLoader.cs
@@ -31,7 +31,7 @@ namespace Raven.Server.Documents.Sharding
             public ShardedDatabaseContext Context => _context;
             public string SourceDatabaseId { get; set; }
 
-            public ShardedReplicationContext([NotNull] ShardedDatabaseContext context, ServerStore serverStore) : base(serverStore, context.DatabaseName, context.Configuration)
+            public ShardedReplicationContext([NotNull] ShardedDatabaseContext context, ServerStore serverStore) : base(serverStore, context.DatabaseName)
             {
                 _context = context ?? throw new ArgumentNullException(nameof(context));
             }

--- a/src/Raven.Server/Documents/Sharding/ShardedDatabaseContext.ReplicationLoader.cs
+++ b/src/Raven.Server/Documents/Sharding/ShardedDatabaseContext.ReplicationLoader.cs
@@ -130,6 +130,10 @@ namespace Raven.Server.Documents.Sharding
 
         public Dictionary<int, Dictionary<Slice, AttachmentReplicationItem>> AttachmentsPerShard = new Dictionary<int, Dictionary<Slice, AttachmentReplicationItem>>();
 
+        public AsyncManualResetEvent MissingAttachments = new AsyncManualResetEvent(false);
+
+        public string MissingAttachmentMessage;
+
         public ReplicationQueue(int numberOfShards)
         {
             SendToShardCompletion = new AsyncCountdownEvent(numberOfShards);

--- a/src/Raven.Server/Documents/Sharding/ShardedDatabaseContext.ReplicationLoader.cs
+++ b/src/Raven.Server/Documents/Sharding/ShardedDatabaseContext.ReplicationLoader.cs
@@ -1,32 +1,20 @@
 ﻿using System;
 using System.Collections.Concurrent;
 using System.Collections.Generic;
-using System.Security.Cryptography.X509Certificates;
 using System.Threading;
 using JetBrains.Annotations;
 using Nito.AsyncEx;
 using Raven.Client.Documents.Operations.Replication;
 using Raven.Client.Documents.Replication;
-using Raven.Client.Documents.Replication.Messages;
 using Raven.Client.Http;
-using Raven.Client.Json.Serialization;
 using Raven.Client.ServerWide.Commands;
-using Raven.Client.ServerWide.Tcp;
 using Raven.Server.Documents.Replication;
-using Raven.Server.Documents.Replication.Outgoing;
 using Raven.Server.Documents.Replication.ReplicationItems;
-using Raven.Server.Documents.Replication.Stats;
 using Raven.Server.Documents.Sharding.Handlers;
 using Raven.Server.Documents.TcpHandlers;
-using Raven.Server.Json;
 using Raven.Server.ServerWide;
-using Raven.Server.ServerWide.Context;
 using Sparrow.Collections;
 using Sparrow.Json;
-using Sparrow.Json.Parsing;
-using Sparrow.Json.Sync;
-using Sparrow.Logging;
-using Sparrow.Server.Json.Sync;
 using Voron;
 
 namespace Raven.Server.Documents.Sharding
@@ -35,15 +23,11 @@ namespace Raven.Server.Documents.Sharding
     {
         public readonly ShardedReplicationContext Replication;
 
-        public class ShardedReplicationContext : IDisposable
+        public class ShardedReplicationContext : AbstractReplicationLoader, IDisposable
         {
             private readonly ReaderWriterLockSlim _locker = new ReaderWriterLockSlim();
 
-            private readonly Logger _logger;
-
             private readonly ShardedDatabaseContext _context;
-
-            private readonly ServerStore _server;
 
             private readonly ConcurrentDictionary<string, ShardedIncomingReplicationHandler> _incoming =
                 new ConcurrentDictionary<string, ShardedIncomingReplicationHandler>();
@@ -51,44 +35,28 @@ namespace Raven.Server.Documents.Sharding
             private readonly ConcurrentSet<ShardedOutgoingReplicationHandler> _outgoing =
                 new ConcurrentSet<ShardedOutgoingReplicationHandler>();
 
-            private int _replicationStatsId;
-
             public string DatabaseName => _context.DatabaseName;
             public ServerStore Server => _server;
             public ShardedDatabaseContext Context => _context;
             public string SourceDatabaseId { get; set; }
 
-            public ShardedReplicationContext([NotNull] ShardedDatabaseContext context, ServerStore serverStore)
+            public ShardedReplicationContext([NotNull] ShardedDatabaseContext context, ServerStore serverStore) : base(serverStore, context.DatabaseName, context.Configuration)
             {
                 _context = context ?? throw new ArgumentNullException(nameof(context));
-                _logger = LoggingSource.Instance.GetLogger<ShardedIndexesContext>(context.DatabaseName);
-                _server = serverStore;
             }
 
             public void AcceptIncomingConnection(TcpConnectionOptions tcpConnectionOptions,
-                TcpConnectionHeaderMessage header,
-                X509Certificate2 certificate,
                 JsonOperationContext.MemoryBuffer buffer,
                 ReplicationQueue replicationQueue)
             {
 
-                var supportedVersions =
-                    TcpConnectionHeaderMessage.GetSupportedFeaturesFor(TcpConnectionHeaderMessage.OperationTypes.Replication, tcpConnectionOptions.ProtocolVersion);
-
-                ReplicationInitialRequest initialRequest = null;
-                if (supportedVersions.Replication.PullReplication)
-                {
-                    using (tcpConnectionOptions.ContextPool.AllocateOperationContext(out JsonOperationContext context))
-                    using (var readerObject = context.Sync.ParseToMemory(tcpConnectionOptions.Stream, "initial-replication-message",
-                        BlittableJsonDocumentBuilder.UsageMode.None, buffer))
-                    {
-                        initialRequest = JsonDeserializationServer.ReplicationInitialRequest(readerObject);
-                    }
-                }
+                var supportedVersions = GetSupportedVersions(tcpConnectionOptions);
+                GetReplicationInitialRequest(tcpConnectionOptions, supportedVersions, buffer);
 
                 CreateIncomingInstance(tcpConnectionOptions, buffer, replicationQueue);
             }
 
+            protected override CancellationToken GetCancellationToken() => _context.DatabaseShutdown;
 
             private void CreateIncomingInstance(TcpConnectionOptions tcpConnectionOptions, JsonOperationContext.MemoryBuffer buffer, ReplicationQueue queue)
             {
@@ -120,195 +88,49 @@ namespace Raven.Server.Documents.Sharding
                 return new ShardedIncomingReplicationHandler(tcpConnectionOptions, this, buffer, getLatestEtagMessage, replicationQueue);
             }
 
-            private ReplicationLatestEtagRequest IncomingInitialHandshake(TcpConnectionOptions tcpConnectionOptions, JsonOperationContext.MemoryBuffer buffer)
+            protected override TcpConnectionInfo GetConnectionInfo(ReplicationNode node)
             {
-                ReplicationLatestEtagRequest getLatestEtagMessage;
+                if (node is ShardReplicationNode shardNode == false)
+                    return null;
 
-                using (tcpConnectionOptions.ContextPool.AllocateOperationContext(out JsonOperationContext context))
-                using (var readerObject = context.Sync.ParseToMemory(
-                    tcpConnectionOptions.Stream,
-                    "IncomingReplication/get-last-etag-message read",
-                    BlittableJsonDocumentBuilder.UsageMode.None,
-                    buffer))
-                {
-                    var exceptionSchema = JsonDeserializationClient.ExceptionSchema(readerObject);
-                    if (exceptionSchema.Type.Equals("Error"))
-                        throw new Exception(exceptionSchema.Message);
-
-                    getLatestEtagMessage = JsonDeserializationServer.ReplicationLatestEtagRequest(readerObject);
-                    if (_logger.IsInfoEnabled)
-                    {
-                        _logger.Info(
-                            $"GetLastEtag: {getLatestEtagMessage.SourceTag}({getLatestEtagMessage.SourceMachineName}) / {getLatestEtagMessage.SourceDatabaseName} ({getLatestEtagMessage.SourceDatabaseId}) - {getLatestEtagMessage.SourceUrl}. Type: {getLatestEtagMessage.ReplicationsType}");
-                    }
-                }
-
-                var connectionInfo = IncomingConnectionInfo.FromGetLatestEtag(getLatestEtagMessage);
-                try
-                {
-                    AssertValidConnection(connectionInfo);
-                }
-                catch (Exception e)
-                {
-                    if (_logger.IsInfoEnabled)
-                        _logger.Info($"Connection from [{connectionInfo}] is rejected.", e);
-
-                    throw;
-                }
-
-                try
-                {
-                    using (_context.ServerStore.ContextPool.AllocateOperationContext(out TransactionOperationContext context))
-                    using (var writer = new BlittableJsonTextWriter(context, tcpConnectionOptions.Stream))
-                    using (context.OpenReadTransaction())
-                    {
-                        var response = new DynamicJsonValue
-                        {
-                            [nameof(ReplicationMessageReply.Type)] = nameof(ReplicationMessageReply.ReplyType.Ok),
-                            [nameof(ReplicationMessageReply.MessageType)] = ReplicationMessageType.Heartbeat,
-                            [nameof(ReplicationMessageReply.NodeTag)] = _server.NodeTag
-                        };
-
-                        context.Write(writer, response);
-                        writer.Flush();
-                    }
-                }
-                catch (Exception)
-                {
-                    try
-                    {
-                        tcpConnectionOptions.Dispose();
-                    }
-                    catch (Exception)
-                    {
-                        // do nothing
-                    }
-
-                    throw;
-                }
-
-                if (_logger.IsInfoEnabled)
-                    _logger.Info(
-                        $"Initialized document replication connection from {connectionInfo.SourceDatabaseName} located at {connectionInfo.SourceUrl}");
-
-                return getLatestEtagMessage;
-            }
-
-            private void AssertValidConnection(IncomingConnectionInfo connectionInfo)
-            {
-                if (_server.IsPassive())
-                {
-                    throw new InvalidOperationException(
-                        $"Cannot accept the incoming replication connection from {connectionInfo.SourceUrl}, because this node is in passive state.");
-                }
-            }
-
-            public void AddAndStartOutgoingReplication(ShardReplicationNode node)
-            {
-                var info = GetShardedReplicationTcpInfo(node, node.Database, node.Shard);
-
-                if (info == null)
-                {
-                    // this means that we were unable to retrieve the tcp connection info and will try it again later
-                    return;
-                }
-
-                if (_locker.TryEnterReadLock(0) == false)
-                {
-                    // the db being disposed
-                    return;
-                }
-
-                try
-                {
-                    var shardedOutgoingReplicationHandler = new ShardedOutgoingReplicationHandler(this, node, node.Shard, info, node.ReplicationQueue);
-
-                    if (_outgoing.TryAdd(shardedOutgoingReplicationHandler) == false)
-                    {
-                        return;
-                    }
-
-                    shardedOutgoingReplicationHandler.Start();
-                }
-                finally
-                {
-                    _locker.ExitReadLock();
-                }
-
-            }
-
-            private TcpConnectionInfo GetShardedReplicationTcpInfo(ShardReplicationNode exNode, string database, int shard)
-            {
                 var shardExecutor = _context.ShardExecutor;
                 using (_context.AllocateContext(out JsonOperationContext ctx))
                 {
-                    var cmd = new GetTcpInfoCommand("sharded-replication", database);
+                    var cmd = new GetTcpInfoCommand("sharded-replication", shardNode.Database);
                     RequestExecutor requestExecutor = null;
                     try
                     {
-                        requestExecutor = shardExecutor.GetRequestExecutorAt(shard);
+                        requestExecutor = shardExecutor.GetRequestExecutorAt(shardNode.Shard);
                         requestExecutor.Execute(cmd, ctx);
                     }
                     finally
                     {
                         // we want to set node Url even if we fail to connect to destination, so they can be used in replication stats
-                        exNode.Database = database;
-                        exNode.Url = requestExecutor?.Url;
+                        node.Database = shardNode.Database;
+                        node.Url = requestExecutor?.Url;
                     }
 
                     return cmd.Result;
                 }
             }
 
-            public X509Certificate2 GetCertificateForReplication(ReplicationNode node, out TcpConnectionHeaderMessage.AuthorizationInfo authorizationInfo)
+            protected override void StartOutgoingReplication(TcpConnectionInfo info, ReplicationNode node)
             {
                 switch (node)
                 {
-                    case ShardReplicationNode _:
-                        authorizationInfo = null;
-                        return _server.Server.Certificate.Certificate;
+                    case ShardReplicationNode shardNode:
+                        var shardedOutgoingReplicationHandler = new ShardedOutgoingReplicationHandler(this, shardNode, shardNode.Shard, info, shardNode.ReplicationQueue);
 
-                    case PullReplicationAsSink sink:
-                        authorizationInfo = new TcpConnectionHeaderMessage.AuthorizationInfo
+                        if (_outgoing.TryAdd(shardedOutgoingReplicationHandler) == false)
                         {
-                            AuthorizeAs = sink.Mode switch
-                            {
-                                PullReplicationMode.HubToSink => TcpConnectionHeaderMessage.AuthorizationInfo.AuthorizeMethod.PullReplication,
-                                PullReplicationMode.SinkToHub => TcpConnectionHeaderMessage.AuthorizationInfo.AuthorizeMethod.PushReplication,
-                                PullReplicationMode.None => throw new ArgumentOutOfRangeException(nameof(node), "Replication mode should be set to pull or push"),
-                                _ => throw new ArgumentOutOfRangeException("Unexpected replication mode: " + sink.Mode)
-                            },
-                            AuthorizationFor = sink.HubName
-                        };
+                            return;
+                        }
 
-                        if (sink.CertificateWithPrivateKey == null)
-                            return _server.Server.Certificate.Certificate;
-
-                        var certBytes = Convert.FromBase64String(sink.CertificateWithPrivateKey);
-                        return new X509Certificate2(certBytes, sink.CertificatePassword, X509KeyStorageFlags.Exportable | X509KeyStorageFlags.MachineKeySet);
+                        shardedOutgoingReplicationHandler.Start();
+                        break;
 
                     default:
-                        throw new ArgumentException($"Unknown node type {node.GetType().FullName}");
-                }
-            }
-
-            public int GetNextReplicationStatsId()
-            {
-                return Interlocked.Increment(ref _replicationStatsId);
-            }
-
-            public void EnsureNotDeleted(string node)
-            {
-                using (_server.ContextPool.AllocateOperationContext(out TransactionOperationContext ctx))
-                using (ctx.OpenReadTransaction())
-                {
-                    using (var rawRecord = _server.Cluster.ReadRawDatabaseRecord(ctx, DatabaseName))
-                    {
-                        if (rawRecord != null && rawRecord.DeletionInProgress.ContainsKey(node))
-                        {
-                            throw new OperationCanceledException($"The database '{DatabaseName}' on node '{node}' is being deleted, so it will not handle replications.");
-                        }
-                    }
+                        throw new InvalidOperationException($"{node} must be of type '{typeof(ShardReplicationNode)}'");
                 }
             }
 

--- a/src/Raven.Server/RavenServer.cs
+++ b/src/Raven.Server/RavenServer.cs
@@ -2428,7 +2428,7 @@ namespace Raven.Server
                         var shardedReplicationLoader = tcp.DatabaseContext.Replication;
                         var queue = new ReplicationQueue(result.DatabaseContext.ShardCount);
 
-                        shardedReplicationLoader.AcceptIncomingConnection(tcp, header, cert, bufferToCopy, queue);
+                        shardedReplicationLoader.AcceptIncomingConnection(tcp, bufferToCopy, queue);
 
                         for (int i = 0; i < tcp.DatabaseContext.ShardCount; i++)
                         {

--- a/src/Raven.Server/RavenServer.cs
+++ b/src/Raven.Server/RavenServer.cs
@@ -2426,21 +2426,8 @@ namespace Raven.Server
                     if (result.DatabaseStatus == DatabasesLandlord.DatabaseSearchResult.Status.Sharded)
                     {
                         var shardedReplicationLoader = tcp.DatabaseContext.Replication;
-                        var queue = new ReplicationQueue(result.DatabaseContext.ShardCount);
 
-                        shardedReplicationLoader.AcceptIncomingConnection(tcp, header, bufferToCopy, queue);
-
-                        for (int i = 0; i < tcp.DatabaseContext.ShardCount; i++)
-                        {
-                            var replicationNode = new ShardReplicationNode
-                            {
-                                Database = ShardHelper.ToShardName(tcp.DatabaseContext.DatabaseName, i),
-                                Shard = i,
-                                ReplicationQueue = queue
-                            };
-
-                            shardedReplicationLoader.AddAndStartOutgoingReplication(replicationNode);
-                        }
+                        shardedReplicationLoader.AcceptIncomingConnection(tcp, header, bufferToCopy);
                         break;
                     }
 

--- a/src/Raven.Server/RavenServer.cs
+++ b/src/Raven.Server/RavenServer.cs
@@ -2428,7 +2428,7 @@ namespace Raven.Server
                         var shardedReplicationLoader = tcp.DatabaseContext.Replication;
                         var queue = new ReplicationQueue(result.DatabaseContext.ShardCount);
 
-                        shardedReplicationLoader.AcceptIncomingConnection(tcp, bufferToCopy, queue);
+                        shardedReplicationLoader.AcceptIncomingConnection(tcp, header, bufferToCopy, queue);
 
                         for (int i = 0; i < tcp.DatabaseContext.ShardCount; i++)
                         {

--- a/src/Raven.Server/ServerWide/ClusterStateMachine.cs
+++ b/src/Raven.Server/ServerWide/ClusterStateMachine.cs
@@ -3505,12 +3505,10 @@ namespace Raven.Server.ServerWide
         {
             using (var databaseRecord = ReadRawDatabaseRecord(context, name))
             {
-                DatabaseTopology topology;
                 if (databaseRecord.IsSharded)
-                    topology = databaseRecord.Sharding?.Orchestrator.Topology;
-                else
-                    topology = databaseRecord.Topology;
-
+                    throw new InvalidOperationException($"The database record '{name}' is sharded and doesn't contain topology directly.");
+                
+                var topology = databaseRecord.Topology;
                 if (topology == null)
                     throw new InvalidOperationException($"The database record '{name}' doesn't contain topology.");
 

--- a/src/Raven.Server/ServerWide/ClusterStateMachine.cs
+++ b/src/Raven.Server/ServerWide/ClusterStateMachine.cs
@@ -3507,7 +3507,7 @@ namespace Raven.Server.ServerWide
             {
                 DatabaseTopology topology;
                 if (databaseRecord.IsSharded)
-                    return databaseRecord.Sharding.Orchestrator.Topology;
+                    topology = databaseRecord.Sharding?.Orchestrator.Topology;
                 else
                     topology = databaseRecord.Topology;
 

--- a/src/Raven.Server/ServerWide/ClusterStateMachine.cs
+++ b/src/Raven.Server/ServerWide/ClusterStateMachine.cs
@@ -3505,10 +3505,12 @@ namespace Raven.Server.ServerWide
         {
             using (var databaseRecord = ReadRawDatabaseRecord(context, name))
             {
+                DatabaseTopology topology;
                 if (databaseRecord.IsSharded)
-                    throw new InvalidOperationException($"The database record '{name}' is sharded and doesn't contain topology directly.");
+                    return databaseRecord.Sharding.Orchestrator.Topology;
+                else
+                    topology = databaseRecord.Topology;
 
-                var topology = databaseRecord.Topology;
                 if (topology == null)
                     throw new InvalidOperationException($"The database record '{name}' doesn't contain topology.");
 

--- a/src/Raven.Server/ServerWide/Maintenance/ClusterMaintenanceWorker.cs
+++ b/src/Raven.Server/ServerWide/Maintenance/ClusterMaintenanceWorker.cs
@@ -358,7 +358,7 @@ namespace Raven.Server.ServerWide.Maintenance
                 var node = outgoing.GetNode();
                 if (node != null)
                 {
-                    report.LastSentEtag.Add(node, outgoing._lastSentDocumentEtag);
+                    report.LastSentEtag.Add(node, outgoing.LastSentDocumentEtag);
                 }
             }
         }

--- a/src/Raven.Server/Web/System/Processors/OngoingTasks/OngoingTasksHandlerProcessorForGetOngoingTasksInfo.cs
+++ b/src/Raven.Server/Web/System/Processors/OngoingTasks/OngoingTasksHandlerProcessorForGetOngoingTasksInfo.cs
@@ -408,7 +408,7 @@ internal abstract class OngoingTasksHandlerProcessorForGetOngoingTasksInfo : Abs
         return ValueTask.FromResult(connectionStatus);
     }
 
-    protected List<IncomingReplicationHandler> GetIncomingHandlers() => RequestHandler.Database.ReplicationLoader.IncomingHandlers.ToList();
+    protected List<IAbstractIncomingReplicationHandler> GetIncomingHandlers() => RequestHandler.Database.ReplicationLoader.IncomingHandlers.ToList();
 
     protected override int SubscriptionsCount => (int)_database.SubscriptionStorage.GetAllSubscriptionsCount();
 

--- a/test/RachisTests/DatabaseCluster/ReplicationTests.cs
+++ b/test/RachisTests/DatabaseCluster/ReplicationTests.cs
@@ -1341,7 +1341,7 @@ namespace RachisTests.DatabaseCluster
             using (var store2 = GetDocumentStore())
             {
                 var database = await Databases.GetDocumentDatabaseInstanceFor(store1);
-                var handlers = new HashSet<OutgoingReplicationHandlerBase>();
+                var handlers = new HashSet<DatabaseOutgoingReplicationHandlerBase>();
 
                 database.ReplicationLoader.OutgoingReplicationAdded += handler =>
                 {
@@ -1358,7 +1358,7 @@ namespace RachisTests.DatabaseCluster
                 {
                     foreach (var handler in database.ReplicationLoader.OutgoingHandlers)
                     {
-                        handlers.Add(handler as OutgoingReplicationHandlerBase);
+                        handlers.Add(handler as DatabaseOutgoingReplicationHandlerBase);
                     }
 
                     return handlers.Count;

--- a/test/RachisTests/DatabaseCluster/ReplicationTests.cs
+++ b/test/RachisTests/DatabaseCluster/ReplicationTests.cs
@@ -1341,7 +1341,7 @@ namespace RachisTests.DatabaseCluster
             using (var store2 = GetDocumentStore())
             {
                 var database = await Databases.GetDocumentDatabaseInstanceFor(store1);
-                var handlers = new HashSet<DatabaseOutgoingReplicationHandlerBase>();
+                var handlers = new HashSet<DatabaseOutgoingReplicationHandler>();
 
                 database.ReplicationLoader.OutgoingReplicationAdded += handler =>
                 {
@@ -1358,7 +1358,7 @@ namespace RachisTests.DatabaseCluster
                 {
                     foreach (var handler in database.ReplicationLoader.OutgoingHandlers)
                     {
-                        handlers.Add(handler as DatabaseOutgoingReplicationHandlerBase);
+                        handlers.Add(handler as DatabaseOutgoingReplicationHandler);
                     }
 
                     return handlers.Count;

--- a/test/RachisTests/DatabaseCluster/ReplicationTests.cs
+++ b/test/RachisTests/DatabaseCluster/ReplicationTests.cs
@@ -212,7 +212,7 @@ namespace RachisTests.DatabaseCluster
                     {
                         var db = s.ServerStore.DatabasesLandlord.TryGetOrCreateResourceStore(source.Database).Result;
                         return db.ReplicationLoader.OutgoingHandlers.Where(h => h.Destination.Database == dest.Database);
-                    }).Single()._parent._server.NodeTag;
+                    }).Single().Server.NodeTag;
                 }, otherNodeTag);
 
                 using (var session = source.OpenAsyncSession())
@@ -1104,7 +1104,7 @@ namespace RachisTests.DatabaseCluster
                 {
                     foreach (var handler in database.ReplicationLoader.OutgoingHandlers)
                     {
-                        handlers.Add(handler);
+                        handlers.Add(handler as OutgoingReplicationHandlerBase);
                     }
 
                     return handlers.Count;

--- a/test/RachisTests/DatabaseCluster/ReplicationTests.cs
+++ b/test/RachisTests/DatabaseCluster/ReplicationTests.cs
@@ -967,7 +967,7 @@ namespace RachisTests.DatabaseCluster
         public async Task ExternalReplicationFailoverFromNonShardedToShardedDatabase()
         {
             var clusterSize = 3;
-            var replicationFactor = 2;
+            var replicationFactor = 3;
 
             var (_, srcLeader) = await CreateRaftCluster(clusterSize);
             var (dstNodes, dstLeader) = await CreateRaftCluster(clusterSize);

--- a/test/SlowTests/Server/Documents/Replication/ServerWideReplication.cs
+++ b/test/SlowTests/Server/Documents/Replication/ServerWideReplication.cs
@@ -17,6 +17,7 @@ using Raven.Client.ServerWide.Operations.OngoingTasks;
 using Raven.Server.ServerWide.Commands;
 using Raven.Server.ServerWide.Context;
 using Sparrow.Json;
+using Tests.Infrastructure;
 using Xunit;
 using Xunit.Abstractions;
 
@@ -29,10 +30,11 @@ namespace SlowTests.Server.Documents.Replication
             DoNotReuseServer();
         }
 
-        [Fact]
-        public async Task CanStoreServerWideExternalReplication()
+        [RavenTheory(RavenTestCategory.Replication)]
+        [RavenData(DatabaseMode = RavenDatabaseMode.All)]
+        public async Task CanStoreServerWideExternalReplication(Options options)
         {
-            using (var store = GetDocumentStore())
+            using (var store = GetDocumentStore(options))
             {
                 var putConfiguration = new ServerWideExternalReplication
                 {
@@ -80,10 +82,11 @@ namespace SlowTests.Server.Documents.Replication
             }
         }
 
-        [Fact]
-        public async Task UpdateServerWideReplicationThroughUpdateReplicationTaskFails()
+        [RavenTheory(RavenTestCategory.Replication)]
+        [RavenData(DatabaseMode = RavenDatabaseMode.All)]
+        public async Task UpdateServerWideReplicationThroughUpdateReplicationTaskFails(Options options)
         {
-            using (var store = GetDocumentStore())
+            using (var store = GetDocumentStore(options))
             {
                 var putConfiguration = new ServerWideExternalReplication
                 {
@@ -119,10 +122,11 @@ namespace SlowTests.Server.Documents.Replication
             }
         }
 
-        [Fact]
-        public async Task ServerWideExternalReplication_WhenRename_ShouldNotCreateNewOne()
+        [RavenTheory(RavenTestCategory.Replication)]
+        [RavenData(DatabaseMode = RavenDatabaseMode.All)]
+        public async Task ServerWideExternalReplication_WhenRename_ShouldNotCreateNewOne(Options options)
         {
-            using var store = GetDocumentStore();
+            using var store = GetDocumentStore(options);
             var putConfiguration = new ServerWideExternalReplication
             {
                 Disabled = true,
@@ -159,10 +163,11 @@ namespace SlowTests.Server.Documents.Replication
                 () => Assert.EndsWith(editSuffix, databaseRecord2After.ExternalReplications.First().Name));
         }
 
-        [Fact]
-        public async Task ServerWideExternalReplication_WhenToggleState_ShouldWork()
+        [RavenTheory(RavenTestCategory.Replication)]
+        [RavenData(DatabaseMode = RavenDatabaseMode.All)]
+        public async Task ServerWideExternalReplication_WhenToggleState_ShouldWork(Options options)
         {
-            using var store = GetDocumentStore();
+            using var store = GetDocumentStore(options);
             var disabled = true;
             var putConfiguration = new ServerWideExternalReplication
             {
@@ -194,11 +199,12 @@ namespace SlowTests.Server.Documents.Replication
             }
         }
 
-        
-        [Fact]
-        public async Task ToggleDisableServerWideExternalReplicationFails()
+
+        [RavenTheory(RavenTestCategory.Replication)]
+        [RavenData(DatabaseMode = RavenDatabaseMode.All)]
+        public async Task ToggleDisableServerWideExternalReplicationFails(Options options)
         {
-            using (var store = GetDocumentStore())
+            using (var store = GetDocumentStore(options))
             {
                 var putConfiguration = new ServerWideExternalReplication
                 {
@@ -221,10 +227,11 @@ namespace SlowTests.Server.Documents.Replication
             }
         }
 
-        [Fact]
-        public async Task CanCreateMoreThanOneServerWideExternalReplication()
+        [RavenTheory(RavenTestCategory.Replication)]
+        [RavenData(DatabaseMode = RavenDatabaseMode.All)]
+        public async Task CanCreateMoreThanOneServerWideExternalReplication(Options options)
         {
-            using (var store = GetDocumentStore())
+            using (var store = GetDocumentStore(options))
             {
                 var putConfiguration = new ServerWideExternalReplication
                 {
@@ -259,10 +266,11 @@ namespace SlowTests.Server.Documents.Replication
             }
         }
 
-        [Fact]
-        public async Task CanDeleteServerWideExternalReplication()
+        [RavenTheory(RavenTestCategory.Replication)]
+        [RavenData(DatabaseMode = RavenDatabaseMode.All)]
+        public async Task CanDeleteServerWideExternalReplication(Options options)
         {
-            using (var store = GetDocumentStore())
+            using (var store = GetDocumentStore(options))
             {
                 var putConfiguration = new ServerWideExternalReplication
                 {
@@ -521,10 +529,11 @@ namespace SlowTests.Server.Documents.Replication
             }
         }
 
-        [Fact]
-        public async Task CanExcludeDatabase()
+        [RavenTheory(RavenTestCategory.Replication)]
+        [RavenData(DatabaseMode = RavenDatabaseMode.All)]
+        public async Task CanExcludeDatabase(Options options)
         {
-            using (var store = GetDocumentStore())
+            using (var store = GetDocumentStore(options))
             {
                 var serverWideExternalReplication = new ServerWideExternalReplication
                 {
@@ -573,10 +582,11 @@ namespace SlowTests.Server.Documents.Replication
             }
         }
 
-        [Fact]
-        public async Task CanExcludeForNewDatabase()
+        [RavenTheory(RavenTestCategory.Replication)]
+        [RavenData(DatabaseMode = RavenDatabaseMode.All)]
+        public async Task CanExcludeForNewDatabase(Options options)
         {
-            using (var store = GetDocumentStore())
+            using (var store = GetDocumentStore(options))
             {
                 var newDbName = store.Database + "-testDatabase";
                 var serverWideExternalReplication = new ServerWideExternalReplication
@@ -663,10 +673,11 @@ namespace SlowTests.Server.Documents.Replication
             }
         }
 
-        [Fact]
-        public async Task FailToAddNullOrEmptyDatabaseNames()
+        [RavenTheory(RavenTestCategory.Replication)]
+        [RavenData(DatabaseMode = RavenDatabaseMode.All)]
+        public async Task FailToAddNullOrEmptyDatabaseNames(Options options)
         {
-            using (var store = GetDocumentStore())
+            using (var store = GetDocumentStore(options))
             {
                 var serverWideExternalReplication = new ServerWideExternalReplication
                 {

--- a/test/SlowTests/Server/Replication/PullReplicationPreventDeletionsTests.cs
+++ b/test/SlowTests/Server/Replication/PullReplicationPreventDeletionsTests.cs
@@ -16,6 +16,7 @@ using Raven.Client.Documents.Operations.Replication;
 using Raven.Client.Documents.Session;
 using Raven.Client.ServerWide.Operations.Certificates;
 using Raven.Server.Config;
+using Raven.Server.Documents.Replication.Incoming;
 using SlowTests.Issues;
 using Tests.Infrastructure;
 using Xunit;
@@ -120,7 +121,9 @@ namespace SlowTests.Server.Replication
             var hubDatabaseInstance = await Databases.GetDocumentDatabaseInstanceFor(hubStore);
             bool expectedError = false;
             string lastError = null;
-            hubDatabaseInstance.ReplicationLoader.IncomingHandlers.ToArray()[0].Failed += (handler, exception) =>
+
+            var incomingHandler = hubDatabaseInstance.ReplicationLoader.IncomingHandlers.ToArray()[0] as IncomingReplicationHandler;
+            incomingHandler.Failed += (handler, exception) =>
             {
                 if (exception.Message.Contains("This hub does not allow for tombstone replication via pull replication"))
                 {

--- a/test/SlowTests/Server/Replication/PullReplicationTests.cs
+++ b/test/SlowTests/Server/Replication/PullReplicationTests.cs
@@ -27,7 +27,7 @@ namespace SlowTests.Server.Replication
         }
 
         [RavenTheory(RavenTestCategory.Replication)]
-        [RavenData(DatabaseMode = RavenDatabaseMode.All)]
+        [RavenData(DatabaseMode = RavenDatabaseMode.Single)]
         public async Task CanDefinePullReplication(Options options)
         {
             using (var store = GetDocumentStore(options))

--- a/test/SlowTests/Server/Replication/ReplicationBasicTestsSlow.cs
+++ b/test/SlowTests/Server/Replication/ReplicationBasicTestsSlow.cs
@@ -257,7 +257,7 @@ namespace SlowTests.Server.Replication
                     Assert.Equal(1, WaitForValue(() => db2.ReplicationLoader.IncomingHandlers.Count(), 1));
                     var outgoingReplicationConnection = db1.ReplicationLoader.OutgoingHandlers.First();
                     var incomingReplicationConnection = db2.ReplicationLoader.IncomingHandlers.First();
-                    Assert.Equal(20, WaitForValue(() => outgoingReplicationConnection._lastSentDocumentEtag, 20));
+                    Assert.Equal(20, WaitForValue(() => outgoingReplicationConnection.LastSentDocumentEtag, 20));
                     Assert.Equal(20, WaitForValue(() => incomingReplicationConnection.LastDocumentEtag, 20));
 
                     var stats1 = store1.Maintenance.Send(new GetStatisticsOperation());

--- a/test/Tests.Infrastructure/ClusterTestBase.Sharding.cs
+++ b/test/Tests.Infrastructure/ClusterTestBase.Sharding.cs
@@ -155,24 +155,8 @@ public partial class ClusterTestBase
             foreach (var store in stores)
             {
                 var storage = await store;
-                using (var collector = new LiveReplicationPulsesCollector(storage))
-                {
-                    var etag1 = storage.DocumentsStorage.GenerateNextEtag();
 
-                    await Task.Delay(3000);
-
-                    var etag2 = storage.DocumentsStorage.GenerateNextEtag();
-
-                    Assert.True(etag1 + 1 == etag2, "Replication loop found :(");
-
-                    var groups = collector.Pulses.GetAll().GroupBy(p => p.Direction);
-                    foreach (var group in groups)
-                    {
-                        var key = group.Key;
-                        var count = group.Count();
-                        Assert.True(count < 50, $"{key} seems to be excessive ({count})");
-                    }
-                }
+                await EnsureNoReplicationLoop(storage);
             }
         }
     }

--- a/test/Tests.Infrastructure/ClusterTestBase.cs
+++ b/test/Tests.Infrastructure/ClusterTestBase.cs
@@ -250,6 +250,12 @@ namespace Tests.Infrastructure
         protected static async Task EnsureNoReplicationLoop(RavenServer server, string database)
         {
             var storage = await server.ServerStore.DatabasesLandlord.TryGetOrCreateResourceStore(database);
+
+            await EnsureNoReplicationLoop(storage);
+        }
+
+        protected static async Task EnsureNoReplicationLoop(DocumentDatabase storage)
+        {
             using (var collector = new LiveReplicationPulsesCollector(storage))
             {
                 var etag1 = storage.DocumentsStorage.GenerateNextEtag();

--- a/test/Tests.Infrastructure/RavenTestBase.Sharding.cs
+++ b/test/Tests.Infrastructure/RavenTestBase.Sharding.cs
@@ -124,7 +124,7 @@ public partial class RavenTestBase
                 DatabaseContext = database,
                 HttpContext = new DefaultHttpContext()
             };
-            handler.Init(ctx);
+            handler.InitForOfflineOperation(ctx);
             return new ShardedOngoingTasksHandlerProcessorForGetOngoingTasks(handler);
         }
 

--- a/test/Tests.Infrastructure/RavenTestBase.Sharding.cs
+++ b/test/Tests.Infrastructure/RavenTestBase.Sharding.cs
@@ -5,6 +5,7 @@ using System.Linq;
 using System.Runtime.CompilerServices;
 using System.Threading;
 using System.Threading.Tasks;
+using Microsoft.AspNetCore.Http;
 using Raven.Client;
 using Raven.Client.Documents;
 using Raven.Client.Documents.Indexes;
@@ -22,8 +23,11 @@ using Raven.Client.ServerWide.Sharding;
 using Raven.Server;
 using Raven.Server.Documents;
 using Raven.Server.Documents.PeriodicBackup;
+using Raven.Server.Documents.Sharding.Handlers;
+using Raven.Server.Documents.Sharding.Handlers.Processors.OngoingTasks;
 using Raven.Server.ServerWide.Context;
 using Raven.Server.Utils;
+using Raven.Server.Web;
 using Raven.Tests.Core.Utils.Entities;
 using Tests.Infrastructure;
 using Xunit;
@@ -109,7 +113,22 @@ public partial class RavenTestBase
             return true;
         }
 
-        public class ShardedBackupTestsBase
+        internal async Task<ShardedOngoingTasksHandlerProcessorForGetOngoingTasks> InstantiateShardedOutgoingTaskProcessor(string name, RavenServer server)
+        {
+            Assert.True(server.ServerStore.DatabasesLandlord.ShardedDatabasesCache.TryGetValue(name, out var db));
+            var database = await db;
+            var handler = new ShardedOngoingTasksHandler();
+            var ctx = new RequestHandlerContext
+            {
+                RavenServer = server,
+                DatabaseContext = database,
+                HttpContext = new DefaultHttpContext()
+            };
+            handler.Init(ctx);
+            return new ShardedOngoingTasksHandlerProcessorForGetOngoingTasks(handler);
+        }
+
+        public class ShardedBackupTestsBase 
         {
             internal readonly RavenTestBase _parent;
 


### PR DESCRIPTION
### Issue link

https://issues.hibernatingrhinos.com/issue/RavenDB-13110/Sharding-external-and-pull-replication-integration

### Additional description

TO DO:

- Handle shards' `Etag `& `ChangeVector` for optimizing replication failovers to not start from scratch. 

- Handle exceptions on replicating to shard.

- Avoid cloning attachments on the orchestrator.

### Type of change

- New feature

### How risky is the change?

- Not relevant

### Backward compatibility

- Not relevant

### Is it platform specific issue?

- No

### Documentation update

- No documentation update is needed 

### Testing 

- Tests have been added that prove the fix is effective or that the feature works
- It has been verified by manual testing

### Is there any existing behavior change of other features due to this change?

- No

### UI work

- No UI work is needed
