### PR TITLE
RavenDB-19129 Assertion message improvements. If ResetArena() was cal…

### DIFF
--- a/src/Sparrow/Json/ArenaMemoryAllocator.cs
+++ b/src/Sparrow/Json/ArenaMemoryAllocator.cs
@@ -372,7 +372,9 @@ namespace Sparrow.Json
             var address = allocation.Address;
 
 #if DEBUG
-            Debug.Assert(address != _ptrCurrent, $"address != _ptrCurrent ({new IntPtr(address)} != {new IntPtr(_ptrCurrent)})");
+            var current = _ptrCurrent;
+
+            Debug.Assert(address != current, $"address != current ({new IntPtr(address)} != {new IntPtr(current)} [{nameof(_ptrCurrent)} = {new IntPtr(_ptrCurrent)}])");
             Debug.Assert(allocation.IsReturned == false, "allocation.IsReturned == false");
             allocation.IsReturned = true;
 


### PR DESCRIPTION
…led while the assertion was thrown then we should see both pointers: current ptr stored as local variable and _ptrCurrent

### Issue link

https://issues.hibernatingrhinos.com/issue/RavenDB-19129

### Additional description

I think the failing assertion might be indication of some race condition. Improving assertion message so if that's the case we'll see it in the message.

### Type of change

- Debug.Assert improvement

### How risky is the change?

- Low 

### Backward compatibility

- Not relevant

### Is it platform specific issue?

- No

### Documentation update

- No documentation update is needed 

### Testing 

- Not relevant

### Is there any existing behavior change of other features due to this change?

- No

### UI work

- No UI work is needed
