### PR TITLE
RavenDB-13373  Add 'exact' for queries on Auto Index Terms

### DIFF
--- a/src/Raven.Studio/typescript/common/queryUtil.ts
+++ b/src/Raven.Studio/typescript/common/queryUtil.ts
@@ -39,21 +39,11 @@ class queryUtil {
         const fromPart = `from index ${escapedIndexName}`;
         let wherePart = `where ${escapedFieldName} == ${escapedValueName}`;
         
-        if (indexName.startsWith("Auto") && 
-            ((value.startsWith("{") && queryUtil.hasUpperCase(value)) || value === "NULL_VALUE")) {
+        if (indexName.startsWith("Auto") && (value.startsWith("{") || value === "NULL_VALUE")) {
             wherePart = `where exact(${escapedFieldName} == ${escapedValueName})`;
         }
         
         return `${fromPart} ${wherePart}`;
-    }
-
-    static hasUpperCase(value: string): boolean {
-        for (let i = 0; i < value.length; i++) {
-            if (/^[A-Z]$/.test(value[i])) {
-                return true;
-            }
-        }
-        return false;
     }
     
     private static wrapWithSingleQuotes(input: string) {

--- a/src/Raven.Studio/typescript/common/queryUtil.ts
+++ b/src/Raven.Studio/typescript/common/queryUtil.ts
@@ -39,11 +39,16 @@ class queryUtil {
         const fromPart = `from index ${escapedIndexName}`;
         let wherePart = `where ${escapedFieldName} == ${escapedValueName}`;
         
-        if (indexName.startsWith("Auto") && (value.startsWith("{") || value === "NULL_VALUE")) {
+        if (indexName.startsWith("Auto") &&
+            ((value.startsWith("{") && (queryUtil.hasUpperCase(value))) || value === "NULL_VALUE")) {
             wherePart = `where exact(${escapedFieldName} == ${escapedValueName})`;
         }
         
         return `${fromPart} ${wherePart}`;
+    }
+    
+    static hasUpperCase(value: string): boolean {
+        return value.toLocaleLowerCase() !== value;
     }
     
     private static wrapWithSingleQuotes(input: string) {

--- a/src/Raven.Studio/typescript/common/queryUtil.ts
+++ b/src/Raven.Studio/typescript/common/queryUtil.ts
@@ -35,7 +35,15 @@ class queryUtil {
         const escapedFieldName = queryUtil.escapeCollectionOrFieldName(fieldName);
         const escapedIndexName = queryUtil.escapeName(indexName);
         const escapedValueName = queryUtil.escapeName(value);
-        return `from index ${escapedIndexName} where ${escapedFieldName} == ${escapedValueName}`;
+        
+        const fromPart = `from index ${escapedIndexName}`;
+        let wherePart = `where ${escapedFieldName} == ${escapedValueName}`;
+        
+        if (indexName.startsWith("Auto") && (value.startsWith("{") || value === "NULL_VALUE")) {
+            wherePart = `where exact(${escapedFieldName} == ${escapedValueName})`;
+        }
+        
+        return `${fromPart} ${wherePart}`;
     }
     
     private static wrapWithSingleQuotes(input: string) {

--- a/src/Raven.Studio/typescript/common/queryUtil.ts
+++ b/src/Raven.Studio/typescript/common/queryUtil.ts
@@ -39,11 +39,21 @@ class queryUtil {
         const fromPart = `from index ${escapedIndexName}`;
         let wherePart = `where ${escapedFieldName} == ${escapedValueName}`;
         
-        if (indexName.startsWith("Auto") && (value.startsWith("{") || value === "NULL_VALUE")) {
+        if (indexName.startsWith("Auto") && 
+            ((value.startsWith("{") && queryUtil.hasUpperCase(value)) || value === "NULL_VALUE")) {
             wherePart = `where exact(${escapedFieldName} == ${escapedValueName})`;
         }
         
         return `${fromPart} ${wherePart}`;
+    }
+
+    static hasUpperCase(value: string): boolean {
+        for (let i = 0; i < value.length; i++) {
+            if (/^[A-Z]$/.test(value[i])) {
+                return true;
+            }
+        }
+        return false;
     }
     
     private static wrapWithSingleQuotes(input: string) {


### PR DESCRIPTION
### Issue link
https://issues.hibernatingrhinos.com/issue/RavenDB-13373

### Additional description
Add 'exact' to queries on Auto index Terms when relevant

### Type of change
- Bug fix

### How risky is the change?
- Low 

### Backward compatibility
- Non breaking change

### Is it platform specific issue?
- No

### Documentation update
- No documentation update is needed 

### Testing 
- It has been verified by manual testing

### Is there any existing behavior change of other features due to this change?
- No

### UI work
- No UI work is needed
