### PR TITLE
RavenDB-18674 - Fix duplicate declared function name printing to log.

### DIFF
--- a/src/Raven.Server/Documents/Queries/AST/JavascriptCodeQueryVisitor.cs
+++ b/src/Raven.Server/Documents/Queries/AST/JavascriptCodeQueryVisitor.cs
@@ -61,7 +61,7 @@ namespace Raven.Server.Documents.Queries.AST
             throw new NotSupportedException();
         }
 
-        public override void VisitDeclaredFunction(StringSegment name, string func, DeclaredFunction.FunctionType type)
+        public override void VisitDeclaredFunction(string func, DeclaredFunction.FunctionType type)
         {
             throw new NotSupportedException();
         }

--- a/src/Raven.Server/Documents/Queries/AST/JavascriptCodeQueryVisitor.cs
+++ b/src/Raven.Server/Documents/Queries/AST/JavascriptCodeQueryVisitor.cs
@@ -61,7 +61,7 @@ namespace Raven.Server.Documents.Queries.AST
             throw new NotSupportedException();
         }
 
-        public override void VisitDeclaredFunction(string func, DeclaredFunction.FunctionType type)
+        public override void VisitDeclaredFunction(string func)
         {
             throw new NotSupportedException();
         }

--- a/src/Raven.Server/Documents/Queries/AST/QueryVisitor.cs
+++ b/src/Raven.Server/Documents/Queries/AST/QueryVisitor.cs
@@ -169,7 +169,7 @@ namespace Raven.Server.Documents.Queries.AST
         {
             foreach (var kvp in declaredFunctions)
             {
-                VisitDeclaredFunction(kvp.Value.FunctionText, kvp.Value.Type);
+                VisitDeclaredFunction(kvp.Value.FunctionText);
             }
         }
 
@@ -305,7 +305,7 @@ namespace Raven.Server.Documents.Queries.AST
             
         }
 
-        public virtual void VisitDeclaredFunction(string func, DeclaredFunction.FunctionType type)
+        public virtual void VisitDeclaredFunction(string func)
         {
             
         }

--- a/src/Raven.Server/Documents/Queries/AST/QueryVisitor.cs
+++ b/src/Raven.Server/Documents/Queries/AST/QueryVisitor.cs
@@ -169,7 +169,7 @@ namespace Raven.Server.Documents.Queries.AST
         {
             foreach (var kvp in declaredFunctions)
             {
-                VisitDeclaredFunction(kvp.Key, kvp.Value.FunctionText, kvp.Value.Type);
+                VisitDeclaredFunction(kvp.Value.FunctionText, kvp.Value.Type);
             }
         }
 
@@ -305,7 +305,7 @@ namespace Raven.Server.Documents.Queries.AST
             
         }
 
-        public virtual void VisitDeclaredFunction(StringSegment name, string func, DeclaredFunction.FunctionType type)
+        public virtual void VisitDeclaredFunction(string func, DeclaredFunction.FunctionType type)
         {
             
         }

--- a/src/Raven.Server/Documents/Queries/AST/StringQueryVisitor.cs
+++ b/src/Raven.Server/Documents/Queries/AST/StringQueryVisitor.cs
@@ -110,10 +110,15 @@ namespace Raven.Server.Documents.Queries.AST
             }
         }
 
-        public override void VisitDeclaredFunction(StringSegment name, string func, DeclaredFunction.FunctionType type)
+        public override void VisitDeclaredFunction(string func, DeclaredFunction.FunctionType type)
         {
             EnsureLine();
-            _sb.Append("DECLARE function ").Append(name.Value).AppendLine(func).AppendLine();
+            _sb.Append("DECLARE");
+            if (func.StartsWith(' ') == false)
+            {
+                _sb.Append(" ");
+            }
+            _sb.AppendLine(func).AppendLine();
         }
 
         public override void VisitWhereClause(QueryExpression where)

--- a/src/Raven.Server/Documents/Queries/AST/StringQueryVisitor.cs
+++ b/src/Raven.Server/Documents/Queries/AST/StringQueryVisitor.cs
@@ -110,13 +110,13 @@ namespace Raven.Server.Documents.Queries.AST
             }
         }
 
-        public override void VisitDeclaredFunction(string func, DeclaredFunction.FunctionType type)
+        public override void VisitDeclaredFunction(string func)
         {
             EnsureLine();
             _sb.Append("DECLARE");
             if (func.StartsWith(' ') == false)
             {
-                _sb.Append(" ");
+                _sb.Append(' ');
             }
             _sb.AppendLine(func).AppendLine();
         }

--- a/test/SlowTests/Issues/RavenDB-18674.cs
+++ b/test/SlowTests/Issues/RavenDB-18674.cs
@@ -43,20 +43,6 @@ namespace SlowTests.Issues
             var s = query.ToString();
             Assert.False(s.Contains("function output function output(o)"), "duplicate of \'function output\' in query.ToString()");
 
-            using var store = GetDocumentStore();
-            using (var session = store.OpenSession())
-            {
-                for (int i = 0; i < 10; i++)
-                {
-                    session.Store(new Item
-                    {
-                        Content = $"Item{i}"
-                    });
-                    session.SaveChanges();
-                }
-            }
-
-            WaitForUserToContinueTheTest(store);
         }
 
         private class Item

--- a/test/SlowTests/Issues/RavenDB-18674.cs
+++ b/test/SlowTests/Issues/RavenDB-18674.cs
@@ -1,0 +1,70 @@
+﻿using System;
+using System.Collections.Generic;
+using System.Diagnostics;
+using System.Linq;
+using System.Threading;
+using System.Threading.Tasks;
+using FastTests;
+using Raven.Client;
+using Raven.Client.Documents;
+using Raven.Client.Documents.Operations.ConnectionStrings;
+using Raven.Client.Documents.Operations.ETL;
+using Raven.Client.Documents.Queries.Timings;
+using Raven.Server;
+using Raven.Server.Documents;
+using Raven.Server.Documents.TimeSeries;
+using Raven.Server.ServerWide.Context;
+using Raven.Tests.Core.Utils.Entities;
+using Raven.Server.Config;
+using Raven.Server.Documents.Queries.AST;
+using Raven.Server.Documents.Queries.Parser;
+using Sparrow.Json;
+using Sparrow.Json.Parsing;
+using Tests.Infrastructure;
+using Xunit;
+using Xunit.Abstractions;
+
+namespace SlowTests.Issues
+{
+    public class RavenDB_18674 : RavenTestBase
+    {
+        public RavenDB_18674(ITestOutputHelper output) : base(output)
+        {
+        }
+
+        [Fact]
+        public void WrongQueryExpressionWhenDeclaringFunction()
+        {
+            var parser = new QueryParser();
+            parser.Init("DECLARE function output(o) { return { Total: o.Total }; }"+
+                            "from index 'Orders/ByCompany' as o " +
+                            "where Total > 1000 select output(o)");
+            var query = parser.Parse(QueryType.Select);
+            var s = query.ToString();
+            Assert.False(s.Contains("function output function output(o)"), "duplicate of \'function output\' in query.ToString()");
+
+            using var store = GetDocumentStore();
+            using (var session = store.OpenSession())
+            {
+                for (int i = 0; i < 10; i++)
+                {
+                    session.Store(new Item
+                    {
+                        Content = $"Item{i}"
+                    });
+                    session.SaveChanges();
+                }
+            }
+
+            WaitForUserToContinueTheTest(store);
+        }
+
+        private class Item
+        {
+            public string Id { get; set; }
+            public string Content { get; set; }
+        }
+
+    }
+
+}


### PR DESCRIPTION
### Issue link

https://issues.hibernatingrhinos.com/issue/RavenDB-18674/Wrong-query-expression-in-the-log

### Additional description

Fix duplicate 'declared function function_name function function_name' printing to admin log when query with declared function failed.

### Type of change

- Bug fix

### How risky is the change?

- Low 

### Backward compatibility

- Not relevant

### Is it platform specific issue?

- No

### Documentation update

- No documentation update is needed 

### Testing 

- Tests have been added that prove the fix is effective or that the feature works

### Is there any existing behavior change of other features due to this change?

- No

### UI work

- No UI work is needed
