### PR TITLE
RavenDB-12603 Query Index with a Given Term - Missing escape character

### DIFF
--- a/src/Raven.Studio/typescript/common/queryUtil.ts
+++ b/src/Raven.Studio/typescript/common/queryUtil.ts
@@ -34,7 +34,8 @@ class queryUtil {
     static formatIndexQuery(indexName: string, fieldName: string, value: string) {
         const escapedFieldName = queryUtil.escapeCollectionOrFieldName(fieldName);
         const escapedIndexName = queryUtil.escapeName(indexName);
-        return `from index ${escapedIndexName} where ${escapedFieldName} = '${value}' `;
+        const escapedValueName = queryUtil.escapeName(value);
+        return `from index ${escapedIndexName} where ${escapedFieldName} == ${escapedValueName}`;
     }
     
     private static wrapWithSingleQuotes(input: string) {


### PR DESCRIPTION
### Issue link
https://issues.hibernatingrhinos.com/issue/RavenDB-12603

### Additional description
Added the missing escape to the value

### Type of change
- Bug fix

### How risky is the change?
- Low 

### Backward compatibility
- Non breaking change

### Is it platform specific issue?
- No

### Documentation update
- No documentation update is needed 

### Testing 
- It has been verified by manual testing

### Is there any existing behavior change of other features due to this change?
- No

### UI work
- No UI work is needed
