### PR TITLE
RavenDB-19040 CalculateMemoryInfoExtended should be done as a backgro…

### DIFF
--- a/src/Raven.Server/Documents/DatabaseMetricCacher.cs
+++ b/src/Raven.Server/Documents/DatabaseMetricCacher.cs
@@ -18,7 +18,7 @@ namespace Raven.Server.Documents
             Register(MetricCacher.Keys.Database.DiskSpaceInfo, TimeSpan.FromSeconds(30), CalculateDiskSpaceInfo);
         }
 
-        private DiskSpaceResult CalculateDiskSpaceInfo()
+        private object CalculateDiskSpaceInfo()
         {
             return DiskUtils.GetDiskSpaceInfo(_database.Configuration.Core.DataDirectory.FullPath);
         }

--- a/src/Raven.Server/RavenServer.cs
+++ b/src/Raven.Server/RavenServer.cs
@@ -549,7 +549,8 @@ namespace Raven.Server
             {
                 try
                 {
-                    var (overallMachineCpuUsage, _, _) = MetricCacher.GetValue(Raven.Server.Utils.MetricCacher.Keys.Server.CpuUsage, CpuUsageCalculator.Calculate);
+                    var cpuUsage = MetricCacher.GetValue(Raven.Server.Utils.MetricCacher.Keys.Server.CpuUsage, CpuUsageCalculator.Calculate);
+                    var overallMachineCpuUsage = cpuUsage.MachineCpuUsage;
                     var utilizationOverAllCores = (overallMachineCpuUsage / 100) * Environment.ProcessorCount;
                     CpuCreditsBalance.CurrentConsumption = utilizationOverAllCores;
                     CpuCreditsBalance.MachineCpuUsage = overallMachineCpuUsage;

--- a/src/Raven.Server/ServerWide/ServerMetricCacher.cs
+++ b/src/Raven.Server/ServerWide/ServerMetricCacher.cs
@@ -58,7 +58,7 @@ namespace Raven.Server.ServerWide
         }
         private static object CalculateMemInfo()
         {
-            if (PlatformDetails.RunningOnPosix == false)
+            if (PlatformDetails.RunningOnPosix == false || PlatformDetails.RunningOnMacOsx)
                 return MemInfo.Invalid;
 
             return MemInfoReader.Read();

--- a/src/Raven.Server/ServerWide/ServerMetricCacher.cs
+++ b/src/Raven.Server/ServerWide/ServerMetricCacher.cs
@@ -47,7 +47,7 @@ namespace Raven.Server.ServerWide
             return MemoryInformation.GetMemoryInfo(_smapsReader, extended: true);
         }
 
-        private DiskSpaceResult CalculateDiskSpaceInfo()
+        private object CalculateDiskSpaceInfo()
         {
             return DiskUtils.GetDiskSpaceInfo(_server.ServerStore.Configuration.Core.DataDirectory.FullPath);
         }
@@ -56,7 +56,7 @@ namespace Raven.Server.ServerWide
         {
             return GC.GetGCMemoryInfo(gcKind);
         }
-        private static MemInfo CalculateMemInfo()
+        private static object CalculateMemInfo()
         {
             if (PlatformDetails.RunningOnPosix == false)
                 return MemInfo.Invalid;

--- a/src/Raven.Server/Utils/MetricCacher.cs
+++ b/src/Raven.Server/Utils/MetricCacher.cs
@@ -69,7 +69,10 @@ namespace Raven.Server.Utils
             if (_metrics.TryGetValue(key, out var value) == false)
                 throw new InvalidOperationException($"Metric '{key}' was not found.");
 
-            return (T)value.GetRefreshedValue();
+            var result = value.GetRefreshedValue();
+            if (result == null)
+                return default;
+            return (T)result;
         }
 
         private class MetricValue
@@ -86,8 +89,19 @@ namespace Raven.Server.Utils
                 _logger = LoggingSource.Instance.GetLogger<MetricValue>(key);
                 _refreshRate = refreshRate;
                 _factory = factory;
-                _value = factory();
                 _task = Task.FromResult(SystemTime.UtcNow + _refreshRate);
+                try
+                {
+                    _value = factory();
+                }
+                catch (Exception e)
+                {
+                    _value = default;
+                    if (_logger.IsOperationsEnabled)
+                    {
+                        _logger.Operations("Got an error while refreshing value", e);
+                    }
+                }
             }
 
             public object GetRefreshedValue()

--- a/src/Raven.Server/Utils/MetricCacher.cs
+++ b/src/Raven.Server/Utils/MetricCacher.cs
@@ -1,6 +1,7 @@
 ﻿using System;
 using System.Collections.Concurrent;
 using System.Threading;
+using System.Threading.Tasks;
 using Raven.Client.Util;
 
 namespace Raven.Server.Utils
@@ -54,11 +55,11 @@ namespace Raven.Server.Utils
             }
         }
 
-        private readonly ConcurrentDictionary<string, MetricValueBase> _metrics = new ConcurrentDictionary<string, MetricValueBase>(StringComparer.OrdinalIgnoreCase);
+        private readonly ConcurrentDictionary<string, MetricValue> _metrics = new(StringComparer.OrdinalIgnoreCase);
 
-        public void Register<T>(string key, TimeSpan refreshRate, Func<T> factory)
+        public void Register(string key, TimeSpan refreshRate, Func<object> factory)
         {
-            if (_metrics.TryAdd(key, new MetricValue<T>(refreshRate, factory)) == false)
+            if (_metrics.TryAdd(key, new MetricValue(refreshRate, factory)) == false)
                 throw new InvalidOperationException($"Cannot cache '{key}' metric, because it already exists.");
         }
 
@@ -67,86 +68,72 @@ namespace Raven.Server.Utils
             if (_metrics.TryGetValue(key, out var value) == false)
                 throw new InvalidOperationException($"Metric '{key}' was not found.");
 
-            if (value.ShouldRefresh(out var first) == false)
-                return (T)value.Value;
-
-            if (first)
-            {
-                lock (value)
-                {
-                    if (value.ShouldRefresh(out first))
-                        value.Refresh();
-
-                    return (T)value.Value;
-                }
-            }
-
-            if (Monitor.TryEnter(value, 0) == false)
-                return (T)value.Value;
-
-            try
-            {
-                if (value.ShouldRefresh(out first))
-                    value.Refresh();
-
-                return (T)value.Value;
-            }
-            finally
-            {
-                Monitor.Exit(value);
-            }
+            return (T)value.GetRefreshedValue();
         }
 
-        private class MetricValue<T> : MetricValueBase
+        private class MetricValue
         {
-            private readonly Func<T> _factory;
+            private readonly TimeSpan _refreshRate;
+            private readonly Func<object> _factory;
+            private Task<DateTime> _task;
+            private object _value;
+            private long _observedFailureTicks;
 
-            public MetricValue(TimeSpan refreshRate, Func<T> factory)
-                : base(refreshRate)
-            {
-                if (factory == null)
-                    throw new ArgumentNullException(nameof(factory));
-
-                _factory = factory;
-            }
-
-            protected override object RefreshInternal()
-            {
-                return _factory();
-            }
-        }
-
-        private abstract class MetricValueBase
-        {
-            private DateTime _lastRefresh;
-            private TimeSpan _refreshRate;
-
-            protected MetricValueBase(TimeSpan refreshRate)
+            public MetricValue(TimeSpan refreshRate, Func<object> factory)
             {
                 _refreshRate = refreshRate;
+                _factory = factory;
+                _value = factory();
+                _task = Task.FromResult(SystemTime.UtcNow + _refreshRate);
             }
 
-            public object Value { get; private set; }
-
-            protected abstract object RefreshInternal();
-
-            internal void Refresh()
+            public object GetRefreshedValue()
             {
-                try
-                {
-                    Value = RefreshInternal();
-                }
-                finally
-                {
-                    _lastRefresh = SystemTime.UtcNow;
-                }
-            }
+                var currentTask = _task;
+                if (currentTask.IsCompleted == false)
+                    return _value; // return current value, while it is being computed
 
-            internal bool ShouldRefresh(out bool first)
-            {
-                first = _lastRefresh == DateTime.MinValue;
+                if (currentTask.IsFaulted)
+                {
+                    // if we failed, we'll retry
+                    var failureAt= new DateTime(_observedFailureTicks);
+                    if (SystemTime.UtcNow - failureAt > _refreshRate)
+                    {
+                        // but only at the same rate as we are expected too
+                        Interlocked.Exchange(ref _observedFailureTicks, SystemTime.UtcNow.Ticks);
+                        TryStartingRefreshTask();
+                    }
+                    // the error must be reported 
+                    throw new InvalidOperationException("Failed to get value", currentTask.Exception);
+                }
 
-                return first || SystemTime.UtcNow - _lastRefresh >= _refreshRate;
+                var nextRefreshForTask = currentTask.Result;
+                if (SystemTime.UtcNow < nextRefreshForTask)
+                    return _value;// no need to refresh yet...
+
+                TryStartingRefreshTask();
+                
+                // we may have started the task (or another thread did), but we don't know if we got a new value or not
+                // we don't care, we are okay with getting the "old" value here, since it will update
+                // soon, and this is likely called many times over, so as long as we get it to some point, we are good
+                return _value;
+
+                void TryStartingRefreshTask()
+                {
+                    var task = new Task<DateTime>(() =>
+                    {
+                        var result = _factory();
+                        var nextRefresh = SystemTime.UtcNow + _refreshRate;
+                        Interlocked.Exchange(ref _value, result);
+                        return nextRefresh;
+                    });
+                    // try to update the task
+                    if (Interlocked.CompareExchange(ref _task, task, currentTask) == currentTask)
+                    {
+                        // we won the right to start the task
+                        task.Start();
+                    }
+                }
             }
         }
     }


### PR DESCRIPTION
…und operation

### Issue link

https://issues.hibernatingrhinos.com/issue/RavenDB-19040 

### Additional description

Changed the way we are handling metrics caching. We now compute the value in the background and not waiting for it or locking.
That ensures that if we have an expensive computation for the metric, we won't hit that all the time in the critical path.

It is okay to get a stale value here (otherwise, we wouldn't be able to use the cache).

### Type of change

- Optimization

### How risky is the change?

- Moderate 

### Backward compatibility

- Non breaking change

### Is it platform specific issue?

- No

### Documentation update

- No documentation update is needed 

### Testing 

- It has been verified by manual testing
