### PR TITLE
RavenDB-19034 fix Infinite leader/follower negotiation

### DIFF
--- a/test/Tests.Infrastructure/RachisConsensusTestBase.cs
+++ b/test/Tests.Infrastructure/RachisConsensusTestBase.cs
@@ -161,8 +161,15 @@ namespace Tests.Infrastructure
             sb.AppendLine("Waited too long for a node to become a leader but no leader was elected.");
             foreach (var node in nodes)
             {
-                sb.AppendLine($"'{node.Tag}' is {node.CurrentState} at term {node.CurrentTerm} (running: {node.Candidate.Running})");
-                sb.AppendJoin(Environment.NewLine, node.Candidate.GetStatus().Values);
+                var candidate = node.Candidate;
+                if (candidate == null)
+                {
+                    sb.AppendLine($"'{node.Tag}' is {node.CurrentState} at term {node.CurrentTerm}, current candidate is null {node.LastStateChangeReason}");
+                    continue;
+                }
+
+                sb.AppendLine($"'{node.Tag}' is {node.CurrentState} at term {node.CurrentTerm} (running: {candidate.Running})");
+                sb.AppendJoin(Environment.NewLine, candidate.GetStatus().Values);
                 sb.AppendLine();
             }
 
@@ -371,6 +378,7 @@ namespace Tests.Infrastructure
                 catch (Exception e)
                 {
                     lastException = e;
+                    await Task.Delay(50);
                 }
             } while (retires-- > 0);
 
@@ -496,6 +504,9 @@ namespace Tests.Infrastructure
             public override DynamicJsonValue ToJson(JsonOperationContext context)
             {
                 var djv = base.ToJson(context);
+                UniqueRequestId ??= Guid.NewGuid().ToString();
+                
+                djv[nameof(UniqueRequestId)] = UniqueRequestId;
                 djv[nameof(Name)] = Name;
                 djv[nameof(Value)] = Value;
 

--- a/test/Tryouts/Program.cs
+++ b/test/Tryouts/Program.cs
@@ -3,6 +3,7 @@ using System.Diagnostics;
 using System.Threading.Tasks;
 using FastTests.Blittable;
 using FastTests.Client;
+using RachisTests;
 using SlowTests.Client.TimeSeries.Replication;
 using SlowTests.Issues;
 using SlowTests.MailingList;
@@ -29,9 +30,9 @@ namespace Tryouts
                 try
                 {
                     using (var testOutputHelper = new ConsoleTestOutputHelper())
-                    using (var test = new TimeSeriesReplicationTests(testOutputHelper))
+                    using (var test = new ElectionTests(testOutputHelper))
                     {
-                         await test.PreferDeletedValues3();
+                         await test.CanElectOnDivergence4();
                     }
                 }
                 catch (Exception e)


### PR DESCRIPTION
### Issue link

https://issues.hibernatingrhinos.com/issue/RavenDB-19034

### Additional description

under very specific shape of the raft log we could have end up in a constant negotiation between the leader and the follower.

### Type of change

- Bug fix

### How risky is the change?

- Low 

### Backward compatibility

- Not relevant (no persistent state involved)

### Is it platform specific issue?

- No

### Documentation update

- No documentation update is needed 

### Testing 

- Tests have been added that prove the fix is effective or that the feature works

### Is there any existing behavior change of other features due to this change?

- No

### UI work

- No UI work is needed
