### PR TITLE
RavenDB-18058 & RavenDB-16877 : fix flaky olap tests

### DIFF
--- a/test/SlowTests/Server/Documents/ETL/Olap/LocalTests.cs
+++ b/test/SlowTests/Server/Documents/ETL/Olap/LocalTests.cs
@@ -28,6 +28,7 @@ namespace SlowTests.Server.Documents.ETL.Olap
     {
         internal const string DefaultFrequency = "* * * * *"; // every minute
         internal const string AllFilesPattern = "*.*";
+        private readonly TimeSpan _defaultTimeout = TimeSpan.FromSeconds(65);
 
         public LocalTests(ITestOutputHelper output) : base(output)
         {
@@ -2032,8 +2033,8 @@ loadToOrders(partitionBy(['year', orderDate.getFullYear()]),
 
                 var database = await GetDatabase(store.Database);
                 var timeout = database.DocumentsStorage.Environment.Options.RunningOn32Bits
-                    ? TimeSpan.FromMinutes(2)
-                    : TimeSpan.FromMinutes(1);
+                    ? _defaultTimeout * 2
+                    : _defaultTimeout;
 
                 Assert.True(etlDone.Wait(timeout), 
                     $"olap etl to local machine did not finish in {timeout.TotalMinutes} minutes. stats : {S3Tests.GetPerformanceStats(database)}");

--- a/test/SlowTests/Server/Documents/ETL/Olap/S3Tests.cs
+++ b/test/SlowTests/Server/Documents/ETL/Olap/S3Tests.cs
@@ -414,8 +414,8 @@ loadToOrders(partitionBy(key), orderData);
         internal static string GetPerformanceStats(DocumentDatabase database)
         {
             var process = database.EtlLoader.Processes.First();
-            var stats = process?.GetLatestPerformanceStats().ToPerformanceStats();
-            return JsonConvert.SerializeObject(stats);
+            var stats = process.GetPerformanceStats();
+            return string.Join(Environment.NewLine, stats.Select(JsonConvert.SerializeObject));
         }
 
         [AmazonS3Fact]


### PR DESCRIPTION
### Issue link

https://issues.hibernatingrhinos.com/issue/RavenDB-18058/SlowTestsServerDocumentsETLOlapLocalTestsCanUpdateRunFrequency

https://issues.hibernatingrhinos.com/issue/RavenDB-16877/SlowTestsServerDocumentsETLOlapFailoverTestsOlapTaskShouldBeHighlyAvailable

### Type of change

- Bug fix

### How risky is the change?

- Low 

### Backward compatibility

- Not relevant

### Is it platform specific issue?

- No

### Documentation update

- No documentation update is needed 


### Is there any existing behavior change of other features due to this change?

- No

### UI work

- No UI work is needed
