### PR TITLE
RavenDB-19077 - Add the index version to the index stats

### DIFF
--- a/src/Raven.Server/Json/BlittableJsonTextWriterExtensions.cs
+++ b/src/Raven.Server/Json/BlittableJsonTextWriterExtensions.cs
@@ -19,6 +19,7 @@ using Raven.Server.Documents;
 using Raven.Server.Documents.ETL.Stats;
 using Raven.Server.Documents.Handlers;
 using Raven.Server.Documents.Includes;
+using Raven.Server.Documents.Indexes;
 using Raven.Server.Documents.Indexes.Debugging;
 using Raven.Server.Documents.Indexes.Spatial;
 using Raven.Server.Documents.Queries;
@@ -1069,13 +1070,20 @@ namespace Raven.Server.Json
             writer.WriteEndArray();
         }
 
-        public static void WriteIndexDefinition(this AbstractBlittableJsonTextWriter writer, JsonOperationContext context, IndexDefinition indexDefinition, bool removeAnalyzers = false)
+        public static void WriteIndexDefinition(this AbstractBlittableJsonTextWriter writer, JsonOperationContext context, IndexDefinition indexDefinition, long? indexVersion = null)
         {
             writer.WriteStartObject();
 
             writer.WritePropertyName(nameof(indexDefinition.Name));
             writer.WriteString(indexDefinition.Name);
             writer.WriteComma();
+
+            if (indexVersion != null)
+            {
+                writer.WritePropertyName(nameof(IndexDefinitionBaseServerSide.Version));
+                writer.WriteInteger(indexVersion.Value);
+                writer.WriteComma();
+            }
 
             writer.WritePropertyName(nameof(indexDefinition.SourceType));
             writer.WriteString(indexDefinition.SourceType.ToString());
@@ -1206,7 +1214,7 @@ namespace Raven.Server.Json
                 isFirstInternal = false;
                 writer.WritePropertyName(kvp.Key);
                 if (kvp.Value != null)
-                    writer.WriteIndexFieldOptions(context, kvp.Value, removeAnalyzers);
+                    writer.WriteIndexFieldOptions(context, kvp.Value, removeAnalyzers: false);
                 else
                     writer.WriteNull();
             }


### PR DESCRIPTION
### Issue link

https://issues.hibernatingrhinos.com/issue/RavenDB-19077/Add-the-index-version-to-the-index-stats

### Additional description

Add the index version to the index stats

### How risky is the change?

- Low 

### Testing 

- It has been verified by manual testing