### PR TITLE
RavenDB-18523 - Fix not abling to include counters, and time series w…

### DIFF
--- a/src/Raven.Server/Documents/Includes/IncludeRevisionsCommand.cs
+++ b/src/Raven.Server/Documents/Includes/IncludeRevisionsCommand.cs
@@ -65,7 +65,7 @@ namespace Raven.Server.Documents.Includes
                   {
                       var bt = BlittableJsonTraverser.Default;
                       if (bt.TryRead(document.Data, path, out var singleOrMultipleCv, out var _) == false)
-                          continue;
+                        throw new InvalidOperationException($"Field `{path}` inside `include revisions(..)` is invalid.");
 
                       switch (singleOrMultipleCv)
                       {

--- a/src/Raven.Server/Documents/Includes/IncludeRevisionsCommand.cs
+++ b/src/Raven.Server/Documents/Includes/IncludeRevisionsCommand.cs
@@ -2,6 +2,7 @@
 using System.Collections.Generic;
 using JetBrains.Annotations;
 using Raven.Server.Documents.Queries.Revisions;
+using Raven.Server.Json;
 using Raven.Server.ServerWide.Context;
 using Sparrow.Json;
 
@@ -62,9 +63,10 @@ namespace Raven.Server.Documents.Includes
             {
                   foreach (var path in _pathsForRevisionsChangeVectors)
                   {
-                      if (document.Data.TryGet(path, out object singleOrMultipleCv) == false)
-                          return;
-                                
+                      var bt = BlittableJsonTraverser.Default;
+                      if (bt.TryRead(document.Data, path, out var singleOrMultipleCv, out var _) == false)
+                          continue;
+
                       switch (singleOrMultipleCv)
                       {
                           case BlittableJsonReaderArray blittableJsonReaderArray:

--- a/src/Raven.Server/Documents/Queries/QueryMetadata.cs
+++ b/src/Raven.Server/Documents/Queries/QueryMetadata.cs
@@ -605,17 +605,13 @@ namespace Raven.Server.Documents.Queries
                             if (string.IsNullOrEmpty(path))
                                 return;
 
-                            var parts = path.Split('.');
-                            if (parts.Length >= 2)
+                            int dotIndex = path.IndexOf('.');
+                            if (dotIndex > -1)
                             {
-                                var alias = parts[0];
+                                var alias = path.Substring(0, dotIndex);
                                 if (Query.From.Alias?.Value == alias)
                                 {
-                                    path = parts[1];
-                                }
-                                else
-                                {
-                                    throw new InvalidOperationException($"Alias {parts[0]} inside `include revisions(..)` is invalid.");
+                                    path = path.Substring(dotIndex + 1);
                                 }
                             }
 

--- a/src/Raven.Server/Documents/Queries/QueryMetadata.cs
+++ b/src/Raven.Server/Documents/Queries/QueryMetadata.cs
@@ -605,8 +605,19 @@ namespace Raven.Server.Documents.Queries
                             if (string.IsNullOrEmpty(path))
                                 return;
 
-                            if (Query.From.Alias != null)
-                                throw new InvalidOperationException($"Alias is not supported `include revisions(..)`.");
+                            var parts = path.Split('.');
+                            if (parts.Length >= 2)
+                            {
+                                var alias = parts[0];
+                                if (Query.From.Alias?.Value == alias)
+                                {
+                                    path = parts[1];
+                                }
+                                else
+                                {
+                                    throw new InvalidOperationException($"Alias {parts[0]} inside `include revisions(..)` is invalid.");
+                                }
+                            }
 
                             if (ParquetTransformedItems.TryParseDate(path, out var dateTimeOffset))
                                 revisionIncludes.AddRevision(dateTimeOffset.DateTime);

--- a/src/Raven.Server/Documents/Queries/QueryMetadata.cs
+++ b/src/Raven.Server/Documents/Queries/QueryMetadata.cs
@@ -592,10 +592,16 @@ namespace Raven.Server.Documents.Queries
                 switch (queryExpression)
                 {
                     case FieldExpression fe:
-                        if (Query.From.Alias != null)
-                            throw new InvalidOperationException($"Alias is not supported `include revisions(..)`.");
-
-                        revisionIncludes.AddRevision(fe.FieldValue);
+                        var fieldPath = fe.FieldValue;
+                        if (fe.Compound.Count > 1)
+                        {
+                            var alias = fe.Compound[0].Value;
+                            if (Query.From.Alias?.Value == alias)
+                            {
+                                fieldPath = fe.FieldValueWithoutAlias;
+                            }
+                        }
+                        revisionIncludes.AddRevision(fieldPath);
                         break;
 
                     case ValueExpression ve:

--- a/test/SlowTests/Tests/Linq/CanQueryAndIncludeRevisions.cs
+++ b/test/SlowTests/Tests/Linq/CanQueryAndIncludeRevisions.cs
@@ -1866,8 +1866,8 @@ select Foo(u)"
                     var error = Assert.Throws<RavenException>(() => session.Advanced
                         .RawQuery<User>("from Users as u include revisions(u.FirstRevision, x.SecondRevision)")
                         .ToList());
-                
-                    Assert.Contains("System.InvalidOperationException: Alias is not supported `include revisions(..)`."
+
+                    Assert.Contains("Field `x.SecondRevision` inside `include revisions(..)` is invalid."
                         , error.Message);
                 }
 
@@ -1880,7 +1880,7 @@ select Foo(u)"
                         .AddParameter("p2", "x.ThirdRevision")
                         .ToList());
 
-                    Assert.Contains("Alias x inside `include revisions(..)` is invalid."
+                    Assert.Contains("Field `x.ThirdRevision` inside `include revisions(..)` is invalid."
                         , error.Message);
                 }
             }
@@ -1911,7 +1911,7 @@ select Foo(u)"
                         .RawQuery<User>("from Users as u include revisions(u.FirstRevision, x.SecondRevision)")
                         .ToList());
 
-                    Assert.Contains("System.InvalidOperationException: Alias is not supported `include revisions(..)`."
+                    Assert.Contains("Field `x.SecondRevision` inside `include revisions(..)` is invalid."
                         , error.Message);
                 }
 
@@ -1924,7 +1924,7 @@ select Foo(u)"
                         .AddParameter("p2", "x.ThirdRevision")
                         .ToListAsync());
 
-                    Assert.Contains("Alias x inside `include revisions(..)` is invalid."
+                    Assert.Contains("Field `x.ThirdRevision` inside `include revisions(..)` is invalid."
                         , error.Message);
                 }
             }


### PR DESCRIPTION
### Issue link

https://issues.hibernatingrhinos.com/issue/RavenDB-18523/Unable-to-include-counters-time-series-when-including-revisions

### Additional description

Fix not abling to include counters, and time series when including revisions.

### Type of change

- Bug fix

### How risky is the change?

- Low 

### Backward compatibility

- Not relevant

### Is it platform specific issue?

- No

### Documentation update

- No documentation update is needed 

### Testing 

- Tests have been added that prove the fix is effective or that the feature works

### Is there any existing behavior change of other features due to this change?

- No

### UI work

- No UI work is needed
