### PR TITLE
RavenDB-19002 /  RavenDB-19046 / RavenDB-17287 If a database load has…

### DIFF
--- a/src/Raven.Server/Documents/ResourceCache.cs
+++ b/src/Raven.Server/Documents/ResourceCache.cs
@@ -241,7 +241,7 @@ namespace Raven.Server.Documents
                 {
                     _forTestingPurposes?.OnRemoveLockAndReturnDispose?.Invoke(this);
 
-                    TryRemove(databaseName, resourceLocked);
+                    TryRemove(databaseName, current);
                 });
             }
 


### PR DESCRIPTION
… failed then we want to remove the faulty task

### Issue link

Original issue:
https://issues.hibernatingrhinos.com/issue/RavenDB-19002/Dangling-DocumentDatabase-instances-due-to-possible-race-with-the-usage-of-ResourceCacheT

Failing tests:
https://issues.hibernatingrhinos.com/issue/RavenDB-19046
https://issues.hibernatingrhinos.com/issue/RavenDB-17287

### Additional description

Two tests started to fail quite often after PR https://github.com/ravendb/ravendb/pull/14602 as noticed in https://github.com/ravendb/ravendb/pull/14602#issuecomment-1199128393

That was indication of real bug.

### Type of change

- Bug fix

### How risky is the change?

- Moderate 

### Backward compatibility

- Not relevant

### Is it platform specific issue?

- No

### Documentation update

- No documentation update is needed 

### Testing 

- Tests have been added that prove the fix is effective or that the feature works
 - Internal classes added to the test class (e.g. entity or index definition classes) have the lowest possible access modifier (preferable `private`) 

### Is there any existing behavior change of other features due to this change?

- No

### UI work

- No UI work is needed
