### PR TITLE
RavenDB-19105 Add original InvalidJournalException as inner exception…

### DIFF
--- a/src/Raven.Server/Storage/Layout/StorageLoader.cs
+++ b/src/Raven.Server/Storage/Layout/StorageLoader.cs
@@ -95,7 +95,7 @@ namespace Raven.Server.Storage.Layout
 
                         }
 
-                        throw new InvalidJournalException($"{message}{Environment.NewLine}Error details: {e.Message}");
+                        throw new InvalidJournalException($"{message}{Environment.NewLine}Error details: {e.Message}", e);
                     }
                 }
 

--- a/src/Voron/Exceptions/InvalidJournalException.cs
+++ b/src/Voron/Exceptions/InvalidJournalException.cs
@@ -7,7 +7,7 @@ namespace Voron.Exceptions
     {
         public long Number { get; }
 
-        public InvalidJournalException(string message) : base(message)
+        public InvalidJournalException(string message, Exception innerException) : base(message, innerException)
         {
 
         }


### PR DESCRIPTION
… so it will give us more context

### Issue link

https://issues.hibernatingrhinos.com/issue/RavenDB-19105/Add-original-InvalidJournalException-as-inner-exception-so-it-will-give-us-more-context

### Type of change

- Enhancement

### How risky is the change?

- Low 

### Backward compatibility

- Not relevant

### Is it platform specific issue?

- No

### Documentation update

- No documentation update is needed 

### Testing 

- Not relevant

### Is there any existing behavior change of other features due to this change?

- No

### UI work

- No UI work is needed
