### PR TITLE
RavenDB-19054 Avoid duplicates in RemovalList when raw list constains duplicated values.

### DIFF
--- a/src/Corax/IndexEntry/IndexEntryWriter.cs
+++ b/src/Corax/IndexEntry/IndexEntryWriter.cs
@@ -74,11 +74,16 @@ public unsafe ref partial struct IndexEntryWriter
         ref int fieldLocation = ref _knownFieldsLocations[field];
         fieldLocation = _dataIndex;
 
+        if (value.Length == 0)
+        {
+            fieldLocation |= Constants.IndexWriter.IntKnownFieldMask;
+            Unsafe.WriteUnaligned(ref _buffer[_dataIndex], IndexEntryFieldType.Empty);
+            _dataIndex += sizeof(IndexEntryFieldType);
+            return;
+        }
+        
         int length = VariableSizeEncoding.Write(_buffer, value.Length, _dataIndex);
         _dataIndex += length;
-        if (value.Length == 0)
-            return;
-
         value.CopyTo(_buffer.Slice(_dataIndex, value.Length));
         _dataIndex += value.Length;
     }

--- a/src/Corax/IndexWriter.cs
+++ b/src/Corax/IndexWriter.cs
@@ -296,6 +296,8 @@ namespace Corax
 
                     while (iterator.ReadNext())
                     {
+                        Debug.Assert((fieldType & IndexEntryFieldType.Tuple) == 0);
+                        
                         if ((fieldType & IndexEntryFieldType.HasNulls) != 0 && (iterator.IsEmpty || iterator.IsNull))
                         {
                             var fieldValue = iterator.IsNull ? Constants.NullValueSlice : Constants.EmptyStringSlice;
@@ -356,8 +358,10 @@ namespace Corax
                 unsafe void ThrowInvalidTokenFoundOnBuffer(IndexFieldBinding binding, ReadOnlySpan<byte> value, Span<byte> wordsBuffer, Span<Token> tokens, Token token)
                 {
                     throw new InvalidDataException(
-                        $"{Environment.NewLine}Got token with: {Environment.NewLine}\tOFFSET {token.Offset}{Environment.NewLine}\tLENGTH: {token.Length}.{Environment.NewLine}" +
-                        $"Total amount of tokens: {tokens.Length}" +
+                        $"{Environment.NewLine}Got token with: " +
+                        $"{Environment.NewLine}\tOFFSET {token.Offset}" +
+                        $"{Environment.NewLine}\tLENGTH: {token.Length}." +
+                        $"{Environment.NewLine}Total amount of tokens: {tokens.Length}" +
                         $"{Environment.NewLine}Buffer contains '{Encodings.Utf8.GetString(wordsBuffer)}' and total length is {wordsBuffer.Length}" +
                         $"{Environment.NewLine}Buffer from ArrayPool: {Environment.NewLine}\tbyte buffer is {_encodingBufferHandler.Length} {Environment.NewLine}\ttokens buffer is {_tokensBufferHandler.Length}" +
                         $"{Environment.NewLine}Original span cointains '{Encodings.Utf8.GetString(value)}' with total length {value.Length}" +

--- a/src/Voron/Data/CompactTrees/PersistentDictionary.cs
+++ b/src/Voron/Data/CompactTrees/PersistentDictionary.cs
@@ -192,7 +192,7 @@ namespace Voron.Data.CompactTrees
         public void Encode(ReadOnlySpan<byte> key, ref Span<byte> encodedKey)
         {
             if (key.Length == 0)
-                throw new ArgumentException();
+                throw new ArgumentException("Cannot encode an empty key!", nameof(key));
 
             if (key[^1] != 0)
             {


### PR DESCRIPTION
### Issue link

https://issues.hibernatingrhinos.com/issue/RavenDB-19054 

### Additional description

We were trying to delete the same entry under term multiple times when the list stored in the index had duplicated values.

List: `["VALUE", "VALUE"]`, ID of doc `1234`

List of removals for term `VALUE`: `[1234, 1234]`

### Type of change

- Bug fix


### How risky is the change?

- Low 


### Backward compatibility


- Not relevant

### Is it platform specific issue?

- No

### Documentation update

- No documentation update is needed 

### Testing 

- Tests have been added that prove the fix is effective or that the feature works


### Is there any existing behavior change of other features due to this change?

- No

### UI work

- No UI work is needed
