### PR TITLE
RavenDB-7070 Adding messages to Debug.Assert so we'll know exacly which one has failed if that reproduces again (it happens occasionally on macos in debug)

### DIFF
--- a/src/Sparrow/Json/ArenaMemoryAllocator.cs
+++ b/src/Sparrow/Json/ArenaMemoryAllocator.cs
@@ -360,8 +360,8 @@ namespace Sparrow.Json
             var address = allocation.Address;
 
 #if DEBUG
-            Debug.Assert(address != _ptrCurrent);
-            Debug.Assert(allocation.IsReturned == false);
+            Debug.Assert(address != _ptrCurrent, $"address != _ptrCurrent ({new IntPtr(address)} != {new IntPtr(_ptrCurrent)})");
+            Debug.Assert(allocation.IsReturned == false, "allocation.IsReturned == false");
             allocation.IsReturned = true;
 
 #endif


### PR DESCRIPTION

### Additional description

We get ocassionally Debug.Assert failures when running tests on MacOS

```
Microsoft.VisualStudio.TestPlatform.TestHost.DebugAssertException : Method Debug.Fail failed with '
', and was translated to Microsoft.VisualStudio.TestPlatform.TestHost.DebugAssertException to avoid terminating the process hosting the test.
  Stack Trace:
     at System.Diagnostics.Debug.Fail(String message, String detailMessage)
   at Sparrow.Json.JsonOperationContext.ReturnMemory(AllocatedMemoryData allocation) in /Users/runner/work/ravendb/ravendb/src/Sparrow/Json/JsonOperationContext.cs:line 1221
   at Sparrow.Json.UnmanagedWriteBuffer.Dispose() in /Users/runner/work/ravendb/ravendb/src/Sparrow/Json/UnmanagedWriteBuffer.cs:line 453
   at Sparrow.Json.BlittableJsonReaderObject.Dispose() in /Users/runner/work/ravendb/ravendb/src/Sparrow/Json/BlittableJsonReaderObject.cs:line 1030
   at Raven.Client.Documents.Session.Operations.BatchOperation.ApplyMetadataModifications(LazyStringValue id, DocumentInfo documentInfo) in /Users/runner/work/ravendb/ravendb/src/Raven.Client/Documents/Session/Operations/BatchOperation.cs:line 191
   at Raven.Client.Documents.Session.Operations.BatchOperation.HandleMetadataModifications(DocumentInfo documentInfo, BlittableJsonReaderObject batchResult, LazyStringValue id, String changeVector) in /Users/runner/work/ravendb/ravendb/src/Raven.Client/Documents/Session/Operations/BatchOperation.cs:line 548
   at Raven.Client.Documents.Session.Operations.BatchOperation.HandlePut(Int32 index, BlittableJsonReaderObject batchResult, Boolean isDeferred) in /Users/runner/work/ravendb/ravendb/src/Raven.Client/Documents/Session/Operations/BatchOperation.cs:line 522
   at Raven.Client.Documents.Session.Operations.BatchOperation.SetResult(BatchCommandResult result) in /Users/runner/work/ravendb/ravendb/src/Raven.Client/Documents/Session/Operations/BatchOperation.cs:line 100
   at Raven.Client.Documents.Session.DocumentSession.SaveChanges() in /Users/runner/work/ravendb/ravendb/src/Raven.Client/Documents/Session/DocumentSession.cs:line 107
```

### Type of change

- Investigation

### How risky is the change?

- Low 

### Backward compatibility

- Not relevant

### Is it platform specific issue?

- No

### Documentation update

- No documentation update is needed 

### Testing 

- Not relevant

### Is there any existing behavior change of other features due to this change?

- No

### UI work

- No UI work is needed
