### PR TITLE
RavenDB-18137  : OLAP GoogleCloudTests fail-on-running-twice

### DIFF
--- a/test/SlowTests/Server/Documents/ETL/Olap/GoogleCloudTests.cs
+++ b/test/SlowTests/Server/Documents/ETL/Olap/GoogleCloudTests.cs
@@ -908,9 +908,12 @@ for (var i = 0; i < this.Lines.length; i++){
             if (string.IsNullOrEmpty(googleCloudSettings.RemoteFolderName) == false)
                 remoteFolderName = $"{googleCloudSettings.RemoteFolderName}/{remoteFolderName}";
 
-            googleCloudSettings.RemoteFolderName = remoteFolderName;
-
-            return googleCloudSettings;
+            return new GoogleCloudSettings
+            {
+                BucketName = googleCloudSettings.BucketName,
+                GoogleCredentialsJson = googleCloudSettings.GoogleCredentialsJson,
+                RemoteFolderName = remoteFolderName
+            };
         }
 
         private static async Task DeleteObjects(GoogleCloudSettings settings)


### PR DESCRIPTION

### Issue link

https://issues.hibernatingrhinos.com/issue/RavenDB-18137/ETLOLAPGoogleCloudTests-fail-on-running-twice

### Additional description

- Do not override `RemoteFolderName` property of **static** `GoogleCloudFactAttribute.GoogleCloudSettings`

- This caused us to have very long remote folder names, e.g. : `olap-tests/GoogleCloudTests-e0134a54-8635-4530-a652-f2a5964e547b/SimpleTransformation_NoPartition/olap-tests/GoogleCloudTests-801f25c7-b27c-476c-ad25-7c9e7b9a0e91/CanModifyPartitionColumnName/olap-tests/GoogleCloudTests-68b0787a-5fe2-4a76-94e6-c9e5024745c3/CanLoadToMultipleTables/olap-tests/GoogleCloudTests-b51406a7-2add-4ea1-8832-f01eff538366/SimpleTransformation_MultiplePartitions/olap-tests/GoogleCloudTests-78c0cae2-95d2-42c4-8ad6-7aef0eae0c2f/CanPartitionByCustomDataFieldViaScript/olap-tests/olap-tests/GoogleCloudTests-82206989-ac08-444c-885b-a2ec3beecda6/CanUploadToGoogleCloud/Orders` and can fail the test when folder name is too long

### Type of change

- Bug fix
- Tests stabilization

### How risky is the change?

- Low 

### Backward compatibility

- Not relevant

### Is it platform specific issue?

- No

### Documentation update

- No documentation update is needed 

### Testing 

- It has been verified by manual testing

### Is there any existing behavior change of other features due to this change?

- No

### UI work

- No UI work is needed
