### PR TITLE
RavenDB-17952 - SlowTests.Client.TimeSeries.Issues.RavenDB_16366.CanU…

### DIFF
--- a/test/SlowTests/Client/TimeSeries/Issues/RavenDB-16366.cs
+++ b/test/SlowTests/Client/TimeSeries/Issues/RavenDB-16366.cs
@@ -360,6 +360,13 @@ namespace SlowTests.Client.TimeSeries.Issues
             };
 
             var now = DateTime.UtcNow;
+
+            if (now.Day == 1 && now.Hour == 0)
+            {
+                // the first hour on the first day of the month requires adding an hour to avoid appending two entries on different months
+                now = now.AddHours(1);
+            }
+            
             var oneHourAgo = now.Subtract(TimeSpan.FromHours(1));
 
             var timeSeries = session.TimeSeriesFor<DispatchEntry>(location);


### PR DESCRIPTION
…seDynamicGrouping

### Issue link

https://issues.hibernatingrhinos.com/issue/RavenDB-17952/SlowTestsClientTimeSeriesIssuesRavenDB16366CanUseDynamicGrouping

### Type of change

- Bug fix

### How risky is the change?

- Low 

### Backward compatibility

- Non breaking change

### Is it platform specific issue?

- No

### Documentation update

- No documentation update is needed 

### Testing 

- It has been verified by manual testing

### Is there any existing behavior change of other features due to this change?

- No

### UI work

- No UI work is needed
