### PR TITLE
RavenDB-19045 : fix flaky test Can_Set_Pin_To_Node_Pull_Replication_As_Sink

### DIFF
--- a/test/SlowTests/Server/Documents/OngoingTasks/PinOnGoingTaskToMentorNodeServerWide.cs
+++ b/test/SlowTests/Server/Documents/OngoingTasks/PinOnGoingTaskToMentorNodeServerWide.cs
@@ -1,27 +1,15 @@
 ﻿using System;
-using System.Collections.Generic;
 using System.Linq;
-using System.Security.Cryptography.X509Certificates;
-using System.Threading;
 using System.Threading.Tasks;
 using FastTests.Server.Replication;
-using Raven.Client.Documents;
-using Raven.Client.Documents.Operations.Backups;
-using Raven.Client.Documents.Operations.ConnectionStrings;
-using Raven.Client.Documents.Operations.ETL;
-using Raven.Client.Documents.Operations.OngoingTasks;
-using Raven.Client.Documents.Operations.Replication;
-using Raven.Client.Documents.Subscriptions;
 using Raven.Client.ServerWide;
 using Raven.Client.ServerWide.Operations;
 using Raven.Client.ServerWide.Operations.OngoingTasks;
-using Raven.Server.Config;
-using Raven.Tests.Core.Utils.Entities;
 using SlowTests.Server.Documents.Replication;
 using Xunit;
 using Xunit.Abstractions;
 
-namespace SlowTests.Server.Documents.ETL;
+namespace SlowTests.Server.Documents.OngoingTasks;
 
 public class PinOnGoingTaskToMentorNodeServerWide : ReplicationTestBase
 {


### PR DESCRIPTION
### Issue link

https://issues.hibernatingrhinos.com/issue/RavenDB-19045

### Type of change

- Bug fix
- Tests stabilization

### How risky is the change?

- Low 

### Backward compatibility

- Not relevant

### Is it platform specific issue?

- No

### Documentation update

- No documentation update is needed 

### Is there any existing behavior change of other features due to this change?

- No

### UI work

- No UI work is needed
