### PR TITLE
RavenDB-13633 Active Tabs in Properties Pane upon New Document

### DIFF
--- a/src/Raven.Studio/typescript/viewmodels/database/documents/editDocument.ts
+++ b/src/Raven.Studio/typescript/viewmodels/database/documents/editDocument.ts
@@ -521,7 +521,7 @@ class editDocument extends viewModelBase {
         });
         
         this.canViewRelated = ko.pureComputed(() => {
-            return !this.isDeleteRevision();
+            return !this.isDeleteRevision() && (this.isClone() || !this.isCreatingNewDocument());
         });
 
         this.canViewCSharpClass = ko.pureComputed(() => {
@@ -582,6 +582,7 @@ class editDocument extends viewModelBase {
     editNewDocument(collectionForNewDocument: string): JQueryPromise<document> {
         this.isCreatingNewDocument(true);
         this.collectionForNewDocument(collectionForNewDocument);
+        this.connectedDocuments.activateRecent();
         
         const documentTask = $.Deferred<document>();
 


### PR DESCRIPTION
### Issue link
https://issues.hibernatingrhinos.com/issue/RavenDB-13633

### Additional description
Disable the 'related' tab for a new document + make 'recent' the current active tab

### Type of change
- Bug fix

### How risky is the change?
- Low 

### Backward compatibility
- Non breaking change

### Is it platform specific issue?
- No

### Documentation update
- No documentation update is needed 

### Testing 
- It has been verified by manual testing

### Is there any existing behavior change of other features due to this change?
- No

### UI work
- No UI work is needed
