### PR TITLE
RavenDB-18704 Remove misleading XML comments

### DIFF
--- a/src/Raven.Client/Documents/Session/IDocumentSession.cs
+++ b/src/Raven.Client/Documents/Session/IDocumentSession.cs
@@ -33,7 +33,6 @@ namespace Raven.Client.Documents.Session
         /// <summary>
         ///     Marks the specified entity for deletion. The entity will be deleted when
         ///     <see cref="IDocumentSession.SaveChanges" /> is called.
-        ///     <para>WARNING: This method will not call beforeDelete listener!</para>
         /// </summary>
         /// <param name="id">entity Id</param>
         void Delete(string id);
@@ -41,7 +40,6 @@ namespace Raven.Client.Documents.Session
         /// <summary>
         ///     Marks the specified entity for deletion. The entity will be deleted when
         ///     <see cref="IDocumentSession.SaveChanges" /> is called.
-        ///     <para>WARNING: This method will not call beforeDelete listener!</para>
         /// </summary>
         /// <param name="id">entity Id</param>
         /// <param name="expectedChangeVector">Expected change vector of a document to delete.</param>


### PR DESCRIPTION
### Issue link

https://issues.hibernatingrhinos.com/issue/RavenDB-18704/Remove-misleading-XML-comments

### Type of change

- Bug fix

### Documentation update

- No documentation update is needed 
