### PR TITLE
RavenDB-19092: Avoid unbounded stackalloc usage

### DIFF
--- a/src/Sparrow/Binary/Bits.cs
+++ b/src/Sparrow/Binary/Bits.cs
@@ -5,6 +5,11 @@ namespace Sparrow.Binary
 {
     public static class Bits
     {
+        public const int InByte = 8;
+        public const int InShort = 16;
+        public const int InInt = 32;
+        public const int InLong = 64;
+
         private const int GB = 1024 * 1024 * 1024;
 
         //https://stackoverflow.com/questions/2709430/count-number-of-bits-in-a-64-bit-long-big-integer


### PR DESCRIPTION
### Issue link

https://issues.hibernatingrhinos.com/issue/RavenDB-19092

### Additional description

If we allow the size of the array to become too big we can allocate way too big a buffer. There is a very big incentive to allocate on the stack for small values, therefore, we split the method in 2. 1 version allocates on the stack and will allocate in the worst case scenario 256 bytes; and for bigger arrays we pay the cost of requesting unmanaged memory to store the intermediate buffer. 

While the code duplication may seem odd, we want the main method to inline and contain the `stackalloc` inside a method call to ensure it doesn't get caught inside a loop during inlining. Most likely the JIT would disallow the inlining of stackalloc since allocations inside loops could become problematic, I prefer to err on the side of caution and add an extra layer of indirection to ensure it is not likely to happen. 

### How risky is the change?

- Low 
