### PR TITLE
RavenDB-18991 - Fix QueriesShouldFailoverIfIndexIsCompactingCluster  …

### DIFF
--- a/src/Raven.Client/ServerWide/Operations/CompactDatabaseOperation.cs
+++ b/src/Raven.Client/ServerWide/Operations/CompactDatabaseOperation.cs
@@ -11,7 +11,7 @@ namespace Raven.Client.ServerWide.Operations
 {
     public class CompactDatabaseOperation : IServerOperation<OperationIdResult>
     {
-        private readonly string _selectedNode;
+        private readonly string _nodeTag;
         private readonly CompactSettings _compactSettings;
 
         public CompactDatabaseOperation(CompactSettings compactSettings)
@@ -19,14 +19,14 @@ namespace Raven.Client.ServerWide.Operations
             _compactSettings = compactSettings ?? throw new ArgumentNullException(nameof(compactSettings));
         }
 
-        internal CompactDatabaseOperation(CompactSettings compactSettings, string selectedNode) : this(compactSettings)
+        internal CompactDatabaseOperation(CompactSettings compactSettings, string nodeTag) : this(compactSettings)
         {
-            _selectedNode = selectedNode;
+            _nodeTag = nodeTag;
         }
 
         public RavenCommand<OperationIdResult> GetCommand(DocumentConventions conventions, JsonOperationContext context)
         {
-            return new CompactDatabaseCommand(conventions, context, _compactSettings, _selectedNode);
+            return new CompactDatabaseCommand(conventions, context, _compactSettings, _nodeTag);
         }
 
         private class CompactDatabaseCommand : RavenCommand<OperationIdResult>

--- a/src/Raven.Client/ServerWide/Operations/CompactDatabaseOperation.cs
+++ b/src/Raven.Client/ServerWide/Operations/CompactDatabaseOperation.cs
@@ -11,6 +11,7 @@ namespace Raven.Client.ServerWide.Operations
 {
     public class CompactDatabaseOperation : IServerOperation<OperationIdResult>
     {
+        private readonly string _selectedNode;
         private readonly CompactSettings _compactSettings;
 
         public CompactDatabaseOperation(CompactSettings compactSettings)
@@ -18,16 +19,21 @@ namespace Raven.Client.ServerWide.Operations
             _compactSettings = compactSettings ?? throw new ArgumentNullException(nameof(compactSettings));
         }
 
+        internal CompactDatabaseOperation(CompactSettings compactSettings, string selectedNode) : this(compactSettings)
+        {
+            _selectedNode = selectedNode;
+        }
+
         public RavenCommand<OperationIdResult> GetCommand(DocumentConventions conventions, JsonOperationContext context)
         {
-            return new CompactDatabaseCommand(conventions, context, _compactSettings);
+            return new CompactDatabaseCommand(conventions, context, _compactSettings, _selectedNode);
         }
 
         private class CompactDatabaseCommand : RavenCommand<OperationIdResult>
         {
             private readonly BlittableJsonReaderObject _compactSettings;
 
-            public CompactDatabaseCommand(DocumentConventions conventions, JsonOperationContext context, CompactSettings compactSettings)
+            public CompactDatabaseCommand(DocumentConventions conventions, JsonOperationContext context, CompactSettings compactSettings, string selectedNode)
             {
                 if (conventions == null)
                     throw new ArgumentNullException(nameof(conventions));
@@ -37,6 +43,8 @@ namespace Raven.Client.ServerWide.Operations
                     throw new ArgumentNullException(nameof(context));
 
                 _compactSettings = DocumentConventions.Default.Serialization.DefaultConverter.ToBlittable(compactSettings, context);
+
+                SelectedNodeTag = selectedNode;
             }
 
             public override HttpRequestMessage CreateRequest(JsonOperationContext ctx, ServerNode node, out string url)


### PR DESCRIPTION
### Issue link

https://issues.hibernatingrhinos.com/issue/RavenDB-18991/SlowTestsIssuesRavenDB18554QueriesShouldFailoverIfIndexIsCompactingCluster

### Additional description

Fixing QueriesShouldFailoverIfIndexIsCompactingCluster test failure.

### Type of change

- Bug fix

### How risky is the change?

- Low 

### Backward compatibility

- Not relevant

### Is it platform specific issue?

- No

### Documentation update

- No documentation update is needed 

### Testing 

- Tests have been added that prove the fix is effective or that the feature works

### Is there any existing behavior change of other features due to this change?

- No

### UI work

- No UI work is needed
